### PR TITLE
Remove old profile sections and embed wallet

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -66,7 +66,7 @@ export default function Layout({ children }) {
 
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
 
-      {(isHome || isWallet) && <CosmicBackground />}
+      {(isHome || isWallet || isAccount) && <CosmicBackground />}
 
       <main className={`flex-grow container mx-auto p-4 ${showNavbar ? 'pb-24' : ''}`.trim()}>
 


### PR DESCRIPTION
## Summary
- clean up profile page by dropping Google integration, referrals and old TPC statements
- embed the wallet page in the profile
- show cosmic background on the profile like the wallet page

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686669d568588329b6d15594cf1002d2