### PR TITLE
Disable snake capture rule

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -153,26 +153,8 @@ export class GameRoom {
         }
     }
 
-    // If a player lands on another, that opponent returns to start and must
-    // roll a six again to become active. This reinstates the classic capture
-    // mechanic removed in the simplified mode.
-    if (player.position !== 0) {
-      for (const opp of this.players) {
-        if (
-          opp !== player &&
-          opp.isActive &&
-          opp.position === player.position &&
-          opp.position !== 0
-        ) {
-          opp.position = 0;
-          opp.isActive = false;
-          this.io.to(this.id).emit('playerReset', {
-            playerId: opp.playerId,
-            index: opp.index
-          });
-        }
-      }
-    }
+    // In the simplified rules players do not capture each other. Landing on an
+    // occupied tile has no effect on the other player's piece.
 
 
     if (player.position === FINAL_TILE) {

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -137,7 +137,7 @@ test('rolling too quickly triggers anti-cheat', () => {
   assert.ok(err, 'error event should be emitted');
 });
 
-test('landing on another player sends them to start', () => {
+test('landing on another player does not reset them', () => {
   const io = new DummyIO();
   const room = new GameRoom('r5', io, 2, {
     snakes: {},
@@ -160,9 +160,9 @@ test('landing on another player sends them to start', () => {
   room.rollDice(s1, 2); // land on player 2
 
   assert.equal(room.players[0].position, 3);
-  assert.equal(room.players[1].position, 0);
-  assert.equal(room.players[1].isActive, false);
+  assert.equal(room.players[1].position, 3);
+  assert.equal(room.players[1].isActive, true);
   const resetEvent = io.emitted.find(e => e.event === 'playerReset');
-  assert.ok(resetEvent, 'playerReset should be emitted');
+  assert.ok(!resetEvent, 'playerReset should not be emitted');
 });
 


### PR DESCRIPTION
## Summary
- disable token capturing logic in snake game engine
- update tests to match new no-capture behaviour

## Testing
- `npm test` *(fails: cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685da79d6b948329aadfb2f7c12a751e