### PR TITLE
Adjust board background clip-path

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -85,7 +85,8 @@ body {
   transform: translate(-50%, -60%) rotate(90deg) translateZ(-1px);
   transform-origin: center;
   /* widen the top of the backdrop while keeping the bottom unchanged */
-  clip-path: polygon(-30% 0, 130% 0, 110% 100%, -10% 100%);
+  /* narrow the bottom of the backdrop so it fits the board */
+  clip-path: polygon(-30% 0, 130% 0, 100% 100%, 0% 100%);
   pointer-events: none;
   z-index: 0;
   background: linear-gradient(


### PR DESCRIPTION
## Summary
- tweak the gradient clip path so the bottom is narrower and fits the board

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6856ab212e2c83298dfda65c3d6a0fcb