### PR TITLE
Add Solflare and WalletConnect wallet adapters

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -13,6 +13,8 @@
     "@solana/wallet-adapter-phantom": "^0.9.28",
     "@solana/wallet-adapter-react": "^0.15.39",
     "@solana/wallet-adapter-react-ui": "^0.9.39",
+    "@solana/wallet-adapter-solflare": "^0.6.32",
+    "@solana/wallet-adapter-walletconnect": "^0.1.21",
     "@solana/web3.js": "^1.98.4",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.15",

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -7,6 +7,9 @@ import { Buffer } from 'buffer';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
 import { PhantomWalletAdapter } from '@solana/wallet-adapter-phantom';
+import { SolflareWalletAdapter } from '@solana/wallet-adapter-solflare';
+import { WalletConnectWalletAdapter } from '@solana/wallet-adapter-walletconnect';
+import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
 import { clusterApiUrl } from '@solana/web3.js';
 import '@solana/wallet-adapter-react-ui/styles.css';
 
@@ -14,7 +17,26 @@ import '@solana/wallet-adapter-react-ui/styles.css';
 if (!window.Buffer) window.Buffer = Buffer;
 
 const endpoint = clusterApiUrl('mainnet-beta');
-const wallets = [new PhantomWalletAdapter()];
+const wallets = [
+  new PhantomWalletAdapter(),
+  new SolflareWalletAdapter(),
+  new WalletConnectWalletAdapter({
+    network: WalletAdapterNetwork.Mainnet,
+    options: {
+      projectId: 'e899c82be21d4acca2c8aec45e893598',
+      relayUrl: 'wss://relay.walletconnect.com',
+      metadata: {
+        name: 'TonPlaygram Web App',
+        description: 'TonPlaygram Web App',
+        url: typeof window !== 'undefined' ? window.location.href : '',
+        icons: []
+      }
+    },
+    modalOptions: {
+      mobileLinks: ['phantom', 'solflare']
+    }
+  })
+];
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- add Solflare and WalletConnect adapters to the wallet list
- configure WalletConnect to deep link to Phantom and Solflare on mobile

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689355cef37c832993de65ba2ba8d839