### PR TITLE
Fix install-all and add test setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ## Installation
 
 1. Install **Node.js 18** or later.
-2. Run `npm run install-all` at the repository root to install dependencies for both the bot and webapp.
+2. Run `npm run install-all` at the repository root to install dependencies for the bot, webapp and test suite.
+   You can also execute `./scripts/setup-tests.sh` when preparing a clean test environment.
 3. Copy `bot/.env.example` to `bot/.env` and update the values. At minimum set:
    - `BOT_TOKEN` – your Telegram bot token
    - `MONGODB_URI` – MongoDB connection string or `memory`

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "main": "bot/server.js",
   "scripts": {
     "start": "node bot/server.js",
-    "install-all": "npm install --prefix bot && npm install --prefix webapp",
-    "postinstall": "npm run install-all",
+    "install-all": "npm install && npm install --prefix bot && npm install --prefix webapp",
     "build": "npm --prefix webapp run build",
     "test": "node --test",
     "recalculate-balances": "node bot/scripts/recalculateBalances.js",

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+npm run install-all


### PR DESCRIPTION
## Summary
- install root, bot and webapp dependencies when running `npm run install-all`
- document setup script for tests
- add helper script `scripts/setup-tests.sh` for CI

## Testing
- `./scripts/setup-tests.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862e480568c83298325e3197078342a