### PR TITLE
Add 3D arena walls to Ludo board

### DIFF
--- a/webapp/src/components/LudoBoard.jsx
+++ b/webapp/src/components/LudoBoard.jsx
@@ -110,6 +110,7 @@ export default function LudoBoard({ players = [] }) {
           '--cell-height': `${cell}px`,
 
           '--board-angle': `${ANGLE}deg`,
+          '--wall-height': `${cell * SIZE}px`,
 
           transform: `translateZ(-50px) rotateX(${ANGLE}deg)`
 
@@ -153,6 +154,10 @@ export default function LudoBoard({ players = [] }) {
             );
           })
         )}
+        <div className="ludo-wall back-wall" />
+        <div className="ludo-wall left-wall" />
+        <div className="ludo-wall right-wall" />
+        <div className="ludo-wall front-wall" />
 
       </div>
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1327,3 +1327,62 @@ input:focus {
 .ludo-green-frame { border-color: #22c55e; }
 .ludo-yellow-frame { border-color: #eab308; }
 .ludo-blue-frame { border-color: #3b82f6; }
+.ludo-wall {
+  position: absolute;
+  overflow: hidden;
+  background-image: url('/assets/TonPlayGramLogo.jpg');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  transform-origin: bottom center;
+}
+
+.ludo-wall::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: inherit;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  height: var(--wall-height, 100%);
+  width: 100%;
+}
+
+.back-wall {
+  width: 100%;
+  height: var(--wall-height, 100%);
+  bottom: 100%;
+  left: 0;
+  transform: rotateX(calc(var(--board-angle, 58deg) * -1));
+}
+
+.left-wall,
+.right-wall {
+  width: var(--wall-height, 100%);
+  height: 100%;
+  top: 0;
+}
+
+.left-wall {
+  right: 100%;
+  transform: rotateY(90deg) rotateX(calc(var(--board-angle, 58deg) * -1));
+}
+
+.right-wall {
+  left: 100%;
+  transform: rotateY(-90deg) rotateX(calc(var(--board-angle, 58deg) * -1));
+}
+
+.front-wall {
+  width: 100%;
+  height: calc(var(--wall-height, 100%) * 0.3);
+  top: 100%;
+  left: 0;
+  transform: rotateX(calc(var(--board-angle, 58deg) * -1));
+}
+
+.front-wall::before {
+  height: var(--wall-height, 100%);
+  transform: translateY(calc(var(--wall-height, 100%) * -0.7));
+}


### PR DESCRIPTION
## Summary
- show TonPlayGram logos on new vertical walls around the Ludo board
- keep front wall at 30% height to act as an open tray

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68690bc67768832987e870e04c6c29f0