### PR TITLE
Add NFT send option in leaderboard popup

### DIFF
--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -1,0 +1,142 @@
+import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import RoomSelector from './RoomSelector.jsx';
+import GiftPopup from './GiftPopup.jsx';
+import GiftIcon from './GiftIcon.jsx';
+import { getAccountInfo, getSnakeResults } from '../utils/api.js';
+import { NFT_GIFTS } from '../utils/nftGifts.js';
+
+export default function PlayerInvitePopup({
+  open,
+  player,
+  stake,
+  onStakeChange,
+  onInvite,
+  onClose,
+}) {
+  const [info, setInfo] = useState(null);
+  const [records, setRecords] = useState([]);
+  const [giftOpen, setGiftOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open || !player) return;
+    if (player.accountId) {
+      getAccountInfo(player.accountId)
+        .then(setInfo)
+        .catch(() => {});
+    }
+    getSnakeResults()
+      .then((data) => {
+        const name =
+          player.nickname || `${player.firstName || ''} ${player.lastName || ''}`.trim();
+        const rec = (data.results || []).filter(
+          (r) => r.winner === name || (Array.isArray(r.participants) && r.participants.includes(name))
+        );
+        setRecords(rec.slice(0, 5));
+      })
+      .catch(() => {});
+  }, [open, player]);
+
+  if (!open || !player) return null;
+
+  const gifts = info?.gifts || [];
+  const balance = info?.balance ?? player.balance;
+  const name = player.nickname || `${player.firstName || ''} ${player.lastName || ''}`.trim();
+
+  return createPortal(
+    <>
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70"
+        onClick={onClose}
+      >
+        <div
+          className="bg-surface border border-border rounded p-4 space-y-3 w-96 max-h-[90vh] overflow-y-auto"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="text-center space-y-1">
+            <img
+              src={player.photo || player.photoUrl || '/assets/icons/profile.svg'}
+              alt="user"
+              className="w-24 h-24 rounded-full mx-auto"
+            />
+            <p className="font-semibold">{name}</p>
+            {player.accountId && (
+              <p className="text-sm break-all">Account: {player.accountId}</p>
+            )}
+            {balance !== undefined && (
+              <p className="text-sm">Balance: {balance}</p>
+            )}
+          </div>
+          <div>
+            <h4 className="font-semibold">NFTs</h4>
+            <div className="flex space-x-1 overflow-x-auto">
+              {gifts.length ? (
+                gifts.map((g) => {
+                  const gi = NFT_GIFTS.find((x) => x.id === g.gift) || {};
+                  return (
+                    <GiftIcon
+                      key={g._id}
+                      icon={gi.icon}
+                      className="w-6 h-6"
+                      title={gi.name || g.gift}
+                    />
+                  );
+                })
+              ) : (
+                <p className="text-sm text-subtext">None</p>
+              )}
+            </div>
+          </div>
+          <div>
+            <h4 className="font-semibold">Recent Games</h4>
+            <ul className="text-sm space-y-0.5 list-disc list-inside">
+              {records.length ? (
+                records.map((r, idx) => (
+                  <li key={idx} className="break-all">
+                    <span className="font-semibold">{r.winner}</span> vs{' '}
+                    {r.participants.filter((p) => p !== r.winner).join(', ') || 'AI'}
+                  </li>
+                ))
+              ) : (
+                <li>No records</li>
+              )}
+            </ul>
+          </div>
+          <RoomSelector selected={stake} onSelect={onStakeChange} />
+          <div className="flex justify-center gap-2">
+            <button
+              onClick={onInvite}
+              className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
+            >
+              Invite
+            </button>
+            <button
+              onClick={() => setGiftOpen(true)}
+              className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
+            >
+              Send NFT
+            </button>
+            <button
+              onClick={onClose}
+              className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+      <GiftPopup
+        open={giftOpen}
+        onClose={() => setGiftOpen(false)}
+        players={[{
+          id: player.accountId,
+          name,
+          photoUrl: player.photo || player.photoUrl || '/assets/icons/profile.svg',
+          index: 0,
+        }]}
+        senderIndex={0}
+      />
+    </>,
+    document.body
+  );
+}

--- a/webapp/src/pages/Friends.jsx
+++ b/webapp/src/pages/Friends.jsx
@@ -19,6 +19,7 @@ import { BOT_USERNAME } from '../utils/constants.js';
 import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
 import { socket } from '../utils/socket.js';
 import InvitePopup from '../components/InvitePopup.jsx';
+import PlayerInvitePopup from '../components/PlayerInvitePopup.jsx';
 
 export default function Friends() {
   useTelegramBackButton();
@@ -306,12 +307,12 @@ export default function Friends() {
       </div>
     </section>
 
-    <InvitePopup
+    <PlayerInvitePopup
       open={!!inviteTarget}
-      name={inviteTarget?.nickname || `${inviteTarget?.firstName || ''} ${inviteTarget?.lastName || ''}`.trim()}
+      player={inviteTarget}
       stake={stake}
       onStakeChange={setStake}
-      onAccept={() => {
+      onInvite={() => {
         if (inviteTarget) {
           const roomId = `invite-${accountId}-${inviteTarget.accountId}-${Date.now()}-2`;
           socket.emit(
@@ -337,7 +338,7 @@ export default function Friends() {
         }
         setInviteTarget(null);
       }}
-      onReject={() => setInviteTarget(null)}
+      onClose={() => setInviteTarget(null)}
     />
     <InvitePopup
       open={groupPopup}


### PR DESCRIPTION
## Summary
- create new `PlayerInvitePopup` component to combine game invite and NFT send options with extra player info
- integrate new popup into friends leaderboard

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_686e608640fc8329b21ee50b43c45fbb