### PR TITLE
Fix home layout

### DIFF
--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -25,14 +25,16 @@ export default function Home() {
   return (
     <div className="space-y-4">
       <div className="flex flex-col items-center">
-        <ConnectWallet />
         {photoUrl && (
           <img
             src={photoUrl}
             alt="profile"
-            className="w-36 h-36 hexagon border-4 border-brand-gold mt-2 object-cover"
+            className="w-36 h-36 hexagon border-4 border-brand-gold -mt-[20%] object-cover"
           />
         )}
+        <div className="mt-3">
+          <ConnectWallet />
+        </div>
 
         <div className="flex items-center justify-between w-full max-w-xs mt-2">
           <Link to="/wallet?mode=send" className="flex items-center space-x-1">


### PR DESCRIPTION
## Summary
- swap profile picture and Connect Wallet on home page
- add spacing to keep profile photo clear of the logo
- overlap profile photo with logo by about 20%
- add a small margin before the Connect Wallet button

## Testing
- `npm --prefix webapp install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dc513546083299bc034d1fa38d360