### PR TITLE
Add script to backfill missing wallet addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,16 @@ Run `npm run refund-withdrawals` to return all pending withdrawal amounts to use
 
 Run `npm run reset-db` to drop the existing MongoDB database and start with a clean one where all user balances are reset to zero. `MONGO_URI` must point to your MongoDB instance.
 
+### Backfill wallet addresses
+
+After deploying a new version you can populate missing user wallet addresses with:
+
+```
+npm run backfill-wallet-addresses
+```
+
+The command connects to the configured MongoDB instance and generates a wallet address for every `User` document where `walletAddress` is absent. Run this once after deployment to ensure all users have an associated address.
+
 ### Deploying the claim wallet
 
 1. **Compile the contract**. Install the FunC compiler and Fift tools, then run:

--- a/bot/utils/ton.js
+++ b/bot/utils/ton.js
@@ -1,4 +1,6 @@
 import TonWeb from 'tonweb';
+import { mnemonicNew, mnemonicToWalletKey } from 'ton-crypto';
+import { WalletContractV4 } from 'ton';
 
 export function normalizeAddress(addr) {
   try {
@@ -6,4 +8,14 @@ export function normalizeAddress(addr) {
   } catch {
     return null;
   }
+}
+
+export async function generateWalletAddress() {
+  const mnemonic = await mnemonicNew(24);
+  const keyPair = await mnemonicToWalletKey(mnemonic);
+  const wallet = WalletContractV4.create({
+    workchain: 0,
+    publicKey: keyPair.publicKey
+  });
+  return wallet.address.toString({ urlSafe: true, bounceable: false });
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "refund-withdrawals": "node bot/scripts/refundPendingWithdrawals.js",
     "reset-tpc-balances": "node bot/scripts/resetTPCBalances.js",
     "reset-db": "node bot/scripts/resetDatabase.js",
+    "backfill-wallet-addresses": "node scripts/backfillWalletAddresses.js",
     "dev": "concurrently -k \"npm --prefix webapp run dev\" \"node bot/server.js\""
   },
   "engines": {

--- a/scripts/backfillWalletAddresses.js
+++ b/scripts/backfillWalletAddresses.js
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import User from '../bot/models/User.js';
+import { generateWalletAddress } from '../bot/utils/ton.js';
+
+dotenv.config();
+
+const uri = process.env.MONGO_URI;
+if (!uri || uri === 'memory') {
+  console.error('MONGO_URI must be set to a MongoDB instance');
+  process.exit(1);
+}
+
+await mongoose.connect(uri);
+
+const users = await User.find({
+  $or: [{ walletAddress: { $exists: false } }, { walletAddress: null }, { walletAddress: '' }]
+});
+
+let processed = 0;
+for (const user of users) {
+  const address = await generateWalletAddress();
+  user.walletAddress = address;
+  await user.save();
+  processed++;
+  console.log(`Updated user ${user.accountId || user._id} with address ${address}`);
+}
+
+console.log(`Backfilled ${processed} user(s).`);
+
+await mongoose.disconnect();


### PR DESCRIPTION
## Summary
- add utility to generate TON wallet addresses
- create backfill script to populate missing user wallet addresses
- document and wire up npm script for post-deploy backfill

## Testing
- `node --test` *(fails: joinRoom clears lobby seat, joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_689646d4a4548329b1c0112ea82b5e09