### PR TITLE
Refine Crazy Dice Duel grid overlay

### DIFF
--- a/webapp/src/components/BoardGridOverlay.jsx
+++ b/webapp/src/components/BoardGridOverlay.jsx
@@ -43,7 +43,7 @@ export default function BoardGridOverlay({ className = '' }) {
           x={i + 0.5}
           y={j + 0.6}
           textAnchor="middle"
-          fontSize={1}
+          fontSize={0.5}
           fill="white"
           opacity={0.7}
         >
@@ -55,7 +55,7 @@ export default function BoardGridOverlay({ className = '' }) {
 
   return (
     <svg
-      className={`fixed inset-0 w-screen h-screen pointer-events-none ${className}`}
+      className={`board-grid-overlay ${className}`}
       viewBox="-0.5 -0.5 21 31"
       xmlns="http://www.w3.org/2000/svg"
       width="100%"

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -118,6 +118,18 @@ input:focus {
   transform: translateY(90px) scale(1.2);
 }
 
+/* Overlay grid covering the entire background image */
+.board-grid-overlay {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -20px;
+  bottom: -160px;
+  pointer-events: none;
+  transform: translateY(90px) scale(1.2);
+  z-index: 0;
+}
+
 @keyframes roll {
   0% {
     transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg) translateY(0);
@@ -416,7 +428,7 @@ input:focus {
   bottom: 100%;
   left: 50%;
   transform: translate(-50%, -0.1rem);
-  font-size: 0.6rem;
+  font-size: 0.5rem;
   color: inherit;
   white-space: nowrap;
 }
@@ -427,7 +439,7 @@ input:focus {
   top: calc(100% + 1.3rem); /* below roll boxes with space */
   left: 50%;
   transform: translateX(-50%);
-  font-size: 0.6rem;
+  font-size: 0.5rem;
   color: inherit;
   white-space: nowrap;
   padding: 0 0.2rem;


### PR DESCRIPTION
## Summary
- shrink grid numbers and player labels
- add grid overlay styling that matches the background

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876274901c08329861418150fb4aa7f