### PR TITLE
Fix 1v1 cheat warning

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2560,8 +2560,6 @@ export default function SnakeAndLadder() {
                   muted={muted}
                   emitRollEvent
                   divRef={diceRollerDivRef}
-                  accountId={myId}
-                  tableId={tableId}
                 />
               );
             }


### PR DESCRIPTION
## Summary
- fix socket payload for multiplayer dice rolls

## Testing
- `npm test` *(fails: Cannot find package 'geoip-lite')*

------
https://chatgpt.com/codex/tasks/task_e_687e5791b6b48329af4b4099641dba73