### PR TITLE
Fix snake timer & cell styles

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -9,6 +9,7 @@ export default function AvatarTimer({
   name,
   isTurn = false,
   color,
+  secondsLeft,
 }) {
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
@@ -27,6 +28,9 @@ export default function AvatarTimer({
         }}
       />
       {isTurn && <span className="turn-indicator">👈</span>}
+      {isTurn && secondsLeft != null && (
+        <span className="timer-count">{secondsLeft}</span>
+      )}
       {rank != null && (
         <span className="rank-number">{rank}</span>
       )}

--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -78,9 +78,7 @@ export default function SnakeBoard({
     const scaleX = scale * (1 + rowPos * widenStep);
     const offsetX = (scaleX - 1) * cellWidth;
     const reversed = r % 2 === 1;
-    const colorIdx = Math.floor(r / (ROWS / 5));
-    const TILE_COLORS = ["#6db0ad", "#4a828e", "#3d7078", "#2d5c66", "#0e3b45"];
-    const rowColor = TILE_COLORS[colorIdx] || "#0e3b45";
+    const rowColor = "#6db0ad";
 
     for (let c = 0; c < COLS; c++) {
       const col = c;

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -327,7 +327,7 @@ input:focus {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -110%) translateZ(20px)
-    rotateX(calc(var(--board-angle, 58deg) * -1));
+    rotateX(calc(var(--board-angle, 58deg) * -1 - 10deg));
   pointer-events: none;
   z-index: 3;
 }
@@ -678,7 +678,7 @@ input:focus {
 
 .cell-marker {
   position: absolute;
-  top: 58%;
+  top: 62%;
   left: 50%;
   /* Center icons slightly lower within the tile */
   transform: translate(-50%, -50%) translateZ(6px)
@@ -708,8 +708,8 @@ input:focus {
 }
 
 .cell-icon {
-  width: calc(var(--cell-width) * 0.7);
-  height: calc(var(--cell-height) * 0.7);
+  width: calc(var(--cell-width) * 0.75);
+  height: calc(var(--cell-height) * 0.75);
   object-fit: contain;
   transition: transform 0.3s ease;
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -220,9 +220,7 @@ function Board({
     // subsequent row alternates direction. Tile 1 is at the bottom-left and
     // tile 100 ends up at the top-right.
     const reversed = r % 2 === 1;
-    const colorIdx = Math.floor(r / (ROWS / 5));
-    const TILE_COLORS = ["#6db0ad", "#4a828e", "#3d7078", "#2d5c66", "#0e3b45"];
-    const rowColor = TILE_COLORS[colorIdx] || "#0e3b45";
+    const rowColor = "#6db0ad";
 
     for (let c = 0; c < COLS; c++) {
       const col = c;
@@ -1770,6 +1768,7 @@ export default function SnakeAndLadder() {
                   ? timeLeft / 15
                   : 1
               }
+              secondsLeft={p.index === currentTurn ? timeLeft : undefined}
               color={p.color}
             />
           ))}

--- a/webapp/src/utils/avatarUtils.js
+++ b/webapp/src/utils/avatarUtils.js
@@ -54,7 +54,10 @@ export function avatarToName(src) {
       return key
         .replace(/_/g, ' ')
         .replace(/\b\w/g, (c) => c.toUpperCase())
-        .replace(/^Flag\s+/i, '');
+        .replace(/^Flag\s+/i, '')
+        .replace(/\b(?:Face|Man|Woman|Male|Female|Person)\b/gi, '')
+        .replace(/\s+/g, ' ')
+        .trim();
     }
     return '';
   }


### PR DESCRIPTION
## Summary
- show numeric turn timer on avatar
- keep board cells one color
- enlarge board icons and move slightly down
- align pot coin rotation with tokens
- clean up avatar name formatting

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bad0c4c288329aa93d8cfc3e818f2