### PR TITLE
Brighten Falling Ball visuals

### DIFF
--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -10,7 +10,7 @@
     body{ background:var(--bg); color:var(--ink); font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif; }
     .app{ position:fixed; inset:0; overflow:hidden; }
     canvas{ display:block; width:100%; height:100%; }
-    .hudTop{ position:absolute; inset-inline:0; top:0; padding:10px; display:flex; flex-wrap:wrap; gap:8px; align-items:center; justify-content:space-between; font-size:12px; color:var(--muted); }
+    .hudTop{ position:absolute; inset-inline:0; top:0; padding:10px; display:flex; flex-wrap:wrap; gap:8px; align-items:center; justify-content:space-between; font-size:12px; color:#fff; }
     .row{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
     .chip{ padding:6px 10px; border-radius:12px; border:1px solid rgba(255,255,255,.15); color:#fff; background:transparent; cursor:pointer; }
     .chip.active{ border-color:#7dd3fc; }
@@ -19,12 +19,12 @@
     .btn:disabled{ opacity:.5; }
     .panel{ position:absolute; left:10px; bottom:10px; right:10px; background:linear-gradient(180deg, rgba(16,23,42,.9), rgba(16,23,42,.6)); border:1px solid rgba(255,255,255,.08); border-radius:16px; padding:10px; }
     .grid{ display:grid; grid-template-columns:repeat(var(--cols,5),minmax(0,1fr)); gap:6px; }
-    .slot{ text-align:center; font-size:12px; color:#cbd5e1; padding:6px 0; border-radius:10px; border:1px dashed rgba(255,255,255,.12); display:flex; flex-direction:column; align-items:center; gap:4px; }
+    .slot{ text-align:center; font-size:12px; color:#fff; padding:6px 0; border-radius:10px; border:1px dashed rgba(255,255,255,.12); display:flex; flex-direction:column; align-items:center; gap:4px; }
     .slot.me{ border-color:#7dd3fc; color:#c7f3ff; }
     .slot img{ width:var(--avatar-size,24px); height:var(--avatar-size,24px); border-radius:50%; }
     .coin-confetti{ position:fixed; top:-40px; width:32px; height:32px; pointer-events:none; animation:coin-fall var(--duration,3s) linear forwards; }
     @keyframes coin-fall{ from{ transform:translateY(-10vh) rotate(0deg); opacity:1; } to{ transform:translateY(100vh) rotate(360deg); opacity:0; } }
-    .status{ position:absolute; left:10px; top:62px; background:rgba(0,0,0,.35); padding:8px 10px; border-radius:12px; border:1px solid rgba(255,255,255,.08); color:var(--muted); font-size:12px; max-width:min(92vw,560px); }
+    .status{ position:absolute; left:10px; top:62px; background:rgba(0,0,0,.35); padding:8px 10px; border-radius:12px; border:1px solid rgba(255,255,255,.08); color:#fff; font-size:12px; max-width:min(92vw,560px); }
     .sep{ opacity:.3; }
     .popup{ position:absolute; inset:0; background:rgba(0,0,0,.6); display:flex; align-items:center; justify-content:center; }
     .popup.hidden{ display:none; }
@@ -43,11 +43,11 @@
     <div class="status" id="statusBox">Obstacles regenerate randomly after each game. Density fixed to high. SFX On/Off.</div>
 
     <div class="panel">
-      <div style="display:flex; justify-content:flex-end; align-items:center; gap:8px; margin-bottom:6px; font-size:12px; color:#cbd5e1;">
+      <div style="display:flex; justify-content:flex-end; align-items:center; gap:8px; margin-bottom:6px; font-size:12px; color:#fff;">
         <div>Winner: <b id="winnerVal">—</b></div>
       </div>
       <div class="grid" id="slots"></div>
-      <div style="margin-top:6px; font-size:12px; color:#cbd5e1;">Pot: <b id="potVal">0</b> TPC (-10% dev fee at end)</div>
+      <div style="margin-top:6px; font-size:12px; color:#fff;">Pot: <b id="potVal">0</b> TPC (-10% dev fee at end)</div>
     </div>
 
     <canvas id="scene"></canvas>
@@ -67,7 +67,7 @@
   let W=innerWidth, H=innerHeight; canvas.width=W; canvas.height=H;
   // background image
   const bgImg = new Image();
-  bgImg.src = '/assets/icons/file_00000000413c620aafbfe1fe5805f17e%20(1)%20(1).webp';
+  bgImg.src = '/assets/icons/Falling%20Ball.jpg';
   let bgReady = false;
   bgImg.onload = () => { bgReady = true; };
   addEventListener('resize', ()=>{ W=innerWidth; H=innerHeight; canvas.width=W; canvas.height=H; genPegField(); carveCorridors(); });
@@ -265,8 +265,8 @@
   function drawObstacles(){
     for(const o of state.obstacles){
       const grad = ctx.createRadialGradient(o.x-2,o.y-2,2, o.x,o.y,(o.r||14));
-      grad.addColorStop(0,'#93c5fd');
-      grad.addColorStop(1,'#3b82f6');
+      grad.addColorStop(0,'#fef08a');
+      grad.addColorStop(1,'#facc15');
       ctx.fillStyle = grad;
       ctx.beginPath();
       ctx.arc(o.x, o.y, o.r || 14, 0, Math.PI*2);


### PR DESCRIPTION
## Summary
- Use dedicated Falling Ball image as game background
- Render obstacles in yellow
- Brighten HUD, panel, and status text for clearer menus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68983f6bc2f88329b7657524d327c64d