### PR TITLE
Update Crazy Dice duel timing and board

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -49,7 +49,7 @@ export default function DiceRoller({
   useEffect(() => {
     if (trigger !== undefined && trigger !== triggerRef.current) {
       triggerRef.current = trigger;
-      setTimeout(() => rollDice(), 1000); // show dice briefly before rolling
+      setTimeout(() => rollDice(), 0); // roll immediately on trigger
     }
   }, [trigger]);
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1256,6 +1256,7 @@ input:focus {
   object-fit: cover;
   object-position: center;
   transform: scale(1.1);
+  filter: brightness(1.2);
   z-index: -1;
 }
 .crazy-dice-board .dice-center {
@@ -1290,6 +1291,35 @@ input:focus {
   position: absolute;
   top: 28%;
   right: 6%;
+}
+
+/* Markers for easier mapping */
+.crazy-dice-board .side-number {
+  position: absolute;
+  font-size: 0.75rem;
+  color: #fff;
+  opacity: 0.7;
+  pointer-events: none;
+}
+.crazy-dice-board .side-number.top {
+  top: 0.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+}
+.crazy-dice-board .side-number.bottom {
+  bottom: 0.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+}
+.crazy-dice-board .side-number.left {
+  left: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.crazy-dice-board .side-number.right {
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 /* Rolling dice animation */

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -76,8 +76,8 @@ export default function CrazyDiceDuel() {
     timerSoundRef.current?.pause();
     const isAI = aiCount > 0 && current > 0;
     if (isAI) {
-      setTimeLeft(3);
-      const end = Date.now() + 3000;
+      setTimeLeft(3.5);
+      const end = Date.now() + 3500;
       timerRef.current = setInterval(() => {
         const remaining = Math.max(0, (end - Date.now()) / 1000);
         if (remaining <= 0) {
@@ -172,6 +172,10 @@ export default function CrazyDiceDuel() {
         alt="board"
         className="board-bg"
       />
+      <div className="side-number top">1</div>
+      <div className="side-number bottom">2</div>
+      <div className="side-number left">3</div>
+      <div className="side-number right">4</div>
       <div className="dice-center">
         {winner == null ? (
           <DiceRoller onRollEnd={onRollEnd} trigger={trigger} />
@@ -200,7 +204,7 @@ export default function CrazyDiceDuel() {
               index={i + 1}
               photoUrl={p.photoUrl}
               active={current === i + 1}
-              timerPct={current === i + 1 ? timeLeft / 3 : 1}
+              timerPct={current === i + 1 ? timeLeft / 3.5 : 1}
               name={`P${i + 2}`}
               score={p.score}
               color={p.color}


### PR DESCRIPTION
## Summary
- brighten Crazy Dice board background
- auto-roll AI dice after 3.5s and show shorter timer
- add small number markers around the board
- trigger dice rolls immediately when timer ends

## Testing
- `npm test` *(fails: tests run but truncated output)*

------
https://chatgpt.com/codex/tasks/task_e_686fe2d335c48329a1e8e52f8146c8bd