### PR TITLE
Improve snake game visuals and audio

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -9,6 +9,7 @@ export default function DiceRoller({
   numDice = 2,
   trigger,
   showButton = true,
+  muted = false,
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -25,10 +26,11 @@ export default function DiceRoller({
   useEffect(() => {
     soundRef.current = new Audio(diceSound);
     soundRef.current.preload = 'auto';
+    soundRef.current.muted = muted;
     return () => {
       soundRef.current?.pause();
     };
-  }, []);
+  }, [muted]);
 
   useEffect(() => {
     if (trigger !== undefined && trigger !== triggerRef.current) {
@@ -39,7 +41,7 @@ export default function DiceRoller({
 
   const rollDice = () => {
     if (rolling) return;
-    if (soundRef.current) {
+    if (soundRef.current && !muted) {
       soundRef.current.currentTime = 0;
       soundRef.current.play().catch(() => {});
     }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -239,7 +239,7 @@ body {
   top: 50%;
   left: 48%;
   transform: translate(-50%, -50%) translateZ(40px);
-  font-size: 4.5rem;
+  font-size: 6rem;
   pointer-events: none;
   animation: flame-up 1.5s forwards;
 }
@@ -254,7 +254,7 @@ body {
 @keyframes flame-up {
   to {
     opacity: 0;
-    transform: translate(-50%, -80%) translateZ(40px) scale(3);
+    transform: translate(-50%, -80%) translateZ(40px) scale(4);
   }
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -533,6 +533,7 @@ export default function SnakeAndLadder() {
 
   const moveSoundRef = useRef(null);
   const snakeSoundRef = useRef(null);
+  const oldSnakeSoundRef = useRef(null);
   const ladderSoundRef = useRef(null);
   const winSoundRef = useRef(null);
   const diceRewardSoundRef = useRef(null);
@@ -581,6 +582,7 @@ export default function SnakeAndLadder() {
     }
     moveSoundRef.current = new Audio(dropSound);
     snakeSoundRef.current = new Audio(snakeSound);
+    oldSnakeSoundRef.current = new Audio(dropSound);
     ladderSoundRef.current = new Audio(ladderSound);
     winSoundRef.current = new Audio("/assets/sounds/successful.mp3");
     diceRewardSoundRef.current = new Audio("/assets/sounds/successful.mp3");
@@ -593,6 +595,7 @@ export default function SnakeAndLadder() {
     return () => {
       moveSoundRef.current?.pause();
       snakeSoundRef.current?.pause();
+      oldSnakeSoundRef.current?.pause();
       ladderSoundRef.current?.pause();
       winSoundRef.current?.pause();
       diceRewardSoundRef.current?.pause();
@@ -614,6 +617,7 @@ export default function SnakeAndLadder() {
       diceRewardSoundRef,
       yabbaSoundRef,
       hahaSoundRef,
+      oldSnakeSoundRef,
       bombSoundRef,
       badLuckSoundRef,
       cheerSoundRef,
@@ -929,8 +933,9 @@ export default function SnakeAndLadder() {
           setPos(next);
           moveSoundRef.current.currentTime = 0;
           if (!muted) moveSoundRef.current.play().catch(() => {});
-            const hType = idx === seq.length - 1 ? type : "path";
-            setHighlight({ cell: next, type: hType });
+          const hType = idx === seq.length - 1 ? type : "path";
+          setHighlight({ cell: next, type: hType });
+          setTrail((t) => [...t, { cell: next, type: hType }]);
           if (idx === seq.length - 2) hahaSoundRef.current?.pause();
           setTimeout(() => stepMove(idx + 1), 700);
         };
@@ -961,6 +966,7 @@ export default function SnakeAndLadder() {
           setMessageColor("text-red-500");
           if (!muted) {
             snakeSoundRef.current?.play().catch(() => {});
+            oldSnakeSoundRef.current?.play().catch(() => {});
             badLuckSoundRef.current?.play().catch(() => {});
           }
           const seq = [];
@@ -1128,8 +1134,9 @@ export default function SnakeAndLadder() {
         setAiPositions([...positions]);
         moveSoundRef.current.currentTime = 0;
         if (!muted) moveSoundRef.current.play().catch(() => {});
-          const hType = idx === seq.length - 1 ? type : "path";
-          setHighlight({ cell: next, type: hType });
+        const hType = idx === seq.length - 1 ? type : "path";
+        setHighlight({ cell: next, type: hType });
+        setTrail((t) => [...t, { cell: next, type: hType }]);
         if (idx === seq.length - 2) hahaSoundRef.current?.pause();
         setTimeout(() => stepMove(idx + 1), 700);
       };
@@ -1201,6 +1208,7 @@ export default function SnakeAndLadder() {
         setTimeout(() => setOffsetPopup(null), 1000);
         if (!muted) {
           snakeSoundRef.current?.play().catch(() => {});
+          oldSnakeSoundRef.current?.play().catch(() => {});
           badLuckSoundRef.current?.play().catch(() => {});
         }
         const seq = [];
@@ -1470,6 +1478,7 @@ export default function SnakeAndLadder() {
             numDice={diceCount + bonusDice}
             trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
             showButton={false}
+            muted={muted}
           />
           {currentTurn === 0 && !aiRollingIndex && !playerAutoRolling && (
             <div className="mt-2 flex flex-col items-center">


### PR DESCRIPTION
## Summary
- keep path trail highlighted during token movement
- enlarge explosion flame when capturing
- mute dice sound when muted
- play additional snake bite audio on snake tiles

## Testing
- `npm test --silent` *(fails: Cannot find package 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_686149af606c8329b237c4b0e7ecea28