### PR TITLE
Fix quest reward delivery

### DIFF
--- a/bot/routes/ads.js
+++ b/bot/routes/ads.js
@@ -83,11 +83,11 @@ router.post('/quest-watch', async (req, res) => {
     { upsert: true, new: true, setDefaultsOnInsert: true }
   );
   ensureTransactionArray(user);
-  user.minedTPC += HOURLY_REWARD;
+  user.balance += HOURLY_REWARD;
   user.transactions.push({
     amount: HOURLY_REWARD,
     type: 'quest',
-    status: 'pending',
+    status: 'delivered',
     date: new Date()
   });
   await user.save();


### PR DESCRIPTION
## Summary
- deliver quest TPC rewards immediately instead of leaving them pending

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688b2ad0247083299256c9146f7618cd