### PR TITLE
Update snake and ladder board visuals

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -64,7 +64,7 @@ body {
   height: calc(var(--board-width) * 1.7);
   /* keep bottom in place by shifting upward */
   /* slightly shift down so the backdrop covers the starting rows */
-  transform: translate(-50%, -55%) rotate(90deg) translateZ(0);
+  transform: translate(-50%, -52%) rotate(90deg) translateZ(0);
   transform-origin: center;
   /* widen the top of the backdrop while keeping the bottom unchanged */
   /* narrow the bottom of the backdrop so it fits the board */
@@ -75,7 +75,7 @@ body {
   /* Expand the bottom of the backdrop so it extends beyond the board */
   /* Make the top even wider next to the logo and taper the bottom */
   /* Narrow top edge and widen bottom edge for a stronger perspective */
-  clip-path: polygon(-45% 0%, 145% 0%, 185% 100%, -85% 100%);
+  clip-path: polygon(-55% 0%, 155% 0%, 110% 100%, -10% 100%);
   pointer-events: none;
   z-index: 0;
   background:
@@ -88,7 +88,7 @@ body {
     ),
     linear-gradient(
       to top,
-      #000a1f,
+      #0b0f19,
       #123840,
       #1f4d58 20%,
       #d9cec2 40%,
@@ -96,7 +96,7 @@ body {
       #b95741 60%,
       #e7b382 80%,
       #4c050d,
-      #220003
+      #0b0f19
     );
 }
 
@@ -610,14 +610,13 @@ body {
   z-index: 3; /* ensure icons appear above connectors */
 }
 
-.cell-icon {
-  width: 1.7rem;
-  height: 1.7rem;
-  object-fit: contain;
+.cell-emoji {
+  font-size: 1.7rem;
+  line-height: 1;
 }
 
 /* Start cell icon tweaks */
-.board-cell[data-cell="1"] .cell-icon {
+.board-cell[data-cell="1"] .cell-emoji {
   width: 4.8rem;
   height: 4.8rem;
   animation: hex-spin 6s linear infinite;
@@ -757,16 +756,15 @@ body {
 
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 6); /* larger logo width */
-  height: calc(var(--cell-height) * 5); /* taller logo */
-  /* position the logo slightly lower on the board */
+  width: calc(var(--cell-width) * 7);
+  height: calc(var(--cell-height) * 5);
   top: calc(
     var(--cell-height) * -10 - var(--cell-height) * 1.7 *
       (var(--final-scale, 1) - 1)
   );
   left: 50%;
   transform: translateX(-50%) rotateX(calc(var(--board-angle, 58deg) * -1))
-    translateZ(-90px) scale(2.1); /* slightly larger logo */
+    translateZ(-90px) scale(2.3);
   transform-origin: bottom center;
   background-image: url("/assets/TonPlayGramLogo.jpg");
   background-size: contain;
@@ -882,14 +880,13 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  font-size: 1.8rem;
   pointer-events: none;
   z-index: 2;
 }
 
-.dice-marker img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
+.dice-emoji {
+  line-height: 1;
 }
 
 .dice-value {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -150,12 +150,8 @@ function Board({
             ? "dice"
             : "";
       const cellClass = cellType ? `${cellType}-cell` : "";
-      const iconPath =
-        cellType === "ladder"
-          ? "/assets/icons/ladder.png"
-          : cellType === "snake"
-            ? "/assets/icons/snake.svg"
-            : null;
+      const iconChar =
+        cellType === "ladder" ? "🪜" : cellType === "snake" ? "🐍" : null;
       const offsetVal =
         cellType === "ladder"
           ? ladderOffsets[num]
@@ -178,10 +174,12 @@ function Board({
           className={`board-cell ${cellClass} ${highlightClass}`}
           style={style}
         >
-          {(iconPath || offsetVal != null) && (
+          {(iconChar || offsetVal != null) && (
             <span className="cell-marker">
-              {iconPath && (
-                <img src={iconPath} className="cell-icon" alt={cellType} />
+              {iconChar && (
+                <span className="cell-emoji" role="img" aria-hidden="true">
+                  {iconChar}
+                </span>
               )}
               {offsetVal != null && (
                 <span className="cell-offset">
@@ -196,7 +194,9 @@ function Board({
           <span className="cell-number">{num}</span>
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
-              <img src="/assets/icons/dice.svg" alt="dice" />
+              <span className="dice-emoji" role="img" aria-hidden="true">
+                🎲
+              </span>
               <span className="dice-value">
                 <span className="dice-sign">+</span>
                 <span className="dice-number">{diceCells[num]}</span>


### PR DESCRIPTION
## Summary
- replace snake, ladder and dice images with emoji
- adjust board background gradient and logo
- remove dark border at the bottom

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685b197f25a48329a556c28c0fde4aea