### PR TITLE
Improve board backdrop blending

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -67,29 +67,21 @@ body {
   /* slightly shift down so the backdrop covers the starting rows */
   transform: translate(-50%, -50%) rotate(90deg) translateZ(0);
   transform-origin: center;
-  /* widen the top of the backdrop while keeping the bottom unchanged */
-  /* narrow the bottom of the backdrop so it fits the board */
-  /* widen the top a bit more so the background fills the screen */
-  /* widen the top even more so the backdrop fills the screen */
-  /* widen the top further so the background spans the full screen */
-  /* Slightly widen the top so the backdrop fills the screen */
-  /* Expand the bottom of the backdrop so it extends beyond the board */
-  /* Make the top even wider next to the logo and taper the bottom */
-  /* Narrow bottom edge and widen top edge for a stronger perspective */
-  /* Wider at the bottom near the logo with a tapered top */
-  clip-path: polygon(-10% 0%, 110% 0%, 180% 100%, -80% 100%);
+  /* widen the top near the logo and taper the bottom a bit */
+  clip-path: polygon(-20% 0%, 120% 0%, 160% 100%, -60% 100%);
   pointer-events: none;
   z-index: 0;
   background:
     linear-gradient(
       to right,
-      rgba(0, 0, 0, 0.5),
+      rgba(0, 0, 0, 0.6),
       rgba(0, 0, 0, 0) 30%,
       rgba(0, 0, 0, 0) 70%,
-      rgba(0, 0, 0, 0.5)
+      rgba(0, 0, 0, 0.6)
     ),
     linear-gradient(
       to top,
+      #000714,
       #000a1f,
       #123840,
       #1f4d58 20%,
@@ -98,7 +90,7 @@ body {
       #b95741 60%,
       #e7b382 80%,
       #4c050d,
-      #220003
+      #110003
     );
 }
 
@@ -759,7 +751,7 @@ body {
 
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 6.7); /* a bit wider */
+  width: calc(var(--cell-width) * 7.2); /* widen near the logo */
   height: calc(var(--cell-height) * 5);
   /* move the logo slightly down */
   top: calc(
@@ -775,6 +767,15 @@ body {
   background-repeat: no-repeat;
   background-position: center;
   z-index: 5;
+  position: relative;
+}
+
+.logo-wall-main::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle, transparent 60%, rgba(0, 0, 0, 0.4));
+  pointer-events: none;
 }
 
 


### PR DESCRIPTION
## Summary
- darken top and bottom of the board's gradient
- widen gradient near the logo so it blends better
- increase logo width and overlay subtle dark radial blend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b90cf6c2c832982874345a7999c8c