### PR TITLE
Fix hexagon base orientation

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -61,12 +61,6 @@ export default function HexPrismToken({ color = "#008080", photoUrl, className =
       [...sideMaterials, topMaterial, bottomMaterial],
     );
     prism.rotation.y = Math.PI / 6; // show a corner toward the viewer
-    if (hexEl) {
-      hexEl.style.setProperty(
-        "--token-rotation",
-        `${THREE.MathUtils.radToDeg(prism.rotation.y)}deg`,
-      );
-    }
     scene.add(prism);
 
     const ambient = new THREE.AmbientLight(0xffffff, 0.6);
@@ -78,12 +72,6 @@ export default function HexPrismToken({ color = "#008080", photoUrl, className =
     let frameId;
     const animate = () => {
       prism.rotation.y += 0.01;
-      if (hexEl) {
-        hexEl.style.setProperty(
-          "--token-rotation",
-          `${THREE.MathUtils.radToDeg(prism.rotation.y)}deg`,
-        );
-      }
       renderer.render(scene, camera);
       frameId = requestAnimationFrame(animate);
     };

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -643,8 +643,7 @@ body {
   pointer-events: none;
   /* Lay flat on the board using the same angle */
   transform: translate(-50%, -50%) translateZ(2px)
-    rotateX(calc(var(--board-angle, 60deg) * -1))
-    rotateY(var(--token-rotation, 30deg));
+    rotateX(calc(var(--board-angle, 60deg) * -1));
   z-index: 0;
 }
 


### PR DESCRIPTION
## Summary
- keep the board highlight hexagon flat while token rotates
- drop unused `--token-rotation` updates

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6855642bacd08329b8e005772895ee20