### PR TITLE
Improve 1v1 invite flow

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -293,7 +293,7 @@ io.on('connection', (socket) => {
     await gameManager.rollDice(socket);
   });
 
-  socket.on('invite1v1', ({ fromId, toId, roomId }, cb) => {
+  socket.on('invite1v1', ({ fromId, fromName, toId, roomId, token, amount }, cb) => {
     fromId = Number(fromId);
     toId = Number(toId);
     if (!fromId || !toId) return cb && cb({ success: false, error: 'invalid ids' });
@@ -306,7 +306,7 @@ io.on('connection', (socket) => {
       return cb && cb({ success: false, error: 'User offline' });
     }
     for (const sid of targets) {
-      io.to(sid).emit('gameInvite', { fromId, roomId });
+      io.to(sid).emit('gameInvite', { fromId, fromName, roomId, token, amount });
     }
     cb && cb({ success: true });
   });

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -1,12 +1,30 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
+import RoomSelector from './RoomSelector.jsx';
 
-export default function InvitePopup({ open, name, onAccept, onReject }) {
+export default function InvitePopup({
+  open,
+  name,
+  onAccept,
+  onReject,
+  stake,
+  onStakeChange,
+  incoming,
+}) {
   if (!open) return null;
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="bg-surface border border-border rounded p-4 space-y-4 text-text w-72">
-        <p className="text-center">Invite {name} to play 1v1?</p>
+        {incoming ? (
+          <p className="text-center">
+            {name} wants to play you for {stake?.amount} {stake?.token}
+          </p>
+        ) : (
+          <>
+            <p className="text-center">Invite {name} to play 1v1?</p>
+            <RoomSelector selected={stake} onSelect={onStakeChange} />
+          </>
+        )}
         <div className="flex justify-center gap-2">
           <button
             onClick={onAccept}


### PR DESCRIPTION
## Summary
- allow specifying stake on 1v1 invites
- show inviter name and stake in popup
- keep sockets online so invites reach users

## Testing
- `npm test` *(fails: cannot find some packages)*

------
https://chatgpt.com/codex/tasks/task_e_68627baed9ac83299f5c467c6c04e315