### PR TITLE
Fix leaderboard play indicators

### DIFF
--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -49,11 +49,6 @@ export default function LeaderboardCard() {
   const [groupPopup, setGroupPopup] = useState(false);
 
   useEffect(() => {
-    getLeaderboard(telegramId).then((data) => {
-      setLeaderboard(data.users);
-      setRank(data.rank);
-    });
-
     const saved = loadAvatar();
     if (saved) {
       setMyPhotoUrl(saved);
@@ -86,6 +81,18 @@ export default function LeaderboardCard() {
           });
         });
     }
+  }, [telegramId]);
+
+  useEffect(() => {
+    function loadLeaderboard() {
+      getLeaderboard(telegramId).then((data) => {
+        setLeaderboard(data.users);
+        setRank(data.rank);
+      });
+    }
+    loadLeaderboard();
+    const id = setInterval(loadLeaderboard, 15000);
+    return () => clearInterval(id);
   }, [telegramId]);
 
   useEffect(() => {

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -3,9 +3,17 @@ import { createPortal } from 'react-dom';
 import RoomSelector from './RoomSelector.jsx';
 import GiftPopup from './GiftPopup.jsx';
 import GiftIcon from './GiftIcon.jsx';
-import { getAccountInfo, getSnakeResults } from '../utils/api.js';
+import { FaTv } from 'react-icons/fa';
+import { getAccountInfo, getSnakeResults, getWatchCount } from '../utils/api.js';
 import { NFT_GIFTS } from '../utils/nftGifts.js';
 import AchievementsCard from './AchievementsCard.jsx';
+
+function getGameFromTableId(id) {
+  if (!id) return 'snake';
+  const prefix = id.split('-')[0];
+  if (['snake', 'ludo', 'crazydice', 'horse'].includes(prefix)) return prefix;
+  return 'snake';
+}
 
 export default function PlayerInvitePopup({
   open,
@@ -19,6 +27,7 @@ export default function PlayerInvitePopup({
   const [records, setRecords] = useState([]);
   const [giftOpen, setGiftOpen] = useState(false);
   const [game, setGame] = useState('snake');
+  const [watchCount, setWatchCount] = useState(0);
 
   useEffect(() => {
     if (!open || !player) return;
@@ -36,6 +45,13 @@ export default function PlayerInvitePopup({
         );
         setRecords(rec.slice(0, 5));
       })
+      .catch(() => {});
+  }, [open, player]);
+
+  useEffect(() => {
+    if (!open || !player?.currentTableId) return;
+    getWatchCount(player.currentTableId)
+      .then((c) => setWatchCount(c.count))
       .catch(() => {});
   }, [open, player]);
 
@@ -75,6 +91,23 @@ export default function PlayerInvitePopup({
                 />
                 {balance}
               </p>
+            )}
+            {player.currentTableId && (
+              <div className="flex items-center justify-center gap-1 mt-1 text-sm">
+                <span className="text-red-500">Playing</span>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    const game = getGameFromTableId(player.currentTableId);
+                    window.location.href = `/games/${game}?table=${player.currentTableId}&watch=1`;
+                  }}
+                  className="text-white flex items-center space-x-1"
+                >
+                  <FaTv />
+                  <span>Watch</span>
+                  <span className="text-green-500">{watchCount}</span>
+                </button>
+              </div>
             )}
           </div>
           <div>


### PR DESCRIPTION
## Summary
- refresh leaderboard periodically
- show playing indicator in invite popup

## Testing
- `npm test` *(fails: Could not complete due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6874e1d0649c8329b46b66746a28333a