### PR TITLE
Remove Crazy Dice board frame

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -76,10 +76,6 @@ input:focus {
   transform-style: preserve-3d;
 }
 
-.board-frame {
-  @apply border-4 border-accent rounded-lg p-1 bg-surface;
-  transform-style: preserve-3d;
-}
 
 /* Tilted view specifically for the Snake & Ladder board */
 .snake-board-tilt {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -172,7 +172,6 @@ export default function CrazyDiceDuel() {
         alt="board"
         className="board-bg"
       />
-      <div className="board-frame absolute inset-0 pointer-events-none" />
       <div className="dice-center">
         {winner == null ? (
           <DiceRoller onRollEnd={onRollEnd} trigger={trigger} />


### PR DESCRIPTION
## Summary
- remove the decorative board frame from the Crazy Dice Duel page
- delete unused `.board-frame` styles

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND for dotenv & mongoose)*

------
https://chatgpt.com/codex/tasks/task_e_686fbd05ca0c8329a7736ec46e700075