### PR TITLE
Validate table selection in Snake and Ladder

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1203,7 +1203,9 @@ export default function SnakeAndLadder() {
     setPlayerColors(colors);
 
     const storedTable = localStorage.getItem('snakeCurrentTable');
-    const table = params.get("table") || storedTable || "snake-4";
+    const tableParam = params.get("table") || storedTable || "snake-4";
+    const validTables = new Set(["snake-2", "snake-3", "snake-4"]);
+    const table = validTables.has(tableParam) ? tableParam : "snake-4";
     setTableId(table);
     localStorage.setItem('snakeCurrentTable', table);
     const boardPromise = isMultiplayer


### PR DESCRIPTION
## Summary
- validate table id so only known capacities are allowed

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688909beda048329a82e3de61eb1ef8c