### PR TITLE
Align user info with HUD in Tetris Royale

### DIFF
--- a/webapp/public/tetris-royale.html
+++ b/webapp/public/tetris-royale.html
@@ -16,7 +16,7 @@
   label{font-size:12px;color:var(--muted);display:block;margin-bottom:6px}
   select,button,input{width:100%;padding:10px 12px;border-radius:10px;border:1px solid #223063;background:#0e1430;color:#e7eefc}
   .btn{background:linear-gradient(180deg,#2a6cf0,#2156c8);border:none;font-weight:700;cursor:pointer}
-  .hud{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+  .hud{display:flex;gap:8px}
   .panel{border:1px solid #223063;background:#0b1228;border-radius:12px;padding:10px;display:flex;align-items:center;justify-content:space-between}
   .score{color:var(--gold);font-weight:800}
   .timer{font-variant-numeric:tabular-nums;font-weight:800}
@@ -25,10 +25,14 @@
   .mini{position:relative;border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:12px;padding:8px;display:flex;flex-direction:column;align-items:center}
   .mini h3{margin:0 0 6px 0;font-size:12px;color:var(--muted)}
   .mini canvas{flex:1;width:100%;height:100%;background:#0e1430;border-radius:8px;image-rendering:pixelated}
-  .userWrap{position:relative;border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:14px;padding:10px;display:flex;flex-direction:column;min-height:0;align-items:center}
-  .userWrap h3{margin:0 0 8px 0;font-size:13px;color:var(--muted);display:flex;align-items:center;gap:8px}
+  .userWrap{position:relative;border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:14px;padding:10px;display:flex;flex-direction:column;min-height:0}
+  .userBar{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:8px}
+  .userInfo{display:flex;align-items:center;gap:8px}
+  .userWrap h3{margin:0;font-size:13px;color:var(--muted)}
   #user{flex:1;width:100%;height:100%;background:#0e1430;border-radius:10px;touch-action:none;image-rendering:pixelated}
-  .avatar{width:32px;height:32px;border-radius:50%;margin-bottom:6px}
+  .avatar{width:32px;height:32px;border-radius:50%}
+  .mini .avatar{margin-bottom:6px}
+  .userInfo .avatar{margin-right:0}
   .countdown{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;font-weight:bold;color:#fff;background:rgba(0,0,0,0.5);z-index:50}
   .countdown.hidden{display:none}
   .toast{position:fixed;left:50%;transform:translateX(-50%);bottom:16px;background:#0d1536;border:1px solid #223063;border-radius:10px;padding:8px 12px;font-size:13px;opacity:0;transition:opacity .2s}
@@ -49,11 +53,6 @@
 <body>
 <div class="app">
   <div id="countdown" class="countdown hidden"></div>
-  <div class="hud">
-    <div class="panel"><strong>Time</strong><span id="time" class="timer">03:00</span></div>
-    <div class="panel"><strong>Pot (TPC)</strong><span id="pot" class="score">0</span></div>
-    <div class="panel"><strong>Your score</strong><span id="myscore" class="score">0</span></div>
-  </div>
   <div class="layout">
     <div class="top">
       <div class="mini"><h3>P1</h3><img src="assets/icons/profile.svg" alt="" class="avatar"/><canvas id="opp1"></canvas></div>
@@ -61,8 +60,17 @@
       <div class="mini"><h3>P3</h3><img src="assets/icons/profile.svg" alt="" class="avatar"/><canvas id="opp3"></canvas></div>
     </div>
     <div class="userWrap">
-      <h3>USER</h3>
-      <img src="assets/icons/profile.svg" alt="" class="avatar"/>
+      <div class="userBar">
+        <div class="userInfo">
+          <img src="assets/icons/profile.svg" alt="" class="avatar" id="userAvatar"/>
+          <h3 id="username">USER</h3>
+        </div>
+        <div class="hud">
+          <div class="panel"><strong>Time</strong><span id="time" class="timer">03:00</span></div>
+          <div class="panel"><strong>Pot (TPC)</strong><span id="pot" class="score">0</span></div>
+          <div class="panel"><strong>Your score</strong><span id="myscore" class="score">0</span></div>
+        </div>
+      </div>
       <canvas id="user"></canvas>
     </div>
   </div>
@@ -124,6 +132,7 @@ window.__TETRIS_ROYALE__ = true;
   if (initParam && !window.Telegram) {
     window.Telegram = { WebApp: { initData: decodeURIComponent(initParam) } };
   }
+  const userName = params.get('name') || params.get('username') || window?.Telegram?.WebApp?.initDataUnsafe?.user?.first_name || 'USER';
 
   function emojiToDataUri(flag){
     return `data:image/svg+xml,${encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='64' height='64'><text x='50%' y='50%' font-size='48' text-anchor='middle' dominant-baseline='central'>${flag}</text></svg>`)}`;
@@ -360,6 +369,7 @@ window.__TETRIS_ROYALE__ = true;
   const canvases = { user: $('#user'), opp1: $('#opp1'), opp2: $('#opp2'), opp3: $('#opp3') };
   const avatarEls = document.querySelectorAll('.avatar');
   const miniWraps = document.querySelectorAll('.top .mini');
+  $('#username').textContent = userName;
   const ui = {
     time: $('#time'), pot: $('#pot'), myscore: $('#myscore'),
     results: $('#results'), winner: $('#winner'),


### PR DESCRIPTION
## Summary
- Move Tetris Royale HUD next to the player info at the bottom
- Display the player's name beside their avatar and load it from query/Telegram data
- Adjust layout and styles for new user bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a4d1f77d48329b97e0553380f238f