### PR TITLE
Update Crazy Dice Duel layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -430,7 +430,7 @@ input:focus {
 /* Horizontal history of previous rolls */
 .roll-history {
   position: absolute;
-  top: calc(100% + 0.7rem);
+  top: calc(100% + 0.4rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -444,7 +444,7 @@ input:focus {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.55rem;
+  font-size: 0.75rem;
   border-radius: 0.15rem;
   background-color: rgba(0, 0, 0, 0.25);
 }
@@ -1343,15 +1343,16 @@ input:focus {
 
 .crazy-dice-board .player-left {
   position: absolute;
-  top: 22%;
-  left: 2%;
+  top: 17.5%;
+  left: 5%;
+  transform: translate(-50%, -50%);
 }
 
 .crazy-dice-board .player-center {
   position: absolute;
   top: 17.5%;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 55%;
+  transform: translate(-50%, -50%);
 }
 .crazy-dice-board .player-center .player-score,
 .crazy-dice-board .player-center .roll-history {
@@ -1368,8 +1369,9 @@ input:focus {
 
 .crazy-dice-board .player-right {
   position: absolute;
-  top: 22%;
-  right: -2%;
+  top: 17.5%;
+  right: 5%;
+  transform: translate(50%, -50%);
 }
 
 /* Markers for easier mapping */

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -76,6 +76,40 @@ export default function CrazyDiceDuel() {
   const boardRef = useRef(null);
   const [diceStyle, setDiceStyle] = useState({ display: 'none' });
   const DICE_SMALL_SCALE = 0.44;
+  const DICE_ANIM_DURATION = 1800;
+  const GRID_ROWS = 20;
+  const GRID_COLS = 10;
+
+  const PLAYER_DICE_CELLS = [
+    ['E19', 'F19'],
+    ['A8', 'B8'],
+    ['E8', 'F8'],
+    ['I8', 'J8'],
+  ];
+
+  const getCellCenter = (label) => {
+    if (!boardRef.current) return { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+    const rect = boardRef.current.getBoundingClientRect();
+    const col = label.charCodeAt(0) - 65;
+    const row = parseInt(label.slice(1)) - 1;
+    const x = rect.left + rect.width * ((col + 0.5) / GRID_COLS);
+    const y = rect.top + rect.height * ((row + 0.5) / GRID_ROWS);
+    return { x, y };
+  };
+
+  const getDiceCenter = () => {
+    const p1 = getCellCenter('E12');
+    const p2 = getCellCenter('F12');
+    return { cx: (p1.x + p2.x) / 2, cy: (p1.y + p2.y) / 2 };
+  };
+
+  const getPlayerDicePos = (idx) => {
+    const cells = PLAYER_DICE_CELLS[idx];
+    if (!cells) return getDiceCenter();
+    const p1 = getCellCenter(cells[0]);
+    const p2 = getCellCenter(cells[1]);
+    return { x: (p1.x + p2.x) / 2, y: (p1.y + p2.y) / 2 };
+  };
 
   useEffect(() => {
     timerSoundRef.current = new Audio(timerBeep);
@@ -155,29 +189,26 @@ export default function CrazyDiceDuel() {
 
   const prepareDiceAnimation = (startIdx) => {
     if (startIdx == null) {
-      const cx = window.innerWidth / 2;
-      const cy = window.innerHeight / 2;
+      const { cx, cy } = getDiceCenter();
       setDiceStyle({
         display: 'block',
         position: 'fixed',
-        left: `${cx}px`,
-        top: `${cy}px`,
-        transform: 'translate(-50%, -50%) scale(1)',
+        left: '0px',
+        top: '0px',
+        transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)`,
         transition: 'none',
         pointerEvents: 'none',
         zIndex: 50,
       });
       return;
     }
-    const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
-    if (!startEl) return;
-    const s = startEl.getBoundingClientRect();
+    const { x, y } = getPlayerDicePos(startIdx);
     setDiceStyle({
       display: 'block',
       position: 'fixed',
-      left: `${s.left + s.width / 2}px`,
-      top: `${s.top + s.height / 2}px`,
-      transform: `translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
+      left: '0px',
+      top: '0px',
+      transform: `translate(${x}px, ${y}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
       transition: 'none',
       pointerEvents: 'none',
       zIndex: 50,
@@ -186,11 +217,9 @@ export default function CrazyDiceDuel() {
 
   const animateDiceToCenter = (startIdx) => {
     const dice = diceRef.current;
-    const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
-    if (!dice || !startEl) return;
-    const s = startEl.getBoundingClientRect();
-    const cx = window.innerWidth / 2;
-    const cy = window.innerHeight / 2;
+    if (!dice) return;
+    const { x, y } = getPlayerDicePos(startIdx);
+    const { cx, cy } = getDiceCenter();
     dice.style.display = 'block';
     dice.style.position = 'fixed';
     dice.style.left = '0px';
@@ -199,17 +228,17 @@ export default function CrazyDiceDuel() {
     dice.style.zIndex = '50';
     dice.animate(
       [
-        { transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(${DICE_SMALL_SCALE})` },
-        { transform: `translate(${cx}px, ${cy}px) scale(1)` },
+        { transform: `translate(${x}px, ${y}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})` },
+        { transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)` },
       ],
-      { duration: 600, easing: 'linear' },
+      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' },
     ).onfinish = () => {
       setDiceStyle({
         display: 'block',
         position: 'fixed',
-        left: `${cx}px`,
-        top: `${cy}px`,
-        transform: 'translate(-50%, -50%) scale(1)',
+        left: '0px',
+        top: '0px',
+        transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)`,
         pointerEvents: 'none',
         zIndex: 50,
       });
@@ -218,24 +247,22 @@ export default function CrazyDiceDuel() {
 
   const animateDiceToPlayer = (idx) => {
     const dice = diceRef.current;
-    const endEl = document.querySelector(`[data-player-index="${idx}"] img`);
-    if (!dice || !endEl) return;
-    const e = endEl.getBoundingClientRect();
-    const cx = window.innerWidth / 2;
-    const cy = window.innerHeight / 2;
+    if (!dice) return;
+    const { x, y } = getPlayerDicePos(idx);
+    const { cx, cy } = getDiceCenter();
     dice.animate(
       [
-        { transform: `translate(${cx}px, ${cy}px) scale(1)` },
-        { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(${DICE_SMALL_SCALE})` },
+        { transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)` },
+        { transform: `translate(${x}px, ${y}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})` },
       ],
-      { duration: 600, easing: 'linear' },
+      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' },
     ).onfinish = () => {
       setDiceStyle({
         display: 'block',
         position: 'fixed',
-        left: `${e.left + e.width / 2}px`,
-        top: `${e.top + e.height / 2}px`,
-        transform: `translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
+        left: '0px',
+        top: '0px',
+        transform: `translate(${x}px, ${y}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
         pointerEvents: 'none',
         zIndex: 50,
       });
@@ -283,8 +310,6 @@ export default function CrazyDiceDuel() {
     nextTurn();
   };
 
-  const GRID_ROWS = 20;
-  const GRID_COLS = 10;
   const gridCells = [];
   for (let r = 0; r < GRID_ROWS; r++) {
     for (let c = 0; c < GRID_COLS; c++) {


### PR DESCRIPTION
## Summary
- adjust Crazy Dice Duel board layout and dice animation
- tune player dice positions and center
- make roll history numbers larger

## Testing
- `npm test` *(fails: snake API endpoints and socket events)*

------
https://chatgpt.com/codex/tasks/task_e_68729190c6ac8329a6fbc333eefde741