### PR TITLE
Replace dice token with Three.js hexagonal prism

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,8 @@
     "vite": "^4.4.9",
     "react-icons": "^4.10.1",
     "canvas-confetti": "^1.9.2",
-    "@ayshrj/ludo.js": "^1.0.10"
+    "@ayshrj/ludo.js": "^1.0.10",
+    "three": "^0.164.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -1,0 +1,63 @@
+import { useRef, useEffect } from "react";
+import * as THREE from "three";
+
+export default function HexPrismToken({ color = "#008080" }) {
+  const mountRef = useRef(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    const width = mount.clientWidth;
+    const height = mount.clientHeight;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 100);
+    camera.position.set(3, 4, 5);
+    camera.lookAt(0, 0, 0);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setSize(width, height);
+    renderer.setPixelRatio(window.devicePixelRatio);
+    mount.appendChild(renderer.domElement);
+
+    const geometry = new THREE.CylinderGeometry(1, 1, 2.5, 6);
+    const material = new THREE.MeshStandardMaterial({ color });
+    const prism = new THREE.Mesh(geometry, material);
+    scene.add(prism);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.6);
+    const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+    directional.position.set(5, 10, 7.5);
+    scene.add(ambient);
+    scene.add(directional);
+
+    let frameId;
+    const animate = () => {
+      prism.rotation.y += 0.01;
+      renderer.render(scene, camera);
+      frameId = requestAnimationFrame(animate);
+    };
+    animate();
+
+    const handleResize = () => {
+      const width = mount.clientWidth;
+      const height = mount.clientHeight;
+      renderer.setSize(width, height);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+    };
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      window.removeEventListener("resize", handleResize);
+      mount.removeChild(renderer.domElement);
+      geometry.dispose();
+      material.dispose();
+      renderer.dispose();
+    };
+  }, [color]);
+
+  return <div className="token-three" ref={mountRef} />;
+}

--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -1,70 +1,12 @@
-import React from 'react';
+import React from "react";
+import HexPrismToken from "./HexPrismToken.jsx";
 
-const diceFaces = {
-  1: [
-    [0, 0, 0],
-    [0, 1, 0],
-    [0, 0, 0],
-  ],
-  2: [
-    [1, 0, 0],
-    [0, 0, 0],
-    [0, 0, 1],
-  ],
-  3: [
-    [1, 0, 0],
-    [0, 1, 0],
-    [0, 0, 1],
-  ],
-  4: [
-    [1, 0, 1],
-    [0, 0, 0],
-    [1, 0, 1],
-  ],
-  5: [
-    [1, 0, 1],
-    [0, 1, 0],
-    [1, 0, 1],
-  ],
-  6: [
-    [1, 0, 1],
-    [1, 0, 1],
-    [1, 0, 1],
-  ],
-};
-
-function Face({ value, className }) {
-  const face = diceFaces[value];
-  return (
-    <div className={`dice-face ${className}`}>
-      <div className="grid grid-cols-3 grid-rows-3 gap-1">
-        {face.flat().map((dot, i) => (
-          <div key={i} className="flex items-center justify-center">
-            {dot ? <div className="dot" /> : null}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-export default function PlayerToken({ type = 'normal', color }) {
-  const colorClass =
-    type === 'ladder' ? 'token-green' : type === 'snake' ? 'token-red' : 'token-yellow';
-  const style = color ? { '--side-color': color, '--border-color': color } : undefined;
-  const orientation =
-    'rotateX(calc(var(--board-angle, 60deg) * -1 - 25deg)) rotateY(25deg)';
-
-  return (
-    <div className={`token-dice ${colorClass}`} style={style}>
-      <div className="dice-cube w-full h-full" style={{ transform: orientation }}>
-        <Face value={2} className="dice-face--front absolute" />
-        <Face value={5} className="dice-face--back absolute" />
-        <Face value={3} className="dice-face--right absolute" />
-        <Face value={4} className="dice-face--left absolute" />
-        <Face value={1} className="dice-face--top absolute" />
-        <Face value={6} className="dice-face--bottom absolute" />
-      </div>
-    </div>
-  );
+export default function PlayerToken({ type = "normal", color }) {
+  let tokenColor = color;
+  if (!tokenColor) {
+    if (type === "ladder") tokenColor = "#86efac"; // green
+    else if (type === "snake") tokenColor = "#fca5a5"; // red
+    else tokenColor = "#fde047"; // yellow
+  }
+  return <HexPrismToken color={tokenColor} />;
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -188,6 +188,21 @@ body {
   background-color: #fff;
 }
 
+/* Three.js token container */
+.token-three {
+  position: absolute;
+  width: 4rem;
+  height: 4rem;
+  transform: translateZ(10px);
+  pointer-events: none;
+}
+
+.token-three canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 .token-cube-inner {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- add `three` library to webapp
- create `HexPrismToken` component using Three.js
- show hex prism token instead of cube in Snake & Ladder
- style token container for Three.js canvas

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851bc6bf698832992a59eef2d6c39a7