### PR TITLE
Add leader sound effects

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -781,9 +781,24 @@ export default function SnakeAndLadder() {
         } else if (avatar.includes('UkraineLeader') || avatar === '🇺🇦') {
           ukraineLeaderSoundRef.current.currentTime = 0;
           ukraineLeaderSoundRef.current.play().catch(() => {});
+        } else if (avatar.includes('IsraelLeader') || avatar === '🇮🇱') {
+          israelLeaderSoundRef.current.currentTime = 0;
+          israelLeaderSoundRef.current.play().catch(() => {});
+        } else if (avatar.includes('EgyptLeader') || avatar === '🇪🇬') {
+          egyptLeaderSoundRef.current.currentTime = 0;
+          egyptLeaderSoundRef.current.play().catch(() => {});
+        } else if (avatar.includes('UnitedKingdomLeader') || avatar === '🇬🇧') {
+          englandLeaderSoundRef.current.currentTime = 0;
+          englandLeaderSoundRef.current.play().catch(() => {});
+        } else if (avatar.includes('SerbiaLeader') || avatar === '🇷🇸') {
+          serbiaLeaderSoundRef.current.currentTime = 0;
+          serbiaLeaderSoundRef.current.play().catch(() => {});
+        } else if (avatar.includes('FranceLeader') || avatar === '🇫🇷') {
+          franceLeaderSoundRef.current.currentTime = 0;
+          franceLeaderSoundRef.current.play().catch(() => {});
         }
       }
-      if (cell <= 4 && !muted) {
+      if (cell <= 4 && !muted && avatar !== '🇵🇸' && !avatar.includes('Palestine')) {
         setTimeout(() => {
           hahaSoundRef.current.currentTime = 0;
           hahaSoundRef.current.play().catch(() => {});
@@ -927,6 +942,11 @@ export default function SnakeAndLadder() {
   const turkeyLeaderSoundRef = useRef(null);
   const ukraineLeaderSoundRef = useRef(null);
   const northKoreaLeaderSoundRef = useRef(null);
+  const israelLeaderSoundRef = useRef(null);
+  const egyptLeaderSoundRef = useRef(null);
+  const englandLeaderSoundRef = useRef(null);
+  const serbiaLeaderSoundRef = useRef(null);
+  const franceLeaderSoundRef = useRef(null);
   const badLuckSoundRef = useRef(null);
   const cheerSoundRef = useRef(null);
   const timerSoundRef = useRef(null);
@@ -989,6 +1009,16 @@ export default function SnakeAndLadder() {
     ukraineLeaderSoundRef.current.volume = vol;
     northKoreaLeaderSoundRef.current = new Audio("/assets/sounds/Chinese_Gong_Meme_Sound_Effect.mp3");
     northKoreaLeaderSoundRef.current.volume = vol;
+    israelLeaderSoundRef.current = new Audio("/assets/sounds/IsraelLeader.mp3");
+    israelLeaderSoundRef.current.volume = vol;
+    egyptLeaderSoundRef.current = new Audio("/assets/sounds/Ancient_Egyptian_Music__The_Nile_River.mp3");
+    egyptLeaderSoundRef.current.volume = vol;
+    englandLeaderSoundRef.current = new Audio("/assets/sounds/EnglandLeader.mp3");
+    englandLeaderSoundRef.current.volume = vol;
+    serbiaLeaderSoundRef.current = new Audio("/assets/sounds/SerbiaLeader.mp3");
+    serbiaLeaderSoundRef.current.volume = vol;
+    franceLeaderSoundRef.current = new Audio("/assets/sounds/FranceLeader.mp3");
+    franceLeaderSoundRef.current.volume = vol;
     badLuckSoundRef.current = new Audio(badLuckSound);
     badLuckSoundRef.current.volume = vol;
     cheerSoundRef.current = new Audio(cheerSound);
@@ -1014,6 +1044,11 @@ export default function SnakeAndLadder() {
       turkeyLeaderSoundRef.current?.pause();
       ukraineLeaderSoundRef.current?.pause();
       northKoreaLeaderSoundRef.current?.pause();
+      israelLeaderSoundRef.current?.pause();
+      egyptLeaderSoundRef.current?.pause();
+      englandLeaderSoundRef.current?.pause();
+      serbiaLeaderSoundRef.current?.pause();
+      franceLeaderSoundRef.current?.pause();
       badLuckSoundRef.current?.pause();
       cheerSoundRef.current?.pause();
       timerSoundRef.current?.pause();
@@ -1040,6 +1075,11 @@ export default function SnakeAndLadder() {
       turkeyLeaderSoundRef,
       ukraineLeaderSoundRef,
       northKoreaLeaderSoundRef,
+      israelLeaderSoundRef,
+      egyptLeaderSoundRef,
+      englandLeaderSoundRef,
+      serbiaLeaderSoundRef,
+      franceLeaderSoundRef,
       badLuckSoundRef,
       cheerSoundRef,
       timerSoundRef,


### PR DESCRIPTION
## Summary
- add new sound references for England, France, Israel, Egypt and Serbia leaders
- hook up audio files for the new leaders
- skip "Haha" sound when Palestine is involved

## Testing
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_687a87f57af48329bc1e3608e658a770