### PR TITLE
Align wallet card tokens

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -104,7 +104,7 @@ function formatValue(value) {
 
 function Token({ icon, value, label }) {
   return (
-    <div className="flex items-center justify-center space-x-1 w-full">
+    <div className="flex items-center justify-start space-x-1 w-full">
       <img src={icon} alt={label} className="w-8 h-8" />
       <span>{formatValue(value)}</span>
     </div>


### PR DESCRIPTION
## Summary
- align token icons to the left so numbers expand rightward

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686118ad11d08329a5b904b64dd3e527