### PR TITLE
Improve TON Connect and snake game

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -26,9 +26,11 @@ import useTelegramAuth from './hooks/useTelegramAuth.js';
 export default function App() {
   useTelegramAuth();
 
+  const manifestUrl = `${window.location.origin}/tonconnect-manifest.json`;
+
   return (
     <BrowserRouter>
-      <TonConnectUIProvider manifestUrl="/tonconnect-manifest.json">
+      <TonConnectUIProvider manifestUrl={manifestUrl}>
         <Layout>
           <Routes>
           <Route path="/" element={<Home />} />

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -758,7 +758,6 @@ export default function SnakeAndLadder() {
     setGameOver(over);
     if (over) {
       localStorage.removeItem(`snakeGameState_${ai}`);
-      window.location.reload();
     }
   };
 
@@ -812,20 +811,15 @@ export default function SnakeAndLadder() {
 
   useEffect(() => {
     const handleUnload = () => {
-      if (reloadingRef.current) return;
       const key = `snakeGameState_${ai}`;
-      try {
-        const stored = JSON.parse(localStorage.getItem(key) || '{}');
-        if (!stored.ranking || !stored.ranking.includes('You')) {
-          stored.ranking = [...(stored.ranking || []), 'You'];
-        }
-        stored.gameOver = true;
-        stored.timestamp = Date.now();
-        localStorage.setItem(key, JSON.stringify(stored));
-      } catch {}
+      localStorage.removeItem(key);
     };
     window.addEventListener('beforeunload', handleUnload);
-    return () => window.removeEventListener('beforeunload', handleUnload);
+    window.addEventListener('pagehide', handleUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleUnload);
+      window.removeEventListener('pagehide', handleUnload);
+    };
   }, [ai]);
 
   const handleRoll = (values) => {


### PR DESCRIPTION
## Summary
- make manifest URL dynamic for TonConnect provider
- reset snake game state on unload and stop auto-reloading when over

## Testing
- `npm test --silent` *(fails: Cannot find package 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_6860dcc67584832985fe4cd87b7081d1