### PR TITLE
Restore snake lobby invites

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -359,15 +359,13 @@ export class GameRoomManager {
         snakes: Object.fromEntries(doc.snakes),
         ladders: Object.fromEntries(doc.ladders)
       }, doc.gameType || 'snake');
-      // Start with an empty room so stale player counts don't persist
-      room.players = [];
-      room.currentTurn = 0;
-      room.status = 'waiting';
-      // Clear any stored players from the database as well
-      await GameRoomModel.updateOne(
-        { roomId: doc.roomId },
-        { players: [], currentTurn: 0, status: 'waiting' }
-      ).catch(() => {});
+      room.players = doc.players.map((p) => ({
+        ...p.toObject(),
+        socketId: null,
+        lastRollTime: 0
+      }));
+      room.currentTurn = doc.currentTurn;
+      room.status = doc.status;
       this.rooms.set(room.id, room);
     }
   }

--- a/webapp/src/hooks/useTelegramAuth.js
+++ b/webapp/src/hooks/useTelegramAuth.js
@@ -1,25 +1,16 @@
 import { useEffect } from 'react';
 import { socket } from '../utils/socket.js';
-import { ensureAccountId } from '../utils/telegram.js';
 
 export default function useTelegramAuth() {
   useEffect(() => {
-    let accountId;
     const user = window?.Telegram?.WebApp?.initDataUnsafe?.user;
-    ensureAccountId()
-      .then((acc) => {
-        accountId = acc;
-        if (acc) {
-          socket.emit('register', { accountId: acc });
-        }
-      })
-      .catch(() => {});
-
-    const onConnect = () => {
-      if (accountId) socket.emit('register', { accountId });
-    };
-    socket.on('connect', onConnect);
-
+    const acc = localStorage.getItem('accountId');
+    if (user?.id) {
+      localStorage.setItem('telegramId', user.id);
+      socket.emit('register', { playerId: acc || user.id });
+    } else if (acc) {
+      socket.emit('register', { playerId: acc });
+    }
     if (user?.username) {
       localStorage.setItem('telegramUsername', user.username);
     }
@@ -32,9 +23,5 @@ export default function useTelegramAuth() {
     if (user) {
       localStorage.setItem('telegramUserData', JSON.stringify(user));
     }
-
-    return () => {
-      socket.off('connect', onConnect);
-    };
   }, []);
 }

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -18,22 +18,17 @@ export function getPlayerId() {
     const aid = localStorage.getItem('accountId');
     if (aid) return aid;
   }
-  return null;
+  return getTelegramId();
 }
 
 export async function ensureAccountId() {
   if (typeof window === 'undefined') return null;
   let id = localStorage.getItem('accountId');
-  if (id) return id;
-  const tgId = getTelegramId();
-  try {
-    const res = await createAccount(tgId);
-    if (res && res.accountId) {
-      localStorage.setItem('accountId', res.accountId);
-      return res.accountId;
-    }
-  } catch {}
-  return null;
+  if (!id) {
+    id = crypto.randomUUID();
+    localStorage.setItem('accountId', id);
+  }
+  return id;
 }
 
 export function getTelegramUsername() {


### PR DESCRIPTION
## Summary
- revert lobby logic to restore 1v1 tracking and group invites
- restore seating logic and lobby updates
- bring back simple Telegram account auth

## Testing
- `npm test` *(fails: npm had warnings and test suite didn't finish)*

------
https://chatgpt.com/codex/tasks/task_e_6888f5b8f7d483299e9e8c245394d72c