### PR TITLE
Adjust gradient near logo

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -77,10 +77,15 @@ body {
   /* Make the top even wider next to the logo and taper the bottom */
   /* Narrow bottom edge and widen top edge for a stronger perspective */
   /* Wider at the bottom near the logo with a tapered top */
-  clip-path: polygon(-10% 0%, 110% 0%, 180% 100%, -80% 100%);
+  clip-path: polygon(-80% 0%, 180% 0%, 110% 100%, -10% 100%);
   pointer-events: none;
   z-index: 0;
   background:
+    linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0.6),
+      rgba(0, 0, 0, 0) 40%
+    ),
     linear-gradient(
       to right,
       rgba(0, 0, 0, 0.5),


### PR DESCRIPTION
## Summary
- widen top of snake board gradient
- taper bottom to fit screen
- darken the area around the logo for a smoother blend

## Testing
- `npm test` *(fails: manifest and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685ba371d030832990b9c2f63fc664a5