### PR TITLE
Make dynamic lobby client configurable

### DIFF
--- a/examples/dynamic-lobby/README.md
+++ b/examples/dynamic-lobby/README.md
@@ -1,0 +1,16 @@
+# Dynamic Lobby Example
+
+This folder contains a simple Socket.IO lobby server and client.
+
+Set the lobby server URL with the `SERVER_URL` environment variable or pass it when creating the client:
+
+```bash
+# using an environment variable
+SERVER_URL=http://127.0.0.1:3000 node client.js
+```
+
+```javascript
+// passing the URL explicitly
+import { createLobbyClient } from './client.js';
+const { joinLobby } = createLobbyClient('http://127.0.0.1:3000');
+```

--- a/examples/dynamic-lobby/client.js
+++ b/examples/dynamic-lobby/client.js
@@ -1,23 +1,28 @@
 import { io } from 'socket.io-client';
 import { v4 as uuidv4 } from 'uuid';
 
-const SERVER_URL = 'http://localhost:3000';
-const socket = io(SERVER_URL);
-
-export function joinLobby(
-  gameType,
-  stake,
-  accountId = uuidv4(),
-  name = 'Player'
+export function createLobbyClient(
+  serverUrl = process.env.SERVER_URL || 'http://localhost:3000'
 ) {
-  socket.emit('joinLobby', { accountId, name, gameType, stake });
-  return accountId;
+  const socket = io(serverUrl);
+
+  function joinLobby(
+    gameType,
+    stake,
+    accountId = uuidv4(),
+    name = 'Player'
+  ) {
+    socket.emit('joinLobby', { accountId, name, gameType, stake });
+    return accountId;
+  }
+
+  socket.on('lobbyUpdate', ({ tableId, players }) => {
+    console.log('Lobby update for', tableId, players);
+  });
+
+  socket.on('gameStart', ({ tableId, players, stake }) => {
+    console.log('Game starting on', tableId, 'stake', stake, players);
+  });
+
+  return { joinLobby, socket };
 }
-
-socket.on('lobbyUpdate', ({ tableId, players }) => {
-  console.log('Lobby update for', tableId, players);
-});
-
-socket.on('gameStart', ({ tableId, players, stake }) => {
-  console.log('Game starting on', tableId, 'stake', stake, players);
-});


### PR DESCRIPTION
## Summary
- make lobby client accept a server URL from `SERVER_URL` env var
- document how to set the URL for the lobby example

## Testing
- `npm run install-all` *(fails: canvas build error until system packages installed)*
- `npm test` *(fails: Bot is not running)*

------
https://chatgpt.com/codex/tasks/task_e_6880ce86b4e883298ad612d190caa921