### PR TITLE
Remove debug logs

### DIFF
--- a/webapp/src/components/TileFrame.jsx
+++ b/webapp/src/components/TileFrame.jsx
@@ -1,9 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 export default function TileFrame({ rect, adjustX = 0, adjustY = 0 }) {
-  useEffect(() => {
-    if (rect) console.log(rect);
-  }, [rect]);
 
   if (!rect) return null;
   const style = {

--- a/webapp/src/utils/socket.js
+++ b/webapp/src/utils/socket.js
@@ -6,7 +6,9 @@ if (typeof window !== 'undefined' && window.location.protocol === 'https:' && ba
   baseUrl = baseUrl.replace(/^http:/, 'https:');
 }
 
-console.log('Socket is trying to connect to:', baseUrl);
+if (import.meta.env.DEV) {
+  console.log('Socket is trying to connect to:', baseUrl);
+}
 export const socket = io(baseUrl, {
   transports: ['websocket', 'polling']
 });


### PR DESCRIPTION
## Summary
- trim logging from TileFrame
- gate socket connection log behind DEV flag

## Testing
- `npm test` *(fails: joinRoom waits until table full)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688367e164c88329b55fdd45d1db0388