### PR TITLE
Fix Crazy Dice 1v1 layout

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -1,7 +1,16 @@
 import { useState, useEffect } from 'react';
 import { AiOutlineInfoCircle, AiOutlineMessage } from 'react-icons/ai';
 import { isGameMuted, toggleGameMuted } from '../utils/sound.js';
-export default function BottomLeftIcons({ onInfo, onChat, onGift }) {
+export default function BottomLeftIcons({
+  onInfo,
+  onChat,
+  onGift,
+  className = 'fixed left-1 bottom-4 flex flex-col items-center space-y-2 z-20',
+  showInfo = true,
+  showChat = true,
+  showGift = true,
+  showMute = true,
+}) {
   const [muted, setMuted] = useState(isGameMuted());
 
   useEffect(() => {
@@ -16,27 +25,31 @@ export default function BottomLeftIcons({ onInfo, onChat, onGift }) {
   };
 
   return (
-    <div className="fixed left-1 bottom-4 flex flex-col items-center space-y-2 z-20">
-      {onChat && (
+    <div className={className}>
+      {showChat && onChat && (
         <button onClick={onChat} className="p-1 flex flex-col items-center">
           <AiOutlineMessage className="text-xl" />
           <span className="text-xs">Chat</span>
         </button>
       )}
-      {onGift && (
+      {showGift && onGift && (
         <button onClick={onGift} className="p-1 flex flex-col items-center">
           <span className="text-xl">🎁</span>
           <span className="text-xs">Gift</span>
         </button>
       )}
-      <button onClick={onInfo} className="p-1 flex flex-col items-center">
-        <AiOutlineInfoCircle className="text-xl" />
-        <span className="text-xs">Info</span>
-      </button>
-      <button onClick={toggle} className="p-1 flex flex-col items-center">
-        <span className="text-lg">{muted ? '🔇' : '🔊'}</span>
-        <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
-      </button>
+      {showInfo && (
+        <button onClick={onInfo} className="p-1 flex flex-col items-center">
+          <AiOutlineInfoCircle className="text-xl" />
+          <span className="text-xs">Info</span>
+        </button>
+      )}
+      {showMute && (
+        <button onClick={toggle} className="p-1 flex flex-col items-center">
+          <span className="text-lg">{muted ? '🔇' : '🔊'}</span>
+          <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
+        </button>
+      )}
     </div>
   );
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1448,6 +1448,12 @@ input:focus {
   /* Match bottom position used when facing multiple opponents */
   bottom: 9%;
 }
+.crazy-dice-board.two-players .player-bottom .roll-history {
+  top: calc(100% + 2rem);
+}
+.crazy-dice-board.two-players .player-bottom .player-score {
+  top: calc(100% + 3.4rem);
+}
 
 .crazy-dice-board .player-left {
   position: absolute;
@@ -1474,6 +1480,12 @@ input:focus {
 .crazy-dice-board.two-players .player-center {
   /* Move the lone opponent slightly further left */
   left: 49.5%;
+}
+.crazy-dice-board.two-players .player-center .player-score {
+  font-size: 1rem;
+}
+.crazy-dice-board.two-players .curved-name text {
+  font-size: 2.4rem;
 }
 .crazy-dice-board .player-center .player-score,
 .crazy-dice-board .player-center .roll-history {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -810,11 +810,27 @@ export default function CrazyDiceDuel() {
           <img src={b.photoUrl} className="w-6 h-6 rounded-full" />
         </div>
       ))}
-      <BottomLeftIcons
-        onInfo={() => {}}
-        onChat={() => setShowChat(true)}
-        onGift={() => setShowGift(true)}
-      />
+      {playerCount === 2 ? (
+        <>
+          <BottomLeftIcons
+            onInfo={() => {}}
+            className="fixed left-1 top-1 flex flex-col items-center space-y-2 z-20"
+          />
+          <BottomLeftIcons
+            onChat={() => setShowChat(true)}
+            onGift={() => setShowGift(true)}
+            className="fixed right-1 top-1 flex flex-col items-center space-y-2 z-20"
+            showInfo={false}
+            showMute={false}
+          />
+        </>
+      ) : (
+        <BottomLeftIcons
+          onInfo={() => {}}
+          onChat={() => setShowChat(true)}
+          onGift={() => setShowGift(true)}
+        />
+      )}
       <QuickMessagePopup
         open={showChat}
         onClose={() => setShowChat(false)}


### PR DESCRIPTION
## Summary
- tweak game layout for Crazy Dice Duel when only two players are present
- support more flexible icon placement
- enlarge fonts and reposition score panels for 1v1 matches

## Testing
- `npm test` *(fails: test timeouts and missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68789ea894c08329be2e06a28a328fd3