### PR TITLE
Fix photo uploads on Wall

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ### The Wall
 
-Users can share photos and messages on **The Wall**. Posts support likes, comments and sharing. Friends see your updates and receive Telegram notifications when they interact with them.
+Users can share photos and messages on **The Wall**. Posts support likes, comments and sharing. You can also attach images up to about 10&nbsp;MB and repost to Telegram, Twitter or Facebook. Friends see your updates and receive Telegram notifications when they interact with them.
 
 ### Using an HTTPS proxy
 

--- a/bot/server.js
+++ b/bot/server.js
@@ -42,7 +42,8 @@ const gameManager = new GameRoomManager(io);
 
 // Middleware and routes
 app.use(compression());
-app.use(express.json());
+// Increase JSON body limit to handle large photo uploads
+app.use(express.json({ limit: '10mb' }));
 app.use('/api/mining', miningRoutes);
 app.use('/api/tasks', tasksRoutes);
 app.use('/api/watch', watchRoutes);


### PR DESCRIPTION
## Summary
- allow larger JSON bodies in server so photo uploads work
- document Wall photo and share support

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855a117972883298733c4185f229623