### PR TITLE
Adjust crazy dice layout and online lobby

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -173,7 +173,7 @@ export default function CrazyDiceDuel() {
           color={players[0].color}
         />
       </div>
-      <div className="absolute top-16 left-1/2 -translate-x-1/2 flex space-x-4 z-10">
+      <div className="absolute top-24 left-0 right-0 flex justify-around z-10">
         {players.slice(1).map((p, i) => (
           <AvatarTimer
             key={i + 1}

--- a/webapp/src/pages/Games/CrazyDiceLobby.jsx
+++ b/webapp/src/pages/Games/CrazyDiceLobby.jsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { pingOnline, getOnlineCount } from '../../utils/api.js';
+import { getPlayerId } from '../../utils/telegram.js';
 import RoomSelector from '../../components/RoomSelector.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 
@@ -12,6 +14,20 @@ export default function CrazyDiceLobby() {
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [vsAI, setVsAI] = useState(false);
   const [aiCount, setAiCount] = useState(1);
+  const [online, setOnline] = useState(0);
+
+  useEffect(() => {
+    const playerId = getPlayerId();
+    function ping() {
+      pingOnline(playerId).catch(() => {});
+      getOnlineCount()
+        .then((d) => setOnline(d.count))
+        .catch(() => {});
+    }
+    ping();
+    const id = setInterval(ping, 30000);
+    return () => clearInterval(id);
+  }, []);
 
   const startGame = () => {
     const params = new URLSearchParams();
@@ -30,6 +46,7 @@ export default function CrazyDiceLobby() {
   return (
     <div className="p-4 space-y-4 text-text">
       <h2 className="text-xl font-bold text-center">Crazy Dice Lobby</h2>
+      <p className="text-center text-sm">Online users: {online}</p>
       <div className="space-y-2">
         <h3 className="font-semibold">Mode</h3>
         <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- shift top avatars further down and spaced across screen
- track online user count in Crazy Dice lobby

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_686fad060f8483299069a4d5f4fcd42d