### PR TITLE
Improve TPC wallet instructions and error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@
    pip install -r requirements.txt
    ```
 
-6. Build the webapp assets:
+6. Build the webapp assets. This step copies `public/tonconnect-manifest.json`
+   into the `dist` folder so wallets can connect:
 
    ```bash
    npm --prefix webapp run build
@@ -79,6 +80,9 @@ is detected.
 - **No Telegram notifications** – confirm `npm start` is running and the bot
   token is valid. Users must interact with the bot in Telegram to receive
   messages.
+- **Cannot send TPC** – this happens when the API cannot verify your Telegram
+  web app data. Ensure the web page was opened from your bot and that the
+  `BOT_TOKEN` in `bot/.env` matches the token used by Telegram.
 
 ### Resetting the TPC wallet
 

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -76,8 +76,10 @@ export default function Wallet() {
     try {
       const res = await sendAccountTpc(accountId, to, amt);
       if (res?.error) {
-        if (res.error === 'unauthorized') {
-          setErrorMsg('You must open the web app from Telegram to send TPC.');
+        if (res.error === 'unauthorized' || res.error === 'forbidden') {
+          setErrorMsg(
+            'Authorization failed. Make sure you opened this page from Telegram and that your bot token is correct.'
+          );
         } else {
           setErrorMsg(res.error);
         }


### PR DESCRIPTION
## Summary
- clarify build step so TonConnect manifest is copied
- explain why sending TPC might fail
- provide clearer authorization error message in wallet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860616def68832983d2e0b91e7d736a