### PR TITLE
Handle Telegram back button navigation

### DIFF
--- a/webapp/src/hooks/useTelegramBackButton.js
+++ b/webapp/src/hooks/useTelegramBackButton.js
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function useTelegramBackButton() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const tg = window?.Telegram?.WebApp;
+    if (!tg) return;
+
+    const handleBack = () => navigate(-1);
+
+    tg.BackButton.show();
+    tg.onEvent('backButtonClicked', handleBack);
+
+    return () => {
+      tg.offEvent('backButtonClicked', handleBack);
+      tg.BackButton.hide();
+    };
+  }, [navigate]);
+}

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
 import { getLeaderboard, getReferralInfo } from '../utils/api.js';
 import { BOT_USERNAME } from '../utils/constants.js';
 
 export default function Friends() {
+  useTelegramBackButton();
   let telegramId;
   try {
     telegramId = getTelegramId();

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -1,6 +1,8 @@
 import GameCard from '../components/GameCard.jsx';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 
 export default function Games() {
+  useTelegramBackButton();
   return (
     <div className="space-y-4">
       <h2 className="text-2xl font-bold text-center">Games</h2>

--- a/webapp/src/pages/Games/Chess.jsx
+++ b/webapp/src/pages/Games/Chess.jsx
@@ -3,8 +3,10 @@ import { Chess } from 'chess.js';
 import { Chessboard } from 'react-chessboard';
 import ConnectWallet from '../../components/ConnectWallet.jsx';
 import RoomPopup from '../../components/RoomPopup.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 
 export default function ChessGame() {
+  useTelegramBackButton();
   const [selection, setSelection] = useState(null);
   const [showRoom, setShowRoom] = useState(true);
   const [game, setGame] = useState(new Chess());

--- a/webapp/src/pages/Games/ConnectFour.jsx
+++ b/webapp/src/pages/Games/ConnectFour.jsx
@@ -5,6 +5,7 @@ import RewardPopup from '../../components/RewardPopup.tsx';
 import { getWalletBalance, updateBalance, addTransaction } from '../../utils/api.js';
 import { getTelegramId } from '../../utils/telegram.js';
 import OpenInTelegram from '../../components/OpenInTelegram.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 
 const ROWS = 6;
 const COLS = 7;
@@ -38,6 +39,7 @@ function checkWinner(board, row, col, player) {
 }
 
 export default function ConnectFour() {
+  useTelegramBackButton();
   let telegramId;
   try {
     telegramId = getTelegramId();

--- a/webapp/src/pages/Games/DiceGame.jsx
+++ b/webapp/src/pages/Games/DiceGame.jsx
@@ -7,6 +7,7 @@ import RoomPopup from '../../components/RoomPopup.jsx';
 import RollPopup from '../../components/RollPopup.jsx';
 
 import GameResult from '../../components/GameResult.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 
 import Board from '../../components/Board.jsx';
 
@@ -31,6 +32,7 @@ function randomInt(min, max) {
 }
 
 export default function DiceGame() {
+  useTelegramBackButton();
 
   const [selection, setSelection] = useState(null);
 

--- a/webapp/src/pages/Games/HorseRacing.jsx
+++ b/webapp/src/pages/Games/HorseRacing.jsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import ConnectWallet from '../../components/ConnectWallet.jsx';
 import RoomPopup from '../../components/RoomPopup.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 
 export default function HorseRacing() {
+  useTelegramBackButton();
   const [selection, setSelection] = useState(null);
   const [showRoom, setShowRoom] = useState(true);
 

--- a/webapp/src/pages/Games/LudoGame.jsx
+++ b/webapp/src/pages/Games/LudoGame.jsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import ConnectWallet from '../../components/ConnectWallet.jsx';
 import RoomPopup from '../../components/RoomPopup.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 
 export default function LudoGame() {
+  useTelegramBackButton();
   const [selection, setSelection] = useState(null);
   const [showRoom, setShowRoom] = useState(true);
 

--- a/webapp/src/pages/Games/SnakeLadders.jsx
+++ b/webapp/src/pages/Games/SnakeLadders.jsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import ConnectWallet from '../../components/ConnectWallet.jsx';
 import RoomPopup from '../../components/RoomPopup.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 
 export default function SnakeLadders() {
+  useTelegramBackButton();
   const [selection, setSelection] = useState(null);
   const [showRoom, setShowRoom] = useState(true);
 

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -15,8 +15,10 @@ import {
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
 import { BOT_USERNAME } from '../utils/constants.js';
 import BalanceSummary from '../components/BalanceSummary.jsx';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 
 export default function MyAccount() {
+  useTelegramBackButton();
   let telegramId;
 
   try {

--- a/webapp/src/pages/Referral.jsx
+++ b/webapp/src/pages/Referral.jsx
@@ -3,8 +3,10 @@ import OpenInTelegram from '../components/OpenInTelegram.jsx';
 import { getTelegramId } from '../utils/telegram.js';
 import { getReferralInfo } from '../utils/api.js';
 import { BOT_USERNAME } from '../utils/constants.js';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 
 export default function Referral() {
+  useTelegramBackButton();
   let telegramId;
   try {
     telegramId = getTelegramId();

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 
 export default function Store() {
+  useTelegramBackButton();
   return (
     <div className="p-4 space-y-2 text-text">
       <h2 className="text-xl font-bold">Store</h2>

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -8,8 +8,10 @@ import OpenInTelegram from '../components/OpenInTelegram.jsx';
 import { IoLogoTwitter, IoLogoTiktok } from 'react-icons/io5';
 
 import { RiTelegramFill } from 'react-icons/ri';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 
 export default function Tasks() {
+  useTelegramBackButton();
   let telegramId;
   try {
     telegramId = getTelegramId();

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -12,8 +12,10 @@ import { getTelegramId } from '../utils/telegram.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
 import ConnectWallet from '../components/ConnectWallet.jsx';
 import { useTonWallet, useTonConnectUI } from '@tonconnect/ui-react';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 
 export default function Wallet() {
+  useTelegramBackButton();
   let telegramId;
 
   try {

--- a/webapp/src/pages/WatchToEarn.jsx
+++ b/webapp/src/pages/WatchToEarn.jsx
@@ -2,8 +2,10 @@ import { useEffect, useState } from 'react';
 import { listVideos, watchVideo } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 
 export default function WatchToEarn() {
+  useTelegramBackButton();
   let telegramId;
   try {
     telegramId = getTelegramId();

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -10,8 +10,10 @@ import {
 } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 
 export default function SpinPage() {
+  useTelegramBackButton();
   let telegramId: number;
   try {
     telegramId = getTelegramId();


### PR DESCRIPTION
## Summary
- add `useTelegramBackButton` hook
- show Telegram back button on non-root pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684eb6b760048329b0c62b5d0d26b8c0