### PR TITLE
Add dice duel game

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -11,6 +11,7 @@ import Store from './pages/Store.jsx';
 
 import LudoGame from './pages/Games/LudoGame.jsx';
 import HorseRacing from './pages/Games/HorseRacing.jsx';
+import DiceDuel from './pages/Games/DiceDuel.jsx';
 import Games from './pages/Games.jsx';
 import SpinPage from './pages/spin.tsx';
 
@@ -29,6 +30,7 @@ export default function App() {
           <Route path="/games" element={<Games />} />
           <Route path="/games/ludo" element={<LudoGame />} />
           <Route path="/games/horse" element={<HorseRacing />} />
+          <Route path="/games/dice" element={<DiceDuel />} />
           <Route path="/spin" element={<SpinPage />} />
           <Route path="/tasks" element={<Tasks />} />
           <Route path="/store" element={<Store />} />

--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+const diceFaces = {
+  1: [
+    [0, 0, 0],
+    [0, 1, 0],
+    [0, 0, 0],
+  ],
+  2: [
+    [1, 0, 0],
+    [0, 0, 0],
+    [0, 0, 1],
+  ],
+  3: [
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+  ],
+  4: [
+    [1, 0, 1],
+    [0, 0, 0],
+    [1, 0, 1],
+  ],
+  5: [
+    [1, 0, 1],
+    [0, 1, 0],
+    [1, 0, 1],
+  ],
+  6: [
+    [1, 0, 1],
+    [1, 0, 1],
+    [1, 0, 1],
+  ],
+};
+
+export default function Dice({ value = 1, rolling = false }) {
+  const face = diceFaces[value] || diceFaces[1];
+  return (
+    <div
+      className={`w-24 h-24 bg-white rounded-xl shadow-lg flex items-center justify-center transition-transform ${
+        rolling ? 'animate-roll' : ''
+      }`}
+    >
+      <div className="grid grid-cols-3 grid-rows-3 gap-1 w-20 h-20">
+        {face.flat().map((dot, i) => (
+          <div key={i} className="flex items-center justify-center">
+            {dot ? <div className="w-3 h-3 bg-black rounded-full" /> : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import Dice from './Dice.jsx';
+
+export default function DiceRoller({ onRollEnd }) {
+  const [value, setValue] = useState(1);
+  const [rolling, setRolling] = useState(false);
+
+  const rollDice = () => {
+    if (rolling) return;
+    setRolling(true);
+    let count = 0;
+    const id = setInterval(() => {
+      const v = Math.floor(Math.random() * 6) + 1;
+      setValue(v);
+      count += 1;
+      if (count >= 20) {
+        clearInterval(id);
+        setRolling(false);
+        onRollEnd && onRollEnd(v);
+      }
+    }, 100);
+  };
+
+  return (
+    <div className="flex flex-col items-center space-y-4">
+      <Dice value={value} rolling={rolling} />
+      <button
+        onClick={rollDice}
+        disabled={rolling}
+        className="px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded disabled:opacity-50"
+      >
+        Roll Dice
+      </button>
+    </div>
+  );
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -30,3 +30,19 @@ body {
   transform: rotateX(55deg) rotateZ(45deg);
   transform-style: preserve-3d;
 }
+
+@keyframes roll {
+  0% {
+    transform: rotateX(0deg) rotateY(0deg);
+  }
+  50% {
+    transform: rotateX(180deg) rotateY(180deg);
+  }
+  100% {
+    transform: rotateX(360deg) rotateY(360deg);
+  }
+}
+
+.animate-roll {
+  animation: roll 1s ease-in-out;
+}

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -8,6 +8,7 @@ export default function Games() {
       <h2 className="text-2xl font-bold text-center">Games</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <GameCard title="Ludo" icon="/assets/icons/ludo.svg" link="/games/ludo" />
+        <GameCard title="Dice Duel" icon="🎲" link="/games/dice" />
       </div>
     </div>
   );

--- a/webapp/src/pages/Games/DiceDuel.jsx
+++ b/webapp/src/pages/Games/DiceDuel.jsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import DiceRoller from '../../components/DiceRoller.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+
+export default function DiceDuel() {
+  useTelegramBackButton();
+  const TARGET = 20;
+  const [scores, setScores] = useState([0, 0]);
+  const [turn, setTurn] = useState(0); // 0 -> player1, 1 -> player2
+  const [winner, setWinner] = useState(null);
+
+  const handleRoll = (value) => {
+    setScores((prev) => {
+      const next = [...prev];
+      next[turn] += value;
+      if (next[turn] >= TARGET) setWinner(turn);
+      return next;
+    });
+    setTurn((t) => (t === 0 ? 1 : 0));
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-text">
+      <h2 className="text-xl font-bold">Dice Duel</h2>
+      <p className="text-center">First to {TARGET} points wins.</p>
+      <div className="flex justify-center space-x-8 text-lg font-semibold">
+        <div>Player 1: {scores[0]}</div>
+        <div>Player 2: {scores[1]}</div>
+      </div>
+      {winner !== null ? (
+        <div className="text-center text-accent font-bold">
+          Player {winner + 1} wins!
+        </div>
+      ) : (
+        <div className="text-center font-semibold">
+          Player {turn + 1}'s turn
+        </div>
+      )}
+      {winner === null && <DiceRoller onRollEnd={handleRoll} />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create Dice & DiceRoller components with animation
- add Dice Duel page and route
- update games list to include Dice Duel
- define roll animation in global CSS

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684efc9b11d88329a9c035c55c8b13c0