### PR TITLE
Update token and pot visuals

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect } from "react";
 import * as THREE from "three";
 
-export default function HexPrismToken({ color = "#008080", photoUrl, className = "" }) {
+export default function HexPrismToken({ color = "#008080", topColor, photoUrl, className = "" }) {
   const mountRef = useRef(null);
 
   useEffect(() => {
@@ -49,7 +49,7 @@ export default function HexPrismToken({ color = "#008080", photoUrl, className =
     }
 
     const topMaterial = new THREE.MeshStandardMaterial({
-      color: baseColor.clone().offsetHSL(0, 0, 0.2),
+      color: topColor ? new THREE.Color(topColor) : baseColor.clone().offsetHSL(0, 0, 0.2),
       side: THREE.DoubleSide,
     });
     const bottomMaterial = new THREE.MeshStandardMaterial({
@@ -96,7 +96,7 @@ export default function HexPrismToken({ color = "#008080", photoUrl, className =
       bottomMaterial.dispose();
       renderer.dispose();
     };
-  }, [color]);
+  }, [color, topColor]);
 
   return (
     <div className={`token-three relative ${className}`} ref={mountRef}>

--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -1,12 +1,19 @@
 import React from "react";
 import HexPrismToken from "./HexPrismToken.jsx";
 
-export default function PlayerToken({ type = "normal", color, photoUrl, className = "" }) {
+export default function PlayerToken({ type = "normal", color, topColor, photoUrl, className = "" }) {
   let tokenColor = color;
   if (!tokenColor) {
     if (type === "ladder") tokenColor = "#86efac"; // green
     else if (type === "snake") tokenColor = "#fca5a5"; // red
     else tokenColor = "#fde047"; // yellow
   }
-  return <HexPrismToken color={tokenColor} photoUrl={photoUrl} className={className} />;
+  return (
+    <HexPrismToken
+      color={tokenColor}
+      topColor={topColor}
+      photoUrl={photoUrl}
+      className={className}
+    />
+  );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -246,7 +246,7 @@ body {
   width: 7.2rem;
   height: 7.2rem;
   /* lower the token an additional 5% */
-  transform: translateZ(34.2px);
+  transform: translateZ(32px);
   /* Preserve 3D space so the photo can be positioned in depth */
   transform-style: preserve-3d;
   pointer-events: none;
@@ -258,17 +258,18 @@ body {
 
 @keyframes token-jump {
   0%, 100% {
-    transform: translateZ(34.2px);
+    transform: translateZ(32px);
   }
   50% {
-    transform: translateY(-20px) translateZ(34.2px);
+    transform: translateY(-20px) translateZ(32px);
   }
 }
 
 .pot-token {
-  /* keep pot token scaled relative to player token */
-  width: 9rem; /* 25% bigger than the reduced token */
-  height: 9rem;
+  /* enlarge pot token 50% and keep its base aligned */
+  width: 10.8rem;
+  height: 10.8rem;
+  transform: translateY(-3.6rem);
 }
 
 .token-three canvas {
@@ -550,22 +551,6 @@ body {
   z-index: 1;
 }
 
-.coin-stack {
-  position: absolute;
-  bottom: 0.2rem;
-  left: 50%;
-  transform: translateX(-50%);
-  pointer-events: none;
-}
-
-.coin-stack-img {
-  position: absolute;
-  width: 4.8rem;
-  height: 4.8rem;
-  left: 50%;
-  transform: translateX(-50%);
-  object-fit: contain;
-}
 
 .pot-cell.highlight {
   box-shadow: 0 0 10px 4px rgba(250, 204, 21, 0.8);
@@ -683,25 +668,6 @@ body {
   }
 }
 
-.token-hexagon {
-  position: absolute;
-  width: 2.9rem;
-  height: 2.9rem;
-  background-color: #fde047;
-  clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
-  left: 50%;
-  top: 50%;
-  pointer-events: none;
-  /* Align with the token photo but sit just underneath */
-  transform: translate(-50%, -50%) translateZ(14.2px)
-    rotateX(calc(var(--board-angle, 75deg) * -1 - 10deg));
-  animation: hex-spin 10.5s linear infinite;
-  z-index: 1;
-}
-
-.token-hexagon.step {
-  background-color: #4b5563; /* dark gray */
-}
 
 @keyframes pot-spin {
   from {
@@ -714,18 +680,6 @@ body {
   }
 }
 
-@keyframes hex-spin {
-  from {
-    transform: translate(-50%, -50%) translateZ(14.2px)
-      rotateX(calc(var(--board-angle, 75deg) * -1 - 10deg))
-      rotateY(0deg);
-  }
-  to {
-    transform: translate(-50%, -50%) translateZ(14.2px)
-      rotateX(calc(var(--board-angle, 75deg) * -1 - 10deg))
-      rotateY(360deg);
-  }
-}
 
 .dice-marker {
   position: absolute;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -161,18 +161,11 @@ function Board({
             </span>
           )}
           {position === num && (
-            <>
-              <div
-                className={`token-hexagon ${
-                  isHighlight ? 'step' : ''
-                }`}
-              />
-              <PlayerToken
-                photoUrl={photoUrl}
-                type={isHighlight ? highlight.type : tokenType}
-                className={isJump ? 'jump' : ''}
-              />
-            </>
+            <PlayerToken
+              photoUrl={photoUrl}
+              type={isHighlight ? highlight.type : tokenType}
+              className={isJump ? 'jump' : ''}
+            />
           )}
           {offsetPopup && offsetPopup.cell === num && (
             <span
@@ -275,22 +268,16 @@ function Board({
             <div
               className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? "highlight" : ""}`}
             >
-              <PlayerToken color="#0d47a1" className="pot-token" />
+              <PlayerToken
+                color="#16a34a"
+                topColor="#ff0000"
+                className="pot-token"
+              />
               <img
                 src={`/icons/${token.toLowerCase()}.svg`}
                 alt="pot token"
                 className="pot-icon"
               />
-              <div className={`coin-stack ${celebrate ? 'invisible' : ''}`}>
-                {Array.from({ length: 8 }).map((_, i) => (
-                  <img
-                    key={i}
-                    src={`/icons/${token.toLowerCase()}.svg`}
-                    className="coin-stack-img"
-                    style={{ bottom: `${i * 3}px` }}
-                  />
-                ))}
-              </div>
               <span className="pot-number">{FINAL_TILE}</span>
               {position === FINAL_TILE && (
                 <PlayerToken


### PR DESCRIPTION
## Summary
- remove base hexagon from player tokens
- enlarge and recolor pot token
- tweak token height
- clean out unused styles

## Testing
- `npm test` *(fails: tests 14, pass 12, fail 2)*

------
https://chatgpt.com/codex/tasks/task_e_6857adfe0ad08329b75271193d548abb