### PR TITLE
Fix missing assets with vite base option

### DIFF
--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- ensure Vite uses relative base path

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6884733bce5c8329861527a85e8a82d1