### PR TITLE
Modify snake game offsets

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -6,13 +6,13 @@ export const DEFAULT_SNAKES = {
   19: 7,
   21: 9,
   54: 34,
-  62: 18,
+  62: 42,
   64: 60,
-  87: 24,
+  87: 67,
   93: 73,
   95: 75,
   98: 79,
-  99: 7,
+  99: 80,
 };
 
 export const DEFAULT_LADDERS = {
@@ -20,7 +20,7 @@ export const DEFAULT_LADDERS = {
   5: 8,
   11: 26,
   20: 29,
-  27: 56,
+  27: 46,
   36: 44,
   51: 67,
   71: 91,
@@ -41,8 +41,8 @@ function generateRandomLadders(snakes, count = 8) {
   while (Object.keys(ladders).length < count) {
     const start = Math.floor(Math.random() * (FINAL_TILE - 20)) + 2;
     const maxStep = Math.min(FINAL_TILE - start - 1, 20);
-    if (maxStep < 3) continue;
-    const end = start + 3 + Math.floor(Math.random() * maxStep);
+    if (maxStep < 1) continue;
+    const end = start + (Math.floor(Math.random() * maxStep) + 1);
     if (used.has(String(start)) || used.has(String(end))) continue;
     if (ladders[start] || Object.values(ladders).some(l => l.end === start || l.end === end)) continue;
     ladders[start] = { end, width: 6 + Math.floor(Math.random() * 6) };

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -24,8 +24,8 @@ test('applySnakesAndLadders resolves moves', () => {
   });
   room.rollCooldown = 0;
   assert.equal(room.applySnakesAndLadders(3), 22); // ladder
-  assert.equal(room.applySnakesAndLadders(27), 56); // ladder
-  assert.equal(room.applySnakesAndLadders(99), 7); // snake
+  assert.equal(room.applySnakesAndLadders(27), 46); // ladder
+  assert.equal(room.applySnakesAndLadders(99), 80); // snake
   assert.equal(room.applySnakesAndLadders(8), 8); // none
 });
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -421,7 +421,9 @@ export default function SnakeAndLadder() {
     const used = new Set();
     while (Object.keys(snakesObj).length < snakeCount) {
       const start = Math.floor(Math.random() * (boardSize - 10)) + 10;
-      const end = Math.floor(Math.random() * (start - 1)) + 1;
+      const maxDrop = Math.min(start - 1, 20);
+      if (maxDrop <= 0) continue;
+      const end = start - (Math.floor(Math.random() * maxDrop) + 1);
       if (used.has(start) || used.has(end) || snakesObj[start]) continue;
       snakesObj[start] = end;
       used.add(start);
@@ -432,9 +434,9 @@ export default function SnakeAndLadder() {
     const usedL = new Set([...used]);
     while (Object.keys(laddersObj).length < ladderCount) {
       const start = Math.floor(Math.random() * (boardSize - 20)) + 2;
-      const max = boardSize - start - 1;
-      if (max < 3) continue;
-      const end = start + 3 + Math.floor(Math.random() * max);
+      const max = Math.min(boardSize - start - 1, 20);
+      if (max < 1) continue;
+      const end = start + (Math.floor(Math.random() * max) + 1);
       if (
         usedL.has(start) ||
         usedL.has(end) ||
@@ -483,7 +485,7 @@ export default function SnakeAndLadder() {
       : values;
 
     setRollResult(value);
-    setTimeout(() => setRollResult(null), 2500);
+    setTimeout(() => setRollResult(null), 1800);
 
     setTimeout(() => {
       setDiceVisible(false);
@@ -556,9 +558,7 @@ export default function SnakeAndLadder() {
 
       if (snakeEnd != null) {
         const offset = startPos - snakeEnd;
-        setTrail((t) =>
-          t.map((h) => (h.cell === startPos ? { ...h, type: 'snake' } : h)),
-        );
+        setTrail([{ cell: startPos, type: 'snake' }]);
         setOffsetPopup({ cell: startPos, type: 'snake', amount: offset });
         setTimeout(() => setOffsetPopup(null), 1000);
         setMessage(`🐍 ${startPos} -${offset}`);
@@ -623,7 +623,7 @@ export default function SnakeAndLadder() {
     };
 
     moveSeq(steps, 'normal', () => applyEffect(target));
-  }, 2500);
+  }, 1800);
   };
 
   return (


### PR DESCRIPTION
## Summary
- limit snake and ladder steps to a maximum of 20
- reset trail when landing on a snake
- shorten dice result display to 1.8s
- update constants and tests for new ranges

## Testing
- `npm test` *(fails: lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6855b893eb1c8329b926d0bb17f0f91a