### PR TITLE
Add token address notification on claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
    - `AIRDROP_ADMIN_TOKENS` – (optional) tokens allowed to trigger airdrops
    - `DEPOSIT_WALLET_ADDRESS` – TON address that receives user deposits
    - `CLAIM_CONTRACT_ADDRESS` – address of the deployed `tpc_claim_wallet` contract
-   - `CLAIM_WALLET_MNEMONIC` – seed phrase used to sign claim transactions
-   - `RPC_URL` – (optional) TON RPC endpoint for claim messages. Defaults to `https://toncenter.com/api/v2/jsonRPC`
+  - `CLAIM_WALLET_MNEMONIC` – seed phrase used to sign claim transactions
+  - `TPC_JETTON_ADDRESS` – token contract address shown after a claim
+  - `RPC_URL` – (optional) TON RPC endpoint for claim messages. Defaults to `https://toncenter.com/api/v2/jsonRPC`
    - `PORT` – (optional) port for the bot API server (defaults to 3000)
 - `DEV_ACCOUNT_ID` – account ID that collects transfer fees
 

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -45,3 +45,6 @@ CLAIM_CONTRACT_ADDRESS=
 # Seed phrase of the admin wallet that signs claim transactions
 CLAIM_WALLET_MNEMONIC=
 
+# Jetton root address used to import TPC in wallets
+TPC_JETTON_ADDRESS=EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X
+

--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -17,6 +17,11 @@ import tonClaim from '../utils/tonClaim.js';
 const USDT_JETTON_HEX =
   '0:b113a994b5024a16719f69139328eb759596c38a25f59028b146fecdc3621dfe';
 
+// Token root address used when directing users to import TPC
+const TPC_JETTON_ADDRESS =
+  process.env.TPC_JETTON_ADDRESS ||
+  'EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X';
+
 const router = Router();
 
 router.post('/balance', authenticate, async (req, res) => {
@@ -410,6 +415,15 @@ router.post('/withdraw', authenticate, async (req, res) => {
     await tonClaim(address, amount);
     tx.status = 'delivered';
     await user.save();
+    try {
+      await sendTPCNotification(
+        bot,
+        telegramId,
+        `\u{1FA99} Claim of ${amount} TPC sent to ${address}. If it doesn't appear, add TPC using ${TPC_JETTON_ADDRESS}`
+      );
+    } catch (err) {
+      console.error('Failed to send Telegram notification:', err.message);
+    }
   } catch (err) {
     console.error('Claim transaction failed:', err.message);
   }
@@ -457,6 +471,15 @@ router.post('/claim-external', authenticate, async (req, res) => {
     await tonClaim(address, amount);
     tx.status = 'delivered';
     await user.save();
+    try {
+      await sendTPCNotification(
+        bot,
+        telegramId,
+        `\u{1FA99} Claim of ${amount} TPC sent to ${address}. If it doesn't appear, add TPC using ${TPC_JETTON_ADDRESS}`
+      );
+    } catch (err) {
+      console.error('Failed to send Telegram notification:', err.message);
+    }
   } catch (err) {
     console.error('Claim transaction failed:', err.message);
   }


### PR DESCRIPTION
## Summary
- expose `TPC_JETTON_ADDRESS` in env docs
- send a Telegram note with the token root after claim

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_687cefcdb01883299f829294cad836af