### PR TITLE
Adjust dice path for 1v1 Crazy Dice

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1333,10 +1333,15 @@ input:focus {
 }
 .crazy-dice-board .dice-center {
   position: absolute;
-  /* Center updated to guide box J25 */
+  /* Default center aligned with J25 */
   top: 84%;
   left: 47.5%;
   transform: translate(-50%, -50%);
+}
+
+/* Adjust dice landing spot for 1v1 games */
+.crazy-dice-board.two-players .dice-center {
+  top: 72%;
 }
 
 /* Player positions around the Crazy Dice board */
@@ -1350,7 +1355,7 @@ input:focus {
 
 /* Adjust bottom player position for 1v1 games */
 .crazy-dice-board.two-players .player-bottom {
-  bottom: 7%;
+  bottom: 8%;
 }
 
 .crazy-dice-board .player-left {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -154,9 +154,9 @@ export default function CrazyDiceDuel() {
   const [rollResult, setRollResult] = useState(null);
   const [showPrompt, setShowPrompt] = useState(false);
   // Dice scales: shrink when at a player's position and expand when rolling
-  // Reduce dice size by 20% when idle or landing
-  const DICE_CENTER_SCALE = 0.8;
-  const DICE_PLAYER_SCALE = 0.48;
+  // In 1v1 mode dice should start small and grow to normal size when rolling
+  const DICE_CENTER_SCALE = 1;
+  const DICE_PLAYER_SCALE = 0.4;
   const DICE_ANIM_DURATION = 1000;
 
   // Board grid size for positioning helpers. Updated to match the
@@ -228,26 +228,23 @@ export default function CrazyDiceDuel() {
 
   const getDiceCenter = (playerIdx = 'center') => {
       const posMap = {
-        // Bottom player dice position – move slightly up in 1v1
+        // Bottom player dice position
         0:
           playerCount === 2
-            ? { label: 'J24' }
+            ? { label: 'J28' }
             : { label: 'K28' },
-        // Top player dice position. When only two players are present this
-        // represents the opponent at the top of the board. When facing two
-        // opponents (three players total) the dice are positioned according
-        // to the updated Crazy Dice board layout.
+        // Top player dice position in 1v1 starts from J16
         1:
           playerCount === 2
-            ? { label: 'K19' }
+            ? { label: 'J16' }
             : { label: 'D16' },
         2:
           playerCount === 3
             ? { label: 'R16' }
             : { label: 'F7' },
         3: { label: 'J8' },
-        // Dice roll animation centre now aligned with guide box J25
-        center: { label: 'J25' },
+        // Dice roll animation centre for 1v1 at J22
+        center: { label: playerCount === 2 ? 'J22' : 'J25' },
       };
     const entry = posMap[playerIdx] || {};
     const label = entry.label;


### PR DESCRIPTION
## Summary
- tweak dice scaling constants
- set new dice path coordinates for 1v1 games
- update grid coordinates in CSS

## Testing
- `npm test` *(fails: BOT_TOKEN not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6875e1c6fef48329b77d7ac07c469d19