### PR TITLE
Handle invalid server responses and fix Google ID index

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -41,7 +41,9 @@ const userSchema = new mongoose.Schema({
 
   telegramId: { type: Number, unique: true },
 
-  googleId: { type: String, unique: true },
+  // Allow multiple users without a Google account by making the unique
+  // index sparse (documents missing googleId won't conflict)
+  googleId: { type: String, default: null },
 
   googleEmail: { type: String, default: '' },
 
@@ -117,7 +119,8 @@ userSchema.index({ telegramId: 1 });
 userSchema.index({ accountId: 1 });
 userSchema.index({ nickname: 1 });
 userSchema.index({ referralCode: 1 });
-userSchema.index({ googleId: 1 });
+// Enforce uniqueness of googleId only when the field exists
+userSchema.index({ googleId: 1 }, { unique: true, sparse: true });
 userSchema.index({ walletAddress: 1 });
 
 userSchema.pre('save', function(next) {

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -27,11 +27,14 @@ async function post(path, body, token) {
     body: JSON.stringify(body)
   });
 
+  // Read response as text first to handle non-JSON replies gracefully
+  const text = await res.text();
   let data;
   try {
-    data = await res.json();
+    data = JSON.parse(text);
   } catch (err) {
-    return { error: err.message };
+    // Provide a generic error instead of exposing parse details
+    return { error: 'Invalid server response' };
   }
   if (!res.ok) {
     return { error: data.error || res.statusText };


### PR DESCRIPTION
## Summary
- Gracefully handle non-JSON API responses to avoid confusing parse errors
- Allow multiple users without Google accounts by using a sparse unique index on `googleId`

## Testing
- `npm test` *(fails: joinRoom clears lobby seat)*

------
https://chatgpt.com/codex/tasks/task_e_68962fd4aab0832999984386fab1ca0d