### PR TITLE
Fix invites and presale wallet normalization

### DIFF
--- a/bot/presaleWatcher.js
+++ b/bot/presaleWatcher.js
@@ -11,20 +11,14 @@ import {
   PRESALE_ROUNDS,
 } from './config.js';
 import { ensureTransactionArray } from './utils/userUtils.js';
+import { normalizeAddress } from './utils/ton.js';
 
-const STORE_ADDRESS = process.env.STORE_DEPOSIT_ADDRESS ||
+const STORE_ADDRESS =
+  process.env.STORE_DEPOSIT_ADDRESS ||
   'UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1';
 const PRESALE_ADDRESS = process.env.PRESALE_DEPOSIT_ADDRESS || STORE_ADDRESS;
 
-function normalize(addr) {
-  try {
-    return new TonWeb.utils.Address(addr).toString(true, false, false);
-  } catch {
-    return null;
-  }
-}
-
-const PRESALE_ADDRESS_NORM = normalize(PRESALE_ADDRESS);
+const PRESALE_ADDRESS_NORM = normalizeAddress(PRESALE_ADDRESS);
 
 const STATE_ID = 'singleton';
 let state = null;
@@ -121,7 +115,7 @@ async function processTransactions() {
         lastTime = Math.max(lastTime, tx.utime);
         continue;
       }
-      const sender = normalize(tx.in_msg.source.address);
+      const sender = normalizeAddress(tx.in_msg.source.address);
       if (!sender) {
         lastTime = Math.max(lastTime, tx.utime);
         continue;

--- a/bot/routes/buy.js
+++ b/bot/routes/buy.js
@@ -13,22 +13,16 @@ import WalletPurchase from '../models/WalletPurchase.js';
 import { ensureTransactionArray } from '../utils/userUtils.js';
 import { withProxy } from '../utils/proxyAgent.js';
 import TonWeb from 'tonweb';
+import { normalizeAddress } from '../utils/ton.js';
 
 const router = Router();
-const STORE_ADDRESS = process.env.STORE_DEPOSIT_ADDRESS ||
+const STORE_ADDRESS =
+  process.env.STORE_DEPOSIT_ADDRESS ||
   'UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1';
 const PRESALE_ADDRESS = process.env.PRESALE_DEPOSIT_ADDRESS || STORE_ADDRESS;
 
-function normalize(addr) {
-  try {
-    return new TonWeb.utils.Address(addr).toString(true, false, false);
-  } catch {
-    return null;
-  }
-}
-
-const STORE_ADDRESS_NORM = normalize(STORE_ADDRESS);
-const PRESALE_ADDRESS_NORM = normalize(PRESALE_ADDRESS);
+const STORE_ADDRESS_NORM = normalizeAddress(STORE_ADDRESS);
+const PRESALE_ADDRESS_NORM = normalizeAddress(PRESALE_ADDRESS);
 
 const STATE_ID = 'singleton';
 let state = null;
@@ -143,9 +137,9 @@ router.post('/claim', async (req, res) => {
     }
     const data = await resp.json();
     const out = (data.out_msgs || []).find(
-      (m) => normalize(m.destination?.address) === PRESALE_ADDRESS_NORM
+      (m) => normalizeAddress(m.destination?.address) === PRESALE_ADDRESS_NORM
     );
-    const sender = normalize(data.in_msg?.source?.address || '');
+    const sender = normalizeAddress(data.in_msg?.source?.address || '');
     if (!out) return res.status(400).json({ error: 'destination mismatch' });
     const tonVal = Number(out.value) / 1e9;
 

--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import User from '../models/User.js';
 import { fetchTelegramInfo } from '../utils/telegram.js';
 import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
+import { normalizeAddress } from '../utils/ton.js';
 
 export function parseTwitterHandle(input) {
   if (!input) return '';
@@ -32,9 +33,13 @@ router.post('/register-wallet', async (req, res) => {
   if (!walletAddress) {
     return res.status(400).json({ error: 'walletAddress required' });
   }
+  const normalized = normalizeAddress(walletAddress);
+  if (!normalized) {
+    return res.status(400).json({ error: 'invalid walletAddress' });
+  }
   const user = await User.findOneAndUpdate(
-    { walletAddress },
-    { $setOnInsert: { walletAddress, referralCode: walletAddress } },
+    { walletAddress: normalized },
+    { $setOnInsert: { walletAddress: normalized, referralCode: normalized } },
     { upsert: true, new: true, setDefaultsOnInsert: true }
   );
   res.json(user);

--- a/bot/server.js
+++ b/bot/server.js
@@ -706,6 +706,7 @@ app.post('/api/snake/invite', async (req, res) => {
 
   pendingInvites.set(roomId, {
     fromId: fromAccount,
+    fromName,
     toIds: [toAccount],
     token,
     amount,
@@ -793,6 +794,19 @@ io.on('connection', (socket) => {
     socket.data.playerId = String(playerId);
     // Mark this user as online immediately
     onlineUsers.set(String(playerId), Date.now());
+
+    for (const [roomId, invite] of pendingInvites) {
+      if (invite.toIds && invite.toIds.includes(String(playerId))) {
+        io.to(socket.id).emit('gameInvite', {
+          fromId: invite.fromId,
+          fromName: invite.fromName,
+          roomId,
+          token: invite.token,
+          amount: invite.amount,
+          game: invite.game
+        });
+      }
+    }
   });
 
   socket.on(
@@ -969,6 +983,7 @@ io.on('connection', (socket) => {
     }
     pendingInvites.set(roomId, {
       fromId,
+      fromName,
       toIds: [toId],
       token,
       amount,
@@ -989,6 +1004,7 @@ io.on('connection', (socket) => {
       }
       pendingInvites.set(roomId, {
         fromId,
+        fromName,
         toIds: [...toIds],
         token,
         amount,

--- a/bot/utils/ton.js
+++ b/bot/utils/ton.js
@@ -1,0 +1,9 @@
+import TonWeb from 'tonweb';
+
+export function normalizeAddress(addr) {
+  try {
+    return new TonWeb.utils.Address(addr).toString(true, false, false);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `normalizeAddress` helper for TON addresses
- ensure user wallet addresses are normalized when registering
- fix presale watcher and buy/store routes to use `normalizeAddress`
- persist `fromName` when storing pending invites and send pending invites on register

## Testing
- `npm test` *(fails: IndexKeySpecsConflict)*

------
https://chatgpt.com/codex/tasks/task_e_6887e5e06bac8329975f47eca0bcf81b