### PR TITLE
Increase chance of rival AI selection

### DIFF
--- a/webapp/src/utils/aiOpponentFlag.js
+++ b/webapp/src/utils/aiOpponentFlag.js
@@ -49,7 +49,11 @@ import { FLAG_EMOJIS } from './flagEmojis.js';
 
 export function getAIOpponentFlag(playerFlag) {
   const rivals = RIVAL_FLAGS[playerFlag];
-  if (Array.isArray(rivals) && rivals.length > 0) {
+  if (
+    Array.isArray(rivals) &&
+    rivals.length > 0 &&
+    Math.random() < 0.8
+  ) {
     return rivals[Math.floor(Math.random() * rivals.length)];
   }
   let flag;


### PR DESCRIPTION
## Summary
- tweak AI opponent selection logic
  - 80% chance to pick from predefined rival flags
  - 20% chance to fall back to random flag

## Testing
- `npm test` *(fails: BOT_TOKEN not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68775818fdfc83298a40aeee844843ac