### PR TITLE
chore: restore previous logo asset

### DIFF
--- a/webapp/src/components/Branding.jsx
+++ b/webapp/src/components/Branding.jsx
@@ -5,7 +5,7 @@ export default function Branding({ scale = 1, offsetY = 0 }) {
     <div className="text-center py-6 space-y-2">
       <img
 
-        src="/assets/icons/file_000000002f08620a8b0d3154b9c3fdaa.webp"
+        src="/assets/icons/TonPlayGramLogo_2_512x512.webp"
         alt="TonPlaygram Logo"
         className="mx-auto"
         style={{ transform: `scale(${scale})`, marginTop: offsetY }}

--- a/webapp/src/components/GameEndPopup.jsx
+++ b/webapp/src/components/GameEndPopup.jsx
@@ -6,7 +6,7 @@ export default function GameEndPopup({ open, ranking, onPlayAgain, onReturn }) {
   return createPortal(
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
-        <img  src="/assets/icons/file_000000002f08620a8b0d3154b9c3fdaa.webp" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
+        <img  src="/assets/icons/TonPlayGramLogo_2_512x512.webp" alt="TonPlaygram Logo" className="w-10 h-10 mx-auto" />
         <h3 className="text-lg font-bold text-center">Game Over</h3>
         <ol className="list-decimal list-inside space-y-1 text-center">
           {ranking.map((name, i) => (

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -132,7 +132,7 @@ export default function LuckyNumber() {
             {(i !== 0 && selected !== i) ? (
               <>
                 <img
-                  src="/assets/icons/file_000000002f08620a8b0d3154b9c3fdaa.webp"
+                  src="/assets/icons/TonPlayGramLogo_2_512x512.webp"
                   alt="Logo"
                   className="absolute inset-0 w-full h-full object-contain opacity-40"
                 />

--- a/webapp/src/components/RoomPopup.jsx
+++ b/webapp/src/components/RoomPopup.jsx
@@ -21,7 +21,7 @@ export default function RoomPopup({
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
         <img
 
-          src="/assets/icons/file_000000002f08620a8b0d3154b9c3fdaa.webp"
+          src="/assets/icons/TonPlayGramLogo_2_512x512.webp"
           alt="TonPlaygram Logo"
           className="w-10 h-10 mx-auto"
         />

--- a/webapp/src/components/TablePopup.jsx
+++ b/webapp/src/components/TablePopup.jsx
@@ -8,7 +8,7 @@ export default function TablePopup({ open, tables, onSelect }) {
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
         <img
 
-          src="/assets/icons/file_000000002f08620a8b0d3154b9c3fdaa.webp"
+          src="/assets/icons/TonPlayGramLogo_2_512x512.webp"
           alt="TonPlaygram Logo"
           className="w-10 h-10 mx-auto"
         />

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1038,7 +1038,7 @@ input:focus {
   transform-origin: bottom center;
   background-image:
     linear-gradient(to bottom, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0) 70%),
-    url("/assets/icons/file_000000002f08620a8b0d3154b9c3fdaa.webp");
+    url("/assets/icons/TonPlayGramLogo_2_512x512.webp");
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;


### PR DESCRIPTION
## Summary
- replace site logo references with `TonPlayGramLogo_2_512x512.webp`
- ensure popups and board styling use the restored logo

## Testing
- `npm test` *(fails: should receive error when table not full)*
- `npm run lint`
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_689741600bd48329a8f940f23c2d27d1