### PR TITLE
Adjust Crazy Dice board background position

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1288,8 +1288,8 @@ input:focus {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  /* Shift the board slightly up and left so the phone edge aligns with the screen */
-  object-position: left top;
+  /* Shift the board slightly to the right so the phone edge aligns with the screen */
+  object-position: 5% top;
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- tweak board image position in Crazy Dice Duel so it shifts slightly right

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_687153e7564c8329b46bf8787638278f