### PR TITLE
Implement auto roll timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ it occurs before `ROLL_COOLDOWN_MS` has elapsed:
 if (Date.now() - player.lastRollTime < this.rollCooldown) return;
 ```
 
+Players have 15 seconds to roll on their turn. When the countdown hits zero
+the server automatically rolls for them so the game keeps moving.
+
 ### Playing against the AI
 
 Opening the Snake & Ladder game without specifying an `ai` parameter now


### PR DESCRIPTION
## Summary
- add a 15 second timer in `GameRoom` that auto-rolls for players
- reset the timer after each roll, on disconnect and when the game ends
- document automatic rolling in the README

## Testing
- `npm test` *(fails: cannot find some packages)*

------
https://chatgpt.com/codex/tasks/task_e_68629b5bce9483298ea113e11b91a4e3