### PR TITLE
Adjust spin game UI

### DIFF
--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -159,7 +159,7 @@ export default function SpinGame() {
       <h3 className="text-lg font-bold text-text">Spin &amp; Win</h3>
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>
       <div className="flex items-start space-x-1">
-        {bonusActive && (
+        <div className="relative" style={{ opacity: bonusActive ? 1 : 0.15 }}>
           <SpinWheel
             ref={leftWheelRef}
             onFinish={handleBonusFinish}
@@ -168,7 +168,12 @@ export default function SpinGame() {
             disabled={!bonusActive}
             showButton={false}
           />
-        )}
+          {!bonusActive && (
+            <span className="absolute inset-0 flex items-center justify-center text-xs text-white text-center pointer-events-none">
+              Bonus to Activate
+            </span>
+          )}
+        </div>
         <SpinWheel
           ref={wheelRef}
           onFinish={handleFinish}
@@ -177,7 +182,7 @@ export default function SpinGame() {
           disabled={!ready}
           showButton={false}
         />
-        {bonusActive && (
+        <div className="relative" style={{ opacity: bonusActive ? 1 : 0.15 }}>
           <SpinWheel
             ref={rightWheelRef}
             onFinish={handleBonusFinish}
@@ -186,7 +191,12 @@ export default function SpinGame() {
             disabled={!bonusActive}
             showButton={false}
           />
-        )}
+          {!bonusActive && (
+            <span className="absolute inset-0 flex items-center justify-center text-xs text-white text-center pointer-events-none">
+              Bonus to Activate
+            </span>
+          )}
+        </div>
       </div>
       <button
         onClick={triggerSpin}

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -136,11 +136,11 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
   return (
 
-    <div className="w-36 mx-auto flex flex-col items-center">
+    <div className="w-32 mx-auto flex flex-col items-center">
 
       <div
 
-        className="relative overflow-hidden w-32"
+        className="relative overflow-hidden w-28"
 
         style={{ height: itemHeight * visibleRows }}
 
@@ -158,7 +158,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
         <div
 
-          className="flex flex-col items-center w-32"
+          className="flex flex-col items-center w-28"
 
           style={{
 
@@ -176,7 +176,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
               key={idx}
 
-              className={`board-style flex items-center justify-center text-sm w-32 font-bold ${
+              className={`board-style flex items-center justify-center text-sm w-28 font-bold ${
 
                 idx === winnerIndex ? 'bg-yellow-300 text-black' : 'text-white'
 
@@ -198,9 +198,9 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
                     className="w-8 h-8 mr-1"
                   />
                   <span>
-                    {val === 1600 && '1 Free Spin'}
-                    {val === 1800 && '2 Free Spins'}
-                    {val === 5000 && '3 Free Spins'}
+                    {val === 1600 && '1'}
+                    {val === 1800 && '2'}
+                    {val === 5000 && '3'}
                   </span>
                 </>
               ) : (


### PR DESCRIPTION
## Summary
- shrink wheel width to reduce box size
- simplify free spin labels to just show the number
- display side wheels at 15% opacity when inactive
- show "Bonus to Activate" text on both side wheels

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868ad9a4c0c83299c26c5864f45e564