### PR TITLE
Fix profile photo display on snake tokens

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -30,6 +30,7 @@ export default function HexPrismToken({ color = "#008080", photoUrl }) {
 
     if (photoUrl) {
       const loader = new THREE.TextureLoader();
+      loader.crossOrigin = 'anonymous';
       loader.load(photoUrl, (tex) => {
         // ensure the profile photo correctly covers the top face
         tex.wrapS = THREE.ClampToEdgeWrapping;


### PR DESCRIPTION
## Summary
- ensure texture loader can fetch Telegram avatars by enabling cross origin requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d517b2b48329ad587f7319c210c6