### PR TITLE
Move balance display under profile photo

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import { FaWallet } from 'react-icons/fa';
+import { useTonWallet } from '@tonconnect/ui-react';
+import { getWalletBalance, getTonBalance } from '../utils/api.js';
+import { getTelegramId } from '../utils/telegram.js';
+import OpenInTelegram from './OpenInTelegram.jsx';
+
+export default function BalanceSummary() {
+  let telegramId;
+  try {
+    telegramId = getTelegramId();
+  } catch (err) {
+    return <OpenInTelegram />;
+  }
+
+  const [balances, setBalances] = useState({ ton: null, tpc: null, usdt: 0 });
+  const wallet = useTonWallet();
+
+  const loadBalances = async () => {
+    try {
+      const prof = await getWalletBalance(telegramId);
+      const ton = wallet?.account?.address
+        ? (await getTonBalance(wallet.account.address)).balance
+        : null;
+      setBalances({ ton, tpc: prof.balance, usdt: 0 });
+    } catch (err) {
+      console.error('Failed to load balances:', err);
+    }
+  };
+
+  useEffect(() => {
+    loadBalances();
+  }, [wallet]);
+
+  return (
+    <div className="text-center mt-2">
+      <p className="text-lg font-bold text-gray-300 flex items-center justify-center space-x-1">
+        <FaWallet />
+        <span>Total Balance</span>
+      </p>
+      <div className="flex justify-around text-sm mt-1">
+        <Token icon="/icons/ton.svg" label="TON" value={balances.ton ?? '...'} />
+        <Token icon="/icons/tpc.svg" label="TPC" value={balances.tpc ?? '...'} />
+        <Token icon="/icons/usdt.svg" label="USDT" value={balances.usdt ?? '0'} />
+      </div>
+    </div>
+  );
+}
+
+function Token({ icon, value, label }) {
+  return (
+    <div className="flex items-center space-x-1">
+      <img src={icon} alt={label} className="w-4 h-4" />
+      <span>{value}</span>
+    </div>
+  );
+}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -6,6 +6,7 @@ import TasksCard from '../components/TasksCard.jsx';
 import { FaUser } from 'react-icons/fa';
 import { ping } from '../utils/api.js';
 import ConnectWallet from "../components/ConnectWallet.jsx";
+import BalanceSummary from '../components/BalanceSummary.jsx';
 import { getTelegramPhotoUrl } from '../utils/telegram.js';
 
 export default function Home() {
@@ -30,6 +31,7 @@ export default function Home() {
             className="w-36 h-36 hexagon border-4 border-brand-gold mt-2 object-cover"
           />
         )}
+        <BalanceSummary />
       </div>
 
       <SpinGame />


### PR DESCRIPTION
## Summary
- show wallet balance summary below profile picture on Home page
- implement `BalanceSummary` component to fetch and display token balances

## Testing
- `npm run build --prefix webapp`


------
https://chatgpt.com/codex/tasks/task_e_684d853b630083299c08f326ce592375