### PR TITLE
Add TON deposit and withdrawal support

### DIFF
--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -148,6 +148,18 @@ export function getTransactions(telegramId) {
 
 }
 
+export function getDepositAddress() {
+  return fetch(API_BASE_URL + '/api/wallet/deposit-address').then((r) => r.json());
+}
+
+export function deposit(telegramId, amount) {
+  return post('/api/wallet/deposit', { telegramId, amount });
+}
+
+export function withdraw(telegramId, address, amount) {
+  return post('/api/wallet/withdraw', { telegramId, address, amount });
+}
+
 export function getReferralInfo(telegramId) {
 
   return post('/api/referral/code', { telegramId });


### PR DESCRIPTION
## Summary
- extend wallet API with deposit address retrieval, deposit, and withdraw routes
- add frontend helpers for deposit/withdraw operations
- support TON deposits and withdrawals in wallet page using TonConnect

## Testing
- `npm run install-all`
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_684e7c23344083299e43d47178b25f9f