### PR TITLE
Adjust Snake & Ladder board size

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -204,7 +204,7 @@ body {
 
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 5); /* bigger width */
+  width: var(--board-width); /* match board width */
   height: calc(var(--cell-height) * 5); /* bigger height */
   top: calc(var(--cell-height) * -4.5); /* ✅ push above pot */
   left: 50%;
@@ -219,7 +219,7 @@ body {
 
 .logo-wall-side {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 4);
+  width: calc(var(--board-width) * 0.8);
   height: calc(var(--cell-height) * 4);
   top: calc(var(--cell-height) * -4.5);
   background-image: url('/assets/TonPlayGramLogo.jpg');

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -82,9 +82,21 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
     }
   }
 
-  // Slightly smaller cells to fit five rows on screen
-  const cellWidth = 80;
-  const cellHeight = 40;
+  // Scale board based on viewport width so it fills the screen.
+  const [cellWidth, setCellWidth] = useState(80);
+  const [cellHeight, setCellHeight] = useState(40);
+
+  useEffect(() => {
+    const updateSize = () => {
+      const width = window.innerWidth;
+      const cw = Math.floor(width / COLS);
+      setCellWidth(cw);
+      setCellHeight(Math.floor(cw / 2));
+    };
+    updateSize();
+    window.addEventListener('resize', updateSize);
+    return () => window.removeEventListener('resize', updateSize);
+  }, []);
 
   const connectors = [];
 
@@ -127,10 +139,10 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
   }
   // Dynamically adjust zoom and camera tilt based on how far the player
   // has progressed. This keeps the logo in focus while following the token.
-  const MIN_ZOOM = 1.1;
-  const MAX_ZOOM = 1.4;
-  const MIN_ANGLE = 60;
-  const MAX_ANGLE = 45;
+  const MIN_ZOOM = 0.9; // board slightly smaller at the bottom
+  const MAX_ZOOM = 1.5; // and larger when reaching the top
+  const MIN_ANGLE = 65;
+  const MAX_ANGLE = 40;
 
   const rowFromBottom = Math.floor(Math.max(position - 1, 0) / COLS);
   const progress = Math.min(1, rowFromBottom / (ROWS - 1));
@@ -179,6 +191,7 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
               gridTemplateRows: `repeat(${ROWS}, ${cellHeight}px)`,
               '--cell-width': `${cellWidth}px`,
               '--cell-height': `${cellHeight}px`,
+              '--board-width': `${cellWidth * COLS}px`,
               // Lower camera angle and zoom dynamically as the player moves
               transform: `rotateX(${angle}deg) scale(${zoom})`,
             }}


### PR DESCRIPTION
## Summary
- scale the Snake & Ladder board based on viewport width
- enlarge the board as the player progresses
- make the top logo fill the board width

## Testing
- `npm test` *(fails: manifest and lobby routes not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6850a40a48708329b783dd3ddb519ed9