### PR TITLE
Fix leader avatars and adjust hints

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1032,7 +1032,7 @@ input:focus {
     var(--cell-height) * -8.7 - var(--cell-height) * 1.7 *
       (var(--final-scale, 1) - 1)
   );
-  left: 48%;
+  left: 47%;
   transform: translateX(-50%) rotateX(calc(var(--board-angle, 58deg) * -1))
     translateZ(-90px) scale(2.31); /* 5% larger */
   transform-origin: bottom center;


### PR DESCRIPTION
## Summary
- match selected leaders during game setup
- remove roll-six hints and tweak info popups
- shift snake leaderboard avatars slightly to the right
- nudge board logo left a bit

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_687a3d9b9b8083298c959c009af4eeb0