### PR TITLE
Fix transparency on Snake & Ladder page

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -11,9 +11,12 @@ export default function Layout({ children }) {
     location.pathname.startsWith('/games/') &&
     !location.pathname.includes('/lobby')
   );
+  const bgClass = location.pathname.startsWith('/games/snake')
+    ? 'bg-transparent'
+    : 'bg-background';
 
   return (
-    <div className="flex flex-col min-h-screen bg-background text-text relative">
+    <div className={`flex flex-col min-h-screen ${bgClass} text-text relative`}>
       <main className={`flex-grow container mx-auto p-4 ${showNavbar ? 'pb-24' : ''}`.trim()}>
         {showBranding && <Branding />}
         {children}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -12,6 +12,10 @@ body {
   @apply bg-background text-text overflow-x-hidden;
 }
 
+body.transparent-bg {
+  background-color: transparent;
+}
+
 .hexagon {
   clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -240,6 +240,11 @@ function Board({
 export default function SnakeAndLadder() {
   useTelegramBackButton();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    document.body.classList.add('transparent-bg');
+    return () => document.body.classList.remove('transparent-bg');
+  }, []);
   const [pos, setPos] = useState(0);
   const [streak, setStreak] = useState(0);
   const [highlight, setHighlight] = useState(null); // { cell: number, type: string }


### PR DESCRIPTION
## Summary
- allow transparent background on the Snake & Ladder page
- add CSS class for transparent body

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68518f2563b0832988d35c9cc7455e48