### PR TITLE
Add NFT minting to gift route

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -30,7 +30,8 @@ const giftSchema = new mongoose.Schema(
     tier: Number,
     fromAccount: String,
     fromName: String,
-    date: { type: Date, default: Date.now }
+    date: { type: Date, default: Date.now },
+    nftTokenId: String
   },
   { _id: false }
 );

--- a/bot/utils/nftService.js
+++ b/bot/utils/nftService.js
@@ -1,0 +1,46 @@
+import { withProxy } from './proxyAgent.js';
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Mint an NFT representing the given gift.
+ *
+ * @param {string} giftId - Gift identifier
+ * @param {string} toAccount - Receiver wallet/account address
+ * @returns {Promise<string>} Resolves to minted NFT token ID
+ */
+export async function mintGiftNFT(giftId, toAccount) {
+  const base = process.env.NFT_API_BASE_URL;
+  // When no external service is configured we generate a dummy token ID
+  if (!base) {
+    return uuidv4();
+  }
+  const url = `${base.replace(/\/$/, '')}/mint`;
+  const resp = await fetch(url, {
+    method: 'POST',
+    ...withProxy({
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ giftId, toAccount }),
+    }),
+  });
+  if (!resp.ok) {
+    let msg;
+    try {
+      msg = await resp.text();
+    } catch {
+      msg = resp.statusText;
+    }
+    throw new Error(msg || 'Mint request failed');
+  }
+  let data;
+  try {
+    data = await resp.json();
+  } catch {
+    throw new Error('Invalid mint response');
+  }
+  if (!data || !data.tokenId) {
+    throw new Error('Invalid mint response');
+  }
+  return data.tokenId;
+}
+
+export default { mintGiftNFT };


### PR DESCRIPTION
## Summary
- add nftService for minting gift NFTs
- store token ID in user's gift records
- mint NFT before recording gift on `/gift` route

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686dedfb09fc8329ad3adeca1994a0e4