### PR TITLE
Remove dice and snake from home page

### DIFF
--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -23,8 +23,6 @@ export default function Home() {
 
       <div className="grid grid-cols-1 gap-4">
         <MiningCard />
-        <GameCard title="Dice Duel" icon="/assets/icons/dice.svg" link="/games/dice" />
-        <GameCard title="Snakes & Ladders" icon="/assets/icons/snake.svg" link="/games/snake" />
         <GameCard title="Tasks" icon="/assets/icons/tasks.svg" link="/tasks" />
         <GameCard title="Profile" icon="/assets/icons/profile.svg" link="/account" />
       </div>


### PR DESCRIPTION
## Summary
- remove Dice Duel and Snakes & Ladders cards from the home page

## Testing
- `npm --prefix webapp install`
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_684bf06734a883299a8f465c6d17e16a