### PR TITLE
Add gold-framed hexagon avatars

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -10,7 +10,7 @@ body {
 }
 
 .hexagon {
-  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+  clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
 }
 
 /* Chess piece color adjustments */

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -27,7 +27,7 @@ export default function Home() {
               <img
                 src={photoUrl}
                 alt="profile"
-                className="w-36 h-10 rounded-full mt-2 object-cover"
+                className="w-36 h-36 hexagon border-4 border-brand-gold mt-2 object-cover"
               />
             )}
         </div>

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -134,6 +134,7 @@ export default function Mining() {
             <thead className="sticky top-0 bg-surface">
               <tr className="border-b border-border text-left">
                 <th className="p-2">#</th>
+                <th className="p-2"></th>
                 <th className="p-2">User</th>
                 <th className="p-2 text-right">TPC</th>
               </tr>
@@ -145,31 +146,33 @@ export default function Mining() {
                   className={`border-b border-border ${u.telegramId === telegramId ? 'bg-accent text-black' : ''}`}
                 >
                   <td className="p-2">{idx + 1}</td>
-                  <td className="p-2 flex items-center space-x-2">
+                  <td className="p-2">
                     {u.photo && (
-                      <img src={u.photo} alt="" className="w-6 h-6 rounded-full" />
+                      <img src={u.photo} alt="" className="w-16 h-16 hexagon border-2 border-brand-gold object-cover" />
                     )}
-                    <span>{u.nickname || `${u.firstName} ${u.lastName}`.trim() || 'User'}</span>
+                  </td>
+                  <td className="p-2">
+                    {u.nickname || `${u.firstName} ${u.lastName}`.trim() || 'User'}
                   </td>
                   <td className="p-2 text-right">{u.balance}</td>
                 </tr>
               ))}
-              {rank && rank > 100 && (
-                <tr className="bg-accent text-black">
-                  <td className="p-2">{rank}</td>
-                  <td className="p-2 flex items-center space-x-2">
-                    {getTelegramPhotoUrl() && (
-                      <img
-                        src={getTelegramPhotoUrl()}
-                        alt=""
-                        className="w-6 h-6 rounded-full"
-                      />
-                    )}
-                    <span>You</span>
-                  </td>
-                  <td className="p-2 text-right">{balances.tpc ?? '...'}</td>
-                </tr>
-              )}
+                {rank && rank > 100 && (
+                  <tr className="bg-accent text-black">
+                    <td className="p-2">{rank}</td>
+                    <td className="p-2">
+                      {getTelegramPhotoUrl() && (
+                        <img
+                          src={getTelegramPhotoUrl()}
+                          alt=""
+                          className="w-16 h-16 hexagon border-2 border-brand-gold object-cover"
+                        />
+                      )}
+                    </td>
+                    <td className="p-2">You</td>
+                    <td className="p-2 text-right">{balances.tpc ?? '...'}</td>
+                  </tr>
+                )}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary
- tweak hexagon clip path for better proportions
- enlarge home page avatar, add gold frame
- show gold framed avatar between rank and name in mining leaderboard

## Testing
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_684d79c134f48329b7792770b708974e