### PR TITLE
Fix AI avatar names and adjust pot icon tilt

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -327,7 +327,7 @@ input:focus {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -110%) translateZ(20px)
-    rotateX(calc(var(--board-angle, 58deg) * -1 - 10deg));
+    rotateX(calc(var(--board-angle, 58deg) * -1 - 7deg));
   pointer-events: none;
   z-index: 3;
 }

--- a/webapp/src/utils/avatarUtils.js
+++ b/webapp/src/utils/avatarUtils.js
@@ -43,18 +43,21 @@ export function avatarToName(src) {
   if (!src.startsWith('/') && !src.startsWith('http')) {
     const key = emojiToNameMap[src];
     if (key) {
-      if (/^[a-z]{2}$/i.test(key)) {
-        const code = key.toUpperCase();
+      let normalized = key.replace(/^flag[-_]+/i, '');
+      normalized = normalized
+        .replace(/^face[-_]+of[-_]+/i, '')
+        .replace(/^face[-_]+/i, '');
+      if (/^[a-z]{2}$/i.test(normalized)) {
+        const code = normalized.toUpperCase();
         try {
           const name = regionNames?.of(code);
           if (name) return name;
         } catch {}
         return code;
       }
-      return key
+      return normalized
         .replace(/_/g, ' ')
-        .replace(/\b\w/g, (c) => c.toUpperCase())
-        .replace(/^Flag\s+/i, '');
+        .replace(/\b\w/g, (c) => c.toUpperCase());
     }
     return '';
   }


### PR DESCRIPTION
## Summary
- show concise AI player names from avatars
- tilt the TPC pot icon slightly more

## Testing
- `npm install`
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686a5852fb688329aca10b5144f9772d