### PR TITLE
Fix token photo orientation

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -218,7 +218,8 @@ body {
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%)
+    rotateX(calc(var(--board-angle, 60deg) * -1));
   width: 4rem;
   height: 4rem;
   border-radius: 50%;


### PR DESCRIPTION
## Summary
- rotate player photo overlay to match board's angle

## Testing
- `npm test` *(fails: manifest and lobby endpoints unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68526f4e74dc8329b9ee0f7e652a9ce6