### PR TITLE
Add coin burst effect for Spin & Win

### DIFF
--- a/webapp/src/components/CoinBurst.tsx
+++ b/webapp/src/components/CoinBurst.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface CoinBurstProps {
+  token?: string;
+}
+
+export default function CoinBurst({ token = 'TPC' }: CoinBurstProps) {
+  const coins = Array.from({ length: 30 }, () => ({
+    dx: (Math.random() - 0.5) * 100,
+    delay: Math.random() * 0.3,
+    dur: 0.8 + Math.random() * 0.4,
+  }));
+  const src =
+    token.toUpperCase() === 'TPC'
+      ? '/assets/icons/TPCcoin.png'
+      : `/icons/${token.toLowerCase()}.svg`;
+  return (
+    <div className="coin-burst">
+      {coins.map((c, i) => (
+        <img
+          loading="lazy"
+          key={i}
+          src={src}
+          className="coin-img"
+          style={{
+            '--dx': `${c.dx}px`,
+            '--delay': `${c.delay}s`,
+            '--dur': `${c.dur}s`,
+          } as React.CSSProperties}
+        />
+      ))}
+    </div>
+  );
+}

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { getGameVolume } from '../utils/sound.js';
-import confetti from 'canvas-confetti';
+import CoinBurst from './CoinBurst.tsx';
 import { Segment } from '../utils/rewardLogic';
 
 interface RewardPopupProps {
@@ -12,16 +12,26 @@ interface RewardPopupProps {
 export default function RewardPopup({ reward, onClose, message }: RewardPopupProps) {
   if (reward === null) return null;
   useEffect(() => {
-    confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
-    const audio = new Audio('/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3');
-    audio.volume = getGameVolume();
-    audio.play().catch(() => {});
-    return () => {
-      audio.pause();
-    };
+    function playCoinSound() {
+      try {
+        const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+        const o = ctx.createOscillator();
+        const g = ctx.createGain();
+        o.type = 'square';
+        o.frequency.setValueAtTime(880, ctx.currentTime);
+        o.frequency.exponentialRampToValueAtTime(1760, ctx.currentTime + 0.1);
+        g.gain.setValueAtTime(getGameVolume(), ctx.currentTime);
+        o.connect(g);
+        g.connect(ctx.destination);
+        o.start();
+        o.stop(ctx.currentTime + 0.2);
+      } catch {}
+    }
+    playCoinSound();
   }, []);
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
+      <CoinBurst />
       <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text w-80">
         <img
           loading="lazy"


### PR DESCRIPTION
## Summary
- add new `CoinBurst` component
- switch reward popup animation to use `CoinBurst`
- generate coin sound via `AudioContext`

## Testing
- `npm install`
- `npm test` *(fails: ERR_MODULE_NOT_FOUND, test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68694f28fa548329a5620f7a11e0eba1