### PR TITLE
Enhance TPC balance reset script

### DIFF
--- a/bot/scripts/resetTPCBalances.js
+++ b/bot/scripts/resetTPCBalances.js
@@ -12,13 +12,39 @@ if (!uri || uri === 'memory') {
 
 await mongoose.connect(uri);
 
-const users = await User.find({});
-for (const user of users) {
-  user.balance = 0;
-  user.minedTPC = 0;
-  user.transactions = [];
-  await user.save();
-  console.log(`Reset TPC for ${user.telegramId || user.accountId}`);
+const ids = process.argv.slice(2);
+
+// If no identifiers are provided, reset every user's TPC balance just like
+// the original behaviour of this script.
+if (ids.length === 0) {
+  const users = await User.find({});
+  for (const user of users) {
+    user.balance = 0;
+    user.minedTPC = 0;
+    user.transactions = [];
+    await user.save();
+    console.log(`Reset TPC for ${user.telegramId || user.accountId}`);
+  }
+} else {
+  // Otherwise, only reset the balances of the specified users. The arguments
+  // may be a telegramId, accountId or nickname.
+  for (const id of ids) {
+    const query = { $or: [{ accountId: id }, { nickname: id }] };
+    const asNumber = Number(id);
+    if (!Number.isNaN(asNumber)) query.$or.push({ telegramId: asNumber });
+
+    const user = await User.findOne(query);
+    if (!user) {
+      console.error(`User ${id} not found`);
+      continue;
+    }
+
+    user.balance = 0;
+    user.minedTPC = 0;
+    user.transactions = [];
+    await user.save();
+    console.log(`Reset TPC for ${user.telegramId || user.accountId || user.nickname}`);
+  }
 }
 
 await mongoose.disconnect();


### PR DESCRIPTION
## Summary
- Support resetting TPC balances for specific users by ID or nickname

## Testing
- `npm test` *(fails: joinRoom clears lobby seat)*

------
https://chatgpt.com/codex/tasks/task_e_68973fa70ae883299f2b303cf0f41c59