### PR TITLE
Fix missing presale API functions

### DIFF
--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -464,4 +464,17 @@ export function getWatchCount(tableId) {
 }
 
 export function getAppStats() {
-  return fetch(API_BASE_URL + '/api/stats').then((r) => r.json());}
+  return fetch(API_BASE_URL + '/api/stats').then((r) => r.json());
+}
+
+export function buyTPC(wallet, amountTON) {
+  return post('/api/buy', { wallet, amountTON });
+}
+
+export function claimPresale(accountId, txHash) {
+  return post('/api/buy/claim', { accountId, txHash });
+}
+
+export function getPresaleStatus() {
+  return fetch(API_BASE_URL + '/api/buy/status').then((r) => r.json());
+}


### PR DESCRIPTION
## Summary
- restore `buyTPC`, `claimPresale` and `getPresaleStatus` exports in `webapp/src/utils/api.js`

## Testing
- `npm test` *(fails: starting over capacity still allowed)*

------
https://chatgpt.com/codex/tasks/task_e_6884a16247c0832988d4b99ecba6ab12