### PR TITLE
feat: add TLS options for MongoDB connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,26 @@
    - `BOT_TOKEN` – your Telegram bot token
    - `MONGODB_URI` – MongoDB connection string or `memory`
      (falls back to an in-memory database if unset)
+   - `MONGODB_TLS_CERT`, `MONGODB_TLS_KEY` – (optional) client TLS certificate
+     and private key for MongoDB
+   - `MONGODB_TLS_CA` – (optional) CA certificate for MongoDB
    - `AIRDROP_ADMIN_TOKENS` – (optional) tokens allowed to trigger airdrops
-  - `DEPOSIT_WALLET_ADDRESS` – TON address that receives user deposits
-  - `STORE_DEPOSIT_ADDRESS` – TON address that receives payments for store bundles
-  - `CLAIM_CONTRACT_ADDRESS` – address of the deployed `tpc_claim_wallet` contract
-  - `CLAIM_WALLET_MNEMONIC` – seed phrase used to sign claim transactions
-  - `TPC_JETTON_ADDRESS` – token contract address shown after a claim
-  - `RPC_URL` – (optional) TON RPC endpoint for claim messages. Defaults to `https://toncenter.com/api/v2/jsonRPC`
+   - `DEPOSIT_WALLET_ADDRESS` – TON address that receives user deposits
+   - `STORE_DEPOSIT_ADDRESS` – TON address that receives payments for store bundles
+   - `CLAIM_CONTRACT_ADDRESS` – address of the deployed `tpc_claim_wallet` contract
+   - `CLAIM_WALLET_MNEMONIC` – seed phrase used to sign claim transactions
+   - `TPC_JETTON_ADDRESS` – token contract address shown after a claim
+   - `RPC_URL` – (optional) TON RPC endpoint for claim messages. Defaults to `https://toncenter.com/api/v2/jsonRPC`
    - `PORT` – (optional) port for the bot API server (defaults to 3000)
-- `DEV_ACCOUNT_ID` – account ID that collects transfer fees
+   - `DEV_ACCOUNT_ID` – account ID that collects transfer fees
 
-  - `DEV_ACCOUNT_ID_1` – (optional) secondary developer account (1% share)
+   - `DEV_ACCOUNT_ID_1` – (optional) secondary developer account (1% share)
 
-  - `DEV_ACCOUNT_ID_2` – (optional) secondary developer account (2% share)
+   - `DEV_ACCOUNT_ID_2` – (optional) secondary developer account (2% share)
 
-  - `API_AUTH_TOKEN` – (optional) token for trusted server-to-server calls
+   - `API_AUTH_TOKEN` – (optional) token for trusted server-to-server calls
 
-  - `RATE_LIMIT_WINDOW_MS` – (optional) timeframe for rate limits in milliseconds (defaults to 900000)
+   - `RATE_LIMIT_WINDOW_MS` – (optional) timeframe for rate limits in milliseconds (defaults to 900000)
 
   - `RATE_LIMIT_MAX` – (optional) max requests per window from one IP (defaults to 100)
 

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -5,6 +5,13 @@ BOT_TOKEN=your-telegram-bot-token
 # MongoDB connection string
 # Use `memory` to run an in-memory database (for testing/dev only)
 MONGODB_URI=memory
+# Optional TLS credentials for MongoDB
+# Provide these if your MongoDB instance requires client certificate authentication
+# Replace \n with actual newlines when setting values via environment variables
+MONGODB_TLS_CERT=
+MONGODB_TLS_KEY=
+# Optional CA certificate
+MONGODB_TLS_CA=
 
 # API port (defaults to 3000 if not set)
 PORT=3000

--- a/bot/server.js
+++ b/bot/server.js
@@ -640,8 +640,22 @@ if (mongoUri === 'memory') {
     }
   });
 } else if (mongoUri) {
+  const tlsCert = process.env.MONGODB_TLS_CERT;
+  const tlsKey = process.env.MONGODB_TLS_KEY;
+  const tlsCA = process.env.MONGODB_TLS_CA;
+  const mongoOptions = {};
+  if (tlsCert && tlsKey) {
+    mongoOptions.sslCert = tlsCert.replace(/\\n/g, '\n');
+    mongoOptions.sslKey = tlsKey.replace(/\\n/g, '\n');
+  }
+  if (tlsCA) {
+    mongoOptions.sslCA = tlsCA.replace(/\\n/g, '\n');
+  }
+  if (tlsCert || tlsKey || tlsCA) {
+    mongoOptions.ssl = true;
+  }
   mongoose
-    .connect(mongoUri)
+    .connect(mongoUri, mongoOptions)
     .then(() => console.log('Connected to MongoDB'))
     .catch((err) => console.error('MongoDB connection error:', err));
 } else {


### PR DESCRIPTION
## Summary
- allow backend to supply TLS certificate and key for MongoDB connections
- document new MongoDB TLS env vars and example configuration

## Testing
- `npm test` *(in progress; partial tests run before timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6895e94fde848329947c2b3247617a36