### PR TITLE
Restore turn logic to pre-socket implementation

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -14,8 +14,6 @@ export default function DiceRoller({
   muted = false,
   emitRollEvent = false,
   divRef,
-  accountId,
-  tableId,
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -89,7 +87,7 @@ export default function DiceRoller({
           startValuesRef.current = results;
           onRollEnd && onRollEnd(results);
           if (emitRollEvent) {
-            socket.emit('rollDice', { accountId, tableId });
+            socket.emit('rollDice');
           }
         }, tick);
       }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1475,11 +1475,6 @@ export default function SnakeAndLadder() {
     socket.on('snakeOrLadder', onSnakeOrLadder);
     socket.on('playerReset', onReset);
     socket.on('turnChanged', onTurn);
-    socket.on('turnUpdate', ({ currentTurn }) => onTurn({ playerId: currentTurn }));
-    socket.on('lobbyUpdate', ({ players: list }) => {
-      setMpPlayers(list.map(p => ({ id: p.id, name: p.name, photoUrl: p.avatar || '/assets/icons/profile.svg', position: p.position || 0 }))); 
-    });
-    socket.on('gameStart', onStarted);
     socket.on('gameStarted', onStarted);
     socket.on('diceRolled', onRolled);
     socket.on('gameWon', onWon);
@@ -1519,9 +1514,6 @@ export default function SnakeAndLadder() {
       socket.off('snakeOrLadder', onSnakeOrLadder);
       socket.off('playerReset', onReset);
       socket.off('turnChanged', onTurn);
-      socket.off('turnUpdate');
-      socket.off('lobbyUpdate');
-      socket.off('gameStart', onStarted);
       socket.off('gameStarted', onStarted);
       socket.off('diceRolled', onRolled);
       socket.off('gameWon', onWon);
@@ -2453,26 +2445,10 @@ export default function SnakeAndLadder() {
         );
       })()}
       {waitingForPlayers && (
-        <div className="absolute inset-0 z-40 flex flex-col items-center justify-center bg-black/60 text-white space-y-2">
-          <p className="text-lg">
+        <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/70">
+          <p className="text-white text-lg">
             Waiting for {playersNeeded} more player{playersNeeded === 1 ? '' : 's'}...
           </p>
-          <ul className="space-y-1 text-sm">
-            {mpPlayers.map((p) => (
-              <li key={p.id} className="flex items-center space-x-2">
-                {p.photoUrl && (
-                  <img src={p.photoUrl} alt="avatar" className="w-6 h-6 rounded-full" />
-                )}
-                <span>{p.name}</span>
-              </li>
-            ))}
-          </ul>
-          <button
-            onClick={() => navigate('/games/snake/lobby')}
-            className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
-          >
-            Leave Table
-          </button>
         </div>
       )}
       {rollResult !== null && (

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -24,11 +24,16 @@ export function getPlayerId() {
 export async function ensureAccountId() {
   if (typeof window === 'undefined') return null;
   let id = localStorage.getItem('accountId');
-  if (!id) {
-    id = crypto.randomUUID();
-    localStorage.setItem('accountId', id);
-  }
-  return id;
+  if (id) return id;
+  const tgId = getTelegramId();
+  try {
+    const res = await createAccount(tgId);
+    if (res && res.accountId) {
+      localStorage.setItem('accountId', res.accountId);
+      return res.accountId;
+    }
+  } catch {}
+  return tgId;
 }
 
 export function getTelegramUsername() {


### PR DESCRIPTION
## Summary
- revert Snake and Ladder turn system to pre-socket version
- remove accountId usage from dice roller
- use old ensureAccountId logic using createAccount

## Testing
- `bash scripts/setup-tests.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68807f1d54048329a014293b6efb5617