### PR TITLE
Improve in-memory DB handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 3. Copy `bot/.env.example` to `bot/.env` and update the values. At minimum set:
    - `BOT_TOKEN` – your Telegram bot token
    - `MONGODB_URI` – MongoDB connection string or `memory`
+     (falls back to an in-memory database if unset)
    - `AIRDROP_ADMIN_TOKENS` – (optional) tokens allowed to trigger airdrops
    - `DEPOSIT_WALLET_ADDRESS` – TON address that receives user deposits
    - `PORT` – (optional) port for the bot API server (defaults to 3000)
@@ -77,6 +78,8 @@ is detected.
 
 - **Balance always zero** – verify MongoDB is running and `MONGODB_URI` points
   to a running database instance. The backend must be able to connect.
+- **In-memory database fails to launch** – the app will start without MongoDB if
+  the `mongodb-memory-server` download fails.
 - **No Telegram notifications** – confirm `npm start` is running and the bot
   token is valid. Users must interact with the bot in Telegram to receive
   messages.

--- a/bot/server.js
+++ b/bot/server.js
@@ -179,11 +179,14 @@ const mongoUri = process.env.MONGODB_URI;
 
 if (mongoUri === 'memory') {
   import('mongodb-memory-server').then(async ({ MongoMemoryServer }) => {
-    const mem = await MongoMemoryServer.create();
-    mongoose
-      .connect(mem.getUri())
-      .then(() => console.log('Using in-memory MongoDB'))
-      .catch((err) => console.error('MongoDB connection error:', err));
+    try {
+      const mem = await MongoMemoryServer.create();
+      await mongoose.connect(mem.getUri());
+      console.log('Using in-memory MongoDB');
+    } catch (err) {
+      console.error('Failed to start in-memory MongoDB:', err.message);
+      console.log('Continuing without database');
+    }
   });
 } else if (mongoUri) {
   mongoose


### PR DESCRIPTION
## Summary
- handle failures when starting the in-memory MongoDB
- clarify README regarding MongoDB configuration and fallback behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686185ba06188329b39e027f32bd082b