### PR TITLE
Fix TonConnect manifest handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ set the `HTTPS_PROXY` (or `https_proxy`) environment variable before running the
 bot. All fetch requests from the Node.js backend will be routed through this
 proxy.
 
+### Troubleshooting wallet connections
+
+If Tonkeeper fails to connect, verify that the TonConnect manifest is reachable
+at the URL configured in `VITE_TONCONNECT_MANIFEST` (frontend) and
+`TONCONNECT_MANIFEST_URL` (backend). The URL must be publicly accessible over
+HTTPS and should match your API's base domain. You can open the manifest in a
+browser to confirm it returns JSON. If your server sits behind a proxy, ensure
+the proxy forwards the `x-forwarded-proto` header so the manifest reports the
+correct `https://` URL.
+
 ## Telegram game bots
 
 Several small Telegram game bots are included in this repository. They use

--- a/bot/server.js
+++ b/bot/server.js
@@ -97,14 +97,12 @@ function ensureWebappBuilt() {
 
 ensureWebappBuilt();
 
-app.use(
-  express.static(webappPath, { maxAge: '1y', immutable: true })
-);
 // Expose TonConnect manifest dynamically so the base URL always matches the
 // current request host. The manifest path is taken from the
 // TONCONNECT_MANIFEST_URL environment variable if provided, otherwise the
-// default `/tonconnect-manifest.json` is used. This avoids 404s when the
-// Express server handles requests before the static middleware.
+// default `/tonconnect-manifest.json` is used. Defining this route before the
+// static middleware ensures it overrides any bundled manifest file so the
+// response always reflects the active host.
 const manifestUrl = process.env.TONCONNECT_MANIFEST_URL || '/tonconnect-manifest.json';
 const manifestPath = new URL(manifestUrl, 'http://placeholder').pathname;
 console.log("TONCONNECT_MANIFEST_URL", manifestUrl);
@@ -122,6 +120,10 @@ app.get(manifestPath, (req, res) => {
     icons: [`${baseUrl}/icons/tpc.svg`]
   });
 });
+
+app.use(
+  express.static(webappPath, { maxAge: '1y', immutable: true })
+);
 
 function sendIndex(res) {
   if (ensureWebappBuilt()) {


### PR DESCRIPTION
## Summary
- serve the TonConnect manifest before static files so the host is always correct
- document troubleshooting steps for wallet connection failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855cb6ec4288329af5659ecccf8b174