### PR TITLE
Remove icons, clarify asset location

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ bash scripts/install_ludo_game.sh
 ```
 
 The compiled assets are copied into `webapp/public/games/ludo`.
+
+### Customizing Snakes & Ladders icons
+
+All webapp icons are stored in `webapp/public/assets/icons`. The board reuses `snake.svg` for snake connectors while ladder connectors are drawn in CSS. To use your own images, replace `snake.svg` or add new files in the same folder and update the paths in `src/index.css`.


### PR DESCRIPTION
## Summary
- revert icon updates so connectors use CSS and inline SVG
- document where to place custom snake and ladder icons

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852a6ca999c8329b673a517c9c71893