### PR TITLE
UI tweaks for wallet card

### DIFF
--- a/webapp/public/tonconnect-manifest.json
+++ b/webapp/public/tonconnect-manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "TonPlaygram",
   "url": "https://tonplaygram.example.com",
-  "iconUrl": "/assets/TonPlayGramLogo.jpg",
+  "iconUrl": "/icons/TPCcoin.png",
   "termsOfUseUrl": "https://tonplaygram.example.com/terms",
   "privacyPolicyUrl": "https://tonplaygram.example.com/privacy"
 }

--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -80,20 +80,33 @@ export default function BalanceSummary({ className = '' }) {
       </p>
       <div className="grid grid-cols-3 text-sm mt-4">
         <Token icon="/icons/TON.png" label="TON" value={tonBalance ?? '...'} />
-        <Token icon="/icons/TPCcoin.png" label="TPC" value={balance ?? 0} isTPC />
+        <Token icon="/icons/TPCcoin.png" label="TPC" value={balance ?? 0} />
         <Token icon="/icons/Usdt.png" label="USDT" value={usdtBalance ?? '...'} />
       </div>
     </div>
   );
 }
 
-function Token({ icon, value, label, isTPC = false }) {
-  const displayValue =
-    typeof value === 'number' && isTPC ? value.toLocaleString() : value;
+function formatValue(value) {
+  if (typeof value !== 'number') {
+    const parsed = parseFloat(value);
+    if (isNaN(parsed)) return value;
+    return parsed.toLocaleString(undefined, {
+      minimumFractionDigits: 4,
+      maximumFractionDigits: 4,
+    });
+  }
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 4,
+  });
+}
+
+function Token({ icon, value, label }) {
   return (
     <div className="flex items-center justify-center space-x-1 w-full">
       <img src={icon} alt={label} className="w-8 h-8" />
-      <span>{displayValue}</span>
+      <span>{formatValue(value)}</span>
     </div>
   );
 }

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -110,7 +110,7 @@ export default function DailyCheckIn() {
 
         className={`board-style w-20 p-2 flex flex-col items-center justify-center text-xs ${
 
-          i === streak - 1 ? 'bg-yellow-300 text-black' : ''
+          i < streak ? 'bg-yellow-300 text-black' : ''
 
         }`}
 

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -122,7 +122,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
         <div
 
-          className="absolute inset-x-0 border-2 border-accent pointer-events-none z-10"
+          className="absolute inset-x-0 border-2 border-yellow-300 pointer-events-none z-10"
 
           style={{ top: itemHeight * winningRow, height: itemHeight }}
 

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -100,7 +100,7 @@ export default function Home() {
               <FaArrowCircleUp className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Send</span>
             </Link>
-            <BalanceSummary className="-ml-4" />
+            <BalanceSummary />
             <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">
               <FaArrowCircleDown className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Receive</span>


### PR DESCRIPTION
## Summary
- align wallet icons on the Home page
- format balances to four decimal places
- fix icon when connecting wallet
- highlight progress days in daily streak
- mark winning slot with yellow border

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861148af3248329b4fc120f0b1826b0