### PR TITLE
Fix AI world leader selection for high-stakes matches

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1092,10 +1092,22 @@ export default function SnakeAndLadder() {
     setAiPositions(Array(aiCount).fill(0));
     setPlayerDiceCounts(Array(aiCount + 1).fill(2));
     if (avatarParam === 'leaders') {
-      const unique = [...LEADER_AVATARS]
-        .sort(() => Math.random() - 0.5)
-        .slice(0, aiCount);
-      setAiAvatars(unique);
+      const isHighStake =
+        aiCount === 3 &&
+        String(t).toUpperCase() === 'TPC' &&
+        Number(amt) === 10000;
+      if (isHighStake) {
+        setAiAvatars([
+          '/assets/icons/UsaLeader.webp',
+          '/assets/icons/RussiaLeader.webp',
+          '/assets/icons/ChinaLeader.webp',
+        ]);
+      } else {
+        const unique = [...LEADER_AVATARS]
+          .sort(() => Math.random() - 0.5)
+          .slice(0, aiCount);
+        setAiAvatars(unique);
+      }
     } else {
       setAiAvatars(
         Array.from({ length: aiCount }, () =>


### PR DESCRIPTION
## Summary
- force specific world leaders in Snake and Ladder single-player mode when playing vs 3 AI opponents and staking 10000 TPC

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68792865d3f083299e909d9c6a53998e