### PR TITLE
Enable auto-start after selecting AI avatars

### DIFF
--- a/webapp/src/components/FlagPickerModal.jsx
+++ b/webapp/src/components/FlagPickerModal.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { FLAG_EMOJIS } from '../utils/flagEmojis.js';
 import { FLAG_CATEGORIES } from '../utils/flagCategories.js';
 
-export default function FlagPickerModal({ open, onClose, count = 1, onSave, selected = [] }) {
+export default function FlagPickerModal({ open, onClose, count = 1, onSave, selected = [], onComplete }) {
   const continents = Object.keys(FLAG_CATEGORIES);
   const [category, setCategory] = useState(continents[0]);
   const [chosen, setChosen] = useState([]);
@@ -13,18 +13,30 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
 
   if (!open) return null;
 
+  const handleComplete = (selection) => {
+    const indices = selection
+      .map((f) => FLAG_EMOJIS.indexOf(f))
+      .filter((i) => i >= 0);
+    onSave(indices.slice(0, count));
+    onClose();
+    if (onComplete) onComplete(indices.slice(0, count));
+  };
+
   const toggle = (flag) => {
-    setChosen(prev => {
-      if (prev.includes(flag)) return prev.filter(f => f !== flag);
-      if (prev.length >= count) return prev;
-      return [...prev, flag];
+    setChosen((prev) => {
+      let next = prev;
+      if (prev.includes(flag)) {
+        next = prev.filter((f) => f !== flag);
+      } else if (prev.length < count) {
+        next = [...prev, flag];
+        if (next.length === count) handleComplete(next);
+      }
+      return next;
     });
   };
 
   const confirm = () => {
-    const indices = chosen.map(f => FLAG_EMOJIS.indexOf(f)).filter(i => i >= 0);
-    onSave(indices.slice(0, count));
-    onClose();
+    handleComplete(chosen);
   };
 
   const randomize = () => {
@@ -34,9 +46,7 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
       const flag = allFlags[Math.floor(Math.random() * allFlags.length)];
       if (!random.includes(flag)) random.push(flag);
     }
-    const indices = random.map(f => FLAG_EMOJIS.indexOf(f)).filter(i => i >= 0);
-    onSave(indices.slice(0, count));
-    onClose();
+    handleComplete(random);
   };
 
   return (

--- a/webapp/src/components/LeaderPickerModal.jsx
+++ b/webapp/src/components/LeaderPickerModal.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { LEADER_AVATARS } from '../utils/leaderAvatars.js';
 import { getAvatarUrl } from '../utils/avatarUtils.js';
 
-export default function LeaderPickerModal({ open, onClose, count = 1, onSave, selected = [] }) {
+export default function LeaderPickerModal({ open, onClose, count = 1, onSave, selected = [], onComplete }) {
   const [chosen, setChosen] = useState(selected);
 
   useEffect(() => {
@@ -11,17 +11,27 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
 
   if (!open) return null;
 
+  const handleComplete = (selection) => {
+    onSave(selection.slice(0, count));
+    onClose();
+    if (onComplete) onComplete(selection.slice(0, count));
+  };
+
   const toggle = (src) => {
     setChosen((prev) => {
-      if (prev.includes(src)) return prev.filter((s) => s !== src);
-      if (prev.length >= count) return prev;
-      return [...prev, src];
+      let next = prev;
+      if (prev.includes(src)) {
+        next = prev.filter((s) => s !== src);
+      } else if (prev.length < count) {
+        next = [...prev, src];
+        if (next.length === count) handleComplete(next);
+      }
+      return next;
     });
   };
 
   const confirm = () => {
-    onSave(chosen.slice(0, count));
-    onClose();
+    handleComplete(chosen);
   };
 
   const randomize = () => {
@@ -30,8 +40,7 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
       const leader = LEADER_AVATARS[Math.floor(Math.random() * LEADER_AVATARS.length)];
       if (!random.includes(leader)) random.push(leader);
     }
-    onSave(random.slice(0, count));
-    onClose();
+    handleComplete(random);
   };
 
   return (

--- a/webapp/src/pages/Games/CrazyDiceLobby.jsx
+++ b/webapp/src/pages/Games/CrazyDiceLobby.jsx
@@ -59,17 +59,19 @@ export default function CrazyDiceLobby() {
     }
   };
 
-  const startGame = () => {
+  const startGame = (flagOverride = flags, leaderOverride = leaders) => {
     const params = new URLSearchParams();
     if (table.id === 'single') {
       params.set('ai', aiCount);
       params.set('players', aiCount + 1);
       params.set('avatars', aiType);
-      if (aiType === 'leaders' && leaders.length) {
-        const ids = leaders.map((l) => LEADER_AVATARS.indexOf(l)).filter((i) => i >= 0);
+      if (aiType === 'leaders' && leaderOverride.length) {
+        const ids = leaderOverride
+          .map((l) => LEADER_AVATARS.indexOf(l))
+          .filter((i) => i >= 0);
         if (ids.length) params.set('leaders', ids.join(','));
-      } else if (aiType === 'flags' && flags.length) {
-        params.set('flags', flags.join(','));
+      } else if (aiType === 'flags' && flagOverride.length) {
+        params.set('flags', flagOverride.join(','));
       }
     } else {
       params.set('players', table.capacity);
@@ -159,6 +161,7 @@ export default function CrazyDiceLobby() {
         selected={leaders}
         onSave={setLeaders}
         onClose={() => setShowLeaderPicker(false)}
+        onComplete={(sel) => startGame(flags, sel)}
       />
       <FlagPickerModal
         open={showFlagPicker}
@@ -166,6 +169,7 @@ export default function CrazyDiceLobby() {
         selected={flags}
         onSave={setFlags}
         onClose={() => setShowFlagPicker(false)}
+        onComplete={(sel) => startGame(sel, leaders)}
       />
     </div>
   );

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -178,7 +178,7 @@ export default function Lobby() {
   }, [players, game, table]);
 
 
-  const startGame = async () => {
+  const startGame = async (flagOverride = flags, leaderOverride = leaders) => {
     const params = new URLSearchParams();
     if (table) params.set('table', table.id);
     if (game === 'snake' && stake.token === 'TON' && stake.amount > 0) {
@@ -208,11 +208,13 @@ export default function Lobby() {
       params.set('ai', aiCount);
       params.set('avatars', aiType);
       params.set('token', 'TPC');
-      if (aiType === 'leaders' && leaders.length) {
-        const ids = leaders.map((l) => LEADER_AVATARS.indexOf(l)).filter((i) => i >= 0);
+      if (aiType === 'leaders' && leaderOverride.length) {
+        const ids = leaderOverride
+          .map((l) => LEADER_AVATARS.indexOf(l))
+          .filter((i) => i >= 0);
         if (ids.length) params.set('leaders', ids.join(','));
-      } else if (aiType === 'flags' && flags.length) {
-        params.set('flags', flags.join(','));
+      } else if (aiType === 'flags' && flagOverride.length) {
+        params.set('flags', flagOverride.join(','));
       }
       if (stake.amount) params.set('amount', stake.amount);
       try {
@@ -338,6 +340,7 @@ export default function Lobby() {
         selected={leaders}
         onSave={setLeaders}
         onClose={() => setShowLeaderPicker(false)}
+        onComplete={(sel) => startGame(flags, sel)}
       />
       <FlagPickerModal
         open={showFlagPicker}
@@ -345,6 +348,7 @@ export default function Lobby() {
         selected={flags}
         onSave={setFlags}
         onClose={() => setShowFlagPicker(false)}
+        onComplete={(sel) => startGame(sel, leaders)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- start the game automatically after the last AI avatar is selected
- support `onComplete` callbacks in leader/flag pickers
- auto-start for both Snake and Crazy Dice lobbies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a259d923c8329949932f17051b829