### PR TITLE
Support multiple dice rolls in SnakeGame

### DIFF
--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -42,7 +42,9 @@ export class SnakeGame {
 
     const dice = Array.isArray(diceValues)
       ? diceValues.map((v) => Math.max(1, Math.min(6, Math.floor(v))))
-      : [Math.floor(Math.random() * 6) + 1];
+      : Array.from({ length: player.diceCount }, () =>
+          Math.floor(Math.random() * 6) + 1
+        );
     const total = dice.reduce((a, b) => a + b, 0);
     const rolledSix = dice.includes(6);
     const doubleSix = dice.length === 2 && dice[0] === 6 && dice[1] === 6;

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -7,6 +7,7 @@ import {
   DEFAULT_SNAKES,
   DEFAULT_LADDERS,
 } from '../bot/gameEngine.js';
+import { SnakeGame } from '../bot/logic/snakeGame.js';
 
 class DummyIO {
   constructor() {
@@ -195,5 +196,17 @@ test('landing on another player sends them to start', () => {
   assert.equal(room.players[1].position, 0);
   const resetEvent = io.emitted.find(e => e.event === 'playerReset');
   assert.ok(resetEvent && resetEvent.data.playerId === 'p2');
+});
+
+test('rollDice uses player diceCount when generating values', () => {
+  const game = new SnakeGame();
+  game.addPlayer('p1', 'A');
+  const res1 = game.rollDice();
+  assert.equal(res1.dice.length, 2);
+  assert.ok(res1.dice.every(d => d >= 1 && d <= 6));
+  game.players[0].diceCount = 1;
+  const res2 = game.rollDice();
+  assert.equal(res2.dice.length, 1);
+  assert.ok(res2.dice[0] >= 1 && res2.dice[0] <= 6);
 });
 


### PR DESCRIPTION
## Summary
- modify `rollDice` to roll `player.diceCount` dice when no values provided
- test that `rollDice` generates the expected number of dice

## Testing
- `npm test` *(fails: Cannot find package 'express')*
- `node --test test/snakeGame.test.js` *(fails: socket.to is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6880ce8427ac8329a9ce3c4ae262f751