### PR TITLE
Send TPC with invites

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -371,6 +371,7 @@ app.post('/api/snake/invite', async (req, res) => {
         roomId,
         token,
         amount,
+        true,
       );
     } catch (err) {
       console.error('Failed to send Telegram notification:', err.message);
@@ -521,6 +522,7 @@ io.on('connection', (socket) => {
           roomId,
           token,
           amount,
+          true,
         );
       } catch (err) {
         console.error('Failed to send Telegram notification:', err.message);
@@ -606,6 +608,7 @@ io.on('connection', (socket) => {
               roomId,
               token,
               amount,
+              true,
             );
           } catch (err) {
             console.error('Failed to send Telegram notification:', err.message);

--- a/bot/utils/inviteTpc.js
+++ b/bot/utils/inviteTpc.js
@@ -1,0 +1,43 @@
+import User from '../models/User.js';
+import { ensureTransactionArray } from './userUtils.js';
+
+export async function transferInviteTpc(fromId, toId, amount = 1) {
+  if (!fromId || !toId || amount <= 0) return;
+
+  const sender = await User.findOne({ telegramId: fromId });
+  if (!sender || sender.balance < amount) return;
+
+  const receiver = await User.findOneAndUpdate(
+    { telegramId: toId },
+    { $setOnInsert: { referralCode: String(toId) } },
+    { upsert: true, new: true },
+  );
+
+  ensureTransactionArray(sender);
+  ensureTransactionArray(receiver);
+
+  const txDate = new Date();
+
+  sender.balance -= amount;
+  receiver.balance += amount;
+
+  sender.transactions.push({
+    amount: -amount,
+    type: 'invite',
+    token: 'TPC',
+    status: 'delivered',
+    date: txDate,
+    toAccount: String(toId),
+  });
+
+  receiver.transactions.push({
+    amount,
+    type: 'invite',
+    token: 'TPC',
+    status: 'delivered',
+    date: txDate,
+    fromAccount: String(fromId),
+  });
+
+  await Promise.all([sender.save(), receiver.save()]);
+}

--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -2,6 +2,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { createCanvas, loadImage } from 'canvas';
 import { fetchTelegramInfo } from './telegram.js';
+import { transferInviteTpc } from './inviteTpc.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const coinPath = path.join(
@@ -116,6 +117,7 @@ export async function sendInviteNotification(
   roomId,
   token,
   amount,
+  sendToken = false,
 ) {
   let info;
   try {
@@ -141,6 +143,14 @@ export async function sendInviteNotification(
       ],
     ],
   };
+
+  if (sendToken) {
+    try {
+      await transferInviteTpc(fromId, toId, 1);
+    } catch (err) {
+      console.error('Failed to send invite TPC:', err.message);
+    }
+  }
 
   const photo = info?.photoUrl ? { url: info.photoUrl } : { source: coinPath };
 


### PR DESCRIPTION
## Summary
- add helper to credit 1 TPC when sending game invites
- update invite notification to optionally send TPC
- send token when creating game invites

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_686840ee83108329830e33a3cacc7a4b