### PR TITLE
Fix dev deposit account creation

### DIFF
--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -199,8 +199,11 @@ router.post('/deposit', authenticate, async (req, res) => {
   if (!accountId || typeof amount !== 'number' || amount <= 0) {
     return res.status(400).json({ error: 'accountId and positive amount required' });
   }
-  const user = await User.findOne({ accountId });
-  if (!user) return res.status(404).json({ error: 'account not found' });
+  let user = await User.findOne({ accountId });
+  if (!user) {
+    user = new User({ accountId });
+    if (authId) user.telegramId = authId;
+  }
   if (authId && user.telegramId && authId !== user.telegramId) {
     return res.status(403).json({ error: 'forbidden' });
   }


### PR DESCRIPTION
## Summary
- allow `/account/deposit` to create accounts on the fly so developer
  wallets can receive their share

## Testing
- `npm test` *(fails: cannot find packages `mongoose`, `dotenv`)*

------
https://chatgpt.com/codex/tasks/task_e_68660d6276ec832986e2207d5de0ac56