### PR TITLE
Refine dice overlay and board layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -117,8 +117,9 @@ body {
 }
 
 .board-cell {
-  @apply relative flex items-center justify-center rounded-xl text-text shadow-inner bg-surface border-2 border-accent;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5);
+  @apply relative flex items-center justify-center rounded-xl text-text bg-surface border-2 border-accent;
+  /* Transparent frame so dice stand out without dark edges */
+  box-shadow: none;
   transform: translateZ(5px);
   transform-style: preserve-3d;
   overflow: visible;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -192,7 +192,7 @@ function Board({
         className="overflow-y-auto"
         style={{
           overflowX: 'visible',
-          height: "80vh",
+          height: "calc(100vh - 3rem)",
           overscrollBehaviorY: "contain",
           paddingTop,
         }}
@@ -438,7 +438,7 @@ export default function SnakeAndLadder() {
   };
 
   return (
-    <div className="p-4 pb-32 space-y-4 text-text flex flex-col justify-end items-center relative w-full flex-grow">
+    <div className="p-4 pb-0 space-y-4 text-text flex flex-col justify-end items-center relative w-full flex-grow">
       <div className="absolute top-0 -right-2 flex flex-col items-end space-y-2 p-2 z-20">
         <button onClick={() => setShowInfo(true)} className="p-2 flex flex-col items-center">
           <AiOutlineInfoCircle className="text-2xl" />
@@ -479,7 +479,7 @@ export default function SnakeAndLadder() {
       {message && (
         <div className={`text-center font-semibold w-full ${messageColor}`}>{message}</div>
       )}
-      <div className="fixed bottom-24 inset-x-0 flex justify-center z-20">
+      <div className="fixed bottom-24 inset-x-0 flex justify-center z-30 bg-transparent">
         <DiceRoller
           onRollEnd={handleRoll}
           onRollStart={() => setTurnMessage('Rolling...')}


### PR DESCRIPTION
## Summary
- let the board extend to the footer without extra padding
- keep dice overlay above the board with transparent background
- remove dark frame around board cells

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68544815d28883298cb9a1806298a005