### PR TITLE
Fix NFT gift entry

### DIFF
--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -282,7 +282,6 @@ router.post('/gift', async (req, res) => {
     tier: g.tier,
     fromAccount: String(fromAccount),
     fromName: sender.nickname || sender.firstName || '',
-    nftTokenId: uuidv4(),
     date: txDate,
     nftTokenId,
   };


### PR DESCRIPTION
## Summary
- remove redundant placeholder when saving minted NFTs

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_687341ad629083298ef5b07898a7d7ab