### PR TITLE
Fix Telegram reload to always serve latest files

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -129,12 +129,20 @@ ensureWebappBuilt();
 
 
 app.use(
-  express.static(webappPath, { maxAge: '1y', immutable: true })
+  express.static(webappPath, {
+    maxAge: '1y',
+    immutable: true,
+    index: false
+  })
 );
 
 function sendIndex(res) {
   if (ensureWebappBuilt()) {
-    res.sendFile(path.join(webappPath, 'index.html'));
+    res.sendFile(path.join(webappPath, 'index.html'), {
+      headers: {
+        'Cache-Control': 'no-store'
+      }
+    });
   } else {
     res.status(503).send('Webapp build not available');
   }


### PR DESCRIPTION
## Summary
- disable serving index.html from `express.static`
- explicitly send index.html with `Cache-Control: no-store`

## Testing
- `npm test -s`

------
https://chatgpt.com/codex/tasks/task_e_6883d41097f08329bcd29c020ebaa3d4