### PR TITLE
Adjust Crazy Dice board layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1289,9 +1289,9 @@ input:focus {
   height: 100%;
   object-fit: cover;
   object-position: center;
-  /* Make the board image larger, move it further toward side #3 and
-     increase the vertical scale so sides 1 and 2 cover the empty space */
-  transform: translate(8%, 0) scale(1.15, 1.12);
+  /* Make the board image larger, move it slightly toward side #3 and
+     expand vertically so sides 1 and 2 cover the empty space */
+  transform: translate(6%, 0) scale(1.15, 1.15);
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- tweak Crazy Dice board positioning and scaling so markers are better aligned

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687115b16fcc8329bcc08d0f8452c93d