### PR TITLE
Fix 1v1 crazy dice layout

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -20,6 +20,7 @@ export default function AvatarTimer({
   imageZoom = 1,
   scoreStyle = {},
   rollHistoryStyle = {},
+  nameCurveRadius = 45,
 }) {
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
@@ -55,10 +56,13 @@ export default function AvatarTimer({
           style={{ color: color || '#fde047' }}
         >
           <defs>
-            <path
-              id={`name-path-${index}`}
-              d="M5,50 A45,45 0 0 1 95,50"
-            />
+            {(() => {
+              const r = nameCurveRadius;
+              const start = 50 - r;
+              const end = 50 + r;
+              const path = `M${start},50 A${r},${r} 0 0 1 ${end},50`;
+              return <path id={`name-path-${index}`} d={path} />;
+            })()}
           </defs>
           <text>
             <textPath href={`#name-path-${index}`} startOffset="50%" textAnchor="middle">

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1451,6 +1451,7 @@ input:focus {
 /* Adjust dice landing spot for 1v1 games */
 .crazy-dice-board.two-players .dice-center {
   top: 72%;
+  left: 50%;
 }
 
 /* Player positions around the Crazy Dice board */
@@ -1474,10 +1475,10 @@ input:focus {
   bottom: 9%;
 }
 .crazy-dice-board.two-players .player-bottom .roll-history {
-  top: calc(100% + 2rem);
+  top: calc(100% + 1.8rem);
 }
 .crazy-dice-board.two-players .player-bottom .player-score {
-  top: calc(100% + 3.4rem);
+  top: calc(100% + 3.2rem);
 }
 
 .crazy-dice-board .player-left {
@@ -1630,6 +1631,9 @@ input:focus {
   pointer-events: none;
   transform: translate(-50%, -50%) scale(1);
   z-index: 101;
+}
+.crazy-dice-board.two-players .dice-travel {
+  transform: translate(-50%, -50%) scale(0.9);
 }
 
 /* Image that appears under the dice when the bottom player rolls */

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -707,6 +707,7 @@ export default function CrazyDiceDuel() {
           imageScale={leaders.includes(0) ? 1.1 : 1}
           imageYOffset={0}
           imageZoom={1}
+          nameCurveRadius={playerCount === 2 ? 50 : 45}
           onClick={rollNow}
         />
       </div>
@@ -797,6 +798,7 @@ export default function CrazyDiceDuel() {
               imageScale={leaders.includes(i + 1) ? 1.1 : 1}
               imageYOffset={playerCount === 2 ? 4 : 0}
               imageZoom={1}
+              nameCurveRadius={playerCount === 2 ? 50 : 45}
               onClick={() => {
                 if (current === i + 1) setTrigger((t) => t + 1);
               }}


### PR DESCRIPTION
## Summary
- tweak the AvatarTimer component to allow custom curve radius
- adjust crazy dice duel player names in 1v1 mode
- refine dice landing and score placement in two player games

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6878b721ff0883298b97effc326a4cba