### PR TITLE
Adjust logo size and camera view in Snake & Ladder

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -156,13 +156,14 @@ body {
   box-shadow: 0 0 10px 4px rgba(250, 204, 21, 0.8);
 }
 
+
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 5); /* bigger width */
-  height: calc(var(--cell-height) * 5); /* bigger height */
-  top: calc(var(--cell-height) * -4.5); /* ✅ push above pot */
+  width: calc(var(--cell-width) * 6);
+  height: calc(var(--cell-height) * 6);
+  top: calc(var(--cell-height) * -5.5);
   left: 50%;
-  transform: translateX(-50%) rotateX(-60deg) translateZ(-20px); /* ✅ behind the pot */
+  transform: translateX(-50%) rotateX(-60deg) translateZ(-20px);
   transform-origin: bottom center;
   background-image: url('/assets/TonPlayGramLogo.jpg');
   background-size: contain;
@@ -173,9 +174,9 @@ body {
 
 .logo-wall-side {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 4);
-  height: calc(var(--cell-height) * 4);
-  top: calc(var(--cell-height) * -4.5);
+  width: calc(var(--cell-width) * 5);
+  height: calc(var(--cell-height) * 5);
+  top: calc(var(--cell-height) * -5.5);
   background-image: url('/assets/TonPlayGramLogo.jpg');
   background-size: contain;
   background-repeat: no-repeat;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -22,7 +22,7 @@ const ROWS = 25;
 const COLS = 4;
 const FINAL_TILE = ROWS * COLS + 1; // 101
 // Portion of the viewport to keep below the player's token when scrolling
-const CAMERA_OFFSET = 0.7;
+const CAMERA_OFFSET = 0.9;
 
 function Board({ position, highlight, photoUrl, pot }) {
   const containerRef = useRef(null);
@@ -101,8 +101,8 @@ function Board({ position, highlight, photoUrl, pot }) {
               gridTemplateRows: `repeat(${ROWS}, ${cellHeight}px)`,
               '--cell-width': `${cellWidth}px`,
               '--cell-height': `${cellHeight}px`,
-              // Lower the viewing angle for a more immersive feel
-              transform: `rotateX(70deg) scale(${zoom})`,
+              // Lower viewing angle so the logo wall is more visible
+              transform: `rotateX(60deg) scale(${zoom})`,
             }}
           >
             {tiles}


### PR DESCRIPTION
## Summary
- enlarge TonPlayGram logo wall inside the Snake & Ladder board
- lower camera angle and tracking offset so the logo is more visible

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68502691f9948329a54e2b02f40caf87