### PR TITLE
Fix gift sending during gameplay

### DIFF
--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { getPlayerId, ensureAccountId } from '../utils/telegram.js';
 import { sendGift } from '../utils/api.js';
@@ -10,12 +10,18 @@ import InfoPopup from './InfoPopup.jsx';
 
 
 export default function GiftPopup({ open, onClose, players = [], senderIndex = 0, onGiftSent }) {
+  const validPlayers = players.filter((p) => p.id);
   const [selected, setSelected] = useState(NFT_GIFTS[0]);
-  const [target, setTarget] = useState(players[0]?.index || 0);
+  const [target, setTarget] = useState(validPlayers[0]?.index || 0);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [infoMsg, setInfoMsg] = useState('');
+  useEffect(() => {
+    if (validPlayers.length > 0 && !validPlayers.some((p) => p.index === target)) {
+      setTarget(validPlayers[0].index);
+    }
+  }, [validPlayers]);
   if (!open && !infoMsg) return null;
-  const recipient = players.find((p) => p.index === target);
+  const recipient = validPlayers.find((p) => p.index === target);
 
   const handleSend = async () => {
     if (!recipient) return;
@@ -74,7 +80,7 @@ export default function GiftPopup({ open, onClose, players = [], senderIndex = 0
         >
           <p className="text-center font-semibold mb-2">Send Gift</p>
           <div className="space-y-1 max-h-32 overflow-y-auto">
-            {players.map((p) => (
+            {validPlayers.map((p) => (
               <button
                 key={p.index}
                 onClick={() => setTarget(p.index)}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1765,6 +1765,7 @@ export default function SnakeAndLadder() {
 
   const players = isMultiplayer
     ? mpPlayers.map((p, i) => ({
+        id: p.id,
         position: p.position,
         photoUrl: p.photoUrl || '/assets/icons/profile.svg',
         type: 'normal',


### PR DESCRIPTION
## Summary
- include player account IDs when building player list in Snake & Ladder
- ignore players without account IDs in GiftPopup to avoid invalid requests

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from server.js)*

------
https://chatgpt.com/codex/tasks/task_e_686e179fb6fc8329a51ca393c611581b