### PR TITLE
Move TPC claim notice outside claim form

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -75,10 +75,6 @@ export default function Store() {
       ))}
       <div className="prism-box p-4 space-y-2 w-80 mx-auto">
         <h3 className="text-center font-semibold">Claim Purchase</h3>
-        <p className="text-center text-xs text-subtext">
-          We are truly sorry if your TPC wasn't delivered. Please enter your
-          transaction hash below to claim it.
-        </p>
         <input
           type="text"
           placeholder="Transaction hash"
@@ -104,6 +100,10 @@ export default function Store() {
           Claim
         </button>
       </div>
+      <p className="text-center text-xs text-subtext">
+        We are truly sorry if your TPC wasn't delivered. Please enter your
+        transaction hash below to claim it.
+      </p>
       <InfoPopup open={!!msg} onClose={() => setMsg('')} title="Store" info={msg} />
     </div>
   );


### PR DESCRIPTION
## Summary
- rearrange Store page layout so the apology text sits outside the prism box

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6866d111da408329ab0d3578b12a6196