### PR TITLE
Fix board padding and background

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -34,7 +34,13 @@ export default function Layout({ children }) {
 
       {isHome && <CosmicBackground />}
 
-      <main className={`flex-grow container mx-auto p-4 ${showNavbar ? 'pb-24' : ''}`.trim()}>
+      <main
+        className={`flex-grow ${
+          showNavbar
+            ? 'container mx-auto p-4 pb-24'
+            : 'w-full p-0'
+        }`.trim()}
+      >
 
         {showBranding && <Branding />}
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -56,11 +56,13 @@ body {
 .snake-gradient-bg {
   position: absolute;
   /* rotate the backdrop 90deg so it runs from top to bottom */
-  top: 50%;
+  /* Shift the gradient slightly downward so it covers the starting rows */
+  top: 60%;
   left: 50%;
   /* slightly taller backdrop */
   width: calc(var(--board-height) * 1.3);
-  height: calc(var(--board-width) * 1.7);
+  /* Make the background taller so the bottom rows aren't left bare */
+  height: calc(var(--board-width) * 2);
   /* keep bottom in place by shifting upward */
   /* slightly shift down so the backdrop covers the starting rows */
   transform: translate(-50%, -50%) rotate(90deg) translateZ(0);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -253,7 +253,10 @@ function Board({
 
   // Remove the extra top padding so the first row is immediately visible
   const paddingTop = 0;
-  const paddingBottom = '15vh';
+  // Remove extra bottom padding so the board sits flush with the bottom
+  // of the viewport. This eliminates the black bar underneath the board
+  // when the dice are displayed.
+  const paddingBottom = 0;
 
   return (
     <div className="flex justify-center items-center w-screen overflow-visible">


### PR DESCRIPTION
## Summary
- let snake board fill the viewport bottom
- remove extra padding and container for game pages
- extend snake background downwards so first rows get covered

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68597c6b0d48832991b4f2cdea73a12a