### PR TITLE
Remove cell icons for snakes and ladders

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -150,18 +150,7 @@ function Board({
             ? "dice"
             : "";
       const cellClass = cellType ? `${cellType}-cell` : "";
-      const iconImage =
-        cellType === "ladder"
-          ? "/assets/icons/ladder.svg"
-          : cellType === "snake"
-            ? "/assets/icons/snake.svg"
-            : null;
-      const offsetVal =
-        cellType === "ladder"
-          ? ladderOffsets[num]
-          : cellType === "snake"
-            ? snakeOffsets[num]
-            : null;
+      const iconImage = null;
       const style = {
         gridRowStart: ROWS - r,
         gridColumnStart: col + 1,
@@ -178,7 +167,7 @@ function Board({
           className={`board-cell ${cellClass} ${highlightClass}`}
           style={style}
         >
-          {(iconImage || offsetVal != null) && (
+          {iconImage && (
             <span className="cell-marker">
               {iconImage && (
                 <img src={iconImage} className="cell-icon" />


### PR DESCRIPTION
## Summary
- keep only the board connectors by removing small snake and ladder icons inside each tile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cd8b438bc83298a5fa3e570600cf1