### PR TITLE
Fix gift popup timing in snake game

### DIFF
--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -32,6 +32,7 @@ export default function GiftPopup({ open, onClose, players = [], senderIndex = 0
       if (res?.error) {
         setInfoMsg(res.error);
         onClose();
+        setTimeout(() => setInfoMsg(""), 1000);
         return;
       }
       const sound = giftSounds[selected.id];
@@ -60,11 +61,19 @@ export default function GiftPopup({ open, onClose, players = [], senderIndex = 0
         }
       }
       setInfoMsg(`Sent ${selected.name} to ${recipient.name}`);
-      onGiftSent && onGiftSent({ from: senderIndex, to: target, gift: selected });
+      onClose();
+      setTimeout(() => {
+        setInfoMsg("");
+        onGiftSent &&
+          onGiftSent({ from: senderIndex, to: target, gift: selected });
+      }, 1000);
+      return;
     } catch {
-      setInfoMsg('Failed to send gift');
+      setInfoMsg("Failed to send gift");
+      onClose();
+      setTimeout(() => setInfoMsg(""), 1000);
+      return;
     }
-    onClose();
   };
 
   const tiers = [1, 2, 3];

--- a/webapp/src/components/GiftShopPopup.jsx
+++ b/webapp/src/components/GiftShopPopup.jsx
@@ -17,9 +17,13 @@ export default function GiftShopPopup({ open, onClose, accountId }) {
     setConfirm(false);
     try {
       await sendGift(accountId, receiver || accountId, selected.id);
-      setInfo(receiver && receiver !== accountId ? 'Gift sent' : 'Gift purchased');
+      setInfo(
+        receiver && receiver !== accountId ? 'Gift sent' : 'Gift purchased'
+      );
+      setTimeout(() => setInfo(''), 1000);
     } catch (err) {
       setInfo('Failed to send gift');
+      setTimeout(() => setInfo(''), 1000);
     }
     onClose();
   };


### PR DESCRIPTION
## Summary
- automatically clear confirmation popups when sending gifts
- start gift animations after popups close to allow gameplay

## Testing
- `npm test` *(fails: duration_ms 2563.377852)*

------
https://chatgpt.com/codex/tasks/task_e_686e1fb597088329b7754197c6abbac8