### PR TITLE
Add player popup and chat feature

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -9,11 +9,12 @@ export default function AvatarTimer({
   name,
   isTurn = false,
   color,
+  onClick,
 }) {
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
   return (
-    <div className="relative w-10 h-10">
+    <div className="relative w-10 h-10" onClick={onClick}>
       {active && (
         <div className="avatar-timer-ring" style={{ '--timer-gradient': gradient }} />
       )}

--- a/webapp/src/components/PlayerPopup.jsx
+++ b/webapp/src/components/PlayerPopup.jsx
@@ -1,0 +1,37 @@
+import { createPortal } from 'react-dom';
+import { sendFriendRequest } from '../utils/api.js';
+import { getTelegramId } from '../utils/telegram.js';
+
+export default function PlayerPopup({ open, onClose, player }) {
+  if (!open || !player) return null;
+  const handleAdd = async () => {
+    try {
+      await sendFriendRequest(getTelegramId(), player.telegramId || player.id);
+      alert('Friend request sent');
+    } catch {
+      alert('Failed to send request');
+    }
+    onClose();
+  };
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface border border-border rounded p-4 space-y-2 w-60"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <img src={player.photoUrl} alt="user" className="w-20 h-20 rounded-full mx-auto" />
+        <p className="text-center font-semibold">{player.name}</p>
+        <button
+          className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
+          onClick={handleAdd}
+        >
+          Add Friend
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/webapp/src/components/QuickMessagePopup.jsx
+++ b/webapp/src/components/QuickMessagePopup.jsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+
+const MESSAGES = [
+  'Nice bro 😀',
+  'Well done 👍',
+  "You're lucky 🍀",
+  "You're cute 😊",
+  "You're beautiful 😍",
+  'No way 😲',
+  'Damn it 😡',
+  'Love it ❤️',
+  'Good job 👏',
+];
+
+export default function QuickMessagePopup({ open, onClose, players = [], onSend }) {
+  const [target, setTarget] = useState(players[0]?.index || 0);
+  const [message, setMessage] = useState(MESSAGES[0]);
+  if (!open) return null;
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface border border-border rounded p-4 space-y-2 w-64"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <select
+          className="w-full border border-border rounded p-1 bg-surface"
+          value={target}
+          onChange={(e) => setTarget(Number(e.target.value))}
+        >
+          {players.map((p) => (
+            <option key={p.index} value={p.index}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        <div className="grid grid-cols-2 gap-1 max-h-40 overflow-y-auto">
+          {MESSAGES.map((m) => (
+            <button
+              key={m}
+              onClick={() => setMessage(m)}
+              className={`text-sm border border-border rounded px-1 py-0.5 ${
+                message === m ? 'bg-accent' : ''
+              }`}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+        <button
+          className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
+          onClick={() => {
+            onSend && onSend(target, message);
+            onClose();
+          }}
+        >
+          Send
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1231,3 +1231,6 @@ input:focus {
     opacity: 0;
   }
 }
+
+.chat-bubble{ @apply fixed bottom-32 left-1/2 -translate-x-1/2 bg-black bg-opacity-70 text-white rounded px-2 py-1 flex items-center space-x-2; }
+


### PR DESCRIPTION
## Summary
- allow `AvatarTimer` to handle clicks
- add `PlayerPopup` for friend requests
- add `QuickMessagePopup` with canned messages
- show chat bubbles and smooth timer countdown in Snake and Ladder
- style chat bubbles

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686be309e58083298cfaf6d9b7472b77