### PR TITLE
Update admin API docs with example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,18 @@ TonPlaygram combines a Telegram bot with a web interface built using React and V
   ```bash
 
   npm --prefix webapp run dev
+  ```
+
 ### Admin API
 
-- `POST /api/airdrop/grant-all` — grant an airdrop to all users (requires bearer token from `AIRDROP_ADMIN_TOKENS`)
+Use a bearer token from `AIRDROP_ADMIN_TOKENS` in the `Authorization` header.
+
+- `POST /api/airdrop/grant-all` — grant an airdrop to all users.
+
+  Example:
+
+  ```bash
+  curl -X POST http://localhost:3000/api/airdrop/grant-all \
+    -H "Authorization: Bearer <YOUR_TOKEN>"
+  ```
 


### PR DESCRIPTION
## Summary
- document the Authorization header requirement for admin API calls
- show how to invoke `POST /api/airdrop/grant-all`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684e7395d1d883298502bcf50ef3f842