### PR TITLE
Handle missing Telegram info

### DIFF
--- a/bot/commands/start.js
+++ b/bot/commands/start.js
@@ -6,16 +6,17 @@ export default function registerStart(bot) {
   bot.start(async (ctx) => {
     const telegramId = ctx.from.id;
     const info = await fetchTelegramInfo(telegramId);
+    const update = { $setOnInsert: { referralCode: telegramId.toString() } };
+    if (info) {
+      update.$set = {
+        firstName: info.firstName,
+        lastName: info.lastName,
+        photo: info.photoUrl,
+      };
+    }
     const user = await User.findOneAndUpdate(
       { telegramId },
-      {
-        $set: {
-          firstName: info.firstName,
-          lastName: info.lastName,
-          photo: info.photoUrl
-        },
-        $setOnInsert: { referralCode: telegramId.toString() }
-      },
+      update,
       { upsert: true, new: true, setDefaultsOnInsert: true }
     );
 

--- a/bot/routes/mining.js
+++ b/bot/routes/mining.js
@@ -57,19 +57,21 @@ router.post('/leaderboard', async (req, res) => {
     users.map(async (u) => {
       if (!u.firstName || !u.lastName || !u.photo) {
         const info = await fetchTelegramInfo(u.telegramId);
-        await User.updateOne(
-          { telegramId: u.telegramId },
-          {
-            $set: {
-              firstName: info.firstName,
-              lastName: info.lastName,
-              photo: info.photoUrl,
-            },
-          }
-        );
-        u.firstName = info.firstName;
-        u.lastName = info.lastName;
-        u.photo = info.photoUrl;
+        if (info) {
+          await User.updateOne(
+            { telegramId: u.telegramId },
+            {
+              $set: {
+                firstName: info.firstName,
+                lastName: info.lastName,
+                photo: info.photoUrl,
+              },
+            }
+          );
+          u.firstName = info.firstName;
+          u.lastName = info.lastName;
+          u.photo = info.photoUrl;
+        }
       }
     })
   );


### PR DESCRIPTION
## Summary
- avoid crash when fetchTelegramInfo fails in mining leaderboard
- make `/start` command robust when profile fetch fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68847e661fc88329a7f1c21d8135fd7c