### PR TITLE
Add new TikTok engagement tasks

### DIFF
--- a/bot/utils/tasksData.js
+++ b/bot/utils/tasksData.js
@@ -1,4 +1,4 @@
-export const TASKS_VERSION = 3;
+export const TASKS_VERSION = 4;
 
 export const TASKS = [
 
@@ -49,6 +49,22 @@ export const TASKS = [
     reward: 2000,
     icon: 'tiktok',
     link: 'https://vt.tiktok.com/ZSBXkX8pu/'
+  },
+
+  {
+    id: 'engage_tiktok_1',
+    description: 'Like, comment & share our TikTok',
+    reward: 2000,
+    icon: 'tiktok',
+    link: 'https://vt.tiktok.com/ZSBnaAGTQ/'
+  },
+
+  {
+    id: 'engage_tiktok_2',
+    description: 'Like, comment & share our TikTok',
+    reward: 2000,
+    icon: 'tiktok',
+    link: 'https://vt.tiktok.com/ZSBnagc3g/'
   },
 
   {

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -40,7 +40,9 @@ const ICONS = {
   join_telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
   
   follow_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-  boost_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />, 
+  boost_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
+  engage_tiktok_1: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
+  engage_tiktok_2: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
   post_tweet: xIcon,
   react_tg_post: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
   engage_tweet: xIcon,

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -206,6 +206,8 @@ export default function Tasks() {
     join_telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
     follow_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
     boost_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
+    engage_tiktok_1: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
+    engage_tiktok_2: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
     post_tweet: xIcon,
     react_tg_post: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
     engage_tweet: xIcon,


### PR DESCRIPTION
## Summary
- expand task list with two new TikTok engagement tasks
- update icons for new TikTok tasks
- bump task version to 4

## Testing
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6879032b87188329b61f99f601feb5bd