### PR TITLE
Add TPC Jetton deployment scripts

### DIFF
--- a/bot/utils/tpcJetton.js
+++ b/bot/utils/tpcJetton.js
@@ -1,0 +1,33 @@
+import { Address, toNano, beginCell } from '@ton/core';
+import { JettonMinter } from '../../wrappers/JettonMinter.js';
+import { JettonWallet } from '../../wrappers/JettonWallet.js';
+
+/**
+ * Get TPC balance of the provided address.
+ * @param {TonClient} client TON client instance
+ * @param {string} minterAddress Jetton minter address
+ * @param {string} ownerAddress Wallet address to check
+ */
+export async function getTpcBalance(client, minterAddress, ownerAddress) {
+  const master = client.open(JettonMinter.createFromAddress(Address.parse(minterAddress)));
+  const walletAddr = await master.getWalletAddress(Address.parse(ownerAddress));
+  const wallet = client.open(JettonWallet.create(walletAddr));
+  return await wallet.getJettonBalance(client.provider(wallet.address));
+}
+
+/**
+ * Send TPC tokens
+ */
+export async function sendTpc(client, minterAddress, sender, toAddress, amount) {
+  const master = client.open(JettonMinter.createFromAddress(Address.parse(minterAddress)));
+  const walletAddr = await master.getWalletAddress(sender.address);
+  const wallet = client.open(JettonWallet.create(walletAddr));
+  await wallet.sendTransfer(client.provider(wallet.address), sender, toNano('0.05'), amount, Address.parse(toAddress), sender.address, beginCell().endCell(), toNano('0.02'), beginCell().endCell());
+}
+
+/**
+ * Show transaction history for provided address
+ */
+export async function getTpcHistory(client, address, limit = 10) {
+  return await client.getTransactions(Address.parse(address), { limit });
+}

--- a/ft/compile.sh
+++ b/ft/compile.sh
@@ -1,0 +1,8 @@
+func -SPA -o ./build/jetton-wallet.fif ../stdlib.fc params.fc op-codes.fc jetton-utils.fc jetton-wallet.fc
+echo '"build/jetton-wallet.fif" include 2 boc+>B "build/jetton-wallet.boc" B>file' | fift -s
+func -SPA -o ./build/jetton-minter.fif ../stdlib.fc params.fc op-codes.fc jetton-utils.fc jetton-minter.fc
+func -SPA -o ./build/jetton-minter-ICO.fif ../stdlib.fc params.fc op-codes.fc jetton-utils.fc jetton-minter-ICO.fc
+func -SPA -o ./build/jetton-discovery.fif ../stdlib.fc params.fc op-codes.fc discovery-params.fc jetton-utils.fc jetton-discovery.fc
+func -SPA -o ./build/jetton-minter-discoverable.fif ../stdlib.fc params.fc op-codes.fc discovery-params.fc jetton-utils.fc jetton-minter-discoverable.fc
+
+fift -s build/print-hex.fif

--- a/ft/discovery-params.fc
+++ b/ft/discovery-params.fc
@@ -1,0 +1,10 @@
+;; moved to the separate file to keep hex of the previous codes unchanged
+
+int op::provide_wallet_address() asm "0x2c76b973 PUSHINT";
+int op::take_wallet_address() asm "0xd1735400 PUSHINT";
+
+int is_resolvable?(slice addr) inline {
+    (int wc, _) = parse_std_addr(addr);
+
+    return wc == workchain();
+}

--- a/ft/jetton-discovery.fc
+++ b/ft/jetton-discovery.fc
@@ -1,0 +1,70 @@
+;; Jettons discovery smart contract for the non-discoverable Jettons
+
+;; 6098(computational_gas_price) * 1000(cur_gas_price) = 6098000
+;; ceil(6098000) = 10000000 ~= 0.01 TON
+int provide_address_gas_consumption() asm "10000000 PUSHINT";
+
+;; storage scheme
+;; storage#_ jetton_minter_address:MsgAddress jetton_wallet_code:^Cell = Storage;
+
+(slice, cell) load_data() inline {
+    slice ds = get_data().begin_parse();
+    return (
+            ds~load_msg_addr(), ;; jetton_minter_address
+            ds~load_ref() ;; jetton_wallet_code
+    );
+}
+
+() recv_internal(int msg_value, cell in_msg_full, slice in_msg_body) impure {
+    if (in_msg_body.slice_empty?()) { ;; ignore empty messages
+        return ();
+    }
+
+    slice cs = in_msg_full.begin_parse();
+    int flags = cs~load_uint(4);
+
+    if (flags & 1) { ;; ignore all bounced messages
+        return ();
+    }
+
+    slice sender_address = cs~load_msg_addr();
+    cs~load_msg_addr(); ;; skip dst
+    cs~load_coins(); ;; skip value
+    cs~skip_bits(1); ;; skip extracurrency collection
+    cs~load_coins(); ;; skip ihr_fee
+    int fwd_fee = muldiv(cs~load_coins(), 3, 2); ;; we use message fwd_fee for estimation of forward_payload costs
+
+    int op = in_msg_body~load_uint(32);
+    int query_id = in_msg_body~load_uint(64);
+
+    if (op == op::provide_wallet_address()) {
+        throw_unless(75, msg_value > fwd_fee + provide_address_gas_consumption());
+
+        (slice jetton_minter_address, cell jetton_wallet_code) = load_data();
+
+        slice owner_address = in_msg_body~load_msg_addr();
+        int include_address? = in_msg_body~load_uint(1);
+
+        cell included_address = include_address?
+                ? begin_cell().store_slice(owner_address).end_cell()
+                : null();
+
+        var msg = begin_cell()
+                .store_uint(0x18, 6)
+                .store_slice(sender_address)
+                .store_coins(0)
+                .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+                .store_uint(op::take_wallet_address(), 32)
+                .store_uint(query_id, 64);
+
+        if (is_resolvable?(owner_address)) {
+            msg = msg.store_slice(calculate_user_jetton_wallet_address(owner_address, jetton_minter_address, jetton_wallet_code));
+        } else {
+            msg = msg.store_uint(0, 2); ;; addr_none
+        }
+        send_raw_message(msg.store_maybe_ref(included_address).end_cell(), 64);
+        return ();
+    }
+
+    throw(0xffff);
+}

--- a/ft/jetton-minter-ICO.fc
+++ b/ft/jetton-minter-ICO.fc
@@ -1,0 +1,121 @@
+;; Jettons minter smart contract
+
+;; storage scheme
+;; storage#_ total_supply:Coins admin_address:MsgAddress content:^Cell jetton_wallet_code:^Cell = Storage;
+
+(int, slice, cell, cell) load_data() inline {
+  slice ds = get_data().begin_parse();
+  return (
+      ds~load_coins(), ;; total_supply
+      ds~load_msg_addr(), ;; admin_address
+      ds~load_ref(), ;; content
+      ds~load_ref()  ;; jetton_wallet_code
+  );
+}
+
+() save_data(int total_supply, slice admin_address, cell content, cell jetton_wallet_code) impure inline {
+  set_data(begin_cell()
+            .store_coins(total_supply)
+            .store_slice(admin_address)
+            .store_ref(content)
+            .store_ref(jetton_wallet_code)
+           .end_cell()
+          );
+}
+
+() mint_tokens(slice to_address, cell jetton_wallet_code, int amount, cell master_msg) impure {
+  cell state_init = calculate_jetton_wallet_state_init(to_address, my_address(), jetton_wallet_code);
+  slice to_wallet_address = calculate_jetton_wallet_address(state_init);
+  var msg = begin_cell()
+    .store_uint(0x18, 6)
+    .store_slice(to_wallet_address)
+    .store_coins(amount)
+    .store_uint(4 + 2 + 1, 1 + 4 + 4 + 64 + 32 + 1 + 1 + 1)
+    .store_ref(state_init)
+    .store_ref(master_msg);
+  send_raw_message(msg.end_cell(), 1); ;; pay transfer fees separately, revert on errors
+}
+
+() recv_internal(int msg_value, cell in_msg_full, slice in_msg_body) impure {
+    slice cs = in_msg_full.begin_parse();
+    int flags = cs~load_uint(4);
+
+    if (flags & 1) { ;; ignore all bounced messages
+        return ();
+    }
+    slice sender_address = cs~load_msg_addr();
+
+    (int total_supply, slice admin_address, cell content, cell jetton_wallet_code) = load_data();
+
+    if (in_msg_body.slice_empty?()) { ;; buy jettons for Toncoin
+
+      int amount = 10000000; ;; for mint message
+      int buy_amount = msg_value - amount;
+      throw_unless(76, buy_amount > 0);
+
+      int jetton_amount = buy_amount; ;; rate 1 jetton = 1 toncoin; multiply to price here
+
+      var master_msg = begin_cell()
+            .store_uint(op::internal_transfer(), 32)
+            .store_uint(0, 64) ;; quert_id
+            .store_coins(jetton_amount)
+            .store_slice(my_address()) ;; from_address
+            .store_slice(sender_address) ;; response_address
+            .store_coins(0) ;; no forward_amount
+            .store_uint(0, 1) ;; forward_payload in this slice, not separate cell
+            .end_cell();
+
+      mint_tokens(sender_address, jetton_wallet_code, amount, master_msg);
+      save_data(total_supply + jetton_amount, admin_address, content, jetton_wallet_code);
+      return ();
+    }
+
+    int op = in_msg_body~load_uint(32);
+    int query_id = in_msg_body~load_uint(64);
+
+    if (op == op::mint()) {
+        throw_unless(73, equal_slices(sender_address, admin_address));
+        slice to_address = in_msg_body~load_msg_addr();
+        int amount = in_msg_body~load_coins();
+        cell master_msg = in_msg_body~load_ref();
+        slice master_msg_cs = master_msg.begin_parse();
+        master_msg_cs~skip_bits(32 + 64); ;; op + query_id
+        int jetton_amount = master_msg_cs~load_coins();
+        mint_tokens(to_address, jetton_wallet_code, amount, master_msg);
+        save_data(total_supply + jetton_amount, admin_address, content, jetton_wallet_code);
+        return ();
+    }
+
+    if (op == op::burn_notification()) {
+        int jetton_amount = in_msg_body~load_coins();
+        slice from_address = in_msg_body~load_msg_addr();
+        throw_unless(74,
+            equal_slices(calculate_user_jetton_wallet_address(from_address, my_address(), jetton_wallet_code), sender_address)
+        );
+        save_data(total_supply - jetton_amount, admin_address, content, jetton_wallet_code);
+        slice response_address = in_msg_body~load_msg_addr();
+        if (response_address.preload_uint(2) != 0) {
+          var msg = begin_cell()
+            .store_uint(0x10, 6) ;; nobounce - int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool src:MsgAddress -> 011000
+            .store_slice(response_address)
+            .store_coins(0)
+            .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+            .store_uint(op::excesses(), 32)
+            .store_uint(query_id, 64);
+          send_raw_message(msg.end_cell(), 2 + 64);
+        }
+        return ();
+    }
+
+    throw(0xffff);
+}
+
+(int, int, slice, cell, cell) get_jetton_data() method_id {
+    (int total_supply, slice admin_address, cell content, cell jetton_wallet_code) = load_data();
+    return (total_supply, -1, admin_address, content, jetton_wallet_code);
+}
+
+slice get_wallet_address(slice owner_address) method_id {
+    (int total_supply, slice admin_address, cell content, cell jetton_wallet_code) = load_data();
+    return calculate_user_jetton_wallet_address(owner_address, my_address(), jetton_wallet_code);
+}

--- a/ft/jetton-minter-discoverable.fc
+++ b/ft/jetton-minter-discoverable.fc
@@ -1,0 +1,150 @@
+;; Jettons discoverable smart contract
+
+;; 6905(computational_gas_price) * 1000(cur_gas_price) = 6905000
+;; ceil(6905000) = 10000000 ~= 0.01 TON
+int provide_address_gas_consumption() asm "10000000 PUSHINT";
+
+;; storage scheme
+;; storage#_ total_supply:Coins admin_address:MsgAddress content:^Cell jetton_wallet_code:^Cell = Storage;
+
+(int, slice, cell, cell) load_data() inline {
+    slice ds = get_data().begin_parse();
+    return (
+            ds~load_coins(), ;; total_supply
+            ds~load_msg_addr(), ;; admin_address
+            ds~load_ref(), ;; content
+            ds~load_ref() ;; jetton_wallet_code
+    );
+}
+
+() save_data(int total_supply, slice admin_address, cell content, cell jetton_wallet_code) impure inline {
+    set_data(begin_cell()
+            .store_coins(total_supply)
+            .store_slice(admin_address)
+            .store_ref(content)
+            .store_ref(jetton_wallet_code)
+            .end_cell()
+    );
+}
+
+() mint_tokens(slice to_address, cell jetton_wallet_code, int amount, cell master_msg) impure {
+    cell state_init = calculate_jetton_wallet_state_init(to_address, my_address(), jetton_wallet_code);
+    slice to_wallet_address = calculate_jetton_wallet_address(state_init);
+    var msg = begin_cell()
+            .store_uint(0x18, 6)
+            .store_slice(to_wallet_address)
+            .store_coins(amount)
+            .store_uint(4 + 2 + 1, 1 + 4 + 4 + 64 + 32 + 1 + 1 + 1)
+            .store_ref(state_init)
+            .store_ref(master_msg);
+    send_raw_message(msg.end_cell(), 1); ;; pay transfer fees separately, revert on errors
+}
+
+() recv_internal(int msg_value, cell in_msg_full, slice in_msg_body) impure {
+    if (in_msg_body.slice_empty?()) { ;; ignore empty messages
+        return ();
+    }
+    slice cs = in_msg_full.begin_parse();
+    int flags = cs~load_uint(4);
+
+    if (flags & 1) { ;; ignore all bounced messages
+        return ();
+    }
+    slice sender_address = cs~load_msg_addr();
+    cs~load_msg_addr(); ;; skip dst
+    cs~load_coins(); ;; skip value
+    cs~skip_bits(1); ;; skip extracurrency collection
+    cs~load_coins(); ;; skip ihr_fee
+    int fwd_fee = muldiv(cs~load_coins(), 3, 2); ;; we use message fwd_fee for estimation of forward_payload costs
+
+    int op = in_msg_body~load_uint(32);
+    int query_id = in_msg_body~load_uint(64);
+
+    (int total_supply, slice admin_address, cell content, cell jetton_wallet_code) = load_data();
+
+    if (op == op::mint()) {
+        throw_unless(73, equal_slices(sender_address, admin_address));
+        slice to_address = in_msg_body~load_msg_addr();
+        int amount = in_msg_body~load_coins();
+        cell master_msg = in_msg_body~load_ref();
+        slice master_msg_cs = master_msg.begin_parse();
+        master_msg_cs~skip_bits(32 + 64); ;; op + query_id
+        int jetton_amount = master_msg_cs~load_coins();
+        mint_tokens(to_address, jetton_wallet_code, amount, master_msg);
+        save_data(total_supply + jetton_amount, admin_address, content, jetton_wallet_code);
+        return ();
+    }
+
+    if (op == op::burn_notification()) {
+        int jetton_amount = in_msg_body~load_coins();
+        slice from_address = in_msg_body~load_msg_addr();
+        throw_unless(74,
+                equal_slices(calculate_user_jetton_wallet_address(from_address, my_address(), jetton_wallet_code), sender_address)
+        );
+        save_data(total_supply - jetton_amount, admin_address, content, jetton_wallet_code);
+        slice response_address = in_msg_body~load_msg_addr();
+        if (response_address.preload_uint(2) != 0) {
+            var msg = begin_cell()
+                    .store_uint(0x10, 6) ;; nobounce - int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool src:MsgAddress -> 011000
+                    .store_slice(response_address)
+                    .store_coins(0)
+                    .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+                    .store_uint(op::excesses(), 32)
+                    .store_uint(query_id, 64);
+            send_raw_message(msg.end_cell(), 2 + 64);
+        }
+        return ();
+    }
+
+    if (op == op::provide_wallet_address()) {
+        throw_unless(75, msg_value > fwd_fee + provide_address_gas_consumption());
+
+        slice owner_address = in_msg_body~load_msg_addr();
+        int include_address? = in_msg_body~load_uint(1);
+
+        cell included_address = include_address?
+                ? begin_cell().store_slice(owner_address).end_cell()
+                : null();
+
+        var msg = begin_cell()
+                .store_uint(0x18, 6)
+                .store_slice(sender_address)
+                .store_coins(0)
+                .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+                .store_uint(op::take_wallet_address(), 32)
+                .store_uint(query_id, 64);
+
+        if (is_resolvable?(owner_address)) {
+            msg = msg.store_slice(calculate_user_jetton_wallet_address(owner_address, my_address(), jetton_wallet_code));
+        } else {
+            msg = msg.store_uint(0, 2); ;; addr_none
+        }
+        send_raw_message(msg.store_maybe_ref(included_address).end_cell(), 64);
+        return ();
+    }
+
+    if (op == 3) { ;; change admin
+        throw_unless(73, equal_slices(sender_address, admin_address));
+        slice new_admin_address = in_msg_body~load_msg_addr();
+        save_data(total_supply, new_admin_address, content, jetton_wallet_code);
+        return ();
+    }
+
+    if (op == 4) { ;; change content, delete this for immutable tokens
+        throw_unless(73, equal_slices(sender_address, admin_address));
+        save_data(total_supply, admin_address, in_msg_body~load_ref(), jetton_wallet_code);
+        return ();
+    }
+
+    throw(0xffff);
+}
+
+(int, int, slice, cell, cell) get_jetton_data() method_id {
+    (int total_supply, slice admin_address, cell content, cell jetton_wallet_code) = load_data();
+    return (total_supply, -1, admin_address, content, jetton_wallet_code);
+}
+
+slice get_wallet_address(slice owner_address) method_id {
+    (int total_supply, slice admin_address, cell content, cell jetton_wallet_code) = load_data();
+    return calculate_user_jetton_wallet_address(owner_address, my_address(), jetton_wallet_code);
+}

--- a/ft/jetton-minter.fc
+++ b/ft/jetton-minter.fc
@@ -1,0 +1,117 @@
+;; It is recommended to use https://github.com/ton-blockchain/token-contract/blob/main/ft/jetton-minter-discoverable.fc
+;; instead of this contract, see https://github.com/ton-blockchain/TEPs/blob/master/text/0089-jetton-wallet-discovery.md
+
+;; Jettons minter smart contract
+
+;; storage scheme
+;; storage#_ total_supply:Coins admin_address:MsgAddress content:^Cell jetton_wallet_code:^Cell = Storage;
+
+(int, slice, cell, cell) load_data() inline {
+  slice ds = get_data().begin_parse();
+  return (
+      ds~load_coins(), ;; total_supply
+      ds~load_msg_addr(), ;; admin_address
+      ds~load_ref(), ;; content
+      ds~load_ref()  ;; jetton_wallet_code
+  );
+}
+
+() save_data(int total_supply, slice admin_address, cell content, cell jetton_wallet_code) impure inline {
+  set_data(begin_cell()
+            .store_coins(total_supply)
+            .store_slice(admin_address)
+            .store_ref(content)
+            .store_ref(jetton_wallet_code)
+           .end_cell()
+          );
+}
+
+() mint_tokens(slice to_address, cell jetton_wallet_code, int amount, cell master_msg) impure {
+  cell state_init = calculate_jetton_wallet_state_init(to_address, my_address(), jetton_wallet_code);
+  slice to_wallet_address = calculate_jetton_wallet_address(state_init);
+  var msg = begin_cell()
+    .store_uint(0x18, 6)
+    .store_slice(to_wallet_address)
+    .store_coins(amount)
+    .store_uint(4 + 2 + 1, 1 + 4 + 4 + 64 + 32 + 1 + 1 + 1)
+    .store_ref(state_init)
+    .store_ref(master_msg);
+  send_raw_message(msg.end_cell(), 1); ;; pay transfer fees separately, revert on errors
+}
+
+() recv_internal(int msg_value, cell in_msg_full, slice in_msg_body) impure {
+    if (in_msg_body.slice_empty?()) { ;; ignore empty messages
+        return ();
+    }
+    slice cs = in_msg_full.begin_parse();
+    int flags = cs~load_uint(4);
+
+    if (flags & 1) { ;; ignore all bounced messages
+        return ();
+    }
+    slice sender_address = cs~load_msg_addr();
+  
+    int op = in_msg_body~load_uint(32);
+    int query_id = in_msg_body~load_uint(64);
+
+    (int total_supply, slice admin_address, cell content, cell jetton_wallet_code) = load_data();
+
+    if (op == op::mint()) {
+        throw_unless(73, equal_slices(sender_address, admin_address));
+        slice to_address = in_msg_body~load_msg_addr();
+        int amount = in_msg_body~load_coins();
+        cell master_msg = in_msg_body~load_ref();
+        slice master_msg_cs = master_msg.begin_parse();
+        master_msg_cs~skip_bits(32 + 64); ;; op + query_id
+        int jetton_amount = master_msg_cs~load_coins();
+        mint_tokens(to_address, jetton_wallet_code, amount, master_msg);
+        save_data(total_supply + jetton_amount, admin_address, content, jetton_wallet_code);
+        return ();
+    }
+
+    if (op == op::burn_notification()) {
+        int jetton_amount = in_msg_body~load_coins();
+        slice from_address = in_msg_body~load_msg_addr();
+        throw_unless(74,
+            equal_slices(calculate_user_jetton_wallet_address(from_address, my_address(), jetton_wallet_code), sender_address)
+        );
+        save_data(total_supply - jetton_amount, admin_address, content, jetton_wallet_code);
+        slice response_address = in_msg_body~load_msg_addr();
+        if (response_address.preload_uint(2) != 0) {
+          var msg = begin_cell()
+            .store_uint(0x10, 6) ;; nobounce - int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool src:MsgAddress -> 011000
+            .store_slice(response_address)
+            .store_coins(0)
+            .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+            .store_uint(op::excesses(), 32)
+            .store_uint(query_id, 64);
+          send_raw_message(msg.end_cell(), 2 + 64);
+        }
+        return ();
+    }
+
+    if (op == 3) { ;; change admin
+        throw_unless(73, equal_slices(sender_address, admin_address));
+        slice new_admin_address = in_msg_body~load_msg_addr();
+        save_data(total_supply, new_admin_address, content, jetton_wallet_code);
+        return ();
+    }
+
+    if (op == 4) { ;; change content, delete this for immutable tokens
+        throw_unless(73, equal_slices(sender_address, admin_address));
+        save_data(total_supply, admin_address, in_msg_body~load_ref(), jetton_wallet_code);
+        return ();
+    }
+
+    throw(0xffff);
+}
+
+(int, int, slice, cell, cell) get_jetton_data() method_id {
+    (int total_supply, slice admin_address, cell content, cell jetton_wallet_code) = load_data();
+    return (total_supply, -1, admin_address, content, jetton_wallet_code);
+}
+
+slice get_wallet_address(slice owner_address) method_id {
+    (int total_supply, slice admin_address, cell content, cell jetton_wallet_code) = load_data();
+    return calculate_user_jetton_wallet_address(owner_address, my_address(), jetton_wallet_code);
+}

--- a/ft/jetton-utils.fc
+++ b/ft/jetton-utils.fc
@@ -1,0 +1,30 @@
+cell pack_jetton_wallet_data(int balance, slice owner_address, slice jetton_master_address, cell jetton_wallet_code) inline {
+   return  begin_cell()
+            .store_coins(balance)
+            .store_slice(owner_address)
+            .store_slice(jetton_master_address)
+            .store_ref(jetton_wallet_code)
+           .end_cell();
+}
+
+cell calculate_jetton_wallet_state_init(slice owner_address, slice jetton_master_address, cell jetton_wallet_code) inline {
+  return begin_cell()
+          .store_uint(0, 2)
+          .store_dict(jetton_wallet_code)
+          .store_dict(pack_jetton_wallet_data(0, owner_address, jetton_master_address, jetton_wallet_code))
+          .store_uint(0, 1)
+         .end_cell();
+}
+
+slice calculate_jetton_wallet_address(cell state_init) inline {
+  return begin_cell().store_uint(4, 3)
+                     .store_int(workchain(), 8)
+                     .store_uint(cell_hash(state_init), 256)
+                     .end_cell()
+                     .begin_parse();
+}
+
+slice calculate_user_jetton_wallet_address(slice owner_address, slice jetton_master_address, cell jetton_wallet_code) inline {
+  return calculate_jetton_wallet_address(calculate_jetton_wallet_state_init(owner_address, jetton_master_address, jetton_wallet_code));
+}
+

--- a/ft/jetton-wallet.fc
+++ b/ft/jetton-wallet.fc
@@ -1,0 +1,248 @@
+;; Jetton Wallet Smart Contract
+
+{-
+
+NOTE that this tokens can be transferred within the same workchain.
+
+This is suitable for most tokens, if you need tokens transferable between workchains there are two solutions:
+
+1) use more expensive but universal function to calculate message forward fee for arbitrary destination (see `misc/forward-fee-calc.cs`)
+
+2) use token holder proxies in target workchain (that way even 'non-universal' token can be used from any workchain)
+
+-}
+
+int min_tons_for_storage() asm "10000000 PUSHINT"; ;; 0.01 TON
+;; Note that 2 * gas_consumptions is expected to be able to cover fees on both wallets (sender and receiver)
+;; and also constant fees on inter-wallet interaction, in particular fwd fee on state_init transfer
+;; that means that you need to reconsider this fee when:
+;; a) jetton logic become more gas-heavy
+;; b) jetton-wallet code (sent with inter-wallet message) become larger or smaller
+;; c) global fee changes / different workchain
+int gas_consumption() asm "15000000 PUSHINT"; ;; 0.015 TON
+
+{-
+  Storage
+  storage#_ balance:Coins owner_address:MsgAddressInt jetton_master_address:MsgAddressInt jetton_wallet_code:^Cell = Storage;
+-}
+
+(int, slice, slice, cell) load_data() inline {
+  slice ds = get_data().begin_parse();
+  return (ds~load_coins(), ds~load_msg_addr(), ds~load_msg_addr(), ds~load_ref());
+}
+
+() save_data (int balance, slice owner_address, slice jetton_master_address, cell jetton_wallet_code) impure inline {
+  set_data(pack_jetton_wallet_data(balance, owner_address, jetton_master_address, jetton_wallet_code));
+}
+
+{-
+  transfer query_id:uint64 amount:(VarUInteger 16) destination:MsgAddress
+           response_destination:MsgAddress custom_payload:(Maybe ^Cell)
+           forward_ton_amount:(VarUInteger 16) forward_payload:(Either Cell ^Cell)
+           = InternalMsgBody;
+  internal_transfer  query_id:uint64 amount:(VarUInteger 16) from:MsgAddress
+                     response_address:MsgAddress
+                     forward_ton_amount:(VarUInteger 16)
+                     forward_payload:(Either Cell ^Cell) 
+                     = InternalMsgBody;
+-}
+
+() send_tokens (slice in_msg_body, slice sender_address, int msg_value, int fwd_fee) impure {
+  int query_id = in_msg_body~load_uint(64);
+  int jetton_amount = in_msg_body~load_coins();
+  slice to_owner_address = in_msg_body~load_msg_addr();
+  force_chain(to_owner_address);
+  (int balance, slice owner_address, slice jetton_master_address, cell jetton_wallet_code) = load_data();
+  balance -= jetton_amount;
+
+  throw_unless(705, equal_slices(owner_address, sender_address));
+  throw_unless(706, balance >= 0);
+
+  cell state_init = calculate_jetton_wallet_state_init(to_owner_address, jetton_master_address, jetton_wallet_code);
+  slice to_wallet_address = calculate_jetton_wallet_address(state_init);
+  slice response_address = in_msg_body~load_msg_addr();
+  cell custom_payload = in_msg_body~load_dict();
+  int forward_ton_amount = in_msg_body~load_coins();
+  throw_unless(708, slice_bits(in_msg_body) >= 1);
+  slice either_forward_payload = in_msg_body;
+  var msg = begin_cell()
+    .store_uint(0x18, 6)
+    .store_slice(to_wallet_address)
+    .store_coins(0)
+    .store_uint(4 + 2 + 1, 1 + 4 + 4 + 64 + 32 + 1 + 1 + 1)
+    .store_ref(state_init);
+  var msg_body = begin_cell()
+    .store_uint(op::internal_transfer(), 32)
+    .store_uint(query_id, 64)
+    .store_coins(jetton_amount)
+    .store_slice(owner_address)
+    .store_slice(response_address)
+    .store_coins(forward_ton_amount)
+    .store_slice(either_forward_payload)
+    .end_cell();
+
+  msg = msg.store_ref(msg_body);
+  int fwd_count = forward_ton_amount ? 2 : 1;
+  throw_unless(709, msg_value >
+                     forward_ton_amount +
+                     ;; 3 messages: wal1->wal2,  wal2->owner, wal2->response
+                     ;; but last one is optional (it is ok if it fails)
+                     fwd_count * fwd_fee +
+                     (2 * gas_consumption() + min_tons_for_storage()));
+                     ;; universal message send fee calculation may be activated here
+                     ;; by using this instead of fwd_fee
+                     ;; msg_fwd_fee(to_wallet, msg_body, state_init, 15)
+
+  send_raw_message(msg.end_cell(), 64); ;; revert on errors
+  save_data(balance, owner_address, jetton_master_address, jetton_wallet_code);
+}
+
+{-
+  internal_transfer  query_id:uint64 amount:(VarUInteger 16) from:MsgAddress
+                     response_address:MsgAddress
+                     forward_ton_amount:(VarUInteger 16)
+                     forward_payload:(Either Cell ^Cell) 
+                     = InternalMsgBody;
+-}
+
+() receive_tokens (slice in_msg_body, slice sender_address, int my_ton_balance, int fwd_fee, int msg_value) impure {
+  ;; NOTE we can not allow fails in action phase since in that case there will be
+  ;; no bounce. Thus check and throw in computation phase.
+  (int balance, slice owner_address, slice jetton_master_address, cell jetton_wallet_code) = load_data();
+  int query_id = in_msg_body~load_uint(64);
+  int jetton_amount = in_msg_body~load_coins();
+  balance += jetton_amount;
+  slice from_address = in_msg_body~load_msg_addr();
+  slice response_address = in_msg_body~load_msg_addr();
+  throw_unless(707,
+      equal_slices(jetton_master_address, sender_address)
+      |
+      equal_slices(calculate_user_jetton_wallet_address(from_address, jetton_master_address, jetton_wallet_code), sender_address)
+  );
+  int forward_ton_amount = in_msg_body~load_coins();
+
+  int ton_balance_before_msg = my_ton_balance - msg_value;
+  int storage_fee = min_tons_for_storage() - min(ton_balance_before_msg, min_tons_for_storage());
+  msg_value -= (storage_fee + gas_consumption());
+  if(forward_ton_amount) {
+    msg_value -= (forward_ton_amount + fwd_fee);
+    slice either_forward_payload = in_msg_body;
+
+    var msg_body = begin_cell()
+        .store_uint(op::transfer_notification(), 32)
+        .store_uint(query_id, 64)
+        .store_coins(jetton_amount)
+        .store_slice(from_address)
+        .store_slice(either_forward_payload)
+        .end_cell();
+
+    var msg = begin_cell()
+      .store_uint(0x10, 6) ;; we should not bounce here cause receiver can have uninitialized contract
+      .store_slice(owner_address)
+      .store_coins(forward_ton_amount)
+      .store_uint(1, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+      .store_ref(msg_body);
+
+    send_raw_message(msg.end_cell(), 1);
+  }
+
+  if ((response_address.preload_uint(2) != 0) & (msg_value > 0)) {
+    var msg = begin_cell()
+      .store_uint(0x10, 6) ;; nobounce - int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool src:MsgAddress -> 010000
+      .store_slice(response_address)
+      .store_coins(msg_value)
+      .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+      .store_uint(op::excesses(), 32)
+      .store_uint(query_id, 64);
+    send_raw_message(msg.end_cell(), 2);
+  }
+
+  save_data(balance, owner_address, jetton_master_address, jetton_wallet_code);
+}
+
+() burn_tokens (slice in_msg_body, slice sender_address, int msg_value, int fwd_fee) impure {
+  ;; NOTE we can not allow fails in action phase since in that case there will be
+  ;; no bounce. Thus check and throw in computation phase.
+  (int balance, slice owner_address, slice jetton_master_address, cell jetton_wallet_code) = load_data();
+  int query_id = in_msg_body~load_uint(64);
+  int jetton_amount = in_msg_body~load_coins();
+  slice response_address = in_msg_body~load_msg_addr();
+  ;; ignore custom payload
+  ;; slice custom_payload = in_msg_body~load_dict();
+  balance -= jetton_amount;
+  throw_unless(705, equal_slices(owner_address, sender_address));
+  throw_unless(706, balance >= 0);
+  throw_unless(707, msg_value > fwd_fee + 2 * gas_consumption());
+
+  var msg_body = begin_cell()
+      .store_uint(op::burn_notification(), 32)
+      .store_uint(query_id, 64)
+      .store_coins(jetton_amount)
+      .store_slice(owner_address)
+      .store_slice(response_address)
+      .end_cell();
+
+  var msg = begin_cell()
+    .store_uint(0x18, 6)
+    .store_slice(jetton_master_address)
+    .store_coins(0)
+    .store_uint(1, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+    .store_ref(msg_body);
+
+  send_raw_message(msg.end_cell(), 64);
+
+  save_data(balance, owner_address, jetton_master_address, jetton_wallet_code);
+}
+
+() on_bounce (slice in_msg_body) impure {
+  in_msg_body~skip_bits(32); ;; 0xFFFFFFFF
+  (int balance, slice owner_address, slice jetton_master_address, cell jetton_wallet_code) = load_data();
+  int op = in_msg_body~load_uint(32);
+  throw_unless(709, (op == op::internal_transfer()) | (op == op::burn_notification()));
+  int query_id = in_msg_body~load_uint(64);
+  int jetton_amount = in_msg_body~load_coins();
+  balance += jetton_amount;
+  save_data(balance, owner_address, jetton_master_address, jetton_wallet_code);
+}
+
+() recv_internal(int my_balance, int msg_value, cell in_msg_full, slice in_msg_body) impure {
+  if (in_msg_body.slice_empty?()) { ;; ignore empty messages
+    return ();
+  }
+
+  slice cs = in_msg_full.begin_parse();
+  int flags = cs~load_uint(4);
+  if (flags & 1) {
+    on_bounce(in_msg_body);
+    return ();
+  }
+  slice sender_address = cs~load_msg_addr();
+  cs~load_msg_addr(); ;; skip dst
+  cs~load_coins(); ;; skip value
+  cs~skip_bits(1); ;; skip extracurrency collection
+  cs~load_coins(); ;; skip ihr_fee
+  int fwd_fee = muldiv(cs~load_coins(), 3, 2); ;; we use message fwd_fee for estimation of forward_payload costs
+
+  int op = in_msg_body~load_uint(32);
+
+  if (op == op::transfer()) { ;; outgoing transfer
+    send_tokens(in_msg_body, sender_address, msg_value, fwd_fee);
+    return ();
+  }
+
+  if (op == op::internal_transfer()) { ;; incoming transfer
+    receive_tokens(in_msg_body, sender_address, my_balance, fwd_fee, msg_value);
+    return ();
+  }
+
+  if (op == op::burn()) { ;; burn
+    burn_tokens(in_msg_body, sender_address, msg_value, fwd_fee);
+    return ();
+  }
+
+  throw(0xffff);
+}
+
+(int, slice, slice, cell) get_wallet_data() method_id {
+  return load_data();
+}

--- a/ft/op-codes.fc
+++ b/ft/op-codes.fc
@@ -1,0 +1,9 @@
+int op::transfer() asm "0xf8a7ea5 PUSHINT";
+int op::transfer_notification() asm "0x7362d09c PUSHINT";
+int op::internal_transfer() asm "0x178d4519 PUSHINT";
+int op::excesses() asm "0xd53276db PUSHINT";
+int op::burn() asm "0x595f07bc PUSHINT";
+int op::burn_notification() asm "0x7bdd97de PUSHINT";
+
+;; Minter
+int op::mint() asm "21 PUSHINT";

--- a/ft/params.fc
+++ b/ft/params.fc
@@ -1,0 +1,6 @@
+int workchain() asm "0 PUSHINT";
+
+() force_chain(slice addr) impure {
+  (int wc, _) = parse_std_addr(addr);
+  throw_unless(333, wc == workchain());
+}

--- a/package.json
+++ b/package.json
@@ -16,15 +16,20 @@
     "node": ">=18"
   },
   "dependencies": {
-    "emoji-name-map": "^2.0.3",
-    "socket.io-client": "^4.8.1",
     "dotenv": "^16.3.1",
+    "emoji-name-map": "^2.0.3",
     "mongoose": "^7.6.0",
-    "solc": "^0.8.30"
+    "socket.io-client": "^4.8.1",
+    "solc": "^0.8.30",
+    "ton": "^13.9.0",
+    "ton-core": "^0.53.0",
+    "ton-crypto": "^3.2.0",
+    "ton-x": "^2.1.0-preview"
   },
   "devDependencies": {
-    "concurrently": "^8.2.2",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
+    "@ton/blueprint": "^0.37.0",
+    "concurrently": "^8.2.2",
     "ethers": "^5.8.0",
     "hardhat": "^2.25.0"
   }

--- a/scripts/deploy_tpc_jetton.js
+++ b/scripts/deploy_tpc_jetton.js
@@ -1,0 +1,54 @@
+import { register } from 'node:module';
+import { pathToFileURL } from 'url';
+register('ts-node/esm', pathToFileURL('./'));
+
+import fs from 'fs';
+import { compile } from '@ton/blueprint';
+import { mnemonicToWalletKey } from 'ton-crypto';
+import { TonClient, TonClient4, WalletContractV4, internal } from 'ton';
+import { Address, toNano, beginCell } from '@ton/core';
+import { JettonMinter, jettonContentToCell, jettonMinterConfigToCell } from '../wrappers/JettonMinter';
+import { JettonWallet } from '../wrappers/JettonWallet';
+
+const mnemonic = process.env.DEPLOY_MNEMONIC;
+if (!mnemonic) {
+  console.error('DEPLOY_MNEMONIC env variable not set');
+  process.exit(1);
+}
+
+const ENDPOINT = process.env.TON_ENDPOINT || 'https://testnet.toncenter.com/api/v2/jsonRPC';
+const ADMIN = Address.parse('UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT');
+
+async function main() {
+  const keyPair = await mnemonicToWalletKey(mnemonic.split(' '));
+  const client = new TonClient4({ endpoint: ENDPOINT });
+  const wallet = WalletContractV4.create({ workchain: 0, publicKey: keyPair.publicKey });
+  const walletContract = client.open(wallet);
+
+  const walletCode = await compile('JettonWallet');
+  const minterCode = await compile('JettonMinter');
+
+  const metadata = JSON.parse(fs.readFileSync('./tpc_metadata.json', 'utf-8'));
+  const contentCell = jettonContentToCell({ type: 1, uri: metadata.image });
+  const minter = JettonMinter.createFromConfig({ admin: ADMIN, content: contentCell, wallet_code: walletCode }, minterCode);
+
+  const sender = walletContract.sender(client.provider(), keyPair.secretKey);
+  await sender.send({
+    value: toNano('0.05'),
+    to: minter.address,
+    bounce: false,
+    init: { code: minterCode, data: jettonMinterConfigToCell({ admin: ADMIN, content: contentCell, wallet_code: walletCode }) },
+    body: beginCell().endCell(),
+  });
+
+  console.log('Jetton minter deployed at', minter.address.toString());
+
+  const fullSupply = 10000000000n * 1000000000n;
+  await minter.sendMint(client.provider(minter.address), sender, ADMIN, fullSupply, toNano('0.01'), toNano('0.02'));
+  console.log('Minted supply to admin');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/stdlib.fc
+++ b/stdlib.fc
@@ -1,0 +1,231 @@
+;; Standard library for funC
+;;
+
+{-
+    This file is part of TON FunC Standard Library.
+
+    FunC Standard Library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    FunC Standard Library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+-}
+
+forall X -> tuple cons(X head, tuple tail) asm "CONS";
+forall X -> (X, tuple) uncons(tuple list) asm "UNCONS";
+forall X -> (tuple, X) list_next(tuple list) asm( -> 1 0) "UNCONS";
+forall X -> X car(tuple list) asm "CAR";
+tuple cdr(tuple list) asm "CDR";
+tuple empty_tuple() asm "NIL";
+forall X -> tuple tpush(tuple t, X value) asm "TPUSH";
+forall X -> (tuple, ()) ~tpush(tuple t, X value) asm "TPUSH";
+forall X -> [X] single(X x) asm "SINGLE";
+forall X -> X unsingle([X] t) asm "UNSINGLE";
+forall X, Y -> [X, Y] pair(X x, Y y) asm "PAIR";
+forall X, Y -> (X, Y) unpair([X, Y] t) asm "UNPAIR";
+forall X, Y, Z -> [X, Y, Z] triple(X x, Y y, Z z) asm "TRIPLE";
+forall X, Y, Z -> (X, Y, Z) untriple([X, Y, Z] t) asm "UNTRIPLE";
+forall X, Y, Z, W -> [X, Y, Z, W] tuple4(X x, Y y, Z z, W w) asm "4 TUPLE";
+forall X, Y, Z, W -> (X, Y, Z, W) untuple4([X, Y, Z, W] t) asm "4 UNTUPLE";
+forall X -> X first(tuple t) asm "FIRST";
+forall X -> X second(tuple t) asm "SECOND";
+forall X -> X third(tuple t) asm "THIRD";
+forall X -> X fourth(tuple t) asm "3 INDEX";
+forall X, Y -> X pair_first([X, Y] p) asm "FIRST";
+forall X, Y -> Y pair_second([X, Y] p) asm "SECOND";
+forall X, Y, Z -> X triple_first([X, Y, Z] p) asm "FIRST";
+forall X, Y, Z -> Y triple_second([X, Y, Z] p) asm "SECOND";
+forall X, Y, Z -> Z triple_third([X, Y, Z] p) asm "THIRD";
+forall X -> X null() asm "PUSHNULL";
+forall X -> (X, ()) ~impure_touch(X x) impure asm "NOP";
+
+int now() asm "NOW";
+slice my_address() asm "MYADDR";
+[int, cell] get_balance() asm "BALANCE";
+int cur_lt() asm "LTIME";
+int block_lt() asm "BLOCKLT";
+
+int cell_hash(cell c) asm "HASHCU";
+int slice_hash(slice s) asm "HASHSU";
+int string_hash(slice s) asm "SHA256U";
+
+int check_signature(int hash, slice signature, int public_key) asm "CHKSIGNU";
+int check_data_signature(slice data, slice signature, int public_key) asm "CHKSIGNS";
+
+(int, int, int) compute_data_size(cell c, int max_cells) impure asm "CDATASIZE";
+(int, int, int) slice_compute_data_size(slice s, int max_cells) impure asm "SDATASIZE";
+(int, int, int, int) compute_data_size?(cell c, int max_cells) asm "CDATASIZEQ NULLSWAPIFNOT2 NULLSWAPIFNOT";
+(int, int, int, int) slice_compute_data_size?(cell c, int max_cells) asm "SDATASIZEQ NULLSWAPIFNOT2 NULLSWAPIFNOT";
+
+;; () throw_if(int excno, int cond) impure asm "THROWARGIF";
+
+() dump_stack() impure asm "DUMPSTK";
+
+cell get_data() asm "c4 PUSH";
+() set_data(cell c) impure asm "c4 POP";
+cont get_c3() impure asm "c3 PUSH";
+() set_c3(cont c) impure asm "c3 POP";
+cont bless(slice s) impure asm "BLESS";
+
+() accept_message() impure asm "ACCEPT";
+() set_gas_limit(int limit) impure asm "SETGASLIMIT";
+() commit() impure asm "COMMIT";
+() buy_gas(int gram) impure asm "BUYGAS";
+
+int min(int x, int y) asm "MIN";
+int max(int x, int y) asm "MAX";
+(int, int) minmax(int x, int y) asm "MINMAX";
+int abs(int x) asm "ABS";
+
+slice begin_parse(cell c) asm "CTOS";
+() end_parse(slice s) impure asm "ENDS";
+(slice, cell) load_ref(slice s) asm( -> 1 0) "LDREF";
+cell preload_ref(slice s) asm "PLDREF";
+;; (slice, int) ~load_int(slice s, int len) asm(s len -> 1 0) "LDIX";
+;; (slice, int) ~load_uint(slice s, int len) asm( -> 1 0) "LDUX";
+;; int preload_int(slice s, int len) asm "PLDIX";
+;; int preload_uint(slice s, int len) asm "PLDUX";
+;; (slice, slice) load_bits(slice s, int len) asm(s len -> 1 0) "LDSLICEX";
+;; slice preload_bits(slice s, int len) asm "PLDSLICEX";
+(slice, int) load_grams(slice s) asm( -> 1 0) "LDGRAMS";
+slice skip_bits(slice s, int len) asm "SDSKIPFIRST";
+(slice, ()) ~skip_bits(slice s, int len) asm "SDSKIPFIRST";
+slice first_bits(slice s, int len) asm "SDCUTFIRST";
+slice skip_last_bits(slice s, int len) asm "SDSKIPLAST";
+(slice, ()) ~skip_last_bits(slice s, int len) asm "SDSKIPLAST";
+slice slice_last(slice s, int len) asm "SDCUTLAST";
+(slice, cell) load_dict(slice s) asm( -> 1 0) "LDDICT";
+cell preload_dict(slice s) asm "PLDDICT";
+slice skip_dict(slice s) asm "SKIPDICT";
+
+(slice, cell) load_maybe_ref(slice s) asm( -> 1 0) "LDOPTREF";
+cell preload_maybe_ref(slice s) asm "PLDOPTREF";
+builder store_maybe_ref(builder b, cell c) asm(c b) "STOPTREF";
+
+int cell_depth(cell c) asm "CDEPTH";
+
+int slice_refs(slice s) asm "SREFS";
+int slice_bits(slice s) asm "SBITS";
+(int, int) slice_bits_refs(slice s) asm "SBITREFS";
+int slice_empty?(slice s) asm "SEMPTY";
+int slice_data_empty?(slice s) asm "SDEMPTY";
+int slice_refs_empty?(slice s) asm "SREMPTY";
+int slice_depth(slice s) asm "SDEPTH";
+
+int builder_refs(builder b) asm "BREFS";
+int builder_bits(builder b) asm "BBITS";
+int builder_depth(builder b) asm "BDEPTH";
+
+builder begin_cell() asm "NEWC";
+cell end_cell(builder b) asm "ENDC";
+builder store_ref(builder b, cell c) asm(c b) "STREF";
+;; builder store_uint(builder b, int x, int len) asm(x b len) "STUX";
+;; builder store_int(builder b, int x, int len) asm(x b len) "STIX";
+builder store_slice(builder b, slice s) asm "STSLICER";
+builder store_grams(builder b, int x) asm "STGRAMS";
+builder store_dict(builder b, cell c) asm(c b) "STDICT";
+
+(slice, slice) load_msg_addr(slice s) asm( -> 1 0) "LDMSGADDR";
+tuple parse_addr(slice s) asm "PARSEMSGADDR";
+(int, int) parse_std_addr(slice s) asm "REWRITESTDADDR";
+(int, slice) parse_var_addr(slice s) asm "REWRITEVARADDR";
+
+cell idict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTISETREF";
+(cell, ()) ~idict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTISETREF";
+cell udict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTUSETREF";
+(cell, ()) ~udict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTUSETREF";
+cell idict_get_ref(cell dict, int key_len, int index) asm(index dict key_len) "DICTIGETOPTREF";
+(cell, int) idict_get_ref?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIGETREF";
+(cell, int) udict_get_ref?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUGETREF";
+(cell, cell) idict_set_get_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTISETGETOPTREF";
+(cell, cell) udict_set_get_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTUSETGETOPTREF";
+(cell, int) idict_delete?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIDEL";
+(cell, int) udict_delete?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUDEL";
+(slice, int) idict_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIGET" "NULLSWAPIFNOT";
+(slice, int) udict_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUGET" "NULLSWAPIFNOT";
+(cell, slice, int) idict_delete_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIDELGET" "NULLSWAPIFNOT";
+(cell, slice, int) udict_delete_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUDELGET" "NULLSWAPIFNOT";
+(cell, (slice, int)) ~idict_delete_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIDELGET" "NULLSWAPIFNOT";
+(cell, (slice, int)) ~udict_delete_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUDELGET" "NULLSWAPIFNOT";
+cell udict_set(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTUSET";
+(cell, ()) ~udict_set(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTUSET";
+cell idict_set(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTISET";
+(cell, ()) ~idict_set(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTISET";
+cell dict_set(cell dict, int key_len, slice index, slice value) asm(value index dict key_len) "DICTSET";
+(cell, ()) ~dict_set(cell dict, int key_len, slice index, slice value) asm(value index dict key_len) "DICTSET";
+(cell, int) udict_add?(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTUADD";
+(cell, int) udict_replace?(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTUREPLACE";
+(cell, int) idict_add?(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTIADD";
+(cell, int) idict_replace?(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTIREPLACE";
+cell udict_set_builder(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTUSETB";
+(cell, ()) ~udict_set_builder(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTUSETB";
+cell idict_set_builder(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTISETB";
+(cell, ()) ~idict_set_builder(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTISETB";
+cell dict_set_builder(cell dict, int key_len, slice index, builder value) asm(value index dict key_len) "DICTSETB";
+(cell, ()) ~dict_set_builder(cell dict, int key_len, slice index, builder value) asm(value index dict key_len) "DICTSETB";
+(cell, int) udict_add_builder?(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTUADDB";
+(cell, int) udict_replace_builder?(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTUREPLACEB";
+(cell, int) idict_add_builder?(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTIADDB";
+(cell, int) idict_replace_builder?(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTIREPLACEB";
+(cell, int, slice, int) udict_delete_get_min(cell dict, int key_len) asm(-> 0 2 1 3) "DICTUREMMIN" "NULLSWAPIFNOT2";
+(cell, (int, slice, int)) ~udict::delete_get_min(cell dict, int key_len) asm(-> 0 2 1 3) "DICTUREMMIN" "NULLSWAPIFNOT2";
+(cell, int, slice, int) idict_delete_get_min(cell dict, int key_len) asm(-> 0 2 1 3) "DICTIREMMIN" "NULLSWAPIFNOT2";
+(cell, (int, slice, int)) ~idict::delete_get_min(cell dict, int key_len) asm(-> 0 2 1 3) "DICTIREMMIN" "NULLSWAPIFNOT2";
+(cell, slice, slice, int) dict_delete_get_min(cell dict, int key_len) asm(-> 0 2 1 3) "DICTREMMIN" "NULLSWAPIFNOT2";
+(cell, (slice, slice, int)) ~dict::delete_get_min(cell dict, int key_len) asm(-> 0 2 1 3) "DICTREMMIN" "NULLSWAPIFNOT2";
+(cell, int, slice, int) udict_delete_get_max(cell dict, int key_len) asm(-> 0 2 1 3) "DICTUREMMAX" "NULLSWAPIFNOT2";
+(cell, (int, slice, int)) ~udict::delete_get_max(cell dict, int key_len) asm(-> 0 2 1 3) "DICTUREMMAX" "NULLSWAPIFNOT2";
+(cell, int, slice, int) idict_delete_get_max(cell dict, int key_len) asm(-> 0 2 1 3) "DICTIREMMAX" "NULLSWAPIFNOT2";
+(cell, (int, slice, int)) ~idict::delete_get_max(cell dict, int key_len) asm(-> 0 2 1 3) "DICTIREMMAX" "NULLSWAPIFNOT2";
+(cell, slice, slice, int) dict_delete_get_max(cell dict, int key_len) asm(-> 0 2 1 3) "DICTREMMAX" "NULLSWAPIFNOT2";
+(cell, (slice, slice, int)) ~dict::delete_get_max(cell dict, int key_len) asm(-> 0 2 1 3) "DICTREMMAX" "NULLSWAPIFNOT2";
+(int, slice, int) udict_get_min?(cell dict, int key_len) asm (-> 1 0 2) "DICTUMIN" "NULLSWAPIFNOT2";
+(int, slice, int) udict_get_max?(cell dict, int key_len) asm (-> 1 0 2) "DICTUMAX" "NULLSWAPIFNOT2";
+(int, cell, int) udict_get_min_ref?(cell dict, int key_len) asm (-> 1 0 2) "DICTUMINREF" "NULLSWAPIFNOT2";
+(int, cell, int) udict_get_max_ref?(cell dict, int key_len) asm (-> 1 0 2) "DICTUMAXREF" "NULLSWAPIFNOT2";
+(int, slice, int) idict_get_min?(cell dict, int key_len) asm (-> 1 0 2) "DICTIMIN" "NULLSWAPIFNOT2";
+(int, slice, int) idict_get_max?(cell dict, int key_len) asm (-> 1 0 2) "DICTIMAX" "NULLSWAPIFNOT2";
+(int, cell, int) idict_get_min_ref?(cell dict, int key_len) asm (-> 1 0 2) "DICTIMINREF" "NULLSWAPIFNOT2";
+(int, cell, int) idict_get_max_ref?(cell dict, int key_len) asm (-> 1 0 2) "DICTIMAXREF" "NULLSWAPIFNOT2";
+(int, slice, int) udict_get_next?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTUGETNEXT" "NULLSWAPIFNOT2";
+(int, slice, int) udict_get_nexteq?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTUGETNEXTEQ" "NULLSWAPIFNOT2";
+(int, slice, int) udict_get_prev?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTUGETPREV" "NULLSWAPIFNOT2";
+(int, slice, int) udict_get_preveq?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTUGETPREVEQ" "NULLSWAPIFNOT2";
+(int, slice, int) idict_get_next?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTIGETNEXT" "NULLSWAPIFNOT2";
+(int, slice, int) idict_get_nexteq?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTIGETNEXTEQ" "NULLSWAPIFNOT2";
+(int, slice, int) idict_get_prev?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTIGETPREV" "NULLSWAPIFNOT2";
+(int, slice, int) idict_get_preveq?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTIGETPREVEQ" "NULLSWAPIFNOT2";
+cell new_dict() asm "NEWDICT";
+int dict_empty?(cell c) asm "DICTEMPTY";
+
+(slice, slice, slice, int) pfxdict_get?(cell dict, int key_len, slice key) asm(key dict key_len) "PFXDICTGETQ" "NULLSWAPIFNOT2";
+(cell, int) pfxdict_set?(cell dict, int key_len, slice key, slice value) asm(value key dict key_len) "PFXDICTSET";
+(cell, int) pfxdict_delete?(cell dict, int key_len, slice key) asm(key dict key_len) "PFXDICTDEL";
+
+cell config_param(int x) asm "CONFIGOPTPARAM";
+int cell_null?(cell c) asm "ISNULL";
+
+() raw_reserve(int amount, int mode) impure asm "RAWRESERVE";
+() raw_reserve_extra(int amount, cell extra_amount, int mode) impure asm "RAWRESERVEX";
+() send_raw_message(cell msg, int mode) impure asm "SENDRAWMSG";
+() set_code(cell new_code) impure asm "SETCODE";
+
+int random() impure asm "RANDU256";
+int rand(int range) impure asm "RAND";
+int get_seed() impure asm "RANDSEED";
+int set_seed() impure asm "SETRAND";
+() randomize(int x) impure asm "ADDRAND";
+() randomize_lt() impure asm "LTIME" "ADDRAND";
+
+builder store_coins(builder b, int x) asm "STVARUINT16";
+(slice, int) load_coins(slice s) asm( -> 1 0) "LDVARUINT16";
+
+int equal_slices (slice a, slice b) asm "SDEQ";
+int builder_null?(builder b) asm "ISNULL";
+builder store_builder(builder to, builder from) asm "STBR";
+

--- a/tpc_metadata.json
+++ b/tpc_metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "TPC",
+  "symbol": "TPC",
+  "decimals": 9,
+  "description": "TonPlaygram Coin (TPC) powers mining, games, and rewards inside the TonPlaygram platform.",
+  "image": "ipfs://replace-with-ipfs-cid"
+}

--- a/wrappers/JettonConstants.ts
+++ b/wrappers/JettonConstants.ts
@@ -1,0 +1,30 @@
+export abstract class Op {
+    static transfer = 0xf8a7ea5;
+    static transfer_notification = 0x7362d09c;
+    static internal_transfer = 0x178d4519;
+    static excesses = 0xd53276db;
+    static burn = 0x595f07bc;
+    static burn_notification = 0x7bdd97de;
+    
+    static provide_wallet_address = 0x2c76b973;
+    static take_wallet_address = 0xd1735400;
+    static mint = 21;
+    static change_admin = 3;
+    static change_content = 4;
+}
+
+export abstract class Errors {
+    static invalid_op = 709;
+    static not_admin  = 73;
+    static unouthorized_burn = 74;
+    static discovery_fee_not_matched = 75;
+    static wrong_op = 0xffff;
+    static not_owner = 705;
+    static not_enough_ton = 709;
+    static not_enough_gas = 707;
+    static not_valid_wallet = 707;
+    static wrong_workchain = 333;
+    static balance_error   = 706;
+}
+
+

--- a/wrappers/JettonMinter.compile.ts
+++ b/wrappers/JettonMinter.compile.ts
@@ -1,0 +1,3 @@
+module.exports.compile = {
+    targets: ['stdlib.fc', 'ft/params.fc','ft/op-codes.fc','ft/discovery-params.fc','ft/jetton-utils.fc','ft/jetton-minter-discoverable.fc'],
+};

--- a/wrappers/JettonMinter.ts
+++ b/wrappers/JettonMinter.ts
@@ -1,0 +1,167 @@
+import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode, toNano, internal as internal_relaxed, storeMessageRelaxed } from '@ton/core';
+
+import { Op } from './JettonConstants';
+
+export type JettonMinterContent = {
+    type:0|1,
+    uri:string
+};
+
+export type JettonMinterConfig = {admin: Address; content: Cell; wallet_code: Cell};
+
+export function jettonMinterConfigToCell(config: JettonMinterConfig): Cell {
+    return beginCell()
+                      .storeCoins(0)
+                      .storeAddress(config.admin)
+                      .storeRef(config.content)
+                      .storeRef(config.wallet_code)
+           .endCell();
+}
+
+export function jettonContentToCell(content:JettonMinterContent) {
+    return beginCell()
+                      .storeUint(content.type, 8)
+                      .storeStringTail(content.uri) //Snake logic under the hood
+           .endCell();
+}
+
+export class JettonMinter implements Contract {
+    constructor(readonly address: Address, readonly init?: { code: Cell; data: Cell }) {}
+
+    static createFromAddress(address: Address) {
+        return new JettonMinter(address);
+    }
+
+    static createFromConfig(config: JettonMinterConfig, code: Cell, workchain = 0) {
+        const data = jettonMinterConfigToCell(config);
+        const init = { code, data };
+        return new JettonMinter(contractAddress(workchain, init), init);
+    }
+
+    async sendDeploy(provider: ContractProvider, via: Sender, value: bigint) {
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: beginCell().endCell(),
+        });
+    }
+
+    protected static jettonInternalTransfer(jetton_amount: bigint,
+                                            forward_ton_amount: bigint,
+                                            response_addr?: Address,
+                                            query_id: number | bigint = 0) {
+        return beginCell()
+                .storeUint(Op.internal_transfer, 32)
+                .storeUint(query_id, 64)
+                .storeCoins(jetton_amount)
+                .storeAddress(null)
+                .storeAddress(response_addr)
+                .storeCoins(forward_ton_amount)
+                .storeBit(false)
+               .endCell();
+
+    }
+    static mintMessage(from: Address, to: Address, jetton_amount: bigint, forward_ton_amount: bigint, total_ton_amount: bigint, query_id: number | bigint = 0) {
+		const mintMsg = beginCell().storeUint(Op.internal_transfer, 32)
+                                   .storeUint(0, 64)
+                                   .storeCoins(jetton_amount)
+                                   .storeAddress(null)
+                                   .storeAddress(from) // Response addr
+                                   .storeCoins(forward_ton_amount)
+                                   .storeMaybeRef(null)
+                    .endCell();
+
+        return beginCell().storeUint(Op.mint, 32).storeUint(query_id, 64) // op, queryId
+                          .storeAddress(to)
+                          .storeCoins(total_ton_amount)
+                          .storeCoins(jetton_amount)
+                          .storeRef(mintMsg)
+               .endCell();
+    }
+    async sendMint(provider: ContractProvider, via: Sender, to: Address, jetton_amount: bigint, forward_ton_amount: bigint, total_ton_amount: bigint) {
+        if(total_ton_amount <= forward_ton_amount) {
+            throw new Error("Total ton amount should be > forward amount");
+        }
+        await provider.internal(via, {
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: JettonMinter.mintMessage(this.address, to, jetton_amount, forward_ton_amount, total_ton_amount),
+            value: total_ton_amount + toNano('0.015'),
+        });
+    }
+
+    /* provide_wallet_address#2c76b973 query_id:uint64 owner_address:MsgAddress include_address:Bool = InternalMsgBody;
+    */
+    static discoveryMessage(owner: Address, include_address: boolean) {
+        return beginCell().storeUint(0x2c76b973, 32).storeUint(0, 64) // op, queryId
+                          .storeAddress(owner).storeBit(include_address)
+               .endCell();
+    }
+
+    async sendDiscovery(provider: ContractProvider, via: Sender, owner: Address, include_address: boolean, value:bigint = toNano('0.1')) {
+        await provider.internal(via, {
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: JettonMinter.discoveryMessage(owner, include_address),
+            value: value,
+        });
+    }
+
+    static changeAdminMessage(newOwner: Address) {
+        return beginCell().storeUint(Op.change_admin, 32).storeUint(0, 64) // op, queryId
+                          .storeAddress(newOwner)
+               .endCell();
+    }
+
+    async sendChangeAdmin(provider: ContractProvider, via: Sender, newOwner: Address) {
+        await provider.internal(via, {
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: JettonMinter.changeAdminMessage(newOwner),
+            value: toNano("0.05"),
+        });
+    }
+    static changeContentMessage(content: Cell) {
+        return beginCell().storeUint(Op.change_content, 32).storeUint(0, 64) // op, queryId
+                          .storeRef(content)
+               .endCell();
+    }
+
+    async sendChangeContent(provider: ContractProvider, via: Sender, content: Cell) {
+        await provider.internal(via, {
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: JettonMinter.changeContentMessage(content),
+            value: toNano("0.05"),
+        });
+    }
+    async getWalletAddress(provider: ContractProvider, owner: Address): Promise<Address> {
+        const res = await provider.get('get_wallet_address', [{ type: 'slice', cell: beginCell().storeAddress(owner).endCell() }])
+        return res.stack.readAddress()
+    }
+
+    async getJettonData(provider: ContractProvider) {
+        let res = await provider.get('get_jetton_data', []);
+        let totalSupply = res.stack.readBigNumber();
+        let mintable = res.stack.readBoolean();
+        let adminAddress = res.stack.readAddress();
+        let content = res.stack.readCell();
+        let walletCode = res.stack.readCell();
+        return {
+            totalSupply,
+            mintable,
+            adminAddress,
+            content,
+            walletCode
+        };
+    }
+
+    async getTotalSupply(provider: ContractProvider) {
+        let res = await this.getJettonData(provider);
+        return res.totalSupply;
+    }
+    async getAdminAddress(provider: ContractProvider) {
+        let res = await this.getJettonData(provider);
+        return res.adminAddress;
+    }
+    async getContent(provider: ContractProvider) {
+        let res = await this.getJettonData(provider);
+        return res.content;
+    }
+}

--- a/wrappers/JettonWallet.compile.ts
+++ b/wrappers/JettonWallet.compile.ts
@@ -1,0 +1,3 @@
+module.exports.compile = {
+    targets: ['stdlib.fc','ft/params.fc','ft/op-codes.fc','ft/jetton-utils.fc','ft/jetton-wallet.fc'],
+};

--- a/wrappers/JettonWallet.ts
+++ b/wrappers/JettonWallet.ts
@@ -1,0 +1,125 @@
+import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode, toNano } from '@ton/core';
+
+export type JettonWalletConfig = {};
+
+export function jettonWalletConfigToCell(config: JettonWalletConfig): Cell {
+    return beginCell().endCell();
+}
+
+export class JettonWallet implements Contract {
+    constructor(readonly address: Address, readonly init?: { code: Cell; data: Cell }) {}
+
+    static createFromAddress(address: Address) {
+        return new JettonWallet(address);
+    }
+
+    static createFromConfig(config: JettonWalletConfig, code: Cell, workchain = 0) {
+        const data = jettonWalletConfigToCell(config);
+        const init = { code, data };
+        return new JettonWallet(contractAddress(workchain, init), init);
+    }
+
+    async sendDeploy(provider: ContractProvider, via: Sender, value: bigint) {
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: beginCell().endCell(),
+        });
+    }
+
+    async getJettonBalance(provider: ContractProvider) {
+        let state = await provider.getState();
+        if (state.state.type !== 'active') {
+            return 0n;
+        }
+        let res = await provider.get('get_wallet_data', []);
+        return res.stack.readBigNumber();
+    }
+    static transferMessage(jetton_amount: bigint, to: Address,
+                           responseAddress:Address,
+                           customPayload: Cell | null,
+                           forward_ton_amount: bigint,
+                           forwardPayload: Cell | null) {
+        return beginCell().storeUint(0xf8a7ea5, 32).storeUint(0, 64) // op, queryId
+                          .storeCoins(jetton_amount).storeAddress(to)
+                          .storeAddress(responseAddress)
+                          .storeMaybeRef(customPayload)
+                          .storeCoins(forward_ton_amount)
+                          .storeMaybeRef(forwardPayload)
+               .endCell();
+    }
+    async sendTransfer(provider: ContractProvider, via: Sender,
+                              value: bigint,
+                              jetton_amount: bigint, to: Address,
+                              responseAddress:Address,
+                              customPayload: Cell,
+                              forward_ton_amount: bigint,
+                              forwardPayload: Cell) {
+        await provider.internal(via, {
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: JettonWallet.transferMessage(jetton_amount, to, responseAddress, customPayload, forward_ton_amount, forwardPayload),
+            value:value
+        });
+
+    }
+    /*
+      burn#595f07bc query_id:uint64 amount:(VarUInteger 16)
+                    response_destination:MsgAddress custom_payload:(Maybe ^Cell)
+                    = InternalMsgBody;
+    */
+    static burnMessage(jetton_amount: bigint,
+                       responseAddress:Address,
+                       customPayload: Cell | null) {
+        return beginCell().storeUint(0x595f07bc, 32).storeUint(0, 64) // op, queryId
+                          .storeCoins(jetton_amount).storeAddress(responseAddress)
+                          .storeMaybeRef(customPayload)
+               .endCell();
+    }
+
+    async sendBurn(provider: ContractProvider, via: Sender, value: bigint,
+                          jetton_amount: bigint,
+                          responseAddress:Address,
+                          customPayload: Cell) {
+        await provider.internal(via, {
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: JettonWallet.burnMessage(jetton_amount, responseAddress, customPayload),
+            value:value
+        });
+
+    }
+    /*
+      withdraw_tons#107c49ef query_id:uint64 = InternalMsgBody;
+    */
+    static withdrawTonsMessage() {
+        return beginCell().storeUint(0x6d8e5e3c, 32).storeUint(0, 64) // op, queryId
+               .endCell();
+    }
+
+    async sendWithdrawTons(provider: ContractProvider, via: Sender) {
+        await provider.internal(via, {
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: JettonWallet.withdrawTonsMessage(),
+            value:toNano('0.1')
+        });
+
+    }
+    /*
+      withdraw_jettons#10 query_id:uint64 wallet:MsgAddressInt amount:Coins = InternalMsgBody;
+    */
+    static withdrawJettonsMessage(from:Address, amount:bigint) {
+        return beginCell().storeUint(0x768a50b2, 32).storeUint(0, 64) // op, queryId
+                          .storeAddress(from)
+                          .storeCoins(amount)
+                          .storeMaybeRef(null)
+               .endCell();
+    }
+
+    async sendWithdrawJettons(provider: ContractProvider, via: Sender, from:Address, amount:bigint) {
+        await provider.internal(via, {
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: JettonWallet.withdrawJettonsMessage(from, amount),
+            value:toNano('0.1')
+        });
+
+    }
+}

--- a/wrappers/ui-utils.ts
+++ b/wrappers/ui-utils.ts
@@ -1,0 +1,163 @@
+import { sleep, NetworkProvider, UIProvider} from '@ton/blueprint';
+import { Address, beginCell, Builder, Cell, Dictionary, DictionaryValue, Slice } from "@ton/core";
+import { sha256 } from 'ton-crypto';
+
+export const defaultJettonKeys = ["uri", "name", "description", "image", "image_data", "symbol", "decimals", "amount_style"];
+export const defaultNftKeys    = ["uri", "name", "description", "image", "image_data"];
+
+export const promptBool = async (prompt:string, options:[string, string], ui:UIProvider, choice: boolean = false) => {
+    let yes  = false;
+    let no   = false;
+    let opts = options.map(o => o.toLowerCase());
+
+    do {
+        let res = (choice ? await ui.choose(prompt, options, (c: string) => c) : await ui.input(`${prompt}(${options[0]}/${options[1]})`)).toLowerCase();
+        yes = res == opts[0]
+        if(!yes)
+            no  = res == opts[1];
+    } while(!(yes || no));
+
+    return yes;
+}
+
+export const promptAddress = async (prompt:string, provider:UIProvider, fallback?:Address) => {
+    let promptFinal = fallback ? prompt.replace(/:$/,'') + `(default:${fallback}):` : prompt ;
+    do {
+        let testAddr = (await provider.input(promptFinal)).replace(/^\s+|\s+$/g,'');
+        try{
+            return testAddr == "" && fallback ? fallback : Address.parse(testAddr);
+        }
+        catch(e) {
+            provider.write(testAddr + " is not valid!\n");
+            prompt = "Please try again:";
+        }
+    } while(true);
+
+};
+
+export const promptAmount = async (prompt:string, provider:UIProvider) => {
+    let resAmount:number;
+    do {
+        let inputAmount = await provider.input(prompt);
+        resAmount = Number(inputAmount);
+        if(isNaN(resAmount)) {
+            provider.write("Failed to convert " + inputAmount + " to float number");
+        }
+        else {
+            return resAmount.toFixed(9);
+        }
+    } while(true);
+}
+
+export const getLastBlock = async (provider: NetworkProvider) => {
+    return (await provider.api().getLastBlock()).last.seqno;
+}
+export const getAccountLastTx = async (provider: NetworkProvider, address: Address) => {
+    const res = await provider.api().getAccountLite(await getLastBlock(provider), address);
+    if(res.account.last == null)
+        throw(Error("Contract is not active"));
+    return res.account.last.lt;
+}
+export const waitForTransaction = async (provider:NetworkProvider, address:Address, curTx:string | null, maxRetry:number, interval:number=1000) => {
+    let done  = false;
+    let count = 0;
+    const ui  = provider.ui();
+
+    do {
+        const lastBlock = await getLastBlock(provider);
+        ui.write(`Awaiting transaction completion (${++count}/${maxRetry})`);
+        await sleep(interval);
+        const curState = await provider.api().getAccountLite(lastBlock, address);
+        if(curState.account.last !== null){
+            done = curState.account.last.lt !== curTx;
+        }
+    } while(!done && count < maxRetry);
+    return done;
+}
+
+const keysToHashMap = async (keys: string[]) => {
+    let keyMap: {[key: string]: bigint} = {};
+    for (let i = 0; i < keys.length; i++) {
+        keyMap[keys[i]] = BigInt("0x" + (await sha256(keys[i])).toString('hex'));
+    }
+}
+
+const contentValue: DictionaryValue<string> = {
+    serialize: (src: string, builder:Builder) => {
+        builder.storeRef(beginCell().storeUint(0, 8).storeStringTail(src).endCell());
+    },
+    parse: (src: Slice) => {
+        const sc = src.loadRef().beginParse();
+        const prefix = sc.loadUint(8);
+        if(prefix == 0) {
+            return sc.loadStringTail();
+        }
+        else if(prefix == 1) {
+            // Not really tested, but feels like it should work
+            const chunkDict = Dictionary.loadDirect(Dictionary.Keys.Uint(32), Dictionary.Values.Cell(), sc);
+            return chunkDict.values().map(x => x.beginParse().loadStringTail()).join('');
+        }
+        else {
+            throw(Error(`Prefix ${prefix} is not supported yet`));
+        }
+    }
+};
+export const displayContentCell = async (content:Cell, ui:UIProvider, jetton:boolean = true, additional?: string[]) => {
+    const cs = content.beginParse();
+    const contentType = cs.loadUint(8);
+    if(contentType == 1) {
+        const noData = cs.remainingBits == 0;
+        if(noData && cs.remainingRefs == 0) {
+            ui.write("No data in content cell!\n");
+        }
+        else {
+            const contentUrl = noData ? cs.loadStringRefTail() : cs.loadStringTail();
+            ui.write(`Content metadata url:${contentUrl}\n`);
+        }
+    }
+    else if(contentType == 0) {
+        let   contentKeys: string[];
+        const hasAdditional = additional !== undefined && additional.length > 0;
+        const contentDict   = Dictionary.load(Dictionary.Keys.BigUint(256), contentValue, cs);
+        const contentMap : {[key: string]: string} = {};
+
+        if(jetton) {
+            contentKeys = hasAdditional ? [...defaultJettonKeys, ...additional] : defaultJettonKeys;
+        }
+        else {
+            contentKeys = hasAdditional ? [...defaultNftKeys, ...additional] : defaultNftKeys;
+        }
+        for (const name of contentKeys) {
+            // I know we should pre-compute hashed keys for known values... just not today.
+            const dictKey   = BigInt("0x" + (await sha256(name)).toString('hex'))
+            const dictValue = contentDict.get(dictKey);
+            if(dictValue !== undefined) {
+                contentMap[name] = dictValue;
+            }
+        }
+        ui.write(`Content:${JSON.stringify(contentMap,null, 2)}`);
+    }
+    else {
+        ui.write(`Unknown content format indicator:${contentType}\n`);
+    }
+}
+
+export const promptUrl = async(prompt:string, ui:UIProvider) => {
+    let retry  = false;
+    let input  = "";
+    let res    = "";
+
+    do {
+        input = await ui.input(prompt);
+        try{
+            let testUrl = new URL(input);
+            res   = testUrl.toString();
+            retry = false;
+        }
+        catch(e) {
+            ui.write(input + " doesn't look like a valid url:\n" + e);
+            retry = !(await promptBool('Use anyway?(y/n)', ['y', 'n'], ui));
+        }
+    } while(retry);
+    return input;
+}


### PR DESCRIPTION
## Summary
- add TON Jetton wrappers and Func sources for compilation
- add deployment script for TPC Jetton
- provide helper utilities to get balances and transfer TPC
- include sample metadata json
- install TON related dependencies

## Testing
- `npm test` *(fails: test timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6867d03ecda4832994e9a19c8bfe95c5