### PR TITLE
Tune snake board gradient and scaling

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -61,7 +61,8 @@ body {
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  background: linear-gradient(to right, #0f172a, #7f1d1d);
+  /* Darker blend in the centre so the board merges with the logo */
+  background: linear-gradient(to right, #0f172a, #1e1e1e 50%, #7f1d1d);
 }
 
 @keyframes roll {
@@ -732,7 +733,9 @@ body {
   transform: translateX(-50%) rotateX(calc(var(--board-angle, 58deg) * -1))
     translateZ(-90px) scale(2.2); /* a touch bigger */
   transform-origin: bottom center;
-  background-image: url("/assets/TonPlayGramLogo.jpg");
+  background-image:
+    linear-gradient(to bottom, rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0) 70%),
+    url("/assets/TonPlayGramLogo.jpg");
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -97,8 +97,9 @@ function Board({
   // Gradual horizontal widening towards the top. Keep the bottom
   // row the same width and slightly expand each successive row so
   // the board forms a soft V shape.
-  const widenStep = 0.05; // how much each row expands horizontally
-  const scaleStep = 0.02; // how much each row's cells scale
+  // Increase the widening and scaling so the top merges with the logo
+  const widenStep = 0.07; // how much each row expands horizontally
+  const scaleStep = 0.03; // how much each row's cells scale
   // Perspective with smaller cells at the bottom growing larger towards the pot
   const finalScale = 1 + (ROWS - 3) * scaleStep;
 


### PR DESCRIPTION
## Summary
- darken the background gradient so the board merges with the logo
- darken the bottom of the logo for a smoother transition
- make top rows of the board wider so they blend with the logo

## Testing
- `npm test` *(fails: manifest endpoint not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685b87875d7c8329997eae54e5eb8a7e