### PR TITLE
Reset database without dropping collections

### DIFF
--- a/bot/scripts/resetDatabase.js
+++ b/bot/scripts/resetDatabase.js
@@ -1,5 +1,9 @@
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
+import User from '../models/User.js';
+
+// Reset all user balances and transactions while keeping the database structure.
+// Also clears other collections so the database starts empty for production.
 
 dotenv.config();
 
@@ -12,10 +16,23 @@ if (!uri || uri === 'memory') {
 await mongoose.connect(uri);
 
 try {
-  await mongoose.connection.dropDatabase();
-  console.log('Database dropped. All user balances reset to 0.');
+  // Reset balances and transactions for all users
+  await User.updateMany({}, {
+    $set: { balance: 0, minedTPC: 0, transactions: [] }
+  });
+
+  // Remove documents from all other collections while keeping their structure
+  const collections = await mongoose.connection.db.collections();
+  for (const collection of collections) {
+    if (collection.collectionName !== 'users') {
+      await collection.deleteMany({});
+    }
+  }
+
+  console.log('Database cleaned. All user balances and transactions reset to 0.');
 } catch (err) {
   console.error('Failed to reset database:', err.message);
 } finally {
   await mongoose.disconnect();
 }
+


### PR DESCRIPTION
## Summary
- Reset balances and transactions for all users without dropping collections
- Clear non-user collections while preserving database structure

## Testing
- `npm test` *(fails: joinRoom clears lobby seat)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893472a31188329a0f0d0973833ebec