### PR TITLE
Remove priceIncreaseStep logic

### DIFF
--- a/bot/presaleWatcher.js
+++ b/bot/presaleWatcher.js
@@ -6,7 +6,6 @@ import { withProxy } from './utils/proxyAgent.js';
 import {
   MAX_TPC_PER_WALLET,
   INITIAL_PRICE,
-  PRICE_INCREASE_STEP,
   PRESALE_ROUNDS,
 } from './config.js';
 import { ensureTransactionArray } from './utils/userUtils.js';
@@ -70,14 +69,13 @@ async function creditRecord(record, user) {
 
   st.tonRaised += tonVal;
   st.tokensSold += tpc;
-  st.currentPrice = Number((st.currentPrice + PRICE_INCREASE_STEP).toFixed(9));
   if (st.tokensSold >= round.maxTokens) {
     st.currentRound += 1;
     st.tokensSold = 0;
     st.tonRaised = 0;
-    const next = PRESALE_ROUNDS[st.currentRound - 1];
-    st.currentPrice = next ? next.pricePerTPC : st.currentPrice;
   }
+  const nextRound = PRESALE_ROUNDS[st.currentRound - 1];
+  st.currentPrice = nextRound ? nextRound.pricePerTPC : st.currentPrice;
   await saveState();
 
   ensureTransactionArray(user);
@@ -158,14 +156,13 @@ async function processTransactions() {
 
         st.tonRaised += tonVal;
         st.tokensSold += tpc;
-        st.currentPrice = Number((st.currentPrice + PRICE_INCREASE_STEP).toFixed(9));
         if (st.tokensSold >= round.maxTokens) {
           st.currentRound += 1;
           st.tokensSold = 0;
           st.tonRaised = 0;
-          const next = PRESALE_ROUNDS[st.currentRound - 1];
-          st.currentPrice = next ? next.pricePerTPC : st.currentPrice;
         }
+        const nextRound = PRESALE_ROUNDS[st.currentRound - 1];
+        st.currentPrice = nextRound ? nextRound.pricePerTPC : st.currentPrice;
         await saveState();
 
         ensureTransactionArray(user);

--- a/bot/utils/presaleUtils.js
+++ b/bot/utils/presaleUtils.js
@@ -1,7 +1,7 @@
 import PresaleTransaction from '../models/PresaleTransaction.js';
 import PresaleState from '../models/PresaleState.js';
 import WalletPurchase from '../models/WalletPurchase.js';
-import { MAX_TPC_PER_WALLET, PRICE_INCREASE_STEP, PRESALE_ROUNDS } from '../config.js';
+import { MAX_TPC_PER_WALLET, PRESALE_ROUNDS } from '../config.js';
 import { ensureTransactionArray } from './userUtils.js';
 
 async function loadState() {
@@ -43,14 +43,13 @@ export async function creditPendingPresale(user) {
 
     state.tonRaised += tonVal;
     state.tokensSold += tpc;
-    state.currentPrice = Number((state.currentPrice + PRICE_INCREASE_STEP).toFixed(9));
     if (state.tokensSold >= round.maxTokens) {
       state.currentRound += 1;
       state.tokensSold = 0;
       state.tonRaised = 0;
-      const next = PRESALE_ROUNDS[state.currentRound - 1];
-      state.currentPrice = next ? next.pricePerTPC : state.currentPrice;
     }
+    const nextRound = PRESALE_ROUNDS[state.currentRound - 1];
+    state.currentPrice = nextRound ? nextRound.pricePerTPC : state.currentPrice;
     ensureTransactionArray(user);
     user.balance += tpc;
     user.transactions.push({

--- a/webapp/src/utils/storeData.js
+++ b/webapp/src/utils/storeData.js
@@ -2,11 +2,6 @@ export const STORE_ADDRESS = 'UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1';
 // Address used for presale purchases, defaults to STORE_ADDRESS
 export const PRESALE_ADDRESS = STORE_ADDRESS;
 
-// Dynamic pricing configuration for the presale
-export const initialPrice = 0.000004; // TON per 1 TPC
-export let currentPrice = initialPrice;
-export const priceIncreaseStep = 0.0000001; // TON added after each purchase
-
 // Presale launch date (UTC)
 export const PRESALE_START = new Date();
 


### PR DESCRIPTION
## Summary
- rely on fixed presale round pricing
- report round price in buy API endpoints
- simplify store data to round prices only

## Testing
- `npm test` *(fails: IndexKeySpecsConflict but tests proceed)*

------
https://chatgpt.com/codex/tasks/task_e_6888b722576c8329a7c43a7d2b8c529a