### PR TITLE
Adjust snake board visuals

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -355,7 +355,7 @@ input:focus {
   top: 50%;
   left: 50%;
   /* Keep the pot icon upright so it remains visible */
-  transform: translate(-50%, -110%) translateZ(20px);
+  transform: translate(-50%, -110%) translateZ(40px);
   pointer-events: none;
   z-index: 6;
 }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2062,7 +2062,7 @@ export default function SnakeAndLadder() {
         onGift={() => setShowGift(true)}
       />
       {/* Player photos stacked vertically */}
-        <div className="fixed left-0 top-[40%] -translate-y-1/2 flex flex-col space-y-5 z-20">
+        <div className="fixed left-0 top-[45%] -translate-y-1/2 flex flex-col space-y-5 z-20">
         {players
           .map((p, i) => ({ ...p, index: i }))
           .map((p) => (


### PR DESCRIPTION
## Summary
- tweak pot icon layering so it shows over the logo
- move avatars slightly lower on the Snake & Ladder page

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_687896bd75f8832986eebacbb6ec9ccf