### PR TITLE
Add close button for ad popup

### DIFF
--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -4,9 +4,10 @@ import { ADSGRAM_WALLET } from '../utils/constants.js';
 interface AdModalProps {
   open: boolean;
   onComplete: () => void;
+  onClose?: () => void;
 }
 
-export default function AdModal({ open, onComplete }: AdModalProps) {
+export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
   const [fallback, setFallback] = useState(false);
 
   useEffect(() => {
@@ -45,7 +46,15 @@ export default function AdModal({ open, onComplete }: AdModalProps) {
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text w-80">
+      <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text w-80 relative">
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"
+          >
+            &times;
+          </button>
+        )}
         <img src="/assets/TonPlayGramLogo.jpg" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
         <h3 className="text-lg font-bold">Watch Ad</h3>
         <div

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -231,7 +231,11 @@ export default function SpinGame() {
         onClose={() => setReward(null)}
         message="Keep spinning every day to earn more!"
       />
-      <AdModal open={showAd} onComplete={handleAdComplete} />
+      <AdModal
+        open={showAd}
+        onComplete={handleAdComplete}
+        onClose={() => setShowAd(false)}
+      />
     </div>
   );
 }

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -148,7 +148,11 @@ export default function TasksCard() {
         </li>
 
       </ul>
-      <AdModal open={showAd} onComplete={handleAdComplete} />
+      <AdModal
+        open={showAd}
+        onComplete={handleAdComplete}
+        onClose={() => setShowAd(false)}
+      />
 
     </div>
 

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -134,7 +134,11 @@ export default function Tasks() {
           )}
         </li>
       </ul>
-      <AdModal open={showAd} onComplete={handleAdComplete} />
+      <AdModal
+        open={showAd}
+        onComplete={handleAdComplete}
+        onClose={() => setShowAd(false)}
+      />
 
     </div>
 

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -184,7 +184,11 @@ export default function SpinPage() {
         onClose={() => setReward(null)}
         message="Keep spinning every day to earn more!"
       />
-      <AdModal open={showAd} onComplete={handleAdComplete} />
+      <AdModal
+        open={showAd}
+        onComplete={handleAdComplete}
+        onClose={() => setShowAd(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add optional `onClose` prop to `AdModal`
- include close button in `AdModal` popup
- allow closing ads popup across spin pages and task cards

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_68690bfb3f80832987c0b5d1a4b61419