### PR TITLE
Fix board background scale and token hex orientation

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -668,7 +668,8 @@ body {
   top: 50%;
   pointer-events: none;
   /* Align with the token photo but sit just underneath */
-  transform: translate(-50%, -50%) translateZ(14.2px);
+  transform: translate(-50%, -50%) translateZ(14.2px)
+    rotateX(calc(var(--board-angle, 60deg) * -1 - 10deg));
   animation: hex-spin 6s linear infinite;
   z-index: 0;
 }
@@ -690,10 +691,12 @@ body {
 
 @keyframes hex-spin {
   from {
-    transform: translate(-50%, -50%) translateZ(14.2px) rotateY(0deg);
+    transform: translate(-50%, -50%) translateZ(14.2px)
+      rotateX(calc(var(--board-angle, 60deg) * -1 - 10deg)) rotateY(0deg);
   }
   to {
-    transform: translate(-50%, -50%) translateZ(14.2px) rotateY(360deg);
+    transform: translate(-50%, -50%) translateZ(14.2px)
+      rotateX(calc(var(--board-angle, 60deg) * -1 - 10deg)) rotateY(360deg);
   }
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -68,7 +68,7 @@ function Board({
   const centerCol = (COLS - 1) / 2;
   // Keep vertical columns evenly spaced rather than widening
   const widenStep = 0; // how much each row expands horizontally
-  const scaleStep = 0.02; // how much each row's cells scale
+  const scaleStep = 0; // disable row scaling so top width matches bottom
   const finalScale = 1 + (ROWS - 3) * scaleStep;
 
   // Precompute vertical offsets so that the gap between rows


### PR DESCRIPTION
## Summary
- remove row scaling so board background is uniform
- tilt hexagonal token layer to match board angle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685658f6964c832983d83fca365c0767