### PR TITLE
Fix board mismatch in multiplayer

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -107,15 +107,9 @@ export class GameRoom {
       clearTimeout(this.startTimer);
       this.startTimer = null;
     }
-    if (this.gameType === 'snake') {
-      // Generate a fresh board for each new game so all players share the
-      // same layout while ensuring variety across games.
-      const board = generateBoard();
-      this.snakes = board.snakes;
-      this.ladders = board.ladders;
-      this.game.snakes = this.snakes;
-      this.game.ladders = this.ladders;
-    }
+    // The board is generated when the room is created or loaded. Do not
+    // regenerate it here or clients that fetched the board earlier would end
+    // up playing on a different layout.
     this.game.currentTurn = 0;
     this.game.finished = false;
     if (this.gameType === 'snake') {


### PR DESCRIPTION
## Summary
- remove board regeneration on game start so clients and server use the same board

## Testing
- `npm test` *(fails: canvas build error)*

------
https://chatgpt.com/codex/tasks/task_e_6883cc03b7888329bc9c9666d87edd81