### PR TITLE
Fix account-based invites and online tracking

### DIFF
--- a/bot/routes/mining.js
+++ b/bot/routes/mining.js
@@ -50,7 +50,7 @@ router.post('/leaderboard', async (req, res) => {
   const users = await User.find()
     .sort({ balance: -1 })
     .limit(100)
-    .select('telegramId balance nickname firstName lastName photo')
+    .select('telegramId accountId balance nickname firstName lastName photo')
     .lean();
 
   await Promise.all(

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { socket } from '../utils/socket.js';
 import { pingOnline } from '../utils/api.js';
-import { getTelegramId } from '../utils/telegram.js';
+import { getPlayerId } from '../utils/telegram.js';
 import InvitePopup from './InvitePopup.jsx';
 
 import Navbar from './Navbar.jsx';
@@ -30,9 +30,9 @@ export default function Layout({ children }) {
   useEffect(() => {
     let id;
     try {
-      const telegramId = getTelegramId();
+      const playerId = getPlayerId();
       function ping() {
-        pingOnline(telegramId).catch(() => {});
+        pingOnline(playerId).catch(() => {});
       }
       ping();
       id = setInterval(ping, 30000);

--- a/webapp/src/hooks/useTelegramAuth.js
+++ b/webapp/src/hooks/useTelegramAuth.js
@@ -4,9 +4,12 @@ import { socket } from '../utils/socket.js';
 export default function useTelegramAuth() {
   useEffect(() => {
     const user = window?.Telegram?.WebApp?.initDataUnsafe?.user;
+    const acc = localStorage.getItem('accountId');
     if (user?.id) {
       localStorage.setItem('telegramId', user.id);
-      socket.emit('register', { telegramId: user.id });
+      socket.emit('register', { telegramId: user.id, playerId: acc || user.id });
+    } else if (acc) {
+      socket.emit('register', { playerId: acc });
     }
     if (user?.username) {
       localStorage.setItem('telegramUsername', user.username);

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LoginOptions from '../components/LoginOptions.jsx';
-import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
+import { getTelegramId, getTelegramPhotoUrl, getPlayerId } from '../utils/telegram.js';
 import { FaCircle } from 'react-icons/fa';
 import {
   getLeaderboard,
@@ -28,6 +28,7 @@ export default function Friends() {
   } catch (err) {
     return <LoginOptions />;
   }
+  const accountId = getPlayerId();
 
   const [referral, setReferral] = useState(null);
   const [leaderboard, setLeaderboard] = useState([]);
@@ -194,15 +195,15 @@ export default function Friends() {
             <tbody>
               {leaderboard.map((u, idx) => (
                 <tr
-                  key={u.telegramId}
-                  className={`border-b border-border h-16 cursor-pointer ${u.telegramId === telegramId ? 'bg-accent text-black' : ''}`}
-                  onClick={() => u.telegramId !== telegramId && setInviteTarget(u)}
+                  key={u.accountId || u.telegramId}
+                  className={`border-b border-border h-16 cursor-pointer ${u.accountId === accountId ? 'bg-accent text-black' : ''}`}
+                  onClick={() => u.accountId !== accountId && setInviteTarget(u)}
                 >
                   <td className="p-2">{idx + 1}</td>
                   <td className="p-2 w-16">
                     <img
                       src={getAvatarUrl(
-                        u.telegramId === telegramId
+                        u.accountId === accountId
                           ? myPhotoUrl || '/assets/icons/profile.svg'
                           : u.photo || u.photoUrl || '/assets/icons/profile.svg'
                       )}
@@ -212,7 +213,7 @@ export default function Friends() {
                   </td>
                   <td className="p-2 flex items-center">
                     {u.nickname || `${u.firstName} ${u.lastName}`.trim() || 'User'}
-                    {onlineUsers.includes(u.telegramId) && (
+                    {onlineUsers.includes(String(u.accountId)) && (
                       <FaCircle className="ml-1 text-green-500" size={8} />
                     )}
                   </td>
@@ -231,11 +232,11 @@ export default function Friends() {
                   </td>
                   <td className="p-2 flex items-center">
                     You
-                    {onlineUsers.includes(telegramId) && (
+                    {onlineUsers.includes(String(accountId)) && (
                       <FaCircle className="ml-1 text-green-500" size={8} />
                     )}
                   </td>
-                  <td className="p-2 text-right">{leaderboard.find((u) => u.telegramId === telegramId)?.balance ?? '...'}</td>
+                  <td className="p-2 text-right">{leaderboard.find((u) => u.accountId === accountId)?.balance ?? '...'}</td>
                 </tr>
               )}
             </tbody>
@@ -249,13 +250,13 @@ export default function Friends() {
         onStakeChange={setStake}
         onAccept={() => {
           if (inviteTarget) {
-            const roomId = `invite-${telegramId}-${inviteTarget.telegramId}-${Date.now()}-2`;
+            const roomId = `invite-${accountId}-${inviteTarget.accountId}-${Date.now()}-2`;
             socket.emit(
               'invite1v1',
               {
-                fromId: telegramId,
+                fromId: accountId,
                 fromName: myName,
-                toId: inviteTarget.telegramId,
+                toId: inviteTarget.accountId,
                 roomId,
                 token: stake.token,
                 amount: stake.amount,


### PR DESCRIPTION
## Summary
- include `accountId` in leaderboard results
- use account ID for online list in server
- store socket registrations by accountId
- update frontend to ping and invite by account ID

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686289b7ffb48329b1cfc489515484c2