### PR TITLE
Add Telegram fetch error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ The webapp now uses **TonConnect** to link a Tonkeeper wallet. Configure
 the server via `TONCONNECT_MANIFEST_URL`. The server serves a dynamic
 `/tonconnect-manifest.json` response that always reflects the current hostname.
 
+## Telegram Profile Data
+
+The **My Account** page displays several fields pulled directly from Telegram:
+
+- **Telegram ID**
+- **First name** and **last name**
+- **Profile photo**
+
+These details are fetched using `getTelegramId()` and `fetchTelegramInfo()` and
+are shown in the "Telegram Info" section of the page. Additional properties such
+as `username` are available through `window.Telegram.WebApp.initDataUnsafe.user`
+and can be displayed if needed.
+
 ## Open Source Games
 - [Chessu](https://github.com/dotnize/chessu) – Competitive chess with socket rooms.
 - [Snakes & Ladders / Chutes & Ladders](https://github.com/yashksaini/snakes-and-ladders-game) – Custom avatars, virtual board, and climb/slide animations.

--- a/bot/utils/telegram.js
+++ b/bot/utils/telegram.js
@@ -1,25 +1,30 @@
 export async function fetchTelegramInfo(telegramId) {
   const base = `https://api.telegram.org/bot${process.env.BOT_TOKEN}`;
-  const infoResp = await fetch(`${base}/getChat?chat_id=${telegramId}`);
-  const infoData = await infoResp.json();
+  try {
+    const infoResp = await fetch(`${base}/getChat?chat_id=${telegramId}`);
+    const infoData = await infoResp.json();
 
-  let photoUrl = '';
-  const photosResp = await fetch(
-    `${base}/getUserProfilePhotos?user_id=${telegramId}&limit=1`
-  );
-  const photosData = await photosResp.json();
-  if (photosData.ok && photosData.result.total_count > 0) {
-    const fileId = photosData.result.photos[0][0].file_id;
-    const fileResp = await fetch(`${base}/getFile?file_id=${fileId}`);
-    const fileData = await fileResp.json();
-    if (fileData.ok) {
-      photoUrl = `${base.replace('/bot', '/file/bot')}/${fileData.result.file_path}`;
+    let photoUrl = '';
+    const photosResp = await fetch(
+      `${base}/getUserProfilePhotos?user_id=${telegramId}&limit=1`
+    );
+    const photosData = await photosResp.json();
+    if (photosData.ok && photosData.result.total_count > 0) {
+      const fileId = photosData.result.photos[0][0].file_id;
+      const fileResp = await fetch(`${base}/getFile?file_id=${fileId}`);
+      const fileData = await fileResp.json();
+      if (fileData.ok) {
+        photoUrl = `${base.replace('/bot', '/file/bot')}/${fileData.result.file_path}`;
+      }
     }
-  }
 
-  return {
-    firstName: infoData.result?.first_name || '',
-    lastName: infoData.result?.last_name || '',
-    photoUrl
-  };
+    return {
+      firstName: infoData.result?.first_name || '',
+      lastName: infoData.result?.last_name || '',
+      photoUrl,
+    };
+  } catch (err) {
+    console.error('fetchTelegramInfo failed', err);
+    return null;
+  }
 }

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -39,21 +39,25 @@ export default function MyAccount() {
     });
     setBalanceInput(data.balance ?? '');
 
-    if (!data.nickname || !data.photo) {
+    if (!data.nickname || !data.photo || !data.firstName || !data.lastName) {
       setAutoUpdating(true);
       try {
         const tg = await fetchTelegramInfo(getTelegramId());
-        const updated = await updateProfile({
-          telegramId: getTelegramId(),
-          nickname: data.nickname || tg.nickname,
-          photo: data.photo || tg.photo
-        });
-        setProfile(updated);
-        setForm({
-          nickname: updated.nickname || '',
-          photo: updated.photo || '',
-          bio: updated.bio || ''
-        });
+        if (tg && !tg.error) {
+          const updated = await updateProfile({
+            telegramId: getTelegramId(),
+            nickname: data.nickname || tg.firstName,
+            photo: data.photo || tg.photoUrl,
+            firstName: data.firstName || tg.firstName,
+            lastName: data.lastName || tg.lastName
+          });
+          setProfile(updated);
+          setForm({
+            nickname: updated.nickname || '',
+            photo: updated.photo || '',
+            bio: updated.bio || ''
+          });
+        }
       } finally {
         setAutoUpdating(false);
       }


### PR DESCRIPTION
## Summary
- handle network failures in `fetchTelegramInfo`
- update profile only when telegram info is available
- auto-fill first and last name in the My Account page

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_684d377557548329b470ecbf72e83d32