### PR TITLE
Fix dice orientation to display rolled numbers

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -66,9 +66,9 @@ function Face({ value, className }) {
 // 🎲 Single cube component
 function DiceCube({ value = 1, rolling = false, playSound = false, prevValue }) {
   const displayVal = rolling ? prevValue ?? value : value;
-  // Keep the cube orientation fixed so the dice appears in the same position
-  // every roll. Only the dots change to reflect the rolled number.
-  const orientation = baseTilt;
+  // Rotate the cube so the rolled face appears on top while keeping
+  // the overall tilt consistent.
+  const orientation = faceTransforms[displayVal];
   const opposite = { 1: 6, 2: 5, 3: 4, 4: 3, 5: 2, 6: 1 };
 
   useEffect(() => {

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -75,7 +75,7 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
             key={i}
             value={val}
             rolling={rolling}
-            startValue={startValuesRef.current[i]}
+            prevValue={startValuesRef.current[i]}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- orient dice using `faceTransforms` so rolled number is visible at rest
- pass `prevValue` into `Dice` components for stable rolling behavior

## Testing
- `npm test` *(fails: manifest and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6850116e088883298184cd286aaf9364