### PR TITLE
Implement new reward formulas

### DIFF
--- a/bot/commands/mine.js
+++ b/bot/commands/mine.js
@@ -35,7 +35,7 @@ export default function registerMine(bot) {
         break;
       case 'status':
       default:
-        updateMiningRewards(user);
+        await updateMiningRewards(user);
         await user.save();
         ctx.reply(`Mining: ${user.isMining ? 'active' : 'inactive'}\nPending rewards: ${user.minedTPC} TPC\nBalance: ${user.balance}`);
         break;

--- a/bot/routes/ads.js
+++ b/bot/routes/ads.js
@@ -4,8 +4,8 @@ import User from '../models/User.js';
 import { ensureTransactionArray } from '../utils/userUtils.js';
 
 const router = Router();
-const DAILY_LIMIT = 10;
-const REWARD = 100;
+const DAILY_LIMIT = 5;
+const REWARD = 50;
 
 function startOfToday() {
   const d = new Date();

--- a/bot/routes/checkin.js
+++ b/bot/routes/checkin.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import User from '../models/User.js';
 import { ensureTransactionArray } from '../utils/userUtils.js';
 
-const REWARDS = Array.from({ length: 30 }, (_, i) => 1000 * (i + 1));
+const REWARDS = Array.from({ length: 30 }, (_, i) => Math.floor(100 + (i + 1) * 50));
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 const router = Router();
@@ -29,7 +29,9 @@ router.post('/check-in', async (req, res) => {
     let streak = 1;
     if (user.lastCheckIn && now - user.lastCheckIn.getTime() < ONE_DAY_MS * 2) {
       streak = user.dailyStreak + 1;
-      if (streak > REWARDS.length) streak = 1;
+    }
+    if (streak > REWARDS.length) {
+      return res.status(400).json({ error: 'max days reached' });
     }
     const reward = REWARDS[streak - 1];
 

--- a/bot/routes/mining.js
+++ b/bot/routes/mining.js
@@ -40,7 +40,7 @@ router.post('/claim', getUser, async (req, res) => {
 });
 
 router.post('/status', getUser, async (req, res) => {
-  updateMiningRewards(req.user);
+  await updateMiningRewards(req.user);
   await req.user.save();
   res.json({ isMining: req.user.isMining, pending: req.user.minedTPC, balance: req.user.balance });
 });

--- a/bot/utils/miningUtils.js
+++ b/bot/utils/miningUtils.js
@@ -1,9 +1,16 @@
 export const MINING_SESSION_MS = 12 * 60 * 60 * 1000; // 12 hours
-export const MINING_REWARD = 2000; // base mining multiplier
+import User from '../models/User.js';
+
+export function getMiningReward(activeMiners) {
+  if (activeMiners < 5000) return 1000;
+  if (activeMiners < 10000) return 750;
+  if (activeMiners < 20000) return 500;
+  return 250;
+}
 
 import { ensureTransactionArray } from './userUtils.js';
 
-export function updateMiningRewards(user) {
+export async function updateMiningRewards(user) {
   ensureTransactionArray(user);
   if (user.isMining && user.lastMineAt) {
     const diffMs = Date.now() - user.lastMineAt.getTime();
@@ -12,7 +19,8 @@ export function updateMiningRewards(user) {
       user.lastMineAt = null;
       user.minedTPC = 0;
       const baseRate = 1;
-      const miningMultiplier = MINING_REWARD;
+      const activeMiners = await User.countDocuments({ isMining: true });
+      const miningMultiplier = getMiningReward(activeMiners);
       let storeRate = 0;
       if (user.storeMiningRate && user.storeMiningExpiresAt) {
         if (user.storeMiningExpiresAt > new Date()) {
@@ -44,14 +52,14 @@ export async function startMining(user) {
 
 export async function stopMining(user) {
   ensureTransactionArray(user);
-  updateMiningRewards(user);
+  await updateMiningRewards(user);
   user.isMining = false;
   await user.save();
 }
 
 export async function claimRewards(user) {
   ensureTransactionArray(user);
-  updateMiningRewards(user);
+  await updateMiningRewards(user);
   const amount = user.minedTPC;
   user.minedTPC = 0;
   user.balance += amount;

--- a/bot/utils/tasksData.js
+++ b/bot/utils/tasksData.js
@@ -6,7 +6,7 @@ export const TASKS = [
 
     description: 'Join us on X',
 
-    reward: 10000,
+    reward: 2500,
 
     icon: 'twitter',
 
@@ -20,7 +20,7 @@ export const TASKS = [
 
     description: 'Join our Community',
 
-    reward: 10000,
+    reward: 2500,
 
     icon: 'telegram',
 
@@ -34,7 +34,7 @@ export const TASKS = [
 
     description: 'Follow us on TikTok',
 
-    reward: 10000,
+    reward: 2500,
 
     icon: 'tiktok',
 

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -8,7 +8,7 @@ import { getTelegramId } from '../utils/telegram.js';
 
 import LoginOptions from './LoginOptions.jsx';
 
-const REWARDS = Array.from({ length: 30 }, (_, i) => 1000 * (i + 1));
+const REWARDS = Array.from({ length: 30 }, (_, i) => Math.floor(100 + (i + 1) * 50));
 
 function formatReward(r) {
   return r >= 1000 ? `${r / 1000}k` : String(r);

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -10,7 +10,7 @@ import { getTelegramId } from '../utils/telegram.js';
 import LoginOptions from './LoginOptions.jsx';
 
 const MINING_DURATION = 12 * 60 * 60; // 12 hours in seconds
-const REWARD_AMOUNT = 2000; // must mirror backend reward
+const REWARD_AMOUNT = 1000; // maximum base reward, actual amount may vary
 
 export default function MiningCard() {
   let telegramId: string;

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -14,10 +14,8 @@ export default function RewardPopup({ reward, onClose, duration = 2500, showClos
   if (reward === null) return null;
   useEffect(() => {
     let icon = '/assets/icons/TPCcoin_1.webp';
-    if (reward === 'BONUS_X3') {
+    if (reward === 'BONUS_X2') {
       icon = '/assets/icons/file_00000000ead061faa3b429466e006f48.webp';
-    } else if (reward === 1600 || reward === 1800) {
-      icon = '/assets/icons/FreeSpin.webp';
     }
     coinConfetti(50, icon);
     const audio = new Audio('/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3');
@@ -34,7 +32,7 @@ export default function RewardPopup({ reward, onClose, duration = 2500, showClos
       <div className="text-center space-y-4 text-text">
         <h3 className="text-lg font-bold">Reward Earned</h3>
         <div className="text-accent text-3xl flex items-center justify-center space-x-2">
-          {reward === 'BONUS_X3' && (
+          {reward === 'BONUS_X2' && (
             <>
               <img
 
@@ -42,35 +40,13 @@ export default function RewardPopup({ reward, onClose, duration = 2500, showClos
                 alt="Bonus"
                 className="w-8 h-8"
               />
-              <span>BONUS X3</span>
+              <span>BONUS X2</span>
             </>
           )}
-          {typeof reward === 'number' && reward === 1600 && (
+          {typeof reward === 'number' && (
             <>
               <img
 
-                src="/assets/icons/FreeSpin.webp"
-                alt="Free Spin"
-                className="w-8 h-8"
-              />
-              <span>+1</span>
-            </>
-          )}
-          {typeof reward === 'number' && reward === 1800 && (
-            <>
-              <img
-
-                src="/assets/icons/FreeSpin.webp"
-                alt="Free Spin"
-                className="w-8 h-8"
-              />
-              <span>+2</span>
-            </>
-          )}
-          {typeof reward === 'number' && reward !== 1600 && reward !== 1800 && (
-            <>
-              <img
-                
                 src="/assets/icons/TPCcoin_1.webp"
                 alt="TPC"
                 className="w-8 h-8"

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -51,28 +51,19 @@ export default function SpinGame() {
   }, [lastSpin]);
 
   const handleFinish = async (r) => {
-    if (r === 'BONUS_X3') {
+    if (r === 'BONUS_X2') {
       setBonusActive(true);
       setAdWatched(false);
       return;
     }
-    let extraSpins = 0;
-    if (r === 1600) extraSpins = 1;
-    else if (r === 1800) extraSpins = 2;
-
-    if (extraSpins > 0) {
-      const total = freeSpins + extraSpins;
-      setFreeSpins(total);
-      localStorage.setItem('freeSpins', String(total));
-    } else if (typeof r === 'number') {
+    if (typeof r === 'number') {
       const id = telegramId;
       const balRes = await getWalletBalance(id);
       const newBalance = (balRes.balance || 0) + r;
       await updateBalance(id, newBalance);
       await addTransaction(id, r, 'spin');
     }
-    const finalCount = freeSpins + extraSpins;
-    if (finalCount === 0) {
+    if (freeSpins === 0) {
       const now = Date.now();
       localStorage.setItem('lastSpin', String(now));
       setLastSpin(now);
@@ -83,23 +74,12 @@ export default function SpinGame() {
 
   const handleBonusFinish = async (r) => {
     if (typeof r !== 'number') return;
-    let extraSpins = 0;
-    if (r === 1600) extraSpins = 1;
-    else if (r === 1800) extraSpins = 2;
-
-    if (extraSpins > 0) {
-      const total = freeSpins + extraSpins;
-      setFreeSpins(total);
-      localStorage.setItem('freeSpins', String(total));
-    } else {
-      const id = telegramId;
-      const balRes = await getWalletBalance(id);
-      const newBalance = (balRes.balance || 0) + r;
-      await updateBalance(id, newBalance);
-      await addTransaction(id, r, 'spin');
-    }
-    const finalCount = freeSpins + extraSpins;
-    if (finalCount === 0) {
+    const id = telegramId;
+    const balRes = await getWalletBalance(id);
+    const newBalance = (balRes.balance || 0) + r;
+    await updateBalance(id, newBalance);
+    await addTransaction(id, r, 'spin');
+    if (freeSpins === 0) {
       const now = Date.now();
       localStorage.setItem('lastSpin', String(now));
       setLastSpin(now);

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -62,7 +62,6 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
   const successSoundRef = useRef<HTMLAudioElement | null>(null);
   const bonusSoundRef = useRef<HTMLAudioElement | null>(null);
   const extraBonusSoundRef1 = useRef<HTMLAudioElement | null>(null);
-  const freeSpinSoundRef = useRef<HTMLAudioElement | null>(null);
 
   useEffect(() => {
     spinSoundRef.current = new Audio('/assets/sounds/spinning.mp3');
@@ -78,15 +77,11 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
     extraBonusSoundRef1.current = new Audio('/assets/sounds/happy-noisesmp3-14568.mp3');
     extraBonusSoundRef1.current.preload = 'auto';
     extraBonusSoundRef1.current.volume = getGameVolume();
-    freeSpinSoundRef.current = new Audio('/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3');
-    freeSpinSoundRef.current.preload = 'auto';
-    freeSpinSoundRef.current.volume = getGameVolume();
     return () => {
       spinSoundRef.current?.pause();
       successSoundRef.current?.pause();
       bonusSoundRef.current?.pause();
       extraBonusSoundRef1.current?.pause();
-      freeSpinSoundRef.current?.pause();
     };
   }, []);
 
@@ -96,7 +91,6 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
       if (successSoundRef.current) successSoundRef.current.volume = getGameVolume();
       if (bonusSoundRef.current) bonusSoundRef.current.volume = getGameVolume();
       if (extraBonusSoundRef1.current) extraBonusSoundRef1.current.volume = getGameVolume();
-      if (freeSpinSoundRef.current) freeSpinSoundRef.current.volume = getGameVolume();
     };
     window.addEventListener('gameVolumeChanged', handler);
     return () => window.removeEventListener('gameVolumeChanged', handler);
@@ -141,18 +135,9 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
       setSpinning(false);
       setWinnerIndex(finalIndex);
 
-      if (reward === 'BONUS_X3') {
+      if (reward === 'BONUS_X2') {
         bonusSoundRef.current?.play().catch(() => {});
         extraBonusSoundRef1.current?.play().catch(() => {});
-        if (successSoundRef.current) {
-          successSoundRef.current.currentTime = 0;
-          successSoundRef.current.play().catch(() => {});
-        }
-      } else if (reward === 1600 || reward === 1800) {
-        if (freeSpinSoundRef.current) {
-          freeSpinSoundRef.current.currentTime = 0;
-          freeSpinSoundRef.current.play().catch(() => {});
-        }
         if (successSoundRef.current) {
           successSoundRef.current.currentTime = 0;
           successSoundRef.current.play().catch(() => {});
@@ -210,30 +195,16 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
             <div
               key={idx}
               className={`board-style border-2 border-border text-sm w-28 font-bold flex items-center ${
-                val === 'BONUS_X3' ? 'justify-center' : 'justify-start pl-2 space-x-1'
+                val === 'BONUS_X2' ? 'justify-center' : 'justify-start pl-2 space-x-1'
               } ${
                 idx === winnerIndex ? 'bg-yellow-300 text-black border-4 border-brand-gold shadow-[0_0_12px_rgba(241,196,15,0.8)]' : 'text-white'
               }`}
               style={{ height: itemHeight }}
             >
-
-              {val === 'BONUS_X3' ? (
+              {val === 'BONUS_X2' ? (
                 <span className="text-red-600 font-bold drop-shadow-[0_0_2px_black]">
-                  BONUS X3
+                  BONUS X2
                 </span>
-              ) : val === 1600 || val === 1800 ? (
-                <>
-                  <img
-
-                    src="/assets/icons/FreeSpin.webp"
-                    alt="Free Spin"
-                    className="w-8 h-8"
-                  />
-                  <span>
-                    {val === 1600 && '1'}
-                    {val === 1800 && '2'}
-                  </span>
-                </>
               ) : (
                 <>
                   <img  src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-8 h-8" />

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -32,7 +32,7 @@ const ICONS = {
 
 };
 
-const REWARDS = Array.from({ length: 30 }, (_, i) => 1000 * (i + 1));
+const REWARDS = Array.from({ length: 30 }, (_, i) => Math.floor(100 + (i + 1) * 50));
 const ONE_DAY = 24 * 60 * 60 * 1000;
 
 export default function TasksCard() {
@@ -215,9 +215,9 @@ export default function TasksCard() {
         <li className="lobby-tile w-full">
           <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
             {ICONS.watch_ad}
-            <span className="text-sm">Watch Ad ({adCount}/10)</span>
-            <span className="text-xs text-subtext flex items-center gap-1">100 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
-            {adCount >= 10 ? (
+            <span className="text-sm">Watch Ad ({adCount}/5)</span>
+            <span className="text-xs text-subtext flex items-center gap-1">50 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
+            {adCount >= 5 ? (
               <span className="text-green-500 font-semibold text-sm">Done</span>
             ) : (
               <button
@@ -240,5 +240,4 @@ export default function TasksCard() {
     </div>
 
   );
-
 }

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -22,7 +22,7 @@ import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 import { STORE_ADDRESS } from '../utils/storeData.js';
 
-const REWARDS = Array.from({ length: 30 }, (_, i) => 1000 * (i + 1));
+const REWARDS = Array.from({ length: 30 }, (_, i) => Math.floor(100 + (i + 1) * 50));
 const ONE_DAY = 24 * 60 * 60 * 1000;
 
 export default function Tasks() {
@@ -206,9 +206,9 @@ export default function Tasks() {
           <li className="lobby-tile w-full">
             <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
               {ICONS.watch_ad}
-              <span className="text-sm">Watch Ad ({adCount}/10)</span>
-              <span className="text-xs text-subtext flex items-center gap-1">100 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
-              {adCount >= 10 ? (
+              <span className="text-sm">Watch Ad ({adCount}/5)</span>
+              <span className="text-xs text-subtext flex items-center gap-1">50 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
+              {adCount >= 5 ? (
                 <span className="text-green-500 font-semibold text-sm">Completed</span>
               ) : (
                 <button

--- a/webapp/src/pages/Tokenomics.jsx
+++ b/webapp/src/pages/Tokenomics.jsx
@@ -358,12 +358,12 @@ export default function TokenomicsPage() {
             <li className="ml-4">🧑‍🤝‍🤝 Online user status, add friends, and inbox chat inside game</li>
             <li className="ml-4">🕹️ Full integration between Telegram Bot and WebApp</li>
             <li><b>Rewards &amp; Incentives</b></li>
-            <li className="ml-4">🔄 Daily Check-In System: 1,000 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> on Day 1 → 30,000 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 ml-1" /> by Day 30</li>
-            <li className="ml-4">⛏️ Mining system (2,000 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> every 12 hours)</li>
-            <li className="ml-4">📺 Ad Watch Rewards: 100 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> per ad (up to 10/day)</li>
-            <li className="ml-4">🎯 Social Tasks: +10,000 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> each for Twitter, Telegram, TikTok</li>
+            <li className="ml-4">🔄 Daily Check-In System: 150 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> on Day 1 → 1,600 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 ml-1" /> by Day 30</li>
+            <li className="ml-4">⛏️ Mining system (250–1,000 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> every 12 hours)</li>
+            <li className="ml-4">📺 Ad Watch Rewards: 50 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> per ad (up to 5/day)</li>
+            <li className="ml-4">🎯 Social Tasks: +2,500 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> each for Twitter, Telegram, TikTok</li>
             <li className="ml-4">📹 Intro Video Views: +5 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> each</li>
-            <li className="ml-4">🎡 Spin &amp; Win Wheel: 300–1800 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> prizes + Bonus x3 chance</li>
+            <li className="ml-4">🎡 Spin &amp; Win Wheel: 400–1,600 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> prizes + Bonus x2 chance</li>
           </ul>
         </div>
 

--- a/webapp/src/utils/rewardLogic.ts
+++ b/webapp/src/utils/rewardLogic.ts
@@ -1,16 +1,15 @@
 // Prize amounts available on the wheel.
-export type Segment = number | 'BONUS_X3';
+export type Segment = number | 'BONUS_X2';
 
 export const segments: Segment[] = [
-  300,
+  400,
+  600,
   800,
   1000,
   1200,
   1400,
-  1500,
   1600,
-  1800,
-  'BONUS_X3',
+  'BONUS_X2',
 ];
 const COOLDOWN = 15 * 60_000; // 15 minutes
 


### PR DESCRIPTION
## Summary
- update social task rewards and ad watch limits
- adjust daily check‑in rules and messages
- replace bonus spin logic with new BONUS_X2
- support dynamic mining rewards based on active miners
- update frontend constants and texts to match new values

## Testing
- `npm test` *(fails: cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686dfa2bee088329a9f8691720205a1e