### PR TITLE
Fix wallet connection prompt

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -26,6 +26,7 @@ export default function BalanceSummary() {
       setBalances({ ton, tpc: prof.balance, usdt: 0 });
     } catch (err) {
       console.error('Failed to load balances:', err);
+      setBalances({ ton: null, tpc: 0, usdt: 0 });
     }
   };
 

--- a/webapp/src/components/ConnectWallet.jsx
+++ b/webapp/src/components/ConnectWallet.jsx
@@ -1,10 +1,11 @@
 import { useEffect } from 'react';
-import { TonConnectButton, useTonWallet } from '@tonconnect/ui-react';
+import { TonConnectButton, useTonWallet, useTonConnectUI } from '@tonconnect/ui-react';
 
 // Simple wrapper around TonConnectButton that remembers the last connected
 // address in localStorage.
 export default function ConnectWallet() {
   const wallet = useTonWallet();
+  const [tonConnectUI] = useTonConnectUI();
 
   // Persist address when wallet changes
   useEffect(() => {
@@ -13,9 +14,22 @@ export default function ConnectWallet() {
     }
   }, [wallet]);
 
+  const handleClick = () => {
+    if (!wallet?.account?.address) {
+      tonConnectUI.connectWallet().catch(() => {});
+    }
+  };
+
+  // Attempt to reconnect using previously saved address
+  useEffect(() => {
+    if (!wallet?.account && localStorage.getItem('walletAddress')) {
+      tonConnectUI.connectWallet().catch(() => {});
+    }
+  }, []);
+
   return (
     <div className="flex items-center space-x-2">
-      <TonConnectButton className="ton-connect-button" />
+      <TonConnectButton className="ton-connect-button" onClick={handleClick} />
       {wallet?.account?.address && (
         <span className="text-sm">
           {wallet.account.address.slice(0, 4)}...


### PR DESCRIPTION
## Summary
- tweak ConnectWallet to use connectWallet API and auto-reconnect when a saved address exists
- keep TPC balance at zero when balance fetch fails

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684f1c95850c83299bd95334c7338bbc