### PR TITLE
Remove extra text from board icons

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -643,47 +643,6 @@ body {
   }
 }
 
-.cell-offset {
-  font-size: 1rem;
-  line-height: 1;
-  font-weight: bold;
-  display: flex;
-  align-items: center;
-  gap: 1px;
-}
-
-.cell-sign {
-  font-weight: bold;
-}
-
-.cell-sign.snake {
-  color: #dc2626;
-  text-shadow: 0 0 2px #fff;
-}
-
-.cell-sign.ladder {
-  color: #16a34a;
-  text-shadow: 0 0 2px #fff;
-}
-
-.cell-sign.dice {
-  color: #dc2626;
-  text-shadow: 0 0 2px #000;
-}
-
-.cell-value {
-  color: #ffffff;
-}
-
-.board-cell.snake-cell .cell-value {
-  color: #dc2626;
-  text-shadow: 0 0 2px #fff;
-}
-
-.board-cell.ladder-cell .cell-value {
-  color: #16a34a;
-  text-shadow: 0 0 2px #fff;
-}
 
 .cell-number {
   position: relative;
@@ -894,26 +853,6 @@ body {
   line-height: 1;
 }
 
-.dice-value {
-  position: absolute;
-  bottom: -0.4rem;
-  right: -0.4rem;
-  font-size: 0.75rem;
-  font-weight: bold;
-  display: flex;
-  align-items: center;
-  gap: 1px;
-}
-
-.dice-sign {
-  color: #dc2626;
-  text-shadow: 0 0 2px #000;
-}
-
-.dice-number {
-  color: #dc2626;
-  text-shadow: 0 0 2px #000;
-}
 
 .start-hexagon {
   position: absolute;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -183,24 +183,12 @@ function Board({
               {iconEmoji && (
                 <span className="cell-icon cell-emoji">{iconEmoji}</span>
               )}
-              {offsetVal != null && (
-                <span className="cell-offset">
-                  <span className={`cell-sign ${cellType}`}> 
-                    {cellType === "snake" ? "-" : "+"}
-                  </span>
-                  <span className="cell-value">{offsetVal}</span>
-                </span>
-              )}
             </span>
           )}
           {!cellType && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
               <span className="dice-icon">\uD83C\uDFB2</span>
-              <span className="dice-value">
-                <span className="dice-sign">+</span>
-                <span className="dice-number">{diceCells[num]}</span>
-              </span>
             </span>
           )}
           {players
@@ -818,7 +806,7 @@ export default function SnakeAndLadder() {
           setTrail([{ cell: startPos, type: "snake" }]);
           setOffsetPopup({ cell: startPos, type: "snake", amount: offset });
           setTimeout(() => setOffsetPopup(null), 1000);
-          setMessage(`🐍 ${startPos} -${offset}`);
+          setMessage('🐍');
           setMessageColor("text-red-500");
           snakeSoundRef.current?.play().catch(() => {});
           const seq = [];
@@ -836,7 +824,7 @@ export default function SnakeAndLadder() {
           );
           setOffsetPopup({ cell: startPos, type: "ladder", amount: offset });
           setTimeout(() => setOffsetPopup(null), 1000);
-          setMessage(`🪜 ${startPos} +${offset}`);
+          setMessage('🪜');
           setMessageColor("text-green-500");
           ladderSoundRef.current?.play().catch(() => {});
           const seq = [];
@@ -885,7 +873,7 @@ export default function SnakeAndLadder() {
             return n;
           });
           setBonusDice(bonus);
-          setTurnMessage(`Bonus roll +${bonus}`);
+          setTurnMessage('Bonus roll');
           diceRewardSoundRef.current?.play().catch(() => {});
         } else {
           setTurnMessage("Your turn");


### PR DESCRIPTION
## Summary
- clean up Snake & Ladder board UI by showing only icon markers
- drop bonus and connector value text from gameplay messages

## Testing
- `npm test` *(fails: tests 15, pass 13, fail 2)*

------
https://chatgpt.com/codex/tasks/task_e_685c4de2d31483298809bb1becc77f79