### PR TITLE
Refactor Inbox integration

### DIFF
--- a/webapp/src/components/InboxWidget.jsx
+++ b/webapp/src/components/InboxWidget.jsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import OpenInTelegram from './OpenInTelegram.jsx';
+import { getTelegramId } from '../utils/telegram.js';
+import { listFriends, getMessages, sendMessage } from '../utils/api.js';
+
+export default function InboxWidget() {
+  let telegramId;
+  try {
+    telegramId = getTelegramId();
+  } catch (err) {
+    return <OpenInTelegram />;
+  }
+
+  const [friends, setFriends] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    listFriends(telegramId).then(setFriends);
+  }, [telegramId]);
+
+  useEffect(() => {
+    if (selected) {
+      getMessages(telegramId, selected.telegramId).then(setMessages);
+    }
+  }, [selected, telegramId]);
+
+  async function handleSend() {
+    if (!text || !selected) return;
+    await sendMessage(telegramId, selected.telegramId, text);
+    setText('');
+    const msgs = await getMessages(telegramId, selected.telegramId);
+    setMessages(msgs);
+  }
+
+  return (
+    <div className="p-2 border border-border rounded bg-surface space-y-2">
+      <h3 className="font-semibold">Inbox</h3>
+      <div className="flex space-x-2 text-sm">
+        <div className="w-1/3 space-y-1">
+          {friends.map((f) => (
+            <div
+              key={f.telegramId}
+              className={`p-1 border border-border rounded cursor-pointer ${selected?.telegramId === f.telegramId ? 'bg-accent' : ''}`}
+              onClick={() => setSelected(f)}
+            >
+              {f.nickname || `${f.firstName} ${f.lastName}`.trim() || 'User'}
+            </div>
+          ))}
+        </div>
+        <div className="flex-1 space-y-1">
+          {selected ? (
+            <>
+              <div className="h-32 overflow-y-auto border border-border rounded p-1 space-y-1">
+                {messages.map((m, idx) => (
+                  <div key={idx} className={`${m.from === telegramId ? 'text-right' : 'text-left'}`}>{m.text}</div>
+                ))}
+              </div>
+              <div className="flex space-x-1">
+                <input
+                  type="text"
+                  value={text}
+                  onChange={(e) => setText(e.target.value)}
+                  className="flex-1 border border-border rounded px-1 py-0.5 bg-surface"
+                />
+                <button onClick={handleSend} className="px-1 py-0.5 bg-primary hover:bg-primary-hover rounded">
+                  Send
+                </button>
+              </div>
+            </>
+          ) : (
+            <p>Select a friend</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/Navbar.jsx
+++ b/webapp/src/components/Navbar.jsx
@@ -4,7 +4,6 @@ import {
   AiOutlineCheckSquare,
   AiOutlineUser,
   AiOutlineShop,
-  AiOutlineMail,
   AiOutlinePicture,
   AiOutlineBell
 } from 'react-icons/ai';
@@ -16,7 +15,6 @@ export default function Navbar() {
       <div className="container mx-auto px-4 py-4 flex items-center justify-between text-base">
         <NavItem to="/" icon={AiOutlineHome} label="Home" />
         <NavItem to="/wall" icon={AiOutlinePicture} label="The Wall" />
-        <NavItem to="/messages" icon={AiOutlineMail} label="Inbox" />
         <NavItem to="/notifications" icon={AiOutlineBell} label="Alerts" />
         <NavItem to="/games" icon={AiOutlinePlayCircle} label="Games" />
         <NavItem to="/tasks" icon={AiOutlineCheckSquare} label="Tasks" />

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -18,6 +18,7 @@ import BalanceSummary from '../components/BalanceSummary.jsx';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import AvatarPickerModal from '../components/AvatarPickerModal.jsx';
 import AvatarPromptModal from '../components/AvatarPromptModal.jsx';
+import InboxWidget from '../components/InboxWidget.jsx';
 
 export default function MyAccount() {
   useTelegramBackButton();
@@ -149,9 +150,6 @@ export default function MyAccount() {
             <a href="/friends" className="underline text-primary">
               Friends
             </a>
-            <a href="/messages" className="underline text-primary">
-              Inbox
-            </a>
             <a href="/wall" className="underline text-primary">
               My Wall
             </a>
@@ -203,6 +201,7 @@ export default function MyAccount() {
           </div>
         )}
       </div>
+      <InboxWidget />
     </div>
   );
 }

--- a/webapp/src/pages/Wall.jsx
+++ b/webapp/src/pages/Wall.jsx
@@ -10,6 +10,7 @@ import {
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
 import { getTelegramId } from '../utils/telegram.js';
+import InboxWidget from '../components/InboxWidget.jsx';
 import {
   listWallFeed,
   listWallPosts,
@@ -126,9 +127,6 @@ export default function Wall() {
         </Link>
         <Link to="/friends#leaderboard" className="hover:underline">
           Leaderboard
-        </Link>
-        <Link to="/messages" className="hover:underline">
-          Inbox
         </Link>
       </div>
       {!idParam && (
@@ -263,6 +261,7 @@ export default function Wall() {
           </div>
         ))}
       </div>
+      <InboxWidget />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `InboxWidget` component so messages can appear in other pages
- remove Inbox link from Navbar and Wall sub-navigation
- add Inbox widget to Wall and My Account pages

## Testing
- `npm test` *(fails: server manifest and snake lobby route)*

------
https://chatgpt.com/codex/tasks/task_e_6855a7db98e8832992e4dc9ec7930da3