### PR TITLE
Add leave button to Snake game

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3,6 +3,7 @@ import DiceRoller from "../../components/DiceRoller.jsx";
 import InfoPopup from "../../components/InfoPopup.jsx";
 import { AiOutlineInfoCircle } from "react-icons/ai";
 import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
+import { useNavigate } from "react-router-dom";
 import { getTelegramPhotoUrl } from "../../utils/telegram.js";
 import { getSnakeBoard } from "../../utils/api.js";
 
@@ -227,6 +228,10 @@ function Board({
 
 export default function SnakeAndLadder() {
   useTelegramBackButton();
+  const navigate = useNavigate();
+  const handleLeave = () => {
+    navigate('/games/snake/lobby');
+  };
   const [pos, setPos] = useState(0);
   const [streak, setStreak] = useState(0);
   const [highlight, setHighlight] = useState(null); // { cell: number, type: string }
@@ -367,6 +372,12 @@ export default function SnakeAndLadder() {
         onClick={() => setShowInfo(true)}
       >
         <AiOutlineInfoCircle className="text-2xl" />
+      </button>
+      <button
+        className="absolute top-8 right-0 p-1 text-xs bg-primary text-white rounded"
+        onClick={handleLeave}
+      >
+        Leave
       </button>
       <Board
         position={pos}


### PR DESCRIPTION
## Summary
- allow navigation back to the lobby from Snake game
- wire button press to navigate away

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68513328b9ec83298c8bf536755e2bbc