### PR TITLE
Cache Brick Breaker bricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ Posts support **markdown formatting** and emoji **reactions**. Owners can pin fa
 
 The Wall also features a **Trending** section showing the most liked posts from the last 24 hours.
 
+### Brick Breaker Royale
+
+Bricks are pre-rendered to off-screen canvases and reused during board drawing, minimizing repeated `fillRect` calls for smoother gameplay.
+
 ### Using an HTTPS proxy
 
 If your server requires a proxy to reach external services like Tonkeeper,

--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -393,6 +393,21 @@
           const POWERUPS = ['multiball', 'fireball', 'wide', 'slow', 'x2'];
           const POINTS = { standard: 10, tough: 20, explosive: 10 };
 
+          const brickCanvasCache = {};
+          const getBrickCanvas = (color, w, h) => {
+            const key = `${color}_${w}x${h}`;
+            if (!brickCanvasCache[key]) {
+              const cv = document.createElement('canvas');
+              cv.width = w;
+              cv.height = h;
+              const ictx = cv.getContext('2d');
+              ictx.fillStyle = color;
+              ictx.fillRect(0, 0, w, h);
+              brickCanvasCache[key] = cv;
+            }
+            return brickCanvasCache[key];
+          };
+
           const state = {
             match: null,
             timerId: null,
@@ -617,8 +632,7 @@
             ctx.fillText('♥'.repeat(b.lives), W - 40, 52);
             for (const br of b.bricks) {
               if (!br.alive) continue;
-              ctx.fillStyle = br.color;
-              ctx.fillRect(br.x, br.y, br.w, br.h);
+              ctx.drawImage(getBrickCanvas(br.color, br.w, br.h), br.x, br.y);
             }
             for (const p of b.powerups) {
               ctx.fillStyle = COLORS.power;


### PR DESCRIPTION
## Summary
- cache brick rectangles in off-screen canvases
- reuse brick canvases in drawBoard to reduce fillRect calls
- document Brick Breaker rendering optimization

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_689addc25ec48329bc4169b7c7536424