### PR TITLE
Enable dice animation in multiplayer snake game

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Dice from './Dice.jsx';
 import { diceSound } from '../assets/soundData.js';
+import { socket } from '../utils/socket.js';
 
 export default function DiceRoller({
   onRollEnd,
@@ -10,6 +11,7 @@ export default function DiceRoller({
   trigger,
   showButton = true,
   muted = false,
+  emitRollEvent = false,
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -73,6 +75,9 @@ export default function DiceRoller({
           setRolling(false);
           startValuesRef.current = results;
           onRollEnd && onRollEnd(results);
+          if (emitRollEvent) {
+            socket.emit('rollDice');
+          }
         }, tick);
       }
     }, tick);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1667,12 +1667,12 @@ export default function SnakeAndLadder() {
             const myIndex = mpPlayers.findIndex(p => p.id === myId);
             if (currentTurn === myIndex && !moving) {
               return (
-                <button
-                  onClick={() => socket.emit('rollDice')}
-                  className="px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded"
-                >
-                  Roll Dice
-                </button>
+                <DiceRoller
+                  clickable
+                  showButton={false}
+                  muted={muted}
+                  emitRollEvent
+                />
               );
             }
             return null;


### PR DESCRIPTION
## Summary
- emit dice roll events from the DiceRoller component
- display DiceRoller instead of button during multiplayer turns

## Testing
- `npm test` *(fails: cannot find optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862e27a9960832993579aecad4b9776