### PR TITLE
Adjust board lines and start icon style

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -514,8 +514,9 @@ body {
 }
 
 .cell-icon {
-  font-size: 1.5rem; /* slightly larger for better visibility */
+  font-size: 1.7rem; /* tiny bit bigger */
   line-height: 1;
+  color: #333; /* dark grey */
 }
 
 .cell-offset {
@@ -825,9 +826,9 @@ body {
 }
 
 .board-line-top {
-  top: 0;
+  bottom: 0;
 }
 
 .board-line-bottom {
-  bottom: 0;
+  top: 0;
 }


### PR DESCRIPTION
## Summary
- swap top and bottom board highlight lines
- enlarge the starting icon slightly and color it dark grey

## Testing
- `npm test` *(fails: snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_6858fdf7f1888329b9a5fc38b168cd69