### PR TITLE
Enhance Snakes & Ladders UX

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -236,7 +236,8 @@ body {
   width: 2.9rem;
   height: 2.9rem;
   top: 50%;
-  left: 52%;
+  /* shift photo slightly left so it aligns better */
+  left: 50%;
   /* Nudge the photo slightly forward so it stands out */
   transform: translate(-50%, -50%) translateZ(15.2px) rotateX(20deg);
   object-fit: cover;
@@ -477,7 +478,8 @@ body {
   height: 12rem;
   top: 40%;
   left: 50%;
-  transform: translate(-50%, -50%) translateZ(20px) rotateX(10deg);
+  transform: translate(-50%, -50%) translateZ(20px) rotateX(10deg) rotateY(0deg);
+  animation: pot-spin 6s linear infinite;
   object-fit: contain;
   pointer-events: none;
   z-index: 1;
@@ -647,6 +649,15 @@ body {
   to {
     transform: translate(-50%, -50%)
       rotateX(calc(var(--board-angle, 60deg) * -1)) rotateY(360deg);
+  }
+}
+
+@keyframes pot-spin {
+  from {
+    transform: translate(-50%, -50%) translateZ(20px) rotateX(10deg) rotateY(0deg);
+  }
+  to {
+    transform: translate(-50%, -50%) translateZ(20px) rotateX(10deg) rotateY(360deg);
   }
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -342,6 +342,7 @@ export default function SnakeAndLadder() {
   const snakeSoundRef = useRef(null);
   const ladderSoundRef = useRef(null);
   const winSoundRef = useRef(null);
+  const diceRewardSoundRef = useRef(null);
 
   useEffect(() => {
     const id = getTelegramId();
@@ -363,11 +364,13 @@ export default function SnakeAndLadder() {
       "https://snakes-and-ladders-game.netlify.app/audio/ladder.mp3",
     );
     winSoundRef.current = new Audio("/assets/sounds/successful.mp3");
+    diceRewardSoundRef.current = new Audio("/assets/sounds/successful.mp3");
     return () => {
       moveSoundRef.current?.pause();
       snakeSoundRef.current?.pause();
       ladderSoundRef.current?.pause();
       winSoundRef.current?.pause();
+      diceRewardSoundRef.current?.pause();
     };
   }, []);
 
@@ -560,8 +563,10 @@ export default function SnakeAndLadder() {
         setMessageColor('');
         winSoundRef.current?.play().catch(() => {});
         setCelebrate(true);
-        setTimeout(() => setCelebrate(false), 1500);
-        setGameOver(true);
+        setTimeout(() => {
+          setCelebrate(false);
+          setGameOver(true);
+        }, 1500);
       }
       if (diceCells[finalPos]) {
         const bonus = diceCells[finalPos];
@@ -572,6 +577,7 @@ export default function SnakeAndLadder() {
         });
         setBonusDice(bonus);
         setTurnMessage(`Bonus roll +${bonus}`);
+        diceRewardSoundRef.current?.play().catch(() => {});
       } else {
         setTurnMessage('Your turn');
         setBonusDice(0);


### PR DESCRIPTION
## Summary
- tweak token photo alignment
- animate the pot icon and restore spin
- delay game over dialog until celebration ends
- play a reward sound when landing on bonus dice cells

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68552ecbe348832994cf1bc0cea19a06