### PR TITLE
Improve snake lobby

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -129,6 +129,17 @@ app.get('/api/snake/lobbies', (req, res) => {
   });
   res.json(lobbies);
 });
+
+app.get('/api/snake/lobby/:id', (req, res) => {
+  const { id } = req.params;
+  const match = /-(\d+)$/.exec(id);
+  const cap = match ? Number(match[1]) : 4;
+  const room = gameManager.getRoom(id, cap);
+  const players = room.players
+    .filter((p) => !p.disconnected)
+    .map((p) => ({ id: p.playerId, name: p.name }));
+  res.json({ id, capacity: cap, players });
+});
 app.get('*', (req, res) => {
   if (req.path.startsWith('/api/')) return res.status(404).end();
   sendIndex(res);

--- a/test/snakeLobbyRoute.test.js
+++ b/test/snakeLobbyRoute.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { setTimeout as delay } from 'timers/promises';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+
+async function startServer(env) {
+  return spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+}
+
+test('snake lobby route lists players', async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3200',
+    MONGODB_URI: 'memory',
+    SKIP_BOT_LAUNCH: '1'
+  };
+  const server = await startServer(env);
+  try {
+    for (let i = 0; i < 20; i++) {
+      try {
+        const res = await fetch('http://localhost:3200/api/snake/lobby/snake-2');
+        if (res.ok) {
+          const data = await res.json();
+          assert.equal(data.id, 'snake-2');
+          assert.ok(Array.isArray(data.players));
+          return;
+        }
+      } catch {}
+      await delay(100);
+    }
+    assert.fail('lobby route not reachable');
+  } finally {
+    server.kill();
+  }
+});

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import TableSelector from '../../components/TableSelector.jsx';
 import RoomSelector from '../../components/RoomSelector.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
-import { getSnakeLobbies } from '../../utils/api.js';
+import { getSnakeLobbies, getSnakeLobby } from '../../utils/api.js';
 
 export default function Lobby() {
   const { game } = useParams();
@@ -13,6 +13,7 @@ export default function Lobby() {
   const [tables, setTables] = useState([]);
   const [table, setTable] = useState(null);
   const [stake, setStake] = useState({ token: '', amount: 0 });
+  const [players, setPlayers] = useState([]);
 
   useEffect(() => {
     if (game === 'snake') {
@@ -33,6 +34,27 @@ export default function Lobby() {
     }
   }, [game]);
 
+  useEffect(() => {
+    if (game === 'snake' && table) {
+      let active = true;
+      function loadPlayers() {
+        getSnakeLobby(table.id)
+          .then((data) => {
+            if (active) setPlayers(data.players);
+          })
+          .catch(() => {});
+      }
+      loadPlayers();
+      const id = setInterval(loadPlayers, 3000);
+      return () => {
+        active = false;
+        clearInterval(id);
+      };
+    } else {
+      setPlayers([]);
+    }
+  }, [game, table]);
+
   const startGame = () => {
     const params = new URLSearchParams();
     if (table) params.set('table', table.id);
@@ -41,7 +63,10 @@ export default function Lobby() {
     navigate(`/games/${game}?${params.toString()}`);
   };
 
-  const disabled = !stake.token || !stake.amount;
+  const disabled =
+    !stake.token ||
+    !stake.amount ||
+    (game === 'snake' && (!table || players.length < table.capacity));
 
   return (
     <div className="p-4 space-y-4 text-text">
@@ -50,6 +75,18 @@ export default function Lobby() {
         <div className="space-y-2">
           <h3 className="font-semibold">Select Table</h3>
           <TableSelector tables={tables} selected={table} onSelect={setTable} />
+        </div>
+      )}
+      {game === 'snake' && table && (
+        <div className="space-y-1">
+          <h3 className="font-semibold">
+            Online Players ({players.length}/{table.capacity})
+          </h3>
+          <ul className="text-sm list-disc list-inside">
+            {players.map((p) => (
+              <li key={p.id}>{p.name}</li>
+            ))}
+          </ul>
         </div>
       )}
       <div className="space-y-2">

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -195,3 +195,7 @@ export function grantAirdropAll(token, amount, reason = '') {
 export function getSnakeLobbies() {
   return fetch(API_BASE_URL + '/api/snake/lobbies').then((r) => r.json());
 }
+
+export function getSnakeLobby(id) {
+  return fetch(API_BASE_URL + '/api/snake/lobby/' + id).then((r) => r.json());
+}


### PR DESCRIPTION
## Summary
- add server API to fetch player details for a snake lobby
- expose `getSnakeLobby` in the webapp API module
- show online players on the snake lobby page and only enable start when room is full
- test the new lobby route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684feb55254083299768269a0872e39b