### PR TITLE
Add HTTPS proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@
    npm test
    ```
 
+### Using an HTTPS proxy
+
+If your server requires a proxy to reach external services like Tonkeeper,
+set the `HTTPS_PROXY` (or `https_proxy`) environment variable before running the
+bot. All fetch requests from the Node.js backend will be routed through this
+proxy.
+
 ## Telegram game bots
 
 Several small Telegram game bots are included in this repository. They use

--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { withProxy } from '../utils/proxyAgent.js';
 
 import User from '../models/User.js';
 
@@ -54,9 +55,8 @@ router.post('/ton-balance', authenticate, async (req, res) => {
   try {
 
     const resp = await fetch(
-
-      `https://toncenter.com/api/v2/getAddressBalance?address=${address}`
-
+      `https://toncenter.com/api/v2/getAddressBalance?address=${address}`,
+      withProxy()
     );
 
     const data = await resp.json();

--- a/bot/server.js
+++ b/bot/server.js
@@ -2,6 +2,7 @@ import dotenv from 'dotenv';
 import express from 'express';
 import bot from './bot.js';
 import mongoose from 'mongoose';
+import { proxyUrl, proxyAgent } from './utils/proxyAgent.js';
 import http from 'http';
 import { Server as SocketIOServer } from 'socket.io';
 import { GameRoomManager } from './gameEngine.js';
@@ -22,6 +23,10 @@ import compression from 'compression';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 dotenv.config({ path: path.join(__dirname, '.env') });
+
+if (proxyUrl) {
+  console.log(`Using HTTPS proxy ${proxyUrl}`);
+}
 
 if (!process.env.MONGODB_URI) {
   process.env.MONGODB_URI = 'memory';

--- a/bot/utils/proxyAgent.js
+++ b/bot/utils/proxyAgent.js
@@ -1,0 +1,9 @@
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+export const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy;
+export const proxyAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined;
+
+export function withProxy(options = {}) {
+  if (!proxyAgent) return options;
+  return { ...options, dispatcher: proxyAgent };
+}

--- a/bot/utils/telegram.js
+++ b/bot/utils/telegram.js
@@ -1,17 +1,26 @@
+import { withProxy } from './proxyAgent.js';
+
 export async function fetchTelegramInfo(telegramId) {
   const base = `https://api.telegram.org/bot${process.env.BOT_TOKEN}`;
   try {
-    const infoResp = await fetch(`${base}/getChat?chat_id=${telegramId}`);
+    const infoResp = await fetch(
+      `${base}/getChat?chat_id=${telegramId}`,
+      withProxy()
+    );
     const infoData = await infoResp.json();
 
     let photoUrl = '';
     const photosResp = await fetch(
-      `${base}/getUserProfilePhotos?user_id=${telegramId}&limit=1`
+      `${base}/getUserProfilePhotos?user_id=${telegramId}&limit=1`,
+      withProxy()
     );
     const photosData = await photosResp.json();
     if (photosData.ok && photosData.result.total_count > 0) {
       const fileId = photosData.result.photos[0][0].file_id;
-      const fileResp = await fetch(`${base}/getFile?file_id=${fileId}`);
+      const fileResp = await fetch(
+        `${base}/getFile?file_id=${fileId}`,
+        withProxy()
+      );
       const fileData = await fileResp.json();
       if (fileData.ok) {
         photoUrl = `${base.replace('/bot', '/file/bot')}/${fileData.result.file_path}`;


### PR DESCRIPTION
## Summary
- add proxyAgent utility to centralize proxy logic
- log HTTPS proxy usage in server startup
- route Telegram and TON API requests through proxy
- document HTTPS proxy setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68550f5e4ac88329af90bfd1652f424a