### PR TITLE
Fix lobby player detection and staking notice

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -248,13 +248,17 @@ export default function Lobby() {
     navigate(`/games/${game}?${params.toString()}`);
   };
 
+  const playerPresent = players.some(
+    (p) => String(p.id) === String(playerName)
+  );
+  const totalPlayers = playerPresent ? players.length : players.length + 1;
   const waitingForPlayers =
     game === 'snake' &&
     table &&
     table.id !== 'single' &&
-    players.length < table.capacity;
+    totalPlayers < table.capacity;
   const disabled =
-    !canStartGame(game, table, stake, aiCount, players.length) ||
+    !canStartGame(game, table, stake, aiCount, totalPlayers) ||
     (game === 'snake' && table?.id === 'single' && !aiType) ||
     (game === 'snake' && table?.id === 'single' && aiType === 'leaders' && leaders.length !== aiCount) ||
     (game === 'snake' && table?.id === 'single' && aiType === 'flags' && flags.length !== aiCount);
@@ -299,7 +303,8 @@ export default function Lobby() {
           tokens={table?.id === 'single' ? ['TPC'] : ['TPC', 'TON', 'USDT']}
         />
         <p className="text-center text-subtext text-sm">
-          Staking is handled via the on-chain contract.
+          TON and USDT staking coming soon. Smart contract under
+          construction.
         </p>
       </div>
       {game === 'snake' && table?.id === 'single' && (


### PR DESCRIPTION
## Summary
- improve snake lobby waiting logic to include current player when not listed
- mention that TON/USDT staking is coming soon in snake lobby

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c0514bf34832981e1780a11bc6ef0