### PR TITLE
Fix board syncing and lobby labels

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -536,6 +536,8 @@ app.get('/api/snake/board/:id', async (req, res) => {
   const match = /-(\d+)$/.exec(id);
   const cap = match ? Number(match[1]) : 4;
   const room = await gameManager.getRoom(id, cap);
+  // Persist the board so all players receive the same layout
+  await gameManager.saveRoom(room).catch(() => {});
   res.json({ snakes: room.snakes, ladders: room.ladders });
 });
 app.get('/api/watchers/count/:id', (req, res) => {

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -80,9 +80,9 @@ export default function Lobby() {
     if (game === 'snake') {
       setTables([
         { id: 'single', label: 'Single Player vs AI', capacity: 1 },
-        { id: 'snake-2', label: 'Table 2p', capacity: 2 },
-        { id: 'snake-3', label: 'Table 3p', capacity: 3 },
-        { id: 'snake-4', label: 'Table 4p', capacity: 4 }
+        { id: 'snake-2', label: 'Table 2 Players', capacity: 2 },
+        { id: 'snake-3', label: 'Table 3 Players', capacity: 3 },
+        { id: 'snake-4', label: 'Table 4 Players', capacity: 4 }
       ]);
     }
   }, [game]);


### PR DESCRIPTION
## Summary
- store the generated snake board immediately so each player sees the same board
- update lobby table labels for multiplayer snake

## Testing
- `npm test` *(fails: IndexKeySpecsConflict)*

------
https://chatgpt.com/codex/tasks/task_e_688b224f667c8329a525a0cb9e8cb554