### PR TITLE
Adjust Crazy Dice background alignment

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1289,9 +1289,9 @@ input:focus {
   height: 100%;
   object-fit: cover;
   object-position: center;
-  /* Make the board image larger, move it further toward side #3 and
-     increase the vertical scale so sides 1 and 2 cover the empty space */
-  transform: translate(8%, 0) scale(1.15, 1.12);
+  /* Shift the board image toward side #3 (left) and enlarge
+     the vertical dimension so sides 1 and 2 fill the empty space */
+  transform: translate(-10%, 0) scale(1.15, 1.2);
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- reposition Crazy Dice board background toward side #3
- enlarge vertical scale so sides 1 and 2 fill empty space

## Testing
- `npm test` *(fails: cannot find package 'dotenv', 'socket.io-client', 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_68710079743083299d7022adda29cc87