### PR TITLE
Fix multiplayer snake lobby sync

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -56,6 +56,11 @@ export default function Lobby() {
   const [online, setOnline] = useState(0);
   const [playerName, setPlayerName] = useState('');
   const autoStartedRef = useRef(false);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    startedRef.current = false;
+  }, [game, table]);
 
   const selectAiType = (t) => {
     setAiType(t);
@@ -131,7 +136,7 @@ export default function Lobby() {
       return () => {
         cancelled = true;
         if (interval) clearInterval(interval);
-        if (pid) unseatTable(pid, table.id).catch(() => {});
+        if (pid && !startedRef.current) unseatTable(pid, table.id).catch(() => {});
       };
     }
   }, [game, table, playerName]);
@@ -251,6 +256,7 @@ export default function Lobby() {
       if (stake.amount) params.set('amount', stake.amount);
     }
 
+    startedRef.current = true;
     navigate(`/games/${game}?${params.toString()}`);
   };
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -39,7 +39,8 @@ import {
   depositAccount,
   getSnakeBoard,
   pingOnline,
-  addTransaction
+  addTransaction,
+  unseatTable
 } from "../../utils/api.js";
 // Developer accounts that receive shares of each pot
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
@@ -1419,7 +1420,10 @@ export default function SnakeAndLadder() {
         setDiceCount(playerDiceCounts[idx] ?? 2);
       }
     };
-    const onStarted = () => setWaitingForPlayers(false);
+    const onStarted = () => {
+      setWaitingForPlayers(false);
+      unseatTable(accountId, tableId).catch(() => {});
+    };
     const onRolled = ({ value }) => {
       setRollResult(value);
       setTimeout(() => setRollResult(null), 2000);
@@ -1528,6 +1532,8 @@ export default function SnakeAndLadder() {
       socket.off('currentPlayers', onCurrentPlayers);
       if (watchOnly) {
         socket.emit('leaveWatch', { roomId: tableId });
+      } else {
+        unseatTable(accountId, tableId).catch(() => {});
       }
     };
   }, [isMultiplayer, tableId, watchOnly]);


### PR DESCRIPTION
## Summary
- prevent unseating when navigating from lobby to the board
- clear lobby seat after the game starts

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND wrappers/GameStake.js)*

------
https://chatgpt.com/codex/tasks/task_e_687b74ce697c8329b0a6d6c70a833f06