### PR TITLE
Fix Telegram bot 409 conflict

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -128,7 +128,13 @@ function launchBotWithDelay() {
   }
   setTimeout(async () => {
     try {
-      await bot.launch();
+      // Ensure no lingering webhook is configured when using polling
+      try {
+        await bot.telegram.deleteWebhook({ drop_pending_updates: true });
+      } catch (err) {
+        console.error('Failed to delete existing webhook:', err.message);
+      }
+      await bot.launch({ dropPendingUpdates: true });
     } catch (err) {
       console.error('Failed to launch Telegram bot:', err.message);
     }


### PR DESCRIPTION
## Summary
- clear existing Telegram webhook before starting the bot
- drop pending updates when launching polling mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68663fea9f8c83298f81f210c8398e2d