### PR TITLE
Fix dice animation display in Snake & Ladder

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -64,7 +64,7 @@ function Face({ value, className }) {
 }
 
 // 🎲 Single cube component
-function DiceCube({ value = 1, rolling = false, playSound = false, prevValue }) {
+export function DiceCube({ value = 1, rolling = false, playSound = false, prevValue }) {
   const displayVal = rolling ? prevValue ?? value : value;
   const orientation = faceTransforms[displayVal] || faceTransforms[1];
 
@@ -103,3 +103,5 @@ export default function DicePair({ values = [1, 1], rolling = false, playSound =
     </div>
   );
 }
+
+export { DiceCube };

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import Dice from './Dice.jsx';
+import { DiceCube } from './Dice.jsx';
 
 export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }) {
   const rand = () => {
@@ -71,11 +71,11 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
         onClick={clickable ? rollDice : undefined}
       >
         {rollingVals.map((val, i) => (
-          <Dice
+          <DiceCube
             key={i}
             value={val}
             rolling={rolling}
-            startValue={startValuesRef.current[i]}
+            prevValue={startValuesRef.current[i]}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- export `DiceCube` component for single dice
- use `DiceCube` in `DiceRoller`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fffc6868083299ca546ef5043bead