### PR TITLE
Fix single-player AI blank screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ The server honors a few extra environment variables when building or serving the
    - `RPC_URL` – TON RPC endpoint (e.g. testnet)
    - `ADMIN_ADDRESS` – address that receives the minted supply
 
-6. Build the webapp assets. This step copies `public/tonconnect-manifest.json`
-   into the `dist` folder so wallets can connect:
+6. **(Optional)** Build the webapp assets. Running `npm start` will
+   automatically build the webapp if `webapp/dist` is missing. Building manually
+   copies `public/tonconnect-manifest.json` into the `dist` folder so wallets can
+   connect:
 
    ```bash
    npm --prefix webapp run build

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "bot/server.js",
   "scripts": {
+    "prestart": "npm run build",
     "start": "node bot/server.js",
     "install-all": "npm install && npm install --prefix bot && npm install --prefix webapp",
     "build": "npm --prefix webapp run build",


### PR DESCRIPTION
## Summary
- add `prestart` script so `npm start` always builds webapp
- clarify in README that the webapp build runs automatically

## Testing
- `npm test` *(fails: EBADENGINE and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6883e21760e88329acf60dd7637dcab6