### PR TITLE
Fix TPC transfer rollback

### DIFF
--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -50,54 +50,86 @@ router.post('/send', async (req, res) => {
     return res.status(400).json({ error: 'insufficient balance' });
   }
 
-  sender.balance -= amount;
-  await sender.save();
-
   const txDate = new Date();
-
-  await User.findOneAndUpdate(
-    { telegramId: toId },
-    { $inc: { balance: amount }, $setOnInsert: { referralCode: toId.toString() } },
-    { upsert: true }
-  );
-
-  const senderTx = {
-    amount: -amount,
-    type: 'send',
-    status: 'delivered',
-    date: txDate
-  };
-
-  const receiverTx = {
-    amount,
-    type: 'receive',
-    status: 'delivered',
-    date: txDate
-  };
-
-  await User.updateOne(
-    { telegramId: fromId },
-    {
-      $push: { transactions: senderTx }
-    }
-  );
-  await User.updateOne(
-    { telegramId: toId },
-    {
-      $push: { transactions: receiverTx }
-    }
-  );
+  let deducted = false;
 
   try {
-    await bot.telegram.sendMessage(
-      String(toId),
-      `You received ${amount} TPC from ${fromId}`
+    await User.findOneAndUpdate(
+      { telegramId: toId },
+      { $inc: { balance: amount }, $setOnInsert: { referralCode: toId.toString() } },
+      { upsert: true }
     );
-  } catch (err) {
-    console.error('Failed to send Telegram notification:', err.message);
-  }
 
-  res.json({ balance: sender.balance, transaction: senderTx });
+    sender.balance -= amount;
+    await sender.save();
+    deducted = true;
+
+    const senderTx = {
+      amount: -amount,
+      type: 'send',
+      status: 'delivered',
+      date: txDate
+    };
+
+    const receiverTx = {
+      amount,
+      type: 'receive',
+      status: 'delivered',
+      date: txDate
+    };
+
+    await User.updateOne(
+      { telegramId: fromId },
+      {
+        $push: { transactions: senderTx }
+      }
+    );
+    await User.updateOne(
+      { telegramId: toId },
+      {
+        $push: { transactions: receiverTx }
+      }
+    );
+
+    try {
+      await bot.telegram.sendMessage(
+        String(toId),
+        `You received ${amount} TPC from ${fromId}`
+      );
+    } catch (err) {
+      console.error('Failed to send Telegram notification:', err.message);
+    }
+
+    return res.json({ balance: sender.balance, transaction: senderTx });
+  } catch (err) {
+    console.error('Failed to complete TPC transfer:', err.message);
+    const failedTx = {
+      amount: -amount,
+      type: 'send',
+      status: 'failed',
+      date: txDate
+    };
+    await User.updateOne(
+      { telegramId: fromId },
+      { $push: { transactions: failedTx } }
+    ).catch((e) => console.error('Failed to log failed transaction:', e.message));
+
+    // Attempt to revert receiver balance in case it was credited
+    await User.updateOne(
+      { telegramId: toId },
+      { $inc: { balance: -amount } }
+    ).catch(() => {});
+
+    // Revert sender deduction if it was saved
+    if (deducted) {
+      await User.updateOne(
+        { telegramId: fromId },
+        { $inc: { balance: amount } }
+      ).catch(() => {});
+    }
+
+    res.status(500).json({ error: 'Failed to send TPC' });
+  }
 });
 
 router.post('/transactions', async (req, res) => {

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -1,5 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
-import { getProfile, updateProfile, fetchTelegramInfo, getReferralInfo } from '../utils/api.js';
+import {
+  getProfile,
+  updateProfile,
+  fetchTelegramInfo,
+  getReferralInfo,
+  getTransactions
+} from '../utils/api.js';
 import {
   getTelegramId,
   getTelegramFirstName,
@@ -22,6 +28,7 @@ export default function MyAccount() {
   const [profile, setProfile] = useState(null);
   const [referral, setReferral] = useState(null);
   const [autoUpdating, setAutoUpdating] = useState(false);
+  const [transactions, setTransactions] = useState([]);
   const timerRef = useRef(null);
 
   useEffect(() => {
@@ -30,6 +37,8 @@ export default function MyAccount() {
       setProfile(data);
       const ref = await getReferralInfo(telegramId);
       setReferral(ref);
+      const tx = await getTransactions(telegramId);
+      setTransactions(tx.transactions || []);
 
       if (!data.photo || !data.firstName || !data.lastName) {
         setAutoUpdating(true);
@@ -122,6 +131,27 @@ export default function MyAccount() {
           <p className="text-sm text-subtext">{referral.referrals} referrals</p>
         </div>
       )}
+
+      <div>
+        <p className="font-semibold">Transaction History</p>
+        {transactions.length === 0 ? (
+          <p className="text-sm text-subtext">No transactions</p>
+        ) : (
+          <div className="space-y-1 text-sm">
+            {transactions.map((tx, i) => (
+              <div
+                key={i}
+                className="flex justify-between border-b border-border pb-1"
+              >
+                <span>{tx.type}</span>
+                <span>{tx.amount}</span>
+                <span>{new Date(tx.date).toLocaleString()}</span>
+                <span className="text-xs">{tx.status}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- ensure `/api/wallet/send` doesn't deduct on failure
- record failed transfers in transaction history
- display user's transaction history on profile page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dcfa6376483299940b4c96e41b027