### PR TITLE
UI tweaks for snake board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -354,8 +354,8 @@ input:focus {
   height: 8rem;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -110%) translateZ(20px)
-    rotateX(calc(var(--board-angle, 58deg) * -1 + 20deg));
+  /* Keep the pot icon upright so it remains visible */
+  transform: translate(-50%, -110%) translateZ(20px);
   pointer-events: none;
   z-index: 3;
 }
@@ -386,9 +386,10 @@ input:focus {
 }
 
 .board-token .token-photo {
-  width: 3rem;
-  height: 3rem;
-  transform: translate(-50%, -95%) translateZ(15.2px)
+  width: 3.4rem;
+  height: 3.4rem;
+  /* Lower the photo so the bottom touches the tile edge */
+  transform: translate(-50%, -90%) translateZ(15.2px)
     rotateX(calc(var(--board-angle, 58deg) * -1 - 10deg));
 }
 
@@ -434,21 +435,22 @@ input:focus {
   position: absolute;
   bottom: 100%;
   left: 50%;
-  transform: translate(-50%, 0.05rem);
-  font-size: 0.6rem;
+  /* Move the curved name closer to the avatar */
+  transform: translate(-50%, 0.6rem);
+  font-size: 1.2rem;
   color: inherit;
   white-space: nowrap;
 }
 .crazy-dice-board.four-players .rank-name {
-  transform: translate(-50%, -0.05rem);
-  font-size: 0.6rem;
+  transform: translate(-50%, 0.6rem);
+  font-size: 1.2rem;
 }
 .crazy-dice-board.three-players .rank-name {
-  transform: translate(-50%, -0.05rem);
-  font-size: 0.5rem;
+  transform: translate(-50%, 0.6rem);
+  font-size: 1.2rem;
 }
 .crazy-dice-board.three-players .curved-name text {
-  font-size: 0.5rem;
+  font-size: 1rem;
 }
 .curved-name {
   width: 110%;
@@ -458,7 +460,7 @@ input:focus {
 }
 .curved-name text {
   fill: currentColor;
-  font-size: 0.5rem;
+  font-size: 1rem;
 }
 
 /* Score display below each avatar */
@@ -1096,8 +1098,8 @@ input:focus {
 
 .dice-marker {
   position: absolute;
-  width: 1.8rem;
-  height: 1.8rem;
+  width: 2.2rem;
+  height: 2.2rem;
   left: 50%;
   top: 57%;
   transform: translate(-50%, -50%) translateZ(6px)
@@ -1111,8 +1113,8 @@ input:focus {
 }
 
 .dice-marker .dice-icon {
-  width: 1.8rem;
-  height: 1.8rem;
+  width: 2.2rem;
+  height: 2.2rem;
   object-fit: contain;
   transition: transform 0.3s ease;
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1144,7 +1144,7 @@ export default function SnakeAndLadder() {
         updatePosition(finalPos);
         setHighlight({ cell: finalPos, type });
         setTrail([]);
-        setTimeout(() => setHighlight(null), 300);
+        setTimeout(() => setHighlight(null), 2300);
         setMoving(false);
       };
       const seq = [];
@@ -1177,7 +1177,7 @@ export default function SnakeAndLadder() {
         updatePosition(finalPos);
         setHighlight({ cell: finalPos, type });
         setTrail([]);
-        setTimeout(() => setHighlight(null), 300);
+        setTimeout(() => setHighlight(null), 2300);
         setMoving(false);
       };
       setMoving(true);
@@ -1587,7 +1587,7 @@ export default function SnakeAndLadder() {
         setHighlight({ cell: finalPos, type });
         setTrail([]);
         setTokenType(type);
-        setTimeout(() => setHighlight(null), 300);
+        setTimeout(() => setHighlight(null), 2300);
         capturePieces(finalPos, 0);
         if (finalPos === FINAL_TILE && !ranking.includes('You')) {
           const first = ranking.length === 0;
@@ -1755,7 +1755,7 @@ export default function SnakeAndLadder() {
       setHighlight({ cell: finalPos, type });
       setTrail([]);
       capturePieces(finalPos, index);
-      setTimeout(() => setHighlight(null), 300);
+      setTimeout(() => setHighlight(null), 2300);
       if (finalPos === FINAL_TILE && !ranking.includes(getPlayerName(index))) {
         const first = ranking.length === 0;
         setRanking(r => [...r, getPlayerName(index)]);


### PR DESCRIPTION
## Summary
- adjust pot icon so it stays upright
- enlarge and reposition board avatars
- grow dice icons
- move leaderboard names downward and double their size
- keep highlight longer when landing on special tiles

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878088194e483299d120c62f56228aa