### PR TITLE
Use DeDust for TPC price and remove stats

### DIFF
--- a/webapp/src/components/StoreAd.jsx
+++ b/webapp/src/components/StoreAd.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { AiOutlineShop } from 'react-icons/ai';
 
-const TON_ADDRESS = 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
 const TPC_ADDRESS = 'EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X';
 
 export default function StoreAd() {
@@ -10,13 +9,18 @@ export default function StoreAd() {
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch(
-          `https://api.ston.fi/v1/swap/simulate?offer_address=${TON_ADDRESS}&ask_address=${TPC_ADDRESS}&units=1000000000&slippage_tolerance=0.003`,
-          { method: 'POST' }
+        const res = await fetch('https://api.dedust.io/v2/pools-lite');
+        const pools = await res.json();
+        const pool = pools.find(
+          (p) =>
+            p.assets.includes('native') &&
+            p.assets.includes(`jetton:${TPC_ADDRESS}`)
         );
-        const data = await res.json();
-        const rate = parseFloat(data?.swap_rate);
-        if (!isNaN(rate)) setTpcPerTon(rate);
+        if (pool) {
+          const [tonReserve, tpcReserve] = pool.reserves.map((r) => Number(r));
+          const rate = tpcReserve / tonReserve;
+          if (!isNaN(rate)) setTpcPerTon(rate);
+        }
       } catch (err) {
         console.error('Failed to load TPC price:', err);
       }
@@ -55,9 +59,9 @@ export default function StoreAd() {
           />
         </div>
       )}
-      <div className="text-center text-sm">Buy TPC on DexScreener</div>
+      <div className="text-center text-sm">Buy TPC on DeDust</div>
       <a
-        href="https://dexscreener.com/ton/eqdpcahghh97azu5bprmxqwgm0ojg56dqni5oboujxdumsg-"
+        href="https://app.tonkeeper.com/dapp/https%3A%2F%2Fdedust.io%2Fswap%2FTON%2FEQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X"
         target="_blank"
         rel="noopener noreferrer"
         className="mx-auto block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow"

--- a/webapp/src/utils/lpToken.js
+++ b/webapp/src/utils/lpToken.js
@@ -1,8 +1,8 @@
 export const PTONTPC_LP_TOKEN = {
-  address: 'EQBQ51T0Oo_iKUQvs2B0-MqAxnS_UZ3DEST-zJmQC7XYw0ix',
-  name: 'LP Token for pTON-TPC',
-  symbol: 'pTON-TPC LP',
+  address: 'EQDpCAhghH97AzU5bprMXQwGM0oJg56DqNI5OboUJxduMsg-',
+  name: 'LP Token for TON-TPC',
+  symbol: 'TON-TPC LP',
   decimals: 9,
-  image: 'https://meta.ston.fi/lp/v1/img/0:50e754f43a8fe229442fb36074f8ca80c674bf519dc31124fecc99900bb5d8c3.png',
-  description: 'Liquidity pool token for Proxy TON and TonPlaygram Coin on STON.fi DEX'
+  image: 'https://dedust.io/favicon.ico',
+  description: 'Liquidity pool token for TON and TonPlaygram Coin on DeDust DEX'
 };


### PR DESCRIPTION
## Summary
- fetch TPC price from DeDust pools and update buy link
- drop home page platform stats section
- switch LP token metadata to DeDust

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68907dcac3808329a069a8bed216e720