### PR TITLE
Add angled gradient under snake board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -64,6 +64,28 @@ body {
   transition: transform 0.3s ease; /* ✅ scaling transition */
 }
 
+.snake-gradient-bg {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%) translateZ(-1px);
+  transform-origin: bottom center;
+  width: var(--board-width);
+  height: 150vh;
+  pointer-events: none;
+  z-index: 0;
+  background: linear-gradient(
+    to right,
+    #123840,
+    #1f4d58 20%,
+    #d9cec2 40%,
+    #f3f0e8 50%,
+    #b95741 60%,
+    #e7b382 80%,
+    #f3d3b0
+  );
+}
+
 @keyframes roll {
   0% {
     transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg) translateY(0);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -291,6 +291,7 @@ function Board({
               transform: `translateX(${boardXOffset}px) rotateX(${angle}deg)`,
             }}
           >
+            <div className="snake-gradient-bg" />
             {tiles}
             <div
               className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? "highlight" : ""}`}


### PR DESCRIPTION
## Summary
- create `snake-gradient-bg` style with colorful gradient
- render gradient plane in snake game board

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68565092a0488329b7473334c1bd3b7d