### PR TITLE
Fix snake logo alignment

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -444,7 +444,9 @@ body {
 
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 5); /* slightly narrower */
+  width: calc(
+    var(--cell-width) * 5 + var(--cell-gap, 0px) * 4
+  ); /* match board width including gaps */
   height: calc(var(--cell-height) * 4.2);
   /* shift the logo up to match the higher pot */
   top: calc(var(--cell-height) * -5.5); /* push above pot */

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -119,6 +119,7 @@ function Board({
   // Scale board based on viewport width so it fills the screen.
   const [cellWidth, setCellWidth] = useState(80);
   const [cellHeight, setCellHeight] = useState(40);
+  const CELL_GAP = 4; // gap-1 => 0.25rem
 
   useEffect(() => {
     const updateSize = () => {
@@ -169,13 +170,14 @@ function Board({
           <div
             className="snake-board-grid grid gap-1 relative mx-auto"
             style={{
-              width: `${cellWidth * COLS}px`,
-              height: `${cellHeight * ROWS}px`,
+              width: `${cellWidth * COLS + CELL_GAP * (COLS - 1)}px`,
+              height: `${cellHeight * ROWS + CELL_GAP * (ROWS - 1)}px`,
               gridTemplateColumns: `repeat(${COLS}, ${cellWidth}px)`,
               gridTemplateRows: `repeat(${ROWS}, ${cellHeight}px)`,
               "--cell-width": `${cellWidth}px`,
               "--cell-height": `${cellHeight}px`,
               "--board-width": `${cellWidth * COLS}px`,
+              "--cell-gap": `${CELL_GAP}px`,
               "--board-angle": `${angle}deg`,
               // Fixed camera angle with no zooming
               transform: `rotateX(${angle}deg)`,


### PR DESCRIPTION
## Summary
- adjust board styles to expose cell gap
- size the snake board logo to match the board width

## Testing
- `npm test` *(fails: manifest and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68539d3108648329920a1fb5c5deb4b0