### PR TITLE
Add variety to Falling Ball obstacles

### DIFF
--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -147,6 +147,7 @@
     fric:0.003,
     time:0,
     maxVy:22,
+    stuckCounter:0,
   };
   const DEFAULT_AVATAR='/assets/icons/9f14924f-e70c-4728-a9e5-ca25ef4138c8.png';
 
@@ -267,18 +268,38 @@
   }
 
   function addStars(){
-    const maxStars = Math.floor(Math.random()*3) + 4; // 4-6 stars
-    const count = Math.min(maxStars, state.obstacles.length);
-    const spins = [0.05, -0.05, 0.04, -0.04, 0.06, -0.06];
+    const starCount = Math.min(Math.floor(Math.random()*4)+5, state.obstacles.length); // 5-8 stars
     const indices = [...Array(state.obstacles.length).keys()];
-    for(let i=0;i<count;i++){
+    const colorPairs=[
+      ['#fff9c4','#facc15'],
+      ['#bfdbfe','#3b82f6'],
+      ['#fecdd3','#f43f5e'],
+      ['#ddd6fe','#8b5cf6'],
+      ['#bbf7d0','#16a34a'],
+      ['#fde68a','#f59e0b'],
+      ['#fbcfe8','#ec4899'],
+      ['#bae6fd','#0ea5e9'],
+    ];
+    for(let i=0;i<starCount;i++){
       const idx = indices.splice(Math.floor(Math.random()*indices.length),1)[0];
       const base = state.obstacles[idx];
-      state.obstacles[idx] = { ...base, type:'star', r: state.ball.r*1.8, drawR: state.ball.r*2.2, angle: Math.random()*Math.PI*2, spin: spins[i] };
+      const sizeMult = randomBetween(1.1,2);
+      const drawMult = randomBetween(1.1,1.5);
+      const spin = (Math.random()*0.05+0.03)*(Math.random()<0.5?-1:1);
+      const colors = colorPairs[Math.floor(Math.random()*colorPairs.length)];
+      state.obstacles[idx] = {
+        ...base,
+        type:'star',
+        r: state.ball.r*sizeMult,
+        drawR: state.ball.r*sizeMult*drawMult,
+        angle: Math.random()*Math.PI*2,
+        spin,
+        colors,
+      };
     }
   }
 
-  function resetBall(){ state.ball.x=W*0.5; state.ball.y=60; state.ball.vx=(Math.random()*2-1)*1.8; state.ball.vy=0; state.resultSlot=null; }
+  function resetBall(){ state.ball.x=W*0.5; state.ball.y=60; state.ball.vx=(Math.random()*2-1)*1.8; state.ball.vy=0; state.resultSlot=null; state.stuckCounter=0; }
 
   function startMatch(){
     refreshSlots();
@@ -308,6 +329,7 @@
   function step(dt){
     if(!state.started || state.resultSlot!==null) return;
     const b=state.ball;
+    const groundY = H - 120;
     b.vy = Math.min(state.maxVy, b.vy + state.gravity);
     b.vx *= (1 - state.fric);
     b.x += b.vx; b.y += b.vy;
@@ -325,8 +347,19 @@
       }
     }
 
+    // shake if stuck
+    if (Math.abs(b.vx)+Math.abs(b.vy) < 0.1 && b.y + b.r < groundY - 5){
+      state.stuckCounter++;
+      if(state.stuckCounter > 60){
+        b.vx += (Math.random()*2-1)*2;
+        b.vy -= Math.random()*2;
+        state.stuckCounter=0;
+      }
+    }else{
+      state.stuckCounter=0;
+    }
+
     // ground / slots
-    const groundY = H - 160;
     if (b.y + b.r >= groundY){
       b.y = groundY - b.r; b.vy *= -state.bounce;
       if (Math.abs(b.vy) < 1.1){
@@ -377,8 +410,10 @@
         ctx.translate(o.x, o.y);
         ctx.rotate(o.angle);
         const grad = ctx.createRadialGradient(0,0,2,0,0,(o.drawR||o.r));
-        grad.addColorStop(0,'#fff9c4');
-        grad.addColorStop(1,'#facc15');
+        const c1 = o.colors ? o.colors[0] : '#fff9c4';
+        const c2 = o.colors ? o.colors[1] : '#facc15';
+        grad.addColorStop(0, c1);
+        grad.addColorStop(1, c2);
         ctx.fillStyle = grad;
         ctx.beginPath();
         const r=(o.drawR||o.r), inner=r*0.35;
@@ -400,7 +435,7 @@
       }
     }
   }
-  function drawSlotsGuide(){ const pad=30; const usable=W-2*pad; const w = usable / state.players; const top = H-160; const bottom=H-120; for(let i=0;i<state.players;i++){ const x1=pad+i*w; ctx.fillStyle='rgba(0,0,0,0.25)'; ctx.fillRect(x1, top, w-2, bottom-top); if (state.resultSlot===i){ ctx.fillStyle='rgba(250,204,21,0.4)'; ctx.fillRect(x1, top, w-2, bottom-top); ctx.strokeStyle='rgba(250,204,21,0.9)'; ctx.lineWidth=3; ctx.strokeRect(x1+1, top, w-4, bottom-top); } } }
+  function drawSlotsGuide(){ const pad=30; const usable=W-2*pad; const w = usable / state.players; const bottom = H-120; const top = bottom-40; for(let i=0;i<state.players;i++){ const x1=pad+i*w; ctx.fillStyle='rgba(0,0,0,0.25)'; ctx.fillRect(x1, top, w-2, bottom-top); if (state.resultSlot===i){ ctx.fillStyle='rgba(250,204,21,0.4)'; ctx.fillRect(x1, top, w-2, bottom-top); ctx.strokeStyle='rgba(250,204,21,0.9)'; ctx.lineWidth=3; ctx.strokeRect(x1+1, top, w-4, bottom-top); } } }
   function drawBall(){ const b=state.ball; ctx.fillStyle='rgba(0,0,0,0.28)'; ctx.beginPath(); ctx.ellipse(b.x, b.y+b.r+6, b.r*1.2, b.r*0.5, 0,0,Math.PI*2); ctx.fill(); const grad = ctx.createRadialGradient(b.x-6,b.y-6,4, b.x,b.y,b.r+6); grad.addColorStop(0,'#fef08a'); grad.addColorStop(0.55,'#facc15'); grad.addColorStop(1,'#ca8a04'); ctx.fillStyle=grad; ctx.beginPath(); ctx.arc(b.x,b.y,b.r,0,Math.PI*2); ctx.fill(); ctx.globalAlpha=0.15; ctx.fillStyle='#fefce8'; ctx.beginPath(); ctx.ellipse(b.x-5,b.y-8,b.r*0.7,b.r*0.35,-0.2,0,Math.PI*2); ctx.fill(); ctx.globalAlpha=1; }
 
   function frame(ts){ const dt = Math.min(33, ts - state.time); state.time=ts; step(dt/16.6667); ctx.clearRect(0,0,W,H); drawBackground(); drawObstacles(); drawSlotsGuide(); drawBall(); requestAnimationFrame(frame); }


### PR DESCRIPTION
## Summary
- Randomize star obstacles (5-8) with varied colors, sizes and spin speeds
- Shake board when ball is stuck and align finish line with avatar slots

## Testing
- `npm test` *(fails: joinRoom waits until table full)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a25a62ce883298fb96bdbb1482d84