### PR TITLE
Support twitter.env for OAuth config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bot/package-lock.json
 .idea
 
 # Environment files
+twitter.env
 .env*
 **/.env*
 /webapp/dist/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
    - `TWITTER_BEARER_TOKEN` – bearer token for verifying retweets. Make sure this line is uncommented in `bot/.env`.
    - `TWITTER_CLIENT_ID` – API key for Twitter OAuth linking.
    - `TWITTER_CLIENT_SECRET` – API secret for Twitter OAuth linking.
+   - You can also place these Twitter credentials in `twitter.env` at the repository root.
 
 4. Copy `webapp/.env.example` to `webapp/.env` and configure:
    - `VITE_API_BASE_URL` – the base URL where the bot API is hosted (e.g. `http://localhost:3000`).
@@ -40,7 +41,7 @@ this account.
 
 ⚠️ Misconfiguring these may prevent the wallet from loading correctly.
 
-All `.env` files are excluded from version control via `.gitignore` so your credentials remain private.
+All `.env` files and `twitter.env` are excluded from version control via `.gitignore` so your credentials remain private.
 
 The server honors a few extra environment variables when building or serving the webapp:
 

--- a/bot/loadEnv.js
+++ b/bot/loadEnv.js
@@ -4,3 +4,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 dotenv.config({ path: path.join(__dirname, '.env') });
+
+// Load Twitter credentials from the repository root if available
+const rootDir = path.join(__dirname, '..');
+dotenv.config({ path: path.join(rootDir, 'twitter.env') });


### PR DESCRIPTION
## Summary
- ignore `twitter.env`
- load twitter credentials from `twitter.env`
- document new file in README

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_68735034437c8329b8b22b193d261a2f