### PR TITLE
Fix left dice orientation to match right

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -64,8 +64,9 @@ function Face({ value, className }) {
 }
 
 // 🎲 Single cube component
-function DiceCube({ value = 1, rolling = false, playSound = false }) {
-  const orientation = faceTransforms[value] || faceTransforms[1];
+function DiceCube({ value = 1, rolling = false, playSound = false, prevValue }) {
+  const displayVal = rolling ? prevValue ?? value : value;
+  const orientation = faceTransforms[displayVal] || faceTransforms[1];
 
   useEffect(() => {
     if (rolling && playSound) {
@@ -80,7 +81,7 @@ function DiceCube({ value = 1, rolling = false, playSound = false }) {
         className={`dice-cube relative w-full h-full transition-transform duration-500 transform-style-preserve-3d ${
           rolling ? 'animate-roll' : ''
         }`}
-        style={!rolling ? { transform: orientation } : undefined}
+        style={{ transform: orientation }}
       >
         <Face value={1} className="dice-face--front absolute" />
         <Face value={6} className="dice-face--back absolute" />
@@ -94,11 +95,11 @@ function DiceCube({ value = 1, rolling = false, playSound = false }) {
 }
 
 // 🎲 Pair of dice — default setup
-export default function DicePair({ values = [1, 1], rolling = false, playSound = false }) {
+export default function DicePair({ values = [1, 1], rolling = false, playSound = false, startValues }) {
   return (
     <div className="flex gap-4 justify-center items-center">
-      <DiceCube value={values[0]} rolling={rolling} playSound={playSound} />
-      <DiceCube value={values[1]} rolling={rolling} playSound={playSound} />
+      <DiceCube value={values[0]} rolling={rolling} playSound={playSound} prevValue={startValues?.[0]} />
+      <DiceCube value={values[1]} rolling={rolling} playSound={playSound} prevValue={startValues?.[1]} />
     </div>
   );
 }

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -2,12 +2,27 @@ import React, { useState, useEffect, useRef } from 'react';
 import Dice from './Dice.jsx';
 
 export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }) {
-  const [values, setValues] = useState(Array(numDice).fill(1));
+  const rand = () => {
+    if (window.crypto && window.crypto.getRandomValues) {
+      const arr = new Uint32Array(1);
+      window.crypto.getRandomValues(arr);
+      return (arr[0] % 6) + 1;
+    }
+    return Math.floor(Math.random() * 6) + 1;
+  };
+
+  const initial = Array.from({ length: numDice }, rand);
+  const [values, setValues] = useState(initial); // shown result for next roll
+  const [rollingVals, setRollingVals] = useState(initial); // temporary values during roll
   const [rolling, setRolling] = useState(false);
   const soundRef = useRef(null);
+  const startValuesRef = useRef(initial);
 
   useEffect(() => {
-    setValues(Array(numDice).fill(1));
+    const init = Array.from({ length: numDice }, rand);
+    setValues(init);
+    setRollingVals(init);
+    startValuesRef.current = init;
   }, [numDice]);
 
   useEffect(() => {
@@ -24,25 +39,20 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
       soundRef.current.currentTime = 0;
       soundRef.current.play().catch(() => {});
     }
+    startValuesRef.current = values.slice();
     setRolling(true);
-    const rand = () => {
-      if (window.crypto && window.crypto.getRandomValues) {
-        const arr = new Uint32Array(1);
-        window.crypto.getRandomValues(arr);
-        return (arr[0] % 6) + 1;
-      }
-      return Math.floor(Math.random() * 6) + 1;
-    };
-
     let count = 0;
     const id = setInterval(() => {
-      const results = Array.from({ length: numDice }, rand);
-      setValues(results);
+      setRollingVals(Array.from({ length: numDice }, rand));
       count += 1;
       if (count >= 20) {
         clearInterval(id);
         setRolling(false);
-        onRollEnd && onRollEnd(results);
+        setRollingVals(startValuesRef.current);
+        onRollEnd && onRollEnd(startValuesRef.current);
+        const next = Array.from({ length: numDice }, rand);
+        setValues(next);
+        startValuesRef.current = next.slice();
       }
     }, 100);
   };
@@ -53,7 +63,7 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
         className={`flex space-x-4 ${clickable ? 'cursor-pointer' : ''}`}
         onClick={clickable ? rollDice : undefined}
       >
-        <Dice values={values} rolling={rolling} />
+        <Dice values={rolling ? rollingVals : values} rolling={rolling} startValues={startValuesRef.current} />
       </div>
       {!clickable && (
         <button


### PR DESCRIPTION
## Summary
- overhaul dice roller logic so both dice finish on the same values they start with
- keep generated next values in a ref and reuse them for the following roll

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684fc568a91c8329a0d23db4806c816c