### PR TITLE
Fix Crazy Dice layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1333,8 +1333,8 @@ input:focus {
 }
 .crazy-dice-board .dice-center {
   position: absolute;
-  /* Center updated to guide box J26 */
-  top: 85%;
+  /* Center updated to guide box J25 */
+  top: 84%;
   left: 47.5%;
   transform: translate(-50%, -50%);
 }
@@ -1343,7 +1343,7 @@ input:focus {
 .crazy-dice-board .player-bottom {
   position: absolute;
   /* Slightly higher than the 1v1 layout */
-  bottom: 4%;
+  bottom: 5%;
   left: 50%;
   transform: translateX(-50%);
 }
@@ -1362,7 +1362,7 @@ input:focus {
 
 .crazy-dice-board.three-players .player-left {
   /* Between C&D horizontally and rows 7&8 vertically */
-  top: 25%;
+  top: 23%;
   left: 17.5%;
 }
 
@@ -1402,7 +1402,7 @@ input:focus {
 }
 
 .crazy-dice-board.three-players .player-right {
-  top: 25%;
+  top: 23%;
   right: 12.5%;
 }
 

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -231,23 +231,23 @@ export default function CrazyDiceDuel() {
         // Bottom player dice position – move slightly up in 1v1
         0:
           playerCount === 2
-            ? { label: 'J25' }
-            : { label: 'K29' },
+            ? { label: 'J24' }
+            : { label: 'K28' },
         // Top player dice position. When only two players are present this
         // represents the opponent at the top of the board. When facing two
         // opponents (three players total) the dice are positioned according
         // to the updated Crazy Dice board layout.
         1:
           playerCount === 2
-            ? { label: 'K20' }
-            : { label: 'D17' },
+            ? { label: 'K19' }
+            : { label: 'D16' },
         2:
           playerCount === 3
-            ? { label: 'R17' }
-            : { label: 'F8' },
-        3: { label: 'J9' },
-        // Dice roll animation centre now aligned with guide box J26
-        center: { label: 'J26' },
+            ? { label: 'R16' }
+            : { label: 'F7' },
+        3: { label: 'J8' },
+        // Dice roll animation centre now aligned with guide box J25
+        center: { label: 'J25' },
       };
     const entry = posMap[playerIdx] || {};
     const label = entry.label;


### PR DESCRIPTION
## Summary
- adjust dice positions slightly upward for 3-player games
- nudge bottom avatar and opponent avatars higher

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875724af8b083299b6c79a8772212ea