### PR TITLE
Handle accountId in online ping route

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -413,9 +413,10 @@ function unseatTableSocket(accountId, tableId, socketId) {
 }
 
 app.post('/api/online/ping', (req, res) => {
-  const { playerId } = req.body || {};
-  if (playerId) {
-    onlineUsers.set(String(playerId), Date.now());
+  const { accountId, playerId } = req.body || {};
+  const id = accountId ?? playerId;
+  if (id) {
+    onlineUsers.set(String(id), Date.now());
   }
   const now = Date.now();
   for (const [id, ts] of onlineUsers) {


### PR DESCRIPTION
## Summary
- Accept `accountId` in `/api/online/ping` and fall back to `playerId`
- Ensure online users are recorded correctly and prevent 502 responses

## Testing
- `node test/onlineRoutes.test.js`
- `node --test` *(fails: should receive error when table not full)*

------
https://chatgpt.com/codex/tasks/task_e_6896690987e88329a15f32fc06069231