### PR TITLE
Update free spin display and reward logic

### DIFF
--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -62,7 +62,7 @@ export default function RewardPopup({
                 alt="Free Spin"
                 className="w-8 h-8"
               />
-              <span>FREE SPIN</span>
+              <span>+2</span>
             </>
           )}
           {typeof reward === 'number' && (

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -55,6 +55,16 @@ export default function SpinGame() {
       setAdWatched(false);
       return;
     }
+
+    if (r === 'FREE_SPIN') {
+      const total = freeSpins + 2;
+      setFreeSpins(total);
+      localStorage.setItem('freeSpins', String(total));
+      setReward(r);
+      setAdWatched(false);
+      return;
+    }
+
     if (typeof r === 'number') {
       const id = telegramId;
       const balRes = await getWalletBalance(id);
@@ -62,6 +72,7 @@ export default function SpinGame() {
       await updateBalance(id, newBalance);
       await addTransaction(id, r, 'spin');
     }
+
     if (freeSpins === 0) {
       const now = Date.now();
       localStorage.setItem('lastSpin', String(now));

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -222,7 +222,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
                     alt="Free Spin"
                     className="w-8 h-8"
                   />
-                  <span>FREE SPIN</span>
+                  <span>+2</span>
                 </>
               ) : (
                 <>

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -100,7 +100,7 @@ export default function SpinPage() {
       }
 
       let extraSpins = 0;
-      if (r === 'FREE_SPIN') extraSpins = 1;
+      if (r === 'FREE_SPIN') extraSpins = 2;
 
       if (extraSpins > 0) {
         const total = freeSpins + extraSpins;


### PR DESCRIPTION
## Summary
- show `+2` instead of `FREE SPIN` on the wheel and reward popup
- award two free spins when landing on the free spin segment

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_686f8379a9908329893b3cfa14c7d18a