### PR TITLE
Adjust snake board tilt

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -298,7 +298,7 @@ body {
   transform-origin: bottom center;
   /* Align the photo with the top face of the token and tilt upward */
   transform: translate(-50%, -50%) translateZ(15.2px)
-    rotateX(calc(var(--board-angle, 60deg) * -1 - 10deg));
+    rotateX(calc(var(--board-angle, 62deg) * -1 - 10deg));
   object-fit: cover;
   border-radius: 50%;
   border: 2px solid #ffd700;
@@ -323,7 +323,7 @@ body {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) translateZ(15.2px)
-    rotateX(calc(var(--board-angle, 60deg) * -1 - 10deg));
+    rotateX(calc(var(--board-angle, 62deg) * -1 - 10deg));
   border-radius: 50%;
   pointer-events: none;
   z-index: 0;
@@ -348,7 +348,7 @@ body {
   height: 100%;
   transform-style: preserve-3d;
   /* Align token with board surface while showing a slight side angle */
-  transform: rotateX(calc(var(--board-angle, 60deg) * -1 - 20deg))
+  transform: rotateX(calc(var(--board-angle, 62deg) * -1 - 20deg))
     rotateY(25deg);
 }
 
@@ -709,13 +709,13 @@ body {
   @apply absolute flex items-center justify-center;
   width: calc(var(--cell-width) * 6); /* larger logo width */
   height: calc(var(--cell-height) * 5); /* taller logo */
-  /* drop the logo closer to the board */
+  /* raise the logo slightly above the board */
   top: calc(
-    var(--cell-height) * -11 - var(--cell-height) * 1.7 *
+    var(--cell-height) * -12 - var(--cell-height) * 1.7 *
       (var(--final-scale, 1) - 1)
   );
   left: 50%;
-  transform: translateX(-50%) rotateX(calc(var(--board-angle, 60deg) * -1))
+  transform: translateX(-50%) rotateX(calc(var(--board-angle, 62deg) * -1))
     translateZ(-90px) scale(1.8);
   transform-origin: bottom center;
   background-image: url("/assets/TonPlayGramLogo.jpg");
@@ -828,7 +828,7 @@ body {
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%) translateZ(6px)
-    rotateX(calc(var(--board-angle, 60deg) * -1));
+    rotateX(calc(var(--board-angle, 62deg) * -1));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -878,10 +878,10 @@ body {
 
 @keyframes hex-spin-reverse {
   from {
-    transform: translateZ(0) rotateX(var(--board-angle, 60deg)) rotate(0deg);
+    transform: translateZ(0) rotateX(var(--board-angle, 62deg)) rotate(0deg);
   }
   to {
-    transform: translateZ(0) rotateX(var(--board-angle, 60deg)) rotate(-360deg);
+    transform: translateZ(0) rotateX(var(--board-angle, 62deg)) rotate(-360deg);
   }
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -252,7 +252,7 @@ function Board({
   // Fixed board angle with no zoom
   // Lowered camera angle so the logo touches the top of the screen
   // Tilt angle for the entire board in 3D space
-  const angle = 55; // set board tilt to 55 degrees
+  const angle = 62; // set board tilt to 62 degrees
   // Small horizontal offset so the board sits perfectly centered
   const boardXOffset = -10; // pixels
   // Lift the board slightly so the bottom row stays visible


### PR DESCRIPTION
## Summary
- tilt the Snake & Ladder board to 62 degrees
- raise the board logo so it stays aligned
- update all board-angle defaults in CSS

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685abce0f7e48329afd0e20f52ac1a32