### PR TITLE
Add snake engine tests and board consistency check

### DIFF
--- a/test/snakeApi.test.js
+++ b/test/snakeApi.test.js
@@ -139,6 +139,7 @@ test('snake API endpoints and socket events', { concurrency: false, timeout: 200
 
     assert.ok(board.snakes && board.ladders);
 
+
     await fetch('http://localhost:3201/api/snake/table/seat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -149,6 +150,11 @@ test('snake API endpoints and socket events', { concurrency: false, timeout: 200
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ tableId: 'snake-2-100', accountId: 'p2', name: 'B', confirmed: true })
     });
+
+    const boardRes2 = await fetch('http://localhost:3201/api/snake/board/snake-2-100');
+    assert.equal(boardRes2.status, 200);
+    const board2 = await boardRes2.json();
+    assert.deepEqual(board2, board);
 
     const s1 = io('http://localhost:3201');
     const s2 = io('http://localhost:3201');

--- a/test/snakeEngine.test.js
+++ b/test/snakeEngine.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SnakeGame, FINAL_TILE } from '../bot/logic/snakeGame.js';
+
+function setupGame() {
+  const game = new SnakeGame({ snakes: {}, ladders: {} });
+  game.addPlayer('p1', 'A');
+  return game;
+}
+
+// Dice rolling should accept provided values and activate token when a six appears
+test('dice roll activates token with six', () => {
+  const game = setupGame();
+  const res = game.rollDice([6, 3]);
+  assert.equal(res.player, 'p1');
+  assert.deepEqual(res.dice, [6, 3]);
+  assert.equal(game.players[0].position, 1);
+  assert.deepEqual(res.path, [1]);
+});
+
+// After entering the board the token moves forward by the dice total
+test('token moves forward by dice total', () => {
+  const game = setupGame();
+  game.players[0].position = 1;
+  const res = game.rollDice([2, 3]);
+  assert.equal(game.players[0].position, 6);
+  assert.deepEqual(res.path, [2, 3, 4, 5, 6]);
+});
+
+// Reaching the final tile ends the game
+test('player wins when reaching final tile', () => {
+  const game = setupGame();
+  game.players[0].position = 100;
+  game.players[0].diceCount = 1;
+  const res = game.rollDice([1]);
+  assert.equal(game.players[0].position, FINAL_TILE);
+  assert.ok(res.finished);
+  assert.ok(game.finished);
+});


### PR DESCRIPTION
## Summary
- add new unit tests covering dice rolling, movement and win detection in `SnakeGame`
- extend API tests to verify `/api/snake/board/:id` is stable for players joining a table

## Testing
- `npm test --silent` *(fails: should receive error when table not full)*

------
https://chatgpt.com/codex/tasks/task_e_68829a32dfe483299db9adbdc26a8bab