### PR TITLE
Adjust board background width

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -86,7 +86,8 @@ body {
   transform-origin: center;
   /* widen the top of the backdrop while keeping the bottom unchanged */
   /* narrow the bottom of the backdrop so it fits the board */
-  clip-path: polygon(-50% 0, 150% 0, 100% 100%, 0% 100%);
+  /* widen the top a bit more so the background fills the screen */
+  clip-path: polygon(-75% 0, 175% 0, 100% 100%, 0% 100%);
   pointer-events: none;
   z-index: 0;
   background: linear-gradient(


### PR DESCRIPTION
## Summary
- expand snake board background at the top so it fills the screen

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6856b1504b50832983466d931f013399