### PR TITLE
Update wallet statement displays

### DIFF
--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -35,6 +35,12 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
   const nameFromProfile = counterparty?.nickname || `${counterparty?.firstName || ''} ${counterparty?.lastName || ''}`.trim();
   const displayName = nameOverride || nameFromProfile || '';
 
+  const sign = tx.amount > 0 ? '+' : '-';
+  const formattedAmount = Math.abs(tx.amount).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="p-4 space-y-4 w-80 relative rounded-xl border-2 border-[#334155] bg-[#2d5c66] text-white">
@@ -57,7 +63,7 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
                 if (isSend) return 'Sent';
                 if (isReceive) return 'Received';
                 return tx.type;
-              })()} {tx.game ? `${tx.amount > 0 ? '+' : '-'}${Math.abs(tx.amount)}` : Math.abs(tx.amount)}
+              })()} {sign}{formattedAmount}
               <img src={icon} alt={token} className="w-5 h-5 inline" />
             </span>
             {tx.game && (

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -26,6 +26,21 @@ import TransactionDetailsPopup from '../components/TransactionDetailsPopup.jsx';
 import { AiOutlineCalendar } from 'react-icons/ai';
 import { FiCopy } from 'react-icons/fi';
 
+function formatValue(value, decimals = 2) {
+  if (typeof value !== 'number') {
+    const parsed = parseFloat(value);
+    if (isNaN(parsed)) return value;
+    return parsed.toLocaleString(undefined, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    });
+  }
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
 export default function MyAccount() {
   useTelegramBackButton();
   let telegramId;
@@ -334,6 +349,8 @@ export default function MyAccount() {
           <div className="space-y-1 text-sm">
             {sortedTransactions.map((tx, i) => {
               const typeLabel = tx.game ? 'game' : tx.type;
+              const sign = tx.amount > 0 ? '+' : '-';
+              const amt = formatValue(Math.abs(tx.amount), 2);
               return (
                 <div
                   key={i}
@@ -342,7 +359,8 @@ export default function MyAccount() {
                 >
                   <span className="capitalize">{typeLabel}</span>
                   <span className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
-                    {tx.amount} {(tx.token || 'TPC').toUpperCase()}
+                    {sign}
+                    {amt} {(tx.token || 'TPC').toUpperCase()}
                   </span>
                   <span>{new Date(tx.date).toLocaleString()}</span>
                   <span className="text-xs">{tx.status}</span>

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -13,7 +13,14 @@ import TransactionDetailsPopup from '../components/TransactionDetailsPopup.jsx';
 import { AiOutlineCalendar } from 'react-icons/ai';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 
-const DEV_ACCOUNT_ID = import.meta.env.VITE_DEV_ACCOUNT_ID;
+const urlParams = new URLSearchParams(window.location.search);
+const DEV_ACCOUNT_ID =
+  urlParams.get('dev') ||
+  localStorage.getItem('devAccountId') ||
+  import.meta.env.VITE_DEV_ACCOUNT_ID;
+if (urlParams.get('dev')) {
+  localStorage.setItem('devAccountId', urlParams.get('dev'));
+}
 
 function formatValue(value, decimals = 2) {
   if (typeof value !== 'number') {
@@ -226,7 +233,7 @@ export default function Wallet() {
             Send
           </button>
           <p className="text-xs text-subtext mt-1">
-            Transfers charge a 2% fee to the developer wallet and deduct 1% from the receiver.
+            Sending TPC 2% charge will be applied.
           </p>
           {sending && (
             <div className="mt-1">
@@ -247,6 +254,7 @@ export default function Wallet() {
           >
             Copy Account Number
           </button>
+          <p className="text-xs text-subtext mt-1">Receive TPC 1% charge will be applied.</p>
         {accountId && (
           <div className="mt-4 flex justify-center">
             <QRCode value={String(accountId)} size={100} />
@@ -312,6 +320,8 @@ export default function Wallet() {
         <div className="space-y-1 text-sm max-h-[40rem] overflow-y-auto border border-border rounded">
           {sortedTransactions.map((tx, i) => {
             const typeLabel = tx.game ? 'game' : tx.type;
+            const sign = tx.amount > 0 ? '+' : '-';
+            const amt = formatValue(Math.abs(tx.amount), 2);
             return (
               <div
                 key={i}
@@ -320,7 +330,8 @@ export default function Wallet() {
               >
                 <span className="capitalize">{typeLabel}</span>
                 <span className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
-                  {tx.amount} {(tx.token || 'TPC').toUpperCase()}
+                  {sign}
+                  {amt} {(tx.token || 'TPC').toUpperCase()}
                 </span>
                 <span className="text-xs">{new Date(tx.date).toLocaleString()}</span>
                 <span className="text-xs">{tx.status}</span>


### PR DESCRIPTION
## Summary
- show + for wins and received transactions, - for losses and sends
- add info texts about transfer charges
- format transaction amounts with locale separators
- allow dev wallet page via `?dev=` query parameter

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_68659e43bcbc832981346956f9b0833a