### PR TITLE
Update crazy dice layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -430,8 +430,8 @@ input:focus {
 /* Horizontal history of previous rolls */
 .roll-history {
   position: absolute;
-  /* Slightly lower so the boxes sit a bit further from the avatar */
-  top: calc(100% + 0.7rem);
+  /* Keep equal spacing between avatar, score and boxes */
+  top: calc(100% + 0.2rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -1372,7 +1372,8 @@ input:focus {
 
 .crazy-dice-board .player-right {
   position: absolute;
-  top: 17.5%;
+  /* Nudge slightly lower for better alignment */
+  top: 19%;
   right: 5%;
   transform: translate(50%, -50%);
 }

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -75,11 +75,7 @@ export default function CrazyDiceDuel() {
   const diceRef = useRef(null);
   const boardRef = useRef(null);
   const [diceStyle, setDiceStyle] = useState({ display: 'none' });
-  // Dice appear slightly smaller when resting at a player's position. The
-  // design calls for them to be roughly 30% smaller than their full size while
-  // rolling in the centre.
-  const DICE_SMALL_SCALE = 0.7;
-  const DICE_ANIM_DURATION = 1800;
+  // Dice remain at the centre with no travel animation
   const GRID_ROWS = 20;
   const GRID_COLS = 10;
 
@@ -186,90 +182,24 @@ export default function CrazyDiceDuel() {
     });
     let n = (current + 1) % players.length;
     while (players[n].rolls >= maxRolls) n = (n + 1) % players.length;
-    animateDiceToPlayer(n);
+    // Dice remain on the centre cell after rolling
   };
 
-  const prepareDiceAnimation = (startIdx) => {
-    if (startIdx == null) {
-      const { cx, cy } = getDiceCenter();
-      setDiceStyle({
-        display: 'block',
-        position: 'fixed',
-        left: '0px',
-        top: '0px',
-        transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)`,
-        transition: 'none',
-        pointerEvents: 'none',
-        zIndex: 50,
-      });
-      return;
-    }
-    const { x, y } = getPlayerDicePos(startIdx);
+  const prepareDiceAnimation = () => {
+    const { cx, cy } = getDiceCenter();
     setDiceStyle({
       display: 'block',
       position: 'fixed',
       left: '0px',
       top: '0px',
-      transform: `translate(${x}px, ${y}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
+      transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)`,
       transition: 'none',
       pointerEvents: 'none',
       zIndex: 50,
     });
   };
 
-  const animateDiceToCenter = (startIdx) => {
-    const dice = diceRef.current;
-    if (!dice) return;
-    const { x, y } = getPlayerDicePos(startIdx);
-    const { cx, cy } = getDiceCenter();
-    dice.style.display = 'block';
-    dice.style.position = 'fixed';
-    dice.style.left = '0px';
-    dice.style.top = '0px';
-    dice.style.pointerEvents = 'none';
-    dice.style.zIndex = '50';
-    dice.animate(
-      [
-        { transform: `translate(${x}px, ${y}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})` },
-        { transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)` },
-      ],
-      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' },
-    ).onfinish = () => {
-      setDiceStyle({
-        display: 'block',
-        position: 'fixed',
-        left: '0px',
-        top: '0px',
-        transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)`,
-        pointerEvents: 'none',
-        zIndex: 50,
-      });
-    };
-  };
 
-  const animateDiceToPlayer = (idx) => {
-    const dice = diceRef.current;
-    if (!dice) return;
-    const { x, y } = getPlayerDicePos(idx);
-    const { cx, cy } = getDiceCenter();
-    dice.animate(
-      [
-        { transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)` },
-        { transform: `translate(${x}px, ${y}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})` },
-      ],
-      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' },
-    ).onfinish = () => {
-      setDiceStyle({
-        display: 'block',
-        position: 'fixed',
-        left: '0px',
-        top: '0px',
-        transform: `translate(${x}px, ${y}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
-        pointerEvents: 'none',
-        zIndex: 50,
-      });
-    };
-  };
 
   const nextTurn = () => {
     setCurrent((c) => {
@@ -367,8 +297,8 @@ export default function CrazyDiceDuel() {
             <DiceRoller
               onRollEnd={onRollEnd}
               onRollStart={() => {
-                prepareDiceAnimation(current);
-                animateDiceToCenter(current);
+                // Position dice directly at the centre cell without animation
+                prepareDiceAnimation();
               }}
               trigger={trigger}
               clickable={aiCount === 0 || current === 0}


### PR DESCRIPTION
## Summary
- tweak spacing of roll history for consistent gap to score
- move top-right player slightly down
- stop dice travel animations in Crazy Dice Duel

## Testing
- `npm test` *(fails: cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6872ad019ea08329beccbb8ac17583f2