### PR TITLE
Update Snake game styles and AI start logic

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -12,7 +12,10 @@ export default function AvatarTimer({ photoUrl, active = false, timerPct = 1, ra
         src={photoUrl}
         alt="player"
         className="w-10 h-10 rounded-full border-2 object-cover"
-        style={{ borderColor: color || '#fde047' }}
+        style={{
+          borderColor: color || '#fde047',
+          boxShadow: isTurn ? `0 0 6px ${color || '#fde047'}` : undefined,
+        }}
       />
       {isTurn && (
         <span className="turn-indicator">👈</span>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -61,8 +61,8 @@ body {
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  filter: brightness(1.5);
-  transform: translateY(70px);
+  filter: brightness(1.8);
+  transform: translateY(90px);
 }
 
 @keyframes roll {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -890,7 +890,7 @@ export default function SnakeAndLadder() {
     let current = positions[index - 1];
     let target = current;
     if (current === 0) {
-      if (rolledSix) target = 1;
+      if (rolledSix) target = Math.min(value, FINAL_TILE);
     } else if (current === 100) {
       if (value === 1) target = FINAL_TILE;
     } else if (current + value <= FINAL_TILE) {


### PR DESCRIPTION
## Summary
- brighten and shift the board background image
- highlight current player avatar with a drop shadow
- allow AI to move the rolled total when starting after a six

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e8c97cad48329a5bcd7edcbb8c613