### PR TITLE
Add Telegram reaction verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ To move from the start you must roll at least one six when rolling two dice. Any
 
 **Influencer admin shows "No submissions"** – Ensure your developer token is set in `bot/.env` via `AIRDROP_ADMIN_TOKENS` and in `webapp/.env` through `VITE_API_AUTH_TOKEN` so the webapp can fetch pending submissions.
 
+**Telegram reaction not detected** – The `/api/tasks/verify-telegram-reaction` endpoint checks that you reacted to [TonPlaygram/1/16](https://t.me/TonPlaygram/1/16) using the Telegram Bot API. Make sure `BOT_TOKEN` is configured and call this endpoint before completing the `react_tg_post` task.
+
 
 ## License
 

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -4,6 +4,7 @@ import {
   listTasks,
   completeTask,
   verifyPost,
+  verifyTelegramReaction,
   getAdStatus,
   watchAd,
   dailyCheckIn,
@@ -109,6 +110,14 @@ export default function TasksCard() {
   const handleClaim = async (task) => {
 
     window.open(task.link, '_blank');
+
+    if (task.id === 'react_tg_post') {
+      const res = await verifyTelegramReaction(telegramId);
+      if (res.error || !res.reacted) {
+        alert(res.error || 'Reaction not verified');
+        return;
+      }
+    }
 
     await completeTask(telegramId, task.id);
 

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -4,6 +4,7 @@ import {
   listTasks,
   completeTask,
   verifyPost,
+  verifyTelegramReaction,
   getAdStatus,
   watchAd,
   getProfile,
@@ -112,6 +113,13 @@ export default function Tasks() {
   const handleClaim = async (task) => {
     if (task.link) {
       window.open(task.link, '_blank');
+    }
+    if (task.id === 'react_tg_post') {
+      const res = await verifyTelegramReaction(telegramId);
+      if (res.error || !res.reacted) {
+        alert(res.error || 'Reaction not verified');
+        return;
+      }
     }
     await completeTask(telegramId, task.id);
     load();

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -87,6 +87,10 @@ export function verifyPost(telegramId, tweetUrl) {
   return post('/api/tasks/verify-post', { telegramId, tweetUrl });
 }
 
+export function verifyTelegramReaction(telegramId) {
+  return post('/api/tasks/verify-telegram-reaction', { telegramId });
+}
+
 export function listVideos(telegramId) {
 
   return post('/api/watch/list', { telegramId });


### PR DESCRIPTION
## Summary
- verify `react_tg_post` through a new `/api/tasks/verify-telegram-reaction` route
- require successful reaction check when completing `react_tg_post`
- expose `verifyTelegramReaction` in the webapp API helper
- check Telegram reactions before claiming the task on the webapp
- document the new verification flow

## Testing
- `npm test` *(fails: tests exit early)*

------
https://chatgpt.com/codex/tasks/task_e_6873832967548329ad0498cce1b50770