### PR TITLE
Fix background images for Crazy Dice Duel

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -139,9 +139,10 @@ export default function CrazyDiceDuel() {
 
   // Board background changes depending on number of opponents
   const BG_BY_PLAYERS = {
-    2: '/assets/icons/file_000000004c0c6243bf81f848563832f3.webp', // 1v1
-    3: '/assets/icons/file_00000000077462468c5871b59180ae3e.webp', // vs 2 others
-    4: '/assets/icons/file_0000000095a06246adc25e3e6ba244a4.webp', // vs 3 others
+    // Backgrounds were renamed in a recent update
+    2: '/assets/icons/file_000000003a9c622f8e50bd5d8f381471.webp', // 1v1
+    3: '/assets/icons/file_000000008b1061f68f37fd941a1efcb4.webp', // vs 2 others
+    4: '/assets/icons/file_00000000c9bc61f5825aa75d64fe234a.webp', // vs 3 others
   };
   const boardBgSrc = BG_BY_PLAYERS[playerCount] || BG_BY_PLAYERS[4];
 


### PR DESCRIPTION
## Summary
- fix board background paths in CrazyDiceDuel

## Testing
- `npm test` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_687536b002bc83299cfce2a01731a46d