### PR TITLE
Add white hexagonal prism frame to home profile photo

### DIFF
--- a/webapp/public/assets/hex_prism_white.svg
+++ b/webapp/public/assets/hex_prism_white.svg
@@ -1,0 +1,10 @@
+<svg width="200" height="220" viewBox="0 0 220 220" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="110,20 160,50 160,110 110,140 60,110 60,50" fill="#ffffff" stroke="#ffffff" stroke-width="2"/>
+  <polygon points="110,80 160,110 160,170 110,200 60,170 60,110" fill="#e5e5e5" stroke="#d0d0d0" stroke-width="2"/>
+  <line x1="110" y1="20" x2="110" y2="80" stroke="#d0d0d0" stroke-width="2"/>
+  <line x1="160" y1="50" x2="160" y2="110" stroke="#d0d0d0" stroke-width="2"/>
+  <line x1="160" y1="110" x2="160" y2="170" stroke="#d0d0d0" stroke-width="2"/>
+  <line x1="110" y1="140" x2="110" y2="200" stroke="#d0d0d0" stroke-width="2"/>
+  <line x1="60" y1="110" x2="60" y2="170" stroke="#d0d0d0" stroke-width="2"/>
+  <line x1="60" y1="50" x2="60" y2="110" stroke="#d0d0d0" stroke-width="2"/>
+</svg>

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -66,17 +66,18 @@ export default function Home() {
       <div className="flex flex-col items-center">
 
         {photoUrl && (
-
-          <img
-
-            src={photoUrl}
-
-            alt="profile"
-
-            className="w-36 h-36 hexagon border-4 border-brand-gold -mt-[20%] mb-3 object-cover"
-
-          />
-
+          <div className="relative w-36 h-36 -mt-[20%] mb-3">
+            <img
+              src={photoUrl}
+              alt="profile"
+              className="hexagon w-full h-full object-cover"
+            />
+            <img
+              src="/assets/hex_prism_white.svg"
+              alt="hex frame"
+              className="absolute inset-0 w-full h-full pointer-events-none"
+            />
+          </div>
         )}
 
         <div className="mb-2">


### PR DESCRIPTION
## Summary
- add new white hex prism SVG asset
- show profile photo inside hexagon with 3D-looking frame on home page

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6856b814055c83298e97b41a55a84bed