### PR TITLE
Update dice board layout

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -128,7 +128,7 @@ export default function DiceSet({
   startValues,
 }) {
   return (
-    <div className="flex gap-4 justify-center items-center">
+    <div className="flex gap-2 justify-center items-center">
       {values.map((v, i) => (
         <DiceCube
           key={i}

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -98,7 +98,7 @@ export default function DiceRoller({
   return (
     <div className={`flex flex-col items-center space-y-4 ${className}`} style={style}>
       <div
-        className={`flex space-x-4 ${clickable ? 'cursor-pointer' : ''}`}
+        className={`flex space-x-2 ${clickable ? 'cursor-pointer' : ''}`}
         onClick={clickable ? rollDice : undefined}
       >
         <Dice values={values} rolling={rolling} startValues={startValuesRef.current} />

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1288,16 +1288,14 @@ input:focus {
   width: 100vw;
   height: 100vh;
   overflow: hidden;
-  transform: translateX(-2%);
+  transform: translateX(-1%);
 }
 .crazy-dice-board .board-bg {
   position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+  inset: -1% 0 -1% -1%;
   object-fit: cover;
   object-position: center;
-  transform: translate(2%, 0) scale(1.15);
+  transform: translate(1%, 0) scale(1.18);
   filter: brightness(1.2);
   z-index: -1;
 }

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -75,6 +75,10 @@ export default function CrazyDiceDuel() {
   }, []);
 
   useEffect(() => {
+    prepareDiceAnimation();
+  }, []);
+
+  useEffect(() => {
     const handler = () => setMuted(isGameMuted());
     window.addEventListener('gameMuteChanged', handler);
     return () => window.removeEventListener('gameMuteChanged', handler);
@@ -141,97 +145,24 @@ export default function CrazyDiceDuel() {
     });
     let n = (current + 1) % players.length;
     while (players[n].rolls >= maxRolls) n = (n + 1) % players.length;
-    animateDiceToPlayer(n);
   };
 
-  const prepareDiceAnimation = (startIdx) => {
-    if (startIdx == null) {
-      const cx = window.innerWidth / 2;
-      const cy = window.innerHeight / 2;
-      setDiceStyle({
-        display: 'block',
-        position: 'fixed',
-        left: `${cx}px`,
-        top: `${cy}px`,
-        transform: 'translate(-50%, -50%) scale(1)',
-        transition: 'none',
-        pointerEvents: 'none',
-        zIndex: 50,
-      });
-      return;
-    }
-    const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
-    if (!startEl) return;
-    const s = startEl.getBoundingClientRect();
+  const prepareDiceAnimation = () => {
+    const cx = window.innerWidth / 2;
+    const cy = window.innerHeight / 2;
     setDiceStyle({
       display: 'block',
       position: 'fixed',
-      left: `${s.left + s.width / 2}px`,
-      top: `${s.top + s.height / 2}px`,
-      transform: `translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
+      left: `${cx}px`,
+      top: `${cy}px`,
+      transform: 'translate(-50%, -50%) scale(1)',
       transition: 'none',
       pointerEvents: 'none',
       zIndex: 50,
     });
   };
 
-  const animateDiceToCenter = (startIdx) => {
-    const dice = diceRef.current;
-    const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
-    if (!dice || !startEl) return;
-    const s = startEl.getBoundingClientRect();
-    const cx = window.innerWidth / 2;
-    const cy = window.innerHeight / 2;
-    dice.style.display = 'block';
-    dice.style.position = 'fixed';
-    dice.style.left = '0px';
-    dice.style.top = '0px';
-    dice.style.pointerEvents = 'none';
-    dice.style.zIndex = '50';
-    dice.animate(
-      [
-        { transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(${DICE_SMALL_SCALE})` },
-        { transform: `translate(${cx}px, ${cy}px) scale(1)` },
-      ],
-      { duration: 600, easing: 'linear' },
-    ).onfinish = () => {
-      setDiceStyle({
-        display: 'block',
-        position: 'fixed',
-        left: `${cx}px`,
-        top: `${cy}px`,
-        transform: 'translate(-50%, -50%) scale(1)',
-        pointerEvents: 'none',
-        zIndex: 50,
-      });
-    };
-  };
-
-  const animateDiceToPlayer = (idx) => {
-    const dice = diceRef.current;
-    const endEl = document.querySelector(`[data-player-index="${idx}"] img`);
-    if (!dice || !endEl) return;
-    const e = endEl.getBoundingClientRect();
-    const cx = window.innerWidth / 2;
-    const cy = window.innerHeight / 2;
-    dice.animate(
-      [
-        { transform: `translate(${cx}px, ${cy}px) scale(1)` },
-        { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(${DICE_SMALL_SCALE})` },
-      ],
-      { duration: 600, easing: 'linear' },
-    ).onfinish = () => {
-      setDiceStyle({
-        display: 'block',
-        position: 'fixed',
-        left: `${e.left + e.width / 2}px`,
-        top: `${e.top + e.height / 2}px`,
-        transform: `translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
-        pointerEvents: 'none',
-        zIndex: 50,
-      });
-    };
-  };
+  /* The dice remain fixed at the center between players. */
 
   const nextTurn = () => {
     setCurrent((c) => {
@@ -295,8 +226,7 @@ export default function CrazyDiceDuel() {
             <DiceRoller
               onRollEnd={onRollEnd}
               onRollStart={() => {
-                prepareDiceAnimation(current);
-                animateDiceToCenter(current);
+                prepareDiceAnimation();
               }}
               trigger={trigger}
               clickable={aiCount === 0 || current === 0}


### PR DESCRIPTION
## Summary
- tweak Crazy Dice Duel board background and dice center logic
- keep dice fixed at the center of the board
- shrink space between dice

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_6870b683bc5c83299a26c6aece0ef7d1