### PR TITLE
Add telegram id support for game invites

### DIFF
--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -306,8 +306,10 @@ export default function Friends() {
               'invite1v1',
               {
                 fromId: accountId,
+                fromTelegramId: telegramId,
                 fromName: myName,
                 toId: inviteTarget.accountId,
+                toTelegramId: inviteTarget.telegramId,
                 roomId,
                 token: stake.token,
                 amount: stake.amount,
@@ -339,8 +341,10 @@ export default function Friends() {
               'inviteGroup',
               {
                 fromId: accountId,
+                fromTelegramId: telegramId,
                 fromName: myName,
                 toIds: selected.map((u) => u.accountId),
+                telegramIds: selected.map((u) => u.telegramId),
                 opponentNames: selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim()),
                 roomId,
                 token: stake.token,


### PR DESCRIPTION
## Summary
- include telegram IDs when sending game invites
- pass telegram IDs to notify via Telegram

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686767327cb88329b009f03a5b5257e0