### PR TITLE
Remove wallet icons on home page

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { FaWallet } from 'react-icons/fa';
 import { useTonWallet } from '@tonconnect/ui-react';
 import { getWalletBalance, getTonBalance } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
@@ -34,24 +33,10 @@ export default function BalanceSummary() {
 
   return (
     <div className="text-center mt-2">
-      <p className="text-lg font-bold text-gray-300 flex items-center justify-center space-x-1">
-        <FaWallet />
-        <span>Total Balance</span>
+      <p className="text-lg font-bold text-gray-300">
+        Total Balance
       </p>
-      <div className="flex justify-around text-sm mt-1">
-        <Token icon="/icons/ton.svg" label="TON" value={balances.ton ?? '...'} />
-        <Token icon="/icons/tpc.svg" label="TPC" value={balances.tpc ?? '...'} />
-        <Token icon="/icons/usdt.svg" label="USDT" value={balances.usdt ?? '0'} />
-      </div>
     </div>
   );
 }
 
-function Token({ icon, value, label }) {
-  return (
-    <div className="flex items-center space-x-1">
-      <img src={icon} alt={label} className="w-4 h-4" />
-      <span>{value}</span>
-    </div>
-  );
-}


### PR DESCRIPTION
## Summary
- simplify `BalanceSummary` component
- drop wallet icon and individual coin balances

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d8d242b5883299bcca559d6ffd747