### PR TITLE
Fix transparent dice background

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -18,7 +18,8 @@ body {
 
 .hex-table {
   clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
-  background: radial-gradient(circle at center, #8b1a1a 0%, #5a0d0d 80%);
+  /* Transparent background so the board remains visible */
+  background: transparent;
   border: 4px solid #b22222;
 }
 


### PR DESCRIPTION
## Summary
- keep board visible by making DicePopup's background transparent

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68518adfd89c8329906379a920ad6c6d