### PR TITLE
Fix duplicate player join

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -83,6 +83,9 @@ export class GameRoom {
   addPlayer(playerId, name, socket) {
     const existing = this.players.find((p) => p.playerId === playerId);
     if (existing) {
+      if (!existing.disconnected) {
+        return { error: 'Player already in room' };
+      }
       existing.socketId = socket.id;
       existing.name = name || existing.name;
       existing.disconnected = false;


### PR DESCRIPTION
## Summary
- prevent same user from joining a room twice

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6880eb432ef08329b9d35a50a15aa442