### PR TITLE
Fix CrazyDiceDuel background mapping

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -140,9 +140,9 @@ export default function CrazyDiceDuel() {
   // Board background changes depending on number of opponents
   const BG_BY_PLAYERS = {
     // Backgrounds were renamed in a recent update
-    2: '/assets/icons/file_000000003a9c622f8e50bd5d8f381471.webp', // 1v1
+    2: '/assets/icons/file_00000000c9bc61f5825aa75d64fe234a.webp', // 1v1
     3: '/assets/icons/file_000000008b1061f68f37fd941a1efcb4.webp', // vs 2 others
-    4: '/assets/icons/file_00000000c9bc61f5825aa75d64fe234a.webp', // vs 3 others
+    4: '/assets/icons/file_000000003a9c622f8e50bd5d8f381471.webp', // vs 3 others
   };
   const boardBgSrc = BG_BY_PLAYERS[playerCount] || BG_BY_PLAYERS[4];
 


### PR DESCRIPTION
## Summary
- correct background image mapping for CrazyDiceDuel

## Testing
- `npm test` *(fails: cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68753ca5dd6c8329ba0989fd9dede3f7