### PR TITLE
Add cosmic overlay to Snake and Ladder

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -611,7 +611,8 @@ body {
   top: calc(var(--cell-height) * -8.25);
   left: 50%;
   transform: translateX(-50%) translateZ(24px);
-  z-index: 50;
+  /* ensure the pot sits above the overlay filter */
+  z-index: 1001;
   background-color: transparent;
   border: none;
   box-shadow: none;
@@ -822,4 +823,154 @@ body {
   to {
     transform: translateZ(6px) rotate(360deg);
   }
+}
+/* Cosmic background elements */
+.cosmic-bg {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.cosmic-stars,
+.cosmic-stars::before,
+.cosmic-stars::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: transparent;
+}
+
+.cosmic-stars {
+  width: 2px;
+  height: 2px;
+  background: #fff;
+  box-shadow:
+    10vw 20vh #fff,
+    30vw 40vh #fff,
+    50vw 10vh #fff,
+    70vw 30vh #fff,
+    90vw 50vh #fff,
+    20vw 70vh #fff,
+    40vw 80vh #fff,
+    60vw 60vh #fff,
+    80vw 20vh #fff,
+    15vw 40vh #fff,
+    25vw 10vh #fff,
+    35vw 55vh #fff,
+    65vw 75vh #fff,
+    85vw 35vh #fff,
+    95vw 15vh #fff;
+  animation: star-flicker 2s infinite alternate;
+}
+
+.cosmic-stars::before {
+  transform: translateX(-50%);
+  box-shadow:
+    5vw 15vh #fff,
+    45vw 25vh #fff,
+    75vw 45vh #fff,
+    55vw 70vh #fff,
+    25vw 80vh #fff,
+    15vw 60vh #fff,
+    85vw 10vh #fff,
+    95vw 55vh #fff;
+}
+
+.cosmic-stars::after {
+  transform: translateX(50%);
+  box-shadow:
+    12vw 65vh #fff,
+    32vw 35vh #fff,
+    52vw 20vh #fff,
+    72vw 80vh #fff,
+    92vw 40vh #fff,
+    22vw 30vh #fff,
+    42vw 50vh #fff,
+    62vw 70vh #fff;
+}
+
+@keyframes star-flicker {
+  from { opacity: 0.6; }
+  to { opacity: 1; }
+}
+
+.planet {
+  position: absolute;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, rgba(255,255,255,0.3), transparent 70%);
+  filter: blur(2px);
+}
+
+.planet.one {
+  width: 120px;
+  height: 120px;
+  top: 8%;
+  right: 6%;
+}
+
+.planet.two {
+  width: 80px;
+  height: 80px;
+  bottom: 12%;
+  left: 8%;
+}
+
+.comet {
+  position: absolute;
+  top: -40px;
+  left: -100px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255,255,255,0.9), rgba(255,255,255,0));
+  box-shadow: 0 0 6px 2px rgba(255,255,255,0.8);
+  animation: comet-move 6s linear infinite;
+}
+
+.comet::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 50px;
+  height: 2px;
+  background: linear-gradient(to left, rgba(255,255,255,0), rgba(255,255,255,0.8));
+  transform: translate(-100%, -50%);
+  filter: blur(2px);
+}
+
+@keyframes comet-move {
+  from { transform: translate(0,0); opacity: 1; }
+  to { transform: translate(120vw, 90vh); opacity: 0; }
+}
+
+.cosmic-frame {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 999;
+}
+
+.cosmic-frame::before,
+.cosmic-frame::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 20%;
+  border: 1px solid rgba(255,255,255,0.2);
+  box-shadow: 0 0 12px rgba(255,255,255,0.3) inset;
+  background: linear-gradient(to bottom, rgba(255,255,255,0.1), rgba(255,255,255,0));
+}
+
+.cosmic-frame::before {
+  left: 0;
+  clip-path: polygon(0 0, 100% 0, 80% 100%, 0% 100%);
+}
+
+.cosmic-frame::after {
+  right: 0;
+  clip-path: polygon(20% 0, 100% 0, 100% 100%, 0% 100%);
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -252,65 +252,74 @@ function Board({
   const paddingBottom = '15vh';
 
   return (
-    <div className="flex justify-center items-center w-screen overflow-hidden">
-      <div
-        ref={containerRef}
-        className="overflow-y-auto"
-        style={{
-          overflowX: "hidden",
-          height: "100vh",
-          overscrollBehaviorY: "contain",
-          paddingTop,
-          paddingBottom,
-        }}
-      >
-        <div className="snake-board-tilt">
-          <div
-            className="snake-board-grid grid gap-x-1 gap-y-2 relative mx-auto"
-            style={{
-              width: `${cellWidth * COLS}px`,
-              height: `${cellHeight * ROWS + offsetYMax}px`,
-              gridTemplateColumns: `repeat(${COLS}, ${cellWidth}px)`,
-              gridTemplateRows: `repeat(${ROWS}, ${cellHeight}px)`,
-              "--cell-width": `${cellWidth}px`,
-              "--cell-height": `${cellHeight}px`,
-              "--board-width": `${cellWidth * COLS}px`,
-              "--board-height": `${cellHeight * ROWS + offsetYMax}px`,
-              "--board-angle": `${angle}deg`,
-              "--final-scale": finalScale,
-              // Fixed camera angle with no zooming
-              // Slightly enlarge the board in both directions
-              // Pull the board slightly back so more of the lower rows are
-              // visible when the game starts
-              transform: `translate(${boardXOffset}px, ${boardYOffset}px) rotateX(${angle}deg) scale(0.9455)`,
-            }}
-          >
-            <div className="snake-gradient-bg" />
-            {tiles}
+    <div className="relative w-screen h-screen overflow-hidden">
+      <div className="cosmic-bg">
+        <div className="cosmic-stars" />
+        <div className="planet one" />
+        <div className="planet two" />
+        <div className="comet" />
+      </div>
+      <div className="flex justify-center items-center w-screen overflow-hidden relative z-10">
+        <div
+          ref={containerRef}
+          className="overflow-y-auto"
+          style={{
+            overflowX: "hidden",
+            height: "100vh",
+            overscrollBehaviorY: "contain",
+            paddingTop,
+            paddingBottom,
+          }}
+        >
+          <div className="snake-board-tilt">
             <div
-              className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? "highlight" : ""}`}
+              className="snake-board-grid grid gap-x-1 gap-y-2 relative mx-auto"
+              style={{
+                width: `${cellWidth * COLS}px`,
+                height: `${cellHeight * ROWS + offsetYMax}px`,
+                gridTemplateColumns: `repeat(${COLS}, ${cellWidth}px)`,
+                gridTemplateRows: `repeat(${ROWS}, ${cellHeight}px)`,
+                "--cell-width": `${cellWidth}px`,
+                "--cell-height": `${cellHeight}px`,
+                "--board-width": `${cellWidth * COLS}px`,
+                "--board-height": `${cellHeight * ROWS + offsetYMax}px`,
+                "--board-angle": `${angle}deg`,
+                "--final-scale": finalScale,
+                // Fixed camera angle with no zooming
+                // Slightly enlarge the board in both directions
+                // Pull the board slightly back so more of the lower rows are
+                // visible when the game starts
+                transform: `translate(${boardXOffset}px, ${boardYOffset}px) rotateX(${angle}deg) scale(0.9455)`,
+              }}
             >
-              <PlayerToken
-                color="#16a34a"
-                topColor="#ff0000"
-                className="pot-token"
-              />
-              {position === FINAL_TILE && (
+              <div className="snake-gradient-bg" />
+              {tiles}
+              <div
+                className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? "highlight" : ""}`}
+              >
                 <PlayerToken
-                  photoUrl={photoUrl}
-                  type={
-                    highlight && highlight.cell === FINAL_TILE
-                      ? highlight.type
-                      : tokenType
-                  }
+                  color="#16a34a"
+                  topColor="#ff0000"
+                  className="pot-token"
                 />
-              )}
-              {celebrate && <CoinBurst token={token} />}
+                {position === FINAL_TILE && (
+                  <PlayerToken
+                    photoUrl={photoUrl}
+                    type={
+                      highlight && highlight.cell === FINAL_TILE
+                        ? highlight.type
+                        : tokenType
+                    }
+                  />
+                )}
+                {celebrate && <CoinBurst token={token} />}
+              </div>
+              <div className="logo-wall-main" />
             </div>
-            <div className="logo-wall-main" />
           </div>
         </div>
       </div>
+      <div className="cosmic-frame" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- layer a cosmic background with stars, planets and a comet
- add fixed HUD-style frame overlay
- raise pot z-index so it sits above the overlay

## Testing
- `npm test` *(fails: manifest endpoint and lobby route unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68585d17efc48329898729100071e747