### PR TITLE
Start multiplayer game when all seats confirmed

### DIFF
--- a/webapp/src/utils/lobby.js
+++ b/webapp/src/utils/lobby.js
@@ -1,9 +1,8 @@
-export function canStartGame(game, table, stake, aiCount = 0, players = 0) {
+export function canStartGame(game, table, stake, aiCount = 0) {
   if (game === 'snake' && table?.id === 'single') {
     if (!stake || !stake.token || !stake.amount) return false;
     return aiCount > 0;
   }
-  // For multiplayer snake games allow confirming before the table is full.
   if (!stake || !stake.token || !stake.amount) return false;
   if (game === 'snake' && !table) return false;
   return true;


### PR DESCRIPTION
## Summary
- fire `tableReady`/`gameStart` once all seats confirm
- simplify lobby readiness checks
- auto-navigate to the game when `tableReady` is received

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884682b8fcc8329bc0638b64f90189d