### PR TITLE
Fix board UI overlay and restore start icon

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -26,6 +26,8 @@ export default function Layout({ children }) {
 
   );
 
+  const showFooter = !location.pathname.startsWith('/games/');
+
   return (
 
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
@@ -52,7 +54,7 @@ export default function Layout({ children }) {
 
       )}
 
-      <Footer />
+      {showFooter && <Footer />}
 
     </div>
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -511,7 +511,7 @@ body {
   /* slightly bigger starting hexagon */
   font-size: 4.8rem;
   display: inline-block;
-  transform: none;
+  transform: rotate(45deg);
 }
 
 /* Rotate the start cell icon in place */


### PR DESCRIPTION
## Summary
- hide footer on game pages
- rotate starting hexagon icon again

## Testing
- `npm test` *(fails: manifest and lobby route unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685966295a0883299380442cf7a75829