### PR TITLE
Fix TonConnect manifest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ TonPlaygram combines a Telegram bot with a web interface built using React and V
 4. Install the Python requirements for the dice roller:
    ```bash
    pip install -r requirements.txt
+5. Copy `webapp/.env.example` to `webapp/.env`.
+   Set `VITE_API_BASE_URL` to the URL where the bot API is hosted.
+   Set `VITE_TONCONNECT_MANIFEST` to `${VITE_API_BASE_URL}/tonconnect-manifest.json` as an absolute URL.
+   Misconfiguring these values causes the wallet page to render blank.
+

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -8,5 +8,5 @@ PORT=3000
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
-# TonConnect parameters
+# TonConnect parameters (also forwarded to the webapp build)
 TONCONNECT_MANIFEST_URL=https://tonplaygramwebapp.onrender.com/tonconnect-manifest.json

--- a/bot/server.js
+++ b/bot/server.js
@@ -91,10 +91,15 @@ function ensureWebappBuilt() {
     const displayBase = apiBase || '(same origin)';
     console.log(`Using API base URL ${displayBase} for webapp build`);
 
+    const manifestBuild = process.env.TONCONNECT_MANIFEST_URL || '';
     execSync('npm run build', {
       cwd: webappDir,
       stdio: 'inherit',
-      env: { ...process.env, VITE_API_BASE_URL: apiBase }
+      env: {
+        ...process.env,
+        VITE_API_BASE_URL: apiBase,
+        VITE_TONCONNECT_MANIFEST: manifestBuild
+      }
     });
     return existsSync(path.join(webappPath, 'index.html'));
   } catch (err) {

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { setTimeout as delay } from 'timers/promises';
+import { runInNewContext } from 'vm';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+
+async function startServer(env) {
+  return spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+}
+
+test('server exposes manifest endpoint from TONCONNECT_MANIFEST_URL', async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3100',
+    MONGODB_URI: 'memory',
+    SKIP_BOT_LAUNCH: '1',
+    TONCONNECT_MANIFEST_URL: '/test-manifest.json'
+  };
+  const server = await startServer(env);
+  try {
+    for (let i = 0; i < 20; i++) {
+      try {
+        const res = await fetch('http://localhost:3100/test-manifest.json');
+        if (res.ok) {
+          const data = await res.json();
+          assert.equal(data.name, 'TonPlaygram');
+          return;
+        }
+      } catch {}
+      await delay(100);
+    }
+    assert.fail('manifest endpoint not reachable');
+  } finally {
+    server.kill();
+  }
+});
+
+test('manifestUrl uses VITE_TONCONNECT_MANIFEST when provided', () => {
+  const src = fs.readFileSync('webapp/src/main.jsx', 'utf8');
+  const match = src.match(/const manifestUrl[\s\S]*?;/);
+  assert(match, 'manifestUrl definition missing');
+  const context = {
+    env: { VITE_TONCONNECT_MANIFEST: 'https://example.com/m.json', VITE_API_BASE_URL: 'http://api' },
+    window: { location: { origin: 'http://host' } }
+  };
+  runInNewContext(match[0].replace(/import\.meta\.env/g, 'env') + '; result = manifestUrl;', context);
+  assert.equal(context.result, 'https://example.com/m.json');
+});

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import { TonConnectUIProvider } from '@tonconnect/ui-react';
@@ -10,10 +10,34 @@ const manifestUrl =
     ? `${import.meta.env.VITE_API_BASE_URL}/tonconnect-manifest.json`
     : `${window.location.origin}/tonconnect-manifest.json`);
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
+function WalletApp() {
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch(manifestUrl)
+      .then((res) => {
+        if (!res.ok) throw new Error('Manifest fetch failed');
+      })
+      .catch(() => setError(true));
+  }, []);
+
+  if (error) {
+    return (
+      <div className="p-4 text-red-500">
+        Failed to load TonConnect manifest. Check VITE_TONCONNECT_MANIFEST.
+      </div>
+    );
+  }
+
+  return (
     <TonConnectUIProvider manifestUrl={manifestUrl}>
       <App />
     </TonConnectUIProvider>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <WalletApp />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- document webapp environment variables
- forward TONCONNECT_MANIFEST_URL to webapp build
- show error when TonConnect manifest fails to load
- add manifest tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ecc9f4fc483299e7a23cb2ad3ab35