### PR TITLE
Fix board icons and start hexagon

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -611,18 +611,17 @@ body {
 }
 
 .cell-icon {
-  font-size: 1.7rem; /* tiny bit bigger */
-  line-height: 1;
-  color: #fff; /* ensure visibility */
+  width: 1.7rem;
+  height: 1.7rem;
+  object-fit: contain;
 }
 
 /* Start cell icon tweaks */
 .board-cell[data-cell="1"] .cell-icon {
-  /* slightly bigger starting hexagon */
-  font-size: 4.8rem;
-  display: inline-block;
-  /* keep the icon upright so the animation starts at 0 degrees */
-  transform: rotate(0deg);
+  width: 4.8rem;
+  height: 4.8rem;
+  animation: hex-spin 6s linear infinite;
+  transform-origin: center;
 }
 
 /* Rotate the start cell icon in place */
@@ -925,11 +924,9 @@ body {
   margin: auto;
   width: var(--cell-height);
   height: var(--cell-height);
-  /* show only the outline so the number sits inside */
-  background-color: transparent;
-  border: 3px solid #facc15;
+  background-color: #3f3f46;
+  border: 3px solid #27272a;
   box-sizing: border-box;
-  /* true regular hexagon */
   clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
   transform: translateZ(6px);
   pointer-events: none;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -150,8 +150,12 @@ function Board({
             ? "dice"
             : "";
       const cellClass = cellType ? `${cellType}-cell` : "";
-      const icon =
-        cellType === "ladder" ? "🪜" : cellType === "snake" ? "🐍" : "";
+      const iconPath =
+        cellType === "ladder"
+          ? "/assets/icons/ladder.png"
+          : cellType === "snake"
+            ? "/assets/icons/snake.svg"
+            : null;
       const offsetVal =
         cellType === "ladder"
           ? ladderOffsets[num]
@@ -174,9 +178,11 @@ function Board({
           className={`board-cell ${cellClass} ${highlightClass}`}
           style={style}
         >
-          {(icon || offsetVal != null) && (
+          {(iconPath || offsetVal != null) && (
             <span className="cell-marker">
-              {icon && <span className="cell-icon">{icon}</span>}
+              {iconPath && (
+                <img src={iconPath} className="cell-icon" alt={cellType} />
+              )}
               {offsetVal != null && (
                 <span className="cell-offset">
                   <span className={`cell-sign ${cellType}`}>


### PR DESCRIPTION
## Summary
- display ladder/snake icons as images
- change start hexagon to dark grey and rotate the start icon

## Testing
- `npm --prefix webapp run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b122bbf208329b4d4095bc8cfb954