### PR TITLE
Remove Telegram requirement for transfers

### DIFF
--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -309,7 +309,9 @@ export function resetTpcWallet(telegramId) {
 // ----- Account based wallet -----
 
 export function createAccount(telegramId) {
-  return post('/api/account/create', { telegramId });
+  const body = {};
+  if (telegramId) body.telegramId = telegramId;
+  return post('/api/account/create', body);
 }
 
 export function getAccountBalance(accountId) {


### PR DESCRIPTION
## Summary
- allow account creation without Telegram ID
- permit token transfers without Telegram authentication
- persist generated account IDs in the Wallet page
- support optional telegramId when creating an account

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860d26981f88329aba21067148a3bd2