### PR TITLE
Update lobby and profile appearance

### DIFF
--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -21,10 +21,10 @@ export default function RoomSelector({ selected, onSelect }) {
             <button
               key={`${id}-${amt}`}
               onClick={() => onSelect({ token: id, amount: amt })}
-              className={`prism-box px-2 py-1 flex items-center space-x-1 cursor-pointer ${
+              className={`lobby-tile px-2 py-1 flex items-center space-x-1 cursor-pointer ${
                 token === id && amount === amt
                   ? 'ring-2 ring-accent text-accent'
-                  : 'text-white'
+                  : ''
               }`}
             >
               <span>{amt}</span>

--- a/webapp/src/components/TableSelector.jsx
+++ b/webapp/src/components/TableSelector.jsx
@@ -7,8 +7,8 @@ export default function TableSelector({ tables, selected, onSelect }) {
         <button
           key={t.id}
           onClick={() => onSelect(t)}
-          className={`w-full px-2 py-1 border rounded flex justify-between ${
-            selected?.id === t.id ? 'bg-yellow-400 text-gray-900' : 'bg-gray-700 text-white'
+          className={`lobby-tile w-full flex justify-between ${
+            selected?.id === t.id ? 'ring-2 ring-accent text-accent' : ''
           }`}
         >
           <span>{t.label || `Table ${t.capacity}p`}</span>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -732,7 +732,7 @@ body {
 .logo-wall-main {
   @apply absolute flex items-center justify-center;
   /* make the logo 5% bigger */
-  width: calc(var(--cell-width) * 9.975);
+  width: calc(var(--cell-width) * 10.5);
   height: calc(var(--cell-height) * 5.25);
   /* move the logo slightly up */
   top: calc(
@@ -951,6 +951,24 @@ body {
 }
 
 .prism-box::after {
+  content: "";
+  position: absolute;
+  inset: 2px;
+  border-radius: inherit;
+  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.6);
+  transform: translateZ(6px);
+}
+
+.lobby-tile {
+  @apply relative flex items-center justify-center rounded-xl text-white font-semibold;
+  background-color: #2d5c66;
+  border: 2px solid #334155;
+  box-shadow: 0 8px 12px rgba(0, 0, 0, 0.6);
+  transform-style: preserve-3d;
+  padding: 0.25rem 0.5rem;
+}
+
+.lobby-tile::after {
   content: "";
   position: absolute;
   inset: 2px;

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -40,34 +40,42 @@ export default function Friends() {
     });
     listFriendRequests(telegramId).then(setFriendRequests);
 
-    getProfile(telegramId)
-      .then((p) => {
-        if (p?.photo) {
-          setMyPhotoUrl(p.photo);
-          saveAvatar(p.photo);
-        } else if (!myPhotoUrl) {
+    const saved = loadAvatar();
+    if (saved) {
+      setMyPhotoUrl(saved);
+    } else {
+      getProfile(telegramId)
+        .then((p) => {
+          if (p?.photo) {
+            setMyPhotoUrl(p.photo);
+            saveAvatar(p.photo);
+          } else {
+            fetchTelegramInfo(telegramId).then((info) => {
+              if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
+            });
+          }
+        })
+        .catch(() => {
           fetchTelegramInfo(telegramId).then((info) => {
             if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
           });
-        }
-      })
-      .catch(() => {
-        if (!myPhotoUrl) {
-          fetchTelegramInfo(telegramId).then((info) => {
-            if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
-          });
-        }
-      });
+        });
+    }
   }, [telegramId]);
 
   useEffect(() => {
     const updatePhoto = () => {
-      getProfile(telegramId)
-        .then((p) => {
-          setMyPhotoUrl(p?.photo || getTelegramPhotoUrl());
-          if (p?.photo) saveAvatar(p.photo);
-        })
-        .catch(() => setMyPhotoUrl(getTelegramPhotoUrl()));
+      const saved = loadAvatar();
+      if (saved) {
+        setMyPhotoUrl(saved);
+      } else {
+        getProfile(telegramId)
+          .then((p) => {
+            setMyPhotoUrl(p?.photo || getTelegramPhotoUrl());
+            if (p?.photo) saveAvatar(p.photo);
+          })
+          .catch(() => setMyPhotoUrl(getTelegramPhotoUrl()));
+      }
     };
     window.addEventListener('profilePhotoUpdated', updatePhoto);
     return () => window.removeEventListener('profilePhotoUpdated', updatePhoto);

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -81,7 +81,12 @@ export default function Lobby() {
   const disabled = !canStartGame(game, table, stake, aiCount);
 
   return (
-    <div className="p-4 space-y-4 text-text">
+    <div className="relative p-4 space-y-4 text-text">
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+      />
       <h2 className="text-xl font-bold text-center capitalize">{game} Lobby</h2>
       {game === 'snake' && (
         <div className="space-y-2">
@@ -115,8 +120,8 @@ export default function Lobby() {
               <button
                 key={n}
                 onClick={() => setAiCount(n)}
-                className={`px-2 py-1 border rounded ${
-                  aiCount === n ? 'bg-yellow-400 text-gray-900' : 'bg-gray-700 text-white'
+                className={`lobby-tile ${
+                  aiCount === n ? 'ring-2 ring-accent text-accent' : ''
                 }`}
               >
                 {n}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -36,24 +36,34 @@ export default function Home() {
       .catch(() => setStatus('offline'));
 
     const id = getTelegramId();
-    getProfile(id)
-      .then((p) => {
-        const src = p?.photo || getTelegramPhotoUrl();
-        setPhotoUrl(src);
-        if (p?.photo) saveAvatar(p.photo);
-      })
-      .catch(() => {
-        setPhotoUrl(getTelegramPhotoUrl());
-      });
+    const saved = loadAvatar();
+    if (saved) {
+      setPhotoUrl(saved);
+    } else {
+      getProfile(id)
+        .then((p) => {
+          const src = p?.photo || getTelegramPhotoUrl();
+          setPhotoUrl(src);
+          if (p?.photo) saveAvatar(p.photo);
+        })
+        .catch(() => {
+          setPhotoUrl(getTelegramPhotoUrl());
+        });
+    }
 
     const handleUpdate = () => {
       const id = getTelegramId();
-      getProfile(id)
-        .then((p) => {
-          setPhotoUrl(p?.photo || getTelegramPhotoUrl());
-          if (p?.photo) saveAvatar(p.photo);
-        })
-        .catch(() => setPhotoUrl(getTelegramPhotoUrl()));
+      const saved = loadAvatar();
+      if (saved) {
+        setPhotoUrl(saved);
+      } else {
+        getProfile(id)
+          .then((p) => {
+            setPhotoUrl(p?.photo || getTelegramPhotoUrl());
+            if (p?.photo) saveAvatar(p.photo);
+          })
+          .catch(() => setPhotoUrl(getTelegramPhotoUrl()));
+      }
     };
     window.addEventListener('profilePhotoUpdated', handleUpdate);
     return () => window.removeEventListener('profilePhotoUpdated', handleUpdate);

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -98,10 +98,15 @@ export default function MyAccount() {
 
   if (!profile) return <div className="p-4 text-subtext">Loading...</div>;
 
-  const photoUrl = profile.photo || loadAvatar() || getTelegramPhotoUrl();
+  const photoUrl = loadAvatar() || profile.photo || getTelegramPhotoUrl();
 
   return (
-    <div className="p-4 space-y-4 text-text">
+    <div className="relative p-4 space-y-4 text-text">
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+      />
       <AvatarPromptModal
         open={showAvatarPrompt}
         onPick={() => {


### PR DESCRIPTION
## Summary
- style lobby buttons like board tiles
- reuse board background on lobby and profile pages
- widen game logo and shift bottom buttons
- keep avatar choice over Telegram photo

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685f9789bc80832996a5063582954c7d