### PR TITLE
Add inbox notifications

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -101,6 +101,8 @@ const userSchema = new mongoose.Schema({
   storeMiningRate: { type: Number, default: 0 },
   storeMiningExpiresAt: { type: Date, default: null },
 
+  // Timestamp of the last time the user opened their inbox
+  inboxReadAt: { type: Date, default: Date.now },
 
   // Track which game table the user is currently seated at
   currentTableId: { type: String, default: null }

--- a/bot/routes/influencer.js
+++ b/bot/routes/influencer.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import InfluencerTask from '../models/InfluencerTask.js';
 import User from '../models/User.js';
+import Message from '../models/Message.js';
 import { ensureTransactionArray } from '../utils/userUtils.js';
 import bot from '../bot.js';
 
@@ -49,6 +50,11 @@ router.post('/submit', async (req, res) => {
             String(devUser.telegramId),
             `New influencer submission: ${videoUrl}`,
           );
+          await Message.create({
+            from: telegramId,
+            to: devUser.telegramId,
+            text: `New influencer submission: ${videoUrl}`
+          });
         }
       } catch (e) {
         console.error('dev notify failed:', e.message);

--- a/bot/routes/social.js
+++ b/bot/routes/social.js
@@ -111,6 +111,24 @@ router.post('/messages', async (req, res) => {
   res.json(msgs);
 });
 
+router.post('/unread-count', async (req, res) => {
+  const { telegramId } = req.body;
+  if (!telegramId)
+    return res.status(400).json({ error: 'telegramId required' });
+  const user = await User.findOne({ telegramId });
+  const since = user?.inboxReadAt || new Date(0);
+  const count = await Message.countDocuments({ to: telegramId, createdAt: { $gt: since } });
+  res.json({ count });
+});
+
+router.post('/mark-read', async (req, res) => {
+  const { telegramId } = req.body;
+  if (!telegramId)
+    return res.status(400).json({ error: 'telegramId required' });
+  await User.updateOne({ telegramId }, { inboxReadAt: new Date() });
+  res.json({ success: true });
+});
+
 router.post('/wall/list', async (req, res) => {
   const { ownerId } = req.body;
   if (!ownerId) return res.status(400).json({ error: 'ownerId required' });

--- a/webapp/src/components/InboxWidget.jsx
+++ b/webapp/src/components/InboxWidget.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import LoginOptions from './LoginOptions.jsx';
 import { getTelegramId } from '../utils/telegram.js';
-import { listFriends, getMessages, sendMessage } from '../utils/api.js';
+import { listFriends, getMessages, sendMessage, markInboxRead } from '../utils/api.js';
 
 export default function InboxWidget() {
   let telegramId;
@@ -22,7 +22,10 @@ export default function InboxWidget() {
 
   useEffect(() => {
     if (selected) {
-      getMessages(telegramId, selected.telegramId).then(setMessages);
+      getMessages(telegramId, selected.telegramId).then((msgs) => {
+        setMessages(msgs);
+        markInboxRead(telegramId);
+      });
     }
   }, [selected, telegramId]);
 
@@ -32,6 +35,7 @@ export default function InboxWidget() {
     setText('');
     const msgs = await getMessages(telegramId, selected.telegramId);
     setMessages(msgs);
+    markInboxRead(telegramId);
   }
 
   return (

--- a/webapp/src/pages/Messages.jsx
+++ b/webapp/src/pages/Messages.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LoginOptions from '../components/LoginOptions.jsx';
 import { getTelegramId } from '../utils/telegram.js';
-import { getMessages, sendMessage, listFriends } from '../utils/api.js';
+import { getMessages, sendMessage, listFriends, markInboxRead } from '../utils/api.js';
 
 export default function Messages() {
   useTelegramBackButton();
@@ -19,12 +19,19 @@ export default function Messages() {
   const [text, setText] = useState('');
 
   useEffect(() => {
+    markInboxRead(telegramId);
+  }, [telegramId]);
+
+  useEffect(() => {
     listFriends(telegramId).then(setFriends);
   }, [telegramId]);
 
   useEffect(() => {
     if (selected) {
-      getMessages(telegramId, selected.telegramId).then(setMessages);
+      getMessages(telegramId, selected.telegramId).then((msgs) => {
+        setMessages(msgs);
+        markInboxRead(telegramId);
+      });
     }
   }, [selected, telegramId]);
 
@@ -34,6 +41,7 @@ export default function Messages() {
     setText('');
     const msgs = await getMessages(telegramId, selected.telegramId);
     setMessages(msgs);
+    markInboxRead(telegramId);
   }
 
   return (

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -7,7 +7,8 @@ import {
   depositAccount,
   sendBroadcast,
   convertGifts,
-  linkSocial
+  linkSocial,
+  getUnreadCount
 } from '../utils/api.js';
 import { NFT_GIFTS } from '../utils/nftGifts.js';
 import GiftIcon from '../components/GiftIcon.jsx';
@@ -74,6 +75,7 @@ export default function MyAccount() {
   const [transferAccount, setTransferAccount] = useState('');
   const [twitterHandle, setTwitterHandle] = useState('');
   const [twitterError, setTwitterError] = useState('');
+  const [unread, setUnread] = useState(0);
 
   useEffect(() => {
     async function load() {
@@ -126,6 +128,10 @@ export default function MyAccount() {
       }
 
       setProfile(finalProfile);
+      try {
+        const res = await getUnreadCount(telegramId);
+        if (!res.error) setUnread(res.count);
+      } catch {}
       setTwitterHandle(finalProfile.social?.twitter || '');
       if (!localStorage.getItem('avatarPromptShown')) {
         setShowAvatarPrompt(true);
@@ -311,8 +317,13 @@ export default function MyAccount() {
             <a href="/mining" className="underline text-primary">
               Mining
             </a>
-            <a href="/messages" className="underline text-primary">
+            <a href="/messages" className="underline text-primary relative">
               Inbox
+              {unread > 0 && (
+                <span className="absolute -top-1 -right-3 bg-red-600 text-background text-xs rounded-full px-1">
+                  {unread}
+                </span>
+              )}
             </a>
           </div>
           {profile.social?.twitter && (

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -340,6 +340,14 @@ export function getMessages(telegramId, withId) {
   return post('/api/social/messages', { telegramId, withId });
 }
 
+export function getUnreadCount(telegramId) {
+  return post('/api/social/unread-count', { telegramId });
+}
+
+export function markInboxRead(telegramId) {
+  return post('/api/social/mark-read', { telegramId });
+}
+
 export function listWallPosts(ownerId) {
   return post('/api/social/wall/list', { ownerId });
 }


### PR DESCRIPTION
## Summary
- track last inbox read time in `User` model
- send dev message when influencer videos are submitted
- expose `/unread-count` and `/mark-read` routes
- support unread counts in API helpers
- mark messages as read when viewed
- show unread badge on profile inbox link

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68727af974d883299f57858918dbe8ca