### PR TITLE
Update board styling

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -505,6 +505,19 @@ body {
   z-index: 5;
 }
 
+.board-top-line {
+  @apply absolute;
+  width: var(--board-width);
+  height: 0.5rem;
+  top: calc(var(--cell-height) * -10 - var(--cell-height) * 1.8 * (var(--final-scale, 1) - 1));
+  left: 50%;
+  transform: translateX(-50%) rotateX(calc(var(--board-angle, 60deg) * -1)) translateZ(-39px);
+  transform-origin: bottom center;
+  background-color: #f1c40f; /* gold */
+  border-radius: 4px;
+  z-index: 6;
+}
+
 
 .snake-connector,
 .ladder-connector {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -187,31 +187,12 @@ function Board({
       container.scrollTop = container.scrollHeight - container.clientHeight;
   }, []);
 
-  // When the player moves beyond the first two rows, keep the
-  // camera locked to the same relative frame by scrolling the
-  // container instead of changing angle or zoom.
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-    const row = Math.floor((position - 1) / COLS);
-    if (row < 2) {
-      container.scrollTop = container.scrollHeight - container.clientHeight;
-      return;
-    }
-    const cell = container.querySelector(`[data-cell="${position}"]`);
-    if (cell) {
-      const offset = cell.offsetTop - cellHeight * 2;
-      const target = Math.min(
-        Math.max(0, offset),
-        container.scrollHeight - container.clientHeight,
-      );
-      container.scrollTo({ top: target, behavior: 'smooth' });
-    }
-  }, [position, cellHeight]);
+  // Previously the container scrolled to keep the player token in view as they
+  // progressed up the board. To keep the camera fixed, this behaviour has been
+  // removed so the board no longer follows the player's position.
 
-  // The board is initially positioned at the bottom. Once the player
-  // reaches the third row, the container scrolls to keep them in view
-  // without altering the camera angle or zoom.
+  // The board is initially positioned at the bottom. It no longer scrolls as
+  // the player moves so the perspective stays fixed.
 
   const paddingTop = `${5.5 * cellHeight}px`;
 
@@ -273,6 +254,7 @@ function Board({
               )}
               {celebrate && <CoinBurst token={token} />}
             </div>
+            <div className="board-top-line" />
             <div className="logo-wall-main" />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- stop auto-scrolling the Snake & Ladder board
- keep camera fixed
- show a gold line above the logo wall for decoration

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL, snake lobby route lists players)*
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_68548449f37c8329bf2b87b2b7fcf8e7