### PR TITLE
Adjust Crazy Dice Duel 1v1 layout

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -83,7 +83,9 @@ export default function CrazyDiceDuel() {
   const boardBgSrc =
     playerCount === 3
       ? '/assets/icons/file_00000000571c6243a07777efa0e0e835 (1).png'
-      : '/assets/icons/file_00000000d410620a8c1878be43e192a1.png';
+      : playerCount === 2
+        ? '/assets/icons/file_000000004fa461f4986874d9da2b93e0 (1).png'
+        : '/assets/icons/file_00000000d410620a8c1878be43e192a1.png';
 
   const boardRef = useRef(null);
   const diceRef = useRef(null);
@@ -166,9 +168,12 @@ export default function CrazyDiceDuel() {
   const getDiceCenter = (playerIdx = 'center') => {
     const posMap = {
       0: { label: 'F19', dx: -0.1 }, // Player 1
-      1: { label: 'B8', dx: -0.1 },  // Player 2
-      2: { label: 'F8' },            // Player 3
-      3: { label: 'J9' },            // Player 4
+      1:
+        playerCount === 2
+          ? { label: 'F8' }
+          : { label: 'B8', dx: -0.1 }, // Player 2
+      2: { label: 'F8' }, // Player 3
+      3: { label: 'J9' }, // Player 4
       center: { label: 'F12' },
     };
     const entry = posMap[playerIdx] || {};
@@ -410,7 +415,9 @@ export default function CrazyDiceDuel() {
         const positions =
           playerCount === 3
             ? ['player-left', 'player-right']
-            : ['player-left', 'player-center', 'player-right'];
+            : playerCount === 2
+              ? ['player-center']
+              : ['player-left', 'player-center', 'player-right'];
         const pos = positions[i] || '';
         return (
           <div key={i + 1} className={`${pos} z-10`}>


### PR DESCRIPTION
## Summary
- update board background for 1v1 Crazy Dice Duel
- center the opponent avatar when only two players
- align dice animations with the centered opponent

## Testing
- `npm test` *(fails: testCodeFailure)*

------
https://chatgpt.com/codex/tasks/task_e_6873b1e3fb148329bdf21b97c95eb929