### PR TITLE
Adjust timer and add Telegram reload via settings

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -307,8 +307,8 @@ body {
 
 .timer-ring {
   position: absolute;
-  width: 3.4rem;
-  height: 3.4rem;
+  width: 3.6rem;
+  height: 3.6rem;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) translateZ(15.2px)

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -356,6 +356,17 @@ function Board({
 
 export default function SnakeAndLadder() {
   useTelegramBackButton();
+  useEffect(() => {
+    const tg = window?.Telegram?.WebApp;
+    if (!tg) return;
+    const handleSettings = () => window.location.reload();
+    tg.SettingsButton.show();
+    tg.onEvent('settingsButtonClicked', handleSettings);
+    return () => {
+      tg.offEvent('settingsButtonClicked', handleSettings);
+      tg.SettingsButton.hide();
+    };
+  }, []);
   const navigate = useNavigate();
   const [pos, setPos] = useState(0);
   const [streak, setStreak] = useState(0);
@@ -950,7 +961,8 @@ export default function SnakeAndLadder() {
 
   useEffect(() => {
     if (setupPhase || gameOver) return;
-    setTimeLeft(15);
+    const maxTime = currentTurn === 0 ? 15 : 3;
+    setTimeLeft(maxTime);
     if (timerRef.current) clearInterval(timerRef.current);
     timerRef.current = setInterval(() => {
       setTimeLeft(t => {
@@ -1025,7 +1037,7 @@ export default function SnakeAndLadder() {
         diceCells={diceCells}
         rollingIndex={rollingIndex}
         currentTurn={currentTurn}
-        timerPct={timeLeft / 15}
+        timerPct={timeLeft / (currentTurn === 0 ? 15 : 3)}
       />
       {rollResult !== null && (
         <div className="fixed bottom-44 inset-x-0 flex justify-center z-30 pointer-events-none">


### PR DESCRIPTION
## Summary
- expose a Telegram settings button that reloads the page
- use shorter 3s timer for AI turns
- make timer indicator slightly larger

## Testing
- `npm test` *(fails: manifest endpoint and lobby route unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685a3ead273c83299c2a85cc3a43087f