### PR TITLE
Fix board icons positions

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -212,3 +212,7 @@ body {
   border-left: 4px solid #16a34a;
   border-right: 4px solid #16a34a;
 }
+
+.board-marker {
+  transform: translateZ(6px);
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -59,10 +59,10 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
         >
           {num}
           {snakes[num] && (
-            <div className="absolute inset-0 flex items-center justify-center text-red-500 text-xl pointer-events-none">🐍</div>
+            <div className="absolute inset-0 flex items-center justify-center text-red-500 text-xl pointer-events-none board-marker">🐍</div>
           )}
           {ladders[num] && (
-            <div className="absolute inset-0 flex items-center justify-center text-green-500 text-xl pointer-events-none">🪜</div>
+            <div className="absolute inset-0 flex items-center justify-center text-green-500 text-xl pointer-events-none board-marker">🪜</div>
           )}
           {position === num && (
             <img src={photoUrl} alt="player" className="token" />
@@ -102,7 +102,7 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
           width: `${length}px`,
           top: `${start.y}px`,
           left: `${start.x}px`,
-          transform: `rotate(${angle}deg)`,
+          transform: `rotate(${angle}deg) translateZ(6px)`,
         }}
       />
     );


### PR DESCRIPTION
## Summary
- lift snake and ladder markers onto the board surface
- ensure snake/ladder connectors render above the board

## Testing
- `npm test --silent` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68507d86058c83299f601e187dcb06fc