### PR TITLE
Add account number to transaction popup

### DIFF
--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -43,12 +43,17 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
         </button>
         <h3 className="text-lg font-bold text-center">Transaction Details</h3>
         <div className="flex flex-col items-center space-y-2">
-          <div className="flex items-center space-x-2">
-            <span className="font-semibold flex items-center space-x-1">
-              {isSend ? 'Sent' : 'Received'} {Math.abs(tx.amount)}
-              <img src={icon} alt={token} className="w-5 h-5 inline" />
+        <div className="flex items-center space-x-2">
+          <span className="font-semibold flex items-center space-x-1">
+            {isSend ? 'Sent' : 'Received'} {Math.abs(tx.amount)}
+            <img src={icon} alt={token} className="w-5 h-5 inline" />
+          </span>
+          {account && (
+            <span className="text-xs text-subtext">
+              {isSend ? 'to' : 'from'} account #{account}
             </span>
-          </div>
+          )}
+        </div>
           {counterparty && (
             <div className="flex items-center space-x-2">
               {counterparty.photo && (


### PR DESCRIPTION
## Summary
- display the account number next to the amount in TransactionDetailsPopup

## Testing
- `npm test` *(fails: cannot find package 'socket.io-client' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6863ea04858c83299d2335c9e4d6391a