### PR TITLE
Reduce board tilt and reposition logo

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -295,7 +295,7 @@ body {
   transform-origin: bottom center;
   /* Align the photo with the top face of the token and tilt upward */
   transform: translate(-50%, -50%) translateZ(15.2px)
-    rotateX(calc(var(--board-angle, 75deg) * -1 - 10deg));
+    rotateX(calc(var(--board-angle, 50deg) * -1 - 10deg));
   object-fit: cover;
   border-radius: 50%;
   border: 2px solid #ffd700;
@@ -310,7 +310,7 @@ body {
   height: 100%;
   transform-style: preserve-3d;
   /* Align token with board surface while showing a slight side angle */
-  transform: rotateX(calc(var(--board-angle, 75deg) * -1 - 20deg))
+  transform: rotateX(calc(var(--board-angle, 50deg) * -1 - 20deg))
     rotateY(25deg);
 }
 
@@ -612,11 +612,11 @@ body {
   height: calc(var(--cell-height) * 5); /* taller logo */
   /* move the logo even higher above the board */
   top: calc(
-    var(--cell-height) * -9.5 - var(--cell-height) * 1.8 *
+    var(--cell-height) * -10 - var(--cell-height) * 1.8 *
       (var(--final-scale, 1) - 1)
   ); /* adjust for scaled top row */
   left: 50%;
-  transform: translateX(-50%) rotateX(calc(var(--board-angle, 75deg) * -1))
+  transform: translateX(-50%) rotateX(calc(var(--board-angle, 50deg) * -1))
     translateZ(-40px) scale(1.8); /* larger logo */
   transform-origin: bottom center;
   background-image: url("/assets/TonPlayGramLogo.jpg");
@@ -780,7 +780,7 @@ body {
   background-color: #555;
   clip-path: polygon(50% 0%, 93% 25%, 93% 75%, 50% 100%, 7% 75%, 7% 25%);
   /* match the board tilt */
-  transform: translateZ(0) rotateX(var(--board-angle, 75deg));
+  transform: translateZ(0) rotateX(var(--board-angle, 50deg));
   animation: hex-spin-reverse 10.5s linear infinite;
   pointer-events: none;
   z-index: 0;
@@ -788,10 +788,10 @@ body {
 
 @keyframes hex-spin-reverse {
   from {
-    transform: translateZ(0) rotateX(var(--board-angle, 75deg)) rotate(0deg);
+    transform: translateZ(0) rotateX(var(--board-angle, 50deg)) rotate(0deg);
   }
   to {
-    transform: translateZ(0) rotateX(var(--board-angle, 75deg)) rotate(-360deg);
+    transform: translateZ(0) rotateX(var(--board-angle, 50deg)) rotate(-360deg);
   }
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -207,9 +207,8 @@ function Board({
   // displayed only once within the cell itself.
   // Fixed board angle with no zoom
   // Lowered camera angle so the logo touches the top of the screen
-  // Increase the camera tilt to give the board a steeper perspective
-  // so the entire scene appears lifted by 15 degrees
-  const angle = 75;
+  // Reduce the camera tilt for a clearer view of the top rows
+  const angle = 50;
   // Small horizontal offset so the board sits perfectly centered
   const boardXOffset = -10; // pixels
   // Lift the board slightly so the bottom row stays visible


### PR DESCRIPTION
## Summary
- lower the camera tilt angle so top rows are easier to see
- move the logo higher to free up board space

## Testing
- `npm test` *(fails: manifest endpoint & lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6858244ac7448329ba18cb2e843721b8