### PR TITLE
Update Crazy Dice Duel UI

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -114,7 +114,7 @@ input:focus {
   top: 0;
   bottom: 0;
   /* Center the background image */
-  filter: brightness(2.6);
+  filter: brightness(3);
   transform: translateY(90px) scale(1.2);
 }
 
@@ -469,8 +469,11 @@ input:focus {
   bottom: calc(100% + 0.25rem);
   left: 50%;
   transform: translateX(-50%);
-  font-size: 0.75rem;
+  font-size: 1rem;
   font-weight: bold;
+  border: none;
+  background: transparent;
+  padding: 0;
 }
 
 .timer-count {
@@ -862,6 +865,13 @@ input:focus {
   font-family: "Comic Sans MS", "Comic Sans", cursive;
   font-weight: bold;
   text-shadow: 0 0 2px #000;
+}
+
+.crazy-dice-board .roll-result {
+  position: absolute;
+  top: -3.5rem;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .reward-dice-container {
@@ -1318,7 +1328,7 @@ input:focus {
   /* Center the board background */
   object-position: center;
   transform: none;
-  filter: brightness(1.2);
+  filter: brightness(1.6);
   z-index: -1;
 }
 .crazy-dice-board .dice-center {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -101,9 +101,7 @@ export default function CrazyDiceDuel() {
     return () => timerSoundRef.current?.pause();
   }, []);
 
-  useEffect(() => {
-    prepareDiceAnimation();
-  }, []);
+
 
   useEffect(() => {
     const handler = () => setMuted(isGameMuted());
@@ -192,7 +190,7 @@ export default function CrazyDiceDuel() {
     if (idx == null) {
       const { cx, cy } = getDiceCenter('center');
       setDiceStyle({
-        display: 'block',
+        display: 'none',
         position: 'fixed',
         left: '0px',
         top: '0px',
@@ -204,7 +202,7 @@ export default function CrazyDiceDuel() {
     }
     const { cx, cy } = getDiceCenter(idx);
     setDiceStyle({
-      display: 'block',
+      display: 'none',
       position: 'fixed',
       left: '0px',
       top: '0px',
@@ -256,15 +254,7 @@ export default function CrazyDiceDuel() {
       ],
       { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' },
     ).onfinish = () => {
-      setDiceStyle({
-        display: 'block',
-        position: 'fixed',
-        left: '0px',
-        top: '0px',
-        transform: `translate(${endX}px, ${endY}px) translate(-50%, -50%) scale(${DICE_PLAYER_SCALE})`,
-        pointerEvents: 'none',
-        zIndex: 50,
-      });
+      setDiceStyle({ display: 'none' });
     };
   };
 
@@ -368,6 +358,9 @@ export default function CrazyDiceDuel() {
       />
       <div ref={diceCenterRef} className="dice-center" />
       <div ref={diceRef} style={diceStyle} className="dice-travel flex flex-col items-center">
+        {rollResult !== null && (
+          <div className="text-5xl roll-result">{rollResult}</div>
+        )}
         {winner == null ? (
           <div className="crazy-dice">
             <DiceRoller
@@ -381,11 +374,6 @@ export default function CrazyDiceDuel() {
         ) : (
           <div className="text-2xl font-bold text-center">
             Player {winner + 1} wins!
-          </div>
-        )}
-        {rollResult !== null && (
-          <div className="text-5xl roll-result" style={{ transform: 'translateY(-6rem)' }}>
-            {rollResult}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- brighten Crazy Dice Duel backgrounds
- hide dice while idle and show result number above dice
- enlarge "your turn" message and remove button styling

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873976f3284832982c62c0bf05496b7