### PR TITLE
Fix board fetch on param change

### DIFF
--- a/test/snakeBoardConsistency.test.js
+++ b/test/snakeBoardConsistency.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { GameRoomManager } from '../bot/gameEngine.js';
+
+class DummyIO {
+  to() { return { emit: () => {} }; }
+  emit() {}
+}
+
+function dummySocket(id) {
+  return { id, join: () => {} };
+}
+
+test('players joining receive identical board', async () => {
+  const manager = new GameRoomManager(new DummyIO());
+  const room = await manager.getRoom('snake-2', 2);
+  const firstSnakes = room.snakes;
+  const firstLadders = room.ladders;
+
+  await manager.joinRoom('snake-2', 'p1', 'A', dummySocket('s1'));
+  await manager.joinRoom('snake-2', 'p2', 'B', dummySocket('s2'));
+  const after = await manager.getRoom('snake-2', 2);
+  assert.deepEqual(after.snakes, firstSnakes);
+  assert.deepEqual(after.ladders, firstLadders);
+});

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -32,7 +32,7 @@ import {
 import BottomLeftIcons from "../../components/BottomLeftIcons.jsx";
 import { isGameMuted, getGameVolume } from "../../utils/sound.js";
 import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { getPlayerId, getTelegramId, ensureAccountId } from "../../utils/telegram.js";
 import {
   getProfileByAccount,
@@ -492,6 +492,7 @@ export default function SnakeAndLadder() {
   const [showQuitInfo, setShowQuitInfo] = useState(true);
   useTelegramBackButton();
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     ensureAccountId().catch(() => {});
@@ -1100,7 +1101,7 @@ export default function SnakeAndLadder() {
   }, []);
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
+    const params = new URLSearchParams(location.search);
     const watchParam = params.get("watch");
     const t = params.get("token");
     const amt = params.get("amount");
@@ -1118,7 +1119,8 @@ export default function SnakeAndLadder() {
         : 1;
     setAi(aiCount);
     setAvatarType(avatarParam);
-    setIsMultiplayer(tableParam && !aiParam);
+    const mp = tableParam && !aiParam;
+    setIsMultiplayer(mp);
     const watching = watchParam === "1";
     setWatchOnly(watching);
     if (watching) {
@@ -1178,10 +1180,10 @@ export default function SnakeAndLadder() {
     setPlayerColors(colors);
 
     const storedTable = localStorage.getItem('snakeCurrentTable');
-    const table = params.get("table") || storedTable || "snake-4";
+    const table = tableParam || storedTable || "snake-4";
     setTableId(table);
     localStorage.setItem('snakeCurrentTable', table);
-    const boardPromise = isMultiplayer
+    const boardPromise = mp
       ? getSnakeBoard(table)
       : Promise.resolve(generateBoard());
     boardPromise
@@ -1234,7 +1236,7 @@ export default function SnakeAndLadder() {
         console.error(err);
         setBoardError('Failed to load board. Please try again.');
       });
-  }, []);
+  }, [location.search]);
 
   useEffect(() => {
     playersRef.current = mpPlayers;


### PR DESCRIPTION
## Summary
- use `useLocation` in `SnakeAndLadder` to watch query params
- compute multiplayer flag locally and use it when loading the board
- reload board when query parameters change
- test that multiple players joining share the same board

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881d8788a808329b4b4b203cd3ad7bb