### PR TITLE
Host TonConnect manifest on public site

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -9,4 +9,4 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
 # TonConnect parameters
-TONCONNECT_MANIFEST_URL=https://your-domain.com/tonconnect-manifest.json
+TONCONNECT_MANIFEST_URL=https://tonplaygramwebapp.onrender.com/tonconnect-manifest.json

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -2,4 +2,4 @@ VITE_API_BASE_URL=http://localhost:3000
 # Set an absolute URL for the TonConnect manifest when the frontend is
 # hosted separately from the API. The manifest should be served by the
 # backend so Tonkeeper can retrieve it.
-VITE_TONCONNECT_MANIFEST=http://localhost:3000/tonconnect-manifest.json
+VITE_TONCONNECT_MANIFEST=https://tonplaygramwebapp.onrender.com/tonconnect-manifest.json

--- a/webapp/public/tonconnect-manifest.json
+++ b/webapp/public/tonconnect-manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "TonPlaygram Chess",
   "description": "Play chess with TPC staking via Tonkeeper",
-  "url": "http://localhost:3000",
-  "icons": ["/icons/tpc.svg"]
+  "url": "https://tonplaygramwebapp.onrender.com",
+  "icons": ["https://tonplaygramwebapp.onrender.com/icons/tpc.svg"]
 }


### PR DESCRIPTION
## Summary
- update tonconnect-manifest.json with public URLs
- update example env files to use new manifest location

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684e8ebe43d883299cb741c0fe543dd1