### PR TITLE
Add automatic Google linking on profile

### DIFF
--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -49,6 +49,20 @@ export default function MyAccount() {
   const [selectedTx, setSelectedTx] = useState(null);
   const dateInputRef = useRef(null);
 
+  // Automatically link Google account if a Google ID was stored earlier
+  useEffect(() => {
+    if (!profile || profile.googleId) return;
+    const storedId = localStorage.getItem('googleId');
+    if (!storedId) return;
+
+    linkGoogleAccount({ telegramId, googleId: storedId })
+      .then((u) => {
+        setProfile(u);
+        localStorage.removeItem('googleId');
+      })
+      .catch((err) => console.error('auto google link failed', err));
+  }, [profile, telegramId]);
+
   useEffect(() => {
     if (!profile || profile.googleId) return;
 


### PR DESCRIPTION
## Summary
- automatically link stored Google account when visiting My Account

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6864fdbd125c83298c626158fa97f6c0