### PR TITLE
Implement simple online snake rooms

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -24,7 +24,8 @@
     "canvas-confetti": "^1.9.2",
     "@ayshrj/ludo.js": "^1.0.10",
     "three": "^0.164.0",
-    "react-markdown": "^9.0.0"
+    "react-markdown": "^9.0.0",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -15,6 +15,7 @@ import Notifications from './pages/Notifications.jsx';
 import LudoGame from './pages/Games/LudoGame.jsx';
 import HorseRacing from './pages/Games/HorseRacing.jsx';
 const SnakeAndLadder = lazy(() => import('./pages/Games/SnakeAndLadder.jsx'));
+const SnakeOnline = lazy(() => import('./pages/Games/SnakeOnline.jsx'));
 const SnakeResults = lazy(() => import('./pages/Games/SnakeResults.jsx'));
 import Lobby from './pages/Games/Lobby.jsx';
 import Games from './pages/Games.jsx';
@@ -36,6 +37,14 @@ export default function App() {
           <Route path="/games/:game/lobby" element={<Lobby />} />
           <Route path="/games/ludo" element={<LudoGame />} />
           <Route path="/games/horse" element={<HorseRacing />} />
+          <Route
+            path="/games/snake/online"
+            element={
+              <Suspense fallback={<div className="p-4 text-center">Loading...</div>}>
+                <SnakeOnline />
+              </Suspense>
+            }
+          />
           <Route
             path="/games/snake"
             element={

--- a/webapp/src/hooks/useSnakeRoom.js
+++ b/webapp/src/hooks/useSnakeRoom.js
@@ -1,0 +1,86 @@
+import { useEffect, useState, useRef } from 'react';
+import { socket } from '../utils/socket.js';
+import { getTelegramId, getTelegramFirstName } from '../utils/telegram.js';
+import { getSnakeBoard } from '../utils/api.js';
+
+export default function useSnakeRoom(roomId) {
+  const playerIdRef = useRef(null);
+  const [players, setPlayers] = useState({});
+  const [currentTurn, setCurrentTurn] = useState(null);
+  const [snakes, setSnakes] = useState({});
+  const [ladders, setLadders] = useState({});
+  const [dice, setDice] = useState(null);
+  const [winner, setWinner] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    playerIdRef.current = getTelegramId();
+    const name = getTelegramFirstName() || 'Player';
+    socket.emit('joinRoom', { roomId, playerId: playerIdRef.current, name });
+
+    getSnakeBoard(roomId)
+      .then(({ snakes = {}, ladders = {} }) => {
+        setSnakes(snakes);
+        setLadders(ladders);
+      })
+      .catch(() => {});
+
+    const handleJoined = ({ playerId, name }) => {
+      setPlayers((p) => {
+        if (p[playerId]) return p;
+        const colorIdx = Object.keys(p).length % 4;
+        const colors = ['#60a5fa', '#ef4444', '#4ade80', '#facc15'];
+        return { ...p, [playerId]: { name, position: 0, color: colors[colorIdx] } };
+      });
+    };
+
+    const handleLeft = ({ playerId }) => {
+      setPlayers((p) => {
+        const copy = { ...p };
+        delete copy[playerId];
+        return copy;
+      });
+    };
+
+    socket.on('playerJoined', handleJoined);
+    socket.on('playerLeft', handleLeft);
+    socket.on('gameStarted', () => {});
+    socket.on('turnChanged', ({ playerId }) => setCurrentTurn(playerId));
+    socket.on('diceRolled', ({ playerId, value }) => setDice({ playerId, value }));
+    const updatePos = ({ playerId, to }) => {
+      setPlayers((p) => ({ ...p, [playerId]: { ...p[playerId], position: to } }));
+    };
+    socket.on('movePlayer', updatePos);
+    socket.on('snakeOrLadder', updatePos);
+    socket.on('playerReset', ({ playerId }) => updatePos({ playerId, to: 0 }));
+    socket.on('gameWon', ({ playerId }) => setWinner(playerId));
+    socket.on('error', (msg) => setError(msg));
+
+    return () => {
+      socket.off('playerJoined', handleJoined);
+      socket.off('playerLeft', handleLeft);
+      socket.off('gameStarted');
+      socket.off('turnChanged');
+      socket.off('diceRolled');
+      socket.off('movePlayer', updatePos);
+      socket.off('snakeOrLadder', updatePos);
+      socket.off('playerReset');
+      socket.off('gameWon');
+      socket.off('error');
+    };
+  }, [roomId]);
+
+  const rollDice = () => socket.emit('rollDice');
+
+  return {
+    players,
+    currentTurn,
+    snakes,
+    ladders,
+    dice,
+    winner,
+    error,
+    playerId: playerIdRef.current,
+    rollDice,
+  };
+}

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -68,7 +68,11 @@ export default function Lobby() {
       if (stake.token) params.set('token', stake.token);
       if (stake.amount) params.set('amount', stake.amount);
     }
-    navigate(`/games/${game}?${params.toString()}`);
+    const path =
+      game === 'snake' && table?.id !== 'single'
+        ? `/games/${game}/online`
+        : `/games/${game}`;
+    navigate(`${path}?${params.toString()}`);
   };
 
   const disabled = !canStartGame(game, table, stake, aiCount);

--- a/webapp/src/pages/Games/SnakeOnline.jsx
+++ b/webapp/src/pages/Games/SnakeOnline.jsx
@@ -1,0 +1,86 @@
+import { useMemo } from 'react';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import useSnakeRoom from '../../hooks/useSnakeRoom.js';
+
+const ROWS = 20;
+const COLS = 5;
+
+function SimpleBoard({ players, snakes, ladders }) {
+  const tiles = [];
+  for (let r = ROWS - 1; r >= 0; r--) {
+    const reversed = r % 2 === 1;
+    for (let c = 0; c < COLS; c++) {
+      const num = r * COLS + (reversed ? COLS - c : c + 1);
+      tiles.push(
+        <div key={num} className="w-8 h-8 border relative text-[10px]">
+          <span className="absolute top-0 left-0">{num}</span>
+          {snakes[num] && <span className="absolute bottom-0 left-0 text-red-500">S</span>}
+          {ladders[num] && <span className="absolute bottom-0 right-0 text-green-500">L</span>}
+          {players
+            .filter((p) => p.position === num)
+            .map((p) => (
+              <span
+                key={p.id}
+                className="absolute inset-0 flex items-center justify-center text-xl"
+                style={{ color: p.color }}
+              >
+                ●
+              </span>
+            ))}
+        </div>
+      );
+    }
+  }
+  return (
+    <div
+      className="grid"
+      style={{ gridTemplateColumns: `repeat(${COLS}, 2rem)` }}
+    >
+      {tiles}
+    </div>
+  );
+}
+
+export default function SnakeOnline() {
+  useTelegramBackButton();
+  const params = new URLSearchParams(window.location.search);
+  const roomId = params.get('table') || 'snake-4';
+  const {
+    players: playerMap,
+    currentTurn,
+    snakes,
+    ladders,
+    dice,
+    winner,
+    error,
+    playerId,
+    rollDice,
+  } = useSnakeRoom(roomId);
+
+  const players = useMemo(() => Object.entries(playerMap).map(([id, p]) => ({ id, ...p })), [playerMap]);
+
+  return (
+    <div className="p-4 space-y-4 text-text">
+      <h2 className="text-xl font-bold">Multiplayer Snake &amp; Ladder</h2>
+      {error && <div className="text-red-500">{error}</div>}
+      <div>Room: {roomId}</div>
+      <SimpleBoard players={players} snakes={snakes} ladders={ladders} />
+      {winner ? (
+        <div className="font-semibold">Winner: {playerMap[winner]?.name}</div>
+      ) : (
+        <div className="space-y-2">
+          <div>Current turn: {playerMap[currentTurn]?.name}</div>
+          {dice && <div>Dice rolled: {dice.value}</div>}
+          {currentTurn === playerId && (
+            <button
+              onClick={rollDice}
+              className="px-4 py-2 bg-primary text-white rounded"
+            >
+              Roll Dice
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `socket.io-client` dependency for webapp
- add hook `useSnakeRoom` for connecting to Socket.IO rooms
- provide minimal multiplayer page `SnakeOnline.jsx`
- route lobby start to new multiplayer page
- expose `/games/snake/online` route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cfb676ffc8329a22cf9049929785d