### PR TITLE
Add alt text support to Wall posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Users can share photos and messages on **The Wall**. Posts support likes, commen
 
 The latest update adds avatars, stylish icon buttons and a simple notification page. Posts now show the author's profile picture and name for a more social look. Buttons for liking, commenting and sharing use crisp icons that suit the premium color scheme. A bell icon on the navigation bar opens an **Alerts** page which reminds users that real notifications arrive via Telegram.
 
+Images in posts now include optional **alt text** descriptions for better accessibility. When creating a post you can add a brief description so screen readers can convey the image content.
+
 ### Using an HTTPS proxy
 
 If your server requires a proxy to reach external services like Tonkeeper,

--- a/bot/models/Post.js
+++ b/bot/models/Post.js
@@ -5,6 +5,7 @@ const postSchema = new mongoose.Schema({
   author: { type: Number, required: true },
   text: { type: String, default: '' },
   photo: { type: String, default: '' },
+  photoAlt: { type: String, default: '' },
   tags: { type: [String], default: [] },
   likes: { type: [Number], default: [] },
   comments: {

--- a/bot/routes/social.js
+++ b/bot/routes/social.js
@@ -131,7 +131,7 @@ router.post('/wall/feed', async (req, res) => {
 });
 
 router.post('/wall/post', async (req, res) => {
-  const { ownerId, authorId, text, photo, tags, sharedPost } = req.body;
+  const { ownerId, authorId, text, photo, photoAlt, tags, sharedPost } = req.body;
   if (!ownerId || !authorId)
     return res.status(400).json({ error: 'ownerId and authorId required' });
   const post = await Post.create({
@@ -139,6 +139,7 @@ router.post('/wall/post', async (req, res) => {
     author: authorId,
     text,
     photo,
+    photoAlt,
     tags: tags || [],
     sharedPost
   });
@@ -203,6 +204,7 @@ router.post('/wall/share', async (req, res) => {
     author: telegramId,
     text: original.text,
     photo: original.photo,
+    photoAlt: original.photoAlt,
     sharedPost: postId
   });
   res.json(shared);

--- a/webapp/src/pages/Wall.jsx
+++ b/webapp/src/pages/Wall.jsx
@@ -36,6 +36,7 @@ export default function Wall() {
   const [posts, setPosts] = useState([]);
   const [text, setText] = useState('');
   const [photo, setPhoto] = useState(null);
+  const [photoAlt, setPhotoAlt] = useState('');
   const [commentText, setCommentText] = useState({});
   const [tags, setTags] = useState('');
   const [profile, setProfile] = useState(null);
@@ -69,9 +70,17 @@ export default function Wall() {
       .split(',')
       .map((t) => t.trim())
       .filter((t) => t);
-    await createWallPost(telegramId, telegramId, text, photo, tagArr);
+    await createWallPost(
+      telegramId,
+      telegramId,
+      text,
+      photo,
+      photoAlt,
+      tagArr
+    );
     setText('');
     setPhoto(null);
+    setPhotoAlt('');
     setTags('');
     const data = await listWallFeed(telegramId);
     setPosts(data);
@@ -156,6 +165,13 @@ export default function Wall() {
               reader.readAsDataURL(file);
             }}
           />
+          <input
+            type="text"
+            value={photoAlt}
+            onChange={(e) => setPhotoAlt(e.target.value)}
+            className="w-full border border-border rounded p-2 bg-surface"
+            placeholder="Image description (alt text)"
+          />
           <button
             onClick={handlePost}
             className="px-2 py-1 bg-primary hover:bg-primary-hover rounded"
@@ -171,7 +187,11 @@ export default function Wall() {
               <div className="flex items-center space-x-2">
                 <img
                   src={authorProfiles[p.author]?.photo || '/assets/icons/profile.svg'}
-                  alt="avatar"
+                  alt={`Avatar of ${
+                    authorProfiles[p.author]?.nickname ||
+                    authorProfiles[p.author]?.firstName ||
+                    'User'
+                  }`}
                   className="w-8 h-8 rounded-full border border-accent"
                 />
                 <div>
@@ -190,7 +210,11 @@ export default function Wall() {
 
             {p.text && <div className="whitespace-pre-wrap">{p.text}</div>}
             {p.photo && (
-              <img src={p.photo} alt="post" className="max-w-full rounded" />
+              <img
+                src={p.photo}
+                alt={p.photoAlt || 'post image'}
+                className="max-w-full rounded"
+              />
             )}
             {p.tags?.length > 0 && (
               <div className="flex flex-wrap gap-1">

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -244,8 +244,24 @@ export function listWallFeed(telegramId) {
   return post('/api/social/wall/feed', { telegramId });
 }
 
-export function createWallPost(ownerId, authorId, text, photo, tags = [], sharedPost) {
-  return post('/api/social/wall/post', { ownerId, authorId, text, photo, tags, sharedPost });
+export function createWallPost(
+  ownerId,
+  authorId,
+  text,
+  photo,
+  photoAlt,
+  tags = [],
+  sharedPost
+) {
+  return post('/api/social/wall/post', {
+    ownerId,
+    authorId,
+    text,
+    photo,
+    photoAlt,
+    tags,
+    sharedPost
+  });
 }
 
 export function likeWallPost(postId, telegramId) {


### PR DESCRIPTION
## Summary
- allow storing alt text for Wall post images
- handle `photoAlt` in Wall API routes
- support alt text field in the Wall UI and display it on images
- document alt text accessibility feature

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_6855ac338e448329b9bbfb41f0251553