### PR TITLE
Make TPC addresses clickable

### DIFF
--- a/webapp/src/pages/Tokenomics.jsx
+++ b/webapp/src/pages/Tokenomics.jsx
@@ -534,8 +534,15 @@ export default function TokenomicsPage() {
           {walletAddresses.map((w) => (
             <li key={w.address} className="flex justify-between items-center gap-2">
               <div>
-                <span className="font-semibold">{w.label}: </span>
-                <span className="text-primary">{w.address}</span>
+                <span className="font-semibold text-brand-gold">{w.label}: </span>
+                <a
+                  href={`https://tonscan.org/address/${w.address}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  {w.address}
+                </a>
               </div>
               {walletBalances[w.address] != null && (
                 <span className="flex items-center whitespace-nowrap">


### PR DESCRIPTION
## Summary
- link wallet addresses to corresponding TON Scan pages
- highlight wallet labels in gold

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_686e29eb4fd083298f07d8b740d9baf9