### PR TITLE
Enhance snake game movement and timing

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -532,6 +532,26 @@ body {
 .board-cell.path-highlight .dice-marker {
   transform: translate(-50%, -50%) translateZ(6px) rotateX(calc(var(--board-angle, 58deg) * -1));
 }
+
+.board-cell.forward-highlight {
+  background-color: #fde047; /* yellow */
+}
+
+.board-cell.forward-highlight .cell-marker,
+.board-cell.forward-highlight .dice-marker {
+  transform: translate(-50%, -50%) translateZ(6px)
+    rotateX(calc(var(--board-angle, 58deg) * -1));
+}
+
+.board-cell.backward-highlight {
+  background-color: #fca5a5; /* red */
+}
+
+.board-cell.backward-highlight .cell-marker,
+.board-cell.backward-highlight .dice-marker {
+  transform: translate(-50%, -50%) translateZ(6px)
+    rotateX(calc(var(--board-angle, 58deg) * -1));
+}
 .board-cell.ladder-cell.normal-highlight,
 .board-cell.snake-cell.normal-highlight {
   background-color: #fde047; /* yellow-300 */


### PR DESCRIPTION
## Summary
- add new forward and backward highlight styles for board tiles
- color movement path based on direction and lock dice while moving
- shorten dice result display and speed up AI turn timing
- ensure AI rolls immediately when its turn starts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686154cb1a3c8329aee0641ae7fa2bb1