### PR TITLE
Add API rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@
    - `DEV_ACCOUNT_ID_1` – (optional) secondary developer account (1% share)
    - `DEV_ACCOUNT_ID_2` – (optional) secondary developer account (2% share)
    - `API_AUTH_TOKEN` – (optional) token for trusted server-to-server calls
-  - `TWITTER_BEARER_TOKEN` – bearer token for verifying reposts on **X**.
+   - `RATE_LIMIT_WINDOW_MS` – (optional) timeframe for rate limits in milliseconds (defaults to 900000)
+   - `RATE_LIMIT_MAX` – (optional) max requests per window from one IP (defaults to 100)
+   - `TWITTER_BEARER_TOKEN` – bearer token for verifying reposts on **X**.
   - `TWITTER_CLIENT_ID` – API key for **X** OAuth linking.
   - `TWITTER_CLIENT_SECRET` – API secret for **X** OAuth linking.
 

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -9,6 +9,10 @@ MONGODB_URI=memory
 # API port (defaults to 3000 if not set)
 PORT=3000
 
+# Rate limit configuration
+RATE_LIMIT_WINDOW_MS=900000
+RATE_LIMIT_MAX=100
+
 # Comma-separated list of admin tokens for the airdrop API.
 # These tokens also authorize access to the /api/broadcast route.
 # AIRDROP_ADMIN_TOKENS=token1,token2

--- a/bot/package.json
+++ b/bot/package.json
@@ -12,6 +12,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-rate-limit": "^7.5.1",
     "geoip-lite": "^1.4.10",
     "https-proxy-agent": "^7.0.2",
     "mongodb-memory-server": "^10.1.4",

--- a/bot/server.js
+++ b/bot/server.js
@@ -30,6 +30,7 @@ import { fileURLToPath } from 'url';
 import { existsSync } from 'fs';
 import { execSync } from 'child_process';
 import compression from 'compression';
+import rateLimit from 'express-rate-limit';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -44,6 +45,9 @@ if (!process.env.MONGODB_URI) {
 
 
 const PORT = process.env.PORT || 3000;
+const rateLimitWindowMs = Number(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
+const rateLimitMax = Number(process.env.RATE_LIMIT_MAX) || 100;
+
 const app = express();
 app.use(cors());
 const httpServer = http.createServer(app);
@@ -88,6 +92,13 @@ bot.action(/^reject_invite:(.+)/, async (ctx) => {
 app.use(compression());
 // Increase JSON body limit to handle large photo uploads
 app.use(express.json({ limit: '10mb' }));
+const apiLimiter = rateLimit({
+  windowMs: rateLimitWindowMs,
+  limit: rateLimitMax,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+app.use('/api', apiLimiter);
 app.use('/api/mining', miningRoutes);
 app.use('/api/tasks', tasksRoutes);
 app.use('/api/watch', watchRoutes);


### PR DESCRIPTION
## Summary
- install `express-rate-limit`
- enable basic rate limiting for all `/api` routes
- document new environment variables for tweaking the limits

## Testing
- `npm test` *(fails: Cannot find module 'wrappers/GameStake.js')*

------
https://chatgpt.com/codex/tasks/task_e_687b6845201c83299d809bc0f1209514