### PR TITLE
Adjust pot and logo position

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -428,7 +428,7 @@ body {
   @apply absolute flex flex-col items-center justify-center;
   width: calc(var(--cell-width) * 1.8);
   height: calc(var(--cell-height) * 1.8);
-  top: calc(var(--cell-height) * -0.95);
+  top: calc(var(--cell-height) * -1.2);
   left: 50%;
   transform: translateX(-50%) translateZ(8px);
   z-index: 15;
@@ -445,7 +445,7 @@ body {
   @apply absolute flex items-center justify-center;
   width: calc(var(--cell-width) * 5.76); /* 20% smaller */
   height: calc(var(--cell-height) * 4.8); /* 20% smaller */
-  top: calc(var(--cell-height) * -4.5); /* ✅ push above pot */
+  top: calc(var(--cell-height) * -5); /* push above pot */
   left: 50%;
   transform: translateX(-50%) rotateX(-60deg) translateZ(-40px) scale(1.8); /* Move back slightly */
   transform-origin: bottom center;


### PR DESCRIPTION
## Summary
- raise the pot closer to the top
- lift the logo higher above the board

## Testing
- `npm test` *(fails: manifest and snake lobby routes not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685314004eac8329b9e801e0b50521b2