### PR TITLE
Adjust pot and logo position above board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -428,8 +428,8 @@ body {
   @apply absolute flex flex-col items-center justify-center;
   width: calc(var(--cell-width) * 1.8);
   height: calc(var(--cell-height) * 1.8);
-  /* move the pot more above the board */
-  top: calc(var(--cell-height) * -4.5);
+  /* move the pot even higher above the board */
+  top: calc(var(--cell-height) * -5.5);
   left: 50%;
   transform: translateX(-50%) translateZ(8px);
   z-index: 15;
@@ -446,8 +446,8 @@ body {
   @apply absolute flex items-center justify-center;
   width: calc(var(--cell-width) * 6); /* larger logo width */
   height: calc(var(--cell-height) * 5); /* taller logo */
-  /* move the logo more above the board */
-  top: calc(var(--cell-height) * -8.5 - var(--cell-height) * 1.8 * (var(--final-scale, 1) - 1)); /* adjust for scaled top row */
+  /* move the logo even higher above the board */
+  top: calc(var(--cell-height) * -9.5 - var(--cell-height) * 1.8 * (var(--final-scale, 1) - 1)); /* adjust for scaled top row */
   left: 50%;
   transform: translateX(-50%) rotateX(calc(var(--board-angle, 60deg) * -1)) translateZ(-40px) scale(1.8); /* larger logo */
   transform-origin: bottom center;


### PR DESCRIPTION
## Summary
- move the pot and logo higher above the Snakes & Ladders board

## Testing
- `npm test` *(fails: cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6853f4050e9c8329aa3183897944adcf