### PR TITLE
Add photo overlay to player token

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -92,5 +92,15 @@ export default function HexPrismToken({ color = "#008080", photoUrl }) {
     };
   }, [color, photoUrl]);
 
-  return <div className="token-three" ref={mountRef} />;
+  return (
+    <div className="token-three relative" ref={mountRef}>
+      {photoUrl && (
+        <img
+          src={photoUrl}
+          alt="token top"
+          className="token-top pointer-events-none"
+        />
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- overlay the player's profile image on the top of the Three.js token

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851e64331c483299bc7ad2a27366522