### PR TITLE
Disable TON/USDT staking options

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceLobby.jsx
+++ b/webapp/src/pages/Games/CrazyDiceLobby.jsx
@@ -92,7 +92,11 @@ export default function CrazyDiceLobby() {
       </div>
       <div className="space-y-2">
         <h3 className="font-semibold">Select Stake</h3>
-        <RoomSelector selected={stake} onSelect={setStake} />
+        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+        <p className="text-center text-subtext text-sm">
+          TON and USDT staking coming soon. Smart contract under
+          construction.
+        </p>
       </div>
       <button
         onClick={startGame}

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -257,8 +257,12 @@ export default function Lobby() {
         <RoomSelector
           selected={stake}
           onSelect={setStake}
-          tokens={table?.id === 'single' ? ['TPC'] : undefined}
+          tokens={['TPC']}
         />
+        <p className="text-center text-subtext text-sm">
+          TON and USDT staking coming soon. Smart contract under
+          construction.
+        </p>
       </div>
       {game === 'snake' && table?.id === 'single' && (
         <div className="space-y-2">


### PR DESCRIPTION
## Summary
- disable TON and USDT staking options in game lobbies
- add notice that smart contract is under construction

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_687635853d9c8329bcb990c53730c62a