### PR TITLE
Update dev fee handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
    - `DEPOSIT_WALLET_ADDRESS` – TON address that receives user deposits
    - `PORT` – (optional) port for the bot API server (defaults to 3000)
    - `DEV_ACCOUNT_ID` – account ID that collects transfer fees
+   - `DEV_ACCOUNT_ID_1` – (optional) secondary developer account (1% share)
+   - `DEV_ACCOUNT_ID_2` – (optional) secondary developer account (2% share)
    - `API_AUTH_TOKEN` – (optional) token for trusted server-to-server calls
 
 4. Copy `webapp/.env.example` to `webapp/.env` and configure:
@@ -20,6 +22,8 @@
      If omitted, the webapp will connect to the same origin it was served from.
    - `VITE_GOOGLE_CLIENT_ID` – OAuth client ID for Google sign-in.
    - `VITE_DEV_ACCOUNT_ID` – account ID that receives the 9% developer share.
+   - `VITE_DEV_ACCOUNT_ID_1` – (optional) account that receives a 1% share.
+   - `VITE_DEV_ACCOUNT_ID_2` – (optional) account that receives a 2% share.
 
    This value is required for the Google button to appear on the login and
    profile pages. When provided, the webapp lets users sign in with Google and

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -18,5 +18,8 @@ PORT=3000
 # Example: EQCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 DEPOSIT_WALLET_ADDRESS=
 
-# Account ID that receives transaction fees
+# Account IDs that receive developer fees
 DEV_ACCOUNT_ID=
+# Optional additional developer accounts
+DEV_ACCOUNT_ID_1=
+DEV_ACCOUNT_ID_2=

--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -123,7 +123,13 @@ router.post('/send', async (req, res) => {
   await receiver.save();
   if (dev) await dev.save();
 
-  if (receiver.telegramId) {
+  const devIds = [
+    process.env.DEV_ACCOUNT_ID,
+    process.env.DEV_ACCOUNT_ID_1,
+    process.env.DEV_ACCOUNT_ID_2,
+  ].filter(Boolean);
+
+  if (receiver.telegramId && !devIds.includes(toAccount)) {
     try {
       await bot.telegram.sendMessage(
         String(receiver.telegramId),
@@ -172,7 +178,12 @@ router.post('/deposit', authenticate, async (req, res) => {
   user.transactions.push(tx);
   await user.save();
 
-  if (user.telegramId) {
+  const devIds = [
+    process.env.DEV_ACCOUNT_ID,
+    process.env.DEV_ACCOUNT_ID_1,
+    process.env.DEV_ACCOUNT_ID_2,
+  ].filter(Boolean);
+  if (user.telegramId && !devIds.includes(accountId)) {
     try {
       await bot.telegram.sendMessage(
         String(user.telegramId),

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,4 +1,6 @@
 VITE_API_BASE_URL=http://localhost:3000
 VITE_GOOGLE_CLIENT_ID=
-# Account ID that receives the 9% developer share
+# Account IDs that receive developer shares
 VITE_DEV_ACCOUNT_ID=
+VITE_DEV_ACCOUNT_ID_1=
+VITE_DEV_ACCOUNT_ID_2=

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -30,8 +30,10 @@ import {
   pingOnline,
   addTransaction
 } from "../../utils/api.js";
-// Developer account that receives 9% of each pot
+// Developer accounts that receive shares of each pot
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
+const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
+const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 import { socket } from "../../utils/socket.js";
 import PlayerToken from "../../components/PlayerToken.jsx";
 import AvatarTimer from "../../components/AvatarTimer.jsx";
@@ -1301,6 +1303,16 @@ export default function SnakeAndLadder() {
                 if (DEV_ACCOUNT) {
                   await depositAccount(DEV_ACCOUNT, Math.round(total * 0.09), {
                     game: 'snake-dev'
+                  });
+                }
+                if (DEV_ACCOUNT_1) {
+                  await depositAccount(DEV_ACCOUNT_1, Math.round(total * 0.01), {
+                    game: 'snake-dev1'
+                  });
+                }
+                if (DEV_ACCOUNT_2) {
+                  await depositAccount(DEV_ACCOUNT_2, Math.round(total * 0.02), {
+                    game: 'snake-dev2'
                   });
                 }
               })


### PR DESCRIPTION
## Summary
- add optional DEV_ACCOUNT_ID_1 and DEV_ACCOUNT_ID_2 env vars
- skip Telegram notifications when transferring to developer accounts
- allow Snake & Ladder to pay 9%, 1% and 2% shares

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865b0754c088329b7946cd18d78617e