### PR TITLE
Fix lobby game start and cleanup saved state

### DIFF
--- a/test/lobbyUtils.test.js
+++ b/test/lobbyUtils.test.js
@@ -2,27 +2,32 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { canStartGame } from '../webapp/src/utils/lobby.js';
 
-const dummyTable = { id: 't1' };
+const dummyTable = { id: 't1', capacity: 2 };
 
 test('single player snake requires ai count', () => {
   assert.equal(
-    canStartGame('snake', { id: 'single' }, { token: '', amount: 0 }, 0),
+    canStartGame('snake', { id: 'single' }, { token: '', amount: 0 }, 0, 0),
     false,
   );
   assert.equal(
-    canStartGame('snake', { id: 'single' }, { token: '', amount: 0 }, 2),
+    canStartGame('snake', { id: 'single' }, { token: '', amount: 0 }, 2, 0),
     true,
   );
 });
 
 test('cannot start without stake', () => {
-  assert.equal(canStartGame('snake', dummyTable, { token: '', amount: 0 }), false);
+  assert.equal(canStartGame('snake', dummyTable, { token: '', amount: 0 }, 0, 2), false);
 });
 
 test('cannot start without table when required', () => {
-  assert.equal(canStartGame('snake', null, { token: 'TON', amount: 100 }), false);
+  assert.equal(canStartGame('snake', null, { token: 'TON', amount: 100 }, 0, 0), false);
 });
 
 test('can start when table and stake present', () => {
-  assert.equal(canStartGame('snake', dummyTable, { token: 'TON', amount: 100 }), true);
+  assert.equal(canStartGame('snake', dummyTable, { token: 'TON', amount: 100 }, 0, 2), true);
+});
+
+test('cannot start multiplayer table until full', () => {
+  assert.equal(canStartGame('snake', dummyTable, { token: 'TON', amount: 100 }, 0, 1), false);
+  assert.equal(canStartGame('snake', dummyTable, { token: 'TON', amount: 100 }, 0, 2), true);
 });

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -125,7 +125,7 @@ export default function Lobby() {
     navigate(`/games/${game}?${params.toString()}`);
   };
 
-  const disabled = !canStartGame(game, table, stake, aiCount);
+  const disabled = !canStartGame(game, table, stake, aiCount, players.length);
 
   return (
     <div className="relative p-4 space-y-4 text-text">

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -656,6 +656,7 @@ export default function SnakeAndLadder() {
     if (amt) setPot(Number(amt));
     const aiCount = aiParam ? Math.max(1, Math.min(3, Number(aiParam))) : 0;
     if (aiParam) setAi(aiCount);
+    localStorage.removeItem(`snakeGameState_${aiCount}`);
     setAiPositions(Array(aiCount).fill(0));
     setAiAvatars(
       Array.from({ length: aiCount }, () =>

--- a/webapp/src/utils/lobby.js
+++ b/webapp/src/utils/lobby.js
@@ -1,6 +1,9 @@
-export function canStartGame(game, table, stake, aiCount = 0) {
+export function canStartGame(game, table, stake, aiCount = 0, players = 0) {
   if (game === 'snake' && table?.id === 'single') {
     return aiCount > 0;
+  }
+  if (game === 'snake' && table && table.id !== 'single') {
+    if (players < (table.capacity || 0)) return false;
   }
   if (!stake || !stake.token || !stake.amount) return false;
   if (game === 'snake' && !table) return false;


### PR DESCRIPTION
## Summary
- prevent starting a multiplayer game until all seats are filled
- clear any old singleplayer board state on new game
- adjust tests for lobby utils

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686193382b608329a14f5f86adb66ee0