### PR TITLE
Update presale dashboard stats

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -217,6 +217,7 @@ app.get('/api/stats', async (req, res) => {
     let giftSends = 0;
     let bundlesSold = 0;
     let tonRaised = 0;
+    let tpcSold = 0;
     let currentNfts = 0;
     let nftValue = 0;
     let appClaimed = 0;
@@ -234,6 +235,9 @@ app.get('/api/stats', async (req, res) => {
           if (tx.detail && BUNDLE_TON_MAP[tx.detail]) {
             tonRaised += BUNDLE_TON_MAP[tx.detail];
           }
+          if (tx.amount) {
+            tpcSold += Math.abs(tx.amount);
+          }
         }
         if (tx.type === 'claim') appClaimed += Math.abs(tx.amount || 0);
         if (tx.type === 'withdraw') externalClaimed += Math.abs(tx.amount || 0);
@@ -248,6 +252,7 @@ app.get('/api/stats', async (req, res) => {
       nftsBurned,
       bundlesSold,
       tonRaised,
+      tpcSold,
       appClaimed: totalBalance,
       externalClaimed,
       nftValue

--- a/webapp/src/components/PresaleDashboardMultiRound.jsx
+++ b/webapp/src/components/PresaleDashboardMultiRound.jsx
@@ -63,8 +63,12 @@ export default function PresaleDashboardMultiRound() {
       <h2 className="text-3xl font-extrabold text-center mb-1 tracking-wide bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 to-blue-500">
         Presale - Round {status ? status.currentRound : '...'} of {PRESALE_ROUNDS.length}
       </h2>
-      <p className="text-center text-sm mb-4 text-gray-300">
-        Price: <span className="text-cyan-400">{status ? status.currentPrice : PRESALE_ROUNDS[roundIndex]?.pricePerTPC} TON</span> / 1 TPC
+      <p className="text-center text-sm mb-4 text-gray-300 flex items-center justify-center gap-1">
+        <span>Price:</span>
+        <span className="text-cyan-400">{status ? status.currentPrice : PRESALE_ROUNDS[roundIndex]?.pricePerTPC} TON</span>
+        /
+        1
+        <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4 inline-block" />
       </p>
 
       <div className="text-center mb-4">
@@ -80,12 +84,14 @@ export default function PresaleDashboardMultiRound() {
       </div>
 
       <div className="text-center mb-4 text-gray-300">
-        <p>
-          Tokens Sold:{' '}
+        <p className="flex items-center justify-center gap-1">
+          <span>Tokens Sold:</span>
           <span className="text-cyan-300">
             {status ? sold.toLocaleString() : '...'}
-          </span>{' '}
-          / {maxTokens.toLocaleString()} TPC
+          </span>
+          /
+          {maxTokens.toLocaleString()}
+          <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4 ml-1 inline-block" />
         </p>
       </div>
 
@@ -106,12 +112,15 @@ export default function PresaleDashboardMultiRound() {
         <p className="text-2xl font-extrabold">
           {stats ? totalTonRaised.toFixed(2) : '...'} TON raised
         </p>
-        <p className="mt-1 text-sm">
-          TPC Sold: {status ? sold.toLocaleString() : '...'}
+        <p className="mt-1 text-sm flex items-center justify-center gap-1">
+          <span>TPC Sold:</span>
+          <span>{status ? sold.toLocaleString() : '...'}</span>
+          <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" />
         </p>
-        <p className="mt-1 text-sm">
-          TGE Amount:{' '}
-          {stats ? (stats.appClaimed + stats.externalClaimed).toLocaleString() : '...'} TPC
+        <p className="mt-1 text-sm flex items-center justify-center gap-1">
+          <span>TGE Amount:</span>
+          <span>{stats ? stats.tpcSold?.toLocaleString() : '...'}</span>
+          <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" />
         </p>
       </div>
 

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -217,6 +217,7 @@ export default function Home() {
           nftsBurned: data.nftsBurned,
           bundlesSold: data.bundlesSold,
           tonRaised: data.tonRaised,
+          tpcSold: data.tpcSold,
           appClaimed: data.appClaimed,
           externalClaimed: data.externalClaimed,
           nftValue: data.nftValue,


### PR DESCRIPTION
## Summary
- show tokens sold with TON in the `/api/stats` endpoint
- display TPC icon in presale dashboard
- use the new `tpcSold` stats value for the TGE amount

## Testing
- `npm test` *(fails: run hangs or incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_688380fe1de08329a179e802b16a37a5