### PR TITLE
Update wallet card layout and balance formatting

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -80,33 +80,33 @@ export default function BalanceSummary({ className = '' }) {
       </p>
       <div className="grid grid-cols-3 text-sm mt-4">
         <Token icon="/icons/TON.png" label="TON" value={tonBalance ?? '...'} />
-        <Token icon="/icons/TPCcoin.png" label="TPC" value={balance ?? 0} />
-        <Token icon="/icons/Usdt.png" label="USDT" value={usdtBalance ?? '...'} />
+        <Token icon="/icons/TPCcoin.png" label="TPC" value={balance ?? 0} decimals={2} />
+        <Token icon="/icons/Usdt.png" label="USDT" value={usdtBalance ?? '...'} decimals={2} />
       </div>
     </div>
   );
 }
 
-function formatValue(value) {
+function formatValue(value, decimals = 4) {
   if (typeof value !== 'number') {
     const parsed = parseFloat(value);
     if (isNaN(parsed)) return value;
     return parsed.toLocaleString(undefined, {
-      minimumFractionDigits: 4,
-      maximumFractionDigits: 4,
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
     });
   }
   return value.toLocaleString(undefined, {
-    minimumFractionDigits: 4,
-    maximumFractionDigits: 4,
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
   });
 }
 
-function Token({ icon, value, label }) {
+function Token({ icon, value, label, decimals }) {
   return (
     <div className="flex items-center justify-start space-x-1 w-full">
       <img src={icon} alt={label} className="w-8 h-8" />
-      <span>{formatValue(value)}</span>
+      <span>{formatValue(value, decimals)}</span>
     </div>
   );
 }

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -100,12 +100,12 @@ export default function Home() {
               <FaArrowCircleUp className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Send</span>
             </Link>
-            <BalanceSummary />
             <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">
               <FaArrowCircleDown className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Receive</span>
             </Link>
           </div>
+          <BalanceSummary className="mt-2" />
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- rearrange wallet card layout on home screen
- format TPC and USDT balances with 2 decimals

## Testing
- `npm test` *(fails: Cannot find package 'mongoose', Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68611d0062148329b9e3f688ef8db62b