### PR TITLE
Configure CORS and WebSocket origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 2. Run `npm run install-all` at the repository root to install dependencies for the bot, webapp and test suite. After the packages finish installing, run `./scripts/setup-tests.sh` once to install OS libraries required by native modules such as `canvas`. Without them `npm test` will fail.
 3. Copy `bot/.env.example` to `bot/.env` and update the values. At minimum set:
    - `BOT_TOKEN` – your Telegram bot token
-   - `MONGO_URI` – MongoDB connection string or `memory`
-     (falls back to an in-memory database if unset)
+   - `MONGO_URI` – MongoDB connection string. If left empty in development it
+     falls back to an in-memory database, but you must provide a real URI in
+     production.
    - `AIRDROP_ADMIN_TOKENS` – (optional) tokens allowed to trigger airdrops
   - `DEPOSIT_WALLET_ADDRESS` – TON address that receives user deposits
   - `STORE_DEPOSIT_ADDRESS` – TON address that receives payments for store bundles
@@ -27,7 +28,9 @@
 
   - `RATE_LIMIT_MAX` – (optional) max requests per window from one IP (defaults to 100)
 
-  - `ALLOWED_ORIGINS` – list of origins allowed for CORS and socket.io. Multiple origins may be comma-separated
+  - `ALLOWED_ORIGINS` – list of origins allowed for CORS and socket.io. Multiple
+    origins may be comma-separated, e.g.
+    `https://tonplaygram-bot.onrender.com,https://t.me,https://web.telegram.org`
 
   - `TWITTER_BEARER_TOKEN` – bearer token for verifying reposts on **X**.
   - `TWITTER_CLIENT_ID` – API key for **X** OAuth linking.
@@ -37,8 +40,9 @@
     When deploying on **Render**, set these values (including `CLAIM_CONTRACT_ADDRESS`, `CLAIM_WALLET_MNEMONIC` and `RPC_URL`) in the service environment instead of storing them in `.env` files.
 
 4. Copy `webapp/.env.example` to `webapp/.env` and configure:
-   - `VITE_API_BASE_URL` – the base URL where the bot API is hosted (e.g. `http://localhost:3000`).
-     If omitted, the webapp will connect to the same origin it was served from.
+   - `VITE_API_BASE_URL` – the base URL where the bot API is hosted (e.g.
+     `https://tonplaygram-bot.onrender.com`). If omitted, the webapp will
+     connect to the same origin it was served from.
    - `VITE_GOOGLE_CLIENT_ID` – OAuth client ID for Google sign-in.
   - `VITE_DEV_ACCOUNT_ID` – account ID that receives the developer share
     (10% by default).

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -10,6 +10,12 @@ MONGO_URI=mongodb://localhost:27017/tonplaygram
 # API port (defaults to 3000 if not set)
 PORT=3000
 
+# Allowed origins for CORS and Socket.IO (comma-separated)
+ALLOWED_ORIGINS=https://tonplaygram-bot.onrender.com,https://t.me,https://web.telegram.org
+
+# Base URL passed to the webapp build when compiling on the server (optional)
+WEBAPP_API_BASE_URL=
+
 # Rate limit configuration
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX=100

--- a/bot/server.js
+++ b/bot/server.js
@@ -67,6 +67,10 @@ if (proxyUrl) {
 }
 
 if (!process.env.MONGO_URI) {
+  if (process.env.NODE_ENV === 'production') {
+    console.error('MONGO_URI is required in production');
+    process.exit(1);
+  }
   process.env.MONGO_URI = 'memory';
   console.log('MONGO_URI not set, defaulting to in-memory MongoDB');
 }
@@ -88,7 +92,10 @@ const app = express();
 app.use(cors({ origin: allowedOrigins.length ? allowedOrigins : '*' }));
 const httpServer = http.createServer(app);
 const io = new SocketIOServer(httpServer, {
-  cors: { origin: allowedOrigins.length ? allowedOrigins : '*' }
+  cors: { origin: allowedOrigins.length ? allowedOrigins : '*', methods: ['GET', 'POST'] },
+  transports: ['websocket', 'polling'],
+  pingInterval: 25000,
+  pingTimeout: 60000
 });
 const gameManager = new GameRoomManager(io);
 

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,5 +1,5 @@
 # Copy this file to `.env` and replace the values as needed.
-VITE_API_BASE_URL=http://localhost:3000
+VITE_API_BASE_URL=https://tonplaygram-bot.onrender.com
 VITE_GOOGLE_CLIENT_ID=
 # Account IDs that receive developer shares
 # Primary developer account (Tur.Alimadhi)

--- a/webapp/src/utils/socket.js
+++ b/webapp/src/utils/socket.js
@@ -6,4 +6,4 @@ if (typeof window !== 'undefined' && window.location.protocol === 'https:' && ba
   baseUrl = baseUrl.replace(/^http:/, 'https:');
 }
 
-export const socket = io(baseUrl);
+export const socket = io(baseUrl, { transports: ['websocket'] });


### PR DESCRIPTION
## Summary
- require a real MONGO_URI in production and wire socket.io with heartbeat and origin checks
- document and sample ALLOWED_ORIGINS and API base variables for backend and webapp
- connect the webapp socket.io client using websocket transport

## Testing
- `npm test` *(fails: should receive error when table not full)*

------
https://chatgpt.com/codex/tasks/task_e_689ac322b1848329bef97ea08082e085