### PR TITLE
Adjust spin probabilities and cooldowns

### DIFF
--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -32,9 +32,11 @@ export default function LuckyNumber() {
   const [canRoll, setCanRoll] = useState(false);
   const [rolling, setRolling] = useState(false);
 
+  const COOLDOWN = 4 * 60 * 60 * 1000; // 4 hours
+
   useEffect(() => {
-    const last = localStorage.getItem('luckyRollDate');
-    setCanRoll(last !== todayKey());
+    const last = parseInt(localStorage.getItem('luckyRollTs') || '0', 10);
+    setCanRoll(Date.now() - last >= COOLDOWN);
   }, []);
 
   useEffect(() => {
@@ -75,7 +77,7 @@ export default function LuckyNumber() {
       localStorage.setItem('bonusX3', 'true');
     }
     setReward(prize);
-    localStorage.setItem('luckyRollDate', todayKey());
+    localStorage.setItem('luckyRollTs', String(Date.now()));
     setCanRoll(false);
   };
 
@@ -143,7 +145,7 @@ export default function LuckyNumber() {
           clickable={canRoll}
         />
         {!canRoll && (
-          <p className="text-sm text-subtext">Come back tomorrow to roll again.</p>
+          <p className="text-sm text-subtext">You can roll again every 4 hours.</p>
         )}
       </div>
       <RewardPopup

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -243,7 +243,7 @@ export default function SpinGame() {
             Next spin in {formatTime(timeLeft)}
           </p>
           <p className="text-sm text-white">
-            Watch an ad every 15 minutes to get a free spin.
+            Watch an ad every hour to get a free spin.
           </p>
         </>
       )}

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -213,7 +213,7 @@ export default function SpinPage() {
             <p className="text-sm text-text font-semibold">
               Next spin in {formatTime(timeLeft)}
             </p>
-            <p className="text-sm text-text">Watch an ad every 15 minutes to get a free spin.</p>
+            <p className="text-sm text-text">Watch an ad every hour to get a free spin.</p>
           </>
         )}
       </div>

--- a/webapp/src/utils/rewardLogic.ts
+++ b/webapp/src/utils/rewardLogic.ts
@@ -11,6 +11,7 @@ export const segments: Segment[] = [
   1600,
   'FREE_SPIN',
   'BONUS_X3',
+  'BONUS_X3',
 ];
 
 export const numericSegments: Segment[] = [
@@ -22,7 +23,7 @@ export const numericSegments: Segment[] = [
   1400,
   1600,
 ];
-const COOLDOWN = 15 * 60_000; // 15 minutes
+const COOLDOWN = 60 * 60_000; // 1 hour
 
 export function canSpin(lastSpin: number | null): boolean {
   if (!lastSpin) return true;


### PR DESCRIPTION
## Summary
- tune spin wheel rewards and reduce free spin frequency
- extend spin cooldown to one hour
- allow Lucky Number rolls every 4 hours
- update text to reflect new cooldowns

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_686f9cbbc6848329b031886f978a5b02