### PR TITLE
Fix board icon display and token size

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -260,8 +260,8 @@ body {
 
 /* Larger token variant used for inactive pieces */
 .token-three.inactive {
-  width: 9rem;
-  height: 9rem;
+  width: 7.2rem;
+  height: 7.2rem;
   transform: translateZ(32px);
 }
 
@@ -551,12 +551,25 @@ body {
   font-size: 1.7rem; /* tiny bit bigger */
   line-height: 1;
   color: #fff; /* ensure visibility */
+  width: 1.7rem;
+  height: 1.7rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cell-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 /* Start cell icon tweaks */
 .board-cell[data-cell="1"] .cell-icon {
   /* slightly bigger starting hexagon */
   font-size: 4.8rem;
+  width: 4.8rem;
+  height: 4.8rem;
   display: inline-block;
   /* keep the icon upright so the animation starts at 0 degrees */
   transform: rotate(0deg);
@@ -725,7 +738,7 @@ body {
 }
 
 .snake-connector {
-  background-image: url("/assets/icons/snake.png");
+  background-image: url("/assets/icons/snake.svg");
   background-size: 100% 100%;
   background-repeat: no-repeat;
   border-radius: 4px;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -145,7 +145,11 @@ function Board({
             : "";
       const cellClass = cellType ? `${cellType}-cell` : "";
       const icon =
-        cellType === "ladder" ? "🪜" : cellType === "snake" ? "🐍" : "";
+        cellType === "ladder"
+          ? "/assets/icons/ladder.png"
+          : cellType === "snake"
+            ? "/assets/icons/snake.svg"
+            : "";
       const offsetVal =
         cellType === "ladder"
           ? ladderOffsets[num]
@@ -169,7 +173,11 @@ function Board({
         >
           {(icon || offsetVal != null) && (
             <span className="cell-marker">
-              {icon && <span className="cell-icon">{icon}</span>}
+              {icon && (
+                <span className="cell-icon">
+                  <img src={icon} alt={cellType} />
+                </span>
+              )}
               {offsetVal != null && (
                 <span className="cell-offset">
                   <span className={`cell-sign ${cellType}`}>


### PR DESCRIPTION
## Summary
- fix inactive token size to match board pieces
- use images for snake and ladder icons on the board
- adjust CSS for cell icons
- fix snake connector image path

## Testing
- `npm test` *(fails: ensureTransactionArray)*

------
https://chatgpt.com/codex/tasks/task_e_685a500084088329afcfd13debb8c531