### PR TITLE
Adjust dice animation and icon size

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1015,8 +1015,8 @@ input:focus {
 
 .dice-marker {
   position: absolute;
-  width: 2.2rem;
-  height: 2.2rem;
+  width: 1.6rem;
+  height: 1.6rem;
   left: 50%;
   top: 55%;
   transform: translate(-50%, -50%) translateZ(6px)
@@ -1025,13 +1025,13 @@ input:focus {
   align-items: center;
   justify-content: center;
   pointer-events: none;
-  z-index: 2;
+  z-index: 4;
   transition: transform 0.3s ease;
 }
 
 .dice-marker .dice-icon {
-  width: 2.2rem;
-  height: 2.2rem;
+  width: 1.6rem;
+  height: 1.6rem;
   object-fit: contain;
   transition: transform 0.3s ease;
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -650,8 +650,9 @@ export default function SnakeAndLadder() {
   const DICE_ANIM_DURATION = 1800;
   // Dice landing spot (matches roll result text position)
   const RESULT_BOTTOM = 13 * 16; // tailwind bottom-52 -> 13rem
-  const RESULT_OFFSET_X = 8; // 0.5rem right shift of text
-  const RESULT_OFFSET_Y = -4; // -0.25rem up shift of text
+  // Slightly shift the dice roll position up and to the left
+  const RESULT_OFFSET_X = -4; // 0.25rem left shift of text
+  const RESULT_OFFSET_Y = -12; // 0.75rem additional upward shift
 
   useEffect(() => {
     prepareDiceAnimation(0);
@@ -763,12 +764,14 @@ export default function SnakeAndLadder() {
     const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
     if (!startEl) return;
     const s = startEl.getBoundingClientRect();
+    const targetX = s.left + s.width / 2;
+    const targetY = s.top - s.height * 0.3;
     setDiceStyle({
       display: 'block',
       position: 'fixed',
       left: '0px',
       top: '0px',
-      transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(${DICE_SMALL_SCALE})`,
+      transform: `translate(${targetX}px, ${targetY}px) scale(${DICE_SMALL_SCALE})`,
       transition: 'none',
       pointerEvents: 'none',
       zIndex: 50,
@@ -780,6 +783,8 @@ export default function SnakeAndLadder() {
     const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
     if (!dice || !startEl) return;
     const s = startEl.getBoundingClientRect();
+    const startX = s.left + s.width / 2;
+    const startY = s.top - s.height * 0.3;
     const { cx, cy } = getDiceCenter();
     dice.style.display = 'block';
     dice.style.position = 'fixed';
@@ -789,7 +794,7 @@ export default function SnakeAndLadder() {
     dice.style.zIndex = '50';
     dice.animate(
       [
-        { transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(${DICE_SMALL_SCALE})` },
+        { transform: `translate(${startX}px, ${startY}px) scale(${DICE_SMALL_SCALE})` },
         { transform: `translate(${cx}px, ${cy}px) scale(1)` },
       ],
       { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' },
@@ -811,11 +816,13 @@ export default function SnakeAndLadder() {
     const endEl = document.querySelector(`[data-player-index="${idx}"] img`);
     if (!dice || !endEl) return;
     const e = endEl.getBoundingClientRect();
+    const endX = e.left + e.width / 2;
+    const endY = e.top - e.height * 0.3;
     const { cx, cy } = getDiceCenter();
     dice.animate(
       [
         { transform: `translate(${cx}px, ${cy}px) scale(1)` },
-        { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(${DICE_SMALL_SCALE})` },
+        { transform: `translate(${endX}px, ${endY}px) scale(${DICE_SMALL_SCALE})` },
       ],
       { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' },
     ).onfinish = () => {
@@ -824,7 +831,7 @@ export default function SnakeAndLadder() {
         position: 'fixed',
         left: '0px',
         top: '0px',
-        transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(${DICE_SMALL_SCALE})`,
+        transform: `translate(${endX}px, ${endY}px) scale(${DICE_SMALL_SCALE})`,
         pointerEvents: 'none',
         zIndex: 50,
       });
@@ -2098,7 +2105,7 @@ export default function SnakeAndLadder() {
         <div className="fixed bottom-52 inset-x-0 flex justify-center z-30 pointer-events-none">
           <div
             className="text-7xl roll-result"
-            style={{ color: rollColor, transform: 'translate(0.5rem, -0.25rem)' }}
+            style={{ color: rollColor, transform: 'translate(-0.25rem, -0.75rem)' }}
           >
             {rollResult}
           </div>


### PR DESCRIPTION
## Summary
- resize dice icons and layer them above tokens
- position dice roll animation a little higher and left
- drop the dice onto tokens slightly above their photo

## Testing
- `npm test` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871097933488329b7df1850bdd56b11