### PR TITLE
Improve spin wheel and store card layout

### DIFF
--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -163,7 +163,7 @@ export default function SpinGame() {
       />
       <h3 className="text-lg font-bold text-text">Spin &amp; Win</h3>
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>
-      <div className="flex items-start space-x-0">
+      <div className="flex items-start space-x-1">
         <div className="relative">
           <div style={{ opacity: bonusActive ? 1 : 0.15 }}>
             <SpinWheel

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -67,6 +67,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
   useEffect(() => {
     spinSoundRef.current = new Audio('/assets/sounds/spinning.mp3');
     spinSoundRef.current.preload = 'auto';
+    spinSoundRef.current.loop = true;
     spinSoundRef.current.volume = getGameVolume();
     successSoundRef.current = new Audio('/assets/sounds/successful.mp3');
     successSoundRef.current.preload = 'auto';
@@ -170,7 +171,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
   return (
 
-    <div className="w-32 mx-auto flex flex-col items-center">
+    <div className="w-28 flex flex-col items-center">
 
       <div
 
@@ -184,7 +185,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
         <div
 
-          className="absolute inset-x-0 border-2 border-yellow-300 pointer-events-none z-10"
+          className="absolute inset-x-0 border-4 border-brand-gold pointer-events-none z-10 shadow-[0_0_12px_rgba(241,196,15,0.8)]"
 
           style={{ top: itemHeight * winningRow, height: itemHeight }}
 
@@ -212,7 +213,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
               className={`board-style border-2 border-border flex items-center justify-center text-sm w-28 font-bold ${
 
-                idx === winnerIndex ? 'bg-yellow-300 text-black' : 'text-white'
+                idx === winnerIndex ? 'bg-yellow-300 text-black border-4 border-brand-gold shadow-[0_0_12px_rgba(241,196,15,0.8)]' : 'text-white'
 
               }`}
 

--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -1,6 +1,7 @@
 import { AiOutlineShop } from 'react-icons/ai';
 import { Link } from 'react-router-dom';
-import { STORE_CATEGORIES } from '../utils/storeData.js';
+import { useState } from 'react';
+import { STORE_CATEGORIES, STORE_BUNDLES } from '../utils/storeData.js';
 
 const CATEGORY_ICONS = {
   Presale: '🌱',
@@ -10,6 +11,7 @@ const CATEGORY_ICONS = {
 };
 
 export default function StoreAd() {
+  const [category, setCategory] = useState(STORE_CATEGORIES[0]);
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden">
       <img
@@ -21,14 +23,32 @@ export default function StoreAd() {
         <AiOutlineShop className="text-accent" />
         <span className="text-lg font-bold">Store</span>
       </div>
-      <div className="flex space-x-4 overflow-x-auto pb-2">
+      <div className="flex space-x-2 overflow-x-auto pb-1">
         {STORE_CATEGORIES.map((c) => (
-          <div key={c} className="store-card flex-shrink-0 w-72">
+          <button
+            key={c}
+            onClick={() => setCategory(c)}
+            className={`lobby-tile px-3 py-1 flex-shrink-0 ${category === c ? 'lobby-selected' : ''}`}
+          >
+            {c}
+          </button>
+        ))}
+      </div>
+      <div className="flex space-x-4 overflow-x-auto pb-2">
+        {STORE_BUNDLES.filter(b => b.category === category).map((b) => (
+          <div key={b.id} className="store-card flex-shrink-0 w-72">
             <div className="flex items-center space-x-2">
-              <span className="text-2xl">{CATEGORY_ICONS[c]}</span>
-              <h3 className="font-semibold">{c}</h3>
+              <span className="text-2xl">{b.icon}</span>
+              <h3 className="font-semibold">{b.name}</h3>
             </div>
-            <p className="text-sm text-subtext">Browse bundles</p>
+            <div className="text-sm flex items-center space-x-1">
+              <span>{b.tpc.toLocaleString()}</span>
+              <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-5 h-5" />
+            </div>
+            <div className="text-sm flex items-center space-x-1 text-primary">
+              <span>{b.ton}</span>
+              <img src="/icons/TON.png" alt="TON" className="w-5 h-5" />
+            </div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- adjust wheel layout spacing and highlight style
- enable seamless spin audio loop
- add category tabs to the home page store card

## Testing
- `npm test` *(fails: player wins when all tokens finish, ludo lobby route lists players, online routes reflect pinged users)*

------
https://chatgpt.com/codex/tasks/task_e_68698c5fdc088329851ffbb91500f494