### PR TITLE
Fix lobby counts update

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1028,6 +1028,12 @@ httpServer.listen(PORT, async () => {
   }
 });
 
+// Periodically clean up stale lobby seats and broadcast updated counts
+setInterval(() => {
+  cleanupSeats();
+  broadcastSnakeLobbies().catch(() => {});
+}, 30_000);
+
 if (process.env.BOT_TOKEN && process.env.BOT_TOKEN !== 'dummy') {
   process.once('SIGINT', () => bot.stop('SIGINT'));
   process.once('SIGTERM', () => bot.stop('SIGTERM'));


### PR DESCRIPTION
## Summary
- ensure lobby seat cleanup runs periodically

## Testing
- `npm test` *(fails: MongoDB index conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6885c408d2f083298f20cd2c9aaa9bb5