### PR TITLE
Fix throwing hand size

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1497,9 +1497,9 @@ input:focus {
 /* Image that appears under the dice when the bottom player rolls */
 .dice-trail-img {
   position: absolute;
-  bottom: -4rem;
+  bottom: -3rem;
   left: 50%;
-  width: 5rem;
+  width: 10rem;
   transform: translateX(-50%) translateY(100%);
   pointer-events: none;
   animation: dice-trail-rise 0.6s ease-out forwards;


### PR DESCRIPTION
## Summary
- make the dice trail hand image bigger and slightly higher

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_68762960aaf4832997a015da4a3a5f04