### PR TITLE
Add presale deposit address

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@
    - `MONGODB_URI` – MongoDB connection string or `memory`
      (falls back to an in-memory database if unset)
    - `AIRDROP_ADMIN_TOKENS` – (optional) tokens allowed to trigger airdrops
-   - `DEPOSIT_WALLET_ADDRESS` – TON address that receives user deposits
-   - `CLAIM_CONTRACT_ADDRESS` – address of the deployed `tpc_claim_wallet` contract
+  - `DEPOSIT_WALLET_ADDRESS` – TON address that receives user deposits
+  - `STORE_DEPOSIT_ADDRESS` – TON address that receives payments for store bundles
+  - `PRESALE_DEPOSIT_ADDRESS` – (optional) address for presale purchases. Defaults to `STORE_DEPOSIT_ADDRESS`
+  - `CLAIM_CONTRACT_ADDRESS` – address of the deployed `tpc_claim_wallet` contract
   - `CLAIM_WALLET_MNEMONIC` – seed phrase used to sign claim transactions
   - `TPC_JETTON_ADDRESS` – token contract address shown after a claim
   - `RPC_URL` – (optional) TON RPC endpoint for claim messages. Defaults to `https://toncenter.com/api/v2/jsonRPC`

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -29,6 +29,8 @@ ENABLE_TWITTER_OAUTH=false
 DEPOSIT_WALLET_ADDRESS=
 # TON address that receives payments for store bundles
 STORE_DEPOSIT_ADDRESS=UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1
+# TON address used for presale purchases. Defaults to STORE_DEPOSIT_ADDRESS when unset
+PRESALE_DEPOSIT_ADDRESS=
 
 # Account IDs that receive developer fees
 # Primary developer account (Tur.Alimadhi)

--- a/bot/presaleWatcher.js
+++ b/bot/presaleWatcher.js
@@ -12,6 +12,7 @@ import { ensureTransactionArray } from './utils/userUtils.js';
 
 const STORE_ADDRESS = process.env.STORE_DEPOSIT_ADDRESS ||
   'UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1';
+const PRESALE_ADDRESS = process.env.PRESALE_DEPOSIT_ADDRESS || STORE_ADDRESS;
 
 function normalize(addr) {
   try {
@@ -20,6 +21,8 @@ function normalize(addr) {
     return null;
   }
 }
+
+const PRESALE_ADDRESS_NORM = normalize(PRESALE_ADDRESS);
 
 const STATE_ID = 'singleton';
 let state = null;
@@ -54,7 +57,7 @@ let lastTime = 0;
 async function processTransactions() {
   try {
     const resp = await fetch(
-      `https://tonapi.io/v2/blockchain/accounts/${STORE_ADDRESS}/transactions?limit=50`
+      `https://tonapi.io/v2/blockchain/accounts/${PRESALE_ADDRESS}/transactions?limit=50`
     );
     if (!resp.ok) return;
     const data = await resp.json();

--- a/bot/routes/buy.js
+++ b/bot/routes/buy.js
@@ -17,6 +17,7 @@ import TonWeb from 'tonweb';
 const router = Router();
 const STORE_ADDRESS = process.env.STORE_DEPOSIT_ADDRESS ||
   'UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1';
+const PRESALE_ADDRESS = process.env.PRESALE_DEPOSIT_ADDRESS || STORE_ADDRESS;
 
 function normalize(addr) {
   try {
@@ -27,6 +28,7 @@ function normalize(addr) {
 }
 
 const STORE_ADDRESS_NORM = normalize(STORE_ADDRESS);
+const PRESALE_ADDRESS_NORM = normalize(PRESALE_ADDRESS);
 
 const STATE_ID = 'singleton';
 let state = null;
@@ -141,7 +143,7 @@ router.post('/claim', async (req, res) => {
     }
     const data = await resp.json();
     const out = (data.out_msgs || []).find(
-      (m) => normalize(m.destination?.address) === STORE_ADDRESS_NORM
+      (m) => normalize(m.destination?.address) === PRESALE_ADDRESS_NORM
     );
     const sender = normalize(data.in_msg?.source?.address || '');
     if (!out) return res.status(400).json({ error: 'destination mismatch' });

--- a/webapp/src/components/BuyTpcCard.jsx
+++ b/webapp/src/components/BuyTpcCard.jsx
@@ -4,7 +4,7 @@ import TonConnectButton from './TonConnectButton.jsx';
 import InfoPopup from './InfoPopup.jsx';
 import { calculateTpcAmount } from '../utils/buyLogic.js';
 import { buyTPC, getPresaleStatus } from '../utils/api.js';
-import { STORE_ADDRESS } from '../utils/storeData.js';
+import { PRESALE_ADDRESS } from '../utils/storeData.js';
 
 export default function BuyTpcCard() {
   const [tonConnectUI] = useTonConnectUI();
@@ -34,7 +34,7 @@ export default function BuyTpcCard() {
     }
     const tx = {
       validUntil: Math.floor(Date.now() / 1000) + 60,
-      messages: [{ address: STORE_ADDRESS, amount: String(amount * 1e9) }]
+      messages: [{ address: PRESALE_ADDRESS, amount: String(amount * 1e9) }]
     };
     try {
       await tonConnectUI.sendTransaction(tx);

--- a/webapp/src/utils/storeData.js
+++ b/webapp/src/utils/storeData.js
@@ -1,4 +1,6 @@
 export const STORE_ADDRESS = 'UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1';
+// Address used for presale purchases, defaults to STORE_ADDRESS
+export const PRESALE_ADDRESS = STORE_ADDRESS;
 
 // Dynamic pricing configuration for the presale
 export const initialPrice = 0.000004; // TON per 1 TPC


### PR DESCRIPTION
## Summary
- make presale deposit address configurable
- point presale purchase code to use the new address
- expose presale address in the web client

## Testing
- `npm test` *(fails: fetch failed; presale watcher error)*

------
https://chatgpt.com/codex/tasks/task_e_6887bdb9b93083298bc3b2902b22c01a