### PR TITLE
Add influencer rewards and claims card

### DIFF
--- a/webapp/src/components/InfluencerClaimsCard.jsx
+++ b/webapp/src/components/InfluencerClaimsCard.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { listAllInfluencer, verifyInfluencer } from '../utils/api.js';
+
+export default function InfluencerClaimsCard() {
+  const [tasks, setTasks] = useState([]);
+  const [views, setViews] = useState({});
+
+  const load = async () => {
+    const data = await listAllInfluencer();
+    if (!data.error) setTasks(data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handle = async (id, status) => {
+    const v = parseInt(views[id] || '0', 10);
+    await verifyInfluencer(id, status, v);
+    load();
+  };
+
+  return (
+    <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
+      <h3 className="font-semibold text-center">Influencer Claims</h3>
+      <ul className="space-y-2 w-full">
+        {tasks.map((t) => (
+          <li key={t._id} className="lobby-tile space-y-2">
+            <div className="text-sm break-all">{t.videoUrl}</div>
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                placeholder="Views"
+                value={views[t._id] || ''}
+                onChange={(e) => setViews({ ...views, [t._id]: e.target.value })}
+                className="px-2 py-1 text-xs bg-surface border border-border rounded"
+              />
+              <button
+                onClick={() => handle(t._id, 'approved')}
+                className="px-2 py-1 bg-primary hover:bg-primary-hover text-background rounded"
+              >
+                Approve
+              </button>
+              <button
+                onClick={() => handle(t._id, 'rejected')}
+                className="px-2 py-1 bg-red-600 text-background rounded"
+              >
+                Reject
+              </button>
+            </div>
+          </li>
+        ))}
+        {tasks.length === 0 && (
+          <p className="text-center text-subtext text-sm">No submissions.</p>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -242,7 +242,7 @@ export default function TasksCard() {
                 <div className="space-y-2 w-full">
                   <button
                     onClick={() => setShowPosts(true)}
-                    className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded w-full"
+                    className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded w-1/2"
                   >
                     View Posts
                   </button>

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -24,6 +24,7 @@ import AvatarPromptModal from '../components/AvatarPromptModal.jsx';
 import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
 import InfoPopup from '../components/InfoPopup.jsx';
 import DevNotifyModal from '../components/DevNotifyModal.jsx';
+import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
 import Wallet from './Wallet.jsx';
 
 import { FiCopy } from 'react-icons/fi';
@@ -311,6 +312,8 @@ export default function MyAccount() {
               Notify
             </button>
           </div>
+
+          <InfluencerClaimsCard />
         </>
       )}
 

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -28,6 +28,15 @@ import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 import { STORE_ADDRESS } from '../utils/storeData.js';
 
 const REWARDS = Array.from({ length: 30 }, (_, i) => Math.floor(100 + (i + 1) * 50));
+const INFLUENCER_REWARDS = [
+  { range: '0 – 149', reward: '0 TPC', notes: 'Below threshold' },
+  { range: '150 – 2,999', reward: '300 TPC', notes: 'Entry-level reward' },
+  { range: '3,000 – 7,999', reward: '900 TPC', notes: 'Small creator range' },
+  { range: '8,000 – 14,999', reward: '1,800 TPC', notes: 'Medium growth videos' },
+  { range: '15,000 – 29,999', reward: '3,500 TPC', notes: 'Strong organic reach' },
+  { range: '30,000 – 99,999', reward: '8,000 TPC', notes: 'Viral tier' },
+  { range: '100,000+', reward: '20,000 TPC', notes: 'Top influencer bonus tier' },
+];
 const ONE_DAY = 24 * 60 * 60 * 1000;
 
 export default function Tasks() {
@@ -241,7 +250,7 @@ export default function Tasks() {
                   <div className="space-y-2 w-full">
                     <button
                       onClick={() => setShowPosts(true)}
-                      className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded w-full"
+                      className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-background text-sm rounded w-1/2"
                     >
                       View Posts
                     </button>
@@ -322,6 +331,24 @@ export default function Tasks() {
               >
                 Submit
               </button>
+              <table className="w-full text-xs text-center mt-2 border-collapse">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="py-1">Views Range</th>
+                    <th className="py-1">Reward (TPC)</th>
+                    <th className="py-1">Notes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {INFLUENCER_REWARDS.map((r) => (
+                    <tr key={r.range} className="border-b border-border last:border-0">
+                      <td className="py-1">{r.range}</td>
+                      <td className="py-1">{r.reward}</td>
+                      <td className="py-1">{r.notes}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
           )}
           {infTab === 'mine' && (


### PR DESCRIPTION
## Summary
- shrink `View Posts` button width in tasks list
- show influencer rewards table when submitting videos
- add claims management card for developers

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68725630abb083299490eef88763fa9c