### PR TITLE
Fix socket usage in snake game tests

### DIFF
--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -18,6 +18,17 @@ class DummyIO {
   }
 }
 
+function dummySocket(id, emitFn = () => {}) {
+  return {
+    id,
+    join: () => {},
+    emit: emitFn,
+    to() {
+      return { emit: emitFn };
+    }
+  };
+}
+
 test('applySnakesAndLadders resolves moves', () => {
   const io = new DummyIO();
   const room = new GameRoom('r', io, 4, {
@@ -38,8 +49,8 @@ test('start requires 6 and rolling 6 does not grant extra turn', () => {
     ladders: DEFAULT_LADDERS,
   });
   room.rollCooldown = 0;
-  const s1 = { id: 's1', join: () => {}, emit: () => {} };
-  const s2 = { id: 's2', join: () => {}, emit: () => {} };
+  const s1 = dummySocket('s1');
+  const s2 = dummySocket('s2');
   room.addPlayer('p1', 'Player1', s1);
   room.addPlayer('p2', 'Player2', s2);
   room.startGame();
@@ -64,7 +75,7 @@ test('rolling multiple sixes does not skip turn', () => {
     ladders: DEFAULT_LADDERS,
   });
   room.rollCooldown = 0;
-  const socket = { id: 's1', join: () => {}, emit: () => {} };
+  const socket = dummySocket('s1');
   room.addPlayer('p1', 'Player', socket);
   room.startGame();
 
@@ -82,8 +93,8 @@ test('room starts when reaching custom capacity', async () => {
   });
   room.gameStartDelay = 0;
   room.rollCooldown = 0;
-  const s1 = { id: 's1', join: () => {}, emit: () => {} };
-  const s2 = { id: 's2', join: () => {}, emit: () => {} };
+  const s1 = dummySocket('s1');
+  const s2 = dummySocket('s2');
   room.addPlayer('p1', 'A', s1);
   assert.equal(room.status, 'waiting');
   room.addPlayer('p2', 'B', s2);
@@ -100,8 +111,8 @@ test('joining player receives full player list', () => {
     snakes: DEFAULT_SNAKES,
     ladders: DEFAULT_LADDERS,
   });
-  const s1 = { id: 's1', join: () => {}, emit: () => {} };
-  const s2 = { id: 's2', join: () => {}, emit: (e,d)=>events.push({event:e,data:d}) };
+  const s1 = dummySocket('s1');
+  const s2 = dummySocket('s2', (e,d)=>events.push({event:e,data:d}));
   room.addPlayer('p1', 'A', s1);
   room.addPlayer('p2', 'B', s2);
   const cur = events.find(e => e.event === 'currentPlayers');
@@ -116,7 +127,7 @@ test('player wins when landing on the final tile', () => {
     ladders: DEFAULT_LADDERS,
   });
   room.rollCooldown = 0;
-  const socket = { id: 's1', join: () => {}, emit: () => {} };
+  const socket = dummySocket('s1');
   room.addPlayer('p1', 'Winner', socket);
   room.startGame();
 
@@ -133,7 +144,7 @@ test('player wins when landing on the final tile', () => {
 test('rolling too quickly triggers anti-cheat', () => {
   const io = new DummyIO();
   const emitted = [];
-  const socket = { id: 's1', join: () => {}, emit: (e, d) => emitted.push({ event: e, data: d }) };
+  const socket = dummySocket('s1', (e, d) => emitted.push({ event: e, data: d }));
   const room = new GameRoom('r4', io, 4, {
     snakes: DEFAULT_SNAKES,
     ladders: DEFAULT_LADDERS,
@@ -154,7 +165,7 @@ test('rolling too quickly triggers anti-cheat', () => {
 test('repeated cheating results in removal', () => {
   const io = new DummyIO();
   const emitted = [];
-  const socket = { id: 'sKick', join: () => {}, emit: (e, d) => emitted.push({ event: e, data: d }) };
+  const socket = dummySocket('sKick', (e, d) => emitted.push({ event: e, data: d }));
   const room = new GameRoom('rKick', io, 1, { snakes: DEFAULT_SNAKES, ladders: DEFAULT_LADDERS });
   room.addPlayer('p1', 'Cheater', socket);
   room.startGame();
@@ -178,8 +189,8 @@ test('landing on another player sends them to start', () => {
     ladders: {},
   });
   room.rollCooldown = 0;
-  const s1 = { id: 's1', join: () => {}, emit: () => {} };
-  const s2 = { id: 's2', join: () => {}, emit: () => {} };
+  const s1 = dummySocket('s1');
+  const s2 = dummySocket('s2');
   room.addPlayer('p1', 'A', s1);
   room.addPlayer('p2', 'B', s2);
   room.startGame();


### PR DESCRIPTION
## Summary
- add `dummySocket` helper in `snakeGame.test.js` to stub `to()`
- use `dummySocket` in tests to avoid `socket.to is not a function` error

## Testing
- `node --test test/snakeGame.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6880d164897c8329ab80dcbc239678c9