### PR TITLE
Update tokenomics with current presale

### DIFF
--- a/webapp/src/components/ProjectAchievementsCard.jsx
+++ b/webapp/src/components/ProjectAchievementsCard.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 
 export default function ProjectAchievementsCard() {
   const achievements = [
-    '🔐 Smart-contract presale live with auto-delivery',
+    '🔐 Smart-contract presale live with auto-delivery (5 stages)',
     '🚀 TPC deployed on TON network',
     '🧾 Wallet transaction history works',
     '💬 In-chat TPC transfers enabled',
@@ -14,7 +14,6 @@ export default function ProjectAchievementsCard() {
     '⛏️ Mining system active',
     '📺 Ad watch rewards',
     '🎯 Social tasks for X, Telegram, TikTok',
-    '📹 Intro video view rewards',
     '🎡 Spin & Win wheel',
     '🍀 Lucky Card prizes',
     '🎁 NFT Gifts marketplace',

--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -23,7 +23,7 @@ export default function StoreAd() {
         <span className="text-lg font-bold">Store</span>
       </div>
       <div className="text-center text-sm">
-        Current Price: {status ? status.currentPrice : '...'} TON / 1 TPC
+        Presale Stage {status ? status.currentRound : '...'} Price: {status ? status.currentPrice : '...'} TON / 1 TPC (5 stages total)
       </div>
       <Link
         to="/store"

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -215,7 +215,6 @@ export default function Home() {
           activeUsers: online.count || data.activeUsers || 0,
           nftsCreated: data.nftsCreated,
           nftsBurned: data.nftsBurned,
-          bundlesSold: data.bundlesSold,
           tonRaised: data.tonRaised,
           tpcSold: data.tpcSold,
           appClaimed: data.appClaimed,
@@ -416,7 +415,6 @@ export default function Home() {
               )}
             </p>
             <p>NFTs Burned: {stats?.nftsBurned ?? '...'}</p>
-            <p>Bundles Sold: {stats?.bundlesSold ?? '...'}</p>
             <p>
               Total Raised: {stats ? formatValue(stats.tonRaised, 2) : '...'}{' '}
               <img src="/assets/icons/TON.webp" alt="TON" className="inline-block w-4 h-4 ml-1" />

--- a/webapp/src/pages/Tokenomics.jsx
+++ b/webapp/src/pages/Tokenomics.jsx
@@ -439,7 +439,6 @@ export default function TokenomicsPage() {
             <li className="ml-4">⛏️ Mining system (250–1,000 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> every 12 hours)</li>
             <li className="ml-4">📺 Ad Watch Rewards: 50 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> per ad (up to 5/day)</li>
             <li className="ml-4">🎯 Social Tasks: +2,500 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> each for X, Telegram, TikTok</li>
-            <li className="ml-4">📹 Intro Video Views: +5 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> each</li>
             <li className="ml-4">🎡 Spin &amp; Win Wheel: 400–1,600 <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 mx-1" /> prizes + Bonus x2 chance</li>
             <li className="ml-4">🍀 Lucky Card daily prizes and free spin chances</li>
             <li className="ml-4">🎁 NFT Gifts with fun on-screen effects</li>
@@ -449,10 +448,15 @@ export default function TokenomicsPage() {
         <div>
           <h4 className="font-semibold text-accent mb-1">What’s Live Right Now</h4>
           <ul className="list-disc pl-6 space-y-1">
-            <li>🛒 Presale Store with bundles up to 5M <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 ml-1" /></li>
+            <li>
+              🛒 Smart-contract presale running in five stages:
+              <span className="ml-1">0.000004</span>,
+              <span>0.000005</span>,
+              <span>0.000006</span>,
+              <span>0.000008</span>,
+              <span>0.000010 TON</span> per TPC
+            </li>
             <li>🧑‍💻 Mining &amp; Boosters (via Virtual Friends)</li>
-            <li>🔁 Spin &amp; Win Packs (with spins and TPC <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 ml-1" />)</li>
-            <li>🎁 Bonus Packs (spins + TPC <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-4 h-4 ml-1" /> + boosts)</li>
             <li>🎲 Crazy Dice Duel mini-game</li>
             <li>🍀 Lucky Card rewards</li>
             <li>🎁 NFT Gifts marketplace</li>


### PR DESCRIPTION
## Summary
- update achievements list with presale stages
- remove bundle references and intro video reward
- show presale stage pricing in Store ad
- clean up stats section

## Testing
- `npm test` *(fails: IndexKeySpecsConflict)*

------
https://chatgpt.com/codex/tasks/task_e_688712b7ec388329af92b358a6763e9a