### PR TITLE
Fix turn after failed starting roll

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -549,8 +549,10 @@ export default function SnakeAndLadder() {
         if (rolledSix) target = 1;
         else {
           setMessage("Need a 6 to start!");
-          setTurnMessage("Your turn");
-          setDiceVisible(true);
+          setTurnMessage("");
+          setDiceVisible(false);
+          const next = (currentTurn + 1) % (ai + 1);
+          setTimeout(() => setCurrentTurn(next), 1500);
           return;
         }
       } else if (current + value <= FINAL_TILE) {


### PR DESCRIPTION
## Summary
- show AI's next turn if the player fails to roll a six when starting in Snake & Ladder

## Testing
- `npm test` *(fails: manifest endpoint not reachable, lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685996cc53688329bb7d25cf965bc83d