### PR TITLE
Adjust dice orientation & board style

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -35,22 +35,15 @@ const diceFaces = {
 
 const baseTilt = 'rotateX(-25deg) rotateY(25deg)';
 
-const valueToSide = {
-  1: 'bottom',
-  2: 'right',
-  3: 'top',
-  4: 'left',
-  5: 'front',
-  6: 'back',
-};
-
-const sideTransforms = {
-  front: 'rotateX(0deg) rotateY(0deg)',
-  back: 'rotateY(180deg)',
-  right: 'rotateY(90deg)',
-  left: 'rotateY(-90deg)',
-  top: 'rotateX(-90deg)',
-  bottom: 'rotateX(90deg)',
+// Rotation needed to bring each numbered face to the top while keeping
+// the overall isometric camera tilt the same.
+const valueToRotation = {
+  1: 'rotateX(180deg)', // bottom -> top
+  2: 'rotateY(-90deg)', // right -> top
+  3: 'rotateX(0deg)', // already top
+  4: 'rotateY(90deg)', // left -> top
+  5: 'rotateX(-90deg)', // front -> top
+  6: 'rotateX(90deg)', // back -> top
 };
 
 function Face({ value, className }) {
@@ -69,8 +62,7 @@ function Face({ value, className }) {
 }
 
 export default function Dice({ value = 1, rolling = false }) {
-  const side = valueToSide[value] || 'front';
-  const transform = sideTransforms[side] || 'rotateX(0deg) rotateY(0deg)';
+  const transform = valueToRotation[value] || 'rotateX(0deg)';
   const orientation = `${transform} ${baseTilt}`;
 
   return (

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import Dice from './Dice.jsx';
 
 export default function DiceRoller({ onRollEnd }) {
-  const [value, setValue] = useState(1);
+  const [values, setValues] = useState([1, 1]);
   const [rolling, setRolling] = useState(false);
 
   const rollDice = () => {
@@ -10,20 +10,24 @@ export default function DiceRoller({ onRollEnd }) {
     setRolling(true);
     let count = 0;
     const id = setInterval(() => {
-      const v = Math.floor(Math.random() * 6) + 1;
-      setValue(v);
+      const v1 = Math.floor(Math.random() * 6) + 1;
+      const v2 = Math.floor(Math.random() * 6) + 1;
+      setValues([v1, v2]);
       count += 1;
       if (count >= 20) {
         clearInterval(id);
         setRolling(false);
-        onRollEnd && onRollEnd(v);
+        onRollEnd && onRollEnd([v1, v2]);
       }
     }, 100);
   };
 
   return (
     <div className="flex flex-col items-center space-y-4">
-      <Dice value={value} rolling={rolling} />
+      <div className="flex space-x-4">
+        <Dice value={values[0]} rolling={rolling} />
+        <Dice value={values[1]} rolling={rolling} />
+      </div>
       <button
         onClick={rollDice}
         disabled={rolling}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -82,7 +82,9 @@ body {
 .dice-face--bottom  { transform: rotateX(-90deg) translateZ(3rem); }
 
 .board-cell {
-  @apply relative flex items-center justify-center bg-green-200 border border-gray-400 shadow-inner;
+  @apply relative flex items-center justify-center rounded-xl shadow-inner text-white;
+  background-color: #000; /* match dice face */
+  border: 2px solid #FFD700; /* metallic gold edges */
   transform: translateZ(5px);
 }
 

--- a/webapp/src/pages/Games/DiceDuel.jsx
+++ b/webapp/src/pages/Games/DiceDuel.jsx
@@ -9,7 +9,8 @@ export default function DiceDuel() {
   const [turn, setTurn] = useState(0); // 0 -> player1, 1 -> player2
   const [winner, setWinner] = useState(null);
 
-  const handleRoll = (value) => {
+  const handleRoll = (values) => {
+    const value = Array.isArray(values) ? values.reduce((a, b) => a + b, 0) : values;
     setScores((prev) => {
       const next = [...prev];
       next[turn] += value;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -49,7 +49,8 @@ export default function SnakeAndLadder() {
 
   const calcRotation = (p) => ((Math.floor((p - 1) / 10) % 4) * 90);
 
-  const handleRoll = (value) => {
+  const handleRoll = (values) => {
+    const value = Array.isArray(values) ? values.reduce((a, b) => a + b, 0) : values;
     setMessage('');
     let current = pos;
     let target = current + value;


### PR DESCRIPTION
## Summary
- orient dice so winning face is on top with fixed isometric angle
- render two dice at once and handle dual values
- style board cells like dice faces
- update Snake and Ladder & Dice Duel games for new dice roller

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684f1c8f9a4c83298a88f4a1d189ae54