### PR TITLE
Fix invite notifications

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -395,7 +395,6 @@ app.post('/api/snake/invite', async (req, res) => {
         roomId,
         token,
         amount,
-        true,
       );
     } catch (err) {
       console.error('Failed to send Telegram notification:', err.message);
@@ -546,7 +545,6 @@ io.on('connection', (socket) => {
           roomId,
           token,
           amount,
-          true,
         );
       } catch (err) {
         console.error('Failed to send Telegram notification:', err.message);
@@ -632,7 +630,6 @@ io.on('connection', (socket) => {
               roomId,
               token,
               amount,
-              true,
             );
           } catch (err) {
             console.error('Failed to send Telegram notification:', err.message);

--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -2,7 +2,6 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { createCanvas, loadImage } from 'canvas';
 import { fetchTelegramInfo } from './telegram.js';
-import { transferInviteTpc } from './inviteTpc.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const coinPath = path.join(
@@ -117,7 +116,6 @@ export async function sendInviteNotification(
   roomId,
   token,
   amount,
-  sendToken = false,
 ) {
   let info;
   try {
@@ -144,20 +142,16 @@ export async function sendInviteNotification(
     ],
   };
 
-  if (sendToken) {
-    try {
-      await transferInviteTpc(fromId, toId, 1);
-    } catch (err) {
-      console.error('Failed to send invite TPC:', err.message);
-    }
-  }
 
   const photo = info?.photoUrl ? { url: info.photoUrl } : { source: coinPath };
-
-  await bot.telegram.sendPhoto(String(toId), photo, {
-    caption,
-    reply_markup: replyMarkup,
-  });
+  try {
+    await bot.telegram.sendPhoto(String(toId), photo, {
+      caption,
+      reply_markup: replyMarkup,
+    });
+  } catch (err) {
+    console.error('Failed to send invite photo:', err.message);
+  }
 
   // Also send a plain text notification like TPC receipts
   await sendTPCNotification(bot, toId, caption, replyMarkup);


### PR DESCRIPTION
## Summary
- fix Telegram invite image sending
- drop 1 TPC transfer on invites

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686adf7f80c48329b74762e1d75d1b0a