### PR TITLE
Fix default AI state in Snake & Ladder

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -659,11 +659,16 @@ export default function SnakeAndLadder() {
     const t = params.get("token");
     const amt = params.get("amount");
     const aiParam = params.get("ai");
+    const tableParam = params.get("table");
     if (t) setToken(t.toUpperCase());
     if (amt) setPot(Number(amt));
-    const aiCount = aiParam ? Math.max(1, Math.min(3, Number(aiParam))) : 0;
-    if (aiParam) setAi(aiCount);
-    setIsMultiplayer(!aiParam);
+    const aiCount = aiParam
+      ? Math.max(1, Math.min(3, Number(aiParam)))
+      : tableParam
+        ? 0
+        : 1;
+    setAi(aiCount);
+    setIsMultiplayer(tableParam && !aiParam);
     localStorage.removeItem(`snakeGameState_${aiCount}`);
     setAiPositions(Array(aiCount).fill(0));
     setAiAvatars(


### PR DESCRIPTION
## Summary
- ensure Snake & Ladder uses one AI opponent when no `ai` param is given

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68625d900f308329a0c36db878c83bc1