### PR TITLE
Adjust Crazy Dice board positions

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1333,8 +1333,8 @@ input:focus {
 }
 .crazy-dice-board .dice-center {
   position: absolute;
-  /* Default center aligned with J25 */
-  top: 84%;
+  /* Default center aligned with J20 */
+  top: 66%;
   left: 47.5%;
   transform: translate(-50%, -50%);
 }
@@ -1353,8 +1353,8 @@ input:focus {
 /* Player positions around the Crazy Dice board */
 .crazy-dice-board .player-bottom {
   position: absolute;
-  /* Slightly higher than the 1v1 layout */
-  bottom: 5%;
+  /* Position aligned with J28 */
+  bottom: 7%;
   left: 50%;
   transform: translateX(-50%);
 }

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -234,27 +234,27 @@ export default function CrazyDiceDuel() {
             ? { label: 'J28' }
             : playerCount === 3
               ? { label: 'J28' }
-              : { label: 'K28' },
+              : { label: 'J28' },
         // Top left player position when playing vs two others
         1:
           playerCount === 2
             ? { label: 'J16' }
             : playerCount === 3
               ? { label: 'E13' }
-              : { label: 'D16' },
+              : { label: 'C14' },
         // Top right player position for three player games
         2:
           playerCount === 3
             ? { label: 'R14' }
-            : { label: 'F7' },
-        3: { label: 'J8' },
+            : { label: 'K20' },
+        3: { label: 'R14' },
         // Dice roll animation centre: adjust for player count
         center:
           playerCount === 2
             ? { label: 'J22' }
             : playerCount === 3
               ? { label: 'J20' }
-              : { label: 'J25' },
+              : { label: 'J20' },
       };
     const entry = posMap[playerIdx] || {};
     const label = entry.label;


### PR DESCRIPTION
## Summary
- position player avatars and dice for 4-player matches
- center dice landing at J20
- adjust bottom player placement to match J28

## Testing
- `npm test` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6875eee1aa088329874d6a5ce87b4cf2