### PR TITLE
Fix npm test missing dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   },
   "dependencies": {
     "emoji-name-map": "^2.0.3",
-    "socket.io-client": "^4.8.1"
+    "socket.io-client": "^4.8.1",
+    "dotenv": "^16.3.1",
+    "mongoose": "^7.6.0"
   },
   "devDependencies": {
     "concurrently": "^8.2.2"


### PR DESCRIPTION
## Summary
- add `dotenv` and `mongoose` to root package.json so `npm test` can find them

## Testing
- `node --test --test-concurrency=1` *(fails: process hangs)*

------
https://chatgpt.com/codex/tasks/task_e_6865a6356b2c8329aaa42967c05ece47