### PR TITLE
Fix snake board perspective

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -87,7 +87,7 @@ body {
   pointer-events: none;
   z-index: 0;
   background: linear-gradient(
-    to right,
+    to top,
     #123840,
     #1f4d58 20%,
     #d9cec2 40%,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -69,21 +69,21 @@ function Board({
   // Keep vertical columns evenly spaced rather than widening
   const widenStep = 0; // how much each row expands horizontally
   const scaleStep = 0.02; // how much each row's cells scale
-  // Invert the perspective so the bottom rows appear larger
-  const finalScale = 1 - (ROWS - 3) * scaleStep;
+  // Perspective with smaller cells at the bottom growing larger towards the pot
+  const finalScale = 1 + (ROWS - 3) * scaleStep;
 
   // Precompute vertical offsets so that the gap between rows
   // stays uniform even as cells are scaled differently per row.
   const rowOffsets = [0];
   for (let r = 1; r < ROWS; r++) {
-    const prevScale = 1 + (2 - (r - 1)) * scaleStep;
+    const prevScale = 1 + (r - 3) * scaleStep;
     rowOffsets[r] = rowOffsets[r - 1] + (prevScale - 1) * cellHeight;
   }
   const offsetYMax = rowOffsets[ROWS - 1];
 
   for (let r = 0; r < ROWS; r++) {
-    // Reversed perspective so earlier rows are scaled larger
-    const rowFactor = 2 - r;
+    // Rows grow larger towards the top of the board
+    const rowFactor = r - 2;
     const scale = 1 + rowFactor * scaleStep;
     // Include the scaled cell width so horizontal gaps remain consistent
     const offsetX = rowFactor * widenStep * cellWidth + (scale - 1) * cellWidth;


### PR DESCRIPTION
## Summary
- scale cells smaller at the bottom and larger toward the pot
- orient the snake board background gradient vertically

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685682ed245c83299639bc83ed5b7fd9