### PR TITLE
Fix lobby table leave logic

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -53,6 +53,21 @@ export default function Lobby() {
   const [joinedTableId, setJoinedTableId] = useState(null);
   const startedRef = useRef(false);
 
+  // When the user leaves this lobby or switches tables after joining one,
+  // notify the server to remove them from the previous seat. This avoids
+  // "gameStart" events for stale tables which previously caused the UI to
+  // navigate to a blank game screen without user confirmation.
+  useEffect(() => {
+    return () => {
+      if (!joinedTableId) return;
+      ensureAccountId()
+        .then((accountId) =>
+          socket.emit('leaveLobby', { accountId, tableId: joinedTableId })
+        )
+        .catch(() => {});
+    };
+  }, [joinedTableId]);
+
   useEffect(() => {
     startedRef.current = false;
     setConfirmed(false);


### PR DESCRIPTION
## Summary
- clear server seat when leaving the lobby or switching tables
- install dependencies for webapp

## Testing
- `npm test`
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_687fb80b97008329b43a10491ffec64a