### PR TITLE
Fix crazy dice top player movement

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -335,13 +335,14 @@ export default function CrazyDiceDuel() {
             ? { label: 'J16' }
             : playerCount === 3
               ? { label: 'E13' }
-              : { label: 'C14' },
-        // Top right player position for three player games
+              : { label: 'D8' },
+        // Top middle player position when facing three opponents
         2:
           playerCount === 3
             ? { label: 'R14' }
-            : { label: 'K20' },
-        3: { label: 'R14' },
+            : { label: 'K8' },
+        // Top right player position in four player games
+        3: { label: 'R8' },
         // Dice roll animation centre: adjust for player count
         center:
           playerCount === 2


### PR DESCRIPTION
## Summary
- align dice origin for top players in Crazy Dice Duel

## Testing
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_687695c22fc4832988419922b879d791