### PR TITLE
Adjust pot behavior and logo position

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -276,7 +276,7 @@ body {
   /* enlarge pot token 50% further */
   width: 16.2rem;
   height: 16.2rem;
-  transform: translateY(-9rem) rotate(-15deg);
+  transform: translateY(-9rem);
 }
 
 .token-three canvas {
@@ -615,17 +615,9 @@ body {
   background-color: transparent;
   border: none;
   box-shadow: none;
+  pointer-events: none;
 }
 
-.pot-number {
-  position: absolute;
-  bottom: -1rem;
-  left: 50%;
-  transform: translateX(-50%);
-  font-weight: bold;
-  color: #ffffff;
-  z-index: 1;
-}
 
 .pot-cell.highlight {
   box-shadow: 0 0 10px 4px rgba(250, 204, 21, 0.8);
@@ -638,12 +630,12 @@ body {
   /* move the logo even higher above the board */
   /* raise the logo slightly higher to compensate for the even steeper board tilt */
   top: calc(
-    var(--cell-height) * -12.5 - var(--cell-height) * 1.8 *
+    var(--cell-height) * -12 - var(--cell-height) * 1.8 *
       (var(--final-scale, 1) - 1)
   ); /* adjust for scaled top row */
   left: 50%;
   transform: translateX(-50%) rotateX(calc(var(--board-angle, 70deg) * -1))
-    translateZ(-40px) scale(1.98); /* 10% larger logo */
+    translateZ(-40px) scale(2.08); /* slightly larger logo */
   transform-origin: bottom center;
   background-image: url("/assets/TonPlayGramLogo.jpg");
   background-size: contain;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -295,7 +295,6 @@ function Board({
                 topColor="#ff0000"
                 className="pot-token"
               />
-              <span className="pot-number">{FINAL_TILE}</span>
               {position === FINAL_TILE && (
                 <PlayerToken
                   photoUrl={photoUrl}
@@ -329,7 +328,7 @@ export default function SnakeAndLadder() {
   const [turnMessage, setTurnMessage] = useState("Your turn");
   const [diceVisible, setDiceVisible] = useState(true);
   const [photoUrl, setPhotoUrl] = useState("");
-  const [pot, setPot] = useState(100);
+  const [pot, setPot] = useState(101);
   const [token, setToken] = useState("TPC");
   const [celebrate, setCelebrate] = useState(false);
   const [showInfo, setShowInfo] = useState(false);


### PR DESCRIPTION
## Summary
- remove rotation from pot token and hide pot label
- default pot amount to 101
- remove invisible pointer area for pot cell
- enlarge and reposition Snake & Ladder logo slightly

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68584eb7a2208329beafe3d83e6bad51