### PR TITLE
Restore constant dice viewpoint

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -1,6 +1,5 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
-// Dice face dot matrix
 const diceFaces = {
   1: [
     [0, 0, 0],
@@ -34,20 +33,10 @@ const diceFaces = {
   ],
 };
 
-// Gentle tilt so three faces are visible
-const baseTilt = 'rotateX(-25deg) rotateY(25deg)';
+// Fixed isometric tilt so three faces are always visible
+const baseTilt = 'rotateX(-35deg) rotateY(45deg)';
 
-// Orientation for each numbered face relative to the viewer
-const faceTransforms = {
-  1: `rotateX(0deg) rotateY(0deg) ${baseTilt}`,
-  2: `rotateX(-90deg) rotateY(0deg) ${baseTilt}`,
-  3: `rotateY(90deg) ${baseTilt}`,
-  4: `rotateY(-90deg) ${baseTilt}`,
-  5: `rotateX(90deg) rotateY(0deg) ${baseTilt}`,
-  6: `rotateY(180deg) ${baseTilt}`,
-};
 
-// 🎲 Single dice face component
 function Face({ value, className }) {
   const face = diceFaces[value];
   return (
@@ -63,19 +52,9 @@ function Face({ value, className }) {
   );
 }
 
-// 🎲 Single cube component
-function DiceCube({ value = 1, rolling = false, playSound = false, prevValue }) {
-  const displayVal = rolling ? prevValue ?? value : value;
-  // Rotate the cube so the rolled face appears on top while keeping
-  // the overall tilt consistent.
-  const orientation = faceTransforms[displayVal];
-
-  useEffect(() => {
-    if (rolling && playSound) {
-      const audio = new Audio('https://snakes-and-ladders-game.netlify.app/audio/dice.mp3');
-      audio.play().catch(() => {}); // Handle autoplay restrictions gracefully
-    }
-  }, [rolling, playSound]);
+export default function Dice({ value = 1, rolling = false }) {
+  // Keep a constant viewing angle regardless of the shown value
+  const orientation = baseTilt;
 
   return (
     <div className="dice-container perspective-1000 w-24 h-24">
@@ -83,25 +62,15 @@ function DiceCube({ value = 1, rolling = false, playSound = false, prevValue }) 
         className={`dice-cube relative w-full h-full transition-transform duration-500 transform-style-preserve-3d ${
           rolling ? 'animate-roll' : ''
         }`}
-        style={{ transform: orientation }}
+        style={!rolling ? { transform: orientation } : undefined}
       >
-        <Face value={1} className="dice-face--front absolute" />
+        <Face value={5} className="dice-face--front absolute" />
         <Face value={6} className="dice-face--back absolute" />
-        <Face value={3} className="dice-face--right absolute" />
+        <Face value={2} className="dice-face--right absolute" />
         <Face value={4} className="dice-face--left absolute" />
-        <Face value={2} className="dice-face--top absolute" />
-        <Face value={5} className="dice-face--bottom absolute" />
+        <Face value={value} className="dice-face--top absolute" />
+        <Face value={7 - value} className="dice-face--bottom absolute" />
       </div>
-    </div>
-  );
-}
-
-// 🎲 Pair of dice — default setup
-export default function DicePair({ values = [1, 1], rolling = false, playSound = false, startValues }) {
-  return (
-    <div className="flex gap-4 justify-center items-center">
-      <DiceCube value={values[0]} rolling={rolling} playSound={playSound} prevValue={startValues?.[0]} />
-      <DiceCube value={values[1]} rolling={rolling} playSound={playSound} prevValue={startValues?.[1]} />
     </div>
   );
 }

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -12,17 +12,13 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
   };
 
   const initial = Array.from({ length: numDice }, rand);
-  const [values, setValues] = useState(initial); // result for next roll
-  const [rollingVals, setRollingVals] = useState(initial); // temp roll visuals
+  const [values, setValues] = useState(initial);
   const [rolling, setRolling] = useState(false);
   const soundRef = useRef(null);
-  const startValuesRef = useRef(initial); // stores values for this roll
 
   useEffect(() => {
     const init = Array.from({ length: numDice }, rand);
     setValues(init);
-    setRollingVals(init);
-    startValuesRef.current = init;
   }, [numDice]);
 
   useEffect(() => {
@@ -41,25 +37,19 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
       soundRef.current.play().catch(() => {});
     }
 
-    // Use current values as fixed starting orientation for the animation
-    startValuesRef.current = values.slice();
+    const result = Array.from({ length: numDice }, rand);
     setRolling(true);
 
     let count = 0;
     const id = setInterval(() => {
-      // Random temp display values during spin
-      setRollingVals(Array.from({ length: numDice }, rand));
+      // show random values during the roll
+      setValues(Array.from({ length: numDice }, rand));
       count += 1;
       if (count >= 20) {
         clearInterval(id);
         setRolling(false);
-        // Restore the original value for consistent final position
-        setRollingVals(startValuesRef.current);
-        onRollEnd && onRollEnd(startValuesRef.current);
-        // Prepare next values for next roll
-        const next = Array.from({ length: numDice }, rand);
-        setValues(next);
-        startValuesRef.current = next.slice();
+        setValues(result);
+        onRollEnd && onRollEnd(result);
       }
     }, 100);
   };
@@ -70,13 +60,8 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
         className={`flex space-x-4 ${clickable ? 'cursor-pointer' : ''}`}
         onClick={clickable ? rollDice : undefined}
       >
-        {rollingVals.map((val, i) => (
-          <Dice
-            key={i}
-            value={val}
-            rolling={rolling}
-            prevValue={startValuesRef.current[i]}
-          />
+        {values.map((val, i) => (
+          <Dice key={i} value={val} rolling={rolling} />
         ))}
       </div>
       {!clickable && (


### PR DESCRIPTION
## Summary
- keep dice orientation fixed instead of rotating to show different faces

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685046de6c448329b7e7aa3581423faa