### PR TITLE
Add optional auto claim for presale purchases

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The server honors a few extra environment variables when building or serving the
 - `SKIP_WEBAPP_BUILD` – set to any value to skip the automatic webapp build that normally runs when `npm start` is executed. Useful if you built the assets manually.
 - `ALLOWED_ORIGINS` – list of origins allowed for CORS and socket.io when serving the API. Separate multiple origins with commas.
 - `ENABLE_PRESALE_WATCHER` – set to `false` to disable automatic crediting of presale purchases. When enabled (default), the backend polls the store address every minute and credits TPC as soon as the payment appears on-chain. Manual hash claims are rarely needed unless the watcher is disabled or cannot reach the TON API.
+- `PRESALE_AUTO_CLAIM` – set to `true` to automatically claim TPC on-chain when a presale transaction is processed. Requires `CLAIM_CONTRACT_ADDRESS` and `CLAIM_WALLET_MNEMONIC`.
 
 5. Copy `scripts/.env.example` to `scripts/.env` and set:
    - `MNEMONIC` – wallet seed phrase used to deploy the Jetton

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -50,3 +50,6 @@ CLAIM_WALLET_MNEMONIC=
 # Jetton root address used to import TPC in wallets
 TPC_JETTON_ADDRESS=EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X
 
+# Set to true to automatically claim presale purchases on-chain
+PRESALE_AUTO_CLAIM=false
+

--- a/bot/presaleWatcher.js
+++ b/bot/presaleWatcher.js
@@ -3,6 +3,7 @@ import User from './models/User.js';
 import WalletPurchase from './models/WalletPurchase.js';
 import PresaleTransaction from './models/PresaleTransaction.js';
 import { withProxy } from './utils/proxyAgent.js';
+import tonClaim from './utils/tonClaim.js';
 import {
   MAX_TPC_PER_WALLET,
   INITIAL_PRICE,
@@ -19,6 +20,8 @@ const PRESALE_ADDRESS = process.env.PRESALE_DEPOSIT_ADDRESS || STORE_ADDRESS;
 const PRESALE_ADDRESS_API = normalizeAddress(PRESALE_ADDRESS);
 
 const PRESALE_ADDRESS_NORM = normalizeAddress(PRESALE_ADDRESS);
+
+const AUTO_CLAIM = process.env.PRESALE_AUTO_CLAIM === 'true';
 
 const STATE_ID = 'singleton';
 let state = null;
@@ -91,6 +94,15 @@ async function creditRecord(record, user) {
     txHash: record.txHash,
   });
   await user.save();
+
+  if (AUTO_CLAIM) {
+    const toAddress = record.wallet || user.walletAddress;
+    try {
+      await tonClaim(toAddress, tpc);
+    } catch (err) {
+      console.error('Presale auto claim failed:', err.message);
+    }
+  }
 
   record.processed = true;
   record.accountId = user.accountId;


### PR DESCRIPTION
## Summary
- add `PRESALE_AUTO_CLAIM` environment flag
- support automatic on-chain transfer in presale watcher when enabled
- document new variable in README and `.env.example`

## Testing
- `npm run lint`
- `npm test` *(fails: tests did not finish in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_688869c2fab48329a993481588c093cd