### PR TITLE
Explain Ludo hosting

### DIFF
--- a/webapp/public/games/ludo/README.md
+++ b/webapp/public/games/ludo/README.md
@@ -5,3 +5,8 @@ The Ludo game displayed in the TonPlaygram web app is loaded from the open sourc
 As of June 2025 that repository does **not** include a license file. In the absence of a published license the code should be considered "all rights reserved" by the author. You may view and play the game through its public site, but you should not redistribute or reuse the code without obtaining permission from the original author.
 
 This directory exists to document the source of the game and does not contain the actual game assets.
+
+If `https://eze4acme.github.io/Ludo-Built-With-React/` returns a 404 you will
+need to host your own build of that repository. Clone the project, run `npm
+install && npm run build`, upload the `dist` folder to a static host and update
+`src/pages/Games/LudoGame.jsx` with your hosted URL.


### PR DESCRIPTION
## Summary
- clarify how to host and load the external Ludo game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ecc74af3483298328e9545bd11447