### PR TITLE
Fix profile background

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -91,6 +91,7 @@ export default function Layout({ children }) {
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
 
       {/* Removed the starry cosmic background */}
+      <DynamicBackground />
 
 
       <main className={`flex-grow ${


### PR DESCRIPTION
## Summary
- restore dynamic background in Layout to avoid blank screens on the account page

## Testing
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_68738ec64c648329b1fd469133b8b310