### PR TITLE
Adjust Crazy Dice layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1247,7 +1247,6 @@ input:focus {
   width: 100vw;
   height: 100vh;
   overflow: hidden;
-  transform: translate(-3%, 0);
 }
 .crazy-dice-board .board-bg {
   position: absolute;
@@ -1256,15 +1255,33 @@ input:focus {
   height: 100%;
   object-fit: cover;
   object-position: center;
-  transform: translate(3%, 0) scale(1.1);
+  transform: none;
   filter: brightness(1.2);
   z-index: -1;
 }
 .crazy-dice-board .dice-center {
   position: absolute;
-  top: 40%;
+  top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+}
+
+.crazy-dice-board .guide-grid {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(20, 1fr);
+  grid-template-rows: repeat(40, 1fr);
+  pointer-events: none;
+  font-size: 0.5rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.crazy-dice-board .guide-grid div {
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Player positions around the Crazy Dice board */

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -65,8 +65,37 @@ export default function CrazyDiceDuel() {
   const timerSoundRef = useRef(null);
   const diceRef = useRef(null);
   const boardRef = useRef(null);
-  const [diceStyle, setDiceStyle] = useState({ display: 'none' });
-  const DICE_SMALL_SCALE = 0.44;
+  const [diceStyle, setDiceStyle] = useState({
+    display: 'block',
+    position: 'fixed',
+    left: '50%',
+    top: '50%',
+    transform: 'translate(-50%, -50%)',
+    pointerEvents: 'none',
+    zIndex: 50,
+  });
+
+  const guideCells = useMemo(() => {
+    const letters = 'ABCDEFGHIJKLMNOPQRST'.split('');
+    const cells = [];
+    for (let r = 0; r < 40; r++) {
+      for (let c = 0; c < 20; c++) {
+        cells.push(`${letters[c]}${r + 1}`);
+      }
+    }
+    return cells;
+  }, []);
+
+  useEffect(() => {
+    if (screen.orientation && screen.orientation.lock) {
+      screen.orientation.lock('portrait').catch(() => {});
+    }
+    return () => {
+      if (screen.orientation && screen.orientation.unlock) {
+        try { screen.orientation.unlock(); } catch (e) {}
+      }
+    };
+  }, []);
 
   useEffect(() => {
     timerSoundRef.current = new Audio(timerBeep);
@@ -141,96 +170,6 @@ export default function CrazyDiceDuel() {
     });
     let n = (current + 1) % players.length;
     while (players[n].rolls >= maxRolls) n = (n + 1) % players.length;
-    animateDiceToPlayer(n);
-  };
-
-  const prepareDiceAnimation = (startIdx) => {
-    if (startIdx == null) {
-      const cx = window.innerWidth / 2;
-      const cy = window.innerHeight / 2;
-      setDiceStyle({
-        display: 'block',
-        position: 'fixed',
-        left: `${cx}px`,
-        top: `${cy}px`,
-        transform: 'translate(-50%, -50%) scale(1)',
-        transition: 'none',
-        pointerEvents: 'none',
-        zIndex: 50,
-      });
-      return;
-    }
-    const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
-    if (!startEl) return;
-    const s = startEl.getBoundingClientRect();
-    setDiceStyle({
-      display: 'block',
-      position: 'fixed',
-      left: `${s.left + s.width / 2}px`,
-      top: `${s.top + s.height / 2}px`,
-      transform: `translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
-      transition: 'none',
-      pointerEvents: 'none',
-      zIndex: 50,
-    });
-  };
-
-  const animateDiceToCenter = (startIdx) => {
-    const dice = diceRef.current;
-    const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
-    if (!dice || !startEl) return;
-    const s = startEl.getBoundingClientRect();
-    const cx = window.innerWidth / 2;
-    const cy = window.innerHeight / 2;
-    dice.style.display = 'block';
-    dice.style.position = 'fixed';
-    dice.style.left = '0px';
-    dice.style.top = '0px';
-    dice.style.pointerEvents = 'none';
-    dice.style.zIndex = '50';
-    dice.animate(
-      [
-        { transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(${DICE_SMALL_SCALE})` },
-        { transform: `translate(${cx}px, ${cy}px) scale(1)` },
-      ],
-      { duration: 600, easing: 'linear' },
-    ).onfinish = () => {
-      setDiceStyle({
-        display: 'block',
-        position: 'fixed',
-        left: `${cx}px`,
-        top: `${cy}px`,
-        transform: 'translate(-50%, -50%) scale(1)',
-        pointerEvents: 'none',
-        zIndex: 50,
-      });
-    };
-  };
-
-  const animateDiceToPlayer = (idx) => {
-    const dice = diceRef.current;
-    const endEl = document.querySelector(`[data-player-index="${idx}"] img`);
-    if (!dice || !endEl) return;
-    const e = endEl.getBoundingClientRect();
-    const cx = window.innerWidth / 2;
-    const cy = window.innerHeight / 2;
-    dice.animate(
-      [
-        { transform: `translate(${cx}px, ${cy}px) scale(1)` },
-        { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(${DICE_SMALL_SCALE})` },
-      ],
-      { duration: 600, easing: 'linear' },
-    ).onfinish = () => {
-      setDiceStyle({
-        display: 'block',
-        position: 'fixed',
-        left: `${e.left + e.width / 2}px`,
-        top: `${e.top + e.height / 2}px`,
-        transform: `translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
-        pointerEvents: 'none',
-        zIndex: 50,
-      });
-    };
   };
 
   const nextTurn = () => {
@@ -285,6 +224,11 @@ export default function CrazyDiceDuel() {
       <div className="side-number bottom">2</div>
       <div className="side-number left">3</div>
       <div className="side-number right">4</div>
+      <div className="guide-grid">
+        {guideCells.map((c, i) => (
+          <div key={i}>{c}</div>
+        ))}
+      </div>
       <div className="dice-center">
         {winner == null ? (
           <div
@@ -294,10 +238,7 @@ export default function CrazyDiceDuel() {
           >
             <DiceRoller
               onRollEnd={onRollEnd}
-              onRollStart={() => {
-                prepareDiceAnimation(current);
-                animateDiceToCenter(current);
-              }}
+              onRollStart={() => {}}
               trigger={trigger}
               clickable={aiCount === 0 || current === 0}
               showButton={aiCount === 0 || current === 0}


### PR DESCRIPTION
## Summary
- make Crazy Dice board background fit the screen
- keep dice in the middle and lock orientation
- add guide grid overlay for positioning

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6870df2a61748329be1106693953614b