### PR TITLE
Implement lobby deposit tracking

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -30,6 +30,7 @@ import { fileURLToPath } from 'url';
 import { existsSync } from 'fs';
 import { execSync } from 'child_process';
 import compression from 'compression';
+import { Address } from 'ton-core';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -48,7 +49,21 @@ const app = express();
 app.use(cors());
 const httpServer = http.createServer(app);
 const io = new SocketIOServer(httpServer, { cors: { origin: '*' } });
-const gameManager = new GameRoomManager(io);
+
+function handleGameFinish(roomId, winnerId) {
+  User.findOne({ accountId: winnerId })
+    .then((user) => {
+      if (user?.walletAddress) {
+        console.log(`Winner ${winnerId} => ${user.walletAddress}`);
+        // Placeholder for sending blockchain payout
+      } else {
+        console.log('Winner wallet not found for', winnerId);
+      }
+    })
+    .catch((err) => console.error('payout lookup failed:', err));
+}
+
+const gameManager = new GameRoomManager(io, handleGameFinish);
 
 // Expose socket.io instance and userSockets map for routes
 app.set('io', io);
@@ -202,6 +217,8 @@ const pendingInvites = new Map();
 app.set('userSockets', userSockets);
 
 const tableWatchers = new Map();
+// Track which players have deposited for each room
+const roomDeposits = new Map();
 const BUNDLE_TON_MAP = Object.fromEntries(
   Object.values(BUNDLES).map((b) => [b.label, b.ton])
 );
@@ -391,6 +408,30 @@ app.get('/api/snake/board/:id', async (req, res) => {
 app.get("/api/watchers/count/:id", (req, res) => {
   const set = tableWatchers.get(req.params.id);
   res.json({ count: set ? set.size : 0 });
+});
+
+// Record that a player has deposited the stake for a room
+app.post('/api/snake/deposit', async (req, res) => {
+  const { roomId, playerId } = req.body || {};
+  if (!roomId || !playerId) return res.status(400).json({ error: 'missing data' });
+  let set = roomDeposits.get(roomId);
+  if (!set) { set = new Set(); roomDeposits.set(roomId, set); }
+  set.add(String(playerId));
+  const room = await gameManager.getRoom(roomId);
+  const players = room.players.filter(p => !p.disconnected);
+  const all = players.length > 0 && players.every(p => set.has(String(p.playerId)));
+  if (all && room.status === 'waiting') {
+    room.startGame();
+    await gameManager.saveRoom(room);
+    roomDeposits.delete(roomId);
+  }
+  res.json({ start: all });
+});
+
+// Check which players have deposited for a room
+app.get('/api/snake/deposit-status/:id', (req, res) => {
+  const set = roomDeposits.get(req.params.id);
+  res.json({ deposited: set ? Array.from(set) : [] });
 });
 
 

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -455,6 +455,18 @@ export function sendBroadcast(data) {
   return post('/api/broadcast/send', data, API_AUTH_TOKEN || undefined);
 }
 
+export function depositStake(roomId, playerId) {
+  return fetch(API_BASE_URL + '/api/snake/deposit', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ roomId, playerId }),
+  }).then((r) => r.json());
+}
+
+export function getDepositStatus(roomId) {
+  return fetch(API_BASE_URL + '/api/snake/deposit-status/' + roomId).then((r) => r.json());
+}
+
 export function getWatchCount(tableId) {
   return fetch(API_BASE_URL + "/api/watchers/count/" + tableId).then(r => r.json());
 }


### PR DESCRIPTION
## Summary
- track deposited players in-memory
- start game after all deposits received
- hook into game finish for payouts
- allow client to submit deposits and poll status

## Testing
- `npm test` *(fails: tests hang or partial output)*

------
https://chatgpt.com/codex/tasks/task_e_687b564131ec83299e83d01c53173a80