### PR TITLE
Update default theme colors

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1052,7 +1052,8 @@ body {
   background: linear-gradient(#87ceeb, #fefefe);
 }
 .weather-bg.clear.night {
-  background: linear-gradient(#001d3d, #111);
+  /* Dark purple night sky */
+  background: linear-gradient(#001d3d, #1a082c);
 }
 .weather-bg.clouds.day {
   background: linear-gradient(#cbd5e1, #94a3b8);

--- a/webapp/tailwind.config.js
+++ b/webapp/tailwind.config.js
@@ -7,9 +7,9 @@ export default {
     extend: {
       colors: {
         // TonPlaygram premium theme
-        background: '#0b0f19',        // Page background
-        surface: '#11172a',           // Cards, panels
-        border: '#27272a',            // Dividers/borders
+        background: '#1a082c',        // Page background (dark purple)
+        surface: '#14213d',           // Cards, panels (dark blue)
+        border: '#334155',            // Dividers/borders (dark blue)
         primary: '#2563eb',           // Button base (TON blue)
         'primary-hover': '#1d4ed8',   // Button hover
         text: '#ffffff',              // Main text


### PR DESCRIPTION
## Summary
- adjust color palette to use dark purple backgrounds
- switch frames to dark blue
- tweak night weather gradient for new palette

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864db5e95d48329a64cc923454b0666