### PR TITLE
Add wallet links for game and dev accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@
 
 4. Copy `webapp/.env.example` to `webapp/.env` and configure:
    - `VITE_API_BASE_URL` – the base URL where the bot API is hosted (e.g. `http://localhost:3000`).
-     If omitted, the webapp will connect to the same origin it was served from.
+   If omitted, the webapp will connect to the same origin it was served from.
    - `VITE_GOOGLE_CLIENT_ID` – OAuth client ID for Google sign-in.
+   - `VITE_GAME_ACCOUNT_ID` – account ID of the games wallet where deposits and payouts occur.
   - `VITE_DEV_ACCOUNT_ID` – account ID that receives the developer share
     (10% by default).
   - `VITE_DEV_ACCOUNT_ID_1` – (optional) secondary developer account. When set,

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,6 +1,7 @@
 # Copy this file to `.env` and replace the values as needed.
 VITE_API_BASE_URL=http://localhost:3000
 VITE_GOOGLE_CLIENT_ID=
+VITE_GAME_ACCOUNT_ID=
 # Account IDs that receive developer shares
 # Primary developer account (Tur.Alimadhi)
 VITE_DEV_ACCOUNT_ID=5ffe7c43-c0ae-48f6-ab8c-9e065ca95466

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -2,6 +2,9 @@ import { Link } from 'react-router-dom';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LeaderboardCard from '../components/LeaderboardCard.jsx';
 
+const GAME_ACCOUNT_ID = import.meta.env.VITE_GAME_ACCOUNT_ID;
+const DEV_ACCOUNT_ID = import.meta.env.VITE_DEV_ACCOUNT_ID;
+
 export default function Games() {
   useTelegramBackButton();
   return (
@@ -52,6 +55,29 @@ export default function Games() {
             </div>
           </div>
         </div>
+        {(GAME_ACCOUNT_ID || DEV_ACCOUNT_ID) && (
+          <div className="relative bg-surface border border-border rounded-xl p-4 shadow-lg overflow-hidden wide-card">
+            <h3 className="text-lg font-bold text-center">Wallets</h3>
+            <div className="flex flex-col items-center space-y-1">
+              {GAME_ACCOUNT_ID && (
+                <Link
+                  to={`/wallet?account=${GAME_ACCOUNT_ID}`}
+                  className="text-primary underline"
+                >
+                  Game Wallet
+                </Link>
+              )}
+              {DEV_ACCOUNT_ID && (
+                <Link
+                  to={`/wallet?account=${DEV_ACCOUNT_ID}`}
+                  className="text-primary underline"
+                >
+                  Dev Wallet
+                </Link>
+              )}
+            </div>
+          </div>
+        )}
         <LeaderboardCard />
       </div>
     </div>

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -31,6 +31,7 @@ const DEV_ACCOUNTS = [
 if (urlParams.get('dev')) {
   localStorage.setItem('devAccountId', urlParams.get('dev'));
 }
+const ACCOUNT_ID_PARAM = urlParams.get('account');
 
 function formatValue(value, decimals = 2) {
   if (typeof value !== 'number') {
@@ -91,9 +92,11 @@ export default function Wallet({ hideClaim = false }) {
 
   const loadBalances = async () => {
     const devMode = urlParams.get('dev') || localStorage.getItem('devAccountId');
-    let id = devMode ? DEV_ACCOUNT_ID : localStorage.getItem('accountId');
+    let id = ACCOUNT_ID_PARAM || (devMode ? DEV_ACCOUNT_ID : localStorage.getItem('accountId'));
     let acc;
-    if (id) {
+    if (ACCOUNT_ID_PARAM) {
+      acc = { accountId: ACCOUNT_ID_PARAM };
+    } else if (id) {
       acc = { accountId: id };
     } else {
       acc = await createAccount(telegramId);


### PR DESCRIPTION
## Summary
- add game and developer wallet links on games page
- allow Wallet page to show transactions for any account via `?account`
- document new `VITE_GAME_ACCOUNT_ID` environment variable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899b3b56ff08329b0e0e6128a8c9931