### PR TITLE
Fix dice trail size

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1465,9 +1465,9 @@ input:focus {
 /* Image that appears under the dice when the bottom player rolls */
 .dice-trail-img {
   position: absolute;
-  bottom: -3.5rem;
+  bottom: -4rem;
   left: 50%;
-  width: 4rem;
+  width: 5rem;
   transform: translateX(-50%) translateY(100%);
   pointer-events: none;
   animation: dice-trail-rise 0.6s ease-out forwards;


### PR DESCRIPTION
## Summary
- adjust dice trail image dimensions in Crazy Dice Duel so effect appears larger

## Testing
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68760faadf688329a612af4f24a24aa5