### PR TITLE
UI tweaks for Snake & Ladder

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -503,7 +503,7 @@ body {
   /* slightly bigger starting hexagon */
   font-size: 4.8rem;
   display: inline-block;
-  transform: rotate(45deg);
+  transform: none;
 }
 
 /* Rotate the start cell icon in place */
@@ -608,12 +608,19 @@ body {
   text-shadow: 0 0 2px #000;
 }
 
+.roll-result {
+  color: #ffffff;
+  font-family: "Comic Sans MS", "Comic Sans", cursive;
+  font-weight: bold;
+  text-shadow: 0 0 2px #000;
+}
+
 .pot-cell {
   @apply absolute flex flex-col items-center justify-center;
   width: calc(var(--cell-width) * 2.7);
   height: calc(var(--cell-height) * 2.7);
   /* move the pot nearer to the board */
-  top: calc(var(--cell-height) * -6);
+  top: calc(var(--cell-height) * -4);
   left: 50%;
   transform: translateX(-50%) translateZ(12px);
   z-index: 50;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -484,7 +484,7 @@ export default function SnakeAndLadder() {
       : values;
 
     setRollResult(value);
-    setTimeout(() => setRollResult(null), 1800);
+    setTimeout(() => setRollResult(null), 1500);
 
     setTimeout(() => {
       setDiceVisible(false);
@@ -653,7 +653,7 @@ export default function SnakeAndLadder() {
       };
 
       moveSeq(steps, "normal", () => applyEffect(target));
-    }, 1800);
+    }, 1500);
   };
 
   return (
@@ -697,14 +697,9 @@ export default function SnakeAndLadder() {
         tokenType={tokenType}
         diceCells={diceCells}
       />
-      {message && (
-        <div className={`text-center font-semibold w-full ${messageColor}`}>
-          {message}
-        </div>
-      )}
       {rollResult !== null && (
         <div className="fixed bottom-44 inset-x-0 flex justify-center z-30 pointer-events-none">
-          <div className="text-6xl italic font-bold">{rollResult}</div>
+          <div className="text-6xl roll-result">{rollResult}</div>
         </div>
       )}
       {diceVisible && (
@@ -721,7 +716,13 @@ export default function SnakeAndLadder() {
           {turnMessage && (
             <div className="mt-2 turn-message">{turnMessage}</div>
           )}
+          {message === 'Need a 6 to start!' && (
+            <div className={`mt-1 turn-message ${messageColor}`}>{message}</div>
+          )}
         </div>
+      )}
+      {message && message !== 'Need a 6 to start!' && (
+        <div className={`text-center font-semibold w-full ${messageColor}`}>{message}</div>
       )}
       <InfoPopup
         open={showInfo}


### PR DESCRIPTION
## Summary
- keep starting icon upright
- shorten dice display delay
- move pot slightly closer
- show "Need a 6 to start!" under the turn message
- style roll result text

## Testing
- `npm test` *(fails: Cannot find package 'dotenv', manifest and lobby route tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68595f48f0b483298522068d79e89c0c