### PR TITLE
Fix Snake & Ladder camera angle

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -449,7 +449,7 @@ body {
   /* shift the logo up to match the higher pot */
   top: calc(var(--cell-height) * -5.5); /* push above pot */
   left: 50%;
-  transform: translateX(-50%) rotateX(-60deg) translateZ(-40px) scale(1.8); /* Move back slightly */
+  transform: translateX(-50%) rotateX(calc(var(--board-angle, 60deg) * -1)) translateZ(-40px) scale(1.8); /* Move back slightly */
   transform-origin: bottom center;
   background-image: url("/assets/TonPlayGramLogo.jpg");
   background-size: contain;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -139,7 +139,8 @@ function Board({
   // board scaled. The markers logic has been removed and the icons are now
   // displayed only once within the cell itself.
   // Fixed board angle with no zoom
-  const angle = 60;
+  // Lowered camera so the logo fits entirely on screen
+  const angle = 75;
 
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
## Summary
- tweak camera angle for the Snake and Ladder board so the logo is fully visible
- rotate the logo wall based on the board angle

## Testing
- `npm test --silent` *(fails: cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685394aa228483299e89a51869848798