### PR TITLE
Ensure bot always attempts to start

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -122,12 +122,10 @@ function sendIndex(res) {
 let botLaunchTriggered = false;
 function launchBotWithDelay() {
   if (botLaunchTriggered) return;
-  if (!process.env.BOT_TOKEN || process.env.BOT_TOKEN === 'dummy') {
-    console.log('Skipping Telegram bot launch');
-    botLaunchTriggered = true;
-    return;
-  }
   botLaunchTriggered = true;
+  if (!process.env.BOT_TOKEN || process.env.BOT_TOKEN === 'dummy') {
+    console.log('BOT_TOKEN not configured. Attempting to launch bot anyway');
+  }
   setTimeout(async () => {
     try {
       await bot.launch();
@@ -410,7 +408,7 @@ io.on('connection', (socket) => {
 httpServer.listen(PORT, async () => {
   console.log(`Server running on port ${PORT}`);
   if (!process.env.BOT_TOKEN || process.env.BOT_TOKEN === 'dummy') {
-    console.log('Skipping Telegram bot launch');
+    console.log('BOT_TOKEN not configured. Bot may fail to connect.');
   }
 });
 


### PR DESCRIPTION
## Summary
- always try to launch the Telegram bot instead of skipping when `BOT_TOKEN` isn't configured
- warn when the token is missing but still attempt to launch
- only register shutdown handlers when a real token is provided

## Testing
- `npm test` *(fails: Bot is not running!)*

------
https://chatgpt.com/codex/tasks/task_e_686621eb515083298bae84c161493958