### PR TITLE
Reverse board tilt

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -55,7 +55,7 @@ body {
 
 .snake-gradient-bg {
   position: absolute;
-  /* rotate the backdrop 90deg so it runs from top to bottom */
+  /* rotate the backdrop -90deg so it runs from top to bottom but from the opposite side */
   top: 50%;
   left: 50%;
   /* slightly taller backdrop */
@@ -63,7 +63,7 @@ body {
   height: calc(var(--board-width) * 1.7);
   /* keep bottom in place by shifting upward */
   /* slightly shift down so the backdrop covers the starting rows */
-  transform: translate(-50%, -50%) rotate(90deg) translateZ(0);
+  transform: translate(-50%, -50%) rotate(-90deg) translateZ(0);
   transform-origin: center;
   /* widen the top of the backdrop while keeping the bottom unchanged */
   /* narrow the bottom of the backdrop so it fits the board */

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -252,7 +252,8 @@ function Board({
   // Fixed board angle with no zoom
   // Lowered camera angle so the logo touches the top of the screen
   // Increase tilt for a more dynamic view of the board
-  const angle = 75;
+  // Reverse the board angle so the camera tilts from the opposite side
+  const angle = -75;
   // Small horizontal offset so the board sits perfectly centered
   const boardXOffset = -10; // pixels
   // Lift the board slightly so the bottom row stays visible


### PR DESCRIPTION
## Summary
- update board angle to show the opposite tilt
- flip gradient background rotation to match

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685a9363727083299736322cf47908dc