### PR TITLE
Adjust board column spacing

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -62,7 +62,8 @@ function Board({
   const [cellHeight, setCellHeight] = useState(40);
   const tiles = [];
   const centerCol = (COLS - 1) / 2;
-  const widenStep = 0.02; // how much each row expands horizontally
+  // Keep vertical columns evenly spaced rather than widening
+  const widenStep = 0; // how much each row expands horizontally
   const scaleStep = 0.02; // how much each row's cells scale
   const finalScale = 1 + (ROWS - 3) * scaleStep;
 


### PR DESCRIPTION
## Summary
- keep vertical columns evenly spaced by removing widen step in the Snake & Ladder board logic

## Testing
- `npm test` *(fails: manifest and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6853dcbb88548329b61bfe76557c2667