### PR TITLE
Add Watch to Earn route

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -13,6 +13,7 @@ import Messages from './pages/Messages.jsx';
 import Trending from './pages/Trending.jsx';
 import Notifications from './pages/Notifications.jsx';
 import TokenomicsPage from './pages/Tokenomics.jsx';
+import WatchToEarn from './pages/WatchToEarn.jsx';
 
 import HorseRacing from './pages/Games/HorseRacing.jsx';
 import SnakeAndLadder from './pages/Games/SnakeAndLadder.jsx';
@@ -49,6 +50,7 @@ export default function App() {
           <Route path="/games/snake/results" element={<SnakeResults />} />
           <Route path="/spin" element={<SpinPage />} />
           <Route path="/tasks" element={<Tasks />} />
+          <Route path="/watch" element={<WatchToEarn />} />
           <Route path="/store" element={<Store />} />
           <Route path="/referral" element={<Referral />} />
           <Route path="/wallet" element={<Wallet />} />

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import {
   listTasks,
@@ -135,6 +136,7 @@ export default function Tasks() {
 
     <div className="relative p-4 space-y-2 text-text flex flex-col items-center wide-card">
       <h2 className="text-xl font-bold">Tasks</h2>
+      <Link to="/watch" className="text-primary underline text-sm">Watch to Earn</Link>
       <div className="flex justify-center space-x-2">
         {['TonPlaygram', 'Partners'].map((c) => (
           <button


### PR DESCRIPTION
## Summary
- expose WatchToEarn component via `/watch` route
- link to the new route from the Tasks page

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68702224230083298ab44a353b6f824c