### PR TITLE
Update four-player Crazy Dice layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1471,10 +1471,12 @@ input:focus {
   bottom: 12%;
 }
 .crazy-dice-board.four-players .player-bottom .roll-history {
-  top: calc(100% + 0.65rem);
+  /* Place roll boxes slightly lower */
+  top: calc(100% + 0.8rem);
 }
 .crazy-dice-board.four-players .player-bottom .player-score {
-  top: calc(100% + 1.85rem);
+  /* Score should appear below the roll boxes */
+  top: calc(100% + 2.1rem);
 }
 .crazy-dice-board.four-players .player-left .player-score,
 .crazy-dice-board.four-players .player-center .player-score,

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -255,20 +255,20 @@ export default function CrazyDiceDuel() {
         top: board.top + cellH * (r + 0.5),
       });
       setP4ScoreStyles([
-        // Top left opponent score between cells 103 and 104
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(2.5, 5) },
-        // Top middle opponent score between cells 90 and 91
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(9.5, 4) },
-        // Top right opponent score between cells 117 and 118
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(16.5, 5) },
+        // Top left opponent score
+        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(2, 6) },
+        // Top middle opponent score just below avatar
+        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(9.5, 6) },
+        // Top right opponent score shifted left
+        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(16, 6) },
       ]);
       setP4HistoryStyles([
-        // Roll boxes starting on cell 102
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(1, 5) },
-        // Roll boxes starting on cell 89
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(8, 4) },
-        // Roll boxes starting on cell 116
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(15, 5) },
+        // Roll boxes for top left player
+        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(0.5, 6) },
+        // Roll boxes for top middle player
+        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(8, 5) },
+        // Roll boxes for top right player
+        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(15, 6) },
       ]);
     };
     update();
@@ -654,7 +654,8 @@ export default function CrazyDiceDuel() {
         className="player-bottom z-10"
         style={{
           bottom: 'auto',
-          ...gridPoint(10, 26),
+          /* Nudge the bottom player slightly upwards */
+          ...gridPoint(10, 25),
           transform: 'translate(-50%, -50%)',
         }}
       >
@@ -697,17 +698,20 @@ export default function CrazyDiceDuel() {
         let historyStyle = undefined;
         if (playerCount === 4) {
           if (i === 0) {
-            const pos = gridPoint(3, 3); // cells 43/44/63/64 intersection
+            /* Top left opponent slightly lower */
+            const pos = gridPoint(3, 4); // shifted down one row
             wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
             scoreStyle = p4ScoreStyles[0];
             historyStyle = p4HistoryStyles[0];
           } else if (i === 1) {
-            const pos = gridPoint(10, 3); // cells 50/51/70/71 intersection
+            /* Top middle opponent nudged lower */
+            const pos = gridPoint(10, 4); // shifted down one row
             wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
             scoreStyle = p4ScoreStyles[1];
             historyStyle = p4HistoryStyles[1];
           } else if (i === 2) {
-            const pos = gridPoint(17, 3); // cells 57/58/77/78 intersection
+            /* Top right opponent moved slightly right and down */
+            const pos = gridPoint(17.5, 4); // shifted and nudged
             wrapperStyle = { top: pos.top, right: `${100 - parseFloat(pos.left)}%` };
             scoreStyle = p4ScoreStyles[2];
             historyStyle = p4HistoryStyles[2];


### PR DESCRIPTION
## Summary
- tweak bottom player position and ensure score is below roll boxes
- adjust four-player top positions for avatars, scores and history boxes

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_687663a968848329b230aa5a507c160b