### PR TITLE
Adjust snake board scaling

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -356,8 +356,8 @@ body {
 
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 5.76); /* 20% smaller */
-  height: calc(var(--cell-height) * 4.8); /* 20% smaller */
+  width: calc(var(--cell-width) * 6.5); /* slightly wider */
+  height: calc(var(--cell-height) * 5.2); /* slightly taller */
   top: calc(var(--cell-height) * -4.5); /* ✅ push above pot */
   left: 50%;
   transform: translateX(-50%) rotateX(-60deg) translateZ(-20px) scale(1.8); /* Enlarged, base anchored */
@@ -371,8 +371,8 @@ body {
 
 .logo-wall-side {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--board-width) * 0.768); /* 20% smaller */
-  height: calc(var(--cell-height) * 3.84); /* 20% smaller */
+  width: calc(var(--board-width) * 0.9); /* slightly wider */
+  height: calc(var(--cell-height) * 4.2); /* slightly taller */
   top: calc(var(--cell-height) * -4.5);
   background-image: url("/assets/TonPlayGramLogo.jpg");
   background-size: contain;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -149,7 +149,7 @@ function Board({
   // Dynamically adjust zoom and camera tilt based on how far the player
   // has progressed. This keeps the logo in focus while following the token.
   const MIN_ZOOM = 1; // keep the bottom scale fixed
-  const MAX_ZOOM = 2; // expand the top so it fills the screen
+  const MAX_ZOOM = 2.4; // widen the board and logo toward the top
   const MIN_ANGLE = 65;
   const MAX_ANGLE = 20;
 


### PR DESCRIPTION
## Summary
- scale board more toward the top
- widen main logo and side logo so they stay visible when zoomed

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851b3536a5483298de77bc911cdac68