### PR TITLE
Swap board lines

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -833,14 +833,16 @@ body {
 }
 
 .board-line-top {
-  bottom: 0.5rem; /* raise above the top row */
-  left: -0.75rem;
-  right: -0.75rem; /* extend slightly wider */
+  /* swapped position with the bottom line */
+  top: 0.25rem; /* move slightly down */
+  left: -0.25rem;
+  right: -0.25rem; /* span width of the bottom row */
 }
 
 
 .board-line-bottom {
-  top: 0.25rem; /* move slightly down */
-  left: -0.25rem;
-  right: -0.25rem; /* span width of the bottom row */
+  /* swapped position with the top line */
+  bottom: 0.5rem; /* raise above the top row */
+  left: -0.75rem;
+  right: -0.75rem; /* extend slightly wider */
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -312,8 +312,9 @@ function Board({
               {celebrate && <CoinBurst token={token} />}
             </div>
             <div className="logo-wall-main" />
-            <div className="board-line board-line-top" />
+            {/* Swapped the board line order */}
             <div className="board-line board-line-bottom" />
+            <div className="board-line board-line-top" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- swap the board line DOM order
- swap the board line sizing in CSS

## Testing
- `npm test` *(fails: manifest endpoint/lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68590c0a85188329bcd2b4dc47765ffd