### PR TITLE
Tweak board visuals

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -296,7 +296,7 @@ body {
   height: 2.9rem;
   top: 50%;
   left: 50%;
-  transform-origin: bottom center;
+  transform-origin: center;
   /* Align the photo with the top face of the token and tilt upward */
   transform: translate(-50%, -50%) translateZ(15.2px)
     rotateX(calc(var(--board-angle, 58deg) * -1 - 10deg));
@@ -726,7 +726,7 @@ body {
 
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 6.7); /* a bit wider */
+  width: calc(var(--cell-width) * 6.9); /* slightly wider */
   height: calc(var(--cell-height) * 5);
   /* move the logo slightly down */
   top: calc(

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -213,7 +213,7 @@ function Board({
                   style={{
                     '--hex-color': p.color,
                     '--hex-border-color': p.color,
-                    '--hex-spin-duration': '10.5s',
+                    '--hex-spin-duration': '7s',
                   }}
                 />
                 <PlayerToken
@@ -328,7 +328,7 @@ function Board({
   // Lift the board slightly so the bottom row stays visible. Lowered slightly
   // so the logo at the top of the board isn't cropped off screen. Zeroing this
   // aligns the board vertically with the frame.
-  const boardYOffset = 20; // pixels - slight downward shift
+  const boardYOffset = 30; // pixels - pull board slightly lower
   // Pull the board away from the camera without changing the angle or zoom
   const boardZOffset = -50; // pixels
 
@@ -428,7 +428,7 @@ function Board({
                       style={{
                         '--hex-color': p.color,
                         '--hex-border-color': p.color,
-                        '--hex-spin-duration': '10.5s',
+                        '--hex-spin-duration': '7s',
                       }}
                     />
                     <PlayerToken


### PR DESCRIPTION
## Summary
- adjust the board position
- make the logo slightly wider
- speed up the rotating hex icon
- center player photos on tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bd8cd669883298e1a88455351f117