### PR TITLE
Adjust camera angle for Snakes & Ladders

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -139,8 +139,8 @@ function Board({
   // board scaled. The markers logic has been removed and the icons are now
   // displayed only once within the cell itself.
   // Fixed board angle with no zoom
-  // Lowered camera so the logo fits entirely on screen
-  const angle = 75;
+  // Lowered camera angle so the logo touches the top of the screen
+  const angle = 60;
 
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
## Summary
- tweak the board angle to keep the logo fully visible without zooming

## Testing
- `npm test` *(fails: manifest endpoint not reachable, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_6853971432648329b3de28e12ee3555c