### PR TITLE
Fix TonConnect manifest URL and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ Start the Express server (which also serves the compiled web app) with:
 
 ```bash
 npm start
+```
+
+### TonConnect manifest
+
+Tonkeeper and other wallets load the manifest from the URL specified in
+`VITE_TONCONNECT_MANIFEST` during the web app build. When the frontend is
+hosted on a different domain than the API, set this variable to the absolute
+URL of your backend, e.g. `https://your-api.example.com/tonconnect-manifest.json`.
+Otherwise the wallet may receive a **404 Not Found** when trying to fetch the
+manifest.

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,2 +1,5 @@
 VITE_API_BASE_URL=http://localhost:3000
-VITE_TONCONNECT_MANIFEST=/tonconnect-manifest.json
+# Set an absolute URL for the TonConnect manifest when the frontend is
+# hosted separately from the API. The manifest should be served by the
+# backend so Tonkeeper can retrieve it.
+VITE_TONCONNECT_MANIFEST=http://localhost:3000/tonconnect-manifest.json

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -4,9 +4,15 @@ import App from './App.jsx';
 import { TonConnectUIProvider } from '@tonconnect/ui-react';
 import './index.css';
 
+const manifestUrl =
+  import.meta.env.VITE_TONCONNECT_MANIFEST ||
+  (import.meta.env.VITE_API_BASE_URL
+    ? `${import.meta.env.VITE_API_BASE_URL}/tonconnect-manifest.json`
+    : `${window.location.origin}/tonconnect-manifest.json`);
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <TonConnectUIProvider manifestUrl={import.meta.env.VITE_TONCONNECT_MANIFEST || '/tonconnect-manifest.json'}>
+    <TonConnectUIProvider manifestUrl={manifestUrl}>
       <App />
     </TonConnectUIProvider>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- compute manifest URL dynamically based on `VITE_API_BASE_URL`
- document how to set the manifest URL when deploying the webapp
- update env example for clarity

## Testing
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_684df94255d08329bba7a90ef5d0d4ca