### PR TITLE
Fix Telegram photo retrieval

### DIFF
--- a/bot/utils/telegram.js
+++ b/bot/utils/telegram.js
@@ -8,22 +8,40 @@ export async function fetchTelegramInfo(telegramId) {
       withProxy()
     );
     const infoData = await infoResp.json();
-
     let photoUrl = '';
-    const photosResp = await fetch(
-      `${base}/getUserProfilePhotos?user_id=${telegramId}&limit=1`,
-      withProxy()
-    );
-    const photosData = await photosResp.json();
-    if (photosData.ok && photosData.result.total_count > 0) {
-      const fileId = photosData.result.photos[0][0].file_id;
-      const fileResp = await fetch(
-        `${base}/getFile?file_id=${fileId}`,
+
+    // Prefer chat photo info returned from getChat if available
+    if (infoData.ok && infoData.result?.photo) {
+      const fileId = infoData.result.photo.big_file_id || infoData.result.photo.small_file_id;
+      if (fileId) {
+        const fileResp = await fetch(
+          `${base}/getFile?file_id=${fileId}`,
+          withProxy()
+        );
+        const fileData = await fileResp.json();
+        if (fileData.ok) {
+          photoUrl = `${base.replace('/bot', '/file/bot')}/${fileData.result.file_path}`;
+        }
+      }
+    }
+
+    // Fallback to getUserProfilePhotos if chat photo not available
+    if (!photoUrl) {
+      const photosResp = await fetch(
+        `${base}/getUserProfilePhotos?user_id=${telegramId}&limit=1`,
         withProxy()
       );
-      const fileData = await fileResp.json();
-      if (fileData.ok) {
-        photoUrl = `${base.replace('/bot', '/file/bot')}/${fileData.result.file_path}`;
+      const photosData = await photosResp.json();
+      if (photosData.ok && photosData.result.total_count > 0) {
+        const fileId = photosData.result.photos[0][0].file_id;
+        const fileResp = await fetch(
+          `${base}/getFile?file_id=${fileId}`,
+          withProxy()
+        );
+        const fileData = await fileResp.json();
+        if (fileData.ok) {
+          photoUrl = `${base.replace('/bot', '/file/bot')}/${fileData.result.file_path}`;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- improve `fetchTelegramInfo` to handle chat photos first
- fall back to `getUserProfilePhotos` when needed

## Testing
- `npm run lint`
- `npm test` *(fails: canvas binary incompatible with Node version)*

------
https://chatgpt.com/codex/tasks/task_e_688cca49d9c48329a3d86c3f7efc671a