### PR TITLE
Keep reloads on the current page

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -30,7 +30,12 @@ export default function Layout({ children }) {
     try {
       const saved = localStorage.getItem('lastPath');
       const current = location.pathname + location.search;
-      if (saved && saved !== current) navigate(saved, { replace: true });
+      if (
+        saved &&
+        saved !== current &&
+        window.history.length <= 1
+      )
+        navigate(saved, { replace: true });
     } catch {}
   }, []);
 


### PR DESCRIPTION
## Summary
- ensure last visited path is only restored on initial load when history is empty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c7d9b3f08329aff7ca01e52ede51