### PR TITLE
Improve Bubble Pop Royale visuals and player info

### DIFF
--- a/webapp/public/bubble-pop-royale.html
+++ b/webapp/public/bubble-pop-royale.html
@@ -168,7 +168,14 @@ window.__BUBBLE_ROYALE_POWER__ = true;
   const devAccount2 = params.get('dev2');
   const initParam = params.get('init');
   if (initParam && !window.Telegram) {
-    window.Telegram = { WebApp: { initData: decodeURIComponent(initParam) } };
+    const decoded = decodeURIComponent(initParam);
+    window.Telegram = { WebApp: { initData: decoded } };
+    try {
+      const parsed = Object.fromEntries(new URLSearchParams(decoded));
+      if (parsed.user) {
+        window.Telegram.WebApp.initDataUnsafe = { user: JSON.parse(parsed.user) };
+      }
+    } catch {}
   }
   async function awardDevShare(total){
     const ops=[];
@@ -227,7 +234,8 @@ window.__BUBBLE_ROYALE_POWER__ = true;
   }
   function fitCanvas(c){
     const r = c.getBoundingClientRect();
-    const dpr = window.devicePixelRatio || 1;
+    const dprBase = window.devicePixelRatio || 1;
+    const dpr = dprBase * 2;
     c.style.width = r.width + 'px';
     c.style.height = r.height + 'px';
     c.width = Math.round(r.width * dpr);


### PR DESCRIPTION
## Summary
- Double canvas pixel ratio for crisper Bubble Pop Royale bubbles.
- Parse Telegram init data to display the real player's profile name.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689af2a41e74832982186c789c9d421b