### PR TITLE
Fix board starting row

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -214,9 +214,9 @@ function Board({
   const boardXOffset = -10; // pixels
 
   // How many board rows to scroll back from the starting position so
-  // the bottom row remains in view but the camera is slightly further away
-  // from the board. A value of 1 shows one additional row above the start.
-  const CAMERA_OFFSET_ROWS = 1;
+  // the bottom row remains in view. Set to 0 to begin at the very first row
+  // without shifting the camera upward.
+  const CAMERA_OFFSET_ROWS = 0;
 
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
## Summary
- start Snake & Ladder board from the very first row

## Testing
- `npm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68579d9478b08329a627939273160f86