### PR TITLE
Lower camera angle for snake game

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -38,11 +38,10 @@ const PLAYERS = 4;
 const ROWS = 25;
 const COLS = 4;
 const FINAL_TILE = ROWS * COLS + 1; // 101
-// Portion of the viewport to keep below the player's token when scrolling
 // Portion of the viewport to keep below the player's token when scrolling.
-// Larger values track the player from a lower angle giving more focus on the
-// logo placed at the top of the board.
-const CAMERA_OFFSET = 0.85;
+// Larger values keep the token closer to the bottom so the board follows
+// the user row by row from a fixed camera position.
+const CAMERA_OFFSET = 0.9;
 
 function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
   const containerRef = useRef(null);
@@ -117,12 +116,11 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
   for (const [s, e] of Object.entries(snakes)) {
     connectors.push(renderConnector(Number(s), Number(e), 'snake'));
   }
-  // Zoom in progressively as the player moves upward so that the logo at the
-  // top of the board stays roughly the same size in the viewport. The closer
-  // the user is to the pot, the more we scale the board.
-  const MIN_ZOOM = 1.1;
-  const MAX_ZOOM = 1.8;
-  const zoom = MIN_ZOOM + (position / FINAL_TILE) * (MAX_ZOOM - MIN_ZOOM);
+  // Use a fixed zoom level so the camera angle stays locked while the board
+  // follows the player every row.
+  const MIN_ZOOM = 1.3;
+  const MAX_ZOOM = 1.3;
+  const zoom = MIN_ZOOM;
 
   useEffect(() => {
     const container = containerRef.current;
@@ -165,8 +163,8 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
               gridTemplateRows: `repeat(${ROWS}, ${cellHeight}px)`,
               '--cell-width': `${cellWidth}px`,
               '--cell-height': `${cellHeight}px`,
-              // Lower camera angle focused on the logo wall
-              transform: `rotateX(80deg) scale(${zoom})`,
+              // Lower camera angle and lock it to follow the player
+              transform: `rotateX(60deg) scale(${zoom})`,
             }}
           >
             {tiles}


### PR DESCRIPTION
## Summary
- adjust camera offset to keep player tokens near the bottom
- lock zoom level and set a lower board angle

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68508a3adc3083299f5a0c303fcccbff