### PR TITLE
Add wallet password backups

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -74,13 +74,21 @@ const userSchema = new mongoose.Schema({
 
   referredBy: { type: String },
 
-  // Optional wallet password settings
+  // Optional wallet password settings with recovery options
   walletPassword: {
     hash: String,
     salt: String,
     method: String,
     passkeyId: String,
-    publicKey: String
+    publicKey: String,
+    backups: [
+      {
+        method: String,
+        passkeyId: String,
+        publicKey: String,
+        hint: String
+      }
+    ]
   },
 
   // Track which game table the user is currently seated at

--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -428,40 +428,32 @@ router.post('/transactions', authenticate, async (req, res) => {
 
 // Set or update wallet password
 router.post('/password', authenticate, async (req, res) => {
-  const { telegramId, password, method, passkeyId, publicKey } = req.body;
+  const { telegramId, password, method, passkeyId, publicKey, backups } = req.body;
   const authId = req.auth?.telegramId;
   if (!telegramId || !password || !method) {
-    return res
-      .status(400)
-      .json({ error: 'telegramId, password and method required' });
+    return res.status(400).json({ error: 'Missing required fields' });
   }
   if (!authId || telegramId !== authId) {
     return res.status(403).json({ error: 'forbidden' });
   }
 
   try {
+    const user = await User.findOne({ telegramId });
+    if (!user) return res.status(404).json({ error: 'User not found' });
+
     const salt = crypto.randomBytes(16).toString('hex');
-    const hash = crypto
-      .pbkdf2Sync(password, salt, 100000, 64, 'sha512')
-      .toString('hex');
+    const hash = crypto.pbkdf2Sync(password, salt, 100000, 64, 'sha512').toString('hex');
 
-    const user = await User.findOneAndUpdate(
-      { telegramId },
-      {
-        $set: {
-          walletPassword: {
-            hash,
-            salt,
-            method,
-            passkeyId,
-            publicKey
-          }
-        },
-        $setOnInsert: { referralCode: telegramId.toString() }
-      },
-      { upsert: true, new: true }
-    );
+    user.walletPassword = {
+      hash,
+      salt,
+      method,
+      passkeyId,
+      publicKey,
+      backups: backups?.slice(0, 2) || []
+    };
 
+    await user.save();
     res.json({ ok: true, walletPassword: user.walletPassword });
   } catch (err) {
     console.error('Failed to set wallet password:', err.message);

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -347,10 +347,15 @@ export function resetTpcWallet(telegramId) {
   return post('/api/wallet/reset', { telegramId });
 }
 
-export function setWalletPassword(telegramId, password, method, passkeyId, publicKey) {
-  const body = { telegramId, password, method };
-  if (passkeyId) body.passkeyId = passkeyId;
-  if (publicKey) body.publicKey = publicKey;
+export function setWalletPassword(
+  telegramId,
+  password,
+  method,
+  passkeyId,
+  publicKey,
+  backups = []
+) {
+  const body = { telegramId, password, method, passkeyId, publicKey, backups };
   return post('/api/wallet/password', body);
 }
 


### PR DESCRIPTION
## Summary
- expand user schema for wallet password recovery backups
- add `/api/wallet/password` endpoint to store primary + backup methods
- allow frontend API helper to send backups
- update wallet page to register passkeys and save 2 recovery methods

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68650b9ca4e8832986d012cd0364473e