### PR TITLE
Add new TikTok task and popup notification

### DIFF
--- a/bot/routes/tasks.js
+++ b/bot/routes/tasks.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import Task from '../models/Task.js';
 import User from '../models/User.js';
-import { TASKS } from '../utils/tasksData.js';
+import { TASKS, TASKS_VERSION } from '../utils/tasksData.js';
 import { ensureTransactionArray } from '../utils/userUtils.js';
 import { TwitterApi } from 'twitter-api-v2';
 import PostRecord from '../models/PostRecord.js';
@@ -15,11 +15,13 @@ router.post('/list', async (req, res) => {
   const { telegramId } = req.body;
   if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
 
-  const tasks = await Promise.all(TASKS.map(async t => {
-    const rec = await Task.findOne({ telegramId, taskId: t.id });
-    return { ...t, completed: !!rec };
-  }));
-  res.json(tasks);
+  const tasks = await Promise.all(
+    TASKS.map(async (t) => {
+      const rec = await Task.findOne({ telegramId, taskId: t.id });
+      return { ...t, completed: !!rec };
+    })
+  );
+  res.json({ version: TASKS_VERSION, tasks });
 });
 
 router.post('/complete', async (req, res) => {

--- a/bot/utils/tasksData.js
+++ b/bot/utils/tasksData.js
@@ -1,3 +1,5 @@
+export const TASKS_VERSION = 2;
+
 export const TASKS = [
 
   {
@@ -39,7 +41,14 @@ export const TASKS = [
     icon: 'tiktok',
 
   link: 'https://www.tiktok.com/@tonplaygram?_t=ZS-8xxPL1nbD9U&_r=1'
+  },
 
+  {
+    id: 'boost_tiktok',
+    description: 'Like & repost our TikTok',
+    reward: 2000,
+    icon: 'tiktok',
+    link: 'https://vt.tiktok.com/ZSBXkX8pu/'
   },
 
   {

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -21,6 +21,7 @@ import { RiTelegramFill } from 'react-icons/ri';
 import { FiVideo } from 'react-icons/fi';
 import AdModal from './AdModal.tsx';
 import PostsModal from './PostsModal.jsx';
+import InfoPopup from './InfoPopup.jsx';
 import { AiOutlineCheckSquare, AiOutlineCheck } from 'react-icons/ai';
 
 const ICONS = {
@@ -30,6 +31,7 @@ const ICONS = {
   join_telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
   
   follow_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
+  boost_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
   post_tweet: <IoLogoTwitter className="text-sky-400 w-5 h-5" />,
   watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />
 
@@ -66,10 +68,19 @@ export default function TasksCard() {
     const ts = localStorage.getItem('lastOnchainCheck');
     return ts ? parseInt(ts, 10) : null;
   });
+  const [showNew, setShowNew] = useState(false);
 
   const load = async () => {
     const data = await listTasks(telegramId);
-    setTasks(data);
+    const tasksList = data.tasks || data;
+    setTasks(tasksList);
+    if (data.version) {
+      const seen = localStorage.getItem('tasksVersion');
+      if (seen !== String(data.version)) {
+        setShowNew(true);
+        localStorage.setItem('tasksVersion', String(data.version));
+      }
+    }
     const ad = await getAdStatus(telegramId);
     if (!ad.error) setAdCount(ad.count);
     try {
@@ -287,6 +298,12 @@ export default function TasksCard() {
         open={showPosts}
         posts={tasks.find((t) => t.id === 'post_tweet')?.posts || []}
         onClose={() => setShowPosts(false)}
+      />
+      <InfoPopup
+        open={showNew}
+        onClose={() => setShowNew(false)}
+        title="New Tasks"
+        info="We've added new tasks!"
       />
 
     </div>

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -22,6 +22,7 @@ import { FiVideo } from 'react-icons/fi';
 import { AiOutlineCheck } from 'react-icons/ai';
 import AdModal from '../components/AdModal.tsx';
 import PostsModal from '../components/PostsModal.jsx';
+import InfoPopup from '../components/InfoPopup.jsx';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 import { STORE_ADDRESS } from '../utils/storeData.js';
@@ -44,6 +45,7 @@ export default function Tasks() {
   const [adCount, setAdCount] = useState(0);
   const [showAd, setShowAd] = useState(false);
   const [showPosts, setShowPosts] = useState(false);
+  const [showNew, setShowNew] = useState(false);
   const [postLink, setPostLink] = useState('');
   const [category, setCategory] = useState('TonPlaygram');
   const [infTab, setInfTab] = useState('submit');
@@ -62,7 +64,15 @@ export default function Tasks() {
 
   const load = async () => {
     const data = await listTasks(telegramId);
-    setTasks(data);
+    const tasksList = data.tasks || data;
+    setTasks(tasksList);
+    if (data.version) {
+      const seen = localStorage.getItem('tasksVersion');
+      if (seen !== String(data.version)) {
+        setShowNew(true);
+        localStorage.setItem('tasksVersion', String(data.version));
+      }
+    }
     const ad = await getAdStatus(telegramId);
     if (!ad.error) setAdCount(ad.count);
     try {
@@ -159,6 +169,7 @@ export default function Tasks() {
     join_twitter: <IoLogoTwitter className="text-sky-400 w-5 h-5" />,
     join_telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
     follow_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
+    boost_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
     post_tweet: <IoLogoTwitter className="text-sky-400 w-5 h-5" />,
     watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />
   };
@@ -344,6 +355,12 @@ export default function Tasks() {
         open={showPosts}
         posts={tasks?.find((t) => t.id === 'post_tweet')?.posts || []}
         onClose={() => setShowPosts(false)}
+      />
+      <InfoPopup
+        open={showNew}
+        onClose={() => setShowNew(false)}
+        title="New Tasks"
+        info="We've added new tasks!"
       />
 
     </div>


### PR DESCRIPTION
## Summary
- introduce TASKS_VERSION for webapp notifications
- add `boost_tiktok` task rewarding 2000 TPC
- expose task version from `/api/tasks/list`
- show popup when tasks change

## Testing
- `npm run install-all`
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_687248c50da883299ac0f2761657e8dd