### PR TITLE
Adjust Crazy Dice Duel positions

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1342,8 +1342,8 @@ input:focus {
 /* Player positions around the Crazy Dice board */
 .crazy-dice-board .player-bottom {
   position: absolute;
-  /* Moved slightly up for better spacing */
-  bottom: 8%;
+  /* Slightly higher than the 1v1 layout */
+  bottom: 4%;
   left: 50%;
   transform: translateX(-50%);
 }
@@ -1356,8 +1356,9 @@ input:focus {
 }
 
 .crazy-dice-board.three-players .player-left {
+  /* Between C&D horizontally and rows 7&8 vertically */
   top: 25%;
-  left: 15%;
+  left: 17.5%;
 }
 
 .crazy-dice-board .player-center {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -229,7 +229,7 @@ export default function CrazyDiceDuel() {
   const getDiceCenter = (playerIdx = 'center') => {
       const posMap = {
         // Bottom player dice position – moved slightly up
-        0: { label: 'K28' },
+        0: { label: 'K29' },
         // Top player dice position. When only two players are present this
         // represents the opponent at the top of the board. When facing two
         // opponents (three players total) the dice are positioned according
@@ -237,7 +237,7 @@ export default function CrazyDiceDuel() {
         1:
           playerCount === 2
             ? { label: 'J20' }
-            : { label: 'E17' },
+            : { label: 'D17' },
         2:
           playerCount === 3
             ? { label: 'R17' }


### PR DESCRIPTION
## Summary
- nudge bottom player higher
- reposition top-left avatar for 3-player mode
- place top-left dice at D17 and tweak bottom dice location

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68756645f3ac8329bf0a1a425672ebf1