### PR TITLE
Fix layout of maintenance popup

### DIFF
--- a/webapp/src/components/InfoPopup.jsx
+++ b/webapp/src/components/InfoPopup.jsx
@@ -13,7 +13,7 @@ export default function InfoPopup({
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div
-        className={`prism-box p-6 space-y-4 text-text relative max-h-[90vh] overflow-y-auto ${widthClass}`}
+        className={`prism-box flex-col p-6 space-y-4 text-text relative max-h-[90vh] overflow-y-auto ${widthClass}`}
       >
         {title && <h3 className="text-lg font-bold text-center">{title}</h3>}
         {info && <p className="text-sm text-subtext text-center">{info}</p>}

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -163,7 +163,7 @@ export default function Layout({ children }) {
       <InfoPopup
         open={showDevNotice}
         onClose={() => setShowDevNotice(false)}
-        title="\u2699\ufe0f Platform in Development \u2014 Built by One Vision"
+        title="Maintenance"
       >
         <div className="space-y-2 text-sm text-subtext">
           <p>


### PR DESCRIPTION
## Summary
- center the maintenance message in its popup
- ensure popup content stacks vertically
- show the title as `Maintenance`

## Testing
- `npm test` *(fails: joinRoom clears lobby seat)*

------
https://chatgpt.com/codex/tasks/task_e_688caaf5e6f0832990cdc4a72b64f09b