### PR TITLE
Enable snake multiplayer via sockets

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -116,9 +116,6 @@ export default function Lobby() {
   const startGame = () => {
     const params = new URLSearchParams();
     if (table) params.set('table', table.id);
-    if (table && table.id !== 'single' && players.length < table.capacity) {
-      params.set('wait', '1');
-    }
     if (table?.id === 'single') {
       localStorage.removeItem(`snakeGameState_${aiCount}`);
       params.set('ai', aiCount);


### PR DESCRIPTION
## Summary
- connect Snake & Ladder game to socket server when no `ai` param
- remove lobby polling and emit socket events instead
- update board component to show multiplayer players and add roll button
- simplify lobby navigation for multiplayer tables

## Testing
- `npm test` *(fails: Cannot find package 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_68623d4cfa9c8329a6a577b107f20b41