### PR TITLE
Update crazy dice player layout

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -16,14 +16,14 @@ export default function AvatarTimer({
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
   return (
-    <div className="relative w-9 h-9" onClick={onClick} data-player-index={index}>
+    <div className="relative w-12 h-12" onClick={onClick} data-player-index={index}>
       {active && (
         <div className="avatar-timer-ring" style={{ '--timer-gradient': gradient }} />
       )}
       <img
         src={getAvatarUrl(photoUrl)}
         alt="player"
-        className="w-9 h-9 rounded-full border-2 object-cover"
+        className="w-12 h-12 rounded-full border-2 object-cover"
         style={{
           borderColor: color || '#fde047',
           boxShadow: isTurn ? `0 0 6px ${color || '#fde047'}` : undefined,

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -406,7 +406,8 @@ input:focus {
   top: calc(100% + 1rem);
   left: 50%;
   transform: translateX(-50%);
-  font-size: 0.6rem;
+  font-size: 0.8rem;
+  font-weight: bold;
   color: inherit;
   white-space: nowrap;
 }
@@ -1276,20 +1277,20 @@ input:focus {
 
 .crazy-dice-board .player-left {
   position: absolute;
-  top: 26%;
+  top: 15%;
   left: 6%;
 }
 
 .crazy-dice-board .player-center {
   position: absolute;
-  top: 22%;
-  left: 46%;
+  top: 8%;
+  left: 50%;
   transform: translateX(-50%);
 }
 
 .crazy-dice-board .player-right {
   position: absolute;
-  top: 28%;
+  top: 15%;
   right: 6%;
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2054,7 +2054,7 @@ export default function SnakeAndLadder() {
       )}
       {rollResult !== null && (
         <div className="fixed inset-0 flex items-center justify-center z-30 pointer-events-none">
-          <div className="text-7xl roll-result" style={{ color: rollColor }}>
+          <div className="text-8xl font-extrabold roll-result" style={{ color: rollColor }}>
             {rollResult}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- realign player positions on Crazy Dice Duel board
- enlarge avatar size
- bump roll result display size
- highlight player scores

## Testing
- `npm test` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686ff00eec24832984618bf53ef15d7a