### PR TITLE
Fix Crazy Dice Duel background position

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -109,6 +109,13 @@ input:focus {
   transform: translateY(90px) scale(1.2);
 }
 
+/* Adjusted placement for Crazy Dice Duel */
+.crazy-dice-bg {
+  top: 0;
+  bottom: 0;
+  transform: none;
+}
+
 @keyframes roll {
   0% {
     transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg) translateY(0);

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -287,17 +287,17 @@ export default function CrazyDiceDuel() {
   return (
     <div className="text-text relative">
       <Branding scale={1.2} />
-      <div className="crazy-dice-board" ref={boardRef}>
       {bgUnlocked && (
         <img
           src="/assets/SnakeLaddersbackground.png"
-          className="background-behind-board object-cover"
+          className="background-behind-board crazy-dice-bg object-cover"
           alt=""
           onError={(e) => {
             e.currentTarget.style.display = 'none';
           }}
         />
       )}
+      <div className="crazy-dice-board" ref={boardRef}>
       {!bgUnlocked && (
         <button
           onClick={unlockBackground}


### PR DESCRIPTION
## Summary
- adjust Crazy Dice Duel background placement so it lines up with the logo
- tweak index.css for a new `.crazy-dice-bg` helper class

## Testing
- `npm run test` *(fails: snake API endpoints and socket events timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68725ba9a6fc8329ac13fb76b545dca9