### PR TITLE
Add popup effect for snakes and ladders

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -517,3 +517,23 @@ body {
     opacity: 0;
   }
 }
+
+.popup-offset {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translate(-50%, 0);
+  pointer-events: none;
+  animation: popup-move 1s ease-out forwards;
+}
+
+@keyframes popup-move {
+  from {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  to {
+    opacity: 0;
+    transform: translate(-50%, -30px);
+  }
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -57,6 +57,7 @@ function Board({
   ladders,
   snakeOffsets,
   ladderOffsets,
+  offsetPopup,
   celebrate,
   token,
   tokenType,
@@ -100,6 +101,16 @@ function Board({
               photoUrl={photoUrl}
               type={isHighlight ? highlight.type : tokenType}
             />
+          )}
+          {offsetPopup && offsetPopup.cell === num && (
+            <span
+              className={`popup-offset italic font-bold ${
+                offsetPopup.type === 'snake' ? 'text-red-500' : 'text-green-500'
+              }`}
+            >
+              {offsetPopup.type === 'snake' ? '-' : '+'}
+              {offsetPopup.amount}
+            </span>
           )}
         </div>,
       );
@@ -276,6 +287,7 @@ export default function SnakeAndLadder() {
   const [ladders, setLadders] = useState({});
   const [snakeOffsets, setSnakeOffsets] = useState({});
   const [ladderOffsets, setLadderOffsets] = useState({});
+  const [offsetPopup, setOffsetPopup] = useState(null); // { cell, type, amount }
 
   const moveSoundRef = useRef(null);
   const snakeSoundRef = useRef(null);
@@ -337,6 +349,7 @@ export default function SnakeAndLadder() {
 
   const handleRoll = (values) => {
     setTurnMessage("");
+    setOffsetPopup(null);
     const value = Array.isArray(values)
       ? values.reduce((a, b) => a + b, 0)
       : values;
@@ -390,6 +403,8 @@ export default function SnakeAndLadder() {
     const applyEffect = (startPos) => {
       if (Object.keys(snakes).includes(String(startPos))) {
         const offset = snakeOffsets[startPos] || 0;
+        setOffsetPopup({ cell: startPos, type: 'snake', amount: offset });
+        setTimeout(() => setOffsetPopup(null), 1000);
         setMessage(`🐍 ${startPos} -${offset}`);
         setMessageColor('text-red-500');
         snakeSoundRef.current?.play().catch(() => {});
@@ -398,6 +413,8 @@ export default function SnakeAndLadder() {
         moveSeq(seq, 'snake', () => finalizeMove(Math.max(0, startPos - offset), 'snake'));
       } else if (Object.keys(ladders).includes(String(startPos))) {
         const offset = ladderOffsets[startPos] || 0;
+        setOffsetPopup({ cell: startPos, type: 'ladder', amount: offset });
+        setTimeout(() => setOffsetPopup(null), 1000);
         setMessage(`🪜 ${startPos} +${offset}`);
         setMessageColor('text-green-500');
         ladderSoundRef.current?.play().catch(() => {});
@@ -460,6 +477,7 @@ export default function SnakeAndLadder() {
         ladders={ladders}
         snakeOffsets={snakeOffsets}
         ladderOffsets={ladderOffsets}
+        offsetPopup={offsetPopup}
         celebrate={celebrate}
         token={token}
         tokenType={tokenType}


### PR DESCRIPTION
## Summary
- show an offset popup from a board cell when landing on a snake or ladder

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852df3b30388329b0c2fde9478b87dd