### PR TITLE
Fix token visibility on Snake board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -120,6 +120,8 @@ body {
   @apply relative flex items-center justify-center rounded-xl text-text shadow-inner bg-surface border-2 border-accent;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5);
   transform: translateZ(5px);
+  transform-style: preserve-3d;
+  overflow: visible;
   width: var(--cell-width);
   height: var(--cell-height);
 }
@@ -193,7 +195,7 @@ body {
   position: absolute;
   width: 12rem;
   height: 12rem;
-  transform: translateZ(30px);
+  transform: translateZ(60px);
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- keep 3D context for Snake board cells and allow overflow
- raise PlayerToken above other board elements to stop occlusion

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68524fd8aec08329b4eb2c701865e4cc