### PR TITLE
Allow NFT gift transfers and show token ids

### DIFF
--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -67,6 +67,8 @@ export default function MyAccount() {
   const [showNotifyModal, setShowNotifyModal] = useState(false);
   const [selectedGifts, setSelectedGifts] = useState([]);
   const [converting, setConverting] = useState(false);
+  const [convertAction, setConvertAction] = useState('burn');
+  const [transferAccount, setTransferAccount] = useState('');
 
   useEffect(() => {
     async function load() {
@@ -179,10 +181,16 @@ export default function MyAccount() {
     if (!selectedGifts.length) return;
     setConverting(true);
     try {
-      const res = await convertGifts(profile.accountId, selectedGifts);
+      const res = await convertGifts(
+        profile.accountId,
+        selectedGifts,
+        convertAction,
+        transferAccount.trim() || undefined
+      );
       if (!res?.error) {
         setProfile((p) => ({ ...p, gifts: res.gifts, balance: res.balance }));
         setSelectedGifts([]);
+        setTransferAccount('');
       }
     } catch (err) {
       console.error('convert gifts failed', err);
@@ -326,7 +334,17 @@ export default function MyAccount() {
                     }}
                   />
                   <span>{info.icon}</span>
-                  <span>{info.name || g.gift}</span>
+                  <span className="flex items-center space-x-1">
+                    <span>{info.name || g.gift}</span>
+                    <a
+                      href={`https://tonscan.org/nft/${g.tokenId || g._id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary underline text-xs"
+                    >
+                      {g.tokenId || g._id}
+                    </a>
+                  </span>
                   <span className="ml-auto">{g.price} TPC</span>
                 </label>
               );
@@ -336,13 +354,40 @@ export default function MyAccount() {
           )}
         </div>
         {profile.gifts && profile.gifts.length > 0 && (
-          <button
-            onClick={handleConvertGifts}
-            disabled={converting || selectedGifts.length === 0}
-            className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
-          >
-            {converting ? 'Converting...' : 'Convert Selected'}
-          </button>
+          <>
+            <div className="flex items-center space-x-2 mt-2">
+              <select
+                value={convertAction}
+                onChange={(e) => setConvertAction(e.target.value)}
+                className="border p-1 rounded text-black"
+              >
+                <option value="burn">Burn for TPC</option>
+                <option value="transfer">Transfer</option>
+              </select>
+              {convertAction === 'transfer' && (
+                <input
+                  type="text"
+                  placeholder="Receiver Account"
+                  value={transferAccount}
+                  onChange={(e) => setTransferAccount(e.target.value)}
+                  className="border p-1 rounded text-black flex-grow"
+                />
+              )}
+            </div>
+            <button
+              onClick={handleConvertGifts}
+              disabled={converting || selectedGifts.length === 0}
+              className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black mt-2"
+            >
+              {converting
+                ? convertAction === 'burn'
+                  ? 'Converting...'
+                  : 'Transferring...'
+                : convertAction === 'burn'
+                ? 'Convert Selected'
+                : 'Transfer Selected'}
+            </button>
+          </>
         )}
       </div>
 

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -300,8 +300,10 @@ export function sendGift(fromId, toId, gift) {
   return post('/api/account/gift', { fromAccount: fromId, toAccount: toId, gift });
 }
 
-export function convertGifts(accountId, giftIds) {
-  return post('/api/account/convert-gifts', { accountId, giftIds });
+export function convertGifts(accountId, giftIds, action = 'burn', toAccount) {
+  const body = { accountId, giftIds, action };
+  if (toAccount) body.toAccount = toAccount;
+  return post('/api/account/convert-gifts', body);
 }
 
 export function getMessages(telegramId, withId) {


### PR DESCRIPTION
## Summary
- show token id links in gift list
- support transferring or burning NFTs when converting gifts
- allow frontend to specify conversion action and receiver

## Testing
- `npm test` *(fails: Cannot find package dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686dee002d3483299feec261d4fec4ca