### PR TITLE
Improve script load and remove Google Fonts

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -4,17 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
-    <script src="https://telegram.org/js/telegram-web-app.js"></script>
-
-    <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap"
-      rel="stylesheet"
-      />
-      <link rel="preload" as="audio" href="/assets/sounds/spinning.mp3" />
-      <link rel="preload" as="audio" href="/assets/sounds/successful.mp3" />
+    <script src="https://telegram.org/js/telegram-web-app.js" defer></script>
+    <link rel="preload" as="audio" href="/assets/sounds/spinning.mp3" />
+    <link rel="preload" as="audio" href="/assets/sounds/successful.mp3" />
 
     <title>TonPlaygram</title>
   </head>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1,11 +1,9 @@
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
-  font-family: 'Montserrat', sans-serif;
+  font-family: Arial, Helvetica, sans-serif;
   @apply bg-background text-text;
 }
 


### PR DESCRIPTION
## Summary
- add defer to Telegram init script
- remove external Google Fonts
- use Arial as a web-safe fallback font

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ebd34be0c8329b65a665d8935b1d1