### PR TITLE
Fix AI ranking display

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1134,7 +1134,7 @@ export default function SnakeAndLadder() {
     .map((p, i) => ({ idx: i, pos: p.position }))
     .sort((a, b) => b.pos - a.pos)
     .forEach((p, i) => {
-      rankMap[p.idx] = p.pos === 0 ? 0 : i + 1;
+      rankMap[p.idx] = i + 1;
     });
 
   const handleForfeit = () => {


### PR DESCRIPTION
## Summary
- show leaderboard numbers for all players, even before they move

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e4c3718108329915d52294e8a296d