### PR TITLE
Add compression middleware and static caching

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -14,6 +14,7 @@
     "telegraf": "^4.12.2",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
-    "mongodb-memory-server": "^10.1.4"
+    "mongodb-memory-server": "^10.1.4",
+    "compression": "^1.7.4"
   }
 }

--- a/bot/server.js
+++ b/bot/server.js
@@ -17,6 +17,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync } from 'fs';
 import { execSync } from 'child_process';
+import compression from 'compression';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 dotenv.config({ path: path.join(__dirname, '.env') });
@@ -30,6 +31,7 @@ const PORT = process.env.PORT || 3000;
 const app = express();
 
 // Middleware and routes
+app.use(compression());
 app.use(express.json());
 app.use(passport.initialize());
 
@@ -103,7 +105,9 @@ function ensureWebappBuilt() {
 
 ensureWebappBuilt();
 
-app.use(express.static(webappPath));
+app.use(
+  express.static(webappPath, { maxAge: '1y', immutable: true })
+);
 // Expose TonConnect manifest dynamically so the base URL always matches the
 // current request host. The manifest path is taken from the
 // TONCONNECT_MANIFEST_URL environment variable if provided, otherwise the


### PR DESCRIPTION
## Summary
- add `compression` dependency to bot package
- use `compression` middleware
- enable long term caching for static assets

## Testing
- `npm start` *(fails to launch Telegram bot: connect ENETUNREACH)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ebd3a08808329b9cd8bebcb9c20f5