### PR TITLE
Add neon cyan framing overlay

### DIFF
--- a/webapp/src/components/NeonFrame.jsx
+++ b/webapp/src/components/NeonFrame.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+
+export default function NeonFrame({ boardRef, containerRef }) {
+  const [rect, setRect] = useState(null);
+
+  useEffect(() => {
+    const update = () => {
+      if (boardRef?.current) {
+        setRect(boardRef.current.getBoundingClientRect());
+      }
+    };
+    update();
+    window.addEventListener('resize', update);
+    const c = containerRef?.current;
+    c?.addEventListener('scroll', update);
+    return () => {
+      window.removeEventListener('resize', update);
+      c?.removeEventListener('scroll', update);
+    };
+  }, [boardRef, containerRef]);
+
+  if (!rect) return null;
+
+  const width = 8;
+  const offset = 10;
+  const left = rect.left - offset;
+  const right = rect.right + offset - width;
+  const top = Math.max(rect.top - offset, 0);
+  const bottom = rect.bottom + offset;
+
+  const baseStyle = {
+    position: 'fixed',
+    backgroundColor: '#0ff',
+    boxShadow: '0 0 8px #0ff, 0 0 16px #0ff',
+    pointerEvents: 'none',
+    zIndex: 1000,
+  };
+
+  return (
+    <>
+      <div
+        style={{
+          ...baseStyle,
+          width: `${width}px`,
+          height: `${bottom}px`,
+          left: `${left}px`,
+          top: 0,
+        }}
+      />
+      <div
+        style={{
+          ...baseStyle,
+          width: `${width}px`,
+          height: `${bottom}px`,
+          left: `${right}px`,
+          top: 0,
+        }}
+      />
+      <div
+        style={{
+          ...baseStyle,
+          height: `${width}px`,
+          width: `${right - left + width}px`,
+          left: `${left}px`,
+          top: `${top}px`,
+        }}
+      />
+    </>
+  );
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -14,6 +14,7 @@ import { useNavigate } from "react-router-dom";
 import { getTelegramId, getTelegramPhotoUrl } from "../../utils/telegram.js";
 import { fetchTelegramInfo, getProfile } from "../../utils/api.js";
 import PlayerToken from "../../components/PlayerToken.jsx";
+import NeonFrame from "../../components/NeonFrame.jsx";
 
 const PLAYERS = 4;
 // Adjusted board dimensions to show five columns
@@ -63,6 +64,7 @@ function Board({
   diceCells,
 }) {
   const containerRef = useRef(null);
+  const boardRef = useRef(null);
   const [cellWidth, setCellWidth] = useState(80);
   const [cellHeight, setCellHeight] = useState(40);
   const tiles = [];
@@ -252,12 +254,14 @@ function Board({
   const paddingBottom = '15vh';
 
   return (
-    <div className="flex justify-center items-center w-screen overflow-hidden">
-      <div
-        ref={containerRef}
-        className="overflow-y-auto"
-        style={{
-          overflowX: "hidden",
+    <>
+      <NeonFrame boardRef={boardRef} containerRef={containerRef} />
+      <div className="flex justify-center items-center w-screen overflow-hidden">
+        <div
+          ref={containerRef}
+          className="overflow-y-auto"
+          style={{
+            overflowX: "hidden",
           height: "100vh",
           overscrollBehaviorY: "contain",
           paddingTop,
@@ -266,6 +270,7 @@ function Board({
       >
         <div className="snake-board-tilt">
           <div
+            ref={boardRef}
             className="snake-board-grid grid gap-x-1 gap-y-2 relative mx-auto"
             style={{
               width: `${cellWidth * COLS}px`,
@@ -312,6 +317,7 @@ function Board({
         </div>
       </div>
     </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add NeonFrame component to render neon cyan frame around the board
- use NeonFrame in Snake and Ladder board page

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6858e5847898832983109f4e165c93e7