### PR TITLE
Tweak Air Hockey goal size and paddle speed

### DIFF
--- a/webapp/public/air-hockey.html
+++ b/webapp/public/air-hockey.html
@@ -224,7 +224,7 @@
     rink.x = Math.round(W*0.06); rink.w = Math.round(W*0.88);
     rink.y = Math.round(H*0.04); rink.h = Math.round(H*0.92);
     centerX = W/2; centerY = H/2;
-    goalWidth = Math.round(W*0.42);
+    goalWidth = Math.round(W*0.36);
     const base = Math.max(24, Math.round(Math.min(W,H)*0.035));
     paddleRadius = base*3.4;
     puck.r = Math.max(20, Math.round(base*1.0));
@@ -420,7 +420,7 @@
       }
     });
     if (best){
-      const ease = 0.45;
+      const ease = 1;
       const tx = best.x, ty = best.y;
       const nx = p.x + (tx - p.x) * ease;
       let ny = p.y + (ty - p.y) * ease;


### PR DESCRIPTION
## Summary
- make goals narrower in Air Hockey
- match paddle speed to finger for responsive control

## Testing
- `npm test` *(fails: joinRoom waits until table full)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a1bf30fb88329b6c64839fb3ff6fd