### PR TITLE
Add group invites and update snake lobby

### DIFF
--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -5,11 +5,13 @@ import RoomSelector from './RoomSelector.jsx';
 export default function InvitePopup({
   open,
   name,
+  opponents = [],
   onAccept,
   onReject,
   stake,
   onStakeChange,
   incoming,
+  group,
 }) {
   if (!open) return null;
   return createPortal(
@@ -17,11 +19,23 @@ export default function InvitePopup({
       <div className="bg-surface border border-border rounded p-4 space-y-4 text-text w-72">
         {incoming ? (
           <p className="text-center">
-            {name} wants to play you for {stake?.amount} {stake?.token}
+            {name} wants to play you for {stake?.amount}{' '}
+            <img
+              src={`/icons/${stake?.token || 'TPC'}${stake?.token === 'TPC' ? 'coin' : ''}.png`}
+              alt="token"
+              className="inline w-4 h-4 mr-1"
+            />
+            {stake?.token}
+            {group && opponents.length > 0 && (
+              <> with {opponents.join(', ')}</>
+            )}
           </p>
         ) : (
           <>
-            <p className="text-center">Invite {name} to play 1v1?</p>
+            <p className="text-center">
+              Invite {Array.isArray(name) ? name.join(', ') : name} to play{' '}
+              {group ? 'group' : '1v1'}?
+            </p>
             <RoomSelector selected={stake} onSelect={onStakeChange} />
           </>
         )}

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -20,8 +20,8 @@ export default function Layout({ children }) {
   const [invite, setInvite] = useState(null);
 
   useEffect(() => {
-    const onInvite = ({ fromId, fromName, roomId, token, amount }) => {
-      setInvite({ fromId, fromName, roomId, token, amount });
+    const onInvite = ({ fromId, fromName, roomId, token, amount, group, opponentNames }) => {
+      setInvite({ fromId, fromName, roomId, token, amount, group, opponentNames });
     };
     socket.on('gameInvite', onInvite);
     return () => socket.off('gameInvite', onInvite);
@@ -95,8 +95,10 @@ export default function Layout({ children }) {
       <InvitePopup
         open={!!invite}
         name={invite?.fromName || invite?.fromId}
+        opponents={invite?.opponentNames || []}
         stake={{ token: invite?.token, amount: invite?.amount }}
         incoming
+        group={Array.isArray(invite?.group)}
         onAccept={() => {
           if (invite)
             navigate(

--- a/webapp/src/components/TableSelector.jsx
+++ b/webapp/src/components/TableSelector.jsx
@@ -3,21 +3,25 @@ import React from 'react';
 export default function TableSelector({ tables, selected, onSelect }) {
   return (
     <div className="space-y-2">
-      {tables.map((t) => (
-        <button
-          key={t.id}
-          onClick={() => onSelect(t)}
-          className={`lobby-tile w-full flex justify-between ${
-            selected?.id === t.id ? 'lobby-selected' : ''
-          }`}
-        >
-          <span>{t.label || `Table ${t.capacity}p`}</span>
-          {t.capacity && (
-            <span>
-              {t.players}/{t.capacity}
-            </span>
+      {tables.map((t, idx) => (
+        <React.Fragment key={t.id}>
+          {idx === 1 && tables[0]?.id === 'single' && (
+            <div className="h-4" />
           )}
-        </button>
+          <button
+            onClick={() => onSelect(t)}
+            className={`lobby-tile w-full flex justify-between ${
+              selected?.id === t.id ? 'lobby-selected' : ''
+            }`}
+          >
+            <span>{t.label || `Table ${t.capacity}p`}</span>
+            {t.capacity && (
+              <span>
+                {t.players}/{t.capacity}
+              </span>
+            )}
+          </button>
+        </React.Fragment>
       ))}
     </div>
   );

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -13,7 +13,7 @@ import {
   unseatTable,
   getProfile,
 } from '../../utils/api.js';
-import { getTelegramId, getPlayerId, ensureAccountId } from '../../utils/telegram.js';
+import { getPlayerId, ensureAccountId } from '../../utils/telegram.js';
 import { canStartGame } from '../../utils/lobby.js';
 
 export default function Lobby() {
@@ -43,10 +43,10 @@ export default function Lobby() {
   const [playerName, setPlayerName] = useState('');
 
   useEffect(() => {
-    const id = getTelegramId();
-    getProfile(id)
-      .then((p) => setPlayerName(p?.nickname || p?.firstName || ''))
-      .catch(() => {});
+    try {
+      const aid = getPlayerId();
+      setPlayerName(String(aid));
+    } catch {}
   }, []);
 
   useEffect(() => {
@@ -69,9 +69,9 @@ export default function Lobby() {
   }, [game]);
 
   useEffect(() => {
-    const telegramId = getPlayerId();
+    const playerId = getPlayerId();
     function ping() {
-      pingOnline(telegramId).catch(() => {});
+      pingOnline(playerId).catch(() => {});
       getOnlineCount()
         .then((d) => setOnline(d.count))
         .catch(() => {});


### PR DESCRIPTION
## Summary
- allow inviting multiple players with new `inviteGroup` socket event
- show token icons in invite popups and display group names
- include opponent info when receiving invites
- visually separate single-player tables in the lobby
- remove Telegram ID usage from lobby and rely on TPC account ID
- add group invite flow on Friends leaderboard

## Testing
- `npm run install-all`
- `npm test` *(fails: MongooseError: Operation `gamerooms.findOne()` buffering timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686306bb322083299b07de05ea429616