### PR TITLE
Restore board highlight lines

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -832,8 +832,15 @@ body {
   z-index: 3;
 }
 
+.board-line-top {
+  bottom: 0.5rem; /* raise above the top row */
+  left: -0.75rem;
+  right: -0.75rem; /* extend slightly wider */
+}
+
 
 .board-line-bottom {
   top: 0.25rem; /* move slightly down */
-  right: -0.25rem; /* shift a touch to the right */
+  left: -0.25rem;
+  right: -0.25rem; /* span width of the bottom row */
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -312,6 +312,7 @@ function Board({
               {celebrate && <CoinBurst token={token} />}
             </div>
             <div className="logo-wall-main" />
+            <div className="board-line board-line-top" />
             <div className="board-line board-line-bottom" />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- bring back top highlight line and update board line widths

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859092676188329b272901ee3c3ac81