### PR TITLE
Fix board shading in Snake and Ladder

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -179,7 +179,8 @@ body {
   inset: 2px;
   border-radius: inherit;
   box-shadow: 0 0 8px rgba(209, 167, 95, 0.5);
-  transform: translateZ(-1px);
+  /* Place the highlight above the tile so the shading is visible */
+  transform: translateZ(6px);
 }
 
 .token {


### PR DESCRIPTION
## Summary
- make the board cell highlight visible by translating it above the tile

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6856fdc213ac8329b684f493ac758779