### PR TITLE
Preload board images before rendering

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -168,6 +168,23 @@ function generateDiceCells(id, snakesMap = {}, laddersMap = {}) {
   return map;
 }
 
+function preloadImages(urls) {
+  return Promise.all(
+    urls.map(
+      (url) =>
+        new Promise((resolve) => {
+          const img = new Image();
+          img.onload = () => resolve();
+          img.onerror = () => {
+            img.src = '/assets/icons/TonPlayGramLogo.webp';
+            resolve();
+          };
+          img.src = url;
+        })
+    )
+  );
+}
+
 
 function CoinBurst({ token }) {
   const coins = Array.from({ length: 30 }, () => ({
@@ -310,7 +327,16 @@ function Board({
         >
           {(iconImage || offsetVal != null) && (
             <span className="cell-marker">
-              {iconImage && <img src={iconImage} className="cell-icon" />}
+              {iconImage && (
+                <img
+                  src={iconImage}
+                  alt="cell icon"
+                  className="cell-icon"
+                  onError={(e) => {
+                    e.currentTarget.src = '/assets/icons/TonPlayGramLogo.webp';
+                  }}
+                />
+              )}
               {offsetVal != null && (
                 <span
                   className={`offset-text ${
@@ -329,7 +355,14 @@ function Board({
           {!cellType && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
-              <img  src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp" className="dice-icon" />
+              <img
+                src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp"
+                alt="dice"
+                className="dice-icon"
+                onError={(e) => {
+                  e.currentTarget.src = '/assets/icons/TonPlayGramLogo.webp';
+                }}
+              />
               <span className="dice-value">+{diceCells[num]}</span>
             </span>
           )}
@@ -689,6 +722,15 @@ export default function SnakeAndLadder() {
   const [showWatchWelcome, setShowWatchWelcome] = useState(false);
   const [boardError, setBoardError] = useState(null);
   const [boardReady, setBoardReady] = useState(false);
+  const [iconsLoaded, setIconsLoaded] = useState(false);
+
+  useEffect(() => {
+    preloadImages([
+      '/assets/icons/Ladder.webp',
+      '/assets/icons/snake_vector_no_bg.webp',
+      '/assets/icons/file_000000009160620a96f728f463de1c3f.webp',
+    ]).then(() => setIconsLoaded(true));
+  }, []);
 
   useEffect(() => {
     const eng = engineRef.current;
@@ -2406,24 +2448,28 @@ export default function SnakeAndLadder() {
             />
           ))}
       </div>
-      <Board
-        players={players}
-        highlight={highlight}
-        trail={trail}
-        pot={pot}
-        snakes={snakes}
-        ladders={ladders}
-        snakeOffsets={snakeOffsets}
-        ladderOffsets={ladderOffsets}
-        offsetPopup={offsetPopup}
-        celebrate={celebrate}
-        token={token}
-        tokenType={tokenType}
-        diceCells={diceCells}
-        rollingIndex={rollingIndex}
-        currentTurn={currentTurn}
-        burning={burning}
-      />
+      {iconsLoaded ? (
+        <Board
+          players={players}
+          highlight={highlight}
+          trail={trail}
+          pot={pot}
+          snakes={snakes}
+          ladders={ladders}
+          snakeOffsets={snakeOffsets}
+          ladderOffsets={ladderOffsets}
+          offsetPopup={offsetPopup}
+          celebrate={celebrate}
+          token={token}
+          tokenType={tokenType}
+          diceCells={diceCells}
+          rollingIndex={rollingIndex}
+          currentTurn={currentTurn}
+          burning={burning}
+        />
+      ) : (
+        <div className="p-4 text-subtext">Loading board...</div>
+      )}
       {chatBubbles.map((b) => (
         <div key={b.id} className="chat-bubble">
           <span>{b.text}</span>
@@ -2577,7 +2623,15 @@ export default function SnakeAndLadder() {
       {rewardDice > 0 && (
         <div className="fixed bottom-40 inset-x-0 flex justify-center z-30 pointer-events-none reward-dice-container">
           {Array.from({ length: rewardDice }).map((_, i) => (
-            <img key={i}  src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp" className="reward-dice" />
+            <img
+              key={i}
+              src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp"
+              alt="dice"
+              className="reward-dice"
+              onError={(e) => {
+                e.currentTarget.src = '/assets/icons/TonPlayGramLogo.webp';
+              }}
+            />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- preload key board icons so they render instantly
- only show the board once these icons are ready
- fall back to TonPlayGram logo if an icon fails to load

## Testing
- `npm test` *(fails: Subtests run then aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68834b49c6ac832986ba35be3f5e2b8a