### PR TITLE
Improve UI visibility and backgrounds

### DIFF
--- a/webapp/src/components/GameCard.jsx
+++ b/webapp/src/components/GameCard.jsx
@@ -12,7 +12,13 @@ export default function GameCard({ title, description, link, icon }) {
   }
 
   return (
-    <div className="bg-surface p-4 rounded-xl shadow-lg space-y-2 text-center">
+    <div className="relative bg-surface border border-border rounded-xl p-4 shadow-lg space-y-2 text-center overflow-hidden">
+      <img
+        loading="lazy"
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+      />
       {iconNode}
       <h3 className="text-lg font-bold text-text">{title}</h3>
       {description && <p className="text-subtext text-sm">{description}</p>}

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -47,13 +47,13 @@ export default function InvitePopup({
         <div className="flex justify-center gap-2">
           <button
             onClick={onAccept}
-            className="px-3 py-1 bg-primary hover:bg-primary-hover rounded"
+            className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
           >
             Yes
           </button>
           <button
             onClick={onReject}
-            className="px-3 py-1 bg-primary hover:bg-primary-hover rounded"
+            className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
           >
             No
           </button>

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -66,7 +66,7 @@ export default function Layout({ children }) {
 
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
 
-      {(isHome || isWallet || isAccount) && <CosmicBackground />}
+      {(isHome || isWallet || isAccount || isGamesRoot) && <CosmicBackground />}
 
       <main className={`flex-grow container mx-auto p-4 ${showNavbar ? 'pb-24' : ''}`.trim()}>
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -921,16 +921,17 @@ input:focus {
 
 .coin-img {
   position: absolute;
-  left: -10px;
+  left: -16px;
   bottom: 0;
-  width: 20px;
-  height: 20px;
+  width: 32px;
+  height: 32px;
   transform: translate(-50%, 0);
   animation-name: coin-up;
   animation-duration: var(--dur);
   animation-delay: var(--delay);
   animation-timing-function: ease-out;
   animation-fill-mode: forwards;
+  filter: brightness(1.5) drop-shadow(0 0 4px gold);
 }
 
 .board-emojis {

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -204,7 +204,7 @@ export default function Friends() {
             <span className="ml-1">{onlineCount}</span>
           </span>
         </h3>
-        <div className="max-h-96 overflow-y-auto border border-border rounded">
+        <div className="max-h-[80rem] overflow-y-auto border border-border rounded">
           <table className="w-full text-sm">
             <thead className="sticky top-0 bg-surface">
               <tr className="border-b border-border text-left">


### PR DESCRIPTION
## Summary
- make coin burst larger and brighter
- ensure invite popup buttons have visible text
- expand friends leaderboard frame size
- show cosmic background on games page
- update game cards with consistent background image

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68696023f4488329bcc71436c1107814