### PR TITLE
Update Crazy Dice Duel card image

### DIFF
--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -13,7 +13,11 @@ export default function Games() {
           icon={<img src="/assets/icons/snakes_and_ladders.webp" alt="" className="h-24 w-24 mx-auto" />}
           link="/games/snake/lobby"
         />
-        <GameCard title="Crazy Dice Duel" icon="🎲" link="/games/crazydice/lobby" />
+        <GameCard
+          title="Crazy Dice Duel"
+          icon={<img src="/assets/icons/Crazy_Dice_Duel_Promo.webp" alt="" className="h-24 w-24 mx-auto" />}
+          link="/games/crazydice/lobby"
+        />
         <LeaderboardCard />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- use Crazy_Dice_Duel_Promo.webp on Games page

## Testing
- `npm test` *(fails: Operation `gameresults.insertOne()` buffering timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68748bc8aa4c8329a0302e436d6b57ac