### PR TITLE
Add 3D box environment for Ludo board

### DIFF
--- a/webapp/src/components/LudoBoard.jsx
+++ b/webapp/src/components/LudoBoard.jsx
@@ -7,139 +7,86 @@ const SIZE = 15;
 const ANGLE = 58;
 
 export default function LudoBoard({ players = [] }) {
-
   const [cell, setCell] = useState(40);
-
   useEffect(() => {
-
     const update = () => {
-
       const width = Math.min(window.innerWidth, 600);
-
       const cw = Math.floor(width / SIZE);
-
       setCell(cw);
-
     };
-
     update();
-
     window.addEventListener('resize', update);
-
     return () => window.removeEventListener('resize', update);
-
   }, []);
-
   const cells = [];
-
   for (let r = 0; r < SIZE; r++) {
-
     for (let c = 0; c < SIZE; c++) {
-
       let cls = 'ludo-cell board-cell';
-
       if (r < 6 && c < 6) cls += ' ludo-red';
-
       else if (r < 6 && c >= 9) cls += ' ludo-green';
-
       else if (r >= 9 && c < 6) cls += ' ludo-yellow';
-
       else if (r >= 9 && c >= 9) cls += ' ludo-blue';
-
       cells.push(<div key={`${r}-${c}`} className={cls}></div>);
-
     }
-
   }
-
   return (
-
     <div className="ludo-board-tilt">
-
       <div
-
-        className="ludo-board-grid board-3d-grid"
-
+        className="ludo-box"
         style={{
-
-          width: `${cell * SIZE}px`,
-
-          height: `${cell * SIZE}px`,
-
-          gridTemplateColumns: `repeat(${SIZE}, ${cell}px)`,
-
-          gridTemplateRows: `repeat(${SIZE}, ${cell}px)`,
-
           '--cell-width': `${cell}px`,
-
           '--cell-height': `${cell}px`,
-
           '--board-angle': `${ANGLE}deg`,
-
-          transform: `translateZ(-50px) rotateX(${ANGLE}deg)`
-
+          '--logo-height': `${cell * 4}px`
         }}
-
       >
-
-        {cells}
-
-        {players.map((p) =>
-
-          p.tokens.map((t, i) => {
-
-            if (t < 0) return null;
-
-            const pos = PATH[t] || { r: 7, c: 7 };
-
-            return (
-
-              <div
-
-                key={`${p.id}-${i}`}
-
-                className="token-wrapper"
-
-                style={{ gridRowStart: pos.r + 1, gridColumnStart: pos.c + 1 }}
-
-              >
-
-                <LudoToken color={p.color} photoUrl={p.photoUrl} />
-
-              </div>
-
-            );
-
-          })
-
-        )}
-
+        <div
+          className="ludo-board-grid board-3d-grid"
+          style={{
+            width: `${cell * SIZE}px`,
+            height: `${cell * SIZE}px`,
+            gridTemplateColumns: `repeat(${SIZE}, ${cell}px)`,
+            gridTemplateRows: `repeat(${SIZE}, ${cell}px)`,
+            '--cell-width': `${cell}px`,
+            '--cell-height': `${cell}px`,
+            '--board-angle': `${ANGLE}deg`,
+            transform: `translateZ(-50px) rotateX(${ANGLE}deg)`
+          }}
+        >
+          {cells}
+          {players.map((p) =>
+            p.tokens.map((t, i) => {
+              if (t < 0) return null;
+              const pos = PATH[t] || { r: 7, c: 7 };
+              return (
+                <div
+                  key={`${p.id}-${i}`}
+                  className="token-wrapper"
+                  style={{ gridRowStart: pos.r + 1, gridColumnStart: pos.c + 1 }}
+                >
+                  <LudoToken color={p.color} photoUrl={p.photoUrl} />
+                </div>
+              );
+            })
+          )}
+        </div>
+        <div className="ludo-wall ludo-wall-back" />
+        <div className="ludo-wall ludo-wall-left" />
+        <div className="ludo-wall ludo-wall-right" />
+        <div className="ludo-wall ludo-wall-front" />
       </div>
-
     </div>
-
   );
-
 }
 
 export const PATH = [
-
   { r: 0, c: 6 }, { r: 1, c: 6 }, { r: 2, c: 6 }, { r: 3, c: 6 }, { r: 4, c: 6 }, { r: 5, c: 6 },
-
   { r: 6, c: 5 }, { r: 6, c: 4 }, { r: 6, c: 3 }, { r: 6, c: 2 }, { r: 6, c: 1 }, { r: 6, c: 0 },
-
   { r: 7, c: 0 }, { r: 8, c: 0 }, { r: 8, c: 1 }, { r: 8, c: 2 }, { r: 8, c: 3 }, { r: 8, c: 4 },
-
   { r: 8, c: 5 }, { r: 9, c: 6 }, { r: 10, c: 6 }, { r: 11, c: 6 }, { r: 12, c: 6 }, { r: 13, c: 6 },
-
   { r: 14, c: 6 }, { r: 14, c: 7 }, { r: 14, c: 8 }, { r: 13, c: 8 }, { r: 12, c: 8 }, { r: 11, c: 8 },
-
   { r: 10, c: 8 }, { r: 9, c: 8 }, { r: 8, c: 9 }, { r: 8, c: 10 }, { r: 8, c: 11 }, { r: 8, c: 12 },
-
   { r: 8, c: 13 }, { r: 8, c: 14 }, { r: 7, c: 14 }, { r: 6, c: 14 }, { r: 6, c: 13 }, { r: 6, c: 12 },
-
   { r: 6, c: 11 }, { r: 6, c: 10 }, { r: 6, c: 9 }, { r: 5, c: 8 }, { r: 4, c: 8 }, { r: 3, c: 8 },
-
   { r: 2, c: 8 }, { r: 1, c: 8 }, { r: 0, c: 8 }, { r: 0, c: 7 }
-
 ];

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1314,3 +1314,55 @@ input:focus {
   transform-style: preserve-3d;
 
 }
+
+.ludo-box {
+  position: relative;
+  transform-style: preserve-3d;
+}
+
+.ludo-wall {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background-image:
+    linear-gradient(to bottom, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0) 70%),
+    url("/assets/TonPlayGramLogo.jpg");
+  background-repeat: no-repeat;
+  background-position: center bottom;
+  background-size: auto var(--logo-height);
+  pointer-events: none;
+  filter: brightness(1.2);
+  transform-origin: bottom center;
+}
+
+.ludo-wall-back {
+  width: calc(var(--cell-width) * 15);
+  height: var(--logo-height);
+  top: calc(var(--logo-height) * -1);
+  left: 50%;
+  transform: translateX(-50%) rotateX(calc(var(--board-angle, 58deg) * -1)) translateZ(-90px);
+}
+
+.ludo-wall-left {
+  width: calc(var(--cell-width) * 15);
+  height: var(--logo-height);
+  top: calc(var(--logo-height) * -1);
+  left: calc(var(--cell-width) * -7.5);
+  transform: rotateY(-90deg) rotateX(calc(var(--board-angle, 58deg) * -1)) translateZ(-90px);
+}
+
+.ludo-wall-right {
+  width: calc(var(--cell-width) * 15);
+  height: var(--logo-height);
+  top: calc(var(--logo-height) * -1);
+  right: calc(var(--cell-width) * -7.5);
+  transform: rotateY(90deg) rotateX(calc(var(--board-angle, 58deg) * -1)) translateZ(-90px);
+}
+
+.ludo-wall-front {
+  width: calc(var(--cell-width) * 15);
+  height: calc(var(--logo-height) * 0.6);
+  bottom: calc(var(--logo-height) * -0.6);
+  left: 50%;
+  transform: translateX(-50%) rotateX(calc(var(--board-angle, 58deg) * -1)) translateZ(20px);
+}


### PR DESCRIPTION
## Summary
- wrap Ludo board in `.ludo-box` container
- add four logo walls around the board
- style new box and wall elements in CSS

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868ff70b0fc832982f596701d304038