### PR TITLE
Add resolution and outline options for Brick Breaker

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -375,9 +375,12 @@
       if (!window.__BBR_INITED__) {
         window.__BBR_INITED__ = true;
         (() => {
+          const params = new URLSearchParams(location.search);
+          const RESOLUTION = parseFloat(params.get('resolution') || '1');
+          const OUTLINE = parseFloat(params.get('outline') || '2');
           let GAME_DURATION_MS = 60000;
-          const CANVAS_W = 360,
-            CANVAS_H = 560;
+          const CANVAS_W = 360 * RESOLUTION,
+            CANVAS_H = 560 * RESOLUTION;
           const COLORS = {
             bg: '#0a0f24',
             wall: '#223063',
@@ -404,6 +407,8 @@
 
           const $strip = document.getElementById('strip');
           const $userCanvas = document.getElementById('userCanvas');
+          $userCanvas.width = CANVAS_W;
+          $userCanvas.height = CANVAS_H;
           const $userLives = document.getElementById('userLives');
           const $time = document.getElementById('time');
           const $pot = document.getElementById('pot');
@@ -468,7 +473,6 @@
             setTimeout(() => container.remove(), 5000);
           }
 
-          const params = new URLSearchParams(location.search);
           const rawPlayers = parseInt(params.get('players'), 10);
           const settings = {
             players: Math.max(
@@ -608,7 +612,7 @@
               H = CANVAS_H;
             ctx.clearRect(0, 0, W, H);
             ctx.strokeStyle = COLORS.wall;
-            ctx.lineWidth = 2;
+            ctx.lineWidth = OUTLINE;
             ctx.strokeRect(8, 60, W - 16, H - 90);
             ctx.fillStyle = COLORS.text;
             ctx.font = '14px system-ui';

--- a/webapp/src/pages/Games/BrickBreakerLobby.jsx
+++ b/webapp/src/pages/Games/BrickBreakerLobby.jsx
@@ -19,6 +19,8 @@ export default function BrickBreakerLobby() {
   const [mode, setMode] = useState('local');
   const [duration, setDuration] = useState(1);
   const [avatar, setAvatar] = useState('');
+  const [resolution, setResolution] = useState('1');
+  const [outline, setOutline] = useState('2');
 
   useEffect(() => {
     try {
@@ -50,6 +52,8 @@ export default function BrickBreakerLobby() {
     params.set('density', 'medium');
     params.set('mode', mode);
     params.set('duration', duration);
+    params.set('resolution', resolution);
+    params.set('outline', outline);
     const initData = window.Telegram?.WebApp?.initData;
     if (stake.token) params.set('token', stake.token);
     if (stake.amount) params.set('amount', stake.amount);
@@ -114,6 +118,30 @@ export default function BrickBreakerLobby() {
             </button>
           ))}
         </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Resolution</h3>
+        <select
+          value={resolution}
+          onChange={(e) => setResolution(e.target.value)}
+          className="w-full bg-surface border border-border rounded p-2"
+        >
+          <option value="1">1x (360×560)</option>
+          <option value="1.5">1.5x (540×840)</option>
+          <option value="2">2x (720×1120)</option>
+        </select>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Outline Thickness</h3>
+        <select
+          value={outline}
+          onChange={(e) => setOutline(e.target.value)}
+          className="w-full bg-surface border border-border rounded p-2"
+        >
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+        </select>
       </div>
       <button
         onClick={startGame}


### PR DESCRIPTION
## Summary
- Add resolution and outline thickness dropdowns in Brick Breaker lobby and send choices as query params.
- Configure brick-breaker.html to read resolution/outline params, adjust canvas dimensions, and set stroke width.

## Testing
- `npm run lint`
- `npm test` *(fails: should receive error when table not full)*

------
https://chatgpt.com/codex/tasks/task_e_689addc1185483299d1d764cb7e2fb56