### PR TITLE
Add new telegram task

### DIFF
--- a/bot/utils/tasksData.js
+++ b/bot/utils/tasksData.js
@@ -1,4 +1,4 @@
-export const TASKS_VERSION = 5;
+export const TASKS_VERSION = 6;
 
 export const TASKS = [
 
@@ -109,6 +109,14 @@ export const TASKS = [
     reward: 2500,
     icon: 'telegram',
     link: 'https://t.me/TonPlaygram/1/16'
+  },
+
+  {
+    id: 'react_tg_post_2',
+    description: 'React to our group post',
+    reward: 2500,
+    icon: 'telegram',
+    link: 'https://t.me/TonPlaygram/19'
   },
 
   {

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -13,7 +13,7 @@ import {
 import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 import { STORE_ADDRESS } from '../utils/storeData.js';
 
-import { getTelegramId } from '../utils/telegram.js';
+import { getTelegramId, parseTelegramPostLink } from '../utils/telegram.js';
 import LoginOptions from './LoginOptions.jsx';
 
 import { IoLogoTiktok } from 'react-icons/io5';
@@ -49,6 +49,7 @@ const ICONS = {
   boost_tiktok_6: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
   post_tweet: xIcon,
   react_tg_post: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
+  react_tg_post_2: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
   engage_tweet: xIcon,
   watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />
 
@@ -132,8 +133,9 @@ export default function TasksCard() {
 
     window.open(task.link, '_blank');
 
-    if (task.id === 'react_tg_post') {
-      const res = await verifyTelegramReaction(telegramId);
+    if (task.id.startsWith('react_tg_post')) {
+      const { messageId, threadId } = parseTelegramPostLink(task.link || '');
+      const res = await verifyTelegramReaction(telegramId, messageId, threadId);
       if (res.error || !res.reacted) {
         alert(res.error || 'Reaction not verified');
         return;

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -13,7 +13,7 @@ import {
   myInfluencerVideos,
 } from '../utils/api.js';
 
-import { getTelegramId } from '../utils/telegram.js';
+import { getTelegramId, parseTelegramPostLink } from '../utils/telegram.js';
 import LoginOptions from '../components/LoginOptions.jsx';
 
 import { IoLogoTiktok } from 'react-icons/io5';
@@ -121,8 +121,9 @@ export default function Tasks() {
     if (task.link) {
       window.open(task.link, '_blank');
     }
-    if (task.id === 'react_tg_post') {
-      const res = await verifyTelegramReaction(telegramId);
+    if (task.id.startsWith('react_tg_post')) {
+      const { messageId, threadId } = parseTelegramPostLink(task.link || '');
+      const res = await verifyTelegramReaction(telegramId, messageId, threadId);
       if (res.error || !res.reacted) {
         alert(res.error || 'Reaction not verified');
         return;
@@ -214,6 +215,7 @@ export default function Tasks() {
     boost_tiktok_6: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
     post_tweet: xIcon,
     react_tg_post: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
+    react_tg_post_2: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
     engage_tweet: xIcon,
     watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />
   };

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -87,8 +87,8 @@ export function verifyPost(telegramId, tweetUrl) {
   return post('/api/tasks/verify-post', { telegramId, tweetUrl });
 }
 
-export function verifyTelegramReaction(telegramId) {
-  return post('/api/tasks/verify-telegram-reaction', { telegramId });
+export function verifyTelegramReaction(telegramId, messageId, threadId) {
+  return post('/api/tasks/verify-telegram-reaction', { telegramId, messageId, threadId });
 }
 
 export function listVideos(telegramId) {

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -94,3 +94,11 @@ export function getTelegramPhotoUrl() {
   }
   return '';
 }
+
+export function parseTelegramPostLink(link) {
+  const m = link.match(/TonPlaygram\/(?:([0-9]+)\/)?([0-9]+)/);
+  return {
+    threadId: m && m[1] ? Number(m[1]) : undefined,
+    messageId: m && m[2] ? Number(m[2]) : undefined,
+  };
+}


### PR DESCRIPTION
## Summary
- bump tasks version and add `react_tg_post_2`
- generalize telegram reaction verification
- expose `parseTelegramPostLink` for webapp
- update Tasks pages/components to handle new task

## Testing
- `npm test` *(fails: test timed out and missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_687a6f8723a8832986a7247acb081172