### PR TITLE
Add local leaderboard and hexagon cell frame

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -572,6 +572,16 @@ body {
   transform: translateY(-10%);
 }
 
+.cell-hexagon {
+  position: absolute;
+  inset: 6px;
+  background-color: #333;
+  clip-path: polygon(50% 0%, 93% 25%, 93% 75%, 50% 100%, 7% 75%, 7% 25%);
+  transform: translateZ(4px) rotateX(var(--board-angle, 70deg));
+  pointer-events: none;
+  z-index: 0;
+}
+
 .board-cell.snake-cell .cell-number,
 .board-cell.ladder-cell .cell-number,
 .board-cell.dice-cell .cell-number {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -159,7 +159,12 @@ function Board({
               )}
             </span>
           )}
-          {cellType === "" && <span className="cell-number">{num}</span>}
+          {cellType === "" && (
+            <>
+              <span className="cell-hexagon" />
+              <span className="cell-number">{num}</span>
+            </>
+          )}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
               <img src="/assets/icons/dice.svg" alt="dice" />
@@ -307,7 +312,6 @@ function Board({
               )}
               {celebrate && <CoinBurst token={token} />}
             </div>
-            <div className="logo-bg-extension" />
             <div className="logo-wall-main" />
           </div>
         </div>
@@ -343,6 +347,12 @@ export default function SnakeAndLadder() {
   const [bonusDice, setBonusDice] = useState(0);
   const [diceCount, setDiceCount] = useState(2);
   const [gameOver, setGameOver] = useState(false);
+  const [leaderboard, setLeaderboard] = useState([
+    { name: 'Alice', score: 0 },
+    { name: 'Bob', score: 0 },
+    { name: 'Carol', score: 0 },
+    { name: 'You', score: 0 },
+  ]);
 
   const moveSoundRef = useRef(null);
   const snakeSoundRef = useRef(null);
@@ -616,6 +626,11 @@ export default function SnakeAndLadder() {
 
       const finalizeMove = (finalPos, type) => {
         setPos(finalPos);
+        setLeaderboard((lb) =>
+          [...lb.map((p) =>
+            p.name === 'You' ? { ...p, score: finalPos } : p
+          )].sort((a, b) => b.score - a.score)
+        );
         setHighlight({ cell: finalPos, type });
         setTrail([]);
         setTokenType(type);
@@ -677,6 +692,14 @@ export default function SnakeAndLadder() {
           <AiOutlineRollback className="text-xl" />
           <span className="text-xs">Lobby</span>
         </button>
+      </div>
+      <div className="absolute top-0 left-1/2 transform -translate-x-1/2 mt-2 z-20 text-xs bg-black bg-opacity-50 rounded px-2 py-1">
+        {leaderboard.map((p, i) => (
+          <div key={i} className="flex justify-between gap-2">
+            <span>{p.name}</span>
+            <span>{p.score}</span>
+          </div>
+        ))}
       </div>
       <Board
         position={pos}


### PR DESCRIPTION
## Summary
- show 4-player leaderboard overlay in the Snake & Ladder game
- remove the background behind the game logo
- frame board numbers with a dark hexagon

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68583e1c093c8329bcf89913e5a91ec4