### PR TITLE
Add world leader opponent selector

### DIFF
--- a/webapp/src/components/LeaderPickerModal.jsx
+++ b/webapp/src/components/LeaderPickerModal.jsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from 'react';
+import { LEADER_AVATARS } from '../utils/leaderAvatars.js';
+import { getAvatarUrl } from '../utils/avatarUtils.js';
+
+export default function LeaderPickerModal({ open, onClose, count = 1, onSave, selected = [] }) {
+  const [chosen, setChosen] = useState(selected);
+
+  useEffect(() => {
+    setChosen(selected);
+  }, [selected, open]);
+
+  if (!open) return null;
+
+  const toggle = (src) => {
+    setChosen((prev) => {
+      if (prev.includes(src)) return prev.filter((s) => s !== src);
+      if (prev.length >= count) return prev;
+      return [...prev, src];
+    });
+  };
+
+  const confirm = () => {
+    onSave(chosen.slice(0, count));
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
+      <div className="bg-surface border border-border p-4 rounded space-y-4 text-center text-text w-96 max-h-[90vh] overflow-y-auto">
+        <h3 className="text-lg font-bold">Select your opponents</h3>
+        <div className="flex flex-wrap justify-center gap-2">
+          {LEADER_AVATARS.map((src) => (
+            <div
+              key={src}
+              className={`w-20 h-20 rounded-full flex items-center justify-center cursor-pointer hover:opacity-80 ${chosen.includes(src) ? 'ring-4 ring-accent' : ''}`}
+              onClick={() => toggle(src)}
+            >
+              <img src={getAvatarUrl(src)} alt="leader" className="w-full h-full rounded-full object-cover" />
+            </div>
+          ))}
+        </div>
+        <button
+          onClick={confirm}
+          disabled={chosen.length !== count}
+          className="w-full px-4 py-1 bg-primary hover:bg-primary-hover rounded disabled:opacity-50"
+        >
+          Confirm
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -73,6 +73,10 @@ export default function CrazyDiceDuel() {
   const [searchParams] = useSearchParams();
   const aiCount = parseInt(searchParams.get('ai')) || 0;
   const avatarType = searchParams.get('avatars') || 'flags';
+  const selectedLeadersParam = searchParams.get('leaders');
+  const selectedLeaders = selectedLeadersParam
+    ? selectedLeadersParam.split(',').map((n) => LEADER_AVATARS[parseInt(n)]).filter(Boolean)
+    : null;
   const playerCount = aiCount > 0
     ? aiCount + 1
     : parseInt(searchParams.get('players')) || 2;
@@ -99,7 +103,14 @@ export default function CrazyDiceDuel() {
     let uniqueLeaders = [...LEADER_AVATARS];
     let uniquePhotos = [...LEADER_PHOTO_AVATARS];
 
-    if (
+    if (selectedLeaders && selectedLeaders.length) {
+      uniqueLeaders = selectedLeaders.slice(0, playerCount - 1);
+      while (uniqueLeaders.length < playerCount - 1) {
+        const rand = LEADER_AVATARS[Math.floor(Math.random() * LEADER_AVATARS.length)];
+        if (!uniqueLeaders.includes(rand)) uniqueLeaders.push(rand);
+      }
+      uniquePhotos = uniqueLeaders.map((p) => p.replace('.webp', '.jpg'));
+    } else if (
       playerCount === 4 &&
       aiCount === 3 &&
       avatarType === 'leaders' &&
@@ -136,7 +147,7 @@ export default function CrazyDiceDuel() {
               : `/assets/avatars/avatar${(i % 5) + 1}.svg`,
       color: COLORS[i % COLORS.length],
     }));
-  }, [playerCount, aiCount, avatarType]);
+  }, [playerCount, aiCount, avatarType, selectedLeadersParam]);
 
   const [players, setPlayers] = useState(initialPlayers);
   const [current, setCurrent] = useState(0);


### PR DESCRIPTION
## Summary
- create `LeaderPickerModal` for choosing AI opponents
- allow selecting world leader opponents in Crazy Dice lobby
- read selected leaders in Crazy Dice duel to set AI avatars

## Testing
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6879e04940188329b150018a1cf627ff