### PR TITLE
Remove telegram IDs from lobby invites

### DIFF
--- a/webapp/src/hooks/useTelegramAuth.js
+++ b/webapp/src/hooks/useTelegramAuth.js
@@ -7,7 +7,7 @@ export default function useTelegramAuth() {
     const acc = localStorage.getItem('accountId');
     if (user?.id) {
       localStorage.setItem('telegramId', user.id);
-      socket.emit('register', { telegramId: user.id, playerId: acc || user.id });
+      socket.emit('register', { playerId: acc || user.id });
     } else if (acc) {
       socket.emit('register', { playerId: acc });
     }

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -242,10 +242,8 @@ export default function Mining() {
             'invite1v1',
             {
               fromId: accountId,
-              fromTelegramId: telegramId,
               fromName: myName,
               toId: inviteTarget.accountId,
-              toTelegramId: inviteTarget.telegramId,
               roomId,
               token: stake.token,
               amount: stake.amount,
@@ -277,10 +275,8 @@ export default function Mining() {
             'inviteGroup',
             {
               fromId: accountId,
-              fromTelegramId: telegramId,
               fromName: myName,
               toIds: selected.map((u) => u.accountId),
-              telegramIds: selected.map((u) => u.telegramId),
               opponentNames: selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim()),
               roomId,
               token: stake.token,


### PR DESCRIPTION
## Summary
- stop storing telegram IDs on socket registration
- remove telegram-based notification logic for invites
- invite players only by account ID on frontend and backend

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_687e19c53fc48329ac62e157d67b2383