### PR TITLE
Restore dice orientation consistency from #426

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 
-// Dice face dot matrix
 const diceFaces = {
   1: [
     [0, 0, 0],
@@ -64,12 +63,15 @@ function Face({ value, className }) {
 }
 
 // 🎲 Single cube component
-function DiceCube({ value = 1, rolling = false, playSound = false }) {
-  const orientation = faceTransforms[value] || faceTransforms[1];
+function DiceCube({ value = 1, rolling = false, playSound = false, prevValue }) {
+  const displayVal = rolling ? prevValue ?? value : value;
+  // Rotate the cube so the rolled face appears on top while keeping
+  // the overall tilt consistent.
+  const orientation = faceTransforms[displayVal];
 
   useEffect(() => {
     if (rolling && playSound) {
-      const audio = new Audio('/sounds/dice-roll.mp3');
+      const audio = new Audio('https://snakes-and-ladders-game.netlify.app/audio/dice.mp3');
       audio.play().catch(() => {}); // Handle autoplay restrictions gracefully
     }
   }, [rolling, playSound]);
@@ -80,25 +82,28 @@ function DiceCube({ value = 1, rolling = false, playSound = false }) {
         className={`dice-cube relative w-full h-full transition-transform duration-500 transform-style-preserve-3d ${
           rolling ? 'animate-roll' : ''
         }`}
-        style={!rolling ? { transform: orientation } : undefined}
+        style={{ transform: orientation }}
       >
-        <Face value={1} className="dice-face--front absolute" />
+        {/* Static side faces */}
+        <Face value={5} className="dice-face--front absolute" />
         <Face value={6} className="dice-face--back absolute" />
-        <Face value={3} className="dice-face--right absolute" />
+        <Face value={2} className="dice-face--right absolute" />
         <Face value={4} className="dice-face--left absolute" />
-        <Face value={2} className="dice-face--top absolute" />
-        <Face value={5} className="dice-face--bottom absolute" />
+
+        {/* Top and bottom change dynamically */}
+        <Face value={value} className="dice-face--top absolute" />
+        <Face value={7 - value} className="dice-face--bottom absolute" />
       </div>
     </div>
   );
 }
 
 // 🎲 Pair of dice — default setup
-export default function DicePair({ values = [1, 1], rolling = false, playSound = false }) {
+export default function DicePair({ values = [1, 1], rolling = false, playSound = false, startValues }) {
   return (
     <div className="flex gap-4 justify-center items-center">
-      <DiceCube value={values[0]} rolling={rolling} playSound={playSound} />
-      <DiceCube value={values[1]} rolling={rolling} playSound={playSound} />
+      <DiceCube value={values[0]} rolling={rolling} playSound={playSound} prevValue={startValues?.[0]} />
+      <DiceCube value={values[1]} rolling={rolling} playSound={playSound} prevValue={startValues?.[1]} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- revert earlier revert of dice orientation changes
- ensure dice orientation stays consistent during rolls

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6850692637c88329b647a5e1efc44ca9