### PR TITLE
Add angled hexagon token for snake board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -137,6 +137,52 @@ body {
   transform: translateZ(10px);
 }
 
+.token-cylinder {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: calc(var(--cell-width) * 0.8);
+  height: calc(var(--cell-width) * 0.8);
+  transform-style: preserve-3d;
+  transform: translate(-50%, -50%) rotateX(var(--board-angle)) translateZ(10px);
+}
+
+.token-cylinder::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  height: calc(var(--cell-height) * 0.25);
+  background: #d1d5db;
+  clip-path: polygon(25% 0%, 75% 0%, 100% 100%, 0% 100%);
+  transform-origin: top;
+  transform: rotateX(90deg);
+}
+
+.token-top {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
+  border: 2px solid #facc15;
+  border-radius: 8px;
+}
+
+.token-side {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: calc(var(--cell-width) * 0.8);
+  height: calc(var(--cell-height) * 0.25);
+  background: #d1d5db;
+  transform-origin: center top;
+  transform: rotateX(90deg)
+    rotateY(calc(var(--i) * 60deg))
+    translateZ(calc(var(--cell-width) * 0.4));
+}
+
 .board-cell.highlight {
   box-shadow: 0 0 10px 4px rgba(250, 204, 21, 0.8);
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -42,6 +42,18 @@ function CoinBurst({ token }) {
   );
 }
 
+function TokenCylinder({ photoUrl }) {
+  const sides = Array.from({ length: 6 });
+  return (
+    <div className="token-cylinder">
+      {sides.map((_, i) => (
+        <div key={i} className="token-side" style={{ "--i": i }} />
+      ))}
+      <img src={photoUrl} alt="player" className="token-top" />
+    </div>
+  );
+}
+
 function Board({
   position,
   highlight,
@@ -71,9 +83,7 @@ function Board({
         >
           {num}
           {/* ladder markers removed */}
-          {position === num && (
-            <img src={photoUrl} alt="player" className="token" />
-          )}
+          {position === num && <TokenCylinder photoUrl={photoUrl} />}
         </div>,
       );
     }
@@ -199,6 +209,7 @@ function Board({
               "--cell-width": `${cellWidth}px`,
               "--cell-height": `${cellHeight}px`,
               "--board-width": `${cellWidth * COLS}px`,
+              "--board-angle": `${angle}deg`,
               // Lower camera angle and zoom dynamically as the player moves
               transform: `rotateX(${angle}deg) scale(${zoom})`,
             }}
@@ -210,9 +221,7 @@ function Board({
             >
               <span className="font-bold">Pot</span>
               <span className="text-sm">{pot}</span>
-              {position === FINAL_TILE && (
-                <img src={photoUrl} alt="player" className="token" />
-              )}
+              {position === FINAL_TILE && <TokenCylinder photoUrl={photoUrl} />}
               {celebrate && <CoinBurst token={token} />}
             </div>
             <div className="logo-wall-main" />


### PR DESCRIPTION
## Summary
- add `TokenCylinder` component to render player photo in 3D hexagon
- rotate token using `--board-angle` so it sits on the board plane
- style new hexagon cylinder in CSS

## Testing
- `npm test` *(fails: `manifest endpoint not reachable`, `lobby route not reachable`)*

------
https://chatgpt.com/codex/tasks/task_e_685133f94f208329bc35067fefabc32b