### PR TITLE
Fix snake board avatar placement

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -388,8 +388,8 @@ input:focus {
 .board-token .token-photo {
   width: 3.4rem;
   height: 3.4rem;
-  /* Lower the photo a bit more so it sits better within each tile */
-  transform: translate(-50%, -40%) translateZ(15.2px)
+  /* Lower the photo further so it sits even closer to the tile */
+  transform: translate(-50%, -30%) translateZ(15.2px)
     rotateX(calc(var(--board-angle, 58deg) * -1 - 10deg));
 }
 


### PR DESCRIPTION
## Summary
- tweak board avatar offset so tokens sit lower within each tile

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_68787ae980e48329b18d262939e386ae