### PR TITLE
Update navbar with Store and rename Mining to Friends

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import Home from './pages/Home.jsx';
-import Mining from './pages/Mining.jsx';
+import Friends from './pages/Friends.jsx';
 import Wallet from './pages/Wallet.jsx';
 import Tasks from './pages/Tasks.jsx';
 import Referral from './pages/Referral.jsx';
 import MyAccount from './pages/MyAccount.jsx';
+import Store from './pages/Store.jsx';
 
 import DiceGame from './pages/Games/DiceGame.jsx';
 import LudoGame from './pages/Games/LudoGame.jsx';
@@ -27,7 +28,7 @@ export default function App() {
       <Layout>
         <Routes>
           <Route path="/" element={<Home />} />
-          <Route path="/mining" element={<Mining />} />
+          <Route path="/friends" element={<Friends />} />
           <Route path="/games" element={<Games />} />
           <Route path="/games/dice" element={<DiceGame />} />
           <Route path="/games/ludo" element={<LudoGame />} />
@@ -36,6 +37,7 @@ export default function App() {
           <Route path="/games/chess" element={<ChessGame />} />
           <Route path="/spin" element={<SpinPage />} />
           <Route path="/tasks" element={<Tasks />} />
+          <Route path="/store" element={<Store />} />
           <Route path="/referral" element={<Referral />} />
           <Route path="/wallet" element={<Wallet />} />
           <Route path="/account" element={<MyAccount />} />

--- a/webapp/src/components/Navbar.jsx
+++ b/webapp/src/components/Navbar.jsx
@@ -1,12 +1,4 @@
-import { AiOutlineHome, AiOutlinePlayCircle, AiOutlineCheckSquare, AiOutlineUsergroupAdd, AiOutlineUser } from 'react-icons/ai';
-
-function MiningIcon({ className }) {
-  return (
-    <span className={className + ' flex items-center justify-center text-xl'}>
-      ⛏
-    </span>
-  );
-}
+import { AiOutlineHome, AiOutlinePlayCircle, AiOutlineCheckSquare, AiOutlineUsergroupAdd, AiOutlineUser, AiOutlineShop } from 'react-icons/ai';
 import NavItem from './NavItem.jsx';
 
 export default function Navbar() {
@@ -14,10 +6,10 @@ export default function Navbar() {
     <nav className="fixed inset-x-0 bottom-0 z-50 bg-surface text-text shadow border-t border-accent">
       <div className="container mx-auto px-4 py-4 flex items-center justify-between text-base">
         <NavItem to="/" icon={AiOutlineHome} label="Home" />
-        <NavItem to="/mining" icon={MiningIcon} label="Mining" />
+        <NavItem to="/friends" icon={AiOutlineUsergroupAdd} label="Friends" />
         <NavItem to="/games" icon={AiOutlinePlayCircle} label="Games" />
         <NavItem to="/tasks" icon={AiOutlineCheckSquare} label="Tasks" />
-        <NavItem to="/referral" icon={AiOutlineUsergroupAdd} label="Referral" />
+        <NavItem to="/store" icon={AiOutlineShop} label="Store" />
         <NavItem to="/account" icon={AiOutlineUser} label="Profile" />
       </div>
     </nav>

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -5,12 +5,14 @@ import {
   claimMining,
   getWalletBalance,
   getTonBalance,
-  getLeaderboard
+  getLeaderboard,
+  getReferralInfo
 } from '../utils/api.js';
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
+import { BOT_USERNAME } from '../utils/constants.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
 
-export default function Mining() {
+export default function Friends() {
   let telegramId;
   try {
     telegramId = getTelegramId();
@@ -24,6 +26,7 @@ export default function Mining() {
   const [balances, setBalances] = useState({ ton: null, tpc: null, usdt: 0 });
   const [leaderboard, setLeaderboard] = useState([]);
   const [rank, setRank] = useState(null);
+  const [referral, setReferral] = useState(null);
   const wallet = useTonWallet();
   const myPhotoUrl = getTelegramPhotoUrl(); // ✅ Cached photo for current user
 
@@ -80,6 +83,10 @@ export default function Mining() {
     }
     loadLeaderboard();
   }, [telegramId, status]);
+
+  useEffect(() => {
+    getReferralInfo(telegramId).then(setReferral);
+  }, [telegramId]);
 
   const handleStart = async () => {
     const now = Date.now();
@@ -181,6 +188,31 @@ export default function Mining() {
           </table>
         </div>
       </div>
+      {referral && (
+        <div className="mt-4 space-y-1">
+          <p className="font-semibold">Your referral link</p>
+          <div className="flex items-center space-x-2">
+            <input
+              type="text"
+              readOnly
+              value={`https://t.me/${BOT_USERNAME}?start=${referral.code}`}
+              onClick={(e) => e.target.select()}
+              className="flex-1 bg-surface border border-border rounded px-2 py-1 text-sm"
+            />
+            <button
+              onClick={() =>
+                navigator.clipboard.writeText(
+                  `https://t.me/${BOT_USERNAME}?start=${referral.code}`
+                )
+              }
+              className="px-2 py-1 bg-primary hover:bg-primary-hover text-text rounded text-sm"
+            >
+              Copy
+            </button>
+          </div>
+          <p className="text-sm text-subtext">{referral.referrals} referrals</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Store() {
+  return (
+    <div className="p-4 space-y-2 text-text">
+      <h2 className="text-xl font-bold">Store</h2>
+      <p>Coming soon...</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a new **Store** page
- rename Mining page to **Friends** and expose referral link there
- update navigation items for Friends and Store
- adjust routes to use new pages

## Testing
- `npm --prefix webapp run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d940346908329bcd38e2ae4907af9