### PR TITLE
Update spin wheel styling and sounds

### DIFF
--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { getGameVolume } from '../utils/sound.js';
 import confetti from 'canvas-confetti';
 import { Segment } from '../utils/rewardLogic';
 
@@ -12,6 +13,12 @@ export default function RewardPopup({ reward, onClose, message }: RewardPopupPro
   if (reward === null) return null;
   useEffect(() => {
     confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
+    const audio = new Audio('/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3');
+    audio.volume = getGameVolume();
+    audio.play().catch(() => {});
+    return () => {
+      audio.pause();
+    };
   }, []);
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -158,7 +158,7 @@ export default function SpinGame() {
       />
       <h3 className="text-lg font-bold text-text">Spin &amp; Win</h3>
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>
-      <div className="flex items-start space-x-1">
+      <div className="flex items-start space-x-0.5">
         <div className="relative" style={{ opacity: bonusActive ? 1 : 0.15 }}>
           <SpinWheel
             ref={leftWheelRef}
@@ -169,7 +169,7 @@ export default function SpinGame() {
             showButton={false}
           />
           {!bonusActive && (
-            <span className="absolute inset-0 flex items-center justify-center text-xs text-white text-center pointer-events-none">
+            <span className="absolute inset-0 flex items-center justify-center text-xs font-bold text-red-600 text-center pointer-events-none drop-shadow-[0_0_2px_white]">
               Bonus to Activate
             </span>
           )}
@@ -192,7 +192,7 @@ export default function SpinGame() {
             showButton={false}
           />
           {!bonusActive && (
-            <span className="absolute inset-0 flex items-center justify-center text-xs text-white text-center pointer-events-none">
+            <span className="absolute inset-0 flex items-center justify-center text-xs font-bold text-red-600 text-center pointer-events-none drop-shadow-[0_0_2px_white]">
               Bonus to Activate
             </span>
           )}

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -60,6 +60,9 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
   const spinSoundRef = useRef<HTMLAudioElement | null>(null);
   const successSoundRef = useRef<HTMLAudioElement | null>(null);
+  const bonusSoundRef = useRef<HTMLAudioElement | null>(null);
+  const extraBonusSoundRef1 = useRef<HTMLAudioElement | null>(null);
+  const freeSpinSoundRef = useRef<HTMLAudioElement | null>(null);
 
   useEffect(() => {
     spinSoundRef.current = new Audio('/assets/sounds/spinning.mp3');
@@ -68,9 +71,21 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
     successSoundRef.current = new Audio('/assets/sounds/successful.mp3');
     successSoundRef.current.preload = 'auto';
     successSoundRef.current.volume = getGameVolume();
+    bonusSoundRef.current = new Audio('/assets/sounds/yabba-dabba-doo.mp3');
+    bonusSoundRef.current.preload = 'auto';
+    bonusSoundRef.current.volume = getGameVolume();
+    extraBonusSoundRef1.current = new Audio('/assets/sounds/happy-noisesmp3-14568.mp3');
+    extraBonusSoundRef1.current.preload = 'auto';
+    extraBonusSoundRef1.current.volume = getGameVolume();
+    freeSpinSoundRef.current = new Audio('/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3');
+    freeSpinSoundRef.current.preload = 'auto';
+    freeSpinSoundRef.current.volume = getGameVolume();
     return () => {
       spinSoundRef.current?.pause();
       successSoundRef.current?.pause();
+      bonusSoundRef.current?.pause();
+      extraBonusSoundRef1.current?.pause();
+      freeSpinSoundRef.current?.pause();
     };
   }, []);
 
@@ -78,6 +93,9 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
     const handler = () => {
       if (spinSoundRef.current) spinSoundRef.current.volume = getGameVolume();
       if (successSoundRef.current) successSoundRef.current.volume = getGameVolume();
+      if (bonusSoundRef.current) bonusSoundRef.current.volume = getGameVolume();
+      if (extraBonusSoundRef1.current) extraBonusSoundRef1.current.volume = getGameVolume();
+      if (freeSpinSoundRef.current) freeSpinSoundRef.current.volume = getGameVolume();
     };
     window.addEventListener('gameVolumeChanged', handler);
     return () => window.removeEventListener('gameVolumeChanged', handler);
@@ -122,9 +140,27 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
       setSpinning(false);
       setWinnerIndex(finalIndex);
 
-      if (successSoundRef.current) {
-        successSoundRef.current.currentTime = 0;
-        successSoundRef.current.play().catch(() => {});
+      if (reward === 'BONUS_X3') {
+        bonusSoundRef.current?.play().catch(() => {});
+        extraBonusSoundRef1.current?.play().catch(() => {});
+        if (successSoundRef.current) {
+          successSoundRef.current.currentTime = 0;
+          successSoundRef.current.play().catch(() => {});
+        }
+      } else if (reward === 1600 || reward === 1800 || reward === 5000) {
+        if (freeSpinSoundRef.current) {
+          freeSpinSoundRef.current.currentTime = 0;
+          freeSpinSoundRef.current.play().catch(() => {});
+        }
+        if (successSoundRef.current) {
+          successSoundRef.current.currentTime = 0;
+          successSoundRef.current.play().catch(() => {});
+        }
+      } else {
+        if (successSoundRef.current) {
+          successSoundRef.current.currentTime = 0;
+          successSoundRef.current.play().catch(() => {});
+        }
       }
       onFinish(reward);
       setWheelSegments(shuffleSegments(baseSegments));


### PR DESCRIPTION
## Summary
- tweak wheel spacing and bonus overlay style
- play cheer sound when reward popup is shown
- add bonus and free-spin sounds to the spin wheel

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6868b49d8fcc8329bcc83fc566dd24a8