### PR TITLE
Adjust wallet section layout

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -78,7 +78,7 @@ export default function BalanceSummary() {
           <span>Wallet</span>
         </Link>
       </p>
-      <div className="flex justify-center text-sm mt-1 space-x-2">
+      <div className="flex justify-center text-sm mt-2 space-x-4">
         <Token icon="/icons/TON.png" label="TON" value={tonBalance ?? '...'} />
         <Token icon="/icons/TPCcoin.png" label="TPC" value={balance ?? 0} />
         <Token icon="/icons/Usdt.png" label="USDT" value={usdtBalance ?? '...'} />

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -96,12 +96,14 @@ export default function Home() {
               className="background-behind-board object-cover"
               alt=""
             />
-            <Link to="/wallet?mode=send" className="flex items-center space-x-1">
+            <Link to="/wallet?mode=send" className="flex items-center space-x-1 -ml-1">
               <FaArrowCircleUp className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Send</span>
             </Link>
-            <BalanceSummary />
-            <Link to="/wallet?mode=receive" className="flex items-center space-x-1">
+            <div className="-mt-1">
+              <BalanceSummary />
+            </div>
+            <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1">
               <FaArrowCircleDown className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Receive</span>
             </Link>


### PR DESCRIPTION
## Summary
- tweak spacing for token balances
- shift send/receive buttons and nudge wallet summary up on home page

## Testing
- `npm test` *(fails: cannot find module 'mongoose', 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6860f9ccec48832989fd1d3cd819bf69