### PR TITLE
Fix board cell sizing

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --cell-width: 135px;
+  --cell-height: 68px;
+}
+
 body {
   font-family: Arial, Helvetica, sans-serif;
   @apply bg-background text-text;
@@ -107,6 +112,8 @@ body {
   border: 2px solid #ffd700; /* metallic gold edges */
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5); /* subtle outer depth */
   transform: translateZ(5px);
+  width: var(--cell-width);
+  height: var(--cell-height);
 }
 
 .board-cell::after {
@@ -126,4 +133,15 @@ body {
 /* cell glows briefly as a piece moves over it */
 .board-cell.highlight {
   box-shadow: 0 0 10px 4px rgba(255, 255, 100, 0.8);
+}
+
+.board-wrapper {
+  width: 100%;
+  height: 100vh;
+  overscroll-behavior: contain;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.board-wrapper::-webkit-scrollbar {
+  display: none;
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -32,6 +32,7 @@ const ladders = {
 };
 
 function Board({ position, highlight, photoUrl }) {
+  const containerRef = useRef(null);
   const tiles = [];
   for (let r = 0; r < 10; r++) {
     const reversed = r % 2 === 1;
@@ -41,6 +42,7 @@ function Board({ position, highlight, photoUrl }) {
       tiles.push(
         <div
           key={num}
+          id={`tile-${num}`}
           className={`board-cell ${highlight === num ? "highlight" : ""}`}
           style={{ gridRowStart: 10 - r, gridColumnStart: col + 1 }}
         >
@@ -63,11 +65,32 @@ function Board({ position, highlight, photoUrl }) {
     }
   }
 
+  const cellWidth = 135; // px
+  const cellHeight = 68; // px
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const el = containerRef.current.querySelector(`#tile-${position}`);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" });
+    }
+  }, [position]);
+
   return (
-    <div className="flex justify-center">
+    <div
+      ref={containerRef}
+      className="board-wrapper overflow-auto flex justify-center items-center"
+    >
       <div
         className="grid grid-rows-10 grid-cols-10 gap-1 relative"
-        style={{ width: '90vmin', height: '90vmin' }}
+        style={{
+          width: `${cellWidth * 10}px`,
+          height: `${cellHeight * 10}px`,
+          gridTemplateColumns: `repeat(10, ${cellWidth}px)`,
+          gridTemplateRows: `repeat(10, ${cellHeight}px)`,
+          '--cell-width': `${cellWidth}px`,
+          '--cell-height': `${cellHeight}px`,
+        }}
       >
         {tiles}
       </div>


### PR DESCRIPTION
## Summary
- resize board cells in Snake & Ladder
- set custom CSS variables for tile size
- restore camera tracking by scrolling active tile into view
- add board-wrapper styles to hide scrollbars

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684fb8196ee483299cb98fcf4298e821