### PR TITLE
Fix duplicate telegramId handling by using sparse unique index

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -39,7 +39,9 @@ nftTokenId: String
 
 const userSchema = new mongoose.Schema({
 
-  telegramId: { type: Number, unique: true },
+  // Allow multiple users without a Telegram account by making the unique
+  // index sparse (documents missing telegramId won't conflict)
+  telegramId: { type: Number },
 
   // Allow multiple users without a Google account by making the unique
   // index sparse (documents missing googleId won't conflict)
@@ -116,6 +118,8 @@ const userSchema = new mongoose.Schema({
 
 // Index commonly queried fields
 userSchema.index({ nickname: 1 });
+// Ensure telegramId remains unique when present
+userSchema.index({ telegramId: 1 }, { unique: true, sparse: true });
 // Enforce uniqueness of googleId only when the field exists
 userSchema.index({ googleId: 1 }, { unique: true, sparse: true });
 // Ensure walletAddress remains unique when present


### PR DESCRIPTION
## Summary
- avoid duplicate key errors when multiple users lack Telegram accounts
- ensure telegramId unique only when present

## Testing
- `npm test` (fails: joinRoom waits until table full)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68998d38bd60832998331c640330dcf0