### PR TITLE
Add AI admin features for Telegram bot

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -10,6 +10,10 @@ import registerTasks from './commands/tasks.js';
 import registerReferral from './commands/referral.js';
 import registerWallet from './commands/wallet.js';
 import registerHorse from './commands/games/horse.js';
+import registerAnnounce from './commands/announce.js';
+import registerAsk from './commands/ask.js';
+import registerWelcome from './commands/welcome.js';
+import registerModeration from './middleware/moderation.js';
 const bot = new Telegraf(process.env.BOT_TOKEN, {
   telegram: { agent: proxyAgent }
 });
@@ -20,5 +24,9 @@ registerTasks(bot);
 registerReferral(bot);
 registerWallet(bot);
 registerHorse(bot);
+registerAnnounce(bot);
+registerAsk(bot);
+registerWelcome(bot);
+registerModeration(bot);
 
 export default bot;

--- a/bot/commands/announce.js
+++ b/bot/commands/announce.js
@@ -1,0 +1,14 @@
+export default function registerAnnounce(bot) {
+  bot.command('announce', async (ctx) => {
+    const message = ctx.message.text.split(' ').slice(1).join(' ').trim();
+    if (!message) {
+      return ctx.reply('Usage: /announce <message>');
+    }
+    const chatId = ctx.chat.id;
+    const member = await ctx.telegram.getChatMember(chatId, ctx.from.id);
+    if (member.status !== 'creator' && member.status !== 'administrator') {
+      return ctx.reply('Only admins can make announcements.');
+    }
+    await ctx.telegram.sendMessage(chatId, message);
+  });
+}

--- a/bot/commands/ask.js
+++ b/bot/commands/ask.js
@@ -1,0 +1,29 @@
+import OpenAI from 'openai';
+
+let client;
+if (process.env.OPENAI_API_KEY) {
+  client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+}
+
+export default function registerAsk(bot) {
+  bot.command('ask', async (ctx) => {
+    const question = ctx.message.text.split(' ').slice(1).join(' ').trim();
+    if (!question) {
+      return ctx.reply('Please provide a question. Usage: /ask <your question>');
+    }
+    if (!client) {
+      return ctx.reply('AI not configured.');
+    }
+    try {
+      const completion = await client.chat.completions.create({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: question }]
+      });
+      const answer = completion.choices[0]?.message?.content?.trim();
+      await ctx.reply(answer || 'No answer returned.');
+    } catch (err) {
+      console.error('AI error:', err);
+      await ctx.reply('Sorry, I could not process that.');
+    }
+  });
+}

--- a/bot/commands/welcome.js
+++ b/bot/commands/welcome.js
@@ -1,0 +1,15 @@
+export default function registerWelcome(bot) {
+  bot.on('new_chat_members', async (ctx) => {
+    for (const member of ctx.message.new_chat_members) {
+      if (member.is_bot) {
+        try {
+          await ctx.banChatMember(member.id);
+        } catch (err) {
+          console.error('Failed to ban bot:', err);
+        }
+      } else {
+        await ctx.reply(`Welcome, ${member.first_name}!`);
+      }
+    }
+  });
+}

--- a/bot/middleware/moderation.js
+++ b/bot/middleware/moderation.js
@@ -1,0 +1,17 @@
+const bannedWords = ['spam', 'scam'];
+
+export default function registerModeration(bot) {
+  bot.on('text', async (ctx, next) => {
+    const text = ctx.message.text.toLowerCase();
+    if (bannedWords.some((w) => text.includes(w))) {
+      try {
+        await ctx.deleteMessage();
+        await ctx.reply('Message removed: violates group rules.');
+      } catch (err) {
+        console.error('Failed to delete message:', err);
+      }
+    } else {
+      return next();
+    }
+  });
+}

--- a/bot/package.json
+++ b/bot/package.json
@@ -17,13 +17,14 @@
     "https-proxy-agent": "^7.0.2",
     "mongodb-memory-server": "^10.1.4",
     "mongoose": "^7.6.0",
+    "openai": "^4.104.0",
     "socket.io": "^4.7.5",
     "telegraf": "^4.12.2",
-    "tonweb": "^0.0.66",
     "ton": "^13.9.0",
     "ton-core": "^0.53.0",
     "ton-crypto": "^3.2.0",
     "ton-x": "^2.1.0-preview",
+    "tonweb": "^0.0.66",
     "twitter-api-v2": "^1.24.0",
     "uuid": "^9.0.1"
   }


### PR DESCRIPTION
## Summary
- add /announce command for admin broadcasts
- add /ask command using OpenAI
- greet new members and ban bots automatically
- basic message moderation

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688f1254d37083298861d9ff69f75f94