### PR TITLE
Add lobby confirmation flow and board sync

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -316,18 +316,22 @@ function maybeStartGame(table) {
     table.ready &&
     table.ready.size === table.maxPlayers
   ) {
-    console.log(`Table ${table.id} confirmed by all players. Starting game.`);
-    io.to(table.id).emit('gameStart', {
-      tableId: table.id,
-      players: table.players,
-      currentTurn: table.currentTurn,
-      stake: table.stake
-    });
-    tableSeats.delete(table.id);
-    const key = `${table.gameType}-${table.maxPlayers}`;
-    lobbyTables[key] = (lobbyTables[key] || []).filter(
-      (t) => t.id !== table.id
-    );
+    if (table.startTimeout) return;
+    table.startTimeout = setTimeout(() => {
+      console.log(`Table ${table.id} confirmed by all players. Starting game.`);
+      io.to(table.id).emit('gameStart', {
+        tableId: table.id,
+        players: table.players,
+        currentTurn: table.currentTurn,
+        stake: table.stake
+      });
+      tableSeats.delete(table.id);
+      const key = `${table.gameType}-${table.maxPlayers}`;
+      lobbyTables[key] = (lobbyTables[key] || []).filter(
+        (t) => t.id !== table.id
+      );
+      table.startTimeout = null;
+    }, 1000);
   }
 }
 


### PR DESCRIPTION
## Summary
- implement delayed auto-start when all players confirm
- allow multiplayer snake players to seat and confirm in the lobby
- show 'Confirm' button instead of 'Start Game' for multiplayer snake tables

## Testing
- `npm test` *(fails: should receive error when table not full)*

------
https://chatgpt.com/codex/tasks/task_e_688b41bd9a98832989d21e784c927451