### PR TITLE
Fix table seating to avoid duplicates

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -238,6 +238,12 @@ async function updateLobby(tableId) {
 function seatTableSocket(accountId, tableId, playerName, socket) {
   if (!tableId || !accountId) return;
   cleanupSeats();
+  // Ensure this user is not seated at any other table
+  for (const id of Array.from(tableSeats.keys())) {
+    if (id !== tableId && tableSeats.get(id)?.has(String(accountId))) {
+      unseatTableSocket(accountId, id);
+    }
+  }
   let map = tableSeats.get(tableId);
   if (!map) {
     map = new Map();


### PR DESCRIPTION
## Summary
- ensure players are removed from other tables when taking a seat

## Testing
- `npm test` *(fails: cannot finish due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687e28ab7eb883298953c7d558861479