### PR TITLE
Fix DexScreener chart width on store page

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -22,7 +22,8 @@ export default function Store() {
       <iframe
         src="https://dexscreener.com/ton/eqbq51t0oo_ikuqvs2b0-mqaxns_uz3dest-zjmqc7xyw0ix"
         title="DexScreener"
-        className="w-full max-w-xl h-[600px] border border-border rounded-xl"
+        className="w-full h-[600px] border-0 -mx-4"
+        frameBorder="0"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- remove border and max width from DexScreener frame
- stretch chart edge-to-edge using negative margins

## Testing
- `node --test test/onlineRoutes.test.js` *(fails: Expected values to be strictly equal)*

------
https://chatgpt.com/codex/tasks/task_e_688cf4273334832994ac8da0fcd865f2