### PR TITLE
Fix duplicate wallet heading

### DIFF
--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -167,7 +167,6 @@ export default function Wallet() {
 
       {/* TPC account section */}
       <div className="space-y-2 border-b border-border pb-4">
-        <h3 className="text-lg font-semibold">TPC Account Wallet</h3>
         <p className="flex items-center justify-center text-lg font-medium mb-4">
           <img src="/icons/TPCcoin.png" alt="TPC" className="w-5 h-5 mr-1" />
           TPC Balance:&nbsp;


### PR DESCRIPTION
## Summary
- remove redundant `TPC Account Wallet` heading in wallet page

## Testing
- `npm test` *(fails: cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_686410ecba50832990ca9dcc64174764