### PR TITLE
Update Crazy Dice Duel positions

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -430,7 +430,7 @@ input:focus {
 /* Horizontal history of previous rolls */
 .roll-history {
   position: absolute;
-  top: calc(100% + 0.4rem);
+  top: calc(100% + 0.6rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -1350,8 +1350,8 @@ input:focus {
 
 .crazy-dice-board .player-center {
   position: absolute;
-  top: 17.5%;
-  left: 55%;
+  top: 16%;
+  left: 52%;
   transform: translate(-50%, -50%);
 }
 .crazy-dice-board .player-center .player-score,
@@ -1360,11 +1360,11 @@ input:focus {
 }
 .crazy-dice-board .player-left .player-score,
 .crazy-dice-board .player-left .roll-history {
-  transform: translateX(-40%);
+  transform: translateX(-35%);
 }
 .crazy-dice-board .player-right .player-score,
 .crazy-dice-board .player-right .roll-history {
-  transform: translateX(-60%);
+  transform: translateX(-65%);
 }
 
 .crazy-dice-board .player-right {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -81,10 +81,10 @@ export default function CrazyDiceDuel() {
   const GRID_COLS = 10;
 
   const PLAYER_DICE_CELLS = [
-    ['E19', 'F19'],
-    ['A8', 'B8'],
-    ['E8', 'F8'],
-    ['I8', 'J8'],
+    ['F19', 'F19'],
+    ['B8', 'B8'],
+    ['F8', 'F8'],
+    ['J8', 'J8'],
   ];
 
   const getCellCenter = (label) => {
@@ -98,9 +98,8 @@ export default function CrazyDiceDuel() {
   };
 
   const getDiceCenter = () => {
-    const p1 = getCellCenter('E12');
-    const p2 = getCellCenter('F12');
-    return { cx: (p1.x + p2.x) / 2, cy: (p1.y + p2.y) / 2 };
+    const { x, y } = getCellCenter('F12');
+    return { cx: x, cy: y };
   };
 
   const getPlayerDicePos = (idx) => {


### PR DESCRIPTION
## Summary
- tweak dice center and player dice resting cells
- nudge player avatars and history boxes on board

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_68729db97fc8832991908a212698d007