### PR TITLE
Fix snake game start flow

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1267,8 +1267,10 @@ export default function SnakeAndLadder() {
     const parts = tableId.split('-');
     const capacity = parseInt(parts[1], 10) || 0;
     if (!watchOnly) {
-      setWaitingForPlayers(true);
-      setPlayersNeeded(capacity);
+      // Players already confirmed in the lobby so avoid showing the
+      // blocking waiting popup when entering the board.
+      setWaitingForPlayers(false);
+      setPlayersNeeded(0);
     } else {
       setWaitingForPlayers(false);
     }
@@ -2127,6 +2129,16 @@ export default function SnakeAndLadder() {
 
   useEffect(() => {
     if (waitingForPlayers || !setupPhase || boardError || aiPositions.length !== ai) return;
+
+    if (isMultiplayer) {
+      // The first player to join the table should roll first.
+      setSetupPhase(false);
+      setTurnMessage(`${getPlayerName(0)} starts first.`);
+      setCurrentTurn(0);
+      setDiceCount(playerDiceCounts[0] ?? 2);
+      return;
+    }
+
     const total = ai + 1;
     if (total === 1) {
       setSetupPhase(false);
@@ -2173,7 +2185,7 @@ export default function SnakeAndLadder() {
       setTimeout(() => rollNext(idx + 1), 1000);
     };
     rollNext(0);
-  }, [ai, aiPositions, setupPhase, boardError]);
+  }, [ai, aiPositions, setupPhase, boardError, waitingForPlayers, isMultiplayer, mpPlayers]);
 
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid blocking waiting popup after lobby confirmation
- ensure first player to join rolls first when multiplayer game starts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68821c1945208329b5c0575b23178691