### PR TITLE
Adjust Crazy Dice layout

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -85,8 +85,9 @@ export default function CrazyDiceDuel() {
   const [diceStyle, setDiceStyle] = useState({ display: 'none' });
   const [rollResult, setRollResult] = useState(null);
   // Dice scales: shrink when at a player's position and expand when rolling
-  const DICE_CENTER_SCALE = 1;
-  const DICE_PLAYER_SCALE = 0.6;
+  // Reduce dice size by 20% when idle or landing
+  const DICE_CENTER_SCALE = 0.8;
+  const DICE_PLAYER_SCALE = 0.48;
   const DICE_ANIM_DURATION = 1000;
 
   // Board grid size for positioning helpers
@@ -155,13 +156,15 @@ export default function CrazyDiceDuel() {
 
   const getDiceCenter = (playerIdx = 'center') => {
     const posMap = {
-      0: 'B8',
-      1: 'F8',
-      2: 'J8',
-      3: 'F19',
-      center: 'F12',
+      0: { label: 'B8', dx: -0.1 }, // slightly to the left
+      1: { label: 'F8' },
+      2: { label: 'J9' }, // moved from J8 to J9
+      3: { label: 'F19', dx: -0.1 }, // slightly to the left
+      center: { label: 'F12' },
     };
-    const label = posMap[playerIdx];
+    const entry = posMap[playerIdx] || {};
+    const label = entry.label;
+    const dx = entry.dx || 0;
     if (label && boardRef.current) {
       const board = boardRef.current.getBoundingClientRect();
       const col = label.charCodeAt(0) - 65;
@@ -169,7 +172,7 @@ export default function CrazyDiceDuel() {
       const cellW = board.width / GRID_COLS;
       const cellH = board.height / GRID_ROWS;
       return {
-        cx: board.left + cellW * (col + 0.5),
+        cx: board.left + cellW * (col + 0.5 + dx),
         cy: board.top + cellH * (row + 0.5),
       };
     }


### PR DESCRIPTION
## Summary
- tweak dice scale factors to be smaller when idle
- adjust dice positions and shift coordinates slightly

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68738095d95c832988d4fae2a36ca5f9