### PR TITLE
Add LP token info to pages

### DIFF
--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -37,6 +37,7 @@ import TonConnectButton from '../components/TonConnectButton.jsx';
 import useTokenBalances from '../hooks/useTokenBalances.js';
 import useWalletUsdValue from '../hooks/useWalletUsdValue.js';
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
+import { PTONTPC_LP_TOKEN } from '../utils/lpToken.js';
 
 // Token contract on the TON network
 const TPC_JETTON_ADDRESS =
@@ -380,6 +381,18 @@ export default function Home() {
                 </li>
               ))}
             </ul>
+          </div>
+          <div className="space-y-1 text-center text-xs">
+            <img
+              src={PTONTPC_LP_TOKEN.image}
+              alt={PTONTPC_LP_TOKEN.symbol}
+              className="w-8 h-8 mx-auto"
+            />
+            <p className="font-semibold">{PTONTPC_LP_TOKEN.name}</p>
+            <p>{PTONTPC_LP_TOKEN.description}</p>
+            <p className="break-all text-brand-gold">
+              Address: {PTONTPC_LP_TOKEN.address}
+            </p>
           </div>
           <Link
             to="/tokenomics"

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -5,6 +5,7 @@ import { createAccount, buyBundle, claimPurchase } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import InfoPopup from '../components/InfoPopup.jsx';
 import { STORE_ADDRESS, STORE_BUNDLES, STORE_CATEGORIES } from '../utils/storeData.js';
+import { PTONTPC_LP_TOKEN } from '../utils/lpToken.js';
 
 export default function Store() {
   useTelegramBackButton();
@@ -43,6 +44,18 @@ export default function Store() {
   return (
     <div className="relative p-4 space-y-4 text-text flex flex-col items-center">
       <h2 className="text-xl font-bold">Store</h2>
+      <div className="bg-surface border border-border rounded-xl p-2 text-center text-xs space-y-1 w-full max-w-sm">
+        <img
+          src={PTONTPC_LP_TOKEN.image}
+          alt={PTONTPC_LP_TOKEN.symbol}
+          className="w-8 h-8 mx-auto"
+        />
+        <p className="font-semibold">{PTONTPC_LP_TOKEN.name}</p>
+        <p>{PTONTPC_LP_TOKEN.description}</p>
+        <p className="break-all text-brand-gold">
+          Address: {PTONTPC_LP_TOKEN.address}
+        </p>
+      </div>
       <div className="flex justify-center space-x-2">
         {STORE_CATEGORIES.map((c) => (
           <button

--- a/webapp/src/utils/lpToken.js
+++ b/webapp/src/utils/lpToken.js
@@ -1,0 +1,8 @@
+export const PTONTPC_LP_TOKEN = {
+  address: 'EQBQ51T0Oo_iKUQvs2B0-MqAxnS_UZ3DEST-zJmQC7XYw0ix',
+  name: 'LP Token for pTON-TPC',
+  symbol: 'pTON-TPC LP',
+  decimals: 9,
+  image: 'https://meta.ston.fi/lp/v1/img/0:50e754f43a8fe229442fb36074f8ca80c674bf519dc31124fecc99900bb5d8c3.png',
+  description: 'Liquidity pool token for Proxy TON and TonPlaygram Coin on STON.fi DEX'
+};


### PR DESCRIPTION
## Summary
- show new pTON-TPC LP token metadata on the homepage and the store
- export LP token metadata in a reusable helper

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688ce47f45148329b48ed66f35c0448c