### PR TITLE
Fix missing stats fields on Home page

### DIFF
--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -186,6 +186,11 @@ export default function Home() {
           accounts: data.accounts,
           activeUsers: online.count || data.activeUsers || 0,
           nftsCreated: data.nftsCreated,
+          nftsBurned: data.nftsBurned,
+          bundlesSold: data.bundlesSold,
+          tonRaised: data.tonRaised,
+          appClaimed: data.appClaimed,
+          externalClaimed: data.externalClaimed,
         });
       } catch (err) {
         console.error('Failed to load stats:', err);


### PR DESCRIPTION
## Summary
- update `Home.jsx` to include additional stats from `/api/stats`

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_686e5a3be02c832997518396f1ff95f4