### PR TITLE
Restrict invites to TPC token only

### DIFF
--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -61,7 +61,11 @@ export default function InvitePopup({
                 />
               </div>
             </div>
-            <RoomSelector selected={stake} onSelect={onStakeChange} />
+            <RoomSelector
+              selected={stake}
+              onSelect={onStakeChange}
+              tokens={['TPC']}
+            />
           </>
         )}
         <div className="flex justify-center gap-2">

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -163,7 +163,11 @@ export default function PlayerInvitePopup({
               />
             </div>
           </div>
-          <RoomSelector selected={stake} onSelect={onStakeChange} />
+          <RoomSelector
+            selected={stake}
+            onSelect={onStakeChange}
+            tokens={['TPC']}
+          />
           <div className="flex justify-center gap-2">
             <button
               onClick={() => onInvite(game)}

--- a/webapp/src/components/RoomPopup.jsx
+++ b/webapp/src/components/RoomPopup.jsx
@@ -37,6 +37,7 @@ export default function RoomPopup({
         <RoomSelector
           selected={selection || { token: '', amount: 0 }}
           onSelect={setSelection}
+          tokens={['TPC']}
         />
         <button
           onClick={onConfirm}


### PR DESCRIPTION
## Summary
- limit token options to TPC when inviting players or joining rooms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687df1afaa8c832985078a4ae84c40e7