### PR TITLE
Adjust snake board background

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -91,8 +91,8 @@ body {
   /* widen the top further so the background spans the full screen */
   /* Slightly widen the top so the backdrop fills the screen */
   /* Expand the bottom of the backdrop so it extends beyond the board */
-  /* Make the right side wider and the left side narrower */
-  clip-path: polygon(0% 0%, 100% 0%, 180% 100%, -20% 100%);
+  /* Make the right side a lot wider and the left side much narrower */
+  clip-path: polygon(0% 0%, 100% 0%, 220% 100%, -60% 100%);
   pointer-events: none;
   z-index: 0;
   background: linear-gradient(


### PR DESCRIPTION
## Summary
- make the Snake & Ladder board background asymmetrical so the right is wider than the left

## Testing
- `npm test` *(fails: manifest endpoint & lobby route unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6856e601dc688329bf56a99e9f7ec669