### PR TITLE
Add avatar picker popup

### DIFF
--- a/webapp/src/components/AvatarPickerModal.jsx
+++ b/webapp/src/components/AvatarPickerModal.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+const BOY_AVATARS = [
+  'https://api.dicebear.com/7.x/open-peeps/png?seed=boy1',
+  'https://api.dicebear.com/7.x/open-peeps/png?seed=boy2',
+  'https://api.dicebear.com/7.x/open-peeps/png?seed=boy3&skinColor=9b5e43',
+  'https://api.dicebear.com/7.x/open-peeps/png?seed=boy4&accessories[]=glasses',
+  'https://api.dicebear.com/7.x/open-peeps/png?seed=boy5'
+];
+
+const GIRL_AVATARS = [
+  'https://api.dicebear.com/7.x/open-peeps/png?seed=girl1',
+  'https://api.dicebear.com/7.x/open-peeps/png?seed=girl2',
+  'https://api.dicebear.com/7.x/open-peeps/png?seed=girl3&skinColor=9b5e43',
+  'https://api.dicebear.com/7.x/open-peeps/png?seed=girl4&accessories[]=glasses',
+  'https://api.dicebear.com/7.x/open-peeps/png?seed=girl5'
+];
+
+export default function AvatarPickerModal({ open, onClose, onSelect }) {
+  if (!open) return null;
+
+  const renderRow = (avatars) => (
+    <div className="flex justify-center space-x-2">
+      {avatars.map((src) => (
+        <img
+          key={src}
+          src={src}
+          alt="avatar"
+          className="w-20 h-20 rounded-full cursor-pointer hover:opacity-80"
+          onClick={() => onSelect(src)}
+        />
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
+      <div className="bg-surface border border-border p-4 rounded space-y-4 text-center text-text">
+        <h3 className="text-lg font-bold">Pick a Profile Avatar</h3>
+        <div>
+          <p className="font-semibold mb-1">Boys</p>
+          {renderRow(BOY_AVATARS)}
+        </div>
+        <div>
+          <p className="font-semibold mb-1 mt-2">Girls</p>
+          {renderRow(GIRL_AVATARS)}
+        </div>
+        <button onClick={onClose} className="mt-4 px-4 py-1 bg-primary hover:bg-primary-hover rounded w-full">
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -16,6 +16,7 @@ import OpenInTelegram from '../components/OpenInTelegram.jsx';
 import { BOT_USERNAME } from '../utils/constants.js';
 import BalanceSummary from '../components/BalanceSummary.jsx';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
+import AvatarPickerModal from '../components/AvatarPickerModal.jsx';
 
 export default function MyAccount() {
   useTelegramBackButton();
@@ -31,12 +32,14 @@ export default function MyAccount() {
   const [referral, setReferral] = useState(null);
   const [autoUpdating, setAutoUpdating] = useState(false);
   const [transactions, setTransactions] = useState([]);
+  const [showAvatarPicker, setShowAvatarPicker] = useState(false);
   const timerRef = useRef(null);
 
   useEffect(() => {
     async function load() {
       const data = await getProfile(telegramId);
       setProfile(data);
+      if (!data.photo) setShowAvatarPicker(true);
       const ref = await getReferralInfo(telegramId);
       setReferral(ref);
       const tx = await getTransactions(telegramId);
@@ -71,6 +74,7 @@ export default function MyAccount() {
           };
 
           setProfile(mergedProfile);
+          if (mergedProfile.photo) setShowAvatarPicker(false);
         } finally {
           setAutoUpdating(false);
         }
@@ -90,6 +94,15 @@ export default function MyAccount() {
 
   return (
     <div className="p-4 space-y-4 text-text">
+      <AvatarPickerModal
+        open={showAvatarPicker}
+        onClose={() => setShowAvatarPicker(false)}
+        onSelect={async (src) => {
+          const updated = await updateProfile({ telegramId, photo: src });
+          setProfile(updated);
+          setShowAvatarPicker(false);
+        }}
+      />
       {autoUpdating && (
         <div className="p-2 text-sm text-subtext">Updating with Telegram info...</div>
       )}


### PR DESCRIPTION
## Summary
- add `AvatarPickerModal` component with 5 boy and 5 girl avatars
- show avatar picker on My Account page when no profile photo is set

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68553190ab648329a31d5c7b46fd5e38