### PR TITLE
Adjust Crazy Dice board scaling

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1289,7 +1289,8 @@ input:focus {
   height: 100%;
   object-fit: cover;
   object-position: center;
-  transform: translate(5.5%, 0) scale(1.05);
+  /* Enlarged board image so sides 1-3 show more */
+  transform: translate(8%, 0) scale(1.1);
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- enlarge Crazy Dice board background so sides 1-3 are visible

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6870f0bf3b048329b3226b05005dee87