### PR TITLE
Fix board state and handle disconnect wins

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@
 4. Copy `webapp/.env.example` to `webapp/.env` and configure:
    - `VITE_API_BASE_URL` – the base URL where the bot API is hosted (e.g. `http://localhost:3000`).
      If omitted, the webapp will connect to the same origin it was served from.
-   - `VITE_GOOGLE_CLIENT_ID` – OAuth client ID for Google sign-in
+   - `VITE_GOOGLE_CLIENT_ID` – OAuth client ID for Google sign-in.
 
-   The webapp uses this client ID to let users sign in with Google. Their
-   Google ID is stored alongside any Telegram information when calling
+   This value is required for the Google button to appear on the login and
+   profile pages. When provided, the webapp lets users sign in with Google and
+   stores their Google ID alongside any Telegram information when calling
    `/api/profile/register-google`.
 
   ⚠️ Misconfiguring these may prevent the wallet from loading correctly.


### PR DESCRIPTION
## Summary
- preserve the generated snakes & ladders board when the game starts
- finish the match when only one player is left connected
- clarify in docs that `VITE_GOOGLE_CLIENT_ID` is required for the Google button

## Testing
- `npm test` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686519498b188329b2047273a64a7e23