### PR TITLE
Add random opponent buttons

### DIFF
--- a/webapp/src/components/FlagPickerModal.jsx
+++ b/webapp/src/components/FlagPickerModal.jsx
@@ -27,6 +27,18 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
     onClose();
   };
 
+  const randomize = () => {
+    const allFlags = Object.values(FLAG_CATEGORIES).flat();
+    const random = [];
+    while (random.length < count) {
+      const flag = allFlags[Math.floor(Math.random() * allFlags.length)];
+      if (!random.includes(flag)) random.push(flag);
+    }
+    const indices = random.map(f => FLAG_EMOJIS.indexOf(f)).filter(i => i >= 0);
+    onSave(indices.slice(0, count));
+    onClose();
+  };
+
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-4 rounded space-y-4 text-center text-text w-96 max-h-[90vh] overflow-y-auto">
@@ -53,13 +65,21 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
             </div>
           ))}
         </div>
-        <button
-          onClick={confirm}
-          disabled={chosen.length !== count}
-          className="w-full px-4 py-1 bg-primary hover:bg-primary-hover rounded disabled:opacity-50"
-        >
-          Confirm
-        </button>
+        <div className="flex space-x-2">
+          <button
+            onClick={confirm}
+            disabled={chosen.length !== count}
+            className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover rounded disabled:opacity-50"
+          >
+            Confirm
+          </button>
+          <button
+            onClick={randomize}
+            className="flex-1 px-4 py-1 border border-border bg-surface rounded"
+          >
+            Random
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/webapp/src/components/LeaderPickerModal.jsx
+++ b/webapp/src/components/LeaderPickerModal.jsx
@@ -24,6 +24,16 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
     onClose();
   };
 
+  const randomize = () => {
+    const random = [];
+    while (random.length < count) {
+      const leader = LEADER_AVATARS[Math.floor(Math.random() * LEADER_AVATARS.length)];
+      if (!random.includes(leader)) random.push(leader);
+    }
+    onSave(random.slice(0, count));
+    onClose();
+  };
+
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-4 rounded space-y-4 text-center text-text w-96 max-h-[90vh] overflow-y-auto">
@@ -39,13 +49,21 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
             </div>
           ))}
         </div>
-        <button
-          onClick={confirm}
-          disabled={chosen.length !== count}
-          className="w-full px-4 py-1 bg-primary hover:bg-primary-hover rounded disabled:opacity-50"
-        >
-          Confirm
-        </button>
+        <div className="flex space-x-2">
+          <button
+            onClick={confirm}
+            disabled={chosen.length !== count}
+            className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover rounded disabled:opacity-50"
+          >
+            Confirm
+          </button>
+          <button
+            onClick={randomize}
+            className="flex-1 px-4 py-1 border border-border bg-surface rounded"
+          >
+            Random
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add random selection logic to flag and leader modals
- show Random button alongside Confirm in both pickers

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND for express)*

------
https://chatgpt.com/codex/tasks/task_e_6879f08d3d548329bb166c7445705da7