### PR TITLE
Fix multiplayer table start conditions

### DIFF
--- a/test/lobbyUtils.test.js
+++ b/test/lobbyUtils.test.js
@@ -35,3 +35,7 @@ test('cannot start multiplayer table until full', () => {
   assert.equal(canStartGame('snake', dummyTable, { token: 'TON', amount: 100 }, 0, 1), false);
   assert.equal(canStartGame('snake', dummyTable, { token: 'TON', amount: 100 }, 0, 2), true);
 });
+
+test('cannot start when table over capacity', () => {
+  assert.equal(canStartGame('snake', dummyTable, { token: 'TON', amount: 100 }, 0, 3), false);
+});

--- a/webapp/src/utils/lobby.js
+++ b/webapp/src/utils/lobby.js
@@ -4,7 +4,8 @@ export function canStartGame(game, table, stake, aiCount = 0, players = 0) {
     return aiCount > 0;
   }
   if (game === 'snake' && table && table.id !== 'single') {
-    if (players < (table.capacity || 0)) return false;
+    const capacity = table.capacity || 0;
+    if (players !== capacity) return false;
   }
   if (!stake || !stake.token || !stake.amount) return false;
   if (game === 'snake' && !table) return false;


### PR DESCRIPTION
## Summary
- ensure player count exactly matches table capacity
- test for start conditions when over capacity

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b7be3abd88329b166dd7ad6c800cc