### PR TITLE
Add game wallet smart contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,25 @@ Run `npm run reset-db` to drop the existing MongoDB database and start with a cl
 4. **Verify the deployment** on TonScan or with `tonos-cli account <address>` to confirm the contract state is active. Test a small claim using `npm run claim-test` and check that the wallet emits a `send_jettons` transfer.
 
 
+### Game wallet contract
+
+`tpc_game_wallet.fc` manages deposits and payouts for games. Compile the contract with:
+
+```bash
+func -SPA -o build/tpc_game_wallet.fif \
+     stdlib.fc ft/params.fc ft/op-codes.fc ft/discovery-params.fc \
+     ft/jetton-utils.fc tpc_game_wallet.fc
+echo '"build/tpc_game_wallet.fif" include 2 boc+>B "build/tpc_game_wallet.boc" B>file' | fift -s
+```
+
+The contract exposes three operations:
+
+- `op::deposit` – increase the internal balance after a stake.
+- `op::payout` – transfer the stake to the winner and send a 10% share to the developer wallet.
+- `op::ai_win` – add the stake to the game balance when the AI wins while still paying the developer share.
+
+Ensure the game wallet begins with at least 1,000,000 TPC so payouts can be covered.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/tpc_game_wallet.fc
+++ b/tpc_game_wallet.fc
@@ -1,0 +1,122 @@
+;; TPC Game Wallet
+;; Manages deposits and payouts for games on TonPlaygram.
+;; Initial funding of 1,000,000 TPC should be transferred to the
+;; jetton wallet owned by this contract.
+
+#include "stdlib.fc";
+#include "ft/params.fc";
+#include "ft/op-codes.fc";
+#include "ft/discovery-params.fc";
+#include "ft/jetton-utils.fc";
+
+const op::deposit = 0x10;
+const op::payout = 0x11;
+const op::ai_win = 0x12;
+
+int wallet_forward_amount() asm "50000000 PUSHINT"; ;; 0.05 TON
+
+;; storage#_ balance:Coins admin_address:MsgAddress dev_address:MsgAddress content:^Cell jetton_wallet_code:^Cell = Storage;
+
+(int, slice, slice, cell, cell) load_data() inline {
+    slice ds = get_data().begin_parse();
+    return (
+        ds~load_coins(),       ;; balance
+        ds~load_msg_addr(),    ;; admin_address
+        ds~load_msg_addr(),    ;; dev_address
+        ds~load_ref(),         ;; content
+        ds~load_ref()          ;; jetton_wallet_code
+    );
+}
+
+() save_data(int balance, slice admin_addr, slice dev_addr, cell content, cell jetton_wallet_code) impure inline {
+    set_data(begin_cell()
+        .store_coins(balance)
+        .store_slice(admin_addr)
+        .store_slice(dev_addr)
+        .store_ref(content)
+        .store_ref(jetton_wallet_code)
+    .end_cell());
+}
+
+() send_jettons(slice to_wallet, int jetton_amount, slice admin_addr, cell content, cell wallet_code) impure {
+    slice root_addr = content.begin_parse();
+    slice game_wallet = calculate_user_jetton_wallet_address(admin_addr, root_addr, wallet_code);
+    var transfer = begin_cell()
+        .store_uint(op::transfer(), 32)
+        .store_uint(0, 64)
+        .store_coins(jetton_amount)
+        .store_slice(to_wallet)
+        .store_slice(my_address())
+        .store_maybe_ref(null())
+        .store_coins(0)
+        .store_maybe_ref(null())
+    .end_cell();
+    var msg = begin_cell()
+        .store_uint(0x18, 6)
+        .store_slice(game_wallet)
+        .store_coins(wallet_forward_amount())
+        .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+        .store_ref(transfer);
+    send_raw_message(msg.end_cell(), 1);
+}
+
+() recv_internal(int msg_value, cell in_msg_full, slice in_msg_body) impure {
+    if (in_msg_body.slice_empty?()) {
+        return ();
+    }
+    slice cs = in_msg_full.begin_parse();
+    int flags = cs~load_uint(4);
+    if (flags & 1) {
+        return (); ;; ignore bounced
+    }
+    slice sender_address = cs~load_msg_addr();
+    cs~load_msg_addr();
+    cs~load_coins();
+    cs~skip_bits(1);
+    cs~load_coins();
+    cs~load_coins();
+
+    int op = in_msg_body~load_uint(32);
+    int query_id = in_msg_body~load_uint(64);
+
+    var (balance, admin_addr, dev_addr, content, wallet_code) = load_data();
+
+    if (op == op::deposit) {
+        int amount = in_msg_body~load_coins();
+        throw_unless(100, equal_slices(sender_address, admin_addr));
+        balance += amount;
+        save_data(balance, admin_addr, dev_addr, content, wallet_code);
+        return ();
+    }
+
+    if (op == op::payout) {
+        slice winner = in_msg_body~load_msg_addr();
+        int stake = in_msg_body~load_coins();
+        throw_unless(100, equal_slices(sender_address, admin_addr));
+        throw_unless(101, balance >= stake);
+        int dev_fee = stake / 10; ;; 10%
+        int win_amount = stake - dev_fee;
+        balance -= stake;
+        send_jettons(winner, win_amount, admin_addr, content, wallet_code);
+        send_jettons(dev_addr, dev_fee, admin_addr, content, wallet_code);
+        save_data(balance, admin_addr, dev_addr, content, wallet_code);
+        return ();
+    }
+
+    if (op == op::ai_win) {
+        int stake = in_msg_body~load_coins();
+        throw_unless(100, equal_slices(sender_address, admin_addr));
+        int dev_fee = stake / 10; ;; 10%
+        balance += stake - dev_fee;
+        send_jettons(dev_addr, dev_fee, admin_addr, content, wallet_code);
+        save_data(balance, admin_addr, dev_addr, content, wallet_code);
+        return ();
+    }
+
+    throw(0xffff);
+}
+
+(int, slice, slice) get_game_data() method_id {
+    (int balance, slice admin_addr, slice dev_addr, cell content, cell wallet_code) = load_data();
+    return (balance, admin_addr, dev_addr);
+}


### PR DESCRIPTION
## Summary
- add `tpc_game_wallet` contract for handling deposits, payouts and developer fees
- document game wallet compilation and operations in README

## Testing
- `npm test` *(fails: joinRoom waits until table full - AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_689987292cf883299d3e94360ff2ed39