### PR TITLE
Update Crazy Dice Duel positioning

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1470,6 +1470,11 @@ input:focus {
   top: 17%;
   left: 48%;
 }
+.crazy-dice-board.four-players .player-center .player-score,
+.crazy-dice-board.four-players .player-center .roll-history {
+  /* Nudge boxes slightly to the right */
+  transform: translateX(-55%);
+}
 .crazy-dice-board.four-players .player-right {
   /* Lower and nudged further right */
   top: 21%;
@@ -1481,11 +1486,11 @@ input:focus {
 }
 .crazy-dice-board.four-players .player-bottom .roll-history {
   /* Place roll boxes a little further down */
-  top: calc(100% + 1.6rem);
+  top: calc(100% + 1.8rem);
 }
 .crazy-dice-board.four-players .player-bottom .player-score {
   /* Score should appear below the roll boxes */
-  top: calc(100% + 2.9rem);
+  top: calc(100% + 3.1rem);
 }
 .crazy-dice-board.four-players .player-left .player-score,
 .crazy-dice-board.four-players .player-center .player-score,

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -698,24 +698,20 @@ export default function CrazyDiceDuel() {
         let historyStyle = undefined;
         if (playerCount === 4) {
           if (i === 0) {
-            /* Top left opponent moved further left */
-            const pos = gridPoint(2, 7);
+            /* Top left opponent moved slightly right */
+            const pos = gridPoint(2.3, 7);
             wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
-            scoreStyle = p4ScoreStyles[0];
-            historyStyle = p4HistoryStyles[0];
           } else if (i === 1) {
-            /* Top middle opponent moved slightly lower */
+            /* Top middle opponent */
             const pos = gridPoint(10, 7);
             wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
-            scoreStyle = undefined;
-            historyStyle = undefined;
           } else if (i === 2) {
-            /* Top right opponent shifted further right */
-            const pos = gridPoint(18, 7);
+            /* Top right opponent shifted slightly left */
+            const pos = gridPoint(17.7, 7);
             wrapperStyle = { top: pos.top, right: `${100 - parseFloat(pos.left)}%` };
-            scoreStyle = p4ScoreStyles[2];
-            historyStyle = p4HistoryStyles[2];
           }
+          scoreStyle = undefined;
+          historyStyle = undefined;
         }
         if (playerCount === 3) {
           if (i === 0) {


### PR DESCRIPTION
## Summary
- tweak four-player board styles
- adjust dice duel player placement when facing 3 opponents

## Testing
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6876b20e6dc883298c82f240d275e3cb