### PR TITLE
Warn when ALLOWED_ORIGINS missing and tighten CORS default

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -45,23 +45,28 @@ if (!process.env.MONGODB_URI) {
 }
 
 const PORT = process.env.PORT || 3000;
-const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
-
-  .split(',')
-
-  .map((o) => o.trim())
-
-  .filter(Boolean);
+const allowedOriginsRaw = process.env.ALLOWED_ORIGINS;
+if (!allowedOriginsRaw) {
+  console.warn(
+    'ALLOWED_ORIGINS not set. Cross-origin requests will be blocked. Set ALLOWED_ORIGINS to a comma-separated list of allowed origins.'
+  );
+}
+const allowedOrigins = allowedOriginsRaw
+  ? allowedOriginsRaw
+      .split(',')
+      .map((o) => o.trim())
+      .filter(Boolean)
+  : [];
 
 const rateLimitWindowMs =
   Number(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
 
 const rateLimitMax = Number(process.env.RATE_LIMIT_MAX) || 100;
 const app = express();
-app.use(cors({ origin: allowedOrigins.length ? allowedOrigins : '*' }));
+app.use(cors({ origin: allowedOrigins }));
 const httpServer = http.createServer(app);
 const io = new SocketIOServer(httpServer, {
-  cors: { origin: allowedOrigins.length ? allowedOrigins : '*' }
+  cors: { origin: allowedOrigins }
 });
 const gameManager = new GameRoomManager(io);
 


### PR DESCRIPTION
## Summary
- warn when ALLOWED_ORIGINS env var is missing and default to blocking cross-origin requests
- remove permissive wildcard fallback for CORS and Socket.IO

## Testing
- `npm test` *(fails: joinRoom clears lobby seat; joinRoom waits until table full)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689479effb9c83299a57c16b2d0629be