### PR TITLE
Add neon ad walls to snake board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -157,6 +157,16 @@ body {
 }
 
 
+
+@keyframes scroll-ad {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(-100%);
+  }
+}
+
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
   width: calc(var(--cell-width) * 6);
@@ -165,32 +175,49 @@ body {
   left: 50%;
   transform: translateX(-50%) rotateX(-60deg) translateZ(-20px);
   transform-origin: bottom center;
+  background-color: #0b0f19;
   background-image: url('/assets/TonPlayGramLogo.jpg');
-  background-size: contain;
+  background-size: 70%;
   background-repeat: no-repeat;
-  background-position: center;
+  background-position: center 20%;
+  clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+  border: 2px solid #facc15;
+  box-shadow: 0 0 20px rgba(250, 204, 21, 0.6);
   z-index: 5;
 }
 
 .logo-wall-side {
-  @apply absolute flex items-center justify-center;
+  @apply absolute flex items-center justify-center overflow-hidden;
   width: calc(var(--cell-width) * 5);
-  height: calc(var(--cell-height) * 5);
-  top: calc(var(--cell-height) * -5.5);
-  background-image: url('/assets/TonPlayGramLogo.jpg');
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
+  height: calc(var(--cell-height) * 8);
+  top: calc(var(--cell-height) * -7.5);
+  background-color: #0b0f19;
+  border: 2px solid #facc15;
+  box-shadow: 0 0 20px rgba(250, 204, 21, 0.6);
   transform-origin: bottom center;
   z-index: 4;
 }
 
+.logo-wall-side .wall-text {
+  position: absolute;
+  bottom: -100%;
+  width: 100%;
+  text-align: center;
+  font-family: monospace;
+  font-size: 1rem;
+  color: #facc15;
+  text-shadow: 0 0 6px rgba(250, 204, 21, 0.8);
+  white-space: nowrap;
+  writing-mode: vertical-rl;
+  animation: scroll-ad 10s linear infinite;
+}
+
 .logo-wall-left {
-  left: -10%;
+  left: -12%;
   transform: rotateY(40deg) rotateX(-60deg) translateZ(-20px);
 }
 
 .logo-wall-right {
-  right: -10%;
+  right: -12%;
   transform: rotateY(-40deg) rotateX(-60deg) translateZ(-20px);
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -114,8 +114,12 @@ function Board({ position, highlight, photoUrl, pot }) {
               )}
             </div>
             <div className="logo-wall-main" />
-            <div className="logo-wall-side logo-wall-left" />
-            <div className="logo-wall-side logo-wall-right" />
+            <div className="logo-wall-side logo-wall-left">
+              <span className="wall-text">Place your ad here o buci 😘</span>
+            </div>
+            <div className="logo-wall-side logo-wall-right">
+              <span className="wall-text">Place your ad here o buci 😘</span>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update Snake and Ladder board with neon side walls
- add animated ad text and triangle logo space styles

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68502f2beea08329bd7e25268f38935c