### PR TITLE
Undo card size changes

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -126,7 +126,7 @@ export default function DailyCheckIn() {
 
   return (
 
-    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 text-center overflow-hidden max-w-md mx-auto">
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 text-center overflow-hidden">
       <img
         
         src="/assets/SnakeLaddersbackground.png"
@@ -149,15 +149,15 @@ export default function DailyCheckIn() {
 
             />
 
-            <h3 className="text-2xl font-bold">Daily Check-In</h3>
+            <h3 className="text-lg font-bold">Daily Check-In</h3>
 
-            <p className="text-base text-subtext">Come back daily to keep your streak!</p>
+            <p className="text-sm text-subtext">Come back daily to keep your streak!</p>
 
             <button
 
               onClick={handleCheckIn}
 
-              className="px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded w-full text-lg"
+              className="px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded w-full"
 
             >
 

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -122,7 +122,7 @@ export default function MiningCard() {
   const minted = isMining ? Math.floor((elapsed / MINING_DURATION) * totalReward) : 0;
 
   return (
-    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-center overflow-hidden max-w-md mx-auto">
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-center overflow-hidden">
       <img
         
         src="/assets/SnakeLaddersbackground.png"

--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -13,7 +13,7 @@ const CATEGORY_ICONS = {
 export default function StoreAd() {
   const [category, setCategory] = useState(STORE_CATEGORIES[0]);
   return (
-    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden max-w-md mx-auto">
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden">
       <img
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -85,7 +85,7 @@ export default function TasksCard() {
 
   return (
 
-    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden max-w-md mx-auto">
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden">
       <img  src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
 
       <h3 className="text-lg font-bold text-text flex items-center justify-center space-x-1"><AiOutlineCheckSquare className="text-accent" /><span>Tasks</span></h3>

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -111,7 +111,7 @@ export default function Home() {
         )}
 
         <div className="w-full mt-2 space-y-4">
-          <div className="relative bg-surface border border-border rounded-xl p-4 flex items-center justify-around overflow-hidden max-w-md mx-auto">
+          <div className="relative bg-surface border border-border rounded-xl p-4 flex items-center justify-around overflow-hidden">
             <img
               
               src="/assets/SnakeLaddersbackground.png"
@@ -128,7 +128,7 @@ export default function Home() {
             </div>
           </div>
 
-          <div className="relative max-w-md mx-auto">
+          <div className="relative">
             <div className="relative bg-surface border border-border rounded-xl p-4 pt-6 space-y-2 overflow-hidden">
               <div className="flex items-center justify-center space-x-1 mb-1">
                 <FaWallet className="text-primary" />


### PR DESCRIPTION
## Summary
- revert `max-w-md mx-auto` restrictions and text size tweaks
- restore card styles in DailyCheckIn, MiningCard, TasksCard, StoreAd, and Home page

## Testing
- `npm test` *(fails: cannot find dotenv & other packages)*

------
https://chatgpt.com/codex/tasks/task_e_686ae34504908329b19f2f39889b71e8