### PR TITLE
Update manifest URL examples

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -3,7 +3,7 @@ BOT_TOKEN=your-telegram-bot-token
 
 # MongoDB connection string
 # Use `memory` to run an in-memory database (for testing/dev only)
-MONGODB_URI=mongodb://localhost:27017/tonplaygram
+MONGODB_URI=memory
 
 # API port (defaults to 3000 if not set)
 PORT=3000
@@ -12,4 +12,4 @@ PORT=3000
 # AIRDROP_ADMIN_TOKENS=token1,token2
 
 # TonConnect settings
-TONCONNECT_MANIFEST_URL=https://tonplaygramwebapp.onrender.com/tonconnect-manifest.json
+TONCONNECT_MANIFEST_URL=https://tonplaygram-bot.onrender.com/tonconnect-manifest.json

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -2,4 +2,4 @@ VITE_API_BASE_URL=http://localhost:3000
 # Set an absolute URL for the TonConnect manifest when the frontend is
 # hosted separately from the API. The manifest should be served by the
 # backend so Tonkeeper can retrieve it.
-VITE_TONCONNECT_MANIFEST=https://tonplaygramwebapp.onrender.com/tonconnect-manifest.json
+VITE_TONCONNECT_MANIFEST=https://tonplaygram-bot.onrender.com/tonconnect-manifest.json


### PR DESCRIPTION
## Summary
- keep env example manifest URLs consistent
- default to in-memory MongoDB in bot example

## Testing
- `npm --prefix webapp run build`
- `npm test`
- `npm start` *(fails: Conflict from Telegram API)*

------
https://chatgpt.com/codex/tasks/task_e_685653a91b508329bad12ed7a69d7960