### PR TITLE
Add multiplayer dice timer and animation

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -10,6 +10,7 @@ export default function DiceRoller({
   trigger,
   showButton = true,
   muted = false,
+  finalValues,
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -68,11 +69,16 @@ export default function DiceRoller({
       count += 1;
       if (count >= iterations) {
         clearInterval(id);
-        // allow the final face to be visible before stopping
+        const final = finalValues
+          ? Array.isArray(finalValues)
+            ? finalValues
+            : [finalValues]
+          : results;
         setTimeout(() => {
+          setValues(final);
           setRolling(false);
-          startValuesRef.current = results;
-          onRollEnd && onRollEnd(results);
+          startValuesRef.current = final;
+          onRollEnd && onRollEnd(final);
         }, tick);
       }
     }, tick);


### PR DESCRIPTION
## Summary
- add optional `finalValues` prop to `DiceRoller`
- display animated dice in multiplayer matches
- auto roll dice after 15 seconds with timer beeps when playing online

## Testing
- `npm test` *(fails: Operation `gameresults.insertOne()` buffering timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6862bb8eb5048329a6ed86f3aef472c4