### PR TITLE
Switch icons to webp assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,11 @@ All webapp icons are stored under `webapp/public`. The board uses emoji symbols
 (🐍, 🪜 and 🎲) for snake, ladder and dice connectors instead of the old SVG
 files.
 
-Token icons for the lobby and wallet are now:
+Token icons for the lobby and wallet are now stored as WebP files:
 
-- `TON.png`
-- `Usdt.png`
-- `assets/icons/TPCcoin.png`
+- `assets/icons/TON.webp`
+- `assets/icons/Usdt.webp`
+- `assets/icons/TPCcoin_1.webp`
 
 Place your own images with those exact names in the same directories to
 override them.

--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -6,7 +6,7 @@ import { fetchTelegramInfo } from './telegram.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const coinPath = path.join(
   __dirname,
-  '../../webapp/public/assets/icons/TPCcoin.png'
+  '../../webapp/public/assets/icons/TPCcoin_1.webp'
 );
 
 export function getInviteUrl(roomId, token, amount) {

--- a/tpc_metadata.json
+++ b/tpc_metadata.json
@@ -3,5 +3,5 @@
   "symbol": "TPC",
   "decimals": 9,
   "description": "TonPlaygram Coin (TPC) powers mining, games, and rewards inside the TonPlaygram platform.",
-  "image": "https://tonplaygramwebapp.onrender.com/assets/icons/TPCcoin.png"
+  "image": "https://tonplaygramwebapp.onrender.com/assets/icons/TPCcoin_1.webp"
 }

--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -20,9 +20,9 @@ export default function BalanceSummary({ className = '', showHeader = true }) {
         </p>
       )}
       <div className="grid grid-cols-3 text-sm mt-4">
-        <Token icon="/icons/TON.png" label="TON" value={tonBalance ?? '...'} />
-        <Token icon="/assets/icons/TPCcoin.png" label="TPC" value={tpcBalance ?? 0} decimals={2} />
-        <Token icon="/icons/Usdt.png" label="USDT" value={usdtBalance ?? '...'} decimals={2} />
+        <Token icon="/assets/icons/TON.webp" label="TON" value={tonBalance ?? '...'} />
+        <Token icon="/assets/icons/TPCcoin_1.webp" label="TPC" value={tpcBalance ?? 0} decimals={2} />
+        <Token icon="/assets/icons/Usdt.webp" label="USDT" value={usdtBalance ?? '...'} decimals={2} />
       </div>
     </div>
   );

--- a/webapp/src/components/Branding.jsx
+++ b/webapp/src/components/Branding.jsx
@@ -4,8 +4,8 @@ export default function Branding({ scale = 1, offsetY = 0 }) {
   return (
     <div className="text-center py-6 space-y-2">
       <img
-        
-        src="/assets/TonPlayGramLogo.jpg"
+
+        src="/assets/icons/TonPlayGramLogo.webp"
         alt="TonPlaygram Logo"
         className="mx-auto"
         style={{ transform: `scale(${scale})`, marginTop: offsetY }}

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -115,7 +115,7 @@ export default function DailyCheckIn() {
 
         <span className="flex items-center">
           {formatReward(REWARDS[i])}
-          <img  src="/assets/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 -ml-1" />
+          <img  src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-8 h-8 -ml-1" />
         </span>
 
         {i === streak - 1 && showPopup && (

--- a/webapp/src/components/GameEndPopup.jsx
+++ b/webapp/src/components/GameEndPopup.jsx
@@ -6,7 +6,7 @@ export default function GameEndPopup({ open, ranking, onPlayAgain, onReturn }) {
   return createPortal(
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
-        <img  src="/assets/TonPlayGramLogo.jpg" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
+        <img  src="/assets/icons/TonPlayGramLogo.webp" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
         <h3 className="text-lg font-bold text-center">Game Over</h3>
         <ol className="list-decimal list-inside space-y-1 text-center">
           {ranking.map((name, i) => (

--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -51,7 +51,7 @@ export default function GiftPopup({ open, onClose, players = [] }) {
                   <span>{g.icon}</span>
                   <span className="flex items-center space-x-0.5">
                     <span>{g.price}</span>
-                    <img src="/assets/icons/TPCcoin.png" className="w-3 h-3" />
+                    <img src="/assets/icons/TPCcoin_1.webp" className="w-3 h-3" />
                   </span>
                 </button>
               ))}
@@ -61,7 +61,7 @@ export default function GiftPopup({ open, onClose, players = [] }) {
         <div className="text-xs text-center mt-2 flex items-center justify-center space-x-1">
           <span>Cost:</span>
           <span>{selected.price}</span>
-          <img src="/assets/icons/TPCcoin.png" className="w-3 h-3" />
+          <img src="/assets/icons/TPCcoin_1.webp" className="w-3 h-3" />
         </div>
         <button className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black" onClick={handleSend}>
           Send {selected.icon} {selected.name}

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -24,8 +24,10 @@ export default function InvitePopup({
               
               src={
                 stake?.token === 'TPC'
-                  ? '/assets/icons/TPCcoin.png'
-                  : `/icons/${stake?.token || 'TPC'}.png`
+                  ? '/assets/icons/TPCcoin_1.webp'
+                  : stake?.token === 'TON'
+                  ? '/assets/icons/TON.webp'
+                  : '/assets/icons/Usdt.webp'
               }
               alt="token"
               className="inline w-4 h-4 mr-1"

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -148,7 +148,7 @@ export default function MiningCard() {
       </button>
       {isMining && (
         <div className="flex items-center justify-center space-x-1 text-sm">
-          <img  src="/assets/icons/TPCcoin.png" alt="TPC" className="w-5 h-5" />
+          <img  src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-5 h-5" />
           <span>{minted}</span>
         </div>
       )}

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -31,8 +31,8 @@ export default function RewardPopup({ reward, onClose, duration = 2500, showClos
           {reward === 'BONUS_X3' && (
             <>
               <img
-                
-                src="/assets/icons/Dice.png"
+
+                src="/assets/icons/file_00000000eeb061f79122a7d007f9bddc.webp"
                 alt="Bonus"
                 className="w-8 h-8"
               />
@@ -65,7 +65,7 @@ export default function RewardPopup({ reward, onClose, duration = 2500, showClos
             <>
               <img
                 
-                src="/assets/icons/TPCcoin.png"
+                src="/assets/icons/TPCcoin_1.webp"
                 alt="TPC"
                 className="w-8 h-8"
               />

--- a/webapp/src/components/RoomPopup.jsx
+++ b/webapp/src/components/RoomPopup.jsx
@@ -20,8 +20,8 @@ export default function RoomPopup({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
         <img
-          
-          src="/assets/TonPlayGramLogo.jpg"
+
+          src="/assets/icons/TonPlayGramLogo.webp"
           alt="TonPlaygram Logo"
           className="w-10 h-10 mx-auto"
         />

--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -6,9 +6,9 @@ const AMOUNTS = {
   USDT: [0.1, 0.5, 1, 5, 10],
 };
 const tokens = [
-  { id: 'TPC', icon: '/assets/icons/TPCcoin.png' },
-  { id: 'TON', icon: '/icons/TON.png' },
-  { id: 'USDT', icon: '/icons/Usdt.png' },
+  { id: 'TPC', icon: '/assets/icons/TPCcoin_1.webp' },
+  { id: 'TON', icon: '/assets/icons/TON.webp' },
+  { id: 'USDT', icon: '/assets/icons/Usdt.webp' },
 ];
 
 export default function RoomSelector({ selected, onSelect, tokens: allowed }) {

--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -20,7 +20,7 @@ function CoinBurst({ token }) {
           key={i}
           src={
             token.toUpperCase() === 'TPC'
-              ? '/assets/icons/TPCcoin.png'
+              ? '/assets/icons/TPCcoin_1.webp'
               : `/icons/${token.toLowerCase()}.svg`
           }
           className="coin-img"
@@ -103,7 +103,7 @@ export default function SnakeBoard({
       const cellClass = cellType ? `${cellType}-cell` : "";
       const iconImage =
         cellType === "ladder"
-          ? "/assets/icons/ladder.svg"
+          ? "/assets/icons/Ladder.webp"
           : cellType === "snake"
           ? "/assets/icons/snake.png"
           : null;
@@ -144,7 +144,7 @@ export default function SnakeBoard({
           {!cellType && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
-              <img  src="/assets/icons/Dice.png" className="dice-icon" />
+              <img  src="/assets/icons/file_00000000eeb061f79122a7d007f9bddc.webp" className="dice-icon" />
               <span className="dice-value">+{diceCells[num]}</span>
             </span>
           )}
@@ -263,10 +263,10 @@ export default function SnakeBoard({
               <img
                 src={
                   token === 'TON'
-                    ? '/icons/TON.png'
+                    ? '/assets/icons/TON.webp'
                     : token === 'USDT'
-                    ? '/icons/Usdt.png'
-                    : '/assets/icons/TPCcoin.png'
+                    ? '/assets/icons/Usdt.webp'
+                    : '/assets/icons/TPCcoin_1.webp'
                 }
                 
                 alt={token}

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -240,7 +240,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
                 </>
               ) : (
                 <>
-                  <img  src="/assets/icons/TPCcoin.png" alt="TPC" className="w-8 h-8 mr-1" />
+                  <img  src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-8 h-8 mr-1" />
                   <span>{val >= 1000 ? `${val / 1000}k` : val}</span>
                 </>
               )}

--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -43,11 +43,11 @@ export default function StoreAd() {
             </div>
             <div className="text-sm flex items-center space-x-1">
               <span>{b.tpc.toLocaleString()}</span>
-              <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-5 h-5" />
+              <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-5 h-5" />
             </div>
             <div className="text-sm flex items-center space-x-1 text-primary">
               <span>{b.ton}</span>
-              <img src="/icons/TON.png" alt="TON" className="w-5 h-5" />
+              <img src="/assets/icons/TON.webp" alt="TON" className="w-5 h-5" />
             </div>
           </div>
         ))}

--- a/webapp/src/components/TablePopup.jsx
+++ b/webapp/src/components/TablePopup.jsx
@@ -7,8 +7,8 @@ export default function TablePopup({ open, tables, onSelect }) {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
         <img
-          
-          src="/assets/TonPlayGramLogo.jpg"
+
+          src="/assets/icons/TonPlayGramLogo.webp"
           alt="TonPlaygram Logo"
           className="w-10 h-10 mx-auto"
         />

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -162,7 +162,7 @@ export default function TasksCard() {
           <div className="flex items-center space-x-2 text-sm">
             <AiOutlineCheck className="w-5 h-5 text-accent" />
             <span>Daily Check-In</span>
-            <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1]} <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-4 h-4" /></span>
+            <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1]} <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
           </div>
           {lastCheck && Date.now() - lastCheck < ONE_DAY ? (
             <span className="text-green-500 font-semibold text-sm">Done</span>
@@ -179,7 +179,7 @@ export default function TasksCard() {
           <div className="flex items-center space-x-2 text-sm">
             <AiOutlineCheck className="w-5 h-5 text-accent" />
             <span>On Chain Check In</span>
-            <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1] * 3} <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-4 h-4" /></span>
+            <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1] * 3} <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
           </div>
           {lastOnchain && Date.now() - lastOnchain < ONE_DAY ? (
             <span className="text-green-500 font-semibold text-sm">Done</span>
@@ -203,7 +203,7 @@ export default function TasksCard() {
 
               <span>{t.description}</span>
 
-              <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-4 h-4" /></span>
+              <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
 
             </div>
 
@@ -234,7 +234,7 @@ export default function TasksCard() {
           <div className="flex items-center space-x-2 text-sm">
             {ICONS.watch_ad}
             <span>Watch Ad ({adCount}/10)</span>
-            <span className="text-xs text-subtext flex items-center gap-1">100 <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-4 h-4" /></span>
+            <span className="text-xs text-subtext flex items-center gap-1">100 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
           </div>
           {adCount >= 10 ? (
             <span className="text-green-500 font-semibold text-sm">Done</span>

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -23,11 +23,11 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
 
   const token = (tx.token || 'TPC').toUpperCase();
   const iconMap = {
-    TPC: '/assets/icons/TPCcoin.png',
-    TON: '/icons/TON.png',
-    USDT: '/icons/Usdt.png'
+    TPC: '/assets/icons/TPCcoin_1.webp',
+    TON: '/assets/icons/TON.webp',
+    USDT: '/assets/icons/Usdt.webp'
   };
-  const icon = iconMap[token] || `/icons/${token.toLowerCase()}.png`;
+  const icon = iconMap[token] || `/assets/icons/${token}.webp`;
   const isSend = tx.type === 'send';
   const isReceive = tx.type === 'receive';
   const account = isSend ? tx.toAccount : tx.fromAccount;

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -859,7 +859,7 @@ input:focus {
   transform-origin: bottom center;
   background-image:
     linear-gradient(to bottom, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0) 70%),
-    url("/assets/TonPlayGramLogo.jpg");
+    url("/assets/icons/TonPlayGramLogo.webp");
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -150,8 +150,10 @@ function CoinBurst({ token }) {
           key={i}
           src={
             token.toUpperCase() === 'TPC'
-              ? '/assets/icons/TPCcoin.png'
-              : `/icons/${token.toLowerCase()}.svg`
+              ? '/assets/icons/TPCcoin_1.webp'
+              : token.toUpperCase() === 'TON'
+              ? '/assets/icons/TON.webp'
+              : '/assets/icons/Usdt.webp'
           }
           className="coin-img"
           style={{
@@ -248,7 +250,7 @@ function Board({
       const cellClass = cellType ? `${cellType}-cell` : "";
       const iconImage =
         cellType === "ladder"
-          ? "/assets/icons/ladder.svg"
+          ? "/assets/icons/Ladder.webp"
           : cellType === "snake"
             ? "/assets/icons/snake.png"
             : null;
@@ -293,7 +295,7 @@ function Board({
           {!cellType && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
-              <img  src="/assets/icons/Dice.png" className="dice-icon" />
+              <img  src="/assets/icons/file_00000000eeb061f79122a7d007f9bddc.webp" className="dice-icon" />
               <span className="dice-value">+{diceCells[num]}</span>
             </span>
           )}
@@ -460,10 +462,10 @@ function Board({
               <img
                 src={
                   token === 'TON'
-                    ? '/icons/TON.png'
+                    ? '/assets/icons/TON.webp'
                     : token === 'USDT'
-                    ? '/icons/Usdt.png'
-                    : '/assets/icons/TPCcoin.png'
+                    ? '/assets/icons/Usdt.webp'
+                    : '/assets/icons/TPCcoin_1.webp'
                 }
                 alt={token}
                 className="pot-icon"
@@ -633,16 +635,13 @@ export default function SnakeAndLadder() {
   // Preload token and avatar images so board icons and AI photos display
   // immediately without waiting for network requests during gameplay.
   useEffect(() => {
-    [
-      'TON.png',
-      'Usdt.png'
-    ].forEach((file) => {
+    ['TON.webp', 'Usdt.webp'].forEach((file) => {
       const img = new Image();
-      img.src = `/icons/${file}`;
+      img.src = `/assets/icons/${file}`;
     });
     {
       const img = new Image();
-      img.src = '/assets/icons/TPCcoin.png';
+      img.src = '/assets/icons/TPCcoin_1.webp';
     }
     AVATARS.forEach((src) => {
       const img = new Image();
@@ -1893,7 +1892,7 @@ export default function SnakeAndLadder() {
       {rewardDice > 0 && (
         <div className="fixed bottom-40 inset-x-0 flex justify-center z-30 pointer-events-none reward-dice-container">
           {Array.from({ length: rewardDice }).map((_, i) => (
-            <img key={i}  src="/assets/icons/Dice.png" className="reward-dice" />
+            <img key={i}  src="/assets/icons/file_00000000eeb061f79122a7d007f9bddc.webp" className="reward-dice" />
           ))}
         </div>
       )}
@@ -2007,10 +2006,10 @@ export default function SnakeAndLadder() {
               <img
                 src={
                   token === 'TON'
-                    ? '/icons/TON.png'
+                    ? '/assets/icons/TON.webp'
                     : token === 'USDT'
-                    ? '/icons/Usdt.png'
-                    : '/assets/icons/TPCcoin.png'
+                    ? '/assets/icons/Usdt.webp'
+                    : '/assets/icons/TPCcoin_1.webp'
                 }
                 alt={token}
                 className="inline w-4 h-4 align-middle"

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -119,11 +119,11 @@ export default function Home() {
               alt=""
             />
             <div className="flex-1 flex items-center justify-center space-x-1">
-              <img src="/icons/TON.png" alt="TON" className="w-8 h-8" />
+              <img src="/assets/icons/TON.webp" alt="TON" className="w-8 h-8" />
               <span className="text-base">{formatValue(tonBalance ?? '...')}</span>
             </div>
             <div className="flex-1 flex items-center justify-center space-x-1">
-              <img src="/icons/Usdt.png" alt="USDT" className="w-8 h-8" />
+              <img src="/assets/icons/Usdt.webp" alt="USDT" className="w-8 h-8" />
               <span className="text-base">{formatValue(usdtBalance ?? '...', 2)}</span>
             </div>
           </div>
@@ -149,7 +149,7 @@ export default function Home() {
                   <span className="text-xs text-accent">Send</span>
                 </Link>
                 <div className="flex flex-col items-center space-y-1">
-                  <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-10 h-10" />
+                  <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-10 h-10" />
                   <span className="text-sm">{formatValue(tpcBalance ?? '...', 2)}</span>
                 </div>
                 <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -65,11 +65,11 @@ export default function Store() {
           </div>
           <div className="text-lg font-bold flex items-center space-x-1">
             <span>{b.tpc.toLocaleString()}</span>
-            <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-6 h-6" />
+            <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-6 h-6" />
           </div>
           <div className="text-primary text-lg flex items-center space-x-1">
             <span>{b.ton}</span>
-            <img src="/icons/TON.png" alt="TON" className="w-6 h-6" />
+            <img src="/assets/icons/TON.webp" alt="TON" className="w-6 h-6" />
           </div>
           <div className="text-xs text-accent">{b.category} Bundle</div>
           {b.boost ? (

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -153,7 +153,7 @@ export default function Tasks() {
               <div className="flex items-center space-x-2 text-sm">
                 <AiOutlineCheck className="w-5 h-5 text-accent" />
                 <span>Daily Check-In</span>
-                <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1]} <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-4 h-4" /></span>
+                <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1]} <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
               </div>
               {lastCheck && Date.now() - lastCheck < ONE_DAY ? (
                 <span className="text-green-500 font-semibold text-sm">Completed</span>
@@ -170,7 +170,7 @@ export default function Tasks() {
               <div className="flex items-center space-x-2 text-sm">
                 <AiOutlineCheck className="w-5 h-5 text-accent" />
                 <span>On Chain Check In</span>
-                <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1] * 3} <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-4 h-4" /></span>
+                <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1] * 3} <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
               </div>
               {lastOnchain && Date.now() - lastOnchain < ONE_DAY ? (
                 <span className="text-green-500 font-semibold text-sm">Completed</span>
@@ -200,7 +200,7 @@ export default function Tasks() {
 
               <span>{t.description}</span>
 
-              <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-4 h-4" /></span>
+              <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
 
             </div>
 
@@ -231,7 +231,7 @@ export default function Tasks() {
           <div className="flex items-center space-x-2 text-sm">
             {ICONS.watch_ad}
             <span>Watch Ad ({adCount}/10)</span>
-            <span className="text-xs text-subtext flex items-center gap-1">100 <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-4 h-4" /></span>
+            <span className="text-xs text-subtext flex items-center gap-1">100 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
           </div>
           {adCount >= 10 ? (
             <span className="text-green-500 font-semibold text-sm">Completed</span>

--- a/webapp/src/pages/Tokenomics.jsx
+++ b/webapp/src/pages/Tokenomics.jsx
@@ -317,30 +317,30 @@ export default function TokenomicsPage() {
           <h4 className="font-semibold text-accent mb-1">TonPlaygram Accomplishments So Far</h4>
           <ul className="list-disc pl-6 space-y-1">
             <li><b>Core Infrastructure</b></li>
-            <li className="ml-4">🔐 Smart-contract-based presale is live — TON sent, TPC <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 ml-1" /> auto-delivered to wallet</li>
+            <li className="ml-4">🔐 Smart-contract-based presale is live — TON sent, TPC <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 ml-1" /> auto-delivered to wallet</li>
             <li className="ml-4">🧾 Wallet transaction history fully functional</li>
-            <li className="ml-4">💬 In-chat TPC <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 ml-1" /> transfers enabled</li>
+            <li className="ml-4">💬 In-chat TPC <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 ml-1" /> transfers enabled</li>
             <li><b>Game Features</b></li>
             <li className="ml-4">🎲 Snake &amp; Ladder Game launched (1v1 vs AI &amp; 2–4 player multiplayer)</li>
             <li className="ml-4">🧑‍🤝‍🤝 Online user status, add friends, and inbox chat inside game</li>
             <li className="ml-4">🕹️ Full integration between Telegram Bot and WebApp</li>
             <li><b>Rewards &amp; Incentives</b></li>
-            <li className="ml-4">🔄 Daily Check-In System: 1,000 <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 mx-1" /> on Day 1 → 30,000 <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 ml-1" /> by Day 30</li>
-            <li className="ml-4">⛏️ Mining system (2,000 <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 mx-1" /> every 12 hours)</li>
-            <li className="ml-4">📺 Ad Watch Rewards: 100 <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 mx-1" /> per ad (up to 10/day)</li>
-            <li className="ml-4">🎯 Social Tasks: +10,000 <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 mx-1" /> each for Twitter, Telegram, TikTok</li>
-            <li className="ml-4">📹 Intro Video Views: +5 <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 mx-1" /> each</li>
-            <li className="ml-4">🎡 Spin &amp; Win Wheel: 300–1800 <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 mx-1" /> prizes + Bonus x3 chance</li>
+            <li className="ml-4">🔄 Daily Check-In System: 1,000 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> on Day 1 → 30,000 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 ml-1" /> by Day 30</li>
+            <li className="ml-4">⛏️ Mining system (2,000 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> every 12 hours)</li>
+            <li className="ml-4">📺 Ad Watch Rewards: 100 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> per ad (up to 10/day)</li>
+            <li className="ml-4">🎯 Social Tasks: +10,000 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> each for Twitter, Telegram, TikTok</li>
+            <li className="ml-4">📹 Intro Video Views: +5 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> each</li>
+            <li className="ml-4">🎡 Spin &amp; Win Wheel: 300–1800 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> prizes + Bonus x3 chance</li>
           </ul>
         </div>
 
         <div>
           <h4 className="font-semibold text-accent mb-1">What’s Live Right Now</h4>
           <ul className="list-disc pl-6 space-y-1">
-            <li>🛒 Presale Store with bundles up to 5M <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 ml-1" /></li>
+            <li>🛒 Presale Store with bundles up to 5M <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 ml-1" /></li>
             <li>🧑‍💻 Mining &amp; Boosters (via Virtual Friends)</li>
-            <li>🔁 Spin &amp; Win Packs (with spins and TPC <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 ml-1" />)</li>
-            <li>🎁 Bonus Packs (spins + TPC <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 ml-1" /> + boosts)</li>
+            <li>🔁 Spin &amp; Win Packs (with spins and TPC <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 ml-1" />)</li>
+            <li>🎁 Bonus Packs (spins + TPC <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 ml-1" /> + boosts)</li>
             <li>📲 Telegram Notifications for token transfers</li>
             <li>👥 Multiplayer game rooms and social features</li>
             <li>💼 Automated wallet system across WebApp and Telegram</li>
@@ -351,8 +351,8 @@ export default function TokenomicsPage() {
           <h4 className="font-semibold text-accent mb-1">Next Phase: Coming Soon</h4>
           <ul className="list-disc pl-6 space-y-1">
             <li><b>Utility &amp; Token Expansion</b></li>
-            <li className="ml-4">🪙 Mint TPC <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 ml-1" /> on TON network</li>
-            <li className="ml-4">🌐 Enable claiming TPC <img src="/assets/icons/TPCcoin.png" alt="TPC" className="inline-block w-4 h-4 ml-1" /> to external wallets (Tonkeeper, OKX, etc.)</li>
+            <li className="ml-4">🪙 Mint TPC <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 ml-1" /> on TON network</li>
+            <li className="ml-4">🌐 Enable claiming TPC <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 ml-1" /> to external wallets (Tonkeeper, OKX, etc.)</li>
             <li className="ml-4">💱 Smart contracts for TON/USDT betting tables</li>
             <li><b>Governance &amp; Growth</b></li>
             <li className="ml-4">🗳️ DAO Governance System launch</li>

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -256,7 +256,7 @@ export default function Wallet() {
       <div className="prism-box p-6 space-y-2 min-h-40 flex flex-col items-start wide-card mx-auto">
         <p className="text-xs break-all w-full text-left">Account: {accountId || '...'}</p>
         <div className="flex items-center space-x-1">
-          <img src="/assets/icons/TPCcoin.png" alt="TPC" className="w-8 h-8" />
+          <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-8 h-8" />
           <span className="text-lg font-medium">TPC Balance</span>
         </div>
         <p className="text-xl font-medium">

--- a/webapp/src/utils/coinConfetti.ts
+++ b/webapp/src/utils/coinConfetti.ts
@@ -12,7 +12,7 @@ export default function coinConfetti(count: number = 50) {
 
   for (let i = 0; i < count; i++) {
     const img = document.createElement('img');
-    img.src = '/assets/icons/TPCcoin.png';
+    img.src = '/assets/icons/TPCcoin_1.webp';
     img.alt = 'TPC Coin';
     img.className = 'coin-confetti';
     const left = Math.random() * 100;


### PR DESCRIPTION
## Summary
- switch token and logo images to the new `.webp` assets
- update dice icon
- update metadata and notification image path
- document the new image names

## Testing
- `npm test` *(fails: snake API endpoints timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686c031f45c0832980ba9dccda1b7413