### PR TITLE
Adjust Crazy Dice board background

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -13,7 +13,6 @@ import Footer from './Footer.jsx';
 
 import Branding from './Branding.jsx';
 
-import CosmicBackground from './CosmicBackground.jsx';
 import DynamicBackground from './DynamicBackground.jsx';
 import SkyBackground from './SkyBackground.jsx';
 
@@ -91,7 +90,8 @@ export default function Layout({ children }) {
 
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
 
-      <CosmicBackground />
+      {/* Removed the starry cosmic background */}
+
 
       <main className={`flex-grow container mx-auto p-4 ${showNavbar ? 'pb-24' : ''}`.trim()}>
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1280,7 +1280,8 @@ input:focus {
   width: 100vw;
   height: 100vh;
   overflow: hidden;
-  transform: translate(-3%, 0);
+  /* Allow full view without locking the layout */
+  transform: translate(0, 0);
 }
 .crazy-dice-board .board-bg {
   position: absolute;
@@ -1292,7 +1293,8 @@ input:focus {
   /* Make the board image larger, move it slightly toward side #3 and
      expand vertically so sides 1 and 2 cover the empty space */
   /* Shift the image slightly left so side #3 is not as cropped */
-  transform: translate(4%, 0) scale(1.15, 1.15);
+  /* Shift board slightly left and make it a bit taller */
+  transform: translate(-2%, 0) scale(1.15, 1.2);
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- remove cosmic background from layout
- reposition Crazy Dice Duel board
- slightly increase board image height

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68711d19da308329a8876ba4c6bf7990