### PR TITLE
Enhance snake game tile highlights

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -137,8 +137,39 @@ body {
   transform: translateZ(10px);
 }
 
-.board-cell.highlight {
-  box-shadow: 0 0 10px 4px rgba(250, 204, 21, 0.8);
+@keyframes lightning {
+  0% {
+    box-shadow: 0 0 10px 4px var(--highlight-color);
+  }
+  50% {
+    box-shadow: 0 0 20px 8px var(--highlight-color);
+  }
+  100% {
+    box-shadow: 0 0 10px 4px var(--highlight-color);
+  }
+}
+
+.board-cell.highlight-yellow,
+.board-cell.highlight-red,
+.board-cell.highlight-green {
+  animation: lightning 0.5s ease-out;
+  background-color: var(--highlight-bg);
+  box-shadow: 0 0 10px 4px var(--highlight-color);
+}
+
+.board-cell.highlight-yellow {
+  --highlight-color: rgba(250, 204, 21, 0.9);
+  --highlight-bg: rgba(250, 204, 21, 0.2);
+}
+
+.board-cell.highlight-red {
+  --highlight-color: rgba(220, 38, 38, 0.9);
+  --highlight-bg: rgba(220, 38, 38, 0.2);
+}
+
+.board-cell.highlight-green {
+  --highlight-color: rgba(34, 197, 94, 0.9);
+  --highlight-bg: rgba(34, 197, 94, 0.2);
 }
 
 .pot-cell {
@@ -152,8 +183,23 @@ body {
   z-index: 10;
 }
 
-.pot-cell.highlight {
-  box-shadow: 0 0 10px 4px rgba(250, 204, 21, 0.8);
+.pot-cell.highlight-yellow,
+.pot-cell.highlight-red,
+.pot-cell.highlight-green {
+  animation: lightning 0.5s ease-out;
+  box-shadow: 0 0 10px 4px var(--highlight-color);
+}
+
+.pot-cell.highlight-yellow {
+  --highlight-color: rgba(250, 204, 21, 0.9);
+}
+
+.pot-cell.highlight-red {
+  --highlight-color: rgba(220, 38, 38, 0.9);
+}
+
+.pot-cell.highlight-green {
+  --highlight-color: rgba(34, 197, 94, 0.9);
 }
 
 .logo-wall-main {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -54,11 +54,16 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
     for (let c = 0; c < COLS; c++) {
       const col = reversed ? COLS - 1 - c : c;
       const num = r * COLS + col + 1;
+      const highlightClass =
+        highlight && highlight.cell === num
+          ? `highlight-${highlight.type}`
+          : "";
+
       tiles.push(
         <div
           key={num}
           data-cell={num}
-          className={`board-cell ${highlight === num ? "highlight" : ""}`}
+          className={`board-cell ${highlightClass}`}
           style={{ gridRowStart: ROWS - r, gridColumnStart: col + 1 }}
         >
           {num}
@@ -172,7 +177,7 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
           >
             {tiles}
             {connectors}
-            <div className={`pot-cell ${highlight === FINAL_TILE ? 'highlight' : ''}`}>
+            <div className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? `highlight-${highlight.type}` : ''}`}>
               <span className="font-bold">Pot</span>
               <span className="text-sm">{pot}</span>
               {position === FINAL_TILE && (
@@ -259,29 +264,28 @@ export default function SnakeAndLadder() {
     const move = (index) => {
       if (index >= steps.length) {
         let finalPos = steps[steps.length - 1] || current;
-        let snake = false;
-        let ladder = false;
+        let type = 'normal';
 
         if (ladders[finalPos]) {
           finalPos = ladders[finalPos];
-          ladder = true;
-        }
-        if (snakes[finalPos]) {
+          type = 'ladder';
+        } else if (snakes[finalPos]) {
           finalPos = snakes[finalPos];
-          snake = true;
+          type = 'snake';
         }
 
+        setHighlight({ cell: finalPos, type });
         setTimeout(() => {
           setPos(finalPos);
-          setHighlight(null);
           if (finalPos === FINAL_TILE) {
             setMessage(`You win ${pot} tokens!`);
             winSoundRef.current?.play().catch(() => {});
-          } else if (ladder) {
+          } else if (type === 'ladder') {
             ladderSoundRef.current?.play().catch(() => {});
-          } else if (snake) {
+          } else if (type === 'snake') {
             snakeSoundRef.current?.play().catch(() => {});
           }
+          setTimeout(() => setHighlight(null), 400);
         }, 300);
         return;
       }
@@ -290,7 +294,7 @@ export default function SnakeAndLadder() {
       setPos(next);
       moveSoundRef.current.currentTime = 0;
       moveSoundRef.current.play().catch(() => {});
-      setHighlight(next);
+      setHighlight({ cell: next, type: 'normal' });
       setTimeout(() => move(index + 1), 300);
     };
 


### PR DESCRIPTION
## Summary
- show colored lightning effects when landing on tiles
- apply new highlight styles for the pot as well

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68509eb9a97483298837495cde27f69b