### PR TITLE
Remove lazy loading in webapp

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -1,10 +1,10 @@
-import React, { Suspense, lazy } from 'react';
+import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { TonConnectUIProvider } from '@tonconnect/ui-react';
 
 import Home from './pages/Home.jsx';
 import Friends from './pages/Friends.jsx';
-const DominoPlay = lazy(() => import('./pages/Games/DominoPlay.jsx'));
+import DominoPlay from './pages/Games/DominoPlay.jsx';
 import Wallet from './pages/Wallet.jsx';
 import Tasks from './pages/Tasks.jsx';
 import Referral from './pages/Referral.jsx';
@@ -15,10 +15,10 @@ import Trending from './pages/Trending.jsx';
 import Notifications from './pages/Notifications.jsx';
 
 import HorseRacing from './pages/Games/HorseRacing.jsx';
-const SnakeAndLadder = lazy(() => import('./pages/Games/SnakeAndLadder.jsx'));
-const SnakeMultiplayer = lazy(() => import('./pages/Games/SnakeMultiplayer.jsx'));
-const SnakeResults = lazy(() => import('./pages/Games/SnakeResults.jsx'));
-const Ludo = lazy(() => import('./pages/Games/Ludo.jsx'));
+import SnakeAndLadder from './pages/Games/SnakeAndLadder.jsx';
+import SnakeMultiplayer from './pages/Games/SnakeMultiplayer.jsx';
+import SnakeResults from './pages/Games/SnakeResults.jsx';
+import Ludo from './pages/Games/Ludo.jsx';
 import Lobby from './pages/Games/Lobby.jsx';
 import Games from './pages/Games.jsx';
 import SpinPage from './pages/spin.tsx';
@@ -42,38 +42,10 @@ export default function App() {
           <Route path="/games/:game/lobby" element={<Lobby />} />
             <Route path="/games/horse" element={<HorseRacing />} />
           <Route path="/games/domino" element={<DominoPlay />} />
-          <Route
-            path="/games/ludo"
-            element={
-              <Suspense fallback={<div className="p-4 text-center">Loading...</div>}>
-                <Ludo />
-              </Suspense>
-            }
-          />
-          <Route
-            path="/games/snake"
-            element={
-              <Suspense fallback={<div className="p-4 text-center">Loading...</div>}>
-                <SnakeAndLadder />
-              </Suspense>
-            }
-          />
-          <Route
-            path="/games/snake/mp"
-            element={
-              <Suspense fallback={<div className="p-4 text-center">Loading...</div>}>
-                <SnakeMultiplayer />
-              </Suspense>
-            }
-          />
-          <Route
-            path="/games/snake/results"
-            element={
-              <Suspense fallback={<div className="p-4 text-center">Loading...</div>}>
-                <SnakeResults />
-              </Suspense>
-            }
-          />
+          <Route path="/games/ludo" element={<Ludo />} />
+          <Route path="/games/snake" element={<SnakeAndLadder />} />
+          <Route path="/games/snake/mp" element={<SnakeMultiplayer />} />
+          <Route path="/games/snake/results" element={<SnakeResults />} />
           <Route path="/spin" element={<SpinPage />} />
           <Route path="/tasks" element={<Tasks />} />
           <Route path="/store" element={<Store />} />

--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -55,7 +55,7 @@ export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
             &times;
           </button>
         )}
-        <img loading="lazy" src="/assets/TonPlayGramLogo.jpg" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
+        <img  src="/assets/TonPlayGramLogo.jpg" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
         <h3 className="text-lg font-bold">Watch Ad</h3>
         <div
           id="adsgram-player"

--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -46,7 +46,7 @@ function formatValue(value, decimals = 4) {
 function Token({ icon, value, label, decimals }) {
   return (
     <div className="flex items-center justify-start space-x-1 w-full">
-      <img loading="lazy" src={icon} alt={label} className="w-8 h-8" />
+      <img  src={icon} alt={label} className="w-8 h-8" />
       <span>{formatValue(value, decimals)}</span>
     </div>
   );

--- a/webapp/src/components/Branding.jsx
+++ b/webapp/src/components/Branding.jsx
@@ -4,7 +4,7 @@ export default function Branding({ scale = 1, offsetY = 0 }) {
   return (
     <div className="text-center py-6 space-y-2">
       <img
-        loading="lazy"
+        
         src="/assets/TonPlayGramLogo.jpg"
         alt="TonPlaygram Logo"
         className="mx-auto"

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -115,7 +115,7 @@ export default function DailyCheckIn() {
 
         <span className="flex items-center">
           {formatReward(REWARDS[i])}
-          <img loading="lazy" src="/assets/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 -ml-1" />
+          <img  src="/assets/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 -ml-1" />
         </span>
 
       </div>
@@ -128,7 +128,7 @@ export default function DailyCheckIn() {
 
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 text-center overflow-hidden">
       <img
-        loading="lazy"
+        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""
@@ -141,7 +141,7 @@ export default function DailyCheckIn() {
           <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text w-80">
 
             <img
-              loading="lazy"
+              
               src="/assets/TonPlayGramLogo.jpg"
               alt="TonPlaygram Logo"
 

--- a/webapp/src/components/GameCard.jsx
+++ b/webapp/src/components/GameCard.jsx
@@ -14,7 +14,7 @@ export default function GameCard({ title, description, link, icon }) {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 shadow-lg space-y-2 text-center overflow-hidden">
       <img
-        loading="lazy"
+        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""

--- a/webapp/src/components/GameEndPopup.jsx
+++ b/webapp/src/components/GameEndPopup.jsx
@@ -6,7 +6,7 @@ export default function GameEndPopup({ open, ranking, onPlayAgain, onReturn }) {
   return createPortal(
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
-        <img loading="lazy" src="/assets/TonPlayGramLogo.jpg" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
+        <img  src="/assets/TonPlayGramLogo.jpg" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
         <h3 className="text-lg font-bold text-center">Game Over</h3>
         <ol className="list-decimal list-inside space-y-1 text-center">
           {ranking.map((name, i) => (

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -21,7 +21,7 @@ export default function InvitePopup({
           <p className="text-center">
             {name} wants to play you for {stake?.amount}{' '}
             <img
-              loading="lazy"
+              
               src={
                 stake?.token === 'TPC'
                   ? '/assets/icons/TPCcoin.png'

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -124,7 +124,7 @@ export default function MiningCard() {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-center overflow-hidden">
       <img
-        loading="lazy"
+        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""
@@ -148,7 +148,7 @@ export default function MiningCard() {
       </button>
       {isMining && (
         <div className="flex items-center justify-center space-x-1 text-sm">
-          <img loading="lazy" src="/assets/icons/TPCcoin.png" alt="TPC" className="w-5 h-5" />
+          <img  src="/assets/icons/TPCcoin.png" alt="TPC" className="w-5 h-5" />
           <span>{minted}</span>
         </div>
       )}

--- a/webapp/src/components/ProfileCard.jsx
+++ b/webapp/src/components/ProfileCard.jsx
@@ -5,7 +5,7 @@ export default function ProfileCard() {
   return (
     <div className="relative bg-surface border border-border p-4 rounded-xl shadow-lg space-y-2 text-center overflow-hidden">
       <img
-        loading="lazy"
+        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -24,7 +24,7 @@ export default function RewardPopup({ reward, onClose, message }: RewardPopupPro
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="text-center space-y-4 text-text">
         <img
-          loading="lazy"
+          
           src="/assets/TonPlayGramLogo.jpg"
           alt="TonPlaygram Logo"
           className="w-10 h-10 mx-auto"
@@ -34,7 +34,7 @@ export default function RewardPopup({ reward, onClose, message }: RewardPopupPro
           {reward === 'BONUS_X3' && (
             <>
               <img
-                loading="lazy"
+                
                 src="/assets/icons/Dice.png"
                 alt="Bonus"
                 className="w-8 h-8"
@@ -45,7 +45,7 @@ export default function RewardPopup({ reward, onClose, message }: RewardPopupPro
           {typeof reward === 'number' && reward === 1600 && (
             <>
               <img
-                loading="lazy"
+                
                 src="/assets/icons/FreeSpin.png"
                 alt="Free Spin"
                 className="w-8 h-8"
@@ -56,7 +56,7 @@ export default function RewardPopup({ reward, onClose, message }: RewardPopupPro
           {typeof reward === 'number' && reward === 1800 && (
             <>
               <img
-                loading="lazy"
+                
                 src="/assets/icons/FreeSpin.png"
                 alt="Free Spin"
                 className="w-8 h-8"
@@ -67,7 +67,7 @@ export default function RewardPopup({ reward, onClose, message }: RewardPopupPro
           {typeof reward === 'number' && reward !== 1600 && reward !== 1800 && (
             <>
               <img
-                loading="lazy"
+                
                 src="/assets/icons/TPCcoin.png"
                 alt="TPC"
                 className="w-8 h-8"

--- a/webapp/src/components/RoomPopup.jsx
+++ b/webapp/src/components/RoomPopup.jsx
@@ -20,7 +20,7 @@ export default function RoomPopup({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
         <img
-          loading="lazy"
+          
           src="/assets/TonPlayGramLogo.jpg"
           alt="TonPlaygram Logo"
           className="w-10 h-10 mx-auto"

--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -30,7 +30,7 @@ export default function RoomSelector({ selected, onSelect, tokens: allowed }) {
                   : ''
               }`}
             >
-              <img loading="lazy" src={icon} alt={id} className="w-8 h-8" />
+              <img  src={icon} alt={id} className="w-8 h-8" />
               <span>{amt}</span>
             </button>
           ))}

--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -16,7 +16,7 @@ function CoinBurst({ token }) {
     <div className="coin-burst">
       {coins.map((c, i) => (
         <img
-          loading="lazy"
+          
           key={i}
           src={
             token.toUpperCase() === 'TPC'
@@ -133,7 +133,7 @@ export default function SnakeBoard({
         >
           {(iconImage || offsetVal != null) && (
             <span className="cell-marker">
-              {iconImage && <img loading="lazy" src={iconImage} className="cell-icon" />}
+              {iconImage && <img  src={iconImage} className="cell-icon" />}
               {offsetVal != null && (
                 <span
                   className={`offset-text ${cellType === 'snake' ? 'snake-text' : 'ladder-text'}`}
@@ -146,7 +146,7 @@ export default function SnakeBoard({
           {!cellType && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
-              <img loading="lazy" src="/assets/icons/Dice.png" className="dice-icon" />
+              <img  src="/assets/icons/Dice.png" className="dice-icon" />
               <span className="dice-value">+{diceCells[num]}</span>
             </span>
           )}
@@ -229,7 +229,7 @@ export default function SnakeBoard({
 
   return (
     <div className="relative flex justify-center items-center w-screen overflow-visible">
-      <img loading="lazy" src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
+      <img  src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
       <div
         ref={containerRef}
         className="overflow-y-auto"
@@ -270,7 +270,7 @@ export default function SnakeBoard({
                     ? '/icons/Usdt.png'
                     : '/assets/icons/TPCcoin.png'
                 }
-                loading="lazy"
+                
                 alt={token}
                 className="pot-icon"
                 />

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -156,7 +156,7 @@ export default function SpinGame() {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 flex flex-col items-center space-y-2 overflow-hidden">
       <img
-        loading="lazy"
+        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -227,7 +227,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
               ) : val === 1600 || val === 1800 ? (
                 <>
                   <img
-                    loading="lazy"
+                    
                     src="/assets/icons/FreeSpin.png"
                     alt="Free Spin"
                     className="w-8 h-8 mr-1"
@@ -239,7 +239,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
                 </>
               ) : (
                 <>
-                  <img loading="lazy" src="/assets/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 mr-1" />
+                  <img  src="/assets/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 mr-1" />
                   <span>{val >= 1000 ? `${val / 1000}k` : val}</span>
                 </>
               )}

--- a/webapp/src/components/TablePopup.jsx
+++ b/webapp/src/components/TablePopup.jsx
@@ -7,7 +7,7 @@ export default function TablePopup({ open, tables, onSelect }) {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
         <img
-          loading="lazy"
+          
           src="/assets/TonPlayGramLogo.jpg"
           alt="TonPlaygram Logo"
           className="w-10 h-10 mx-auto"

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -86,7 +86,7 @@ export default function TasksCard() {
   return (
 
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden">
-      <img loading="lazy" src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
+      <img  src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
 
       <h3 className="text-lg font-bold text-text flex items-center justify-center space-x-1"><AiOutlineCheckSquare className="text-accent" /><span>Tasks</span></h3>
 

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -45,7 +45,7 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="relative p-4 space-y-4 w-80 rounded-xl border border-border bg-surface text-text overflow-hidden">
         <img
-          loading="lazy"
+          
           src="/assets/SnakeLaddersbackground.png"
           className="background-behind-board object-cover"
           alt=""
@@ -70,7 +70,7 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
                 if (isReceive) return 'Received';
                 return tx.type;
               })()} {sign}{formattedAmount}
-              <img loading="lazy" src={icon} alt={token} className="w-5 h-5 inline" />
+              <img  src={icon} alt={token} className="w-5 h-5 inline" />
             </span>
             {tx.game && (
               <span className="text-xs capitalize">{tx.type}</span>

--- a/webapp/src/components/WalletCard.jsx
+++ b/webapp/src/components/WalletCard.jsx
@@ -34,7 +34,7 @@ export default function WalletCard() {
   return (
     <div className="relative bg-surface border border-border p-4 rounded-xl shadow-lg text-text space-y-2 overflow-hidden">
       <img
-        loading="lazy"
+        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -122,7 +122,7 @@ export default function Friends() {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-text overflow-hidden">
       <img
-        loading="lazy"
+        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""
@@ -181,7 +181,7 @@ export default function Friends() {
 
       <section id="leaderboard" className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden">
         <img
-          loading="lazy"
+          
           src="/assets/SnakeLaddersbackground.png"
           className="background-behind-board object-cover"
           alt=""

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -6,7 +6,7 @@ export default function Games() {
   return (
     <div className="relative space-y-4 text-text">
       <img
-        loading="lazy"
+        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""

--- a/webapp/src/pages/Games/DominoPlay.jsx
+++ b/webapp/src/pages/Games/DominoPlay.jsx
@@ -124,7 +124,7 @@ export default function DominoPlay() {
     return (
       <div className="relative p-4 space-y-4 text-text flex flex-col items-center overflow-hidden">
         <img
-          loading="lazy"
+          
           src="/assets/icons/file_0000000091786243919bf8966d4d73ce.png"
           className="background-behind-board object-cover"
           alt=""
@@ -140,7 +140,7 @@ export default function DominoPlay() {
   return (
     <div className="relative p-4 space-y-4 text-text flex flex-col items-center overflow-hidden">
       <img
-        loading="lazy"
+        
         src="/assets/icons/file_0000000091786243919bf8966d4d73ce.png"
         className="background-behind-board object-cover"
         alt=""

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -250,7 +250,7 @@ export default function Lobby() {
   return (
     <div className="relative p-4 space-y-4 text-text">
       <img
-        loading="lazy"
+        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -290,7 +290,7 @@ function Board({
           {!cellType && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
-              <img loading="lazy" src="/assets/icons/Dice.png" className="dice-icon" />
+              <img  src="/assets/icons/Dice.png" className="dice-icon" />
               <span className="dice-value">+{diceCells[num]}</span>
             </span>
           )}
@@ -412,7 +412,7 @@ function Board({
 
   return (
     <div className="relative flex justify-center items-center w-screen overflow-visible">
-      <img loading="lazy" src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
+      <img  src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
       <div
         ref={containerRef}
         className="overflow-y-auto"
@@ -1810,7 +1810,7 @@ export default function SnakeAndLadder() {
       {rewardDice > 0 && (
         <div className="fixed bottom-40 inset-x-0 flex justify-center z-30 pointer-events-none reward-dice-container">
           {Array.from({ length: rewardDice }).map((_, i) => (
-            <img key={i} loading="lazy" src="/assets/icons/Dice.png" className="reward-dice" />
+            <img key={i}  src="/assets/icons/Dice.png" className="reward-dice" />
           ))}
         </div>
       )}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -114,7 +114,7 @@ export default function Home() {
         <div className="w-full mt-2 space-y-4">
           <div className="relative bg-surface border border-border rounded-xl p-4 flex items-center justify-around overflow-hidden">
             <img
-              loading="lazy"
+              
               src="/assets/SnakeLaddersbackground.png"
               className="background-behind-board object-cover"
               alt=""
@@ -136,7 +136,7 @@ export default function Home() {
                 <span className="text-lg font-bold">Wallet</span>
               </div>
               <img
-                loading="lazy"
+                
                 src="/assets/SnakeLaddersbackground.png"
                 className="background-behind-board object-cover"
                 alt=""

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -68,7 +68,7 @@ export default function Tasks() {
 
     <div className="relative p-4 space-y-2 text-text">
 
-      <img loading="lazy" src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
+      <img  src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
       <h2 className="text-xl font-bold">Tasks</h2>
 
       <ul className="space-y-2">


### PR DESCRIPTION
## Summary
- load all page components directly instead of using `React.lazy`
- drop `loading="lazy"` attributes from all images

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_6869795486888329bed137ce137c2924