### PR TITLE
Adjust AI roll timer

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -972,7 +972,7 @@ export default function SnakeAndLadder() {
         }
       }
       turn = (turn + 1) % (ai + 1);
-      elapsed -= 2000;
+      elapsed -= 2500;
     }
     setPos(p);
     setAiPositions(aiPos);
@@ -1443,7 +1443,7 @@ export default function SnakeAndLadder() {
         if (aiRollTimeoutRef.current) clearTimeout(aiRollTimeoutRef.current);
         aiRollTimeoutRef.current = setTimeout(() => {
           triggerAIRoll(currentTurn);
-        }, 2000);
+        }, 2500);
       }
       return () => {
         clearInterval(timerRef.current);


### PR DESCRIPTION
## Summary
- tweak AI autoplay delay to 2.5 seconds
- keep game state fast-forward logic consistent with new delay

## Testing
- `npm test` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6864311f10c48329b0e734463f42f0e5