### PR TITLE
Implement free spins and ad gating

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -43,7 +43,7 @@ export default function DailyCheckIn() {
     return Date.now() - parseInt(ts, 10) >= ONE_DAY;
   });
 
-  const [reward, setReward] = useState(null);
+  const [reward, setReward] = useState<{ type: 'tpc'; value: number } | null>(null);
 
   useEffect(() => {
     async function fetchData() {
@@ -78,7 +78,7 @@ export default function DailyCheckIn() {
         return;
       }
       setStreak(res.streak);
-      setReward(res.reward);
+      setReward({ type: 'tpc', value: res.reward });
       const now = Date.now();
       setLastCheck(now);
       localStorage.setItem('lastCheckIn', String(now));

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import confetti from 'canvas-confetti';
 
 interface RewardPopupProps {
-  reward: number | null;
+  reward: { type: 'tpc'; value: number } | { type: 'spin'; value: number } | null;
   onClose: () => void;
   message?: string;
 }
@@ -12,6 +12,10 @@ export default function RewardPopup({ reward, onClose, message }: RewardPopupPro
   useEffect(() => {
     confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
   }, []);
+  const rewardText =
+    reward.type === 'tpc'
+      ? `+${reward.value} TPC`
+      : `+${reward.value} Free Spin${reward.value > 1 ? 's' : ''}`;
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text w-80">
@@ -21,7 +25,7 @@ export default function RewardPopup({ reward, onClose, message }: RewardPopupPro
           className="w-10 h-10 mx-auto"
         />
         <h3 className="text-lg font-bold">Reward Earned</h3>
-        <div className="text-accent text-3xl">+{reward} TPC</div>
+        <div className="text-accent text-3xl">{rewardText}</div>
         {message && <p className="text-sm text-subtext">{message}</p>}
         <button
           onClick={onClose}

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import SpinWheel from './SpinWheel.tsx';
 import RewardPopup from './RewardPopup.tsx';
 import AdModal from './AdModal.tsx';
-import { canSpin, nextSpinTime } from '../utils/rewardLogic';
+import { canSpin, nextSpinTime, Segment } from '../utils/rewardLogic';
 import {
   getWalletBalance,
   updateBalance,
@@ -20,6 +20,7 @@ export default function SpinGame() {
   }
   const [lastSpin, setLastSpin] = useState(null);
   const [reward, setReward] = useState(null);
+  const [freeSpins, setFreeSpins] = useState(0);
   const [spinning, setSpinning] = useState(false);
   const [showAd, setShowAd] = useState(false);
   const [timeLeft, setTimeLeft] = useState(0);
@@ -40,15 +41,20 @@ export default function SpinGame() {
   }, [lastSpin]);
 
   const handleFinish = async (r) => {
-    const now = Date.now();
-    localStorage.setItem('lastSpin', String(now));
-    setLastSpin(now);
-    setReward(r);
-    const id = telegramId;
-    const balRes = await getWalletBalance(id);
-    const newBalance = (balRes.balance || 0) + r;
-    await updateBalance(id, newBalance);
-    await addTransaction(id, r, 'spin');
+    if (r.type === 'tpc') {
+      const now = Date.now();
+      localStorage.setItem('lastSpin', String(now));
+      setLastSpin(now);
+      setReward(r);
+      const id = telegramId;
+      const balRes = await getWalletBalance(id);
+      const newBalance = (balRes.balance || 0) + r.value;
+      await updateBalance(id, newBalance);
+      await addTransaction(id, r.value, 'spin');
+    } else {
+      setReward(r);
+      setFreeSpins(fs => fs + r.value);
+    }
   };
 
   const formatTime = (ms) => {

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -1,8 +1,8 @@
-import {  forwardRef, useImperativeHandle } from 'react';
+import { forwardRef, useImperativeHandle } from 'react';
 import { useState, useEffect, useRef } from 'react';
 import { getGameVolume } from '../utils/sound.js';
 
-import { segments } from '../utils/rewardLogic';
+import { segments, Segment } from '../utils/rewardLogic';
 
 export interface SpinWheelHandle {
   spin: () => void;
@@ -10,7 +10,7 @@ export interface SpinWheelHandle {
 
 interface SpinWheelProps {
 
-  onFinish: (reward: number) => void;
+  onFinish: (reward: Segment) => void;
 
   spinning: boolean;
 
@@ -73,7 +73,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
     return () => window.removeEventListener('gameVolumeChanged', handler);
   }, []);
 
-  const items = Array.from(
+  const items: Segment[] = Array.from(
     { length: segments.length * loops * maxSpins + visibleRows },
     (_, i) => segments[i % segments.length]
   );
@@ -155,27 +155,25 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
         >
 
           {items.map((val, idx) => (
-
             <div
-
               key={idx}
-
               className={`board-style flex items-center justify-center text-sm w-32 font-bold ${
-
                 idx === winnerIndex ? 'bg-yellow-300 text-black' : 'text-white'
-
               }`}
-
               style={{ height: itemHeight }}
-
             >
-
-              <img src="/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 mr-1" />
-
-              <span>{val >= 1000 ? `${val / 1000}k` : val}</span>
-
+              {val.type === 'tpc' ? (
+                <>
+                  <img src="/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 mr-1" />
+                  <span>{val.value >= 1000 ? `${val.value / 1000}k` : val.value}</span>
+                </>
+              ) : (
+                <>
+                  <img src="/assets/icons/FreeSpin.png" alt="Free Spin" className="w-8 h-8 mr-1" />
+                  <span className="text-red-500 font-bold">{val.value}</span>
+                </>
+              )}
             </div>
-
           ))}
 
         </div>

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import SpinWheel, { SpinWheelHandle } from '../components/SpinWheel.tsx';
 import RewardPopup from '../components/RewardPopup.tsx';
 import AdModal from '../components/AdModal.tsx';
-import { canSpin, nextSpinTime } from '../utils/rewardLogic';
+import { canSpin, nextSpinTime, Segment } from '../utils/rewardLogic';
 import {
   getWalletBalance,
   updateBalance,
@@ -21,7 +21,7 @@ export default function SpinPage() {
     return <LoginOptions />;
   }
   const [lastSpin, setLastSpin] = useState<number | null>(null);
-  const [reward, setReward] = useState<number | null>(null);
+  const [reward, setReward] = useState<Segment | null>(null);
   const [spinningMain, setSpinningMain] = useState(false);
   const [spinningLeft, setSpinningLeft] = useState(false);
   const [spinningMiddle, setSpinningMiddle] = useState(false);
@@ -29,6 +29,7 @@ export default function SpinPage() {
   const [multiplier, setMultiplier] = useState(false);
   const [showAd, setShowAd] = useState(false);
   const [adWatched, setAdWatched] = useState(false);
+  const [freeSpins, setFreeSpins] = useState(0);
   const [timeLeft, setTimeLeft] = useState(0);
 
   const mainRef = useRef<SpinWheelHandle>(null);
@@ -52,32 +53,47 @@ export default function SpinPage() {
     return () => clearInterval(id);
   }, [lastSpin]);
 
-  useEffect(() => {
-    if (ready && !adWatched) {
-      setShowAd(true);
-    }
-  }, [ready, adWatched]);
 
-  const handleFinish = async (r: number) => {
-    const now = Date.now();
-    localStorage.setItem('lastSpin', String(now));
-    setLastSpin(now);
-    const finalReward = multiplier ? r * 3 : r;
-    setReward(finalReward);
-    const id = telegramId;
-    const balRes = await getWalletBalance(id);
-    const newBalance = (balRes.balance || 0) + finalReward;
-    await updateBalance(id, newBalance);
-    await addTransaction(id, finalReward, 'spin');
+  const usingFreeSpinRef = useRef(false);
+
+  const handleFinish = async (r: Segment) => {
+    if (!usingFreeSpinRef.current) {
+      const now = Date.now();
+      localStorage.setItem('lastSpin', String(now));
+      setLastSpin(now);
+      setAdWatched(false);
+    }
+
+    if (r.type === 'tpc') {
+      const finalReward = multiplier ? r.value * 3 : r.value;
+      setReward({ type: 'tpc', value: finalReward });
+      const id = telegramId;
+      const balRes = await getWalletBalance(id);
+      const newBalance = (balRes.balance || 0) + finalReward;
+      await updateBalance(id, newBalance);
+      await addTransaction(id, finalReward, 'spin');
+    } else {
+      setReward({ type: 'spin', value: r.value });
+      setFreeSpins(fs => fs + r.value);
+    }
+    usingFreeSpinRef.current = false;
   };
 
   const triggerSpin = () => {
-    if (!adWatched) {
-      setShowAd(true);
-      return;
+    if (spinning) return;
+
+    if (freeSpins === 0) {
+      if (!ready) return;
+      if (!adWatched) {
+        setShowAd(true);
+        return;
+      }
+    } else {
+      usingFreeSpinRef.current = true;
+      setFreeSpins(fs => fs - 1);
     }
-    if (spinning || !ready) return;
-    if (multiplier) {
+
+    if (multiplier && freeSpins === 0) {
       leftRef.current?.spin();
       middleRef.current?.spin();
     }
@@ -89,7 +105,11 @@ export default function SpinPage() {
     setShowAd(false);
   };
 
-  const spinBtnClass = `px-4 py-1 ${ready && adWatched ? 'bg-green-600 hover:bg-green-500' : 'bg-primary hover:bg-primary-hover'} text-background text-sm font-bold rounded disabled:bg-gray-500`;
+  const spinBtnClass = `px-4 py-1 ${
+    (freeSpins > 0 || (ready && adWatched))
+      ? 'bg-green-600 hover:bg-green-500'
+      : 'bg-primary hover:bg-primary-hover'
+  } text-background text-sm font-bold rounded disabled:bg-gray-500`;
 
   const formatTime = (ms: number) => {
     const total = Math.ceil(ms / 1000);
@@ -133,18 +153,21 @@ export default function SpinPage() {
           <button
             onClick={triggerSpin}
             className={spinBtnClass}
-            disabled={spinning || !ready || !adWatched}
+            disabled={spinning || (freeSpins === 0 && (!ready || !adWatched))}
           >
             Spin
           </button>
           <button
             onClick={() => setMultiplier(m => !m)}
             className="px-4 py-1 bg-primary hover:bg-primary-hover text-background text-sm font-bold rounded"
-            disabled={spinning || !ready || !adWatched}
+            disabled={spinning || (freeSpins === 0 && (!ready || !adWatched))}
           >
             x3
           </button>
         </div>
+        {freeSpins > 0 && (
+          <p className="text-sm text-text font-semibold">Free spins left: {freeSpins}</p>
+        )}
         {!ready && (
           <>
             <p className="text-sm text-text font-semibold">

--- a/webapp/src/utils/rewardLogic.ts
+++ b/webapp/src/utils/rewardLogic.ts
@@ -1,5 +1,25 @@
 // Prize amounts available on the wheel. Added a 5000 TPC jackpot.
-export const segments = [300, 800, 1000, 1200, 1400, 1500, 1600, 1800, 5000];
+export type Segment =
+  | { type: 'tpc'; value: number }
+  | { type: 'spin'; value: number };
+
+// Mix TPC prizes with free spin rewards
+export const segments: Segment[] = [
+  { type: 'tpc', value: 300 },
+  { type: 'spin', value: 1 },
+  { type: 'tpc', value: 800 },
+  { type: 'spin', value: 2 },
+  { type: 'tpc', value: 1000 },
+  { type: 'spin', value: 3 },
+  { type: 'tpc', value: 1200 },
+  { type: 'spin', value: 4 },
+  { type: 'tpc', value: 1400 },
+  { type: 'tpc', value: 1500 },
+  { type: 'tpc', value: 1600 },
+  { type: 'spin', value: 5 },
+  { type: 'tpc', value: 1800 },
+  { type: 'tpc', value: 5000 },
+];
 const COOLDOWN = 15 * 60_000; // 15 minutes
 
 export function canSpin(lastSpin: number | null): boolean {
@@ -11,7 +31,7 @@ export function nextSpinTime(lastSpin: number | null): number {
   return lastSpin ? lastSpin + COOLDOWN : Date.now();
 }
 
-export function getRandomReward(): number {
+export function getRandomReward(): Segment {
   const index = Math.floor(Math.random() * segments.length);
   return segments[index];
 }


### PR DESCRIPTION
## Summary
- mix five free spin slots into the spin wheel
- show icon and red value for free spins
- require ad view before spin button turns green
- display free spin rewards in popup

## Testing
- `npm test` *(fails: snake API tests require unavailable packages)*

------
https://chatgpt.com/codex/tasks/task_e_6866ac26d82483299cf008f1dc65023f