### PR TITLE
Update Snake & Ladder token to match board angle

### DIFF
--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -1,21 +1,23 @@
 import React from 'react';
 
-export default function PlayerToken({ photoUrl, type = 'normal', color }) {
+export default function PlayerToken({ photoUrl, type = 'normal', color, angle }) {
   const colorClass =
     type === 'ladder' ? 'token-green' : type === 'snake' ? 'token-red' : 'token-yellow';
-  const style = color ? { '--side-color': color, '--border-color': color } : undefined;
+  const style = {
+    ...(color ? { '--side-color': color, '--border-color': color } : {}),
+    ...(angle !== undefined ? { '--board-angle': `${angle}deg` } : {}),
+  };
+
   return (
-    <div className={`player-token ${colorClass}`} style={style}>
-      <img src={photoUrl} alt="player" className="token-top" />
-      <div className="hex-cylinder">
-        <div className="hex-side side-1" />
-        <div className="hex-side side-2" />
-        <div className="hex-side side-3" />
-        <div className="hex-side side-4" />
-        <div className="hex-side side-5" />
-        <div className="hex-side side-6" />
+    <div className={`token-cube ${colorClass}`} style={style}>
+      <div className="token-cube-inner">
+        <img src={photoUrl} alt="player" className="cube-face cube-top" />
+        <div className="cube-face cube-bottom" />
+        <div className="cube-face cube-front" />
+        <div className="cube-face cube-back" />
+        <div className="cube-face cube-right" />
+        <div className="cube-face cube-left" />
       </div>
-      <div className="token-base" />
     </div>
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -139,6 +139,7 @@ body {
 }
 
 /* Player photo on a hexagonal cylinder */
+/* Deprecated hexagonal token - kept for reference */
 .player-token {
   position: absolute;
   width: 4rem;
@@ -150,6 +151,62 @@ body {
   --cyl-apothem: calc(var(--token-radius) * 0.866); /* distance from center */
   --side-color: #facc15; /* default amber */
   --border-color: #d97706;
+}
+
+/* New cube-style token */
+.token-cube {
+  position: absolute;
+  width: 4rem;
+  height: 4rem;
+  transform: translateZ(10px);
+  transform-style: preserve-3d;
+  --side-color: #fde047; /* yellow-300 */
+  --border-color: #d97706; /* amber-600 */
+}
+
+.token-cube-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transform: rotateX(var(--board-angle, 0deg));
+}
+
+.cube-face {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: var(--side-color);
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+.cube-top {
+  object-fit: cover;
+  background-color: transparent;
+  transform: rotateX(90deg) translateZ(2rem);
+  clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
+}
+
+.cube-bottom {
+  transform: rotateX(-90deg) translateZ(2rem);
+}
+
+.cube-front {
+  transform: rotateY(0deg) translateZ(2rem);
+}
+
+.cube-back {
+  transform: rotateY(180deg) translateZ(2rem);
+}
+
+.cube-right {
+  transform: rotateY(90deg) translateZ(2rem);
+}
+
+.cube-left {
+  transform: rotateY(-90deg) translateZ(2rem);
 }
 
 .token-top {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -81,6 +81,7 @@ function Board({
             <PlayerToken
               photoUrl={photoUrl}
               type={isHighlight ? highlight.type : 'normal'}
+              angle={angle}
             />
           )}
         </div>,
@@ -222,7 +223,12 @@ function Board({
               {position === FINAL_TILE && (
                 <PlayerToken
                   photoUrl={photoUrl}
-                  type={highlight && highlight.cell === FINAL_TILE ? highlight.type : 'normal'}
+                  type={
+                    highlight && highlight.cell === FINAL_TILE
+                      ? highlight.type
+                      : 'normal'
+                  }
+                  angle={angle}
                 />
               )}
               {celebrate && <CoinBurst token={token} />}


### PR DESCRIPTION
## Summary
- pass board angle to PlayerToken
- rotate token cube using the provided angle
- clip player photo on top face as hexagon

## Testing
- `npm test` *(fails: manifest and lobby endpoints unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851960fe4d083298ea587198cfd3d37