### PR TITLE
Fix fallback to stored telegram ID

### DIFF
--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -1,7 +1,12 @@
 export function getTelegramId() {
   if (typeof window !== 'undefined') {
     const tgId = window?.Telegram?.WebApp?.initDataUnsafe?.user?.id;
-    if (tgId) return tgId;
+    if (tgId) {
+      localStorage.setItem('telegramId', tgId);
+      return tgId;
+    }
+    const stored = localStorage.getItem('telegramId');
+    if (stored) return Number(stored);
   }
   throw new Error(
     'Telegram user not found. Please open this application via the Telegram bot.'


### PR DESCRIPTION
## Summary
- fallback to `telegramId` stored in `localStorage` if Telegram API isn't available

## Testing
- `npm install --prefix bot`
- `npm install --prefix webapp`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f04b64ac88329850de454e6bb224b