### PR TITLE
Fix proxy env for telegram photo fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ The Wall also features a **Trending** section showing the most liked posts from 
 ### Using an HTTPS proxy
 
 If your server requires a proxy to reach external services like Tonkeeper,
-set the `HTTPS_PROXY` (or `https_proxy`) environment variable before running the
-bot. All fetch requests from the Node.js backend will be routed through this
-proxy.
+set the `HTTPS_PROXY`/`https_proxy` or `HTTP_PROXY`/`http_proxy` environment
+variable before running the bot. All fetch requests from the Node.js backend
+will be routed through this proxy.
 
 
 ### Wallet overview

--- a/bot/utils/proxyAgent.js
+++ b/bot/utils/proxyAgent.js
@@ -1,6 +1,11 @@
 import { ProxyAgent } from 'undici';
 
-export const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy;
+export const proxyUrl =
+  process.env.HTTPS_PROXY ||
+  process.env.https_proxy ||
+  process.env.HTTP_PROXY ||
+  process.env.http_proxy;
+
 export const proxyAgent = proxyUrl ? new ProxyAgent(proxyUrl) : undefined;
 
 export function withProxy(options = {}) {


### PR DESCRIPTION
## Summary
- support `HTTP_PROXY`/`http_proxy` in proxyAgent
- note HTTP proxy variables in README

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688cbd2a784883299f2569c8711e348c