### PR TITLE
Increase snake board cell height

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -4,7 +4,8 @@
 
 :root {
   --cell-width: 135px;
-  --cell-height: 68px;
+  /* Slightly taller default height for snake board cells */
+  --cell-height: 80px;
 }
 
 body {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -163,7 +163,8 @@ function Board({
       const width = window.innerWidth;
       const cw = Math.floor(width / COLS);
       setCellWidth(cw);
-      const ch = Math.floor(cw / 2);
+      // Make each cell slightly taller while keeping spacing consistent
+      const ch = Math.floor(cw / 1.7);
       setCellHeight(ch);
     };
     updateSize();


### PR DESCRIPTION
## Summary
- make snake board cells a bit taller
- bump default `--cell-height`

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6854ff7375e08329b2c15401cee8082c