### PR TITLE
Adjust dice size next to avatars

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -648,7 +648,10 @@ export default function SnakeAndLadder() {
   const [showGift, setShowGift] = useState(false);
   const [chatBubbles, setChatBubbles] = useState([]);
 
-  const DICE_SMALL_SCALE = 0.6;
+  // Scale the dice when they rest beside each player's photo.
+  // Board dice icons measure about 2.2rem (~35px) so match
+  // that size against the Dice component's default 80px width.
+  const DICE_SMALL_SCALE = 0.44;
 
   function prepareDiceAnimation(startIdx) {
     if (startIdx == null) {


### PR DESCRIPTION
## Summary
- keep dice overlay consistent by scaling to match board icon size

## Testing
- `npm test` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_687004dd47b08329b7d43a86d4dba98a