### PR TITLE
Update wallet and transaction popup styling

### DIFF
--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { FiCopy } from 'react-icons/fi';
-import { getLeaderboard } from '../utils/api.js';
+import { getProfileByAccount } from '../utils/api.js';
 import { getAvatarUrl } from '../utils/avatarUtils.js';
 
 export default function TransactionDetailsPopup({ tx, onClose }) {
@@ -9,12 +9,14 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
 
   useEffect(() => {
     if (!tx) return;
-    getLeaderboard().then((data) => {
-      const users = data?.users || [];
-      const account = tx.type === 'send' ? tx.toAccount : tx.fromAccount;
-      const profile = users.find((u) => u.accountId === account);
-      setCounterparty(profile || null);
-    });
+    const account = tx.type === 'send' ? tx.toAccount : tx.fromAccount;
+    if (!account) {
+      setCounterparty(null);
+      return;
+    }
+    getProfileByAccount(account)
+      .then((profile) => setCounterparty(profile || null))
+      .catch(() => setCounterparty(null));
   }, [tx]);
 
   if (!tx) return null;
@@ -34,7 +36,7 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
 
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
-      <div className="bg-surface border border-border p-4 rounded space-y-4 text-text w-80 relative">
+      <div className="p-4 space-y-4 w-80 relative rounded-xl border-2 border-[#334155] bg-[#2d5c66] text-white">
         <button
           onClick={onClose}
           className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -141,7 +141,12 @@ export default function Wallet() {
 
 
   return (
-    <div className="p-4 space-y-4">
+    <div className="relative p-4 space-y-4 text-text">
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+      />
       <h2 className="text-xl font-bold">Wallet</h2>
       <p className="text-sm">Account #{accountId || '...'}</p>
 
@@ -257,14 +262,14 @@ export default function Wallet() {
           {sortedTransactions.map((tx, i) => (
             <div
               key={i}
-              className="flex justify-between border-b border-border pb-1 cursor-pointer hover:bg-white/10"
+              className="lobby-tile w-full flex justify-between items-center cursor-pointer"
               onClick={() => setSelectedTx(tx)}
             >
               <span className="capitalize">{tx.type}</span>
               <span className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
                 {tx.amount} {(tx.token || 'TPC').toUpperCase()}
               </span>
-              <span>{new Date(tx.date).toLocaleString()}</span>
+              <span className="text-xs">{new Date(tx.date).toLocaleString()}</span>
               <span className="text-xs">{tx.status}</span>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- enhance `TransactionDetailsPopup` by loading profile data directly via `getProfileByAccount`
- restyle the transaction popup to use the task colors
- apply game-style background to the Wallet page
- style wallet transaction list with the same colors as tasks

## Testing
- `npm test` *(fails: Cannot find packages `socket.io-client`, `mongoose`, `dotenv`)*

------
https://chatgpt.com/codex/tasks/task_e_6863f1d4989c8329a5bfaa619b602110