### PR TITLE
Add daily check-in

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import RewardPopup from './RewardPopup.tsx';
+
+const REWARDS = Array.from({ length: 30 }, (_, i) => 1000 * (i + 1));
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+export default function DailyCheckIn() {
+  const [streak, setStreak] = useState(1);
+  const [lastCheck, setLastCheck] = useState(null);
+  const [showPopup, setShowPopup] = useState(false);
+  const [reward, setReward] = useState(null);
+
+  useEffect(() => {
+    const savedStreak = parseInt(localStorage.getItem('dailyStreak') || '1', 10);
+    const savedLast = localStorage.getItem('lastCheckIn');
+    setStreak(savedStreak);
+    setLastCheck(savedLast ? parseInt(savedLast, 10) : null);
+
+    const now = Date.now();
+    if (!savedLast || now - parseInt(savedLast, 10) >= ONE_DAY) {
+      setShowPopup(true);
+    }
+  }, []);
+
+  const handleCheckIn = () => {
+    const now = Date.now();
+    let newStreak = 1;
+    if (lastCheck && now - lastCheck < ONE_DAY * 2) {
+      newStreak = Math.min(streak + 1, 30);
+    }
+    setStreak(newStreak);
+    setLastCheck(now);
+    localStorage.setItem('dailyStreak', String(newStreak));
+    localStorage.setItem('lastCheckIn', String(now));
+    setReward(REWARDS[newStreak - 1]);
+    setShowPopup(false);
+  };
+
+  const progress = [];
+  for (let i = streak - 1; i < Math.min(streak + 5, REWARDS.length); i++) {
+    progress.push(
+      <div
+        key={i}
+        className={`flex flex-col items-center p-2 rounded border border-border w-20 text-xs ${
+          i === streak - 1 ? 'bg-accent text-white' : 'bg-surface text-text'
+        }`}
+      >
+        <span>Day {i + 1}</span>
+        <span>{REWARDS[i]} TPC</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full space-y-2">
+      {showPopup && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
+          <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text">
+            <p className="font-semibold">Daily Check-In</p>
+            <button onClick={handleCheckIn} className="px-4 py-2 bg-blue-600 text-white rounded">
+              Check in
+            </button>
+          </div>
+        </div>
+      )}
+      {reward !== null && <RewardPopup reward={reward} onClose={() => setReward(null)} />}
+      <div className="flex space-x-2 overflow-x-auto">{progress}</div>
+    </div>
+  );
+}

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -102,7 +102,7 @@ export default function MiningCard() {
         >
           Start
         </button>
-        <p className="text-accent font-medium">
+        <p className="text-white font-medium">
           {status === 'Mining' ? formatTimeLeft(timeLeft) : '00:00:00'}
         </p>
         <p>

--- a/webapp/src/components/NavItem.jsx
+++ b/webapp/src/components/NavItem.jsx
@@ -8,7 +8,7 @@ export default function NavItem({ to, icon: Icon, label }) {
         `flex flex-col items-center text-sm ${isActive ? 'text-accent' : 'text-text hover:text-accent'}`
       }
     >
-      <Icon className="w-8 h-8 mb-1" />
+      <Icon className="w-8 h-8 mb-1 text-accent" />
       <span>{label}</span>
     </NavLink>
   );

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import SpinWheel from './SpinWheel.tsx';
 import RewardPopup from './RewardPopup.tsx';
 import AdModal from './AdModal.tsx';
+import DailyCheckIn from './DailyCheckIn.jsx';
 import { canSpin, nextSpinTime } from '../utils/rewardLogic';
 import {
   getWalletBalance,
@@ -45,17 +46,18 @@ export default function SpinGame() {
       />
       {!ready && (
         <>
-          <p className="text-sm text-yellow-400">
+          <p className="text-sm text-white font-semibold">
             Next spin at {new Date(nextSpinTime(lastSpin)).toLocaleTimeString()}
           </p>
           <button
-            className="text-yellow-400 underline text-sm"
+            className="text-white underline text-sm"
             onClick={() => setShowAd(true)}
           >
             Watch an ad every hour to get a free spin.
           </button>
         </>
       )}
+      <DailyCheckIn />
       <RewardPopup reward={reward} onClose={() => setReward(null)} />
       <AdModal open={showAd} onClose={() => setShowAd(false)} />
     </div>

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -120,9 +120,9 @@ export default function SpinWheel({
 
               key={idx}
 
-              className={`flex items-center justify-center text-sm w-full ${
+              className={`flex items-center justify-center text-sm w-full font-bold ${
 
-                idx === winnerIndex ? 'bg-yellow-500 text-black font-bold' : 'text-yellow-400'
+                idx === winnerIndex ? 'bg-yellow-500 text-white' : 'text-white'
 
               }`}
 

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -7,6 +7,7 @@ import { getTelegramId } from '../utils/telegram.js';
 import { IoLogoTwitter, IoLogoTiktok } from 'react-icons/io5';
 
 import { RiTelegramFill } from 'react-icons/ri';
+import { AiOutlineCheckSquare } from 'react-icons/ai';
 
 const ICONS = {
 
@@ -64,7 +65,7 @@ export default function TasksCard() {
 
     <div className="bg-surface border border-border rounded-xl p-4 space-y-2">
 
-      <h3 className="text-lg font-bold text-text text-center">Tasks</h3>
+      <h3 className="text-lg font-bold text-text flex items-center justify-center space-x-1"><AiOutlineCheckSquare className="text-accent" /><span>Tasks</span></h3>
 
       <ul className="space-y-2">
 

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -46,8 +46,8 @@ export default function SpinPage() {
         />
         {!ready && (
           <>
-            <p className="text-sm text-yellow-400">Next spin at {new Date(nextSpinTime(lastSpin)).toLocaleTimeString()}</p>
-            <button className="text-yellow-400 underline text-sm" onClick={() => setShowAd(true)}>
+            <p className="text-sm text-white font-semibold">Next spin at {new Date(nextSpinTime(lastSpin)).toLocaleTimeString()}</p>
+            <button className="text-white underline text-sm" onClick={() => setShowAd(true)}>
               Watch an ad every hour to get a free spin.
             </button>
           </>


### PR DESCRIPTION
## Summary
- implement DailyCheckIn component for 30-day streak rewards
- display progress and popup for daily check-in
- show check-in section under the spin-game ad message

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c8872fe648329859de3a39598ded8