### PR TITLE
Add Lucky card background

### DIFF
--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import luckyCardBg from '/assets/icons/lucky_card_bg.webp';
 import DiceRoller from './DiceRoller.jsx';
 import RewardPopup from './RewardPopup.tsx';
 import { numericSegments } from '../utils/rewardLogic';
@@ -95,9 +96,9 @@ export default function LuckyNumber() {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 text-center overflow-hidden wide-card">
       <img
-        src="/assets/icons/lucky_card_bg.webp"
+        src={luckyCardBg}
         className="absolute inset-0 w-full h-full object-cover -z-10 pointer-events-none"
-        alt=""
+        alt="Lucky card background"
         onError={(e) => {
           e.currentTarget.style.display = 'none';
         }}


### PR DESCRIPTION
## Summary
- set dedicated background image for Lucky Number card

## Testing
- `npm test` *(fails: Failed to store game result)*

------
https://chatgpt.com/codex/tasks/task_e_687527e2fb648329b81b32d909eedae2