### PR TITLE
feat: add roll state machine and tests

### DIFF
--- a/QA_NOTES.md
+++ b/QA_NOTES.md
@@ -1,0 +1,22 @@
+# QA Notes
+
+## Install
+```
+npm i
+npx playwright install
+```
+
+## Build
+```
+npm run build
+```
+
+## Unit tests
+```
+npm test
+```
+
+## E2E tests
+```
+npm run e2e
+```

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "refund-withdrawals": "node bot/scripts/refundPendingWithdrawals.js",
     "reset-tpc-balances": "node bot/scripts/resetTPCBalances.js",
     "reset-db": "node bot/scripts/resetDatabase.js",
-    "dev": "concurrently -k \"npm --prefix webapp run dev\" \"node bot/server.js\""
+    "dev": "concurrently -k \"npm --prefix webapp run dev\" \"node bot/server.js\"",
+    "e2e": "playwright test"
   },
   "engines": {
     "node": ">=18"
@@ -48,6 +49,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "prettier": "^3.6.2",
     "mongodb-memory-server": "^10.1.4",
-    "vitest": "^1.5.0"
+    "vitest": "^1.5.0",
+    "@playwright/test": "^1.48.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  use: {
+    viewport: { width: 390, height: 844 }
+  }
+});

--- a/test/rollStateMachine.test.js
+++ b/test/rollStateMachine.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRollStateMachine } from '../webapp/src/utils/rollStateMachine.js';
+import { rebuildFromSnapshot } from '../webapp/src/utils/rejoin.js';
+
+test('state machine transitions', async () => {
+  const log = [];
+  const machine = createRollStateMachine({
+    apiRoll: async () => {
+      log.push('api');
+      return { value: 4, sig: 'sig' };
+    },
+    animate: async () => { log.push('anim'); },
+    apply: () => { log.push('apply'); }
+  });
+
+  assert.equal(machine.phase, 'IDLE');
+  const p = machine.roll('r1');
+  assert.equal(machine.phase, 'ROLL_REQUESTED');
+  await p;
+  assert.equal(machine.phase, 'IDLE');
+  assert.deepEqual(log, ['api', 'anim', 'apply']);
+});
+
+test('duplicate roll ignored', async () => {
+  let apiCalls = 0;
+  const machine = createRollStateMachine({
+    apiRoll: async () => { apiCalls++; return { value: 1, sig: 's' }; },
+    animate: async () => {},
+    apply: () => {}
+  });
+  const p1 = machine.roll('room');
+  const p2 = machine.roll('room');
+  await p1;
+  assert.equal(apiCalls, 1);
+  assert.equal(machine.phase, 'IDLE');
+  assert.equal(await p2, false); // second call ignored
+});
+
+test('rebuild from snapshot', () => {
+  const snap = { board: { a: 1 }, positions: { p1: 2 }, currentTurn: 'p1', lastRoll: 3, timers: { p1: 10 }, startedAt: 42 };
+  assert.deepEqual(rebuildFromSnapshot(snap), snap);
+  assert.deepEqual(rebuildFromSnapshot(), { board: {}, positions: {}, currentTurn: null, lastRoll: null, timers: {}, startedAt: null });
+});

--- a/tests/e2e/snake.spec.ts
+++ b/tests/e2e/snake.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+import { createRollStateMachine } from '../../webapp/src/utils/rollStateMachine.js';
+
+test('roll ignores double tap', async () => {
+  let apiCalls = 0;
+  const machine = createRollStateMachine({
+    apiRoll: async () => { apiCalls++; return { value: 3, sig: 's' }; },
+    animate: async () => {},
+    apply: () => {}
+  });
+  const first = machine.roll('room');
+  const second = machine.roll('room');
+  await first;
+  expect(apiCalls).toBe(1);
+  expect(await second).toBe(false);
+  expect(machine.phase).toBe('IDLE');
+});

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -281,6 +281,14 @@ export function getSnakeResults() {
   return fetch(API_BASE_URL + '/api/snake/results').then((r) => r.json());
 }
 
+export function rollSnake(roomId, nonce) {
+  return fetch(API_BASE_URL + '/api/snake/roll', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ roomId, nonce })
+  }).then(r => r.json());
+}
+
 export function seatTable(playerId, tableId, name) {
   return fetch(API_BASE_URL + '/api/snake/table/seat', {
     method: 'POST',

--- a/webapp/src/utils/rejoin.js
+++ b/webapp/src/utils/rejoin.js
@@ -1,0 +1,11 @@
+export function rebuildFromSnapshot(snapshot = {}) {
+  const {
+    board = {},
+    positions = {},
+    currentTurn = null,
+    lastRoll = null,
+    timers = {},
+    startedAt = null
+  } = snapshot || {};
+  return { board, positions, currentTurn, lastRoll, timers, startedAt };
+}

--- a/webapp/src/utils/rollStateMachine.js
+++ b/webapp/src/utils/rollStateMachine.js
@@ -1,0 +1,35 @@
+export function createRollStateMachine({ apiRoll, animate, apply }) {
+  const state = { phase: 'IDLE' };
+
+  async function roll(roomId) {
+    if (state.phase !== 'IDLE') return false;
+    state.phase = 'ROLL_REQUESTED';
+    const nonce = globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2);
+    let res;
+    try {
+      res = await apiRoll(roomId, nonce);
+    } catch (err) {
+      state.phase = 'IDLE';
+      throw err;
+    }
+    if (!res || typeof res.value !== 'number' || !res.sig) {
+      state.phase = 'IDLE';
+      throw new Error('Malformed roll result');
+    }
+    state.phase = 'ANIMATING';
+    await animate(res.value);
+    apply(res.value);
+    state.phase = 'APPLIED';
+    // microtask before returning to IDLE to allow observers to read APPLIED
+    await Promise.resolve();
+    state.phase = 'IDLE';
+    return res.value;
+  }
+
+  return {
+    roll,
+    get phase() {
+      return state.phase;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add roll state machine utility with server-side roll support
- implement API helper for snake roll endpoint
- add unit and Playwright tests for roll flow and document QA steps

## Testing
- `node --test test/rollStateMachine.test.js`
- `npm run build`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_689666b58cac83298a4d736db44f813f