### PR TITLE
Fix leader avatar name display

### DIFF
--- a/webapp/src/utils/avatarUtils.js
+++ b/webapp/src/utils/avatarUtils.js
@@ -75,8 +75,17 @@ export function avatarToName(src) {
   const match = src.match(/avatar(\d+)\.svg$/);
   if (match) return `Avatar ${match[1]}`;
   const file = src.split('/').pop().split('.')[0];
-  return file
+  let name = file
     .replace(/[_-]/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
     .replace(/\bLeader\b/gi, '')
-    .replace(/\b\w/g, (c) => c.toUpperCase());
+    .trim();
+  name = name
+    .split(' ')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+  if (/^[A-Za-z]{2,3}$/.test(name)) {
+    return name.toUpperCase();
+  }
+  return name;
 }


### PR DESCRIPTION
## Summary
- format avatar file names better
- special-case 2-3 letter names like USA

## Testing
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6877c1b13e8483299d9280f5edef5c61