### PR TITLE
Implement capture and end popup

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -169,6 +169,14 @@ export class GameRoom {
         player.position = final;
         this.io.to(this.id).emit('snakeOrLadder', { playerId: player.playerId, from: to, to: final });
       }
+      // Check if landing on another player
+      for (const other of this.players) {
+        if (other !== player && other.position === player.position && !other.disconnected) {
+          other.position = 0;
+          other.isActive = false;
+          this.io.to(this.id).emit('playerReset', { playerId: other.playerId });
+        }
+      }
     }
 
     if (player.position === FINAL_TILE) {

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -112,3 +112,30 @@ test('rolling too quickly triggers anti-cheat', () => {
   assert.ok(err, 'error event should be emitted');
 });
 
+test('landing on another player sends them to start', () => {
+  const io = new DummyIO();
+  const room = new GameRoom('r5', io, 2, {
+    snakes: {},
+    ladders: {},
+  });
+  room.rollCooldown = 0;
+  const s1 = { id: 's1', join: () => {} };
+  const s2 = { id: 's2', join: () => {} };
+  room.addPlayer('p1', 'A', s1);
+  room.addPlayer('p2', 'B', s2);
+  room.startGame();
+
+  room.players[0].isActive = true;
+  room.players[0].position = 1;
+  room.players[1].isActive = true;
+  room.players[1].position = 3;
+  room.currentTurn = 0;
+
+  room.rollDice(s1, 2); // land on player 2
+
+  assert.equal(room.players[0].position, 3);
+  assert.equal(room.players[1].position, 0);
+  const resetEvent = io.emitted.find(e => e.event === 'playerReset');
+  assert.ok(resetEvent && resetEvent.data.playerId === 'p2');
+});
+

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -238,7 +238,7 @@ body {
   top: 50%;
   left: 52%;
   /* Nudge the photo slightly forward so it stands out */
-  transform: translate(-50%, -50%) translateZ(15.2px) rotateX(15deg);
+  transform: translate(-50%, -50%) translateZ(15.2px) rotateX(20deg);
   object-fit: cover;
   border-radius: 50%;
   border: 2px solid #ffd700;
@@ -642,11 +642,11 @@ body {
 @keyframes hex-spin {
   from {
     transform: translate(-50%, -50%)
-      rotateX(calc(var(--board-angle, 60deg) * -1)) rotateZ(0deg);
+      rotateX(calc(var(--board-angle, 60deg) * -1)) rotateY(0deg);
   }
   to {
     transform: translate(-50%, -50%)
-      rotateX(calc(var(--board-angle, 60deg) * -1)) rotateZ(360deg);
+      rotateX(calc(var(--board-angle, 60deg) * -1)) rotateY(360deg);
   }
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import DiceRoller from "../../components/DiceRoller.jsx";
 import InfoPopup from "../../components/InfoPopup.jsx";
+import GameEndPopup from "../../components/GameEndPopup.jsx";
 import {
   AiOutlineInfoCircle,
   AiOutlineLogout,
@@ -335,6 +336,7 @@ export default function SnakeAndLadder() {
   const [rollResult, setRollResult] = useState(null);
   const [diceCells, setDiceCells] = useState({});
   const [bonusDice, setBonusDice] = useState(0);
+  const [gameOver, setGameOver] = useState(false);
 
   const moveSoundRef = useRef(null);
   const snakeSoundRef = useRef(null);
@@ -559,6 +561,7 @@ export default function SnakeAndLadder() {
         winSoundRef.current?.play().catch(() => {});
         setCelebrate(true);
         setTimeout(() => setCelebrate(false), 1500);
+        setGameOver(true);
       }
       if (diceCells[finalPos]) {
         const bonus = diceCells[finalPos];
@@ -647,6 +650,12 @@ export default function SnakeAndLadder() {
         onClose={() => setShowInfo(false)}
         title="Snake & Ladder"
         info="Roll the dice to move across the board. Ladders move you up, snakes bring you down. The Pot at the top collects everyone's stake – reach it first to claim the total amount."
+      />
+      <GameEndPopup
+        open={gameOver}
+        ranking={["You"]}
+        onPlayAgain={() => window.location.reload()}
+        onReturn={() => navigate('/games/snake/lobby')}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- tweak token photo angle and synchronize hexagon spin
- implement player capture rule in backend
- add GameEndPopup to Snake and Ladder board
- test capturing player when landing on same tile

## Testing
- `npm test` *(fails: manifest endpoint and lobby route tests require network)*

------
https://chatgpt.com/codex/tasks/task_e_68552a1f0e7c832999b24dddd1097ff9