### PR TITLE
Adjust snake leaderboard layout

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -18,7 +18,7 @@ export default function AvatarTimer({
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
   return (
-    <div className="relative w-14 h-14" onClick={onClick} data-player-index={index}>
+    <div className="relative w-[3.25rem] h-[3.25rem]" onClick={onClick} data-player-index={index}>
       {/* turn indicator removed */}
       {active && (
         <div className="avatar-timer-ring" style={{ '--timer-gradient': gradient }} />
@@ -26,7 +26,7 @@ export default function AvatarTimer({
       <img
         src={getAvatarUrl(photoUrl)}
         alt="player"
-        className="w-14 h-14 rounded-full border-2 object-cover"
+        className="w-[3.25rem] h-[3.25rem] rounded-full border-2 object-cover"
         style={{
           borderColor: color || '#fde047',
           boxShadow: isTurn ? `0 0 6px ${color || '#fde047'}` : undefined,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -821,7 +821,7 @@ export default function SnakeAndLadder() {
     if (!dice || !endEl) return;
     const e = endEl.getBoundingClientRect();
     // Land slightly to the right of the avatar centre
-    const endX = e.left + e.width / 2 + 14;
+    const endX = e.left + e.width / 2 + 10;
     const endY = e.top + e.height / 2;
     const { cx, cy } = getDiceCenter();
     dice.animate(
@@ -1923,7 +1923,7 @@ export default function SnakeAndLadder() {
         onGift={() => setShowGift(true)}
       />
       {/* Player photos stacked vertically */}
-      <div className="fixed left-1 top-[40%] -translate-y-1/2 flex flex-col space-y-4 z-20">
+      <div className="fixed left-0 top-[40%] -translate-y-1/2 flex flex-col space-y-3 z-20">
         {players
           .map((p, i) => ({ ...p, index: i }))
           .map((p) => (


### PR DESCRIPTION
## Summary
- tweak leaderboard alignment and avatar spacing
- slightly reduce avatar size
- shift dice landing position

## Testing
- `npm test` *(fails: snake/ludo tests)*

------
https://chatgpt.com/codex/tasks/task_e_68714b70c010832983ceaf6f93f6b2da