### PR TITLE
Fix account number display

### DIFF
--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { v4 as uuidv4 } from 'uuid';
 import User from '../models/User.js';
 import { fetchTelegramInfo } from '../utils/telegram.js';
 import { ensureTransactionArray } from '../utils/userUtils.js';
@@ -72,6 +73,11 @@ router.post('/get', async (req, res) => {
       update,
       { upsert: true, new: true }
     );
+  }
+
+  if (!user.accountId) {
+    user.accountId = uuidv4();
+    await user.save();
   }
 
   res.json({ ...user.toObject(), filledFromTelegram });

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -44,9 +44,9 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
         <h3 className="text-lg font-bold text-center">Transaction Details</h3>
         <div className="flex flex-col items-center space-y-2">
           <div className="flex items-center space-x-2">
-            <img src={icon} alt={token} className="w-5 h-5" />
-            <span className="font-semibold">
-              {isSend ? 'Sent' : 'Received'} {Math.abs(tx.amount)} {token}
+            <span className="font-semibold flex items-center space-x-1">
+              {isSend ? 'Sent' : 'Received'} {Math.abs(tx.amount)}
+              <img src={icon} alt={token} className="w-5 h-5 inline" />
             </span>
           </div>
           {counterparty && (

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -24,6 +24,7 @@ import InfoPopup from '../components/InfoPopup.jsx';
 import InboxWidget from '../components/InboxWidget.jsx';
 import TransactionDetailsPopup from '../components/TransactionDetailsPopup.jsx';
 import { AiOutlineCalendar } from 'react-icons/ai';
+import { FiCopy } from 'react-icons/fi';
 
 export default function MyAccount() {
   useTelegramBackButton();
@@ -200,7 +201,13 @@ export default function MyAccount() {
           <p className="font-semibold">
             {profile.firstName} {profile.lastName}
           </p>
-          <p className="text-sm text-subtext">Account: {profile.accountId}</p>
+          <div className="text-sm text-subtext flex items-center space-x-1">
+            <span>Account: {profile.accountId}</span>
+            <FiCopy
+              className="w-4 h-4 cursor-pointer"
+              onClick={() => navigator.clipboard.writeText(String(profile.accountId))}
+            />
+          </div>
           <button
             onClick={() => setShowAvatarPicker(true)}
             className="mt-2 px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm"


### PR DESCRIPTION
## Summary
- ensure accountId exists when fetching profile
- show token icon in transaction details without text
- add copy button for account number

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_6863d0778a3c8329a21a49357c9acec3