### PR TITLE
Ensure players wait for full table in snake lobby

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -295,6 +295,17 @@ io.on('connection', (socket) => {
 
   socket.on('joinRoom', async ({ roomId, playerId, name }) => {
     const map = tableSeats.get(roomId);
+    const lobbyCount = map ? map.size : 0;
+    const match = /(\d+)$/.exec(roomId);
+    const cap = match ? Number(match[1]) : 4;
+    const room = await gameManager.getRoom(roomId, cap);
+    const joined = room.players.filter((p) => !p.disconnected).length;
+
+    if (lobbyCount + joined < room.capacity) {
+      socket.emit('error', 'table not full');
+      return;
+    }
+
     if (map) {
       map.delete(String(playerId));
       if (map.size === 0) tableSeats.delete(roomId);

--- a/test/lobbyWait.test.js
+++ b/test/lobbyWait.test.js
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { setTimeout as delay } from 'timers/promises';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+test('joinRoom waits until table full', { concurrency: false, timeout: 20000 }, async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+  const env = {
+    ...process.env,
+    PORT: '3203',
+    MONGODB_URI: 'memory',
+    BOT_TOKEN: 'dummy',
+    SKIP_WEBAPP_BUILD: '1'
+  };
+  const server = await startServer(env);
+  try {
+    await fetch('http://localhost:3203/api/snake/table/seat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tableId: 'snake-2', playerId: 'p1', name: 'A' })
+    });
+
+    const s1 = io('http://localhost:3203');
+    const errors = [];
+    s1.on('error', (e) => errors.push(e));
+    s1.emit('joinRoom', { roomId: 'snake-2', playerId: 'p1', name: 'A' });
+    await delay(500);
+    assert.ok(errors.length > 0, 'should receive error when table not full');
+    s1.off('error');
+    errors.length = 0;
+
+    await fetch('http://localhost:3203/api/snake/table/seat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tableId: 'snake-2', playerId: 'p2', name: 'B' })
+    });
+
+    s1.emit('joinRoom', { roomId: 'snake-2', playerId: 'p1', name: 'A' });
+    await delay(200);
+    assert.equal(errors.length, 0, 'should join when table full');
+    s1.disconnect();
+  } finally {
+    server.kill();
+  }
+});

--- a/test/snakeApi.test.js
+++ b/test/snakeApi.test.js
@@ -139,14 +139,22 @@ test('snake API endpoints and socket events', { concurrency: false, timeout: 200
 
     assert.ok(board.snakes && board.ladders);
 
+    await fetch('http://localhost:3201/api/snake/table/seat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tableId: 'snake-2', playerId: 'p1', name: 'A' })
+    });
+    await fetch('http://localhost:3201/api/snake/table/seat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tableId: 'snake-2', playerId: 'p2', name: 'B' })
+    });
+
     const s1 = io('http://localhost:3201');
-
     const s2 = io('http://localhost:3201');
-
     const events = [];
 
     s1.onAny((e) => events.push(e));
-
     s2.onAny((e) => events.push(e));
 
     s1.emit('joinRoom', { roomId: 'snake-2', playerId: 'p1', name: 'A' });

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -144,6 +144,14 @@ export default function Lobby() {
   }, [game, table]);
 
   const startGame = (flagOverride = flags, leaderOverride = leaders) => {
+    if (
+      table &&
+      table.id !== 'single' &&
+      players.length !== table.capacity
+    ) {
+      // Wait in the lobby until the table is full
+      return;
+    }
     const params = new URLSearchParams();
     if (table) params.set('table', table.id);
     if (table?.id === 'single') {
@@ -171,15 +179,7 @@ export default function Lobby() {
     if (aiType === 'leaders' && leaders.length !== aiCount) disabled = true;
     if (aiType === 'flags' && flags.length !== aiCount) disabled = true;
   }
-  if (
-    game === 'snake' &&
-    table &&
-    table.id !== 'single' &&
-    players.length > 0 &&
-    players.length < table.capacity
-  ) {
-    disabled = false;
-  }
+  // Multiplayer games require a full table before starting
 
   return (
     <div className="relative p-4 space-y-4 text-text">


### PR DESCRIPTION
## Summary
- enforce a check in the Snake lobby UI so players cannot start until the table is full
- server now rejects `joinRoom` when the table isn't filled yet
- update the Snake API test accordingly and add a new test for waiting in the lobby

## Testing
- `npm test` *(fails: canvas build missing pixman-1)*

------
https://chatgpt.com/codex/tasks/task_e_68808e0f1e5c8329b22bf6ff9632bec4