### PR TITLE
Improve board loading error message

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1288,7 +1288,9 @@ export default function SnakeAndLadder() {
           } else if (attempt < 3) {
             setTimeout(() => fetchBoard(attempt + 1), 1000 * attempt);
           } else {
-            setBoardError('Failed to load board data');
+            setBoardError(
+              'Unable to load board \u2013 please check your connection or use the same table ID as other players.'
+            );
             setBoardReady(false);
           }
           return;


### PR DESCRIPTION
## Summary
- clarify board loading failure message on multiplayer mode

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_68836f0e27b88329b87de57b316d1ca8