### PR TITLE
Fix token hexagon overlay orientation

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -643,7 +643,7 @@ body {
   pointer-events: none;
   /* Align with the token photo but sit just underneath */
   transform: translate(-50%, -50%) translateZ(14.2px)
-    rotateX(calc(var(--board-angle, 60deg) * -1 - 10deg)) rotateY(0deg);
+    rotateX(calc(var(--board-angle, 60deg) * -1)) rotateY(0deg);
   animation: hex-spin 6s linear infinite;
   z-index: 0;
 }
@@ -666,11 +666,11 @@ body {
 @keyframes hex-spin {
   from {
     transform: translate(-50%, -50%) translateZ(14.2px)
-      rotateX(calc(var(--board-angle, 60deg) * -1 - 10deg)) rotateY(0deg);
+      rotateX(calc(var(--board-angle, 60deg) * -1)) rotateY(0deg);
   }
   to {
     transform: translate(-50%, -50%) translateZ(14.2px)
-      rotateX(calc(var(--board-angle, 60deg) * -1 - 10deg)) rotateY(360deg);
+      rotateX(calc(var(--board-angle, 60deg) * -1)) rotateY(360deg);
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust rotation for the CSS token hexagon overlay so it's flat with the board

## Testing
- `npm test` *(fails: manifest endpoint and lobby route unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6855a31b4e2c8329a10ad6c2307954a5