### PR TITLE
Fix lingering snake lobby players

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -542,6 +542,10 @@ io.on('connection', (socket) => {
     socket.leave(roomId);
   });
 
+  socket.on('leaveRoom', async () => {
+    await gameManager.leaveRoom(socket);
+  });
+
   socket.on('rollDice', async () => {
     await gameManager.rollDice(socket);
   });

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1663,6 +1663,7 @@ export default function SnakeAndLadder() {
       if (watchOnly) {
         socket.emit('leaveWatch', { roomId: tableId });
       } else {
+        socket.emit('leaveRoom');
         unseatTable(accountId, tableId).catch(() => {});
       }
     };


### PR DESCRIPTION
## Summary
- handle players leaving a room by adding a `leaveRoom` event
- call `leaveRoom` on the client when exiting Snake and Ladder games

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883c14b54008329a4d08cecfb904227