### PR TITLE
Fix transaction details lookup

### DIFF
--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -8,11 +8,16 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
 
   useEffect(() => {
     if (!tx) return;
-    getLeaderboard().then((data) => {
+    const account = tx.type === 'send' ? tx.toAccount : tx.fromAccount;
+    if (!account) {
+      setCounterparty(null);
+      return;
+    }
+    setCounterparty(null);
+    getLeaderboard({ accountId: account }).then((data) => {
       const users = data?.users || [];
-      const account = tx.type === 'send' ? tx.toAccount : tx.fromAccount;
-      const profile = users.find((u) => u.accountId === account);
-      setCounterparty(profile || null);
+      const profile = users.find((u) => u.accountId === account) || null;
+      setCounterparty(profile);
     });
   }, [tx]);
 

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -298,7 +298,7 @@ export default function MyAccount() {
               <div
                 key={i}
                 className="flex justify-between border-b border-border pb-1 cursor-pointer hover:bg-white/10"
-                onClick={() => setSelectedTx(tx)}
+              onClick={() => setSelectedTx({ ...tx })}
               >
                 <span className="capitalize">{tx.type}</span>
                 <span className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -258,7 +258,7 @@ export default function Wallet() {
             <div
               key={i}
               className="flex justify-between border-b border-border pb-1 cursor-pointer hover:bg-white/10"
-              onClick={() => setSelectedTx(tx)}
+              onClick={() => setSelectedTx({ ...tx })}
             >
               <span className="capitalize">{tx.type}</span>
               <span className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>


### PR DESCRIPTION
## Summary
- fetch leaderboard info for the transaction counterparty using account id
- ensure selected transaction is copied before opening modal

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_6863b77114488329a2d37d4130069e19