### PR TITLE
Add base hexagon to snake token

### DIFF
--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -15,6 +15,7 @@ export default function PlayerToken({ photoUrl, type = 'normal', color }) {
         <div className="hex-side side-5" />
         <div className="hex-side side-6" />
       </div>
+      <div className="token-base" />
     </div>
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -160,6 +160,16 @@ body {
   transform: translateZ(var(--cyl-h));
 }
 
+.token-base {
+  @apply w-full h-full absolute;
+  clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
+  background-color: var(--side-color, #facc15);
+  border: 1px solid var(--border-color, #d97706);
+  top: calc(100% + var(--cyl-h));
+  left: 0;
+  transform: translateZ(0);
+}
+
 .hex-cylinder {
   position: absolute;
   top: 100%;


### PR DESCRIPTION
## Summary
- add bottom hexagon element to player token
- style token base to match token top

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68515678fb6483299dd13b1de5e5a13b