### PR TITLE
Add store preview card on home page

### DIFF
--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -1,0 +1,43 @@
+import { AiOutlineShop } from 'react-icons/ai';
+import { Link } from 'react-router-dom';
+import { STORE_BUNDLES } from '../utils/storeData.js';
+
+export default function StoreAd() {
+  return (
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden">
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+      />
+      <div className="flex items-center justify-center space-x-1">
+        <AiOutlineShop className="text-accent" />
+        <span className="text-lg font-bold">Store</span>
+      </div>
+      <div className="flex space-x-4 overflow-x-auto pb-2">
+        {STORE_BUNDLES.map((b) => (
+          <div key={b.id} className="store-card flex-shrink-0 w-60">
+            <div className="flex items-center space-x-2">
+              <span className="text-2xl">{b.icon}</span>
+              <h3 className="font-semibold">{b.name}</h3>
+            </div>
+            <div className="text-lg font-bold flex items-center space-x-1">
+              <span>{b.tpc.toLocaleString()}</span>
+              <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-6 h-6" />
+            </div>
+            <div className="text-primary text-lg flex items-center space-x-1">
+              <span>{b.ton}</span>
+              <img src="/icons/TON.png" alt="TON" className="w-6 h-6" />
+            </div>
+          </div>
+        ))}
+      </div>
+      <Link
+        to="/store"
+        className="inline-block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow"
+      >
+        Open Store
+      </Link>
+    </div>
+  );
+}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -9,6 +9,7 @@ import SpinGame from '../components/SpinGame.jsx';
 import DailyCheckIn from '../components/DailyCheckIn.jsx';
 
 import TasksCard from '../components/TasksCard.jsx';
+import StoreAd from '../components/StoreAd.jsx';
 
 import {
   FaUser,
@@ -167,6 +168,7 @@ export default function Home() {
       <div className="grid grid-cols-1 gap-4">
         <MiningCard />
         <TasksCard />
+        <StoreAd />
         <ProfileCard />
       </div>
 

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -4,18 +4,7 @@ import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { createAccount, buyBundle, claimPurchase } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import InfoPopup from '../components/InfoPopup.jsx';
-
-const STORE_ADDRESS = 'UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT';
-const BUNDLES = [
-  { id: 'newbie', name: 'Newbie Pack', icon: '🌱', tpc: 25000, ton: 0.25, boost: 0, presale: true },
-  { id: 'rookie', name: 'Rookie', icon: '🎯', tpc: 50000, ton: 0.4, boost: 0, presale: true },
-  { id: 'starter', name: 'Starter', icon: '🚀', tpc: 100000, ton: 0.75, boost: 0, presale: true },
-  { id: 'miner', name: 'Miner Pack', icon: '⛏️', tpc: 250000, ton: 1.6, boost: 0.03, presale: true },
-  { id: 'grinder', name: 'Grinder', icon: '⚙️', tpc: 500000, ton: 3.0, boost: 0.05, presale: true },
-  { id: 'pro', name: 'Pro Bundle', icon: '🏆', tpc: 1000000, ton: 5.5, boost: 0.08, presale: true },
-  { id: 'whale', name: 'Whale Bundle', icon: '🐋', tpc: 2500000, ton: 10.5, boost: 0.12, presale: true },
-  { id: 'max', name: 'Max Presale', icon: '👑', tpc: 5000000, ton: 20, boost: 0.15, presale: true }
-];
+import { STORE_ADDRESS, STORE_BUNDLES } from '../utils/storeData.js';
 
 export default function Store() {
   useTelegramBackButton();
@@ -53,7 +42,7 @@ export default function Store() {
   return (
     <div className="relative p-4 space-y-4 text-text">
       <h2 className="text-xl font-bold">Store</h2>
-      {BUNDLES.map((b) => (
+      {STORE_BUNDLES.map((b) => (
         <div
           key={b.id}
           className="store-card w-80 mx-auto"

--- a/webapp/src/utils/storeData.js
+++ b/webapp/src/utils/storeData.js
@@ -1,0 +1,12 @@
+export const STORE_ADDRESS = 'UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT';
+
+export const STORE_BUNDLES = [
+  { id: 'newbie', name: 'Newbie Pack', icon: '🌱', tpc: 25000, ton: 0.25, boost: 0, presale: true },
+  { id: 'rookie', name: 'Rookie', icon: '🎯', tpc: 50000, ton: 0.4, boost: 0, presale: true },
+  { id: 'starter', name: 'Starter', icon: '🚀', tpc: 100000, ton: 0.75, boost: 0, presale: true },
+  { id: 'miner', name: 'Miner Pack', icon: '⛏️', tpc: 250000, ton: 1.6, boost: 0.03, presale: true },
+  { id: 'grinder', name: 'Grinder', icon: '⚙️', tpc: 500000, ton: 3.0, boost: 0.05, presale: true },
+  { id: 'pro', name: 'Pro Bundle', icon: '🏆', tpc: 1000000, ton: 5.5, boost: 0.08, presale: true },
+  { id: 'whale', name: 'Whale Bundle', icon: '🐋', tpc: 2500000, ton: 10.5, boost: 0.12, presale: true },
+  { id: 'max', name: 'Max Presale', icon: '👑', tpc: 5000000, ton: 20, boost: 0.15, presale: true }
+];


### PR DESCRIPTION
## Summary
- add shared store data definition
- update Store page to use shared store data
- create `StoreAd` component to show store bundles in a horizontal scroll
- insert store preview card between Tasks and Profile on the Home page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686921e480cc8329b438d2a584b9db14