### PR TITLE
Compute wallet balance from transaction history

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -9,20 +9,21 @@
   },
   "type": "module",
   "dependencies": {
+    "@ayshrj/ludo.js": "^1.0.10",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.15",
+    "canvas-confetti": "^1.9.2",
     "framer-motion": "^10.18.0",
     "postcss": "^8.4.31",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.10.1",
+    "react-markdown": "^9.0.0",
+    "react-qr-code": "^2.0.16",
     "react-router-dom": "^6.22.3",
     "tailwindcss": "^3.4.1",
-    "vite": "^4.4.9",
-    "react-icons": "^4.10.1",
-    "canvas-confetti": "^1.9.2",
-    "@ayshrj/ludo.js": "^1.0.10",
     "three": "^0.164.0",
-    "react-markdown": "^9.0.0"
+    "vite": "^4.4.9"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { FaWallet } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
-import { getWalletBalance } from '../utils/api.js';
+import { getTransactions } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import LoginOptions from './LoginOptions.jsx';
 
@@ -17,8 +17,12 @@ export default function BalanceSummary() {
 
   const loadBalances = async () => {
     try {
-      const prof = await getWalletBalance(telegramId);
-      setBalance(prof.balance);
+      const tx = await getTransactions(telegramId);
+      const total = (tx.transactions || []).reduce(
+        (sum, t) => sum + (typeof t.amount === 'number' ? t.amount : 0),
+        0
+      );
+      setBalance(total);
     } catch (err) {
       console.error('Failed to load balances:', err);
       setBalance(0);

--- a/webapp/src/components/WalletCard.jsx
+++ b/webapp/src/components/WalletCard.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { getWalletBalance } from '../utils/api.js';
+import { getTransactions } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import LoginOptions from './LoginOptions.jsx';
 
@@ -19,8 +19,12 @@ export default function WalletCard() {
   const [tpcBalance, setTpcBalance] = useState(null);
 
   const loadBalance = async () => {
-    const prof = await getWalletBalance(telegramId);
-    setTpcBalance(prof.balance);
+    const tx = await getTransactions(telegramId);
+    const total = (tx.transactions || []).reduce(
+      (sum, t) => sum + (typeof t.amount === 'number' ? t.amount : 0),
+      0
+    );
+    setTpcBalance(total);
   };
 
   useEffect(() => {

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -234,7 +234,9 @@ export default function MyAccount() {
                 className="flex justify-between border-b border-border pb-1"
               >
                 <span>{tx.type}</span>
-                <span>{tx.amount}</span>
+                <span className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
+                  {tx.amount}
+                </span>
                 <span>{new Date(tx.date).toLocaleString()}</span>
                 <span className="text-xs">{tx.status}</span>
               </div>

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import QRCode from 'react-qr-code';
 import {
   createAccount,
   getAccountBalance,
@@ -147,6 +148,11 @@ export default function Wallet() {
           >
             Copy Account Number
           </button>
+          {accountId && (
+            <div className="mt-2 flex justify-center">
+              <QRCode value={String(accountId)} size={100} />
+            </div>
+          )}
         </div>
       </div>
 
@@ -160,7 +166,9 @@ export default function Wallet() {
               className="flex justify-between border-b border-border pb-1"
             >
               <span>{tx.type}</span>
-              <span>{tx.amount}</span>
+              <span className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
+                {tx.amount}
+              </span>
               <span>{new Date(tx.date).toLocaleString()}</span>
               <span className="text-xs">{tx.status}</span>
             </div>


### PR DESCRIPTION
## Summary
- derive wallet balance by summing transactions
- show green/red amounts for received/sent history
- display QR code for account id
- use new `react-qr-code` library

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686021e0d5c083298769539c7ed0278d