### PR TITLE
Propagate Telegram init data to arcade games for payouts

### DIFF
--- a/webapp/public/air-hockey.html
+++ b/webapp/public/air-hockey.html
@@ -93,6 +93,10 @@
   const devAccount1 = params.get('dev1');
   const devAccount2 = params.get('dev2');
   const tgId = params.get('tgId');
+  const initParam = params.get('init');
+  if (initParam && !window.Telegram) {
+    window.Telegram = { WebApp: { initData: decodeURIComponent(initParam) } };
+  }
   const oppAccountId = params.get('oppAcc') || params.get('oppId') || params.get('p2AccountId');
   const oppTgId = params.get('oppTg') || params.get('p2TgId');
   const mode = params.get('mode') || 'ai';

--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -172,6 +172,10 @@
   const devAccountId = params.get('dev');
   const devAccountId1 = params.get('dev1');
   const devAccountId2 = params.get('dev2');
+  const initParam = params.get('init');
+  if (initParam && !window.Telegram) {
+    window.Telegram = { WebApp: { initData: decodeURIComponent(initParam) } };
+  }
   const myTelegramId = params.get('tgId') || window?.Telegram?.WebApp?.initDataUnsafe?.user?.id;
   const accountsParam = params.get('accounts');
   const tgIdsParam = params.get('tgIds');

--- a/webapp/src/pages/Games/AirHockeyLobby.jsx
+++ b/webapp/src/pages/Games/AirHockeyLobby.jsx
@@ -45,6 +45,7 @@ export default function AirHockeyLobby() {
     params.set('mode', mode);
     params.set('target', goal);
     if (mode === 'ai') params.set('difficulty', difficulty);
+    const initData = window.Telegram?.WebApp?.initData;
     if (stake.token) params.set('token', stake.token);
     if (stake.amount) params.set('amount', stake.amount);
     if (avatar) params.set('avatar', avatar);
@@ -56,6 +57,7 @@ export default function AirHockeyLobby() {
     if (devAcc) params.set('dev', devAcc);
     if (devAcc1) params.set('dev1', devAcc1);
     if (devAcc2) params.set('dev2', devAcc2);
+    if (initData) params.set('init', encodeURIComponent(initData));
     navigate(`/games/airhockey?${params.toString()}`);
   };
 

--- a/webapp/src/pages/Games/FallingBallLobby.jsx
+++ b/webapp/src/pages/Games/FallingBallLobby.jsx
@@ -48,13 +48,16 @@ export default function FallingBallLobby() {
     params.set('players', players);
     params.set('density', 'high');
     params.set('mode', mode);
+    const initData = window.Telegram?.WebApp?.initData;
     if (stake.token) params.set('token', stake.token);
     if (stake.amount) params.set('amount', stake.amount);
     if (avatar) params.set('avatar', avatar);
+    if (tgId) params.set('tgId', tgId);
     if (accountId) params.set('accountId', accountId);
     if (DEV_ACCOUNT) params.set('dev', DEV_ACCOUNT);
     if (DEV_ACCOUNT_1) params.set('dev1', DEV_ACCOUNT_1);
     if (DEV_ACCOUNT_2) params.set('dev2', DEV_ACCOUNT_2);
+    if (initData) params.set('init', encodeURIComponent(initData));
     navigate(`/games/fallingball?${params.toString()}`);
   };
 


### PR DESCRIPTION
## Summary
- include telegram init data and user id in Falling Ball lobby and game
- forward init data from Air Hockey lobby to game for authenticated payouts

## Testing
- `node --test` *(fails: joinRoom clears lobby seat; joinRoom waits until table full)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899ad00dc3c8329a2d4a035d3db6491