### PR TITLE
Add Telegram user info endpoint

### DIFF
--- a/bot/commands/start.js
+++ b/bot/commands/start.js
@@ -1,11 +1,43 @@
 import User from '../models/User.js';
 
+async function fetchTelegramInfo(telegramId, token) {
+  const base = `https://api.telegram.org/bot${token}`;
+  const chatResp = await fetch(`${base}/getChat?chat_id=${telegramId}`);
+  const chatData = await chatResp.json();
+  let photoUrl = '';
+  const photoResp = await fetch(
+    `${base}/getUserProfilePhotos?user_id=${telegramId}&limit=1`
+  );
+  const photoData = await photoResp.json();
+  if (photoData.ok && photoData.result.total_count > 0) {
+    const fileId = photoData.result.photos[0][0].file_id;
+    const fileResp = await fetch(`${base}/getFile?file_id=${fileId}`);
+    const fileData = await fileResp.json();
+    if (fileData.ok) {
+      photoUrl = `${base.replace('/bot', '/file/bot')}/${fileData.result.file_path}`;
+    }
+  }
+  return {
+    firstName: chatData.result?.first_name || '',
+    lastName: chatData.result?.last_name || '',
+    photoUrl
+  };
+}
+
 export default function registerStart(bot) {
   bot.start(async (ctx) => {
     const telegramId = ctx.from.id;
+    const info = await fetchTelegramInfo(telegramId, process.env.BOT_TOKEN);
     await User.findOneAndUpdate(
       { telegramId },
-      { $setOnInsert: { referralCode: telegramId.toString() } },
+      {
+        $set: {
+          firstName: info.firstName,
+          lastName: info.lastName,
+          photo: info.photoUrl
+        },
+        $setOnInsert: { referralCode: telegramId.toString() }
+      },
       { upsert: true }
     );
     ctx.reply('Welcome to TonPlaygram!', {

--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -16,6 +16,10 @@ const userSchema = new mongoose.Schema({
 
   nickname: { type: String, default: '' },
 
+  firstName: { type: String, default: '' },
+
+  lastName: { type: String, default: '' },
+
   photo: { type: String, default: '' },
 
   bio: { type: String, default: '' },

--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -2,28 +2,78 @@ import { Router } from 'express';
 import passport from 'passport';
 import User from '../models/User.js';
 
+async function fetchTelegramInfo(telegramId) {
+  const base = `https://api.telegram.org/bot${process.env.BOT_TOKEN}`;
+  const infoResp = await fetch(`${base}/getChat?chat_id=${telegramId}`);
+  const infoData = await infoResp.json();
+
+  let photoUrl = '';
+  const photosResp = await fetch(
+    `${base}/getUserProfilePhotos?user_id=${telegramId}&limit=1`
+  );
+  const photosData = await photosResp.json();
+  if (photosData.ok && photosData.result.total_count > 0) {
+    const fileId = photosData.result.photos[0][0].file_id;
+    const fileResp = await fetch(`${base}/getFile?file_id=${fileId}`);
+    const fileData = await fileResp.json();
+    if (fileData.ok) {
+      photoUrl = `${base.replace('/bot', '/file/bot')}/${fileData.result.file_path}`;
+    }
+  }
+
+  return {
+    firstName: infoData.result?.first_name || '',
+    lastName: infoData.result?.last_name || '',
+    photoUrl
+  };
+}
+
 const router = Router();
+
+router.post('/telegram-info', async (req, res) => {
+  const { telegramId } = req.body;
+  if (!telegramId) {
+    return res.status(400).json({ error: 'telegramId required' });
+  }
+  try {
+    const info = await fetchTelegramInfo(telegramId);
+    res.json(info);
+  } catch (err) {
+    console.error('Error fetching telegram info:', err);
+    res.status(500).json({ error: 'failed to fetch telegram info' });
+  }
+});
 
 router.post('/get', async (req, res) => {
   const { telegramId } = req.body;
   if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
+  const info = await fetchTelegramInfo(telegramId);
 
   const user = await User.findOneAndUpdate(
     { telegramId },
-    { $setOnInsert: { referralCode: telegramId.toString() } },
+    {
+      $set: {
+        firstName: info.firstName,
+        lastName: info.lastName,
+        photo: info.photoUrl
+      },
+      $setOnInsert: { referralCode: telegramId.toString() }
+    },
     { upsert: true, new: true }
   );
   res.json(user);
 });
 
 router.post('/update', async (req, res) => {
-  const { telegramId, nickname, photo, bio } = req.body;
+  const { telegramId, nickname, photo, bio, firstName, lastName } = req.body;
   if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
 
   const update = {};
   if (nickname !== undefined) update.nickname = nickname;
   if (photo !== undefined) update.photo = photo;
   if (bio !== undefined) update.bio = bio;
+  if (firstName !== undefined) update.firstName = firstName;
+  if (lastName !== undefined) update.lastName = lastName;
 
   const user = await User.findOneAndUpdate(
     { telegramId },


### PR DESCRIPTION
## Summary
- add firstName/lastName fields to `User` model
- implement `/api/profile/telegram-info` to fetch profile photo and names
- store Telegram info when creating/updating users
- update bot `/start` command to save fetched info

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d02e6f00c8329adfc5add9ec6f5b7