### PR TITLE
Remove player targeting and unsuitable quick messages

### DIFF
--- a/webapp/src/components/QuickMessagePopup.jsx
+++ b/webapp/src/components/QuickMessagePopup.jsx
@@ -5,16 +5,13 @@ const MESSAGES = [
   'Nice bro 😀',
   'Well done 👍',
   "You're lucky 🍀",
-  "You're cute 😊",
-  "You're beautiful 😍",
   'No way 😲',
   'Damn it 😡',
   'Love it ❤️',
   'Good job 👏',
 ];
 
-export default function QuickMessagePopup({ open, onClose, players = [], onSend }) {
-  const [target, setTarget] = useState(players[0]?.index || 0);
+export default function QuickMessagePopup({ open, onClose, onSend }) {
   const [message, setMessage] = useState(MESSAGES[0]);
   if (!open) return null;
   return createPortal(
@@ -26,17 +23,6 @@ export default function QuickMessagePopup({ open, onClose, players = [], onSend 
         className="bg-surface border border-border rounded p-4 space-y-2 w-64"
         onClick={(e) => e.stopPropagation()}
       >
-        <select
-          className="w-full border border-border rounded p-1 bg-surface"
-          value={target}
-          onChange={(e) => setTarget(Number(e.target.value))}
-        >
-          {players.map((p) => (
-            <option key={p.index} value={p.index}>
-              {p.name}
-            </option>
-          ))}
-        </select>
         <div className="grid grid-cols-2 gap-1 max-h-40 overflow-y-auto">
           {MESSAGES.map((m) => (
             <button
@@ -53,7 +39,7 @@ export default function QuickMessagePopup({ open, onClose, players = [], onSend 
         <button
           className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
           onClick={() => {
-            onSend && onSend(target, message);
+            onSend && onSend(message);
             onClose();
           }}
         >

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1856,11 +1856,9 @@ export default function SnakeAndLadder() {
       <QuickMessagePopup
         open={showChat}
         onClose={() => setShowChat(false)}
-        players={players.map((p, i) => ({ ...p, index: i, name: getPlayerName(i) }))}
-        onSend={(idx, text) => {
-          const target = players[idx];
+        onSend={(text) => {
           const id = Date.now();
-          setChatBubbles((b) => [...b, { id, text, photoUrl: target.photoUrl }]);
+          setChatBubbles((b) => [...b, { id, text, photoUrl }]);
           setTimeout(
             () => setChatBubbles((b) => b.filter((bb) => bb.id !== id)),
             3000,


### PR DESCRIPTION
## Summary
- tone down the quick message list by removing flirtatious messages
- simplify QuickMessagePopup so quick messages don't target specific players
- adapt SnakeAndLadder to the new QuickMessagePopup API

## Testing
- `npm test` *(fails: testTimeoutFailure)*

------
https://chatgpt.com/codex/tasks/task_e_686c2e88d8c08329a4bf6b6d58782007