### PR TITLE
Update README with webapp environment vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ this account.
 
 Both `.env` files are excluded from version control via `.gitignore` so your credentials remain private.
 
+The server honors a few extra environment variables when building or serving the webapp:
+
+- `WEBAPP_API_BASE_URL` – overrides the API base used during the webapp build. Set this when the bot API is hosted on another domain or port. If left empty the webapp assumes it is served from the same origin.
+- `TONCONNECT_MANIFEST_URL` – full URL for a custom `tonconnect-manifest.json`. Defaults to the manifest bundled with the build when unset.
+- `SKIP_WEBAPP_BUILD` – set to any value to skip the automatic webapp build that normally runs when `npm start` is executed. Useful if you built the assets manually.
+
 5. Install the Python requirements for the dice roller:
 
    ```bash


### PR DESCRIPTION
## Summary
- document `WEBAPP_API_BASE_URL`, `TONCONNECT_MANIFEST_URL` and `SKIP_WEBAPP_BUILD`

## Testing
- `npm test` *(fails: tests 12, pass 7, fail 2)*

------
https://chatgpt.com/codex/tasks/task_e_6866cf69996c8329bcee683f02f6ad0d