### PR TITLE
Fix X task cooldown and add countdown timer

### DIFF
--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -135,6 +135,19 @@ export default function TasksCard() {
   useEffect(() => {
     const id = setInterval(() => {
       setQuestTime((t) => (t > 1000 ? t - 1000 : 0));
+      setTasks((list) =>
+        list
+          ? list.map((task) =>
+              task.cooldown
+                ? {
+                    ...task,
+                    cooldown: task.cooldown > 1000 ? task.cooldown - 1000 : 0,
+                    completed: task.cooldown > 1000
+                  }
+                : task
+            )
+          : list
+      );
     }, 1000);
     return () => clearInterval(id);
   }, []);
@@ -170,7 +183,6 @@ export default function TasksCard() {
     }
     const res = await verifyPost(telegramId, postLink);
     if (!res.error) {
-      await completeTask(telegramId, 'post_tweet');
       setPostLink('');
       load();
     } else {
@@ -224,9 +236,11 @@ export default function TasksCard() {
 
   const formatTime = (ms) => {
     const total = Math.ceil(ms / 1000);
-    const m = Math.floor(total / 60);
+    const h = Math.floor(total / 3600);
+    const m = Math.floor((total % 3600) / 60);
     const s = total % 60;
-    return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+    const hh = h > 0 ? `${h.toString().padStart(2, '0')}:` : '';
+    return `${hh}${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
   };
 
   if (!tasks) {
@@ -299,7 +313,9 @@ export default function TasksCard() {
               {ICONS[t.id]}
               <span className="text-sm">{t.description}</span>
               <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
-              {t.completed ? (
+              {t.completed && t.id === 'post_tweet' && t.cooldown > 0 ? (
+                <span className="text-sm text-subtext">{formatTime(t.cooldown)}</span>
+              ) : t.completed ? (
                 <span className="text-green-500 font-semibold text-sm">Done</span>
               ) : t.id === 'post_tweet' ? (
                 <div className="space-y-2 w-full">

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -123,6 +123,19 @@ export default function Tasks() {
   useEffect(() => {
     const id = setInterval(() => {
       setQuestTime((t) => (t > 1000 ? t - 1000 : 0));
+      setTasks((list) =>
+        list
+          ? list.map((task) =>
+              task.cooldown
+                ? {
+                    ...task,
+                    cooldown: task.cooldown > 1000 ? task.cooldown - 1000 : 0,
+                    completed: task.cooldown > 1000
+                  }
+                : task
+            )
+          : list
+      );
     }, 1000);
     return () => clearInterval(id);
   }, []);
@@ -206,9 +219,11 @@ export default function Tasks() {
 
   const formatTime = (ms) => {
     const total = Math.ceil(ms / 1000);
-    const m = Math.floor(total / 60);
+    const h = Math.floor(total / 3600);
+    const m = Math.floor((total % 3600) / 60);
     const s = total % 60;
-    return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+    const hh = h > 0 ? `${h.toString().padStart(2, '0')}:` : '';
+    return `${hh}${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
   };
 
   const handleVideoSubmit = async () => {
@@ -305,7 +320,9 @@ export default function Tasks() {
                 {ICONS[t.id]}
                 <span className="text-sm">{t.description}</span>
                 <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" /></span>
-                {t.completed ? (
+                {t.completed && t.id === 'post_tweet' && t.cooldown > 0 ? (
+                  <span className="text-sm text-subtext">{formatTime(t.cooldown)}</span>
+                ) : t.completed ? (
                   <span className="text-green-500 font-semibold text-sm">Completed</span>
                 ) : t.id === 'post_tweet' ? (
                   <div className="space-y-2 w-full">


### PR DESCRIPTION
## Summary
- reset "Share a TonPlaygram update on X" task every 12h and expose cooldown
- show countdown timer in tasks UI while X task is on cooldown
- disallow completing X task without verification

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f3b6755108329b65f6bc2e6714a55