### PR TITLE
Update Crazy Dice Duel background

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1287,10 +1287,8 @@ input:focus {
   inset: 0;
   width: 100%;
   height: 100%;
-  object-fit: contain;
+  object-fit: cover;
   object-position: center;
-  /* Scale the board slightly to remove visible gaps */
-  transform: scale(1.02, 1.1);
   filter: brightness(1.2);
   z-index: -1;
 }

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -277,7 +277,7 @@ export default function CrazyDiceDuel() {
   return (
     <div className="crazy-dice-board text-text" ref={boardRef}>
       <img
-        src="/assets/icons/file_00000000316461fdac87111607fc8ada%20(1).png"
+        src="/assets/icons/file_00000000d410620a8c1878be43e192a1.png"
         alt="board"
         className="board-bg"
       />


### PR DESCRIPTION
## Summary
- switch Crazy Dice Duel board background image
- adjust board CSS so the image covers the full screen with no gaps

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_68714944265883298a72f75babba0515