### PR TITLE
Fix Dexscreener layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1408,6 +1408,28 @@ input:focus {
   @apply -mx-4;
 }
 
+/* Dexscreener responsive embed */
+#dexscreener-embed {
+  position: relative;
+  width: 100%;
+  padding-bottom: 125%;
+}
+
+@media (min-width: 1400px) {
+  #dexscreener-embed {
+    padding-bottom: 65%;
+  }
+}
+
+#dexscreener-embed iframe {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  border: 0;
+}
+
 
 
 

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -19,12 +19,12 @@ export default function Store() {
           Address: {PTONTPC_LP_TOKEN.address}
         </p>
       </div>
-      <iframe
-        src="https://dexscreener.com/ton/eqbq51t0oo_ikuqvs2b0-mqaxns_uz3dest-zjmqc7xyw0ix"
-        title="DexScreener"
-        className="w-full h-[650px] border-0 -mx-4"
-        frameBorder="0"
-      />
+      <div id="dexscreener-embed" className="wide-card">
+        <iframe
+          src="https://dexscreener.com/ton/EQBQ51T0Oo_iKUQvs2B0-MqAxnS_UZ3DEST-zJmQC7XYw0ix?embed=1&loadChartSettings=0&tabs=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=dark&theme=light&chartStyle=0&chartType=usd&interval=15"
+          title="DexScreener"
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use a responsive container for the Dexscreener chart
- add styling for dex chart embed

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688d06599c70832984fd0dfff32b743e