### PR TITLE
Fix gifts and transactions retrieval

### DIFF
--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import {
-  getProfile,
+  getAccountInfo,
+  createAccount,
   updateProfile,
   fetchTelegramInfo,
   depositAccount,
@@ -69,7 +70,16 @@ export default function MyAccount() {
 
   useEffect(() => {
     async function load() {
-      const data = await getProfile(telegramId);
+      const acc = await createAccount(telegramId);
+      if (acc?.error) {
+        console.error('Failed to load account:', acc.error);
+        return;
+      }
+      if (acc.accountId) {
+        localStorage.setItem('accountId', acc.accountId);
+      }
+
+      const data = await getAccountInfo(acc.accountId);
       let finalProfile = data;
 
       if (!data.photo || !data.firstName || !data.lastName) {
@@ -97,8 +107,9 @@ export default function MyAccount() {
 
           const hasRealPhoto = updated.photo || tg?.photoUrl;
           const mergedProfile = {
+            ...data,
             ...updated,
-            photo: hasRealPhoto || getTelegramPhotoUrl()
+            photo: hasRealPhoto || getTelegramPhotoUrl(),
           };
 
           finalProfile = mergedProfile;

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -381,6 +381,10 @@ export function getAccountBalance(accountId) {
   return post('/api/account/balance', { accountId });
 }
 
+export function getAccountInfo(accountId) {
+  return post('/api/account/info', { accountId });
+}
+
 export function sendAccountTpc(fromAccount, toAccount, amount, note) {
   const body = { fromAccount, toAccount, amount };
   if (note) body.note = note;


### PR DESCRIPTION
## Summary
- add `/api/account/info` route to provide gifts and transactions for an account
- add `getAccountInfo` API helper
- load profile data through the new route in `MyAccount`

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686d30be37148329bc2e5f6e839e4b9a