### PR TITLE
Update stats and remove contract balance

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -272,10 +272,15 @@ app.get('/api/stats', async (req, res) => {
     let bundlesSold = 0;
     let tonRaised = 0;
     let currentNfts = 0;
+    let nftValue = 0;
     let appClaimed = 0;
     let externalClaimed = 0;
     for (const u of users) {
-      currentNfts += (u.gifts || []).filter((g) => g.nftTokenId).length;
+      const nftGifts = (u.gifts || []).filter((g) => g.nftTokenId);
+      currentNfts += nftGifts.length;
+      for (const g of nftGifts) {
+        nftValue += g.price || 0;
+      }
       for (const tx of u.transactions || []) {
         if (tx.type === 'gift') giftSends++;
         if (tx.type === 'store') {
@@ -297,8 +302,9 @@ app.get('/api/stats', async (req, res) => {
       nftsBurned,
       bundlesSold,
       tonRaised,
-      appClaimed,
+      appClaimed: totalBalance,
       externalClaimed,
+      nftValue,
     });
   } catch (err) {
     console.error('Failed to compute stats:', err.message);

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -191,6 +191,7 @@ export default function Home() {
           tonRaised: data.tonRaised,
           appClaimed: data.appClaimed,
           externalClaimed: data.externalClaimed,
+          nftValue: data.nftValue,
         });
       } catch (err) {
         console.error('Failed to load stats:', err);
@@ -304,12 +305,9 @@ export default function Home() {
             {holders != null && (
               <p className="text-sm text-subtext">Holders: {holders}</p>
             )}
-            {contractTonBalance != null && (
-              <p className="text-sm text-subtext">
-                Contract TON balance: {formatValue(contractTonBalance, 3)} TON
-              </p>
-            )}
-            <p className="text-xs break-all mt-1 text-primary">{TPC_JETTON_ADDRESS}</p>
+            <p className="text-xs break-all mt-1 text-brand-gold">
+              Token Contract: {TPC_JETTON_ADDRESS}
+            </p>
           </div>
           <div className="space-y-1">
             <h4 className="text-sm font-bold text-center">TPC Wallet Addresses</h4>
@@ -361,7 +359,12 @@ export default function Home() {
             </p>
             <p>Accounts: {stats.accounts}</p>
             <p>Active Users: {stats.activeUsers}</p>
-            <p>NFTs Created: {stats.nftsCreated}</p>
+            <p>
+              NFTs Created: {stats.nftsCreated}
+              {stats.nftValue != null && (
+                <span> ({formatValue(stats.nftValue, 0)} TPC)</span>
+              )}
+            </p>
             <p>NFTs Burned: {stats.nftsBurned}</p>
             <p>Bundles Sold: {stats.bundlesSold}</p>
             <p>

--- a/webapp/src/pages/Tokenomics.jsx
+++ b/webapp/src/pages/Tokenomics.jsx
@@ -511,13 +511,8 @@ export default function TokenomicsPage() {
           {holders != null && (
             <p className="text-sm text-subtext">Holders: {holders}</p>
           )}
-          {tonBalance != null && (
-            <p className="text-sm text-subtext">
-              Contract TON balance: {formatValue(tonBalance, 3)} TON
-            </p>
-          )}
-          <p className="text-xs break-all mt-1 text-primary">
-            {TPC_JETTON_ADDRESS}
+          <p className="text-xs break-all mt-1 text-brand-gold">
+            Token Contract: {TPC_JETTON_ADDRESS}
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show the token contract instead of TON balance on Home and Tokenomics pages
- compute NFT value and circulating supply on the server
- display NFT value next to created NFTs and use new stat for app claimed coins

## Testing
- `npm test` *(fails: Cannot find packages)*
- `npm --prefix webapp run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e64ee0ea48329aecaa7809791832e