### PR TITLE
Adjust bottom player position for 3-player dice duel

### DIFF
--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -676,8 +676,8 @@ export default function CrazyDiceDuel() {
         className="player-bottom z-10"
         style={{
           bottom: 'auto',
-          /* Place the bottom player slightly lower */
-          ...gridPoint(10, 26.5),
+          /* Raise the bottom player slightly when facing two opponents */
+          ...gridPoint(10, playerCount === 3 ? 25.5 : 26.5),
           transform: 'translate(-50%, -50%)',
         }}
       >


### PR DESCRIPTION
## Summary
- bump up the bottom player's avatar and messages when facing two opponents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878be0b05688329a612c10e2d4ceb7c