### PR TITLE
Add nftTokenId field to gifts

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -30,6 +30,7 @@ const giftSchema = new mongoose.Schema(
     tier: Number,
     fromAccount: String,
     fromName: String,
+    nftTokenId: String,
     date: { type: Date, default: Date.now }
   },
   { _id: false }

--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -268,6 +268,7 @@ router.post('/gift', async (req, res) => {
     tier: g.tier,
     fromAccount: String(fromAccount),
     fromName: sender.nickname || sender.firstName || '',
+    nftTokenId: uuidv4(),
     date: txDate,
   };
   receiver.gifts.push(giftEntry);


### PR DESCRIPTION
## Summary
- extend `giftSchema` with `nftTokenId`
- store an NFT token ID when gifts are created

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_686dedf5c174832994076d1252a34c07