### PR TITLE
Remove logo from ads

### DIFF
--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -55,7 +55,6 @@ export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
             &times;
           </button>
         )}
-        <img  src="/assets/TonPlayGramLogo.jpg" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
         <h3 className="text-lg font-bold">Watch Ad</h3>
         <div
           id="adsgram-player"


### PR DESCRIPTION
## Summary
- removed TonPlaygram logo from advertising modal

## Testing
- `npm test` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686bd2b620e883298952f28d94068d7e