### PR TITLE
Fix snake lobby navigation

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -210,7 +210,6 @@ export default function Lobby() {
         confirmed &&
         !startedRef.current &&
         table &&
-        players.length > 0 &&
         stake.token &&
         stake.amount
       ) {


### PR DESCRIPTION
## Summary
- prevent blank game screens by navigating as soon as `gameStart` fires even if the players list hasn't loaded yet

## Testing
- `npm test` *(fails: `concurrent getRoom returns identical boards` and others)*

------
https://chatgpt.com/codex/tasks/task_e_6884bea6ca408329b54266c52d7f7a0a