### PR TITLE
Unify gift transfers with TPC account routes

### DIFF
--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
-import { getTelegramId } from '../utils/telegram.js';
+import { getPlayerId } from '../utils/telegram.js';
 import { sendGift } from '../utils/api.js';
 import { GIFTS } from '../utils/gifts.js';
 import {
@@ -50,11 +50,7 @@ export default function GiftPopup({ open, onClose, players = [], senderIndex = 0
     if (!recipient) return;
     setConfirmOpen(false);
     try {
-      await sendGift(
-        getTelegramId(),
-        recipient.telegramId || recipient.id,
-        selected.id
-      );
+      await sendGift(getPlayerId(), recipient.id, selected.id);
       const sound = giftSounds[selected.id];
       if (sound) {
         const a = new Audio(sound);

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -297,7 +297,7 @@ export function sendMessage(fromId, toId, text) {
 }
 
 export function sendGift(fromId, toId, gift) {
-  return post('/api/social/send-gift', { fromId, toId, gift });
+  return post('/api/account/gift', { fromAccount: fromId, toAccount: toId, gift });
 }
 
 export function getMessages(telegramId, withId) {


### PR DESCRIPTION
## Summary
- add `/api/account/gift` route to handle gifting via account IDs
- call the new route from the webapp API
- update `GiftPopup` to use account IDs when sending gifts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686cf24e0bc483299261da055bde8173