### PR TITLE
Wait for server output in tests

### DIFF
--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -11,6 +11,17 @@ async function startServer(env) {
   const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
   server.stdout.on('data', (chunk) => process.stdout.write(chunk));
   server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+
   return server;
 }
 

--- a/test/snakeLobbyRoute.test.js
+++ b/test/snakeLobbyRoute.test.js
@@ -10,6 +10,17 @@ async function startServer(env) {
   const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
   server.stdout.on('data', (chunk) => process.stdout.write(chunk));
   server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+
   return server;
 }
 


### PR DESCRIPTION
## Summary
- ensure test server is ready in `manifest.test.js`
- ensure test server is ready in `snakeLobbyRoute.test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c566eb3bc8329b71aeff2ad8fd297