### PR TITLE
Add cleanup for Telegram update notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ if (!data.nickname || !data.photo || !data.firstName || !data.lastName) {
     setAutoUpdating(false);
   }
 }
+
+When the profile is updated from Telegram, the UI briefly displays a
+notification that says `Info retrieved from Telegram`.

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getProfile, updateProfile, fetchTelegramInfo } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
@@ -14,6 +14,7 @@ export default function MyAccount() {
   const [profile, setProfile] = useState(null);
   const [autoUpdating, setAutoUpdating] = useState(false);
   const [wasUpdatedFromTelegram, setWasUpdatedFromTelegram] = useState(false);
+  const timerRef = useRef(null);
 
   useEffect(() => {
     async function load() {
@@ -32,7 +33,10 @@ export default function MyAccount() {
             });
             setProfile(updated);
             setWasUpdatedFromTelegram(true);
-            setTimeout(() => setWasUpdatedFromTelegram(false), 4000);
+            if (timerRef.current) {
+              clearTimeout(timerRef.current);
+            }
+            timerRef.current = setTimeout(() => setWasUpdatedFromTelegram(false), 4000);
           }
         } finally {
           setAutoUpdating(false);
@@ -40,6 +44,11 @@ export default function MyAccount() {
       }
     }
     load();
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
   }, [telegramId]);
 
   if (!profile) return <div className="p-4 text-subtext">Loading...</div>;


### PR DESCRIPTION
## Summary
- clear and cleanup timer when auto-filling profile from Telegram
- document Telegram update notice in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d5d448d34832986ca42c5d8200934