### PR TITLE
Add rotating start hex and rolling token highlight

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect } from "react";
 import * as THREE from "three";
 
-export default function HexPrismToken({ color = "#008080", topColor, photoUrl, className = "" }) {
+export default function HexPrismToken({ color = "#008080", topColor, photoUrl, className = "", rolling = false }) {
   const mountRef = useRef(null);
 
   useEffect(() => {
@@ -95,7 +95,11 @@ export default function HexPrismToken({ color = "#008080", topColor, photoUrl, c
   return (
     <div className={`token-three relative ${className}`} ref={mountRef}>
       {photoUrl && (
-        <img src={photoUrl} alt="token" className="token-photo" />
+        <img
+          src={photoUrl}
+          alt="token"
+          className={`token-photo${rolling ? " rolling" : ""}`}
+        />
       )}
     </div>
   );

--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import HexPrismToken from "./HexPrismToken.jsx";
 
-export default function PlayerToken({ type = "normal", color, topColor, photoUrl, className = "" }) {
+export default function PlayerToken({ type = "normal", color, topColor, photoUrl, className = "", rolling = false }) {
   let tokenColor = color;
   if (!tokenColor) {
     if (type === "ladder") tokenColor = "#86efac"; // green
@@ -14,6 +14,7 @@ export default function PlayerToken({ type = "normal", color, topColor, photoUrl
       topColor={topColor}
       photoUrl={photoUrl}
       className={className}
+      rolling={rolling}
     />
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -291,9 +291,14 @@ body {
   object-fit: cover;
   border-radius: 50%;
   border: 2px solid #ffd700;
+  transition: border-color 0.3s ease;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
   pointer-events: none;
   z-index: 1;
+}
+
+.token-photo.rolling {
+  border-color: #16a34a;
 }
 
 .token-cube-inner {
@@ -820,10 +825,12 @@ body {
   position: absolute;
   inset: 6px;
   background-color: #555;
-  clip-path: polygon(50% 0%, 93% 25%, 93% 75%, 50% 100%, 7% 75%, 7% 25%);
+  /* regular hexagon with equal radii */
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
   transform: translateZ(6px);
   pointer-events: none;
   z-index: 0;
+  animation: hex-spin 6s linear infinite;
 }
 
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -76,6 +76,7 @@ function Board({
   token,
   tokenType,
   diceCells,
+  rollingIndex,
 }) {
   const containerRef = useRef(null);
   const [cellWidth, setCellWidth] = useState(80);
@@ -197,6 +198,7 @@ function Board({
                 photoUrl={p.photoUrl}
                 type={p.type || (p.index === 0 ? (isHighlight ? highlight.type : tokenType) : "normal")}
                 color={p.color}
+                rolling={p.index === rollingIndex}
                 className={
                   p.position === 0
                     ? "start"
@@ -381,6 +383,7 @@ export default function SnakeAndLadder() {
   const [setupPhase, setSetupPhase] = useState(true);
   const [aiRollingIndex, setAiRollingIndex] = useState(null);
   const [aiRollTrigger, setAiRollTrigger] = useState(0);
+  const [rollingIndex, setRollingIndex] = useState(null);
 
   const playerName = (idx) => (
     <span style={{ color: playerColors[idx] }}>
@@ -925,6 +928,7 @@ export default function SnakeAndLadder() {
         token={token}
         tokenType={tokenType}
         diceCells={diceCells}
+        rollingIndex={rollingIndex}
       />
       {rollResult !== null && (
         <div className="fixed bottom-44 inset-x-0 flex justify-center z-30 pointer-events-none">
@@ -943,11 +947,15 @@ export default function SnakeAndLadder() {
                 handleRoll(vals);
                 setBonusDice(0);
               }
+              setRollingIndex(null);
             }}
             onRollStart={() =>
-              aiRollingIndex
-                ? setTurnMessage(<>{playerName(aiRollingIndex)} rolling...</>)
-                : setTurnMessage("Rolling...")
+              {
+                setRollingIndex(aiRollingIndex || 0);
+                return aiRollingIndex
+                  ? setTurnMessage(<>{playerName(aiRollingIndex)} rolling...</>)
+                  : setTurnMessage("Rolling...");
+              }
             }
             clickable={!aiRollingIndex}
             numDice={diceCount + bonusDice}


### PR DESCRIPTION
## Summary
- spin the start cell hexagon with a regular polygon clip-path
- change token photo border to green while rolling
- track which player is currently rolling
- highlight active player token during rolls

## Testing
- `npm test` *(fails: server exposes manifest endpoint, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_6859b35f62ec83299e443cc2dfdf65a4