### PR TITLE
Implement simple TPC transfers and UI tweaks

### DIFF
--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -34,4 +34,40 @@ router.post('/ton-balance', async (req, res) => {
   }
 });
 
+// Transfer TPC from one Telegram user to another
+router.post('/send', async (req, res) => {
+  const { fromId, toId, amount } = req.body;
+  if (!fromId || !toId || typeof amount !== 'number') {
+    return res.status(400).json({ error: 'fromId, toId and amount required' });
+  }
+  if (amount <= 0) {
+    return res.status(400).json({ error: 'amount must be positive' });
+  }
+
+  const sender = await User.findOne({ telegramId: fromId });
+  if (!sender || sender.balance < amount) {
+    return res.status(400).json({ error: 'insufficient balance' });
+  }
+
+  sender.balance -= amount;
+  await sender.save();
+
+  await User.findOneAndUpdate(
+    { telegramId: toId },
+    { $inc: { balance: amount }, $setOnInsert: { referralCode: toId.toString() } },
+    { upsert: true }
+  );
+
+  await User.updateOne(
+    { telegramId: fromId },
+    { $push: { transactions: { amount: -amount, type: 'send', date: new Date() } } }
+  );
+  await User.updateOne(
+    { telegramId: toId },
+    { $push: { transactions: { amount, type: 'receive', date: new Date() } } }
+  );
+
+  res.json({ balance: sender.balance });
+});
+
 export default router;

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -100,24 +100,13 @@ export default function MiningCard() {
         <span>Mining</span>
       </h3>
 
-      <div className="flex items-center justify-between text-sm">
-        <button
-          className="px-2 py-1 bg-green-500 text-white rounded disabled:opacity-50"
-          onClick={handleStart}
-          disabled={status === 'Mining'}
-        >
-          Start
-        </button>
-        <p className="text-white font-medium">
-          {status === 'Mining' ? formatTimeLeft(timeLeft) : '00:00:00'}
-        </p>
-        <p>
-          Status{' '}
-          <span className={status === 'Mining' ? 'text-green-500' : 'text-red-500'}>
-            {status}
-          </span>
-        </p>
-      </div>
+      <button
+        className={`w-full py-4 rounded text-white font-semibold ${status === 'Mining' ? 'bg-green-600' : 'bg-red-600'}`}
+        onClick={handleStart}
+        disabled={status === 'Mining'}
+      >
+        {status === 'Mining' ? formatTimeLeft(timeLeft) : 'Start Mining'}
+      </button>
 
       <p className="text-lg font-bold text-gray-300">Total Balance</p>
     </div>

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -3,7 +3,8 @@ import GameCard from '../components/GameCard.jsx';
 import MiningCard from '../components/MiningCard.tsx';
 import SpinGame from '../components/SpinGame.jsx';
 import TasksCard from '../components/TasksCard.jsx';
-import { FaUser } from 'react-icons/fa';
+import { FaUser, FaArrowCircleUp, FaArrowCircleDown } from 'react-icons/fa';
+import { Link } from 'react-router-dom';
 import { ping } from '../utils/api.js';
 import ConnectWallet from "../components/ConnectWallet.jsx";
 import BalanceSummary from '../components/BalanceSummary.jsx';
@@ -31,7 +32,15 @@ export default function Home() {
             className="w-36 h-36 hexagon border-4 border-brand-gold mt-2 object-cover"
           />
         )}
-        <BalanceSummary />
+        <div className="flex items-center justify-between w-full max-w-xs mt-2">
+          <Link to="/wallet?mode=send">
+            <FaArrowCircleUp className="text-accent w-8 h-8" />
+          </Link>
+          <BalanceSummary />
+          <Link to="/wallet?mode=receive">
+            <FaArrowCircleDown className="text-accent w-8 h-8" />
+          </Link>
+        </div>
       </div>
 
       <SpinGame />

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { tonToTpc, tpcToTon } from '../utils/tokenomics.js';
-import { getWalletBalance, getTonBalance } from '../utils/api.js';
+import { getWalletBalance, getTonBalance, sendTpc } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
 import ConnectWallet from '../components/ConnectWallet.jsx';
@@ -17,6 +17,8 @@ export default function Wallet() {
   const [tpc, setTpc] = useState('');
   const [tonBalance, setTonBalance] = useState(null);
   const [tpcBalance, setTpcBalance] = useState(null);
+  const [receiver, setReceiver] = useState('');
+  const [amount, setAmount] = useState('');
   const wallet = useTonWallet();
 
   const loadBalances = async () => {
@@ -44,9 +46,19 @@ export default function Wallet() {
     setTon(value ? tpcToTon(Number(value)) : '');
   };
 
+  const handleSend = async () => {
+    const amt = Number(amount);
+    if (!receiver || !amt) return;
+    await sendTpc(telegramId, Number(receiver), amt);
+    setReceiver('');
+    setAmount('');
+    loadBalances();
+  };
+
   return (
     <div className="p-4 space-y-2">
       <h2 className="text-xl font-bold">Wallet</h2>
+      <p className="text-sm">Account #{telegramId}</p>
       <ConnectWallet />
       <p>TON Balance: {tonBalance === null ? '...' : tonBalance}</p>
       <p>TPC Balance: {tpcBalance === null ? '...' : tpcBalance}</p>
@@ -67,6 +79,38 @@ export default function Wallet() {
           onChange={handleTpcChange}
           className="border p-1 rounded w-full"
         />
+      </div>
+      <div className="space-y-1">
+        <label className="block">Send TPC</label>
+        <input
+          type="number"
+          placeholder="Receiver Telegram ID"
+          value={receiver}
+          onChange={(e) => setReceiver(e.target.value)}
+          className="border p-1 rounded w-full"
+        />
+        <input
+          type="number"
+          placeholder="Amount"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="border p-1 rounded w-full mt-1"
+        />
+        <button
+          onClick={handleSend}
+          className="mt-1 px-3 py-1 bg-blue-600 text-white rounded"
+        >
+          Send
+        </button>
+      </div>
+      <div className="space-y-1">
+        <label className="block">Receive TPC</label>
+        <button
+          onClick={() => navigator.clipboard.writeText(String(telegramId))}
+          className="px-3 py-1 bg-green-600 text-white rounded"
+        >
+          Copy Account Number
+        </button>
       </div>
     </div>
   );

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -85,6 +85,10 @@ export function getTonBalance(address) {
   return post('/api/wallet/ton-balance', { address });
 }
 
+export function sendTpc(fromId, toId, amount) {
+  return post('/api/wallet/send', { fromId, toId, amount });
+}
+
 export function getReferralInfo(telegramId) {
   return post('/api/referral/code', { telegramId });
 }


### PR DESCRIPTION
## Summary
- allow server to send TPC between Telegram IDs
- expose `sendTpc` helper in the webapp API
- show send/receive actions in wallet page and display the account number
- add send/receive icons to the home page
- redesign mining card with a single large button

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d9b4a99e48329a834e0a53f0b3f86