### PR TITLE
Add tweet posts popup

### DIFF
--- a/webapp/src/components/PostsModal.jsx
+++ b/webapp/src/components/PostsModal.jsx
@@ -1,0 +1,43 @@
+import { createPortal } from 'react-dom';
+
+export default function PostsModal({ open, posts = [], onClose }) {
+  if (!open) return null;
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface border border-border p-4 rounded space-y-2 w-80 text-text"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-lg font-bold text-center">Ready-Made Posts</h3>
+        {posts.map((p, i) => (
+          <div
+            key={i}
+            className="flex items-start gap-2 border border-border p-2 rounded"
+          >
+            <textarea
+              readOnly
+              value={p}
+              className="flex-1 text-xs bg-surface border-none resize-none"
+            />
+            <button
+              onClick={() => navigator.clipboard.writeText(p)}
+              className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded"
+            >
+              Copy
+            </button>
+          </div>
+        ))}
+        <button
+          onClick={onClose}
+          className="w-full px-4 py-1 bg-primary hover:bg-primary-hover rounded text-background"
+        >
+          Close
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -20,6 +20,7 @@ import { IoLogoTwitter, IoLogoTiktok } from 'react-icons/io5';
 import { RiTelegramFill } from 'react-icons/ri';
 import { FiVideo } from 'react-icons/fi';
 import AdModal from './AdModal.tsx';
+import PostsModal from './PostsModal.jsx';
 import { AiOutlineCheckSquare, AiOutlineCheck } from 'react-icons/ai';
 
 const ICONS = {
@@ -52,6 +53,7 @@ export default function TasksCard() {
   const [tasks, setTasks] = useState(null);
   const [adCount, setAdCount] = useState(0);
   const [showAd, setShowAd] = useState(false);
+  const [showPosts, setShowPosts] = useState(false);
   const [postLink, setPostLink] = useState('');
   const walletAddress = useTonAddress();
   const [tonConnectUI] = useTonConnectUI();
@@ -225,21 +227,12 @@ export default function TasksCard() {
                 <span className="text-green-500 font-semibold text-sm">Done</span>
               ) : t.id === 'post_tweet' ? (
                 <div className="space-y-2 w-full">
-                  {t.posts.map((p, i) => (
-                    <div key={i} className="flex items-start gap-2 border border-border p-2 rounded">
-                      <textarea
-                        readOnly
-                        value={p}
-                        className="flex-1 text-xs bg-surface border-none resize-none"
-                      />
-                      <button
-                        onClick={() => navigator.clipboard.writeText(p)}
-                        className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded"
-                      >
-                        Copy
-                      </button>
-                    </div>
-                  ))}
+                  <button
+                    onClick={() => setShowPosts(true)}
+                    className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded w-full"
+                  >
+                    View Posts
+                  </button>
                   <div className="flex items-center gap-2">
                     <input
                       value={postLink}
@@ -289,6 +282,11 @@ export default function TasksCard() {
         open={showAd}
         onComplete={handleAdComplete}
         onClose={() => setShowAd(false)}
+      />
+      <PostsModal
+        open={showPosts}
+        posts={tasks.find((t) => t.id === 'post_tweet')?.posts || []}
+        onClose={() => setShowPosts(false)}
       />
 
     </div>

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -19,6 +19,7 @@ import { RiTelegramFill } from 'react-icons/ri';
 import { FiVideo } from 'react-icons/fi';
 import { AiOutlineCheck } from 'react-icons/ai';
 import AdModal from '../components/AdModal.tsx';
+import PostsModal from '../components/PostsModal.jsx';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 import { STORE_ADDRESS } from '../utils/storeData.js';
@@ -40,6 +41,7 @@ export default function Tasks() {
   const [tasks, setTasks] = useState(null);
   const [adCount, setAdCount] = useState(0);
   const [showAd, setShowAd] = useState(false);
+  const [showPosts, setShowPosts] = useState(false);
   const [postLink, setPostLink] = useState('');
   const [category, setCategory] = useState('TonPlaygram');
   const [streak, setStreak] = useState(1);
@@ -207,12 +209,12 @@ export default function Tasks() {
                   <span className="text-green-500 font-semibold text-sm">Completed</span>
                 ) : t.id === 'post_tweet' ? (
                   <div className="space-y-2 w-full">
-                    {t.posts.map((p, i) => (
-                      <div key={i} className="flex items-start gap-2 border border-border p-2 rounded">
-                        <textarea readOnly value={p} className="flex-1 text-xs bg-surface border-none resize-none" />
-                        <button onClick={() => navigator.clipboard.writeText(p)} className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded">Copy</button>
-                      </div>
-                    ))}
+                    <button
+                      onClick={() => setShowPosts(true)}
+                      className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded w-full"
+                    >
+                      View Posts
+                    </button>
                     <div className="flex items-center gap-2">
                       <input
                         value={postLink}
@@ -261,6 +263,11 @@ export default function Tasks() {
         open={showAd}
         onComplete={handleAdComplete}
         onClose={() => setShowAd(false)}
+      />
+      <PostsModal
+        open={showPosts}
+        posts={tasks?.find((t) => t.id === 'post_tweet')?.posts || []}
+        onClose={() => setShowPosts(false)}
       />
 
     </div>


### PR DESCRIPTION
## Summary
- add `PostsModal` for viewing pre-made tweets
- open posts popup from Tasks cards
- use popup in Tasks page too

## Testing
- `npm test` *(fails: test suite has 4 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68720fd295b08329b6df44ac522cbfdf