### PR TITLE
Fix multiplayer lobby button

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -312,7 +312,7 @@ export default function Lobby() {
       <button
         onClick={confirmSeat}
         disabled={disabled || confirmed}
-        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-text rounded disabled:opacity-50"
+        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded disabled:opacity-50"
       >
         {confirmed ? 'Waiting...' : 'Confirm'}
       </button>

--- a/webapp/src/utils/lobby.js
+++ b/webapp/src/utils/lobby.js
@@ -3,10 +3,7 @@ export function canStartGame(game, table, stake, aiCount = 0, players = 0) {
     if (!stake || !stake.token || !stake.amount) return false;
     return aiCount > 0;
   }
-  if (game === 'snake' && table && table.id !== 'single') {
-    const capacity = table.capacity || 0;
-    if (players !== capacity) return false;
-  }
+  // For multiplayer snake games allow confirming before the table is full.
   if (!stake || !stake.token || !stake.amount) return false;
   if (game === 'snake' && !table) return false;
   return true;


### PR DESCRIPTION
## Summary
- ensure lobby confirm button text is readable
- allow confirming a table before it is full

## Testing
- `npm test` *(fails: cannot find package 'geoip-lite' imported in conflictMatchmaking.js)*

------
https://chatgpt.com/codex/tasks/task_e_6880b1da988c83298130d4e6c81a8f1f