### PR TITLE
Add dice token for snake board

### DIFF
--- a/webapp/src/components/DiceToken.jsx
+++ b/webapp/src/components/DiceToken.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+const diceFaces = {
+  1: [
+    [0, 0, 0],
+    [0, 1, 0],
+    [0, 0, 0],
+  ],
+  2: [
+    [1, 0, 0],
+    [0, 0, 0],
+    [0, 0, 1],
+  ],
+  3: [
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+  ],
+  4: [
+    [1, 0, 1],
+    [0, 0, 0],
+    [1, 0, 1],
+  ],
+  5: [
+    [1, 0, 1],
+    [0, 1, 0],
+    [1, 0, 1],
+  ],
+  6: [
+    [1, 0, 1],
+    [1, 0, 1],
+    [1, 0, 1],
+  ],
+};
+
+function Face({ value, className }) {
+  const face = diceFaces[value];
+  return (
+    <div className={`dice-face ${className}`}>
+      <div className="grid grid-cols-3 grid-rows-3 gap-1">
+        {face.flat().map((dot, i) => (
+          <div key={i} className="flex items-center justify-center">
+            {dot ? <div className="dot" /> : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function DiceToken({ value = 1 }) {
+  const orientation = `rotateX(calc(var(--board-angle, 60deg) * -1 - 25deg)) rotateY(25deg)`;
+  const sides = [2, 3];
+  return (
+    <div className="dice-container w-16 h-16 perspective-1000" style={{ position: 'absolute', transform: 'translateZ(10px)' }}>
+      <div
+        className="dice-cube relative w-full h-full transform-style-preserve-3d"
+        style={{ transform: orientation }}
+      >
+        <Face value={sides[0]} className="dice-face--front absolute" />
+        <Face value={7 - sides[0]} className="dice-face--back absolute" />
+        <Face value={sides[1]} className="dice-face--right absolute" />
+        <Face value={7 - sides[1]} className="dice-face--left absolute" />
+        <Face value={value} className="dice-face--top absolute" />
+        <Face value={7 - value} className="dice-face--bottom absolute" />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -48,6 +48,8 @@ function CoinBurst({ token }) {
   );
 }
 
+import DiceToken from "../../components/DiceToken.jsx";
+
 function Board({
   position,
   highlight,
@@ -57,6 +59,7 @@ function Board({
   ladders,
   celebrate,
   token,
+  tokenType = "photo",
 }) {
   const containerRef = useRef(null);
   const tiles = [];
@@ -78,10 +81,14 @@ function Board({
           {num}
           {/* ladder markers removed */}
           {position === num && (
-            <PlayerToken
-              photoUrl={photoUrl}
-              type={isHighlight ? highlight.type : 'normal'}
-            />
+            tokenType === 'dice' ? (
+              <DiceToken value={1} />
+            ) : (
+              <PlayerToken
+                photoUrl={photoUrl}
+                type={isHighlight ? highlight.type : 'normal'}
+              />
+            )
           )}
         </div>,
       );
@@ -221,10 +228,14 @@ function Board({
               <span className="font-bold">Pot</span>
               <span className="text-sm">{pot}</span>
               {position === FINAL_TILE && (
-                <PlayerToken
-                  photoUrl={photoUrl}
-                  type={highlight && highlight.cell === FINAL_TILE ? highlight.type : 'normal'}
-                />
+                tokenType === 'dice' ? (
+                  <DiceToken value={1} />
+                ) : (
+                  <PlayerToken
+                    photoUrl={photoUrl}
+                    type={highlight && highlight.cell === FINAL_TILE ? highlight.type : 'normal'}
+                  />
+                )
               )}
               {celebrate && <CoinBurst token={token} />}
             </div>
@@ -414,6 +425,7 @@ export default function SnakeAndLadder() {
         ladders={ladders}
         celebrate={celebrate}
         token={token}
+        tokenType="dice"
       />
       {message && (
         <div className="text-center font-semibold w-full">{message}</div>


### PR DESCRIPTION
## Summary
- add new `DiceToken` component that replicates the 3D dice look
- update the Snake & Ladder board to optionally use dice tokens
- render the board using the dice token

## Testing
- `npm test` *(fails: manifest endpoint not reachable, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_6851a96b53a88329b2a93b1180b84a44