### PR TITLE
Fix Crazy Dice board and dice sizes

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -124,7 +124,7 @@ input:focus {
 }
 
 .dice-cube {
-  @apply relative w-10 h-10 bg-white rounded-xl;
+  @apply relative w-12 h-12 bg-white rounded-xl;
   border: none;
   transform-style: preserve-3d;
   transition: transform 0.5s;
@@ -1295,12 +1295,12 @@ input:focus {
   top: -2%;
   bottom: -2%;
   left: -2%;
-  right: 0;
-  width: auto;
-  height: auto;
+  right: -2%;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   object-position: center;
-  transform: scale(1.1);
+  transform: scale(1.15);
   filter: brightness(1.2);
   z-index: -1;
 }

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -259,7 +259,7 @@ export default function CrazyDiceDuel() {
             className="dice-travel flex flex-col items-center"
           >
             <DiceRoller
-              className="scale-[0.6]"
+              className="scale-75"
               onRollEnd={onRollEnd}
               onRollStart={() => {
                 prepareDiceAnimation();


### PR DESCRIPTION
## Summary
- enlarge board background with negative offsets
- make dice cube a bit larger
- size dice roller to match other dice

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND, test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6870a843900c83299d556570eac8d0d5