### PR TITLE
Add player name to rotating token

### DIFF
--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -1,12 +1,12 @@
 import React from "react";
 import HexPrismToken from "./HexPrismToken.jsx";
 
-export default function PlayerToken({ type = "normal", color, photoUrl }) {
+export default function PlayerToken({ type = "normal", color, photoUrl, name }) {
   let tokenColor = color;
   if (!tokenColor) {
     if (type === "ladder") tokenColor = "#86efac"; // green
     else if (type === "snake") tokenColor = "#fca5a5"; // red
     else tokenColor = "#fde047"; // yellow
   }
-  return <HexPrismToken color={tokenColor} photoUrl={photoUrl} />;
+  return <HexPrismToken color={tokenColor} photoUrl={photoUrl} name={name} />;
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -8,7 +8,11 @@ import {
 } from "react-icons/ai";
 import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
 import { useNavigate } from "react-router-dom";
-import { getTelegramId, getTelegramPhotoUrl } from "../../utils/telegram.js";
+import {
+  getTelegramId,
+  getTelegramPhotoUrl,
+  getTelegramFirstName,
+} from "../../utils/telegram.js";
 import { getSnakeBoard, fetchTelegramInfo } from "../../utils/api.js";
 import PlayerToken from "../../components/PlayerToken.jsx";
 
@@ -52,6 +56,7 @@ function Board({
   position,
   highlight,
   photoUrl,
+  playerName,
   pot,
   snakes,
   ladders,
@@ -103,6 +108,7 @@ function Board({
           {position === num && (
             <PlayerToken
               photoUrl={photoUrl}
+              name={playerName}
               type={isHighlight ? highlight.type : tokenType}
             />
           )}
@@ -220,6 +226,7 @@ function Board({
               {position === FINAL_TILE && (
                 <PlayerToken
                   photoUrl={photoUrl}
+                  name={playerName}
                   type={highlight && highlight.cell === FINAL_TILE ? highlight.type : tokenType}
                 />
               )}
@@ -244,6 +251,7 @@ export default function SnakeAndLadder() {
   const [messageColor, setMessageColor] = useState("");
   const [turnMessage, setTurnMessage] = useState("Your turn");
   const [photoUrl, setPhotoUrl] = useState("");
+  const [playerName, setPlayerName] = useState("");
   const [pot, setPot] = useState(100);
   const [token, setToken] = useState("TPC");
   const [celebrate, setCelebrate] = useState(false);
@@ -262,11 +270,14 @@ export default function SnakeAndLadder() {
   useEffect(() => {
     const id = getTelegramId();
     const url = getTelegramPhotoUrl();
+    const first = getTelegramFirstName();
+    if (first) setPlayerName(first);
     if (url) {
       setPhotoUrl(url);
     } else if (id) {
       fetchTelegramInfo(id).then((info) => {
         if (info?.photoUrl) setPhotoUrl(info.photoUrl);
+        if (!first && info?.firstName) setPlayerName(info.firstName);
       });
     }
     moveSoundRef.current = new Audio(
@@ -448,6 +459,7 @@ export default function SnakeAndLadder() {
         position={pos}
         highlight={highlight}
         photoUrl={photoUrl}
+        playerName={playerName}
         pot={pot}
         snakes={snakes}
         ladders={ladders}


### PR DESCRIPTION
## Summary
- show player name on rotating token faces
- pass playerName through the Snake and Ladder board
- fetch user's first name when loading the game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852f1079c688329ae0e61f772cbfa8e