### PR TITLE
Fix duplicate players in Snake leaderboard

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -110,9 +110,9 @@ export class GameRoom {
       position: p.position,
     }));
     socket.emit('currentPlayers', list);
-    this.io.to(this.id).emit('currentPlayers', list);
+    socket.to(this.id).emit('currentPlayers', list);
     if (!existing) {
-      this.io.to(this.id).emit('playerJoined', { playerId, name });
+      socket.to(this.id).emit('playerJoined', { playerId, name });
       if (this.players.length === this.capacity) {
         if (this.startTimer) clearTimeout(this.startTimer);
         this.io.to(this.id).emit('gameStarting', { startIn: this.gameStartDelay });


### PR DESCRIPTION
## Summary
- fix socket events to avoid sending `currentPlayers` and `playerJoined` to the joining player twice

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6880c73574a08329bc1f98c58881019a