### PR TITLE
Fix default table selection in snake lobby

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -101,6 +101,12 @@ export default function Lobby() {
   }, [game]);
 
   useEffect(() => {
+    if (game === 'snake' && !table && tables.length) {
+      setTable(tables[0]);
+    }
+  }, [game, tables, table]);
+
+  useEffect(() => {
     let cancelled = false;
     let interval;
     ensureAccountId()


### PR DESCRIPTION
## Summary
- auto-select the first table in snake lobby once lobbies load

## Testing
- `npm test` *(fails: canvas build error)*

------
https://chatgpt.com/codex/tasks/task_e_6889be5a7c0c832987669f7bced84221