### PR TITLE
Upsert Telegram account on webapp startup

### DIFF
--- a/webapp/src/hooks/useTelegramAuth.js
+++ b/webapp/src/hooks/useTelegramAuth.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { socket } from '../utils/socket.js';
+import { createAccount } from '../utils/api.js';
 
 export default function useTelegramAuth() {
   useEffect(() => {
@@ -8,6 +9,9 @@ export default function useTelegramAuth() {
     if (user?.id) {
       localStorage.setItem('telegramId', user.id);
       socket.emit('register', { playerId: acc || user.id });
+      createAccount(user.id).catch(err => {
+        console.error('Failed to create account', err);
+      });
     } else if (acc) {
       socket.emit('register', { playerId: acc });
     }


### PR DESCRIPTION
## Summary
- create account on webapp launch when Telegram user ID is available
- log and ignore errors to avoid blocking login

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689646d69d1483299e9f4d0f169430bf