### PR TITLE
Update dice and performance

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -96,7 +96,7 @@ function DiceCube({
   }, [rolling, playSound]);
 
   return (
-    <div className="dice-container perspective-1000 w-20 h-20">
+    <div className="dice-container perspective-1000 w-16 h-16">
       <div
         className={`dice-cube relative w-full h-full transition-transform duration-500 transform-style-preserve-3d ${
           rolling ? "animate-roll" : ""

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import confetti from 'canvas-confetti';
 
 interface RewardPopupProps {
   reward: number | null;
@@ -10,7 +9,9 @@ interface RewardPopupProps {
 export default function RewardPopup({ reward, onClose, message }: RewardPopupProps) {
   if (reward === null) return null;
   useEffect(() => {
-    confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
+    import('canvas-confetti').then(({ default: confetti }) =>
+      confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } })
+    );
   }, []);
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -111,7 +111,7 @@ body {
 }
 
 .dice-cube {
-  @apply relative w-12 h-12 bg-white rounded-xl;
+  @apply relative w-10 h-10 bg-white rounded-xl;
   border: none;
   transform-style: preserve-3d;
   transition: transform 0.5s;
@@ -123,26 +123,26 @@ body {
 }
 
 .dice-face .dot {
-  @apply w-2 h-2 bg-black rounded-full;
+  @apply w-1.5 h-1.5 bg-black rounded-full;
 }
 
 .dice-face--front {
-  transform: rotateY(0deg) translateZ(1.5rem);
+  transform: rotateY(0deg) translateZ(1.25rem);
 }
 .dice-face--back {
-  transform: rotateY(180deg) translateZ(1.5rem);
+  transform: rotateY(180deg) translateZ(1.25rem);
 }
 .dice-face--right {
-  transform: rotateY(90deg) translateZ(1.5rem);
+  transform: rotateY(90deg) translateZ(1.25rem);
 }
 .dice-face--left {
-  transform: rotateY(-90deg) translateZ(1.5rem);
+  transform: rotateY(-90deg) translateZ(1.25rem);
 }
 .dice-face--top {
-  transform: rotateX(90deg) translateZ(1.5rem);
+  transform: rotateX(90deg) translateZ(1.25rem);
 }
 .dice-face--bottom {
-  transform: rotateX(-90deg) translateZ(1.5rem);
+  transform: rotateX(-90deg) translateZ(1.25rem);
 }
 
 .board-cell {
@@ -221,7 +221,7 @@ body {
 }
 
 .token-dice .dice-face .dot {
-  @apply w-2 h-2 bg-black;
+  @apply w-1.5 h-1.5 bg-black;
 }
 
 /* Three.js token container */
@@ -503,7 +503,7 @@ body {
   /* slightly bigger starting hexagon */
   font-size: 4.8rem;
   display: inline-block;
-  transform: rotate(45deg);
+  transform: none;
 }
 
 /* Rotate the start cell icon in place */

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1,5 +1,4 @@
-import { useState, useEffect, useRef } from "react";
-import confetti from "canvas-confetti";
+import React, { useState, useEffect, useRef } from "react";
 import DiceRoller from "../../components/DiceRoller.jsx";
 import { dropSound, snakeSound, ladderSound } from "../../assets/soundData.js";
 import InfoPopup from "../../components/InfoPopup.jsx";
@@ -44,9 +43,9 @@ function CoinBurst({ token }) {
       ))}
     </div>
   );
-}
+});
 
-function Board({
+const Board = React.memo(function Board({
   position,
   highlight,
   trail,
@@ -484,7 +483,7 @@ export default function SnakeAndLadder() {
       : values;
 
     setRollResult(value);
-    setTimeout(() => setRollResult(null), 1800);
+    setTimeout(() => setRollResult(null), 1500);
 
     setTimeout(() => {
       setDiceVisible(false);
@@ -627,7 +626,9 @@ export default function SnakeAndLadder() {
           setMessage(`You win ${pot} ${token}!`);
           setMessageColor("");
           winSoundRef.current?.play().catch(() => {});
-          confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
+          import("canvas-confetti").then(({ default: confetti }) =>
+            confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } })
+          );
           setCelebrate(true);
           setTimeout(() => {
             setCelebrate(false);
@@ -653,7 +654,7 @@ export default function SnakeAndLadder() {
       };
 
       moveSeq(steps, "normal", () => applyEffect(target));
-    }, 1800);
+    }, 1500);
   };
 
   return (


### PR DESCRIPTION
## Summary
- reduce dice cube size and matching dot sizes
- undo start tile icon rotation
- defer confetti load for faster startup and memoize board
- shorten dice result display to 1.5s

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859580701bc8329818baa01cfe8fff1