### PR TITLE
Adjust Crazy Dice UI and endgame logic

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -14,11 +14,18 @@ export default function AvatarTimer({
   color,
   onClick,
   index,
+  size = 1,
 }) {
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
+  const sizeRem = 3.25 * size;
   return (
-    <div className="relative w-[3.25rem] h-[3.25rem]" onClick={onClick} data-player-index={index}>
+    <div
+      className="relative"
+      style={{ width: `${sizeRem}rem`, height: `${sizeRem}rem` }}
+      onClick={onClick}
+      data-player-index={index}
+    >
       {/* turn indicator removed */}
       {active && (
         <div className="avatar-timer-ring" style={{ '--timer-gradient': gradient }} />
@@ -26,7 +33,7 @@ export default function AvatarTimer({
       <img
         src={getAvatarUrl(photoUrl)}
         alt="player"
-        className="w-[3.25rem] h-[3.25rem] rounded-full border-2 object-cover"
+        className="rounded-full border-2 object-cover w-full h-full"
         style={{
           borderColor: color || '#fde047',
           boxShadow: isTurn ? `0 0 6px ${color || '#fde047'}` : undefined,

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1354,7 +1354,7 @@ input:focus {
 }
 
 .crazy-dice-board.three-players .player-left {
-  top: 12%;
+  top: 14%;
 }
 
 .crazy-dice-board .player-center {
@@ -1387,7 +1387,7 @@ input:focus {
 }
 
 .crazy-dice-board.three-players .player-right {
-  top: 13%;
+  top: 15%;
 }
 
 

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -331,31 +331,33 @@ export default function CrazyDiceDuel() {
 
   const allRolled = players.every((p) => p.rolls >= maxRolls);
 
-  if (winner == null && allRolled) {
-    const max = Math.max(...players.map((p) => p.score));
-    const leaders = players.filter((p) => p.score === max);
-    if (leaders.length === 1) {
-      setWinner(players.indexOf(leaders[0]));
-    } else {
-      // tie break
-      setTiePlayers(leaders.map((p, idx) => players.indexOf(p)));
-      setPlayers((prev) => prev.map((p) => ({ ...p, rolls: 0, results: [] })));
+  useEffect(() => {
+    if (winner == null && allRolled) {
+      const max = Math.max(...players.map((p) => p.score));
+      const leaders = players.filter((p) => p.score === max);
+      if (leaders.length === 1) {
+        setWinner(players.indexOf(leaders[0]));
+      } else {
+        // tie break
+        setTiePlayers(leaders.map((p) => players.indexOf(p)));
+        setPlayers((prev) => prev.map((p) => ({ ...p, rolls: 0, results: [] })));
+      }
+      setCurrent(0);
     }
-    setCurrent(0);
-    return null;
-  }
+  }, [allRolled, players, winner, maxRolls]);
 
-  if (tiePlayers && players.every((p) => p.rolls >= maxRolls)) {
-    const max = Math.max(...players.map((p) => p.score));
-    const leaders = players.filter((p) => p.score === max);
-    if (leaders.length === 1) {
-      setWinner(players.indexOf(leaders[0]));
-    } else {
-      setPlayers((prev) => prev.map((p) => ({ ...p, rolls: 0, results: [] }))); 
+  useEffect(() => {
+    if (tiePlayers && players.every((p) => p.rolls >= maxRolls)) {
+      const max = Math.max(...players.map((p) => p.score));
+      const leaders = players.filter((p) => p.score === max);
+      if (leaders.length === 1) {
+        setWinner(players.indexOf(leaders[0]));
+      } else {
+        setPlayers((prev) => prev.map((p) => ({ ...p, rolls: 0, results: [] })));
+      }
+      setCurrent(0);
     }
-    setCurrent(0);
-    return null;
-  }
+  }, [players, tiePlayers, maxRolls]);
 
 
 
@@ -426,6 +428,7 @@ export default function CrazyDiceDuel() {
           rollHistory={players[0].results}
           maxRolls={maxRolls}
           color={players[0].color}
+          size={playerCount === 2 ? 1.3 : 1}
           onClick={rollNow}
         />
       </div>
@@ -454,6 +457,7 @@ export default function CrazyDiceDuel() {
             rollHistory={p.results}
             maxRolls={maxRolls}
             color={p.color}
+            size={playerCount === 3 ? 1.1 : 1}
             onClick={() => {
               if (current === i + 1) setTrigger((t) => t + 1);
             }}


### PR DESCRIPTION
## Summary
- scale avatars dynamically via a new `size` prop
- tweak Crazy Dice avatar sizes for 1v1 and 3-player games
- nudge top opponent avatars downward
- move endgame winner logic into effects to avoid freeze

## Testing
- `npm test` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6873be00b82483298a6020ae124cee12