### PR TITLE
Adjust Snake & Ladder visuals

### DIFF
--- a/webapp/src/components/Footer.jsx
+++ b/webapp/src/components/Footer.jsx
@@ -1,6 +1,6 @@
 export default function Footer() {
   return (
-    <footer className="bg-surface text-subtext text-sm border-t border-accent">
+    <footer className="bg-surface text-subtext text-sm border-t-2 border-accent">
       <div className="container mx-auto p-4 text-center">
         &copy; {new Date().getFullYear()} TonPlaygram
       </div>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -710,7 +710,7 @@ body {
   width: calc(var(--cell-width) * 2.7);
   height: calc(var(--cell-height) * 2.7);
   /* move the pot nearer to the board */
-  top: calc(var(--cell-height) * -3.5);
+  top: calc(var(--cell-height) * -3.8);
   left: 50%;
   transform: translateX(-50%) translateZ(12px);
   z-index: 50;
@@ -729,9 +729,9 @@ body {
   @apply absolute flex items-center justify-center;
   width: calc(var(--cell-width) * 6.9); /* slightly wider */
   height: calc(var(--cell-height) * 5);
-  /* move the logo slightly down */
+  /* move the logo slightly up */
   top: calc(
-    var(--cell-height) * -8 - var(--cell-height) * 1.7 *
+    var(--cell-height) * -8.5 - var(--cell-height) * 1.7 *
       (var(--final-scale, 1) - 1)
   );
   left: 50%;
@@ -739,7 +739,7 @@ body {
     translateZ(-90px) scale(2.2); /* a touch bigger */
   transform-origin: bottom center;
   background-image:
-    linear-gradient(to bottom, rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0) 70%),
+    linear-gradient(to bottom, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0) 70%),
     url("/assets/TonPlayGramLogo.jpg");
   background-size: contain;
   background-repeat: no-repeat;
@@ -752,6 +752,7 @@ body {
   position: absolute;
   inset: 0;
   border: 6px solid #ffd700;
+  border-radius: 0.75rem;
   box-shadow:
     0 0 10px rgba(255, 215, 0, 0.9),
     inset 0 0 10px rgba(255, 215, 0, 0.6);
@@ -951,7 +952,7 @@ body {
   border: 8px solid #ffd700;
   border-radius: 1rem;
   box-shadow: 0 0 15px rgba(255, 215, 0, 0.8);
-  clip-path: polygon(10% 100%, 90% 100%, 100% 0, 0 0);
+  clip-path: none;
 }
 
 /*

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -328,8 +328,8 @@ function Board({
   // Lift the board slightly so the bottom row stays visible. Lowered slightly
   // so the logo at the top of the board isn't cropped off screen. Zeroing this
   // aligns the board vertically with the frame.
-  // Move the board a bit further down so the bottom rows sit nearer the footer
-  const boardYOffset = 60; // pixels
+  // Move the board slightly higher so the pot and logo sit closer to the top
+  const boardYOffset = 40; // pixels
   // Pull the board away from the camera without changing the angle or zoom
   const boardZOffset = -50; // pixels
 


### PR DESCRIPTION
## Summary
- move board a bit higher and adjust pot position
- lighten and brighten the logo
- round the logo frame and show all four sides
- thicken the footer line

## Testing
- `npm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_685be2b914d08329ab9c59c9d92b10d0