### PR TITLE
Align token orientation with board angle

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -169,7 +169,8 @@ body {
   width: 100%;
   height: 100%;
   transform-style: preserve-3d;
-  transform: rotateX(-25deg) rotateY(25deg);
+  /* Match board tilt so the token sits flush on the surface */
+  transform: rotateY(25deg);
 }
 
 .cube-face {


### PR DESCRIPTION
## Summary
- tweak token cube rotation so it follows the board tilt

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68519a1560d8832992a63a1d24707075