### PR TITLE
Update UI colors and icons

### DIFF
--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -102,7 +102,7 @@ export default function MiningCard() {
         >
           Start
         </button>
-        <p className="text-accent font-medium">
+        <p className="text-white font-medium">
           {status === 'Mining' ? formatTimeLeft(timeLeft) : '00:00:00'}
         </p>
         <p>

--- a/webapp/src/components/NavItem.jsx
+++ b/webapp/src/components/NavItem.jsx
@@ -8,7 +8,7 @@ export default function NavItem({ to, icon: Icon, label }) {
         `flex flex-col items-center text-sm ${isActive ? 'text-accent' : 'text-text hover:text-accent'}`
       }
     >
-      <Icon className="w-8 h-8 mb-1" />
+      <Icon className="w-8 h-8 mb-1 text-accent" />
       <span>{label}</span>
     </NavLink>
   );

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -45,11 +45,11 @@ export default function SpinGame() {
       />
       {!ready && (
         <>
-          <p className="text-sm text-yellow-400">
+          <p className="text-sm text-white font-semibold">
             Next spin at {new Date(nextSpinTime(lastSpin)).toLocaleTimeString()}
           </p>
           <button
-            className="text-yellow-400 underline text-sm"
+            className="text-white underline text-sm"
             onClick={() => setShowAd(true)}
           >
             Watch an ad every hour to get a free spin.

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -120,9 +120,9 @@ export default function SpinWheel({
 
               key={idx}
 
-              className={`flex items-center justify-center text-sm w-full ${
+              className={`flex items-center justify-center text-sm w-full font-bold ${
 
-                idx === winnerIndex ? 'bg-yellow-500 text-black font-bold' : 'text-yellow-400'
+                idx === winnerIndex ? 'bg-yellow-500 text-white' : 'text-white'
 
               }`}
 

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -7,6 +7,7 @@ import { getTelegramId } from '../utils/telegram.js';
 import { IoLogoTwitter, IoLogoTiktok } from 'react-icons/io5';
 
 import { RiTelegramFill } from 'react-icons/ri';
+import { AiOutlineCheckSquare } from 'react-icons/ai';
 
 const ICONS = {
 
@@ -64,7 +65,7 @@ export default function TasksCard() {
 
     <div className="bg-surface border border-border rounded-xl p-4 space-y-2">
 
-      <h3 className="text-lg font-bold text-text text-center">Tasks</h3>
+      <h3 className="text-lg font-bold text-text flex items-center justify-center space-x-1"><AiOutlineCheckSquare className="text-accent" /><span>Tasks</span></h3>
 
       <ul className="space-y-2">
 

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -46,8 +46,8 @@ export default function SpinPage() {
         />
         {!ready && (
           <>
-            <p className="text-sm text-yellow-400">Next spin at {new Date(nextSpinTime(lastSpin)).toLocaleTimeString()}</p>
-            <button className="text-yellow-400 underline text-sm" onClick={() => setShowAd(true)}>
+            <p className="text-sm text-white font-semibold">Next spin at {new Date(nextSpinTime(lastSpin)).toLocaleTimeString()}</p>
+            <button className="text-white underline text-sm" onClick={() => setShowAd(true)}>
               Watch an ad every hour to get a free spin.
             </button>
           </>


### PR DESCRIPTION
## Summary
- make wheel prizes display white text
- show next spin info in white
- change mining card timer to white
- colorize navbar icons
- add colored icon to Tasks card

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c8872fe648329859de3a39598ded8