### PR TITLE
Add gradient background to homepage

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -13,7 +13,7 @@ export default function Layout({ children }) {
   );
 
   return (
-    <div className="flex flex-col min-h-screen bg-background text-text relative">
+    <div className="flex flex-col min-h-screen text-text relative">
       <main className={`flex-grow container mx-auto p-4 ${showNavbar ? 'pb-24' : ''}`.trim()}>
         {showBranding && <Branding />}
         {children}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -10,7 +10,17 @@
 
 body {
   font-family: Arial, Helvetica, sans-serif;
-  @apply bg-background text-text overflow-x-hidden;
+  background: linear-gradient(
+    to right,
+    #123840,
+    #1f4d58 20%,
+    #d9cec2 40%,
+    #f3f0e8 50%,
+    #b95741 60%,
+    #e7b382 80%,
+    #f3d3b0
+  );
+  @apply text-text overflow-x-hidden;
 }
 
 .hexagon {


### PR DESCRIPTION
## Summary
- remove solid background from Layout to allow gradient
- add left-to-right gradient for the entire page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856690cfd348329bd983c99a733eadd