### PR TITLE
Improve Snake & Ladder dice timing

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -33,7 +33,7 @@ export default function DiceRoller({
   useEffect(() => {
     if (trigger !== undefined && trigger !== triggerRef.current) {
       triggerRef.current = trigger;
-      rollDice();
+      setTimeout(() => rollDice(), 1000); // show dice briefly before rolling
     }
   }, [trigger]);
 
@@ -56,8 +56,8 @@ export default function DiceRoller({
       return Math.floor(Math.random() * 6) + 1;
     };
 
-    const tick = 35; // ms between face changes
-    const iterations = 14; // show final value just before animation ends
+    const tick = 50; // ms between face changes
+    const iterations = 20; // ~1 second of rolling
     let count = 0;
 
     const id = setInterval(() => {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1291,12 +1291,19 @@ export default function SnakeAndLadder() {
   useEffect(() => {
     if (setupPhase || gameOver) return;
     if (currentTurn !== 0) {
-      setTimeLeft(2);
-      if (timerRef.current) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => {
+      setTimeLeft(15);
+      if (timerRef.current) clearInterval(timerRef.current);
+      timerRef.current = setInterval(() => {
+        setTimeLeft((t) => Math.max(0, t - 1));
+      }, 1000);
+      if (aiRollTimeoutRef.current) clearTimeout(aiRollTimeoutRef.current);
+      aiRollTimeoutRef.current = setTimeout(() => {
         triggerAIRoll(currentTurn);
-      }, 1800);
-      return () => clearTimeout(timerRef.current);
+      }, 2000);
+      return () => {
+        clearInterval(timerRef.current);
+        clearTimeout(aiRollTimeoutRef.current);
+      };
     }
     const limit = 15;
     setTimeLeft(limit);
@@ -1383,7 +1390,7 @@ export default function SnakeAndLadder() {
               isTurn={p.index === currentTurn}
               timerPct={
                 p.index === currentTurn
-                  ? timeLeft / (p.index === 0 ? 15 : 3)
+                  ? timeLeft / 15
                   : 1
               }
               color={p.color}


### PR DESCRIPTION
## Summary
- tweak AI timer logic to roll in 2s but display 15s countdown
- adjust timer bar calculation
- show dice for a second before auto-rolling
- extend dice rolling animation length

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68612312d5308329b85b0f9d0fe6dcf4