### PR TITLE
Fix LuckyNumber background

### DIFF
--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -93,7 +93,7 @@ export default function LuckyNumber() {
 
 
   return (
-    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 text-center overflow-hidden wide-card">
+    <div className="relative bg-transparent border border-border rounded-xl p-4 space-y-2 text-center overflow-hidden wide-card">
       <img
         src="/assets/icons/lucky_card_bg.webp"
         className="absolute inset-0 w-full h-full object-cover -z-10 pointer-events-none"


### PR DESCRIPTION
## Summary
- make the Lucky Number card background transparent so the image is visible

## Testing
- `npm test` *(fails to finish due to environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68761e736a9883298f646c245af1ac4d