### PR TITLE
Fix dice visibility

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -970,7 +970,7 @@ input:focus {
   left: 0;
   top: 0;
   pointer-events: none;
-  z-index: 50;
+  z-index: 101;
 }
 
 .coin-img {
@@ -1421,7 +1421,7 @@ input:focus {
   position: fixed;
   pointer-events: none;
   transform: translate(-50%, -50%) scale(1);
-  z-index: 50;
+  z-index: 101;
 }
 
 @keyframes dice-bounce {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -81,7 +81,7 @@ export default function CrazyDiceDuel() {
   const timerSoundRef = useRef(null);
   const diceRef = useRef(null);
   const boardRef = useRef(null);
-  const [diceStyle, setDiceStyle] = useState({ display: 'none' });
+  const [diceStyle, setDiceStyle] = useState({});
 
   // Dice remain at the centre with no travel animation
   const GRID_ROWS = 20;


### PR DESCRIPTION
## Summary
- show Crazy Dice dice on load
- place dice above overlays

## Testing
- `npm test` *(fails: test suite errors and missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6872c686fc2c83298bd9822147d06937