### PR TITLE
Fix jetton claim wallet transfer fee

### DIFF
--- a/tpc_claim_wallet.fc
+++ b/tpc_claim_wallet.fc
@@ -13,7 +13,8 @@ const op::claim = 0x01;
 const op::bundle_purchase = 0x02;
 
 ;; Additional ton amount forwarded with wallet deployment/transfer
-int wallet_forward_amount() asm "10000000 PUSHINT"; ;; 0.01 TON
+;; Increased to cover creation and transfer fees of the jetton wallet
+int wallet_forward_amount() asm "50000000 PUSHINT"; ;; 0.05 TON
 
 ;; storage#_ total_supply:Coins admin_address:MsgAddress content:^Cell jetton_wallet_code:^Cell bundles:^Cell = Storage;
 


### PR DESCRIPTION
## Summary
- adjust `wallet_forward_amount` in `tpc_claim_wallet` to send more TON when deploying a jetton wallet

## Testing
- `npm test` *(fails: cannot complete due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687cd181f4c88329998cd393083dd771