### PR TITLE
Adjust dice result position and avatar sizes

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -246,9 +246,9 @@ input:focus {
 /* Three.js token container */
 .token-three {
   position: absolute;
-  /* shrink token by another 20% */
-  width: 7.2rem;
-  height: 7.2rem;
+  /* shrink token slightly */
+  width: 6.6rem;
+  height: 6.6rem;
   /* lower the token an additional 5% */
   transform: translateZ(32px);
   /* Preserve 3D space so the photo can be positioned in depth */
@@ -299,8 +299,8 @@ input:focus {
 
 /* Larger token variant used for inactive pieces */
 .token-three.inactive {
-  width: 7.2rem;
-  height: 7.2rem;
+  width: 6.6rem;
+  height: 6.6rem;
   transform: translateZ(32px);
 }
 
@@ -316,9 +316,9 @@ input:focus {
 
 .pot-token {
   /* enlarge pot token 50% further */
-  width: 16.2rem;
-  height: 16.2rem;
-  transform: translateY(-9rem);
+  width: 14.8rem;
+  height: 14.8rem;
+  transform: translateY(-8rem);
 }
 
 .pot-icon {
@@ -341,8 +341,8 @@ input:focus {
 
 .token-photo {
   position: absolute;
-  width: 2.9rem;
-  height: 2.9rem;
+  width: 2.7rem;
+  height: 2.7rem;
   top: 50%;
   left: 50%;
   transform-origin: center;
@@ -363,8 +363,8 @@ input:focus {
 .timer-ring {
   position: absolute;
   /* match the player photo size so the ring wraps perfectly */
-  width: 2.9rem;
-  height: 2.9rem;
+  width: 2.7rem;
+  height: 2.7rem;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) translateZ(15.2px)

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2112,7 +2112,7 @@ export default function SnakeAndLadder() {
             className="text-7xl roll-result"
             // Move the number slightly higher so it's clearer on small screens
             // and still shifted right so it doesn't overlap the dice image
-            style={{ color: rollColor, transform: 'translate(1rem, -4rem)' }}
+            style={{ color: rollColor, transform: 'translate(1rem, -6rem)' }}
           >
             {rollResult}
           </div>


### PR DESCRIPTION
## Summary
- reposition Snake & Ladder dice result higher
- shrink avatars and matching timer ring
- slightly reduce pot token size for consistency

## Testing
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68713b46b53083298716cc5c84db0b2d