### PR TITLE
Reduce dice size

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -97,7 +97,7 @@ function DiceCube({
   }, [rolling, playSound]);
 
   return (
-    <div className="dice-container perspective-1000 w-24 h-24">
+    <div className="dice-container perspective-1000 w-20 h-20">
       <div
         className={`dice-cube relative w-full h-full transition-transform duration-500 transform-style-preserve-3d ${
           rolling ? "animate-roll" : ""

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -83,7 +83,7 @@ body {
 }
 
 .dice-cube {
-  @apply relative w-16 h-16;
+  @apply relative w-12 h-12;
   transform-style: preserve-3d;
   transition: transform 0.5s;
 }
@@ -93,26 +93,26 @@ body {
 }
 
 .dice-face .dot {
-  @apply w-4 h-4 bg-black rounded-full;
+  @apply w-3 h-3 bg-black rounded-full;
 }
 
 .dice-face--front {
-  transform: rotateY(0deg) translateZ(2rem);
+  transform: rotateY(0deg) translateZ(1.5rem);
 }
 .dice-face--back {
-  transform: rotateY(180deg) translateZ(2rem);
+  transform: rotateY(180deg) translateZ(1.5rem);
 }
 .dice-face--right {
-  transform: rotateY(90deg) translateZ(2rem);
+  transform: rotateY(90deg) translateZ(1.5rem);
 }
 .dice-face--left {
-  transform: rotateY(-90deg) translateZ(2rem);
+  transform: rotateY(-90deg) translateZ(1.5rem);
 }
 .dice-face--top {
-  transform: rotateX(90deg) translateZ(2rem);
+  transform: rotateX(90deg) translateZ(1.5rem);
 }
 .dice-face--bottom {
-  transform: rotateX(-90deg) translateZ(2rem);
+  transform: rotateX(-90deg) translateZ(1.5rem);
 }
 
 .board-cell {
@@ -144,7 +144,7 @@ body {
   height: 4rem;
   transform-style: preserve-3d;
   transform: translateZ(10px);
-  --cyl-h: 2rem; /* half of dice size */
+  --cyl-h: 1.5rem; /* half of dice size */
   --token-radius: 2rem;
   --cyl-apothem: calc(var(--token-radius) * 0.866); /* distance from center */
 }


### PR DESCRIPTION
## Summary
- shrink the dice cube and dots
- reduce translation distances for smaller cube size
- scale the player token cylinder height
- update dice container size in Dice component

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851480238848329a8b649840315168d