### PR TITLE
Add AIRDROP_ADMIN_TOKENS example

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,6 +1,8 @@
 BOT_TOKEN=your-telegram-bot-token
 MONGODB_URI=memory
 PORT=3000
+# comma-separated list of admin tokens for airdrop API
+# AIRDROP_ADMIN_TOKENS=
 # Optional Google OAuth configuration
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=


### PR DESCRIPTION
## Summary
- add placeholder for airdrop admin tokens in `.env.example`

## Testing
- `npm install --prefix webapp`
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_684e7399c5288329a7eb6daee8b5bc40