### PR TITLE
Implement automatic start for full snake lobby

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -53,6 +53,7 @@ export default function Lobby() {
   const [flags, setFlags] = useState([]);
   const [online, setOnline] = useState(0);
   const [playerName, setPlayerName] = useState('');
+  const [autoStart, setAutoStart] = useState(false);
 
   const selectAiType = (t) => {
     setAiType(t);
@@ -142,6 +143,19 @@ export default function Lobby() {
       setPlayers([]);
     }
   }, [game, table]);
+
+  useEffect(() => {
+    if (
+      game === 'snake' &&
+      table &&
+      table.id !== 'single' &&
+      players.length === table.capacity &&
+      !autoStart
+    ) {
+      setAutoStart(true);
+      startGame();
+    }
+  }, [game, table, players, autoStart]);
 
   const startGame = (flagOverride = flags, leaderOverride = leaders) => {
     if (
@@ -259,7 +273,7 @@ export default function Lobby() {
         disabled={disabled}
         className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-text rounded disabled:opacity-50"
       >
-        Start Game
+        {game === 'snake' && table?.id !== 'single' && players.length === table.capacity ? 'Confirm' : 'Start Game'}
       </button>
       <LeaderPickerModal
         open={showLeaderPicker}


### PR DESCRIPTION
## Summary
- auto-start Snake & Ladder match once table is full
- show `Confirm` label on Start button when table reached capacity

## Testing
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'geoip-lite')*

------
https://chatgpt.com/codex/tasks/task_e_6880951d294883298d2420cbc571d52b