### PR TITLE
Update token icons and AI reward logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,15 @@ Each script will start a bot that responds to commands such as `/roll` or `/star
 
 ### Customizing Snakes & Ladders icons
 
-All webapp icons are stored in `webapp/public/assets/icons`. The board now uses emoji symbols (🐍, 🪜 and 🎲) for snake, ladder and dice connectors instead of `snake.svg`, `ladder.svg` and `dice.svg`.
+All webapp icons are stored in `webapp/public/icons`. The board now uses emoji symbols (🐍, 🪜 and 🎲) for snake, ladder and dice connectors instead of `snake.svg`, `ladder.svg` and `dice.svg`.
+
+Token icons for the lobby and wallet are:
+
+- `TON.png`
+- `TPCcoin.png`
+- `Usdt.png`
+
+Place your own images with those exact names in `webapp/public/icons` to override them.
 
 ### Snake & Ladder engine notes
 

--- a/webapp/public/tonconnect-manifest.json
+++ b/webapp/public/tonconnect-manifest.json
@@ -2,5 +2,5 @@
   "name": "TonPlaygram",
   "description": "Play games with TPC staking via Tonkeeper",
   "url": "https://tonplaygram-bot.onrender.com/",
-  "icons": ["https://tonplaygram-bot.onrender.com/icons/tpc.svg"]
+  "icons": ["https://tonplaygram-bot.onrender.com/icons/TPCcoin.png"]
 }

--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -43,9 +43,9 @@ export default function BalanceSummary() {
         </Link>
       </p>
       <div className="flex justify-around text-sm mt-1">
-        <Token icon="/icons/ton.svg" label="TON" value={balances.ton ?? '...'} />
-        <Token icon="/icons/tpc.svg" label="TPC" value={balances.tpc ?? '...'} />
-        <Token icon="/icons/usdt.svg" label="USDT" value={balances.usdt ?? '0'} />
+        <Token icon="/icons/TON.png" label="TON" value={balances.ton ?? '...'} />
+        <Token icon="/icons/TPCcoin.png" label="TPC" value={balances.tpc ?? '...'} />
+        <Token icon="/icons/Usdt.png" label="USDT" value={balances.usdt ?? '0'} />
       </div>
     </div>
   );

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -118,7 +118,7 @@ export default function DailyCheckIn() {
 
           {REWARDS[i]}
 
-          <img src="/icons/tpc.svg" alt="TPC" className="w-4 h-4 ml-1" />
+          <img src="/icons/TPCcoin.png" alt="TPC" className="w-4 h-4 ml-1" />
 
         </span>
 

--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 const amounts = [100, 500, 1000, 5000, 10000];
 const tokens = [
-  { id: 'TPC', icon: '/icons/tpc.svg' },
-  { id: 'TON', icon: '/icons/ton.svg' },
-  { id: 'USDT', icon: '/icons/usdt.svg' },
+  { id: 'TPC', icon: '/icons/TPCcoin.png' },
+  { id: 'TON', icon: '/icons/TON.png' },
+  { id: 'USDT', icon: '/icons/Usdt.png' },
 ];
 
 export default function RoomSelector({ selected, onSelect }) {

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -158,7 +158,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
             >
 
-              <img src="/icons/tpc.svg" alt="TPC" className="w-5 h-5 mr-1" />
+              <img src="/icons/TPCcoin.png" alt="TPC" className="w-5 h-5 mr-1" />
 
               <span>{val}</span>
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -441,9 +441,13 @@ export default function SnakeAndLadder() {
   // Preload token and avatar images so board icons and AI photos display
   // immediately without waiting for network requests during gameplay.
   useEffect(() => {
-    ['ton', 'tpc', 'usdt'].forEach((t) => {
+    [
+      'TON.png',
+      'TPCcoin.png',
+      'Usdt.png'
+    ].forEach((file) => {
       const img = new Image();
-      img.src = `/icons/${t}.svg`;
+      img.src = `/icons/${file}`;
     });
     AVATARS.forEach((src) => {
       const img = new Image();
@@ -1038,6 +1042,9 @@ export default function SnakeAndLadder() {
       if (next === 0) setTurnMessage('Your turn');
       setCurrentTurn(next);
       setDiceVisible(true);
+      if (extraTurn && next === index) {
+        setTimeout(() => triggerAIRoll(index), 1800);
+      }
     };
 
     const applyEffect = (startPos) => {


### PR DESCRIPTION
## Summary
- swap TON, TPC and USDT icons to new PNG images
- document icon file names in README
- trigger AI reward rolls automatically in Snake & Ladder
- reference new icon in TonConnect manifest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ec23c8794832998f2c695d680924c