### PR TITLE
Fix Crazy Dice board layout and turn indicator

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -19,6 +19,9 @@ export default function AvatarTimer({
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
   return (
     <div className="relative w-14 h-14" onClick={onClick} data-player-index={index}>
+      {isTurn && (
+        <div className="turn-indicator">🫵 your turn</div>
+      )}
       {active && (
         <div className="avatar-timer-ring" style={{ '--timer-gradient': gradient }} />
       )}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -432,11 +432,27 @@ input:focus {
   justify-content: center;
 }
 
+.crazy-dice-board .player-left .player-score,
+.crazy-dice-board .player-left .roll-history {
+  left: calc(100% + 0.5rem);
+  transform: translateX(0);
+}
+
+.crazy-dice-board .player-right .player-score,
+.crazy-dice-board .player-right .roll-history {
+  right: calc(100% + 0.5rem);
+  left: auto;
+  transform: translateX(0);
+}
+
 .turn-indicator {
   position: absolute;
-  top: 50%;
-  right: -1.2rem;
-  transform: translateY(-50%);
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, -0.25rem);
+  font-size: 0.75rem;
+  font-weight: bold;
+  white-space: nowrap;
   pointer-events: none;
 }
 
@@ -1302,7 +1318,7 @@ input:focus {
 .crazy-dice-board .player-left {
   position: absolute;
   top: 3%;
-  left: 0%;
+  left: -2%;
 }
 
 .crazy-dice-board .player-center {
@@ -1315,7 +1331,7 @@ input:focus {
 .crazy-dice-board .player-right {
   position: absolute;
   top: 3%;
-  right: 0%;
+  right: -2%;
 }
 
 /* Markers for easier mapping */

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -64,6 +64,7 @@ export default function CrazyDiceDuel() {
   const timerRef = useRef(null);
   const timerSoundRef = useRef(null);
   const diceRef = useRef(null);
+  const boardRef = useRef(null);
   const [diceStyle, setDiceStyle] = useState({ display: 'none' });
   const DICE_SMALL_SCALE = 0.44;
 
@@ -145,11 +146,17 @@ export default function CrazyDiceDuel() {
 
   const prepareDiceAnimation = (startIdx) => {
     if (startIdx == null) {
+      const board = boardRef.current;
+      const rect = board
+        ? board.getBoundingClientRect()
+        : { left: window.innerWidth / 2, top: window.innerHeight / 2, width: 0, height: 0 };
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
       setDiceStyle({
         display: 'block',
         position: 'fixed',
-        left: '50%',
-        top: '50%',
+        left: `${cx}px`,
+        top: `${cy}px`,
         transform: 'translate(-50%, -50%) scale(1)',
         transition: 'none',
         pointerEvents: 'none',
@@ -177,8 +184,12 @@ export default function CrazyDiceDuel() {
     const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
     if (!dice || !startEl) return;
     const s = startEl.getBoundingClientRect();
-    const cx = window.innerWidth / 2;
-    const cy = window.innerHeight / 2;
+    const board = boardRef.current;
+    const rect = board
+      ? board.getBoundingClientRect()
+      : { left: window.innerWidth / 2, top: window.innerHeight / 2, width: 0, height: 0 };
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
     dice.style.display = 'block';
     dice.style.position = 'fixed';
     dice.style.left = '0px';
@@ -209,8 +220,12 @@ export default function CrazyDiceDuel() {
     const endEl = document.querySelector(`[data-player-index="${idx}"] img`);
     if (!dice || !endEl) return;
     const e = endEl.getBoundingClientRect();
-    const cx = window.innerWidth / 2;
-    const cy = window.innerHeight / 2;
+    const board = boardRef.current;
+    const rect = board
+      ? board.getBoundingClientRect()
+      : { left: window.innerWidth / 2, top: window.innerHeight / 2, width: 0, height: 0 };
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
     dice.animate(
       [
         { transform: `translate(${cx}px, ${cy}px) scale(1)` },
@@ -272,7 +287,7 @@ export default function CrazyDiceDuel() {
   };
 
   return (
-    <div className="crazy-dice-board text-text">
+    <div className="crazy-dice-board text-text" ref={boardRef}>
       <img
         src="/assets/icons/file_00000000316461fdac87111607fc8ada%20(1).png"
         alt="board"
@@ -311,6 +326,7 @@ export default function CrazyDiceDuel() {
           index={0}
           photoUrl={players[0].photoUrl}
           active={current === 0}
+          isTurn={current === 0}
           timerPct={current === 0 ? timeLeft / 15 : 1}
           name="You"
           score={players[0].score}
@@ -327,6 +343,7 @@ export default function CrazyDiceDuel() {
             index={i + 1}
             photoUrl={p.photoUrl}
             active={current === i + 1}
+            isTurn={current === i + 1}
             timerPct={current === i + 1 ? timeLeft / 3.5 : 1}
             name={`P${i + 2}`}
             score={p.score}


### PR DESCRIPTION
## Summary
- animate dice relative to board
- highlight active player with a turn indicator
- adjust player positions and scoreboard offsets

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_6870184b7bb48329a03167bd90026ced