### PR TITLE
fix: credit browser winners via account

### DIFF
--- a/webapp/public/falling-ball-api.js
+++ b/webapp/public/falling-ball-api.js
@@ -32,8 +32,18 @@
     return data;
   }
   window.fbApi = {
-    depositAccount(accountId, amount, extra = {}) {
-      return post('/api/account/deposit', { accountId, amount, ...extra });
+    async depositAccount(accountId, amount, extra = {}) {
+      const res = await post('/api/account/deposit', { accountId, amount, ...extra });
+      if (res && res.error) {
+        return post('/api/profile/addTransaction', {
+          telegramId: null,
+          amount,
+          type: 'deposit',
+          accountId,
+          ...extra,
+        });
+      }
+      return res;
     },
     addTransaction(telegramId, amount, type, extra = {}) {
       return post('/api/profile/addTransaction', {

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -602,11 +602,21 @@ export default function CrazyDiceDuel() {
         try {
           const aid = await ensureAccountId();
           const winAmt = Math.round(total * 0.91);
-          await Promise.all([
-            depositAccount(aid, winAmt, { game: 'crazydice-win' }),
-            awardDevShare(total),
-          ]);
           const tgId = getTelegramId();
+          if (tgId) {
+            await Promise.all([
+              depositAccount(aid, winAmt, { game: 'crazydice-win' }),
+              awardDevShare(total),
+            ]);
+          } else {
+            await Promise.all([
+              addTransaction(null, winAmt, 'deposit', {
+                game: 'crazydice-win',
+                accountId: aid,
+              }),
+              awardDevShare(total),
+            ]);
+          }
           addTransaction(tgId, 0, 'win', {
             game: 'crazydice',
             players: playerCount,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1253,10 +1253,20 @@ export default function SnakeAndLadder() {
           ensureAccountId()
             .then(async (aid) => {
               const winAmt = Math.round(total * 0.91);
-              await Promise.all([
-                depositAccount(aid, winAmt, { game: 'snake-win' }),
-                awardDevShare(total)
-              ]);
+              if (tgId) {
+                await Promise.all([
+                  depositAccount(aid, winAmt, { game: 'snake-win' }),
+                  awardDevShare(total)
+                ]);
+              } else {
+                await Promise.all([
+                  addTransaction(null, winAmt, 'deposit', {
+                    game: 'snake-win',
+                    accountId: aid
+                  }),
+                  awardDevShare(total)
+                ]);
+              }
               addTransaction(tgId, 0, 'win', {
                 game: 'snake',
                 players: totalPlayers,


### PR DESCRIPTION
## Summary
- ensure TPC winnings for browser users credit the correct account
- fall back to addTransaction when deposit requires Telegram auth

## Testing
- `npm test` *(fails: should receive error when table not full)*

------
https://chatgpt.com/codex/tasks/task_e_6899c8e93a608329a7b9ee36feaa7b3b