### PR TITLE
Add lobby and game debugging logs

### DIFF
--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -60,6 +60,7 @@ export class SnakeGame {
 
   rollDice(diceValues) {
     if (this.finished) return null;
+    console.log('[SnakeGame] currentTurn before rollDice', this.currentTurn);
     const player = this.players[this.currentTurn];
     if (!player) return null;
     this.cancelTurnTimer();
@@ -126,6 +127,8 @@ export class SnakeGame {
     if (!extraTurn && !this.finished) {
       this.currentTurn = this.nextPlayerIndex(this.currentTurn);
     }
+
+    console.log('[SnakeGame] currentTurn after rollDice', this.currentTurn);
 
     if (!this.finished) {
       this.startTurnTimer();

--- a/bot/server.js
+++ b/bot/server.js
@@ -386,6 +386,7 @@ app.get('/api/snake/lobby/:id', async (req, res) => {
   const { id } = req.params;
   const parts = id.split('-');
   const cap = Number(parts[1]) || 4;
+  console.log('[Server] lobby', id, 'tableSeats', tableSeats.get(id)?.size, 'rooms', gameManager.rooms.size);
   const room = await gameManager.getRoom(id, cap);
   const roomPlayers = room.players
     .filter((p) => !p.disconnected)

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -28,6 +28,14 @@ export default function Layout({ children }) {
   }, []);
 
   useEffect(() => {
+    const onConnect = () => {
+      console.log('Connected to lobby server');
+    };
+    socket.on('connect', onConnect);
+    return () => socket.off('connect', onConnect);
+  }, []);
+
+  useEffect(() => {
     let id;
     let cancelled = false;
     ensureAccountId()

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -79,11 +79,13 @@ export default function Lobby() {
       function load() {
         getSnakeLobbies()
           .then((data) => {
-            if (active)
+            if (active) {
               setTables([
                 { id: 'single', label: 'Single Player vs AI' },
                 ...data
               ]);
+              console.log('[Lobby] Loaded tables', data);
+            }
           })
           .catch(() => {});
       }
@@ -124,11 +126,18 @@ export default function Lobby() {
       let interval;
       let cancelled = false;
       const tableRef = `${table.id}-${stake.amount}`;
+      console.log('[Lobby] seatTable interval setup', {
+        tableRef,
+        stake,
+        player: playerName
+      });
       ensureAccountId()
         .then((accountId) => {
           if (cancelled || !accountId) return;
+          console.log('[Lobby] seatTable()', { tableRef, accountId });
           seatTable(accountId, tableRef, playerName).catch(() => {});
           interval = setInterval(() => {
+            console.log('[Lobby] seatTable()', { tableRef, accountId });
             seatTable(accountId, tableRef, playerName).catch(() => {});
           }, 30000);
         })
@@ -170,16 +179,17 @@ export default function Lobby() {
             if (!active) return;
             const unique = [];
             const seen = new Set();
-            for (const p of data.players || []) {
-              const key = p.telegramId || p.id;
-              if (!seen.has(key)) {
-                seen.add(key);
-                unique.push(p);
+              for (const p of data.players || []) {
+                const key = p.telegramId || p.id;
+                if (!seen.has(key)) {
+                  seen.add(key);
+                  unique.push(p);
+                }
               }
-            }
-            setPlayers(unique);
-          })
-          .catch(() => {});
+              setPlayers(unique);
+              console.log('[Lobby] Loaded players', unique);
+            })
+            .catch(() => {});
       }
       loadPlayers();
       const id = setInterval(loadPlayers, 3000);
@@ -230,6 +240,7 @@ export default function Lobby() {
     }
     if (!stake.amount) return;
     const tableRef = `${table.id}-${stake.amount}`;
+    console.log('[Lobby] Confirm clicked', { tableRef, stake, nextConfirmed: !confirmed });
     ensureAccountId()
       .then((accountId) => {
         if (!accountId) return;


### PR DESCRIPTION
## Summary
- log lobby table & player loads
- log seatTable activity and confirm clicks
- log socket connection
- log lobby route info on server
- log SnakeGame turn changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883dc55dda88329a5df3f3246a8917d