### PR TITLE
Restore hexagon token design

### DIFF
--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -1,23 +1,21 @@
 import React from 'react';
 
-export default function PlayerToken({
-  photoUrl,
-  indicator,
-  type = 'normal',
-  color,
-}) {
+export default function PlayerToken({ photoUrl, type = 'normal', color }) {
   const colorClass =
     type === 'ladder' ? 'token-green' : type === 'snake' ? 'token-red' : 'token-yellow';
   const style = color ? { '--side-color': color, '--border-color': color } : undefined;
   return (
     <div className={`player-token ${colorClass}`} style={style}>
       <img src={photoUrl} alt="player" className="token-top" />
-      <div className="tri-cylinder">
-        <div className="tri-side side-1" />
-        <div className="tri-side side-2" />
-        <div className="tri-side side-3" />
+      <div className="hex-cylinder">
+        <div className="hex-side side-1" />
+        <div className="hex-side side-2" />
+        <div className="hex-side side-3" />
+        <div className="hex-side side-4" />
+        <div className="hex-side side-5" />
+        <div className="hex-side side-6" />
       </div>
-      <div className="token-base">{indicator}</div>
+      <div className="token-base" />
     </div>
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -137,7 +137,7 @@ body {
   transform: translateZ(10px);
 }
 
-/* Player photo on a triangular prism */
+/* Player photo on a hexagonal cylinder */
 .player-token {
   position: absolute;
   width: 4rem;
@@ -146,14 +146,14 @@ body {
   transform: translateZ(10px);
   --cyl-h: 1.5rem; /* half of dice size */
   --token-radius: 2rem;
-  --cyl-apothem: calc(var(--token-radius) * 0.289); /* distance from center */
+  --cyl-apothem: calc(var(--token-radius) * 0.866); /* distance from center */
   --side-color: #facc15; /* default amber */
   --border-color: #d97706;
 }
 
 .token-top {
-  @apply w-full h-full object-cover flex items-center justify-center;
-  clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+  @apply w-full h-full object-cover;
+  clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
   position: absolute;
   top: 0;
   left: 0;
@@ -161,8 +161,8 @@ body {
 }
 
 .token-base {
-  @apply w-full h-full absolute flex items-center justify-center font-bold text-xs;
-  clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+  @apply w-full h-full absolute;
+  clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
   background-color: var(--side-color, #facc15);
   border: 1px solid var(--border-color, #d97706);
   top: calc(100% + var(--cyl-h));
@@ -170,7 +170,7 @@ body {
   transform: translateZ(0);
 }
 
-.tri-cylinder {
+.hex-cylinder {
   position: absolute;
   top: 100%;
   left: 0;
@@ -180,7 +180,7 @@ body {
   transform-origin: center bottom;
 }
 
-.tri-side {
+.hex-side {
   position: absolute;
   left: calc(50% - var(--token-radius) / 2);
   width: var(--token-radius);
@@ -190,8 +190,11 @@ body {
 }
 
 .side-1 { transform: rotateY(0deg) translateZ(var(--cyl-apothem)); }
-.side-2 { transform: rotateY(120deg) translateZ(var(--cyl-apothem)); }
-.side-3 { transform: rotateY(240deg) translateZ(var(--cyl-apothem)); }
+.side-2 { transform: rotateY(60deg) translateZ(var(--cyl-apothem)); }
+.side-3 { transform: rotateY(120deg) translateZ(var(--cyl-apothem)); }
+.side-4 { transform: rotateY(180deg) translateZ(var(--cyl-apothem)); }
+.side-5 { transform: rotateY(240deg) translateZ(var(--cyl-apothem)); }
+.side-6 { transform: rotateY(300deg) translateZ(var(--cyl-apothem)); }
 
 /* Token color variations */
 .token-yellow {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -81,7 +81,6 @@ function Board({
             <PlayerToken
               photoUrl={photoUrl}
               type={isHighlight ? highlight.type : 'normal'}
-              indicator={num}
             />
           )}
         </div>,
@@ -225,7 +224,6 @@ function Board({
                 <PlayerToken
                   photoUrl={photoUrl}
                   type={highlight && highlight.cell === FINAL_TILE ? highlight.type : 'normal'}
-                  indicator={FINAL_TILE}
                 />
               )}
               {celebrate && <CoinBurst token={token} />}


### PR DESCRIPTION
## Summary
- revert triangular token customization

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685165d6cb4c8329a03747937d254145