### PR TITLE
Fix sender balance calculation before TPC transfers

### DIFF
--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -180,13 +180,18 @@ router.post('/send', authenticate, async (req, res) => {
 
   const sender = await User.findOne({ telegramId: fromId });
 
-  if (!sender || sender.balance < amount) {
+  ensureTransactionArray(sender);
 
+  if (!sender) {
     return res.status(400).json({ error: 'insufficient balance' });
-
   }
 
-  ensureTransactionArray(sender);
+  const senderBalance = calculateBalance(sender);
+  sender.balance = senderBalance;
+
+  if (senderBalance < amount) {
+    return res.status(400).json({ error: 'insufficient balance' });
+  }
 
   let receiver = await User.findOne({ telegramId: toId });
 


### PR DESCRIPTION
## Summary
- Recompute sender balance from transaction history before allowing TPC transfers

## Testing
- `npm test` *(fails: joinRoom clears lobby seat, joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_68962991885c83298f5349894bcc6e20