### PR TITLE
Add snake icons on board

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -75,6 +75,11 @@ function Board({
               🪜
             </div>
           )}
+          {snakes[num] && (
+            <div className="absolute inset-0 flex items-center justify-center text-red-500 text-3xl pointer-events-none board-marker">
+              🐍
+            </div>
+          )}
           {position === num && (
             <img src={photoUrl} alt="player" className="token" />
           )}


### PR DESCRIPTION
## Summary
- show snake markers on the Snake & Ladder board

## Testing
- `npm test` *(fails: manifest endpoint and lobby route unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68512f9f71e08329bdd1c1cbc61fba09