### PR TITLE
Fix spin wheel bonus logic

### DIFF
--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -100,9 +100,12 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
       spinSoundRef.current.play().catch(() => {});
     }
 
-    const index = Math.floor(Math.random() * wheelSegments.length);
+    const segments = shuffleSegments(baseSegments);
+    setWheelSegments(segments);
 
-    const reward = wheelSegments[index];
+    const index = Math.floor(Math.random() * segments.length);
+
+    const reward = segments[index];
 
     spinCountRef.current += 1;
     const finalIndex = spinCountRef.current * loops * wheelSegments.length + index;
@@ -127,8 +130,6 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
         successSoundRef.current.play().catch(() => {});
       }
       onFinish(reward);
-      setWheelSegments(shuffleSegments(baseSegments));
-      setOffset(0);
     }, 4000);
   };
 
@@ -136,11 +137,11 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
   return (
 
-    <div className="w-36 mx-auto flex flex-col items-center">
+    <div className="w-28 mx-auto flex flex-col items-center">
 
       <div
 
-        className="relative overflow-hidden w-32"
+        className="relative overflow-hidden w-24"
 
         style={{ height: itemHeight * visibleRows }}
 
@@ -158,13 +159,15 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
         <div
 
-          className="flex flex-col items-center w-32"
+          className="flex flex-col items-center w-24"
 
           style={{
 
             transform: `translateY(${offset}px)`,
 
-            transition: 'transform 4s cubic-bezier(0.33,1,0.68,1)'
+            transition: spinning
+              ? 'transform 4s cubic-bezier(0.33,1,0.68,1)'
+              : 'none'
 
           }}
 
@@ -176,7 +179,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
               key={idx}
 
-              className={`board-style flex items-center justify-center text-sm w-32 font-bold ${
+              className={`board-style flex items-center justify-center text-sm w-24 font-bold ${
 
                 idx === winnerIndex ? 'bg-yellow-300 text-black' : 'text-white'
 
@@ -197,7 +200,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
                     alt="Free Spin"
                     className="w-8 h-8 mr-1"
                   />
-                  <span>
+                  <span class="text-xs">
                     {val === 1600 && '1 Free Spin'}
                     {val === 1800 && '2 Free Spins'}
                     {val === 5000 && '3 Free Spins'}


### PR DESCRIPTION
## Summary
- spin all wheels during BONUS X3 and total their rewards
- show smaller free spin text and reduce wheel width for mobile
- prevent wheel from continuing to spin after landing

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867f99057a88329bac89f3d08b92eba