### PR TITLE
Add broadcast message route

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ Use these options if you need to completely start over:
 
 After resetting you can reconnect and deposit again as if it were a new account.
 
+### Broadcasting messages
+
+An admin can send a text message to every registered Telegram user.
+
+```
+POST /api/broadcast/send
+Authorization: Bearer <admin token>
+{ "text": "hello users" }
+```
+
+The request body must include a `text` field. Only tokens listed in
+`AIRDROP_ADMIN_TOKENS` are allowed to call this endpoint.
+
+
 ## Telegram game bots
 
 Several small Telegram game bots are included in this repository. They use

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -8,7 +8,8 @@ MONGODB_URI=memory
 # API port (defaults to 3000 if not set)
 PORT=3000
 
-# Comma-separated list of admin tokens for the airdrop API
+# Comma-separated list of admin tokens for the airdrop API.
+# These tokens also authorize access to the /api/broadcast route.
 # AIRDROP_ADMIN_TOKENS=token1,token2
 
 

--- a/bot/routes/broadcast.js
+++ b/bot/routes/broadcast.js
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+import bot from '../bot.js';
+import User from '../models/User.js';
+
+const router = Router();
+
+function adminOnly(req, res, next) {
+  const auth = req.get('authorization') || '';
+  const token = auth.replace(/^Bearer\s+/i, '');
+  const list = process.env.AIRDROP_ADMIN_TOKENS;
+  if (!list) {
+    return res.status(403).json({ error: 'Airdrop admin tokens not configured' });
+  }
+  const allowed = list.split(',').map(t => t.trim()).filter(Boolean);
+  if (!token || !allowed.includes(token)) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  next();
+}
+
+router.post('/send', adminOnly, async (req, res) => {
+  const { text } = req.body || {};
+  if (!text) return res.status(400).json({ error: 'text required' });
+  try {
+    const users = await User.find().select('telegramId');
+    let count = 0;
+    for (const user of users) {
+      if (!user.telegramId) continue;
+      try {
+        await bot.telegram.sendMessage(String(user.telegramId), text);
+        count++;
+      } catch (err) {
+        console.error('Failed to send message to', user.telegramId, err.message);
+      }
+    }
+    res.json({ count });
+  } catch (err) {
+    console.error('Broadcast failed:', err.message);
+    res.status(500).json({ error: 'failed to send broadcast' });
+  }
+});
+
+export default router;

--- a/bot/server.js
+++ b/bot/server.js
@@ -17,6 +17,7 @@ import profileRoutes from './routes/profile.js';
 import airdropRoutes from './routes/airdrop.js';
 import checkinRoutes from './routes/checkin.js';
 import socialRoutes from './routes/social.js';
+import broadcastRoutes from './routes/broadcast.js';
 import User from './models/User.js';
 import GameResult from "./models/GameResult.js";
 import path from 'path';
@@ -58,6 +59,7 @@ app.use('/api/profile', profileRoutes);
 app.use('/api/airdrop', airdropRoutes);
 app.use('/api/checkin', checkinRoutes);
 app.use('/api/social', socialRoutes);
+app.use('/api/broadcast', broadcastRoutes);
 
 // Serve the built React app
 const webappPath = path.join(__dirname, '../webapp/dist');


### PR DESCRIPTION
## Summary
- create broadcast route for admins to send messages
- mount new route in server
- document broadcast API
- clarify usage of admin tokens in `.env.example`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6861966f1c908329979d061a90010bfa