### PR TITLE
Improve TPC wallet feedback

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { FaWallet } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
-import { getTransactions } from '../utils/api.js';
+import { createAccount, getAccountBalance } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import LoginOptions from './LoginOptions.jsx';
 
@@ -17,12 +17,11 @@ export default function BalanceSummary() {
 
   const loadBalances = async () => {
     try {
-      const tx = await getTransactions(telegramId);
-      const total = (tx.transactions || []).reduce(
-        (sum, t) => sum + (typeof t.amount === 'number' ? t.amount : 0),
-        0
-      );
-      setBalance(total);
+      const acc = await createAccount(telegramId);
+      if (acc?.error) throw new Error(acc.error);
+      const bal = await getAccountBalance(acc.accountId);
+      if (bal?.error) throw new Error(bal.error);
+      setBalance(bal.balance ?? 0);
     } catch (err) {
       console.error('Failed to load balances:', err);
       setBalance(0);

--- a/webapp/src/components/ConfirmPopup.jsx
+++ b/webapp/src/components/ConfirmPopup.jsx
@@ -4,13 +4,19 @@ export default function ConfirmPopup({ open, message, onConfirm, onCancel }) {
   if (!open) return null;
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
+      <div className="prism-box p-6 space-y-4 text-text w-80">
         <p className="text-sm text-center">{message}</p>
         <div className="flex gap-2">
-          <button onClick={onConfirm} className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded">
+          <button
+            onClick={onConfirm}
+            className="flex-1 lobby-tile text-sm"
+          >
             Yes
           </button>
-          <button onClick={onCancel} className="flex-1 px-4 py-1 border border-border bg-surface rounded">
+          <button
+            onClick={onCancel}
+            className="flex-1 lobby-tile text-sm"
+          >
             No
           </button>
         </div>

--- a/webapp/src/components/InfoPopup.jsx
+++ b/webapp/src/components/InfoPopup.jsx
@@ -4,7 +4,7 @@ export default function InfoPopup({ open, onClose, title, info }) {
   if (!open) return null;
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
-      <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80 relative">
+      <div className="prism-box p-6 space-y-4 text-text w-80 relative">
         <button
           onClick={onClose}
           className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"


### PR DESCRIPTION
## Summary
- style ConfirmPopup and InfoPopup with prism box design
- connect balance summary to account API
- show styled confirmation & error popups when sending TPC
- use green progress bar for transaction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68602b5bf8cc8329ade218e15cc8e05a