### PR TITLE
Enhance Crazy Dice UI

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -7,6 +7,7 @@ export default function AvatarTimer({
   timerPct = 1,
   rank,
   name,
+  score,
   isTurn = false,
   color,
   onClick,
@@ -34,6 +35,11 @@ export default function AvatarTimer({
       {name && (
         <span className="rank-name" style={{ color: color || '#fde047' }}>
           {name}
+        </span>
+      )}
+      {score != null && (
+        <span className="player-score" style={{ color: color || '#fde047' }}>
+          Score: {score}
         </span>
       )}
     </div>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -405,6 +405,16 @@ input:focus {
   white-space: nowrap;
 }
 
+.player-score {
+  position: absolute;
+  top: calc(100% + 1rem);
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.6rem;
+  color: inherit;
+  white-space: nowrap;
+}
+
 .turn-indicator {
   position: absolute;
   top: 50%;
@@ -1240,6 +1250,7 @@ input:focus {
   width: 100vw;
   height: 100vh;
   overflow: hidden;
+  transform: translateX(-2%);
 }
 .crazy-dice-board .board-bg {
   position: absolute;
@@ -1248,7 +1259,7 @@ input:focus {
   height: 100%;
   object-fit: contain;
   object-position: left center;
-  transform: translateX(-5%);
+  transform: translateX(-5%) scaleY(1.05);
   z-index: -1;
 }
 .crazy-dice-board .dice-center {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -67,8 +67,17 @@ export default function CrazyDiceDuel() {
     timerSoundRef.current?.pause();
     const isAI = aiCount > 0 && current > 0;
     if (isAI) {
-      const id = setTimeout(() => setTrigger((t) => t + 1), 1000);
-      return () => clearTimeout(id);
+      setTimeLeft(3);
+      const end = Date.now() + 3000;
+      timerRef.current = setInterval(() => {
+        const remaining = Math.max(0, (end - Date.now()) / 1000);
+        if (remaining <= 0) {
+          clearInterval(timerRef.current);
+          setTrigger((t) => t + 1);
+        }
+        setTimeLeft(remaining);
+      }, 100);
+      return () => clearInterval(timerRef.current);
     }
     setTimeLeft(15);
     const end = Date.now() + 15000;
@@ -170,6 +179,7 @@ export default function CrazyDiceDuel() {
           active={current === 0}
           timerPct={current === 0 ? timeLeft / 15 : 1}
           name="You"
+          score={players[0].score}
           color={players[0].color}
         />
       </div>
@@ -180,8 +190,9 @@ export default function CrazyDiceDuel() {
             index={i + 1}
             photoUrl={p.photoUrl}
             active={current === i + 1}
-            timerPct={current === i + 1 ? timeLeft / 15 : 1}
+            timerPct={current === i + 1 ? timeLeft / 3 : 1}
             name={`P${i + 2}`}
+            score={p.score}
             color={p.color}
           />
         ))}


### PR DESCRIPTION
## Summary
- show player scores under avatars
- tweak AI turn timer to 3 seconds
- shift board visuals left and slightly taller

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_686fb2445678832983877aeafe770571