### PR TITLE
Update mining and leaderboard pages

### DIFF
--- a/webapp/public/sitemap.xml
+++ b/webapp/public/sitemap.xml
@@ -3,7 +3,7 @@
   <url><loc>https://tonplaygram.example.com/</loc></url>
   <url><loc>https://tonplaygram.example.com/wallet</loc></url>
   <url><loc>https://tonplaygram.example.com/games</loc></url>
-  <url><loc>https://tonplaygram.example.com/friends</loc></url>
+  <url><loc>https://tonplaygram.example.com/mining</loc></url>
   <url><loc>https://tonplaygram.example.com/tasks</loc></url>
   <url><loc>https://tonplaygram.example.com/store</loc></url>
   <url><loc>https://tonplaygram.example.com/referral</loc></url>

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -3,7 +3,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { TonConnectUIProvider } from '@tonconnect/ui-react';
 
 import Home from './pages/Home.jsx';
-import Friends from './pages/Friends.jsx';
+import Mining from './pages/Mining.jsx';
 import Wallet from './pages/Wallet.jsx';
 import Tasks from './pages/Tasks.jsx';
 import Referral from './pages/Referral.jsx';
@@ -36,7 +36,7 @@ export default function App() {
         <Layout>
           <Routes>
           <Route path="/" element={<Home />} />
-          <Route path="/friends" element={<Friends />} />
+          <Route path="/mining" element={<Mining />} />
           <Route path="/games" element={<Games />} />
           <Route path="/games/:game/lobby" element={<Lobby />} />
             <Route path="/games/horse" element={<HorseRacing />} />

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -68,7 +68,7 @@ export default function Layout({ children }) {
   }, []);
 
   const isHome = location.pathname === '/';
-  const isFriends = location.pathname === '/friends';
+  const isMining = location.pathname === '/mining';
   const isTasks = location.pathname === '/tasks';
   const isStore = location.pathname === '/store';
   const isAccount = location.pathname === '/account';
@@ -97,8 +97,8 @@ export default function Layout({ children }) {
 
         {showBranding && (
         <Branding
-            scale={isFriends || isTasks || isStore || isAccount || isGamesRoot || isWallet ? 1.2 : 1}
-            offsetY={isFriends ? '0.5rem' : 0}
+            scale={isMining || isTasks || isStore || isAccount || isGamesRoot || isWallet ? 1.2 : 1}
+            offsetY={isMining ? '0.5rem' : 0}
           />
         )}
 

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -1,0 +1,298 @@
+import { useEffect, useState } from 'react';
+import { FaCircle } from 'react-icons/fa';
+import LoginOptions from './LoginOptions.jsx';
+import { getTelegramId, getTelegramPhotoUrl, getPlayerId } from '../utils/telegram.js';
+import {
+  getLeaderboard,
+  getOnlineCount,
+  getOnlineUsers,
+  fetchTelegramInfo,
+  getProfile,
+} from '../utils/api.js';
+import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
+import { socket } from '../utils/socket.js';
+import InvitePopup from './InvitePopup.jsx';
+import PlayerInvitePopup from './PlayerInvitePopup.jsx';
+
+export default function LeaderboardCard() {
+  let telegramId;
+  try {
+    telegramId = getTelegramId();
+  } catch (err) {
+    return <LoginOptions />;
+  }
+
+  const accountId = getPlayerId();
+
+  const [leaderboard, setLeaderboard] = useState([]);
+  const [rank, setRank] = useState(null);
+  const [myPhotoUrl, setMyPhotoUrl] = useState(
+    loadAvatar() || getTelegramPhotoUrl()
+  );
+  const [inviteTarget, setInviteTarget] = useState(null);
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [myName, setMyName] = useState('');
+  const [onlineUsers, setOnlineUsers] = useState([]);
+  const [onlineCount, setOnlineCount] = useState(0);
+  const [mode, setMode] = useState('1v1');
+  const [selected, setSelected] = useState([]);
+  const [groupPopup, setGroupPopup] = useState(false);
+
+  useEffect(() => {
+    getLeaderboard(telegramId).then((data) => {
+      setLeaderboard(data.users);
+      setRank(data.rank);
+    });
+
+    const saved = loadAvatar();
+    if (saved) {
+      setMyPhotoUrl(saved);
+      getProfile(telegramId)
+        .then((p) =>
+          setMyName(
+            p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim()
+          )
+        )
+        .catch(() => {});
+    } else {
+      getProfile(telegramId)
+        .then((p) => {
+          if (p?.photo) {
+            setMyPhotoUrl(p.photo);
+            saveAvatar(p.photo);
+          } else {
+            fetchTelegramInfo(telegramId).then((info) => {
+              if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
+            });
+          }
+          setMyName(
+            p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim()
+          );
+        })
+        .catch(() => {
+          fetchTelegramInfo(telegramId).then((info) => {
+            if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
+            setMyName(`${info?.firstName || ''} ${info?.lastName || ''}`.trim());
+          });
+        });
+    }
+  }, [telegramId]);
+
+  useEffect(() => {
+    function loadOnline() {
+      getOnlineUsers().then((d) => setOnlineUsers(d.users || []));
+      getOnlineCount().then((d) => setOnlineCount(d.count || 0));
+    }
+    loadOnline();
+    const id = setInterval(loadOnline, 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <>
+      <section
+        id="leaderboard"
+        className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card mt-4"
+      >
+        <img
+          src="/assets/SnakeLaddersbackground.png"
+          className="background-behind-board object-cover"
+          alt=""
+        />
+        <h3 className="text-lg font-semibold text-center">Leaderboard</h3>
+        <div className="flex items-center justify-between">
+          <span className="flex items-center space-x-2">
+            <select
+              value={mode}
+              onChange={(e) => {
+                setMode(e.target.value);
+                setSelected([]);
+              }}
+              className="bg-surface border border-border rounded text-sm"
+            >
+              <option value="1v1">1v1</option>
+              <option value="group">Group</option>
+            </select>
+            {mode === 'group' && (
+              <button
+                onClick={() => setGroupPopup(true)}
+                disabled={selected.length === 0}
+                className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow disabled:opacity-50"
+              >
+                Invite {selected.length}/3
+              </button>
+            )}
+            <FaCircle
+              className={onlineCount > 0 ? 'text-green-500' : 'text-red-500'}
+              size={10}
+            />
+            <span className="ml-1">{onlineCount}</span>
+          </span>
+        </div>
+        <div className="max-h-[80rem] overflow-y-auto border border-border rounded">
+          <table className="w-full text-sm">
+            <thead className="sticky top-0 bg-surface">
+              <tr className="border-b border-border text-left">
+                <th className="p-2">#</th>
+                <th className="p-2 w-16"></th>
+                <th className="p-2">User</th>
+                <th className="p-2 text-right">TPC</th>
+              </tr>
+            </thead>
+            <tbody>
+              {leaderboard.map((u, idx) => (
+                <tr
+                  key={u.accountId || u.telegramId}
+                  className={`border-b border-border h-16 ${
+                    u.accountId === accountId ? 'bg-accent text-black' : 'cursor-pointer'
+                  }`}
+                  onClick={() => {
+                    if (u.accountId === accountId || u.currentTableId) return;
+                    if (mode === 'group') {
+                      setSelected((prev) => {
+                        const exists = prev.find((p) => p.accountId === u.accountId);
+                        if (exists) return prev.filter((p) => p.accountId !== u.accountId);
+                        if (prev.length >= 3) return prev;
+                        return [...prev, u];
+                      });
+                    } else {
+                      setInviteTarget(u);
+                    }
+                  }}
+                >
+                  <td className="p-2">{idx + 1}</td>
+                  <td className="p-2 w-16">
+                    <img
+                      src={getAvatarUrl(
+                        u.accountId === accountId
+                          ? myPhotoUrl || '/assets/icons/profile.svg'
+                          : u.photo || u.photoUrl || '/assets/icons/profile.svg'
+                      )}
+                      alt="avatar"
+                      className="w-16 h-16 hexagon border-2 border-brand-gold object-cover shadow-[0_0_12px_rgba(241,196,15,0.8)]"
+                    />
+                  </td>
+                  <td className="p-2 flex items-center">
+                    {mode === 'group' && u.accountId !== accountId && (
+                      <input
+                        type="checkbox"
+                        disabled={!!u.currentTableId}
+                        checked={selected.some((p) => p.accountId === u.accountId)}
+                        onChange={() => {}}
+                        className="mr-1"
+                      />
+                    )}
+                    {u.nickname || `${u.firstName} ${u.lastName}`.trim() || 'User'}
+                    {u.accountId !== accountId &&
+                      u.currentTableId && (
+                        <span className="ml-1 text-xs text-red-500">Playing</span>
+                      )}
+                    {onlineUsers.includes(String(u.accountId)) && (
+                      <FaCircle className="ml-1 text-green-500" size={8} />
+                    )}
+                  </td>
+                  <td className="p-2 text-right">{u.balance}</td>
+                </tr>
+              ))}
+              {rank && rank > 100 && (
+                <tr className="bg-accent text-black h-16">
+                  <td className="p-2">{rank}</td>
+                  <td className="p-2 w-16">
+                    <img
+                      src={getAvatarUrl(myPhotoUrl || '/assets/icons/profile.svg')}
+                      alt="avatar"
+                      className="w-16 h-16 hexagon border-2 border-brand-gold object-cover shadow-[0_0_12px_rgba(241,196,15,0.8)]"
+                    />
+                  </td>
+                  <td className="p-2 flex items-center">
+                    You
+                    {onlineUsers.includes(String(accountId)) && (
+                      <FaCircle className="ml-1 text-green-500" size={8} />
+                    )}
+                  </td>
+                  <td className="p-2 text-right">
+                    {leaderboard.find((u) => u.accountId === accountId)?.balance ?? '...'}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <PlayerInvitePopup
+        open={!!inviteTarget}
+        player={inviteTarget}
+        stake={stake}
+        onStakeChange={setStake}
+        onInvite={() => {
+          if (inviteTarget) {
+            const roomId = `invite-${accountId}-${inviteTarget.accountId}-${Date.now()}-2`;
+            socket.emit(
+              'invite1v1',
+              {
+                fromId: accountId,
+                fromTelegramId: telegramId,
+                fromName: myName,
+                toId: inviteTarget.accountId,
+                toTelegramId: inviteTarget.telegramId,
+                roomId,
+                token: stake.token,
+                amount: stake.amount,
+              },
+              (res) => {
+                if (res && res.success) {
+                  window.location.href = `/games/snake?table=${roomId}&token=${stake.token}&amount=${stake.amount}`;
+                } else {
+                  alert(res?.error || 'Failed to send invite');
+                }
+              }
+            );
+          }
+          setInviteTarget(null);
+        }}
+        onClose={() => setInviteTarget(null)}
+      />
+      <InvitePopup
+        open={groupPopup}
+        name={selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim())}
+        stake={stake}
+        onStakeChange={setStake}
+        group
+        opponents={selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim())}
+        onAccept={() => {
+          if (selected.length > 0) {
+            const roomId = `invite-${accountId}-${Date.now()}-${selected.length + 1}`;
+            socket.emit(
+              'inviteGroup',
+              {
+                fromId: accountId,
+                fromTelegramId: telegramId,
+                fromName: myName,
+                toIds: selected.map((u) => u.accountId),
+                telegramIds: selected.map((u) => u.telegramId),
+                opponentNames: selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim()),
+                roomId,
+                token: stake.token,
+                amount: stake.amount,
+              },
+              (res) => {
+                if (res && res.success) {
+                  window.location.href = `/games/snake?table=${roomId}&token=${stake.token}&amount=${stake.amount}`;
+                } else {
+                  alert(res?.error || 'Failed to send invite');
+                }
+              }
+            );
+          }
+          setGroupPopup(false);
+          setSelected([]);
+        }}
+        onReject={() => {
+          setGroupPopup(false);
+          setSelected([]);
+        }}
+      />
+    </>
+  );
+}

--- a/webapp/src/components/Navbar.jsx
+++ b/webapp/src/components/Navbar.jsx
@@ -3,9 +3,9 @@ import {
   AiOutlinePlayCircle,
   AiOutlineCheckSquare,
   AiOutlineUser,
-  AiOutlineShop,
-  AiOutlineUsergroupAdd
+  AiOutlineShop
 } from 'react-icons/ai';
+import { GiMining } from 'react-icons/gi';
 import NavItem from './NavItem.jsx';
 
 export default function Navbar() {
@@ -13,7 +13,7 @@ export default function Navbar() {
     <nav className="fixed inset-x-0 bottom-0 z-50 bg-surface text-text shadow border-t border-accent">
       <div className="container mx-auto px-4 py-4 flex items-center justify-between text-base">
         <NavItem to="/" icon={AiOutlineHome} label="Home" />
-        <NavItem to="/friends" icon={AiOutlineUsergroupAdd} label="Friends" />
+        <NavItem to="/mining" icon={GiMining} label="Mining" />
         <NavItem to="/games" icon={AiOutlinePlayCircle} label="Games" />
         <NavItem to="/tasks" icon={AiOutlineCheckSquare} label="Tasks" />
         <NavItem to="/store" icon={AiOutlineShop} label="Store" />

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -1,5 +1,6 @@
 import GameCard from '../components/GameCard.jsx';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
+import LeaderboardCard from '../components/LeaderboardCard.jsx';
 
 export default function Games() {
   useTelegramBackButton();
@@ -8,6 +9,7 @@ export default function Games() {
       <h2 className="text-2xl font-bold text-center mt-4">Games</h2>
       <div className="space-y-4">
         <GameCard title="Snake & Ladder" icon="🎲" link="/games/snake/lobby" />
+        <LeaderboardCard />
       </div>
     </div>
   );

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -2,10 +2,6 @@ import { useEffect, useState, useRef } from 'react';
 
 import GameCard from '../components/GameCard.jsx';
 
-import MiningCard from '../components/MiningCard.tsx';
-
-import SpinGame from '../components/SpinGame.jsx';
-import DailyCheckIn from '../components/DailyCheckIn.jsx';
 
 import TasksCard from '../components/TasksCard.jsx';
 import StoreAd from '../components/StoreAd.jsx';
@@ -302,11 +298,7 @@ export default function Home() {
 
       </div>
 
-      <DailyCheckIn />
-      <SpinGame />
-
       <div className="grid grid-cols-1 gap-4">
-        <MiningCard />
         <TasksCard />
         <StoreAd />
         <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -4,6 +4,9 @@ import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LoginOptions from '../components/LoginOptions.jsx';
 import { getTelegramId, getTelegramPhotoUrl, getPlayerId } from '../utils/telegram.js';
 import { FaCircle } from 'react-icons/fa';
+import DailyCheckIn from '../components/DailyCheckIn.jsx';
+import SpinGame from '../components/SpinGame.jsx';
+import MiningCard from '../components/MiningCard.tsx';
 import {
   getLeaderboard,
   getReferralInfo,
@@ -21,7 +24,7 @@ import { socket } from '../utils/socket.js';
 import InvitePopup from '../components/InvitePopup.jsx';
 import PlayerInvitePopup from '../components/PlayerInvitePopup.jsx';
 
-export default function Friends() {
+export default function Mining() {
   useTelegramBackButton();
   let telegramId;
   try {
@@ -129,7 +132,7 @@ export default function Friends() {
         className="background-behind-board object-cover"
         alt=""
       />
-        <h2 className="text-xl font-bold text-center">Friends</h2>
+        <h2 className="text-xl font-bold text-center">Mining</h2>
 
       {friendRequests.length > 0 && (
         <section className="space-y-1">
@@ -187,125 +190,9 @@ export default function Friends() {
       </section>
     </div>
 
-    <section id="leaderboard" className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card mt-4">
-      <img
-        src="/assets/SnakeLaddersbackground.png"
-        className="background-behind-board object-cover"
-        alt=""
-      />
-      <h3 className="text-lg font-semibold text-center">Leaderboard</h3>
-      <div className="flex items-center justify-between">
-        <span className="flex items-center space-x-2">
-          <select
-            value={mode}
-            onChange={(e) => {
-              setMode(e.target.value);
-              setSelected([]);
-            }}
-            className="bg-surface border border-border rounded text-sm"
-          >
-            <option value="1v1">1v1</option>
-            <option value="group">Group</option>
-          </select>
-          {mode === 'group' && (
-            <button
-              onClick={() => setGroupPopup(true)}
-              disabled={selected.length === 0}
-              className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow disabled:opacity-50"
-            >
-              Invite {selected.length}/3
-            </button>
-          )}
-          <FaCircle className={onlineCount > 0 ? 'text-green-500' : 'text-red-500'} size={10} />
-          <span className="ml-1">{onlineCount}</span>
-        </span>
-      </div>
-      <div className="max-h-[80rem] overflow-y-auto border border-border rounded">
-        <table className="w-full text-sm">
-          <thead className="sticky top-0 bg-surface">
-            <tr className="border-b border-border text-left">
-              <th className="p-2">#</th>
-              <th className="p-2 w-16"></th>
-              <th className="p-2">User</th>
-              <th className="p-2 text-right">TPC</th>
-            </tr>
-          </thead>
-          <tbody>
-            {leaderboard.map((u, idx) => (
-              <tr
-                key={u.accountId || u.telegramId}
-                className={`border-b border-border h-16 ${u.accountId === accountId ? 'bg-accent text-black' : 'cursor-pointer'}`}
-                onClick={() => {
-                  if (u.accountId === accountId || u.currentTableId) return;
-                  if (mode === 'group') {
-                    setSelected((prev) => {
-                      const exists = prev.find((p) => p.accountId === u.accountId);
-                      if (exists) return prev.filter((p) => p.accountId !== u.accountId);
-                      if (prev.length >= 3) return prev;
-                      return [...prev, u];
-                    });
-                  } else {
-                    setInviteTarget(u);
-                  }
-                }}
-              >
-                <td className="p-2">{idx + 1}</td>
-                <td className="p-2 w-16">
-                  <img
-                    src={getAvatarUrl(
-                      u.accountId === accountId
-                        ? myPhotoUrl || '/assets/icons/profile.svg'
-                        : u.photo || u.photoUrl || '/assets/icons/profile.svg'
-                    )}
-                    alt="avatar"
-                    className="w-16 h-16 hexagon border-2 border-brand-gold object-cover shadow-[0_0_12px_rgba(241,196,15,0.8)]"
-                  />
-                </td>
-                <td className="p-2 flex items-center">
-                  {mode === 'group' && u.accountId !== accountId && (
-                    <input
-                      type="checkbox"
-                      disabled={!!u.currentTableId}
-                      checked={selected.some((p) => p.accountId === u.accountId)}
-                      onChange={() => {}}
-                      className="mr-1"
-                    />
-                  )}
-                  {u.nickname || `${u.firstName} ${u.lastName}`.trim() || 'User'}
-                  {u.accountId !== accountId &&
-                    u.currentTableId && (
-                      <span className="ml-1 text-xs text-red-500">Playing</span>
-                    )}
-                  {onlineUsers.includes(String(u.accountId)) && (
-                    <FaCircle className="ml-1 text-green-500" size={8} />
-                  )}
-                </td>
-                <td className="p-2 text-right">{u.balance}</td>
-              </tr>
-            ))}
-            {rank && rank > 100 && (
-              <tr className="bg-accent text-black h-16">
-                <td className="p-2">{rank}</td>
-                <td className="p-2 w-16">
-                  <img
-                    src={getAvatarUrl(myPhotoUrl || '/assets/icons/profile.svg')}
-                    alt="avatar"
-                    className="w-16 h-16 hexagon border-2 border-brand-gold object-cover shadow-[0_0_12px_rgba(241,196,15,0.8)]"
-                  />
-                </td>
-                <td className="p-2 flex items-center">
-                  You
-                  {onlineUsers.includes(String(accountId)) && (
-                    <FaCircle className="ml-1 text-green-500" size={8} />
-                  )}
-                </td>
-                <td className="p-2 text-right">{leaderboard.find((u) => u.accountId === accountId)?.balance ?? '...'}</td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-    </section>
+    <DailyCheckIn />
+    <SpinGame />
+    <MiningCard />
 
     <PlayerInvitePopup
       open={!!inviteTarget}

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -271,8 +271,8 @@ export default function MyAccount() {
             Use Telegram Photo
           </button>
           <div className="mt-2 space-x-2">
-            <a href="/friends" className="underline text-primary">
-              Friends
+            <a href="/mining" className="underline text-primary">
+              Mining
             </a>
             <a href="/messages" className="underline text-primary">
               Inbox


### PR DESCRIPTION
## Summary
- rename Friends page to Mining
- move leaderboard card to Games page and add LeaderboardCard component
- show mining, spin and daily check-in on new Mining page
- remove those cards from Home page
- update navigation and sitemap for `/mining`

## Testing
- `npm test` *(fails: test suite reports 4 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686e90dd5a0883299dcb8f5cc803a161