### PR TITLE
Improve dynamic lobby game flow

### DIFF
--- a/examples/dynamic-lobby/README.md
+++ b/examples/dynamic-lobby/README.md
@@ -2,6 +2,13 @@
 
 This folder contains a simple Socket.IO lobby server and client.
 
+When a table fills up the server waits a short delay before emitting a
+`gameStart` event so that the final player has time to connect. A fresh
+Snakes & Ladders board is generated at that moment and included in the
+event payload. If more players request the same table size and stake
+while an existing table is already full, a new table with the same
+conditions is created automatically.
+
 Set the lobby server URL with the `SERVER_URL` environment variable or pass it when creating the client:
 
 ```bash


### PR DESCRIPTION
## Summary
- add board generation and game start delay to `examples/dynamic-lobby/server.js`
- cancel start timer when a player leaves or a table is cleaned up
- document new lobby behaviour in `examples/dynamic-lobby/README.md`

## Testing
- `npm test` *(fails: canvas build error)*

------
https://chatgpt.com/codex/tasks/task_e_6881f4d4044083298f2dceaaba505a45