### PR TITLE
Update leaderboard playing status

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -576,6 +576,10 @@ io.on('connection', (socket) => {
     }
     if (playerId) {
       onlineUsers.set(String(playerId), Date.now());
+      // Track the user's current table when they actually join a room
+      User.updateOne({ accountId: playerId }, { currentTableId: roomId }).catch(
+        () => {}
+      );
     }
     const result = await gameManager.joinRoom(roomId, playerId, name, socket);
     if (result.error) socket.emit('error', result.error);
@@ -794,6 +798,8 @@ io.on('connection', (socket) => {
         if (set.size === 0) userSockets.delete(String(pid));
       }
       onlineUsers.delete(String(pid));
+      // Clear the table tracking when the user disconnects
+      User.updateOne({ accountId: pid }, { currentTableId: null }).catch(() => {})
     }
     for (const [id, set] of tableWatchers) {
       if (set.delete(socket.id)) {


### PR DESCRIPTION
## Summary
- update player `currentTableId` when joining rooms
- clear `currentTableId` on disconnect

## Testing
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686fbabc6dbc8329b544d9937b096f77