### PR TITLE
Fix hexagon shape and revise dice turn rules

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -823,11 +823,14 @@ body {
 
 .start-hexagon {
   position: absolute;
-  inset: 6px;
+  top: 50%;
+  left: 50%;
+  width: calc(var(--cell-height) - 12px);
+  height: calc(var(--cell-height) - 12px);
   background-color: #555;
   /* regular hexagon with equal radii */
   clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
-  transform: translateZ(6px);
+  transform: translate(-50%, -50%) translateZ(6px);
   pointer-events: none;
   z-index: 0;
   animation: hex-spin 6s linear infinite;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -559,7 +559,6 @@ export default function SnakeAndLadder() {
       setStreak(newStreak);
       let current = pos;
       let target = current;
-      let extraTurn = false;
 
       if (current === 100 && diceCount === 2) {
         if (rolledSix) {
@@ -599,7 +598,7 @@ export default function SnakeAndLadder() {
         return;
       }
 
-      extraTurn = rolledSix && target !== current;
+
 
       const steps = [];
       for (let i = current + 1; i <= target; i++) steps.push(i);
@@ -690,8 +689,8 @@ export default function SnakeAndLadder() {
             setGameOver(true);
           }, 1500);
         }
-        if (diceCells[finalPos]) {
-          const bonus = diceCells[finalPos];
+        const bonus = diceCells[finalPos];
+        if (bonus) {
           setDiceCells((d) => {
             const n = { ...d };
             delete n[finalPos];
@@ -706,7 +705,7 @@ export default function SnakeAndLadder() {
         }
         setDiceVisible(true);
         if (!gameOver) {
-          const next = extraTurn ? currentTurn : (currentTurn + 1) % (ai + 1);
+          const next = bonus ? currentTurn : (currentTurn + 1) % (ai + 1);
           setCurrentTurn(next);
         }
       };
@@ -739,9 +738,6 @@ export default function SnakeAndLadder() {
     } else if (current + value <= FINAL_TILE) {
       target = current + value;
     }
-
-    const rolledSix = value === 6;
-    const extraTurn = rolledSix && target !== current;
 
     const steps = [];
     for (let i = current + 1; i <= target; i++) steps.push(i);
@@ -782,10 +778,26 @@ export default function SnakeAndLadder() {
         setDiceVisible(false);
         return;
       }
-      const next = extraTurn ? index : (index + 1) % (ai + 1);
-      if (next === 0) setTurnMessage('Your turn');
-      setCurrentTurn(next);
-      setDiceVisible(true);
+      const bonus = diceCells[finalPos];
+      if (bonus) {
+        setDiceCells((d) => {
+          const n = { ...d };
+          delete n[finalPos];
+          return n;
+        });
+        setBonusDice(bonus);
+        setTurnMessage(`Bonus roll +${bonus}`);
+        diceRewardSoundRef.current?.play().catch(() => {});
+        setCurrentTurn(index);
+        setDiceVisible(true);
+        setTimeout(() => triggerAIRoll(index), 1000);
+      } else {
+        setBonusDice(0);
+        const next = (index + 1) % (ai + 1);
+        if (next === 0) setTurnMessage('Your turn');
+        setCurrentTurn(next);
+        setDiceVisible(true);
+      }
     };
 
     const applyEffect = (startPos) => {


### PR DESCRIPTION
## Summary
- center start hexagon and maintain 1:1 ratio
- remove extra turns from rolling a six
- keep current player when landing on a bonus dice cell
- trigger AI bonus rolls automatically

## Testing
- `npm test` *(fails: manifest endpoint and lobby route unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859b9b2b8f08329b89d4da2bce84b62