### PR TITLE
Align 3D token with board orientation

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -33,7 +33,11 @@ export default function HexPrismToken({ color = "#008080", photoUrl }) {
       color,
       side: THREE.DoubleSide,
     });
-    const prism = new THREE.Mesh(geometry, [sideMaterial, topMaterial, bottomMaterial]);
+    const prism = new THREE.Mesh(
+      geometry,
+      [sideMaterial, topMaterial, bottomMaterial],
+    );
+    prism.position.y = (1.8 * SCALE) / 2; // align base with board surface
     prism.rotation.y = Math.PI / 6; // show a corner toward the viewer
 
     if (photoUrl) {

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -193,7 +193,11 @@ body {
   position: absolute;
   width: 12rem;
   height: 12rem;
-  transform: translateZ(30px);
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%) translateZ(30px)
+    rotateX(calc(var(--board-angle, 60deg) * -1));
+  transform-origin: bottom center;
   pointer-events: none;
 }
 
@@ -208,8 +212,8 @@ body {
   width: 100%;
   height: 100%;
   transform-style: preserve-3d;
-  /* Align token with board surface while showing a slight side angle */
-  transform: rotateX(calc(var(--board-angle, 60deg) * -1 - 25deg)) rotateY(25deg);
+  /* Align token with board surface */
+  transform: rotateX(calc(var(--board-angle, 60deg) * -1)) rotateY(25deg);
 }
 
 .cube-face {


### PR DESCRIPTION
## Summary
- rotate the token container so it mirrors the board angle
- position the prism base flush with the board
- remove extra tilt from token cube

## Testing
- `npm test` *(fails: manifest endpoint & lobby route unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68524c7ddae8832996b02e0e14221b4b