### PR TITLE
Show additional platform stats

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -272,6 +272,8 @@ app.get('/api/stats', async (req, res) => {
     let bundlesSold = 0;
     let tonRaised = 0;
     let currentNfts = 0;
+    let appClaimed = 0;
+    let externalClaimed = 0;
     for (const u of users) {
       currentNfts += (u.gifts || []).filter((g) => g.nftTokenId).length;
       for (const tx of u.transactions || []) {
@@ -282,6 +284,8 @@ app.get('/api/stats', async (req, res) => {
             tonRaised += BUNDLE_TON_MAP[tx.detail];
           }
         }
+        if (tx.type === 'claim') appClaimed += Math.abs(tx.amount || 0);
+        if (tx.type === 'withdraw') externalClaimed += Math.abs(tx.amount || 0);
       }
     }
     const nftsBurned = giftSends - currentNfts;
@@ -293,6 +297,8 @@ app.get('/api/stats', async (req, res) => {
       nftsBurned,
       bundlesSold,
       tonRaised,
+      appClaimed,
+      externalClaimed,
     });
   } catch (err) {
     console.error('Failed to compute stats:', err.message);

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -290,9 +290,9 @@ export default function Home() {
           />
           <h3 className="text-lg font-bold text-text text-center">Tokenomics &amp; Roadmap</h3>
           {/* Removed outdated emission schedule */}
-          <div className="space-y-1">
+          <div className="space-y-1 text-center">
             <p className="text-lg font-bold">Total Balance</p>
-            <p className="text-2xl flex items-center gap-1">
+            <p className="text-2xl flex items-center gap-1 justify-center">
               {supply == null ? '...' : formatValue(supply, 2)}
               <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" />
             </p>
@@ -363,6 +363,8 @@ export default function Home() {
               Total Raised: {formatValue(stats.tonRaised, 2)}{' '}
               <img src="/assets/icons/TON.webp" alt="TON" className="inline-block w-4 h-4 ml-1" />
             </p>
+            <p>TPC App Claimed: {formatValue(stats.appClaimed, 0)}</p>
+            <p>TPC External Wallet Claimed: {formatValue(stats.externalClaimed, 0)}</p>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- compute additional statistics for claimed tokens
- center tokenomics card text on the home page
- display new stats on the home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e55b29cc88329a8cba8f47aad0f28