### PR TITLE
Add grid overlay to Crazy Dice

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1308,6 +1308,27 @@ input:focus {
   filter: brightness(1.2);
   z-index: -1;
 }
+.crazy-dice-board .grid-overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  grid-template-rows: repeat(20, 1fr);
+  pointer-events: none;
+  z-index: 0;
+}
+.crazy-dice-board .grid-overlay .grid-cell {
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  position: relative;
+}
+.crazy-dice-board .grid-overlay .grid-label {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  font-size: 0.5rem;
+  color: #fff;
+  opacity: 0.6;
+}
 .crazy-dice-board .dice-center {
   position: absolute;
   top: 40%;

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -6,7 +6,6 @@ import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
 import GiftPopup from '../../components/GiftPopup.jsx';
 import GameEndPopup from '../../components/GameEndPopup.jsx';
-import Branding from '../../components/Branding.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { chatBeep, timerBeep } from '../../assets/soundData.js';
@@ -284,9 +283,20 @@ export default function CrazyDiceDuel() {
     nextTurn();
   };
 
+  const GRID_ROWS = 20;
+  const GRID_COLS = 10;
+  const gridCells = [];
+  for (let r = 0; r < GRID_ROWS; r++) {
+    for (let c = 0; c < GRID_COLS; c++) {
+      const label =
+        (r === 0 ? String.fromCharCode(65 + c) : '') +
+        (c === 0 ? r + 1 : '');
+      gridCells.push({ label });
+    }
+  }
+
   return (
     <div className="text-text relative">
-      <Branding scale={1.2} />
       {bgUnlocked && (
         <img
           src="/assets/SnakeLaddersbackground.png"
@@ -311,6 +321,13 @@ export default function CrazyDiceDuel() {
         alt="board"
         className="board-bg"
       />
+      <div className="grid-overlay">
+        {gridCells.map((cell, i) => (
+          <div key={i} className="grid-cell">
+            {cell.label && <span className="grid-label">{cell.label}</span>}
+          </div>
+        ))}
+      </div>
       <div className="side-number top">1</div>
       <div className="side-number bottom">2</div>
       <div className="side-number left">3</div>


### PR DESCRIPTION
## Summary
- remove branding from Crazy Dice Duel
- overlay 20x10 grid with alphanumeric labels for placement guidance

## Testing
- `npm test` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68727e406ef483298f06641655456eea