### PR TITLE
Implement scroll follow stop at ninth row

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -194,10 +194,14 @@ function Board({
     const container = containerRef.current;
     if (!container) return;
     const row = Math.floor((position - 1) / COLS);
+    // Keep the board initially pinned to the bottom for the first two rows
     if (row < 2) {
       container.scrollTop = container.scrollHeight - container.clientHeight;
       return;
     }
+    // Follow the player only between rows 3 and 8 (inclusive). Once the
+    // player reaches the 9th row the camera stops tracking their movement.
+    if (row >= 8) return;
     const cell = container.querySelector(`[data-cell="${position}"]`);
     if (cell) {
       const containerRect = container.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- limit board camera follow to rows 3–8 so it stops after the 9th row

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854f64b3bc4832985d42594876d1815