### PR TITLE
Adjust snake board layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -738,7 +738,7 @@ body {
 
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
-  width: calc(var(--cell-width) * 7.5); /* wider */
+  width: calc(var(--cell-width) * 8.5); /* slightly wider */
   height: calc(var(--cell-height) * 5);
   /* move the logo slightly up */
   top: calc(

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -329,7 +329,7 @@ function Board({
   // so the logo at the top of the board isn't cropped off screen. Zeroing this
   // aligns the board vertically with the frame.
   // Move the board slightly higher so the pot and logo sit closer to the top
-  const boardYOffset = 20; // pixels - slightly lower
+  const boardYOffset = 40; // pixels - slightly lower
   // Pull the board away from the camera without changing the angle or zoom
   const boardZOffset = -50; // pixels
 
@@ -442,9 +442,6 @@ function Board({
               {celebrate && <CoinBurst token={token} />}
             </div>
             <div className="logo-wall-main" />
-            <div className="board-emojis" aria-hidden="true">
-              \uD83D\uDC0D \uD83E\uDEAC \uD83C\uDFB2
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- tweak board offset on Snake & Ladder page so the board sits lower
- remove decorative emojis below the board
- widen the logo area a bit for a better fit

## Testing
- `npm test` *(fails: lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685bebe6b57c8329b1c5d96af3b803f3