### PR TITLE
Add Connect Four game with staking

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ hosted on a different domain than the API, set this variable to the absolute
 URL of your backend, e.g. `https://your-api.example.com/tonconnect-manifest.json`.
 Otherwise the wallet may receive a **404 Not Found** when trying to fetch the
 manifest.
+
+### Available Games
+
+- Chess with staking
+- Connect Four with staking
+- Spin & Win mini game

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -12,6 +12,7 @@ import registerDice from './commands/games/dice.js';
 import registerLudo from './commands/games/ludo.js';
 import registerHorse from './commands/games/horse.js';
 import registerSnake from './commands/games/snake.js';
+import registerConnectFour from './commands/games/connectfour.js';
 const bot = new Telegraf(process.env.BOT_TOKEN);
 registerStart(bot);
 registerMine(bot);
@@ -23,5 +24,6 @@ registerDice(bot);
 registerLudo(bot);
 registerHorse(bot);
 registerSnake(bot);
+registerConnectFour(bot);
 
 export default bot;

--- a/bot/commands/games/connectfour.js
+++ b/bot/commands/games/connectfour.js
@@ -1,0 +1,3 @@
+export default function registerConnectFour(bot) {
+  bot.command('connectfour', (ctx) => ctx.reply('Connect Four coming soon.'));
+}

--- a/webapp/public/assets/icons/connect4.svg
+++ b/webapp/public/assets/icons/connect4.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 120" fill="none">
+  <rect width="140" height="120" rx="10" fill="#374151"/>
+  <g fill="white">
+    <circle cx="15" cy="15" r="6"/>
+    <circle cx="33" cy="15" r="6"/>
+    <circle cx="51" cy="15" r="6"/>
+    <circle cx="69" cy="15" r="6"/>
+    <circle cx="87" cy="15" r="6"/>
+    <circle cx="105" cy="15" r="6"/>
+    <circle cx="123" cy="15" r="6"/>
+    <circle cx="15" cy="33" r="6"/>
+    <circle cx="33" cy="33" r="6"/>
+    <circle cx="51" cy="33" r="6"/>
+    <circle cx="69" cy="33" r="6"/>
+    <circle cx="87" cy="33" r="6"/>
+    <circle cx="105" cy="33" r="6"/>
+    <circle cx="123" cy="33" r="6"/>
+    <circle cx="15" cy="51" r="6"/>
+    <circle cx="33" cy="51" r="6"/>
+    <circle cx="51" cy="51" r="6"/>
+    <circle cx="69" cy="51" r="6"/>
+    <circle cx="87" cy="51" r="6"/>
+    <circle cx="105" cy="51" r="6"/>
+    <circle cx="123" cy="51" r="6"/>
+    <circle cx="15" cy="69" r="6"/>
+    <circle cx="33" cy="69" r="6"/>
+    <circle cx="51" cy="69" r="6"/>
+    <circle cx="69" cy="69" r="6"/>
+    <circle cx="87" cy="69" r="6"/>
+    <circle cx="105" cy="69" r="6"/>
+    <circle cx="123" cy="69" r="6"/>
+    <circle cx="15" cy="87" r="6"/>
+    <circle cx="33" cy="87" r="6"/>
+    <circle cx="51" cy="87" r="6"/>
+    <circle cx="69" cy="87" r="6"/>
+    <circle cx="87" cy="87" r="6"/>
+    <circle cx="105" cy="87" r="6"/>
+    <circle cx="123" cy="87" r="6"/>
+    <circle cx="15" cy="105" r="6"/>
+    <circle cx="33" cy="105" r="6"/>
+    <circle cx="51" cy="105" r="6"/>
+    <circle cx="69" cy="105" r="6"/>
+    <circle cx="87" cy="105" r="6"/>
+    <circle cx="105" cy="105" r="6"/>
+    <circle cx="123" cy="105" r="6"/>
+  </g>\n</svg>

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -14,6 +14,7 @@ import LudoGame from './pages/Games/LudoGame.jsx';
 import HorseRacing from './pages/Games/HorseRacing.jsx';
 import SnakeLadders from './pages/Games/SnakeLadders.jsx';
 import ChessGame from './pages/Games/Chess.jsx';
+import ConnectFour from './pages/Games/ConnectFour.jsx';
 import Games from './pages/Games.jsx';
 import SpinPage from './pages/spin.tsx';
 
@@ -34,6 +35,7 @@ export default function App() {
           <Route path="/games/ludo" element={<LudoGame />} />
           <Route path="/games/horse" element={<HorseRacing />} />
           <Route path="/games/snake" element={<SnakeLadders />} />
+          <Route path="/games/connectfour" element={<ConnectFour />} />
           <Route path="/games/chess" element={<ChessGame />} />
           <Route path="/spin" element={<SpinPage />} />
           <Route path="/tasks" element={<Tasks />} />

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -7,6 +7,7 @@ export default function Games() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <GameCard title="Chess" icon="/assets/icons/horse.svg" link="/games/chess" />
         <GameCard title="Snakes & Ladders" icon="/assets/icons/snake.svg" link="/games/snake" />
+        <GameCard title="Connect Four" icon="/assets/icons/connect4.svg" link="/games/connectfour" />
         <GameCard title="Dice Duel" icon="/assets/icons/dice.svg" link="/games/dice" />
       </div>
     </div>

--- a/webapp/src/pages/Games/ConnectFour.jsx
+++ b/webapp/src/pages/Games/ConnectFour.jsx
@@ -1,0 +1,153 @@
+import { useState } from 'react';
+import ConnectWallet from '../../components/ConnectWallet.jsx';
+import RoomPopup from '../../components/RoomPopup.jsx';
+import RewardPopup from '../../components/RewardPopup.tsx';
+import { getWalletBalance, updateBalance, addTransaction } from '../../utils/api.js';
+import { getTelegramId } from '../../utils/telegram.js';
+import OpenInTelegram from '../../components/OpenInTelegram.jsx';
+
+const ROWS = 6;
+const COLS = 7;
+
+function createBoard() {
+  return Array.from({ length: ROWS }, () => Array(COLS).fill(null));
+}
+
+function checkWinner(board, row, col, player) {
+  const directions = [
+    [1, 0],
+    [0, 1],
+    [1, 1],
+    [1, -1]
+  ];
+  for (const [dx, dy] of directions) {
+    let count = 1;
+    let r = row + dx;
+    let c = col + dy;
+    while (r >= 0 && r < ROWS && c >= 0 && c < COLS && board[r][c] === player) {
+      count++; r += dx; c += dy;
+    }
+    r = row - dx;
+    c = col - dy;
+    while (r >= 0 && r < ROWS && c >= 0 && c < COLS && board[r][c] === player) {
+      count++; r -= dx; c -= dy;
+    }
+    if (count >= 4) return true;
+  }
+  return false;
+}
+
+export default function ConnectFour() {
+  let telegramId;
+  try {
+    telegramId = getTelegramId();
+  } catch (err) {
+    return <OpenInTelegram />;
+  }
+  const [selection, setSelection] = useState(null);
+  const [showRoom, setShowRoom] = useState(true);
+  const [board, setBoard] = useState(createBoard());
+  const [current, setCurrent] = useState('R');
+  const [winner, setWinner] = useState(null);
+  const [reward, setReward] = useState(null);
+
+  const resetGame = () => {
+    setBoard(createBoard());
+    setCurrent('R');
+    setWinner(null);
+  };
+
+  const handleStake = async () => {
+    if (!selection || selection.token !== 'TPC') return;
+    const balRes = await getWalletBalance(telegramId);
+    if ((balRes.balance || 0) < selection.amount) {
+      alert('Insufficient balance');
+      setShowRoom(true);
+      return false;
+    }
+    const newBal = (balRes.balance || 0) - selection.amount;
+    await updateBalance(telegramId, newBal);
+    await addTransaction(telegramId, -selection.amount, 'connectfour-stake');
+    return true;
+  };
+
+  const handleWin = async (player) => {
+    setWinner(player);
+    if (selection && selection.token === 'TPC') {
+      const balRes = await getWalletBalance(telegramId);
+      const rewardAmt = selection.amount * 2;
+      const newBal = (balRes.balance || 0) + rewardAmt;
+      await updateBalance(telegramId, newBal);
+      await addTransaction(telegramId, rewardAmt, 'connectfour-win');
+      setReward(rewardAmt);
+    }
+  };
+
+  const drop = (col) => {
+    if (winner) return;
+    const newBoard = board.map((r) => r.slice());
+    for (let r = ROWS - 1; r >= 0; r--) {
+      if (!newBoard[r][col]) {
+        newBoard[r][col] = current;
+        setBoard(newBoard);
+        if (checkWinner(newBoard, r, col, current)) {
+          handleWin(current);
+        } else if (newBoard.every((row) => row.every(Boolean))) {
+          setWinner('draw');
+        } else {
+          setCurrent(current === 'R' ? 'Y' : 'R');
+        }
+        break;
+      }
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-text">
+      <h2 className="text-xl font-bold">Connect Four</h2>
+      <RoomPopup
+        open={showRoom}
+        selection={selection}
+        setSelection={setSelection}
+        onConfirm={async () => {
+          const ok = await handleStake();
+          if (ok !== false) setShowRoom(false);
+        }}
+      />
+      <ConnectWallet />
+      <div className="grid grid-rows-6 grid-cols-7 gap-1 max-w-xs mx-auto mt-4">
+        {board.map((row, r) =>
+          row.map((cell, c) => (
+            <div
+              key={`${r}-${c}`}
+              onClick={() => drop(c)}
+              className="w-10 h-10 bg-gray-700 flex items-center justify-center rounded-full cursor-pointer"
+            >
+              {cell && (
+                <div
+                  className={`w-8 h-8 rounded-full ${
+                    cell === 'R' ? 'bg-red-500' : 'bg-yellow-300'
+                  }`}
+                />
+              )}
+            </div>
+          ))
+        )}
+      </div>
+      {winner && (
+        <div className="text-center space-y-2">
+          <p className="text-lg font-semibold">
+            {winner === 'draw' ? 'Draw game!' : `${winner === 'R' ? 'Red' : 'Yellow'} wins!`}
+          </p>
+          <button
+            onClick={resetGame}
+            className="px-4 py-1 border border-yellow-500 rounded text-yellow-500"
+          >
+            Play Again
+          </button>
+        </div>
+      )}
+      <RewardPopup reward={reward} onClose={() => setReward(null)} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement Connect Four React page with staking logic
- add bot command for `/connectfour`
- link new route and game card in webapp
- include Connect Four icon
- document available games in README

## Testing
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_684e46f2467c8329b3ec4c4be0da7dcf