### PR TITLE
Fix avatar names and remove overlay

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -411,7 +411,6 @@ function Board({
 
   return (
     <div className="relative flex justify-center items-center w-screen overflow-visible">
-      <div className="background-behind-board bg-surface" />
       <div
         ref={containerRef}
         className="overflow-y-auto"

--- a/webapp/src/utils/avatarUtils.js
+++ b/webapp/src/utils/avatarUtils.js
@@ -44,6 +44,15 @@ export function avatarToName(src) {
   if (!src.startsWith('/') && !src.startsWith('http')) {
     const key = emojiToNameMap[src];
     if (key) {
+      const flagMatch = key.match(/flag[-_]?([a-z]{2})/i);
+      if (flagMatch) {
+        const code = flagMatch[1].toUpperCase();
+        try {
+          const name = regionNames?.of(code) || countryNames[code];
+          if (name) return name;
+        } catch {}
+        return countryNames[code] || code;
+      }
       if (/^[a-z]{2}$/i.test(key)) {
         const code = key.toUpperCase();
         try {


### PR DESCRIPTION
## Summary
- ensure full country names are used for flag avatars
- remove blue overlay behind snake board so only galaxy background remains

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bdaad218083298a981eda9b2c6889