### PR TITLE
Add seat/unseat API test

### DIFF
--- a/test/snakeSeat.test.js
+++ b/test/snakeSeat.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+test('seat and unseat endpoints update lobby', { concurrency: false, timeout: 20000 }, async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3202',
+    MONGODB_URI: 'memory',
+    BOT_TOKEN: 'dummy',
+    SKIP_WEBAPP_BUILD: '1'
+  };
+
+  const server = await startServer(env);
+  try {
+    let res = await fetch('http://localhost:3202/api/snake/table/seat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tableId: 'snake-2', playerId: 'p100', name: 'Tester' })
+    });
+    assert.equal(res.status, 200);
+
+    res = await fetch('http://localhost:3202/api/snake/lobby/snake-2');
+    assert.equal(res.status, 200);
+    let lobby = await res.json();
+    assert.ok(lobby.players.some(p => p.id === 'p100' && p.name === 'Tester'));
+
+    res = await fetch('http://localhost:3202/api/snake/table/unseat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tableId: 'snake-2', playerId: 'p100' })
+    });
+    assert.equal(res.status, 200);
+
+    res = await fetch('http://localhost:3202/api/snake/lobby/snake-2');
+    assert.equal(res.status, 200);
+    lobby = await res.json();
+    assert.ok(!lobby.players.some(p => p.id === 'p100'));
+  } finally {
+    server.kill();
+  }
+});


### PR DESCRIPTION
## Summary
- add a new integration test for seating and unseating snake players

## Testing
- `node --test test/snakeSeat.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686626dad1b08329abc5d07ec0a0f106