### PR TITLE
feat: display TON to TPC rate

### DIFF
--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -44,6 +44,7 @@ export default function StoreAd() {
       </div>
       {tpcPerTon != null && (
         <div className="text-center text-sm flex items-center justify-center gap-1">
+          <span>1</span>
           <img src="/assets/icons/TON.webp" alt="TON" className="w-4 h-4" />
           <span>= {formatPrice(tpcPerTon)}</span>
           <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- show 1 TON to TPC conversion in Buy TPC ad

## Testing
- `npm run lint`
- `npm test` *(fails: AssertionError in lobbyWait.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d4fbf98832986baf62184ae078b