### PR TITLE
chore: switch FE service to node runtime

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -11,10 +11,10 @@ services:
         value: mongodb://localhost:27017/tonplaygram
 
   - type: web
-    runtime: static
+    runtime: node
     name: tonplaygram-fe
     branch: main
     rootDir: webapp
     buildCommand: npm install && npm run build
-    staticPublishPath: dist
+    startCommand: npm start
 


### PR DESCRIPTION
## Summary
- serve front-end via Node runtime instead of static hosting

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_689749352f048329864aba4656112735