### PR TITLE
Fix lobby capacity checks

### DIFF
--- a/webapp/src/utils/lobby.js
+++ b/webapp/src/utils/lobby.js
@@ -4,11 +4,10 @@ export function canStartGame(game, table, stake, aiCount = 0, players = 0) {
     return aiCount > 0;
   }
   if (game === 'snake' && table && table.id !== 'single') {
-    // Allow players to confirm their readiness even if the table is not yet
-    // full. The server will begin the match once all participants have
-    // confirmed, so we don't enforce player count here.
     const capacity = table.capacity || 0;
     if (capacity <= 0) return false;
+    if (players < capacity) return false;
+    if (players > capacity) return false;
   }
   if (!stake || !stake.token || !stake.amount) return false;
   if (game === 'snake' && !table) return false;


### PR DESCRIPTION
## Summary
- enforce lobby capacity rules in `canStartGame`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b2aa74760832988ab0f4d67aac04f