### PR TITLE
Add side walls for Snake & Ladder board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -626,6 +626,33 @@ body {
   z-index: 5;
 }
 
+/* Side walls for the Snake & Ladder board */
+.board-wall {
+  position: absolute;
+  top: calc(
+    var(--cell-height) * -9.5 - var(--cell-height) * 1.8 *
+      (var(--final-scale, 1) - 1)
+  );
+  bottom: 0;
+  width: var(--wall-width, 110px);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.board-wall-left {
+  left: calc(var(--wall-width, 110px) * -1);
+  background: linear-gradient(to top, #0c1020, #11172a);
+  transform-origin: left center;
+  transform: rotateY(30deg);
+}
+
+.board-wall-right {
+  right: calc(var(--wall-width, 110px) * -1);
+  background: linear-gradient(to top, #2a0c0c, #401010);
+  transform-origin: right center;
+  transform: rotateY(-30deg);
+}
+
 .snake-connector,
 .ladder-connector {
   position: absolute;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -275,6 +275,8 @@ function Board({
             }}
           >
             <div className="snake-gradient-bg" />
+            <div className="board-wall board-wall-left" />
+            <div className="board-wall board-wall-right" />
             {tiles}
             <div
               className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? "highlight" : ""}`}


### PR DESCRIPTION
## Summary
- create CSS classes for left/right board walls with gradients and 3D transforms
- render the two side wall elements inside the Snake & Ladder board

## Testing
- `npm test` *(fails: 2 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_6857fdb8059c8329966aa0b70868b2c3