### PR TITLE
Implement jetton claim transfer details

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,11 @@ awarding the developer share after a game ends.
 
 Withdrawals and `/claim-external` trigger a signed message to
 `CLAIM_CONTRACT_ADDRESS` using the mnemonic in `CLAIM_WALLET_MNEMONIC`.
-The contract mints the claimed amount directly to the provided address.
-If the call succeeds the transaction status becomes `delivered`; on failure
-it stays `pending` so it can be retried.
+The `tpc_claim_wallet` contract forwards this call to the TPC Jetton root
+(`EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X`) so the specified amount of
+TPC is transferred directly to the provided address. If the call succeeds the
+transaction status becomes `delivered`; on failure it stays `pending` so it can
+be retried.
 
 ### Common issues
 

--- a/bot/utils/tonClaim.js
+++ b/bot/utils/tonClaim.js
@@ -4,6 +4,8 @@ import { mnemonicToWalletKey } from 'ton-crypto';
 const endpoint = process.env.RPC_URL || 'https://toncenter.com/api/v2/jsonRPC';
 const contract = process.env.CLAIM_CONTRACT_ADDRESS;
 const mnemonic = process.env.CLAIM_WALLET_MNEMONIC;
+// Root address of the TPC Jetton contract used for all claims
+const TPC_JETTON_ROOT = 'EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X';
 
 export default async function tonClaim(toAddress, amount) {
   if (!contract || !mnemonic) {


### PR DESCRIPTION
## Summary
- clarify README instructions about on-chain TPC claims
- note jetton root in tonClaim utility

## Testing
- `npm test` *(fails: geoip-lite package missing)*

------
https://chatgpt.com/codex/tasks/task_e_687cfaf3c3488329856256b8e657e3b8