### PR TITLE
Adjust Crazy Dice Duel avatars

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -15,6 +15,7 @@ export default function AvatarTimer({
   onClick,
   index,
   size = 1,
+  imageScale = 1,
   scoreStyle = {},
   rollHistoryStyle = {},
 }) {
@@ -39,6 +40,7 @@ export default function AvatarTimer({
         style={{
           borderColor: color || '#fde047',
           boxShadow: isTurn ? `0 0 6px ${color || '#fde047'}` : undefined,
+          transform: `scale(${imageScale})`,
         }}
       />
       {rank != null && (

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -437,14 +437,14 @@ input:focus {
   font-size: 0.6rem;
 }
 .crazy-dice-board.three-players .rank-name {
-  transform: translate(-50%, 0.3rem);
-  font-size: 2.5rem;
+  transform: translate(-50%, -0.05rem);
+  font-size: 0.5rem;
 }
 .crazy-dice-board.three-players .curved-name text {
-  font-size: 2.5rem;
+  font-size: 0.5rem;
 }
 .curved-name {
-  width: 120%;
+  width: 110%;
   height: 1.2rem;
   pointer-events: none;
   overflow: visible;

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -119,6 +119,7 @@ export default function CrazyDiceDuel() {
   const [trigger, setTrigger] = useState(0);
   const [winner, setWinner] = useState(null);
   const [tiePlayers, setTiePlayers] = useState(null);
+  const [leaders, setLeaders] = useState([0]);
   const ranking = useMemo(
     () =>
       players
@@ -142,6 +143,20 @@ export default function CrazyDiceDuel() {
   const [timeLeft, setTimeLeft] = useState(15);
   const timerRef = useRef(null);
   const timerSoundRef = useRef(null);
+
+  useEffect(() => {
+    if (aiCount === 0) {
+      setLeaders([]);
+      return;
+    }
+    const max = Math.max(...players.map((p) => p.score));
+    setLeaders(
+      players.reduce((arr, p, idx) => {
+        if (p.score === max) arr.push(idx);
+        return arr;
+      }, [])
+    );
+  }, [players, aiCount]);
 
   // Board background changes depending on number of opponents
   const BG_BY_PLAYERS = {
@@ -688,6 +703,7 @@ export default function CrazyDiceDuel() {
           size={
             playerCount === 3 ? 1.2 : playerCount > 3 ? 1.1 : 1
           }
+          imageScale={leaders.includes(0) ? 1.1 : 1}
           onClick={rollNow}
         />
       </div>
@@ -733,12 +749,12 @@ export default function CrazyDiceDuel() {
         if (playerCount === 3) {
           if (i === 0) {
             // Nudge the top left opponent slightly left and higher
-            wrapperStyle = { ...gridPoint(3.3, 6.0), right: 'auto' };
-            avatarSize = 1.3;
+            wrapperStyle = { ...gridPoint(3.0, 5.8), right: 'auto' };
+            avatarSize = 1.35;
           } else if (i === 1) {
             // Move the top right opponent slightly further left
-            wrapperStyle = { ...gridPoint(14.0, 6.5), right: 'auto' };
-            avatarSize = 1.3;
+            wrapperStyle = { ...gridPoint(13.2, 6.2), right: 'auto' };
+            avatarSize = 1.35;
           }
         }
         return (
@@ -761,6 +777,7 @@ export default function CrazyDiceDuel() {
               scoreStyle={scoreStyle}
               rollHistoryStyle={historyStyle}
               size={avatarSize}
+              imageScale={leaders.includes(i + 1) ? 1.1 : 1}
               onClick={() => {
                 if (current === i + 1) setTrigger((t) => t + 1);
               }}


### PR DESCRIPTION
## Summary
- tweak avatar name styling for Crazy Dice Duel
- add imageScale prop to `AvatarTimer` so leading players can be zoomed in
- highlight leading avatars when playing against AI
- slightly adjust 3-player avatar positions

## Testing
- `npm test` *(fails: test timed out due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877e8c55af88329bc2e549d9a101e99