### PR TITLE
Fix tests by skipping webapp build

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -50,6 +50,10 @@ app.use('/api/checkin', checkinRoutes);
 const webappPath = path.join(__dirname, '../webapp/dist');
 
 function ensureWebappBuilt() {
+  if (process.env.SKIP_WEBAPP_BUILD) {
+    console.log('Skipping webapp build');
+    return true;
+  }
   if (
     existsSync(path.join(webappPath, 'index.html')) &&
     existsSync(path.join(webappPath, 'assets'))

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -20,6 +20,7 @@ test('server exposes manifest endpoint from TONCONNECT_MANIFEST_URL', async () =
     PORT: '3100',
     MONGODB_URI: 'memory',
     SKIP_BOT_LAUNCH: '1',
+    SKIP_WEBAPP_BUILD: '1',
     TONCONNECT_MANIFEST_URL: '/test-manifest.json'
   };
   const server = await startServer(env);

--- a/test/snakeLobbyRoute.test.js
+++ b/test/snakeLobbyRoute.test.js
@@ -18,7 +18,8 @@ test('snake lobby route lists players', async () => {
     ...process.env,
     PORT: '3200',
     MONGODB_URI: 'memory',
-    SKIP_BOT_LAUNCH: '1'
+    SKIP_BOT_LAUNCH: '1',
+    SKIP_WEBAPP_BUILD: '1'
   };
   const server = await startServer(env);
   try {


### PR DESCRIPTION
## Summary
- don't build the webapp when `SKIP_WEBAPP_BUILD` env var is set
- set `SKIP_WEBAPP_BUILD` in integration tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850325ee3288329afbd7d1226689ef1