### PR TITLE
Integrate backend daily check‑in

### DIFF
--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -100,3 +100,7 @@ export function getReferralInfo(telegramId) {
 export function claimReferral(telegramId, code) {
   return post('/api/referral/claim', { telegramId, code });
 }
+
+export function checkIn(telegramId) {
+  return post('/api/checkin/check-in', { telegramId });
+}


### PR DESCRIPTION
## Summary
- add `checkIn` helper in `api.js`
- fetch profile and post check-in via API in `DailyCheckIn.jsx`
- display streak and reward returned from backend

## Testing
- `npm --prefix webapp install`
- `npm --prefix webapp run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e55986ba483299e53a6f7db94a776