### PR TITLE
Enable Start Game button in snake lobby

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -63,10 +63,8 @@ export default function Lobby() {
     navigate(`/games/${game}?${params.toString()}`);
   };
 
-  const disabled =
-    !stake.token ||
-    !stake.amount ||
-    (game === 'snake' && (!table || players.length < table.capacity));
+  // Allow starting the game without fulfilling lobby requirements while testing
+  const disabled = false; // TODO: restore lobby checks when done testing
 
   return (
     <div className="p-4 space-y-4 text-text">


### PR DESCRIPTION
## Summary
- temporarily allow Start Game in Snake & Ladder lobby without meeting normal requirements

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684ff53e23f0832987101c4ab56b436d