### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ TonPlaygram combines a Telegram bot with a web interface built using React and V
   ```bash
 
   npm --prefix webapp run dev
+  ```
 ### Admin API
 
 - `POST /api/airdrop/grant-all` — grant an airdrop to all users (requires bearer token from `AIRDROP_ADMIN_TOKENS`)


### PR DESCRIPTION
## Summary
- fix README code block to render Admin API section properly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684e739b772083298345e69943ae9876