### PR TITLE
Fix Crazy Dice background

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1280,7 +1280,6 @@ input:focus {
   width: 100vw;
   height: 100vh;
   overflow: hidden;
-  transform: translate(-3%, 0);
 }
 .crazy-dice-board .board-bg {
   position: absolute;
@@ -1289,9 +1288,8 @@ input:focus {
   height: 100%;
   object-fit: cover;
   object-position: center;
-  /* Make the board image larger, move it further toward side #3 and
-     increase the vertical scale so sides 1 and 2 cover the empty space */
-  transform: translate(8%, 0) scale(1.15, 1.12);
+  /* Cover the whole screen without leaving gaps */
+  transform: none;
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- remove extra transforms from Crazy Dice board
- ensure the board background covers the entire screen

## Testing
- `npm test` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_68710b0a12ac832997415d9759b5eb30