### PR TITLE
Improve domino piece rendering

### DIFF
--- a/webapp/src/components/DominoBoard.jsx
+++ b/webapp/src/components/DominoBoard.jsx
@@ -1,13 +1,24 @@
 import React from 'react';
 import DominoPiece from './DominoPiece.jsx';
 
-export default function DominoBoard({ pieces = [] }) {
+export default function DominoBoard({ pieces = [], highlight = {}, onPlaceLeft, onPlaceRight }) {
   return (
     <div className="domino-table">
       <div className="domino-board">
+        {highlight.left && (
+          <div className="highlight-slot" onClick={onPlaceLeft} />
+        )}
         {pieces.map((p, i) => (
-          <DominoPiece key={i} left={p.left} right={p.right} />
+          <DominoPiece
+            key={i}
+            left={p.left}
+            right={p.right}
+            vertical={p.left !== p.right}
+          />
         ))}
+        {highlight.right && (
+          <div className="highlight-slot" onClick={onPlaceRight} />
+        )}
       </div>
     </div>
   );

--- a/webapp/src/components/DominoPiece.jsx
+++ b/webapp/src/components/DominoPiece.jsx
@@ -1,11 +1,54 @@
 import React from 'react';
 
+const dotPositions = {
+  0: [],
+  1: [[50, 50]],
+  2: [[25, 25], [75, 75]],
+  3: [[25, 25], [50, 50], [75, 75]],
+  4: [
+    [25, 25],
+    [25, 75],
+    [75, 25],
+    [75, 75],
+  ],
+  5: [
+    [25, 25],
+    [25, 75],
+    [50, 50],
+    [75, 25],
+    [75, 75],
+  ],
+  6: [
+    [25, 25],
+    [25, 50],
+    [25, 75],
+    [75, 25],
+    [75, 50],
+    [75, 75],
+  ],
+};
+
+function renderHalf(value) {
+  const dots = dotPositions[value] || [];
+  return (
+    <div className="domino-half">
+      {dots.map(([top, left], idx) => (
+        <span
+          key={idx}
+          className="domino-dot"
+          style={{ top: `${top}%`, left: `${left}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+
 export default function DominoPiece({ left, right, vertical = false }) {
   return (
-    <div className={`domino-piece ${vertical ? 'domino-vert' : ''}`}> 
-      <div className="domino-half">{left}</div>
+    <div className={`domino-piece ${vertical ? 'domino-vert' : ''}`}>
+      {renderHalf(left)}
       <span className="domino-divider" />
-      <div className="domino-half">{right}</div>
+      {renderHalf(right)}
     </div>
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1253,6 +1253,26 @@ input:focus {
   transform-style: preserve-3d;
 }
 
+.domino-piece.domino-vert {
+  width: 2rem;
+  height: 4rem;
+  flex-direction: column;
+  padding: 0.25rem 0;
+}
+
+.domino-piece.domino-vert .domino-divider {
+  left: 0.15rem;
+  right: 0.15rem;
+  top: 50%;
+  width: auto;
+  height: 2px;
+}
+
+.domino-piece.domino-vert .domino-half {
+  width: 100%;
+  height: 50%;
+}
+
 .domino-divider {
   position: absolute;
   top: 0.15rem;
@@ -1264,11 +1284,27 @@ input:focus {
 }
 
 .domino-half {
+  position: relative;
   width: 50%;
-  text-align: center;
-  font-weight: bold;
-  font-size: 1rem;
+  height: 100%;
   z-index: 1;
+}
+
+.domino-dot {
+  position: absolute;
+  width: 0.5rem;
+  height: 0.5rem;
+  background: #000;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.highlight-slot {
+  width: 2rem;
+  height: 4rem;
+  border: 2px dashed yellow;
+  border-radius: 0.25rem;
+  margin: 0 0.25rem;
 }
 .ludo-board-tilt {
 

--- a/webapp/src/pages/Games/DominoPlay.jsx
+++ b/webapp/src/pages/Games/DominoPlay.jsx
@@ -15,6 +15,8 @@ export default function DominoPlay() {
   const [board, setBoard] = useState([]);
   const [turn, setTurn] = useState(0);
   const [winner, setWinner] = useState(null);
+  const [highlight, setHighlight] = useState({ left: false, right: false });
+  const [selectedIndex, setSelectedIndex] = useState(null);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -55,6 +57,21 @@ export default function DominoPlay() {
     const piece = hands[0][idx];
     if (!canPlay(piece)) return;
     placePiece(0, idx, piece);
+    setHighlight({ left: false, right: false });
+    setSelectedIndex(null);
+  };
+
+  const showHighlight = (piece) => {
+    if (board.length === 0) {
+      setHighlight({ left: true, right: true });
+      return;
+    }
+    const leftEnd = board[0].left;
+    const rightEnd = board[board.length - 1].right;
+    setHighlight({
+      left: piece.left === leftEnd || piece.right === leftEnd,
+      right: piece.left === rightEnd || piece.right === rightEnd,
+    });
   };
 
   const canPlay = (piece) => {
@@ -136,11 +153,28 @@ export default function DominoPlay() {
       <h2 className="text-xl font-bold text-center">DominoPlay</h2>
       <p className="text-center">Stake: {amount} {token}</p>
       {winner !== null && <div className="text-center">Player {winner + 1} wins!</div>}
-      <DominoBoard pieces={board} />
+      <DominoBoard
+        pieces={board}
+        highlight={highlight}
+        onPlaceLeft={() => selectedIndex !== null && play(selectedIndex)}
+        onPlaceRight={() => selectedIndex !== null && play(selectedIndex)}
+      />
       <div className="flex space-x-2 overflow-x-auto">
         {hands[0].map((p, i) => (
-          <div key={i} onClick={() => play(i)} className="cursor-pointer">
-            <DominoPiece left={p.left} right={p.right} />
+          <div
+            key={i}
+            onClick={() => {
+              if (selectedIndex === i) {
+                play(i);
+                setSelectedIndex(null);
+              } else {
+                showHighlight(p);
+                setSelectedIndex(i);
+              }
+            }}
+            className="cursor-pointer"
+          >
+            <DominoPiece left={p.left} right={p.right} vertical />
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- render domino pieces with black dots using new `DominoPiece` component logic
- orient dominoes vertically or horizontally based on play
- highlight available positions on the board when a piece is selected
- show yellow placeholder slots using `DominoBoard`

## Testing
- `npm test` *(fails: snake API endpoints timeout)*

------
https://chatgpt.com/codex/tasks/task_e_686a995fc42883299ee099fc46f4c10e