### PR TITLE
Apply neon theme

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -11,6 +11,33 @@
 body {
   font-family: Arial, Helvetica, sans-serif;
   @apply bg-background text-text overflow-x-hidden;
+  text-shadow: 0 0 4px #00f7ff;
+}
+
+/* Neon theme elements */
+.border-border {
+  box-shadow: 0 0 8px #00f7ff;
+}
+
+.bg-surface {
+  box-shadow: inset 0 0 10px rgba(0, 247, 255, 0.4);
+}
+
+.text-text {
+  text-shadow: 0 0 4px #00f7ff;
+}
+
+button,
+input {
+  border-color: #00f7ff;
+  color: #00f7ff;
+  box-shadow: 0 0 6px rgba(0, 247, 255, 0.6);
+}
+
+button:focus,
+input:focus {
+  outline: none;
+  box-shadow: 0 0 10px #00f7ff;
 }
 
 .hexagon {

--- a/webapp/tailwind.config.js
+++ b/webapp/tailwind.config.js
@@ -6,18 +6,18 @@ export default {
   theme: {
     extend: {
       colors: {
-        // TonPlaygram premium theme
-        background: '#1a082c',        // Page background (dark purple)
-        surface: '#14213d',           // Cards, panels (dark blue)
-        border: '#334155',            // Dividers/borders (dark blue)
-        primary: '#2563eb',           // Button base (TON blue)
-        'primary-hover': '#1d4ed8',   // Button hover
-        text: '#ffffff',              // Main text
-        subtext: '#94a3b8',           // Dimmed/inactive text
-        accent: '#facc15',            // Highlights (yellow/gold)
+        // Futuristic neon theme
+        background: '#050f1a',        // Dark navy background
+        surface: '#050f1a',           // Panels use same dark tone
+        border: '#00f7ff',            // Glowing cyan borders
+        primary: '#00f7ff',           // Button base in electric blue
+        'primary-hover': '#66fcff',   // Lighter hover effect
+        text: '#00f7ff',              // Electric blue text
+        subtext: '#66fcff',           // Slightly dimmed blue
+        accent: '#00f7ff',            // Accent color
         brand: {
-          gold: '#f1c40f',            // Optional brand gold
-          black: '#000000'            // Contrast color
+          gold: '#00f7ff',            // Not used but keep scheme consistent
+          black: '#000000'
         }
       }
     }


### PR DESCRIPTION
## Summary
- apply neon blue palette in Tailwind configuration
- add global glow styles for borders, text and inputs

## Testing
- `npm test` *(fails: Cannot find package 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_6864df351d9c8329a5c8f4d8d630a3b7