### PR TITLE
Add wallet auth middleware

### DIFF
--- a/bot/middleware/auth.js
+++ b/bot/middleware/auth.js
@@ -1,0 +1,47 @@
+import crypto from 'crypto';
+
+function verifyTelegramInitData(initData) {
+  try {
+    const params = new URLSearchParams(initData);
+    const hash = params.get('hash');
+    if (!hash) return null;
+    params.delete('hash');
+    const dataCheckString = [...params.entries()]
+      .map(([k, v]) => `${k}=${v}`)
+      .sort()
+      .join('\n');
+    const secret = crypto
+      .createHmac('sha256', 'WebAppData')
+      .update(process.env.BOT_TOKEN || '')
+      .digest();
+    const computed = crypto
+      .createHmac('sha256', secret)
+      .update(dataCheckString)
+      .digest('hex');
+    if (computed !== hash) return null;
+    return Object.fromEntries(params.entries());
+  } catch {
+    return null;
+  }
+}
+
+export default function authenticate(req, res, next) {
+  const auth = req.get('authorization') || '';
+  const token = auth.replace(/^Bearer\s+/i, '');
+  const allowedToken = process.env.API_AUTH_TOKEN;
+  const initData = req.get('x-telegram-init-data');
+
+  if (initData) {
+    const data = verifyTelegramInitData(initData);
+    if (data) {
+      req.auth = { telegramId: data.user ? Number(JSON.parse(data.user).id) : undefined };
+      return next();
+    }
+  }
+
+  if (allowedToken && token === allowedToken) {
+    return next();
+  }
+
+  res.status(401).json({ error: 'unauthorized' });
+}

--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -2,10 +2,11 @@ import { Router } from 'express';
 import User from '../models/User.js';
 import bot from '../bot.js';
 import { ensureTransactionArray } from '../utils/userUtils.js';
+import authenticate from '../middleware/auth.js';
 
 const router = Router();
 
-router.post('/balance', async (req, res) => {
+router.post('/balance', authenticate, async (req, res) => {
   const { telegramId } = req.body;
   if (!telegramId) {
     return res.status(400).json({ error: 'telegramId required' });
@@ -15,7 +16,7 @@ router.post('/balance', async (req, res) => {
 });
 
 // Fetch TON balance from the blockchain using a public API
-router.post('/ton-balance', async (req, res) => {
+router.post('/ton-balance', authenticate, async (req, res) => {
   const { address } = req.body;
   if (!address) {
     return res.status(400).json({ error: 'address required' });
@@ -37,7 +38,7 @@ router.post('/ton-balance', async (req, res) => {
 });
 
 // Transfer TPC from one Telegram user to another
-router.post('/send', async (req, res) => {
+router.post('/send', authenticate, async (req, res) => {
   const { fromId, toId, amount } = req.body;
   if (!fromId || !toId || typeof amount !== 'number') {
     return res.status(400).json({ error: 'fromId, toId and amount required' });
@@ -124,7 +125,7 @@ router.post('/send', async (req, res) => {
   }
 });
 
-router.post('/transactions', async (req, res) => {
+router.post('/transactions', authenticate, async (req, res) => {
   const { telegramId } = req.body;
   if (!telegramId) {
     return res.status(400).json({ error: 'telegramId required' });

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -15,10 +15,10 @@ export async function ping() {
 }
 
 async function post(path, body, token) {
-
   const headers = { 'Content-Type': 'application/json' };
-
   if (token) headers['Authorization'] = `Bearer ${token}`;
+  const initData = window?.Telegram?.WebApp?.initData;
+  if (initData) headers['X-Telegram-Init-Data'] = initData;
 
   const res = await fetch(API_BASE_URL + path, {
 


### PR DESCRIPTION
## Summary
- add authentication middleware that verifies Telegram Web App signed data or a bearer token
- secure wallet routes with the new middleware
- attach Telegram init data on frontend API requests

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e7c2619c88329bb3022f2b80c4c98