### PR TITLE
Enhance transaction views

### DIFF
--- a/webapp/src/components/TransactionCard.jsx
+++ b/webapp/src/components/TransactionCard.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { getAvatarUrl } from '../utils/avatarUtils.js';
+
+export default function TransactionCard({ tx, profile, onClick }) {
+  if (!tx) return null;
+  const name = (
+    profile?.nickname || `${profile?.firstName || ''} ${profile?.lastName || ''}`.trim()
+  ).slice(0, 30);
+  const account = tx.type === 'send' ? tx.toAccount : tx.fromAccount;
+  const amountClass = tx.amount > 0 ? 'text-green-500' : 'text-red-500';
+  return (
+    <div
+      className="flex items-center space-x-2 border-b border-border pb-2 cursor-pointer hover:bg-white/10"
+      onClick={onClick}
+    >
+      {profile?.photo && (
+        <img
+          src={getAvatarUrl(profile.photo)}
+          alt=""
+          className="w-12 h-12 rounded-full object-cover"
+        />
+      )}
+      <div className="flex-1">
+        <div className="font-semibold">{name || 'Unknown'}</div>
+        <div className="text-xs text-subtext">Account: {account}</div>
+        <div className="text-xs text-subtext">{new Date(tx.date).toLocaleString()}</div>
+        {tx.hash && (
+          <div className="text-xs text-subtext break-all">{tx.hash}</div>
+        )}
+      </div>
+      <div className={amountClass}>{tx.amount}</div>
+    </div>
+  );
+}

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -6,31 +6,32 @@ import { getAvatarUrl } from '../utils/avatarUtils.js';
 export default function TransactionDetailsPopup({ tx, onClose }) {
   const [fromProfile, setFromProfile] = useState(null);
   const [toProfile, setToProfile] = useState(null);
-  const [otherName, setOtherName] = useState('');
+
   useEffect(() => {
     if (!tx) return;
     getLeaderboard().then((data) => {
       const users = data?.users || [];
       if (tx.fromAccount) {
-        const p = users.find((u) => u.accountId === tx.fromAccount);
-        setFromProfile(p || null);
-        if (!tx.fromName && p && (p.nickname || p.firstName || p.lastName)) {
-          setOtherName(
-            p.nickname || `${p.firstName || ''} ${p.lastName || ''}`.trim()
-          );
-        }
+        setFromProfile(users.find((u) => u.accountId === tx.fromAccount) || null);
       } else {
         setFromProfile(null);
       }
       if (tx.toAccount) {
-        const p = users.find((u) => u.accountId === tx.toAccount);
-        setToProfile(p || null);
+        setToProfile(users.find((u) => u.accountId === tx.toAccount) || null);
       } else {
         setToProfile(null);
       }
     });
   }, [tx]);
+
   if (!tx) return null;
+
+  const getName = (p) =>
+    (p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim()).slice(
+      0,
+      30,
+    );
+
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="bg-surface border border-border p-4 rounded space-y-2 text-text w-96 relative">
@@ -42,60 +43,66 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
         </button>
         <h3 className="text-lg font-bold text-center capitalize">{tx.type} details</h3>
         {(tx.type === 'send' || tx.type === 'receive') && (
-          <p className="text-sm text-center">
-            {tx.type === 'send' ? 'Sent' : 'Received'}{' '}
-            {Math.abs(tx.amount)} TPC{' '}
-            <img src="/icons/tpc.svg" alt="tpc" className="inline w-4 h-4" /> on{' '}
-            {new Date(tx.date).toLocaleDateString()} {' '}
-            {tx.type === 'send' ? 'to' : 'from'} account {tx.type === 'send' ? tx.toAccount : tx.fromAccount}{' '}
-            {(tx.type === 'send' ? toProfile : fromProfile) && (
-              <>
-                {' '}belonging to{' '}
-                {(tx.type === 'send' ? toProfile : fromProfile).nickname ||
-                  `${(tx.type === 'send' ? toProfile : fromProfile).firstName || ''} ${(tx.type === 'send' ? toProfile : fromProfile).lastName || ''}`.trim()}
-              </>
-            )}
-          </p>
+          <div className="space-y-2">
+            <div className="flex items-center space-x-2">
+              {(tx.type === 'send' ? toProfile : fromProfile)?.photo && (
+                <img
+                  src={getAvatarUrl((tx.type === 'send' ? toProfile : fromProfile).photo)}
+                  alt=""
+                  className="w-12 h-12 rounded-full object-cover"
+                />
+              )}
+              <div>
+                <div className="font-semibold">
+                  {tx.type === 'send' ? 'To: ' : 'From: '}
+                  {getName(tx.type === 'send' ? toProfile : fromProfile) ||
+                    (tx.type === 'send' ? tx.toName : tx.fromName)}
+                </div>
+                <div className="text-xs text-subtext">
+                  Account: TPC Account #{tx.type === 'send' ? tx.toAccount : tx.fromAccount}
+                </div>
+              </div>
+            </div>
+            <div className="flex justify-between">
+              <span>{tx.type === 'send' ? 'Amount Sent:' : 'Amount Received:'}</span>
+              <span>{Math.abs(tx.amount)} TPC</span>
+            </div>
+          </div>
         )}
-        <div className="text-sm space-y-2">
-          <div className="flex justify-between"><span>Amount:</span><span className={tx.amount >= 0 ? 'text-green-500' : 'text-red-500'}>{tx.amount}</span></div>
-          {tx.fromAccount && (
-            <div className="flex items-center space-x-2">
-              <span>From:</span>
-              <img src="/icons/tpc.svg" alt="tpc" className="w-4 h-4" />
-              {fromProfile?.photo && (
-                <img src={getAvatarUrl(fromProfile.photo)} alt="" className="w-6 h-6 rounded-full" />
-              )}
-              <div>
-                <div>{tx.fromName || fromProfile?.nickname || `${fromProfile?.firstName || ''} ${fromProfile?.lastName || ''}`.trim() || otherName}</div>
-                <div className="text-xs text-subtext">{tx.fromAccount}</div>
-              </div>
-            </div>
-          )}
-          {tx.toAccount && (
-            <div className="flex items-center space-x-2">
-              <span>To:</span>
-              <img src="/icons/tpc.svg" alt="tpc" className="w-4 h-4" />
-              {toProfile?.photo && (
-                <img src={getAvatarUrl(toProfile.photo)} alt="" className="w-6 h-6 rounded-full" />
-              )}
-              <div>
-                <div>{tx.toName || toProfile?.nickname || `${toProfile?.firstName || ''} ${toProfile?.lastName || ''}`.trim()}</div>
-                <div className="text-xs text-subtext">{tx.toAccount}</div>
-              </div>
-            </div>
-          )}
-          {tx.game && (
-            <div className="flex justify-between"><span>Game:</span><span>{tx.game}</span></div>
-          )}
-          {tx.players && (
-            <div className="flex justify-between"><span>Players:</span><span>{tx.players}</span></div>
-          )}
-          <div className="flex justify-between"><span>Date:</span><span>{new Date(tx.date).toLocaleString()}</span></div>
-          <div className="flex justify-between"><span>Status:</span><span>{tx.status}</span></div>
+        {tx.type !== 'send' && tx.type !== 'receive' && (
+          <div className="flex justify-between">
+            <span>Amount:</span>
+            <span className={tx.amount >= 0 ? 'text-green-500' : 'text-red-500'}>{tx.amount}</span>
+          </div>
+        )}
+        {tx.game && (
+          <div className="flex justify-between">
+            <span>Game:</span>
+            <span>{tx.game}</span>
+          </div>
+        )}
+        {tx.players && (
+          <div className="flex justify-between">
+            <span>Players:</span>
+            <span>{tx.players}</span>
+          </div>
+        )}
+        <div className="flex justify-between">
+          <span>Timestamp:</span>
+          <span>{new Date(tx.date).toLocaleString()}</span>
+        </div>
+        {tx.hash && (
+          <div className="flex justify-between">
+            <span>Tx Hash:</span>
+            <span className="break-all">{tx.hash}</span>
+          </div>
+        )}
+        <div className="flex justify-between">
+          <span>Status:</span>
+          <span>{tx.status}</span>
         </div>
       </div>
     </div>,
-    document.body
+    document.body,
   );
 }

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -5,7 +5,8 @@ import {
   fetchTelegramInfo,
   getReferralInfo,
   getTransactions,
-  linkGoogleAccount
+  linkGoogleAccount,
+  getLeaderboard
 } from '../utils/api.js';
 import {
   getTelegramId,
@@ -23,6 +24,7 @@ import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
 import InfoPopup from '../components/InfoPopup.jsx';
 import InboxWidget from '../components/InboxWidget.jsx';
 import TransactionDetailsPopup from '../components/TransactionDetailsPopup.jsx';
+import TransactionCard from '../components/TransactionCard.jsx';
 import { AiOutlineCalendar } from 'react-icons/ai';
 
 export default function MyAccount() {
@@ -46,6 +48,7 @@ export default function MyAccount() {
   const [filterDate, setFilterDate] = useState('');
   const [sortOrder, setSortOrder] = useState('desc');
   const [selectedTx, setSelectedTx] = useState(null);
+  const [users, setUsers] = useState([]);
   const dateInputRef = useRef(null);
 
   useEffect(() => {
@@ -88,6 +91,8 @@ export default function MyAccount() {
       setReferral(ref);
       const tx = await getTransactions(telegramId);
       setTransactions(tx.transactions || []);
+      const lb = await getLeaderboard();
+      setUsers(lb?.users || []);
 
       if (!data.photo || !data.firstName || !data.lastName) {
         setAutoUpdating(true);
@@ -294,20 +299,18 @@ export default function MyAccount() {
           <p className="text-sm text-subtext">No transactions</p>
         ) : (
           <div className="space-y-1 text-sm">
-            {sortedTransactions.map((tx, i) => (
-              <div
-                key={i}
-                className="flex justify-between border-b border-border pb-1 cursor-pointer hover:bg-white/10"
-                onClick={() => setSelectedTx(tx)}
-              >
-                <span className="capitalize">{tx.type}</span>
-                <span className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
-                  {tx.amount}
-                </span>
-                <span>{new Date(tx.date).toLocaleString()}</span>
-                <span className="text-xs">{tx.status}</span>
-              </div>
-            ))}
+            {sortedTransactions.map((tx, i) => {
+              const acc = tx.type === 'send' ? tx.toAccount : tx.fromAccount;
+              const prof = users.find((u) => u.accountId === acc);
+              return (
+                <TransactionCard
+                  key={i}
+                  tx={tx}
+                  profile={prof}
+                  onClick={() => setSelectedTx(tx)}
+                />
+              );
+            })}
           </div>
         )}
       </div>

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -4,12 +4,14 @@ import {
   createAccount,
   getAccountBalance,
   sendAccountTpc,
-  getAccountTransactions
+  getAccountTransactions,
+  getLeaderboard
 } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import ConfirmPopup from '../components/ConfirmPopup.jsx';
 import InfoPopup from '../components/InfoPopup.jsx';
 import TransactionDetailsPopup from '../components/TransactionDetailsPopup.jsx';
+import TransactionCard from '../components/TransactionCard.jsx';
 import { AiOutlineCalendar } from 'react-icons/ai';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 
@@ -36,6 +38,7 @@ export default function Wallet() {
   const [filterUser, setFilterUser] = useState('');
   const [sortOrder, setSortOrder] = useState('desc');
   const [selectedTx, setSelectedTx] = useState(null);
+  const [users, setUsers] = useState([]);
   const dateInputRef = useRef(null);
 
   const txTypes = Array.from(new Set(transactions.map((t) => t.type))).filter(
@@ -74,6 +77,8 @@ export default function Wallet() {
       if (id) {
         const txRes = await getAccountTransactions(id);
         setTransactions(txRes.transactions || []);
+        const lb = await getLeaderboard();
+        setUsers(lb?.users || []);
       }
     });
   }, []);
@@ -125,9 +130,19 @@ export default function Wallet() {
     if (filterType && tx.type !== filterType) return false;
     if (filterUser) {
       const q = filterUser.toLowerCase();
-      const name = (tx.fromName || tx.toName || '').toLowerCase();
       const account = tx.fromAccount || tx.toAccount || '';
-      if (!name.includes(q) && !String(account).includes(q)) return false;
+      const name = (tx.fromName || tx.toName || '').toLowerCase();
+      const prof = users.find((u) => u.accountId === account);
+      const lbName = prof
+        ? (prof.nickname || `${prof.firstName || ''} ${prof.lastName || ''}`)
+            .toLowerCase()
+        : '';
+      if (
+        !name.includes(q) &&
+        !lbName.includes(q) &&
+        !String(account).includes(q)
+      )
+        return false;
     }
     return true;
   });
@@ -254,20 +269,18 @@ export default function Wallet() {
           </div>
         </div>
         <div className="space-y-1 text-sm">
-          {sortedTransactions.map((tx, i) => (
-            <div
-              key={i}
-              className="flex justify-between border-b border-border pb-1 cursor-pointer hover:bg-white/10"
-              onClick={() => setSelectedTx(tx)}
-            >
-              <span className="capitalize">{tx.type}</span>
-              <span className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
-                {tx.amount}
-              </span>
-              <span>{new Date(tx.date).toLocaleString()}</span>
-              <span className="text-xs">{tx.status}</span>
-            </div>
-          ))}
+          {sortedTransactions.map((tx, i) => {
+            const acc = tx.type === 'send' ? tx.toAccount : tx.fromAccount;
+            const prof = users.find((u) => u.accountId === acc);
+            return (
+              <TransactionCard
+                key={i}
+                tx={tx}
+                profile={prof}
+                onClick={() => setSelectedTx(tx)}
+              />
+            );
+          })}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- fetch leaderboard info when displaying wallet or account transactions
- show user info and tx hash in the details popup
- create `TransactionCard` for transaction rows
- display profile, account, timestamp and amount on transaction cards

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_6863aac9575483298984a648bc0ffe89