### PR TITLE
Improve Snake & Ladder camera follow

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -189,13 +189,18 @@ function Board({
 
   // When the player moves beyond the first two rows, keep the
   // camera locked to the same relative frame by scrolling the
-  // container instead of changing angle or zoom.
+  // container instead of changing angle or zoom. Stop following
+  // once row nine is reached.
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
     const row = Math.floor((position - 1) / COLS);
     if (row < 2) {
       container.scrollTop = container.scrollHeight - container.clientHeight;
+      return;
+    }
+    if (row > 8) {
+      // past the ninth row keep the board static
       return;
     }
     const cell = container.querySelector(`[data-cell="${position}"]`);
@@ -384,7 +389,8 @@ export default function SnakeAndLadder() {
       : values;
 
     setRollResult(value);
-    setTimeout(() => setRollResult(null), 2500);
+    // Show the rolled value for 2 seconds instead of 2.5s
+    setTimeout(() => setRollResult(null), 2000);
 
     setTimeout(() => {
       setDiceVisible(false);
@@ -504,7 +510,8 @@ export default function SnakeAndLadder() {
     };
 
     moveSeq(steps, 'normal', () => applyEffect(target));
-  }, 2500);
+  // Start applying the move after the dice result has been shown
+  }, 2000);
   };
 
   return (


### PR DESCRIPTION
## Summary
- follow the snake board with smooth scrolling until the ninth row
- speed up dice result display to 2 seconds

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6854f0915d8c832987d2bd2b8294020b