### PR TITLE
Improve instructions for Telegram launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ correct `https://` URL.
 
 Wallet features rely on `window.Telegram.WebApp.initData` being set by the
 Telegram client. Make sure you open the WebApp via a Telegram link containing
-`?startapp=<payload>` so `initData` is populated. Otherwise the wallet screens
-may appear blank or fail to connect.
+`?startapp=<payload>` so `initData` is populated. If you see a blank (black)
+wallet screen it usually means the page wasn't opened from Telegram. Use the
+link provided by the bot or the *Open in Telegram* button to launch the WebApp.
 
 ### Wallet overview
 

--- a/webapp/src/components/OpenInTelegram.jsx
+++ b/webapp/src/components/OpenInTelegram.jsx
@@ -11,7 +11,10 @@ export default function OpenInTelegram() {
 
     <div className="p-4 text-text">
 
-      <p>Please open this application via the Telegram bot.</p>
+      <p>
+        This page only works from within Telegram. If you see a blank wallet
+        screen, open the WebApp using the bot link below.
+      </p>
 
       <a
 


### PR DESCRIPTION
## Summary
- clarify troubleshooting notes in README about launching from Telegram
- improve the `OpenInTelegram` message so users know how to open the webapp

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685972546ea88329b50dde5516d590a1