### PR TITLE
Fix board separation per table

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -212,7 +212,8 @@ export class GameRoom {
         this.status = 'finished';
         GameResult.create({
           winner: player.name,
-          participants: this.players.map((p) => p.name)
+          participants: this.players.map((p) => p.name),
+          tableId: this.id
         }).catch((err) =>
           console.error('Failed to store game result:', err.message)
         );
@@ -286,6 +287,7 @@ export class GameRoom {
         GameResult.create({
           winner: winner.name,
           participants: this.players.map((p) => p.name),
+          tableId: this.id,
         }).catch((err) =>
           console.error('Failed to store game result:', err.message)
         );

--- a/bot/models/GameResult.js
+++ b/bot/models/GameResult.js
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 const gameResultSchema = new mongoose.Schema({
   winner: { type: String, required: true },
   participants: { type: [String], default: [] },
+  tableId: { type: String, default: null },
   createdAt: { type: Date, default: Date.now }
 });
 

--- a/bot/server.js
+++ b/bot/server.js
@@ -231,16 +231,20 @@ app.get('/api/snake/board/:id', async (req, res) => {
 });
 
 app.get('/api/snake/results', async (req, res) => {
-  if (req.query.leaderboard) {
-    const leaderboard = await GameResult.aggregate([
+  const { leaderboard, tableId } = req.query;
+  if (leaderboard) {
+    const match = tableId ? { tableId } : {};
+    const leaderboardData = await GameResult.aggregate([
+      { $match: match },
       { $group: { _id: '$winner', wins: { $sum: 1 } } },
       { $sort: { wins: -1 } },
       { $limit: 20 },
     ]);
-    return res.json({ leaderboard });
+    return res.json({ leaderboard: leaderboardData });
   }
   const limit = Number(req.query.limit) || 20;
-  const results = await GameResult.find()
+  const query = tableId ? { tableId } : {};
+  const results = await GameResult.find(query)
     .sort({ createdAt: -1 })
     .limit(limit)
     .lean();

--- a/webapp/src/pages/Games/SnakeResults.jsx
+++ b/webapp/src/pages/Games/SnakeResults.jsx
@@ -7,7 +7,9 @@ export default function SnakeResults() {
   const [results, setResults] = useState([]);
 
   useEffect(() => {
-    getSnakeResults().then((data) => setResults(data.results || []));
+    const params = new URLSearchParams(window.location.search);
+    const table = params.get('table');
+    getSnakeResults(table).then((data) => setResults(data.results || []));
   }, []);
 
   return (

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -271,8 +271,10 @@ export async function getSnakeBoard(id) {
   return response.json();
 }
 
-export function getSnakeResults() {
-  return fetch(API_BASE_URL + '/api/snake/results').then((r) => r.json());
+export function getSnakeResults(tableId) {
+  let url = API_BASE_URL + '/api/snake/results';
+  if (tableId) url += '?tableId=' + encodeURIComponent(tableId);
+  return fetch(url).then((r) => r.json());
 }
 
 export function seatTable(accountId, tableId, name, confirmed) {


### PR DESCRIPTION
## Summary
- include tableId in GameResult records
- persist tableId when storing snake game results
- filter game results by table
- support table filtering in the webapp API helpers
- load table-specific results when viewing game results

## Testing
- `npm test` *(fails: canvas build dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_688145c542648329a6fc6ef836bf2ef4