### PR TITLE
Add styled transaction image for TPC notifications

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -7,16 +7,17 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "canvas": "^2.11.2",
+    "compression": "^1.7.4",
+    "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "https-proxy-agent": "^7.0.2",
-    "mongoose": "^7.6.0",
-    "telegraf": "^4.12.2",
     "mongodb-memory-server": "^10.1.4",
-    "compression": "^1.7.4",
+    "mongoose": "^7.6.0",
     "socket.io": "^4.7.5",
-    "cors": "^2.8.5",
-    "uuid": "^9.0.1",
-    "tonweb": "^0.0.66"
+    "telegraf": "^4.12.2",
+    "tonweb": "^0.0.66",
+    "uuid": "^9.0.1"
   }
 }

--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { createCanvas, loadImage } from 'canvas';
 import { fetchTelegramInfo } from './telegram.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,6 +13,47 @@ export function getInviteUrl(roomId, token, amount) {
   return `${baseUrl}/games/snake?table=${roomId}&token=${token}&amount=${amount}`;
 }
 
+async function renderTransferImage(name, amount, date) {
+  const width = 320;
+  const height = 180;
+  const canvas = createCanvas(width, height);
+  const ctx = canvas.getContext('2d');
+
+  ctx.fillStyle = '#2d5c66';
+  ctx.fillRect(0, 0, width, height);
+  ctx.strokeStyle = '#334155';
+  ctx.lineWidth = 4;
+  ctx.strokeRect(0, 0, width, height);
+
+  ctx.fillStyle = '#ffffff';
+  ctx.font = 'bold 18px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.fillText('TPC Statement Details', width / 2, 32);
+
+  const sign = amount > 0 ? '+' : '-';
+  const formatted = Math.abs(amount).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const text = `Received ${sign}${formatted} TPC`;
+  ctx.font = 'bold 16px sans-serif';
+  ctx.fillText(text, width / 2, 70);
+
+  ctx.font = '14px sans-serif';
+  ctx.fillText(`From: ${name}`, width / 2, 100);
+
+  ctx.font = '12px sans-serif';
+  ctx.fillText(date.toLocaleString(), width / 2, height - 20);
+
+  try {
+    const coin = await loadImage(coinPath);
+    const tw = ctx.measureText(text).width;
+    ctx.drawImage(coin, width / 2 + tw / 2 + 6, 54, 24, 24);
+  } catch {}
+
+  return canvas.toBuffer();
+}
+
 export async function sendTransferNotification(bot, toId, fromId, amount) {
   let info;
   try {
@@ -22,13 +64,9 @@ export async function sendTransferNotification(bot, toId, fromId, amount) {
   const name =
     (info?.firstName || '') + (info?.lastName ? ` ${info.lastName}` : '') ||
     String(fromId);
-  const caption = `\u{1FA99} You received ${amount} TPC from ${name}`;
-  const photo = info?.photoUrl
-    ? { url: info.photoUrl }
-    : { source: coinPath };
-  await bot.telegram.sendPhoto(String(toId), photo, {
-    caption,
-  });
+
+  const buffer = await renderTransferImage(name, amount, new Date());
+  await bot.telegram.sendPhoto(String(toId), { source: buffer });
 }
 
 export async function sendInviteNotification(


### PR DESCRIPTION
## Summary
- generate a transaction details image using `canvas`
- use the image when notifying a user about incoming TPC transfers
- add `canvas` as a bot dependency

## Testing
- `npm test` *(fails: Operation `gameresults.insertOne()` buffering timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686775a8af84832982ec2a71a5202e30