### PR TITLE
Adjust Branding layout

### DIFF
--- a/webapp/src/components/Branding.jsx
+++ b/webapp/src/components/Branding.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-export default function Branding({ small = false }) {
-  const classes = small ? 'text-center pt-2 pb-4 space-y-2' : 'text-center py-6 space-y-2';
+export default function Branding({ scale = 1, offsetY = 0 }) {
   return (
-    <div className={classes}>
+    <div className="text-center py-6 space-y-2">
       <img
         src="/assets/TonPlayGramLogo.jpg"
         alt="TonPlaygram Logo"
-        className={`mx-auto ${small ? 'scale-95 -mt-2' : ''}`}
+        className="mx-auto"
+        style={{ transform: `scale(${scale})`, marginTop: offsetY }}
       />
     </div>
   );

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -6,7 +6,7 @@ import Navbar from './Navbar.jsx';
 
 import Footer from './Footer.jsx';
 
-import Branding from "./Branding.jsx";
+import Branding from './Branding.jsx';
 
 import CosmicBackground from './CosmicBackground.jsx';
 
@@ -16,8 +16,12 @@ export default function Layout({ children }) {
 
   const isHome = location.pathname === '/';
   const isFriends = location.pathname === '/friends';
+  const isTasks = location.pathname === '/tasks';
+  const isStore = location.pathname === '/store';
+  const isAccount = location.pathname === '/account';
+  const isGamesRoot = location.pathname === '/games';
 
-  const showBranding = !location.pathname.startsWith('/games');
+  const showBranding = isGamesRoot || !location.pathname.startsWith('/games');
 
   const showNavbar = !(
 
@@ -37,7 +41,12 @@ export default function Layout({ children }) {
 
       <main className={`flex-grow container mx-auto p-4 ${showNavbar ? 'pb-24' : ''}`.trim()}>
 
-        {showBranding && <Branding small={isFriends} />}
+        {showBranding && (
+          <Branding
+            scale={isFriends || isTasks || isStore || isAccount || isGamesRoot ? 1.2 : 1}
+            offsetY={isFriends ? '0.5rem' : 0}
+          />
+        )}
 
         {children}
 


### PR DESCRIPTION
## Summary
- improve Branding component with scale and offset props
- enlarge logo on friends, tasks, account, store and games pages
- show logo on /games root page and lower it a bit on Friends

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860501e3f188329a780953f08e9dfac