### PR TITLE
UI updates for profile, store and tasks

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1195,7 +1195,7 @@ input:focus {
 
 /* Store page styles */
 .store-card {
-  @apply prism-box flex-col space-y-2 rounded-xl p-4 items-center;
+  @apply prism-box flex-col space-y-2 rounded-xl p-4 items-center w-full;
   box-shadow: 0 0 12px rgba(0, 247, 255, 0.5);
 }
 

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -276,9 +276,7 @@ export default function MyAccount() {
       )}
 
       {/* Wallet section */}
-      <div className="bg-surface border border-border rounded-xl p-4 wide-card">
-        <Wallet />
-      </div>
+      <Wallet />
       <InboxWidget />
       <DevNotifyModal
         open={showNotifyModal}

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -42,6 +42,11 @@ export default function Store() {
 
   return (
     <div className="relative p-4 space-y-4 text-text">
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+      />
       <h2 className="text-xl font-bold">Store</h2>
       <div className="flex justify-center space-x-2">
         {STORE_CATEGORIES.map((c) => (

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -11,6 +11,7 @@ import { RiTelegramFill } from 'react-icons/ri';
 import { FiVideo } from 'react-icons/fi';
 import AdModal from '../components/AdModal.tsx';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
+import DailyCheckIn from '../components/DailyCheckIn.jsx';
 
 export default function Tasks() {
   useTelegramBackButton();
@@ -24,6 +25,7 @@ export default function Tasks() {
   const [tasks, setTasks] = useState(null);
   const [adCount, setAdCount] = useState(0);
   const [showAd, setShowAd] = useState(false);
+  const [category, setCategory] = useState('TonPlaygram');
 
   const load = async () => {
     const data = await listTasks(telegramId);
@@ -70,8 +72,21 @@ export default function Tasks() {
 
       <img  src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
       <h2 className="text-xl font-bold">Tasks</h2>
-
-      <ul className="space-y-2">
+      <div className="flex justify-center space-x-2">
+        {['TonPlaygram', 'Partners'].map((c) => (
+          <button
+            key={c}
+            onClick={() => setCategory(c)}
+            className={`lobby-tile px-3 py-1 ${category === c ? 'lobby-selected' : ''}`}
+          >
+            {c}
+          </button>
+        ))}
+      </div>
+      {category === 'TonPlaygram' && (
+        <>
+          <DailyCheckIn />
+          <ul className="space-y-2">
 
         {tasks.map((t) => (
 
@@ -134,6 +149,11 @@ export default function Tasks() {
           )}
         </li>
       </ul>
+        </>
+      )}
+      {category === 'Partners' && (
+        <p className="text-center text-subtext">Partner tasks coming soon.</p>
+      )}
       <AdModal
         open={showAd}
         onComplete={handleAdComplete}

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -251,7 +251,7 @@ export default function Wallet() {
 
 
   return (
-    <div className="relative p-4 space-y-4 text-text">
+    <div className="relative p-4 space-y-4 text-text wide-card">
       <h2 className="text-xl font-bold text-center">TPC Account Wallet</h2>
       <div className="prism-box p-6 space-y-2 w-80 mx-auto min-h-40 flex flex-col items-start">
         <p className="text-xs break-all w-full text-left">Account: {accountId || '...'}</p>
@@ -272,7 +272,7 @@ export default function Wallet() {
 
       {/* TPC account section */}
       <div className="space-y-2 border-b border-border pb-4">
-        <div className="prism-box p-6 space-y-3 text-center mb-4 flex flex-col items-center w-80 mx-auto min-h-40">
+        <div className="p-6 space-y-3 text-center mb-4 flex flex-col items-center w-80 mx-auto min-h-40">
           <label className="block font-semibold">Send TPC</label>
           <input
             type="text"
@@ -316,7 +316,7 @@ export default function Wallet() {
           )}
         </div>
 
-      <div className="prism-box p-6 space-y-3 text-center mt-4 mb-4 flex flex-col items-center w-80 mx-auto">
+      <div className="p-6 space-y-3 text-center mt-4 mb-4 flex flex-col items-center w-80 mx-auto">
         <label className="block font-semibold">Receive TPC</label>
           <button
             onClick={() => navigator.clipboard.writeText(String(accountId))}
@@ -333,7 +333,7 @@ export default function Wallet() {
       </div>
 
       {DEV_ACCOUNTS.includes(accountId) && (
-        <div className="prism-box p-6 space-y-3 text-center mt-4 mb-4 flex flex-col items-center w-80 mx-auto">
+        <div className="p-6 space-y-3 text-center mt-4 mb-4 flex flex-col items-center w-80 mx-auto">
           <label className="block font-semibold">Top Up Developer Account</label>
           <input
             type="number"
@@ -354,7 +354,7 @@ export default function Wallet() {
     </div>
 
 
-    <div className="prism-box p-4 space-y-2 text-center mt-4 flex flex-col items-center w-80 mx-auto">
+    <div className="p-4 space-y-2 text-center mt-4 flex flex-col items-center w-80 mx-auto">
         <h3 className="font-semibold text-center">TPC Statements</h3>
         <div className="flex items-center justify-center">
           <div className="flex items-center space-x-1 flex-wrap justify-center">


### PR DESCRIPTION
## Summary
- widen store cards and add galaxy background to the store page
- center wallet section on profile page and remove outer frame
- simplify wallet send/receive layouts
- add categories and daily check‑in to the Tasks page

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_686b8b31cac483299889ba6fc9ba8ce7