### PR TITLE
Improve snake & ladder board visuals

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -193,3 +193,22 @@ body {
   right: -10%;
   transform: rotateY(-40deg) rotateX(-60deg) translateZ(-20px);
 }
+
+.snake-connector,
+.ladder-connector {
+  position: absolute;
+  height: 8px;
+  transform-origin: 0 50%;
+  z-index: 2;
+}
+
+.snake-connector {
+  background: repeating-linear-gradient(45deg, #dc2626 0 10px, #f87171 10px 20px);
+  border-radius: 4px;
+}
+
+.ladder-connector {
+  background-color: #4ade80;
+  border-left: 4px solid #16a34a;
+  border-right: 4px solid #16a34a;
+}


### PR DESCRIPTION
## Summary
- randomize snakes and ladders each game session
- draw connectors between snake/ladder start and end cells
- add styles for connectors

## Testing
- `npm test` *(fails: manifest and lobby route tests due to server not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685073e4bf008329a76594ddc0ca6dc3