### PR TITLE
Adjust board background width

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -88,7 +88,8 @@ body {
   /* narrow the bottom of the backdrop so it fits the board */
   /* widen the top a bit more so the background fills the screen */
   /* widen the top even more so the backdrop fills the screen */
-  clip-path: polygon(-100% 0, 200% 0, 100% 100%, 0% 100%);
+  /* widen the top further so the background spans the full screen */
+  clip-path: polygon(-150% 0, 250% 0, 100% 100%, 0% 100%);
   pointer-events: none;
   z-index: 0;
   background: linear-gradient(


### PR DESCRIPTION
## Summary
- widen the clip-path for the snake and ladder board gradient so the top fills the screen

## Testing
- `npm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6856b79ba6388329bd0064e23740d42c