### PR TITLE
Fix Snake & Ladder background scaling

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -54,52 +54,14 @@ body {
   transition: transform 0.3s ease; /* ✅ scaling transition */
 }
 
-.snake-gradient-bg {
+
+/* Full-screen stage behind the Snake & Ladder board */
+.background-behind-board {
   position: absolute;
-  /* rotate the backdrop 90deg so it runs from top to bottom */
-  top: 50%;
-  left: 50%;
-  /* slightly taller backdrop */
-  width: calc(var(--board-height) * 1.4);
-  /* trim one row from top and bottom */
-  height: calc(var(--board-width) * 1.7 - var(--cell-height) * 2);
-  /* keep bottom in place by shifting upward */
-  /* slightly shift down so the backdrop covers the starting rows */
-  transform: translate(-50%, -50%) rotate(90deg) translateZ(0);
-  transform-origin: center;
-  /* widen the top of the backdrop while keeping the bottom unchanged */
-  /* narrow the bottom of the backdrop so it fits the board */
-  /* widen the top a bit more so the background fills the screen */
-  /* widen the top even more so the backdrop fills the screen */
-  /* widen the top further so the background spans the full screen */
-  /* Slightly widen the top so the backdrop fills the screen */
-  /* Expand the bottom of the backdrop so it extends beyond the board */
-  /* Make the top even wider next to the logo and taper the bottom */
-  /* Narrow bottom edge and widen top edge for a stronger perspective */
-  /* Wider at the bottom near the logo with a tapered top */
-  clip-path: polygon(-10% 0%, 110% 0%, 180% 100%, -80% 100%);
+  inset: 0;
+  z-index: -1;
   pointer-events: none;
-  z-index: 0;
-  background:
-    linear-gradient(
-      to right,
-      rgba(0, 0, 0, 0.5),
-      rgba(0, 0, 0, 0) 30%,
-      rgba(0, 0, 0, 0) 70%,
-      rgba(0, 0, 0, 0.5)
-    ),
-    linear-gradient(
-      to top,
-      #000a1f,
-      #123840,
-      #1f4d58 20%,
-      #d9cec2 40%,
-      #f3f0e8 50%,
-      #b95741 60%,
-      #e7b382 80%,
-      #4c050d,
-      #220003
-    );
+  background: linear-gradient(to right, #0f172a, #7f1d1d);
 }
 
 @keyframes roll {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -357,6 +357,7 @@ function Board({
 
   return (
     <div className="relative flex justify-center items-center w-screen overflow-visible">
+      <div className="background-behind-board" />
       <div
         ref={containerRef}
         className="overflow-y-auto"
@@ -389,7 +390,7 @@ function Board({
               transform: `translate(${boardXOffset}px, ${boardYOffset}px) translateZ(${boardZOffset}px) rotateX(${angle}deg) scale(0.9)`,
             }}
           >
-            <div className="snake-gradient-bg" />
+            {/* Game background is rendered outside the grid */}
             {connectors.map((c, i) => (
               <div
                 key={i}


### PR DESCRIPTION
## Summary
- make the board wrapper render a full-screen background element
- define `.background-behind-board` stage gradient

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685b856055208329b79b8fd6702e1a40