### PR TITLE
Update snake board colors

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -118,7 +118,9 @@ body {
 }
 
 .board-cell {
-  @apply relative flex items-center justify-center rounded-xl text-text bg-surface border-2 border-accent;
+  @apply relative flex items-center justify-center rounded-xl text-text;
+  background-color: var(--tile-bg, #0e3b45);
+  border: 2px solid #d1a75f;
   /* Removed dark drop shadow that created a black frame around dice */
   box-shadow: none;
   transform: translateZ(5px);
@@ -133,7 +135,7 @@ body {
   position: absolute;
   inset: 2px;
   border-radius: inherit;
-  box-shadow: 0 0 8px rgba(250, 204, 21, 0.5);
+  box-shadow: 0 0 8px rgba(209, 167, 95, 0.5);
   transform: translateZ(-1px);
 }
 
@@ -448,6 +450,8 @@ body {
 .cell-number {
   position: relative;
   z-index: 1;
+  color: #ffffff;
+  text-shadow: 0 1px 0 #cdd5d6;
 }
 
 .board-cell.snake-cell .cell-number,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -90,6 +90,16 @@ function Board({
     // subsequent row alternates direction. Tile 1 is at the bottom-left and
     // tile 100 ends up at the top-right.
     const reversed = r % 2 === 1;
+    const colorIdx = Math.floor(r / (ROWS / 5));
+    const TILE_COLORS = [
+      "#6db0ad",
+      "#4a828e",
+      "#3d7078",
+      "#2d5c66",
+      "#0e3b45",
+    ];
+    const rowColor = TILE_COLORS[colorIdx] || "#0e3b45";
+
     for (let c = 0; c < COLS; c++) {
       const col = c;
       const num = reversed ? (r + 1) * COLS - c : r * COLS + c + 1;
@@ -112,17 +122,20 @@ function Board({
           : cellType === "snake"
           ? snakeOffsets[num]
           : null;
+      const style = {
+        gridRowStart: ROWS - r,
+        gridColumnStart: col + 1,
+        transform: `translate(${translateX}px, ${translateY}px) scale(${scale}) translateZ(5px)`,
+        transformOrigin: 'bottom center',
+      };
+      if (!highlightClass) style.backgroundColor = rowColor;
+
       tiles.push(
         <div
           key={num}
           data-cell={num}
           className={`board-cell ${cellClass} ${highlightClass}`}
-          style={{
-            gridRowStart: ROWS - r,
-            gridColumnStart: col + 1,
-            transform: `translate(${translateX}px, ${translateY}px) scale(${scale}) translateZ(5px)`,
-            transformOrigin: 'bottom center',
-          }}
+          style={style}
         >
           {(icon || offsetVal != null) && (
             <span className="cell-marker">


### PR DESCRIPTION
## Summary
- change snake board tile and border colors
- add text shadow for cell numbers

## Testing
- `npm test` *(fails: manifest and lobby routes not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685649d63c2c8329a1ce8d0d09678d9a