### PR TITLE
Restore dice functionality

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -13,8 +13,6 @@ export default function DiceRoller({
   showButton = true,
   muted = false,
   emitRollEvent = false,
-  className = '',
-  style = {},
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -96,7 +94,7 @@ export default function DiceRoller({
   };
 
   return (
-    <div className={`flex flex-col items-center space-y-4 ${className}`} style={style}>
+    <div className="flex flex-col items-center space-y-4">
       <div
         className={`flex space-x-4 ${clickable ? 'cursor-pointer' : ''}`}
         onClick={clickable ? rollDice : undefined}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -76,6 +76,10 @@ input:focus {
   transform-style: preserve-3d;
 }
 
+.board-frame {
+  @apply border-4 border-accent rounded-lg p-1 bg-surface;
+  transform-style: preserve-3d;
+}
 
 /* Tilted view specifically for the Snake & Ladder board */
 .snake-board-tilt {
@@ -1253,9 +1257,9 @@ input:focus {
   inset: 0;
   width: 100%;
   height: 100%;
-  object-fit: cover;
-  object-position: center;
-  transform: scale(1.1);
+  object-fit: contain;
+  object-position: left center;
+  transform: translateX(-5%) scaleY(1.05);
   z-index: -1;
 }
 .crazy-dice-board .dice-center {
@@ -1263,69 +1267,4 @@ input:focus {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-}
-
-/* Player positions around the Crazy Dice board */
-.crazy-dice-board .player-bottom {
-  position: absolute;
-  bottom: 20%;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-.crazy-dice-board .player-left {
-  position: absolute;
-  top: 26%;
-  left: 6%;
-}
-
-.crazy-dice-board .player-center {
-  position: absolute;
-  top: 22%;
-  left: 46%;
-  transform: translateX(-50%);
-}
-
-.crazy-dice-board .player-right {
-  position: absolute;
-  top: 28%;
-  right: 6%;
-}
-
-/* Rolling dice animation */
-.dice-screen-animation {
-  position: fixed;
-  bottom: 3rem;
-  left: 3rem;
-  animation: dice-bounce 2.5s ease-in-out forwards;
-  pointer-events: none;
-  z-index: 100;
-}
-
-.dice-travel {
-  position: fixed;
-  pointer-events: none;
-  transform: translate(-50%, -50%) scale(1);
-  z-index: 50;
-}
-
-@keyframes dice-bounce {
-  0% {
-    transform: translate(0, 0) scale(0.4) rotate(0deg);
-  }
-  20% {
-    transform: translate(30vw, -20vh) scale(1) rotate(360deg);
-  }
-  40% {
-    transform: translate(-25vw, -50vh) scale(1) rotate(720deg);
-  }
-  60% {
-    transform: translate(25vw, 10vh) scale(1) rotate(1080deg);
-  }
-  80% {
-    transform: translate(-20vw, 20vh) scale(1) rotate(1440deg);
-  }
-  100% {
-    transform: translate(50vw, 40vh) scale(0.4) rotate(1800deg);
-  }
 }


### PR DESCRIPTION
## Summary
- revert DiceRoller to simpler version
- remove unused dice animation styles

## Testing
- `npm test` *(fails: Operation `gameresults.insertOne()` buffering timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686fe1b505848329b1e314908e0297e2