### PR TITLE
Fix Crazy Dice duel layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -437,30 +437,30 @@ input:focus {
   left: 50%;
   /* Move the curved name closer to the avatar */
   transform: translate(-50%, 0.6rem);
-  font-size: 1.2rem;
+  font-size: 2.4rem;
   color: inherit;
   white-space: nowrap;
 }
 .crazy-dice-board.four-players .rank-name {
   transform: translate(-50%, 0.6rem);
-  font-size: 1.2rem;
+  font-size: 2.4rem;
 }
 .crazy-dice-board.three-players .rank-name {
   transform: translate(-50%, 0.6rem);
-  font-size: 1.2rem;
+  font-size: 2.4rem;
 }
 .crazy-dice-board.three-players .curved-name text {
-  font-size: 1.2rem;
+  font-size: 2.4rem;
 }
 .curved-name {
   width: 110%;
-  height: 1.2rem;
+  height: 2.4rem;
   pointer-events: none;
   overflow: visible;
 }
 .curved-name text {
   fill: currentColor;
-  font-size: 1.2rem;
+  font-size: 2.4rem;
 }
 
 /* Score display below each avatar */
@@ -1510,6 +1510,12 @@ input:focus {
 }
 .crazy-dice-board .player-bottom .player-score {
   top: calc(100% + 1.45rem);
+}
+.crazy-dice-board.two-players .player-bottom .roll-history {
+  top: calc(100% + 0.75rem);
+}
+.crazy-dice-board.two-players .player-bottom .player-score {
+  top: calc(100% + 1.95rem);
 }
 
 .crazy-dice-board.three-players .player-bottom .roll-history {


### PR DESCRIPTION
## Summary
- adjust the 1v1 bottom player UI positioning
- double the name size above avatars for better readability

## Testing
- `npm test` *(fails: cannot find package 'express' imported from /workspace/TonPlaygramWebApp/bot/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_687897557dc08329b8f08fef3ae27f8b