### PR TITLE
Fix horizontal scroll on Snake and Ladder board

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -186,12 +186,12 @@ function Board({
   const paddingTop = `${5.5 * cellHeight}px`;
 
   return (
-    <div className="flex justify-center items-center w-screen overflow-visible">
+    <div className="flex justify-center items-center w-screen overflow-hidden">
       <div
         ref={containerRef}
         className="overflow-y-auto"
         style={{
-          overflowX: 'visible',
+          overflowX: 'hidden',
           height: "80vh",
           overscrollBehaviorY: "contain",
           paddingTop,


### PR DESCRIPTION
## Summary
- disable horizontal scrolling on the Snake & Ladder board view

## Testing
- `npm test` *(fails: manifest endpoint not reachable & lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685457e5e82883299aa710cde19ef48c