### PR TITLE
Enable TON/USDT staking placeholders

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -22,7 +22,7 @@ ENABLE_TWITTER_OAUTH=false
 # TON deposit address that users will send funds to when topping up their
 # off-chain TPC balance
 # Example: EQCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-DEPOSIT_WALLET_ADDRESS=
+DEPOSIT_WALLET_ADDRESS=UQAn9FQSsmpimKRnosCZ9Lw2V1TW1SdPwCpeXYjEoP5WBhxY
 # TON address that receives payments for store bundles
 STORE_DEPOSIT_ADDRESS=UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT
 

--- a/ft/game-stake.fc
+++ b/ft/game-stake.fc
@@ -1,0 +1,27 @@
+;; Game lobby stake contract
+;; Players send TON to this contract before starting a match.
+;; When the game is finished, call op#1 with the winner address
+;; to distribute 90% of the balance to the winner and 10% to the developer.
+
+const DEV_ADDR = 0x0; ;; placeholder replaced during deployment
+const END_GAME_OP = 1;
+
+() recv_internal(int my_balance, int msg_value, cell in_msg_full, slice in_msg_body) impure {
+  if (in_msg_body.slice_empty?()) {
+    accept_message();
+    return ();
+  }
+  int op = in_msg_body~load_uint(32);
+  if (op != END_GAME_OP) {
+    accept_message();
+    return ();
+  }
+  slice winner = in_msg_body~load_msg_addr();
+  int dev_share = my_balance / 10;
+  int win_share = my_balance - dev_share;
+  builder b1 = begin_cell().store_slice(winner).store_coins(win_share);
+  send_raw_message(b1.end_cell(), 1);
+  builder b2 = begin_cell().store_slice(DEV_ADDR).store_coins(dev_share);
+  send_raw_message(b2.end_cell(), 1);
+  accept_message();
+}

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -181,19 +181,35 @@ export default function Lobby() {
   const startGame = async (flagOverride = flags, leaderOverride = leaders) => {
     const params = new URLSearchParams();
     if (table) params.set('table', table.id);
-    if (game === 'snake' && stake.token === 'TON' && stake.amount > 0) {
+    if (
+      game === 'snake' &&
+      (stake.token === 'TON' || stake.token === 'USDT') &&
+      stake.amount > 0
+    ) {
       if (!walletAddress) {
         tonConnectUI.openModal();
         return;
       }
-      const tx = {
-        validUntil: Math.floor(Date.now() / 1000) + 60,
-        messages: [
+      let messages;
+      if (stake.token === 'TON') {
+        messages = [
           {
             address: SNAKE_CONTRACT_ADDRESS,
             amount: String(stake.amount * 1e9),
           },
-        ],
+        ];
+      } else {
+        messages = [
+          {
+            address: SNAKE_CONTRACT_ADDRESS,
+            amount: '2000000',
+            payload: `USDT:${stake.amount}`,
+          },
+        ];
+      }
+      const tx = {
+        validUntil: Math.floor(Date.now() / 1000) + 60,
+        messages,
       };
       try {
         await tonConnectUI.sendTransaction(tx);
@@ -286,11 +302,10 @@ export default function Lobby() {
         <RoomSelector
           selected={stake}
           onSelect={setStake}
-          tokens={['TPC']}
+          tokens={['TPC', 'TON', 'USDT']}
         />
         <p className="text-center text-subtext text-sm">
-          TON and USDT staking coming soon. Smart contract under
-          construction.
+          Staking is handled via the on-chain contract.
         </p>
       </div>
       {game === 'snake' && table?.id === 'single' && (

--- a/webapp/src/utils/constants.js
+++ b/webapp/src/utils/constants.js
@@ -8,6 +8,13 @@ export const DEV_INFO = {
 // TON wallet used for store purchases and Adsgram payouts
 export const ADSGRAM_WALLET = 'UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT';
 
+// Address where players stake TON or USDT before each game
+export const STAKE_CONTRACT_ADDRESS =
+  'UQAn9FQSsmpimKRnosCZ9Lw2V1TW1SdPwCpeXYjEoP5WBhxY';
+
+// Developer wallet receiving 10% of the winnings
+export const DEV_STAKE_ADDRESS =
+  'UQDdZ3cl-SV5W02dcqmfQ4r-W3cAuEZG5JtDQgVUY1HO1_vq';
+
 // Address of the Snake & Ladder smart contract used for TON bets
-export const SNAKE_CONTRACT_ADDRESS =
-  'EQCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+export const SNAKE_CONTRACT_ADDRESS = STAKE_CONTRACT_ADDRESS;

--- a/wrappers/GameStake.compile.ts
+++ b/wrappers/GameStake.compile.ts
@@ -1,0 +1,3 @@
+module.exports.compile = {
+  targets: ['stdlib.fc', 'ft/game-stake.fc'],
+};

--- a/wrappers/GameStake.ts
+++ b/wrappers/GameStake.ts
@@ -1,0 +1,42 @@
+import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
+
+export type GameStakeConfig = { developer: Address };
+
+export function gameStakeConfigToCell(config: GameStakeConfig): Cell {
+  return beginCell().storeAddress(config.developer).endCell();
+}
+
+export class GameStake implements Contract {
+  constructor(readonly address: Address, readonly init?: { code: Cell; data: Cell }) {}
+
+  static createFromAddress(address: Address) {
+    return new GameStake(address);
+  }
+
+  static createFromConfig(config: GameStakeConfig, code: Cell, workchain = 0) {
+    const data = gameStakeConfigToCell(config);
+    const init = { code, data };
+    return new GameStake(contractAddress(workchain, init), init);
+  }
+
+  async sendDeploy(provider: ContractProvider, via: Sender, value: bigint) {
+    await provider.internal(via, {
+      value,
+      sendMode: SendMode.PAY_GAS_SEPARATELY,
+      body: beginCell().endCell(),
+    });
+  }
+
+  async sendEndGame(provider: ContractProvider, via: Sender, winner: Address, value: bigint, queryId = 0) {
+    const body = beginCell()
+      .storeUint(1, 32)
+      .storeUint(queryId, 64)
+      .storeAddress(winner)
+      .endCell();
+    await provider.internal(via, {
+      value,
+      sendMode: SendMode.PAY_GAS_SEPARATELY,
+      body,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- expose staking deposit address in `.env.example`
- add constants for staking addresses
- allow TON/USDT stake selection in lobby
- add placeholder contract `GameStake` to split winnings

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b2de0acdc8329858dd741ebe1fefb