### PR TITLE
Track Telegram IDs for snake players

### DIFF
--- a/bot/models/GameRoom.js
+++ b/bot/models/GameRoom.js
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 const playerSchema = new mongoose.Schema(
   {
     playerId: String,
+    telegramId: Number,
     name: String,
     position: { type: Number, default: 0 },
     isActive: { type: Boolean, default: false },

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -167,7 +167,17 @@ export default function Lobby() {
       function loadPlayers() {
         getSnakeLobby(tableRef)
           .then((data) => {
-            if (active) setPlayers(data.players);
+            if (!active) return;
+            const unique = [];
+            const seen = new Set();
+            for (const p of data.players || []) {
+              const key = p.telegramId || p.id;
+              if (!seen.has(key)) {
+                seen.add(key);
+                unique.push(p);
+              }
+            }
+            setPlayers(unique);
           })
           .catch(() => {});
       }
@@ -288,7 +298,7 @@ export default function Lobby() {
           </h3>
           <ul className="text-sm list-disc list-inside">
             {players.map((p) => (
-              <li key={p.id}>
+              <li key={p.telegramId || p.id}>
                 {p.name}
                 {p.confirmed && ' ✓'}
               </li>


### PR DESCRIPTION
## Summary
- extend snake game player schema to include `telegramId`
- track Telegram IDs when seating and joining rooms
- deduplicate lobby players using Telegram ID
- expose Telegram ID in socket events and lobby API
- update lobby and game pages to handle Telegram IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883a2f417108329ba1e6583e32bb4cd