### PR TITLE
Align 3D tokens with board tilt

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -33,7 +33,11 @@ export default function HexPrismToken({ color = "#008080", photoUrl }) {
       color,
       side: THREE.DoubleSide,
     });
-    const prism = new THREE.Mesh(geometry, [sideMaterial, topMaterial, bottomMaterial]);
+    const prism = new THREE.Mesh(
+      geometry,
+      [sideMaterial, topMaterial, bottomMaterial],
+    );
+    prism.position.y = (1.8 * SCALE) / 2; // align base with board surface
     prism.rotation.y = Math.PI / 6; // show a corner toward the viewer
 
     if (photoUrl) {

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -193,7 +193,11 @@ body {
   position: absolute;
   width: 12rem;
   height: 12rem;
-  transform: translateZ(30px);
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%) translateZ(30px)
+    rotateX(calc(var(--board-angle, 60deg) * -1));
+  transform-origin: bottom center;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- orient three.js tokens to match board rotation
- anchor token base at bottom center of each board tile

## Testing
- `npm test` *(fails: manifest endpoint not reachable and missing dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68524a0c33e083299e54862027749a58