### PR TITLE
Apply uniform styles and board icon scaling

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -540,6 +540,21 @@ body {
   background-color: #86efac; /* green-300 */
 }
 
+.board-cell.snake-highlight .cell-marker,
+.board-cell.ladder-highlight .cell-marker,
+.board-cell.dice-cell.normal-highlight .dice-marker {
+  transform: translate(-50%, -50%) translateZ(6px)
+    rotateX(calc(var(--board-angle, 58deg) * -1)) scale(3);
+}
+
+.board-cell.snake-highlight .cell-icon,
+.board-cell.ladder-highlight .cell-icon,
+.board-cell.snake-highlight .dice-icon,
+.board-cell.ladder-highlight .dice-icon,
+.board-cell.dice-cell.normal-highlight .dice-icon {
+  transform: scale(1);
+}
+
 .board-cell.snake-cell.snake-highlight {
   background-color: #fca5a5; /* red-300 */
 }
@@ -577,6 +592,7 @@ body {
   gap: 2px;
   pointer-events: none;
   z-index: 3; /* ensure icons appear above connectors */
+  transition: transform 0.3s ease;
 }
 
 .offset-text {
@@ -598,6 +614,7 @@ body {
   width: calc(var(--cell-width) * 0.7);
   height: calc(var(--cell-height) * 0.7);
   object-fit: contain;
+  transition: transform 0.3s ease;
 }
 
 .cell-emoji {
@@ -869,12 +886,14 @@ body {
   justify-content: center;
   pointer-events: none;
   z-index: 2;
+  transition: transform 0.3s ease;
 }
 
 .dice-marker .dice-icon {
   width: 1.8rem;
   height: 1.8rem;
   object-fit: contain;
+  transition: transform 0.3s ease;
 }
 
 .dice-value {
@@ -998,5 +1017,5 @@ body {
   box-shadow: inset 0 0 6px rgba(0,0,0,0.6);
 }
 .friend-background{
-  transform: translateY(60px) scale(1.4);
+  transform: translateY(90px) scale(1.5);
 }

--- a/webapp/src/pages/Games/DiceDuel.jsx
+++ b/webapp/src/pages/Games/DiceDuel.jsx
@@ -43,7 +43,7 @@ export default function DiceDuel() {
       {winner === null && (
         <button
           onClick={() => setShowDice(true)}
-          className="mx-auto px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded"
+          className="mx-auto px-4 py-2 bg-primary hover:bg-primary-hover text-text rounded"
         >
           Roll Dice
         </button>

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -133,7 +133,7 @@ export default function Lobby() {
       <button
         onClick={startGame}
         disabled={disabled}
-        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-white rounded disabled:opacity-50"
+        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-text rounded disabled:opacity-50"
       >
         Start Game
       </button>

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -115,7 +115,7 @@ export default function Wallet() {
           />
           <button
             onClick={handleSend}
-            className="mt-1 px-3 py-1 bg-blue-600 text-white rounded"
+            className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover text-text rounded"
           >
             Send
           </button>
@@ -141,13 +141,13 @@ export default function Wallet() {
           <label className="block">Receive TPC</label>
           <button
             onClick={() => navigator.clipboard.writeText(String(telegramId))}
-            className="px-3 py-1 bg-green-600 text-white rounded"
+            className="px-3 py-1 bg-primary hover:bg-primary-hover text-text rounded"
           >
             Copy Account Number
           </button>
           <button
             onClick={handleResetTpc}
-            className="mt-1 px-3 py-1 bg-red-600 text-white rounded"
+            className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover text-text rounded"
           >
             Reset TPC Wallet
           </button>

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -96,14 +96,14 @@ export default function SpinPage() {
         <div className="flex space-x-2 mt-4">
           <button
             onClick={triggerSpin}
-            className="px-4 py-1 bg-green-600 text-white text-sm font-bold rounded disabled:bg-gray-500"
+            className="px-4 py-1 bg-primary hover:bg-primary-hover text-text text-sm font-bold rounded disabled:bg-gray-500"
             disabled={spinning || !ready}
           >
             Spin
           </button>
           <button
             onClick={() => setMultiplier(m => !m)}
-            className={`px-4 py-1 text-white text-sm font-bold rounded ${multiplier ? 'bg-red-700' : 'bg-red-500'}`}
+            className="px-4 py-1 bg-primary hover:bg-primary-hover text-text text-sm font-bold rounded"
             disabled={spinning || !ready}
           >
             x3
@@ -111,8 +111,8 @@ export default function SpinPage() {
         </div>
         {!ready && (
           <>
-            <p className="text-sm text-white font-semibold">Next spin at {new Date(nextSpinTime(lastSpin)).toLocaleTimeString()}</p>
-            <button className="text-white underline text-sm" onClick={() => setShowAd(true)}>
+            <p className="text-sm text-text font-semibold">Next spin at {new Date(nextSpinTime(lastSpin)).toLocaleTimeString()}</p>
+            <button className="text-text underline text-sm" onClick={() => setShowAd(true)}>
               Watch an ad every hour to get a free spin.
             </button>
           </>


### PR DESCRIPTION
## Summary
- tweak friend page background position and scale
- apply tasks button style across Wallet, Lobby, Dice Duel and spin pages
- animate board icons to scale up when highlighted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fd46984e88329b09fca62f6109f57