### PR TITLE
Fix lobby wait state & leaderboard duplicates

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -4,7 +4,8 @@ export const DEFAULT_SNAKES = { 99: 80 };
 export const DEFAULT_LADDERS = { 3: 22, 27: 46 };
 export const ROLL_COOLDOWN_MS = 1000;
 export const RECONNECT_GRACE_MS = 60000;
-export const GAME_START_DELAY_MS = 5000;
+// Start multiplayer games immediately once all players join
+export const GAME_START_DELAY_MS = 0;
 import { SnakeGame } from './logic/snakeGame.js';
 import { LudoGame } from './logic/ludoGame.js';
 

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -86,7 +86,15 @@ export default function LeaderboardCard() {
   useEffect(() => {
     function loadLeaderboard() {
       getLeaderboard(telegramId).then((data) => {
-        setLeaderboard(data.users);
+        const seen = new Set();
+        const unique = [];
+        for (const u of data.users) {
+          if (!seen.has(u.accountId)) {
+            seen.add(u.accountId);
+            unique.push(u);
+          }
+        }
+        setLeaderboard(unique);
         setRank(data.rank);
       });
     }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1291,7 +1291,9 @@ export default function SnakeAndLadder() {
     }
 
     const updateNeeded = (players) => {
-      setPlayersNeeded(Math.max(0, capacity - players.length));
+      const need = Math.max(0, capacity - players.length);
+      setPlayersNeeded(need);
+      if (need === 0) setWaitingForPlayers(false);
     };
 
     const onJoined = ({ playerId }) => {


### PR DESCRIPTION
## Summary
- start multiplayer games immediately by setting `GAME_START_DELAY_MS` to 0
- update waiting logic in Snake board when table is full
- filter duplicate users before rendering leaderboard

## Testing
- `npm install`
- `npm test` *(fails: missing build deps for canvas)*

------
https://chatgpt.com/codex/tasks/task_e_6880bd4dfcfc8329bd1732a5edd9cee8