### PR TITLE
Improve wallet transaction details and dev share tracking

### DIFF
--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -125,7 +125,7 @@ router.post('/transactions', async (req, res) => {
 
 // Deposit rewards into account
 router.post('/deposit', authenticate, async (req, res) => {
-  const { accountId, amount } = req.body;
+  const { accountId, amount, game } = req.body;
   const authId = req.auth?.telegramId;
   if (!accountId || typeof amount !== 'number' || amount <= 0) {
     return res.status(400).json({ error: 'accountId and positive amount required' });
@@ -144,6 +144,7 @@ router.post('/deposit', authenticate, async (req, res) => {
     status: 'delivered',
     date: new Date()
   };
+  if (game) tx.game = game;
   user.transactions.push(tx);
   await user.save();
 

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -29,6 +29,7 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
   };
   const icon = iconMap[token] || `/icons/${token.toLowerCase()}.png`;
   const isSend = tx.type === 'send';
+  const isReceive = tx.type === 'receive';
   const account = isSend ? tx.toAccount : tx.fromAccount;
   const nameOverride = isSend ? tx.toName : tx.fromName;
   const nameFromProfile = counterparty?.nickname || `${counterparty?.firstName || ''} ${counterparty?.lastName || ''}`.trim();
@@ -49,7 +50,14 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
             <span
               className={`font-semibold flex items-center space-x-1 ${tx.amount > 0 ? 'text-green-500' : 'text-red-500'}`}
             >
-              {isSend ? 'Sent' : 'Received'} {Math.abs(tx.amount)}
+              {(() => {
+                if (tx.game) {
+                  return tx.amount > 0 ? 'Win' : 'Lost';
+                }
+                if (isSend) return 'Sent';
+                if (isReceive) return 'Received';
+                return tx.type;
+              })()} {tx.game ? `${tx.amount > 0 ? '+' : '-'}${Math.abs(tx.amount)}` : Math.abs(tx.amount)}
               <img src={icon} alt={token} className="w-5 h-5 inline" />
             </span>
             {tx.game && (

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1251,9 +1251,11 @@ export default function SnakeAndLadder() {
               .then(async (aid) => {
                 const total = pot * (ai + 1);
                 const winAmt = Math.round(total * 0.91);
-                await depositAccount(aid, winAmt);
+                await depositAccount(aid, winAmt, { game: 'snake-win' });
                 if (DEV_ACCOUNT) {
-                  await depositAccount(DEV_ACCOUNT, Math.round(total * 0.09));
+                  await depositAccount(DEV_ACCOUNT, Math.round(total * 0.09), {
+                    game: 'snake-dev'
+                  });
                 }
               })
               .catch(() => {});

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -372,6 +372,6 @@ export function getAccountTransactions(accountId) {
   return post('/api/account/transactions', { accountId });
 }
 
-export function depositAccount(accountId, amount) {
-  return post('/api/account/deposit', { accountId, amount });
+export function depositAccount(accountId, amount, extra = {}) {
+  return post('/api/account/deposit', { accountId, amount, ...extra });
 }


### PR DESCRIPTION
## Summary
- mark game deposits with optional `game` field in backend
- allow depositAccount API to accept extra params
- show win/lost labels and +/- amounts in transaction detail popup
- track 9% game revenue for developer wallet
- pass game info when depositing winnings and dev share

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68657f6030ac83299f868c9131a48305