### PR TITLE
Fix snake board row spacing

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -71,9 +71,10 @@ function Board({
   const rowOffsets = [0];
   for (let r = 1; r < ROWS; r++) {
     const prevScale = 1 + (r - 1 - 2) * scaleStep;
-    rowOffsets[r] = rowOffsets[r - 1] + (prevScale - 1) * cellHeight;
+    const currScale = 1 + (r - 2) * scaleStep;
+    rowOffsets[r] = rowOffsets[r - 1] + (prevScale - currScale) * 0.5 * cellHeight;
   }
-  const offsetYMax = rowOffsets[ROWS - 1];
+  const offsetYMax = Math.abs(rowOffsets[ROWS - 1]) - 2 * scaleStep * cellHeight;
 
   for (let r = 0; r < ROWS; r++) {
     // Allow negative rowFactor so the bottom rows appear slightly smaller


### PR DESCRIPTION
## Summary
- adjust rowOffsets to keep vertical gaps constant on the Snake & Ladder board

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6853d95e46108329bcfb4d9d816c6857