### PR TITLE
Adjust dice animations and UI

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -105,13 +105,13 @@ input:focus {
 
 @keyframes roll {
   0% {
-    transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg) translateY(0);
+    transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg);
   }
   50% {
-    transform: rotateX(360deg) rotateY(360deg) rotateZ(360deg) translateY(-1rem);
+    transform: rotateX(360deg) rotateY(360deg) rotateZ(360deg);
   }
   100% {
-    transform: rotateX(720deg) rotateY(720deg) rotateZ(720deg) translateY(0);
+    transform: rotateX(720deg) rotateY(720deg) rotateZ(720deg);
   }
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -648,6 +648,8 @@ export default function SnakeAndLadder() {
   const [showGift, setShowGift] = useState(false);
   const [chatBubbles, setChatBubbles] = useState([]);
 
+  const DICE_SMALL_SCALE = 0.6;
+
   function prepareDiceAnimation(startIdx) {
     if (startIdx == null) {
       setDiceStyle({
@@ -670,7 +672,7 @@ export default function SnakeAndLadder() {
       position: 'fixed',
       left: `${s.left + s.width / 2}px`,
       top: `${s.top + s.height / 2}px`,
-      transform: 'translate(-50%, -50%) scale(1)',
+      transform: `translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
       transition: 'none',
       pointerEvents: 'none',
       zIndex: 50,
@@ -692,8 +694,7 @@ export default function SnakeAndLadder() {
     dice.style.zIndex = '50';
     dice.animate(
       [
-        { transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(1)` },
-        { transform: `translate(${cx}px, ${cy}px) scale(3)`, offset: 0.5 },
+        { transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(${DICE_SMALL_SCALE})` },
         { transform: `translate(${cx}px, ${cy}px) scale(1)` },
       ],
       { duration: 600, easing: 'linear' },
@@ -720,8 +721,7 @@ export default function SnakeAndLadder() {
     dice.animate(
       [
         { transform: `translate(${cx}px, ${cy}px) scale(1)` },
-        { transform: `translate(${cx}px, ${cy}px) scale(3)`, offset: 0.5 },
-        { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(1)` },
+        { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(${DICE_SMALL_SCALE})` },
       ],
       { duration: 600, easing: 'linear' },
     ).onfinish = () => {
@@ -730,7 +730,7 @@ export default function SnakeAndLadder() {
         position: 'fixed',
         left: `${e.left + e.width / 2}px`,
         top: `${e.top + e.height / 2}px`,
-        transform: 'translate(-50%, -50%) scale(1)',
+        transform: `translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
         pointerEvents: 'none',
         zIndex: 50,
       });
@@ -2167,7 +2167,7 @@ export default function SnakeAndLadder() {
             muted={muted}
           />
           {currentTurn === 0 && !aiRollingIndex && !playerAutoRolling && !moving && (
-            <div className="mt-2 flex flex-col items-center">
+            <div className="mt-12 flex flex-col items-center">
               <a href="#" onClick={handlePlayerTurnClick} className="text-5xl">🫵</a>
               <a
                 href="#"
@@ -2212,7 +2212,7 @@ export default function SnakeAndLadder() {
                 <a
                   href="#"
                   onClick={handlePlayerTurnClick}
-                  className="turn-message text-2xl mt-1"
+                  className="turn-message text-2xl mt-12"
                   style={{ color: players[currentTurn]?.color }}
                 >
                   🫵 your turn to roll the dices


### PR DESCRIPTION
## Summary
- shrink dice roll animation so the dice don't bounce
- keep dice small near player icons and normal size at center
- space "Your turn" prompt a few lines below the dice

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_686ff8f012cc8329bffab0b263280634