### PR TITLE
Replace confetti with falling TPC coins

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -15,7 +15,6 @@
     "@tonconnect/ui-react": "^2.2.0",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.15",
-    "canvas-confetti": "^1.9.2",
     "emoji-name-map": "^2.0.3",
     "framer-motion": "^10.18.0",
     "lucide-react": "^0.525.0",

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { getGameVolume } from '../utils/sound.js';
-import confetti from 'canvas-confetti';
+import coinConfetti from '../utils/coinConfetti';
 import { Segment } from '../utils/rewardLogic';
 
 interface RewardPopupProps {
@@ -12,7 +12,7 @@ interface RewardPopupProps {
 export default function RewardPopup({ reward, onClose, message }: RewardPopupProps) {
   if (reward === null) return null;
   useEffect(() => {
-    confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
+    coinConfetti(50);
     const audio = new Audio('/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3');
     audio.volume = getGameVolume();
     audio.play().catch(() => {});

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1332,3 +1332,23 @@ input:focus {
 .ludo-green-frame { border-color: #22c55e; }
 .ludo-yellow-frame { border-color: #eab308; }
 .ludo-blue-frame { border-color: #3b82f6; }
+
+.coin-confetti {
+  position: fixed;
+  top: -40px;
+  width: 32px;
+  height: 32px;
+  pointer-events: none;
+  animation: coin-fall var(--duration, 3s) linear forwards;
+}
+
+@keyframes coin-fall {
+  from {
+    transform: translateY(-10vh) rotate(0deg);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(100vh) rotate(360deg);
+    opacity: 0;
+  }
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useLayoutEffect, Fragment } from "react";
-import confetti from "canvas-confetti";
+import coinConfetti from "../../utils/coinConfetti";
 import DiceRoller from "../../components/DiceRoller.jsx";
 import {
   dropSound,
@@ -1407,7 +1407,7 @@ export default function SnakeAndLadder() {
           setMessage(`You win ${winAmt} ${token}!`);
           setMessageColor("");
           if (!muted) winSoundRef.current?.play().catch(() => {});
-          confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
+          coinConfetti(50);
           setCelebrate(true);
           setTimeout(() => {
             setCelebrate(false);

--- a/webapp/src/utils/coinConfetti.ts
+++ b/webapp/src/utils/coinConfetti.ts
@@ -1,0 +1,30 @@
+export default function coinConfetti(count: number = 50) {
+  const container = document.createElement('div');
+  container.style.position = 'fixed';
+  container.style.top = '0';
+  container.style.left = '0';
+  container.style.width = '100%';
+  container.style.height = '0';
+  container.style.pointerEvents = 'none';
+  container.style.overflow = 'visible';
+  document.body.appendChild(container);
+
+  for (let i = 0; i < count; i++) {
+    const img = document.createElement('img');
+    img.src = '/assets/icons/TPCcoin.png';
+    img.alt = 'TPC Coin';
+    img.className = 'coin-confetti';
+    const left = Math.random() * 100;
+    const delay = Math.random() * 0.2;
+    const duration = 2 + Math.random() * 2;
+    img.style.left = left + 'vw';
+    img.style.animationDelay = delay + 's';
+    img.style.setProperty('--duration', duration + 's');
+    container.appendChild(img);
+  }
+
+  setTimeout(() => {
+    container.remove();
+  }, 5000);
+}
+


### PR DESCRIPTION
## Summary
- add `coinConfetti` utility to show TPC coins falling
- use it in `RewardPopup` and `SnakeAndLadder` pages
- drop `canvas-confetti` dependency
- style falling coin animation in Tailwind CSS

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686959fba03083298c29c3a4a4db1c78