### PR TITLE
Enhance Snake & Ladder player display

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,28 @@ The compiled assets are copied into `webapp/public/games/ludo`.
 ### Customizing Snakes & Ladders icons
 
 All webapp icons are stored in `webapp/public/assets/icons`. The board now uses `snake.png` and `ladder.png` for snake and ladder connectors. Replace these files or add new ones in the same folder and update the paths in `src/index.css` if you want custom graphics.
+
+### Snake & Ladder engine notes
+
+Active games live in memory via `GameRoom` objects in `bot/gameEngine.js`. Each
+player tracks whether their socket has disconnected and the timestamp of their
+most recent roll.
+
+Turns skip over disconnected players:
+
+```js
+while (this.players[this.currentTurn].disconnected) {
+  this.currentTurn = (this.currentTurn + 1) % this.players.length;
+}
+```
+
+Rooms are deleted once everyone disconnects. There is no automatic reconnect
+timeout, but a player can reload the webapp to restore state from `localStorage`
+and continue if the room still exists.
+
+Rolls are subject to a cooldown to prevent spamming. A request is ignored when
+it occurs before `ROLL_COOLDOWN_MS` has elapsed:
+
+```js
+if (Date.now() - player.lastRollTime < this.rollCooldown) return;
+```

--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function AvatarTimer({ photoUrl, active = false, timerPct = 1 }) {
+  const angle = (1 - timerPct) * 360;
+  const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
+  return (
+    <div className="relative w-12 h-12">
+      {active && (
+        <div className="avatar-timer-ring" style={{ '--timer-gradient': gradient }} />
+      )}
+      <img
+        src={photoUrl}
+        alt="player"
+        className="w-12 h-12 rounded-full border border-yellow-400 object-cover"
+      />
+    </div>
+  );
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -332,6 +332,16 @@ body {
           mask: radial-gradient(farthest-side, transparent 65%, black 66%);
 }
 
+.avatar-timer-ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  pointer-events: none;
+  background: var(--timer-gradient);
+  -webkit-mask: radial-gradient(farthest-side, transparent 65%, black 66%);
+          mask: radial-gradient(farthest-side, transparent 65%, black 66%);
+}
+
 .token-cube-inner {
   position: relative;
   width: 100%;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -16,6 +16,7 @@ import { useNavigate } from "react-router-dom";
 import { getTelegramId, getTelegramPhotoUrl } from "../../utils/telegram.js";
 import { fetchTelegramInfo, getProfile, deposit } from "../../utils/api.js";
 import PlayerToken from "../../components/PlayerToken.jsx";
+import AvatarTimer from "../../components/AvatarTimer.jsx";
 import ConfirmPopup from "../../components/ConfirmPopup.jsx";
 
 const TOKEN_COLORS = [
@@ -1015,18 +1016,17 @@ export default function SnakeAndLadder() {
           <span className="text-xs">Lobby</span>
         </button>
       </div>
-      {/* Inactive tokens fixed to the top left */}
+      {/* Player photos for tokens not yet active */}
       <div className="fixed left-2 top-4 flex flex-col space-y-2 z-20">
         {players
           .map((p, i) => ({ ...p, index: i }))
           .filter((p) => p.position === 0)
           .map((p) => (
-            <PlayerToken
+            <AvatarTimer
               key={`inactive-${p.index}`}
               photoUrl={p.photoUrl}
-              type={"normal"}
-              color={p.color}
-              className="inactive"
+              active={p.index === currentTurn}
+              timerPct={p.index === currentTurn ? timeLeft / 15 : 1}
             />
           ))}
       </div>


### PR DESCRIPTION
## Summary
- show player photos at the top left when tokens are inactive
- add `AvatarTimer` component and supporting CSS
- document disconnect handling and roll cooldowns in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a53563a3883299a05305d3c4d01fe