### PR TITLE
Add board highlights and snake icons

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -34,17 +34,17 @@ const diceFaces = {
   ],
 };
 
-// Enhanced isometric tilt: Z → X → Y
-const baseTilt = 'rotateY(-15deg) rotateX(-35deg) rotateZ(45deg)';
+// Gentle tilt so three faces are visible
+const baseTilt = 'rotateX(-25deg) rotateY(25deg)';
 
-// Face orientation to bring correct number on top
-const valueToRotation = {
-  1: 'rotateX(180deg)',
-  2: 'rotateZ(-90deg)',
-  3: 'rotateX(0deg)',
-  4: 'rotateZ(90deg)',
-  5: 'rotateX(-90deg)',
-  6: 'rotateX(90deg)',
+// Orientation for each numbered face relative to the viewer
+const faceTransforms = {
+  1: `rotateX(0deg) rotateY(0deg) ${baseTilt}`,
+  2: `rotateX(-90deg) rotateY(0deg) ${baseTilt}`,
+  3: `rotateY(90deg) ${baseTilt}`,
+  4: `rotateY(-90deg) ${baseTilt}`,
+  5: `rotateX(90deg) rotateY(0deg) ${baseTilt}`,
+  6: `rotateY(180deg) ${baseTilt}`,
 };
 
 // 🎲 Single dice face component
@@ -55,9 +55,7 @@ function Face({ value, className }) {
       <div className="grid grid-cols-3 grid-rows-3 gap-1">
         {face.flat().map((dot, i) => (
           <div key={i} className="flex items-center justify-center">
-            {dot ? (
-              <div className="dot shadow-md shadow-yellow-300" />
-            ) : null}
+            {dot ? <div className="dot" /> : null}
           </div>
         ))}
       </div>
@@ -67,8 +65,7 @@ function Face({ value, className }) {
 
 // 🎲 Single cube component
 function DiceCube({ value = 1, rolling = false, playSound = false }) {
-  const transform = valueToRotation[value] || 'rotateX(0deg)';
-  const orientation = `${transform} ${baseTilt}`;
+  const orientation = faceTransforms[value] || faceTransforms[1];
 
   useEffect(() => {
     if (rolling && playSound) {
@@ -85,12 +82,12 @@ function DiceCube({ value = 1, rolling = false, playSound = false }) {
         }`}
         style={!rolling ? { transform: orientation } : undefined}
       >
-        <Face value={5} className="dice-face--front absolute" />
+        <Face value={1} className="dice-face--front absolute" />
         <Face value={6} className="dice-face--back absolute" />
-        <Face value={2} className="dice-face--right absolute" />
+        <Face value={3} className="dice-face--right absolute" />
         <Face value={4} className="dice-face--left absolute" />
-        <Face value={3} className="dice-face--top absolute" />
-        <Face value={1} className="dice-face--bottom absolute" />
+        <Face value={2} className="dice-face--top absolute" />
+        <Face value={5} className="dice-face--bottom absolute" />
       </div>
     </div>
   );

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -20,7 +20,9 @@ body {
   background-image:
     radial-gradient(#ffffff 1px, transparent 1px),
     radial-gradient(#ffffff 1px, transparent 1px);
-  background-position: 0 0, 25px 25px;
+  background-position:
+    0 0,
+    25px 25px;
   background-size: 50px 50px;
 }
 
@@ -59,41 +61,50 @@ body {
 }
 
 .dice-cube {
-  @apply relative w-24 h-24;
+  /* smaller cube so a board cell can match its size */
+  @apply relative w-16 h-16;
   transform-style: preserve-3d;
   transition: transform 0.5s;
 }
 
 .dice-face {
-  @apply absolute w-full h-full flex items-center justify-center rounded-xl shadow-lg;
-  background-color: #000; /* ultra-matte black */
-  border: 2px solid #FFD700; /* metallic gold edges */
+  @apply absolute w-full h-full flex items-center justify-center bg-white rounded-xl shadow-lg;
 }
 
 .dice-face .dot {
-  @apply w-4 h-4 rounded-full;
-  background-color: #000; /* recessed center */
-  border: 2px solid #FFD700; /* embossed gold ring */
-  box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.6); /* soft shadow inside */
+  /* classic black pips */
+  @apply w-4 h-4 bg-black rounded-full;
 }
 
-.dice-face--front   { transform: rotateY(0deg) translateZ(3rem); }
-.dice-face--back    { transform: rotateY(180deg) translateZ(3rem); }
-.dice-face--right   { transform: rotateY(90deg) translateZ(3rem); }
-.dice-face--left    { transform: rotateY(-90deg) translateZ(3rem); }
-.dice-face--top     { transform: rotateX(90deg) translateZ(3rem); }
-.dice-face--bottom  { transform: rotateX(-90deg) translateZ(3rem); }
+.dice-face--front {
+  transform: rotateY(0deg) translateZ(2rem);
+}
+.dice-face--back {
+  transform: rotateY(180deg) translateZ(2rem);
+}
+.dice-face--right {
+  transform: rotateY(90deg) translateZ(2rem);
+}
+.dice-face--left {
+  transform: rotateY(-90deg) translateZ(2rem);
+}
+.dice-face--top {
+  transform: rotateX(90deg) translateZ(2rem);
+}
+.dice-face--bottom {
+  transform: rotateX(-90deg) translateZ(2rem);
+}
 
 .board-cell {
   @apply relative flex items-center justify-center rounded-xl text-white shadow-inner;
   background-color: #000; /* match dice face */
-  border: 2px solid #FFD700; /* metallic gold edges */
+  border: 2px solid #ffd700; /* metallic gold edges */
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5); /* subtle outer depth */
   transform: translateZ(5px);
 }
 
 .board-cell::after {
-  content: '';
+  content: "";
   position: absolute;
   inset: 2px;
   border-radius: inherit;
@@ -104,4 +115,9 @@ body {
 .token {
   @apply absolute w-4 h-4 bg-blue-600 rounded-full shadow-lg;
   transform: translateZ(10px);
+}
+
+/* cell glows briefly as a piece moves over it */
+.board-cell.highlight {
+  box-shadow: 0 0 10px 4px rgba(255, 255, 100, 0.8);
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1,6 +1,6 @@
-import { useRef, useState } from 'react';
-import DiceRoller from '../../components/DiceRoller.jsx';
-import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { useRef, useState } from "react";
+import DiceRoller from "../../components/DiceRoller.jsx";
+import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
 
 // Simple snake and ladder layout for a 10x10 board
 const snakes = {
@@ -8,17 +8,17 @@ const snakes = {
   48: 30,
   62: 19,
   88: 24,
-  95: 56
+  95: 56,
 };
 const ladders = {
   3: 22,
   25: 44,
   40: 60,
   51: 67,
-  71: 90
+  71: 90,
 };
 
-function Board({ position }) {
+function Board({ position, highlight }) {
   const tiles = [];
   for (let r = 9; r >= 0; r--) {
     const reversed = (9 - r) % 2 === 1;
@@ -28,19 +28,29 @@ function Board({ position }) {
       tiles.push(
         <div
           key={num}
-          className="board-cell"
+          className={`board-cell ${highlight === num ? "highlight" : ""}`}
           style={{ gridRowStart: 10 - r, gridColumnStart: col + 1 }}
         >
           {num}
+          {snakes[num] && (
+            <div className="absolute inset-0 flex items-center justify-center text-red-500 text-xl pointer-events-none">
+              🐍
+            </div>
+          )}
+          {ladders[num] && (
+            <div className="absolute inset-0 flex items-center justify-center text-green-500 text-xl pointer-events-none">
+              🪜
+            </div>
+          )}
           {position === num && <div className="token" />}
-        </div>
+        </div>,
       );
     }
   }
 
   return (
     <div className="flex justify-center">
-      <div className="grid grid-rows-10 grid-cols-10 gap-1 w-[512px] h-[512px] relative">
+      <div className="grid grid-rows-10 grid-cols-10 gap-1 w-[640px] h-[640px] relative">
         {tiles}
       </div>
     </div>
@@ -50,13 +60,15 @@ function Board({ position }) {
 export default function SnakeAndLadder() {
   useTelegramBackButton();
   const [pos, setPos] = useState(1);
-  const [message, setMessage] = useState('');
+  const [highlight, setHighlight] = useState(null);
+  const [message, setMessage] = useState("");
   const containerRef = useRef(null);
 
-
   const handleRoll = (values) => {
-    const value = Array.isArray(values) ? values.reduce((a, b) => a + b, 0) : values;
-    setMessage('');
+    const value = Array.isArray(values)
+      ? values.reduce((a, b) => a + b, 0)
+      : values;
+    setMessage("");
     let current = pos;
     let target = current + value;
     if (target > 100) target = 100;
@@ -70,12 +82,14 @@ export default function SnakeAndLadder() {
         if (snakes[finalPos]) finalPos = snakes[finalPos];
         setTimeout(() => {
           setPos(finalPos);
-          if (finalPos === 100) setMessage('You win!');
+          setHighlight(null);
+          if (finalPos === 100) setMessage("You win!");
         }, 300);
         return;
       }
       const next = steps[index];
       setPos(next);
+      setHighlight(next);
       setTimeout(() => move(index + 1), 300);
     };
     move(0);
@@ -94,10 +108,13 @@ export default function SnakeAndLadder() {
   return (
     <div className="p-4 space-y-4 text-text" ref={containerRef}>
       <h2 className="text-xl font-bold">Snake &amp; Ladder</h2>
-      <Board position={pos} />
+      <Board position={pos} highlight={highlight} />
       {message && <div className="text-center font-semibold">{message}</div>}
       <DiceRoller onRollEnd={handleRoll} />
-      <button onClick={toggleFull} className="px-3 py-1 bg-primary text-white rounded">
+      <button
+        onClick={toggleFull}
+        className="px-3 py-1 bg-primary text-white rounded"
+      >
         Toggle Full Screen
       </button>
     </div>


### PR DESCRIPTION
## Summary
- shrink dice so board cells can match their size
- scale board to match new dice dimensions
- highlight cells as the token moves
- display snake and ladder icons on start squares

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684f2fcdc0fc8329ba05d3759ac9ad2c