### PR TITLE
Fix Wallet balance box height

### DIFF
--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -160,7 +160,7 @@ export default function Wallet() {
   return (
     <div className="relative p-4 space-y-4 text-text">
       <h2 className="text-xl font-bold text-center">TPC Account Wallet</h2>
-      <div className="prism-box p-6 space-y-2 text-center w-80 mx-auto border-[#334155]">
+      <div className="prism-box p-6 space-y-2 text-center w-80 mx-auto border-[#334155] min-h-40">
         <p className="text-sm break-all">Account {accountId || '...'}</p>
         <p className="flex items-center justify-center text-lg font-medium">
           <img src="/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 mr-1" />
@@ -171,7 +171,7 @@ export default function Wallet() {
 
       {/* TPC account section */}
       <div className="space-y-2 border-b border-border pb-4">
-        <div className="prism-box p-6 space-y-3 text-center mb-4 flex flex-col items-center w-80 mx-auto border-[#334155]">
+        <div className="prism-box p-6 space-y-3 text-center mb-4 flex flex-col items-center w-80 mx-auto border-[#334155] min-h-40">
           <label className="block font-semibold">Send TPC</label>
           <input
             type="text"


### PR DESCRIPTION
## Summary
- keep the TPC balance frame the same height as the Send TPC frame by applying a `min-h-40` class to both sections

## Testing
- `npm test` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_6864b4ef7f9c83299592ceb1e0e901f8