### PR TITLE
Implement presale transaction logging

### DIFF
--- a/bot/models/PresaleTransaction.js
+++ b/bot/models/PresaleTransaction.js
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose';
+
+const presaleTransactionSchema = new mongoose.Schema({
+  txHash: { type: String, required: true, unique: true },
+  wallet: { type: String, required: true },
+  ton: { type: Number, required: true },
+  tpc: { type: Number, required: true },
+  timestamp: { type: Date, required: true },
+  processed: { type: Boolean, default: false },
+  accountId: { type: String, default: null }
+});
+
+presaleTransactionSchema.index({ txHash: 1 }, { unique: true });
+
+export default mongoose.model('PresaleTransaction', presaleTransactionSchema);

--- a/bot/presaleWatcher.js
+++ b/bot/presaleWatcher.js
@@ -2,6 +2,8 @@ import TonWeb from 'tonweb';
 import PresaleState from './models/PresaleState.js';
 import User from './models/User.js';
 import WalletPurchase from './models/WalletPurchase.js';
+import PresaleTransaction from './models/PresaleTransaction.js';
+import { withProxy } from './utils/proxyAgent.js';
 import {
   MAX_TPC_PER_WALLET,
   INITIAL_PRICE,
@@ -54,10 +56,58 @@ async function saveState() {
 
 let lastTime = 0;
 
+async function creditRecord(record, user) {
+  let tpc = record.tpc;
+  const tonVal = record.ton;
+  const st = await loadState();
+  const round = PRESALE_ROUNDS[st.currentRound - 1];
+  if (!round) return;
+  let wp = await WalletPurchase.findOne({ wallet: record.wallet });
+  if (!wp) wp = new WalletPurchase({ wallet: record.wallet, tpc: 0, ton: 0, last: 0 });
+  if (wp.tpc + tpc > MAX_TPC_PER_WALLET) {
+    tpc = MAX_TPC_PER_WALLET - wp.tpc;
+    if (tpc <= 0) return;
+    record.tpc = tpc;
+  }
+  wp.tpc += tpc;
+  wp.ton += tonVal;
+  wp.last = record.timestamp;
+  await wp.save();
+
+  st.tonRaised += tonVal;
+  st.tokensSold += tpc;
+  st.currentPrice = Number((st.currentPrice + PRICE_INCREASE_STEP).toFixed(9));
+  if (st.tokensSold >= round.maxTokens) {
+    st.currentRound += 1;
+    st.tokensSold = 0;
+    st.tonRaised = 0;
+    const next = PRESALE_ROUNDS[st.currentRound - 1];
+    st.currentPrice = next ? next.pricePerTPC : st.currentPrice;
+  }
+  await saveState();
+
+  ensureTransactionArray(user);
+  user.balance += tpc;
+  user.transactions.push({
+    amount: tpc,
+    type: 'presale',
+    token: 'TPC',
+    status: 'delivered',
+    date: record.timestamp,
+    txHash: record.txHash,
+  });
+  await user.save();
+
+  record.processed = true;
+  record.accountId = user.accountId;
+  await record.save();
+}
+
 async function processTransactions() {
   try {
     const resp = await fetch(
-      `https://tonapi.io/v2/blockchain/accounts/${PRESALE_ADDRESS}/transactions?limit=50`
+      `https://tonapi.io/v2/blockchain/accounts/${PRESALE_ADDRESS}/transactions?limit=50`,
+      withProxy()
     );
     if (!resp.ok) return;
     const data = await resp.json();
@@ -66,18 +116,13 @@ async function processTransactions() {
       if (!tx.in_msg || !tx.in_msg.source?.address) continue;
       if (tx.utime <= lastTime) continue;
       const txHash = tx.hash;
-      const dup = await User.findOne({ 'transactions.txHash': txHash });
+      const dup = await PresaleTransaction.findOne({ txHash });
       if (dup) {
         lastTime = Math.max(lastTime, tx.utime);
         continue;
       }
       const sender = normalize(tx.in_msg.source.address);
       if (!sender) {
-        lastTime = Math.max(lastTime, tx.utime);
-        continue;
-      }
-      const user = await User.findOne({ walletAddress: sender });
-      if (!user) {
         lastTime = Math.max(lastTime, tx.utime);
         continue;
       }
@@ -92,43 +137,59 @@ async function processTransactions() {
       }
       const remaining = round.maxTokens - st.tokensSold;
       if (tpc > remaining) tpc = remaining;
-      let rec = await WalletPurchase.findOne({ wallet: sender });
-      if (!rec) rec = new WalletPurchase({ wallet: sender, tpc: 0, ton: 0, last: 0 });
-      if (rec.tpc + tpc > MAX_TPC_PER_WALLET) {
-        tpc = MAX_TPC_PER_WALLET - rec.tpc;
-        if (tpc <= 0) {
-          lastTime = Math.max(lastTime, tx.utime);
-          continue;
-        }
-      }
-      rec.tpc += tpc;
-      rec.ton += tonVal;
-      rec.last = new Date(tx.utime * 1000);
-      await rec.save();
-
-      st.tonRaised += tonVal;
-      st.tokensSold += tpc;
-      st.currentPrice = Number((st.currentPrice + PRICE_INCREASE_STEP).toFixed(9));
-      if (st.tokensSold >= round.maxTokens) {
-        st.currentRound += 1;
-        st.tokensSold = 0;
-        st.tonRaised = 0;
-        const next = PRESALE_ROUNDS[st.currentRound - 1];
-        st.currentPrice = next ? next.pricePerTPC : st.currentPrice;
-      }
-      await saveState();
-
-      ensureTransactionArray(user);
-      user.balance += tpc;
-      user.transactions.push({
-        amount: tpc,
-        type: 'presale',
-        token: 'TPC',
-        status: 'delivered',
-        date: new Date(tx.utime * 1000),
+      const record = new PresaleTransaction({
         txHash,
+        wallet: sender,
+        ton: tonVal,
+        tpc,
+        timestamp: new Date(tx.utime * 1000),
       });
-      await user.save();
+      const user = await User.findOne({ walletAddress: sender });
+      if (user) {
+        let wp = await WalletPurchase.findOne({ wallet: sender });
+        if (!wp) wp = new WalletPurchase({ wallet: sender, tpc: 0, ton: 0, last: 0 });
+        if (wp.tpc + tpc > MAX_TPC_PER_WALLET) {
+          tpc = MAX_TPC_PER_WALLET - wp.tpc;
+          if (tpc <= 0) {
+            await record.save();
+            lastTime = Math.max(lastTime, tx.utime);
+            continue;
+          }
+          record.tpc = tpc;
+        }
+        wp.tpc += tpc;
+        wp.ton += tonVal;
+        wp.last = new Date(tx.utime * 1000);
+        await wp.save();
+
+        st.tonRaised += tonVal;
+        st.tokensSold += tpc;
+        st.currentPrice = Number((st.currentPrice + PRICE_INCREASE_STEP).toFixed(9));
+        if (st.tokensSold >= round.maxTokens) {
+          st.currentRound += 1;
+          st.tokensSold = 0;
+          st.tonRaised = 0;
+          const next = PRESALE_ROUNDS[st.currentRound - 1];
+          st.currentPrice = next ? next.pricePerTPC : st.currentPrice;
+        }
+        await saveState();
+
+        ensureTransactionArray(user);
+        user.balance += tpc;
+        user.transactions.push({
+          amount: tpc,
+          type: 'presale',
+          token: 'TPC',
+          status: 'delivered',
+          date: new Date(tx.utime * 1000),
+          txHash,
+        });
+        await user.save();
+
+        record.processed = true;
+        record.accountId = user.accountId;
+      }
+      await record.save();
       lastTime = Math.max(lastTime, tx.utime);
     }
   } catch (err) {
@@ -136,7 +197,21 @@ async function processTransactions() {
   }
 }
 
+async function processPendingRecords() {
+  const records = await PresaleTransaction.find({ processed: false });
+  for (const record of records) {
+    const user = await User.findOne({ walletAddress: record.wallet });
+    if (user) {
+      await creditRecord(record, user);
+    }
+  }
+}
+
 export function startPresaleWatcher() {
   processTransactions();
   setInterval(processTransactions, 60_000);
+  processPendingRecords();
+  setInterval(processPendingRecords, 60_000);
 }
+
+export { processTransactions, processPendingRecords };

--- a/test/presaleWatcher.test.js
+++ b/test/presaleWatcher.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+import PresaleTransaction from '../bot/models/PresaleTransaction.js';
+import User from '../bot/models/User.js';
+import { processTransactions, processPendingRecords } from '../bot/presaleWatcher.js';
+
+const wallet = 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
+const txHash = 'testhash123';
+const utime = Math.floor(Date.now() / 1000);
+
+test('presale watcher stores and processes pending transactions', { concurrency: false }, async () => {
+  const mem = await MongoMemoryServer.create();
+  await mongoose.connect(mem.getUri(), { autoIndex: false });
+
+  const origFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({
+      transactions: [
+        {
+          in_msg: { source: { address: wallet }, value: '1000000000' },
+          utime,
+          hash: txHash,
+        },
+      ],
+    }),
+  });
+
+  await processTransactions();
+
+  let rec = await PresaleTransaction.findOne({ txHash });
+  assert.ok(rec, 'transaction record saved');
+  assert.equal(rec.processed, false);
+
+  const user = new User({ telegramId: 1, walletAddress: wallet });
+  await user.save();
+
+  await processPendingRecords();
+
+  rec = await PresaleTransaction.findOne({ txHash });
+  const updatedUser = await User.findOne({ walletAddress: wallet });
+  assert.ok(rec.processed, 'record processed');
+  assert.equal(rec.accountId, updatedUser.accountId);
+  assert.equal(updatedUser.balance, rec.tpc);
+
+  await mongoose.disconnect();
+  await mem.stop();
+  global.fetch = origFetch;
+});


### PR DESCRIPTION
## Summary
- add `PresaleTransaction` model for presale purchase logging
- extend presale watcher to store and process pending transactions
- periodically process unhandled presale payments
- add regression test for presale transaction processing

## Testing
- `npm test` *(fails: MongoDB index conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6887cb59b0c08329b5e67d079d7e770d