### PR TITLE
Add gift popup and adjust message layout

### DIFF
--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { getTelegramId } from '../utils/telegram.js';
+import { sendGift } from '../utils/api.js';
+import { GIFTS } from '../utils/gifts.js';
+
+export default function GiftPopup({ open, onClose, recipient }) {
+  const [selected, setSelected] = useState(GIFTS[0]);
+  if (!open || !recipient) return null;
+
+  const handleSend = async () => {
+    try {
+      await sendGift(getTelegramId(), recipient.telegramId || recipient.id, selected.id);
+      alert(`Sent ${selected.name} to ${recipient.name}`);
+    } catch {
+      alert('Failed to send gift');
+    }
+    onClose();
+  };
+
+  const tiers = [1, 2, 3];
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70" onClick={onClose}>
+      <div className="bg-surface border border-border rounded p-4 space-y-2 w-72" onClick={(e) => e.stopPropagation()}>
+        <p className="text-center font-semibold mb-2">Send Gift to {recipient.name}</p>
+        {tiers.map(tier => (
+          <div key={tier} className="space-y-1">
+            <p className="text-sm font-bold">Tier {tier}</p>
+            <div className="grid grid-cols-2 gap-1">
+              {GIFTS.filter(g => g.tier === tier).map(g => (
+                <button
+                  key={g.id}
+                  onClick={() => setSelected(g)}
+                  className={`border border-border rounded px-1 py-0.5 text-sm flex items-center justify-center space-x-1 ${selected.id === g.id ? 'bg-accent' : ''}`}
+                >
+                  <span>{g.icon}</span>
+                  <span>{g.price}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+        <div className="text-xs text-center mt-2">Cost: {selected.price} TPC + 3%</div>
+        <button className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black" onClick={handleSend}>
+          Send {selected.icon} {selected.name}
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/webapp/src/components/PlayerPopup.jsx
+++ b/webapp/src/components/PlayerPopup.jsx
@@ -1,8 +1,11 @@
+import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { sendFriendRequest } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
+import GiftPopup from './GiftPopup.jsx';
 
 export default function PlayerPopup({ open, onClose, player }) {
+  const [giftOpen, setGiftOpen] = useState(false);
   if (!open || !player) return null;
   const handleAdd = async () => {
     try {
@@ -24,13 +27,22 @@ export default function PlayerPopup({ open, onClose, player }) {
       >
         <img src={player.photoUrl} alt="user" className="w-20 h-20 rounded-full mx-auto" />
         <p className="text-center font-semibold">{player.name}</p>
-        <button
-          className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
-          onClick={handleAdd}
-        >
-          Add Friend
-        </button>
+        <div className="flex space-x-2">
+          <button
+            className="flex-1 px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
+            onClick={handleAdd}
+          >
+            Add Friend
+          </button>
+          <button
+            className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
+            onClick={() => setGiftOpen(true)}
+          >
+            🎁
+          </button>
+        </div>
       </div>
+      <GiftPopup open={giftOpen} onClose={() => setGiftOpen(false)} recipient={player} />
     </div>,
     document.body,
   );

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1232,5 +1232,5 @@ input:focus {
   }
 }
 
-.chat-bubble{ @apply fixed bottom-32 left-1/2 -translate-x-1/2 bg-black bg-opacity-70 text-white rounded px-2 py-1 flex items-center space-x-2; }
+.chat-bubble{ @apply fixed bottom-4 left-1/2 -translate-x-1/2 bg-black bg-opacity-70 text-white rounded px-2 py-1 flex items-center space-x-2; }
 

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -296,6 +296,10 @@ export function sendMessage(fromId, toId, text) {
   return post('/api/social/send-message', { fromId, toId, text });
 }
 
+export function sendGift(fromId, toId, gift) {
+  return post('/api/social/send-gift', { fromId, toId, gift });
+}
+
 export function getMessages(telegramId, withId) {
   return post('/api/social/messages', { telegramId, withId });
 }

--- a/webapp/src/utils/gifts.js
+++ b/webapp/src/utils/gifts.js
@@ -1,0 +1,18 @@
+export const GIFTS = [
+  // Tier 1
+  { id: 'fireworks', name: 'Fireworks', icon: '🎆', price: 100, tier: 1, effect: 'Simple visual burst' },
+  { id: 'laugh_bomb', name: 'Laugh Bomb', icon: '😂', price: 150, tier: 1, effect: "Makes others' screen shake briefly" },
+  { id: 'pizza_slice', name: 'Pizza Slice', icon: '🍕', price: 200, tier: 1, effect: 'Shows pizza fly across screen' },
+  { id: 'coffee_boost', name: 'Coffee Boost', icon: '☕', price: 300, tier: 1, effect: 'Funny “energy up” animation' },
+  { id: 'baby_chick', name: 'Baby Chick', icon: '🐣', price: 500, tier: 1, effect: 'Cute chick dances on screen' },
+  // Tier 2
+  { id: 'speed_racer', name: 'Speed Racer', icon: '🏎️', price: 1000, tier: 2, effect: 'Car zooms across the game board' },
+  { id: 'bullseye', name: 'Bullseye', icon: '🎯', price: 2000, tier: 2, effect: "Dart hits target on player's profile" },
+  { id: 'magic_trick', name: 'Magic Trick', icon: '🎩', price: 3000, tier: 2, effect: 'Random gift animation (slot-style)' },
+  { id: 'surprise_box', name: 'Surprise Box', icon: '🎁', price: 5000, tier: 2, effect: 'Opens to show random emoji effect' },
+  // Tier 3
+  { id: 'dragon_burst', name: 'Dragon Burst', icon: '🐉', price: 10000, tier: 3, effect: 'Dragon flies across board breathing fire' },
+  { id: 'rocket_blast', name: 'Rocket Blast', icon: '🚀', price: 20000, tier: 3, effect: 'Rocket launches with flame trail' },
+  { id: 'royal_crown', name: 'Royal Crown', icon: '👑', price: 50000, tier: 3, effect: "Crown lands on recipient's avatar" },
+  { id: 'alien_visit', name: 'Alien Visit', icon: '🛸', price: 100000, tier: 3, effect: 'UFO beam + abduction animation' },
+];


### PR DESCRIPTION
## Summary
- align message bubbles with mute/chat icons
- add GiftPopup component
- allow sending gifts from the player popup
- expose sendGift API
- list available gifts

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_686be876c13c832980b418876b49df0e