### PR TITLE
Show profile photo on token

### DIFF
--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -8,5 +8,16 @@ export default function PlayerToken({ type = "normal", color, photoUrl }) {
     else if (type === "snake") tokenColor = "#fca5a5"; // red
     else tokenColor = "#fde047"; // yellow
   }
-  return <HexPrismToken color={tokenColor} photoUrl={photoUrl} />;
+  return (
+    <div className="relative">
+      <HexPrismToken color={tokenColor} photoUrl={photoUrl} />
+      {photoUrl && (
+        <img
+          src={photoUrl}
+          alt="token avatar"
+          className="absolute top-1/2 left-1/2 w-16 h-16 rounded-full -translate-x-1/2 -translate-y-1/2 pointer-events-none"
+        />
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- display the player's photo above the 3D game token so that it's clearly visible

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685259eb0b5c8329ae97d674340f9289