### PR TITLE
Fix Ludo AI token movement

### DIFF
--- a/tonplaygram_ludo.py
+++ b/tonplaygram_ludo.py
@@ -95,7 +95,12 @@ PATH: List[tuple[int, int]] = [
 def load_sessions() -> Dict:
     if DATA_FILE.exists():
         with DATA_FILE.open("r") as f:
-            return json.load(f)
+            data = json.load(f)
+        for sess in data.values():
+            tokens = sess.get("tokens")
+            if tokens:
+                sess["tokens"] = {int(k): v for k, v in tokens.items()}
+        return data
     return {}
 
 


### PR DESCRIPTION
## Summary
- fix sessions loading so tokens map to integer player IDs

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685d624144b48329980abc14c9d590cf