### PR TITLE
Fix bottom layout in 4-player Crazy Dice Duel

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1594,12 +1594,12 @@ input:focus {
   bottom: 9%;
 }
 .crazy-dice-board.four-players .player-bottom .roll-history {
-  /* Place roll boxes a little further down */
-  top: calc(100% + 2rem);
+  /* Place roll boxes a little further up */
+  top: calc(100% + 1.8rem);
 }
 .crazy-dice-board.four-players .player-bottom .player-score {
   /* Score should appear below the roll boxes */
-  top: calc(100% + 3.4rem);
+  top: calc(100% + 3.2rem);
 }
 .crazy-dice-board.four-players .player-left .player-score,
 .crazy-dice-board.four-players .player-center .player-score,

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -677,7 +677,14 @@ export default function CrazyDiceDuel() {
         style={{
           bottom: 'auto',
           /* Raise the bottom player slightly when facing two opponents */
-          ...gridPoint(10, playerCount === 3 ? 25.5 : 26.5),
+          ...gridPoint(
+            10,
+            playerCount === 3
+              ? 25.5
+              : playerCount === 4
+                ? 26
+                : 26.5,
+          ),
           transform: 'translate(-50%, -50%)',
         }}
       >


### PR DESCRIPTION
## Summary
- tweak bottom player's avatar position when facing 3 opponents
- raise roll history and score boxes for the bottom player in 4-player mode

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND, test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6878c4192c188329b6c09270de6e1139