### PR TITLE
Remove unused layout effect

### DIFF
--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useLayoutEffect, Fragment } from "react";
+import { useState, useEffect, useRef, Fragment } from "react";
 import PlayerToken from "./PlayerToken.jsx";
 
 // Board dimensions
@@ -205,7 +205,6 @@ export default function SnakeBoard({
     return () => window.removeEventListener('resize', updateSize);
   }, []);
 
-  useLayoutEffect(() => {}, [cellWidth, cellHeight]);
 
   const angle = 58;
   const boardXOffset = 10;


### PR DESCRIPTION
## Summary
- tidy SnakeBoard component by removing an unused `useLayoutEffect`

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND, test timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_686920edc0088329a08c87c07f51af0b