### PR TITLE
Rotate snake board gradient to right

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -75,15 +75,14 @@ body {
 
 .snake-gradient-bg {
   position: absolute;
-  /* move the gradient lower so it anchors near the bottom */
-  top: calc(var(--cell-height) * -2);
-  bottom: 0;
+  /* rotate the backdrop 90deg so it runs from top to bottom */
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%) translateZ(-1px);
-  transform-origin: bottom center;
-  /* slightly expand the backdrop and widen its top edge */
-  width: calc(var(--board-width) * 1.2);
-  /* flip orientation so the base is narrower than the top */
+  width: calc(var(--board-height) * 1.2);
+  height: calc(var(--board-width) * 1.2);
+  transform: translate(-50%, -50%) rotate(90deg) translateZ(-1px);
+  transform-origin: center;
+  /* keep the same wedge shape with the base narrower than the top */
   clip-path: polygon(0 0, 100% 0, 110% 100%, -10% 100%);
   pointer-events: none;
   z-index: 0;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -286,6 +286,7 @@ function Board({
               "--cell-width": `${cellWidth}px`,
               "--cell-height": `${cellHeight}px`,
               "--board-width": `${cellWidth * COLS}px`,
+              "--board-height": `${cellHeight * ROWS + offsetYMax}px`,
               "--board-angle": `${angle}deg`,
               "--final-scale": finalScale,
               // Fixed camera angle with no zooming


### PR DESCRIPTION
## Summary
- add `--board-height` CSS variable for board size
- rotate snake board gradient 90deg to the right and center it

## Testing
- `npm test --silent` *(fails: manifest and lobby routes not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68568b5817cc83299713ea5c31b6a5ba