### PR TITLE
Fix ad modal auto close

### DIFF
--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -15,10 +15,22 @@ export default function AdModal({ open, onComplete }: AdModalProps) {
         containerId: 'adsgram-player',
         walletAddress: ADSGRAM_WALLET,
       });
-      ad.on('finish', () => {
+
+      const handleFinish = () => {
         onComplete();
-      });
-      return () => ad.destroy?.();
+      };
+
+      ad.on?.('finish', handleFinish);
+      // Some versions emit 'close' or 'complete' when the ad ends
+      ad.on?.('close', handleFinish);
+      ad.on?.('complete', handleFinish);
+
+      return () => {
+        ad.off?.('finish', handleFinish);
+        ad.off?.('close', handleFinish);
+        ad.off?.('complete', handleFinish);
+        ad.destroy?.();
+      };
     }
   }, [open, onComplete]);
 


### PR DESCRIPTION
## Summary
- fix Adsgram ad modal not closing automatically after video ends

## Testing
- `npm test` *(fails: Cannot find package 'dotenv', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6868cb2e6b5c8329a4d205457b5f2891