### PR TITLE
Improve popup styling

### DIFF
--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -7,9 +7,15 @@ export default function AdModal({ open, onClose }: AdModalProps) {
   if (!open) return null;
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="bg-gray-800 p-4 rounded text-center space-y-4 w-64">
-        <p className="text-yellow-400">Watch an ad every hour to get a free spin.</p>
-        <button onClick={onClose} className="px-4 py-1 bg-blue-600 text-white rounded">
+      <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text w-80">
+        <img
+          src="/assets/TonPlayGramLogo.jpg"
+          alt="TonPlaygram Logo"
+          className="w-12 h-12 mx-auto transform scale-110"
+        />
+        <h3 className="text-lg font-bold">Watch Ad</h3>
+        <p className="text-sm text-subtext">Watch an ad every hour to get a free spin.</p>
+        <button onClick={onClose} className="px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded w-full">
           Close
         </button>
       </div>

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -63,12 +63,17 @@ export default function DailyCheckIn() {
     <div className="w-full space-y-2">
       {showPopup && (
         <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-          <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text">
-            <p className="font-semibold">Daily Check-In</p>
+          <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text w-80">
+            <img
+              src="/assets/TonPlayGramLogo.jpg"
+              alt="TonPlaygram Logo"
+              className="w-12 h-12 mx-auto transform scale-110"
+            />
+            <h3 className="text-lg font-bold">Daily Check-In</h3>
             <p className="text-sm text-subtext">Come back daily to keep your streak!</p>
             <button
               onClick={handleCheckIn}
-              className="px-4 py-2 bg-blue-600 text-white rounded"
+              className="px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded w-full"
             >
               Check in
             </button>

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -14,12 +14,18 @@ export default function RewardPopup({ reward, onClose, message }: RewardPopupPro
   }, []);
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text">
-        <div className="text-yellow-400 text-3xl">+{reward} TPC</div>
+      <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text w-80">
+        <img
+          src="/assets/TonPlayGramLogo.jpg"
+          alt="TonPlaygram Logo"
+          className="w-12 h-12 mx-auto transform scale-110"
+        />
+        <h3 className="text-lg font-bold">Reward Earned</h3>
+        <div className="text-accent text-3xl">+{reward} TPC</div>
         {message && <p className="text-sm text-subtext">{message}</p>}
         <button
           onClick={onClose}
-          className="px-4 py-1 bg-blue-600 text-white rounded"
+          className="px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded w-full"
         >
           Close
         </button>

--- a/webapp/src/components/RoomPopup.jsx
+++ b/webapp/src/components/RoomPopup.jsx
@@ -5,12 +5,19 @@ export default function RoomPopup({ open, selection, setSelection, onConfirm }) 
   const disabled = !selection || !selection.token || !selection.amount;
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
-      <div className="bg-surface border border-border p-4 rounded space-y-4 text-text">
+      <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
+        <img
+          src="/assets/TonPlayGramLogo.jpg"
+          alt="TonPlaygram Logo"
+          className="w-12 h-12 mx-auto transform scale-110"
+        />
+        <h3 className="text-lg font-bold text-center">Join a Room</h3>
+        <p className="text-sm text-subtext text-center">Choose your token and amount</p>
         <RoomSelector selected={selection || { token: '', amount: 0 }} onSelect={setSelection} />
         <button
           onClick={onConfirm}
           disabled={disabled}
-          className={`px-4 py-1 bg-blue-600 text-white rounded w-full disabled:opacity-50`}
+          className={`px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded w-full disabled:opacity-50`}
         >
           Confirm
         </button>


### PR DESCRIPTION
## Summary
- update DailyCheckIn popup styling and layout
- refresh RewardPopup visuals
- unify AdModal design
- give RoomPopup title and brand icon
- enlarge popup logos for better visibility

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dd760b9c883299c36078258ad80e6