### PR TITLE
Remove wallet button from pages

### DIFF
--- a/webapp/src/components/WalletCard.jsx
+++ b/webapp/src/components/WalletCard.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTonWallet } from '@tonconnect/ui-react';
-import ConnectWallet from './ConnectWallet.jsx';
 import { getWalletBalance, getTonBalance } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import OpenInTelegram from './OpenInTelegram.jsx';
@@ -43,7 +42,6 @@ export default function WalletCard() {
         <span>💰</span>
         <span>Wallet</span>
       </h3>
-      <ConnectWallet />
       <p>TON Balance: {tonBalance === null ? '...' : tonBalance}</p>
       <p>TPC Balance: {tpcBalance === null ? '...' : tpcBalance}</p>
       <p>USDT Balance: {usdtBalance === null ? '...' : usdtBalance}</p>

--- a/webapp/src/pages/Games/HorseRacing.jsx
+++ b/webapp/src/pages/Games/HorseRacing.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import ConnectWallet from '../../components/ConnectWallet.jsx';
 import RoomPopup from '../../components/RoomPopup.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 
@@ -17,7 +16,6 @@ export default function HorseRacing() {
         setSelection={setSelection}
         onConfirm={() => setShowRoom(false)}
       />
-      <ConnectWallet />
       <p>Horse racing game coming soon.</p>
     </div>
   );

--- a/webapp/src/pages/Games/LudoGame.jsx
+++ b/webapp/src/pages/Games/LudoGame.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { Ludo } from '@ayshrj/ludo.js';
-import ConnectWallet from '../../components/ConnectWallet.jsx';
 import RoomPopup from '../../components/RoomPopup.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 
@@ -202,7 +201,6 @@ export default function LudoGame() {
         onConfirm={() => setShowRoom(false)}
       />
 
-      <ConnectWallet />
 
       <LudoBoard game={ludo} state={gameState} />
     </div>

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -10,7 +10,6 @@ import {
 } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
-import ConnectWallet from '../components/ConnectWallet.jsx';
 import { useTonWallet, useTonConnectUI } from '@tonconnect/ui-react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 
@@ -194,7 +193,6 @@ export default function Wallet() {
       <div className="space-y-2 pt-4">
         <h3 className="text-lg font-semibold">Tonkeeper Wallet</h3>
 
-        <ConnectWallet />
         <p>TON Balance: {tonBalance === null ? '...' : tonBalance}</p>
         <p>USDT Balance: 0</p>
 


### PR DESCRIPTION
## Summary
- keep wallet connection on home page only
- drop the ConnectWallet component from Wallet, Ludo, HorseRacing, and WalletCard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f34a76a6c8329a5e25a75f09594d2