### PR TITLE
Centralized snake game state

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -22,6 +22,7 @@ import SnakeResults from './pages/Games/SnakeResults.jsx';
 import CrazyDiceDuel from './pages/Games/CrazyDiceDuel.jsx';
 import CrazyDiceLobby from './pages/Games/CrazyDiceLobby.jsx';
 import Lobby from './pages/Games/Lobby.jsx';
+import { GameProvider } from './store/gameState.js';
 import Games from './pages/Games.jsx';
 import SpinPage from './pages/spin.tsx';
 
@@ -47,9 +48,30 @@ export default function App() {
           <Route path="/games/crazydice/lobby" element={<CrazyDiceLobby />} />
           <Route path="/games/:game/lobby" element={<Lobby />} />
             <Route path="/games/horse" element={<HorseRacing />} />
-          <Route path="/games/snake" element={<SnakeAndLadder />} />
-          <Route path="/games/snake/mp" element={<SnakeMultiplayer />} />
-          <Route path="/games/snake/results" element={<SnakeResults />} />
+          <Route
+            path="/games/snake"
+            element={
+              <GameProvider>
+                <SnakeAndLadder />
+              </GameProvider>
+            }
+          />
+          <Route
+            path="/games/snake/mp"
+            element={
+              <GameProvider>
+                <SnakeMultiplayer />
+              </GameProvider>
+            }
+          />
+          <Route
+            path="/games/snake/results"
+            element={
+              <GameProvider>
+                <SnakeResults />
+              </GameProvider>
+            }
+          />
           <Route path="/spin" element={<SpinPage />} />
           <Route path="/admin/influencer" element={<InfluencerAdmin />} />
           <Route path="/tasks" element={<Tasks />} />

--- a/webapp/src/store/gameState.js
+++ b/webapp/src/store/gameState.js
@@ -1,0 +1,43 @@
+import { createContext, useContext, useState } from 'react';
+import { SnakeGame } from '../../bot/logic/snakeGame.js';
+
+const GameContext = createContext(null);
+
+export function GameProvider({ board = {}, children }) {
+  const [state, setState] = useState({
+    game: new SnakeGame(board),
+    last: null,
+  });
+
+  const dispatch = (action) => {
+    let result = null;
+    setState((s) => {
+      const next = { ...s };
+      switch (action.type) {
+        case 'INIT':
+          next.game = new SnakeGame(action.board);
+          next.last = null;
+          break;
+        case 'ADD_PLAYER':
+          next.game.addPlayer(action.id, action.name);
+          break;
+        case 'ROLL':
+          result = next.game.rollDice(action.dice);
+          next.last = result;
+          break;
+        default:
+          break;
+      }
+      return { ...next };
+    });
+    return result;
+  };
+
+  return (
+    <GameContext.Provider value={{ state, dispatch }}>
+      {children}
+    </GameContext.Provider>
+  );
+}
+
+export const useGame = () => useContext(GameContext);


### PR DESCRIPTION
## Summary
- add GameState context backed by SnakeGame
- wrap snake routes with GameProvider
- refactor SnakeAndLadder rolls to use GameState

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(terminated due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68829a3149a08329ad3b1f1b7befc945