### PR TITLE
Adjust background for Crazy Dice Duel

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -20,10 +20,7 @@ body {
 }
 
 .bg-surface {
-  background:
-    radial-gradient(2px 2px at 20% 30%, rgba(255, 255, 255, 0.15), transparent 40%),
-    radial-gradient(1.5px 1.5px at 80% 70%, rgba(255, 255, 255, 0.1), transparent 50%),
-    linear-gradient(#081428, #102040);
+  background: linear-gradient(#081428, #102040);
   background-color: #0b1a2f;
   box-shadow: inset 0 0 10px rgba(0, 247, 255, 0.4);
 }
@@ -100,7 +97,7 @@ input:focus {
   pointer-events: none;
   /* slightly brighter and scaled up */
   filter: brightness(2.4);
-  transform: translateY(90px) scale(1.2);
+  transform: translate(30px, 90px) scale(1.2);
 }
 
 @keyframes roll {


### PR DESCRIPTION
## Summary
- remove starry effects from `.bg-surface`
- nudge the board image to the right

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6870ca7146548329b7aa481feef2bc45