### PR TITLE
feat: force latest assets on reload

### DIFF
--- a/webapp/public/service-worker.js
+++ b/webapp/public/service-worker.js
@@ -1,0 +1,16 @@
+// Simple service worker to ensure latest assets are served
+self.addEventListener('install', () => {
+  // Take control immediately after installation
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  // Become the active worker for all clients
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+  // Always go to the network and avoid caches
+  event.respondWith(fetch(event.request, { cache: 'no-store' }));
+});
+

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -8,3 +8,20 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <App />
   </React.StrictMode>
 );
+
+// Register a service worker to always fetch the latest files
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/service-worker.js')
+      .then(() => {
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          // When a new service worker takes control, reload to fetch fresh assets
+          window.location.reload();
+        });
+      })
+      .catch((error) => {
+        console.error('Service worker registration failed:', error);
+      });
+  });
+}


### PR DESCRIPTION
## Summary
- register a service worker that refreshes the page when updated
- add service worker to bypass caches and always fetch latest files

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898b20ea518832991e33991a4492d7d