### PR TITLE
Fix player layout in Crazy Dice Duel

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1277,20 +1277,20 @@ input:focus {
 
 .crazy-dice-board .player-left {
   position: absolute;
-  top: 15%;
+  top: 3%;
   left: 6%;
 }
 
 .crazy-dice-board .player-center {
   position: absolute;
-  top: 8%;
+  top: 3%;
   left: 50%;
   transform: translateX(-50%);
 }
 
 .crazy-dice-board .player-right {
   position: absolute;
-  top: 15%;
+  top: 3%;
   right: 6%;
 }
 


### PR DESCRIPTION
## Summary
- tweak player positions around the Crazy Dice board to align at the top

## Testing
- `npm run test` *(fails: BOT_TOKEN not configured, server started then tests stop)*

------
https://chatgpt.com/codex/tasks/task_e_686ff469e39c83298ddb935adc5921de