### PR TITLE
Fix snake game state persistence

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1085,6 +1085,19 @@ export default function SnakeAndLadder() {
     localStorage.setItem(key, JSON.stringify(data));
   }, [ai, pos, aiPositions, currentTurn, diceCells, snakes, ladders, snakeOffsets, ladderOffsets, ranking, gameOver]);
 
+  // Ensure stored state is cleared when leaving the page
+  useEffect(() => {
+    const key = `snakeGameState_${ai}`;
+    const handleUnload = () => {
+      localStorage.removeItem(key);
+    };
+    window.addEventListener('beforeunload', handleUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleUnload);
+      localStorage.removeItem(key);
+    };
+  }, [ai]);
+
 
 
   const handleRoll = (values) => {


### PR DESCRIPTION
## Summary
- clean up single player Snake & Ladder state on page unload
- ensure quitting via hardware or browser back resets game

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_6865402f76fc8329bdc68b86ef0ed5ba