### PR TITLE
Add simple test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ The webapp now uses **TonConnect** to link a Tonkeeper wallet. Configure
 `VITE_TONCONNECT_MANIFEST` in `webapp/.env` and expose the same manifest URL on
 the server via `TONCONNECT_MANIFEST_URL`.
 
+## Testing
+Currently there is no automated test suite. The `npm test` script simply prints "No tests" for each package.
+
+
 ## Open Source Games
 - [Chessu](https://github.com/dotnize/chessu) – Competitive chess with socket rooms.
 - [Snakes & Ladders / Chutes & Ladders](https://github.com/yashksaini/snakes-and-ladders-game) – Custom avatars, virtual board, and climb/slide animations.

--- a/bot/package.json
+++ b/bot/package.json
@@ -4,7 +4,8 @@
   "main": "server.js",
   "type": "module",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "echo \"No tests\""
   },
   "dependencies": {
     "dotenv": "^16.3.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node bot/server.js",
     "install-all": "npm install --prefix bot && npm install --prefix webapp",
     "postinstall": "npm run install-all",
-    "build": "npm --prefix webapp run build"
+    "build": "npm --prefix webapp run build",
+    "test": "echo \"No tests\""
   },
   "engines": {
     "node": ">=18"

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "echo \"No tests\""
   },
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary
- add `test` scripts that just echo a placeholder message
- mention absence of real tests in README

## Testing
- `npm test --silent`
- `npm --prefix bot test --silent`
- `npm --prefix webapp test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684bcda58a548329a50046bdb112c7a2