### PR TITLE
Fix presale stats retrieval after lobby restore

### DIFF
--- a/bot/routes/buy.js
+++ b/bot/routes/buy.js
@@ -35,14 +35,20 @@ async function loadState() {
   if (!state) {
     state = await PresaleState.findById(STATE_ID);
     if (!state) {
-      state = new PresaleState({
-        _id: STATE_ID,
-        currentRound: 1,
-        tokensSold: 0,
-        tonRaised: 0,
-        currentPrice: INITIAL_PRICE,
-      });
-      await state.save();
+      // Fallback for databases using the old schema without a fixed ID
+      const legacy = await PresaleState.findOne();
+      if (legacy) {
+        state = legacy;
+      } else {
+        state = new PresaleState({
+          _id: STATE_ID,
+          currentRound: 1,
+          tokensSold: 0,
+          tonRaised: 0,
+          currentPrice: INITIAL_PRICE,
+        });
+        await state.save();
+      }
     }
   }
   return state;


### PR DESCRIPTION
## Summary
- fix `loadState` to fallback to legacy presale document

## Testing
- `npm test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6885107c264083299af8c77d936d9218