### PR TITLE
Add TON Connect button and fix send confirmation

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -10,6 +10,8 @@
   "type": "module",
   "dependencies": {
     "@ayshrj/ludo.js": "^1.0.10",
+    "@tonconnect/sdk": "^3.2.0",
+    "@tonconnect/ui-react": "^2.2.0",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.15",
     "canvas-confetti": "^1.9.2",

--- a/webapp/public/tonconnect-manifest.json
+++ b/webapp/public/tonconnect-manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "TonPlaygram",
+  "url": "https://tonplaygram.example.com",
+  "iconUrl": "/assets/TonPlayGramLogo.jpg",
+  "termsOfUseUrl": "https://tonplaygram.example.com/terms",
+  "privacyPolicyUrl": "https://tonplaygram.example.com/privacy"
+}

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { Suspense, lazy } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { TonConnectUIProvider } from '@tonconnect/ui-react';
 
 import Home from './pages/Home.jsx';
 import Friends from './pages/Friends.jsx';
@@ -27,8 +28,9 @@ export default function App() {
 
   return (
     <BrowserRouter>
-      <Layout>
-        <Routes>
+      <TonConnectUIProvider manifestUrl="/tonconnect-manifest.json">
+        <Layout>
+          <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/friends" element={<Friends />} />
           <Route path="/games" element={<Games />} />
@@ -60,7 +62,8 @@ export default function App() {
           <Route path="/trending" element={<Trending />} />
           <Route path="/account" element={<MyAccount />} />
         </Routes>
-      </Layout>
+        </Layout>
+      </TonConnectUIProvider>
     </BrowserRouter>
   );
 }

--- a/webapp/src/components/ConfirmPopup.jsx
+++ b/webapp/src/components/ConfirmPopup.jsx
@@ -3,23 +3,14 @@ import React from 'react';
 export default function ConfirmPopup({ open, message, onConfirm, onCancel }) {
   if (!open) return null;
   return (
-    <div
-      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70"
-      style={{ zIndex: 60 }}
-    >
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="prism-box p-6 space-y-4 text-text w-80">
         <p className="text-sm text-center">{message}</p>
         <div className="flex gap-2">
-          <button
-            onClick={onConfirm}
-            className="flex-1 lobby-tile text-sm"
-          >
+          <button type="button" onClick={onConfirm} className="flex-1 lobby-tile text-sm">
             Yes
           </button>
-          <button
-            onClick={onCancel}
-            className="flex-1 lobby-tile text-sm"
-          >
+          <button type="button" onClick={onCancel} className="flex-1 lobby-tile text-sm">
             No
           </button>
         </div>

--- a/webapp/src/components/TonConnectButton.jsx
+++ b/webapp/src/components/TonConnectButton.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { TonConnectButton as ConnectButton } from '@tonconnect/ui-react';
+
+export default function TonConnectButton() {
+  return (
+    <div className="mt-2">
+      <ConnectButton className="lobby-tile px-3 py-1" />
+    </div>
+  );
+}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -19,6 +19,7 @@ import { ping } from '../utils/api.js';
 import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
 
 import BalanceSummary from '../components/BalanceSummary.jsx';
+import TonConnectButton from '../components/TonConnectButton.jsx';
 
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
 import { getProfile } from '../utils/api.js';
@@ -84,6 +85,8 @@ export default function Home() {
             />
           </div>
         )}
+
+        <TonConnectButton />
 
 
         <div className="w-full max-w-xs mt-2">


### PR DESCRIPTION
## Summary
- add TON Connect provider and button component
- display TON Connect button below the profile photo
- create manifest for TON Connect
- make ConfirmPopup buttons clickable and above page

## Testing
- `npm test`
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_6860496740488329ba139263f84f38d1