### PR TITLE
Remove daily popup check-in, add inline claim link

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -139,42 +139,6 @@ export default function DailyCheckIn() {
         aria-hidden="true"
         loading="lazy"
       />
-
-      {showPopup && (
-
-        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-
-          <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text w-80">
-
-            <img
-              src="/assets/TonPlayGramLogo.jpg"
-              alt="TonPlaygram Logo"
-              loading="lazy"
-              className="w-10 h-10 mx-auto"
-            />
-
-            <h3 className="text-lg font-bold">Daily Check-In</h3>
-
-            <p className="text-sm text-subtext">Come back daily to keep your streak!</p>
-
-            <button
-
-              onClick={handleCheckIn}
-
-              className="px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded w-full"
-
-            >
-
-              Check in
-
-            </button>
-
-          </div>
-
-        </div>
-
-      )}
-
       {reward !== null && (
 
         <RewardPopup
@@ -184,9 +148,16 @@ export default function DailyCheckIn() {
 
       )}
 
+
       <h3 className="text-lg font-bold text-text">Daily Streaks</h3>
 
       <div className="flex space-x-2 overflow-x-auto justify-center">{progress}</div>
+
+      {showPopup && (
+        <button onClick={handleCheckIn} className="text-brand-gold font-bold">
+          Claim
+        </button>
+      )}
 
       <p className="text-sm text-subtext">Check in each day for increasing rewards.</p>
 


### PR DESCRIPTION
## Summary
- update DailyCheckIn component
  - remove popup overlay
  - provide inline **Claim** button on the streak section

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_686a9edee3c88329bba6c8e3f8eda359