### PR TITLE
Fix missing photo on leaderboard

### DIFF
--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -80,7 +80,11 @@ export default function Friends() {
                   <td className="p-2">{idx + 1}</td>
                   <td className="p-2 w-16">
                     <img
-                      src={u.telegramId === telegramId ? myPhotoUrl : u.photo || u.photoUrl}
+                      src={
+                        u.telegramId === telegramId
+                          ? myPhotoUrl || '/assets/icons/profile.svg'
+                          : u.photo || u.photoUrl || '/assets/icons/profile.svg'
+                      }
                       alt="avatar"
                       className="w-16 h-16 hexagon border-2 border-brand-gold object-cover"
                     />
@@ -96,7 +100,7 @@ export default function Friends() {
                   <td className="p-2">{rank}</td>
                   <td className="p-2 w-16">
                     <img
-                      src={myPhotoUrl}
+                      src={myPhotoUrl || '/assets/icons/profile.svg'}
                       alt="avatar"
                       className="w-16 h-16 hexagon border-2 border-brand-gold object-cover"
                     />


### PR DESCRIPTION
## Summary
- show a default profile avatar on leaderboard when no photo is available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ed5621e688329bcb21b460b9b0ead