### PR TITLE
Store TPC wallet addresses and claim info

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -17,7 +17,9 @@ const transactionSchema = new mongoose.Schema(
     detail: String,
     category: String,
     txHash: String,
-    giftId: String
+    giftId: String,
+    // External TON address involved in the transaction (e.g. withdraw/claim)
+    address: String
   },
   { _id: false }
 );
@@ -50,6 +52,9 @@ const userSchema = new mongoose.Schema({
   walletAddress: { type: String, unique: true, sparse: true },
   walletPublicKey: { type: String },
   walletSecretKey: { type: String },
+
+  // Latest TPC jetton wallet address used by the user
+  tpcAccountAddress: { type: String },
 
 
   accountId: { type: String, unique: true },

--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -409,13 +409,15 @@ router.post('/withdraw', authenticate, async (req, res) => {
   ensureTransactionArray(user);
 
   user.balance -= amount;
+  user.tpcAccountAddress = address;
 
   const tx = {
     amount: -amount,
     type: 'withdraw',
     token: 'TPC',
     status: 'pending',
-    date: new Date()
+    date: new Date(),
+    address
   };
 
   user.transactions.push(tx);
@@ -470,6 +472,7 @@ router.post('/claim-external', authenticate, async (req, res) => {
   ensureTransactionArray(user);
 
   user.balance -= amount;
+  user.tpcAccountAddress = address;
 
   const tx = {
     amount: -amount,


### PR DESCRIPTION
## Summary
- track external TON address on user records for TPC wallet operations
- record address used in withdraw and claim-external transactions

## Testing
- `npm test --ignore-scripts` *(fails: joinRoom waits until table full)*
- `npx eslint bot/models/User.js bot/routes/wallet.js`

------
https://chatgpt.com/codex/tasks/task_e_689662ea74708329b54391fcc2619642