### PR TITLE
Fix board icons using coordinate overlays

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useLayoutEffect } from "react";
 import confetti from "canvas-confetti";
 import DiceRoller from "../../components/DiceRoller.jsx";
 import { dropSound, snakeSound, ladderSound, timerBeep, bombSound } from "../../assets/soundData.js";
@@ -86,6 +86,8 @@ function Board({
   burning = [],
 }) {
   const containerRef = useRef(null);
+  const gridRef = useRef(null);
+  const [connectors, setConnectors] = useState([]);
   const [cellWidth, setCellWidth] = useState(80);
   const [cellHeight, setCellHeight] = useState(40);
   const tiles = [];
@@ -246,6 +248,52 @@ function Board({
     return () => window.removeEventListener("resize", updateSize);
   }, []);
 
+  useLayoutEffect(() => {
+    const grid = gridRef.current;
+    if (!grid) return;
+
+    const posFor = (cell) => {
+      const el = grid.querySelector(`[data-cell='${cell}']`);
+      if (!el) return null;
+      return {
+        x: el.offsetLeft + el.offsetWidth / 2,
+        y: el.offsetTop + el.offsetHeight / 2,
+      };
+    };
+
+    const conns = [];
+    Object.entries(snakes || {}).forEach(([s, e]) => {
+      const start = posFor(Number(s));
+      const end = posFor(Number(e));
+      if (!start || !end) return;
+      const dx = end.x - start.x;
+      const dy = end.y - start.y;
+      conns.push({
+        type: 'snake',
+        x: start.x,
+        y: start.y,
+        len: Math.sqrt(dx * dx + dy * dy),
+        angle: (Math.atan2(dy, dx) * 180) / Math.PI,
+      });
+    });
+    Object.entries(ladders || {}).forEach(([s, e]) => {
+      const endCell = typeof e === 'object' ? e.end : e;
+      const start = posFor(Number(s));
+      const end = posFor(Number(endCell));
+      if (!start || !end) return;
+      const dx = end.x - start.x;
+      const dy = end.y - start.y;
+      conns.push({
+        type: 'ladder',
+        x: start.x,
+        y: start.y,
+        len: Math.sqrt(dx * dx + dy * dy),
+        angle: (Math.atan2(dy, dx) * 180) / Math.PI,
+      });
+    });
+    setConnectors(conns);
+  }, [cellWidth, cellHeight, snakes, ladders]);
+
   // Icons are rendered directly inside each cell so that they stay perfectly
   // aligned with the grid. Previously additional absolutely positioned markers
   // were added which resulted in duplicate icons and misalignment when the
@@ -307,6 +355,7 @@ function Board({
       >
         <div className="snake-board-tilt">
           <div
+            ref={gridRef}
             className="snake-board-grid grid gap-x-1 gap-y-2 relative mx-auto"
             style={{
               width: `${cellWidth * COLS}px`,
@@ -326,6 +375,18 @@ function Board({
             }}
           >
             <div className="snake-gradient-bg" />
+            {connectors.map((c, i) => (
+              <div
+                key={i}
+                className={`${c.type}-connector`}
+                style={{
+                  left: `${c.x}px`,
+                  top: `${c.y}px`,
+                  width: `${c.len}px`,
+                  transform: `translateY(-50%) rotate(${c.angle}deg) translateZ(6px)`,
+                }}
+              />
+            ))}
             {tiles}
             <div
               className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? "highlight" : ""}`}


### PR DESCRIPTION
## Summary
- render snakes and ladders by computing connector coordinates
- hook into board sizing to position connectors

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685aec4350d0832995da872386b5c50b