### PR TITLE
Update board background and token indicator

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -59,8 +59,8 @@ body {
   top: 50%;
   left: 50%;
   /* slightly taller backdrop */
-  width: calc(var(--board-height) * 1.2);
-  height: calc(var(--board-width) * 1.5);
+  width: calc(var(--board-height) * 1.4);
+  height: calc(var(--board-width) * 1.8);
   /* keep bottom in place by shifting upward */
   transform: translate(-50%, -60%) rotate(90deg) translateZ(-1px);
   transform-origin: center;
@@ -73,7 +73,7 @@ body {
   /* Expand the bottom of the backdrop so it extends beyond the board */
   /* Make the top even wider next to the logo and taper the bottom */
   /* Narrow top edge and widen bottom edge for a stronger perspective */
-  clip-path: polygon(-30% 0%, 130% 0%, 180% 100%, -80% 100%);
+  clip-path: polygon(-40% 0%, 140% 0%, 190% 100%, -90% 100%);
   pointer-events: none;
   z-index: 0;
   background: linear-gradient(
@@ -507,7 +507,7 @@ body {
 
 /* Rotate the start cell icon in place */
 .board-cell[data-cell="1"] .cell-marker {
-  animation: start-rotate 4s linear infinite;
+  animation: none;
   transform: translate(-50%, -50%);
 }
 
@@ -780,7 +780,6 @@ body {
   inset: 6px;
   background-color: #555;
   clip-path: polygon(50% 0%, 93% 25%, 93% 75%, 50% 100%, 7% 75%, 7% 25%);
-  animation: hex-spin 4s linear infinite;
   transform: translateZ(6px);
   pointer-events: none;
   z-index: 0;
@@ -794,7 +793,6 @@ body {
   clip-path: polygon(50% 0%, 93% 25%, 93% 75%, 50% 100%, 7% 75%, 7% 25%);
   /* match the board tilt */
   transform: translateZ(0) rotateX(var(--board-angle, 70deg));
-  animation: hex-spin-reverse 10.5s linear infinite;
   pointer-events: none;
   z-index: 0;
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -175,11 +175,14 @@ function Board({
             </span>
           )}
           {position === num && (
-            <PlayerToken
-              photoUrl={photoUrl}
-              type={isHighlight ? highlight.type : tokenType}
-              className={isJump ? "jump" : ""}
-            />
+            <>
+              {position > 0 && <span className="token-hexagon" />}
+              <PlayerToken
+                photoUrl={photoUrl}
+                type={isHighlight ? highlight.type : tokenType}
+                className={isJump ? "jump" : ""}
+              />
+            </>
           )}
           {offsetPopup && offsetPopup.cell === num && (
             <span
@@ -300,14 +303,17 @@ function Board({
                 className="pot-token"
               />
               {position === FINAL_TILE && (
-                <PlayerToken
-                  photoUrl={photoUrl}
-                  type={
-                    highlight && highlight.cell === FINAL_TILE
-                      ? highlight.type
-                      : tokenType
-                  }
-                />
+                <>
+                  <span className="token-hexagon" />
+                  <PlayerToken
+                    photoUrl={photoUrl}
+                    type={
+                      highlight && highlight.cell === FINAL_TILE
+                        ? highlight.type
+                        : tokenType
+                    }
+                  />
+                </>
               )}
               {celebrate && <CoinBurst token={token} />}
             </div>


### PR DESCRIPTION
## Summary
- enlarge the snake & ladder board gradient background
- stop hexagon decorations from spinning
- show a hexagon indicator with the token

## Testing
- `npm test --silent` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68593a03d5d88329a2daaf26a0e7cc50