### PR TITLE
Use flags as avatars

### DIFF
--- a/webapp/src/components/AvatarPickerModal.jsx
+++ b/webapp/src/components/AvatarPickerModal.jsx
@@ -2,22 +2,8 @@ import React, { useState } from 'react';
 import { FLAG_EMOJIS } from '../utils/flagEmojis.js';
 import { getAvatarUrl } from '../utils/avatarUtils.js';
 
-// Pre-bundled DiceBear SVG avatars stored locally under /assets/avatars
-// to avoid network requests and speed up image loading in the game.
-const IMAGE_AVATARS = [
-  '/assets/avatars/avatar1.svg',
-  '/assets/avatars/avatar2.svg',
-  '/assets/avatars/avatar3.svg',
-  '/assets/avatars/avatar4.svg',
-  '/assets/avatars/avatar5.svg'
-];
-
-const EMOJI_AVATARS = [
-  '🤡','👹','👺','👻','😼','😻','🙉','💩','😸','🥸','🤓','😎','👽','💀','🕵‍♂️','👳‍♂️','👳','🎅','🧕','👲','🧛‍♀️','🧛','🧛‍♂️','🦹‍♀️','🦹‍♂️','🦸','🦸‍♀️','🦸‍♂️','🧙‍♂️','👰','👰‍♀️','👩‍🍼','👸','🤴','🫅','👩‍🚀','👨‍✈️','👮‍♀️','👮‍♂️','🐵','🦁','🐶','🦧','🐺','🦊','🦝','🐭','🐷','🐸','🧿',
-  ...FLAG_EMOJIS
-];
-
-export const AVATARS = [...IMAGE_AVATARS, ...EMOJI_AVATARS];
+// Avatars are limited to flag emojis only
+export const AVATARS = [...FLAG_EMOJIS];
 
 export default function AvatarPickerModal({ open, onClose, onSave }) {
   const [selected, setSelected] = useState(null);

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -96,19 +96,15 @@ export default function CrazyDiceDuel() {
     const me = loadAvatar() || '/assets/icons/profile.svg';
     const playerFlag = FLAG_EMOJIS.includes(me) ? me : null;
     const randFlag = () =>
-      playerFlag
-        ? getAIOpponentFlag(playerFlag)
-        : FLAG_EMOJIS[Math.floor(Math.random() * FLAG_EMOJIS.length)];
+      getAIOpponentFlag(
+        playerFlag || FLAG_EMOJIS[Math.floor(Math.random() * FLAG_EMOJIS.length)]
+      );
     return Array.from({ length: playerCount }, (_, i) => ({
       score: 0,
       rolls: 0,
       results: [],
       photoUrl:
-        i === 0
-          ? me
-          : aiCount > 0
-            ? randFlag()
-            : `/assets/avatars/avatar${(i % 5) + 1}.svg`,
+        i === 0 ? me : randFlag(),
       color: COLORS[i % COLORS.length],
     }));
   }, [playerCount, aiCount]);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -995,11 +995,11 @@ export default function SnakeAndLadder() {
     localStorage.removeItem(`snakeGameState_${aiCount}`);
     setAiPositions(Array(aiCount).fill(0));
     const isFlag = FLAG_EMOJIS.includes(photoUrl);
+    const randomFlag = () =>
+      FLAG_EMOJIS[Math.floor(Math.random() * FLAG_EMOJIS.length)];
     setAiAvatars(
       Array.from({ length: aiCount }, () =>
-        isFlag
-          ? getAIOpponentFlag(photoUrl)
-          : AVATARS[Math.floor(Math.random() * AVATARS.length)]
+        getAIOpponentFlag(isFlag ? photoUrl : randomFlag())
       )
     );
     const colors = shuffle(TOKEN_COLORS).slice(0, aiCount + 1).map(c => c.color);


### PR DESCRIPTION
## Summary
- limit avatar options to flag emojis only
- make AI avatars use rival flags even when the player uses a non-flag avatar
- use flags for all players in Crazy Dice Duel

## Testing
- `npm --prefix webapp run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68774e7aae988329ab40426e4f176640