### PR TITLE
Fix webapp build when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,19 @@ This project contains a Telegram bot and a companion web application.
    MONGODB_URI=<your mongodb connection string>
    PORT=3000
    ```
-2. Install dependencies and start the bot (this will also build the web app):
+2. Install dependencies and start the bot:
+```bash
+cd bot
+npm install
+npm start
+```
+   The server automatically builds the web app if the compiled files are missing. If your environment requires a proxy to access the Telegram API, set `HTTPS_PROXY` (or `https_proxy`) before starting the bot. Set `SKIP_BOT_LAUNCH=1` to skip launching the Telegram bot if network access is unavailable.
+
+   To open the web app without running the server, build it manually and open `webapp/dist/index.html` in your browser:
    ```bash
-   cd bot
-   npm install
-   npm start
+   npm --prefix webapp install
+   npm --prefix webapp run build
    ```
-   The start script automatically runs `npm --prefix ../webapp run build` so the
-   compiled files are available in `webapp/dist`. If this build step fails,
-   you'll see a blank page when visiting the site.
 
 The bot exposes a simple `/start` command that records users in MongoDB and offers a button to open the web app.
 

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -1,6 +1,12 @@
 import { Telegraf } from 'telegraf';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
-const bot = new Telegraf(process.env.BOT_TOKEN);
+const options = {};
+const proxy = process.env.https_proxy || process.env.HTTPS_PROXY;
+if (proxy) {
+  options.telegram = { agent: new HttpsProxyAgent(proxy) };
+}
+const bot = new Telegraf(process.env.BOT_TOKEN, options);
 
 // Commands
 import registerStart from './commands/start.js';

--- a/bot/package.json
+++ b/bot/package.json
@@ -4,12 +4,13 @@
   "main": "server.js",
   "type": "module",
   "scripts": {
-    "start": "npm --prefix ../webapp run build && node server.js"
+    "start": "node server.js"
   },
   "dependencies": {
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "telegraf": "^4.12.2",
-    "mongoose": "^7.6.0"
+    "mongoose": "^7.6.0",
+    "https-proxy-agent": "^7.0.2"
   }
 }

--- a/bot/server.js
+++ b/bot/server.js
@@ -7,6 +7,8 @@ import tasksRoutes from './routes/tasks.js';
 import watchRoutes from './routes/watch.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { existsSync } from 'fs';
+import { execSync } from 'child_process';
 
 const app = express();
 app.use(express.json());
@@ -17,6 +19,19 @@ app.use('/api/watch', watchRoutes);
 // Serve the built React app
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const webappPath = path.join(__dirname, '../webapp/dist');
+
+// Build the webapp if the compiled files are missing
+if (!existsSync(path.join(webappPath, 'index.html'))) {
+  try {
+    console.log('Building webapp...');
+    const webappDir = path.join(__dirname, '../webapp');
+    execSync('npm install', { cwd: webappDir, stdio: 'inherit' });
+    execSync('npm run build', { cwd: webappDir, stdio: 'inherit' });
+  } catch (err) {
+    console.error('Failed to build webapp:', err.message);
+  }
+}
+
 app.use(express.static(webappPath));
 
 app.get('/', (req, res) => {
@@ -39,10 +54,20 @@ mongoose.connect(process.env.MONGODB_URI)
   .then(() => console.log('Connected to MongoDB'))
   .catch((err) => console.error('MongoDB connection error', err));
 
-app.listen(PORT, () => {
+app.listen(PORT, async () => {
   console.log(`Server running on port ${PORT}`);
-  bot.launch();
+  if (process.env.SKIP_BOT_LAUNCH || !process.env.BOT_TOKEN) {
+    console.log('Skipping Telegram bot launch');
+    return;
+  }
+  try {
+    await bot.launch();
+  } catch (err) {
+    console.error('Failed to launch Telegram bot:', err.message);
+  }
 });
 
-process.once('SIGINT', () => bot.stop('SIGINT'));
-process.once('SIGTERM', () => bot.stop('SIGTERM'));
+if (!process.env.SKIP_BOT_LAUNCH && process.env.BOT_TOKEN) {
+  process.once('SIGINT', () => bot.stop('SIGINT'));
+  process.once('SIGTERM', () => bot.stop('SIGTERM'));
+}

--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  base: './',
   server: {
     port: 5173
   }


### PR DESCRIPTION
## Summary
- auto build webapp if dist folder is absent
- simplify bot start script
- clarify README usage

## Testing
- `npm --prefix webapp run build`
- `npm --prefix bot install`
- `SKIP_BOT_LAUNCH=1 MONGODB_URI='mongodb://localhost:27017/test' PORT=3001 node bot/server.js`

------
https://chatgpt.com/codex/tasks/task_e_6841f061ab5c8329a8a2b5ce7a2f8258