### PR TITLE
Add Socket.IO lobby example

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ the URL – or pick the number in the lobby – to change how many AI players jo
 ### Multiplayer status
 
 Online multiplayer has arrived. Join a table in the lobby to create or enter that room. Wait for other players to join you. Once everyone is ready the match starts and you all move on the same board in real time.
+### Dynamic lobby example
+
+A simplified Socket.IO lobby is provided in `examples/dynamic-lobby`. Players join tables by game type and stake, and the server creates new tables as needed. When a table fills up it emits a `gameStart` event.
 
 ### Entering the Snake & Ladder game
 

--- a/examples/dynamic-lobby/client.js
+++ b/examples/dynamic-lobby/client.js
@@ -1,0 +1,15 @@
+import { io } from 'socket.io-client';
+
+const socket = io('http://localhost:3000');
+
+export function joinLobby(gameType, stake, accountId, name) {
+  socket.emit('joinLobby', { accountId, name, gameType, stake });
+}
+
+socket.on('lobbyUpdate', ({ tableId, players }) => {
+  console.log('Lobby update for', tableId, players);
+});
+
+socket.on('gameStart', ({ tableId, players, stake }) => {
+  console.log('Game starting on', tableId, 'stake', stake, players);
+});

--- a/examples/dynamic-lobby/server.js
+++ b/examples/dynamic-lobby/server.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+const crypto = require('crypto');
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server, { cors: { origin: '*' } });
+
+const tables = {}; // key = `${gameType}-${stake}` -> array of tables
+
+function createNewTable(gameType, stake) {
+  const maxPlayers = gameType === '1v1' ? 2 : (gameType === '3player' ? 3 : 4);
+  const table = { id: crypto.randomUUID(), gameType, stake, maxPlayers, players: [] };
+  const key = `${gameType}-${stake}`;
+  if (!tables[key]) tables[key] = [];
+  tables[key].push(table);
+  return table;
+}
+
+function getAvailableTable(gameType, stake) {
+  const key = `${gameType}-${stake}`;
+  if (!tables[key]) tables[key] = [];
+  const open = tables[key].find(t => t.players.length < t.maxPlayers);
+  return open || createNewTable(gameType, stake);
+}
+
+io.on('connection', socket => {
+  socket.on('joinLobby', ({ accountId, name, gameType, stake }) => {
+    const table = getAvailableTable(gameType, stake);
+    if (!table.players.find(p => p.id === accountId)) {
+      table.players.push({ id: accountId, name });
+    }
+    socket.join(table.id);
+    io.to(table.id).emit('lobbyUpdate', { tableId: table.id, players: table.players });
+    if (table.players.length === table.maxPlayers) {
+      io.to(table.id).emit('gameStart', { tableId: table.id, players: table.players, stake: table.stake });
+    }
+  });
+
+  socket.on('leaveLobby', ({ accountId, gameType, stake }) => {
+    const key = `${gameType}-${stake}`;
+    (tables[key] || []).forEach(table => {
+      table.players = table.players.filter(p => p.id !== accountId);
+      io.to(table.id).emit('lobbyUpdate', { tableId: table.id, players: table.players });
+    });
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => console.log('Lobby server listening on', PORT));


### PR DESCRIPTION
## Summary
- add simple dynamic lobby server and client code
- document new example in README

## Testing
- `scripts/setup-tests.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e4fcb0b50832993d44e3ea5c3c041