### PR TITLE
Serve dynamic TonConnect manifest

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -93,7 +93,13 @@ app.use(express.static(webappPath));
 // deployments hit this Express server before the static middleware. Providing
 // an explicit route avoids 404 errors.
 app.get('/tonconnect-manifest.json', (req, res) => {
-  res.sendFile(path.join(webappPath, 'tonconnect-manifest.json'));
+  const baseUrl = `${req.protocol}://${req.get('host')}`;
+  res.json({
+    name: 'TonPlaygram Chess',
+    description: 'Play chess with TPC staking via Tonkeeper',
+    url: baseUrl,
+    icons: [`${baseUrl}/icons/tpc.svg`]
+  });
 });
 app.get('/', (req, res) => {
   res.sendFile(path.join(webappPath, 'index.html'));

--- a/webapp/public/tonconnect-manifest.json
+++ b/webapp/public/tonconnect-manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "TonPlaygram Chess",
   "description": "Play chess with TPC staking via Tonkeeper",
-  "url": "https://tonplaygram.example.com",
-  "icons": ["https://tonplaygram.example.com/icon.png"]
+  "url": "http://localhost:3000",
+  "icons": ["/icons/tpc.svg"]
 }


### PR DESCRIPTION
## Summary
- generate the TonConnect manifest dynamically using the request host
- update the public manifest to use a local URL and SVG icon

## Testing
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_684c0ceb8dc88329a4943ec174b80469