### PR TITLE
Modify Snake & Ladder board and gameplay

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -59,7 +59,7 @@ body {
 .background-behind-board {
   position: absolute;
   inset: 0;
-  bottom: -20vh;
+  bottom: -30vh;
   z-index: -1;
   pointer-events: none;
   background: url('/assets/SnakeLaddersbackground.png') center/cover no-repeat;
@@ -563,7 +563,7 @@ body {
 
 .cell-marker {
   position: absolute;
-  top: 50%;
+  top: 55%;
   left: 50%;
   /* Center icons exactly within the tile */
   transform: translate(-50%, -50%) translateZ(6px)
@@ -577,9 +577,16 @@ body {
 }
 
 .cell-icon {
-  width: calc(var(--cell-width) * 0.6);
-  height: calc(var(--cell-height) * 0.6);
+  width: calc(var(--cell-width) * 0.7);
+  height: calc(var(--cell-height) * 0.7);
   object-fit: contain;
+}
+
+.cell-value {
+  font-size: 0.9rem;
+  font-weight: bold;
+  text-shadow: 0 0 2px #000;
+  transform: rotateX(calc(var(--board-angle, 58deg) * -1));
 }
 
 .cell-emoji {
@@ -828,10 +835,10 @@ body {
 
 .dice-marker {
   position: absolute;
-  width: 1.8rem;
-  height: 1.8rem;
+  width: 2.2rem;
+  height: 2.2rem;
   left: 50%;
-  top: 50%;
+  top: 55%;
   transform: translate(-50%, -50%) translateZ(6px)
     rotateX(calc(var(--board-angle, 58deg) * -1));
   display: flex;
@@ -842,9 +849,18 @@ body {
 }
 
 .dice-marker .dice-icon {
-  width: 1.8rem;
-  height: 1.8rem;
+  width: 2.2rem;
+  height: 2.2rem;
   object-fit: contain;
+}
+
+.dice-value {
+  margin-left: 2px;
+  font-size: 0.8rem;
+  font-weight: bold;
+  color: #ffffff;
+  text-shadow: 0 0 2px #000;
+  transform: rotateX(calc(var(--board-angle, 58deg) * -1));
 }
 
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -181,12 +181,21 @@ function Board({
               {iconImage && (
                 <img src={iconImage} className="cell-icon" />
               )}
+              {offsetVal != null && (
+                <span
+                  className="cell-value"
+                  style={{ color: cellType === 'snake' ? '#ef4444' : '#4ade80' }}
+                >
+                  {offsetVal > 0 ? `+${offsetVal}` : `-${Math.abs(offsetVal)}`}
+                </span>
+              )}
             </span>
           )}
           {!cellType && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
               <img src="/assets/icons/Dice.png" className="dice-icon" />
+              <span className="dice-value">+{diceCells[num]}</span>
             </span>
           )}
           {players
@@ -698,6 +707,8 @@ export default function SnakeAndLadder() {
       const rolledSix = Array.isArray(values)
         ? values.includes(6)
         : value === 6;
+      const rolledDoubleSix =
+        Array.isArray(values) && values.filter((v) => v === 6).length >= 2;
 
       setMessage("");
       let current = pos;
@@ -852,10 +863,15 @@ export default function SnakeAndLadder() {
           setTurnMessage("Your turn");
           setBonusDice(0);
         }
-        setDiceVisible(true);
-        if (!gameOver) {
-          const next = (currentTurn + 1) % (ai + 1);
-          setCurrentTurn(next);
+        if (rolledDoubleSix && finalPos !== FINAL_TILE && !gameOver) {
+          setTurnMessage('Roll again');
+          setDiceVisible(true);
+        } else {
+          setDiceVisible(true);
+          if (!gameOver) {
+            const next = (currentTurn + 1) % (ai + 1);
+            setCurrentTurn(next);
+          }
         }
       };
 
@@ -1215,7 +1231,7 @@ export default function SnakeAndLadder() {
             <div className="mt-4 flex flex-col items-center space-y-1">
               <div className="text-5xl">🫵</div>
               <div className="text-sm font-bold" style={{ color: playerColors[0] }}>
-                Your turn
+                {turnMessage}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- tweak background positioning
- enlarge and offset board icons
- show board icon values
- allow extra roll on double six
- display turn hint based on state

## Testing
- `npm test` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d259803e88329a73f84668614a69b