### PR TITLE
Add quit win notice and stake icon

### DIFF
--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -258,6 +258,11 @@ export default function SnakeBoard({
             {tiles}
             <div className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? 'highlight' : ''}`}>
               <PlayerToken color="#16a34a" topColor="#ff0000" className="pot-token" />
+              <img
+                src={`/icons/${token === 'TON' ? 'TON.png' : token === 'USDT' ? 'Usdt.png' : 'TPCcoin.png'}`}
+                alt={token}
+                className="pot-icon"
+              />
               {players
                 .map((p, i) => ({ ...p, index: i }))
                 .filter((p) => p.position === FINAL_TILE)

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -315,6 +315,18 @@ input:focus {
   transform: translateY(-9rem);
 }
 
+.pot-icon {
+  position: absolute;
+  width: 3rem;
+  height: 3rem;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -110%) translateZ(20px)
+    rotateX(calc(var(--board-angle, 58deg) * -1));
+  pointer-events: none;
+  z-index: 3;
+}
+
 .token-three canvas {
   width: 100%;
   height: 100%;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -415,6 +415,11 @@ function Board({
                 topColor="#ff0000"
                 className="pot-token"
               />
+              <img
+                src={`/icons/${token === 'TON' ? 'TON.png' : token === 'USDT' ? 'Usdt.png' : 'TPCcoin.png'}`}
+                alt={token}
+                className="pot-icon"
+              />
               {players
                 .map((p, i) => ({ ...p, index: i }))
                 .filter((p) => p.position === FINAL_TILE)
@@ -487,6 +492,7 @@ export default function SnakeAndLadder() {
   const [pot, setPot] = useState(101);
   const [token, setToken] = useState("TPC");
   const [celebrate, setCelebrate] = useState(false);
+  const [leftWinner, setLeftWinner] = useState(null);
   const [showInfo, setShowInfo] = useState(false);
   const [muted, setMuted] = useState(false);
   const [snakes, setSnakes] = useState({});
@@ -830,6 +836,9 @@ export default function SnakeAndLadder() {
         if (leaving && !ranking.includes(leaving.name)) {
           setRanking((r) => [...r, leaving.name]);
         }
+        if (leaving && arr.length === 1 && capacity === 2) {
+          setLeftWinner(leaving.name);
+        }
         return arr;
       });
     };
@@ -924,7 +933,11 @@ export default function SnakeAndLadder() {
     };
     const onWon = ({ playerId }) => {
       setGameOver(true);
-      setRanking([playerId === accountId ? myName : playerId]);
+      const winnerName = playerId === accountId ? myName : playerId;
+      setRanking((r) => {
+        const others = r.filter((n) => n !== winnerName);
+        return [winnerName, ...others];
+      });
       if (playerId === accountId) {
         const totalPlayers = isMultiplayer ? mpPlayers.length : ai + 1;
         const tgId = getTelegramId();
@@ -1744,6 +1757,23 @@ export default function SnakeAndLadder() {
         onClose={() => setShowInfo(false)}
         title="Snake & Ladder"
         info="Roll the dice to move across the board. Ladders move you up, snakes bring you down. The Pot at the top collects everyone's stake – reach it first to claim the total amount."
+      />
+      <InfoPopup
+        open={!!leftWinner}
+        onClose={() => setLeftWinner(null)}
+        title="Opponent Left"
+        info={
+          leftWinner && (
+            <span>
+              {leftWinner} left the game. You win {Math.round(pot * 2 * 0.91)}{' '}
+              <img
+                src={`/icons/${token === 'TON' ? 'TON.png' : token === 'USDT' ? 'Usdt.png' : 'TPCcoin.png'}`}
+                alt={token}
+                className="inline w-4 h-4 align-middle"
+              />
+            </span>
+          )
+        }
       />
       <GameEndPopup
         open={gameOver}


### PR DESCRIPTION
## Summary
- show the staked token icon on the board pot
- handle opponent quitting in 1v1 by recording the leaving player
- preserve ranking when a player wins
- notify when an opponent leaves and player wins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68656b0f15488329a9e3059a70ed0afc