### PR TITLE
Name AI players based on avatar

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "emoji-name-map": "^2.0.3",
     "socket.io-client": "^4.8.1"
   },
   "devDependencies": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -16,6 +16,7 @@
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.15",
     "canvas-confetti": "^1.9.2",
+    "emoji-name-map": "^2.0.3",
     "framer-motion": "^10.18.0",
     "lucide-react": "^0.525.0",
     "postcss": "^8.4.31",

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -11,7 +11,7 @@ import {
   cheerSound,
 } from "../../assets/soundData.js";
 import { AVATARS } from "../../components/AvatarPickerModal.jsx";
-import { getAvatarUrl, saveAvatar, loadAvatar } from "../../utils/avatarUtils.js";
+import { getAvatarUrl, saveAvatar, loadAvatar, avatarToName } from "../../utils/avatarUtils.js";
 import InfoPopup from "../../components/InfoPopup.jsx";
 import GameEndPopup from "../../components/GameEndPopup.jsx";
 import {
@@ -601,7 +601,9 @@ export default function SnakeAndLadder() {
     if (isMultiplayer) {
       return mpPlayers[idx]?.name || `Player ${idx + 1}`;
     }
-    return `AI ${idx}`;
+    const avatar = aiAvatars[idx - 1];
+    const name = avatarToName(avatar);
+    return name || `AI ${idx}`;
   };
 
   const playerName = (idx) => (
@@ -1075,8 +1077,8 @@ export default function SnakeAndLadder() {
         }
         if (p === pos) p = 0;
         aiPos = aiPos.map((v, i) => (i === idx ? pos : v === pos ? 0 : v));
-        if (pos === FINAL_TILE && !rank.includes(`AI ${turn}`)) {
-          rank.push(`AI ${turn}`);
+        if (pos === FINAL_TILE && !rank.includes(getPlayerName(turn))) {
+          rank.push(getPlayerName(turn));
           if (rank.length === 1) over = true;
         }
       }

--- a/webapp/src/utils/avatarUtils.js
+++ b/webapp/src/utils/avatarUtils.js
@@ -27,3 +27,40 @@ export function loadAvatar() {
   }
   return '';
 }
+
+import { emoji } from 'emoji-name-map';
+
+const emojiToNameMap = Object.fromEntries(
+  Object.entries(emoji).map(([name, char]) => [char, name])
+);
+const regionNames =
+  typeof Intl !== 'undefined'
+    ? new Intl.DisplayNames(['en'], { type: 'region' })
+    : null;
+
+export function avatarToName(src) {
+  if (!src) return '';
+  if (!src.startsWith('/') && !src.startsWith('http')) {
+    const key = emojiToNameMap[src];
+    if (key) {
+      if (/^[a-z]{2}$/i.test(key)) {
+        const code = key.toUpperCase();
+        try {
+          const name = regionNames?.of(code);
+          if (name) return name;
+        } catch {}
+        return code;
+      }
+      return key
+        .replace(/_/g, ' ')
+        .replace(/\b\w/g, (c) => c.toUpperCase());
+    }
+    return '';
+  }
+  const match = src.match(/avatar(\d+)\.svg$/);
+  if (match) return `Avatar ${match[1]}`;
+  const file = src.split('/').pop().split('.')[0];
+  return file
+    .replace(/[_-]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}


### PR DESCRIPTION
## Summary
- name AI players in Snake and Ladder using their avatar instead of generic `AI #`
- add `emoji-name-map` dependency to map emojis to country/animal names
- export `avatarToName` helper in avatar utils

## Testing
- `npm test` *(fails: Cannot find package 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_6865a20ebd548329bd3e21b3297f6809