### PR TITLE
Implement automatic reward payouts

### DIFF
--- a/webapp/public/assets/icons/profile.svg
+++ b/webapp/public/assets/icons/profile.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <circle cx="12" cy="8" r="4"/>
+  <path d="M4 20c0-4 8-6 8-6s8 2 8 6H4z"/>
+</svg>

--- a/webapp/public/assets/icons/tasks.svg
+++ b/webapp/public/assets/icons/tasks.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M4 5h1v2H4V5zm3 0h13v2H7V5zm-3 7h1v2H4v-2zm3 0h13v2H7v-2zm-3 7h1v2H4v-2zm3 0h13v2H7v-2z"/>
+</svg>

--- a/webapp/public/icons/usdt.svg
+++ b/webapp/public/icons/usdt.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
   <circle cx="12" cy="12" r="12" fill="#26a17b"/>
-  <text x="12" y="16" font-size="12" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif">U</text>
+  <text x="12" y="16" font-size="12" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif">$</text>
 </svg>

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -5,6 +5,13 @@ import Footer from './Footer.jsx';
 export default function Layout({ children }) {
   return (
     <div className="flex flex-col min-h-screen bg-background text-text relative">
+      <header className="flex justify-center p-4">
+        <img
+          src="https://i.imgur.com/fvscsfn.png"
+          alt="TonPlaygram Logo"
+          className="max-w-[200px] w-full h-auto drop-shadow"
+        />
+      </header>
       <main className="flex-grow container mx-auto p-4 pb-24">
         {children}
       </main>

--- a/webapp/src/components/MiningCard.jsx
+++ b/webapp/src/components/MiningCard.jsx
@@ -1,24 +1,60 @@
 import { useEffect, useState } from 'react';
-import { getMiningStatus, startMining, claimMining } from '../utils/api.js';
+import {
+  getMiningStatus,
+  startMining,
+  claimMining,
+  getWalletBalance,
+  getTonBalance
+} from '../utils/api.js';
+import { useTonWallet } from '@tonconnect/ui-react';
 import { getTelegramId } from '../utils/telegram.js';
 
 export default function MiningCard() {
   const [status, setStatus] = useState('Not Mining');
   const [startTime, setStartTime] = useState(null);
+  const [timeLeft, setTimeLeft] = useState(0);
+  const [balances, setBalances] = useState({ ton: null, tpc: null, usdt: 0 });
+  const wallet = useTonWallet();
+
+  const loadBalances = async () => {
+    const prof = await getWalletBalance(getTelegramId());
+    const ton = wallet?.account?.address
+      ? (await getTonBalance(wallet.account.address)).balance
+      : null;
+    setBalances({ ton, tpc: prof.balance, usdt: 0 });
+  };
 
   const refresh = async () => {
-    const data = await getMiningStatus(getTelegramId());
-    setStatus(data.isMining ? 'Mining' : 'Not Mining');
+    try {
+      const data = await getMiningStatus(getTelegramId());
+      setStatus(data.isMining ? 'Mining' : 'Not Mining');
+    } catch (err) {
+      console.error(err);
+    }
+    loadBalances();
   };
 
   useEffect(() => {
     refresh();
-  }, []);
+    const saved = localStorage.getItem('miningStart');
+    if (saved) {
+      const start = parseInt(saved, 10);
+      setStartTime(start);
+      setStatus('Mining');
+      const elapsed = Date.now() - start;
+      const twelveHours = 12 * 60 * 60 * 1000;
+      setTimeLeft(Math.max(0, twelveHours - elapsed));
+    }
+  }, [wallet]);
 
   const handleStart = async () => {
-    setStartTime(Date.now());
+    const now = Date.now();
+    setStartTime(now);
+    setTimeLeft(12 * 60 * 60 * 1000);
+    localStorage.setItem('miningStart', String(now));
     setStatus('Mining');
     await startMining(getTelegramId());
+    loadBalances();
   };
 
   useEffect(() => {
@@ -26,8 +62,9 @@ export default function MiningCard() {
       const interval = setInterval(() => {
         const now = Date.now();
         const elapsed = now - startTime;
-        const twentyFourHours = 24 * 60 * 60 * 1000;
-        if (elapsed >= twentyFourHours) {
+        const twelveHours = 12 * 60 * 60 * 1000;
+        setTimeLeft(Math.max(0, twelveHours - elapsed));
+        if (elapsed >= twelveHours) {
           setStatus('Not Mining');
           autoDistributeRewards();
         }
@@ -38,6 +75,8 @@ export default function MiningCard() {
 
   const autoDistributeRewards = async () => {
     await claimMining(getTelegramId());
+    localStorage.removeItem('miningStart');
+    setTimeLeft(0);
     refresh();
   };
 
@@ -55,15 +94,47 @@ export default function MiningCard() {
         <span>⛏</span>
         <span>Mining</span>
       </h3>
-      <p>
-        Status:{' '}
-        <span className={status === 'Mining' ? 'text-green-500' : 'text-red-500'}>
-          {status}
-        </span>
-      </p>
-      <div>
-        <button className="px-2 py-1 bg-green-500 text-white" onClick={handleStart} disabled={status === 'Mining'}>Start</button>
+      <p className="text-xs text-gray-300">Total Balance</p>
+      <div className="flex justify-around text-xs mb-2">
+        <Token icon="/icons/ton.svg" value={balances.ton ?? '...'} />
+        <Token icon="/icons/tpc.svg" value={balances.tpc ?? '...'} />
+        <Token icon="/icons/usdt.svg" value={balances.usdt ?? '0'} />
+      </div>
+      <div className="flex items-center justify-between">
+        <button className="px-2 py-1 bg-green-500 text-white disabled:opacity-50" onClick={handleStart} disabled={status === 'Mining'}>
+          Start
+        </button>
+        <p className="text-sm">
+          Status{' '}
+          <span className={status === 'Mining' ? 'text-green-500' : 'text-red-500'}>
+            {status}
+            {status === 'Mining' && ` - ${formatTimeLeft(timeLeft)}`}
+          </span>
+        </p>
       </div>
     </div>
+  );
+}
+
+function Token({ icon, value }) {
+  return (
+    <div className="flex items-center space-x-1">
+      <img src={icon} alt="token" className="w-4 h-4" />
+      <span>{value}</span>
+    </div>
+  );
+}
+
+function formatTimeLeft(ms) {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return (
+    hours.toString().padStart(2, '0') +
+    ':' +
+    minutes.toString().padStart(2, '0') +
+    ':' +
+    seconds.toString().padStart(2, '0')
   );
 }

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -3,6 +3,12 @@ import SpinWheel from './SpinWheel.tsx';
 import RewardPopup from './RewardPopup.tsx';
 import AdModal from './AdModal.tsx';
 import { canSpin, nextSpinTime } from '../utils/rewardLogic';
+import {
+  getWalletBalance,
+  updateBalance,
+  addTransaction
+} from '../utils/api.js';
+import { getTelegramId } from '../utils/telegram.js';
 
 export default function SpinGame() {
   const [lastSpin, setLastSpin] = useState(null);
@@ -15,18 +21,22 @@ export default function SpinGame() {
     if (ts) setLastSpin(parseInt(ts, 10));
   }, []);
 
-  const handleFinish = (r) => {
+  const handleFinish = async (r) => {
     const now = Date.now();
     localStorage.setItem('lastSpin', String(now));
     setLastSpin(now);
     setReward(r);
+    const id = getTelegramId();
+    const balRes = await getWalletBalance(id);
+    const newBalance = (balRes.balance || 0) + r;
+    await updateBalance(id, newBalance);
+    await addTransaction(id, r, 'spin');
   };
 
   const ready = canSpin(lastSpin);
 
   return (
     <div className="bg-gray-800 rounded p-4 flex flex-col items-center space-y-2">
-      <div className="text-yellow-400 text-lg">Balance 9.87 M TPC</div>
       <SpinWheel
         onFinish={handleFinish}
         spinning={spinning}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -25,8 +25,8 @@ export default function Home() {
         <MiningCard />
         <GameCard title="Dice Duel" icon="/assets/icons/dice.svg" link="/games/dice" />
         <GameCard title="Snakes & Ladders" icon="/assets/icons/snake.svg" link="/games/snake" />
-        <GameCard title="Tasks" icon="✅" link="/tasks" />
-        <GameCard title="Profile" icon="👤" link="/account" />
+        <GameCard title="Tasks" icon="/assets/icons/tasks.svg" link="/tasks" />
+        <GameCard title="Profile" icon="/assets/icons/profile.svg" link="/account" />
       </div>
 
       <p className="text-center text-xs text-subtext">Status: {status}</p>

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -6,6 +6,7 @@ import { getTelegramId } from '../utils/telegram.js';
 export default function Mining() {
   const [status, setStatus] = useState('Not Mining');
   const [startTime, setStartTime] = useState(null);
+  const [timeLeft, setTimeLeft] = useState(0);
   const [balances, setBalances] = useState({ ton: null, tpc: null, usdt: 0 });
   const wallet = useTonWallet();
 
@@ -19,6 +20,15 @@ export default function Mining() {
 
   useEffect(() => {
     loadBalances();
+    const saved = localStorage.getItem('miningStart');
+    if (saved) {
+      const start = parseInt(saved, 10);
+      setStartTime(start);
+      setStatus('Mining');
+      const elapsed = Date.now() - start;
+      const twelveHours = 12 * 60 * 60 * 1000;
+      setTimeLeft(Math.max(0, twelveHours - elapsed));
+    }
   }, [wallet]);
 
   useEffect(() => {
@@ -26,8 +36,9 @@ export default function Mining() {
       const interval = setInterval(() => {
         const now = Date.now();
         const elapsed = now - startTime;
-        const twentyFourHours = 24 * 60 * 60 * 1000;
-        if (elapsed >= twentyFourHours) {
+        const twelveHours = 12 * 60 * 60 * 1000;
+        setTimeLeft(Math.max(0, twelveHours - elapsed));
+        if (elapsed >= twelveHours) {
           setStatus('Not Mining');
           autoDistributeRewards();
         }
@@ -37,13 +48,18 @@ export default function Mining() {
   }, [status, startTime]);
 
   const handleStart = async () => {
-    setStartTime(Date.now());
+    const now = Date.now();
+    setStartTime(now);
+    setTimeLeft(12 * 60 * 60 * 1000);
+    localStorage.setItem('miningStart', String(now));
     setStatus('Mining');
     await startMining(getTelegramId());
   };
 
   const autoDistributeRewards = async () => {
     await claimMining(getTelegramId());
+    localStorage.removeItem('miningStart');
+    setTimeLeft(0);
     loadBalances();
   };
 
@@ -58,20 +74,21 @@ export default function Mining() {
         </div>
       </div>
 
-      <div className="text-center mt-4">
+      <div className="flex items-center justify-between mt-4">
+        <button
+          onClick={handleStart}
+          disabled={status === 'Mining'}
+          className="bg-green-500 hover:bg-green-600 text-white px-4 py-1 rounded-full font-semibold disabled:opacity-50"
+        >
+          Start
+        </button>
         <p>
           Status:{' '}
           <span className={status === 'Mining' ? 'text-green-400' : 'text-red-400'}>
             {status}
+            {status === 'Mining' && ` - ${formatTimeLeft(timeLeft)}`}
           </span>
         </p>
-        <button
-          onClick={handleStart}
-          disabled={status === 'Mining'}
-          className="mt-2 bg-green-500 hover:bg-green-600 text-white px-4 py-1 rounded-full font-semibold"
-        >
-          Start
-        </button>
       </div>
     </div>
   );
@@ -83,5 +100,19 @@ function Token({ icon, value }) {
       <img src={icon} alt="token" className="w-5 h-5" />
       <span>{value}</span>
     </div>
+  );
+}
+
+function formatTimeLeft(ms) {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return (
+    hours.toString().padStart(2, '0') +
+    ':' +
+    minutes.toString().padStart(2, '0') +
+    ':' +
+    seconds.toString().padStart(2, '0')
   );
 }

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -3,6 +3,12 @@ import SpinWheel from '../components/SpinWheel.tsx';
 import RewardPopup from '../components/RewardPopup.tsx';
 import AdModal from '../components/AdModal.tsx';
 import { canSpin, nextSpinTime } from '../utils/rewardLogic';
+import {
+  getWalletBalance,
+  updateBalance,
+  addTransaction
+} from '../utils/api.js';
+import { getTelegramId } from '../utils/telegram.js';
 
 export default function SpinPage() {
   const [lastSpin, setLastSpin] = useState<number | null>(null);
@@ -15,18 +21,22 @@ export default function SpinPage() {
     if (ts) setLastSpin(parseInt(ts, 10));
   }, []);
 
-  const handleFinish = (r: number) => {
+  const handleFinish = async (r: number) => {
     const now = Date.now();
     localStorage.setItem('lastSpin', String(now));
     setLastSpin(now);
     setReward(r);
+    const id = getTelegramId();
+    const balRes = await getWalletBalance(id);
+    const newBalance = (balRes.balance || 0) + r;
+    await updateBalance(id, newBalance);
+    await addTransaction(id, r, 'spin');
   };
 
   const ready = canSpin(lastSpin);
 
   return (
     <div className="starry-bg min-h-screen flex flex-col items-center pt-8 text-white space-y-6">
-      <div className="text-yellow-400 text-lg">Balance 9.87 M TPC</div>
       <SpinWheel
         onFinish={handleFinish}
         spinning={spinning}


### PR DESCRIPTION
## Summary
- update spin game to auto-credit rewards to wallet
- remove balance label from both spin wheel UIs
- stop mining automatically after 12 hours and claim mined rewards
- tweak USDT icon letter
- sync mining status across pages and show wallet token balances
- add missing tasks and profile icons
- ensure mining card balance loads even if mining status fails
- show total balance on mining card and add countdown timer
- add TonPlaygram logo header

## Testing
- `npm --prefix webapp install`
- `npm --prefix webapp run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bdd992d388329968e5338319407cb