### PR TITLE
Add lobby for Domino game

### DIFF
--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -13,7 +13,7 @@ export default function Games() {
       <h2 className="text-2xl font-bold text-center mt-4">Games</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <GameCard title="Snake & Ladder" icon="🎲" link="/games/snake/lobby" />
-        <GameCard title="DominoPlay" icon="🁫" link="/games/domino" />
+        <GameCard title="DominoPlay" icon="🁫" link="/games/domino/lobby" />
       </div>
     </div>
   );

--- a/webapp/src/pages/Games/DominoPlay.jsx
+++ b/webapp/src/pages/Games/DominoPlay.jsx
@@ -8,11 +8,24 @@ export default function DominoPlay() {
   useTelegramBackButton();
   const [mode, setMode] = useState('ai-easy');
   const [started, setStarted] = useState(false);
+  const [token, setToken] = useState('TPC');
+  const [amount, setAmount] = useState(0);
   const [hands, setHands] = useState([]);
   const [deck, setDeck] = useState([]);
   const [board, setBoard] = useState([]);
   const [turn, setTurn] = useState(0);
   const [winner, setWinner] = useState(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const tok = params.get('token');
+    const amt = params.get('amount');
+    if (tok) setToken(tok.toUpperCase());
+    if (amt) setAmount(Number(amt));
+    if (tok || amt) {
+      startGame();
+    }
+  }, []);
 
   useEffect(() => {
     if (started && mode.startsWith('ai') && turn === 1 && !winner) {
@@ -121,6 +134,7 @@ export default function DominoPlay() {
   return (
     <div className="p-4 space-y-4 text-text">
       <h2 className="text-xl font-bold text-center">DominoPlay</h2>
+      <p className="text-center">Stake: {amount} {token}</p>
       {winner !== null && <div className="text-center">Player {winner + 1} wins!</div>}
       <DominoBoard pieces={board} />
       <div className="flex space-x-2 overflow-x-auto">

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -71,7 +71,10 @@ export default function Lobby() {
         active = false;
         clearInterval(id);
       };
-  }
+    } else if (game === 'domino') {
+      setTables([{ id: 'single', label: 'Single Player vs AI' }]);
+      setTable({ id: 'single', label: 'Single Player vs AI' });
+    }
   }, [game]);
 
   useEffect(() => {
@@ -126,7 +129,7 @@ export default function Lobby() {
   const startGame = async () => {
     const params = new URLSearchParams();
     if (table) params.set('table', table.id);
-    if (stake.token === 'TON' && stake.amount > 0) {
+    if (game === 'snake' && stake.token === 'TON' && stake.amount > 0) {
       if (!walletAddress) {
         tonConnectUI.openModal();
         return;
@@ -148,7 +151,7 @@ export default function Lobby() {
       }
     }
 
-    if (table?.id === 'single') {
+    if (game === 'snake' && table?.id === 'single') {
       localStorage.removeItem(`snakeGameState_${aiCount}`);
       params.set('ai', aiCount);
       params.set('token', 'TPC');
@@ -170,6 +173,7 @@ export default function Lobby() {
       if (stake.token) params.set('token', stake.token);
       if (stake.amount) params.set('amount', stake.amount);
     }
+
     navigate(`/games/${game}?${params.toString()}`);
   };
 

--- a/webapp/src/utils/lobby.js
+++ b/webapp/src/utils/lobby.js
@@ -3,6 +3,10 @@ export function canStartGame(game, table, stake, aiCount = 0, players = 0) {
     if (!stake || !stake.token || !stake.amount) return false;
     return aiCount > 0;
   }
+  if (game === 'domino') {
+    if (!stake || !stake.token || !stake.amount) return false;
+    return true;
+  }
   if (game === 'snake' && table && table.id !== 'single') {
     if (players < (table.capacity || 0)) return false;
   }


### PR DESCRIPTION
## Summary
- route Domino game through a new lobby
- parse lobby parameters in DominoPlay
- allow lobby.js to validate Domino games

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868b1438e7c8329936e84f62830f929