### PR TITLE
Add gift category to TPC statements

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -15,6 +15,7 @@ const transactionSchema = new mongoose.Schema(
     game: String,
     players: Number,
     detail: String,
+    category: String,
     txHash: String
   },
   { _id: false }

--- a/bot/routes/social.js
+++ b/bot/routes/social.js
@@ -137,6 +137,7 @@ router.post('/send-gift', async (req, res) => {
     date: txDate,
     toAccount: String(toId),
     detail: gift,
+    category: String(g.tier),
   });
   receiver.transactions.push({
     amount: recvAmount,
@@ -145,6 +146,7 @@ router.post('/send-gift', async (req, res) => {
     date: txDate,
     fromAccount: String(fromId),
     detail: gift,
+    category: String(g.tier),
   });
   if (devUser) {
     devUser.transactions.push({

--- a/bot/utils/gifts.js
+++ b/bot/utils/gifts.js
@@ -1,16 +1,19 @@
 export const GIFTS = [
-  { id: 'fireworks', price: 100 },
-  { id: 'laugh_bomb', price: 150 },
-  { id: 'pizza_slice', price: 200 },
-  { id: 'coffee_boost', price: 300 },
-  { id: 'baby_chick', price: 500 },
-  { id: 'speed_racer', price: 1000 },
-  { id: 'bullseye', price: 2000 },
-  { id: 'magic_trick', price: 3000 },
-  { id: 'surprise_box', price: 5000 },
-  { id: 'dragon_burst', price: 10000 },
-  { id: 'rocket_blast', price: 20000 },
-  { id: 'royal_crown', price: 50000 },
-  { id: 'alien_visit', price: 100000 },
+  // Tier 1 gifts
+  { id: 'fireworks', price: 100, tier: 1 },
+  { id: 'laugh_bomb', price: 150, tier: 1 },
+  { id: 'pizza_slice', price: 200, tier: 1 },
+  { id: 'coffee_boost', price: 300, tier: 1 },
+  { id: 'baby_chick', price: 500, tier: 1 },
+  // Tier 2 gifts
+  { id: 'speed_racer', price: 1000, tier: 2 },
+  { id: 'bullseye', price: 2000, tier: 2 },
+  { id: 'magic_trick', price: 3000, tier: 2 },
+  { id: 'surprise_box', price: 5000, tier: 2 },
+  // Tier 3 gifts
+  { id: 'dragon_burst', price: 10000, tier: 3 },
+  { id: 'rocket_blast', price: 20000, tier: 3 },
+  { id: 'royal_crown', price: 50000, tier: 3 },
+  { id: 'alien_visit', price: 100000, tier: 3 },
 ];
 export default GIFTS;

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -225,17 +225,14 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
           )}
 
           {gift && (
-
             <div className="text-sm flex items-center space-x-1">
-
               <span>Gift:</span>
-
               <span>{gift.icon}</span>
-
               <span>{gift.name}</span>
-
+              {typeof (tx.category || gift.tier) !== 'undefined' && (
+                <span className="text-xs text-subtext">(Tier {tx.category || gift.tier})</span>
+              )}
             </div>
-
           )}
 
           {gift && giftFee !== null && (

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -438,6 +438,7 @@ export default function Wallet() {
               if (tx.type === 'gift-fee') return 'gift fee';
               return tx.game ? 'game' : tx.type;
             })();
+            const categoryLabel = tx.category ? ` (Tier ${tx.category})` : '';
             const sign = tx.amount > 0 ? '+' : '-';
             const amt = formatValue(Math.abs(tx.amount), 2);
             return (
@@ -446,7 +447,10 @@ export default function Wallet() {
                 className="lobby-tile w-full flex justify-between items-center cursor-pointer"
                 onClick={() => setSelectedTx(tx)}
               >
-                <span className="capitalize">{typeLabel}</span>
+                <span className="capitalize">
+                  {typeLabel}
+                  {categoryLabel}
+                </span>
                 <span className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
                   {sign}
                   {amt} {(tx.token || 'TPC').toUpperCase()}


### PR DESCRIPTION
## Summary
- store gift tiers in bot's gift list
- record gift tier as `category` in gift transactions
- expose gift tier in TPC statements and details

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686ce2e0c42c8329b2ea6270278a4796