### PR TITLE
Fix multiplayer board fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Online multiplayer has arrived. Join a table in the lobby to create or enter tha
 
 A simplified Socket.IO lobby is provided in `examples/dynamic-lobby`. Players join tables by game type and stake, and the server creates new tables as needed. When a table fills up it emits a `gameStart` event.
 
-If a multiplayer board appears empty, ensure the web server is running and that all players load the game with the same `table` parameter. The client fetches board data from `/api/snake/board/:id`; if this request fails a local board is used which will not match other players.
+If a multiplayer board appears empty, ensure the web server is running and that all players load the game with the same `table` parameter. The client now fetches board data from `/api/snake/board/:id` whenever a table ID is present in the URL or stored from a previous session. If this request fails a local board is used which will not match other players.
 
 ### Entering the Snake & Ladder game
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1179,8 +1179,12 @@ export default function SnakeAndLadder() {
         : 1;
     setAi(aiCount);
     setAvatarType(avatarParam);
-    const mp = tableParam && !aiParam;
-    setIsMultiplayer(mp);
+    const storedTable = localStorage.getItem('snakeCurrentTable');
+    const table = tableParam || storedTable || "snake-4";
+    const mp = !aiParam && (tableParam || storedTable);
+    setIsMultiplayer(!!mp);
+    setTableId(table);
+    localStorage.setItem('snakeCurrentTable', table);
     const watching = watchParam === "1";
     setWatchOnly(watching);
     if (watching) {
@@ -1239,10 +1243,6 @@ export default function SnakeAndLadder() {
     const colors = shuffle(TOKEN_COLORS).slice(0, aiCount + 1).map(c => c.color);
     setPlayerColors(colors);
 
-    const storedTable = localStorage.getItem('snakeCurrentTable');
-    const table = tableParam || storedTable || "snake-4";
-    setTableId(table);
-    localStorage.setItem('snakeCurrentTable', table);
     async function fetchBoard(attempt = 1) {
       try {
         const { snakes: snakesObj = {}, ladders: laddersObj = {} } = mp


### PR DESCRIPTION
## Summary
- ensure Snake & Ladder always fetches board for stored tables
- clarify board retrieval in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68831e011b54832996a6d13ef003b97e