### PR TITLE
Fix crazy dice board bg

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1288,8 +1288,8 @@ input:focus {
   height: 100%;
   object-fit: cover;
   object-position: center;
-  /* Enlarged board image so sides 1-3 show more */
-  transform: translate(8%, 0) scale(1.1);
+  /* Make the board image slightly larger and shift towards side #3 */
+  transform: translate(4%, 0) scale(1.15);
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- tweak Crazy Dice background image to show more of sides 1-3

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870f276ebe48329ad1f7caa98cfe26f