### PR TITLE
Add DominoPlay game

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -4,6 +4,7 @@ import { TonConnectUIProvider } from '@tonconnect/ui-react';
 
 import Home from './pages/Home.jsx';
 import Friends from './pages/Friends.jsx';
+const DominoPlay = lazy(() => import('./pages/Games/DominoPlay.jsx'));
 import Wallet from './pages/Wallet.jsx';
 import Tasks from './pages/Tasks.jsx';
 import Referral from './pages/Referral.jsx';
@@ -39,6 +40,7 @@ export default function App() {
           <Route path="/games" element={<Games />} />
           <Route path="/games/:game/lobby" element={<Lobby />} />
             <Route path="/games/horse" element={<HorseRacing />} />
+          <Route path="/games/domino" element={<DominoPlay />} />
           <Route
             path="/games/snake"
             element={

--- a/webapp/src/components/DominoBoard.jsx
+++ b/webapp/src/components/DominoBoard.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import DominoPiece from './DominoPiece.jsx';
+
+export default function DominoBoard({ pieces = [] }) {
+  return (
+    <div className="domino-board">
+      {pieces.map((p, i) => (
+        <DominoPiece key={i} left={p.left} right={p.right} />
+      ))}
+    </div>
+  );
+}

--- a/webapp/src/components/DominoPiece.jsx
+++ b/webapp/src/components/DominoPiece.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function DominoPiece({ left, right, vertical = false }) {
+  return (
+    <div className={`domino-piece ${vertical ? 'domino-vert' : ''}`}> 
+      <div className="domino-half">{left}</div>
+      <span className="domino-divider" />
+      <div className="domino-half">{right}</div>
+    </div>
+  );
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1198,3 +1198,40 @@ input:focus {
   box-shadow: 0 0 8px #00f7ff, 0 0 16px #00f7ff;
 }
 
+
+.domino-board {
+  @apply flex flex-wrap justify-center items-center gap-2 board-3d;
+}
+
+.domino-piece {
+  position: relative;
+  width: 4rem;
+  height: 2rem;
+  background: linear-gradient(#fff, #ddd);
+  border: 2px solid #333;
+  border-radius: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 0.25rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+  transform-style: preserve-3d;
+}
+
+.domino-divider {
+  position: absolute;
+  top: 0.15rem;
+  bottom: 0.15rem;
+  left: 50%;
+  width: 2px;
+  background: #333;
+  transform: translateZ(1px);
+}
+
+.domino-half {
+  width: 50%;
+  text-align: center;
+  font-weight: bold;
+  font-size: 1rem;
+  z-index: 1;
+}

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -13,6 +13,7 @@ export default function Games() {
       <h2 className="text-2xl font-bold text-center mt-4">Games</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <GameCard title="Snake & Ladder" icon="🎲" link="/games/snake/lobby" />
+        <GameCard title="DominoPlay" icon="🁫" link="/games/domino" />
       </div>
     </div>
   );

--- a/webapp/src/pages/Games/DominoPlay.jsx
+++ b/webapp/src/pages/Games/DominoPlay.jsx
@@ -1,0 +1,135 @@
+import { useState, useEffect } from 'react';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import DominoBoard from '../../components/DominoBoard.jsx';
+import DominoPiece from '../../components/DominoPiece.jsx';
+import { dealHands } from '../../utils/domino.js';
+
+export default function DominoPlay() {
+  useTelegramBackButton();
+  const [mode, setMode] = useState('ai-easy');
+  const [started, setStarted] = useState(false);
+  const [hands, setHands] = useState([]);
+  const [deck, setDeck] = useState([]);
+  const [board, setBoard] = useState([]);
+  const [turn, setTurn] = useState(0);
+  const [winner, setWinner] = useState(null);
+
+  useEffect(() => {
+    if (started && mode.startsWith('ai') && turn === 1 && !winner) {
+      setTimeout(() => aiMove(), 500);
+    }
+  }, [turn, started, mode, winner]);
+
+  const startGame = () => {
+    const { hands: dealt, deck } = dealHands(28, 2);
+    const start = dealt[0].findIndex((d) => d.left === d.right && d.left === 6);
+    let first;
+    if (start !== -1) {
+      first = dealt[0].splice(start, 1)[0];
+    } else {
+      first = deck.pop();
+    }
+    setHands(dealt);
+    setDeck(deck);
+    setBoard([first]);
+    setTurn(0);
+    setWinner(null);
+    setStarted(true);
+  };
+
+  const play = (idx) => {
+    if (winner || turn !== 0) return;
+    const piece = hands[0][idx];
+    if (!canPlay(piece)) return;
+    placePiece(0, idx, piece);
+  };
+
+  const canPlay = (piece) => {
+    if (board.length === 0) return true;
+    const leftEnd = board[0].left;
+    const rightEnd = board[board.length - 1].right;
+    return piece.left === leftEnd || piece.right === leftEnd || piece.left === rightEnd || piece.right === rightEnd;
+  };
+
+  const placePiece = (player, index, piece) => {
+    setHands((h) => {
+      const copy = h.map((hand) => [...hand]);
+      copy[player].splice(index, 1);
+      return copy;
+    });
+    setBoard((b) => {
+      const next = [...b];
+      if (next.length === 0) {
+        next.push(piece);
+      } else {
+        const leftEnd = next[0].left;
+        const rightEnd = next[next.length - 1].right;
+        if (piece.right === leftEnd) {
+          next.unshift({ left: piece.left, right: piece.right });
+        } else if (piece.left === leftEnd) {
+          next.unshift({ left: piece.right, right: piece.left });
+        } else if (piece.left === rightEnd) {
+          next.push({ left: piece.left, right: piece.right });
+        } else {
+          next.push({ left: piece.right, right: piece.left });
+        }
+      }
+      return next;
+    });
+    checkWinner(player);
+    setTurn((t) => (t === 0 ? 1 : 0));
+  };
+
+  const aiMove = () => {
+    for (let i = 0; i < hands[1].length; i++) {
+      if (canPlay(hands[1][i])) {
+        placePiece(1, i, hands[1][i]);
+        return;
+      }
+    }
+    // draw if cannot play
+    if (deck.length) {
+      setHands((h) => {
+        const copy = h.map((hand) => [...hand]);
+        copy[1].push(deck.pop());
+        return copy;
+      });
+      setDeck([...deck]);
+      aiMove();
+    } else {
+      setTurn(0);
+    }
+  };
+
+  const checkWinner = (p) => {
+    if (hands[p].length === 1) {
+      setWinner(p);
+    }
+  };
+
+  if (!started) {
+    return (
+      <div className="p-4 space-y-4 text-text">
+        <h2 className="text-xl font-bold text-center">DominoPlay</h2>
+        <div className="flex justify-center space-x-4">
+          <button className="px-4 py-2 bg-primary rounded text-white" onClick={startGame}>Start vs AI</button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4 text-text">
+      <h2 className="text-xl font-bold text-center">DominoPlay</h2>
+      {winner !== null && <div className="text-center">Player {winner + 1} wins!</div>}
+      <DominoBoard pieces={board} />
+      <div className="flex space-x-2 overflow-x-auto">
+        {hands[0].map((p, i) => (
+          <div key={i} onClick={() => play(i)} className="cursor-pointer">
+            <DominoPiece left={p.left} right={p.right} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/utils/domino.js
+++ b/webapp/src/utils/domino.js
@@ -1,0 +1,30 @@
+export function generateDominoSet() {
+  const set = [];
+  for (let i = 0; i <= 6; i++) {
+    for (let j = i; j <= 6; j++) {
+      set.push({ left: i, right: j });
+    }
+  }
+  return set;
+}
+
+export function shuffle(array) {
+  const a = [...array];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+export function dealHands(count, players) {
+  const deck = shuffle(generateDominoSet());
+  const handSize = players <= 2 ? 7 : 5;
+  const hands = Array.from({ length: players }, () => []);
+  for (let i = 0; i < handSize; i++) {
+    for (let p = 0; p < players; p++) {
+      hands[p].push(deck.pop());
+    }
+  }
+  return { hands, deck };
+}


### PR DESCRIPTION
## Summary
- add DominoPlay game page and board components
- support domino piece styles in `index.css`
- list DominoPlay in game selection
- route `/games/domino` to the new page

## Testing
- `npm test` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6868ab42a10883299d7a100d2316310d