### PR TITLE
Refine snake game helper text

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1642,7 +1642,7 @@ export default function SnakeAndLadder() {
           });
           setMessage("Six rolled! One die removed.");
         } else {
-          setMessage("Need a 6 to remove a die.");
+          setMessage("Need a six to drop a die.");
           setShowRemoveDiceHelp(true);
         }
         setTurnMessage("Your turn");
@@ -1671,7 +1671,7 @@ export default function SnakeAndLadder() {
           if (!muted) cheerSoundRef.current?.play().catch(() => {});
         }
         else {
-          setMessage("Need a 6 to start!");
+          setMessage("Need a six to enter the game.");
           setShowStartHelp(true);
           setTurnMessage("");
           setDiceVisible(false);
@@ -1687,7 +1687,7 @@ export default function SnakeAndLadder() {
       } else if (current + value <= FINAL_TILE) {
         target = current + value;
       } else {
-        setMessage("Need exact roll!");
+        setMessage("Need the exact roll.");
         setShowExactHelp(true);
         setTurnMessage("");
         setDiceVisible(false);
@@ -2509,28 +2509,31 @@ export default function SnakeAndLadder() {
         open={showInfo}
         onClose={() => setShowInfo(false)}
         title="Snake & Ladder"
-        info="Roll two dice each turn. You need a six to leave the start. Move forward by their sum. Ladders lift you up and snakes bring you down. You must land exactly on the pot tile to win. From tile 100 roll a six to drop one die, then a one to reach the pot."
+        info="Roll two dice each turn. Need a six to enter the board. Move by their sum. Ladders lift you up and snakes pull you down. Land exactly on the pot to win. From tile 100 roll a six to drop a die, then a one to win."
       />
       )}
       {!watchOnly && (
       <HintPopup
         open={showStartHelp}
         onClose={() => setShowStartHelp(false)}
-        message="Roll at least one six to enter the board."
+        message="Need a six to enter the game."
+        duration={1500}
       />
       )}
       {!watchOnly && (
       <HintPopup
         open={showExactHelp}
         onClose={() => setShowExactHelp(false)}
-        message="You must roll the exact number to land on the pot."
+        message="Need the exact roll to reach the pot."
+        duration={1500}
       />
       )}
       {!watchOnly && (
       <HintPopup
         open={showRemoveDiceHelp}
         onClose={() => setShowRemoveDiceHelp(false)}
-        message="On tile 100 you need a six to drop one die before you can win."
+        message="On tile 100 roll a six to drop a die before you can win."
+        duration={1500}
       />
       )}
       {!watchOnly && (


### PR DESCRIPTION
## Summary
- shorten instructions shown in Snake & Ladder
- tweak hint messages and show them briefly

## Testing
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'geoip-lite', ...)*

------
https://chatgpt.com/codex/tasks/task_e_687a2d25c6e483299a7c636ec3e099c6