### PR TITLE
chore: remove tokenomics section from home page

### DIFF
--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -1,15 +1,11 @@
 import { useEffect, useState } from 'react';
 
-import GameCard from '../components/GameCard.jsx';
-
-
 import TasksCard from '../components/TasksCard.jsx';
 import NftGiftCard from '../components/NftGiftCard.jsx';
 import ProjectAchievementsCard from '../components/ProjectAchievementsCard.jsx';
 import HomeGamesCard from '../components/HomeGamesCard.jsx';
 
 import {
-  FaUser,
   FaArrowCircleUp,
   FaArrowCircleDown,
   FaWallet
@@ -36,40 +32,6 @@ import TonConnectButton from '../components/TonConnectButton.jsx';
 import useTokenBalances from '../hooks/useTokenBalances.js';
 import useWalletUsdValue from '../hooks/useWalletUsdValue.js';
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
-import { PTONTPC_LP_TOKEN } from '../utils/lpToken.js';
-
-// Token contract on the TON network
-const TPC_JETTON_ADDRESS =
-  'EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X';
-
-// Public wallet addresses with initial allocations
-const walletAddresses = [
-  {
-    label: 'Mining',
-    address: 'UQDM5AVaMaeoLEvSwBn3C6MuMZ-Ouf0IQXEA-kbnzCuKLRBJ',
-  },
-  { label: 'Dev', address: 'UQC5D42owfZ9JzYhyDid93QdVCX8D-DhgupB27FMpKNMf0lb' },
-  {
-    label: 'DEX/CEX & Liquidity',
-    address: 'UQDSPHxwE8o9HoEUF89U-U577GPI_5pdESDkUBIQ4RzFWiH1',
-  },
-  {
-    label: 'Development & Treasury',
-    address: 'UQCGMf2Xqdw6uDpPidA0ufcEeXU4Z7i2DwIxT5gkH4AENmaJ',
-  },
-  {
-    label: 'Marketing & Growth',
-    address: 'UQCGfGKrqLQ8vmsVNLMzBtOUZ-S2-83kQGPoDlHUiKLcf1pm',
-  },
-  {
-    label: 'Referral Leaderboard Airdrop',
-    address: 'UQB28dBa2IUtMfeK2k68FLYqCfXV7_Oh6rB1BdiSZKcvrwxB',
-  },
-  {
-    label: 'Advisors & Partners',
-    address: 'UQDZmB800S6JkIpStYXocag08stDFEHgo1lbxHOXP8bfQRto',
-  },
-];
 
 
 export default function Home() {
@@ -81,14 +43,7 @@ export default function Home() {
   const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
   const walletAddress = useTonAddress();
   const [tonConnectUI] = useTonConnectUI();
-  const shortAddress = walletAddress
-    ? `${walletAddress.slice(0, 4)}...${walletAddress.slice(-4)}`
-    : '';
 
-  const [supply, setSupply] = useState(null);
-  const [holders, setHolders] = useState(null);
-  const [contractTonBalance, setContractTonBalance] = useState(null);
-  const [walletBalances, setWalletBalances] = useState({});
 
   useEffect(() => {
     ping()
@@ -148,55 +103,6 @@ export default function Home() {
     };
     window.addEventListener('profilePhotoUpdated', handleUpdate);
     return () => window.removeEventListener('profilePhotoUpdated', handleUpdate);
-  }, []);
-
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await fetch(
-          `https://tonapi.io/v2/jettons/${TPC_JETTON_ADDRESS}`
-        );
-        const data = await res.json();
-        const decimals = Number(data.metadata?.decimals) || 0;
-        setSupply(Number(data.total_supply) / 10 ** decimals);
-        setHolders(data.holders_count);
-      } catch (err) {
-        console.error('Failed to load TPC info:', err);
-      }
-      try {
-        const res = await fetch(
-          `https://tonapi.io/v2/accounts/${TPC_JETTON_ADDRESS}`
-        );
-        const acc = await res.json();
-        setContractTonBalance(Number(acc.balance) / 1e9);
-      } catch (err) {
-        console.error('Failed to load contract balance:', err);
-      }
-    }
-    load();
-  }, []);
-
-  useEffect(() => {
-    async function loadBalances() {
-      const map = {};
-      await Promise.all(
-        walletAddresses.map(async (w) => {
-          try {
-            const res = await fetch(
-              `https://tonapi.io/v2/accounts/${w.address}/jettons/${TPC_JETTON_ADDRESS}`
-            );
-            if (!res.ok) return;
-            const data = await res.json();
-            const decimals = Number(data.jetton?.decimals) || 0;
-            map[w.address] = Number(data.balance) / 10 ** decimals;
-          } catch (err) {
-            console.error('Failed to load balance for', w.address, err);
-          }
-        })
-      );
-      setWalletBalances(map);
-    }
-    loadBalances();
   }, []);
 
 
@@ -285,74 +191,10 @@ export default function Home() {
 
       </div>
 
-      <div className="grid grid-cols-1 gap-4">
-        <TasksCard />
-        <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
-          <img
-            src="/assets/SnakeLaddersbackground.png"
-            className="background-behind-board object-cover"
-            alt=""
-              onError={(e) => { e.currentTarget.style.display = "none"; }}
-          />
-          <h3 className="text-lg font-bold text-text text-center">Tokenomics &amp; Roadmap</h3>
-          {/* Removed outdated emission schedule */}
-          <div className="space-y-1 text-center">
-            <p className="text-lg font-bold">Total Balance</p>
-            <p className="text-2xl flex items-center gap-1 justify-center">
-              {supply == null ? '...' : formatValue(supply, 2)}
-              <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="w-4 h-4" />
-            </p>
-            {holders != null && (
-              <p className="text-sm text-subtext">Holders: {holders}</p>
-            )}
-          </div>
-          <div className="space-y-1">
-            <h4 className="text-sm font-bold text-center">TPC Wallet Addresses</h4>
-            <ul className="text-xs break-all space-y-1">
-              {walletAddresses.map((w) => (
-                <li key={w.address} className="flex justify-between items-center gap-2">
-                  <div>
-                    <span className="font-semibold text-brand-gold">{w.label}: </span>
-                    <a
-                      href={`https://tonscan.org/address/${w.address}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-primary hover:underline"
-                    >
-                      {w.address}
-                    </a>
-                  </div>
-                  {walletBalances[w.address] != null && (
-                    <span className="flex items-center whitespace-nowrap">
-                      {formatValue(walletBalances[w.address], 2)}{' '}
-                      <img src="/assets/icons/TPCcoin_1.webp" alt="TPC" className="inline-block w-3 h-3 ml-1" />
-                    </span>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className="space-y-1 text-center text-xs">
-            <img
-              src={PTONTPC_LP_TOKEN.image}
-              alt={PTONTPC_LP_TOKEN.symbol}
-              className="w-8 h-8 mx-auto"
-            />
-            <p className="font-semibold">{PTONTPC_LP_TOKEN.name}</p>
-            <p>{PTONTPC_LP_TOKEN.description}</p>
-            <p className="break-all text-brand-gold">
-              Address: {PTONTPC_LP_TOKEN.address}
-            </p>
-          </div>
-          <Link
-            to="/tokenomics"
-            className="mx-auto block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow text-center"
-          >
-            Learn More
-          </Link>
+        <div className="grid grid-cols-1 gap-4">
+          <TasksCard />
         </div>
-      </div>
-      <ProjectAchievementsCard />
+        <ProjectAchievementsCard />
 
       <div className="flex justify-center space-x-4 mt-4">
         <a


### PR DESCRIPTION
## Summary
- remove tokenomics & Roadmap card from home page
- drop unused tokenomics imports and state

## Testing
- `npm test` *(fails: joinRoom waits until table full)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689472226db88329978b55cd65abf069