### PR TITLE
Implement six entry rule shared util

### DIFF
--- a/test/diceRules.test.js
+++ b/test/diceRules.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { canEnterGame } from '../webapp/src/utils/diceRules.js';
+
+test('canEnterGame validates six combinations', () => {
+  const valid = [
+    [6, 1],
+    [1, 6],
+    [6, 6],
+    [2, 6],
+  ];
+  for (const combo of valid) {
+    assert.ok(canEnterGame(combo), `should allow ${combo[0]}+${combo[1]}`);
+  }
+
+  const invalid = [
+    [1, 1],
+    [3, 4],
+    [5, 5],
+  ];
+  for (const combo of invalid) {
+    assert.equal(canEnterGame(combo), false, `should block ${combo[0]}+${combo[1]}`);
+  }
+});

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useLayoutEffect, Fragment } from "react";
+import { canEnterGame } from "../../utils/diceRules.js";
 import confetti from "canvas-confetti";
 import DiceRoller from "../../components/DiceRoller.jsx";
 import { dropSound, ladderSound, bombSound, timerBeep, cheerSound } from "../../assets/soundData.js";
@@ -43,9 +44,6 @@ function shuffle(arr) {
   return copy;
 }
 
-function hasSix(values) {
-  return values.some((v) => Number(v) === 6);
-}
 
 function CoinBurst({ token }) {
   const coins = Array.from({ length: 30 }, () => ({
@@ -735,7 +733,7 @@ export default function SnakeAndLadder() {
     setRollCooldown(1);
     const vals = Array.isArray(values) ? values.map(Number) : [Number(values)];
     const value = vals.reduce((a, b) => a + b, 0);
-    const rolledSix = hasSix(vals);
+    const rolledSix = canEnterGame(vals);
     const doubleSix = vals.length === 2 && vals[0] === 6 && vals[1] === 6;
     let displayValue = value;
     if ((pos === 0 || (pos === 100 && diceCount === 2)) && rolledSix) {
@@ -975,7 +973,7 @@ export default function SnakeAndLadder() {
       ? vals.map(Number)
       : [vals ?? Math.floor(Math.random() * 6) + 1];
     const value = arr.reduce((a, b) => a + b, 0);
-    const rolledSix = hasSix(arr);
+    const rolledSix = canEnterGame(arr);
     const doubleSix = arr.length === 2 && arr[0] === 6 && arr[1] === 6;
     let displayValue = value;
     const currentPos = aiPositions[index - 1];

--- a/webapp/src/utils/diceRules.js
+++ b/webapp/src/utils/diceRules.js
@@ -1,0 +1,3 @@
+export function canEnterGame(values) {
+  return values.some(v => Number(v) === 6);
+}


### PR DESCRIPTION
## Summary
- add `diceRules.canEnterGame` helper for evaluating entry rolls
- use `canEnterGame` for player and AI rolls
- test six combo logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eeec8e94883299e5b691feb2fb9b3