### PR TITLE
Update snake and ladder board UI

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -220,8 +220,8 @@ body {
 
 .pot-token {
   /* keep pot token scaled relative to player token */
-  width: 8.64rem; /* 20% bigger than the reduced token */
-  height: 8.64rem;
+  width: 9rem; /* 25% bigger than the reduced token */
+  height: 9rem;
 }
 
 .token-three canvas {
@@ -232,15 +232,16 @@ body {
 
 .token-photo {
   position: absolute;
-  /* enlarge photo by 10% and lower it proportionally */
-  width: 2.75rem;
-  height: 2.75rem;
+  /* enlarge photo by 5% and lower it proportionally */
+  width: 2.9rem;
+  height: 2.9rem;
   top: 50%;
   left: 50%;
   /* Nudge the photo slightly forward so it stands out */
   transform: translate(-50%, -50%) translateZ(15.2px) rotateX(10deg);
   object-fit: cover;
   border-radius: 50%;
+  border: 2px solid #ffd700;
   pointer-events: none;
   z-index: 1;
 }
@@ -479,6 +480,16 @@ body {
   transform: translate(-50%, -50%) translateZ(20px) rotateX(10deg);
   object-fit: contain;
   pointer-events: none;
+  z-index: 1;
+}
+
+.pot-number {
+  position: absolute;
+  bottom: -1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-weight: bold;
+  color: #ffffff;
   z-index: 1;
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -283,7 +283,7 @@ function Board({
                   />
                 ))}
               </div>
-              <span className="text-sm mt-1">{pot}</span>
+              <span className="pot-number">{FINAL_TILE}</span>
               {position === FINAL_TILE && (
                 <PlayerToken
                   photoUrl={photoUrl}
@@ -369,22 +369,48 @@ export default function SnakeAndLadder() {
         const snakeData = data.snakes || {};
         const ladderData = data.ladders || {};
 
-        // Remove any snake that starts on the same tile as a ladder to avoid
-        // duplicate icons occupying a single cell.
+        const boardSize = ROWS * COLS;
+
+        // Remove invalid or overlapping snakes
         const cleanSnakes = {};
-        Object.keys(snakeData).forEach((k) => {
-          if (!ladderData[k]) cleanSnakes[k] = snakeData[k];
+        Object.entries(snakeData).forEach(([s, e]) => {
+          const start = Number(s);
+          const end = Number(e);
+          if (
+            start > 0 &&
+            start <= boardSize &&
+            end > 0 &&
+            end < start &&
+            end <= boardSize &&
+            !ladderData[s]
+          )
+            cleanSnakes[start] = end;
+        });
+
+        // Remove invalid ladders
+        const cleanLadders = {};
+        Object.entries(ladderData).forEach(([s, e]) => {
+          const start = Number(s);
+          const endVal = typeof e === 'object' ? e.end : e;
+          if (
+            start > 0 &&
+            start <= boardSize &&
+            endVal > start &&
+            endVal <= boardSize &&
+            !cleanSnakes[start]
+          )
+            cleanLadders[start] = e;
         });
 
         setSnakes(cleanSnakes);
-        setLadders(ladderData);
+        setLadders(cleanLadders);
 
         const snk = {};
         Object.keys(cleanSnakes).forEach((k) => {
           snk[k] = Math.floor(Math.random() * 10) + 1;
         });
         const lad = {};
-        Object.keys(ladderData).forEach((k) => {
+        Object.keys(cleanLadders).forEach((k) => {
           lad[k] = Math.floor(Math.random() * 10) + 1;
         });
         setSnakeOffsets(snk);


### PR DESCRIPTION
## Summary
- filter out invalid snake/ladder positions
- enlarge player photo slightly and add gold border
- enlarge pot token 25% and label it as tile 101

## Testing
- `npm test` *(fails: manifest endpoint not reachable, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_68551bc325b883299a5b102f509ded35