### PR TITLE
Implement multiplayer dice animation

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -10,11 +10,13 @@ export default function DiceRoller({
   trigger,
   showButton = true,
   muted = false,
+  finalValues,
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
   const soundRef = useRef(null);
   const startValuesRef = useRef(values);
+  const finalValuesRef = useRef(finalValues);
   const triggerRef = useRef(trigger);
 
   useEffect(() => {
@@ -31,6 +33,10 @@ export default function DiceRoller({
       soundRef.current?.pause();
     };
   }, [muted]);
+
+  useEffect(() => {
+    finalValuesRef.current = finalValues;
+  }, [finalValues]);
 
   useEffect(() => {
     if (trigger !== undefined && trigger !== triggerRef.current) {
@@ -68,11 +74,16 @@ export default function DiceRoller({
       count += 1;
       if (count >= iterations) {
         clearInterval(id);
+        const finalResults =
+          finalValuesRef.current && finalValuesRef.current.length === numDice
+            ? finalValuesRef.current
+            : results;
+        setValues(finalResults);
         // allow the final face to be visible before stopping
         setTimeout(() => {
           setRolling(false);
-          startValuesRef.current = results;
-          onRollEnd && onRollEnd(results);
+          startValuesRef.current = finalResults;
+          onRollEnd && onRollEnd(finalResults);
         }, tick);
       }
     }, tick);


### PR DESCRIPTION
## Summary
- allow DiceRoller to accept final dice values
- fetch profile data for multiplayer rooms
- display dice roller in multiplayer games
- trigger dice animation on server roll events

## Testing
- `npm test` *(fails: cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_6862b201ab848329946e6f5ddaaac1b3