### PR TITLE
Ensure falling ball winners receive TPC and show as game won

### DIFF
--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -125,9 +125,19 @@
     setTimeout(()=>container.remove(),5000);
   }
 
+  let cachedAccountId = null;
   async function awardTpc(telegramId, amount){
     try{
-      await fetch('/api/profile/addTransaction',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({telegramId,amount,type:'win',game:'fallingball'})});
+      if(!cachedAccountId){
+        const profRes = await fetch('/api/profile/get',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({telegramId})});
+        const profData = await profRes.json();
+        cachedAccountId = profData.accountId;
+      }
+      if(!cachedAccountId) return;
+      const headers={'Content-Type':'application/json'};
+      const initData=window?.Telegram?.WebApp?.initData;
+      if(initData) headers['X-Telegram-Init-Data']=initData;
+      await fetch('/api/account/deposit',{method:'POST',headers,body:JSON.stringify({accountId:cachedAccountId,amount,game:'fallingball-win'})});
     }catch(err){ console.warn('Failed to award TPC',err); }
   }
 

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -447,6 +447,7 @@ export default function Wallet({ hideClaim = false }) {
               if (tx.type === 'gift') return 'gift sent';
               if (tx.type === 'gift-receive') return 'gift received';
               if (tx.type === 'gift-fee') return 'gift fee';
+              if (tx.game && tx.type === 'deposit') return 'game won';
               return tx.game ? 'game' : tx.type;
             })();
             const categoryLabel = tx.category ? ` (Tier ${tx.category})` : '';


### PR DESCRIPTION
## Summary
- Deposit Falling Ball winnings into the player's TPC account by looking up their profile
- Show game deposits in wallet history as "game won" with green highlight

## Testing
- `npm run lint`
- `npm test` *(hangs after executing subtests; manual interruption)*

------
https://chatgpt.com/codex/tasks/task_e_6898bb3cd1c88329b7d831c0da899063