### PR TITLE
Update snake game mechanics

### DIFF
--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -9,14 +9,11 @@ export default function PlayerToken({ type = "normal", color, topColor, photoUrl
     else tokenColor = "#fde047"; // yellow
   }
   return (
-    <>
-      {photoUrl && <span className="token-hexagon" />}
-      <HexPrismToken
-        color={tokenColor}
-        topColor={topColor}
-        photoUrl={photoUrl}
-        className={className}
-      />
-    </>
+    <HexPrismToken
+      color={tokenColor}
+      topColor={topColor}
+      photoUrl={photoUrl}
+      className={className}
+    />
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -273,10 +273,10 @@ body {
 }
 
 .pot-token {
-  /* enlarge pot token 50% and keep its base aligned */
-  width: 10.8rem;
-  height: 10.8rem;
-  transform: translateY(-3.6rem);
+  /* enlarge pot token 50% further */
+  width: 16.2rem;
+  height: 16.2rem;
+  transform: translateY(-9rem);
 }
 
 .token-three canvas {
@@ -580,10 +580,10 @@ body {
 
 .pot-cell {
   @apply absolute flex flex-col items-center justify-center;
-  width: calc(var(--cell-width) * 1.8);
-  height: calc(var(--cell-height) * 1.8);
+  width: calc(var(--cell-width) * 2.7);
+  height: calc(var(--cell-height) * 2.7);
   /* move the pot even higher above the board */
-  top: calc(var(--cell-height) * -5.5);
+  top: calc(var(--cell-height) * -8.25);
   left: 50%;
   transform: translateX(-50%) translateZ(8px);
   z-index: 15;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import confetti from "canvas-confetti";
 import DiceRoller from "../../components/DiceRoller.jsx";
 import { dropSound, snakeSound, ladderSound } from "../../assets/soundData.js";
 import InfoPopup from "../../components/InfoPopup.jsx";
@@ -339,6 +340,7 @@ export default function SnakeAndLadder() {
   const [rollResult, setRollResult] = useState(null);
   const [diceCells, setDiceCells] = useState({});
   const [bonusDice, setBonusDice] = useState(0);
+  const [diceCount, setDiceCount] = useState(2);
   const [gameOver, setGameOver] = useState(false);
 
   const moveSoundRef = useRef(null);
@@ -504,7 +506,26 @@ export default function SnakeAndLadder() {
       let current = pos;
       let target = current;
 
-      if (current === 0) {
+      if (current === 100 && diceCount === 2) {
+        if (rolledSix) {
+          setDiceCount(1);
+          setMessage("Six rolled! One die removed.");
+        } else {
+          setMessage("Need a 6 to remove a die.");
+        }
+        setTurnMessage("Your turn");
+        setDiceVisible(true);
+        return;
+      } else if (current === 100 && diceCount === 1) {
+        if (value === 1) {
+          target = FINAL_TILE;
+        } else {
+          setMessage("Need a 1 to win!");
+          setTurnMessage("Your turn");
+          setDiceVisible(true);
+          return;
+        }
+      } else if (current === 0) {
         if (rolledSix) target = 1;
         else {
           setMessage("Need a 6 to start!");
@@ -518,6 +539,7 @@ export default function SnakeAndLadder() {
         setMessage("Need exact roll!");
         setTurnMessage("Your turn");
         setDiceVisible(true);
+        return;
       }
 
       const steps = [];
@@ -601,9 +623,11 @@ export default function SnakeAndLadder() {
           setMessage(`You win ${pot} ${token}!`);
           setMessageColor("");
           winSoundRef.current?.play().catch(() => {});
+          confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
           setCelebrate(true);
           setTimeout(() => {
             setCelebrate(false);
+            setDiceCount(2);
             setGameOver(true);
           }, 1500);
         }
@@ -688,7 +712,7 @@ export default function SnakeAndLadder() {
             }}
             onRollStart={() => setTurnMessage("Rolling...")}
             clickable
-            numDice={2 + bonusDice}
+            numDice={diceCount + bonusDice}
           />
           {turnMessage && (
             <div className="mt-2 text-sm font-semibold">{turnMessage}</div>


### PR DESCRIPTION
## Summary
- enlarge the pot token and cell
- remove decorative layer under player token
- add confetti celebration when reaching the pot
- require rolling a 6 on square 100 to remove a die, then a 1 to win
- allow changing number of dice dynamically

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685836c4bc9c8329a8f551fafb220077