### PR TITLE
Add online user indicator to lobby

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { FaUsers } from 'react-icons/fa';
 import { useNavigate, useParams } from 'react-router-dom';
 import TableSelector from '../../components/TableSelector.jsx';
 import RoomSelector from '../../components/RoomSelector.jsx';
@@ -91,7 +92,17 @@ export default function Lobby() {
       <h2 className="text-xl font-bold text-center capitalize">{game} Lobby</h2>
       {game === 'snake' && (
         <div className="space-y-2">
-          <h3 className="font-semibold">Select Table</h3>
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold">Select Table</h3>
+            {table && (
+              <span className="flex items-center">
+                <FaUsers
+                  className={`ml-2 ${players.length > 0 ? 'text-green-500' : 'text-red-500'}`}
+                />
+                <span className="ml-1">{players.length}</span>
+              </span>
+            )}
+          </div>
           <TableSelector tables={tables} selected={table} onSelect={setTable} />
         </div>
       )}


### PR DESCRIPTION
## Summary
- show online user count next to "Select Table" heading
- color the icon green when players are present, red otherwise
- include `react-icons` FaUsers icon

## Testing
- `npm --prefix webapp install`
- `npm install`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_686173fb02788329906b3bffa9ffb0ac