### PR TITLE
Enable realtime snake lobby updates

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -9,7 +9,6 @@ import { LEADER_AVATARS } from '../../utils/leaderAvatars.js';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
   getSnakeLobbies,
-  getSnakeLobby,
   pingOnline,
   getOnlineCount,
   seatTable,
@@ -22,6 +21,7 @@ import {
   getPlayerId
 } from '../../utils/telegram.js';
 import { canStartGame } from '../../utils/lobby.js';
+import { socket } from '../../utils/socket.js';
 
 export default function Lobby() {
   const { game } = useParams();
@@ -75,25 +75,16 @@ export default function Lobby() {
 
   useEffect(() => {
     if (game === 'snake') {
-      let active = true;
-      function load() {
-        getSnakeLobbies()
-          .then((data) => {
-            if (active) {
-              setTables([
-                { id: 'single', label: 'Single Player vs AI' },
-                ...data
-              ]);
-              console.log('[Lobby] Loaded tables', data);
-            }
-          })
-          .catch(() => {});
-      }
-      load();
-      const id = setInterval(load, 5000);
+      let cancelled = false;
+      getSnakeLobbies()
+        .then((data) => {
+          if (!cancelled) {
+            setTables([{ id: 'single', label: 'Single Player vs AI' }, ...data]);
+          }
+        })
+        .catch(() => {});
       return () => {
-        active = false;
-        clearInterval(id);
+        cancelled = true;
       };
     }
   }, [game]);
@@ -172,35 +163,47 @@ export default function Lobby() {
   useEffect(() => {
     if (game === 'snake' && table && table.id !== 'single' && stake.amount) {
       const tableRef = `${table.id}-${stake.amount}`;
-      let active = true;
-      function loadPlayers() {
-        getSnakeLobby(tableRef)
-          .then((data) => {
-            if (!active) return;
-            const unique = [];
-            const seen = new Set();
-              for (const p of data.players || []) {
-                const key = p.telegramId || p.id;
-                if (!seen.has(key)) {
-                  seen.add(key);
-                  unique.push(p);
-                }
-              }
-              setPlayers(unique);
-              console.log('[Lobby] Loaded players', unique);
-            })
-            .catch(() => {});
-      }
-      loadPlayers();
-      const id = setInterval(loadPlayers, 3000);
+
+      const onUpdate = ({ tableId, players: pls }) => {
+        if (tableId !== tableRef) return;
+        const unique = [];
+        const seen = new Set();
+        for (const p of pls || []) {
+          const key = p.telegramId || p.id;
+          if (!seen.has(key)) {
+            seen.add(key);
+            unique.push(p);
+          }
+        }
+        setPlayers(unique);
+        setTables((ts) =>
+          ts.map((t) =>
+            t.id === table.id ? { ...t, players: unique.length } : t
+          )
+        );
+      };
+
+      socket.on('lobbyUpdate', onUpdate);
+
+      ensureAccountId()
+        .then((accountId) => {
+          if (accountId) {
+            socket.emit('joinLobby', {
+              tableId: tableRef,
+              accountId,
+              name: playerName
+            });
+          }
+        })
+        .catch(() => {});
+
       return () => {
-        active = false;
-        clearInterval(id);
+        socket.off('lobbyUpdate', onUpdate);
       };
     } else {
       setPlayers([]);
     }
-  }, [game, table, stake]);
+  }, [game, table, stake, playerName]);
 
   const startGame = (flagOverride = flags, leaderOverride = leaders) => {
     if (


### PR DESCRIPTION
## Summary
- wire `Lobby.jsx` to socket.io for lobby updates
- send `joinLobby` socket events when selecting a table
- track lobby seats on the server and broadcast `lobbyUpdate`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688468247a9c8329bc9a8d5d768cceb9