### PR TITLE
Apply bold cartoon style to snake board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -551,3 +551,37 @@ body {
     transform: translate(-50%, -30px);
   }
 }
+
+/* Bold 2D Cartoon Vector Style for Snake & Ladder board */
+.cartoon-board {
+  transform: none !important;
+}
+
+.cartoon-board .board-cell {
+  border: 4px solid #000;
+  background-color: #fff8dc;
+  box-shadow: none;
+  transform: none;
+}
+
+.cartoon-board .board-cell::after {
+  box-shadow: none;
+}
+
+.cartoon-board .cell-number {
+  font-weight: bold;
+  color: #000;
+}
+
+.cartoon-board .snake-connector,
+.cartoon-board .ladder-connector {
+  filter: drop-shadow(2px 2px 0 #000);
+}
+
+.cartoon-board .board-cell.snake-cell {
+  background-color: #fb7185;
+}
+
+.cartoon-board .board-cell.ladder-cell {
+  background-color: #34d399;
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -137,8 +137,8 @@ function Board({
   // were added which resulted in duplicate icons and misalignment when the
   // board scaled. The markers logic has been removed and the icons are now
   // displayed only once within the cell itself.
-  // Fixed board angle and scale so the camera does not zoom
-  const angle = 60;
+  // Display the board in a straight 2D view for a bold cartoon look
+  const angle = 0;
   const zoom = 1;
 
   useEffect(() => {
@@ -185,7 +185,7 @@ function Board({
       >
         <div className="snake-board-tilt">
           <div
-            className="snake-board-grid grid gap-1 relative mx-auto"
+            className="snake-board-grid cartoon-board grid gap-1 relative mx-auto"
             style={{
               width: `${cellWidth * COLS}px`,
               height: `${cellHeight * ROWS}px`,


### PR DESCRIPTION
## Summary
- add 'cartoon-board' CSS rules for a bold 2D vector look
- show the snake board using this style

## Testing
- `npm test` *(fails: manifest endpoint not reachable and snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_68531cef227c8329a9d19459e067ae26