### PR TITLE
feat: add 3D poker demo

### DIFF
--- a/app/poker/page.tsx
+++ b/app/poker/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import PokerScene from '../../components/poker/PokerScene';
+import HUD from '../../components/poker/HUD';
+import RoomSelector from '../../components/poker/RoomSelector';
+import { FEATURE_FLAGS, BRAND } from '../../lib/config';
+import type { TableState, PlayerAction, JoinRoomPayload, StakeTier, Card } from '../../shared/pokerTypes';
+import { startHand, applyAction } from '../../shared/pokerLogic';
+
+// Placeholder stake locking functions for future TON integration
+export async function lockStakeTPC(_wallet: string, _amount: number, _roomId: string) {}
+export async function releaseStakeTPC(_wallet: string, _pot: number, _feeBps: number) {}
+
+export default function PokerPage() {
+  const useLocal = FEATURE_FLAGS.useLocalDemo;
+  const [joined, setJoined] = useState(false);
+  const [table, setTable] = useState<TableState | null>(null);
+  const [deck, setDeck] = useState<Card[]>([]);
+  const cardsRef = useRef<THREE.Mesh[]>([]);
+
+  const onJoin = ({ stake, seats }: JoinRoomPayload) => {
+    const players = [
+      { id: 'you', stack: stake * 10, bet: 0, folded: false },
+      { id: 'bot', stack: stake * 10, bet: 0, folded: false },
+    ];
+    const t: TableState = {
+      roomId: 'local',
+      stake,
+      seats,
+      players,
+      board: [],
+      pot: 0,
+      minRaise: stake / 5,
+    };
+    setTable(t);
+    setDeck([]);
+    setJoined(true);
+    lockStakeTPC('wallet', stake * 10, t.roomId);
+  };
+
+  const start = () => {
+    if (!table) return;
+    const { table: t, deck: d } = startHand(table);
+    setTable(t);
+    setDeck(d);
+    if (t.activePlayerId === 'bot') {
+      const afterBot = botAct(t, d);
+      setTable(afterBot.table);
+      setDeck(afterBot.deck);
+    }
+  };
+
+  const changeStake = (s: StakeTier) => {
+    setTable(t => (t ? { ...t, stake: s, minRaise: s / 5 } : t));
+  };
+
+  const advanceIfNeeded = (t: TableState, d: Card[]): { table: TableState; deck: Card[] } => {
+    const active = t.players.filter(p => !p.folded);
+    if (active.length <= 1) {
+      const winner = active[0];
+      const players = t.players.map(p =>
+        p.id === winner.id ? { ...p, stack: p.stack + t.pot, bet: 0 } : { ...p, bet: 0 }
+      );
+      releaseStakeTPC('wallet', t.pot, 0);
+      return { table: { ...t, players, pot: 0, activePlayerId: undefined, handFinished: true }, deck: d };
+    }
+    const maxBet = Math.max(...active.map(p => p.bet));
+    const allEqual = active.every(p => p.bet === maxBet);
+    if (!allEqual || t.activePlayerId) return { table: t, deck: d };
+    // betting round complete
+    let nextBoard: Card[] = t.board;
+    let take = 0;
+    if (t.board.length === 0) take = 3; // flop
+    else if (t.board.length === 3) take = 1; // turn
+    else if (t.board.length === 4) take = 1; // river
+    else {
+      // showdown
+      const winner = roughWinner(t);
+      const players = t.players.map(p =>
+        p.id === winner ? { ...p, stack: p.stack + t.pot, bet: 0 } : { ...p, bet: 0 }
+      );
+      releaseStakeTPC('wallet', t.pot, 0);
+      return {
+        table: { ...t, players, pot: 0, activePlayerId: undefined, handFinished: true },
+        deck: d,
+      };
+    }
+    nextBoard = [...t.board, ...d.slice(0, take)];
+    const nextDeck = d.slice(take);
+    const resetPlayers = t.players.map(p => ({ ...p, bet: 0 }));
+    return {
+      table: { ...t, board: nextBoard, players: resetPlayers, activePlayerId: active[0].id },
+      deck: nextDeck,
+    };
+  };
+
+  const botAct = (t: TableState, d: Card[]): { table: TableState; deck: Card[] } => {
+    if (t.activePlayerId !== 'bot') return { table: t, deck: d };
+    let action: PlayerAction = { type: 'CHECK_CALL' };
+    if (Math.random() < 0.2) action = { type: 'RAISE', amount: t.minRaise };
+    if (Math.random() < 0.1) action = { type: 'FOLD' };
+    let tableAfter = applyAction(t, 'bot', action);
+    let deckAfter = d;
+    ({ table: tableAfter, deck: deckAfter } = advanceIfNeeded(tableAfter, deckAfter));
+    return { table: tableAfter, deck: deckAfter };
+  };
+
+  const onAction = (a: PlayerAction) => {
+    if (!table) return;
+    let t = applyAction(table, 'you', a);
+    let d = deck;
+    ({ table: t, deck: d } = advanceIfNeeded(t, d));
+    if (!t.handFinished) {
+      const botRes = botAct(t, d);
+      t = botRes.table;
+      d = botRes.deck;
+    }
+    setTable(t);
+    setDeck(d);
+  };
+
+  // development smoke tests
+  const ranSmoke = useRef(false);
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production' || !table || ranSmoke.current) return;
+    ranSmoke.current = true;
+    console.log('cards length', cardsRef.current.length);
+    console.log('visible initial', cardsRef.current.filter(c => c.visible).length);
+    setTable(t => (t ? { ...t, board: ['Ah', 'Kd', 'Qc'] } : t));
+    setTimeout(() => {
+      console.log('visible after 3', cardsRef.current.filter(c => c.visible).length);
+      setTable(t => (t ? { ...t, board: [] } : t));
+    }, 0);
+  }, [table]);
+
+  if (!joined || !table) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ background: BRAND.bg }}>
+        <RoomSelector onJoin={onJoin} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative min-h-screen" style={{ background: BRAND.bg }}>
+      <PokerScene table={table} cardsRef={cardsRef} />
+      <HUD table={table} onAction={onAction} onStart={start} onStakeChange={changeStake} />
+    </div>
+  );
+}
+
+function roughWinner(t: TableState): string {
+  const ranks = '23456789TJQKA';
+  const strength = (cards: Card[]) => Math.max(...cards.map(c => ranks.indexOf(c[0])));
+  const you = t.players[0];
+  const bot = t.players[1];
+  const youScore = strength([...(you.hole ?? []), ...t.board]);
+  const botScore = strength([...(bot.hole ?? []), ...t.board]);
+  return youScore >= botScore ? you.id : bot.id;
+}

--- a/components/poker/HUD.tsx
+++ b/components/poker/HUD.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import type { TableState, StakeTier, PlayerAction } from '../../shared/pokerTypes';
+import { BRAND } from '../../lib/config';
+
+const STAKES: StakeTier[] = [100, 500, 1000, 5000, 10000];
+
+interface Props {
+  table: TableState;
+  onAction: (a: PlayerAction) => void;
+  onStart: () => void;
+  onStakeChange: (s: StakeTier) => void;
+}
+
+export default function HUD({ table, onAction, onStart, onStakeChange }: Props) {
+  const you = table.players[0];
+  const bot = table.players[1];
+  const isYourTurn = table.activePlayerId === you.id;
+  const stakeButtons = STAKES.map(s => (
+    <button
+      key={s}
+      onClick={() => onStakeChange(s)}
+      className={`px-2 py-1 rounded text-xs border ${
+        table.stake === s ? 'bg-[--gold] text-black' : 'bg-transparent text-[--gold]'
+      }`}
+    >
+      {s}
+    </button>
+  ));
+
+  return (
+    <div className="pointer-events-none text-white" style={{ '--gold': BRAND.gold } as any}>
+      <div className="absolute top-0 w-full flex flex-col items-center gap-2 p-2 pointer-events-auto">
+        <div className="flex gap-2">{stakeButtons}</div>
+        <button
+          onClick={onStart}
+          className="px-4 py-1 bg-[--gold] text-black rounded"
+        >
+          START
+        </button>
+        <div className="text-xs opacity-70">Pot: {table.pot} | Room: {table.roomId}</div>
+      </div>
+      <div className="absolute bottom-0 w-full p-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] pointer-events-auto">
+        <div className="flex justify-between text-sm mb-3">
+          <div>Ti: {you.stack}</div>
+          <div>Bot: {bot.stack}</div>
+        </div>
+        <div className="flex gap-2 justify-center">
+          <button
+            onClick={() => onAction({ type: 'FOLD' })}
+            disabled={!isYourTurn}
+            className="flex-1 py-2 rounded bg-[--gold] text-black disabled:opacity-30"
+          >
+            Fold
+          </button>
+          <button
+            onClick={() => onAction({ type: 'CHECK_CALL' })}
+            disabled={!isYourTurn}
+            className="flex-1 py-2 rounded bg-[--gold] text-black disabled:opacity-30"
+          >
+            Check/Call
+          </button>
+          <button
+            onClick={() => onAction({ type: 'RAISE', amount: table.minRaise })}
+            disabled={!isYourTurn}
+            className="flex-1 py-2 rounded bg-[--gold] text-black disabled:opacity-30"
+          >
+            Raise
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/poker/PokerScene.tsx
+++ b/components/poker/PokerScene.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, Environment } from '@react-three/drei';
+import * as THREE from 'three';
+import { MutableRefObject } from 'react';
+import Table3D from './objects/Table3D';
+import Chips3D from './objects/Chips3D';
+import Cards3D from './objects/Cards3D';
+import type { TableState } from '../../shared/pokerTypes';
+
+interface Props {
+  table?: TableState;
+  cardsRef?: MutableRefObject<THREE.Mesh[]>;
+}
+
+export default function PokerScene({ table, cardsRef }: Props) {
+  return (
+    <Canvas dpr={[1, 2]} camera={{ fov: 55, position: [0, 6.5, 10] }}>
+      <ambientLight intensity={0.5} />
+      <spotLight position={[0, 8, 5]} angle={0.3} penumbra={1} />
+      <Environment preset="city" />
+      <Table3D />
+      <Chips3D />
+      <Cards3D table={table} cardsRef={cardsRef} />
+      <OrbitControls enableZoom={false} maxPolarAngle={Math.PI / 2.2} />
+    </Canvas>
+  );
+}

--- a/components/poker/RoomSelector.tsx
+++ b/components/poker/RoomSelector.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+import type { StakeTier, SeatsOption, JoinRoomPayload } from '../../shared/pokerTypes';
+import { BRAND } from '../../lib/config';
+
+const STAKES: StakeTier[] = [100, 500, 1000, 5000, 10000];
+const SEATS: SeatsOption[] = [2, 4, 6, 9];
+
+interface Props {
+  onJoin: (p: JoinRoomPayload) => void;
+}
+
+export default function RoomSelector({ onJoin }: Props) {
+  const [stake, setStake] = useState<StakeTier>(STAKES[0]);
+  const [seats, setSeats] = useState<SeatsOption>(SEATS[0]);
+  return (
+    <div className="p-4 space-y-4 text-white" style={{ background: BRAND.panel }}>
+      <div>
+        <div className="mb-2">Stake</div>
+        <select
+          className="w-full p-2 rounded bg-transparent border border-[--gold]"
+          style={{ '--gold': BRAND.gold } as any}
+          value={stake}
+          onChange={e => setStake(Number(e.target.value) as StakeTier)}
+        >
+          {STAKES.map(s => (
+            <option key={s} value={s} className="text-black">
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <div className="mb-2">Seats</div>
+        <select
+          className="w-full p-2 rounded bg-transparent border border-[--gold]"
+          style={{ '--gold': BRAND.gold } as any}
+          value={seats}
+          onChange={e => setSeats(Number(e.target.value) as SeatsOption)}
+        >
+          {SEATS.map(s => (
+            <option key={s} value={s} className="text-black">
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button
+        className="w-full py-2 rounded bg-[--gold] text-black"
+        style={{ '--gold': BRAND.gold } as any}
+        onClick={() => onJoin({ stake, seats })}
+      >
+        Join Table
+      </button>
+    </div>
+  );
+}

--- a/components/poker/objects/Cards3D.tsx
+++ b/components/poker/objects/Cards3D.tsx
@@ -1,0 +1,53 @@
+import { useRef, useEffect } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import type { TableState } from '../../../shared/pokerTypes';
+
+interface Props {
+  table?: TableState;
+  cardsRef?: React.MutableRefObject<THREE.Mesh[]>;
+}
+
+export default function Cards3D({ table, cardsRef }: Props) {
+  const internal = useRef<THREE.Mesh[]>([]);
+  const cards = cardsRef ?? internal;
+  const rotations = useRef<number[]>(Array(5).fill(Math.PI));
+
+  useEffect(() => {
+    const n = table?.board.length ?? 0;
+    rotations.current = rotations.current.map((rot, i) => (i < n ? rot : Math.PI));
+  }, [table?.board]);
+
+  useFrame(() => {
+    const n = table?.board.length ?? 0;
+    cards.current.forEach((m, i) => {
+      if (!m) return;
+      const target = i < n ? 0 : Math.PI;
+      const current = rotations.current[i];
+      const next = current + (target - current) * 0.15;
+      rotations.current[i] = next;
+      m.rotation.y = next;
+      m.visible = i < n;
+    });
+  });
+
+  return (
+    <group position={[0, 0.05, 0]}>
+      {[0,1,2,3,4].map(i => (
+        <mesh
+          key={i}
+          ref={el => (cards.current[i] = el!)}
+          position={[i * 1.2 - 2.4, 0, 0]}
+          rotation={[0, Math.PI, 0]}
+        >
+          <boxGeometry args={[1, 0.02, 1.5]} />
+          <meshStandardMaterial color="white" />
+          <lineSegments>
+            <edgesGeometry args={[new THREE.BoxGeometry(1,0.02,1.5)]} />
+            <lineBasicMaterial color="#777" />
+          </lineSegments>
+        </mesh>
+      ))}
+    </group>
+  );
+}

--- a/components/poker/objects/Chips3D.tsx
+++ b/components/poker/objects/Chips3D.tsx
@@ -1,0 +1,14 @@
+import { BRAND } from '../../../lib/config';
+
+export default function Chips3D() {
+  return (
+    <group>
+      {[0, 0.15, 0.3].map(y => (
+        <mesh key={y} position={[0, y, 0]} rotation={[Math.PI / 2, 0, 0]}> 
+          <cylinderGeometry args={[0.5, 0.5, 0.1, 32]} />
+          <meshStandardMaterial color={BRAND.gold} metalness={0.9} roughness={0.3} />
+        </mesh>
+      ))}
+    </group>
+  );
+}

--- a/components/poker/objects/Table3D.tsx
+++ b/components/poker/objects/Table3D.tsx
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+import { MeshProps } from '@react-three/fiber';
+import { BRAND } from '../../../lib/config';
+import { PrismMaterial } from '../../../lib/prismMaterial';
+
+export default function Table3D(props: MeshProps) {
+  const radiusTop = 5;
+  const height = 0.3;
+  const segments = 32;
+  const rim = useMemo(() => (
+    <torus args={[radiusTop + 0.4, 0.2, 16, 64]} rotation={[Math.PI / 2, 0, 0]}>
+      <meshStandardMaterial color={BRAND.gold} metalness={0.8} roughness={0.3} />
+    </torus>
+  ), []);
+
+  return (
+    <group {...props}>
+      <mesh rotation={[Math.PI / 2, 0, 0]}>
+        <cylinderGeometry args={[radiusTop, radiusTop, height, segments]} />
+        <PrismMaterial />
+      </mesh>
+      <mesh rotation={[Math.PI / 2, 0, 0]} position={[0, 0.02, 0]}>
+        <cylinderGeometry args={[radiusTop - 0.2, radiusTop - 0.2, height / 2, segments]} />
+        <meshStandardMaterial color={BRAND.bg} metalness={0.2} roughness={0.9} />
+      </mesh>
+      {rim}
+    </group>
+  );
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,5 @@
+export const BRAND = { bg: '#0c1020', panel: '#11172a', gold: '#d4af37' } as const;
+
+export const FEATURE_FLAGS = { useLocalDemo: true } as const;
+
+export const POKER_WS_URL = process.env.NEXT_PUBLIC_POKER_WS_URL ?? 'http://localhost:4001';

--- a/lib/prismMaterial.ts
+++ b/lib/prismMaterial.ts
@@ -1,0 +1,15 @@
+import { JSX } from 'react';
+
+export function PrismMaterial(props: JSX.IntrinsicElements['meshPhysicalMaterial']) {
+  return (
+    <meshPhysicalMaterial
+      clearcoat={1}
+      transmission={0.12}
+      ior={1.4}
+      metalness={0.85}
+      roughness={0.2}
+      color="#0f1224"
+      {...props}
+    />
+  );
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "prettier": "^3.6.2",
-    "mongodb-memory-server": "^10.1.4"
+    "mongodb-memory-server": "^10.1.4",
+    "vitest": "^1.5.0"
   }
 }

--- a/shared/deck.ts
+++ b/shared/deck.ts
@@ -1,0 +1,23 @@
+import type { Card } from './pokerTypes';
+
+const RANKS = ['A','K','Q','J','T','9','8','7','6','5','4','3','2'] as const;
+const SUITS = ['h','d','c','s'] as const;
+
+export function newDeck(): Card[] {
+  const deck: Card[] = [];
+  for (const r of RANKS) {
+    for (const s of SUITS) {
+      deck.push(`${r}${s}` as Card);
+    }
+  }
+  return deck;
+}
+
+export function shuffle<T>(a: T[], rng: () => number = Math.random): T[] {
+  const arr = [...a];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}

--- a/shared/pokerLogic.ts
+++ b/shared/pokerLogic.ts
@@ -1,0 +1,83 @@
+import { newDeck, shuffle } from './deck';
+import type { TableState, PlayerAction, Card } from './pokerTypes';
+
+function rotateActive(ts: TableState): string | undefined {
+  if (!ts.activePlayerId) return undefined;
+  const idx = ts.players.findIndex(p => p.id === ts.activePlayerId);
+  for (let i = 1; i <= ts.players.length; i++) {
+    const p = ts.players[(idx + i) % ts.players.length];
+    if (!p.folded && p.stack > 0) return p.id;
+  }
+  return undefined;
+}
+
+export function startHand(ts: TableState, rng: () => number = Math.random): { table: TableState; deck: Card[] } {
+  const deck = shuffle(newDeck(), rng);
+  const players = ts.players.map(p => ({ ...p, bet: 0, folded: false, hole: [] as Card[] }));
+  // blinds
+  const sb = ts.stake / 10;
+  const bb = ts.stake / 5;
+  if (players[0]) {
+    players[0].bet = sb;
+    players[0].stack -= sb;
+  }
+  if (players[1]) {
+    players[1].bet = bb;
+    players[1].stack -= bb;
+  }
+  let deckIdx = 0;
+  for (let r = 0; r < 2; r++) {
+    for (const p of players) {
+      p.hole!.push(deck[deckIdx++]);
+    }
+  }
+  return {
+    table: {
+      ...ts,
+      players,
+      board: [],
+      pot: sb + bb,
+      minRaise: ts.stake / 5,
+      activePlayerId: players[2]?.id ?? players[0]?.id,
+      handFinished: false,
+    },
+    deck: deck.slice(deckIdx),
+  };
+}
+
+export function applyAction(ts: TableState, pid: string, action: PlayerAction): TableState {
+  const players = ts.players.map(p => ({ ...p }));
+  const actor = players.find(p => p.id === pid);
+  if (!actor) return ts;
+  let pot = ts.pot;
+  let minRaise = ts.minRaise;
+  switch (action.type) {
+    case 'FOLD':
+      actor.folded = true;
+      break;
+    case 'CHECK_CALL': {
+      const maxBet = Math.max(...players.map(p => p.bet));
+      const toCall = Math.max(0, maxBet - actor.bet);
+      const call = Math.min(toCall, actor.stack);
+      actor.bet += call;
+      actor.stack -= call;
+      pot += call;
+      break;
+    }
+    case 'RAISE': {
+      const maxBet = Math.max(...players.map(p => p.bet));
+      const raiseTo = maxBet + action.amount;
+      const diff = raiseTo - actor.bet;
+      const paid = Math.min(diff, actor.stack);
+      actor.bet += paid;
+      actor.stack -= paid;
+      pot += paid;
+      minRaise = action.amount;
+      break;
+    }
+  }
+  const activePlayerId = rotateActive({ ...ts, players, activePlayerId: pid });
+  const othersActive = players.filter(p => !p.folded).length;
+  const handFinished = othersActive <= 1;
+  return { ...ts, players, activePlayerId, handFinished, pot, minRaise };
+}

--- a/shared/pokerTypes.ts
+++ b/shared/pokerTypes.ts
@@ -1,0 +1,44 @@
+export type StakeTier = 100 | 500 | 1000 | 5000 | 10000;
+export type SeatsOption = 2 | 4 | 6 | 9;
+
+export type Card = `${'A'|'K'|'Q'|'J'|'T'|'9'|'8'|'7'|'6'|'5'|'4'|'3'|'2'}${'h'|'d'|'c'|'s'}`;
+
+export interface PlayerState {
+  id: string;
+  stack: number;
+  bet: number;
+  folded: boolean;
+  hole?: Card[];
+}
+
+export interface TableState {
+  roomId: string;
+  stake: StakeTier;
+  seats: SeatsOption;
+  players: PlayerState[];
+  board: Card[];
+  pot: number;
+  minRaise: number;
+  activePlayerId?: string;
+  handFinished?: boolean;
+}
+
+export type PlayerAction =
+  | { type: 'FOLD' }
+  | { type: 'CHECK_CALL' }
+  | { type: 'RAISE'; amount: number };
+
+export interface JoinRoomPayload {
+  stake: StakeTier;
+  seats: SeatsOption;
+}
+
+export enum ServerEvent {
+  TABLE_UPDATE = 'TABLE_UPDATE',
+}
+
+export enum ClientEvent {
+  JOIN_ROOM = 'JOIN_ROOM',
+  PLAYER_ACTION = 'PLAYER_ACTION',
+  START_HAND = 'START_HAND',
+}

--- a/test/deck.test.ts
+++ b/test/deck.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { newDeck, shuffle } from '../shared/deck';
+
+describe('deck', () => {
+  it('builds 52 unique cards', () => {
+    const deck = newDeck();
+    expect(deck.length).toBe(52);
+    expect(new Set(deck).size).toBe(52);
+  });
+
+  it('shuffle keeps all cards', () => {
+    const deck = newDeck();
+    const shuffled = shuffle(deck, () => 0.42);
+    expect(shuffled.length).toBe(52);
+    expect(new Set(shuffled).size).toBe(52);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "lib": ["DOM", "ESNext"],
+    "jsx": "react-jsx",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "baseUrl": "."
+  },
+  "include": ["app", "components", "lib", "shared", "test"]
+}


### PR DESCRIPTION
## Summary
- implement local Texas Hold'em demo with React Three Fiber scene and Tailwind HUD
- add shared poker types, deck generator, and minimal betting logic
- provide RoomSelector, HUD controls, and placeholder stake locking

## Testing
- `npx vitest run test/deck.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68964a4da24c83299de8d23d62673622