### PR TITLE
Align pot coin icon with board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -480,7 +480,9 @@ body {
   height: 12rem;
   top: 40%;
   left: 50%;
-  transform: translate(-50%, -50%) translateZ(20px) rotateX(10deg) rotateY(0deg);
+  transform-origin: bottom center;
+  transform: translate(-50%, -50%) translateZ(20px)
+    rotateX(calc(var(--board-angle, 60deg) * -1 - 10deg)) rotateY(0deg);
   animation: pot-spin 6s linear infinite;
   object-fit: contain;
   pointer-events: none;
@@ -658,10 +660,12 @@ body {
 
 @keyframes pot-spin {
   from {
-    transform: translate(-50%, -50%) translateZ(20px) rotateX(10deg) rotateY(0deg);
+    transform: translate(-50%, -50%) translateZ(20px)
+      rotateX(calc(var(--board-angle, 60deg) * -1 - 10deg)) rotateY(0deg);
   }
   to {
-    transform: translate(-50%, -50%) translateZ(20px) rotateX(10deg) rotateY(360deg);
+    transform: translate(-50%, -50%) translateZ(20px)
+      rotateX(calc(var(--board-angle, 60deg) * -1 - 10deg)) rotateY(360deg);
   }
 }
 


### PR DESCRIPTION
## Summary
- align coin icon on the pot with the same board angle transform as player tokens
- update pot rotation animation to account for board angle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68555772da408329976c94da835ea153