### PR TITLE
Adjust start icon size and remove top board line

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -521,7 +521,7 @@ body {
 
 /* Start cell icon tweaks */
 .board-cell[data-cell="1"] .cell-icon {
-  font-size: 2.2rem; /* 30% bigger */
+  font-size: 2.5rem; /* slightly larger */
   display: inline-block;
   transform: rotate(45deg); /* keep centred while rotated */
 }
@@ -832,11 +832,6 @@ body {
   z-index: 3;
 }
 
-.board-line-top {
-  bottom: 0.25rem; /* move slightly upward */
-  left: -0.5rem;
-  right: -0.5rem; /* make a bit wider */
-}
 
 .board-line-bottom {
   top: 0.25rem; /* move slightly down */

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -312,7 +312,6 @@ function Board({
               {celebrate && <CoinBurst token={token} />}
             </div>
             <div className="logo-wall-main" />
-            <div className="board-line board-line-top" />
             <div className="board-line board-line-bottom" />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- enlarge start cell hex icon
- remove duplicate board highlight line

## Testing
- `npm test` *(fails: manifest endpoint/lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859042d14d08329917e24d5bce6d10c