### PR TITLE
Add Dex chart card and display TPC price

### DIFF
--- a/webapp/src/components/DexChartCard.jsx
+++ b/webapp/src/components/DexChartCard.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function DexChartCard() {
+  return (
+    <div id="dexscreener-embed" className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
+      <iframe
+        src="https://dexscreener.com/ton/eqbq51t0oo_ikuqvs2b0-mqaxns_uz3dest-zjmqc7xyw0ix?embed=1&loadChartSettings=0&tabs=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=dark&theme=light&chartStyle=0&chartType=usd&interval=15"
+        title="DexScreener"
+      />
+    </div>
+  );
+}

--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -1,7 +1,29 @@
+import { useEffect, useState } from 'react';
 import { AiOutlineShop } from 'react-icons/ai';
 
 
 export default function StoreAd() {
+  const [priceTon, setPriceTon] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(
+          'https://api.dexscreener.com/latest/dex/pairs/ton/eqbq51t0oo_ikuqvs2b0-mqaxns_uz3dest-zjmqc7xyw0ix'
+        );
+        const data = await res.json();
+        const p = parseFloat(data?.pair?.priceNative);
+        if (!isNaN(p)) setPriceTon(p);
+      } catch (err) {
+        console.error('Failed to load TPC price:', err);
+      }
+    }
+    load();
+  }, []);
+
+  const formatPrice = (v) =>
+    v != null ? Number(v).toLocaleString(undefined, { maximumFractionDigits: 6 }) : '...';
+
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
       <img
@@ -16,6 +38,13 @@ export default function StoreAd() {
         <AiOutlineShop className="text-accent" />
         <span className="text-lg font-bold">Buy TPC</span>
       </div>
+      {priceTon != null && (
+        <div className="text-center text-sm flex items-center justify-center gap-1">
+          <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" />
+          <span>= {formatPrice(priceTon)}</span>
+          <img src="/assets/icons/TON.webp" alt="TON" className="w-4 h-4" />
+        </div>
+      )}
       <div className="text-center text-sm">Swap TON for TPC on Ston.fi</div>
       <a
         href="https://app.ston.fi/swap?chartVisible=false&chartInterval=1w&ft=TON&tt=EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X"

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -5,6 +5,7 @@ import GameCard from '../components/GameCard.jsx';
 
 import TasksCard from '../components/TasksCard.jsx';
 import StoreAd from '../components/StoreAd.jsx';
+import DexChartCard from '../components/DexChartCard.jsx';
 import NftGiftCard from '../components/NftGiftCard.jsx';
 import ProjectAchievementsCard from '../components/ProjectAchievementsCard.jsx';
 import HomeGamesCard from '../components/HomeGamesCard.jsx';
@@ -336,6 +337,7 @@ export default function Home() {
 
       <div className="grid grid-cols-1 gap-4">
         <TasksCard />
+        <DexChartCard />
         <StoreAd />
         <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
           <img


### PR DESCRIPTION
## Summary
- add DexChartCard component for home page
- fetch TPC price in StoreAd and display with icons
- show Dex chart card and updated store card on home page

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688d233b912883298281b21ca63723f8