### PR TITLE
Restore Adsgram SDK integration

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -50,10 +50,12 @@ cspDirectives['script-src'] = [
   ...cspDirectives['script-src'],
   'https://telegram.org',
   'https://accounts.google.com',
+  'https://adsgram.io',
 ];
 cspDirectives['connect-src'] = [
   ...(cspDirectives['connect-src'] || ["'self'"]),
   'https://raw.githubusercontent.com',
+  'https://adsgram.io',
 ];
 cspDirectives['img-src'] = [
   ...(cspDirectives['img-src'] || ["'self'"]),

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -27,6 +27,7 @@
       href="https://tonplaygramwebapp.onrender.com/"
     />
     <script src="https://telegram.org/js/telegram-web-app.js" defer></script>
+    <script src="https://adsgram.io/sdk.js"></script>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
     <link rel="preload" as="audio" href="/assets/sounds/spinning.mp3" />
     <link rel="preload" as="audio" href="/assets/sounds/successful.mp3" />

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -3,9 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
-    <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <title>TonPlaygram</title>
+      <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
+      <script src="https://telegram.org/js/telegram-web-app.js"></script>
+      <script src="https://adsgram.io/sdk.js"></script>
+      <title>TonPlaygram</title>
   </head>
   <body>
     <script src="/init.js"></script>


### PR DESCRIPTION
## Summary
- re-add Adsgram script and CSP rules

## Testing
- `npm test` *(fails: tests=15, pass=8, fail=3, cancelled=4)*

------
https://chatgpt.com/codex/tasks/task_e_686ad0b2068c8329a3e86c51a4ae3293