### PR TITLE
Adjust Home page layout

### DIFF
--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -88,6 +88,12 @@ export default function Home() {
 
     <div className="space-y-4">
 
+      {!walletAddress && (
+        <div className="flex justify-center">
+          <TonConnectButton />
+        </div>
+      )}
+
       <div className="flex flex-col items-center">
 
         {photoUrl && (
@@ -112,51 +118,50 @@ export default function Home() {
         )}
 
         <div className="w-full mt-2 space-y-4">
-          <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden">
+          <div className="relative bg-surface border border-border rounded-xl p-4 flex items-center justify-around overflow-hidden">
             <img
               src="/assets/SnakeLaddersbackground.png"
               className="background-behind-board object-cover"
               alt=""
             />
-
-            <p className="flex justify-center mb-1">
-              <Link to="/wallet" className="flex items-center space-x-1 font-bold">
-                <FaWallet className="text-primary" />
-                <span>Wallet</span>
-              </Link>
-            </p>
-            <p className="text-center text-xs text-subtext">Only to send and receive TPC coins</p>
-
-            <div className="flex items-start justify-between">
-              <Link to="/wallet?mode=send" className="flex items-center space-x-1 -ml-1 pt-1">
-                <FaArrowCircleUp className="text-accent w-8 h-8" />
-                <span className="text-xs text-accent">Send</span>
-              </Link>
-              <div className="flex flex-col items-center space-y-1">
-                <img src="/icons/TPCcoin.png" alt="TPC" className="w-8 h-8" />
-                <span className="text-xs">{formatValue(tpcBalance ?? '...', 2)}</span>
-              </div>
-              <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">
-                <FaArrowCircleDown className="text-accent w-8 h-8" />
-                <span className="text-xs text-accent">Receive</span>
-              </Link>
-            </div>
-          </div>
-
-          <div className="relative bg-surface border border-border rounded-xl p-4 flex items-center justify-between overflow-hidden">
-            <img
-              src="/assets/SnakeLaddersbackground.png"
-              className="background-behind-board object-cover"
-              alt=""
-            />
-            <div className="flex items-center space-x-1">
+            <div className="flex-1 flex items-center justify-center space-x-1">
               <img src="/icons/TON.png" alt="TON" className="w-6 h-6" />
               <span className="text-sm">{formatValue(tonBalance ?? '...')}</span>
             </div>
-            {!walletAddress && <TonConnectButton small className="mt-0" />}
-            <div className="flex items-center space-x-1">
+            <div className="flex-1 flex items-center justify-center space-x-1">
               <img src="/icons/Usdt.png" alt="USDT" className="w-6 h-6" />
               <span className="text-sm">{formatValue(usdtBalance ?? '...')}</span>
+            </div>
+          </div>
+
+          <div className="relative">
+            <div className="absolute -top-5 left-1/2 -translate-x-1/2 flex items-center space-x-1 bg-surface px-2">
+              <FaWallet className="text-primary" />
+              <span className="text-lg font-bold">Wallet</span>
+            </div>
+            <div className="relative bg-surface border border-border rounded-xl p-4 pt-6 space-y-2 overflow-hidden">
+              <img
+                src="/assets/SnakeLaddersbackground.png"
+                className="background-behind-board object-cover"
+                alt=""
+              />
+
+              <p className="text-center text-xs text-subtext">Only to send and receive TPC coins</p>
+
+              <div className="flex items-start justify-between">
+                <Link to="/wallet?mode=send" className="flex items-center space-x-1 -ml-1 pt-1">
+                  <FaArrowCircleUp className="text-accent w-8 h-8" />
+                  <span className="text-xs text-accent">Send</span>
+                </Link>
+                <div className="flex flex-col items-center space-y-1">
+                  <img src="/icons/TPCcoin.png" alt="TPC" className="w-8 h-8" />
+                  <span className="text-xs">{formatValue(tpcBalance ?? '...', 2)}</span>
+                </div>
+                <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">
+                  <FaArrowCircleDown className="text-accent w-8 h-8" />
+                  <span className="text-xs text-accent">Receive</span>
+                </Link>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- move TON/USDT card below profile picture and center balances
- overlay wallet label above wallet card
- show TonConnectButton above avatar
- run `npm run build` to verify build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686133fbfa388329a444ce7f3fe3b594