### PR TITLE
Update snake timer and visuals

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -64,10 +64,10 @@ body {
   /* Darker blend in the centre so the board merges with the logo */
   background: linear-gradient(
     to right,
-    #0c1020,
-    #11172a,
-    #1e2235,
-    #271e26
+    #14264a,
+    #1c3158,
+    #25384f,
+    #5a3022
   );
 }
 
@@ -719,8 +719,8 @@ body {
   @apply absolute flex flex-col items-center justify-center;
   width: calc(var(--cell-width) * 2.7);
   height: calc(var(--cell-height) * 2.7);
-  /* move the pot higher so it aligns better with the final tile */
-  top: calc(var(--cell-height) * -5.5);
+  /* move the pot slightly higher */
+  top: calc(var(--cell-height) * -6);
   left: 50%;
   transform: translateX(-50%) translateZ(12px);
   z-index: 50;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useLayoutEffect, Fragment } from "react";
 import confetti from "canvas-confetti";
 import DiceRoller from "../../components/DiceRoller.jsx";
-import { dropSound, snakeSound, ladderSound, bombSound } from "../../assets/soundData.js";
+import { dropSound, snakeSound, ladderSound, bombSound, timerBeep } from "../../assets/soundData.js";
 import { AVATARS } from "../../components/AvatarPickerModal.jsx";
 import InfoPopup from "../../components/InfoPopup.jsx";
 import GameEndPopup from "../../components/GameEndPopup.jsx";
@@ -568,9 +568,7 @@ export default function SnakeAndLadder() {
     winSoundRef.current = new Audio("/assets/sounds/successful.mp3");
     diceRewardSoundRef.current = new Audio("/assets/sounds/successful.mp3");
     bombSoundRef.current = new Audio(bombSound);
-    // Use the same wheel spinning sound effect as the Spin & Win page
-    timerSoundRef.current = new Audio('/assets/sounds/spinning.mp3');
-    timerSoundRef.current.loop = true;
+    timerSoundRef.current = new Audio(timerBeep);
     return () => {
       moveSoundRef.current?.pause();
       snakeSoundRef.current?.pause();
@@ -1077,13 +1075,14 @@ export default function SnakeAndLadder() {
     const limit = currentTurn === 0 ? 15 : 3;
     setTimeLeft(limit);
     if (timerRef.current) clearInterval(timerRef.current);
-    if (timerSoundRef.current) {
-      timerSoundRef.current.currentTime = 0;
-      timerSoundRef.current.play().catch(() => {});
-    }
+    if (timerSoundRef.current) timerSoundRef.current.pause();
     timerRef.current = setInterval(() => {
       setTimeLeft((t) => {
         const next = t - 1;
+        if (next <= 5 && next >= 0 && timerSoundRef.current) {
+          timerSoundRef.current.currentTime = 0;
+          timerSoundRef.current.play().catch(() => {});
+        }
         if (next <= 0) {
           timerSoundRef.current?.pause();
           clearInterval(timerRef.current);


### PR DESCRIPTION
## Summary
- move pot higher in the Snake & Ladder board
- lighten game background gradient
- play timer sound only during the last 5 seconds

## Testing
- `npm test` *(fails: ensureTransactionArray tests)*

------
https://chatgpt.com/codex/tasks/task_e_685c0b71db3c8329a45358c0703d2f67