### PR TITLE
Fix token movement logic

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -827,20 +827,10 @@ export default function SnakeAndLadder() {
         setTrail([]);
         setTokenType(type);
         setTimeout(() => setHighlight(null), 300);
-        // Capture any AI pieces on the same tile and reset them to start.
-        setAiPositions((positions) => {
-          return positions.map((p, idx) => {
-            if (p === finalPos && finalPos !== 0 && finalPos !== FINAL_TILE) {
-              setBurning((b) => [...b, idx + 1]);
-              setTimeout(
-                () => setBurning((b) => b.filter((i) => i !== idx + 1)),
-                1500
-              );
-              return 0;
-            }
-            return p;
-          });
-        });
+        // In the simplified rules tokens do not capture each other.
+        // Simply keep the other pieces in place when the player lands
+        // on an occupied tile so only the roller's position changes.
+        setAiPositions((positions) => positions);
         if (finalPos === FINAL_TILE && !ranking.includes('You')) {
           const first = ranking.length === 0;
           if (first) {
@@ -951,27 +941,8 @@ export default function SnakeAndLadder() {
       setAiPositions([...positions]);
       setHighlight({ cell: finalPos, type });
       setTrail([]);
-      // Capture the player's token or other AI tokens if landed upon.
-      if (finalPos !== 0 && finalPos !== FINAL_TILE) {
-        if (pos === finalPos) {
-          setBurning((b) => [...b, 0]);
-          setTimeout(() => setBurning((b) => b.filter((i) => i !== 0)), 1500);
-          setPos(0);
-        }
-        setAiPositions((curr) =>
-          curr.map((p, idx) => {
-            if (idx !== index - 1 && p === finalPos) {
-              setBurning((b) => [...b, idx + 1]);
-              setTimeout(
-                () => setBurning((b) => b.filter((i) => i !== idx + 1)),
-                1500
-              );
-              return 0;
-            }
-            return p;
-          })
-        );
-      }
+      // In this mode tokens cannot capture each other, so just ignore
+      // any pieces already on the destination cell.
       setTimeout(() => setHighlight(null), 300);
       if (finalPos === FINAL_TILE && !ranking.includes(`AI ${index}`)) {
         const first = ranking.length === 0;


### PR DESCRIPTION
## Summary
- disable piece capturing so AI dice rolls don't move the player's token
- keep AI and player positions independent when pieces land on the same cell

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685daadf0c848329bed2a53814a96f9b