### PR TITLE
Improve web vitals and SEO

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -3,11 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Play games and manage your TON wallet with TonPlaygram." />
     <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
     <script src="https://telegram.org/js/telegram-web-app.js" defer></script>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <link rel="preload" as="image" href="/assets/SnakeLaddersbackground.png" />
     <link rel="preload" as="audio" href="/assets/sounds/spinning.mp3" />
     <link rel="preload" as="audio" href="/assets/sounds/successful.mp3" />
+    <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
 
     <title>TonPlaygram</title>
   </head>

--- a/webapp/public/robots.txt
+++ b/webapp/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: /sitemap.xml

--- a/webapp/public/sitemap.xml
+++ b/webapp/public/sitemap.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>/</loc></url>
+  <url><loc>/friends</loc></url>
+  <url><loc>/games</loc></url>
+  <url><loc>/wallet</loc></url>
+  <url><loc>/tasks</loc></url>
+  <url><loc>/store</loc></url>
+  <url><loc>/trending</loc></url>
+</urlset>

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -1,27 +1,27 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { TonConnectUIProvider } from '@tonconnect/ui-react';
 
-import Home from './pages/Home.jsx';
-import Friends from './pages/Friends.jsx';
-import DominoPlay from './pages/Games/DominoPlay.jsx';
-import Wallet from './pages/Wallet.jsx';
-import Tasks from './pages/Tasks.jsx';
-import Referral from './pages/Referral.jsx';
-import MyAccount from './pages/MyAccount.jsx';
-import Store from './pages/Store.jsx';
-import Messages from './pages/Messages.jsx';
-import Trending from './pages/Trending.jsx';
-import Notifications from './pages/Notifications.jsx';
+const Home = lazy(() => import('./pages/Home.jsx'));
+const Friends = lazy(() => import('./pages/Friends.jsx'));
+const DominoPlay = lazy(() => import('./pages/Games/DominoPlay.jsx'));
+const Wallet = lazy(() => import('./pages/Wallet.jsx'));
+const Tasks = lazy(() => import('./pages/Tasks.jsx'));
+const Referral = lazy(() => import('./pages/Referral.jsx'));
+const MyAccount = lazy(() => import('./pages/MyAccount.jsx'));
+const Store = lazy(() => import('./pages/Store.jsx'));
+const Messages = lazy(() => import('./pages/Messages.jsx'));
+const Trending = lazy(() => import('./pages/Trending.jsx'));
+const Notifications = lazy(() => import('./pages/Notifications.jsx'));
 
-import HorseRacing from './pages/Games/HorseRacing.jsx';
-import SnakeAndLadder from './pages/Games/SnakeAndLadder.jsx';
-import SnakeMultiplayer from './pages/Games/SnakeMultiplayer.jsx';
-import SnakeResults from './pages/Games/SnakeResults.jsx';
-import Ludo from './pages/Games/Ludo.jsx';
-import Lobby from './pages/Games/Lobby.jsx';
-import Games from './pages/Games.jsx';
-import SpinPage from './pages/spin.tsx';
+const HorseRacing = lazy(() => import('./pages/Games/HorseRacing.jsx'));
+const SnakeAndLadder = lazy(() => import('./pages/Games/SnakeAndLadder.jsx'));
+const SnakeMultiplayer = lazy(() => import('./pages/Games/SnakeMultiplayer.jsx'));
+const SnakeResults = lazy(() => import('./pages/Games/SnakeResults.jsx'));
+const Ludo = lazy(() => import('./pages/Games/Ludo.jsx'));
+const Lobby = lazy(() => import('./pages/Games/Lobby.jsx'));
+const Games = lazy(() => import('./pages/Games.jsx'));
+const SpinPage = lazy(() => import('./pages/spin.tsx'));
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -35,6 +35,7 @@ export default function App() {
     <BrowserRouter>
       <TonConnectUIProvider manifestUrl={manifestUrl}>
         <Layout>
+          <Suspense fallback={null}>
           <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/friends" element={<Friends />} />
@@ -56,6 +57,7 @@ export default function App() {
           <Route path="/trending" element={<Trending />} />
           <Route path="/account" element={<MyAccount />} />
         </Routes>
+          </Suspense>
         </Layout>
       </TonConnectUIProvider>
     </BrowserRouter>

--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -21,6 +21,8 @@ export default function AvatarTimer({
         src={getAvatarUrl(photoUrl)}
         alt="player"
         className="w-10 h-10 rounded-full border-2 object-cover"
+        width="40"
+        height="40"
         style={{
           borderColor: color || '#fde047',
           boxShadow: isTurn ? `0 0 6px ${color || '#fde047'}` : undefined,

--- a/webapp/src/components/Branding.jsx
+++ b/webapp/src/components/Branding.jsx
@@ -4,11 +4,12 @@ export default function Branding({ scale = 1, offsetY = 0 }) {
   return (
     <div className="text-center py-6 space-y-2">
       <img
-        
         src="/assets/TonPlayGramLogo.jpg"
         alt="TonPlaygram Logo"
         className="mx-auto"
         style={{ transform: `scale(${scale})`, marginTop: offsetY }}
+        width="100"
+        height="100"
       />
     </div>
   );

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -128,10 +128,11 @@ export default function DailyCheckIn() {
 
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 text-center overflow-hidden">
       <img
-        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
-        alt=""
+        alt="Background"
+        width="1024"
+        height="1536"
       />
 
       {showPopup && (

--- a/webapp/src/components/GameCard.jsx
+++ b/webapp/src/components/GameCard.jsx
@@ -5,7 +5,7 @@ export default function GameCard({ title, description, link, icon }) {
   if (icon) {
     iconNode =
       typeof icon === 'string' ? (
-        <img src={icon} alt="" className="h-8 w-8 mx-auto" />
+        <img src={icon} alt={title} className="h-8 w-8 mx-auto" width="32" height="32" />
       ) : (
         <span className="text-3xl text-accent">{icon}</span>
       );

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -124,10 +124,11 @@ export default function MiningCard() {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-center overflow-hidden">
       <img
-        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
-        alt=""
+        alt="Background"
+        width="1024"
+        height="1536"
       />
       <div className="flex justify-center items-center space-x-1">
         <GiMining className="w-5 h-5 text-accent" />

--- a/webapp/src/components/ProfileCard.jsx
+++ b/webapp/src/components/ProfileCard.jsx
@@ -5,10 +5,11 @@ export default function ProfileCard() {
   return (
     <div className="relative bg-surface border border-border p-4 rounded-xl shadow-lg space-y-2 text-center overflow-hidden">
       <img
-        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
-        alt=""
+        alt="Background"
+        width="1024"
+        height="1536"
       />
       <FaUser className="text-accent text-3xl mx-auto" />
       <h3 className="text-lg font-bold text-text">Profile</h3>

--- a/webapp/src/components/RoomPopup.jsx
+++ b/webapp/src/components/RoomPopup.jsx
@@ -20,10 +20,11 @@ export default function RoomPopup({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
         <img
-          
           src="/assets/TonPlayGramLogo.jpg"
           alt="TonPlaygram Logo"
           className="w-10 h-10 mx-auto"
+          width="40"
+          height="40"
         />
         <h3 className="text-lg font-bold text-center">Join a Room</h3>
         <p className="text-sm text-subtext text-center">Choose your token and amount</p>

--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -16,7 +16,6 @@ function CoinBurst({ token }) {
     <div className="coin-burst">
       {coins.map((c, i) => (
         <img
-          
           key={i}
           src={
             token.toUpperCase() === 'TPC'
@@ -24,6 +23,8 @@ function CoinBurst({ token }) {
               : `/icons/${token.toLowerCase()}.svg`
           }
           className="coin-img"
+          width="24"
+          height="24"
           style={{
             "--dx": `${c.dx}px`,
             "--delay": `${c.delay}s`,
@@ -132,7 +133,15 @@ export default function SnakeBoard({
         >
           {(iconImage || offsetVal != null) && (
             <span className="cell-marker">
-              {iconImage && <img  src={iconImage} className="cell-icon" />}
+              {iconImage && (
+                <img
+                  src={iconImage}
+                  alt="icon"
+                  className="cell-icon"
+                  width="24"
+                  height="24"
+                />
+              )}
               {offsetVal != null && (
                 <span
                   className={`offset-text ${cellType === 'snake' ? 'snake-text' : 'ladder-text'}`}
@@ -145,7 +154,7 @@ export default function SnakeBoard({
           {!cellType && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
-              <img  src="/assets/icons/Dice.png" className="dice-icon" />
+              <img src="/assets/icons/Dice.png" alt="dice" className="dice-icon" width="24" height="24" />
               <span className="dice-value">+{diceCells[num]}</span>
             </span>
           )}
@@ -268,10 +277,11 @@ export default function SnakeBoard({
                     ? '/icons/Usdt.png'
                     : '/assets/icons/TPCcoin.png'
                 }
-                
                 alt={token}
                 className="pot-icon"
-                />
+                width="24"
+                height="24"
+              />
               {players
                 .map((p, i) => ({ ...p, index: i }))
                 .filter((p) => p.position === FINAL_TILE)

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -156,10 +156,11 @@ export default function SpinGame() {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 flex flex-col items-center space-y-2 overflow-hidden">
       <img
-        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
-        alt=""
+        alt="Background"
+        width="1024"
+        height="1536"
       />
       <h3 className="text-lg font-bold text-text">Spin &amp; Win</h3>
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>

--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -17,7 +17,9 @@ export default function StoreAd() {
       <img
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
-        alt=""
+        alt="Background"
+        width="1024"
+        height="1536"
       />
       <div className="flex items-center justify-center space-x-1">
         <AiOutlineShop className="text-accent" />

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -86,7 +86,13 @@ export default function TasksCard() {
   return (
 
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden">
-      <img  src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt="Background"
+        width="1024"
+        height="1536"
+      />
 
       <h3 className="text-lg font-bold text-text flex items-center justify-center space-x-1"><AiOutlineCheckSquare className="text-accent" /><span>Tasks</span></h3>
 

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -45,10 +45,11 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="relative p-4 space-y-4 w-80 rounded-xl border border-border bg-surface text-text overflow-hidden">
         <img
-          
           src="/assets/SnakeLaddersbackground.png"
           className="background-behind-board object-cover"
-          alt=""
+          alt="Background"
+          width="1024"
+          height="1536"
         />
         <button
           onClick={onClose}
@@ -81,8 +82,10 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
               {counterparty.photo && (
                 <img
                   src={getAvatarUrl(counterparty.photo)}
-                  alt=""
+                  alt="User avatar"
                   className="w-8 h-8 rounded-full"
+                  width="32"
+                  height="32"
                 />
               )}
               <div className="text-left">

--- a/webapp/src/components/WalletCard.jsx
+++ b/webapp/src/components/WalletCard.jsx
@@ -34,10 +34,11 @@ export default function WalletCard() {
   return (
     <div className="relative bg-surface border border-border p-4 rounded-xl shadow-lg text-text space-y-2 overflow-hidden">
       <img
-        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
-        alt=""
+        alt="Background"
+        width="1024"
+        height="1536"
       />
       <h3 className="text-lg font-bold flex items-center space-x-2">
         <span>💰</span>

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -123,10 +123,11 @@ export default function Friends() {
     <>
       <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-text overflow-hidden">
       <img
-        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
-        alt=""
+        alt="Background"
+        width="1024"
+        height="1536"
       />
         <h2 className="text-xl font-bold text-center">Friends</h2>
 
@@ -190,7 +191,9 @@ export default function Friends() {
       <img
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
-        alt=""
+        alt="Background"
+        width="1024"
+        height="1536"
       />
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-semibold flex-1 text-center">Leaderboard</h3>

--- a/webapp/src/pages/Games/DominoPlay.jsx
+++ b/webapp/src/pages/Games/DominoPlay.jsx
@@ -124,10 +124,11 @@ export default function DominoPlay() {
     return (
       <div className="relative p-4 space-y-4 text-text flex flex-col items-center overflow-hidden">
         <img
-          
           src="/assets/icons/file_0000000091786243919bf8966d4d73ce.png"
           className="background-behind-board object-cover"
-          alt=""
+          alt="Background"
+          width="1024"
+          height="1536"
         />
         <h2 className="text-xl font-bold text-center">DominoPlay</h2>
         <div className="flex justify-center space-x-4">
@@ -140,10 +141,11 @@ export default function DominoPlay() {
   return (
     <div className="relative p-4 space-y-4 text-text flex flex-col items-center overflow-hidden">
       <img
-        
         src="/assets/icons/file_0000000091786243919bf8966d4d73ce.png"
         className="background-behind-board object-cover"
-        alt=""
+        alt="Background"
+        width="1024"
+        height="1536"
       />
       <h2 className="text-xl font-bold text-center">DominoPlay</h2>
       <p className="text-center">Stake: {amount} {token}</p>

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -250,10 +250,11 @@ export default function Lobby() {
   return (
     <div className="relative p-4 space-y-4 text-text">
       <img
-        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
-        alt=""
+        alt="Background"
+        width="1024"
+        height="1536"
       />
       <h2 className="text-xl font-bold text-center capitalize">{game} Lobby</h2>
       <p className="text-center text-sm">Online users: {online}</p>

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -113,10 +113,11 @@ export default function Home() {
         <div className="w-full mt-2 space-y-4">
           <div className="relative bg-surface border border-border rounded-xl p-4 flex items-center justify-around overflow-hidden">
             <img
-              
               src="/assets/SnakeLaddersbackground.png"
               className="background-behind-board object-cover"
-              alt=""
+              alt="Background"
+              width="1024"
+              height="1536"
             />
             <div className="flex-1 flex items-center justify-center space-x-1">
               <img src="/icons/TON.png" alt="TON" className="w-8 h-8" />
@@ -135,10 +136,11 @@ export default function Home() {
                 <span className="text-lg font-bold">Wallet</span>
               </div>
               <img
-                
                 src="/assets/SnakeLaddersbackground.png"
                 className="background-behind-board object-cover"
-                alt=""
+                alt="Background"
+                width="1024"
+                height="1536"
               />
 
               <p className="text-center text-xs text-subtext">Only to send and receive TPC coins</p>

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -68,7 +68,13 @@ export default function Tasks() {
 
     <div className="relative p-4 space-y-2 text-text">
 
-      <img  src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt="Background"
+        width="1024"
+        height="1536"
+      />
       <h2 className="text-xl font-bold">Tasks</h2>
 
       <ul className="space-y-2">


### PR DESCRIPTION
## Summary
- lazy load page components via `React.lazy`
- add meta description and sitemap links
- add robots.txt and sitemap.xml assets
- add descriptive alt text and fixed dimensions for images
- revert background image change to avoid adding binary assets

## Testing
- `npm test` *(fails: test suites report failures)*

------
https://chatgpt.com/codex/tasks/task_e_686a43d8fb408329b8ad4517278d9460