### PR TITLE
Update ad video and repeat tweet task

### DIFF
--- a/bot/utils/tasksData.js
+++ b/bot/utils/tasksData.js
@@ -129,7 +129,7 @@ export const TASKS = [
 
   {
     id: 'post_tweet',
-    description: 'Share a TonPlaygram update on X',
+    description: 'Share a TonPlaygram update on X (every 12h)',
     reward: 2000,
     icon: 'x',
     posts: [

--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 
 // URL for the rewarded video ad iframe
 const AD_VIDEO_URL =
-  'https://www.profitableratecpm.com/ee29ns0ue?key=548d7cc2fa500f230382d44b52e931c0';
+  'https://samplelib.com/lib/preview/mp4/sample-5s.mp4';
 
 interface AdModalProps {
   open: boolean;

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -184,7 +184,6 @@ export default function Tasks() {
     }
     const res = await verifyPost(telegramId, postLink);
     if (!res.error) {
-      await completeTask(telegramId, 'post_tweet');
       setPostLink('');
       load();
     } else {


### PR DESCRIPTION
## Summary
- switch rewarded ads to a sample 5‑second video
- allow `post_tweet` task to repeat every 12h without marking it complete
- document cooldown in task description

## Testing
- `npm test` *(fails: joinRoom waits until table full)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cbc550c8883299105cc3bbdcf1ba0