### PR TITLE
Update snake and ladder background

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -61,8 +61,14 @@ body {
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  /* Darker blend in the centre so the board merges with the logo */
-  background: linear-gradient(to right, #0f172a, #1e1e1e 50%, #7f1d1d);
+  /* Radial blend from centre (#0c1020) to dark edges */
+  background: radial-gradient(
+    circle at center,
+    #0c1020 0%,
+    #11172a 40%,
+    #1e2235 70%,
+    #271e26 100%
+  );
 }
 
 @keyframes roll {
@@ -734,7 +740,7 @@ body {
     translateZ(-90px) scale(2.2); /* a touch bigger */
   transform-origin: bottom center;
   background-image:
-    linear-gradient(to bottom, rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0) 70%),
+    radial-gradient(circle at center, rgba(0, 0, 0, 0) 60%, rgba(0, 0, 0, 0.6) 100%),
     url("/assets/TonPlayGramLogo.jpg");
   background-size: contain;
   background-repeat: no-repeat;


### PR DESCRIPTION
## Summary
- tweak Snake & Ladder page background gradient to use new theme colors
- darken edges around the game logo

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685bc5753a3883298d6d4d3dc28d7033