### PR TITLE
Enhance presale dashboard and store page

### DIFF
--- a/webapp/src/components/BuyTpcCard.jsx
+++ b/webapp/src/components/BuyTpcCard.jsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
+import TonConnectButton from './TonConnectButton.jsx';
+import InfoPopup from './InfoPopup.jsx';
+import { calculateTpcAmount } from '../utils/buyLogic.js';
+import { buyTPC, getPresaleStatus } from '../utils/api.js';
+import { STORE_ADDRESS } from '../utils/storeData.js';
+
+export default function BuyTpcCard() {
+  const [tonConnectUI] = useTonConnectUI();
+  const walletAddress = useTonAddress();
+  const [amountTon, setAmountTon] = useState('');
+  const [tpcAmount, setTpcAmount] = useState('');
+  const [msg, setMsg] = useState('');
+  const [status, setStatus] = useState(null);
+
+  useEffect(() => {
+    getPresaleStatus().then(setStatus).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    setTpcAmount(calculateTpcAmount(amountTon, status?.currentPrice));
+  }, [amountTon, status]);
+
+  const handleBuy = async () => {
+    if (!walletAddress) {
+      tonConnectUI.openModal();
+      return;
+    }
+    const amount = parseFloat(amountTon);
+    if (!amount || amount <= 0) {
+      setMsg('Enter TON amount');
+      return;
+    }
+    const tx = {
+      validUntil: Math.floor(Date.now() / 1000) + 60,
+      messages: [{ address: STORE_ADDRESS, amount: String(amount * 1e9) }]
+    };
+    try {
+      await tonConnectUI.sendTransaction(tx);
+      const res = await buyTPC(walletAddress, amount);
+      if (res.error) setMsg(res.error);
+      else setMsg('Purchase successful');
+      setAmountTon('');
+      getPresaleStatus().then(setStatus).catch(() => {});
+    } catch {
+      setMsg('Transaction failed');
+    }
+  };
+
+  return (
+    <div className="checkout-card">
+      <label className="self-start text-sm">TON You Pay</label>
+      <input
+        type="number"
+        placeholder="0"
+        value={amountTon}
+        onChange={(e) => setAmountTon(e.target.value)}
+        className="w-full p-1 text-black rounded"
+      />
+      <label className="self-start text-sm">TPC You Receive</label>
+      <input
+        type="text"
+        value={tpcAmount}
+        readOnly
+        className="w-full p-1 text-black rounded"
+      />
+      <TonConnectButton className="w-full" />
+      <div className="flex items-center justify-center text-xs">
+        Payment Method: TON only <img src="/assets/icons/TON.webp" alt="TON" className="w-4 h-4 ml-1" />
+      </div>
+      <button onClick={handleBuy} className="buy-button w-full mt-1">Buy TPC</button>
+      <InfoPopup open={!!msg} onClose={() => setMsg('')} title="Store" info={msg} />
+    </div>
+  );
+}

--- a/webapp/src/components/PresaleDashboardMultiRound.jsx
+++ b/webapp/src/components/PresaleDashboardMultiRound.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+import BuyTpcCard from './BuyTpcCard.jsx';
 import { getPresaleStatus, getAppStats } from '../utils/api.js';
 import { PRESALE_ROUNDS, PRESALE_START } from '../utils/storeData.js';
 
@@ -107,12 +108,12 @@ export default function PresaleDashboardMultiRound() {
         <h3 className="text-lg font-bold mb-3 text-center text-cyan-300">Sales Progress</h3>
         <div className="h-64">
           <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={salesData}>
+            <BarChart data={salesData}>
               <XAxis dataKey="name" stroke="#ccc" />
               <YAxis stroke="#ccc" />
               <Tooltip />
-              <Line type="monotone" dataKey="sold" stroke="#00FFFF" strokeWidth={2} dot={false} />
-            </LineChart>
+              <Bar dataKey="sold" fill="#00FF00" />
+            </BarChart>
           </ResponsiveContainer>
         </div>
       </div>
@@ -126,17 +127,7 @@ export default function PresaleDashboardMultiRound() {
         </p>
       </div>
 
-      <div className="bg-gray-800 p-5 rounded-xl shadow-inner text-center border border-gray-700 mt-6">
-        <h3 className="text-lg font-bold mb-2 text-cyan-300">Buy TPC</h3>
-        <input
-          type="number"
-          placeholder="TON Amount"
-          className="p-2 w-full rounded-md bg-gray-700 text-white mb-3 border border-gray-600"
-        />
-        <button className="bg-gradient-to-r from-cyan-400 to-blue-500 hover:from-cyan-300 hover:to-blue-400 text-black font-bold py-2 px-4 rounded-lg w-full transition-all duration-300 shadow-md">
-          Buy Now
-        </button>
-      </div>
+      <BuyTpcCard />
     </div>
   );
 }

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -5,6 +5,7 @@ import { createAccount, buyTPC, getPresaleStatus, claimPurchase, getAppStats } f
 import { getTelegramId } from '../utils/telegram.js';
 import InfoPopup from '../components/InfoPopup.jsx';
 import TonConnectButton from '../components/TonConnectButton.jsx';
+import PresaleDashboardMultiRound from '../components/PresaleDashboardMultiRound.jsx';
 import { calculateTpcAmount } from '../utils/buyLogic.js';
 import { STORE_ADDRESS, PRESALE_ROUNDS, PRESALE_START } from '../utils/storeData.js';
 import { MAX_TPC_PER_WALLET } from '../config.js';
@@ -90,6 +91,7 @@ export default function Store() {
       <img src="/assets/icons/TonPlayGramLogo.webp" alt="TonPlaygram" className="w-16" />
       <p className="text-brand-gold text-xs tracking-widest">PLAY. EARN. DOMINATE.</p>
       <h2 className="text-2xl font-bold">Buy TPC</h2>
+      <PresaleDashboardMultiRound />
       <div className="store-info-bar">
         <div className="flex items-center space-x-1">
           <img src="/assets/icons/TON.webp" alt="TON" className="w-4 h-4" />

--- a/webapp/src/utils/storeData.js
+++ b/webapp/src/utils/storeData.js
@@ -6,7 +6,7 @@ export let currentPrice = initialPrice;
 export const priceIncreaseStep = 0.0000001; // TON added after each purchase
 
 // Presale launch date (UTC)
-export const PRESALE_START = new Date('2025-07-01T00:00:00Z');
+export const PRESALE_START = new Date();
 
 export const PRESALE_ROUNDS = [
   { round: 1, maxTokens: 125000000, pricePerTPC: 0.000004 },


### PR DESCRIPTION
## Summary
- add BuyTpcCard component with TON amount logic
- replace simple form in presale dashboard with BuyTpcCard and switch sales chart to green bars
- show presale dashboard on the store page
- start presale rounds from current date

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688372f7f5348329957d5ba5ec0fcd31