### PR TITLE
Record gifts as pending transactions

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -16,7 +16,8 @@ const transactionSchema = new mongoose.Schema(
     players: Number,
     detail: String,
     category: String,
-    txHash: String
+    txHash: String,
+    giftId: String
   },
   { _id: false }
 );


### PR DESCRIPTION
## Summary
- track gift transactions with new `giftId` field
- record pending `gift-receive` transaction when sending a gift
- replace pending gift transaction when gifts are converted

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686d2d68b90c83298235b91eece3bd1a