### PR TITLE
Add side logo walls to Snake & Ladder board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -587,6 +587,34 @@ body {
   z-index: 5;
 }
 
+/* Side walls extending the top TonPlaygram logo down the board */
+.logo-wall-side {
+  @apply absolute flex items-center justify-center;
+  width: calc(var(--cell-width) * 6);
+  height: calc(var(--board-height) * 1.1);
+  top: calc(var(--cell-height) * -9.5 - var(--cell-height) * 1.8 * (var(--final-scale, 1) - 1));
+  background-image: url("/assets/TonPlayGramLogo.jpg");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  transform: rotateX(calc(var(--board-angle, 75deg) * -1)) translateZ(-40px) scale(1.8);
+  z-index: 4;
+}
+
+.logo-wall-left {
+  left: 0;
+  transform-origin: top right;
+  transform: translateX(-100%) rotateY(20deg)
+    rotateX(calc(var(--board-angle, 75deg) * -1)) translateZ(-40px) scale(1.8);
+}
+
+.logo-wall-right {
+  right: 0;
+  transform-origin: top left;
+  transform: translateX(100%) rotateY(-20deg)
+    rotateX(calc(var(--board-angle, 75deg) * -1)) translateZ(-40px) scale(1.8);
+}
+
 
 .snake-connector,
 .ladder-connector {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -296,6 +296,8 @@ function Board({
               {celebrate && <CoinBurst token={token} />}
             </div>
             <div className="logo-wall-main" />
+            <div className="logo-wall-side logo-wall-left" />
+            <div className="logo-wall-side logo-wall-right" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- extend board styling with left and right logo walls
- update Snake & Ladder board markup to include new wall elements

## Testing
- `npm test`
- `npm --prefix webapp run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a15cf61483299d535f14e74aaa85