### PR TITLE
Fix snake board zoom

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -57,8 +57,8 @@ function Board({ position, highlight, photoUrl, pot }) {
 
   const cellWidth = 100;
   const cellHeight = 50;
-  // Slightly closer camera that zooms in more as the player climbs
-  const zoom = 1.1 + (position / FINAL_TILE) * 0.5;
+  // Zoom out gradually as the player climbs so the top logo stays visible
+  const zoom = 1.6 - (position / FINAL_TILE) * 0.5;
 
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
## Summary
- invert board zoom so the camera zooms out as the player climbs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685039343b248329b93d76602668833f