### PR TITLE
Fix snake ladder timer and restore logo

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -9,7 +9,6 @@ export default function AvatarTimer({
   name,
   isTurn = false,
   color,
-  secondsLeft,
 }) {
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
@@ -28,9 +27,6 @@ export default function AvatarTimer({
         }}
       />
       {isTurn && <span className="turn-indicator">👈</span>}
-      {isTurn && secondsLeft != null && (
-        <span className="timer-count">{secondsLeft}</span>
-      )}
       {rank != null && (
         <span className="rank-number">{rank}</span>
       )}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -19,8 +19,6 @@ import {
   AiOutlineReload,
 } from "react-icons/ai";
 import BottomLeftIcons from "../../components/BottomLeftIcons.jsx";
-import Branding from "../../components/Branding.jsx";
-import CosmicBackground from "../../components/CosmicBackground.jsx";
 import { isGameMuted, getGameVolume } from "../../utils/sound.js";
 import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
 import { useNavigate } from "react-router-dom";
@@ -412,6 +410,7 @@ function Board({
 
   return (
     <div className="relative flex justify-center items-center w-screen overflow-visible">
+      <img src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
       <div
         ref={containerRef}
         className="overflow-y-auto"
@@ -487,6 +486,7 @@ function Board({
                 ))}
               {celebrate && <CoinBurst token={token} />}
             </div>
+            <div className="logo-wall-main" />
           </div>
         </div>
       </div>
@@ -1688,7 +1688,12 @@ export default function SnakeAndLadder() {
     timerRef.current = setInterval(() => {
       setTimeLeft((t) => {
         const next = t - 1;
-        if (next <= 7 && next >= 0 && timerSoundRef.current) {
+        if (
+          currentTurn === myIndex &&
+          next <= 7 &&
+          next >= 0 &&
+          timerSoundRef.current
+        ) {
           timerSoundRef.current.currentTime = 0;
           if (!muted) timerSoundRef.current.play().catch(() => {});
         }
@@ -1747,8 +1752,6 @@ export default function SnakeAndLadder() {
 
   return (
     <div className="p-4 pb-32 space-y-4 text-text flex flex-col justify-end items-center relative w-full flex-grow">
-      <CosmicBackground />
-      <Branding scale={1.2} />
       {/* Bottom left controls */}
       <BottomLeftIcons onInfo={() => setShowInfo(true)} />
       {/* Player photos stacked vertically */}
@@ -1768,7 +1771,6 @@ export default function SnakeAndLadder() {
                   ? timeLeft / 15
                   : 1
               }
-              secondsLeft={p.index === currentTurn ? timeLeft : undefined}
               color={p.color}
             />
           ))}

--- a/webapp/src/utils/avatarUtils.js
+++ b/webapp/src/utils/avatarUtils.js
@@ -54,7 +54,8 @@ export function avatarToName(src) {
       return key
         .replace(/_/g, ' ')
         .replace(/\b\w/g, (c) => c.toUpperCase())
-        .replace(/^Flag\s+/i, '')
+        .replace(/\bflag\b/gi, '')
+        .replace(/\bof\b/gi, '')
         .replace(/\b(?:Face|Man|Woman|Male|Female|Person)\b/gi, '')
         .replace(/\s+/g, ' ')
         .trim();


### PR DESCRIPTION
## Summary
- show original background and logo on Snake & Ladder board
- hide countdown numbers on avatar timer
- only beep for player in final seconds
- strip 'flag' from AI avatar names

## Testing
- `npm test` *(fails: testCodeFailure and cancelledByParent)*

------
https://chatgpt.com/codex/tasks/task_e_686bb7d8f394832999d4a132e130ac62