### PR TITLE
Add claim to TON wallet

### DIFF
--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -218,6 +218,10 @@ export function withdraw(telegramId, address, amount) {
   return post('/api/wallet/withdraw', { telegramId, address, amount });
 }
 
+export function claimExternal(telegramId, address, amount) {
+  return post('/api/wallet/claim-external', { telegramId, address, amount });
+}
+
 export function getReferralInfo(telegramId) {
 
   return post('/api/referral/code', { telegramId });


### PR DESCRIPTION
## Summary
- allow claiming TPC to an external TON wallet via new API route
- expose `claimExternal` helper in the webapp API utils
- add claim form on the wallet page

## Testing
- `npm test` *(fails: cannot complete due to missing environment dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c7b7cdf1c8329bf3dc28f6360c10c