### PR TITLE
Update spin rewards and add Ludo lobby

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -18,6 +18,7 @@ import HorseRacing from './pages/Games/HorseRacing.jsx';
 const SnakeAndLadder = lazy(() => import('./pages/Games/SnakeAndLadder.jsx'));
 const SnakeMultiplayer = lazy(() => import('./pages/Games/SnakeMultiplayer.jsx'));
 const SnakeResults = lazy(() => import('./pages/Games/SnakeResults.jsx'));
+const Ludo = lazy(() => import('./pages/Games/Ludo.jsx'));
 import Lobby from './pages/Games/Lobby.jsx';
 import Games from './pages/Games.jsx';
 import SpinPage from './pages/spin.tsx';
@@ -41,6 +42,14 @@ export default function App() {
           <Route path="/games/:game/lobby" element={<Lobby />} />
             <Route path="/games/horse" element={<HorseRacing />} />
           <Route path="/games/domino" element={<DominoPlay />} />
+          <Route
+            path="/games/ludo"
+            element={
+              <Suspense fallback={<div className="p-4 text-center">Loading...</div>}>
+                <Ludo />
+              </Suspense>
+            }
+          />
           <Route
             path="/games/snake"
             element={

--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { ADSGRAM_WALLET } from '../utils/constants.js';
 
 interface AdModalProps {
@@ -7,8 +7,13 @@ interface AdModalProps {
 }
 
 export default function AdModal({ open, onComplete }: AdModalProps) {
+  const [fallback, setFallback] = useState(false);
+
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      setFallback(false);
+      return;
+    }
     const sdk = (window as any).AdsgramSDK;
     if (sdk?.createVideoAd) {
       const ad = sdk.createVideoAd({
@@ -31,6 +36,8 @@ export default function AdModal({ open, onComplete }: AdModalProps) {
         ad.off?.('complete', handleFinish);
         ad.destroy?.();
       };
+    } else {
+      setFallback(true);
     }
   }, [open, onComplete]);
 
@@ -41,14 +48,19 @@ export default function AdModal({ open, onComplete }: AdModalProps) {
       <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text w-80">
         <img src="/assets/TonPlayGramLogo.jpg" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
         <h3 className="text-lg font-bold">Watch Ad</h3>
-        <div id="adsgram-player" className="w-full h-40 bg-black" />
-        <video
-          className="w-full h-40"
-          autoPlay
-          controls
-          onEnded={onComplete}
-          src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
+        <div
+          id="adsgram-player"
+          className={`w-full h-40 bg-black ${fallback ? 'hidden' : ''}`}
         />
+        {fallback && (
+          <video
+            className="w-full h-40"
+            autoPlay
+            controls
+            onEnded={onComplete}
+            src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
+          />
+        )}
         <p className="text-sm text-subtext">Watch the ad completely to unlock the spin.</p>
       </div>
     </div>

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -33,8 +33,7 @@ export default function RewardPopup({ reward, onClose, message }: RewardPopupPro
           {reward === 'BONUS_X3' && 'BONUS X3'}
           {typeof reward === 'number' && reward === 1600 && '+1 Free Spin'}
           {typeof reward === 'number' && reward === 1800 && '+2 Free Spins'}
-          {typeof reward === 'number' && reward === 5000 && '+3 Free Spins'}
-          {typeof reward === 'number' && reward !== 1600 && reward !== 1800 && reward !== 5000 && `+${reward} TPC`}
+          {typeof reward === 'number' && reward !== 1600 && reward !== 1800 && `+${reward} TPC`}
         </div>
         {message && <p className="text-sm text-subtext">{message}</p>}
         <button

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -59,7 +59,6 @@ export default function SpinGame() {
     let extraSpins = 0;
     if (r === 1600) extraSpins = 1;
     else if (r === 1800) extraSpins = 2;
-    else if (r === 5000) extraSpins = 3;
 
     if (extraSpins > 0) {
       const total = freeSpins + extraSpins;
@@ -87,7 +86,6 @@ export default function SpinGame() {
     let extraSpins = 0;
     if (r === 1600) extraSpins = 1;
     else if (r === 1800) extraSpins = 2;
-    else if (r === 5000) extraSpins = 3;
 
     if (extraSpins > 0) {
       const total = freeSpins + extraSpins;

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -147,7 +147,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
           successSoundRef.current.currentTime = 0;
           successSoundRef.current.play().catch(() => {});
         }
-      } else if (reward === 1600 || reward === 1800 || reward === 5000) {
+      } else if (reward === 1600 || reward === 1800) {
         if (freeSpinSoundRef.current) {
           freeSpinSoundRef.current.currentTime = 0;
           freeSpinSoundRef.current.play().catch(() => {});
@@ -224,7 +224,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
                 <span className="text-red-600 font-bold drop-shadow-[0_0_2px_black]">
                   BONUS X3
                 </span>
-              ) : val === 1600 || val === 1800 || val === 5000 ? (
+              ) : val === 1600 || val === 1800 ? (
                 <>
                   <img
                     src="/assets/icons/FreeSpin.png"
@@ -234,7 +234,6 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
                   <span>
                     {val === 1600 && '1'}
                     {val === 1800 && '2'}
-                    {val === 5000 && '3'}
                   </span>
                 </>
               ) : (

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -14,6 +14,7 @@ export default function Games() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <GameCard title="Snake & Ladder" icon="🎲" link="/games/snake/lobby" />
         <GameCard title="DominoPlay" icon="🁫" link="/games/domino/lobby" />
+        <GameCard title="Ludo" icon="🎲" link="/games/ludo/lobby" />
       </div>
     </div>
   );

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -16,6 +16,7 @@ import {
   getAccountBalance,
   addTransaction,
 } from '../../utils/api.js';
+import { getLudoLobbies, getLudoLobby } from '../../utils/ludoApi.js';
 import { getPlayerId, ensureAccountId, getTelegramId } from '../../utils/telegram.js';
 import { canStartGame } from '../../utils/lobby.js';
 import { SNAKE_CONTRACT_ADDRESS } from '../../utils/constants.js';
@@ -81,13 +82,20 @@ export default function Lobby() {
       setTables(dominoTables);
       setTable(dominoTables[0]);
     } else if (game === 'ludo') {
-      const ludoTables = [
-        { id: 'ludo-2', capacity: 2, players: 0 },
-        { id: 'ludo-3', capacity: 3, players: 0 },
-        { id: 'ludo-4', capacity: 4, players: 0 }
-      ];
-      setTables(ludoTables);
-      setTable(ludoTables[0]);
+      let active = true;
+      function load() {
+        getLudoLobbies()
+          .then((data) => {
+            if (active) setTables([{ id: 'single', label: 'Single Player vs AI' }, ...data]);
+          })
+          .catch(() => {});
+      }
+      load();
+      const id = setInterval(load, 5000);
+      return () => {
+        active = false;
+        clearInterval(id);
+      };
     }
   }, [game]);
 
@@ -116,6 +124,10 @@ export default function Lobby() {
         unseatTable(playerId, table.id).catch(() => {});
       };
     }
+    if (game === 'ludo' && table && table.id !== 'single') {
+      // No seat tracking for ludo yet
+      return undefined;
+    }
   }, [game, table, playerName]);
 
   useEffect(() => {
@@ -123,6 +135,21 @@ export default function Lobby() {
       let active = true;
       function loadPlayers() {
         getSnakeLobby(table.id)
+          .then((data) => {
+            if (active) setPlayers(data.players);
+          })
+          .catch(() => {});
+      }
+      loadPlayers();
+      const id = setInterval(loadPlayers, 3000);
+      return () => {
+        active = false;
+        clearInterval(id);
+      };
+    } else if (game === 'ludo' && table && table.id !== 'single') {
+      let active = true;
+      function loadPlayers() {
+        getLudoLobby(table.id)
           .then((data) => {
             if (active) setPlayers(data.players);
           })
@@ -180,6 +207,24 @@ export default function Lobby() {
         const tgId = getTelegramId();
         await addTransaction(tgId, -stake.amount, 'stake', {
           game: 'snake-ai',
+          players: aiCount + 1,
+        });
+      } catch {}
+    } else if (game === 'ludo' && table?.id === 'single') {
+      localStorage.removeItem(`ludoGameState_${aiCount}`);
+      params.set('ai', aiCount);
+      params.set('token', 'TPC');
+      if (stake.amount) params.set('amount', stake.amount);
+      try {
+        const accountId = await ensureAccountId();
+        const balRes = await getAccountBalance(accountId);
+        if ((balRes.balance || 0) < stake.amount) {
+          alert('Insufficient balance');
+          return;
+        }
+        const tgId = getTelegramId();
+        await addTransaction(tgId, -stake.amount, 'stake', {
+          game: 'ludo-ai',
           players: aiCount + 1,
         });
       } catch {}
@@ -247,7 +292,7 @@ export default function Lobby() {
           tokens={table?.id === 'single' ? ['TPC'] : undefined}
         />
       </div>
-      {game === 'snake' && table?.id === 'single' && (
+      {['snake', 'ludo'].includes(game) && table?.id === 'single' && (
         <div className="space-y-2">
           <h3 className="font-semibold">How many AI opponents?</h3>
           <div className="flex gap-2">

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -60,7 +60,6 @@ export default function SpinPage() {
     let extraSpins = 0;
     if (r === 1600) extraSpins = 1;
     else if (r === 1800) extraSpins = 2;
-    else if (r === 5000) extraSpins = 3;
 
     if (extraSpins > 0) {
       const total = freeSpins + extraSpins;

--- a/webapp/src/utils/lobby.js
+++ b/webapp/src/utils/lobby.js
@@ -1,5 +1,5 @@
 export function canStartGame(game, table, stake, aiCount = 0, players = 0) {
-  if (game === 'snake' && table?.id === 'single') {
+  if ((game === 'snake' || game === 'ludo') && table?.id === 'single') {
     if (!stake || !stake.token || !stake.amount) return false;
     return aiCount > 0;
   }
@@ -7,10 +7,10 @@ export function canStartGame(game, table, stake, aiCount = 0, players = 0) {
     if (!stake || !stake.token || !stake.amount) return false;
     return true;
   }
-  if (game === 'snake' && table && table.id !== 'single') {
+  if ((game === 'snake' || game === 'ludo') && table && table.id !== 'single') {
     if (players < (table.capacity || 0)) return false;
   }
   if (!stake || !stake.token || !stake.amount) return false;
-  if (game === 'snake' && !table) return false;
+  if ((game === 'snake' || game === 'ludo') && !table) return false;
   return true;
 }

--- a/webapp/src/utils/rewardLogic.ts
+++ b/webapp/src/utils/rewardLogic.ts
@@ -1,4 +1,4 @@
-// Prize amounts available on the wheel. Added a 5000 TPC jackpot.
+// Prize amounts available on the wheel.
 export type Segment = number | 'BONUS_X3';
 
 export const segments: Segment[] = [
@@ -10,7 +10,6 @@ export const segments: Segment[] = [
   1500,
   1600,
   1800,
-  5000,
   'BONUS_X3',
 ];
 const COOLDOWN = 15 * 60_000; // 15 minutes


### PR DESCRIPTION
## Summary
- remove 3 free spin reward from spin game
- improve AdModal fallback video handling
- add Ludo game card and route
- extend lobby to support Ludo tables and AI
- update lobby validation logic

## Testing
- `npm test` *(fails: Cannot find package dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6868d2dad674832987fa02937f07a5c9