### PR TITLE
Add mining start time tracking

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -12,6 +12,9 @@ const userSchema = new mongoose.Schema({
 
   minedTPC: { type: Number, default: 0 },
 
+  // Timestamp of the last mining start or reward update
+  lastMineAt: { type: Date },
+
   balance: { type: Number, default: 0 },
 
   nickname: { type: String, default: '' },

--- a/bot/routes/mining.js
+++ b/bot/routes/mining.js
@@ -22,7 +22,7 @@ router.post('/start', getUser, async (req, res) => {
     return res.json({ message: 'already mining' });
   }
   await startMining(req.user);
-  res.json({ message: 'mining started' });
+  res.json({ message: 'mining started', lastMineAt: req.user.lastMineAt });
 });
 
 router.post('/stop', getUser, async (req, res) => {
@@ -41,7 +41,12 @@ router.post('/claim', getUser, async (req, res) => {
 router.post('/status', getUser, async (req, res) => {
   updateMiningRewards(req.user);
   await req.user.save();
-  res.json({ isMining: req.user.isMining, pending: req.user.minedTPC, balance: req.user.balance });
+  res.json({
+    isMining: req.user.isMining,
+    pending: req.user.minedTPC,
+    balance: req.user.balance,
+    lastMineAt: req.user.lastMineAt
+  });
 });
 
 export default router;

--- a/webapp/src/components/MiningCard.jsx
+++ b/webapp/src/components/MiningCard.jsx
@@ -9,6 +9,7 @@ export default function MiningCard() {
   const refresh = async () => {
     const data = await getMiningStatus(getTelegramId());
     setStatus(data.isMining ? 'Mining' : 'Not Mining');
+    setStartTime(data.lastMineAt ? new Date(data.lastMineAt).getTime() : null);
   };
 
   useEffect(() => {
@@ -16,9 +17,9 @@ export default function MiningCard() {
   }, []);
 
   const handleStart = async () => {
-    setStartTime(Date.now());
+    const data = await startMining(getTelegramId());
+    setStartTime(data.lastMineAt ? new Date(data.lastMineAt).getTime() : Date.now());
     setStatus('Mining');
-    await startMining(getTelegramId());
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- include `lastMineAt` field in `User` model
- return `lastMineAt` in mining start and status routes
- use server-provided mining start time in Home and Mining pages

## Testing
- `npm --prefix webapp run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bcdb5b4348329bb47b42c38d1e5a6