### PR TITLE
Implement session based telegram id fallback

### DIFF
--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -3,10 +3,15 @@ export function getTelegramId() {
     const tgId = window?.Telegram?.WebApp?.initDataUnsafe?.user?.id;
     if (tgId) {
       localStorage.setItem('telegramId', tgId);
+      sessionStorage.setItem('telegramId', tgId);
       return tgId;
     }
-    const stored = localStorage.getItem('telegramId');
-    if (stored) return Number(stored);
+    const session = sessionStorage.getItem('telegramId');
+    if (session) return Number(session);
+    const id = Math.floor(Math.random() * 1e9);
+    localStorage.setItem('telegramId', id);
+    sessionStorage.setItem('telegramId', id);
+    return id;
   }
   // Fallback for non-Telegram browsers
   return 1;


### PR DESCRIPTION
## Summary
- improve fallback ID logic when telegram user info isn't available
- persist generated fallback ID across reloads but rotate each browser session

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68621f0618348329bb0ee53b19888fe1