### PR TITLE
Reduce snake token size

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -194,17 +194,19 @@ body {
 /* Three.js token container */
 .token-three {
   position: absolute;
-  width: 12rem;
-  height: 12rem;
-  transform: translateZ(60px);
+  /* shrink token by 25% */
+  width: 9rem;
+  height: 9rem;
+  transform: translateZ(45px); /* lowered proportionally */
   /* Preserve 3D space so the photo can be positioned in depth */
   transform-style: preserve-3d;
   pointer-events: none;
 }
 
 .pot-token {
-  width: 14.4rem; /* 20% bigger */
-  height: 14.4rem;
+  /* keep pot token scaled relative to player token */
+  width: 10.8rem; /* 20% bigger than the reduced token */
+  height: 10.8rem;
 }
 
 .token-three canvas {


### PR DESCRIPTION
## Summary
- shrink token models so they take up less space on the board
- keep pot token scaled relative to player tokens

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_68545a317c088329a1c433ef93e65128