### PR TITLE
Fix photo loading for token and leaderboard

### DIFF
--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
-import { getLeaderboard, getReferralInfo } from '../utils/api.js';
+import { getLeaderboard, getReferralInfo, fetchTelegramInfo } from '../utils/api.js';
 import { BOT_USERNAME } from '../utils/constants.js';
 
 export default function Friends() {
@@ -17,7 +17,7 @@ export default function Friends() {
   const [referral, setReferral] = useState(null);
   const [leaderboard, setLeaderboard] = useState([]);
   const [rank, setRank] = useState(null);
-  const myPhotoUrl = getTelegramPhotoUrl();
+  const [myPhotoUrl, setMyPhotoUrl] = useState(getTelegramPhotoUrl());
 
   useEffect(() => {
     getReferralInfo(telegramId).then(setReferral);
@@ -25,6 +25,11 @@ export default function Friends() {
       setLeaderboard(data.users);
       setRank(data.rank);
     });
+    if (!myPhotoUrl) {
+      fetchTelegramInfo(telegramId).then((info) => {
+        if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
+      });
+    }
   }, [telegramId]);
 
   if (!referral) return <div className="p-4">Loading...</div>;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -8,8 +8,8 @@ import {
 } from "react-icons/ai";
 import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
 import { useNavigate } from "react-router-dom";
-import { getTelegramPhotoUrl } from "../../utils/telegram.js";
-import { getSnakeBoard } from "../../utils/api.js";
+import { getTelegramId, getTelegramPhotoUrl } from "../../utils/telegram.js";
+import { getSnakeBoard, fetchTelegramInfo } from "../../utils/api.js";
 import PlayerToken from "../../components/PlayerToken.jsx";
 
 const PLAYERS = 4;
@@ -260,7 +260,15 @@ export default function SnakeAndLadder() {
   const winSoundRef = useRef(null);
 
   useEffect(() => {
-    setPhotoUrl(getTelegramPhotoUrl());
+    const id = getTelegramId();
+    const url = getTelegramPhotoUrl();
+    if (url) {
+      setPhotoUrl(url);
+    } else if (id) {
+      fetchTelegramInfo(id).then((info) => {
+        if (info?.photoUrl) setPhotoUrl(info.photoUrl);
+      });
+    }
     moveSoundRef.current = new Audio(
       "https://snakes-and-ladders-game.netlify.app/audio/drop.mp3",
     );


### PR DESCRIPTION
## Summary
- fetch Telegram profile photo when not available in local storage
- ensure Snake & Ladder board loads user photo for token
- ensure leaderboard loads user photo when missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d83439b48329a60e38240b10ddde