### PR TITLE
Add grid references overlay for Crazy Dice Duel

### DIFF
--- a/webapp/src/components/BoardGridOverlay.jsx
+++ b/webapp/src/components/BoardGridOverlay.jsx
@@ -57,15 +57,37 @@ export default function BoardGridOverlay({ className = '' }) {
     </text>
   ));
 
+  const cellLabels = [];
+  for (let i = 0; i < COLS; i++) {
+    for (let j = 0; j < ROWS; j++) {
+      cellLabels.push(
+        <text
+          key={`c${i}-${j}`}
+          x={i + 0.5}
+          y={j + 0.6}
+          textAnchor="middle"
+          fontSize={0.6}
+          fill="white"
+          opacity={0.5}
+        >
+          {`${LETTERS[i]}${j + 1}`}
+        </text>
+      );
+    }
+  }
+
   return (
     <svg
-      className={`absolute inset-0 pointer-events-none ${className}`}
+      className={`fixed inset-0 w-screen h-screen pointer-events-none ${className}`}
       viewBox="-0.5 -0.5 21 31"
       xmlns="http://www.w3.org/2000/svg"
+      width="100%"
+      height="100%"
     >
       {lines}
       {letterLabels}
       {numberLabels}
+      {cellLabels}
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- enhance Crazy Dice board overlay to fill the screen
- add per-cell labels like A1, B2, ... for easier positioning

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_6875da1170808329a821865aaaafe3da