### PR TITLE
Handle snake board load errors

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -637,6 +637,7 @@ export default function SnakeAndLadder() {
   const [showGift, setShowGift] = useState(false);
   const [chatBubbles, setChatBubbles] = useState([]);
   const [showWatchWelcome, setShowWatchWelcome] = useState(false);
+  const [boardError, setBoardError] = useState(null);
 
   const diceRef = useRef(null);
   const diceRollerDivRef = useRef(null);
@@ -1185,6 +1186,7 @@ export default function SnakeAndLadder() {
       : Promise.resolve(generateBoard());
     boardPromise
       .then(({ snakes: snakesObj = {}, ladders: laddersObj = {} }) => {
+        setBoardError(null);
         const limit = (obj) => {
           return Object.fromEntries(Object.entries(obj).slice(0, 8));
         };
@@ -1228,7 +1230,10 @@ export default function SnakeAndLadder() {
         });
         setDiceCells(diceMap);
       })
-      .catch(() => {});
+      .catch((err) => {
+        console.error(err);
+        setBoardError('Failed to load board. Please try again.');
+      });
   }, []);
 
   useEffect(() => {
@@ -2066,7 +2071,7 @@ export default function SnakeAndLadder() {
   };
 
   useEffect(() => {
-    if (waitingForPlayers || !setupPhase || aiPositions.length !== ai) return;
+    if (waitingForPlayers || !setupPhase || boardError || aiPositions.length !== ai) return;
     const total = ai + 1;
     if (total === 1) {
       setSetupPhase(false);
@@ -2113,7 +2118,7 @@ export default function SnakeAndLadder() {
       setTimeout(() => rollNext(idx + 1), 1000);
     };
     rollNext(0);
-  }, [ai, aiPositions, setupPhase]);
+  }, [ai, aiPositions, setupPhase, boardError]);
 
 
   useEffect(() => {
@@ -2652,6 +2657,21 @@ export default function SnakeAndLadder() {
         info="You're watching this match. Support your player by sending NFT GIFs and chat messages. Watching is free, but each chat costs 10 TPC."
       />
       )}
+      <InfoPopup
+        open={!!boardError}
+        onClose={() => setBoardError(null)}
+        title="Error"
+        info={boardError}
+      >
+        <div className="flex justify-center mt-2">
+          <button
+            onClick={() => window.location.reload()}
+            className="lobby-tile px-4 py-1"
+          >
+            Retry
+          </button>
+        </div>
+      </InfoPopup>
       <GameEndPopup
         open={gameOver}
         ranking={ranking}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -262,8 +262,13 @@ export function getSnakeLobby(id) {
   return fetch(API_BASE_URL + '/api/snake/lobby/' + id).then((r) => r.json());
 }
 
-export function getSnakeBoard(id) {
-  return fetch(API_BASE_URL + '/api/snake/board/' + id).then((r) => r.json());
+export async function getSnakeBoard(id) {
+  const response = await fetch(API_BASE_URL + '/api/snake/board/' + id);
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(text || response.statusText);
+  }
+  return response.json();
 }
 
 export function getSnakeResults() {


### PR DESCRIPTION
## Summary
- handle API board fetch failures
- surface board loading errors in Snake and Ladder UI

## Testing
- `npm test` *(fails: canvas build error)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688120ec02fc832997df2ffb6e186c4f