### PR TITLE
Improve spectator experience

### DIFF
--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -189,7 +189,7 @@ export default function LeaderboardCard() {
                   }}
                 >
                   <td className="p-2">{idx + 1}</td>
-                  <td className="p-2 w-16 relative">
+                  <td className="p-2 w-16">
                     <img
                       src={getAvatarUrl(
                         u.accountId === accountId
@@ -199,26 +199,6 @@ export default function LeaderboardCard() {
                       alt="avatar"
                       className="w-16 h-16 hexagon border-2 border-brand-gold object-cover shadow-[0_0_12px_rgba(241,196,15,0.8)]"
                     />
-                    {u.accountId !== accountId &&
-                      u.currentTableId && (
-                        <div className="absolute bottom-0 right-0 flex items-center space-x-1">
-                          <span className="text-xs text-red-500 bg-surface px-1 rounded">Playing</span>
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              const game = u.currentTableId.startsWith('ludo')
-                                ? 'ludo'
-                                : 'snake';
-                              window.location.href = `/games/${game}?table=${u.currentTableId}&watch=1`;
-                            }}
-                            className="text-xs text-blue-500 flex items-center space-x-1"
-                          >
-                            <FaTv />
-                            <span>Watch</span>
-                            <span className="ml-0.5 text-green-500">{watchCounts[u.currentTableId] || 0}</span>
-                          </button>
-                        </div>
-                      )}
                   </td>
                   <td className="p-2 flex items-center">
                     {mode === 'group' && u.accountId !== accountId && (
@@ -235,23 +215,51 @@ export default function LeaderboardCard() {
                       <FaCircle className="ml-1 text-green-500" size={8} />
                     )}
                   </td>
-                  <td className="p-2 text-right">{u.balance}</td>
+                  <td className="p-2 text-right flex items-center justify-end space-x-2">
+                    <span>{u.balance}</span>
+                    {u.accountId !== accountId && u.currentTableId && (
+                      <div className="flex items-center space-x-1">
+                        <span className="text-xs text-red-500 bg-surface px-1 rounded">Playing</span>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            const game = u.currentTableId.startsWith('ludo') ? 'ludo' : 'snake';
+                            window.location.href = `/games/${game}?table=${u.currentTableId}&watch=1`;
+                          }}
+                          className="text-xs text-blue-500 flex items-center space-x-1"
+                        >
+                          <FaTv />
+                          <span>Watch</span>
+                          <span className="ml-0.5 text-green-500">{watchCounts[u.currentTableId] || 0}</span>
+                        </button>
+                      </div>
+                    )}
+                  </td>
                 </tr>
               ))}
-              {rank && rank > 100 && (
+                {rank && rank > 100 && (
                 <tr className="bg-accent text-black h-16">
                   <td className="p-2">{rank}</td>
-                  <td className="p-2 w-16 relative">
+                  <td className="p-2 w-16">
                     <img
                       src={getAvatarUrl(myPhotoUrl || '/assets/icons/profile.svg')}
                       alt="avatar"
                       className="w-16 h-16 hexagon border-2 border-brand-gold object-cover shadow-[0_0_12px_rgba(241,196,15,0.8)]"
                     />
+                  </td>
+                  <td className="p-2 flex items-center">
+                    You
+                    {onlineUsers.includes(String(accountId)) && (
+                      <FaCircle className="ml-1 text-green-500" size={8} />
+                    )}
+                  </td>
+                  <td className="p-2 text-right flex items-center justify-end space-x-2">
+                    <span>{leaderboard.find((u) => u.accountId === accountId)?.balance ?? '...'}</span>
                     {(() => {
                       const myTable = leaderboard.find((u) => u.accountId === accountId)?.currentTableId;
                       if (!aiPlaying && !myTable) return null;
                       return (
-                        <div className="absolute bottom-0 right-0 flex items-center space-x-1">
+                        <div className="flex items-center space-x-1">
                           <span className="text-xs text-red-500 bg-surface px-1 rounded">Playing</span>
                           {myTable && (
                             <button
@@ -270,15 +278,6 @@ export default function LeaderboardCard() {
                         </div>
                       );
                     })()}
-                  </td>
-                  <td className="p-2 flex items-center">
-                    You
-                    {onlineUsers.includes(String(accountId)) && (
-                      <FaCircle className="ml-1 text-green-500" size={8} />
-                    )}
-                  </td>
-                  <td className="p-2 text-right">
-                    {leaderboard.find((u) => u.accountId === accountId)?.balance ?? '...'}
                   </td>
                 </tr>
               )}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -512,8 +512,14 @@ function Board({
 
 export default function SnakeAndLadder() {
   const [showLobbyConfirm, setShowLobbyConfirm] = useState(false);
-  const [showQuitInfo, setShowQuitInfo] = useState(true);
-  const handleBack = useCallback(() => setShowLobbyConfirm(true), []);
+  const [showQuitInfo, setShowQuitInfo] = useState(false);
+  const handleBack = useCallback(() => {
+    if (spectator) {
+      navigate('/games/snake/lobby');
+    } else {
+      setShowLobbyConfirm(true);
+    }
+  }, [spectator, navigate]);
   useTelegramBackButton(handleBack);
   const navigate = useNavigate();
 
@@ -524,12 +530,16 @@ export default function SnakeAndLadder() {
   useEffect(() => {
     const handlePop = (e) => {
       e.preventDefault();
-      setShowLobbyConfirm(true);
-      window.history.pushState(null, '');
+      if (spectator) {
+        navigate('/games/snake/lobby');
+      } else {
+        setShowLobbyConfirm(true);
+        window.history.pushState(null, '');
+      }
     };
     window.addEventListener('popstate', handlePop);
     return () => window.removeEventListener('popstate', handlePop);
-  }, []);
+  }, [spectator, navigate]);
 
   useEffect(() => {
     const handler = () => setMuted(isGameMuted());
@@ -900,6 +910,7 @@ export default function SnakeAndLadder() {
     setAi(aiCount);
     setIsMultiplayer(tableParam && !aiParam);
     setSpectator(!!watchParam);
+    setShowQuitInfo(!watchParam);
     localStorage.removeItem(`snakeGameState_${aiCount}`);
     setAiPositions(Array(aiCount).fill(0));
     setAiAvatars(
@@ -2144,7 +2155,7 @@ export default function SnakeAndLadder() {
         </div>
       )}
       <InfoPopup
-        open={showQuitInfo}
+        open={!spectator && showQuitInfo}
         onClose={() => setShowQuitInfo(false)}
         title="Warning"
         info="If you quit the game your funds will be lost and you will be placed last."
@@ -2224,7 +2235,7 @@ export default function SnakeAndLadder() {
         }}
       />
       <ConfirmPopup
-        open={showLobbyConfirm}
+        open={!spectator && showLobbyConfirm}
         message="Quit the game? If you leave, your funds will be lost and you'll be placed last."
         onConfirm={() => {
           localStorage.removeItem(`snakeGameState_${ai}`);


### PR DESCRIPTION
## Summary
- avoid warning popups when watching games
- center watch button and status next to balance on the leaderboard

## Testing
- `npm test` *(fails: test suite has failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686fd9eddd7083298cd1d831d44e8b39