### PR TITLE
Fix regex injection in social search

### DIFF
--- a/bot/routes/social.js
+++ b/bot/routes/social.js
@@ -10,7 +10,8 @@ const router = Router();
 router.post('/search', async (req, res) => {
   const { query } = req.body;
   if (!query) return res.json([]);
-  const regex = new RegExp(query, 'i');
+  const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(escapeRegExp(query), 'i');
   const users = await User.find({
     $or: [
       { firstName: regex },


### PR DESCRIPTION
## Summary
- escape regex characters in `social.js` search query

## Testing
- `npm test` *(fails: test timeout and module not found)*

------
https://chatgpt.com/codex/tasks/task_e_687341ae13548329bebb57082163ff88