### PR TITLE
Fix gradient background sizing

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -66,12 +66,12 @@ body {
 
 .snake-gradient-bg {
   position: absolute;
+  top: calc(var(--cell-height) * -5.5);
   bottom: 0;
   left: 50%;
   transform: translateX(-50%) translateZ(-1px);
   transform-origin: bottom center;
   width: var(--board-width);
-  height: 150vh;
   pointer-events: none;
   z-index: 0;
   background: linear-gradient(


### PR DESCRIPTION
## Summary
- adjust gradient background to start at pot position

## Testing
- `npm test` *(fails: manifest endpoint and lobby route tests)*

------
https://chatgpt.com/codex/tasks/task_e_6856535553f483298e64701ee324e4e0