### PR TITLE
Disable caching and use high-res game background

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -15,6 +15,10 @@
     <meta name="twitter:title" content="TonPlaygram" />
     <meta name="twitter:description" content="Play games and earn TonPlaygram Coin on the TON blockchain." />
 
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+
     <title>TonPlaygram</title>
   </head>
   <body>

--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <title>TonPlaygram – Falling Ball PvP (SFX + Visuals)</title>
   <style>
     :root{ --bg:#f0fdf4; --panel:#10172a; --ink:#000; --muted:#10b981; --accent:#94a3b8; }

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <title>TonPlaygram</title>
   </head>
   <body>

--- a/webapp/src/components/AchievementsCard.jsx
+++ b/webapp/src/components/AchievementsCard.jsx
@@ -36,7 +36,7 @@ export default function AchievementsCard({ telegramId: propTelegramId }) {
     return (
       <div className="relative bg-surface border border-border rounded-xl p-4 text-subtext text-center overflow-hidden wide-card">
         <img
-          src="/assets/SnakeLaddersbackground.png"
+          src="/assets/icons/snakes_and_ladders.webp"
           className="background-behind-board object-cover"
           alt=""
           onError={(e) => { e.currentTarget.style.display = 'none'; }}
@@ -49,7 +49,7 @@ export default function AchievementsCard({ telegramId: propTelegramId }) {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
       <img
-        src="/assets/SnakeLaddersbackground.png"
+        src="/assets/icons/snakes_and_ladders.webp"
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => { e.currentTarget.style.display = 'none'; }}

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -159,7 +159,7 @@ export default function DailyCheckIn() {
 
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 text-center overflow-hidden wide-card">
       <img
-        src="/assets/SnakeLaddersbackground.png"
+        src="/assets/icons/snakes_and_ladders.webp"
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => {

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -4,7 +4,7 @@ export default function HomeGamesCard() {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
       <img
-        src="/assets/SnakeLaddersbackground.png"
+        src="/assets/icons/snakes_and_ladders.webp"
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => {

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -145,7 +145,7 @@ export default function LeaderboardCard() {
         className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card mt-4 -ml-3"
       >
         <img
-          src="/assets/SnakeLaddersbackground.png"
+          src="/assets/icons/snakes_and_ladders.webp"
           className="background-behind-board object-cover"
           alt=""
           onError={(e) => {

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -124,7 +124,7 @@ export default function MiningCard() {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-center overflow-hidden wide-card">
       <img
-        src="/assets/SnakeLaddersbackground.png"
+        src="/assets/icons/snakes_and_ladders.webp"
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => {

--- a/webapp/src/components/NftGiftCard.jsx
+++ b/webapp/src/components/NftGiftCard.jsx
@@ -54,7 +54,7 @@ export default function NftGiftCard({ accountId: propAccountId }) {
   return (
     <div className="relative prism-box p-6 space-y-3 flex flex-col items-center text-center overflow-hidden min-h-40 wide-card mx-auto">
       <img
-        src="/assets/SnakeLaddersbackground.png"
+        src="/assets/icons/snakes_and_ladders.webp"
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => {

--- a/webapp/src/components/ProfileCard.jsx
+++ b/webapp/src/components/ProfileCard.jsx
@@ -5,7 +5,7 @@ export default function ProfileCard() {
   return (
     <div className="relative bg-surface border border-border p-4 rounded-xl shadow-lg space-y-2 text-center overflow-hidden wide-card">
       <img
-        src="/assets/SnakeLaddersbackground.png"
+        src="/assets/icons/snakes_and_ladders.webp"
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => {

--- a/webapp/src/components/ProjectAchievementsCard.jsx
+++ b/webapp/src/components/ProjectAchievementsCard.jsx
@@ -20,7 +20,7 @@ export default function ProjectAchievementsCard() {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
       <img
-        src="/assets/SnakeLaddersbackground.png"
+        src="/assets/icons/snakes_and_ladders.webp"
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => { e.currentTarget.style.display = 'none'; }}

--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -226,7 +226,7 @@ export default function SnakeBoard({
   return (
     <div className="relative flex justify-center items-center w-screen overflow-visible">
       <img
-        src="/assets/SnakeLaddersbackground.png"
+        src="/assets/icons/snakes_and_ladders.webp"
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => {

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -224,7 +224,7 @@ export default function SpinGame() {
       className="relative bg-surface border border-border rounded-xl p-4 flex flex-col items-center space-y-2 overflow-hidden wide-card"
     >
       <img
-        src="/assets/SnakeLaddersbackground.png"
+        src="/assets/icons/snakes_and_ladders.webp"
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => {

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -234,7 +234,7 @@ export default function TasksCard() {
 
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
       <img
-        src="/assets/SnakeLaddersbackground.png"
+        src="/assets/icons/snakes_and_ladders.webp"
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => {

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -100,7 +100,7 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
       <div className="relative p-4 space-y-4 w-80 rounded-xl border border-border bg-surface text-text overflow-hidden">
 
         <img
-          src="/assets/SnakeLaddersbackground.png"
+          src="/assets/icons/snakes_and_ladders.webp"
           className="background-behind-board object-cover"
           alt=""
           onError={(e) => {

--- a/webapp/src/components/WalletCard.jsx
+++ b/webapp/src/components/WalletCard.jsx
@@ -34,7 +34,7 @@ export default function WalletCard() {
   return (
     <div className="relative bg-surface border border-border p-4 rounded-xl shadow-lg text-text space-y-2 overflow-hidden wide-card">
       <img
-        src="/assets/SnakeLaddersbackground.png"
+        src="/assets/icons/snakes_and_ladders.webp"
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -630,7 +630,7 @@ export default function CrazyDiceDuel() {
     <div className="text-text relative">
       {bgUnlocked && (
         <img
-          src="/assets/SnakeLaddersbackground.png"
+          src="/assets/icons/snakes_and_ladders.webp"
           className="background-behind-board crazy-dice-bg object-cover"
           alt=""
           onError={(e) => {

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -135,7 +135,7 @@ export default function Home() {
         <div className="w-full mt-2 space-y-4">
           <div className="relative bg-surface border border-border rounded-xl p-4 flex items-center justify-around overflow-hidden wide-card">
             <img
-              src="/assets/SnakeLaddersbackground.png"
+              src="/assets/icons/snakes_and_ladders.webp"
               className="background-behind-board object-cover"
               alt=""
               onError={(e) => {
@@ -160,7 +160,7 @@ export default function Home() {
               </div>
               <img
                 
-                src="/assets/SnakeLaddersbackground.png"
+                src="/assets/icons/snakes_and_ladders.webp"
                 className="background-behind-board object-cover"
                 alt=""
               onError={(e) => { e.currentTarget.style.display = "none"; }}

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -136,7 +136,7 @@ export default function Mining() {
 
       <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-text overflow-hidden wide-card">
       <img
-        src="/assets/SnakeLaddersbackground.png"
+        src="/assets/icons/snakes_and_ladders.webp"
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => {


### PR DESCRIPTION
## Summary
- ensure latest assets by adding no-cache headers to index and game pages
- restore crisp game visuals by switching to high-res snakes_and_ladders background

## Testing
- `npm test` *(fails: should receive error when table not full)*

------
https://chatgpt.com/codex/tasks/task_e_68986e4cc7b4832987f7737ffdf4d60b