### PR TITLE
Update token visuals and timer

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -147,9 +147,9 @@ function Board({
       const cellClass = cellType ? `${cellType}-cell` : "";
       const icon =
         cellType === "ladder"
-          ? "/assets/icons/ladder.png"
+          ? "🪜"
           : cellType === "snake"
-            ? "/assets/icons/snake.svg"
+            ? "🐍"
             : "";
       const offsetVal =
         cellType === "ladder"
@@ -175,9 +175,7 @@ function Board({
           {(icon || offsetVal != null) && (
             <span className="cell-marker">
               {icon && (
-                <span className="cell-icon">
-                  <img src={icon} alt={cellType} />
-                </span>
+                <span className="cell-icon">{icon}</span>
               )}
               {offsetVal != null && (
                 <span className="cell-offset">
@@ -189,7 +187,6 @@ function Board({
               )}
             </span>
           )}
-          {num === 1 && <div className="start-hexagon" />}
           {cellType === "" && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
@@ -204,22 +201,24 @@ function Board({
             .map((p, i) => ({ ...p, index: i }))
             .filter((p) => p.position !== 0 && p.position === num)
             .map((p) => (
-              <PlayerToken
-                key={p.index}
-                photoUrl={p.photoUrl}
-                type={p.type || (p.index === 0 ? (isHighlight ? highlight.type : tokenType) : "normal")}
-                color={p.color}
-                rolling={p.index === rollingIndex}
-                active={p.index === currentTurn}
-                timerPct={p.index === currentTurn ? timerPct : 1}
-                className={
-                  p.position === 0
-                    ? "start"
-                    : p.index === 0 && isJump
-                      ? "jump"
-                      : ""
-                }
-              />
+              <React.Fragment key={p.index}>
+                <div className="start-hexagon" />
+                <PlayerToken
+                  photoUrl={p.photoUrl}
+                  type={p.type || (p.index === 0 ? (isHighlight ? highlight.type : tokenType) : "normal")}
+                  color={p.color}
+                  rolling={p.index === rollingIndex}
+                  active={p.index === currentTurn}
+                  timerPct={p.index === currentTurn ? timerPct : 1}
+                  className={
+                    p.position === 0
+                      ? "start"
+                      : p.index === 0 && isJump
+                        ? "jump"
+                        : ""
+                  }
+                />
+              </React.Fragment>
             ))}
           {offsetPopup && offsetPopup.cell === num && (
             <span
@@ -956,7 +955,8 @@ export default function SnakeAndLadder() {
 
   useEffect(() => {
     if (setupPhase || gameOver) return;
-    setTimeLeft(15);
+    const limit = currentTurn === 0 ? 15 : 3;
+    setTimeLeft(limit);
     if (timerRef.current) clearInterval(timerRef.current);
     timerRef.current = setInterval(() => {
       setTimeLeft(t => {
@@ -1026,7 +1026,7 @@ export default function SnakeAndLadder() {
               key={`inactive-${p.index}`}
               photoUrl={p.photoUrl}
               active={p.index === currentTurn}
-              timerPct={p.index === currentTurn ? timeLeft / 15 : 1}
+              timerPct={p.index === currentTurn ? timeLeft / (currentTurn === 0 ? 15 : 3) : 1}
             />
           ))}
       </div>
@@ -1046,7 +1046,7 @@ export default function SnakeAndLadder() {
         diceCells={diceCells}
         rollingIndex={rollingIndex}
         currentTurn={currentTurn}
-        timerPct={timeLeft / 15}
+        timerPct={timeLeft / (currentTurn === 0 ? 15 : 3)}
       />
       {rollResult !== null && (
         <div className="fixed bottom-44 inset-x-0 flex justify-center z-30 pointer-events-none">


### PR DESCRIPTION
## Summary
- use emoji icons for snakes and ladders
- attach rotating hexagon to each token
- shorten AI roll timer to 3 seconds
- keep player timer at 15 seconds

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685a58b4132483298ace95f8d582f6a8