### PR TITLE
Tune avatar layout in 3‑player Crazy Dice

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -436,6 +436,13 @@ input:focus {
   transform: translate(-50%, -0.05rem);
   font-size: 0.6rem;
 }
+.crazy-dice-board.three-players .rank-name {
+  transform: translate(-50%, 0.3rem);
+  font-size: 2.5rem;
+}
+.crazy-dice-board.three-players .curved-name text {
+  font-size: 2.5rem;
+}
 .curved-name {
   width: 120%;
   height: 1.2rem;

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -719,13 +719,26 @@ export default function CrazyDiceDuel() {
           scoreStyle = undefined;
           historyStyle = undefined;
         }
+        let avatarSize =
+          playerCount === 2
+            ? 2
+            : playerCount === 3
+              ? 1.2
+              : playerCount === 4
+                ? 1.3
+                : playerCount > 4
+                  ? 1.05
+                  : 1;
+
         if (playerCount === 3) {
           if (i === 0) {
             // Nudge the top left opponent slightly left and higher
             wrapperStyle = { ...gridPoint(3.3, 6.0), right: 'auto' };
+            avatarSize = 1.3;
           } else if (i === 1) {
             // Move the top right opponent slightly further left
-            wrapperStyle = { ...gridPoint(15.0, 6.5), right: 'auto' };
+            wrapperStyle = { ...gridPoint(14.0, 6.5), right: 'auto' };
+            avatarSize = 1.3;
           }
         }
         return (
@@ -747,17 +760,7 @@ export default function CrazyDiceDuel() {
               color={p.color}
               scoreStyle={scoreStyle}
               rollHistoryStyle={historyStyle}
-              size={
-                playerCount === 2
-                  ? 2
-                  : playerCount === 3
-                    ? 1.2
-                    : playerCount === 4
-                      ? 1.3
-                      : playerCount > 4
-                        ? 1.05
-                        : 1
-              }
+              size={avatarSize}
               onClick={() => {
                 if (current === i + 1) setTrigger((t) => t + 1);
               }}


### PR DESCRIPTION
## Summary
- tweak placement of top avatars in 3-player matches
- make avatars slightly larger for those opponents
- enlarge curved names in three-player mode

## Testing
- `npm test` *(fails: Subtest: snake API endpoints and socket events)*

------
https://chatgpt.com/codex/tasks/task_e_6877e09bea30832989d6485dbeed40c8