### PR TITLE
Add store category filtering

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -4,7 +4,7 @@ import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { createAccount, buyBundle, claimPurchase } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import InfoPopup from '../components/InfoPopup.jsx';
-import { STORE_ADDRESS, STORE_BUNDLES } from '../utils/storeData.js';
+import { STORE_ADDRESS, STORE_BUNDLES, STORE_CATEGORIES } from '../utils/storeData.js';
 
 export default function Store() {
   useTelegramBackButton();
@@ -13,6 +13,7 @@ export default function Store() {
   const [accountId, setAccountId] = useState('');
   const [msg, setMsg] = useState('');
   const [claimHash, setClaimHash] = useState('');
+  const [category, setCategory] = useState('Presale');
 
   useEffect(() => {
     let id;
@@ -42,7 +43,18 @@ export default function Store() {
   return (
     <div className="relative p-4 space-y-4 text-text">
       <h2 className="text-xl font-bold">Store</h2>
-      {STORE_BUNDLES.map((b) => (
+      <div className="flex justify-center space-x-2">
+        {STORE_CATEGORIES.map((c) => (
+          <button
+            key={c}
+            onClick={() => setCategory(c)}
+            className={`lobby-tile px-3 py-1 ${category === c ? 'lobby-selected' : ''}`}
+          >
+            {c}
+          </button>
+        ))}
+      </div>
+      {STORE_BUNDLES.filter(b => b.category === category).map((b) => (
         <div
           key={b.id}
           className="store-card w-80 mx-auto"
@@ -59,7 +71,7 @@ export default function Store() {
             <span>{b.ton}</span>
             <img src="/icons/TON.png" alt="TON" className="w-6 h-6" />
           </div>
-          <div className="text-xs text-accent">Presale Bundle</div>
+          <div className="text-xs text-accent">{b.category} Bundle</div>
           <div className="text-sm">
             {b.boost ? `Mining Boost: +${b.boost * 100}%` : 'No Mining Boost'}
           </div>

--- a/webapp/src/utils/storeData.js
+++ b/webapp/src/utils/storeData.js
@@ -1,12 +1,14 @@
 export const STORE_ADDRESS = 'UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT';
 
+export const STORE_CATEGORIES = ['Presale', 'Spin & Win', 'Virtual Friends'];
+
 export const STORE_BUNDLES = [
-  { id: 'newbie', name: 'Newbie Pack', icon: '🌱', tpc: 25000, ton: 0.25, boost: 0, presale: true },
-  { id: 'rookie', name: 'Rookie', icon: '🎯', tpc: 50000, ton: 0.4, boost: 0, presale: true },
-  { id: 'starter', name: 'Starter', icon: '🚀', tpc: 100000, ton: 0.75, boost: 0, presale: true },
-  { id: 'miner', name: 'Miner Pack', icon: '⛏️', tpc: 250000, ton: 1.6, boost: 0.03, presale: true },
-  { id: 'grinder', name: 'Grinder', icon: '⚙️', tpc: 500000, ton: 3.0, boost: 0.05, presale: true },
-  { id: 'pro', name: 'Pro Bundle', icon: '🏆', tpc: 1000000, ton: 5.5, boost: 0.08, presale: true },
-  { id: 'whale', name: 'Whale Bundle', icon: '🐋', tpc: 2500000, ton: 10.5, boost: 0.12, presale: true },
-  { id: 'max', name: 'Max Presale', icon: '👑', tpc: 5000000, ton: 20, boost: 0.15, presale: true }
+  { id: 'newbie', name: 'Newbie Pack', icon: '🌱', tpc: 25000, ton: 0.25, boost: 0, category: 'Presale' },
+  { id: 'rookie', name: 'Rookie', icon: '🎯', tpc: 50000, ton: 0.4, boost: 0, category: 'Presale' },
+  { id: 'starter', name: 'Starter', icon: '🚀', tpc: 100000, ton: 0.75, boost: 0, category: 'Presale' },
+  { id: 'miner', name: 'Miner Pack', icon: '⛏️', tpc: 250000, ton: 1.6, boost: 0.03, category: 'Presale' },
+  { id: 'grinder', name: 'Grinder', icon: '⚙️', tpc: 500000, ton: 3.0, boost: 0.05, category: 'Presale' },
+  { id: 'pro', name: 'Pro Bundle', icon: '🏆', tpc: 1000000, ton: 5.5, boost: 0.08, category: 'Presale' },
+  { id: 'whale', name: 'Whale Bundle', icon: '🐋', tpc: 2500000, ton: 10.5, boost: 0.12, category: 'Presale' },
+  { id: 'max', name: 'Max Presale', icon: '👑', tpc: 5000000, ton: 20, boost: 0.15, category: 'Presale' }
 ];


### PR DESCRIPTION
## Summary
- add `STORE_CATEGORIES` list and migrate bundles to use a `category` field
- add category selector to Store page and filter bundles

## Testing
- `npm test` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68695cdd0d588329b3a86b0ac61a850a