### PR TITLE
Handle ad completion

### DIFF
--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -23,11 +23,22 @@ export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
     const container = containerRef.current;
     container.appendChild(iframe);
 
+    const handleMessage = (e: MessageEvent) => {
+      if (
+        e.origin.includes('profitableratecpm.com') &&
+        (e.data === 'complete' || e.data === 'adComplete')
+      ) {
+        onComplete();
+      }
+    };
+    window.addEventListener('message', handleMessage);
+
     const timer = setTimeout(() => {
       onComplete();
-    }, 30000);
+    }, 40000);
 
     return () => {
+      window.removeEventListener('message', handleMessage);
       clearTimeout(timer);
       iframe.remove();
     };


### PR DESCRIPTION
## Summary
- auto-close ad modal when video finishes via postMessage
- add fallback timeout for ad completion

## Testing
- `npm test` *(fails: AssertionError in lobby tests)*

------
https://chatgpt.com/codex/tasks/task_e_6889ca96e1488329958382dba8cc636a