### PR TITLE
Fix Telegram bot launch conditions

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -38,6 +38,9 @@ if (!process.env.MONGODB_URI) {
   console.log('MONGODB_URI not set, defaulting to in-memory MongoDB');
 }
 
+const skipBot = String(process.env.SKIP_BOT_LAUNCH || '').toLowerCase();
+const SKIP_BOT_LAUNCH = skipBot === '1' || skipBot === 'true';
+
 const PORT = process.env.PORT || 3000;
 const app = express();
 app.use(cors());
@@ -121,7 +124,7 @@ function sendIndex(res) {
 let botLaunchTriggered = false;
 function launchBotWithDelay() {
   if (botLaunchTriggered) return;
-  if (process.env.SKIP_BOT_LAUNCH || !process.env.BOT_TOKEN) {
+  if (SKIP_BOT_LAUNCH || !process.env.BOT_TOKEN) {
     console.log('Skipping Telegram bot launch');
     botLaunchTriggered = true;
     return;
@@ -406,12 +409,12 @@ io.on('connection', (socket) => {
 // Start the server
 httpServer.listen(PORT, async () => {
   console.log(`Server running on port ${PORT}`);
-  if (process.env.SKIP_BOT_LAUNCH || !process.env.BOT_TOKEN) {
+  if (SKIP_BOT_LAUNCH || !process.env.BOT_TOKEN) {
     console.log('Skipping Telegram bot launch');
   }
 });
 
-if (!process.env.SKIP_BOT_LAUNCH && process.env.BOT_TOKEN) {
+if (!SKIP_BOT_LAUNCH && process.env.BOT_TOKEN) {
   process.once('SIGINT', () => bot.stop('SIGINT'));
   process.once('SIGTERM', () => bot.stop('SIGTERM'));
 }


### PR DESCRIPTION
## Summary
- treat `SKIP_BOT_LAUNCH` environment variable as boolean
- check the new `SKIP_BOT_LAUNCH` flag instead of just presence

## Testing
- `npm test` *(fails: duration_ms 1797.500288)*

------
https://chatgpt.com/codex/tasks/task_e_68660d8c8fb88329b606998cc826f778