### PR TITLE
Align token halo and revert dice color

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -132,17 +132,17 @@ body {
 }
 
 .dice-cube {
-  @apply relative w-12 h-12 bg-black rounded-xl border border-white;
+  @apply relative w-12 h-12 bg-white rounded-xl border border-black;
   transform-style: preserve-3d;
   transition: transform 0.5s;
 }
 
 .dice-face {
-  @apply absolute w-full h-full flex items-center justify-center bg-black rounded-xl shadow-lg border border-white;
+  @apply absolute w-full h-full flex items-center justify-center bg-white rounded-xl shadow-lg border border-black;
 }
 
 .dice-face .dot {
-  @apply w-3 h-3 bg-white rounded-full;
+  @apply w-3 h-3 bg-black rounded-full;
 }
 
 .dice-face--front {
@@ -234,13 +234,13 @@ body {
 }
 
 .token-dice .dice-face {
-  background-color: #000; /* black dice */
-  border: 1px solid #fff;
+  background-color: #fff; /* white dice */
+  border: 1px solid #000;
   border-radius: 0.5rem;
 }
 
 .token-dice .dice-face .dot {
-  background-color: #fff;
+  background-color: #000;
 }
 
 /* Three.js token container */
@@ -249,8 +249,8 @@ body {
   /* shrink token by another 20% */
   width: 7.2rem;
   height: 7.2rem;
-  /* lower the token an additional 5% */
-  transform: translateZ(32px);
+  /* lower the token slightly */
+  transform: translateZ(28px);
   /* Preserve 3D space so the photo can be positioned in depth */
   transform-style: preserve-3d;
   pointer-events: none;
@@ -263,10 +263,10 @@ body {
 @keyframes token-jump {
   0%,
   100% {
-    transform: translateZ(32px);
+    transform: translateZ(28px);
   }
   50% {
-    transform: translateY(-20px) translateZ(32px);
+    transform: translateY(-20px) translateZ(28px);
   }
 }
 
@@ -560,6 +560,7 @@ body {
 
 .cell-number {
   position: relative;
+  top: -2px;
   z-index: 1;
   color: #ffffff;
   font-family: "Comic Sans MS", "Comic Sans", cursive;
@@ -772,13 +773,23 @@ body {
 
 .token-hexagon {
   position: absolute;
-  inset: 4px;
+  inset: 0;
   background-color: #555;
   clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
-  animation: hex-spin 10.5s linear infinite;
-  transform: translateZ(6px);
+  animation: token-hex-spin 10.5s linear infinite;
+  transform-style: preserve-3d;
+  transform: translateZ(6px) rotateY(30deg);
   pointer-events: none;
   z-index: 0;
+}
+
+@keyframes token-hex-spin {
+  from {
+    transform: translateZ(6px) rotateY(30deg);
+  }
+  to {
+    transform: translateZ(6px) rotateY(390deg);
+  }
 }
 
 @keyframes hex-spin {


### PR DESCRIPTION
## Summary
- sync hexagon halo size and rotation with token
- lower 3D token position a bit
- nudge board numbers upward
- revert dice visuals to white with black dots

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_6857d963e36c8329a3599521907110e8