### PR TITLE
Add ready confirmation before starting snake games

### DIFF
--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -270,11 +270,14 @@ export function getSnakeResults() {
   return fetch(API_BASE_URL + '/api/snake/results').then((r) => r.json());
 }
 
-export function seatTable(playerId, tableId, name) {
+export function seatTable(playerId, tableId, name, confirmed) {
+  const body = { playerId, tableId };
+  if (name) body.name = name;
+  if (typeof confirmed === 'boolean') body.confirmed = confirmed;
   return fetch(API_BASE_URL + '/api/snake/table/seat', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ playerId, tableId, name }),
+    body: JSON.stringify(body),
   }).then((r) => r.json());
 }
 


### PR DESCRIPTION
## Summary
- update `seatTable` API helper to support a `confirmed` flag
- manage table seating in snake lobby when selecting a table
- mark player ready via `seatTable(..., true)` when pressing confirm
- clarify comment describing new lobby behaviour

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884a9753cfc83299b18ca038f1a073f