### PR TITLE
Fix invite acceptance handling

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -76,6 +76,14 @@ export default function Layout({ children }) {
   }, []);
 
   useEffect(() => {
+    const onAccepted = ({ roomId, token, amount, game }) => {
+      navigate(`/games/${game || 'snake'}?table=${roomId}&token=${token}&amount=${amount}`);
+    };
+    socket.on('inviteAccepted', onAccepted);
+    return () => socket.off('inviteAccepted', onAccepted);
+  }, [navigate]);
+
+  useEffect(() => {
     let id;
     let cancelled = false;
     ensureAccountId()

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -250,7 +250,7 @@ export default function Mining() {
             },
             (res) => {
               if (res && res.success) {
-                window.location.href = `/games/snake?table=${roomId}&token=${stake.token}&amount=${stake.amount}`;
+                alert('Invite sent!');
               } else {
                 alert(res?.error || 'Failed to send invite');
               }
@@ -277,14 +277,16 @@ export default function Mining() {
               fromId: accountId,
               fromName: myName,
               toIds: selected.map((u) => u.accountId),
-              opponentNames: selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim()),
+              opponentNames: selected.map((u) =>
+                u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim(),
+              ),
               roomId,
               token: stake.token,
               amount: stake.amount,
             },
             (res) => {
               if (res && res.success) {
-                window.location.href = `/games/snake?table=${roomId}&token=${stake.token}&amount=${stake.amount}`;
+                alert('Invites sent!');
               } else {
                 alert(res?.error || 'Failed to send invite');
               }


### PR DESCRIPTION
## Summary
- wait for invite acceptance before navigating to game
- alert when invites are sent instead of auto-joining
- open game for sender when invite is accepted

## Testing
- `npm run install-all`
- `npm test` *(fails: IndexKeySpecsConflict but tests completed)*

------
https://chatgpt.com/codex/tasks/task_e_688861c55a048329a21db2e1f827ed24