### PR TITLE
Adjust UI layout for 3‑player Crazy Dice duel

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -478,7 +478,7 @@ input:focus {
 
 .your-turn-message {
   position: absolute;
-  bottom: calc(100% + 0.5rem);
+  bottom: calc(100% + 0.7rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -1351,14 +1351,14 @@ input:focus {
   position: absolute;
   /* Default center aligned with J20 */
   top: 66%;
-  left: 47.5%;
+  left: 48%;
   transform: translate(-50%, -50%);
 }
 
 /* Dice landing spot when facing two opponents */
 .crazy-dice-board.three-players .dice-center {
   top: 66%;
-  left: 47.5%;
+  left: 48%;
 }
 
 /* Adjust dice landing spot for 1v1 games */
@@ -1417,8 +1417,8 @@ input:focus {
 }
 .crazy-dice-board .player-left .player-score,
 .crazy-dice-board .player-left .roll-history {
-  /* Move boxes a tad further left */
-  transform: translateX(-40%);
+  /* Move boxes slightly further left */
+  transform: translateX(-45%);
 }
 .crazy-dice-board .player-right .player-score,
 .crazy-dice-board .player-right .roll-history {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -157,7 +157,7 @@ export default function CrazyDiceDuel() {
   const trailTimeoutRef = useRef(null);
   // Dice scales: shrink when at a player's position and expand when rolling
   // In 1v1 mode dice should start small and grow to normal size when rolling
-  const DICE_CENTER_SCALE = 1;
+  const DICE_CENTER_SCALE = 0.9;
   const DICE_PLAYER_SCALE = 0.4;
   const DICE_SHRINK_SCALE = 0.2;
   const DICE_ANIM_DURATION = 1000;
@@ -718,8 +718,8 @@ export default function CrazyDiceDuel() {
             // Nudge the top left opponent slightly left and up
             wrapperStyle = { ...gridPoint(3.3, 6.2), right: 'auto' };
           } else if (i === 1) {
-            // Move the top right opponent a bit further left
-            wrapperStyle = { ...gridPoint(15.8, 6.5), right: 'auto' };
+            // Move the top right opponent slightly further left
+            wrapperStyle = { ...gridPoint(15.5, 6.5), right: 'auto' };
           }
         }
         return (


### PR DESCRIPTION
## Summary
- fine-tune the position of the `your-turn` indicator
- nudge top-left player's result boxes further left
- tweak dice landing spot and reduce landed dice scale
- adjust top-right avatar position in 3-player games

## Testing
- `npm test` *(fails: test timed out and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68773d173e6c832982d32955adeef2a0