### PR TITLE
Implement biometric or PIN authentication for wallet and profile pages

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -9,6 +9,7 @@ import Wallet from './pages/Wallet.jsx';
 import Tasks from './pages/Tasks.jsx';
 import Referral from './pages/Referral.jsx';
 import MyAccount from './pages/MyAccount.jsx';
+import ProtectedRoute from './components/ProtectedRoute.jsx';
 import Store from './pages/Store.jsx';
 import Messages from './pages/Messages.jsx';
 import Trending from './pages/Trending.jsx';
@@ -78,11 +79,11 @@ export default function App() {
           <Route path="/tasks" element={<Tasks />} />
           <Route path="/store" element={<Store />} />
           <Route path="/referral" element={<Referral />} />
-          <Route path="/wallet" element={<Wallet />} />
+          <Route path="/wallet" element={<ProtectedRoute><Wallet /></ProtectedRoute>} />
           <Route path="/messages" element={<Messages />} />
           <Route path="/notifications" element={<Notifications />} />
           <Route path="/trending" element={<Trending />} />
-          <Route path="/account" element={<MyAccount />} />
+          <Route path="/account" element={<ProtectedRoute><MyAccount /></ProtectedRoute>} />
         </Routes>
         </Layout>
       </TonConnectUIProvider>

--- a/webapp/src/components/ProtectedRoute.jsx
+++ b/webapp/src/components/ProtectedRoute.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useSecureAuth } from '../hooks/useSecureAuth.js';
+import UnlockModal from './UnlockModal.jsx';
+
+export default function ProtectedRoute({ children }) {
+  const { authenticated } = useSecureAuth();
+
+  return (
+    <>
+      {!authenticated && <UnlockModal open={!authenticated} />}
+      {authenticated && children}
+    </>
+  );
+}

--- a/webapp/src/components/UnlockModal.jsx
+++ b/webapp/src/components/UnlockModal.jsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useSecureAuth } from '../hooks/useSecureAuth.js';
+
+async function authenticateBiometric() {
+  try {
+    const publicKey = {
+      challenge: new Uint8Array(32),
+      userVerification: 'preferred',
+      timeout: 60000,
+    };
+    const cred = await navigator.credentials.get({ publicKey });
+    return cred !== null;
+  } catch {
+    return false;
+  }
+}
+
+async function hashPin(pin) {
+  const enc = new TextEncoder().encode(pin);
+  const buf = await crypto.subtle.digest('SHA-256', enc);
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export default function UnlockModal({ open }) {
+  const { login } = useSecureAuth();
+  const [mode, setMode] = useState(null); // null | 'pin'
+  const [pin, setPin] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState('');
+  const storedHash = localStorage.getItem('pinHash');
+
+  if (!open) return null;
+
+  const handleBiometric = async () => {
+    const ok = await authenticateBiometric();
+    if (ok) login();
+    else setError('Biometric authentication failed');
+  };
+
+  const handlePinSubmit = async () => {
+    if (!storedHash) {
+      if (pin.length < 4 || pin.length > 6 || pin !== confirm) {
+        setError('PINs must match and be 4-6 digits');
+        return;
+      }
+      const h = await hashPin(pin);
+      localStorage.setItem('pinHash', h);
+      login();
+      return;
+    }
+    const h = await hashPin(pin);
+    if (h === storedHash) {
+      login();
+    } else {
+      setError('Incorrect PIN');
+    }
+  };
+
+  const renderPin = () => (
+    <div className="space-y-2">
+      <input
+        type="password"
+        value={pin}
+        onChange={(e) => setPin(e.target.value)}
+        placeholder="Enter PIN"
+        className="w-full p-2 bg-black bg-opacity-30 border border-gray-700"
+      />
+      {!storedHash && (
+        <input
+          type="password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          placeholder="Confirm PIN"
+          className="w-full p-2 bg-black bg-opacity-30 border border-gray-700"
+        />
+      )}
+      <button onClick={handlePinSubmit} className="lobby-tile w-full">
+        Submit
+      </button>
+      <button onClick={() => { setMode(null); setError(''); }} className="lobby-tile w-full">
+        Back
+      </button>
+    </div>
+  );
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
+      <div className="prism-box p-6 space-y-4 text-text w-80">
+        <h3 className="text-lg font-bold text-center">For your security, unlock your account.</h3>
+        {error && <p className="text-red-500 text-sm text-center">{error}</p>}
+        {mode === 'pin' ? (
+          renderPin()
+        ) : (
+          <div className="space-y-2">
+            <button onClick={handleBiometric} className="lobby-tile w-full">
+              Use Fingerprint / Face ID
+            </button>
+            <button onClick={() => { setMode('pin'); setError(''); }} className="lobby-tile w-full">
+              Use PIN
+            </button>
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/webapp/src/hooks/useSecureAuth.js
+++ b/webapp/src/hooks/useSecureAuth.js
@@ -1,0 +1,32 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const SecureAuthContext = createContext({ authenticated: false });
+
+export function SecureAuthProvider({ children }) {
+  const [authenticated, setAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const flag = sessionStorage.getItem('isAuthenticated');
+    if (flag === 'true') setAuthenticated(true);
+  }, []);
+
+  const login = () => {
+    setAuthenticated(true);
+    sessionStorage.setItem('isAuthenticated', 'true');
+  };
+
+  const logout = () => {
+    setAuthenticated(false);
+    sessionStorage.removeItem('isAuthenticated');
+  };
+
+  return (
+    <SecureAuthContext.Provider value={{ authenticated, login, logout }}>
+      {children}
+    </SecureAuthContext.Provider>
+  );
+}
+
+export function useSecureAuth() {
+  return useContext(SecureAuthContext);
+}

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import { SecureAuthProvider } from './hooks/useSecureAuth.js';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <SecureAuthProvider>
+      <App />
+    </SecureAuthProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add a small authentication provider to keep session state
- create unlock modal supporting WebAuthn and custom PIN
- protect wallet and account pages with a ProtectedRoute wrapper
- wrap App with the new SecureAuthProvider

## Testing
- `npm test` *(fails: 3, pass: 8)*

------
https://chatgpt.com/codex/tasks/task_e_68692f1445f88329b7603a8b998e5881