### PR TITLE
Fix 4-player flag selection

### DIFF
--- a/bot/utils/conflictMatchmaking.js
+++ b/bot/utils/conflictMatchmaking.js
@@ -162,11 +162,18 @@ for (const [flag, info] of Object.entries(CONFLICT_MAP)) {
 }
 
 export function get4PlayerConflict(region = null) {
-  const groups = region && REGION_GROUPS[region] ? [region] : Object.keys(REGION_GROUPS);
+  const groups =
+    region && REGION_GROUPS[region] ? [region] : Object.keys(REGION_GROUPS);
   const chosenRegion = randomItem(groups);
-  const flags = REGION_GROUPS[chosenRegion];
+  const flags = [...REGION_GROUPS[chosenRegion]];
+  // Ensure we always have at least 4 candidate flags
+  const allFlags = Object.keys(CONFLICT_MAP);
+  while (flags.length < 4) {
+    const next = randomItem(allFlags);
+    if (!flags.includes(next)) flags.push(next);
+  }
   const set = new Set();
-  while (set.size < Math.min(4, flags.length)) {
+  while (set.size < 4) {
     set.add(randomItem(flags));
   }
   return Array.from(set);

--- a/webapp/src/utils/conflictMatchmaking.js
+++ b/webapp/src/utils/conflictMatchmaking.js
@@ -193,11 +193,18 @@ export async function get3PlayerConflict(region = null) {
 }
 
 export function get4PlayerConflict(region = null) {
-  const groups = region && REGION_GROUPS[region] ? [region] : Object.keys(REGION_GROUPS);
+  const groups =
+    region && REGION_GROUPS[region] ? [region] : Object.keys(REGION_GROUPS);
   const chosenRegion = randomItem(groups);
-  const flags = REGION_GROUPS[chosenRegion];
+  const flags = [...REGION_GROUPS[chosenRegion]];
+  // Ensure we always have at least 4 candidate flags
+  const allFlags = Object.keys(CONFLICT_MAP);
+  while (flags.length < 4) {
+    const next = randomItem(allFlags);
+    if (!flags.includes(next)) flags.push(next);
+  }
   const set = new Set();
-  while (set.size < Math.min(4, flags.length)) {
+  while (set.size < 4) {
     set.add(randomItem(flags));
   }
   return Array.from(set);


### PR DESCRIPTION
## Summary
- ensure conflict matchmaking returns four flags even when a region has fewer than four

## Testing
- `node --test test/conflictMatchmaking.test.js`
- `npm test` *(fails: no final summary)*

------
https://chatgpt.com/codex/tasks/task_e_68779722d1c08329a65b7a9c80e084a3