### PR TITLE
Fix multiplayer avatars

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -79,11 +79,12 @@ export class GameRoom {
     this.players = this.game.players;
   }
 
-  addPlayer(playerId, name, socket) {
+  addPlayer(playerId, name, socket, avatar = '') {
     const existing = this.players.find((p) => p.playerId === playerId);
     if (existing) {
       existing.socketId = socket.id;
       existing.name = name || existing.name;
+      if (avatar) existing.avatar = avatar;
       existing.disconnected = false;
       if (existing.disconnectTimer) {
         clearTimeout(existing.disconnectTimer);
@@ -101,12 +102,14 @@ export class GameRoom {
       player.disconnected = false;
       player.lastRollTime = 0;
       player.disconnectTimer = null;
+      player.avatar = avatar || '';
     }
     socket.join(this.id);
     const list = this.players.filter((p) => !p.disconnected).map((p) => ({
       playerId: p.playerId,
       name: p.name,
       position: p.position,
+      avatar: p.avatar || ''
     }));
     socket.emit('currentPlayers', list);
     this.io.to(this.id).emit('currentPlayers', list);
@@ -433,11 +436,11 @@ export class GameRoomManager {
     return room;
   }
 
-  async joinRoom(roomId, playerId, name, socket) {
+  async joinRoom(roomId, playerId, name, socket, avatar = '') {
     const match = /-(\d+)$/.exec(roomId);
     const cap = match ? Number(match[1]) : 4;
     const room = await this.getRoom(roomId, cap);
-    const result = room.addPlayer(playerId, name, socket);
+    const result = room.addPlayer(playerId, name, socket, avatar);
     if (!result.error) await this.saveRoom(room);
     return result;
   }

--- a/bot/server.js
+++ b/bot/server.js
@@ -745,7 +745,7 @@ io.on('connection', (socket) => {
     maybeStartGame(table);
   });
 
-  socket.on('joinRoom', async ({ roomId, playerId, name }) => {
+  socket.on('joinRoom', async ({ roomId, playerId, name, avatar }) => {
     const map = tableSeats.get(roomId);
     if (map) {
       map.delete(String(playerId));
@@ -758,7 +758,7 @@ io.on('connection', (socket) => {
         () => {}
       );
     }
-    const result = await gameManager.joinRoom(roomId, playerId, name, socket);
+    const result = await gameManager.joinRoom(roomId, playerId, name, socket, avatar);
     if (result.error) socket.emit('error', result.error);
   });
   socket.on('watchRoom', ({ roomId }) => {

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -28,6 +28,7 @@ export default function Layout({ children }) {
     beepRef.current = new Audio(chatBeep);
     beepRef.current.volume = getGameVolume();
     beepRef.current.muted = isGameMuted();
+    beepRef.current.load();
     const volumeHandler = () => {
       if (beepRef.current) beepRef.current.volume = getGameVolume();
     };

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1286,19 +1286,17 @@ export default function SnakeAndLadder() {
       setPlayersNeeded(Math.max(0, capacity - players.length));
     };
 
-    const onJoined = ({ playerId }) => {
-      getProfileByAccount(playerId).then((prof) => {
-        const name = prof?.nickname || `${prof?.firstName || ''} ${prof?.lastName || ''}`.trim() || `Player`;
-        const photoUrl = prof?.photo || '/assets/icons/profile.svg';
-        setMpPlayers((p) => {
-          if (p.some((pl) => pl.id === playerId)) {
-            updateNeeded(p);
-            return p;
-          }
-          const arr = [...p, { id: playerId, name, photoUrl, position: 0 }];
-          updateNeeded(arr);
-          return arr;
-        });
+    const onJoined = ({ playerId, name: joinedName, avatar }) => {
+      const name = joinedName || `Player`;
+      const photoUrl = avatar || '/assets/icons/profile.svg';
+      setMpPlayers((p) => {
+        if (p.some((pl) => pl.id === playerId)) {
+          updateNeeded(p);
+          return p;
+        }
+        const arr = [...p, { id: playerId, name, photoUrl, position: 0 }];
+        updateNeeded(arr);
+        return arr;
       });
     };
     const onLeft = ({ playerId }) => {
@@ -1436,17 +1434,14 @@ export default function SnakeAndLadder() {
     };
 
     const onCurrentPlayers = (players) => {
-      Promise.all(
-        players.map(async (p) => {
-          const prof = await getProfileByAccount(p.playerId).catch(() => ({}));
-          const name = prof?.nickname || `${prof?.firstName || ''} ${prof?.lastName || ''}`.trim() || p.name;
-          const photoUrl = prof?.photo || '/assets/icons/profile.svg';
-          return { id: p.playerId, name, photoUrl, position: p.position || 0 };
-        })
-      ).then((arr) => {
-        setMpPlayers(arr);
-        updateNeeded(arr);
-      });
+      const arr = players.map((p) => ({
+        id: p.playerId,
+        name: p.name || `Player`,
+        photoUrl: p.avatar || '/assets/icons/profile.svg',
+        position: p.position || 0
+      }));
+      setMpPlayers(arr);
+      updateNeeded(arr);
     };
 
     socket.on('playerJoined', onJoined);
@@ -1506,7 +1501,7 @@ export default function SnakeAndLadder() {
         })
         .catch(() => {});
     } else {
-      socket.emit('joinRoom', { roomId: tableId, playerId: accountId, name });
+      socket.emit('joinRoom', { roomId: tableId, playerId: accountId, name, avatar: photoUrl });
     }
 
 


### PR DESCRIPTION
## Summary
- keep avatars when users join multiplayer games
- expose avatar info in join room events
- preload invitation beep sound so it doesn't lag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b33f1376083298970caa1163a2a49