### PR TITLE
Fix developer share payout

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@
    - `VITE_API_BASE_URL` – the base URL where the bot API is hosted (e.g. `http://localhost:3000`).
      If omitted, the webapp will connect to the same origin it was served from.
    - `VITE_GOOGLE_CLIENT_ID` – OAuth client ID for Google sign-in.
-   - `VITE_DEV_ACCOUNT_ID` – account ID that receives the 9% developer share.
-   - `VITE_DEV_ACCOUNT_ID_1` – (optional) account that receives a 1% share.
-  - `VITE_DEV_ACCOUNT_ID_2` – (optional) account that receives a 2% share.
+  - `VITE_DEV_ACCOUNT_ID` – account ID that receives the developer share
+    (10% by default).
+  - `VITE_DEV_ACCOUNT_ID_1` – (optional) secondary developer account. When set,
+    the main account receives 9% and this account receives 1%.
+  - `VITE_DEV_ACCOUNT_ID_2` – (optional) additional developer account. When set,
+    the main account receives 9% and this account receives 2%.
   - `VITE_API_AUTH_TOKEN` – (optional) token used when calling privileged API
     endpoints outside Telegram.
 

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -34,24 +34,32 @@ const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 
 async function awardDevShare(total) {
   const promises = [];
-  if (DEV_ACCOUNT) {
+  if (DEV_ACCOUNT_1 || DEV_ACCOUNT_2) {
+    if (DEV_ACCOUNT) {
+      promises.push(
+        depositAccount(DEV_ACCOUNT, Math.round(total * 0.09), {
+          game: 'crazydice-dev',
+        })
+      );
+    }
+    if (DEV_ACCOUNT_1) {
+      promises.push(
+        depositAccount(DEV_ACCOUNT_1, Math.round(total * 0.01), {
+          game: 'crazydice-dev1',
+        })
+      );
+    }
+    if (DEV_ACCOUNT_2) {
+      promises.push(
+        depositAccount(DEV_ACCOUNT_2, Math.round(total * 0.02), {
+          game: 'crazydice-dev2',
+        })
+      );
+    }
+  } else if (DEV_ACCOUNT) {
     promises.push(
-      depositAccount(DEV_ACCOUNT, Math.round(total * 0.09), {
+      depositAccount(DEV_ACCOUNT, Math.round(total * 0.1), {
         game: 'crazydice-dev',
-      })
-    );
-  }
-  if (DEV_ACCOUNT_1) {
-    promises.push(
-      depositAccount(DEV_ACCOUNT_1, Math.round(total * 0.01), {
-        game: 'crazydice-dev1',
-      })
-    );
-  }
-  if (DEV_ACCOUNT_2) {
-    promises.push(
-      depositAccount(DEV_ACCOUNT_2, Math.round(total * 0.02), {
-        game: 'crazydice-dev2',
       })
     );
   }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -48,24 +48,32 @@ const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 
 async function awardDevShare(total) {
   const promises = [];
-  if (DEV_ACCOUNT) {
+  if (DEV_ACCOUNT_1 || DEV_ACCOUNT_2) {
+    if (DEV_ACCOUNT) {
+      promises.push(
+        depositAccount(DEV_ACCOUNT, Math.round(total * 0.09), {
+          game: 'snake-dev',
+        })
+      );
+    }
+    if (DEV_ACCOUNT_1) {
+      promises.push(
+        depositAccount(DEV_ACCOUNT_1, Math.round(total * 0.01), {
+          game: 'snake-dev1',
+        })
+      );
+    }
+    if (DEV_ACCOUNT_2) {
+      promises.push(
+        depositAccount(DEV_ACCOUNT_2, Math.round(total * 0.02), {
+          game: 'snake-dev2',
+        })
+      );
+    }
+  } else if (DEV_ACCOUNT) {
     promises.push(
-      depositAccount(DEV_ACCOUNT, Math.round(total * 0.09), {
+      depositAccount(DEV_ACCOUNT, Math.round(total * 0.1), {
         game: 'snake-dev',
-      })
-    );
-  }
-  if (DEV_ACCOUNT_1) {
-    promises.push(
-      depositAccount(DEV_ACCOUNT_1, Math.round(total * 0.01), {
-        game: 'snake-dev1',
-      })
-    );
-  }
-  if (DEV_ACCOUNT_2) {
-    promises.push(
-      depositAccount(DEV_ACCOUNT_2, Math.round(total * 0.02), {
-        game: 'snake-dev2',
       })
     );
   }


### PR DESCRIPTION
## Summary
- adjust developer share logic so main account gets full 10% when no other dev accounts are set
- document the default 10% developer share in README

## Testing
- `npm test` *(fails: Cannot find package 'geoip-lite', 'express', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687b47acf8a48329b24316a325162fab