### PR TITLE
Fix hexagon overlay orientation

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -641,9 +641,9 @@ body {
   left: 50%;
   top: 50%;
   pointer-events: none;
-  /* Lay flat on the board using the same angle */
+  /* Match the board angle so the hexagon lays flat */
   transform: translate(-50%, -50%) translateZ(2px)
-    rotateX(calc(var(--board-angle, 60deg) * -1)) rotateY(0deg);
+    rotateX(var(--board-angle, 60deg)) rotateY(0deg);
   animation: hex-spin 6s linear infinite;
   z-index: 0;
 }
@@ -666,11 +666,11 @@ body {
 @keyframes hex-spin {
   from {
     transform: translate(-50%, -50%) translateZ(2px)
-      rotateX(calc(var(--board-angle, 60deg) * -1)) rotateY(0deg);
+      rotateX(var(--board-angle, 60deg)) rotateY(0deg);
   }
   to {
     transform: translate(-50%, -50%) translateZ(2px)
-      rotateX(calc(var(--board-angle, 60deg) * -1)) rotateY(360deg);
+      rotateX(var(--board-angle, 60deg)) rotateY(360deg);
   }
 }
 


### PR DESCRIPTION
## Summary
- rotate board token overlay using the board angle so it lies flat
- update `hex-spin` animation to match new rotation

## Testing
- `npm test` *(fails: manifest and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68556e51d01883298cce99f0daeeb546