### PR TITLE
Fix store card width

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -7,7 +7,7 @@ export default function Store() {
   return (
     <div className="relative p-4 space-y-4 text-text flex flex-col items-center">
       <h2 className="text-xl font-bold">Store</h2>
-      <div className="bg-surface border border-border rounded-xl p-2 text-center text-xs space-y-1 w-full max-w-sm">
+      <div className="relative bg-surface border border-border rounded-xl p-2 text-center text-xs space-y-1 overflow-hidden wide-card">
         <img
           src={PTONTPC_LP_TOKEN.image}
           alt={PTONTPC_LP_TOKEN.symbol}


### PR DESCRIPTION
## Summary
- adjust token info card on Store page to use `wide-card` layout

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688d1d780d74832990a1102a2b07e419