### PR TITLE
Fix AI freezing and UI tweaks

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -62,6 +62,7 @@ body {
   z-index: -1;
   pointer-events: none;
   background: url('/assets/SnakeLaddersbackground.png') center/cover no-repeat;
+  filter: brightness(1.1);
 }
 
 @keyframes roll {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -392,7 +392,7 @@ export default function SnakeAndLadder() {
   const [messageColor, setMessageColor] = useState("");
   const [turnMessage, setTurnMessage] = useState("Your turn");
   const [diceVisible, setDiceVisible] = useState(true);
-  const [photoUrl, setPhotoUrl] = useState("");
+  const [photoUrl, setPhotoUrl] = useState(getTelegramPhotoUrl());
   const [pot, setPot] = useState(101);
   const [token, setToken] = useState("TPC");
   const [celebrate, setCelebrate] = useState(false);
@@ -493,6 +493,7 @@ export default function SnakeAndLadder() {
   const bombSoundRef = useRef(null);
   const timerSoundRef = useRef(null);
   const timerRef = useRef(null);
+  const aiRollTimeoutRef = useRef(null);
 
   useEffect(() => {
     const id = getTelegramId();
@@ -1010,6 +1011,17 @@ export default function SnakeAndLadder() {
       setTurnMessage('Your turn');
     }
   }, [currentTurn, setupPhase, gameOver]);
+
+  // Failsafe: ensure AI roll proceeds even if dice animation doesn't start
+  useEffect(() => {
+    if (aiRollingIndex != null) {
+      if (aiRollTimeoutRef.current) clearTimeout(aiRollTimeoutRef.current);
+      aiRollTimeoutRef.current = setTimeout(() => {
+        setAiRollTrigger((t) => t + 1);
+      }, 3000);
+      return () => clearTimeout(aiRollTimeoutRef.current);
+    }
+  }, [aiRollingIndex]);
 
   useEffect(() => {
     if (setupPhase || gameOver) return;


### PR DESCRIPTION
## Summary
- brighten snake & ladder background
- default to Telegram photo when launching snake game
- auto-trigger AI roll if dice animation stalls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cfb2830248329987461fdbccf4392