### PR TITLE
Orient snake board vertically

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -51,6 +51,16 @@ body {
   transform-style: preserve-3d;
 }
 
+/* Tilted view specifically for the Snake & Ladder board */
+.snake-board-tilt {
+  perspective: 800px;
+}
+
+.snake-board-grid {
+  transform: rotateX(45deg);
+  transform-style: preserve-3d;
+}
+
 @keyframes roll {
   0% {
     transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg) translateY(0);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -16,8 +16,9 @@ const ladders = {
 };
 
 const PLAYERS = 4;
-const ROWS = 4;
-const COLS = 25;
+// Board dimensions. Using more rows than columns gives a vertical layout
+const ROWS = 25;
+const COLS = 4;
 const FINAL_TILE = ROWS * COLS + 1; // 101
 
 function Board({ position, highlight, photoUrl, pot }) {
@@ -52,29 +53,32 @@ function Board({ position, highlight, photoUrl, pot }) {
     }
   }
 
-  const cellWidth = 135;
-  const cellHeight = 68;
+  // Slightly smaller cells for better fit when tilting the board
+  const cellWidth = 100;
+  const cellHeight = 50;
 
   return (
     <div className="flex justify-center">
-      <div
-        className="grid gap-1 relative"
-        style={{
-          width: `${cellWidth * COLS}px`,
-          height: `${cellHeight * ROWS}px`,
-          gridTemplateColumns: `repeat(${COLS}, ${cellWidth}px)`,
-          gridTemplateRows: `repeat(${ROWS}, ${cellHeight}px)`,
-          '--cell-width': `${cellWidth}px`,
-          '--cell-height': `${cellHeight}px`,
-        }}
-      >
-        {tiles}
-        <div className={`pot-cell ${highlight === FINAL_TILE ? 'highlight' : ''}`}>
-          <span className="font-bold">Pot</span>
-          <span className="text-sm">{pot}</span>
-          {position === FINAL_TILE && (
-            <img src={photoUrl} alt="player" className="token" />
-          )}
+      <div className="snake-board-tilt">
+        <div
+          className="snake-board-grid grid gap-1 relative"
+          style={{
+            width: `${cellWidth * COLS}px`,
+            height: `${cellHeight * ROWS}px`,
+            gridTemplateColumns: `repeat(${COLS}, ${cellWidth}px)`,
+            gridTemplateRows: `repeat(${ROWS}, ${cellHeight}px)`,
+            '--cell-width': `${cellWidth}px`,
+            '--cell-height': `${cellHeight}px`,
+          }}
+        >
+          {tiles}
+          <div className={`pot-cell ${highlight === FINAL_TILE ? 'highlight' : ''}`}>
+            <span className="font-bold">Pot</span>
+            <span className="text-sm">{pot}</span>
+            {position === FINAL_TILE && (
+              <img src={photoUrl} alt="player" className="token" />
+            )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- rotate snake board to a 4 column vertical layout
- slightly shrink cell size and tilt board 45° so pot is visible

## Testing
- `npm --prefix webapp run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684fe1d8d0dc832999d802f021960690