### PR TITLE
Add profile picture to Snake token

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -31,12 +31,14 @@ export default function HexPrismToken({ color = "#008080", photoUrl }) {
     if (photoUrl) {
       const loader = new THREE.TextureLoader();
       loader.load(photoUrl, (tex) => {
+        // ensure the profile photo correctly covers the top face
+        tex.wrapS = THREE.ClampToEdgeWrapping;
+        tex.wrapT = THREE.ClampToEdgeWrapping;
+        tex.center.set(0.5, 0.5);
+        tex.rotation = -Math.PI / 2; // align with board orientation
         tex.needsUpdate = true;
         topMaterial.map = tex;
         topMaterial.needsUpdate = true;
-        // scale height based on image aspect ratio
-        const scale = tex.image.height / tex.image.width;
-        prism.scale.set(1, scale * 2.5, 1);
       });
     }
     scene.add(prism);


### PR DESCRIPTION
## Summary
- align Snake & Ladder token texture with board orientation
- load profile photo onto token top face

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851d236d9f08329a9ddb9c1b9024acd