### PR TITLE
Add project achievements card and relocate user achievements

### DIFF
--- a/webapp/src/components/AchievementsCard.jsx
+++ b/webapp/src/components/AchievementsCard.jsx
@@ -4,16 +4,18 @@ import { getTelegramId } from '../utils/telegram.js';
 import LoginOptions from './LoginOptions.jsx';
 import { Link } from 'react-router-dom';
 
-export default function AchievementsCard() {
-  let telegramId;
-  try {
-    telegramId = getTelegramId();
-  } catch (err) {
-    return (
-      <div className="bg-surface border border-border rounded-xl wide-card">
-        <LoginOptions />
-      </div>
-    );
+export default function AchievementsCard({ telegramId: propTelegramId }) {
+  let telegramId = propTelegramId;
+  if (!telegramId) {
+    try {
+      telegramId = getTelegramId();
+    } catch (err) {
+      return (
+        <div className="bg-surface border border-border rounded-xl wide-card">
+          <LoginOptions />
+        </div>
+      );
+    }
   }
 
   const [profile, setProfile] = useState(null);

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -5,6 +5,7 @@ import GiftPopup from './GiftPopup.jsx';
 import GiftIcon from './GiftIcon.jsx';
 import { getAccountInfo, getSnakeResults } from '../utils/api.js';
 import { NFT_GIFTS } from '../utils/nftGifts.js';
+import AchievementsCard from './AchievementsCard.jsx';
 
 export default function PlayerInvitePopup({
   open,
@@ -111,6 +112,7 @@ export default function PlayerInvitePopup({
               )}
             </ul>
           </div>
+          <AchievementsCard telegramId={player.telegramId} />
           <div className="space-y-1">
             <p className="font-semibold">Game</p>
             <div className="flex justify-center space-x-2">

--- a/webapp/src/components/ProjectAchievementsCard.jsx
+++ b/webapp/src/components/ProjectAchievementsCard.jsx
@@ -1,0 +1,45 @@
+import { Link } from 'react-router-dom';
+
+export default function ProjectAchievementsCard() {
+  const achievements = [
+    '🔐 Smart-contract presale live with auto-delivery',
+    '🚀 TPC deployed on TON network',
+    '🧾 Wallet transaction history works',
+    '💬 In-chat TPC transfers enabled',
+    '🎲 Snake & Ladder multiplayer game',
+    '🧑‍🤝‍🤝 Friends and inbox chat',
+    '🕹️ Telegram bot and web app integration',
+    '🎲 Crazy Dice Duel mini-game',
+    '🔄 Daily Check-In rewards',
+    '⛏️ Mining system active',
+    '📺 Ad watch rewards',
+    '🎯 Social tasks for Twitter, Telegram, TikTok',
+    '📹 Intro video view rewards',
+    '🎡 Spin & Win wheel',
+    '🍀 Lucky Card prizes',
+    '🎁 NFT Gifts marketplace',
+  ];
+
+  return (
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
+      <img
+        src="/assets/SnakeLaddersbackground.png"
+        className="background-behind-board object-cover"
+        alt=""
+        onError={(e) => { e.currentTarget.style.display = 'none'; }}
+      />
+      <h3 className="text-lg font-bold text-center">TonPlaygram Achievements</h3>
+      <ul className="list-disc pl-6 text-sm space-y-1">
+        {achievements.map((a) => (
+          <li key={a}>{a}</li>
+        ))}
+      </ul>
+      <Link
+        to="/tokenomics"
+        className="mx-auto block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow text-center"
+      >
+        View More
+      </Link>
+    </div>
+  );
+}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -6,7 +6,7 @@ import GameCard from '../components/GameCard.jsx';
 import TasksCard from '../components/TasksCard.jsx';
 import StoreAd from '../components/StoreAd.jsx';
 import NftGiftCard from '../components/NftGiftCard.jsx';
-import AchievementsCard from '../components/AchievementsCard.jsx';
+import ProjectAchievementsCard from '../components/ProjectAchievementsCard.jsx';
 import HomeGamesCard from '../components/HomeGamesCard.jsx';
 
 import {
@@ -381,7 +381,7 @@ export default function Home() {
           </Link>
         </div>
       </div>
-      <AchievementsCard />
+      <ProjectAchievementsCard />
 
       {stats && (
         <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -28,6 +28,7 @@ import InfoPopup from '../components/InfoPopup.jsx';
 import DevNotifyModal from '../components/DevNotifyModal.jsx';
 import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
 import Wallet from './Wallet.jsx';
+import AchievementsCard from '../components/AchievementsCard.jsx';
 
 import { FiCopy } from 'react-icons/fi';
 
@@ -383,6 +384,7 @@ export default function MyAccount() {
       </div>
 
       <BalanceSummary className="bg-surface border border-border rounded-xl p-4 wide-card" />
+      <AchievementsCard telegramId={telegramId} />
 
       {profile && profile.accountId === DEV_ACCOUNT_ID && (
         <>


### PR DESCRIPTION
## Summary
- add re-usable AchievementsCard with optional telegramId prop
- show AchievementsCard in user invite popup and profile page
- create ProjectAchievementsCard for home page
- replace home page Achievements card with project achievements

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874c29de0f8832980091b1afafda580