### PR TITLE
Fix presale stats endpoint

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -15,6 +15,7 @@ import referralRoutes from './routes/referral.js';
 import walletRoutes from './routes/wallet.js';
 import accountRoutes from './routes/account.js';
 import profileRoutes from './routes/profile.js';
+import buyRoutes from './routes/buy.js';
 import twitterAuthRoutes from './routes/twitterAuth.js';
 import airdropRoutes from './routes/airdrop.js';
 import checkinRoutes from './routes/checkin.js';
@@ -105,6 +106,7 @@ app.use('/api/airdrop', airdropRoutes);
 app.use('/api/checkin', checkinRoutes);
 app.use('/api/social', socialRoutes);
 app.use('/api/broadcast', broadcastRoutes);
+app.use('/api/buy', buyRoutes);
 app.use('/api/store', storeRoutes);
 
 // Serve the built React app


### PR DESCRIPTION
## Summary
- mount `buyRoutes` so presale data is served from MongoDB

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_68851fd19a9c8329b32836984636e301