### PR TITLE
Extend test retry loops

### DIFF
--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -8,7 +8,10 @@ import { runInNewContext } from 'vm';
 const distDir = new URL('../webapp/dist/', import.meta.url);
 
 async function startServer(env) {
-  return spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  return server;
 }
 
 test('server exposes manifest endpoint from TONCONNECT_MANIFEST_URL', async () => {
@@ -25,7 +28,7 @@ test('server exposes manifest endpoint from TONCONNECT_MANIFEST_URL', async () =
   };
   const server = await startServer(env);
   try {
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 100; i++) {
       try {
         const res = await fetch('http://localhost:3100/test-manifest.json');
         if (res.ok) {

--- a/test/snakeLobbyRoute.test.js
+++ b/test/snakeLobbyRoute.test.js
@@ -7,7 +7,10 @@ import { setTimeout as delay } from 'timers/promises';
 const distDir = new URL('../webapp/dist/', import.meta.url);
 
 async function startServer(env) {
-  return spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  return server;
 }
 
 test('snake lobby route lists players', async () => {
@@ -23,7 +26,7 @@ test('snake lobby route lists players', async () => {
   };
   const server = await startServer(env);
   try {
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 100; i++) {
       try {
         const res = await fetch('http://localhost:3200/api/snake/lobby/snake-2');
         if (res.ok) {


### PR DESCRIPTION
## Summary
- keep server output visible in manifest and lobby route tests
- retry the manifest and snake lobby requests for ~10s

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL; snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_685111ca79b48329a254a45c1146d217