### PR TITLE
Fix conflict-based avatars and add region selection

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceLobby.jsx
+++ b/webapp/src/pages/Games/CrazyDiceLobby.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { pingOnline, getOnlineCount } from '../../utils/api.js';
 import { getPlayerId } from '../../utils/telegram.js';
+import { REGIONS } from '../../utils/conflictMatchmaking.js';
 import RoomSelector from '../../components/RoomSelector.jsx';
 import TableSelector from '../../components/TableSelector.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
@@ -21,6 +22,7 @@ export default function CrazyDiceLobby() {
   const [rolls, setRolls] = useState(1);
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [aiCount, setAiCount] = useState(1);
+  const [region, setRegion] = useState('');
   const [online, setOnline] = useState(0);
 
   useEffect(() => {
@@ -47,6 +49,7 @@ export default function CrazyDiceLobby() {
     params.set('rolls', rolls);
     if (stake.token) params.set('token', stake.token);
     if (stake.amount) params.set('amount', stake.amount);
+    if (region) params.set('region', region);
     navigate(`/games/crazydice?${params.toString()}`);
   };
 
@@ -89,6 +92,21 @@ export default function CrazyDiceLobby() {
             </button>
           ))}
         </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Conflict Region</h3>
+        <select
+          value={region}
+          onChange={(e) => setRegion(e.target.value)}
+          className="lobby-tile w-full text-black"
+        >
+          <option value="">Auto (Local)</option>
+          {REGIONS.map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
       </div>
       <div className="space-y-2">
         <h3 className="font-semibold">Select Stake</h3>

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import TableSelector from '../../components/TableSelector.jsx';
 import RoomSelector from '../../components/RoomSelector.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { REGIONS } from '../../utils/conflictMatchmaking.js';
 import {
   getSnakeLobbies,
   getSnakeLobby,
@@ -45,6 +46,7 @@ export default function Lobby() {
   const [stake, setStake] = useState({ token: '', amount: 0 });
   const [players, setPlayers] = useState([]);
   const [aiCount, setAiCount] = useState(0);
+  const [region, setRegion] = useState('');
   const [online, setOnline] = useState(0);
   const [playerName, setPlayerName] = useState('');
   const autoStartedRef = useRef(false);
@@ -192,6 +194,7 @@ export default function Lobby() {
       params.set('ai', aiCount);
       params.set('token', 'TPC');
       if (stake.amount) params.set('amount', stake.amount);
+      if (region) params.set('region', region);
       try {
         const accountId = await ensureAccountId();
         const balRes = await getAccountBalance(accountId);
@@ -208,6 +211,7 @@ export default function Lobby() {
     } else {
       if (stake.token) params.set('token', stake.token);
       if (stake.amount) params.set('amount', stake.amount);
+      if (region) params.set('region', region);
     }
 
     navigate(`/games/${game}?${params.toString()}`);
@@ -263,6 +267,21 @@ export default function Lobby() {
           TON and USDT staking coming soon. Smart contract under
           construction.
         </p>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Conflict Region</h3>
+        <select
+          value={region}
+          onChange={(e) => setRegion(e.target.value)}
+          className="lobby-tile w-full text-black"
+        >
+          <option value="">Auto (Local)</option>
+          {REGIONS.map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
       </div>
       {game === 'snake' && table?.id === 'single' && (
         <div className="space-y-2">

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -20,8 +20,11 @@ import {
 } from "../../assets/soundData.js";
 import { AVATARS } from "../../components/AvatarPickerModal.jsx";
 import { getAvatarUrl, saveAvatar, loadAvatar, avatarToName } from "../../utils/avatarUtils.js";
-import { FLAG_EMOJIS } from "../../utils/flagEmojis.js";
-import { getAIOpponentFlag } from "../../utils/aiOpponentFlag.js";
+import {
+  get2PlayerConflict,
+  get3PlayerConflict,
+  get4PlayerConflict,
+} from "../../utils/conflictMatchmaking.js";
 import InfoPopup from "../../components/InfoPopup.jsx";
 import GameEndPopup from "../../components/GameEndPopup.jsx";
 import {
@@ -994,14 +997,14 @@ export default function SnakeAndLadder() {
     }
     localStorage.removeItem(`snakeGameState_${aiCount}`);
     setAiPositions(Array(aiCount).fill(0));
-    const isFlag = FLAG_EMOJIS.includes(photoUrl);
-    const randomFlag = () =>
-      FLAG_EMOJIS[Math.floor(Math.random() * FLAG_EMOJIS.length)];
-    setAiAvatars(
-      Array.from({ length: aiCount }, () =>
-        getAIOpponentFlag(isFlag ? photoUrl : randomFlag())
-      )
-    );
+    const region = params.get("region") || null;
+    (async () => {
+      let flags;
+      if (aiCount === 1) flags = await get2PlayerConflict(region);
+      else if (aiCount === 2) flags = await get3PlayerConflict(region);
+      else flags = get4PlayerConflict(region);
+      setAiAvatars(flags.slice(1));
+    })();
     const colors = shuffle(TOKEN_COLORS).slice(0, aiCount + 1).map(c => c.color);
     setPlayerColors(colors);
 

--- a/webapp/src/utils/conflictMatchmaking.js
+++ b/webapp/src/utils/conflictMatchmaking.js
@@ -1,0 +1,194 @@
+// Browser-friendly conflict matchmaking utilities
+// Derived from bot/utils/conflictMatchmaking.js
+
+export const CONFLICT_MAP = {
+  '\ud83c\udde6\ud83c\uddf1': {
+    region: 'Balkans',
+    rivals: ['\ud83c\uddf7\ud83c\uddf8', '\ud83c\uddec\ud83c\uddf7', '\ud83c\uddf2\ud83c\uddf0'],
+    reason: 'Ethnic tensions, historical disputes, minority rights, recognition of Kosovo'
+  },
+  '\ud83c\uddf7\ud83c\uddf8': {
+    region: 'Balkans',
+    rivals: ['\ud83c\udde6\ud83c\uddf1', '\ud83c\uddfd\ud83c\uddf0', '\ud83c\udded\ud83c\uddf7', '\ud83c\udde7\ud83c\udde6'],
+    reason: 'Post-Yugoslav wars, Kosovo, nationalism, ethnic conflicts'
+  },
+  '\ud83c\uddfd\ud83c\uddf0': {
+    region: 'Balkans',
+    rivals: ['\ud83c\uddf7\ud83c\uddf8'],
+    reason: 'Unrecognized independence by Serbia, historical control'
+  },
+  '\ud83c\udde8\ud83c\uddf1': {
+    region: 'Middle East',
+    rivals: ['\ud83c\uddee\ud83c\uddf7', '\ud83c\uddf5\ud83c\uddf8', '\ud83c\uddf8\ud83c\uddfe', '\ud83c\uddf1\ud83c\udde7'],
+    reason: 'Territorial occupation, religious conflict, Iran-Israel enmity'
+  },
+  '\ud83c\uddf5\ud83c\uddf8': {
+    region: 'Middle East',
+    rivals: ['\ud83c\udde8\ud83c\uddf1'],
+    reason: 'Occupation of West Bank & Gaza, calls for statehood'
+  },
+  '\ud83c\uddee\ud83c\uddf7': {
+    region: 'Middle East',
+    rivals: ['\ud83c\udde8\ud83c\uddf1', '\ud83c\uddf8\ud83c\udde6', '\ud83c\uddfa\ud83c\uddf8'],
+    reason: 'Nuclear program, proxy wars, sectarian divide'
+  },
+  '\ud83c\uddf8\ud83c\udde6': {
+    region: 'Middle East',
+    rivals: ['\ud83c\uddee\ud83c\uddf7', '\ud83c\uddfe\ud83c\uddea', '\ud83c\uddf6\ud83c\uddea'],
+    reason: 'Regional dominance, Sunni-Shia divide, Yemen war'
+  },
+  '\ud83c\uddf9\ud83c\uddf7': {
+    region: 'Europe/Middle East',
+    rivals: ['\ud83c\uddec\ud83c\uddf7', '\ud83c\udde6\ud83c\uddf2', '\ud83c\udde8\ud83c\uddfe'],
+    reason: 'Aegean Sea disputes, Cyprus division, Armenian genocide denial'
+  },
+  '\ud83c\uddee\ud83c\uddf3': {
+    region: 'South Asia',
+    rivals: ['\ud83c\uddf5\ud83c\uddf0', '\ud83c\udde8\ud83c\uddf3'],
+    reason: 'Kashmir conflict, border skirmishes, political tension'
+  },
+  '\ud83c\uddf5\ud83c\uddf0': {
+    region: 'South Asia',
+    rivals: ['\ud83c\uddee\ud83c\uddf3'],
+    reason: 'Territorial claims in Kashmir, terrorism accusations'
+  },
+  '\ud83c\udde8\ud83c\uddf3': {
+    region: 'East Asia',
+    rivals: ['\ud83c\uddf9\ud83c\uddfc', '\ud83c\uddfa\ud83c\uddf8', '\ud83c\uddee\ud83c\uddf3', '\ud83c\uddef\ud83c\uddf5', '\ud83c\uddf5\ud83c\udded'],
+    reason: 'South China Sea, Taiwan sovereignty, border tension'
+  },
+  '\ud83c\uddf9\ud83c\uddfc': {
+    region: 'East Asia',
+    rivals: ['\ud83c\udde8\ud83c\uddf3'],
+    reason: 'China claims Taiwan as its province; Taiwan claims independence'
+  },
+  '\ud83c\uddf7\ud83c\uddfa': {
+    region: 'Eurasia',
+    rivals: ['\ud83c\uddfa\ud83c\udde6', '\ud83c\uddf5\ud83c\uddf1', '\ud83c\uddfa\ud83c\uddf8', '\ud83c\uddec\ud83c\udde7', '\ud83c\uddf1\ud83c\uddf9'],
+    reason: 'Ukraine war, NATO expansion, post-Soviet influence'
+  },
+  '\ud83c\uddfa\ud83c\udde6': {
+    region: 'Eurasia',
+    rivals: ['\ud83c\uddf7\ud83c\uddfa'],
+    reason: "Russia's annexation of Crimea and invasion in 2022"
+  },
+  '\ud83c\uddfa\ud83c\uddf8': {
+    region: 'Global',
+    rivals: ['\ud83c\udde8\ud83c\uddf3', '\ud83c\uddf7\ud83c\uddfa', '\ud83c\uddee\ud83c\uddf7', '\ud83c\uddfb\ud83c\uddea', '\ud83c\uddf0\ud83c\uddf5', '\ud83c\uddfa\ud83c\uddfa'],
+    reason: 'Cold War legacy, nuclear threats, ideological opposition'
+  },
+  '\ud83c\uddfb\ud83c\uddea': {
+    region: 'Americas',
+    rivals: ['\ud83c\uddfa\ud83c\uddf8', '\ud83c\udde8\ud83c\uddf4'],
+    reason: 'US sanctions, regime change attempts, border clashes'
+  },
+  '\ud83c\udde8\ud83c\uddf4': {
+    region: 'Caribbean',
+    rivals: ['\ud83c\uddfa\ud83c\uddf8'],
+    reason: 'Embargoes, Cold War history, failed diplomacy'
+  },
+  '\ud83c\uddf0\ud83c\uddf5': {
+    region: 'East Asia',
+    rivals: ['\ud83c\uddf0\ud83c\uddf7', '\ud83c\uddfa\ud83c\uddf8', '\ud83c\uddef\ud83c\uddf5'],
+    reason: 'Nuclear program, Korean War legacy'
+  },
+  '\ud83c\uddec\ud83c\uddf7': {
+    region: 'Europe',
+    rivals: ['\ud83c\uddf9\ud83c\uddf7', '\ud83c\udde6\ud83c\uddf1'],
+    reason: 'Aegean disputes, maritime borders, minority rights'
+  },
+  '\ud83c\uddec\ud83c\udde7': {
+    region: 'Caucasus',
+    rivals: ['\ud83c\uddf7\ud83c\uddfa'],
+    reason: 'Russian support for separatists in Abkhazia and South Ossetia'
+  },
+  '\ud83c\udde6\ud83c\uddf2': {
+    region: 'Caucasus',
+    rivals: ['\ud83c\udde7\ud83c\udfff', '\ud83c\uddf9\ud83c\uddf7'],
+    reason: 'Nagorno-Karabakh conflict, genocide recognition'
+  },
+  '\ud83c\udde7\ud83c\udfff': {
+    region: 'Caucasus',
+    rivals: ['\ud83c\udde6\ud83c\uddf2'],
+    reason: 'Ongoing conflict over Nagorno-Karabakh region'
+  }
+};
+
+function codeToFlag(code) {
+  if (!code || code.length !== 2) return '🏳️';
+  const points = [...code.toUpperCase()].map(c => 0x1f1e6 + c.charCodeAt(0) - 65);
+  return String.fromCodePoint(...points);
+}
+
+async function ipToFlag() {
+  try {
+    const res = await fetch('https://ipinfo.io/json');
+    const data = await res.json();
+    return codeToFlag(data && data.country ? data.country : 'US');
+  } catch {
+    return '🇺🇸';
+  }
+}
+
+function randomItem(list) {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+const REGION_GROUPS = {};
+for (const [flag, info] of Object.entries(CONFLICT_MAP)) {
+  if (!REGION_GROUPS[info.region]) REGION_GROUPS[info.region] = [];
+  REGION_GROUPS[info.region].push(flag);
+}
+
+export const REGIONS = Object.keys(REGION_GROUPS);
+
+export async function get2PlayerConflict(region = null) {
+  const flag = region && REGION_GROUPS[region]
+    ? randomItem(REGION_GROUPS[region])
+    : await ipToFlag();
+  const rivals = CONFLICT_MAP[flag]?.rivals || [];
+  const filtered = region
+    ? rivals.filter(r => REGION_GROUPS[region].includes(r))
+    : rivals;
+  const rival = filtered.length
+    ? randomItem(filtered)
+    : randomItem(Object.keys(CONFLICT_MAP));
+  return [flag, rival];
+}
+
+export async function get3PlayerConflict(region = null) {
+  const flag = region && REGION_GROUPS[region]
+    ? randomItem(REGION_GROUPS[region])
+    : await ipToFlag();
+  const rivals = CONFLICT_MAP[flag]?.rivals || [];
+  const usable = region
+    ? rivals.filter(r => REGION_GROUPS[region].includes(r))
+    : rivals;
+  if (usable.length >= 2) {
+    const first = randomItem(usable);
+    const secondCandidates = usable.filter(
+      r => r !== first && (CONFLICT_MAP[first]?.rivals || []).includes(r)
+    );
+    if (secondCandidates.length) {
+      const second = randomItem(secondCandidates);
+      return [flag, first, second];
+    }
+  }
+  const allFlags = (region ? REGION_GROUPS[region] : Object.keys(CONFLICT_MAP)).filter(f => f !== flag);
+  while (allFlags.length < 2) allFlags.push(flag);
+  const choice1 = randomItem(allFlags);
+  let choice2 = randomItem(allFlags);
+  while (choice2 === choice1) choice2 = randomItem(allFlags);
+  return [flag, choice1, choice2];
+}
+
+export function get4PlayerConflict(region = null) {
+  const groups = region && REGION_GROUPS[region] ? [region] : Object.keys(REGION_GROUPS);
+  const chosenRegion = randomItem(groups);
+  const flags = REGION_GROUPS[chosenRegion];
+  const set = new Set();
+  while (set.size < Math.min(4, flags.length)) {
+    set.add(randomItem(flags));
+  }
+  return Array.from(set);
+}


### PR DESCRIPTION
## Summary
- add a conflict matchmaking helper for the webapp
- allow selecting conflict region in game lobbies
- choose AI avatars using conflict-based flags

## Testing
- `npm test` *(fails: get4PlayerConflict test expected 4 flags but got 3)*

------
https://chatgpt.com/codex/tasks/task_e_68776f8b59a88329858c4bfb36639ca8