### PR TITLE
fix: avoid duplicate users during balance check

### DIFF
--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -39,10 +39,11 @@ router.post('/balance', authenticate, async (req, res) => {
     return res.status(403).json({ error: "forbidden" });
   }
 
-  let user = await User.findOne({ telegramId: id });
-  if (!user) {
-    user = await User.create({ telegramId: id, referralCode: String(id) });
-  }
+  const user = await User.findOneAndUpdate(
+    { telegramId: id },
+    { $setOnInsert: { referralCode: String(id) } },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
   const balance = calculateBalance(user);
   if (user.balance !== balance) {
     user.balance = balance;


### PR DESCRIPTION
## Summary
- avoid race condition in wallet balance endpoint by using atomic upsert

## Testing
- `npm test` *(fails: ERR_DLOPEN_FAILED from canvas; joinRoom waits until table full test cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6896e678c7f48329a367d2ce57035b6e