### PR TITLE
Store Telegram user info

### DIFF
--- a/webapp/src/hooks/useTelegramAuth.js
+++ b/webapp/src/hooks/useTelegramAuth.js
@@ -5,9 +5,18 @@ export default function useTelegramAuth() {
     const user = window?.Telegram?.WebApp?.initDataUnsafe?.user;
     if (user?.id) {
       localStorage.setItem('telegramId', user.id);
-      if (user.username) {
-        localStorage.setItem('telegramUsername', user.username);
-      }
+    }
+    if (user?.username) {
+      localStorage.setItem('telegramUsername', user.username);
+    }
+    if (user?.first_name) {
+      localStorage.setItem('telegramFirstName', user.first_name);
+    }
+    if (user?.last_name) {
+      localStorage.setItem('telegramLastName', user.last_name);
+    }
+    if (user) {
+      localStorage.setItem('telegramUserData', JSON.stringify(user));
     }
   }, []);
 }

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -17,3 +17,39 @@ export function getTelegramUsername() {
   }
   return '';
 }
+
+export function getTelegramFirstName() {
+  if (typeof window !== 'undefined') {
+    const first = window?.Telegram?.WebApp?.initDataUnsafe?.user?.first_name;
+    if (first) return first;
+    const stored = localStorage.getItem('telegramFirstName');
+    if (stored) return stored;
+  }
+  return '';
+}
+
+export function getTelegramLastName() {
+  if (typeof window !== 'undefined') {
+    const last = window?.Telegram?.WebApp?.initDataUnsafe?.user?.last_name;
+    if (last) return last;
+    const stored = localStorage.getItem('telegramLastName');
+    if (stored) return stored;
+  }
+  return '';
+}
+
+export function getTelegramUserData() {
+  if (typeof window !== 'undefined') {
+    const user = window?.Telegram?.WebApp?.initDataUnsafe?.user;
+    if (user) return user;
+    const stored = localStorage.getItem('telegramUserData');
+    if (stored) {
+      try {
+        return JSON.parse(stored);
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- save entire Telegram user data in localStorage
- expose helpers to retrieve additional Telegram fields

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d02e7c8188329adf322ec6535747f