### PR TITLE
Add free spin prize and x3 bonus mode

### DIFF
--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -23,8 +23,10 @@ export default function RewardPopup({
     let audio: HTMLAudioElement | undefined;
     if (!disableEffects) {
       let icon = '/assets/icons/TPCcoin_1.webp';
-      if (reward === 'BONUS_X2') {
+      if (reward === 'BONUS_X3') {
         icon = '/assets/icons/file_00000000ead061faa3b429466e006f48.webp';
+      } else if (reward === 'FREE_SPIN') {
+        icon = '/assets/icons/file_00000000ae68620a96d269fe76d158e5_256x256.webp';
       }
       coinConfetti(50, icon);
       audio = new Audio('/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3');
@@ -42,7 +44,7 @@ export default function RewardPopup({
       <div className="text-center space-y-4 text-text">
         <h3 className="text-lg font-bold">Reward Earned</h3>
         <div className="text-accent text-3xl flex items-center justify-center space-x-2">
-          {reward === 'BONUS_X2' && (
+          {reward === 'BONUS_X3' && (
             <>
               <img
 
@@ -50,7 +52,17 @@ export default function RewardPopup({
                 alt="Bonus"
                 className="w-8 h-8"
               />
-              <span>BONUS X2</span>
+              <span>BONUS X3</span>
+            </>
+          )}
+          {reward === 'FREE_SPIN' && (
+            <>
+              <img
+                src="/assets/icons/file_00000000ae68620a96d269fe76d158e5_256x256.webp"
+                alt="Free Spin"
+                className="w-8 h-8"
+              />
+              <span>FREE SPIN</span>
             </>
           )}
           {typeof reward === 'number' && (

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -45,7 +45,7 @@ export default function SpinGame() {
   }, [lastSpin]);
 
   const handleFinish = async (r) => {
-    if (r === 'BONUS_X2') {
+    if (r === 'BONUS_X3') {
       setReward(r);
       if (freeSpins === 0) {
         const now = Date.now();

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -12,6 +12,7 @@ interface SpinWheelProps {
   onFinish: (reward: Segment) => void;
   spinning: boolean;
   setSpinning: (b: boolean) => void;
+  segments?: Segment[];
   disabled?: boolean;
   showButton?: boolean;
   disableSound?: boolean;
@@ -33,6 +34,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
     onFinish,
     spinning,
     setSpinning,
+    segments,
     disabled,
     showButton = true,
     disableSound = false,
@@ -53,8 +55,12 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
       .map((x) => x[1]);
 
   const [wheelSegments, setWheelSegments] = useState<Segment[]>(() =>
-    shuffleSegments(baseSegments)
+    shuffleSegments(segments ?? baseSegments)
   );
+
+  useEffect(() => {
+    setWheelSegments(shuffleSegments(segments ?? baseSegments));
+  }, [segments]);
 
   const spinSoundRef = useRef<HTMLAudioElement | null>(null);
   const successSoundRef = useRef<HTMLAudioElement | null>(null);
@@ -138,7 +144,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
       setWinnerIndex(finalIndex);
 
       if (!disableSound) {
-        if (reward === 'BONUS_X2') {
+        if (reward === 'BONUS_X3') {
           bonusSoundRef.current?.play().catch(() => {});
           extraBonusSoundRef1.current?.play().catch(() => {});
           if (successSoundRef.current) {
@@ -197,19 +203,30 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
             <div
               key={idx}
               className={`board-style border-2 border-border text-sm w-28 font-bold flex items-center ${
-                val === 'BONUS_X2' ? 'justify-center' : 'justify-center space-x-1'
+                val === 'BONUS_X3' || val === 'FREE_SPIN'
+                  ? 'justify-center'
+                  : 'justify-center space-x-1'
               } ${
                 idx === winnerIndex ? 'bg-yellow-300 text-black border-4 border-brand-gold shadow-[0_0_12px_rgba(241,196,15,0.8)]' : 'text-white'
               }`}
               style={{ height: itemHeight }}
             >
-              {val === 'BONUS_X2' ? (
+              {val === 'BONUS_X3' ? (
                 <span className="text-red-600 font-bold drop-shadow-[0_0_2px_black]">
-                  BONUS X2
+                  BONUS X3
                 </span>
+              ) : val === 'FREE_SPIN' ? (
+                <>
+                  <img
+                    src="/assets/icons/file_00000000ae68620a96d269fe76d158e5_256x256.webp"
+                    alt="Free Spin"
+                    className="w-8 h-8"
+                  />
+                  <span>FREE SPIN</span>
+                </>
               ) : (
                 <>
-                  <img  src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-8 h-8" />
+                  <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-8 h-8" />
                   <span>{val >= 1000 ? `${val / 1000}k` : val}</span>
                 </>
               )}

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -3,7 +3,7 @@ import SpinWheel, { SpinWheelHandle } from '../components/SpinWheel.tsx';
 import type { Segment } from '../utils/rewardLogic';
 import RewardPopup from '../components/RewardPopup.tsx';
 import AdModal from '../components/AdModal.tsx';
-import { canSpin, nextSpinTime } from '../utils/rewardLogic';
+import { canSpin, nextSpinTime, numericSegments } from '../utils/rewardLogic';
 import {
   getWalletBalance,
   updateBalance,
@@ -89,36 +89,35 @@ export default function SpinPage() {
     setAdWatched(false);
   };
 
-  const handleFinish = async (r: Segment) => {
-    if (r === 'BONUS_X2') {
-      setBonusMode(true);
-      setLeftReward(null);
-      setRightReward(null);
-      leftRef.current?.spin();
-      rightRef.current?.spin();
-      return;
-    }
+    const handleFinish = async (r: Segment) => {
+      if (r === 'BONUS_X3') {
+        setBonusMode(true);
+        setLeftReward(null);
+        setRightReward(null);
+        leftRef.current?.spin();
+        rightRef.current?.spin();
+        return;
+      }
 
-    let extraSpins = 0;
-    if (r === 1600) extraSpins = 1;
-    else if (r === 1800) extraSpins = 2;
+      let extraSpins = 0;
+      if (r === 'FREE_SPIN') extraSpins = 1;
 
-    if (extraSpins > 0) {
-      const total = freeSpins + extraSpins;
-      setFreeSpins(total);
-      localStorage.setItem('freeSpins', String(total));
-    } else {
-      await finalizeReward(r as number);
-    }
+      if (extraSpins > 0) {
+        const total = freeSpins + extraSpins;
+        setFreeSpins(total);
+        localStorage.setItem('freeSpins', String(total));
+      } else {
+        if (typeof r === 'number') await finalizeReward(r as number);
+      }
 
-    const finalCount = freeSpins + extraSpins;
-    if (finalCount === 0) {
-      const now = Date.now();
-      localStorage.setItem('lastSpin', String(now));
-      setLastSpin(now);
-    }
-    if (extraSpins > 0) setReward(r as number);
-  };
+      const finalCount = freeSpins + extraSpins;
+      if (finalCount === 0) {
+        const now = Date.now();
+        localStorage.setItem('lastSpin', String(now));
+        setLastSpin(now);
+      }
+      setReward(r);
+    };
 
   const handleLeftFinish = (val: Segment) => {
     if (typeof val === 'number') setLeftReward(val);
@@ -176,6 +175,7 @@ export default function SpinPage() {
               setSpinning={setSpinningLeft}
               disabled={!ready}
               showButton={false}
+              segments={numericSegments}
             />
           )}
           <SpinWheel
@@ -185,6 +185,7 @@ export default function SpinPage() {
             setSpinning={setSpinningMain}
             disabled={!ready}
             showButton={false}
+            segments={bonusMode ? numericSegments : undefined}
           />
           {bonusMode && (
             <SpinWheel
@@ -194,6 +195,7 @@ export default function SpinPage() {
               setSpinning={setSpinningRight}
               disabled={!ready}
               showButton={false}
+              segments={numericSegments}
             />
           )}
         </div>

--- a/webapp/src/utils/rewardLogic.ts
+++ b/webapp/src/utils/rewardLogic.ts
@@ -1,5 +1,5 @@
 // Prize amounts available on the wheel.
-export type Segment = number | 'BONUS_X2';
+export type Segment = number | 'BONUS_X3' | 'FREE_SPIN';
 
 export const segments: Segment[] = [
   400,
@@ -9,7 +9,18 @@ export const segments: Segment[] = [
   1200,
   1400,
   1600,
-  'BONUS_X2',
+  'FREE_SPIN',
+  'BONUS_X3',
+];
+
+export const numericSegments: Segment[] = [
+  400,
+  600,
+  800,
+  1000,
+  1200,
+  1400,
+  1600,
 ];
 const COOLDOWN = 15 * 60_000; // 15 minutes
 


### PR DESCRIPTION
## Summary
- update reward segments to include FREE_SPIN and BONUS_X3
- support custom segment lists in `<SpinWheel>`
- show new FREE_SPIN icon and bonus X3 text in RewardPopup
- adjust spin logic for FREE_SPIN and bonus X3
- only numeric prizes on side wheels when bonus is active

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' etc.)*
- `npm --prefix webapp run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7ee7414083298118ffd42ff12dd7