### PR TITLE
Fix Telegram notifications behind proxy

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -1,4 +1,5 @@
 import { Telegraf } from 'telegraf';
+import { proxyAgent } from './utils/proxyAgent.js';
 
 
 // Commands
@@ -10,7 +11,9 @@ import registerReferral from './commands/referral.js';
 import registerWallet from './commands/wallet.js';
 import registerLudo from './commands/games/ludo.js';
 import registerHorse from './commands/games/horse.js';
-const bot = new Telegraf(process.env.BOT_TOKEN);
+const bot = new Telegraf(process.env.BOT_TOKEN, {
+  telegram: { agent: proxyAgent }
+});
 registerStart(bot);
 registerMine(bot);
 registerWatch(bot);


### PR DESCRIPTION
## Summary
- wire `proxyAgent` into Telegraf so Telegram API calls go through the configured HTTPS proxy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855bd78ab10832986308c2be0f9b024