### PR TITLE
Adjust Crazy Dice Duel UX

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -20,7 +20,7 @@ export default function AvatarTimer({
   return (
     <div className="relative w-14 h-14" onClick={onClick} data-player-index={index}>
       {isTurn && (
-        <div className="turn-indicator">🫵 your turn</div>
+        <div className="turn-indicator" onClick={onClick}>🫵 your turn</div>
       )}
       {active && (
         <div className="avatar-timer-ring" style={{ '--timer-gradient': gradient }} />

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -434,7 +434,7 @@ input:focus {
 
 .crazy-dice-board .player-left .player-score,
 .crazy-dice-board .player-left .roll-history {
-  left: calc(100% + 0.5rem);
+  left: calc(100% + 0.3rem);
   transform: translateX(0);
 }
 
@@ -449,11 +449,12 @@ input:focus {
   position: absolute;
   bottom: 100%;
   left: 50%;
-  transform: translate(-50%, -0.25rem);
+  transform: translate(-50%, -0.5rem);
   font-size: 0.75rem;
   font-weight: bold;
   white-space: nowrap;
-  pointer-events: none;
+  pointer-events: auto;
+  cursor: pointer;
 }
 
 .timer-count {
@@ -1326,6 +1327,10 @@ input:focus {
   top: 3%;
   left: 50%;
   transform: translateX(-50%);
+}
+.crazy-dice-board .player-center .player-score,
+.crazy-dice-board .player-center .roll-history {
+  transform: translateX(-60%);
 }
 
 .crazy-dice-board .player-right {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -146,12 +146,8 @@ export default function CrazyDiceDuel() {
 
   const prepareDiceAnimation = (startIdx) => {
     if (startIdx == null) {
-      const board = boardRef.current;
-      const rect = board
-        ? board.getBoundingClientRect()
-        : { left: window.innerWidth / 2, top: window.innerHeight / 2, width: 0, height: 0 };
-      const cx = rect.left + rect.width / 2;
-      const cy = rect.top + rect.height / 2;
+      const cx = window.innerWidth / 2;
+      const cy = window.innerHeight / 2;
       setDiceStyle({
         display: 'block',
         position: 'fixed',
@@ -184,12 +180,8 @@ export default function CrazyDiceDuel() {
     const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
     if (!dice || !startEl) return;
     const s = startEl.getBoundingClientRect();
-    const board = boardRef.current;
-    const rect = board
-      ? board.getBoundingClientRect()
-      : { left: window.innerWidth / 2, top: window.innerHeight / 2, width: 0, height: 0 };
-    const cx = rect.left + rect.width / 2;
-    const cy = rect.top + rect.height / 2;
+    const cx = window.innerWidth / 2;
+    const cy = window.innerHeight / 2;
     dice.style.display = 'block';
     dice.style.position = 'fixed';
     dice.style.left = '0px';
@@ -220,12 +212,8 @@ export default function CrazyDiceDuel() {
     const endEl = document.querySelector(`[data-player-index="${idx}"] img`);
     if (!dice || !endEl) return;
     const e = endEl.getBoundingClientRect();
-    const board = boardRef.current;
-    const rect = board
-      ? board.getBoundingClientRect()
-      : { left: window.innerWidth / 2, top: window.innerHeight / 2, width: 0, height: 0 };
-    const cx = rect.left + rect.width / 2;
-    const cy = rect.top + rect.height / 2;
+    const cx = window.innerWidth / 2;
+    const cy = window.innerHeight / 2;
     dice.animate(
       [
         { transform: `translate(${cx}px, ${cy}px) scale(1)` },
@@ -333,6 +321,9 @@ export default function CrazyDiceDuel() {
           rollHistory={players[0].results}
           maxRolls={maxRolls}
           color={players[0].color}
+          onClick={() => {
+            if (current === 0) setTrigger((t) => t + 1);
+          }}
         />
       </div>
       {players.slice(1).map((p, i) => {
@@ -350,6 +341,9 @@ export default function CrazyDiceDuel() {
             rollHistory={p.results}
             maxRolls={maxRolls}
             color={p.color}
+            onClick={() => {
+              if (current === i + 1) setTrigger((t) => t + 1);
+            }}
           />
           </div>
         );


### PR DESCRIPTION
## Summary
- ensure dice animation uses window center
- nudge player scoring layouts
- make turn indicator clickable for rolling dice
- allow avatar click to trigger roll

## Testing
- `npm test` *(fails: Failed to store game result, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68701e5ff0c8832993cfb8e35df5ce73