### PR TITLE
Add board frame and token display

### DIFF
--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -152,7 +152,7 @@ export default function SnakeBoard({
               )}
             </span>
           )}
-          {!cellType && <span className="cell-number">{num}</span>}
+          <span className="cell-number">{num}</span>
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
               <img
@@ -203,6 +203,12 @@ export default function SnakeBoard({
               {offsetPopup.amount}
             </span>
           )}
+          <div className="cell-tokens">
+            <span className="simple-token token-blue" />
+            <span className="simple-token token-yellow" />
+            <span className="simple-token token-green" />
+            <span className="simple-token token-red" />
+          </div>
         </div>
       );
     }
@@ -256,9 +262,10 @@ export default function SnakeBoard({
         }}
       >
         <div className="snake-board-tilt">
-          <div
-            ref={gridRef}
-            className="snake-board-grid grid gap-x-1 gap-y-2 relative mx-auto"
+          <div className="snake-board-frame">
+            <div
+              ref={gridRef}
+              className="snake-board-grid grid gap-x-1 gap-y-2 relative mx-auto"
             style={{
               width: `${cellWidth * COLS}px`,
               height: `${cellHeight * ROWS + offsetYMax}px`,
@@ -270,7 +277,7 @@ export default function SnakeBoard({
               '--board-height': `${cellHeight * ROWS + offsetYMax}px`,
               '--board-angle': `${angle}deg`,
               '--final-scale': finalScale,
-              transform: `translate(${boardXOffset}px, ${boardYOffset}px) translateZ(${boardZOffset}px) rotateX(${angle}deg) scale(0.9)`,
+              transform: `translate(${boardXOffset}px, ${boardYOffset}px) translateZ(${boardZOffset}px) rotateZ(-45deg) rotateX(${angle}deg) scale(0.9)`,
             }}
           >
             {tiles}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -92,6 +92,15 @@ input:focus {
   transition: transform 0.3s ease; /* ✅ scaling transition */
 }
 
+/* Yellow frame surrounding the entire board */
+.snake-board-frame {
+  border: 12px solid #facc15;
+  border-radius: 1rem;
+  padding: 0.25rem;
+  display: inline-block;
+  box-sizing: content-box;
+}
+
 
 /* Full-screen stage behind the Snake & Ladder board */
 .background-behind-board {
@@ -1353,3 +1362,27 @@ input:focus {
     opacity: 0;
   }
 }
+
+/* Tokens displayed in every board cell */
+.cell-tokens {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  place-items: center;
+  transform: translateZ(8px);
+  pointer-events: none;
+}
+
+.simple-token {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  border: 1px solid #000;
+}
+
+.token-blue { background-color: #3b82f6; }
+.token-yellow { background-color: #eab308; }
+.token-green { background-color: #16a34a; }
+.token-red { background-color: #dc2626; }


### PR DESCRIPTION
## Summary
- show numbers on all snake board tiles
- surround board with yellow frame and rotate view
- display four coloured tokens in each tile

## Testing
- `npm test` *(fails: cannot find package `dotenv`)*

------
https://chatgpt.com/codex/tasks/task_e_686a8e404bfc8329990d36d666d47ea3