### PR TITLE
Adjust NFT cards

### DIFF
--- a/webapp/src/components/GiftIcon.jsx
+++ b/webapp/src/components/GiftIcon.jsx
@@ -3,7 +3,13 @@ import React from 'react';
 export default function GiftIcon({ icon, className }) {
   if (typeof icon === 'string' && icon.startsWith('/')) {
     if (icon.match(/\.(png|jpg|jpeg|webp|svg)$/)) {
-      return <img src={icon} className={className} alt="" />;
+      return (
+        <img
+          src={icon}
+          className={`${className || ''} object-contain`}
+          alt=""
+        />
+      );
     }
   }
   return <span className={className}>{icon}</span>;

--- a/webapp/src/components/NftGiftCard.jsx
+++ b/webapp/src/components/NftGiftCard.jsx
@@ -37,14 +37,14 @@ export default function NftGiftCard({ accountId: propAccountId }) {
   }, [accountId, open]);
 
   return (
-    <div className="relative bg-surface border border-border rounded-xl p-6 space-y-3 overflow-hidden wide-card">
+    <div className="relative prism-box p-6 space-y-3 flex flex-col items-center text-center overflow-hidden min-h-40 wide-card mx-auto">
       <img
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""
       />
       <h3 className="text-lg font-bold text-center">NFT Gifts</h3>
-      <div className="flex space-x-2 overflow-x-auto pb-2 text-sm">
+      <div className="flex space-x-2 overflow-x-auto pb-2 text-sm w-full flex-grow justify-center">
         {gifts.length ? (
           gifts.map((g) => {
             const info = NFT_GIFTS.find((x) => x.id === g.gift) || {};
@@ -53,7 +53,7 @@ export default function NftGiftCard({ accountId: propAccountId }) {
                 key={g._id}
                 className="flex-shrink-0 flex flex-col items-center space-y-1 border border-border rounded p-2 min-w-[72px]"
               >
-                <GiftIcon icon={info.icon} className="text-xl" />
+                <GiftIcon icon={info.icon} className="w-12 h-12" />
                 <span className="text-center">{info.name || g.gift}</span>
                 <span className="text-xs">{g.price} TPC</span>
               </div>
@@ -65,7 +65,7 @@ export default function NftGiftCard({ accountId: propAccountId }) {
       </div>
       <button
         onClick={() => setOpen(true)}
-        className="mx-auto block px-3 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow"
+        className="mt-auto px-3 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow w-full max-w-xs"
       >
         Buy / Send Gift
       </button>

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -315,9 +315,9 @@ export default function MyAccount() {
       )}
 
       {/* NFT Gifts card */}
-      <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
-        <h3 className="font-semibold text-center">NFT Gifts</h3>
-        <div className="max-h-40 overflow-y-auto space-y-1 text-sm">
+      <div className="prism-box p-6 mt-4 space-y-2 mx-auto flex flex-col items-center text-center min-h-40 wide-card">
+        <h3 className="font-semibold">NFT Gifts</h3>
+        <div className="max-h-40 overflow-y-auto space-y-1 text-sm w-full flex-grow">
           {profile.gifts && profile.gifts.length > 0 ? (
             profile.gifts.map((g) => {
               const info = NFT_GIFTS.find((x) => x.id === g.gift) || {};
@@ -356,7 +356,7 @@ export default function MyAccount() {
         </div>
         {profile.gifts && profile.gifts.length > 0 && (
           <>
-            <div className="flex items-center space-x-2 mt-2">
+            <div className="flex items-center space-x-2 mt-2 w-full">
               <select
                 value={convertAction}
                 onChange={(e) => setConvertAction(e.target.value)}
@@ -378,7 +378,7 @@ export default function MyAccount() {
             <button
               onClick={handleConvertGifts}
               disabled={converting || selectedGifts.length === 0}
-              className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black mt-2"
+              className="mt-auto px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black w-full max-w-xs"
             >
               {converting
                 ? convertAction === 'burn'


### PR DESCRIPTION
## Summary
- tweak GiftIcon to ensure images fit using `object-contain`
- restyle NftGiftCard for a layout like Send TPC card
- enlarge NFT card on My Account and center convert button

## Testing
- `npm run install-all`
- `npm test` *(fails: Subtest snake API endpoints and socket events)*

------
https://chatgpt.com/codex/tasks/task_e_686e4eaa233c83298603666131a1e2b0