### PR TITLE
Fix non-telegram game win rewards

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -42,6 +42,18 @@ export default function Layout({ children }) {
     } catch {}
   }, [location]);
 
+  // Ensure the current path is saved if the page is reloaded or closed
+  useEffect(() => {
+    const savePath = () => {
+      try {
+        const current = window.location.pathname + window.location.search;
+        localStorage.setItem('lastPath', current);
+      } catch {}
+    };
+    window.addEventListener('beforeunload', savePath);
+    return () => window.removeEventListener('beforeunload', savePath);
+  }, []);
+
   useEffect(() => {
     beepRef.current = new Audio(chatBeep);
     beepRef.current.volume = getGameVolume();

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1248,11 +1248,29 @@ export default function SnakeAndLadder() {
       if (playerId === accountId) {
         const totalPlayers = isMultiplayer ? mpPlayers.length : ai + 1;
         const tgId = getTelegramId();
-        addTransaction(tgId, 0, 'win', {
-          game: 'snake',
-          players: totalPlayers,
-          accountId
-        });
+        if (token === 'TPC' && pot > 0) {
+          const total = pot * totalPlayers;
+          ensureAccountId()
+            .then(async (aid) => {
+              const winAmt = Math.round(total * 0.91);
+              await Promise.all([
+                depositAccount(aid, winAmt, { game: 'snake-win' }),
+                awardDevShare(total)
+              ]);
+              addTransaction(tgId, 0, 'win', {
+                game: 'snake',
+                players: totalPlayers,
+                accountId: aid
+              });
+            })
+            .catch(() => {});
+        } else {
+          addTransaction(tgId, 0, 'win', {
+            game: 'snake',
+            players: totalPlayers,
+            accountId
+          });
+        }
       }
     };
 

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -514,7 +514,11 @@ export function getAccountTransactions(accountId) {
 }
 
 export function depositAccount(accountId, amount, extra = {}) {
-  return post('/api/account/deposit', { accountId, amount, ...extra });
+  return post(
+    '/api/account/deposit',
+    { accountId, amount, ...extra },
+    API_AUTH_TOKEN || undefined
+  );
 }
 
 export function buyBundle(accountId, bundle) {


### PR DESCRIPTION
## Summary
- credit Snake and Ladder winners through account deposit with dev share
- authorize account deposits for non-Telegram sessions
- persist current path before reload to stay on same page

## Testing
- `npm test` *(fails: should receive error when table not full)*

------
https://chatgpt.com/codex/tasks/task_e_6899b88bced8832983137e23132c775c