### PR TITLE
Add experimental multiplayer mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,10 @@ the URL – or pick the number in the lobby – to change how many AI players jo
 
 ### Multiplayer status
 
-The web version currently supports only single-player games versus computer
-opponents. Choosing a shared table in the lobby will not create a real
-multiplayer match yet. Each participant plays their own separate board even if
-they joined the same room. Networked play is planned for a future update.
+The Snake & Ladder game now includes experimental real-time multiplayer.
+Choose a table with more than one seat in the lobby to play on the same board
+with friends. When all seats are filled the game starts automatically and turns
+are synchronized via WebSockets.
 
 ### Entering the Snake & Ladder game
 

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -23,6 +23,7 @@
     "react-markdown": "^9.0.0",
     "react-qr-code": "^2.0.16",
     "react-router-dom": "^6.22.3",
+    "socket.io-client": "^4.7.5",
     "tailwindcss": "^3.4.1",
     "three": "^0.164.0",
     "vite": "^4.4.9"

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -15,6 +15,7 @@ import Notifications from './pages/Notifications.jsx';
 
 import HorseRacing from './pages/Games/HorseRacing.jsx';
 const SnakeAndLadder = lazy(() => import('./pages/Games/SnakeAndLadder.jsx'));
+const SnakeMultiplayer = lazy(() => import('./pages/Games/SnakeMultiplayer.jsx'));
 const SnakeResults = lazy(() => import('./pages/Games/SnakeResults.jsx'));
 import Lobby from './pages/Games/Lobby.jsx';
 import Games from './pages/Games.jsx';
@@ -43,6 +44,14 @@ export default function App() {
             element={
               <Suspense fallback={<div className="p-4 text-center">Loading...</div>}>
                 <SnakeAndLadder />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/games/snake/multiplayer"
+            element={
+              <Suspense fallback={<div className="p-4 text-center">Loading...</div>}>
+                <SnakeMultiplayer />
               </Suspense>
             }
           />

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -122,11 +122,12 @@ export default function Lobby() {
     if (table?.id === 'single') {
       localStorage.removeItem(`snakeGameState_${aiCount}`);
       params.set('ai', aiCount);
+      navigate(`/games/${game}?${params.toString()}`);
     } else {
       if (stake.token) params.set('token', stake.token);
       if (stake.amount) params.set('amount', stake.amount);
+      navigate(`/games/${game}/multiplayer?${params.toString()}`);
     }
-    navigate(`/games/${game}?${params.toString()}`);
   };
 
   let disabled = !canStartGame(game, table, stake, aiCount, players.length);

--- a/webapp/src/pages/Games/SnakeMultiplayer.jsx
+++ b/webapp/src/pages/Games/SnakeMultiplayer.jsx
@@ -1,0 +1,113 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { socket } from '../../utils/socket.js';
+import { getTelegramId, getTelegramFirstName } from '../../utils/telegram.js';
+import { getSnakeBoard } from '../../utils/api.js';
+
+const COLORS = ['#60a5fa', '#ef4444', '#4ade80', '#facc15'];
+
+export default function SnakeMultiplayer() {
+  const navigate = useNavigate();
+  const params = new URLSearchParams(window.location.search);
+  const table = params.get('table') || 'snake-2';
+  const telegramId = String(getTelegramId());
+  const name = getTelegramFirstName() || telegramId;
+
+  const [players, setPlayers] = useState([]); // {id,name,position,color}
+  const [currentTurn, setCurrentTurn] = useState(null);
+  const [dice, setDice] = useState(null);
+  const [winner, setWinner] = useState(null);
+  const [waiting, setWaiting] = useState(true);
+
+  useEffect(() => {
+    getSnakeBoard(table).catch(() => {});
+    socket.emit('joinRoom', { roomId: table, playerId: telegramId, name });
+
+    const onPlayerJoined = ({ playerId, name }) =>
+      setPlayers((p) => {
+        if (p.some((pl) => pl.id === playerId)) return p;
+        const color = COLORS[p.length % COLORS.length];
+        return [...p, { id: playerId, name, position: 0, color }];
+      });
+    const onGameStarted = () => setWaiting(false);
+    const onTurnChanged = ({ playerId }) => setCurrentTurn(playerId);
+    const onDiceRolled = ({ playerId, value }) => setDice(value);
+    const onMove = ({ playerId, to }) =>
+      setPlayers((p) => p.map((pl) => (pl.id === playerId ? { ...pl, position: to } : pl)));
+    const onSnakeLadder = ({ playerId, to }) =>
+      setPlayers((p) => p.map((pl) => (pl.id === playerId ? { ...pl, position: to } : pl)));
+    const onPlayerReset = ({ playerId }) =>
+      setPlayers((p) => p.map((pl) => (pl.id === playerId ? { ...pl, position: 0 } : pl)));
+    const onPlayerLeft = ({ playerId }) =>
+      setPlayers((p) => p.filter((pl) => pl.id !== playerId));
+    const onGameWon = ({ playerId }) => setWinner(playerId);
+
+    socket.on('playerJoined', onPlayerJoined);
+    socket.on('gameStarted', onGameStarted);
+    socket.on('turnChanged', onTurnChanged);
+    socket.on('diceRolled', onDiceRolled);
+    socket.on('movePlayer', onMove);
+    socket.on('snakeOrLadder', onSnakeLadder);
+    socket.on('playerReset', onPlayerReset);
+    socket.on('playerLeft', onPlayerLeft);
+    socket.on('gameWon', onGameWon);
+
+    return () => {
+      socket.off('playerJoined', onPlayerJoined);
+      socket.off('gameStarted', onGameStarted);
+      socket.off('turnChanged', onTurnChanged);
+      socket.off('diceRolled', onDiceRolled);
+      socket.off('movePlayer', onMove);
+      socket.off('snakeOrLadder', onSnakeLadder);
+      socket.off('playerReset', onPlayerReset);
+      socket.off('playerLeft', onPlayerLeft);
+      socket.off('gameWon', onGameWon);
+    };
+  }, [table, telegramId, name]);
+
+  const handleRoll = () => {
+    socket.emit('rollDice');
+  };
+
+  const cells = [];
+  for (let r = 9; r >= 0; r--) {
+    for (let c = 0; c < 10; c++) {
+      const num = r % 2 === 0 ? r * 10 + c + 1 : r * 10 + (9 - c) + 1;
+      cells.push(num);
+    }
+  }
+
+  return (
+    <div className="p-4 space-y-2 text-text">
+      <h2 className="text-xl font-bold text-center">Multiplayer Snake &amp; Ladder</h2>
+      {waiting && <p className="text-center">Waiting for players...</p>}
+      {winner && <p className="text-center">Winner: {winner}</p>}
+      <div className="grid grid-cols-10 gap-px mx-auto w-max">
+        {cells.map((cell) => (
+          <div key={cell} className="relative border border-border w-8 h-8 text-[10px] flex items-center justify-center">
+            {cell}
+            <div className="absolute inset-0 flex items-center justify-center space-x-1">
+              {players.filter((p) => p.position === cell).map((p) => (
+                <div key={p.id} className="w-3 h-3 rounded-full" style={{ background: p.color }} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      {currentTurn === telegramId && !winner && !waiting && (
+        <div className="text-center">
+          <button onClick={handleRoll} className="px-4 py-2 bg-primary text-white rounded">
+            Roll Dice
+          </button>
+        </div>
+      )}
+      {dice != null && <p className="text-center">Last roll: {dice}</p>}
+      <div className="text-center mt-2">
+        <button onClick={() => navigate('/games/snake/lobby')} className="text-sm underline">
+          Exit
+        </button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add socket.io client dependency for webapp
- implement `SnakeMultiplayer` page using sockets
- update lobby to open multiplayer page
- register route for new page
- document new multiplayer status

## Testing
- `npm install --prefix webapp`
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861b7f21fcc8329b3894f9c1f78c6f8