### PR TITLE
Fix game invite notifications

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -135,10 +135,14 @@ export async function sendInviteNotification(
   };
 
   const photo = info?.photoUrl ? { url: info.photoUrl } : { source: coinPath };
+
   await bot.telegram.sendPhoto(String(toId), photo, {
     caption,
     reply_markup: replyMarkup,
   });
+
+  // Also send a plain text notification like TPC receipts
+  await sendTPCNotification(bot, toId, caption);
 
   return url;
 }


### PR DESCRIPTION
## Summary
- send a plain text Telegram message in addition to photo when notifying about game invites

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68678c4662c08329b6a9dd414606a672