### PR TITLE
Disable capturing and fix turn timing

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -151,11 +151,11 @@ export class GameRoom {
         }
     }
 
+    // Players no longer send others back to start when landing on the same tile
+    // so each token only moves based on its own roll.
     for (const p of this.players) {
       if (p !== player && !p.disconnected && p.position === player.position) {
-        p.position = 0;
-        p.isActive = false;
-        this.io.to(this.id).emit('playerReset', { playerId: p.playerId, index: p.index });
+        // Capturing disabled
       }
     }
 
@@ -175,10 +175,16 @@ export class GameRoom {
     do {
       this.currentTurn = (this.currentTurn + 1) % this.players.length;
     } while (this.players[this.currentTurn].disconnected);
-    setTimeout(() => {
+    if (this.turnDelay === 0) {
+      // Immediately advance when no delay is configured so tests can run
       this.turnLock = false;
       this.emitNextTurn();
-    }, this.turnDelay);
+    } else {
+      setTimeout(() => {
+        this.turnLock = false;
+        this.emitNextTurn();
+      }, this.turnDelay);
+    }
   }
 
   handleDisconnect(socket) {

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -137,7 +137,7 @@ test('rolling too quickly triggers anti-cheat', () => {
   assert.ok(err, 'error event should be emitted');
 });
 
-test('landing on another player sends them to start', () => {
+test('landing on another player no longer affects them', () => {
   const io = new DummyIO();
   const room = new GameRoom('r5', io, 2, {
     snakes: {},
@@ -160,8 +160,8 @@ test('landing on another player sends them to start', () => {
   room.rollDice(s1, 2); // land on player 2
 
   assert.equal(room.players[0].position, 3);
-  assert.equal(room.players[1].position, 0);
+  assert.equal(room.players[1].position, 3);
   const resetEvent = io.emitted.find(e => e.event === 'playerReset');
-  assert.ok(resetEvent && resetEvent.data.playerId === 'p2');
+  assert.ok(!resetEvent, 'playerReset should not be emitted');
 });
 

--- a/tonplaygram_ludo.py
+++ b/tonplaygram_ludo.py
@@ -326,12 +326,8 @@ def apply_roll(session:GameSession, player:Dict, dice:int):
         session.tokens[player['id']][idx]=max(0,session.tokens[player['id']][idx])+dice
         if session.tokens[player['id']][idx]<PATH_LENGTH:
             pos=(START_INDICES[player['color']]+session.tokens[player['id']][idx])%PATH_LENGTH
-            for p in session.players:
-                if p['id']==player['id']:
-                    continue
-                for j,st in enumerate(session.tokens[p['id']]):
-                    if 0<=st<PATH_LENGTH and (START_INDICES[p['color']]+st)%PATH_LENGTH==pos:
-                        session.tokens[p['id']][j]=-1
+            # Capturing disabled: tokens sharing a square no longer send
+            # others back to start.
         session.next_turn(dice==6)
     return messages
 


### PR DESCRIPTION
## Summary
- remove capture logic from Ludo and Snakes & Ladders so pieces don't reset when another player lands on them
- adjust snake game tests for new rule
- immediately advance turn when `turnDelay` is 0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d6d06cfa083299554f74d215e7390