### PR TITLE
Add 3D Snake and Ladder game

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -11,6 +11,7 @@ import Store from './pages/Store.jsx';
 
 import LudoGame from './pages/Games/LudoGame.jsx';
 import HorseRacing from './pages/Games/HorseRacing.jsx';
+import SnakeAndLadder from './pages/Games/SnakeAndLadder.jsx';
 import Games from './pages/Games.jsx';
 import SpinPage from './pages/spin.tsx';
 
@@ -29,6 +30,7 @@ export default function App() {
           <Route path="/games" element={<Games />} />
           <Route path="/games/ludo" element={<LudoGame />} />
           <Route path="/games/horse" element={<HorseRacing />} />
+          <Route path="/games/snake" element={<SnakeAndLadder />} />
           <Route path="/spin" element={<SpinPage />} />
           <Route path="/tasks" element={<Tasks />} />
           <Route path="/store" element={<Store />} />

--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+const diceFaces = {
+  1: [
+    [0, 0, 0],
+    [0, 1, 0],
+    [0, 0, 0],
+  ],
+  2: [
+    [1, 0, 0],
+    [0, 0, 0],
+    [0, 0, 1],
+  ],
+  3: [
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+  ],
+  4: [
+    [1, 0, 1],
+    [0, 0, 0],
+    [1, 0, 1],
+  ],
+  5: [
+    [1, 0, 1],
+    [0, 1, 0],
+    [1, 0, 1],
+  ],
+  6: [
+    [1, 0, 1],
+    [1, 0, 1],
+    [1, 0, 1],
+  ],
+};
+
+// Base tilt so the cube appears three dimensional even when static
+const baseTilt = 'rotateX(-25deg) rotateY(25deg)';
+
+// Orientations for each face relative to the viewer
+const faceTransforms = {
+  1: `rotateX(0deg) rotateY(0deg) ${baseTilt}`,
+  2: `rotateX(-90deg) rotateY(0deg) ${baseTilt}`,
+  3: `rotateY(90deg) ${baseTilt}`,
+  4: `rotateY(-90deg) ${baseTilt}`,
+  5: `rotateX(90deg) rotateY(0deg) ${baseTilt}`,
+  6: `rotateY(180deg) ${baseTilt}`,
+};
+
+function Face({ value, className }) {
+  const face = diceFaces[value];
+  return (
+    <div className={`dice-face ${className}`}>
+      <div className="grid grid-cols-3 grid-rows-3 gap-1">
+        {face.flat().map((dot, i) => (
+          <div key={i} className="flex items-center justify-center">
+            {dot ? <div className="dot" /> : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function Dice({ value = 1, rolling = false }) {
+  const orientation = faceTransforms[value] || faceTransforms[1];
+  return (
+    <div className="dice-container">
+      <div
+        className={`dice-cube ${rolling ? 'animate-roll' : ''}`}
+        style={!rolling ? { transform: orientation } : undefined}
+      >
+        <Face value={1} className="dice-face--front" />
+        <Face value={6} className="dice-face--back" />
+        <Face value={3} className="dice-face--right" />
+        <Face value={4} className="dice-face--left" />
+        <Face value={2} className="dice-face--top" />
+        <Face value={5} className="dice-face--bottom" />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import Dice from './Dice.jsx';
+
+export default function DiceRoller({ onRollEnd }) {
+  const [value, setValue] = useState(1);
+  const [rolling, setRolling] = useState(false);
+
+  const rollDice = () => {
+    if (rolling) return;
+    setRolling(true);
+    let count = 0;
+    const id = setInterval(() => {
+      const v = Math.floor(Math.random() * 6) + 1;
+      setValue(v);
+      count += 1;
+      if (count >= 20) {
+        clearInterval(id);
+        setRolling(false);
+        onRollEnd && onRollEnd(v);
+      }
+    }, 100);
+  };
+
+  return (
+    <div className="flex flex-col items-center space-y-4">
+      <Dice value={value} rolling={rolling} />
+      <button
+        onClick={rollDice}
+        disabled={rolling}
+        className="px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded disabled:opacity-50"
+      >
+        Roll Dice
+      </button>
+    </div>
+  );
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -30,3 +30,72 @@ body {
   transform: rotateX(55deg) rotateZ(45deg);
   transform-style: preserve-3d;
 }
+
+@keyframes roll {
+  0% {
+    transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg) translateY(0);
+  }
+  50% {
+    transform: rotateX(360deg) rotateY(360deg) rotateZ(360deg) translateY(-1rem);
+  }
+  100% {
+    transform: rotateX(720deg) rotateY(720deg) rotateZ(720deg) translateY(0);
+  }
+}
+
+.animate-roll {
+  animation: roll 1s ease-in-out;
+}
+
+.dice-container {
+  perspective: 600px;
+}
+
+.dice-cube {
+  @apply relative w-24 h-24;
+  transform-style: preserve-3d;
+  transition: transform 0.5s;
+}
+
+.dice-face {
+  @apply absolute w-full h-full flex items-center justify-center bg-white rounded-xl shadow-lg;
+}
+
+.dice-face .dot {
+  /* make dots slightly larger for better visibility */
+  @apply w-4 h-4 bg-black rounded-full;
+}
+
+.dice-face--front {
+  transform: rotateY(0deg) translateZ(3rem);
+}
+
+.dice-face--back {
+  transform: rotateY(180deg) translateZ(3rem);
+}
+
+.dice-face--right {
+  transform: rotateY(90deg) translateZ(3rem);
+}
+
+.dice-face--left {
+  transform: rotateY(-90deg) translateZ(3rem);
+}
+
+.dice-face--top {
+  transform: rotateX(90deg) translateZ(3rem);
+}
+
+.dice-face--bottom {
+  transform: rotateX(-90deg) translateZ(3rem);
+}
+
+.board-cell {
+  @apply relative flex items-center justify-center bg-green-200 border border-gray-400 shadow-inner;
+  transform: translateZ(5px);
+}
+
+.token {
+  @apply absolute w-4 h-4 bg-blue-600 rounded-full shadow-lg;
+  transform: translateZ(10px);
+}

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -8,6 +8,7 @@ export default function Games() {
       <h2 className="text-2xl font-bold text-center">Games</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <GameCard title="Ludo" icon="/assets/icons/ludo.svg" link="/games/ludo" />
+        <GameCard title="Snake & Ladder" icon="🎲" link="/games/snake" />
       </div>
     </div>
   );

--- a/webapp/src/pages/Games/DiceDuel.jsx
+++ b/webapp/src/pages/Games/DiceDuel.jsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import DiceRoller from '../../components/DiceRoller.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+
+export default function DiceDuel() {
+  useTelegramBackButton();
+  const TARGET = 20;
+  const [scores, setScores] = useState([0, 0]);
+  const [turn, setTurn] = useState(0); // 0 -> player1, 1 -> player2
+  const [winner, setWinner] = useState(null);
+
+  const handleRoll = (value) => {
+    setScores((prev) => {
+      const next = [...prev];
+      next[turn] += value;
+      if (next[turn] >= TARGET) setWinner(turn);
+      return next;
+    });
+    setTurn((t) => (t === 0 ? 1 : 0));
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-text">
+      <h2 className="text-xl font-bold">Dice Duel</h2>
+      <p className="text-center">First to {TARGET} points wins.</p>
+      <div className="flex justify-center space-x-8 text-lg font-semibold">
+        <div>Player 1: {scores[0]}</div>
+        <div>Player 2: {scores[1]}</div>
+      </div>
+      {winner !== null ? (
+        <div className="text-center text-accent font-bold">
+          Player {winner + 1} wins!
+        </div>
+      ) : (
+        <div className="text-center font-semibold">
+          Player {turn + 1}'s turn
+        </div>
+      )}
+      {winner === null && <DiceRoller onRollEnd={handleRoll} />}
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1,0 +1,71 @@
+import { useRef, useState } from 'react';
+import DiceRoller from '../../components/DiceRoller.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+
+const snakes = { 14: 7, 11: 5 };
+const ladders = { 3: 8, 6: 12 };
+
+function Board({ position }) {
+  const rows = [];
+  for (let r = 4; r >= 0; r--) {
+    const cols = [];
+    const dir = (4 - r) % 2 === 0 ? [1, 2, 3] : [3, 2, 1];
+    for (const c of dir) {
+      const num = r * 3 + c;
+      cols.push(
+        <div key={num} className="board-cell">
+          {num}
+          {position === num && <div className="token" />}
+        </div>
+      );
+    }
+    rows.push(cols);
+  }
+  return (
+    <div className="board-3d flex justify-center">
+      <div className="board-3d-grid grid grid-rows-5 grid-cols-3 gap-1 w-60 h-96">
+        {rows.flat()}
+      </div>
+    </div>
+  );
+}
+
+export default function SnakeAndLadder() {
+  useTelegramBackButton();
+  const [pos, setPos] = useState(1);
+  const [message, setMessage] = useState('');
+  const containerRef = useRef(null);
+
+  const handleRoll = (value) => {
+    setPos((p) => {
+      let next = p + value;
+      if (next > 15) next = 15;
+      if (ladders[next]) next = ladders[next];
+      if (snakes[next]) next = snakes[next];
+      if (next === 15) setMessage('You win!');
+      return next;
+    });
+  };
+
+  const toggleFull = () => {
+    const el = containerRef.current;
+    if (!el) return;
+    if (document.fullscreenElement) {
+      document.exitFullscreen?.();
+    } else {
+      el.requestFullscreen?.();
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-text" ref={containerRef}>
+      <h2 className="text-xl font-bold">Snake &amp; Ladder</h2>
+      <Board position={pos} />
+      {message && <div className="text-center font-semibold">{message}</div>}
+      <DiceRoller onRollEnd={handleRoll} />
+      <button onClick={toggleFull} className="px-3 py-1 bg-primary text-white rounded">
+        Toggle Full Screen
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- switch Dice Duel to a new Snake & Ladder game
- use the existing 3D dice roller
- add a 3×5 board with a 3D tilt and token
- allow toggling fullscreen for the game

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684efc9b11d88329a9c035c55c8b13c0