### PR TITLE
Update bomb capture effect

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -296,7 +296,8 @@ input:focus {
 }
 
 .token-three.burning {
-  animation: token-burn 1.5s forwards;
+  /* Scale up immediately after the explosion and slowly shrink */
+  animation: token-burn 10s forwards;
 }
 
 .token-three.burning::after {
@@ -311,9 +312,15 @@ input:focus {
 }
 
 @keyframes token-burn {
+  from {
+    /* Double in size right after the explosion */
+    transform: translateZ(32px) scale(2);
+    opacity: 1;
+  }
   to {
+    /* Fade out while returning to normal size */
     opacity: 0;
-    transform: translateZ(32px) scale(0.3);
+    transform: translateZ(32px) scale(1);
   }
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -109,6 +109,8 @@ const ROWS = 20;
 const COLS = 5;
 const FINAL_TILE = ROWS * COLS + 1; // 101
 const TURN_TIME = 15;
+// Duration of the burn animation/sound effect in milliseconds
+const BURN_ANIM_DURATION = 10000;
 
 function shuffle(arr) {
   const copy = [...arr];
@@ -821,8 +823,8 @@ export default function SnakeAndLadder() {
       }
       victims.forEach((idx) => {
         setBurning((b) => [...b, idx]);
+        // Reset the piece position after the initial explosion effect
         setTimeout(() => {
-          setBurning((b) => b.filter((v) => v !== idx));
           if (idx === 0) setPos(0);
           else setAiPositions((arr) => {
             const copy = [...arr];
@@ -830,6 +832,10 @@ export default function SnakeAndLadder() {
             return copy;
           });
         }, 1000);
+        // Keep the burning animation for the duration of the sound effect
+        setTimeout(() => {
+          setBurning((b) => b.filter((v) => v !== idx));
+        }, BURN_ANIM_DURATION);
       });
     }
   };
@@ -1395,11 +1401,15 @@ export default function SnakeAndLadder() {
         hahaSoundRef.current.currentTime = 0;
         hahaSoundRef.current.play().catch(() => {});
       }
+      // Move the player back to the start shortly after the explosion
       setTimeout(() => {
-        setBurning((b) => b.filter((v) => v !== idx));
         setMpPlayers((p) => p.map((pl) => (pl.id === playerId ? { ...pl, position: 0 } : pl)));
         if (playerId === accountId) setPos(0);
       }, 1000);
+      // Allow the burn animation to play out fully before clearing the state
+      setTimeout(() => {
+        setBurning((b) => b.filter((v) => v !== idx));
+      }, BURN_ANIM_DURATION);
     };
     const onTurn = ({ playerId }) => {
       const idx = playersRef.current.findIndex((pl) => pl.id === playerId);


### PR DESCRIPTION
## Summary
- scale captured avatars larger before shrinking to normal size
- run burn animation for the entire bomb sound duration

## Testing
- `npm test` *(fails: Cannot find package 'geoip-lite')*

------
https://chatgpt.com/codex/tasks/task_e_687b896715e88329abbbaa6fdaf01cf2