### PR TITLE
Fix crazy dice board vertical offset

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1317,6 +1317,9 @@ input:focus {
   width: 100vw;
   height: 100vh;
   overflow: hidden;
+  /* Move the entire board down a bit so overlays align with the
+     new background while keeping their original sizes */
+  transform: translateY(10vh);
   /* Ensure the entire board image is visible */
 }
 .crazy-dice-board .board-bg {


### PR DESCRIPTION
## Summary
- move `crazy-dice-board` 10vh down so avatars and dice match new background

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_687500bb44ac8329a3a17af8d5f3b3a6