### PR TITLE
Fix Snake and Ladder board orientation

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -69,21 +69,21 @@ function Board({
   // Keep vertical columns evenly spaced rather than widening
   const widenStep = 0; // how much each row expands horizontally
   const scaleStep = 0.02; // how much each row's cells scale
-  // Invert the perspective so the bottom rows appear larger
-  const finalScale = 1 - (ROWS - 3) * scaleStep;
+  // Reverse perspective so the top rows appear larger
+  const finalScale = 1 + (ROWS - 3) * scaleStep;
 
   // Precompute vertical offsets so that the gap between rows
   // stays uniform even as cells are scaled differently per row.
   const rowOffsets = [0];
   for (let r = 1; r < ROWS; r++) {
-    const prevScale = 1 + (2 - (r - 1)) * scaleStep;
+    const prevScale = 1 + ((r - 1) - 2) * scaleStep;
     rowOffsets[r] = rowOffsets[r - 1] + (prevScale - 1) * cellHeight;
   }
   const offsetYMax = rowOffsets[ROWS - 1];
 
   for (let r = 0; r < ROWS; r++) {
-    // Reversed perspective so earlier rows are scaled larger
-    const rowFactor = 2 - r;
+    // Reverse perspective so later rows are scaled larger
+    const rowFactor = r - 2;
     const scale = 1 + rowFactor * scaleStep;
     // Include the scaled cell width so horizontal gaps remain consistent
     const offsetX = rowFactor * widenStep * cellWidth + (scale - 1) * cellWidth;


### PR DESCRIPTION
## Summary
- reverse the board perspective so the top rows appear larger

## Testing
- `npm test` *(fails: Cannot find package 'dotenv', lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68566746113883299a1582d402b12dfd