### PR TITLE
Remove Achievements section and update maintenance popup

### DIFF
--- a/webapp/src/components/InfoPopup.jsx
+++ b/webapp/src/components/InfoPopup.jsx
@@ -7,23 +7,25 @@ export default function InfoPopup({
   title,
   info,
   children,
-  widthClass = 'w-96',
+  widthClass = 'w-11/12 max-w-sm sm:w-96'
 }) {
   if (!open) return null;
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
-      <div className={`prism-box p-6 space-y-4 text-text relative ${widthClass}`}>
-        <button
-          onClick={onClose}
-          className="absolute -top-3 -right-3 bg-black bg-opacity-70 text-white rounded-full w-6 h-6 flex items-center justify-center"
-        >
-          &times;
-        </button>
+      <div
+        className={`prism-box p-6 space-y-4 text-text relative max-h-[90vh] overflow-y-auto ${widthClass}`}
+      >
         {title && <h3 className="text-lg font-bold text-center">{title}</h3>}
         {info && <p className="text-sm text-subtext text-center">{info}</p>}
         {children}
+        <button
+          onClick={onClose}
+          className="mx-auto block px-3 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow"
+        >
+          Close
+        </button>
       </div>
     </div>,
-    document.body,
+    document.body
   );
 }

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -25,7 +25,6 @@ import InfoPopup from '../components/InfoPopup.jsx';
 import DevNotifyModal from '../components/DevNotifyModal.jsx';
 import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
 import Wallet from './Wallet.jsx';
-import AchievementsCard from '../components/AchievementsCard.jsx';
 
 import { FiCopy } from 'react-icons/fi';
 
@@ -355,8 +354,6 @@ export default function MyAccount() {
       </div>
 
       <BalanceSummary className="bg-surface border border-border rounded-xl p-4 wide-card" />
-      <AchievementsCard telegramId={telegramId} />
-
       {profile && profile.accountId === DEV_ACCOUNT_ID && (
         <>
           <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">


### PR DESCRIPTION
## Summary
- remove Achievements card from the profile page
- adjust InfoPopup so close button is at the bottom and width is mobile friendly

## Testing
- `node --test` *(fails: EADDRINUSE in lobbyWait.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688ca6a0f77c832991b6519f6646e1ef