### PR TITLE
Remove TPC sold line and add icon

### DIFF
--- a/webapp/src/components/BuyTpcCard.jsx
+++ b/webapp/src/components/BuyTpcCard.jsx
@@ -58,7 +58,10 @@ export default function BuyTpcCard() {
         onChange={(e) => setAmountTon(e.target.value)}
         className="w-full p-1 text-black rounded"
       />
-      <label className="self-start text-sm">TPC You Receive</label>
+      <label className="self-start text-sm flex items-center gap-1">
+        TPC You Receive
+        <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" />
+      </label>
       <input
         type="text"
         value={tpcAmount}

--- a/webapp/src/components/PresaleDashboardMultiRound.jsx
+++ b/webapp/src/components/PresaleDashboardMultiRound.jsx
@@ -113,11 +113,6 @@ export default function PresaleDashboardMultiRound() {
           {stats ? totalTonRaised.toFixed(2) : '...'} TON raised
         </p>
         <p className="mt-1 text-sm flex items-center justify-center gap-1">
-          <span>TPC Sold:</span>
-          <span>{status ? sold.toLocaleString() : '...'}</span>
-          <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" />
-        </p>
-        <p className="mt-1 text-sm flex items-center justify-center gap-1">
           <span>TGE Amount:</span>
           <span>{stats ? stats.tpcSold?.toLocaleString() : '...'}</span>
           <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- remove `TPC Sold` from presale stats card
- add a TPC coin icon next to "TPC You Receive"

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688388b8012c8329b0a8b6b7d0b61a59