### PR TITLE
Add dice animation from player avatar

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -13,6 +13,8 @@ export default function DiceRoller({
   showButton = true,
   muted = false,
   emitRollEvent = false,
+  className = '',
+  style = {},
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -94,7 +96,7 @@ export default function DiceRoller({
   };
 
   return (
-    <div className="flex flex-col items-center space-y-4">
+    <div className={`flex flex-col items-center space-y-4 ${className}`} style={style}>
       <div
         className={`flex space-x-4 ${clickable ? 'cursor-pointer' : ''} ${rolling ? 'dice-screen-animation' : ''}`}
         onClick={clickable ? rollDice : undefined}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1302,6 +1302,13 @@ input:focus {
   z-index: 100;
 }
 
+.dice-travel {
+  position: fixed;
+  pointer-events: none;
+  transform: translate(-50%, -50%) scale(1);
+  z-index: 50;
+}
+
 @keyframes dice-bounce {
   0% {
     transform: translate(0, 0) scale(0.4) rotate(0deg);


### PR DESCRIPTION
## Summary
- allow DiceRoller to accept `className` and `style`
- add dice animation starting from the active player's avatar
- show "Your turn" text as a clickable link to trigger rolling
- style dice-travel container

## Testing
- `npm test` *(fails: Cannot find package 'dotenv', other module errors)*

------
https://chatgpt.com/codex/tasks/task_e_686fc3291c28832993bfd7b1a806982e