### PR TITLE
Fix board alignment for Crazy Dice

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1288,7 +1288,8 @@ input:focus {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  object-position: center;
+  /* Shift the board slightly up and left so the phone edge aligns with the screen */
+  object-position: left top;
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- tweak Crazy Dice board background to align to the top-left corner

## Testing
- `npm test` *(fails: test timed out, missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68714c3132dc8329822b351b935f7914