### PR TITLE
Fix board cell sizing

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --cell-width: 135px;
+  --cell-height: 68px;
+}
+
 body {
   font-family: Arial, Helvetica, sans-serif;
   @apply bg-background text-text;
@@ -107,6 +112,8 @@ body {
   border: 2px solid #ffd700; /* metallic gold edges */
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5); /* subtle outer depth */
   transform: translateZ(5px);
+  width: var(--cell-width);
+  height: var(--cell-height);
 }
 
 .board-cell::after {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -63,11 +63,21 @@ function Board({ position, highlight, photoUrl }) {
     }
   }
 
+  const cellWidth = 135; // px
+  const cellHeight = 68; // px
+
   return (
     <div className="flex justify-center">
       <div
         className="grid grid-rows-10 grid-cols-10 gap-1 relative"
-        style={{ width: '90vmin', height: '90vmin' }}
+        style={{
+          width: `${cellWidth * 10}px`,
+          height: `${cellHeight * 10}px`,
+          gridTemplateColumns: `repeat(10, ${cellWidth}px)`,
+          gridTemplateRows: `repeat(10, ${cellHeight}px)`,
+          '--cell-width': `${cellWidth}px`,
+          '--cell-height': `${cellHeight}px`,
+        }}
       >
         {tiles}
       </div>


### PR DESCRIPTION
## Summary
- resize board cells in Snake & Ladder
- set custom CSS variables for tile size

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684fb8196ee483299cb98fcf4298e821