### PR TITLE
Fix jetton delivery on claim

### DIFF
--- a/tpc_claim_wallet.fc
+++ b/tpc_claim_wallet.fc
@@ -1,48 +1,194 @@
 ;; TPC Claim Jetton Minter
 ;; Admin Wallet: UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1
-;; This contract handles claims and store bundle payouts.
+;; This contract handles claims and automatically transfers Jettons
+;; when a claim or bundle purchase is confirmed.
 
 #include "stdlib.fc";
-#include "cell.fc";
+#include "ft/params.fc";
+#include "ft/op-codes.fc";
+#include "ft/discovery-params.fc";
+#include "ft/jetton-utils.fc";
 
 const op::claim = 0x01;
 const op::bundle_purchase = 0x02;
 
-global jetton_total_supply = 0;
-global admin_address = "UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1";
-global bundles = dict_new(); ;; bundle_id -> jetton amount
+;; Additional ton amount forwarded with wallet deployment/transfer
+int wallet_forward_amount() asm "10000000 PUSHINT"; ;; 0.01 TON
 
-;; --- Helpers ---
-int is_admin(slice sender) {
-    return equal_slice_bits(sender, admin_address);
+;; storage#_ total_supply:Coins admin_address:MsgAddress content:^Cell jetton_wallet_code:^Cell bundles:^Cell = Storage;
+
+(int, slice, cell, cell, cell) load_data() inline {
+    slice ds = get_data().begin_parse();
+    return (
+        ds~load_coins(),       ;; total_supply
+        ds~load_msg_addr(),    ;; admin_address
+        ds~load_ref(),         ;; content
+        ds~load_ref(),         ;; jetton_wallet_code
+        ds~load_ref()          ;; bundles dictionary
+    );
 }
 
-() send_jettons(slice user_wallet, int amount) impure {
-    jetton_total_supply += amount;
-    ;; Pseudo: integrate Jetton wallet transfer message
+() save_data(int total_supply, slice admin_address, cell content, cell jetton_wallet_code, cell bundles) impure inline {
+    set_data(begin_cell()
+        .store_coins(total_supply)
+        .store_slice(admin_address)
+        .store_ref(content)
+        .store_ref(jetton_wallet_code)
+        .store_ref(bundles)
+    .end_cell());
 }
 
-;; --- External message handler ---
-() recv_external(slice in_msg_body, slice in_msg_sender) impure {
+() mint_tokens(slice to_address, cell jetton_wallet_code, int ton_amount, cell master_msg) impure {
+    cell state_init = calculate_jetton_wallet_state_init(to_address, my_address(), jetton_wallet_code);
+    slice to_wallet_address = calculate_jetton_wallet_address(state_init);
+    var msg = begin_cell()
+        .store_uint(0x18, 6)
+        .store_slice(to_wallet_address)
+        .store_coins(ton_amount)
+        .store_uint(4 + 2 + 1, 1 + 4 + 4 + 64 + 32 + 1 + 1 + 1)
+        .store_ref(state_init)
+        .store_ref(master_msg);
+    send_raw_message(msg.end_cell(), 1);
+}
+
+() send_jettons(slice user_wallet, int jetton_amount) impure {
+    var (total_supply, admin_addr, content, wallet_code, bundles) = load_data();
+    var transfer = begin_cell()
+        .store_uint(op::internal_transfer(), 32)
+        .store_uint(0, 64)
+        .store_coins(jetton_amount)
+        .store_slice(my_address())
+        .store_slice(user_wallet)
+        .store_coins(0)
+        .store_uint(0, 1)
+    .end_cell();
+    mint_tokens(user_wallet, wallet_code, wallet_forward_amount(), transfer);
+    save_data(total_supply + jetton_amount, admin_addr, content, wallet_code, bundles);
+}
+
+() recv_internal(int msg_value, cell in_msg_full, slice in_msg_body) impure {
+    if (in_msg_body.slice_empty?()) {
+        return ();
+    }
+    slice cs = in_msg_full.begin_parse();
+    int flags = cs~load_uint(4);
+    if (flags & 1) {
+        return (); ;; ignore bounced
+    }
+    slice sender_address = cs~load_msg_addr();
+    cs~load_msg_addr();
+    cs~load_coins();
+    cs~skip_bits(1);
+    cs~load_coins();
+    cs~load_coins();
+
     int op = in_msg_body~load_uint(32);
+    int query_id = in_msg_body~load_uint(64);
+
+    var (total_supply, admin_addr, content, wallet_code, bundles) = load_data();
 
     if (op == op::claim) {
-        var user_wallet = in_msg_body~load_msg_addr();
-        var amount = in_msg_body~load_coins();
-        throw_if_not(is_admin(in_msg_sender), 101);
+        slice user_wallet = in_msg_body~load_msg_addr();
+        int amount = in_msg_body~load_coins();
+        throw_unless(101, equal_slices(sender_address, admin_addr));
         send_jettons(user_wallet, amount);
-    } elseif (op == op::bundle_purchase) {
-        var user_wallet = in_msg_body~load_msg_addr();
-        var bundle_id = in_msg_body~load_uint(32);
-        throw_if_not(dict_has_key(bundles, bundle_id), 102);
-        var bundle_amount = dict_get(bundles, bundle_id);
-        send_jettons(user_wallet, bundle_amount);
-    } else {
-        throw(100);
+        return ();
     }
+
+    if (op == op::bundle_purchase) {
+        slice user_wallet = in_msg_body~load_msg_addr();
+        int bundle_id = in_msg_body~load_uint(32);
+        slice value;
+        int ok;
+        (value, ok) = udict_get?(bundles, 64, bundle_id);
+        throw_unless(102, ok);
+        int bundle_amount = value~load_uint(slice_bits(value));
+        send_jettons(user_wallet, bundle_amount);
+        return ();
+    }
+
+    ;; Standard Jetton minter operations
+    if (op == op::mint()) {
+        throw_unless(73, equal_slices(sender_address, admin_addr));
+        slice to_address = in_msg_body~load_msg_addr();
+        int ton_amount = in_msg_body~load_coins();
+        cell master_msg = in_msg_body~load_ref();
+        slice mm = master_msg.begin_parse();
+        mm~skip_bits(32 + 64);
+        int jetton_amount = mm~load_coins();
+        mint_tokens(to_address, wallet_code, ton_amount, master_msg);
+        save_data(total_supply + jetton_amount, admin_addr, content, wallet_code, bundles);
+        return ();
+    }
+
+    if (op == op::burn_notification()) {
+        int jetton_amount = in_msg_body~load_coins();
+        slice from_address = in_msg_body~load_msg_addr();
+        throw_unless(74, equal_slices(calculate_user_jetton_wallet_address(from_address, my_address(), wallet_code), sender_address));
+        save_data(total_supply - jetton_amount, admin_addr, content, wallet_code, bundles);
+        slice response = in_msg_body~load_msg_addr();
+        if (response.preload_uint(2) != 0) {
+            var msg = begin_cell()
+                .store_uint(0x10, 6)
+                .store_slice(response)
+                .store_coins(0)
+                .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+                .store_uint(op::excesses(), 32)
+                .store_uint(query_id, 64);
+            send_raw_message(msg.end_cell(), 2 + 64);
+        }
+        return ();
+    }
+
+    if (op == op::provide_wallet_address()) {
+        slice owner = in_msg_body~load_msg_addr();
+        int include? = in_msg_body~load_uint(1);
+        cell included = include? ? begin_cell().store_slice(owner).end_cell() : null();
+        var msg = begin_cell()
+            .store_uint(0x18, 6)
+            .store_slice(sender_address)
+            .store_coins(0)
+            .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+            .store_uint(op::take_wallet_address(), 32)
+            .store_uint(query_id, 64);
+        if (is_resolvable?(owner)) {
+            msg = msg.store_slice(calculate_user_jetton_wallet_address(owner, my_address(), wallet_code));
+        } else {
+            msg = msg.store_uint(0, 2);
+        }
+        send_raw_message(msg.store_maybe_ref(included).end_cell(), 64);
+        return ();
+    }
+
+    if (op == 3) {
+        throw_unless(73, equal_slices(sender_address, admin_addr));
+        slice new_admin = in_msg_body~load_msg_addr();
+        save_data(total_supply, new_admin, content, wallet_code, bundles);
+        return ();
+    }
+
+    if (op == 4) {
+        throw_unless(73, equal_slices(sender_address, admin_addr));
+        save_data(total_supply, admin_addr, in_msg_body~load_ref(), wallet_code, bundles);
+        return ();
+    }
+
+    throw(0xffff);
+}
+
+(int, int, slice, cell, cell) get_jetton_data() method_id {
+    (int ts, slice admin_addr, cell content, cell wallet_code, cell bundles) = load_data();
+    return (ts, -1, admin_addr, content, wallet_code);
+}
+
+slice get_wallet_address(slice owner_address) method_id {
+    (int ts, slice admin_addr, cell content, cell wallet_code, cell bundles) = load_data();
+    return calculate_user_jetton_wallet_address(owner_address, my_address(), wallet_code);
 }
 
 () set_bundle(int bundle_id, int amount, slice sender) impure {
-    throw_if_not(is_admin(sender), 103);
-    bundles = dict_set(bundles, bundle_id, amount);
+    var (total_supply, admin_addr, content, wallet_code, bundles) = load_data();
+    throw_unless(103, equal_slices(sender, admin_addr));
+    bundles = udict_set(bundles, 64, bundle_id, begin_cell().store_uint(amount, 32).end_cell());
+    save_data(total_supply, admin_addr, content, wallet_code, bundles);
 }


### PR DESCRIPTION
## Summary
- implement full jetton minter logic in `tpc_claim_wallet.fc`
- automatically send jettons when a claim or bundle purchase is confirmed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687caf9379588329b852d583a2c3e065