### PR TITLE
Update home cards & lobby styles

### DIFF
--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -100,7 +100,12 @@ export default function MiningCard() {
   };
 
   return (
-    <div className="bg-surface border border-border rounded-xl p-4 space-y-4 text-center">
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-center overflow-hidden">
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+      />
       <div className="flex justify-center items-center space-x-1">
         <GiMining className="w-5 h-5 text-accent" />
         <span className="text-lg font-bold text-text">Mining</span>

--- a/webapp/src/components/ProfileCard.jsx
+++ b/webapp/src/components/ProfileCard.jsx
@@ -3,7 +3,12 @@ import { Link } from 'react-router-dom';
 
 export default function ProfileCard() {
   return (
-    <div className="bg-surface p-4 rounded-xl shadow-lg space-y-2 text-center">
+    <div className="relative bg-surface border border-border p-4 rounded-xl shadow-lg space-y-2 text-center overflow-hidden">
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+      />
       <FaUser className="text-accent text-3xl mx-auto" />
       <h3 className="text-lg font-bold text-text">Profile</h3>
       <Link

--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -21,14 +21,14 @@ export default function RoomSelector({ selected, onSelect }) {
             <button
               key={`${id}-${amt}`}
               onClick={() => onSelect({ token: id, amount: amt })}
-              className={`lobby-tile px-2 py-1 flex items-center space-x-1 cursor-pointer ${
+              className={`lobby-tile w-20 px-4 py-2 flex flex-col items-center space-y-1 cursor-pointer ${
                 token === id && amount === amt
                   ? 'lobby-selected'
                   : ''
               }`}
             >
-              <span>{amt}</span>
               <img src={icon} alt={id} className="w-8 h-8" />
+              <span>{amt}</span>
             </button>
           ))}
         </div>

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -74,7 +74,8 @@ export default function TasksCard() {
 
   return (
 
-    <div className="bg-surface border border-border rounded-xl p-4 space-y-2">
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden">
+      <img src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
 
       <h3 className="text-lg font-bold text-text flex items-center justify-center space-x-1"><AiOutlineCheckSquare className="text-accent" /><span>Tasks</span></h3>
 
@@ -82,7 +83,7 @@ export default function TasksCard() {
 
         {tasks.map((t) => (
 
-          <li key={t.id} className="flex justify-between items-center">
+          <li key={t.id} className="lobby-tile w-full flex justify-between items-center">
 
             <div className="flex items-center space-x-2 text-sm">
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -998,5 +998,5 @@ body {
   box-shadow: inset 0 0 6px rgba(0,0,0,0.6);
 }
 .friend-background{
-  transform: translateY(90px) scale(1.4);
+  transform: translateY(60px) scale(1.4);
 }

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -87,7 +87,12 @@ export default function Home() {
 
 
         <div className="w-full max-w-xs mt-2">
-          <div className="flex items-center justify-between bg-surface border border-border rounded-xl p-2">
+          <div className="relative flex items-center justify-between bg-surface border border-border rounded-xl p-2 overflow-hidden">
+            <img
+              src="/assets/SnakeLaddersbackground.png"
+              className="background-behind-board object-cover"
+              alt=""
+            />
             <Link to="/wallet?mode=send" className="flex items-center space-x-1">
               <FaArrowCircleUp className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Send</span>

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -72,7 +72,7 @@ export default function Tasks() {
 
             key={t.id}
 
-            className="bg-surface border border-border rounded p-2 flex justify-between items-center"
+            className="lobby-tile w-full flex justify-between items-center"
 
           >
 


### PR DESCRIPTION
## Summary
- add board backgrounds to wallet, mining, tasks and profile cards
- style tasks like lobby tables
- enlarge coin selection buttons on the snake lobby
- slightly raise the friends page background

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685fcb92937c8329bfe1ce635e6dd6f4