### PR TITLE
Restore board layout to 7:30am state

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -54,44 +54,15 @@ body {
   transition: transform 0.3s ease; /* ✅ scaling transition */
 }
 
-.snake-gradient-bg {
+
+/* Full-screen stage behind the Snake & Ladder board */
+.background-behind-board {
   position: absolute;
-  /* rotate the backdrop 90deg so it runs from top to bottom */
-  top: 50%;
-  left: 50%;
-  /* slightly taller backdrop */
-  width: calc(var(--board-height) * 1.4);
-  /* trim one row from top and bottom */
-  height: calc(var(--board-width) * 1.7 - var(--cell-height) * 2);
-  /* keep bottom in place by shifting upward */
-  /* slightly shift down so the backdrop covers the starting rows */
-  transform: translate(-50%, -50%) rotate(90deg) translateZ(0);
-  transform-origin: center;
-  /* Make the top wider near the logo and taper towards the footer */
-  clip-path: polygon(-80% 0%, 180% 0%, 110% 100%, -10% 100%);
+  inset: 0;
+  z-index: -1;
   pointer-events: none;
-  z-index: 0;
-  background:
-    linear-gradient(
-      to right,
-      rgba(0, 0, 0, 0.6),
-      rgba(0, 0, 0, 0) 30%,
-      rgba(0, 0, 0, 0) 70%,
-      rgba(0, 0, 0, 0.6)
-    ),
-    linear-gradient(
-      to top,
-      #000714,
-      #000a1f,
-      #123840,
-      #1f4d58 20%,
-      #d9cec2 40%,
-      #f3f0e8 50%,
-      #b95741 60%,
-      #e7b382 80%,
-      #4c050d,
-      #110003
-    );
+  /* Darker blend in the centre so the board merges with the logo */
+  background: linear-gradient(to right, #0f172a, #1e1e1e 50%, #7f1d1d);
 }
 
 @keyframes roll {
@@ -751,7 +722,7 @@ body {
 
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 7.2); /* widen near the logo */
+  width: calc(var(--cell-width) * 6.7); /* a bit wider */
   height: calc(var(--cell-height) * 5);
   /* move the logo slightly down */
   top: calc(
@@ -762,20 +733,13 @@ body {
   transform: translateX(-50%) rotateX(calc(var(--board-angle, 58deg) * -1))
     translateZ(-90px) scale(2.2); /* a touch bigger */
   transform-origin: bottom center;
-  background-image: url("/assets/TonPlayGramLogo.jpg");
+  background-image:
+    linear-gradient(to bottom, rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0) 70%),
+    url("/assets/TonPlayGramLogo.jpg");
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
   z-index: 5;
-  position: relative;
-}
-
-.logo-wall-main::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle, transparent 60%, rgba(0, 0, 0, 0.4));
-  pointer-events: none;
 }
 
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -97,8 +97,9 @@ function Board({
   // Gradual horizontal widening towards the top. Keep the bottom
   // row the same width and slightly expand each successive row so
   // the board forms a soft V shape.
-  const widenStep = 0.05; // how much each row expands horizontally
-  const scaleStep = 0.02; // how much each row's cells scale
+  // Increase the widening and scaling so the top merges with the logo
+  const widenStep = 0.07; // how much each row expands horizontally
+  const scaleStep = 0.03; // how much each row's cells scale
   // Perspective with smaller cells at the bottom growing larger towards the pot
   const finalScale = 1 + (ROWS - 3) * scaleStep;
 
@@ -357,6 +358,7 @@ function Board({
 
   return (
     <div className="relative flex justify-center items-center w-screen overflow-visible">
+      <div className="background-behind-board" />
       <div
         ref={containerRef}
         className="overflow-y-auto"
@@ -389,7 +391,7 @@ function Board({
               transform: `translate(${boardXOffset}px, ${boardYOffset}px) translateZ(${boardZOffset}px) rotateX(${angle}deg) scale(0.9)`,
             }}
           >
-            <div className="snake-gradient-bg" />
+            {/* Game background is rendered outside the grid */}
             {connectors.map((c, i) => (
               <div
                 key={i}


### PR DESCRIPTION
## Summary
- revert board CSS and layout tweaks to the version from ~7:30am

## Testing
- `npm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_685bbcee31ec8329a27025c24ebc6d37