### PR TITLE
Update account creation

### DIFF
--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -9,11 +9,16 @@ const router = Router();
 // Create or fetch account for a user
 router.post('/create', async (req, res) => {
   const { telegramId } = req.body;
-  if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
 
-  let user = await User.findOne({ telegramId });
+  let user = null;
+  if (telegramId) {
+    user = await User.findOne({ telegramId });
+  }
+
   if (!user) {
-    user = new User({ telegramId, accountId: uuidv4(), referralCode: String(telegramId) });
+    user = new User({ accountId: uuidv4() });
+    if (telegramId) user.telegramId = telegramId;
+    user.referralCode = String(telegramId || user.accountId);
     await user.save();
   } else if (!user.accountId) {
     user.accountId = uuidv4();

--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -2,22 +2,13 @@ import { useEffect, useState } from 'react';
 import { FaWallet } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 import { createAccount, getAccountBalance } from '../utils/api.js';
-import { getTelegramId } from '../utils/telegram.js';
-import LoginOptions from './LoginOptions.jsx';
 
 export default function BalanceSummary() {
-  let telegramId;
-  try {
-    telegramId = getTelegramId();
-  } catch (err) {
-    return <LoginOptions />;
-  }
-
   const [balance, setBalance] = useState(null);
 
   const loadBalances = async () => {
     try {
-      const acc = await createAccount(telegramId);
+      const acc = await createAccount();
       if (acc?.error) throw new Error(acc.error);
       const bal = await getAccountBalance(acc.accountId);
       if (bal?.error) throw new Error(bal.error);

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -6,21 +6,12 @@ import {
   sendAccountTpc,
   getAccountTransactions
 } from '../utils/api.js';
-import { getTelegramId } from '../utils/telegram.js';
-import LoginOptions from '../components/LoginOptions.jsx';
 import ConfirmPopup from '../components/ConfirmPopup.jsx';
 import InfoPopup from '../components/InfoPopup.jsx';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 
 export default function Wallet() {
   useTelegramBackButton();
-  let telegramId;
-
-  try {
-    telegramId = getTelegramId();
-  } catch (err) {
-    return <LoginOptions />;
-  }
 
   const [accountId, setAccountId] = useState('');
   const [tpcBalance, setTpcBalance] = useState(null);
@@ -34,7 +25,7 @@ export default function Wallet() {
 
 
   const loadBalances = async () => {
-    const acc = await createAccount(telegramId);
+    const acc = await createAccount();
     if (acc?.error) {
       console.error('Failed to load account:', acc.error);
       return null;

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -309,7 +309,8 @@ export function resetTpcWallet(telegramId) {
 // ----- Account based wallet -----
 
 export function createAccount(telegramId) {
-  return post('/api/account/create', { telegramId });
+  const payload = telegramId ? { telegramId } : {};
+  return post('/api/account/create', payload);
 }
 
 export function getAccountBalance(accountId) {


### PR DESCRIPTION
## Summary
- remove telegram requirement from account creation
- make `createAccount` API call optional for `telegramId`
- adjust wallet and balance summary components to not depend on Telegram login

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686065b287908329bcc6a3a04d0517bc