### PR TITLE
Add retweet verification task

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
    - `DEV_ACCOUNT_ID_1` – (optional) secondary developer account (1% share)
    - `DEV_ACCOUNT_ID_2` – (optional) secondary developer account (2% share)
    - `API_AUTH_TOKEN` – (optional) token for trusted server-to-server calls
+   - `TWITTER_BEARER_TOKEN` – bearer token for verifying retweets
 
 4. Copy `webapp/.env.example` to `webapp/.env` and configure:
    - `VITE_API_BASE_URL` – the base URL where the bot API is hosted (e.g. `http://localhost:3000`).

--- a/bot/package.json
+++ b/bot/package.json
@@ -18,6 +18,7 @@
     "socket.io": "^4.7.5",
     "telegraf": "^4.12.2",
     "tonweb": "^0.0.66",
+    "twitter-api-v2": "^1.24.0",
     "uuid": "^9.0.1"
   }
 }

--- a/bot/routes/tasks.js
+++ b/bot/routes/tasks.js
@@ -3,8 +3,12 @@ import Task from '../models/Task.js';
 import User from '../models/User.js';
 import { TASKS } from '../utils/tasksData.js';
 import { ensureTransactionArray } from '../utils/userUtils.js';
+import { TwitterApi } from 'twitter-api-v2';
 
 const router = Router();
+const twitterClient = process.env.TWITTER_BEARER_TOKEN
+  ? new TwitterApi(process.env.TWITTER_BEARER_TOKEN)
+  : null;
 
 router.post('/list', async (req, res) => {
   const { telegramId } = req.body;
@@ -44,6 +48,78 @@ router.post('/complete', async (req, res) => {
   await user.save();
 
   res.json({ message: 'completed', reward: config.reward });
+});
+
+router.post('/verify-retweet', async (req, res) => {
+  const { telegramId, tweetUrl } = req.body;
+  if (!telegramId || !tweetUrl) {
+    return res.status(400).json({ error: 'telegramId and tweetUrl required' });
+  }
+
+  const config = TASKS.find((t) => t.id === 'retweet_post');
+  if (!config) return res.status(500).json({ error: 'task not configured' });
+
+  const existing = await Task.findOne({ telegramId, taskId: 'retweet_post' });
+  if (existing) return res.json({ message: 'already completed' });
+
+  if (!twitterClient) {
+    return res.status(500).json({ error: 'Twitter API not configured' });
+  }
+
+  const targetId = (config.link.match(/status\/(\d+)/) || [])[1];
+  const providedId = (tweetUrl.match(/status\/(\d+)/) || [])[1];
+  if (!targetId || !providedId) {
+    return res.status(400).json({ error: 'invalid tweet URL' });
+  }
+
+  try {
+    const tweet = await twitterClient.v2.singleTweet(providedId, {
+      expansions: ['author_id', 'referenced_tweets.id'],
+      'tweet.fields': ['author_id', 'referenced_tweets']
+    });
+
+    const author = await twitterClient.v2.user(tweet.data.author_id);
+    const user = await User.findOne({ telegramId });
+    const linked = user?.social?.twitter?.replace(/^@/, '');
+    if (!linked || author.data.username.toLowerCase() !== linked.toLowerCase()) {
+      return res.status(400).json({ error: 'twitter handle mismatch' });
+    }
+
+    let valid = false;
+    if (tweet.data.referenced_tweets) {
+      valid = tweet.data.referenced_tweets.some((r) => r.id === targetId);
+    }
+    if (!valid) {
+      const [likes, rts] = await Promise.all([
+        twitterClient.v2.tweetLikedBy(targetId, { asPaginator: false }),
+        twitterClient.v2.tweetRetweetedBy(targetId, { asPaginator: false })
+      ]);
+      const uid = tweet.data.author_id;
+      const liked = likes.data?.some((u) => u.id === uid);
+      const retweeted = rts.data?.some((u) => u.id === uid);
+      valid = liked || retweeted;
+    }
+
+    if (!valid) {
+      return res.status(400).json({ error: 'retweet/like/comment not found' });
+    }
+
+    await Task.create({ telegramId, taskId: 'retweet_post', completedAt: new Date() });
+    ensureTransactionArray(user);
+    user.minedTPC += config.reward;
+    user.transactions.push({
+      amount: config.reward,
+      type: 'task',
+      status: 'pending',
+      date: new Date()
+    });
+    await user.save();
+
+    res.json({ message: 'verified', reward: config.reward });
+  } catch (err) {
+    console.error('verify-retweet failed:', err.message);
+    res.status(500).json({ error: 'verification failed' });
+  }
 });
 
 export default router;

--- a/bot/utils/tasksData.js
+++ b/bot/utils/tasksData.js
@@ -40,6 +40,20 @@ export const TASKS = [
 
   link: 'https://www.tiktok.com/@tonplaygram?_t=ZS-8xxPL1nbD9U&_r=1'
 
+  },
+
+  {
+
+    id: 'retweet_post',
+
+    description: 'Retweet our post',
+
+    reward: 2500,
+
+    icon: 'twitter',
+
+  link: 'https://x.com/TonPlaygram/status/1234567890'
+
   }
 
 ];

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import {
   listTasks,
   completeTask,
+  verifyRetweet,
   getAdStatus,
   watchAd,
   dailyCheckIn,
@@ -26,8 +27,9 @@ const ICONS = {
   join_twitter: <IoLogoTwitter className="text-sky-400 w-5 h-5" />,
 
   join_telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
-
+  
   follow_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
+  retweet_post: <IoLogoTwitter className="text-sky-400 w-5 h-5" />,
   watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />
 
 };
@@ -50,6 +52,7 @@ export default function TasksCard() {
   const [tasks, setTasks] = useState(null);
   const [adCount, setAdCount] = useState(0);
   const [showAd, setShowAd] = useState(false);
+  const [retweetLink, setRetweetLink] = useState('');
   const walletAddress = useTonAddress();
   const [tonConnectUI] = useTonConnectUI();
   const [streak, setStreak] = useState(1);
@@ -96,6 +99,18 @@ export default function TasksCard() {
 
     load();
 
+  };
+
+  const handleRetweet = async () => {
+    if (!retweetLink) return;
+    const res = await verifyRetweet(telegramId, retweetLink);
+    if (!res.error) {
+      await completeTask(telegramId, 'retweet_post');
+      setRetweetLink('');
+      load();
+    } else {
+      alert(res.error);
+    }
   };
 
   const handleDailyCheck = async () => {
@@ -208,6 +223,21 @@ export default function TasksCard() {
               <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
               {t.completed ? (
                 <span className="text-green-500 font-semibold text-sm">Done</span>
+              ) : t.id === 'retweet_post' ? (
+                <div className="flex items-center gap-2">
+                  <input
+                    value={retweetLink}
+                    onChange={(e) => setRetweetLink(e.target.value)}
+                    placeholder="Retweet link"
+                    className="px-1 py-0.5 text-xs bg-surface border border-border rounded"
+                  />
+                  <button
+                    onClick={handleRetweet}
+                    className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded"
+                  >
+                    Verify
+                  </button>
+                </div>
               ) : (
                 <button
                   onClick={() => handleClaim(t)}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -83,6 +83,10 @@ export function completeTask(telegramId, taskId) {
 
 }
 
+export function verifyRetweet(telegramId, tweetUrl) {
+  return post('/api/tasks/verify-retweet', { telegramId, tweetUrl });
+}
+
 export function listVideos(telegramId) {
 
   return post('/api/watch/list', { telegramId });


### PR DESCRIPTION
## Summary
- add new `retweet_post` task
- verify retweets via Twitter API
- expose verifyRetweet API call in webapp
- handle retweet input in `TasksCard`
- document Twitter creds

## Testing
- `npm test` *(fails: Cannot find package 'socket.io-client')*

------
https://chatgpt.com/codex/tasks/task_e_6871f91893e0832984a3d552fdc59929