### PR TITLE
Fix crazy dice board gap

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1289,7 +1289,8 @@ input:focus {
   height: 100%;
   object-fit: contain;
   object-position: center;
-  transform: none;
+  /* Scale the board slightly to remove visible gaps */
+  transform: scale(1.02, 1.1);
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- tweak crazy dice board background scaling to remove gaps

## Testing
- `npm test` *(fails: test timeout and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6871378aef00832981d0f35021ea5388