### PR TITLE
Align cube token perspective with dice

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -170,7 +170,7 @@ body {
   height: 100%;
   transform-style: preserve-3d;
   /* Align token with board surface while showing a slight side angle */
-  transform: rotateY(25deg);
+  transform: rotateX(calc(var(--board-angle, 60deg) * -1 - 25deg)) rotateY(25deg);
 }
 
 .cube-face {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -208,6 +208,7 @@ function Board({
               "--cell-width": `${cellWidth}px`,
               "--cell-height": `${cellHeight}px`,
               "--board-width": `${cellWidth * COLS}px`,
+              "--board-angle": `${angle}deg`,
               // Lower camera angle and zoom dynamically as the player moves
               transform: `rotateX(${angle}deg) scale(${zoom})`,
             }}


### PR DESCRIPTION
## Summary
- match the cube token perspective with the dice orientation
- expose `--board-angle` CSS variable from the Snake & Ladder board grid

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_6851a7210d2c8329ba1adf09b008cc18