### PR TITLE
Fix socket re-registration on reconnect

### DIFF
--- a/webapp/src/hooks/useTelegramAuth.js
+++ b/webapp/src/hooks/useTelegramAuth.js
@@ -4,12 +4,22 @@ import { ensureAccountId } from '../utils/telegram.js';
 
 export default function useTelegramAuth() {
   useEffect(() => {
+    let accountId;
     const user = window?.Telegram?.WebApp?.initDataUnsafe?.user;
-    ensureAccountId().then((acc) => {
-      if (acc) {
-        socket.emit('register', { accountId: acc });
-      }
-    }).catch(() => {});
+    ensureAccountId()
+      .then((acc) => {
+        accountId = acc;
+        if (acc) {
+          socket.emit('register', { accountId: acc });
+        }
+      })
+      .catch(() => {});
+
+    const onConnect = () => {
+      if (accountId) socket.emit('register', { accountId });
+    };
+    socket.on('connect', onConnect);
+
     if (user?.username) {
       localStorage.setItem('telegramUsername', user.username);
     }
@@ -22,5 +32,9 @@ export default function useTelegramAuth() {
     if (user) {
       localStorage.setItem('telegramUserData', JSON.stringify(user));
     }
+
+    return () => {
+      socket.off('connect', onConnect);
+    };
   }, []);
 }


### PR DESCRIPTION
## Summary
- ensure socket registration persists across reconnects

## Testing
- `npm test` *(fails: canvas prebuild binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_68822b2ce9cc8329a750fb81be321ecf