### PR TITLE
Fix lobby avatar update

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -87,6 +87,15 @@ export default function Lobby() {
   }, []);
 
   useEffect(() => {
+    const updatePhoto = () => {
+      const saved = loadAvatar();
+      setPlayerAvatar(saved || getTelegramPhotoUrl());
+    };
+    window.addEventListener('profilePhotoUpdated', updatePhoto);
+    return () => window.removeEventListener('profilePhotoUpdated', updatePhoto);
+  }, []);
+
+  useEffect(() => {
     if (game === 'snake') {
       setTables([
         { id: 'single', label: 'Single Player vs AI', capacity: 1 },


### PR DESCRIPTION
## Summary
- refresh lobby player avatar when Telegram photo loads

## Testing
- `npm test` *(fails: joinRoom clears lobby seat)*

------
https://chatgpt.com/codex/tasks/task_e_688d16daae4c8329a60461fce6b29587