### PR TITLE
Adjust Crazy Dice duel layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1460,30 +1460,30 @@ input:focus {
   right: 12.5%;
 }
 .crazy-dice-board.four-players .player-left {
-  /* Shifted slightly down and towards the center */
+  /* Move the top left avatar closer to the screen edge */
   top: 21%;
-  left: 9%;
+  left: 6%;
 }
 .crazy-dice-board.four-players .player-center {
   top: 17%;
   left: 48%;
 }
 .crazy-dice-board.four-players .player-right {
-  /* Lower and nudged a bit left */
+  /* Lower and nudged further right */
   top: 21%;
-  right: 9%;
+  right: 6%;
 }
 .crazy-dice-board.four-players .player-bottom {
   /* Raise the bottom player slightly */
   bottom: 9%;
 }
 .crazy-dice-board.four-players .player-bottom .roll-history {
-  /* Place roll boxes slightly lower */
-  top: calc(100% + 1.4rem);
+  /* Place roll boxes a little further down */
+  top: calc(100% + 1.6rem);
 }
 .crazy-dice-board.four-players .player-bottom .player-score {
   /* Score should appear below the roll boxes */
-  top: calc(100% + 2.7rem);
+  top: calc(100% + 2.9rem);
 }
 .crazy-dice-board.four-players .player-left .player-score,
 .crazy-dice-board.four-players .player-center .player-score,

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -698,8 +698,8 @@ export default function CrazyDiceDuel() {
         let historyStyle = undefined;
         if (playerCount === 4) {
           if (i === 0) {
-            /* Top left opponent moved down and a bit right */
-            const pos = gridPoint(3, 7);
+            /* Top left opponent moved further left */
+            const pos = gridPoint(2, 7);
             wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
             scoreStyle = p4ScoreStyles[0];
             historyStyle = p4HistoryStyles[0];
@@ -710,8 +710,8 @@ export default function CrazyDiceDuel() {
             scoreStyle = undefined;
             historyStyle = undefined;
           } else if (i === 2) {
-            /* Top right opponent moved down and a bit left */
-            const pos = gridPoint(17, 7);
+            /* Top right opponent shifted further right */
+            const pos = gridPoint(18, 7);
             wrapperStyle = { top: pos.top, right: `${100 - parseFloat(pos.left)}%` };
             scoreStyle = p4ScoreStyles[2];
             historyStyle = p4HistoryStyles[2];


### PR DESCRIPTION
## Summary
- tweak 4-player avatar positions in Crazy Dice Duel
- drop bottom player's score boxes slightly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68769cb3be50832989a4c5bd2fa52aca