### PR TITLE
Scale snake board 8%

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -275,7 +275,7 @@ function Board({
               // Slightly enlarge the board in both directions
               // Pull the board slightly back so more of the lower rows are
               // visible when the game starts
-              transform: `translate(${boardXOffset}px, ${boardYOffset}px) rotateX(${angle}deg) scale(0.8755)`,
+              transform: `translate(${boardXOffset}px, ${boardYOffset}px) rotateX(${angle}deg) scale(0.9455)`,
             }}
           >
             <div className="snake-gradient-bg" />


### PR DESCRIPTION
## Summary
- enlarge the Snake & Ladder board by 8%

## Testing
- `npm test` *(fails: manifest endpoint and lobby route tests)*

------
https://chatgpt.com/codex/tasks/task_e_68581e8fbb24832983c4091f4c6e998a