### PR TITLE
Add collision impact effects and particle system to Brick Breaker

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -587,6 +587,7 @@
               slow: false,
               bricks: genBricks(settings.density),
               powerups: [],
+              particles: [],
               over: false
             };
           }
@@ -642,10 +643,46 @@
             ctx.fillStyle = COLORS.paddle;
             ctx.fillRect(b.paddle.x, b.paddle.y, b.paddle.w, b.paddle.h);
             for (const ball of b.balls) {
+              ctx.save();
+              ctx.translate(ball.x, ball.y);
+              if (ball.bump > 0) {
+                const s = 1 + ball.bump * 0.5;
+                ctx.scale(s, s);
+                ctx.rotate((ball.spin || 0) * ball.bump);
+              }
               ctx.fillStyle = ball.fire ? COLORS.danger : COLORS.ball;
               ctx.beginPath();
-              ctx.arc(ball.x, ball.y, ball.r, 0, Math.PI * 2);
+              ctx.arc(0, 0, ball.r, 0, Math.PI * 2);
               ctx.fill();
+              ctx.restore();
+            }
+            for (const part of b.particles) {
+              ctx.save();
+              ctx.globalAlpha = part.a;
+              ctx.translate(part.x, part.y);
+              ctx.rotate(part.rot);
+              ctx.scale(part.s, part.s);
+              ctx.fillStyle = part.color;
+              ctx.beginPath();
+              ctx.arc(0, 0, part.r, 0, Math.PI * 2);
+              ctx.fill();
+              ctx.restore();
+            }
+          }
+
+          function spawnParticles(b, x, y, color) {
+            for (let i = 0; i < 12; i++) {
+              b.particles.push({
+                x,
+                y,
+                vx: rand(-2, 2),
+                vy: rand(-2, 2),
+                a: 1,
+                r: rand(1, 3),
+                rot: rand(0, Math.PI * 2),
+                s: rand(0.6, 1.4),
+                color
+              });
             }
           }
 
@@ -695,6 +732,12 @@
 
           function updateBoard(b, dt, inputX = null) {
             if (b.over) return;
+            for (const part of b.particles) {
+              part.x += part.vx * (dt * 0.06);
+              part.y += part.vy * (dt * 0.06);
+              part.a -= dt * 0.003;
+            }
+            b.particles = b.particles.filter((p) => p.a > 0);
             if (inputX != null) {
               const target = clamp(
                 inputX - b.paddle.w / 2,
@@ -725,17 +768,27 @@
             for (const ball of [...b.balls]) {
               ball.x += ball.vx * (dt * 0.06) * (b.slow ? 0.75 : 1);
               ball.y += ball.vy * (dt * 0.06) * (b.slow ? 0.75 : 1);
+              ball.bump = Math.max(0, (ball.bump || 0) - dt * 0.004);
               if (ball.x - ball.r < 10) {
                 ball.x = 10 + ball.r;
                 ball.vx = Math.abs(ball.vx);
+                spawnParticles(b, ball.x, ball.y, ball.fire ? COLORS.danger : COLORS.ball);
+                ball.bump = 1;
+                ball.spin = rand(-0.5, 0.5);
               }
               if (ball.x + ball.r > CANVAS_W - 10) {
                 ball.x = CANVAS_W - 10 - ball.r;
                 ball.vx = -Math.abs(ball.vx);
+                spawnParticles(b, ball.x, ball.y, ball.fire ? COLORS.danger : COLORS.ball);
+                ball.bump = 1;
+                ball.spin = rand(-0.5, 0.5);
               }
               if (ball.y - ball.r < 62) {
                 ball.y = 62 + ball.r;
                 ball.vy = Math.abs(ball.vy);
+                spawnParticles(b, ball.x, ball.y, ball.fire ? COLORS.danger : COLORS.ball);
+                ball.bump = 1;
+                ball.spin = rand(-0.5, 0.5);
               }
               if (ball.y - ball.r > CANVAS_H - 20) {
                 b.balls = b.balls.filter((x) => x !== ball);
@@ -771,6 +824,9 @@
                 const speedBoost = 3.1 + Math.min(2.0, Math.abs(hit) * 1.6);
                 ball.vx = hit * speedBoost;
                 ball.vy = -Math.abs(speedBoost);
+                spawnParticles(b, ball.x, ball.y, ball.fire ? COLORS.danger : COLORS.ball);
+                ball.bump = 1;
+                ball.spin = rand(-0.5, 0.5);
               }
               for (const br of b.bricks) {
                 if (!br.alive) continue;
@@ -796,11 +852,17 @@
                       }
                     }
                     if (!ball.fire) ball.vy *= -1;
+                    spawnParticles(b, ball.x, ball.y, br.color);
+                    ball.bump = 1;
+                    ball.spin = rand(-0.5, 0.5);
                   } else {
                     br.hits--;
                     if (br.hits <= 0) br.alive = false;
                     else br.color = '#ffbb7d';
                     if (!ball.fire) ball.vy *= -1;
+                    spawnParticles(b, ball.x, ball.y, br.color);
+                    ball.bump = 1;
+                    ball.spin = rand(-0.5, 0.5);
                   }
                   if (Math.random() < 0.12) {
                     b.powerups.push({


### PR DESCRIPTION
## Summary
- Add particle array to board state and spawnParticles helper
- Draw balls with save/restore, scale, and rotate for exaggerated impacts and render particles
- Update board logic to animate particles and spawn them on wall, paddle, and brick collisions

## Testing
- `npm test` *(fails: joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_689addbfc4c8832989aae30fbb6142f3