### PR TITLE
Add airdrop and daily check-in backend

### DIFF
--- a/bot/models/Airdrop.js
+++ b/bot/models/Airdrop.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+
+const airdropSchema = new mongoose.Schema({
+  telegramId: { type: Number, required: true },
+  amount: { type: Number, required: true },
+  reason: { type: String, default: '' },
+  createdAt: { type: Date, default: Date.now }
+});
+
+airdropSchema.index({ telegramId: 1, createdAt: -1 });
+
+export default mongoose.model('Airdrop', airdropSchema);

--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -13,6 +13,9 @@ const userSchema = new mongoose.Schema({
 
   minedTPC: { type: Number, default: 0 },
 
+  dailyStreak: { type: Number, default: 0 },
+  lastCheckIn: { type: Date, default: null },
+
   balance: { type: Number, default: 0 },
 
   nickname: { type: String, default: '' },

--- a/bot/routes/airdrop.js
+++ b/bot/routes/airdrop.js
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+import User from '../models/User.js';
+import Airdrop from '../models/Airdrop.js';
+import { ensureTransactionArray } from '../utils/userUtils.js';
+
+const router = Router();
+
+// Grant an airdrop to a user
+router.post('/grant', async (req, res) => {
+  const { telegramId, amount, reason } = req.body;
+  if (!telegramId || typeof amount !== 'number') {
+    return res.status(400).json({ error: 'telegramId and amount required' });
+  }
+  if (amount <= 0) {
+    return res.status(400).json({ error: 'amount must be positive' });
+  }
+
+  try {
+    const user = await User.findOneAndUpdate(
+      { telegramId },
+      { $setOnInsert: { referralCode: telegramId.toString() } },
+      { upsert: true, new: true }
+    );
+    ensureTransactionArray(user);
+    user.balance += amount;
+    user.transactions.push({
+      amount,
+      type: 'airdrop',
+      status: 'delivered',
+      date: new Date()
+    });
+    await user.save();
+
+    await Airdrop.create({ telegramId, amount, reason });
+
+    res.json({ balance: user.balance });
+  } catch (err) {
+    console.error('Failed to grant airdrop:', err.message);
+    res.status(500).json({ error: 'Failed to grant airdrop' });
+  }
+});
+
+export default router;

--- a/bot/routes/checkin.js
+++ b/bot/routes/checkin.js
@@ -1,0 +1,48 @@
+import { Router } from 'express';
+import User from '../models/User.js';
+import { ensureTransactionArray } from '../utils/userUtils.js';
+
+const REWARDS = Array.from({ length: 30 }, (_, i) => 1000 * (i + 1));
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+const router = Router();
+
+// Perform daily check-in and award mining credits
+router.post('/check-in', async (req, res) => {
+  const { telegramId } = req.body;
+  if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
+
+  try {
+    const user = await User.findOneAndUpdate(
+      { telegramId },
+      { $setOnInsert: { referralCode: telegramId.toString() } },
+      { upsert: true, new: true }
+    );
+    ensureTransactionArray(user);
+
+    const now = Date.now();
+    let streak = 1;
+    if (user.lastCheckIn && now - user.lastCheckIn.getTime() < ONE_DAY_MS * 2) {
+      streak = Math.min(user.dailyStreak + 1, REWARDS.length);
+    }
+    const reward = REWARDS[streak - 1];
+
+    user.lastCheckIn = new Date(now);
+    user.dailyStreak = streak;
+    user.minedTPC += reward;
+    user.transactions.push({
+      amount: reward,
+      type: 'daily',
+      status: 'pending',
+      date: new Date(now)
+    });
+    await user.save();
+
+    res.json({ streak, reward });
+  } catch (err) {
+    console.error('Daily check-in failed:', err.message);
+    res.status(500).json({ error: 'Failed to check in' });
+  }
+});
+
+export default router;

--- a/bot/routes/tasks.js
+++ b/bot/routes/tasks.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import Task from '../models/Task.js';
 import User from '../models/User.js';
 import { TASKS } from '../utils/tasksData.js';
+import { ensureTransactionArray } from '../utils/userUtils.js';
 
 const router = Router();
 
@@ -32,7 +33,14 @@ router.post('/complete', async (req, res) => {
     { $setOnInsert: { referralCode: telegramId.toString() } },
     { upsert: true, new: true }
   );
+  ensureTransactionArray(user);
   user.minedTPC += config.reward;
+  user.transactions.push({
+    amount: config.reward,
+    type: 'task',
+    status: 'pending',
+    date: new Date()
+  });
   await user.save();
 
   res.json({ message: 'completed', reward: config.reward });

--- a/bot/routes/watch.js
+++ b/bot/routes/watch.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { VIDEOS } from '../utils/watchData.js';
 import WatchRecord from '../models/WatchRecord.js';
 import User from '../models/User.js';
+import { ensureTransactionArray } from '../utils/userUtils.js';
 
 const router = Router();
 
@@ -33,7 +34,14 @@ router.post('/watch', async (req, res) => {
     { $setOnInsert: { referralCode: telegramId.toString() } },
     { upsert: true, new: true }
   );
+  ensureTransactionArray(user);
   user.minedTPC += video.reward;
+  user.transactions.push({
+    amount: video.reward,
+    type: 'watch',
+    status: 'pending',
+    date: new Date()
+  });
   await user.save();
 
   res.json({ message: 'watched', reward: video.reward });

--- a/bot/server.js
+++ b/bot/server.js
@@ -10,6 +10,8 @@ import watchRoutes from './routes/watch.js';
 import referralRoutes from './routes/referral.js';
 import walletRoutes from './routes/wallet.js';
 import profileRoutes from './routes/profile.js';
+import airdropRoutes from './routes/airdrop.js';
+import checkinRoutes from './routes/checkin.js';
 import User from './models/User.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -60,6 +62,8 @@ app.use('/api/watch', watchRoutes);
 app.use('/api/referral', referralRoutes);
 app.use('/api/wallet', walletRoutes);
 app.use('/api/profile', profileRoutes);
+app.use('/api/airdrop', airdropRoutes);
+app.use('/api/checkin', checkinRoutes);
 
 // Serve the built React app
 const webappPath = path.join(__dirname, '../webapp/dist');


### PR DESCRIPTION
## Summary
- add new Airdrop model and route
- store daily check-in streaks in the database
- create /api/checkin endpoint to process check-ins
- credit airdrops via /api/airdrop
- log task and watch rewards as pending transactions

## Testing
- `npm install --prefix webapp`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684e4bcca11883298833defbb74823cd