### PR TITLE
Implement referral links

### DIFF
--- a/webapp/src/components/OpenInTelegram.jsx
+++ b/webapp/src/components/OpenInTelegram.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import { RiTelegramFill } from 'react-icons/ri';
-
-const BOT_USERNAME = 'TonPlaygramBot';
+import { BOT_USERNAME } from '../utils/constants.js';
 
 const TG_LINK = `https://t.me/${BOT_USERNAME}`;
 

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { getProfile, updateProfile, fetchTelegramInfo } from '../utils/api.js';
+import { getProfile, updateProfile, fetchTelegramInfo, getReferralInfo } from '../utils/api.js';
 import {
   getTelegramId,
   getTelegramFirstName,
@@ -7,6 +7,7 @@ import {
   getTelegramPhotoUrl
 } from '../utils/telegram.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
+import { BOT_USERNAME } from '../utils/constants.js';
 
 export default function MyAccount() {
   let telegramId;
@@ -18,6 +19,7 @@ export default function MyAccount() {
   }
 
   const [profile, setProfile] = useState(null);
+  const [referral, setReferral] = useState(null);
   const [autoUpdating, setAutoUpdating] = useState(false);
   const timerRef = useRef(null);
 
@@ -25,6 +27,8 @@ export default function MyAccount() {
     async function load() {
       const data = await getProfile(telegramId);
       setProfile(data);
+      const ref = await getReferralInfo(telegramId);
+      setReferral(ref);
 
       if (!data.photo || !data.firstName || !data.lastName) {
         setAutoUpdating(true);
@@ -93,6 +97,28 @@ export default function MyAccount() {
           <p className="text-sm text-subtext">ID: {profile.telegramId}</p>
         </div>
       </div>
+
+      {referral && (
+        <div className="space-y-1">
+          <p className="font-semibold">Referral Link</p>
+          <div className="flex items-center space-x-2">
+            <input
+              type="text"
+              readOnly
+              value={`https://t.me/${BOT_USERNAME}?start=${referral.code}`}
+              onClick={(e) => e.target.select()}
+              className="flex-1 bg-surface border border-border rounded px-2 py-1 text-sm"
+            />
+            <button
+              onClick={() => navigator.clipboard.writeText(`https://t.me/${BOT_USERNAME}?start=${referral.code}`)}
+              className="px-2 py-1 bg-primary hover:bg-primary-hover text-text rounded text-sm"
+            >
+              Copy
+            </button>
+          </div>
+          <p className="text-sm text-subtext">{referral.referrals} referrals</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/webapp/src/pages/Referral.jsx
+++ b/webapp/src/pages/Referral.jsx
@@ -1,8 +1,49 @@
+import { useEffect, useState } from 'react';
+import OpenInTelegram from '../components/OpenInTelegram.jsx';
+import { getTelegramId } from '../utils/telegram.js';
+import { getReferralInfo } from '../utils/api.js';
+import { BOT_USERNAME } from '../utils/constants.js';
+
 export default function Referral() {
+  let telegramId;
+  try {
+    telegramId = getTelegramId();
+  } catch (err) {
+    return <OpenInTelegram />;
+  }
+
+  const [info, setInfo] = useState(null);
+
+  useEffect(() => {
+    getReferralInfo(telegramId).then(setInfo);
+  }, [telegramId]);
+
+  if (!info) return <div className="p-4">Loading...</div>;
+
+  const link = `https://t.me/${BOT_USERNAME}?start=${info.code}`;
+
   return (
-    <div className="p-4">
+    <div className="p-4 space-y-2 text-text">
       <h2 className="text-xl font-bold">Referral</h2>
-      <p>Referral system coming soon.</p>
+      <div>
+        <p className="mb-1">Share this link with your friends:</p>
+        <div className="flex items-center space-x-2">
+          <input
+            type="text"
+            readOnly
+            value={link}
+            onClick={(e) => e.target.select()}
+            className="flex-1 bg-surface border border-border rounded px-2 py-1 text-sm"
+          />
+          <button
+            onClick={() => navigator.clipboard.writeText(link)}
+            className="px-2 py-1 bg-primary hover:bg-primary-hover text-text rounded text-sm"
+          >
+            Copy
+          </button>
+        </div>
+        <p className="text-sm text-subtext mt-1">{info.referrals} referrals</p>
+      </div>
     </div>
   );
 }

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -84,3 +84,11 @@ export function getWalletBalance(telegramId) {
 export function getTonBalance(address) {
   return post('/api/wallet/ton-balance', { address });
 }
+
+export function getReferralInfo(telegramId) {
+  return post('/api/referral/code', { telegramId });
+}
+
+export function claimReferral(telegramId, code) {
+  return post('/api/referral/claim', { telegramId, code });
+}

--- a/webapp/src/utils/constants.js
+++ b/webapp/src/utils/constants.js
@@ -1,0 +1,1 @@
+export const BOT_USERNAME = 'TonPlaygramBot';


### PR DESCRIPTION
## Summary
- add shared bot username constant
- add API helpers for referral endpoints
- show invite link on Referral page
- display referral info in My Account page
- update OpenInTelegram component to reuse constant

## Testing
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_684d8e3fdefc832994ca6fbe491fdf0e