### PR TITLE
Update frame overlay

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -827,12 +827,13 @@ body {
 /* Neon edge lines for the Snake & Ladder board */
 .neon-edge-line {
   position: absolute;
-  background-color: #1affff;
-  box-shadow: 0 0 12px rgba(26, 255, 255, 0.7);
+  background-color: var(--side-color, #facc15);
+  box-shadow: 0 0 12px rgba(250, 204, 21, 0.7);
   pointer-events: none;
   transform: translateZ(4px);
-  z-index: 1;
+  z-index: 3;
 }
+
 
 .neon-left,
 .neon-right {
@@ -843,10 +844,12 @@ body {
 
 .neon-left {
   left: 2px;
+  clip-path: polygon(0 0, 100% 0, 80% 100%, 0 100%);
 }
 
 .neon-right {
   right: 2px;
+  clip-path: polygon(20% 100%, 100% 100%, 100% 0, 0 0);
 }
 
 .neon-bottom {


### PR DESCRIPTION
## Summary
- adjust neon edge frame colors to match board
- taper side lines with clip-path so frame widens at the top

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6858ee3eba788329999a75cf82092097