### PR TITLE
Use flag names for AI players

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -147,7 +147,7 @@ export default function CrazyDiceDuel() {
             i === 0
               ? 'You'
               : aiCount > 0
-                ? avatarToName(p.photoUrl) || `AI ${i}`
+                ? avatarToName(p.photoUrl) || 'AI'
                 : `P${i + 1}`,
           score: p.score,
         }))
@@ -758,7 +758,7 @@ export default function CrazyDiceDuel() {
               timerPct={current === i + 1 ? timeLeft / 2.5 : 1}
               name={
                 aiCount > 0
-                  ? avatarToName(p.photoUrl) || `AI ${i + 1}`
+                  ? avatarToName(p.photoUrl) || 'AI'
                   : `P${i + 2}`
               }
               score={p.score}
@@ -818,7 +818,7 @@ export default function CrazyDiceDuel() {
             i === 0
               ? 'You'
               : aiCount > 0
-                ? avatarToName(p.photoUrl) || `AI ${i}`
+                ? avatarToName(p.photoUrl) || 'AI'
                 : `P${i + 1}`,
         }))}
         senderIndex={0}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -718,7 +718,7 @@ export default function SnakeAndLadder() {
     }
     const avatar = aiAvatars[idx - 1];
     const name = avatarToName(avatar);
-    return name || `AI ${idx}`;
+    return name || 'AI';
   };
 
   const playerName = (idx) => (


### PR DESCRIPTION
## Summary
- derive AI player names from the country flag avatar
- fall back to a generic "AI" if the name can't be determined

## Testing
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68777ff2007c8329a275c052a9ca9535