### PR TITLE
Add avatar save flow and refresh profile photos

### DIFF
--- a/webapp/src/components/AvatarPickerModal.jsx
+++ b/webapp/src/components/AvatarPickerModal.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 // Use DiceBear's adventurer-neutral SVG avatars which are gender-neutral
 // and small text-based files instead of binary PNG images.
@@ -10,7 +10,9 @@ const AVATARS = [
   'https://api.dicebear.com/7.x/adventurer-neutral/svg?seed=avatar5'
 ];
 
-export default function AvatarPickerModal({ open, onClose, onSelect }) {
+export default function AvatarPickerModal({ open, onClose, onSave }) {
+  const [selected, setSelected] = useState(null);
+
   if (!open) return null;
 
   return (
@@ -23,14 +25,25 @@ export default function AvatarPickerModal({ open, onClose, onSelect }) {
               key={src}
               src={src}
               alt="avatar"
-              className="w-20 h-20 rounded-full cursor-pointer hover:opacity-80"
-              onClick={() => onSelect(src)}
+              className={`w-20 h-20 rounded-full cursor-pointer hover:opacity-80 ${selected === src ? 'ring-4 ring-accent' : ''}`}
+              onClick={() => setSelected(src)}
             />
           ))}
         </div>
-        <button onClick={onClose} className="mt-4 px-4 py-1 bg-primary hover:bg-primary-hover rounded w-full">
-          Close
-        </button>
+        <div className="flex space-x-2">
+          <button
+            onClick={() => {
+              if (selected) onSave(selected);
+            }}
+            disabled={!selected}
+            className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover rounded disabled:opacity-50"
+          >
+            Save
+          </button>
+          <button onClick={onClose} className="flex-1 px-4 py-1 border border-border bg-surface rounded">
+            Cancel
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -45,6 +45,16 @@ export default function Friends() {
       });
   }, [telegramId]);
 
+  useEffect(() => {
+    const updatePhoto = () => {
+      getProfile(telegramId)
+        .then((p) => setMyPhotoUrl(p?.photo || getTelegramPhotoUrl()))
+        .catch(() => setMyPhotoUrl(getTelegramPhotoUrl()));
+    };
+    window.addEventListener('profilePhotoUpdated', updatePhoto);
+    return () => window.removeEventListener('profilePhotoUpdated', updatePhoto);
+  }, [telegramId]);
+
   if (!referral) return <div className="p-4">Loading...</div>;
 
   const link = `https://t.me/${BOT_USERNAME}?start=${referral.code}`;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -392,6 +392,17 @@ export default function SnakeAndLadder() {
   }, []);
 
   useEffect(() => {
+    const updatePhoto = () => {
+      const id = getTelegramId();
+      getProfile(id)
+        .then((p) => setPhotoUrl(p?.photo || getTelegramPhotoUrl()))
+        .catch(() => setPhotoUrl(getTelegramPhotoUrl()));
+    };
+    window.addEventListener('profilePhotoUpdated', updatePhoto);
+    return () => window.removeEventListener('profilePhotoUpdated', updatePhoto);
+  }, []);
+
+  useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const t = params.get("token");
     const amt = params.get("amount");

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -46,6 +46,17 @@ export default function Home() {
       .catch(() => {
         setPhotoUrl(getTelegramPhotoUrl());
       });
+
+    const handleUpdate = () => {
+      const id = getTelegramId();
+      getProfile(id)
+        .then((p) => {
+          setPhotoUrl(p?.photo || getTelegramPhotoUrl());
+        })
+        .catch(() => setPhotoUrl(getTelegramPhotoUrl()));
+    };
+    window.addEventListener('profilePhotoUpdated', handleUpdate);
+    return () => window.removeEventListener('profilePhotoUpdated', handleUpdate);
   }, []);
 
   return (

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -115,10 +115,11 @@ export default function MyAccount() {
       <AvatarPickerModal
         open={showAvatarPicker}
         onClose={() => setShowAvatarPicker(false)}
-        onSelect={async (src) => {
+        onSave={async (src) => {
           const updated = await updateProfile({ telegramId, photo: src });
           setProfile(updated);
           setShowAvatarPicker(false);
+          window.dispatchEvent(new Event('profilePhotoUpdated'));
         }}
       />
       {autoUpdating && (


### PR DESCRIPTION
## Summary
- implement selection and saving in `AvatarPickerModal`
- update `MyAccount` page to dispatch `profilePhotoUpdated` when avatar saved
- listen for `profilePhotoUpdated` in Home, Friends, and Snake and Ladder pages

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*
- `npm --prefix webapp install`
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_685542781b508329abda65ec15c99792