### PR TITLE
Add rotating hex shadow under token

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -645,6 +645,11 @@ body {
   transform: translate(-50%, -50%) translateZ(2px)
     rotateX(calc(var(--board-angle, 60deg) * -1));
   z-index: 0;
+  animation: hex-spin 10s linear infinite;
+}
+
+.token-hexagon.step {
+  background-color: #4b5563; /* dark gray */
 }
 
 @keyframes hex-spin {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -144,7 +144,11 @@ function Board({
           )}
           {position === num && (
             <>
-              <div className="token-hexagon" />
+              <div
+                className={`token-hexagon ${
+                  isHighlight ? 'step' : ''
+                }`}
+              />
               <PlayerToken
                 photoUrl={photoUrl}
                 type={isHighlight ? highlight.type : tokenType}


### PR DESCRIPTION
## Summary
- add rotating hexagon shadow beneath player token
- turn hexagon dark gray while stepping

## Testing
- `npm test` *(fails: 12 passing, 2 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68555e15b3c48329b14707d7926d8d36