### PR TITLE
Adjust snake board background width

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -91,7 +91,8 @@ body {
   /* widen the top further so the background spans the full screen */
   /* Slightly widen the top so the backdrop fills the screen */
   /* Expand the bottom of the backdrop so it extends beyond the board */
-  clip-path: polygon(0% 0%, 100% 0%, 150% 100%, -50% 100%);
+  /* Make the right side wider and the left side narrower */
+  clip-path: polygon(0% 0%, 100% 0%, 180% 100%, -20% 100%);
   pointer-events: none;
   z-index: 0;
   background: linear-gradient(


### PR DESCRIPTION
## Summary
- widen the right side of the snake board backdrop while narrowing the left

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6856e4048ad48329a46598551db57caa