### PR TITLE
Make webapp build optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,12 @@ When deploying on **Render**, provide the same keys using the service's
 loads values from the runtime environment automatically so you can keep the
 `.env` files only for local development.
 
-The server honors a few extra environment variables when building or serving the webapp:
+The server honors a few extra environment variables when serving the webapp:
 
 - `WEBAPP_API_BASE_URL` – overrides the API base used during the webapp build. Set this when the bot API is hosted on another domain or port. If left empty the webapp assumes it is served from the same origin.
 - `TONCONNECT_MANIFEST_URL` – full URL for a custom `tonconnect-manifest.json`. Defaults to the manifest bundled with the build when unset.
-- `SKIP_WEBAPP_BUILD` – set to any value to skip the automatic webapp build that normally runs when `npm start` is executed. Useful if you built the assets manually.
+- `AUTO_WEBAPP_BUILD` – set to any value to automatically build the webapp on start when the `dist` folder is missing. Without this variable the server expects the build to be done manually.
+- `SKIP_WEBAPP_BUILD` – skip the build check entirely. Useful for tests.
 - `ALLOWED_ORIGINS` – comma-separated list of origins allowed for CORS and socket.io when serving the API.
 
 5. Copy `scripts/.env.example` to `scripts/.env` and set:
@@ -88,8 +89,10 @@ The server honors a few extra environment variables when building or serving the
    - `RPC_URL` – TON RPC endpoint (e.g. testnet)
    - `ADMIN_ADDRESS` – address that receives the minted supply
 
-6. Build the webapp assets. This step copies `public/tonconnect-manifest.json`
-   into the `dist` folder so wallets can connect:
+6. Build the webapp assets. The server no longer builds the webapp
+   automatically, so this must be done before starting it. The step also copies
+   `public/tonconnect-manifest.json` into the `dist` folder so wallets can
+   connect:
 
    ```bash
    npm --prefix webapp run build

--- a/bot/server.js
+++ b/bot/server.js
@@ -65,16 +65,30 @@ app.use('/api/broadcast', broadcastRoutes);
 const webappPath = path.join(__dirname, '../webapp/dist');
 
 function ensureWebappBuilt() {
-  if (process.env.SKIP_WEBAPP_BUILD) {
-    console.log('Skipping webapp build');
-    return true;
-  }
-  if (
+  const built =
     existsSync(path.join(webappPath, 'index.html')) &&
-    existsSync(path.join(webappPath, 'assets'))
-  ) {
+    existsSync(path.join(webappPath, 'assets'));
+
+  if (process.env.SKIP_WEBAPP_BUILD) {
+    if (!built) {
+      console.warn('Webapp build not found but SKIP_WEBAPP_BUILD is set');
+    } else {
+      console.log('Skipping webapp build');
+    }
+    return built;
+  }
+
+  if (built) {
     return true;
   }
+
+  if (!process.env.AUTO_WEBAPP_BUILD) {
+    console.warn(
+      'Webapp assets missing. Run "npm --prefix webapp run build" or set AUTO_WEBAPP_BUILD=1'
+    );
+    return false;
+  }
+
   try {
     console.log('Building webapp...');
     const webappDir = path.join(__dirname, '../webapp');


### PR DESCRIPTION
## Summary
- make the automatic webapp build opt‑in via `AUTO_WEBAPP_BUILD`
- update docs for manual build step and new env var

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688113cc3454832980ff7b0b7997f79f