### PR TITLE
Add 3D ludo board style

### DIFF
--- a/webapp/src/components/LudoBoard.jsx
+++ b/webapp/src/components/LudoBoard.jsx
@@ -1,13 +1,27 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import LudoToken from './LudoToken.jsx';
 
 const SIZE = 15;
+const ANGLE = 58;
 
 export default function LudoBoard({ players = [] }) {
+  const [cell, setCell] = useState(40);
+
+  useEffect(() => {
+    const update = () => {
+      const width = Math.min(window.innerWidth, 600);
+      const cw = Math.floor(width / SIZE);
+      setCell(cw);
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
   const cells = [];
   for (let r = 0; r < SIZE; r++) {
     for (let c = 0; c < SIZE; c++) {
-      let cls = 'ludo-cell';
+      let cls = 'board-cell';
       if (r < 6 && c < 6) cls += ' ludo-red';
       else if (r < 6 && c >= 9) cls += ' ludo-green';
       else if (r >= 9 && c < 6) cls += ' ludo-yellow';
@@ -17,23 +31,37 @@ export default function LudoBoard({ players = [] }) {
   }
 
   return (
-    <div className="ludo-board">
-      {cells}
-      {players.map((p) =>
-        p.tokens.map((t, i) => {
-          if (t < 0) return null;
-          const pos = PATH[t] || { r: 7, c: 7 };
-          return (
-            <div
-              key={`${p.id}-${i}`}
-              className="token-wrapper"
-              style={{ gridRowStart: pos.r + 1, gridColumnStart: pos.c + 1 }}
-            >
-              <LudoToken color={p.color} />
-            </div>
-          );
-        })
-      )}
+    <div className="ludo-board-tilt">
+      <div
+        className="ludo-board-grid"
+        style={{
+          width: `${cell * SIZE}px`,
+          height: `${cell * SIZE}px`,
+          gridTemplateColumns: `repeat(${SIZE}, ${cell}px)`,
+          gridTemplateRows: `repeat(${SIZE}, ${cell}px)`,
+          '--cell-width': `${cell}px`,
+          '--cell-height': `${cell}px`,
+          '--board-angle': `${ANGLE}deg`,
+          transform: `translateZ(-50px) rotateX(${ANGLE}deg)`
+        }}
+      >
+        {cells}
+        {players.map((p) =>
+          p.tokens.map((t, i) => {
+            if (t < 0) return null;
+            const pos = PATH[t] || { r: 7, c: 7 };
+            return (
+              <div
+                key={`${p.id}-${i}`}
+                className="token-wrapper"
+                style={{ gridRowStart: pos.r + 1, gridColumnStart: pos.c + 1 }}
+              >
+                <LudoToken color={p.color} />
+              </div>
+            );
+          })
+        )}
+      </div>
     </div>
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1235,18 +1235,19 @@ input:focus {
   font-size: 1rem;
   z-index: 1;
 }
-.ludo-board {
-  display: grid;
-  grid-template-columns: repeat(15, 1fr);
-  grid-template-rows: repeat(15, 1fr);
-  gap: 2px;
-  width: 300px;
-  height: 300px;
-  position: relative;
+.ludo-board-tilt {
+  perspective: 1200px;
 }
+
+.ludo-board-grid {
+  display: grid;
+  gap: 2px;
+  position: relative;
+  transform-style: preserve-3d;
+  transform-origin: bottom center;
+}
+
 .ludo-cell {
-  width: 100%;
-  height: 100%;
   background: #eee;
 }
 .ludo-red { background:#fecaca; }
@@ -1254,12 +1255,14 @@ input:focus {
 .ludo-yellow { background:#fef08a; }
 .ludo-blue { background:#bfdbfe; }
 .ludo-token {
-  width: 18px;
-  height: 18px;
+  width: calc(var(--cell-width) * 0.6);
+  height: calc(var(--cell-height) * 0.6);
   border-radius: 50%;
   border: 2px solid #000;
   transition: transform 0.3s;
+  transform: translateZ(10px);
 }
 .token-wrapper {
   position: absolute;
+  transform-style: preserve-3d;
 }


### PR DESCRIPTION
## Summary
- upgrade LudoBoard to render a 3D-looking board with equal-sized tiles
- tweak styles for Ludo board and tokens

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_6868e6979f788329a6dca0a4de545e3f