### PR TITLE
Apply SnakeLadder gradient to home page

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -6,6 +6,7 @@ import Branding from "./Branding.jsx";
 
 export default function Layout({ children }) {
   const location = useLocation();
+  const isHome = location.pathname === '/';
   const showBranding = !location.pathname.startsWith('/games');
   const showNavbar = !(
     location.pathname.startsWith('/games/') &&
@@ -13,7 +14,11 @@ export default function Layout({ children }) {
   );
 
   return (
-    <div className="flex flex-col min-h-screen bg-background text-text relative">
+    <div
+      className={`flex flex-col min-h-screen text-text relative ${
+        isHome ? 'snake-gradient-page' : 'bg-background'
+      }`}
+    >
       <main className={`flex-grow container mx-auto p-4 ${showNavbar ? 'pb-24' : ''}`.trim()}>
         {showBranding && <Branding />}
         {children}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -86,6 +86,20 @@ body {
   );
 }
 
+.snake-gradient-page {
+  min-height: 100%;
+  background: linear-gradient(
+    to bottom,
+    #123840,
+    #1f4d58 20%,
+    #d9cec2 40%,
+    #f3f0e8 50%,
+    #b95741 60%,
+    #e7b382 80%,
+    #f3d3b0
+  );
+}
+
 @keyframes roll {
   0% {
     transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg) translateY(0);


### PR DESCRIPTION
## Summary
- add full page gradient style matching Snake & Ladder board
- use gradient on home page via Layout component

## Testing
- `npm test` *(fails: 2 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_685664cd99d083298dc6d8d759f349d5