### PR TITLE
Update store page icons

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -62,14 +62,20 @@ export default function Store() {
             <span className="text-xl">{b.icon}</span>
             <h3 className="font-semibold">{b.name}</h3>
           </div>
-          <div className="text-lg font-bold">{b.tpc.toLocaleString()} TPC</div>
-          <div className="text-primary text-lg">{b.ton} TON</div>
+          <div className="text-lg font-bold flex items-center space-x-1">
+            <span>{b.tpc.toLocaleString()}</span>
+            <img src="/icons/TPCcoin.png" alt="TPC" className="w-5 h-5" />
+          </div>
+          <div className="text-primary text-lg flex items-center space-x-1">
+            <span>{b.ton}</span>
+            <img src="/icons/TON.png" alt="TON" className="w-5 h-5" />
+          </div>
           <div className="text-xs text-accent">Presale Bundle</div>
           <div className="text-sm">
             {b.boost ? `Mining Boost: +${b.boost * 100}%` : 'No Mining Boost'}
           </div>
           {b.supply && (
-            <div className="text-xs text-subtext">Supply Cap: {b.supply}</div>
+            <div className="text-xs text-subtext">{b.supply}</div>
           )}
           <button
             onClick={() => handleBuy(b)}


### PR DESCRIPTION
## Summary
- update `Store` page to show token icons instead of text
- remove `Supply Cap:` label

## Testing
- `npm test` *(fails: Cannot find package 'dotenv', cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_6867a56013908329b0d712dbbd9c3d6a