### PR TITLE
Update Crazy Dice Duel delays and layout

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -16,14 +16,14 @@ export default function AvatarTimer({
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
   return (
-    <div className="relative w-12 h-12" onClick={onClick} data-player-index={index}>
+    <div className="relative w-14 h-14" onClick={onClick} data-player-index={index}>
       {active && (
         <div className="avatar-timer-ring" style={{ '--timer-gradient': gradient }} />
       )}
       <img
         src={getAvatarUrl(photoUrl)}
         alt="player"
-        className="w-12 h-12 rounded-full border-2 object-cover"
+        className="w-14 h-14 rounded-full border-2 object-cover"
         style={{
           borderColor: color || '#fde047',
           boxShadow: isTurn ? `0 0 6px ${color || '#fde047'}` : undefined,

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -73,7 +73,7 @@ export default function DiceRoller({
     };
 
     const tick = 50; // ms between face changes
-    const iterations = 20; // ~1 second of rolling
+    const iterations = 48; // ~2.4 seconds of rolling
     let count = 0;
 
     const id = setInterval(() => {

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1282,7 +1282,7 @@ input:focus {
 .crazy-dice-board .player-left {
   position: absolute;
   top: 3%;
-  left: 6%;
+  left: 3%;
 }
 
 .crazy-dice-board .player-center {
@@ -1295,7 +1295,7 @@ input:focus {
 .crazy-dice-board .player-right {
   position: absolute;
   top: 3%;
-  right: 6%;
+  right: 3%;
 }
 
 /* Markers for easier mapping */


### PR DESCRIPTION
## Summary
- stretch player avatars slightly larger
- extend dice rolling animation to 2.4s
- tweak left and right player positions on the Crazy Dice board

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_686ff9dedd6883298da7c483dff78b63