### PR TITLE
Fix button layout in leader and flag pickers

### DIFF
--- a/webapp/src/components/FlagPickerModal.jsx
+++ b/webapp/src/components/FlagPickerModal.jsx
@@ -41,7 +41,7 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="bg-surface border border-border p-4 rounded text-center text-text w-96 max-h-[90vh] flex flex-col space-y-4">
+      <div className="bg-surface border border-border p-4 rounded text-center text-text w-96 max-h-[90vh] flex flex-col space-y-4 overflow-hidden">
         <h3 className="text-lg font-bold">Select your opponents</h3>
         <div className="flex-1 min-h-0 overflow-y-auto space-y-2">
           <div className="flex flex-wrap justify-center gap-2">
@@ -67,7 +67,7 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
             ))}
           </div>
         </div>
-        <div className="flex space-x-2 pt-2">
+        <div className="flex space-x-2 pt-2 mt-auto">
           <button
             onClick={confirm}
             disabled={chosen.length !== count}

--- a/webapp/src/components/LeaderPickerModal.jsx
+++ b/webapp/src/components/LeaderPickerModal.jsx
@@ -36,7 +36,7 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="bg-surface border border-border p-4 rounded text-center text-text w-96 max-h-[90vh] flex flex-col space-y-4">
+      <div className="bg-surface border border-border p-4 rounded text-center text-text w-96 max-h-[90vh] flex flex-col space-y-4 overflow-hidden">
         <h3 className="text-lg font-bold">Select your opponents</h3>
         <div className="flex-1 min-h-0 overflow-y-auto flex flex-wrap justify-center gap-2">
           {LEADER_AVATARS.map((src) => (
@@ -49,7 +49,7 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
             </div>
           ))}
         </div>
-        <div className="flex space-x-2 pt-2">
+        <div className="flex space-x-2 pt-2 mt-auto">
           <button
             onClick={confirm}
             disabled={chosen.length !== count}


### PR DESCRIPTION
## Summary
- ensure confirm and quick play buttons always display at the bottom of leader and flag selection popups

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a038714a483298ee9899ca7b111c2