### PR TITLE
Fix check-in by defaulting to memory MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ MONGODB_URI=mongodb://localhost:27017/tonplaygram
 ```
 
 If `MONGODB_URI` is set to `memory`, the server launches an in-memory MongoDB for testing only.
+If no `MONGODB_URI` is provided, the server will also default to an in-memory instance so development can continue without configuring a database.

--- a/bot/server.js
+++ b/bot/server.js
@@ -21,6 +21,11 @@ import { execSync } from 'child_process';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 dotenv.config({ path: path.join(__dirname, '.env') });
 
+if (!process.env.MONGODB_URI) {
+  process.env.MONGODB_URI = 'memory';
+  console.log('MONGODB_URI not set, defaulting to in-memory MongoDB');
+}
+
 const PORT = process.env.PORT || 3000;
 const app = express();
 


### PR DESCRIPTION
## Summary
- default to in-memory MongoDB if `MONGODB_URI` is missing
- document the new behavior in README

## Testing
- `npm run install-all`
- `SKIP_BOT_LAUNCH=1 node bot/server.js` *(fails: npm run build blocked by environment)*

------
https://chatgpt.com/codex/tasks/task_e_684e893368488329a5e7774179d55410