### PR TITLE
Fix presale payouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ The server honors a few extra environment variables when building or serving the
 
 - `WEBAPP_API_BASE_URL` – overrides the API base used during the webapp build. Set this when the bot API is hosted on another domain or port. If left empty the webapp assumes it is served from the same origin.
 - `TONCONNECT_MANIFEST_URL` – full URL for a custom `tonconnect-manifest.json`. Defaults to the manifest bundled with the build when unset.
- - `SKIP_WEBAPP_BUILD` – set to any value to skip the automatic webapp build that normally runs when `npm start` is executed. Useful if you built the assets manually.
- - `ALLOWED_ORIGINS` – list of origins allowed for CORS and socket.io when serving the API. Separate multiple origins with commas.
+- `SKIP_WEBAPP_BUILD` – set to any value to skip the automatic webapp build that normally runs when `npm start` is executed. Useful if you built the assets manually.
+- `ALLOWED_ORIGINS` – list of origins allowed for CORS and socket.io when serving the API. Separate multiple origins with commas.
+- `ENABLE_PRESALE_WATCHER` – set to `true` to automatically credit presale purchases when on-chain transactions to the store address are detected.
 
 5. Copy `scripts/.env.example` to `scripts/.env` and set:
    - `MNEMONIC` – wallet seed phrase used to deploy the Jetton

--- a/bot/presaleWatcher.js
+++ b/bot/presaleWatcher.js
@@ -1,0 +1,139 @@
+import TonWeb from 'tonweb';
+import PresaleState from './models/PresaleState.js';
+import User from './models/User.js';
+import WalletPurchase from './models/WalletPurchase.js';
+import {
+  MAX_TPC_PER_WALLET,
+  INITIAL_PRICE,
+  PRICE_INCREASE_STEP,
+  PRESALE_ROUNDS,
+} from './config.js';
+import { ensureTransactionArray } from './utils/userUtils.js';
+
+const STORE_ADDRESS = process.env.STORE_DEPOSIT_ADDRESS ||
+  'UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1';
+
+function normalize(addr) {
+  try {
+    return new TonWeb.utils.Address(addr).toString(true, false, false);
+  } catch {
+    return null;
+  }
+}
+
+const STATE_ID = 'singleton';
+let state = null;
+async function loadState() {
+  if (!state) {
+    state = await PresaleState.findById(STATE_ID);
+    if (!state) {
+      const legacy = await PresaleState.findOne();
+      if (legacy) {
+        state = legacy;
+      } else {
+        state = new PresaleState({
+          _id: STATE_ID,
+          currentRound: 1,
+          tokensSold: 0,
+          tonRaised: 0,
+          currentPrice: INITIAL_PRICE,
+        });
+        await state.save();
+      }
+    }
+  }
+  return state;
+}
+
+async function saveState() {
+  if (state) await state.save();
+}
+
+let lastTime = 0;
+
+async function processTransactions() {
+  try {
+    const resp = await fetch(
+      `https://tonapi.io/v2/blockchain/accounts/${STORE_ADDRESS}/transactions?limit=50`
+    );
+    if (!resp.ok) return;
+    const data = await resp.json();
+    const txs = (data.transactions || []).sort((a, b) => a.utime - b.utime);
+    for (const tx of txs) {
+      if (!tx.in_msg || !tx.in_msg.source?.address) continue;
+      if (tx.utime <= lastTime) continue;
+      const txHash = tx.hash;
+      const dup = await User.findOne({ 'transactions.txHash': txHash });
+      if (dup) {
+        lastTime = Math.max(lastTime, tx.utime);
+        continue;
+      }
+      const sender = normalize(tx.in_msg.source.address);
+      if (!sender) {
+        lastTime = Math.max(lastTime, tx.utime);
+        continue;
+      }
+      const user = await User.findOne({ walletAddress: sender });
+      if (!user) {
+        lastTime = Math.max(lastTime, tx.utime);
+        continue;
+      }
+      const tonVal = Number(tx.in_msg.value) / 1e9;
+      const st = await loadState();
+      const round = PRESALE_ROUNDS[st.currentRound - 1];
+      if (!round) continue;
+      let tpc = Math.floor(tonVal / st.currentPrice);
+      if (tpc <= 0) {
+        lastTime = Math.max(lastTime, tx.utime);
+        continue;
+      }
+      const remaining = round.maxTokens - st.tokensSold;
+      if (tpc > remaining) tpc = remaining;
+      let rec = await WalletPurchase.findOne({ wallet: sender });
+      if (!rec) rec = new WalletPurchase({ wallet: sender, tpc: 0, ton: 0, last: 0 });
+      if (rec.tpc + tpc > MAX_TPC_PER_WALLET) {
+        tpc = MAX_TPC_PER_WALLET - rec.tpc;
+        if (tpc <= 0) {
+          lastTime = Math.max(lastTime, tx.utime);
+          continue;
+        }
+      }
+      rec.tpc += tpc;
+      rec.ton += tonVal;
+      rec.last = new Date(tx.utime * 1000);
+      await rec.save();
+
+      st.tonRaised += tonVal;
+      st.tokensSold += tpc;
+      st.currentPrice = Number((st.currentPrice + PRICE_INCREASE_STEP).toFixed(9));
+      if (st.tokensSold >= round.maxTokens) {
+        st.currentRound += 1;
+        st.tokensSold = 0;
+        st.tonRaised = 0;
+        const next = PRESALE_ROUNDS[st.currentRound - 1];
+        st.currentPrice = next ? next.pricePerTPC : st.currentPrice;
+      }
+      await saveState();
+
+      ensureTransactionArray(user);
+      user.balance += tpc;
+      user.transactions.push({
+        amount: tpc,
+        type: 'presale',
+        token: 'TPC',
+        status: 'delivered',
+        date: new Date(tx.utime * 1000),
+        txHash,
+      });
+      await user.save();
+      lastTime = Math.max(lastTime, tx.utime);
+    }
+  } catch (err) {
+    console.error('Presale watcher error:', err.message);
+  }
+}
+
+export function startPresaleWatcher() {
+  processTransactions();
+  setInterval(processTransactions, 60_000);
+}

--- a/bot/server.js
+++ b/bot/server.js
@@ -767,6 +767,15 @@ mongoose.connection.once('open', async () => {
   gameManager
     .loadRooms()
     .catch((err) => console.error('Failed to load game rooms:', err));
+
+  if (process.env.ENABLE_PRESALE_WATCHER === 'true') {
+    try {
+      const { startPresaleWatcher } = await import('./presaleWatcher.js');
+      startPresaleWatcher();
+    } catch (err) {
+      console.error('Failed to start presale watcher:', err.message);
+    }
+  }
 });
 
 io.on('connection', (socket) => {


### PR DESCRIPTION
## Summary
- add a presale watcher that polls tonapi for payments
- start the watcher when `ENABLE_PRESALE_WATCHER=true`
- document the new environment variable

## Testing
- `npm test` *(fails: IndexKeySpecsConflict)*

------
https://chatgpt.com/codex/tasks/task_e_68878edbaedc8329b0f57fee8f46f961