### PR TITLE
Fix table capacity parsing bug

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1273,7 +1273,8 @@ export default function SnakeAndLadder() {
     if (!isMultiplayer) return;
     const accountId = getPlayerId();
     const name = myName;
-    const capacity = parseInt(tableId.split('-').pop(), 10) || 0;
+    const parts = tableId.split('-');
+    const capacity = parseInt(parts[1], 10) || 0;
     if (!watchOnly) {
       setWaitingForPlayers(true);
       setPlayersNeeded(capacity);


### PR DESCRIPTION
## Summary
- correctly parse snake table capacity from table ID

## Testing
- `npm test` *(fails: npm output shows progress but is interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6884a5583c3883298799ebe3d37db280