### PR TITLE
Fix table selection confirm state

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -74,7 +74,7 @@ export default function Lobby() {
     setConfirmed(false);
     setReadyList([]);
     setJoinedTableId(null);
-    setWaitingForConfirm(false);
+    setWaitingForConfirm(Boolean(table));
   }, [game, table]);
 
   const selectAiType = (t) => {


### PR DESCRIPTION
## Summary
- ensure lobby confirm button is enabled after table selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687fcfa0f7b083299a5d6f11300340dd