### PR TITLE
Add dark blue panel to Snake & Ladder board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -193,3 +193,15 @@ body {
   right: -10%;
   transform: rotateY(-40deg) rotateX(-60deg) translateZ(-20px);
 }
+
+/* Dark blue side panel next to the Snake & Ladder board */
+.board-right-panel {
+  @apply absolute bg-blue-900;
+  width: calc(var(--cell-width) * 1.5);
+  height: calc(var(--cell-height) * 5);
+  top: calc(var(--cell-height) * -4.5);
+  right: -20%;
+  transform: rotateY(-40deg) rotateX(-60deg) translateZ(-20px);
+  transform-origin: bottom center;
+  z-index: 3;
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -116,6 +116,7 @@ function Board({ position, highlight, photoUrl, pot }) {
             <div className="logo-wall-main" />
             <div className="logo-wall-side logo-wall-left" />
             <div className="logo-wall-side logo-wall-right" />
+            <div className="board-right-panel" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add dark blue panel style for Snake & Ladder board
- render the panel beside the board

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685047954ad08329b82e3e11fab4dfdd