### PR TITLE
Implement lobby online user count

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -121,6 +121,28 @@ app.get('/', (req, res) => {
 app.get('/api/ping', (req, res) => {
   res.json({ message: 'pong' });
 });
+
+const onlineUsers = new Map();
+
+app.post('/api/online/ping', (req, res) => {
+  const { telegramId } = req.body || {};
+  if (telegramId) {
+    onlineUsers.set(Number(telegramId), Date.now());
+  }
+  const now = Date.now();
+  for (const [id, ts] of onlineUsers) {
+    if (now - ts > 60_000) onlineUsers.delete(id);
+  }
+  res.json({ success: true });
+});
+
+app.get('/api/online/count', (req, res) => {
+  const now = Date.now();
+  for (const [id, ts] of onlineUsers) {
+    if (now - ts > 60_000) onlineUsers.delete(id);
+  }
+  res.json({ count: onlineUsers.size });
+});
 app.get('/api/snake/lobbies', async (req, res) => {
   const capacities = [2, 3, 4];
   const lobbies = await Promise.all(

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -4,7 +4,13 @@ import { useNavigate, useParams } from 'react-router-dom';
 import TableSelector from '../../components/TableSelector.jsx';
 import RoomSelector from '../../components/RoomSelector.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
-import { getSnakeLobbies, getSnakeLobby } from '../../utils/api.js';
+import {
+  getSnakeLobbies,
+  getSnakeLobby,
+  pingOnline,
+  getOnlineCount,
+} from '../../utils/api.js';
+import { getTelegramId } from '../../utils/telegram.js';
 import { canStartGame } from '../../utils/lobby.js';
 
 export default function Lobby() {
@@ -26,6 +32,7 @@ export default function Lobby() {
   const [stake, setStake] = useState({ token: '', amount: 0 });
   const [players, setPlayers] = useState([]);
   const [aiCount, setAiCount] = useState(0);
+  const [online, setOnline] = useState(0);
 
   useEffect(() => {
     if (game === 'snake') {
@@ -45,6 +52,19 @@ export default function Lobby() {
       };
   }
   }, [game]);
+
+  useEffect(() => {
+    const telegramId = getTelegramId();
+    function ping() {
+      pingOnline(telegramId).catch(() => {});
+      getOnlineCount()
+        .then((d) => setOnline(d.count))
+        .catch(() => {});
+    }
+    ping();
+    const id = setInterval(ping, 30000);
+    return () => clearInterval(id);
+  }, []);
 
   useEffect(() => {
     if (game === 'snake' && table && table.id !== 'single') {
@@ -90,6 +110,7 @@ export default function Lobby() {
         alt=""
       />
       <h2 className="text-xl font-bold text-center capitalize">{game} Lobby</h2>
+      <p className="text-center text-sm">Online users: {online}</p>
       {game === 'snake' && (
         <div className="space-y-2">
           <div className="flex items-center justify-between">

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -214,6 +214,18 @@ export function getSnakeResults() {
   return fetch(API_BASE_URL + '/api/snake/results').then((r) => r.json());
 }
 
+export function pingOnline(telegramId) {
+  return fetch(API_BASE_URL + '/api/online/ping', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ telegramId }),
+  }).then((r) => r.json());
+}
+
+export function getOnlineCount() {
+  return fetch(API_BASE_URL + '/api/online/count').then((r) => r.json());
+}
+
 export function registerWallet(walletAddress) {
   return post('/api/profile/register-wallet', { walletAddress });
 }


### PR DESCRIPTION
## Summary
- add in-memory tracking for online users in the server
- expose `/api/online/ping` and `/api/online/count` endpoints
- support online user polling from the webapp
- display online count in the lobby

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861889587d48329b7a679192959506c