### PR TITLE
Fix multiplayer turn handling

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -14,6 +14,8 @@ export default function DiceRoller({
   muted = false,
   emitRollEvent = false,
   divRef,
+  accountId,
+  tableId,
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -87,7 +89,7 @@ export default function DiceRoller({
           startValuesRef.current = results;
           onRollEnd && onRollEnd(results);
           if (emitRollEvent) {
-            socket.emit('rollDice');
+            socket.emit('rollDice', { accountId, tableId });
           }
         }, tick);
       }

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -33,6 +33,7 @@ export default function Lobby() {
   const [table, setTable] = useState(null);
   const [stake, setStake] = useState({ token: '', amount: 0 });
   const [players, setPlayers] = useState([]);
+  const [currentTurn, setCurrentTurn] = useState(null);
   const [aiCount, setAiCount] = useState(0);
   const [aiType, setAiType] = useState('');
   const [showLeaderPicker, setShowLeaderPicker] = useState(false);
@@ -122,9 +123,10 @@ export default function Lobby() {
   }, [game, table, playerName]);
 
   useEffect(() => {
-    const onUpdate = ({ tableId, players: list }) => {
+    const onUpdate = ({ tableId, players: list, currentTurn }) => {
       if (table && tableId === table.id) {
         setPlayers(list);
+        if (currentTurn != null) setCurrentTurn(currentTurn);
       }
     };
     socket.on('lobbyUpdate', onUpdate);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2560,6 +2560,8 @@ export default function SnakeAndLadder() {
                   muted={muted}
                   emitRollEvent
                   divRef={diceRollerDivRef}
+                  accountId={myId}
+                  tableId={tableId}
                 />
               );
             }

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -24,16 +24,11 @@ export function getPlayerId() {
 export async function ensureAccountId() {
   if (typeof window === 'undefined') return null;
   let id = localStorage.getItem('accountId');
-  if (id) return id;
-  const tgId = getTelegramId();
-  try {
-    const res = await createAccount(tgId);
-    if (res && res.accountId) {
-      localStorage.setItem('accountId', res.accountId);
-      return res.accountId;
-    }
-  } catch {}
-  return tgId;
+  if (!id) {
+    id = crypto.randomUUID();
+    localStorage.setItem('accountId', id);
+  }
+  return id;
 }
 
 export function getTelegramUsername() {


### PR DESCRIPTION
## Summary
- keep unique accountId on the client
- send tableId and accountId when rolling dice
- track table avatars and current turn server-side
- include avatars and currentTurn in lobby updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e1253843483299fba58ae5fff9577