### PR TITLE
Remove old board background

### DIFF
--- a/webapp/src/components/GameCard.jsx
+++ b/webapp/src/components/GameCard.jsx
@@ -13,12 +13,6 @@ export default function GameCard({ title, description, link, icon }) {
 
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 shadow-lg space-y-2 text-center overflow-hidden">
-      <img
-        
-        src="/assets/SnakeLaddersbackground.png"
-        className="background-behind-board object-cover"
-        alt=""
-      />
       {iconNode}
       <h3 className="text-lg font-bold text-text">{title}</h3>
       {description && <p className="text-subtext text-sm">{description}</p>}

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -5,12 +5,6 @@ export default function Games() {
   useTelegramBackButton();
   return (
     <div className="relative space-y-4 text-text">
-      <img
-        
-        src="/assets/SnakeLaddersbackground.png"
-        className="background-behind-board object-cover"
-        alt=""
-      />
       <h2 className="text-2xl font-bold text-center mt-4">Games</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <GameCard title="Snake & Ladder" icon="🎲" link="/games/snake/lobby" />


### PR DESCRIPTION
## Summary
- remove legacy board background from GameCard component and Games page
- rely on cosmic star background

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68697f1492288329ac14103854cd66af