### PR TITLE
Add mining animation without binary asset

### DIFF
--- a/webapp/src/components/MiningAnimation.jsx
+++ b/webapp/src/components/MiningAnimation.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+
+export default function MiningAnimation() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const interval = setInterval(() => {
+      const coin = document.createElement('div');
+      coin.className = 'coin';
+      coin.textContent = '🪙';
+      coin.style.left = `${10 + Math.random() * 80}%`;
+      container.appendChild(coin);
+      coin.addEventListener('animationend', () => {
+        coin.remove();
+      });
+    }, 2000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="mining-animation" ref={containerRef}>
+      <div className="miner" aria-label="miner" role="img">
+        🧑‍🏭
+      </div>
+      <div className="ground" />
+    </div>
+  );
+}

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { GiMining } from 'react-icons/gi';
+import MiningAnimation from './MiningAnimation.jsx';
 import {
   getMiningStatus,
   startMining,
@@ -123,6 +124,7 @@ export default function MiningCard() {
           {formatTime(isMining ? Math.max(MINING_DURATION - elapsed, 0) : MINING_DURATION)}
         </div>
       </button>
+      {isMining && <MiningAnimation />}
     </div>
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1174,3 +1174,62 @@ input:focus {
     background-position: -400px 0, 400px 0, -200px 0;
   }
 }
+
+.mining-animation {
+  position: relative;
+  width: 100%;
+  height: 120px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  overflow: hidden;
+}
+
+.mining-animation .miner {
+  font-size: 2rem;
+  animation: miner-dig 0.8s ease-in-out infinite;
+}
+
+.mining-animation .ground {
+  position: relative;
+  width: 100%;
+  height: 8px;
+  background: #754c24;
+  margin-top: 4px;
+  border-radius: 4px;
+}
+
+.mining-animation .coin {
+  position: absolute;
+  bottom: 8px;
+  font-size: 24px;
+  animation: coin-pop 1.2s ease-out forwards;
+}
+
+@keyframes miner-dig {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes coin-pop {
+  0% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+  30% {
+    opacity: 1;
+  }
+  50% {
+    transform: translateY(-40px);
+  }
+  100% {
+    transform: translateY(-60px);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- refactor `MiningAnimation` to use emoji coin instead of PNG image
- remove unused `tpc-coin.png` asset
- adjust CSS for coin styles

## Testing
- `npm test` *(fails: 2 tests fail due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68655beec8d48329b98be1f6c9e1eefb