### PR TITLE
Add turn notice for Snake and Ladder

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Dice from './Dice.jsx';
 
-export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }) {
+export default function DiceRoller({ onRollEnd, onRollStart, clickable = false, numDice = 2 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
   const soundRef = useRef(null);
@@ -29,6 +29,7 @@ export default function DiceRoller({ onRollEnd, clickable = false, numDice = 2 }
     }
     startValuesRef.current = values;
     setRolling(true);
+    onRollStart && onRollStart();
 
     const rand = () => {
       if (window.crypto && window.crypto.getRandomValues) {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -244,6 +244,7 @@ export default function SnakeAndLadder() {
   const [streak, setStreak] = useState(0);
   const [highlight, setHighlight] = useState(null); // { cell: number, type: string }
   const [message, setMessage] = useState("");
+  const [turnMessage, setTurnMessage] = useState("Your turn");
   const [photoUrl, setPhotoUrl] = useState("");
   const [pot, setPot] = useState(100);
   const [token, setToken] = useState("TPC");
@@ -293,6 +294,7 @@ export default function SnakeAndLadder() {
   }, []);
 
   const handleRoll = (values) => {
+    setTurnMessage("");
     const value = Array.isArray(values)
       ? values.reduce((a, b) => a + b, 0)
       : values;
@@ -305,6 +307,7 @@ export default function SnakeAndLadder() {
     if (newStreak === 3) {
       setStreak(0);
       setMessage("Third 6 rolled, turn skipped!");
+      setTurnMessage("Your turn");
       return;
     }
 
@@ -316,12 +319,14 @@ export default function SnakeAndLadder() {
       if (rolledSix) target = 1;
       else {
         setMessage("Need a 6 to start!");
+        setTurnMessage("Your turn");
         return;
       }
     } else if (current + value <= FINAL_TILE) {
       target = current + value;
     } else {
       setMessage("Need exact roll!");
+      setTurnMessage("Your turn");
     }
 
     const steps = [];
@@ -357,6 +362,7 @@ export default function SnakeAndLadder() {
             snakeSoundRef.current?.play().catch(() => {});
             setMessage(`Snake! Slide to tile ${finalPos}`);
           }
+          setTurnMessage("Your turn");
         }, 300);
         return;
       }
@@ -394,6 +400,9 @@ export default function SnakeAndLadder() {
           <AiOutlineRollback className="text-xl" />
           <span className="text-xs">Lobby</span>
         </button>
+        {turnMessage && (
+          <div className="text-xs font-semibold text-right w-full">{turnMessage}</div>
+        )}
       </div>
       <Board
         position={pos}
@@ -409,7 +418,12 @@ export default function SnakeAndLadder() {
         <div className="text-center font-semibold w-full">{message}</div>
       )}
       <div className="fixed bottom-24 inset-x-0 flex justify-center z-20">
-        <DiceRoller onRollEnd={handleRoll} clickable numDice={2} />
+        <DiceRoller
+          onRollEnd={handleRoll}
+          onRollStart={() => setTurnMessage('Rolling...')}
+          clickable
+          numDice={2}
+        />
       </div>
       <InfoPopup
         open={showInfo}


### PR DESCRIPTION
## Summary
- allow `DiceRoller` to notify when rolling starts
- show a `Your turn` message under the board icons in Snake and Ladder

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851574cd8288329a978ef622af8bafc