### PR TITLE
Adjust cosmic background layering and icon sizing

### DIFF
--- a/webapp/src/components/CosmicBackground.jsx
+++ b/webapp/src/components/CosmicBackground.jsx
@@ -84,9 +84,9 @@ export default function CosmicBackground() {
   }, []);
 
   return (
-    <div className="fixed inset-0 pointer-events-none z-0">
+    <div className="fixed inset-0 pointer-events-none -z-10">
       <canvas id="space-bg" ref={canvasRef} className="w-full h-full" />
-      <div className="absolute top-10 left-10 text-4xl">🌙 🪐</div>
+      <div className="absolute top-4 right-4 flex space-x-2 text-xl">🌙 🪐</div>
     </div>
   );
 }

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -86,7 +86,7 @@ export default function Home() {
               alt="profile"
               className="w-36 h-36 hexagon border-4 border-brand-gold -mt-[20%] mb-3 object-cover"
             />
-            <span className="absolute -right-10 top-1/2 -translate-y-1/2 text-3xl">{globe}</span>
+            <span className="absolute -right-6 top-1/2 -translate-y-1/2 text-xl">{globe}</span>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- push the CosmicBackground behind other content
- reposition moon and planet icons to top-right and shrink them
- shrink the globe icon on the profile

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685947e255908329b83beeb13a932e9a