### PR TITLE
Make ad modal fullscreen

### DIFF
--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -37,22 +37,20 @@ export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text w-80 relative">
+      <div className="relative w-full h-full">
         {onClose && (
           <button
             onClick={onClose}
-            className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"
+            className="absolute top-2 right-2 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"
           >
             &times;
           </button>
         )}
-        <h3 className="text-lg font-bold">Watch Ad</h3>
         <div
           id="adsgram-player"
           ref={containerRef}
-          className="w-full h-40 bg-black"
+          className="w-full h-full bg-black"
         />
-        <p className="text-sm text-subtext">Watch the ad completely to unlock the spin.</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- resize video ad popup so it fills the screen

## Testing
- `npm test` *(fails: should receive error when table not full)*

------
https://chatgpt.com/codex/tasks/task_e_6889c7075f208329860a667843228fcb