### PR TITLE
Fix token photo styling

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -211,8 +211,9 @@ body {
   height: 4rem;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
-  clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
+  transform: translate(-50%, -50%)
+    rotateX(calc(var(--board-angle, 60deg) * -1));
+  border-radius: 50%;
   object-fit: cover;
   pointer-events: none;
   z-index: 1;


### PR DESCRIPTION
## Summary
- make the player token's photo round
- rotate the photo to match the board angle

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685260371874832990f82133c4ba3f7d