### PR TITLE
Fix multiplayer snake board icons

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -168,6 +168,19 @@ function generateDiceCells(id, snakesMap = {}, laddersMap = {}) {
   return map;
 }
 
+function preloadImages(urls) {
+  return Promise.all(
+    urls.map(
+      (url) =>
+        new Promise((resolve) => {
+          const img = new Image();
+          img.onload = () => resolve();
+          img.onerror = () => resolve();
+          img.src = url;
+        })
+    )
+  );
+}
 
 function CoinBurst({ token }) {
   const coins = Array.from({ length: 30 }, () => ({
@@ -310,7 +323,16 @@ function Board({
         >
           {(iconImage || offsetVal != null) && (
             <span className="cell-marker">
-              {iconImage && <img src={iconImage} className="cell-icon" />}
+              {iconImage && (
+                <img
+                  src={iconImage}
+                  alt="cell icon"
+                  className="cell-icon"
+                  onError={(e) => {
+                    e.currentTarget.src = '/assets/icons/TonPlayGramLogo.webp';
+                  }}
+                />
+              )}
               {offsetVal != null && (
                 <span
                   className={`offset-text ${
@@ -329,7 +351,14 @@ function Board({
           {!cellType && <span className="cell-number">{num}</span>}
           {diceCells && diceCells[num] && (
             <span className="dice-marker">
-              <img  src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp" className="dice-icon" />
+              <img
+                src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp"
+                alt="dice"
+                className="dice-icon"
+                onError={(e) => {
+                  e.currentTarget.src = '/assets/icons/TonPlayGramLogo.webp';
+                }}
+              />
               <span className="dice-value">+{diceCells[num]}</span>
             </span>
           )}
@@ -498,6 +527,9 @@ function Board({
                   }
                   alt={token}
                   className="coin-face front"
+                  onError={(e) => {
+                    e.currentTarget.src = '/assets/icons/TonPlayGramLogo.webp';
+                  }}
                 />
                 <img
                   src={
@@ -509,6 +541,9 @@ function Board({
                   }
                   alt=""
                   className="coin-face back"
+                  onError={(e) => {
+                    e.currentTarget.src = '/assets/icons/TonPlayGramLogo.webp';
+                  }}
                 />
               </div>
               {players
@@ -689,6 +724,7 @@ export default function SnakeAndLadder() {
   const [showWatchWelcome, setShowWatchWelcome] = useState(false);
   const [boardError, setBoardError] = useState(null);
   const [boardReady, setBoardReady] = useState(false);
+  const [iconsLoaded, setIconsLoaded] = useState(false);
 
   useEffect(() => {
     const eng = engineRef.current;
@@ -752,17 +788,18 @@ export default function SnakeAndLadder() {
     return () => clearTimeout(trailTimeoutRef.current);
   }, []);
 
-  // Preload token and avatar images so board icons and AI photos display
-  // immediately without waiting for network requests during gameplay.
+  // Preload board icons, tokens and avatars so everything displays immediately
+  // without waiting for network requests during gameplay.
   useEffect(() => {
-    ['TON.webp', 'Usdt.webp'].forEach((file) => {
+    preloadImages([
+      '/assets/icons/Ladder.webp',
+      '/assets/icons/snake_vector_no_bg.webp',
+      '/assets/icons/file_000000009160620a96f728f463de1c3f.webp',
+    ]).then(() => setIconsLoaded(true));
+    ['TON.webp', 'Usdt.webp', 'TPCcoin_1.webp'].forEach((file) => {
       const img = new Image();
       img.src = `/assets/icons/${file}`;
     });
-    {
-      const img = new Image();
-      img.src = '/assets/icons/TPCcoin_1.webp';
-    }
     AVATARS.forEach((src) => {
       const img = new Image();
       img.src = getAvatarUrl(src);
@@ -1302,6 +1339,15 @@ export default function SnakeAndLadder() {
 
   useEffect(() => {
     playersRef.current = mpPlayers;
+  }, [mpPlayers]);
+
+  useEffect(() => {
+    mpPlayers.forEach((p) => {
+      if (p.photoUrl) {
+        const img = new Image();
+        img.src = p.photoUrl;
+      }
+    });
   }, [mpPlayers]);
 
   useEffect(() => {
@@ -2406,24 +2452,28 @@ export default function SnakeAndLadder() {
             />
           ))}
       </div>
-      <Board
-        players={players}
-        highlight={highlight}
-        trail={trail}
-        pot={pot}
-        snakes={snakes}
-        ladders={ladders}
-        snakeOffsets={snakeOffsets}
-        ladderOffsets={ladderOffsets}
-        offsetPopup={offsetPopup}
-        celebrate={celebrate}
-        token={token}
-        tokenType={tokenType}
-        diceCells={diceCells}
-        rollingIndex={rollingIndex}
-        currentTurn={currentTurn}
-        burning={burning}
-      />
+      {iconsLoaded ? (
+        <Board
+          players={players}
+          highlight={highlight}
+          trail={trail}
+          pot={pot}
+          snakes={snakes}
+          ladders={ladders}
+          snakeOffsets={snakeOffsets}
+          ladderOffsets={ladderOffsets}
+          offsetPopup={offsetPopup}
+          celebrate={celebrate}
+          token={token}
+          tokenType={tokenType}
+          diceCells={diceCells}
+          rollingIndex={rollingIndex}
+          currentTurn={currentTurn}
+          burning={burning}
+        />
+      ) : (
+        <div className="p-4 text-subtext">Loading board...</div>
+      )}
       {chatBubbles.map((b) => (
         <div key={b.id} className="chat-bubble">
           <span>{b.text}</span>
@@ -2577,7 +2627,15 @@ export default function SnakeAndLadder() {
       {rewardDice > 0 && (
         <div className="fixed bottom-40 inset-x-0 flex justify-center z-30 pointer-events-none reward-dice-container">
           {Array.from({ length: rewardDice }).map((_, i) => (
-            <img key={i}  src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp" className="reward-dice" />
+            <img
+              key={i}
+              src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp"
+              alt="dice"
+              className="reward-dice"
+              onError={(e) => {
+                e.currentTarget.src = '/assets/icons/TonPlayGramLogo.webp';
+              }}
+            />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- restore board icons preloading for Snake and Ladder
- load snake and ladder icons first and add fallback images
- preload avatars and board images for smoother multiplayer gameplay

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688357e0edbc83299d60275713b5b9f5