### PR TITLE
Update Snake & Ladder token to 3D cube

### DIFF
--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -4,18 +4,17 @@ export default function PlayerToken({ photoUrl, type = 'normal', color }) {
   const colorClass =
     type === 'ladder' ? 'token-green' : type === 'snake' ? 'token-red' : 'token-yellow';
   const style = color ? { '--side-color': color, '--border-color': color } : undefined;
+
   return (
-    <div className={`player-token ${colorClass}`} style={style}>
-      <img src={photoUrl} alt="player" className="token-top" />
-      <div className="hex-cylinder">
-        <div className="hex-side side-1" />
-        <div className="hex-side side-2" />
-        <div className="hex-side side-3" />
-        <div className="hex-side side-4" />
-        <div className="hex-side side-5" />
-        <div className="hex-side side-6" />
+    <div className={`token-cube ${colorClass}`} style={style}>
+      <div className="token-cube-inner">
+        <img src={photoUrl} alt="player" className="cube-face cube-top" />
+        <div className="cube-face cube-bottom" />
+        <div className="cube-face cube-front" />
+        <div className="cube-face cube-back" />
+        <div className="cube-face cube-right" />
+        <div className="cube-face cube-left" />
       </div>
-      <div className="token-base" />
     </div>
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -139,6 +139,7 @@ body {
 }
 
 /* Player photo on a hexagonal cylinder */
+/* Deprecated hexagonal token - kept for reference */
 .player-token {
   position: absolute;
   width: 4rem;
@@ -150,6 +151,61 @@ body {
   --cyl-apothem: calc(var(--token-radius) * 0.866); /* distance from center */
   --side-color: #facc15; /* default amber */
   --border-color: #d97706;
+}
+
+/* New cube-style token */
+.token-cube {
+  position: absolute;
+  width: 4rem;
+  height: 4rem;
+  transform: translateZ(10px);
+  transform-style: preserve-3d;
+  --side-color: #fde047; /* yellow-300 */
+  --border-color: #d97706; /* amber-600 */
+}
+
+.token-cube-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transform: rotateX(-25deg) rotateY(25deg);
+}
+
+.cube-face {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: var(--side-color);
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+.cube-top {
+  object-fit: cover;
+  background-color: transparent;
+  transform: rotateX(90deg) translateZ(2rem);
+}
+
+.cube-bottom {
+  transform: rotateX(-90deg) translateZ(2rem);
+}
+
+.cube-front {
+  transform: rotateY(0deg) translateZ(2rem);
+}
+
+.cube-back {
+  transform: rotateY(180deg) translateZ(2rem);
+}
+
+.cube-right {
+  transform: rotateY(90deg) translateZ(2rem);
+}
+
+.cube-left {
+  transform: rotateY(-90deg) translateZ(2rem);
 }
 
 .token-top {


### PR DESCRIPTION
## Summary
- show a new cube-style token with the player's photo on top
- keep old hex token styles as reference
- adapt CSS for new cube

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851960fe4d083298ea587198cfd3d37