### PR TITLE
Restore classic token capture logic

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -153,8 +153,26 @@ export class GameRoom {
         }
     }
 
-    // In the simplified rules players do not capture each other. Landing on an
-    // occupied tile has no effect on the other player's piece.
+    // If a player lands on another, that opponent returns to start and must
+    // roll a six again to become active. This reinstates the classic capture
+    // mechanic removed in the simplified mode.
+    if (player.position !== 0) {
+      for (const opp of this.players) {
+        if (
+          opp !== player &&
+          opp.isActive &&
+          opp.position === player.position &&
+          opp.position !== 0
+        ) {
+          opp.position = 0;
+          opp.isActive = false;
+          this.io.to(this.id).emit('playerReset', {
+            playerId: opp.playerId,
+            index: opp.index
+          });
+        }
+      }
+    }
 
 
     if (player.position === FINAL_TILE) {

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -137,7 +137,7 @@ test('rolling too quickly triggers anti-cheat', () => {
   assert.ok(err, 'error event should be emitted');
 });
 
-test('landing on another player does not reset them', () => {
+test('landing on another player sends them to start', () => {
   const io = new DummyIO();
   const room = new GameRoom('r5', io, 2, {
     snakes: {},
@@ -160,9 +160,9 @@ test('landing on another player does not reset them', () => {
   room.rollDice(s1, 2); // land on player 2
 
   assert.equal(room.players[0].position, 3);
-  assert.equal(room.players[1].position, 3);
-  assert.equal(room.players[1].isActive, true);
+  assert.equal(room.players[1].position, 0);
+  assert.equal(room.players[1].isActive, false);
   const resetEvent = io.emitted.find(e => e.event === 'playerReset');
-  assert.ok(!resetEvent, 'playerReset should not be emitted');
+  assert.ok(resetEvent && resetEvent.data.playerId === 'p2');
 });
 


### PR DESCRIPTION
## Summary
- restore capture logic in game engine
- reimplement capture mechanics in Snake & Ladder React page
- update tests to expect captured tokens reset to start

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685daebec10c8329ba93089249d3683f