### PR TITLE
Require confirmation to start game

### DIFF
--- a/webapp/src/components/FlagPickerModal.jsx
+++ b/webapp/src/components/FlagPickerModal.jsx
@@ -3,7 +3,7 @@ import { FLAG_EMOJIS } from '../utils/flagEmojis.js';
 import { FLAG_CATEGORIES } from '../utils/flagCategories.js';
 import { avatarToName } from '../utils/avatarUtils.js';
 
-export default function FlagPickerModal({ open, onClose, count = 1, onSave, selected = [], onComplete }) {
+export default function FlagPickerModal({ open, onClose, count = 1, onSave, selected = [] }) {
   const continents = Object.keys(FLAG_CATEGORIES);
   const [category, setCategory] = useState(continents[0]);
   const [chosen, setChosen] = useState([]);
@@ -20,7 +20,6 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
       .filter((i) => i >= 0);
     onSave(indices.slice(0, count));
     onClose();
-    if (onComplete) onComplete(indices.slice(0, count));
   };
 
   const toggle = (flag) => {
@@ -30,7 +29,6 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
         next = prev.filter((f) => f !== flag);
       } else if (prev.length < count) {
         next = [...prev, flag];
-        if (next.length === count) handleComplete(next);
       }
       return next;
     });
@@ -47,7 +45,7 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
       const flag = allFlags[Math.floor(Math.random() * allFlags.length)];
       if (!random.includes(flag)) random.push(flag);
     }
-    handleComplete(random);
+    setChosen(random);
   };
 
   return (

--- a/webapp/src/components/LeaderPickerModal.jsx
+++ b/webapp/src/components/LeaderPickerModal.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { LEADER_AVATARS, LEADER_NAMES } from '../utils/leaderAvatars.js';
 import { getAvatarUrl } from '../utils/avatarUtils.js';
 
-export default function LeaderPickerModal({ open, onClose, count = 1, onSave, selected = [], onComplete }) {
+export default function LeaderPickerModal({ open, onClose, count = 1, onSave, selected = [] }) {
   const [chosen, setChosen] = useState(selected);
 
   useEffect(() => {
@@ -14,7 +14,6 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
   const handleComplete = (selection) => {
     onSave(selection.slice(0, count));
     onClose();
-    if (onComplete) onComplete(selection.slice(0, count));
   };
 
   const toggle = (src) => {
@@ -24,7 +23,6 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
         next = prev.filter((s) => s !== src);
       } else if (prev.length < count) {
         next = [...prev, src];
-        if (next.length === count) handleComplete(next);
       }
       return next;
     });
@@ -40,7 +38,7 @@ export default function LeaderPickerModal({ open, onClose, count = 1, onSave, se
       const leader = LEADER_AVATARS[Math.floor(Math.random() * LEADER_AVATARS.length)];
       if (!random.includes(leader)) random.push(leader);
     }
-    handleComplete(random);
+    setChosen(random);
   };
 
   return (

--- a/webapp/src/pages/Games/CrazyDiceLobby.jsx
+++ b/webapp/src/pages/Games/CrazyDiceLobby.jsx
@@ -157,7 +157,6 @@ export default function CrazyDiceLobby() {
         selected={leaders}
         onSave={setLeaders}
         onClose={() => setShowLeaderPicker(false)}
-        onComplete={(sel) => startGame(flags, sel)}
       />
       <FlagPickerModal
         open={showFlagPicker}
@@ -165,7 +164,6 @@ export default function CrazyDiceLobby() {
         selected={flags}
         onSave={setFlags}
         onClose={() => setShowFlagPicker(false)}
-        onComplete={(sel) => startGame(sel, leaders)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- modify leader and flag pickers so they don't auto-start games
- update Crazy Dice lobby to only start from the main confirm button

## Testing
- `npm test` *(passes)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687fdb8d258c8329b8e1e5bd0e509c2d