### PR TITLE
Fix bottom avatar spot in 4-player Crazy Dice Duel

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -652,7 +652,14 @@ export default function CrazyDiceDuel() {
           </div>
         )}
       </div>
-      <div className="player-bottom z-10">
+      <div
+        className="player-bottom z-10"
+        style={{
+          bottom: 'auto',
+          ...gridPoint(10, 26),
+          transform: 'translate(-50%, -50%)',
+        }}
+      >
         {showPrompt && (
           <button
             className="your-turn-message"


### PR DESCRIPTION
## Summary
- adjust bottom player's avatar position when playing against three opponents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876328938ec8329b807a7902a5586db