### PR TITLE
Remove duplicate env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@
   - `TWITTER_BEARER_TOKEN` – bearer token for verifying reposts on **X**.
   - `TWITTER_CLIENT_ID` – API key for **X** OAuth linking.
   - `TWITTER_CLIENT_SECRET` – API secret for **X** OAuth linking.
-  - `ALLOWED_ORIGINS` – (optional) comma-separated list of origins allowed for
-    CORS and socket.io connections.
 
     When deploying on **Render**, set these values (including `CLAIM_CONTRACT_ADDRESS`, `CLAIM_WALLET_MNEMONIC` and `RPC_URL`) in the service environment instead of storing them in `.env` files.
 


### PR DESCRIPTION
## Summary
- remove repeated `ALLOWED_ORIGINS` entry from README

## Testing
- `grep -n ALLOWED_ORIGINS -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_68811e40623883298f3744f74e50c6de