### PR TITLE
Adjust pot icon overlay

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -440,9 +440,9 @@ body {
 
 .pot-icon {
   position: absolute;
-  width: 2.5rem;
-  height: 2.5rem;
-  top: 50%;
+  width: 3rem;
+  height: 3rem;
+  top: 40%;
   left: 50%;
   transform: translate(-50%, -50%) translateZ(20px) rotateX(10deg);
   object-fit: contain;


### PR DESCRIPTION
## Summary
- increase size and shift position of pot icon overlay so it sits higher on the pot

## Testing
- `npm test` *(fails: manifest and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68542920687083299b0fb5e67c4ac9fc