### PR TITLE
Fix Telegram notification icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Token icons for the lobby and wallet are now:
 
 - `TON.png`
 - `Usdt.png`
-- `assets/icons/coin_embedded.svg`
+- `assets/icons/TPCcoin.png`
 
 Place your own images with those exact names in the same directories to
 override them.

--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -6,7 +6,7 @@ import { fetchTelegramInfo } from './telegram.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const coinPath = path.join(
   __dirname,
-  '../../webapp/public/assets/icons/coin_embedded.svg'
+  '../../webapp/public/assets/icons/TPCcoin.png'
 );
 
 export function getInviteUrl(roomId, token, amount) {

--- a/tpc_metadata.json
+++ b/tpc_metadata.json
@@ -3,5 +3,5 @@
   "symbol": "TPC",
   "decimals": 9,
   "description": "TonPlaygram Coin (TPC) powers mining, games, and rewards inside the TonPlaygram platform.",
-  "image": "https://tonplaygramwebapp.onrender.com/assets/icons/coin_embedded.svg"
+  "image": "https://tonplaygramwebapp.onrender.com/assets/icons/TPCcoin.png"
 }


### PR DESCRIPTION
## Summary
- use a PNG image for Telegram invite notifications
- update icon references in README and metadata

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*
- `npm install` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68683c34a320832980d23b84099b13fe