### PR TITLE
Fix lobby player list update

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -127,18 +127,22 @@ export default function Lobby() {
       ensureAccountId()
         .then((accountId) => {
           if (cancelled || !accountId) return;
-          socket.emit('seatTable', {
-            accountId,
-            tableId: table.id,
-            playerName
-          });
-          interval = setInterval(() => {
+          async function seat() {
             socket.emit('seatTable', {
               accountId,
               tableId: table.id,
               playerName
             });
-          }, 30000);
+            try {
+              const data = await getSnakeLobby(table.id);
+              if (!cancelled)
+                setPlayers(
+                  data.players.map((p) => ({ ...p, confirmed: false }))
+                );
+            } catch {}
+          }
+          seat();
+          interval = setInterval(seat, 30000);
         })
         .catch(() => {});
       return () => {


### PR DESCRIPTION
## Summary
- fix table seating effect to refresh player list

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_6885a1dc14c0832980df4d3de7b5945b