### PR TITLE
Adjust snake game visuals and sounds

### DIFF
--- a/webapp/src/assets/soundData.js
+++ b/webapp/src/assets/soundData.js
@@ -6,3 +6,4 @@ export const snakeSound = "data:audio/mpeg;base64,//vQxAAAKam07lWsAA6vwh8XO7AAAB
 // Timer beep sound file path
 export const timerBeep = "/assets/sounds/clock-ticking-60-second-countdown-118231.mp3";
 export const bombSound = "/assets/sounds/a-bomb-139689.mp3";
+export const beepSound = "/assets/sounds/successful.mp3";

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -24,6 +24,7 @@ export default function DiceRoller({
 
   useEffect(() => {
     soundRef.current = new Audio(diceSound);
+    soundRef.current.volume = 0.7;
     soundRef.current.preload = 'auto';
     return () => {
       soundRef.current?.pause();

--- a/webapp/src/hooks/useTelegramBackButton.js
+++ b/webapp/src/hooks/useTelegramBackButton.js
@@ -1,14 +1,17 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-export default function useTelegramBackButton() {
+export default function useTelegramBackButton(onBack) {
   const navigate = useNavigate();
 
   useEffect(() => {
     const tg = window?.Telegram?.WebApp;
     if (!tg) return;
 
-    const handleBack = () => navigate(-1);
+    const handleBack = () => {
+      if (onBack) onBack();
+      else navigate(-1);
+    };
 
     tg.BackButton.show();
     tg.onEvent('backButtonClicked', handleBack);
@@ -17,5 +20,5 @@ export default function useTelegramBackButton() {
       tg.offEvent('backButtonClicked', handleBack);
       tg.BackButton.hide();
     };
-  }, [navigate]);
+  }, [navigate, onBack]);
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -59,10 +59,11 @@ body {
 .background-behind-board {
   position: absolute;
   inset: 0;
+  bottom: -20vh;
   z-index: -1;
   pointer-events: none;
   background: url('/assets/SnakeLaddersbackground.png') center/cover no-repeat;
-  filter: brightness(1.1);
+  filter: brightness(1.2);
 }
 
 @keyframes roll {


### PR DESCRIPTION
## Summary
- tweak board background style for brightness and height
- lower dice sound volume
- add beep sound and adjust timer logic
- allow customizing Telegram back button handler
- show "Your turn" indicator under pointer
- persist state on reload
- confirm lobby navigation when pressing back

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_685d1fa59c70832985c017b0c7fceaf3