### PR TITLE
Improve board styling

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -490,34 +490,44 @@ body {
 .cell-offset {
   font-size: 1rem;
   line-height: 1;
+  display: flex;
+  align-items: center;
+  gap: 1px;
+}
+.offset-sign {
+  font-weight: bold;
+}
+.offset-num {
   color: #ffffff;
   font-weight: bold;
+}
+
+.snake-cell .offset-sign {
+  color: #ef4444; /* red */
+}
+
+.ladder-cell .offset-sign {
+  color: #16a34a; /* green */
+}
+
+.board-cell.dice-cell {
+  background-color: #bfdbfe; /* blue-200 */
 }
 
 .cell-number {
   position: relative;
   z-index: 1;
-  color: #ffffff;
+  color: #000000;
   font-family: "Comic Sans MS", "Comic Sans", cursive;
   font-weight: bold;
   font-size: 1.1rem; /* slightly bigger numbers */
   line-height: 1;
-  text-shadow: 0 1px 0 #cdd5d6;
 }
 
 .board-cell.snake-cell .cell-number,
-.board-cell.ladder-cell .cell-number {
-  visibility: visible;
-}
-
-.board-cell.snake-cell .cell-number {
-  color: #ffffff;
-  text-shadow: 0 0 2px #ff0000;
-}
-
-.board-cell.ladder-cell .cell-number {
-  color: #ffffff;
-  text-shadow: 0 0 2px #16a34a;
+.board-cell.ladder-cell .cell-number,
+.board-cell.dice-cell .cell-number {
+  display: none;
 }
 
 .board-cell.snake-cell,
@@ -697,6 +707,14 @@ body {
   right: -0.4rem;
   font-size: 0.75rem;
   font-weight: bold;
-  color: #dc2626;
+  display: flex;
+  align-items: center;
+  gap: 1px;
+}
+.dice-sign {
+  color: #3b82f6; /* blue */
+}
+.dice-num {
+  color: #ffffff;
   text-shadow: 0 0 2px #fff;
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -96,14 +96,8 @@ function Board({
     // tile 100 ends up at the top-right.
     const reversed = r % 2 === 1;
     const colorIdx = Math.floor(r / (ROWS / 5));
-    const TILE_COLORS = [
-      "#6db0ad",
-      "#4a828e",
-      "#3d7078",
-      "#2d5c66",
-      "#0e3b45",
-    ];
-    const rowColor = TILE_COLORS[colorIdx] || "#0e3b45";
+    const TILE_COLORS = ["#ffffff", "#ffffff", "#ffffff", "#ffffff", "#ffffff"];
+    const rowColor = TILE_COLORS[colorIdx] || "#ffffff";
 
     for (let c = 0; c < COLS; c++) {
       const col = c;
@@ -120,6 +114,8 @@ function Board({
       const isJump = isHighlight && highlight.type === 'normal';
       const cellType = ladders[num] ? "ladder" : snakes[num] ? "snake" : "";
       const cellClass = cellType ? `${cellType}-cell` : "";
+      const hasDice = diceCells && diceCells[num];
+      const allClasses = `board-cell ${cellClass} ${hasDice ? 'dice-cell' : ''} ${highlightClass}`;
       const icon = cellType === "ladder" ? "🪜" : cellType === "snake" ? "🐍" : "";
       const offsetVal =
         cellType === "ladder"
@@ -139,7 +135,7 @@ function Board({
         <div
           key={num}
           data-cell={num}
-          className={`board-cell ${cellClass} ${highlightClass}`}
+          className={allClasses}
           style={style}
         >
           {(icon || offsetVal != null) && (
@@ -147,17 +143,22 @@ function Board({
               {icon && <span className="cell-icon">{icon}</span>}
               {offsetVal != null && (
                 <span className="cell-offset">
-                  {cellType === "snake" ? "-" : "+"}
-                  {offsetVal}
+                  <span className="offset-sign">
+                    {cellType === 'snake' ? '-' : '+'}
+                  </span>
+                  <span className="offset-num">{offsetVal}</span>
                 </span>
               )}
             </span>
           )}
-          <span className="cell-number">{num}</span>
+          {!(cellType || hasDice) && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
               <img src="/assets/icons/dice.svg" alt="dice" />
-              <span className="dice-value">+{diceCells[num]}</span>
+              <span className="dice-value">
+                <span className="dice-sign">+</span>
+                <span className="dice-num">{diceCells[num]}</span>
+              </span>
             </span>
           )}
           {position === num && (


### PR DESCRIPTION
## Summary
- show dice cell indicator and hide numbers on snake/ladder/dice cells
- simplify tile colors
- tweak board CSS for new colour scheme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c3902f6483299d933da38e968481