### PR TITLE
Add 3D ludo example

### DIFF
--- a/ludo_game_threejs.html
+++ b/ludo_game_threejs.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3D Ludo Game</title>
+  <style>
+    body { margin: 0; overflow: hidden; }
+    #board { width: 100vw; height: 100vh; display: block; }
+  </style>
+</head>
+<body>
+  <canvas id="board"></canvas>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script>
+    // ----- Core Three.js Setup -----
+    const canvas = document.getElementById('board');
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 1, 1000);
+    camera.position.set(0, 40, 40);
+    camera.lookAt(0, 0, 0);
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.shadowMap.enabled = true;
+
+    // ----- Lights -----
+    const ambient = new THREE.AmbientLight(0xffffff, 0.4);
+    scene.add(ambient);
+    const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+    directional.position.set(10, 20, 10);
+    directional.castShadow = true;
+    scene.add(directional);
+
+    // ----- Board Constants & Path Mapping -----
+    const TILE_SIZE = 2;
+    const PATH_LENGTH = 52;
+    const START_POSITIONS = {
+      red: { x: -9, z: 9 },
+      green: { x: 9, z: 9 },
+      yellow: { x: 9, z: -9 },
+      blue: { x: -9, z: -9 }
+    };
+    let globalPath = [];
+
+    // Generate global path coordinates
+    (function() {
+      const coords = [];
+      // Top row (left->right)
+      for (let i = -6; i <= 6; i += TILE_SIZE) coords.push({ x: i, z: 8 });
+      // Right column (top->bottom)
+      for (let i = 6; i >= -6; i -= TILE_SIZE) coords.push({ x: 8, z: i });
+      // Bottom row (right->left)
+      for (let i = 6; i >= -6; i -= TILE_SIZE) coords.push({ x: i, z: -8 });
+      // Left column (bottom->top)
+      for (let i = -6; i <= 6; i += TILE_SIZE) coords.push({ x: -8, z: i });
+      globalPath = coords;
+    })();
+
+    // ----- Board Tiles -----
+    function createTile(x, z, color=0xdddddd) {
+      const geom = new THREE.BoxGeometry(TILE_SIZE, 0.5, TILE_SIZE);
+      const mat = new THREE.MeshLambertMaterial({ color });
+      const mesh = new THREE.Mesh(geom, mat);
+      mesh.position.set(x, 0, z);
+      mesh.receiveShadow = true;
+      scene.add(mesh);
+      return mesh;
+    }
+
+    // Draw path
+    globalPath.forEach((p, idx) => {
+      createTile(p.x, p.z, idx % 2 ? 0xffffff : 0xeeeeee);
+    });
+
+    // Home bases (prism style)
+    Object.entries(START_POSITIONS).forEach(([clr, pos]) => {
+      const shape = new THREE.Shape();
+      const s = TILE_SIZE * 4;
+      shape.moveTo(0, 0);
+      shape.lineTo(s, 0);
+      shape.lineTo(s, s);
+      shape.lineTo(0, s);
+      shape.lineTo(0, 0);
+      const extrudeSettings = { depth: 1, bevelEnabled: false };
+      const geom = new THREE.ExtrudeGeometry(shape, extrudeSettings);
+      const mat = new THREE.MeshLambertMaterial({ color: clr });
+      const mesh = new THREE.Mesh(geom, mat);
+      mesh.rotation.x = -Math.PI/2;
+      mesh.position.set(pos.x - 4, 0.25, pos.z - 4);
+      mesh.castShadow = true;
+      scene.add(mesh);
+    });
+
+    // ----- Tokens -----
+    class Token {
+      constructor(color, startIndex) {
+        this.color = color;
+        this.index = startIndex;
+        const geom = new THREE.SphereGeometry(0.7, 16, 16);
+        const mat = new THREE.MeshLambertMaterial({ color });
+        this.mesh = new THREE.Mesh(geom, mat);
+        scene.add(this.mesh);
+        this.setPositionByIndex(startIndex);
+      }
+      setPositionByIndex(i) {
+        const pos = globalPath[i % PATH_LENGTH];
+        this.mesh.position.set(pos.x, 1, pos.z);
+      }
+      move(steps, onComplete) {
+        const start = this.index;
+        const end = (this.index + steps) % PATH_LENGTH;
+        let progress = 0;
+        const path = [];
+        for (let j = 1; j <= steps; j++)
+          path.push(globalPath[(start + j) % PATH_LENGTH]);
+        const animate = () => {
+          if (progress < path.length) {
+            const p = path[progress];
+            this.mesh.position.lerpVectors(
+              new THREE.Vector3(path[progress - 1]?.x || globalPath[start].x, 1, path[progress -1]?.z || globalPath[start].z),
+              new THREE.Vector3(p.x, 1, p.z),
+              0.1
+            );
+            if (this.mesh.position.distanceTo(new THREE.Vector3(p.x,1,p.z)) < 0.05) {
+              progress++;
+            }
+            requestAnimationFrame(animate);
+          } else {
+            this.index = end;
+            onComplete && onComplete();
+          }
+        };
+        animate();
+      }
+    }
+
+    // ----- Game Logic -----
+    class LudoGame {
+      constructor() {
+        this.players = ['red','green','yellow','blue'];
+        this.tokens = [];
+        this.players.forEach((clr, idx) => {
+          for (let t=0; t<4; t++)
+            this.tokens.push(new Token(clr, idx*13));
+        });
+      }
+      playTurn(playerIndex, diceValue) {
+        // Choose token (simple: first token)
+        const tok = this.tokens.find(t=>t.color===this.players[playerIndex]);
+        tok.move(diceValue, ()=> console.log(`${tok.color} moved ${diceValue}`));
+      }
+    }
+
+    const game = new LudoGame();
+
+    // Example: move red by 4 steps on click
+    window.addEventListener('click', ()=> game.playTurn(0, 4));
+
+    // ----- Render Loop -----
+    function animate() {
+      requestAnimationFrame(animate);
+      renderer.render(scene, camera);
+    }
+    animate();
+
+    // ----- Responsive -----
+    window.addEventListener('resize', () => {
+      camera.aspect = window.innerWidth/window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `ludo_game_threejs.html` with a standalone example of a 3D ludo board using three.js

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_686a82e4f00883298b9b3c43da9242b4