### PR TITLE
Fix dice cube background

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -83,7 +83,7 @@ body {
 }
 
 .dice-cube {
-  @apply relative w-12 h-12;
+  @apply relative w-12 h-12 bg-white rounded-xl;
   transform-style: preserve-3d;
   transition: transform 0.5s;
 }


### PR DESCRIPTION
## Summary
- ensure dice cubes have a white background so transparent corners appear white

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68514eb9a2b88329a1b9416e584beb63