### PR TITLE
Fix missing TON modules for bot

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -20,6 +20,10 @@
     "socket.io": "^4.7.5",
     "telegraf": "^4.12.2",
     "tonweb": "^0.0.66",
+    "ton": "^13.9.0",
+    "ton-core": "^0.53.0",
+    "ton-crypto": "^3.2.0",
+    "ton-x": "^2.1.0-preview",
     "twitter-api-v2": "^1.24.0",
     "uuid": "^9.0.1"
   }


### PR DESCRIPTION
## Summary
- add `ton` packages to `bot/package.json` so Render installs them for the API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cc43b582c8329b2983cb5f5a450cc