### PR TITLE
Add Falling Ball lobby with player and stake options

### DIFF
--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -99,6 +99,16 @@
     maxVy:22,
   };
 
+  const params = new URLSearchParams(location.search);
+  const p = Number(params.get('players'));
+  if (p >= 2 && p <= 10) state.players = p;
+  const dens = params.get('density');
+  if (dens) state.density = dens.charAt(0).toUpperCase() + dens.slice(1).toLowerCase();
+  const m = params.get('mode');
+  if (m === 'local' || m === 'online') state.mode = m;
+  const amt = Number(params.get('amount'));
+  if (amt > 0) state.stake = amt;
+
   // ========================= HUD =========================
   const playerRow=document.getElementById('playerRow');
   for(let n=2;n<=10;n++){
@@ -288,7 +298,14 @@
 
   // ========================= Init =========================
   function resetBall(){ state.ball.x=W*0.5; state.ball.y=60; state.ball.vx=(Math.random()*2-1)*2; state.ball.vy=0; state.resultSlot=null; }
-  function init(){ refreshSlots(); refreshText(); genPegField(); carveCorridors(); genPaddles(); resetBall(); }
+  function init(){
+    toggleModeButtons();
+    refreshSlots();
+    refreshText();
+    setDensity(state.density);
+    genPaddles();
+    resetBall();
+  }
   init();
 
   // ========== Smoke Tests ==========

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -24,6 +24,7 @@ import Lobby from './pages/Games/Lobby.jsx';
 import Games from './pages/Games.jsx';
 import SpinPage from './pages/spin.tsx';
 import FallingBall from './pages/Games/FallingBall.jsx';
+import FallingBallLobby from './pages/Games/FallingBallLobby.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -50,6 +51,7 @@ export default function App() {
             <Route path="/games/snake" element={<SnakeAndLadder />} />
             <Route path="/games/snake/mp" element={<SnakeMultiplayer />} />
             <Route path="/games/snake/results" element={<SnakeResults />} />
+            <Route path="/games/fallingball/lobby" element={<FallingBallLobby />} />
             <Route path="/games/fallingball" element={<FallingBall />} />
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -34,7 +34,7 @@ export default function Games() {
                 <img src="/assets/icons/falling_ball.svg" alt="" className="h-24 w-24" />
                 <h3 className="text-lg font-bold">Falling Ball</h3>
                 <Link
-                  to="/games/fallingball"
+                  to="/games/fallingball/lobby"
                   className="inline-block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow"
                 >
                   Open

--- a/webapp/src/pages/Games/FallingBall.jsx
+++ b/webapp/src/pages/Games/FallingBall.jsx
@@ -1,10 +1,12 @@
+import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 
 export default function FallingBall() {
   useTelegramBackButton();
+  const { search } = useLocation();
   return (
     <iframe
-      src="/falling-ball.html"
+      src={`/falling-ball.html${search}`}
       title="Falling Ball"
       className="w-full h-screen border-0"
     />

--- a/webapp/src/pages/Games/FallingBallLobby.jsx
+++ b/webapp/src/pages/Games/FallingBallLobby.jsx
@@ -1,0 +1,118 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { ensureAccountId, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+
+export default function FallingBallLobby() {
+  const navigate = useNavigate();
+  useTelegramBackButton();
+
+  const [players, setPlayers] = useState(2);
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [density, setDensity] = useState('low');
+  const [mode, setMode] = useState('local');
+  const [avatar, setAvatar] = useState('');
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  const startGame = async () => {
+    try {
+      const accountId = await ensureAccountId();
+      const balRes = await getAccountBalance(accountId);
+      if ((balRes.balance || 0) < stake.amount) {
+        alert('Insufficient balance');
+        return;
+      }
+      const tgId = getTelegramId();
+      await addTransaction(tgId, -stake.amount, 'stake', { game: 'fallingball' });
+    } catch {}
+
+    const params = new URLSearchParams();
+    params.set('players', players);
+    params.set('density', density);
+    params.set('mode', mode);
+    if (stake.token) params.set('token', stake.token);
+    if (stake.amount) params.set('amount', stake.amount);
+    navigate(`/games/fallingball?${params.toString()}`);
+  };
+
+  return (
+    <div className="relative p-4 space-y-4 text-text">
+      <h2 className="text-xl font-bold text-center">Falling Ball Lobby</h2>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Lojtarë</h3>
+        <div className="flex gap-2 flex-wrap">
+          {[2,3,4,5,6,7,8,9,10].map((n) => (
+            <button
+              key={n}
+              onClick={() => setPlayers(n)}
+              className={`lobby-tile ${players === n ? 'lobby-selected' : ''}`}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Stake</h3>
+        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Densiteti</h3>
+        <div className="flex gap-2">
+          {['low','med','high'].map((d) => (
+            <button
+              key={d}
+              onClick={() => setDensity(d)}
+              className={`lobby-tile capitalize ${density === d ? 'lobby-selected' : ''}`}
+            >
+              {d === 'med' ? 'Med' : d.charAt(0).toUpperCase() + d.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Mode</h3>
+        <div className="flex gap-2">
+          {[
+            { id: 'local', label: 'Local (AI)' },
+            { id: 'online', label: 'Online' }
+          ].map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setMode(id)}
+              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex gap-2">
+        {Array.from({ length: players }).map((_, idx) => (
+          <img
+            key={idx}
+            src={idx === 0 ? avatar : '/assets/icons/9f14924f-e70c-4728-a9e5-ca25ef4138c8.png'}
+            alt="avatar"
+            className="w-10 h-10 rounded-full border"
+          />
+        ))}
+      </div>
+      <button
+        onClick={startGame}
+        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
+      >
+        START
+      </button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add lobby for Falling Ball with configurable players, stake, density and mode, plus account balance deduction
- wire up routes and query parameters so lobby selections reach the game
- parse query string in falling-ball HTML to preconfigure match settings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689784722be88329ab4aa856e00a168a