### PR TITLE
fix: persist current path before reload

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -35,7 +35,7 @@ export default function Layout({ children }) {
   }, []);
 
   // Persist the current path so reloads return to the same page
-  useEffect(() => {
+  useLayoutEffect(() => {
     try {
       const current = location.pathname + location.search;
       localStorage.setItem('lastPath', current);


### PR DESCRIPTION
## Summary
- persist current path immediately on navigation to keep refresh on same page

## Testing
- `npm test` (failed: joinRoom clears lobby seat, joinRoom waits until table full)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899014fc2b48329bce4f270e9aac0ed