### PR TITLE
Add helmet to Express server

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -15,6 +15,7 @@
     "https-proxy-agent": "^7.0.2",
     "mongodb-memory-server": "^10.1.4",
     "mongoose": "^7.6.0",
+    "helmet": "^8.1.0",
     "socket.io": "^4.7.5",
     "telegraf": "^4.12.2",
     "tonweb": "^0.0.66",

--- a/bot/server.js
+++ b/bot/server.js
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import express from 'express';
 import cors from 'cors';
+import helmet from 'helmet';
 import bot from './bot.js';
 import { sendInviteNotification, getInviteUrl } from './utils/notifications.js';
 import mongoose from 'mongoose';
@@ -44,6 +45,7 @@ if (!process.env.MONGODB_URI) {
 
 const PORT = process.env.PORT || 3000;
 const app = express();
+app.use(helmet());
 app.use(cors());
 const httpServer = http.createServer(app);
 const io = new SocketIOServer(httpServer, { cors: { origin: '*' } });


### PR DESCRIPTION
## Summary
- install helmet middleware for the bot
- apply helmet early in `bot/server.js`

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_686a4ffc38788329b5b484dc375bf1d0