### PR TITLE
Fix crazy dice background alignment

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1289,8 +1289,8 @@ input:focus {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  /* Center the board background so it fills the screen evenly */
-  object-position: left top;
+  /* Nudge the board slightly left so the "3" side aligns with the icons */
+  object-position: -4px top;
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- align Crazy Dice Duel board with left icons so side 3 lines up properly

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687173ae4b548329b0b85e2d44c508f2