### PR TITLE
Refine Snake & Ladder board styling

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -504,7 +504,17 @@ body {
 
 .board-cell.snake-cell .cell-number,
 .board-cell.ladder-cell .cell-number {
-  visibility: hidden;
+  visibility: visible;
+}
+
+.board-cell.snake-cell .cell-number {
+  color: #ffffff;
+  text-shadow: 0 0 2px #ff0000;
+}
+
+.board-cell.ladder-cell .cell-number {
+  color: #ffffff;
+  text-shadow: 0 0 2px #16a34a;
 }
 
 .board-cell.snake-cell,
@@ -526,20 +536,6 @@ body {
   box-shadow: none;
 }
 
-.pot-icon {
-  position: absolute;
-  width: 12rem;
-  height: 12rem;
-  top: 40%;
-  left: 50%;
-  transform-origin: bottom center;
-  transform: translate(-50%, -50%) translateZ(20px)
-    rotateX(calc(var(--board-angle, 75deg) * -1 - 10deg)) rotateY(0deg);
-  animation: pot-spin 6s linear infinite;
-  object-fit: contain;
-  pointer-events: none;
-  z-index: 1;
-}
 
 .pot-number {
   position: absolute;
@@ -669,16 +665,7 @@ body {
 }
 
 
-@keyframes pot-spin {
-  from {
-    transform: translate(-50%, -50%) translateZ(20px)
-      rotateX(calc(var(--board-angle, 75deg) * -1 - 10deg)) rotateY(0deg);
-  }
-  to {
-    transform: translate(-50%, -50%) translateZ(20px)
-      rotateX(calc(var(--board-angle, 75deg) * -1 - 10deg)) rotateY(360deg);
-  }
-}
+
 
 
 .dice-marker {
@@ -707,5 +694,6 @@ body {
   right: -0.4rem;
   font-size: 0.75rem;
   font-weight: bold;
-  color: #000;
+  color: #dc2626;
+  text-shadow: 0 0 2px #fff;
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -260,7 +260,7 @@ function Board({
               "--final-scale": finalScale,
               // Fixed camera angle with no zooming
               // Slightly enlarge the board in both directions
-              transform: `translateX(${boardXOffset}px) rotateX(${angle}deg) scale(1.05)`,
+              transform: `translateX(${boardXOffset}px) rotateX(${angle}deg) scale(0.95)`,
             }}
           >
             <div className="snake-gradient-bg" />
@@ -272,11 +272,6 @@ function Board({
                 color="#16a34a"
                 topColor="#ff0000"
                 className="pot-token"
-              />
-              <img
-                src={`/icons/${token.toLowerCase()}.svg`}
-                alt="pot token"
-                className="pot-icon"
               />
               <span className="pot-number">{FINAL_TILE}</span>
               {position === FINAL_TILE && (


### PR DESCRIPTION
## Summary
- tune board scale for a wider camera view
- remove rotating TPC coin from the pot
- show numbers on snake and ladder cells and colour dice markers

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6857bcac596883299e6372fa5d28a7cb