### PR TITLE
Fix dice independence and snake roll

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -63,6 +63,8 @@ function DiceCube({
   rolling = false,
   playSound = false,
   prevValue,
+  size = 64,
+  rollingScale = 1,
 }) {
   // Keep a fixed isometric orientation and simply swap the top face.
   const orientation = baseTilt;
@@ -99,12 +101,15 @@ function DiceCube({
   }, [rolling, playSound]);
 
   return (
-    <div className="dice-container perspective-1000 w-16 h-16">
+    <div
+      className="dice-container perspective-1000"
+      style={{ width: `${size}px`, height: `${size}px` }}
+    >
       <div
         className={`dice-cube relative w-full h-full transition-transform duration-500 transform-style-preserve-3d ${
           rolling ? "animate-roll" : ""
         }`}
-        style={{ transform: orientation }}
+        style={{ transform: `${orientation} scale(${rolling ? rollingScale : 1})` }}
       >
         {/* Dynamic side faces */}
         <Face value={sides[0]} className="dice-face--front absolute" />
@@ -126,6 +131,8 @@ export default function DiceSet({
   rolling = false,
   playSound = false,
   startValues,
+  size = 64,
+  rollingScale = 1,
 }) {
   return (
     <div className="flex gap-4 justify-center items-center">
@@ -136,6 +143,8 @@ export default function DiceSet({
           rolling={rolling}
           playSound={playSound}
           prevValue={startValues?.[i]}
+          size={size}
+          rollingScale={rollingScale}
         />
       ))}
     </div>

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -16,6 +16,8 @@ export default function DiceRoller({
   className = '',
   style = {},
   diceContainerClassName = 'space-x-4',
+  size = 64,
+  rollingScale = 1,
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -102,7 +104,13 @@ export default function DiceRoller({
         className={`flex ${clickable ? 'cursor-pointer' : ''} ${diceContainerClassName}`}
         onClick={clickable ? rollDice : undefined}
       >
-        <Dice values={values} rolling={rolling} startValues={startValuesRef.current} />
+        <Dice
+          values={values}
+          rolling={rolling}
+          startValues={startValuesRef.current}
+          size={size}
+          rollingScale={rollingScale}
+        />
       </div>
       {!clickable && showButton && (
         <button

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -146,6 +146,7 @@ export default function LuckyNumber() {
           onRollStart={handleRollStart}
           showButton={false}
           clickable={canRoll}
+          className="lucky-dice"
         />
         {!canRoll && (
           <p className="text-sm text-subtext">You can roll again every 4 hours.</p>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -158,6 +158,22 @@ input:focus {
   transform: rotateX(-90deg) translateZ(2rem);
 }
 
+/* Game specific dice sizing */
+.lucky-dice .dice-container {
+  width: 4rem;
+  height: 4rem;
+}
+
+.snake-dice .dice-container {
+  width: 4rem;
+  height: 4rem;
+}
+
+.crazy-dice .dice-container {
+  width: 4.5rem;
+  height: 4.5rem;
+}
+
 .board-cell {
   @apply relative flex items-center justify-center rounded-xl text-text;
   background-color: var(--tile-bg, #0e3b45);

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -302,6 +302,7 @@ export default function CrazyDiceDuel() {
               clickable={aiCount === 0 || current === 0}
               showButton={aiCount === 0 || current === 0}
               diceContainerClassName="space-x-8"
+              className="crazy-dice"
             />
           </div>
         ) : (

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2142,8 +2142,8 @@ export default function SnakeAndLadder() {
           className="dice-travel flex flex-col items-center"
         >
           <DiceRoller
-            className=""
-            style={{ transform: 'scale(0.85)' }}
+            className="snake-dice"
+            rollingScale={0.85}
             onRollEnd={(vals) => {
               if (aiRollingIndex) {
                 handleAIRoll(aiRollingIndex, vals);
@@ -2197,7 +2197,7 @@ export default function SnakeAndLadder() {
         <div
           className="fixed inset-0 z-20 pointer-events-none"
         >
-          <div className="flex flex-col items-center justify-center h-full pointer-events-auto" style={{ transform: 'scale(0.85)' }}>
+          <div className="flex flex-col items-center justify-center h-full pointer-events-auto">
             {(() => {
               const myId = getPlayerId();
               const myIndex = mpPlayers.findIndex(p => p.id === myId);
@@ -2209,6 +2209,8 @@ export default function SnakeAndLadder() {
                     muted={muted}
                     emitRollEvent
                     numDice={2}
+                    className="snake-dice"
+                    rollingScale={0.85}
                   />
                 );
               }


### PR DESCRIPTION
## Summary
- allow customizing Dice component size and rolling scale
- size the dice per game so Lucky Number, Snake & Ladder and Crazy Dice Duel don't share styles
- scale dice while rolling in Snake & Ladder

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND dotenv etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6870c16e9ecc83298c705796e434637b