### PR TITLE
Update token contract display on homepage

### DIFF
--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -305,8 +305,16 @@ export default function Home() {
             {holders != null && (
               <p className="text-sm text-subtext">Holders: {holders}</p>
             )}
-            <p className="text-xs break-all mt-1 text-brand-gold">
-              Token Contract: {TPC_JETTON_ADDRESS}
+            <p className="text-xs break-all mt-1">
+              <span className="font-semibold text-brand-gold">Token Contract: </span>
+              <a
+                href={`https://tonscan.org/address/${TPC_JETTON_ADDRESS}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                {TPC_JETTON_ADDRESS}
+              </a>
             </p>
           </div>
           <div className="space-y-1">


### PR DESCRIPTION
## Summary
- show Token Contract with a link in the Tokenomics & Roadmap card instead of plain yellow text

## Testing
- `npm test` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_686e81c653d083299c7e2cbfb66ef40f