### PR TITLE
Fix snake board background clipping

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -90,7 +90,7 @@ body {
   /* widen the top even more so the backdrop fills the screen */
   /* widen the top further so the background spans the full screen */
   /* Slightly widen the top so the backdrop fills the screen */
-  clip-path: polygon(-100% 0%, 200% 0%, 85% 100%, 15% 100%);
+  clip-path: polygon(-500% 0%, 600% 0%, 92% 100%, 8% 100%);
   pointer-events: none;
   z-index: 0;
   background: linear-gradient(


### PR DESCRIPTION
## Summary
- tweak CSS clip-path for the Snake & Ladder board background

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6856dacd9a8c8329a816842518b688a1