### PR TITLE
Fix board frame tilt

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -830,7 +830,8 @@ body {
   background-color: var(--side-color, #facc15);
   box-shadow: 0 0 12px rgba(250, 204, 21, 0.7);
   pointer-events: none;
-  transform: translateZ(4px);
+  /* Match the board tilt so the frame hugs the board surface */
+  transform: translateZ(4px) rotateX(var(--board-angle, 70deg));
   z-index: 3;
 }
 


### PR DESCRIPTION
## Summary
- align the neon frame angle with the board tilt

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6858f54fe678832999f1df8879cdf526