### PR TITLE
Update board visuals and leaderboard frames

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function AvatarTimer({ photoUrl, active = false, timerPct = 1, rank, name, isTurn = false }) {
+export default function AvatarTimer({ photoUrl, active = false, timerPct = 1, rank, name, isTurn = false, color }) {
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
   return (
@@ -11,7 +11,8 @@ export default function AvatarTimer({ photoUrl, active = false, timerPct = 1, ra
       <img
         src={photoUrl}
         alt="player"
-        className="w-10 h-10 rounded-full border border-yellow-400 object-cover"
+        className="w-10 h-10 rounded-full border-2 object-cover"
+        style={{ borderColor: color || '#fde047' }}
       />
       {isTurn && (
         <span className="turn-indicator">👈</span>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -61,8 +61,8 @@ body {
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  background: url('/assets/SnakeLaddersbackground.png') center/cover no-repeat;
-  filter: brightness(1.1);
+  filter: brightness(1.2);
+  transform: translateY(40px);
 }
 
 @keyframes roll {
@@ -575,6 +575,21 @@ body {
   z-index: 3; /* ensure icons appear above connectors */
 }
 
+.offset-text {
+  font-size: 0.75rem;
+  font-weight: bold;
+  text-shadow: 0 0 2px #000;
+  transform: rotateX(calc(var(--board-angle, 58deg) * -1));
+}
+
+.snake-text {
+  color: #ef4444;
+}
+
+.ladder-text {
+  color: #22c55e;
+}
+
 .cell-icon {
   width: calc(var(--cell-width) * 0.6);
   height: calc(var(--cell-height) * 0.6);
@@ -844,6 +859,15 @@ body {
   width: 1.8rem;
   height: 1.8rem;
   object-fit: contain;
+}
+
+.dice-value {
+  margin-left: 0.2rem;
+  font-size: 0.75rem;
+  font-weight: bold;
+  color: #3b82f6;
+  text-shadow: 0 0 2px #000;
+  transform: rotateX(calc(var(--board-angle, 58deg) * -1));
 }
 
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -152,7 +152,7 @@ function Board({
         cellType === "ladder"
           ? "/assets/icons/ladder.svg"
           : cellType === "snake"
-            ? "/assets/icons/snake.svg"
+            ? "/assets/icons/snake.png"
             : null;
       const offsetVal =
         cellType === "ladder"
@@ -178,8 +178,17 @@ function Board({
         >
           {(iconImage || offsetVal != null) && (
             <span className="cell-marker">
-              {iconImage && (
-                <img src={iconImage} className="cell-icon" />
+              {iconImage && <img src={iconImage} className="cell-icon" />}
+              {offsetVal != null && (
+                <span
+                  className={`offset-text ${
+                    cellType === 'snake'
+                      ? 'snake-text'
+                      : 'ladder-text'
+                  }`}
+                >
+                  {offsetVal > 0 ? `+${offsetVal}` : offsetVal}
+                </span>
               )}
             </span>
           )}
@@ -187,6 +196,7 @@ function Board({
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
               <img src="/assets/icons/Dice.png" className="dice-icon" />
+              <span className="dice-value">+{diceCells[num]}</span>
             </span>
           )}
           {players
@@ -1134,6 +1144,7 @@ export default function SnakeAndLadder() {
                   ? timeLeft / (p.index === 0 ? 15 : 3)
                   : 1
               }
+              color={p.color}
             />
           ))}
       </div>


### PR DESCRIPTION
## Summary
- update snake graphic to use PNG icon
- show offset values beside board icons
- display dice values with dice icons
- allow AvatarTimer to receive custom frame color
- brighten and lower the board background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e7cccd5788329ac299b34c8eec36f