### PR TITLE
Add daily streak progress card

### DIFF
--- a/bot/routes/checkin.js
+++ b/bot/routes/checkin.js
@@ -23,7 +23,8 @@ router.post('/check-in', async (req, res) => {
     const now = Date.now();
     let streak = 1;
     if (user.lastCheckIn && now - user.lastCheckIn.getTime() < ONE_DAY_MS * 2) {
-      streak = Math.min(user.dailyStreak + 1, REWARDS.length);
+      streak = user.dailyStreak + 1;
+      if (streak > REWARDS.length) streak = 1;
     }
     const reward = REWARDS[streak - 1];
 

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -142,7 +142,7 @@ export default function DailyCheckIn() {
 
   return (
 
-    <div className="w-full space-y-2">
+    <div className="bg-surface border border-border rounded p-4 space-y-2">
 
       {showPopup && (
 

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import SpinWheel from './SpinWheel.tsx';
 import RewardPopup from './RewardPopup.tsx';
 import AdModal from './AdModal.tsx';
-import DailyCheckIn from './DailyCheckIn.jsx';
 import { canSpin, nextSpinTime } from '../utils/rewardLogic';
 import {
   getWalletBalance,
@@ -66,7 +65,6 @@ export default function SpinGame() {
           </button>
         </>
       )}
-      <DailyCheckIn />
       <RewardPopup
         reward={reward}
         onClose={() => setReward(null)}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -6,6 +6,7 @@ import ProfileCard from '../components/ProfileCard.jsx';
 import MiningCard from '../components/MiningCard.tsx';
 
 import SpinGame from '../components/SpinGame.jsx';
+import DailyCheckIn from '../components/DailyCheckIn.jsx';
 
 import TasksCard from '../components/TasksCard.jsx';
 
@@ -89,6 +90,7 @@ export default function Home() {
 
       </div>
 
+      <DailyCheckIn />
       <SpinGame />
 
       <div className="grid grid-cols-1 gap-4">


### PR DESCRIPTION
## Summary
- show next five days of daily streak on Home
- restyle streak UI to match other cards
- reset streak after completing the 30‑day cycle
- remove duplicate streak display from SpinGame

## Testing
- `npm run install-all`
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_684e6645501c8329ac5240974292849a