### PR TITLE
Remove React lazy loading

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -1,18 +1,18 @@
-import React, { Suspense, lazy } from 'react';
+import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
-const Home = lazy(() => import('./pages/Home.jsx'));
-const Friends = lazy(() => import('./pages/Friends.jsx'));
-const Wallet = lazy(() => import('./pages/Wallet.jsx'));
-const Tasks = lazy(() => import('./pages/Tasks.jsx'));
-const Referral = lazy(() => import('./pages/Referral.jsx'));
-const MyAccount = lazy(() => import('./pages/MyAccount.jsx'));
-const Store = lazy(() => import('./pages/Store.jsx'));
+import Home from './pages/Home.jsx';
+import Friends from './pages/Friends.jsx';
+import Wallet from './pages/Wallet.jsx';
+import Tasks from './pages/Tasks.jsx';
+import Referral from './pages/Referral.jsx';
+import MyAccount from './pages/MyAccount.jsx';
+import Store from './pages/Store.jsx';
 
-const LudoGame = lazy(() => import('./pages/Games/LudoGame.jsx'));
-const HorseRacing = lazy(() => import('./pages/Games/HorseRacing.jsx'));
-const Games = lazy(() => import('./pages/Games.jsx'));
-const SpinPage = lazy(() => import('./pages/spin.tsx'));
+import LudoGame from './pages/Games/LudoGame.jsx';
+import HorseRacing from './pages/Games/HorseRacing.jsx';
+import Games from './pages/Games.jsx';
+import SpinPage from './pages/spin.tsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -23,7 +23,6 @@ export default function App() {
   return (
     <BrowserRouter>
       <Layout>
-        <Suspense fallback={<div>Loading...</div>}>
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/friends" element={<Friends />} />
@@ -37,7 +36,6 @@ export default function App() {
           <Route path="/wallet" element={<Wallet />} />
           <Route path="/account" element={<MyAccount />} />
         </Routes>
-        </Suspense>
       </Layout>
     </BrowserRouter>
   );


### PR DESCRIPTION
## Summary
- import all page components directly instead of using `React.lazy`
- drop the `<Suspense>` wrapper in `App.jsx`

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684ed1c82cfc8329826953c77419513f