### PR TITLE
Adjust profile card placement and style

### DIFF
--- a/webapp/src/components/ProfileCard.jsx
+++ b/webapp/src/components/ProfileCard.jsx
@@ -1,0 +1,17 @@
+import { FaUser } from 'react-icons/fa';
+import { Link } from 'react-router-dom';
+
+export default function ProfileCard() {
+  return (
+    <div className="bg-surface p-4 rounded-xl shadow-lg space-y-2 text-center">
+      <FaUser className="text-accent text-3xl mx-auto" />
+      <h3 className="text-lg font-bold text-text">Profile</h3>
+      <Link
+        to="/account"
+        className="inline-block mt-1 px-3 py-1 bg-primary text-text rounded hover:bg-primary-hover"
+      >
+        Open
+      </Link>
+    </div>
+  );
+}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import GameCard from '../components/GameCard.jsx';
+import ProfileCard from '../components/ProfileCard.jsx';
 
 import MiningCard from '../components/MiningCard.tsx';
 
@@ -91,22 +92,9 @@ export default function Home() {
       <SpinGame />
 
       <div className="grid grid-cols-1 gap-4">
-
         <MiningCard />
-
-
-        <GameCard
-
-          title="Profile"
-
-          icon={<FaUser className="text-accent" />}
-
-          link="/account"
-
-        />
-
         <TasksCard />
-
+        <ProfileCard />
       </div>
 
       <p className="text-center text-xs text-subtext">Status: {status}</p>


### PR DESCRIPTION
## Summary
- add `ProfileCard` component
- reorder cards on home page
- use `ProfileCard` for profile link
- center icon and title in profile card

## Testing
- `npm --prefix webapp install`
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_684dcee02d8883298fed60646fd8b38c