### PR TITLE
Improve Crazy Dice board layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -433,16 +433,17 @@ input:focus {
 }
 
 .crazy-dice-board .player-left .player-score,
-.crazy-dice-board .player-left .roll-history {
-  left: calc(100% + 0.3rem);
-  transform: translateX(0);
-}
-
+.crazy-dice-board .player-left .roll-history,
 .crazy-dice-board .player-right .player-score,
 .crazy-dice-board .player-right .roll-history {
-  right: calc(100% + 0.5rem);
-  left: auto;
-  transform: translateX(0);
+  left: 50%;
+  right: auto;
+  transform: translateX(-50%);
+}
+
+.crazy-dice-board .player-center .player-score,
+.crazy-dice-board .player-center .roll-history {
+  transform: translateX(-50%);
 }
 
 .turn-indicator {
@@ -1298,6 +1299,8 @@ input:focus {
   object-fit: cover;
   object-position: center;
   transform: translate(3%, 0) scale(1.1);
+  /* Slightly crop top/bottom more and left a bit for better framing */
+  clip-path: inset(3% 0 3% 1%);
   filter: brightness(1.2);
   z-index: -1;
 }
@@ -1319,7 +1322,7 @@ input:focus {
 .crazy-dice-board .player-left {
   position: absolute;
   top: 3%;
-  left: -2%;
+  left: 16%;
 }
 
 .crazy-dice-board .player-center {
@@ -1330,13 +1333,13 @@ input:focus {
 }
 .crazy-dice-board .player-center .player-score,
 .crazy-dice-board .player-center .roll-history {
-  transform: translateX(-60%);
+  transform: translateX(-50%);
 }
 
 .crazy-dice-board .player-right {
   position: absolute;
   top: 3%;
-  right: -2%;
+  right: 16%;
 }
 
 /* Markers for easier mapping */
@@ -1366,6 +1369,18 @@ input:focus {
   right: 0.5rem;
   top: 50%;
   transform: translateY(-50%);
+}
+
+/* Temporary overlay grid to help with alignment */
+.guid-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.2) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.2) 1px, transparent 1px);
+  background-size: 50px 50px;
+  pointer-events: none;
+  z-index: 9999;
 }
 
 /* Rolling dice animation */

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -276,6 +276,7 @@ export default function CrazyDiceDuel() {
 
   return (
     <div className="crazy-dice-board text-text" ref={boardRef}>
+      <div className="guid-grid" />
       <img
         src="/assets/icons/file_00000000316461fdac87111607fc8ada%20(1).png"
         alt="board"


### PR DESCRIPTION
## Summary
- tweak board background cropping
- realign top player slots and scores
- overlay a guide grid for design

## Testing
- `npm test` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6870c32b5e9483298b17d9d12ff12f0f