### PR TITLE
Fix avatar country names

### DIFF
--- a/webapp/src/utils/avatarUtils.js
+++ b/webapp/src/utils/avatarUtils.js
@@ -53,7 +53,8 @@ export function avatarToName(src) {
       }
       return key
         .replace(/_/g, ' ')
-        .replace(/\b\w/g, (c) => c.toUpperCase());
+        .replace(/\b\w/g, (c) => c.toUpperCase())
+        .replace(/^Flag\s+/i, '');
     }
     return '';
   }


### PR DESCRIPTION
## Summary
- strip leading `Flag` from avatar country names

## Testing
- `npm test` *(fails: test timed out due to missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686662e6c308832984bf8d8cad8ff1d7