### PR TITLE
feat: add user status selection for leaderboard

### DIFF
--- a/test/onlineRoutes.test.js
+++ b/test/onlineRoutes.test.js
@@ -38,7 +38,7 @@ test('online routes reflect pinged users', { concurrency: false }, async () => {
     const pingRes = await fetch('http://localhost:3202/api/online/ping', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ accountId: 'player1' })
+      body: JSON.stringify({ playerId: 'player1', status: 'online' })
     });
     assert.equal(pingRes.status, 200);
     const ping = await pingRes.json();
@@ -52,7 +52,7 @@ test('online routes reflect pinged users', { concurrency: false }, async () => {
     const listRes = await fetch('http://localhost:3202/api/online/list');
     assert.equal(listRes.status, 200);
     const list = await listRes.json();
-    assert.deepEqual(list.users, ['player1']);
+    assert.deepEqual(list.users, [{ id: 'player1', status: 'online' }]);
   } finally {
     server.kill();
   }

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -79,7 +79,8 @@ export default function Layout({ children }) {
     try {
       const playerId = getPlayerId();
       function ping() {
-        pingOnline(playerId).catch(() => {});
+        const status = localStorage.getItem('onlineStatus') || 'online';
+        pingOnline(playerId, status).catch(() => {});
       }
       ping();
       id = setInterval(ping, 30000);

--- a/webapp/src/pages/Games/CrazyDiceLobby.jsx
+++ b/webapp/src/pages/Games/CrazyDiceLobby.jsx
@@ -34,7 +34,8 @@ export default function CrazyDiceLobby() {
       .then((accountId) => {
         if (cancelled || !accountId) return;
         function ping() {
-          pingOnline(accountId).catch(() => {});
+          const status = localStorage.getItem('onlineStatus') || 'online';
+          pingOnline(accountId, status).catch(() => {});
           getOnlineCount()
             .then((d) => setOnline(d.count))
             .catch(() => {});

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -113,7 +113,8 @@ export default function Lobby() {
       .then((playerId) => {
         if (cancelled) return;
         function ping() {
-          pingOnline(playerId).catch(() => {});
+          const status = localStorage.getItem('onlineStatus') || 'online';
+          pingOnline(playerId, status).catch(() => {});
           getOnlineCount()
             .then((d) => setOnline(d.count))
             .catch(() => {});

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -564,7 +564,8 @@ export default function SnakeAndLadder() {
   useEffect(() => {
     const id = getPlayerId();
     function ping() {
-      pingOnline(id).catch(() => {});
+      const status = localStorage.getItem('onlineStatus') || 'online';
+      pingOnline(id, status).catch(() => {});
     }
     ping();
     const t = setInterval(ping, 30000);

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -360,8 +360,8 @@ export function unseatTable(playerId, tableId) {
   return post('/api/snake/table/unseat', { playerId, tableId });
 }
 
-export function pingOnline(playerId) {
-  return post('/api/online/ping', { playerId });
+export function pingOnline(playerId, status) {
+  return post('/api/online/ping', { playerId, status });
 }
 
 export function getOnlineCount() {


### PR DESCRIPTION
## Summary
- allow players to set their online status (online, busy, offline)
- show status icons in the leaderboard and expose status through `/api/online/list`
- adjust pings throughout app to send chosen status

## Testing
- `npm run lint`
- `npm test` *(fails: joinRoom clears lobby seat, joinRoom waits until table full)*

------
https://chatgpt.com/codex/tasks/task_e_689af37069cc83298a70bc11804fd00a