### PR TITLE
Implement V-shape scaling for snake board

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -65,24 +65,24 @@ function Board({
   const [cellHeight, setCellHeight] = useState(40);
   const tiles = [];
   const centerCol = (COLS - 1) / 2;
-  // Keep vertical columns evenly spaced rather than widening
-  const widenStep = 0; // how much each row expands horizontally
-  const scaleStep = 0.02; // how much each row's cells scale
+  // Gradually widen each row so the board forms a "V" shape
+  const widenStep = 0.2; // how much each row expands horizontally
+  const scaleStep = 0.05; // how much each row's cells scale
   // Perspective with smaller cells at the bottom growing larger towards the pot
-  const finalScale = 1 + (ROWS - 3) * scaleStep;
+  const finalScale = 1 + (ROWS - 1) * scaleStep;
 
   // Precompute vertical offsets so that the gap between rows
   // stays uniform even as cells are scaled differently per row.
   const rowOffsets = [0];
   for (let r = 1; r < ROWS; r++) {
-    const prevScale = 1 + (r - 3) * scaleStep;
+    const prevScale = 1 + (r - 1) * scaleStep;
     rowOffsets[r] = rowOffsets[r - 1] + (prevScale - 1) * cellHeight;
   }
   const offsetYMax = rowOffsets[ROWS - 1];
 
   for (let r = 0; r < ROWS; r++) {
     // Rows grow larger towards the top of the board
-    const rowFactor = r - 2;
+    const rowFactor = r;
     const scale = 1 + rowFactor * scaleStep;
     // Include the scaled cell width so horizontal gaps remain consistent
     const offsetX = rowFactor * widenStep * cellWidth + (scale - 1) * cellWidth;


### PR DESCRIPTION
## Summary
- gradually expand board rows toward the top so it forms a V

## Testing
- `npm test` *(fails: server manifest & snake lobby route tests)*

------
https://chatgpt.com/codex/tasks/task_e_68570f75154c832990e978191d5406fa