### PR TITLE
Fix avatar placement on snake board

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -388,8 +388,8 @@ input:focus {
 .board-token .token-photo {
   width: 3.4rem;
   height: 3.4rem;
-  /* Lower the photo slightly more so it aligns better with the tile */
-  transform: translate(-50%, -45%) translateZ(15.2px)
+  /* Lower the photo a bit more so it sits better within each tile */
+  transform: translate(-50%, -40%) translateZ(15.2px)
     rotateX(calc(var(--board-angle, 58deg) * -1 - 10deg));
 }
 


### PR DESCRIPTION
## Summary
- tweak `.board-token .token-photo` transform so avatars sit lower in the tile

## Testing
- `npm test` *(fails: Cannot find package 'geoip-lite', 'express', 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_687876c220c4832989989cc56215947b