### PR TITLE
Fix gift status recording

### DIFF
--- a/bot/routes/social.js
+++ b/bot/routes/social.js
@@ -138,6 +138,7 @@ router.post('/send-gift', async (req, res) => {
     amount: -g.price,
     type: 'gift',
     token: 'TPC',
+    status: 'delivered',
     date: txDate,
     toAccount: String(receiver.accountId),
     detail: gift,
@@ -147,6 +148,7 @@ router.post('/send-gift', async (req, res) => {
     amount: recvAmount,
     type: 'gift-receive',
     token: 'TPC',
+    status: 'delivered',
     date: txDate,
     fromAccount: String(sender.accountId),
     detail: gift,
@@ -157,6 +159,7 @@ router.post('/send-gift', async (req, res) => {
       amount: devShare,
       type: 'gift-fee',
       token: 'TPC',
+      status: 'delivered',
       date: txDate,
       fromAccount: String(sender.accountId),
     });


### PR DESCRIPTION
## Summary
- log `status: 'delivered'` when recording gift transactions via social route

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_686cfb815dfc832986e138b852f6d952