### PR TITLE
Add dice screen animation

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -36,7 +36,8 @@ const diceFaces = {
 };
 
 // Gentle tilt so three faces are visible
-const baseTilt = "rotateX(-25deg) rotateY(25deg)";
+// Increased angle for a clearer view of the top face
+const baseTilt = "rotateX(-40deg) rotateY(40deg)";
 
 // Orientation for each numbered face relative to the viewer
 

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -96,7 +96,7 @@ export default function DiceRoller({
   return (
     <div className="flex flex-col items-center space-y-4">
       <div
-        className={`flex space-x-4 ${clickable ? 'cursor-pointer' : ''}`}
+        className={`flex space-x-4 ${clickable ? 'cursor-pointer' : ''} ${rolling ? 'dice-screen-animation' : ''}`}
         onClick={clickable ? rollDice : undefined}
       >
         <Dice values={values} rolling={rolling} startValues={startValuesRef.current} />

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1295,3 +1295,34 @@ input:focus {
   top: 28%;
   right: 6%;
 }
+
+/* Rolling dice animation */
+.dice-screen-animation {
+  position: fixed;
+  bottom: 3rem;
+  left: 3rem;
+  animation: dice-bounce 2.5s ease-in-out forwards;
+  pointer-events: none;
+  z-index: 100;
+}
+
+@keyframes dice-bounce {
+  0% {
+    transform: translate(0, 0) scale(0.4) rotate(0deg);
+  }
+  20% {
+    transform: translate(30vw, -20vh) scale(1) rotate(360deg);
+  }
+  40% {
+    transform: translate(-25vw, -50vh) scale(1) rotate(720deg);
+  }
+  60% {
+    transform: translate(25vw, 10vh) scale(1) rotate(1080deg);
+  }
+  80% {
+    transform: translate(-20vw, 20vh) scale(1) rotate(1440deg);
+  }
+  100% {
+    transform: translate(50vw, 40vh) scale(0.4) rotate(1800deg);
+  }
+}


### PR DESCRIPTION
## Summary
- tweak dice tilt for better visibility
- animate dice across the screen while rolling

## Testing
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_686fbeadb0808329a22b3cc9defb53bb