### PR TITLE
Fix local token updates for multiplayer moves

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -17,6 +17,7 @@ import { fetchTelegramInfo, getProfile, deposit, getSnakeBoard } from "../../uti
 import PlayerToken from "../../components/PlayerToken.jsx";
 import AvatarTimer from "../../components/AvatarTimer.jsx";
 import ConfirmPopup from "../../components/ConfirmPopup.jsx";
+import { socket } from "../../utils/socket.js";
 
 const TOKEN_COLORS = [
   { name: "blue", color: "#60a5fa" },
@@ -390,6 +391,7 @@ function Board({
 
 export default function SnakeAndLadder() {
   const navigate = useNavigate();
+  const myPlayerId = getTelegramId();
   const [pos, setPos] = useState(0);
   const [highlight, setHighlight] = useState(null); // { cell: number, type: string }
   const [trail, setTrail] = useState([]);
@@ -474,6 +476,22 @@ export default function SnakeAndLadder() {
     }, 1000);
     return () => clearInterval(id);
   }, [rollCooldown]);
+
+  useEffect(() => {
+    const handleMove = ({ playerId, index, from, to }) => {
+      if (playerId === myPlayerId) {
+        setPos(to);
+      } else {
+        setAiPositions((arr) => {
+          const copy = [...arr];
+          if (index > 0 && index - 1 < copy.length) copy[index - 1] = to;
+          return copy;
+        });
+      }
+    };
+    socket.on('movePlayer', handleMove);
+    return () => socket.off('movePlayer', handleMove);
+  }, [myPlayerId]);
 
   const playerName = (idx) => (
     <span style={{ color: playerColors[idx] }}>


### PR DESCRIPTION
## Summary
- register socket util in the Snake & Ladder game
- store the current player's id and use it when processing move events
- only update my token when the `movePlayer` event is for me

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dc362d1748329930b2a4c843a2b8d