### PR TITLE
Fix token photo positioning

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -207,11 +207,11 @@ body {
 
 .token-photo {
   position: absolute;
-  width: 4rem;
-  height: 4rem;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  transform: none;
   clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
   object-fit: cover;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- keep the hex prism token unchanged but adjust the overlay photo
- stretch `.token-photo` to fill the token and align to the top hexagon

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852896f5b10832981cfcbf354a85c68