### PR TITLE
chore: update dexscreener link

### DIFF
--- a/webapp/src/components/DexChartCard.jsx
+++ b/webapp/src/components/DexChartCard.jsx
@@ -7,7 +7,7 @@ export default function DexChartCard() {
       className="relative bg-surface border border-border rounded-xl overflow-hidden wide-card"
     >
       <iframe
-        src="https://dexscreener.com/ton/EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X?embed=1&loadChartSettings=0&trades=0&tabs=0&info=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=dark&theme=dark&chartStyle=1&chartType=usd&interval=15"
+        src="https://dexscreener.com/ton/eqdpcahghh97azu5bprmxqwgm0ojg56dqni5oboujxdumsg-?embed=1&loadChartSettings=0&trades=0&tabs=0&info=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=dark&theme=dark&chartStyle=1&chartType=usd&interval=15"
         title="DexScreener"
       />
     </div>

--- a/webapp/src/hooks/useWalletUsdValue.js
+++ b/webapp/src/hooks/useWalletUsdValue.js
@@ -34,15 +34,15 @@ export default function useWalletUsdValue(tonBalance, tpcWalletBalance) {
       }
 
       let tpcPrice = 0;
-      try {
-        const res = await fetch(
-          'https://api.dexscreener.com/latest/dex/tokens/EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X'
-        );
-        const data = await res.json();
-        tpcPrice = parseFloat(data?.pairs?.[0]?.priceUsd) || 0;
-      } catch (err) {
-        console.error('Failed to load TPC price from dexscreener:', err);
-      }
+        try {
+          const res = await fetch(
+            'https://api.dexscreener.com/latest/dex/tokens/eqdpcahghh97azu5bprmxqwgm0ojg56dqni5oboujxdumsg-'
+          );
+          const data = await res.json();
+          tpcPrice = parseFloat(data?.pairs?.[0]?.priceUsd) || 0;
+        } catch (err) {
+          console.error('Failed to load TPC price from dexscreener:', err);
+        }
 
       const total =
         (tonBalance ?? 0) * tonPrice + (tpcWalletBalance ?? 0) * tpcPrice;


### PR DESCRIPTION
## Summary
- point Dex chart embed to new pair address
- fetch TPC price from updated DexScreener API endpoint

## Testing
- `npm test` *(fails: should receive error when table not full)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68906f3deb4483298db50a793961b987