### PR TITLE
Implement player colored base for Snake board token

### DIFF
--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-export default function PlayerToken({ photoUrl, type = 'normal', color }) {
+export default function PlayerToken({ photoUrl, type = 'normal', color = '#2563eb' }) {
   const colorClass =
     type === 'ladder' ? 'token-green' : type === 'snake' ? 'token-red' : 'token-yellow';
-  const style = color ? { '--side-color': color, '--border-color': color } : undefined;
+  const style = { '--base-color': color };
   return (
     <div className={`player-token ${colorClass}`} style={style}>
       <img src={photoUrl} alt="player" className="token-top" />

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -149,6 +149,7 @@ body {
   --cyl-apothem: calc(var(--token-radius) * 0.866); /* distance from center */
   --side-color: #facc15; /* default amber */
   --border-color: #d97706;
+  --base-color: var(--side-color);
 }
 
 .token-top {
@@ -163,8 +164,8 @@ body {
 .token-base {
   @apply w-full h-full absolute;
   clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
-  background-color: var(--side-color, #facc15);
-  border: 1px solid var(--border-color, #d97706);
+  background-color: var(--base-color, #facc15);
+  border: 1px solid var(--base-color, #d97706);
   top: calc(100% + var(--cyl-h));
   left: 0;
   transform: translateZ(0);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -81,6 +81,7 @@ function Board({
             <PlayerToken
               photoUrl={photoUrl}
               type={isHighlight ? highlight.type : 'normal'}
+              color={playerColor}
             />
           )}
         </div>,
@@ -225,6 +226,7 @@ function Board({
                 <PlayerToken
                   photoUrl={photoUrl}
                   type={highlight && highlight.cell === FINAL_TILE ? highlight.type : 'normal'}
+                  color={playerColor}
                 />
               )}
               {celebrate && <CoinBurst token={token} />}
@@ -254,6 +256,7 @@ export default function SnakeAndLadder() {
   const [showInfo, setShowInfo] = useState(false);
   const [snakes, setSnakes] = useState({});
   const [ladders, setLadders] = useState({});
+  const [playerColor, setPlayerColor] = useState("#2563eb");
 
   const moveSoundRef = useRef(null);
   const snakeSoundRef = useRef(null);
@@ -285,8 +288,10 @@ export default function SnakeAndLadder() {
     const room = params.get("table") || "snake-4";
     const t = params.get("token");
     const amt = params.get("amount");
+    const col = params.get("color");
     if (t) setToken(t.toUpperCase());
     if (amt) setPot(Number(amt));
+    if (col) setPlayerColor(col.startsWith("#") ? col : `#${col}`);
     getSnakeBoard(room)
       .then((data) => {
         setSnakes(data.snakes || {});


### PR DESCRIPTION
## Summary
- add `playerColor` to snake token state and parse from URL
- style token base via new CSS variable
- keep player photo but color the base using the new prop

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685178b8b7b08329acf5e2cc6884709d