### PR TITLE
Adjust Snake game visuals

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -1,17 +1,18 @@
 import React from 'react';
 
-export default function AvatarTimer({ photoUrl, active = false, timerPct = 1, rank, name, isTurn = false }) {
+export default function AvatarTimer({ photoUrl, active = false, timerPct = 1, rank, name, isTurn = false, color }) {
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
   return (
-    <div className="relative w-10 h-10">
+    <div className="relative w-10 h-10" style={{ '--token-border-color': color }}>
       {active && (
         <div className="avatar-timer-ring" style={{ '--timer-gradient': gradient }} />
       )}
       <img
         src={photoUrl}
         alt="player"
-        className="w-10 h-10 rounded-full border border-yellow-400 object-cover"
+        className="w-10 h-10 rounded-full border-4 object-cover shadow-lg"
+        style={{ borderColor: color }}
       />
       {isTurn && (
         <span className="turn-indicator">👈</span>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -59,7 +59,7 @@ body {
 .background-behind-board {
   position: absolute;
   inset: 0;
-  bottom: -30vh;
+  bottom: -20vh;
   z-index: -1;
   pointer-events: none;
   background: url('/assets/SnakeLaddersbackground.png') center/cover no-repeat;
@@ -868,8 +868,8 @@ body {
   position: absolute;
   inset: 0;
   margin: auto;
-  width: var(--cell-height);
-  height: var(--cell-height);
+  width: calc(var(--cell-height) * 0.9);
+  height: calc(var(--cell-height) * 0.9);
   background-color: var(--hex-color, #3f3f46);
   border: 3px solid var(--hex-border-color, #27272a);
   box-sizing: border-box;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -208,7 +208,7 @@ function Board({
                   style={{
                     '--hex-color': p.color,
                     '--hex-border-color': p.color,
-                    '--hex-spin-duration': '7s',
+                    '--hex-spin-duration': '9s',
                   }}
                 />
                 <PlayerToken
@@ -368,7 +368,7 @@ function Board({
                       style={{
                         '--hex-color': p.color,
                         '--hex-border-color': p.color,
-                        '--hex-spin-duration': '7s',
+                        '--hex-spin-duration': '9s',
                       }}
                     />
                     <PlayerToken
@@ -1140,7 +1140,7 @@ export default function SnakeAndLadder() {
           onClick={() => setMuted((m) => !m)}
           className="p-2 flex flex-col items-center"
         >
-          <span className="text-xl">🔇</span>
+          <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
           <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
         </button>
         <button
@@ -1160,6 +1160,7 @@ export default function SnakeAndLadder() {
               key={`player-${p.index}`}
               photoUrl={p.photoUrl}
               active={p.index === currentTurn}
+              color={p.color}
               rank={rankMap[p.index]}
               name={p.index === 0 ? 'You' : `AI ${p.index}`}
               isTurn={p.index === currentTurn}
@@ -1224,13 +1225,22 @@ export default function SnakeAndLadder() {
             }
             clickable={!aiRollingIndex && !playerAutoRolling && rollCooldown === 0}
             numDice={diceCount + bonusDice}
-            trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
+            trigger={aiRollingIndex != null ? aiRollTrigger : playerRollTrigger}
             showButton={!aiRollingIndex && !playerAutoRolling}
           />
           {currentTurn === 0 && !aiRollingIndex && !playerAutoRolling && (
-            <div className="mt-4 flex flex-col items-center space-y-1">
+            <div
+              className="mt-4 flex flex-col items-center space-y-1 cursor-pointer"
+              onClick={() => {
+                if (rollCooldown > 0) return;
+                setPlayerRollTrigger((r) => r + 1);
+              }}
+            >
               <div className="text-5xl">🫵</div>
-              <div className="text-sm font-bold" style={{ color: playerColors[0] }}>
+              <div
+                className="text-lg font-bold"
+                style={{ color: playerColors[0], textShadow: '0 0 4px #000' }}
+              >
                 {turnMessage}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- let players roll by tapping the 'your turn' prompt
- enlarge the prompt text and add shadow
- slow down and shrink the rotating hexagon
- update leaderboard avatars to use token-colour borders
- tweak background position and mute icon

## Testing
- `npm test` *(fails: cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685d2a069478832997db017d0b8ede28