### PR TITLE
Restore bot setup

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -12,6 +12,6 @@
     "https-proxy-agent": "^7.0.2",
     "mongodb-memory-server": "^10.1.4",
     "mongoose": "^7.6.0",
-
+    "telegraf": "^4.12.2"
   }
 }

--- a/bot/server.js
+++ b/bot/server.js
@@ -61,9 +61,30 @@ app.get('*', (req, res) => {
 });
 
 let mongoUri = process.env.MONGODB_URI;
+async function connectMongo(uri) {
+  try {
+    await mongoose.connect(uri);
+    console.log('Connected to MongoDB');
+  } catch (err) {
+    console.error('MongoDB connection error', err);
+  }
+}
 
-
-
+if (mongoUri === 'memory') {
+  MongoMemoryServer.create()
+    .then((mem) => {
+      mongoUri = mem.getUri();
+      console.log(`Using in-memory MongoDB at ${mongoUri}`);
+      connectMongo(mongoUri);
+    })
+    .catch((err) => {
+      console.error('Failed to start in-memory MongoDB:', err.message);
+    });
+} else if (mongoUri) {
+  connectMongo(mongoUri);
+} else {
+  console.log('No MongoDB URI configured, continuing without database');
+}
 app.listen(PORT, async () => {
   console.log(`Server running on port ${PORT}`);
   if (process.env.SKIP_BOT_LAUNCH || !process.env.BOT_TOKEN) {


### PR DESCRIPTION
## Summary
- fix bot package dependencies
- restore MongoDB initialization logic

## Testing
- `npm --prefix bot install`
- `PORT=3000 SKIP_BOT_LAUNCH=1 node bot/server.js`

------
https://chatgpt.com/codex/tasks/task_e_68468b05212c83299b6a6e1f05fbfd4c