### PR TITLE
Fix snake lobby confirmation flow

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -269,8 +269,7 @@ export default function Lobby() {
       table?.id === 'single' &&
       aiType === 'flags' &&
       flags.length !== aiCount) ||
-    confirmed ||
-    waitingForPlayers;
+    confirmed;
 
   return (
     <div className="relative p-4 space-y-4 text-text">
@@ -358,17 +357,12 @@ export default function Lobby() {
         disabled={disabled}
         className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded disabled:opacity-50"
       >
-        {waitingForPlayers
-          ? `Waiting for ${table.capacity - players.length} more player${
-              table.capacity - players.length === 1 ? '' : 's'
-            }...`
-          : confirmed
-            ? 'Waiting for others...'
-            : 'Confirm'}
+        {confirmed ? 'Waiting for others...' : 'Confirm'}
       </button>
-      {confirmed && !waitingForPlayers && (
+      {confirmed && (
         <p className="text-center text-sm text-subtext">
-          Waiting for others...
+          Waiting for {table.capacity - players.length} more player
+          {table.capacity - players.length === 1 ? '' : 's'}...
         </p>
       )}
       <LeaderPickerModal

--- a/webapp/src/utils/lobby.js
+++ b/webapp/src/utils/lobby.js
@@ -4,8 +4,11 @@ export function canStartGame(game, table, stake, aiCount = 0, players = 0) {
     return aiCount > 0;
   }
   if (game === 'snake' && table && table.id !== 'single') {
+    // Allow players to confirm their readiness even if the table is not yet
+    // full. The server will begin the match once all participants have
+    // confirmed, so we don't enforce player count here.
     const capacity = table.capacity || 0;
-    if (players !== capacity) return false;
+    if (capacity <= 0) return false;
   }
   if (!stake || !stake.token || !stake.amount) return false;
   if (game === 'snake' && !table) return false;


### PR DESCRIPTION
## Summary
- allow confirming snake matches before table is full
- simplify button messaging on the snake lobby

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_6889c66b8a688329b21fe9dac5937187