### PR TITLE
Fix dice orientation consistency during rolls

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -64,8 +64,9 @@ function Face({ value, className }) {
 }
 
 // 🎲 Single cube component
-function DiceCube({ value = 1, rolling = false, playSound = false }) {
-  const orientation = faceTransforms[value] || faceTransforms[1];
+function DiceCube({ value = 1, rolling = false, playSound = false, prevValue }) {
+  const displayVal = rolling ? prevValue ?? value : value;
+  const orientation = faceTransforms[displayVal] || faceTransforms[1];
 
   useEffect(() => {
     if (rolling && playSound) {
@@ -80,7 +81,7 @@ function DiceCube({ value = 1, rolling = false, playSound = false }) {
         className={`dice-cube relative w-full h-full transition-transform duration-500 transform-style-preserve-3d ${
           rolling ? 'animate-roll' : ''
         }`}
-        style={!rolling ? { transform: orientation } : undefined}
+        style={{ transform: orientation }}
       >
         <Face value={1} className="dice-face--front absolute" />
         <Face value={6} className="dice-face--back absolute" />
@@ -94,11 +95,11 @@ function DiceCube({ value = 1, rolling = false, playSound = false }) {
 }
 
 // 🎲 Pair of dice — default setup
-export default function DicePair({ values = [1, 1], rolling = false, playSound = false }) {
+export default function DicePair({ values = [1, 1], rolling = false, playSound = false, startValues }) {
   return (
     <div className="flex gap-4 justify-center items-center">
-      <DiceCube value={values[0]} rolling={rolling} playSound={playSound} />
-      <DiceCube value={values[1]} rolling={rolling} playSound={playSound} />
+      <DiceCube value={values[0]} rolling={rolling} playSound={playSound} prevValue={startValues?.[0]} />
+      <DiceCube value={values[1]} rolling={rolling} playSound={playSound} prevValue={startValues?.[1]} />
     </div>
   );
 }

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -5,9 +5,12 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
   const soundRef = useRef(null);
+  const startValuesRef = useRef(values);
 
   useEffect(() => {
-    setValues(Array(numDice).fill(1));
+    const initial = Array(numDice).fill(1);
+    setValues(initial);
+    startValuesRef.current = initial;
   }, [numDice]);
 
   useEffect(() => {
@@ -24,6 +27,7 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
       soundRef.current.currentTime = 0;
       soundRef.current.play().catch(() => {});
     }
+    startValuesRef.current = values;
     setRolling(true);
     const rand = () => {
       if (window.crypto && window.crypto.getRandomValues) {
@@ -42,6 +46,7 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
       if (count >= 20) {
         clearInterval(id);
         setRolling(false);
+        startValuesRef.current = results;
         onRollEnd && onRollEnd(results);
       }
     }, 100);
@@ -53,7 +58,7 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
         className={`flex space-x-4 ${clickable ? 'cursor-pointer' : ''}`}
         onClick={clickable ? rollDice : undefined}
       >
-        <Dice values={values} rolling={rolling} />
+        <Dice values={values} rolling={rolling} startValues={startValuesRef.current} />
       </div>
       {!clickable && (
         <button


### PR DESCRIPTION
## Summary
- keep dice orientation constant while rolling
- remember starting dice faces when rolling begins
- restore final orientation after the roll

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fc568a91c8329a0d23db4806c816c