### PR TITLE
UI tweaks and spin popup update

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -106,7 +106,7 @@ export default function DailyCheckIn() {
 
       <div
         key={i}
-        className={`board-style w-20 p-2 flex flex-col items-center justify-center text-xs ${
+        className={`board-style border-2 border-border w-20 p-2 flex flex-col items-center justify-center text-xs ${
           i === streak - 1 ? 'border-4 border-brand-gold' : ''
         }`}
       >

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -6,21 +6,23 @@ import { Segment } from '../utils/rewardLogic';
 interface RewardPopupProps {
   reward: Segment | null;
   onClose: () => void;
+  duration?: number;
+  showCloseButton?: boolean;
 }
 
-export default function RewardPopup({ reward, onClose }: RewardPopupProps) {
+export default function RewardPopup({ reward, onClose, duration = 2500, showCloseButton = true }: RewardPopupProps) {
   if (reward === null) return null;
   useEffect(() => {
     coinConfetti(50);
     const audio = new Audio('/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3');
     audio.volume = getGameVolume();
     audio.play().catch(() => {});
-    const timer = setTimeout(onClose, 2500);
+    const timer = setTimeout(onClose, duration);
     return () => {
       audio.pause();
       clearTimeout(timer);
     };
-  }, [onClose]);
+  }, [onClose, duration]);
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="text-center space-y-4 text-text">
@@ -71,12 +73,14 @@ export default function RewardPopup({ reward, onClose }: RewardPopupProps) {
             </>
           )}
         </div>
-        <button
-          onClick={onClose}
-          className="px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded w-full"
-        >
-          Close
-        </button>
+        {showCloseButton && (
+          <button
+            onClick={onClose}
+            className="px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded w-full"
+          >
+            Close
+          </button>
+        )}
       </div>
     </div>
   );

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -210,7 +210,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
               key={idx}
 
-              className={`board-style flex items-center justify-center text-sm w-28 font-bold ${
+              className={`board-style border-2 border-border flex items-center justify-center text-sm w-28 font-bold ${
 
                 idx === winnerIndex ? 'bg-yellow-300 text-black' : 'text-white'
 

--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -1,6 +1,13 @@
 import { AiOutlineShop } from 'react-icons/ai';
 import { Link } from 'react-router-dom';
-import { STORE_BUNDLES } from '../utils/storeData.js';
+import { STORE_CATEGORIES } from '../utils/storeData.js';
+
+const CATEGORY_ICONS = {
+  Presale: '🌱',
+  'Spin & Win': '🎰',
+  'Virtual Friends': '🤖',
+  'Bonus Bundles': '🎁',
+};
 
 export default function StoreAd() {
   return (
@@ -15,20 +22,13 @@ export default function StoreAd() {
         <span className="text-lg font-bold">Store</span>
       </div>
       <div className="flex space-x-4 overflow-x-auto pb-2">
-        {STORE_BUNDLES.map((b) => (
-          <div key={b.id} className="store-card flex-shrink-0 w-60">
+        {STORE_CATEGORIES.map((c) => (
+          <div key={c} className="store-card flex-shrink-0 w-72">
             <div className="flex items-center space-x-2">
-              <span className="text-2xl">{b.icon}</span>
-              <h3 className="font-semibold">{b.name}</h3>
+              <span className="text-2xl">{CATEGORY_ICONS[c]}</span>
+              <h3 className="font-semibold">{c}</h3>
             </div>
-            <div className="text-lg font-bold flex items-center space-x-1">
-              <span>{b.tpc.toLocaleString()}</span>
-              <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-6 h-6" />
-            </div>
-            <div className="text-primary text-lg flex items-center space-x-1">
-              <span>{b.ton}</span>
-              <img src="/icons/TON.png" alt="TON" className="w-6 h-6" />
-            </div>
+            <p className="text-sm text-subtext">Browse bundles</p>
           </div>
         ))}
       </div>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1081,7 +1081,6 @@ input:focus {
 
 .board-style {
   background-color: #0e3b45;
-  border: 2px solid #334155;
   color: #ffffff;
 }
 .friend-background{

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -200,6 +200,15 @@ export default function Friends() {
               <option value="1v1">1v1</option>
               <option value="group">Group</option>
             </select>
+            {mode === 'group' && (
+              <button
+                onClick={() => setGroupPopup(true)}
+                disabled={selected.length === 0}
+                className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm disabled:opacity-50"
+              >
+                Invite {selected.length}/3
+              </button>
+            )}
             <FaCircle className={onlineCount > 0 ? 'text-green-500' : 'text-red-500'} size={10} />
             <span className="ml-1">{onlineCount}</span>
           </span>
@@ -293,18 +302,6 @@ export default function Friends() {
         <h3 className="text-lg font-semibold">Add Friends</h3>
         <UserSearchBar />
       </section>
-      {mode === 'group' && (
-        <div className="space-y-2">
-          <p className="text-sm">Selected {selected.length}/3</p>
-          <button
-            onClick={() => setGroupPopup(true)}
-            disabled={selected.length === 0}
-            className="px-2 py-1 bg-primary hover:bg-primary-hover rounded disabled:opacity-50"
-          >
-            Invite Group
-          </button>
-        </div>
-      )}
       <InvitePopup
         open={!!inviteTarget}
         name={inviteTarget?.nickname || `${inviteTarget?.firstName || ''} ${inviteTarget?.lastName || ''}`.trim()}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 
 import GameCard from '../components/GameCard.jsx';
-import ProfileCard from '../components/ProfileCard.jsx';
 
 import MiningCard from '../components/MiningCard.tsx';
 
@@ -171,7 +170,6 @@ export default function Home() {
         <MiningCard />
         <TasksCard />
         <StoreAd />
-        <ProfileCard />
       </div>
 
       <p className="text-center text-xs text-subtext">Status: {status}</p>

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -128,15 +128,17 @@ export default function SpinPage() {
       <h1 className="text-xl font-bold">Spin &amp; Win</h1>
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>
       <div className="bg-surface border border-border rounded p-4 flex flex-col items-center space-y-2">
-        <div className="flex space-x-2">
-          <SpinWheel
-            ref={leftRef}
-            onFinish={() => {}}
-            spinning={spinningLeft}
-            setSpinning={setSpinningLeft}
-            disabled={!ready}
-            showButton={false}
-          />
+        <div className="flex justify-center">
+          <div className="mr-[-8px]">
+            <SpinWheel
+              ref={leftRef}
+              onFinish={() => {}}
+              spinning={spinningLeft}
+              setSpinning={setSpinningLeft}
+              disabled={!ready}
+              showButton={false}
+            />
+          </div>
           <SpinWheel
             ref={mainRef}
             onFinish={handleFinish}
@@ -145,14 +147,16 @@ export default function SpinPage() {
             disabled={!ready}
             showButton={false}
           />
-          <SpinWheel
-            ref={middleRef}
-            onFinish={() => {}}
-            spinning={spinningMiddle}
-            setSpinning={setSpinningMiddle}
-            disabled={!ready}
-            showButton={false}
-          />
+          <div className="ml-[-8px]">
+            <SpinWheel
+              ref={middleRef}
+              onFinish={() => {}}
+              spinning={spinningMiddle}
+              setSpinning={setSpinningMiddle}
+              disabled={!ready}
+              showButton={false}
+            />
+          </div>
         </div>
         <div className="flex space-x-2 mt-4">
           <button
@@ -182,6 +186,8 @@ export default function SpinPage() {
       <RewardPopup
         reward={reward}
         onClose={() => setReward(null)}
+        duration={1500}
+        showCloseButton={false}
       />
       <AdModal
         open={showAd}

--- a/webapp/tailwind.config.js
+++ b/webapp/tailwind.config.js
@@ -16,7 +16,7 @@ export default {
         subtext: '#66fcff',           // Slightly dimmed blue
         accent: '#00f7ff',            // Accent color
         brand: {
-          gold: '#00f7ff',            // Not used but keep scheme consistent
+          gold: '#facc15',            // Yellow highlight
           black: '#000000'
         }
       }


### PR DESCRIPTION
## Summary
- show yellow highlight via brand.gold color
- allow custom duration in reward popup and auto-close option
- fix daily streak border style
- adjust spin wheels layout for mobile
- enlarge Store card and show categories
- drop profile card from home page
- move group invite button near mode switch

## Testing
- `npm test` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_686987092d408329897a57a3bca30d67