### PR TITLE
Fix multiplayer board sync

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1152,7 +1152,8 @@ export default function SnakeAndLadder() {
         : 1;
     setAi(aiCount);
     setAvatarType(avatarParam);
-    setIsMultiplayer(tableParam && !aiParam);
+    const multiplayer = tableParam && !aiParam;
+    setIsMultiplayer(multiplayer);
     const watching = watchParam === "1";
     setWatchOnly(watching);
     if (watching) {
@@ -1215,7 +1216,7 @@ export default function SnakeAndLadder() {
     const table = params.get("table") || storedTable || "snake-4";
     setTableId(table);
     localStorage.setItem('snakeCurrentTable', table);
-    const boardPromise = isMultiplayer
+    const boardPromise = multiplayer
       ? getSnakeBoard(table)
       : Promise.resolve(generateBoardLocal());
     boardPromise


### PR DESCRIPTION
## Summary
- ensure board is fetched from server when starting a multiplayer game

## Testing
- `npm test` *(fails: Cannot find package 'geoip-lite')*

------
https://chatgpt.com/codex/tasks/task_e_6880f9018d7883299f4e3de800ab19d4