### PR TITLE
Add claim wallet integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
      (falls back to an in-memory database if unset)
    - `AIRDROP_ADMIN_TOKENS` – (optional) tokens allowed to trigger airdrops
    - `DEPOSIT_WALLET_ADDRESS` – TON address that receives user deposits
+   - `STORE_DEPOSIT_ADDRESS` – address receiving TON for store bundles
+   - `TPC_CLAIM_WALLET_ADDRESS` – Jetton wallet used for external claims
+   - `TPC_CLAIM_MNEMONIC` – seed phrase for the claim wallet
+   - `CLAIM_RPC_URL` – RPC endpoint used when sending claim transactions
    - `PORT` – (optional) port for the bot API server (defaults to 3000)
 - `DEV_ACCOUNT_ID` – account ID that collects transfer fees
 

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -28,7 +28,14 @@ ENABLE_TWITTER_OAUTH=false
 # Example: EQCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 DEPOSIT_WALLET_ADDRESS=
 # TON address that receives payments for store bundles
-STORE_DEPOSIT_ADDRESS=UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT
+STORE_DEPOSIT_ADDRESS=UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1
+
+# Jetton wallet used for external TPC claims
+TPC_CLAIM_WALLET_ADDRESS=UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1
+# Seed phrase for the claim wallet
+TPC_CLAIM_MNEMONIC=
+# RPC endpoint for sending claim transactions
+CLAIM_RPC_URL=https://testnet.toncenter.com/api/v2/jsonRPC
 
 # Account IDs that receive developer fees
 # Primary developer account (Tur.Alimadhi)

--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -8,7 +8,7 @@ import TonWeb from 'tonweb';
 const router = Router();
 
 const STORE_ADDRESS = process.env.STORE_DEPOSIT_ADDRESS ||
-  'UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT';
+  'UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1';
 
 function normalize(addr) {
   try {

--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -7,6 +7,7 @@ import User from '../models/User.js';
 import bot from '../bot.js';
 import Message from '../models/Message.js';
 import { sendTransferNotification, sendTPCNotification } from '../utils/notifications.js';
+import { sendClaim } from '../utils/claimWallet.js';
 
 import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
 
@@ -446,8 +447,11 @@ router.post('/claim-external', authenticate, async (req, res) => {
 
   user.transactions.push(tx);
   await user.save();
-
-  // In a real implementation the server would transfer TPC to `address` here
+  try {
+    await sendClaim(address, amount);
+  } catch (err) {
+    console.error('Failed to send on-chain claim:', err.message);
+  }
 
   res.json({ balance: user.balance, transaction: tx });
 });

--- a/bot/utils/claimWallet.js
+++ b/bot/utils/claimWallet.js
@@ -1,0 +1,30 @@
+import { mnemonicToWalletKey } from 'ton-crypto';
+import { TonClient4, WalletContractV4 } from 'ton';
+import { Address, beginCell, toNano } from '@ton/core';
+
+export async function sendClaim(toAddress, amount) {
+  const mnemonic = process.env.TPC_CLAIM_MNEMONIC;
+  const endpoint = process.env.CLAIM_RPC_URL;
+  const walletAddr = process.env.TPC_CLAIM_WALLET_ADDRESS;
+  if (!mnemonic || !endpoint || !walletAddr) {
+    throw new Error('claim wallet credentials not set');
+  }
+  const keyPair = await mnemonicToWalletKey(mnemonic.trim().split(/\s+/));
+  const client = new TonClient4({ endpoint });
+  const wallet = WalletContractV4.create({ workchain: 0, publicKey: keyPair.publicKey });
+  const walletContract = client.open(wallet);
+  const jettonWallet = Address.parse(walletAddr);
+  const jettonAmount = BigInt(amount) * 1000000000n;
+  const body = beginCell()
+    .storeUint(0xf8a7ea5, 32)
+    .storeUint(0, 64)
+    .storeCoins(jettonAmount)
+    .storeAddress(Address.parse(toAddress))
+    .storeAddress(wallet.address)
+    .storeMaybeRef(null)
+    .storeCoins(0n)
+    .storeMaybeRef(null)
+    .endCell();
+  const sender = walletContract.sender(client.provider(), keyPair.secretKey);
+  await sender.send({ to: jettonWallet, value: toNano('0.05'), bounce: true, body });
+}

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -1,3 +1,3 @@
 MNEMONIC=your twelve or twenty-four word phrase
 RPC_URL=https://testnet.toncenter.com/api/v2/jsonRPC
-ADMIN_ADDRESS=UQDqDBiNU132j15Qka5EmSf37jCTLF-RdOlaQOXLHIJ5t-XT
+ADMIN_ADDRESS=UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1


### PR DESCRIPTION
## Summary
- use new TON address for store payments
- document claim wallet variables in README and env example
- update admin address sample
- implement `sendClaim` helper for on-chain claims
- call the helper from the external claim route

## Testing
- `npm test` *(fails: Subtest: cannot start when table over capacity)*

------
https://chatgpt.com/codex/tasks/task_e_687c8ec6d49c83299337d63b11078639