### PR TITLE
Update wallet page layout

### DIFF
--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -160,7 +160,7 @@ export default function Wallet() {
   return (
     <div className="relative p-4 space-y-4 text-text">
       <h2 className="text-xl font-bold text-center">TPC Account Wallet</h2>
-      <div className="prism-box p-4 space-y-2 text-center w-80 mx-auto bg-[#2d5c66] border-[#334155]">
+      <div className="prism-box p-6 space-y-3 text-center w-80 mx-auto border-[#334155]">
         <p className="text-sm break-all">Account #{accountId || '...'}</p>
         <p className="flex items-center justify-center text-lg font-medium">
           <img src="/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 mr-1" />
@@ -171,7 +171,7 @@ export default function Wallet() {
 
       {/* TPC account section */}
       <div className="space-y-2 border-b border-border pb-4">
-        <div className="prism-box p-6 space-y-3 text-center mb-4 flex flex-col items-center w-80 mx-auto bg-[#2d5c66] border-[#334155]">
+        <div className="prism-box p-6 space-y-3 text-center mb-4 flex flex-col items-center w-80 mx-auto border-[#334155]">
           <label className="block font-semibold">Send TPC</label>
           <input
             type="text"
@@ -204,7 +204,7 @@ export default function Wallet() {
           )}
         </div>
 
-        <div className="prism-box p-6 space-y-3 text-center mt-4 mb-4 flex flex-col items-center w-80 mx-auto bg-[#2d5c66] border-[#334155]">
+        <div className="prism-box p-6 space-y-3 text-center mt-4 mb-4 flex flex-col items-center w-80 mx-auto border-[#334155]">
           <label className="block font-semibold">Receive TPC</label>
           <button
             onClick={() => navigator.clipboard.writeText(String(accountId))}
@@ -221,7 +221,7 @@ export default function Wallet() {
       </div>
 
 
-      <div className="prism-box p-4 space-y-2 text-center mt-4 flex flex-col items-center w-80 mx-auto bg-[#2d5c66] border-[#334155]">
+      <div className="prism-box p-4 space-y-2 text-center mt-4 flex flex-col items-center w-80 mx-auto border-[#334155]">
         <h3 className="font-semibold text-center">Transactions</h3>
         <div className="flex items-center justify-center">
           <div className="flex items-center space-x-1 flex-wrap justify-center">
@@ -274,7 +274,7 @@ export default function Wallet() {
             )}
           </div>
         </div>
-        <div className="space-y-1 text-sm max-h-60 overflow-y-auto border border-border rounded">
+        <div className="space-y-1 text-sm max-h-[30rem] overflow-y-auto border border-border rounded">
           {sortedTransactions.slice(0, 20).map((tx, i) => (
             <div
               key={i}


### PR DESCRIPTION
## Summary
- match padding for TPC balance box to Send TPC form
- remove teal backgrounds from wallet boxes
- double transaction list height

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_6864aebb9660832981a64a198164a839