### PR TITLE
Fix env loading for Twitter API

### DIFF
--- a/bot/loadEnv.js
+++ b/bot/loadEnv.js
@@ -1,0 +1,6 @@
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, '.env') });

--- a/bot/server.js
+++ b/bot/server.js
@@ -1,4 +1,4 @@
-import dotenv from 'dotenv';
+import './loadEnv.js';
 import express from 'express';
 import cors from 'cors';
 import bot from './bot.js';
@@ -30,7 +30,6 @@ import { execSync } from 'child_process';
 import compression from 'compression';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-dotenv.config({ path: path.join(__dirname, '.env') });
 
 if (proxyUrl) {
   console.log(`Using HTTPS proxy ${proxyUrl}`);


### PR DESCRIPTION
## Summary
- ensure bot uses `.env` config before requiring modules
- create `loadEnv.js` helper

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_68722022f6148329af09a99e519f0c9b