### PR TITLE
Fix buttons in leader/flag pickers

### DIFF
--- a/webapp/src/components/FlagPickerModal.jsx
+++ b/webapp/src/components/FlagPickerModal.jsx
@@ -41,31 +41,33 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="bg-surface border border-border p-4 rounded space-y-4 text-center text-text w-96 max-h-[90vh] overflow-y-auto">
+      <div className="bg-surface border border-border p-4 rounded text-center text-text w-96 max-h-[90vh] flex flex-col space-y-4">
         <h3 className="text-lg font-bold">Select your opponents</h3>
-        <div className="flex flex-wrap justify-center gap-2">
-          {continents.map(c => (
-            <button
-              key={c}
-              onClick={() => setCategory(c)}
-              className={`lobby-tile ${category === c ? 'lobby-selected' : ''}`}
-            >
-              {c}
-            </button>
-          ))}
+        <div className="flex-1 overflow-y-auto space-y-2">
+          <div className="flex flex-wrap justify-center gap-2">
+            {continents.map(c => (
+              <button
+                key={c}
+                onClick={() => setCategory(c)}
+                className={`lobby-tile ${category === c ? 'lobby-selected' : ''}`}
+              >
+                {c}
+              </button>
+            ))}
+          </div>
+          <div className="flex flex-wrap justify-center gap-2 mt-2">
+            {FLAG_CATEGORIES[category].map(flag => (
+              <div
+                key={flag}
+                className={`w-12 h-12 flex items-center justify-center text-2xl cursor-pointer hover:opacity-80 ${chosen.includes(flag) ? 'ring-4 ring-accent' : ''}`}
+                onClick={() => toggle(flag)}
+              >
+                {flag}
+              </div>
+            ))}
+          </div>
         </div>
-        <div className="flex flex-wrap justify-center gap-2 mt-2">
-          {FLAG_CATEGORIES[category].map(flag => (
-            <div
-              key={flag}
-              className={`w-12 h-12 flex items-center justify-center text-2xl cursor-pointer hover:opacity-80 ${chosen.includes(flag) ? 'ring-4 ring-accent' : ''}`}
-              onClick={() => toggle(flag)}
-            >
-              {flag}
-            </div>
-          ))}
-        </div>
-        <div className="flex space-x-2">
+        <div className="flex space-x-2 pt-2">
           <button
             onClick={confirm}
             disabled={chosen.length !== count}

--- a/webapp/src/components/LeaderPickerModal.jsx
+++ b/webapp/src/components/LeaderPickerModal.jsx
@@ -36,9 +36,9 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="bg-surface border border-border p-4 rounded space-y-4 text-center text-text w-96 max-h-[90vh] overflow-y-auto">
+      <div className="bg-surface border border-border p-4 rounded text-center text-text w-96 max-h-[90vh] flex flex-col space-y-4">
         <h3 className="text-lg font-bold">Select your opponents</h3>
-        <div className="flex flex-wrap justify-center gap-2">
+        <div className="flex-1 overflow-y-auto flex flex-wrap justify-center gap-2">
           {LEADER_AVATARS.map((src) => (
             <div
               key={src}
@@ -49,7 +49,7 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
             </div>
           ))}
         </div>
-        <div className="flex space-x-2">
+        <div className="flex space-x-2 pt-2">
           <button
             onClick={confirm}
             disabled={chosen.length !== count}


### PR DESCRIPTION
## Summary
- keep `Confirm` and `Quick Play` buttons visible on flag and leader pickers
- make the lists scroll when there are too many items

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879f94ecce8832996a724ba999fc86f