### PR TITLE
Improve invite lookup logic

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -459,7 +459,10 @@ io.on('connection', (socket) => {
     if (!fromId || !toId) return cb && cb({ success: false, error: 'invalid ids' });
 
     if (!toTelegramId) {
-      const user = await User.findOne({ accountId: toId });
+      let user = await User.findOne({ accountId: toId });
+      if (!user) {
+        user = await User.findOne({ telegramId: Number(toId) });
+      }
       if (user) toTelegramId = user.telegramId;
     }
 
@@ -531,7 +534,10 @@ io.on('connection', (socket) => {
         const toId = toIds[i];
         let tgId = telegramIds[i];
         if (!tgId) {
-          const user = await User.findOne({ accountId: toId });
+          let user = await User.findOne({ accountId: toId });
+          if (!user) {
+            user = await User.findOne({ telegramId: Number(toId) });
+          }
           if (user) {
             tgId = user.telegramId;
             telegramIds[i] = tgId;


### PR DESCRIPTION
## Summary
- search for users by telegram ID if account ID lookup fails
- keep websocket notifications unchanged

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68680ae326208329893c4ed470be7b2d