### PR TITLE
Fix leader/flag popup buttons

### DIFF
--- a/webapp/src/components/FlagPickerModal.jsx
+++ b/webapp/src/components/FlagPickerModal.jsx
@@ -43,7 +43,7 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-4 rounded text-center text-text w-96 max-h-[90vh] flex flex-col space-y-4">
         <h3 className="text-lg font-bold">Select your opponents</h3>
-        <div className="flex-1 overflow-y-auto space-y-2">
+        <div className="flex-1 min-h-0 overflow-y-auto space-y-2">
           <div className="flex flex-wrap justify-center gap-2">
             {continents.map(c => (
               <button
@@ -71,7 +71,7 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
           <button
             onClick={confirm}
             disabled={chosen.length !== count}
-            className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover rounded disabled:opacity-50"
+            className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover text-background rounded disabled:opacity-50"
           >
             Confirm
           </button>

--- a/webapp/src/components/LeaderPickerModal.jsx
+++ b/webapp/src/components/LeaderPickerModal.jsx
@@ -38,7 +38,7 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-4 rounded text-center text-text w-96 max-h-[90vh] flex flex-col space-y-4">
         <h3 className="text-lg font-bold">Select your opponents</h3>
-        <div className="flex-1 overflow-y-auto flex flex-wrap justify-center gap-2">
+        <div className="flex-1 min-h-0 overflow-y-auto flex flex-wrap justify-center gap-2">
           {LEADER_AVATARS.map((src) => (
             <div
               key={src}
@@ -53,7 +53,7 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
           <button
             onClick={confirm}
             disabled={chosen.length !== count}
-            className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover rounded disabled:opacity-50"
+            className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover text-background rounded disabled:opacity-50"
           >
             Confirm
           </button>


### PR DESCRIPTION
## Summary
- ensure flag and leader selectors keep buttons visible
- style confirm buttons so text shows against background

## Testing
- `npm test` *(fails: tests hang but partial output shows run)*

------
https://chatgpt.com/codex/tasks/task_e_6879fe18d1b08329a2c290c7eda2e1d3