### PR TITLE
Update docs for test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ The server honors a few extra environment variables when building or serving the
    npm --prefix webapp run build
    ```
 
-7. Run the test suite to verify the setup:
+7. Run the test suite to verify the setup. Ensure all packages are installed
+   first by executing `npm run install-all` (or `npm install` in each package)
+   so dependencies like `express` and `socket.io-client` are available:
 
    ```bash
    npm test

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
+# Install dependencies for the root package, bot and webapp. Run this before
+# executing `npm test` when setting up a fresh environment so required modules
+# like `express` and `socket.io-client` are available.
 set -e
 npm run install-all


### PR DESCRIPTION
## Summary
- document installing dependencies prior to running tests
- clarify test setup helper script

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_687341af6850832987ba06f954581dc7