### PR TITLE
Refactor snake logic

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -21,6 +21,7 @@ import { AVATARS } from "../../components/AvatarPickerModal.jsx";
 import { LEADER_AVATARS } from "../../utils/leaderAvatars.js";
 import { FLAG_EMOJIS } from "../../utils/flagEmojis.js";
 import generateBoard from "../../utils/generateBoard.js";
+import { applySnakesAndLadders } from "../../utils/snakeGame.js";
 import { getAvatarUrl, saveAvatar, loadAvatar, avatarToName } from "../../utils/avatarUtils.js";
 import InfoPopup from "../../components/InfoPopup.jsx";
 import HintPopup from "../../components/HintPopup.jsx";
@@ -1602,11 +1603,7 @@ export default function SnakeAndLadder() {
         } else if (p + roll <= FINAL_TILE) {
           p += roll;
         }
-        if (state.snakes[p] != null) p = Math.max(0, state.snakes[p]);
-        else if (state.ladders[p] != null) {
-          const lad = state.ladders[p];
-          p = typeof lad === 'object' ? lad.end : lad;
-        }
+        p = applySnakesAndLadders(p, state.snakes, state.ladders);
         aiPos = aiPos.map((pos) => (pos === p ? 0 : pos));
         if (p === FINAL_TILE && !rank.includes('You')) {
           rank.push('You');
@@ -1620,11 +1617,7 @@ export default function SnakeAndLadder() {
         } else if (pos + roll <= FINAL_TILE) {
           pos += roll;
         }
-        if (state.snakes[pos] != null) pos = Math.max(0, state.snakes[pos]);
-        else if (state.ladders[pos] != null) {
-          const lad = state.ladders[pos];
-          pos = typeof lad === 'object' ? lad.end : lad;
-        }
+        pos = applySnakesAndLadders(pos, state.snakes, state.ladders);
         if (p === pos) p = 0;
         aiPos = aiPos.map((v, i) => (i === idx ? pos : v === pos ? 0 : v));
         if (pos === FINAL_TILE && !rank.includes(getPlayerName(turn))) {
@@ -1741,11 +1734,7 @@ export default function SnakeAndLadder() {
     } else if (preview !== 100 || diceCount !== 2) {
       if (preview + value <= FINAL_TILE) preview = preview + value;
     }
-    if (snakes[preview] != null) preview = Math.max(0, snakes[preview]);
-    else if (ladders[preview] != null) {
-      const ladObj = ladders[preview];
-      preview = typeof ladObj === 'object' ? ladObj.end : ladObj;
-    }
+    preview = applySnakesAndLadders(preview, snakes, ladders);
     const willCapture = aiPositions.some((p) => p === preview);
 
     setRollResult(value);
@@ -1837,12 +1826,7 @@ export default function SnakeAndLadder() {
       }
 
 
-      let predicted = target;
-      if (snakes[predicted] != null) predicted = Math.max(0, snakes[predicted]);
-      else if (ladders[predicted] != null) {
-        const ladObj = ladders[predicted];
-        predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
-      }
+      let predicted = applySnakesAndLadders(target, snakes, ladders);
       const extraPred = diceCells[predicted] || doubleSix;
       const nextPlayer = extraPred ? currentTurn : (currentTurn + 1) % (ai + 1);
       animateDiceToPlayer(nextPlayer);
@@ -1974,11 +1958,7 @@ export default function SnakeAndLadder() {
     } else if (preview + value <= FINAL_TILE) {
       preview = preview + value;
     }
-    if (snakes[preview] != null) preview = Math.max(0, snakes[preview]);
-    else if (ladders[preview] != null) {
-      const ladObj = ladders[preview];
-      preview = typeof ladObj === 'object' ? ladObj.end : ladObj;
-    }
+    preview = applySnakesAndLadders(preview, snakes, ladders);
     const capture =
       (index !== 0 && pos === preview) ||
       aiPositions.some((p, i) => i !== index - 1 && p === preview);
@@ -2046,12 +2026,7 @@ export default function SnakeAndLadder() {
       target = current + value;
     }
 
-    let predicted = target;
-    if (snakes[predicted] != null) predicted = Math.max(0, snakes[predicted]);
-    else if (ladders[predicted] != null) {
-      const ladObj = ladders[predicted];
-      predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
-    }
+    let predicted = applySnakesAndLadders(target, snakes, ladders);
     const extraPred = diceCells[predicted] || doubleSix;
     const nextPlayer = extraPred ? index : (index + 1) % (ai + 1);
     animateDiceToPlayer(nextPlayer);

--- a/webapp/src/utils/snakeGame.js
+++ b/webapp/src/utils/snakeGame.js
@@ -1,0 +1,1 @@
+export * from '../../../bot/logic/snakeGame.js';


### PR DESCRIPTION
## Summary
- expose backend SnakeGame utils to the frontend
- use `applySnakesAndLadders` for both singleplayer and multiplayer logic

## Testing
- `npm test` *(fails: canvas build error)*

------
https://chatgpt.com/codex/tasks/task_e_68828896067c8329b536cc11b585f521