### PR TITLE
Fix lobby sync

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -123,6 +123,22 @@ export default function Lobby() {
   }, [game, table, playerName]);
 
   useEffect(() => {
+    if (game === 'snake' && table && table.id !== 'single') {
+      let active = true;
+      getSnakeLobby(table.id)
+        .then((data) => {
+          if (!active) return;
+          setPlayers(data.players || []);
+          if (data.currentTurn != null) setCurrentTurn(data.currentTurn);
+        })
+        .catch(() => {});
+      return () => {
+        active = false;
+      };
+    }
+  }, [game, table]);
+
+  useEffect(() => {
     const onUpdate = ({ tableId, players: list, currentTurn }) => {
       if (table && tableId === table.id) {
         setPlayers(list);


### PR DESCRIPTION
## Summary
- fetch current table state when selecting a lobby table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e3f6144f0832986f967decdc077ac