### PR TITLE
Adjust Crazy Dice 1v1 layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1333,15 +1333,17 @@ input:focus {
 }
 .crazy-dice-board .dice-center {
   position: absolute;
-  top: 78.33%;
-  left: 52.5%;
+  /* Center updated to guide box J26 */
+  top: 85%;
+  left: 47.5%;
   transform: translate(-50%, -50%);
 }
 
 /* Player positions around the Crazy Dice board */
 .crazy-dice-board .player-bottom {
   position: absolute;
-  bottom: 2%;
+  /* Moved slightly up for better spacing */
+  bottom: 8%;
   left: 50%;
   transform: translateX(-50%);
 }
@@ -1361,7 +1363,8 @@ input:focus {
 .crazy-dice-board .player-center {
   position: absolute;
   top: 18%;
-  left: 48%;
+  /* Nudged slightly to the right */
+  left: 52%;
   transform: translate(-50%, -50%);
 }
 .crazy-dice-board .player-center .player-score,

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -228,23 +228,23 @@ export default function CrazyDiceDuel() {
 
   const getDiceCenter = (playerIdx = 'center') => {
       const posMap = {
-        // Bottom player dice position – centre bottom of the board
-        0: { label: 'K30' },
+        // Bottom player dice position – moved slightly up
+        0: { label: 'K28' },
         // Top player dice position. When only two players are present this
         // represents the opponent at the top of the board. When facing two
         // opponents (three players total) the dice are positioned according
         // to the updated Crazy Dice board layout.
         1:
           playerCount === 2
-            ? { label: 'K20' }
+            ? { label: 'J20' }
             : { label: 'E17' },
         2:
           playerCount === 3
             ? { label: 'R17' }
             : { label: 'F8' },
         3: { label: 'J9' },
-        // Dice roll animation centre
-        center: { label: 'K24' },
+        // Dice roll animation centre now aligned with guide box J26
+        center: { label: 'J26' },
       };
     const entry = posMap[playerIdx] || {};
     const label = entry.label;


### PR DESCRIPTION
## Summary
- nudge the dice landing location and player positions in 1v1 Crazy Dice Duel
- move the bottom player's avatar and dice slightly up
- shift the top player's avatar a bit right
- align dice landing animation to board guide J26

## Testing
- `npm test` *(fails: cannot find packages express/mongoose)*

------
https://chatgpt.com/codex/tasks/task_e_687562f454808329bb09e1fbab00406d