### PR TITLE
Add optional Google OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This project contains a Telegram bot and a companion web application.
    # Set MONGODB_URI=memory to run without a real MongoDB server
    MONGODB_URI=<your mongodb connection string or 'memory'>
    PORT=3000
+   # Optional Google OAuth credentials
+   GOOGLE_CLIENT_ID=
+   GOOGLE_CLIENT_SECRET=
    ```
 2. Copy `webapp/.env.example` to `webapp/.env`. The default value points the
    front-end at the local bot server:

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,3 +1,7 @@
 BOT_TOKEN=your-telegram-bot-token
 MONGODB_URI=memory
 PORT=3000
+# Optional Google OAuth configuration
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback

--- a/bot/commands/mine.js
+++ b/bot/commands/mine.js
@@ -6,7 +6,11 @@ export default function registerMine(bot) {
     const parts = ctx.message.text.split(' ');
     const sub = parts[1];
     const telegramId = ctx.from.id;
-    const user = await User.findOneAndUpdate({ telegramId }, {}, { upsert: true, new: true });
+    const user = await User.findOneAndUpdate(
+      { telegramId },
+      { $setOnInsert: { referralCode: telegramId.toString() } },
+      { upsert: true, new: true }
+    );
 
     switch (sub) {
       case 'start':

--- a/bot/commands/start.js
+++ b/bot/commands/start.js
@@ -3,7 +3,11 @@ import User from '../models/User.js';
 export default function registerStart(bot) {
   bot.start(async (ctx) => {
     const telegramId = ctx.from.id;
-    await User.findOneAndUpdate({ telegramId }, {}, { upsert: true });
+    await User.findOneAndUpdate(
+      { telegramId },
+      { $setOnInsert: { referralCode: telegramId.toString() } },
+      { upsert: true }
+    );
     ctx.reply('Welcome to TonPlaygram!', {
       reply_markup: {
         inline_keyboard: [

--- a/bot/commands/tasks.js
+++ b/bot/commands/tasks.js
@@ -17,7 +17,11 @@ export default function registerTasks(bot) {
       if (existing) return ctx.reply('Task already completed.');
 
       await Task.create({ telegramId, taskId, completedAt: new Date() });
-      const user = await User.findOneAndUpdate({ telegramId }, {}, { upsert: true, new: true });
+      const user = await User.findOneAndUpdate(
+        { telegramId },
+        { $setOnInsert: { referralCode: telegramId.toString() } },
+        { upsert: true, new: true }
+      );
       user.minedTPC += config.reward;
       await user.save();
       return ctx.reply(`Task completed! You earned ${config.reward} TPC.`);

--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -6,7 +6,32 @@ const userSchema = new mongoose.Schema({
   isMining: { type: Boolean, default: false },
   lastMineAt: { type: Date },
   minedTPC: { type: Number, default: 0 },
-  balance: { type: Number, default: 0 }
+  balance: { type: Number, default: 0 },
+  nickname: { type: String, default: '' },
+  photo: { type: String, default: '' },
+  bio: { type: String, default: '' },
+  social: {
+    twitter: String,
+    telegram: String,
+    discord: String,
+    googleId: String
+  },
+  transactions: [
+    {
+      amount: Number,
+      type: String,
+      date: { type: Date, default: Date.now }
+    }
+  ],
+  referralCode: { type: String, unique: true },
+  referredBy: { type: String }
+});
+
+userSchema.pre('save', function(next) {
+  if (!this.referralCode) {
+    this.referralCode = this.telegramId.toString();
+  }
+  next();
 });
 
 export default mongoose.model('User', userSchema);

--- a/bot/package.json
+++ b/bot/package.json
@@ -11,6 +11,8 @@
     "express": "^4.18.2",
     "https-proxy-agent": "^7.0.2",
     "mongoose": "^7.6.0",
-    "telegraf": "^4.12.2"
+    "telegraf": "^4.12.2",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0"
   }
 }

--- a/bot/routes/mining.js
+++ b/bot/routes/mining.js
@@ -9,7 +9,11 @@ async function getUser(req, res, next) {
   if (!telegramId) {
     return res.status(400).json({ error: 'telegramId required' });
   }
-  req.user = await User.findOneAndUpdate({ telegramId }, {}, { upsert: true, new: true });
+  req.user = await User.findOneAndUpdate(
+    { telegramId },
+    { $setOnInsert: { referralCode: telegramId.toString() } },
+    { upsert: true, new: true }
+  );
   next();
 }
 

--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -1,0 +1,95 @@
+import { Router } from 'express';
+import passport from 'passport';
+import User from '../models/User.js';
+
+const router = Router();
+
+router.post('/get', async (req, res) => {
+  const { telegramId } = req.body;
+  if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
+
+  const user = await User.findOneAndUpdate(
+    { telegramId },
+    { $setOnInsert: { referralCode: telegramId.toString() } },
+    { upsert: true, new: true }
+  );
+  res.json(user);
+});
+
+router.post('/update', async (req, res) => {
+  const { telegramId, nickname, photo, bio } = req.body;
+  if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
+
+  const update = {};
+  if (nickname !== undefined) update.nickname = nickname;
+  if (photo !== undefined) update.photo = photo;
+  if (bio !== undefined) update.bio = bio;
+
+  const user = await User.findOneAndUpdate(
+    { telegramId },
+    { $set: update, $setOnInsert: { referralCode: telegramId.toString() } },
+    { upsert: true, new: true }
+  );
+  res.json(user);
+});
+
+router.post('/updateBalance', async (req, res) => {
+  const { telegramId, balance } = req.body;
+  if (!telegramId || balance === undefined) {
+    return res.status(400).json({ error: 'telegramId and balance required' });
+  }
+  const user = await User.findOneAndUpdate(
+    { telegramId },
+    { $set: { balance }, $setOnInsert: { referralCode: telegramId.toString() } },
+    { upsert: true, new: true }
+  );
+  res.json({ balance: user.balance });
+});
+
+router.post('/addTransaction', async (req, res) => {
+  const { telegramId, amount, type } = req.body;
+  if (!telegramId || amount === undefined || !type) {
+    return res.status(400).json({ error: 'telegramId, amount and type required' });
+  }
+  const user = await User.findOneAndUpdate(
+    { telegramId },
+    {
+      $push: { transactions: { amount, type, date: new Date() } },
+      $setOnInsert: { referralCode: telegramId.toString() }
+    },
+    { upsert: true, new: true }
+  );
+  res.json({ transactions: user.transactions });
+});
+
+router.post('/link-social', async (req, res) => {
+  const { telegramId, twitter, telegramHandle, discord, googleId } = req.body;
+  if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
+
+  const update = {};
+  if (twitter !== undefined) update['social.twitter'] = twitter;
+  if (telegramHandle !== undefined) update['social.telegram'] = telegramHandle;
+  if (discord !== undefined) update['social.discord'] = discord;
+  if (googleId !== undefined) update['social.googleId'] = googleId;
+
+  const user = await User.findOneAndUpdate(
+    { telegramId },
+    { $set: update, $setOnInsert: { referralCode: telegramId.toString() } },
+    { upsert: true, new: true }
+  );
+  res.json({ social: user.social });
+});
+
+if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+  router.get('/google', passport.authenticate('google', { scope: ['profile'] }));
+
+  router.get(
+    '/google/callback',
+    passport.authenticate('google', { session: false }),
+    (req, res) => {
+      res.json({ message: 'google linked', user: req.user });
+    }
+  );
+}
+
+export default router;

--- a/bot/routes/tasks.js
+++ b/bot/routes/tasks.js
@@ -27,7 +27,11 @@ router.post('/complete', async (req, res) => {
   if (existing) return res.json({ message: 'already completed' });
 
   await Task.create({ telegramId, taskId, completedAt: new Date() });
-  const user = await User.findOneAndUpdate({ telegramId }, {}, { upsert: true, new: true });
+  const user = await User.findOneAndUpdate(
+    { telegramId },
+    { $setOnInsert: { referralCode: telegramId.toString() } },
+    { upsert: true, new: true }
+  );
   user.minedTPC += config.reward;
   await user.save();
 

--- a/bot/routes/watch.js
+++ b/bot/routes/watch.js
@@ -28,7 +28,11 @@ router.post('/watch', async (req, res) => {
   if (existing) return res.json({ message: 'already watched' });
 
   await WatchRecord.create({ telegramId, videoId });
-  const user = await User.findOneAndUpdate({ telegramId }, {}, { upsert: true, new: true });
+  const user = await User.findOneAndUpdate(
+    { telegramId },
+    { $setOnInsert: { referralCode: telegramId.toString() } },
+    { upsert: true, new: true }
+  );
   user.minedTPC += video.reward;
   await user.save();
 

--- a/bot/server.js
+++ b/bot/server.js
@@ -2,11 +2,15 @@ import dotenv from 'dotenv';
 import express from 'express';
 import bot from './bot.js';
 import mongoose from 'mongoose';
+import passport from 'passport';
+import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import miningRoutes from './routes/mining.js';
 import tasksRoutes from './routes/tasks.js';
 import watchRoutes from './routes/watch.js';
 import referralRoutes from './routes/referral.js';
 import walletRoutes from './routes/wallet.js';
+import profileRoutes from './routes/profile.js';
+import User from './models/User.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync } from 'fs';
@@ -20,11 +24,42 @@ const app = express();
 
 // Middleware and routes
 app.use(express.json());
+app.use(passport.initialize());
+
+if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+  passport.use(
+    new GoogleStrategy(
+      {
+        clientID: process.env.GOOGLE_CLIENT_ID,
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+        callbackURL: process.env.GOOGLE_CALLBACK_URL || '/api/profile/google/callback'
+      },
+      async (_accessToken, _refreshToken, profile, done) => {
+        try {
+          const user = await User.findOneAndUpdate(
+            { telegramId: profile.id },
+            {
+              $set: { 'social.googleId': profile.id },
+              $setOnInsert: { referralCode: profile.id.toString() }
+            },
+            { upsert: true, new: true }
+          );
+          done(null, user);
+        } catch (err) {
+          done(err);
+        }
+      }
+    )
+  );
+} else {
+  console.log('Google OAuth credentials not provided, skipping Google auth setup');
+}
 app.use('/api/mining', miningRoutes);
 app.use('/api/tasks', tasksRoutes);
 app.use('/api/watch', watchRoutes);
 app.use('/api/referral', referralRoutes);
 app.use('/api/wallet', walletRoutes);
+app.use('/api/profile', profileRoutes);
 
 // Serve the built React app
 const webappPath = path.join(__dirname, '../webapp/dist');

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -6,6 +6,7 @@ import Wallet from './pages/Wallet.jsx';
 import WatchToEarn from './pages/WatchToEarn.jsx';
 import Tasks from './pages/Tasks.jsx';
 import Referral from './pages/Referral.jsx';
+import Profile from './pages/Profile.jsx';
 import DiceGame from './pages/Games/DiceGame.jsx';
 import LudoGame from './pages/Games/LudoGame.jsx';
 import HorseRacing from './pages/Games/HorseRacing.jsx';
@@ -27,6 +28,7 @@ export default function App() {
           <Route path="/tasks" element={<Tasks />} />
           <Route path="/referral" element={<Referral />} />
           <Route path="/wallet" element={<Wallet />} />
+          <Route path="/profile" element={<Profile />} />
         </Routes>
       </Layout>
     </BrowserRouter>

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -22,6 +22,7 @@ export default function Home() {
         <GameCard title="Watch to Earn" icon="▶️" link="/watch" />
         <GameCard title="Tasks" icon="✅" link="/tasks" />
         <GameCard title="Wallet" icon="💰" link="/wallet" />
+        <GameCard title="Profile" icon="👤" link="/profile" />
       </div>
       <p className="text-center text-xs text-gray-500">Status: {status}</p>
     </div>

--- a/webapp/src/pages/Profile.jsx
+++ b/webapp/src/pages/Profile.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { TELEGRAM_ID } from '../utils/telegram.js';
+import { getProfile, updateProfile, linkSocial } from '../utils/api.js';
+
+export default function Profile() {
+  const [profile, setProfile] = useState(null);
+  const [form, setForm] = useState({ nickname: '', photo: '', bio: '' });
+
+  const load = async () => {
+    const data = await getProfile(TELEGRAM_ID);
+    setProfile(data);
+    setForm({ nickname: data.nickname || '', photo: data.photo || '', bio: data.bio || '' });
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSave = async () => {
+    const res = await updateProfile({ telegramId: TELEGRAM_ID, ...form });
+    setProfile(res);
+    alert('Profile updated');
+  };
+
+  const handleLinkGoogle = () => {
+    window.open('/api/profile/google', '_blank');
+  };
+
+  if (!profile) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4 space-y-2">
+      <h2 className="text-xl font-bold">Profile</h2>
+      <div className="space-y-2">
+        <input name="nickname" value={form.nickname} onChange={handleChange} placeholder="Nickname" className="w-full p-1 border" />
+        <input name="photo" value={form.photo} onChange={handleChange} placeholder="Photo URL" className="w-full p-1 border" />
+        <textarea name="bio" value={form.bio} onChange={handleChange} placeholder="Bio" className="w-full p-1 border" />
+        <button className="px-3 py-1 bg-blue-500 text-white" onClick={handleSave}>Save</button>
+      </div>
+      <div>
+        <button className="px-3 py-1 bg-red-500 text-white" onClick={handleLinkGoogle}>Link Google</button>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -48,3 +48,23 @@ export function listVideos(telegramId) {
 export function watchVideo(telegramId, videoId) {
   return post('/api/watch/watch', { telegramId, videoId });
 }
+
+export function getProfile(telegramId) {
+  return post('/api/profile/get', { telegramId });
+}
+
+export function updateProfile(data) {
+  return post('/api/profile/update', data);
+}
+
+export function updateBalance(telegramId, balance) {
+  return post('/api/profile/updateBalance', { telegramId, balance });
+}
+
+export function addTransaction(telegramId, amount, type) {
+  return post('/api/profile/addTransaction', { telegramId, amount, type });
+}
+
+export function linkSocial(data) {
+  return post('/api/profile/link-social', data);
+}


### PR DESCRIPTION
## Summary
- allow running the server when Google OAuth credentials aren't provided
- wrap Google auth routes so they're only registered when configured
- document optional Google credentials in README and `.env.example`

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(works without Google credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68492f413e248329a100620bde6f568f