### PR TITLE
Fix Twitter handle parsing and add tests

### DIFF
--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -4,7 +4,7 @@ import User from '../models/User.js';
 import { fetchTelegramInfo } from '../utils/telegram.js';
 import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
 
-function parseTwitterHandle(input) {
+export function parseTwitterHandle(input) {
   if (!input) return '';
   let handle = String(input).trim();
   // Support handles like "x.com/user" without protocol

--- a/test/parseTwitterHandle.test.js
+++ b/test/parseTwitterHandle.test.js
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseTwitterHandle } from '../bot/routes/profile.js';
+
+test('parses usernames from URLs', () => {
+  assert.equal(parseTwitterHandle('https://twitter.com/user'), 'user');
+  assert.equal(parseTwitterHandle('twitter.com/user'), 'user');
+  assert.equal(parseTwitterHandle('https://x.com/user'), 'user');
+  assert.equal(parseTwitterHandle('x.com/user'), 'user');
+  assert.equal(parseTwitterHandle('@user'), 'user');
+});


### PR DESCRIPTION
## Summary
- export `parseTwitterHandle` utility
- add regression tests covering X/Twitter handle parsing

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_687386596f048329bd4fff3fff1daa59