### PR TITLE
Fix telegram invite notifications

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -66,16 +66,11 @@ export async function sendInviteNotification(
     ],
   };
 
-  if (info?.photoUrl) {
-    await bot.telegram.sendPhoto(String(toId), { url: info.photoUrl }, {
-      caption,
-      reply_markup: replyMarkup,
-    });
-  } else {
-    await bot.telegram.sendMessage(String(toId), caption, {
-      reply_markup: replyMarkup,
-    });
-  }
+  const photo = info?.photoUrl ? { url: info.photoUrl } : { source: coinPath };
+  await bot.telegram.sendPhoto(String(toId), photo, {
+    caption,
+    reply_markup: replyMarkup,
+  });
 
   return url;
 }


### PR DESCRIPTION
## Summary
- always send a photo when notifying game invitations

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686754b6d3008329993b690776f95dbe