### PR TITLE
Fix Crazy Dice duel right player dice position

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -166,16 +166,19 @@ export default function CrazyDiceDuel() {
   }, [current, aiCount, muted]);
 
   const getDiceCenter = (playerIdx = 'center') => {
-    const posMap = {
-      0: { label: 'F19', dx: -0.1 }, // Player 1
-      1:
-        playerCount === 2
-          ? { label: 'F8' }
-          : { label: 'B8', dx: -0.1 }, // Player 2
-      2: { label: 'F8' }, // Player 3
-      3: { label: 'J9' }, // Player 4
-      center: { label: 'F12' },
-    };
+      const posMap = {
+        0: { label: 'F19', dx: -0.1 }, // Player 1
+        1:
+          playerCount === 2
+            ? { label: 'F8' }
+            : { label: 'B8', dx: -0.1 }, // Player 2
+        2:
+          playerCount === 3
+            ? { label: 'J9' }
+            : { label: 'F8' }, // Player 3
+        3: { label: 'J9' }, // Player 4
+        center: { label: 'F12' },
+      };
     const entry = posMap[playerIdx] || {};
     const label = entry.label;
     const dx = entry.dx || 0;


### PR DESCRIPTION
## Summary
- correct top-right dice target when playing 3-player Crazy Dice Duel

## Testing
- `npm test` *(fails: tests hang due to missing configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6873b46a2ed48329927cdbff762b4209