### PR TITLE
Improve snake game interaction and visuals

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -56,8 +56,8 @@ export default function DiceRoller({
       return Math.floor(Math.random() * 6) + 1;
     };
 
-    const tick = 50; // ms between face changes
-    const iterations = 19; // show final value just before animation ends
+    const tick = 35; // ms between face changes
+    const iterations = 14; // show final value just before animation ends
     let count = 0;
 
     const id = setInterval(() => {

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -61,7 +61,7 @@ body {
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  filter: brightness(1.8);
+  filter: brightness(2);
   transform: translateY(90px);
 }
 
@@ -78,7 +78,7 @@ body {
 }
 
 .animate-roll {
-  animation: roll 1s ease-in-out;
+  animation: roll 0.5s ease-in-out;
 }
 
 .dice-container {
@@ -235,7 +235,7 @@ body {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) translateZ(40px);
-  font-size: 3rem;
+  font-size: 4.5rem;
   pointer-events: none;
   animation: flame-up 1.5s forwards;
 }
@@ -250,7 +250,7 @@ body {
 @keyframes flame-up {
   to {
     opacity: 0;
-    transform: translate(-50%, -80%) translateZ(40px) scale(2);
+    transform: translate(-50%, -80%) translateZ(40px) scale(3);
   }
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -323,7 +323,7 @@ function Board({
         style={{
           overflowX: "hidden",
           height: "100vh",
-          overscrollBehaviorY: "contain",
+          overscrollBehaviorY: "none",
           paddingTop,
           paddingBottom,
         }}
@@ -1111,34 +1111,38 @@ export default function SnakeAndLadder() {
       if (aiRollTimeoutRef.current) clearTimeout(aiRollTimeoutRef.current);
       aiRollTimeoutRef.current = setTimeout(() => {
         setAiRollTrigger((t) => t + 1);
-      }, 3000);
+      }, 1800);
       return () => clearTimeout(aiRollTimeoutRef.current);
     }
   }, [aiRollingIndex]);
 
   useEffect(() => {
     if (setupPhase || gameOver) return;
-    const limit = currentTurn === 0 ? 15 : 3;
+    if (currentTurn !== 0) {
+      setTimeLeft(2);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        triggerAIRoll(currentTurn);
+      }, 1800);
+      return () => clearTimeout(timerRef.current);
+    }
+    const limit = 15;
     setTimeLeft(limit);
     if (timerRef.current) clearInterval(timerRef.current);
     if (timerSoundRef.current) timerSoundRef.current.pause();
     timerRef.current = setInterval(() => {
       setTimeLeft((t) => {
         const next = t - 1;
-        if (next <= 7 && next >= 0 && timerSoundRef.current) {
+        if (currentTurn === 0 && next <= 7 && next >= 0 && timerSoundRef.current) {
           timerSoundRef.current.currentTime = 0;
           if (!muted) timerSoundRef.current.play().catch(() => {});
         }
         if (next <= 0) {
           timerSoundRef.current?.pause();
           clearInterval(timerRef.current);
-          if (currentTurn === 0) {
-            setPlayerAutoRolling(true);
-            setTurnMessage('Rolling...');
-            setPlayerRollTrigger((r) => r + 1);
-          } else {
-            triggerAIRoll(currentTurn);
-          }
+          setPlayerAutoRolling(true);
+          setTurnMessage('Rolling...');
+          setPlayerRollTrigger((r) => r + 1);
         }
         return next;
       });
@@ -1280,7 +1284,12 @@ export default function SnakeAndLadder() {
                 return setTurnMessage("Rolling...");
               }
             }
-            clickable={!aiRollingIndex && !playerAutoRolling && rollCooldown === 0}
+            clickable={
+              !aiRollingIndex &&
+              !playerAutoRolling &&
+              rollCooldown === 0 &&
+              currentTurn === 0
+            }
             numDice={diceCount + bonusDice}
             trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
             showButton={false}


### PR DESCRIPTION
## Summary
- enlarge burn animation
- brighten game board background
- allow dice rolls only during the player's turn
- trigger AI rolls after ~1.8s
- play timer beeps only on player's turn
- speed up dice animation

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685e99d50eb883299e3e193198304680