### PR TITLE
Adjust Snake & Ladder board icons

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -327,7 +327,7 @@ input:focus {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -110%) translateZ(20px)
-    rotateX(calc(var(--board-angle, 58deg) * -1));
+    rotateX(calc(var(--board-angle, 58deg) * -1 - 10deg));
   pointer-events: none;
   z-index: 3;
 }
@@ -678,7 +678,7 @@ input:focus {
 
 .cell-marker {
   position: absolute;
-  top: 60%;
+  top: 65%;
   left: 50%;
   /* Center icons slightly lower within the tile */
   transform: translate(-50%, -50%) translateZ(6px)
@@ -708,8 +708,8 @@ input:focus {
 }
 
 .cell-icon {
-  width: calc(var(--cell-width) * 0.8);
-  height: calc(var(--cell-height) * 0.8);
+  width: calc(var(--cell-width) * 0.9);
+  height: calc(var(--cell-height) * 0.9);
   object-fit: contain;
   transition: transform 0.3s ease;
 }
@@ -974,10 +974,10 @@ input:focus {
 
 .dice-marker {
   position: absolute;
-  width: 2rem;
-  height: 2rem;
+  width: 2.4rem;
+  height: 2.4rem;
   left: 50%;
-  top: 54%;
+  top: 59%;
   transform: translate(-50%, -50%) translateZ(6px)
     rotateX(calc(var(--board-angle, 58deg) * -1));
   display: flex;
@@ -989,8 +989,8 @@ input:focus {
 }
 
 .dice-marker .dice-icon {
-  width: 2rem;
-  height: 2rem;
+  width: 2.4rem;
+  height: 2.4rem;
   object-fit: contain;
   transition: transform 0.3s ease;
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -282,7 +282,11 @@ function Board({
                       : 'ladder-text'
                   }`}
                 >
-                  {offsetVal > 0 ? `+${offsetVal}` : offsetVal}
+                  {cellType === 'snake'
+                    ? `-${offsetVal}`
+                    : offsetVal > 0
+                      ? `+${offsetVal}`
+                      : offsetVal}
                 </span>
               )}
             </span>


### PR DESCRIPTION
## Summary
- tweak board cell marker styles so icons sit lower and appear larger
- enlarge dice icon and offset it downward
- show negative values for snake drops
- tilt pot icon at same angle as the winning photo

## Testing
- `npm run install-all`
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_686a3213713c83299ade299571a300e4