### PR TITLE
Adjust hexagon token base tilt

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -683,7 +683,7 @@ body {
   /* Align with the token photo but sit just underneath */
   transform: translate(-50%, -50%)
     translateZ(14.2px)
-    rotateX(calc(var(--board-angle, 60deg) * -1));
+    rotateX(-45deg);
   animation: hex-spin 6s linear infinite;
   z-index: 1;
 }


### PR DESCRIPTION
## Summary
- reduce board tilt of token hexagon to a fixed 45° layback

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68568c2d4ba4832989f5447518b7f444