### PR TITLE
Fix player list desync in game rooms

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -365,6 +365,7 @@ export class GameRoomManager {
         socketId: null,
         lastRollTime: 0
       }));
+      room.game.players = room.players;
       room.currentTurn = doc.currentTurn;
       room.status = doc.status;
       this.rooms.set(room.id, room);
@@ -409,6 +410,7 @@ export class GameRoomManager {
           socketId: null,
           lastRollTime: 0
         }));
+        room.game.players = room.players;
         room.currentTurn = record.currentTurn;
         room.status = record.status;
       } else {


### PR DESCRIPTION
## Summary
- ensure restored rooms copy the player list to `SnakeGame`

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6880e175506c8329908eacc28a18891c