### PR TITLE
Enhance home page tasks and UI

### DIFF
--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -212,7 +212,7 @@ export default function SpinGame() {
       )}
       <button
         onClick={triggerSpin}
-        className="mt-2 px-4 py-1 bg-green-600 text-white text-sm font-bold rounded disabled:bg-gray-500"
+        className="mt-2 px-6 py-2 bg-green-600 text-white text-sm font-bold rounded disabled:bg-gray-500"
         disabled={spinning || !ready}
       >
         Spin

--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -54,7 +54,7 @@ export default function StoreAd() {
       </div>
       <Link
         to="/store"
-        className="inline-block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow"
+        className="mx-auto block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow"
       >
         Open Store
       </Link>

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -1,6 +1,15 @@
 import { useEffect, useState } from 'react';
 
-import { listTasks, completeTask, getAdStatus, watchAd } from '../utils/api.js';
+import {
+  listTasks,
+  completeTask,
+  getAdStatus,
+  watchAd,
+  dailyCheckIn,
+  getProfile
+} from '../utils/api.js';
+import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
+import { STORE_ADDRESS } from '../utils/storeData.js';
 
 import { getTelegramId } from '../utils/telegram.js';
 import LoginOptions from './LoginOptions.jsx';
@@ -23,6 +32,9 @@ const ICONS = {
 
 };
 
+const REWARDS = Array.from({ length: 30 }, (_, i) => 1000 * (i + 1));
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
 export default function TasksCard() {
   let telegramId;
   try {
@@ -38,12 +50,37 @@ export default function TasksCard() {
   const [tasks, setTasks] = useState(null);
   const [adCount, setAdCount] = useState(0);
   const [showAd, setShowAd] = useState(false);
+  const walletAddress = useTonAddress();
+  const [tonConnectUI] = useTonConnectUI();
+
+  const [streak, setStreak] = useState(1);
+  const [lastCheck, setLastCheck] = useState(() => {
+    const ts = localStorage.getItem('lastCheckIn');
+    return ts ? parseInt(ts, 10) : null;
+  });
+  const [lastOnchain, setLastOnchain] = useState(() => {
+    const ts = localStorage.getItem('lastOnchainCheck');
+    return ts ? parseInt(ts, 10) : null;
+  });
 
   const load = async () => {
     const data = await listTasks(telegramId);
     setTasks(data);
     const ad = await getAdStatus(telegramId);
     if (!ad.error) setAdCount(ad.count);
+    try {
+      const profile = await getProfile(telegramId);
+      if (profile.dailyStreak) setStreak(profile.dailyStreak);
+      const serverTs = profile.lastCheckIn
+        ? new Date(profile.lastCheckIn).getTime()
+        : null;
+      const localTs = lastCheck || 0;
+      const ts = Math.max(serverTs || 0, localTs);
+      if (ts) {
+        setLastCheck(ts);
+        localStorage.setItem('lastCheckIn', String(ts));
+      }
+    } catch {}
   };
 
   useEffect(() => {
@@ -62,6 +99,33 @@ export default function TasksCard() {
 
   };
 
+  const handleDailyCheck = async () => {
+    try {
+      const res = await dailyCheckIn(telegramId);
+      if (!res.error) {
+        setStreak(res.streak);
+        const now = Date.now();
+        setLastCheck(now);
+        localStorage.setItem("lastCheckIn", String(now));
+      }
+    } catch {}
+  };
+
+  const handleOnchainCheck = async () => {
+    if (!walletAddress) {
+      tonConnectUI.openModal();
+      return;
+    }
+    const tx = { validUntil: Math.floor(Date.now() / 1000) + 60, messages: [{ address: STORE_ADDRESS, amount: String(0.05 * 1e9) }] };
+    try {
+      await tonConnectUI.sendTransaction(tx);
+      const now = Date.now();
+      setLastOnchain(now);
+      localStorage.setItem("lastOnchainCheck", String(now));
+    } catch {
+      alert("Transaction failed");
+    }
+  };
   const handleAdComplete = async () => {
     await watchAd(telegramId);
     const ad = await getAdStatus(telegramId);
@@ -90,53 +154,71 @@ export default function TasksCard() {
 
       <h3 className="text-lg font-bold text-text flex items-center justify-center space-x-1"><AiOutlineCheckSquare className="text-accent" /><span>Tasks</span></h3>
 
-      <ul className="space-y-2">
+            <ul className="space-y-2">
+
+        <li className="lobby-tile w-full flex justify-between items-center">
+          <div className="flex items-center space-x-2 text-sm">
+            <AiOutlineCheck className="w-5 h-5 text-accent" />
+            <span>Daily Check-In</span>
+            <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1]} <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-4 h-4" /></span>
+          </div>
+          {lastCheck && Date.now() - lastCheck < ONE_DAY ? (
+            <span className="text-green-500 font-semibold text-sm">Done</span>
+          ) : (
+            <button
+              onClick={handleDailyCheck}
+              className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded"
+            >
+              Claim
+            </button>
+          )}
+        </li>
+
+        <li className="lobby-tile w-full flex justify-between items-center">
+          <div className="flex items-center space-x-2 text-sm">
+            <AiOutlineCheck className="w-5 h-5 text-accent" />
+            <span>On Chain Check In</span>
+            <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1] * 3} <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-4 h-4" /></span>
+          </div>
+          {lastOnchain && Date.now() - lastOnchain < ONE_DAY ? (
+            <span className="text-green-500 font-semibold text-sm">Done</span>
+          ) : (
+            <button
+              onClick={handleOnchainCheck}
+              className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded"
+            >
+              Claim
+            </button>
+          )}
+        </li>
 
         {tasks.map((t) => (
-
           <li key={t.id} className="lobby-tile w-full flex justify-between items-center">
-
             <div className="flex items-center space-x-2 text-sm">
-
               {ICONS[t.id]}
-
               <span>{t.description}</span>
-
-              <span className="text-xs text-subtext">{t.reward} TPC</span>
-
+              <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-4 h-4" /></span>
             </div>
-
             {t.completed ? (
-
-              <span className="text-accent font-semibold text-sm">Done</span>
-
+              <span className="text-green-500 font-semibold text-sm">Done</span>
             ) : (
-
               <button
-
                 onClick={() => handleClaim(t)}
-
-                  className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded"
-
+                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded"
               >
-
                 Claim
-
               </button>
-
             )}
-
           </li>
-
         ))}
         <li className="lobby-tile w-full flex justify-between items-center">
           <div className="flex items-center space-x-2 text-sm">
             {ICONS.watch_ad}
             <span>Watch Ad ({adCount}/10)</span>
-            <span className="text-xs text-subtext">100 TPC</span>
+            <span className="text-xs text-subtext flex items-center gap-1">100 <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-4 h-4" /></span>
           </div>
           {adCount >= 10 ? (
-            <span className="text-accent font-semibold text-sm">Done</span>
+            <span className="text-green-500 font-semibold text-sm">Done</span>
           ) : (
             <button
               onClick={() => setShowAd(true)}
@@ -148,6 +230,7 @@ export default function TasksCard() {
         </li>
 
       </ul>
+
       <AdModal
         open={showAd}
         onComplete={handleAdComplete}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -179,7 +179,7 @@ export default function Home() {
           <h3 className="text-lg font-bold text-text text-center">Tokenomics &amp; Roadmap</h3>
           <Link
             to="/tokenomics"
-            className="inline-block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow text-center"
+            className="mx-auto block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow text-center"
           >
             Learn More
           </Link>


### PR DESCRIPTION
## Summary
- show daily and on-chain check-in tasks on the homepage
- show coin icons and green text when tasks are done
- center the store and tokenomics buttons
- enlarge Spin & Win button slightly

## Testing
- `npm test` *(fails: 3, pass: 8)*

------
https://chatgpt.com/codex/tasks/task_e_686baebfc0348329a25403b8d1a0b687