### PR TITLE
Update branding to use logo

### DIFF
--- a/webapp/src/components/Branding.jsx
+++ b/webapp/src/components/Branding.jsx
@@ -1,17 +1,13 @@
 import React from 'react';
-import ConnectWallet from './ConnectWallet.jsx';
 
 export default function Branding() {
   return (
     <div className="text-center py-6 space-y-2">
-      <div className="hexagon w-16 h-16 mx-auto bg-accent flex items-center justify-center">
-        <span className="text-3xl font-extrabold text-background">P</span>
-      </div>
-      <h1 className="text-2xl font-bold text-text">TONPLAYGRAM</h1>
-      <p className="text-accent text-xs tracking-widest">PLAY. EARN. DOMINATE.</p>
-      <div className="flex justify-center">
-        <ConnectWallet />
-      </div>
+      <img
+        src="/assets/TonPlaygramLogo.JPG"
+        alt="TonPlaygram Logo"
+        className="mx-auto w-16 h-16"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove placeholder image
- Branding component still references `TonPlaygramLogo.JPG`

## Testing
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_684c7adc92ac832996de8160ce77193b