### PR TITLE
Adjust Crazy Dice Duel layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -124,7 +124,7 @@ input:focus {
 }
 
 .dice-cube {
-  @apply relative w-12 h-12 bg-white rounded-xl;
+  @apply relative w-10 h-10 bg-white rounded-xl;
   border: none;
   transform-style: preserve-3d;
   transition: transform 0.5s;
@@ -1292,9 +1292,12 @@ input:focus {
 }
 .crazy-dice-board .board-bg {
   position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+  top: -2%;
+  bottom: -2%;
+  left: -2%;
+  right: 0;
+  width: auto;
+  height: auto;
   object-fit: cover;
   object-position: center;
   transform: scale(1.1);
@@ -1303,7 +1306,7 @@ input:focus {
 }
 .crazy-dice-board .dice-center {
   position: absolute;
-  top: 50%;
+  top: 55%;
   left: 50%;
   transform: translate(-50%, -50%);
 }
@@ -1311,14 +1314,14 @@ input:focus {
 /* Player positions around the Crazy Dice board */
 .crazy-dice-board .player-bottom {
   position: absolute;
-  bottom: 20%;
+  bottom: 10%;
   left: 50%;
   transform: translateX(-50%);
 }
 
 .crazy-dice-board .player-left {
   position: absolute;
-  top: 3%;
+  top: 5%;
   left: -2%;
 }
 
@@ -1335,7 +1338,7 @@ input:focus {
 
 .crazy-dice-board .player-right {
   position: absolute;
-  top: 3%;
+  top: 5%;
   right: -2%;
 }
 

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -259,7 +259,7 @@ export default function CrazyDiceDuel() {
             className="dice-travel flex flex-col items-center"
           >
             <DiceRoller
-              className="scale-75"
+              className="scale-[0.6]"
               onRollEnd={onRollEnd}
               onRollStart={() => {
                 prepareDiceAnimation();


### PR DESCRIPTION
## Summary
- tweak board background to extend on top, bottom, and left
- position dice between E6 and F6 and reduce dice size
- move player positions slightly to align with guide boxes

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6870a48c93b08329aa43c180798d2fdf