### PR TITLE
Adjust token photo position

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -213,8 +213,8 @@ body {
   height: 2.5rem;
   top: 50%;
   left: 50%;
-  /* Nudge the photo slightly forward so it stands out */
-  transform: translate(-50%, -50%) translateZ(20px) rotateX(10deg);
+  /* Nudge the photo slightly further forward so it stands out */
+  transform: translate(-50%, -50%) translateZ(30px) rotateX(10deg);
   object-fit: cover;
   border-radius: 50%;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- push the player's profile photo a bit further forward on the snake board token

## Testing
- `npm test` *(fails: lobby route not reachable due to missing dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_6852a857dcb0832994c193ee298e75b0