### PR TITLE
Implement socket game start event

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -129,6 +129,14 @@ export class GameRoom {
     }
     this.status = 'playing';
     this.currentTurn = 0;
+    this.io.to(this.id).emit('game:start', {
+      tableId: this.id,
+      players: this.players.map((p) => ({
+        accountId: p.playerId,
+        name: p.name,
+        avatar: p.photoUrl
+      }))
+    });
     this.io.to(this.id).emit('gameStarted', {
       snakes: this.snakes,
       ladders: this.ladders

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1589,29 +1589,11 @@ export default function SnakeAndLadder() {
     socket.on('gameWon', onWon);
     socket.on('currentPlayers', onCurrentPlayers);
     socket.on('watchState', onWatchState);
+    socket.on('game:start', (data) => setMpPlayers(data.players || []));
 
     if (watchOnly) {
       socket.emit('watchRoom', { roomId: tableId });
-      getSnakeLobby(tableId)
-        .then((data) => {
-          const players = data.players || [];
-          return Promise.all(
-            players.map(async (p) => {
-              const prof = await getProfileByAccount(p.id).catch(() => ({}));
-              const n =
-                p.name ||
-                prof?.nickname ||
-                `${prof?.firstName || ''} ${prof?.lastName || ''}`.trim() ||
-                'Player';
-              const photoUrl = prof?.photo || '/assets/icons/profile.svg';
-              return { id: p.id, name: n, photoUrl, position: 0 };
-            })
-          ).then((arr) => {
-            setMpPlayers(arr);
-            setPlayersNeeded(Math.max(0, capacity - arr.length));
-          });
-        })
-        .catch(() => {});
+      // Player list will be provided via 'game:start'
     } else {
       socket.emit('joinRoom', { roomId: tableId, accountId, name });
     }
@@ -1632,6 +1614,7 @@ export default function SnakeAndLadder() {
       socket.off('gameWon', onWon);
       socket.off('currentPlayers', onCurrentPlayers);
       socket.off('watchState', onWatchState);
+      socket.off('game:start');
       if (watchOnly) {
         socket.emit('leaveWatch', { roomId: tableId });
       } else {


### PR DESCRIPTION
## Summary
- emit `game:start` with player info when a room starts
- listen for the new socket event in the Snake and Ladder game
- drop unused lobby-based player initialization

## Testing
- `npm test` *(fails: canvas build error)*

------
https://chatgpt.com/codex/tasks/task_e_68834b499cb88329837cf7a48eb44503