### PR TITLE
Implement timer countdown with auto roll

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import { getAvatarUrl } from '../utils/avatarUtils.js';
 
-export default function AvatarTimer({ photoUrl, active = false, timerPct = 1, rank, name, isTurn = false, color }) {
+export default function AvatarTimer({
+  photoUrl,
+  active = false,
+  timerPct = 1,
+  rank,
+  name,
+  isTurn = false,
+  color,
+  secondsLeft,
+}) {
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
   return (
@@ -18,8 +27,9 @@ export default function AvatarTimer({ photoUrl, active = false, timerPct = 1, ra
           boxShadow: isTurn ? `0 0 6px ${color || '#fde047'}` : undefined,
         }}
       />
-      {isTurn && (
-        <span className="turn-indicator">👈</span>
+      {isTurn && <span className="turn-indicator">👈</span>}
+      {isTurn && secondsLeft != null && (
+        <span className="timer-count">{secondsLeft}</span>
       )}
       {rank != null && (
         <span className="rank-number">{rank}</span>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -363,6 +363,17 @@ body {
   pointer-events: none;
 }
 
+.timer-count {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 0.65rem;
+  font-weight: bold;
+  color: white;
+  pointer-events: none;
+}
+
 .token-cube-inner {
   position: relative;
   width: 100%;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1428,21 +1428,29 @@ export default function SnakeAndLadder() {
 
   useEffect(() => {
     if (setupPhase || gameOver || moving) return;
-    if (currentTurn !== 0) {
+
+    const myIndex = isMultiplayer
+      ? mpPlayers.findIndex((p) => p.id === getPlayerId())
+      : 0;
+
+    if (currentTurn !== myIndex) {
       setTimeLeft(15);
       if (timerRef.current) clearInterval(timerRef.current);
       timerRef.current = setInterval(() => {
         setTimeLeft((t) => Math.max(0, t - 1));
       }, 1000);
-      if (aiRollTimeoutRef.current) clearTimeout(aiRollTimeoutRef.current);
-      aiRollTimeoutRef.current = setTimeout(() => {
-        triggerAIRoll(currentTurn);
-      }, 2000);
+      if (!isMultiplayer) {
+        if (aiRollTimeoutRef.current) clearTimeout(aiRollTimeoutRef.current);
+        aiRollTimeoutRef.current = setTimeout(() => {
+          triggerAIRoll(currentTurn);
+        }, 2000);
+      }
       return () => {
         clearInterval(timerRef.current);
         clearTimeout(aiRollTimeoutRef.current);
       };
     }
+
     const limit = 15;
     setTimeLeft(limit);
     if (timerRef.current) clearInterval(timerRef.current);
@@ -1450,7 +1458,7 @@ export default function SnakeAndLadder() {
     timerRef.current = setInterval(() => {
       setTimeLeft((t) => {
         const next = t - 1;
-        if (currentTurn === 0 && next <= 7 && next >= 0 && timerSoundRef.current) {
+        if (next <= 7 && next >= 0 && timerSoundRef.current) {
           timerSoundRef.current.currentTime = 0;
           if (!muted) timerSoundRef.current.play().catch(() => {});
         }
@@ -1468,7 +1476,7 @@ export default function SnakeAndLadder() {
       clearInterval(timerRef.current);
       timerSoundRef.current?.pause();
     };
-  }, [currentTurn, setupPhase, gameOver, refreshTick, moving]);
+  }, [currentTurn, setupPhase, gameOver, refreshTick, moving, isMultiplayer, mpPlayers]);
 
   // Periodically refresh the component state to avoid freezes
   useEffect(() => {
@@ -1543,6 +1551,7 @@ export default function SnakeAndLadder() {
                   ? timeLeft / 15
                   : 1
               }
+              secondsLeft={p.index === currentTurn ? timeLeft : undefined}
               color={p.color}
             />
           ))}


### PR DESCRIPTION
## Summary
- show remaining time on AvatarTimer component
- play countdown sound for last seconds regardless of player order
- disable AI roll trigger in multiplayer mode
- display numeric timer beside active avatar

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_68640036b2888329ae40d54899ba7acd