### PR TITLE
Fix Crazy Dice duel dice animation

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -416,7 +416,15 @@ export default function CrazyDiceDuel() {
       ],
       { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' },
     ).onfinish = () => {
-      setDiceStyle({ display: 'none' });
+      setDiceStyle({
+        display: 'block',
+        position: 'fixed',
+        left: '0px',
+        top: '0px',
+        transform: `translate(${endX}px, ${endY}px) translate(-50%, -50%) scale(${DICE_PLAYER_SCALE})`,
+        pointerEvents: 'none',
+        zIndex: 50,
+      });
     };
   };
 


### PR DESCRIPTION
## Summary
- keep dice visible after landing on next player position in Crazy Dice Duel

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_6875fc9e72708329a191f4ee5bd6a671