### PR TITLE
Update AdModal video logic and maintenance notice

### DIFF
--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-// URL for the rewarded video ad iframe
+// URL for the rewarded video ad
 const AD_VIDEO_URL =
   'https://samplelib.com/lib/preview/mp4/sample-5s.mp4';
 
@@ -11,40 +11,23 @@ interface AdModalProps {
 }
 
 export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
-    if (!open || !containerRef.current) return;
+    if (!open || !videoRef.current) return;
 
-    const iframe = document.createElement('iframe');
-    // load rewarded video ad
-    iframe.src = AD_VIDEO_URL;
-    iframe.width = '100%';
-    iframe.height = '100%';
-    iframe.setAttribute('frameborder', '0');
-    iframe.setAttribute('allowfullscreen', '');
+    const video = videoRef.current;
 
-    const container = containerRef.current;
-    container.appendChild(iframe);
-
-    const handleMessage = (e: MessageEvent) => {
-      if (
-        e.origin.includes('profitableratecpm.com') &&
-        (e.data === 'complete' || e.data === 'adComplete')
-      ) {
-        onComplete();
-      }
-    };
-    window.addEventListener('message', handleMessage);
-
-    const timer = setTimeout(() => {
+    const handleEnded = () => {
       onComplete();
-    }, 40000);
+    };
+
+    video.addEventListener('ended', handleEnded);
+    video.play().catch(() => {});
 
     return () => {
-      window.removeEventListener('message', handleMessage);
-      clearTimeout(timer);
-      iframe.remove();
+      video.removeEventListener('ended', handleEnded);
+      video.pause();
     };
   }, [open, onComplete]);
 
@@ -52,7 +35,7 @@ export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="relative w-full h-full">
+      <div className="relative w-[640px] h-[360px]">
         {onClose && (
           <button
             onClick={onClose}
@@ -61,10 +44,11 @@ export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
             &times;
           </button>
         )}
-        <div
-          id="adsgram-player"
-          ref={containerRef}
-          className="w-full h-full bg-black"
+        <video
+          ref={videoRef}
+          src={AD_VIDEO_URL}
+          className="w-[640px] h-[360px]"
+          controls
         />
       </div>
     </div>

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -163,7 +163,7 @@ export default function Layout({ children }) {
       <InfoPopup
         open={showDevNotice}
         onClose={() => setShowDevNotice(false)}
-        title="Maintenance"
+        title="Notice"
       >
         <div className="space-y-2 text-sm text-subtext">
           <p>
@@ -192,6 +192,12 @@ export default function Layout({ children }) {
             Once sufficient funding is raised, TonPlaygram will be rebuilt
             professionally with a dedicated team to scale the experience,
             enhance the design, and unlock the full potential of our vision.
+          </p>
+          <p>
+            50 million coins will be added as part of presale for raising
+            funds. 20 million will be taken from the marketing wallet and 30
+            million from the liquidity wallet. The main objective is to launch
+            CEXs and DEXs on September 17.
           </p>
           <p>Thank you for being part of the journey. This is just the beginning. 🚀</p>
           <img


### PR DESCRIPTION
## Summary
- tweak rewarded video `AdModal` so the video element controls size and closes when finished
- rename the "Maintenance" popup to "Notice" and add presale information

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688cc58016108329873c9908b4a8e160