### PR TITLE
Restore game engine token logic to yesterday state

### DIFF
--- a/bot/models/GameRoom.js
+++ b/bot/models/GameRoom.js
@@ -4,7 +4,6 @@ const playerSchema = new mongoose.Schema(
   {
     playerId: String,
     name: String,
-    index: Number,
     position: { type: Number, default: 0 },
     isActive: { type: Boolean, default: false },
     disconnected: { type: Boolean, default: false }

--- a/test/aiTokenIsolation.test.js
+++ b/test/aiTokenIsolation.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * Simulates React's asynchronous state updates by queueing
+ * updater functions and applying them sequentially.
+ */
+function createState(initial) {
+  let state = initial;
+  const queue = [];
+  const setState = (updater) => {
+    queue.push(updater);
+  };
+  const flush = () => {
+    while (queue.length) {
+      const updater = queue.shift();
+      state = updater(state);
+    }
+  };
+  const getState = () => state;
+  return { setState, flush, getState };
+}
+
+test('AI moves update only their own token', () => {
+  const { setState: setAiPositions, flush, getState } = createState([0, 0]);
+
+  // Schedule two moves concurrently for AI 1 and AI 2
+  setAiPositions(arr => arr.map((p, i) => (i === 0 ? 3 : p)));
+  setAiPositions(arr => arr.map((p, i) => (i === 1 ? 5 : p)));
+
+  flush();
+
+  assert.deepEqual(getState(), [3, 5]);
+});

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -63,8 +63,8 @@ body {
   z-index: -1;
   pointer-events: none;
   background: url('/assets/SnakeLaddersbackground.png') center/cover no-repeat;
-  filter: brightness(1.8);
-  transform: translateY(120px);
+  filter: brightness(1.4);
+  transform: translateY(20px);
 }
 
 @keyframes roll {


### PR DESCRIPTION
## Summary
- revert game engine to state from yesterday midday
- restore GameRoom model schema
- reintroduce AI token isolation test
- adjust board background brightness

## Testing
- `npm test` *(fails: server exposes manifest endpoint from TONCONNECT_MANIFEST_URL)*

------
https://chatgpt.com/codex/tasks/task_e_685e6d6258cc8329a61178896c5cecb5