### PR TITLE
Fix transfer rollbacks and MongoDB docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,10 @@ TonPlaygram combines a Telegram bot with a web interface built using React and V
 ## Installation
 
 1. Install **Node.js 18** or later.
-
 2. Run `npm run install-all` at the repository root to install dependencies for both the bot and webapp.
-
 3. Copy `bot/.env.example` to `bot/.env` and update the values. At minimum set:
-
-   - `BOT_TOKEN` for your Telegram bot  
-   - `MONGODB_URI` for the database (use `memory` for a temporary in‑memory store)  
+   - `BOT_TOKEN` for your Telegram bot
+   - `MONGODB_URI` for the database (use `memory` for a temporary in-memory store)
    - `AIRDROP_ADMIN_TOKENS` to enable the airdrop API (comma-separated list of tokens)
 
 ---
@@ -26,3 +23,22 @@ TonPlaygram combines a Telegram bot with a web interface built using React and V
 
   ```bash
   npm --prefix webapp run dev
+  ```
+
+### Bot
+
+- Start the bot:
+
+  ```bash
+  npm start
+  ```
+
+### Database Configuration
+
+Set `MONGODB_URI` in `bot/.env` to your MongoDB connection string. For a local MongoDB instance, you might use:
+
+```env
+MONGODB_URI=mongodb://localhost:27017/tonplaygram
+```
+
+If `MONGODB_URI` is set to `memory`, the server launches an in-memory MongoDB for testing only.

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,5 +1,6 @@
 BOT_TOKEN=your-telegram-bot-token
-MONGODB_URI=memory
+MONGODB_URI=mongodb://localhost:27017/tonplaygram
+# Set to `memory` to use an in-memory MongoDB instance
 PORT=3000
 # comma-separated list of admin tokens for airdrop API
 # AIRDROP_ADMIN_TOKENS=

--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -69,7 +69,6 @@ router.post('/send', async (req, res) => {
     ensureTransactionArray(receiver);
 
     sender.balance -= amount;
-    await sender.save();
 
     const senderTx = {
       amount: -amount,
@@ -108,6 +107,7 @@ router.post('/send', async (req, res) => {
       status: 'failed',
       date: txDate
     };
+    sender.balance += amount;
     sender.transactions.push(failedTx);
     await sender.save().catch((e) =>
       console.error('Failed to log failed transaction:', e.message)


### PR DESCRIPTION
## Summary
- refund balance on failed TPC transfers
- document local MongoDB config and bot usage in README
- update example `.env` with a real MongoDB URI

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e763167cc8329ba9e9c14e65e06cf