### PR TITLE
Fix crazy dice duel background

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1253,9 +1253,9 @@ input:focus {
   inset: 0;
   width: 100%;
   height: 100%;
-  object-fit: contain;
-  object-position: left center;
-  transform: translateX(-5%) scaleY(1.05);
+  object-fit: cover;
+  object-position: center;
+  transform: scale(1.1);
   z-index: -1;
 }
 .crazy-dice-board .dice-center {


### PR DESCRIPTION
## Summary
- scale Crazy Dice Duel board background larger and center it

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_686fd8d972988329a190bf614f60b2b2