### PR TITLE
Adjust snake board visuals

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -323,12 +323,12 @@ input:focus {
 
 .pot-icon {
   position: absolute;
-  width: 3rem;
-  height: 3rem;
+  width: 4rem;
+  height: 4rem;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -110%) translateZ(20px)
-    rotateX(calc(var(--board-angle, 58deg) * -1 - 10deg));
+    rotateX(calc(var(--board-angle, 58deg) * -1 + 20deg));
   pointer-events: none;
   z-index: 3;
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -295,7 +295,9 @@ function Board({
                       : 'ladder-text'
                   }`}
                 >
-                  {offsetVal > 0 ? `+${offsetVal}` : offsetVal}
+                  {cellType === 'snake'
+                    ? `-${offsetVal}`
+                    : `+${offsetVal}`}
                 </span>
               )}
             </span>
@@ -1923,7 +1925,7 @@ export default function SnakeAndLadder() {
         onGift={() => setShowGift(true)}
       />
       {/* Player photos stacked vertically */}
-      <div className="fixed left-0 top-[40%] -translate-y-1/2 flex flex-col space-y-3 z-20">
+        <div className="fixed left-0 top-[40%] -translate-y-1/2 flex flex-col space-y-5 z-20">
         {players
           .map((p, i) => ({ ...p, index: i }))
           .map((p) => (


### PR DESCRIPTION
## Summary
- expand spacing between player avatars on Snake and Ladder board
- show negative values for snake offsets
- make pot coin larger and adjust angle

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687156a320e08329b80cdcd971dd391b