### PR TITLE
Improve radio and sound handling

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -1,10 +1,23 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { AiOutlineInfoCircle } from 'react-icons/ai';
 import { Headphones } from 'lucide-react';
 import RadioPopup from './RadioPopup.jsx';
-
-export default function BottomLeftIcons({ onInfo, muted, toggleMute }) {
+import { isGameMuted, toggleGameMuted } from '../utils/sound.js';
+export default function BottomLeftIcons({ onInfo }) {
   const [showRadio, setShowRadio] = useState(false);
+  const [muted, setMuted] = useState(isGameMuted());
+
+  useEffect(() => {
+    const handler = () => setMuted(isGameMuted());
+    window.addEventListener('gameMuteChanged', handler);
+    return () => window.removeEventListener('gameMuteChanged', handler);
+  }, []);
+
+  const toggle = () => {
+    toggleGameMuted();
+    setMuted(isGameMuted());
+  };
+
   return (
     <>
       <div className="fixed left-1 bottom-4 flex flex-col items-center space-y-2 z-20">
@@ -16,7 +29,7 @@ export default function BottomLeftIcons({ onInfo, muted, toggleMute }) {
           <AiOutlineInfoCircle className="text-2xl" />
           <span className="text-xs">Info</span>
         </button>
-        <button onClick={toggleMute} className="p-2 flex flex-col items-center">
+        <button onClick={toggle} className="p-2 flex flex-col items-center">
           <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
           <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
         </button>

--- a/webapp/src/components/RadioPopup.jsx
+++ b/webapp/src/components/RadioPopup.jsx
@@ -1,62 +1,89 @@
 import { createPortal } from 'react-dom';
-import { useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { X } from 'lucide-react';
-
-const stations = [
-  { name: 'Capital FM (London)', url: 'https://media-ssl.musicradio.com/CapitalMP3' },
-  { name: 'Paris Jazz Café', url: 'https://radiospinner.com/radio/paris-jazz-cafe/stream' },
-  { name: '103.5 KTU (New York)', url: 'https://n12a-e2.revma.ihrhls.com/zc2743' },
-  { name: 'J1 Radio (Tokyo)', url: 'https://j1.stream/hi.mp3' },
-  { name: 'Top Albania Radio', url: 'https://live.topalbaniaradio.com:8000/live.mp3' },
-];
+import {
+  stations,
+  play,
+  pause,
+  stop,
+  getCurrent,
+  setVolume,
+} from '../utils/radio.js';
+import { isGameMuted, toggleGameMuted } from '../utils/sound.js';
 
 export default function RadioPopup({ open, onClose }) {
-  const audioRefs = useRef([]);
-  const [mutedAll, setMutedAll] = useState(false);
+  const [selected, setSelected] = useState(getCurrent() || stations[0].url);
+  const [playing, setPlaying] = useState(false);
+  const [radioMuted, setRadioMuted] = useState(false);
+  const [gameMuted, setGameMutedState] = useState(isGameMuted());
+
+  useEffect(() => {
+    setGameMutedState(isGameMuted());
+  }, [open]);
 
   if (!open) return null;
 
-  const play = i => audioRefs.current[i]?.play();
-  const pause = i => audioRefs.current[i]?.pause();
-  const stop = i => {
-    const a = audioRefs.current[i];
-    if (a) { a.pause(); a.currentTime = 0; }
+  const handlePlay = () => {
+    play(selected);
+    setPlaying(true);
   };
-  const toggleMute = i => {
-    const a = audioRefs.current[i];
-    if (a) a.muted = !a.muted;
+  const handlePause = () => {
+    pause();
+    setPlaying(false);
   };
-  const stopAll = () => audioRefs.current.forEach(a => { if (a) { a.pause(); a.currentTime = 0; } });
-  const toggleMuteAll = () => {
-    const newVal = !mutedAll;
-    setMutedAll(newVal);
-    audioRefs.current.forEach(a => { if (a) a.muted = newVal; });
+  const handleStop = () => {
+    stop();
+    setPlaying(false);
+  };
+  const toggleRadioMute = () => {
+    const newVal = !radioMuted;
+    setRadioMuted(newVal);
+    // volume 0 or 1
+    setVolume(newVal ? 0 : 1);
+  };
+  const toggleGameMute = () => {
+    toggleGameMuted();
+    setGameMutedState(isGameMuted());
   };
 
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
       <div className="bg-surface p-4 w-80 space-y-4 relative rounded">
-        <button onClick={onClose} className="absolute -top-3 -right-3 bg-black/70 text-white rounded-full w-6 h-6 flex items-center justify-center">
+        <button
+          onClick={onClose}
+          className="absolute -top-3 -right-3 bg-black/70 text-white rounded-full w-6 h-6 flex items-center justify-center"
+        >
           <X size={14} />
         </button>
         <h3 className="text-center font-bold">Radio Stations</h3>
-        <div className="space-y-3 max-h-60 overflow-y-auto">
-          {stations.map((s, i) => (
-            <div key={i} className="space-y-1">
-              <p className="text-sm font-semibold">{s.name}</p>
-              <audio ref={el => audioRefs.current[i] = el} src={s.url} className="w-full" />
-              <div className="flex items-center justify-between text-xs">
-                <button onClick={() => play(i)}>Play</button>
-                <button onClick={() => pause(i)}>Pause</button>
-                <button onClick={() => stop(i)}>Stop</button>
-                <button onClick={() => toggleMute(i)}>Mute</button>
-              </div>
-            </div>
+        <div className="space-y-2 max-h-60 overflow-y-auto">
+          {stations.map((s) => (
+            <label key={s.url} className="flex items-center space-x-2">
+              <input
+                type="radio"
+                name="station"
+                value={s.url}
+                checked={selected === s.url}
+                onChange={() => setSelected(s.url)}
+              />
+              <span className="text-sm font-semibold">{s.name}</span>
+            </label>
           ))}
         </div>
-        <div className="flex items-center justify-between pt-2 text-xs">
-          <button onClick={stopAll}>Stop All</button>
-          <button onClick={toggleMuteAll}>{mutedAll ? 'Unmute All' : 'Mute All'}</button>
+        <div className="flex justify-center space-x-4 pt-2 text-xl">
+          <button onClick={handlePlay}>▶️</button>
+          <button onClick={handlePause}>⏸️</button>
+          <button onClick={handleStop}>⏹️</button>
+        </div>
+        <div className="flex justify-around pt-2 text-xs">
+          <button onClick={toggleRadioMute} className="flex flex-col items-center">
+            <span>{radioMuted ? '🔇' : '🔊'}</span>
+            <span>Radio</span>
+          </button>
+          <button onClick={toggleGameMute} className="flex flex-col items-center">
+            <span>{gameMuted ? '🔇' : '🔊'}</span>
+            <span>Game</span>
+          </button>
         </div>
       </div>
     </div>,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -19,6 +19,7 @@ import {
   AiOutlineReload,
 } from "react-icons/ai";
 import BottomLeftIcons from "../../components/BottomLeftIcons.jsx";
+import { isGameMuted } from "../../utils/sound.js";
 import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
 import { useNavigate } from "react-router-dom";
 import { getPlayerId, getTelegramId, ensureAccountId } from "../../utils/telegram.js";
@@ -472,6 +473,12 @@ export default function SnakeAndLadder() {
   }, []);
 
   useEffect(() => {
+    const handler = () => setMuted(isGameMuted());
+    window.addEventListener('gameMuteChanged', handler);
+    return () => window.removeEventListener('gameMuteChanged', handler);
+  }, []);
+
+  useEffect(() => {
     const id = getPlayerId();
     function ping() {
       pingOnline(id).catch(() => {});
@@ -495,7 +502,7 @@ export default function SnakeAndLadder() {
   const [celebrate, setCelebrate] = useState(false);
   const [leftWinner, setLeftWinner] = useState(null);
   const [showInfo, setShowInfo] = useState(false);
-  const [muted, setMuted] = useState(false);
+  const [muted, setMuted] = useState(isGameMuted());
   const [snakes, setSnakes] = useState({});
   const [ladders, setLadders] = useState({});
   const [snakeOffsets, setSnakeOffsets] = useState({});
@@ -1607,11 +1614,7 @@ export default function SnakeAndLadder() {
   return (
     <div className="p-4 pb-32 space-y-4 text-text flex flex-col justify-end items-center relative w-full flex-grow">
       {/* Bottom left controls */}
-      <BottomLeftIcons
-        onInfo={() => setShowInfo(true)}
-        muted={muted}
-        toggleMute={() => setMuted((m) => !m)}
-      />
+      <BottomLeftIcons onInfo={() => setShowInfo(true)} />
       {/* Player photos stacked vertically */}
       <div className="fixed left-1 top-[50%] -translate-y-1/2 flex flex-col space-y-3 z-20">
         {players

--- a/webapp/src/utils/radio.js
+++ b/webapp/src/utils/radio.js
@@ -1,0 +1,44 @@
+const player = new Audio();
+player.preload = 'none';
+player.loop = true;
+
+export const stations = [
+  { name: 'Capital FM (London)', url: 'https://media-ssl.musicradio.com/CapitalMP3' },
+  { name: 'Paris Jazz Café', url: 'https://radiospinner.com/radio/paris-jazz-cafe/stream' },
+  { name: '103.5 KTU (New York)', url: 'https://n12a-e2.revma.ihrhls.com/zc2743' },
+  { name: 'J1 Radio (Tokyo)', url: 'https://j1.stream/hi.mp3' },
+  { name: 'Top Albania Radio', url: 'https://live.topalbaniaradio.com:8000/live.mp3' },
+];
+
+let current = '';
+
+export function play(url) {
+  if (url && player.src !== url) {
+    player.src = url;
+    current = url;
+  }
+  player.play().catch(() => {});
+}
+
+export function pause() {
+  player.pause();
+}
+
+export function stop() {
+  player.pause();
+  player.currentTime = 0;
+}
+
+export function getCurrent() {
+  return current;
+}
+
+export function setVolume(v) {
+  player.volume = v;
+}
+
+export function getVolume() {
+  return player.volume;
+}
+
+export default player;

--- a/webapp/src/utils/sound.js
+++ b/webapp/src/utils/sound.js
@@ -1,0 +1,17 @@
+let gameMuted = localStorage.getItem('gameMuted') === 'true';
+
+export function isGameMuted() {
+  return gameMuted;
+}
+
+export function setGameMuted(val) {
+  gameMuted = val;
+  try {
+    localStorage.setItem('gameMuted', val ? 'true' : 'false');
+  } catch (err) {}
+  window.dispatchEvent(new Event('gameMuteChanged'));
+}
+
+export function toggleGameMuted() {
+  setGameMuted(!gameMuted);
+}


### PR DESCRIPTION
## Summary
- add persistent radio player module
- manage game audio mute state globally
- update RadioPopup for single player controls and volume buttons
- simplify BottomLeftIcons and connect to global mute
- use global mute state in Snake & Ladder

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_686590b06be0832988077ffc3983fb32