### PR TITLE
Improve lobby tracking and update presale stats

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -332,6 +332,13 @@ export class GameRoom {
       },
       { upsert: true }
     ).catch(() => {});
+
+    if (player.playerId) {
+      User.updateOne(
+        { accountId: player.playerId },
+        { currentTableId: null }
+      ).catch(() => {});
+    }
   }
 }
 
@@ -457,7 +464,15 @@ export class GameRoomManager {
       } catch {}
     }
     const result = room.addPlayer(playerId, playerName, telegramId, socket);
-    if (!result.error) await this.saveRoom(room);
+    if (!result.error) {
+      await this.saveRoom(room);
+      if (playerId) {
+        User.updateOne(
+          { accountId: playerId },
+          { currentTableId: roomId }
+        ).catch(() => {});
+      }
+    }
     return result;
   }
 

--- a/webapp/src/components/BuyTpcCard.jsx
+++ b/webapp/src/components/BuyTpcCard.jsx
@@ -43,6 +43,7 @@ export default function BuyTpcCard() {
       else setMsg('Purchase successful');
       setAmountTon('');
       getPresaleStatus().then(setStatus).catch(() => {});
+      window.dispatchEvent(new Event('presaleUpdate'));
     } catch {
       setMsg('Transaction failed');
     }

--- a/webapp/src/components/ClaimPurchaseCard.jsx
+++ b/webapp/src/components/ClaimPurchaseCard.jsx
@@ -21,6 +21,7 @@ export default function ClaimPurchaseCard() {
       if (res?.error) setMsg(res.error);
       else setMsg('Claim submitted');
       setTxHash('');
+      window.dispatchEvent(new Event('presaleUpdate'));
     } catch {
       setMsg('Claim failed');
     }

--- a/webapp/src/components/PresaleDashboardMultiRound.jsx
+++ b/webapp/src/components/PresaleDashboardMultiRound.jsx
@@ -55,7 +55,12 @@ export default function PresaleDashboardMultiRound() {
     }
     load();
     const interval = setInterval(load, 30000);
-    return () => clearInterval(interval);
+    const listener = () => load();
+    window.addEventListener('presaleUpdate', listener);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener('presaleUpdate', listener);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- track users' current table via Telegram ID when seating/unseating
- persist table status when players join rooms or disconnect
- fire events when TON presale purchases and claims occur
- refresh Presale dashboard on these events

## Testing
- `npm test` *(fails: canvas native build dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6883ac6dea3c83298eb17b1aa56f6e43