### PR TITLE
Document license of Ludo game

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ TonPlaygram combines a Telegram bot with a web interface built using React and V
 4. Install the Python requirements for the dice roller:
    ```bash
    pip install -r requirements.txt
+   ```
+5. See [webapp/public/games/ludo/README.md](webapp/public/games/ludo/README.md) for attribution and licensing details of the Ludo game.

--- a/webapp/public/games/ludo/README.md
+++ b/webapp/public/games/ludo/README.md
@@ -1,0 +1,7 @@
+# Ludo Game
+
+The Ludo game displayed in the TonPlaygram web app is loaded from the open source project [`Ludo-Built-With-React`](https://github.com/eze4acme/Ludo-Built-With-React).
+
+As of June 2025 that repository does **not** include a license file. In the absence of a published license the code should be considered "all rights reserved" by the author. You may view and play the game through its public site, but you should not redistribute or reuse the code without obtaining permission from the original author.
+
+This directory exists to document the source of the game and does not contain the actual game assets.


### PR DESCRIPTION
## Summary
- clarify that the Ludo game in the web app is loaded from an external repo
- note that the repo lacks a license so redistribution isn't permitted
- link this new README from the main project documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ec139e01c8329b4b2a51bc7c7079c