### PR TITLE
Persist presale state

### DIFF
--- a/bot/models/PresaleState.js
+++ b/bot/models/PresaleState.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+import { INITIAL_PRICE } from '../config.js';
+
+const presaleStateSchema = new mongoose.Schema({
+  currentRound: { type: Number, default: 1 },
+  tokensSold: { type: Number, default: 0 },
+  currentPrice: { type: Number, default: INITIAL_PRICE }
+});
+
+export default mongoose.model('PresaleState', presaleStateSchema);

--- a/bot/routes/buy.js
+++ b/bot/routes/buy.js
@@ -1,6 +1,5 @@
 import { Router } from 'express';
-import fs from 'fs';
-import path from 'path';
+
 import {
   MAX_TPC_PER_WALLET,
   PURCHASE_INTERVAL_MS,
@@ -8,6 +7,7 @@ import {
   PRICE_INCREASE_STEP,
   PRESALE_ROUNDS,
 } from '../config.js';
+import PresaleState from '../models/PresaleState.js';
 import User from '../models/User.js';
 import WalletPurchase from '../models/WalletPurchase.js';
 import { ensureTransactionArray } from '../utils/userUtils.js';
@@ -15,8 +15,6 @@ import { withProxy } from '../utils/proxyAgent.js';
 import TonWeb from 'tonweb';
 
 const router = Router();
-const dataDir = path.join(path.dirname(new URL(import.meta.url).pathname), '../data');
-const statePath = path.join(dataDir, 'presaleState.json');
 const STORE_ADDRESS = process.env.STORE_DEPOSIT_ADDRESS ||
   'UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1';
 
@@ -30,36 +28,41 @@ function normalize(addr) {
 
 const STORE_ADDRESS_NORM = normalize(STORE_ADDRESS);
 
-function readJson(file, def) {
-  try {
-    return JSON.parse(fs.readFileSync(file, 'utf8'));
-  } catch {
-    return def;
+let state = null;
+
+async function loadState() {
+  if (!state) {
+    state = await PresaleState.findOne();
+    if (!state) {
+      state = new PresaleState({
+        currentRound: 1,
+        tokensSold: 0,
+        currentPrice: INITIAL_PRICE,
+      });
+      await state.save();
+    }
   }
+  return state;
 }
 
-function writeJson(file, data) {
-  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+async function saveState() {
+  if (state) await state.save();
 }
 
-let state = readJson(statePath, {
-  currentRound: 1,
-  tokensSold: 0,
-  currentPrice: INITIAL_PRICE,
-});
-
-router.get('/status', (_req, res) => {
-  const round = PRESALE_ROUNDS[state.currentRound - 1] || {};
-  const remaining = round.maxTokens ? round.maxTokens - state.tokensSold : 0;
+router.get('/status', async (_req, res) => {
+  const st = await loadState();
+  const round = PRESALE_ROUNDS[st.currentRound - 1] || {};
+  const remaining = round.maxTokens ? round.maxTokens - st.tokensSold : 0;
   res.json({
-    currentPrice: state.currentPrice,
-    currentRound: state.currentRound,
+    currentPrice: st.currentPrice,
+    currentRound: st.currentRound,
     remainingTokens: remaining,
     maxPerWallet: MAX_TPC_PER_WALLET,
   });
 });
 
 router.post('/', async (req, res) => {
+  await loadState();
   const { wallet, amountTON } = req.body;
   if (!wallet || typeof amountTON !== 'number' || amountTON <= 0) {
     return res.status(400).json({ error: 'wallet and amountTON required' });
@@ -96,11 +99,12 @@ router.post('/', async (req, res) => {
     state.currentPrice = next ? next.pricePerTPC : state.currentPrice;
   }
   await info.save();
-  writeJson(statePath, state);
+  await saveState();
   res.json({ tpc, currentPrice: state.currentPrice, round: state.currentRound });
 });
 
 router.post('/claim', async (req, res) => {
+  await loadState();
   const { accountId, txHash } = req.body;
   if (!accountId || !txHash) {
     return res.status(400).json({ error: 'accountId and txHash required' });
@@ -165,7 +169,7 @@ router.post('/claim', async (req, res) => {
       const next = PRESALE_ROUNDS[state.currentRound - 1];
       state.currentPrice = next ? next.pricePerTPC : state.currentPrice;
     }
-    writeJson(statePath, state);
+    await saveState();
 
     ensureTransactionArray(user);
     user.balance += tpc;


### PR DESCRIPTION
## Summary
- add new `PresaleState` model
- store presale progress in MongoDB

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883d9d02d708329968ddf851a301d94