### PR TITLE
Update avatar handling

### DIFF
--- a/webapp/src/components/AvatarPickerModal.jsx
+++ b/webapp/src/components/AvatarPickerModal.jsx
@@ -1,49 +1,32 @@
 import React from 'react';
 
-const BOY_AVATARS = [
-  'https://api.dicebear.com/7.x/open-peeps/png?seed=boy1',
-  'https://api.dicebear.com/7.x/open-peeps/png?seed=boy2',
-  'https://api.dicebear.com/7.x/open-peeps/png?seed=boy3&skinColor=9b5e43',
-  'https://api.dicebear.com/7.x/open-peeps/png?seed=boy4&accessories[]=glasses',
-  'https://api.dicebear.com/7.x/open-peeps/png?seed=boy5'
-];
-
-const GIRL_AVATARS = [
-  'https://api.dicebear.com/7.x/open-peeps/png?seed=girl1',
-  'https://api.dicebear.com/7.x/open-peeps/png?seed=girl2',
-  'https://api.dicebear.com/7.x/open-peeps/png?seed=girl3&skinColor=9b5e43',
-  'https://api.dicebear.com/7.x/open-peeps/png?seed=girl4&accessories[]=glasses',
-  'https://api.dicebear.com/7.x/open-peeps/png?seed=girl5'
+// Use DiceBear's adventurer-neutral SVG avatars which are gender-neutral
+// and small text-based files instead of binary PNG images.
+const AVATARS = [
+  'https://api.dicebear.com/7.x/adventurer-neutral/svg?seed=avatar1',
+  'https://api.dicebear.com/7.x/adventurer-neutral/svg?seed=avatar2',
+  'https://api.dicebear.com/7.x/adventurer-neutral/svg?seed=avatar3',
+  'https://api.dicebear.com/7.x/adventurer-neutral/svg?seed=avatar4',
+  'https://api.dicebear.com/7.x/adventurer-neutral/svg?seed=avatar5'
 ];
 
 export default function AvatarPickerModal({ open, onClose, onSelect }) {
   if (!open) return null;
 
-  const renderRow = (avatars) => (
-    <div className="flex justify-center space-x-2">
-      {avatars.map((src) => (
-        <img
-          key={src}
-          src={src}
-          alt="avatar"
-          className="w-20 h-20 rounded-full cursor-pointer hover:opacity-80"
-          onClick={() => onSelect(src)}
-        />
-      ))}
-    </div>
-  );
-
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-4 rounded space-y-4 text-center text-text">
         <h3 className="text-lg font-bold">Pick a Profile Avatar</h3>
-        <div>
-          <p className="font-semibold mb-1">Boys</p>
-          {renderRow(BOY_AVATARS)}
-        </div>
-        <div>
-          <p className="font-semibold mb-1 mt-2">Girls</p>
-          {renderRow(GIRL_AVATARS)}
+        <div className="flex justify-center space-x-2">
+          {AVATARS.map((src) => (
+            <img
+              key={src}
+              src={src}
+              alt="avatar"
+              className="w-20 h-20 rounded-full cursor-pointer hover:opacity-80"
+              onClick={() => onSelect(src)}
+            />
+          ))}
         </div>
         <button onClick={onClose} className="mt-4 px-4 py-1 bg-primary hover:bg-primary-hover rounded w-full">
           Close

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
-import { getLeaderboard, getReferralInfo, fetchTelegramInfo } from '../utils/api.js';
+import { getLeaderboard, getReferralInfo, fetchTelegramInfo, getProfile } from '../utils/api.js';
 import { BOT_USERNAME } from '../utils/constants.js';
 
 export default function Friends() {
@@ -25,11 +25,24 @@ export default function Friends() {
       setLeaderboard(data.users);
       setRank(data.rank);
     });
-    if (!myPhotoUrl) {
-      fetchTelegramInfo(telegramId).then((info) => {
-        if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
+
+    getProfile(telegramId)
+      .then((p) => {
+        if (p?.photo) {
+          setMyPhotoUrl(p.photo);
+        } else if (!myPhotoUrl) {
+          fetchTelegramInfo(telegramId).then((info) => {
+            if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
+          });
+        }
+      })
+      .catch(() => {
+        if (!myPhotoUrl) {
+          fetchTelegramInfo(telegramId).then((info) => {
+            if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
+          });
+        }
       });
-    }
   }, [telegramId]);
 
   if (!referral) return <div className="p-4">Loading...</div>;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -10,7 +10,7 @@ import {
 import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
 import { useNavigate } from "react-router-dom";
 import { getTelegramId, getTelegramPhotoUrl } from "../../utils/telegram.js";
-import { fetchTelegramInfo } from "../../utils/api.js";
+import { fetchTelegramInfo, getProfile } from "../../utils/api.js";
 import PlayerToken from "../../components/PlayerToken.jsx";
 
 const PLAYERS = 4;
@@ -346,14 +346,31 @@ export default function SnakeAndLadder() {
 
   useEffect(() => {
     const id = getTelegramId();
-    const url = getTelegramPhotoUrl();
-    if (url) {
-      setPhotoUrl(url);
-    } else if (id) {
-      fetchTelegramInfo(id).then((info) => {
-        if (info?.photoUrl) setPhotoUrl(info.photoUrl);
+    getProfile(id)
+      .then((p) => {
+        if (p?.photo) {
+          setPhotoUrl(p.photo);
+        } else {
+          const url = getTelegramPhotoUrl();
+          if (url) {
+            setPhotoUrl(url);
+          } else {
+            fetchTelegramInfo(id).then((info) => {
+              if (info?.photoUrl) setPhotoUrl(info.photoUrl);
+            });
+          }
+        }
+      })
+      .catch(() => {
+        const url = getTelegramPhotoUrl();
+        if (url) {
+          setPhotoUrl(url);
+        } else {
+          fetchTelegramInfo(id).then((info) => {
+            if (info?.photoUrl) setPhotoUrl(info.photoUrl);
+          });
+        }
       });
-    }
     moveSoundRef.current = new Audio(
       "https://snakes-and-ladders-game.netlify.app/audio/drop.mp3",
     );

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -20,7 +20,8 @@ import ConnectWallet from "../components/ConnectWallet.jsx";
 
 import BalanceSummary from '../components/BalanceSummary.jsx';
 
-import { getTelegramPhotoUrl } from '../utils/telegram.js';
+import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
+import { getProfile } from '../utils/api.js';
 
 export default function Home() {
 
@@ -29,15 +30,22 @@ export default function Home() {
   const [photoUrl, setPhotoUrl] = useState('');
 
   useEffect(() => {
-
     ping()
-
       .then(() => setStatus('online'))
-
       .catch(() => setStatus('offline'));
 
-    setPhotoUrl(getTelegramPhotoUrl());
-
+    const id = getTelegramId();
+    getProfile(id)
+      .then((p) => {
+        if (p?.photo) {
+          setPhotoUrl(p.photo);
+        } else {
+          setPhotoUrl(getTelegramPhotoUrl());
+        }
+      })
+      .catch(() => {
+        setPhotoUrl(getTelegramPhotoUrl());
+      });
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- switch avatar picker to gender-neutral SVGs
- load saved avatar from API on home screen
- show user avatar in friends leaderboard
- use stored avatar in Snakes & Ladders

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68553e1412248329812f2182a2d8c1db