### PR TITLE
Adjust Crazy Dice Duel layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -481,6 +481,10 @@ input:focus {
   bottom: calc(100% + 0.25rem);
   left: 50%;
   transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  white-space: nowrap;
   font-size: 1rem;
   font-weight: bold;
   border: none;
@@ -1487,6 +1491,12 @@ input:focus {
 .crazy-dice-board.four-players .player-center .roll-history,
 .crazy-dice-board.four-players .player-right .roll-history {
   top: calc(100% + 3rem);
+}
+.crazy-dice-board.four-players .player-center .player-score {
+  top: calc(100% + 4rem);
+}
+.crazy-dice-board.four-players .player-center .roll-history {
+  top: calc(100% + 5rem);
 }
 
 

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -258,7 +258,7 @@ export default function CrazyDiceDuel() {
         // Top left opponent score
         { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(2, 6) },
         // Top middle opponent score just below avatar
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(9.5, 6) },
+        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(9.5, 10) },
         // Top right opponent score shifted left
         { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(16.5, 6) },
       ]);
@@ -266,7 +266,7 @@ export default function CrazyDiceDuel() {
         // Roll boxes for top left player
         { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(0.5, 6) },
         // Roll boxes for top middle player
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(8, 6) },
+        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(8, 11) },
         // Roll boxes for top right player
         { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(15, 6) },
       ]);
@@ -698,20 +698,20 @@ export default function CrazyDiceDuel() {
         let historyStyle = undefined;
         if (playerCount === 4) {
           if (i === 0) {
-            /* Align top left opponent with top right */
-            const pos = gridPoint(3, 5); // lowered by one row
+            /* Top left opponent moved slightly left and down */
+            const pos = gridPoint(2, 6);
             wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
             scoreStyle = p4ScoreStyles[0];
             historyStyle = p4HistoryStyles[0];
           } else if (i === 1) {
-            /* Top middle opponent slightly lower */
-            const pos = gridPoint(10, 6); // moved down a bit
+            /* Top middle opponent moved slightly lower */
+            const pos = gridPoint(10, 7);
             wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
-            scoreStyle = p4ScoreStyles[1];
-            historyStyle = p4HistoryStyles[1];
+            scoreStyle = undefined;
+            historyStyle = undefined;
           } else if (i === 2) {
-            /* Top right opponent */
-            const pos = gridPoint(17, 5); // same level as top left
+            /* Top right opponent moved slightly right and down */
+            const pos = gridPoint(18, 6);
             wrapperStyle = { top: pos.top, right: `${100 - parseFloat(pos.left)}%` };
             scoreStyle = p4ScoreStyles[2];
             historyStyle = p4HistoryStyles[2];


### PR DESCRIPTION
## Summary
- tweak player positions in Crazy Dice Duel for four-player matches
- move center player's score display further down
- keep "your turn" prompt horizontal

## Testing
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68768300f318832996c92e9f37b6b735