### PR TITLE
feat: enhance falling ball with avatars and winner popup

### DIFF
--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -19,8 +19,13 @@
     .btn:disabled{ opacity:.5; }
     .panel{ position:absolute; left:10px; bottom:10px; right:10px; background:linear-gradient(180deg, rgba(16,23,42,.9), rgba(16,23,42,.6)); border:1px solid rgba(255,255,255,.08); border-radius:16px; padding:10px; }
     .grid{ display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:6px; }
-    .slot{ text-align:center; font-size:12px; color:#cbd5e1; padding:6px 0; border-radius:10px; border:1px dashed rgba(255,255,255,.12); }
+    .slot{ display:flex; flex-direction:column; align-items:center; gap:4px; padding:6px 0; color:#cbd5e1; font-size:12px; border-radius:10px; border-left:1px dashed rgba(255,255,255,.12); border-right:1px dashed rgba(255,255,255,.12); border-bottom:1px dashed rgba(255,255,255,.12); }
     .slot.me{ border-color:#7dd3fc; color:#c7f3ff; }
+    .slotName{ }
+    .slotAvatar{ width:32px; height:32px; border-radius:50%; border:1px solid rgba(255,255,255,.15); }
+    .popup{ position:absolute; inset:0; background:rgba(0,0,0,.6); display:none; align-items:center; justify-content:center; z-index:20; }
+    .popup.show{ display:flex; }
+    .popupBox{ background:var(--panel); padding:20px; border-radius:16px; border:1px solid rgba(255,255,255,.15); text-align:center; color:var(--ink); }
     .status{ position:absolute; left:10px; top:62px; background:rgba(0,0,0,.35); padding:8px 10px; border-radius:12px; border:1px solid rgba(255,255,255,.08); color:var(--muted); font-size:12px; max-width:min(92vw,560px); }
     .sep{ opacity:.3; }
     .avatar{ width:40px; height:40px; border-radius:50%; border:1px solid rgba(255,255,255,.15); }
@@ -47,6 +52,12 @@
     </div>
 
     <canvas id="scene"></canvas>
+    <div class="popup" id="winnerPopup">
+      <div class="popupBox">
+        <div id="winnerText" style="margin-bottom:12px; font-size:16px; font-weight:600;"></div>
+        <button class="btn primary" id="lobbyBtn">Return to Lobby</button>
+      </div>
+    </div>
   </div>
 
   <script>
@@ -102,8 +113,12 @@
     const wrap=document.getElementById('slots'); wrap.innerHTML=''; state.slots=[];
     const names=['You','Nova','Quark','Rex','Vega','Bolt','Iris','Mira','Axel','Luna'];
     for(let i=0;i<state.players;i++){
-      const el=document.createElement('div'); el.className='slot'+(i===0?' me':''); el.textContent=names[i%names.length]; wrap.appendChild(el);
-      state.slots.push({ idx:i, name:el.textContent, el, left:0, right:0 });
+      const el=document.createElement('div'); el.className='slot'+(i===0?' me':'');
+      const name=document.createElement('div'); name.className='slotName'; name.textContent=names[i%names.length];
+      const img=document.createElement('img'); img.className='slotAvatar';
+      img.src = (i===0 && avatarUrl)? avatarUrl : '/assets/icons/9f14924f-e70c-4728-a9e5-ca25ef4138c8.png';
+      el.appendChild(name); el.appendChild(img); wrap.appendChild(el);
+      state.slots.push({ idx:i, name:name.textContent, el, left:0, right:0 });
     }
   }
 
@@ -117,7 +132,7 @@
   function genPegField(){
     const pegs=[]; const ballDia = state.ball.r*2; const clearance = ballDia*1.5; // ≥ 1.5× diametri
     const usableTop = 110, usableBottom = H-180; const pad=20;
-    const target = (state.density==='Low') ? 72 : (state.density==='Med') ? 108 : 144;
+    const target = (state.density==='Low') ? 86 : (state.density==='Med') ? 130 : 173;
     const maxAttempts = target*25;
     let attempts=0;
     while (pegs.length<target && attempts++ < maxAttempts){
@@ -129,12 +144,20 @@
       for(const p of pegs){ const minCenter = p.r + cand.r + clearance; const dx=cand.x-p.x, dy=cand.y-p.y; if (dx*dx+dy*dy < minCenter*minCenter){ ok=false; break; } }
       if (ok) pegs.push(cand);
     }
-    const spinnerCount = state.density==='High' ? 7 : state.density==='Med' ? 5 : 4;
+    const spinnerCount = state.density==='High' ? 8 : state.density==='Med' ? 6 : 5;
     for(let i=0;i<spinnerCount;i++){
       const r = randomBetween(14,18);
       const x = randomBetween(pad+r+20, W-pad-r-20);
       const y = randomBetween(usableTop+r+40, usableBottom-r-40);
       const cand = { x, y, r, type:'spinner', angle:0, spin: randomBetween(-0.06,0.06) };
+      let ok=true; for(const p of pegs){ const minCenter = p.r + cand.r + clearance; const dx=cand.x-p.x, dy=cand.y-p.y; if (dx*dx+dy*dy < minCenter*minCenter){ ok=false; break; } }
+      if (ok) pegs.push(cand);
+    const lCount = state.density==='High' ? 4 : state.density==='Med' ? 3 : 2;
+    for(let i=0;i<lCount;i++){
+      const size = randomBetween(20,30);
+      const x = randomBetween(pad+size+20, W-pad-size-20);
+      const y = randomBetween(usableTop+size+40, usableBottom-size-40);
+      const cand = { x, y, r:size, size, type:'lshape', angle:0, spin:randomBetween(-0.04,0.04) };
       let ok=true; for(const p of pegs){ const minCenter = p.r + cand.r + clearance; const dx=cand.x-p.x, dy=cand.y-p.y; if (dx*dx+dy*dy < minCenter*minCenter){ ok=false; break; } }
       if (ok) pegs.push(cand);
     }
@@ -177,9 +200,16 @@
     if (b.x + b.r > W-10){ b.x = W-10 - b.r; b.vx = -Math.abs(b.vx)*0.85; SFX.bounce(); }
     if (b.y - b.r < 10){ b.y = 10 + b.r; b.vy *= -state.bounce; SFX.bounce(); }
 
-    // pegs & spinners
+    // pegs, spinners & L-shapes
     for(const o of state.obstacles){
-      if (collideCircle(b, o, o.type==='spinner'?1.08:1)){
+      if (o.type==='lshape'){
+        o.angle = (o.angle||0) + (o.spin||0);
+        const s=o.size||30;
+        const hx=o.x + Math.cos(o.angle)*s, hy=o.y + Math.sin(o.angle)*s;
+        const vx=o.x - Math.sin(o.angle)*s, vy=o.y + Math.cos(o.angle)*s;
+        segmentBounce(o.x,o.y,hx,hy,b);
+        segmentBounce(o.x,o.y,vx,vy,b);
+      }else if (collideCircle(b, o, o.type==='spinner'?1.08:1)){
         if (o.type==='spinner'){ o.angle = (o.angle || 0) + (o.spin||0); SFX.spinner(); }
         else { SFX.bounce(); }
       }
@@ -205,7 +235,7 @@
     if (b.y + b.r >= groundY){
       b.y = groundY - b.r; b.vy *= -state.bounce;
       if (Math.abs(b.vy) < 1.1){
-        const idx = pickSlotFromX(b.x); state.resultSlot = idx; const fee = Math.floor(state.pot*0.10); const prize = state.pot - fee; document.getElementById('winnerVal').textContent = `${state.slots[idx].name} +${prize} TPC`; setStatus(`Winner: ${state.slots[idx].name}. Payout ${prize} TPC (-${fee} dev)`); SFX.win();
+        const idx = pickSlotFromX(b.x); state.resultSlot = idx; const fee = Math.floor(state.pot*0.10); const prize = state.pot - fee; document.getElementById('winnerVal').textContent = `${state.slots[idx].name} +${prize} TPC`; setStatus(`Winner: ${state.slots[idx].name}. Payout ${prize} TPC (-${fee} dev)`); SFX.win(); showWinnerPopup(state.slots[idx].name);
       }
     }
   }
@@ -224,7 +254,11 @@
   }
 
   function segmentCircleHit(x1,y1,x2,y2, cx,cy, r){ const dx=x2-x1, dy=y2-y1; const fx=cx-x1, fy=cy-y1; const t = Math.max(0, Math.min(1, (fx*dx+fy*dy)/(dx*dx+dy*dy||1))); const px=x1+dx*t, py=y1+dy*t; const dd=(cx-px)**2+(cy-py)**2; return dd <= r*r; }
+  function segmentBounce(x1,y1,x2,y2,b){ const dx=x2-x1, dy=y2-y1; const fx=b.x-x1, fy=b.y-y1; const t = Math.max(0, Math.min(1, (fx*dx+fy*dy)/(dx*dx+dy*dy||1))); const px=x1+dx*t, py=y1+dy*t; const dd=(b.x-px)**2+(b.y-py)**2; if (dd <= b.r*b.r){ const dist=Math.max(0.0001, Math.sqrt(dd)); const nx=(b.x-px)/dist, ny=(b.y-py)/dist; const overlap=b.r-dist+0.2; b.x+=nx*overlap; b.y+=ny*overlap; const vn=b.vx*nx+b.vy*ny; b.vx-=(1+state.bounce)*vn*nx; b.vy-=(1+state.bounce)*vn*ny; SFX.bounce(); return true; } return false; }
   function pickSlotFromX(x){ const pad=20; const usable=W-2*pad; const w = usable / state.players; const i=Math.max(0, Math.min(state.players-1, Math.floor((x-pad)/w))); return i; }
+
+  function showWinnerPopup(name){ const box=document.getElementById('winnerPopup'); document.getElementById('winnerText').textContent=`${name} Wins! 🎉`; box.classList.add('show'); }
+  document.getElementById('lobbyBtn').onclick=()=>{ if (window.parent){ try{ window.parent.history.back(); }catch(e){ history.back(); } } else { history.back(); } };
 
   // ========================= Render =========================
   function drawBackground(){
@@ -244,17 +278,24 @@
   }
   function drawObstacles(){
     for(const o of state.obstacles){
-      const grad = ctx.createRadialGradient(o.x-6,o.y-8,4, o.x,o.y,(o.r||14)+12);
-      grad.addColorStop(0,'#223259'); grad.addColorStop(0.6,'#142246'); grad.addColorStop(1,'#0a1022');
-      ctx.fillStyle=grad; ctx.beginPath(); ctx.arc(o.x,o.y,o.r||14,0,Math.PI*2); ctx.fill();
-      ctx.strokeStyle='rgba(255,255,255,0.06)'; ctx.stroke();
-      if (o.type==='spinner'){
-        const ang=o.angle||0; const r=(o.r||16)+4; ctx.strokeStyle='rgba(148,163,184,0.35)'; ctx.beginPath(); ctx.moveTo(o.x, o.y); ctx.lineTo(o.x+Math.cos(ang)*r, o.y+Math.sin(ang)*r); ctx.stroke();
+      if(o.type==='lshape'){
+        const s=o.size||30; ctx.strokeStyle='rgba(148,163,184,0.35)'; ctx.lineWidth=6;
+        const hx=o.x+Math.cos(o.angle||0)*s, hy=o.y+Math.sin(o.angle||0)*s;
+        const vx=o.x-Math.sin(o.angle||0)*s, vy=o.y+Math.cos(o.angle||0)*s;
+        ctx.beginPath(); ctx.moveTo(o.x,o.y); ctx.lineTo(hx,hy); ctx.moveTo(o.x,o.y); ctx.lineTo(vx,vy); ctx.stroke();
+      }else{
+        const grad = ctx.createRadialGradient(o.x-6,o.y-8,4, o.x,o.y,(o.r||14)+12);
+        grad.addColorStop(0,'#223259'); grad.addColorStop(0.6,'#142246'); grad.addColorStop(1,'#0a1022');
+        ctx.fillStyle=grad; ctx.beginPath(); ctx.arc(o.x,o.y,o.r||14,0,Math.PI*2); ctx.fill();
+        ctx.strokeStyle='rgba(255,255,255,0.06)'; ctx.stroke();
+        if (o.type==='spinner'){
+          const ang=o.angle||0; const r=(o.r||16)+4; ctx.strokeStyle='rgba(148,163,184,0.35)'; ctx.beginPath(); ctx.moveTo(o.x,o.y); ctx.lineTo(o.x+Math.cos(ang)*r, o.y+Math.sin(ang)*r); ctx.stroke();
+        }
       }
     }
   }
   function drawSideGuides(){ if (!state.sideGuides) return; const t = Math.sin(state.time*0.0016)*0.5+0.5; const padYTop = H*0.78-80, padYBot=H-130; const gap=W*0.24, width=W*0.22; const leftX = W*0.5 - gap*0.5 - width*t; const rightX= W*0.5 + gap*0.5 + width*t; ctx.strokeStyle='rgba(148,163,184,0.35)'; ctx.lineWidth=6; ctx.beginPath(); ctx.moveTo(leftX,padYTop); ctx.lineTo(leftX,padYBot); ctx.stroke(); ctx.beginPath(); ctx.moveTo(rightX,padYTop); ctx.lineTo(rightX,padYBot); ctx.stroke(); }
-  function drawSlotsGuide(){ const pad=20; const usable=W-2*pad; const w = usable / state.players; const top = H-140; const bottom=H-120; for(let i=0;i<state.players;i++){ const x1=pad+i*w; ctx.fillStyle='rgba(255,255,255,0.05)'; ctx.fillRect(x1, top, w-2, bottom-top); if (state.resultSlot===i){ ctx.strokeStyle='rgba(125,211,252,0.9)'; ctx.lineWidth=3; ctx.strokeRect(x1+1, top, w-4, bottom-top); } } }
+  function drawSlotsGuide(){ const pad=20; const usable=W-2*pad; const w = usable / state.players; const top = H-140; const bottom=H-120; for(let i=0;i<state.players;i++){ const x1=pad+i*w; ctx.strokeStyle='rgba(255,255,255,0.05)'; ctx.lineWidth=2; ctx.beginPath(); ctx.moveTo(x1,bottom); ctx.lineTo(x1,top); ctx.moveTo(x1,bottom); ctx.lineTo(x1+w,bottom); ctx.moveTo(x1+w,bottom); ctx.lineTo(x1+w,top); ctx.stroke(); if (state.resultSlot===i){ ctx.strokeStyle='rgba(125,211,252,0.9)'; ctx.lineWidth=3; ctx.beginPath(); ctx.moveTo(x1,bottom); ctx.lineTo(x1,top); ctx.moveTo(x1,bottom); ctx.lineTo(x1+w,bottom); ctx.moveTo(x1+w,bottom); ctx.lineTo(x1+w,top); ctx.stroke(); } } }
   function drawBall(){ const b=state.ball; ctx.fillStyle='rgba(0,0,0,0.28)'; ctx.beginPath(); ctx.ellipse(b.x, b.y+b.r+6, b.r*1.2, b.r*0.5, 0,0,Math.PI*2); ctx.fill(); const grad = ctx.createRadialGradient(b.x-6,b.y-6,4, b.x,b.y,b.r+6); grad.addColorStop(0,'#5c7ad1'); grad.addColorStop(0.55,'#2a3a6a'); grad.addColorStop(1,'#0b1022'); ctx.fillStyle=grad; ctx.beginPath(); ctx.arc(b.x,b.y,b.r,0,Math.PI*2); ctx.fill(); ctx.globalAlpha=0.15; ctx.fillStyle='#cde6ff'; ctx.beginPath(); ctx.ellipse(b.x-5,b.y-8,b.r*0.7,b.r*0.35,-0.2,0,Math.PI*2); ctx.fill(); ctx.globalAlpha=1; }
 
   function frame(ts){ const dt = Math.min(33, ts - state.time); state.time=ts; step(dt/16.6667); ctx.clearRect(0,0,W,H); drawBackground(); drawPrismPanel(); drawObstacles(); drawSideGuides(); drawSlotsGuide(); drawBall(); requestAnimationFrame(frame); }


### PR DESCRIPTION
## Summary
- show player avatars with names in U-shaped slots
- add L-shaped rotating obstacles and increase obstacle density by 20%
- display celebratory popup on win with return-to-lobby button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689798e40c248329a696b7f4b5e65b16