### PR TITLE
Add helmet for security headers

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -14,6 +14,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^7.5.1",
     "geoip-lite": "^1.4.10",
+    "helmet": "^8.1.0",
     "https-proxy-agent": "^7.0.2",
     "mongodb-memory-server": "^10.1.4",
     "mongoose": "^7.6.0",

--- a/bot/server.js
+++ b/bot/server.js
@@ -32,6 +32,7 @@ import { execSync } from 'child_process';
 import { randomUUID } from 'crypto';
 import compression from 'compression';
 import rateLimit from 'express-rate-limit';
+import helmet from 'helmet';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -58,6 +59,21 @@ const rateLimitWindowMs =
 
 const rateLimitMax = Number(process.env.RATE_LIMIT_MAX) || 100;
 const app = express();
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        connectSrc: ["'self'", ...allowedOrigins],
+        imgSrc: ["'self'", 'data:', 'blob:'],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        scriptSrc: ["'self'"]
+      }
+    },
+    crossOriginEmbedderPolicy: false,
+    crossOriginResourcePolicy: false
+  })
+);
 app.use(cors({ origin: allowedOrigins.length ? allowedOrigins : '*' }));
 const httpServer = http.createServer(app);
 const io = new SocketIOServer(httpServer, {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
   "dependencies": {
     "dotenv": "^16.3.1",
     "emoji-name-map": "^2.0.3",
-    "geoip-lite": "^1.4.10",
-    "mongoose": "^7.6.0",
     "express": "^4.19.2",
+    "geoip-lite": "^1.4.10",
+    "helmet": "^8.1.0",
+    "mongoose": "^7.6.0",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.8.1",
     "ton": "^13.9.0",
@@ -46,7 +47,7 @@
     "eslint-plugin-promise": "^6.6.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "prettier": "^3.6.2",
-    "mongodb-memory-server": "^10.1.4"
+    "mongodb-memory-server": "^10.1.4",
+    "prettier": "^3.6.2"
   }
 }


### PR DESCRIPTION
## Summary
- Add helmet dependency
- Apply helmet middleware with CSP to bot server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689479edb4488329bce78a943408da5d