### PR TITLE
Fix board generation and turn indicator

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -100,9 +100,12 @@ export class GameRoom {
       clearTimeout(this.startTimer);
       this.startTimer = null;
     }
-    // The board is generated when the room is created and should remain
-    // consistent for all players. Do not regenerate it here.
     if (this.gameType === 'snake') {
+      // Generate a fresh board for each new game so all players share the
+      // same layout while ensuring variety across games.
+      const board = generateBoard();
+      this.snakes = board.snakes;
+      this.ladders = board.ladders;
       this.game.snakes = this.snakes;
       this.game.ladders = this.ladders;
     }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2519,21 +2519,29 @@ export default function SnakeAndLadder() {
           </div>
         </div>
       )}
-      {currentTurn === 0 && !aiRollingIndex && !playerAutoRolling && (
-        <div
-          className="fixed bottom-24 inset-x-0 flex flex-col items-center z-20 cursor-pointer"
-          style={{ transform: 'translateX(2rem)' }}
-          onClick={() => diceRollerDivRef.current?.click()}
-        >
-          <div className="text-5xl">🫵</div>
-          <div
-            className="turn-message text-2xl mt-1"
-            style={{ color: players[currentTurn]?.color }}
-          >
-            Your turn
-          </div>
-        </div>
-      )}
+      {(() => {
+        const myId = getPlayerId();
+        const myIndex = isMultiplayer
+          ? mpPlayers.findIndex((p) => p.id === myId)
+          : 0;
+        return (
+          currentTurn === myIndex && !aiRollingIndex && !playerAutoRolling && (
+            <div
+              className="fixed bottom-24 inset-x-0 flex flex-col items-center z-20 cursor-pointer"
+              style={{ transform: 'translateX(2rem)' }}
+              onClick={() => diceRollerDivRef.current?.click()}
+            >
+              <div className="text-5xl">🫵</div>
+              <div
+                className="turn-message text-2xl mt-1"
+                style={{ color: players[currentTurn]?.color }}
+              >
+                Your turn
+              </div>
+            </div>
+          )
+        );
+      })()}
       {isMultiplayer && (
         <div
           className="fixed bottom-24 inset-x-0 flex flex-col items-center z-20 cursor-pointer"


### PR DESCRIPTION
## Summary
- regenerate Snake & Ladder board every new game so players see the same board
- show "Your turn" indicator only to the player whose turn it is

## Testing
- `npm test` *(fails: canvas dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881d188690083298083e2884a402b5f