### PR TITLE
Add Twitter Post task with verification

### DIFF
--- a/bot/models/PostRecord.js
+++ b/bot/models/PostRecord.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const postRecordSchema = new mongoose.Schema({
+  telegramId: { type: Number, required: true },
+  tweetId: { type: String, required: true },
+  postedAt: { type: Date, default: Date.now }
+});
+
+postRecordSchema.index({ telegramId: 1, postedAt: 1 });
+
+export default mongoose.model('PostRecord', postRecordSchema);

--- a/bot/utils/tasksData.js
+++ b/bot/utils/tasksData.js
@@ -43,17 +43,19 @@ export const TASKS = [
   },
 
   {
-
-    id: 'retweet_post',
-
-    description: 'Like, comment and repost this tweet',
-
-    reward: 2500,
-
+    id: 'post_tweet',
+    description: 'Share a TonPlaygram update on X',
+    reward: 5000,
     icon: 'twitter',
-
-  link: 'https://x.com/TonPlaygram/status/1943907328652402954?t=KV_XywSPiqk0dJVDGPXocA&s=19'
-
+    posts: [
+      `Tokenomics Drop \uD83E\uDE99\n\n\uD83D\uDEA8 TonPlaygram Tokenomics Revealed \uD83D\uDEA8\n\n1B $TPC \u2014 Fixed Supply\n\u2705 40% Play-to-Earn & Mining\n\u2705 20% Liquidity & Ecosystem\n\u2705 15% Team (Vested)\n\u2705 10% Dev/Treasury\n\u2705 Smart contracts power it all.\nLet\u2019s build GameFi on TON.\n\uD83D\uDCDC https://tonplaygramwebapp.onrender.com\n\n#TON #GameFi #CryptoGaming`,
+      `Game Fee Model \uD83E\uDEAE\n\nEvery winner pays a 10% fee. Here\u2019s where it goes \uD83D\uDC47\n\n\uD83D\uDD25 3% Buyback & Burn\n\uD83E\uDD01 3% Dev/Operations\n\uD83C\uDFC6 2% Ecosystem Rewards\n\uD83D\uDCA7 1% Liquidity\n\uD83D\uDCE3 1% Marketing\n\n\uD83D\uDCB0 90% goes to the winner.\nPlay. Earn. Burn. Repeat.\n#TonPlaygram $TPC #PlayToEarn`,
+      `Roadmap to 2027 \uD83D\uDE80\n\nWhat\u2019s coming for @TonPlaygram?\n\n\uD83D\uDCF1 Mobile App\n\uD83D\uDDF3\uFE0F DAO Governance\n\uD83C\uDFB2 More Games\n\uD83D\uDCB1 TON/USDT Tables\n\uD83D\uDCC8 CEX & DEX Listings\n\uD83D\uDD25 Emissions end by 2027 \u2192 Real demand kicks in\n\n#TONCommunity, we\u2019re just getting started \uD83D\uDC8E\n#Web3Gaming #TPC`,
+      `Built Different \uD83D\uDEE0\uFE0F + Tokenomics Tease\n\n\uD83D\uDD25 TonPlaygram is LIVE and growing fast:\n\n\u2705 Snake & Ladder Multiplayer\n\u2705 In-chat TPC Transfers\n\u2705 Presale Store, Mining, Spin Wheel\n\u2705 +2500 TPC for tasks (X, TikTok, TG)\n\nNow backed by 1B $TPC tokenomics:\n\uD83D\uDD10 40% Play-to-Earn\n\uD83D\uDCA7 20% Liquidity\n\uD83D\uDEE0\uFE0F 15% Team (Vested)\n\n\u27A1\uFE0F https://tonplaygramwebapp.onrender.com\n#GameFi #TON #TonPlaygram`,
+      `Real Utility, Real Progress \uD83D\uDCCA\n\nWe\u2019re not just a token. We\u2019re a platform.\n\n\uD83C\uDFAE Games? \u2705\n\u26CF\uFE0F Mining? \u2705\n\uD83C\uDF81 Airdrops? \u2705\n\uD83D\uDCAC Telegram\u2013WebApp sync? \u2705\n\uD83D\uDCF2 Mobile App next.\n\nAnd our 1B $TPC is fully governed by smart contracts.\n\u274C No inflation.\n\uD83D\uDD25 3% Burn on every game.\nLet\u2019s GameFi $TON.\n#TonPlaygram #PlayToEarn`,
+      `From Zero to Roadmap \uD83D\uDE80\n\nIn 6 months:\n\n\uD83D\uDCE6 Presale Store live\n\uD83D\uDC65 Friend & Chat system\n\uD83D\uDCB8 Wallet: TPC auto-delivery\n\uD83C\uDDE4\uFE0F Spin & Boost packs\n\uD83C\uDFC6 7 token-holding wallets\n\nNow launching:\n\n\uD83D\uDDF3\uFE0F DAO\n\uD83D\uDCF1 Mobile App\n\uD83D\uDCC8 CEX/DEX listings\n\nTPC = The future of TON gaming.\n#CryptoGaming #TonPlaygram $TPC`,
+      `\uD83D\uDD25 TonPlaygram is LIVE \u2014 not just another GameFi idea, but a full ecosystem already delivering:\n\n\uD83C\uDFAE Snake & Ladder Multiplayer (1v1 & 4P)\n\uD83D\uDCAC Real-time friend list & in-game chat\n\uD83E\uDDD1\u200D\uD83D\uDCBB Telegram \u2194 WebApp synced wallet & mining\n\uD83D\uDECD\uFE0F Presale Store + Bonus Packs + Spin Wheel\n\uD83D\uDCF2 Watch Ads, Daily Check-ins, and Social Tasks\n\uD83D\uDCB0 Earn up to +2,500 TPC for TikTok, X, Telegram`
+    ]
   }
 
 ];

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import {
   listTasks,
   completeTask,
-  verifyRetweet,
+  verifyPost,
   getAdStatus,
   watchAd,
   dailyCheckIn,
@@ -29,7 +29,7 @@ const ICONS = {
   join_telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
   
   follow_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-  retweet_post: <IoLogoTwitter className="text-sky-400 w-5 h-5" />,
+  post_tweet: <IoLogoTwitter className="text-sky-400 w-5 h-5" />,
   watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />
 
 };
@@ -52,7 +52,7 @@ export default function TasksCard() {
   const [tasks, setTasks] = useState(null);
   const [adCount, setAdCount] = useState(0);
   const [showAd, setShowAd] = useState(false);
-  const [retweetLink, setRetweetLink] = useState('');
+  const [postLink, setPostLink] = useState('');
   const walletAddress = useTonAddress();
   const [tonConnectUI] = useTonConnectUI();
   const [streak, setStreak] = useState(1);
@@ -101,12 +101,12 @@ export default function TasksCard() {
 
   };
 
-  const handleRetweet = async () => {
-    if (!retweetLink) return;
-    const res = await verifyRetweet(telegramId, retweetLink);
+  const handlePostVerify = async () => {
+    if (!postLink) return;
+    const res = await verifyPost(telegramId, postLink);
     if (!res.error) {
-      await completeTask(telegramId, 'retweet_post');
-      setRetweetLink('');
+      await completeTask(telegramId, 'post_tweet');
+      setPostLink('');
       load();
     } else {
       alert(res.error);
@@ -223,20 +223,37 @@ export default function TasksCard() {
               <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
               {t.completed ? (
                 <span className="text-green-500 font-semibold text-sm">Done</span>
-              ) : t.id === 'retweet_post' ? (
-                <div className="flex items-center gap-2">
-                  <input
-                    value={retweetLink}
-                    onChange={(e) => setRetweetLink(e.target.value)}
-                    placeholder="Retweet link"
-                    className="px-1 py-0.5 text-xs bg-surface border border-border rounded"
-                  />
-                  <button
-                    onClick={handleRetweet}
-                    className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded"
-                  >
-                    Verify
-                  </button>
+              ) : t.id === 'post_tweet' ? (
+                <div className="space-y-2 w-full">
+                  {t.posts.map((p, i) => (
+                    <div key={i} className="flex items-start gap-2 border border-border p-2 rounded">
+                      <textarea
+                        readOnly
+                        value={p}
+                        className="flex-1 text-xs bg-surface border-none resize-none"
+                      />
+                      <button
+                        onClick={() => navigator.clipboard.writeText(p)}
+                        className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded"
+                      >
+                        Copy
+                      </button>
+                    </div>
+                  ))}
+                  <div className="flex items-center gap-2">
+                    <input
+                      value={postLink}
+                      onChange={(e) => setPostLink(e.target.value)}
+                      placeholder="Tweet link"
+                      className="px-1 py-0.5 text-xs bg-surface border border-border rounded flex-1"
+                    />
+                    <button
+                      onClick={handlePostVerify}
+                      className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded"
+                    >
+                      Verify
+                    </button>
+                  </div>
                 </div>
               ) : (
                 <button

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -83,8 +83,8 @@ export function completeTask(telegramId, taskId) {
 
 }
 
-export function verifyRetweet(telegramId, tweetUrl) {
-  return post('/api/tasks/verify-retweet', { telegramId, tweetUrl });
+export function verifyPost(telegramId, tweetUrl) {
+  return post('/api/tasks/verify-post', { telegramId, tweetUrl });
 }
 
 export function listVideos(telegramId) {


### PR DESCRIPTION
## Summary
- create PostRecord model for tracking user tweets
- remove retweet task and add post_tweet task with prepared tweets
- verify user tweets via new `/verify-post` endpoint
- expose `verifyPost` to the webapp API
- display post task and posts with copy buttons on the tasks card and tasks page

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_687207dcb9dc8329bbbe997c97c19e2c