### PR TITLE
Adjust camera zoom on board scroll

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -53,12 +53,27 @@ function Board({ position, highlight, photoUrl, pot }) {
 
   const cellWidth = 100;
   const cellHeight = 50;
-  // Slightly closer camera that zooms in more as the player climbs
-  const zoom = 1.1 + (position / FINAL_TILE) * 0.5;
+
+  const [zoom, setZoom] = useState(1.1);
 
   useEffect(() => {
     const container = containerRef.current;
-    if (container) container.scrollTop = container.scrollHeight;
+    if (container) {
+      container.scrollTop = container.scrollHeight;
+    }
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const handleScroll = () => {
+      const max = container.scrollHeight - container.clientHeight;
+      const progress = max > 0 ? container.scrollTop / max : 0;
+      setZoom(1.1 + progress * 0.5);
+    };
+    handleScroll();
+    container.addEventListener('scroll', handleScroll);
+    return () => container.removeEventListener('scroll', handleScroll);
   }, []);
 
   useEffect(() => {
@@ -72,6 +87,9 @@ function Board({ position, highlight, photoUrl, pot }) {
       // follows from behind rather than centering exactly
       const offset = cellRect.top - cRect.top - cRect.height * 0.7 + cellRect.height / 2;
       container.scrollBy({ top: offset, behavior: 'smooth' });
+      const max = container.scrollHeight - container.clientHeight;
+      const progress = max > 0 ? (container.scrollTop + offset) / max : 0;
+      setZoom(1.1 + progress * 0.5);
     }
   }, [position]);
 
@@ -80,7 +98,7 @@ function Board({ position, highlight, photoUrl, pot }) {
       <div
         ref={containerRef}
         className="overflow-y-auto"
-        style={{ height: '80vh' }}
+        style={{ height: '80vh', paddingTop: `${cellHeight * 5}px` }}
       >
         <div className="snake-board-tilt">
           <div


### PR DESCRIPTION
## Summary
- make camera scale depend on scroll position in the Snake & Ladder board
- pad the board container so the logo scrolls to the very top

## Testing
- `npm test` *(fails: manifest endpoint and snake lobby route)*

------
https://chatgpt.com/codex/tasks/task_e_6850183b94408329bedcfc5e1b550c19