### PR TITLE
Fix reload failing on snake lobby

### DIFF
--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: './',
+  base: '/',
   plugins: [react()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- ensure Vite builds assets with absolute paths so reloading subroutes works

## Testing
- `npm test` *(fails: concurrent getRoom returns identical boards, start allowed before lobby full, starting over capacity still allowed)*

------
https://chatgpt.com/codex/tasks/task_e_6884c35806bc832985a2200b5775fd64