### PR TITLE
Update board gradient bottom

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -86,7 +86,8 @@ body {
   transform-origin: center;
   /* widen the top of the backdrop while keeping the bottom unchanged */
   /* narrow the bottom of the backdrop so it fits the board */
-  clip-path: polygon(-30% 0, 130% 0, 100% 100%, 0% 100%);
+  /* Keep the same wide top but taper the bottom more */
+  clip-path: polygon(-30% 0, 130% 0, 70% 100%, 30% 100%);
   pointer-events: none;
   z-index: 0;
   background: linear-gradient(


### PR DESCRIPTION
## Summary
- make the snake board's background taper more at the bottom to fit the board

## Testing
- `npm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6856aca291108329a297e32662e0b69f