### PR TITLE
Fix card width

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -132,7 +132,7 @@ export default function DailyCheckIn() {
 
   return (
 
-    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 text-center overflow-hidden">
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 text-center overflow-hidden wide-card">
       <img
         
         src="/assets/SnakeLaddersbackground.png"

--- a/webapp/src/components/GameCard.jsx
+++ b/webapp/src/components/GameCard.jsx
@@ -12,7 +12,7 @@ export default function GameCard({ title, description, link, icon }) {
   }
 
   return (
-    <div className="relative bg-surface border border-border rounded-xl p-4 shadow-lg space-y-2 text-center overflow-hidden">
+    <div className="relative bg-surface border border-border rounded-xl p-4 shadow-lg space-y-2 text-center overflow-hidden wide-card">
       {iconNode}
       <h3 className="text-lg font-bold text-text">{title}</h3>
       {description && <p className="text-subtext text-sm">{description}</p>}

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -122,7 +122,7 @@ export default function MiningCard() {
   const minted = isMining ? Math.floor((elapsed / MINING_DURATION) * totalReward) : 0;
 
   return (
-    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-center overflow-hidden">
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-center overflow-hidden wide-card">
       <img
         
         src="/assets/SnakeLaddersbackground.png"

--- a/webapp/src/components/ProfileCard.jsx
+++ b/webapp/src/components/ProfileCard.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 export default function ProfileCard() {
   return (
-    <div className="relative bg-surface border border-border p-4 rounded-xl shadow-lg space-y-2 text-center overflow-hidden">
+    <div className="relative bg-surface border border-border p-4 rounded-xl shadow-lg space-y-2 text-center overflow-hidden wide-card">
       <img
         
         src="/assets/SnakeLaddersbackground.png"

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -154,7 +154,7 @@ export default function SpinGame() {
   const ready = freeSpins > 0 || canSpin(lastSpin);
 
   return (
-    <div className="relative bg-surface border border-border rounded-xl p-4 flex flex-col items-center space-y-2 overflow-hidden">
+    <div className="relative bg-surface border border-border rounded-xl p-4 flex flex-col items-center space-y-2 overflow-hidden wide-card">
       <img
         
         src="/assets/SnakeLaddersbackground.png"

--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -13,7 +13,7 @@ const CATEGORY_ICONS = {
 export default function StoreAd() {
   const [category, setCategory] = useState(STORE_CATEGORIES[0]);
   return (
-    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden">
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
       <img
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -29,7 +29,7 @@ export default function TasksCard() {
     telegramId = getTelegramId();
   } catch (err) {
     return (
-      <div className="bg-surface border border-border rounded-xl">
+      <div className="bg-surface border border-border rounded-xl wide-card">
         <LoginOptions />
       </div>
     );
@@ -73,7 +73,7 @@ export default function TasksCard() {
 
     return (
 
-      <div className="bg-surface border border-border rounded-xl p-4 text-subtext text-center">
+      <div className="bg-surface border border-border rounded-xl p-4 text-subtext text-center wide-card">
 
         Loading tasks...
 
@@ -85,7 +85,7 @@ export default function TasksCard() {
 
   return (
 
-    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden">
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
       <img  src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
 
       <h3 className="text-lg font-bold text-text flex items-center justify-center space-x-1"><AiOutlineCheckSquare className="text-accent" /><span>Tasks</span></h3>

--- a/webapp/src/components/WalletCard.jsx
+++ b/webapp/src/components/WalletCard.jsx
@@ -10,7 +10,7 @@ export default function WalletCard() {
     telegramId = getTelegramId();
   } catch (err) {
     return (
-      <div className="bg-surface border border-border rounded-xl">
+      <div className="bg-surface border border-border rounded-xl wide-card">
         <LoginOptions />
       </div>
     );
@@ -32,7 +32,7 @@ export default function WalletCard() {
   }, []);
 
   return (
-    <div className="relative bg-surface border border-border p-4 rounded-xl shadow-lg text-text space-y-2 overflow-hidden">
+    <div className="relative bg-surface border border-border p-4 rounded-xl shadow-lg text-text space-y-2 overflow-hidden wide-card">
       <img
         
         src="/assets/SnakeLaddersbackground.png"

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1204,6 +1204,11 @@ input:focus {
   box-shadow: 0 0 8px #00f7ff, 0 0 16px #00f7ff;
 }
 
+/* Utility class to widen cards edge-to-edge */
+.wide-card {
+  @apply -mx-4;
+}
+
 
 
 

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -121,7 +121,7 @@ export default function Friends() {
 
   return (
     <>
-      <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-text overflow-hidden -mx-4">
+      <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-text overflow-hidden wide-card">
       <img
         
         src="/assets/SnakeLaddersbackground.png"

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -111,7 +111,7 @@ export default function Home() {
         )}
 
         <div className="w-full mt-2 space-y-4">
-          <div className="relative bg-surface border border-border rounded-xl p-4 flex items-center justify-around overflow-hidden">
+          <div className="relative bg-surface border border-border rounded-xl p-4 flex items-center justify-around overflow-hidden wide-card">
             <img
               
               src="/assets/SnakeLaddersbackground.png"
@@ -129,7 +129,7 @@ export default function Home() {
           </div>
 
           <div className="relative">
-            <div className="relative bg-surface border border-border rounded-xl p-4 pt-6 space-y-2 overflow-hidden">
+            <div className="relative bg-surface border border-border rounded-xl p-4 pt-6 space-y-2 overflow-hidden wide-card">
               <div className="flex items-center justify-center space-x-1 mb-1">
                 <FaWallet className="text-primary" />
                 <span className="text-lg font-bold">Wallet</span>

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -127,7 +127,7 @@ export default function SpinPage() {
     <div className="p-4 space-y-6 flex flex-col items-center text-text">
       <h1 className="text-xl font-bold">Spin &amp; Win</h1>
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>
-      <div className="bg-surface border border-border rounded p-4 flex flex-col items-center space-y-2">
+      <div className="bg-surface border border-border rounded p-4 flex flex-col items-center space-y-2 wide-card">
         <div className="flex justify-center">
           <div className="mr-[-8px]">
             <SpinWheel


### PR DESCRIPTION
## Summary
- add `wide-card` utility class to stretch negative margin
- use the new class on all cards

## Testing
- `npm test` *(fails: Cannot find package 'dotenv', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686b7a4f819c8329b7e09b589f72949a