### PR TITLE
Fix balance rollback on transfer failure

### DIFF
--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -69,7 +69,6 @@ router.post('/send', async (req, res) => {
     ensureTransactionArray(receiver);
 
     sender.balance -= amount;
-    await sender.save();
 
     const senderTx = {
       amount: -amount,
@@ -109,6 +108,7 @@ router.post('/send', async (req, res) => {
       date: txDate
     };
     sender.transactions.push(failedTx);
+    sender.balance += amount;
     await sender.save().catch((e) =>
       console.error('Failed to log failed transaction:', e.message)
     );


### PR DESCRIPTION
## Summary
- prevent sender balance deduction on failed `/send`
- save sender only after preparing transactions

## Testing
- `npm --prefix bot install`
- `PORT=3000 MONGODB_URI=memory SKIP_BOT_LAUNCH=1 node bot/server.js > /tmp/server.log 2>&1 &` *(fails: uses built webapp)*

------
https://chatgpt.com/codex/tasks/task_e_684e773831188329aa6c1fbe657e5eea