### PR TITLE
Add Crazy Dice Duel game

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -18,6 +18,8 @@ import HorseRacing from './pages/Games/HorseRacing.jsx';
 import SnakeAndLadder from './pages/Games/SnakeAndLadder.jsx';
 import SnakeMultiplayer from './pages/Games/SnakeMultiplayer.jsx';
 import SnakeResults from './pages/Games/SnakeResults.jsx';
+import CrazyDiceDuel from './pages/Games/CrazyDiceDuel.jsx';
+import CrazyDiceLobby from './pages/Games/CrazyDiceLobby.jsx';
 import Lobby from './pages/Games/Lobby.jsx';
 import Games from './pages/Games.jsx';
 import SpinPage from './pages/spin.tsx';
@@ -38,6 +40,8 @@ export default function App() {
           <Route path="/" element={<Home />} />
           <Route path="/mining" element={<Mining />} />
           <Route path="/games" element={<Games />} />
+          <Route path="/games/crazydice" element={<CrazyDiceDuel />} />
+          <Route path="/games/crazydice/lobby" element={<CrazyDiceLobby />} />
           <Route path="/games/:game/lobby" element={<Lobby />} />
             <Route path="/games/horse" element={<HorseRacing />} />
           <Route path="/games/snake" element={<SnakeAndLadder />} />

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1234,3 +1234,24 @@ input:focus {
 
 .chat-bubble{ @apply fixed bottom-4 left-1/2 -translate-x-1/2 bg-black bg-opacity-70 text-white rounded px-2 py-1 flex items-center space-x-2; font-size:1.2rem; }
 
+
+.crazy-dice-board {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+.crazy-dice-board .board-bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  z-index: -1;
+}
+.crazy-dice-board .dice-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -9,6 +9,7 @@ export default function Games() {
       <h2 className="text-2xl font-bold text-center mt-4">Games</h2>
       <div className="space-y-4">
         <GameCard title="Snake & Ladder" icon="🎲" link="/games/snake/lobby" />
+        <GameCard title="Crazy Dice Duel" icon="🎲" link="/games/crazydice/lobby" />
         <LeaderboardCard />
       </div>
     </div>

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -1,0 +1,113 @@
+import { useState, useMemo } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import DiceRoller from '../../components/DiceRoller.jsx';
+import AvatarTimer from '../../components/AvatarTimer.jsx';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+
+const COLORS = ['#60a5fa', '#ef4444', '#4ade80', '#facc15'];
+
+export default function CrazyDiceDuel() {
+  const navigate = useNavigate();
+  useTelegramBackButton(() => navigate('/games/crazydice/lobby', { replace: true }));
+  const [searchParams] = useSearchParams();
+  const playerCount = parseInt(searchParams.get('players')) || 2;
+  const maxRolls = parseInt(searchParams.get('rolls')) || 1;
+
+  const initialPlayers = useMemo(() => (
+    Array.from({ length: playerCount }, (_, i) => ({
+      score: 0,
+      rolls: 0,
+      photoUrl: loadAvatar() || '/assets/icons/profile.svg',
+      color: COLORS[i % COLORS.length],
+    }))
+  ), [playerCount]);
+
+  const [players, setPlayers] = useState(initialPlayers);
+  const [current, setCurrent] = useState(0);
+  const [trigger, setTrigger] = useState(0);
+  const [winner, setWinner] = useState(null);
+  const [tiePlayers, setTiePlayers] = useState(null);
+
+  const handleRollEnd = (values) => {
+    const value = Array.isArray(values) ? values.reduce((a, b) => a + b, 0) : values;
+    setPlayers((prev) => {
+      const next = prev.map((p, idx) =>
+        idx === current ? { ...p, score: p.score + value, rolls: p.rolls + 1 } : p
+      );
+      return next;
+    });
+    setTrigger((t) => t + 1);
+  };
+
+  const nextTurn = () => {
+    setCurrent((c) => {
+      let n = (c + 1) % players.length;
+      while (players[n].rolls >= maxRolls) n = (n + 1) % players.length;
+      return n;
+    });
+  };
+
+  const allRolled = players.every((p) => p.rolls >= maxRolls);
+
+  if (winner == null && allRolled) {
+    const max = Math.max(...players.map((p) => p.score));
+    const leaders = players.filter((p) => p.score === max);
+    if (leaders.length === 1) {
+      setWinner(players.indexOf(leaders[0]));
+    } else {
+      // tie break
+      setTiePlayers(leaders.map((p, idx) => players.indexOf(p)));
+      setPlayers((prev) => prev.map((p) => ({ ...p, rolls: 0 })));
+    }
+    setCurrent(0);
+    return null;
+  }
+
+  if (tiePlayers && players.every((p) => p.rolls >= maxRolls)) {
+    const max = Math.max(...players.map((p) => p.score));
+    const leaders = players.filter((p) => p.score === max);
+    if (leaders.length === 1) {
+      setWinner(players.indexOf(leaders[0]));
+    } else {
+      setPlayers((prev) => prev.map((p) => ({ ...p, rolls: 0 })));
+    }
+    setCurrent(0);
+    return null;
+  }
+
+  const onRollEnd = (values) => {
+    handleRollEnd(values);
+    nextTurn();
+  };
+
+  return (
+    <div className="crazy-dice-board text-text">
+      <img src="/assets/icons/file_00000000ce2461f7a5c5347320c3167c.webp" alt="board" className="board-bg" />
+      <div className="dice-center">
+        {winner == null ? (
+          <DiceRoller onRollEnd={onRollEnd} trigger={trigger} />
+        ) : (
+          <div className="text-2xl font-bold text-center">
+            Player {winner + 1} wins!
+          </div>
+        )}
+      </div>
+      <div className="fixed left-1 top-1/2 -translate-y-1/2 flex flex-col space-y-4 z-10">
+        {players.map((p, i) => (
+          <AvatarTimer
+            key={i}
+            index={i}
+            photoUrl={p.photoUrl}
+            active={i === current}
+            timerPct={1}
+            name={`P${i + 1}`}
+            color={p.color}
+          />
+        ))}
+      </div>
+      <BottomLeftIcons onInfo={() => {}} />
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/CrazyDiceLobby.jsx
+++ b/webapp/src/pages/Games/CrazyDiceLobby.jsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+
+export default function CrazyDiceLobby() {
+  const navigate = useNavigate();
+  useTelegramBackButton(() => navigate('/games', { replace: true }));
+
+  const [players, setPlayers] = useState(2);
+  const [rolls, setRolls] = useState(1);
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+
+  const startGame = () => {
+    const params = new URLSearchParams();
+    params.set('players', players);
+    params.set('rolls', rolls);
+    if (stake.token) params.set('token', stake.token);
+    if (stake.amount) params.set('amount', stake.amount);
+    navigate(`/games/crazydice?${params.toString()}`);
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-text">
+      <h2 className="text-xl font-bold text-center">Crazy Dice Lobby</h2>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Players</h3>
+        <div className="flex gap-2">
+          {[1, 2, 3, 4].map((n) => (
+            <button
+              key={n}
+              onClick={() => setPlayers(n)}
+              className={`lobby-tile ${players === n ? 'lobby-selected' : ''}`}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Rolls</h3>
+        <div className="flex gap-2">
+          {[1, 2, 3, 4, 5].map((n) => (
+            <button
+              key={n}
+              onClick={() => setRolls(n)}
+              className={`lobby-tile ${rolls === n ? 'lobby-selected' : ''}`}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Select Stake</h3>
+        <RoomSelector selected={stake} onSelect={setStake} />
+      </div>
+      <button
+        onClick={startGame}
+        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
+      >
+        Start Game
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Crazy Dice Duel and its lobby
- show new game card on games page
- wire routes for Crazy Dice Duel
- style board for the new game

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686f99973ea48329a6aaa06d7d4662f5