### PR TITLE
Add 3D pillar style for player token

### DIFF
--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -7,10 +7,13 @@ export default function PlayerToken({ photoUrl, type = 'normal', color }) {
   return (
     <div className={`player-token ${colorClass}`} style={style}>
       <img src={photoUrl} alt="player" className="token-top" />
-      <div className="token-pillar">
-        <div className="pillar-face pillar-front" />
-        <div className="pillar-face pillar-right" />
-        <div className="pillar-face pillar-left" />
+      <div className="hex-cylinder">
+        <div className="hex-side side-1" />
+        <div className="hex-side side-2" />
+        <div className="hex-side side-3" />
+        <div className="hex-side side-4" />
+        <div className="hex-side side-5" />
+        <div className="hex-side side-6" />
       </div>
       <div className="token-base" />
     </div>


### PR DESCRIPTION
## Summary
- render Snake & Ladder player tokens using a six-sided pillar

## Testing
- `npm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_685185f107288329b7d148231e279147