### PR TITLE
Update Crazy Dice styling

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -425,15 +425,12 @@ input:focus {
   color: inherit;
   white-space: nowrap;
   padding: 0 0.2rem;
-  border: 1px solid currentColor;
-  border-radius: 0.15rem;
-  background-color: rgba(0, 0, 0, 0.25);
 }
 
 /* Horizontal history of previous rolls */
 .roll-history {
   position: absolute;
-  top: calc(100% + 0.5rem);
+  top: calc(100% + 0.7rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -288,9 +288,7 @@ export default function CrazyDiceDuel() {
   const gridCells = [];
   for (let r = 0; r < GRID_ROWS; r++) {
     for (let c = 0; c < GRID_COLS; c++) {
-      const label =
-        (r === 0 ? String.fromCharCode(65 + c) : '') +
-        (c === 0 ? r + 1 : '');
+      const label = `${String.fromCharCode(65 + c)}${r + 1}`;
       gridCells.push({ label });
     }
   }


### PR DESCRIPTION
## Summary
- label all grid cells on the Crazy Dice board (A1, A2…)
- tweak player score style
- increase gap between score and roll history boxes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68728a31c4fc83299b00ba95bcdd0682