### PR TITLE
Fix board tilt perspective

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -59,7 +59,8 @@ body {
 
 .snake-board-grid {
   transform-style: preserve-3d;
-  transform-origin: bottom center;
+  /* Anchor at the top so the board tapers toward the bottom */
+  transform-origin: top center;
   transition: transform 0.3s ease; /* ✅ scaling transition */
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -209,8 +209,8 @@ function Board({
               "--cell-height": `${cellHeight}px`,
               "--board-width": `${cellWidth * COLS}px`,
               "--board-angle": `${angle}deg`,
-              // Lower camera angle and zoom dynamically as the player moves
-              transform: `rotateX(${angle}deg) scale(${zoom})`,
+              // Flip the tilt so the top appears larger than the bottom
+              transform: `rotateX(-${angle}deg) scale(${zoom})`,
             }}
           >
             {tiles}


### PR DESCRIPTION
## Summary
- adjust Snake & Ladder board origin to top
- tilt board in opposite direction so the top is wider than the bottom

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*
- `npm --prefix webapp run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851afec8a908329ae455397fa6e5e71