### PR TITLE
Refine board frame alignment

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -837,24 +837,33 @@ body {
 
 .neon-left,
 .neon-right {
-  top: 2px;
-  bottom: 2px;
+  top: 0;
+  bottom: 0;
   width: 0.6rem;
 }
 
+
 .neon-left {
-  left: 2px;
-  clip-path: polygon(0 0, 100% 0, 80% 100%, 0 100%);
+  left: 0;
+  clip-path: polygon(0 0, 100% 0, 55% 100%, 0 100%);
 }
 
+
 .neon-right {
-  right: 2px;
-  clip-path: polygon(20% 100%, 100% 100%, 100% 0, 0 0);
+  right: 0;
+  clip-path: polygon(45% 100%, 100% 100%, 100% 0, 0 0);
 }
 
 .neon-bottom {
-  left: 2px;
-  right: 2px;
-  bottom: 2px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 0.6rem;
+}
+
+.neon-top {
+  left: 0;
+  right: 0;
+  top: 0;
   height: 0.6rem;
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -310,6 +310,7 @@ function Board({
             <div className="logo-wall-main" />
             <div className="neon-edge-line neon-left" />
             <div className="neon-edge-line neon-right" />
+            <div className="neon-edge-line neon-top" />
             <div className="neon-edge-line neon-bottom" />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- tune neon frame overlay so it properly encloses the board
- add top edge to the frame

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6858f2b6d9188329a452258d9aef44a5