### PR TITLE
Adjust logo depth on Snake & Ladder board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -445,7 +445,7 @@ body {
   height: calc(var(--cell-height) * 4.8); /* 20% smaller */
   top: calc(var(--cell-height) * -4.5); /* ✅ push above pot */
   left: 50%;
-  transform: translateX(-50%) rotateX(-60deg) translateZ(-20px) scale(1.8); /* Enlarged, base anchored */
+  transform: translateX(-50%) rotateX(-60deg) translateZ(-40px) scale(1.8); /* Move back slightly */
   transform-origin: bottom center;
   background-image: url("/assets/TonPlayGramLogo.jpg");
   background-size: contain;


### PR DESCRIPTION
## Summary
- tweak board CSS so logo sits further back and does not cover the pot

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_6853003ff7348329910425e353ce1106