### PR TITLE
Overlay profile photo on token

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -92,5 +92,11 @@ export default function HexPrismToken({ color = "#008080", photoUrl }) {
     };
   }, [color, photoUrl]);
 
-  return <div className="token-three relative" ref={mountRef} />;
+  return (
+    <div className="token-three relative" ref={mountRef}>
+      {photoUrl && (
+        <img src={photoUrl} alt="token" className="token-photo" />
+      )}
+    </div>
+  );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -205,6 +205,19 @@ body {
   display: block;
 }
 
+.token-photo {
+  position: absolute;
+  width: 4rem;
+  height: 4rem;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
+  object-fit: cover;
+  pointer-events: none;
+  z-index: 1;
+}
+
 .token-cube-inner {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- display player's profile photo above the 3D token
- add styling for hexagon-shaped photo overlay

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68525d10d3b48329a5da8889f9a414fc