### PR TITLE
Align snake background with board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -529,19 +529,17 @@ body {
 }
 
 .logo-wall-main {
-  @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 6); /* larger logo width */
-  height: calc(var(--cell-height) * 5); /* taller logo */
-  /* move the logo even higher above the board */
-  top: calc(var(--cell-height) * -9.5 - var(--cell-height) * 1.8 * (var(--final-scale, 1) - 1)); /* adjust for scaled top row */
-  left: 50%;
-  transform: translateX(-50%) rotateX(calc(var(--board-angle, 60deg) * -1)) translateZ(-40px) scale(1.8); /* larger logo */
+  @apply absolute inset-0 flex items-center justify-center;
+  width: 100vw;
+  height: 100vh;
+  transform: rotateX(var(--board-angle, 60deg)) translateZ(-40px) scale(1.8);
   transform-origin: bottom center;
   background-image: url("/assets/TonPlayGramLogo.jpg");
-  background-size: contain;
+  background-size: cover;
   background-repeat: no-repeat;
   background-position: center;
-  z-index: 5;
+  pointer-events: none;
+  z-index: -1;
 }
 
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -268,6 +268,7 @@ function Board({
         }}
       >
         <div className="snake-board-tilt">
+          <div className="logo-wall-main" />
           <div
             className="snake-board-grid grid gap-1 relative mx-auto"
             style={{
@@ -311,9 +312,8 @@ function Board({
                   type={highlight && highlight.cell === FINAL_TILE ? highlight.type : tokenType}
                 />
               )}
-              {celebrate && <CoinBurst token={token} />}
-            </div>
-            <div className="logo-wall-main" />
+            {celebrate && <CoinBurst token={token} />}
+          </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- tilt the background logo to match the board
- expand the snake board background to cover the full viewport
- move the background element outside the grid so it's positioned correctly

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68564666c2d083298ed744072feced57