### PR TITLE
Adjust token photo depth

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -196,6 +196,8 @@ body {
   width: 12rem;
   height: 12rem;
   transform: translateZ(60px);
+  /* Preserve 3D space so the photo can be positioned in depth */
+  transform-style: preserve-3d;
   pointer-events: none;
 }
 
@@ -211,7 +213,8 @@ body {
   height: 2.5rem;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  /* Nudge the photo slightly forward so it stands out */
+  transform: translate(-50%, -50%) translateZ(20px);
   object-fit: cover;
   border-radius: 50%;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- preserve 3D transforms for tokens so child elements keep depth
- bring the player's photo slightly forward in the Snake & Ladder board

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68529a513208832996e2b994854ac8bb