### PR TITLE
Replace token with 3D dice

### DIFF
--- a/webapp/src/components/PlayerDice.jsx
+++ b/webapp/src/components/PlayerDice.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+const diceFaces = {
+  1: [
+    [0, 0, 0],
+    [0, 1, 0],
+    [0, 0, 0],
+  ],
+  2: [
+    [1, 0, 0],
+    [0, 0, 0],
+    [0, 0, 1],
+  ],
+  3: [
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+  ],
+  4: [
+    [1, 0, 1],
+    [0, 0, 0],
+    [1, 0, 1],
+  ],
+  5: [
+    [1, 0, 1],
+    [0, 1, 0],
+    [1, 0, 1],
+  ],
+  6: [
+    [1, 0, 1],
+    [1, 0, 1],
+    [1, 0, 1],
+  ],
+};
+
+function Face({ value, className }) {
+  const face = diceFaces[value];
+  return (
+    <div className={`dice-face ${className}`}>
+      <div className="grid grid-cols-3 grid-rows-3 gap-1">
+        {face.flat().map((dot, i) => (
+          <div key={i} className="flex items-center justify-center">
+            {dot ? <div className="dot" /> : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function PlayerDice({ value = 1 }) {
+  return (
+    <div className="player-token" style={{ width: '3rem', height: '3rem' }}>
+      <div className="dice-container w-full h-full">
+        <div
+          className="dice-cube"
+          style={{ width: '100%', height: '100%', transform: 'rotateX(0deg) rotateY(0deg)' }}
+        >
+          <Face value={2} className="dice-face--front absolute" />
+          <Face value={5} className="dice-face--back absolute" />
+          <Face value={3} className="dice-face--right absolute" />
+          <Face value={4} className="dice-face--left absolute" />
+          <Face value={value} className="dice-face--top absolute" />
+          <Face value={7 - value} className="dice-face--bottom absolute" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -10,7 +10,7 @@ import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
 import { useNavigate } from "react-router-dom";
 import { getTelegramPhotoUrl } from "../../utils/telegram.js";
 import { getSnakeBoard } from "../../utils/api.js";
-import PlayerToken from "../../components/PlayerToken.jsx";
+import PlayerDice from "../../components/PlayerDice.jsx";
 
 const PLAYERS = 4;
 // Adjusted board dimensions to show five columns
@@ -77,12 +77,7 @@ function Board({
         >
           {num}
           {/* ladder markers removed */}
-          {position === num && (
-            <PlayerToken
-              photoUrl={photoUrl}
-              type={isHighlight ? highlight.type : 'normal'}
-            />
-          )}
+          {position === num && <PlayerDice />}
         </div>,
       );
     }
@@ -219,12 +214,7 @@ function Board({
             >
               <span className="font-bold">Pot</span>
               <span className="text-sm">{pot}</span>
-              {position === FINAL_TILE && (
-                <PlayerToken
-                  photoUrl={photoUrl}
-                  type={highlight && highlight.cell === FINAL_TILE ? highlight.type : 'normal'}
-                />
-              )}
+              {position === FINAL_TILE && <PlayerDice />}
               {celebrate && <CoinBurst token={token} />}
             </div>
             <div className="logo-wall-main" />


### PR DESCRIPTION
## Summary
- implement `PlayerDice` component that renders a static cube using the same dice style
- use the dice token in the Snake & Ladder board

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68519207ccc48329bf35239ee15fdcf7