### PR TITLE
Prebuild webapp and simplify runtime asset serving

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,10 @@ services:
     name: tonplaygram-api
     branch: main
     rootDir: bot
-    buildCommand: npm install && npm --prefix ../webapp install && npm --prefix ../webapp run build
+    buildCommand: |
+      npm install
+      npm --prefix ../webapp ci
+      npm --prefix ../webapp run build
     startCommand: npm start
 
   - type: web


### PR DESCRIPTION
## Summary
- prebuild the webapp during CI/CD via render.yaml
- remove runtime webapp build logic and serve only static assets if present

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689479eecd508329940c0605b4a4471e