### PR TITLE
Add Quick Play option for leader and flag selection

### DIFF
--- a/webapp/src/components/FlagPickerModal.jsx
+++ b/webapp/src/components/FlagPickerModal.jsx
@@ -77,7 +77,7 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
             onClick={randomize}
             className="flex-1 px-4 py-1 border border-border bg-surface rounded"
           >
-            Random
+            Quick Play
           </button>
         </div>
       </div>

--- a/webapp/src/components/LeaderPickerModal.jsx
+++ b/webapp/src/components/LeaderPickerModal.jsx
@@ -61,7 +61,7 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
             onClick={randomize}
             className="flex-1 px-4 py-1 border border-border bg-surface rounded"
           >
-            Random
+            Quick Play
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update flag and leader picker modals
- rename `Random` button to `Quick Play`

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_6879f4a301fc83298681845578a06fa5