### PR TITLE
Update wallet card layout

### DIFF
--- a/webapp/public/tonconnect-manifest.json
+++ b/webapp/public/tonconnect-manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "TonPlaygram",
   "url": "https://tonplaygram.example.com",
-  "iconUrl": "/icons/TPCcoin.png",
+  "iconUrl": "/assets/TonPlayGramLogo.jpg",
   "termsOfUseUrl": "https://tonplaygram.example.com/terms",
   "privacyPolicyUrl": "https://tonplaygram.example.com/privacy"
 }

--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -11,7 +11,7 @@ import { getTelegramId } from '../utils/telegram.js';
 import LoginOptions from './LoginOptions.jsx';
 import { useTonAddress } from '@tonconnect/ui-react';
 
-export default function BalanceSummary() {
+export default function BalanceSummary({ className = '' }) {
   let telegramId;
   try {
     telegramId = getTelegramId();
@@ -71,27 +71,29 @@ export default function BalanceSummary() {
   }, [walletAddress]);
 
   return (
-    <div className="text-center">
+    <div className={`text-center ${className}`}>
       <p className="text-lg font-bold text-gray-300 flex items-center justify-center space-x-1">
         <Link to="/wallet" className="flex items-center space-x-1">
           <FaWallet className="text-primary" />
           <span>Wallet</span>
         </Link>
       </p>
-      <div className="grid grid-cols-3 text-sm mt-2">
+      <div className="grid grid-cols-3 text-sm mt-4">
         <Token icon="/icons/TON.png" label="TON" value={tonBalance ?? '...'} />
-        <Token icon="/icons/TPCcoin.png" label="TPC" value={balance ?? 0} />
+        <Token icon="/icons/TPCcoin.png" label="TPC" value={balance ?? 0} isTPC />
         <Token icon="/icons/Usdt.png" label="USDT" value={usdtBalance ?? '...'} />
       </div>
     </div>
   );
 }
 
-function Token({ icon, value, label }) {
+function Token({ icon, value, label, isTPC = false }) {
+  const displayValue =
+    typeof value === 'number' && isTPC ? value.toLocaleString() : value;
   return (
     <div className="flex items-center justify-center space-x-1 w-full">
       <img src={icon} alt={label} className="w-8 h-8" />
-      <span>{value}</span>
+      <span>{displayValue}</span>
     </div>
   );
 }

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -110,7 +110,7 @@ export default function DailyCheckIn() {
 
         className={`board-style w-20 p-2 flex flex-col items-center justify-center text-xs ${
 
-          i === streak - 1 ? 'bg-accent text-black' : ''
+          i === streak - 1 ? 'bg-yellow-300 text-black' : ''
 
         }`}
 

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -150,7 +150,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
               className={`board-style flex items-center justify-center text-sm w-32 font-bold ${
 
-                idx === winnerIndex ? 'bg-accent text-black' : 'text-white'
+                idx === winnerIndex ? 'bg-yellow-300 text-black' : 'text-white'
 
               }`}
 

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -100,7 +100,7 @@ export default function Home() {
               <FaArrowCircleUp className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Send</span>
             </Link>
-            <BalanceSummary />
+            <BalanceSummary className="-ml-4" />
             <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">
               <FaArrowCircleDown className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Receive</span>


### PR DESCRIPTION
## Summary
- shift wallet summary left under the send button
- move wallet token icons down
- display TPC balance with thousands separators
- swap tonconnect manifest icon with TonPlaygram logo
- highlight active streak day and wheel win in yellow

## Testing
- `npm test` *(fails: Cannot find package 'mongoose' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68610e34e6e88329847bac22e837539f