### PR TITLE
Improve board background & AI dice

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -55,15 +55,14 @@ body {
 
 .snake-gradient-bg {
   position: absolute;
-  /* rotate the backdrop 90deg so it runs from top to bottom */
   top: 50%;
   left: 50%;
-  /* slightly taller backdrop */
   width: calc(var(--board-height) * 1.3);
   height: calc(var(--board-width) * 1.7);
-  /* keep bottom in place by shifting upward */
-  /* slightly shift down so the backdrop covers the starting rows */
-  transform: translate(-50%, -50%) rotate(90deg) translateZ(0);
+  transform-style: preserve-3d;
+  /* Align the backdrop with the board's tilt so the lower rows show it */
+  transform: translate(-50%, -50%) rotateX(var(--board-angle, 70deg)) rotate(90deg)
+    translateZ(-2px);
   transform-origin: center;
   /* widen the top of the backdrop while keeping the bottom unchanged */
   /* narrow the bottom of the backdrop so it fits the board */

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import confetti from "canvas-confetti";
 import DiceRoller from "../../components/DiceRoller.jsx";
+import Dice from "../../components/Dice.jsx";
 import { dropSound, snakeSound, ladderSound } from "../../assets/soundData.js";
 import InfoPopup from "../../components/InfoPopup.jsx";
 import GameEndPopup from "../../components/GameEndPopup.jsx";
@@ -355,6 +356,7 @@ export default function SnakeAndLadder() {
   const [turnOrder, setTurnOrder] = useState([]);
   const [initialRolls, setInitialRolls] = useState([]);
   const [setupPhase, setSetupPhase] = useState(true);
+  const [aiRoll, setAiRoll] = useState(null); // { index, value, rolling }
 
   const moveSoundRef = useRef(null);
   const snakeSoundRef = useRef(null);
@@ -678,35 +680,43 @@ export default function SnakeAndLadder() {
 
   const handleAIRoll = (index, fixedValue) => {
     const value = fixedValue ?? Math.floor(Math.random() * 6) + 1;
-    setTurnMessage(`AI ${index} rolled ${value}`);
-    let positions = [...aiPositions];
-    let current = positions[index - 1];
-    let target = current;
-    if (current === 0) {
-      if (value === 6) target = 1;
-    } else if (current === 100) {
-      if (value === 1) target = FINAL_TILE;
-    } else if (current + value <= FINAL_TILE) {
-      target = current + value;
-    }
-    const final = snakes[target]
-      ? snakes[target]
-      : ladders[target]
-        ? typeof ladders[target] === 'object'
-          ? ladders[target].end
-          : ladders[target]
-        : target;
-    positions[index - 1] = final;
-    setAiPositions(positions);
-    if (final === FINAL_TILE) {
-      setMessage(`AI ${index} wins!`);
-      setGameOver(true);
-      setDiceVisible(false);
-      return;
-    }
-    const extra = value === 6 && final !== current;
-    const next = extra ? index : (index + 1) % (ai + 1);
-    setCurrentTurn(next);
+    setAiRoll({ index, value, rolling: true });
+    setTurnMessage(`AI ${index} rolling...`);
+    setTimeout(() => {
+      setAiRoll({ index, value, rolling: false });
+      setTurnMessage(`AI ${index} rolled ${value}`);
+
+      let positions = [...aiPositions];
+      let current = positions[index - 1];
+      let target = current;
+      if (current === 0) {
+        if (value === 6) target = 1;
+      } else if (current === 100) {
+        if (value === 1) target = FINAL_TILE;
+      } else if (current + value <= FINAL_TILE) {
+        target = current + value;
+      }
+      const final = snakes[target]
+        ? snakes[target]
+        : ladders[target]
+          ? typeof ladders[target] === 'object'
+            ? ladders[target].end
+            : ladders[target]
+          : target;
+      positions[index - 1] = final;
+      setAiPositions(positions);
+      if (final === FINAL_TILE) {
+        setMessage(`AI ${index} wins!`);
+        setGameOver(true);
+        setDiceVisible(false);
+        setAiRoll(null);
+        return;
+      }
+      const extra = value === 6 && final !== current;
+      const next = extra ? index : (index + 1) % (ai + 1);
+      setAiRoll(null);
+      setCurrentTurn(next);
+    }, 1500);
   };
 
   useEffect(() => {
@@ -809,6 +819,12 @@ export default function SnakeAndLadder() {
       {rollResult !== null && (
         <div className="fixed bottom-44 inset-x-0 flex justify-center z-30 pointer-events-none">
           <div className="text-6xl roll-result">{rollResult}</div>
+        </div>
+      )}
+      {aiRoll && (
+        <div className="fixed bottom-24 inset-x-0 flex flex-col items-center z-20 pointer-events-none">
+          <Dice values={[aiRoll.value]} rolling={aiRoll.rolling} />
+          <div className="mt-2 turn-message">AI {aiRoll.index} {aiRoll.rolling ? 'rolling...' : `rolled ${aiRoll.value}`}</div>
         </div>
       )}
       {diceVisible && (


### PR DESCRIPTION
## Summary
- tilt snake board backdrop so it's visible under the lower rows
- show dice animation for AI turns in Snake & Ladder game

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68598f37c4808329a097836606034688