### PR TITLE
Adjust board tilt and logo alignment

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -245,7 +245,7 @@ body {
   width: calc(var(--cell-width) * 5.76); /* 20% smaller */
   height: calc(var(--cell-height) * 4.8); /* 20% smaller */
   top: calc(var(--cell-height) * -4.5); /* ✅ push above pot */
-  left: 50%;
+  left: 47%;
   transform: translateX(-50%) rotateX(-60deg) translateZ(-20px) scale(1.8); /* Enlarged, base anchored */
   transform-origin: bottom center;
   background-image: url("/assets/TonPlayGramLogo.jpg");

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -153,6 +153,7 @@ function Board({
   const MAX_ZOOM = 1.5; // and larger when reaching the top
   const MIN_ANGLE = 65;
   const MAX_ANGLE = 40;
+  const BOARD_Y_TILT = -10; // slight rotation so the board top leans left
 
   const rowFromBottom = Math.floor(Math.max(position - 1, 0) / COLS);
   const progress = Math.min(1, rowFromBottom / (ROWS - 1));
@@ -210,7 +211,7 @@ function Board({
               "--cell-height": `${cellHeight}px`,
               "--board-width": `${cellWidth * COLS}px`,
               // Lower camera angle and zoom dynamically as the player moves
-              transform: `rotateX(${angle}deg) scale(${zoom})`,
+              transform: `rotateX(${angle}deg) rotateY(${BOARD_Y_TILT}deg) scale(${zoom})`,
             }}
           >
             {tiles}


### PR DESCRIPTION
## Summary
- tweak the 3D board transform so the top leans a bit left
- offset the top logo slightly left to match new board angle

## Testing
- `npm test` *(fails: manifest and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685164a1fd14832985766a13b75e076a