### PR TITLE
Fix Crazy Dice duel layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1472,11 +1472,11 @@ input:focus {
 }
 .crazy-dice-board.four-players .player-bottom .roll-history {
   /* Place roll boxes slightly lower */
-  top: calc(100% + 1rem);
+  top: calc(100% + 1.2rem);
 }
 .crazy-dice-board.four-players .player-bottom .player-score {
   /* Score should appear below the roll boxes */
-  top: calc(100% + 2.3rem);
+  top: calc(100% + 2.5rem);
 }
 .crazy-dice-board.four-players .player-left .player-score,
 .crazy-dice-board.four-players .player-center .player-score,

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -698,20 +698,20 @@ export default function CrazyDiceDuel() {
         let historyStyle = undefined;
         if (playerCount === 4) {
           if (i === 0) {
-            /* Top left opponent slightly lower */
-            const pos = gridPoint(3, 4); // shifted down one row
+            /* Align top left opponent with top right */
+            const pos = gridPoint(3, 5); // lowered by one row
             wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
             scoreStyle = p4ScoreStyles[0];
             historyStyle = p4HistoryStyles[0];
           } else if (i === 1) {
-            /* Top middle opponent nudged slightly lower */
-            const pos = gridPoint(10, 5); // move down a touch
+            /* Top middle opponent slightly lower */
+            const pos = gridPoint(10, 6); // moved down a bit
             wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
             scoreStyle = p4ScoreStyles[1];
             historyStyle = p4HistoryStyles[1];
           } else if (i === 2) {
-            /* Top right opponent moved a bit left and down */
-            const pos = gridPoint(17, 5); // nudge position
+            /* Top right opponent */
+            const pos = gridPoint(17, 5); // same level as top left
             wrapperStyle = { top: pos.top, right: `${100 - parseFloat(pos.left)}%` };
             scoreStyle = p4ScoreStyles[2];
             historyStyle = p4HistoryStyles[2];


### PR DESCRIPTION
## Summary
- tweak four-player positioning in Crazy Dice Duel
- drop bottom player's info slightly

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_68767181fbec8329be9bbdd7f6ad2e24