### PR TITLE
Adjust snake board scaling

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -447,7 +447,7 @@ body {
   width: calc(var(--cell-width) * 6); /* larger logo width */
   height: calc(var(--cell-height) * 5); /* taller logo */
   /* shift the logo up to match the higher pot */
-  top: calc(var(--cell-height) * -5.5); /* push above pot */
+  top: calc(var(--cell-height) * -5.5 - var(--cell-height) * 1.8 * (var(--final-scale, 1) - 1)); /* adjust for scaled top row */
   left: 50%;
   transform: translateX(-50%) rotateX(calc(var(--board-angle, 60deg) * -1)) translateZ(-40px) scale(1.8); /* larger logo */
   transform-origin: bottom center;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -62,8 +62,9 @@ function Board({
   const [cellHeight, setCellHeight] = useState(40);
   const tiles = [];
   const centerCol = (COLS - 1) / 2;
-  const widenStep = 0.02; // how much each row expands
-  const scaleStep = 0.02; // how much each row's cells widen
+  const widenStep = 0.02; // how much each row expands horizontally
+  const scaleStep = 0.02; // how much each row's cells scale
+  const finalScale = 1 + (ROWS - 3) * scaleStep;
 
   for (let r = 0; r < ROWS; r++) {
     const rowFactor = Math.max(0, r - 2);
@@ -93,8 +94,8 @@ function Board({
           style={{
             gridRowStart: ROWS - r,
             gridColumnStart: col + 1,
-            transform: `translateX(${translateX}px) scaleX(${scale}) translateZ(5px)`,
-            transformOrigin: 'center',
+            transform: `translateX(${translateX}px) scale(${scale}) translateZ(5px)`,
+            transformOrigin: 'bottom center',
           }}
         >
           {(icon || offsetVal != null) && (
@@ -190,6 +191,7 @@ function Board({
               "--cell-height": `${cellHeight}px`,
               "--board-width": `${cellWidth * COLS}px`,
               "--board-angle": `${angle}deg`,
+              "--final-scale": finalScale,
               // Fixed camera angle with no zooming
               transform: `rotateX(${angle}deg)`,
             }}


### PR DESCRIPTION
## Summary
- scale snake & ladder board cells uniformly with row index
- reposition logo when top row expands

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6853ab3f49b083298b038f11d172508a