### PR TITLE
Fix TonConnect manifest route

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -107,7 +107,7 @@ const manifestPath = new URL(manifestUrl, 'http://placeholder').pathname;
 console.log("TONCONNECT_MANIFEST_URL", manifestUrl);
 console.log("manifestpath", manifestPath);
 
-app.get(manifestUrl, (req, res) => {
+app.get(manifestPath, (req, res) => {
   const proto = req.get('x-forwarded-proto') || req.protocol;
   const baseUrl = `${proto}://${req.get('host')}`;
   console.log("proto: ", proto);


### PR DESCRIPTION
## Summary
- correct TonConnect manifest route to handle absolute URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68550d99bca88329a73e79e3628a151c