### PR TITLE
Implement automatic reward payouts

### DIFF
--- a/webapp/public/icons/usdt.svg
+++ b/webapp/public/icons/usdt.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
   <circle cx="12" cy="12" r="12" fill="#26a17b"/>
-  <text x="12" y="16" font-size="12" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif">U</text>
+  <text x="12" y="16" font-size="12" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif">$</text>
 </svg>

--- a/webapp/src/components/MiningCard.jsx
+++ b/webapp/src/components/MiningCard.jsx
@@ -26,8 +26,8 @@ export default function MiningCard() {
       const interval = setInterval(() => {
         const now = Date.now();
         const elapsed = now - startTime;
-        const twentyFourHours = 24 * 60 * 60 * 1000;
-        if (elapsed >= twentyFourHours) {
+        const twelveHours = 12 * 60 * 60 * 1000;
+        if (elapsed >= twelveHours) {
           setStatus('Not Mining');
           autoDistributeRewards();
         }

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -3,6 +3,12 @@ import SpinWheel from './SpinWheel.tsx';
 import RewardPopup from './RewardPopup.tsx';
 import AdModal from './AdModal.tsx';
 import { canSpin, nextSpinTime } from '../utils/rewardLogic';
+import {
+  getWalletBalance,
+  updateBalance,
+  addTransaction
+} from '../utils/api.js';
+import { getTelegramId } from '../utils/telegram.js';
 
 export default function SpinGame() {
   const [lastSpin, setLastSpin] = useState(null);
@@ -15,18 +21,22 @@ export default function SpinGame() {
     if (ts) setLastSpin(parseInt(ts, 10));
   }, []);
 
-  const handleFinish = (r) => {
+  const handleFinish = async (r) => {
     const now = Date.now();
     localStorage.setItem('lastSpin', String(now));
     setLastSpin(now);
     setReward(r);
+    const id = getTelegramId();
+    const balRes = await getWalletBalance(id);
+    const newBalance = (balRes.balance || 0) + r;
+    await updateBalance(id, newBalance);
+    await addTransaction(id, r, 'spin');
   };
 
   const ready = canSpin(lastSpin);
 
   return (
     <div className="bg-gray-800 rounded p-4 flex flex-col items-center space-y-2">
-      <div className="text-yellow-400 text-lg">Balance 9.87 M TPC</div>
       <SpinWheel
         onFinish={handleFinish}
         spinning={spinning}

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -26,8 +26,8 @@ export default function Mining() {
       const interval = setInterval(() => {
         const now = Date.now();
         const elapsed = now - startTime;
-        const twentyFourHours = 24 * 60 * 60 * 1000;
-        if (elapsed >= twentyFourHours) {
+        const twelveHours = 12 * 60 * 60 * 1000;
+        if (elapsed >= twelveHours) {
           setStatus('Not Mining');
           autoDistributeRewards();
         }


### PR DESCRIPTION
## Summary
- update spin game to auto-credit rewards to wallet
- remove balance label from the spin UI
- stop mining automatically after 12 hours and claim mined rewards
- tweak USDT icon letter

## Testing
- `npm --prefix webapp install`
- `npm --prefix webapp run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bdd992d388329968e5338319407cb