### PR TITLE
Align token photo center and tweak menu layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -292,14 +292,13 @@ body {
 
 .token-photo {
   position: absolute;
-  /* enlarge photo by 5% and lower it proportionally */
   width: 2.9rem;
   height: 2.9rem;
   top: 50%;
   left: 50%;
   transform-origin: center;
-  /* Align the photo with the top face of the token and tilt upward */
-  transform: translate(-50%, -50%) translateZ(15.2px)
+  /* Place the bottom of the photo at the centre of the top face */
+  transform: translate(-50%, -100%) translateZ(15.2px)
     rotateX(calc(var(--board-angle, 58deg) * -1 - 10deg));
   object-fit: cover;
   border-radius: 50%;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1130,7 +1130,7 @@ export default function SnakeAndLadder() {
   return (
     <div className="p-4 pb-32 space-y-4 text-text flex flex-col justify-end items-center relative w-full flex-grow">
       {/* Action menu fixed to the top right */}
-      <div className="fixed right-2 top-4 flex flex-col items-end space-y-2 z-20">
+      <div className="fixed right-1 top-4 flex flex-col items-center space-y-2 z-20">
         <button
           onClick={handleReload}
           className="p-2 flex flex-col items-center"


### PR DESCRIPTION
## Summary
- center bottom of player token photo on the hexagonal top
- adjust action menu alignment on the right side

## Testing
- `npm test` *(fails: manifest endpoint and lobby route not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_685befce6b0083299239346c8e981064