### PR TITLE
Handle dev wallets and quit popup

### DIFF
--- a/webapp/src/components/InfoPopup.jsx
+++ b/webapp/src/components/InfoPopup.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
 
-export default function InfoPopup({ open, onClose, title, info }) {
+export default function InfoPopup({ open, onClose, title, info, children }) {
   if (!open) return null;
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
@@ -14,6 +14,7 @@ export default function InfoPopup({ open, onClose, title, info }) {
         </button>
         {title && <h3 className="text-lg font-bold text-center">{title}</h3>}
         {info && <p className="text-sm text-subtext text-center">{info}</p>}
+        {children}
       </div>
     </div>,
     document.body,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1842,7 +1842,16 @@ export default function SnakeAndLadder() {
             </span>
           )
         }
-      />
+      >
+        <div className="flex justify-center mt-2">
+          <button
+            onClick={() => navigate('/games/snake/lobby')}
+            className="lobby-tile px-4 py-1"
+          >
+            Return to Lobby
+          </button>
+        </div>
+      </InfoPopup>
       <GameEndPopup
         open={gameOver}
         ranking={ranking}

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -18,6 +18,13 @@ const DEV_ACCOUNT_ID =
   urlParams.get('dev') ||
   localStorage.getItem('devAccountId') ||
   import.meta.env.VITE_DEV_ACCOUNT_ID;
+const DEV_ACCOUNT_ID_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
+const DEV_ACCOUNT_ID_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
+const DEV_ACCOUNTS = [
+  DEV_ACCOUNT_ID,
+  DEV_ACCOUNT_ID_1,
+  DEV_ACCOUNT_ID_2,
+].filter(Boolean);
 if (urlParams.get('dev')) {
   localStorage.setItem('devAccountId', urlParams.get('dev'));
 }
@@ -101,7 +108,7 @@ export default function Wallet() {
         const txRes = await getAccountTransactions(id);
         const list = txRes.transactions || [];
         setTransactions(list);
-        if (id === DEV_ACCOUNT_ID) {
+        if (DEV_ACCOUNTS.includes(id)) {
           const sum = list
             .filter((t) => t.type === 'deposit' && t.game)
             .reduce((s, t) => s + (t.amount || 0), 0);
@@ -112,7 +119,7 @@ export default function Wallet() {
   }, []);
 
   useEffect(() => {
-    if (accountId === DEV_ACCOUNT_ID) {
+    if (DEV_ACCOUNTS.includes(accountId)) {
       const sum = transactions
         .filter((t) => t.type === 'deposit' && t.game)
         .reduce((s, t) => s + (t.amount || 0), 0);
@@ -152,7 +159,7 @@ export default function Wallet() {
       const txRes = await getAccountTransactions(id || accountId);
       const list = txRes.transactions || [];
       setTransactions(list);
-      if ((id || accountId) === DEV_ACCOUNT_ID) {
+      if (DEV_ACCOUNTS.includes(id || accountId)) {
         const sum = list
           .filter((t) => t.type === 'deposit' && t.game)
           .reduce((s, t) => s + (t.amount || 0), 0);
@@ -204,7 +211,7 @@ export default function Wallet() {
         <p className="text-xl font-medium">
           {tpcBalance === null ? '...' : formatValue(tpcBalance, 2)}
         </p>
-        {accountId === DEV_ACCOUNT_ID && (
+        {DEV_ACCOUNTS.includes(accountId) && (
           <p className="text-sm">9% games: {formatValue(devShare, 2)}</p>
         )}
       </div>


### PR DESCRIPTION
## Summary
- extend InfoPopup to support children so extra actions can be rendered
- show 'Return to Lobby' when opponent quits Snake and Ladder
- detect all developer accounts in wallet page and show dev earnings for each

## Testing
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6866570765d48329a8ef48ffdd13bbf3