### PR TITLE
Fix dice visibility and move score

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -40,11 +40,6 @@ export default function AvatarTimer({
           {name}
         </span>
       )}
-      {score != null && (
-        <span className="player-score" style={{ color: color || '#fde047' }}>
-          Score: {score}
-        </span>
-      )}
       {rollHistory && maxRolls > 0 && (
         <div className="roll-history" style={{ color: color || '#fde047' }}>
           {Array.from({ length: maxRolls }).map((_, i) => (
@@ -53,6 +48,11 @@ export default function AvatarTimer({
             </div>
           ))}
         </div>
+      )}
+      {score != null && (
+        <span className="player-score" style={{ color: color || '#fde047' }}>
+          Score: {score}
+        </span>
       )}
     </div>
   );

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -418,7 +418,7 @@ input:focus {
 /* Score display below each avatar */
 .player-score {
   position: absolute;
-  top: calc(100% + 0.1rem);
+  top: calc(100% + 1.3rem); /* below roll boxes with space */
   left: 50%;
   transform: translateX(-50%);
   font-size: 0.6rem;
@@ -430,8 +430,8 @@ input:focus {
 /* Horizontal history of previous rolls */
 .roll-history {
   position: absolute;
-  /* Keep equal spacing between avatar, score and boxes */
-  top: calc(100% + 0.2rem);
+  /* Directly below avatar */
+  top: calc(100% + 0.1rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -75,6 +75,7 @@ export default function CrazyDiceDuel() {
   const diceRef = useRef(null);
   const boardRef = useRef(null);
   const [diceStyle, setDiceStyle] = useState({ display: 'none' });
+
   // Dice remain at the centre with no travel animation
   const GRID_ROWS = 20;
   const GRID_COLS = 10;
@@ -195,9 +196,14 @@ export default function CrazyDiceDuel() {
       transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)`,
       transition: 'none',
       pointerEvents: 'none',
-      zIndex: 50,
+      zIndex: 100,
     });
   };
+
+  // Ensure dice are visible on the board when the component mounts
+  useEffect(() => {
+    prepareDiceAnimation();
+  }, []);
 
 
 


### PR DESCRIPTION
## Summary
- keep dice visible by default and lift them above other elements
- reorder AvatarTimer so roll boxes appear above score
- space out score display below roll boxes

## Testing
- `npm test` *(fails: test timed out / module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872b8c46e508329a6cd9d58da532bc9