### PR TITLE
Fix token photo tilt

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -214,7 +214,7 @@ body {
   top: 50%;
   left: 50%;
   /* Nudge the photo slightly forward so it stands out */
-  transform: translate(-50%, -50%) translateZ(20px) rotateX(30deg);
+  transform: translate(-50%, -50%) translateZ(20px) rotateX(15deg);
   object-fit: cover;
   border-radius: 50%;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- correct the CSS so token photos tilt at 15 degrees

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852a2761d3083298f8fe76fbfd73b57