### PR TITLE
Update Snake & Ladder visuals and sounds

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -119,7 +119,7 @@ body {
 }
 
 .token {
-  @apply absolute w-4 h-4 bg-blue-600 rounded-full shadow-lg;
+  @apply absolute w-16 h-16 rounded-full shadow-lg object-cover;
   transform: translateZ(10px);
 }
 


### PR DESCRIPTION
## Summary
- scale the Snake & Ladder board so cells match the dice
- use user's profile photo as the token
- play distinct sounds for snakes, ladders and winning

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684faae5c81083298e28662276a0511f