### PR TITLE
Add developer broadcast panel

### DIFF
--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -393,3 +393,7 @@ export function buyBundle(accountId, bundle) {
 export function claimPurchase(accountId, txHash) {
   return post('/api/store/purchase', { accountId, txHash });
 }
+
+export function sendBroadcast(data) {
+  return post('/api/broadcast/send', data);
+}


### PR DESCRIPTION
## Summary
- allow devs to send a broadcast with photo or text
- expose `sendBroadcast` API helper
- add notification composer on My Account page for devs only

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6867a348652083298d7d19d069a83cbb