### PR TITLE
Add close buttons for popups

### DIFF
--- a/webapp/src/components/ConfirmPopup.jsx
+++ b/webapp/src/components/ConfirmPopup.jsx
@@ -5,7 +5,17 @@ export default function ConfirmPopup({ open, message, onConfirm, onCancel }) {
   if (!open) return null;
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
-      <div className="prism-box p-6 space-y-4 text-text w-80">
+      <div className="prism-box p-6 space-y-4 text-text w-80 relative">
+        <button
+          onClick={() => {
+            if (window.confirm('Are you sure you want to close?')) {
+              onCancel();
+            }
+          }}
+          className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"
+        >
+          &times;
+        </button>
         <p className="text-sm text-center">{message}</p>
         <div className="flex gap-2">
           <button
@@ -25,6 +35,6 @@ export default function ConfirmPopup({ open, message, onConfirm, onCancel }) {
         </div>
       </div>
     </div>,
-    document.body,
+    document.body
   );
 }

--- a/webapp/src/components/GameEndPopup.jsx
+++ b/webapp/src/components/GameEndPopup.jsx
@@ -1,12 +1,30 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
 
-export default function GameEndPopup({ open, ranking, onPlayAgain, onReturn }) {
+export default function GameEndPopup({
+  open,
+  ranking,
+  onPlayAgain,
+  onReturn,
+  onClose
+}) {
   if (!open) return null;
   return createPortal(
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
-        <img  src="/assets/icons/TonPlayGramLogo.webp" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
+      <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80 relative">
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"
+          >
+            &times;
+          </button>
+        )}
+        <img
+          src="/assets/icons/TonPlayGramLogo.webp"
+          alt="TonPlaygram Logo"
+          className="w-10 h-10 mx-auto"
+        />
         <h3 className="text-lg font-bold text-center">Game Over</h3>
         <ol className="list-decimal list-inside space-y-1 text-center">
           {ranking.map((name, i) => (
@@ -29,6 +47,6 @@ export default function GameEndPopup({ open, ranking, onPlayAgain, onReturn }) {
         </div>
       </div>
     </div>,
-    document.body,
+    document.body
   );
 }

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -12,31 +12,37 @@ export default function InvitePopup({
   onStakeChange,
   incoming,
   group,
+  onClose
 }) {
   if (!open) return null;
   const [game, setGame] = React.useState('snake');
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
-      <div className="bg-surface border border-border rounded p-4 space-y-4 text-text w-72">
+      <div className="bg-surface border border-border rounded p-4 space-y-4 text-text w-72 relative">
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"
+          >
+            &times;
+          </button>
+        )}
         {incoming ? (
           <p className="text-center">
             {name} wants to play you for {stake?.amount}{' '}
             <img
-              
               src={
                 stake?.token === 'TPC'
                   ? '/assets/icons/TPCcoin_1.webp'
                   : stake?.token === 'TON'
-                  ? '/assets/icons/TON.webp'
-                  : '/assets/icons/Usdt.webp'
+                    ? '/assets/icons/TON.webp'
+                    : '/assets/icons/Usdt.webp'
               }
               alt="token"
               className="inline w-4 h-4 mr-1"
             />
             {stake?.token}
-            {group && opponents.length > 0 && (
-              <> with {opponents.join(', ')}</>
-            )}
+            {group && opponents.length > 0 && <> with {opponents.join(', ')}</>}
           </p>
         ) : (
           <>
@@ -80,6 +86,6 @@ export default function InvitePopup({
         </div>
       </div>
     </div>,
-    document.body,
+    document.body
   );
 }

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -43,8 +43,26 @@ export default function Layout({ children }) {
   }, []);
 
   useEffect(() => {
-    const onInvite = ({ fromId, fromName, roomId, token, amount, group, opponentNames, game }) => {
-      setInvite({ fromId, fromName, roomId, token, amount, group, opponentNames, game });
+    const onInvite = ({
+      fromId,
+      fromName,
+      roomId,
+      token,
+      amount,
+      group,
+      opponentNames,
+      game
+    }) => {
+      setInvite({
+        fromId,
+        fromName,
+        roomId,
+        token,
+        amount,
+        group,
+        opponentNames,
+        game
+      });
       if (beepRef.current && !isGameMuted()) {
         beepRef.current.currentTime = 0;
         beepRef.current.play().catch(() => {});
@@ -78,45 +96,45 @@ export default function Layout({ children }) {
   const showBranding = isGamesRoot || !location.pathname.startsWith('/games');
 
   const showNavbar = !(
-
     location.pathname.startsWith('/games/') &&
-
     !location.pathname.includes('/lobby')
-
   );
 
   const showFooter = !location.pathname.startsWith('/games/');
 
   return (
-
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
-
       <CosmicBackground />
-      <main className={`flex-grow ${
-        showNavbar ? 'container mx-auto p-4 pb-24' : 'w-full p-0'
-      }`}>
-
+      <main
+        className={`flex-grow ${
+          showNavbar ? 'container mx-auto p-4 pb-24' : 'w-full p-0'
+        }`}
+      >
         {showBranding && (
-        <Branding
-            scale={isMining || isTasks || isStore || isAccount || isGamesRoot || isWallet ? 1.2 : 1}
+          <Branding
+            scale={
+              isMining ||
+              isTasks ||
+              isStore ||
+              isAccount ||
+              isGamesRoot ||
+              isWallet
+                ? 1.2
+                : 1
+            }
             offsetY={isMining ? '0.5rem' : 0}
           />
         )}
 
         {children}
-
       </main>
 
       {/* Fixed Bottom Navbar */}
 
       {showNavbar && (
-
         <div className="fixed bottom-0 inset-x-0 z-50">
-
           <Navbar />
-
         </div>
-
       )}
 
       {showFooter && <Footer />}
@@ -128,18 +146,16 @@ export default function Layout({ children }) {
         stake={{ token: invite?.token, amount: invite?.amount }}
         incoming
         group={Array.isArray(invite?.group)}
+        onClose={() => setInvite(null)}
         onAccept={() => {
           if (invite)
             navigate(
-              `/games/${invite.game || 'snake'}?table=${invite.roomId}&token=${invite.token}&amount=${invite.amount}`,
+              `/games/${invite.game || 'snake'}?table=${invite.roomId}&token=${invite.token}&amount=${invite.amount}`
             );
           setInvite(null);
         }}
         onReject={() => setInvite(null)}
       />
-
     </div>
-
   );
-
 }

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -1,14 +1,18 @@
 import { useEffect, useState } from 'react';
 import { FaCircle, FaTv } from 'react-icons/fa';
 import LoginOptions from './LoginOptions.jsx';
-import { getTelegramId, getTelegramPhotoUrl, getPlayerId } from '../utils/telegram.js';
+import {
+  getTelegramId,
+  getTelegramPhotoUrl,
+  getPlayerId
+} from '../utils/telegram.js';
 import {
   getLeaderboard,
   getOnlineCount,
   getOnlineUsers,
   fetchTelegramInfo,
   getProfile,
-  getWatchCount,
+  getWatchCount
 } from '../utils/api.js';
 import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
 import { socket } from '../utils/socket.js';
@@ -77,7 +81,9 @@ export default function LeaderboardCard() {
         .catch(() => {
           fetchTelegramInfo(telegramId).then((info) => {
             if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
-            setMyName(`${info?.firstName || ''} ${info?.lastName || ''}`.trim());
+            setMyName(
+              `${info?.firstName || ''} ${info?.lastName || ''}`.trim()
+            );
           });
         });
     }
@@ -97,9 +103,11 @@ export default function LeaderboardCard() {
 
   useEffect(() => {
     const tables = new Set(
-      leaderboard.map((u) => u.currentTableId).filter(Boolean),
+      leaderboard.map((u) => u.currentTableId).filter(Boolean)
     );
-    const myTable = leaderboard.find((u) => u.accountId === accountId)?.currentTableId;
+    const myTable = leaderboard.find(
+      (u) => u.accountId === accountId
+    )?.currentTableId;
     if (myTable) tables.add(myTable);
     if (aiPlaying && !myTable) {
       const local = localStorage.getItem('snakeCurrentTable');
@@ -107,7 +115,7 @@ export default function LeaderboardCard() {
     }
     if (tables.size === 0) return;
     Promise.all(
-      [...tables].map((id) => getWatchCount(id).then((c) => [id, c.count])),
+      [...tables].map((id) => getWatchCount(id).then((c) => [id, c.count]))
     )
       .then((arr) => {
         const obj = {};
@@ -197,14 +205,21 @@ export default function LeaderboardCard() {
                 <tr
                   key={u.accountId || u.telegramId}
                   className={`border-b border-border h-16 ${
-                    u.accountId === accountId ? 'bg-accent text-black' : 'cursor-pointer'
+                    u.accountId === accountId
+                      ? 'bg-accent text-black'
+                      : 'cursor-pointer'
                   }`}
                   onClick={() => {
                     if (u.accountId === accountId || u.currentTableId) return;
                     if (mode === 'group') {
                       setSelected((prev) => {
-                        const exists = prev.find((p) => p.accountId === u.accountId);
-                        if (exists) return prev.filter((p) => p.accountId !== u.accountId);
+                        const exists = prev.find(
+                          (p) => p.accountId === u.accountId
+                        );
+                        if (exists)
+                          return prev.filter(
+                            (p) => p.accountId !== u.accountId
+                          );
                         if (prev.length >= 3) return prev;
                         return [...prev, u];
                       });
@@ -232,12 +247,16 @@ export default function LeaderboardCard() {
                         <input
                           type="checkbox"
                           disabled={!!u.currentTableId}
-                          checked={selected.some((p) => p.accountId === u.accountId)}
+                          checked={selected.some(
+                            (p) => p.accountId === u.accountId
+                          )}
                           onChange={() => {}}
                           className="mr-1"
                         />
                       )}
-                      {u.nickname || `${u.firstName} ${u.lastName}`.trim() || 'User'}
+                      {u.nickname ||
+                        `${u.firstName} ${u.lastName}`.trim() ||
+                        'User'}
                       {onlineUsers.includes(String(u.accountId)) && (
                         <FaCircle className="ml-1 text-green-500" size={8} />
                       )}
@@ -255,7 +274,9 @@ export default function LeaderboardCard() {
                         >
                           <FaTv />
                           <span>Watch</span>
-                          <span className="text-green-500">{watchCounts[u.currentTableId] || 0}</span>
+                          <span className="text-green-500">
+                            {watchCounts[u.currentTableId] || 0}
+                          </span>
                         </button>
                       </div>
                     )}
@@ -270,7 +291,9 @@ export default function LeaderboardCard() {
                   <td className="p-2">{rank}</td>
                   <td className="p-2 w-14 relative">
                     <img
-                      src={getAvatarUrl(myPhotoUrl || '/assets/icons/profile.svg')}
+                      src={getAvatarUrl(
+                        myPhotoUrl || '/assets/icons/profile.svg'
+                      )}
                       alt="avatar"
                       className="w-14 h-14 hexagon border-2 border-brand-gold object-cover shadow-[0_0_12px_rgba(241,196,15,0.8)]"
                     />
@@ -283,7 +306,9 @@ export default function LeaderboardCard() {
                       )}
                     </div>
                     {(() => {
-                      const myTable = leaderboard.find((u) => u.accountId === accountId)?.currentTableId;
+                      const myTable = leaderboard.find(
+                        (u) => u.accountId === accountId
+                      )?.currentTableId;
                       if (!aiPlaying && !myTable) return null;
                       return (
                         <div className="flex items-center mt-1 text-xs space-x-1">
@@ -299,7 +324,9 @@ export default function LeaderboardCard() {
                             >
                               <FaTv />
                               <span>Watch</span>
-                              <span className="text-green-500">{watchCounts[myTable] || 0}</span>
+                              <span className="text-green-500">
+                                {watchCounts[myTable] || 0}
+                              </span>
                             </button>
                           )}
                         </div>
@@ -307,7 +334,10 @@ export default function LeaderboardCard() {
                     })()}
                   </td>
                   <td className="p-2 text-right flex items-center justify-end space-x-1">
-                    <span>{leaderboard.find((u) => u.accountId === accountId)?.balance ?? '...'}</span>
+                    <span>
+                      {leaderboard.find((u) => u.accountId === accountId)
+                        ?.balance ?? '...'}
+                    </span>
                   </td>
                 </tr>
               )}
@@ -335,7 +365,7 @@ export default function LeaderboardCard() {
                 roomId,
                 game,
                 token: stake.token,
-                amount: stake.amount,
+                amount: stake.amount
               },
               (res) => {
                 if (res && res.success) {
@@ -352,11 +382,19 @@ export default function LeaderboardCard() {
       />
       <InvitePopup
         open={groupPopup}
-        name={selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim())}
+        name={selected.map(
+          (u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim()
+        )}
         stake={stake}
         onStakeChange={setStake}
         group
-        opponents={selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim())}
+        opponents={selected.map(
+          (u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim()
+        )}
+        onClose={() => {
+          setGroupPopup(false);
+          setSelected([]);
+        }}
         onAccept={(game) => {
           if (selected.length > 0) {
             const roomId = `invite-${accountId}-${Date.now()}-${selected.length + 1}`;
@@ -368,11 +406,15 @@ export default function LeaderboardCard() {
                 fromName: myName,
                 toIds: selected.map((u) => u.accountId),
                 telegramIds: selected.map((u) => u.telegramId),
-                opponentNames: selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim()),
+                opponentNames: selected.map(
+                  (u) =>
+                    u.nickname ||
+                    `${u.firstName || ''} ${u.lastName || ''}`.trim()
+                ),
                 roomId,
                 game,
                 token: stake.token,
-                amount: stake.amount,
+                amount: stake.amount
               },
               (res) => {
                 if (res && res.success) {

--- a/webapp/src/components/PlayerPopup.jsx
+++ b/webapp/src/components/PlayerPopup.jsx
@@ -22,10 +22,20 @@ export default function PlayerPopup({ open, onClose, player }) {
       onClick={onClose}
     >
       <div
-        className="bg-surface border border-border rounded p-4 space-y-2 w-60"
+        className="bg-surface border border-border rounded p-4 space-y-2 w-60 relative"
         onClick={(e) => e.stopPropagation()}
       >
-        <img src={player.photoUrl} alt="user" className="w-20 h-20 rounded-full mx-auto" />
+        <button
+          onClick={onClose}
+          className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"
+        >
+          &times;
+        </button>
+        <img
+          src={player.photoUrl}
+          alt="user"
+          className="w-20 h-20 rounded-full mx-auto"
+        />
         <p className="text-center font-semibold">{player.name}</p>
         <div className="flex space-x-2">
           <button
@@ -42,8 +52,12 @@ export default function PlayerPopup({ open, onClose, player }) {
           </button>
         </div>
       </div>
-      <GiftPopup open={giftOpen} onClose={() => setGiftOpen(false)} recipient={player} />
+      <GiftPopup
+        open={giftOpen}
+        onClose={() => setGiftOpen(false)}
+        recipient={player}
+      />
     </div>,
-    document.body,
+    document.body
   );
 }

--- a/webapp/src/components/QuickMessagePopup.jsx
+++ b/webapp/src/components/QuickMessagePopup.jsx
@@ -15,7 +15,7 @@ const MESSAGES = [
   'Yay! 🎉',
   'This is fun 🤩',
   "I'm lost 🤯",
-  'Great comeback 🏆',
+  'Great comeback 🏆'
 ];
 
 export default function QuickMessagePopup({ open, onClose, onSend }) {
@@ -27,9 +27,15 @@ export default function QuickMessagePopup({ open, onClose, onSend }) {
       onClick={onClose}
     >
       <div
-        className="bg-surface border border-border rounded p-4 space-y-2 w-64"
+        className="bg-surface border border-border rounded p-4 space-y-2 w-64 relative"
         onClick={(e) => e.stopPropagation()}
       >
+        <button
+          onClick={onClose}
+          className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"
+        >
+          &times;
+        </button>
         <div className="grid grid-cols-2 gap-1 max-h-40 overflow-y-auto">
           {MESSAGES.map((m) => (
             <button
@@ -54,6 +60,6 @@ export default function QuickMessagePopup({ open, onClose, onSend }) {
         </button>
       </div>
     </div>,
-    document.body,
+    document.body
   );
 }

--- a/webapp/src/components/RoomPopup.jsx
+++ b/webapp/src/components/RoomPopup.jsx
@@ -7,26 +7,39 @@ export default function RoomPopup({
   selection,
   setSelection,
   onConfirm,
+  onClose,
   tables,
   selectedTable,
-  setSelectedTable,
+  setSelectedTable
 }) {
   if (!open) return null;
 
   const disabled =
-    !selection || !selection.token || !selection.amount || (tables && !selectedTable);
+    !selection ||
+    !selection.token ||
+    !selection.amount ||
+    (tables && !selectedTable);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
-      <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
+      <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80 relative">
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"
+          >
+            &times;
+          </button>
+        )}
         <img
-
           src="/assets/icons/TonPlayGramLogo.webp"
           alt="TonPlaygram Logo"
           className="w-10 h-10 mx-auto"
         />
         <h3 className="text-lg font-bold text-center">Join a Room</h3>
-        <p className="text-sm text-subtext text-center">Choose your token and amount</p>
+        <p className="text-sm text-subtext text-center">
+          Choose your token and amount
+        </p>
         {tables && (
           <TableSelector
             tables={tables}

--- a/webapp/src/components/TablePopup.jsx
+++ b/webapp/src/components/TablePopup.jsx
@@ -1,13 +1,20 @@
 import React from 'react';
 import TableSelector from './TableSelector.jsx';
 
-export default function TablePopup({ open, tables, onSelect }) {
+export default function TablePopup({ open, tables, onSelect, onClose }) {
   if (!open) return null;
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
-      <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
+      <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80 relative">
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"
+          >
+            &times;
+          </button>
+        )}
         <img
-
           src="/assets/icons/TonPlayGramLogo.webp"
           alt="TonPlaygram Logo"
           className="w-10 h-10 mx-auto"

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -1,10 +1,4 @@
-import {
-  useState,
-  useMemo,
-  useEffect,
-  useRef,
-  useCallback,
-} from 'react';
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import DiceRoller from '../../components/DiceRoller.jsx';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
@@ -13,12 +7,12 @@ import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
 import GiftPopup from '../../components/GiftPopup.jsx';
 import GameEndPopup from '../../components/GameEndPopup.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
-import {
-  loadAvatar,
-  avatarToName,
-} from '../../utils/avatarUtils.js';
+import { loadAvatar, avatarToName } from '../../utils/avatarUtils.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
-import { LEADER_AVATARS, LEADER_PHOTO_AVATARS } from '../../utils/leaderAvatars.js';
+import {
+  LEADER_AVATARS,
+  LEADER_PHOTO_AVATARS
+} from '../../utils/leaderAvatars.js';
 import { chatBeep, timerBeep } from '../../assets/soundData.js';
 import { getGameVolume, isGameMuted } from '../../utils/sound.js';
 import { giftSounds } from '../../utils/giftSounds.js';
@@ -38,28 +32,28 @@ async function awardDevShare(total) {
     if (DEV_ACCOUNT) {
       promises.push(
         depositAccount(DEV_ACCOUNT, Math.round(total * 0.09), {
-          game: 'crazydice-dev',
+          game: 'crazydice-dev'
         })
       );
     }
     if (DEV_ACCOUNT_1) {
       promises.push(
         depositAccount(DEV_ACCOUNT_1, Math.round(total * 0.01), {
-          game: 'crazydice-dev1',
+          game: 'crazydice-dev1'
         })
       );
     }
     if (DEV_ACCOUNT_2) {
       promises.push(
         depositAccount(DEV_ACCOUNT_2, Math.round(total * 0.02), {
-          game: 'crazydice-dev2',
+          game: 'crazydice-dev2'
         })
       );
     }
   } else if (DEV_ACCOUNT) {
     promises.push(
       depositAccount(DEV_ACCOUNT, Math.round(total * 0.1), {
-        game: 'crazydice-dev',
+        game: 'crazydice-dev'
       })
     );
   }
@@ -83,15 +77,20 @@ export default function CrazyDiceDuel() {
   const avatarType = searchParams.get('avatars') || 'flags';
   const selectedLeadersParam = searchParams.get('leaders');
   const selectedLeaders = selectedLeadersParam
-    ? selectedLeadersParam.split(',').map((n) => LEADER_AVATARS[parseInt(n)]).filter(Boolean)
+    ? selectedLeadersParam
+        .split(',')
+        .map((n) => LEADER_AVATARS[parseInt(n)])
+        .filter(Boolean)
     : null;
   const selectedFlagsParam = searchParams.get('flags');
   const selectedFlags = selectedFlagsParam
-    ? selectedFlagsParam.split(',').map((n) => FLAG_EMOJIS[parseInt(n)]).filter(Boolean)
+    ? selectedFlagsParam
+        .split(',')
+        .map((n) => FLAG_EMOJIS[parseInt(n)])
+        .filter(Boolean)
     : null;
-  const playerCount = aiCount > 0
-    ? aiCount + 1
-    : parseInt(searchParams.get('players')) || 2;
+  const playerCount =
+    aiCount > 0 ? aiCount + 1 : parseInt(searchParams.get('players')) || 2;
   const maxRolls = parseInt(searchParams.get('rolls')) || 1;
   const token = searchParams.get('token') || 'TPC';
   const amount = Number(searchParams.get('amount')) || 0;
@@ -100,8 +99,8 @@ export default function CrazyDiceDuel() {
     ensureAccountId().catch(() => {});
   }, []);
 
-  const [bgUnlocked, setBgUnlocked] = useState(() =>
-    localStorage.getItem('crazyDiceBgUnlocked') === 'true',
+  const [bgUnlocked, setBgUnlocked] = useState(
+    () => localStorage.getItem('crazyDiceBgUnlocked') === 'true'
   );
 
   const unlockBackground = () => {
@@ -118,7 +117,8 @@ export default function CrazyDiceDuel() {
     if (selectedLeaders && selectedLeaders.length) {
       uniqueLeaders = selectedLeaders.slice(0, playerCount - 1);
       while (uniqueLeaders.length < playerCount - 1) {
-        const rand = LEADER_AVATARS[Math.floor(Math.random() * LEADER_AVATARS.length)];
+        const rand =
+          LEADER_AVATARS[Math.floor(Math.random() * LEADER_AVATARS.length)];
         if (!uniqueLeaders.includes(rand)) uniqueLeaders.push(rand);
       }
       uniquePhotos = uniqueLeaders.map((p) => p.replace('.webp', '.jpg'));
@@ -132,7 +132,7 @@ export default function CrazyDiceDuel() {
       uniqueLeaders = [
         '/assets/icons/UsaLeader.webp',
         '/assets/icons/RussiaLeader.webp',
-        '/assets/icons/ChinaLeader.webp',
+        '/assets/icons/ChinaLeader.webp'
       ];
       uniquePhotos = uniqueLeaders.map((p) => p.replace('.webp', '.jpg'));
     } else {
@@ -155,13 +155,19 @@ export default function CrazyDiceDuel() {
             : aiCount > 0
               ? avatarType === 'leaders'
                 ? uniqueLeaders[i - 1]
-                : (selectedFlags && selectedFlags[i - 1])
+                : selectedFlags && selectedFlags[i - 1]
                   ? selectedFlags[i - 1]
                   : randFlag()
               : `/assets/avatars/avatar${(i % 5) + 1}.svg`,
-      color: COLORS[i % COLORS.length],
+      color: COLORS[i % COLORS.length]
     }));
-  }, [playerCount, aiCount, avatarType, selectedLeadersParam, selectedFlagsParam]);
+  }, [
+    playerCount,
+    aiCount,
+    avatarType,
+    selectedLeadersParam,
+    selectedFlagsParam
+  ]);
 
   const [players, setPlayers] = useState(initialPlayers);
   const [current, setCurrent] = useState(0);
@@ -179,11 +185,11 @@ export default function CrazyDiceDuel() {
               : aiCount > 0
                 ? avatarToName(p.photoUrl) || `AI ${i}`
                 : `P${i + 1}`,
-          score: p.score,
+          score: p.score
         }))
         .sort((a, b) => b.score - a.score)
         .map((p) => p.name),
-    [players, aiCount],
+    [players, aiCount]
   );
   const [showChat, setShowChat] = useState(false);
   const [showGift, setShowGift] = useState(false);
@@ -212,10 +218,17 @@ export default function CrazyDiceDuel() {
     // Backgrounds were renamed in a recent update
     2: '/assets/icons/file_00000000c9bc61f5825aa75d64fe234a.webp', // 1v1
     3: '/assets/icons/file_000000008b1061f68f37fd941a1efcb4.webp', // vs 2 others
-    4: '/assets/icons/file_000000003a9c622f8e50bd5d8f381471.webp', // vs 3 others
+    4: '/assets/icons/file_000000003a9c622f8e50bd5d8f381471.webp' // vs 3 others
   };
   const boardBgSrc = BG_BY_PLAYERS[playerCount] || BG_BY_PLAYERS[4];
-  const boardClass = playerCount === 4 ? "four-players" : playerCount === 3 ? "three-players" : playerCount === 2 ? "two-players" : "";
+  const boardClass =
+    playerCount === 4
+      ? 'four-players'
+      : playerCount === 3
+        ? 'three-players'
+        : playerCount === 2
+          ? 'two-players'
+          : '';
 
   const boardRef = useRef(null);
   const diceRef = useRef(null);
@@ -249,13 +262,13 @@ export default function CrazyDiceDuel() {
     const row = parseInt(label.slice(1), 10) - 1;
     return {
       left: `${((col + 0.5) / GRID_COLS) * 100}%`,
-      top: `${((row + 0.5) / GRID_ROWS) * 100}%`,
+      top: `${((row + 0.5) / GRID_ROWS) * 100}%`
     };
   };
 
   const gridPoint = (col, row) => ({
     left: `${(col / GRID_COLS) * 100}%`,
-    top: `${(row / GRID_ROWS) * 100}%`,
+    top: `${(row / GRID_ROWS) * 100}%`
   });
 
   useEffect(() => {
@@ -263,8 +276,6 @@ export default function CrazyDiceDuel() {
     timerSoundRef.current.volume = getGameVolume();
     return () => timerSoundRef.current?.pause();
   }, []);
-
-
 
   useEffect(() => {
     const handler = () => setMuted(isGameMuted());
@@ -285,27 +296,27 @@ export default function CrazyDiceDuel() {
       const cellH = board.height / GRID_ROWS;
       const center = (c, r) => ({
         left: board.left + cellW * (c + 0.5),
-        top: board.top + cellH * (r + 0.5),
+        top: board.top + cellH * (r + 0.5)
       });
       setTlScoreStyle({
         position: 'fixed',
         transform: 'translate(-50%, -50%)',
-        ...center(2, 10), // top left score (same as 4 players)
+        ...center(2, 10) // top left score (same as 4 players)
       });
       setTlHistoryStyle({
         position: 'fixed',
         transform: 'translate(-50%, -50%)',
-        ...center(0.5, 11), // top left history (same as 4 players)
+        ...center(0.5, 11) // top left history (same as 4 players)
       });
       setTrScoreStyle({
         position: 'fixed',
         transform: 'translate(-50%, -50%)',
-        ...center(16.5, 10), // top right score (same as 4 players)
+        ...center(16.5, 10) // top right score (same as 4 players)
       });
       setTrHistoryStyle({
         position: 'fixed',
         transform: 'translate(-50%, -50%)',
-        ...center(15, 11), // top right history (same as 4 players)
+        ...center(15, 11) // top right history (same as 4 players)
       });
     };
     update();
@@ -322,23 +333,47 @@ export default function CrazyDiceDuel() {
       const cellH = board.height / GRID_ROWS;
       const center = (c, r) => ({
         left: board.left + cellW * (c + 0.5),
-        top: board.top + cellH * (r + 0.5),
+        top: board.top + cellH * (r + 0.5)
       });
       setP4ScoreStyles([
         // Top left opponent score aligned with center
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(2, 10) },
+        {
+          position: 'fixed',
+          transform: 'translate(-50%, -50%)',
+          ...center(2, 10)
+        },
         // Top middle opponent score just below avatar
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(9.5, 10) },
+        {
+          position: 'fixed',
+          transform: 'translate(-50%, -50%)',
+          ...center(9.5, 10)
+        },
         // Top right opponent score aligned with center
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(16.5, 10) },
+        {
+          position: 'fixed',
+          transform: 'translate(-50%, -50%)',
+          ...center(16.5, 10)
+        }
       ]);
       setP4HistoryStyles([
         // Roll boxes for top left player
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(0.5, 11) },
+        {
+          position: 'fixed',
+          transform: 'translate(-50%, -50%)',
+          ...center(0.5, 11)
+        },
         // Roll boxes for top middle player
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(8, 11) },
+        {
+          position: 'fixed',
+          transform: 'translate(-50%, -50%)',
+          ...center(8, 11)
+        },
         // Roll boxes for top right player
-        { position: 'fixed', transform: 'translate(-50%, -50%)', ...center(15, 11) },
+        {
+          position: 'fixed',
+          transform: 'translate(-50%, -50%)',
+          ...center(15, 11)
+        }
       ]);
     };
     update();
@@ -391,35 +426,32 @@ export default function CrazyDiceDuel() {
   }, [current, aiCount, muted]);
 
   const getDiceCenter = (playerIdx = 'center') => {
-      const posMap = {
-        // Bottom player dice position
-        0:
-          playerCount === 2
+    const posMap = {
+      // Bottom player dice position
+      0:
+        playerCount === 2
+          ? { label: 'J28' }
+          : playerCount === 3
             ? { label: 'J28' }
-            : playerCount === 3
-              ? { label: 'J28' }
-              : { label: 'J28' },
-        // Top left player position when playing vs two others
-        1:
-          playerCount === 2
-            ? { label: 'J16' }
-            : playerCount === 3
-              ? { label: 'C14' }
-              : { label: 'C14' },
-        // Top right player position for three player games
-        2:
-          playerCount === 3
-            ? { label: 'R14' }
-            : { label: 'K20' },
-        3: { label: 'R14' },
-        // Dice roll animation centre: adjust for player count
-        center:
-          playerCount === 2
-            ? { label: 'J22' }
-            : playerCount === 3
-              ? { label: 'J20' }
-              : { label: 'J20' },
-      };
+            : { label: 'J28' },
+      // Top left player position when playing vs two others
+      1:
+        playerCount === 2
+          ? { label: 'J16' }
+          : playerCount === 3
+            ? { label: 'C14' }
+            : { label: 'C14' },
+      // Top right player position for three player games
+      2: playerCount === 3 ? { label: 'R14' } : { label: 'K20' },
+      3: { label: 'R14' },
+      // Dice roll animation centre: adjust for player count
+      center:
+        playerCount === 2
+          ? { label: 'J22' }
+          : playerCount === 3
+            ? { label: 'J20' }
+            : { label: 'J20' }
+    };
     if (typeof playerIdx === 'string' && /^[A-Za-z][0-9]+$/.test(playerIdx)) {
       const label = playerIdx.toUpperCase();
       if (boardRef.current) {
@@ -430,7 +462,7 @@ export default function CrazyDiceDuel() {
         const cellH = board.height / GRID_ROWS;
         return {
           cx: board.left + cellW * (col + 0.5),
-          cy: board.top + cellH * (row + 0.5),
+          cy: board.top + cellH * (row + 0.5)
         };
       }
     }
@@ -445,13 +477,13 @@ export default function CrazyDiceDuel() {
       const cellH = board.height / GRID_ROWS;
       return {
         cx: board.left + cellW * (col + 0.5 + dx),
-        cy: board.top + cellH * (row + 0.5),
+        cy: board.top + cellH * (row + 0.5)
       };
     }
     const rect = diceCenterRef.current?.getBoundingClientRect();
     return {
       cx: rect ? rect.left + rect.width / 2 : window.innerWidth / 2,
-      cy: rect ? rect.top + rect.height / 2 : window.innerHeight / 2,
+      cy: rect ? rect.top + rect.height / 2 : window.innerHeight / 2
     };
   };
 
@@ -465,7 +497,7 @@ export default function CrazyDiceDuel() {
         top: '0px',
         transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(${DICE_CENTER_SCALE})`,
         pointerEvents: 'none',
-        zIndex: 50,
+        zIndex: 50
       });
       return;
     }
@@ -477,7 +509,7 @@ export default function CrazyDiceDuel() {
       top: '0px',
       transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(${DICE_PLAYER_SCALE})`,
       pointerEvents: 'none',
-      zIndex: 50,
+      zIndex: 50
     });
   };
 
@@ -494,10 +526,14 @@ export default function CrazyDiceDuel() {
     dice.style.zIndex = '50';
     dice.animate(
       [
-        { transform: `translate(${startX}px, ${startY}px) translate(-50%, -50%) scale(${DICE_PLAYER_SCALE})` },
-        { transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(${DICE_CENTER_SCALE})` },
+        {
+          transform: `translate(${startX}px, ${startY}px) translate(-50%, -50%) scale(${DICE_PLAYER_SCALE})`
+        },
+        {
+          transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(${DICE_CENTER_SCALE})`
+        }
       ],
-      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' },
+      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' }
     ).onfinish = () => {
       setDiceStyle({
         display: 'block',
@@ -506,7 +542,7 @@ export default function CrazyDiceDuel() {
         top: '0px',
         transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(${DICE_CENTER_SCALE})`,
         pointerEvents: 'none',
-        zIndex: 50,
+        zIndex: 50
       });
     };
   };
@@ -518,10 +554,14 @@ export default function CrazyDiceDuel() {
     const { cx: endX, cy: endY } = getDiceCenter(idx);
     dice.animate(
       [
-        { transform: `translate(${startX}px, ${startY}px) translate(-50%, -50%) scale(${DICE_CENTER_SCALE})` },
-        { transform: `translate(${endX}px, ${endY}px) translate(-50%, -50%) scale(${DICE_PLAYER_SCALE})` },
+        {
+          transform: `translate(${startX}px, ${startY}px) translate(-50%, -50%) scale(${DICE_CENTER_SCALE})`
+        },
+        {
+          transform: `translate(${endX}px, ${endY}px) translate(-50%, -50%) scale(${DICE_PLAYER_SCALE})`
+        }
       ],
-      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' },
+      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' }
     ).onfinish = () => {
       setDiceStyle({ display: 'none' });
     };
@@ -534,10 +574,14 @@ export default function CrazyDiceDuel() {
     const { cx: endX, cy: endY } = getDiceCenter(label);
     dice.animate(
       [
-        { transform: `translate(${startX}px, ${startY}px) translate(-50%, -50%) scale(${DICE_CENTER_SCALE})` },
-        { transform: `translate(${endX}px, ${endY}px) translate(-50%, -50%) scale(${endScale})` },
+        {
+          transform: `translate(${startX}px, ${startY}px) translate(-50%, -50%) scale(${DICE_CENTER_SCALE})`
+        },
+        {
+          transform: `translate(${endX}px, ${endY}px) translate(-50%, -50%) scale(${endScale})`
+        }
       ],
-      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' },
+      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' }
     ).onfinish = () => {
       setDiceStyle({ display: 'none' });
     };
@@ -560,7 +604,9 @@ export default function CrazyDiceDuel() {
   };
 
   const handleRollEnd = (values) => {
-    const value = Array.isArray(values) ? values.reduce((a, b) => a + b, 0) : values;
+    const value = Array.isArray(values)
+      ? values.reduce((a, b) => a + b, 0)
+      : values;
     let nextIndex = current;
     setPlayers((prev) => {
       const updated = prev.map((p, idx) =>
@@ -569,13 +615,16 @@ export default function CrazyDiceDuel() {
               ...p,
               score: p.score + value,
               rolls: p.rolls + 1,
-              results: [...p.results, value],
+              results: [...p.results, value]
             }
           : p
       );
       nextIndex = (current + 1) % updated.length;
       let attempts = 0;
-      while (updated[nextIndex].rolls >= maxRolls && attempts < updated.length) {
+      while (
+        updated[nextIndex].rolls >= maxRolls &&
+        attempts < updated.length
+      ) {
         nextIndex = (nextIndex + 1) % updated.length;
         attempts += 1;
       }
@@ -601,9 +650,6 @@ export default function CrazyDiceDuel() {
     }
   };
 
-
-
-
   const allRolled = players.every((p) => p.rolls >= maxRolls);
 
   useEffect(() => {
@@ -615,7 +661,9 @@ export default function CrazyDiceDuel() {
       } else {
         // tie break
         setTiePlayers(leaders.map((p) => players.indexOf(p)));
-        setPlayers((prev) => prev.map((p) => ({ ...p, rolls: 0, results: [] })));
+        setPlayers((prev) =>
+          prev.map((p) => ({ ...p, rolls: 0, results: [] }))
+        );
       }
       setCurrent(0);
     }
@@ -628,7 +676,9 @@ export default function CrazyDiceDuel() {
       if (leaders.length === 1) {
         setWinner(players.indexOf(leaders[0]));
       } else {
-        setPlayers((prev) => prev.map((p) => ({ ...p, rolls: 0, results: [] })));
+        setPlayers((prev) =>
+          prev.map((p) => ({ ...p, rolls: 0, results: [] }))
+        );
       }
       setCurrent(0);
     }
@@ -645,13 +695,13 @@ export default function CrazyDiceDuel() {
           const winAmt = Math.round(total * 0.91);
           await Promise.all([
             depositAccount(aid, winAmt, { game: 'crazydice-win' }),
-            awardDevShare(total),
+            awardDevShare(total)
           ]);
           const tgId = getTelegramId();
           addTransaction(tgId, 0, 'win', {
             game: 'crazydice',
             players: playerCount,
-            accountId: aid,
+            accountId: aid
           });
         } catch {}
       } else {
@@ -665,8 +715,6 @@ export default function CrazyDiceDuel() {
     return () => clearTimeout(trailTimeoutRef.current);
   }, []);
 
-
-
   return (
     <div className="text-text relative">
       {bgUnlocked && (
@@ -679,305 +727,322 @@ export default function CrazyDiceDuel() {
           }}
         />
       )}
-        <div
-          ref={boardRef}
-          className={`crazy-dice-board ${boardClass}`}
-        >
-      {!bgUnlocked && (
-        <button
-          onClick={unlockBackground}
-          className="absolute top-2 right-2 z-20 px-2 py-1 text-sm bg-primary hover:bg-primary-hover text-background rounded"
-        >
-          Unlock Background
-        </button>
-      )}
-      <img src={boardBgSrc} alt="board" className="board-bg" />
-      <div ref={diceCenterRef} className="dice-center" />
-      <div ref={diceRef} style={diceStyle} className="dice-travel flex flex-col items-center relative">
-        {showTrail && (
-          <img
-            src="/assets/icons/file_00000000926061f590feca40199ee88d.webp"
-            alt=""
-            className="dice-trail-img"
-          />
-        )}
-        {rollResult !== null && (
-          <div className="text-6xl roll-result">{rollResult}</div>
-        )}
-        {winner == null ? (
-          <div className="crazy-dice">
-            <DiceRoller
-              onRollEnd={handleRollEnd}
-              onRollStart={handleRollStart}
-              trigger={trigger}
-              clickable={aiCount === 0 || current === 0}
-              showButton={aiCount === 0 || current === 0}
-            />
-          </div>
-        ) : (
-          <div className="text-2xl font-bold text-center">
-            Player {winner + 1} wins!
-          </div>
-        )}
-      </div>
-      <div
-        className="player-bottom z-10"
-        style={{
-          bottom: 'auto',
-          /* Raise the bottom player slightly when facing two opponents */
-          ...gridPoint(
-            10,
-            playerCount === 3
-              ? 25.5
-              : playerCount === 4
-                ? 26
-                : 26.5,
-          ),
-          transform: 'translate(-50%, -50%)',
-        }}
-      >
-        {showPrompt && (
+      <div ref={boardRef} className={`crazy-dice-board ${boardClass}`}>
+        {!bgUnlocked && (
           <button
-            className="your-turn-message"
-            style={{ color: players[0].color }}
-            onClick={rollNow}
+            onClick={unlockBackground}
+            className="absolute top-2 right-2 z-20 px-2 py-1 text-sm bg-primary hover:bg-primary-hover text-background rounded"
           >
-            🫵 you're turn
+            Unlock Background
           </button>
         )}
-        <AvatarTimer
-          index={0}
-          photoUrl={players[0].photoUrl}
-          active={current === 0}
-          isTurn={current === 0}
-          timerPct={current === 0 ? timeLeft / 15 : 1}
-          name="You"
-          score={players[0].score}
-          rollHistory={players[0].results}
-          maxRolls={maxRolls}
-          color={players[0].color}
-          size={
-            playerCount === 3 ? 1.2 : playerCount > 3 ? 1.1 : 1
-          }
-          imageScale={leaders.includes(0) ? 1.1 : 1}
-          imageYOffset={0}
-          imageZoom={1}
-          nameCurveRadius={playerCount === 2 ? 50 : 45}
-          onClick={rollNow}
-        />
-      </div>
-      {players.slice(1).map((p, i) => {
-        const positions =
-          playerCount === 3
-            ? ['player-left', 'player-right']
-            : playerCount === 2
-              ? ['player-center']
-              : ['player-left', 'player-center', 'player-right'];
-        const pos = positions[i] || '';
-        let wrapperStyle = undefined;
-        let scoreStyle = undefined;
-        let historyStyle = undefined;
-        if (playerCount === 4) {
-          if (i === 0) {
-            /* Top left opponent slightly lower and larger */
-            const pos = gridPoint(2.3, 6.6);
-            wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
-          } else if (i === 1) {
-            /* Top middle opponent moved slightly down */
-            const pos = gridPoint(10, 6.5);
-            wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
-          } else if (i === 2) {
-            /* Top right opponent slightly lower */
-            const pos = gridPoint(17.7, 6.6);
-            wrapperStyle = { top: pos.top, right: `${100 - parseFloat(pos.left)}%` };
-          }
-          scoreStyle = undefined;
-          historyStyle = undefined;
-        } else if (playerCount === 2) {
-          // In 1v1 mode place history and score near the bottom of the board
-          scoreStyle = {
-            position: 'fixed',
-            left: '50%',
-            bottom: '4rem',
-            transform: 'translateX(-50%)',
-          };
-          historyStyle = {
-            position: 'fixed',
-            left: '50%',
-            bottom: '2rem',
-            transform: 'translateX(-50%)',
-          };
-        }
-        let avatarSize =
-          playerCount === 2
-            ? 2
-            : playerCount === 3
-              ? 1.2
-              : playerCount === 4
-                ? 1.3
-                : playerCount > 4
-                  ? 1.05
-                  : 1;
-
-        if (playerCount === 3) {
-          if (i === 0) {
-            // Move the top left opponent slightly right and enlarge
-            wrapperStyle = { ...gridPoint(3.6, 5.8), right: 'auto' };
-            avatarSize = 1.45;
-          } else if (i === 1) {
-            // Lower the top right opponent a bit
-            wrapperStyle = { ...gridPoint(13.2, 6.7), right: 'auto' };
-            avatarSize = 1.35;
-          }
-        }
-        return (
-          <div key={i + 1} className={`${pos} z-10`} style={wrapperStyle}>
-            <AvatarTimer
-              index={i + 1}
-              photoUrl={p.photoUrl}
-              active={current === i + 1}
-              isTurn={current === i + 1}
-              timerPct={current === i + 1 ? timeLeft / 2.5 : 1}
-              name={
-                aiCount > 0
-                  ? avatarToName(p.photoUrl) || `AI ${i + 1}`
-                  : `P${i + 2}`
-              }
-              score={p.score}
-              rollHistory={p.results}
-              maxRolls={maxRolls}
-              color={p.color}
-              scoreStyle={scoreStyle}
-              rollHistoryStyle={historyStyle}
-              size={avatarSize}
-              imageScale={leaders.includes(i + 1) ? 1.1 : 1}
-              imageYOffset={playerCount === 2 ? 4 : 0}
-              imageZoom={1}
-              nameCurveRadius={playerCount === 2 ? 50 : 45}
-              onClick={() => {
-                if (current === i + 1) setTrigger((t) => t + 1);
-              }}
+        <img src={boardBgSrc} alt="board" className="board-bg" />
+        <div ref={diceCenterRef} className="dice-center" />
+        <div
+          ref={diceRef}
+          style={diceStyle}
+          className="dice-travel flex flex-col items-center relative"
+        >
+          {showTrail && (
+            <img
+              src="/assets/icons/file_00000000926061f590feca40199ee88d.webp"
+              alt=""
+              className="dice-trail-img"
             />
-          </div>
-        );
-      })}
-      {chatBubbles.map((b) => (
-        <div key={b.id} className="chat-bubble">
-          <span>{b.text}</span>
-          <img src={b.photoUrl} className="w-6 h-6 rounded-full" />
+          )}
+          {rollResult !== null && (
+            <div className="text-6xl roll-result">{rollResult}</div>
+          )}
+          {winner == null ? (
+            <div className="crazy-dice">
+              <DiceRoller
+                onRollEnd={handleRollEnd}
+                onRollStart={handleRollStart}
+                trigger={trigger}
+                clickable={aiCount === 0 || current === 0}
+                showButton={aiCount === 0 || current === 0}
+              />
+            </div>
+          ) : (
+            <div className="text-2xl font-bold text-center">
+              Player {winner + 1} wins!
+            </div>
+          )}
         </div>
-      ))}
-      {playerCount === 2 ? (
-        <>
+        <div
+          className="player-bottom z-10"
+          style={{
+            bottom: 'auto',
+            /* Raise the bottom player slightly when facing two opponents */
+            ...gridPoint(
+              10,
+              playerCount === 3 ? 25.5 : playerCount === 4 ? 26 : 26.5
+            ),
+            transform: 'translate(-50%, -50%)'
+          }}
+        >
+          {showPrompt && (
+            <button
+              className="your-turn-message"
+              style={{ color: players[0].color }}
+              onClick={rollNow}
+            >
+              🫵 you're turn
+            </button>
+          )}
+          <AvatarTimer
+            index={0}
+            photoUrl={players[0].photoUrl}
+            active={current === 0}
+            isTurn={current === 0}
+            timerPct={current === 0 ? timeLeft / 15 : 1}
+            name="You"
+            score={players[0].score}
+            rollHistory={players[0].results}
+            maxRolls={maxRolls}
+            color={players[0].color}
+            size={playerCount === 3 ? 1.2 : playerCount > 3 ? 1.1 : 1}
+            imageScale={leaders.includes(0) ? 1.1 : 1}
+            imageYOffset={0}
+            imageZoom={1}
+            nameCurveRadius={playerCount === 2 ? 50 : 45}
+            onClick={rollNow}
+          />
+        </div>
+        {players.slice(1).map((p, i) => {
+          const positions =
+            playerCount === 3
+              ? ['player-left', 'player-right']
+              : playerCount === 2
+                ? ['player-center']
+                : ['player-left', 'player-center', 'player-right'];
+          const pos = positions[i] || '';
+          let wrapperStyle = undefined;
+          let scoreStyle = undefined;
+          let historyStyle = undefined;
+          if (playerCount === 4) {
+            if (i === 0) {
+              /* Top left opponent slightly lower and larger */
+              const pos = gridPoint(2.3, 6.6);
+              wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
+            } else if (i === 1) {
+              /* Top middle opponent moved slightly down */
+              const pos = gridPoint(10, 6.5);
+              wrapperStyle = { left: pos.left, top: pos.top, right: 'auto' };
+            } else if (i === 2) {
+              /* Top right opponent slightly lower */
+              const pos = gridPoint(17.7, 6.6);
+              wrapperStyle = {
+                top: pos.top,
+                right: `${100 - parseFloat(pos.left)}%`
+              };
+            }
+            scoreStyle = undefined;
+            historyStyle = undefined;
+          } else if (playerCount === 2) {
+            // In 1v1 mode place history and score near the bottom of the board
+            scoreStyle = {
+              position: 'fixed',
+              left: '50%',
+              bottom: '4rem',
+              transform: 'translateX(-50%)'
+            };
+            historyStyle = {
+              position: 'fixed',
+              left: '50%',
+              bottom: '2rem',
+              transform: 'translateX(-50%)'
+            };
+          }
+          let avatarSize =
+            playerCount === 2
+              ? 2
+              : playerCount === 3
+                ? 1.2
+                : playerCount === 4
+                  ? 1.3
+                  : playerCount > 4
+                    ? 1.05
+                    : 1;
+
+          if (playerCount === 3) {
+            if (i === 0) {
+              // Move the top left opponent slightly right and enlarge
+              wrapperStyle = { ...gridPoint(3.6, 5.8), right: 'auto' };
+              avatarSize = 1.45;
+            } else if (i === 1) {
+              // Lower the top right opponent a bit
+              wrapperStyle = { ...gridPoint(13.2, 6.7), right: 'auto' };
+              avatarSize = 1.35;
+            }
+          }
+          return (
+            <div key={i + 1} className={`${pos} z-10`} style={wrapperStyle}>
+              <AvatarTimer
+                index={i + 1}
+                photoUrl={p.photoUrl}
+                active={current === i + 1}
+                isTurn={current === i + 1}
+                timerPct={current === i + 1 ? timeLeft / 2.5 : 1}
+                name={
+                  aiCount > 0
+                    ? avatarToName(p.photoUrl) || `AI ${i + 1}`
+                    : `P${i + 2}`
+                }
+                score={p.score}
+                rollHistory={p.results}
+                maxRolls={maxRolls}
+                color={p.color}
+                scoreStyle={scoreStyle}
+                rollHistoryStyle={historyStyle}
+                size={avatarSize}
+                imageScale={leaders.includes(i + 1) ? 1.1 : 1}
+                imageYOffset={playerCount === 2 ? 4 : 0}
+                imageZoom={1}
+                nameCurveRadius={playerCount === 2 ? 50 : 45}
+                onClick={() => {
+                  if (current === i + 1) setTrigger((t) => t + 1);
+                }}
+              />
+            </div>
+          );
+        })}
+        {chatBubbles.map((b) => (
+          <div key={b.id} className="chat-bubble">
+            <span>{b.text}</span>
+            <img src={b.photoUrl} className="w-6 h-6 rounded-full" />
+          </div>
+        ))}
+        {playerCount === 2 ? (
+          <>
+            <BottomLeftIcons
+              onInfo={() => {}}
+              className="fixed left-1 top-1 flex flex-col items-center space-y-2 z-20"
+            />
+            <BottomLeftIcons
+              onChat={() => setShowChat(true)}
+              onGift={() => setShowGift(true)}
+              className="fixed right-1 top-1 flex flex-col items-center space-y-2 z-20"
+              showInfo={false}
+              showMute={false}
+            />
+          </>
+        ) : (
           <BottomLeftIcons
             onInfo={() => {}}
-            className="fixed left-1 top-1 flex flex-col items-center space-y-2 z-20"
-          />
-          <BottomLeftIcons
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
-            className="fixed right-1 top-1 flex flex-col items-center space-y-2 z-20"
-            showInfo={false}
-            showMute={false}
           />
-        </>
-      ) : (
-        <BottomLeftIcons
-          onInfo={() => {}}
-          onChat={() => setShowChat(true)}
-          onGift={() => setShowGift(true)}
-        />
-      )}
-      <QuickMessagePopup
-        open={showChat}
-        onClose={() => setShowChat(false)}
-        onSend={(text) => {
-          const id = Date.now();
-          setChatBubbles((b) => [...b, { id, text, photoUrl: players[0].photoUrl }]);
-          if (!muted) {
-            const a = new Audio(chatBeep);
-            a.volume = getGameVolume();
-            a.play().catch(() => {});
-          }
-          setTimeout(() => setChatBubbles((b) => b.filter((bb) => bb.id !== id)), 3000);
-        }}
-      />
-      <GiftPopup
-        open={showGift}
-        onClose={() => setShowGift(false)}
-        players={players.map((p, i) => ({
-          ...p,
-          index: i,
-          name:
-            i === 0
-              ? 'You'
-              : aiCount > 0
-                ? avatarToName(p.photoUrl) || `AI ${i}`
-                : `P${i + 1}`,
-        }))}
-        senderIndex={0}
-        onGiftSent={({ from, to, gift }) => {
-          const start = document.querySelector(`[data-player-index="${from}"]`);
-          const end = document.querySelector(`[data-player-index="${to}"]`);
-          if (start && end) {
-            const s = start.getBoundingClientRect();
-            const e = end.getBoundingClientRect();
-            const cx = window.innerWidth / 2;
-            const cy = window.innerHeight / 2;
-            let icon;
-            if (typeof gift.icon === 'string' && gift.icon.match(/\.(png|jpg|jpeg|webp|svg)$/)) {
-              icon = document.createElement('img');
-              icon.src = gift.icon;
-              icon.className = 'w-6 h-6';
-            } else {
-              icon = document.createElement('div');
-              icon.textContent = gift.icon;
-              icon.style.fontSize = '24px';
-            }
-            icon.style.position = 'fixed';
-            icon.style.left = '0px';
-            icon.style.top = '0px';
-            icon.style.pointerEvents = 'none';
-            icon.style.transform = `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(1)`;
-            icon.style.zIndex = '9999';
-            document.body.appendChild(icon);
-            const giftSound = giftSounds[gift.id];
-            if (giftSound && !muted) {
-              const a = new Audio(giftSound);
+        )}
+        <QuickMessagePopup
+          open={showChat}
+          onClose={() => setShowChat(false)}
+          onSend={(text) => {
+            const id = Date.now();
+            setChatBubbles((b) => [
+              ...b,
+              { id, text, photoUrl: players[0].photoUrl }
+            ]);
+            if (!muted) {
+              const a = new Audio(chatBeep);
               a.volume = getGameVolume();
               a.play().catch(() => {});
             }
-            const animation = icon.animate(
-              [
-                { transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(1)` },
-                { transform: `translate(${cx}px, ${cy}px) scale(3)`, offset: 0.5 },
-                { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(1)` },
-              ],
-              { duration: 3500, easing: 'linear' },
+            setTimeout(
+              () => setChatBubbles((b) => b.filter((bb) => bb.id !== id)),
+              3000
             );
-            animation.onfinish = () => icon.remove();
-          }
-        }}
-      />
-      <GameEndPopup
-        open={winner != null}
-        ranking={ranking}
-        onPlayAgain={() => window.location.reload()}
-        onReturn={() => navigate('/games/crazydice/lobby')}
-      />
-      <InfoPopup
-        open={showQuitInfo}
-        onClose={() => setShowQuitInfo(false)}
-        title="Warning"
-        info="If you quit the game your funds will be lost and you will be placed last."
-        widthClass="w-80"
-      />
-      <ConfirmPopup
-        open={showLobbyConfirm}
-        message="Quit the game? If you leave, your funds will be lost and you'll be placed last."
-        onConfirm={() => navigate('/games/crazydice/lobby')}
-        onCancel={() => setShowLobbyConfirm(false)}
-      />
+          }}
+        />
+        <GiftPopup
+          open={showGift}
+          onClose={() => setShowGift(false)}
+          players={players.map((p, i) => ({
+            ...p,
+            index: i,
+            name:
+              i === 0
+                ? 'You'
+                : aiCount > 0
+                  ? avatarToName(p.photoUrl) || `AI ${i}`
+                  : `P${i + 1}`
+          }))}
+          senderIndex={0}
+          onGiftSent={({ from, to, gift }) => {
+            const start = document.querySelector(
+              `[data-player-index="${from}"]`
+            );
+            const end = document.querySelector(`[data-player-index="${to}"]`);
+            if (start && end) {
+              const s = start.getBoundingClientRect();
+              const e = end.getBoundingClientRect();
+              const cx = window.innerWidth / 2;
+              const cy = window.innerHeight / 2;
+              let icon;
+              if (
+                typeof gift.icon === 'string' &&
+                gift.icon.match(/\.(png|jpg|jpeg|webp|svg)$/)
+              ) {
+                icon = document.createElement('img');
+                icon.src = gift.icon;
+                icon.className = 'w-6 h-6';
+              } else {
+                icon = document.createElement('div');
+                icon.textContent = gift.icon;
+                icon.style.fontSize = '24px';
+              }
+              icon.style.position = 'fixed';
+              icon.style.left = '0px';
+              icon.style.top = '0px';
+              icon.style.pointerEvents = 'none';
+              icon.style.transform = `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(1)`;
+              icon.style.zIndex = '9999';
+              document.body.appendChild(icon);
+              const giftSound = giftSounds[gift.id];
+              if (giftSound && !muted) {
+                const a = new Audio(giftSound);
+                a.volume = getGameVolume();
+                a.play().catch(() => {});
+              }
+              const animation = icon.animate(
+                [
+                  {
+                    transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(1)`
+                  },
+                  {
+                    transform: `translate(${cx}px, ${cy}px) scale(3)`,
+                    offset: 0.5
+                  },
+                  {
+                    transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(1)`
+                  }
+                ],
+                { duration: 3500, easing: 'linear' }
+              );
+              animation.onfinish = () => icon.remove();
+            }
+          }}
+        />
+        <GameEndPopup
+          open={winner != null}
+          ranking={ranking}
+          onPlayAgain={() => window.location.reload()}
+          onReturn={() => navigate('/games/crazydice/lobby')}
+          onClose={() => setWinner(null)}
+        />
+        <InfoPopup
+          open={showQuitInfo}
+          onClose={() => setShowQuitInfo(false)}
+          title="Warning"
+          info="If you quit the game your funds will be lost and you will be placed last."
+          widthClass="w-80"
+        />
+        <ConfirmPopup
+          open={showLobbyConfirm}
+          message="Quit the game? If you leave, your funds will be lost and you'll be placed last."
+          onConfirm={() => navigate('/games/crazydice/lobby')}
+          onCancel={() => setShowLobbyConfirm(false)}
+        />
       </div>
     </div>
   );

--- a/webapp/src/pages/Games/HorseRacing.jsx
+++ b/webapp/src/pages/Games/HorseRacing.jsx
@@ -15,6 +15,7 @@ export default function HorseRacing() {
         selection={selection}
         setSelection={setSelection}
         onConfirm={() => setShowRoom(false)}
+        onClose={() => setShowRoom(false)}
       />
       <p>Horse racing game coming soon.</p>
     </div>

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -4,10 +4,10 @@ import {
   useRef,
   useLayoutEffect,
   Fragment,
-  useCallback,
-} from "react";
-import coinConfetti from "../../utils/coinConfetti";
-import DiceRoller from "../../components/DiceRoller.jsx";
+  useCallback
+} from 'react';
+import coinConfetti from '../../utils/coinConfetti';
+import DiceRoller from '../../components/DiceRoller.jsx';
 import {
   dropSound,
   snakeSound,
@@ -16,24 +16,30 @@ import {
   timerBeep,
   badLuckSound,
   cheerSound,
-  chatBeep,
-} from "../../assets/soundData.js";
-import { AVATARS } from "../../components/AvatarPickerModal.jsx";
-import { LEADER_AVATARS } from "../../utils/leaderAvatars.js";
-import { FLAG_EMOJIS } from "../../utils/flagEmojis.js";
-import { getAvatarUrl, saveAvatar, loadAvatar, avatarToName } from "../../utils/avatarUtils.js";
-import InfoPopup from "../../components/InfoPopup.jsx";
-import HintPopup from "../../components/HintPopup.jsx";
-import GameEndPopup from "../../components/GameEndPopup.jsx";
+  chatBeep
+} from '../../assets/soundData.js';
+import { AVATARS } from '../../components/AvatarPickerModal.jsx';
+import { LEADER_AVATARS } from '../../utils/leaderAvatars.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import {
-  AiOutlineRollback,
-  AiOutlineReload,
-} from "react-icons/ai";
-import BottomLeftIcons from "../../components/BottomLeftIcons.jsx";
-import { isGameMuted, getGameVolume } from "../../utils/sound.js";
-import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
-import { useNavigate } from "react-router-dom";
-import { getPlayerId, getTelegramId, ensureAccountId } from "../../utils/telegram.js";
+  getAvatarUrl,
+  saveAvatar,
+  loadAvatar,
+  avatarToName
+} from '../../utils/avatarUtils.js';
+import InfoPopup from '../../components/InfoPopup.jsx';
+import HintPopup from '../../components/HintPopup.jsx';
+import GameEndPopup from '../../components/GameEndPopup.jsx';
+import { AiOutlineRollback, AiOutlineReload } from 'react-icons/ai';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import { isGameMuted, getGameVolume } from '../../utils/sound.js';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { useNavigate } from 'react-router-dom';
+import {
+  getPlayerId,
+  getTelegramId,
+  ensureAccountId
+} from '../../utils/telegram.js';
 import {
   getProfileByAccount,
   depositAccount,
@@ -41,7 +47,7 @@ import {
   pingOnline,
   addTransaction,
   unseatTable
-} from "../../utils/api.js";
+} from '../../utils/api.js';
 // Developer accounts that receive shares of each pot
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -53,28 +59,28 @@ async function awardDevShare(total) {
     if (DEV_ACCOUNT) {
       promises.push(
         depositAccount(DEV_ACCOUNT, Math.round(total * 0.09), {
-          game: 'snake-dev',
+          game: 'snake-dev'
         })
       );
     }
     if (DEV_ACCOUNT_1) {
       promises.push(
         depositAccount(DEV_ACCOUNT_1, Math.round(total * 0.01), {
-          game: 'snake-dev1',
+          game: 'snake-dev1'
         })
       );
     }
     if (DEV_ACCOUNT_2) {
       promises.push(
         depositAccount(DEV_ACCOUNT_2, Math.round(total * 0.02), {
-          game: 'snake-dev2',
+          game: 'snake-dev2'
         })
       );
     }
   } else if (DEV_ACCOUNT) {
     promises.push(
       depositAccount(DEV_ACCOUNT, Math.round(total * 0.1), {
-        game: 'snake-dev',
+        game: 'snake-dev'
       })
     );
   }
@@ -86,21 +92,25 @@ async function awardDevShare(total) {
     }
   }
 }
-import { socket } from "../../utils/socket.js";
-import PlayerToken from "../../components/PlayerToken.jsx";
-import AvatarTimer from "../../components/AvatarTimer.jsx";
-import ConfirmPopup from "../../components/ConfirmPopup.jsx";
-import PlayerPopup from "../../components/PlayerPopup.jsx";
-import QuickMessagePopup from "../../components/QuickMessagePopup.jsx";
-import GiftPopup from "../../components/GiftPopup.jsx";
-import { giftSounds } from "../../utils/giftSounds.js";
-import { moveSeq, flashHighlight, applyEffect as applyEffectHelper } from "../../utils/moveHelpers.js";
+import { socket } from '../../utils/socket.js';
+import PlayerToken from '../../components/PlayerToken.jsx';
+import AvatarTimer from '../../components/AvatarTimer.jsx';
+import ConfirmPopup from '../../components/ConfirmPopup.jsx';
+import PlayerPopup from '../../components/PlayerPopup.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { giftSounds } from '../../utils/giftSounds.js';
+import {
+  moveSeq,
+  flashHighlight,
+  applyEffect as applyEffectHelper
+} from '../../utils/moveHelpers.js';
 
 const TOKEN_COLORS = [
-  { name: "blue", color: "#60a5fa" },
-  { name: "red", color: "#ef4444" },
-  { name: "green", color: "#4ade80" },
-  { name: "yellow", color: "#facc15" },
+  { name: 'blue', color: '#60a5fa' },
+  { name: 'red', color: '#ef4444' },
+  { name: 'green', color: '#4ade80' },
+  { name: 'yellow', color: '#facc15' }
 ];
 
 const PLAYERS = 4;
@@ -131,7 +141,8 @@ function generateBoardLocal() {
     const maxDrop = Math.min(start - 1, 20);
     if (maxDrop <= 0) continue;
     const end = start - (Math.floor(Math.random() * maxDrop) + 1);
-    if (used.has(start) || used.has(end) || snakes[start] || end === 1) continue;
+    if (used.has(start) || used.has(end) || snakes[start] || end === 1)
+      continue;
     snakes[start] = end;
     used.add(start);
     used.add(end);
@@ -161,7 +172,7 @@ function CoinBurst({ token }) {
   const coins = Array.from({ length: 30 }, () => ({
     dx: (Math.random() - 0.5) * 100,
     delay: Math.random() * 0.3,
-    dur: 0.8 + Math.random() * 0.4,
+    dur: 0.8 + Math.random() * 0.4
   }));
   return (
     <div className="coin-burst">
@@ -172,14 +183,14 @@ function CoinBurst({ token }) {
             token.toUpperCase() === 'TPC'
               ? '/assets/icons/TPCcoin_1.webp'
               : token.toUpperCase() === 'TON'
-              ? '/assets/icons/TON.webp'
-              : '/assets/icons/Usdt.webp'
+                ? '/assets/icons/TON.webp'
+                : '/assets/icons/Usdt.webp'
           }
           className="coin-img"
           style={{
-            "--dx": `${c.dx}px`,
-            "--delay": `${c.delay}s`,
-            "--dur": `${c.dur}s`,
+            '--dx': `${c.dx}px`,
+            '--delay': `${c.delay}s`,
+            '--dur': `${c.dur}s`
           }}
         />
       ))}
@@ -203,7 +214,7 @@ function Board({
   diceCells,
   rollingIndex,
   currentTurn,
-  burning = [],
+  burning = []
 }) {
   const containerRef = useRef(null);
   const gridRef = useRef(null);
@@ -245,7 +256,7 @@ function Board({
     // subsequent row alternates direction. Tile 1 is at the bottom-left and
     // tile 100 ends up at the top-right.
     const reversed = r % 2 === 1;
-    const rowColor = "#6db0ad";
+    const rowColor = '#6db0ad';
 
     for (let c = 0; c < COLS; c++) {
       const col = c;
@@ -258,33 +269,33 @@ function Board({
         ? `${highlight.type}-highlight`
         : trailHighlight
           ? `${trailHighlight.type}-highlight`
-          : "";
-      const isJump = isHighlight && highlight.type === "normal";
+          : '';
+      const isJump = isHighlight && highlight.type === 'normal';
       const cellType = ladders[num]
-        ? "ladder"
+        ? 'ladder'
         : snakes[num]
-          ? "snake"
+          ? 'snake'
           : diceCells && diceCells[num]
-            ? "dice"
-            : "";
-      const cellClass = cellType ? `${cellType}-cell` : "";
+            ? 'dice'
+            : '';
+      const cellClass = cellType ? `${cellType}-cell` : '';
       const iconImage =
-        cellType === "ladder"
-          ? "/assets/icons/Ladder.webp"
-          : cellType === "snake"
-            ? "/assets/icons/snake_vector_no_bg.webp"
+        cellType === 'ladder'
+          ? '/assets/icons/Ladder.webp'
+          : cellType === 'snake'
+            ? '/assets/icons/snake_vector_no_bg.webp'
             : null;
       const offsetVal =
-        cellType === "ladder"
+        cellType === 'ladder'
           ? ladderOffsets[num]
-          : cellType === "snake"
+          : cellType === 'snake'
             ? snakeOffsets[num]
             : null;
       const style = {
         gridRowStart: ROWS - r,
         gridColumnStart: col + 1,
         transform: `translate(${translateX}px, ${translateY}px) scaleX(${scaleX}) scaleY(${scale}) translateZ(5px)`,
-        transformOrigin: "bottom center",
+        transformOrigin: 'bottom center'
       };
       if (!highlightClass) style.backgroundColor = rowColor;
 
@@ -302,14 +313,10 @@ function Board({
               {offsetVal != null && (
                 <span
                   className={`offset-text ${
-                    cellType === 'snake'
-                      ? 'snake-text'
-                      : 'ladder-text'
+                    cellType === 'snake' ? 'snake-text' : 'ladder-text'
                   }`}
                 >
-                  {cellType === 'snake'
-                    ? `-${offsetVal}`
-                    : `+${offsetVal}`}
+                  {cellType === 'snake' ? `-${offsetVal}` : `+${offsetVal}`}
                 </span>
               )}
             </span>
@@ -317,7 +324,10 @@ function Board({
           {!cellType && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
-              <img  src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp" className="dice-icon" />
+              <img
+                src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp"
+                className="dice-icon"
+              />
               <span className="dice-value">+{diceCells[num]}</span>
             </span>
           )}
@@ -328,19 +338,26 @@ function Board({
               <Fragment key={p.index}>
                 <PlayerToken
                   photoUrl={p.photoUrl}
-                  type={p.type || (p.index === 0 ? (isHighlight ? highlight.type : tokenType) : "normal")}
+                  type={
+                    p.type ||
+                    (p.index === 0
+                      ? isHighlight
+                        ? highlight.type
+                        : tokenType
+                      : 'normal')
+                  }
                   color={p.color}
                   rolling={p.index === rollingIndex}
                   active={p.index === currentTurn}
                   photoOnly
                   className={
-                    "board-token " +
+                    'board-token ' +
                     (p.position === 0
-                      ? "start"
+                      ? 'start'
                       : p.index === 0 && isJump
-                        ? "jump"
-                        : "") +
-                    (burning.includes(p.index) ? " burning" : "")
+                        ? 'jump'
+                        : '') +
+                    (burning.includes(p.index) ? ' burning' : '')
                   }
                 />
               </Fragment>
@@ -348,14 +365,14 @@ function Board({
           {offsetPopup && offsetPopup.cell === num && (
             <span
               className={`popup-offset italic font-bold ${
-                offsetPopup.type === "snake" ? "text-red-500" : "text-green-500"
+                offsetPopup.type === 'snake' ? 'text-red-500' : 'text-green-500'
               }`}
             >
-              {offsetPopup.type === "snake" ? "-" : "+"}
+              {offsetPopup.type === 'snake' ? '-' : '+'}
               {offsetPopup.amount}
             </span>
           )}
-        </div>,
+        </div>
       );
     }
   }
@@ -372,15 +389,13 @@ function Board({
       setCellHeight(ch);
     };
     updateSize();
-    window.addEventListener("resize", updateSize);
-    return () => window.removeEventListener("resize", updateSize);
+    window.addEventListener('resize', updateSize);
+    return () => window.removeEventListener('resize', updateSize);
   }, []);
 
   useLayoutEffect(() => {
     // board layout recalculations
   }, [cellWidth, cellHeight]);
-
-
 
   // Icons are rendered directly inside each cell so that they stay perfectly
   // aligned with the grid. Previously additional absolutely positioned markers
@@ -437,11 +452,11 @@ function Board({
         ref={containerRef}
         className="overflow-y-auto"
         style={{
-          overflowX: "hidden",
-          height: "100vh",
-          overscrollBehaviorY: "none",
+          overflowX: 'hidden',
+          height: '100vh',
+          overscrollBehaviorY: 'none',
           paddingTop,
-          paddingBottom,
+          paddingBottom
         }}
       >
         <div className="snake-board-tilt">
@@ -453,22 +468,22 @@ function Board({
               height: `${cellHeight * ROWS + offsetYMax}px`,
               gridTemplateColumns: `repeat(${COLS}, ${cellWidth}px)`,
               gridTemplateRows: `repeat(${ROWS}, ${cellHeight}px)`,
-              "--cell-width": `${cellWidth}px`,
-              "--cell-height": `${cellHeight}px`,
-              "--board-width": `${cellWidth * COLS}px`,
-              "--board-height": `${cellHeight * ROWS + offsetYMax}px`,
-              "--board-angle": `${angle}deg`,
-              "--final-scale": finalScale,
+              '--cell-width': `${cellWidth}px`,
+              '--cell-height': `${cellHeight}px`,
+              '--board-width': `${cellWidth * COLS}px`,
+              '--board-height': `${cellHeight * ROWS + offsetYMax}px`,
+              '--board-angle': `${angle}deg`,
+              '--final-scale': finalScale,
               // Fixed camera angle with no zooming
               // Pull the board slightly back so more of the lower rows are
               // visible when the game starts without changing zoom or angle
-              transform: `translate(${boardXOffset}px, ${boardYOffset}px) translateZ(${boardZOffset}px) rotateX(${angle}deg) scale(0.9)`,
+              transform: `translate(${boardXOffset}px, ${boardYOffset}px) translateZ(${boardZOffset}px) rotateX(${angle}deg) scale(0.9)`
             }}
           >
             {/* Game background is rendered outside the grid */}
             {tiles}
             <div
-              className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? "highlight" : ""}`}
+              className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? 'highlight' : ''}`}
             >
               <PlayerToken
                 color="#16a34a"
@@ -580,7 +595,7 @@ export default function SnakeAndLadder() {
         palestineFlagSoundRef,
         badLuckSoundRef,
         cheerSoundRef,
-        timerSoundRef,
+        timerSoundRef
       ].forEach((r) => {
         if (r.current) r.current.volume = vol;
       });
@@ -612,15 +627,15 @@ export default function SnakeAndLadder() {
   const [pos, setPos] = useState(0);
   const [highlight, setHighlight] = useState(null); // { cell: number, type: string }
   const [trail, setTrail] = useState([]);
-  const [tokenType, setTokenType] = useState("normal");
-  const [message, setMessage] = useState("");
-  const [messageColor, setMessageColor] = useState("");
-  const [turnMessage, setTurnMessage] = useState("Your turn");
+  const [tokenType, setTokenType] = useState('normal');
+  const [message, setMessage] = useState('');
+  const [messageColor, setMessageColor] = useState('');
+  const [turnMessage, setTurnMessage] = useState('Your turn');
   const [diceVisible, setDiceVisible] = useState(true);
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
   const [myName, setMyName] = useState('You');
   const [pot, setPot] = useState(101);
-  const [token, setToken] = useState("TPC");
+  const [token, setToken] = useState('TPC');
   const [celebrate, setCelebrate] = useState(false);
   const [leftWinner, setLeftWinner] = useState(null);
   const [disconnectMsg, setDisconnectMsg] = useState(null);
@@ -696,7 +711,6 @@ export default function SnakeAndLadder() {
   useEffect(() => {
     prepareDiceAnimation(0);
   }, []);
-
 
   useEffect(() => {
     return () => clearTimeout(trailTimeoutRef.current);
@@ -807,7 +821,11 @@ export default function SnakeAndLadder() {
           } else if (avatar.includes('EgyptLeader') || avatar === '🇪🇬') {
             egyptLeaderSoundRef.current.currentTime = 0;
             egyptLeaderSoundRef.current.play().catch(() => {});
-          } else if (avatar.includes('UnitedKingdomLeader') || avatar.includes('EnglandLeader') || avatar === '🇬🇧') {
+          } else if (
+            avatar.includes('UnitedKingdomLeader') ||
+            avatar.includes('EnglandLeader') ||
+            avatar === '🇬🇧'
+          ) {
             englandLeaderSoundRef.current.currentTime = 0;
             englandLeaderSoundRef.current.play().catch(() => {});
           } else if (avatar.includes('FranceLeader') || avatar === '🇫🇷') {
@@ -836,11 +854,12 @@ export default function SnakeAndLadder() {
         setTimeout(() => {
           setBurning((b) => b.filter((v) => v !== idx));
           if (idx === 0) setPos(0);
-          else setAiPositions((arr) => {
-            const copy = [...arr];
-            copy[idx - 1] = 0;
-            return copy;
-          });
+          else
+            setAiPositions((arr) => {
+              const copy = [...arr];
+              copy[idx - 1] = 0;
+              return copy;
+            });
         }, 1000);
       });
     }
@@ -864,11 +883,13 @@ export default function SnakeAndLadder() {
         transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)`,
         transition: 'none',
         pointerEvents: 'none',
-        zIndex: 50,
+        zIndex: 50
       });
       return;
     }
-    const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
+    const startEl = document.querySelector(
+      `[data-player-index="${startIdx}"] img`
+    );
     if (!startEl) return;
     const s = startEl.getBoundingClientRect();
     const targetX = s.left + s.width / 2;
@@ -882,13 +903,15 @@ export default function SnakeAndLadder() {
       transform: `translate(${targetX}px, ${targetY}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
       transition: 'none',
       pointerEvents: 'none',
-      zIndex: 50,
+      zIndex: 50
     });
   };
 
   const animateDiceToCenter = (startIdx) => {
     const dice = diceRef.current;
-    const startEl = document.querySelector(`[data-player-index="${startIdx}"] img`);
+    const startEl = document.querySelector(
+      `[data-player-index="${startIdx}"] img`
+    );
     if (!dice || !startEl) return;
     const s = startEl.getBoundingClientRect();
     const startX = s.left + s.width / 2;
@@ -903,10 +926,14 @@ export default function SnakeAndLadder() {
     dice.style.zIndex = '50';
     dice.animate(
       [
-        { transform: `translate(${startX}px, ${startY}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})` },
-        { transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)` },
+        {
+          transform: `translate(${startX}px, ${startY}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`
+        },
+        {
+          transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)`
+        }
       ],
-      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' },
+      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' }
     ).onfinish = () => {
       setDiceStyle({
         display: 'block',
@@ -915,7 +942,7 @@ export default function SnakeAndLadder() {
         top: '0px',
         transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)`,
         pointerEvents: 'none',
-        zIndex: 50,
+        zIndex: 50
       });
     };
   };
@@ -931,10 +958,14 @@ export default function SnakeAndLadder() {
     const { cx, cy } = getDiceCenter();
     dice.animate(
       [
-        { transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)` },
-        { transform: `translate(${endX}px, ${endY}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})` },
+        {
+          transform: `translate(${cx}px, ${cy}px) translate(-50%, -50%) scale(1)`
+        },
+        {
+          transform: `translate(${endX}px, ${endY}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`
+        }
       ],
-      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' },
+      { duration: DICE_ANIM_DURATION, easing: 'ease-in-out' }
     ).onfinish = () => {
       setDiceStyle({
         display: 'block',
@@ -943,7 +974,7 @@ export default function SnakeAndLadder() {
         top: '0px',
         transform: `translate(${endX}px, ${endY}px) translate(-50%, -50%) scale(${DICE_SMALL_SCALE})`,
         pointerEvents: 'none',
-        zIndex: 50,
+        zIndex: 50
       });
     };
   };
@@ -994,7 +1025,9 @@ export default function SnakeAndLadder() {
           setPhotoUrl((prev) => prev || p.photo);
           saveAvatar(p.photo);
         }
-        setMyName(p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim());
+        setMyName(
+          p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim()
+        );
       })
       .catch(() => {});
     const vol = getGameVolume();
@@ -1006,45 +1039,61 @@ export default function SnakeAndLadder() {
     oldSnakeSoundRef.current.volume = vol;
     ladderSoundRef.current = new Audio(ladderSound);
     ladderSoundRef.current.volume = vol;
-    winSoundRef.current = new Audio("/assets/sounds/successful.mp3");
+    winSoundRef.current = new Audio('/assets/sounds/successful.mp3');
     winSoundRef.current.volume = vol;
-    diceRewardSoundRef.current = new Audio("/assets/sounds/successful.mp3");
+    diceRewardSoundRef.current = new Audio('/assets/sounds/successful.mp3');
     diceRewardSoundRef.current.volume = vol;
-    yabbaSoundRef.current = new Audio("/assets/sounds/yabba-dabba-doo.mp3");
+    yabbaSoundRef.current = new Audio('/assets/sounds/yabba-dabba-doo.mp3');
     yabbaSoundRef.current.volume = vol;
-    hahaSoundRef.current = new Audio("/assets/sounds/Haha.mp3");
+    hahaSoundRef.current = new Audio('/assets/sounds/Haha.mp3');
     hahaSoundRef.current.volume = vol;
     bombSoundRef.current = new Audio(bombSound);
     bombSoundRef.current.volume = vol;
-    usaLeaderSoundRef.current = new Audio("/assets/sounds/trumpspeach.mp3");
+    usaLeaderSoundRef.current = new Audio('/assets/sounds/trumpspeach.mp3');
     usaLeaderSoundRef.current.volume = vol;
-    chinaLeaderSoundRef.current = new Audio("/assets/sounds/chingpingu.mp3");
+    chinaLeaderSoundRef.current = new Audio('/assets/sounds/chingpingu.mp3');
     chinaLeaderSoundRef.current.volume = vol;
-    russiaLeaderSoundRef.current = new Audio("/assets/sounds/Russia_edit._URA.mp3");
+    russiaLeaderSoundRef.current = new Audio(
+      '/assets/sounds/Russia_edit._URA.mp3'
+    );
     russiaLeaderSoundRef.current.volume = vol;
-    italyLeaderSoundRef.current = new Audio("/assets/sounds/meloni preident 2.mp3");
+    italyLeaderSoundRef.current = new Audio(
+      '/assets/sounds/meloni preident 2.mp3'
+    );
     italyLeaderSoundRef.current.volume = vol;
-    albaniaLeaderSoundRef.current = new Audio("/assets/sounds/Sorry_for_being_balkanik_shorts_youtubeshorts_motorcycle_motoguzziv9_motoguzzi_b.mp3");
+    albaniaLeaderSoundRef.current = new Audio(
+      '/assets/sounds/Sorry_for_being_balkanik_shorts_youtubeshorts_motorcycle_motoguzziv9_motoguzzi_b.mp3'
+    );
     albaniaLeaderSoundRef.current.volume = vol;
-    greeceLeaderSoundRef.current = new Audio("/assets/sounds/potukseri.mp3");
+    greeceLeaderSoundRef.current = new Audio('/assets/sounds/potukseri.mp3');
     greeceLeaderSoundRef.current.volume = vol;
-    turkeyLeaderSoundRef.current = new Audio("/assets/sounds/erdogan.mp3");
+    turkeyLeaderSoundRef.current = new Audio('/assets/sounds/erdogan.mp3');
     turkeyLeaderSoundRef.current.volume = vol;
-    ukraineLeaderSoundRef.current = new Audio("/assets/sounds/2FilesMerged_20250717_131957.mp3");
+    ukraineLeaderSoundRef.current = new Audio(
+      '/assets/sounds/2FilesMerged_20250717_131957.mp3'
+    );
     ukraineLeaderSoundRef.current.volume = vol;
-    northKoreaLeaderSoundRef.current = new Audio("/assets/sounds/Chinese_Gong_Meme_Sound_Effect.mp3");
+    northKoreaLeaderSoundRef.current = new Audio(
+      '/assets/sounds/Chinese_Gong_Meme_Sound_Effect.mp3'
+    );
     northKoreaLeaderSoundRef.current.volume = vol;
-    egyptLeaderSoundRef.current = new Audio("/assets/sounds/Ancient_Egyptian_Music__The_Nile_River.mp3");
+    egyptLeaderSoundRef.current = new Audio(
+      '/assets/sounds/Ancient_Egyptian_Music__The_Nile_River.mp3'
+    );
     egyptLeaderSoundRef.current.volume = vol;
-    englandLeaderSoundRef.current = new Audio("/assets/sounds/EnglandLeader.mp3");
+    englandLeaderSoundRef.current = new Audio(
+      '/assets/sounds/EnglandLeader.mp3'
+    );
     englandLeaderSoundRef.current.volume = vol;
-    franceLeaderSoundRef.current = new Audio("/assets/sounds/FranceLeader.mp3");
+    franceLeaderSoundRef.current = new Audio('/assets/sounds/FranceLeader.mp3');
     franceLeaderSoundRef.current.volume = vol;
-    israelLeaderSoundRef.current = new Audio("/assets/sounds/IsraelLeader.mp3");
+    israelLeaderSoundRef.current = new Audio('/assets/sounds/IsraelLeader.mp3');
     israelLeaderSoundRef.current.volume = vol;
-    serbiaLeaderSoundRef.current = new Audio("/assets/sounds/SerbiaLeader.mp3");
+    serbiaLeaderSoundRef.current = new Audio('/assets/sounds/SerbiaLeader.mp3');
     serbiaLeaderSoundRef.current.volume = vol;
-    palestineFlagSoundRef.current = new Audio('/assets/sounds/palestineflag.mp3');
+    palestineFlagSoundRef.current = new Audio(
+      '/assets/sounds/palestineflag.mp3'
+    );
     palestineFlagSoundRef.current.volume = vol;
     badLuckSoundRef.current = new Audio(badLuckSound);
     badLuckSoundRef.current.volume = vol;
@@ -1111,7 +1160,7 @@ export default function SnakeAndLadder() {
       palestineFlagSoundRef,
       badLuckSoundRef,
       cheerSoundRef,
-      timerSoundRef,
+      timerSoundRef
     ].forEach((r) => {
       if (r.current) r.current.muted = muted;
     });
@@ -1128,24 +1177,26 @@ export default function SnakeAndLadder() {
         .then((p) => {
           setPhotoUrl((prev) => prev || p?.photo || '');
           if (p?.photo) saveAvatar(p.photo);
-          setMyName(p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim());
+          setMyName(
+            p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim()
+          );
         })
         .catch(() => {});
     };
-    window.addEventListener("profilePhotoUpdated", updatePhoto);
-    return () => window.removeEventListener("profilePhotoUpdated", updatePhoto);
+    window.addEventListener('profilePhotoUpdated', updatePhoto);
+    return () => window.removeEventListener('profilePhotoUpdated', updatePhoto);
   }, []);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const watchParam = params.get("watch");
-    const t = params.get("token");
-    const amt = params.get("amount");
-    const aiParam = params.get("ai");
-    const avatarParam = params.get("avatars") || 'flags';
+    const watchParam = params.get('watch');
+    const t = params.get('token');
+    const amt = params.get('amount');
+    const aiParam = params.get('ai');
+    const avatarParam = params.get('avatars') || 'flags';
     const flagsParam = params.get('flags');
     const leadersParam = params.get('leaders');
-    const tableParam = params.get("table");
+    const tableParam = params.get('table');
     if (t) setToken(t.toUpperCase());
     if (amt) setPot(Number(amt));
     const aiCount = aiParam
@@ -1156,7 +1207,7 @@ export default function SnakeAndLadder() {
     setAi(aiCount);
     setAvatarType(avatarParam);
     setIsMultiplayer(tableParam && !aiParam);
-    const watching = watchParam === "1";
+    const watching = watchParam === '1';
     setWatchOnly(watching);
     if (watching) {
       setShowQuitInfo(false);
@@ -1179,7 +1230,8 @@ export default function SnakeAndLadder() {
           .filter((i) => i >= 0 && i < LEADER_AVATARS.length);
         const chosen = indices.map((i) => LEADER_AVATARS[i]);
         while (chosen.length < aiCount) {
-          const rand = LEADER_AVATARS[Math.floor(Math.random() * LEADER_AVATARS.length)];
+          const rand =
+            LEADER_AVATARS[Math.floor(Math.random() * LEADER_AVATARS.length)];
           if (!chosen.includes(rand)) chosen.push(rand);
         }
         setAiAvatars(chosen.slice(0, aiCount));
@@ -1187,7 +1239,7 @@ export default function SnakeAndLadder() {
         setAiAvatars([
           '/assets/icons/UsaLeader.webp',
           '/assets/icons/RussiaLeader.webp',
-          '/assets/icons/ChinaLeader.webp',
+          '/assets/icons/ChinaLeader.webp'
         ]);
       } else {
         const unique = [...LEADER_AVATARS]
@@ -1197,25 +1249,33 @@ export default function SnakeAndLadder() {
       }
     } else {
       if (flagsParam) {
-        const indices = flagsParam.split(',').map((n) => parseInt(n)).filter((i) => i >= 0 && i < FLAG_EMOJIS.length);
+        const indices = flagsParam
+          .split(',')
+          .map((n) => parseInt(n))
+          .filter((i) => i >= 0 && i < FLAG_EMOJIS.length);
         const chosen = indices.map((i) => FLAG_EMOJIS[i]);
         while (chosen.length < aiCount) {
-          chosen.push(FLAG_EMOJIS[Math.floor(Math.random() * FLAG_EMOJIS.length)]);
+          chosen.push(
+            FLAG_EMOJIS[Math.floor(Math.random() * FLAG_EMOJIS.length)]
+          );
         }
         setAiAvatars(chosen.slice(0, aiCount));
       } else {
         setAiAvatars(
-          Array.from({ length: aiCount }, () =>
-            FLAG_EMOJIS[Math.floor(Math.random() * FLAG_EMOJIS.length)]
+          Array.from(
+            { length: aiCount },
+            () => FLAG_EMOJIS[Math.floor(Math.random() * FLAG_EMOJIS.length)]
           )
         );
       }
     }
-    const colors = shuffle(TOKEN_COLORS).slice(0, aiCount + 1).map(c => c.color);
+    const colors = shuffle(TOKEN_COLORS)
+      .slice(0, aiCount + 1)
+      .map((c) => c.color);
     setPlayerColors(colors);
 
     const storedTable = localStorage.getItem('snakeCurrentTable');
-    const table = params.get("table") || storedTable || "snake-4";
+    const table = params.get('table') || storedTable || 'snake-4';
     setTableId(table);
     localStorage.setItem('snakeCurrentTable', table);
     const boardPromise = isMultiplayer
@@ -1236,7 +1296,7 @@ export default function SnakeAndLadder() {
         });
         const lad = {};
         Object.entries(laddersLim).forEach(([s, e]) => {
-          const end = typeof e === "object" ? e.end : e;
+          const end = typeof e === 'object' ? e.end : e;
           lad[s] = end - s;
         });
         setSnakeOffsets(snk);
@@ -1249,7 +1309,7 @@ export default function SnakeAndLadder() {
           ...Object.keys(snakesLim),
           ...Object.keys(laddersLim),
           ...Object.values(snakesLim),
-          ...Object.values(laddersLim),
+          ...Object.values(laddersLim)
         ]);
         diceValues.forEach((val) => {
           let cell;
@@ -1299,7 +1359,10 @@ export default function SnakeAndLadder() {
 
     const onJoined = ({ playerId }) => {
       getProfileByAccount(playerId).then((prof) => {
-        const name = prof?.nickname || `${prof?.firstName || ''} ${prof?.lastName || ''}`.trim() || `Player`;
+        const name =
+          prof?.nickname ||
+          `${prof?.firstName || ''} ${prof?.lastName || ''}`.trim() ||
+          `Player`;
         const photoUrl = prof?.photo || '/assets/icons/profile.svg';
         setMpPlayers((p) => {
           if (p.some((pl) => pl.id === playerId)) {
@@ -1335,7 +1398,9 @@ export default function SnakeAndLadder() {
     };
     const onMove = ({ playerId, from = 0, to }) => {
       const updatePosition = (pos) => {
-        setMpPlayers((p) => p.map((pl) => (pl.id === playerId ? { ...pl, position: pos } : pl)));
+        setMpPlayers((p) =>
+          p.map((pl) => (pl.id === playerId ? { ...pl, position: pos } : pl))
+        );
         if (playerId === accountId) setPos(pos);
       };
       const ctx = {
@@ -1352,7 +1417,7 @@ export default function SnakeAndLadder() {
         ladderSoundRef,
         badLuckSoundRef,
         muted,
-        FINAL_TILE,
+        FINAL_TILE
       };
       const finalizeMove = (finalPos, type) => {
         updatePosition(finalPos);
@@ -1368,7 +1433,9 @@ export default function SnakeAndLadder() {
     };
     const onSnakeOrLadder = ({ playerId, from, to }) => {
       const updatePosition = (pos) => {
-        setMpPlayers((p) => p.map((pl) => (pl.id === playerId ? { ...pl, position: pos } : pl)));
+        setMpPlayers((p) =>
+          p.map((pl) => (pl.id === playerId ? { ...pl, position: pos } : pl))
+        );
         if (playerId === accountId) setPos(pos);
       };
       const ctx = {
@@ -1385,7 +1452,7 @@ export default function SnakeAndLadder() {
         ladderSoundRef,
         badLuckSoundRef,
         muted,
-        FINAL_TILE,
+        FINAL_TILE
       };
       const finalizeMove = (finalPos, type) => {
         updatePosition(finalPos);
@@ -1409,7 +1476,9 @@ export default function SnakeAndLadder() {
       }
       setTimeout(() => {
         setBurning((b) => b.filter((v) => v !== idx));
-        setMpPlayers((p) => p.map((pl) => (pl.id === playerId ? { ...pl, position: 0 } : pl)));
+        setMpPlayers((p) =>
+          p.map((pl) => (pl.id === playerId ? { ...pl, position: 0 } : pl))
+        );
         if (playerId === accountId) setPos(0);
       }, 1000);
     };
@@ -1450,7 +1519,10 @@ export default function SnakeAndLadder() {
       Promise.all(
         players.map(async (p) => {
           const prof = await getProfileByAccount(p.playerId).catch(() => ({}));
-          const name = prof?.nickname || `${prof?.firstName || ''} ${prof?.lastName || ''}`.trim() || p.name;
+          const name =
+            prof?.nickname ||
+            `${prof?.firstName || ''} ${prof?.lastName || ''}`.trim() ||
+            p.name;
           const photoUrl = prof?.photo || '/assets/icons/profile.svg';
           return { id: p.playerId, name, photoUrl, position: p.position || 0 };
         })
@@ -1466,7 +1538,8 @@ export default function SnakeAndLadder() {
       if (playerId === accountId) {
         setConnectionLost(true);
       } else if (capacity > 2) {
-        const name = playersRef.current.find((p) => p.id === playerId)?.name || playerId;
+        const name =
+          playersRef.current.find((p) => p.id === playerId)?.name || playerId;
         setDisconnectMsg(`${name} disconnected`);
         setTimeout(() => setDisconnectMsg(null), 3000);
       }
@@ -1475,7 +1548,8 @@ export default function SnakeAndLadder() {
       if (playerId === accountId) {
         setConnectionLost(false);
       } else if (capacity > 2) {
-        const name = playersRef.current.find((p) => p.id === playerId)?.name || playerId;
+        const name =
+          playersRef.current.find((p) => p.id === playerId)?.name || playerId;
         setDisconnectMsg(`${name} rejoined`);
         setTimeout(() => setDisconnectMsg(null), 3000);
       }
@@ -1501,7 +1575,9 @@ export default function SnakeAndLadder() {
             players.map(async (p) => {
               const prof = await getProfileByAccount(p.id).catch(() => ({}));
               const n =
-                prof?.nickname || `${prof?.firstName || ''} ${prof?.lastName || ''}`.trim() || p.name;
+                prof?.nickname ||
+                `${prof?.firstName || ''} ${prof?.lastName || ''}`.trim() ||
+                p.name;
               const photoUrl = prof?.photo || '/assets/icons/profile.svg';
               return { id: p.id, name: n, photoUrl, position: 0 };
             })
@@ -1514,7 +1590,6 @@ export default function SnakeAndLadder() {
     } else {
       socket.emit('joinRoom', { roomId: tableId, playerId: accountId, name });
     }
-
 
     return () => {
       socket.off('playerJoined', onJoined);
@@ -1644,10 +1719,22 @@ export default function SnakeAndLadder() {
       ranking,
       gameOver,
       aiAvatars,
-      timestamp: Date.now(),
+      timestamp: Date.now()
     };
     localStorage.setItem(key, JSON.stringify(data));
-  }, [ai, pos, aiPositions, currentTurn, diceCells, snakes, ladders, snakeOffsets, ladderOffsets, ranking, gameOver]);
+  }, [
+    ai,
+    pos,
+    aiPositions,
+    currentTurn,
+    diceCells,
+    snakes,
+    ladders,
+    snakeOffsets,
+    ladderOffsets,
+    ranking,
+    gameOver
+  ]);
 
   // Ensure stored state is cleared when leaving the page
   useEffect(() => {
@@ -1666,11 +1753,9 @@ export default function SnakeAndLadder() {
     };
   }, [ai, gameOver]);
 
-
-
   const handleRoll = (values) => {
     setMoving(true);
-    setTurnMessage("");
+    setTurnMessage('');
     setRollCooldown(1);
     const value = Array.isArray(values)
       ? values.reduce((a, b) => a + b, 0)
@@ -1678,7 +1763,8 @@ export default function SnakeAndLadder() {
     const rolledSix = Array.isArray(values)
       ? values.some((v) => Number(v) === 6)
       : Number(value) === 6;
-    const doubleSix = Array.isArray(values) && values[0] === 6 && values[1] === 6;
+    const doubleSix =
+      Array.isArray(values) && values[0] === 6 && values[1] === 6;
 
     setRollColor(playerColors[0] || '#fff');
 
@@ -1714,8 +1800,7 @@ export default function SnakeAndLadder() {
       setOffsetPopup(null);
       setTrail([]);
 
-
-      setMessage("");
+      setMessage('');
       let current = pos;
       let target = current;
 
@@ -1727,11 +1812,11 @@ export default function SnakeAndLadder() {
             copy[currentTurn] = 1;
             return copy;
           });
-          setMessage("Six rolled! One die removed.");
+          setMessage('Six rolled! One die removed.');
         } else {
-          setMessage("");
+          setMessage('');
         }
-        setTurnMessage("Your turn");
+        setTurnMessage('Your turn');
         setDiceVisible(true);
         setMoving(false);
         return;
@@ -1739,8 +1824,8 @@ export default function SnakeAndLadder() {
         if (value === 1) {
           target = FINAL_TILE;
         } else {
-          setMessage("Need a 1 to win!");
-          setTurnMessage("");
+          setMessage('Need a 1 to win!');
+          setTurnMessage('');
           setDiceVisible(false);
           const next = (currentTurn + 1) % (ai + 1);
           animateDiceToPlayer(next);
@@ -1755,10 +1840,9 @@ export default function SnakeAndLadder() {
         if (rolledSix) {
           target = 1;
           if (!muted) cheerSoundRef.current?.play().catch(() => {});
-        }
-        else {
-          setMessage("");
-          setTurnMessage("");
+        } else {
+          setMessage('');
+          setTurnMessage('');
           setDiceVisible(false);
           const next = (currentTurn + 1) % (ai + 1);
           animateDiceToPlayer(next);
@@ -1772,9 +1856,9 @@ export default function SnakeAndLadder() {
       } else if (current + value <= FINAL_TILE) {
         target = current + value;
       } else {
-        setMessage("Need exact roll!");
+        setMessage('Need exact roll!');
         setShowExactHelp(true);
-        setTurnMessage("");
+        setTurnMessage('');
         setDiceVisible(false);
         const next = (currentTurn + 1) % (ai + 1);
         animateDiceToPlayer(next);
@@ -1785,7 +1869,6 @@ export default function SnakeAndLadder() {
         setTimeout(() => setMoving(false), 2000);
         return;
       }
-
 
       let predicted = target;
       if (snakes[predicted] != null) predicted = Math.max(0, snakes[predicted]);
@@ -1800,7 +1883,7 @@ export default function SnakeAndLadder() {
       const steps = [];
       for (let i = current + 1; i <= target; i++) steps.push(i);
 
-        setHighlight(null);
+      setHighlight(null);
       const ctx = {
         updatePosition: (p) => setPos(p),
         setHighlight,
@@ -1815,7 +1898,7 @@ export default function SnakeAndLadder() {
         ladderSoundRef,
         badLuckSoundRef,
         muted,
-        FINAL_TILE,
+        FINAL_TILE
       };
 
       const applyEffect = (startPos) =>
@@ -1837,7 +1920,7 @@ export default function SnakeAndLadder() {
                 const winAmt = Math.round(total * 0.91);
                 await Promise.all([
                   depositAccount(aid, winAmt, { game: 'snake-win' }),
-                  awardDevShare(total),
+                  awardDevShare(total)
                 ]);
               })
               .catch(() => {});
@@ -1846,7 +1929,7 @@ export default function SnakeAndLadder() {
           if (first) setGameOver(true);
           const winAmt = Math.round(total * 0.91);
           setMessage(`You win ${winAmt} ${token}!`);
-          setMessageColor("");
+          setMessageColor('');
           if (!muted) winSoundRef.current?.play().catch(() => {});
           coinConfetti(50);
           setCelebrate(true);
@@ -1882,7 +1965,7 @@ export default function SnakeAndLadder() {
           setBonusDice(0);
           extraTurn = true;
         } else {
-          setTurnMessage("Your turn");
+          setTurnMessage('Your turn');
           setBonusDice(0);
         }
         setDiceVisible(true);
@@ -1909,7 +1992,7 @@ export default function SnakeAndLadder() {
     setMoving(true);
     const value = Array.isArray(vals)
       ? vals.reduce((a, b) => a + b, 0)
-      : vals ?? Math.floor(Math.random() * 6) + 1;
+      : (vals ?? Math.floor(Math.random() * 6) + 1);
     const rolledSix = Array.isArray(vals)
       ? vals.some((v) => Number(v) === 6)
       : Number(value) === 6;
@@ -1933,7 +2016,11 @@ export default function SnakeAndLadder() {
       (index !== 0 && pos === preview) ||
       aiPositions.some((p, i) => i !== index - 1 && p === preview);
 
-    setTurnMessage(<>{playerName(index)} rolled {value}</>);
+    setTurnMessage(
+      <>
+        {playerName(index)} rolled {value}
+      </>
+    );
     setRollResult(value);
     if (doubleSix && !muted) {
       yabbaSoundRef.current.currentTime = 0;
@@ -1946,148 +2033,152 @@ export default function SnakeAndLadder() {
     setTimeout(() => setRollResult(null), 2000);
     setTimeout(() => {
       setDiceVisible(false);
-    let positions = [...aiPositions];
-    let current = positions[index - 1];
-    let target = current;
-    if (current === 0) {
-      if (rolledSix) {
-        target = 1;
-        if (!muted) cheerSoundRef.current?.play().catch(() => {});
+      let positions = [...aiPositions];
+      let current = positions[index - 1];
+      let target = current;
+      if (current === 0) {
+        if (rolledSix) {
+          target = 1;
+          if (!muted) cheerSoundRef.current?.play().catch(() => {});
+        }
+      } else if (current === 100 && playerDiceCounts[index] === 2) {
+        if (rolledSix) {
+          setPlayerDiceCounts((arr) => {
+            const copy = [...arr];
+            copy[index] = 1;
+            return copy;
+          });
+          if (currentTurn === index) setDiceCount(1);
+          setTurnMessage(`${getPlayerName(index)}'s turn`);
+          setDiceVisible(true);
+          setMoving(false);
+          return;
+        } else {
+          setTurnMessage(`${getPlayerName(index)} needs a 6`);
+          setDiceVisible(false);
+          const next = (currentTurn + 1) % (ai + 1);
+          animateDiceToPlayer(next);
+          setTimeout(() => {
+            setCurrentTurn(next);
+            setDiceCount(playerDiceCounts[next] ?? 2);
+          }, 2000);
+          setTimeout(() => setMoving(false), 2000);
+          return;
+        }
+      } else if (current === 100 && playerDiceCounts[index] === 1) {
+        if (value === 1) target = FINAL_TILE;
+        else {
+          setTurnMessage('');
+          setDiceVisible(false);
+          const next = (currentTurn + 1) % (ai + 1);
+          animateDiceToPlayer(next);
+          setTimeout(() => {
+            setCurrentTurn(next);
+            setDiceCount(playerDiceCounts[next] ?? 2);
+          }, 2000);
+          setTimeout(() => setMoving(false), 2000);
+          return;
+        }
+      } else if (current + value <= FINAL_TILE) {
+        target = current + value;
       }
-    } else if (current === 100 && playerDiceCounts[index] === 2) {
-      if (rolledSix) {
-        setPlayerDiceCounts(arr => {
-          const copy = [...arr];
-          copy[index] = 1;
-          return copy;
-        });
-        if (currentTurn === index) setDiceCount(1);
-        setTurnMessage(`${getPlayerName(index)}'s turn`);
-        setDiceVisible(true);
-        setMoving(false);
-        return;
-      } else {
-        setTurnMessage(`${getPlayerName(index)} needs a 6`);
-        setDiceVisible(false);
-        const next = (currentTurn + 1) % (ai + 1);
-        animateDiceToPlayer(next);
-        setTimeout(() => {
-          setCurrentTurn(next);
-          setDiceCount(playerDiceCounts[next] ?? 2);
-        }, 2000);
-        setTimeout(() => setMoving(false), 2000);
-        return;
-      }
-    } else if (current === 100 && playerDiceCounts[index] === 1) {
-      if (value === 1) target = FINAL_TILE;
-      else {
-        setTurnMessage('');
-        setDiceVisible(false);
-        const next = (currentTurn + 1) % (ai + 1);
-        animateDiceToPlayer(next);
-        setTimeout(() => {
-          setCurrentTurn(next);
-          setDiceCount(playerDiceCounts[next] ?? 2);
-        }, 2000);
-        setTimeout(() => setMoving(false), 2000);
-        return;
-      }
-    } else if (current + value <= FINAL_TILE) {
-      target = current + value;
-    }
 
-    let predicted = target;
-    if (snakes[predicted] != null) predicted = Math.max(0, snakes[predicted]);
-    else if (ladders[predicted] != null) {
-      const ladObj = ladders[predicted];
-      predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
-    }
-    const extraPred = diceCells[predicted] || doubleSix;
-    const nextPlayer = extraPred ? index : (index + 1) % (ai + 1);
-    animateDiceToPlayer(nextPlayer);
+      let predicted = target;
+      if (snakes[predicted] != null) predicted = Math.max(0, snakes[predicted]);
+      else if (ladders[predicted] != null) {
+        const ladObj = ladders[predicted];
+        predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
+      }
+      const extraPred = diceCells[predicted] || doubleSix;
+      const nextPlayer = extraPred ? index : (index + 1) % (ai + 1);
+      animateDiceToPlayer(nextPlayer);
 
-    const steps = [];
-    for (let i = current + 1; i <= target; i++) steps.push(i);
+      const steps = [];
+      for (let i = current + 1; i <= target; i++) steps.push(i);
 
       setHighlight(null);
-    const ctx = {
-      updatePosition: (p) => {
-        positions[index - 1] = p;
+      const ctx = {
+        updatePosition: (p) => {
+          positions[index - 1] = p;
+          setAiPositions([...positions]);
+        },
+        setHighlight,
+        setTrail,
+        moveSoundRef,
+        hahaSoundRef,
+        snakes,
+        ladders,
+        setOffsetPopup,
+        snakeSoundRef,
+        oldSnakeSoundRef,
+        ladderSoundRef,
+        badLuckSoundRef,
+        muted,
+        FINAL_TILE
+      };
+
+      const finalizeMove = async (finalPos, type) => {
+        positions[index - 1] = finalPos;
         setAiPositions([...positions]);
-      },
-      setHighlight,
-      setTrail,
-      moveSoundRef,
-      hahaSoundRef,
-      snakes,
-      ladders,
-      setOffsetPopup,
-      snakeSoundRef,
-      oldSnakeSoundRef,
-      ladderSoundRef,
-      badLuckSoundRef,
-      muted,
-      FINAL_TILE,
-    };
-
-    const finalizeMove = async (finalPos, type) => {
-      positions[index - 1] = finalPos;
-      setAiPositions([...positions]);
-      setHighlight({ cell: finalPos, type });
-      setTrail([]);
-      capturePieces(finalPos, index);
-      setTimeout(() => setHighlight(null), 2300);
-      if (finalPos === FINAL_TILE && !ranking.includes(getPlayerName(index))) {
-        const first = ranking.length === 0;
-        setRanking(r => [...r, getPlayerName(index)]);
-        if (first) {
-          await awardDevShare(pot * (ai + 1));
-          setGameOver(true);
+        setHighlight({ cell: finalPos, type });
+        setTrail([]);
+        capturePieces(finalPos, index);
+        setTimeout(() => setHighlight(null), 2300);
+        if (
+          finalPos === FINAL_TILE &&
+          !ranking.includes(getPlayerName(index))
+        ) {
+          const first = ranking.length === 0;
+          setRanking((r) => [...r, getPlayerName(index)]);
+          if (first) {
+            await awardDevShare(pot * (ai + 1));
+            setGameOver(true);
+          }
+          setMessage(`${getPlayerName(index)} wins!`);
+          setPlayerDiceCounts((arr) => {
+            const copy = [...arr];
+            copy[index] = 2;
+            return copy;
+          });
+          setDiceVisible(false);
+          setMoving(false);
+          return;
         }
-        setMessage(`${getPlayerName(index)} wins!`);
-        setPlayerDiceCounts(arr => {
-          const copy = [...arr];
-          copy[index] = 2;
-          return copy;
-        });
-        setDiceVisible(false);
+        let extraTurn = false;
+        if (diceCells[finalPos]) {
+          const bonus = diceCells[finalPos];
+          setDiceCells((d) => {
+            const n = { ...d };
+            delete n[finalPos];
+            return n;
+          });
+          setBonusDice(bonus);
+          setRewardDice(bonus);
+          setTurnMessage('Bonus roll');
+          extraTurn = true;
+          if (!muted) {
+            diceRewardSoundRef.current?.play().catch(() => {});
+            yabbaSoundRef.current?.play().catch(() => {});
+          }
+          setTimeout(() => setRewardDice(0), 1000);
+        } else if (doubleSix) {
+          extraTurn = true;
+        }
+        const next = extraTurn ? index : (index + 1) % (ai + 1);
+        if (next === 0) setTurnMessage('Your turn');
+        setCurrentTurn(next);
+        setDiceCount(playerDiceCounts[next] ?? 2);
+        setDiceVisible(true);
         setMoving(false);
-        return;
-      }
-      let extraTurn = false;
-      if (diceCells[finalPos]) {
-        const bonus = diceCells[finalPos];
-        setDiceCells((d) => {
-          const n = { ...d };
-          delete n[finalPos];
-          return n;
-        });
-        setBonusDice(bonus);
-        setRewardDice(bonus);
-        setTurnMessage('Bonus roll');
-        extraTurn = true;
-        if (!muted) {
-          diceRewardSoundRef.current?.play().catch(() => {});
-          yabbaSoundRef.current?.play().catch(() => {});
+        if (extraTurn && next === index) {
+          setTimeout(() => triggerAIRoll(index), 1800);
         }
-        setTimeout(() => setRewardDice(0), 1000);
-      } else if (doubleSix) {
-        extraTurn = true;
-      }
-      const next = extraTurn ? index : (index + 1) % (ai + 1);
-      if (next === 0) setTurnMessage('Your turn');
-      setCurrentTurn(next);
-      setDiceCount(playerDiceCounts[next] ?? 2);
-      setDiceVisible(true);
-      setMoving(false);
-      if (extraTurn && next === index) {
-        setTimeout(() => triggerAIRoll(index), 1800);
-      }
-    };
+      };
 
-    const applyEffect = (startPos) => applyEffectHelper(startPos, ctx, finalizeMove);
+      const applyEffect = (startPos) =>
+        applyEffectHelper(startPos, ctx, finalizeMove);
 
-    moveSeq(steps, 'normal', ctx, () => applyEffect(target), 'forward');
+      moveSeq(steps, 'normal', ctx, () => applyEffect(target), 'forward');
     }, 2000);
   };
 
@@ -2104,7 +2195,8 @@ export default function SnakeAndLadder() {
     const indices = Array.from({ length: total }, (_, i) => i);
     const start = Math.floor(Math.random() * total);
     const rollOrder = [];
-    for (let i = 0; i < total; i++) rollOrder.push(indices[(start + i) % total]);
+    for (let i = 0; i < total; i++)
+      rollOrder.push(indices[(start + i) % total]);
     setDiceVisible(false);
     const results = [];
     const rollNext = (idx) => {
@@ -2135,12 +2227,15 @@ export default function SnakeAndLadder() {
       const idxPlayer = rollOrder[idx];
       const roll = Math.floor(Math.random() * 6) + 1;
       results.push({ index: idxPlayer, roll });
-      setTurnMessage(<>{playerName(idxPlayer)} rolled {roll}</>);
+      setTurnMessage(
+        <>
+          {playerName(idxPlayer)} rolled {roll}
+        </>
+      );
       setTimeout(() => rollNext(idx + 1), 1000);
     };
     rollNext(0);
   }, [ai, aiPositions, setupPhase]);
-
 
   useEffect(() => {
     if (!setupPhase && currentTurn === 0 && !gameOver) {
@@ -2172,10 +2267,7 @@ export default function SnakeAndLadder() {
       setTimeLeft(TURN_TIME);
       if (timerRef.current) clearInterval(timerRef.current);
       timerRef.current = setInterval(() => {
-        const remaining = Math.max(
-          0,
-          (turnEndRef.current - Date.now()) / 1000
-        );
+        const remaining = Math.max(0, (turnEndRef.current - Date.now()) / 1000);
         prevTimeLeftRef.current = remaining;
         setTimeLeft(parseFloat(remaining.toFixed(1)));
       }, 100);
@@ -2202,10 +2294,7 @@ export default function SnakeAndLadder() {
     if (timerRef.current) clearInterval(timerRef.current);
     if (timerSoundRef.current) timerSoundRef.current.pause();
     timerRef.current = setInterval(() => {
-      const remaining = Math.max(
-        0,
-        (turnEndRef.current - Date.now()) / 1000
-      );
+      const remaining = Math.max(0, (turnEndRef.current - Date.now()) / 1000);
       const next = parseFloat(remaining.toFixed(1));
       if (
         currentTurn === myIndex &&
@@ -2231,7 +2320,15 @@ export default function SnakeAndLadder() {
       clearInterval(timerRef.current);
       timerSoundRef.current?.pause();
     };
-  }, [currentTurn, setupPhase, gameOver, moving, isMultiplayer, mpPlayers, muted]);
+  }, [
+    currentTurn,
+    setupPhase,
+    gameOver,
+    moving,
+    isMultiplayer,
+    mpPlayers,
+    muted
+  ]);
 
   // Periodically refresh the component state to avoid freezes
   useEffect(() => {
@@ -2240,8 +2337,6 @@ export default function SnakeAndLadder() {
     }, 5000);
     return () => clearInterval(id);
   }, []);
-
-
 
   const players = isMultiplayer
     ? mpPlayers.map((p, i) => ({
@@ -2270,7 +2365,6 @@ export default function SnakeAndLadder() {
       rankMap[p.idx] = p.pos === 0 ? 0 : i + 1;
     });
 
-
   return (
     <div className="p-4 pb-32 space-y-4 text-text flex flex-col justify-end items-center relative w-full flex-grow">
       {/* Bottom left controls */}
@@ -2280,7 +2374,7 @@ export default function SnakeAndLadder() {
         onGift={() => setShowGift(true)}
       />
       {/* Player photos stacked vertically */}
-        <div className="fixed left-0 top-[45%] -translate-x-1 -translate-y-1/2 flex flex-col space-y-5 z-20">
+      <div className="fixed left-0 top-[45%] -translate-x-1 -translate-y-1/2 flex flex-col space-y-5 z-20">
         {players
           .map((p, i) => ({ ...p, index: i }))
           .map((p) => (
@@ -2292,15 +2386,11 @@ export default function SnakeAndLadder() {
               rank={rankMap[p.index]}
               name={getPlayerName(p.index)}
               isTurn={p.index === currentTurn}
-              timerPct={
-                p.index === currentTurn
-                  ? timeLeft / TURN_TIME
-                  : 1
-              }
+              timerPct={p.index === currentTurn ? timeLeft / TURN_TIME : 1}
               color={p.color}
               onClick={() => {
                 const myIdx = isMultiplayer
-                  ? mpPlayers.findIndex(pl => pl.id === getPlayerId())
+                  ? mpPlayers.findIndex((pl) => pl.id === getPlayerId())
                   : 0;
                 if (p.index !== myIdx) setPlayerPopup(p);
               }}
@@ -2349,7 +2439,7 @@ export default function SnakeAndLadder() {
           }
           setTimeout(
             () => setChatBubbles((b) => b.filter((bb) => bb.id !== id)),
-            3000,
+            3000
           );
         }}
       />
@@ -2361,10 +2451,16 @@ export default function SnakeAndLadder() {
           <GiftPopup
             open={showGift}
             onClose={() => setShowGift(false)}
-            players={players.map((p, i) => ({ ...p, index: i, name: getPlayerName(i) }))}
+            players={players.map((p, i) => ({
+              ...p,
+              index: i,
+              name: getPlayerName(i)
+            }))}
             senderIndex={myIdx}
             onGiftSent={({ from, to, gift }) => {
-              const start = document.querySelector(`[data-player-index="${from}"]`);
+              const start = document.querySelector(
+                `[data-player-index="${from}"]`
+              );
               const end = document.querySelector(`[data-player-index="${to}"]`);
               if (start && end) {
                 const s = start.getBoundingClientRect();
@@ -2372,7 +2468,10 @@ export default function SnakeAndLadder() {
                 const cx = window.innerWidth / 2;
                 const cy = window.innerHeight / 2;
                 let icon;
-                if (typeof gift.icon === 'string' && gift.icon.match(/\.(png|jpg|jpeg|webp|svg)$/)) {
+                if (
+                  typeof gift.icon === 'string' &&
+                  gift.icon.match(/\.(png|jpg|jpeg|webp|svg)$/)
+                ) {
                   icon = document.createElement('img');
                   icon.src = gift.icon;
                   icon.className = 'w-6 h-6';
@@ -2443,12 +2542,19 @@ export default function SnakeAndLadder() {
                 }
                 const animation = icon.animate(
                   [
-                    { transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(1)` },
-                    { transform: `translate(${cx}px, ${cy}px) scale(3)`, offset: 0.5 },
-                    { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(1)` },
+                    {
+                      transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(1)`
+                    },
+                    {
+                      transform: `translate(${cx}px, ${cy}px) scale(3)`,
+                      offset: 0.5
+                    },
+                    {
+                      transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(1)`
+                    }
                   ],
                   // Slow down gift animation to roughly 3.5 seconds
-                  { duration: 3500, easing: 'linear' },
+                  { duration: 3500, easing: 'linear' }
                 );
                 animation.onfinish = () => icon.remove();
               }
@@ -2459,7 +2565,8 @@ export default function SnakeAndLadder() {
       {waitingForPlayers && (
         <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/70">
           <p className="text-white text-lg">
-            Waiting for {playersNeeded} more player{playersNeeded === 1 ? '' : 's'}...
+            Waiting for {playersNeeded} more player
+            {playersNeeded === 1 ? '' : 's'}...
           </p>
         </div>
       )}
@@ -2478,12 +2585,20 @@ export default function SnakeAndLadder() {
       {rewardDice > 0 && (
         <div className="fixed bottom-40 inset-x-0 flex justify-center z-30 pointer-events-none reward-dice-container">
           {Array.from({ length: rewardDice }).map((_, i) => (
-            <img key={i}  src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp" className="reward-dice" />
+            <img
+              key={i}
+              src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp"
+              className="reward-dice"
+            />
           ))}
         </div>
       )}
       {!isMultiplayer && (
-        <div ref={diceRef} style={diceStyle} className="dice-travel flex flex-col items-center relative">
+        <div
+          ref={diceRef}
+          style={diceStyle}
+          className="dice-travel flex flex-col items-center relative"
+        >
           {showTrail && (
             <img
               src="/assets/icons/throwing_hand_down.webp"
@@ -2499,13 +2614,13 @@ export default function SnakeAndLadder() {
                   handleAIRoll(aiRollingIndex, vals);
                   setAiRollingIndex(null);
                 } else {
-                handleRoll(vals);
-                setBonusDice(0);
-              }
-              setRollingIndex(null);
-              setPlayerAutoRolling(false);
-            }}
-            onRollStart={() => {
+                  handleRoll(vals);
+                  setBonusDice(0);
+                }
+                setRollingIndex(null);
+                setPlayerAutoRolling(false);
+              }}
+              onRollStart={() => {
                 if (timerRef.current) clearInterval(timerRef.current);
                 timerSoundRef.current?.pause();
                 setRollingIndex(aiRollingIndex || 0);
@@ -2516,26 +2631,33 @@ export default function SnakeAndLadder() {
                 clearTimeout(trailTimeoutRef.current);
                 trailTimeoutRef.current = setTimeout(
                   () => setShowTrail(false),
-                  DICE_ANIM_DURATION,
+                  DICE_ANIM_DURATION
                 );
                 if (aiRollingIndex)
-                  return setTurnMessage(<>{playerName(aiRollingIndex)} rolling...</>);
+                  return setTurnMessage(
+                    <>{playerName(aiRollingIndex)} rolling...</>
+                  );
                 if (playerAutoRolling) return setTurnMessage('Rolling...');
-                return setTurnMessage("Rolling...");
+                return setTurnMessage('Rolling...');
+              }}
+              clickable={
+                !aiRollingIndex &&
+                !playerAutoRolling &&
+                rollCooldown === 0 &&
+                currentTurn === 0 &&
+                !moving
               }
-            }
-            clickable={
-              !aiRollingIndex &&
-              !playerAutoRolling &&
-              rollCooldown === 0 &&
-              currentTurn === 0 &&
-              !moving
-            }
-            numDice={diceCount + bonusDice}
-            trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
-            showButton={false}
-            muted={muted}
-          />
+              numDice={diceCount + bonusDice}
+              trigger={
+                aiRollingIndex != null
+                  ? aiRollTrigger
+                  : playerAutoRolling
+                    ? playerRollTrigger
+                    : undefined
+              }
+              showButton={false}
+              muted={muted}
+            />
           </div>
         </div>
       )}
@@ -2561,122 +2683,122 @@ export default function SnakeAndLadder() {
           onClick={() => diceRollerDivRef.current?.click()}
         >
           <div className="scale-90">
-          {(() => {
-            const myId = getPlayerId();
-            const myIndex = mpPlayers.findIndex(p => p.id === myId);
-            if (currentTurn === myIndex && !moving) {
-              return (
-                <DiceRoller
-                  clickable
-                  showButton={false}
-                  muted={muted}
-                  emitRollEvent
-                  divRef={diceRollerDivRef}
-                />
-              );
-            }
-            return null;
-          })()}
+            {(() => {
+              const myId = getPlayerId();
+              const myIndex = mpPlayers.findIndex((p) => p.id === myId);
+              if (currentTurn === myIndex && !moving) {
+                return (
+                  <DiceRoller
+                    clickable
+                    showButton={false}
+                    muted={muted}
+                    emitRollEvent
+                    divRef={diceRollerDivRef}
+                  />
+                );
+              }
+              return null;
+            })()}
           </div>
         </div>
       )}
       {!watchOnly && (
-      <InfoPopup
-        open={showQuitInfo}
-        onClose={() => setShowQuitInfo(false)}
-        title="Warning"
-        info="If you quit the game your funds will be lost and you will be placed last."
-        widthClass="w-80"
-      />
+        <InfoPopup
+          open={showQuitInfo}
+          onClose={() => setShowQuitInfo(false)}
+          title="Warning"
+          info="If you quit the game your funds will be lost and you will be placed last."
+          widthClass="w-80"
+        />
       )}
       {!watchOnly && (
-      <InfoPopup
-        open={showInfo}
-        onClose={() => setShowInfo(false)}
-        title="Snake & Ladder"
-        info="Roll two dice each turn. Move forward by their sum. Ladders lift you up and snakes bring you down. You must land exactly on the pot tile to win."
-      />
+        <InfoPopup
+          open={showInfo}
+          onClose={() => setShowInfo(false)}
+          title="Snake & Ladder"
+          info="Roll two dice each turn. Move forward by their sum. Ladders lift you up and snakes bring you down. You must land exactly on the pot tile to win."
+        />
       )}
       {!watchOnly && (
-      <HintPopup
-        open={showExactHelp}
-        onClose={() => setShowExactHelp(false)}
-        message="You must roll the exact number to land on the pot."
-      />
+        <HintPopup
+          open={showExactHelp}
+          onClose={() => setShowExactHelp(false)}
+          message="You must roll the exact number to land on the pot."
+        />
       )}
       {!watchOnly && (
-      <InfoPopup
-        open={connectionLost}
-        onClose={() => setConnectionLost(false)}
-        title="Connection Lost"
-        info="Attempting to reconnect..."
-      />
+        <InfoPopup
+          open={connectionLost}
+          onClose={() => setConnectionLost(false)}
+          title="Connection Lost"
+          info="Attempting to reconnect..."
+        />
       )}
       {!watchOnly && (
-      <InfoPopup
-        open={forfeitMsg}
-        onClose={() => setForfeitMsg(false)}
-        title="Disconnected"
-        info="You were disconnected too long and forfeited the match."
-      />
+        <InfoPopup
+          open={forfeitMsg}
+          onClose={() => setForfeitMsg(false)}
+          title="Disconnected"
+          info="You were disconnected too long and forfeited the match."
+        />
       )}
       {!watchOnly && (
-      <InfoPopup
-        open={!!disconnectMsg}
-        onClose={() => setDisconnectMsg(null)}
-        title="Player Update"
-        info={disconnectMsg}
-      />
+        <InfoPopup
+          open={!!disconnectMsg}
+          onClose={() => setDisconnectMsg(null)}
+          title="Player Update"
+          info={disconnectMsg}
+        />
       )}
       {!watchOnly && (
-      <InfoPopup
-        open={!!cheatMsg}
-        onClose={() => setCheatMsg(null)}
-        title="Warning"
-        info={cheatMsg}
-      />
+        <InfoPopup
+          open={!!cheatMsg}
+          onClose={() => setCheatMsg(null)}
+          title="Warning"
+          info={cheatMsg}
+        />
       )}
       {!watchOnly && (
-      <InfoPopup
-        open={!!leftWinner}
-        onClose={() => setLeftWinner(null)}
-        title="Opponent Left"
-        info={
-          leftWinner && (
-            <span>
-              {leftWinner} left the game. You win {Math.round(pot * 2 * 0.91)}{' '}
-              <img
-                src={
-                  token === 'TON'
-                    ? '/assets/icons/TON.webp'
-                    : token === 'USDT'
-                    ? '/assets/icons/Usdt.webp'
-                    : '/assets/icons/TPCcoin_1.webp'
-                }
-                alt={token}
-                className="inline w-4 h-4 align-middle"
-              />
-            </span>
-          )
-        }
-      >
-        <div className="flex justify-center mt-2">
-          <button
-            onClick={() => navigate('/games/snake/lobby')}
-            className="lobby-tile px-4 py-1"
-          >
-            Return to Lobby
-          </button>
-        </div>
-      </InfoPopup>
+        <InfoPopup
+          open={!!leftWinner}
+          onClose={() => setLeftWinner(null)}
+          title="Opponent Left"
+          info={
+            leftWinner && (
+              <span>
+                {leftWinner} left the game. You win {Math.round(pot * 2 * 0.91)}{' '}
+                <img
+                  src={
+                    token === 'TON'
+                      ? '/assets/icons/TON.webp'
+                      : token === 'USDT'
+                        ? '/assets/icons/Usdt.webp'
+                        : '/assets/icons/TPCcoin_1.webp'
+                  }
+                  alt={token}
+                  className="inline w-4 h-4 align-middle"
+                />
+              </span>
+            )
+          }
+        >
+          <div className="flex justify-center mt-2">
+            <button
+              onClick={() => navigate('/games/snake/lobby')}
+              className="lobby-tile px-4 py-1"
+            >
+              Return to Lobby
+            </button>
+          </div>
+        </InfoPopup>
       )}
       {watchOnly && (
-      <InfoPopup
-        open={showWatchWelcome}
-        onClose={() => setShowWatchWelcome(false)}
-        title="Watching Game"
-        info="You're watching this match. Support your player by sending NFT GIFs and chat messages. Watching is free, but each chat costs 10 TPC."
-      />
+        <InfoPopup
+          open={showWatchWelcome}
+          onClose={() => setShowWatchWelcome(false)}
+          title="Watching Game"
+          info="You're watching this match. Support your player by sending NFT GIFs and chat messages. Watching is free, but each chat costs 10 TPC."
+        />
       )}
       <GameEndPopup
         open={gameOver}
@@ -2687,19 +2809,20 @@ export default function SnakeAndLadder() {
         }}
         onReturn={() => {
           localStorage.removeItem(`snakeGameState_${ai}`);
-          navigate("/games/snake/lobby");
+          navigate('/games/snake/lobby');
         }}
+        onClose={() => setGameOver(false)}
       />
       {!watchOnly && (
-      <ConfirmPopup
-        open={showLobbyConfirm}
-        message="Quit the game? If you leave, your funds will be lost and you'll be placed last."
-        onConfirm={() => {
-          localStorage.removeItem(`snakeGameState_${ai}`);
-          navigate("/games/snake/lobby");
-        }}
-        onCancel={() => setShowLobbyConfirm(false)}
-      />
+        <ConfirmPopup
+          open={showLobbyConfirm}
+          message="Quit the game? If you leave, your funds will be lost and you'll be placed last."
+          onConfirm={() => {
+            localStorage.removeItem(`snakeGameState_${ai}`);
+            navigate('/games/snake/lobby');
+          }}
+          onCancel={() => setShowLobbyConfirm(false)}
+        />
       )}
     </div>
   );

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LoginOptions from '../components/LoginOptions.jsx';
-import { getTelegramId, getTelegramPhotoUrl, getPlayerId } from '../utils/telegram.js';
+import {
+  getTelegramId,
+  getTelegramPhotoUrl,
+  getPlayerId
+} from '../utils/telegram.js';
 import { FaCircle } from 'react-icons/fa';
 import DailyCheckIn from '../components/DailyCheckIn.jsx';
 import SpinGame from '../components/SpinGame.jsx';
@@ -68,8 +72,8 @@ export default function Mining() {
       getProfile(telegramId)
         .then((p) =>
           setMyName(
-            p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim(),
-          ),
+            p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim()
+          )
         )
         .catch(() => {});
     } else {
@@ -83,12 +87,16 @@ export default function Mining() {
               if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
             });
           }
-          setMyName(p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim());
+          setMyName(
+            p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim()
+          );
         })
         .catch(() => {
           fetchTelegramInfo(telegramId).then((info) => {
             if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
-            setMyName(`${info?.firstName || ''} ${info?.lastName || ''}`.trim());
+            setMyName(
+              `${info?.firstName || ''} ${info?.lastName || ''}`.trim()
+            );
           });
         });
     }
@@ -104,7 +112,9 @@ export default function Mining() {
           .then((p) => {
             setMyPhotoUrl(p?.photo || getTelegramPhotoUrl());
             if (p?.photo) saveAvatar(p.photo);
-            setMyName(p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim());
+            setMyName(
+              p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim()
+            );
           })
           .catch(() => setMyPhotoUrl(getTelegramPhotoUrl()));
       }
@@ -129,180 +139,206 @@ export default function Mining() {
 
   return (
     <>
-    <DailyCheckIn />
-    <SpinGame />
-    <LuckyNumber />
-    <MiningCard />
+      <DailyCheckIn />
+      <SpinGame />
+      <LuckyNumber />
+      <MiningCard />
 
       <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-text overflow-hidden wide-card">
-      <img
-        src="/assets/SnakeLaddersbackground.png"
-        className="background-behind-board object-cover"
-        alt=""
-        onError={(e) => {
-          e.currentTarget.style.display = 'none';
-        }}
-      />
+        <img
+          src="/assets/SnakeLaddersbackground.png"
+          className="background-behind-board object-cover"
+          alt=""
+          onError={(e) => {
+            e.currentTarget.style.display = 'none';
+          }}
+        />
         <h2 className="text-xl font-bold text-center">Mining</h2>
 
-      {friendRequests.length > 0 && (
-        <section className="space-y-1">
-          <h3 className="text-lg font-semibold">Friend Requests</h3>
-          {friendRequests.map((fr) => (
-            <div key={fr._id} className="lobby-tile flex items-center justify-between">
-              <span>{fr.from}</span>
-              <button
-                onClick={async () => {
-                  await acceptFriendRequest(fr._id);
-                  listFriendRequests(telegramId).then(setFriendRequests);
-                }}
-                className="px-2 py-1 text-sm bg-primary hover:bg-primary-hover rounded"
+        {friendRequests.length > 0 && (
+          <section className="space-y-1">
+            <h3 className="text-lg font-semibold">Friend Requests</h3>
+            {friendRequests.map((fr) => (
+              <div
+                key={fr._id}
+                className="lobby-tile flex items-center justify-between"
               >
-                Accept
-              </button>
-            </div>
-          ))}
-        </section>
-      )}
-
-      <section className="space-y-1">
-        <h3 className="text-lg font-semibold">Friends</h3>
-        <p>Invited friends: {referral.referralCount}</p>
-        <p>Mining boost: +{referral.bonusMiningRate * 100}%</p>
-        {referral.storeMiningRate && referral.storeMiningExpiresAt && (
-          <p className="text-sm text-subtext">
-            Boost ends in {Math.max(0, Math.floor((new Date(referral.storeMiningExpiresAt).getTime() - Date.now()) / 86400000))}d
-          </p>
+                <span>{fr.from}</span>
+                <button
+                  onClick={async () => {
+                    await acceptFriendRequest(fr._id);
+                    listFriendRequests(telegramId).then(setFriendRequests);
+                  }}
+                  className="px-2 py-1 text-sm bg-primary hover:bg-primary-hover rounded"
+                >
+                  Accept
+                </button>
+              </div>
+            ))}
+          </section>
         )}
-      </section>
 
-      <section className="space-y-1">
-        <h3 className="text-lg font-semibold">Referral</h3>
-        <div className="flex items-center space-x-2">
-          <input
-            type="text"
-            readOnly
-            value={link}
-            onClick={(e) => e.target.select()}
-            className="flex-1 bg-surface border border-border rounded px-2 py-1 text-sm"
-          />
-          <button
-            onClick={() => navigator.clipboard.writeText(link)}
-            className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"
-          >
-            Copy
-          </button>
-        </div>
-        <div className="flex items-center space-x-2 mt-2">
-          <input
-            type="text"
-            placeholder="Paste link or code"
-            value={claim}
-            onChange={(e) => setClaim(e.target.value)}
-            className="flex-1 bg-surface border border-border rounded px-2 py-1 text-sm"
-          />
-          <button
-            onClick={async () => {
-              const c = claim.includes('start=') ? claim.split('start=')[1] : claim;
-              try {
-                const res = await claimReferral(telegramId, c.trim());
-                if (!res.error) {
-                  setClaimMsg('Referral claimed!');
-                  getReferralInfo(telegramId).then(setReferral);
-                } else {
-                  setClaimMsg(res.error || res.message || 'Failed');
+        <section className="space-y-1">
+          <h3 className="text-lg font-semibold">Friends</h3>
+          <p>Invited friends: {referral.referralCount}</p>
+          <p>Mining boost: +{referral.bonusMiningRate * 100}%</p>
+          {referral.storeMiningRate && referral.storeMiningExpiresAt && (
+            <p className="text-sm text-subtext">
+              Boost ends in{' '}
+              {Math.max(
+                0,
+                Math.floor(
+                  (new Date(referral.storeMiningExpiresAt).getTime() -
+                    Date.now()) /
+                    86400000
+                )
+              )}
+              d
+            </p>
+          )}
+        </section>
+
+        <section className="space-y-1">
+          <h3 className="text-lg font-semibold">Referral</h3>
+          <div className="flex items-center space-x-2">
+            <input
+              type="text"
+              readOnly
+              value={link}
+              onClick={(e) => e.target.select()}
+              className="flex-1 bg-surface border border-border rounded px-2 py-1 text-sm"
+            />
+            <button
+              onClick={() => navigator.clipboard.writeText(link)}
+              className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"
+            >
+              Copy
+            </button>
+          </div>
+          <div className="flex items-center space-x-2 mt-2">
+            <input
+              type="text"
+              placeholder="Paste link or code"
+              value={claim}
+              onChange={(e) => setClaim(e.target.value)}
+              className="flex-1 bg-surface border border-border rounded px-2 py-1 text-sm"
+            />
+            <button
+              onClick={async () => {
+                const c = claim.includes('start=')
+                  ? claim.split('start=')[1]
+                  : claim;
+                try {
+                  const res = await claimReferral(telegramId, c.trim());
+                  if (!res.error) {
+                    setClaimMsg('Referral claimed!');
+                    getReferralInfo(telegramId).then(setReferral);
+                  } else {
+                    setClaimMsg(res.error || res.message || 'Failed');
+                  }
+                } catch {
+                  setClaimMsg('Failed');
                 }
-              } catch {
-                setClaimMsg('Failed');
-              }
-            }}
-            className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"
-          >
-            Claim
-          </button>
-        </div>
-        {claimMsg && <p className="text-xs text-subtext">{claimMsg}</p>}
-      </section>
+              }}
+              className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"
+            >
+              Claim
+            </button>
+          </div>
+          {claimMsg && <p className="text-xs text-subtext">{claimMsg}</p>}
+        </section>
 
-      <section className="space-y-1">
-        <h3 className="text-lg font-semibold text-center">Add Friends</h3>
-        <UserSearchBar />
-      </section>
-    </div>
+        <section className="space-y-1">
+          <h3 className="text-lg font-semibold text-center">Add Friends</h3>
+          <UserSearchBar />
+        </section>
+      </div>
 
-    <PlayerInvitePopup
-      open={!!inviteTarget}
-      player={inviteTarget}
-      stake={stake}
-      onStakeChange={setStake}
-      onInvite={() => {
-        if (inviteTarget) {
-          const roomId = `invite-${accountId}-${inviteTarget.accountId}-${Date.now()}-2`;
-          socket.emit(
-            'invite1v1',
-            {
-              fromId: accountId,
-              fromTelegramId: telegramId,
-              fromName: myName,
-              toId: inviteTarget.accountId,
-              toTelegramId: inviteTarget.telegramId,
-              roomId,
-              token: stake.token,
-              amount: stake.amount,
-            },
-            (res) => {
-              if (res && res.success) {
-                window.location.href = `/games/snake?table=${roomId}&token=${stake.token}&amount=${stake.amount}`;
-              } else {
-                alert(res?.error || 'Failed to send invite');
+      <PlayerInvitePopup
+        open={!!inviteTarget}
+        player={inviteTarget}
+        stake={stake}
+        onStakeChange={setStake}
+        onInvite={() => {
+          if (inviteTarget) {
+            const roomId = `invite-${accountId}-${inviteTarget.accountId}-${Date.now()}-2`;
+            socket.emit(
+              'invite1v1',
+              {
+                fromId: accountId,
+                fromTelegramId: telegramId,
+                fromName: myName,
+                toId: inviteTarget.accountId,
+                toTelegramId: inviteTarget.telegramId,
+                roomId,
+                token: stake.token,
+                amount: stake.amount
+              },
+              (res) => {
+                if (res && res.success) {
+                  window.location.href = `/games/snake?table=${roomId}&token=${stake.token}&amount=${stake.amount}`;
+                } else {
+                  alert(res?.error || 'Failed to send invite');
+                }
               }
-            },
-          );
-        }
-        setInviteTarget(null);
-      }}
-      onClose={() => setInviteTarget(null)}
-    />
-    <InvitePopup
-      open={groupPopup}
-      name={selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim())}
-      stake={stake}
-      onStakeChange={setStake}
-      group
-      opponents={selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim())}
-      onAccept={() => {
-        if (selected.length > 0) {
-          const roomId = `invite-${accountId}-${Date.now()}-${selected.length + 1}`;
-          socket.emit(
-            'inviteGroup',
-            {
-              fromId: accountId,
-              fromTelegramId: telegramId,
-              fromName: myName,
-              toIds: selected.map((u) => u.accountId),
-              telegramIds: selected.map((u) => u.telegramId),
-              opponentNames: selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim()),
-              roomId,
-              token: stake.token,
-              amount: stake.amount,
-            },
-            (res) => {
-              if (res && res.success) {
-                window.location.href = `/games/snake?table=${roomId}&token=${stake.token}&amount=${stake.amount}`;
-              } else {
-                alert(res?.error || 'Failed to send invite');
+            );
+          }
+          setInviteTarget(null);
+        }}
+        onClose={() => setInviteTarget(null)}
+      />
+      <InvitePopup
+        open={groupPopup}
+        name={selected.map(
+          (u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim()
+        )}
+        stake={stake}
+        onStakeChange={setStake}
+        group
+        opponents={selected.map(
+          (u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim()
+        )}
+        onClose={() => {
+          setGroupPopup(false);
+          setSelected([]);
+        }}
+        onAccept={() => {
+          if (selected.length > 0) {
+            const roomId = `invite-${accountId}-${Date.now()}-${selected.length + 1}`;
+            socket.emit(
+              'inviteGroup',
+              {
+                fromId: accountId,
+                fromTelegramId: telegramId,
+                fromName: myName,
+                toIds: selected.map((u) => u.accountId),
+                telegramIds: selected.map((u) => u.telegramId),
+                opponentNames: selected.map(
+                  (u) =>
+                    u.nickname ||
+                    `${u.firstName || ''} ${u.lastName || ''}`.trim()
+                ),
+                roomId,
+                token: stake.token,
+                amount: stake.amount
+              },
+              (res) => {
+                if (res && res.success) {
+                  window.location.href = `/games/snake?table=${roomId}&token=${stake.token}&amount=${stake.amount}`;
+                } else {
+                  alert(res?.error || 'Failed to send invite');
+                }
               }
-            },
-          );
-        }
-        setGroupPopup(false);
-        setSelected([]);
-      }}
-      onReject={() => {
-        setGroupPopup(false);
-        setSelected([]);
-      }}
-    />
+            );
+          }
+          setGroupPopup(false);
+          setSelected([]);
+        }}
+        onReject={() => {
+          setGroupPopup(false);
+          setSelected([]);
+        }}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add top-right close buttons to various popups
- warn before closing confirmation popups
- close invite dialog from multiple pages
- allow dismissing end game popups

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm test` *(fails: cannot find module 'wrappers/GameStake.js')*

------
https://chatgpt.com/codex/tasks/task_e_687b7b368db08329956ab17b985c0455