### PR TITLE
Modify board scaling for snake game

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -67,7 +67,8 @@ function Board({
   const finalScale = 1 + (ROWS - 3) * scaleStep;
 
   for (let r = 0; r < ROWS; r++) {
-    const rowFactor = Math.max(0, r - 2);
+    // Allow negative rowFactor so the bottom rows appear slightly smaller
+    const rowFactor = r - 2;
     const offsetX = rowFactor * widenStep * cellWidth;
     const scale = 1 + rowFactor * scaleStep;
     const reversed = r % 2 === 1;


### PR DESCRIPTION
## Summary
- adjust board row scaling so bottom rows appear a little smaller

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6853be2b79e08329bb785f876b701032