### PR TITLE
Add lobby tables to snake game

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -119,6 +119,16 @@ app.get('/', (req, res) => {
 app.get('/api/ping', (req, res) => {
   res.json({ message: 'pong' });
 });
+app.get('/api/snake/lobbies', (req, res) => {
+  const capacities = [2, 3, 4];
+  const lobbies = capacities.map((cap) => {
+    const id = `snake-${cap}`;
+    const room = gameManager.getRoom(id, cap);
+    const players = room.players.filter((p) => !p.disconnected).length;
+    return { id, capacity: cap, players };
+  });
+  res.json(lobbies);
+});
 app.get('*', (req, res) => {
   if (req.path.startsWith('/api/')) return res.status(404).end();
   sendIndex(res);

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -39,3 +39,16 @@ test('start requires 6 and triple six skips turn', () => {
   assert.equal(room.players[0].position, 7); // third six should skip move
 });
 
+test('room starts when reaching custom capacity', () => {
+  const io = new DummyIO();
+  const room = new GameRoom('r2', io, 2);
+  const s1 = { id: 's1', join: () => {} };
+  const s2 = { id: 's2', join: () => {} };
+  room.addPlayer('p1', 'A', s1);
+  assert.equal(room.status, 'waiting');
+  room.addPlayer('p2', 'B', s2);
+  assert.equal(room.status, 'playing');
+  const res = room.addPlayer('p3', 'C', { id: 's3', join: () => {} });
+  assert.ok(res.error, 'should not allow extra players');
+});
+

--- a/webapp/src/components/RoomPopup.jsx
+++ b/webapp/src/components/RoomPopup.jsx
@@ -1,8 +1,18 @@
 import RoomSelector from './RoomSelector.jsx';
+import TableSelector from './TableSelector.jsx';
 
-export default function RoomPopup({ open, selection, setSelection, onConfirm }) {
+export default function RoomPopup({
+  open,
+  selection,
+  setSelection,
+  onConfirm,
+  tables,
+  selectedTable,
+  setSelectedTable,
+}) {
   if (!open) return null;
-  const disabled = !selection || !selection.token || !selection.amount;
+  const disabled =
+    !selection || !selection.token || !selection.amount || (tables && !selectedTable);
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
@@ -13,6 +23,9 @@ export default function RoomPopup({ open, selection, setSelection, onConfirm }) 
         />
         <h3 className="text-lg font-bold text-center">Join a Room</h3>
         <p className="text-sm text-subtext text-center">Choose your token and amount</p>
+        {tables && (
+          <TableSelector tables={tables} selected={selectedTable} onSelect={setSelectedTable} />
+        )}
         <RoomSelector selected={selection || { token: '', amount: 0 }} onSelect={setSelection} />
         <button
           onClick={onConfirm}

--- a/webapp/src/components/TableSelector.jsx
+++ b/webapp/src/components/TableSelector.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function TableSelector({ tables, selected, onSelect }) {
+  return (
+    <div className="space-y-2">
+      {tables.map((t) => (
+        <button
+          key={t.id}
+          onClick={() => onSelect(t)}
+          className={`w-full px-2 py-1 border rounded flex justify-between ${
+            selected?.id === t.id ? 'bg-yellow-400 text-gray-900' : 'bg-gray-700 text-white'
+          }`}
+        >
+          <span>Table {t.capacity}p</span>
+          <span>
+            {t.players}/{t.capacity}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3,6 +3,7 @@ import DiceRoller from "../../components/DiceRoller.jsx";
 import RoomPopup from "../../components/RoomPopup.jsx";
 import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
 import { getTelegramPhotoUrl } from "../../utils/telegram.js";
+import { getSnakeLobbies } from "../../utils/api.js";
 
 // Simple snake and ladder layout for a 10x10 board
 const snakes = {
@@ -90,6 +91,8 @@ export default function SnakeAndLadder() {
   const [pos, setPos] = useState(0);
   const [selection, setSelection] = useState(null);
   const [showRoom, setShowRoom] = useState(true);
+  const [tables, setTables] = useState([]);
+  const [selectedTable, setSelectedTable] = useState(null);
   const [streak, setStreak] = useState(0);
   const [highlight, setHighlight] = useState(null);
   const [message, setMessage] = useState("");
@@ -114,6 +117,23 @@ export default function SnakeAndLadder() {
       snakeSoundRef.current?.pause();
       ladderSoundRef.current?.pause();
       winSoundRef.current?.pause();
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    function load() {
+      getSnakeLobbies()
+        .then((data) => {
+          if (active) setTables(data);
+        })
+        .catch(() => {});
+    }
+    load();
+    const id = setInterval(load, 5000);
+    return () => {
+      active = false;
+      clearInterval(id);
     };
   }, []);
 
@@ -197,6 +217,9 @@ export default function SnakeAndLadder() {
         selection={selection}
         setSelection={setSelection}
         onConfirm={() => setShowRoom(false)}
+        tables={tables}
+        selectedTable={selectedTable}
+        setSelectedTable={setSelectedTable}
       />
       <Board position={pos} highlight={highlight} photoUrl={photoUrl} />
       {message && <div className="text-center font-semibold">{message}</div>}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -191,3 +191,7 @@ export function grantAirdrop(token, telegramId, amount, reason = '') {
 export function grantAirdropAll(token, amount, reason = '') {
   return post('/api/airdrop/grant-all', { amount, reason }, token);
 }
+
+export function getSnakeLobbies() {
+  return fetch(API_BASE_URL + '/api/snake/lobbies').then((r) => r.json());
+}


### PR DESCRIPTION
## Summary
- support variable max players in `GameRoom`
- expose lobby counts via `/api/snake/lobbies`
- show available tables in Snake & Ladder room popup
- add table selector component
- test custom room capacity

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684fcb433b188329b6f18092146aeffa