### PR TITLE
Shift leaderboard left

### DIFF
--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -120,7 +120,7 @@ export default function LeaderboardCard() {
     <>
       <section
         id="leaderboard"
-        className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card mt-4"
+        className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card mt-4 -ml-2"
       >
         <img
           src="/assets/SnakeLaddersbackground.png"


### PR DESCRIPTION
## Summary
- adjust leaderboard card spacing so it sits slightly left

## Testing
- `npm test` *(fails: cannot find packages dotenv, mongoose, socket.io-client)*

------
https://chatgpt.com/codex/tasks/task_e_68713e7497ac83298b2d3468f2aeead6