### PR TITLE
Persist presale stats in MongoDB

### DIFF
--- a/bot/models/PresaleState.js
+++ b/bot/models/PresaleState.js
@@ -1,9 +1,14 @@
 import mongoose from 'mongoose';
 import { INITIAL_PRICE } from '../config.js';
 
+// Keep a single document that tracks presale progress. Using a fixed _id
+// prevents multiple documents from being created on each server start and
+// ensures the stats persist across deployments.
 const presaleStateSchema = new mongoose.Schema({
+  _id: { type: String, default: 'singleton' },
   currentRound: { type: Number, default: 1 },
   tokensSold: { type: Number, default: 0 },
+  tonRaised: { type: Number, default: 0 },
   currentPrice: { type: Number, default: INITIAL_PRICE }
 });
 

--- a/webapp/src/components/PresaleDashboardMultiRound.jsx
+++ b/webapp/src/components/PresaleDashboardMultiRound.jsx
@@ -34,7 +34,8 @@ export default function PresaleDashboardMultiRound() {
   const percent = maxTokens
     ? ((sold / maxTokens) * 100).toFixed(2)
     : '0';
-  const tonRaised = sold * (status?.currentPrice || PRESALE_ROUNDS[roundIndex]?.pricePerTPC || 0);
+  const tonRaised = status?.tonRaised ??
+    sold * (status?.currentPrice || PRESALE_ROUNDS[roundIndex]?.pricePerTPC || 0);
   const totalTonRaised = stats?.tonRaised || 0;
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure presale state uses a single MongoDB document
- track TON raised per round and expose it via `/api/buy/status`
- reset raised amount when advancing rounds
- show ton raised directly from backend in Presale dashboard

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6884949dad2c83299d26bfd1eeaeeeb3