### PR TITLE
Restore prior colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ After deploying, visit the service URL in your browser. You should see the TonPl
 
 Set `MONGODB_URI=memory` in the environment if you do not have a database. Otherwise provide your MongoDB connection string. The server logs should show `Server running on port` and `Connected to MongoDB`. Any connection errors will appear in the logs and usually indicate an incorrect URI or firewall rules.
 
+### Wallet integration
+
+The webapp now uses **TonConnect** to link a Tonkeeper wallet. Configure
+`VITE_TONCONNECT_MANIFEST` in `webapp/.env` and expose the same manifest URL on
+the server via `TONCONNECT_MANIFEST_URL`.
+
 ## Open Source Games
+- [Chessu](https://github.com/dotnize/chessu) – Competitive chess with socket rooms.
 - [Snakes & Ladders / Chutes & Ladders](https://github.com/yashksaini/snakes-and-ladders-game) – Custom avatars, virtual board, and climb/slide animations.
 

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -5,3 +5,5 @@ PORT=3000
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
+# TonConnect parameters
+TONCONNECT_MANIFEST_URL=https://your-domain.com/tonconnect-manifest.json

--- a/bot/server.js
+++ b/bot/server.js
@@ -88,6 +88,13 @@ if (
 }
 
 app.use(express.static(webappPath));
+// Expose TonConnect manifest directly at the root path so wallet extensions
+// can fetch it. Render will serve static files from `webapp/dist`, but some
+// deployments hit this Express server before the static middleware. Providing
+// an explicit route avoids 404 errors.
+app.get('/tonconnect-manifest.json', (req, res) => {
+  res.sendFile(path.join(webappPath, 'tonconnect-manifest.json'));
+});
 app.get('/', (req, res) => {
   res.sendFile(path.join(webappPath, 'index.html'));
 });

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,1 +1,2 @@
 VITE_API_BASE_URL=http://localhost:3000
+VITE_TONCONNECT_MANIFEST=/tonconnect-manifest.json

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet">

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -9,15 +9,17 @@
   },
   "type": "module",
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3",
-    "vite": "^4.4.9",
+    "@tonconnect/sdk": "^3.1.0",
+    "@tonconnect/ui-react": "^2.1.0",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.15",
+    "chess.js": "^1.3.1",
     "postcss": "^8.4.31",
-    "tailwindcss": "^3.4.1"
-  },
-  "devDependencies": {
+    "react": "^18.2.0",
+    "react-chessboard": "^4.7.3",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "tailwindcss": "^3.4.1",
+    "vite": "^4.4.9"
   }
 }

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TonPlaygram</title>
   </head>
   <body>

--- a/webapp/public/tonconnect-manifest.json
+++ b/webapp/public/tonconnect-manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "TonPlaygram Chess",
+  "description": "Play chess with TPC staking via Tonkeeper",
+  "url": "https://tonplaygram.example.com",
+  "icons": ["https://tonplaygram.example.com/icon.png"]
+}

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -10,6 +10,7 @@ import DiceGame from './pages/Games/DiceGame.jsx';
 import LudoGame from './pages/Games/LudoGame.jsx';
 import HorseRacing from './pages/Games/HorseRacing.jsx';
 import SnakeLadders from './pages/Games/SnakeLadders.jsx';
+import ChessGame from './pages/Games/Chess.jsx';
 import Layout from './components/Layout.jsx';
 
 export default function App() {
@@ -23,6 +24,7 @@ export default function App() {
           <Route path="/games/ludo" element={<LudoGame />} />
           <Route path="/games/horse" element={<HorseRacing />} />
           <Route path="/games/snake" element={<SnakeLadders />} />
+          <Route path="/games/chess" element={<ChessGame />} />
           <Route path="/tasks" element={<Tasks />} />
           <Route path="/referral" element={<Referral />} />
           <Route path="/wallet" element={<Wallet />} />

--- a/webapp/src/components/ConnectWallet.jsx
+++ b/webapp/src/components/ConnectWallet.jsx
@@ -1,47 +1,27 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
+import { TonConnectButton, useTonWallet } from '@tonconnect/ui-react';
 
+// Simple wrapper around TonConnectButton that remembers the last connected
+// address in localStorage.
 export default function ConnectWallet() {
-  const [address, setAddress] = useState('');
-  const [editing, setEditing] = useState(false);
+  const wallet = useTonWallet();
 
+  // Persist address when wallet changes
   useEffect(() => {
-    const stored = localStorage.getItem('walletAddress');
-    if (stored) setAddress(stored);
-  }, []);
-
-  const handleSave = () => {
-    if (address.trim()) {
-      localStorage.setItem('walletAddress', address.trim());
+    if (wallet?.account?.address) {
+      localStorage.setItem('walletAddress', wallet.account.address);
     }
-    setEditing(false);
-  };
-
-  if (editing) {
-    return (
-      <div className="flex items-center space-x-2">
-        <input
-          className="border p-1 rounded text-black"
-          value={address}
-          onChange={(e) => setAddress(e.target.value)}
-          placeholder="Wallet address"
-        />
-        <button
-          onClick={handleSave}
-          className="px-2 py-1 bg-green-600 text-white rounded"
-        >
-          Save
-        </button>
-      </div>
-    );
-  }
+  }, [wallet]);
 
   return (
-    <button
-      onClick={() => setEditing(true)}
-      className="px-2 py-1 bg-gray-700 rounded"
-    >
-      {address ? `Wallet: ${address.slice(0, 4)}...${address.slice(-4)}` : 'Connect Wallet'}
-    </button>
+    <div className="flex items-center space-x-2">
+      <TonConnectButton className="ton-connect-button" />
+      {wallet?.account?.address && (
+        <span className="text-sm">
+          {wallet.account.address.slice(0, 4)}...
+          {wallet.account.address.slice(-4)}
+        </span>
+      )}
+    </div>
   );
 }
-

--- a/webapp/src/components/Navbar.jsx
+++ b/webapp/src/components/Navbar.jsx
@@ -7,10 +7,9 @@ export default function Navbar() {
         <div className="flex-1 space-x-4 text-sm">
           <Link className="hover:text-yellow-400" to="/">Home</Link>
           <Link className="hover:text-yellow-400" to="/mining">Mining</Link>
-          <Link className="hover:text-yellow-400" to="/games/dice">Games</Link>
+          <Link className="hover:text-yellow-400" to="/games/chess">Chess</Link>
           <Link className="hover:text-yellow-400" to="/tasks">Tasks</Link>
           <Link className="hover:text-yellow-400" to="/referral">Referral</Link>
-          <Link className="hover:text-yellow-400" to="/wallet">Wallet</Link>
           <Link className="hover:text-yellow-400" to="/account">My Account</Link>
         </div>
       </div>

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import { TonConnectUIProvider } from '@tonconnect/ui-react';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <TonConnectUIProvider manifestUrl={import.meta.env.VITE_TONCONNECT_MANIFEST || '/tonconnect-manifest.json'}>
+      <App />
+    </TonConnectUIProvider>
   </React.StrictMode>
 );

--- a/webapp/src/pages/Games/Chess.jsx
+++ b/webapp/src/pages/Games/Chess.jsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { Chess } from 'chess.js';
+import { Chessboard } from 'react-chessboard';
+import ConnectWallet from '../../components/ConnectWallet.jsx';
+
+// Minimal chess game using chess.js and react-chessboard.
+export default function ChessGame() {
+  const [stake, setStake] = useState(100);
+  const [game, setGame] = useState(new Chess());
+
+  const onDrop = (sourceSquare, targetSquare) => {
+    const newGame = new Chess(game.fen());
+    const move = newGame.move({ from: sourceSquare, to: targetSquare, promotion: 'q' });
+    if (move === null) return false;
+    setGame(newGame);
+    return true;
+  };
+
+  const resetGame = () => setGame(new Chess());
+
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-bold mb-4">Chessu</h2>
+      <p className="mb-4">Stake TPC and challenge another player.</p>
+      <div className="space-x-2 mb-4">
+        {[100, 500, 1000, 5000, 10000].map((amt) => (
+          <button
+            key={amt}
+            onClick={() => setStake(amt)}
+            className={`px-2 py-1 border rounded ${stake === amt ? 'bg-yellow-500 text-gray-900' : 'bg-gray-700 text-white'}`}
+          >
+            {amt} TPC
+          </button>
+        ))}
+      </div>
+      <ConnectWallet />
+      <div className="mt-8 flex flex-col items-center space-y-2">
+        <Chessboard
+          id="chess-board"
+          position={game.fen()}
+          onPieceDrop={onDrop}
+          boardWidth={350}
+          boardOrientation="white"
+        />
+        <button onClick={resetGame} className="px-2 py-1 border rounded bg-blue-600 text-white">Reset</button>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -125,7 +125,7 @@ export default function MyAccount() {
         <button className="px-3 py-1 bg-blue-500 text-white" onClick={handleSaveSocial}>
           Save Social
         </button>
-        <button className="px-3 py-1 bg-red-500 text-white" onClick={handleLinkGoogle}>
+        <button className="px-3 py-1 bg-blue-600 text-white" onClick={handleLinkGoogle}>
           Link Google
         </button>
       </div>


### PR DESCRIPTION
## Summary
- revert to gray gradient and blue accent style
- keep chess and wallet integration

## Testing
- `npm --prefix webapp install`
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_684a6ecdad308329a59de1d66de741c4