### PR TITLE
Fix dev wallet & always start Telegram bot

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -139,6 +139,8 @@ function launchBotWithDelay() {
   }, 5000);
 }
 
+launchBotWithDelay();
+
 app.get('/', (req, res) => {
   sendIndex(res);
 });

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -69,7 +69,8 @@ export default function Wallet() {
 
 
   const loadBalances = async () => {
-    let id = localStorage.getItem('accountId');
+    const devMode = urlParams.get('dev') || localStorage.getItem('devAccountId');
+    let id = devMode ? DEV_ACCOUNT_ID : localStorage.getItem('accountId');
     let acc;
     if (id) {
       acc = { accountId: id };


### PR DESCRIPTION
## Summary
- start Telegram bot automatically on server startup
- allow wallet to load developer account when the `dev` query param is present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686616b2042c83298e0b9888ad5f3d42