### PR TITLE
Fix coin visibility

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -915,6 +915,7 @@ input:focus {
   bottom: 50%;
   width: 0;
   height: 0;
+  z-index: 60;
   pointer-events: none;
   overflow: visible;
 }

--- a/webapp/src/utils/coinConfetti.ts
+++ b/webapp/src/utils/coinConfetti.ts
@@ -6,6 +6,7 @@ export default function coinConfetti(count: number = 50) {
   container.style.width = '100%';
   container.style.height = '0';
   container.style.pointerEvents = 'none';
+  container.style.zIndex = '60';
   container.style.overflow = 'visible';
   document.body.appendChild(container);
 


### PR DESCRIPTION
## Summary
- keep coins above popups during celebrations

## Testing
- `npm test` *(fails: test timed out and modules not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697220af7c8329b57a8337f8172ca6