### PR TITLE
Add BONUS X3 bonus wheel feature

### DIFF
--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
 import confetti from 'canvas-confetti';
+import { Segment } from '../utils/rewardLogic';
 
 interface RewardPopupProps {
-  reward: number | null;
+  reward: Segment | null;
   onClose: () => void;
   message?: string;
 }
@@ -22,10 +23,11 @@ export default function RewardPopup({ reward, onClose, message }: RewardPopupPro
         />
         <h3 className="text-lg font-bold">Reward Earned</h3>
         <div className="text-accent text-3xl">
-          {reward === 1600 && '+1 Free Spin'}
-          {reward === 1800 && '+2 Free Spins'}
-          {reward === 5000 && '+3 Free Spins'}
-          {reward !== 1600 && reward !== 1800 && reward !== 5000 && `+${reward} TPC`}
+          {reward === 'BONUS_X3' && 'BONUS X3'}
+          {typeof reward === 'number' && reward === 1600 && '+1 Free Spin'}
+          {typeof reward === 'number' && reward === 1800 && '+2 Free Spins'}
+          {typeof reward === 'number' && reward === 5000 && '+3 Free Spins'}
+          {typeof reward === 'number' && reward !== 1600 && reward !== 1800 && reward !== 5000 && `+${reward} TPC`}
         </div>
         {message && <p className="text-sm text-subtext">{message}</p>}
         <button

--- a/webapp/src/utils/rewardLogic.ts
+++ b/webapp/src/utils/rewardLogic.ts
@@ -1,5 +1,18 @@
 // Prize amounts available on the wheel. Added a 5000 TPC jackpot.
-export const segments = [300, 800, 1000, 1200, 1400, 1500, 1600, 1800, 5000];
+export type Segment = number | 'BONUS_X3';
+
+export const segments: Segment[] = [
+  300,
+  800,
+  1000,
+  1200,
+  1400,
+  1500,
+  1600,
+  1800,
+  5000,
+  'BONUS_X3',
+];
 const COOLDOWN = 15 * 60_000; // 15 minutes
 
 export function canSpin(lastSpin: number | null): boolean {
@@ -11,7 +24,7 @@ export function nextSpinTime(lastSpin: number | null): number {
   return lastSpin ? lastSpin + COOLDOWN : Date.now();
 }
 
-export function getRandomReward(): number {
+export function getRandomReward(): Segment {
   const index = Math.floor(Math.random() * segments.length);
   return segments[index];
 }


### PR DESCRIPTION
## Summary
- randomize wheel prizes after each spin
- add `BONUS_X3` reward type
- show Bonus X3 in wheel and reward popup
- allow activating two bonus wheels when `BONUS_X3` hit
- spin three wheels simultaneously when bonus active

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' etc.)*
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_686770f79f688329ba38a8c2ad37e306