### PR TITLE
feat: embed dexscreener chart

### DIFF
--- a/webapp/src/components/DexChartCard.jsx
+++ b/webapp/src/components/DexChartCard.jsx
@@ -4,10 +4,10 @@ export default function DexChartCard() {
   return (
     <div
       id="dexscreener-embed"
-      className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card"
+      className="relative bg-surface border border-border rounded-xl overflow-hidden wide-card"
     >
       <iframe
-        src="https://dexscreener.com/ton/EQBQ51T0Oo_iKUQvs2B0-MqAxnS_UZ3DEST-zJmQC7XYw0ix?embed=1&loadChartSettings=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=dark&theme=dark&chartStyle=0&chartType=usd&interval=15"
+        src="https://dexscreener.com/ton/EQBQ51T0Oo_iKUQvs2B0-MqAxnS_UZ3DEST-zJmQC7XYw0ix?embed=1&loadChartSettings=0&trades=0&tabs=0&info=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=dark&theme=dark&chartStyle=0&chartType=usd&interval=60"
         title="DexScreener"
       />
     </div>

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1,5 +1,6 @@
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { PTONTPC_LP_TOKEN } from '../utils/lpToken.js';
+import DexChartCard from '../components/DexChartCard.jsx';
 
 export default function Store() {
   useTelegramBackButton();
@@ -19,15 +20,7 @@ export default function Store() {
           Address: {PTONTPC_LP_TOKEN.address}
         </p>
       </div>
-      <div
-        id="dexscreener-embed"
-        className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card"
-      >
-        <iframe
-          src="https://dexscreener.com/ton/EQBQ51T0Oo_iKUQvs2B0-MqAxnS_UZ3DEST-zJmQC7XYw0ix?embed=1&loadChartSettings=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=dark&theme=dark&chartStyle=0&chartType=usd&interval=15"
-          title="DexScreener"
-        />
-      </div>
+      <DexChartCard />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use updated DexScreener component
- reuse chart on store page

## Testing
- `npm test` (failed: should receive error when table not full)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688da2c50cf0832999564189d8bf6a3c