### PR TITLE
Extend board display

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -290,7 +290,7 @@ function Board({
               "--board-angle": `${angle}deg`,
               "--final-scale": finalScale,
               // Fixed camera angle with no zooming
-              transform: `translateX(${boardXOffset}px) rotateX(${angle}deg)`,
+              transform: `translateX(${boardXOffset}px) rotateX(${angle}deg) scale(1.03)`,
             }}
           >
             <div className="snake-gradient-bg" />


### PR DESCRIPTION
## Summary
- enlarge Snakes & Ladders board by scaling it by 3%

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6856edcf61f88329b98576c6ad8bc382