### PR TITLE
Adjust board avatar alignment

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -388,8 +388,8 @@ input:focus {
 .board-token .token-photo {
   width: 3.4rem;
   height: 3.4rem;
-  /* Lower the photo so the bottom touches the tile edge */
-  transform: translate(-50%, -50%) translateZ(15.2px)
+  /* Lower the photo slightly more so it aligns better with the tile */
+  transform: translate(-50%, -45%) translateZ(15.2px)
     rotateX(calc(var(--board-angle, 58deg) * -1 - 10deg));
 }
 


### PR DESCRIPTION
## Summary
- shift board avatars down a bit so they sit nicer on tiles

## Testing
- `npm test` *(fails: cannot find package 'geoip-lite')*

------
https://chatgpt.com/codex/tasks/task_e_6878714675c48329925a9d2790bc1cdc