### PR TITLE
Adjust logo size for Snake & Ladder

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -444,12 +444,12 @@ body {
 
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 5); /* slightly narrower */
-  height: calc(var(--cell-height) * 4.2);
+  width: calc(var(--cell-width) * 6); /* larger logo width */
+  height: calc(var(--cell-height) * 5); /* taller logo */
   /* shift the logo up to match the higher pot */
   top: calc(var(--cell-height) * -5.5); /* push above pot */
   left: 50%;
-  transform: translateX(-50%) rotateX(calc(var(--board-angle, 60deg) * -1)) translateZ(-40px) scale(1.2); /* smaller logo */
+  transform: translateX(-50%) rotateX(calc(var(--board-angle, 60deg) * -1)) translateZ(-40px) scale(1.8); /* larger logo */
   transform-origin: bottom center;
   background-image: url("/assets/TonPlayGramLogo.jpg");
   background-size: contain;


### PR DESCRIPTION
## Summary
- enlarge the logo on the Snake & Ladder board so it is more prominent

## Testing
- `npm test` *(fails: manifest and lobby routes not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6853a46f7a448329b09f6f558e8eda8d