### PR TITLE
Fix mobile tile frame centering

### DIFF
--- a/webapp/src/components/TileFrame.jsx
+++ b/webapp/src/components/TileFrame.jsx
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
-export default function TileFrame({ rect }) {
+export default function TileFrame({ rect, adjustX = 0, adjustY = 0 }) {
+  useEffect(() => {
+    if (rect) console.log(rect);
+  }, [rect]);
+
   if (!rect) return null;
   const style = {
-    position: 'fixed',
+    position: 'absolute',
     pointerEvents: 'none',
-    left: rect.x - rect.width / 2,
-    top: rect.y - rect.height / 2,
+    left: rect.x - rect.width / 2 + adjustX,
+    top: rect.y - rect.height / 2 + adjustY,
     width: rect.width,
     height: rect.height,
     zIndex: 4,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -93,6 +93,11 @@ function Board({
   const [cellWidth, setCellWidth] = useState(80);
   const [cellHeight, setCellHeight] = useState(40);
   const [tileRect, setTileRect] = useState(null);
+  const adjustX = 0;
+  const adjustY = 0;
+  useEffect(() => {
+    if (tileRect) console.log(tileRect);
+  }, [tileRect]);
   const tiles = [];
   const centerCol = (COLS - 1) / 2;
   // Gradual horizontal widening towards the top. Keep the bottom
@@ -246,9 +251,10 @@ function Board({
       // Make each cell slightly taller while keeping spacing consistent
       const ch = Math.floor(cw / 1.7);
       setCellHeight(ch);
-      if (tile1Ref.current) {
-        const { x, y, width: w, height: h } = tile1Ref.current.getBoundingClientRect();
-        setTileRect({ x, y, width: w, height: h });
+      if (tile1Ref.current && containerRef.current) {
+        const { left, top, width: w, height: h } = tile1Ref.current.getBoundingClientRect();
+        const { left: cl, top: ct } = containerRef.current.getBoundingClientRect();
+        setTileRect({ x: left + w / 2 - cl, y: top + h / 2 - ct, width: w, height: h });
       }
     };
     updateSize();
@@ -257,9 +263,10 @@ function Board({
   }, []);
 
   useLayoutEffect(() => {
-    if (tile1Ref.current) {
-      const { x, y, width, height } = tile1Ref.current.getBoundingClientRect();
-      setTileRect({ x, y, width, height });
+    if (tile1Ref.current && containerRef.current) {
+      const { left, top, width, height } = tile1Ref.current.getBoundingClientRect();
+      const { left: cl, top: ct } = containerRef.current.getBoundingClientRect();
+      setTileRect({ x: left + width / 2 - cl, y: top + height / 2 - ct, width, height });
     }
   }, [cellWidth, cellHeight]);
 
@@ -357,7 +364,7 @@ function Board({
   const paddingBottom = '15vh';
 
   return (
-    <div className="flex justify-center items-center w-screen overflow-visible">
+    <div className="relative flex justify-center items-center w-screen overflow-visible">
       <div
         ref={containerRef}
         className="overflow-y-auto"
@@ -429,7 +436,7 @@ function Board({
           </div>
         </div>
       </div>
-      <TileFrame rect={tileRect} />
+      <TileFrame rect={tileRect} adjustX={adjustX} adjustY={adjustY} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- center the start tile frame using bounding rect coordinates
- add optional offsets for fine tuning
- log the screen coordinates for debugging
- position overlay relative to the board container

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685b0c84a12c8329af17638101fa9d8a