### PR TITLE
Fix AI names and tilt TPC pot coin

### DIFF
--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -268,9 +268,9 @@ export default function SnakeBoard({
                     ? '/icons/Usdt.png'
                     : '/assets/icons/TPCcoin.png'
                 }
-                
+
                 alt={token}
-                className="pot-icon"
+                className={`pot-icon${token === 'TPC' ? ' pot-icon-tpc' : ''}`}
                 />
               {players
                 .map((p, i) => ({ ...p, index: i }))

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -332,6 +332,11 @@ input:focus {
   z-index: 3;
 }
 
+.pot-icon-tpc {
+  transform: translate(-50%, -110%) translateZ(20px)
+    rotateX(calc(var(--board-angle, 58deg) * -1 - 10deg)) rotateZ(-65deg);
+}
+
 .token-three canvas {
   width: 100%;
   height: 100%;

--- a/webapp/src/utils/avatarUtils.js
+++ b/webapp/src/utils/avatarUtils.js
@@ -43,6 +43,15 @@ export function avatarToName(src) {
   if (!src.startsWith('/') && !src.startsWith('http')) {
     const key = emojiToNameMap[src];
     if (key) {
+      const flagCode = key.match(/^flag[-_]?([a-z]{2})$/i);
+      if (flagCode) {
+        const code = flagCode[1].toUpperCase();
+        try {
+          const name = regionNames?.of(code);
+          if (name) return name;
+        } catch {}
+        return code;
+      }
       if (/^[a-z]{2}$/i.test(key)) {
         const code = key.toUpperCase();
         try {
@@ -51,10 +60,15 @@ export function avatarToName(src) {
         } catch {}
         return code;
       }
-      return key
+      let name = key
         .replace(/_/g, ' ')
         .replace(/\b\w/g, (c) => c.toUpperCase())
-        .replace(/^Flag\s+/i, '');
+        .replace(/^Flag\s+/i, '')
+        .replace(/^Face\s+Of\s+/i, '')
+        .replace(/\bFace\b/gi, '')
+        .replace(/\s{2,}/g, ' ')
+        .trim();
+      return name;
     }
     return '';
   }


### PR DESCRIPTION
## Summary
- improve avatar name resolution for flags and faces
- tilt the TPC pot coin

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_686a43c328348329b7a5b3ecaa1340f7