### PR TITLE
Fix side walls height to align with logo

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -629,8 +629,9 @@ body {
 /* Side walls for the Snake & Ladder board */
 .board-wall {
   position: absolute;
+  /* Raise the side walls so they meet the logo */
   top: calc(
-    var(--cell-height) * -14.5 - var(--cell-height) * 1.8 *
+    var(--cell-height) * -9.5 - var(--cell-height) * 1.8 *
       (var(--final-scale, 1) - 1)
   );
   bottom: 0;


### PR DESCRIPTION
## Summary
- adjust board-wall top offset so the side walls reach the logo

## Testing
- `npm --prefix webapp run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685806414134832982acd1fe80c3405b