### PR TITLE
Add spectator mode on leaderboard

### DIFF
--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -413,5 +413,9 @@ export function sendBroadcast(data) {
   return post('/api/broadcast/send', data, API_AUTH_TOKEN || undefined);
 }
 
+export function getWatchCount(tableId) {
+  return fetch(API_BASE_URL + "/api/watchers/count/" + tableId).then(r => r.json());
+}
+
 export function getAppStats() {
   return fetch(API_BASE_URL + '/api/stats').then((r) => r.json());}


### PR DESCRIPTION
## Summary
- add watch count tracking on the server
- expose `/api/watchers/count` endpoint
- support `watchRoom` and `leaveWatch` socket events
- display Watch button on leaderboard with viewer count
- allow loading game in spectator mode

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_686fb522383c8329bcd7bd6ade6af03f