### PR TITLE
Remove small snake markers and enlarge ladders

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -209,7 +209,7 @@ body {
 .snake-connector,
 .ladder-connector {
   position: absolute;
-  height: 8px;
+  height: 12px;
   transform-origin: 0 50%;
   z-index: 2;
 }
@@ -223,8 +223,8 @@ body {
 
 .ladder-connector {
   background-color: #4ade80;
-  border-left: 4px solid #16a34a;
-  border-right: 4px solid #16a34a;
+  border-left: 6px solid #16a34a;
+  border-right: 6px solid #16a34a;
 }
 
 .board-marker {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -38,30 +38,8 @@ function Board({ position, highlight, photoUrl, pot, snakes, ladders }) {
           style={{ gridRowStart: ROWS - r, gridColumnStart: col + 1 }}
         >
           {num}
-          {snakes[num] && (
-            <svg
-              viewBox="0 0 64 64"
-              className="absolute inset-0 pointer-events-none board-marker"
-            >
-              <path
-                d="M12 16c8-8 16-8 24 0s16 8 24 0"
-                stroke="#16a34a"
-                strokeWidth="4"
-                fill="none"
-                strokeLinecap="round"
-              />
-              <path
-                d="M60 48c-8 8-16 8-24 0s-16-8-24 0"
-                stroke="#16a34a"
-                strokeWidth="4"
-                fill="none"
-                strokeLinecap="round"
-              />
-              <circle cx="56" cy="16" r="4" fill="#dc2626" />
-            </svg>
-          )}
           {ladders[num] && (
-            <div className="absolute inset-0 flex items-center justify-center text-green-500 text-xl pointer-events-none board-marker">🪜</div>
+            <div className="absolute inset-0 flex items-center justify-center text-green-500 text-3xl pointer-events-none board-marker">🪜</div>
           )}
           {position === num && (
             <img src={photoUrl} alt="player" className="token" />


### PR DESCRIPTION
## Summary
- clean up board markers in the Snake & Ladder board
- enlarge ladder icon and connectors

## Testing
- `npm test` *(fails: manifest endpoint/lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851169824d08329ae9191831558a87c