### PR TITLE
Move Brick Breaker title to bottom

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -58,7 +58,7 @@
         gap: 12px;
         align-items: center;
         justify-content: space-between;
-        margin-bottom: 12px;
+        margin: 12px 0;
       }
       .brand {
         display: flex;
@@ -365,12 +365,6 @@
   </head>
   <body>
     <div class="app">
-      <header>
-        <div class="brand">
-          <h1>Brick Breaker Royale</h1>
-        </div>
-      </header>
-
       <div class="hud">
         <div class="panel">
           <strong>Time</strong> <span class="timer" id="time">00:00</span>
@@ -401,6 +395,11 @@
           </div>
         </div>
       </div>
+      <header>
+        <div class="brand">
+          <h1>Brick Breaker Royale</h1>
+        </div>
+      </header>
     </div>
 
     <div id="toast" class="toast"></div>


### PR DESCRIPTION
## Summary
- Relocate Brick Breaker Royale heading to bottom of game layout for balanced layout
- Apply symmetric vertical margins to header

## Testing
- `npm test` *(fails: joinRoom clears lobby seat; joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_6899f06d5a608329a923f146158b0320