### PR TITLE
Add spin/daily titles and countdown

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -36,10 +36,10 @@ export default function BalanceSummary() {
   return (
     <div className="text-center mt-2">
       <p className="text-lg font-bold text-gray-300 flex items-center justify-center space-x-1">
-        <Link to="/wallet" className="flex items-center">
+        <Link to="/wallet" className="flex items-center space-x-1">
           <FaWallet className="text-primary" />
+          <span>Wallet</span>
         </Link>
-        <span>Wallet</span>
       </p>
       <div className="flex justify-around text-sm mt-1">
         <Token icon="/icons/ton.svg" label="TON" value={balances.ton ?? '...'} />

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -65,6 +65,7 @@ export default function DailyCheckIn() {
         <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
           <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text">
             <p className="font-semibold">Daily Check-In</p>
+            <p className="text-sm text-subtext">Come back daily to keep your streak!</p>
             <button
               onClick={handleCheckIn}
               className="px-4 py-2 bg-blue-600 text-white rounded"
@@ -74,8 +75,16 @@ export default function DailyCheckIn() {
           </div>
         </div>
       )}
-      {reward !== null && <RewardPopup reward={reward} onClose={() => setReward(null)} />}
+      {reward !== null && (
+        <RewardPopup
+          reward={reward}
+          onClose={() => setReward(null)}
+          message="Keep the streak alive for bigger rewards!"
+        />
+      )}
       {/* Place below your spin-game ad message */}
+      <h3 className="text-lg font-bold text-text text-center">Daily Streaks</h3>
+      <p className="text-sm text-subtext text-center">Check in each day for increasing rewards.</p>
       <div className="flex space-x-2 overflow-x-auto">{progress}</div>
     </div>
   );

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -16,6 +16,8 @@ import { getTelegramId } from '../utils/telegram.js';
 
 import OpenInTelegram from './OpenInTelegram.jsx';
 
+const MINING_DURATION = 12 * 60 * 60; // 12 hours in seconds
+
 export default function MiningCard() {
 
   let telegramId: string;
@@ -56,7 +58,7 @@ export default function MiningCard() {
 
         const diff = Math.floor((Date.now() - start) / 1000);
 
-        if (diff >= 43200) {
+        if (diff >= MINING_DURATION) {
 
           stopMining(telegramId);
 
@@ -110,7 +112,7 @@ export default function MiningCard() {
 
       const diff = Math.floor((Date.now() - start) / 1000);
 
-      if (diff >= 43200) {
+      if (diff >= MINING_DURATION) {
 
         await stopMining(telegramId);
 
@@ -210,7 +212,7 @@ export default function MiningCard() {
 
         <div>{isMining ? 'Mining' : 'Not Mining'}</div>
 
-        <div className="text-sm">{formatTime(elapsed)}</div>
+          <div className="text-sm">{formatTime(isMining ? Math.max(MINING_DURATION - elapsed, 0) : MINING_DURATION)}</div>
 
       </button>
 

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -4,9 +4,10 @@ import confetti from 'canvas-confetti';
 interface RewardPopupProps {
   reward: number | null;
   onClose: () => void;
+  message?: string;
 }
 
-export default function RewardPopup({ reward, onClose }: RewardPopupProps) {
+export default function RewardPopup({ reward, onClose, message }: RewardPopupProps) {
   if (reward === null) return null;
   useEffect(() => {
     confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
@@ -15,6 +16,7 @@ export default function RewardPopup({ reward, onClose }: RewardPopupProps) {
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text">
         <div className="text-yellow-400 text-3xl">+{reward} TPC</div>
+        {message && <p className="text-sm text-subtext">{message}</p>}
         <button
           onClick={onClose}
           className="px-4 py-1 bg-blue-600 text-white rounded"

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -45,6 +45,8 @@ export default function SpinGame() {
 
   return (
     <div className="bg-surface border border-border rounded p-4 flex flex-col items-center space-y-2">
+      <h3 className="text-lg font-bold text-text">Spin &amp; Win</h3>
+      <p className="text-sm text-subtext">Try your luck and win rewards!</p>
       <SpinWheel
         onFinish={handleFinish}
         spinning={spinning}
@@ -65,7 +67,11 @@ export default function SpinGame() {
         </>
       )}
       <DailyCheckIn />
-      <RewardPopup reward={reward} onClose={() => setReward(null)} />
+      <RewardPopup
+        reward={reward}
+        onClose={() => setReward(null)}
+        message="Keep spinning every day to earn more!"
+      />
       <AdModal open={showAd} onClose={() => setShowAd(false)} />
     </div>
   );

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -94,7 +94,6 @@ export default function Home() {
 
         <MiningCard />
 
-        <TasksCard />
 
         <GameCard
 
@@ -105,6 +104,8 @@ export default function Home() {
           link="/account"
 
         />
+
+        <TasksCard />
 
       </div>
 

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -44,6 +44,8 @@ export default function SpinPage() {
 
   return (
     <div className="p-4 space-y-6 flex flex-col items-center text-text">
+      <h1 className="text-xl font-bold">Spin &amp; Win</h1>
+      <p className="text-sm text-subtext">Try your luck and win rewards!</p>
       <div className="bg-surface border border-border rounded p-4 flex flex-col items-center space-y-2">
         <SpinWheel
           onFinish={handleFinish}
@@ -60,7 +62,11 @@ export default function SpinPage() {
           </>
         )}
       </div>
-      <RewardPopup reward={reward} onClose={() => setReward(null)} />
+      <RewardPopup
+        reward={reward}
+        onClose={() => setReward(null)}
+        message="Keep spinning every day to earn more!"
+      />
       <AdModal open={showAd} onClose={() => setShowAd(false)} />
     </div>
   );


### PR DESCRIPTION
## Summary
- link the Wallet text on home to the wallet page
- show Daily Streaks heading with slogans and popup message
- add message support to reward popup component
- display Spin & Win title and slogan
- reorder profile card on home
- add countdown timer for mining button
- add headings and slogans to dedicated spin page

## Testing
- `npm --prefix webapp run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dcbde30448329a0ab763dadd17da3