### PR TITLE
Add lobby and room logging

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -334,6 +334,7 @@ app.post('/api/snake/table/seat', async (req, res) => {
   info.ts = Date.now();
   if (typeof confirmed === 'boolean') info.confirmed = confirmed;
   map.set(key, info);
+  console.log('[Server] Player seated:', { tableId, id: pid, confirmed: info.confirmed });
 
   if (user) {
     user.currentTableId = tableId;
@@ -513,7 +514,16 @@ io.on('connection', (socket) => {
       onlineUsers.set(String(accountId), Date.now());
     }
     const result = await gameManager.joinRoom(roomId, accountId, name, socket);
-    if (result.error) socket.emit('error', result.error);
+    if (result.error) {
+      socket.emit('error', result.error);
+    } else {
+      const lobbySize = tableSeats.get(roomId)?.size || 0;
+      const roomPlayers = room.players.filter((p) => !p.disconnected).length;
+      console.log('[Server] joinRoom', roomId, {
+        lobby: lobbySize,
+        room: roomPlayers
+      });
+    }
   });
 
   socket.on('watchRoom', async ({ roomId }) => {
@@ -552,7 +562,16 @@ io.on('connection', (socket) => {
   });
 
   socket.on('leaveRoom', async () => {
+    const room = gameManager.findRoomBySocket(socket.id);
     await gameManager.leaveRoom(socket);
+    if (room) {
+      const lobbySize = tableSeats.get(room.id)?.size || 0;
+      const roomPlayers = room.players.filter((p) => !p.disconnected).length;
+      console.log('[Server] leaveRoom', room.id, {
+        lobby: lobbySize,
+        room: roomPlayers
+      });
+    }
   });
 
   socket.on('rollDice', async () => {

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -22,11 +22,20 @@ import {
   getPlayerId
 } from '../../utils/telegram.js';
 import { canStartGame } from '../../utils/lobby.js';
+import { socket } from '../../utils/socket.js';
 
 export default function Lobby() {
   const { game } = useParams();
   const navigate = useNavigate();
   useTelegramBackButton(() => navigate('/games', { replace: true }));
+
+  useEffect(() => {
+    const handler = (event, ...args) => {
+      console.log('[Lobby] Socket event', event, ...args);
+    };
+    socket.onAny(handler);
+    return () => socket.offAny(handler);
+  }, []);
 
   useEffect(() => {
     ensureAccountId().catch(() => {});
@@ -245,7 +254,10 @@ export default function Lobby() {
       .then((accountId) => {
         if (!accountId) return;
         seatTable(accountId, tableRef, playerName, !confirmed)
-          .then(() => setConfirmed((c) => !c))
+          .then((res) => {
+            console.log('[Lobby] seatTable response', res);
+            setConfirmed((c) => !c);
+          })
           .catch(() => {});
       })
       .catch(() => {});


### PR DESCRIPTION
## Summary
- log when seats are confirmed on the server
- output lobby/room state for join/leave events
- echo socket events and seat confirmations in the lobby UI

## Testing
- `npm test` *(fails: tests hang)*

------
https://chatgpt.com/codex/tasks/task_e_688468261ca88329a210421369a5a56e