### PR TITLE
Improve wallet transaction filters and details

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -10,7 +10,9 @@ const transactionSchema = new mongoose.Schema(
     fromAccount: String,
     fromName: String,
     toAccount: String,
-    toName: String
+    toName: String,
+    game: String,
+    players: Number
   },
   { _id: false }
 );

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -1,7 +1,26 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { getProfileByAccount } from '../utils/api.js';
 
 export default function TransactionDetailsPopup({ tx, onClose }) {
+  const [otherName, setOtherName] = useState('');
+  useEffect(() => {
+    if (!tx) return;
+    let id = null;
+    if (tx.fromAccount && !tx.fromName) id = tx.fromAccount;
+    else if (tx.toAccount && !tx.toName) id = tx.toAccount;
+    if (id) {
+      getProfileByAccount(id).then((p) => {
+        if (p && (p.nickname || p.firstName || p.lastName)) {
+          setOtherName(
+            p.nickname || `${p.firstName || ''} ${p.lastName || ''}`.trim()
+          );
+        }
+      });
+    } else {
+      setOtherName('');
+    }
+  }, [tx]);
   if (!tx) return null;
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
@@ -15,9 +34,34 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
         <h3 className="text-lg font-bold text-center capitalize">{tx.type} details</h3>
         <div className="text-sm space-y-1">
           <div className="flex justify-between"><span>Amount:</span><span className={tx.amount >= 0 ? 'text-green-500' : 'text-red-500'}>{tx.amount}</span></div>
-          {tx.fromName && <div className="flex justify-between"><span>From:</span><span>{tx.fromName}</span></div>}
-          {tx.fromAccount && !tx.fromName && <div className="flex justify-between"><span>From:</span><span>{tx.fromAccount}</span></div>}
-          {tx.toAccount && <div className="flex justify-between"><span>To:</span><span>{tx.toAccount}</span></div>}
+          {tx.fromAccount && (
+            <div className="flex justify-between">
+              <span>From:</span>
+              <span>
+                {tx.fromName || otherName ? (
+                  <>
+                    {tx.fromName || otherName} ({tx.fromAccount})
+                  </>
+                ) : (
+                  tx.fromAccount
+                )}
+              </span>
+            </div>
+          )}
+          {tx.toAccount && (
+            <div className="flex justify-between">
+              <span>To:</span>
+              <span>
+                {tx.toName ? `${tx.toName} (${tx.toAccount})` : tx.toAccount}
+              </span>
+            </div>
+          )}
+          {tx.game && (
+            <div className="flex justify-between"><span>Game:</span><span>{tx.game}</span></div>
+          )}
+          {tx.players && (
+            <div className="flex justify-between"><span>Players:</span><span>{tx.players}</span></div>
+          )}
           <div className="flex justify-between"><span>Date:</span><span>{new Date(tx.date).toLocaleString()}</span></div>
           <div className="flex justify-between"><span>Status:</span><span>{tx.status}</span></div>
         </div>

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -22,7 +22,13 @@ import {
 import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
 import { useNavigate } from "react-router-dom";
 import { getTelegramId, getTelegramPhotoUrl, getPlayerId, ensureAccountId } from "../../utils/telegram.js";
-import { getProfile, depositAccount, getSnakeBoard, pingOnline } from "../../utils/api.js";
+import {
+  getProfile,
+  depositAccount,
+  getSnakeBoard,
+  pingOnline,
+  addTransaction
+} from "../../utils/api.js";
 import { socket } from "../../utils/socket.js";
 import PlayerToken from "../../components/PlayerToken.jsx";
 import AvatarTimer from "../../components/AvatarTimer.jsx";
@@ -872,6 +878,15 @@ export default function SnakeAndLadder() {
     const onWon = ({ playerId }) => {
       setGameOver(true);
       setRanking([playerId === accountId ? myName : playerId]);
+      if (playerId === accountId) {
+        const totalPlayers = isMultiplayer ? mpPlayers.length : ai + 1;
+        const tgId = getTelegramId();
+        addTransaction(tgId, 0, 'win', {
+          game: 'snake',
+          players: totalPlayers,
+          accountId
+        });
+      }
     };
 
     const onCurrentPlayers = (players) => {

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -32,8 +32,14 @@ export default function Wallet() {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
   const [filterDate, setFilterDate] = useState('');
+  const [filterType, setFilterType] = useState('');
+  const [filterUser, setFilterUser] = useState('');
   const [selectedTx, setSelectedTx] = useState(null);
   const dateInputRef = useRef(null);
+
+  const txTypes = Array.from(new Set(transactions.map((t) => t.type))).filter(
+    Boolean
+  );
 
 
   const loadBalances = async () => {
@@ -117,9 +123,18 @@ export default function Wallet() {
   };
 
   const filteredTransactions = transactions.filter((tx) => {
-    if (!filterDate) return true;
-    const d = new Date(tx.date).toISOString().slice(0, 10);
-    return d === filterDate;
+    if (filterDate) {
+      const d = new Date(tx.date).toISOString().slice(0, 10);
+      if (d !== filterDate) return false;
+    }
+    if (filterType && tx.type !== filterType) return false;
+    if (filterUser) {
+      const q = filterUser.toLowerCase();
+      const name = (tx.fromName || tx.toName || '').toLowerCase();
+      const account = tx.fromAccount || tx.toAccount || '';
+      if (!name.includes(q) && !String(account).includes(q)) return false;
+    }
+    return true;
   });
 
 
@@ -195,7 +210,7 @@ export default function Wallet() {
       <div className="mt-4">
         <div className="flex items-center justify-between mb-1">
           <h3 className="font-semibold">Transactions</h3>
-          <div className="flex items-center space-x-1">
+          <div className="flex items-center space-x-1 flex-wrap">
             <input
               type="date"
               ref={dateInputRef}
@@ -208,12 +223,32 @@ export default function Wallet() {
               onClick={() => dateInputRef.current?.showPicker && dateInputRef.current.showPicker()}
             />
             {filterDate && (
-              <button
-                onClick={() => setFilterDate('')}
-                className="text-xs text-subtext"
-              >
-                Clear
-              </button>
+              <button onClick={() => setFilterDate('')} className="text-xs text-subtext">Clear</button>
+            )}
+            <select
+              value={filterType}
+              onChange={(e) => setFilterType(e.target.value)}
+              className="border border-border rounded text-black text-xs px-1"
+            >
+              <option value="">All</option>
+              {txTypes.map((t) => (
+                <option key={t} value={t} className="capitalize">
+                  {t}
+                </option>
+              ))}
+            </select>
+            {filterType && (
+              <button onClick={() => setFilterType('')} className="text-xs text-subtext">Clear</button>
+            )}
+            <input
+              type="text"
+              placeholder="User or account"
+              value={filterUser}
+              onChange={(e) => setFilterUser(e.target.value)}
+              className="border border-border rounded text-black text-xs px-1"
+            />
+            {filterUser && (
+              <button onClick={() => setFilterUser('')} className="text-xs text-subtext">Clear</button>
             )}
           </div>
         </div>

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -110,10 +110,17 @@ export function updateBalance(telegramId, balance) {
 
 }
 
-export function addTransaction(telegramId, amount, type) {
+export function addTransaction(telegramId, amount, type, extra = {}) {
+  return post('/api/profile/addTransaction', {
+    telegramId,
+    amount,
+    type,
+    ...extra,
+  });
+}
 
-  return post('/api/profile/addTransaction', { telegramId, amount, type });
-
+export function getProfileByAccount(accountId) {
+  return post('/api/profile/by-account', { accountId });
 }
 
 export function linkSocial(data) {


### PR DESCRIPTION
## Summary
- include game and player count fields on transactions
- add profile lookup by account
- allow extra data when adding a transaction
- show more info in transaction details modal
- log game wins and filter transactions by type or user

## Testing
- `npm test` *(fails: Cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_68638f05f5308329b69fe04211bba166