### PR TITLE
Darken edges of snake board background

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -64,12 +64,12 @@ body {
   /* Vertical colour bands behind the Snake & Ladder board */
   background: linear-gradient(
     to right,
-    #0e2a36,
+    #061a2b,
     #295663,
     #6a7b83,
     #d8d7d4,
     #dca996,
-    #aa4736
+    #772d18
   );
 }
 
@@ -742,6 +742,13 @@ body {
   box-shadow: 0 0 0 6px rgba(0, 0, 0, 0.6);
   background-image:
     linear-gradient(to bottom, rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0) 70%),
+    linear-gradient(
+      to right,
+      #061a2b,
+      rgba(0, 0, 0, 0) 20%,
+      rgba(0, 0, 0, 0) 80%,
+      #772d18
+    ),
     url("/assets/TonPlayGramLogo.jpg");
   background-size: contain;
   background-repeat: no-repeat;


### PR DESCRIPTION
## Summary
- tweak background gradient for Snake & Ladder board
- overlay darker side gradient around board logo

## Testing
- `npm test` *(fails: manifest and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685bd493e060832984a068c8e7254dcc