### PR TITLE
Add neon lines to board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -823,3 +823,35 @@ body {
     transform: translateZ(6px) rotate(360deg);
   }
 }
+
+/* Neon edge lines for the Snake & Ladder board */
+.neon-edge-line {
+  position: absolute;
+  background-color: #1affff;
+  box-shadow: 0 0 12px rgba(26, 255, 255, 0.7);
+  pointer-events: none;
+  transform: translateZ(4px);
+  z-index: 1;
+}
+
+.neon-left,
+.neon-right {
+  top: 2px;
+  bottom: 2px;
+  width: 0.6rem;
+}
+
+.neon-left {
+  left: 2px;
+}
+
+.neon-right {
+  right: 2px;
+}
+
+.neon-bottom {
+  left: 2px;
+  right: 2px;
+  bottom: 2px;
+  height: 0.6rem;
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -308,6 +308,9 @@ function Board({
               {celebrate && <CoinBurst token={token} />}
             </div>
             <div className="logo-wall-main" />
+            <div className="neon-edge-line neon-left" />
+            <div className="neon-edge-line neon-right" />
+            <div className="neon-edge-line neon-bottom" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add neon edge lines on top of the Snake and Ladder board
- style neon lines to glow and align with board perspective

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_6858ea9736ac83298b2baf4d2df2ec64