### PR TITLE
Implement live lobby seat tracking

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -77,22 +77,23 @@ export default function Lobby() {
   useEffect(() => {
     if (game === 'snake') {
       let active = true;
+      function apply(data) {
+        if (active)
+          setTables([
+            { id: 'single', label: 'Single Player vs AI' },
+            ...data
+          ]);
+      }
       function load() {
-        getSnakeLobbies()
-          .then((data) => {
-            if (active)
-              setTables([
-                { id: 'single', label: 'Single Player vs AI' },
-                ...data
-              ]);
-          })
-          .catch(() => {});
+        getSnakeLobbies().then(apply).catch(() => {});
       }
       load();
-      const id = setInterval(load, 5000);
+      socket.on('snakeLobbies', apply);
+      const id = setInterval(load, 30000);
       return () => {
         active = false;
         clearInterval(id);
+        socket.off('snakeLobbies', apply);
       };
     }
   }, [game]);


### PR DESCRIPTION
## Summary
- broadcast live snake lobby table counts when players seat or leave
- update lobby UI to listen for `snakeLobbies` socket events

## Testing
- `npm test` *(fails: should receive error when table not full)*

------
https://chatgpt.com/codex/tasks/task_e_688529f07eb08329b582f5c2194d1077