### PR TITLE
Integrate Adsgram ad into spin flow

### DIFF
--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -1,20 +1,44 @@
+import { useEffect } from 'react';
+import { ADSGRAM_WALLET } from '../utils/constants.js';
+
 interface AdModalProps {
   open: boolean;
   onClose: () => void;
+  onComplete: () => void;
 }
 
-export default function AdModal({ open, onClose }: AdModalProps) {
+export default function AdModal({ open, onClose, onComplete }: AdModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    const sdk = (window as any).AdsgramSDK;
+    if (sdk?.createVideoAd) {
+      const ad = sdk.createVideoAd({
+        containerId: 'adsgram-player',
+        walletAddress: ADSGRAM_WALLET,
+      });
+      ad.on('finish', () => {
+        onComplete();
+      });
+      return () => ad.destroy?.();
+    }
+  }, [open, onComplete]);
+
   if (!open) return null;
+
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text w-80">
-        <img
-          src="/assets/TonPlayGramLogo.jpg"
-          alt="TonPlaygram Logo"
-          className="w-10 h-10 mx-auto"
-        />
+        <img src="/assets/TonPlayGramLogo.jpg" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
         <h3 className="text-lg font-bold">Watch Ad</h3>
-        <p className="text-sm text-subtext">Watch an ad every hour to get a free spin.</p>
+        <div id="adsgram-player" className="w-full h-40 bg-black" />
+        <video
+          className="w-full h-40"
+          autoPlay
+          controls
+          onEnded={onComplete}
+          src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
+        />
+        <p className="text-sm text-subtext">Watch the ad completely to unlock the spin.</p>
         <button onClick={onClose} className="px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded w-full">
           Close
         </button>

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -28,15 +28,24 @@ export default function SpinPage() {
   const spinning = spinningMain || spinningLeft || spinningMiddle;
   const [multiplier, setMultiplier] = useState(false);
   const [showAd, setShowAd] = useState(false);
+  const [adWatched, setAdWatched] = useState(false);
 
   const mainRef = useRef<SpinWheelHandle>(null);
   const leftRef = useRef<SpinWheelHandle>(null);
   const middleRef = useRef<SpinWheelHandle>(null);
 
+  const ready = canSpin(lastSpin);
+
   useEffect(() => {
     const ts = localStorage.getItem('lastSpin');
     if (ts) setLastSpin(parseInt(ts, 10));
   }, []);
+
+  useEffect(() => {
+    if (ready && !adWatched) {
+      setShowAd(true);
+    }
+  }, [ready, adWatched]);
 
   const handleFinish = async (r: number) => {
     const now = Date.now();
@@ -52,6 +61,10 @@ export default function SpinPage() {
   };
 
   const triggerSpin = () => {
+    if (!adWatched) {
+      setShowAd(true);
+      return;
+    }
     if (spinning || !ready) return;
     if (multiplier) {
       leftRef.current?.spin();
@@ -60,7 +73,10 @@ export default function SpinPage() {
     mainRef.current?.spin();
   };
 
-  const ready = canSpin(lastSpin);
+  const handleAdComplete = () => {
+    setAdWatched(true);
+    setShowAd(false);
+  };
 
   return (
     <div className="p-4 space-y-6 flex flex-col items-center text-text">
@@ -97,14 +113,14 @@ export default function SpinPage() {
           <button
             onClick={triggerSpin}
             className="px-4 py-1 bg-primary hover:bg-primary-hover text-background text-sm font-bold rounded disabled:bg-gray-500"
-            disabled={spinning || !ready}
+            disabled={spinning || !ready || !adWatched}
           >
             Spin
           </button>
           <button
             onClick={() => setMultiplier(m => !m)}
             className="px-4 py-1 bg-primary hover:bg-primary-hover text-background text-sm font-bold rounded"
-            disabled={spinning || !ready}
+            disabled={spinning || !ready || !adWatched}
           >
             x3
           </button>
@@ -123,7 +139,7 @@ export default function SpinPage() {
         onClose={() => setReward(null)}
         message="Keep spinning every day to earn more!"
       />
-      <AdModal open={showAd} onClose={() => setShowAd(false)} />
+      <AdModal open={showAd} onClose={() => setShowAd(false)} onComplete={handleAdComplete} />
     </div>
   );
 }

--- a/webapp/src/utils/constants.js
+++ b/webapp/src/utils/constants.js
@@ -4,3 +4,6 @@ export const DEV_INFO = {
   name: 'Tur.Alimadhi',
   account: '5ffe7c43-c0ae-48f6-ab8c-9e065ca95466',
 };
+
+// TON wallet used for store purchases and Adsgram payouts
+export const ADSGRAM_WALLET = 'UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT';


### PR DESCRIPTION
## Summary
- add `ADSGRAM_WALLET` constant so payouts use the store deposit address
- embed placeholder video ad and Adsgram SDK hook in `AdModal`
- require watching an ad before each spin

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686687698f4c8329afe5c4c537dee6cb