### PR TITLE
Adjust board scaling and token base

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -569,7 +569,7 @@ body {
   font-size: 1.1rem; /* slightly bigger numbers */
   line-height: 1;
   text-shadow: 0 0 2px #000;
-  transform: translateY(-10%);
+  transform: translateY(0);
 }
 
 .board-cell.snake-cell .cell-number,
@@ -779,8 +779,8 @@ body {
   inset: 10px;
   background-color: #555;
   clip-path: polygon(50% 0%, 93% 25%, 93% 75%, 50% 100%, 7% 75%, 7% 25%);
-  /* match the board tilt */
-  transform: translateZ(0) rotateX(var(--board-angle, 75deg));
+  /* keep the hexagon flat on the board */
+  transform: translateZ(0);
   animation: hex-spin-reverse 10.5s linear infinite;
   pointer-events: none;
   z-index: 0;
@@ -788,10 +788,10 @@ body {
 
 @keyframes hex-spin-reverse {
   from {
-    transform: translateZ(0) rotateX(var(--board-angle, 75deg)) rotate(0deg);
+    transform: translateZ(0) rotate(0deg);
   }
   to {
-    transform: translateZ(0) rotateX(var(--board-angle, 75deg)) rotate(-360deg);
+    transform: translateZ(0) rotate(-360deg);
   }
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -66,9 +66,9 @@ function Board({
   const [cellHeight, setCellHeight] = useState(40);
   const tiles = [];
   const centerCol = (COLS - 1) / 2;
-  // Keep vertical columns evenly spaced rather than widening
-  const widenStep = 0; // how much each row expands horizontally
-  const scaleStep = 0.02; // how much each row's cells scale
+  // Gradually widen and scale the rows by about 3%
+  const widenStep = 0.03; // how much each row expands horizontally
+  const scaleStep = 0.03; // how much each row's cells scale
   // Perspective with smaller cells at the bottom growing larger towards the pot
   const finalScale = 1 + (ROWS - 3) * scaleStep;
 


### PR DESCRIPTION
## Summary
- increase board row scale and widen steps in Snake & Ladder board
- keep token base flat on the board
- remove offset from cell numbers

## Testing
- `npm test` *(fails: server exposes manifest endpoint, snake lobby route)*

------
https://chatgpt.com/codex/tasks/task_e_6858138644e88329bbd9ea137d69dc6a