### PR TITLE
Fix presale TON tracking in stats

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -266,7 +266,8 @@ app.get('/api/stats', async (req, res) => {
     const purchasesPath = path.join(dataDir, 'walletPurchases.json');
     const walletPurchases = readJson(purchasesPath, {});
     for (const info of Object.values(walletPurchases)) {
-      if (info && info.tpc) tpcSold += info.tpc;
+      if (info && typeof info.tpc === 'number') tpcSold += info.tpc;
+      if (info && typeof info.ton === 'number') tonRaised += info.ton;
     }
     const nftsBurned = giftSends - currentNfts;
     res.json({


### PR DESCRIPTION
## Summary
- track TON values for presale purchases
- persist presale TON when claiming purchases
- include presale TON in stats computation

## Testing
- `npm test --` *(fails: node --test run did not finish successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6883b762f6d88329ab874df7c09251a5