### PR TITLE
Update transfer notification to show avatar

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -92,11 +92,12 @@ export async function sendTransferNotification(bot, toId, fromId, amount) {
     'TPC Statement Details',
     `You received ${sign}${formatted} TPC ${coinIcon}`,
     `From: ${name} ${profileIcon}`,
-    `TPC Account #${fromId}`,
     new Date().toLocaleString(),
   ];
 
-  await bot.telegram.sendMessage(String(toId), lines.join('\n'));
+  const caption = lines.join('\n');
+  const photo = info?.photoUrl ? { url: info.photoUrl } : { source: coinPath };
+  await bot.telegram.sendPhoto(String(toId), photo, { caption });
 }
 
 export async function sendInviteNotification(


### PR DESCRIPTION
## Summary
- show Telegram username instead of account ID in transfer notification
- include sender's profile photo with the message

## Testing
- `npm test` *(fails: Operation `gameresults.insertOne()` buffering timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68678bcfbde88329b29b6f5e7021686a