### PR TITLE
Update wallet frames

### DIFF
--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -174,7 +174,7 @@ export default function Wallet() {
           TPC Balance:&nbsp;
           {tpcBalance === null ? '...' : formatValue(tpcBalance, 2)}
         </p>
-        <div className="prism-box p-4 space-y-2 text-center mb-4">
+        <div className="prism-box p-6 space-y-3 text-center mb-4 flex flex-col items-center w-80 mx-auto">
           <label className="block font-semibold">Send TPC</label>
           <input
             type="text"
@@ -207,7 +207,7 @@ export default function Wallet() {
           )}
         </div>
 
-        <div className="prism-box p-4 space-y-2 text-center mt-4 mb-4">
+        <div className="prism-box p-6 space-y-3 text-center mt-4 mb-4 flex flex-col items-center w-80 mx-auto">
           <label className="block font-semibold">Receive TPC</label>
           <button
             onClick={() => navigator.clipboard.writeText(String(accountId))}


### PR DESCRIPTION
## Summary
- enlarge send and receive boxes on Wallet page so text and button fit centered

## Testing
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686432e42aec8329a60bf15dc359a542