### PR TITLE
UI fixes and profile avatar improvements

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -71,7 +71,7 @@ export default function BalanceSummary() {
   }, [walletAddress]);
 
   return (
-    <div className="text-center mt-2">
+    <div className="text-center">
       <p className="text-lg font-bold text-gray-300 flex items-center justify-center space-x-1">
         <Link to="/wallet" className="flex items-center space-x-1">
           <FaWallet className="text-primary" />

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -89,7 +89,7 @@ export default function Home() {
         <TonConnectButton />
 
 
-        <div className="w-full max-w-xs mt-2">
+        <div className="w-full mt-2">
           <div className="relative flex items-center justify-between bg-surface border border-border rounded-xl p-2 overflow-hidden">
             <img
               src="/assets/SnakeLaddersbackground.png"
@@ -100,9 +100,7 @@ export default function Home() {
               <FaArrowCircleUp className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Send</span>
             </Link>
-            <div className="-mt-1">
-              <BalanceSummary />
-            </div>
+            <BalanceSummary />
             <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1">
               <FaArrowCircleDown className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Receive</span>

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -20,6 +20,7 @@ import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import AvatarPickerModal from '../components/AvatarPickerModal.jsx';
 import AvatarPromptModal from '../components/AvatarPromptModal.jsx';
 import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
+import InfoPopup from '../components/InfoPopup.jsx';
 import InboxWidget from '../components/InboxWidget.jsx';
 
 export default function MyAccount() {
@@ -38,6 +39,7 @@ export default function MyAccount() {
   const [transactions, setTransactions] = useState([]);
   const [showAvatarPicker, setShowAvatarPicker] = useState(false);
   const [showAvatarPrompt, setShowAvatarPrompt] = useState(false);
+  const [showSaved, setShowSaved] = useState(false);
   const timerRef = useRef(null);
 
   useEffect(() => {
@@ -160,6 +162,8 @@ export default function MyAccount() {
           saveAvatar(src);
           setProfile(updated);
           setShowAvatarPicker(false);
+          setShowSaved(true);
+          setTimeout(() => setShowSaved(false), 1500);
           window.dispatchEvent(new Event('profilePhotoUpdated'));
         }}
       />
@@ -185,6 +189,20 @@ export default function MyAccount() {
             className="mt-2 px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm"
           >
             Change Avatar
+          </button>
+          <button
+            onClick={async () => {
+              const url = getTelegramPhotoUrl();
+              const updated = await updateProfile({ telegramId, photo: url });
+              localStorage.removeItem('profilePhoto');
+              setProfile(updated);
+              setShowSaved(true);
+              setTimeout(() => setShowSaved(false), 1500);
+              window.dispatchEvent(new Event('profilePhotoUpdated'));
+            }}
+            className="mt-2 ml-2 px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm"
+          >
+            Use Telegram Photo
           </button>
           <div className="mt-2 space-x-2">
             <a href="/friends" className="underline text-primary">
@@ -245,6 +263,11 @@ export default function MyAccount() {
         )}
       </div>
       <InboxWidget />
+      <InfoPopup
+        open={showSaved}
+        onClose={() => setShowSaved(false)}
+        info="Profile saved"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- tweak BalanceSummary layout so tokens align with icons
- make home wallet card full width and adjust icon spacing
- let users switch between Telegram photo and avatar
- show confirmation when saving avatar

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686100c29f488329bb56ee4118673185