### PR TITLE
Fix legacy transaction data handling

### DIFF
--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -312,6 +312,23 @@ router.post('/transactions', authenticate, async (req, res) => {
 
   const user = await User.findOne({ telegramId });
 
+  if (user) {
+    // Ensure the transactions property is always an array
+    ensureTransactionArray(user);
+
+    // Persist fixes for legacy string data
+    if (user.isModified('transactions')) {
+      try {
+        await user.save();
+      } catch (err) {
+        console.error(
+          'Failed to save user after ensuring transaction array:',
+          err.message
+        );
+      }
+    }
+  }
+
   res.json({ transactions: user ? user.transactions : [] });
 
 });


### PR DESCRIPTION
## Summary
- ensure user transactions are always an array when fetching history

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ea7ccc238832981101938e00494f8