### PR TITLE
Remove store cards and add TPC reset script

### DIFF
--- a/bot/scripts/resetTPCBalances.js
+++ b/bot/scripts/resetTPCBalances.js
@@ -1,0 +1,24 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import User from '../models/User.js';
+
+dotenv.config();
+
+const uri = process.env.MONGODB_URI;
+if (!uri || uri === 'memory') {
+  console.error('MONGODB_URI must be set to a MongoDB instance');
+  process.exit(1);
+}
+
+await mongoose.connect(uri);
+
+const users = await User.find({});
+for (const user of users) {
+  user.balance = 0;
+  user.minedTPC = 0;
+  user.transactions = [];
+  await user.save();
+  console.log(`Reset TPC for ${user.telegramId || user.accountId}`);
+}
+
+await mongoose.disconnect();

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "ban-user": "node bot/scripts/banUser.js",
     "claim-test": "node bot/scripts/claimTest.js",
     "refund-withdrawals": "node bot/scripts/refundPendingWithdrawals.js",
+    "reset-tpc-balances": "node bot/scripts/resetTPCBalances.js",
     "dev": "concurrently -k \"npm --prefix webapp run dev\" \"node bot/server.js\""
   },
   "engines": {

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1,6 +1,4 @@
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
-import { PTONTPC_LP_TOKEN } from '../utils/lpToken.js';
-import DexChartCard from '../components/DexChartCard.jsx';
 
 export default function Store() {
   useTelegramBackButton();
@@ -8,19 +6,7 @@ export default function Store() {
   return (
     <div className="relative p-4 space-y-4 text-text flex flex-col items-center">
       <h2 className="text-xl font-bold">Store</h2>
-      <div className="relative bg-surface border border-border rounded-xl p-2 text-center text-xs space-y-1 overflow-hidden wide-card">
-        <img
-          src={PTONTPC_LP_TOKEN.image}
-          alt={PTONTPC_LP_TOKEN.symbol}
-          className="w-8 h-8 mx-auto"
-        />
-        <p className="font-semibold">{PTONTPC_LP_TOKEN.name}</p>
-        <p>{PTONTPC_LP_TOKEN.description}</p>
-        <p className="break-all text-brand-gold">
-          Address: {PTONTPC_LP_TOKEN.address}
-        </p>
-      </div>
-      <DexChartCard />
+      <p className="text-subtext text-sm">No bundles are currently available.</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Remove token info and Dex chart cards from the store page
- Add script to reset every user's TPC balance and transactions to zero
- Add npm script `reset-tpc-balances` to run the reset utility

## Testing
- `node --test` *(fails: should receive error when table not full)*

------
https://chatgpt.com/codex/tasks/task_e_689326d7fc688329bbdb73beb9d13072