### PR TITLE
Fix twitter handle parsing for x.com URLs

### DIFF
--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -7,6 +7,10 @@ import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js'
 function parseTwitterHandle(input) {
   if (!input) return '';
   let handle = String(input).trim();
+  // Support handles like "x.com/user" without protocol
+  if (/^(?:x|twitter)\.com\//.test(handle)) {
+    handle = 'https://' + handle;
+  }
   // Remove URL parts if a full profile link was provided
   try {
     const url = new URL(handle);


### PR DESCRIPTION
## Summary
- handle `x.com/username` links when linking Twitter on profile page

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_687392743c70832981efa7cabc629c80