### PR TITLE
Add bonus mode animation for spin game

### DIFF
--- a/webapp/src/components/BonusAnimation.tsx
+++ b/webapp/src/components/BonusAnimation.tsx
@@ -1,0 +1,25 @@
+import { motion, AnimatePresence } from 'framer-motion';
+interface BonusAnimationProps {
+  show: boolean;
+  onComplete?: () => void;
+}
+
+export default function BonusAnimation({ show, onComplete }: BonusAnimationProps) {
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          className="fixed inset-0 flex items-center justify-center pointer-events-none z-50"
+          initial={{ opacity: 1, scale: 1 }}
+          animate={{ scale: [1, 3, 1], opacity: [1, 1, 0] }}
+          transition={{ duration: 2 }}
+          onAnimationComplete={onComplete}
+        >
+          <span className="text-red-600 text-5xl font-extrabold drop-shadow-[0_0_4px_black]">
+            BONUS X3
+          </span>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/webapp/src/pages/spin.tsx
+++ b/webapp/src/pages/spin.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import SpinWheel, { SpinWheelHandle } from '../components/SpinWheel.tsx';
+import BonusAnimation from '../components/BonusAnimation.tsx';
 import type { Segment } from '../utils/rewardLogic';
 import RewardPopup from '../components/RewardPopup.tsx';
 import AdModal from '../components/AdModal.tsx';
@@ -34,12 +35,21 @@ export default function SpinPage() {
   const [rightReward, setRightReward] = useState<number | null>(null);
   const [spinningLeft, setSpinningLeft] = useState(false);
   const [spinningRight, setSpinningRight] = useState(false);
+  const [showBonusAnim, setShowBonusAnim] = useState(false);
+  const [bonusVisible, setBonusVisible] = useState(false);
 
   const mainRef = useRef<SpinWheelHandle>(null);
   const leftRef = useRef<SpinWheelHandle>(null);
   const rightRef = useRef<SpinWheelHandle>(null);
 
   const globalSpinning = spinningMain || spinningLeft || spinningRight;
+
+  useEffect(() => {
+    if (bonusMode) {
+      leftRef.current?.spin();
+      rightRef.current?.spin();
+    }
+  }, [bonusMode]);
 
   useEffect(() => {
     if (
@@ -53,6 +63,7 @@ export default function SpinPage() {
       setLeftReward(null);
       setRightReward(null);
       setBonusMode(false);
+      setBonusVisible(false);
     }
   }, [bonusMode, leftReward, rightReward, spinningLeft, spinningRight]);
 
@@ -92,10 +103,10 @@ export default function SpinPage() {
     const handleFinish = async (r: Segment) => {
       if (r === 'BONUS_X3') {
         setBonusMode(true);
+        setBonusVisible(false);
+        setShowBonusAnim(true);
         setLeftReward(null);
         setRightReward(null);
-        leftRef.current?.spin();
-        rightRef.current?.spin();
         return;
       }
 
@@ -168,15 +179,17 @@ export default function SpinPage() {
       <div className="bg-surface border border-border rounded p-4 flex flex-col items-center space-y-2 wide-card">
         <div className="flex justify-center">
           {bonusMode && (
-            <SpinWheel
-              ref={leftRef}
-              onFinish={handleLeftFinish}
-              spinning={spinningLeft}
-              setSpinning={setSpinningLeft}
-              disabled={!ready}
-              showButton={false}
-              segments={numericSegments}
-            />
+            <div className={bonusVisible ? '' : 'invisible'}>
+              <SpinWheel
+                ref={leftRef}
+                onFinish={handleLeftFinish}
+                spinning={spinningLeft}
+                setSpinning={setSpinningLeft}
+                disabled={!ready}
+                showButton={false}
+                segments={numericSegments}
+              />
+            </div>
           )}
           <SpinWheel
             ref={mainRef}
@@ -188,15 +201,17 @@ export default function SpinPage() {
             segments={bonusMode ? numericSegments : undefined}
           />
           {bonusMode && (
-            <SpinWheel
-              ref={rightRef}
-              onFinish={handleRightFinish}
-              spinning={spinningRight}
-              setSpinning={setSpinningRight}
-              disabled={!ready}
-              showButton={false}
-              segments={numericSegments}
-            />
+            <div className={bonusVisible ? '' : 'invisible'}>
+              <SpinWheel
+                ref={rightRef}
+                onFinish={handleRightFinish}
+                spinning={spinningRight}
+                setSpinning={setSpinningRight}
+                disabled={!ready}
+                showButton={false}
+                segments={numericSegments}
+              />
+            </div>
           )}
         </div>
         <div className="flex space-x-2 mt-4">
@@ -222,6 +237,13 @@ export default function SpinPage() {
         onClose={() => setReward(null)}
         duration={1500}
         showCloseButton={false}
+      />
+      <BonusAnimation
+        show={showBonusAnim}
+        onComplete={() => {
+          setBonusVisible(true);
+          setShowBonusAnim(false);
+        }}
       />
       <AdModal
         open={showAd}


### PR DESCRIPTION
## Summary
- add `BonusAnimation` component using framer-motion
- show animation while loading bonus wheels in `SpinPage`
- hide bonus wheels until animation ends

## Testing
- `npm --prefix webapp run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fa70ae93c8329996f81305781b4f0