### PR TITLE
Fix Snake & Ladder board background

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -137,10 +137,12 @@ export default function DailyCheckIn() {
 
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 text-center overflow-hidden wide-card">
       <img
-        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""
+        onError={(e) => {
+          e.currentTarget.style.display = 'none';
+        }}
       />
 
 

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -126,6 +126,9 @@ export default function LeaderboardCard() {
           src="/assets/SnakeLaddersbackground.png"
           className="background-behind-board object-cover"
           alt=""
+          onError={(e) => {
+            e.currentTarget.style.display = 'none';
+          }}
         />
         <h3 className="text-lg font-semibold text-center">Leaderboard</h3>
         <div className="flex items-center justify-between">

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -91,6 +91,9 @@ export default function LuckyNumber() {
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""
+        onError={(e) => {
+          e.currentTarget.style.display = 'none';
+        }}
       />
       <h3 className="text-lg font-bold text-text">Lucky Number</h3>
       <div className="grid grid-cols-3 gap-2 justify-items-center">

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -124,10 +124,12 @@ export default function MiningCard() {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-center overflow-hidden wide-card">
       <img
-        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""
+        onError={(e) => {
+          e.currentTarget.style.display = 'none';
+        }}
       />
       <div className="flex justify-center items-center space-x-1">
         <GiMining className="w-5 h-5 text-accent" />

--- a/webapp/src/components/NftGiftCard.jsx
+++ b/webapp/src/components/NftGiftCard.jsx
@@ -54,6 +54,9 @@ export default function NftGiftCard({ accountId: propAccountId }) {
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""
+        onError={(e) => {
+          e.currentTarget.style.display = 'none';
+        }}
       />
       <h3 className="text-lg font-bold text-center">NFT Gifts</h3>
       <div className="flex space-x-2 overflow-x-auto pb-2 text-sm w-full flex-grow justify-center">

--- a/webapp/src/components/ProfileCard.jsx
+++ b/webapp/src/components/ProfileCard.jsx
@@ -5,10 +5,12 @@ export default function ProfileCard() {
   return (
     <div className="relative bg-surface border border-border p-4 rounded-xl shadow-lg space-y-2 text-center overflow-hidden wide-card">
       <img
-        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""
+        onError={(e) => {
+          e.currentTarget.style.display = 'none';
+        }}
       />
       <FaUser className="text-accent text-3xl mx-auto" />
       <h3 className="text-lg font-bold text-text">Profile</h3>

--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -231,7 +231,14 @@ export default function SnakeBoard({
 
   return (
     <div className="relative flex justify-center items-center w-screen overflow-visible">
-      <img  src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+        onError={(e) => {
+          e.currentTarget.style.display = 'none';
+        }}
+      />
       <div
         ref={containerRef}
         className="overflow-y-auto"

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -181,10 +181,12 @@ export default function SpinGame() {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 flex flex-col items-center space-y-2 overflow-hidden wide-card">
       <img
-        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""
+        onError={(e) => {
+          e.currentTarget.style.display = 'none';
+        }}
       />
       <h3 className="text-lg font-bold text-text">Spin &amp; Win</h3>
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>

--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -18,6 +18,9 @@ export default function StoreAd() {
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""
+        onError={(e) => {
+          e.currentTarget.style.display = 'none';
+        }}
       />
       <div className="flex items-center justify-center space-x-1">
         <AiOutlineShop className="text-accent" />

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -153,7 +153,14 @@ export default function TasksCard() {
   return (
 
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
-      <img  src="/assets/SnakeLaddersbackground.png" className="background-behind-board object-cover" alt="" />
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+        onError={(e) => {
+          e.currentTarget.style.display = 'none';
+        }}
+      />
 
       <h3 className="text-lg font-bold text-text flex items-center justify-center space-x-1"><AiOutlineCheckSquare className="text-accent" /><span>Tasks</span></h3>
 

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -100,13 +100,12 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
       <div className="relative p-4 space-y-4 w-80 rounded-xl border border-border bg-surface text-text overflow-hidden">
 
         <img
-
           src="/assets/SnakeLaddersbackground.png"
-
           className="background-behind-board object-cover"
-
           alt=""
-
+          onError={(e) => {
+            e.currentTarget.style.display = 'none';
+          }}
         />
 
         <button

--- a/webapp/src/components/WalletCard.jsx
+++ b/webapp/src/components/WalletCard.jsx
@@ -34,10 +34,12 @@ export default function WalletCard() {
   return (
     <div className="relative bg-surface border border-border p-4 rounded-xl shadow-lg text-text space-y-2 overflow-hidden wide-card">
       <img
-        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""
+        onError={(e) => {
+          e.currentTarget.style.display = 'none';
+        }}
       />
       <h3 className="text-lg font-bold flex items-center space-x-2">
         <span>💰</span>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -102,6 +102,7 @@ input:focus {
   bottom: -160px;
   z-index: -1;
   pointer-events: none;
+  background: radial-gradient(circle at center, #164e63, #0f172a);
   /* slightly brighter and scaled up */
   filter: brightness(2.4);
   transform: translateY(90px) scale(1.2);

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -250,6 +250,7 @@ export default function Home() {
               src="/assets/SnakeLaddersbackground.png"
               className="background-behind-board object-cover"
               alt=""
+              onError={(e) => { e.currentTarget.style.display = "none"; }}
             />
             <div className="flex-1 flex items-center justify-center space-x-1">
               <img src="/assets/icons/TON.webp" alt="TON" className="w-8 h-8" />
@@ -272,6 +273,7 @@ export default function Home() {
                 src="/assets/SnakeLaddersbackground.png"
                 className="background-behind-board object-cover"
                 alt=""
+              onError={(e) => { e.currentTarget.style.display = "none"; }}
               />
 
               <p className="text-center text-xs text-subtext">Only to send and receive TPC coins</p>
@@ -306,6 +308,7 @@ export default function Home() {
             src="/assets/SnakeLaddersbackground.png"
             className="background-behind-board object-cover"
             alt=""
+              onError={(e) => { e.currentTarget.style.display = "none"; }}
           />
           <h3 className="text-lg font-bold text-text text-center">Tokenomics &amp; Roadmap</h3>
           {/* Removed outdated emission schedule */}
@@ -360,6 +363,7 @@ export default function Home() {
             src="/assets/SnakeLaddersbackground.png"
             className="background-behind-board object-cover"
             alt=""
+              onError={(e) => { e.currentTarget.style.display = "none"; }}
           />
           <h3 className="text-lg font-bold text-text text-center">Platform Stats</h3>
           <div className="text-center space-y-1 text-base">

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -133,10 +133,12 @@ export default function Mining() {
 
       <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-text overflow-hidden wide-card">
       <img
-        
         src="/assets/SnakeLaddersbackground.png"
         className="background-behind-board object-cover"
         alt=""
+        onError={(e) => {
+          e.currentTarget.style.display = 'none';
+        }}
       />
         <h2 className="text-xl font-bold text-center">Mining</h2>
 

--- a/webapp/src/pages/Tokenomics.jsx
+++ b/webapp/src/pages/Tokenomics.jsx
@@ -254,6 +254,7 @@ export default function TokenomicsPage() {
           src="/assets/SnakeLaddersbackground.png"
           className="background-behind-board object-cover"
           alt=""
+          onError={(e) => { e.currentTarget.style.display = "none"; }}
         />
         <h2 className="text-xl font-bold">Tokenomics &amp; Roadmap</h2>
         <p className="text-subtext">
@@ -267,6 +268,7 @@ export default function TokenomicsPage() {
           src="/assets/SnakeLaddersbackground.png"
           className="background-behind-board object-cover"
           alt=""
+          onError={(e) => { e.currentTarget.style.display = "none"; }}
         />
         <h3 className="text-lg font-bold text-center">Token Allocation</h3>
         <div className="mx-auto w-40">
@@ -305,6 +307,7 @@ export default function TokenomicsPage() {
           src="/assets/SnakeLaddersbackground.png"
           className="background-behind-board object-cover"
           alt=""
+          onError={(e) => { e.currentTarget.style.display = "none"; }}
         />
         <h3 className="text-lg font-bold text-center">Game Fee Distribution (per Table)</h3>
         <div className="mx-auto w-40">
@@ -343,6 +346,7 @@ export default function TokenomicsPage() {
           src="/assets/SnakeLaddersbackground.png"
           className="background-behind-board object-cover"
           alt=""
+          onError={(e) => { e.currentTarget.style.display = "none"; }}
         />
         <h3 className="text-lg font-bold mb-2 text-center">Full Token Allocation Breakdown</h3>
         <table className="w-full text-sm text-left min-w-[32rem]">
@@ -373,6 +377,7 @@ export default function TokenomicsPage() {
           src="/assets/SnakeLaddersbackground.png"
           className="background-behind-board object-cover"
           alt=""
+          onError={(e) => { e.currentTarget.style.display = "none"; }}
         />
         <div>
           <h4 className="font-semibold text-accent mb-1">Total Supply</h4>
@@ -474,6 +479,7 @@ export default function TokenomicsPage() {
           src="/assets/SnakeLaddersbackground.png"
           className="background-behind-board object-cover"
           alt=""
+          onError={(e) => { e.currentTarget.style.display = "none"; }}
         />
         <h3 className="text-lg font-bold text-center">Roadmap</h3>
         <div className="space-y-2 text-sm">
@@ -499,6 +505,7 @@ export default function TokenomicsPage() {
           src="/assets/SnakeLaddersbackground.png"
           className="background-behind-board object-cover"
           alt=""
+          onError={(e) => { e.currentTarget.style.display = "none"; }}
         />
         <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-16 h-16" />
         <div>
@@ -522,6 +529,7 @@ export default function TokenomicsPage() {
           src="/assets/SnakeLaddersbackground.png"
           className="background-behind-board object-cover"
           alt=""
+          onError={(e) => { e.currentTarget.style.display = "none"; }}
         />
         <h3 className="text-lg font-bold text-center">TPC Wallet Addresses</h3>
         <ul className="text-xs break-all space-y-1">


### PR DESCRIPTION
## Summary
- add fallback gradient background for board
- hide missing board background images with `onError`

## Testing
- `npm test` *(fails: Cannot find package 'dotenv', 'socket.io-client', 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_6870f20b83e88329a4f181ed8e48a8e3