### PR TITLE
Add wall sections and profile navigation

### DIFF
--- a/bot/models/Post.js
+++ b/bot/models/Post.js
@@ -5,6 +5,7 @@ const postSchema = new mongoose.Schema({
   author: { type: Number, required: true },
   text: { type: String, default: '' },
   photo: { type: String, default: '' },
+  tags: { type: [String], default: [] },
   likes: { type: [Number], default: [] },
   comments: {
     type: [

--- a/bot/routes/social.js
+++ b/bot/routes/social.js
@@ -131,7 +131,7 @@ router.post('/wall/feed', async (req, res) => {
 });
 
 router.post('/wall/post', async (req, res) => {
-  const { ownerId, authorId, text, photo, sharedPost } = req.body;
+  const { ownerId, authorId, text, photo, tags, sharedPost } = req.body;
   if (!ownerId || !authorId)
     return res.status(400).json({ error: 'ownerId and authorId required' });
   const post = await Post.create({
@@ -139,6 +139,7 @@ router.post('/wall/post', async (req, res) => {
     author: authorId,
     text,
     photo,
+    tags: tags || [],
     sharedPost
   });
   res.json(post);

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -42,6 +42,7 @@ export default function App() {
           <Route path="/wallet" element={<Wallet />} />
           <Route path="/messages" element={<Messages />} />
           <Route path="/wall" element={<Wall />} />
+          <Route path="/wall/:id" element={<Wall />} />
           <Route path="/account" element={<MyAccount />} />
         </Routes>
       </Layout>

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
@@ -122,7 +123,7 @@ export default function Friends() {
         </div>
       </section>
 
-      <section className="space-y-2">
+      <section id="leaderboard" className="space-y-2">
         <h3 className="text-lg font-semibold">Leaderboard</h3>
         <div className="max-h-96 overflow-y-auto border border-border rounded">
           <table className="w-full text-sm">
@@ -142,18 +143,22 @@ export default function Friends() {
                 >
                   <td className="p-2">{idx + 1}</td>
                   <td className="p-2 w-16">
-                    <img
-                      src={
-                        u.telegramId === telegramId
-                          ? myPhotoUrl || '/assets/icons/profile.svg'
-                          : u.photo || u.photoUrl || '/assets/icons/profile.svg'
-                      }
-                      alt="avatar"
-                      className="w-16 h-16 hexagon border-2 border-brand-gold object-cover"
-                    />
+                    <Link to={`/wall/${u.telegramId}`}> 
+                      <img
+                        src={
+                          u.telegramId === telegramId
+                            ? myPhotoUrl || '/assets/icons/profile.svg'
+                            : u.photo || u.photoUrl || '/assets/icons/profile.svg'
+                        }
+                        alt="avatar"
+                        className="w-16 h-16 hexagon border-2 border-brand-gold object-cover"
+                      />
+                    </Link>
                   </td>
                   <td className="p-2">
-                    {u.nickname || `${u.firstName} ${u.lastName}`.trim() || 'User'}
+                    <Link to={`/wall/${u.telegramId}`} className="hover:underline">
+                      {u.nickname || `${u.firstName} ${u.lastName}`.trim() || 'User'}
+                    </Link>
                   </td>
                   <td className="p-2 text-right">{u.balance}</td>
                 </tr>
@@ -168,7 +173,9 @@ export default function Friends() {
                       className="w-16 h-16 hexagon border-2 border-brand-gold object-cover"
                     />
                   </td>
-                  <td className="p-2">You</td>
+                  <td className="p-2">
+                    <Link to={`/wall/${telegramId}`} className="hover:underline">You</Link>
+                  </td>
                   <td className="p-2 text-right">{leaderboard.find((u) => u.telegramId === telegramId)?.balance ?? '...'}</td>
                 </tr>
               )}

--- a/webapp/src/pages/Wall.jsx
+++ b/webapp/src/pages/Wall.jsx
@@ -1,13 +1,17 @@
 import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { FaTelegramPlane, FaTwitter, FaFacebook } from 'react-icons/fa';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
 import { getTelegramId } from '../utils/telegram.js';
 import {
   listWallFeed,
+  listWallPosts,
   createWallPost,
   likeWallPost,
   commentWallPost,
-  shareWallPost
+  shareWallPost,
+  getProfile
 } from '../utils/api.js';
 
 export default function Wall() {
@@ -19,27 +23,42 @@ export default function Wall() {
     return <OpenInTelegram />;
   }
 
+  const { id } = useParams();
+  const idParam = id;
+
   const [posts, setPosts] = useState([]);
   const [text, setText] = useState('');
   const [photo, setPhoto] = useState(null);
   const [commentText, setCommentText] = useState({});
+  const [tags, setTags] = useState('');
+  const [profile, setProfile] = useState(null);
 
   useEffect(() => {
-    listWallFeed(telegramId).then(setPosts);
-  }, [telegramId]);
+    if (id) {
+      listWallPosts(id).then(setPosts);
+      getProfile(id).then(setProfile).catch(() => {});
+    } else {
+      listWallFeed(telegramId).then(setPosts);
+    }
+  }, [telegramId, id]);
 
   async function handlePost() {
     if (!text && !photo) return;
-    await createWallPost(telegramId, telegramId, text, photo);
+    const tagArr = tags
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t);
+    await createWallPost(telegramId, telegramId, text, photo, tagArr);
     setText('');
     setPhoto(null);
+    setTags('');
     const data = await listWallFeed(telegramId);
     setPosts(data);
   }
 
   async function handleLike(id) {
     await likeWallPost(id, telegramId);
-    const data = await listWallFeed(telegramId);
+    const data = idParam ? await listWallPosts(idParam) : await listWallFeed(telegramId);
     setPosts(data);
   }
 
@@ -47,45 +66,86 @@ export default function Wall() {
     if (!commentText[id]) return;
     await commentWallPost(id, telegramId, commentText[id]);
     setCommentText({ ...commentText, [id]: '' });
-    const data = await listWallFeed(telegramId);
+    const data = idParam ? await listWallPosts(idParam) : await listWallFeed(telegramId);
     setPosts(data);
   }
 
   async function handleShare(id) {
     await shareWallPost(id, telegramId);
-    const data = await listWallFeed(telegramId);
+    const data = idParam ? await listWallPosts(idParam) : await listWallFeed(telegramId);
     setPosts(data);
+  }
+
+  function shareOn(platform, post) {
+    const url = `${window.location.origin}/wall/${post.owner}?post=${post._id}`;
+    const text = post.text || '';
+    let shareUrl = '';
+    if (platform === 'telegram') {
+      shareUrl = `https://t.me/share/url?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`;
+    } else if (platform === 'twitter') {
+      shareUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`;
+    } else if (platform === 'facebook') {
+      shareUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
+    }
+    window.open(shareUrl, '_blank');
   }
 
   return (
     <div className="p-4 space-y-4 text-text">
-      <h2 className="text-xl font-bold">The Wall</h2>
-      <div className="space-y-2">
-        <textarea
-          className="w-full border border-border rounded p-2 bg-surface"
-          rows="3"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          placeholder="Write something..."
-        />
-        <input
-          type="file"
-          accept="image/*"
-          onChange={(e) => {
-            const file = e.target.files[0];
-            if (!file) return setPhoto(null);
-            const reader = new FileReader();
-            reader.onload = (ev) => setPhoto(ev.target.result);
-            reader.readAsDataURL(file);
-          }}
-        />
-        <button
-          onClick={handlePost}
-          className="px-2 py-1 bg-primary hover:bg-primary-hover rounded"
-        >
-          Post
-        </button>
+      <h2 className="text-xl font-bold">
+        {idParam && profile
+          ? `${profile.nickname || profile.firstName || 'User'}'s Wall`
+          : 'The Wall'}
+      </h2>
+      <div className="flex space-x-4 text-sm border-b border-border pb-2">
+        <Link to="/wall" className="hover:underline">
+          Wall
+        </Link>
+        <Link to="/friends" className="hover:underline">
+          Friends
+        </Link>
+        <Link to="/friends#leaderboard" className="hover:underline">
+          Leaderboard
+        </Link>
+        <Link to="/messages" className="hover:underline">
+          Inbox
+        </Link>
       </div>
+      {!idParam && (
+        <div className="space-y-2">
+          <textarea
+            className="w-full border border-border rounded p-2 bg-surface"
+            rows="3"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Write something..."
+          />
+          <input
+            type="text"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            className="w-full border border-border rounded p-2 bg-surface"
+            placeholder="Tags (comma separated)"
+          />
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) => {
+              const file = e.target.files[0];
+              if (!file) return setPhoto(null);
+              const reader = new FileReader();
+              reader.onload = (ev) => setPhoto(ev.target.result);
+              reader.readAsDataURL(file);
+            }}
+          />
+          <button
+            onClick={handlePost}
+            className="px-2 py-1 bg-primary hover:bg-primary-hover rounded"
+          >
+            Post
+          </button>
+        </div>
+      )}
       <div className="space-y-2">
         {posts.map((p) => (
           <div key={p._id} className="border border-border rounded p-2 space-y-1">
@@ -96,9 +156,19 @@ export default function Wall() {
             {p.photo && (
               <img src={p.photo} alt="post" className="max-w-full rounded" />
             )}
+            {p.tags?.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {p.tags.map((t, idx) => (
+                  <span key={idx} className="bg-accent text-xs px-1 rounded">#{t}</span>
+                ))}
+              </div>
+            )}
             <div className="flex space-x-2 text-sm">
               <button onClick={() => handleLike(p._id)}>Like ({p.likes?.length || 0})</button>
-              <button onClick={() => handleShare(p._id)}>Share</button>
+              <button onClick={() => handleShare(p._id)}>Repost</button>
+              <FaTelegramPlane className="cursor-pointer" onClick={() => shareOn('telegram', p)} />
+              <FaTwitter className="cursor-pointer" onClick={() => shareOn('twitter', p)} />
+              <FaFacebook className="cursor-pointer" onClick={() => shareOn('facebook', p)} />
             </div>
             <div className="space-y-1">
               {p.comments?.map((c, idx) => (

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -244,8 +244,8 @@ export function listWallFeed(telegramId) {
   return post('/api/social/wall/feed', { telegramId });
 }
 
-export function createWallPost(ownerId, authorId, text, photo, sharedPost) {
-  return post('/api/social/wall/post', { ownerId, authorId, text, photo, sharedPost });
+export function createWallPost(ownerId, authorId, text, photo, tags = [], sharedPost) {
+  return post('/api/social/wall/post', { ownerId, authorId, text, photo, tags, sharedPost });
 }
 
 export function likeWallPost(postId, telegramId) {


### PR DESCRIPTION
## Summary
- support post tags server-side and on the wall
- add social share icons and tab navigation on the wall page
- allow viewing other users' walls
- link leaderboard users to their walls

## Testing
- `npm test` *(fails: server manifest and snake lobby route tests)*

------
https://chatgpt.com/codex/tasks/task_e_685570830fd08329940a0d7a7e6d7d4f