### PR TITLE
Fix gradient background shape near logo

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -77,10 +77,15 @@ body {
   /* Make the top even wider next to the logo and taper the bottom */
   /* Narrow bottom edge and widen top edge for a stronger perspective */
   /* Wider at the bottom near the logo with a tapered top */
-  clip-path: polygon(-10% 0%, 110% 0%, 180% 100%, -80% 100%);
+  clip-path: polygon(-80% 0%, 180% 0%, 100% 100%, 0% 100%);
   pointer-events: none;
   z-index: 0;
   background:
+    linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0.3),
+      rgba(0, 0, 0, 0) 40%
+    ),
     linear-gradient(
       to right,
       rgba(0, 0, 0, 0.5),


### PR DESCRIPTION
## Summary
- tweak background clip-path to widen the top and narrow the bottom
- darken area where gradient meets the logo with an additional overlay

## Testing
- `npm test` *(fails: cannot find package 'dotenv', manifest and lobby route unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685ba9852cd48329a5c6c7f483f4b842