### PR TITLE
Fix highlight persistence on snake board

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -360,7 +360,10 @@ export default function SnakeAndLadder() {
 
         setTimeout(() => {
           setPos(finalPos);
-          setHighlight(null);
+          setHighlight({
+            cell: finalPos,
+            type: ladder ? 'ladder' : snake ? 'snake' : 'normal',
+          });
           setTokenType(ladder ? 'ladder' : snake ? 'snake' : 'normal');
           if (finalPos === FINAL_TILE) {
             setMessage(`You win ${pot} ${token}!`);


### PR DESCRIPTION
## Summary
- keep tile highlight after the token stops moving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852b2322ca08329bec1ea0a8e6dcad6