### PR TITLE
Update snake timer behavior

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -9,7 +9,6 @@ export default function AvatarTimer({
   name,
   isTurn = false,
   color,
-  secondsLeft,
 }) {
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
@@ -28,9 +27,6 @@ export default function AvatarTimer({
         }}
       />
       {isTurn && <span className="turn-indicator">👈</span>}
-      {isTurn && secondsLeft != null && (
-        <span className="timer-count">{secondsLeft}</span>
-      )}
       {rank != null && (
         <span className="rank-number">{rank}</span>
       )}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1551,7 +1551,6 @@ export default function SnakeAndLadder() {
                   ? timeLeft / 15
                   : 1
               }
-              secondsLeft={p.index === currentTurn ? timeLeft : undefined}
               color={p.color}
             />
           ))}


### PR DESCRIPTION
## Summary
- drop numeric timer from snake and ladder avatars
- keep timer ring only
- adjust avatar timer usage

## Testing
- `npm test` *(fails: snake API endpoints run but summary not produced)*

------
https://chatgpt.com/codex/tasks/task_e_686406929d708329a7d5a7f162744837