### PR TITLE
Fix snake lobby to use TPC-only stakes

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -416,8 +416,8 @@ export class GameRoomManager {
   }
 
   async joinRoom(roomId, playerId, name, socket) {
-    const match = /-(\d+)$/.exec(roomId);
-    const cap = match ? Number(match[1]) : 4;
+    const parts = roomId.split('-');
+    const cap = Number(parts[1]) || 4;
     const room = await this.getRoom(roomId, cap);
     let playerName = name;
     if (!playerName && playerId) {

--- a/test/lobbyUtils.test.js
+++ b/test/lobbyUtils.test.js
@@ -24,27 +24,27 @@ test('cannot start without stake', () => {
 });
 
 test('cannot start without table when required', () => {
-  assert.equal(canStartGame('snake', null, { token: 'TON', amount: 100 }, 0, 0), false);
+  assert.equal(canStartGame('snake', null, { token: 'TPC', amount: 100 }, 0, 0), false);
 });
 
 test('can start when table and stake present', () => {
-  assert.equal(canStartGame('snake', dummyTable, { token: 'TON', amount: 100 }, 0, 2), true);
+  assert.equal(canStartGame('snake', dummyTable, { token: 'TPC', amount: 100 }, 0, 2), true);
 });
 
 test('start allowed before lobby full', () => {
   assert.equal(
-    canStartGame('snake', dummyTable, { token: 'TON', amount: 100 }, 0, 1),
+    canStartGame('snake', dummyTable, { token: 'TPC', amount: 100 }, 0, 1),
     true,
   );
   assert.equal(
-    canStartGame('snake', dummyTable, { token: 'TON', amount: 100 }, 0, 2),
+    canStartGame('snake', dummyTable, { token: 'TPC', amount: 100 }, 0, 2),
     true,
   );
 });
 
 test('starting over capacity still allowed', () => {
   assert.equal(
-    canStartGame('snake', dummyTable, { token: 'TON', amount: 100 }, 0, 3),
+    canStartGame('snake', dummyTable, { token: 'TPC', amount: 100 }, 0, 3),
     true,
   );
 });

--- a/test/lobbyWait.test.js
+++ b/test/lobbyWait.test.js
@@ -39,14 +39,14 @@ test('joinRoom waits until table full', { concurrency: false, timeout: 20000 }, 
     await fetch('http://localhost:3203/api/snake/table/seat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tableId: 'snake-2', accountId: 'p1', name: 'A', confirmed: true })
+      body: JSON.stringify({ tableId: 'snake-2-100', accountId: 'p1', name: 'A', confirmed: true })
     });
 
     const s1 = io('http://localhost:3203');
     const errors = [];
     await new Promise((resolve) => s1.on('connect', resolve));
     s1.on('error', (e) => errors.push(e));
-    s1.emit('joinRoom', { roomId: 'snake-2', accountId: 'p1', name: 'A' });
+    s1.emit('joinRoom', { roomId: 'snake-2-100', accountId: 'p1', name: 'A' });
     await delay(1500);
     assert.ok(errors.length > 0, 'should receive error when table not full');
     s1.off('error');
@@ -55,10 +55,10 @@ test('joinRoom waits until table full', { concurrency: false, timeout: 20000 }, 
     await fetch('http://localhost:3203/api/snake/table/seat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tableId: 'snake-2', accountId: 'p2', name: 'B', confirmed: true })
+      body: JSON.stringify({ tableId: 'snake-2-100', accountId: 'p2', name: 'B', confirmed: true })
     });
 
-    s1.emit('joinRoom', { roomId: 'snake-2', accountId: 'p1', name: 'A' });
+    s1.emit('joinRoom', { roomId: 'snake-2-100', accountId: 'p1', name: 'A' });
     await delay(200);
     assert.equal(errors.length, 0, 'should join when table full');
     s1.disconnect();

--- a/test/snakeApi.test.js
+++ b/test/snakeApi.test.js
@@ -131,7 +131,7 @@ test('snake API endpoints and socket events', { concurrency: false, timeout: 200
 
     assert.ok(lobbies.every((l) => l.id && l.capacity));
 
-    const boardRes = await fetch('http://localhost:3201/api/snake/board/snake-2');
+    const boardRes = await fetch('http://localhost:3201/api/snake/board/snake-2-100');
 
     assert.equal(boardRes.status, 200);
 
@@ -142,12 +142,12 @@ test('snake API endpoints and socket events', { concurrency: false, timeout: 200
     await fetch('http://localhost:3201/api/snake/table/seat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tableId: 'snake-2', accountId: 'p1', name: 'A', confirmed: true })
+      body: JSON.stringify({ tableId: 'snake-2-100', accountId: 'p1', name: 'A', confirmed: true })
     });
     await fetch('http://localhost:3201/api/snake/table/seat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tableId: 'snake-2', accountId: 'p2', name: 'B', confirmed: true })
+      body: JSON.stringify({ tableId: 'snake-2-100', accountId: 'p2', name: 'B', confirmed: true })
     });
 
     const s1 = io('http://localhost:3201');
@@ -157,10 +157,10 @@ test('snake API endpoints and socket events', { concurrency: false, timeout: 200
     s1.onAny((e) => events.push(e));
     s2.onAny((e) => events.push(e));
 
-    s1.emit('joinRoom', { roomId: 'snake-2', accountId: 'p1', name: 'A' });
+    s1.emit('joinRoom', { roomId: 'snake-2-100', accountId: 'p1', name: 'A' });
     await delay(200);
 
-    s2.emit('joinRoom', { roomId: 'snake-2', accountId: 'p2', name: 'B' });
+    s2.emit('joinRoom', { roomId: 'snake-2-100', accountId: 'p2', name: 'B' });
 
     for (let i = 0; i < 100 && !events.includes('gameStarted'); i++) {
 

--- a/test/snakeLobbyRoute.test.js
+++ b/test/snakeLobbyRoute.test.js
@@ -40,10 +40,10 @@ test('snake lobby route lists players', async () => {
   try {
     for (let i = 0; i < 100; i++) {
       try {
-        const res = await fetch('http://localhost:3200/api/snake/lobby/snake-2');
+        const res = await fetch('http://localhost:3200/api/snake/lobby/snake-2-100');
         if (res.ok) {
           const data = await res.json();
-          assert.equal(data.id, 'snake-2');
+          assert.equal(data.id, 'snake-2-100');
           assert.ok(Array.isArray(data.players));
           return;
         }

--- a/test/snakeSeat.test.js
+++ b/test/snakeSeat.test.js
@@ -39,11 +39,11 @@ test('seat and unseat endpoints update lobby', { concurrency: false, timeout: 20
     let res = await fetch('http://localhost:3202/api/snake/table/seat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tableId: 'snake-2', accountId: 'p100', name: 'Tester' })
+      body: JSON.stringify({ tableId: 'snake-2-100', accountId: 'p100', name: 'Tester' })
     });
     assert.equal(res.status, 200);
 
-    res = await fetch('http://localhost:3202/api/snake/lobby/snake-2');
+    res = await fetch('http://localhost:3202/api/snake/lobby/snake-2-100');
     assert.equal(res.status, 200);
     let lobby = await res.json();
     assert.ok(lobby.players.some(p => p.id === 'p100' && p.name === 'Tester'));
@@ -51,11 +51,11 @@ test('seat and unseat endpoints update lobby', { concurrency: false, timeout: 20
     res = await fetch('http://localhost:3202/api/snake/table/unseat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tableId: 'snake-2', accountId: 'p100' })
+      body: JSON.stringify({ tableId: 'snake-2-100', accountId: 'p100' })
     });
     assert.equal(res.status, 200);
 
-    res = await fetch('http://localhost:3202/api/snake/lobby/snake-2');
+    res = await fetch('http://localhost:3202/api/snake/lobby/snake-2-100');
     assert.equal(res.status, 200);
     lobby = await res.json();
     assert.ok(!lobby.players.some(p => p.id === 'p100'));

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1252,7 +1252,8 @@ export default function SnakeAndLadder() {
     if (!isMultiplayer) return;
     const accountId = getPlayerId();
     const name = myName;
-    const capacity = parseInt(tableId.split('-').pop(), 10) || 0;
+    const parts = tableId.split('-');
+    const capacity = parseInt(parts[1], 10) || 0;
     if (!watchOnly) {
       setWaitingForPlayers(true);
       setPlayersNeeded(capacity);


### PR DESCRIPTION
## Summary
- restrict snake lobby stake selector to TPC only
- include stake value in table IDs when seating players
- adjust server lobby routes to parse new table IDs
- update capacity parsing in game engine
- update tests for new table ID format

## Testing
- `scripts/setup-tests.sh`
- `npm test` *(fails: canvas build error)*

------
https://chatgpt.com/codex/tasks/task_e_6881c76ab27c8329804dedc1ab562097