### PR TITLE
Implement Jetton game stakes

### DIFF
--- a/ft/game-stake.fc
+++ b/ft/game-stake.fc
@@ -1,27 +1,64 @@
 ;; Game lobby stake contract
-;; Players send TON to this contract before starting a match.
-;; When the game is finished, call op#1 with the winner address
-;; to distribute 90% of the balance to the winner and 10% to the developer.
+;; Players send TON or jettons to this contract before starting a match.
+;; When the game is finished, call op#1 with the winner address.
+;; The contract distributes the balance between the winner and the developer
+;; according to a configurable share. When a jetton wallet is configured the
+;; payout is performed by instructing that wallet to withdraw jettons.
 
-const DEV_ADDR = 0x0; ;; placeholder replaced during deployment
 const END_GAME_OP = 1;
 
+(slice dev_addr, int dev_share, slice jetton_wallet) load_config() inline {
+  slice ds = get_data().begin_parse();
+  return (ds~load_msg_addr(), ds~load_uint(8), ds~load_msg_addr());
+}
+
 () recv_internal(int my_balance, int msg_value, cell in_msg_full, slice in_msg_body) impure {
+  var (dev_addr, dev_pct, jetton_wallet) = load_config();
   if (in_msg_body.slice_empty?()) {
     accept_message();
     return ();
   }
   int op = in_msg_body~load_uint(32);
-  if (op != END_GAME_OP) {
-    accept_message();
-    return ();
-  }
+  throw_unless(401, op == END_GAME_OP);
   slice winner = in_msg_body~load_msg_addr();
-  int dev_share = my_balance / 10;
+  int dev_share = my_balance * dev_pct / 100;
   int win_share = my_balance - dev_share;
-  builder b1 = begin_cell().store_slice(winner).store_coins(win_share);
-  send_raw_message(b1.end_cell(), 1);
-  builder b2 = begin_cell().store_slice(DEV_ADDR).store_coins(dev_share);
-  send_raw_message(b2.end_cell(), 1);
+
+  if (jetton_wallet.preload_uint(2) == 0) {
+    builder b1 = begin_cell().store_slice(winner).store_coins(win_share);
+    send_raw_message(b1.end_cell(), 1);
+    builder b2 = begin_cell().store_slice(dev_addr).store_coins(dev_share);
+    send_raw_message(b2.end_cell(), 1);
+  } else {
+    cell body1 = begin_cell()
+      .store_uint(0x768a50b2, 32)
+      .store_uint(0, 64)
+      .store_slice(winner)
+      .store_coins(win_share)
+      .store_maybe_ref(null)
+      .end_cell();
+    builder msg1 = begin_cell()
+      .store_uint(0x10, 6)
+      .store_slice(jetton_wallet)
+      .store_coins(msg_value / 2)
+      .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+      .store_ref(body1);
+    send_raw_message(msg1.end_cell(), 1);
+
+    cell body2 = begin_cell()
+      .store_uint(0x768a50b2, 32)
+      .store_uint(0, 64)
+      .store_slice(dev_addr)
+      .store_coins(dev_share)
+      .store_maybe_ref(null)
+      .end_cell();
+    builder msg2 = begin_cell()
+      .store_uint(0x10, 6)
+      .store_slice(jetton_wallet)
+      .store_coins(msg_value - msg_value / 2)
+      .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+      .store_ref(body2);
+    send_raw_message(msg2.end_cell(), 1);
+  }
   accept_message();
 }

--- a/test/gameStakeConfig.test.js
+++ b/test/gameStakeConfig.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Address } from '@ton/core';
+import { gameStakeConfigToCell } from '../wrappers/GameStake.js';
+
+test('game stake config stores share and wallet', () => {
+  const dev = Address.parse('EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c');
+  const wallet = Address.parse('EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0w');
+  const cell = gameStakeConfigToCell({ developer: dev, developerShare: 15, jettonWallet: wallet });
+  const slice = cell.beginParse();
+  assert.equal(slice.loadAddress().toString(), dev.toString());
+  assert.equal(slice.loadUint(8), 15);
+  assert.equal(slice.loadAddress().toString(), wallet.toString());
+});

--- a/test/ludoGame.test.js
+++ b/test/ludoGame.test.js
@@ -14,10 +14,10 @@ test('token requires 6 to leave base', () => {
 
 test('player wins when all tokens finish', () => {
   const game = new LudoGame(1);
-  game.players[0].tokens = Array(4).fill(57);
+  game.players[0].tokens = Array(4).fill(56);
   game.players[0].finished = 3;
   game.currentTurn = 0;
-  const res = game.rollDice(6);
+  const res = game.rollDice(1);
   assert.ok(game.finished);
 });
 

--- a/wrappers/GameStake.ts
+++ b/wrappers/GameStake.ts
@@ -1,9 +1,14 @@
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
 
-export type GameStakeConfig = { developer: Address };
+export type GameStakeConfig = { developer: Address; developerShare: number; jettonWallet?: Address };
 
 export function gameStakeConfigToCell(config: GameStakeConfig): Cell {
-  return beginCell().storeAddress(config.developer).endCell();
+  const wallet = config.jettonWallet ?? Address.parse('0:0');
+  return beginCell()
+    .storeAddress(config.developer)
+    .storeUint(config.developerShare, 8)
+    .storeAddress(wallet)
+    .endCell();
 }
 
 export class GameStake implements Contract {


### PR DESCRIPTION
## Summary
- support Jetton payouts in `game-stake.fc`
- parameterize developer share and wallet
- expose new options in `GameStake` wrapper
- fix ludo game test and add config test

## Testing
- `npm test` *(fails: The test runner hangs or reports errors in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_687b4e26a26c8329812e7f658999fee5