### PR TITLE
Improve snake and ladder visuals

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -129,8 +129,8 @@ body {
 .board-cell {
   @apply relative flex items-center justify-center rounded-xl text-text;
   background-color: var(--tile-bg, #0e3b45);
-  /* Richer golden border for a shiny prism look */
-  border: 3px solid #ffd700;
+  /* Subtle border to separate tiles */
+  border: 2px solid #334155;
   /* Cast a shadow dark enough for a stronger 3D effect */
   box-shadow: 0 8px 12px rgba(0, 0, 0, 0.6);
   transform: translateZ(5px);
@@ -145,8 +145,8 @@ body {
   position: absolute;
   inset: 2px;
   border-radius: inherit;
-  /* Shiny inner glow emphasising the prism frame */
-  box-shadow: 0 0 10px rgba(255, 215, 0, 0.9);
+  /* Soft inner shadow */
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.6);
   /* Place the highlight above the tile so the shading is visible */
   transform: translateZ(6px);
 }
@@ -586,10 +586,21 @@ body {
   object-fit: contain;
 }
 
+.cell-emoji {
+  font-size: 1.7rem;
+  line-height: 1;
+}
+
 /* Start cell icon tweaks */
 .board-cell[data-cell="1"] .cell-icon {
   width: 4.8rem;
   height: 4.8rem;
+  animation: hex-spin 10.5s linear infinite;
+  transform-origin: center;
+}
+
+.board-cell[data-cell="1"] .cell-emoji {
+  font-size: 4.8rem;
   animation: hex-spin 10.5s linear infinite;
   transform-origin: center;
 }
@@ -727,7 +738,7 @@ body {
 
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 6.9); /* slightly wider */
+  width: calc(var(--cell-width) * 7.5); /* wider */
   height: calc(var(--cell-height) * 5);
   /* move the logo slightly up */
   top: calc(
@@ -744,6 +755,7 @@ body {
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
+  filter: brightness(1.2);
   z-index: 5;
 }
 
@@ -756,17 +768,18 @@ body {
   pointer-events: none;
 }
 
+
 .logo-wall-main::before {
-  border-left: 6px solid #ffd700;
-  border-right: 6px solid #ffd700;
+  border-left: 6px solid #334155;
+  border-right: 6px solid #334155;
 }
 
 .logo-wall-main::after {
-  border-top: 6px solid #ffd700;
-  border-bottom: 6px solid #ffd700;
+  border-top: 6px solid #334155;
+  border-bottom: 6px solid #334155;
   box-shadow:
-    0 0 10px rgba(255, 215, 0, 0.9),
-    inset 0 0 10px rgba(255, 215, 0, 0.6);
+    0 0 10px rgba(0, 0, 0, 0.8),
+    inset 0 0 10px rgba(0, 0, 0, 0.5);
 }
 
 
@@ -837,6 +850,15 @@ body {
   animation-fill-mode: forwards;
 }
 
+.board-emojis {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  font-size: 2rem;
+  pointer-events: none;
+  z-index: 10;
+}
+
 @keyframes coin-up {
   to {
     transform: translate(calc(-50% + var(--dx)), -120px);
@@ -880,10 +902,9 @@ body {
   z-index: 2;
 }
 
-.dice-marker img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
+.dice-marker .dice-icon {
+  font-size: 1.8rem;
+  line-height: 1;
 }
 
 .dice-value {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -150,11 +150,11 @@ function Board({
             ? "dice"
             : "";
       const cellClass = cellType ? `${cellType}-cell` : "";
-      const iconPath =
+      const iconEmoji =
         cellType === "ladder"
-          ? "/assets/icons/ladder.png"
+          ? "\uD83E\uDEA4" // 🪜
           : cellType === "snake"
-            ? "/assets/icons/snake.svg"
+            ? "\uD83D\uDC0D" // 🐍
             : null;
       const offsetVal =
         cellType === "ladder"
@@ -178,14 +178,14 @@ function Board({
           className={`board-cell ${cellClass} ${highlightClass}`}
           style={style}
         >
-          {(iconPath || offsetVal != null) && (
+          {(iconEmoji || offsetVal != null) && (
             <span className="cell-marker">
-              {iconPath && (
-                <img src={iconPath} className="cell-icon" alt={cellType} />
+              {iconEmoji && (
+                <span className="cell-icon cell-emoji">{iconEmoji}</span>
               )}
               {offsetVal != null && (
                 <span className="cell-offset">
-                  <span className={`cell-sign ${cellType}`}>
+                  <span className={`cell-sign ${cellType}`}> 
                     {cellType === "snake" ? "-" : "+"}
                   </span>
                   <span className="cell-value">{offsetVal}</span>
@@ -196,7 +196,7 @@ function Board({
           <span className="cell-number">{num}</span>
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
-              <img src="/assets/icons/dice.svg" alt="dice" />
+              <span className="dice-icon">\uD83C\uDFB2</span>
               <span className="dice-value">
                 <span className="dice-sign">+</span>
                 <span className="dice-number">{diceCells[num]}</span>
@@ -329,7 +329,7 @@ function Board({
   // so the logo at the top of the board isn't cropped off screen. Zeroing this
   // aligns the board vertically with the frame.
   // Move the board slightly higher so the pot and logo sit closer to the top
-  const boardYOffset = 40; // pixels
+  const boardYOffset = 20; // pixels - slightly lower
   // Pull the board away from the camera without changing the angle or zoom
   const boardZOffset = -50; // pixels
 
@@ -442,6 +442,9 @@ function Board({
               {celebrate && <CoinBurst token={token} />}
             </div>
             <div className="logo-wall-main" />
+            <div className="board-emojis" aria-hidden="true">
+              \uD83D\uDC0D \uD83E\uDEAC \uD83C\uDFB2
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- brighten and widen the main logo
- remove golden borders from board tiles
- display snake, ladder and dice icons as emojis
- lower the board a little and show big emoji label

## Testing
- `npm test` *(fails: 2 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_685be7e6f4988329b6e7bb9eb758d25b