### PR TITLE
Adjust crazy dice duel layout

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -15,6 +15,7 @@ export default function DiceRoller({
   emitRollEvent = false,
   className = '',
   style = {},
+  diceContainerClassName = 'space-x-4',
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -98,7 +99,7 @@ export default function DiceRoller({
   return (
     <div className={`flex flex-col items-center space-y-4 ${className}`} style={style}>
       <div
-        className={`flex space-x-4 ${clickable ? 'cursor-pointer' : ''}`}
+        className={`flex ${clickable ? 'cursor-pointer' : ''} ${diceContainerClassName}`}
         onClick={clickable ? rollDice : undefined}
       >
         <Dice values={values} rolling={rolling} startValues={startValuesRef.current} />

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1288,7 +1288,7 @@ input:focus {
   width: 100vw;
   height: 100vh;
   overflow: hidden;
-  transform: translateX(-2%);
+  transform: translate(-3%, 0);
 }
 .crazy-dice-board .board-bg {
   position: absolute;
@@ -1297,13 +1297,13 @@ input:focus {
   height: 100%;
   object-fit: cover;
   object-position: center;
-  transform: translate(2%, 0) scale(1.15);
+  transform: translate(3%, 0) scale(1.1);
   filter: brightness(1.2);
   z-index: -1;
 }
 .crazy-dice-board .dice-center {
   position: absolute;
-  top: 50%;
+  top: 40%;
   left: 50%;
   transform: translate(-50%, -50%);
 }

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -301,6 +301,7 @@ export default function CrazyDiceDuel() {
               trigger={trigger}
               clickable={aiCount === 0 || current === 0}
               showButton={aiCount === 0 || current === 0}
+              diceContainerClassName="space-x-8"
             />
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- tweak dice roller to accept custom gap class
- make crazy dice board smaller on three sides
- nudge dice roll position
- add more gap between crazy dice duel dice

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870bdbec1288329bbc174ab40a7ea57