### PR TITLE
Add new tasks for Telegram and X engagement

### DIFF
--- a/bot/utils/tasksData.js
+++ b/bot/utils/tasksData.js
@@ -1,4 +1,4 @@
-export const TASKS_VERSION = 2;
+export const TASKS_VERSION = 3;
 
 export const TASKS = [
 
@@ -49,6 +49,22 @@ export const TASKS = [
     reward: 2000,
     icon: 'tiktok',
     link: 'https://vt.tiktok.com/ZSBXkX8pu/'
+  },
+
+  {
+    id: 'react_tg_post',
+    description: 'React to our group post',
+    reward: 2500,
+    icon: 'telegram',
+    link: 'https://t.me/TonPlaygram/1/16'
+  },
+
+  {
+    id: 'engage_tweet',
+    description: 'Like, comment & repost on X',
+    reward: 2500,
+    icon: 'twitter',
+    link: 'https://x.com/TonPlaygram/status/1943907328652402954?t=bG-Ps1S8rbJ-afx2OwcZhA&s=19'
   },
 
   {

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -31,8 +31,10 @@ const ICONS = {
   join_telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
   
   follow_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-  boost_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-  post_tweet: <IoLogoTwitter className="text-sky-400 w-5 h-5" />,
+  boost_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />, 
+  post_tweet: <IoLogoTwitter className="text-sky-400 w-5 h-5" />, 
+  react_tg_post: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
+  engage_tweet: <IoLogoTwitter className="text-sky-400 w-5 h-5" />,
   watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />
 
 };

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -171,6 +171,8 @@ export default function Tasks() {
     follow_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
     boost_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
     post_tweet: <IoLogoTwitter className="text-sky-400 w-5 h-5" />,
+    react_tg_post: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
+    engage_tweet: <IoLogoTwitter className="text-sky-400 w-5 h-5" />,
     watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />
   };
 


### PR DESCRIPTION
## Summary
- introduce new tasks for reacting to a Telegram post and engaging with a tweet
- bump `TASKS_VERSION`
- show icons for the new tasks

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_687250910c5c8329bb9da2952c2bc079