### PR TITLE
Show photos in mining leaderboard

### DIFF
--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -134,7 +134,7 @@ export default function Mining() {
             <thead className="sticky top-0 bg-surface">
               <tr className="border-b border-border text-left">
                 <th className="p-2">#</th>
-                <th className="p-2"></th>
+                <th className="p-2 w-16"></th>
                 <th className="p-2">User</th>
                 <th className="p-2 text-right">TPC</th>
               </tr>
@@ -143,12 +143,12 @@ export default function Mining() {
               {leaderboard.map((u, idx) => (
                 <tr
                   key={u.telegramId}
-                  className={`border-b border-border ${u.telegramId === telegramId ? 'bg-accent text-black' : ''}`}
+                  className={`border-b border-border h-16 ${u.telegramId === telegramId ? 'bg-accent text-black' : ''}`}
                 >
                   <td className="p-2">{idx + 1}</td>
-                  <td className="p-2">
+                  <td className="p-2 w-16">
                     {u.photo && (
-                      <img src={u.photo} alt="" className="w-16 h-16 hexagon border-2 border-brand-gold object-cover" />
+                      <img src={u.photo} alt="avatar" className="w-16 h-16 hexagon border-2 border-brand-gold object-cover" />
                     )}
                   </td>
                   <td className="p-2">
@@ -158,13 +158,13 @@ export default function Mining() {
                 </tr>
               ))}
                 {rank && rank > 100 && (
-                  <tr className="bg-accent text-black">
+                  <tr className="bg-accent text-black h-16">
                     <td className="p-2">{rank}</td>
-                    <td className="p-2">
+                    <td className="p-2 w-16">
                       {getTelegramPhotoUrl() && (
                         <img
                           src={getTelegramPhotoUrl()}
-                          alt=""
+                          alt="avatar"
                           className="w-16 h-16 hexagon border-2 border-brand-gold object-cover"
                         />
                       )}


### PR DESCRIPTION
## Summary
- display user avatar next to name on the mining leaderboard
- keep avatar size consistent with profile page and constrain row height

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d81924a7483298ac8fa48c0790c1b