### PR TITLE
Enlarge Snake & Ladder board

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -250,7 +250,8 @@ function Board({
               "--board-angle": `${angle}deg`,
               "--final-scale": finalScale,
               // Fixed camera angle with no zooming
-              transform: `translateX(${boardXOffset}px) rotateX(${angle}deg) scale(1.03)`,
+              // Slightly enlarge the board in both directions
+              transform: `translateX(${boardXOffset}px) rotateX(${angle}deg) scale(1.05)`,
             }}
           >
             <div className="snake-gradient-bg" />


### PR DESCRIPTION
## Summary
- enlarge Snake & Ladder board by scaling 5%
- keep board locked while allowing manual scrolling

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6856f386781c83298cdfde33cf7f7eb1