### PR TITLE
Update home page balances

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -1,86 +1,27 @@
-import { useEffect, useState } from 'react';
 import { FaWallet } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
-import {
-  createAccount,
-  getAccountBalance,
-  getTonBalance,
-  getUsdtBalance
-} from '../utils/api.js';
-import { getTelegramId } from '../utils/telegram.js';
 import LoginOptions from './LoginOptions.jsx';
-import { useTonAddress } from '@tonconnect/ui-react';
+import useTokenBalances from '../hooks/useTokenBalances.js';
 
-export default function BalanceSummary({ className = '' }) {
-  let telegramId;
-  try {
-    telegramId = getTelegramId();
-  } catch (err) {
+export default function BalanceSummary({ className = '', showHeader = true }) {
+  const { tpcBalance, tonBalance, usdtBalance, telegramId } = useTokenBalances();
+  if (!telegramId) {
     return <LoginOptions />;
   }
 
-  const [balance, setBalance] = useState(null);
-  const [tonBalance, setTonBalance] = useState(null);
-  const [usdtBalance, setUsdtBalance] = useState(null);
-
-  const walletAddress = useTonAddress(true);
-
-  const loadBalances = async () => {
-    try {
-      const acc = await createAccount(telegramId);
-      if (acc?.error) throw new Error(acc.error);
-      const bal = await getAccountBalance(acc.accountId);
-      if (bal?.error) throw new Error(bal.error);
-      setBalance(bal.balance ?? 0);
-    } catch (err) {
-      console.error('Failed to load balances:', err);
-      setBalance(0);
-    }
-  };
-
-  const loadExternalBalances = async () => {
-    if (!walletAddress) {
-      setTonBalance(null);
-      setUsdtBalance(null);
-      return;
-    }
-    try {
-      const ton = await getTonBalance(walletAddress);
-      if (ton?.error) throw new Error(ton.error);
-      setTonBalance(ton.balance ?? 0);
-    } catch (err) {
-      console.error('Failed to load TON balance:', err);
-      setTonBalance(0);
-    }
-    try {
-      const usdt = await getUsdtBalance(walletAddress);
-      if (usdt?.error) throw new Error(usdt.error);
-      setUsdtBalance(usdt.balance ?? 0);
-    } catch (err) {
-      console.error('Failed to load USDT balance:', err);
-      setUsdtBalance(0);
-    }
-  };
-
-  useEffect(() => {
-    loadBalances();
-  }, []);
-
-  useEffect(() => {
-    loadExternalBalances();
-  }, [walletAddress]);
-
   return (
     <div className={`text-center ${className}`}>
-      <p className="text-lg font-bold text-gray-300 flex items-center justify-center space-x-1">
-        <Link to="/wallet" className="flex items-center space-x-1">
-          <FaWallet className="text-primary" />
-          <span>Wallet</span>
-        </Link>
-      </p>
+      {showHeader && (
+        <p className="text-lg font-bold text-gray-300 flex items-center justify-center space-x-1">
+          <Link to="/wallet" className="flex items-center space-x-1">
+            <FaWallet className="text-primary" />
+            <span>Wallet</span>
+          </Link>
+        </p>
+      )}
       <div className="grid grid-cols-3 text-sm mt-4">
         <Token icon="/icons/TON.png" label="TON" value={tonBalance ?? '...'} />
-        <Token icon="/icons/TPCcoin.png" label="TPC" value={balance ?? 0} decimals={2} />
+        <Token icon="/icons/TPCcoin.png" label="TPC" value={tpcBalance ?? 0} decimals={2} />
         <Token icon="/icons/Usdt.png" label="USDT" value={usdtBalance ?? '...'} decimals={2} />
       </div>
     </div>

--- a/webapp/src/components/TonConnectButton.jsx
+++ b/webapp/src/components/TonConnectButton.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { TonConnectButton as ConnectButton } from '@tonconnect/ui-react';
 
-export default function TonConnectButton() {
+export default function TonConnectButton({ small = false, className = '' }) {
+  const sizeClass = small ? 'px-2 py-0.5 text-sm' : 'px-3 py-1';
   return (
-    <div className="mt-2">
-      <ConnectButton className="lobby-tile px-3 py-1 cursor-pointer" />
+    <div className={`mt-2 ${className}`}>
+      <ConnectButton className={`lobby-tile cursor-pointer ${sizeClass}`} />
     </div>
   );
 }

--- a/webapp/src/hooks/useTokenBalances.js
+++ b/webapp/src/hooks/useTokenBalances.js
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import { createAccount, getAccountBalance, getTonBalance, getUsdtBalance } from '../utils/api.js';
+import { getTelegramId } from '../utils/telegram.js';
+import { useTonAddress } from '@tonconnect/ui-react';
+
+export default function useTokenBalances() {
+  let telegramId;
+  try {
+    telegramId = getTelegramId();
+  } catch (err) {
+    telegramId = undefined;
+  }
+
+  const [tpcBalance, setTpcBalance] = useState(null);
+  const [tonBalance, setTonBalance] = useState(null);
+  const [usdtBalance, setUsdtBalance] = useState(null);
+
+  const walletAddress = useTonAddress(true);
+
+  useEffect(() => {
+    async function loadTpc() {
+      if (!telegramId) return;
+      try {
+        const acc = await createAccount(telegramId);
+        if (acc?.error) throw new Error(acc.error);
+        const bal = await getAccountBalance(acc.accountId);
+        if (bal?.error) throw new Error(bal.error);
+        setTpcBalance(bal.balance ?? 0);
+      } catch (err) {
+        console.error('Failed to load TPC balance:', err);
+        setTpcBalance(0);
+      }
+    }
+    loadTpc();
+  }, [telegramId]);
+
+  useEffect(() => {
+    async function loadExternal() {
+      if (!walletAddress) {
+        setTonBalance(null);
+        setUsdtBalance(null);
+        return;
+      }
+      try {
+        const ton = await getTonBalance(walletAddress);
+        if (ton?.error) throw new Error(ton.error);
+        setTonBalance(ton.balance ?? 0);
+      } catch (err) {
+        console.error('Failed to load TON balance:', err);
+        setTonBalance(0);
+      }
+      try {
+        const usdt = await getUsdtBalance(walletAddress);
+        if (usdt?.error) throw new Error(usdt.error);
+        setUsdtBalance(usdt.balance ?? 0);
+      } catch (err) {
+        console.error('Failed to load USDT balance:', err);
+        setUsdtBalance(0);
+      }
+    }
+    loadExternal();
+  }, [walletAddress]);
+
+  return { tpcBalance, tonBalance, usdtBalance, telegramId };
+}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -10,7 +10,7 @@ import DailyCheckIn from '../components/DailyCheckIn.jsx';
 
 import TasksCard from '../components/TasksCard.jsx';
 
-import { FaUser, FaArrowCircleUp, FaArrowCircleDown } from 'react-icons/fa';
+import { FaUser, FaArrowCircleUp, FaArrowCircleDown, FaWallet } from 'react-icons/fa';
 
 import { Link } from 'react-router-dom';
 
@@ -18,8 +18,8 @@ import { ping } from '../utils/api.js';
 
 import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
 
-import BalanceSummary from '../components/BalanceSummary.jsx';
 import TonConnectButton from '../components/TonConnectButton.jsx';
+import useTokenBalances from '../hooks/useTokenBalances.js';
 
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
 import { getProfile } from '../utils/api.js';
@@ -29,6 +29,7 @@ export default function Home() {
   const [status, setStatus] = useState('checking');
 
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
+  const { tpcBalance, tonBalance, usdtBalance } = useTokenBalances();
 
   useEffect(() => {
     ping()
@@ -86,10 +87,25 @@ export default function Home() {
           </div>
         )}
 
-        <TonConnectButton />
-
+        <div className="w-full flex items-center justify-between mt-2">
+          <div className="flex items-center space-x-1">
+            <img src="/icons/TON.png" alt="TON" className="w-6 h-6" />
+            <span className="text-sm">{formatValue(tonBalance ?? '...')}</span>
+          </div>
+          <TonConnectButton small className="mt-0" />
+          <div className="flex items-center space-x-1">
+            <img src="/icons/Usdt.png" alt="USDT" className="w-6 h-6" />
+            <span className="text-sm">{formatValue(usdtBalance ?? '...')}</span>
+          </div>
+        </div>
 
         <div className="w-full mt-2">
+          <p className="flex justify-center mb-1">
+            <Link to="/wallet" className="flex items-center space-x-1">
+              <FaWallet className="text-primary" />
+              <span>Wallet</span>
+            </Link>
+          </p>
           <div className="relative flex items-start justify-between bg-surface border border-border rounded-xl p-2 overflow-hidden">
             <img
               src="/assets/SnakeLaddersbackground.png"
@@ -100,12 +116,15 @@ export default function Home() {
               <FaArrowCircleUp className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Send</span>
             </Link>
+            <div className="flex flex-col items-center space-y-1">
+              <img src="/icons/TPCcoin.png" alt="TPC" className="w-8 h-8" />
+              <span className="text-xs">{formatValue(tpcBalance ?? '...', 2)}</span>
+            </div>
             <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">
               <FaArrowCircleDown className="text-accent w-8 h-8" />
               <span className="text-xs text-accent">Receive</span>
             </Link>
           </div>
-          <BalanceSummary className="mt-2" />
         </div>
 
       </div>
@@ -125,4 +144,19 @@ export default function Home() {
 
   );
 
+}
+
+function formatValue(value, decimals = 4) {
+  if (typeof value !== 'number') {
+    const parsed = parseFloat(value);
+    if (isNaN(parsed)) return value;
+    return parsed.toLocaleString(undefined, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    });
+  }
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
 }


### PR DESCRIPTION
## Summary
- shrink ton connect button size
- add reusable `useTokenBalances` hook
- refactor `BalanceSummary` to use new hook
- realign balance display on home page

## Testing
- `npm --prefix webapp run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861216856d88329b53154b64fdeafb7