### PR TITLE
Adjust Crazy Dice duel layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -430,7 +430,8 @@ input:focus {
 /* Horizontal history of previous rolls */
 .roll-history {
   position: absolute;
-  top: calc(100% + 0.6rem);
+  /* Slightly lower so the boxes sit a bit further from the avatar */
+  top: calc(100% + 0.7rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -1360,11 +1361,13 @@ input:focus {
 }
 .crazy-dice-board .player-left .player-score,
 .crazy-dice-board .player-left .roll-history {
-  transform: translateX(-35%);
+  /* Nudge slightly to the right */
+  transform: translateX(-30%);
 }
 .crazy-dice-board .player-right .player-score,
 .crazy-dice-board .player-right .roll-history {
-  transform: translateX(-65%);
+  /* And the right side slightly to the left */
+  transform: translateX(-70%);
 }
 
 .crazy-dice-board .player-right {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -75,7 +75,10 @@ export default function CrazyDiceDuel() {
   const diceRef = useRef(null);
   const boardRef = useRef(null);
   const [diceStyle, setDiceStyle] = useState({ display: 'none' });
-  const DICE_SMALL_SCALE = 0.44;
+  // Dice appear slightly smaller when resting at a player's position. The
+  // design calls for them to be roughly 30% smaller than their full size while
+  // rolling in the centre.
+  const DICE_SMALL_SCALE = 0.7;
   const DICE_ANIM_DURATION = 1800;
   const GRID_ROWS = 20;
   const GRID_COLS = 10;


### PR DESCRIPTION
## Summary
- make the dice 30% smaller when at player spots
- push roll history down slightly
- tweak left and right player score alignment

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_6872a6ca53b48329bf0645f4c9597ec9