### PR TITLE
Add gradient background for home page

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -6,6 +6,7 @@ import Branding from "./Branding.jsx";
 
 export default function Layout({ children }) {
   const location = useLocation();
+  const isHome = location.pathname === '/';
   const showBranding = !location.pathname.startsWith('/games');
   const showNavbar = !(
     location.pathname.startsWith('/games/') &&
@@ -13,7 +14,7 @@ export default function Layout({ children }) {
   );
 
   return (
-    <div className="flex flex-col min-h-screen bg-background text-text relative">
+    <div className={`flex flex-col min-h-screen ${isHome ? 'home-gradient-bg' : 'bg-background'} text-text relative`}>
       <main className={`flex-grow container mx-auto p-4 ${showNavbar ? 'pb-24' : ''}`.trim()}>
         {showBranding && <Branding />}
         {children}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -39,6 +39,15 @@ body {
   background-size: 50px 50px;
 }
 
+/* Gradient background for the Home page */
+.home-gradient-bg {
+  background-image:
+    radial-gradient(circle at center, rgba(249, 179, 45, 0.2) 0%, rgba(249, 179, 45, 0) 60%),
+    linear-gradient(to bottom, #0c1020 0%, #11172a 80%, #0c1020 100%);
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
 .board-3d {
   perspective: 800px;
 }


### PR DESCRIPTION
## Summary
- create `home-gradient-bg` style with a gold radial glow
- detect home page path in `Layout` and apply gradient background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685680892330832982f99552b17c0aec