### PR TITLE
Add gift categories to wallet statement filters

### DIFF
--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -75,15 +75,32 @@ export default function Wallet() {
   const [selectedTx, setSelectedTx] = useState(null);
   const dateInputRef = useRef(null);
 
+  const DEFAULT_TX_TYPES = [
+    'mining',
+    'spin',
+    'daily',
+    'receive',
+    'send',
+    'stake',
+    'win',
+    'deposit',
+    'ad',
+    'invite',
+    'gift-sent',
+    'gift-received',
+    'gift-fee',
+  ];
+
   const txTypes = Array.from(
-    new Set(
-      transactions.map((t) => {
+    new Set([
+      ...DEFAULT_TX_TYPES,
+      ...transactions.map((t) => {
         if (t.type === 'gift') return 'gift-sent';
         if (t.type === 'gift-receive') return 'gift-received';
         if (t.type === 'gift-fee') return 'gift-fee';
         return t.type;
-      })
-    )
+      }),
+    ])
   ).filter(Boolean);
 
 


### PR DESCRIPTION
## Summary
- include `gift` transaction types in wallet statement filters

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_686d528539788329943e7dbf9ba95971