### PR TITLE
Fix token photo alignment with board tilt

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -214,7 +214,9 @@ body {
   top: 50%;
   left: 50%;
   /* Nudge the photo slightly forward so it stands out */
-  transform: translate(-50%, -50%) translateZ(20px) rotateX(10deg);
+  /* Rotate with the board angle so the image stays centered */
+  transform: translate(-50%, -50%) translateZ(20px)
+    rotateX(calc(var(--board-angle, 60deg) * -1));
   object-fit: cover;
   border-radius: 50%;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- keep player photo centered on token while board angle changes

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852b7fb6bcc83298b0be8c2b92803d2