### PR TITLE
feat: add database reset script

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,10 @@ Run `npm run claim-test <TON_ADDRESS> <AMOUNT>` to send TPC from the claim walle
 
 Run `npm run refund-withdrawals` to return all pending withdrawal amounts to user balances. `MONGODB_URI` must point to your MongoDB instance.
 
+### Reset database
+
+Run `npm run reset-db` to drop the existing MongoDB database and start with a clean one where all user balances are reset to zero. `MONGODB_URI` must point to your MongoDB instance.
+
 ### Deploying the claim wallet
 
 1. **Compile the contract**. Install the FunC compiler and Fift tools, then run:

--- a/bot/scripts/resetDatabase.js
+++ b/bot/scripts/resetDatabase.js
@@ -1,0 +1,21 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const uri = process.env.MONGODB_URI;
+if (!uri || uri === 'memory') {
+  console.error('MONGODB_URI must be set to a MongoDB instance');
+  process.exit(1);
+}
+
+await mongoose.connect(uri);
+
+try {
+  await mongoose.connection.dropDatabase();
+  console.log('Database dropped. All user balances reset to 0.');
+} catch (err) {
+  console.error('Failed to reset database:', err.message);
+} finally {
+  await mongoose.disconnect();
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "claim-test": "node bot/scripts/claimTest.js",
     "refund-withdrawals": "node bot/scripts/refundPendingWithdrawals.js",
     "reset-tpc-balances": "node bot/scripts/resetTPCBalances.js",
+    "reset-db": "node bot/scripts/resetDatabase.js",
     "dev": "concurrently -k \"npm --prefix webapp run dev\" \"node bot/server.js\""
   },
   "engines": {


### PR DESCRIPTION
## Summary
- add script to drop MongoDB database and reset balances
- expose reset via `npm run reset-db`
- document reset procedure in README

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_6893412c8fa08329b554db16cca06ebd