### PR TITLE
Add Not Found troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,14 @@ service (e.g. `https://tonplaygramwebapp.onrender.com`). **Do not include** the
 
 If you accidentally deploy as a Static Site you'll only see `index.html` referencing `/src/main.jsx`. Switch to a Web Service and use the commands above so the compiled files are served.
 
-After deploying, visit the service URL in your browser. You should see the TonPlaygram interface. If Render shows a plain **Not Found** page, the Node service is likely not running. Verify that the service type is **Web Service** and check the logs for any startup errors.
+After deploying, visit the service URL in your browser. You should see the TonPlaygram interface.
+
+### Troubleshooting "Not Found" pages
+
+If your browser displays a plain **Not Found** page, the Node service probably isn't running.
+Confirm that the service type is **Web Service** and inspect the logs for startup errors.
+Locally you can run `npm start` inside the `bot` directory (or from the repository root) and look for `Server running on port` in the output.
+
 
 Set `MONGODB_URI=memory` in the environment if you do not have a database. Otherwise provide your MongoDB connection string. The server logs should show `Server running on port` and `Connected to MongoDB`. Any connection errors will appear in the logs and usually indicate an incorrect URI or firewall rules.
 


### PR DESCRIPTION
## Summary
- document how to resolve "Not Found" pages by ensuring the Node service is running

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bc4b647b083298b9ca4b54d686422