### PR TITLE
Add board cell color feedback

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -141,6 +141,18 @@ body {
   box-shadow: 0 0 10px 4px rgba(250, 204, 21, 0.8);
 }
 
+.board-cell.normal-highlight {
+  background-color: #fde047; /* yellow-300 */
+}
+
+.board-cell.ladder-highlight {
+  background-color: #86efac; /* green-300 */
+}
+
+.board-cell.snake-highlight {
+  background-color: #fca5a5; /* red-300 */
+}
+
 .pot-cell {
   @apply absolute flex flex-col items-center justify-center hexagon bg-primary text-background border-2 border-accent;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -55,11 +55,13 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
     for (let c = 0; c < COLS; c++) {
       const col = reversed ? COLS - 1 - c : c;
       const num = r * COLS + col + 1;
+      const isHighlight = highlight && highlight.cell === num;
+      const highlightClass = isHighlight ? `${highlight.type}-highlight` : "";
       tiles.push(
         <div
           key={num}
           data-cell={num}
-          className={`board-cell ${highlight === num ? "highlight" : ""}`}
+          className={`board-cell ${highlightClass}`}
           style={{ gridRowStart: ROWS - r, gridColumnStart: col + 1 }}
         >
           {num}
@@ -212,7 +214,7 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
           >
             {tiles}
             {connectors}
-            <div className={`pot-cell ${highlight === FINAL_TILE ? 'highlight' : ''}`}>
+            <div className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? 'highlight' : ''}`}>
               <span className="font-bold">Pot</span>
               <span className="text-sm">{pot}</span>
               {position === FINAL_TILE && (
@@ -233,7 +235,7 @@ export default function SnakeAndLadder() {
   useTelegramBackButton();
   const [pos, setPos] = useState(0);
   const [streak, setStreak] = useState(0);
-  const [highlight, setHighlight] = useState(null);
+  const [highlight, setHighlight] = useState(null); // { cell: number, type: string }
   const [message, setMessage] = useState("");
   const [photoUrl, setPhotoUrl] = useState("");
   const [pot, setPot] = useState(100);
@@ -330,7 +332,8 @@ export default function SnakeAndLadder() {
       setPos(next);
       moveSoundRef.current.currentTime = 0;
       moveSoundRef.current.play().catch(() => {});
-      setHighlight(next);
+      const type = ladders[next] ? 'ladder' : snakes[next] ? 'snake' : 'normal';
+      setHighlight({ cell: next, type });
       setTimeout(() => move(index + 1), 300);
     };
 


### PR DESCRIPTION
## Summary
- color board cells when stepped on
- highlight ladders and snakes with green/red

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68510cfac8e483299daca47f041bd47d