### PR TITLE
Refactor dice component for single view

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -33,8 +33,8 @@ const diceFaces = {
   ],
 };
 
-// Gentle tilt so three faces are visible
-const baseTilt = 'rotateX(-25deg) rotateY(25deg)';
+// Fixed isometric tilt so the winning number is clearly visible
+const baseTilt = 'rotateX(-35deg) rotateY(45deg)';
 
 // Orientation for each numbered face relative to the viewer
 const faceTransforms = {
@@ -102,8 +102,8 @@ function DiceCube({ value = 1, rolling = false, playSound = false, prevValue }) 
 export default function DicePair({ values = [1, 1], rolling = false, playSound = false, startValues }) {
   return (
     <div className="flex gap-4 justify-center items-center">
+      {/* Keep only the left dice for a cleaner layout */}
       <DiceCube value={values[0]} rolling={rolling} playSound={playSound} prevValue={startValues?.[0]} />
-      <DiceCube value={values[1]} rolling={rolling} playSound={playSound} prevValue={startValues?.[1]} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- adjust dice orientation to a fixed isometric tilt for clear winning numbers
- display only the left dice cube in `DicePair`

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68506c8b6f548329ae1afb6072b1ae07