### PR TITLE
Enhance transaction popup

### DIFF
--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -82,8 +82,8 @@ router.post('/by-account', async (req, res) => {
   if (!accountId) return res.status(400).json({ error: 'accountId required' });
   const user = await User.findOne({ accountId });
   if (!user) return res.status(404).json({ error: 'account not found' });
-  const { nickname, firstName, lastName } = user;
-  res.json({ nickname, firstName, lastName });
+  const { nickname, firstName, lastName, photo } = user;
+  res.json({ nickname, firstName, lastName, photo });
 });
 
 router.post('/update', async (req, res) => {

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -1,24 +1,30 @@
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { getProfileByAccount } from '../utils/api.js';
+import { getAvatarUrl } from '../utils/avatarUtils.js';
 
 export default function TransactionDetailsPopup({ tx, onClose }) {
+  const [fromProfile, setFromProfile] = useState(null);
+  const [toProfile, setToProfile] = useState(null);
   const [otherName, setOtherName] = useState('');
   useEffect(() => {
     if (!tx) return;
-    let id = null;
-    if (tx.fromAccount && !tx.fromName) id = tx.fromAccount;
-    else if (tx.toAccount && !tx.toName) id = tx.toAccount;
-    if (id) {
-      getProfileByAccount(id).then((p) => {
-        if (p && (p.nickname || p.firstName || p.lastName)) {
+    if (tx.fromAccount) {
+      getProfileByAccount(tx.fromAccount).then((p) => {
+        setFromProfile(p || null);
+        if (!tx.fromName && p && (p.nickname || p.firstName || p.lastName)) {
           setOtherName(
             p.nickname || `${p.firstName || ''} ${p.lastName || ''}`.trim()
           );
         }
       });
     } else {
-      setOtherName('');
+      setFromProfile(null);
+    }
+    if (tx.toAccount) {
+      getProfileByAccount(tx.toAccount).then((p) => setToProfile(p || null));
+    } else {
+      setToProfile(null);
     }
   }, [tx]);
   if (!tx) return null;
@@ -32,28 +38,32 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
           &times;
         </button>
         <h3 className="text-lg font-bold text-center capitalize">{tx.type} details</h3>
-        <div className="text-sm space-y-1">
+        <div className="text-sm space-y-2">
           <div className="flex justify-between"><span>Amount:</span><span className={tx.amount >= 0 ? 'text-green-500' : 'text-red-500'}>{tx.amount}</span></div>
           {tx.fromAccount && (
-            <div className="flex justify-between">
+            <div className="flex items-center space-x-2">
               <span>From:</span>
-              <span>
-                {tx.fromName || otherName ? (
-                  <>
-                    {tx.fromName || otherName} ({tx.fromAccount})
-                  </>
-                ) : (
-                  tx.fromAccount
-                )}
-              </span>
+              <img src="/icons/tpc.svg" alt="tpc" className="w-4 h-4" />
+              {fromProfile?.photo && (
+                <img src={getAvatarUrl(fromProfile.photo)} alt="" className="w-6 h-6 rounded-full" />
+              )}
+              <div>
+                <div>{tx.fromName || fromProfile?.nickname || `${fromProfile?.firstName || ''} ${fromProfile?.lastName || ''}`.trim() || otherName}</div>
+                <div className="text-xs text-subtext">{tx.fromAccount}</div>
+              </div>
             </div>
           )}
           {tx.toAccount && (
-            <div className="flex justify-between">
+            <div className="flex items-center space-x-2">
               <span>To:</span>
-              <span>
-                {tx.toName ? `${tx.toName} (${tx.toAccount})` : tx.toAccount}
-              </span>
+              <img src="/icons/tpc.svg" alt="tpc" className="w-4 h-4" />
+              {toProfile?.photo && (
+                <img src={getAvatarUrl(toProfile.photo)} alt="" className="w-6 h-6 rounded-full" />
+              )}
+              <div>
+                <div>{tx.toName || toProfile?.nickname || `${toProfile?.firstName || ''} ${toProfile?.lastName || ''}`.trim()}</div>
+                <div className="text-xs text-subtext">{tx.toAccount}</div>
+              </div>
             </div>
           )}
           {tx.game && (

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -44,6 +44,7 @@ export default function MyAccount() {
   const [showSaved, setShowSaved] = useState(false);
   const timerRef = useRef(null);
   const [filterDate, setFilterDate] = useState('');
+  const [sortOrder, setSortOrder] = useState('desc');
   const [selectedTx, setSelectedTx] = useState(null);
   const dateInputRef = useRef(null);
 
@@ -145,6 +146,11 @@ export default function MyAccount() {
     const d = new Date(tx.date).toISOString().slice(0, 10);
     return d === filterDate;
   });
+  const sortedTransactions = [...filteredTransactions].sort((a, b) =>
+    sortOrder === 'desc'
+      ? new Date(b.date) - new Date(a.date)
+      : new Date(a.date) - new Date(b.date)
+  );
 
   return (
     <div className="relative p-4 space-y-4 text-text">
@@ -260,7 +266,7 @@ export default function MyAccount() {
               ref={dateInputRef}
               value={filterDate}
               onChange={(e) => setFilterDate(e.target.value)}
-              className="border border-border rounded text-black text-xs px-1"
+              className="hidden"
             />
             <AiOutlineCalendar
               className="w-5 h-5 cursor-pointer"
@@ -274,13 +280,21 @@ export default function MyAccount() {
                 Clear
               </button>
             )}
+            <select
+              value={sortOrder}
+              onChange={(e) => setSortOrder(e.target.value)}
+              className="border border-border rounded text-black text-xs px-1"
+            >
+              <option value="desc">Newest</option>
+              <option value="asc">Oldest</option>
+            </select>
           </div>
         </div>
-        {filteredTransactions.length === 0 ? (
+        {sortedTransactions.length === 0 ? (
           <p className="text-sm text-subtext">No transactions</p>
         ) : (
           <div className="space-y-1 text-sm">
-            {filteredTransactions.map((tx, i) => (
+            {sortedTransactions.map((tx, i) => (
               <div
                 key={i}
                 className="flex justify-between border-b border-border pb-1 cursor-pointer hover:bg-white/10"

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -34,6 +34,7 @@ export default function Wallet() {
   const [filterDate, setFilterDate] = useState('');
   const [filterType, setFilterType] = useState('');
   const [filterUser, setFilterUser] = useState('');
+  const [sortOrder, setSortOrder] = useState('desc');
   const [selectedTx, setSelectedTx] = useState(null);
   const dateInputRef = useRef(null);
 
@@ -102,13 +103,7 @@ export default function Wallet() {
         }
         return;
       }
-      setReceipt({
-        to,
-        amount: amt,
-        date: res.transaction?.date
-          ? new Date(res.transaction.date).toLocaleString()
-          : new Date().toLocaleString()
-      });
+      setReceipt(res.transaction);
       setReceiver('');
       setAmount('');
       const id = await loadBalances();
@@ -136,6 +131,11 @@ export default function Wallet() {
     }
     return true;
   });
+  const sortedTransactions = [...filteredTransactions].sort((a, b) =>
+    sortOrder === 'desc'
+      ? new Date(b.date) - new Date(a.date)
+      : new Date(a.date) - new Date(b.date)
+  );
 
 
 
@@ -179,14 +179,7 @@ export default function Wallet() {
             </div>
           )}
           {receipt && (
-            <div className="border border-border p-2 rounded mt-2 text-sm flex justify-between items-center">
-              <div>
-                <div>Sent {receipt.amount} TPC to {receipt.to}</div>
-                <div className="text-xs">{receipt.date}</div>
-                <div className="text-xs text-green-600">Delivered</div>
-              </div>
-              <button className="text-xs" onClick={() => setReceipt(null)}>x</button>
-            </div>
+            <TransactionDetailsPopup tx={receipt} onClose={() => setReceipt(null)} />
           )}
         </div>
 
@@ -216,7 +209,7 @@ export default function Wallet() {
               ref={dateInputRef}
               value={filterDate}
               onChange={(e) => setFilterDate(e.target.value)}
-              className="border border-border rounded text-black text-xs px-1"
+              className="hidden"
             />
             <AiOutlineCalendar
               className="w-5 h-5 cursor-pointer"
@@ -240,6 +233,14 @@ export default function Wallet() {
             {filterType && (
               <button onClick={() => setFilterType('')} className="text-xs text-subtext">Clear</button>
             )}
+            <select
+              value={sortOrder}
+              onChange={(e) => setSortOrder(e.target.value)}
+              className="border border-border rounded text-black text-xs px-1"
+            >
+              <option value="desc">Newest</option>
+              <option value="asc">Oldest</option>
+            </select>
             <input
               type="text"
               placeholder="User or account"
@@ -253,7 +254,7 @@ export default function Wallet() {
           </div>
         </div>
         <div className="space-y-1 text-sm">
-          {filteredTransactions.map((tx, i) => (
+          {sortedTransactions.map((tx, i) => (
             <div
               key={i}
               className="flex justify-between border-b border-border pb-1 cursor-pointer hover:bg-white/10"


### PR DESCRIPTION
## Summary
- include user photo in by-account API
- show avatars and account numbers in transaction detail popup
- display receipt in detail popup when sending TPC
- simplify calendar filter and add sorting on transactions

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_6863953b04748329b0678de9fb03f069