### PR TITLE
Refine cosmic background placement

### DIFF
--- a/webapp/src/components/CosmicBackground.jsx
+++ b/webapp/src/components/CosmicBackground.jsx
@@ -6,7 +6,8 @@ export default function CosmicBackground({ full = false }) {
 
   const stars = useMemo(() => {
     return Array.from({ length: starCount }).map(() => ({
-      top: Math.random() * (full ? 100 : 40),
+      // Bias positions toward the top of the screen
+      top: Math.pow(Math.random(), 2) * (full ? 100 : 40),
       left: Math.random() * 100,
       size: 1 + Math.random() * 2,
       dur: 1.5 + Math.random() * 2,
@@ -17,7 +18,8 @@ export default function CosmicBackground({ full = false }) {
 
   const comets = useMemo(() => {
     return Array.from({ length: cometCount }).map(() => ({
-      top: Math.random() * (full ? 100 : 40),
+      // Bias start positions near the logo area at the top
+      top: Math.pow(Math.random(), 2) * (full ? 100 : 40),
       left: Math.random() * 100,
       dur: 6 + Math.random() * 4,
       delay: Math.random() * 10,

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -830,7 +830,7 @@ body {
   inset: 0;
   overflow: hidden;
   pointer-events: none;
-  z-index: -1;
+  z-index: 0;
 }
 .cosmic-bg.top-only {
   height: 50%;


### PR DESCRIPTION
## Summary
- adjust star and comet positions to bias toward upper screen area
- keep cosmic overlay behind UI elements by z-index

## Testing
- `npm test` *(fails: manifest endpoint not reachable / cannot find dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_6858dd13ce08832987f6c7c6a0d08534