### PR TITLE
Fix Crazy Dice board background

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1291,7 +1291,8 @@ input:focus {
   object-position: center;
   /* Make the board image larger, move it slightly toward side #3 and
      expand vertically so sides 1 and 2 cover the empty space */
-  transform: translate(6%, 0) scale(1.15, 1.15);
+  /* Shift the image slightly left so side #3 is not as cropped */
+  transform: translate(4%, 0) scale(1.15, 1.15);
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- move Crazy Dice Duel board background slightly to the left

## Testing
- `npm test` *(fails: test suite has failing cases)*

------
https://chatgpt.com/codex/tasks/task_e_68711989e47883299fb1a13bca7bf274