### PR TITLE
Implement wallet-based account creation

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -12,7 +12,9 @@ const transactionSchema = new mongoose.Schema(
 
 const userSchema = new mongoose.Schema({
 
-  telegramId: { type: Number, required: true, unique: true },
+  telegramId: { type: Number, unique: true },
+
+  walletAddress: { type: String, unique: true },
 
   createdAt: { type: Date, default: Date.now },
 
@@ -57,15 +59,11 @@ const userSchema = new mongoose.Schema({
 });
 
 userSchema.pre('save', function(next) {
-
   if (!this.referralCode) {
-
-    this.referralCode = this.telegramId.toString();
-
+    const base = this.telegramId || this.walletAddress || '';
+    this.referralCode = String(base);
   }
-
   next();
-
 });
 
 export default mongoose.model('User', userSchema);

--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -5,6 +5,19 @@ import { ensureTransactionArray } from '../utils/userUtils.js';
 
 const router = Router();
 
+router.post('/register-wallet', async (req, res) => {
+  const { walletAddress } = req.body;
+  if (!walletAddress) {
+    return res.status(400).json({ error: 'walletAddress required' });
+  }
+  const user = await User.findOneAndUpdate(
+    { walletAddress },
+    { $setOnInsert: { walletAddress, referralCode: walletAddress } },
+    { upsert: true, new: true }
+  );
+  res.json(user);
+});
+
 router.post('/telegram-info', async (req, res) => {
   const { telegramId } = req.body;
   if (!telegramId) {

--- a/webapp/src/components/ConnectWallet.jsx
+++ b/webapp/src/components/ConnectWallet.jsx
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 import { TonConnectButton, useTonWallet, useTonConnectUI } from '@tonconnect/ui-react';
+import { registerWallet } from '../utils/api.js';
+import { getTelegramId } from '../utils/telegram.js';
 
 // Simple wrapper around TonConnectButton that remembers the last connected
 // address in localStorage.
@@ -11,6 +13,11 @@ export default function ConnectWallet() {
   useEffect(() => {
     if (wallet?.account?.address) {
       localStorage.setItem('walletAddress', wallet.account.address);
+      try {
+        getTelegramId();
+      } catch {
+        registerWallet(wallet.account.address).catch(() => {});
+      }
     }
   }, [wallet]);
 

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -68,13 +68,14 @@ export default function MyAccount() {
             lastName
           });
 
+          const hasRealPhoto = updated.photo || tg?.photoUrl;
           const mergedProfile = {
             ...updated,
-            photo: updated.photo || tg?.photoUrl || getTelegramPhotoUrl()
+            photo: hasRealPhoto || getTelegramPhotoUrl()
           };
 
           setProfile(mergedProfile);
-          if (mergedProfile.photo) setShowAvatarPicker(false);
+          setShowAvatarPicker(!hasRealPhoto);
         } finally {
           setAutoUpdating(false);
         }

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -203,3 +203,7 @@ export function getSnakeLobby(id) {
 export function getSnakeBoard(id) {
   return fetch(API_BASE_URL + '/api/snake/board/' + id).then((r) => r.json());
 }
+
+export function registerWallet(walletAddress) {
+  return post('/api/profile/register-wallet', { walletAddress });
+}


### PR DESCRIPTION
## Summary
- show avatar picker for default Telegram avatars
- register users by wallet address when connecting via Web3
- expose register wallet endpoint in server API
- store wallet address in user model

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68553617964c8329963dac4abb2f33f7