### PR TITLE
Adjust top of Snake & Ladder backdrop

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -87,7 +87,8 @@ body {
   /* widen the top of the backdrop while keeping the bottom unchanged */
   /* narrow the bottom of the backdrop so it fits the board */
   /* widen the top a bit more so the background fills the screen */
-  clip-path: polygon(-75% 0, 175% 0, 100% 100%, 0% 100%);
+  /* widen the top even more so the backdrop fills the screen */
+  clip-path: polygon(-100% 0, 200% 0, 100% 100%, 0% 100%);
   pointer-events: none;
   z-index: 0;
   background: linear-gradient(


### PR DESCRIPTION
## Summary
- keep bottom of board unchanged and widen the top so the gradient fills the screen

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6856b2dce77c8329b7054f57cbcd15de