### PR TITLE
Refactor Brick Breaker start flow and winner handling

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -1,335 +1,1010 @@
-<!DOCTYPE html>
-<html lang="sq">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"/>
-<title>Brick Breaker Royale — TonPlaygram (Local Test)</title>
-<style>
-  :root{ --bg:#0c1020; --panel:#11172a; --primary:#2563eb; --gold:#d4af37; --text:#e7eefc; --muted:#8fa1d2; --danger:#ff5a6b; --success:#34d399; }
-  *{box-sizing:border-box;font-family:Inter,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
-  html,body{height:100vh}
-  body{margin:0;background:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;color:var(--text);} 
-
-  .app{max-width:1100px;margin:0 auto;padding:16px;height:100vh;display:flex;flex-direction:column}
-  header{display:flex;gap:12px;align-items:center;justify-content:space-between;margin-bottom:12px}
-  .brand{display:flex;align-items:center;gap:10px}
-  .badge{background:linear-gradient(90deg,#1d2753,#11172a);padding:6px 10px;border-radius:10px;border:1px solid #1e2a56;color:var(--muted);font-size:12px}
-  h1{font-size:18px;margin:0}
-  .card{background:linear-gradient(180deg,#11172a 0%,#0e1428 100%);border:1px solid #1f2a58;border-radius:14px;padding:14px}
-  .settings{display:grid;grid-template-columns:repeat(4,1fr) auto;gap:10px;align-items:end}
-  label{font-size:12px;color:var(--muted);display:block;margin-bottom:6px}
-  input,select,button{width:100%;padding:10px 12px;border-radius:10px;border:1px solid #223063;background:#0e1430;color:var(--text);outline:none}
-  input:focus,select:focus{border-color:var(--primary)}
-  .btn{background:linear-gradient(180deg,#2a6cf0,#2156c8);border:none;cursor:pointer;font-weight:600}
-  .btn:disabled{opacity:.6;cursor:not-allowed}
-  .hud{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin:12px 0}
-  .hud .panel{border-radius:12px;border:1px solid #223063;background:#0b1228;padding:10px;display:flex;align-items:center;justify-content:space-between}
-  .panel strong{font-size:14px}
-  .timer{font-variant-numeric:tabular-nums;font-weight:700}
-
-  .game-layout{display:grid;grid-template-rows:25vh 1fr;gap:12px;min-height:0;flex:1}
-  .strip{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;min-height:0}
-  .mini{position:relative;border-radius:14px;border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);padding:10px;display:flex;flex-direction:column}
-  .mini h3{margin:0 0 6px 0;font-size:13px;color:var(--muted);display:flex;flex-direction:column;gap:6px;align-items:flex-start}
-  .mini .avatar{width:24px;height:24px;border-radius:50%;}
-  .mini canvas{width:100%;height:100%;border-radius:10px;background:linear-gradient(0deg,#0a1026,#0c1430);display:block}
-
-  .user-area{min-height:0;display:flex;flex-direction:column;gap:8px}
-  .user-board{position:relative;border-radius:14px;border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);padding:10px;display:flex;flex-direction:column;min-height:0;flex:1}
-  .user-board h3{margin:0 0 8px 0;font-size:13px;color:var(--muted);display:flex;align-items:center;gap:8px}
-  .user-board .avatar{width:32px;height:32px;border-radius:50%;}
-  canvas.main{width:100%;height:100%;display:block;border-radius:10px;background:linear-gradient(0deg,#0a1026,#0c1430);touch-action:none}
-
-  .pill{display:inline-flex;align-items:center;gap:6px;background:#0f1736;border:1px solid #223063;border-radius:999px;padding:4px 8px;font-size:12px}
-  .life{color:var(--danger)}
-  .score{color:var(--gold);font-weight:700}
-  .toast{position:fixed;left:50%;transform:translateX(-50%);bottom:18px;background:#0d1536;border:1px solid #223063;padding:8px 12px;border-radius:10px;font-size:13px;opacity:0;transition:opacity .25s}
-  .toast.show{opacity:1}
-  dialog{border:none;border-radius:16px;padding:0;background:#0d1330;color:var(--text);max-width:520px;width:calc(100% - 24px)}
-  .modal{padding:16px;border:1px solid #223063;border-radius:16px;background:linear-gradient(180deg,#0f1736,#0b1126)}
-  .modal h2{margin:6px 0 10px 0}
-  .grid{display:grid;gap:10px}
-  .grid.two{grid-template-columns:1fr 1fr}
-  .kpi{background:#0b1228;border:1px solid #223063;border-radius:12px;padding:10px;text-align:center}
-  .kpi .v{font-size:22px;font-weight:800}
-  .split{font-size:12px;color:var(--muted)}
-  .actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
-  .ghost{background:#0f1736;border:1px solid #223063}
-  .success{background:linear-gradient(180deg,#37d493,#1ea76e)}
-</style>
-</head>
-<body>
-<div class="app">
-  <header>
-    <div class="brand">
-      <h1>Brick Breaker Royale</h1>
-      <span class="badge">Local test • TPC only</span>
-    </div>
-  </header>
-
-  <div class="card settings">
-    <div>
-      <label>Numri i lojtarëve</label>
-      <select id="players">
-        <option value="2">2 lojtarë</option>
-        <option value="3">3 lojtarë</option>
-        <option value="4" selected>4 lojtarë</option>
-      </select>
-    </div>
-    <div>
-      <label>Stake për lojtar (TPC)</label>
-      <input id="stake" type="number" min="0" step="50" value="500">
-    </div>
-    <div>
-      <label>Densiteti i tullave</label>
-      <select id="density">
-        <option value="low">Low (easy)</option>
-        <option value="medium" selected>Medium</option>
-        <option value="high">High (hard)</option>
-      </select>
-    </div>
-    <div>
-      <label>Kohëzgjatja (min)</label>
-      <select id="duration">
-        <option value="1">1</option>
-        <option value="3">3</option>
-        <option value="5">5</option>
-      </select>
-    </div>
-    <div>
-      <button id="start" class="btn">Start Match</button>
-    </div>
-  </div>
-
-  <div class="hud">
-    <div class="panel"><strong>Koha</strong> <span class="timer" id="time">00:00</span></div>
-    <div class="panel"><strong>Pot (TPC)</strong> <span id="pot" class="score">0</span></div>
-  </div>
-
-  <div class="game-layout">
-    <div id="strip" class="strip"></div>
-    <div class="user-area">
-      <div class="user-board">
-        <h3><img class="avatar" id="userAvatar" alt="avatar"/> <span id="userLabel">USER</span> <span class="pill"><span class="life" id="userLives">♥♥♥</span> • <span class="score" id="userScore">0</span></span></h3>
-        <canvas id="userCanvas" class="main" width="360" height="560"></canvas>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div id="toast" class="toast"></div>
-
-<dialog id="results">
-  <div class="modal">
-    <h2>Rezultatet e raundit</h2>
-    <div class="grid two">
-      <div class="kpi"><div class="v" id="winner">-</div><div>Fituesi</div></div>
-      <div class="kpi"><div class="v" id="payout">0</div><div>Payout TPC</div></div>
-    </div>
-    <div class="grid" style="margin-top:10px">
-      <div class="kpi">
-        <div class="v" id="fee">0</div>
-        <div>Fee 10% • <span class="split">3% Burn • 3% Dev • 2% Eco • 1% LP • 1% Mkt</span></div>
-      </div>
-      <div class="kpi">
-        <div class="v" id="potFinal">0</div>
-        <div>Pot Final (pas fees)</div>
-      </div>
-    </div>
-    <div class="grid" id="scoreList" style="margin-top:10px"></div>
-    <div class="actions">
-      <button class="btn success" id="rematch">Rematch</button>
-      <button class="btn ghost" id="change">Ndrysho Stake / Settings</button>
-    </div>
-  </div>
-</dialog>
-
-<script src="/brick-breaker-api.js"></script>
-<script>
-if(!window.__BBR_INITED__){
-window.__BBR_INITED__ = true;
-(() => {
-  let GAME_DURATION_MS = 60000;
-  const CANVAS_W = 360, CANVAS_H = 560;
-  const COLORS = { bg:'#0a0f24', wall:'#223063', paddle:'#2563eb', ball:'#d4af37', brickA:'#5aa2ff', brickB:'#ff9d5a', brickC:'#ff5a6b', text:'#e7eefc', power:'#34d399', danger:'#ff5a6b' };
-  const POWERUPS = ['multiball','fireball','wide','slow','x2'];
-  const POINTS = { standard:10, tough:20, explosive:10 };
-
-  const state = {
-    match:null, timerId:null, endAt:0, running:false, last:performance.now(), userInputX:null
-  };
-
-  const $strip = document.getElementById('strip');
-  const $userCanvas = document.getElementById('userCanvas');
-  const $userScore = document.getElementById('userScore');
-  const $userLives = document.getElementById('userLives');
-  const $players = document.getElementById('players');
-  const $stake = document.getElementById('stake');
-  const $density = document.getElementById('density');
-  const $duration = document.getElementById('duration');
-  const $start = document.getElementById('start');
-  const $time = document.getElementById('time');
-  const $pot = document.getElementById('pot');
-  const $toast = document.getElementById('toast');
-  const $results = document.getElementById('results');
-  const $winner = document.getElementById('winner');
-  const $payout = document.getElementById('payout');
-  const $fee = document.getElementById('fee');
-  const $potFinal = document.getElementById('potFinal');
-  const $scoreList = document.getElementById('scoreList');
-  const $rematch = document.getElementById('rematch');
-  const $change = document.getElementById('change');
-
-  const showToast = (msg) => { $toast.textContent = msg; $toast.classList.add('show'); setTimeout(() => $toast.classList.remove('show'), 1700); };
-
-  const clamp=(v,mi,ma)=>Math.max(mi,Math.min(ma,v));
-  const rand = (a,b)=>Math.random()*(b-a)+a;
-  const choice = (arr)=>arr[(Math.random()*arr.length)|0];
-  const formatTime = (ms)=>{ const s=Math.max(0,Math.ceil(ms/1000)); const m=String((s/60)|0).padStart(2,'0'); const ss=String(s%60).padStart(2,'0'); return `${m}:${ss}`; };
-
-  const params = new URLSearchParams(location.search);
-  const names = params.get('names') ? params.get('names').split(',').map(decodeURIComponent) : [];
-  const avatars = params.get('avatars') ? params.get('avatars').split(',').map(decodeURIComponent) : [];
-  const accounts = params.get('accounts') ? params.get('accounts').split(',') : [];
-  const tgIds = params.get('tgIds') ? params.get('tgIds').split(',') : [];
-  const devAccountId = params.get('dev');
-  const initParam = params.get('init');
-  if (initParam && !window.Telegram) {
-    window.Telegram = { WebApp: { initData: decodeURIComponent(initParam) } };
-  }
-
-  function genBricks(density){
-    const cols = 10, rows = density==='high'?9:(density==='medium'?8:7);
-    const bricks = [];
-    for(let r=0;r<rows;r++){
-      for(let c=0;c<cols;c++){
-        const roll = Math.random();
-        let type='standard', hits=1, pts=POINTS.standard, col=COLORS.brickA;
-        if(roll>0.82){ type='explosive'; hits=1; pts=POINTS.explosive; col=COLORS.brickC; }
-        else if(roll>0.55){ type='tough'; hits=2; pts=POINTS.tough; col=COLORS.brickB; }
-        bricks.push({ x: c*(CANVAS_W/cols)+4, y: 80 + r*28, w: CANVAS_W/cols - 8, h: 20, type, hits, pts, color:col, alive:true });
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
+    <title>Brick Breaker Royale — TonPlaygram (Local Test)</title>
+    <style>
+      :root {
+        --bg: #0c1020;
+        --panel: #11172a;
+        --primary: #2563eb;
+        --gold: #d4af37;
+        --text: #e7eefc;
+        --muted: #8fa1d2;
+        --danger: #ff5a6b;
+        --success: #34d399;
       }
-    }
-    return bricks;
-  }
+      * {
+        box-sizing: border-box;
+        font-family:
+          Inter,
+          system-ui,
+          Segoe UI,
+          Roboto,
+          Helvetica,
+          Arial,
+          sans-serif;
+      }
+      html,
+      body {
+        height: 100vh;
+      }
+      body {
+        margin: 0;
+        background: radial-gradient(
+            1200px 800px at 70% -10%,
+            #1a2450 0%,
+            #0c1020 38%,
+            #0c1020 100%
+          )
+          fixed;
+        color: var(--text);
+      }
 
-  function createBoardState(index){
-    return { index, paddle:{ x:CANVAS_W/2-45, y:CANVAS_H-36, w:90, h:12 }, balls:[{ x:CANVAS_W/2, y:CANVAS_H-60, r:6, vx:2.2*(Math.random()<.5?-1:1), vy:-3.2, fire:false }], lives:3, score:0, mult:1, slow:false, bricks: genBricks($density.value), powerups:[], over:false };
-  }
+      .app {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 16px;
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      header {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 12px;
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .badge {
+        background: linear-gradient(90deg, #1d2753, #11172a);
+        padding: 6px 10px;
+        border-radius: 10px;
+        border: 1px solid #1e2a56;
+        color: var(--muted);
+        font-size: 12px;
+      }
+      h1 {
+        font-size: 18px;
+        margin: 0;
+      }
+      .card {
+        background: linear-gradient(180deg, #11172a 0%, #0e1428 100%);
+        border: 1px solid #1f2a58;
+        border-radius: 14px;
+        padding: 14px;
+      }
+      .settings {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr) auto;
+        gap: 10px;
+        align-items: end;
+      }
+      label {
+        font-size: 12px;
+        color: var(--muted);
+        display: block;
+        margin-bottom: 6px;
+      }
+      input,
+      select,
+      button {
+        width: 100%;
+        padding: 10px 12px;
+        border-radius: 10px;
+        border: 1px solid #223063;
+        background: #0e1430;
+        color: var(--text);
+        outline: none;
+      }
+      input:focus,
+      select:focus {
+        border-color: var(--primary);
+      }
+      .btn {
+        background: linear-gradient(180deg, #2a6cf0, #2156c8);
+        border: none;
+        cursor: pointer;
+        font-weight: 600;
+      }
+      .btn:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+      .hud {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 10px;
+        margin: 12px 0;
+      }
+      .hud .panel {
+        border-radius: 12px;
+        border: 1px solid #223063;
+        background: #0b1228;
+        padding: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+      .panel strong {
+        font-size: 14px;
+      }
+      .timer {
+        font-variant-numeric: tabular-nums;
+        font-weight: 700;
+      }
 
-  function addMiniSlot(label, avatar){
-    const wrap = document.createElement('div');
-    wrap.className='mini';
-    wrap.innerHTML = `<h3>${label}<img class="avatar" src="${avatar}" alt="avatar"/></h3>`;
-    const cv = document.createElement('canvas'); cv.width=CANVAS_W; cv.height=CANVAS_H; wrap.appendChild(cv); $strip.appendChild(wrap);
-    return cv.getContext('2d');
-  }
+      .game-layout {
+        display: grid;
+        grid-template-rows: 25vh 1fr;
+        gap: 12px;
+        min-height: 0;
+        flex: 1;
+      }
+      .strip {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 12px;
+        min-height: 0;
+      }
+      .mini {
+        position: relative;
+        border-radius: 14px;
+        border: 1px solid #223063;
+        background: linear-gradient(180deg, #0f1530, #0a0f24);
+        padding: 10px;
+        display: flex;
+        flex-direction: column;
+      }
+      .mini h3 {
+        margin: 0 0 6px 0;
+        font-size: 13px;
+        color: var(--muted);
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        align-items: flex-start;
+      }
+      .mini .avatar {
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+      }
+      .mini canvas {
+        width: 100%;
+        height: 100%;
+        border-radius: 10px;
+        background: linear-gradient(0deg, #0a1026, #0c1430);
+        display: block;
+      }
 
-  function drawBoard(ctx,b){
-    const W=CANVAS_W, H=CANVAS_H;
-    ctx.clearRect(0,0,W,H);
-    ctx.strokeStyle = COLORS.wall; ctx.lineWidth=2; ctx.strokeRect(8,60,W-16,H-90);
-    ctx.fillStyle = COLORS.text; ctx.font='12px system-ui'; ctx.fillText(`Score: ${b.score}`, 12, 50);
-    ctx.fillStyle = COLORS.danger; ctx.fillText('♥'.repeat(b.lives), W-40, 50);
-    for(const br of b.bricks){ if(!br.alive) continue; ctx.fillStyle=br.color; ctx.fillRect(br.x,br.y,br.w,br.h); }
-    for(const p of b.powerups){ ctx.fillStyle=COLORS.power; ctx.beginPath(); ctx.arc(p.x,p.y,7,0,Math.PI*2); ctx.fill(); ctx.fillStyle=COLORS.bg; ctx.font='10px system-ui'; ctx.textAlign='center'; const tag={multiball:'M',fireball:'F',wide:'W',slow:'S','x2':'2'}[p.kind]||'?'; ctx.fillText(tag,p.x,p.y+3); ctx.textAlign='start'; }
-    ctx.fillStyle = COLORS.paddle; ctx.fillRect(b.paddle.x,b.paddle.y,b.paddle.w,b.paddle.h);
-    for(const ball of b.balls){ ctx.fillStyle = ball.fire?COLORS.danger:COLORS.ball; ctx.beginPath(); ctx.arc(ball.x,ball.y,ball.r,0,Math.PI*2); ctx.fill(); }
-  }
+      .user-area {
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .user-board {
+        position: relative;
+        border-radius: 14px;
+        border: 1px solid #223063;
+        background: linear-gradient(180deg, #0f1530, #0a0f24);
+        padding: 10px;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        flex: 1;
+      }
+      .user-board h3 {
+        margin: 0 0 8px 0;
+        font-size: 13px;
+        color: var(--muted);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .user-board .avatar {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+      }
+      canvas.main {
+        width: 100%;
+        height: 100%;
+        display: block;
+        border-radius: 10px;
+        background: linear-gradient(0deg, #0a1026, #0c1430);
+        touch-action: none;
+      }
 
-  function applyPowerup(b, kind){
-    if(kind==='multiball'){
-      const base = b.balls[0] || {x:CANVAS_W/2,y:CANVAS_H-80,r:6,vx:2.1,vy:-3.0};
-      while(b.balls.length<3){ b.balls.push({x:base.x,y:base.y,r:6,vx:rand(-2.5,2.5),vy:-rand(2.5,3.8),fire:false}); }
-      setTimeout(()=>{ b.balls = [b.balls[0]]; }, 10000);
-    }
-    if(kind==='fireball'){ b.balls.forEach(ball=>ball.fire=true); setTimeout(()=> b.balls.forEach(ball=>ball.fire=false), 5000); }
-    if(kind==='wide'){ b.paddle.w=Math.min(150,b.paddle.w+40); setTimeout(()=> b.paddle.w=90, 10000); }
-    if(kind==='slow'){ b.slow=true; setTimeout(()=> b.slow=false, 5000); }
-    if(kind==='x2'){ b.mult=2; setTimeout(()=> b.mult=1, 5000); }
-  }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: #0f1736;
+        border: 1px solid #223063;
+        border-radius: 999px;
+        padding: 4px 8px;
+        font-size: 12px;
+      }
+      .life {
+        color: var(--danger);
+      }
+      .score {
+        color: var(--gold);
+        font-weight: 700;
+      }
+      .toast {
+        position: fixed;
+        left: 50%;
+        transform: translateX(-50%);
+        bottom: 18px;
+        background: #0d1536;
+        border: 1px solid #223063;
+        padding: 8px 12px;
+        border-radius: 10px;
+        font-size: 13px;
+        opacity: 0;
+        transition: opacity 0.25s;
+      }
+      .toast.show {
+        opacity: 1;
+      }
+      dialog {
+        border: none;
+        border-radius: 16px;
+        padding: 0;
+        background: #0d1330;
+        color: var(--text);
+        max-width: 520px;
+        width: calc(100% - 24px);
+      }
+      .modal {
+        padding: 16px;
+        border: 1px solid #223063;
+        border-radius: 16px;
+        background: linear-gradient(180deg, #0f1736, #0b1126);
+      }
+      .modal h2 {
+        margin: 6px 0 10px 0;
+      }
+      .grid {
+        display: grid;
+        gap: 10px;
+      }
+      .grid.two {
+        grid-template-columns: 1fr 1fr;
+      }
+      .kpi {
+        background: #0b1228;
+        border: 1px solid #223063;
+        border-radius: 12px;
+        padding: 10px;
+        text-align: center;
+      }
+      .kpi .v {
+        font-size: 22px;
+        font-weight: 800;
+      }
+      .split {
+        font-size: 12px;
+        color: var(--muted);
+      }
+      .actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 8px;
+      }
+      .ghost {
+        background: #0f1736;
+        border: 1px solid #223063;
+      }
+      .success {
+        background: linear-gradient(180deg, #37d493, #1ea76e);
+      }
+      .countdown {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 48px;
+        font-weight: 700;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 50;
+      }
+      .countdown.hidden {
+        display: none;
+      }
+      .winner-popup {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.7);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        z-index: 60;
+      }
+      .winner-popup.hidden {
+        display: none;
+      }
+      .winner-popup img {
+        width: 120px;
+        height: 120px;
+        border-radius: 50%;
+      }
+      .winner-popup .buttons {
+        display: flex;
+        gap: 12px;
+      }
+      .coin-confetti {
+        position: fixed;
+        top: -40px;
+        width: 32px;
+        height: 32px;
+        pointer-events: none;
+        animation: coin-fall var(--duration, 3s) linear forwards;
+        z-index: 70;
+      }
+      @keyframes coin-fall {
+        from {
+          transform: translateY(-10vh) rotate(0deg);
+          opacity: 1;
+        }
+        to {
+          transform: translateY(100vh) rotate(360deg);
+          opacity: 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <header>
+        <div class="brand">
+          <h1>Brick Breaker Royale</h1>
+          <span class="badge">Local test • TPC only</span>
+        </div>
+      </header>
 
-  function updateBoard(b, dt, inputX=null){
-    if(b.over) return;
-    if(inputX!=null){ const target = clamp(inputX - b.paddle.w/2, 12, CANVAS_W - b.paddle.w - 12); b.paddle.x = target; }
-    else { const t = Date.now()/700 + b.index; b.paddle.x = clamp((Math.sin(t)*0.5+0.5)*(CANVAS_W- b.paddle.w - 24) + 12, 12, CANVAS_W-b.paddle.w-12); }
+      <div class="hud">
+        <div class="panel">
+          <strong>Time</strong> <span class="timer" id="time">00:00</span>
+        </div>
+        <div class="panel">
+          <strong>Pot (TPC)</strong> <span id="pot" class="score">0</span>
+        </div>
+      </div>
 
-    for(const ball of [...b.balls]){
-      ball.x += ball.vx * (dt*0.06) * (b.slow?0.75:1);
-      ball.y += ball.vy * (dt*0.06) * (b.slow?0.75:1);
-      if(ball.x - ball.r < 10){ ball.x = 10+ball.r; ball.vx = Math.abs(ball.vx); }
-      if(ball.x + ball.r > CANVAS_W-10){ ball.x = CANVAS_W-10-ball.r; ball.vx = -Math.abs(ball.vx); }
-      if(ball.y - ball.r < 62){ ball.y = 62+ball.r; ball.vy = Math.abs(ball.vy); }
-      if(ball.y - ball.r > CANVAS_H-20){ b.balls = b.balls.filter(x=>x!==ball); if(b.balls.length===0){ b.lives--; if(inputX!=null) $userLives.textContent = '♥'.repeat(Math.max(0,b.lives)); if(b.lives<=0){ b.over=true; continue; } b.balls.push({x:CANVAS_W/2,y:CANVAS_H-60,r:6,vx:2.2*(Math.random()<.5?-1:1),vy:-3.2,fire:false}); } continue; }
-      const p=b.paddle; if(ball.y + ball.r >= p.y && ball.y - ball.r <= p.y + p.h && ball.x >= p.x && ball.x <= p.x + p.w && ball.vy>0){ ball.y = p.y - ball.r; const hit = ((ball.x - p.x)/p.w - 0.5)*2; const speedBoost = 3.1 + Math.min(2.0, Math.abs(hit)*1.6); ball.vx = hit * speedBoost; ball.vy = -Math.abs(speedBoost); }
-      for(const br of b.bricks){ if(!br.alive) continue; if(ball.x > br.x && ball.x < br.x+br.w && ball.y > br.y && ball.y < br.y+br.h){ b.score += br.pts * b.mult; if(inputX!=null) $userScore.textContent = b.score; if(br.type==='explosive'){ br.alive=false; for(const nb of b.bricks){ if(!nb.alive) continue; if(Math.hypot((nb.x+nb.w/2)-(br.x+br.w/2),(nb.y+nb.h/2)-(br.y+br.h/2))<48){ nb.alive=false; b.score += nb.pts * b.mult; if(inputX!=null) $userScore.textContent = b.score; } } if(!ball.fire) ball.vy *= -1; } else { br.hits--; if(br.hits<=0) br.alive=false; else br.color='#ffbb7d'; if(!ball.fire) ball.vy *= -1; } if(Math.random()<0.12){ b.powerups.push({x:ball.x,y:br.y+br.h,vy:1.6,kind:choice(POWERUPS)}); } break; } }
-    }
+      <div class="game-layout">
+        <div id="strip" class="strip"></div>
+        <div class="user-area">
+          <div class="user-board">
+            <h3>
+              <img class="avatar" id="userAvatar" alt="avatar" />
+              <span id="userLabel">USER</span>
+              <span class="pill"
+                ><span class="life" id="userLives">♥♥♥</span> •
+                <span class="score" id="userScore">0</span></span
+              >
+            </h3>
+            <canvas
+              id="userCanvas"
+              class="main"
+              width="360"
+              height="560"
+            ></canvas>
+          </div>
+        </div>
+      </div>
+    </div>
 
-    for(const pu of [...b.powerups]){ pu.y += pu.vy * (dt*0.06); const p=b.paddle; if(pu.y >= p.y-4 && pu.x>=p.x && pu.x<=p.x+p.w){ applyPowerup(b, pu.kind); b.powerups = b.powerups.filter(x=>x!==pu); if(inputX!=null) showToast(`USER: ${pu.kind.toUpperCase()}!`); } if(pu.y>CANVAS_H+10){ b.powerups = b.powerups.filter(x=>x!==pu); } }
-  }
+    <div id="toast" class="toast"></div>
 
-  function startMatch(){
-    const n = Math.max(2, Math.min(4, parseInt($players.value,10)||4));
-    const stake = Math.max(0, parseInt($stake.value||'0',10));
-    const duration = parseInt($duration.value,10)||1; GAME_DURATION_MS = duration*60000;
-    $pot.textContent = String(stake*n);
+    <div id="winnerPopup" class="winner-popup hidden">
+      <img id="winnerAvatar" alt="winner avatar" />
+      <div id="winnerName"></div>
+      <div class="buttons">
+        <button class="btn success" id="playAgain">Play Again</button>
+        <button class="btn ghost" id="lobbyBtn">Return Lobby</button>
+      </div>
+    </div>
+    <div id="countdown" class="countdown hidden"></div>
 
-    const states = []; for(let i=0;i<n;i++) states.push(createBoardState(i));
-    const players=[]; for(let i=0;i<n;i++){ players.push({ name:names[i]||`P${i+1}`, avatar:avatars[i]||'/assets/icons/9f14924f-e70c-4728-a9e5-ca25ef4138c8.png', accountId:accounts[i], telegramId:tgIds[i] }); }
-    document.getElementById('userLabel').textContent = players[n-1].name; document.getElementById('userAvatar').src = players[n-1].avatar;
-    $strip.innerHTML=''; const miniCtxs=[]; const oppCount=Math.min(3,n-1);
-    for(let i=0;i<oppCount;i++){ miniCtxs[i]=addMiniSlot(players[i].name, players[i].avatar); }
+    <script src="/flag-emojis.js"></script>
+    <script src="/brick-breaker-api.js"></script>
+    <script>
+      if (!window.__BBR_INITED__) {
+        window.__BBR_INITED__ = true;
+        (() => {
+          let GAME_DURATION_MS = 60000;
+          const CANVAS_W = 360,
+            CANVAS_H = 560;
+          const COLORS = {
+            bg: '#0a0f24',
+            wall: '#223063',
+            paddle: '#2563eb',
+            ball: '#d4af37',
+            brickA: '#5aa2ff',
+            brickB: '#ff9d5a',
+            brickC: '#ff5a6b',
+            text: '#e7eefc',
+            power: '#34d399',
+            danger: '#ff5a6b'
+          };
+          const POWERUPS = ['multiball', 'fireball', 'wide', 'slow', 'x2'];
+          const POINTS = { standard: 10, tough: 20, explosive: 10 };
 
-    state.match = { n, stakeTPC:stake, states, miniCtxs, userIdx:n-1, userCtx:$userCanvas.getContext('2d'), players };
+          const state = {
+            match: null,
+            timerId: null,
+            endAt: 0,
+            running: false,
+            last: performance.now(),
+            userInputX: null
+          };
 
-    const setUserX = (clientX)=>{ const r = $userCanvas.getBoundingClientRect(); state.userInputX = (clientX - r.left) / r.width * CANVAS_W; };
-    $userCanvas.onpointerdown = e=> setUserX(e.clientX);
-    $userCanvas.onpointermove = e=>{ if(e.buttons===1) setUserX(e.clientX); };
+          const $strip = document.getElementById('strip');
+          const $userCanvas = document.getElementById('userCanvas');
+          const $userScore = document.getElementById('userScore');
+          const $userLives = document.getElementById('userLives');
+          const $time = document.getElementById('time');
+          const $pot = document.getElementById('pot');
+          const $toast = document.getElementById('toast');
+          const $winnerPopup = document.getElementById('winnerPopup');
+          const $winnerAvatar = document.getElementById('winnerAvatar');
+          const $winnerName = document.getElementById('winnerName');
+          const $playAgain = document.getElementById('playAgain');
+          const $lobbyBtn = document.getElementById('lobbyBtn');
+          const $countdown = document.getElementById('countdown');
 
-    state.endAt = performance.now() + GAME_DURATION_MS;
-    state.running = true; state.last = performance.now();
-    loop(); if(state.timerId) cancelAnimationFrame(state.timerId); updateTimer();
-  }
+          const showToast = (msg) => {
+            $toast.textContent = msg;
+            $toast.classList.add('show');
+            setTimeout(() => $toast.classList.remove('show'), 1700);
+          };
 
-  function updateTimer(){
-    if(!state.running) return; const ms = state.endAt - performance.now(); $time.textContent = formatTime(ms); if(ms<=0){ endMatch(); return; } state.timerId = requestAnimationFrame(updateTimer);
-  }
+          const clamp = (v, mi, ma) => Math.max(mi, Math.min(ma, v));
+          const rand = (a, b) => Math.random() * (b - a) + a;
+          const choice = (arr) => arr[(Math.random() * arr.length) | 0];
+          const formatTime = (ms) => {
+            const s = Math.max(0, Math.ceil(ms / 1000));
+            const m = String((s / 60) | 0).padStart(2, '0');
+            const ss = String(s % 60).padStart(2, '0');
+            return `${m}:${ss}`;
+          };
+          const flagToDataUri = (flag) =>
+            `data:image/svg+xml,${encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='64' height='64'><text x='50%' y='50%' font-size='48' text-anchor='middle' dominant-baseline='central'>${flag}</text></svg>`)}`;
+          function coinConfetti(
+            count = 50,
+            iconSrc = '/assets/icons/file_000000005f0c61f48998df883554c3e8 (2).webp'
+          ) {
+            const container = document.createElement('div');
+            container.style.position = 'fixed';
+            container.style.top = '0';
+            container.style.left = '0';
+            container.style.width = '100%';
+            container.style.height = '0';
+            container.style.pointerEvents = 'none';
+            container.style.zIndex = '70';
+            container.style.overflow = 'visible';
+            document.body.appendChild(container);
+            for (let i = 0; i < count; i++) {
+              const img = document.createElement('img');
+              img.src = iconSrc;
+              img.alt = 'confetti icon';
+              img.className = 'coin-confetti';
+              const left = Math.random() * 100;
+              const delay = Math.random() * 0.2;
+              const duration = 2 + Math.random() * 2;
+              img.style.left = left + 'vw';
+              img.style.animationDelay = delay + 's';
+              img.style.setProperty('--duration', duration + 's');
+              container.appendChild(img);
+            }
+            setTimeout(() => container.remove(), 5000);
+          }
 
-  function loop(){
-    if(!state.running) return; const now = performance.now(); const dt = now - state.last; state.last = now;
-    const oppCount = Math.min(3, state.match.n-1);
-    for(let i=0;i<oppCount;i++){ const st = state.match.states[i]; updateBoard(st, dt, null); drawBoard(state.match.miniCtxs[i], st); }
-    const u = state.match.states[state.match.userIdx]; updateBoard(u, dt, state.userInputX); drawBoard(state.match.userCtx, u);
-    requestAnimationFrame(loop);
-  }
+          const params = new URLSearchParams(location.search);
+          const rawPlayers = parseInt(params.get('players'), 10);
+          const settings = {
+            players: Math.max(
+              2,
+              Math.min(4, isNaN(rawPlayers) ? 4 : rawPlayers)
+            ),
+            stake: Math.max(0, parseInt(params.get('amount') || '0', 10)),
+            density: params.get('density') || 'medium',
+            duration: parseInt(params.get('duration'), 10) || 1
+          };
+          const names = params.get('names')
+            ? params.get('names').split(',').map(decodeURIComponent)
+            : [];
+          const avatars = params.get('avatars')
+            ? params.get('avatars').split(',').map(decodeURIComponent)
+            : [];
+          const accounts = params.get('accounts')
+            ? params.get('accounts').split(',')
+            : [];
+          const tgIds = params.get('tgIds')
+            ? params.get('tgIds').split(',')
+            : [];
+          const userAvatar = params.get('avatar');
+          const userAccount = params.get('accountId');
+          const userTgId = params.get('tgId');
+          const devAccountId = params.get('dev');
+          const initParam = params.get('init');
+          if (initParam && !window.Telegram) {
+            window.Telegram = {
+              WebApp: { initData: decodeURIComponent(initParam) }
+            };
+          }
 
-  async function awardDevShare(total){
-    if(!devAccountId) return; try{ await bbApi.depositAccount(devAccountId, Math.round(total*0.1), {game:'brickbreaker-dev'}); }catch{}
-  }
+          function genBricks(density) {
+            const cols = 10,
+              rows = density === 'high' ? 9 : density === 'medium' ? 8 : 7;
+            const bricks = [];
+            for (let r = 0; r < rows; r++) {
+              for (let c = 0; c < cols; c++) {
+                const roll = Math.random();
+                let type = 'standard',
+                  hits = 1,
+                  pts = POINTS.standard,
+                  col = COLORS.brickA;
+                if (roll > 0.82) {
+                  type = 'explosive';
+                  hits = 1;
+                  pts = POINTS.explosive;
+                  col = COLORS.brickC;
+                } else if (roll > 0.55) {
+                  type = 'tough';
+                  hits = 2;
+                  pts = POINTS.tough;
+                  col = COLORS.brickB;
+                }
+                bricks.push({
+                  x: c * (CANVAS_W / cols) + 4,
+                  y: 80 + r * 28,
+                  w: CANVAS_W / cols - 8,
+                  h: 20,
+                  type,
+                  hits,
+                  pts,
+                  color: col,
+                  alive: true
+                });
+              }
+            }
+            return bricks;
+          }
 
-  function endMatch(){
-    state.running=false; const scores = state.match.states.map((s,i)=>({i,score:s.score,lives:s.lives})); const max=Math.max(...scores.map(s=>s.score)); const winners=scores.filter(s=>s.score===max);
-    const potGross = state.match.stakeTPC * state.match.n; const fee=Math.round(potGross*0.10); const potNet=potGross-fee; const payoutEach=winners.length?Math.floor(potNet/winners.length):0;
-    $winner.textContent = winners.length>1 ? `Barazim (${winners.map(w=>'P'+(w.i+1)).join(', ')})` : `P${winners[0].i+1}`;
-    $payout.textContent = String(payoutEach); $fee.textContent = String(fee); $potFinal.textContent = String(potNet);
-    $scoreList.innerHTML = scores.sort((a,b)=>b.score-a.score).map(s=>`<div class='kpi'><div class='v'>P${s.i+1}: ${s.score}</div><div>Jetë: ${'♥'.repeat(Math.max(0,s.lives))}</div></div>`).join('');
-    if(!$results.open) $results.showModal();
-    awardDevShare(potGross);
-    winners.forEach(w=>{
-      const info = state.match.players[w.i];
-      if(info && info.accountId && payoutEach>0){ bbApi.depositAccount(info.accountId, payoutEach, { game:'brickbreaker-win' }); if(info.telegramId) bbApi.addTransaction(info.telegramId, 0, 'win', { game:'brickbreaker', players: state.match.n, accountId: info.accountId }); }
-    });
-  }
+          function createBoardState(index) {
+            return {
+              index,
+              paddle: { x: CANVAS_W / 2 - 45, y: CANVAS_H - 36, w: 90, h: 12 },
+              balls: [
+                {
+                  x: CANVAS_W / 2,
+                  y: CANVAS_H - 60,
+                  r: 6,
+                  vx: 2.2 * (Math.random() < 0.5 ? -1 : 1),
+                  vy: -3.2,
+                  fire: false
+                }
+              ],
+              lives: 3,
+              score: 0,
+              mult: 1,
+              slow: false,
+              bricks: genBricks(settings.density),
+              powerups: [],
+              over: false
+            };
+          }
 
-  function updateStartLabel(){ const m=$duration.value; $start.textContent=`Start Match (${m}:00)`; }
-  updateStartLabel();
-  $duration.addEventListener('change', updateStartLabel);
+          function addMiniSlot(label, avatar) {
+            const wrap = document.createElement('div');
+            wrap.className = 'mini';
+            wrap.innerHTML = `<h3>${label}<img class="avatar" src="${avatar}" alt="avatar"/></h3>`;
+            const cv = document.createElement('canvas');
+            cv.width = CANVAS_W;
+            cv.height = CANVAS_H;
+            wrap.appendChild(cv);
+            $strip.appendChild(wrap);
+            return cv.getContext('2d');
+          }
 
-  $start.addEventListener('click', startMatch);
-  $rematch.addEventListener('click', ()=>{ $results.close(); startMatch(); });
-  $change.addEventListener('click', ()=>{ $results.close(); showToast('Ndrysho parametrat dhe shtyp Start.'); });
-})();
-}
-</script>
-</body>
+          function drawBoard(ctx, b) {
+            const W = CANVAS_W,
+              H = CANVAS_H;
+            ctx.clearRect(0, 0, W, H);
+            ctx.strokeStyle = COLORS.wall;
+            ctx.lineWidth = 2;
+            ctx.strokeRect(8, 60, W - 16, H - 90);
+            ctx.fillStyle = COLORS.text;
+            ctx.font = '12px system-ui';
+            ctx.fillText(`Score: ${b.score}`, 12, 50);
+            ctx.fillStyle = COLORS.danger;
+            ctx.fillText('♥'.repeat(b.lives), W - 40, 50);
+            for (const br of b.bricks) {
+              if (!br.alive) continue;
+              ctx.fillStyle = br.color;
+              ctx.fillRect(br.x, br.y, br.w, br.h);
+            }
+            for (const p of b.powerups) {
+              ctx.fillStyle = COLORS.power;
+              ctx.beginPath();
+              ctx.arc(p.x, p.y, 7, 0, Math.PI * 2);
+              ctx.fill();
+              ctx.fillStyle = COLORS.bg;
+              ctx.font = '10px system-ui';
+              ctx.textAlign = 'center';
+              const tag =
+                {
+                  multiball: 'M',
+                  fireball: 'F',
+                  wide: 'W',
+                  slow: 'S',
+                  x2: '2'
+                }[p.kind] || '?';
+              ctx.fillText(tag, p.x, p.y + 3);
+              ctx.textAlign = 'start';
+            }
+            ctx.fillStyle = COLORS.paddle;
+            ctx.fillRect(b.paddle.x, b.paddle.y, b.paddle.w, b.paddle.h);
+            for (const ball of b.balls) {
+              ctx.fillStyle = ball.fire ? COLORS.danger : COLORS.ball;
+              ctx.beginPath();
+              ctx.arc(ball.x, ball.y, ball.r, 0, Math.PI * 2);
+              ctx.fill();
+            }
+          }
+
+          function applyPowerup(b, kind) {
+            if (kind === 'multiball') {
+              const base = b.balls[0] || {
+                x: CANVAS_W / 2,
+                y: CANVAS_H - 80,
+                r: 6,
+                vx: 2.1,
+                vy: -3.0
+              };
+              while (b.balls.length < 3) {
+                b.balls.push({
+                  x: base.x,
+                  y: base.y,
+                  r: 6,
+                  vx: rand(-2.5, 2.5),
+                  vy: -rand(2.5, 3.8),
+                  fire: false
+                });
+              }
+              setTimeout(() => {
+                b.balls = [b.balls[0]];
+              }, 10000);
+            }
+            if (kind === 'fireball') {
+              b.balls.forEach((ball) => (ball.fire = true));
+              setTimeout(
+                () => b.balls.forEach((ball) => (ball.fire = false)),
+                5000
+              );
+            }
+            if (kind === 'wide') {
+              b.paddle.w = Math.min(150, b.paddle.w + 40);
+              setTimeout(() => (b.paddle.w = 90), 10000);
+            }
+            if (kind === 'slow') {
+              b.slow = true;
+              setTimeout(() => (b.slow = false), 5000);
+            }
+            if (kind === 'x2') {
+              b.mult = 2;
+              setTimeout(() => (b.mult = 1), 5000);
+            }
+          }
+
+          function updateBoard(b, dt, inputX = null) {
+            if (b.over) return;
+            if (inputX != null) {
+              const target = clamp(
+                inputX - b.paddle.w / 2,
+                12,
+                CANVAS_W - b.paddle.w - 12
+              );
+              b.paddle.x = target;
+            } else {
+              const t = Date.now() / 700 + b.index;
+              b.paddle.x = clamp(
+                (Math.sin(t) * 0.5 + 0.5) * (CANVAS_W - b.paddle.w - 24) + 12,
+                12,
+                CANVAS_W - b.paddle.w - 12
+              );
+            }
+
+            for (const ball of [...b.balls]) {
+              ball.x += ball.vx * (dt * 0.06) * (b.slow ? 0.75 : 1);
+              ball.y += ball.vy * (dt * 0.06) * (b.slow ? 0.75 : 1);
+              if (ball.x - ball.r < 10) {
+                ball.x = 10 + ball.r;
+                ball.vx = Math.abs(ball.vx);
+              }
+              if (ball.x + ball.r > CANVAS_W - 10) {
+                ball.x = CANVAS_W - 10 - ball.r;
+                ball.vx = -Math.abs(ball.vx);
+              }
+              if (ball.y - ball.r < 62) {
+                ball.y = 62 + ball.r;
+                ball.vy = Math.abs(ball.vy);
+              }
+              if (ball.y - ball.r > CANVAS_H - 20) {
+                b.balls = b.balls.filter((x) => x !== ball);
+                if (b.balls.length === 0) {
+                  b.lives--;
+                  if (inputX != null)
+                    $userLives.textContent = '♥'.repeat(Math.max(0, b.lives));
+                  if (b.lives <= 0) {
+                    b.over = true;
+                    continue;
+                  }
+                  b.balls.push({
+                    x: CANVAS_W / 2,
+                    y: CANVAS_H - 60,
+                    r: 6,
+                    vx: 2.2 * (Math.random() < 0.5 ? -1 : 1),
+                    vy: -3.2,
+                    fire: false
+                  });
+                }
+                continue;
+              }
+              const p = b.paddle;
+              if (
+                ball.y + ball.r >= p.y &&
+                ball.y - ball.r <= p.y + p.h &&
+                ball.x >= p.x &&
+                ball.x <= p.x + p.w &&
+                ball.vy > 0
+              ) {
+                ball.y = p.y - ball.r;
+                const hit = ((ball.x - p.x) / p.w - 0.5) * 2;
+                const speedBoost = 3.1 + Math.min(2.0, Math.abs(hit) * 1.6);
+                ball.vx = hit * speedBoost;
+                ball.vy = -Math.abs(speedBoost);
+              }
+              for (const br of b.bricks) {
+                if (!br.alive) continue;
+                if (
+                  ball.x > br.x &&
+                  ball.x < br.x + br.w &&
+                  ball.y > br.y &&
+                  ball.y < br.y + br.h
+                ) {
+                  b.score += br.pts * b.mult;
+                  if (inputX != null) $userScore.textContent = b.score;
+                  if (br.type === 'explosive') {
+                    br.alive = false;
+                    for (const nb of b.bricks) {
+                      if (!nb.alive) continue;
+                      if (
+                        Math.hypot(
+                          nb.x + nb.w / 2 - (br.x + br.w / 2),
+                          nb.y + nb.h / 2 - (br.y + br.h / 2)
+                        ) < 48
+                      ) {
+                        nb.alive = false;
+                        b.score += nb.pts * b.mult;
+                        if (inputX != null) $userScore.textContent = b.score;
+                      }
+                    }
+                    if (!ball.fire) ball.vy *= -1;
+                  } else {
+                    br.hits--;
+                    if (br.hits <= 0) br.alive = false;
+                    else br.color = '#ffbb7d';
+                    if (!ball.fire) ball.vy *= -1;
+                  }
+                  if (Math.random() < 0.12) {
+                    b.powerups.push({
+                      x: ball.x,
+                      y: br.y + br.h,
+                      vy: 1.6,
+                      kind: choice(POWERUPS)
+                    });
+                  }
+                  break;
+                }
+              }
+            }
+
+            for (const pu of [...b.powerups]) {
+              pu.y += pu.vy * (dt * 0.06);
+              const p = b.paddle;
+              if (pu.y >= p.y - 4 && pu.x >= p.x && pu.x <= p.x + p.w) {
+                applyPowerup(b, pu.kind);
+                b.powerups = b.powerups.filter((x) => x !== pu);
+                if (inputX != null)
+                  showToast(`USER: ${pu.kind.toUpperCase()}!`);
+              }
+              if (pu.y > CANVAS_H + 10) {
+                b.powerups = b.powerups.filter((x) => x !== pu);
+              }
+            }
+          }
+
+          function startMatch() {
+            const n = settings.players;
+            const stake = settings.stake;
+            GAME_DURATION_MS = settings.duration * 60000;
+            $pot.textContent = String(stake * n);
+
+            const states = [];
+            for (let i = 0; i < n; i++) states.push(createBoardState(i));
+            const players = [];
+            for (let i = 0; i < n; i++) {
+              let avatar = i === n - 1 ? userAvatar || avatars[i] : avatars[i];
+              if (!avatar) {
+                const flag = choice(FLAG_EMOJIS);
+                avatar = flagToDataUri(flag);
+              }
+              players.push({
+                name: names[i] || `P${i + 1}`,
+                avatar,
+                accountId: i === n - 1 ? userAccount : accounts[i],
+                telegramId: i === n - 1 ? userTgId : tgIds[i]
+              });
+            }
+            document.getElementById('userLabel').textContent =
+              players[n - 1].name;
+            document.getElementById('userAvatar').src = players[n - 1].avatar;
+            $strip.innerHTML = '';
+            const miniCtxs = [];
+            const oppCount = Math.min(3, n - 1);
+            for (let i = 0; i < oppCount; i++) {
+              miniCtxs[i] = addMiniSlot(players[i].name, players[i].avatar);
+            }
+
+            state.match = {
+              n,
+              stakeTPC: stake,
+              states,
+              miniCtxs,
+              userIdx: n - 1,
+              userCtx: $userCanvas.getContext('2d'),
+              players
+            };
+
+            const setUserX = (clientX) => {
+              const r = $userCanvas.getBoundingClientRect();
+              state.userInputX = ((clientX - r.left) / r.width) * CANVAS_W;
+            };
+            $userCanvas.onpointerdown = (e) => setUserX(e.clientX);
+            $userCanvas.onpointermove = (e) => {
+              if (e.buttons === 1) setUserX(e.clientX);
+            };
+
+            state.endAt = performance.now() + GAME_DURATION_MS;
+            state.running = true;
+            state.last = performance.now();
+            loop();
+            if (state.timerId) cancelAnimationFrame(state.timerId);
+            updateTimer();
+          }
+
+          function updateTimer() {
+            if (!state.running) return;
+            const ms = state.endAt - performance.now();
+            $time.textContent = formatTime(ms);
+            if (ms <= 0) {
+              endMatch();
+              return;
+            }
+            state.timerId = requestAnimationFrame(updateTimer);
+          }
+
+          function loop() {
+            if (!state.running) return;
+            const now = performance.now();
+            const dt = now - state.last;
+            state.last = now;
+            const oppCount = Math.min(3, state.match.n - 1);
+            for (let i = 0; i < oppCount; i++) {
+              const st = state.match.states[i];
+              updateBoard(st, dt, null);
+              drawBoard(state.match.miniCtxs[i], st);
+            }
+            const u = state.match.states[state.match.userIdx];
+            updateBoard(u, dt, state.userInputX);
+            drawBoard(state.match.userCtx, u);
+            requestAnimationFrame(loop);
+          }
+
+          function countdownAndStart() {
+            let c = 3;
+            $countdown.textContent = c;
+            $countdown.classList.remove('hidden');
+            const timer = setInterval(() => {
+              c--;
+              if (c > 0) {
+                $countdown.textContent = c;
+              } else {
+                clearInterval(timer);
+                $countdown.classList.add('hidden');
+                startMatch();
+              }
+            }, 1000);
+          }
+
+          async function awardDevShare(total) {
+            if (!devAccountId) return;
+            try {
+              await bbApi.depositAccount(
+                devAccountId,
+                Math.round(total * 0.1),
+                { game: 'brickbreaker-dev' }
+              );
+            } catch {}
+          }
+
+          function endMatch() {
+            state.running = false;
+            const scores = state.match.states.map((s, i) => ({
+              i,
+              score: s.score,
+              lives: s.lives
+            }));
+            const max = Math.max(...scores.map((s) => s.score));
+            const winners = scores.filter((s) => s.score === max);
+            const potGross = state.match.stakeTPC * state.match.n;
+            const fee = Math.round(potGross * 0.1);
+            const potNet = potGross - fee;
+            const payoutEach = winners.length
+              ? Math.floor(potNet / winners.length)
+              : 0;
+            awardDevShare(potGross);
+            winners.forEach((w) => {
+              const info = state.match.players[w.i];
+              if (info && info.accountId && payoutEach > 0) {
+                bbApi.depositAccount(info.accountId, payoutEach, {
+                  game: 'brickbreaker-win'
+                });
+                if (info.telegramId)
+                  bbApi.addTransaction(info.telegramId, 0, 'win', {
+                    game: 'brickbreaker',
+                    players: state.match.n,
+                    accountId: info.accountId
+                  });
+              }
+            });
+            const winInfo = state.match.players[winners[0].i];
+            $winnerAvatar.src = winInfo.avatar;
+            $winnerName.textContent = `${winInfo.name} wins ${payoutEach} TPC`;
+            $winnerPopup.classList.remove('hidden');
+            coinConfetti(50);
+          }
+
+          $playAgain.addEventListener('click', () => {
+            $winnerPopup.classList.add('hidden');
+            countdownAndStart();
+          });
+          $lobbyBtn.addEventListener('click', () => {
+            location.href = '/games/brickbreaker/lobby';
+          });
+
+          countdownAndStart();
+        })();
+      }
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove in-game settings from Brick Breaker and start matches after a 3-2-1 countdown
- Use players' avatars and flag-based placeholders for AI opponents
- Show winner celebration with avatar, confetti, and lobby/play-again actions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899de0c85b08329ad706d3b7d965a8a