### PR TITLE
chore: remove dummy dist setup from tests

### DIFF
--- a/test/joinSeatCleanup.test.js
+++ b/test/joinSeatCleanup.test.js
@@ -1,11 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import fs from 'fs';
 import { spawn } from 'child_process';
 import { setTimeout as delay } from 'timers/promises';
 import { io } from 'socket.io-client';
-
-const distDir = new URL('../webapp/dist/', import.meta.url);
 
 async function startServer(env) {
   const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
@@ -24,8 +21,6 @@ async function startServer(env) {
 }
 
 test('joinRoom clears lobby seat', { concurrency: false, timeout: 20000 }, async () => {
-  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
-  fs.writeFileSync(new URL('index.html', distDir), '');
   const env = {
     ...process.env,
     PORT: '3204',

--- a/test/lobbyWait.test.js
+++ b/test/lobbyWait.test.js
@@ -1,11 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import fs from 'fs';
 import { spawn } from 'child_process';
 import { setTimeout as delay } from 'timers/promises';
 import { io } from 'socket.io-client';
-
-const distDir = new URL('../webapp/dist/', import.meta.url);
 
 async function startServer(env) {
   const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
@@ -24,8 +21,6 @@ async function startServer(env) {
 }
 
 test('joinRoom waits until table full', { concurrency: false, timeout: 20000 }, async () => {
-  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
-  fs.writeFileSync(new URL('index.html', distDir), '');
   const env = {
     ...process.env,
     PORT: '3203',

--- a/test/ludoLobbyRoute.test.js
+++ b/test/ludoLobbyRoute.test.js
@@ -1,10 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import fs from 'fs';
 import { spawn } from 'child_process';
 import { setTimeout as delay } from 'timers/promises';
-
-const distDir = new URL('../webapp/dist/', import.meta.url);
 
 async function startServer(env) {
   const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
@@ -25,9 +22,6 @@ async function startServer(env) {
 }
 
 test('ludo lobby route lists players', async () => {
-  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
-  fs.writeFileSync(new URL('index.html', distDir), '');
-
   const env = {
     ...process.env,
     PORT: '3203',

--- a/test/onlineRoutes.test.js
+++ b/test/onlineRoutes.test.js
@@ -1,9 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import fs from 'fs';
 import { spawn } from 'child_process';
-
-const distDir = new URL('../webapp/dist/', import.meta.url);
 
 async function startServer(env) {
   const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
@@ -22,9 +19,6 @@ async function startServer(env) {
 }
 
 test('online routes reflect pinged users', { concurrency: false }, async () => {
-  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
-  fs.writeFileSync(new URL('index.html', distDir), '');
-
   const env = {
     ...process.env,
     PORT: '3202',

--- a/test/referralRoutes.test.js
+++ b/test/referralRoutes.test.js
@@ -1,9 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import fs from 'fs';
 import { spawn } from 'child_process';
-
-const distDir = new URL('../webapp/dist/', import.meta.url);
 
 async function startServer(env) {
   const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
@@ -24,9 +21,6 @@ async function startServer(env) {
 }
 
 test('claiming a referral updates inviter stats', { concurrency: false }, async () => {
-  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
-  fs.writeFileSync(new URL('index.html', distDir), '');
-
   const env = {
     ...process.env,
     PORT: '3210',

--- a/test/snakeApi.test.js
+++ b/test/snakeApi.test.js
@@ -2,8 +2,6 @@ import test from 'node:test';
 
 import assert from 'node:assert/strict';
 
-import fs from 'fs';
-
 import { spawn } from 'child_process';
 
 import { setTimeout as delay } from 'timers/promises';
@@ -11,8 +9,6 @@ import { setTimeout as delay } from 'timers/promises';
 import { io } from 'socket.io-client';
 
 import { GameRoom, DEFAULT_SNAKES, DEFAULT_LADDERS } from '../bot/gameEngine.js';
-
-const distDir = new URL('../webapp/dist/', import.meta.url);
 
 class DummyIO {
 
@@ -99,10 +95,6 @@ async function startServer(env) {
 }
 
 test('snake API endpoints and socket events', { concurrency: false, timeout: 20000 }, async () => {
-
-  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
-
-  fs.writeFileSync(new URL('index.html', distDir), '');
 
   const env = {
 

--- a/test/snakeLobbyRoute.test.js
+++ b/test/snakeLobbyRoute.test.js
@@ -1,10 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import fs from 'fs';
 import { spawn } from 'child_process';
 import { setTimeout as delay } from 'timers/promises';
-
-const distDir = new URL('../webapp/dist/', import.meta.url);
 
 async function startServer(env) {
   const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
@@ -25,9 +22,6 @@ async function startServer(env) {
 }
 
 test('snake lobby route lists players', async () => {
-  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
-  fs.writeFileSync(new URL('index.html', distDir), '');
-
   const env = {
     ...process.env,
     PORT: '3200',

--- a/test/snakeSeat.test.js
+++ b/test/snakeSeat.test.js
@@ -1,9 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import fs from 'fs';
 import { spawn } from 'child_process';
-
-const distDir = new URL('../webapp/dist/', import.meta.url);
 
 async function startServer(env) {
   const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
@@ -22,9 +19,6 @@ async function startServer(env) {
 }
 
 test('seat and unseat endpoints update lobby', { concurrency: false, timeout: 20000 }, async () => {
-  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
-  fs.writeFileSync(new URL('index.html', distDir), '');
-
   const env = {
     ...process.env,
     PORT: '3202',

--- a/test/walletRoutes.test.js
+++ b/test/walletRoutes.test.js
@@ -1,10 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import fs from 'fs';
 import { spawn } from 'child_process';
 import crypto from 'crypto';
-
-const distDir = new URL('../webapp/dist/', import.meta.url);
 
 function createInitData(id, token) {
   const params = new URLSearchParams();
@@ -54,9 +51,6 @@ async function deposit(port, token, telegramId, amount) {
 }
 
 test('withdraw route reverts balance on claim failure', { concurrency: false }, async () => {
-  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
-  fs.writeFileSync(new URL('index.html', distDir), '');
-
   const env = {
     ...process.env,
     PORT: '3211',
@@ -96,9 +90,6 @@ test('withdraw route reverts balance on claim failure', { concurrency: false }, 
 });
 
 test('claim-external route reverts balance on claim failure', { concurrency: false }, async () => {
-  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
-  fs.writeFileSync(new URL('index.html', distDir), '');
-
   const env = {
     ...process.env,
     PORT: '3212',


### PR DESCRIPTION
## Summary
- stop creating placeholder `webapp/dist` assets in server tests
- run tests against server without dummy index.html or assets folders

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_68974932b240832994f43eb67a5ecb2e