### PR TITLE
Persist presale state in MongoDB

### DIFF
--- a/bot/models/PresaleState.js
+++ b/bot/models/PresaleState.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+
+const presaleStateSchema = new mongoose.Schema({
+  currentRound: { type: Number, default: 1 },
+  tokensSold: { type: Number, default: 0 },
+  currentPrice: { type: Number, default: 0.000004 }
+});
+
+export default mongoose.model('PresaleState', presaleStateSchema);


### PR DESCRIPTION
## Summary
- add `PresaleState` mongoose model
- load/save presale state from MongoDB instead of only a JSON file
- persist presale state on updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883d9dc63e483299accce20d4bd8ab2