### PR TITLE
Add socket.io-client to webapp deps

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -23,6 +23,7 @@
     "react-markdown": "^9.0.0",
     "react-qr-code": "^2.0.16",
     "react-router-dom": "^6.22.3",
+    "socket.io-client": "^4.7.5",
     "tailwindcss": "^3.4.1",
     "three": "^0.164.0",
     "vite": "^4.4.9"


### PR DESCRIPTION
## Summary
- add missing socket.io-client dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68622b8428608329b34f832211353ece