### PR TITLE
Fix board scrolling on Snake & Ladder

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -200,7 +200,10 @@ function Board({
     }
     const cell = container.querySelector(`[data-cell="${position}"]`);
     if (cell) {
-      const offset = cell.offsetTop - cellHeight * 2;
+      const containerRect = container.getBoundingClientRect();
+      const cellRect = cell.getBoundingClientRect();
+      const offset =
+        cellRect.top - containerRect.top + container.scrollTop - cellHeight * 2;
       const target = Math.min(
         Math.max(0, offset),
         container.scrollHeight - container.clientHeight,


### PR DESCRIPTION
## Summary
- fix camera follow math when token is far from bottom

## Testing
- `npm test` *(fails: manifest and lobby routes not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6854ea1540fc8329be68c0d2abc24ce1