### PR TITLE
Adjust Lucky card dice position

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -14,6 +14,7 @@ export default function DiceRoller({
   muted = false,
   emitRollEvent = false,
   divRef,
+  className = '',
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -95,7 +96,7 @@ export default function DiceRoller({
   };
 
   return (
-    <div className="flex flex-col items-center space-y-4">
+    <div className={`flex flex-col items-center space-y-4 ${className}`}>
       <div
         className={`flex space-x-4 ${clickable ? 'cursor-pointer' : ''}`}
         onClick={clickable ? rollDice : undefined}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1689,3 +1689,8 @@ input:focus {
     transform: translate(50vw, 40vh) scale(0.4) rotate(1800deg);
   }
 }
+
+/* Slight adjustment for the Lucky Number dice position */
+.lucky-dice {
+  transform: translate(0.75rem, 0.75rem);
+}


### PR DESCRIPTION
## Summary
- allow `DiceRoller` to accept a custom `className`
- bump the Lucky Card dice down and to the right via new `.lucky-dice` style

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6881cfcce52483299d28a08310fa6c82