### PR TITLE
Enhance snake board visuals

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -9,6 +9,7 @@
     <link rel="preload" as="audio" href="/assets/sounds/successful.mp3" />
     <link rel="preload" as="audio" href="https://snakes-and-ladders-game.netlify.app/audio/dice.mp3" />
     <link rel="preload" as="audio" href="https://snakes-and-ladders-game.netlify.app/audio/drop.mp3" />
+    <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@700&display=swap" rel="stylesheet" />
 
     <title>TonPlaygram</title>
   </head>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -164,9 +164,9 @@ body {
   @apply relative flex items-center justify-center rounded-xl text-text;
   background-color: var(--tile-bg, #0e3b45);
   border: 2px solid #d1a75f;
-  /* Cast a shadow dark enough for a stronger 3D effect */
-  box-shadow: 0 8px 12px rgba(0, 0, 0, 0.6);
-  transform: translateZ(5px);
+  /* Deeper shadow for a stronger 3D button look */
+  box-shadow: 0 8px 12px rgba(0, 0, 0, 0.7);
+  transform: translateZ(8px);
   transform-style: preserve-3d;
   overflow: visible;
   width: var(--cell-width);
@@ -179,9 +179,9 @@ body {
   inset: 2px;
   border-radius: inherit;
   /* Darker inner glow to emphasise depth */
-  box-shadow: 0 0 8px rgba(209, 167, 95, 0.8);
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.6);
   /* Place the highlight above the tile so the shading is visible */
-  transform: translateZ(6px);
+  transform: translateZ(9px);
 }
 
 .token {
@@ -496,9 +496,11 @@ body {
   position: relative;
   z-index: 1;
   color: #ffffff;
-  font-family: "Comic Sans MS", "Comic Sans", cursive;
-  font-weight: bold;
-  text-shadow: 0 1px 0 #cdd5d6;
+  font-family: "Baloo 2", "Comic Sans MS", "Comic Sans", cursive;
+  font-weight: 700;
+  text-shadow: 0 1px 0 #000;
+  -webkit-text-stroke: 1px #000000;
+  transform: translateZ(10px);
 }
 
 .board-cell.snake-cell .cell-number,


### PR DESCRIPTION
## Summary
- make snake-and-ladder tiles appear higher with darker inset shadow
- darken tile highlight to emphasize 3D depth
- style tile numbers in Baloo 2 with black stroke
- load Baloo 2 font in the app

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_6857042fbd508329b660abe457e51218