### PR TITLE
Adjust board logo

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -158,11 +158,11 @@ body {
 
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 7.2); /* 20% wider */
-  height: calc(var(--cell-height) * 6); /* 20% taller */
-  top: calc(var(--cell-height) * -4.5); /* ✅ push above pot */
+  width: calc(var(--cell-width) * 8); /* slightly wider */
+  height: calc(var(--cell-height) * 7); /* slightly taller */
+  top: calc(var(--cell-height) * -7); /* align bottom with board top */
   left: 50%;
-  transform: translateX(-50%) rotateX(-60deg) translateZ(-20px); /* ✅ behind the pot */
+  transform: translateX(-50%) rotateX(-60deg) translateZ(-20px);
   transform-origin: bottom center;
   background-image: url('/assets/TonPlayGramLogo.jpg');
   background-size: contain;
@@ -173,9 +173,9 @@ body {
 
 .logo-wall-side {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--board-width) * 0.96); /* 20% wider */
-  height: calc(var(--cell-height) * 4.8); /* 20% taller */
-  top: calc(var(--cell-height) * -4.5);
+  width: calc(var(--board-width) * 1.2); /* slightly wider */
+  height: calc(var(--cell-height) * 7); /* slightly taller */
+  top: calc(var(--cell-height) * -7); /* align bottom with board top */
   background-image: url('/assets/TonPlayGramLogo.jpg');
   background-size: contain;
   background-repeat: no-repeat;


### PR DESCRIPTION
## Summary
- tweak TonPlayGram logo panel sizes
- align logo with top row of the Snake & Ladder board

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68510d5963fc832999a508167957fa83