### PR TITLE
Use accountId for lobby tracking

### DIFF
--- a/test/lobbyWait.test.js
+++ b/test/lobbyWait.test.js
@@ -38,13 +38,13 @@ test('joinRoom waits until table full', { concurrency: false, timeout: 20000 }, 
     await fetch('http://localhost:3203/api/snake/table/seat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tableId: 'snake-2', playerId: 'p1', name: 'A', confirmed: true })
+      body: JSON.stringify({ tableId: 'snake-2', accountId: 'p1', name: 'A', confirmed: true })
     });
 
     const s1 = io('http://localhost:3203');
     const errors = [];
     s1.on('error', (e) => errors.push(e));
-    s1.emit('joinRoom', { roomId: 'snake-2', playerId: 'p1', name: 'A' });
+    s1.emit('joinRoom', { roomId: 'snake-2', accountId: 'p1', name: 'A' });
     await delay(500);
     assert.ok(errors.length > 0, 'should receive error when table not full');
     s1.off('error');
@@ -53,10 +53,10 @@ test('joinRoom waits until table full', { concurrency: false, timeout: 20000 }, 
     await fetch('http://localhost:3203/api/snake/table/seat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tableId: 'snake-2', playerId: 'p2', name: 'B', confirmed: true })
+      body: JSON.stringify({ tableId: 'snake-2', accountId: 'p2', name: 'B', confirmed: true })
     });
 
-    s1.emit('joinRoom', { roomId: 'snake-2', playerId: 'p1', name: 'A' });
+    s1.emit('joinRoom', { roomId: 'snake-2', accountId: 'p1', name: 'A' });
     await delay(200);
     assert.equal(errors.length, 0, 'should join when table full');
     s1.disconnect();

--- a/test/onlineRoutes.test.js
+++ b/test/onlineRoutes.test.js
@@ -37,7 +37,7 @@ test('online routes reflect pinged users', { concurrency: false }, async () => {
     const pingRes = await fetch('http://localhost:3202/api/online/ping', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ playerId: 'player1' })
+      body: JSON.stringify({ accountId: 'player1' })
     });
     assert.equal(pingRes.status, 200);
     const ping = await pingRes.json();

--- a/test/snakeApi.test.js
+++ b/test/snakeApi.test.js
@@ -142,12 +142,12 @@ test('snake API endpoints and socket events', { concurrency: false, timeout: 200
     await fetch('http://localhost:3201/api/snake/table/seat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tableId: 'snake-2', playerId: 'p1', name: 'A', confirmed: true })
+      body: JSON.stringify({ tableId: 'snake-2', accountId: 'p1', name: 'A', confirmed: true })
     });
     await fetch('http://localhost:3201/api/snake/table/seat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tableId: 'snake-2', playerId: 'p2', name: 'B', confirmed: true })
+      body: JSON.stringify({ tableId: 'snake-2', accountId: 'p2', name: 'B', confirmed: true })
     });
 
     const s1 = io('http://localhost:3201');
@@ -157,10 +157,10 @@ test('snake API endpoints and socket events', { concurrency: false, timeout: 200
     s1.onAny((e) => events.push(e));
     s2.onAny((e) => events.push(e));
 
-    s1.emit('joinRoom', { roomId: 'snake-2', playerId: 'p1', name: 'A' });
+    s1.emit('joinRoom', { roomId: 'snake-2', accountId: 'p1', name: 'A' });
     await delay(200);
 
-    s2.emit('joinRoom', { roomId: 'snake-2', playerId: 'p2', name: 'B' });
+    s2.emit('joinRoom', { roomId: 'snake-2', accountId: 'p2', name: 'B' });
 
     for (let i = 0; i < 100 && !events.includes('gameStarted'); i++) {
 

--- a/test/snakeSeat.test.js
+++ b/test/snakeSeat.test.js
@@ -38,7 +38,7 @@ test('seat and unseat endpoints update lobby', { concurrency: false, timeout: 20
     let res = await fetch('http://localhost:3202/api/snake/table/seat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tableId: 'snake-2', playerId: 'p100', name: 'Tester' })
+      body: JSON.stringify({ tableId: 'snake-2', accountId: 'p100', name: 'Tester' })
     });
     assert.equal(res.status, 200);
 
@@ -50,7 +50,7 @@ test('seat and unseat endpoints update lobby', { concurrency: false, timeout: 20
     res = await fetch('http://localhost:3202/api/snake/table/unseat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tableId: 'snake-2', playerId: 'p100' })
+      body: JSON.stringify({ tableId: 'snake-2', accountId: 'p100' })
     });
     assert.equal(res.status, 200);
 

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { socket } from '../utils/socket.js';
 import { pingOnline } from '../utils/api.js';
-import { getPlayerId } from '../utils/telegram.js';
+import { ensureAccountId } from '../utils/telegram.js';
 import InvitePopup from './InvitePopup.jsx';
 
 import Navbar from './Navbar.jsx';
@@ -29,15 +29,21 @@ export default function Layout({ children }) {
 
   useEffect(() => {
     let id;
-    try {
-      const playerId = getPlayerId();
-      function ping() {
-        pingOnline(playerId).catch(() => {});
-      }
-      ping();
-      id = setInterval(ping, 30000);
-    } catch {}
-    return () => clearInterval(id);
+    let cancelled = false;
+    ensureAccountId()
+      .then((accountId) => {
+        if (cancelled || !accountId) return;
+        function ping() {
+          pingOnline(accountId).catch(() => {});
+        }
+        ping();
+        id = setInterval(ping, 30000);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+      if (id) clearInterval(id);
+    };
   }, []);
 
   const isHome = location.pathname === '/';

--- a/webapp/src/hooks/useTelegramAuth.js
+++ b/webapp/src/hooks/useTelegramAuth.js
@@ -1,16 +1,15 @@
 import { useEffect } from 'react';
 import { socket } from '../utils/socket.js';
+import { ensureAccountId } from '../utils/telegram.js';
 
 export default function useTelegramAuth() {
   useEffect(() => {
     const user = window?.Telegram?.WebApp?.initDataUnsafe?.user;
-    const acc = localStorage.getItem('accountId');
-    if (user?.id) {
-      localStorage.setItem('telegramId', user.id);
-      socket.emit('register', { playerId: acc || user.id });
-    } else if (acc) {
-      socket.emit('register', { playerId: acc });
-    }
+    ensureAccountId().then((acc) => {
+      if (acc) {
+        socket.emit('register', { accountId: acc });
+      }
+    }).catch(() => {});
     if (user?.username) {
       localStorage.setItem('telegramUsername', user.username);
     }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -578,13 +578,22 @@ export default function SnakeAndLadder() {
   }, []);
 
   useEffect(() => {
-    const id = getPlayerId();
-    function ping() {
-      pingOnline(id).catch(() => {});
-    }
-    ping();
-    const t = setInterval(ping, 30000);
-    return () => clearInterval(t);
+    let t;
+    let cancelled = false;
+    ensureAccountId()
+      .then((accountId) => {
+        if (cancelled || !accountId) return;
+        function ping() {
+          pingOnline(accountId).catch(() => {});
+        }
+        ping();
+        t = setInterval(ping, 30000);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+      if (t) clearInterval(t);
+    };
   }, []);
 
   useEffect(() => {
@@ -1500,7 +1509,7 @@ export default function SnakeAndLadder() {
         })
         .catch(() => {});
     } else {
-      socket.emit('joinRoom', { roomId: tableId, playerId: accountId, name });
+      socket.emit('joinRoom', { roomId: tableId, accountId, name });
     }
 
 

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -270,8 +270,8 @@ export function getSnakeResults() {
   return fetch(API_BASE_URL + '/api/snake/results').then((r) => r.json());
 }
 
-export function seatTable(playerId, tableId, name, confirmed) {
-  const body = { playerId, tableId };
+export function seatTable(accountId, tableId, name, confirmed) {
+  const body = { accountId, tableId };
   if (name) body.name = name;
   if (typeof confirmed === 'boolean') body.confirmed = confirmed;
   return fetch(API_BASE_URL + '/api/snake/table/seat', {
@@ -281,19 +281,19 @@ export function seatTable(playerId, tableId, name, confirmed) {
   }).then((r) => r.json());
 }
 
-export function unseatTable(playerId, tableId) {
+export function unseatTable(accountId, tableId) {
   return fetch(API_BASE_URL + '/api/snake/table/unseat', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ playerId, tableId }),
+    body: JSON.stringify({ accountId, tableId }),
   }).then((r) => r.json());
 }
 
-export function pingOnline(playerId) {
+export function pingOnline(accountId) {
   return fetch(API_BASE_URL + '/api/online/ping', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ playerId }),
+    body: JSON.stringify({ accountId }),
   }).then((r) => r.json());
 }
 

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -18,7 +18,7 @@ export function getPlayerId() {
     const aid = localStorage.getItem('accountId');
     if (aid) return aid;
   }
-  return getTelegramId();
+  return null;
 }
 
 export async function ensureAccountId() {
@@ -33,7 +33,7 @@ export async function ensureAccountId() {
       return res.accountId;
     }
   } catch {}
-  return tgId;
+  return null;
 }
 
 export function getTelegramUsername() {


### PR DESCRIPTION
## Summary
- track online and lobby players by accountId
- adjust websocket events and HTTP routes
- update web client to use accountId only
- revise tests for accountId changes

## Testing
- `npm test` *(fails: canvas build dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880a945477c8329beb7ff77db4954cb