### PR TITLE
Update Ludo visuals

### DIFF
--- a/webapp/src/components/LudoBoard.jsx
+++ b/webapp/src/components/LudoBoard.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import LudoToken from './LudoToken.jsx';
 
+const CELL_SIZE = 24; // px
+
 const SIZE = 15;
 
 export default function LudoBoard({ players = [] }) {
   const cells = [];
   for (let r = 0; r < SIZE; r++) {
     for (let c = 0; c < SIZE; c++) {
-      let cls = 'ludo-cell';
+      let cls = 'ludo-cell board-cell';
       if (r < 6 && c < 6) cls += ' ludo-red';
       else if (r < 6 && c >= 9) cls += ' ludo-green';
       else if (r >= 9 && c < 6) cls += ' ludo-yellow';
@@ -17,23 +19,33 @@ export default function LudoBoard({ players = [] }) {
   }
 
   return (
-    <div className="ludo-board">
-      {cells}
-      {players.map((p) =>
-        p.tokens.map((t, i) => {
-          if (t < 0) return null;
-          const pos = PATH[t] || { r: 7, c: 7 };
-          return (
-            <div
-              key={`${p.id}-${i}`}
-              className="token-wrapper"
-              style={{ gridRowStart: pos.r + 1, gridColumnStart: pos.c + 1 }}
-            >
-              <LudoToken color={p.color} />
-            </div>
-          );
-        })
-      )}
+    <div className="board-3d">
+      <div
+        className="ludo-board board-3d-grid"
+        style={{
+          '--cell-width': `${CELL_SIZE}px`,
+          '--cell-height': `${CELL_SIZE}px`,
+          width: `${CELL_SIZE * SIZE}px`,
+          height: `${CELL_SIZE * SIZE}px`,
+        }}
+      >
+        {cells}
+        {players.map((p) =>
+          p.tokens.map((t, i) => {
+            if (t < 0) return null;
+            const pos = PATH[t] || { r: 7, c: 7 };
+            return (
+              <div
+                key={`${p.id}-${i}`}
+                className="token-wrapper"
+                style={{ gridRowStart: pos.r + 1, gridColumnStart: pos.c + 1 }}
+              >
+                <LudoToken color={p.color} photoUrl={p.photoUrl} />
+              </div>
+            );
+          })
+        )}
+      </div>
     </div>
   );
 }

--- a/webapp/src/components/LudoToken.jsx
+++ b/webapp/src/components/LudoToken.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
+import PlayerToken from './PlayerToken.jsx';
 
-export default function LudoToken({ color = 'red' }) {
+export default function LudoToken({ color = 'red', photoUrl }) {
   return (
-    <div
-      className="ludo-token"
-      style={{ backgroundColor: color }}
-    />
+    <PlayerToken color={color} photoUrl={photoUrl} />
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1236,30 +1236,19 @@ input:focus {
   z-index: 1;
 }
 .ludo-board {
+  @apply board-3d-grid relative;
   display: grid;
-  grid-template-columns: repeat(15, 1fr);
-  grid-template-rows: repeat(15, 1fr);
+  grid-template-columns: repeat(15, var(--cell-width));
+  grid-template-rows: repeat(15, var(--cell-height));
   gap: 2px;
-  width: 300px;
-  height: 300px;
-  position: relative;
 }
 .ludo-cell {
-  width: 100%;
-  height: 100%;
-  background: #eee;
+  @apply board-cell;
 }
 .ludo-red { background:#fecaca; }
 .ludo-green { background:#bbf7d0; }
 .ludo-yellow { background:#fef08a; }
 .ludo-blue { background:#bfdbfe; }
-.ludo-token {
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  border: 2px solid #000;
-  transition: transform 0.3s;
-}
 .token-wrapper {
   position: absolute;
 }

--- a/webapp/src/pages/Games/Ludo.jsx
+++ b/webapp/src/pages/Games/Ludo.jsx
@@ -14,7 +14,7 @@ export default function Ludo() {
   }));
 
   const handleRoll = (vals) => {
-    const value = vals[0];
+    const value = vals.reduce((a, b) => a + b, 0);
     const p = game.players[game.turn];
     for (let i = 0; i < p.tokens.length; i++) {
       if (p.tokens[i] === -1 && value === 6) {
@@ -34,7 +34,7 @@ export default function Ludo() {
       <div className="flex justify-center">
         <LudoBoard players={game.players} />
       </div>
-      <DiceRoller numDice={1} onRollEnd={handleRoll} clickable />
+      <DiceRoller numDice={2} onRollEnd={handleRoll} clickable />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- switch Ludo tokens to the 3D prism PlayerToken
- render Ludo board using 3D board styles
- update Ludo page to roll two dice and sum their values

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6868eb13e2d08329ba4ee33845c4feed