### PR TITLE
Fix dice animation center height

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -733,7 +733,8 @@ export default function SnakeAndLadder() {
 
   const getDiceCenter = () => {
     const cx = window.innerWidth / 2 + 32;
-    const cy = window.innerHeight - 160; // position dice slightly higher
+    // Keep the dice a little higher so it doesn't drop too low
+    const cy = window.innerHeight - 200;
     return { cx, cy };
   };
 
@@ -784,7 +785,7 @@ export default function SnakeAndLadder() {
         { transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(${DICE_SMALL_SCALE})` },
         { transform: `translate(${cx}px, ${cy}px) scale(1)` },
       ],
-      { duration: 1750, easing: 'linear' },
+      { duration: 1000, easing: 'ease-in-out' },
     ).onfinish = () => {
       setDiceStyle({
         display: 'block',
@@ -809,7 +810,7 @@ export default function SnakeAndLadder() {
         { transform: `translate(${cx}px, ${cy}px) scale(1)` },
         { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(${DICE_SMALL_SCALE})` },
       ],
-      { duration: 1750, easing: 'linear' },
+      { duration: 1000, easing: 'ease-in-out' },
     ).onfinish = () => {
       setDiceStyle({
         display: 'block',


### PR DESCRIPTION
## Summary
- tweak dice center height to keep dice above bottom
- use ease-in-out animations for dice movement

## Testing
- `npm test` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_6870e3b42d8883299ca16a4a51676749