### PR TITLE
Adjust camera follow for 3-row view

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -162,8 +162,8 @@ function Board({
       target = maxScroll;
     } else {
       // Once past the third row, keep the logo visible and show
-      // two rows behind the player
-      const desiredBottom = boardHeight - (rowFromBottom - 2) * cellHeightPx;
+      // three rows behind the player
+      const desiredBottom = boardHeight - (rowFromBottom - 3) * cellHeightPx;
       target = desiredBottom - container.clientHeight;
       if (target < 0) target = 0;
       if (target > maxScroll) target = maxScroll;


### PR DESCRIPTION
## Summary
- tweak Snake & Ladder scroll calculation so camera shows three rows behind the player

## Testing
- `npm test` *(fails: snake lobby route lists players and server exposes manifest endpoint tests)*

------
https://chatgpt.com/codex/tasks/task_e_68538e310a388329949d6ccb7fea0ca6