### PR TITLE
Implement random snake and ladder effects

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -425,7 +425,20 @@ body {
 }
 
 .board-marker {
-  transform: translateZ(6px);
+  position: absolute;
+  transform: translate(-50%, -50%) translateZ(6px);
+}
+
+.snake-marker {
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZD0iTTEyIDE2YzgtOCAxNi04IDI0IDBzMTYgOCAyNCAwIiBzdHJva2U9IiMxNmEzNGEiIHN0cm9rZS13aWR0aD0iNCIgZmlsbD0ibm9uZSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+PHBhdGggZD0iTTYwIDQ4Yy04IDgtMTYgOC0yNCAwcy0xNi04LTI0IDAiIHN0cm9rZT0iIzE2YTM0YSIgc3Ryb2tlLXdpZHRoPSI0IiBmaWxsPSJub25lIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48Y2lyY2xlIGN4PSI1NiIgY3k9IjE2IiByPSI0IiBmaWxsPSIjZGMyNjI2Ii8+PC9zdmc+");
+  background-size: contain;
+  background-repeat: no-repeat;
+}
+
+.ladder-marker {
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+PGcgc3Ryb2tlPSIjMTZhMzRhIiBzdHJva2Utd2lkdGg9IjYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgZmlsbD0ibm9uZSI+PGxpbmUgeDE9IjIwIiB5MT0iNCIgeDI9IjIwIiB5Mj0iNjAiIC8+PGxpbmUgeDE9IjQ0IiB5MT0iNCIgeDI9IjQ0IiB5Mj0iNjAiIC8+PGxpbmUgeDE9IjIwIiB5MT0iMTYiIHgyPSI0NCIgeTI9IjE2IiAvPjxsaW5lIHgxPSIyMCIgeTE9IjMwIiB4Mj0iNDQiIHkyPSIzMCIgLz48bGluZSB4MT0iMjAiIHkxPSI0NCIgeDI9IjQ0IiB5Mj0iNDQiIC8+PC9nPjwvc3ZnPg==");
+  background-size: contain;
+  background-repeat: no-repeat;
 }
 
 .coin-burst {


### PR DESCRIPTION
## Summary
- render snake and ladder icons on board cells
- show messages in green/red when ladders/snakes trigger
- animate token movement forward or backward by a random amount
- style new board markers

## Testing
- `npm test` *(fails: server manifest and snake lobby tests)*

------
https://chatgpt.com/codex/tasks/task_e_6852bc50a550832985d0d58cb9661f91