### PR TITLE
Adjust pot coin alignment

### DIFF
--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -264,7 +264,7 @@ export default function SnakeBoard({
           >
             {tiles}
             <div className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? 'highlight' : ''}`}>
-              <PlayerToken color="#16a34a" topColor="#ff0000" className="pot-token" spin={false} />
+              <PlayerToken color="#16a34a" topColor="#ff0000" className="pot-token" />
               <div className="pot-icon">
                 <img
                   src={

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -355,7 +355,13 @@ input:focus {
   top: 50%;
   left: 50%;
   transform-style: preserve-3d;
-  transform: translate(-50%, -100%) translateZ(40px);
+  /*
+    Position the coin so its bottom sits flush with the top of the
+    pot token. The pot token is 14.8rem tall and shifted upward
+    by 8rem. Move the coin up by the same amount so it aligns
+    perfectly with the token's upper surface.
+  */
+  transform: translate(-50%, calc(-100% - 15.4rem)) translateZ(40px);
   animation: coin-spin 3s linear infinite;
   pointer-events: none;
   z-index: 6;
@@ -378,10 +384,10 @@ input:focus {
 
 @keyframes coin-spin {
   from {
-    transform: translate(-50%, -100%) translateZ(40px) rotateY(0deg);
+    transform: translate(-50%, calc(-100% - 15.4rem)) translateZ(40px) rotateY(0deg);
   }
   to {
-    transform: translate(-50%, -100%) translateZ(40px) rotateY(360deg);
+    transform: translate(-50%, calc(-100% - 15.4rem)) translateZ(40px) rotateY(360deg);
   }
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -464,7 +464,6 @@ function Board({
                 color="#16a34a"
                 topColor="#ff0000"
                 className="pot-token"
-                spin={false}
               />
               <div className="pot-icon">
                 <img


### PR DESCRIPTION
## Summary
- adjust pot coin transform so it sits on top of the pot token
- remove `spin={false}` so the pot token rotates

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_6878c62ce6ac8329a43b79603985b093