### PR TITLE
Add extra TikTok tasks

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -12,6 +12,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "geoip-lite": "^1.4.10",
     "https-proxy-agent": "^7.0.2",
     "mongodb-memory-server": "^10.1.4",
     "mongoose": "^7.6.0",

--- a/bot/utils/tasksData.js
+++ b/bot/utils/tasksData.js
@@ -1,4 +1,4 @@
-export const TASKS_VERSION = 4;
+export const TASKS_VERSION = 5;
 
 export const TASKS = [
 
@@ -65,6 +65,42 @@ export const TASKS = [
     reward: 2000,
     icon: 'tiktok',
     link: 'https://vt.tiktok.com/ZSBnagc3g/'
+  },
+
+  {
+    id: 'boost_tiktok_3',
+    description: 'Like, comment & repost on TikTok',
+    reward: 2000,
+    icon: 'tiktok',
+    link: 'https://vt.tiktok.com/ZSBngGPdy/',
+    hideOnHome: true
+  },
+
+  {
+    id: 'boost_tiktok_4',
+    description: 'Like, comment & repost on TikTok',
+    reward: 2000,
+    icon: 'tiktok',
+    link: 'https://vt.tiktok.com/ZSBngp3GD/',
+    hideOnHome: true
+  },
+
+  {
+    id: 'boost_tiktok_5',
+    description: 'Like, comment & repost on TikTok',
+    reward: 2000,
+    icon: 'tiktok',
+    link: 'https://vt.tiktok.com/ZSBngWDnQ/',
+    hideOnHome: true
+  },
+
+  {
+    id: 'boost_tiktok_6',
+    description: 'Like, comment & repost on TikTok',
+    reward: 2000,
+    icon: 'tiktok',
+    link: 'https://vt.tiktok.com/ZSBnpkW5v/',
+    hideOnHome: true
   },
 
   {

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -87,7 +87,7 @@ export default function TasksCard() {
 
   const load = async () => {
     const data = await listTasks(telegramId);
-    const tasksList = data.tasks || data;
+    const tasksList = (data.tasks || data).filter((t) => !t.hideOnHome);
     setTasks(tasksList);
     if (data.version) {
       const seen = localStorage.getItem('tasksVersion');


### PR DESCRIPTION
## Summary
- add four new TikTok tasks in `tasksData.js`
- filter tasks hidden from the home page
- install `geoip-lite` for tests

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_6879385f40cc8329a2ffc17403e314a7