### PR TITLE
Improve snake game reload and lobby back handling

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -9,7 +9,16 @@ import { canStartGame } from '../../utils/lobby.js';
 export default function Lobby() {
   const { game } = useParams();
   const navigate = useNavigate();
-  useTelegramBackButton();
+  useTelegramBackButton(() => navigate('/games', { replace: true }));
+
+  useEffect(() => {
+    const handlePop = (e) => {
+      e.preventDefault();
+      navigate('/games', { replace: true });
+    };
+    window.addEventListener('popstate', handlePop);
+    return () => window.removeEventListener('popstate', handlePop);
+  }, [navigate]);
 
   const [tables, setTables] = useState([]);
   const [table, setTable] = useState(null);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1152,8 +1152,32 @@ export default function SnakeAndLadder() {
     setShowLobbyConfirm(false);
   };
 
-  const handleReload = () => {
-    window.location.reload();
+  const handleReload = async () => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const table = params.get('table') || 'snake-4';
+      const { snakes: snakesObj = {}, ladders: laddersObj = {} } =
+        await getSnakeBoard(table);
+      const limit = (obj) =>
+        Object.fromEntries(Object.entries(obj).slice(0, 8));
+      const snakesLim = limit(snakesObj);
+      const laddersLim = limit(laddersObj);
+      setSnakes(snakesLim);
+      setLadders(laddersLim);
+      const snk = {};
+      Object.entries(snakesLim).forEach(([s, e]) => {
+        snk[s] = s - e;
+      });
+      const lad = {};
+      Object.entries(laddersLim).forEach(([s, e]) => {
+        const end = typeof e === 'object' ? e.end : e;
+        lad[s] = end - s;
+      });
+      setSnakeOffsets(snk);
+      setLadderOffsets(lad);
+    } catch {
+      // ignore errors so players stay in the game
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- keep Snake & Ladder board state on reload instead of reloading the whole page
- make lobby back navigation always return to the games page before leaving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e44b90d708329913c1538f0528df2