### PR TITLE
Modify board zigzag pattern

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -82,7 +82,10 @@ function Board({
     const scale = 1 + rowFactor * scaleStep;
     // Include the scaled cell width so horizontal gaps remain consistent
     const offsetX = rowFactor * widenStep * cellWidth + (scale - 1) * cellWidth;
-    const reversed = r % 2 === 1;
+    // Use a repeating zigzag pattern that reverses the second and third
+    // rows within each group of three. This results in the sequence:
+    // first row left-to-right, next two rows right-to-left, then repeat.
+    const reversed = r % 3 !== 0;
     for (let c = 0; c < COLS; c++) {
       const col = reversed ? COLS - 1 - c : c;
       const num = r * COLS + col + 1;


### PR DESCRIPTION
## Summary
- tweak `SnakeAndLadder.jsx` zigzag calculation so that every group of three rows
  has the second and third rows reversed

## Testing
- `npm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6854014fb4a883298de51e2ba3ebac75