### PR TITLE
Add real-time Snake & Ladder example

### DIFF
--- a/examples/realtime-snake/ReactClient.jsx
+++ b/examples/realtime-snake/ReactClient.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import { io } from 'socket.io-client';
+
+const socket = io('http://localhost:3000');
+
+export default function ReactClient({
+  roomId = 'room1',
+  playerName = 'Player'
+}) {
+  const [state, setState] = useState(null);
+
+  useEffect(() => {
+    socket.emit('joinRoom', { roomId, name: playerName });
+    socket.on('gameStateUpdate', (game) => setState(game));
+    return () => {
+      socket.off('gameStateUpdate');
+    };
+  }, [roomId, playerName]);
+
+  const rollDice = () => socket.emit('rollDice', { roomId });
+
+  if (!state) return <div>Loading...</div>;
+
+  const me = socket.id;
+  const current = state.players[state.currentPlayer]?.id;
+
+  return (
+    <div>
+      <h3>Room: {state.roomId}</h3>
+      <p>Current Player: {current}</p>
+      <p>Last Dice Roll: {state.diceRoll}</p>
+      <ul>
+        {state.players.map((p) => (
+          <li key={p.id}>
+            {p.name}: {p.position}
+          </li>
+        ))}
+      </ul>
+      <button onClick={rollDice} disabled={me !== current || state.winner}>
+        Roll Dice
+      </button>
+      {state.winner && <p>Winner: {state.winner}</p>}
+    </div>
+  );
+}

--- a/examples/realtime-snake/gameLogic.js
+++ b/examples/realtime-snake/gameLogic.js
@@ -1,0 +1,76 @@
+export const BOARD_SIZE = 100;
+
+export const DEFAULT_SNAKES = {
+  16: 6,
+  48: 26,
+  49: 11,
+  56: 53,
+  62: 19,
+  64: 60,
+  87: 24,
+  93: 73,
+  95: 75,
+  98: 78
+};
+
+export const DEFAULT_LADDERS = {
+  1: 38,
+  4: 14,
+  9: 31,
+  21: 42,
+  28: 84,
+  36: 44,
+  51: 67,
+  71: 91,
+  80: 100
+};
+
+export class Game {
+  constructor(roomId) {
+    this.roomId = roomId;
+    this.players = [];
+    this.currentPlayer = 0;
+    this.diceRoll = null;
+    this.snakes = { ...DEFAULT_SNAKES };
+    this.ladders = { ...DEFAULT_LADDERS };
+    this.winner = null;
+  }
+
+  addPlayer(id, name) {
+    if (this.players.length >= 4) return null;
+    const existing = this.players.find((p) => p.id === id);
+    if (existing) return existing;
+    const player = { id, name, position: 0 };
+    this.players.push(player);
+    return player;
+  }
+
+  rollDice(playerId) {
+    if (this.winner) return;
+    const current = this.players[this.currentPlayer];
+    if (!current || current.id !== playerId) return;
+    const value = Math.floor(Math.random() * 6) + 1;
+    this.diceRoll = value;
+    let newPos = current.position + value;
+    if (newPos > BOARD_SIZE) newPos = current.position;
+    newPos = this.snakes[newPos] || this.ladders[newPos] || newPos;
+    current.position = newPos;
+    if (newPos === BOARD_SIZE) {
+      this.winner = current.id;
+    } else {
+      this.currentPlayer = (this.currentPlayer + 1) % this.players.length;
+    }
+  }
+
+  getState() {
+    return {
+      roomId: this.roomId,
+      players: this.players,
+      currentPlayer: this.currentPlayer,
+      diceRoll: this.diceRoll,
+      snakes: this.snakes,
+      ladders: this.ladders,
+      winner: this.winner
+    };
+  }
+}

--- a/examples/realtime-snake/server.js
+++ b/examples/realtime-snake/server.js
@@ -1,0 +1,38 @@
+import express from 'express';
+import http from 'http';
+import { Server } from 'socket.io';
+import { Game } from './gameLogic.js';
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server, { cors: { origin: '*' } });
+
+const games = new Map();
+
+function getGame(roomId) {
+  if (!games.has(roomId)) {
+    games.set(roomId, new Game(roomId));
+  }
+  return games.get(roomId);
+}
+
+io.on('connection', (socket) => {
+  socket.on('joinRoom', ({ roomId, name }) => {
+    const game = getGame(roomId);
+    game.addPlayer(socket.id, name || 'Player');
+    socket.join(roomId);
+    io.to(roomId).emit('gameStateUpdate', game.getState());
+  });
+
+  socket.on('rollDice', ({ roomId }) => {
+    const game = games.get(roomId);
+    if (!game) return;
+    game.rollDice(socket.id);
+    io.to(roomId).emit('gameStateUpdate', game.getState());
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Game server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a small Socket.IO game server example
- include game logic module
- add React client showing how to sync board state

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_68891e33ff6c83298be358062531aa98