### PR TITLE
Tighten Brick Breaker HUD spacing and allow fullscreen

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -583,7 +583,7 @@ const CANVAS_W = 720,
                 }
                 bricks.push({
                   x: c * (VIEW_W / cols) + 4,
-                  y: 80 + r * 28,
+                  y: 72 + r * 28,
                   w: VIEW_W / cols - 8,
                   h: 20,
                   type,
@@ -641,12 +641,12 @@ const CANVAS_W = 720,
             ctx.clearRect(0, 0, W, H);
             ctx.strokeStyle = COLORS.wall;
             ctx.lineWidth = OUTLINE;
-            ctx.strokeRect(8, 60, W - 16, H - 90);
+            ctx.strokeRect(8, 52, W - 16, H - 82);
             ctx.fillStyle = COLORS.text;
             ctx.font = '14px system-ui';
-            ctx.fillText(`Score: ${b.score}`, 12, 52);
+            ctx.fillText(`Score: ${b.score}`, 12, 44);
             ctx.fillStyle = COLORS.danger;
-            ctx.fillText('♥'.repeat(b.lives), W - 40, 52);
+            ctx.fillText('♥'.repeat(b.lives), W - 40, 44);
             for (const br of b.bricks) {
               if (!br.alive) continue;
 ctx.fillStyle = br.color;
@@ -778,8 +778,8 @@ ctx.strokeRect(br.x, br.y, br.w, br.h);
                 ball.x = VIEW_W - 10 - ball.r;
                 ball.vx = -Math.abs(ball.vx);
               }
-              if (ball.y - ball.r < 62) {
-                ball.y = 62 + ball.r;
+              if (ball.y - ball.r < 54) {
+                ball.y = 54 + ball.r;
                 ball.vy = Math.abs(ball.vy);
               }
               if (ball.y - ball.r > VIEW_H - 20) {

--- a/webapp/src/pages/Games/BrickBreaker.jsx
+++ b/webapp/src/pages/Games/BrickBreaker.jsx
@@ -7,6 +7,8 @@ export default function BrickBreaker() {
       src={`/brick-breaker.html${search}`}
       title="Brick Breaker Royale"
       className="w-screen h-screen border-0"
+      allow="fullscreen"
+      allowFullScreen
     />
   );
 }


### PR DESCRIPTION
## Summary
- Reduce gap between player info row and score by shifting HUD elements and playfield upward
- Enable fullscreen mode for Brick Breaker iframe to remove phone home button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aee700bcc83299138e8623c88b02c