### PR TITLE
Fix Snake & Ladder scrolling

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -79,7 +79,7 @@ function Board({ position, highlight, photoUrl, pot }) {
     <div className="flex justify-center">
       <div
         ref={containerRef}
-        className="overflow-y-auto"
+        className="overflow-y-auto overscroll-none"
         style={{ height: '80vh' }}
       >
         <div className="snake-board-tilt">
@@ -125,6 +125,12 @@ export default function SnakeAndLadder() {
   const snakeSoundRef = useRef(null);
   const ladderSoundRef = useRef(null);
   const winSoundRef = useRef(null);
+
+  useEffect(() => {
+    if (!document.fullscreenElement && document.documentElement.requestFullscreen) {
+      document.documentElement.requestFullscreen().catch(() => {});
+    }
+  }, []);
 
   useEffect(() => {
     setPhotoUrl(getTelegramPhotoUrl());


### PR DESCRIPTION
## Summary
- prevent overscrolling past the logo so the board doesn't go blank
- auto-request fullscreen on game start

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68501414caf48329a54ce07e0895b73d