### PR TITLE
Highlight start tile with animated frame

### DIFF
--- a/webapp/src/components/TileFrame.jsx
+++ b/webapp/src/components/TileFrame.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function TileFrame({ rect }) {
+  if (!rect) return null;
+  const style = {
+    position: 'fixed',
+    pointerEvents: 'none',
+    left: rect.x - rect.width / 2,
+    top: rect.y - rect.height / 2,
+    width: rect.width,
+    height: rect.height,
+    zIndex: 4,
+  };
+  return <div className="tile-frame" style={style} />;
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -961,3 +961,21 @@ body {
 .board-frame-overlay {
   display: none;
 }
+
+.tile-frame {
+  border: 3px solid rgba(255, 230, 0, 0.9);
+  border-radius: 0.5rem;
+  pointer-events: none;
+  animation: tile-pulse 1.5s ease-in-out infinite;
+  box-shadow: 0 0 8px rgba(255, 230, 0, 0.6);
+}
+
+@keyframes tile-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 8px rgba(255, 230, 0, 0.6);
+  }
+  50% {
+    box-shadow: 0 0 16px rgba(255, 230, 0, 1);
+  }
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -18,6 +18,7 @@ import { fetchTelegramInfo, getProfile, deposit } from "../../utils/api.js";
 import PlayerToken from "../../components/PlayerToken.jsx";
 import AvatarTimer from "../../components/AvatarTimer.jsx";
 import ConfirmPopup from "../../components/ConfirmPopup.jsx";
+import TileFrame from "../../components/TileFrame.jsx";
 
 const TOKEN_COLORS = [
   { name: "blue", color: "#60a5fa" },
@@ -87,9 +88,11 @@ function Board({
 }) {
   const containerRef = useRef(null);
   const gridRef = useRef(null);
+  const tile1Ref = useRef(null);
   const [connectors, setConnectors] = useState([]);
   const [cellWidth, setCellWidth] = useState(80);
   const [cellHeight, setCellHeight] = useState(40);
+  const [tileRect, setTileRect] = useState(null);
   const tiles = [];
   const centerCol = (COLS - 1) / 2;
   // Gradual horizontal widening towards the top. Keep the bottom
@@ -168,6 +171,7 @@ function Board({
         <div
           key={num}
           data-cell={num}
+          ref={num === 1 ? tile1Ref : null}
           className={`board-cell ${cellClass} ${highlightClass}`}
           style={style}
         >
@@ -242,11 +246,22 @@ function Board({
       // Make each cell slightly taller while keeping spacing consistent
       const ch = Math.floor(cw / 1.7);
       setCellHeight(ch);
+      if (tile1Ref.current) {
+        const { x, y, width: w, height: h } = tile1Ref.current.getBoundingClientRect();
+        setTileRect({ x, y, width: w, height: h });
+      }
     };
     updateSize();
     window.addEventListener("resize", updateSize);
     return () => window.removeEventListener("resize", updateSize);
   }, []);
+
+  useLayoutEffect(() => {
+    if (tile1Ref.current) {
+      const { x, y, width, height } = tile1Ref.current.getBoundingClientRect();
+      setTileRect({ x, y, width, height });
+    }
+  }, [cellWidth, cellHeight]);
 
   useLayoutEffect(() => {
     const grid = gridRef.current;
@@ -414,6 +429,7 @@ function Board({
           </div>
         </div>
       </div>
+      <TileFrame rect={tileRect} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `TileFrame` component to show glowing border
- measure tile 1 size/position using refs
- render frame fixed over tile 1
- style frame with pulsing glow animation

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0af904948329a948d66a07b9ef1f