### PR TITLE
Use shared TPC payment route for Falling Ball game

### DIFF
--- a/webapp/public/falling-ball-api.js
+++ b/webapp/public/falling-ball-api.js
@@ -1,0 +1,47 @@
+(function(){
+  const API_BASE_URL = window.API_BASE_URL || '';
+  async function post(path, body){
+    const headers = { 'Content-Type': 'application/json' };
+    const initData = window?.Telegram?.WebApp?.initData;
+    if (initData) headers['X-Telegram-Init-Data'] = initData;
+    let res;
+    try {
+      res = await fetch(API_BASE_URL + path, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body)
+      });
+    } catch (err) {
+      return { error: 'Network request failed' };
+    }
+    let text;
+    try {
+      text = await res.text();
+    } catch {
+      return { error: 'Invalid server response' };
+    }
+    let data;
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      return { error: 'Invalid server response' };
+    }
+    if (!res.ok) {
+      return { error: data.error || res.statusText || 'Request failed' };
+    }
+    return data;
+  }
+  window.fbApi = {
+    depositAccount(accountId, amount, extra = {}) {
+      return post('/api/account/deposit', { accountId, amount, ...extra });
+    },
+    addTransaction(telegramId, amount, type, extra = {}) {
+      return post('/api/profile/addTransaction', {
+        telegramId,
+        amount,
+        type,
+        ...extra
+      });
+    }
+  };
+})();

--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -69,6 +69,7 @@
   </div>
 
   <script src="/flag-emojis.js"></script>
+  <script src="/falling-ball-api.js"></script>
   <script>
   // ========================= Canvas & Brand =========================
   const canvas = document.getElementById('scene');
@@ -125,15 +126,6 @@
     setTimeout(()=>container.remove(),5000);
   }
 
-  async function depositTpc(accountId, amount, tag){
-    try{
-      const headers = { 'Content-Type':'application/json' };
-      const initData = window?.Telegram?.WebApp?.initData;
-      if (initData) headers['X-Telegram-Init-Data'] = initData;
-      await fetch('/api/account/deposit',{method:'POST',headers,body:JSON.stringify({accountId,amount,game:tag})});
-    }catch(err){ console.warn('Failed to deposit TPC',err); }
-  }
-
   const sfxToggleBtn = document.getElementById('sfxToggle');
   sfxToggleBtn.onclick = (e)=>{
     sfxOn = !sfxOn;
@@ -171,6 +163,7 @@
   if (amt > 0) state.stake = amt;
   const myAccountId = params.get('accountId');
   const devAccountId = params.get('dev');
+  const myTelegramId = window?.Telegram?.WebApp?.initDataUnsafe?.user?.id;
   // ========================= HUD =========================
   const startBtn = document.getElementById('startBtn');
   startBtn.onclick = startMatch;
@@ -312,7 +305,7 @@
     if (b.y + b.r >= groundY){
       b.y = groundY - b.r; b.vy *= -state.bounce;
       if (Math.abs(b.vy) < 1.1){
-        const idx = pickSlotFromX(b.x); state.resultSlot = idx; const fee = Math.floor(state.pot*0.10); const prize = state.pot - fee; document.getElementById('winnerVal').textContent = `${state.slots[idx].name} +${prize} TPC`; setStatus(`Winner: ${state.slots[idx].name}. Payout ${prize} TPC (-${fee} dev)`); SFX.win(); coinConfetti(50); if(state.slots[idx].isMe && myAccountId){ depositTpc(myAccountId, prize, 'fallingball-win'); } if(devAccountId){ depositTpc(devAccountId, fee, 'fallingball-dev'); } setTimeout(()=>showWinnerPopup(state.slots[idx].name),2000);
+        const idx = pickSlotFromX(b.x); state.resultSlot = idx; const fee = Math.floor(state.pot*0.10); const prize = state.pot - fee; document.getElementById('winnerVal').textContent = `${state.slots[idx].name} +${prize} TPC`; setStatus(`Winner: ${state.slots[idx].name}. Payout ${prize} TPC (-${fee} dev)`); SFX.win(); coinConfetti(50); if(state.slots[idx].isMe && myAccountId){ fbApi.depositAccount(myAccountId, prize, { game: 'fallingball-win' }); if(myTelegramId) fbApi.addTransaction(myTelegramId, 0, 'win', { game: 'fallingball', players: state.players, accountId: myAccountId }); } if(devAccountId){ fbApi.depositAccount(devAccountId, fee, { game: 'fallingball-dev' }); } setTimeout(()=>showWinnerPopup(state.slots[idx].name),2000);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Load new `falling-ball-api.js` helper to reuse `/api/account/deposit` and transaction routes
- Record winner and developer payouts in Falling Ball via shared TPC API

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_6898d3e8eaf483298863acd0cfd09f44