### PR TITLE
Adjust board background bottom

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -88,7 +88,8 @@ body {
   /* narrow the bottom of the backdrop so it fits the board */
   /* widen the top a bit more so the background fills the screen */
   /* widen the top even more so the backdrop fills the screen */
-  clip-path: polygon(-100% 0, 200% 0, 100% 100%, 0% 100%);
+  /* taper the bottom so the backdrop fits within the board */
+  clip-path: polygon(-100% 0, 200% 0, 70% 100%, 30% 100%);
   pointer-events: none;
   z-index: 0;
   background: linear-gradient(


### PR DESCRIPTION
## Summary
- taper the bottom of the Snake & Ladder backdrop so it fits within the board

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6856b5253b808329a3345aad489acc93