### PR TITLE
Fix multiplayer player count

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1291,7 +1291,9 @@ export default function SnakeAndLadder() {
     }
 
     const updateNeeded = (players) => {
-      const need = Math.max(0, capacity - players.length);
+      // Deduplicate by player id so repeated entries do not skew the count
+      const unique = Array.from(new Set(players.map((p) => p.id)));
+      const need = Math.max(0, capacity - unique.length);
       setPlayersNeeded(need);
       if (need === 0) setWaitingForPlayers(false);
     };
@@ -1454,8 +1456,16 @@ export default function SnakeAndLadder() {
           return { id: p.playerId, name, photoUrl, position: p.position || 0 };
         })
       ).then((arr) => {
-        setMpPlayers(arr);
-        updateNeeded(arr);
+        const unique = [];
+        const seen = new Set();
+        for (const p of arr) {
+          if (!seen.has(p.id)) {
+            seen.add(p.id);
+            unique.push(p);
+          }
+        }
+        setMpPlayers(unique);
+        updateNeeded(unique);
       });
     };
 


### PR DESCRIPTION
## Summary
- dedupe player IDs when calculating slots needed and updating player list

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_6880d9b658ac8329a442d5940561b9e9