### PR TITLE
Add angled logos for snake board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -156,10 +156,10 @@ body {
   box-shadow: 0 0 10px 4px rgba(250, 204, 21, 0.8);
 }
 
-.logo-wall {
+.logo-wall-main {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 4); /* ✅ 4 columns */
-  height: calc(var(--cell-height) * 4); /* ✅ 4 rows */
+  width: calc(var(--cell-width) * 5); /* bigger width */
+  height: calc(var(--cell-height) * 5); /* bigger height */
   top: calc(var(--cell-height) * -4.5); /* ✅ push above pot */
   left: 50%;
   transform: translateX(-50%) rotateX(-60deg) translateZ(-20px); /* ✅ behind the pot */
@@ -169,4 +169,27 @@ body {
   background-repeat: no-repeat;
   background-position: center;
   z-index: 5;
+}
+
+.logo-wall-side {
+  @apply absolute flex items-center justify-center;
+  width: calc(var(--cell-width) * 4);
+  height: calc(var(--cell-height) * 4);
+  top: calc(var(--cell-height) * -4.5);
+  background-image: url('/assets/TonPlayGramLogo.jpg');
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  transform-origin: bottom center;
+  z-index: 4;
+}
+
+.logo-wall-left {
+  left: -10%;
+  transform: rotateY(40deg) rotateX(-60deg) translateZ(-20px);
+}
+
+.logo-wall-right {
+  right: -10%;
+  transform: rotateY(-40deg) rotateX(-60deg) translateZ(-20px);
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -113,7 +113,9 @@ function Board({ position, highlight, photoUrl, pot }) {
                 <img src={photoUrl} alt="player" className="token" />
               )}
             </div>
-            <div className="logo-wall" />
+            <div className="logo-wall-main" />
+            <div className="logo-wall-side logo-wall-left" />
+            <div className="logo-wall-side logo-wall-right" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- make space for bigger billboard with `.logo-wall-main`
- add two angled side logos to Snake & Ladder board

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850210b061c8329abeae1320d073f30