### PR TITLE
Add room selection modal and center streak number

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -36,7 +36,6 @@ export default function DailyCheckIn() {
     setShowPopup(false);
   };
 
-  // Show only current streak day and the next 4 days (total 5)
   const progress = [];
   for (
     let i = streak - 1;
@@ -46,4 +45,33 @@ export default function DailyCheckIn() {
     progress.push(
       <div
         key={i}
-        className={`flex flex-col items-center p-2 rounded border border-border w-20 text-xs ${
+        className={`flex flex-col items-center justify-center p-2 rounded border border-border w-20 text-xs ${
+          i === streak - 1 ? 'bg-accent text-white' : 'bg-surface text-text'
+        }`}
+      >
+        <span className="text-lg font-bold">{i + 1}</span>
+        <span className="flex items-center">
+          {REWARDS[i]}
+          <img src="/icons/tpc.svg" alt="TPC" className="w-4 h-4 ml-1" />
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full space-y-2">
+      {showPopup && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
+          <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text">
+            <p className="font-semibold">Daily Check-In</p>
+            <button onClick={handleCheckIn} className="px-4 py-2 bg-blue-600 text-white rounded">
+              Check in
+            </button>
+          </div>
+        </div>
+      )}
+      {reward !== null && <RewardPopup reward={reward} onClose={() => setReward(null)} />}
+      <div className="flex space-x-2 overflow-x-auto">{progress}</div>
+    </div>
+  );
+}

--- a/webapp/src/components/RoomPopup.jsx
+++ b/webapp/src/components/RoomPopup.jsx
@@ -1,0 +1,20 @@
+import RoomSelector from './RoomSelector.jsx';
+
+export default function RoomPopup({ open, selection, setSelection, onConfirm }) {
+  if (!open) return null;
+  const disabled = !selection || !selection.token || !selection.amount;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
+      <div className="bg-surface border border-border p-4 rounded space-y-4 text-text">
+        <RoomSelector selected={selection || { token: '', amount: 0 }} onSelect={setSelection} />
+        <button
+          onClick={onConfirm}
+          disabled={disabled}
+          className={`px-4 py-1 bg-blue-600 text-white rounded w-full disabled:opacity-50`}
+        >
+          Confirm
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -1,25 +1,30 @@
 import React from 'react';
 
 const amounts = [100, 500, 1000, 5000, 10000];
-const tokens = ['TPC', 'TON', 'USDT'];
+const tokens = [
+  { id: 'TPC', icon: '/icons/tpc.svg' },
+  { id: 'TON', icon: '/icons/ton.svg' },
+  { id: 'USDT', icon: '/icons/usdt.svg' },
+];
 
 export default function RoomSelector({ selected, onSelect }) {
   const { token, amount } = selected;
   return (
     <div className="space-y-2">
-      {tokens.map((tok) => (
-        <div key={tok} className="space-x-2">
+      {tokens.map(({ id, icon }) => (
+        <div key={id} className="flex items-center space-x-2">
           {amounts.map((amt) => (
             <button
-              key={`${tok}-${amt}`}
-              onClick={() => onSelect({ token: tok, amount: amt })}
-              className={`px-2 py-1 border rounded ${
-                token === tok && amount === amt
+              key={`${id}-${amt}`}
+              onClick={() => onSelect({ token: id, amount: amt })}
+              className={`px-2 py-1 border rounded flex items-center space-x-1 ${
+                token === id && amount === amt
                   ? 'bg-yellow-400 text-gray-900'
                   : 'bg-gray-700 text-white'
               }`}
             >
-              {amt} {tok}
+              <span>{amt}</span>
+              <img src={icon} alt={id} className="w-4 h-4" />
             </button>
           ))}
         </div>

--- a/webapp/src/pages/Games/Chess.jsx
+++ b/webapp/src/pages/Games/Chess.jsx
@@ -2,10 +2,11 @@ import { useEffect, useState } from 'react';
 import { Chess } from 'chess.js';
 import { Chessboard } from 'react-chessboard';
 import ConnectWallet from '../../components/ConnectWallet.jsx';
-import RoomSelector from '../../components/RoomSelector.jsx';
+import RoomPopup from '../../components/RoomPopup.jsx';
 
 export default function ChessGame() {
-  const [selection, setSelection] = useState({ token: 'TPC', amount: 100 });
+  const [selection, setSelection] = useState(null);
+  const [showRoom, setShowRoom] = useState(true);
   const [game, setGame] = useState(new Chess());
   const [seconds, setSeconds] = useState(5 * 60); // 5-minute timer
 
@@ -34,18 +35,23 @@ export default function ChessGame() {
 
   return (
     <div className="p-4 space-y-4 text-text">
-      <RoomSelector selected={selection} onSelect={setSelection} />
+      <RoomPopup
+        open={showRoom}
+        selection={selection}
+        setSelection={setSelection}
+        onConfirm={() => setShowRoom(false)}
+      />
 
       {/* Top Player Bar */}
       <div className="flex items-center justify-between">
         <div className="text-center">
           <img src="https://placehold.co/64" alt="Player" className="rounded-full mx-auto" />
-          <p className="text-xs mt-1">0.5 {selection.token}</p>
+          <p className="text-xs mt-1">0.5 {selection?.token}</p>
         </div>
         <div className="text-xl font-bold">{formatTime(seconds)}</div>
         <div className="text-center">
           <img src="https://placehold.co/64" alt="Opponent" className="rounded-full mx-auto" />
-          <p className="text-xs mt-1">0.5 {selection.token}</p>
+          <p className="text-xs mt-1">0.5 {selection?.token}</p>
         </div>
       </div>
 
@@ -73,7 +79,7 @@ export default function ChessGame() {
         </div>
         <div className="flex items-center space-x-1">
           <span className="text-yellow-400">🪙</span>
-          <span>{selection.amount * 2} {selection.token}</span>
+          <span>{(selection?.amount ?? 0) * 2} {selection?.token}</span>
         </div>
         <button className="px-3 py-1 border border-yellow-500 rounded text-yellow-500 hover:bg-yellow-500 hover:text-black transition">
           LEAVE

--- a/webapp/src/pages/Games/DiceGame.jsx
+++ b/webapp/src/pages/Games/DiceGame.jsx
@@ -1,14 +1,20 @@
 import { useState } from 'react';
 import ConnectWallet from '../../components/ConnectWallet.jsx';
-import RoomSelector from '../../components/RoomSelector.jsx';
+import RoomPopup from '../../components/RoomPopup.jsx';
 
 export default function DiceGame() {
-  const [selection, setSelection] = useState({ token: 'TPC', amount: 100 });
+  const [selection, setSelection] = useState(null);
+  const [showRoom, setShowRoom] = useState(true);
 
   return (
     <div className="p-4 space-y-4">
       <h2 className="text-xl font-bold">Dice Duel</h2>
-      <RoomSelector selected={selection} onSelect={setSelection} />
+      <RoomPopup
+        open={showRoom}
+        selection={selection}
+        setSelection={setSelection}
+        onConfirm={() => setShowRoom(false)}
+      />
       <ConnectWallet />
       <p>Dice game coming soon.</p>
     </div>

--- a/webapp/src/pages/Games/HorseRacing.jsx
+++ b/webapp/src/pages/Games/HorseRacing.jsx
@@ -1,14 +1,20 @@
 import { useState } from 'react';
 import ConnectWallet from '../../components/ConnectWallet.jsx';
-import RoomSelector from '../../components/RoomSelector.jsx';
+import RoomPopup from '../../components/RoomPopup.jsx';
 
 export default function HorseRacing() {
-  const [selection, setSelection] = useState({ token: 'TPC', amount: 100 });
+  const [selection, setSelection] = useState(null);
+  const [showRoom, setShowRoom] = useState(true);
 
   return (
     <div className="p-4 space-y-4">
       <h2 className="text-xl font-bold">Horse Racing</h2>
-      <RoomSelector selected={selection} onSelect={setSelection} />
+      <RoomPopup
+        open={showRoom}
+        selection={selection}
+        setSelection={setSelection}
+        onConfirm={() => setShowRoom(false)}
+      />
       <ConnectWallet />
       <p>Horse racing game coming soon.</p>
     </div>

--- a/webapp/src/pages/Games/LudoGame.jsx
+++ b/webapp/src/pages/Games/LudoGame.jsx
@@ -1,14 +1,20 @@
 import { useState } from 'react';
 import ConnectWallet from '../../components/ConnectWallet.jsx';
-import RoomSelector from '../../components/RoomSelector.jsx';
+import RoomPopup from '../../components/RoomPopup.jsx';
 
 export default function LudoGame() {
-  const [selection, setSelection] = useState({ token: 'TPC', amount: 100 });
+  const [selection, setSelection] = useState(null);
+  const [showRoom, setShowRoom] = useState(true);
 
   return (
     <div className="p-4 space-y-4">
       <h2 className="text-xl font-bold">Ludo Game</h2>
-      <RoomSelector selected={selection} onSelect={setSelection} />
+      <RoomPopup
+        open={showRoom}
+        selection={selection}
+        setSelection={setSelection}
+        onConfirm={() => setShowRoom(false)}
+      />
       <ConnectWallet />
       <p>Ludo game coming soon.</p>
     </div>

--- a/webapp/src/pages/Games/SnakeLadders.jsx
+++ b/webapp/src/pages/Games/SnakeLadders.jsx
@@ -1,14 +1,20 @@
 import { useState } from 'react';
 import ConnectWallet from '../../components/ConnectWallet.jsx';
-import RoomSelector from '../../components/RoomSelector.jsx';
+import RoomPopup from '../../components/RoomPopup.jsx';
 
 export default function SnakeLadders() {
-  const [selection, setSelection] = useState({ token: 'TPC', amount: 100 });
+  const [selection, setSelection] = useState(null);
+  const [showRoom, setShowRoom] = useState(true);
 
   return (
     <div className="p-4 space-y-4">
       <h2 className="text-xl font-bold">Snakes &amp; Ladders</h2>
-      <RoomSelector selected={selection} onSelect={setSelection} />
+      <RoomPopup
+        open={showRoom}
+        selection={selection}
+        setSelection={setSelection}
+        onConfirm={() => setShowRoom(false)}
+      />
       <ConnectWallet />
       <iframe
         src="https://snakes-and-ladders-game.netlify.app/"


### PR DESCRIPTION
## Summary
- restore and improve daily check-in component
- show day number centered in progress items
- use token icons in room selector
- add reusable room popup modal
- require room selection on every game page

## Testing
- `npm --prefix webapp install`
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_684c9896cb7c8329a41f2723e58686eb