### PR TITLE
Fix TONAPI rates query

### DIFF
--- a/webapp/src/hooks/useWalletUsdValue.js
+++ b/webapp/src/hooks/useWalletUsdValue.js
@@ -10,7 +10,7 @@ export default function useWalletUsdValue(tonBalance, usdtBalance) {
         return;
       }
       try {
-        const res = await fetch('https://tonapi.io/v2/rates?tokens=ton&currencies=usd');
+        const res = await fetch('https://tonapi.io/v2/rates?tokens=TON&currencies=usd');
         const data = await res.json();
         const tonPrice = data?.rates?.TON?.prices?.USD ?? 0;
         const total = (tonBalance ?? 0) * tonPrice + (usdtBalance ?? 0);


### PR DESCRIPTION
## Summary
- fix USDT/TON price fetch by using correct `TON` token symbol

## Testing
- `npm test` *(fails: cannot find module 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_68616b56f0c48329adb2197248c289b2