### PR TITLE
Adjust avatar layout in CrazyDiceDuel

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -686,7 +686,7 @@ export default function CrazyDiceDuel() {
           maxRolls={maxRolls}
           color={players[0].color}
           size={
-            playerCount === 3 ? 1.1 : playerCount > 3 ? 1.05 : 1
+            playerCount === 3 ? 1.1 : playerCount > 3 ? 1.1 : 1
           }
           onClick={rollNow}
         />
@@ -704,16 +704,16 @@ export default function CrazyDiceDuel() {
         let historyStyle = undefined;
         if (playerCount === 4) {
           if (i === 0) {
-            /* Top left opponent moved slightly right */
-            const pos = gridPoint(2.3, 6.5);
+            /* Top left opponent slightly higher */
+            const pos = gridPoint(2.3, 6.3);
             wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
           } else if (i === 1) {
-            /* Top middle opponent */
-            const pos = gridPoint(10, 6.5);
+            /* Top middle opponent raised a little more */
+            const pos = gridPoint(10, 6.2);
             wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
           } else if (i === 2) {
-            /* Top right opponent shifted slightly left */
-            const pos = gridPoint(17.7, 6.5);
+            /* Top right opponent slightly higher */
+            const pos = gridPoint(17.7, 6.3);
             wrapperStyle = { top: pos.top, right: `${100 - parseFloat(pos.left)}%` };
           }
           scoreStyle = undefined;
@@ -753,7 +753,7 @@ export default function CrazyDiceDuel() {
                   : playerCount === 3
                     ? 1.1
                     : playerCount === 4
-                      ? 1.15
+                      ? 1.2
                       : playerCount > 4
                         ? 1.05
                         : 1


### PR DESCRIPTION
## Summary
- tweak avatar coordinates for four-player Crazy Dice Duel
- slightly enlarge avatars when four players are present
- increase bottom player's avatar size

## Testing
- `npm test` *(fails: cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6877cc097ff48329aed5a1d26f7972fa