### PR TITLE
Add presale countdown

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
-import { createAccount, buyTPC, getPresaleStatus, claimPurchase } from '../utils/api.js';
+import { createAccount, buyTPC, getPresaleStatus, claimPurchase, getAppStats } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import InfoPopup from '../components/InfoPopup.jsx';
 import TonConnectButton from '../components/TonConnectButton.jsx';
 import { calculateTpcAmount } from '../utils/buyLogic.js';
-import { STORE_ADDRESS } from '../utils/storeData.js';
+import { STORE_ADDRESS, PRESALE_ROUNDS, PRESALE_START } from '../utils/storeData.js';
 import { MAX_TPC_PER_WALLET } from '../config.js';
 import { FaCubes, FaWallet } from 'react-icons/fa';
 
@@ -20,6 +20,8 @@ export default function Store() {
   const [amountTon, setAmountTon] = useState('');
   const [tpcAmount, setTpcAmount] = useState('');
   const [status, setStatus] = useState(null);
+  const [stats, setStats] = useState(null);
+  const [timeLeft, setTimeLeft] = useState(0);
 
   useEffect(() => {
     let id;
@@ -28,11 +30,25 @@ export default function Store() {
     } catch {}
     createAccount(id).then((acc) => setAccountId(acc.accountId));
     getPresaleStatus().then(setStatus);
+    getAppStats().then(setStats).catch(() => {});
   }, []);
 
   useEffect(() => {
     setTpcAmount(calculateTpcAmount(amountTon, status?.currentPrice));
   }, [amountTon, status]);
+
+  useEffect(() => {
+    if (!status) return;
+    const duration = 4 * 7 * 24 * 60 * 60 * 1000;
+    const update = () => {
+      const start = new Date(PRESALE_START).getTime() + duration * (status.currentRound - 1);
+      const end = start + duration;
+      setTimeLeft(end - Date.now());
+    };
+    update();
+    const timer = setInterval(update, 1000);
+    return () => clearInterval(timer);
+  }, [status]);
 
   const handleBuy = async () => {
     if (!walletAddress) {
@@ -60,6 +76,15 @@ export default function Store() {
     }
   };
 
+  function formatTime(ms) {
+    if (!ms || ms <= 0) return '0d 0h 0m';
+    const totalSec = Math.floor(ms / 1000);
+    const days = Math.floor(totalSec / 86400);
+    const hours = Math.floor((totalSec % 86400) / 3600);
+    const minutes = Math.floor((totalSec % 3600) / 60);
+    return `${days}d ${hours}h ${minutes}m`;
+  }
+
   return (
     <div className="relative p-4 space-y-4 text-text flex flex-col items-center min-h-screen bg-surface">
       <img src="/assets/icons/TonPlayGramLogo.webp" alt="TonPlaygram" className="w-16" />
@@ -77,6 +102,12 @@ export default function Store() {
         <div className="flex items-center space-x-1">
           <FaWallet />
           <span>Max {MAX_TPC_PER_WALLET.toLocaleString()}</span>
+        </div>
+        <div className="flex items-center space-x-1">
+          <span>Stage ends in {formatTime(timeLeft)}</span>
+        </div>
+        <div className="flex items-center space-x-1">
+          <span>Total Raised: {stats ? stats.tonRaised.toLocaleString(undefined, { maximumFractionDigits: 2 }) : '...'} TON</span>
         </div>
       </div>
       <div className="checkout-card">
@@ -100,6 +131,15 @@ export default function Store() {
           Payment Method: TON only <img src="/assets/icons/TON.webp" alt="TON" className="w-4 h-4 ml-1" />
         </div>
         <button onClick={handleBuy} className="buy-button w-full mt-1">Buy TPC</button>
+      </div>
+      <div className="store-card space-y-1 max-w-md">
+        <h3 className="font-semibold text-center">Other Stages</h3>
+        {PRESALE_ROUNDS.filter(r => status && r.round !== status.currentRound).map(r => (
+          <div key={r.round} className="text-xs flex justify-between px-2">
+            <span>Stage {r.round}</span>
+            <span>{r.pricePerTPC} TON</span>
+          </div>
+        ))}
       </div>
       <div className="prism-box p-4 space-y-2 w-full max-w-md">
         <h3 className="text-center font-semibold">Claim Your Purchase</h3>

--- a/webapp/src/utils/storeData.js
+++ b/webapp/src/utils/storeData.js
@@ -5,6 +5,9 @@ export const initialPrice = 0.000004; // TON per 1 TPC
 export let currentPrice = initialPrice;
 export const priceIncreaseStep = 0.0000001; // TON added after each purchase
 
+// Presale launch date (UTC)
+export const PRESALE_START = new Date('2025-07-01T00:00:00Z');
+
 export const PRESALE_ROUNDS = [
   { round: 1, maxTokens: 125000000, pricePerTPC: 0.000004 },
   { round: 2, maxTokens: 100000000, pricePerTPC: 0.000005 },


### PR DESCRIPTION
## Summary
- show presale countdown in Store
- display total amount raised and other stages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68835f88e55c8329971fccbaa632d206