### PR TITLE
Fix crazy dice duel freeze on last roll

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -351,7 +351,11 @@ export default function CrazyDiceDuel() {
           : p
       );
       nextIndex = (current + 1) % updated.length;
-      while (updated[nextIndex].rolls >= maxRolls) nextIndex = (nextIndex + 1) % updated.length;
+      let attempts = 0;
+      while (updated[nextIndex].rolls >= maxRolls && attempts < updated.length) {
+        nextIndex = (nextIndex + 1) % updated.length;
+        attempts += 1;
+      }
       return updated;
     });
     setRollResult(value);


### PR DESCRIPTION
## Summary
- avoid infinite loop when finding next player in Crazy Dice Duel

## Testing
- `npm test` *(fails: Bot may fail to connect, tests hang)*

------
https://chatgpt.com/codex/tasks/task_e_68741a7126f48329811c33e3c4bce0a4