### PR TITLE
Fix spin confetti and wheel layout

### DIFF
--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -13,7 +13,13 @@ interface RewardPopupProps {
 export default function RewardPopup({ reward, onClose, duration = 2500, showCloseButton = true }: RewardPopupProps) {
   if (reward === null) return null;
   useEffect(() => {
-    coinConfetti(50);
+    let icon = '/assets/icons/TPCcoin_1.webp';
+    if (reward === 'BONUS_X3') {
+      icon = '/assets/icons/file_00000000ead061faa3b429466e006f48.webp';
+    } else if (reward === 1600 || reward === 1800) {
+      icon = '/assets/icons/FreeSpin.webp';
+    }
+    coinConfetti(50, icon);
     const audio = new Audio('/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3');
     audio.volume = getGameVolume();
     audio.play().catch(() => {});
@@ -22,7 +28,7 @@ export default function RewardPopup({ reward, onClose, duration = 2500, showClos
       audio.pause();
       clearTimeout(timer);
     };
-  }, [onClose, duration]);
+  }, [onClose, duration, reward]);
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="text-center space-y-4 text-text">

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -208,17 +208,13 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
           {items.map((val, idx) => (
 
             <div
-
               key={idx}
-
-              className={`board-style border-2 border-border flex items-center justify-center text-sm w-28 font-bold ${
-
+              className={`board-style border-2 border-border text-sm w-28 font-bold flex items-center ${
+                val === 'BONUS_X3' ? 'justify-center' : 'justify-start pl-2 space-x-1'
+              } ${
                 idx === winnerIndex ? 'bg-yellow-300 text-black border-4 border-brand-gold shadow-[0_0_12px_rgba(241,196,15,0.8)]' : 'text-white'
-
               }`}
-
               style={{ height: itemHeight }}
-
             >
 
               {val === 'BONUS_X3' ? (
@@ -231,7 +227,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
 
                     src="/assets/icons/FreeSpin.webp"
                     alt="Free Spin"
-                    className="w-8 h-8 mr-1"
+                    className="w-8 h-8"
                   />
                   <span>
                     {val === 1600 && '1'}
@@ -240,7 +236,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
                 </>
               ) : (
                 <>
-                  <img  src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-8 h-8 mr-1" />
+                  <img  src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-8 h-8" />
                   <span>{val >= 1000 ? `${val / 1000}k` : val}</span>
                 </>
               )}

--- a/webapp/src/utils/coinConfetti.ts
+++ b/webapp/src/utils/coinConfetti.ts
@@ -1,4 +1,4 @@
-export default function coinConfetti(count: number = 50) {
+export default function coinConfetti(count: number = 50, iconSrc: string = '/assets/icons/TPCcoin_1.webp') {
   const container = document.createElement('div');
   container.style.position = 'fixed';
   container.style.top = '0';
@@ -12,8 +12,8 @@ export default function coinConfetti(count: number = 50) {
 
   for (let i = 0; i < count; i++) {
     const img = document.createElement('img');
-    img.src = '/assets/icons/TPCcoin_1.webp';
-    img.alt = 'TPC Coin';
+    img.src = iconSrc;
+    img.alt = 'confetti icon';
     img.className = 'coin-confetti';
     const left = Math.random() * 100;
     const delay = Math.random() * 0.2;


### PR DESCRIPTION
## Summary
- align icons in spin wheel rows
- allow custom icons for confetti
- burst free spin or bonus icons when appropriate

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686cb602b02483299b8c83cda5dfcee8