### PR TITLE
Add wallet reset actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ This app exposes two separate wallets:
   token is valid. Users must interact with the bot in Telegram to receive
   messages.
 
+### Resetting TonConnect and TPC wallet
+
+Use these options if you need to completely start over:
+
+1. Open the wallet page in the webapp.
+2. Click **Reset TonConnect** to remove the saved wallet address and disconnect.
+   The page reloads so you can connect again from scratch.
+3. Click **Reset TPC Wallet** to erase your off-chain balance and transaction
+   history stored in MongoDB. Your TPC balance will be set to zero.
+
+After resetting you can reconnect and deposit again as if it were a new account.
+
 ## Telegram game bots
 
 Several small Telegram game bots are included in this repository. They use

--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -351,4 +351,29 @@ router.post('/transactions', authenticate, async (req, res) => {
 
 });
 
+// Reset TPC wallet balance and history
+router.post('/reset', authenticate, async (req, res) => {
+  const { telegramId } = req.body;
+  const authId = req.auth?.telegramId;
+  if (!telegramId) {
+    return res.status(400).json({ error: 'telegramId required' });
+  }
+  if (!authId || telegramId !== authId) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  try {
+    const user = await User.findOne({ telegramId });
+    if (user) {
+      user.balance = 0;
+      user.minedTPC = 0;
+      user.transactions = [];
+      await user.save();
+    }
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('Failed to reset wallet:', err.message);
+    res.status(500).json({ error: 'failed to reset wallet' });
+  }
+});
+
 export default router;

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -6,7 +6,8 @@ import {
   getTransactions,
   getDepositAddress,
   deposit,
-  withdraw
+  withdraw,
+  resetTpcWallet
 } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import OpenInTelegram from '../components/OpenInTelegram.jsx';
@@ -138,6 +139,23 @@ export default function Wallet() {
     }
   };
 
+  const handleResetTpc = async () => {
+    if (!window.confirm('Reset your TPC wallet? This will delete all balance and transactions.')) return;
+    const res = await resetTpcWallet(telegramId);
+    if (res?.error) {
+      alert(res.error);
+      return;
+    }
+    setTpcBalance(0);
+    setTransactions([]);
+  };
+
+  const handleResetTonConnect = () => {
+    localStorage.removeItem('walletAddress');
+    if (tonConnectUI.disconnect) tonConnectUI.disconnect();
+    window.location.reload();
+  };
+
   return (
     <div className="p-4 space-y-4">
       <h2 className="text-xl font-bold">Wallet</h2>
@@ -196,6 +214,12 @@ export default function Wallet() {
           >
             Copy Account Number
           </button>
+          <button
+            onClick={handleResetTpc}
+            className="mt-1 px-3 py-1 bg-red-600 text-white rounded"
+          >
+            Reset TPC Wallet
+          </button>
         </div>
       </div>
 
@@ -244,6 +268,12 @@ export default function Wallet() {
             className="mt-1 px-3 py-1 bg-yellow-600 text-white rounded"
           >
             Withdraw
+          </button>
+          <button
+            onClick={handleResetTonConnect}
+            className="mt-1 px-3 py-1 bg-red-600 text-white rounded"
+          >
+            Reset TonConnect
           </button>
         </div>
       </div>

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -291,3 +291,7 @@ export function pinWallPost(postId, telegramId, pinned) {
 export function listTrendingPosts(limit = 20) {
   return post('/api/social/wall/trending', { limit });
 }
+
+export function resetTpcWallet(telegramId) {
+  return post('/api/wallet/reset', { telegramId });
+}


### PR DESCRIPTION
## Summary
- add `/wallet/reset` backend route for clearing balance and transactions
- expose `resetTpcWallet` helper in the webapp API
- add reset buttons on the wallet page for TonConnect and TPC wallet
- document how to reset wallets in README

## Testing
- `npm test` *(fails: manifest endpoint and snake lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859774dd95c83299e4dda566320f564