### PR TITLE
Add frame to Snakes & Ladders board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -48,7 +48,7 @@ body {
 }
 
 .board-frame {
-  @apply border-4 border-accent rounded-lg p-1 bg-surface;
+  @apply border-4 border-accent rounded-lg p-1 bg-surface inline-block;
   transform-style: preserve-3d;
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -197,21 +197,25 @@ function Board({
       >
         <div className="snake-board-tilt">
           <div
-            className="snake-board-grid grid gap-1 relative mx-auto"
+            className="board-frame mx-auto"
             style={{
-              width: `${cellWidth * COLS}px`,
-              height: `${cellHeight * ROWS + offsetYMax}px`,
-              gridTemplateColumns: `repeat(${COLS}, ${cellWidth}px)`,
-              gridTemplateRows: `repeat(${ROWS}, ${cellHeight}px)`,
-              "--cell-width": `${cellWidth}px`,
-              "--cell-height": `${cellHeight}px`,
-              "--board-width": `${cellWidth * COLS}px`,
-              "--board-angle": `${angle}deg`,
-              "--final-scale": finalScale,
-              // Fixed camera angle with no zooming
               transform: `rotateX(${angle}deg)`,
             }}
           >
+            <div
+              className="snake-board-grid grid gap-1 relative mx-auto"
+              style={{
+                width: `${cellWidth * COLS}px`,
+                height: `${cellHeight * ROWS + offsetYMax}px`,
+                gridTemplateColumns: `repeat(${COLS}, ${cellWidth}px)`,
+                gridTemplateRows: `repeat(${ROWS}, ${cellHeight}px)`,
+                "--cell-width": `${cellWidth}px`,
+                "--cell-height": `${cellHeight}px`,
+                "--board-width": `${cellWidth * COLS}px`,
+                "--board-angle": `${angle}deg`,
+                "--final-scale": finalScale,
+              }}
+            >
             {tiles}
             <div
               className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? "highlight" : ""}`}
@@ -242,6 +246,7 @@ function Board({
               {celebrate && <CoinBurst token={token} />}
             </div>
             <div className="logo-wall-main" />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- wrap Snakes & Ladders board in a themed frame
- make `board-frame` display inline-block so the border hugs the board

## Testing
- `npm test` *(fails: server exposes manifest endpoint, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_6854343a5e008329840d0fb0a737a44c