### PR TITLE
Adjust Snake & Ladder board position

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -170,6 +170,8 @@ function Board({
   // Fixed board angle with no zoom
   // Lowered camera angle so the logo touches the top of the screen
   const angle = 60;
+  // Small horizontal offset so the board sits perfectly centered
+  const boardXOffset = -10; // pixels
 
   useEffect(() => {
     const container = containerRef.current;
@@ -209,7 +211,7 @@ function Board({
               "--board-angle": `${angle}deg`,
               "--final-scale": finalScale,
               // Fixed camera angle with no zooming
-              transform: `rotateX(${angle}deg)`,
+              transform: `translateX(${boardXOffset}px) rotateX(${angle}deg)`,
             }}
           >
             {tiles}


### PR DESCRIPTION
## Summary
- shift the Snake & Ladder board and logo slightly left so the center column is in the middle of the screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685442601db083299ba4823cc31224b0