### PR TITLE
Enhance snake board 3D look

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -54,7 +54,7 @@ body {
 
 /* Tilted view specifically for the Snake & Ladder board */
 .snake-board-tilt {
-  perspective: 1200px;
+  perspective: 1600px;
 }
 
 .snake-board-grid {
@@ -124,6 +124,20 @@ body {
   overflow: visible;
   width: var(--cell-width);
   height: var(--cell-height);
+}
+
+.board-cell::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -8px;
+  height: 8px;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.4));
+  border-bottom-left-radius: inherit;
+  border-bottom-right-radius: inherit;
+  transform: translateZ(-4px) skewX(-45deg);
+  transform-origin: top left;
 }
 
 .board-cell::after {
@@ -466,7 +480,7 @@ body {
 }
 
 .snake-connector {
-  background-image: url("/assets/icons/snake.png");
+  background-image: url("/assets/icons/snake.svg");
   background-size: 100% 100%;
   background-repeat: no-repeat;
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- adjust board perspective
- update snake connector icon path
- add pseudo-element for board tiles giving a prism-style side

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6853176167f48329b26eb997e283d04c