### PR TITLE
Fix tweet verification

### DIFF
--- a/bot/routes/tasks.js
+++ b/bot/routes/tasks.js
@@ -5,7 +5,7 @@ import { TASKS, TASKS_VERSION } from '../utils/tasksData.js';
 import { ensureTransactionArray } from '../utils/userUtils.js';
 import { TwitterApi } from 'twitter-api-v2';
 import PostRecord from '../models/PostRecord.js';
-import { similarityRatio } from '../utils/textSimilarity.js';
+import { similarityRatio, normalizeText } from '../utils/textSimilarity.js';
 
 const router = Router();
 const twitterClient = process.env.TWITTER_BEARER_TOKEN
@@ -93,10 +93,10 @@ router.post('/verify-post', async (req, res) => {
       return res.status(404).json({ error: 'user not found' });
     }
 
-    const text = tweet.data.text.trim().replace(/\s+/g, ' ');
+    const text = normalizeText(tweet.data.text);
     const highest = Math.max(
       ...config.posts.map((p) => {
-        const norm = p.trim().replace(/\s+/g, ' ');
+        const norm = normalizeText(p);
         return similarityRatio(text, norm);
       })
     );

--- a/bot/utils/textSimilarity.js
+++ b/bot/utils/textSimilarity.js
@@ -24,3 +24,12 @@ export function similarityRatio(a = '', b = '') {
   const maxLen = Math.max(a.length, b.length);
   return maxLen === 0 ? 1 : 1 - distance / maxLen;
 }
+
+export function normalizeText(text = '') {
+  return text
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, '')
+    .replace(/[^a-z0-9@#]+/gi, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}


### PR DESCRIPTION
## Summary
- make text matching case insensitive and ignore punctuation
- normalize user tweets and sample posts when comparing

## Testing
- `npm install`
- `npm install --prefix bot`
- `npm install --prefix webapp`
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_6873789074c08329878da2d14596d394