### PR TITLE
Improve wallet transaction history

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -6,7 +6,11 @@ const transactionSchema = new mongoose.Schema(
     amount: Number,
     type: { type: String },
     status: { type: String, default: 'delivered' },
-    date: { type: Date, default: Date.now }
+    date: { type: Date, default: Date.now },
+    fromAccount: String,
+    fromName: String,
+    toAccount: String,
+    toName: String
   },
   { _id: false }
 );

--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -75,8 +75,22 @@ router.post('/send', async (req, res) => {
   sender.balance -= amount;
   receiver.balance = (receiver.balance || 0) + amount;
 
-  const senderTx = { amount: -amount, type: 'send', status: 'delivered', date: txDate };
-  const receiverTx = { amount, type: 'receive', status: 'delivered', date: txDate };
+  const senderTx = {
+    amount: -amount,
+    type: 'send',
+    status: 'delivered',
+    date: txDate,
+    toAccount: toAccount,
+    toName: receiver.nickname || receiver.firstName || ''
+  };
+  const receiverTx = {
+    amount,
+    type: 'receive',
+    status: 'delivered',
+    date: txDate,
+    fromAccount: fromAccount,
+    fromName: sender.nickname || sender.firstName || ''
+  };
   sender.transactions.push(senderTx);
   receiver.transactions.push(receiverTx);
 

--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -197,27 +197,21 @@ router.post('/send', authenticate, async (req, res) => {
     sender.balance -= amount;
 
     const senderTx = {
-
       amount: -amount,
-
       type: 'send',
-
       status: 'delivered',
-
-      date: txDate
-
+      date: txDate,
+      toAccount: String(toId),
+      toName: receiver.nickname || receiver.firstName || ''
     };
 
     const receiverTx = {
-
       amount,
-
       type: 'receive',
-
       status: 'delivered',
-
-      date: txDate
-
+      date: txDate,
+      fromAccount: String(fromId),
+      fromName: sender.nickname || sender.firstName || ''
     };
 
     sender.transactions.push(senderTx);

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+
+export default function TransactionDetailsPopup({ tx, onClose }) {
+  if (!tx) return null;
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
+      <div className="bg-surface border border-border p-4 rounded space-y-2 text-text w-80 relative">
+        <button
+          onClick={onClose}
+          className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"
+        >
+          &times;
+        </button>
+        <h3 className="text-lg font-bold text-center capitalize">{tx.type} details</h3>
+        <div className="text-sm space-y-1">
+          <div className="flex justify-between"><span>Amount:</span><span className={tx.amount >= 0 ? 'text-green-500' : 'text-red-500'}>{tx.amount}</span></div>
+          {tx.fromName && <div className="flex justify-between"><span>From:</span><span>{tx.fromName}</span></div>}
+          {tx.fromAccount && !tx.fromName && <div className="flex justify-between"><span>From:</span><span>{tx.fromAccount}</span></div>}
+          {tx.toAccount && <div className="flex justify-between"><span>To:</span><span>{tx.toAccount}</span></div>}
+          <div className="flex justify-between"><span>Date:</span><span>{new Date(tx.date).toLocaleString()}</span></div>
+          <div className="flex justify-between"><span>Status:</span><span>{tx.status}</span></div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}


### PR DESCRIPTION
## Summary
- extend transaction schema to record sender/receiver info
- include sender name when sending or receiving TPC
- show wallet and account transactions in a filterable list
- add a popup to display transaction details on click

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_686381b0742483298c16e312e2257888