### PR TITLE
Enhance snake board camera effects

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -5,6 +5,8 @@
 :root {
   --cell-width: 135px;
   --cell-height: 68px;
+  /* Perspective distance controlling the apparent field of view */
+  --snake-board-perspective: 1000px;
 }
 
 body {
@@ -53,13 +55,26 @@ body {
 
 /* Tilted view specifically for the Snake & Ladder board */
 .snake-board-tilt {
-  perspective: 1200px;
+  perspective: var(--snake-board-perspective);
+  perspective-origin: center top;
 }
 
 .snake-board-grid {
   transform-style: preserve-3d;
   transform-origin: bottom center;
   transition: transform 0.3s ease; /* ✅ scaling transition */
+  position: relative;
+}
+
+.snake-board-grid::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.3), rgba(0, 0, 0, 0) 70%);
+  mix-blend-mode: overlay;
+  opacity: 0.5;
+  transform: translateZ(1px);
 }
 
 @keyframes roll {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -116,11 +116,18 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
   for (const [s, e] of Object.entries(snakes)) {
     connectors.push(renderConnector(Number(s), Number(e), 'snake'));
   }
-  // Use a fixed zoom level so the camera angle stays locked while the board
-  // follows the player every row.
+  // Base camera zoom to keep a consistent angle on the board
   const MIN_ZOOM = 1.3;
-  const MAX_ZOOM = 1.3;
-  const zoom = MIN_ZOOM;
+  const MAX_ZOOM = 1.35;
+  const [zoom, setZoom] = useState(MIN_ZOOM);
+
+  // Briefly zoom in on each movement for a dynamic feel
+  useEffect(() => {
+    if (highlight === null) return;
+    setZoom(MAX_ZOOM);
+    const id = setTimeout(() => setZoom(MIN_ZOOM), 300);
+    return () => clearTimeout(id);
+  }, [highlight]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -164,7 +171,7 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
               '--cell-width': `${cellWidth}px`,
               '--cell-height': `${cellHeight}px`,
               // Lower camera angle and lock it to follow the player
-              transform: `rotateX(60deg) scale(${zoom})`,
+              transform: `translateY(-20px) translateZ(-15px) rotateX(60deg) scale(${zoom})`,
             }}
           >
             {tiles}


### PR DESCRIPTION
## Summary
- add perspective variable for board view
- implement lighting overlay on the board
- tweak Snake & Ladder board transform to mimic camera position
- zoom board slightly during movement

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6850915554048329894a80a6be616b37