### PR TITLE
Implement turn-based table system

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1475,6 +1475,11 @@ export default function SnakeAndLadder() {
     socket.on('snakeOrLadder', onSnakeOrLadder);
     socket.on('playerReset', onReset);
     socket.on('turnChanged', onTurn);
+    socket.on('turnUpdate', ({ currentTurn }) => onTurn({ playerId: currentTurn }));
+    socket.on('lobbyUpdate', ({ players: list }) => {
+      setMpPlayers(list.map(p => ({ id: p.id, name: p.name, photoUrl: p.avatar || '/assets/icons/profile.svg', position: p.position || 0 }))); 
+    });
+    socket.on('gameStart', onStarted);
     socket.on('gameStarted', onStarted);
     socket.on('diceRolled', onRolled);
     socket.on('gameWon', onWon);
@@ -1514,6 +1519,9 @@ export default function SnakeAndLadder() {
       socket.off('snakeOrLadder', onSnakeOrLadder);
       socket.off('playerReset', onReset);
       socket.off('turnChanged', onTurn);
+      socket.off('turnUpdate');
+      socket.off('lobbyUpdate');
+      socket.off('gameStart', onStarted);
       socket.off('gameStarted', onStarted);
       socket.off('diceRolled', onRolled);
       socket.off('gameWon', onWon);


### PR DESCRIPTION
## Summary
- extend table state with turn info and player avatars
- emit real-time `lobbyUpdate`, `gameStart`, `turnUpdate` and `diceRolled`
- update lobby page to send avatar and show avatars in seat list
- handle new events in the Snake & Ladder client

## Testing
- `npm test` *(fails: geoip-lite install issues, tests hang)*

------
https://chatgpt.com/codex/tasks/task_e_687f2e571f3c8329b3d8fa08cf20be88