### PR TITLE
Fix wallet balance layout

### DIFF
--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -164,9 +164,7 @@ export default function Wallet() {
         <p className="text-sm break-all">Account {accountId || '...'}</p>
         <p className="flex items-center justify-center text-lg font-medium">
           <img src="/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 mr-1" />
-          TPC Balance:
-        </p>
-        <p className="text-lg font-medium">
+          TPC Balance:&nbsp;
           {tpcBalance === null ? '...' : formatValue(tpcBalance, 2)}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- revert TPC Balance layout so icon and value sit on the same line

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_6864bedeabb48329a0b7043a04aff31f