### PR TITLE
Allow profile lookup by account ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ variable is set, you may instead supply `Authorization: Bearer <token>` to
 bypass Telegram checks. This is useful for server‑side actions such as
 awarding the developer share after a game ends.
 
+### Account IDs and player profiles
+
+Each user has a unique **TPC account ID** which serves as the main identifier
+when locating players. Most endpoints accept either an `accountId` or a
+Telegram ID. When a profile is requested the server first tries to find the
+account by `accountId`. Missing details such as the name or avatar are
+automatically filled from Telegram when a `telegramId` is provided.
+
 ### Claiming TPC on-chain
 
 Withdrawals and `/claim-external` trigger a signed message to

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -137,10 +137,12 @@ export function verifyInfluencer(id, status, views) {
   }).then(r => r.json());
 }
 
-export function getProfile(telegramId) {
-
-  return post('/api/profile/get', { telegramId });
-
+export function getProfile(id) {
+  let body;
+  if (typeof id === 'object') body = id;
+  else if (typeof id === 'string' && id.includes('-')) body = { accountId: id };
+  else body = { telegramId: id };
+  return post('/api/profile/get', body);
 }
 
 export function updateProfile(data) {


### PR DESCRIPTION
## Summary
- allow `/api/profile/get` to accept either `accountId` or `telegramId`
- update webapp `getProfile` helper to detect account IDs
- document account ID usage in README

## Testing
- `npm test` *(fails: output truncated)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68848fbdf70483298fc18f8250497e16