### PR TITLE
Adjust dice position on Snake & Ladder board

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -652,8 +652,10 @@ export default function SnakeAndLadder() {
   // Board dice icons measure about 2.2rem (~35px) so match
   // that size against the Dice component's default 80px width.
   const DICE_SMALL_SCALE = 0.44;
-  // Fixed Y position where dice are rolled (around bottom of the screen)
-  const DICE_ROLL_Y_OFFSET = 120;
+  // Offset from the bottom of the screen where dice roll
+  const DICE_ROLL_Y_OFFSET = 180;
+  // Horizontal nudge so the gap between dice aligns with the middle column
+  const DICE_ROLL_X_OFFSET = boardXOffset;
 
   useEffect(() => {
     // Ensure dice and turn prompt are visible when the game loads
@@ -665,7 +667,7 @@ export default function SnakeAndLadder() {
     setDiceStyle({
       display: 'block',
       position: 'fixed',
-      left: '50%',
+      left: `calc(50% + ${DICE_ROLL_X_OFFSET}px)`,
       top: `${cy}px`,
       transform: 'translate(-50%, -50%) scale(1)',
       transition: 'none',
@@ -679,7 +681,7 @@ export default function SnakeAndLadder() {
     setDiceStyle({
       display: 'block',
       position: 'fixed',
-      left: '50%',
+      left: `calc(50% + ${DICE_ROLL_X_OFFSET}px)`,
       top: `${cy}px`,
       transform: 'translate(-50%, -50%) scale(1)',
       pointerEvents: 'none',
@@ -692,7 +694,7 @@ export default function SnakeAndLadder() {
     setDiceStyle({
       display: 'block',
       position: 'fixed',
-      left: '50%',
+      left: `calc(50% + ${DICE_ROLL_X_OFFSET}px)`,
       top: `${cy}px`,
       transform: 'translate(-50%, -50%) scale(1)',
       pointerEvents: 'none',


### PR DESCRIPTION
## Summary
- tweak the dice placement in Snake & Ladder
- align the gap between the dice with the board centre

## Testing
- `npm test` *(fails: cannot find package 'dotenv' and others)*

------
https://chatgpt.com/codex/tasks/task_e_6870a067b7108329a70fa2a7cb599ef2