### PR TITLE
Add Achievements card on home page

### DIFF
--- a/webapp/src/components/AchievementsCard.jsx
+++ b/webapp/src/components/AchievementsCard.jsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import { getProfile } from '../utils/api.js';
+import { getTelegramId } from '../utils/telegram.js';
+import LoginOptions from './LoginOptions.jsx';
+import { Link } from 'react-router-dom';
+
+export default function AchievementsCard() {
+  let telegramId;
+  try {
+    telegramId = getTelegramId();
+  } catch (err) {
+    return (
+      <div className="bg-surface border border-border rounded-xl wide-card">
+        <LoginOptions />
+      </div>
+    );
+  }
+
+  const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const prof = await getProfile(telegramId);
+        setProfile(prof);
+      } catch (err) {
+        console.error('Failed to load profile', err);
+      }
+    }
+    load();
+  }, [telegramId]);
+
+  if (!profile) {
+    return (
+      <div className="relative bg-surface border border-border rounded-xl p-4 text-subtext text-center overflow-hidden wide-card">
+        <img
+          src="/assets/SnakeLaddersbackground.png"
+          className="background-behind-board object-cover"
+          alt=""
+          onError={(e) => { e.currentTarget.style.display = 'none'; }}
+        />
+        Loading achievements...
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+        onError={(e) => { e.currentTarget.style.display = 'none'; }}
+      />
+      <h3 className="text-lg font-bold text-center">Achievements</h3>
+      <p className="text-center text-sm">Daily Streak: {profile.dailyStreak || 0} days</p>
+      <p className="text-center text-sm">Mined TPC: {formatValue(profile.minedTPC || 0, 0)}</p>
+      <p className="text-center text-sm">Gifts Collected: {profile.gifts ? profile.gifts.length : 0}</p>
+      <Link
+        to="/tasks"
+        className="mx-auto block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow text-center"
+      >
+        View Tasks
+      </Link>
+    </div>
+  );
+}
+
+function formatValue(value, decimals = 2) {
+  if (typeof value !== 'number') {
+    const parsed = parseFloat(value);
+    if (isNaN(parsed)) return value;
+    return parsed.toLocaleString(undefined, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    });
+  }
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -6,6 +6,7 @@ import GameCard from '../components/GameCard.jsx';
 import TasksCard from '../components/TasksCard.jsx';
 import StoreAd from '../components/StoreAd.jsx';
 import NftGiftCard from '../components/NftGiftCard.jsx';
+import AchievementsCard from '../components/AchievementsCard.jsx';
 import HomeGamesCard from '../components/HomeGamesCard.jsx';
 
 import {
@@ -380,6 +381,7 @@ export default function Home() {
           </Link>
         </div>
       </div>
+      <AchievementsCard />
 
       {stats && (
         <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">


### PR DESCRIPTION
## Summary
- show achievements between the Tokenomics and Platform Stats sections
- fetch basic profile info for achievements

## Testing
- `npm test` *(fails: Failed to store game result)*

------
https://chatgpt.com/codex/tasks/task_e_6874b53f430c83298904aeba82b57949