### PR TITLE
Fix Snake & Ladder layout and auto-refresh

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -61,10 +61,11 @@ body {
   left: 50%;
   /* slightly taller backdrop */
   width: calc(var(--board-height) * 1.4);
-  height: calc(var(--board-width) * 1.7);
+  /* trim one row from top and bottom */
+  height: calc(var(--board-width) * 1.7 - var(--cell-height) * 2);
   /* keep bottom in place by shifting upward */
   /* slightly shift down so the backdrop covers the starting rows */
-  transform: translate(-50%, -55%) rotate(90deg) translateZ(0);
+  transform: translate(-50%, -50%) rotate(90deg) translateZ(0);
   transform-origin: center;
   /* widen the top of the backdrop while keeping the bottom unchanged */
   /* narrow the bottom of the backdrop so it fits the board */
@@ -762,7 +763,7 @@ body {
   height: calc(var(--cell-height) * 5);
   /* move the logo slightly down */
   top: calc(
-    var(--cell-height) * -9 - var(--cell-height) * 1.7 *
+    var(--cell-height) * -8 - var(--cell-height) * 1.7 *
       (var(--final-scale, 1) - 1)
   );
   left: 50%;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -479,6 +479,7 @@ export default function SnakeAndLadder() {
   const [timeLeft, setTimeLeft] = useState(15);
   const [aiAvatars, setAiAvatars] = useState([]);
   const [burning, setBurning] = useState([]); // indices of tokens burning
+  const [refreshTick, setRefreshTick] = useState(0);
 
   const playerName = (idx) => (
     <span style={{ color: playerColors[idx] }}>
@@ -1083,6 +1084,14 @@ export default function SnakeAndLadder() {
     }, 1000);
     return () => clearInterval(timerRef.current);
   }, [currentTurn, setupPhase, gameOver]);
+
+  // Periodically refresh the component state to avoid freezes
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRefreshTick((t) => t + 1);
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
 
   const players = [
     { position: pos, photoUrl, type: tokenType, color: playerColors[0] },


### PR DESCRIPTION
## Summary
- tweak `snake-gradient-bg` height and translation to trim top and bottom rows
- drop the board logo slightly to fill removed space
- add a periodic refresh in `SnakeAndLadder` to avoid freezes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b7ae1279c8329877c19932da24765