### PR TITLE
Fix anti-cheat warnings on extra turns

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -139,6 +139,7 @@ export class GameRoom {
   emitNextTurn() {
     const current = this.players[this.currentTurn];
     if (current) {
+      current.lastRollTime = 0; // reset cooldown at the start of every turn
       this.io.to(this.id).emit('turnChanged', { playerId: current.playerId });
       if (this.turnTimer) clearTimeout(this.turnTimer);
       this.turnTimer = setTimeout(() => {


### PR DESCRIPTION
## Summary
- reset player's roll cooldown at the start of every turn

## Testing
- `npm test` *(fails: stuck, partially run)*

------
https://chatgpt.com/codex/tasks/task_e_68833717ef7c8329b8c8e31d36833e23