### PR TITLE
Delay Telegram bot launch until webapp is accessed

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -115,6 +115,25 @@ function sendIndex(res) {
   } else {
     res.status(503).send('Webapp build not available');
   }
+  launchBotWithDelay();
+}
+
+let botLaunchTriggered = false;
+function launchBotWithDelay() {
+  if (botLaunchTriggered) return;
+  if (process.env.SKIP_BOT_LAUNCH || !process.env.BOT_TOKEN) {
+    console.log('Skipping Telegram bot launch');
+    botLaunchTriggered = true;
+    return;
+  }
+  botLaunchTriggered = true;
+  setTimeout(async () => {
+    try {
+      await bot.launch();
+    } catch (err) {
+      console.error('Failed to launch Telegram bot:', err.message);
+    }
+  }, 5000);
 }
 
 app.get('/', (req, res) => {
@@ -389,13 +408,6 @@ httpServer.listen(PORT, async () => {
   console.log(`Server running on port ${PORT}`);
   if (process.env.SKIP_BOT_LAUNCH || !process.env.BOT_TOKEN) {
     console.log('Skipping Telegram bot launch');
-    return;
-  }
-
-  try {
-    await bot.launch();
-  } catch (err) {
-    console.error('Failed to launch Telegram bot:', err.message);
   }
 });
 


### PR DESCRIPTION
## Summary
- start Telegram bot after serving index page
- avoid launch errors if Telegram isn't ready at server startup

## Testing
- `npm test` *(fails: test suite hangs)*

------
https://chatgpt.com/codex/tasks/task_e_6865a61073fc8329a774be3cc50f03fb