### PR TITLE
Fix 3-player layout for Crazy Dice Duel

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1377,8 +1377,8 @@ input:focus {
 
 /* Position of the bottom avatar when facing two opponents */
 .crazy-dice-board.three-players .player-bottom {
-  bottom: 8%;
-  left: 47.5%;
+  bottom: 9%;
+  left: 50%;
 }
 
 /* Adjust bottom player position for 1v1 games */
@@ -1446,6 +1446,13 @@ input:focus {
 }
 .crazy-dice-board .player-bottom .player-score {
   top: calc(100% + 1.45rem);
+}
+
+.crazy-dice-board.three-players .player-bottom .roll-history {
+  top: calc(100% + 2rem);
+}
+.crazy-dice-board.three-players .player-bottom .player-score {
+  top: calc(100% + 3.4rem);
 }
 
 .crazy-dice-board .player-right {


### PR DESCRIPTION
## Summary
- align 3-player Crazy Dice Duel layout to match the 4-player layout
- adjust bottom player info boxes for 3-player matches

## Testing
- `npm test` *(fails: test environment missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6876bf9529f083299601d1d51bc82860