### PR TITLE
Implement Telegram reload and auto refresh

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1246,6 +1246,17 @@ export default function SnakeAndLadder() {
     return () => clearInterval(id);
   }, []);
 
+  // Automatically reload to fetch the latest updates
+  useEffect(() => {
+    const id = setInterval(() => {
+      reloadingRef.current = true;
+      const tg = window?.Telegram?.WebApp;
+      if (tg?.reload) tg.reload();
+      else window.location.reload();
+    }, 3000);
+    return () => clearInterval(id);
+  }, []);
+
   const players = [
     { position: pos, photoUrl, type: tokenType, color: playerColors[0] },
     ...aiPositions.map((p, i) => ({ position: p, photoUrl: aiAvatars[i] || '/assets/icons/profile.svg', type: 'normal', color: playerColors[i + 1] }))
@@ -1262,7 +1273,9 @@ export default function SnakeAndLadder() {
 
   const handleReload = () => {
     reloadingRef.current = true;
-    window.location.reload();
+    const tg = window?.Telegram?.WebApp;
+    if (tg?.reload) tg.reload();
+    else window.location.reload();
   };
 
   return (


### PR DESCRIPTION
## Summary
- enable Telegram WebApp reload for the Snake & Ladder reload button
- add periodic page refresh to keep the game updated

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685f0a8eb36c8329bb327293b234df9b