### PR TITLE
Add jump animation and flash for snake actions

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -204,6 +204,19 @@ body {
   pointer-events: none;
 }
 
+.token-three.jump {
+  animation: token-jump 0.4s ease-out;
+}
+
+@keyframes token-jump {
+  0%, 100% {
+    transform: translateZ(34.2px);
+  }
+  50% {
+    transform: translateY(-20px) translateZ(34.2px);
+  }
+}
+
 .pot-token {
   /* keep pot token scaled relative to player token */
   width: 8.64rem; /* 20% bigger than the reduced token */


### PR DESCRIPTION
## Summary
- add jump animation class for tokens
- slow down token movement to show jumping
- flash board cell twice before moving on snake or ladder

## Testing
- `npm test` *(fails: manifest and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68546da158808329ba60542a086c3238