### PR TITLE
Fix snake board background height

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -270,7 +270,7 @@ function Board({
         className="overflow-y-auto"
         style={{
           overflowX: 'hidden',
-          height: "80vh",
+          height: "100vh",
           overscrollBehaviorY: "contain",
           paddingTop,
         }}


### PR DESCRIPTION
## Summary
- make snake board container full height so the background extends from tile 101 downward

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68566f944e548329a7750fa83d8dcb13