### PR TITLE
Fix token scaling and restore photo top

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -8,12 +8,15 @@ export default function HexPrismToken({ color = "#008080", photoUrl }) {
     const mount = mountRef.current;
     if (!mount) return;
 
+    // Scale factor to match the enlarged CSS container
+    const SCALE = 3;
+
     const width = mount.clientWidth;
     const height = mount.clientHeight;
 
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 100);
-    camera.position.set(3, 4, 5);
+    camera.position.set(3 * SCALE, 4 * SCALE, 5 * SCALE);
     camera.lookAt(0, 0, 0);
 
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
@@ -22,6 +25,7 @@ export default function HexPrismToken({ color = "#008080", photoUrl }) {
     mount.appendChild(renderer.domElement);
 
     const geometry = new THREE.CylinderGeometry(1, 1, 2.5, 6);
+    geometry.scale(SCALE, SCALE, SCALE);
     const sideMaterial = new THREE.MeshStandardMaterial({ color });
     const bottomMaterial = new THREE.MeshStandardMaterial({ color });
 


### PR DESCRIPTION
## Summary
- keep the hex prism visible after enlarging token
- scale the geometry and adjust camera distance so the photo is visible on the top face

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851ddb0538c8329a7d3eff4df73e6e6