### PR TITLE
Fix crazy dice board background gap

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1288,8 +1288,8 @@ input:focus {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  /* Shift the board slightly to the right so the phone edge aligns with the screen */
-  object-position: 5% top;
+  /* Center the board background so it fills the screen evenly */
+  object-position: center top;
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- center the Crazy Dice board background so no space shows on the left

## Testing
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_687161ab9b7483299e73b2412c3bcf6f