### PR TITLE
Update icons to new WebP versions

### DIFF
--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -32,7 +32,7 @@ export default function RewardPopup({ reward, onClose, duration = 2500, showClos
             <>
               <img
 
-                src="/assets/icons/file_00000000eeb061f79122a7d007f9bddc.webp"
+                src="/assets/icons/file_00000000ead061faa3b429466e006f48.webp"
                 alt="Bonus"
                 className="w-8 h-8"
               />
@@ -42,8 +42,8 @@ export default function RewardPopup({ reward, onClose, duration = 2500, showClos
           {typeof reward === 'number' && reward === 1600 && (
             <>
               <img
-                
-                src="/assets/icons/FreeSpin.png"
+
+                src="/assets/icons/FreeSpin.webp"
                 alt="Free Spin"
                 className="w-8 h-8"
               />
@@ -53,8 +53,8 @@ export default function RewardPopup({ reward, onClose, duration = 2500, showClos
           {typeof reward === 'number' && reward === 1800 && (
             <>
               <img
-                
-                src="/assets/icons/FreeSpin.png"
+
+                src="/assets/icons/FreeSpin.webp"
                 alt="Free Spin"
                 className="w-8 h-8"
               />

--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -105,7 +105,7 @@ export default function SnakeBoard({
         cellType === "ladder"
           ? "/assets/icons/Ladder.webp"
           : cellType === "snake"
-          ? "/assets/icons/snake.png"
+          ? "/assets/icons/snake_vector_no_bg.webp"
           : null;
       const offsetVal =
         cellType === "ladder"
@@ -144,7 +144,7 @@ export default function SnakeBoard({
           {!cellType && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
-              <img  src="/assets/icons/file_00000000eeb061f79122a7d007f9bddc.webp" className="dice-icon" />
+              <img  src="/assets/icons/file_00000000ead061faa3b429466e006f48.webp" className="dice-icon" />
               <span className="dice-value">+{diceCells[num]}</span>
             </span>
           )}

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -228,8 +228,8 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
               ) : val === 1600 || val === 1800 ? (
                 <>
                   <img
-                    
-                    src="/assets/icons/FreeSpin.png"
+
+                    src="/assets/icons/FreeSpin.webp"
                     alt="Free Spin"
                     className="w-8 h-8 mr-1"
                   />

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -252,7 +252,7 @@ function Board({
         cellType === "ladder"
           ? "/assets/icons/Ladder.webp"
           : cellType === "snake"
-            ? "/assets/icons/snake.png"
+            ? "/assets/icons/snake_vector_no_bg.webp"
             : null;
       const offsetVal =
         cellType === "ladder"
@@ -295,7 +295,7 @@ function Board({
           {!cellType && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
-              <img  src="/assets/icons/file_00000000eeb061f79122a7d007f9bddc.webp" className="dice-icon" />
+              <img  src="/assets/icons/file_00000000ead061faa3b429466e006f48.webp" className="dice-icon" />
               <span className="dice-value">+{diceCells[num]}</span>
             </span>
           )}
@@ -1892,7 +1892,7 @@ export default function SnakeAndLadder() {
       {rewardDice > 0 && (
         <div className="fixed bottom-40 inset-x-0 flex justify-center z-30 pointer-events-none reward-dice-container">
           {Array.from({ length: rewardDice }).map((_, i) => (
-            <img key={i}  src="/assets/icons/file_00000000eeb061f79122a7d007f9bddc.webp" className="reward-dice" />
+            <img key={i}  src="/assets/icons/file_00000000ead061faa3b429466e006f48.webp" className="reward-dice" />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- switch snake icon to `snake_vector_no_bg.webp`
- update dice icon to `file_00000000ead061faa3b429466e006f48.webp`
- use `FreeSpin.webp` icon in reward UI

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686c244ba6e48329a1900a2be7f559e4