### PR TITLE
Add bold frame around snake board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -48,8 +48,9 @@ body {
 }
 
 .board-frame {
-  @apply border-4 border-accent rounded-lg p-1 bg-surface inline-block;
+  @apply border-8 border-accent rounded-lg p-1 bg-surface inline-block;
   transform-style: preserve-3d;
+  padding-top: calc(var(--cell-height, 40px) * 9.5);
 }
 
 /* Tilted view specifically for the Snake & Ladder board */

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -200,6 +200,8 @@ function Board({
             className="board-frame mx-auto"
             style={{
               transform: `rotateX(${angle}deg)`,
+              paddingTop: `${cellHeight * 9.5}px`,
+              "--cell-height": `${cellHeight}px`,
             }}
           >
             <div


### PR DESCRIPTION
## Summary
- add padding and thicker border to `.board-frame`
- ensure board frame includes logo area in SnakeAndLadder game

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68543c4996948329892b537e4a57549f