### PR TITLE
UI tweaks for Snake & Ladder board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -254,6 +254,10 @@ body {
   transform: translateY(20%) translateZ(32px);
 }
 
+.token-three.small {
+  transform: translateZ(32px) scale(0.25);
+}
+
 @keyframes token-jump {
   0%,
   100% {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -193,10 +193,7 @@ function Board({
           )}
           {players
             .map((p, i) => ({ ...p, index: i }))
-            .filter(
-              (p) =>
-                p.position === num || (p.position === 0 && num === p.index + 1),
-            )
+            .filter((p) => p.position !== 0 && p.position === num)
             .map((p) => (
               <PlayerToken
                 key={p.index}
@@ -991,35 +988,51 @@ export default function SnakeAndLadder() {
 
   return (
     <div className="p-4 pb-32 space-y-4 text-text flex flex-col justify-end items-center relative w-full flex-grow">
-      <div className="absolute top-0 -right-2 flex flex-col items-end space-y-2 p-2 z-20">
-        <button
-          onClick={() => window.location.reload()}
-          className="p-2 flex flex-col items-center"
-        >
-          <AiOutlineReload className="text-xl" />
-          <span className="text-xs">Reload</span>
-        </button>
-        <button
-          onClick={() => setShowInfo(true)}
-          className="p-2 flex flex-col items-center"
-        >
-          <AiOutlineInfoCircle className="text-2xl" />
-          <span className="text-xs">Info</span>
-        </button>
-        <button
-          onClick={() => setShowExitConfirm(true)}
-          className="p-2 flex flex-col items-center"
-        >
-          <AiOutlineLogout className="text-xl" />
-          <span className="text-xs">Exit</span>
-        </button>
-        <button
-          onClick={() => setShowLobbyConfirm(true)}
-          className="p-2 flex flex-col items-center"
-        >
-          <AiOutlineRollback className="text-xl" />
-          <span className="text-xs">Lobby</span>
-        </button>
+      <div className="absolute top-0 right-0 flex flex-col items-end p-2 z-20 space-y-2">
+        <div className="flex space-x-2">
+          <button
+            onClick={() => window.location.reload()}
+            className="p-2 flex flex-col items-center"
+          >
+            <AiOutlineReload className="text-xl" />
+            <span className="text-xs">Reload</span>
+          </button>
+          <button
+            onClick={() => setShowInfo(true)}
+            className="p-2 flex flex-col items-center"
+          >
+            <AiOutlineInfoCircle className="text-2xl" />
+            <span className="text-xs">Info</span>
+          </button>
+          <button
+            onClick={() => setShowExitConfirm(true)}
+            className="p-2 flex flex-col items-center"
+          >
+            <AiOutlineLogout className="text-xl" />
+            <span className="text-xs">Exit</span>
+          </button>
+          <button
+            onClick={() => setShowLobbyConfirm(true)}
+            className="p-2 flex flex-col items-center"
+          >
+            <AiOutlineRollback className="text-xl" />
+            <span className="text-xs">Lobby</span>
+          </button>
+        </div>
+        <div className="flex space-x-2">
+          {players
+            .map((p, i) => ({ ...p, index: i }))
+            .filter((p) => p.position === 0)
+            .map((p) => (
+              <PlayerToken
+                key={`inactive-${p.index}`}
+                photoUrl={p.photoUrl}
+                type={"normal"}
+                color={p.color}
+                className="small"
+              />
+            ))}
+        </div>
       </div>
       <Board
         players={players}


### PR DESCRIPTION
## Summary
- hide tokens off board until game start
- add a row of inactive tokens below menu buttons
- show menu buttons horizontally
- support mini token style

## Testing
- `npm test` *(fails: server exposes manifest endpoint and snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_685a43a9775083299bfb9de5abc0461e