### PR TITLE
Fix flag avatar fallback

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -34,7 +34,10 @@ export default function AvatarTimer({
       )}
       <img
         src={getAvatarUrl(photoUrl)}
-        alt="player"
+        alt={name || 'player'}
+        onError={(e) => {
+          e.currentTarget.src = '/assets/icons/profile.svg';
+        }}
         className="rounded-full border-2 object-cover w-full h-full"
         style={{
           borderColor: color || '#fde047',

--- a/webapp/src/utils/conflictMatchmaking.js
+++ b/webapp/src/utils/conflictMatchmaking.js
@@ -121,10 +121,20 @@ function codeToFlag(code) {
 }
 
 export async function ipToFlag() {
+  if (typeof localStorage !== 'undefined') {
+    const cached = localStorage.getItem('ipFlag');
+    if (cached) return cached;
+  }
   try {
     const res = await fetch('https://ipinfo.io/json');
     const data = await res.json();
-    return codeToFlag(data && data.country ? data.country : 'US');
+    const flag = codeToFlag(data && data.country ? data.country : 'US');
+    if (typeof localStorage !== 'undefined') {
+      try {
+        localStorage.setItem('ipFlag', flag);
+      } catch {}
+    }
+    return flag;
   } catch {
     return '🇺🇸';
   }


### PR DESCRIPTION
## Summary
- cache ip-based flag in localStorage
- show placeholder when avatar images fail to load

## Testing
- `npm test` *(fails: get4PlayerConflict returns four flags in region, player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_687790577f988329bcf72e4b93bfb902