### PR TITLE
Limit CORS origins via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@
    - `AIRDROP_ADMIN_TOKENS` – (optional) tokens allowed to trigger airdrops
    - `DEPOSIT_WALLET_ADDRESS` – TON address that receives user deposits
    - `PORT` – (optional) port for the bot API server (defaults to 3000)
-   - `DEV_ACCOUNT_ID` – account ID that collects transfer fees
-   - `DEV_ACCOUNT_ID_1` – (optional) secondary developer account (1% share)
-   - `DEV_ACCOUNT_ID_2` – (optional) secondary developer account (2% share)
-   - `API_AUTH_TOKEN` – (optional) token for trusted server-to-server calls
+  - `DEV_ACCOUNT_ID` – account ID that collects transfer fees
+  - `DEV_ACCOUNT_ID_1` – (optional) secondary developer account (1% share)
+  - `DEV_ACCOUNT_ID_2` – (optional) secondary developer account (2% share)
+  - `API_AUTH_TOKEN` – (optional) token for trusted server-to-server calls
   - `TWITTER_BEARER_TOKEN` – bearer token for verifying reposts on **X**.
   - `TWITTER_CLIENT_ID` – API key for **X** OAuth linking.
   - `TWITTER_CLIENT_SECRET` – API secret for **X** OAuth linking.
+  - `ALLOWED_ORIGINS` – (optional) comma-separated list of origins allowed for
+    CORS and socket.io connections.
 
     When deploying on **Render**, set these values in the service environment instead of storing them in `.env` files.
 
@@ -62,8 +64,9 @@ local development.
 The server honors a few extra environment variables when building or serving the webapp:
 
 - `WEBAPP_API_BASE_URL` – overrides the API base used during the webapp build. Set this when the bot API is hosted on another domain or port. If left empty the webapp assumes it is served from the same origin.
- - `TONCONNECT_MANIFEST_URL` – full URL for a custom `tonconnect-manifest.json`. Defaults to the manifest bundled with the build when unset.
- - `SKIP_WEBAPP_BUILD` – set to any value to skip the automatic webapp build that normally runs when `npm start` is executed. Useful if you built the assets manually.
+- `TONCONNECT_MANIFEST_URL` – full URL for a custom `tonconnect-manifest.json`. Defaults to the manifest bundled with the build when unset.
+- `SKIP_WEBAPP_BUILD` – set to any value to skip the automatic webapp build that normally runs when `npm start` is executed. Useful if you built the assets manually.
+- `ALLOWED_ORIGINS` – comma-separated list of origins allowed for CORS and socket.io when serving the API.
 
 5. Copy `scripts/.env.example` to `scripts/.env` and set:
    - `MNEMONIC` – wallet seed phrase used to deploy the Jetton

--- a/bot/server.js
+++ b/bot/server.js
@@ -44,10 +44,16 @@ if (!process.env.MONGODB_URI) {
 
 
 const PORT = process.env.PORT || 3000;
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((o) => o.trim())
+  .filter(Boolean);
 const app = express();
-app.use(cors());
+app.use(cors({ origin: allowedOrigins.length ? allowedOrigins : '*' }));
 const httpServer = http.createServer(app);
-const io = new SocketIOServer(httpServer, { cors: { origin: '*' } });
+const io = new SocketIOServer(httpServer, {
+  cors: { origin: allowedOrigins.length ? allowedOrigins : '*' },
+});
 const gameManager = new GameRoomManager(io);
 
 // Expose socket.io instance and userSockets map for routes


### PR DESCRIPTION
## Summary
- restrict CORS and socket.io origins through the `ALLOWED_ORIGINS` env var
- document the new variable in the README

## Testing
- `npm run install-all`
- `npm test` *(fails: tests run for long time and were interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687b68154dd08329933b927345342725