### PR TITLE
UI tweaks for snake board

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect } from "react";
 import * as THREE from "three";
 
-export default function HexPrismToken({ color = "#008080", topColor, photoUrl, className = "", rolling = false, active = false, timerPct = 1 }) {
+export default function HexPrismToken({ color = "#008080", topColor, photoUrl, className = "", rolling = false, active = false }) {
   const mountRef = useRef(null);
 
   useEffect(() => {
@@ -92,12 +92,9 @@ export default function HexPrismToken({ color = "#008080", topColor, photoUrl, c
     };
   }, [color, topColor]);
 
-  const angle = (1 - timerPct) * 360;
-  const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
 
   return (
     <div className={`token-three relative ${className}`} ref={mountRef}>
-      {active && <div className="timer-ring" style={{ '--timer-gradient': gradient }} />}
       {photoUrl && (
         <img
           src={photoUrl}

--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import HexPrismToken from "./HexPrismToken.jsx";
 
-export default function PlayerToken({ type = "normal", color, topColor, photoUrl, className = "", rolling = false, active = false, timerPct = 1 }) {
+export default function PlayerToken({ type = "normal", color, topColor, photoUrl, className = "", rolling = false, active = false }) {
   let tokenColor = color;
   if (!tokenColor) {
     if (type === "ladder") tokenColor = "#86efac"; // green
@@ -16,7 +16,6 @@ export default function PlayerToken({ type = "normal", color, topColor, photoUrl
       className={className}
       rolling={rolling}
       active={active}
-      timerPct={timerPct}
     />
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -350,12 +350,10 @@ body {
 .rank-name {
   position: absolute;
   top: -0.3rem;
-  right: 1rem;
+  right: -0.3rem;
+  transform: translateX(100%);
   font-size: 0.6rem;
   color: #fff;
-  background-color: #334155;
-  padding: 0 0.25rem;
-  border-radius: 0.25rem;
 }
 
 .token-cube-inner {
@@ -733,6 +731,7 @@ body {
   transform: translateX(-50%) rotateX(calc(var(--board-angle, 58deg) * -1))
     translateZ(-90px) scale(2.2); /* a touch bigger */
   transform-origin: bottom center;
+  box-shadow: 0 0 0 6px rgba(0, 0, 0, 0.6);
   background-image:
     linear-gradient(to bottom, rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0) 70%),
     url("/assets/TonPlayGramLogo.jpg");

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -82,7 +82,6 @@ function Board({
   diceCells,
   rollingIndex,
   currentTurn,
-  timerPct,
   burning = [],
 }) {
   const containerRef = useRef(null);
@@ -216,7 +215,6 @@ function Board({
                   color={p.color}
                   rolling={p.index === rollingIndex}
                   active={p.index === currentTurn}
-                  timerPct={p.index === currentTurn ? timerPct : 1}
                   className={
                     (p.position === 0
                       ? "start"
@@ -323,7 +321,7 @@ function Board({
   // Lift the board slightly so the bottom row stays visible. Lowered slightly
   // so the logo at the top of the board isn't cropped off screen. Zeroing this
   // aligns the board vertically with the frame.
-  const boardYOffset = 0; // pixels
+  const boardYOffset = 10; // pixels - slight downward shift
   // Pull the board away from the camera without changing the angle or zoom
   const boardZOffset = -50; // pixels
 
@@ -1182,7 +1180,6 @@ export default function SnakeAndLadder() {
         diceCells={diceCells}
         rollingIndex={rollingIndex}
         currentTurn={currentTurn}
-        timerPct={timeLeft / (currentTurn === 0 ? 15 : 3)}
         burning={burning}
       />
       {rollResult !== null && (


### PR DESCRIPTION
## Summary
- remove timer ring from player tokens
- tweak leaderboard name styles
- dark frame around snake board logo
- shift board down slightly

## Testing
- `npm test` *(fails: manifest endpoint and lobby route unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685bc9b65cac8329a4039a30dc421a3e