### PR TITLE
Update wallet layout and background

### DIFF
--- a/webapp/src/components/CosmicBackground.jsx
+++ b/webapp/src/components/CosmicBackground.jsx
@@ -14,6 +14,10 @@ export default function CosmicBackground() {
 
     const stars = [];
     const comets = [];
+    const storms = [
+      { x: 0.35, y: 0.4, r: 160, angle: 0, color: 'rgba(20,40,80,0.5)' },
+      { x: 0.75, y: 0.6, r: 120, angle: 0, color: 'rgba(180,60,20,0.4)' },
+    ];
 
     const dpr = window.devicePixelRatio || 1;
     let width = window.innerWidth;
@@ -38,6 +42,10 @@ export default function CosmicBackground() {
           colorChange: i < 2,
         });
       }
+      storms[0].x = width * 0.35;
+      storms[0].y = height * 0.4;
+      storms[1].x = width * 0.75;
+      storms[1].y = height * 0.6;
     };
 
     const resize = () => initScene();
@@ -84,6 +92,21 @@ export default function CosmicBackground() {
         c.y += c.vy;
         if (c.y > height || c.x > width) comets.splice(i, 1);
       }
+
+      storms.forEach((s) => {
+        ctx.save();
+        ctx.translate(s.x, s.y);
+        ctx.rotate(s.angle);
+        const grad = ctx.createRadialGradient(0, 0, 0, 0, 0, s.r);
+        grad.addColorStop(0, s.color);
+        grad.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.fillStyle = grad;
+        ctx.beginPath();
+        ctx.arc(0, 0, s.r, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+        s.angle += 0.0015;
+      });
 
       frameId = requestAnimationFrame(draw);
     };

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -160,7 +160,7 @@ export default function Wallet() {
   return (
     <div className="relative p-4 space-y-4 text-text">
       <h2 className="text-xl font-bold text-center">TPC Account Wallet</h2>
-      <div className="prism-box p-4 space-y-2 text-center w-96 mx-auto bg-[#2d5c66] border-[#334155]">
+      <div className="prism-box p-4 space-y-2 text-center w-80 mx-auto bg-[#2d5c66] border-[#334155]">
         <p className="text-sm break-all">Account #{accountId || '...'}</p>
         <p className="flex items-center justify-center text-lg font-medium">
           <img src="/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 mr-1" />
@@ -274,7 +274,7 @@ export default function Wallet() {
             )}
           </div>
         </div>
-        <div className="space-y-1 text-sm max-h-[30rem] overflow-y-auto border border-border rounded">
+        <div className="space-y-1 text-sm max-h-60 overflow-y-auto border border-border rounded">
           {sortedTransactions.slice(0, 20).map((tx, i) => (
             <div
               key={i}


### PR DESCRIPTION
## Summary
- keep wallet balance frame same size as send form
- keep transaction list fixed and scrollable
- add cosmic storm effects to cosmic backdrop

## Testing
- `npm test` *(fails: snake API endpoints and socket events)*

------
https://chatgpt.com/codex/tasks/task_e_686451eca9788329b428f36415ecf293