### PR TITLE
Add socket.io-client dependency

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -23,6 +23,7 @@
     "react-markdown": "^9.0.0",
     "react-qr-code": "^2.0.16",
     "react-router-dom": "^6.22.3",
+    "socket.io-client": "^4.8.1",
     "tailwindcss": "^3.4.1",
     "three": "^0.164.0",
     "vite": "^4.4.9"


### PR DESCRIPTION
## Summary
- add `socket.io-client` 4.8.1 to dependencies

## Testing
- `npm install --prefix webapp`
- `npm run build --prefix webapp`

------
https://chatgpt.com/codex/tasks/task_e_68623d4bd67883299c088858f157f00b