### PR TITLE
Update spin reward popup

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -174,13 +174,8 @@ export default function DailyCheckIn() {
       {reward !== null && (
 
         <RewardPopup
-
           reward={reward}
-
           onClose={() => setReward(null)}
-
-          message="Keep the streak alive for bigger rewards!"
-
         />
 
       )}

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -6,29 +6,24 @@ import { Segment } from '../utils/rewardLogic';
 interface RewardPopupProps {
   reward: Segment | null;
   onClose: () => void;
-  message?: string;
 }
 
-export default function RewardPopup({ reward, onClose, message }: RewardPopupProps) {
+export default function RewardPopup({ reward, onClose }: RewardPopupProps) {
   if (reward === null) return null;
   useEffect(() => {
     coinConfetti(50);
     const audio = new Audio('/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3');
     audio.volume = getGameVolume();
     audio.play().catch(() => {});
+    const timer = setTimeout(onClose, 2500);
     return () => {
       audio.pause();
+      clearTimeout(timer);
     };
-  }, []);
+  }, [onClose]);
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="text-center space-y-4 text-text">
-        <img
-          
-          src="/assets/TonPlayGramLogo.jpg"
-          alt="TonPlaygram Logo"
-          className="w-10 h-10 mx-auto"
-        />
         <h3 className="text-lg font-bold">Reward Earned</h3>
         <div className="text-accent text-3xl flex items-center justify-center space-x-2">
           {reward === 'BONUS_X3' && (
@@ -76,7 +71,6 @@ export default function RewardPopup({ reward, onClose, message }: RewardPopupPro
             </>
           )}
         </div>
-        {message && <p className="text-sm text-subtext">{message}</p>}
         <button
           onClick={onClose}
           className="px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded w-full"

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -230,7 +230,6 @@ export default function SpinGame() {
       <RewardPopup
         reward={reward}
         onClose={() => setReward(null)}
-        message="Keep spinning every day to earn more!"
       />
       <AdModal
         open={showAd}

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -182,7 +182,6 @@ export default function SpinPage() {
       <RewardPopup
         reward={reward}
         onClose={() => setReward(null)}
-        message="Keep spinning every day to earn more!"
       />
       <AdModal
         open={showAd}


### PR DESCRIPTION
## Summary
- auto-close RewardPopup after 2.5s
- remove logo and message from spin reward popup
- update spin components for new RewardPopup API

## Testing
- `npm test` *(fails: Cannot find package 'dotenv', others)*

------
https://chatgpt.com/codex/tasks/task_e_68697d839ed883298632b02f01dcf01c