### PR TITLE
Hide AI dice button

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -8,6 +8,7 @@ export default function DiceRoller({
   clickable = false,
   numDice = 2,
   trigger,
+  showButton = true,
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -83,7 +84,7 @@ export default function DiceRoller({
       >
         <Dice values={values} rolling={rolling} startValues={startValuesRef.current} />
       </div>
-      {!clickable && (
+      {!clickable && showButton && (
         <button
           onClick={rollDice}
           disabled={rolling}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -875,6 +875,7 @@ export default function SnakeAndLadder() {
             clickable={!aiRollingIndex}
             numDice={diceCount + bonusDice}
             trigger={aiRollingIndex ? aiRollTrigger : undefined}
+            showButton={!aiRollingIndex}
           />
           {turnMessage && <div className="mt-2 turn-message">{turnMessage}</div>}
           {message === 'Need a 6 to start!' && (


### PR DESCRIPTION
## Summary
- add a `showButton` prop to `DiceRoller` so the roll button can be hidden
- hide the roll button on AI turns in Snake & Ladder

## Testing
- `npm test` *(fails: manifest and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859a037805c83298a2667dda70aacf6