### PR TITLE
Fix lobby connection for https

### DIFF
--- a/webapp/src/utils/socket.js
+++ b/webapp/src/utils/socket.js
@@ -1,4 +1,9 @@
 import { io } from 'socket.io-client';
 
-const baseUrl = import.meta.env.VITE_API_BASE_URL || window.location.origin;
+let baseUrl = import.meta.env.VITE_API_BASE_URL || window.location.origin;
+
+if (typeof window !== 'undefined' && window.location.protocol === 'https:' && baseUrl.startsWith('http:')) {
+  baseUrl = baseUrl.replace(/^http:/, 'https:');
+}
+
 export const socket = io(baseUrl);


### PR DESCRIPTION
## Summary
- adjust socket url to prefer `https` when page is served over `https`

## Testing
- `npm test` *(fails: cannot find module `wrappers/GameStake.js`)*

------
https://chatgpt.com/codex/tasks/task_e_687bdcaabf8c8329987760ca8b853298