### PR TITLE
Improve Crazy Dice duel UX

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -73,7 +73,7 @@ export default function DiceRoller({
     };
 
     const tick = 50; // ms between face changes
-    const iterations = 48; // ~2.4 seconds of rolling
+    const iterations = 24; // faster roll (~1.2s)
     let count = 0;
 
     const id = setInterval(() => {

--- a/webapp/src/hooks/useTelegramBackButton.js
+++ b/webapp/src/hooks/useTelegramBackButton.js
@@ -1,15 +1,22 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export default function useTelegramBackButton(onBack) {
   const navigate = useNavigate();
+  const cbRef = useRef(onBack);
+
+  // Keep the latest callback without re-registering the listener
+  useEffect(() => {
+    cbRef.current = onBack;
+  }, [onBack]);
 
   useEffect(() => {
     const tg = window?.Telegram?.WebApp;
     if (!tg) return;
 
     const handleBack = () => {
-      if (onBack) onBack();
+      const cb = cbRef.current;
+      if (cb) cb();
       else navigate(-1);
     };
 
@@ -20,5 +27,5 @@ export default function useTelegramBackButton(onBack) {
       tg.offEvent('backButtonClicked', handleBack);
       tg.BackButton.hide();
     };
-  }, [navigate, onBack]);
+  }, [navigate]);
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1282,7 +1282,7 @@ input:focus {
 .crazy-dice-board .player-left {
   position: absolute;
   top: 3%;
-  left: 3%;
+  left: 1%;
 }
 
 .crazy-dice-board .player-center {
@@ -1295,7 +1295,7 @@ input:focus {
 .crazy-dice-board .player-right {
   position: absolute;
   top: 3%;
-  right: 3%;
+  right: 1%;
 }
 
 /* Markers for easier mapping */

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import DiceRoller from '../../components/DiceRoller.jsx';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
@@ -16,7 +16,11 @@ const COLORS = ['#60a5fa', '#ef4444', '#4ade80', '#facc15'];
 
 export default function CrazyDiceDuel() {
   const navigate = useNavigate();
-  useTelegramBackButton(() => navigate('/games/crazydice/lobby', { replace: true }));
+  const handleBack = useCallback(
+    () => navigate('/games/crazydice/lobby', { replace: true }),
+    [navigate],
+  );
+  useTelegramBackButton(handleBack);
   const [searchParams] = useSearchParams();
   const aiCount = parseInt(searchParams.get('ai')) || 0;
   const playerCount = aiCount > 0
@@ -92,7 +96,9 @@ export default function CrazyDiceDuel() {
     const end = Date.now() + 15000;
     timerRef.current = setInterval(() => {
       const remaining = Math.max(0, (end - Date.now()) / 1000);
+      const isHumanTurn = aiCount === 0 || current === 0;
       if (
+        isHumanTurn &&
         remaining <= 7 &&
         Math.ceil(remaining) !== Math.ceil(timeLeft) &&
         timerSoundRef.current
@@ -121,7 +127,6 @@ export default function CrazyDiceDuel() {
       );
       return next;
     });
-    setTrigger((t) => t + 1);
   };
 
   const nextTurn = () => {
@@ -178,7 +183,12 @@ export default function CrazyDiceDuel() {
       <div className="side-number right">4</div>
       <div className="dice-center">
         {winner == null ? (
-          <DiceRoller onRollEnd={onRollEnd} trigger={trigger} />
+          <DiceRoller
+            onRollEnd={onRollEnd}
+            trigger={trigger}
+            clickable={aiCount === 0 || current === 0}
+            showButton={aiCount === 0 || current === 0}
+          />
         ) : (
           <div className="text-2xl font-bold text-center">
             Player {winner + 1} wins!


### PR DESCRIPTION
## Summary
- keep Telegram back button stable to stop flicker
- speed up dice roll animation
- adjust player avatars on the Crazy Dice board
- enforce turn based rolling in Crazy Dice Duel

## Testing
- `npm test` *(fails: cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68700291be5c8329b9d90001ca35a5fa