### PR TITLE
Add guide grid and smaller dice

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -99,7 +99,7 @@ function DiceCube({
   }, [rolling, playSound]);
 
   return (
-    <div className="dice-container perspective-1000 w-20 h-20">
+    <div className="dice-container perspective-1000 w-16 h-16">
       <div
         className={`dice-cube relative w-full h-full transition-transform duration-500 transform-style-preserve-3d ${
           rolling ? "animate-roll" : ""

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1368,6 +1368,26 @@ input:focus {
   transform: translateY(-50%);
 }
 
+/* Temporary guide grid for placement */
+.guide-grid {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  grid-template-rows: repeat(10, 1fr);
+  pointer-events: none;
+  z-index: 1;
+  font-size: 0.75rem;
+  color: #fff;
+}
+
+.guide-grid .grid-cell {
+  border: 1px dashed rgba(255, 255, 255, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* Rolling dice animation */
 .dice-screen-animation {
   position: fixed;

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -14,6 +14,23 @@ import { giftSounds } from '../../utils/giftSounds.js';
 
 const COLORS = ['#60a5fa', '#ef4444', '#4ade80', '#facc15'];
 
+function GuideGrid() {
+  const letters = 'ABCDEFGHIJ'.split('');
+  const rows = Array.from({ length: 10 }, (_, i) => i + 1);
+  return (
+    <div className="guide-grid">
+      {rows.map((r) =>
+        letters.map((l) => (
+          <div key={`${l}${r}`} className="grid-cell">
+            {l}
+            {r}
+          </div>
+        )),
+      )}
+    </div>
+  );
+}
+
 export default function CrazyDiceDuel() {
   const navigate = useNavigate();
   const handleBack = useCallback(
@@ -229,6 +246,7 @@ export default function CrazyDiceDuel() {
         alt="board"
         className="board-bg"
       />
+      <GuideGrid />
       <div className="side-number top">1</div>
       <div className="side-number bottom">2</div>
       <div className="side-number left">3</div>


### PR DESCRIPTION
## Summary
- shrink dice size on Crazy Dice Duel
- overlay a temporary placement grid

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68709f4726a08329afd1ba24232b8939