### PR TITLE
Implement claim flow and shorter spin cooldown

### DIFF
--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -22,11 +22,22 @@ export default function SpinGame() {
   const [reward, setReward] = useState(null);
   const [spinning, setSpinning] = useState(false);
   const [showAd, setShowAd] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(0);
 
   useEffect(() => {
     const ts = localStorage.getItem('lastSpin');
     if (ts) setLastSpin(parseInt(ts, 10));
   }, []);
+
+  useEffect(() => {
+    const update = () => {
+      const t = nextSpinTime(lastSpin) - Date.now();
+      setTimeLeft(t > 0 ? t : 0);
+    };
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [lastSpin]);
 
   const handleFinish = async (r) => {
     const now = Date.now();
@@ -38,6 +49,13 @@ export default function SpinGame() {
     const newBalance = (balRes.balance || 0) + r;
     await updateBalance(id, newBalance);
     await addTransaction(id, r, 'spin');
+  };
+
+  const formatTime = (ms) => {
+    const total = Math.ceil(ms / 1000);
+    const m = Math.floor(total / 60);
+    const s = total % 60;
+    return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
   };
 
   const ready = canSpin(lastSpin);
@@ -60,13 +78,13 @@ export default function SpinGame() {
       {!ready && (
         <>
           <p className="text-sm text-white font-semibold">
-            Next spin at {new Date(nextSpinTime(lastSpin)).toLocaleTimeString()}
+            Next spin in {formatTime(timeLeft)}
           </p>
           <button
             className="text-white underline text-sm"
             onClick={() => setShowAd(true)}
           >
-            Watch an ad every hour to get a free spin.
+            Watch an ad every 15 minutes to get a free spin.
           </button>
         </>
       )}

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
-import { createAccount, buyBundle } from '../utils/api.js';
+import { createAccount, buyBundle, claimPurchase } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import InfoPopup from '../components/InfoPopup.jsx';
 
@@ -19,6 +19,7 @@ export default function Store() {
   const walletAddress = useTonAddress();
   const [accountId, setAccountId] = useState('');
   const [msg, setMsg] = useState('');
+  const [claimHash, setClaimHash] = useState('');
 
   useEffect(() => {
     let id;
@@ -37,9 +38,7 @@ export default function Store() {
     };
     try {
       await tonConnectUI.sendTransaction(tx);
-      const hash = prompt('Enter transaction hash');
-      if (!hash) return;
-      const res = await buyBundle(accountId, hash, bundle.id);
+      const res = await buyBundle(accountId, bundle.id);
       if (res.error) setMsg(res.error);
       else setMsg('Purchase successful');
     } catch (e) {
@@ -69,6 +68,28 @@ export default function Store() {
           </button>
         </div>
       ))}
+      <div className="prism-box p-4 space-y-2 w-80 mx-auto">
+        <h3 className="text-center font-semibold">Claim Purchase</h3>
+        <input
+          type="text"
+          placeholder="Transaction hash"
+          value={claimHash}
+          onChange={e => setClaimHash(e.target.value)}
+          className="w-full p-1 text-black rounded"
+        />
+        <button
+          onClick={async () => {
+            if (!claimHash) return;
+            const res = await claimPurchase(accountId, claimHash);
+            if (res.error) setMsg(res.error);
+            else setMsg('Claim successful');
+            setClaimHash('');
+          }}
+          className="lobby-tile w-full cursor-pointer"
+        >
+          Claim
+        </button>
+      </div>
       <InfoPopup open={!!msg} onClose={() => setMsg('')} title="Store" info={msg} />
     </div>
   );

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -29,6 +29,7 @@ export default function SpinPage() {
   const [multiplier, setMultiplier] = useState(false);
   const [showAd, setShowAd] = useState(false);
   const [adWatched, setAdWatched] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(0);
 
   const mainRef = useRef<SpinWheelHandle>(null);
   const leftRef = useRef<SpinWheelHandle>(null);
@@ -40,6 +41,16 @@ export default function SpinPage() {
     const ts = localStorage.getItem('lastSpin');
     if (ts) setLastSpin(parseInt(ts, 10));
   }, []);
+
+  useEffect(() => {
+    const update = () => {
+      const t = nextSpinTime(lastSpin) - Date.now();
+      setTimeLeft(t > 0 ? t : 0);
+    };
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [lastSpin]);
 
   useEffect(() => {
     if (ready && !adWatched) {
@@ -78,6 +89,15 @@ export default function SpinPage() {
     setShowAd(false);
   };
 
+  const spinBtnClass = `px-4 py-1 ${ready && adWatched ? 'bg-green-600 hover:bg-green-500' : 'bg-primary hover:bg-primary-hover'} text-background text-sm font-bold rounded disabled:bg-gray-500`;
+
+  const formatTime = (ms: number) => {
+    const total = Math.ceil(ms / 1000);
+    const m = Math.floor(total / 60);
+    const s = total % 60;
+    return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+  };
+
   return (
     <div className="p-4 space-y-6 flex flex-col items-center text-text">
       <h1 className="text-xl font-bold">Spin &amp; Win</h1>
@@ -112,7 +132,7 @@ export default function SpinPage() {
         <div className="flex space-x-2 mt-4">
           <button
             onClick={triggerSpin}
-            className="px-4 py-1 bg-primary hover:bg-primary-hover text-background text-sm font-bold rounded disabled:bg-gray-500"
+            className={spinBtnClass}
             disabled={spinning || !ready || !adWatched}
           >
             Spin
@@ -127,9 +147,11 @@ export default function SpinPage() {
         </div>
         {!ready && (
           <>
-            <p className="text-sm text-text font-semibold">Next spin at {new Date(nextSpinTime(lastSpin)).toLocaleTimeString()}</p>
+            <p className="text-sm text-text font-semibold">
+              Next spin in {formatTime(timeLeft)}
+            </p>
             <button className="text-text underline text-sm" onClick={() => setShowAd(true)}>
-              Watch an ad every hour to get a free spin.
+              Watch an ad every 15 minutes to get a free spin.
             </button>
           </>
         )}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -376,6 +376,10 @@ export function depositAccount(accountId, amount, extra = {}) {
   return post('/api/account/deposit', { accountId, amount, ...extra });
 }
 
-export function buyBundle(accountId, txHash, bundle) {
-  return post('/api/store/purchase', { accountId, txHash, bundle });
+export function buyBundle(accountId, bundle) {
+  return post('/api/store/purchase', { accountId, bundle });
+}
+
+export function claimPurchase(accountId, txHash) {
+  return post('/api/store/purchase', { accountId, txHash });
 }

--- a/webapp/src/utils/rewardLogic.ts
+++ b/webapp/src/utils/rewardLogic.ts
@@ -1,14 +1,14 @@
 // Prize amounts available on the wheel. Added a 5000 TPC jackpot.
 export const segments = [300, 800, 1000, 1200, 1400, 1500, 1600, 1800, 5000];
-const ONE_HOUR = 3600_000;
+const COOLDOWN = 15 * 60_000; // 15 minutes
 
 export function canSpin(lastSpin: number | null): boolean {
   if (!lastSpin) return true;
-  return Date.now() - lastSpin >= ONE_HOUR;
+  return Date.now() - lastSpin >= COOLDOWN;
 }
 
 export function nextSpinTime(lastSpin: number | null): number {
-  return lastSpin ? lastSpin + ONE_HOUR : Date.now();
+  return lastSpin ? lastSpin + COOLDOWN : Date.now();
 }
 
 export function getRandomReward(): number {


### PR DESCRIPTION
## Summary
- remove transaction hash prompt in store flow and add manual claim feature
- extend server purchase route to verify optional tx hash
- update spin cooldown to 15 minutes with countdown timer
- adjust spin button style when ad watched

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68668ea6c9ac8329a46d573ed9cd9409