### PR TITLE
Restore lobby start checks

### DIFF
--- a/test/lobbyUtils.test.js
+++ b/test/lobbyUtils.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { canStartGame } from '../webapp/src/utils/lobby.js';
+
+const dummyTable = { id: 't1' };
+
+test('cannot start without stake', () => {
+  assert.equal(canStartGame('snake', dummyTable, { token: '', amount: 0 }), false);
+});
+
+test('cannot start without table when required', () => {
+  assert.equal(canStartGame('snake', null, { token: 'TON', amount: 100 }), false);
+});
+
+test('can start when table and stake present', () => {
+  assert.equal(canStartGame('snake', dummyTable, { token: 'TON', amount: 100 }), true);
+});

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -4,6 +4,7 @@ import TableSelector from '../../components/TableSelector.jsx';
 import RoomSelector from '../../components/RoomSelector.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { getSnakeLobbies, getSnakeLobby } from '../../utils/api.js';
+import { canStartGame } from '../../utils/lobby.js';
 
 export default function Lobby() {
   const { game } = useParams();
@@ -63,8 +64,7 @@ export default function Lobby() {
     navigate(`/games/${game}?${params.toString()}`);
   };
 
-  // Allow starting the game without fulfilling lobby requirements while testing
-  const disabled = false; // TODO: restore lobby checks when done testing
+  const disabled = !canStartGame(game, table, stake);
 
   return (
     <div className="p-4 space-y-4 text-text">

--- a/webapp/src/utils/lobby.js
+++ b/webapp/src/utils/lobby.js
@@ -1,0 +1,5 @@
+export function canStartGame(game, table, stake) {
+  if (!stake || !stake.token || !stake.amount) return false;
+  if (game === 'snake' && !table) return false;
+  return true;
+}


### PR DESCRIPTION
## Summary
- add `canStartGame` utility to check stake and table selection
- use `canStartGame` to enable/disable the Start Game button
- add unit tests for lobby start conditions

## Testing
- `npm test` *(fails: manifest and snake lobby route tests because web server couldn't start)*

------
https://chatgpt.com/codex/tasks/task_e_685111cecf4c832997ae530df280d307