### PR TITLE
Add alternating board colors

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -126,6 +126,7 @@ body {
   overflow: visible;
   width: var(--cell-width);
   height: var(--cell-height);
+  background-color: var(--cell-bg, #11172a);
 }
 
 .board-cell::after {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -112,17 +112,21 @@ function Board({
           : cellType === "snake"
           ? snakeOffsets[num]
           : null;
+      const baseColor = num % 2 === 1 ? '#0d47a1' : '#6a0dad';
+      const style = {
+        gridRowStart: ROWS - r,
+        gridColumnStart: col + 1,
+        transform: `translate(${translateX}px, ${translateY}px) scale(${scale}) translateZ(5px)`,
+        transformOrigin: 'bottom center',
+      };
+      if (!cellType) style['--cell-bg'] = baseColor;
+
       tiles.push(
         <div
           key={num}
           data-cell={num}
           className={`board-cell ${cellClass} ${highlightClass}`}
-          style={{
-            gridRowStart: ROWS - r,
-            gridColumnStart: col + 1,
-            transform: `translate(${translateX}px, ${translateY}px) scale(${scale}) translateZ(5px)`,
-            transformOrigin: 'bottom center',
-          }}
+          style={style}
         >
           {(icon || offsetVal != null) && (
             <span className="cell-marker">


### PR DESCRIPTION
## Summary
- alternate Snake & Ladder board cell colors using CSS variable
- set color from board number when generating tiles

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685632c96a80832980782e5608b232af