### PR TITLE
Add Ludo game

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ TonPlaygram combines a Telegram bot with a web interface built using React and V
 
 - Launch the TonPlaygram Roller (requires `BOT_TOKEN`):
 
-  ```bash
-  BOT_TOKEN=your_token python3 tonplaygram_grid_roller.py
-  ```
+```bash
+BOT_TOKEN=your_token python3 tonplaygram_grid_roller.py
+```
+
+The Ludo game is now playable directly in the web app at `/games/ludo`.
 
 ### Database Configuration
 

--- a/bot/commands/games/ludo.js
+++ b/bot/commands/games/ludo.js
@@ -1,3 +1,5 @@
 export default function registerLudo(bot) {
-  bot.command('ludo', (ctx) => ctx.reply('Ludo game coming soon.'));
+  bot.command('ludo', (ctx) =>
+    ctx.reply('Play Ludo in the TonPlaygram web app: https://tonplaygramwebapp.onrender.com/games/ludo')
+  );
 }

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -8,6 +8,7 @@ export default function Games() {
         <GameCard title="Chess" icon="/assets/icons/horse.svg" link="/games/chess" />
         <GameCard title="Snakes & Ladders" icon="/assets/icons/snake.svg" link="/games/snake" />
         <GameCard title="Connect Four" icon="/assets/icons/connect4.svg" link="/games/connectfour" />
+        <GameCard title="Ludo" icon="/assets/icons/ludo.svg" link="/games/ludo" />
         <GameCard title="Dice Duel" icon="/assets/icons/dice.svg" link="/games/dice" />
       </div>
     </div>

--- a/webapp/src/pages/Games/LudoGame.jsx
+++ b/webapp/src/pages/Games/LudoGame.jsx
@@ -3,11 +3,12 @@ import ConnectWallet from '../../components/ConnectWallet.jsx';
 import RoomPopup from '../../components/RoomPopup.jsx';
 
 export default function LudoGame() {
+
   const [selection, setSelection] = useState(null);
   const [showRoom, setShowRoom] = useState(true);
 
   return (
-    <div className="p-4 space-y-4">
+    <div className="p-4 space-y-4 text-text">
       <h2 className="text-xl font-bold">Ludo Game</h2>
       <RoomPopup
         open={showRoom}
@@ -16,7 +17,11 @@ export default function LudoGame() {
         onConfirm={() => setShowRoom(false)}
       />
       <ConnectWallet />
-      <p>Ludo game coming soon.</p>
+      <iframe
+        src="https://eze4acme.github.io/Ludo-Built-With-React/"
+        title="Ludo Game"
+        className="w-full h-[80vh] border rounded"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- embed a playable Ludo board in the web app
- link to the Ludo page from the Telegram /ludo command
- remove old bot-based Ludo instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684eae3506f883299066e1140c2dda68