### PR TITLE
Add box shadows for snake board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -164,8 +164,8 @@ body {
   @apply relative flex items-center justify-center rounded-xl text-text;
   background-color: var(--tile-bg, #0e3b45);
   border: 2px solid #d1a75f;
-  /* Removed dark drop shadow that created a black frame around dice */
-  box-shadow: none;
+  /* Cast a soft shadow so tiles stand out at the board's angle */
+  box-shadow: 0 8px 12px rgba(0, 0, 0, 0.4);
   transform: translateZ(5px);
   transform-style: preserve-3d;
   overflow: visible;


### PR DESCRIPTION
## Summary
- add subtle drop shadow to board tiles so their shadows match the board's angle

## Testing
- `npm test` *(fails: manifest and lobby routes unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6856faea89ac8329b7a6be456fd2e253