### PR TITLE
Fix wallet icon and USDT formatting

### DIFF
--- a/webapp/public/tonconnect-manifest.json
+++ b/webapp/public/tonconnect-manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "TonPlaygram",
   "url": "https://tonplaygram.example.com",
-  "iconUrl": "/icons/TPCcoin.png",
+  "iconUrl": "/assets/icons/file_0000000010ec6246b26018aa42d5880a.png",
   "termsOfUseUrl": "https://tonplaygram.example.com/terms",
   "privacyPolicyUrl": "https://tonplaygram.example.com/privacy"
 }

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -105,15 +105,10 @@ export default function DailyCheckIn() {
     progress.push(
 
       <div
-
         key={i}
-
         className={`board-style w-20 p-2 flex flex-col items-center justify-center text-xs ${
-
-          i < streak ? 'bg-yellow-300 text-black' : ''
-
+          i === streak - 1 ? 'border-4 border-brand-gold' : ''
         }`}
-
       >
 
         <span>Day {i + 1}</span>

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -121,7 +121,7 @@ export default function Home() {
             </div>
             <div className="flex-1 flex items-center justify-center space-x-1">
               <img src="/icons/Usdt.png" alt="USDT" className="w-8 h-8" />
-              <span className="text-base">{formatValue(usdtBalance ?? '...')}</span>
+              <span className="text-base">{formatValue(usdtBalance ?? '...', 2)}</span>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- update TonConnect manifest to use the new icon
- show only two decimals for USDT in the Home page
- highlight only the current streak day with a yellow frame

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68614c868f08832988986e79ca0420b0