### PR TITLE
Improve snake order roll logic

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -961,24 +961,23 @@ export default function SnakeAndLadder() {
         const sorted = [...results].sort((a, b) => b.roll - a.roll);
         setInitialRolls(results);
         setTurnOrder(sorted.map((r) => r.index));
+        const first = sorted[0];
         setTurnMessage(
           <>
-            Order: {sorted.map((r, i) => (
+            Order:{' '}
+            {sorted.map((r, i) => (
               <span key={r.index} style={{ color: playerColors[r.index] }}>
-                {i > 0 && ', '} {r.index === 0 ? 'You' : `AI ${r.index}`}
-                ({r.roll})
+                {i > 0 && ', '} {r.index === 0 ? 'You' : `AI ${r.index}`}({r.roll})
               </span>
             ))}
+            . {first.index === 0 ? 'You' : `AI ${first.index}`} start first.
           </>
         );
-        const first = sorted[0];
         setTimeout(() => {
           setSetupPhase(false);
           setDiceVisible(true);
           setCurrentTurn(first.index);
-          if (first.index === 0) handleRoll(first.roll);
-          else handleAIRoll(first.index, first.roll);
-        }, 1000);
+        }, 1500);
         return;
       }
       const idxPlayer = rollOrder[idx];


### PR DESCRIPTION
## Summary
- adjust first roll logic for Snake & Ladder so initial rolls only decide turn order

## Testing
- `npm test` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_685d0c562a048329a5497067e0de4b85