### PR TITLE
Fix token hexagon alignment

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -680,9 +680,11 @@ body {
   top: 50%;
   pointer-events: none;
   /* Align with the token photo but sit just underneath */
-  transform: translate(-50%, -50%) translateZ(14.2px);
+  transform: translate(-50%, -50%)
+    translateZ(14.2px)
+    rotateX(calc(var(--board-angle, 60deg) * -1));
   animation: hex-spin 6s linear infinite;
-  z-index: 0;
+  z-index: 1;
 }
 
 .token-hexagon.step {


### PR DESCRIPTION
## Summary
- align token hexagon with board angle
- increase z-index so hexagon remains visible under token

## Testing
- `npm test` *(fails: 2 failed, 12 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685680ff18a08329b10e3e10a22ee660