### PR TITLE
Add emoji markers for ladders and snakes

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -372,6 +372,23 @@ body {
   background-color: #fca5a5; /* red-300 */
 }
 
+/* Indicate ladder or snake on the board */
+.board-cell.ladder-cell {
+  background-color: #86efac; /* green-300 */
+}
+
+.board-cell.snake-cell {
+  background-color: #fca5a5; /* red-300 */
+}
+
+.cell-icon {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
 .pot-cell {
   @apply absolute flex flex-col items-center justify-center hexagon bg-primary text-background border-2 border-accent;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5);
@@ -429,16 +446,21 @@ body {
   transform: translate(-50%, -50%) translateZ(6px);
 }
 
-.snake-marker {
-  background-image: url("/assets/icons/snake.png");
-  background-size: contain;
-  background-repeat: no-repeat;
+.snake-marker,
+.ladder-marker {
+  font-size: 1.5rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.ladder-marker {
-  background-image: url("/assets/icons/ladder.png");
-  background-size: contain;
-  background-repeat: no-repeat;
+.snake-marker::before {
+  content: "🐍";
+}
+
+.ladder-marker::before {
+  content: "🪜";
 }
 
 .coin-burst {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -69,13 +69,17 @@ function Board({
       const num = r * COLS + col + 1;
       const isHighlight = highlight && highlight.cell === num;
       const highlightClass = isHighlight ? `${highlight.type}-highlight` : "";
+      const cellType = ladders[num] ? "ladder" : snakes[num] ? "snake" : "";
+      const cellClass = cellType ? `${cellType}-cell` : "";
+      const icon = cellType === "ladder" ? "🪜" : cellType === "snake" ? "🐍" : "";
       tiles.push(
         <div
           key={num}
           data-cell={num}
-          className={`board-cell ${highlightClass}`}
+          className={`board-cell ${cellClass} ${highlightClass}`}
           style={{ gridRowStart: ROWS - r, gridColumnStart: col + 1 }}
         >
+          {icon && <span className="cell-icon">{icon}</span>}
           {num}
           {position === num && (
             <PlayerToken
@@ -360,7 +364,7 @@ export default function SnakeAndLadder() {
     const applyEffect = (startPos) => {
       if (Object.keys(snakes).includes(String(startPos))) {
         const offset = Math.floor(Math.random() * 10) + 1;
-        setMessage(`-${offset}`);
+        setMessage(`🐍 ${startPos} -${offset}`);
         setMessageColor('text-red-500');
         snakeSoundRef.current?.play().catch(() => {});
         const seq = [];
@@ -368,7 +372,7 @@ export default function SnakeAndLadder() {
         moveSeq(seq, 'snake', () => finalizeMove(Math.max(0, startPos - offset), 'snake'));
       } else if (Object.keys(ladders).includes(String(startPos))) {
         const offset = Math.floor(Math.random() * 10) + 1;
-        setMessage(`+${offset}`);
+        setMessage(`🪜 ${startPos} +${offset}`);
         setMessageColor('text-green-500');
         ladderSoundRef.current?.play().catch(() => {});
         const seq = [];


### PR DESCRIPTION
## Summary
- display ladder and snake icons directly on board cells
- colour ladder cells green and snake cells red
- show 🪜/🐍 plus tile number and offset in messages
- style markers using emoji instead of images

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852ca965de48329bfb1aa3574e8ea20