### PR TITLE
Improve install docs and pretest step

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 1. Install **Node.js 18** or later.
-2. Run `npm run install-all` at the repository root to install dependencies for both the bot and webapp.
+2. Run `npm install` at the repository root. This installs all root packages and automatically runs `npm install --prefix bot` and `npm install --prefix webapp` for the individual projects.
 3. Copy `bot/.env.example` to `bot/.env` and update the values. At minimum set:
    - `BOT_TOKEN` – your Telegram bot token
    - `MONGODB_URI` – MongoDB connection string or `memory`
@@ -35,7 +35,7 @@
    npm --prefix webapp run build
    ```
 
-7. Run the test suite to verify the setup:
+7. Run the test suite to verify the setup (after running `npm install` or `npm install --prefix bot`):
 
    ```bash
    npm test

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node bot/server.js",
     "install-all": "npm install --prefix bot && npm install --prefix webapp",
     "postinstall": "npm run install-all",
+    "pretest": "npm run install-all",
     "build": "npm --prefix webapp run build",
     "test": "node --test",
     "recalculate-balances": "node bot/scripts/recalculateBalances.js"


### PR DESCRIPTION
## Summary
- clarify install step in README
- mention npm install before npm test
- run install-all automatically before npm test

## Testing
- `npm install`
- `npm install --prefix bot`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862232d81ac8329b104fd6ea741f7c3