### PR TITLE
Fix snake turn timer on overshoot

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1333,9 +1333,11 @@ export default function SnakeAndLadder() {
           target = FINAL_TILE;
         } else {
           setMessage("Need a 1 to win!");
-          setTurnMessage("Your turn");
-          setDiceVisible(true);
-          setMoving(false);
+          setTurnMessage("");
+          setDiceVisible(false);
+          const next = (currentTurn + 1) % (ai + 1);
+          setTimeout(() => setCurrentTurn(next), 1500);
+          setTimeout(() => setMoving(false), 1500);
           return;
         }
       } else if (current === 0) {
@@ -1356,9 +1358,11 @@ export default function SnakeAndLadder() {
         target = current + value;
       } else {
         setMessage("Need exact roll!");
-        setTurnMessage("Your turn");
-        setDiceVisible(true);
-        setMoving(false);
+        setTurnMessage("");
+        setDiceVisible(false);
+        const next = (currentTurn + 1) % (ai + 1);
+        setTimeout(() => setCurrentTurn(next), 1500);
+        setTimeout(() => setMoving(false), 1500);
         return;
       }
 


### PR DESCRIPTION
## Summary
- move to next player if final roll isn't exact
- continue timer when player overshoots the pot

## Testing
- `npm test --silent` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686cb7785008832985d019067c96d68d