### PR TITLE
Fix socket connection logging and config

### DIFF
--- a/webapp/src/utils/socket.js
+++ b/webapp/src/utils/socket.js
@@ -6,4 +6,7 @@ if (typeof window !== 'undefined' && window.location.protocol === 'https:' && ba
   baseUrl = baseUrl.replace(/^http:/, 'https:');
 }
 
-export const socket = io(baseUrl);
+console.log('Socket is trying to connect to:', baseUrl);
+export const socket = io(baseUrl, {
+  transports: ['websocket', 'polling']
+});


### PR DESCRIPTION
## Summary
- add debug logging for socket initialization
- force WebSocket and polling transports for socket.io
- demonstrate `.env` customization for a remote API URL

## Testing
- `npm test` *(fails: canvas module build error)*

------
https://chatgpt.com/codex/tasks/task_e_6881bed8a78c8329a7e3d1e7da81d246