### PR TITLE
Fix camera follow boundary

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -192,7 +192,7 @@ function Board({
   // When the player moves beyond the first two rows start following
   // their progress by scrolling the container. The camera tracks each
   // row up to the ninth without changing angle or zoom. Once the
-  // tenth row is reached the scroll position is locked and no further
+  // ninth row is reached the scroll position is locked and no further
   // following occurs.
   useEffect(() => {
     const container = containerRef.current;
@@ -200,7 +200,7 @@ function Board({
     const row = Math.floor((position - 1) / COLS);
 
     const startFollow = 2; // third row
-    const stopFollow = 9; // tenth row
+    const stopFollow = 8; // ninth row
 
     if (row < startFollow) {
       setLockedScroll(null);


### PR DESCRIPTION
## Summary
- stop following the board after reaching the ninth row

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68550fe55890832986e3b6ed559123cb