### PR TITLE
Add 3D pawn to Snake board start tile

### DIFF
--- a/webapp/src/components/PawnModel.jsx
+++ b/webapp/src/components/PawnModel.jsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+export default function PawnModel({ src, className = '' }) {
+  const mountRef = useRef(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+    const width = mount.clientWidth;
+    const height = mount.clientHeight;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 100);
+    camera.position.set(2.5, 3.5, 4.5);
+    camera.lookAt(0, 0, 0);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setSize(width, height);
+    renderer.setPixelRatio(window.devicePixelRatio);
+    mount.appendChild(renderer.domElement);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.8);
+    const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+    directional.position.set(5, 10, 7.5);
+    scene.add(ambient);
+    scene.add(directional);
+
+    const loader = new GLTFLoader();
+    let model;
+    loader.load(src, (gltf) => {
+      model = gltf.scene;
+      scene.add(model);
+    });
+
+    let frameId;
+    const animate = () => {
+      if (model) model.rotation.y += 0.01;
+      renderer.render(scene, camera);
+      frameId = requestAnimationFrame(animate);
+    };
+    animate();
+
+    const handleResize = () => {
+      const width = mount.clientWidth;
+      const height = mount.clientHeight;
+      renderer.setSize(width, height);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      window.removeEventListener('resize', handleResize);
+      if (model) scene.remove(model);
+      renderer.dispose();
+      mount.removeChild(renderer.domElement);
+    };
+  }, [src]);
+
+  return <div ref={mountRef} className={`token-three ${className}`}></div>;
+}

--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, Fragment } from "react";
 import PlayerToken from "./PlayerToken.jsx";
+import PawnModel from "./PawnModel.jsx";
 
 // Board dimensions
 const ROWS = 20;
@@ -180,6 +181,7 @@ export default function SnakeBoard({
                 />
               </Fragment>
             ))}
+          {num === 1 && <PawnModel src="/assets/blue_pawn_with_face.glb" />}
           {offsetPopup && offsetPopup.cell === num && (
             <span
               className={`popup-offset italic font-bold ${offsetPopup.type === 'snake' ? 'text-red-500' : 'text-green-500'}`}


### PR DESCRIPTION
## Summary
- add reusable `PawnModel` three.js component for GLB models
- place blue pawn model on tile 1 in `SnakeBoard`

## Testing
- `npm test` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686a06bb983c8329a829ed13c7e1707d