### PR TITLE
feat: integrate solana wallet adapter

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -10,8 +10,13 @@
   "type": "module",
   "dependencies": {
     "@github/webauthn-json": "^2.0.2",
+    "@solana/wallet-adapter-phantom": "^0.9.28",
+    "@solana/wallet-adapter-react": "^0.15.39",
+    "@solana/wallet-adapter-react-ui": "^0.9.39",
+    "@solana/web3.js": "^1.98.4",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.15",
+    "buffer": "^6.0.3",
     "emoji-name-map": "^2.0.3",
     "framer-motion": "^10.18.0",
     "lucide-react": "^0.525.0",

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -3,8 +3,27 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
 
+import { Buffer } from 'buffer';
+import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
+import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
+import { PhantomWalletAdapter } from '@solana/wallet-adapter-phantom';
+import { clusterApiUrl } from '@solana/web3.js';
+import '@solana/wallet-adapter-react-ui/styles.css';
+
+// Polyfill Buffer for browser environment
+if (!window.Buffer) window.Buffer = Buffer;
+
+const endpoint = clusterApiUrl('mainnet-beta');
+const wallets = [new PhantomWalletAdapter()];
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <ConnectionProvider endpoint={endpoint}>
+      <WalletProvider wallets={wallets} autoConnect>
+        <WalletModalProvider>
+          <App />
+        </WalletModalProvider>
+      </WalletProvider>
+    </ConnectionProvider>
   </React.StrictMode>
 );

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { useWallet, useConnection } from '@solana/wallet-adapter-react';
+import { WalletMultiButton } from '@solana/wallet-adapter-react-ui';
 
 import TasksCard from '../components/TasksCard.jsx';
 import NftGiftCard from '../components/NftGiftCard.jsx';
@@ -30,47 +32,30 @@ export default function Home() {
 
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
 
+  const { publicKey } = useWallet();
+  const { connection } = useConnection();
   const [walletUsd, setWalletUsd] = useState(null);
-  const [connecting, setConnecting] = useState(false);
 
-  const connectPhantom = async () => {
-    const provider = window.solana;
-    if (!provider?.isPhantom) {
-      alert('Phantom wallet not found');
+  useEffect(() => {
+    if (!publicKey) {
+      setWalletUsd(null);
       return;
     }
-    try {
-      setConnecting(true);
-      const resp = await provider.connect();
-      const pubKey = resp.publicKey.toString();
-
-      const balResp = await fetch('https://api.mainnet-beta.solana.com', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: 1,
-          method: 'getBalance',
-          params: [pubKey],
-        }),
-      });
-      const balData = await balResp.json();
-      const lamports = balData?.result?.value || 0;
-      const sol = lamports / 1e9;
-
-      const priceRes = await fetch(
-        'https://api.coingecko.com/api/v3/simple/price?ids=solana&vs_currencies=usd'
-      );
-      const priceJson = await priceRes.json();
-      const price = priceJson?.solana?.usd || 0;
-
-      setWalletUsd(sol * price);
-    } catch (err) {
-      console.error('Phantom connect failed', err);
-    } finally {
-      setConnecting(false);
-    }
-  };
+    (async () => {
+      try {
+        const lamports = await connection.getBalance(publicKey);
+        const sol = lamports / 1e9;
+        const priceRes = await fetch(
+          'https://api.coingecko.com/api/v3/simple/price?ids=solana&vs_currencies=usd'
+        );
+        const priceJson = await priceRes.json();
+        const price = priceJson?.solana?.usd || 0;
+        setWalletUsd(sol * price);
+      } catch (err) {
+        console.error('Failed to fetch balance', err);
+      }
+    })();
+  }, [publicKey, connection]);
 
   useEffect(() => {
     ping()
@@ -151,17 +136,16 @@ export default function Home() {
           </div>
         )}
 
-        {walletUsd === null ? (
-          <button
-            onClick={connectPhantom}
-            disabled={connecting}
-            className="px-4 py-1 bg-brand-gold text-black rounded"
-          >
-            {connecting ? 'Connecting...' : 'Connect Phantom'}
-          </button>
+        {!publicKey ? (
+          <WalletMultiButton className="px-4 py-1 bg-brand-gold text-black rounded" />
+        ) : walletUsd === null ? (
+          <p className="text-center font-semibold">Loading...</p>
         ) : (
           <p className="text-center font-semibold">
-            ${walletUsd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            ${walletUsd.toLocaleString(undefined, {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}
           </p>
         )}
 


### PR DESCRIPTION
## Summary
- add Solana wallet adapter libraries
- wrap app with wallet providers and replace Phantom button with wallet modal

## Testing
- `npm --prefix webapp run build`
- `npm test` *(fails: joinRoom tests)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68934809ad1c8329a842656fd34fa99e