### PR TITLE
Fix Snake & Ladder reconnect handling

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -612,14 +612,24 @@ export default function SnakeAndLadder() {
 
   useEffect(() => {
     const onDisc = () => setConnectionLost(true);
-    const onRec = () => setConnectionLost(false);
+    const onRec = () => {
+      setConnectionLost(false);
+      if (isMultiplayer) {
+        const accountId = getPlayerId();
+        if (watchOnly) {
+          socket.emit('watchRoom', { roomId: tableId });
+        } else if (accountId) {
+          socket.emit('joinRoom', { roomId: tableId, accountId, name: myName });
+        }
+      }
+    };
     socket.on('disconnect', onDisc);
     socket.io.on('reconnect', onRec);
     return () => {
       socket.off('disconnect', onDisc);
       socket.io.off('reconnect', onRec);
     };
-  }, []);
+  }, [isMultiplayer, tableId, watchOnly, myName]);
   const [pos, setPos] = useState(0);
   const [highlight, setHighlight] = useState(null); // { cell: number, type: string }
   const [trail, setTrail] = useState([]);


### PR DESCRIPTION
## Summary
- rejoin the current room on Socket.IO reconnect so the board stays in sync

## Testing
- `npm test` *(fails: canvas build requires dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6883d34e30048329ba0d63fb5e7955d5