### PR TITLE
UI tweaks

### DIFF
--- a/webapp/src/components/Branding.jsx
+++ b/webapp/src/components/Branding.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-export default function Branding() {
+export default function Branding({ small = false }) {
   return (
     <div className="text-center py-6 space-y-2">
       <img
         src="/assets/TonPlayGramLogo.jpg"
         alt="TonPlaygram Logo"
-        className="mx-auto "
+        className={`mx-auto ${small ? 'scale-95' : ''}`}
       />
     </div>
   );

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -131,7 +131,7 @@ export default function DailyCheckIn() {
 
   return (
 
-    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 text-center">
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 text-center overflow-hidden">
       <img
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -15,6 +15,7 @@ export default function Layout({ children }) {
   const location = useLocation();
 
   const isHome = location.pathname === '/';
+  const isFriends = location.pathname === '/friends';
 
   const showBranding = !location.pathname.startsWith('/games');
 
@@ -36,7 +37,7 @@ export default function Layout({ children }) {
 
       <main className={`flex-grow container mx-auto p-4 ${showNavbar ? 'pb-24' : ''}`.trim()}>
 
-        {showBranding && <Branding />}
+        {showBranding && <Branding small={isFriends} />}
 
         {children}
 

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -43,7 +43,7 @@ export default function SpinGame() {
   const ready = canSpin(lastSpin);
 
   return (
-    <div className="relative bg-surface border border-border rounded-xl p-4 flex flex-col items-center space-y-2">
+    <div className="relative bg-surface border border-border rounded-xl p-4 flex flex-col items-center space-y-2 overflow-hidden">
       <img
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -86,26 +86,18 @@ export default function Home() {
         )}
 
 
-        <div className="flex items-center justify-between w-full max-w-xs mt-2">
-
-          <Link to="/wallet?mode=send" className="flex items-center space-x-1">
-
-            <FaArrowCircleUp className="text-accent w-8 h-8" />
-
-            <span className="text-xs text-accent">Send</span>
-
-          </Link>
-
-          <BalanceSummary />
-
-          <Link to="/wallet?mode=receive" className="flex items-center space-x-1">
-
-            <FaArrowCircleDown className="text-accent w-8 h-8" />
-
-            <span className="text-xs text-accent">Receive</span>
-
-          </Link>
-
+        <div className="w-full max-w-xs mt-2">
+          <div className="flex items-center justify-between bg-surface border border-border rounded-xl p-2">
+            <Link to="/wallet?mode=send" className="flex items-center space-x-1">
+              <FaArrowCircleUp className="text-accent w-8 h-8" />
+              <span className="text-xs text-accent">Send</span>
+            </Link>
+            <BalanceSummary />
+            <Link to="/wallet?mode=receive" className="flex items-center space-x-1">
+              <FaArrowCircleDown className="text-accent w-8 h-8" />
+              <span className="text-xs text-accent">Receive</span>
+            </Link>
+          </div>
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- keep daily streaks and spin backgrounds inside their frames
- reduce Branding logo size on Friends page
- frame send/receive bar on home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc6630008832991c745134da5b036