### PR TITLE
Update dice result positions

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -651,8 +651,10 @@ export default function SnakeAndLadder() {
   // Dice landing spot (matches roll result text position)
   const RESULT_BOTTOM = 13 * 16; // tailwind bottom-52 -> 13rem
   // Slightly offset the dice roll landing spot so it sits a bit right and higher
-  const RESULT_OFFSET_X = 12; // small right shift of text
-  const RESULT_OFFSET_Y = -32; // lift the result slightly
+  // Shift the dice landing spot a bit further right so the
+  // dice doesn't overlap the roll result number
+  const RESULT_OFFSET_X = 20; // increased right shift
+  const RESULT_OFFSET_Y = -32; // keep the same vertical position
 
   useEffect(() => {
     prepareDiceAnimation(0);
@@ -2108,7 +2110,9 @@ export default function SnakeAndLadder() {
         <div className="fixed bottom-52 inset-x-0 flex justify-center z-30 pointer-events-none">
           <div
             className="text-7xl roll-result"
-            style={{ color: rollColor, transform: 'translate(0.5rem, -1.5rem)' }}
+            // Move the number slightly up and to the right so it
+            // doesn't overlap the dice image
+            style={{ color: rollColor, transform: 'translate(1rem, -2rem)' }}
           >
             {rollResult}
           </div>


### PR DESCRIPTION
## Summary
- nudge dice landing position further right
- shift roll result text up and right

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND, test timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68712aedea9c832984bfe1d49f04c7b0