### PR TITLE
Center board markers and enlarge popup

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -381,18 +381,23 @@ body {
   background-color: #fca5a5; /* red-300 */
 }
 
-.cell-icon {
+.cell-marker {
   position: absolute;
-  top: 2px;
-  left: 2px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  pointer-events: none;
+}
+
+.cell-icon {
   font-size: 1.5rem; /* slightly larger for better visibility */
   line-height: 1;
 }
 
 .cell-offset {
-  position: absolute;
-  top: 2px;
-  right: 2px;
   font-size: 1rem;
   line-height: 1;
   color: #ffffff;
@@ -525,6 +530,7 @@ body {
   left: 50%;
   transform: translate(-50%, 0);
   pointer-events: none;
+  font-size: 3rem;
   animation: popup-move 1s ease-out forwards;
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -88,11 +88,15 @@ function Board({
           className={`board-cell ${cellClass} ${highlightClass}`}
           style={{ gridRowStart: ROWS - r, gridColumnStart: col + 1 }}
         >
-          {icon && <span className="cell-icon">{icon}</span>}
-          {offsetVal != null && (
-            <span className="cell-offset">
-              {cellType === "snake" ? "-" : "+"}
-              {offsetVal}
+          {(icon || offsetVal != null) && (
+            <span className="cell-marker">
+              {icon && <span className="cell-icon">{icon}</span>}
+              {offsetVal != null && (
+                <span className="cell-offset">
+                  {cellType === "snake" ? "-" : "+"}
+                  {offsetVal}
+                </span>
+              )}
             </span>
           )}
           <span className="cell-number">{num}</span>


### PR DESCRIPTION
## Summary
- center snake/ladder marker icon and value
- enlarge popup text when landing on snake or ladder

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_6852e2de093483299cbb959d5a6c9404