### PR TITLE
Add Crazy Dice Duel grid overlay

### DIFF
--- a/webapp/src/components/BoardGridOverlay.jsx
+++ b/webapp/src/components/BoardGridOverlay.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+const COLS = 20;
+const ROWS = 30;
+const LETTERS = 'ABCDEFGHIJKLMNOPQRST'.split('');
+
+export default function BoardGridOverlay({ className = '' }) {
+  const lines = [];
+  for (let i = 0; i <= COLS; i++) {
+    lines.push(
+      <line
+        key={`v${i}`}
+        x1={i}
+        y1={0}
+        x2={i}
+        y2={ROWS}
+        stroke="rgba(255,255,255,0.3)"
+        strokeWidth={0.05}
+      />,
+    );
+  }
+  for (let j = 0; j <= ROWS; j++) {
+    lines.push(
+      <line
+        key={`h${j}`}
+        x1={0}
+        y1={j}
+        x2={COLS}
+        y2={j}
+        stroke="rgba(255,255,255,0.3)"
+        strokeWidth={0.05}
+      />,
+    );
+  }
+  const letterLabels = LETTERS.map((l, i) => (
+    <text
+      key={`l${i}`}
+      x={i + 0.5}
+      y={-0.3}
+      textAnchor="middle"
+      fontSize={0.8}
+      fill="white"
+    >
+      {l}
+    </text>
+  ));
+  const numberLabels = Array.from({ length: ROWS }, (_, j) => (
+    <text
+      key={`n${j}`}
+      x={-0.3}
+      y={j + 0.7}
+      textAnchor="end"
+      fontSize={0.8}
+      fill="white"
+    >
+      {j + 1}
+    </text>
+  ));
+
+  return (
+    <svg
+      className={`absolute inset-0 pointer-events-none ${className}`}
+      viewBox="-0.5 -0.5 21 31"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {lines}
+      {letterLabels}
+      {numberLabels}
+    </svg>
+  );
+}

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -12,6 +12,7 @@ import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
 import GiftPopup from '../../components/GiftPopup.jsx';
 import GameEndPopup from '../../components/GameEndPopup.jsx';
+import BoardGridOverlay from '../../components/BoardGridOverlay.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
   loadAvatar,
@@ -461,6 +462,7 @@ export default function CrazyDiceDuel() {
         </button>
       )}
       <img src={boardBgSrc} alt="board" className="board-bg" />
+      <BoardGridOverlay />
       <div ref={diceCenterRef} className="dice-center" />
       <div ref={diceRef} style={diceStyle} className="dice-travel flex flex-col items-center">
         {rollResult !== null && (


### PR DESCRIPTION
## Summary
- revert image replacements and overlay the grid programmatically
- new `BoardGridOverlay` component draws a 20×30 labelled grid
- Crazy Dice Duel backgrounds now include the overlay

## Testing
- `npm test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6875476fa4ac83298cbe89c12dfe4363