### PR TITLE
Fix wallet manifest fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
    - `VITE_TONCONNECT_MANIFEST` – must be `${VITE_API_BASE_URL}/tonconnect-manifest.json` (absolute URL)
 
   ⚠️ Misconfiguring these may prevent the wallet from loading correctly.
+  If the wallet page appears blank, ensure these variables are set. A working
+  configuration is included in `webapp/.env` which points to the live demo API.
 
 5. Install the Python requirements for the dice roller:
 

--- a/webapp/.env
+++ b/webapp/.env
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=http://localhost:3000
+VITE_TONCONNECT_MANIFEST=https://tonplaygramwebapp.onrender.com/tonconnect-manifest.json

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -10,15 +10,42 @@ const manifestUrl =
     ? `${import.meta.env.VITE_API_BASE_URL}/tonconnect-manifest.json`
     : `${window.location.origin}/tonconnect-manifest.json`);
 
+const BACKUP_MANIFEST =
+  'https://tonplaygramwebapp.onrender.com/tonconnect-manifest.json';
+const BACKUP_KEY = 'manifestBackupExpires';
+
 function WalletApp() {
   const [error, setError] = useState(false);
+  const [url, setUrl] = useState(null);
 
   useEffect(() => {
-    fetch(manifestUrl)
-      .then((res) => {
-        if (!res.ok) throw new Error('Manifest fetch failed');
-      })
-      .catch(() => setError(true));
+    async function load() {
+      const expiry = Number(localStorage.getItem(BACKUP_KEY));
+      const now = Date.now();
+
+      const tryFetch = async (target, fallback) => {
+        try {
+          const res = await fetch(target);
+          if (!res.ok) throw new Error('Manifest fetch failed');
+          localStorage.setItem(BACKUP_KEY, String(now + 24 * 60 * 60 * 1000));
+          setUrl(target);
+        } catch {
+          if (fallback) {
+            await tryFetch(fallback, null);
+          } else {
+            setError(true);
+          }
+        }
+      };
+
+      if (expiry && now < expiry) {
+        await tryFetch(BACKUP_MANIFEST, null);
+      } else {
+        await tryFetch(manifestUrl, BACKUP_MANIFEST);
+      }
+    }
+
+    load();
   }, []);
 
   if (error) {
@@ -29,8 +56,10 @@ function WalletApp() {
     );
   }
 
+  if (!url) return null;
+
   return (
-    <TonConnectUIProvider manifestUrl={manifestUrl}>
+    <TonConnectUIProvider manifestUrl={url}>
       <App />
     </TonConnectUIProvider>
   );


### PR DESCRIPTION
## Summary
- update README with troubleshooting note
- add example `.env` with working manifest URL
- fallback to a known-good manifest URL for 24h if the configured one fails

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f006f613c8329a504042b2543b436