### PR TITLE
Fix token movement broadcast

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -125,7 +125,9 @@ export class GameRoom {
     this.turnLock = true;
 
     const dice = value ?? Math.floor(Math.random() * 6) + 1;
-    this.io.to(this.id).emit('diceRolled', { playerId: player.playerId, index: player.index, value: dice });
+    if (typeof socket.emit === 'function') {
+      socket.emit('diceRolled', { playerId: player.playerId, index: player.index, value: dice });
+    }
 
     let from = player.position;
     let to = player.position;


### PR DESCRIPTION
## Summary
- only send dice results to the rolling player
- keep broadcasting moves to the room

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d7fd331208329917aee1c4b4ecfc9