### PR TITLE
Adjust board angle and logo

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -298,7 +298,7 @@ body {
   transform-origin: bottom center;
   /* Align the photo with the top face of the token and tilt upward */
   transform: translate(-50%, -50%) translateZ(15.2px)
-    rotateX(calc(var(--board-angle, 70deg) * -1 - 10deg));
+    rotateX(calc(var(--board-angle, 75deg) * -1 - 10deg));
   object-fit: cover;
   border-radius: 50%;
   border: 2px solid #ffd700;
@@ -323,7 +323,7 @@ body {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) translateZ(15.2px)
-    rotateX(calc(var(--board-angle, 70deg) * -1 - 10deg));
+    rotateX(calc(var(--board-angle, 75deg) * -1 - 10deg));
   border-radius: 50%;
   pointer-events: none;
   z-index: 0;
@@ -348,7 +348,7 @@ body {
   height: 100%;
   transform-style: preserve-3d;
   /* Align token with board surface while showing a slight side angle */
-  transform: rotateX(calc(var(--board-angle, 70deg) * -1 - 20deg))
+  transform: rotateX(calc(var(--board-angle, 75deg) * -1 - 20deg))
     rotateY(25deg);
 }
 
@@ -715,8 +715,8 @@ body {
       (var(--final-scale, 1) - 1)
   );
   left: 50%;
-  transform: translateX(-50%) rotateX(calc(var(--board-angle, 70deg) * -1))
-    translateZ(-90px) scale(2.08);
+  transform: translateX(-50%) rotateX(calc(var(--board-angle, 75deg) * -1))
+    translateZ(-90px) scale(1.8);
   transform-origin: bottom center;
   background-image: url("/assets/TonPlayGramLogo.jpg");
   background-size: contain;
@@ -828,7 +828,7 @@ body {
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%) translateZ(6px)
-    rotateX(calc(var(--board-angle, 70deg) * -1));
+    rotateX(calc(var(--board-angle, 75deg) * -1));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -878,10 +878,10 @@ body {
 
 @keyframes hex-spin-reverse {
   from {
-    transform: translateZ(0) rotateX(var(--board-angle, 70deg)) rotate(0deg);
+    transform: translateZ(0) rotateX(var(--board-angle, 75deg)) rotate(0deg);
   }
   to {
-    transform: translateZ(0) rotateX(var(--board-angle, 70deg)) rotate(-360deg);
+    transform: translateZ(0) rotateX(var(--board-angle, 75deg)) rotate(-360deg);
   }
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -252,7 +252,7 @@ function Board({
   // Fixed board angle with no zoom
   // Lowered camera angle so the logo touches the top of the screen
   // Increase tilt for a more dynamic view of the board
-  const angle = 70;
+  const angle = 75;
   // Small horizontal offset so the board sits perfectly centered
   const boardXOffset = -10; // pixels
   // Lift the board slightly so the bottom row stays visible
@@ -318,7 +318,7 @@ function Board({
               // Slightly enlarge the board in both directions
               // Pull the board slightly back so more of the lower rows are
               // visible when the game starts
-              transform: `translate(${boardXOffset}px, ${boardYOffset}px) rotateX(${angle}deg) scale(0.9455)`,
+              transform: `translate(${boardXOffset}px, ${boardYOffset}px) rotateX(${angle}deg) scale(0.9)`,
             }}
           >
             <div className="snake-gradient-bg" />


### PR DESCRIPTION
## Summary
- tweak snake board angle to 75°
- show board at 90% scale
- rotate elements using 75° default
- resize and rotate logo to remain upright

## Testing
- `npm test` *(fails: manifest and lobby route unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685a7c78917c83299b82bc390ef05393