### PR TITLE
Fix pot coin rotation

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -355,6 +355,7 @@ input:focus {
   top: 50%;
   left: 50%;
   transform-style: preserve-3d;
+  transform-origin: center;
   transform: translate(-50%, -110%) translateZ(40px);
   animation: coin-spin 3s linear infinite;
   pointer-events: none;
@@ -365,15 +366,15 @@ input:focus {
   position: absolute;
   width: 100%;
   height: 100%;
-  left: 0;
-  top: 0;
+  left: 50%;
+  top: 50%;
   object-fit: contain;
   backface-visibility: hidden;
-  transform: translate(-50%, -110%) translateZ(40px);
+  transform: translate(-50%, -50%) translateZ(40px);
 }
 
 .pot-icon .coin-face.back {
-  transform: translate(-50%, -110%) translateZ(40px) rotateY(180deg);
+  transform: translate(-50%, -50%) translateZ(40px) rotateY(180deg);
 }
 
 @keyframes coin-spin {


### PR DESCRIPTION
## Summary
- fix pot coin faces translation so they spin in place above the pot

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_6878acd1f4688329a54327d49638d337