### PR TITLE
Add gift sound effects

### DIFF
--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -26,7 +26,26 @@ export default function GiftPopup({ open, onClose, players = [], senderIndex = 0
       if (sound) {
         const a = new Audio(sound);
         a.volume = getGameVolume();
-        a.play().catch(() => {});
+        if (selected.id === 'bullseye') {
+          setTimeout(() => {
+            a.play().catch(() => {});
+          }, 2500);
+        } else {
+          a.play().catch(() => {});
+        }
+        if (selected.id === 'magic_trick') {
+          setTimeout(() => {
+            a.pause();
+          }, 4000);
+        } else if (selected.id === 'fireworks') {
+          setTimeout(() => {
+            a.pause();
+          }, 6000);
+        } else if (selected.id === 'surprise_box') {
+          setTimeout(() => {
+            a.pause();
+          }, 5000);
+        }
       }
       setInfoMsg(`Sent ${selected.name} to ${recipient.name}`);
       onGiftSent && onGiftSent({ from: senderIndex, to: target, gift: selected });

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1921,6 +1921,33 @@ export default function SnakeAndLadder() {
                   const a = new Audio(giftSound);
                   a.volume = getGameVolume();
                   a.play().catch(() => {});
+                } else if (gift.id === 'magic_trick' && !muted) {
+                  const a = new Audio(giftSound);
+                  a.volume = getGameVolume();
+                  a.play().catch(() => {});
+                  setTimeout(() => {
+                    a.pause();
+                  }, 4000);
+                } else if (gift.id === 'fireworks' && !muted) {
+                  const a = new Audio(giftSound);
+                  a.volume = getGameVolume();
+                  a.play().catch(() => {});
+                  setTimeout(() => {
+                    a.pause();
+                  }, 6000);
+                } else if (gift.id === 'surprise_box' && !muted) {
+                  const a = new Audio(giftSound);
+                  a.volume = getGameVolume();
+                  a.play().catch(() => {});
+                  setTimeout(() => {
+                    a.pause();
+                  }, 5000);
+                } else if (gift.id === 'bullseye' && !muted) {
+                  const a = new Audio(giftSound);
+                  a.volume = getGameVolume();
+                  setTimeout(() => {
+                    a.play().catch(() => {});
+                  }, 2500);
                 } else if (giftSound) {
                   const a = new Audio(giftSound);
                   a.volume = getGameVolume();

--- a/webapp/src/utils/giftSounds.js
+++ b/webapp/src/utils/giftSounds.js
@@ -15,19 +15,20 @@ import {
 } from '../assets/soundData.js';
 
 export const giftSounds = {
-  fireworks: giftSound_gift_00,
+  fireworks: "/assets/sounds/fireworks-29629.mp3",
   laugh_bomb: giftSound_gift_01,
   pizza_slice: "/assets/sounds/life_is_beautiful_italiano-108264.mp3",
   coffee_boost: "/assets/sounds/drinking-coffee-214463.mp3",
   baby_chick: "/assets/sounds/bebek-220068.mp3",
-  speed_racer: giftSound_gift_05,
-  bullseye: giftSound_gift_06,
-  magic_trick: giftSound_gift_07,
-  surprise_box: giftSound_gift_08,
-  dragon_burst: giftSound_gift_09,
-  rocket_blast: giftSound_gift_10,
-  royal_crown: giftSound_gift_11,
-  alien_visit: giftSound_gift_12,
+  speed_racer: "/assets/sounds/race-care-151963.mp3",
+  bullseye: "/assets/sounds/080998_bullet-hit-39870.mp3",
+  magic_trick: "/assets/sounds/ah-good-morning-sir-would-you-like-a-cup-of-tea-26151.mp3",
+  surprise_box: "/assets/sounds/082229_pinkie-pie-39surprise39wav-86428.mp3",
+  dragon_burst: "/assets/sounds/snake-hissing-high-quality-240154.mp3",
+  rocket_blast: "/assets/sounds/launch-85216.mp3",
+  royal_crown: "/assets/sounds/king-conversation-48272.mp3",
+  alien_visit: "/assets/sounds/ufo-sound-effect-240256.mp3",
+  snake: "/assets/sounds/snake-hissing-high-quality-240154.mp3",
 };
 
 export default giftSounds;


### PR DESCRIPTION
## Summary
- update sounds for each gift
- limit playback for magic trick, fireworks and surprise box
- delay bullseye sound until the gift is about to arrive
- update sending gift logic to use the new sounds

## Testing
- `npm test` *(fails: testCodeFailure, cancelledByParent)*

------
https://chatgpt.com/codex/tasks/task_e_686d3422206c832980a5ca8da9c0b1eb