### PR TITLE
Add 3D domino table

### DIFF
--- a/webapp/src/components/DominoBoard.jsx
+++ b/webapp/src/components/DominoBoard.jsx
@@ -3,10 +3,12 @@ import DominoPiece from './DominoPiece.jsx';
 
 export default function DominoBoard({ pieces = [] }) {
   return (
-    <div className="domino-board">
-      {pieces.map((p, i) => (
-        <DominoPiece key={i} left={p.left} right={p.right} />
-      ))}
+    <div className="domino-table">
+      <div className="domino-board">
+        {pieces.map((p, i) => (
+          <DominoPiece key={i} left={p.left} right={p.right} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1205,8 +1205,28 @@ input:focus {
 }
 
 
+
+/* Container holding the domino board table */
+.domino-table {
+  @apply board-3d flex items-center justify-center;
+  width: 100%;
+  max-width: 450px;
+  height: 60vh;
+  margin: 0 auto;
+  position: relative;
+}
+
+/* Top surface of the table */
 .domino-board {
-  @apply flex flex-wrap justify-center items-center gap-2 board-3d;
+  @apply flex flex-wrap justify-center items-center gap-2;
+  width: 100%;
+  height: 100%;
+  transform: rotateX(20deg) translateZ(-20px);
+  transform-origin: bottom center;
+  border-radius: 1rem;
+  background: radial-gradient(circle at 50% 40%, #137a1f, #055613);
+  border: 16px solid #8b4513;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
 }
 
 .domino-piece {


### PR DESCRIPTION
## Summary
- redesign Domino board with a 3D poker-style table
- wrap board pieces inside the new table container

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_686a8f6e3c7883299813496cbab0c7e7