### PR TITLE
Add home screen gradient background

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -11,9 +11,12 @@ export default function Layout({ children }) {
     location.pathname.startsWith('/games/') &&
     !location.pathname.includes('/lobby')
   );
+  const isHome = location.pathname === '/';
 
   return (
-    <div className="flex flex-col min-h-screen bg-background text-text relative">
+    <div
+      className={`flex flex-col min-h-screen text-text relative ${isHome ? 'home-bg' : 'bg-background'}`}
+    >
       <main className={`flex-grow container mx-auto p-4 ${showNavbar ? 'pb-24' : ''}`.trim()}>
         {showBranding && <Branding />}
         {children}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -39,6 +39,24 @@ body {
   background-size: 50px 50px;
 }
 
+.home-bg {
+  /* Mobile home screen gradient background */
+  background-color: #0c1020;
+  background-image:
+    radial-gradient(circle at center,
+      rgba(249, 179, 45, 0.15),
+      rgba(17, 23, 42, 0.8) 40%,
+      #0c1020 80%),
+    linear-gradient(to bottom,
+      rgba(0, 0, 0, 0.6),
+      rgba(0, 0, 0, 0) 30%,
+      rgba(0, 0, 0, 0) 70%,
+      rgba(0, 0, 0, 0.6));
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
+}
+
 .board-3d {
   perspective: 800px;
 }


### PR DESCRIPTION
## Summary
- remove `mobile_bg.png` asset
- implement a gradient `.home-bg` style for the home screen

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68567617c550832993d28f6cbcca8fa3