### PR TITLE
Fix four-player avatar layout

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -49,6 +49,14 @@ export default function AvatarTimer({
           {name}
         </span>
       )}
+      {score != null && (
+        <span
+          className="player-score"
+          style={{ color: color || '#fde047', ...scoreStyle }}
+        >
+          Score: {score}
+        </span>
+      )}
       {rollHistory && maxRolls > 0 && (
         <div
           className="roll-history"
@@ -60,14 +68,6 @@ export default function AvatarTimer({
             </div>
           ))}
         </div>
-      )}
-      {score != null && (
-        <span
-          className="player-score"
-          style={{ color: color || '#fde047', ...scoreStyle }}
-        >
-          Score: {score}
-        </span>
       )}
     </div>
   );

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1444,28 +1444,35 @@ input:focus {
   right: 12.5%;
 }
 .crazy-dice-board.four-players .player-left {
-  top: 15%;
-  left: 7.5%;
+  top: 16%;
+  left: 9%;
 }
 .crazy-dice-board.four-players .player-center {
-  top: 15%;
-  left: 47.5%;
+  top: 16%;
+  left: 48%;
 }
 .crazy-dice-board.four-players .player-right {
-  top: 15%;
-  right: 7.5%;
+  top: 16%;
+  right: 9%;
 }
 .crazy-dice-board.four-players .player-bottom {
-  bottom: 10%;
+  bottom: 12%;
 }
 .crazy-dice-board.four-players .player-bottom .roll-history {
-  top: calc(100% + 0.45rem);
+  top: calc(100% + 0.65rem);
 }
 .crazy-dice-board.four-players .player-bottom .player-score {
-  top: calc(100% + 1.65rem);
+  top: calc(100% + 1.85rem);
 }
-.crazy-dice-board.four-players .player-center .roll-history {
-  top: calc(100% + 3.7rem);
+.crazy-dice-board.four-players .player-left .player-score,
+.crazy-dice-board.four-players .player-center .player-score,
+.crazy-dice-board.four-players .player-right .player-score {
+  top: calc(100% + 1.8rem);
+}
+.crazy-dice-board.four-players .player-left .roll-history,
+.crazy-dice-board.four-players .player-center .roll-history,
+.crazy-dice-board.four-players .player-right .roll-history {
+  top: calc(100% + 3rem);
 }
 
 


### PR DESCRIPTION
## Summary
- tweak avatar, score, and history placement on the four-player board
- render scores before roll history

## Testing
- `npm test` *(fails: testCodeFailure and missing BOT_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68761c965d24832981a50fc8e53480c6