### PR TITLE
Add social links to homepage and update task URLs

### DIFF
--- a/bot/utils/tasksData.js
+++ b/bot/utils/tasksData.js
@@ -10,7 +10,7 @@ export const TASKS = [
 
     icon: 'twitter',
 
-    link: 'https://x.com/TonPlaygram'
+  link: 'https://x.com/TonPlaygram?t=SyGyXA0H8PdLz7z2kfIWQw&s=09'
 
   },
 
@@ -24,7 +24,7 @@ export const TASKS = [
 
     icon: 'telegram',
 
-    link: 'https://t.me/TonPlaygramCommunity'
+  link: 'https://t.me/TonPlaygram'
 
   },
 
@@ -38,7 +38,7 @@ export const TASKS = [
 
     icon: 'tiktok',
 
-    link: 'https://tiktok.com/@TonPlaygram'
+  link: 'https://www.tiktok.com/@tonplaygram?_t=ZS-8xxPL1nbD9U&_r=1'
 
   }
 

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -13,6 +13,8 @@ import {
   FaArrowCircleDown,
   FaWallet
 } from 'react-icons/fa';
+import { IoLogoTwitter, IoLogoTiktok } from 'react-icons/io5';
+import { RiTelegramFill } from 'react-icons/ri';
 import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 
 import { Link } from 'react-router-dom';
@@ -391,6 +393,29 @@ export default function Home() {
         </div>
       )}
 
+      <div className="flex justify-center space-x-4 mt-4">
+        <a
+          href="https://x.com/TonPlaygram?t=SyGyXA0H8PdLz7z2kfIWQw&s=09"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <IoLogoTwitter className="text-sky-400 w-6 h-6" />
+        </a>
+        <a
+          href="https://t.me/TonPlaygram"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <RiTelegramFill className="text-sky-400 w-6 h-6" />
+        </a>
+        <a
+          href="https://www.tiktok.com/@tonplaygram?_t=ZS-8xxPL1nbD9U&_r=1"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <IoLogoTiktok className="text-pink-500 w-6 h-6" />
+        </a>
+      </div>
       <p className="text-center text-xs text-subtext">Status: {status}</p>
 
 


### PR DESCRIPTION
## Summary
- update X, Telegram and TikTok URLs for tasks
- import icons on Home page
- show X, Telegram and TikTok icons with links at the bottom of the homepage

## Testing
- `npm test` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871eb264b90832983640aea1a59d353