### PR TITLE
Tweak Snake & Ladder camera and board styling

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -477,6 +477,7 @@ body {
   transform: translate(-50%, -50%);
   display: flex;
   align-items: center;
+  justify-content: center; /* keep icon and offset perfectly centred */
   gap: 2px;
   pointer-events: none;
 }
@@ -499,6 +500,8 @@ body {
   color: #ffffff;
   font-family: "Comic Sans MS", "Comic Sans", cursive;
   font-weight: bold;
+  font-size: 1.1rem; /* slightly bigger numbers */
+  line-height: 1;
   text-shadow: 0 1px 0 #cdd5d6;
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -214,7 +214,10 @@ function Board({
   // How many board rows to scroll back from the starting position so
   // the bottom row remains in view. Set to 0 to begin at the very first row
   // without shifting the camera upward.
-  const CAMERA_OFFSET_ROWS = 0;
+  // Pull the camera back slightly so the first row is visible when the
+  // game starts. Using a positive offset scrolls up a couple of rows
+  // from the very bottom of the board.
+  const CAMERA_OFFSET_ROWS = 2;
 
   useEffect(() => {
     const container = containerRef.current;
@@ -260,7 +263,9 @@ function Board({
               "--final-scale": finalScale,
               // Fixed camera angle with no zooming
               // Slightly enlarge the board in both directions
-              transform: `translateX(${boardXOffset}px) rotateX(${angle}deg) scale(0.95)`,
+              // Pull the board slightly back so more of the lower rows are
+              // visible when the game starts
+              transform: `translateX(${boardXOffset}px) rotateX(${angle}deg) scale(0.9)`,
             }}
           >
             <div className="snake-gradient-bg" />


### PR DESCRIPTION
## Summary
- show the bottom row at game start by offsetting the camera
- back the board away slightly
- enlarge cell numbers and center markers

## Testing
- `npm test` *(fails: manifest endpoint and snake lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6857c05c03c483299c452673c3f542bb