### PR TITLE
Fix board sync for Snake & Ladder

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -127,7 +127,10 @@ export class GameRoom {
       socket.emit('gameStarted');
       this.emitNextTurn();
     }
-    return { success: true };
+    return {
+      success: true,
+      board: { snakes: this.snakes, ladders: this.ladders }
+    };
   }
 
   startGame() {

--- a/bot/server.js
+++ b/bot/server.js
@@ -763,9 +763,13 @@ io.on('connection', (socket) => {
       );
     }
     const result = await gameManager.joinRoom(roomId, playerId, name, socket, avatar);
-    if (result.error) socket.emit('error', result.error);
+    if (result.error) {
+      socket.emit('error', result.error);
+    } else if (result.board) {
+      socket.emit('boardData', result.board);
+    }
   });
-  socket.on('watchRoom', ({ roomId }) => {
+  socket.on('watchRoom', async ({ roomId }) => {
     if (!roomId) return;
     let set = tableWatchers.get(roomId);
     if (!set) {
@@ -774,6 +778,10 @@ io.on('connection', (socket) => {
     }
     set.add(socket.id);
     socket.join(roomId);
+    try {
+      const room = await gameManager.getRoom(roomId);
+      socket.emit('boardData', { snakes: room.snakes, ladders: room.ladders });
+    } catch {}
     io.to(roomId).emit('watchCount', { roomId, count: set.size });
   });
 

--- a/test/snakeApi.test.js
+++ b/test/snakeApi.test.js
@@ -154,6 +154,10 @@ test('snake API endpoints and socket events', { concurrency: false, timeout: 200
 
     s2.emit('joinRoom', { roomId: 'snake-2', playerId: 'p2', name: 'B' });
 
+    for (let i = 0; i < 50 && !events.includes('boardData'); i++) {
+      await delay(100);
+    }
+
     for (let i = 0; i < 100 && !events.includes('gameStarted'); i++) {
 
       await delay(100);
@@ -183,6 +187,7 @@ test('snake API endpoints and socket events', { concurrency: false, timeout: 200
     s2.disconnect();
 
     assert.ok(events.includes('diceRolled'));
+    assert.ok(events.includes('boardData'));
 
   } finally {
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1480,6 +1480,24 @@ export default function SnakeAndLadder() {
     socket.on('diceRolled', onRolled);
     socket.on('gameWon', onWon);
     socket.on('currentPlayers', onCurrentPlayers);
+    socket.on('boardData', ({ snakes: sn, ladders: lad }) => {
+      const limit = (obj) => Object.fromEntries(Object.entries(obj).slice(0, 8));
+      const snakesLim = limit(sn || {});
+      const laddersLim = limit(lad || {});
+      setSnakes(snakesLim);
+      setLadders(laddersLim);
+      const snk = {};
+      Object.entries(snakesLim).forEach(([s, e]) => {
+        snk[s] = s - e;
+      });
+      const ladOff = {};
+      Object.entries(laddersLim).forEach(([s, e]) => {
+        const end = typeof e === 'object' ? e.end : e;
+        ladOff[s] = end - s;
+      });
+      setSnakeOffsets(snk);
+      setLadderOffsets(ladOff);
+    });
 
     if (watchOnly) {
       socket.emit('watchRoom', { roomId: tableId });
@@ -1522,6 +1540,7 @@ export default function SnakeAndLadder() {
       socket.off('diceRolled', onRolled);
       socket.off('gameWon', onWon);
       socket.off('currentPlayers', onCurrentPlayers);
+      socket.off('boardData');
       if (watchOnly) {
         socket.emit('leaveWatch', { roomId: tableId });
       } else {


### PR DESCRIPTION
## Summary
- return board layout info when players join a room
- broadcast the board via socket on join and when watching a room
- handle `boardData` event on the client
- expect the new event in tests

## Testing
- `npm test` *(fails: canvas build dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_688b4aa5f0248329a9bec8d145291e02