### PR TITLE
Fix wallet access and improve game UI

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -25,7 +25,7 @@ export default function AvatarTimer({ photoUrl, active = false, timerPct = 1, ra
         <span className="rank-number">{rank}</span>
       )}
       {name && (
-        <span className="rank-name" style={{ color: active ? '#4ade80' : undefined }}>
+        <span className="rank-name" style={{ color: color || '#fde047' }}>
           {name}
         </span>
       )}

--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react';
 import { FaWallet } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
-import { useTonWallet } from '@tonconnect/ui-react';
-import { getWalletBalance, getTonBalance, getUsdtBalance } from '../utils/api.js';
+import { getWalletBalance } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import OpenInTelegram from './OpenInTelegram.jsx';
 
@@ -14,28 +13,21 @@ export default function BalanceSummary() {
     return <OpenInTelegram />;
   }
 
-  const [balances, setBalances] = useState({ ton: null, tpc: null, usdt: null });
-  const wallet = useTonWallet();
+  const [balance, setBalance] = useState(null);
 
   const loadBalances = async () => {
     try {
       const prof = await getWalletBalance(telegramId);
-      let ton = null;
-      let usdt = null;
-      if (wallet?.account?.address) {
-        ton = (await getTonBalance(wallet.account.address)).balance;
-        usdt = (await getUsdtBalance(wallet.account.address)).balance;
-      }
-      setBalances({ ton, tpc: prof.balance, usdt });
+      setBalance(prof.balance);
     } catch (err) {
       console.error('Failed to load balances:', err);
-      setBalances({ ton: null, tpc: 0, usdt: null });
+      setBalance(0);
     }
   };
 
   useEffect(() => {
     loadBalances();
-  }, [wallet]);
+  }, []);
 
   return (
     <div className="text-center mt-2">
@@ -45,10 +37,8 @@ export default function BalanceSummary() {
           <span>Wallet</span>
         </Link>
       </p>
-      <div className="flex justify-around text-sm mt-1">
-        <Token icon="/icons/TON.png" label="TON" value={balances.ton ?? 0} />
-        <Token icon="/icons/TPCcoin.png" label="TPC" value={balances.tpc ?? 0} />
-        <Token icon="/icons/Usdt.png" label="USDT" value={balances.usdt ?? 0} />
+      <div className="flex justify-center text-sm mt-1">
+        <Token icon="/icons/TPCcoin.png" label="TPC" value={balance ?? 0} />
       </div>
     </div>
   );

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -347,11 +347,12 @@ body {
 }
 .rank-name {
   position: absolute;
-  top: -0.3rem;
-  right: -0.3rem;
-  transform: translateX(100%);
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, -0.1rem);
   font-size: 0.6rem;
-  color: #fff;
+  color: inherit;
+  white-space: nowrap;
 }
 
 .turn-indicator {
@@ -1017,5 +1018,5 @@ body {
   box-shadow: inset 0 0 6px rgba(0,0,0,0.6);
 }
 .friend-background{
-  transform: translateY(90px) scale(1.65);
+  transform: translateY(90px) scale(1.98);
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -400,8 +400,19 @@ function Board({
 }
 
 export default function SnakeAndLadder() {
-  useTelegramBackButton();
+  const [showLobbyConfirm, setShowLobbyConfirm] = useState(false);
+  useTelegramBackButton(() => setShowLobbyConfirm(true));
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const handlePop = (e) => {
+      e.preventDefault();
+      setShowLobbyConfirm(true);
+      window.history.pushState(null, '');
+    };
+    window.addEventListener('popstate', handlePop);
+    return () => window.removeEventListener('popstate', handlePop);
+  }, []);
   const [pos, setPos] = useState(0);
   const [highlight, setHighlight] = useState(null); // { cell: number, type: string }
   const [trail, setTrail] = useState([]);
@@ -415,7 +426,6 @@ export default function SnakeAndLadder() {
   const [token, setToken] = useState("TPC");
   const [celebrate, setCelebrate] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
-  const [showLobbyConfirm, setShowLobbyConfirm] = useState(false);
   const [muted, setMuted] = useState(false);
   const [snakes, setSnakes] = useState({});
   const [ladders, setLadders] = useState({});
@@ -1364,7 +1374,7 @@ export default function SnakeAndLadder() {
         </button>
       </div>
       {/* Player photos stacked vertically */}
-      <div className="fixed left-1 top-1/2 -translate-y-1/2 flex flex-col space-y-2 z-20">
+      <div className="fixed left-1 top-[45%] -translate-y-1/2 flex flex-col space-y-2 z-20">
         {players
           .map((p, i) => ({ ...p, index: i }))
           .map((p) => (
@@ -1482,7 +1492,7 @@ export default function SnakeAndLadder() {
       />
       <ConfirmPopup
         open={showLobbyConfirm}
-        message="Return to lobby and end the game?"
+        message="Quit the game?"
         onConfirm={() => {
           localStorage.removeItem(`snakeGameState_${ai}`);
           navigate("/games/snake/lobby");


### PR DESCRIPTION
## Summary
- show only TPC balance in the wallet overview
- enlarge friends page background and move leaderboard names above avatars
- shift the in‑game leaderboard up slightly
- prompt before quitting Snake & Ladder via back button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fe75a8b408329adbada98b0cef4b9