### PR TITLE
Fix dice positions and spacing

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -127,7 +127,7 @@ export default function DiceSet({
   startValues,
 }) {
   return (
-    <div className="flex gap-4 justify-center items-center">
+    <div className="flex gap-2 justify-center items-center">
       {values.map((v, i) => (
         <DiceCube
           key={i}

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -156,10 +156,10 @@ export default function CrazyDiceDuel() {
 
   const getDiceCenter = (playerIdx = 'center') => {
     const posMap = {
-      0: { label: 'B8', dx: -0.1 }, // slightly to the left
-      1: { label: 'F8' },
-      2: { label: 'J9' }, // moved from J8 to J9
-      3: { label: 'F19', dx: -0.1 }, // slightly to the left
+      0: { label: 'F19', dx: -0.1 }, // Player 1
+      1: { label: 'B8', dx: -0.1 },  // Player 2
+      2: { label: 'F8' },            // Player 3
+      3: { label: 'J9' },            // Player 4
       center: { label: 'F12' },
     };
     const entry = posMap[playerIdx] || {};


### PR DESCRIPTION
## Summary
- align Crazy Dice Duel positions to match players' turns
- slightly reduce space between dice visuals

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687384cca6088329bc0ae03b97bf0ce3