### PR TITLE
Fix board icons orientation

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -600,7 +600,8 @@ body {
   top: 50%;
   left: 50%;
   /* match the number position so icons align perfectly */
-  transform: translate(-50%, -60%) translateZ(6px);
+  transform: translate(-50%, -60%) translateZ(6px)
+    rotateX(calc(var(--board-angle, 58deg) * -1));
   display: flex;
   align-items: center;
   justify-content: center; /* keep icon and offset perfectly centred */


### PR DESCRIPTION
## Summary
- ensure board cell markers rotate upright with board tilt

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL, snake lobby route lists players)*

------
https://chatgpt.com/codex/tasks/task_e_685af86844e483298e06e46dab825eb5