### PR TITLE
Fix invite popup layering

### DIFF
--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -13,7 +13,7 @@ export default function InvitePopup({
 }) {
   if (!open) return null;
   return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70 pointer-events-auto">
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black bg-opacity-70 pointer-events-auto">
       <div className="bg-surface border border-border rounded p-4 space-y-4 text-text w-72">
         {incoming ? (
           <p className="text-center">


### PR DESCRIPTION
## Summary
- bump invite popup z-index so it isn't hidden by other UI layers

## Testing
- `npm test` *(fails: EADDRINUSE and joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_68889c51b4008329880bcc656b6f9c8d