### PR TITLE
Add persistent game rooms

### DIFF
--- a/bot/models/GameRoom.js
+++ b/bot/models/GameRoom.js
@@ -1,0 +1,25 @@
+import mongoose from 'mongoose';
+
+const playerSchema = new mongoose.Schema(
+  {
+    playerId: String,
+    name: String,
+    position: { type: Number, default: 0 },
+    isActive: { type: Boolean, default: false },
+    disconnected: { type: Boolean, default: false },
+    sixStreak: { type: Number, default: 0 }
+  },
+  { _id: false }
+);
+
+const gameRoomSchema = new mongoose.Schema({
+  roomId: { type: String, unique: true },
+  capacity: { type: Number, default: 4 },
+  status: { type: String, default: 'waiting' },
+  currentTurn: { type: Number, default: 0 },
+  snakes: { type: Map, of: Number, default: {} },
+  ladders: { type: Map, of: Number, default: {} },
+  players: { type: [playerSchema], default: [] }
+});
+
+export default mongoose.model('GameRoom', gameRoomSchema);


### PR DESCRIPTION
## Summary
- persist Snake game rooms in MongoDB
- load any saved rooms when server starts
- update server routes and socket handlers to use async game room manager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c566c789c8329b8eb6f2405974199