### PR TITLE
Increase snake board token height

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -22,7 +22,9 @@ export default function HexPrismToken({ color = "#008080", photoUrl }) {
     renderer.setPixelRatio(window.devicePixelRatio);
     mount.appendChild(renderer.domElement);
 
-    const geometry = new THREE.CylinderGeometry(1.1, 1.1, 0.6, 6);
+    // Make the prism noticeably taller so tokens stand out on the board
+    // Height is tripled relative to the original design
+    const geometry = new THREE.CylinderGeometry(1.1, 1.1, 1.8, 6);
     geometry.scale(SCALE, SCALE, SCALE);
     const sideMaterial = new THREE.MeshStandardMaterial({ color });
     const bottomMaterial = new THREE.MeshStandardMaterial({ color });


### PR DESCRIPTION
## Summary
- stretch the snake & ladder token geometry so the prism is much taller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68524130375c8329a7c822429f88fe5c