### PR TITLE
Improve Snakes and Ladders UI

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -572,18 +572,18 @@ body {
   transform: translateY(-10%);
 }
 
-/* Hexagon overlay for the starting cell */
-.start-cell-circle {
+/* Small hexagonal frame for the starting cell number */
+.start-cell-hex {
   position: absolute;
-  width: 7.2rem;
-  height: 7.2rem;
+  width: 2.5rem;
+  height: 2.5rem;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -60%) rotateX(var(--board-angle, 70deg))
     translateZ(6px);
   border: 2px solid #d1a75f;
-  background-color: rgba(255, 255, 255, 0.15);
-  border-radius: 50%;
+  background-color: transparent;
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
   pointer-events: none;
   z-index: 2;
 }
@@ -611,7 +611,7 @@ body {
   top: calc(var(--cell-height) * -8.25);
   left: 50%;
   transform: translateX(-50%) translateZ(24px);
-  z-index: 15;
+  z-index: 50;
   background-color: transparent;
   border: none;
   box-shadow: none;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -160,7 +160,7 @@ function Board({
             </span>
           )}
           {cellType === "" && <span className="cell-number">{num}</span>}
-          {num === 1 && <div className="start-cell-circle" />}
+          {num === 1 && <div className="start-cell-hex" />}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
               <img src="/assets/icons/dice.svg" alt="dice" />


### PR DESCRIPTION
## Summary
- show a small hex frame instead of the circle on tile 1
- keep the pot above the logo by increasing its z-index

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68585877bc5c83299430489fd6e35e6f