### PR TITLE
Refine spin wheel and mining layout

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -21,7 +21,8 @@
     "react-router-dom": "^6.22.3",
     "tailwindcss": "^3.4.1",
     "vite": "^4.4.9",
-    "react-icons": "^4.10.1"
+    "react-icons": "^4.10.1",
+    "canvas-confetti": "^1.9.2"
   },
   "devDependencies": {
     "typescript": "^5.4.0",

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -5,13 +5,7 @@ import Footer from './Footer.jsx';
 export default function Layout({ children }) {
   return (
     <div className="flex flex-col min-h-screen bg-background text-text relative">
-      <header className="flex justify-center p-4">
-        <img
-          src="https://i.imgur.com/fvscsfn.png"
-          alt="TonPlaygram Logo"
-          className="max-w-[200px] w-full h-auto drop-shadow"
-        />
-      </header>
+      {/* Removed header logo per design change */}
       <main className="flex-grow container mx-auto p-4 pb-24">
         {children}
       </main>

--- a/webapp/src/components/MiningCard.jsx
+++ b/webapp/src/components/MiningCard.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { FaWallet } from 'react-icons/fa';
 import {
   getMiningStatus,
   startMining,
@@ -95,14 +96,7 @@ export default function MiningCard() {
         <span>Mining</span>
       </h3>
 
-      <p className="text-xs text-gray-300">Total Balance</p>
-      <div className="flex justify-around text-xs mb-2">
-        <Token icon="/icons/ton.svg" label="TON" value={balances.ton ?? '...'} />
-        <Token icon="/icons/tpc.svg" label="TPC" value={balances.tpc ?? '...'} />
-        <Token icon="/icons/usdt.svg" label="USDT" value={balances.usdt ?? '0'} />
-      </div>
-
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between text-sm">
         <button
           className="px-2 py-1 bg-green-500 text-white rounded disabled:opacity-50"
           onClick={handleStart}
@@ -110,13 +104,25 @@ export default function MiningCard() {
         >
           Start
         </button>
-        <p className="text-sm">
+        <p className="text-accent font-medium">
+          {status === 'Mining' ? formatTimeLeft(timeLeft) : '00:00:00'}
+        </p>
+        <p>
           Status{' '}
           <span className={status === 'Mining' ? 'text-green-500' : 'text-red-500'}>
             {status}
-            {status === 'Mining' && ` - ${formatTimeLeft(timeLeft)}`}
           </span>
         </p>
+      </div>
+
+      <p className="text-lg font-bold text-gray-300 flex items-center space-x-1">
+        <FaWallet />
+        <span>Total Balance</span>
+      </p>
+      <div className="flex justify-around text-sm mb-2">
+        <Token icon="/icons/ton.svg" label="TON" value={balances.ton ?? '...'} />
+        <Token icon="/icons/tpc.svg" label="TPC" value={balances.tpc ?? '...'} />
+        <Token icon="/icons/usdt.svg" label="USDT" value={balances.usdt ?? '0'} />
       </div>
     </div>
   );
@@ -126,7 +132,7 @@ function Token({ icon, value, label }) {
   return (
     <div className="flex items-center space-x-1">
       <img src={icon} alt={label} className="w-4 h-4" />
-      <span>{value}</span>
+      <span className="text-base">{value}</span>
     </div>
   );
 }

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -1,3 +1,6 @@
+import { useEffect } from 'react';
+import confetti from 'canvas-confetti';
+
 interface RewardPopupProps {
   reward: number | null;
   onClose: () => void;
@@ -5,6 +8,9 @@ interface RewardPopupProps {
 
 export default function RewardPopup({ reward, onClose }: RewardPopupProps) {
   if (reward === null) return null;
+  useEffect(() => {
+    confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
+  }, []);
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-gray-800 p-6 rounded text-center space-y-4">

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -18,7 +18,10 @@ export default function SpinWheel({ onFinish, spinning, setSpinning, disabled }:
     const reward = getRandomReward();
     const index = segments.indexOf(reward);
     const rotations = 4;
-    const final = rotations * 360 + index * segmentAngle + segmentAngle / 2;
+    const final =
+      rotations * 360 +
+      (segments.length - index) * segmentAngle -
+      segmentAngle / 2;
     setAngle(final);
     setSpinning(true);
     setTimeout(() => {
@@ -29,35 +32,37 @@ export default function SpinWheel({ onFinish, spinning, setSpinning, disabled }:
 
   return (
     <div className="relative w-64 h-64 mx-auto">
+      <div className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 w-0 h-0 border-l-8 border-r-8 border-b-[16px] border-l-transparent border-r-transparent border-b-yellow-500 z-10" />
       <div
         className="w-full h-full rounded-full border-4 border-yellow-500 flex items-center justify-center transition-transform duration-[4000ms]"
         style={{
           transform: `rotate(${angle}deg)`,
           backgroundImage:
-            'conic-gradient(#333 0deg 45deg, #111 45deg 90deg, #333 90deg 135deg, #111 135deg 180deg, #333 180deg 225deg, #111 225deg 270deg, #333 270deg 315deg, #111 315deg 360deg)'
+            'conic-gradient(from -90deg, #333 0deg 45deg, #111 45deg 90deg, #333 90deg 135deg, #111 135deg 180deg, #333 180deg 225deg, #111 225deg 270deg, #333 270deg 315deg, #111 315deg 360deg)'
         }}
       >
         {segments.map((s, i) => (
-          <span
+          <div
             key={i}
-            className="absolute text-yellow-400 text-sm"
+            className="absolute flex items-center text-yellow-400 text-sm"
             style={{
-              transform: `rotate(${i * segmentAngle}deg) translateY(-110px) rotate(${-i * segmentAngle}deg)`
+              transform: `rotate(${i * segmentAngle}deg) translateY(-90px) rotate(${-i * segmentAngle}deg)`
             }}
           >
-            {s}
-          </span>
+            <img src="/icons/tpc.svg" alt="TPC" className="w-4 h-4 mr-1" />
+            <span>{s}</span>
+          </div>
         ))}
 
-        {/* Centered Red Spin Button */}
-        <button
-          onClick={spin}
-          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-16 h-16 rounded-full bg-red-600 text-white text-sm font-bold flex items-center justify-center disabled:bg-gray-500"
-          disabled={spinning || disabled}
-        >
-          Spin
-        </button>
+        {/* wheel content */}
       </div>
+      <button
+        onClick={spin}
+        className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-16 h-16 rounded-full bg-green-600 text-white text-sm font-bold flex items-center justify-center disabled:bg-gray-500"
+        disabled={spinning || disabled}
+      >
+        Spin
+      </button>
     </div>
   );
 }

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -3,6 +3,7 @@ import GameCard from '../components/GameCard.jsx';
 import MiningCard from '../components/MiningCard.jsx';
 import Branding from '../components/Branding.jsx';
 import SpinGame from '../components/SpinGame.jsx';
+import { FaTasks, FaUser } from 'react-icons/fa';
 import { ping } from '../utils/api.js';
 
 export default function Home() {
@@ -23,10 +24,16 @@ export default function Home() {
 
       <div className="grid grid-cols-1 gap-4">
         <MiningCard />
-        <GameCard title="Dice Duel" icon="/assets/icons/dice.svg" link="/games/dice" />
-        <GameCard title="Snakes & Ladders" icon="/assets/icons/snake.svg" link="/games/snake" />
-        <GameCard title="Tasks" icon="/assets/icons/tasks.svg" link="/tasks" />
-        <GameCard title="Profile" icon="/assets/icons/profile.svg" link="/account" />
+        <GameCard
+          title="Tasks"
+          icon={<FaTasks className="text-primary" />}
+          link="/tasks"
+        />
+        <GameCard
+          title="Profile"
+          icon={<FaUser className="text-accent" />}
+          link="/account"
+        />
       </div>
 
       <p className="text-center text-xs text-subtext">Status: {status}</p>


### PR DESCRIPTION
## Summary
- keep spin button static and flip reward pointer
- stop wheel in slice center with icons centered
- move mining status row above balances with a wallet icon

## Testing
- `npm --prefix webapp install`
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_684bf06734a883299a8f465c6d17e16a