### PR TITLE
feat: support alternate MongoDB env names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 3. Copy `bot/.env.example` to `bot/.env` and update the values. At minimum set:
    - `BOT_TOKEN` – your Telegram bot token
    - `MONGODB_URI` – MongoDB connection string or `memory`
-     (falls back to an in-memory database if unset)
+     (aliases: `MONGO_URI`, `MONGODB_URL`; falls back to an in-memory database if unset)
    - `AIRDROP_ADMIN_TOKENS` – (optional) tokens allowed to trigger airdrops
   - `DEPOSIT_WALLET_ADDRESS` – TON address that receives user deposits
   - `STORE_DEPOSIT_ADDRESS` – TON address that receives payments for store bundles
@@ -120,6 +120,7 @@ The tests require minimal configuration via environment variables. Copy
 
 - `BOT_TOKEN` – any string is sufficient for testing
 - `MONGODB_URI` – set to `memory` to use the in-memory database
+  (aliases: `MONGO_URI`, `MONGODB_URL`)
 
 With these variables in place you can run the test suite with:
 

--- a/bot/scripts/banUser.js
+++ b/bot/scripts/banUser.js
@@ -1,10 +1,11 @@
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
 import User from '../models/User.js';
+import { getMongoUri } from '../utils/mongoUri.js';
 
 dotenv.config();
 
-const uri = process.env.MONGODB_URI;
+const uri = getMongoUri();
 if (!uri || uri === 'memory') {
   console.error('MONGODB_URI must be set to a MongoDB instance');
   process.exit(1);

--- a/bot/scripts/recalculateBalances.js
+++ b/bot/scripts/recalculateBalances.js
@@ -2,10 +2,11 @@ import mongoose from 'mongoose';
 import dotenv from 'dotenv';
 import User from '../models/User.js';
 import { ensureTransactionArray } from '../utils/userUtils.js';
+import { getMongoUri } from '../utils/mongoUri.js';
 
 dotenv.config();
 
-const uri = process.env.MONGODB_URI;
+const uri = getMongoUri();
 if (!uri || uri === 'memory') {
   console.error('MONGODB_URI must be set to a MongoDB instance');
   process.exit(1);

--- a/bot/scripts/refundPendingWithdrawals.js
+++ b/bot/scripts/refundPendingWithdrawals.js
@@ -2,10 +2,11 @@ import mongoose from 'mongoose';
 import dotenv from 'dotenv';
 import User from '../models/User.js';
 import { ensureTransactionArray } from '../utils/userUtils.js';
+import { getMongoUri } from '../utils/mongoUri.js';
 
 dotenv.config();
 
-const uri = process.env.MONGODB_URI;
+const uri = getMongoUri();
 if (!uri || uri === 'memory') {
   console.error('MONGODB_URI must be set to a MongoDB instance');
   process.exit(1);

--- a/bot/scripts/resetDatabase.js
+++ b/bot/scripts/resetDatabase.js
@@ -1,13 +1,14 @@
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
 import User from '../models/User.js';
+import { getMongoUri } from '../utils/mongoUri.js';
 
 // Reset all user balances and transactions while keeping the database structure.
 // Also clears other collections so the database starts empty for production.
 
 dotenv.config();
 
-const uri = process.env.MONGODB_URI;
+const uri = getMongoUri();
 if (!uri || uri === 'memory') {
   console.error('MONGODB_URI must be set to a MongoDB instance');
   process.exit(1);

--- a/bot/scripts/resetTPCBalances.js
+++ b/bot/scripts/resetTPCBalances.js
@@ -1,10 +1,11 @@
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
 import User from '../models/User.js';
+import { getMongoUri } from '../utils/mongoUri.js';
 
 dotenv.config();
 
-const uri = process.env.MONGODB_URI;
+const uri = getMongoUri();
 if (!uri || uri === 'memory') {
   console.error('MONGODB_URI must be set to a MongoDB instance');
   process.exit(1);

--- a/bot/scripts/reverseMistakenTPC.js
+++ b/bot/scripts/reverseMistakenTPC.js
@@ -1,5 +1,6 @@
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
+import { getMongoUri } from '../utils/mongoUri.js';
 
 dotenv.config();
 
@@ -64,7 +65,7 @@ async function reverseMistakenTPC() {
   }
 }
 
-const uri = process.env.MONGODB_URI;
+const uri = getMongoUri();
 if (!uri || uri === 'memory') {
   console.error('MONGODB_URI must be set to a MongoDB instance');
   process.exit(1);

--- a/bot/server.js
+++ b/bot/server.js
@@ -32,6 +32,7 @@ import { execSync } from 'child_process';
 import { randomUUID } from 'crypto';
 import compression from 'compression';
 import rateLimit from 'express-rate-limit';
+import { getMongoUri } from './utils/mongoUri.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -39,7 +40,7 @@ if (proxyUrl) {
   console.log(`Using HTTPS proxy ${proxyUrl}`);
 }
 
-if (!process.env.MONGODB_URI) {
+if (!getMongoUri()) {
   process.env.MONGODB_URI = 'memory';
   console.log('MONGODB_URI not set, defaulting to in-memory MongoDB');
 }

--- a/bot/utils/mongoUri.js
+++ b/bot/utils/mongoUri.js
@@ -1,0 +1,10 @@
+export function getMongoUri() {
+  const uri =
+    process.env.MONGODB_URI ||
+    process.env.MONGO_URI ||
+    process.env.MONGODB_URL;
+  if (uri) {
+    process.env.MONGODB_URI = uri;
+  }
+  return uri;
+}


### PR DESCRIPTION
## Summary
- ensure `MONGODB_URI` falls back to `MONGO_URI` or `MONGODB_URL`
- centralize MongoDB URI resolution and update scripts to use it
- document accepted MongoDB env var aliases

## Testing
- `npm run lint`
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_6895eff44a1c8329b249263d57b971e8