### PR TITLE
Remove duplicate balance restore

### DIFF
--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -109,7 +109,6 @@ router.post('/send', async (req, res) => {
     };
     sender.balance += amount;
     sender.transactions.push(failedTx);
-    sender.balance += amount;
     await sender.save().catch((e) =>
       console.error('Failed to log failed transaction:', e.message)
     );


### PR DESCRIPTION
## Summary
- fix double addition when a TPC transfer fails

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684e7c2704508329a43bf5d76d2f0d6b