### PR TITLE
Ensure crazy dice board fits phone screens

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1280,19 +1280,16 @@ input:focus {
   width: 100vw;
   height: 100vh;
   overflow: hidden;
-  transform: translate(-2%, 0); /* slightly recenter board */
+  /* Ensure the entire board image is visible */
 }
 .crazy-dice-board .board-bg {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
   object-position: center;
-  /* Make the board image larger, move it slightly toward side #3 and
-     expand vertically so sides 1 and 2 cover the empty space */
-  /* Shift the image slightly left so side #3 is not as cropped */
-  transform: translate(-8%, 0) scale(1.1, 1.1); /* zoomed out a bit */
+  transform: none;
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- tweak CSS for crazy dice board so the image scales within phone screens using `object-fit: contain`

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_6871307cf190832998017b3d36f68964