### PR TITLE
Show TON/USDT balances on home page

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -1,9 +1,15 @@
 import { useEffect, useState } from 'react';
 import { FaWallet } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
-import { createAccount, getAccountBalance } from '../utils/api.js';
+import {
+  createAccount,
+  getAccountBalance,
+  getTonBalance,
+  getUsdtBalance
+} from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import LoginOptions from './LoginOptions.jsx';
+import { useTonAddress } from '@tonconnect/ui-react';
 
 export default function BalanceSummary() {
   let telegramId;
@@ -14,6 +20,10 @@ export default function BalanceSummary() {
   }
 
   const [balance, setBalance] = useState(null);
+  const [tonBalance, setTonBalance] = useState(null);
+  const [usdtBalance, setUsdtBalance] = useState(null);
+
+  const walletAddress = useTonAddress(true);
 
   const loadBalances = async () => {
     try {
@@ -28,9 +38,37 @@ export default function BalanceSummary() {
     }
   };
 
+  const loadExternalBalances = async () => {
+    if (!walletAddress) {
+      setTonBalance(null);
+      setUsdtBalance(null);
+      return;
+    }
+    try {
+      const ton = await getTonBalance(walletAddress);
+      if (ton?.error) throw new Error(ton.error);
+      setTonBalance(ton.balance ?? 0);
+    } catch (err) {
+      console.error('Failed to load TON balance:', err);
+      setTonBalance(0);
+    }
+    try {
+      const usdt = await getUsdtBalance(walletAddress);
+      if (usdt?.error) throw new Error(usdt.error);
+      setUsdtBalance(usdt.balance ?? 0);
+    } catch (err) {
+      console.error('Failed to load USDT balance:', err);
+      setUsdtBalance(0);
+    }
+  };
+
   useEffect(() => {
     loadBalances();
   }, []);
+
+  useEffect(() => {
+    loadExternalBalances();
+  }, [walletAddress]);
 
   return (
     <div className="text-center mt-2">
@@ -40,8 +78,10 @@ export default function BalanceSummary() {
           <span>Wallet</span>
         </Link>
       </p>
-      <div className="flex justify-center text-sm mt-1">
+      <div className="flex justify-center text-sm mt-1 space-x-2">
+        <Token icon="/icons/TON.png" label="TON" value={tonBalance ?? '...'} />
         <Token icon="/icons/TPCcoin.png" label="TPC" value={balance ?? 0} />
+        <Token icon="/icons/Usdt.png" label="USDT" value={usdtBalance ?? '...'} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- fetch external wallet balances if connected via Ton Connect
- display TON and USDT amounts beside the TPC balance

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860e245d4108329839851449d668592