### PR TITLE
Add hourly advertising quest

### DIFF
--- a/bot/models/AdView.js
+++ b/bot/models/AdView.js
@@ -2,9 +2,10 @@ import mongoose from 'mongoose';
 
 const adViewSchema = new mongoose.Schema({
   telegramId: { type: Number, required: true },
+  type: { type: String, default: 'daily' },
   viewedAt: { type: Date, default: Date.now }
 });
 
-adViewSchema.index({ telegramId: 1, viewedAt: 1 });
+adViewSchema.index({ telegramId: 1, type: 1, viewedAt: 1 });
 
 export default mongoose.model('AdView', adViewSchema);

--- a/bot/routes/ads.js
+++ b/bot/routes/ads.js
@@ -6,6 +6,8 @@ import { ensureTransactionArray } from '../utils/userUtils.js';
 const router = Router();
 const DAILY_LIMIT = 5;
 const REWARD = 50;
+const HOURLY_REWARD = 200;
+const HOUR_MS = 60 * 60 * 1000;
 
 function startOfToday() {
   const d = new Date();
@@ -19,6 +21,7 @@ router.post('/status', async (req, res) => {
 
   const count = await AdView.countDocuments({
     telegramId,
+    type: 'daily',
     viewedAt: { $gte: startOfToday() }
   });
 
@@ -30,12 +33,12 @@ router.post('/watch', async (req, res) => {
   if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
 
   const today = startOfToday();
-  const count = await AdView.countDocuments({ telegramId, viewedAt: { $gte: today } });
+  const count = await AdView.countDocuments({ telegramId, type: 'daily', viewedAt: { $gte: today } });
   if (count >= DAILY_LIMIT) {
     return res.status(400).json({ error: 'limit reached' });
   }
 
-  await AdView.create({ telegramId });
+  await AdView.create({ telegramId, type: 'daily' });
   const user = await User.findOneAndUpdate(
     { telegramId },
     { $setOnInsert: { referralCode: telegramId.toString() } },
@@ -52,6 +55,44 @@ router.post('/watch', async (req, res) => {
   await user.save();
 
   res.json({ message: 'watched', reward: REWARD, remaining: DAILY_LIMIT - count - 1 });
+});
+
+router.post('/quest-status', async (req, res) => {
+  const { telegramId } = req.body;
+  if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
+
+  const last = await AdView.findOne({ telegramId, type: 'quest' }).sort({ viewedAt: -1 });
+  const ts = last ? last.viewedAt.getTime() : 0;
+  const remaining = HOUR_MS - (Date.now() - ts);
+  res.json({ remaining: remaining > 0 ? remaining : 0 });
+});
+
+router.post('/quest-watch', async (req, res) => {
+  const { telegramId } = req.body;
+  if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
+
+  const last = await AdView.findOne({ telegramId, type: 'quest' }).sort({ viewedAt: -1 });
+  if (last && Date.now() - last.viewedAt.getTime() < HOUR_MS) {
+    return res.status(400).json({ error: 'not ready' });
+  }
+
+  await AdView.create({ telegramId, type: 'quest' });
+  const user = await User.findOneAndUpdate(
+    { telegramId },
+    { $setOnInsert: { referralCode: telegramId.toString() } },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+  ensureTransactionArray(user);
+  user.minedTPC += HOURLY_REWARD;
+  user.transactions.push({
+    amount: HOURLY_REWARD,
+    type: 'quest',
+    status: 'pending',
+    date: new Date()
+  });
+  await user.save();
+
+  res.json({ reward: HOURLY_REWARD });
 });
 
 export default router;

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -111,6 +111,14 @@ export function watchAd(telegramId) {
   return post('/api/ads/watch', { telegramId });
 }
 
+export function getQuestStatus(telegramId) {
+  return post('/api/ads/quest-status', { telegramId });
+}
+
+export function completeQuest(telegramId) {
+  return post('/api/ads/quest-watch', { telegramId });
+}
+
 export function submitInfluencerVideo(telegramId, platform, videoUrl) {
   return post('/api/influencer/submit', { telegramId, platform, videoUrl });
 }


### PR DESCRIPTION
## Summary
- expand AdView model with `type` field
- implement hourly quest endpoints
- expose quest API methods to webapp
- show hourly advertising quest on Tasks page and home Tasks card

## Testing
- `npm test` *(fails: Expected values to be strictly equal)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b2036dc288329bb14e634fa628f6b