### PR TITLE
Fix token photo tilt

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -214,7 +214,7 @@ body {
   top: 50%;
   left: 50%;
   /* Nudge the photo slightly forward so it stands out */
-  transform: translate(-50%, -50%) translateZ(20px);
+  transform: translate(-50%, -50%) translateZ(20px) rotateX(30deg);
   object-fit: cover;
   border-radius: 50%;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- tilt token photo to a 30 degree angle so it matches the board perspective

## Testing
- `npm test` *(fails: `ERR_MODULE_NOT_FOUND` for `dotenv`)*

------
https://chatgpt.com/codex/tasks/task_e_6852a042fe048329979498f38b8fc095