### PR TITLE
Increase board tilt by 5°

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -295,7 +295,7 @@ body {
   transform-origin: bottom center;
   /* Align the photo with the top face of the token and tilt upward */
   transform: translate(-50%, -50%) translateZ(15.2px)
-    rotateX(calc(var(--board-angle, 65deg) * -1 - 10deg));
+    rotateX(calc(var(--board-angle, 70deg) * -1 - 10deg));
   object-fit: cover;
   border-radius: 50%;
   border: 2px solid #ffd700;
@@ -310,7 +310,7 @@ body {
   height: 100%;
   transform-style: preserve-3d;
   /* Align token with board surface while showing a slight side angle */
-  transform: rotateX(calc(var(--board-angle, 65deg) * -1 - 20deg))
+  transform: rotateX(calc(var(--board-angle, 70deg) * -1 - 20deg))
     rotateY(25deg);
 }
 
@@ -611,13 +611,13 @@ body {
   width: calc(var(--cell-width) * 6); /* larger logo width */
   height: calc(var(--cell-height) * 5); /* taller logo */
   /* move the logo even higher above the board */
-  /* raise the logo slightly to compensate for the steeper board tilt */
+  /* raise the logo slightly higher to compensate for the even steeper board tilt */
   top: calc(
-    var(--cell-height) * -12 - var(--cell-height) * 1.8 *
+    var(--cell-height) * -12.5 - var(--cell-height) * 1.8 *
       (var(--final-scale, 1) - 1)
   ); /* adjust for scaled top row */
   left: 50%;
-  transform: translateX(-50%) rotateX(calc(var(--board-angle, 65deg) * -1))
+  transform: translateX(-50%) rotateX(calc(var(--board-angle, 70deg) * -1))
     translateZ(-40px) scale(1.8); /* larger logo */
   transform-origin: bottom center;
   background-image: url("/assets/TonPlayGramLogo.jpg");
@@ -781,7 +781,7 @@ body {
   background-color: #555;
   clip-path: polygon(50% 0%, 93% 25%, 93% 75%, 50% 100%, 7% 75%, 7% 25%);
   /* match the board tilt */
-  transform: translateZ(0) rotateX(var(--board-angle, 65deg));
+  transform: translateZ(0) rotateX(var(--board-angle, 70deg));
   animation: hex-spin-reverse 10.5s linear infinite;
   pointer-events: none;
   z-index: 0;
@@ -789,10 +789,10 @@ body {
 
 @keyframes hex-spin-reverse {
   from {
-    transform: translateZ(0) rotateX(var(--board-angle, 65deg)) rotate(0deg);
+    transform: translateZ(0) rotateX(var(--board-angle, 70deg)) rotate(0deg);
   }
   to {
-    transform: translateZ(0) rotateX(var(--board-angle, 65deg)) rotate(-360deg);
+    transform: translateZ(0) rotateX(var(--board-angle, 70deg)) rotate(-360deg);
   }
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -214,7 +214,7 @@ function Board({
   // Fixed board angle with no zoom
   // Lowered camera angle so the logo touches the top of the screen
   // Increase tilt for a more dynamic view of the board
-  const angle = 65;
+  const angle = 70;
   // Small horizontal offset so the board sits perfectly centered
   const boardXOffset = -10; // pixels
   // Lift the board slightly so the bottom row stays visible


### PR DESCRIPTION
## Summary
- adjust board tilt constant to 70 degrees
- update CSS fallbacks to 70deg and nudge logo higher

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_685831cef36083298233606407197421