### PR TITLE
feat: add flexible rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@
 
   - `API_AUTH_TOKEN` – (optional) token for trusted server-to-server calls
 
-  - `RATE_LIMIT_WINDOW_MS` – (optional) timeframe for rate limits in milliseconds (defaults to 900000)
+  - `RATE_LIMIT_WINDOW_MS` – (optional) timeframe for rate limits in milliseconds (defaults to 60000)
 
-  - `RATE_LIMIT_MAX` – (optional) max requests per window from one IP (defaults to 100)
+  - `RATE_LIMIT_MAX` – (optional) max requests per window from one IP or authenticated user (defaults to 100)
+
+  - `SENSITIVE_RATE_LIMIT_WINDOW_MS` – (optional) timeframe for sensitive route limits in milliseconds (defaults to 300000)
+
+  - `SENSITIVE_RATE_LIMIT_MAX` – (optional) max requests per window for sensitive routes (defaults to 10)
 
   - `ALLOWED_ORIGINS` – list of origins allowed for CORS and socket.io. Multiple origins may be comma-separated
 

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -10,8 +10,10 @@ MONGODB_URI=memory
 PORT=3000
 
 # Rate limit configuration
-RATE_LIMIT_WINDOW_MS=900000
+RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX=100
+SENSITIVE_RATE_LIMIT_WINDOW_MS=300000
+SENSITIVE_RATE_LIMIT_MAX=10
 
 # Comma-separated list of admin tokens for the airdrop API.
 # These tokens also authorize access to the /api/broadcast route.


### PR DESCRIPTION
## Summary
- support per-IP or user rate limiting via keyGenerator
- add stricter rate limits for wallet and account routes
- document rate limit environment variables

## Testing
- `npm run lint`
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_689479ec15048329839f8884671b1cfb