### PR TITLE
UI tweaks for profile and snake game

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1018,5 +1018,10 @@ body {
   box-shadow: inset 0 0 6px rgba(0,0,0,0.6);
 }
 .friend-background{
-  transform: translateY(90px) scale(1.98);
+  transform: translateY(70px) scale(1.98);
+}
+
+/* Slightly larger background for the profile page */
+.account-background{
+  transform: translateY(90px) scale(1.35);
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1357,7 +1357,7 @@ export default function SnakeAndLadder() {
   return (
     <div className="p-4 pb-32 space-y-4 text-text flex flex-col justify-end items-center relative w-full flex-grow">
       {/* Action menu moved to the bottom left with only info and mute */}
-      <div className="fixed left-2 bottom-4 flex flex-col items-center space-y-2 z-20">
+      <div className="fixed left-1 bottom-4 flex flex-col items-center space-y-2 z-20">
         <button
           onClick={() => setShowInfo(true)}
           className="p-2 flex flex-col items-center"
@@ -1369,12 +1369,12 @@ export default function SnakeAndLadder() {
           onClick={() => setMuted((m) => !m)}
           className="p-2 flex flex-col items-center"
         >
-          <span className="text-xl">🔇</span>
+          <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
           <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
         </button>
       </div>
       {/* Player photos stacked vertically */}
-      <div className="fixed left-1 top-[45%] -translate-y-1/2 flex flex-col space-y-2 z-20">
+      <div className="fixed left-1 top-[50%] -translate-y-1/2 flex flex-col space-y-3 z-20">
         {players
           .map((p, i) => ({ ...p, index: i }))
           .map((p) => (

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -104,7 +104,7 @@ export default function MyAccount() {
     <div className="relative p-4 space-y-4 text-text">
       <img
         src="/assets/SnakeLaddersbackground.png"
-        className="background-behind-board object-cover"
+        className="background-behind-board account-background object-cover"
         alt=""
       />
       <AvatarPromptModal


### PR DESCRIPTION
## Summary
- enlarge profile page background
- adjust friend page background spacing
- nudge snake game leaderboard and icons
- swap mute icon when sound on/off

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_685fedfe5c5c8329a0f456d9a0d2cae5