### PR TITLE
Implement automatic reward payouts

### DIFF
--- a/webapp/public/assets/icons/profile.svg
+++ b/webapp/public/assets/icons/profile.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <circle cx="12" cy="8" r="4"/>
+  <path d="M4 20c0-4 8-6 8-6s8 2 8 6H4z"/>
+</svg>

--- a/webapp/public/assets/icons/tasks.svg
+++ b/webapp/public/assets/icons/tasks.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M4 5h1v2H4V5zm3 0h13v2H7V5zm-3 7h1v2H4v-2zm3 0h13v2H7v-2zm-3 7h1v2H4v-2zm3 0h13v2H7v-2z"/>
+</svg>

--- a/webapp/public/icons/usdt.svg
+++ b/webapp/public/icons/usdt.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
   <circle cx="12" cy="12" r="12" fill="#26a17b"/>
-  <text x="12" y="16" font-size="12" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif">U</text>
+  <text x="12" y="16" font-size="12" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif">$</text>
 </svg>

--- a/webapp/src/components/MiningCard.jsx
+++ b/webapp/src/components/MiningCard.jsx
@@ -1,24 +1,50 @@
 import { useEffect, useState } from 'react';
-import { getMiningStatus, startMining, claimMining } from '../utils/api.js';
+import {
+  getMiningStatus,
+  startMining,
+  claimMining,
+  getWalletBalance,
+  getTonBalance
+} from '../utils/api.js';
+import { useTonWallet } from '@tonconnect/ui-react';
 import { getTelegramId } from '../utils/telegram.js';
 
 export default function MiningCard() {
   const [status, setStatus] = useState('Not Mining');
   const [startTime, setStartTime] = useState(null);
+  const [balances, setBalances] = useState({ ton: null, tpc: null, usdt: 0 });
+  const wallet = useTonWallet();
+
+  const loadBalances = async () => {
+    const prof = await getWalletBalance(getTelegramId());
+    const ton = wallet?.account?.address
+      ? (await getTonBalance(wallet.account.address)).balance
+      : null;
+    setBalances({ ton, tpc: prof.balance, usdt: 0 });
+  };
 
   const refresh = async () => {
     const data = await getMiningStatus(getTelegramId());
     setStatus(data.isMining ? 'Mining' : 'Not Mining');
+    loadBalances();
   };
 
   useEffect(() => {
     refresh();
-  }, []);
+    const saved = localStorage.getItem('miningStart');
+    if (saved) {
+      setStartTime(parseInt(saved, 10));
+      setStatus('Mining');
+    }
+  }, [wallet]);
 
   const handleStart = async () => {
-    setStartTime(Date.now());
+    const now = Date.now();
+    setStartTime(now);
+    localStorage.setItem('miningStart', String(now));
     setStatus('Mining');
     await startMining(getTelegramId());
+    loadBalances();
   };
 
   useEffect(() => {
@@ -26,8 +52,8 @@ export default function MiningCard() {
       const interval = setInterval(() => {
         const now = Date.now();
         const elapsed = now - startTime;
-        const twentyFourHours = 24 * 60 * 60 * 1000;
-        if (elapsed >= twentyFourHours) {
+        const twelveHours = 12 * 60 * 60 * 1000;
+        if (elapsed >= twelveHours) {
           setStatus('Not Mining');
           autoDistributeRewards();
         }
@@ -38,6 +64,7 @@ export default function MiningCard() {
 
   const autoDistributeRewards = async () => {
     await claimMining(getTelegramId());
+    localStorage.removeItem('miningStart');
     refresh();
   };
 
@@ -56,14 +83,30 @@ export default function MiningCard() {
         <span>Mining</span>
       </h3>
       <p>
-        Status:{' '}
+        Status{' '}
         <span className={status === 'Mining' ? 'text-green-500' : 'text-red-500'}>
           {status}
         </span>
       </p>
-      <div>
-        <button className="px-2 py-1 bg-green-500 text-white" onClick={handleStart} disabled={status === 'Mining'}>Start</button>
+      <div className="flex justify-around text-xs">
+        <Token icon="/icons/ton.svg" value={balances.ton ?? '...'} />
+        <Token icon="/icons/tpc.svg" value={balances.tpc ?? '...'} />
+        <Token icon="/icons/usdt.svg" value={balances.usdt ?? '0'} />
       </div>
+      <div>
+        <button className="px-2 py-1 bg-green-500 text-white" onClick={handleStart} disabled={status === 'Mining'}>
+          Start
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Token({ icon, value }) {
+  return (
+    <div className="flex items-center space-x-1">
+      <img src={icon} alt="token" className="w-4 h-4" />
+      <span>{value}</span>
     </div>
   );
 }

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -3,6 +3,12 @@ import SpinWheel from './SpinWheel.tsx';
 import RewardPopup from './RewardPopup.tsx';
 import AdModal from './AdModal.tsx';
 import { canSpin, nextSpinTime } from '../utils/rewardLogic';
+import {
+  getWalletBalance,
+  updateBalance,
+  addTransaction
+} from '../utils/api.js';
+import { getTelegramId } from '../utils/telegram.js';
 
 export default function SpinGame() {
   const [lastSpin, setLastSpin] = useState(null);
@@ -15,18 +21,22 @@ export default function SpinGame() {
     if (ts) setLastSpin(parseInt(ts, 10));
   }, []);
 
-  const handleFinish = (r) => {
+  const handleFinish = async (r) => {
     const now = Date.now();
     localStorage.setItem('lastSpin', String(now));
     setLastSpin(now);
     setReward(r);
+    const id = getTelegramId();
+    const balRes = await getWalletBalance(id);
+    const newBalance = (balRes.balance || 0) + r;
+    await updateBalance(id, newBalance);
+    await addTransaction(id, r, 'spin');
   };
 
   const ready = canSpin(lastSpin);
 
   return (
     <div className="bg-gray-800 rounded p-4 flex flex-col items-center space-y-2">
-      <div className="text-yellow-400 text-lg">Balance 9.87 M TPC</div>
       <SpinWheel
         onFinish={handleFinish}
         spinning={spinning}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -25,8 +25,8 @@ export default function Home() {
         <MiningCard />
         <GameCard title="Dice Duel" icon="/assets/icons/dice.svg" link="/games/dice" />
         <GameCard title="Snakes & Ladders" icon="/assets/icons/snake.svg" link="/games/snake" />
-        <GameCard title="Tasks" icon="✅" link="/tasks" />
-        <GameCard title="Profile" icon="👤" link="/account" />
+        <GameCard title="Tasks" icon="/assets/icons/tasks.svg" link="/tasks" />
+        <GameCard title="Profile" icon="/assets/icons/profile.svg" link="/account" />
       </div>
 
       <p className="text-center text-xs text-subtext">Status: {status}</p>

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -19,6 +19,11 @@ export default function Mining() {
 
   useEffect(() => {
     loadBalances();
+    const saved = localStorage.getItem('miningStart');
+    if (saved) {
+      setStartTime(parseInt(saved, 10));
+      setStatus('Mining');
+    }
   }, [wallet]);
 
   useEffect(() => {
@@ -26,8 +31,8 @@ export default function Mining() {
       const interval = setInterval(() => {
         const now = Date.now();
         const elapsed = now - startTime;
-        const twentyFourHours = 24 * 60 * 60 * 1000;
-        if (elapsed >= twentyFourHours) {
+        const twelveHours = 12 * 60 * 60 * 1000;
+        if (elapsed >= twelveHours) {
           setStatus('Not Mining');
           autoDistributeRewards();
         }
@@ -37,13 +42,16 @@ export default function Mining() {
   }, [status, startTime]);
 
   const handleStart = async () => {
-    setStartTime(Date.now());
+    const now = Date.now();
+    setStartTime(now);
+    localStorage.setItem('miningStart', String(now));
     setStatus('Mining');
     await startMining(getTelegramId());
   };
 
   const autoDistributeRewards = async () => {
     await claimMining(getTelegramId());
+    localStorage.removeItem('miningStart');
     loadBalances();
   };
 


### PR DESCRIPTION
## Summary
- update spin game to auto-credit rewards to wallet
- remove balance label from the spin UI
- stop mining automatically after 12 hours and claim mined rewards
- tweak USDT icon letter
- sync mining status across pages
- show token balance on the home mining card
- add missing tasks and profile icons

## Testing
- `npm --prefix webapp install`
- `npm --prefix webapp run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bdd992d388329968e5338319407cb