### PR TITLE
Increase Ludo board size

### DIFF
--- a/webapp/src/components/LudoBoard.jsx
+++ b/webapp/src/components/LudoBoard.jsx
@@ -43,13 +43,13 @@ function getColorName(color = '') {
 
 export default function LudoBoard({ players = [] }) {
 
-  const [cell, setCell] = useState(40);
+  const [cell, setCell] = useState(60);
 
   useEffect(() => {
 
     const update = () => {
 
-      const width = Math.min(window.innerWidth, 600);
+      const width = Math.min(window.innerWidth, 900);
 
       const cw = Math.floor(width / SIZE);
 
@@ -111,7 +111,7 @@ export default function LudoBoard({ players = [] }) {
 
           '--board-angle': `${ANGLE}deg`,
 
-          transform: `translateZ(-50px) rotateX(${ANGLE}deg)`
+          transform: `translateZ(-50px) rotateX(${ANGLE}deg) scale(1.3)`
 
         }}
 


### PR DESCRIPTION
## Summary
- enlarge each Ludo board square by default
- allow the board grid to render scaled up

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686929f6175c8329a3e94a9fd70da9cb