### PR TITLE
Fix board display issues

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -55,7 +55,7 @@ export default function AvatarTimer({
           <defs>
             <path
               id={`name-path-${index}`}
-              d="M10,50 A40,40 0 0 1 90,50"
+              d="M5,50 A45,45 0 0 1 95,50"
             />
           </defs>
           <text>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -357,7 +357,7 @@ input:focus {
   /* Keep the pot icon upright so it remains visible */
   transform: translate(-50%, -110%) translateZ(20px);
   pointer-events: none;
-  z-index: 3;
+  z-index: 6;
 }
 
 .token-three canvas {
@@ -389,7 +389,7 @@ input:focus {
   width: 3.4rem;
   height: 3.4rem;
   /* Lower the photo so the bottom touches the tile edge */
-  transform: translate(-50%, -90%) translateZ(15.2px)
+  transform: translate(-50%, -50%) translateZ(15.2px)
     rotateX(calc(var(--board-angle, 58deg) * -1 - 10deg));
 }
 
@@ -450,7 +450,7 @@ input:focus {
   font-size: 1.2rem;
 }
 .crazy-dice-board.three-players .curved-name text {
-  font-size: 1rem;
+  font-size: 1.2rem;
 }
 .curved-name {
   width: 110%;
@@ -460,7 +460,7 @@ input:focus {
 }
 .curved-name text {
   fill: currentColor;
-  font-size: 1rem;
+  font-size: 1.2rem;
 }
 
 /* Score display below each avatar */


### PR DESCRIPTION
## Summary
- ensure pot icon overlays the logo by raising its z-index
- move board tokens down to align with their cells
- enlarge curved name labels above avatars
- adjust curved path radius to match avatar

## Testing
- `npm test` *(fails: snake API endpoints test timed out)*
- `npm --prefix webapp run build`

------
https://chatgpt.com/codex/tasks/task_e_68780e2d30108329ba4204c87eaba702