### PR TITLE
Fix dice placement in Crazy Dice Duel

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -99,7 +99,7 @@ export default function CrazyDiceDuel() {
   }, []);
 
   useEffect(() => {
-    prepareDiceAnimation(0);
+    prepareDiceAnimation();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- show the dice at the board center when the game first loads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68735cbc2298832995b626d3758b14f8