### PR TITLE
Enhance Crazy Dice duel avatars

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -45,9 +45,23 @@ export default function AvatarTimer({
         <span className="rank-number">{rank}</span>
       )}
       {name && (
-        <span className="rank-name" style={{ color: color || '#fde047' }}>
-          {name}
-        </span>
+        <svg
+          className="rank-name curved-name"
+          viewBox="0 0 100 50"
+          style={{ color: color || '#fde047' }}
+        >
+          <defs>
+            <path
+              id={`name-path-${index}`}
+              d="M10,50 A40,40 0 0 1 90,50"
+            />
+          </defs>
+          <text>
+            <textPath href={`#name-path-${index}`} startOffset="50%" textAnchor="middle">
+              {name}
+            </textPath>
+          </text>
+        </svg>
       )}
       {score != null && (
         <span

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -432,6 +432,16 @@ input:focus {
   color: inherit;
   white-space: nowrap;
 }
+.curved-name {
+  width: 120%;
+  height: 1.2rem;
+  pointer-events: none;
+  overflow: visible;
+}
+.curved-name text {
+  fill: currentColor;
+  font-size: 0.5rem;
+}
 
 /* Score display below each avatar */
 .player-score {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -705,15 +705,15 @@ export default function CrazyDiceDuel() {
         if (playerCount === 4) {
           if (i === 0) {
             /* Top left opponent moved slightly right */
-            const pos = gridPoint(2.3, 7);
+            const pos = gridPoint(2.3, 6.5);
             wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
           } else if (i === 1) {
             /* Top middle opponent */
-            const pos = gridPoint(10, 7);
+            const pos = gridPoint(10, 6.5);
             wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
           } else if (i === 2) {
             /* Top right opponent shifted slightly left */
-            const pos = gridPoint(17.7, 7);
+            const pos = gridPoint(17.7, 6.5);
             wrapperStyle = { top: pos.top, right: `${100 - parseFloat(pos.left)}%` };
           }
           scoreStyle = undefined;
@@ -752,9 +752,11 @@ export default function CrazyDiceDuel() {
                   ? 2
                   : playerCount === 3
                     ? 1.1
-                    : playerCount > 3
-                      ? 1.05
-                      : 1
+                    : playerCount === 4
+                      ? 1.15
+                      : playerCount > 4
+                        ? 1.05
+                        : 1
               }
               onClick={() => {
                 if (current === i + 1) setTrigger((t) => t + 1);


### PR DESCRIPTION
## Summary
- shift top player avatars up slightly in four-player mode
- enlarge top avatars when four players are present
- display player names along a curved path above each avatar

## Testing
- `npm run install-all`
- `npm test` *(fails: ERR_MODULE_NOT_FOUND: Cannot find package 'geoip-lite', plus other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6877c5ab62b083298d82325cf0ffec40