### PR TITLE
Remove celebrations and sounds

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -142,12 +142,11 @@ export default function DailyCheckIn() {
 
 
       {reward !== null && (
-
         <RewardPopup
           reward={reward}
           onClose={() => setReward(null)}
+          disableEffects
         />
-
       )}
 
       <h3 className="text-lg font-bold text-text">Daily Streaks</h3>
@@ -159,5 +158,4 @@ export default function DailyCheckIn() {
     </div>
 
   );
-
 }

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -8,25 +8,35 @@ interface RewardPopupProps {
   onClose: () => void;
   duration?: number;
   showCloseButton?: boolean;
+  disableEffects?: boolean;
 }
 
-export default function RewardPopup({ reward, onClose, duration = 2500, showCloseButton = true }: RewardPopupProps) {
+export default function RewardPopup({
+  reward,
+  onClose,
+  duration = 2500,
+  showCloseButton = true,
+  disableEffects = false,
+}: RewardPopupProps) {
   if (reward === null) return null;
   useEffect(() => {
-    let icon = '/assets/icons/TPCcoin_1.webp';
-    if (reward === 'BONUS_X2') {
-      icon = '/assets/icons/file_00000000ead061faa3b429466e006f48.webp';
+    let audio: HTMLAudioElement | undefined;
+    if (!disableEffects) {
+      let icon = '/assets/icons/TPCcoin_1.webp';
+      if (reward === 'BONUS_X2') {
+        icon = '/assets/icons/file_00000000ead061faa3b429466e006f48.webp';
+      }
+      coinConfetti(50, icon);
+      audio = new Audio('/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3');
+      audio.volume = getGameVolume();
+      audio.play().catch(() => {});
     }
-    coinConfetti(50, icon);
-    const audio = new Audio('/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3');
-    audio.volume = getGameVolume();
-    audio.play().catch(() => {});
     const timer = setTimeout(onClose, duration);
     return () => {
-      audio.pause();
+      if (audio) audio.pause();
       clearTimeout(timer);
     };
-  }, [onClose, duration, reward]);
+  }, [onClose, duration, reward, disableEffects]);
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="text-center space-y-4 text-text">

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -153,6 +153,7 @@ export default function SpinGame() {
               setSpinning={setLeftSpinning}
               disabled={!bonusActive}
               showButton={false}
+              disableSound
             />
           </div>
           {!bonusActive && (
@@ -168,6 +169,7 @@ export default function SpinGame() {
           setSpinning={setSpinning}
           disabled={!ready}
           showButton={false}
+          disableSound
         />
         <div className="relative">
           <div style={{ opacity: bonusActive ? 1 : 0.15 }}>
@@ -178,6 +180,7 @@ export default function SpinGame() {
               setSpinning={setRightSpinning}
               disabled={!bonusActive}
               showButton={false}
+              disableSound
             />
           </div>
           {!bonusActive && (
@@ -210,6 +213,7 @@ export default function SpinGame() {
       <RewardPopup
         reward={reward}
         onClose={() => setReward(null)}
+        disableEffects
       />
       <AdModal
         open={showAd}

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -9,15 +9,12 @@ export interface SpinWheelHandle {
 }
 
 interface SpinWheelProps {
-
   onFinish: (reward: Segment) => void;
-
   spinning: boolean;
-
   setSpinning: (b: boolean) => void;
-
   disabled?: boolean;
   showButton?: boolean;
+  disableSound?: boolean;
 }
 
 // Slot machine style settings
@@ -38,6 +35,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
     setSpinning,
     disabled,
     showButton = true,
+    disableSound = false,
   }: SpinWheelProps,
   ref
 ) {
@@ -64,6 +62,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
   const extraBonusSoundRef1 = useRef<HTMLAudioElement | null>(null);
 
   useEffect(() => {
+    if (disableSound) return;
     spinSoundRef.current = new Audio('/assets/sounds/spinning.mp3');
     spinSoundRef.current.preload = 'auto';
     spinSoundRef.current.loop = true;
@@ -83,9 +82,10 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
       bonusSoundRef.current?.pause();
       extraBonusSoundRef1.current?.pause();
     };
-  }, []);
+  }, [disableSound]);
 
   useEffect(() => {
+    if (disableSound) return;
     const handler = () => {
       if (spinSoundRef.current) spinSoundRef.current.volume = getGameVolume();
       if (successSoundRef.current) successSoundRef.current.volume = getGameVolume();
@@ -94,7 +94,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
     };
     window.addEventListener('gameVolumeChanged', handler);
     return () => window.removeEventListener('gameVolumeChanged', handler);
-  }, []);
+  }, [disableSound]);
 
   const items = useMemo(
     () =>
@@ -108,7 +108,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
   const spin = () => {
 
     if (spinning || disabled) return;
-    if (spinSoundRef.current) {
+    if (!disableSound && spinSoundRef.current) {
       spinSoundRef.current.currentTime = 0;
       spinSoundRef.current.play().catch(() => {});
     }
@@ -129,21 +129,23 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
     setWinnerIndex(null);
 
     setTimeout(() => {
-      spinSoundRef.current?.pause();
-      if (spinSoundRef.current) spinSoundRef.current.currentTime = 0;
+      if (!disableSound) {
+        spinSoundRef.current?.pause();
+        if (spinSoundRef.current) spinSoundRef.current.currentTime = 0;
+      }
 
       setSpinning(false);
       setWinnerIndex(finalIndex);
 
-      if (reward === 'BONUS_X2') {
-        bonusSoundRef.current?.play().catch(() => {});
-        extraBonusSoundRef1.current?.play().catch(() => {});
-        if (successSoundRef.current) {
-          successSoundRef.current.currentTime = 0;
-          successSoundRef.current.play().catch(() => {});
-        }
-      } else {
-        if (successSoundRef.current) {
+      if (!disableSound) {
+        if (reward === 'BONUS_X2') {
+          bonusSoundRef.current?.play().catch(() => {});
+          extraBonusSoundRef1.current?.play().catch(() => {});
+          if (successSoundRef.current) {
+            successSoundRef.current.currentTime = 0;
+            successSoundRef.current.play().catch(() => {});
+          }
+        } else if (successSoundRef.current) {
           successSoundRef.current.currentTime = 0;
           successSoundRef.current.play().catch(() => {});
         }

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -125,6 +125,10 @@ export default function Mining() {
 
   return (
     <>
+    <DailyCheckIn />
+    <SpinGame />
+    <MiningCard />
+
       <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-text overflow-hidden wide-card">
       <img
         
@@ -189,10 +193,6 @@ export default function Mining() {
         <UserSearchBar />
       </section>
     </div>
-
-    <DailyCheckIn />
-    <SpinGame />
-    <MiningCard />
 
     <PlayerInvitePopup
       open={!!inviteTarget}

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -137,6 +137,7 @@ export default function SpinPage() {
               setSpinning={setSpinningLeft}
               disabled={!ready}
               showButton={false}
+              disableSound
             />
           </div>
           <SpinWheel
@@ -146,6 +147,7 @@ export default function SpinPage() {
             setSpinning={setSpinningMain}
             disabled={!ready}
             showButton={false}
+            disableSound
           />
           <div className="ml-[-8px]">
             <SpinWheel
@@ -155,6 +157,7 @@ export default function SpinPage() {
               setSpinning={setSpinningMiddle}
               disabled={!ready}
               showButton={false}
+              disableSound
             />
           </div>
         </div>
@@ -188,6 +191,7 @@ export default function SpinPage() {
         onClose={() => setReward(null)}
         duration={1500}
         showCloseButton={false}
+        disableEffects
       />
       <AdModal
         open={showAd}


### PR DESCRIPTION
## Summary
- tone down RewardPopup with new `disableEffects` option
- silence SpinWheel with optional `disableSound`
- use these options in DailyCheckIn, SpinGame, and the standalone spin page
- move the friends card on the Mining page to the bottom

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_686e97c49db08329bbac3e5e26926649