### PR TITLE
Adjust crazy dice duel layout for three players

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1333,8 +1333,8 @@ input:focus {
 }
 .crazy-dice-board .dice-center {
   position: absolute;
-  top: 57.5%;
-  left: 55%;
+  top: 78.33%;
+  left: 52.5%;
   transform: translate(-50%, -50%);
 }
 
@@ -1354,7 +1354,8 @@ input:focus {
 }
 
 .crazy-dice-board.three-players .player-left {
-  top: 14%;
+  top: 25%;
+  left: 15%;
 }
 
 .crazy-dice-board .player-center {
@@ -1387,8 +1388,8 @@ input:focus {
 }
 
 .crazy-dice-board.three-players .player-right {
-  top: 14%;
-  right: 4%;
+  top: 25%;
+  right: 12.5%;
 }
 
 

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -231,18 +231,20 @@ export default function CrazyDiceDuel() {
         // Bottom player dice position – centre bottom of the board
         0: { label: 'K30' },
         // Top player dice position. When only two players are present this
-        // represents the opponent at the top of the board.
+        // represents the opponent at the top of the board. When facing two
+        // opponents (three players total) the dice are positioned according
+        // to the updated Crazy Dice board layout.
         1:
           playerCount === 2
             ? { label: 'K20' }
-            : { label: 'B8', dx: -0.1 },
+            : { label: 'E17' },
         2:
           playerCount === 3
-            ? { label: 'J9' }
+            ? { label: 'R17' }
             : { label: 'F8' },
         3: { label: 'J9' },
         // Dice roll animation centre
-        center: { label: 'K25' },
+        center: { label: 'K24' },
       };
     const entry = posMap[playerIdx] || {};
     const label = entry.label;


### PR DESCRIPTION
## Summary
- reposition dice centers for three-player games in Crazy Dice Duel
- move top player dice to E17 and R17
- drop dice to K24
- update CSS for avatar and dice positions when three players join

## Testing
- `npm run install-all`
- `npm test` *(fails: BOT_TOKEN not configured)*

------
https://chatgpt.com/codex/tasks/task_e_687559bc19d08329975a629fefe60c77