### PR TITLE
Add new store bundles

### DIFF
--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -22,6 +22,12 @@ const STORE_ADDRESS_NORM = normalize(STORE_ADDRESS);
 
 const BOOST_EXPIRY = new Date('2025-08-21T00:00:00Z');
 
+function daysFromNow(days) {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  return d;
+}
+
 const BUNDLES = {
   newbie: { tpc: 25000, ton: 0.25, label: 'Newbie Pack' },
   rookie: { tpc: 50000, ton: 0.4, label: 'Rookie' },
@@ -31,6 +37,21 @@ const BUNDLES = {
   pro: { tpc: 1000000, ton: 5.5, label: 'Pro Bundle', boost: 0.08 },
   whale: { tpc: 2500000, ton: 10.5, label: 'Whale Bundle', boost: 0.12 },
   max: { tpc: 5000000, ton: 20, label: 'Max Presale', boost: 0.15 },
+
+  // Spin & Win Bundles
+  luckyStarter: { tpc: 5000, ton: 0.25, label: 'Lucky Starter' },
+  spinx3: { tpc: 10000, ton: 0.4, label: 'Spin x3 Pack' },
+  megaSpin: { tpc: 25000, ton: 1.0, label: 'Mega Spin Pack' },
+
+  // Virtual Friends
+  lazyLarry: { tpc: 0, ton: 0.15, label: 'Lazy Larry', boost: 0.25, duration: 7 },
+  smartSia: { tpc: 0, ton: 0.3, label: 'Smart Sia', boost: 0.5, duration: 7 },
+  grindBot: { tpc: 0, ton: 0.7, label: 'GrindBot3000', boost: 1.25, duration: 14 },
+
+  // Bonus Bundles
+  powerPack: { tpc: 20000, ton: 0.35, label: 'Power Pack', boost: 0.5, duration: 3 },
+  proPack: { tpc: 40000, ton: 0.6, label: 'Pro Pack', boost: 0.5, duration: 7 },
+  galaxyPack: { tpc: 100000, ton: 1.2, label: 'Galaxy Pack', boost: 1.25, duration: 7 },
 };
 
 router.post('/purchase', authenticate, async (req, res) => {
@@ -85,8 +106,9 @@ router.post('/purchase', authenticate, async (req, res) => {
   const txDate = new Date();
   user.balance += pack.tpc;
   if (pack.boost) {
-    if (!user.storeMiningExpiresAt || user.storeMiningExpiresAt < BOOST_EXPIRY) {
-      user.storeMiningExpiresAt = BOOST_EXPIRY;
+    const expiry = pack.duration ? daysFromNow(pack.duration) : BOOST_EXPIRY;
+    if (!user.storeMiningExpiresAt || user.storeMiningExpiresAt < expiry) {
+      user.storeMiningExpiresAt = expiry;
     }
     if ((user.storeMiningRate || 0) < pack.boost) {
       user.storeMiningRate = pack.boost;

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -72,9 +72,15 @@ export default function Store() {
             <img src="/icons/TON.png" alt="TON" className="w-6 h-6" />
           </div>
           <div className="text-xs text-accent">{b.category} Bundle</div>
-          <div className="text-sm">
-            {b.boost ? `Mining Boost: +${b.boost * 100}%` : 'No Mining Boost'}
-          </div>
+          {b.boost ? (
+            <div className="text-sm">Mining Boost: +{b.boost * 100}%</div>
+          ) : null}
+          {b.spins ? (
+            <div className="text-sm">Spins: {b.spins}</div>
+          ) : null}
+          {b.duration ? (
+            <div className="text-xs text-subtext">Duration: {b.duration}d</div>
+          ) : null}
           <button
             onClick={() => handleBuy(b)}
             className="buy-button mt-2"

--- a/webapp/src/utils/storeData.js
+++ b/webapp/src/utils/storeData.js
@@ -1,6 +1,11 @@
 export const STORE_ADDRESS = 'UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT';
 
-export const STORE_CATEGORIES = ['Presale', 'Spin & Win', 'Virtual Friends'];
+export const STORE_CATEGORIES = [
+  'Presale',
+  'Spin & Win',
+  'Virtual Friends',
+  'Bonus Bundles'
+];
 
 export const STORE_BUNDLES = [
   { id: 'newbie', name: 'Newbie Pack', icon: '🌱', tpc: 25000, ton: 0.25, boost: 0, category: 'Presale' },
@@ -10,5 +15,20 @@ export const STORE_BUNDLES = [
   { id: 'grinder', name: 'Grinder', icon: '⚙️', tpc: 500000, ton: 3.0, boost: 0.05, category: 'Presale' },
   { id: 'pro', name: 'Pro Bundle', icon: '🏆', tpc: 1000000, ton: 5.5, boost: 0.08, category: 'Presale' },
   { id: 'whale', name: 'Whale Bundle', icon: '🐋', tpc: 2500000, ton: 10.5, boost: 0.12, category: 'Presale' },
-  { id: 'max', name: 'Max Presale', icon: '👑', tpc: 5000000, ton: 20, boost: 0.15, category: 'Presale' }
+  { id: 'max', name: 'Max Presale', icon: '👑', tpc: 5000000, ton: 20, boost: 0.15, category: 'Presale' },
+
+  // Spin & Win Bundles
+  { id: 'luckyStarter', name: 'Lucky Starter', icon: '🎁', tpc: 5000, ton: 0.25, spins: 3, category: 'Spin & Win' },
+  { id: 'spinx3', name: 'Spin x3 Pack', icon: '🔁', tpc: 10000, ton: 0.4, spins: 5, category: 'Spin & Win' },
+  { id: 'megaSpin', name: 'Mega Spin Pack', icon: '💎', tpc: 25000, ton: 1.0, spins: 15, category: 'Spin & Win' },
+
+  // Virtual Friends (Mining Boosters)
+  { id: 'lazyLarry', name: 'Lazy Larry', icon: '🐣', tpc: 0, ton: 0.15, boost: 0.25, duration: 7, category: 'Virtual Friends' },
+  { id: 'smartSia', name: 'Smart Sia', icon: '🧠', tpc: 0, ton: 0.3, boost: 0.5, duration: 7, category: 'Virtual Friends' },
+  { id: 'grindBot', name: 'GrindBot3000', icon: '🤖', tpc: 0, ton: 0.7, boost: 1.25, duration: 14, category: 'Virtual Friends' },
+
+  // Bonus Bundles
+  { id: 'powerPack', name: 'Power Pack', icon: '⚡', tpc: 20000, ton: 0.35, boost: 0.5, duration: 3, category: 'Bonus Bundles' },
+  { id: 'proPack', name: 'Pro Pack', icon: '🎯', tpc: 40000, ton: 0.6, spins: 3, boost: 0.5, duration: 7, category: 'Bonus Bundles' },
+  { id: 'galaxyPack', name: 'Galaxy Pack', icon: '🚀', tpc: 100000, ton: 1.2, spins: 5, boost: 1.25, duration: 7, category: 'Bonus Bundles' }
 ];


### PR DESCRIPTION
## Summary
- extend store categories and bundles
- display new bundle details in the store page
- update backend store route with new bundles and dynamic boost expiry

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68697b0221b08329b830aa02fc34c64e