### PR TITLE
Implement final ranking popup for Ludo

### DIFF
--- a/webapp/src/components/GameEndPopup.jsx
+++ b/webapp/src/components/GameEndPopup.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export default function GameEndPopup({ open, ranking, onPlayAgain, onReturn }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
+      <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
+        <img src="/assets/TonPlayGramLogo.jpg" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
+        <h3 className="text-lg font-bold text-center">Game Over</h3>
+        <ol className="list-decimal list-inside space-y-1 text-center">
+          {ranking.map((name, i) => (
+            <li key={i}>{name}</li>
+          ))}
+        </ol>
+        <div className="flex gap-2">
+          <button onClick={onPlayAgain} className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded">
+            Play Again
+          </button>
+          <button onClick={onReturn} className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded">
+            Return to Lobby
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/LudoGame.jsx
+++ b/webapp/src/pages/Games/LudoGame.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import { Ludo } from '@ayshrj/ludo.js';
+import { useNavigate } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import GameEndPopup from '../../components/GameEndPopup.jsx';
 
 const COLOR_MAP = {
   red: '#FF0000',
@@ -176,6 +178,7 @@ function LudoBoard({ game, state }) {
 
 export default function LudoGame() {
   useTelegramBackButton();
+  const navigate = useNavigate();
   const [ludo] = useState(() => new Ludo(4));
   const [gameState, setGameState] = useState(ludo.getCurrentState());
 
@@ -186,10 +189,28 @@ export default function LudoGame() {
     return () => ludo.off('stateChange', handler);
   }, [ludo]);
 
+  const gameOver =
+    gameState.ranking.length === gameState.players.length &&
+    gameState.players.length > 0;
+
+  const handlePlayAgain = () => {
+    ludo.reset();
+  };
+
+  const handleReturn = () => {
+    navigate('/games/ludo/lobby');
+  };
+
   return (
     <div className="p-4 space-y-4 text-text">
       <h2 className="text-xl font-bold">Ludo Game</h2>
       <LudoBoard game={ludo} state={gameState} />
+      <GameEndPopup
+        open={gameOver}
+        ranking={gameState.ranking}
+        onPlayAgain={handlePlayAgain}
+        onReturn={handleReturn}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `GameEndPopup` component for showing rankings
- display popup in `LudoGame` when match ends

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68511dbad2c083298a4de51c8bccb918