### PR TITLE
Fix default fields for new profiles

### DIFF
--- a/bot/commands/mine.js
+++ b/bot/commands/mine.js
@@ -9,7 +9,7 @@ export default function registerMine(bot) {
     const user = await User.findOneAndUpdate(
       { telegramId },
       { $setOnInsert: { referralCode: telegramId.toString() } },
-      { upsert: true, new: true }
+      { upsert: true, new: true, setDefaultsOnInsert: true }
     );
 
     switch (sub) {

--- a/bot/commands/referral.js
+++ b/bot/commands/referral.js
@@ -6,7 +6,7 @@ export default function registerReferral(bot) {
     const user = await User.findOneAndUpdate(
       { telegramId },
       { $setOnInsert: { referralCode: telegramId.toString() } },
-      { upsert: true, new: true }
+      { upsert: true, new: true, setDefaultsOnInsert: true }
     );
     const count = await User.countDocuments({ referredBy: user.referralCode });
     const link = `https://t.me/${process.env.BOT_USERNAME || 'YourBot'}?start=${user.referralCode}`;

--- a/bot/commands/start.js
+++ b/bot/commands/start.js
@@ -15,7 +15,7 @@ export default function registerStart(bot) {
         },
         $setOnInsert: { referralCode: telegramId.toString() }
       },
-      { upsert: true }
+      { upsert: true, new: true, setDefaultsOnInsert: true }
     );
     ctx.reply('Welcome to TonPlaygram!', {
       reply_markup: {

--- a/bot/commands/tasks.js
+++ b/bot/commands/tasks.js
@@ -20,7 +20,7 @@ export default function registerTasks(bot) {
       const user = await User.findOneAndUpdate(
         { telegramId },
         { $setOnInsert: { referralCode: telegramId.toString() } },
-        { upsert: true, new: true }
+        { upsert: true, new: true, setDefaultsOnInsert: true }
       );
       user.minedTPC += config.reward;
       await user.save();

--- a/bot/commands/wallet.js
+++ b/bot/commands/wallet.js
@@ -34,7 +34,7 @@ export default function registerWallet(bot) {
         let receiver = await User.findOneAndUpdate(
           { telegramId: toId },
           { $inc: { balance: amount }, $setOnInsert: { referralCode: toId.toString() } },
-          { upsert: true, new: true }
+          { upsert: true, new: true, setDefaultsOnInsert: true }
         );
         ensureTransactionArray(receiver);
         sender.balance -= amount;

--- a/bot/routes/ads.js
+++ b/bot/routes/ads.js
@@ -39,7 +39,7 @@ router.post('/watch', async (req, res) => {
   const user = await User.findOneAndUpdate(
     { telegramId },
     { $setOnInsert: { referralCode: telegramId.toString() } },
-    { upsert: true, new: true }
+    { upsert: true, new: true, setDefaultsOnInsert: true }
   );
   ensureTransactionArray(user);
   user.minedTPC += REWARD;

--- a/bot/routes/airdrop.js
+++ b/bot/routes/airdrop.js
@@ -64,7 +64,7 @@ router.post('/grant', adminOnly, async (req, res) => {
 
       { $setOnInsert: { referralCode: telegramId.toString() } },
 
-      { upsert: true, new: true }
+      { upsert: true, new: true, setDefaultsOnInsert: true }
 
     );
 

--- a/bot/routes/checkin.js
+++ b/bot/routes/checkin.js
@@ -16,7 +16,7 @@ router.post('/check-in', async (req, res) => {
     const user = await User.findOneAndUpdate(
       { telegramId },
       { $setOnInsert: { referralCode: telegramId.toString() } },
-      { upsert: true, new: true }
+      { upsert: true, new: true, setDefaultsOnInsert: true }
     );
     ensureTransactionArray(user);
 

--- a/bot/routes/mining.js
+++ b/bot/routes/mining.js
@@ -13,7 +13,7 @@ async function getUser(req, res, next) {
   req.user = await User.findOneAndUpdate(
     { telegramId },
     { $setOnInsert: { referralCode: telegramId.toString() } },
-    { upsert: true, new: true }
+    { upsert: true, new: true, setDefaultsOnInsert: true }
   );
   next();
 }

--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -14,7 +14,7 @@ router.post('/register-wallet', async (req, res) => {
   const user = await User.findOneAndUpdate(
     { walletAddress },
     { $setOnInsert: { walletAddress, referralCode: walletAddress } },
-    { upsert: true, new: true }
+    { upsert: true, new: true, setDefaultsOnInsert: true }
   );
   res.json(user);
 });
@@ -27,7 +27,7 @@ router.post('/register-google', async (req, res) => {
   const user = await User.findOneAndUpdate(
     { googleId },
     { $setOnInsert: { googleId, referralCode: googleId } },
-    { upsert: true, new: true }
+    { upsert: true, new: true, setDefaultsOnInsert: true }
   );
   res.json(user);
 });
@@ -71,7 +71,7 @@ router.post('/get', async (req, res) => {
     user = await User.findOneAndUpdate(
       { telegramId },
       update,
-      { upsert: true, new: true }
+      { upsert: true, new: true, setDefaultsOnInsert: true }
     );
   }
 
@@ -106,7 +106,7 @@ router.post('/update', async (req, res) => {
   const user = await User.findOneAndUpdate(
     { telegramId },
     { $set: update, $setOnInsert: { referralCode: telegramId.toString() } },
-    { upsert: true, new: true }
+    { upsert: true, new: true, setDefaultsOnInsert: true }
   );
   res.json(user);
 });
@@ -119,7 +119,7 @@ router.post('/updateBalance', async (req, res) => {
   const user = await User.findOneAndUpdate(
     { telegramId },
     { $set: { balance }, $setOnInsert: { referralCode: telegramId.toString() } },
-    { upsert: true, new: true }
+    { upsert: true, new: true, setDefaultsOnInsert: true }
   );
   res.json({ balance: user.balance });
 });
@@ -169,7 +169,7 @@ router.post('/link-google', async (req, res) => {
   const user = await User.findOneAndUpdate(
     { telegramId },
     { $set: update, $setOnInsert: { referralCode: telegramId.toString() } },
-    { upsert: true, new: true }
+    { upsert: true, new: true, setDefaultsOnInsert: true }
   );
   res.json(user);
 });
@@ -186,7 +186,7 @@ router.post('/link-social', async (req, res) => {
   const user = await User.findOneAndUpdate(
     { telegramId },
     { $set: update, $setOnInsert: { referralCode: telegramId.toString() } },
-    { upsert: true, new: true }
+    { upsert: true, new: true, setDefaultsOnInsert: true }
   );
   res.json({ social: user.social });
 });

--- a/bot/routes/referral.js
+++ b/bot/routes/referral.js
@@ -10,7 +10,7 @@ router.post('/code', async (req, res) => {
   const user = await User.findOneAndUpdate(
     { telegramId },
     { $setOnInsert: { referralCode: telegramId.toString() } },
-    { upsert: true, new: true }
+    { upsert: true, new: true, setDefaultsOnInsert: true }
   );
 
   const count = await User.countDocuments({ referredBy: user.referralCode });
@@ -40,7 +40,7 @@ router.post('/claim', async (req, res) => {
   const user = await User.findOneAndUpdate(
     { telegramId },
     { $setOnInsert: { referralCode: telegramId.toString() } },
-    { upsert: true, new: true }
+    { upsert: true, new: true, setDefaultsOnInsert: true }
   );
 
   if (user.referredBy) {

--- a/bot/routes/tasks.js
+++ b/bot/routes/tasks.js
@@ -31,7 +31,7 @@ router.post('/complete', async (req, res) => {
   const user = await User.findOneAndUpdate(
     { telegramId },
     { $setOnInsert: { referralCode: telegramId.toString() } },
-    { upsert: true, new: true }
+    { upsert: true, new: true, setDefaultsOnInsert: true }
   );
   ensureTransactionArray(user);
   user.minedTPC += config.reward;

--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -198,7 +198,7 @@ router.post('/send', authenticate, async (req, res) => {
 
       { $inc: { balance: amount }, $setOnInsert: { referralCode: toId.toString() } },
 
-      { upsert: true, new: true }
+      { upsert: true, new: true, setDefaultsOnInsert: true }
 
     );
 
@@ -329,7 +329,7 @@ router.post('/deposit', authenticate, async (req, res) => {
 
     { $inc: { balance: amount }, $setOnInsert: { referralCode: telegramId.toString() } },
 
-    { upsert: true, new: true }
+    { upsert: true, new: true, setDefaultsOnInsert: true }
 
   );
 

--- a/bot/routes/watch.js
+++ b/bot/routes/watch.js
@@ -32,7 +32,7 @@ router.post('/watch', async (req, res) => {
   const user = await User.findOneAndUpdate(
     { telegramId },
     { $setOnInsert: { referralCode: telegramId.toString() } },
-    { upsert: true, new: true }
+    { upsert: true, new: true, setDefaultsOnInsert: true }
   );
   ensureTransactionArray(user);
   user.minedTPC += video.reward;


### PR DESCRIPTION
## Summary
- ensure new User documents get default arrays when upserting
- update multiple routes and bot commands to set defaults on insert

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686d28a63ce483298c8873d847ad53f3