### PR TITLE
Add coin stack and burst animation

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -450,6 +450,23 @@ body {
   z-index: 1;
 }
 
+.coin-stack {
+  position: absolute;
+  bottom: 0.2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.coin-stack-img {
+  position: absolute;
+  width: 1.2rem;
+  height: 1.2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  object-fit: contain;
+}
+
 .pot-cell.highlight {
   box-shadow: 0 0 10px 4px rgba(250, 204, 21, 0.8);
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -20,7 +20,7 @@ const COLS = 5;
 const FINAL_TILE = ROWS * COLS + 1; // 101
 
 function CoinBurst({ token }) {
-  const coins = Array.from({ length: 15 }, () => ({
+  const coins = Array.from({ length: 30 }, () => ({
     dx: (Math.random() - 0.5) * 100,
     delay: Math.random() * 0.3,
     dur: 0.8 + Math.random() * 0.4,
@@ -222,6 +222,16 @@ function Board({
                 alt="pot token"
                 className="pot-icon"
               />
+              <div className={`coin-stack ${celebrate ? 'invisible' : ''}`}>
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <img
+                    key={i}
+                    src={`/icons/${token.toLowerCase()}.svg`}
+                    className="coin-stack-img"
+                    style={{ bottom: `${i * 3}px` }}
+                  />
+                ))}
+              </div>
               <span className="text-sm mt-1">{pot}</span>
               {position === FINAL_TILE && (
                 <PlayerToken


### PR DESCRIPTION
## Summary
- add coin stack inside pot cell
- burst more coins when celebrating
- style new coin stack icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68543104e84883298f048e1bccec7b40