### PR TITLE
Fix Crazy Dice Duel background alignment

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1289,8 +1289,8 @@ input:focus {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  /* Center the board background so it fills the screen evenly */
-  object-position: left top;
+  /* Nudge the board slightly left so the "3" side aligns with the icons */
+  object-position: -4px top;
   filter: brightness(1.2);
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- nudge the Crazy Dice Duel background slightly left so side 3 is visible

## Testing
- `npm test` *(fails: Cannot find package 'dotenv' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6871788116948329bb09db2328ff2d93