### PR TITLE
Add Bubble Pop Royale game

### DIFF
--- a/webapp/public/assets/icons/bubble_pop.svg
+++ b/webapp/public/assets/icons/bubble_pop.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#0e1430"/>
+  <circle cx="20" cy="20" r="12" fill="#5aa2ff"/>
+  <circle cx="44" cy="24" r="10" fill="#ff5a6b"/>
+  <circle cx="24" cy="44" r="8" fill="#34d399"/>
+</svg>

--- a/webapp/public/bubble-pop-royale.html
+++ b/webapp/public/bubble-pop-royale.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+<title>Bubble Pop Royale — Power Edition</title>
+<style>
+  :root{ --bg:#0c1020; --panel:#11172a; --primary:#2563eb; --gold:#d4af37; --text:#e7eefc; --muted:#8fa1d2; --danger:#ff5a6b; }
+  *{box-sizing:border-box;font-family:Inter,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+  html,body{height:100vh}
+  body{margin:0;background:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;color:var(--text);overflow:hidden}
+  .app{height:100vh;display:flex;flex-direction:column;padding:12px;gap:10px;max-width:1100px;margin:0 auto}
+  header{display:flex;gap:12px;align-items:center;justify-content:space-between}
+  .badge{background:#0f1736;border:1px solid #223063;border-radius:10px;padding:6px 10px;color:var(--muted);font-size:12px}
+  .controls{display:grid;grid-template-columns:1fr 1fr 1fr auto;gap:8px}
+  label{font-size:12px;color:var(--muted);display:block;margin-bottom:6px}
+  select,button,input{width:100%;padding:10px 12px;border-radius:10px;border:1px solid #223063;background:#0e1430;color:#e7eefc}
+  .btn{background:linear-gradient(180deg,#2a6cf0,#2156c8);border:none;font-weight:700;cursor:pointer}
+  .hud{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+  .panel{border:1px solid #223063;background:#0b1228;border-radius:12px;padding:10px;display:flex;align-items:center;justify-content:space-between}
+  .score{color:var(--gold);font-weight:800}
+  .timer{font-variant-numeric:tabular-nums;font-weight:800}
+  .layout{display:grid;grid-template-rows:25vh 1fr;gap:10px;flex:1;min-height:0}
+  .top{display:grid;grid-template-columns:repeat(3,1fr);gap:10px}
+  .mini{position:relative;border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:12px;padding:8px;display:flex;flex-direction:column}
+  .mini h3{margin:0 0 6px 0;font-size:12px;color:var(--muted)}
+  .mini canvas{flex:1;width:100%;height:100%;background:#0e1430;border-radius:8px}
+  .userWrap{position:relative;border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:14px;padding:10px;display:flex;flex-direction:column;min-height:0}
+  .userWrap h3{margin:0 0 8px 0;font-size:13px;color:var(--muted);display:flex;align-items:center;gap:8px}
+  #user{flex:1;width:100%;height:100%;background:#0e1430;border-radius:10px;touch-action:none}
+  .overlayButtons{position:absolute;right:10px;bottom:10px;display:flex;gap:8px}
+  .small{padding:8px 10px;border-radius:10px;border:1px solid #223063;background:#15204a;color:#e7eefc;font-size:12px;cursor:pointer}
+  .avatar{width:32px;height:32px;border-radius:50%;margin-bottom:6px}
+  .toast{position:fixed;left:50%;transform:translateX(-50%);bottom:16px;background:#0d1536;border:1px solid #223063;border-radius:10px;padding:8px 12px;font-size:13px;opacity:0;transition:opacity .2s}
+  .toast.show{opacity:1}
+  dialog{border:none;border-radius:16px;background:#0d1330;color:#e7eefc;max-width:520px;width:calc(100% - 24px)}
+  .modal{padding:16px;border:1px solid #223063;border-radius:16px;background:linear-gradient(180deg,#0f1736,#0b1126)}
+  .grid{display:grid;gap:10px}
+  .grid.two{grid-template-columns:1fr 1fr}
+  .kpi{background:#0b1228;border:1px solid #223063;border-radius:12px;padding:10px;text-align:center}
+  .kpi .v{font-size:22px;font-weight:800}
+</style>
+</head>
+<body>
+<div class="app">
+  <header>
+    <div style="display:flex;align-items:center;gap:10px">
+      <h1 style="margin:0;font-size:18px">Bubble Pop Royale</h1>
+      <span class="badge">Local test • TPC only</span>
+    </div>
+  </header>
+  <div class="controls">
+    <div>
+      <label>Players</label>
+      <select id="players">
+        <option value="2">2 players</option>
+        <option value="3">3 players</option>
+        <option value="4" selected>4 players</option>
+      </select>
+    </div>
+    <div>
+      <label>Duration</label>
+      <select id="duration">
+        <option value="60">1 min</option>
+        <option value="180" selected>3 min</option>
+        <option value="300">5 min</option>
+      </select>
+    </div>
+    <div>
+      <label>Stake per player (TPC)</label>
+      <input id="stake" type="number" value="300" min="0" step="50"/>
+    </div>
+    <div>
+      <button id="start" class="btn">Start Match</button>
+    </div>
+  </div>
+  <div class="hud">
+    <div class="panel"><strong>Time</strong><span id="time" class="timer">03:00</span></div>
+    <div class="panel"><strong>Pot (TPC)</strong><span id="pot" class="score">0</span></div>
+    <div class="panel"><strong>Your score</strong><span id="myscore" class="score">0</span></div>
+  </div>
+  <div class="layout">
+    <div class="top">
+      <div class="mini"><h3>P1</h3><img id="avatar1" src="assets/icons/profile.svg" alt="" class="avatar"/><canvas id="opp1"></canvas></div>
+      <div class="mini"><h3>P2</h3><img id="avatar2" src="assets/icons/profile.svg" alt="" class="avatar"/><canvas id="opp2"></canvas></div>
+      <div class="mini"><h3>P3</h3><img id="avatar3" src="assets/icons/profile.svg" alt="" class="avatar"/><canvas id="opp3"></canvas></div>
+    </div>
+    <div class="userWrap">
+      <h3>USER</h3>
+      <img id="avatarUser" src="assets/icons/profile.svg" alt="" class="avatar"/>
+      <canvas id="user"></canvas>
+      <div class="overlayButtons">
+        <button id="swapBtn" class="small">Swap</button>
+        <button id="soundBtn" class="small">🔊</button>
+      </div>
+    </div>
+  </div>
+</div>
+<div id="toast" class="toast"></div>
+<dialog id="results">
+  <div class="modal">
+    <h2>Round results</h2>
+    <div class="grid two">
+      <div class="kpi"><div class="v" id="winner">-</div><div>Winner</div></div>
+      <div class="kpi"><div class="v" id="payout">0</div><div>Payout TPC</div></div>
+    </div>
+    <div class="grid" style="margin-top:10px">
+      <div class="kpi"><div class="v" id="fee">0</div><div>Fee 10%</div></div>
+      <div class="kpi"><div class="v" id="potFinal">0</div><div>Final Pot</div></div>
+    </div>
+    <div class="grid" id="scoreList" style="margin-top:10px"></div>
+    <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:8px">
+      <button class="btn" id="rematch">Rematch</button>
+      <button class="btn" id="change">Change settings</button>
+    </div>
+  </div>
+</dialog>
+<script src="/falling-ball-api.js"></script>
+<script>
+if(!window.__BUBBLE_ROYALE_POWER__){
+window.__BUBBLE_ROYALE_POWER__ = true;
+(function(){
+  const params = new URLSearchParams(location.search);
+  let n = Math.max(2, Math.min(4, parseInt(params.get('players'),10)||4));
+  let stake = Math.max(0, parseInt(params.get('amount'),10)||300);
+  let durSec = Math.max(10, parseInt(params.get('duration'),10)||180);
+  const avatarParam = params.get('avatar') || '';
+  const tgId = params.get('tgId');
+  const accountId = params.get('accountId');
+  const devAccount = params.get('dev');
+  const devAccount1 = params.get('dev1');
+  const devAccount2 = params.get('dev2');
+  const initParam = params.get('init');
+  if (initParam && !window.Telegram) {
+    window.Telegram = { WebApp: { initData: decodeURIComponent(initParam) } };
+  }
+  async function awardDevShare(total){
+    const ops=[];
+    if(devAccount1||devAccount2){
+      if(devAccount) ops.push(fbApi.depositAccount(devAccount, Math.round(total*0.09), {game:'bubblepop-dev'}));
+      if(devAccount1) ops.push(fbApi.depositAccount(devAccount1, Math.round(total*0.01), {game:'bubblepop-dev1'}));
+      if(devAccount2) ops.push(fbApi.depositAccount(devAccount2, Math.round(total*0.02), {game:'bubblepop-dev2'}));
+    }else if(devAccount){
+      ops.push(fbApi.depositAccount(devAccount, Math.round(total*0.1), {game:'bubblepop-dev'}));
+    }
+    if(ops.length){ try{ await Promise.all(ops); }catch{} }
+  }
+  const GRID_COLS = 12, GRID_ROWS = 18;
+  const COLORS = ['#5aa2ff','#ff9d5a','#ff5a6b','#d4af37','#34d399','#a78bfa'];
+  const POP_SCORE = 10;
+  const LAUNCH_SPEED = 540;
+  const BOUNCE_DAMP = 1;
+  const SPECIALS = ['H','V','B'];
+  const SPECIAL_RATE_SEED = 0.06;
+  const SPECIAL_RATE_NEXT = 0.10;
+  const S = (function(){
+    let ctx=null, enabled=true;
+    function ensure(){ if(!ctx){ ctx = new (window.AudioContext||window.webkitAudioContext)(); } if(ctx.state==='suspended') ctx.resume(); }
+    function tone(freq=440, time=0.08, type='sine', gain=0.02){ if(!enabled) return; ensure(); const o = ctx.createOscillator(); const g = ctx.createGain(); o.type=type; o.frequency.value=freq; g.gain.value=gain; o.connect(g); g.connect(ctx.destination); const now = ctx.currentTime; g.gain.setValueAtTime(gain, now); g.gain.exponentialRampToValueAtTime(0.0001, now+time); o.start(now); o.stop(now+time); }
+    function chord(freqs, t=0.12, type='sine', baseGain=0.02){ if(!enabled) return; ensure(); const now=ctx.currentTime; freqs.forEach((f,i)=>{ const o=ctx.createOscillator(), g=ctx.createGain(); o.type=type; o.frequency.value=f; g.gain.value=baseGain/(i+1); o.connect(g); g.connect(ctx.destination); g.gain.setValueAtTime(g.gain.value, now); g.gain.exponentialRampToValueAtTime(0.0001, now+t); o.start(now); o.stop(now+t); }); }
+    return { enable(v){ enabled = v; if(v) ensure(); }, launch(){ tone(520,0.09,'triangle',0.03); }, bounce(){ tone(280,0.03,'square',0.02); }, pop(){ chord([880,660],0.07,'sine',0.03); }, clear(){ chord([330,440,660],0.12,'triangle',0.03); }, swap(){ tone(740,0.05,'sine',0.025); }, over(){ chord([220,196,174],0.35,'sawtooth',0.03); } };
+  })();
+  const $ = s => document.querySelector(s);
+  const toast = $('#toast');
+  const showToast = (m)=>{ toast.textContent=m; toast.classList.add('show'); setTimeout(()=>toast.classList.remove('show'),1200); };
+  const clamp=(v,mi,ma)=>Math.max(mi,Math.min(ma,v));
+  const fmt = (s)=>{ const m = String((s/60)|0).padStart(2,'0'); const ss = String(Math.max(0, s%60)).padStart(2,'0'); return `${m}:${ss}`; };
+  const randColor = ()=> COLORS[(Math.random()*COLORS.length)|0];
+  const chance = (p)=> Math.random()<p;
+  function fitCanvas(c){ const r=c.getBoundingClientRect(); c.width=r.width; c.height=r.height; }
+  function createBubbleGame(canvas){
+    const ctx = canvas.getContext('2d');
+    fitCanvas(canvas);
+    const game = {
+      cell: { w: 0, h: 0, r: 0 },
+      grid: Array.from({length:GRID_ROWS},()=>Array(GRID_COLS).fill(null)),
+      cur: { x:0, y:0, vx:0, vy:0, bubble: null, active:false },
+      nextBubble: null,
+      score: 0,
+      over:false,
+      aimAngle: -Math.PI/4,
+      isUser:false
+    };
+    function bubble(color, special=null){ return {color, special}; }
+    function recomputeCell(){ game.cell.w = canvas.width / GRID_COLS; game.cell.h = game.cell.w; game.cell.r = game.cell.w*0.48; }
+    function seedRows(rows=4){ for(let y=0;y<rows;y++){ for(let x=0;x<GRID_COLS;x++){ if(Math.random() < 0.75){ const col = randColor(); const sp = chance(SPECIAL_RATE_SEED) ? SPECIALS[(Math.random()*SPECIALS.length)|0] : null; game.grid[y][x] = bubble(col, sp); } } } }
+    function worldToCell(x,y){ return { cx: Math.round(x / game.cell.w - 0.5), cy: Math.round(y / game.cell.h - 0.5) }; }
+    function cellToWorld(cx,cy){ return { x: (cx+0.5)*game.cell.w, y: (cy+0.5)*game.cell.h }; }
+    function validCell(cx,cy){ return cx>=0 && cx<GRID_COLS && cy>=0 && cy<GRID_ROWS; }
+    function neighbors(cx,cy){ const n = []; const dirs = [[1,0],[-1,0],[0,1],[0,-1],[1,1],[-1,-1]]; for(const [dx,dy] of dirs){ const nx=cx+dx, ny=cy+dy; if(validCell(nx,ny)) n.push([nx,ny]); } return n; }
+    function collidesAny(x,y){ if(y - game.cell.r <= 0) return { hit:true, cell:{cx: Math.round(x/game.cell.w-0.5), cy:0 }}; for(let cy=0; cy<GRID_ROWS; cy++){ for(let cx=0; cx<GRID_COLS; cx++){ const obj = game.grid[cy][cx]; if(!obj) continue; const w = cellToWorld(cx,cy); const d2 = (w.x - x)*(w.x - x) + (w.y - y)*(w.y - y); if(d2 <= (game.cell.r*2 - 2)*(game.cell.r*2 - 2)){ return { hit:true, cell:{cx,cy} }; } } } return { hit:false }; }
+    function placeIntoGrid(x,y,bub){ let { cx, cy } = worldToCell(x,y); cx = clamp(cx, 0, GRID_COLS-1); cy = clamp(cy, 0, GRID_ROWS-1); const ring = [[0,0],[1,0],[-1,0],[0,1],[0,-1],[1,1],[-1,-1],[1,-1],[-1,1]]; for(const [dx,dy] of ring){ const nx=cx+dx, ny=cy+dy; if(validCell(nx,ny) && !game.grid[ny][nx]){ game.grid[ny][nx]=bub; return {cx:nx,cy:ny}; } } if(!game.grid[cy][cx]){ game.grid[cy][cx]=bub; return {cx,cy}; } for(let yy=0;yy<GRID_ROWS;yy++){ if(!game.grid[yy][cx]){ game.grid[yy][cx]=bub; return {cx,cy:yy}; } } game.over = true; return {cx,cy}; }
+    function floodSame(startCx,startCy,color){ const seen = new Set(); const q = [[startCx,startCy]]; const cluster = []; while(q.length){ const [cx,cy] = q.shift(); const key = cx+','+cy; if(seen.has(key)) continue; seen.add(key); if(!validCell(cx,cy)) continue; const cell = game.grid[cy][cx]; if(!cell || cell.color !== color || cell.special) continue; cluster.push([cx,cy]); for(const [nx,ny] of neighbors(cx,cy)) q.push([nx,ny]); } return cluster; }
+    function removeFloating(){ const seen = new Set(); const stack = []; for(let x=0;x<GRID_COLS;x++){ if(game.grid[0][x]) stack.push([x,0]); } while(stack.length){ const [cx,cy] = stack.pop(); const k=cx+','+cy; if(seen.has(k)) continue; seen.add(k); for(const [nx,ny] of neighbors(cx,cy)){ if(validCell(nx,ny) && game.grid[ny][nx]) stack.push([nx,ny]); } } let removed = 0; for(let y=0;y<GRID_ROWS;y++){ for(let x=0;x<GRID_COLS;x++){ if(game.grid[y][x] && !seen.has(x+','+y)){ game.grid[y][x]=null; removed++; } } } return removed; }
+    function triggerSpecial(cx,cy,kind){ let removed = 0; if(kind==='H'){ for(let x=0;x<GRID_COLS;x++){ if(game.grid[cy][x]){ game.grid[cy][x]=null; removed++; } } S.clear(); } else if(kind==='V'){ for(let y=0;y<GRID_ROWS;y++){ if(game.grid[y][cx]){ game.grid[y][cx]=null; removed++; } } S.clear(); } else if(kind==='B'){ for(let y=cy-1;y<=cy+1;y++){ for(let x=cx-1;x<=cx+1;x++){ if(validCell(x,y) && game.grid[y][x]){ game.grid[y][x]=null; removed++; } } } S.clear(); } game.score += removed * POP_SCORE; return removed; }
+    function launchToward(targetX, targetY){ if(game.cur.active || game.over) return; const ox = canvas.width/2, oy = canvas.height - game.cell.r - 6; let ang = Math.atan2(targetY - oy, targetX - ox); const minA = (-85 * Math.PI/180), maxA = (-5 * Math.PI/180); ang = clamp(ang, minA, maxA); game.cur.x = ox; game.cur.y = oy; game.cur.vx = Math.cos(ang)*LAUNCH_SPEED; game.cur.vy = Math.sin(ang)*LAUNCH_SPEED; if(!game.cur.bubble) game.cur.bubble = game.nextBubble || bubble(randColor(), chance(SPECIAL_RATE_NEXT)?SPECIALS[(Math.random()*3)|0]:null); game.cur.active = true; S.launch(); }
+    function swapBubble(){ const next = game.nextBubble || bubble(randColor(), chance(SPECIAL_RATE_NEXT)?SPECIALS[(Math.random()*3)|0]:null); const curColor = game.cur.bubble ? game.cur.bubble.color : randColor(); const curSpecial = game.cur.bubble ? game.cur.bubble.special : null; game.nextBubble = { color: curColor, special: curSpecial }; game.cur.bubble = bubble(next.color, next.special); S.swap(); showToast('Swapped'); }
+    function step(dt){ if(game.over) return; if(game.cur.active){ game.cur.x += game.cur.vx * dt; game.cur.y += game.cur.vy * dt; const r = game.cell.r; if(game.cur.x - r < 0){ game.cur.x = r; game.cur.vx = Math.abs(game.cur.vx)*BOUNCE_DAMP; S.bounce(); } if(game.cur.x + r > canvas.width){ game.cur.x = canvas.width - r; game.cur.vx = -Math.abs(game.cur.vx)*BOUNCE_DAMP; S.bounce(); } const col = collidesAny(game.cur.x, game.cur.y); if(col.hit || game.cur.y - r <= 0){ const bub = game.cur.bubble || bubble(randColor(), null); const spot = placeIntoGrid(game.cur.x, game.cur.y, bub); if(bub.special){ const cleared = triggerSpecial(spot.cx, spot.cy, bub.special); const floating = removeFloating(); if(cleared+floating>0) S.pop(); } else { const cluster = floodSame(spot.cx, spot.cy, bub.color); if(cluster.length >= 3){ for(const [cx,cy] of cluster) game.grid[cy][cx] = null; game.score += cluster.length * POP_SCORE; const floating = removeFloating(); game.score += floating * POP_SCORE; S.pop(); } } game.cur.active = false; game.cur.bubble = null; game.nextBubble = bubble(randColor(), chance(SPECIAL_RATE_NEXT)?SPECIALS[(Math.random()*3)|0]:null); for(let x=0;x<GRID_COLS;x++){ if(game.grid[GRID_ROWS-1][x]){ game.over = true; S.over(); break; } } } } }
+    function draw(){ ctx.clearRect(0,0,canvas.width,canvas.height); for(let y=0;y<GRID_ROWS;y++){ for(let x=0;x<GRID_COLS;x++){ const cell = game.grid[y][x]; if(!cell) continue; const w = cellToWorld(x,y); ctx.fillStyle = cell.color; ctx.beginPath(); ctx.arc(w.x, w.y, game.cell.r, 0, Math.PI*2); ctx.fill(); if(cell.special){ ctx.fillStyle = '#0b1228'; ctx.font = `bold ${Math.floor(game.cell.r*1.0)}px system-ui`; ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillText(cell.special, w.x, w.y+1); } } } if(game.cur.active || game.cur.bubble){ const y = game.cur.active ? game.cur.y : (canvas.height - game.cell.r - 6); const x = game.cur.active ? game.cur.x : (canvas.width/2); const b = game.cur.bubble || {color:COLORS[0], special:null}; ctx.fillStyle = b.color; ctx.beginPath(); ctx.arc(x, y, game.cell.r, 0, Math.PI*2); ctx.fill(); if(b.special){ ctx.fillStyle = '#0b1228'; ctx.font = `bold ${Math.floor(game.cell.r*1.0)}px system-ui`; ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillText(b.special, x, y+1); } } if(game.nextBubble){ ctx.fillStyle = game.nextBubble.color; ctx.beginPath(); ctx.arc(canvas.width - 24, canvas.height - 24, Math.min(12, game.cell.r*0.6), 0, Math.PI*2); ctx.fill(); if(game.nextBubble.special){ ctx.fillStyle = '#0b1228'; ctx.font = 'bold 10px system-ui'; ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillText(game.nextBubble.special, canvas.width - 24, canvas.height - 24); } } if(game.isUser && game.over){ ctx.fillStyle = 'rgba(0,0,0,0.45)'; ctx.fillRect(0,0,canvas.width,canvas.height); ctx.fillStyle = '#e7eefc'; ctx.font='bold 16px system-ui'; ctx.fillText('Board filled!', 14, 28); } }
+    game.resize = function(){ fitCanvas(canvas); recomputeCell(); };
+    game.tick = function(dt){ step(dt); draw(); };
+    game.start = function(){ recomputeCell(); seedRows(4); game.cur.bubble = bubble(randColor(), chance(SPECIAL_RATE_NEXT)?SPECIALS[(Math.random()*3)|0]:null); game.nextBubble = bubble(randColor(), chance(SPECIAL_RATE_NEXT)?SPECIALS[(Math.random()*3)|0]:null); };
+    function bindUserInput(){ const swapBtn = document.getElementById('swapBtn'); const soundBtn = document.getElementById('soundBtn'); let soundOn = true; const unlock = ()=>{ S.enable(true); canvas.removeEventListener('pointerdown', unlock); }; canvas.addEventListener('pointerdown', unlock, {once:true}); canvas.addEventListener('pointerup', (e)=>{ if(!game.isUser || game.over) return; const r = canvas.getBoundingClientRect(); const x = e.clientX - r.left, y = e.clientY - r.top; launchToward(x,y); }); swapBtn.onclick = ()=>{ if(!game.cur.active) swapBubble(); }; soundBtn.onclick = ()=>{ soundOn = !soundOn; S.enable(soundOn); soundBtn.textContent = soundOn ? '🔊' : '🔇'; }; }
+    game.bindUserInput = bindUserInput;
+    return game;
+  }
+  function botStep(bot, dt){ if(bot.over) return; if(!bot.cur.active){ const canvas = bot.__canvas; const targetX = (Math.random()*canvas.width*0.9) + canvas.width*0.05; const targetY = (Math.random()*canvas.height*0.4) + canvas.height*0.1; const ox = canvas.width/2, oy = canvas.height - bot.cell.r - 6; let ang = Math.atan2(targetY - oy, targetX - ox); const minA = (-85 * Math.PI/180), maxA = (-5 * Math.PI/180); ang = clamp(ang, minA, maxA); bot.cur.x = ox; bot.cur.y = oy; bot.cur.vx = Math.cos(ang)*LAUNCH_SPEED; bot.cur.vy = Math.sin(ang)*LAUNCH_SPEED; if(!bot.cur.bubble) bot.cur.bubble = { color: COLORS[(Math.random()*COLORS.length)|0], special: Math.random()<0.05? ['H','V','B'][(Math.random()*3)|0] : null }; bot.cur.active = true; } }
+  const canvases = { user: $('#user'), opp1: $('#opp1'), opp2: $('#opp2'), opp3: $('#opp3') };
+  const ui = { time: $('#time'), pot: $('#pot'), myscore: $('#myscore'), duration: $('#duration'), players: $('#players'), stake: $('#stake'), start: $('#start'), results: $('#results'), winner: $('#winner'), payout: $('#payout'), fee: $('#fee'), potFinal: $('#potFinal'), scoreList: $('#scoreList'), rematch: $('#rematch'), change: $('#change') };
+  ui.players.value = n;
+  ui.duration.value = durSec;
+  ui.stake.value = stake;
+  document.querySelector('.controls').style.display='none';
+  document.querySelector('header').style.display='none';
+  const avatarUser = document.getElementById('avatarUser');
+  if(avatarParam) avatarUser.src = avatarParam;
+  let games = [];
+  let last = performance.now();
+  let endAt = 0; let running = false; let rafId = null;
+  function layoutCanvases(){ Object.values(canvases).forEach(c=>{ if(!c) return; fitCanvas(c); }); }
+  function startMatch(){ layoutCanvases(); ui.pot.textContent = String(stake * n); ui.time.textContent = fmt(durSec); games = []; const oppSlots = [canvases.opp1, canvases.opp2, canvases.opp3]; for(let i=0;i<n-1;i++){ const g = createBubbleGame(oppSlots[i]); g.__canvas = oppSlots[i]; g.isUser = false; g.start(); games.push(g); } const userGame = createBubbleGame(canvases.user); userGame.__canvas = canvases.user; userGame.isUser = true; userGame.start(); userGame.bindUserInput(); games.push(userGame); endAt = performance.now() + durSec*1000; running = true; last = performance.now(); loop(); }
+  function updateTimer(){ const remain = Math.max(0, Math.ceil((endAt - performance.now())/1000)); ui.time.textContent = fmt(remain); if(remain<=0){ finish(); } }
+  function loop(){ if(!running) return; const now = performance.now(); const dt = (now - last)/1000; last = now; for(let i=0;i<games.length;i++){ const g = games[i]; if(!g.isUser) botStep(g, dt); g.tick(dt); } ui.myscore.textContent = String(games[games.length-1].score); updateTimer(); rafId = requestAnimationFrame(loop); }
+  async function finish(){ if(!running) return; running=false; if(rafId) cancelAnimationFrame(rafId); const gross = stake * n; const fee = Math.round(gross*0.10); const net = gross - fee; const scores = games.map((g,i)=>({i,score:g.score})); const max = Math.max(...scores.map(s=>s.score)); const winners = scores.filter(s=>s.score===max); const payout = winners.length? Math.floor(net / winners.length) : 0; ui.winner.textContent = winners.length>1 ? `Tie (${winners.map(w=>'P'+(w.i+1)).join(', ')})` : `P${winners[0].i+1}`; ui.payout.textContent = String(payout); ui.fee.textContent = String(fee); ui.potFinal.textContent = String(net); ui.scoreList.innerHTML = scores.sort((a,b)=>b.score-a.score).map(s=>`<div class="kpi"><div class="v">P${s.i+1}: ${s.score}</div><div>—</div></div>`).join(''); if(winners.some(w=>w.i===n-1) && accountId){ try{ await fbApi.depositAccount(accountId, payout, {game:'bubblepop-win'}); if(tgId) await fbApi.addTransaction(tgId, 0, 'win', {game:'bubblepop', players:n, accountId}); }catch{} } await awardDevShare(gross); if(!ui.results.open) ui.results.showModal(); }
+  ui.rematch.addEventListener('click', ()=>{ ui.results.close(); startMatch(); });
+  ui.change.addEventListener('click', ()=>{ ui.results.close(); location.href='/games/bubblepoproyale/lobby'; });
+  window.addEventListener('resize', layoutCanvases);
+  layoutCanvases();
+  startMatch();
+})();
+}
+</script>
+</body>
+</html>

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -31,6 +31,8 @@ import BrickBreaker from './pages/Games/BrickBreaker.jsx';
 import BrickBreakerLobby from './pages/Games/BrickBreakerLobby.jsx';
 import TetrisRoyale from './pages/Games/TetrisRoyale.jsx';
 import TetrisRoyaleLobby from './pages/Games/TetrisRoyaleLobby.jsx';
+import BubblePopRoyale from './pages/Games/BubblePopRoyale.jsx';
+import BubblePopRoyaleLobby from './pages/Games/BubblePopRoyaleLobby.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -65,6 +67,8 @@ export default function App() {
             <Route path="/games/brickbreaker" element={<BrickBreaker />} />
             <Route path="/games/tetrisroyale/lobby" element={<TetrisRoyaleLobby />} />
             <Route path="/games/tetrisroyale" element={<TetrisRoyale />} />
+            <Route path="/games/bubblepoproyale/lobby" element={<BubblePopRoyaleLobby />} />
+            <Route path="/games/bubblepoproyale" element={<BubblePopRoyale />} />
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />
             <Route path="/tasks" element={<Tasks />} />

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -41,6 +41,13 @@ export default function HomeGamesCard() {
               className="w-24 h-24"
             />
           </Link>
+          <Link to="/games/bubblepoproyale/lobby" className="flex-shrink-0">
+            <img
+              src="/assets/icons/bubble_pop.svg"
+              alt="Bubble Pop Royale"
+              className="w-24 h-24"
+            />
+          </Link>
         </div>
       <Link
         to="/games"

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -61,6 +61,16 @@ export default function Games() {
               </Link>
             </div>
             <div className="flex flex-col items-center space-y-1">
+              <img src="/assets/icons/bubble_pop.svg" alt="" className="h-24 w-24" />
+              <h3 className="text-lg font-bold">Bubble Pop Royale</h3>
+              <Link
+                to="/games/bubblepoproyale/lobby"
+                className="inline-block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow"
+              >
+                Open
+              </Link>
+            </div>
+            <div className="flex flex-col items-center space-y-1">
               <img src="/assets/icons/tetris.svg" alt="" className="h-24 w-24" />
               <h3 className="text-lg font-bold">Tetris Royale</h3>
               <Link

--- a/webapp/src/pages/Games/BubblePopRoyale.jsx
+++ b/webapp/src/pages/Games/BubblePopRoyale.jsx
@@ -1,0 +1,14 @@
+import { useLocation } from 'react-router-dom';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+
+export default function BubblePopRoyale() {
+  useTelegramBackButton();
+  const { search } = useLocation();
+  return (
+    <iframe
+      src={`/bubble-pop-royale.html${search}`}
+      title="Bubble Pop Royale"
+      className="w-full h-screen border-0"
+    />
+  );
+}

--- a/webapp/src/pages/Games/BubblePopRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/BubblePopRoyaleLobby.jsx
@@ -1,0 +1,125 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { ensureAccountId, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+
+const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
+const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
+const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
+
+export default function BubblePopRoyaleLobby() {
+  const navigate = useNavigate();
+  useTelegramBackButton();
+
+  const [players, setPlayers] = useState(2);
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [mode, setMode] = useState('local');
+  const [duration, setDuration] = useState(1);
+  const [avatar, setAvatar] = useState('');
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  const startGame = async () => {
+    let tgId;
+    let accountId;
+    try {
+      accountId = await ensureAccountId();
+      const balRes = await getAccountBalance(accountId);
+      if ((balRes.balance || 0) < stake.amount) {
+        alert('Insufficient balance');
+        return;
+      }
+      tgId = getTelegramId();
+      await addTransaction(tgId, -stake.amount, 'stake', {
+        game: 'bubblepop',
+        players,
+        accountId,
+      });
+    } catch {}
+
+    const params = new URLSearchParams();
+    params.set('players', players);
+    params.set('mode', mode);
+    params.set('duration', duration * 60);
+    const initData = window.Telegram?.WebApp?.initData;
+    if (stake.token) params.set('token', stake.token);
+    if (stake.amount) params.set('amount', stake.amount);
+    if (avatar) params.set('avatar', avatar);
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    if (DEV_ACCOUNT) params.set('dev', DEV_ACCOUNT);
+    if (DEV_ACCOUNT_1) params.set('dev1', DEV_ACCOUNT_1);
+    if (DEV_ACCOUNT_2) params.set('dev2', DEV_ACCOUNT_2);
+    if (initData) params.set('init', encodeURIComponent(initData));
+    navigate(`/games/bubblepoproyale?${params.toString()}`);
+  };
+
+  return (
+    <div className="relative p-4 space-y-4 text-text">
+      <h2 className="text-xl font-bold text-center">Bubble Pop Royale Lobby</h2>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Players</h3>
+        <div className="flex gap-2 flex-wrap">
+          {[2,3,4].map((n) => (
+            <button
+              key={n}
+              onClick={() => setPlayers(n)}
+              className={`lobby-tile ${players === n ? 'lobby-selected' : ''}`}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Stake</h3>
+        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Mode</h3>
+        <div className="flex gap-2">
+          {[
+            { id: 'local', label: 'Local (AI)' },
+            { id: 'online', label: 'Online' }
+          ].map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setMode(id)}
+              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Duration (minutes)</h3>
+        <div className="flex gap-2">
+          {[1,3,5].map((m) => (
+            <button
+              key={m}
+              onClick={() => setDuration(m)}
+              className={`lobby-tile ${duration === m ? 'lobby-selected' : ''}`}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+      </div>
+      <button
+        onClick={startGame}
+        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
+      >
+        START
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Bubble Pop Royale lobby and game routes
- expose Bubble Pop Royale from home and games listings
- bundle Bubble Pop Royale HTML and assets with payout logic

## Testing
- `npm test` *(fails: should receive error when table not full)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689a121004108329b68cfae4aad4fc9a