### PR TITLE
feat: show TPC price from Stonfi

### DIFF
--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -2,18 +2,22 @@ import { useEffect, useState } from 'react';
 import { AiOutlineShop } from 'react-icons/ai';
 
 
+const TON_ADDRESS = 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
+const TPC_ADDRESS = 'EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X';
+
 export default function StoreAd() {
-  const [priceTon, setPriceTon] = useState(null);
+  const [tpcPerTon, setTpcPerTon] = useState(null);
 
   useEffect(() => {
     async function load() {
       try {
         const res = await fetch(
-          'https://api.dexscreener.com/latest/dex/tokens/EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X'
+          `https://api.ston.fi/v1/swap/simulate?offer_address=${TON_ADDRESS}&ask_address=${TPC_ADDRESS}&units=1000000000&slippage_tolerance=0.003`,
+          { method: 'POST' }
         );
         const data = await res.json();
-        const p = parseFloat(data?.pairs?.[0]?.priceNative);
-        if (!isNaN(p)) setPriceTon(p);
+        const rate = parseFloat(data?.swap_rate);
+        if (!isNaN(rate)) setTpcPerTon(rate);
       } catch (err) {
         console.error('Failed to load TPC price:', err);
       }
@@ -22,7 +26,7 @@ export default function StoreAd() {
   }, []);
 
   const formatPrice = (v) =>
-    v != null ? Number(v).toLocaleString(undefined, { maximumFractionDigits: 6 }) : '...';
+    v != null ? Number(v).toLocaleString(undefined, { maximumFractionDigits: 2 }) : '...';
 
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
@@ -35,14 +39,14 @@ export default function StoreAd() {
         }}
       />
       <div className="flex items-center justify-center space-x-1">
-        <AiOutlineShop className="text-accent" />
-        <span className="text-lg font-bold">Buy TPC</span>
+          <AiOutlineShop className="text-accent" />
+          <span className="text-lg font-bold">Buy TPC</span>
       </div>
-      {priceTon != null && (
+      {tpcPerTon != null && (
         <div className="text-center text-sm flex items-center justify-center gap-1">
-          <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" />
-          <span>= {formatPrice(priceTon)}</span>
           <img src="/assets/icons/TON.webp" alt="TON" className="w-4 h-4" />
+          <span>= {formatPrice(tpcPerTon)}</span>
+          <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" />
         </div>
       )}
       <div className="text-center text-sm">Swap TON for TPC on Ston.fi</div>


### PR DESCRIPTION
## Summary
- fetch TPC/Ton rate from Ston.fi and show 1 TON worth of TPC on Buy TPC card

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_688f3aab447c8329a474ea3df2573e0f