### PR TITLE
Remove spin timer sound

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1062,10 +1062,6 @@ export default function SnakeAndLadder() {
     setTimeLeft(limit);
     if (timerRef.current) clearInterval(timerRef.current);
     if (timerSoundRef.current) timerSoundRef.current.pause();
-    if (currentTurn === 0 && beepSoundRef.current) {
-      beepSoundRef.current.currentTime = 0;
-      if (!muted) beepSoundRef.current.play().catch(() => {});
-    }
     timerRef.current = setInterval(() => {
       setTimeLeft((t) => {
         const next = t - 1;


### PR DESCRIPTION
## Summary
- remove spin sound from the user's turn timer

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_685d46fedbb8832985b73387d73ad247