### PR TITLE
Add refund script for pending withdrawals

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ Run `npm run ban-user -- <accountId>` to mark an account as banned in the databa
 
 Run `npm run claim-test <TON_ADDRESS> <AMOUNT>` to send TPC from the claim wallet manually. The amount is specified in nanoTPC as expected by `tonClaim`.
 
+### Refund pending withdrawals
+
+Run `npm run refund-withdrawals` to return all pending withdrawal amounts to user balances. `MONGODB_URI` must point to your MongoDB instance.
+
 ### Deploying the claim wallet
 
 1. **Compile the contract**. Install the FunC compiler and Fift tools, then run:

--- a/bot/scripts/refundPendingWithdrawals.js
+++ b/bot/scripts/refundPendingWithdrawals.js
@@ -1,0 +1,45 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import User from '../models/User.js';
+import { ensureTransactionArray } from '../utils/userUtils.js';
+
+dotenv.config();
+
+const uri = process.env.MONGODB_URI;
+if (!uri || uri === 'memory') {
+  console.error('MONGODB_URI must be set to a MongoDB instance');
+  process.exit(1);
+}
+
+await mongoose.connect(uri);
+
+const users = await User.find({
+  transactions: { $elemMatch: { type: 'withdraw', status: 'pending' } }
+});
+
+for (const user of users) {
+  ensureTransactionArray(user);
+  let refundTotal = 0;
+  for (const tx of user.transactions) {
+    if (tx.type === 'withdraw' && tx.status === 'pending') {
+      const amount = Math.abs(tx.amount || 0);
+      refundTotal += amount;
+      tx.status = 'failed';
+      user.transactions.push({
+        amount,
+        type: 'refund',
+        token: tx.token || 'TPC',
+        status: 'delivered',
+        date: new Date(),
+        detail: 'Refund of pending withdrawal'
+      });
+    }
+  }
+  if (refundTotal > 0) {
+    user.balance += refundTotal;
+    await user.save();
+    console.log(`Refunded ${refundTotal} TPC to ${user.telegramId || user.accountId}`);
+  }
+}
+
+await mongoose.disconnect();

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "recalculate-balances": "node bot/scripts/recalculateBalances.js",
     "ban-user": "node bot/scripts/banUser.js",
     "claim-test": "node bot/scripts/claimTest.js",
+    "refund-withdrawals": "node bot/scripts/refundPendingWithdrawals.js",
     "dev": "concurrently -k \"npm --prefix webapp run dev\" \"node bot/server.js\""
   },
   "engines": {


### PR DESCRIPTION
## Summary
- add a script to refund pending withdrawals and log totals
- expose the script via npm as `refund-withdrawals`
- document the command in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687df228b4048329b2647c59c68b17b7