### PR TITLE
Handle missing profile photo

### DIFF
--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -13,6 +13,7 @@ export default function MyAccount() {
 
   const [profile, setProfile] = useState(null);
   const [autoUpdating, setAutoUpdating] = useState(false);
+  const [wasUpdatedFromTelegram, setWasUpdatedFromTelegram] = useState(false);
 
   useEffect(() => {
     async function load() {
@@ -29,7 +30,15 @@ export default function MyAccount() {
               firstName: data.firstName || tg.firstName,
               lastName: data.lastName || tg.lastName
             });
-            setProfile(updated);
+            const withPhoto = {
+              ...updated,
+              photo: updated.photo || tg.photoUrl
+            };
+            setProfile(withPhoto);
+            if (withPhoto.photo) {
+              setWasUpdatedFromTelegram(true);
+              setTimeout(() => setWasUpdatedFromTelegram(false), 4000);
+            }
           }
         } finally {
           setAutoUpdating(false);
@@ -46,7 +55,12 @@ export default function MyAccount() {
       {autoUpdating && (
         <div className="p-2 text-sm text-subtext">Updating with Telegram info...</div>
       )}
-      <h2 className="text-xl font-bold">My Account</h2>
+      <div className="flex items-center space-x-2">
+        <h2 className="text-xl font-bold">My Account</h2>
+        {wasUpdatedFromTelegram && (
+          <span className="text-sm text-accent">Info retrieved from Telegram.</span>
+        )}
+      </div>
       <div className="flex items-center space-x-4">
         {profile.photo && (
           <img src={profile.photo} alt="avatar" className="w-16 h-16 rounded-full" />


### PR DESCRIPTION
## Summary
- ensure photo from Telegram persists in account state

## Testing
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_684d5e0ee1b883298fb6181bbc356eb8