### PR TITLE
Fix gradient placement on snake board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -57,7 +57,7 @@ body {
 .snake-gradient-bg {
   position: absolute;
   /* rotate the backdrop 90deg so it runs from top to bottom */
-  top: 50%;
+  top: 35%;
   left: 50%;
   /* slightly taller backdrop */
   width: calc(var(--board-height) * 1.4);
@@ -67,6 +67,7 @@ body {
   /* slightly shift down so the backdrop covers the starting rows */
   transform: translate(-50%, -50%) rotate(90deg) translateZ(0);
   transform-origin: center;
+  background-position: center top;
   /* widen the top of the backdrop while keeping the bottom unchanged */
   /* narrow the bottom of the backdrop so it fits the board */
   /* widen the top a bit more so the background fills the screen */


### PR DESCRIPTION
## Summary
- adjust `.snake-gradient-bg` positioning so the wider glow sits near the logo

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685b9a73cd60832987a7aa13824a576e