### PR TITLE
Update Crazy Dice duel layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1339,6 +1339,12 @@ input:focus {
   transform: translate(-50%, -50%);
 }
 
+/* Dice landing spot when facing two opponents */
+.crazy-dice-board.three-players .dice-center {
+  top: 66%;
+  left: 47.5%;
+}
+
 /* Adjust dice landing spot for 1v1 games */
 .crazy-dice-board.two-players .dice-center {
   top: 72%;
@@ -1351,6 +1357,12 @@ input:focus {
   bottom: 5%;
   left: 50%;
   transform: translateX(-50%);
+}
+
+/* Position of the bottom avatar when facing two opponents */
+.crazy-dice-board.three-players .player-bottom {
+  bottom: 8%;
+  left: 47.5%;
 }
 
 /* Adjust bottom player position for 1v1 games */
@@ -1366,9 +1378,9 @@ input:focus {
 }
 
 .crazy-dice-board.three-players .player-left {
-  /* Between C&D horizontally and rows 7&8 vertically */
-  top: 23%;
-  left: 17.5%;
+  /* Positioned around E13 on the grid */
+  top: 42%;
+  left: 22.5%;
 }
 
 .crazy-dice-board .player-center {
@@ -1407,7 +1419,8 @@ input:focus {
 }
 
 .crazy-dice-board.three-players .player-right {
-  top: 23%;
+  /* Positioned around R14 on the grid */
+  top: 45%;
   right: 12.5%;
 }
 

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -232,19 +232,29 @@ export default function CrazyDiceDuel() {
         0:
           playerCount === 2
             ? { label: 'J28' }
-            : { label: 'K28' },
-        // Top player dice position in 1v1 starts from J16
+            : playerCount === 3
+              ? { label: 'J28' }
+              : { label: 'K28' },
+        // Top left player position when playing vs two others
         1:
           playerCount === 2
             ? { label: 'J16' }
-            : { label: 'D16' },
+            : playerCount === 3
+              ? { label: 'E13' }
+              : { label: 'D16' },
+        // Top right player position for three player games
         2:
           playerCount === 3
-            ? { label: 'R16' }
+            ? { label: 'R14' }
             : { label: 'F7' },
         3: { label: 'J8' },
-        // Dice roll animation centre for 1v1 at J22
-        center: { label: playerCount === 2 ? 'J22' : 'J25' },
+        // Dice roll animation centre: adjust for player count
+        center:
+          playerCount === 2
+            ? { label: 'J22' }
+            : playerCount === 3
+              ? { label: 'J20' }
+              : { label: 'J25' },
       };
     const entry = posMap[playerIdx] || {};
     const label = entry.label;


### PR DESCRIPTION
## Summary
- adjust dice animation coordinates for three-player games
- tweak CSS positions for avatars and dice center when facing two opponents

## Testing
- `npm test` *(fails: test timed out while setting up bot server)*

------
https://chatgpt.com/codex/tasks/task_e_6875e864fbd48329821cc4a04c066443