### PR TITLE
Adjust planet icon position

### DIFF
--- a/webapp/src/components/CosmicBackground.jsx
+++ b/webapp/src/components/CosmicBackground.jsx
@@ -109,7 +109,8 @@ export default function CosmicBackground() {
   return (
     <div className="fixed inset-0 pointer-events-none -z-10">
       <canvas id="space-bg" ref={canvasRef} className="w-full h-full" />
-      <div className="absolute top-24 right-4 flex space-x-4 text-xs">🌒 🪐</div>
+      <div className="absolute top-24 right-4 text-xs">🌒</div>
+      <div className="absolute top-28 right-20 text-xs">🪐</div>
       <div className="absolute bottom-4 left-4 text-xs">{globe}</div>
       <div className="absolute top-32 left-1/2 -translate-x-1/2 text-xs">🌍</div>
     </div>


### PR DESCRIPTION
## Summary
- tweak CosmicBackground layout to place the planet icon between moon and earth

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859c6afb7288329a254076943f6c0fd