### PR TITLE
Add referral list API

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ The request body must include a `text` field. Only tokens listed in
 `AIRDROP_ADMIN_TOKENS` are allowed to call this endpoint.
 
 
+### Referral
+
+List everyone invited by a specific referral code:
+
+```
+GET /api/referral/list/<code>
+```
+
+The response is an array of users with at least their Telegram ID and
+nickname or name fields.
+
+
 ### Customizing Snakes & Ladders icons
 
 All webapp icons are stored under `webapp/public`. The board uses emoji symbols

--- a/bot/routes/referral.js
+++ b/bot/routes/referral.js
@@ -60,4 +60,13 @@ router.post('/claim', async (req, res) => {
   res.json({ message: 'claimed', total: count });
 });
 
+router.get('/list/:code', async (req, res) => {
+  const { code } = req.params;
+  const users = await User.find(
+    { referredBy: code },
+    'telegramId nickname firstName lastName'
+  ).lean();
+  res.json(users);
+});
+
 export default router;


### PR DESCRIPTION
## Summary
- add GET /api/referral/list/:code endpoint
- document the new route in README

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6874c7f1b6b883299002b5c5f418ab81