### PR TITLE
Implement referral mining bonuses

### DIFF
--- a/bot/commands/referral.js
+++ b/bot/commands/referral.js
@@ -1,3 +1,17 @@
+import User from '../models/User.js';
+
 export default function registerReferral(bot) {
-  bot.command('referral', (ctx) => ctx.reply('Referral info coming soon.'));
+  bot.command('referral', async (ctx) => {
+    const telegramId = ctx.from.id;
+    const user = await User.findOneAndUpdate(
+      { telegramId },
+      { $setOnInsert: { referralCode: telegramId.toString() } },
+      { upsert: true, new: true }
+    );
+    const count = await User.countDocuments({ referredBy: user.referralCode });
+    const link = `https://t.me/${process.env.BOT_USERNAME || 'YourBot'}?start=${user.referralCode}`;
+    ctx.reply(
+      `Invite friends to increase your mining rate!\nReferral link: ${link}\nFriends invited: ${count}\nMining boost: +${(user.bonusMiningRate || 0) * 100}%`
+    );
+  });
 }

--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -74,6 +74,8 @@ const userSchema = new mongoose.Schema({
 
   referredBy: { type: String },
 
+  bonusMiningRate: { type: Number, default: 0 },
+
 
   // Track which game table the user is currently seated at
   currentTableId: { type: String, default: null }

--- a/bot/routes/referral.js
+++ b/bot/routes/referral.js
@@ -14,7 +14,11 @@ router.post('/code', async (req, res) => {
   );
 
   const count = await User.countDocuments({ referredBy: user.referralCode });
-  res.json({ code: user.referralCode, referrals: count });
+  res.json({
+    referralCode: user.referralCode,
+    referralCount: count,
+    bonusMiningRate: user.bonusMiningRate || 0,
+  });
 });
 
 router.post('/claim', async (req, res) => {
@@ -41,6 +45,9 @@ router.post('/claim', async (req, res) => {
 
   user.referredBy = code;
   await user.save();
+
+  inviter.bonusMiningRate = Math.min((inviter.bonusMiningRate || 0) + 0.1, 2.0);
+  await inviter.save();
 
   const count = await User.countDocuments({ referredBy: code });
   res.json({ message: 'claimed', total: count });

--- a/bot/utils/miningUtils.js
+++ b/bot/utils/miningUtils.js
@@ -1,5 +1,5 @@
 export const MINING_SESSION_MS = 12 * 60 * 60 * 1000; // 12 hours
-export const MINING_REWARD = 2000;
+export const MINING_REWARD = 2000; // base mining multiplier
 
 import { ensureTransactionArray } from './userUtils.js';
 
@@ -11,9 +11,13 @@ export function updateMiningRewards(user) {
       user.isMining = false;
       user.lastMineAt = null;
       user.minedTPC = 0;
-      user.balance += MINING_REWARD;
+      const baseRate = 1;
+      const miningMultiplier = MINING_REWARD;
+      const totalRate = baseRate + (user.bonusMiningRate || 0);
+      const reward = totalRate * miningMultiplier;
+      user.balance += reward;
       user.transactions.push({
-        amount: MINING_REWARD,
+        amount: reward,
         type: 'mining',
         status: 'delivered',
         date: new Date()

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -117,7 +117,7 @@ export default function Friends() {
 
   if (!referral) return <div className="p-4">Loading...</div>;
 
-  const link = `https://t.me/${BOT_USERNAME}?start=${referral.code}`;
+  const link = `https://t.me/${BOT_USERNAME}?start=${referral.referralCode}`;
 
   return (
     <div className="relative p-4 space-y-4 text-text">
@@ -155,7 +155,8 @@ export default function Friends() {
 
       <section className="space-y-1">
         <h3 className="text-lg font-semibold">Friends</h3>
-        <p>You have {referral.referrals} referrals</p>
+        <p>Invited friends: {referral.referralCount}</p>
+        <p>Mining boost: +{referral.bonusMiningRate * 100}%</p>
       </section>
 
       <section className="space-y-1">

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -279,18 +279,19 @@ export default function MyAccount() {
             <input
               type="text"
               readOnly
-              value={`https://t.me/${BOT_USERNAME}?start=${referral.code}`}
+              value={`https://t.me/${BOT_USERNAME}?start=${referral.referralCode}`}
               onClick={(e) => e.target.select()}
               className="flex-1 bg-surface border border-border rounded px-2 py-1 text-sm"
             />
             <button
-              onClick={() => navigator.clipboard.writeText(`https://t.me/${BOT_USERNAME}?start=${referral.code}`)}
+              onClick={() => navigator.clipboard.writeText(`https://t.me/${BOT_USERNAME}?start=${referral.referralCode}`)}
               className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"
             >
               Copy
             </button>
           </div>
-          <p className="text-sm text-subtext">{referral.referrals} referrals</p>
+          <p className="text-sm text-subtext">Invited friends: {referral.referralCount}</p>
+          <p className="text-sm text-subtext">Mining boost: +{referral.bonusMiningRate * 100}%</p>
         </div>
       )}
 

--- a/webapp/src/pages/Referral.jsx
+++ b/webapp/src/pages/Referral.jsx
@@ -22,7 +22,7 @@ export default function Referral() {
 
   if (!info) return <div className="p-4">Loading...</div>;
 
-  const link = `https://t.me/${BOT_USERNAME}?start=${info.code}`;
+  const link = `https://t.me/${BOT_USERNAME}?start=${info.referralCode}`;
 
   return (
     <div className="p-4 space-y-2 text-text">
@@ -44,7 +44,8 @@ export default function Referral() {
             Copy
           </button>
         </div>
-        <p className="text-sm text-subtext mt-1">{info.referrals} referrals</p>
+        <p className="text-sm text-subtext mt-1">Invited friends: {info.referralCount}</p>
+        <p className="text-sm text-subtext">Mining boost: +{info.bonusMiningRate * 100}%</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `bonusMiningRate` field to `User` model
- return mining bonus info from `/api/referral/code`
- boost inviter reward in `/api/referral/claim`
- apply mining bonus when distributing rewards
- update Telegram `/referral` command
- show bonus stats in Referral, Friends, and MyAccount pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686551776090832985a5d6c3f6f259c7