### PR TITLE
Restore wallet fallback for non-telegram users

### DIFF
--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -8,9 +8,8 @@ export function getTelegramId() {
     const stored = localStorage.getItem('telegramId');
     if (stored) return Number(stored);
   }
-  throw new Error(
-    'Telegram user not found. Please open this application via the Telegram bot.'
-  );
+  // Fallback for non-Telegram browsers
+  return 1;
 }
 
 export function getTelegramUsername() {


### PR DESCRIPTION
## Summary
- allow wallet to load outside Telegram again by falling back to demo user id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ff964e10083298e3ab5f5a36314b1