### PR TITLE
Fix dice top face rotation

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -37,14 +37,20 @@ const diceFaces = {
 // Gentle tilt so three faces are visible
 const baseTilt = 'rotateX(-25deg) rotateY(25deg)';
 
-// Orientation for each numbered face relative to the viewer
+// Orientation for each numbered face so the value appears on the top
 const faceTransforms = {
-  1: `rotateX(0deg) rotateY(0deg) ${baseTilt}`,
-  2: `rotateX(-90deg) rotateY(0deg) ${baseTilt}`,
-  3: `rotateY(90deg) ${baseTilt}`,
-  4: `rotateY(-90deg) ${baseTilt}`,
-  5: `rotateX(90deg) rotateY(0deg) ${baseTilt}`,
-  6: `rotateY(180deg) ${baseTilt}`,
+  // Front face (1) rotated to the top
+  1: `rotateX(-90deg) ${baseTilt}`,
+  // Top face (2) is already on top
+  2: `${baseTilt}`,
+  // Right face (3) rotated to the top
+  3: `rotateZ(-90deg) ${baseTilt}`,
+  // Left face (4) rotated to the top
+  4: `rotateZ(90deg) ${baseTilt}`,
+  // Bottom face (5) rotated to the top
+  5: `rotateX(180deg) ${baseTilt}`,
+  // Back face (6) rotated to the top
+  6: `rotateX(90deg) ${baseTilt}`,
 };
 
 // 🎲 Single dice face component


### PR DESCRIPTION
## Summary
- ensure rolled value appears on the top face of the 3D dice

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6850313af3e48329a62e84cccb78d40d