### PR TITLE
Fix placement for three-player Crazy Dice Duel

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1353,6 +1353,10 @@ input:focus {
   transform: translate(-50%, -50%);
 }
 
+.crazy-dice-board.three-players .player-left {
+  top: 12%;
+}
+
 .crazy-dice-board .player-center {
   position: absolute;
   top: 16%;
@@ -1380,6 +1384,10 @@ input:focus {
   top: 19%;
   right: 5%;
   transform: translate(50%, -50%);
+}
+
+.crazy-dice-board.three-players .player-right {
+  top: 13%;
 }
 
 

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -348,7 +348,10 @@ export default function CrazyDiceDuel() {
           }}
         />
       )}
-      <div ref={boardRef} className="crazy-dice-board">
+        <div
+          ref={boardRef}
+          className={`crazy-dice-board ${playerCount === 3 ? 'three-players' : ''}`}
+        >
       {!bgUnlocked && (
         <button
           onClick={unlockBackground}


### PR DESCRIPTION
## Summary
- bump up player positions when playing Crazy Dice Duel with three players
- mark three-player boards with a CSS class

## Testing
- `npm test` *(fails: cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6873acc957208329ac9091c648a2be63