### PR TITLE
Emit next-turn from server and rely on event

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -139,11 +139,19 @@ export class GameRoom {
     this.emitNextTurn();
   }
 
-  emitNextTurn() {
+  notifyTurnChange() {
+    const current = this.players[this.currentTurn];
+    if (current) {
+      console.log('[Server] Next turn for player', current.playerId);
+      this.io.to(this.id).emit('turnChanged', { playerId: current.playerId });
+    }
+  }
+
+  emitNextTurn(sendEvent = true) {
     const current = this.players[this.currentTurn];
     if (current) {
       current.lastRollTime = 0; // reset cooldown at the start of every turn
-      this.io.to(this.id).emit('turnChanged', { playerId: current.playerId });
+      if (sendEvent) this.notifyTurnChange();
       if (this.turnTimer) clearTimeout(this.turnTimer);
       this.turnTimer = setTimeout(() => {
         if (
@@ -254,7 +262,8 @@ export class GameRoom {
       }
       this.currentTurn = this.game.currentTurn;
     }
-    this.emitNextTurn();
+    this.notifyTurnChange();
+    this.emitNextTurn(false);
   }
 
   handleDisconnect(socket) {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2226,8 +2226,6 @@ export default function SnakeAndLadder() {
       // The first player to join the table should roll first.
       setSetupPhase(false);
       setTurnMessage(`${getPlayerName(0)} starts first.`);
-      setCurrentTurn(0);
-      setDiceCount(playerDiceCounts[0] ?? 2);
       return;
     }
 


### PR DESCRIPTION
## Summary
- send `turnChanged` directly after each dice roll and log who is up next
- adjust client startup logic to await the server event

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68846829e87c83298a5f47f3753b9f99