### PR TITLE
Adjust Crazy Dice Duel avatar layout

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -16,6 +16,8 @@ export default function AvatarTimer({
   index,
   size = 1,
   imageScale = 1,
+  imageYOffset = 0,
+  imageZoom = 1,
   scoreStyle = {},
   rollHistoryStyle = {},
 }) {
@@ -40,7 +42,7 @@ export default function AvatarTimer({
         style={{
           borderColor: color || '#fde047',
           boxShadow: isTurn ? `0 0 6px ${color || '#fde047'}` : undefined,
-          transform: `scale(${imageScale})`,
+          transform: `translateY(${imageYOffset}%) scale(${imageScale * imageZoom})`,
         }}
       />
       {rank != null && (

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1445,7 +1445,8 @@ input:focus {
 
 /* Adjust bottom player position for 1v1 games */
 .crazy-dice-board.two-players .player-bottom {
-  bottom: 8%;
+  /* Match bottom position used when facing multiple opponents */
+  bottom: 9%;
 }
 
 .crazy-dice-board .player-left {
@@ -1471,7 +1472,8 @@ input:focus {
 
 /* Slightly shift opponent avatar left in 1v1 games */
 .crazy-dice-board.two-players .player-center {
-  left: 51%;
+  /* Move the lone opponent slightly further left */
+  left: 49.5%;
 }
 .crazy-dice-board .player-center .player-score,
 .crazy-dice-board .player-center .roll-history {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -705,6 +705,8 @@ export default function CrazyDiceDuel() {
             playerCount === 3 ? 1.2 : playerCount > 3 ? 1.1 : 1
           }
           imageScale={leaders.includes(0) ? 1.1 : 1}
+          imageYOffset={0}
+          imageZoom={1}
           onClick={rollNow}
         />
       </div>
@@ -779,6 +781,8 @@ export default function CrazyDiceDuel() {
               rollHistoryStyle={historyStyle}
               size={avatarSize}
               imageScale={leaders.includes(i + 1) ? 1.1 : 1}
+              imageYOffset={playerCount === 2 ? 4 : 0}
+              imageZoom={playerCount === 2 ? 1.05 : 1}
               onClick={() => {
                 if (current === i + 1) setTrigger((t) => t + 1);
               }}


### PR DESCRIPTION
## Summary
- tweak bottom player position for 1v1 matches
- move top opponent further left when playing 1v1
- allow AvatarTimer to offset and zoom avatar photos
- apply the photo offset/zoom to the top opponent in 1v1

## Testing
- `npm test` *(fails: Cannot find package 'geoip-lite')*

------
https://chatgpt.com/codex/tasks/task_e_687888edde488329995867c9242b6dbd