### PR TITLE
Adjust snake board gradient shape

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -82,8 +82,8 @@ body {
   height: calc(var(--board-width) * 1.2);
   transform: translate(-50%, -50%) rotate(90deg) translateZ(-1px);
   transform-origin: center;
-  /* keep the same wedge shape with the base narrower than the top */
-  clip-path: polygon(0 0, 100% 0, 110% 100%, -10% 100%);
+  /* widen towards the pot and narrow near the first row */
+  clip-path: polygon(-10% 0, 110% 0, 90% 100%, 10% 100%);
   pointer-events: none;
   z-index: 0;
   background: linear-gradient(


### PR DESCRIPTION
## Summary
- update the board background wedge to widen near the pot and narrow at the first row

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_685691e43ca48329ae2d614552ab0c5a