### PR TITLE
Improve waiting overlay

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2453,8 +2453,8 @@ export default function SnakeAndLadder() {
         );
       })()}
       {waitingForPlayers && (
-        <div className="absolute inset-0 z-40 flex flex-col items-center justify-center bg-black/70 text-white">
-          <p className="text-lg mb-2">
+        <div className="absolute inset-0 z-40 flex flex-col items-center justify-center bg-black/60 text-white space-y-2">
+          <p className="text-lg">
             Waiting for {playersNeeded} more player{playersNeeded === 1 ? '' : 's'}...
           </p>
           <ul className="space-y-1 text-sm">
@@ -2467,6 +2467,12 @@ export default function SnakeAndLadder() {
               </li>
             ))}
           </ul>
+          <button
+            onClick={() => navigate('/games/snake/lobby')}
+            className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
+          >
+            Leave Table
+          </button>
         </div>
       )}
       {rollResult !== null && (


### PR DESCRIPTION
## Summary
- lighten waiting overlay and offer a leave button

## Testing
- `npm test` *(fails: stuck running tests)*

------
https://chatgpt.com/codex/tasks/task_e_687f5809c8dc8329a85592ee5b84dec9