### PR TITLE
Update TPC icon paths

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -21,7 +21,7 @@ export default function BalanceSummary({ className = '', showHeader = true }) {
       )}
       <div className="grid grid-cols-3 text-sm mt-4">
         <Token icon="/icons/TON.png" label="TON" value={tonBalance ?? '...'} />
-        <Token icon="/assets/icons/coin_embedded.svg" label="TPC" value={tpcBalance ?? 0} decimals={2} />
+        <Token icon="/assets/icons/TPCcoin.png" label="TPC" value={tpcBalance ?? 0} decimals={2} />
         <Token icon="/icons/Usdt.png" label="USDT" value={usdtBalance ?? '...'} decimals={2} />
       </div>
     </div>

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -115,7 +115,7 @@ export default function DailyCheckIn() {
 
         <span className="flex items-center">
           {formatReward(REWARDS[i])}
-          <img src="/assets/icons/coin_embedded.svg" alt="TPC" className="w-8 h-8 -ml-1" />
+          <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 -ml-1" />
         </span>
 
       </div>

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -21,7 +21,11 @@ export default function InvitePopup({
           <p className="text-center">
             {name} wants to play you for {stake?.amount}{' '}
             <img
-              src={`/icons/${stake?.token || 'TPC'}${stake?.token === 'TPC' ? 'coin' : ''}.png`}
+              src={
+                stake?.token === 'TPC'
+                  ? '/assets/icons/TPCcoin.png'
+                  : `/icons/${stake?.token || 'TPC'}.png`
+              }
               alt="token"
               className="inline w-4 h-4 mr-1"
             />

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -147,7 +147,7 @@ export default function MiningCard() {
       </button>
       {isMining && (
         <div className="flex items-center justify-center space-x-1 text-sm">
-          <img src="/assets/icons/coin_embedded.svg" alt="TPC" className="w-5 h-5" />
+          <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-5 h-5" />
           <span>{minted}</span>
         </div>
       )}

--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -6,7 +6,7 @@ const AMOUNTS = {
   USDT: [0.1, 0.5, 1, 5, 10],
 };
 const tokens = [
-  { id: 'TPC', icon: '/assets/icons/coin_embedded.svg' },
+  { id: 'TPC', icon: '/assets/icons/TPCcoin.png' },
   { id: 'TON', icon: '/icons/TON.png' },
   { id: 'USDT', icon: '/icons/Usdt.png' },
 ];

--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -17,7 +17,11 @@ function CoinBurst({ token }) {
       {coins.map((c, i) => (
         <img
           key={i}
-          src={`/icons/${token.toLowerCase()}.svg`}
+          src={
+            token.toUpperCase() === 'TPC'
+              ? '/assets/icons/TPCcoin.png'
+              : `/icons/${token.toLowerCase()}.svg`
+          }
           className="coin-img"
           style={{
             "--dx": `${c.dx}px`,
@@ -264,7 +268,7 @@ export default function SnakeBoard({
                     ? '/icons/TON.png'
                     : token === 'USDT'
                     ? '/icons/Usdt.png'
-                    : '/assets/icons/coin_embedded.svg'
+                    : '/assets/icons/TPCcoin.png'
                 }
                 alt={token}
                 className="pot-icon"

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -205,7 +205,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
                 </>
               ) : (
                 <>
-                  <img src="/assets/icons/coin_embedded.svg" alt="TPC" className="w-8 h-8 mr-1" />
+                  <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 mr-1" />
                   <span>{val >= 1000 ? `${val / 1000}k` : val}</span>
                 </>
               )}

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -23,7 +23,7 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
 
   const token = (tx.token || 'TPC').toUpperCase();
   const iconMap = {
-    TPC: '/assets/icons/coin_embedded.svg',
+    TPC: '/assets/icons/TPCcoin.png',
     TON: '/icons/TON.png',
     USDT: '/icons/Usdt.png'
   };

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -143,7 +143,11 @@ function CoinBurst({ token }) {
       {coins.map((c, i) => (
         <img
           key={i}
-          src={`/icons/${token.toLowerCase()}.svg`}
+          src={
+            token.toUpperCase() === 'TPC'
+              ? '/assets/icons/TPCcoin.png'
+              : `/icons/${token.toLowerCase()}.svg`
+          }
           className="coin-img"
           style={{
             "--dx": `${c.dx}px`,
@@ -457,7 +461,7 @@ function Board({
                     ? '/icons/TON.png'
                     : token === 'USDT'
                     ? '/icons/Usdt.png'
-                    : '/assets/icons/coin_embedded.svg'
+                    : '/assets/icons/TPCcoin.png'
                 }
                 alt={token}
                 className="pot-icon"
@@ -632,7 +636,7 @@ export default function SnakeAndLadder() {
     });
     {
       const img = new Image();
-      img.src = '/assets/icons/coin_embedded.svg';
+      img.src = '/assets/icons/TPCcoin.png';
     }
     AVATARS.forEach((src) => {
       const img = new Image();
@@ -1923,7 +1927,7 @@ export default function SnakeAndLadder() {
                     ? '/icons/TON.png'
                     : token === 'USDT'
                     ? '/icons/Usdt.png'
-                    : '/assets/icons/coin_embedded.svg'
+                    : '/assets/icons/TPCcoin.png'
                 }
                 alt={token}
                 className="inline w-4 h-4 align-middle"

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -153,7 +153,7 @@ export default function Home() {
                   <span className="text-xs text-accent">Send</span>
                 </Link>
                 <div className="flex flex-col items-center space-y-1">
-                  <img src="/assets/icons/coin_embedded.svg" alt="TPC" className="w-10 h-10" />
+                  <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-10 h-10" />
                   <span className="text-sm">{formatValue(tpcBalance ?? '...', 2)}</span>
                 </div>
                 <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -64,7 +64,7 @@ export default function Store() {
           </div>
           <div className="text-lg font-bold flex items-center space-x-1">
             <span>{b.tpc.toLocaleString()}</span>
-            <img src="/assets/icons/coin_embedded.svg" alt="TPC" className="w-6 h-6" />
+            <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-6 h-6" />
           </div>
           <div className="text-primary text-lg flex items-center space-x-1">
             <span>{b.ton}</span>

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -256,7 +256,7 @@ export default function Wallet() {
       <div className="prism-box p-6 space-y-2 w-80 mx-auto border-[#334155] min-h-40 flex flex-col items-start">
         <p className="text-xs break-all w-full text-left">Account: {accountId || '...'}</p>
         <div className="flex items-center space-x-1">
-          <img src="/assets/icons/coin_embedded.svg" alt="TPC" className="w-8 h-8" />
+          <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-8 h-8" />
           <span className="text-lg font-medium">TPC Balance</span>
         </div>
         <p className="text-xl font-medium">


### PR DESCRIPTION
## Summary
- use `TPCcoin.png` everywhere the TPC icon appears
- adjust dynamic icon logic for invites, snake boards and wheels

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686831ada2c483298a577a4f19e65107