### PR TITLE
feat: add public game and development wallet pages

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -27,6 +27,8 @@ import FallingBall from './pages/Games/FallingBall.jsx';
 import FallingBallLobby from './pages/Games/FallingBallLobby.jsx';
 import AirHockey from './pages/Games/AirHockey.jsx';
 import AirHockeyLobby from './pages/Games/AirHockeyLobby.jsx';
+import GamesWallet from './pages/GamesWallet.jsx';
+import DevelopmentWallet from './pages/DevelopmentWallet.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -63,6 +65,8 @@ export default function App() {
             <Route path="/store" element={<Store />} />
             <Route path="/referral" element={<Referral />} />
             <Route path="/wallet" element={<Wallet />} />
+            <Route path="/wallet/games" element={<GamesWallet />} />
+            <Route path="/wallet/development" element={<DevelopmentWallet />} />
             <Route path="/messages" element={<Messages />} />
             <Route path="/notifications" element={<Notifications />} />
             <Route path="/trending" element={<Trending />} />

--- a/webapp/src/components/PublicWallet.jsx
+++ b/webapp/src/components/PublicWallet.jsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+import { getAccountBalance, getAccountTransactions } from '../utils/api.js';
+import TransactionDetailsPopup from './TransactionDetailsPopup.jsx';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
+
+function formatValue(value, decimals = 2) {
+  if (typeof value !== 'number') {
+    const parsed = parseFloat(value);
+    if (isNaN(parsed)) return value;
+    return parsed.toLocaleString(undefined, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    });
+  }
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
+export default function PublicWallet({ title, accountId }) {
+  useTelegramBackButton();
+  const [balance, setBalance] = useState(null);
+  const [transactions, setTransactions] = useState([]);
+  const [selectedTx, setSelectedTx] = useState(null);
+
+  useEffect(() => {
+    if (!accountId) return;
+    getAccountBalance(accountId).then((b) => {
+      if (b && typeof b.balance === 'number') {
+        setBalance(b.balance);
+      } else {
+        setBalance(0);
+      }
+    });
+    getAccountTransactions(accountId).then((tx) => {
+      setTransactions(tx.transactions || []);
+    });
+  }, [accountId]);
+
+  return (
+    <div className="relative space-y-4 text-text">
+      <h2 className="text-2xl font-bold text-center mt-4">{title}</h2>
+
+      <div className="bg-surface border border-border rounded-xl p-4 space-y-2 text-center wide-card">
+        <h3 className="font-semibold">TPC Balance</h3>
+        <div>{balance === null ? '...' : formatValue(balance)}</div>
+      </div>
+
+      <div className="bg-surface border border-border rounded-xl p-4 space-y-2 text-center mt-4 wide-card">
+        <h3 className="font-semibold text-center">TPC Statements</h3>
+        <div className="space-y-1 text-sm max-h-[40rem] overflow-y-auto border border-border rounded">
+          {transactions.map((tx, i) => (
+            <div
+              key={i}
+              className="lobby-tile w-full flex flex-col cursor-pointer"
+              onClick={() => setSelectedTx(tx)}
+            >
+              <div className="flex justify-between">
+                <span className="capitalize">{tx.game || tx.type}</span>
+                <span className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
+                  {tx.amount > 0 ? '+' : '-'}
+                  {formatValue(Math.abs(tx.amount))} {(tx.token || 'TPC').toUpperCase()}
+                </span>
+              </div>
+              {(tx.fromAccount || tx.fromName) && (
+                <div className="text-xs text-subtext">
+                  {tx.fromName ? `${tx.fromName} ` : ''}
+                  {tx.fromAccount ? `#${tx.fromAccount}` : ''}
+                </div>
+              )}
+              {tx.toAccount && tx.game && (
+                <div className="text-xs text-subtext">To #{tx.toAccount}</div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <TransactionDetailsPopup tx={selectedTx} onClose={() => setSelectedTx(null)} />
+    </div>
+  );
+}

--- a/webapp/src/pages/DevelopmentWallet.jsx
+++ b/webapp/src/pages/DevelopmentWallet.jsx
@@ -1,0 +1,6 @@
+import PublicWallet from '../components/PublicWallet.jsx';
+
+export default function DevelopmentWallet() {
+  const accountId = import.meta.env.VITE_DEV_WALLET_ID;
+  return <PublicWallet title="Development Wallet" accountId={accountId} />;
+}

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -52,6 +52,23 @@ export default function Games() {
             </div>
           </div>
         </div>
+        <div className="relative bg-surface border border-border rounded-xl p-4 shadow-lg overflow-hidden wide-card">
+          <h3 className="text-lg font-bold text-center mb-2">Public Wallets</h3>
+          <div className="flex justify-around items-center flex-wrap gap-4">
+            <Link
+              to="/wallet/games"
+              className="inline-block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow"
+            >
+              Games Wallet
+            </Link>
+            <Link
+              to="/wallet/development"
+              className="inline-block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow"
+            >
+              Development Wallet
+            </Link>
+          </div>
+        </div>
         <LeaderboardCard />
       </div>
     </div>

--- a/webapp/src/pages/GamesWallet.jsx
+++ b/webapp/src/pages/GamesWallet.jsx
@@ -1,0 +1,6 @@
+import PublicWallet from '../components/PublicWallet.jsx';
+
+export default function GamesWallet() {
+  const accountId = import.meta.env.VITE_GAMES_ACCOUNT_ID;
+  return <PublicWallet title="Games Wallet" accountId={accountId} />;
+}


### PR DESCRIPTION
## Summary
- add PublicWallet component to show balance and transaction history
- expose games and development wallet pages
- link public wallets from Games page and register routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68997908eb9c8329a1a623d2e2481a7d