### PR TITLE
Implement wallet balances and UI fixes

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { FaWallet } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 import { useTonWallet } from '@tonconnect/ui-react';
-import { getWalletBalance, getTonBalance } from '../utils/api.js';
+import { getWalletBalance, getTonBalance, getUsdtBalance } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import OpenInTelegram from './OpenInTelegram.jsx';
 
@@ -14,19 +14,22 @@ export default function BalanceSummary() {
     return <OpenInTelegram />;
   }
 
-  const [balances, setBalances] = useState({ ton: null, tpc: null, usdt: 0 });
+  const [balances, setBalances] = useState({ ton: null, tpc: null, usdt: null });
   const wallet = useTonWallet();
 
   const loadBalances = async () => {
     try {
       const prof = await getWalletBalance(telegramId);
-      const ton = wallet?.account?.address
-        ? (await getTonBalance(wallet.account.address)).balance
-        : null;
-      setBalances({ ton, tpc: prof.balance, usdt: 0 });
+      let ton = null;
+      let usdt = null;
+      if (wallet?.account?.address) {
+        ton = (await getTonBalance(wallet.account.address)).balance;
+        usdt = (await getUsdtBalance(wallet.account.address)).balance;
+      }
+      setBalances({ ton, tpc: prof.balance, usdt });
     } catch (err) {
       console.error('Failed to load balances:', err);
-      setBalances({ ton: null, tpc: 0, usdt: 0 });
+      setBalances({ ton: null, tpc: 0, usdt: null });
     }
   };
 

--- a/webapp/src/components/WalletCard.jsx
+++ b/webapp/src/components/WalletCard.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTonWallet } from '@tonconnect/ui-react';
-import { getWalletBalance, getTonBalance } from '../utils/api.js';
+import { getWalletBalance, getTonBalance, getUsdtBalance } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import OpenInTelegram from './OpenInTelegram.jsx';
 
@@ -27,9 +27,12 @@ export default function WalletCard() {
     if (wallet?.account?.address) {
       const bal = await getTonBalance(wallet.account.address);
       setTonBalance(bal.balance);
+      const usd = await getUsdtBalance(wallet.account.address);
+      setUsdtBalance(usd.balance);
+    } else {
+      setTonBalance(null);
+      setUsdtBalance(null);
     }
-    // USDT balance not implemented yet
-    setUsdtBalance(0);
   };
 
   useEffect(() => {

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -237,7 +237,7 @@ body {
   content: "\1F525"; /* fire emoji */
   position: absolute;
   top: 50%;
-  left: 50%;
+  left: 48%;
   transform: translate(-50%, -50%) translateZ(40px);
   font-size: 4.5rem;
   pointer-events: none;
@@ -756,7 +756,7 @@ body {
     var(--cell-height) * -8.7 - var(--cell-height) * 1.7 *
       (var(--final-scale, 1) - 1)
   );
-  left: 50%;
+  left: 48%;
   transform: translateX(-50%) rotateX(calc(var(--board-angle, 58deg) * -1))
     translateZ(-90px) scale(2.31); /* 5% larger */
   transform-origin: bottom center;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1364,7 +1364,7 @@ export default function SnakeAndLadder() {
         </button>
       </div>
       {/* Player photos stacked vertically */}
-      <div className="fixed left-1 top-4 flex flex-col space-y-2 z-20">
+      <div className="fixed left-1 top-1/2 -translate-y-1/2 flex flex-col space-y-2 z-20">
         {players
           .map((p, i) => ({ ...p, index: i }))
           .map((p) => (

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -135,9 +135,11 @@ export function getWalletBalance(telegramId) {
 }
 
 export function getTonBalance(address) {
-
   return post('/api/wallet/ton-balance', { address });
+}
 
+export function getUsdtBalance(address) {
+  return post('/api/wallet/usdt-balance', { address });
 }
 
 export function sendTpc(fromId, toId, amount) {


### PR DESCRIPTION
## Summary
- create a user on balance lookup and add USDT balance endpoint
- show TON and USDT balances in wallet components
- adjust leaderboard position and move board logo slightly left

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fe1deb1a08329849a2112e8ca57c0