### PR TITLE
Fix dice scaling and display turn prompt

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -645,10 +645,14 @@ input:focus {
 }
 
 .board-cell.snake-highlight .cell-marker,
-.board-cell.ladder-highlight .cell-marker,
-.board-cell.dice-cell.normal-highlight .dice-marker {
+.board-cell.ladder-highlight .cell-marker {
   transform: translate(-50%, -50%) translateZ(6px)
     rotateX(calc(var(--board-angle, 58deg) * -1)) scale(3);
+}
+
+.board-cell.dice-cell.normal-highlight .dice-marker {
+  transform: translate(-50%, -50%) translateZ(6px)
+    rotateX(calc(var(--board-angle, 58deg) * -1));
 }
 
 .board-cell.snake-highlight .cell-icon,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2124,7 +2124,11 @@ export default function SnakeAndLadder() {
         </div>
       )}
       {diceVisible && !isMultiplayer && (
-        <div ref={diceRef} style={diceStyle} className="dice-travel">
+        <div
+          ref={diceRef}
+          style={diceStyle}
+          className="dice-travel flex flex-col items-center"
+        >
           <DiceRoller
             className="scale-90"
             onRollEnd={(vals) => {
@@ -2162,19 +2166,19 @@ export default function SnakeAndLadder() {
             showButton={false}
             muted={muted}
           />
-        </div>
-      )}
-      {currentTurn === 0 && !aiRollingIndex && !playerAutoRolling && !moving && (
-        <div className="mt-2 flex flex-col items-center">
-          <a href="#" onClick={handlePlayerTurnClick} className="text-5xl">🫵</a>
-          <a
-            href="#"
-            onClick={handlePlayerTurnClick}
-            className="turn-message text-2xl mt-1"
-            style={{ color: players[currentTurn]?.color }}
-          >
-            🫵 your turn to roll the dices
-          </a>
+          {currentTurn === 0 && !aiRollingIndex && !playerAutoRolling && !moving && (
+            <div className="mt-2 flex flex-col items-center">
+              <a href="#" onClick={handlePlayerTurnClick} className="text-5xl">🫵</a>
+              <a
+                href="#"
+                onClick={handlePlayerTurnClick}
+                className="turn-message text-2xl mt-1"
+                style={{ color: players[currentTurn]?.color }}
+              >
+                🫵 your turn to roll the dices
+              </a>
+            </div>
+          )}
         </div>
       )}
       {isMultiplayer && (
@@ -2183,23 +2187,40 @@ export default function SnakeAndLadder() {
           style={{ transform: 'translateX(2rem)' }}
         >
           <div className="scale-90">
+            {(() => {
+              const myId = getPlayerId();
+              const myIndex = mpPlayers.findIndex(p => p.id === myId);
+              if (currentTurn === myIndex && !moving) {
+                return (
+                  <DiceRoller
+                    clickable
+                    showButton={false}
+                    muted={muted}
+                    emitRollEvent
+                    numDice={2}
+                  />
+                );
+              }
+              return null;
+            })()}
+          </div>
           {(() => {
             const myId = getPlayerId();
             const myIndex = mpPlayers.findIndex(p => p.id === myId);
             if (currentTurn === myIndex && !moving) {
               return (
-                <DiceRoller
-                  clickable
-                  showButton={false}
-                  muted={muted}
-                  emitRollEvent
-                  numDice={2}
-                />
+                <a
+                  href="#"
+                  onClick={handlePlayerTurnClick}
+                  className="turn-message text-2xl mt-1"
+                  style={{ color: players[currentTurn]?.color }}
+                >
+                  🫵 your turn to roll the dices
+                </a>
               );
             }
             return null;
           })()}
-          </div>
         </div>
       )}
       <InfoPopup


### PR DESCRIPTION
## Summary
- avoid 3x scaling on dice icons when highlighted
- move "your turn" prompt into dice area so it's directly below the roller

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686ff3a980f88329866b862d9586c978