### PR TITLE
Update snake game turn rules

### DIFF
--- a/bot/models/GameRoom.js
+++ b/bot/models/GameRoom.js
@@ -6,8 +6,7 @@ const playerSchema = new mongoose.Schema(
     name: String,
     position: { type: Number, default: 0 },
     isActive: { type: Boolean, default: false },
-    disconnected: { type: Boolean, default: false },
-    sixStreak: { type: Number, default: 0 }
+    disconnected: { type: Boolean, default: false }
   },
   { _id: false }
 );

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -29,9 +29,35 @@ test('applySnakesAndLadders resolves moves', () => {
   assert.equal(room.applySnakesAndLadders(8), 8); // none
 });
 
-test('start requires 6 and triple six skips turn', () => {
+test('start requires 6 and rolling 6 does not grant extra turn', () => {
   const io = new DummyIO();
-  const room = new GameRoom('r', io, 4, {
+  const room = new GameRoom('r', io, 2, {
+    snakes: DEFAULT_SNAKES,
+    ladders: DEFAULT_LADDERS,
+  });
+  room.rollCooldown = 0;
+  const s1 = { id: 's1', join: () => {} };
+  const s2 = { id: 's2', join: () => {} };
+  room.addPlayer('p1', 'Player1', s1);
+  room.addPlayer('p2', 'Player2', s2);
+  room.startGame();
+
+  room.rollDice(s1, 4);
+  assert.equal(room.players[0].position, 0);
+  assert.equal(room.currentTurn, 1);
+
+  room.rollDice(s2, 6);
+  assert.equal(room.players[1].position, 1);
+  assert.equal(room.currentTurn, 0);
+
+  room.rollDice(s1, 6);
+  assert.equal(room.players[0].position, 1);
+  assert.equal(room.currentTurn, 1);
+});
+
+test('rolling multiple sixes does not skip turn', () => {
+  const io = new DummyIO();
+  const room = new GameRoom('r1', io, 1, {
     snakes: DEFAULT_SNAKES,
     ladders: DEFAULT_LADDERS,
   });
@@ -40,17 +66,10 @@ test('start requires 6 and triple six skips turn', () => {
   room.addPlayer('p1', 'Player', socket);
   room.startGame();
 
-  room.rollDice(socket, 4);
-  assert.equal(room.players[0].position, 0);
-
   room.rollDice(socket, 6);
-  assert.equal(room.players[0].position, 1);
-
   room.rollDice(socket, 6);
-  assert.equal(room.players[0].position, 7);
-
   room.rollDice(socket, 6);
-  assert.equal(room.players[0].position, 7); // third six should skip move
+  assert.equal(room.players[0].position, 13);
 });
 
 test('room starts when reaching custom capacity', () => {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -384,7 +384,6 @@ export default function SnakeAndLadder() {
   useTelegramBackButton();
   const navigate = useNavigate();
   const [pos, setPos] = useState(0);
-  const [streak, setStreak] = useState(0);
   const [highlight, setHighlight] = useState(null); // { cell: number, type: string }
   const [trail, setTrail] = useState([]);
   const [tokenType, setTokenType] = useState("normal");
@@ -670,20 +669,8 @@ export default function SnakeAndLadder() {
         : value === 6;
 
       setMessage("");
-      let newStreak = rolledSix ? streak + 1 : 0;
-
-      if (newStreak === 3) {
-        setStreak(0);
-        setMessage("Third 6 rolled, turn skipped!");
-        setTurnMessage("Your turn");
-        setDiceVisible(true);
-        return;
-      }
-
-      setStreak(newStreak);
       let current = pos;
       let target = current;
-      let extraTurn = false;
 
       if (current === 100 && diceCount === 2) {
         if (rolledSix) {
@@ -723,7 +710,6 @@ export default function SnakeAndLadder() {
         return;
       }
 
-      extraTurn = rolledSix && target !== current;
 
       const steps = [];
       for (let i = current + 1; i <= target; i++) steps.push(i);
@@ -837,7 +823,7 @@ export default function SnakeAndLadder() {
         }
         setDiceVisible(true);
         if (!gameOver) {
-          const next = extraTurn ? currentTurn : (currentTurn + 1) % (ai + 1);
+          const next = (currentTurn + 1) % (ai + 1);
           setCurrentTurn(next);
         }
       };
@@ -872,7 +858,6 @@ export default function SnakeAndLadder() {
     }
 
     const rolledSix = value === 6;
-    const extraTurn = rolledSix && target !== current;
 
     const steps = [];
     for (let i = current + 1; i <= target; i++) steps.push(i);
@@ -916,7 +901,7 @@ export default function SnakeAndLadder() {
         setDiceVisible(false);
         return;
       }
-      const next = extraTurn ? index : (index + 1) % (ai + 1);
+      const next = (index + 1) % (ai + 1);
       if (next === 0) setTurnMessage('Your turn');
       setCurrentTurn(next);
       setDiceVisible(true);
@@ -1032,7 +1017,7 @@ export default function SnakeAndLadder() {
     timerRef.current = setInterval(() => {
       setTimeLeft((t) => {
         const next = t - 1;
-        if (next <= 5 && next >= 0 && timerSoundRef.current) {
+        if (next <= 7 && next >= 0 && timerSoundRef.current) {
           timerSoundRef.current.currentTime = 0;
           timerSoundRef.current.play().catch(() => {});
         }
@@ -1175,6 +1160,8 @@ export default function SnakeAndLadder() {
             }}
             onRollStart={() =>
               {
+                if (timerRef.current) clearInterval(timerRef.current);
+                timerSoundRef.current?.pause();
                 setRollingIndex(aiRollingIndex || 0);
                 if (aiRollingIndex)
                   return setTurnMessage(<>{playerName(aiRollingIndex)} rolling...</>);


### PR DESCRIPTION
## Summary
- remove six streak tracking and bonus turns in gameEngine
- drop `sixStreak` from GameRoom model
- update snake game tests for new rules
- disable bonus turns and adjust timer behaviour in SnakeAndLadder frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d082252a8832981e4bf049434a4d1