### PR TITLE
Add radio popup and icons

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -10,12 +10,14 @@
   "type": "module",
   "dependencies": {
     "@ayshrj/ludo.js": "^1.0.10",
+    "@github/webauthn-json": "^2.0.2",
     "@tonconnect/sdk": "^3.2.0",
     "@tonconnect/ui-react": "^2.2.0",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.15",
     "canvas-confetti": "^1.9.2",
     "framer-motion": "^10.18.0",
+    "lucide-react": "^0.525.0",
     "postcss": "^8.4.31",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -25,7 +27,6 @@
     "react-router-dom": "^6.22.3",
     "socket.io-client": "^4.8.1",
     "tailwindcss": "^3.4.1",
-    "@github/webauthn-json": "^2.0.2",
     "three": "^0.164.0",
     "vite": "^4.4.9"
   },

--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import { AiOutlineInfoCircle } from 'react-icons/ai';
+import { Headphones } from 'lucide-react';
+import RadioPopup from './RadioPopup.jsx';
+
+export default function BottomLeftIcons({ onInfo, muted, toggleMute }) {
+  const [showRadio, setShowRadio] = useState(false);
+  return (
+    <>
+      <div className="fixed left-1 bottom-4 flex flex-col items-center space-y-2 z-20">
+        <button onClick={() => setShowRadio(true)} className="p-2 flex flex-col items-center">
+          <Headphones className="w-6 h-6" />
+          <span className="text-xs">Radio</span>
+        </button>
+        <button onClick={onInfo} className="p-2 flex flex-col items-center">
+          <AiOutlineInfoCircle className="text-2xl" />
+          <span className="text-xs">Info</span>
+        </button>
+        <button onClick={toggleMute} className="p-2 flex flex-col items-center">
+          <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
+          <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
+        </button>
+      </div>
+      <RadioPopup open={showRadio} onClose={() => setShowRadio(false)} />
+    </>
+  );
+}

--- a/webapp/src/components/RadioPopup.jsx
+++ b/webapp/src/components/RadioPopup.jsx
@@ -1,0 +1,65 @@
+import { createPortal } from 'react-dom';
+import { useRef, useState } from 'react';
+import { X } from 'lucide-react';
+
+const stations = [
+  { name: 'Capital FM (London)', url: 'https://media-ssl.musicradio.com/CapitalMP3' },
+  { name: 'Paris Jazz Café', url: 'https://radiospinner.com/radio/paris-jazz-cafe/stream' },
+  { name: '103.5 KTU (New York)', url: 'https://n12a-e2.revma.ihrhls.com/zc2743' },
+  { name: 'J1 Radio (Tokyo)', url: 'https://j1.stream/hi.mp3' },
+  { name: 'Top Albania Radio', url: 'https://live.topalbaniaradio.com:8000/live.mp3' },
+];
+
+export default function RadioPopup({ open, onClose }) {
+  const audioRefs = useRef([]);
+  const [mutedAll, setMutedAll] = useState(false);
+
+  if (!open) return null;
+
+  const play = i => audioRefs.current[i]?.play();
+  const pause = i => audioRefs.current[i]?.pause();
+  const stop = i => {
+    const a = audioRefs.current[i];
+    if (a) { a.pause(); a.currentTime = 0; }
+  };
+  const toggleMute = i => {
+    const a = audioRefs.current[i];
+    if (a) a.muted = !a.muted;
+  };
+  const stopAll = () => audioRefs.current.forEach(a => { if (a) { a.pause(); a.currentTime = 0; } });
+  const toggleMuteAll = () => {
+    const newVal = !mutedAll;
+    setMutedAll(newVal);
+    audioRefs.current.forEach(a => { if (a) a.muted = newVal; });
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
+      <div className="bg-surface p-4 w-80 space-y-4 relative rounded">
+        <button onClick={onClose} className="absolute -top-3 -right-3 bg-black/70 text-white rounded-full w-6 h-6 flex items-center justify-center">
+          <X size={14} />
+        </button>
+        <h3 className="text-center font-bold">Radio Stations</h3>
+        <div className="space-y-3 max-h-60 overflow-y-auto">
+          {stations.map((s, i) => (
+            <div key={i} className="space-y-1">
+              <p className="text-sm font-semibold">{s.name}</p>
+              <audio ref={el => audioRefs.current[i] = el} src={s.url} className="w-full" />
+              <div className="flex items-center justify-between text-xs">
+                <button onClick={() => play(i)}>Play</button>
+                <button onClick={() => pause(i)}>Pause</button>
+                <button onClick={() => stop(i)}>Stop</button>
+                <button onClick={() => toggleMute(i)}>Mute</button>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="flex items-center justify-between pt-2 text-xs">
+          <button onClick={stopAll}>Stop All</button>
+          <button onClick={toggleMuteAll}>{mutedAll ? 'Unmute All' : 'Mute All'}</button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -15,10 +15,10 @@ import { getAvatarUrl, saveAvatar, loadAvatar } from "../../utils/avatarUtils.js
 import InfoPopup from "../../components/InfoPopup.jsx";
 import GameEndPopup from "../../components/GameEndPopup.jsx";
 import {
-  AiOutlineInfoCircle,
   AiOutlineRollback,
   AiOutlineReload,
 } from "react-icons/ai";
+import BottomLeftIcons from "../../components/BottomLeftIcons.jsx";
 import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
 import { useNavigate } from "react-router-dom";
 import { getPlayerId, getTelegramId, ensureAccountId } from "../../utils/telegram.js";
@@ -1606,23 +1606,12 @@ export default function SnakeAndLadder() {
 
   return (
     <div className="p-4 pb-32 space-y-4 text-text flex flex-col justify-end items-center relative w-full flex-grow">
-      {/* Action menu moved to the bottom left with only info and mute */}
-      <div className="fixed left-1 bottom-4 flex flex-col items-center space-y-2 z-20">
-        <button
-          onClick={() => setShowInfo(true)}
-          className="p-2 flex flex-col items-center"
-        >
-          <AiOutlineInfoCircle className="text-2xl" />
-          <span className="text-xs">Info</span>
-        </button>
-        <button
-          onClick={() => setMuted((m) => !m)}
-          className="p-2 flex flex-col items-center"
-        >
-          <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
-          <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
-        </button>
-      </div>
+      {/* Bottom left controls */}
+      <BottomLeftIcons
+        onInfo={() => setShowInfo(true)}
+        muted={muted}
+        toggleMute={() => setMuted((m) => !m)}
+      />
       {/* Player photos stacked vertically */}
       <div className="fixed left-1 top-[50%] -translate-y-1/2 flex flex-col space-y-3 z-20">
         {players

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -30,12 +30,15 @@ import useWalletUsdValue from '../hooks/useWalletUsdValue.js';
 
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
 import { getProfile } from '../utils/api.js';
+import { Headphones } from 'lucide-react';
+import RadioPopup from '../components/RadioPopup.jsx';
 
 export default function Home() {
 
   const [status, setStatus] = useState('checking');
 
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
+  const [showRadio, setShowRadio] = useState(false);
   const { tpcBalance, tonBalance, usdtBalance } = useTokenBalances();
   const usdValue = useWalletUsdValue(tonBalance, usdtBalance);
   const walletAddress = useTonAddress();
@@ -87,6 +90,11 @@ export default function Home() {
   return (
 
     <div className="space-y-4">
+      <div className="fixed top-2 left-2 z-20 flex items-center">
+        <button onClick={() => setShowRadio(true)}>
+          <Headphones className="w-5 h-5" />
+        </button>
+      </div>
 
       <div className="flex flex-col items-center">
 
@@ -169,6 +177,8 @@ export default function Home() {
       </div>
 
       <p className="text-center text-xs text-subtext">Status: {status}</p>
+
+      <RadioPopup open={showRadio} onClose={() => setShowRadio(false)} />
 
     </div>
 


### PR DESCRIPTION
## Summary
- add lucide-react dependency
- create `BottomLeftIcons` component with radio support
- create `RadioPopup` component listing stations
- integrate bottom-left radio icon in Snake & Ladder game
- display small radio icon on Home page

## Testing
- `npm test` *(fails: Cannot find package 'mongoose')*


------
https://chatgpt.com/codex/tasks/task_e_6865886841488329a0a407ef414a710c