### PR TITLE
Fix dice roll UI

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -19,9 +19,7 @@ export default function AvatarTimer({
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
   return (
     <div className="relative w-14 h-14" onClick={onClick} data-player-index={index}>
-      {isTurn && (
-        <div className="turn-indicator" onClick={onClick}>🫵 your turn</div>
-      )}
+      {/* turn indicator removed */}
       {active && (
         <div className="avatar-timer-ring" style={{ '--timer-gradient': gradient }} />
       )}

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -13,6 +13,7 @@ export default function DiceRoller({
   showButton = true,
   muted = false,
   emitRollEvent = false,
+  divRef,
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -98,6 +99,7 @@ export default function DiceRoller({
       <div
         className={`flex space-x-4 ${clickable ? 'cursor-pointer' : ''}`}
         onClick={clickable ? rollDice : undefined}
+        ref={divRef}
       >
         <Dice values={values} rolling={rolling} startValues={startValuesRef.current} />
       </div>

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -642,6 +642,7 @@ export default function SnakeAndLadder() {
   const [chatBubbles, setChatBubbles] = useState([]);
 
   const diceRef = useRef(null);
+  const diceRollerDivRef = useRef(null);
   const [diceStyle, setDiceStyle] = useState({ display: 'none' });
   const DICE_SMALL_SCALE = 0.44;
 
@@ -732,7 +733,7 @@ export default function SnakeAndLadder() {
 
   const getDiceCenter = () => {
     const cx = window.innerWidth / 2 + 32;
-    const cy = window.innerHeight - 96;
+    const cy = window.innerHeight - 160; // position dice slightly higher
     return { cx, cy };
   };
 
@@ -783,7 +784,7 @@ export default function SnakeAndLadder() {
         { transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(${DICE_SMALL_SCALE})` },
         { transform: `translate(${cx}px, ${cy}px) scale(1)` },
       ],
-      { duration: 600, easing: 'linear' },
+      { duration: 1750, easing: 'linear' },
     ).onfinish = () => {
       setDiceStyle({
         display: 'block',
@@ -808,7 +809,7 @@ export default function SnakeAndLadder() {
         { transform: `translate(${cx}px, ${cy}px) scale(1)` },
         { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(${DICE_SMALL_SCALE})` },
       ],
-      { duration: 600, easing: 'linear' },
+      { duration: 1750, easing: 'linear' },
     ).onfinish = () => {
       setDiceStyle({
         display: 'block',
@@ -2106,6 +2107,7 @@ export default function SnakeAndLadder() {
         <div ref={diceRef} style={diceStyle} className="dice-travel flex flex-col items-center">
           <div className="scale-90">
             <DiceRoller
+              divRef={diceRollerDivRef}
               onRollEnd={(vals) => {
                 if (aiRollingIndex) {
                   handleAIRoll(aiRollingIndex, vals);
@@ -2147,8 +2149,9 @@ export default function SnakeAndLadder() {
       )}
       {currentTurn === 0 && !aiRollingIndex && !playerAutoRolling && (
         <div
-          className="fixed bottom-24 inset-x-0 flex flex-col items-center z-20 pointer-events-none"
+          className="fixed bottom-24 inset-x-0 flex flex-col items-center z-20 cursor-pointer"
           style={{ transform: 'translateX(2rem)' }}
+          onClick={() => diceRollerDivRef.current?.click()}
         >
           <div className="text-5xl">🫵</div>
           <div
@@ -2161,8 +2164,9 @@ export default function SnakeAndLadder() {
       )}
       {isMultiplayer && (
         <div
-          className="fixed bottom-24 inset-x-0 flex flex-col items-center z-20"
+          className="fixed bottom-24 inset-x-0 flex flex-col items-center z-20 cursor-pointer"
           style={{ transform: 'translateX(2rem)' }}
+          onClick={() => diceRollerDivRef.current?.click()}
         >
           <div className="scale-90">
           {(() => {
@@ -2175,6 +2179,7 @@ export default function SnakeAndLadder() {
                   showButton={false}
                   muted={muted}
                   emitRollEvent
+                  divRef={diceRollerDivRef}
                 />
               );
             }


### PR DESCRIPTION
## Summary
- remove text indicator from leaderboard avatars
- expose DiceRoller div ref
- move dice a bit higher when rolling and slow travel animation
- make "Your turn" overlay clickable to roll dice

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870de6eeae88329b0b97d67d918ad44