### PR TITLE
Add env-based configuration for jetton deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bot/package-lock.json
 .idea
 bot/.env
 webapp/.env
+scripts/.env
 /webapp/dist/
 # Hardhat build artifacts
 artifacts/

--- a/README.md
+++ b/README.md
@@ -37,34 +37,39 @@ this account.
 
 ⚠️ Misconfiguring these may prevent the wallet from loading correctly.
 
-Both `.env` files are excluded from version control via `.gitignore` so your credentials remain private.
+All `.env` files are excluded from version control via `.gitignore` so your credentials remain private.
 
 The server honors a few extra environment variables when building or serving the webapp:
 
 - `WEBAPP_API_BASE_URL` – overrides the API base used during the webapp build. Set this when the bot API is hosted on another domain or port. If left empty the webapp assumes it is served from the same origin.
-- `TONCONNECT_MANIFEST_URL` – full URL for a custom `tonconnect-manifest.json`. Defaults to the manifest bundled with the build when unset.
-- `SKIP_WEBAPP_BUILD` – set to any value to skip the automatic webapp build that normally runs when `npm start` is executed. Useful if you built the assets manually.
+ - `TONCONNECT_MANIFEST_URL` – full URL for a custom `tonconnect-manifest.json`. Defaults to the manifest bundled with the build when unset.
+ - `SKIP_WEBAPP_BUILD` – set to any value to skip the automatic webapp build that normally runs when `npm start` is executed. Useful if you built the assets manually.
 
-5. Install the Python requirements for the dice roller:
+5. Copy `scripts/.env.example` to `scripts/.env` and set:
+   - `MNEMONIC` – wallet seed phrase used to deploy the Jetton
+   - `RPC_URL` – TON RPC endpoint (e.g. testnet)
+   - `ADMIN_ADDRESS` – address that receives the minted supply
+
+6. Install the Python requirements for the dice roller:
 
    ```bash
    pip install -r requirements.txt
    ```
 
-6. Build the webapp assets. This step copies `public/tonconnect-manifest.json`
+7. Build the webapp assets. This step copies `public/tonconnect-manifest.json`
    into the `dist` folder so wallets can connect:
 
    ```bash
    npm --prefix webapp run build
    ```
 
-7. Run the test suite to verify the setup:
+8. Run the test suite to verify the setup:
 
    ```bash
    npm test
    ```
 
-8. Start the API server and Telegram bot:
+9. Start the API server and Telegram bot:
 
    ```bash
    npm start

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -1,0 +1,3 @@
+MNEMONIC=your twelve or twenty-four word phrase
+RPC_URL=https://testnet.toncenter.com/api/v2/jsonRPC
+ADMIN_ADDRESS=UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT

--- a/scripts/deploy_tpc_jetton.js
+++ b/scripts/deploy_tpc_jetton.js
@@ -1,8 +1,10 @@
 import { register } from 'node:module';
-import { pathToFileURL } from 'url';
+import { pathToFileURL, fileURLToPath } from 'url';
 register('ts-node/esm', pathToFileURL('./'));
 
 import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
 import { compile } from '@ton/blueprint';
 import { mnemonicToWalletKey } from 'ton-crypto';
 import { TonClient, TonClient4, WalletContractV4, internal } from 'ton';
@@ -10,10 +12,17 @@ import { Address, toNano, beginCell } from '@ton/core';
 import { JettonMinter, jettonContentToCell, jettonMinterConfigToCell } from '../wrappers/JettonMinter';
 import { JettonWallet } from '../wrappers/JettonWallet';
 
-const mnemonic = 'credit resist ship monster act grocery satoshi orphan apart flee inform dry ozone work devote job entry shock special boring hawk bench unlock cluster';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, '.env') });
 
-const ENDPOINT = 'https://testnet.toncenter.com/api/v2/jsonRPC';
-const ADMIN = Address.parse('UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT');
+const mnemonic = process.env.MNEMONIC;
+const ENDPOINT = process.env.RPC_URL;
+const ADMIN = process.env.ADMIN_ADDRESS && Address.parse(process.env.ADMIN_ADDRESS);
+
+if (!mnemonic || !ENDPOINT || !ADMIN) {
+  console.error('MNEMONIC, RPC_URL and ADMIN_ADDRESS must be set in scripts/.env');
+  process.exit(1);
+}
 
 async function main() {
   const keyPair = await mnemonicToWalletKey(mnemonic.split(' '));


### PR DESCRIPTION
## Summary
- load `.env` variables in `deploy_tpc_jetton.js`
- add example environment file for scripts
- ignore `scripts/.env`
- document new setup step in README

## Testing
- `npm test` *(fails: test suite errors and timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_686811ecbc3c83299f21c2d33cb6cc28