### PR TITLE
chore: remove prestart build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "main": "bot/server.js",
   "scripts": {
-    "prestart": "npm run build",
     "start": "node bot/server.js",
     "install-all": "npm install && npm install --prefix bot && npm install --prefix webapp",
     "build": "npm --prefix webapp run build",


### PR DESCRIPTION
## Summary
- drop prestart build script so server start no longer triggers webapp build

## Testing
- `npm test` *(fails: process hung; terminated after partial run)*
- `node --test test/parseTwitterHandle.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68974933864c8329822971e7ab5eda63