### PR TITLE
Allow tweets to loosely match

### DIFF
--- a/bot/utils/textSimilarity.js
+++ b/bot/utils/textSimilarity.js
@@ -1,0 +1,26 @@
+export function levenshteinDistance(a = '', b = '') {
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  const dp = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + cost
+      );
+    }
+  }
+  return dp[m][n];
+}
+
+export function similarityRatio(a = '', b = '') {
+  const distance = levenshteinDistance(a, b);
+  const maxLen = Math.max(a.length, b.length);
+  return maxLen === 0 ? 1 : 1 - distance / maxLen;
+}


### PR DESCRIPTION
## Summary
- add text similarity helper
- relax verify-post to skip account link check and accept 85% similarity

## Testing
- `npm test` *(fails: Cannot find package 'express' imported from bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_68736c3922908329845b6df7f571c75b