### PR TITLE
Fix gifts visibility on profile

### DIFF
--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import User from '../models/User.js';
 import { fetchTelegramInfo } from '../utils/telegram.js';
-import { ensureTransactionArray } from '../utils/userUtils.js';
+import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
 
 const router = Router();
 
@@ -77,6 +77,14 @@ router.post('/get', async (req, res) => {
 
   if (!user.accountId) {
     user.accountId = uuidv4();
+    await user.save();
+  }
+
+  ensureTransactionArray(user);
+  if (!Array.isArray(user.gifts)) user.gifts = [];
+  const balance = calculateBalance(user);
+  if (user.balance !== balance) {
+    user.balance = balance;
     await user.save();
   }
 


### PR DESCRIPTION
## Summary
- ensure transactions and gifts are available in profile API
- recalc account balance when fetching profile

## Testing
- `npm test` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_686d6ca335dc8329a5ddd46931ef2f77