### PR TITLE
Add icon-based bottom navbar

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -20,7 +20,8 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
     "tailwindcss": "^3.4.1",
-    "vite": "^4.4.9"
+    "vite": "^4.4.9",
+    "react-icons": "^4.10.1"
   },
   "devDependencies": {
     "typescript": "^5.4.0",

--- a/webapp/src/components/NavItem.jsx
+++ b/webapp/src/components/NavItem.jsx
@@ -1,0 +1,15 @@
+import { NavLink } from 'react-router-dom';
+
+export default function NavItem({ to, icon: Icon, label }) {
+  return (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        `flex flex-col items-center text-xs ${isActive ? 'text-accent' : 'text-text hover:text-accent'}`
+      }
+    >
+      <Icon className="w-6 h-6 mb-1" />
+      <span>{label}</span>
+    </NavLink>
+  );
+}

--- a/webapp/src/components/Navbar.jsx
+++ b/webapp/src/components/Navbar.jsx
@@ -1,15 +1,16 @@
-import { Link } from 'react-router-dom';
+import { AiOutlineHome, AiOutlineTrophy, AiOutlinePlayCircle, AiOutlineCheckSquare, AiOutlineUsergroupAdd, AiOutlineUser } from 'react-icons/ai';
+import NavItem from './NavItem.jsx';
 
 export default function Navbar() {
   return (
     <nav className="fixed inset-x-0 bottom-0 z-50 bg-surface text-text shadow border-t border-accent">
-      <div className="container mx-auto px-4 py-3 flex items-center justify-between text-sm">
-        <Link className="hover:text-accent" to="/">Home</Link>
-        <Link className="hover:text-accent" to="/mining">Mining</Link>
-        <Link className="hover:text-accent" to="/games">Games</Link>
-        <Link className="hover:text-accent" to="/tasks">Tasks</Link>
-        <Link className="hover:text-accent" to="/referral">Referral</Link>
-        <Link className="hover:text-accent" to="/account">Profile</Link>
+      <div className="container mx-auto px-4 py-2 flex items-center justify-between text-sm">
+        <NavItem to="/" icon={AiOutlineHome} label="Home" />
+        <NavItem to="/mining" icon={AiOutlineTrophy} label="Mining" />
+        <NavItem to="/games" icon={AiOutlinePlayCircle} label="Games" />
+        <NavItem to="/tasks" icon={AiOutlineCheckSquare} label="Tasks" />
+        <NavItem to="/referral" icon={AiOutlineUsergroupAdd} label="Referral" />
+        <NavItem to="/account" icon={AiOutlineUser} label="Profile" />
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- use `react-icons` to show clipart icons in the bottom navigation
- add generic `NavItem` component for navbar links

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684bab9986388329ae040dde4a8a32c0