### PR TITLE
Fix back button behavior

### DIFF
--- a/webapp/src/hooks/useTelegramBackButton.js
+++ b/webapp/src/hooks/useTelegramBackButton.js
@@ -1,8 +1,9 @@
 import { useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 export default function useTelegramBackButton(onBack) {
   const navigate = useNavigate();
+  const location = useLocation();
   const cbRef = useRef(onBack);
 
   // Keep the latest callback without re-registering the listener
@@ -13,6 +14,11 @@ export default function useTelegramBackButton(onBack) {
   useEffect(() => {
     const tg = window?.Telegram?.WebApp;
     if (!tg) return;
+
+    if (window.history.length <= 1 || location.pathname === '/') {
+      tg.BackButton.hide();
+      return;
+    }
 
     const handleBack = () => {
       const cb = cbRef.current;
@@ -27,5 +33,5 @@ export default function useTelegramBackButton(onBack) {
       tg.offEvent('backButtonClicked', handleBack);
       tg.BackButton.hide();
     };
-  }, [navigate]);
+  }, [navigate, location.pathname]);
 }

--- a/webapp/src/pages/Games/CrazyDiceLobby.jsx
+++ b/webapp/src/pages/Games/CrazyDiceLobby.jsx
@@ -11,7 +11,7 @@ import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 
 export default function CrazyDiceLobby() {
   const navigate = useNavigate();
-  useTelegramBackButton(() => navigate('/games', { replace: true }));
+  useTelegramBackButton();
 
   const TABLES = [
     { id: 'single', label: 'Single Player vs AI', capacity: 1 },

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -28,20 +28,11 @@ export default function Lobby() {
   const navigate = useNavigate();
   const walletAddress = useTonAddress();
   const [tonConnectUI] = useTonConnectUI();
-  useTelegramBackButton(() => navigate('/games', { replace: true }));
+  useTelegramBackButton();
 
   useEffect(() => {
     ensureAccountId().catch(() => {});
   }, []);
-
-  useEffect(() => {
-    const handlePop = (e) => {
-      e.preventDefault();
-      navigate('/games', { replace: true });
-    };
-    window.addEventListener('popstate', handlePop);
-    return () => window.removeEventListener('popstate', handlePop);
-  }, [navigate]);
 
   const [tables, setTables] = useState([]);
   const [table, setTable] = useState(null);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -4,7 +4,6 @@ import {
   useRef,
   useLayoutEffect,
   Fragment,
-  useCallback,
 } from "react";
 import coinConfetti from "../../utils/coinConfetti";
 import DiceRoller from "../../components/DiceRoller.jsx";
@@ -526,22 +525,11 @@ function Board({
 export default function SnakeAndLadder() {
   const [showLobbyConfirm, setShowLobbyConfirm] = useState(false);
   const [showQuitInfo, setShowQuitInfo] = useState(true);
-  const handleBack = useCallback(() => setShowLobbyConfirm(true), []);
-  useTelegramBackButton(handleBack);
+  useTelegramBackButton();
   const navigate = useNavigate();
 
   useEffect(() => {
     ensureAccountId().catch(() => {});
-  }, []);
-
-  useEffect(() => {
-    const handlePop = (e) => {
-      e.preventDefault();
-      setShowLobbyConfirm(true);
-      window.history.pushState(null, '');
-    };
-    window.addEventListener('popstate', handlePop);
-    return () => window.removeEventListener('popstate', handlePop);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- improve `useTelegramBackButton` to hide button on first page
- drop custom popstate handlers from game lobbies
- call back button hook directly in lobbies

## Testing
- `npm test` *(fails: Cannot find module '/workspace/TonPlaygramWebApp/wrappers/GameStake.js')*

------
https://chatgpt.com/codex/tasks/task_e_687b7b36307c8329972f149025b755e3