### PR TITLE
Enhance prism styling on homepage widgets

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -126,7 +126,7 @@ export default function DailyCheckIn() {
 
   return (
 
-    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 text-center overflow-hidden">
+    <div className="prism-box flex flex-col space-y-2 text-center p-4 overflow-hidden">
       <img
         
         src="/assets/SnakeLaddersbackground.png"

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -154,7 +154,7 @@ export default function SpinGame() {
   const ready = freeSpins > 0 || canSpin(lastSpin);
 
   return (
-    <div className="relative bg-surface border border-border rounded-xl p-4 flex flex-col items-center space-y-2 overflow-hidden">
+    <div className="prism-box flex flex-col items-center space-y-2 p-4 overflow-hidden">
       <img
         
         src="/assets/SnakeLaddersbackground.png"

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1063,7 +1063,11 @@ input:focus {
 */
 
 .prism-box {
-  @apply relative flex items-center justify-center rounded-lg bg-surface border border-border;
+  @apply relative flex items-center justify-center rounded-lg bg-surface border border-border text-text;
+  box-shadow:
+    inset 0 0 12px rgba(0, 0, 0, 0.6),
+    inset 0 0 20px rgba(0, 247, 255, 0.2),
+    0 0 12px rgba(0, 247, 255, 0.4);
 }
 
 .lobby-tile {


### PR DESCRIPTION
## Summary
- add holographic box-shadow to `.prism-box`
- use `prism-box` styling on DailyCheckIn and SpinGame components

## Testing
- `npm test` *(fails: Cannot find package 'dotenv', 'mongoose', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68699486c13c8329b678c3d644f151d9