### PR TITLE
Improve wallet docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
    - `MONGODB_URI` – MongoDB connection string or `memory`
    - `AIRDROP_ADMIN_TOKENS` – (optional) tokens allowed to trigger airdrops
    - `TONCONNECT_MANIFEST_URL` – public URL to your TonConnect manifest
+   - `DEPOSIT_WALLET_ADDRESS` – TON address that receives user deposits
    - `PORT` – (optional) port for the bot API server (defaults to 3000)
 
 4. Copy `webapp/.env.example` to `webapp/.env` and configure:
@@ -69,6 +70,17 @@ HTTPS and should match your API's base domain. You can open the manifest in a
 browser to confirm it returns JSON. If your server sits behind a proxy, ensure
 the proxy forwards the `x-forwarded-proto` header so the manifest reports the
 correct `https://` URL.
+
+### Wallet overview
+
+This app exposes two separate wallets:
+
+- **TPC Wallet** – an off-chain balance stored in MongoDB. Commands like
+  `/wallet balance` and `/wallet send` interact with this database record.
+- **Tonkeeper Wallet** – an on-chain TON account connected through TonConnect.
+  Deposits sent to `DEPOSIT_WALLET_ADDRESS` credit the TPC balance after the
+  transfer is detected. Withdrawals deduct TPC and would transfer TON to the
+  provided address in a full implementation.
 
 ### Common issues
 

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -13,3 +13,8 @@ PORT=3000
 
 # TonConnect settings
 TONCONNECT_MANIFEST_URL=https://tonplaygram-bot.onrender.com/tonconnect-manifest.json
+
+# TON deposit address that users will send funds to when topping up their
+# off-chain TPC balance
+# Example: EQCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+DEPOSIT_WALLET_ADDRESS=


### PR DESCRIPTION
## Summary
- document deposit wallet address in bot example env
- explain TPC wallet vs Tonkeeper connection in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685659c60fe883299a08a325f7b35682