### PR TITLE
Fix 3-player avatar placement for Crazy Dice

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1394,9 +1394,9 @@ input:focus {
 }
 
 .crazy-dice-board.three-players .player-left {
-  /* Positioned around E13 on the grid */
-  top: 42%;
-  left: 22.5%;
+  /* Same placement as four-player top left */
+  top: 21%;
+  left: 6%;
 }
 
 .crazy-dice-board .player-center {
@@ -1455,9 +1455,9 @@ input:focus {
 }
 
 .crazy-dice-board.three-players .player-right {
-  /* Positioned around R14 on the grid */
-  top: 45%;
-  right: 12.5%;
+  /* Same placement as four-player top right */
+  top: 21%;
+  right: 6%;
 }
 .crazy-dice-board.four-players .player-left {
   /* Move the top left avatar closer to the screen edge */

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -220,22 +220,22 @@ export default function CrazyDiceDuel() {
       setTlScoreStyle({
         position: 'fixed',
         transform: 'translate(-50%, -50%)',
-        ...center(3, 8), // D9
+        ...center(2, 10), // top left score (same as 4 players)
       });
       setTlHistoryStyle({
         position: 'fixed',
         transform: 'translate(-50%, -50%)',
-        ...center(1, 7), // B8
+        ...center(0.5, 11), // top left history (same as 4 players)
       });
       setTrScoreStyle({
         position: 'fixed',
         transform: 'translate(-50%, -50%)',
-        ...center(16, 8), // Q9
+        ...center(16.5, 10), // top right score (same as 4 players)
       });
       setTrHistoryStyle({
         position: 'fixed',
         transform: 'translate(-50%, -50%)',
-        ...center(14, 7), // O8
+        ...center(15, 11), // top right history (same as 4 players)
       });
     };
     update();
@@ -334,7 +334,7 @@ export default function CrazyDiceDuel() {
           playerCount === 2
             ? { label: 'J16' }
             : playerCount === 3
-              ? { label: 'E13' }
+              ? { label: 'C14' }
               : { label: 'C14' },
         // Top right player position for three player games
         2:
@@ -719,11 +719,13 @@ export default function CrazyDiceDuel() {
         }
         if (playerCount === 3) {
           if (i === 0) {
-            wrapperStyle = { ...gridPoint(3, 3), right: 'auto' };
+            // Use same placement as four-player top left
+            wrapperStyle = { ...gridPoint(2, 7), right: 'auto' };
             scoreStyle = tlScoreStyle;
             historyStyle = tlHistoryStyle;
           } else if (i === 1) {
-            wrapperStyle = { ...gridPoint(17, 3), right: 'auto' };
+            // Use same placement as four-player top right
+            wrapperStyle = { ...gridPoint(18, 7), right: 'auto' };
             scoreStyle = trScoreStyle;
             historyStyle = trHistoryStyle;
           }


### PR DESCRIPTION
## Summary
- position top avatars in 3‑player Crazy Dice the same as in four-player games
- update dice centre lookup for 3‑player mode

## Testing
- `npm test` *(fails: test suite requires services not present)*

------
https://chatgpt.com/codex/tasks/task_e_6876a488846083299df89bad2351b913