### PR TITLE
Adjust wallet card layout

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -78,7 +78,7 @@ export default function BalanceSummary() {
           <span>Wallet</span>
         </Link>
       </p>
-      <div className="flex justify-center text-sm mt-2 space-x-4">
+      <div className="grid grid-cols-3 text-sm mt-2">
         <Token icon="/icons/TON.png" label="TON" value={tonBalance ?? '...'} />
         <Token icon="/icons/TPCcoin.png" label="TPC" value={balance ?? 0} />
         <Token icon="/icons/Usdt.png" label="USDT" value={usdtBalance ?? '...'} />
@@ -89,7 +89,7 @@ export default function BalanceSummary() {
 
 function Token({ icon, value, label }) {
   return (
-    <div className="flex items-center space-x-1">
+    <div className="flex items-center justify-center space-x-1 w-full">
       <img src={icon} alt={label} className="w-8 h-8" />
       <span>{value}</span>
     </div>

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -90,18 +90,18 @@ export default function Home() {
 
 
         <div className="w-full mt-2">
-          <div className="relative flex items-center justify-between bg-surface border border-border rounded-xl p-2 overflow-hidden">
+          <div className="relative flex items-start justify-between bg-surface border border-border rounded-xl p-2 overflow-hidden">
             <img
               src="/assets/SnakeLaddersbackground.png"
               className="background-behind-board object-cover"
               alt=""
             />
-            <Link to="/wallet?mode=send" className="flex items-center space-x-1 -ml-1">
+            <Link to="/wallet?mode=send" className="flex items-center space-x-1 -ml-1 pt-1">
               <FaArrowCircleUp className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Send</span>
             </Link>
             <BalanceSummary />
-            <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1">
+            <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">
               <FaArrowCircleDown className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Receive</span>
             </Link>


### PR DESCRIPTION
## Summary
- tweak wallet card layout on Home page
- space out token balances equally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68610594bc9c832991d885fa1bfa53c7