### PR TITLE
Improve dice roll speed

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -29,6 +29,7 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
     }
     startValuesRef.current = values;
     setRolling(true);
+
     const rand = () => {
       if (window.crypto && window.crypto.getRandomValues) {
         const arr = new Uint32Array(1);
@@ -38,18 +39,24 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
       return Math.floor(Math.random() * 6) + 1;
     };
 
+    const tick = 50; // ms between face changes
+    const iterations = 19; // show final value just before animation ends
     let count = 0;
+
     const id = setInterval(() => {
       const results = Array.from({ length: numDice }, rand);
       setValues(results);
       count += 1;
-      if (count >= 20) {
+      if (count >= iterations) {
         clearInterval(id);
-        setRolling(false);
-        startValuesRef.current = results;
-        onRollEnd && onRollEnd(results);
+        // allow the final face to be visible before stopping
+        setTimeout(() => {
+          setRolling(false);
+          startValuesRef.current = results;
+          onRollEnd && onRollEnd(results);
+        }, tick);
       }
-    }, 100);
+    }, tick);
   };
 
   return (


### PR DESCRIPTION
## Summary
- speed up dice value changes to match roll animation
- show final face slightly before the roll stops

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68508998fee083298fc00ad7654161d3