### PR TITLE
Add 10k TPC bundle

### DIFF
--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -21,6 +21,7 @@ function normalize(addr) {
 const STORE_ADDRESS_NORM = normalize(STORE_ADDRESS);
 
 const BUNDLES = {
+  '10k': { tpc: 10000, ton: 0.012, label: '10k TPC' },
   '100k': { tpc: 100000, ton: 0.05, label: '100k TPC' },
   '250k': { tpc: 250000, ton: 0.1, label: '250k TPC' }
 };

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -7,6 +7,7 @@ import InfoPopup from '../components/InfoPopup.jsx';
 
 const STORE_ADDRESS = 'UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT';
 const BUNDLES = [
+  { id: '10k', tpc: 10000, ton: 0.012 },
   { id: '20k', tpc: 20000, ton: 0.02 },
   { id: '100k', tpc: 100000, ton: 0.05 },
   { id: '250k', tpc: 250000, ton: 0.1 }
@@ -50,7 +51,7 @@ export default function Store() {
     <div className="relative p-4 space-y-4 text-text">
       <h2 className="text-xl font-bold">Store</h2>
       {BUNDLES.map((b) => (
-        <div key={b.id} className="prism-box p-4 space-y-2 w-72 mx-auto">
+        <div key={b.id} className="prism-box p-4 space-y-2 w-80 mx-auto">
           <div className="text-center font-semibold flex items-center justify-center space-x-1">
             <img src="/icons/TPCcoin.png" alt="TPC" className="w-5 h-5" />
             <span>{b.tpc.toLocaleString()} TPC</span>


### PR DESCRIPTION
## Summary
- update store bundles server-side to include a 10k pack
- list the 10k pack in the webapp store page
- widen store item cards so contents fit nicely

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68667f5c61f4832990c339e8ca791791