### PR TITLE
style: update falling ball visuals

### DIFF
--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -14,8 +14,9 @@
     .row{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
     .chip{ padding:6px 10px; border-radius:12px; border:1px solid rgba(255,255,255,.15); color:#fff; background:transparent; cursor:pointer; }
     .chip.active{ border-color:#7dd3fc; }
-    .btn{ appearance:none; border:1px solid rgba(255,255,255,.15); background:rgba(255,255,255,.06); color:#fff; padding:10px 14px; border-radius:14px; font-weight:600; font-size:14px; cursor:pointer; }
-    .btn.primary{ background:linear-gradient(135deg,#7dd3fc,#60a5fa); color:#fff; border:none; box-shadow:0 6px 18px rgba(96,165,250,.35); }
+      .btn{ appearance:none; border:1px solid #00f7ff; background:rgba(0,0,0,.3); color:#00f7ff; padding:10px 14px; border-radius:14px; font-weight:600; font-size:14px; cursor:pointer; text-shadow:0 0 4px #00f7ff; }
+      .btn.primary{ background:#00f7ff; color:#fff; border:none; box-shadow:0 0 8px rgba(0,247,255,.5); }
+      .btn.primary:hover{ background:#66fcff; }
     .btn:disabled{ opacity:.5; }
     .panel{ position:absolute; left:10px; bottom:10px; right:10px; background:transparent; border:none; border-radius:16px; padding:10px; }
     .grid{ display:grid; grid-template-columns:repeat(var(--cols,5),minmax(0,1fr)); gap:6px; }
@@ -26,9 +27,9 @@
     @keyframes coin-fall{ from{ transform:translateY(-10vh) rotate(0deg); opacity:1; } to{ transform:translateY(100vh) rotate(360deg); opacity:0; } }
     .status{ position:absolute; left:10px; top:62px; background:rgba(0,0,0,.35); padding:8px 10px; border-radius:12px; border:1px solid rgba(255,255,255,.08); color:#fff; font-size:12px; max-width:min(92vw,560px); }
     .sep{ opacity:.3; }
-    .popup{ position:absolute; inset:0; background:rgba(0,0,0,.6); display:flex; align-items:center; justify-content:center; }
-    .popup.hidden{ display:none; }
-    .popup .box{ background:var(--panel); padding:20px; border-radius:12px; text-align:center; }
+      .popup{ position:absolute; inset:0; background:rgba(0,0,0,.7); display:flex; align-items:center; justify-content:center; }
+      .popup.hidden{ display:none; }
+      .popup .box{ background:linear-gradient(#081428,#102040); background-color:#0b1a2f; border:1px solid #00f7ff; box-shadow:0 0 8px #00f7ff, inset 0 0 10px rgba(0,247,255,.4); padding:20px; border-radius:12px; text-align:center; color:#00f7ff; }
     .countdown{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; font-size:48px; font-weight:bold; color:#fff; background:rgba(0,0,0,0.5); z-index:50; }
     .countdown.hidden{ display:none; }
   </style>
@@ -58,7 +59,7 @@
     <div id="winnerPopup" class="popup hidden">
       <div class="box">
         <div id="winnerText" style="margin-bottom:10px;"></div>
-        <button class="btn" id="lobbyBtn">Return Lobby</button>
+        <button class="btn primary" id="lobbyBtn">Return Lobby</button>
       </div>
     </div>
     <div id="countdown" class="countdown hidden"></div>
@@ -71,8 +72,8 @@
   const ctx = canvas.getContext('2d');
   let W=innerWidth, H=innerHeight; canvas.width=W; canvas.height=H;
   // background image
-  const bgImg = new Image();
-  bgImg.src = '/assets/icons/Falling%20Ball.jpg';
+    const bgImg = new Image();
+    bgImg.src = '/assets/icons/file_00000000e6e46246bc1e1a1e5eaaa784.webp';
   let bgReady = false;
   bgImg.onload = () => { bgReady = true; };
   addEventListener('resize', ()=>{ W=innerWidth; H=innerHeight; canvas.width=W; canvas.height=H; genPegField(); carveCorridors(); });


### PR DESCRIPTION
## Summary
- use neon popup styling to match the site
- switch Falling Ball background image to new webp asset

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_6898591607f0832998af53efb1027b90