### PR TITLE
Add mining leaderboard

### DIFF
--- a/bot/routes/mining.js
+++ b/bot/routes/mining.js
@@ -44,4 +44,23 @@ router.post('/status', getUser, async (req, res) => {
   res.json({ isMining: req.user.isMining, pending: req.user.minedTPC, balance: req.user.balance });
 });
 
+router.post('/leaderboard', async (req, res) => {
+  const { telegramId } = req.body;
+  const users = await User.find()
+    .sort({ balance: -1 })
+    .limit(100)
+    .select('telegramId balance nickname firstName lastName photo')
+    .lean();
+
+  let rank = null;
+  if (telegramId) {
+    const user = await User.findOne({ telegramId });
+    if (user) {
+      rank = (await User.countDocuments({ balance: { $gt: user.balance } })) + 1;
+    }
+  }
+
+  res.json({ users, rank });
+});
+
 export default router;

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -4,7 +4,8 @@ import {
   startMining,
   claimMining,
   getWalletBalance,
-  getTonBalance
+  getTonBalance,
+  getLeaderboard
 } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
@@ -20,6 +21,8 @@ export default function Mining() {
   const [startTime, setStartTime] = useState(null);
   const [timeLeft, setTimeLeft] = useState(0);
   const [balances, setBalances] = useState({ ton: null, tpc: null, usdt: 0 });
+  const [leaderboard, setLeaderboard] = useState([]);
+  const [rank, setRank] = useState(null);
   const wallet = useTonWallet();
 
   const loadBalances = async () => {
@@ -62,6 +65,19 @@ export default function Mining() {
       return () => clearInterval(interval);
     }
   }, [status, startTime]);
+
+  useEffect(() => {
+    async function loadLeaderboard() {
+      try {
+        const data = await getLeaderboard(telegramId);
+        setLeaderboard(data.users);
+        setRank(data.rank);
+      } catch (err) {
+        console.error('Failed to load leaderboard:', err);
+      }
+    }
+    loadLeaderboard();
+  }, [telegramId, status]);
 
   const handleStart = async () => {
     const now = Date.now();
@@ -109,6 +125,42 @@ export default function Mining() {
             {status === 'Mining' && ` - ${formatTimeLeft(timeLeft)}`}
           </span>
         </p>
+      </div>
+
+      <div className="mt-6">
+        <h3 className="text-lg font-semibold mb-2">Leaderboard</h3>
+        <div className="max-h-96 overflow-y-auto border border-border rounded">
+          <table className="w-full text-sm">
+            <thead className="sticky top-0 bg-surface">
+              <tr className="border-b border-border text-left">
+                <th className="p-2">#</th>
+                <th className="p-2">User</th>
+                <th className="p-2 text-right">TPC</th>
+              </tr>
+            </thead>
+            <tbody>
+              {leaderboard.map((u, idx) => (
+                <tr
+                  key={u.telegramId}
+                  className={`border-b border-border ${u.telegramId === telegramId ? 'bg-accent text-black' : ''}`}
+                >
+                  <td className="p-2">{idx + 1}</td>
+                  <td className="p-2">
+                    {u.nickname || u.firstName || 'User'}
+                  </td>
+                  <td className="p-2 text-right">{u.balance}</td>
+                </tr>
+              ))}
+              {rank && rank > 100 && (
+                <tr className="bg-accent text-black">
+                  <td className="p-2">{rank}</td>
+                  <td className="p-2">You</td>
+                  <td className="p-2 text-right">{balances.tpc ?? '...'}</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -33,6 +33,10 @@ export function claimMining(telegramId) {
   return post('/api/mining/claim', { telegramId });
 }
 
+export function getLeaderboard(telegramId) {
+  return post('/api/mining/leaderboard', { telegramId });
+}
+
 export function listTasks(telegramId) {
   return post('/api/tasks/list', { telegramId });
 }


### PR DESCRIPTION
## Summary
- add leaderboard endpoint to mining API
- expose `getLeaderboard` in webapp API helpers
- fetch and show the top 100 leaderboard on the Mining page

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_684d0fccd1d483298559becd60c41a60