### PR TITLE
Fix Snake lobby player counts

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -359,13 +359,15 @@ export class GameRoomManager {
         snakes: Object.fromEntries(doc.snakes),
         ladders: Object.fromEntries(doc.ladders)
       }, doc.gameType || 'snake');
-      room.players = doc.players.map((p) => ({
-        ...p.toObject(),
-        socketId: null,
-        lastRollTime: 0
-      }));
-      room.currentTurn = doc.currentTurn;
-      room.status = doc.status;
+      // Start with an empty room so stale player counts don't persist
+      room.players = [];
+      room.currentTurn = 0;
+      room.status = 'waiting';
+      // Clear any stored players from the database as well
+      await GameRoomModel.updateOne(
+        { roomId: doc.roomId },
+        { players: [], currentTurn: 0, status: 'waiting' }
+      ).catch(() => {});
       this.rooms.set(room.id, room);
     }
   }


### PR DESCRIPTION
## Summary
- clear stale players when loading Snake rooms so lobby counts reset

## Testing
- `npm test` *(fails: EBADENGINE Node 20)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6885d8cf45348329b1fd940449812464