### PR TITLE
Add zoom effect and logo wall to Snake & Ladder

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -57,9 +57,9 @@ body {
 }
 
 .snake-board-grid {
-  transform: rotateX(60deg) scale(0.85);
   transform-style: preserve-3d;
   transform-origin: bottom center;
+  transition: transform 0.3s ease;
 }
 
 @keyframes roll {
@@ -154,4 +154,19 @@ body {
 
 .pot-cell.highlight {
   box-shadow: 0 0 10px 4px rgba(250, 204, 21, 0.8);
+}
+
+.logo-wall {
+  @apply absolute flex items-center justify-center;
+  width: calc(var(--cell-width) * 4);
+  height: calc(var(--cell-height) * 4);
+  top: calc(var(--cell-height) * -4.5);
+  left: 50%;
+  transform: translateX(-50%) rotateX(-60deg) translateZ(-20px);
+  transform-origin: bottom center;
+  background-image: url('/assets/TonPlayGramLogo.jpg');
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  z-index: 5;
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -53,6 +53,7 @@ function Board({ position, highlight, photoUrl, pot }) {
 
   const cellWidth = 100;
   const cellHeight = 50;
+  const zoom = 1 + (position / FINAL_TILE) * 0.4;
 
   useEffect(() => {
     const container = containerRef.current;
@@ -90,6 +91,7 @@ function Board({ position, highlight, photoUrl, pot }) {
               gridTemplateRows: `repeat(${ROWS}, ${cellHeight}px)`,
               '--cell-width': `${cellWidth}px`,
               '--cell-height': `${cellHeight}px`,
+              transform: `rotateX(60deg) scale(${zoom})`,
             }}
           >
             {tiles}
@@ -100,6 +102,7 @@ function Board({ position, highlight, photoUrl, pot }) {
                 <img src={photoUrl} alt="player" className="token" />
               )}
             </div>
+            <div className="logo-wall" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add scaling transition in `snake-board-grid` and style for logo wall
- compute zoom factor for board based on player position
- apply zoom in board style and show logo wall with TonPlayGram logo
- tweak zoom formula to start at scale 1 and enlarge as the player progresses
- enlarge logo wall to four rows and push it behind the pot

## Testing
- `npm test` *(fails: manifest and lobby endpoints not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684ffe52bf90832986c5b2eb08ea2864