### PR TITLE
Update tasks and unify UI styling

### DIFF
--- a/bot/utils/tasksData.js
+++ b/bot/utils/tasksData.js
@@ -1,4 +1,20 @@
 export const TASKS = [
-  { id: 'join_twitter', description: 'Join our Twitter', reward: 10 },
-  { id: 'join_telegram', description: 'Join our Telegram', reward: 10 }
+  {
+    id: 'join_twitter',
+    description: 'Join our Twitter',
+    reward: 10,
+    icon: 'twitter'
+  },
+  {
+    id: 'join_telegram',
+    description: 'Join our Telegram',
+    reward: 10,
+    icon: 'telegram'
+  },
+  {
+    id: 'follow_tiktok',
+    description: 'Follow our TikTok @TonPlaygram',
+    reward: 10,
+    icon: 'tiktok'
+  }
 ];

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -88,7 +88,7 @@ export default function MiningCard() {
   };
 
   return (
-    <div className="bg-gray-800/60 p-4 rounded-xl shadow-lg text-white space-y-2">
+    <div className="bg-surface border border-border p-4 rounded-xl shadow-lg text-text space-y-2">
       <h3 className="text-lg font-bold flex items-center space-x-2">
         <span>⛏</span>
         <span>Mining</span>

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -13,7 +13,7 @@ export default function RewardPopup({ reward, onClose }: RewardPopupProps) {
   }, []);
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="bg-gray-800 p-6 rounded text-center space-y-4">
+      <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text">
         <div className="text-yellow-400 text-3xl">+{reward} TPC</div>
         <button
           onClick={onClose}

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -36,7 +36,7 @@ export default function SpinGame() {
   const ready = canSpin(lastSpin);
 
   return (
-    <div className="bg-gray-800 rounded p-4 flex flex-col items-center space-y-2">
+    <div className="bg-surface border border-border rounded p-4 flex flex-col items-center space-y-2">
       <SpinWheel
         onFinish={handleFinish}
         spinning={spinning}

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -4,7 +4,13 @@ import { getTelegramId } from '../utils/telegram.js';
 import { IoLogoTwitter, IoLogoTiktok } from 'react-icons/io5';
 import { RiTelegramFill } from 'react-icons/ri';
 
-export default function Tasks() {
+const ICONS = {
+  join_twitter: <IoLogoTwitter className="text-sky-400 w-5 h-5" />,
+  join_telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
+  follow_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />
+};
+
+export default function TasksCard() {
   const [tasks, setTasks] = useState(null);
 
   const load = async () => {
@@ -21,34 +27,33 @@ export default function Tasks() {
     load();
   };
 
-  if (!tasks) return <div className="p-4 text-subtext">Loading...</div>;
-
-  const ICONS = {
-    join_twitter: <IoLogoTwitter className="text-sky-400 w-5 h-5" />,
-    join_telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
-    follow_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />
-  };
+  if (!tasks) {
+    return (
+      <div className="bg-surface border border-border rounded-xl p-4 text-subtext text-center">
+        Loading tasks...
+      </div>
+    );
+  }
 
   return (
-    <div className="p-4 space-y-2 text-text">
-      <h2 className="text-xl font-bold">Tasks</h2>
-
+    <div className="bg-surface border border-border rounded-xl p-4 space-y-2">
+      <h3 className="text-lg font-bold text-text text-center">Tasks</h3>
       <ul className="space-y-2">
         {tasks.map((t) => (
           <li
             key={t.id}
-            className="bg-surface border border-border rounded p-2 flex justify-between items-center"
+            className="flex justify-between items-center"
           >
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center space-x-2 text-sm">
               {ICONS[t.id]}
               <span>{t.description}</span>
             </div>
             {t.completed ? (
-              <span className="text-accent font-semibold">Completed</span>
+              <span className="text-accent font-semibold text-sm">Done</span>
             ) : (
               <button
                 onClick={() => handleComplete(t.id)}
-                className="px-2 py-1 bg-primary hover:bg-primary-hover text-text rounded"
+                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-text text-sm rounded"
               >
                 Complete
               </button>

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -3,7 +3,8 @@ import GameCard from '../components/GameCard.jsx';
 import MiningCard from '../components/MiningCard.tsx';
 import Branding from '../components/Branding.jsx';
 import SpinGame from '../components/SpinGame.jsx';
-import { FaTasks, FaUser } from 'react-icons/fa';
+import TasksCard from '../components/TasksCard.jsx';
+import { FaUser } from 'react-icons/fa';
 import { ping } from '../utils/api.js';
 
 export default function Home() {
@@ -24,11 +25,7 @@ export default function Home() {
 
       <div className="grid grid-cols-1 gap-4">
         <MiningCard />
-        <GameCard
-          title="Tasks"
-          icon={<FaTasks className="text-primary" />}
-          link="/tasks"
-        />
+        <TasksCard />
         <GameCard
           title="Profile"
           icon={<FaUser className="text-accent" />}

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -77,7 +77,7 @@ export default function Mining() {
   };
 
   return (
-    <div className="bg-[#11172a] text-white p-4 rounded-lg shadow-lg">
+    <div className="bg-surface border border-border text-text p-4 rounded-lg shadow-lg">
       <div className="text-center mb-4">
         <p className="text-gray-300 mb-2">Total Balance</p>
         <div className="flex justify-around items-center text-sm">

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -36,21 +36,23 @@ export default function SpinPage() {
   const ready = canSpin(lastSpin);
 
   return (
-    <div className="starry-bg min-h-screen flex flex-col items-center pt-8 text-white space-y-6">
-      <SpinWheel
-        onFinish={handleFinish}
-        spinning={spinning}
-        setSpinning={setSpinning}
-        disabled={!ready}
-      />
-      {!ready && (
-        <>
-          <p className="text-sm text-yellow-400">Next spin at {new Date(nextSpinTime(lastSpin)).toLocaleTimeString()}</p>
-          <button className="text-yellow-400 underline text-sm" onClick={() => setShowAd(true)}>
-            Watch an ad every hour to get a free spin.
-          </button>
-        </>
-      )}
+    <div className="p-4 space-y-6 flex flex-col items-center text-text">
+      <div className="bg-surface border border-border rounded p-4 flex flex-col items-center space-y-2">
+        <SpinWheel
+          onFinish={handleFinish}
+          spinning={spinning}
+          setSpinning={setSpinning}
+          disabled={!ready}
+        />
+        {!ready && (
+          <>
+            <p className="text-sm text-yellow-400">Next spin at {new Date(nextSpinTime(lastSpin)).toLocaleTimeString()}</p>
+            <button className="text-yellow-400 underline text-sm" onClick={() => setShowAd(true)}>
+              Watch an ad every hour to get a free spin.
+            </button>
+          </>
+        )}
+      </div>
       <RewardPopup reward={reward} onClose={() => setReward(null)} />
       <AdModal open={showAd} onClose={() => setShowAd(false)} />
     </div>


### PR DESCRIPTION
## Summary
- add TikTok follow task to backend task list
- display icons on Tasks page
- add new TasksCard on home page showing tasks
- use new card styles for Mining, Spin & Win and reward popup
- update MiningCard styling

## Testing
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_684c5ccf26c883298395c9d159937c06