### PR TITLE
Fix leaderboard availability labels

### DIFF
--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -271,8 +271,12 @@ export default function Friends() {
                     />
                   )}
                   {u.nickname || `${u.firstName} ${u.lastName}`.trim() || 'User'}
-                  {u.currentTableId && (
-                    <span className="ml-1 text-xs text-red-500">playing not available</span>
+                  {u.accountId !== accountId && (
+                    u.currentTableId ? (
+                      <span className="ml-1 text-xs text-red-500">Playing</span>
+                    ) : (
+                      <span className="ml-1 text-xs text-green-500">Available</span>
+                    )
                   )}
                   {onlineUsers.includes(String(u.accountId)) && (
                     <FaCircle className="ml-1 text-green-500" size={8} />


### PR DESCRIPTION
## Summary
- show whether a player is `Playing` or `Available` on the Friends leaderboard

## Testing
- `npm test` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_686bfae323488329a229e5ced462a404