### PR TITLE
Ensure presale credits on profile actions

### DIFF
--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import User from '../models/User.js';
 import { fetchTelegramInfo } from '../utils/telegram.js';
 import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
+import { creditPendingPresale } from '../utils/presaleUtils.js';
 import { normalizeAddress } from '../utils/ton.js';
 
 export function parseTwitterHandle(input) {
@@ -42,6 +43,7 @@ router.post('/register-wallet', async (req, res) => {
     { $setOnInsert: { walletAddress: normalized, referralCode: normalized } },
     { upsert: true, new: true, setDefaultsOnInsert: true }
   );
+  await creditPendingPresale(user);
   res.json(user);
 });
 
@@ -114,6 +116,8 @@ router.post('/get', async (req, res) => {
     user.accountId = uuidv4();
     await user.save();
   }
+
+  await creditPendingPresale(user);
 
   ensureTransactionArray(user);
   if (!Array.isArray(user.gifts)) user.gifts = [];

--- a/bot/utils/presaleUtils.js
+++ b/bot/utils/presaleUtils.js
@@ -1,0 +1,70 @@
+import PresaleTransaction from '../models/PresaleTransaction.js';
+import PresaleState from '../models/PresaleState.js';
+import WalletPurchase from '../models/WalletPurchase.js';
+import { MAX_TPC_PER_WALLET, PRICE_INCREASE_STEP, PRESALE_ROUNDS } from '../config.js';
+import { ensureTransactionArray } from './userUtils.js';
+
+async function loadState() {
+  const st = await PresaleState.findById('singleton');
+  return st;
+}
+
+async function saveState(state) {
+  if (state) await state.save();
+}
+
+export async function creditPendingPresale(user) {
+  if (!user?.walletAddress) return;
+  const wallet = user.walletAddress;
+  const records = await PresaleTransaction.find({ wallet, processed: false });
+  if (!records.length) return;
+
+  let state = await loadState();
+  for (const rec of records) {
+    let tpc = rec.tpc;
+    const tonVal = rec.ton;
+    const round = PRESALE_ROUNDS[state.currentRound - 1];
+    if (!round) continue;
+    let wp = await WalletPurchase.findOne({ wallet });
+    if (!wp) wp = new WalletPurchase({ wallet, tpc: 0, ton: 0, last: 0 });
+    if (wp.tpc + tpc > MAX_TPC_PER_WALLET) {
+      tpc = MAX_TPC_PER_WALLET - wp.tpc;
+      if (tpc <= 0) {
+        rec.processed = true;
+        await rec.save();
+        continue;
+      }
+      rec.tpc = tpc;
+    }
+    wp.tpc += tpc;
+    wp.ton += tonVal;
+    wp.last = rec.timestamp;
+    await wp.save();
+
+    state.tonRaised += tonVal;
+    state.tokensSold += tpc;
+    state.currentPrice = Number((state.currentPrice + PRICE_INCREASE_STEP).toFixed(9));
+    if (state.tokensSold >= round.maxTokens) {
+      state.currentRound += 1;
+      state.tokensSold = 0;
+      state.tonRaised = 0;
+      const next = PRESALE_ROUNDS[state.currentRound - 1];
+      state.currentPrice = next ? next.pricePerTPC : state.currentPrice;
+    }
+    ensureTransactionArray(user);
+    user.balance += tpc;
+    user.transactions.push({
+      amount: tpc,
+      type: 'presale',
+      token: 'TPC',
+      status: 'delivered',
+      date: rec.timestamp,
+      txHash: rec.txHash,
+    });
+    rec.processed = true;
+    rec.accountId = user.accountId;
+    await rec.save();
+  }
+  await saveState(state);
+  await user.save();
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-promise": "^6.6.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "mongodb-memory-server": "^10.1.4"
   }
 }


### PR DESCRIPTION
## Summary
- add helper to process pending presale transactions
- credit pending presale records when registering a wallet or fetching profile
- include `mongodb-memory-server` in root devDependencies

## Testing
- `npm run lint`
- `node --test test/presaleWatcher.test.js` *(fails: Operation `presaletransactions.findOne()` buffering timed out)*


------
https://chatgpt.com/codex/tasks/task_e_688876faef248329941885970a3bb7af