### PR TITLE
Add extended platform stats

### DIFF
--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -28,7 +28,7 @@ function daysFromNow(days) {
   return d;
 }
 
-const BUNDLES = {
+export const BUNDLES = {
   newbie: { tpc: 50000, ton: 0.2, label: 'Newbie Pack' },
   rookie: { tpc: 100000, ton: 0.35, label: 'Rookie' },
   starter: { tpc: 200000, ton: 0.6, label: 'Starter' },

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -357,6 +357,12 @@ export default function Home() {
             <p>Accounts: {stats.accounts}</p>
             <p>Active Users: {stats.activeUsers}</p>
             <p>NFTs Created: {stats.nftsCreated}</p>
+            <p>NFTs Burned: {stats.nftsBurned}</p>
+            <p>Bundles Sold: {stats.bundlesSold}</p>
+            <p>
+              Total Raised: {formatValue(stats.tonRaised, 2)}{' '}
+              <img src="/assets/icons/TON.webp" alt="TON" className="inline-block w-4 h-4 ml-1" />
+            </p>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- export `BUNDLES` for reuse
- calculate bundle and NFT stats in `/api/stats`
- show new stats on the home page

## Testing
- `npm test` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686e51371ef083298aedad603f14ebbb