### PR TITLE
Remove sensitive wallet data

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -49,7 +49,6 @@ const userSchema = new mongoose.Schema({
 
   walletAddress: { type: String, unique: true, sparse: true },
   walletPublicKey: { type: String },
-  walletSecretKey: { type: String },
 
 
   accountId: { type: String, unique: true },

--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -31,7 +31,6 @@ router.post('/create', async (req, res) => {
         referralCode: String(telegramId),
         walletAddress: wallet.address,
         walletPublicKey: wallet.publicKey,
-        walletSecretKey: wallet.secretKey,
       });
       await user.save();
     } else {
@@ -44,7 +43,6 @@ router.post('/create', async (req, res) => {
         const wallet = await generateWalletAddress();
         user.walletAddress = wallet.address;
         user.walletPublicKey = wallet.publicKey;
-        user.walletSecretKey = wallet.secretKey;
         updated = true;
       }
       if (updated) await user.save();
@@ -57,7 +55,6 @@ router.post('/create', async (req, res) => {
       referralCode: id,
       walletAddress: wallet.address,
       walletPublicKey: wallet.publicKey,
-      walletSecretKey: wallet.secretKey,
     });
     await user.save();
   }

--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import User from '../models/User.js';
 import { fetchTelegramInfo } from '../utils/telegram.js';
-import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
+import { ensureTransactionArray, calculateBalance, sanitizeUser } from '../utils/userUtils.js';
 import { normalizeAddress } from '../utils/ton.js';
 
 export function parseTwitterHandle(input) {
@@ -42,7 +42,7 @@ router.post('/register-wallet', async (req, res) => {
     { $setOnInsert: { walletAddress: normalized, referralCode: normalized } },
     { upsert: true, new: true, setDefaultsOnInsert: true }
   );
-  res.json(user);
+  res.json(sanitizeUser(user));
 });
 
 router.post('/register-google', async (req, res) => {
@@ -55,7 +55,7 @@ router.post('/register-google', async (req, res) => {
     { $setOnInsert: { googleId, referralCode: googleId } },
     { upsert: true, new: true, setDefaultsOnInsert: true }
   );
-  res.json(user);
+  res.json(sanitizeUser(user));
 });
 
 router.post('/telegram-info', async (req, res) => {
@@ -124,7 +124,7 @@ router.post('/get', async (req, res) => {
     await user.save();
   }
 
-  res.json({ ...user.toObject(), filledFromTelegram });
+  res.json({ ...sanitizeUser(user), filledFromTelegram });
 });
 
 router.post('/by-account', async (req, res) => {
@@ -152,7 +152,7 @@ router.post('/update', async (req, res) => {
     { $set: update, $setOnInsert: { referralCode: telegramId.toString() } },
     { upsert: true, new: true, setDefaultsOnInsert: true }
   );
-  res.json(user);
+  res.json(sanitizeUser(user));
 });
 
 router.post('/updateBalance', async (req, res) => {
@@ -215,7 +215,7 @@ router.post('/link-google', async (req, res) => {
     { $set: update, $setOnInsert: { referralCode: telegramId.toString() } },
     { upsert: true, new: true, setDefaultsOnInsert: true }
   );
-  res.json(user);
+  res.json(sanitizeUser(user));
 });
 
 router.post('/link-social', async (req, res) => {

--- a/bot/routes/twitterAuth.js
+++ b/bot/routes/twitterAuth.js
@@ -28,6 +28,7 @@ router.post('/start', async (req, res) => {
     const callbackUrl = `${req.protocol}://${req.get('host')}/api/twitter/callback`;
     const { url, oauth_token, oauth_token_secret } = await twitterClient.generateAuthLink(callbackUrl);
     oauthStore.set(oauth_token, { secret: oauth_token_secret, telegramId });
+    setTimeout(() => oauthStore.delete(oauth_token), 5 * 60 * 1000);
     res.json({ url });
   } catch (err) {
     console.error('x start failed:', err);

--- a/bot/utils/userUtils.js
+++ b/bot/utils/userUtils.js
@@ -38,3 +38,21 @@ export async function incrementReferralBonus(code) {
     ]
   );
 }
+
+export function sanitizeUser(user) {
+  if (!user) return null;
+  return {
+    accountId: user.accountId,
+    walletAddress: user.walletAddress,
+    walletPublicKey: user.walletPublicKey,
+    nickname: user.nickname,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    photo: user.photo,
+    bio: user.bio,
+    balance: user.balance,
+    gifts: user.gifts,
+    transactions: user.transactions,
+    social: user.social
+  };
+}

--- a/bot/utils/wallet.js
+++ b/bot/utils/wallet.js
@@ -9,7 +9,6 @@ export async function generateWalletAddress() {
   return {
     address,
     publicKey: Buffer.from(keyPair.publicKey).toString('hex'),
-    secretKey: Buffer.from(keyPair.secretKey).toString('hex'),
-    mnemonic: mnemonics.join(' ')
+    // secret key and mnemonic intentionally omitted to avoid sensitive data exposure
   };
 }


### PR DESCRIPTION
## Summary
- Drop walletSecretKey storage from user records and account creation
- Sanitize profile responses and omit private wallet material
- Limit OAuth token retention and avoid returning wallet mnemonics or secret keys

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689723fd01448329897d4ef35b730023