### PR TITLE
Swap mining button colors

### DIFF
--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -110,7 +110,7 @@ export default function MiningCard() {
         onClick={toggleMining}
         disabled={isMining}
         className={`w-full py-4 rounded text-white text-xl font-semibold ${
-          isMining ? 'bg-green-600 cursor-not-allowed' : 'bg-red-600'
+          isMining ? 'bg-red-600 cursor-not-allowed' : 'bg-green-600'
         }`}
       >
         <div>{isMining ? 'Mining' : 'Start Mining'}</div>


### PR DESCRIPTION
## Summary
- show red button when mining
- show green button when not mining

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eb8e6ad7883299d6f783be3a0ef7d