### PR TITLE
Implement gift conversion

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -21,6 +21,19 @@ const transactionSchema = new mongoose.Schema(
   { _id: false }
 );
 
+const giftSchema = new mongoose.Schema(
+  {
+    _id: { type: String, default: uuidv4 },
+    gift: String,
+    price: Number,
+    tier: Number,
+    fromAccount: String,
+    fromName: String,
+    date: { type: Date, default: Date.now }
+  },
+  { _id: false }
+);
+
 const userSchema = new mongoose.Schema({
 
   telegramId: { type: Number, unique: true },
@@ -72,6 +85,8 @@ const userSchema = new mongoose.Schema({
   },
 
   transactions: [transactionSchema],
+
+  gifts: { type: [giftSchema], default: [] },
 
   referralCode: { type: String, unique: true },
 

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -300,6 +300,10 @@ export function sendGift(fromId, toId, gift) {
   return post('/api/account/gift', { fromAccount: fromId, toAccount: toId, gift });
 }
 
+export function convertGifts(accountId, giftIds) {
+  return post('/api/account/convert-gifts', { accountId, giftIds });
+}
+
 export function getMessages(telegramId, withId) {
   return post('/api/social/messages', { telegramId, withId });
 }


### PR DESCRIPTION
## Summary
- support gifts array on user model
- store gift for receiver without instant transfer
- add endpoint to convert gifts to TPC
- expose API helper to convert gifts
- show gifts on My Account page with convert option

## Testing
- `npm test` *(fails: Cannot find module 'dotenv', 'mongoose', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686d1d767b90832983acd53ab3f5ee22