### PR TITLE
Fix left gap on Crazy Dice Duel page

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -10,6 +10,7 @@
 
 body {
   font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
   @apply bg-background text-text overflow-x-hidden;
   text-shadow: 0 0 4px #00f7ff;
 }


### PR DESCRIPTION
## Summary
- remove default body margin to eliminate left gap in webapp

## Testing
- `npm test` *(fails: cannot find package 'dotenv' & others)*

------
https://chatgpt.com/codex/tasks/task_e_687170151bf08329a478562a60e63e13