### PR TITLE
Add Snake & Ladder background image

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -61,6 +61,7 @@ body {
   inset: 0;
   z-index: -1;
   pointer-events: none;
+  background: url('/assets/SnakeLaddersbackground.png') center/cover no-repeat;
 }
 
 @keyframes roll {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -18,7 +18,6 @@ import { fetchTelegramInfo, getProfile, deposit, getSnakeBoard } from "../../uti
 import PlayerToken from "../../components/PlayerToken.jsx";
 import AvatarTimer from "../../components/AvatarTimer.jsx";
 import ConfirmPopup from "../../components/ConfirmPopup.jsx";
-import FuturisticBackground from "../../components/FuturisticBackground.jsx";
 
 const TOKEN_COLORS = [
   { name: "blue", color: "#60a5fa" },
@@ -353,7 +352,7 @@ function Board({
 
   return (
     <div className="relative flex justify-center items-center w-screen overflow-visible">
-      <FuturisticBackground className="background-behind-board" />
+      <img src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
       <div
         ref={containerRef}
         className="overflow-y-auto"


### PR DESCRIPTION
## Summary
- replace the canvas background in Snake & Ladder with a static image
- apply the new background via CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c650589548329a501e7d63b1f6885