### PR TITLE
Add ESLint and Prettier configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,26 @@
+{
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true
+  },
+  "extends": [
+    "standard",
+    "plugin:react/recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "ignorePatterns": ["webapp/dist/**"],
+  "plugins": ["react"],
+  "rules": {}
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,8 @@ jobs:
       - name: Install dependencies
         run: npm run install-all
 
+      - name: Run ESLint
+        run: npm run lint
+
       - name: Run tests
         run: npm test

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "none"
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "install-all": "npm install && npm install --prefix bot && npm install --prefix webapp",
     "build": "npm --prefix webapp run build",
     "test": "node --test",
+    "lint": "eslint .",
+    "format": "prettier --write .",
     "recalculate-balances": "node bot/scripts/recalculateBalances.js",
     "ban-user": "node bot/scripts/banUser.js",
     "dev": "concurrently -k \"npm --prefix webapp run dev\" \"node bot/server.js\""
@@ -28,6 +30,14 @@
   },
   "devDependencies": {
     "@ton/blueprint": "^0.37.0",
-    "concurrently": "^8.2.2"
+    "concurrently": "^8.2.2",
+    "eslint": "^8.57.1",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-promise": "^6.6.0",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "prettier": "^3.6.2"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint and Prettier dev dependencies
- define `.eslintrc` and `.prettierrc`
- expose `lint` and `format` npm scripts
- run `npm run lint` during CI

## Testing
- `npm run install-all`
- `npm test`
- `npm run lint` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_687b68292a548329b0c5be76f289aec5