### PR TITLE
Add hex table popup and improve dice randomness

### DIFF
--- a/webapp/src/components/DicePopup.jsx
+++ b/webapp/src/components/DicePopup.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import DiceRoller from './DiceRoller.jsx';
+
+export default function DicePopup({ open, onClose, onRollEnd }) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
+      <div className="relative">
+        <button
+          onClick={onClose}
+          className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"
+        >
+          &times;
+        </button>
+        <div className="hex-table p-8">
+          <DiceRoller onRollEnd={onRollEnd} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -21,10 +21,19 @@ export default function DiceRoller({ onRollEnd }) {
       soundRef.current.play().catch(() => {});
     }
     setRolling(true);
+    const rand = () => {
+      if (window.crypto && window.crypto.getRandomValues) {
+        const arr = new Uint32Array(1);
+        window.crypto.getRandomValues(arr);
+        return (arr[0] % 6) + 1;
+      }
+      return Math.floor(Math.random() * 6) + 1;
+    };
+
     let count = 0;
     const id = setInterval(() => {
-      const v1 = Math.floor(Math.random() * 6) + 1;
-      const v2 = Math.floor(Math.random() * 6) + 1;
+      const v1 = rand();
+      const v2 = rand();
       setValues([v1, v2]);
       count += 1;
       if (count >= 20) {

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -11,6 +11,12 @@ body {
   clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
 }
 
+.hex-table {
+  clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
+  background: radial-gradient(circle at center, #8b1a1a 0%, #5a0d0d 80%);
+  border: 4px solid #b22222;
+}
+
 .player-avatar {
   @apply w-12 h-12 rounded-full border border-yellow-400;
 }

--- a/webapp/src/pages/Games/DiceDuel.jsx
+++ b/webapp/src/pages/Games/DiceDuel.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import DiceRoller from '../../components/DiceRoller.jsx';
+import DicePopup from '../../components/DicePopup.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 
 export default function DiceDuel() {
@@ -8,6 +9,7 @@ export default function DiceDuel() {
   const [scores, setScores] = useState([0, 0]);
   const [turn, setTurn] = useState(0); // 0 -> player1, 1 -> player2
   const [winner, setWinner] = useState(null);
+  const [showDice, setShowDice] = useState(false);
 
   const handleRoll = (values) => {
     const value = Array.isArray(values) ? values.reduce((a, b) => a + b, 0) : values;
@@ -18,6 +20,7 @@ export default function DiceDuel() {
       return next;
     });
     setTurn((t) => (t === 0 ? 1 : 0));
+    setShowDice(false);
   };
 
   return (
@@ -37,7 +40,15 @@ export default function DiceDuel() {
           Player {turn + 1}'s turn
         </div>
       )}
-      {winner === null && <DiceRoller onRollEnd={handleRoll} />}
+      {winner === null && (
+        <button
+          onClick={() => setShowDice(true)}
+          className="mx-auto px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded"
+        >
+          Roll Dice
+        </button>
+      )}
+      <DicePopup open={showDice} onClose={() => setShowDice(false)} onRollEnd={handleRoll} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- improve randomness using `crypto.getRandomValues`
- add a `DicePopup` component with hexagonal red table
- show popup dice roller in Dice Duel page
- style `.hex-table` in CSS

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684f50a9f50483298eb324b01d95d657