### PR TITLE
Fix icon scaling for Snake & Ladder board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -573,13 +573,13 @@ body {
 }
 
 .cell-icon {
-  width: 1.7rem;
-  height: 1.7rem;
+  width: calc(var(--cell-width) * 0.6);
+  height: calc(var(--cell-height) * 0.6);
   object-fit: contain;
 }
 
 .cell-emoji {
-  font-size: 1.7rem;
+  font-size: calc(var(--cell-height) * 0.6);
   line-height: 1;
 }
 


### PR DESCRIPTION
## Summary
- resize snake & ladder icons relative to cell size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cd14bec6c832995b4d7cd53eb126a