### PR TITLE
Fix modal layering for button clicks

### DIFF
--- a/webapp/src/components/ConfirmPopup.jsx
+++ b/webapp/src/components/ConfirmPopup.jsx
@@ -1,20 +1,30 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 
 export default function ConfirmPopup({ open, message, onConfirm, onCancel }) {
   if (!open) return null;
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="prism-box p-6 space-y-4 text-text w-80">
         <p className="text-sm text-center">{message}</p>
         <div className="flex gap-2">
-          <button type="button" onClick={onConfirm} className="flex-1 lobby-tile text-sm cursor-pointer">
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="flex-1 lobby-tile text-sm cursor-pointer"
+          >
             Yes
           </button>
-          <button type="button" onClick={onCancel} className="flex-1 lobby-tile text-sm cursor-pointer">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 lobby-tile text-sm cursor-pointer"
+          >
             No
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/webapp/src/components/GameEndPopup.jsx
+++ b/webapp/src/components/GameEndPopup.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 
 export default function GameEndPopup({ open, ranking, onPlayAgain, onReturn }) {
   if (!open) return null;
-  return (
+  return createPortal(
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
         <img src="/assets/TonPlayGramLogo.jpg" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
@@ -13,14 +14,21 @@ export default function GameEndPopup({ open, ranking, onPlayAgain, onReturn }) {
           ))}
         </ol>
         <div className="flex gap-2">
-          <button onClick={onPlayAgain} className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded">
+          <button
+            onClick={onPlayAgain}
+            className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded"
+          >
             Play Again
           </button>
-          <button onClick={onReturn} className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded">
+          <button
+            onClick={onReturn}
+            className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded"
+          >
             Return to Lobby
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/webapp/src/components/InfoPopup.jsx
+++ b/webapp/src/components/InfoPopup.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 
 export default function InfoPopup({ open, onClose, title, info }) {
   if (!open) return null;
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="prism-box p-6 space-y-4 text-text w-80 relative">
         <button
@@ -14,6 +15,7 @@ export default function InfoPopup({ open, onClose, title, info }) {
         {title && <h3 className="text-lg font-bold text-center">{title}</h3>}
         {info && <p className="text-sm text-subtext text-center">{info}</p>}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
## Summary
- ensure popups render above 3D board via `createPortal`
- use portal pattern in ConfirmPopup, GameEndPopup, and InfoPopup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860570914508329ace59581114be624