### PR TITLE
Improve lobby auto-start

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -18,7 +18,8 @@ import {
 } from '../../utils/api.js';
 import {
   getTelegramId,
-  ensureAccountId
+  ensureAccountId,
+  getPlayerId
 } from '../../utils/telegram.js';
 import { canStartGame } from '../../utils/lobby.js';
 
@@ -225,8 +226,11 @@ export default function Lobby() {
     players.every((p) => p.confirmed ?? true);
 
   useEffect(() => {
+    const accountId = getPlayerId();
+    const me = players.find((p) => p.id === accountId);
+    if (me?.confirmed && !confirmed) setConfirmed(true);
     if (
-      confirmed &&
+      me?.confirmed &&
       game === 'snake' &&
       table &&
       table.id !== 'single' &&
@@ -234,7 +238,7 @@ export default function Lobby() {
     ) {
       startGame();
     }
-  }, [players, confirmed]);
+  }, [players, table, game, allConfirmed, confirmed]);
   // Multiplayer games require a full table before starting
 
   return (


### PR DESCRIPTION
## Summary
- check server confirmation before starting multiplayer games
- import helper to read current account ID

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688374ec659c8329b2e7daa9fc82944a