### PR TITLE
Restore early 3D dice version

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -1,6 +1,5 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
-// Dice face dot matrix
 const diceFaces = {
   1: [
     [0, 0, 0],
@@ -34,20 +33,20 @@ const diceFaces = {
   ],
 };
 
-// Gentle tilt so three faces are visible
-const baseTilt = 'rotateX(-25deg) rotateY(25deg)';
+// Fixed isometric tilt so three faces are always visible
+const baseTilt = 'rotateX(-35deg) rotateY(45deg)';
 
-// Orientation for each numbered face relative to the viewer
-const faceTransforms = {
-  1: `rotateX(0deg) rotateY(0deg) ${baseTilt}`,
-  2: `rotateX(-90deg) rotateY(0deg) ${baseTilt}`,
-  3: `rotateY(90deg) ${baseTilt}`,
-  4: `rotateY(-90deg) ${baseTilt}`,
-  5: `rotateX(90deg) rotateY(0deg) ${baseTilt}`,
-  6: `rotateY(180deg) ${baseTilt}`,
+// Rotation needed to bring each numbered face to the top while keeping
+// the overall isometric camera tilt the same.
+const valueToRotation = {
+  1: 'rotateX(180deg)',  // bottom -> top
+  2: 'rotateZ(-90deg)',  // right -> top
+  3: 'rotateX(0deg)',    // already top
+  4: 'rotateZ(90deg)',   // left -> top
+  5: 'rotateX(-90deg)',  // front -> top
+  6: 'rotateX(90deg)',   // back -> top
 };
 
-// 🎲 Single dice face component
 function Face({ value, className }) {
   const face = diceFaces[value];
   return (
@@ -63,19 +62,10 @@ function Face({ value, className }) {
   );
 }
 
-// 🎲 Single cube component
-function DiceCube({ value = 1, rolling = false, playSound = false, prevValue }) {
-  const displayVal = rolling ? prevValue ?? value : value;
-  // Rotate the cube so the rolled face appears on top while keeping
-  // the overall tilt consistent.
-  const orientation = faceTransforms[displayVal];
-
-  useEffect(() => {
-    if (rolling && playSound) {
-      const audio = new Audio('https://snakes-and-ladders-game.netlify.app/audio/dice.mp3');
-      audio.play().catch(() => {}); // Handle autoplay restrictions gracefully
-    }
-  }, [rolling, playSound]);
+export default function Dice({ value = 1, rolling = false }) {
+  const transform = valueToRotation[value] || 'rotateX(0deg)';
+  // Apply value rotation first, then the common isometric tilt
+  const orientation = `${baseTilt} ${transform}`;
 
   return (
     <div className="dice-container perspective-1000 w-24 h-24">
@@ -83,25 +73,15 @@ function DiceCube({ value = 1, rolling = false, playSound = false, prevValue }) 
         className={`dice-cube relative w-full h-full transition-transform duration-500 transform-style-preserve-3d ${
           rolling ? 'animate-roll' : ''
         }`}
-        style={{ transform: orientation }}
+        style={!rolling ? { transform: orientation } : undefined}
       >
-        <Face value={1} className="dice-face--front absolute" />
+        <Face value={5} className="dice-face--front absolute" />
         <Face value={6} className="dice-face--back absolute" />
-        <Face value={3} className="dice-face--right absolute" />
+        <Face value={2} className="dice-face--right absolute" />
         <Face value={4} className="dice-face--left absolute" />
-        <Face value={2} className="dice-face--top absolute" />
-        <Face value={5} className="dice-face--bottom absolute" />
+        <Face value={3} className="dice-face--top absolute" />
+        <Face value={1} className="dice-face--bottom absolute" />
       </div>
-    </div>
-  );
-}
-
-// 🎲 Pair of dice — default setup
-export default function DicePair({ values = [1, 1], rolling = false, playSound = false, startValues }) {
-  return (
-    <div className="flex gap-4 justify-center items-center">
-      <DiceCube value={values[0]} rolling={rolling} playSound={playSound} prevValue={startValues?.[0]} />
-      <DiceCube value={values[1]} rolling={rolling} playSound={playSound} prevValue={startValues?.[1]} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- revert Dice component to isometric 3D implementation
- remove temporary Dice3D backup file

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685046de6c448329b7e7aa3581423faa