### PR TITLE
fix: ensure Bubble Pop Royale fits viewport

### DIFF
--- a/webapp/public/bubble-pop-royale.html
+++ b/webapp/public/bubble-pop-royale.html
@@ -7,9 +7,9 @@
 <style>
   :root{ --bg:#0c1020; --panel:#11172a; --primary:#2563eb; --gold:#d4af37; --text:#e7eefc; --muted:#8fa1d2; --danger:#ff5a6b; }
   *{box-sizing:border-box;font-family:Inter,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
-  html,body{height:100vh}
+  html,body{height:100dvh}
   body{margin:0;background:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;color:var(--text);overflow:hidden}
-  .app{height:100vh;display:flex;flex-direction:column;padding:12px;gap:10px;max-width:1100px;margin:0 auto}
+  .app{height:100dvh;display:flex;flex-direction:column;padding:12px;gap:10px;max-width:1100px;margin:0 auto}
   header{display:flex;gap:12px;align-items:center;justify-content:space-between}
   .badge{background:#0f1736;border:1px solid #223063;border-radius:10px;padding:6px 10px;color:var(--muted);font-size:12px}
   .controls{display:grid;grid-template-columns:1fr 1fr 1fr auto;gap:8px}

--- a/webapp/src/pages/Games/BubblePopRoyale.jsx
+++ b/webapp/src/pages/Games/BubblePopRoyale.jsx
@@ -8,7 +8,7 @@ export default function BubblePopRoyale() {
     <iframe
       src={`/bubble-pop-royale.html${search}`}
       title="Bubble Pop Royale"
-      className="w-full h-screen border-0"
+      className="w-full h-[100dvh] border-0"
     />
   );
 }


### PR DESCRIPTION
## Summary
- make Bubble Pop Royale iframe use dynamic viewport height
- update Bubble Pop Royale standalone HTML to fill dynamic viewport

## Testing
- `npm test` (fails: should receive error when table not full)
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_689a1fbc4abc8329afd4b440fb34b563