### PR TITLE
Add gift sounds to animations

### DIFF
--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -3,40 +3,11 @@ import { createPortal } from 'react-dom';
 import { getPlayerId } from '../utils/telegram.js';
 import { sendGift } from '../utils/api.js';
 import { GIFTS } from '../utils/gifts.js';
-import {
-  giftSound_gift_00,
-  giftSound_gift_01,
-  giftSound_gift_02,
-  giftSound_gift_03,
-  giftSound_gift_04,
-  giftSound_gift_05,
-  giftSound_gift_06,
-  giftSound_gift_07,
-  giftSound_gift_08,
-  giftSound_gift_09,
-  giftSound_gift_10,
-  giftSound_gift_11,
-  giftSound_gift_12,
-} from '../assets/soundData.js';
+import { giftSounds } from '../utils/giftSounds.js';
 import { getGameVolume } from '../utils/sound.js';
 import ConfirmPopup from './ConfirmPopup.jsx';
 import InfoPopup from './InfoPopup.jsx';
 
-const giftSounds = {
-  fireworks: giftSound_gift_00,
-  laugh_bomb: giftSound_gift_01,
-  pizza_slice: giftSound_gift_02,
-  coffee_boost: giftSound_gift_03,
-  baby_chick: giftSound_gift_04,
-  speed_racer: giftSound_gift_05,
-  bullseye: giftSound_gift_06,
-  magic_trick: giftSound_gift_07,
-  surprise_box: giftSound_gift_08,
-  dragon_burst: giftSound_gift_09,
-  rocket_blast: giftSound_gift_10,
-  royal_crown: giftSound_gift_11,
-  alien_visit: giftSound_gift_12,
-};
 
 export default function GiftPopup({ open, onClose, players = [], senderIndex = 0, onGiftSent }) {
   const [selected, setSelected] = useState(GIFTS[0]);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -81,6 +81,7 @@ import ConfirmPopup from "../../components/ConfirmPopup.jsx";
 import PlayerPopup from "../../components/PlayerPopup.jsx";
 import QuickMessagePopup from "../../components/QuickMessagePopup.jsx";
 import GiftPopup from "../../components/GiftPopup.jsx";
+import { giftSounds } from "../../utils/giftSounds.js";
 import { moveSeq, flashHighlight, applyEffect as applyEffectHelper } from "../../utils/moveHelpers.js";
 
 const TOKEN_COLORS = [
@@ -1899,6 +1900,12 @@ export default function SnakeAndLadder() {
                 icon.style.transform = `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(1)`;
                 icon.style.zIndex = '9999';
                 document.body.appendChild(icon);
+                const giftSound = giftSounds[gift.id];
+                if (giftSound) {
+                  const a = new Audio(giftSound);
+                  a.volume = getGameVolume();
+                  a.play().catch(() => {});
+                }
                 const animation = icon.animate(
                   [
                     { transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(1)` },

--- a/webapp/src/utils/giftSounds.js
+++ b/webapp/src/utils/giftSounds.js
@@ -1,0 +1,33 @@
+import {
+  giftSound_gift_00,
+  giftSound_gift_01,
+  giftSound_gift_02,
+  giftSound_gift_03,
+  giftSound_gift_04,
+  giftSound_gift_05,
+  giftSound_gift_06,
+  giftSound_gift_07,
+  giftSound_gift_08,
+  giftSound_gift_09,
+  giftSound_gift_10,
+  giftSound_gift_11,
+  giftSound_gift_12,
+} from '../assets/soundData.js';
+
+export const giftSounds = {
+  fireworks: giftSound_gift_00,
+  laugh_bomb: giftSound_gift_01,
+  pizza_slice: giftSound_gift_02,
+  coffee_boost: giftSound_gift_03,
+  baby_chick: giftSound_gift_04,
+  speed_racer: giftSound_gift_05,
+  bullseye: giftSound_gift_06,
+  magic_trick: giftSound_gift_07,
+  surprise_box: giftSound_gift_08,
+  dragon_burst: giftSound_gift_09,
+  rocket_blast: giftSound_gift_10,
+  royal_crown: giftSound_gift_11,
+  alien_visit: giftSound_gift_12,
+};
+
+export default giftSounds;


### PR DESCRIPTION
## Summary
- centralize gift sound mapping for reuse
- use gift sounds in gift popup
- play corresponding sound during gift animation

## Testing
- `npm test` *(fails: player wins when all tokens finish, ludo lobby route lists players, online routes reflect pinged users, snake lobby route lists players, seat and unseat endpoints update lobby)*

------
https://chatgpt.com/codex/tasks/task_e_686cf87199bc832983346566d262b78b