### PR TITLE
Restore snake lobby

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -14,8 +14,7 @@ export default function DiceRoller({
   muted = false,
   emitRollEvent = false,
   divRef,
-  accountId,
-  tableId,
+  className = '',
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -89,7 +88,7 @@ export default function DiceRoller({
           startValuesRef.current = results;
           onRollEnd && onRollEnd(results);
           if (emitRollEvent) {
-            socket.emit('rollDice', { accountId, tableId });
+            socket.emit('rollDice');
           }
         }, tick);
       }
@@ -97,7 +96,7 @@ export default function DiceRoller({
   };
 
   return (
-    <div className="flex flex-col items-center space-y-4">
+    <div className={`flex flex-col items-center space-y-4 ${className}`}>
       <div
         className={`flex space-x-4 ${clickable ? 'cursor-pointer' : ''}`}
         onClick={clickable ? rollDice : undefined}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -270,14 +270,11 @@ export function getSnakeResults() {
   return fetch(API_BASE_URL + '/api/snake/results').then((r) => r.json());
 }
 
-export function seatTable(playerId, tableId, name, confirmed) {
-  const body = { playerId, tableId };
-  if (name) body.name = name;
-  if (typeof confirmed === 'boolean') body.confirmed = confirmed;
+export function seatTable(playerId, tableId, name) {
   return fetch(API_BASE_URL + '/api/snake/table/seat', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body: JSON.stringify({ playerId, tableId, name }),
   }).then((r) => r.json());
 }
 


### PR DESCRIPTION
## Summary
- revert lobby to earlier version with manual confirmation
- simplify table seating API call
- adjust dice roller event

## Testing
- `npm test --silent` *(fails: getRoomConcurrency/lobbyUtils)*

------
https://chatgpt.com/codex/tasks/task_e_6884af6b06848329afb3568e8ad76a7d