### PR TITLE
Add free spin reward to Spin & Win

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -82,7 +82,7 @@ export default function DailyCheckIn() {
       )}
       {reward !== null && (
         <RewardPopup
-          reward={reward}
+          reward={{ tpc: reward }}
           onClose={() => setReward(null)}
           message="Keep the streak alive for bigger rewards!"
         />

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
 import confetti from 'canvas-confetti';
+import { RewardSegment } from '../utils/rewardLogic';
 
 interface RewardPopupProps {
-  reward: number | null;
+  reward: RewardSegment | null;
   onClose: () => void;
   message?: string;
 }
@@ -21,7 +22,9 @@ export default function RewardPopup({ reward, onClose, message }: RewardPopupPro
           className="w-10 h-10 mx-auto"
         />
         <h3 className="text-lg font-bold">Reward Earned</h3>
-        <div className="text-accent text-3xl">+{reward} TPC</div>
+        <div className="text-accent text-3xl">
+          {reward.tpc !== undefined ? `+${reward.tpc} TPC` : `${reward.spins} Free Spins`}
+        </div>
         {message && <p className="text-sm text-subtext">{message}</p>}
         <button
           onClick={onClose}

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import SpinWheel from './SpinWheel.tsx';
 import RewardPopup from './RewardPopup.tsx';
+import { canSpin, nextSpinTime } from '../utils/rewardLogic';
 import AdModal from './AdModal.tsx';
 import DailyCheckIn from './DailyCheckIn.jsx';
-import { canSpin, nextSpinTime } from '../utils/rewardLogic';
 import {
   getWalletBalance,
   updateBalance,
@@ -21,6 +21,7 @@ export default function SpinGame() {
   }
   const [lastSpin, setLastSpin] = useState(null);
   const [reward, setReward] = useState(null);
+  const [extraSpins, setExtraSpins] = useState(0);
   const [spinning, setSpinning] = useState(false);
   const [showAd, setShowAd] = useState(false);
 
@@ -30,18 +31,24 @@ export default function SpinGame() {
   }, []);
 
   const handleFinish = async (r) => {
+    if (r.spins) {
+      setExtraSpins(s => s + r.spins);
+      setReward(r);
+      return;
+    }
     const now = Date.now();
     localStorage.setItem('lastSpin', String(now));
     setLastSpin(now);
-    setReward(r);
+    const base = r.tpc || 0;
+    setReward({ tpc: base });
     const id = telegramId;
     const balRes = await getWalletBalance(id);
-    const newBalance = (balRes.balance || 0) + r;
+    const newBalance = (balRes.balance || 0) + base;
     await updateBalance(id, newBalance);
-    await addTransaction(id, r, 'spin');
+    await addTransaction(id, base, 'spin');
   };
 
-  const ready = canSpin(lastSpin);
+  const ready = canSpin(lastSpin, extraSpins);
 
   return (
     <div className="bg-surface border border-border rounded p-4 flex flex-col items-center space-y-2">
@@ -53,6 +60,9 @@ export default function SpinGame() {
         setSpinning={setSpinning}
         disabled={!ready}
       />
+      {extraSpins > 0 && (
+        <p className="text-sm text-white font-semibold">Free spins left: {extraSpins}</p>
+      )}
       {!ready && (
         <>
           <p className="text-sm text-white font-semibold">

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -1,7 +1,7 @@
 import {  forwardRef, useImperativeHandle } from 'react';
 import { useState, useEffect, useRef } from 'react';
 
-import { segments } from '../utils/rewardLogic';
+import { segments, RewardSegment } from '../utils/rewardLogic';
 
 export interface SpinWheelHandle {
   spin: () => void;
@@ -9,7 +9,7 @@ export interface SpinWheelHandle {
 
 interface SpinWheelProps {
 
-  onFinish: (reward: number) => void;
+  onFinish: (reward: RewardSegment) => void;
 
   spinning: boolean;
 
@@ -158,9 +158,14 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
             >
 
-              <img src="/icons/tpc.svg" alt="TPC" className="w-5 h-5 mr-1" />
-
-              <span>{val}</span>
+              {val.tpc !== undefined ? (
+                <>
+                  <img src="/icons/tpc.svg" alt="TPC" className="w-5 h-5 mr-1" />
+                  <span>{val.tpc}</span>
+                </>
+              ) : (
+                <span>{val.spins} Spins</span>
+              )}
 
             </div>
 

--- a/webapp/src/utils/rewardLogic.ts
+++ b/webapp/src/utils/rewardLogic.ts
@@ -1,8 +1,30 @@
 // Prize amounts available on the wheel. Added a 5000 TPC jackpot.
-export const segments = [300, 800, 1000, 1200, 1400, 1500, 1600, 1800, 5000];
+// Possible prizes on the wheel. "spins" grants free spins instead of TPC.
+export interface RewardSegment {
+  tpc?: number;
+  spins?: number;
+}
+
+export const segments: RewardSegment[] = [
+  { tpc: 300 },
+  { tpc: 800 },
+  { tpc: 1000 },
+  { tpc: 1200 },
+  { tpc: 1400 },
+  { tpc: 1500 },
+  { tpc: 1600 },
+  { tpc: 1800 },
+  { tpc: 5000 },
+  { spins: 5 },
+  { tpc: 8888 },
+  { tpc: 888 },
+  { tpc: 33333 },
+  { tpc: 5555 }
+];
 const ONE_HOUR = 3600_000;
 
-export function canSpin(lastSpin: number | null): boolean {
+export function canSpin(lastSpin: number | null, freeSpins: number = 0): boolean {
+  if (freeSpins > 0) return true;
   if (!lastSpin) return true;
   return Date.now() - lastSpin >= ONE_HOUR;
 }
@@ -11,7 +33,7 @@ export function nextSpinTime(lastSpin: number | null): number {
   return lastSpin ? lastSpin + ONE_HOUR : Date.now();
 }
 
-export function getRandomReward(): number {
+export function getRandomReward(): RewardSegment {
   const index = Math.floor(Math.random() * segments.length);
   return segments[index];
 }


### PR DESCRIPTION
## Summary
- support complex reward types with free spins
- show free spin counts in SpinGame and spin page
- extend reward list with new TPC prizes
- update popup UI to display free spins

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684df87d435c832981980608a7c42ff7