### PR TITLE
Implement ban user script

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ To move from the start you must roll at least one six when rolling two dice. Any
 
 **Telegram reaction not detected** – The `/api/tasks/verify-telegram-reaction` endpoint relies on `BOT_TOKEN`. If this token is missing the check is skipped and the task automatically succeeds. Configure it only if you require strict validation.
 
+### Banning a user
+
+Run `npm run ban-user -- <accountId>` to mark an account as banned in the database. `MONGODB_URI` must point to your MongoDB instance.
+
 
 ## License
 

--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -58,6 +58,9 @@ const userSchema = new mongoose.Schema({
 
   isWatched: { type: Boolean, default: false },
 
+  // Whether the account is banned from using the platform
+  isBanned: { type: Boolean, default: false },
+
   minedTPC: { type: Number, default: 0 },
 
   dailyStreak: { type: Number, default: 0 },

--- a/bot/scripts/banUser.js
+++ b/bot/scripts/banUser.js
@@ -1,0 +1,32 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import User from '../models/User.js';
+
+dotenv.config();
+
+const uri = process.env.MONGODB_URI;
+if (!uri || uri === 'memory') {
+  console.error('MONGODB_URI must be set to a MongoDB instance');
+  process.exit(1);
+}
+
+const accountId = process.argv[2];
+if (!accountId) {
+  console.error('Usage: node bot/scripts/banUser.js <accountId>');
+  process.exit(1);
+}
+
+await mongoose.connect(uri);
+
+const user = await User.findOne({ accountId });
+if (!user) {
+  console.error('User not found');
+  await mongoose.disconnect();
+  process.exit(1);
+}
+
+user.isBanned = true;
+await user.save();
+console.log(`User ${accountId} banned`);
+
+await mongoose.disconnect();

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "npm --prefix webapp run build",
     "test": "node --test",
     "recalculate-balances": "node bot/scripts/recalculateBalances.js",
+    "ban-user": "node bot/scripts/banUser.js",
     "dev": "concurrently -k \"npm --prefix webapp run dev\" \"node bot/server.js\""
   },
   "engines": {


### PR DESCRIPTION
## Summary
- add `isBanned` flag to user schema
- provide `bot/scripts/banUser.js` utility to mark an account as banned
- expose script via npm `ban-user` command
- document how to ban a user in README

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_6876734700ec8329be34d8dda7022f49