### PR TITLE
Update TPC icon and site logo assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Token icons for the lobby and wallet are now stored as WebP files:
 
 - `assets/icons/TON.webp`
 - `assets/icons/Usdt.webp`
-- `assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp`
+- `assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp`
 
 Place your own images with those exact names in the same directories to
 override them.

--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -6,7 +6,7 @@ import { fetchTelegramInfo } from './telegram.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const coinPath = path.join(
   __dirname,
-  '../../webapp/public/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp'
+  '../../webapp/public/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp'
 );
 
 export function getInviteUrl(roomId, token, amount, game = 'snake') {

--- a/tpc_metadata.json
+++ b/tpc_metadata.json
@@ -3,5 +3,5 @@
   "symbol": "TPC",
   "decimals": 9,
   "description": "TonPlaygram Coin (TPC) powers mining, games, and rewards inside the TonPlaygram platform.",
-  "image": "https://tonplaygramwebapp.onrender.com/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp"
+  "image": "https://tonplaygramwebapp.onrender.com/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp"
 }

--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -22,8 +22,8 @@ export default function BalanceSummary({ className = '', showHeader = true }) {
       )}
       <div className="grid grid-cols-3 text-sm mt-4">
         <Token icon="/assets/icons/TON.webp" label="TON" value={tonBalance ?? '...'} />
-        <Token icon="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" label="TPC (App)" value={tpcBalance ?? 0} decimals={2} />
-        <Token icon="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" label="TPC" value={tpcWalletBalance ?? '...'} decimals={2} />
+        <Token icon="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" label="TPC (App)" value={tpcBalance ?? 0} decimals={2} />
+        <Token icon="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" label="TPC" value={tpcWalletBalance ?? '...'} decimals={2} />
       </div>
     </div>
   );

--- a/webapp/src/components/Branding.jsx
+++ b/webapp/src/components/Branding.jsx
@@ -5,7 +5,7 @@ export default function Branding({ scale = 1, offsetY = 0 }) {
     <div className="text-center py-6 space-y-2">
       <img
 
-        src="/assets/icons/file_000000002f08620a8b0d3154b9c3fdaa.webp"
+        src="/assets/icons/TonPlayGramLogo_2_512x512.webp"
         alt="TonPlaygram Logo"
         className="mx-auto"
         style={{ transform: `scale(${scale})`, marginTop: offsetY }}

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -137,7 +137,7 @@ export default function DailyCheckIn() {
 
         <span className="flex items-center">
           {formatReward(REWARDS[i])}
-          <img  src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-8 h-8 -ml-1" />
+          <img  src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-8 h-8 -ml-1" />
         </span>
 
         {i === streak - 1 && showPopup && (

--- a/webapp/src/components/GameEndPopup.jsx
+++ b/webapp/src/components/GameEndPopup.jsx
@@ -6,7 +6,7 @@ export default function GameEndPopup({ open, ranking, onPlayAgain, onReturn }) {
   return createPortal(
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
-        <img  src="/assets/icons/file_000000002f08620a8b0d3154b9c3fdaa.webp" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
+        <img  src="/assets/icons/TonPlayGramLogo_2_512x512.webp" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
         <h3 className="text-lg font-bold text-center">Game Over</h3>
         <ol className="list-decimal list-inside space-y-1 text-center">
           {ranking.map((name, i) => (

--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -118,7 +118,7 @@ export default function GiftPopup({ open, onClose, players = [], senderIndex = 0
                   <GiftIcon icon={g.icon} className="w-4 h-4" />
                     <span className="flex items-center space-x-0.5">
                       <span>{g.price}</span>
-                      <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-3 h-3" />
+                      <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-3 h-3" />
                     </span>
                   </button>
                 ))}
@@ -128,7 +128,7 @@ export default function GiftPopup({ open, onClose, players = [], senderIndex = 0
           <div className="text-xs text-center mt-2 flex items-center justify-center space-x-1">
             <span>Cost:</span>
             <span>{selected.price}</span>
-            <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-3 h-3" />
+            <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-3 h-3" />
           </div>
           <button
             className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"

--- a/webapp/src/components/GiftShopPopup.jsx
+++ b/webapp/src/components/GiftShopPopup.jsx
@@ -49,7 +49,7 @@ export default function GiftShopPopup({ open, onClose, accountId }) {
                 </span>
                 <span className="flex items-center space-x-0.5">
                   <span>{g.price}</span>
-                  <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-3 h-3" />
+                  <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-3 h-3" />
                 </span>
               </button>
             ))}

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -25,7 +25,7 @@ export default function InvitePopup({
               
               src={
                 stake?.token === 'TPC'
-                  ? '/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp'
+                  ? '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp'
                   : stake?.token === 'TON'
                   ? '/assets/icons/TON.webp'
                   : '/assets/icons/Usdt.webp'

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -132,7 +132,7 @@ export default function LuckyNumber() {
             {(i !== 0 && selected !== i) ? (
               <>
                 <img
-                  src="/assets/icons/file_000000002f08620a8b0d3154b9c3fdaa.webp"
+                  src="/assets/icons/TonPlayGramLogo_2_512x512.webp"
                   alt="Logo"
                   className="absolute inset-0 w-full h-full object-contain opacity-40"
                 />
@@ -160,7 +160,7 @@ export default function LuckyNumber() {
                   </>
                 ) : (
                   <>
-                    <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-8 h-8" />
+                    <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-8 h-8" />
                     <span className="font-bold">{val}</span>
                     {i === 0 && <span className="text-red-500 text-xs">FREE</span>}
                   </>

--- a/webapp/src/components/NftGiftCard.jsx
+++ b/webapp/src/components/NftGiftCard.jsx
@@ -121,7 +121,7 @@ export default function NftGiftCard({ accountId: propAccountId }) {
             <div className="mt-auto flex flex-col items-center space-y-2 w-full">
               <span className="flex items-center space-x-1 text-lg">
                 <span>{previewInfo.price}</span>
-                <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-6 h-6" />
+                <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-6 h-6" />
               </span>
               <button
                 onClick={() => setConfirmConvert(true)}

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -85,7 +85,7 @@ export default function PlayerInvitePopup({
               <p className="text-sm flex items-center justify-center gap-1">
                 Balance:
                 <img
-                  src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp"
+                  src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp"
                   alt="TPC"
                   className="inline w-4 h-4"
                 />

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -22,7 +22,7 @@ export default function RewardPopup({
   useEffect(() => {
     let audio: HTMLAudioElement | undefined;
     if (!disableEffects) {
-      let icon = '/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp';
+      let icon = '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp';
       if (reward === 'BONUS_X3') {
         icon = '/assets/icons/file_00000000ead061faa3b429466e006f48.webp';
       } else if (reward === 'FREE_SPIN') {
@@ -69,7 +69,7 @@ export default function RewardPopup({
             <>
               <img
 
-                src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp"
+                src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp"
                 alt="TPC"
                 className="w-8 h-8"
               />

--- a/webapp/src/components/RoomPopup.jsx
+++ b/webapp/src/components/RoomPopup.jsx
@@ -21,7 +21,7 @@ export default function RoomPopup({
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
         <img
 
-          src="/assets/icons/file_000000002f08620a8b0d3154b9c3fdaa.webp"
+          src="/assets/icons/TonPlayGramLogo_2_512x512.webp"
           alt="TonPlaygram Logo"
           className="w-10 h-10 mx-auto"
         />

--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -6,7 +6,7 @@ const AMOUNTS = {
   USDT: [0.1, 0.5, 1, 5, 10],
 };
 const tokens = [
-  { id: 'TPC', icon: '/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp' },
+  { id: 'TPC', icon: '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp' },
   { id: 'TON', icon: '/assets/icons/TON.webp' },
   { id: 'USDT', icon: '/assets/icons/Usdt.webp' },
 ];

--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -19,7 +19,7 @@ function CoinBurst({ token }) {
           key={i}
           src={
             token.toUpperCase() === 'TPC'
-              ? '/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp'
+              ? '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp'
               : `/icons/${token.toLowerCase()}.svg`
           }
           alt=""
@@ -272,7 +272,7 @@ export default function SnakeBoard({
                       ? '/assets/icons/TON.webp'
                       : token === 'USDT'
                         ? '/assets/icons/Usdt.webp'
-                        : '/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp'
+                        : '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp'
                   }
 
                   alt={token}
@@ -284,7 +284,7 @@ export default function SnakeBoard({
                       ? '/assets/icons/TON.webp'
                       : token === 'USDT'
                         ? '/assets/icons/Usdt.webp'
-                        : '/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp'
+                        : '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp'
                   }
                   alt=""
                   className="coin-face back"

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -226,7 +226,7 @@ export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(
                 </>
               ) : (
                 <>
-                  <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-8 h-8" />
+                  <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-8 h-8" />
                   <span>{val >= 1000 ? `${val / 1000}k` : val}</span>
                 </>
               )}

--- a/webapp/src/components/TablePopup.jsx
+++ b/webapp/src/components/TablePopup.jsx
@@ -8,7 +8,7 @@ export default function TablePopup({ open, tables, onSelect }) {
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
         <img
 
-          src="/assets/icons/file_000000002f08620a8b0d3154b9c3fdaa.webp"
+          src="/assets/icons/TonPlayGramLogo_2_512x512.webp"
           alt="TonPlaygram Logo"
           className="w-10 h-10 mx-auto"
         />

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -249,7 +249,7 @@ export default function TasksCard() {
           <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
             <AiOutlineCheck className="w-5 h-5 text-accent" />
             <span className="text-sm">Daily Check-In</span>
-            <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1]} <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-4 h-4" /></span>
+            <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1]} <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-4 h-4" /></span>
             {lastCheck && Date.now() - lastCheck < ONE_DAY ? (
               <span className="text-green-500 font-semibold text-sm">Done</span>
             ) : (
@@ -267,7 +267,7 @@ export default function TasksCard() {
             <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
               {ICONS[t.id]}
               <span className="text-sm">{t.description}</span>
-              <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-4 h-4" /></span>
+              <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-4 h-4" /></span>
               {t.completed && t.id === 'post_tweet' && t.cooldown > 0 ? (
                 <span className="text-sm text-subtext">{formatTime(t.cooldown)}</span>
               ) : t.completed ? (
@@ -310,7 +310,7 @@ export default function TasksCard() {
           <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
             {ICONS.watch_ad}
             <span className="text-sm">Watch Ad ({adCount}/5)</span>
-            <span className="text-xs text-subtext flex items-center gap-1">50 <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-4 h-4" /></span>
+            <span className="text-xs text-subtext flex items-center gap-1">50 <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-4 h-4" /></span>
             {adCount >= 5 ? (
               <span className="text-green-500 font-semibold text-sm">Done</span>
             ) : (
@@ -327,7 +327,7 @@ export default function TasksCard() {
           <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
             {ICONS.watch_ad}
             <span className="text-sm">Advertising Quest</span>
-            <span className="text-xs text-subtext flex items-center gap-1">200 <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-4 h-4" /></span>
+            <span className="text-xs text-subtext flex items-center gap-1">200 <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-4 h-4" /></span>
             {questTime > 0 ? (
               <span className="text-sm text-subtext">{formatTime(questTime)}</span>
             ) : (

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -47,7 +47,7 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
 
   const iconMap = {
 
-    TPC: '/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp',
+    TPC: '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp',
 
     TON: '/assets/icons/TON.webp',
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1038,7 +1038,7 @@ input:focus {
   transform-origin: bottom center;
   background-image:
     linear-gradient(to bottom, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0) 70%),
-    url("/assets/icons/file_000000002f08620a8b0d3154b9c3fdaa.webp");
+    url("/assets/icons/TonPlayGramLogo_2_512x512.webp");
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -168,7 +168,7 @@ function CoinBurst({ token }) {
           key={i}
           src={
             token.toUpperCase() === 'TPC'
-              ? '/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp'
+              ? '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp'
               : token.toUpperCase() === 'TON'
               ? '/assets/icons/TON.webp'
               : '/assets/icons/Usdt.webp'
@@ -480,7 +480,7 @@ function Board({
                       ? '/assets/icons/TON.webp'
                       : token === 'USDT'
                         ? '/assets/icons/Usdt.webp'
-                        : '/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp'
+                        : '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp'
                   }
                   alt={token}
                   className="coin-face front"
@@ -491,7 +491,7 @@ function Board({
                       ? '/assets/icons/TON.webp'
                       : token === 'USDT'
                         ? '/assets/icons/Usdt.webp'
-                        : '/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp'
+                        : '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp'
                   }
                   alt=""
                   className="coin-face back"
@@ -682,7 +682,7 @@ export default function SnakeAndLadder() {
     });
     {
       const img = new Image();
-      img.src = '/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp';
+      img.src = '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp';
     }
     AVATARS.forEach((src) => {
       const img = new Image();
@@ -2495,7 +2495,7 @@ export default function SnakeAndLadder() {
                     ? '/assets/icons/TON.webp'
                     : token === 'USDT'
                     ? '/assets/icons/Usdt.webp'
-                    : '/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp'
+                    : '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp'
                 }
                 alt={token}
                 className="inline w-4 h-4 align-middle"

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -147,7 +147,7 @@ export default function Home() {
               <span className="text-base">{formatValue(tonBalance ?? '...')}</span>
             </div>
             <div className="flex-1 flex items-center justify-center space-x-1">
-              <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-8 h-8" />
+              <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-8 h-8" />
               <span className="text-base">{formatValue(tpcWalletBalance ?? '...', 2)}</span>
             </div>
           </div>
@@ -174,7 +174,7 @@ export default function Home() {
                   <span className="text-xs text-accent">Send</span>
                 </Link>
                 <div className="flex flex-col items-center space-y-1">
-                  <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-10 h-10" />
+                  <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-10 h-10" />
                   <span className="text-sm">{formatValue(tpcBalance ?? '...', 2)}</span>
                 </div>
                 <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -258,7 +258,7 @@ export default function Tasks() {
                 <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
                   <AiOutlineCheck className="w-5 h-5 text-accent" />
                   <span className="text-sm">Daily Check-In</span>
-                  <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1]} <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-4 h-4" /></span>
+                  <span className="text-xs text-subtext flex items-center gap-1">{REWARDS[streak - 1]} <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-4 h-4" /></span>
                   {lastCheck && Date.now() - lastCheck < ONE_DAY ? (
                     <span className="text-green-500 font-semibold text-sm">Completed</span>
                   ) : (
@@ -276,7 +276,7 @@ export default function Tasks() {
               <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
                 {ICONS[t.id]}
                 <span className="text-sm">{t.description}</span>
-                <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-4 h-4" /></span>
+                <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-4 h-4" /></span>
                 {t.completed && t.id === 'post_tweet' && t.cooldown > 0 ? (
                   <span className="text-sm text-subtext">{formatTime(t.cooldown)}</span>
                 ) : t.completed ? (
@@ -314,7 +314,7 @@ export default function Tasks() {
             <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
               {ICONS.watch_ad}
               <span className="text-sm">Watch Ad ({adCount}/5)</span>
-              <span className="text-xs text-subtext flex items-center gap-1">50 <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-4 h-4" /></span>
+              <span className="text-xs text-subtext flex items-center gap-1">50 <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-4 h-4" /></span>
               {adCount >= 5 ? (
                 <span className="text-green-500 font-semibold text-sm">Completed</span>
               ) : (
@@ -331,7 +331,7 @@ export default function Tasks() {
             <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
               {ICONS.watch_ad}
               <span className="text-sm">Advertising Quest</span>
-              <span className="text-xs text-subtext flex items-center gap-1">200 <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-4 h-4" /></span>
+              <span className="text-xs text-subtext flex items-center gap-1">200 <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-4 h-4" /></span>
               {questTime > 0 ? (
                 <span className="text-sm text-subtext">{formatTime(questTime)}</span>
               ) : (
@@ -387,7 +387,7 @@ export default function Tasks() {
                 <thead>
                   <tr className="border-b border-border">
                     <th className="py-1">Views Range</th>
-                    <th className="py-1 flex items-center justify-center gap-1">Reward <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-4 h-4" /></th>
+                    <th className="py-1 flex items-center justify-center gap-1">Reward <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-4 h-4" /></th>
                     <th className="py-1">Notes</th>
                   </tr>
                 </thead>
@@ -395,7 +395,7 @@ export default function Tasks() {
                   {INFLUENCER_REWARDS.map((r) => (
                     <tr key={r.range} className="border-b border-border last:border-0">
                       <td className="py-1">{r.range}</td>
-                      <td className="py-1 flex items-center justify-center gap-1">{r.reward.toLocaleString()} <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-4 h-4" /></td>
+                      <td className="py-1 flex items-center justify-center gap-1">{r.reward.toLocaleString()} <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-4 h-4" /></td>
                       <td className="py-1">{r.notes}</td>
                     </tr>
                   ))}
@@ -413,7 +413,7 @@ export default function Tasks() {
                   </div>
                   <div className="flex justify-between text-xs">
                     <span>Status: {s.status}</span>
-                    <span className="flex items-center gap-1">{s.rewardTPC.toLocaleString()} <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-4 h-4" /></span>
+                    <span className="flex items-center gap-1">{s.rewardTPC.toLocaleString()} <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-4 h-4" /></span>
                   </div>
                 </li>
               ))}

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -282,7 +282,7 @@ export default function Wallet({ hideClaim = false }) {
       <div className="prism-box p-6 space-y-2 min-h-40 flex flex-col items-start wide-card mx-auto">
         <p className="text-xs break-all w-full text-left">Account: {accountId || '...'}</p>
         <div className="flex items-center space-x-1">
-          <img src="/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp" alt="TPC" className="w-8 h-8" />
+          <img src="/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp" alt="TPC" className="w-8 h-8" />
           <span className="text-lg font-medium">TPC Balance</span>
         </div>
         <p className="text-xl font-medium">

--- a/webapp/src/utils/coinConfetti.ts
+++ b/webapp/src/utils/coinConfetti.ts
@@ -1,4 +1,4 @@
-export default function coinConfetti(count: number = 50, iconSrc: string = '/assets/icons/eab316f3-7625-42b2-9468-d421f81c4d7c.webp') {
+export default function coinConfetti(count: number = 50, iconSrc: string = '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp') {
   const container = document.createElement('div');
   container.style.position = 'fixed';
   container.style.top = '0';


### PR DESCRIPTION
## Summary
- Replace old TPC coin icon references with `file_000000005f0c61f48998df883554c3e8 (2).webp`
- Update branding to use `TonPlayGramLogo_2_512x512.webp` for logo components and styles

## Testing
- `npm test` *(fails: joinRoom waits until table full)*


------
https://chatgpt.com/codex/tasks/task_e_6895aa17627083298f385db31c2a2381