### PR TITLE
Make game invites free

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -395,7 +395,6 @@ app.post('/api/snake/invite', async (req, res) => {
         roomId,
         token,
         amount,
-        true,
       );
     } catch (err) {
       console.error('Failed to send Telegram notification:', err.message);
@@ -546,7 +545,6 @@ io.on('connection', (socket) => {
           roomId,
           token,
           amount,
-          true,
         );
       } catch (err) {
         console.error('Failed to send Telegram notification:', err.message);
@@ -632,7 +630,6 @@ io.on('connection', (socket) => {
               roomId,
               token,
               amount,
-              true,
             );
           } catch (err) {
             console.error('Failed to send Telegram notification:', err.message);

--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -2,7 +2,6 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { createCanvas, loadImage } from 'canvas';
 import { fetchTelegramInfo } from './telegram.js';
-import { transferInviteTpc } from './inviteTpc.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const coinPath = path.join(
@@ -144,13 +143,6 @@ export async function sendInviteNotification(
     ],
   };
 
-  if (sendToken) {
-    try {
-      await transferInviteTpc(fromId, toId, 1);
-    } catch (err) {
-      console.error('Failed to send invite TPC:', err.message);
-    }
-  }
 
   const photo = info?.photoUrl ? { url: info.photoUrl } : { source: coinPath };
 


### PR DESCRIPTION
## Summary
- remove transferInviteTpc call so inviting costs nothing
- stop passing the `sendToken` flag in server

## Testing
- `npm test --silent` *(fails: ERR_MODULE_NOT_FOUND: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686a2bc9995c8329b9041d12806e5247