### PR TITLE
Enable presale watcher by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The server honors a few extra environment variables when building or serving the
 - `TONCONNECT_MANIFEST_URL` – full URL for a custom `tonconnect-manifest.json`. Defaults to the manifest bundled with the build when unset.
 - `SKIP_WEBAPP_BUILD` – set to any value to skip the automatic webapp build that normally runs when `npm start` is executed. Useful if you built the assets manually.
 - `ALLOWED_ORIGINS` – list of origins allowed for CORS and socket.io when serving the API. Separate multiple origins with commas.
-- `ENABLE_PRESALE_WATCHER` – set to `true` to automatically credit presale purchases when on-chain transactions to the store address are detected.
+- `ENABLE_PRESALE_WATCHER` – set to `false` to disable automatic crediting of presale purchases. By default the server watches on-chain transactions to the store address and credits tokens automatically.
 
 5. Copy `scripts/.env.example` to `scripts/.env` and set:
    - `MNEMONIC` – wallet seed phrase used to deploy the Jetton

--- a/bot/server.js
+++ b/bot/server.js
@@ -768,7 +768,8 @@ mongoose.connection.once('open', async () => {
     .loadRooms()
     .catch((err) => console.error('Failed to load game rooms:', err));
 
-  if (process.env.ENABLE_PRESALE_WATCHER === 'true') {
+  const watchPresaleEnv = process.env.ENABLE_PRESALE_WATCHER;
+  if (watchPresaleEnv !== 'false') {
     try {
       const { startPresaleWatcher } = await import('./presaleWatcher.js');
       startPresaleWatcher();


### PR DESCRIPTION
## Summary
- watch presale transactions unless `ENABLE_PRESALE_WATCHER=false`
- document new default behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68879bda48448329911ea598614d9a9b