### PR TITLE
Add new presale tiers and neon store design

### DIFF
--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -23,19 +23,14 @@ const STORE_ADDRESS_NORM = normalize(STORE_ADDRESS);
 const BOOST_EXPIRY = new Date('2025-08-21T00:00:00Z');
 
 const BUNDLES = {
-  '10k': { tpc: 10000, ton: 0.012, label: '10k TPC' },
-  '25k': { tpc: 25000, ton: 0.02, label: '25k TPC' },
-  '50k': { tpc: 50000, ton: 0.03, label: '50k TPC' },
-  '100k': { tpc: 100000, ton: 0.06, label: '100k TPC' },
-  '250k': { tpc: 250000, ton: 0.12, label: '250k TPC' },
-  '500k': { tpc: 500000, ton: 0.2, label: '500k TPC' },
-
-  '1m': { tpc: 1000000, ton: 0.35, label: '1M TPC', boost: 0.05 },
-  '2m5': { tpc: 2500000, ton: 0.80, label: '2.5M TPC', boost: 0.07 },
-  '5m': { tpc: 5000000, ton: 1.40, label: '5M TPC', boost: 0.10 },
-  '10m': { tpc: 10000000, ton: 2.40, label: '10M TPC', boost: 0.12 },
-  '25m': { tpc: 25000000, ton: 5.50, label: '25M TPC', boost: 0.15 },
-  '50m': { tpc: 50000000, ton: 9.50, label: '50M TPC', boost: 0.20 },
+  newbie: { tpc: 25000, ton: 0.25, label: 'Newbie Pack', supply: 500000 },
+  rookie: { tpc: 50000, ton: 0.4, label: 'Rookie', supply: 1000000 },
+  starter: { tpc: 100000, ton: 0.75, label: 'Starter', supply: 2000000 },
+  miner: { tpc: 250000, ton: 1.6, label: 'Miner Pack', boost: 0.03, supply: 5000000 },
+  grinder: { tpc: 500000, ton: 3.0, label: 'Grinder', boost: 0.05, supply: 7500000 },
+  pro: { tpc: 1000000, ton: 5.5, label: 'Pro Bundle', boost: 0.08, supply: 10000000 },
+  whale: { tpc: 2500000, ton: 10.5, label: 'Whale Bundle', boost: 0.12, supply: 12500000 },
+  max: { tpc: 5000000, ton: 20, label: 'Max Presale', boost: 0.15, supply: 15000000 },
 };
 
 router.post('/purchase', authenticate, async (req, res) => {

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1186,3 +1186,15 @@ input:focus {
     background-position: -400px 0, 400px 0, -200px 0;
   }
 }
+
+/* Store page styles */
+.store-card {
+  @apply prism-box flex-col space-y-2 rounded-xl p-4 items-center;
+  box-shadow: 0 0 12px rgba(0, 247, 255, 0.5);
+}
+
+.buy-button {
+  @apply lobby-tile w-full rounded-full cursor-pointer text-black bg-primary;
+  box-shadow: 0 0 8px #00f7ff, 0 0 16px #00f7ff;
+}
+

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -7,19 +7,14 @@ import InfoPopup from '../components/InfoPopup.jsx';
 
 const STORE_ADDRESS = 'UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT';
 const BUNDLES = [
-  { id: '10k', tpc: 10000, ton: 0.012 },
-  { id: '25k', tpc: 25000, ton: 0.02 },
-  { id: '50k', tpc: 50000, ton: 0.03 },
-  { id: '100k', tpc: 100000, ton: 0.06 },
-  { id: '250k', tpc: 250000, ton: 0.12 },
-  { id: '500k', tpc: 500000, ton: 0.2 },
-
-  { id: '1m', tpc: 1000000, ton: 0.35, boost: 0.05, presale: true },
-  { id: '2m5', tpc: 2500000, ton: 0.80, boost: 0.07, presale: true },
-  { id: '5m', tpc: 5000000, ton: 1.40, boost: 0.10, presale: true },
-  { id: '10m', tpc: 10000000, ton: 2.40, boost: 0.12, presale: true },
-  { id: '25m', tpc: 25000000, ton: 5.50, boost: 0.15, presale: true },
-  { id: '50m', tpc: 50000000, ton: 9.50, boost: 0.20, presale: true }
+  { id: 'newbie', name: 'Newbie Pack', icon: '🌱', tpc: 25000, ton: 0.25, supply: '0.5M', boost: 0, presale: true },
+  { id: 'rookie', name: 'Rookie', icon: '🎯', tpc: 50000, ton: 0.4, supply: '1M', boost: 0, presale: true },
+  { id: 'starter', name: 'Starter', icon: '🚀', tpc: 100000, ton: 0.75, supply: '2M', boost: 0, presale: true },
+  { id: 'miner', name: 'Miner Pack', icon: '⛏️', tpc: 250000, ton: 1.6, supply: '5M', boost: 0.03, presale: true },
+  { id: 'grinder', name: 'Grinder', icon: '⚙️', tpc: 500000, ton: 3.0, supply: '7.5M', boost: 0.05, presale: true },
+  { id: 'pro', name: 'Pro Bundle', icon: '🏆', tpc: 1000000, ton: 5.5, supply: '10M', boost: 0.08, presale: true },
+  { id: 'whale', name: 'Whale Bundle', icon: '🐋', tpc: 2500000, ton: 10.5, supply: '12.5M', boost: 0.12, presale: true },
+  { id: 'max', name: 'Max Presale', icon: '👑', tpc: 5000000, ton: 20, supply: '15M', boost: 0.15, presale: true }
 ];
 
 export default function Store() {
@@ -58,34 +53,30 @@ export default function Store() {
   return (
     <div className="relative p-4 space-y-4 text-text">
       <h2 className="text-xl font-bold">Store</h2>
-      {BUNDLES.sort((a, b) => a.tpc - b.tpc).map((b) => (
+      {BUNDLES.map((b) => (
         <div
           key={b.id}
-          className="prism-box p-4 space-y-2 w-80 mx-auto flex flex-col items-center"
+          className="store-card w-80 mx-auto"
         >
+          <div className="flex items-center space-x-2">
+            <span className="text-xl">{b.icon}</span>
+            <h3 className="font-semibold">{b.name}</h3>
+          </div>
+          <div className="text-lg font-bold">{b.tpc.toLocaleString()} TPC</div>
+          <div className="text-primary text-lg">{b.ton} TON</div>
+          <div className="text-xs text-accent">Presale Bundle</div>
+          <div className="text-sm">
+            {b.boost ? `Mining Boost: +${b.boost * 100}%` : 'No Mining Boost'}
+          </div>
+          {b.supply && (
+            <div className="text-xs text-subtext">Supply Cap: {b.supply}</div>
+          )}
           <button
             onClick={() => handleBuy(b)}
-            className="lobby-tile px-4 cursor-pointer"
+            className="buy-button mt-2"
           >
             Buy
           </button>
-          <div className="mt-auto flex flex-col space-y-1 w-full">
-            <div className="text-center font-semibold flex items-center justify-center space-x-1">
-              <img src="/icons/TPCcoin.png" alt="TPC" className="w-5 h-5" />
-              <span>{b.tpc.toLocaleString()}</span>
-            </div>
-            <div className="text-center text-sm flex items-center justify-center space-x-1">
-              <span>Price:</span>
-              <img src="/icons/TON.png" alt="TON" className="w-5 h-5" />
-              <span>{b.ton}</span>
-            </div>
-            {b.presale && (
-              <div className="text-center text-xs text-accent">Presale Bundle</div>
-            )}
-            {b.boost && (
-              <div className="text-center text-xs">Mining Boost: +{b.boost * 100}%</div>
-            )}
-          </div>
         </div>
       ))}
       <div className="prism-box p-4 space-y-2 w-80 mx-auto">


### PR DESCRIPTION
## Summary
- replace old store bundles with new presale tiers in API and webapp
- redesign store page cards and buy button for neon theme

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867a03330788329a2114ed11ef2bb59