### PR TITLE
Add mining leaderboard

### DIFF
--- a/bot/routes/mining.js
+++ b/bot/routes/mining.js
@@ -44,4 +44,32 @@ router.post('/status', getUser, async (req, res) => {
   res.json({ isMining: req.user.isMining, pending: req.user.minedTPC, balance: req.user.balance });
 });
 
+router.get('/leaderboard', async (req, res) => {
+  const telegramId = req.query.telegramId;
+  const top = await User.find()
+    .sort({ balance: -1 })
+    .limit(100)
+    .lean();
+  const leaderboard = top.map((u, i) => ({
+    telegramId: u.telegramId,
+    nickname: u.nickname,
+    firstName: u.firstName,
+    lastName: u.lastName,
+    photo: u.photo,
+    balance: u.balance,
+    rank: i + 1
+  }));
+
+  let myRank = null;
+  if (telegramId) {
+    const me = await User.findOne({ telegramId }).lean();
+    if (me) {
+      myRank = (await User.countDocuments({ balance: { $gt: me.balance } })) + 1;
+    }
+  }
+
+  res.json({ leaderboard, myRank });
+});
+
 export default router;
+export const miningRouter = router;

--- a/bot/server.js
+++ b/bot/server.js
@@ -4,7 +4,7 @@ import bot from './bot.js';
 import mongoose from 'mongoose';
 import passport from 'passport';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
-import miningRoutes from './routes/mining.js';
+import { miningRouter } from './routes/mining.js';
 import tasksRoutes from './routes/tasks.js';
 import watchRoutes from './routes/watch.js';
 import referralRoutes from './routes/referral.js';
@@ -54,7 +54,7 @@ if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
 } else {
   console.log('Google OAuth credentials not provided, skipping Google auth setup');
 }
-app.use('/api/mining', miningRoutes);
+app.use('/api/mining', miningRouter);
 app.use('/api/tasks', tasksRoutes);
 app.use('/api/watch', watchRoutes);
 app.use('/api/referral', referralRoutes);

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -4,7 +4,8 @@ import {
   startMining,
   claimMining,
   getWalletBalance,
-  getTonBalance
+  getTonBalance,
+  getLeaderboard
 } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
@@ -20,6 +21,8 @@ export default function Mining() {
   const [startTime, setStartTime] = useState(null);
   const [timeLeft, setTimeLeft] = useState(0);
   const [balances, setBalances] = useState({ ton: null, tpc: null, usdt: 0 });
+  const [leaderboard, setLeaderboard] = useState([]);
+  const [myRank, setMyRank] = useState(null);
   const wallet = useTonWallet();
 
   const loadBalances = async () => {
@@ -36,6 +39,10 @@ export default function Mining() {
 
   useEffect(() => {
     loadBalances();
+    getLeaderboard(telegramId).then((data) => {
+      setLeaderboard(data.leaderboard);
+      setMyRank(data.myRank);
+    });
     const saved = localStorage.getItem('miningStart');
     if (saved) {
       const start = parseInt(saved, 10);
@@ -109,6 +116,38 @@ export default function Mining() {
             {status === 'Mining' && ` - ${formatTimeLeft(timeLeft)}`}
           </span>
         </p>
+      </div>
+
+      <h3 className="text-lg font-bold mt-6 mb-2">Leaderboard</h3>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-subtext">
+              <th className="px-2 py-1">Rank</th>
+              <th className="px-2 py-1">User</th>
+              <th className="px-2 py-1 text-right">TPC</th>
+            </tr>
+          </thead>
+          <tbody>
+            {leaderboard.map((u) => (
+              <tr
+                key={u.telegramId}
+                className={`border-b border-border ${
+                  u.telegramId === telegramId ? 'bg-primary/20' : ''
+                }`}
+              >
+                <td className="px-2 py-1">{u.rank}</td>
+                <td className="px-2 py-1">
+                  {u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim() || u.telegramId}
+                </td>
+                <td className="px-2 py-1 text-right">{u.balance}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {myRank && !leaderboard.some((u) => u.telegramId === telegramId) && (
+          <p className="text-center text-sm mt-2">Your rank: {myRank}</p>
+        )}
       </div>
     </div>
   );

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -80,3 +80,9 @@ export function getWalletBalance(telegramId) {
 export function getTonBalance(address) {
   return post('/api/wallet/ton-balance', { address });
 }
+
+export async function getLeaderboard(telegramId) {
+  const qs = telegramId ? `?telegramId=${telegramId}` : '';
+  const res = await fetch(API_BASE_URL + '/api/mining/leaderboard' + qs);
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- revert previous changes
- add leaderboard API in mining routes
- fetch leaderboard data in webapp
- display top users on Mining page and highlight current player
- export miningRouter and use named import

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d0fccd1d483298559becd60c41a60