### PR TITLE
Replace cosmic background with animated sky

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -14,6 +14,7 @@ import Branding from './Branding.jsx';
 
 import CosmicBackground from './CosmicBackground.jsx';
 import DynamicBackground from './DynamicBackground.jsx';
+import SkyBackground from './SkyBackground.jsx';
 
 export default function Layout({ children }) {
   const location = useLocation();
@@ -66,7 +67,8 @@ export default function Layout({ children }) {
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
 
       {isHome && <DynamicBackground />}
-      {(isHome || isWallet) && <CosmicBackground />}
+      {isHome && <SkyBackground />}
+      {isWallet && <CosmicBackground />}
 
       <main className={`flex-grow container mx-auto p-4 ${showNavbar ? 'pb-24' : ''}`.trim()}>
 

--- a/webapp/src/components/SkyBackground.jsx
+++ b/webapp/src/components/SkyBackground.jsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+
+export default function SkyBackground() {
+  const planes = useRef([]);
+
+  useEffect(() => {
+    const elems = planes.current;
+    elems.forEach((plane, i) => {
+      const startY = i % 2 === 0 ? '30vh' : '60vh';
+      plane.style.top = startY;
+      plane.style.left = '-50px';
+      plane.style.animation = `fly-${i} 20s linear infinite`;
+    });
+  }, []);
+
+  return (
+    <div className="sky-container fixed inset-0 -z-10 pointer-events-none overflow-hidden">
+      <div className="sky-background absolute inset-0" />
+      {[0, 1].map((n) => (
+        <div
+          key={n}
+          ref={(el) => (planes.current[n] = el)}
+          className="plane absolute text-3xl"
+          aria-label="airplane"
+        >
+          ✈
+          <div className="trail left"></div>
+          <div className="trail right"></div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1072,3 +1072,71 @@ body {
 .weather-bg.mist {
   background: linear-gradient(#e2e8f0, #94a3b8);
 }
+
+/* Sky background with animated planes */
+.sky-background {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, #99caff 0%, #eaf6ff 80%);
+}
+.sky-background::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(255, 255, 255, 0.8) 0%, rgba(255, 255, 255, 0) 60%),
+    radial-gradient(circle at 70% 30%, rgba(255, 255, 255, 0.7) 0%, rgba(255, 255, 255, 0) 60%),
+    radial-gradient(circle at 50% 80%, rgba(255, 255, 255, 0.6) 0%, rgba(255, 255, 255, 0) 60%);
+  background-size: 200% 100%;
+  animation: clouds-move 60s linear infinite;
+}
+.plane {
+  transform: translateX(-50px);
+}
+.plane .trail {
+  position: absolute;
+  top: 45%;
+  width: 2px;
+  height: 60px;
+  background: rgba(255, 255, 255, 0.7);
+  animation: trail-fade 20s linear infinite;
+}
+.plane .trail.left {
+  left: -4px;
+}
+.plane .trail.right {
+  right: -4px;
+}
+@keyframes trail-fade {
+  0% {
+    opacity: 0.7;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+@keyframes fly-0 {
+  from {
+    transform: translateX(-50px);
+  }
+  to {
+    transform: translateX(110vw);
+  }
+}
+@keyframes fly-1 {
+  from {
+    transform: translateX(-50px);
+  }
+  to {
+    transform: translateX(110vw);
+  }
+}
+
+@keyframes clouds-move {
+  from {
+    background-position: 0 0, 0 0, 0 0;
+  }
+  to {
+    background-position: -400px 0, 400px 0, -200px 0;
+  }
+}


### PR DESCRIPTION
## Summary
- remove binary sky image
- render new CSS-based sky background with moving clouds
- show planes with trails on the homepage

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_6864c3d79db48329a769224fa3310821