### PR TITLE
Enable online Snake & Ladder play

### DIFF
--- a/webapp/src/hooks/useSnakeSocket.js
+++ b/webapp/src/hooks/useSnakeSocket.js
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { socket } from '../utils/socket';
+import { getSnakeBoard } from '../utils/api.js';
+
+export default function useSnakeSocket(roomId, playerId, name) {
+  const [players, setPlayers] = useState([]);
+  const [currentTurn, setCurrentTurn] = useState(null);
+  const [snakes, setSnakes] = useState({});
+  const [ladders, setLadders] = useState({});
+  const [lastRoll, setLastRoll] = useState(null);
+  const [ranking, setRanking] = useState([]);
+
+  useEffect(() => {
+    if (!roomId || !playerId) return;
+
+    getSnakeBoard(roomId)
+      .then(({ snakes = {}, ladders = {} }) => {
+        setSnakes(snakes);
+        setLadders(ladders);
+      })
+      .catch(() => {});
+
+    socket.emit('joinRoom', { roomId, playerId, name });
+
+    const handlePlayerJoined = ({ playerId: id, name }) => {
+      setPlayers((arr) => {
+        if (arr.some((p) => p.id === id)) return arr;
+        return [...arr, { id, name, position: 0 }];
+      });
+    };
+    const handleTurnChanged = ({ playerId: id }) => setCurrentTurn(id);
+    const handleDiceRolled = ({ playerId: id, value }) => {
+      setLastRoll({ playerId: id, value });
+    };
+    const updatePos = ({ playerId: id, to }) => {
+      setPlayers((arr) => arr.map((p) => (p.id === id ? { ...p, position: to } : p)));
+    };
+    const handlePlayerReset = ({ playerId: id }) => {
+      setPlayers((arr) => arr.map((p) => (p.id === id ? { ...p, position: 0 } : p)));
+    };
+    const handlePlayerLeft = ({ playerId: id }) => {
+      setPlayers((arr) => arr.filter((p) => p.id !== id));
+    };
+    const handleGameWon = ({ playerId: id }) => {
+      setRanking((r) => [...r, id]);
+    };
+
+    socket.on('playerJoined', handlePlayerJoined);
+    socket.on('turnChanged', handleTurnChanged);
+    socket.on('movePlayer', updatePos);
+    socket.on('snakeOrLadder', updatePos);
+    socket.on('diceRolled', handleDiceRolled);
+    socket.on('playerReset', handlePlayerReset);
+    socket.on('gameWon', handleGameWon);
+    socket.on('playerLeft', handlePlayerLeft);
+
+    return () => {
+      socket.off('playerJoined', handlePlayerJoined);
+      socket.off('turnChanged', handleTurnChanged);
+      socket.off('movePlayer', updatePos);
+      socket.off('snakeOrLadder', updatePos);
+      socket.off('diceRolled', handleDiceRolled);
+      socket.off('playerReset', handlePlayerReset);
+      socket.off('gameWon', handleGameWon);
+      socket.off('playerLeft', handlePlayerLeft);
+    };
+  }, [roomId, playerId, name]);
+
+  const rollDice = () => socket.emit('rollDice');
+
+  return { players, currentTurn, snakes, ladders, lastRoll, ranking, rollDice };
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -21,8 +21,9 @@ import {
 } from "react-icons/ai";
 import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
 import { useNavigate } from "react-router-dom";
-import { getTelegramId, getTelegramPhotoUrl } from "../../utils/telegram.js";
+import { getTelegramId, getTelegramPhotoUrl, getTelegramFirstName } from "../../utils/telegram.js";
 import { fetchTelegramInfo, getProfile, deposit, getSnakeBoard } from "../../utils/api.js";
+import useSnakeSocket from "../../hooks/useSnakeSocket.js";
 import PlayerToken from "../../components/PlayerToken.jsx";
 import AvatarTimer from "../../components/AvatarTimer.jsx";
 import ConfirmPopup from "../../components/ConfirmPopup.jsx";
@@ -439,6 +440,7 @@ export default function SnakeAndLadder() {
   const [diceCount, setDiceCount] = useState(2);
   const [gameOver, setGameOver] = useState(false);
   const [ai, setAi] = useState(0);
+  const [online, setOnline] = useState(false);
   const [aiPositions, setAiPositions] = useState([]);
   const [playerColors, setPlayerColors] = useState([]);
   const [rollColor, setRollColor] = useState('#fff');
@@ -458,6 +460,55 @@ export default function SnakeAndLadder() {
   const [refreshTick, setRefreshTick] = useState(0);
   const [rollCooldown, setRollCooldown] = useState(0);
   const [moving, setMoving] = useState(false);
+
+  const paramsInit = new URLSearchParams(window.location.search);
+  const roomId = paramsInit.get('table') || 'snake-4';
+  const playerIdVal = getTelegramId();
+  const playerNameVal = getTelegramFirstName();
+  const {
+    players: onlinePlayers,
+    currentTurn: onlineTurn,
+    snakes: onlineSnakes,
+    ladders: onlineLadders,
+    lastRoll: onlineRoll,
+    ranking: onlineRanking,
+    rollDice: onlineRollDice
+  } = useSnakeSocket(online ? roomId : null, online ? String(playerIdVal) : null, playerNameVal);
+
+  useEffect(() => {
+    if (online && onlineSnakes && onlineLadders) {
+      setSnakes(onlineSnakes);
+      setLadders(onlineLadders);
+    }
+  }, [online, onlineSnakes, onlineLadders]);
+
+  useEffect(() => {
+    if (online) {
+      setRanking(onlineRanking.map((id) =>
+        id === String(playerIdVal) ? 'You' : onlinePlayers.find((p) => p.id === id)?.name || id
+      ));
+    }
+  }, [onlineRanking, onlinePlayers, online]);
+
+  useEffect(() => {
+    if (!online) return;
+    const idxMap = new Map();
+    onlinePlayers.forEach((p, i) => idxMap.set(p.id, i));
+    const me = idxMap.get(String(playerIdVal));
+    if (me != null) setPos(onlinePlayers[me].position);
+    const others = onlinePlayers.filter((p) => p.id !== String(playerIdVal));
+    setAi(others.length);
+    setAiPositions(others.map((p) => p.position));
+    setPlayerColors(
+      shuffle(TOKEN_COLORS)
+        .slice(0, onlinePlayers.length)
+        .map((c) => c.color)
+    );
+    if (onlineTurn) {
+      const turnIdx = idxMap.get(onlineTurn);
+      if (turnIdx != null) setCurrentTurn(turnIdx);
+    }
+  }, [onlinePlayers, onlineTurn, online]);
 
   // Preload token and avatar images so board icons and AI photos display
   // immediately without waiting for network requests during gameplay.
@@ -490,11 +541,15 @@ export default function SnakeAndLadder() {
     return () => clearInterval(id);
   }, [rollCooldown]);
 
-  const playerName = (idx) => (
-    <span style={{ color: playerColors[idx] }}>
-      {idx === 0 ? 'You' : `AI ${idx}`}
-    </span>
-  );
+  const playerName = (idx) => {
+    const color = playerColors[idx] || '#fff';
+    let label = idx === 0 ? 'You' : `AI ${idx}`;
+    if (online) {
+      const p = onlinePlayers[idx];
+      if (p) label = p.id === String(playerIdVal) ? 'You' : p.name;
+    }
+    return <span style={{ color }}>{label}</span>;
+  };
 
   const capturePieces = (cell, mover) => {
     const victims = [];
@@ -652,22 +707,27 @@ export default function SnakeAndLadder() {
     const t = params.get("token");
     const amt = params.get("amount");
     const aiParam = params.get("ai");
+    const table = params.get("table") || "snake-4";
     if (t) setToken(t.toUpperCase());
     if (amt) setPot(Number(amt));
     const aiCount = aiParam ? Math.max(1, Math.min(3, Number(aiParam))) : 0;
+    const onlineMode = table && !aiParam;
+    setOnline(onlineMode);
     if (aiParam) setAi(aiCount);
     setAiPositions(Array(aiCount).fill(0));
-    setAiAvatars(
-      Array.from({ length: aiCount }, () =>
-        AVATARS[Math.floor(Math.random() * AVATARS.length)]
-      )
-    );
+    if (!onlineMode) {
+      setAiAvatars(
+        Array.from({ length: aiCount }, () =>
+          AVATARS[Math.floor(Math.random() * AVATARS.length)]
+        )
+      );
+    }
     const colors = shuffle(TOKEN_COLORS).slice(0, aiCount + 1).map(c => c.color);
     setPlayerColors(colors);
 
-    const table = params.get("table") || "snake-4";
-    getSnakeBoard(table)
-      .then(({ snakes: snakesObj = {}, ladders: laddersObj = {} }) => {
+    if (!onlineMode) {
+      getSnakeBoard(table)
+        .then(({ snakes: snakesObj = {}, ladders: laddersObj = {} }) => {
         const limit = (obj) => {
           return Object.fromEntries(Object.entries(obj).slice(0, 8));
         };
@@ -707,6 +767,7 @@ export default function SnakeAndLadder() {
         setDiceCells(diceMap);
       })
       .catch(() => {});
+    }
   }, []);
 
   const fastForward = (elapsed, state) => {
@@ -1329,17 +1390,19 @@ export default function SnakeAndLadder() {
   }, [aiRollingIndex]);
 
   useEffect(() => {
-    if (setupPhase || gameOver || moving) return;
+    if (online || setupPhase || gameOver || moving) return;
     if (currentTurn !== 0) {
       setTimeLeft(15);
       if (timerRef.current) clearInterval(timerRef.current);
       timerRef.current = setInterval(() => {
         setTimeLeft((t) => Math.max(0, t - 1));
       }, 1000);
-      if (aiRollTimeoutRef.current) clearTimeout(aiRollTimeoutRef.current);
-      aiRollTimeoutRef.current = setTimeout(() => {
-        triggerAIRoll(currentTurn);
-      }, 2000);
+      if (!online) {
+        if (aiRollTimeoutRef.current) clearTimeout(aiRollTimeoutRef.current);
+        aiRollTimeoutRef.current = setTimeout(() => {
+          triggerAIRoll(currentTurn);
+        }, 2000);
+      }
       return () => {
         clearInterval(timerRef.current);
         clearTimeout(aiRollTimeoutRef.current);
@@ -1382,10 +1445,22 @@ export default function SnakeAndLadder() {
 
 
 
-  const players = [
-    { position: pos, photoUrl, type: tokenType, color: playerColors[0] },
-    ...aiPositions.map((p, i) => ({ position: p, photoUrl: aiAvatars[i] || '/assets/icons/profile.svg', type: 'normal', color: playerColors[i + 1] }))
-  ];
+  const players = online
+    ? onlinePlayers.map((p, i) => ({
+        position: p.position,
+        photoUrl: p.id === String(playerIdVal) ? photoUrl : '/assets/icons/profile.svg',
+        type: 'normal',
+        color: playerColors[i] || '#fff'
+      }))
+    : [
+        { position: pos, photoUrl, type: tokenType, color: playerColors[0] },
+        ...aiPositions.map((p, i) => ({
+          position: p,
+          photoUrl: aiAvatars[i] || '/assets/icons/profile.svg',
+          type: 'normal',
+          color: playerColors[i + 1]
+        }))
+      ];
 
   // determine ranking numbers based on board positions
   const rankMap = {};
@@ -1476,7 +1551,9 @@ export default function SnakeAndLadder() {
         <div className="fixed bottom-24 inset-x-0 flex flex-col items-center z-20">
           <DiceRoller
             onRollEnd={(vals) => {
-              if (aiRollingIndex) {
+              if (online) {
+                onlineRollDice();
+              } else if (aiRollingIndex) {
                 handleAIRoll(aiRollingIndex, vals);
                 setAiRollingIndex(null);
               } else {


### PR DESCRIPTION
## Summary
- add `useSnakeSocket` hook for Socket.IO room events
- extend Snake & Ladder page to connect to server rooms
- join tables when `table` param is present
- update board state and turn order via socket

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861154fe5f8832981352f6a3be88407