### PR TITLE
Update spin wheel appearance

### DIFF
--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -8,9 +8,12 @@ interface SpinWheelProps {
   disabled?: boolean;
 }
 
-const itemHeight = 60; // Height per row in pixels
-const visibleRows = 7;
-const loops = 6;
+// Visual settings for the wheel
+const itemHeight = 56; // Height per row in pixels
+const visibleRows = 7; // Show seven prices with the third row as the winner
+const winningRow = 2; // Index of the winning row (0-based)
+const loops = 12; // How many times the list repeats while spinning
+const pointerSize = 12; // Triangle height/width in pixels
 
 export default function SpinWheel({
   onFinish,
@@ -27,7 +30,7 @@ export default function SpinWheel({
     const reward = getRandomReward();
     const index = segments.indexOf(reward);
     const finalIndex = loops * segments.length + index;
-    const finalOffset = -(finalIndex - Math.floor(visibleRows / 2)) * itemHeight;
+    const finalOffset = -(finalIndex - winningRow) * itemHeight;
 
     setOffset(finalOffset);
     setSpinning(true);
@@ -41,25 +44,49 @@ export default function SpinWheel({
   };
 
   const items = Array.from(
-    { length: segments.length * loops + visibleRows },
+    { length: segments.length * loops + visibleRows + segments.length },
     (_, i) => segments[i % segments.length]
   );
 
   return (
-    <div className="relative w-32 mx-auto flex flex-col items-center">
-      {/* Top pointer */}
-      <div className="absolute -top-2 left-1/2 -translate-x-1/2 w-0 h-0 
-                      border-l-8 border-r-8 border-b-8 
-                      border-l-transparent border-r-transparent border-b-yellow-500 z-10" />
+    <div className="relative w-40 mx-auto flex flex-col items-center">
+      {/* Highlight for winning row */}
+      <div
+        className="absolute inset-x-0 border-4 border-yellow-500 pointer-events-none"
+        style={{ top: itemHeight * winningRow, height: itemHeight }}
+      />
 
-      {/* Bottom pointer */}
-      <div className="absolute -bottom-2 left-1/2 -translate-x-1/2 w-0 h-0 
-                      border-l-8 border-r-8 border-t-8 
-                      border-l-transparent border-r-transparent border-t-yellow-500 z-10" />
+      {/* Left pointer */}
+      <div
+        className="absolute z-10"
+        style={{
+          top: itemHeight * winningRow + itemHeight / 2 - pointerSize,
+          left: -pointerSize * 2,
+          width: 0,
+          height: 0,
+          borderTop: `${pointerSize}px solid transparent`,
+          borderBottom: `${pointerSize}px solid transparent`,
+          borderRight: `${pointerSize * 1.5}px solid #eab308`
+        }}
+      />
+
+      {/* Right pointer */}
+      <div
+        className="absolute z-10"
+        style={{
+          top: itemHeight * winningRow + itemHeight / 2 - pointerSize,
+          right: -pointerSize * 2,
+          width: 0,
+          height: 0,
+          borderTop: `${pointerSize}px solid transparent`,
+          borderBottom: `${pointerSize}px solid transparent`,
+          borderLeft: `${pointerSize * 1.5}px solid #eab308`
+        }}
+      />
 
       {/* Slot container */}
       <div
-        className="overflow-hidden w-full border-4 border-yellow-500 rounded bg-gray-900"
+        className="overflow-hidden w-full"
         style={{ height: itemHeight * visibleRows }}
       >
         <div
@@ -72,11 +99,12 @@ export default function SpinWheel({
           {items.map((val, idx) => (
             <div
               key={idx}
-              className={`h-[60px] flex items-center justify-center text-sm w-full ${
-                idx === winnerIndex ? 'bg-yellow-600 text-white' : 'text-yellow-400'
+              className={`flex items-center justify-center text-xl w-full ${
+                idx === winnerIndex ? 'bg-yellow-500 text-black font-bold' : 'text-yellow-400'
               }`}
+              style={{ height: itemHeight }}
             >
-              <img src="/icons/tpc.svg" alt="TPC" className="w-4 h-4 mr-1" />
+              <img src="/icons/tpc.svg" alt="TPC" className="w-6 h-6 mr-1" />
               <span>{val}</span>
             </div>
           ))}

--- a/webapp/src/utils/rewardLogic.ts
+++ b/webapp/src/utils/rewardLogic.ts
@@ -1,4 +1,5 @@
-export const segments = [300, 800, 1000, 1200, 1400, 1500, 1600, 1800];
+// Prize amounts available on the wheel. Added a 5000 TPC jackpot.
+export const segments = [300, 800, 1000, 1200, 1400, 1500, 1600, 1800, 5000];
 const ONE_HOUR = 3600_000;
 
 export function canSpin(lastSpin: number | null): boolean {


### PR DESCRIPTION
## Summary
- tweak spin wheel design
- add 5000 TPC jackpot to possible rewards
- remove pointers and highlight third row
- show seven prizes while spinning

## Testing
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_684c3b4c2d548329a2e64eb6139f96b9