### PR TITLE
Add base Ludo game implementation

### DIFF
--- a/bot/logic/ludoGame.js
+++ b/bot/logic/ludoGame.js
@@ -1,0 +1,78 @@
+export const PATH_LENGTH = 52;
+export const HOME_LENGTH = 6;
+
+const START_INDICES = [0, 13, 26, 39];
+const HOME_ENTRY = [51, 12, 25, 38];
+
+export class LudoGame {
+  constructor(players = 4) {
+    this.players = [];
+    for (let i = 0; i < players; i++) {
+      this.players.push({
+        id: i,
+        name: `Player${i + 1}`,
+        tokens: Array(4).fill(-1),
+        finished: 0
+      });
+    }
+    this.currentTurn = 0;
+    this.finished = false;
+  }
+
+  addPlayer(id, name) {
+    const p = this.players[id];
+    if (p) p.name = name;
+  }
+
+  nextPlayer() {
+    do {
+      this.currentTurn = (this.currentTurn + 1) % this.players.length;
+    } while (this.players[this.currentTurn].finished === 4);
+  }
+
+  canMove(playerIdx, tokenIdx, dice) {
+    const pos = this.players[playerIdx].tokens[tokenIdx];
+    if (pos === HOME_LENGTH + PATH_LENGTH - 1) return false;
+    if (pos === -1) return dice === 6;
+    const target = pos + dice;
+    if (pos < PATH_LENGTH && target > HOME_ENTRY[playerIdx] && target < PATH_LENGTH)
+      return false;
+    return target <= PATH_LENGTH + HOME_LENGTH - 1;
+  }
+
+  moveToken(playerIdx, tokenIdx, dice) {
+    const player = this.players[playerIdx];
+    let pos = player.tokens[tokenIdx];
+    if (pos === -1) {
+      pos = 0;
+    } else {
+      pos += dice;
+    }
+    player.tokens[tokenIdx] = pos;
+    if (pos === PATH_LENGTH + HOME_LENGTH - 1) {
+      player.finished += 1;
+      if (player.finished === 4) this.finished = true;
+    }
+    return pos;
+  }
+
+  rollDice(diceValue) {
+    if (this.finished) return null;
+    const dice = diceValue || Math.floor(Math.random() * 6) + 1;
+    const playerIdx = this.currentTurn;
+    const player = this.players[playerIdx];
+    const movable = [];
+    for (let i = 0; i < player.tokens.length; i++) {
+      if (this.canMove(playerIdx, i, dice)) movable.push(i);
+    }
+    let tokenIndex = movable.length ? movable[0] : -1;
+    if (tokenIndex !== -1) {
+      const pos = this.moveToken(playerIdx, tokenIndex, dice);
+      if (dice !== 6) this.nextPlayer();
+      return { player: playerIdx, token: tokenIndex, dice, position: pos, finished: this.finished };
+    } else {
+      this.nextPlayer();
+      return { player: playerIdx, dice, token: -1, position: null, finished: this.finished };
+    }
+  }
+}

--- a/bot/models/GameRoom.js
+++ b/bot/models/GameRoom.js
@@ -13,6 +13,7 @@ const playerSchema = new mongoose.Schema(
 
 const gameRoomSchema = new mongoose.Schema({
   roomId: { type: String, unique: true },
+  gameType: { type: String, default: 'snake' },
   capacity: { type: Number, default: 4 },
   status: { type: String, default: 'waiting' },
   currentTurn: { type: Number, default: 0 },

--- a/test/ludoGame.test.js
+++ b/test/ludoGame.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { LudoGame } from '../bot/logic/ludoGame.js';
+
+test('token requires 6 to leave base', () => {
+  const game = new LudoGame(2);
+  const res = game.rollDice(3);
+  assert.equal(game.players[0].tokens[0], -1);
+  assert.equal(game.currentTurn, 1);
+  game.currentTurn = 0;
+  game.rollDice(6);
+  assert.equal(game.players[0].tokens[0], 0);
+});
+
+test('player wins when all tokens finish', () => {
+  const game = new LudoGame(1);
+  game.players[0].tokens = Array(4).fill(57);
+  game.players[0].finished = 3;
+  game.currentTurn = 0;
+  const res = game.rollDice(6);
+  assert.ok(game.finished);
+});
+

--- a/webapp/src/components/LudoBoard.jsx
+++ b/webapp/src/components/LudoBoard.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import LudoToken from './LudoToken.jsx';
+
+const SIZE = 15;
+
+export default function LudoBoard({ players = [] }) {
+  const cells = [];
+  for (let r = 0; r < SIZE; r++) {
+    for (let c = 0; c < SIZE; c++) {
+      let cls = 'ludo-cell';
+      if (r < 6 && c < 6) cls += ' ludo-red';
+      else if (r < 6 && c >= 9) cls += ' ludo-green';
+      else if (r >= 9 && c < 6) cls += ' ludo-yellow';
+      else if (r >= 9 && c >= 9) cls += ' ludo-blue';
+      cells.push(<div key={`${r}-${c}`} className={cls}></div>);
+    }
+  }
+
+  return (
+    <div className="ludo-board">
+      {cells}
+      {players.map((p) =>
+        p.tokens.map((t, i) => {
+          if (t < 0) return null;
+          const pos = PATH[t] || { r: 7, c: 7 };
+          return (
+            <div
+              key={`${p.id}-${i}`}
+              className="token-wrapper"
+              style={{ gridRowStart: pos.r + 1, gridColumnStart: pos.c + 1 }}
+            >
+              <LudoToken color={p.color} />
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+// simplified path coordinates
+export const PATH = [
+  { r: 0, c: 6 },
+  { r: 1, c: 6 },
+  { r: 2, c: 6 },
+  { r: 3, c: 6 },
+  { r: 4, c: 6 },
+  { r: 5, c: 6 },
+  { r: 6, c: 5 },
+  { r: 6, c: 4 },
+  { r: 6, c: 3 },
+  { r: 6, c: 2 },
+  { r: 6, c: 1 },
+  { r: 6, c: 0 },
+  { r: 7, c: 0 },
+  { r: 8, c: 0 },
+  { r: 8, c: 1 },
+  { r: 8, c: 2 },
+  { r: 8, c: 3 },
+  { r: 8, c: 4 },
+  { r: 8, c: 5 },
+  { r: 9, c: 6 },
+  { r: 10, c: 6 },
+  { r: 11, c: 6 },
+  { r: 12, c: 6 },
+  { r: 13, c: 6 },
+  { r: 14, c: 6 },
+  { r: 14, c: 7 },
+  { r: 14, c: 8 },
+  { r: 13, c: 8 },
+  { r: 12, c: 8 },
+  { r: 11, c: 8 },
+  { r: 10, c: 8 },
+  { r: 9, c: 8 },
+  { r: 8, c: 9 },
+  { r: 8, c: 10 },
+  { r: 8, c: 11 },
+  { r: 8, c: 12 },
+  { r: 8, c: 13 },
+  { r: 8, c: 14 },
+  { r: 7, c: 14 },
+  { r: 6, c: 14 },
+  { r: 6, c: 13 },
+  { r: 6, c: 12 },
+  { r: 6, c: 11 },
+  { r: 6, c: 10 },
+  { r: 6, c: 9 },
+  { r: 5, c: 8 },
+  { r: 4, c: 8 },
+  { r: 3, c: 8 },
+  { r: 2, c: 8 },
+  { r: 1, c: 8 },
+  { r: 0, c: 8 },
+  { r: 0, c: 7 }
+];

--- a/webapp/src/components/LudoToken.jsx
+++ b/webapp/src/components/LudoToken.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function LudoToken({ color = 'red' }) {
+  return (
+    <div
+      className="ludo-token"
+      style={{ backgroundColor: color }}
+    />
+  );
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1235,3 +1235,31 @@ input:focus {
   font-size: 1rem;
   z-index: 1;
 }
+.ludo-board {
+  display: grid;
+  grid-template-columns: repeat(15, 1fr);
+  grid-template-rows: repeat(15, 1fr);
+  gap: 2px;
+  width: 300px;
+  height: 300px;
+  position: relative;
+}
+.ludo-cell {
+  width: 100%;
+  height: 100%;
+  background: #eee;
+}
+.ludo-red { background:#fecaca; }
+.ludo-green { background:#bbf7d0; }
+.ludo-yellow { background:#fef08a; }
+.ludo-blue { background:#bfdbfe; }
+.ludo-token {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid #000;
+  transition: transform 0.3s;
+}
+.token-wrapper {
+  position: absolute;
+}

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -80,6 +80,14 @@ export default function Lobby() {
       ];
       setTables(dominoTables);
       setTable(dominoTables[0]);
+    } else if (game === 'ludo') {
+      const ludoTables = [
+        { id: 'ludo-2', capacity: 2, players: 0 },
+        { id: 'ludo-3', capacity: 3, players: 0 },
+        { id: 'ludo-4', capacity: 4, players: 0 }
+      ];
+      setTables(ludoTables);
+      setTable(ludoTables[0]);
     }
   }, [game]);
 
@@ -203,7 +211,7 @@ export default function Lobby() {
       />
       <h2 className="text-xl font-bold text-center capitalize">{game} Lobby</h2>
       <p className="text-center text-sm">Online users: {online}</p>
-      {['snake', 'domino'].includes(game) && (
+      {['snake', 'domino', 'ludo'].includes(game) && (
         <div className="space-y-2">
           <div className="flex items-center justify-between">
             <h3 className="font-semibold">Select Table</h3>

--- a/webapp/src/pages/Games/Ludo.jsx
+++ b/webapp/src/pages/Games/Ludo.jsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import LudoBoard from '../../components/LudoBoard.jsx';
+import DiceRoller from '../../components/DiceRoller.jsx';
+
+export default function Ludo() {
+  useTelegramBackButton();
+  const [game] = useState(() => ({
+    players: [
+      { id: 0, color: '#ef4444', tokens: [-1, -1, -1, -1] },
+      { id: 1, color: '#22c55e', tokens: [-1, -1, -1, -1] },
+    ],
+    turn: 0
+  }));
+
+  const handleRoll = (vals) => {
+    const value = vals[0];
+    const p = game.players[game.turn];
+    for (let i = 0; i < p.tokens.length; i++) {
+      if (p.tokens[i] === -1 && value === 6) {
+        p.tokens[i] = 0;
+        break;
+      } else if (p.tokens[i] >= 0 && p.tokens[i] < 51) {
+        p.tokens[i] += value;
+        break;
+      }
+    }
+    if (value !== 6) game.turn = (game.turn + 1) % game.players.length;
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-bold text-center">Ludo</h2>
+      <div className="flex justify-center">
+        <LudoBoard players={game.players} />
+      </div>
+      <DiceRoller numDice={1} onRollEnd={handleRoll} clickable />
+    </div>
+  );
+}

--- a/webapp/src/utils/ludoApi.js
+++ b/webapp/src/utils/ludoApi.js
@@ -1,0 +1,29 @@
+import { API_BASE_URL } from './api.js';
+
+export function getLudoLobbies() {
+  return fetch(API_BASE_URL + '/api/ludo/lobbies').then((r) => r.json());
+}
+
+export function getLudoLobby(id) {
+  return fetch(API_BASE_URL + '/api/ludo/lobby/' + id).then((r) => r.json());
+}
+
+export function getLudoBoard(id) {
+  return fetch(API_BASE_URL + '/api/ludo/board/' + id).then((r) => r.json());
+}
+
+export function rollDice(id) {
+  return fetch(API_BASE_URL + '/api/ludo/roll/' + id, { method: 'POST' }).then((r) => r.json());
+}
+
+export function moveToken(id, token) {
+  return fetch(API_BASE_URL + '/api/ludo/move/' + id, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token })
+  }).then((r) => r.json());
+}
+
+export function endTurn(id) {
+  return fetch(API_BASE_URL + '/api/ludo/end/' + id, { method: 'POST' }).then((r) => r.json());
+}


### PR DESCRIPTION
## Summary
- implement `LudoGame` logic and tests
- extend server game engine and room model to handle a `gameType`
- add Ludo board, token and page in the webapp
- expose simple Ludo API helpers
- update lobby to list Ludo tables
- basic styles for new board

## Testing
- `npm test` *(fails: test timed out due to missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6868c9370ab0832993ff127297495689