### PR TITLE
Improve snake game dice turns

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -2,11 +2,18 @@ import React, { useState, useEffect, useRef } from 'react';
 import Dice from './Dice.jsx';
 import { diceSound } from '../assets/soundData.js';
 
-export default function DiceRoller({ onRollEnd, onRollStart, clickable = false, numDice = 2 }) {
+export default function DiceRoller({
+  onRollEnd,
+  onRollStart,
+  clickable = false,
+  numDice = 2,
+  trigger,
+}) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
   const soundRef = useRef(null);
   const startValuesRef = useRef(values);
+  const triggerRef = useRef(trigger);
 
   useEffect(() => {
     const initial = Array(numDice).fill(1);
@@ -21,6 +28,13 @@ export default function DiceRoller({ onRollEnd, onRollStart, clickable = false, 
       soundRef.current?.pause();
     };
   }, []);
+
+  useEffect(() => {
+    if (trigger !== undefined && trigger !== triggerRef.current) {
+      triggerRef.current = trigger;
+      rollDice();
+    }
+  }, [trigger]);
 
   const rollDice = () => {
     if (rolling) return;


### PR DESCRIPTION
## Summary
- update DiceRoller to support automatic rolls via `trigger`
- show dice rolls for AI players in Snake & Ladder

## Testing
- `npm test` *(fails: manifest endpoint and snake lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859930905cc832999b8091e4f49dffd