### PR TITLE
Fix transactions array casting error

### DIFF
--- a/bot/utils/miningUtils.js
+++ b/bot/utils/miningUtils.js
@@ -1,7 +1,10 @@
 export const MINING_SESSION_MS = 12 * 60 * 60 * 1000; // 12 hours
 export const MINING_REWARD = 2000;
 
+import { ensureTransactionArray } from './userUtils.js';
+
 export function updateMiningRewards(user) {
+  ensureTransactionArray(user);
   if (user.isMining && user.lastMineAt) {
     const diffMs = Date.now() - user.lastMineAt.getTime();
     if (diffMs >= MINING_SESSION_MS) {
@@ -20,18 +23,21 @@ export function updateMiningRewards(user) {
 }
 
 export async function startMining(user) {
+  ensureTransactionArray(user);
   user.isMining = true;
   user.lastMineAt = new Date();
   await user.save();
 }
 
 export async function stopMining(user) {
+  ensureTransactionArray(user);
   updateMiningRewards(user);
   user.isMining = false;
   await user.save();
 }
 
 export async function claimRewards(user) {
+  ensureTransactionArray(user);
   updateMiningRewards(user);
   const amount = user.minedTPC;
   user.minedTPC = 0;

--- a/bot/utils/userUtils.js
+++ b/bot/utils/userUtils.js
@@ -1,0 +1,9 @@
+export function ensureTransactionArray(user) {
+  if (user && typeof user.transactions === 'string') {
+    try {
+      user.transactions = JSON.parse(user.transactions);
+    } catch {
+      user.transactions = [];
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- ensure user transactions are parsed as arrays
- sanitize transactions when mining, sending TPC and adding manual entries

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dfc39d0588329aeb7b7dcf57e999c