### PR TITLE
Add token verification for player seating

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,16 @@ Telegram ID. When a profile is requested the server first tries to find the
 account by `accountId`. Missing details such as the name or avatar are
 automatically filled from Telegram when a `telegramId` is provided.
 
+### Seating players
+
+Endpoints and socket events that seat a user at a lobby table now require a
+`token` alongside the `accountId`/`playerId`. The token must be the HMAC-SHA256
+signature of the account ID using the bot token as the secret. Include this
+value when calling `POST /api/snake/table/seat` or emitting the `seatTable`
+socket event. The webapp derives this value using the `VITE_BOT_TOKEN` build
+variable. Requests with an invalid token are rejected and sockets are
+disconnected.
+
 ### Claiming TPC on-chain
 
 Withdrawals and `/claim-external` trigger a signed message to

--- a/bot/server.js
+++ b/bot/server.js
@@ -29,7 +29,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync } from 'fs';
 import { execSync } from 'child_process';
-import { randomUUID } from 'crypto';
+import { randomUUID, createHmac } from 'crypto';
 import compression from 'compression';
 import rateLimit from 'express-rate-limit';
 
@@ -237,6 +237,15 @@ function cleanupSeats() {
     }
     if (players.size === 0) tableSeats.delete(tableId);
   }
+}
+
+function verifyAccountToken(accountId, token) {
+  const secret = process.env.BOT_TOKEN || '';
+  if (!accountId || !token || !secret) return false;
+  const expected = createHmac('sha256', secret)
+    .update(String(accountId))
+    .digest('hex');
+  return expected === token;
 }
 
 async function seatTableSocket(
@@ -489,9 +498,14 @@ app.get('/api/stats', async (req, res) => {
 });
 
 app.post('/api/snake/table/seat', (req, res) => {
-  const { tableId, playerId, name, avatar } = req.body || {};
+  const { tableId, playerId, name, avatar, token } = req.body || {};
   const pid = playerId;
-  if (!tableId || !pid) return res.status(400).json({ error: 'missing data' });
+  if (!tableId || !pid || !token) {
+    return res.status(400).json({ error: 'missing data' });
+  }
+  if (!verifyAccountToken(pid, token)) {
+    return res.status(401).json({ error: 'invalid token' });
+  }
   const [gameType, capStr] = tableId.split('-');
   seatTableSocket(pid, gameType, 0, Number(capStr) || 4, name, null, avatar);
   res.json({ success: true });
@@ -511,7 +525,15 @@ app.get('/api/snake/lobbies', async (req, res) => {
       const id = `snake-${cap}`;
       const room = await gameManager.getRoom(id, cap);
       const roomCount = room.players.filter((p) => !p.disconnected).length;
-      const lobbyCount = tableSeats.get(id)?.size || 0;
+      const lobbyCount = Array.from(tableSeats.entries()).reduce(
+        (cnt, [tid, players]) => {
+          const t = tableMap.get(tid);
+          return t && t.gameType === 'snake' && t.maxPlayers === cap
+            ? cnt + players.size
+            : cnt;
+        },
+        0
+      );
       const players = roomCount + lobbyCount;
       return { id, capacity: cap, players };
     })
@@ -678,6 +700,7 @@ io.on('connection', (socket) => {
     async (
       {
         accountId,
+        token,
         gameType,
         stake,
         maxPlayers = 4,
@@ -687,6 +710,11 @@ io.on('connection', (socket) => {
       },
       cb
     ) => {
+      if (!verifyAccountToken(accountId, token)) {
+        if (cb) cb({ success: false, error: 'invalid_token' });
+        socket.disconnect(true);
+        return;
+      }
       let table;
       if (tableId) {
         const [gt, capStr] = tableId.split('-');

--- a/test/joinSeatCleanup.test.js
+++ b/test/joinSeatCleanup.test.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { spawn } from 'child_process';
 import { setTimeout as delay } from 'timers/promises';
 import { io } from 'socket.io-client';
+import crypto from 'crypto';
 
 const distDir = new URL('../webapp/dist/', import.meta.url);
 
@@ -36,10 +37,14 @@ test('joinRoom clears lobby seat', { concurrency: false, timeout: 20000 }, async
   };
   const server = await startServer(env);
   try {
+    const token = crypto
+      .createHmac('sha256', 'dummy')
+      .update('p1')
+      .digest('hex');
     await fetch('http://localhost:3204/api/snake/table/seat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tableId: 'snake-2-100', accountId: 'p1', name: 'A', confirmed: true })
+      body: JSON.stringify({ tableId: 'snake-2-100', playerId: 'p1', name: 'A', token, confirmed: true })
     });
 
     let res = await fetch('http://localhost:3204/api/snake/lobbies');

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -18,7 +18,8 @@ import {
 import {
   getPlayerId,
   ensureAccountId,
-  getTelegramId
+  getTelegramId,
+  signAccountId
 } from '../../utils/telegram.js';
 import { canStartGame } from '../../utils/lobby.js';
 
@@ -192,10 +193,12 @@ export default function Lobby() {
     if (game === 'snake' && table && table.id !== 'single') {
       const accountId = await ensureAccountId().catch(() => null);
       if (!accountId) return;
+      const token = await signAccountId(accountId);
       socket.emit(
         'seatTable',
         {
           accountId,
+          token,
           gameType: 'snake',
           stake: stake.amount,
           maxPlayers: table.capacity,

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -278,11 +278,11 @@ export function getSnakeResults() {
   return fetch(API_BASE_URL + '/api/snake/results').then((r) => r.json());
 }
 
-export function seatTable(playerId, tableId, name) {
+export function seatTable(playerId, tableId, name, token) {
   return fetch(API_BASE_URL + '/api/snake/table/seat', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ playerId, tableId, name }),
+    body: JSON.stringify({ playerId, tableId, name, token }),
   }).then((r) => r.json());
 }
 

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -42,6 +42,23 @@ export async function ensureAccountId() {
   return id;
 }
 
+export async function signAccountId(id) {
+  const secret = import.meta.env.VITE_BOT_TOKEN;
+  if (!id || !secret) return '';
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(String(id)));
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
 export function getTelegramUsername() {
   if (typeof window !== 'undefined') {
     const name = window?.Telegram?.WebApp?.initDataUnsafe?.user?.username;


### PR DESCRIPTION
## Summary
- require HMAC token when seating players
- validate tokens before seating and disconnect invalid sockets
- document and expose token signing helper on client

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895dddf97d88329aeb75f8e4b3fc69d