### PR TITLE
Tilt token with board angle

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -1,7 +1,11 @@
 import { useRef, useEffect } from "react";
 import * as THREE from "three";
 
-export default function HexPrismToken({ color = "#008080", photoUrl }) {
+export default function HexPrismToken({
+  color = "#008080",
+  photoUrl,
+  boardAngle = 60,
+}) {
   const mountRef = useRef(null);
 
   useEffect(() => {
@@ -33,6 +37,8 @@ export default function HexPrismToken({ color = "#008080", photoUrl }) {
     });
     const prism = new THREE.Mesh(geometry, [sideMaterial, topMaterial, bottomMaterial]);
     prism.rotation.y = Math.PI / 6; // show a corner toward the viewer
+    // Tilt token relative to the board so the top face is visible
+    prism.rotation.x = THREE.MathUtils.degToRad(-boardAngle - 25);
 
     if (photoUrl) {
       const loader = new THREE.TextureLoader();
@@ -88,7 +94,7 @@ export default function HexPrismToken({ color = "#008080", photoUrl }) {
       bottomMaterial.dispose();
       renderer.dispose();
     };
-  }, [color, photoUrl]);
+  }, [color, photoUrl, boardAngle]);
 
   return <div className="token-three relative" ref={mountRef} />;
 }

--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -1,12 +1,23 @@
 import React from "react";
 import HexPrismToken from "./HexPrismToken.jsx";
 
-export default function PlayerToken({ type = "normal", color, photoUrl }) {
+export default function PlayerToken({
+  type = "normal",
+  color,
+  photoUrl,
+  boardAngle = 60,
+}) {
   let tokenColor = color;
   if (!tokenColor) {
     if (type === "ladder") tokenColor = "#86efac"; // green
     else if (type === "snake") tokenColor = "#fca5a5"; // red
     else tokenColor = "#fde047"; // yellow
   }
-  return <HexPrismToken color={tokenColor} photoUrl={photoUrl} />;
+  return (
+    <HexPrismToken
+      color={tokenColor}
+      photoUrl={photoUrl}
+      boardAngle={boardAngle}
+    />
+  );
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -80,6 +80,7 @@ function Board({
           {position === num && (
             <PlayerToken
               photoUrl={photoUrl}
+              boardAngle={angle}
               type={isHighlight ? highlight.type : 'normal'}
             />
           )}
@@ -225,6 +226,7 @@ function Board({
               {position === FINAL_TILE && (
                 <PlayerToken
                   photoUrl={photoUrl}
+                  boardAngle={angle}
                   type={highlight && highlight.cell === FINAL_TILE ? highlight.type : 'normal'}
                 />
               )}


### PR DESCRIPTION
## Summary
- tilt 3D token so that the photo on top is visible
- expose `boardAngle` through `PlayerToken` and propagate from the board

## Testing
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68523d9f37b483299b4c49482e10de48