### PR TITLE
Add more chat messages and gift confirmation

### DIFF
--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -3,71 +3,110 @@ import { createPortal } from 'react-dom';
 import { getTelegramId } from '../utils/telegram.js';
 import { sendGift } from '../utils/api.js';
 import { GIFTS } from '../utils/gifts.js';
+import ConfirmPopup from './ConfirmPopup.jsx';
+import InfoPopup from './InfoPopup.jsx';
 
 export default function GiftPopup({ open, onClose, players = [] }) {
   const [selected, setSelected] = useState(GIFTS[0]);
   const [target, setTarget] = useState(players[0]?.index || 0);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [infoMsg, setInfoMsg] = useState('');
   if (!open) return null;
   const recipient = players.find((p) => p.index === target);
 
   const handleSend = async () => {
     if (!recipient) return;
+    setConfirmOpen(false);
     try {
-      await sendGift(getTelegramId(), recipient.telegramId || recipient.id, selected.id);
-      alert(`Sent ${selected.name} to ${recipient.name}`);
+      await sendGift(
+        getTelegramId(),
+        recipient.telegramId || recipient.id,
+        selected.id
+      );
+      setInfoMsg(`Sent ${selected.name} to ${recipient.name}`);
     } catch {
-      alert('Failed to send gift');
+      setInfoMsg('Failed to send gift');
     }
     onClose();
   };
 
   const tiers = [1, 2, 3];
   return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70" onClick={onClose}>
-      <div className="bg-surface border border-border rounded p-4 space-y-2 w-72" onClick={(e) => e.stopPropagation()}>
-        <p className="text-center font-semibold mb-2">Send Gift</p>
-        <div className="space-y-1 max-h-32 overflow-y-auto">
-          {players.map((p) => (
-            <button
-              key={p.index}
-              onClick={() => setTarget(p.index)}
-              className={`w-full flex items-center space-x-2 border border-border rounded px-1 py-0.5 text-sm ${target === p.index ? 'bg-accent' : ''}`}
-            >
-              <img src={p.photoUrl} className="w-6 h-6 rounded-full" />
-              <span>{p.name}</span>
-            </button>
-          ))}
-        </div>
-        {tiers.map(tier => (
-          <div key={tier} className="space-y-1">
-            <p className="text-sm font-bold">Tier {tier}</p>
-            <div className="grid grid-cols-2 gap-1">
-              {GIFTS.filter(g => g.tier === tier).map(g => (
-                <button
-                  key={g.id}
-                  onClick={() => setSelected(g)}
-                  className={`border border-border rounded px-1 py-0.5 text-sm flex items-center justify-center space-x-1 ${selected.id === g.id ? 'bg-accent' : ''}`}
-                >
-                  <span>{g.icon}</span>
-                  <span className="flex items-center space-x-0.5">
-                    <span>{g.price}</span>
-                    <img src="/assets/icons/TPCcoin_1.webp" className="w-3 h-3" />
-                  </span>
-                </button>
-              ))}
-            </div>
+    <>
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70"
+        onClick={onClose}
+      >
+        <div
+          className="bg-surface border border-border rounded p-4 space-y-2 w-72"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <p className="text-center font-semibold mb-2">Send Gift</p>
+          <div className="space-y-1 max-h-32 overflow-y-auto">
+            {players.map((p) => (
+              <button
+                key={p.index}
+                onClick={() => setTarget(p.index)}
+                className={`w-full flex items-center space-x-2 border border-border rounded px-1 py-0.5 text-sm ${
+                  target === p.index ? 'bg-accent' : ''
+                }`}
+              >
+                <img src={p.photoUrl} className="w-6 h-6 rounded-full" />
+                <span>{p.name}</span>
+              </button>
+            ))}
           </div>
-        ))}
-        <div className="text-xs text-center mt-2 flex items-center justify-center space-x-1">
-          <span>Cost:</span>
-          <span>{selected.price}</span>
-          <img src="/assets/icons/TPCcoin_1.webp" className="w-3 h-3" />
+          {tiers.map((tier) => (
+            <div key={tier} className="space-y-1">
+              <p className="text-sm font-bold">Tier {tier}</p>
+              <div className="grid grid-cols-2 gap-1">
+                {GIFTS.filter((g) => g.tier === tier).map((g) => (
+                  <button
+                    key={g.id}
+                    onClick={() => setSelected(g)}
+                    className={`border border-border rounded px-1 py-0.5 text-sm flex items-center justify-center space-x-1 ${
+                      selected.id === g.id ? 'bg-accent' : ''
+                    }`}
+                  >
+                    <span>{g.icon}</span>
+                    <span className="flex items-center space-x-0.5">
+                      <span>{g.price}</span>
+                      <img src="/assets/icons/TPCcoin_1.webp" className="w-3 h-3" />
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+          <div className="text-xs text-center mt-2 flex items-center justify-center space-x-1">
+            <span>Cost:</span>
+            <span>{selected.price}</span>
+            <img src="/assets/icons/TPCcoin_1.webp" className="w-3 h-3" />
+          </div>
+          <button
+            className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
+            onClick={() => setConfirmOpen(true)}
+          >
+            Send {selected.icon} {selected.name}
+          </button>
+          <p className="text-xs text-center mt-1">
+            10% charge and the amount of the gift will be deducted from your balance.
+          </p>
         </div>
-        <button className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black" onClick={handleSend}>
-          Send {selected.icon} {selected.name}
-        </button>
       </div>
-    </div>,
+      <ConfirmPopup
+        open={confirmOpen}
+        message="10% charge and the amount of the gift will be deducted from your balance. Continue?"
+        onConfirm={handleSend}
+        onCancel={() => setConfirmOpen(false)}
+      />
+      <InfoPopup
+        open={Boolean(infoMsg)}
+        onClose={() => setInfoMsg('')}
+        title="Gift"
+        info={infoMsg}
+      />
+    </>,
     document.body,
   );
 }

--- a/webapp/src/components/QuickMessagePopup.jsx
+++ b/webapp/src/components/QuickMessagePopup.jsx
@@ -9,6 +9,13 @@ const MESSAGES = [
   'Damn it 😡',
   'Love it ❤️',
   'Good job 👏',
+  'So close 😬',
+  'Amazing move 😎',
+  'Too hard 😖',
+  'Yay! 🎉',
+  'This is fun 🤩',
+  "I'm lost 🤯",
+  'Great comeback 🏆',
 ];
 
 export default function QuickMessagePopup({ open, onClose, onSend }) {

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -75,9 +75,13 @@ export default function Wallet() {
   const [selectedTx, setSelectedTx] = useState(null);
   const dateInputRef = useRef(null);
 
-  const txTypes = Array.from(new Set(transactions.map((t) => t.type))).filter(
-    Boolean
-  );
+  const txTypes = Array.from(
+    new Set(
+      transactions.map((t) =>
+        ['gift', 'gift-receive', 'gift-fee'].includes(t.type) ? 'gift' : t.type
+      )
+    )
+  ).filter(Boolean);
 
 
   const loadBalances = async () => {
@@ -229,7 +233,20 @@ export default function Wallet() {
       const d = new Date(tx.date).toISOString().slice(0, 10);
       if (d !== filterDate) return false;
     }
-    if (filterType && tx.type !== filterType) return false;
+    if (filterType) {
+      if (
+        filterType === 'gift' &&
+        !['gift', 'gift-receive', 'gift-fee'].includes(tx.type)
+      ) {
+        return false;
+      }
+      if (
+        filterType !== 'gift' &&
+        tx.type !== filterType
+      ) {
+        return false;
+      }
+    }
     if (filterUser) {
       const q = filterUser.toLowerCase();
       const name = (tx.fromName || tx.toName || '').toLowerCase();


### PR DESCRIPTION
## Summary
- expand quick chat message options
- add confirmation and info popups when sending gifts
- unify gift filter option in statements

## Testing
- `npm test` *(fails: player and lobby tests)*

------
https://chatgpt.com/codex/tasks/task_e_686cc63a1288832987080845b0f41976