### PR TITLE
Fix unclickable buttons and simplify style

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -974,35 +974,13 @@ body {
 
 .prism-box {
   @apply relative flex items-center justify-center rounded-lg bg-surface border border-border;
-  box-shadow: 0 8px 12px rgba(0, 0, 0, 0.6);
-  transform-style: preserve-3d;
-}
-
-.prism-box::after {
-  content: "";
-  position: absolute;
-  inset: 2px;
-  border-radius: inherit;
-  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.6);
-  transform: translateZ(6px);
 }
 
 .lobby-tile {
   @apply relative flex items-center justify-center rounded-xl text-white font-semibold;
   background-color: #2d5c66;
   border: 2px solid #334155;
-  box-shadow: 0 8px 12px rgba(0, 0, 0, 0.6);
-  transform-style: preserve-3d;
   padding: 0.25rem 0.5rem;
-}
-
-.lobby-tile::after {
-  content: "";
-  position: absolute;
-  inset: 2px;
-  border-radius: inherit;
-  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.6);
-  transform: translateZ(6px);
 }
 
 .lobby-selected {
@@ -1014,16 +992,7 @@ body {
 .board-style {
   background-color: #0e3b45;
   border: 2px solid #334155;
-  box-shadow: 0 8px 12px rgba(0,0,0,0.6);
-  position: relative;
   color: #ffffff;
-}
-.board-style::after {
-  content: "";
-  position: absolute;
-  inset: 2px;
-  border-radius: inherit;
-  box-shadow: inset 0 0 6px rgba(0,0,0,0.6);
 }
 .friend-background{
   transform: translateY(70px) scale(1.98);


### PR DESCRIPTION
## Summary
- flatten prism/lobby/board styles so overlays don't block clicks

## Testing
- `npm run install-all`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68605c5b5e3c832989f9ac47927fb4f5