### PR TITLE
Enable account-based avatars in Snake multiplayer

### DIFF
--- a/bot/routes/mining.js
+++ b/bot/routes/mining.js
@@ -46,7 +46,7 @@ router.post('/status', getUser, async (req, res) => {
 });
 
 router.post('/leaderboard', async (req, res) => {
-  const { telegramId } = req.body;
+  const { telegramId, accountId } = req.body || {};
   const users = await User.find()
     .sort({ balance: -1 })
     .limit(100)
@@ -75,8 +75,9 @@ router.post('/leaderboard', async (req, res) => {
   );
 
   let rank = null;
-  if (telegramId) {
-    const user = await User.findOne({ telegramId });
+  const queryId = telegramId ? { telegramId } : accountId ? { accountId } : null;
+  if (queryId) {
+    const user = await User.findOne(queryId);
     if (user) {
       rank = (await User.countDocuments({ balance: { $gt: user.balance } })) + 1;
     }

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -62,10 +62,12 @@ export function claimMining(telegramId) {
 
 }
 
-export function getLeaderboard(telegramId) {
-
-  return post('/api/mining/leaderboard', { telegramId });
-
+export function getLeaderboard(id) {
+  let body;
+  if (typeof id === 'object') body = id;
+  else if (typeof id === 'string' && id.includes('-')) body = { accountId: id };
+  else body = { telegramId: id };
+  return post("/api/mining/leaderboard", body);
 }
 
 export function listTasks(telegramId) {


### PR DESCRIPTION
## Summary
- support accountId in leaderboard API
- fetch multiplayer profile info from leaderboard
- remove Telegram-based avatar lookups

## Testing
- `npm test` *(fails: mongoose missing)*

------
https://chatgpt.com/codex/tasks/task_e_6863b0ecf67c832981fb8bfa27f70bbb