### PR TITLE
Add missing TWITTER_BEARER_TOKEN example

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -12,6 +12,7 @@ PORT=3000
 # Comma-separated list of admin tokens for the airdrop API.
 # These tokens also authorize access to the /api/broadcast route.
 # AIRDROP_ADMIN_TOKENS=token1,token2
+# TWITTER_BEARER_TOKEN=your-twitter-bearer-token
 
 
 # TON deposit address that users will send funds to when topping up their


### PR DESCRIPTION
## Summary
- document TWITTER_BEARER_TOKEN in `bot/.env.example`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687216016a60832983382507026a01dd