### PR TITLE
Fix Snake & Ladder board numbering

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -33,8 +33,8 @@ const ladders = {
 
 function Board({ position, highlight, photoUrl }) {
   const tiles = [];
-  for (let r = 9; r >= 0; r--) {
-    const reversed = (9 - r) % 2 === 1;
+  for (let r = 0; r < 10; r++) {
+    const reversed = r % 2 === 1;
     for (let c = 0; c < 10; c++) {
       const col = reversed ? 9 - c : c;
       const num = r * 10 + col + 1;


### PR DESCRIPTION
## Summary
- make the board start from the bottom left to match game logic

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684fb517f2ac8329b87b6490d79b5a56