### PR TITLE
Fix Snake and Ladder start view

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -219,10 +219,10 @@ function Board({
   // Pull the camera back slightly so the first row is visible when the
   // game starts. Using a positive offset scrolls up a couple of rows
   // from the very bottom of the board.
-  // Shift the starting camera up a few rows so players immediately see
-  // more of the board when the game loads. Increasing this value scrolls
-  // up from the very bottom of the board.
-  const CAMERA_OFFSET_ROWS = 3;
+  // Start the camera at the very bottom of the board so the first row is
+  // visible without any manual scrolling. This keeps two additional rows
+  // in view above it so players immediately see the starting area.
+  const CAMERA_OFFSET_ROWS = 0;
 
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
## Summary
- start the Snake & Ladder board at the very bottom

## Testing
- `npm test` *(fails: manifest endpoint not reachable and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6857f2f21ee88329b97ebf9d064fd34b