### PR TITLE
Remove Twitter OAuth logic and add manual profile URL

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -15,6 +15,8 @@ PORT=3000
 TWITTER_BEARER_TOKEN=your-twitter-bearer-token # remove the # to enable retweet verification
 TWITTER_CLIENT_ID=your-twitter-api-key
 TWITTER_CLIENT_SECRET=your-twitter-api-secret
+# Enable OAuth routes for linking X (Twitter) accounts
+ENABLE_TWITTER_OAUTH=false
 
 
 # TON deposit address that users will send funds to when topping up their

--- a/bot/server.js
+++ b/bot/server.js
@@ -97,7 +97,9 @@ app.use('/api/referral', referralRoutes);
 app.use('/api/wallet', walletRoutes);
 app.use('/api/account', accountRoutes);
 app.use('/api/profile', profileRoutes);
-app.use('/api/twitter', twitterAuthRoutes);
+if (process.env.ENABLE_TWITTER_OAUTH === 'true') {
+  app.use('/api/twitter', twitterAuthRoutes);
+}
 app.use('/api/airdrop', airdropRoutes);
 app.use('/api/checkin', checkinRoutes);
 app.use('/api/social', socialRoutes);

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -74,6 +74,7 @@ export default function MyAccount() {
   const [convertAction, setConvertAction] = useState('burn');
   const [transferAccount, setTransferAccount] = useState('');
   const [twitterError, setTwitterError] = useState('');
+  const [twitterUrl, setTwitterUrl] = useState('');
   const [unread, setUnread] = useState(0);
 
   useEffect(() => {
@@ -147,6 +148,12 @@ export default function MyAccount() {
 
   const photoUrl = loadAvatar() || profile.photo || getTelegramPhotoUrl();
 
+  useEffect(() => {
+    if (profile?.social?.twitter) {
+      setTwitterUrl(profile.social.twitter);
+    }
+  }, [profile?.social?.twitter]);
+
 
   const handleDevTopup = async () => {
     const amt = Number(devTopup);
@@ -210,37 +217,20 @@ export default function MyAccount() {
   };
 
 
-  const handleConnectTwitter = async () => {
+  const handleSaveTwitter = async () => {
     setTwitterError('');
     try {
-      const res = await fetch('/api/twitter/start', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ telegramId })
-      }).then(r => r.json());
-      if (res.url) {
-        window.open(res.url, '_blank');
-      } else if (res.error) {
-        setTwitterError(res.error);
-      }
-    } catch (err) {
-      console.error('connect twitter failed', err);
-      setTwitterError('Failed to start Twitter auth');
-    }
-  };
-
-  const handleClearTwitter = async () => {
-    setTwitterError('');
-    try {
-      const res = await linkSocial({ telegramId, twitter: '' });
+      const res = await linkSocial({ telegramId, twitter: twitterUrl.trim() });
       if (res?.error) {
         setTwitterError(res.error);
       } else {
         setProfile((p) => ({ ...p, social: res.social }));
+        setShowSaved(true);
+        setTimeout(() => setShowSaved(false), 1500);
       }
     } catch (err) {
-      console.error('clear twitter failed', err);
-      setTwitterError('Failed to clear');
+      console.error('save twitter failed', err);
+      setTwitterError('Failed to save');
     }
   };
 
@@ -327,24 +317,21 @@ export default function MyAccount() {
               )}
             </a>
           </div>
-          {profile.social?.twitter ? (
-            <p className="text-sm mt-2">
-              Linked Twitter: @{profile.social.twitter}{' '}
-              <button
-                onClick={handleClearTwitter}
-                className="underline text-primary ml-1"
-              >
-                Clear
-              </button>
-            </p>
-          ) : (
+          <div className="mt-2 flex items-center space-x-2">
+            <input
+              type="text"
+              placeholder="X profile URL"
+              value={twitterUrl}
+              onChange={(e) => setTwitterUrl(e.target.value)}
+              className="border p-1 rounded text-black flex-grow"
+            />
             <button
-              onClick={handleConnectTwitter}
-              className="mt-2 px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"
+              onClick={handleSaveTwitter}
+              className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"
             >
-              Connect Twitter
+              Save
             </button>
-          )}
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add ability to store an X profile URL instead of using OAuth
- remove OAuth button from MyAccount page
- guard old Twitter OAuth route behind `ENABLE_TWITTER_OAUTH`
- document the new feature flag in `.env.example`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873888820108329bad86368fea134da