### PR TITLE
Adjust pot and photo positions

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -428,7 +428,8 @@ body {
   @apply absolute flex flex-col items-center justify-center;
   width: calc(var(--cell-width) * 1.8);
   height: calc(var(--cell-height) * 1.8);
-  top: calc(var(--cell-height) * -1.2);
+  /* raise the pot slightly higher */
+  top: calc(var(--cell-height) * -1.8);
   left: 50%;
   transform: translateX(-50%) translateZ(8px);
   z-index: 15;
@@ -445,7 +446,8 @@ body {
   @apply absolute flex items-center justify-center;
   width: calc(var(--cell-width) * 5.76); /* 20% smaller */
   height: calc(var(--cell-height) * 4.8); /* 20% smaller */
-  top: calc(var(--cell-height) * -5); /* push above pot */
+  /* shift the logo up to match the higher pot */
+  top: calc(var(--cell-height) * -5.5); /* push above pot */
   left: 50%;
   transform: translateX(-50%) rotateX(-60deg) translateZ(-40px) scale(1.8); /* Move back slightly */
   transform-origin: bottom center;


### PR DESCRIPTION
## Summary
- tweak board CSS to move the pot and logo higher

## Testing
- `npm test` *(fails: manifest endpoint and snake lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68531f4525e0832985e0066b1cf1d470