### PR TITLE
Handle TonConnect manifest load errors

### DIFF
--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import { TonConnectUIProvider } from '@tonconnect/ui-react';
@@ -10,10 +10,34 @@ const manifestUrl =
     ? `${import.meta.env.VITE_API_BASE_URL}/tonconnect-manifest.json`
     : `${window.location.origin}/tonconnect-manifest.json`);
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
+function WalletApp() {
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch(manifestUrl)
+      .then((res) => {
+        if (!res.ok) throw new Error('Manifest fetch failed');
+      })
+      .catch(() => setError(true));
+  }, []);
+
+  if (error) {
+    return (
+      <div className="p-4 text-red-500">
+        Failed to load TonConnect manifest. Check VITE_TONCONNECT_MANIFEST.
+      </div>
+    );
+  }
+
+  return (
     <TonConnectUIProvider manifestUrl={manifestUrl}>
       <App />
     </TonConnectUIProvider>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <WalletApp />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add error handling when fetching TonConnect manifest so wallet page doesn't render blank

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*


------
https://chatgpt.com/codex/tasks/task_e_684ee471df5483298854055db43ff350