### PR TITLE
Refactor avatar animations to use refs

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { getAvatarUrl } from '../utils/avatarUtils.js';
 
-export default function AvatarTimer({
+function AvatarTimer({
   photoUrl,
   active = false,
   timerPct = 1,
@@ -17,7 +17,7 @@ export default function AvatarTimer({
   size = 1,
   scoreStyle = {},
   rollHistoryStyle = {},
-}) {
+}, ref) {
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
   const sizeRem = 3.25 * size;
@@ -27,6 +27,7 @@ export default function AvatarTimer({
       style={{ width: `${sizeRem}rem`, height: `${sizeRem}rem` }}
       onClick={onClick}
       data-player-index={index}
+      ref={ref}
     >
       {/* turn indicator removed */}
       {active && (
@@ -72,3 +73,5 @@ export default function AvatarTimer({
     </div>
   );
 }
+
+export default forwardRef(AvatarTimer);

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -153,6 +153,7 @@ export default function CrazyDiceDuel() {
   const boardClass = playerCount === 4 ? "four-players" : playerCount === 3 ? "three-players" : playerCount === 2 ? "two-players" : "";
 
   const boardRef = useRef(null);
+  const avatarRefs = useRef([]);
   const diceRef = useRef(null);
   const diceCenterRef = useRef(null);
   const [diceStyle, setDiceStyle] = useState({ display: 'none' });
@@ -684,6 +685,7 @@ export default function CrazyDiceDuel() {
           rollHistory={players[0].results}
           maxRolls={maxRolls}
           color={players[0].color}
+          ref={(el) => (avatarRefs.current[0] = el)}
           size={
             playerCount === 3 ? 1.1 : playerCount > 3 ? 1.05 : 1
           }
@@ -743,8 +745,9 @@ export default function CrazyDiceDuel() {
               score={p.score}
               rollHistory={p.results}
               maxRolls={maxRolls}
-              color={p.color}
-              scoreStyle={scoreStyle}
+          color={p.color}
+          ref={(el) => (avatarRefs.current[i + 1] = el)}
+          scoreStyle={scoreStyle}
               rollHistoryStyle={historyStyle}
               size={
                 playerCount === 2
@@ -802,8 +805,8 @@ export default function CrazyDiceDuel() {
         }))}
         senderIndex={0}
         onGiftSent={({ from, to, gift }) => {
-          const start = document.querySelector(`[data-player-index="${from}"]`);
-          const end = document.querySelector(`[data-player-index="${to}"]`);
+          const start = avatarRefs.current[from];
+          const end = avatarRefs.current[to];
           if (start && end) {
             const s = start.getBoundingClientRect();
             const e = end.getBoundingClientRect();

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -640,6 +640,7 @@ export default function SnakeAndLadder() {
   const [watchOnly, setWatchOnly] = useState(false);
   const [mpPlayers, setMpPlayers] = useState([]);
   const playersRef = useRef([]);
+  const avatarRefs = useRef([]);
   const [tableId, setTableId] = useState('snake-4');
   const [playerPopup, setPlayerPopup] = useState(null);
   const [showChat, setShowChat] = useState(false);
@@ -775,7 +776,7 @@ export default function SnakeAndLadder() {
       });
       return;
     }
-    const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
+    const startEl = avatarRefs.current[startIdx];
     if (!startEl) return;
     const s = startEl.getBoundingClientRect();
     const targetX = s.left + s.width / 2;
@@ -795,7 +796,7 @@ export default function SnakeAndLadder() {
 
   const animateDiceToCenter = (startIdx) => {
     const dice = diceRef.current;
-    const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
+    const startEl = avatarRefs.current[startIdx];
     if (!dice || !startEl) return;
     const s = startEl.getBoundingClientRect();
     const startX = s.left + s.width / 2;
@@ -829,7 +830,7 @@ export default function SnakeAndLadder() {
 
   const animateDiceToPlayer = (idx) => {
     const dice = diceRef.current;
-    const endEl = document.querySelector(`[data-player-index="${idx}"] img`);
+    const endEl = avatarRefs.current[idx];
     if (!dice || !endEl) return;
     const e = endEl.getBoundingClientRect();
     // Land slightly to the right of the avatar centre
@@ -2005,6 +2006,7 @@ export default function SnakeAndLadder() {
               index={p.index}
               photoUrl={p.photoUrl}
               active={p.index === currentTurn}
+              ref={(el) => (avatarRefs.current[p.index] = el)}
               rank={rankMap[p.index]}
               name={getPlayerName(p.index)}
               isTurn={p.index === currentTurn}
@@ -2080,8 +2082,8 @@ export default function SnakeAndLadder() {
             players={players.map((p, i) => ({ ...p, index: i, name: getPlayerName(i) }))}
             senderIndex={myIdx}
             onGiftSent={({ from, to, gift }) => {
-              const start = document.querySelector(`[data-player-index="${from}"]`);
-              const end = document.querySelector(`[data-player-index="${to}"]`);
+              const start = avatarRefs.current[from];
+              const end = avatarRefs.current[to];
               if (start && end) {
                 const s = start.getBoundingClientRect();
                 const e = end.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- forward AvatarTimer refs to access avatar elements
- store avatar refs in CrazyDiceDuel and SnakeAndLadder
- update animation helpers to reference avatar refs
- remove global `querySelector` calls

## Testing
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND])*

------
https://chatgpt.com/codex/tasks/task_e_687746925fb0832999601442aee3df9c