### PR TITLE
Update Crazy Dice Duel backgrounds

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -139,9 +139,12 @@ export default function CrazyDiceDuel() {
 
   // Board background changes depending on number of opponents
   const BG_BY_PLAYERS = {
-    2: '/assets/icons/file_000000004c0c6243bf81f848563832f3.webp', // 1v1
-    3: '/assets/icons/file_00000000077462468c5871b59180ae3e.webp', // vs 2 others
-    4: '/assets/icons/file_0000000095a06246adc25e3e6ba244a4.webp', // vs 3 others
+    // 1v1 match
+    2: '/assets/icons/file_00000000c9bc61f5825aa75d64fe234a.webp',
+    // Versus two other players
+    3: '/assets/icons/file_000000008b1061f68f37fd941a1efcb4.webp',
+    // Versus three other players
+    4: '/assets/icons/file_000000003a9c622f8e50bd5d8f381471.webp',
   };
   const boardBgSrc = BG_BY_PLAYERS[playerCount] || BG_BY_PLAYERS[4];
 


### PR DESCRIPTION
## Summary
- use new background images for Crazy Dice Duel depending on player count

## Testing
- `npm test` *(fails: test suite userUtils.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68752fc9342c8329aff5a9e03f2b4338