### PR TITLE
Add waiting popup on snake board

### DIFF
--- a/webapp/src/components/WaitingPopup.jsx
+++ b/webapp/src/components/WaitingPopup.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+
+export default function WaitingPopup({ open, message }) {
+  if (!open) return null;
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
+      <div className="prism-box p-6 text-text w-80">
+        <p className="text-sm text-center">{message}</p>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -37,7 +37,6 @@ export default function Lobby() {
   const [aiCount, setAiCount] = useState(0);
   const [online, setOnline] = useState(0);
   const [playerName, setPlayerName] = useState('');
-  const [waiting, setWaiting] = useState(false);
 
   useEffect(() => {
     const id = getTelegramId();
@@ -113,42 +112,23 @@ export default function Lobby() {
     }
   }, [game, table]);
 
-  useEffect(() => {
-    if (
-      waiting &&
-      game === 'snake' &&
-      table &&
-      table.id !== 'single' &&
-      players.length >= table.capacity
-    ) {
-      const params = new URLSearchParams();
-      params.set('table', table.id);
-      if (stake.token) params.set('token', stake.token);
-      if (stake.amount) params.set('amount', stake.amount);
-      navigate(`/games/${game}?${params.toString()}`);
-    }
-  }, [waiting, players, table, stake, navigate, game]);
 
   const startGame = () => {
-    if (table && table.id !== 'single' && players.length < table.capacity) {
-      setWaiting(true);
-      return;
-    }
     const params = new URLSearchParams();
     if (table) params.set('table', table.id);
     if (table?.id === 'single') {
       localStorage.removeItem(`snakeGameState_${aiCount}`);
       params.set('ai', aiCount);
     } else {
+      if (players.length < table.capacity) params.set('wait', '1');
       if (stake.token) params.set('token', stake.token);
       if (stake.amount) params.set('amount', stake.amount);
     }
     navigate(`/games/${game}?${params.toString()}`);
   };
 
-  let disabled = waiting || !canStartGame(game, table, stake, aiCount, players.length);
+  let disabled = !canStartGame(game, table, stake, aiCount, players.length);
   if (
-    !waiting &&
     game === 'snake' &&
     table &&
     table.id !== 'single' &&
@@ -218,9 +198,6 @@ export default function Lobby() {
             ))}
           </div>
         </div>
-      )}
-      {waiting && (
-        <p className="text-center text-sm">Waiting for players...</p>
       )}
       <button
         onClick={startGame}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -22,10 +22,19 @@ import {
 import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
 import { useNavigate } from "react-router-dom";
 import { getTelegramId, getTelegramPhotoUrl } from "../../utils/telegram.js";
-import { fetchTelegramInfo, getProfile, deposit, getSnakeBoard } from "../../utils/api.js";
+import {
+  fetchTelegramInfo,
+  getProfile,
+  deposit,
+  getSnakeBoard,
+  seatTable,
+  unseatTable,
+  getSnakeLobby,
+} from "../../utils/api.js";
 import PlayerToken from "../../components/PlayerToken.jsx";
 import AvatarTimer from "../../components/AvatarTimer.jsx";
 import ConfirmPopup from "../../components/ConfirmPopup.jsx";
+import WaitingPopup from "../../components/WaitingPopup.jsx";
 
 const TOKEN_COLORS = [
   { name: "blue", color: "#60a5fa" },
@@ -458,6 +467,11 @@ export default function SnakeAndLadder() {
   const [refreshTick, setRefreshTick] = useState(0);
   const [rollCooldown, setRollCooldown] = useState(0);
   const [moving, setMoving] = useState(false);
+  const [waiting, setWaiting] = useState(false);
+  const [table, setTable] = useState('snake-4');
+  const [players, setPlayers] = useState([]);
+  const [tableCap, setTableCap] = useState(0);
+  const [playerName, setPlayerName] = useState('');
 
   // Preload token and avatar images so board icons and AI photos display
   // immediately without waiting for network requests during gameplay.
@@ -652,6 +666,14 @@ export default function SnakeAndLadder() {
     const t = params.get("token");
     const amt = params.get("amount");
     const aiParam = params.get("ai");
+    const wait = params.get('wait');
+    const tbl = params.get('table') || 'snake-4';
+    setTable(tbl);
+    if (wait) setWaiting(true);
+    const id = getTelegramId();
+    getProfile(id)
+      .then((p) => setPlayerName(p?.nickname || p?.firstName || ''))
+      .catch(() => {});
     if (t) setToken(t.toUpperCase());
     if (amt) setPot(Number(amt));
     const aiCount = aiParam ? Math.max(1, Math.min(3, Number(aiParam))) : 0;
@@ -666,8 +688,7 @@ export default function SnakeAndLadder() {
     const colors = shuffle(TOKEN_COLORS).slice(0, aiCount + 1).map(c => c.color);
     setPlayerColors(colors);
 
-    const table = params.get("table") || "snake-4";
-    getSnakeBoard(table)
+    getSnakeBoard(tbl)
       .then(({ snakes: snakesObj = {}, ladders: laddersObj = {} }) => {
         const limit = (obj) => {
           return Object.fromEntries(Object.entries(obj).slice(0, 8));
@@ -709,6 +730,45 @@ export default function SnakeAndLadder() {
       })
       .catch(() => {});
   }, []);
+
+  useEffect(() => {
+    if (!table || table === 'single') return;
+    const telegramId = getTelegramId();
+    seatTable(telegramId, table, playerName).catch(() => {});
+    const id = setInterval(() => {
+      seatTable(telegramId, table, playerName).catch(() => {});
+    }, 30000);
+    return () => {
+      clearInterval(id);
+      unseatTable(telegramId, table).catch(() => {});
+    };
+  }, [table, playerName]);
+
+  useEffect(() => {
+    if (!waiting || !table || table === 'single') return;
+    let active = true;
+    function loadPlayers() {
+      getSnakeLobby(table)
+        .then((data) => {
+          if (!active) return;
+          setPlayers(data.players);
+          setTableCap(data.capacity || 0);
+        })
+        .catch(() => {});
+    }
+    loadPlayers();
+    const id = setInterval(loadPlayers, 3000);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, [waiting, table]);
+
+  useEffect(() => {
+    if (waiting && tableCap > 0 && players.length >= tableCap) {
+      setWaiting(false);
+    }
+  }, [waiting, players, tableCap]);
 
   const fastForward = (elapsed, state) => {
     let p = state.pos ?? 0;
@@ -1264,7 +1324,7 @@ export default function SnakeAndLadder() {
   };
 
   useEffect(() => {
-    if (!setupPhase || aiPositions.length !== ai) return;
+    if (waiting || !setupPhase || aiPositions.length !== ai) return;
     const total = ai + 1;
     if (total === 1) {
       setSetupPhase(false);
@@ -1309,7 +1369,7 @@ export default function SnakeAndLadder() {
       setTimeout(() => rollNext(idx + 1), 1000);
     };
     rollNext(0);
-  }, [ai, aiPositions, setupPhase]);
+  }, [ai, aiPositions, setupPhase, waiting]);
 
 
   useEffect(() => {
@@ -1523,6 +1583,10 @@ export default function SnakeAndLadder() {
         onClose={() => setShowInfo(false)}
         title="Snake & Ladder"
         info="Roll the dice to move across the board. Ladders move you up, snakes bring you down. The Pot at the top collects everyone's stake – reach it first to claim the total amount."
+      />
+      <WaitingPopup
+        open={waiting}
+        message={`Waiting for ${Math.max(0, tableCap - players.length)} more player${tableCap - players.length === 1 ? '' : 's'}...`}
       />
       <GameEndPopup
         open={gameOver}


### PR DESCRIPTION
## Summary
- add WaitingPopup component to show waiting message
- start Snake board early with `wait` param and keep table seating
- update Lobby navigation to board when waiting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861ac5b15b483298640de00b21e402c