### PR TITLE
Fix dice orientation and tweak leaderboard

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -35,8 +35,8 @@ const diceFaces = {
   ],
 };
 
-// Gentle tilt so three faces are visible
-const baseTilt = "rotateX(-25deg) rotateY(25deg)";
+// Isometric tilt so three faces are equally visible
+const baseTilt = "rotateX(-35deg) rotateY(45deg)";
 
 // Orientation for each numbered face relative to the viewer
 

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -120,7 +120,7 @@ export default function LeaderboardCard() {
     <>
       <section
         id="leaderboard"
-        className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card mt-4 -ml-2"
+        className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card mt-4 -ml-3"
       >
         <img
           src="/assets/SnakeLaddersbackground.png"


### PR DESCRIPTION
## Summary
- adjust cube tilt so all three dice faces have equal visibility
- nudge leaderboard section slightly left

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687143d273d4832998a902611b2e4b1a