### PR TITLE
UI tweaks for Crazy Dice duel

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -457,13 +457,13 @@ input:focus {
 }
 
 .roll-box {
-  width: 0.9rem;
-  height: 0.9rem;
+  width: 1.1rem;
+  height: 1.1rem;
   border: 1px solid currentColor;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.75rem;
+  font-size: 0.85rem;
   border-radius: 0.15rem;
   background-color: rgba(0, 0, 0, 0.25);
 }
@@ -1417,13 +1417,13 @@ input:focus {
 }
 .crazy-dice-board .player-left .player-score,
 .crazy-dice-board .player-left .roll-history {
-  /* Nudge slightly to the right */
-  transform: translateX(-30%);
+  /* Move boxes a tad further left */
+  transform: translateX(-40%);
 }
 .crazy-dice-board .player-right .player-score,
 .crazy-dice-board .player-right .roll-history {
-  /* And the right side slightly to the left */
-  transform: translateX(-70%);
+  /* Shift right side slightly right */
+  transform: translateX(-60%);
 }
 
 /* Position roll boxes and scores for top players around row 9/10 */
@@ -1486,11 +1486,11 @@ input:focus {
 }
 .crazy-dice-board.four-players .player-bottom .roll-history {
   /* Place roll boxes a little further down */
-  top: calc(100% + 1.8rem);
+  top: calc(100% + 2rem);
 }
 .crazy-dice-board.four-players .player-bottom .player-score {
   /* Score should appear below the roll boxes */
-  top: calc(100% + 3.1rem);
+  top: calc(100% + 3.4rem);
 }
 .crazy-dice-board.four-players .player-left .player-score,
 .crazy-dice-board.four-players .player-center .player-score,

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -632,7 +632,7 @@ export default function CrazyDiceDuel() {
           />
         )}
         {rollResult !== null && (
-          <div className="text-5xl roll-result">{rollResult}</div>
+          <div className="text-6xl roll-result">{rollResult}</div>
         )}
         {winner == null ? (
           <div className="crazy-dice">


### PR DESCRIPTION
## Summary
- tweak board CSS for four-player mode
- adjust dice result overlay size
- make roll history boxes bigger
- run build and tests

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find package 'express' and others)*

------
https://chatgpt.com/codex/tasks/task_e_6876bc88f9dc8329ae8864ff078a1de9