### PR TITLE
Fix stake token list for single-player mode

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -302,7 +302,7 @@ export default function Lobby() {
         <RoomSelector
           selected={stake}
           onSelect={setStake}
-          tokens={['TPC', 'TON', 'USDT']}
+          tokens={table?.id === 'single' ? ['TPC'] : ['TPC', 'TON', 'USDT']}
         />
         <p className="text-center text-subtext text-sm">
           Staking is handled via the on-chain contract.


### PR DESCRIPTION
## Summary
- restrict token options to TPC when the AI table is selected

## Testing
- `npm test` *(fails: player wins when all tokens finish)*

------
https://chatgpt.com/codex/tasks/task_e_687b3c1977cc83298203a7dc338ea876