### PR TITLE
Adjust Snake & Ladder token visuals

### DIFF
--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -7,14 +7,6 @@ export default function PlayerToken({ photoUrl, type = 'normal', color }) {
   return (
     <div className={`player-token ${colorClass}`} style={style}>
       <img src={photoUrl} alt="player" className="token-top" />
-      <div className="hex-cylinder">
-        <div className="hex-side side-1" />
-        <div className="hex-side side-2" />
-        <div className="hex-side side-3" />
-        <div className="hex-side side-4" />
-        <div className="hex-side side-5" />
-        <div className="hex-side side-6" />
-      </div>
       <div className="token-base" />
     </div>
   );

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -143,11 +143,9 @@ body {
   width: 4rem;
   height: 4rem;
   transform-style: preserve-3d;
-  transform: translateZ(10px);
-  --cyl-h: 1.5rem; /* half of dice size */
-  --token-radius: 2rem;
-  --cyl-apothem: calc(var(--token-radius) * 0.866); /* distance from center */
-  --side-color: #facc15; /* default amber */
+  transform: translateZ(5px);
+  --cyl-h: 0rem;
+  --side-color: #facc15;
   --border-color: #d97706;
 }
 
@@ -170,31 +168,6 @@ body {
   transform: translateZ(0);
 }
 
-.hex-cylinder {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  width: 100%;
-  height: var(--cyl-h);
-  transform-style: preserve-3d;
-  transform-origin: center bottom;
-}
-
-.hex-side {
-  position: absolute;
-  left: calc(50% - var(--token-radius) / 2);
-  width: var(--token-radius);
-  height: 100%;
-  background-color: var(--side-color, #facc15);
-  border: 1px solid var(--border-color, #d97706);
-}
-
-.side-1 { transform: rotateY(0deg) translateZ(var(--cyl-apothem)); }
-.side-2 { transform: rotateY(60deg) translateZ(var(--cyl-apothem)); }
-.side-3 { transform: rotateY(120deg) translateZ(var(--cyl-apothem)); }
-.side-4 { transform: rotateY(180deg) translateZ(var(--cyl-apothem)); }
-.side-5 { transform: rotateY(240deg) translateZ(var(--cyl-apothem)); }
-.side-6 { transform: rotateY(300deg) translateZ(var(--cyl-apothem)); }
 
 /* Token color variations */
 .token-yellow {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -67,12 +67,11 @@ function Board({
       const col = reversed ? COLS - 1 - c : c;
       const num = r * COLS + col + 1;
       const isHighlight = highlight && highlight.cell === num;
-      const highlightClass = isHighlight ? `${highlight.type}-highlight` : "";
       tiles.push(
         <div
           key={num}
           data-cell={num}
-          className={`board-cell ${highlightClass}`}
+          className="board-cell"
           style={{ gridRowStart: ROWS - r, gridColumnStart: col + 1 }}
         >
           {num}


### PR DESCRIPTION
## Summary
- simplify PlayerToken markup and remove midsection faces
- tweak player token styles to sit lower and remove unused cylinder sides
- rely on token base color for board highlighting

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685169c1d4e48329b8da27d59063749d