### PR TITLE
Make store chart card size match tasks

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -19,7 +19,10 @@ export default function Store() {
           Address: {PTONTPC_LP_TOKEN.address}
         </p>
       </div>
-      <div id="dexscreener-embed" className="wide-card">
+      <div
+        id="dexscreener-embed"
+        className="relative bg-surface border border-border rounded-xl p-4 overflow-hidden wide-card"
+      >
         <iframe
           src="https://dexscreener.com/ton/EQBQ51T0Oo_iKUQvs2B0-MqAxnS_UZ3DEST-zJmQC7XYw0ix?embed=1&loadChartSettings=0&tabs=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=dark&theme=light&chartStyle=0&chartType=usd&interval=15"
           title="DexScreener"


### PR DESCRIPTION
## Summary
- make Dexscreener chart card use the same container styling as the Tasks card

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688d0fe1e5a48329959732ba5540bc8c