### PR TITLE
Reduce TPC rewards for store bundles

### DIFF
--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -29,19 +29,19 @@ function daysFromNow(days) {
 }
 
 export const BUNDLES = {
-  newbie: { tpc: 50000, ton: 0.2, label: 'Newbie Pack' },
-  rookie: { tpc: 100000, ton: 0.35, label: 'Rookie' },
-  starter: { tpc: 200000, ton: 0.6, label: 'Starter' },
-  miner: { tpc: 400000, ton: 1.2, label: 'Miner Pack', boost: 0.03 },
-  grinder: { tpc: 750000, ton: 2.0, label: 'Grinder', boost: 0.05 },
-  pro: { tpc: 1500000, ton: 3.8, label: 'Pro Bundle', boost: 0.08 },
-  whale: { tpc: 4000000, ton: 9.0, label: 'Whale Bundle', boost: 0.12 },
-  max: { tpc: 8000000, ton: 18.0, label: 'Max Bundle', boost: 0.15 },
+  newbie: { tpc: 20000, ton: 0.2, label: 'Newbie Pack' },
+  rookie: { tpc: 40000, ton: 0.35, label: 'Rookie' },
+  starter: { tpc: 80000, ton: 0.6, label: 'Starter' },
+  miner: { tpc: 160000, ton: 1.2, label: 'Miner Pack', boost: 0.03 },
+  grinder: { tpc: 300000, ton: 2.0, label: 'Grinder', boost: 0.05 },
+  pro: { tpc: 600000, ton: 3.8, label: 'Pro Bundle', boost: 0.08 },
+  whale: { tpc: 1600000, ton: 9.0, label: 'Whale Bundle', boost: 0.12 },
+  max: { tpc: 3200000, ton: 18.0, label: 'Max Bundle', boost: 0.15 },
 
   // Spin & Win Bundles
-  luckyStarter: { tpc: 6000, ton: 0.15, label: 'Lucky Starter' },
-  spinx3: { tpc: 12000, ton: 0.25, label: 'Spin x3 Pack' },
-  megaSpin: { tpc: 30000, ton: 0.7, label: 'Mega Spin Pack' },
+  luckyStarter: { tpc: 2400, ton: 0.15, label: 'Lucky Starter' },
+  spinx3: { tpc: 4800, ton: 0.25, label: 'Spin x3 Pack' },
+  megaSpin: { tpc: 12000, ton: 0.7, label: 'Mega Spin Pack' },
 
   // Virtual Friends
   lazyLarry: { tpc: 0, ton: 0.1, label: 'Lazy Larry', boost: 0.25, duration: 7 },
@@ -49,9 +49,9 @@ export const BUNDLES = {
   grindBot: { tpc: 0, ton: 0.5, label: 'GrindBot3000', boost: 1.25, duration: 14 },
 
   // Bonus Bundles
-  powerPack: { tpc: 10000, ton: 0.25, label: 'Power Pack', boost: 0.5, duration: 3 },
-  proPack: { tpc: 25000, ton: 0.4, label: 'Pro Pack', boost: 0.5, duration: 7 },
-  galaxyPack: { tpc: 60000, ton: 1.0, label: 'Galaxy Pack', boost: 1.25, duration: 7 },
+  powerPack: { tpc: 4000, ton: 0.25, label: 'Power Pack', boost: 0.5, duration: 3 },
+  proPack: { tpc: 10000, ton: 0.4, label: 'Pro Pack', boost: 0.5, duration: 7 },
+  galaxyPack: { tpc: 24000, ton: 1.0, label: 'Galaxy Pack', boost: 1.25, duration: 7 },
 };
 
 router.post('/purchase', authenticate, async (req, res) => {

--- a/webapp/src/utils/storeData.js
+++ b/webapp/src/utils/storeData.js
@@ -8,19 +8,19 @@ export const STORE_CATEGORIES = [
 ];
 
 export const STORE_BUNDLES = [
-  { id: 'newbie', name: 'Newbie Pack', icon: '🌱', tpc: 50000, ton: 0.2, boost: 0, category: 'Bundles' },
-  { id: 'rookie', name: 'Rookie', icon: '🎯', tpc: 100000, ton: 0.35, boost: 0, category: 'Bundles' },
-  { id: 'starter', name: 'Starter', icon: '🚀', tpc: 200000, ton: 0.6, boost: 0, category: 'Bundles' },
-  { id: 'miner', name: 'Miner Pack', icon: '⛏️', tpc: 400000, ton: 1.2, boost: 0.03, category: 'Bundles' },
-  { id: 'grinder', name: 'Grinder', icon: '⚙️', tpc: 750000, ton: 2.0, boost: 0.05, category: 'Bundles' },
-  { id: 'pro', name: 'Pro Bundle', icon: '🏆', tpc: 1500000, ton: 3.8, boost: 0.08, category: 'Bundles' },
-  { id: 'whale', name: 'Whale Bundle', icon: '🐋', tpc: 4000000, ton: 9.0, boost: 0.12, category: 'Bundles' },
-  { id: 'max', name: 'Max Bundle', icon: '👑', tpc: 8000000, ton: 18.0, boost: 0.15, category: 'Bundles' },
+  { id: 'newbie', name: 'Newbie Pack', icon: '🌱', tpc: 20000, ton: 0.2, boost: 0, category: 'Bundles' },
+  { id: 'rookie', name: 'Rookie', icon: '🎯', tpc: 40000, ton: 0.35, boost: 0, category: 'Bundles' },
+  { id: 'starter', name: 'Starter', icon: '🚀', tpc: 80000, ton: 0.6, boost: 0, category: 'Bundles' },
+  { id: 'miner', name: 'Miner Pack', icon: '⛏️', tpc: 160000, ton: 1.2, boost: 0.03, category: 'Bundles' },
+  { id: 'grinder', name: 'Grinder', icon: '⚙️', tpc: 300000, ton: 2.0, boost: 0.05, category: 'Bundles' },
+  { id: 'pro', name: 'Pro Bundle', icon: '🏆', tpc: 600000, ton: 3.8, boost: 0.08, category: 'Bundles' },
+  { id: 'whale', name: 'Whale Bundle', icon: '🐋', tpc: 1600000, ton: 9.0, boost: 0.12, category: 'Bundles' },
+  { id: 'max', name: 'Max Bundle', icon: '👑', tpc: 3200000, ton: 18.0, boost: 0.15, category: 'Bundles' },
 
   // Spin & Win Bundles
-  { id: 'luckyStarter', name: 'Lucky Starter', icon: '🎁', tpc: 6000, ton: 0.15, spins: 3, category: 'Spin & Win' },
-  { id: 'spinx3', name: 'Spin x3 Pack', icon: '🔁', tpc: 12000, ton: 0.25, spins: 5, category: 'Spin & Win' },
-  { id: 'megaSpin', name: 'Mega Spin Pack', icon: '💎', tpc: 30000, ton: 0.7, spins: 15, category: 'Spin & Win' },
+  { id: 'luckyStarter', name: 'Lucky Starter', icon: '🎁', tpc: 2400, ton: 0.15, spins: 3, category: 'Spin & Win' },
+  { id: 'spinx3', name: 'Spin x3 Pack', icon: '🔁', tpc: 4800, ton: 0.25, spins: 5, category: 'Spin & Win' },
+  { id: 'megaSpin', name: 'Mega Spin Pack', icon: '💎', tpc: 12000, ton: 0.7, spins: 15, category: 'Spin & Win' },
 
   // Virtual Friends (Mining Boosters)
   { id: 'lazyLarry', name: 'Lazy Larry', icon: '🐣', tpc: 0, ton: 0.1, boost: 0.25, duration: 7, category: 'Virtual Friends' },
@@ -28,7 +28,7 @@ export const STORE_BUNDLES = [
   { id: 'grindBot', name: 'GrindBot3000', icon: '🤖', tpc: 0, ton: 0.5, boost: 1.25, duration: 14, category: 'Virtual Friends' },
 
   // Bonus Bundles
-  { id: 'powerPack', name: 'Power Pack', icon: '⚡', tpc: 10000, ton: 0.25, boost: 0.5, duration: 3, category: 'Bonus Bundles' },
-  { id: 'proPack', name: 'Pro Pack', icon: '🎯', tpc: 25000, ton: 0.4, spins: 3, boost: 0.5, duration: 7, category: 'Bonus Bundles' },
-  { id: 'galaxyPack', name: 'Galaxy Pack', icon: '🚀', tpc: 60000, ton: 1.0, spins: 5, boost: 1.25, duration: 7, category: 'Bonus Bundles' }
+  { id: 'powerPack', name: 'Power Pack', icon: '⚡', tpc: 4000, ton: 0.25, boost: 0.5, duration: 3, category: 'Bonus Bundles' },
+  { id: 'proPack', name: 'Pro Pack', icon: '🎯', tpc: 10000, ton: 0.4, spins: 3, boost: 0.5, duration: 7, category: 'Bonus Bundles' },
+  { id: 'galaxyPack', name: 'Galaxy Pack', icon: '🚀', tpc: 24000, ton: 1.0, spins: 5, boost: 1.25, duration: 7, category: 'Bonus Bundles' }
 ];


### PR DESCRIPTION
## Summary
- decrease TPC rewards in `BUNDLES` server-side
- mirror new bundle amounts in the web app data

## Testing
- `npm test` *(fails: `joinRoom waits until table full`)*

------
https://chatgpt.com/codex/tasks/task_e_6889179090a8832996ee26a7ddda8a2d