### PR TITLE
Update Snake & Ladder board colors

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -118,7 +118,7 @@ body {
 }
 
 .board-cell {
-  @apply relative flex items-center justify-center rounded-xl text-text bg-surface border-2 border-accent;
+  @apply relative flex items-center justify-center rounded-xl text-text border-2 border-accent;
   /* Removed dark drop shadow that created a black frame around dice */
   box-shadow: none;
   transform: translateZ(5px);
@@ -126,6 +126,14 @@ body {
   overflow: visible;
   width: var(--cell-width);
   height: var(--cell-height);
+}
+
+.board-dark {
+  background-color: #0b0f19; /* homepage dark blue */
+}
+
+.board-light {
+  background-color: #11172a; /* lighter dark blue */
 }
 
 .board-cell::after {
@@ -414,12 +422,9 @@ body {
 }
 
 /* Indicate ladder or snake on the board */
-.board-cell.ladder-cell {
-  background-color: #86efac; /* green-300 */
-}
-
+.board-cell.ladder-cell,
 .board-cell.snake-cell {
-  background-color: #fca5a5; /* red-300 */
+  background-color: inherit;
 }
 
 .cell-marker {
@@ -448,6 +453,8 @@ body {
 .cell-number {
   position: relative;
   z-index: 1;
+  color: #ffffff;
+  font-weight: bold;
 }
 
 .board-cell.snake-cell .cell-number,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -105,6 +105,7 @@ function Board({
       const isJump = isHighlight && highlight.type === 'normal';
       const cellType = ladders[num] ? "ladder" : snakes[num] ? "snake" : "";
       const cellClass = cellType ? `${cellType}-cell` : "";
+      const patternClass = (r + c) % 2 === 0 ? "board-dark" : "board-light";
       const icon = cellType === "ladder" ? "🪜" : cellType === "snake" ? "🐍" : "";
       const offsetVal =
         cellType === "ladder"
@@ -116,7 +117,7 @@ function Board({
         <div
           key={num}
           data-cell={num}
-          className={`board-cell ${cellClass} ${highlightClass}`}
+          className={`board-cell ${patternClass} ${cellClass} ${highlightClass}`}
           style={{
             gridRowStart: ROWS - r,
             gridColumnStart: col + 1,


### PR DESCRIPTION
## Summary
- update Snake and Ladder board to use alternating dark/light blue squares
- inherit snake/ladder cell background from board pattern
- show board numbers in bold white text

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_6855bd13f81c83298d5f50903bf0d7fd