### PR TITLE
Add claim purchase feature

### DIFF
--- a/webapp/src/components/ClaimPurchaseCard.jsx
+++ b/webapp/src/components/ClaimPurchaseCard.jsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { ensureAccountId } from '../utils/telegram.js';
+import { claimPurchase } from '../utils/api.js';
+import InfoPopup from './InfoPopup.jsx';
+
+export default function ClaimPurchaseCard() {
+  const [txHash, setTxHash] = useState('');
+  const [sending, setSending] = useState(false);
+  const [msg, setMsg] = useState('');
+
+  const handleClaim = async () => {
+    const hash = txHash.trim();
+    if (!hash) {
+      setMsg('Enter transaction hash');
+      return;
+    }
+    setSending(true);
+    try {
+      const accountId = await ensureAccountId();
+      const res = await claimPurchase(accountId, hash);
+      if (res?.error) setMsg(res.error);
+      else setMsg('Claim submitted');
+      setTxHash('');
+    } catch {
+      setMsg('Claim failed');
+    }
+    setSending(false);
+  };
+
+  return (
+    <div className="prism-box p-6 space-y-3 text-center mt-4 flex flex-col items-center wide-card mx-auto">
+      <label className="block font-semibold">Claim Purchase</label>
+      <input
+        type="text"
+        placeholder="Transaction Hash"
+        value={txHash}
+        onChange={(e) => setTxHash(e.target.value)}
+        className="border p-1 rounded w-full max-w-xs mx-auto text-black"
+      />
+      <button
+        onClick={handleClaim}
+        className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover text-background rounded"
+        disabled={sending}
+      >
+        {sending ? 'Processing...' : 'Claim'}
+      </button>
+      <InfoPopup open={!!msg} onClose={() => setMsg('')} title="Claim Purchase" info={msg} />
+    </div>
+  );
+}

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1,5 +1,6 @@
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import PresaleDashboardMultiRound from '../components/PresaleDashboardMultiRound.jsx';
+import ClaimPurchaseCard from '../components/ClaimPurchaseCard.jsx';
 
 export default function Store() {
   useTelegramBackButton();
@@ -9,6 +10,7 @@ export default function Store() {
       <p className="text-brand-gold text-xs tracking-widest">PLAY. EARN. DOMINATE.</p>
       <h2 className="text-2xl font-bold">Buy TPC</h2>
       <PresaleDashboardMultiRound />
+      <ClaimPurchaseCard />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add component for claiming presale purchases via transaction hash
- show claim button on store page

## Testing
- `npm test` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_68838e62d4e48329954a6ca20c4eba90