### PR TITLE
feat: add poker game card to games page

### DIFF
--- a/webapp/public/assets/icons/poker.svg
+++ b/webapp/public/assets/icons/poker.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="10" y="10" width="80" height="80" rx="10" ry="10" fill="white" stroke="black" stroke-width="5" />
+  <text x="50" y="60" font-size="40" text-anchor="middle" fill="black">♠</text>
+</svg>

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -8,9 +8,9 @@ export default function Games() {
     <div className="relative space-y-4 text-text">
       <h2 className="text-2xl font-bold text-center mt-4">Games</h2>
       <div className="space-y-4">
-        <div className="relative bg-surface border border-border rounded-xl p-4 shadow-lg overflow-hidden wide-card">
-          <div className="flex justify-around items-center">
-            <div className="flex flex-col items-center space-y-1">
+        <div className="relative bg-surface border border-border rounded-xl p-4 shadow-lg overflow-x-auto wide-card">
+          <div className="flex items-center space-x-6">
+            <div className="flex flex-col items-center space-y-1 flex-shrink-0">
               <img src="/assets/icons/snakes_and_ladders.webp" alt="" className="h-24 w-24" />
               <h3 className="text-lg font-bold">Snake &amp; Ladder</h3>
               <Link
@@ -20,7 +20,7 @@ export default function Games() {
                 Open
               </Link>
             </div>
-            <div className="flex flex-col items-center space-y-1">
+            <div className="flex flex-col items-center space-y-1 flex-shrink-0">
               <img src="/assets/icons/Crazy_Dice_Duel_Promo.webp" alt="" className="h-24 w-24" />
               <h3 className="text-lg font-bold">Crazy Dice Duel</h3>
               <Link
@@ -29,6 +29,16 @@ export default function Games() {
               >
                 Open
               </Link>
+            </div>
+            <div className="flex flex-col items-center space-y-1 flex-shrink-0">
+              <img src="/assets/icons/poker.svg" alt="" className="h-24 w-24" />
+              <h3 className="text-lg font-bold">Poker</h3>
+              <a
+                href="/poker"
+                className="inline-block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow"
+              >
+                Open
+              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add poker icon asset
- show poker game in games page with horizontal scrollable card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68965019ab1883299c0078b72e46f20c