### PR TITLE
Fix multiplayer player id restore

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -340,6 +340,7 @@ export class GameRoomManager {
       }, doc.gameType || 'snake');
       room.players = doc.players.map((p) => ({
         ...p.toObject(),
+        id: p.playerId,
         socketId: null,
         lastRollTime: 0
       }));
@@ -414,6 +415,7 @@ export class GameRoomManager {
       );
       room.players = record.players.map((p) => ({
         ...p.toObject(),
+        id: p.playerId,
         socketId: null,
         lastRollTime: 0
       }));


### PR DESCRIPTION
## Summary
- maintain `id` field when restoring players from DB

## Testing
- `npm test` *(fails: canvas dependency build error)*

------
https://chatgpt.com/codex/tasks/task_e_6881fae7d9d883298c9b0697105b50f5