### PR TITLE
Adjust gift animation duration

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1932,7 +1932,8 @@ export default function SnakeAndLadder() {
                     { transform: `translate(${cx}px, ${cy}px) scale(3)`, offset: 0.5 },
                     { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(1)` },
                   ],
-                  { duration: 2000, easing: 'linear' },
+                  // Slow down gift animation to roughly 4.5 seconds
+                  { duration: 4500, easing: 'linear' },
                 );
                 animation.onfinish = () => icon.remove();
               }


### PR DESCRIPTION
## Summary
- slow down the gift animation in Snake & Ladder by extending the animation duration to ~4.5 seconds

## Testing
- `npm test` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_686d1a4e04b08329874d07db692ba7a6