### PR TITLE
Adjust pot coin visuals

### DIFF
--- a/webapp/src/components/HexPrismToken.jsx
+++ b/webapp/src/components/HexPrismToken.jsx
@@ -2,7 +2,7 @@ import { useRef, useEffect } from "react";
 import * as THREE from "three";
 import { getAvatarUrl } from '../utils/avatarUtils.js';
 
-export default function HexPrismToken({ color = "#008080", topColor, photoUrl, className = "", rolling = false, active = false }) {
+export default function HexPrismToken({ color = "#008080", topColor, photoUrl, className = "", rolling = false, active = false, spin = true }) {
   const mountRef = useRef(null);
 
   useEffect(() => {
@@ -66,7 +66,9 @@ export default function HexPrismToken({ color = "#008080", topColor, photoUrl, c
 
     let frameId;
     const animate = () => {
-      prism.rotation.y += 0.01;
+      if (spin) {
+        prism.rotation.y += 0.01;
+      }
       renderer.render(scene, camera);
       frameId = requestAnimationFrame(animate);
     };
@@ -91,7 +93,7 @@ export default function HexPrismToken({ color = "#008080", topColor, photoUrl, c
       bottomMaterial.dispose();
       renderer.dispose();
     };
-  }, [color, topColor]);
+  }, [color, topColor, spin]);
 
 
   return (

--- a/webapp/src/components/PlayerToken.jsx
+++ b/webapp/src/components/PlayerToken.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import HexPrismToken from "./HexPrismToken.jsx";
 import { getAvatarUrl } from "../utils/avatarUtils.js";
 
-export default function PlayerToken({ type = "normal", color, topColor, photoUrl, className = "", rolling = false, active = false, photoOnly = false }) {
+export default function PlayerToken({ type = "normal", color, topColor, photoUrl, className = "", rolling = false, active = false, photoOnly = false, spin = true }) {
   let tokenColor = color;
   if (!tokenColor) {
     if (type === "ladder") tokenColor = "#86efac"; // green
@@ -32,6 +32,7 @@ export default function PlayerToken({ type = "normal", color, topColor, photoUrl
       className={className}
       rolling={rolling}
       active={active}
+      spin={spin}
     />
   );
 }

--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -264,19 +264,32 @@ export default function SnakeBoard({
           >
             {tiles}
             <div className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? 'highlight' : ''}`}>
-              <PlayerToken color="#16a34a" topColor="#ff0000" className="pot-token" />
-              <img
-                src={
-                  token === 'TON'
-                    ? '/assets/icons/TON.webp'
-                    : token === 'USDT'
-                    ? '/assets/icons/Usdt.webp'
-                    : '/assets/icons/TPCcoin_1.webp'
-                }
-                
-                alt={token}
-                className="pot-icon"
+              <PlayerToken color="#16a34a" topColor="#ff0000" className="pot-token" spin={false} />
+              <div className="pot-icon">
+                <img
+                  src={
+                    token === 'TON'
+                      ? '/assets/icons/TON.webp'
+                      : token === 'USDT'
+                        ? '/assets/icons/Usdt.webp'
+                        : '/assets/icons/TPCcoin_1.webp'
+                  }
+
+                  alt={token}
+                  className="coin-face front"
                 />
+                <img
+                  src={
+                    token === 'TON'
+                      ? '/assets/icons/TON.webp'
+                      : token === 'USDT'
+                        ? '/assets/icons/Usdt.webp'
+                        : '/assets/icons/TPCcoin_1.webp'
+                  }
+                  alt=""
+                  className="coin-face back"
+                />
+              </div>
               {players
                 .map((p, i) => ({ ...p, index: i }))
                 .filter((p) => p.position === FINAL_TILE)

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -350,14 +350,39 @@ input:focus {
 
 .pot-icon {
   position: absolute;
-  width: 8rem;
-  height: 8rem;
+  width: 6rem;
+  height: 6rem;
   top: 50%;
   left: 50%;
-  /* Keep the pot icon upright so it remains visible */
+  transform-style: preserve-3d;
   transform: translate(-50%, -110%) translateZ(40px);
+  animation: coin-spin 3s linear infinite;
   pointer-events: none;
   z-index: 6;
+}
+
+.pot-icon .coin-face {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  object-fit: contain;
+  backface-visibility: hidden;
+  transform: translate(-50%, -110%) translateZ(40px);
+}
+
+.pot-icon .coin-face.back {
+  transform: translate(-50%, -110%) translateZ(40px) rotateY(180deg);
+}
+
+@keyframes coin-spin {
+  from {
+    transform: translate(-50%, -110%) translateZ(40px) rotateY(0deg);
+  }
+  to {
+    transform: translate(-50%, -110%) translateZ(40px) rotateY(360deg);
+  }
 }
 
 .token-three canvas {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -464,18 +464,32 @@ function Board({
                 color="#16a34a"
                 topColor="#ff0000"
                 className="pot-token"
+                spin={false}
               />
-              <img
-                src={
-                  token === 'TON'
-                    ? '/assets/icons/TON.webp'
-                    : token === 'USDT'
-                    ? '/assets/icons/Usdt.webp'
-                    : '/assets/icons/TPCcoin_1.webp'
-                }
-                alt={token}
-                className="pot-icon"
-              />
+              <div className="pot-icon">
+                <img
+                  src={
+                    token === 'TON'
+                      ? '/assets/icons/TON.webp'
+                      : token === 'USDT'
+                        ? '/assets/icons/Usdt.webp'
+                        : '/assets/icons/TPCcoin_1.webp'
+                  }
+                  alt={token}
+                  className="coin-face front"
+                />
+                <img
+                  src={
+                    token === 'TON'
+                      ? '/assets/icons/TON.webp'
+                      : token === 'USDT'
+                        ? '/assets/icons/Usdt.webp'
+                        : '/assets/icons/TPCcoin_1.webp'
+                  }
+                  alt=""
+                  className="coin-face back"
+                />
+              </div>
               {players
                 .map((p, i) => ({ ...p, index: i }))
                 .filter((p) => p.position === FINAL_TILE)
@@ -2062,7 +2076,7 @@ export default function SnakeAndLadder() {
         onGift={() => setShowGift(true)}
       />
       {/* Player photos stacked vertically */}
-        <div className="fixed left-0 top-[45%] -translate-y-1/2 flex flex-col space-y-5 z-20">
+        <div className="fixed left-0 top-[45%] -translate-x-2 -translate-y-1/2 flex flex-col space-y-5 z-20">
         {players
           .map((p, i) => ({ ...p, index: i }))
           .map((p) => (


### PR DESCRIPTION
## Summary
- tweak avatar sidebar position
- stop rotating pot token and rotate coin icon instead
- shrink pot coin size and spin in 3D

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_68789ca30aa0832980ffe0e6d25e5e67