### PR TITLE
Revamp snake board colors

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -118,7 +118,7 @@ body {
 }
 
 .board-cell {
-  @apply relative flex items-center justify-center rounded-xl text-text bg-surface border-2 border-accent;
+  @apply relative flex items-center justify-center rounded-xl text-brand-black bg-white border-2 border-accent;
   /* Removed dark drop shadow that created a black frame around dice */
   box-shadow: none;
   transform: translateZ(5px);
@@ -388,38 +388,21 @@ body {
   box-shadow: 0 0 10px 4px rgba(250, 204, 21, 0.8);
 }
 
-.board-cell.normal-highlight {
-  background-color: #fde047; /* yellow-300 */
-}
-
+.board-cell.normal-highlight,
 .board-cell.ladder-cell.normal-highlight,
-.board-cell.snake-cell.normal-highlight {
-  background-color: #fde047; /* yellow-300 */
-}
-
-.board-cell.ladder-highlight {
-  background-color: #86efac; /* green-300 */
-}
-
-.board-cell.snake-highlight {
-  background-color: #fca5a5; /* red-300 */
-}
-
-.board-cell.ladder-cell.ladder-highlight {
-  background-color: #86efac; /* green-300 */
-}
-
+.board-cell.snake-cell.normal-highlight,
+.board-cell.ladder-highlight,
+.board-cell.snake-highlight,
+.board-cell.ladder-cell.ladder-highlight,
 .board-cell.snake-cell.snake-highlight {
-  background-color: #fca5a5; /* red-300 */
+  border-color: #facc15; /* accent */
 }
 
 /* Indicate ladder or snake on the board */
-.board-cell.ladder-cell {
-  background-color: #86efac; /* green-300 */
-}
-
+.board-cell.ladder-cell,
 .board-cell.snake-cell {
-  background-color: #fca5a5; /* red-300 */
+  border-color: #facc15;
+  color: #000000;
 }
 
 .cell-marker {
@@ -457,7 +440,7 @@ body {
 
 .board-cell.snake-cell,
 .board-cell.ladder-cell {
-  color: #ffffff;
+  color: #000000;
 }
 
 .pot-cell {
@@ -533,6 +516,8 @@ body {
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
+  background-color: transparent;
+  mix-blend-mode: multiply;
   z-index: 5;
 }
 


### PR DESCRIPTION
## Summary
- apply TonPlaygram palette to snake & ladder board
- keep board tiles white and highlight borders only
- blend the board logo with the background

## Testing
- `npm test` *(fails: 2 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6855af68491c832984a8837027dfa9a8