### PR TITLE
Fix snake-ladder example server dependencies and cleanup

### DIFF
--- a/examples/snake-ladder/README.md
+++ b/examples/snake-ladder/README.md
@@ -5,8 +5,16 @@ how to synchronize game state across multiple players.
 
 ## Running the server
 
+Install dependencies once in the repository root:
+
 ```
-node server.js
+npm install
+```
+
+Then start the example server:
+
+```
+node examples/snake-ladder/server.js
 ```
 
 ## Using the React client

--- a/examples/snake-ladder/gameLogic.js
+++ b/examples/snake-ladder/gameLogic.js
@@ -45,6 +45,24 @@ export class Game {
     return player;
   }
 
+  removePlayer(id) {
+    const index = this.players.findIndex((p) => p.id === id);
+    if (index === -1) return false;
+    this.players.splice(index, 1);
+    if (this.players.length === 0) {
+      this.currentPlayer = 0;
+      this.winner = null;
+    } else {
+      if (this.currentPlayer >= this.players.length) {
+        this.currentPlayer = 0;
+      }
+      if (this.winner === id) {
+        this.winner = null;
+      }
+    }
+    return true;
+  }
+
   rollDice(playerId) {
     if (this.winner) return;
     const current = this.players[this.currentPlayer];

--- a/examples/snake-ladder/server.js
+++ b/examples/snake-ladder/server.js
@@ -30,6 +30,14 @@ io.on('connection', (socket) => {
     game.rollDice(socket.id);
     io.to(roomId).emit('gameStateUpdate', game.getState());
   });
+
+  socket.on('disconnect', () => {
+    games.forEach((game, id) => {
+      if (game.removePlayer(socket.id)) {
+        io.to(id).emit('gameStateUpdate', game.getState());
+      }
+    });
+  });
 });
 
 const PORT = process.env.PORT || 3000;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "emoji-name-map": "^2.0.3",
     "geoip-lite": "^1.4.10",
     "mongoose": "^7.6.0",
+    "express": "^4.19.2",
+    "socket.io": "^4.7.5",
     "socket.io-client": "^4.8.1",
     "ton": "^13.9.0",
     "ton-core": "^0.53.0",


### PR DESCRIPTION
## Summary
- add `express` and `socket.io` deps
- handle player disconnects in the example server
- support removing players in game logic
- document how to run the example

## Testing
- `npm install`
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688a0d0e4e4c8329b7bb7b19079d4855