### PR TITLE
Improve gift notification details

### DIFF
--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -4,7 +4,11 @@ import User from '../models/User.js';
 import authenticate from '../middleware/auth.js';
 import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
 import bot from '../bot.js';
-import { sendTransferNotification, sendTPCNotification } from '../utils/notifications.js';
+import {
+  sendTransferNotification,
+  sendTPCNotification,
+  sendGiftNotification,
+} from '../utils/notifications.js';
 import NFT_GIFTS from '../utils/nftGifts.js';
 
 import { mintGiftNFT } from '../utils/nftService.js';
@@ -303,9 +307,12 @@ router.post('/gift', async (req, res) => {
 
   if (receiver.telegramId) {
     try {
-      await bot.telegram.sendMessage(
-        String(receiver.telegramId),
-        `\u{1FA99} You received a ${g.name} gift`
+      await sendGiftNotification(
+        bot,
+        receiver.telegramId,
+        g,
+        sender.nickname || sender.firstName || String(fromAccount),
+        txDate,
       );
     } catch (err) {
       console.error('Failed to send Telegram notification:', err.message);

--- a/bot/utils/nftGifts.js
+++ b/bot/utils/nftGifts.js
@@ -1,20 +1,20 @@
 export const NFT_GIFTS = [
   // Tier 1 gifts
-  { id: 'fireworks', price: 200, tier: 1 },
-  { id: 'laugh_bomb', price: 300, tier: 1 },
-  { id: 'pizza_slice', price: 500, tier: 1 },
-  { id: 'coffee_boost', price: 750, tier: 1 },
-  { id: 'baby_chick', price: 1000, tier: 1 },
+  { id: 'fireworks',    name: 'Fireworks',    icon: '🎆', price: 200,  tier: 1 },
+  { id: 'laugh_bomb',   name: 'Laugh Bomb',   icon: '😂', price: 300,  tier: 1 },
+  { id: 'pizza_slice',  name: 'Pizza Slice',  icon: '🍕', price: 500,  tier: 1 },
+  { id: 'coffee_boost', name: 'Coffee Boost', icon: '☕', price: 750,  tier: 1 },
+  { id: 'baby_chick',   name: 'Baby Chick',   icon: '🐣', price: 1000, tier: 1 },
   // Tier 2 gifts
-  { id: 'poop', price: 1200, tier: 2 },
-  { id: 'speed_racer', price: 1800, tier: 2, icon: '/assets/icons/futuristic_racing_car.webp' },
-  { id: 'bullseye', price: 3000, tier: 2 },
-  { id: 'magic_trick', price: 5000, tier: 2 },
-  { id: 'surprise_box', price: 8000, tier: 2 },
+  { id: 'poop',         name: 'Poop',         icon: '💩', price: 1200,  tier: 2 },
+  { id: 'speed_racer',  name: 'Speed Racer',  icon: '/assets/icons/futuristic_racing_car.webp', price: 1800,  tier: 2 },
+  { id: 'bullseye',     name: 'Bullseye',     icon: '🎯', price: 3000,  tier: 2 },
+  { id: 'magic_trick',  name: 'Magic Trick',  icon: '🎩', price: 5000,  tier: 2 },
+  { id: 'surprise_box', name: 'Surprise Box', icon: '🎁', price: 8000,  tier: 2 },
   // Tier 3 gifts
-  { id: 'dragon_burst', price: 20000, tier: 3 },
-  { id: 'rocket_blast', price: 35000, tier: 3 },
-  { id: 'royal_crown', price: 90000, tier: 3 },
-  { id: 'alien_visit', price: 150000, tier: 3 },
+  { id: 'dragon_burst', name: 'Dragon Burst', icon: '🐉', price: 20000,  tier: 3 },
+  { id: 'rocket_blast', name: 'Rocket Blast', icon: '🚀', price: 35000,  tier: 3 },
+  { id: 'royal_crown',  name: 'Royal Crown',  icon: '👑', price: 90000,  tier: 3 },
+  { id: 'alien_visit',  name: 'Alien Visit',  icon: '🛸', price: 150000, tier: 3 },
 ];
 export default NFT_GIFTS;

--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -75,6 +75,35 @@ async function renderTransferImage(name, amount, date, photoUrl) {
   return canvas.toBuffer();
 }
 
+async function renderGiftImage(icon) {
+  const scale = 2;
+  const size = 160 * scale;
+  const canvas = createCanvas(size, size);
+  const ctx = canvas.getContext('2d');
+
+  ctx.fillStyle = '#2d5c66';
+  ctx.fillRect(0, 0, size, size);
+  ctx.strokeStyle = '#334155';
+  ctx.lineWidth = 4 * scale;
+  ctx.strokeRect(0, 0, size, size);
+
+  if (typeof icon === 'string' && icon.startsWith('/')) {
+    try {
+      const img = await loadImage(path.join(__dirname, `../../webapp/public${icon}`));
+      const padding = 20 * scale;
+      ctx.drawImage(img, padding, padding, size - padding * 2, size - padding * 2);
+    } catch {}
+  } else {
+    ctx.fillStyle = '#ffffff';
+    ctx.font = `${48 * scale}px serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(icon || '🎁', size / 2, size / 2);
+  }
+
+  return canvas.toBuffer();
+}
+
 export async function sendTransferNotification(bot, toId, fromId, amount, note) {
   let info;
   try {
@@ -104,6 +133,16 @@ export async function sendTransferNotification(bot, toId, fromId, amount, note) 
   const noteText = note ? `\nNote: ${note}` : '';
   const caption = `You received ${sign}${formatted} TPC from ${name} ${profileIcon}${noteText}`;
 
+  await bot.telegram.sendMessage(String(toId), caption);
+}
+
+export async function sendGiftNotification(bot, toId, gift, senderName, date) {
+  const image = await renderGiftImage(gift.icon);
+  try {
+    await bot.telegram.sendPhoto(String(toId), { source: image });
+  } catch {}
+
+  const caption = `\u{1FA99} You received a ${gift.name} worth ${gift.price} TPC from ${senderName} on ${date.toLocaleString()}`;
   await bot.telegram.sendMessage(String(toId), caption);
 }
 


### PR DESCRIPTION
## Summary
- add name and icon metadata to bot gift list
- send gift image notifications with sender info
- wire up new gift notification in API route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e59922778832984f1a0330c9249fc