### PR TITLE
Fix double gap on dice board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1280,8 +1280,7 @@ input:focus {
   width: 100vw;
   height: 100vh;
   overflow: hidden;
-  /* Allow full view without locking the layout */
-  transform: translate(0, 0);
+  transform: translate(-3%, 0);
 }
 .crazy-dice-board .board-bg {
   position: absolute;
@@ -1293,8 +1292,7 @@ input:focus {
   /* Make the board image larger, move it slightly toward side #3 and
      expand vertically so sides 1 and 2 cover the empty space */
   /* Shift the image slightly left so side #3 is not as cropped */
-  /* Shift board slightly left and make it a bit taller */
-  transform: translate(-2%, 0) scale(1.15, 1.2);
+  transform: translate(4%, 0) scale(1.15, 1.15);
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- undo incorrect board positioning causing double gap

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68712269fc808329a829642a63106e41