### PR TITLE
Adjust card alignment and width

### DIFF
--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -186,7 +186,7 @@ export default function Friends() {
       </section>
     </div>
 
-    <section id="leaderboard" className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden">
+    <section id="leaderboard" className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
       <img
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -6,7 +6,7 @@ export default function Games() {
   return (
     <div className="relative space-y-4 text-text">
       <h2 className="text-2xl font-bold text-center mt-4">Games</h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div className="space-y-4">
         <GameCard title="Snake & Ladder" icon="🎲" link="/games/snake/lobby" />
       </div>
     </div>

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -242,11 +242,11 @@ export default function MyAccount() {
         </div>
       </div>
 
-      <BalanceSummary />
+      <BalanceSummary className="bg-surface border border-border rounded-xl p-4 wide-card" />
 
       {profile && profile.accountId === DEV_ACCOUNT_ID && (
         <>
-          <div className="prism-box p-4 mt-4 space-y-2 w-80 mx-auto">
+          <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
             <label className="block font-semibold text-center">Top Up Developer Account</label>
             <input
               type="number"
@@ -264,7 +264,7 @@ export default function MyAccount() {
             </button>
           </div>
 
-          <div className="prism-box p-4 mt-4 space-y-2 w-80 mx-auto">
+          <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
             <button
               onClick={() => setShowNotifyModal(true)}
               className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background w-full"
@@ -276,7 +276,9 @@ export default function MyAccount() {
       )}
 
       {/* Wallet section */}
-      <Wallet />
+      <div className="bg-surface border border-border rounded-xl p-4 wide-card">
+        <Wallet />
+      </div>
       <InboxWidget />
       <DevNotifyModal
         open={showNotifyModal}

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -57,7 +57,7 @@ export default function Store() {
       {STORE_BUNDLES.filter(b => b.category === category).map((b) => (
         <div
           key={b.id}
-          className="store-card w-80 mx-auto"
+          className="store-card mx-auto wide-card"
         >
           <div className="flex items-center space-x-2">
             <span className="text-2xl">{b.icon}</span>


### PR DESCRIPTION
## Summary
- center and widen cards on the profile page
- widen leaderboard on the friends page
- make the games list single column with wide cards
- widen store bundles

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686b84e1f8dc8329b909ce4863dc8858