### PR TITLE
Improve dice face randomness

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 
 const diceFaces = {
   1: [
@@ -73,9 +73,7 @@ function DiceCube({
     return Math.floor(Math.random() * 6) + 1;
   };
 
-  const [sides, setSides] = useState([2, 4]);
-
-  useEffect(() => {
+  const sides = useMemo(() => {
     const used = new Set([value]);
     let front = rand();
     while (used.has(front)) {
@@ -86,7 +84,7 @@ function DiceCube({
     while (used.has(right)) {
       right = rand();
     }
-    setSides([front, right]);
+    return [front, right];
   }, [value]);
 
   useEffect(() => {

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -29,6 +29,7 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
     }
     startValuesRef.current = values;
     setRolling(true);
+
     const rand = () => {
       if (window.crypto && window.crypto.getRandomValues) {
         const arr = new Uint32Array(1);
@@ -38,18 +39,24 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
       return Math.floor(Math.random() * 6) + 1;
     };
 
+    const tick = 50; // ms between face changes
+    const iterations = 19; // show final value just before animation ends
     let count = 0;
+
     const id = setInterval(() => {
       const results = Array.from({ length: numDice }, rand);
       setValues(results);
       count += 1;
-      if (count >= 20) {
+      if (count >= iterations) {
         clearInterval(id);
-        setRolling(false);
-        startValuesRef.current = results;
-        onRollEnd && onRollEnd(results);
+        // allow the final face to be visible before stopping
+        setTimeout(() => {
+          setRolling(false);
+          startValuesRef.current = results;
+          onRollEnd && onRollEnd(results);
+        }, tick);
       }
-    }, 100);
+    }, tick);
   };
 
   return (


### PR DESCRIPTION
## Summary
- guarantee dice side values are recalculated immediately when the top value changes

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68508998fee083298fc00ad7654161d3