### PR TITLE
Add note field and send HD transfer images

### DIFF
--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -58,6 +58,7 @@ export default function Wallet() {
   const [tpcBalance, setTpcBalance] = useState(null);
   const [receiver, setReceiver] = useState('');
   const [amount, setAmount] = useState('');
+  const [note, setNote] = useState('');
   const [transactions, setTransactions] = useState([]);
   const [devShare, setDevShare] = useState(0);
   const [feeShare, setFeeShare] = useState(0);
@@ -153,7 +154,7 @@ export default function Wallet() {
     setConfirmOpen(false);
     setSending(true);
     try {
-      const res = await sendAccountTpc(accountId, to, amt);
+    const res = await sendAccountTpc(accountId, to, amt, note.trim());
       if (res?.error) {
         if (res.error === 'unauthorized' || res.error === 'forbidden') {
           setErrorMsg(
@@ -167,6 +168,7 @@ export default function Wallet() {
       setReceipt(res.transaction);
       setReceiver('');
       setAmount('');
+      setNote('');
       const id = await loadBalances();
       const txRes = await getAccountTransactions(id || accountId);
       const list = txRes.transactions || [];
@@ -284,6 +286,14 @@ export default function Wallet() {
             placeholder="Amount"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
+            className="border p-1 rounded w-full max-w-xs mx-auto mt-1 text-black"
+          />
+          <input
+            type="text"
+            placeholder="Note (optional)"
+            value={note}
+            maxLength={150}
+            onChange={(e) => setNote(e.target.value.slice(0, 150))}
             className="border p-1 rounded w-full max-w-xs mx-auto mt-1 text-black"
           />
           <button

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -158,11 +158,11 @@ export function getTonBalance(address) {
 export function getUsdtBalance(address) {
   return post('/api/wallet/usdt-balance', { address });
 }
+export function sendTpc(fromId, toId, amount, note) {
 
-export function sendTpc(fromId, toId, amount) {
-
-  return post('/api/wallet/send', { fromId, toId, amount });
-
+  const body = { fromId, toId, amount };
+  if (note) body.note = note;
+  return post("/api/wallet/send", body);
 }
 
 export function getTransactions(telegramId) {
@@ -372,8 +372,10 @@ export function getAccountBalance(accountId) {
   return post('/api/account/balance', { accountId });
 }
 
-export function sendAccountTpc(fromAccount, toAccount, amount) {
-  return post('/api/account/send', { fromAccount, toAccount, amount });
+export function sendAccountTpc(fromAccount, toAccount, amount, note) {
+  const body = { fromAccount, toAccount, amount };
+  if (note) body.note = note;
+  return post('/api/account/send', body);
 }
 
 export function getAccountTransactions(accountId) {


### PR DESCRIPTION
## Summary
- upgrade transfer notification images to HD and render via `sendPhoto`
- attach optional note to transfers (client & server)
- display note input in wallet page
- allow note param in API utilities

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6867978f00a08329b8be89840448f557