### PR TITLE
Add ludo lobby endpoints

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -296,6 +296,30 @@ app.get('/api/snake/board/:id', async (req, res) => {
   res.json({ snakes: room.snakes, ladders: room.ladders });
 });
 
+app.get('/api/ludo/lobbies', async (req, res) => {
+  const capacities = [2, 3, 4];
+  const lobbies = await Promise.all(
+    capacities.map(async (cap) => {
+      const id = `ludo-${cap}`;
+      const room = await gameManager.getRoom(id, cap);
+      const players = room.players.filter((p) => !p.disconnected).length;
+      return { id, capacity: cap, players };
+    })
+  );
+  res.json(lobbies);
+});
+
+app.get('/api/ludo/lobby/:id', async (req, res) => {
+  const { id } = req.params;
+  const match = /-(\d+)$/.exec(id);
+  const cap = match ? Number(match[1]) : 4;
+  const room = await gameManager.getRoom(id, cap);
+  const players = room.players
+    .filter((p) => !p.disconnected)
+    .map((p) => ({ id: p.playerId, name: p.name }));
+  res.json({ id, capacity: cap, players });
+});
+
 app.post('/api/snake/invite', async (req, res) => {
   let {
     fromAccount,

--- a/test/ludoLobbyRoute.test.js
+++ b/test/ludoLobbyRoute.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { setTimeout as delay } from 'timers/promises';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+
+  return server;
+}
+
+test('ludo lobby route lists players', async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3203',
+    MONGODB_URI: 'memory',
+    SKIP_WEBAPP_BUILD: '1',
+    BOT_TOKEN: 'dummy'
+  };
+  const server = await startServer(env);
+  try {
+    for (let i = 0; i < 100; i++) {
+      try {
+        const res = await fetch('http://localhost:3203/api/ludo/lobby/ludo-2');
+        if (res.ok) {
+          const data = await res.json();
+          assert.equal(data.id, 'ludo-2');
+          assert.ok(Array.isArray(data.players));
+          return;
+        }
+      } catch {}
+      await delay(100);
+    }
+    assert.fail('lobby route not reachable');
+  } finally {
+    server.kill();
+  }
+});


### PR DESCRIPTION
## Summary
- add HTTP routes for ludo lobbies in server
- add a test covering ludo lobby route

## Testing
- `npm test` *(fails: test timed out and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6868d8b8699c8329bc2292d3f6cb5463