### PR TITLE
Add poop gift and shorter animation

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1959,8 +1959,8 @@ export default function SnakeAndLadder() {
                     { transform: `translate(${cx}px, ${cy}px) scale(3)`, offset: 0.5 },
                     { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(1)` },
                   ],
-                  // Slow down gift animation to roughly 4.5 seconds
-                  { duration: 4500, easing: 'linear' },
+                  // Slow down gift animation to roughly 3.5 seconds
+                  { duration: 3500, easing: 'linear' },
                 );
                 animation.onfinish = () => icon.remove();
               }

--- a/webapp/src/utils/giftSounds.js
+++ b/webapp/src/utils/giftSounds.js
@@ -24,6 +24,7 @@ export const giftSounds = {
   bullseye: "/assets/sounds/080998_bullet-hit-39870.mp3",
   magic_trick: "/assets/sounds/ah-good-morning-sir-would-you-like-a-cup-of-tea-26151.mp3",
   surprise_box: "/assets/sounds/082229_pinkie-pie-39surprise39wav-86428.mp3",
+  poop: "/assets/sounds/fart-5-228245.mp3",
   dragon_burst: "/assets/sounds/snake-hissing-high-quality-240154.mp3",
   rocket_blast: "/assets/sounds/launch-85216.mp3",
   royal_crown: "/assets/sounds/king-conversation-48272.mp3",

--- a/webapp/src/utils/gifts.js
+++ b/webapp/src/utils/gifts.js
@@ -6,6 +6,7 @@ export const GIFTS = [
   { id: 'coffee_boost', name: 'Coffee Boost', icon: '☕', price: 300, tier: 1, effect: 'Funny “energy up” animation' },
   { id: 'baby_chick', name: 'Baby Chick', icon: '🐣', price: 500, tier: 1, effect: 'Cute chick dances on screen' },
   // Tier 2
+  { id: 'poop', name: 'Poop', icon: '💩', price: 666, tier: 2, effect: 'Smelly surprise' },
   { id: 'speed_racer', name: 'Speed Racer', icon: '🏎️', price: 1000, tier: 2, effect: 'Car zooms across the game board' },
   { id: 'bullseye', name: 'Bullseye', icon: '🎯', price: 2000, tier: 2, effect: "Dart hits target on player's profile" },
   { id: 'magic_trick', name: 'Magic Trick', icon: '🎩', price: 3000, tier: 2, effect: 'Random gift animation (slot-style)' },


### PR DESCRIPTION
## Summary
- add new `poop` gift for 666 TPC with fart sound
- shorten gift animation duration to 3.5 seconds

## Testing
- `npm test` *(fails: pass 8, fail 3)*

------
https://chatgpt.com/codex/tasks/task_e_686d3b2774508329bd4c014da6d3f735