### PR TITLE
Update snake graphics using inline SVG

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -249,7 +249,9 @@ body {
 }
 
 .snake-connector {
-  background: repeating-linear-gradient(45deg, #dc2626 0 10px, #f87171 10px 20px);
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+CiAgPHBhdGggZD0iTTEyIDE2YzgtOCAxNi04IDI0IDBzMTYgOCAyNCAwIiBzdHJva2U9IiMxNmEzNGEiIHN0cm9rZS13aWR0aD0iNCIgZmlsbD0ibm9uZSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+CiAgPHBhdGggZD0iTTYwIDQ4Yy04IDgtMTYgOC0yNCAwcy0xNi04LTI0IDAiIHN0cm9rZT0iIzE2YTM0YSIgc3Ryb2tlLXdpZHRoPSI0IiBmaWxsPSJub25lIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICA8Y2lyY2xlIGN4PSI1NiIgY3k9IjE2IiByPSI0IiBmaWxsPSIjZGMyNjI2Ii8+Cjwvc3ZnPg==');
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
   border-radius: 4px;
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -69,7 +69,26 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
         >
           {num}
           {snakes[num] && (
-            <div className="absolute inset-0 flex items-center justify-center text-red-500 text-xl pointer-events-none board-marker">🐍</div>
+            <svg
+              viewBox="0 0 64 64"
+              className="absolute inset-0 pointer-events-none board-marker"
+            >
+              <path
+                d="M12 16c8-8 16-8 24 0s16 8 24 0"
+                stroke="#16a34a"
+                strokeWidth="4"
+                fill="none"
+                strokeLinecap="round"
+              />
+              <path
+                d="M60 48c-8 8-16 8-24 0s-16-8-24 0"
+                stroke="#16a34a"
+                strokeWidth="4"
+                fill="none"
+                strokeLinecap="round"
+              />
+              <circle cx="56" cy="16" r="4" fill="#dc2626" />
+            </svg>
           )}
           {ladders[num] && (
             <div className="absolute inset-0 flex items-center justify-center text-green-500 text-xl pointer-events-none board-marker">🪜</div>


### PR DESCRIPTION
## Summary
- replace the snake image file with an inline SVG marker
- embed the same SVG as a data URI for connector backgrounds

## Testing
- `npm test` *(fails: manifest and lobby endpoints not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6850a2ff635c8329b5ab679e46fa5a35