### PR TITLE
Display coin icon on pot

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -438,6 +438,18 @@ body {
   box-shadow: none;
 }
 
+.pot-icon {
+  position: absolute;
+  width: 2.5rem;
+  height: 2.5rem;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) translateZ(20px) rotateX(10deg);
+  object-fit: contain;
+  pointer-events: none;
+  z-index: 1;
+}
+
 .pot-cell.highlight {
   box-shadow: 0 0 10px 4px rgba(250, 204, 21, 0.8);
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -217,6 +217,11 @@ function Board({
               className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? "highlight" : ""}`}
             >
               <PlayerToken color="#0d47a1" className="pot-token" />
+              <img
+                src={`/icons/${token.toLowerCase()}.svg`}
+                alt="pot token"
+                className="pot-icon"
+              />
               <span className="text-sm mt-1">{pot}</span>
               {position === FINAL_TILE && (
                 <PlayerToken


### PR DESCRIPTION
## Summary
- show whichever token the player bets on the pot
- style for the pot icon overlay

## Testing
- `npm test --silent` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68542787c3588329b72ee49aa1997957