### PR TITLE
Update board visuals

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -76,18 +76,26 @@ body {
   clip-path: polygon(-35% 0%, 135% 0%, 185% 100%, -85% 100%);
   pointer-events: none;
   z-index: 0;
-  background: linear-gradient(
-    to top,
-    #000a1f,
-    #123840,
-    #1f4d58 20%,
-    #d9cec2 40%,
-    #f3f0e8 50%,
-    #b95741 60%,
-    #e7b382 80%,
-    #4c050d,
-    #220003
-  );
+  background:
+    linear-gradient(
+      to right,
+      rgba(0, 0, 0, 0.5),
+      rgba(0, 0, 0, 0) 30%,
+      rgba(0, 0, 0, 0) 70%,
+      rgba(0, 0, 0, 0.5)
+    ),
+    linear-gradient(
+      to top,
+      #000a1f,
+      #123840,
+      #1f4d58 20%,
+      #d9cec2 40%,
+      #f3f0e8 50%,
+      #b95741 60%,
+      #e7b382 80%,
+      #4c050d,
+      #220003
+    );
 }
 
 @keyframes roll {
@@ -513,6 +521,10 @@ body {
   transform-style: preserve-3d;
 }
 
+.start-rotate {
+  animation: start-rotate 6s linear infinite;
+}
+
 /* Center the start cell number inside the enlarged hexagon */
 .board-cell[data-cell="1"] .cell-number {
   transform: translateY(0);
@@ -620,7 +632,7 @@ body {
   width: calc(var(--cell-width) * 2.7);
   height: calc(var(--cell-height) * 2.7);
   /* move the pot nearer to the board */
-  top: calc(var(--cell-height) * -4);
+  top: calc(var(--cell-height) * -3.5);
   left: 50%;
   transform: translateX(-50%) translateZ(12px);
   z-index: 50;


### PR DESCRIPTION
## Summary
- add rotating start icon
- darken gradient edges for a smoother look
- lower the pot position slightly

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859627e3bcc8329ae5009d827578e60