### PR TITLE
Add NFT gift card

### DIFF
--- a/webapp/src/components/GiftShopPopup.jsx
+++ b/webapp/src/components/GiftShopPopup.jsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { sendGift } from '../utils/api.js';
+import { NFT_GIFTS } from '../utils/nftGifts.js';
+import ConfirmPopup from './ConfirmPopup.jsx';
+import InfoPopup from './InfoPopup.jsx';
+
+export default function GiftShopPopup({ open, onClose, accountId }) {
+  const [selected, setSelected] = useState(NFT_GIFTS[0]);
+  const [receiver, setReceiver] = useState('');
+  const [confirm, setConfirm] = useState(false);
+  const [info, setInfo] = useState('');
+
+  if (!open) return null;
+
+  const handleSend = async () => {
+    setConfirm(false);
+    try {
+      await sendGift(accountId, receiver || accountId, selected.id);
+      setInfo(receiver && receiver !== accountId ? 'Gift sent' : 'Gift purchased');
+    } catch (err) {
+      setInfo('Failed to send gift');
+    }
+    onClose();
+  };
+
+  return createPortal(
+    <>
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70"
+        onClick={onClose}
+      >
+        <div
+          className="bg-surface border border-border rounded p-4 space-y-2 w-72"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <p className="text-center font-semibold mb-2">Buy or Send Gift</p>
+          <div className="space-y-1 max-h-40 overflow-y-auto">
+            {NFT_GIFTS.map((g) => (
+              <button
+                key={g.id}
+                onClick={() => setSelected(g)}
+                className={`w-full flex items-center justify-between border border-border rounded px-1 py-0.5 text-sm ${selected.id === g.id ? 'bg-accent' : ''}`}
+              >
+                <span className="flex items-center space-x-1">
+                  <span>{g.icon}</span>
+                  <span>{g.name}</span>
+                </span>
+                <span className="flex items-center space-x-0.5">
+                  <span>{g.price}</span>
+                  <img src="/assets/icons/TPCcoin_1.webp" className="w-3 h-3" />
+                </span>
+              </button>
+            ))}
+          </div>
+          <input
+            type="text"
+            placeholder="Recipient Account (optional)"
+            value={receiver}
+            onChange={(e) => setReceiver(e.target.value)}
+            className="border p-1 rounded w-full text-black text-sm"
+          />
+          <button
+            className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
+            onClick={() => setConfirm(true)}
+          >
+            {receiver && receiver !== accountId ? 'Send' : 'Buy'} {selected.icon} {selected.name}
+          </button>
+        </div>
+      </div>
+      <ConfirmPopup
+        open={confirm}
+        message={`Spend ${selected.price} TPC to ${receiver && receiver !== accountId ? 'send' : 'buy'} ${selected.name}?`}
+        onConfirm={handleSend}
+        onCancel={() => setConfirm(false)}
+      />
+      <InfoPopup open={!!info} onClose={() => setInfo('')} title="Gift" info={info} />
+    </>,
+    document.body,
+  );
+}

--- a/webapp/src/components/NftGiftCard.jsx
+++ b/webapp/src/components/NftGiftCard.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { createAccount, getAccountInfo } from '../utils/api.js';
+import { getTelegramId } from '../utils/telegram.js';
+import { NFT_GIFTS } from '../utils/nftGifts.js';
+import GiftShopPopup from './GiftShopPopup.jsx';
+
+export default function NftGiftCard({ accountId: propAccountId }) {
+  const [accountId, setAccountId] = useState(propAccountId || '');
+  const [gifts, setGifts] = useState([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    async function ensureAccount() {
+      let id = propAccountId || localStorage.getItem('accountId');
+      if (!id) {
+        try {
+          const acc = await createAccount(getTelegramId());
+          if (acc?.accountId) {
+            id = acc.accountId;
+            localStorage.setItem('accountId', id);
+          }
+        } catch {}
+      }
+      if (id) setAccountId(id);
+    }
+    ensureAccount();
+  }, [propAccountId]);
+
+  useEffect(() => {
+    if (!accountId) return;
+    getAccountInfo(accountId)
+      .then((info) => {
+        if (info && Array.isArray(info.gifts)) setGifts(info.gifts);
+      })
+      .catch(() => {});
+  }, [accountId, open]);
+
+  return (
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+      />
+      <h3 className="text-lg font-bold text-center">NFT Gifts</h3>
+      <div className="max-h-32 overflow-y-auto text-sm space-y-1">
+        {gifts.length ? (
+          gifts.map((g) => {
+            const info = NFT_GIFTS.find((x) => x.id === g.gift) || {};
+            return (
+              <div key={g._id} className="flex justify-between items-center">
+                <span className="flex items-center space-x-1">
+                  <span>{info.icon}</span>
+                  <span>{info.name || g.gift}</span>
+                </span>
+                <span className="text-xs">{g.price} TPC</span>
+              </div>
+            );
+          })
+        ) : (
+          <p className="text-center text-subtext">No NFTs</p>
+        )}
+      </div>
+      <button
+        onClick={() => setOpen(true)}
+        className="mx-auto block px-3 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow"
+      >
+        Buy / Send Gift
+      </button>
+      <GiftShopPopup open={open} onClose={() => setOpen(false)} accountId={accountId} />
+    </div>
+  );
+}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -9,6 +9,7 @@ import DailyCheckIn from '../components/DailyCheckIn.jsx';
 
 import TasksCard from '../components/TasksCard.jsx';
 import StoreAd from '../components/StoreAd.jsx';
+import NftGiftCard from '../components/NftGiftCard.jsx';
 
 import {
   FaUser,
@@ -159,6 +160,8 @@ export default function Home() {
               </div>
             </div>
           </div>
+
+          <NftGiftCard />
         </div>
 
       </div>

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -11,6 +11,7 @@ import { getTelegramId } from '../utils/telegram.js';
 import ConfirmPopup from '../components/ConfirmPopup.jsx';
 import InfoPopup from '../components/InfoPopup.jsx';
 import TransactionDetailsPopup from '../components/TransactionDetailsPopup.jsx';
+import NftGiftCard from '../components/NftGiftCard.jsx';
 import { AiOutlineCalendar } from 'react-icons/ai';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 
@@ -354,6 +355,8 @@ export default function Wallet() {
           </div>
         )}
       </div>
+
+      <NftGiftCard accountId={accountId} />
 
       {DEV_ACCOUNTS.includes(accountId) && (
         <div className="prism-box p-6 space-y-3 text-center mt-4 flex flex-col items-center w-80 mx-auto">


### PR DESCRIPTION
## Summary
- add GiftShopPopup component for buying or sending gift NFTs
- add NftGiftCard component to show owned NFTs and open popup
- show NftGiftCard on the homepage under the wallet card
- include NftGiftCard on the Wallet page

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_686e0433104c83298ecb73a23880c965