### PR TITLE
feat: simplify brick breaker settings

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -140,6 +140,8 @@
         border-radius: 10px;
         background: linear-gradient(0deg, #0a1026, #0c1430);
         display: block;
+        image-rendering: pixelated;
+        filter: saturate(1.2);
       }
 
       .user-area {
@@ -179,6 +181,8 @@
         border-radius: 10px;
         background: linear-gradient(0deg, #0a1026, #0c1430);
         touch-action: none;
+        image-rendering: pixelated;
+        filter: saturate(1.2);
       }
 
       .pill {
@@ -376,8 +380,8 @@
         window.__BBR_INITED__ = true;
         (() => {
           const params = new URLSearchParams(location.search);
-          const RESOLUTION = parseFloat(params.get('resolution') || '1');
-          const OUTLINE = parseFloat(params.get('outline') || '2');
+          const RESOLUTION = parseFloat(params.get('resolution') || '2');
+          const OUTLINE = parseFloat(params.get('outline') || '1');
           let GAME_DURATION_MS = 60000;
 const CANVAS_W = 720,
 

--- a/webapp/src/pages/Games/BrickBreakerLobby.jsx
+++ b/webapp/src/pages/Games/BrickBreakerLobby.jsx
@@ -19,8 +19,6 @@ export default function BrickBreakerLobby() {
   const [mode, setMode] = useState('local');
   const [duration, setDuration] = useState(1);
   const [avatar, setAvatar] = useState('');
-  const [resolution, setResolution] = useState('1');
-  const [outline, setOutline] = useState('2');
 
   useEffect(() => {
     try {
@@ -52,8 +50,8 @@ export default function BrickBreakerLobby() {
     params.set('density', 'medium');
     params.set('mode', mode);
     params.set('duration', duration);
-    params.set('resolution', resolution);
-    params.set('outline', outline);
+    params.set('resolution', '2');
+    params.set('outline', '1');
     const initData = window.Telegram?.WebApp?.initData;
     if (stake.token) params.set('token', stake.token);
     if (stake.amount) params.set('amount', stake.amount);
@@ -118,30 +116,6 @@ export default function BrickBreakerLobby() {
             </button>
           ))}
         </div>
-      </div>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Resolution</h3>
-        <select
-          value={resolution}
-          onChange={(e) => setResolution(e.target.value)}
-          className="w-full bg-surface border border-border rounded p-2"
-        >
-          <option value="1">1x (360×560)</option>
-          <option value="1.5">1.5x (540×840)</option>
-          <option value="2">2x (720×1120)</option>
-        </select>
-      </div>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Outline Thickness</h3>
-        <select
-          value={outline}
-          onChange={(e) => setOutline(e.target.value)}
-          className="w-full bg-surface border border-border rounded p-2"
-        >
-          <option value="1">1</option>
-          <option value="2">2</option>
-          <option value="3">3</option>
-        </select>
       </div>
       <button
         onClick={startGame}


### PR DESCRIPTION
## Summary
- remove resolution and outline selectors from Brick Breaker lobby and fix their values to 2x resolution and outline thickness 1
- apply cartoon-style rendering to Brick Breaker canvases

## Testing
- `npm run lint`
- `npm test` *(fails: not ok 5 - joinRoom clears lobby seat)*

------
https://chatgpt.com/codex/tasks/task_e_689ae5b213c88329a397013f61393dcc