### PR TITLE
Add dice travel animation to Snake & Ladder

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -920,6 +920,14 @@ input:focus {
   overflow: visible;
 }
 
+.dice-travel {
+  position: fixed;
+  left: 0;
+  top: 0;
+  pointer-events: none;
+  z-index: 50;
+}
+
 .coin-img {
   position: absolute;
   left: -16px;


### PR DESCRIPTION
## Summary
- animate dice moving between player avatars and board center in Snake & Ladder
- keep dice visible by placing it in a fixed container
- show "Your turn" indicator separately at the bottom
- add helper CSS class for travelling dice

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870d81b119083298c1168448a3376be