### PR TITLE
Update backgrounds and icon sizes

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -54,7 +54,7 @@ export default function BalanceSummary() {
 function Token({ icon, value, label }) {
   return (
     <div className="flex items-center space-x-1">
-      <img src={icon} alt={label} className="w-6 h-6" />
+      <img src={icon} alt={label} className="w-8 h-8" />
       <span>{value}</span>
     </div>
   );

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -118,7 +118,7 @@ export default function DailyCheckIn() {
 
           {REWARDS[i]}
 
-          <img src="/icons/TPCcoin.png" alt="TPC" className="w-6 h-6 ml-1" />
+          <img src="/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 ml-1" />
 
         </span>
 
@@ -130,7 +130,7 @@ export default function DailyCheckIn() {
 
   return (
 
-    <div className="bg-surface border border-border rounded p-4 space-y-2">
+    <div className="prism-box p-4 space-y-2">
 
       {showPopup && (
 

--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -28,7 +28,7 @@ export default function RoomSelector({ selected, onSelect }) {
               }`}
             >
               <span>{amt}</span>
-              <img src={icon} alt={id} className="w-6 h-6" />
+              <img src={icon} alt={id} className="w-8 h-8" />
             </button>
           ))}
         </div>

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -43,7 +43,7 @@ export default function SpinGame() {
   const ready = canSpin(lastSpin);
 
   return (
-    <div className="bg-surface border border-border rounded p-4 flex flex-col items-center space-y-2">
+    <div className="prism-box p-4 flex flex-col items-center space-y-2">
       <h3 className="text-lg font-bold text-text">Spin &amp; Win</h3>
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>
       <SpinWheel

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -158,7 +158,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
             >
 
-              <img src="/icons/TPCcoin.png" alt="TPC" className="w-6 h-6 mr-1" />
+              <img src="/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 mr-1" />
 
               <span>{val}</span>
 

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -86,7 +86,12 @@ export default function Friends() {
   const link = `https://t.me/${BOT_USERNAME}?start=${referral.code}`;
 
   return (
-    <div className="p-4 space-y-4 text-text">
+    <div className="relative p-4 space-y-4 text-text">
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+      />
       <h2 className="text-xl font-bold">Friends</h2>
 
       <section className="space-y-1">

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -4,7 +4,12 @@ import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 export default function Games() {
   useTelegramBackButton();
   return (
-    <div className="space-y-4">
+    <div className="relative space-y-4 text-text">
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+      />
       <h2 className="text-2xl font-bold text-center">Games</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <GameCard title="Snake & Ladder" icon="🎲" link="/games/snake/lobby" />

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -59,8 +59,9 @@ export default function Tasks() {
 
   return (
 
-    <div className="p-4 space-y-2 text-text">
+    <div className="relative p-4 space-y-2 text-text">
 
+      <img src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
       <h2 className="text-xl font-bold">Tasks</h2>
 
       <ul className="space-y-2">


### PR DESCRIPTION
## Summary
- add the snake & ladder background on Games, Friends and Tasks pages
- style Daily Streaks and Spin & Win widgets with prism boxes
- enlarge TPC, TON and USDT token icons

## Testing
- `npm test` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_685f9d27b8ec83299df8c70255d9ec99