### PR TITLE
Fix snake lobby seat on page unload

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -146,6 +146,21 @@ export default function Lobby() {
   }, [game, table, playerName, stake]);
 
   useEffect(() => {
+    if (game !== 'snake' || !table || table.id === 'single' || !stake.amount)
+      return;
+    const tableRef = `${table.id}-${stake.amount}`;
+    const handleUnload = () => {
+      ensureAccountId()
+        .then((accountId) => {
+          if (accountId) unseatTable(accountId, tableRef).catch(() => {});
+        })
+        .catch(() => {});
+    };
+    window.addEventListener('beforeunload', handleUnload);
+    return () => window.removeEventListener('beforeunload', handleUnload);
+  }, [game, table, stake]);
+
+  useEffect(() => {
     if (game === 'snake' && table && table.id !== 'single' && stake.amount) {
       const tableRef = `${table.id}-${stake.amount}`;
       let active = true;


### PR DESCRIPTION
## Summary
- clean up table seat when the page unloads to avoid duplicate seats

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_68837d4d072c83298d3051302ea637e9