### PR TITLE
Add waiting overlay to Snake board

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -37,7 +37,6 @@ export default function Lobby() {
   const [aiCount, setAiCount] = useState(0);
   const [online, setOnline] = useState(0);
   const [playerName, setPlayerName] = useState('');
-  const [waiting, setWaiting] = useState(false);
 
   useEffect(() => {
     const id = getTelegramId();
@@ -113,29 +112,13 @@ export default function Lobby() {
     }
   }, [game, table]);
 
-  useEffect(() => {
-    if (
-      waiting &&
-      game === 'snake' &&
-      table &&
-      table.id !== 'single' &&
-      players.length >= table.capacity
-    ) {
-      const params = new URLSearchParams();
-      params.set('table', table.id);
-      if (stake.token) params.set('token', stake.token);
-      if (stake.amount) params.set('amount', stake.amount);
-      navigate(`/games/${game}?${params.toString()}`);
-    }
-  }, [waiting, players, table, stake, navigate, game]);
 
   const startGame = () => {
-    if (table && table.id !== 'single' && players.length < table.capacity) {
-      setWaiting(true);
-      return;
-    }
     const params = new URLSearchParams();
     if (table) params.set('table', table.id);
+    if (table && table.id !== 'single' && players.length < table.capacity) {
+      params.set('wait', '1');
+    }
     if (table?.id === 'single') {
       localStorage.removeItem(`snakeGameState_${aiCount}`);
       params.set('ai', aiCount);
@@ -146,9 +129,8 @@ export default function Lobby() {
     navigate(`/games/${game}?${params.toString()}`);
   };
 
-  let disabled = waiting || !canStartGame(game, table, stake, aiCount, players.length);
+  let disabled = !canStartGame(game, table, stake, aiCount, players.length);
   if (
-    !waiting &&
     game === 'snake' &&
     table &&
     table.id !== 'single' &&
@@ -218,9 +200,6 @@ export default function Lobby() {
             ))}
           </div>
         </div>
-      )}
-      {waiting && (
-        <p className="text-center text-sm">Waiting for players...</p>
       )}
       <button
         onClick={startGame}


### PR DESCRIPTION
## Summary
- allow entering the board before table is full
- poll lobby from the board when `wait` parameter is set
- show overlay in board while waiting for players

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861b40abf388329a6e31734f8d0a508