### PR TITLE
Implement token captures in Snake & Ladder

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -153,9 +153,27 @@ export class GameRoom {
         }
     }
 
-    // Originally pieces landing on an occupied tile would send the other player
-    // back to start. To keep each player's movement isolated this behaviour has
-    // been removed.
+    // If a player lands on another, that opponent returns to start and must
+    // roll a six again to become active. This reinstates the classic capture
+    // mechanic removed in the simplified mode.
+    if (player.position !== 0) {
+      for (const opp of this.players) {
+        if (
+          opp !== player &&
+          opp.isActive &&
+          opp.position === player.position &&
+          opp.position !== 0
+        ) {
+          opp.position = 0;
+          opp.isActive = false;
+          this.io.to(this.id).emit('playerReset', {
+            playerId: opp.playerId,
+            index: opp.index
+          });
+        }
+      }
+    }
+
 
     if (player.position === FINAL_TILE) {
       this.status = 'finished';

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -160,8 +160,9 @@ test('landing on another player sends them to start', () => {
   room.rollDice(s1, 2); // land on player 2
 
   assert.equal(room.players[0].position, 3);
-  assert.equal(room.players[1].position, 3);
+  assert.equal(room.players[1].position, 0);
+  assert.equal(room.players[1].isActive, false);
   const resetEvent = io.emitted.find(e => e.event === 'playerReset');
-  assert.ok(!resetEvent, 'no player should be reset');
+  assert.ok(resetEvent, 'playerReset should be emitted');
 });
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -64,7 +64,7 @@ body {
   pointer-events: none;
   background: url('/assets/SnakeLaddersbackground.png') center/cover no-repeat;
   filter: brightness(1.8);
-  transform: translateY(60px);
+  transform: translateY(120px);
 }
 
 @keyframes roll {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -827,8 +827,20 @@ export default function SnakeAndLadder() {
         setTrail([]);
         setTokenType(type);
         setTimeout(() => setHighlight(null), 300);
-        // Removed piece capture behaviour to keep each player's position
-        // independent. Tokens can now share the same tile without resetting.
+        // Capture any AI pieces on the same tile and reset them to start.
+        setAiPositions((positions) => {
+          return positions.map((p, idx) => {
+            if (p === finalPos && finalPos !== 0 && finalPos !== FINAL_TILE) {
+              setBurning((b) => [...b, idx + 1]);
+              setTimeout(
+                () => setBurning((b) => b.filter((i) => i !== idx + 1)),
+                1500
+              );
+              return 0;
+            }
+            return p;
+          });
+        });
         if (finalPos === FINAL_TILE && !ranking.includes('You')) {
           const first = ranking.length === 0;
           if (first) {
@@ -939,8 +951,27 @@ export default function SnakeAndLadder() {
       setAiPositions([...positions]);
       setHighlight({ cell: finalPos, type });
       setTrail([]);
-      // Do not reset other players when tokens overlap. Dice results only
-      // move the rolling player's token in this mode.
+      // Capture the player's token or other AI tokens if landed upon.
+      if (finalPos !== 0 && finalPos !== FINAL_TILE) {
+        if (pos === finalPos) {
+          setBurning((b) => [...b, 0]);
+          setTimeout(() => setBurning((b) => b.filter((i) => i !== 0)), 1500);
+          setPos(0);
+        }
+        setAiPositions((curr) =>
+          curr.map((p, idx) => {
+            if (idx !== index - 1 && p === finalPos) {
+              setBurning((b) => [...b, idx + 1]);
+              setTimeout(
+                () => setBurning((b) => b.filter((i) => i !== idx + 1)),
+                1500
+              );
+              return 0;
+            }
+            return p;
+          })
+        );
+      }
       setTimeout(() => setHighlight(null), 300);
       if (finalPos === FINAL_TILE && !ranking.includes(`AI ${index}`)) {
         const first = ranking.length === 0;


### PR DESCRIPTION
## Summary
- allow piece capture again in `gameEngine`
- test new capture behaviour
- move game background down
- reset captured pieces in web game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685da3a1e3e483299eee8526cae3cca7