### PR TITLE
Adjust camera angle on snake board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -64,7 +64,8 @@ body {
 
 /* Tilted view specifically for the Snake & Ladder board */
 .snake-board-tilt {
-  perspective: 1200px;
+  /* Move the camera slightly closer */
+  perspective: 1000px;
 }
 
 .snake-board-grid {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -207,7 +207,8 @@ function Board({
   // displayed only once within the cell itself.
   // Fixed board angle with no zoom
   // Lowered camera angle so the logo touches the top of the screen
-  const angle = 60;
+  // Tilt the board a bit more so the camera looks down toward the logo
+  const angle = 65;
   // Small horizontal offset so the board sits perfectly centered
   const boardXOffset = -10; // pixels
 


### PR DESCRIPTION
## Summary
- tweak board camera angle so it looks down toward the logo
- move camera closer with lower perspective value

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_68571bce01d48329ad012cd5458d0272