### PR TITLE
Replace USDT references with TPC data and add burn info

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -4,7 +4,7 @@ import LoginOptions from './LoginOptions.jsx';
 import useTokenBalances from '../hooks/useTokenBalances.js';
 
 export default function BalanceSummary({ className = '', showHeader = true }) {
-  const { tpcBalance, tonBalance, usdtBalance, telegramId } = useTokenBalances();
+  const { tpcBalance, tonBalance, tpcWalletBalance, telegramId } = useTokenBalances();
   if (!telegramId) {
     return <LoginOptions />;
   }
@@ -21,8 +21,8 @@ export default function BalanceSummary({ className = '', showHeader = true }) {
       )}
       <div className="grid grid-cols-3 text-sm mt-4">
         <Token icon="/assets/icons/TON.webp" label="TON" value={tonBalance ?? '...'} />
-        <Token icon="/assets/icons/TPCcoin_1.webp" label="TPC" value={tpcBalance ?? 0} decimals={2} />
-        <Token icon="/assets/icons/Usdt.webp" label="USDT" value={usdtBalance ?? '...'} decimals={2} />
+        <Token icon="/assets/icons/TPCcoin_1.webp" label="TPC (App)" value={tpcBalance ?? 0} decimals={2} />
+        <Token icon="/assets/icons/TPCcoin_1.webp" label="TPC" value={tpcWalletBalance ?? '...'} decimals={2} />
       </div>
     </div>
   );

--- a/webapp/src/components/DexChartCard.jsx
+++ b/webapp/src/components/DexChartCard.jsx
@@ -7,7 +7,7 @@ export default function DexChartCard() {
       className="relative bg-surface border border-border rounded-xl overflow-hidden wide-card"
     >
       <iframe
-        src="https://dexscreener.com/ton/EQBQ51T0Oo_iKUQvs2B0-MqAxnS_UZ3DEST-zJmQC7XYw0ix?embed=1&loadChartSettings=0&trades=0&tabs=0&info=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=dark&theme=dark&chartStyle=1&chartType=usd&interval=15"
+        src="https://dexscreener.com/ton/EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X?embed=1&loadChartSettings=0&trades=0&tabs=0&info=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=dark&theme=dark&chartStyle=1&chartType=usd&interval=15"
         title="DexScreener"
       />
     </div>

--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -9,10 +9,10 @@ export default function StoreAd() {
     async function load() {
       try {
         const res = await fetch(
-          'https://api.dexscreener.com/latest/dex/pairs/ton/eqbq51t0oo_ikuqvs2b0-mqaxns_uz3dest-zjmqc7xyw0ix'
+          'https://api.dexscreener.com/latest/dex/tokens/EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X'
         );
         const data = await res.json();
-        const p = parseFloat(data?.pair?.priceNative);
+        const p = parseFloat(data?.pairs?.[0]?.priceNative);
         if (!isNaN(p)) setPriceTon(p);
       } catch (err) {
         console.error('Failed to load TPC price:', err);

--- a/webapp/src/hooks/useWalletUsdValue.js
+++ b/webapp/src/hooks/useWalletUsdValue.js
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 
-export default function useWalletUsdValue(tonBalance, usdtBalance) {
+export default function useWalletUsdValue(tonBalance, tpcWalletBalance) {
   const [usdValue, setUsdValue] = useState(null);
 
   useEffect(() => {
     async function load() {
-      if (tonBalance == null && usdtBalance == null) {
+      if (tonBalance == null && tpcWalletBalance == null) {
         setUsdValue(null);
         return;
       }
@@ -33,11 +33,23 @@ export default function useWalletUsdValue(tonBalance, usdtBalance) {
         }
       }
 
-      const total = (tonBalance ?? 0) * tonPrice + (usdtBalance ?? 0);
+      let tpcPrice = 0;
+      try {
+        const res = await fetch(
+          'https://api.dexscreener.com/latest/dex/tokens/EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X'
+        );
+        const data = await res.json();
+        tpcPrice = parseFloat(data?.pairs?.[0]?.priceUsd) || 0;
+      } catch (err) {
+        console.error('Failed to load TPC price from dexscreener:', err);
+      }
+
+      const total =
+        (tonBalance ?? 0) * tonPrice + (tpcWalletBalance ?? 0) * tpcPrice;
       setUsdValue(total);
     }
     load();
-  }, [tonBalance, usdtBalance]);
+  }, [tonBalance, tpcWalletBalance]);
 
   return usdValue;
 }

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -79,8 +79,8 @@ export default function Home() {
   const [status, setStatus] = useState('checking');
 
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
-  const { tpcBalance, tonBalance, usdtBalance } = useTokenBalances();
-  const usdValue = useWalletUsdValue(tonBalance, usdtBalance);
+  const { tpcBalance, tonBalance, tpcWalletBalance } = useTokenBalances();
+  const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
   const walletAddress = useTonAddress();
   const [tonConnectUI] = useTonConnectUI();
   const shortAddress = walletAddress
@@ -280,19 +280,20 @@ export default function Home() {
         <div className="w-full mt-2 space-y-4">
           <div className="relative bg-surface border border-border rounded-xl p-4 flex items-center justify-around overflow-hidden wide-card">
             <img
-              
               src="/assets/SnakeLaddersbackground.png"
               className="background-behind-board object-cover"
               alt=""
-              onError={(e) => { e.currentTarget.style.display = "none"; }}
+              onError={(e) => {
+                e.currentTarget.style.display = 'none';
+              }}
             />
             <div className="flex-1 flex items-center justify-center space-x-1">
               <img src="/assets/icons/TON.webp" alt="TON" className="w-8 h-8" />
               <span className="text-base">{formatValue(tonBalance ?? '...')}</span>
             </div>
             <div className="flex-1 flex items-center justify-center space-x-1">
-              <img src="/assets/icons/Usdt.webp" alt="USDT" className="w-8 h-8" />
-              <span className="text-base">{formatValue(usdtBalance ?? '...', 2)}</span>
+              <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-8 h-8" />
+              <span className="text-base">{formatValue(tpcWalletBalance ?? '...', 2)}</span>
             </div>
           </div>
 
@@ -402,6 +403,24 @@ export default function Home() {
           >
             Learn More
           </Link>
+        </div>
+        <div className="bg-[#0c1020] text-white p-4 rounded-2xl shadow-lg wide-card">
+          <h2 className="text-xl font-bold mb-2">🔥 Burned TPC</h2>
+          <p className="text-3xl font-semibold text-yellow-400">
+            3,521,290.38 TPC
+          </p>
+          <p className="text-sm mt-2 text-gray-400">Burned on August 1, 2025</p>
+          <p className="text-xs mt-1 text-gray-500 break-all">
+            Burn address: UQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJKZ
+          </p>
+          <a
+            href="https://tonviewer.com/transaction/1cde028b723c0871ee7b7e3faf911d80330fba51a9bf2b5029bd239b1a39b3e8"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 underline text-sm mt-2 inline-block"
+          >
+            View on TonViewer
+          </a>
         </div>
       </div>
       <ProjectAchievementsCard />

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -327,6 +327,9 @@ export default function Wallet({ hideClaim = false }) {
         <p className="text-xl font-medium">
           {tpcBalance === null ? '...' : formatValue(tpcBalance, 2)}
         </p>
+        <p className="text-xs text-subtext">
+          Balance is off-chain and stored within the app
+        </p>
         {DEV_ACCOUNTS.includes(accountId) && (
           <>
             <p className="text-sm">Earnings from games: {formatValue(devShare, 2)}</p>


### PR DESCRIPTION
## Summary
- Fetch 1 TPC pricing from Dexscreener token endpoint and show TPC chart.
- Replace USDT balance with on-chain TPC balance and add Burned TPC card on the home page.
- Clarify in-wallet TPC balance is off-chain within the app.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f347e1bf48329b5df6334eccb81a1