### PR TITLE
Allow wallet without Telegram ID

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -102,6 +102,13 @@ function ensureWebappBuilt() {
 
 ensureWebappBuilt();
 
+// Serve tonconnect manifest directly to avoid missing file errors
+app.get('/tonconnect-manifest.json', (req, res) => {
+  const built = path.join(webappPath, 'tonconnect-manifest.json');
+  const fallback = path.join(__dirname, '../webapp/public/tonconnect-manifest.json');
+  const manifest = existsSync(built) ? built : fallback;
+  res.sendFile(manifest);
+});
 
 app.use(
   express.static(webappPath, { maxAge: '1y', immutable: true })

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -309,7 +309,8 @@ export function resetTpcWallet(telegramId) {
 // ----- Account based wallet -----
 
 export function createAccount(telegramId) {
-  return post('/api/account/create', { telegramId });
+  const body = telegramId ? { telegramId } : {};
+  return post('/api/account/create', body);
 }
 
 export function getAccountBalance(accountId) {


### PR DESCRIPTION
## Summary
- permit anonymous account creation on the backend
- remove Telegram requirement from wallet page
- send tonconnect manifest directly from Express to avoid 404s

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68606a3bfc848329b4c9472081b05cbc