### PR TITLE
Adjust entry roll & UI tweaks

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -566,9 +566,9 @@ body {
 
 .cell-marker {
   position: absolute;
-  top: 50%;
+  top: 55%;
   left: 50%;
-  /* Center icons exactly within the tile */
+  /* Center icons slightly lower within the tile */
   transform: translate(-50%, -50%) translateZ(6px)
     rotateX(calc(var(--board-angle, 58deg) * -1));
   display: flex;
@@ -580,7 +580,7 @@ body {
 }
 
 .offset-text {
-  font-size: 0.9rem;
+  font-size: 1rem;
   font-weight: bold;
   text-shadow: 0 0 2px #000;
   transform: rotateX(calc(var(--board-angle, 58deg) * -1));
@@ -595,13 +595,13 @@ body {
 }
 
 .cell-icon {
-  width: calc(var(--cell-width) * 0.6);
-  height: calc(var(--cell-height) * 0.6);
+  width: calc(var(--cell-width) * 0.65);
+  height: calc(var(--cell-height) * 0.65);
   object-fit: contain;
 }
 
 .cell-emoji {
-  font-size: calc(var(--cell-height) * 0.6);
+  font-size: calc(var(--cell-height) * 0.65);
   line-height: 1;
 }
 
@@ -622,6 +622,7 @@ body {
 /* Rotate the start cell icon in place */
 .board-cell[data-cell="1"] .cell-marker {
   animation: start-sway 2.5s ease-in-out infinite;
+  top: 55%;
   transform: translate(-50%, -50%) translateZ(6px);
   transform-style: preserve-3d;
 }
@@ -664,7 +665,7 @@ body {
   color: #ffffff;
   font-family: "Comic Sans MS", "Comic Sans", cursive;
   font-weight: bold;
-  font-size: 1.1rem; /* slightly bigger numbers */
+  font-size: 1.2rem; /* slightly bigger numbers */
   line-height: 1;
   text-shadow: 0 0 2px #000;
   transform: translateY(-10%);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -932,7 +932,7 @@ export default function SnakeAndLadder() {
 
     let preview = aiPositions[index - 1];
     if (preview === 0) {
-      if (rolledSix) preview = Math.min(value, FINAL_TILE);
+      if (rolledSix) preview = 1;
     } else if (preview === 100) {
       if (value === 1) preview = FINAL_TILE;
     } else if (preview + value <= FINAL_TILE) {
@@ -964,7 +964,7 @@ export default function SnakeAndLadder() {
     let current = positions[index - 1];
     let target = current;
     if (current === 0) {
-      if (rolledSix) target = Math.min(value, FINAL_TILE);
+      if (rolledSix) target = 1;
     } else if (current === 100) {
       if (value === 1) target = FINAL_TILE;
     } else if (current + value <= FINAL_TILE) {


### PR DESCRIPTION
## Summary
- tweak AI start condition to require rolling a 6 like the player
- enlarge board numbers and icons slightly
- move board icons slightly downward

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685eb878c1c08329a537824517c86f3f