### PR TITLE
Remove wallet password and randomize snake board

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -104,6 +104,18 @@ export class GameRoom {
 
   startGame() {
     if (this.status !== 'waiting') return;
+    const board = generateBoard();
+    this.snakes = board.snakes;
+    this.ladders = board.ladders;
+    this.game.snakes = this.snakes;
+    this.game.ladders = this.ladders;
+    this.game.currentTurn = 0;
+    this.game.finished = false;
+    this.players.forEach((p) => {
+      p.position = 0;
+      p.diceCount = 2;
+      p.isActive = false;
+    });
     this.status = 'playing';
     this.currentTurn = 0;
     this.io.to(this.id).emit('gameStarted');

--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -74,22 +74,6 @@ const userSchema = new mongoose.Schema({
 
   referredBy: { type: String },
 
-  // Optional wallet password settings with recovery options
-  walletPassword: {
-    hash: String,
-    salt: String,
-    method: String,
-    passkeyId: String,
-    publicKey: String,
-    backups: [
-      {
-        method: String,
-        passkeyId: String,
-        publicKey: String,
-        hint: String
-      }
-    ]
-  },
 
   // Track which game table the user is currently seated at
   currentTableId: { type: String, default: null }

--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -426,40 +426,6 @@ router.post('/transactions', authenticate, async (req, res) => {
 
 });
 
-// Set or update wallet password
-router.post('/password', authenticate, async (req, res) => {
-  const { telegramId, password, method, passkeyId, publicKey, backups } = req.body;
-  const authId = req.auth?.telegramId;
-  if (!telegramId || !password || !method) {
-    return res.status(400).json({ error: 'Missing required fields' });
-  }
-  if (!authId || telegramId !== authId) {
-    return res.status(403).json({ error: 'forbidden' });
-  }
-
-  try {
-    const user = await User.findOne({ telegramId });
-    if (!user) return res.status(404).json({ error: 'User not found' });
-
-    const salt = crypto.randomBytes(16).toString('hex');
-    const hash = crypto.pbkdf2Sync(password, salt, 100000, 64, 'sha512').toString('hex');
-
-    user.walletPassword = {
-      hash,
-      salt,
-      method,
-      passkeyId,
-      publicKey,
-      backups: backups?.slice(0, 2) || []
-    };
-
-    await user.save();
-    res.json({ ok: true, walletPassword: user.walletPassword });
-  } catch (err) {
-    console.error('Failed to set wallet password:', err.message);
-    res.status(500).json({ error: 'failed to set password' });
-  }
-});
 
 // Reset TPC wallet balance and history
 router.post('/reset', authenticate, async (req, res) => {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -58,6 +58,43 @@ function shuffle(arr) {
   return copy;
 }
 
+function generateBoardLocal() {
+  const boardSize = FINAL_TILE - 1;
+  const snakeCount = 6 + Math.floor(Math.random() * 3);
+  const ladderCount = 6 + Math.floor(Math.random() * 3);
+  const snakes = {};
+  const used = new Set();
+  while (Object.keys(snakes).length < snakeCount) {
+    const start = Math.floor(Math.random() * (boardSize - 10)) + 10;
+    const maxDrop = Math.min(start - 1, 20);
+    if (maxDrop <= 0) continue;
+    const end = start - (Math.floor(Math.random() * maxDrop) + 1);
+    if (used.has(start) || used.has(end) || snakes[start] || end === 1) continue;
+    snakes[start] = end;
+    used.add(start);
+    used.add(end);
+  }
+  const ladders = {};
+  const usedL = new Set([...used]);
+  while (Object.keys(ladders).length < ladderCount) {
+    const start = Math.floor(Math.random() * (boardSize - 20)) + 2;
+    const max = Math.min(boardSize - start - 1, 20);
+    if (max < 1) continue;
+    const end = start + (Math.floor(Math.random() * max) + 1);
+    if (
+      usedL.has(start) ||
+      usedL.has(end) ||
+      ladders[start] ||
+      Object.values(ladders).includes(end)
+    )
+      continue;
+    ladders[start] = end;
+    usedL.add(start);
+    usedL.add(end);
+  }
+  return { snakes, ladders };
+}
+
 function CoinBurst({ token }) {
   const coins = Array.from({ length: 30 }, () => ({
     dx: (Math.random() - 0.5) * 100,
@@ -693,7 +730,10 @@ export default function SnakeAndLadder() {
     const table = params.get("table") || storedTable || "snake-4";
     setTableId(table);
     localStorage.setItem('snakeCurrentTable', table);
-    getSnakeBoard(table)
+    const boardPromise = isMultiplayer
+      ? getSnakeBoard(table)
+      : Promise.resolve(generateBoardLocal());
+    boardPromise
       .then(({ snakes: snakesObj = {}, ladders: laddersObj = {} }) => {
         const limit = (obj) => {
           return Object.fromEntries(Object.entries(obj).slice(0, 8));

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -347,17 +347,6 @@ export function resetTpcWallet(telegramId) {
   return post('/api/wallet/reset', { telegramId });
 }
 
-export function setWalletPassword(
-  telegramId,
-  password,
-  method,
-  passkeyId,
-  publicKey,
-  backups = []
-) {
-  const body = { telegramId, password, method, passkeyId, publicKey, backups };
-  return post('/api/wallet/password', body);
-}
 
 export function registerWalletPasskey(telegramId, passkeyId, publicKey) {
   return post('/api/wallet/passkey', { telegramId, passkeyId, publicKey });


### PR DESCRIPTION
## Summary
- strip wallet password support from backend and frontend
- reset snake board every game start and randomize board locally for singleplayer

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_686511aace3c8329896fa70db5179a1a