### PR TITLE
feat: brighten Falling Ball visuals

### DIFF
--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -5,17 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>TonPlaygram – Falling Ball PvP (SFX + Visuals)</title>
   <style>
-    :root{ --bg:#d1fae5; --panel:#10172a; --ink:#000; --muted:#065f46; --accent:#94a3b8; }
+    :root{ --bg:#f0fdf4; --panel:#10172a; --ink:#000; --muted:#10b981; --accent:#94a3b8; }
     html,body{ height:100%; margin:0; }
     body{ background:var(--bg); color:var(--ink); font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif; }
     .app{ position:fixed; inset:0; overflow:hidden; }
     canvas{ display:block; width:100%; height:100%; }
     .hudTop{ position:absolute; inset-inline:0; top:0; padding:10px; display:flex; flex-wrap:wrap; gap:8px; align-items:center; justify-content:space-between; font-size:12px; color:var(--muted); }
     .row{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
-    .chip{ padding:6px 10px; border-radius:12px; border:1px solid rgba(255,255,255,.15); color:#eee; background:transparent; cursor:pointer; }
+    .chip{ padding:6px 10px; border-radius:12px; border:1px solid rgba(255,255,255,.15); color:#fff; background:transparent; cursor:pointer; }
     .chip.active{ border-color:#7dd3fc; }
-    .btn{ appearance:none; border:1px solid rgba(255,255,255,.15); background:rgba(255,255,255,.06); color:var(--ink); padding:10px 14px; border-radius:14px; font-weight:600; font-size:14px; cursor:pointer; }
-    .btn.primary{ background:linear-gradient(135deg,#7dd3fc,#60a5fa); color:#001122; border:none; box-shadow:0 6px 18px rgba(96,165,250,.35); }
+    .btn{ appearance:none; border:1px solid rgba(255,255,255,.15); background:rgba(255,255,255,.06); color:#fff; padding:10px 14px; border-radius:14px; font-weight:600; font-size:14px; cursor:pointer; }
+    .btn.primary{ background:linear-gradient(135deg,#7dd3fc,#60a5fa); color:#fff; border:none; box-shadow:0 6px 18px rgba(96,165,250,.35); }
     .btn:disabled{ opacity:.5; }
     .panel{ position:absolute; left:10px; bottom:10px; right:10px; background:linear-gradient(180deg, rgba(16,23,42,.9), rgba(16,23,42,.6)); border:1px solid rgba(255,255,255,.08); border-radius:16px; padding:10px; }
     .grid{ display:grid; grid-template-columns:repeat(var(--cols,5),minmax(0,1fr)); gap:6px; }
@@ -258,13 +258,15 @@
   function drawBackground(){
     if(bgReady){
       ctx.drawImage(bgImg, 0, 0, W, H);
+      ctx.fillStyle = 'rgba(255,255,255,0.15)';
+      ctx.fillRect(0, 0, W, H);
     }
   }
   function drawObstacles(){
     for(const o of state.obstacles){
       const grad = ctx.createRadialGradient(o.x-2,o.y-2,2, o.x,o.y,(o.r||14));
-      grad.addColorStop(0,'#1e40af');
-      grad.addColorStop(1,'#1e3a8a');
+      grad.addColorStop(0,'#93c5fd');
+      grad.addColorStop(1,'#3b82f6');
       ctx.fillStyle = grad;
       ctx.beginPath();
       ctx.arc(o.x, o.y, o.r || 14, 0, Math.PI*2);


### PR DESCRIPTION
## Summary
- use lighter theme colors for Falling Ball menu and buttons
- lighten game background and obstacle colors for better visibility

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_6898379528c4832992735f26a9fba0c8