### PR TITLE
Fix turn order and tweak board background

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -3,7 +3,7 @@ export const FINAL_TILE = 101;
 export const DEFAULT_SNAKES = { 99: 80 };
 export const DEFAULT_LADDERS = { 3: 22, 27: 46 };
 export const ROLL_COOLDOWN_MS = 1000;
-export const TURN_DELAY_MS = 2000;
+export const TURN_DELAY_MS = 6000;
 
 import GameRoomModel from './models/GameRoom.js';
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -63,8 +63,8 @@ body {
   z-index: -1;
   pointer-events: none;
   background: url('/assets/SnakeLaddersbackground.png') center/cover no-repeat;
-  filter: brightness(1.4);
-  transform: translateY(20px);
+  filter: brightness(1.8);
+  transform: translateY(60px);
 }
 
 @keyframes roll {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1219,6 +1219,7 @@ export default function SnakeAndLadder() {
               {
                 if (timerRef.current) clearInterval(timerRef.current);
                 timerSoundRef.current?.pause();
+                setMoving(true);
                 setRollingIndex(aiRollingIndex ?? 0);
                 if (aiRollingIndex != null)
                   return setTurnMessage(<>{playerName(aiRollingIndex)} rolling...</>);


### PR DESCRIPTION
## Summary
- prevent new rolls until board animations finish
- extend backend turn delay
- brighten and lower Snakes & Ladders background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d8d4a42548329a35a35a6483da50e