### PR TITLE
Add bold border to Snake & Ladder frame

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -48,7 +48,8 @@ body {
 }
 
 .board-frame {
-  @apply border-4 border-accent rounded-lg p-1 bg-surface inline-block;
+  /* Bold accent border matching the app theme */
+  @apply border-8 border-accent rounded-lg p-1 bg-surface inline-block;
   transform-style: preserve-3d;
 }
 


### PR DESCRIPTION
## Summary
- give the board frame in Snake & Ladder a thicker accent border

## Testing
- `npm test` *(fails: Cannot find package 'dotenv', manifest and lobby route tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68543825dedc83298ca0ab4631054ff7