### PR TITLE
Update Ludo board layout

### DIFF
--- a/webapp/src/components/LudoBoard.jsx
+++ b/webapp/src/components/LudoBoard.jsx
@@ -33,23 +33,11 @@ export default function LudoBoard({ players = [] }) {
   const cells = [];
 
   for (let r = 0; r < SIZE; r++) {
-
     for (let c = 0; c < SIZE; c++) {
-
-      let cls = 'ludo-cell board-cell';
-
-      if (r < 6 && c < 6) cls += ' ludo-red';
-
-      else if (r < 6 && c >= 9) cls += ' ludo-green';
-
-      else if (r >= 9 && c < 6) cls += ' ludo-yellow';
-
-      else if (r >= 9 && c >= 9) cls += ' ludo-blue';
-
-      cells.push(<div key={`${r}-${c}`} className={cls}></div>);
-
+      cells.push(
+        <div key={`${r}-${c}`} className="ludo-cell board-cell"></div>
+      );
     }
-
   }
 
   return (
@@ -83,6 +71,14 @@ export default function LudoBoard({ players = [] }) {
       >
 
         {cells}
+        {[{ color: "ludo-red", r: 0, c: 0 }, { color: "ludo-green", r: 0, c: 9 }, { color: "ludo-yellow", r: 9, c: 0 }, { color: "ludo-blue", r: 9, c: 9 }].map(({ color, r, c }) => (
+          <div key={color} className={`ludo-base ${color}`} style={{ gridRowStart: r + 1, gridColumnStart: c + 1 }}>
+            <div className={`board-cell ${color}`}></div>
+            <div className={`board-cell ${color}`}></div>
+            <div className={`board-cell ${color}`}></div>
+            <div className={`board-cell ${color}`}></div>
+          </div>
+        ))}
 
         {players.map((p) =>
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1297,13 +1297,29 @@ input:focus {
 
   height: calc(var(--cell-height) * 0.6);
 
-  border-radius: 50%;
+  border-radius: 0;
 
   border: 2px solid #000;
 
   transition: transform 0.3s;
 
   transform: translateZ(10px);
+
+}
+
+.ludo-base {
+
+  position: absolute;
+
+  display: grid;
+
+  grid-template-columns: 1fr 1fr;
+
+  grid-template-rows: 1fr 1fr;
+
+  gap: 2px;
+
+  transform-style: preserve-3d;
 
 }
 
@@ -1314,3 +1330,4 @@ input:focus {
   transform-style: preserve-3d;
 
 }
+


### PR DESCRIPTION
## Summary
- simplify Ludo board cell generation
- add square home bases in all four colours
- square off the ludo tokens

## Testing
- `npm test` *(fails: Cannot find package 'dotenv', 'socket.io-client', 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_6868f22740dc832987296132f2d0fa9a