### PR TITLE
Implement gradual perspective scaling

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -65,27 +65,27 @@ function Board({
   const [cellHeight, setCellHeight] = useState(40);
   const tiles = [];
   const centerCol = (COLS - 1) / 2;
-  // Keep vertical columns evenly spaced rather than widening
-  const widenStep = 0; // how much each row expands horizontally
-  const scaleStep = 0.02; // how much each row's cells scale
-  // Perspective with smaller cells at the bottom growing larger towards the pot
-  const finalScale = 1 + (ROWS - 3) * scaleStep;
+  // Minimum and maximum scale for the perspective effect
+  const minScale = 0.95; // bottom row
+  const maxScale = 1.1; // top row
+  const finalScale = maxScale;
 
   // Precompute vertical offsets so that the gap between rows
   // stays uniform even as cells are scaled differently per row.
   const rowOffsets = [0];
   for (let r = 1; r < ROWS; r++) {
-    const prevScale = 1 + (r - 3) * scaleStep;
+    const prevProgress = (r - 1) / (ROWS - 1);
+    const prevScale = minScale + (maxScale - minScale) * prevProgress;
     rowOffsets[r] = rowOffsets[r - 1] + (prevScale - 1) * cellHeight;
   }
   const offsetYMax = rowOffsets[ROWS - 1];
 
   for (let r = 0; r < ROWS; r++) {
-    // Rows grow larger towards the top of the board
-    const rowFactor = r - 2;
-    const scale = 1 + rowFactor * scaleStep;
-    // Include the scaled cell width so horizontal gaps remain consistent
-    const offsetX = rowFactor * widenStep * cellWidth + (scale - 1) * cellWidth;
+    // Scale rows gradually from bottom (minScale) to top (maxScale)
+    const progress = r / (ROWS - 1);
+    const scale = minScale + (maxScale - minScale) * progress;
+    // Horizontal offset keeps columns aligned as tiles scale
+    const offsetX = (scale - 1) * cellWidth;
     // Arrange cell numbers so the bottom row starts on the left and each
     // subsequent row alternates direction. Tile 1 is at the bottom-left and
     // tile 100 ends up at the top-right.


### PR DESCRIPTION
## Summary
- adjust Snake and Ladder board to scale rows between a minimum and maximum
- compute row offsets based on new scale formula
- translate tiles with offsets to keep grid aligned

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685729698b588329902b2c8121d9efd6