### PR TITLE
Update README and env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
    - `DEV_ACCOUNT_ID_1` – (optional) secondary developer account (1% share)
    - `DEV_ACCOUNT_ID_2` – (optional) secondary developer account (2% share)
    - `API_AUTH_TOKEN` – (optional) token for trusted server-to-server calls
-   - `TWITTER_BEARER_TOKEN` – bearer token for verifying retweets
+   - `TWITTER_BEARER_TOKEN` – bearer token for verifying retweets. Make sure this line is uncommented in `bot/.env`.
 
 4. Copy `webapp/.env.example` to `webapp/.env` and configure:
    - `VITE_API_BASE_URL` – the base URL where the bot API is hosted (e.g. `http://localhost:3000`).

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -12,7 +12,7 @@ PORT=3000
 # Comma-separated list of admin tokens for the airdrop API.
 # These tokens also authorize access to the /api/broadcast route.
 # AIRDROP_ADMIN_TOKENS=token1,token2
-# TWITTER_BEARER_TOKEN=your-twitter-bearer-token
+TWITTER_BEARER_TOKEN=your-twitter-bearer-token # remove the # to enable retweet verification
 
 
 # TON deposit address that users will send funds to when topping up their


### PR DESCRIPTION
## Summary
- clarify that `TWITTER_BEARER_TOKEN` must be uncommented in `bot/.env`
- show the variable uncommented in `bot/.env.example`

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_687258295274832996a4c8a488a4446a