### PR TITLE
Add Domino ZigZag board

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -5,6 +5,7 @@ import { TonConnectUIProvider, TonConnect } from '@tonconnect/ui-react';
 import Home from './pages/Home.jsx';
 const Friends = React.lazy(() => import('./pages/Friends.jsx'));
 const DominoPlay = React.lazy(() => import('./pages/Games/DominoPlay.jsx'));
+const DominoZigZag = React.lazy(() => import('./pages/Games/DominoZigZag.jsx'));
 const Wallet = React.lazy(() => import('./pages/Wallet.jsx'));
 const Tasks = React.lazy(() => import('./pages/Tasks.jsx'));
 const Referral = React.lazy(() => import('./pages/Referral.jsx'));
@@ -45,6 +46,7 @@ export default function App() {
           <Route path="/games/:game/lobby" element={<Lobby />} />
             <Route path="/games/horse" element={<HorseRacing />} />
           <Route path="/games/domino" element={<DominoPlay />} />
+          <Route path="/games/domino-zigzag" element={<DominoZigZag />} />
           <Route path="/games/ludo" element={<Ludo />} />
           <Route path="/games/snake" element={<SnakeAndLadder />} />
           <Route path="/games/snake/mp" element={<SnakeMultiplayer />} />

--- a/webapp/src/components/DominoPiece.jsx
+++ b/webapp/src/components/DominoPiece.jsx
@@ -44,6 +44,10 @@ function renderHalf(value) {
 }
 
 export default function DominoPiece({ left, right, vertical = false, style = {} }) {
+  const isBack = left < 0 || right < 0;
+  if (isBack) {
+    return <div className={`domino-piece ${vertical ? 'domino-vert' : ''} domino-back`} style={style} />;
+  }
   return (
     <div className={`domino-piece ${vertical ? 'domino-vert' : ''}`} style={style}>
       {renderHalf(left)}

--- a/webapp/src/components/DominoZigZagBoard.jsx
+++ b/webapp/src/components/DominoZigZagBoard.jsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useRef, useState } from 'react';
+import DominoPiece from './DominoPiece.jsx';
+
+export default function DominoZigZagBoard({ pieces = [], highlight = null, onSlotsChange }) {
+  const boardRef = useRef(null);
+  const [positions, setPositions] = useState([]);
+  const [slotLeft, setSlotLeft] = useState(null);
+  const [slotRight, setSlotRight] = useState(null);
+
+  const H_WIDTH = 64;
+  const H_HEIGHT = 32;
+  const V_WIDTH = 32;
+  const V_HEIGHT = 64;
+
+  const layout = (list, width, height) => {
+    let dir = 'right';
+    let x = width / 2 - H_WIDTH;
+    let y = height / 2 - H_HEIGHT / 2;
+    const pos = [];
+
+    list.forEach((piece, idx) => {
+      const isDouble = piece.left === piece.right;
+      const vertical = (dir === 'up' || dir === 'down') && !isDouble;
+      const w = vertical ? V_WIDTH : H_WIDTH;
+      const h = vertical ? V_HEIGHT : H_HEIGHT;
+
+      if (x < 0) x = 0;
+      if (x + w > width) x = width - w;
+      if (y < 0) y = 0;
+      if (y + h > height) y = height - h;
+
+      pos.push({ left: x, top: y, vertical });
+
+      const next = list[idx + 1];
+      const nextDouble = next && next.left === next.right;
+      const nextVert = (dir === 'up' || dir === 'down') && !nextDouble;
+      const nextW = nextVert ? V_WIDTH : H_WIDTH;
+      const nextH = nextVert ? V_HEIGHT : H_HEIGHT;
+
+      if (dir === 'right') {
+        if (x + w + nextW > width) {
+          dir = 'down';
+          y += h;
+        } else {
+          x += w;
+        }
+      } else if (dir === 'down') {
+        if (y + h + nextH > height) {
+          dir = 'left';
+          x -= w;
+        } else {
+          y += h;
+        }
+      } else if (dir === 'left') {
+        if (x - nextW < 0) {
+          dir = 'up';
+          y -= h;
+        } else {
+          x -= w;
+        }
+      } else if (dir === 'up') {
+        if (y - nextH < 0) {
+          dir = 'right';
+          x += w;
+        } else {
+          y -= h;
+        }
+      }
+    });
+
+    return { pos, dir, x, y };
+  };
+
+  useEffect(() => {
+    const board = boardRef.current;
+    if (!board) return;
+    const boardWidth = board.clientWidth;
+    const boardHeight = board.clientHeight;
+
+    const { pos } = layout(pieces, boardWidth, boardHeight);
+    setPositions(pos);
+
+    let leftPos = null;
+    let rightPos = null;
+    if (highlight && (highlight.left || highlight.right)) {
+      if (highlight.left) {
+        const { pos: p } = layout([highlight.piece, ...pieces], boardWidth, boardHeight);
+        leftPos = p[0];
+        setSlotLeft(leftPos);
+      } else {
+        setSlotLeft(null);
+      }
+      if (highlight.right) {
+        const { pos: p } = layout([...pieces, highlight.piece], boardWidth, boardHeight);
+        rightPos = p[p.length - 1];
+        setSlotRight(rightPos);
+      } else {
+        setSlotRight(null);
+      }
+    } else {
+      setSlotLeft(null);
+      setSlotRight(null);
+    }
+    if (onSlotsChange) onSlotsChange({ left: leftPos, right: rightPos });
+  }, [pieces, highlight, onSlotsChange]);
+
+  return (
+    <div className="domino-table">
+      <div ref={boardRef} className="domino-board relative">
+        {positions.map((pos, i) => (
+          <DominoPiece
+            key={i}
+            left={pieces[i].left}
+            right={pieces[i].right}
+            vertical={pos.vertical}
+            style={{ position: 'absolute', top: pos.top, left: pos.left }}
+          />
+        ))}
+        {highlight && highlight.left && slotLeft && (
+          <div
+            className={`highlight-slot ${slotLeft.vertical ? 'domino-vert' : ''}`}
+            style={{ position: 'absolute', top: slotLeft.top, left: slotLeft.left }}
+          />
+        )}
+        {highlight && highlight.right && slotRight && (
+          <div
+            className={`highlight-slot ${slotRight.vertical ? 'domino-vert' : ''}`}
+            style={{ position: 'absolute', top: slotRight.top, left: slotRight.left }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1254,6 +1254,15 @@ input:focus {
   transition: top 0.3s ease, left 0.3s ease, transform 0.3s ease;
   animation: domino-drop 0.3s ease;
 }
+.domino-piece.domino-back {
+  background: repeating-linear-gradient(
+    45deg,
+    #999,
+    #999 10px,
+    #ccc 10px,
+    #ccc 20px
+  );
+}
 
 .domino-piece.domino-vert {
   width: 2rem;
@@ -1302,11 +1311,21 @@ input:focus {
 }
 
 .highlight-slot {
-  width: 2rem;
-  height: 4rem;
+  width: 4rem;
+  height: 2rem;
   border: 2px dashed yellow;
   border-radius: 0.25rem;
   margin: 0 0.25rem;
+  pointer-events: none;
+  position: absolute;
+}
+.highlight-slot.domino-vert {
+  width: 2rem;
+  height: 4rem;
+}
+
+.domino-stack > div {
+  margin-bottom: 0.25rem;
 }
 
 @keyframes domino-drop {

--- a/webapp/src/pages/Games/DominoZigZag.jsx
+++ b/webapp/src/pages/Games/DominoZigZag.jsx
@@ -1,0 +1,190 @@
+import { useState, useEffect } from 'react';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import DominoZigZagBoard from '../../components/DominoZigZagBoard.jsx';
+import DominoPiece from '../../components/DominoPiece.jsx';
+import { generateDominoSet, shuffle } from '../../utils/domino.js';
+
+const HAND_SIZE = 7;
+
+function initGame() {
+  const deck = shuffle(generateDominoSet());
+  const hands = [[], []];
+  for (let i = 0; i < HAND_SIZE; i++) {
+    for (let p = 0; p < 2; p++) {
+      hands[p].push(deck.pop());
+    }
+  }
+
+  let firstIndex = deck.findIndex((d) => d.left === d.right);
+  if (firstIndex === -1) firstIndex = deck.length - 1;
+  for (let v = 6; v >= 0; v--) {
+    const i0 = hands[0].findIndex((d) => d.left === v && d.right === v);
+    const i1 = hands[1].findIndex((d) => d.left === v && d.right === v);
+    if (i0 !== -1) {
+      const piece = hands[0].splice(i0, 1)[0];
+      return { hands, deck, board: [piece], startPlayer: 1 };
+    }
+    if (i1 !== -1) {
+      const piece = hands[1].splice(i1, 1)[0];
+      return { hands, deck, board: [piece], startPlayer: 0 };
+    }
+  }
+  const piece = deck.splice(firstIndex, 1)[0];
+  return { hands, deck, board: [piece], startPlayer: 0 };
+}
+
+export default function DominoZigZag() {
+  useTelegramBackButton();
+  const [game, setGame] = useState(() => initGame());
+  const [turn, setTurn] = useState(game.startPlayer);
+  const [selected, setSelected] = useState(null); // {index, piece}
+  const [highlight, setHighlight] = useState(null); // {left:true,right:false,piece}
+  const [winner, setWinner] = useState(null);
+  const [dragPos, setDragPos] = useState(null);
+  const [slots, setSlots] = useState({ left: null, right: null });
+
+  const boardEnds = () => {
+    const left = game.board[0].left;
+    const right = game.board[game.board.length - 1].right;
+    return { left, right };
+  };
+
+  const canPlay = (piece) => {
+    if (game.board.length === 0) return true;
+    const { left, right } = boardEnds();
+    return piece.left === left || piece.right === left || piece.left === right || piece.right === right;
+  };
+
+  const updateHighlight = (piece) => {
+    if (!piece) {
+      setHighlight(null);
+      return;
+    }
+    if (game.board.length === 0) {
+      setHighlight({ left: true, right: true, piece });
+      return;
+    }
+    const { left, right } = boardEnds();
+    setHighlight({
+      left: piece.left === left || piece.right === left,
+      right: piece.left === right || piece.right === right,
+      piece,
+    });
+  };
+
+  const placePiece = (side) => {
+    if (!selected) return;
+    const idx = selected.index;
+    const piece = game.hands[turn][idx];
+    if (!canPlay(piece)) return;
+    setGame((g) => {
+      const hands = g.hands.map((h) => [...h]);
+      const board = [...g.board];
+      hands[turn].splice(idx, 1);
+      if (side === 'left') {
+        const end = board[0].left;
+        if (piece.right === end) board.unshift({ left: piece.left, right: piece.right });
+        else board.unshift({ left: piece.right, right: piece.left });
+      } else {
+        const end = board[board.length - 1].right;
+        if (piece.left === end) board.push({ left: piece.left, right: piece.right });
+        else board.push({ left: piece.right, right: piece.left });
+      }
+      return { ...g, hands, board };
+    });
+    setSelected(null);
+    setHighlight(null);
+    checkWinner(turn);
+    setTurn((t) => (t === 0 ? 1 : 0));
+  };
+
+  const drawTile = (index) => {
+    if (game.deck.length <= 2) return;
+    setGame((g) => {
+      const deck = [...g.deck];
+      const hands = g.hands.map((h) => [...h]);
+      hands[turn].push(deck.splice(index, 1)[0]);
+      return { ...g, deck, hands };
+    });
+  };
+
+  const checkWinner = (player) => {
+    if (game.hands[player].length === 0) {
+      setWinner(player);
+    }
+  };
+
+  useEffect(() => {
+    if (selected) updateHighlight(selected.piece);
+  }, [selected, game.board]);
+
+  const startDrag = (idx, piece, e) => {
+    if (turn !== 0 || winner) return;
+    setSelected({ index: idx, piece });
+    setDragPos({ x: e.clientX, y: e.clientY });
+  };
+
+  const onDrag = (e) => {
+    if (!dragPos) return;
+    setDragPos({ x: e.clientX, y: e.clientY });
+  };
+
+  const endDrag = (e) => {
+    if (!dragPos) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = dragPos.x - rect.left;
+    const y = dragPos.y - rect.top;
+    if (highlight?.left && slotMatch(x, y, slots.left)) {
+      placePiece('left');
+    } else if (highlight?.right && slotMatch(x, y, slots.right)) {
+      placePiece('right');
+    }
+    setDragPos(null);
+  };
+
+  const slotMatch = (x, y, slot) => {
+    if (!slot) return false;
+    return (
+      x >= slot.left &&
+      x <= slot.left + (slot.vertical ? 32 : 64) &&
+      y >= slot.top &&
+      y <= slot.top + (slot.vertical ? 64 : 32)
+    );
+  };
+
+  return (
+    <div className="relative p-4 space-y-4 flex flex-col items-center overflow-hidden text-text" onPointerMove={onDrag} onPointerUp={endDrag}>
+      <h2 className="text-xl font-bold text-center">Domino ZigZag</h2>
+      {winner !== null && <div className="text-center">Player {winner + 1} wins!</div>}
+      <DominoZigZagBoard pieces={game.board} highlight={highlight} onSlotsChange={setSlots} />
+      <div className="flex space-x-2 overflow-x-auto">
+        {game.hands[turn].map((p, i) => (
+          <div key={i} className="cursor-pointer" onPointerDown={(e) => startDrag(i, p, e)}>
+            <DominoPiece left={p.left} right={p.right} vertical />
+          </div>
+        ))}
+      </div>
+      <div className="domino-stack flex flex-col absolute right-2 top-2">
+        {game.deck.map((p, i) => (
+          <div key={i} className={`cursor-pointer ${i >= game.deck.length - 2 ? 'opacity-50 pointer-events-none' : ''}`} onClick={() => drawTile(i)}>
+            <DominoPiece left={-1} right={-1} />
+          </div>
+        ))}
+      </div>
+      {dragPos && selected && (
+        <DominoPiece
+          left={selected.piece.left}
+          right={selected.piece.right}
+          vertical
+          style={{
+            position: 'fixed',
+            top: dragPos.y - 32,
+            left: dragPos.x - 16,
+            pointerEvents: 'none',
+            zIndex: 50,
+          }}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `DominoZigZagBoard` component for zig-zag layout with highlight slots
- add dragging logic and draw pile UI in new `DominoZigZag` page
- support face-down domino pieces
- expose domino-zigzag route
- tweak board styles for highlight slots and draw pile

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686aaecd8dc883298bd635cf66f8f960