### PR TITLE
Fix invite sound

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -5,6 +5,7 @@ import { socket } from '../utils/socket.js';
 import { pingOnline } from '../utils/api.js';
 import { getPlayerId } from '../utils/telegram.js';
 import { isGameMuted, getGameVolume } from '../utils/sound.js';
+import { chatBeep } from '../assets/soundData.js';
 import InvitePopup from './InvitePopup.jsx';
 
 import Navbar from './Navbar.jsx';
@@ -24,7 +25,7 @@ export default function Layout({ children }) {
   const beepRef = useRef(null);
 
   useEffect(() => {
-    beepRef.current = new Audio('/assets/sounds/successful.mp3');
+    beepRef.current = new Audio(chatBeep);
     beepRef.current.volume = getGameVolume();
     beepRef.current.muted = isGameMuted();
     const volumeHandler = () => {


### PR DESCRIPTION
## Summary
- hook up chatBeep sound for game invites

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_6888fe3205788329b9551974f4894525