### PR TITLE
Adjust Crazy Dice Duel visuals

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -113,7 +113,7 @@ input:focus {
 .crazy-dice-bg {
   top: 0;
   bottom: 0;
-  transform: none;
+  transform: translateX(-1rem);
 }
 
 @keyframes roll {
@@ -423,12 +423,16 @@ input:focus {
   font-size: 0.6rem;
   color: inherit;
   white-space: nowrap;
+  padding: 0 0.2rem;
+  border: 1px solid currentColor;
+  border-radius: 0.15rem;
+  background-color: rgba(0, 0, 0, 0.25);
 }
 
 /* Horizontal history of previous rolls */
 .roll-history {
   position: absolute;
-  top: calc(100% + 1rem);
+  top: calc(100% + 0.5rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -444,6 +448,7 @@ input:focus {
   justify-content: center;
   font-size: 0.55rem;
   border-radius: 0.15rem;
+  background-color: rgba(0, 0, 0, 0.25);
 }
 
 .turn-indicator {


### PR DESCRIPTION
## Summary
- tweak background alignment for Crazy Dice Duel
- add framing to player scores and dice roll boxes
- tighten spacing around score history

## Testing
- `npm test` *(fails: cannot find modules `express`, `socket.io-client`, `mongoose`)*

------
https://chatgpt.com/codex/tasks/task_e_68726a52a06c8329a042d6e6143dfa90