### PR TITLE
Align Tetris Royale user info layout with Bubble Pop

### DIFF
--- a/webapp/public/tetris-royale.html
+++ b/webapp/public/tetris-royale.html
@@ -16,7 +16,7 @@
   label{font-size:12px;color:var(--muted);display:block;margin-bottom:6px}
   select,button,input{width:100%;padding:10px 12px;border-radius:10px;border:1px solid #223063;background:#0e1430;color:#e7eefc}
   .btn{background:linear-gradient(180deg,#2a6cf0,#2156c8);border:none;font-weight:700;cursor:pointer}
-  .hud{display:flex;gap:8px;margin-bottom:8px}
+  .hud{display:flex;gap:8px}
   .panel{border:1px solid #223063;background:#0b1228;border-radius:12px;padding:10px;display:flex;align-items:center;justify-content:space-between}
   .score{color:var(--gold);font-weight:800}
   .timer{font-variant-numeric:tabular-nums;font-weight:800}
@@ -28,11 +28,11 @@
   .mini canvas{flex:1;width:100%;height:100%;background:#0e1430;border-radius:8px;image-rendering:pixelated}
   .userWrap{position:relative;border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:14px;padding:10px;display:flex;flex-direction:column;min-height:0}
   .userWrap h3{margin:0;font-size:13px;color:var(--muted)}
+  .userHeader{display:flex;align-items:center;gap:8px;margin-bottom:8px}
   #user{flex:1;width:100%;height:100%;background:#0e1430;border-radius:10px;touch-action:none;image-rendering:pixelated}
   .avatar{width:32px;height:32px;border-radius:50%}
   .mini h3 .avatar{width:16px;height:16px;border-radius:2px}
   .scorePanel{flex-direction:column;align-items:center;justify-content:center}
-  .userFooter{position:absolute;right:10px;bottom:10px;display:flex;align-items:center;gap:6px}
   .countdown{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;font-weight:bold;color:#fff;background:rgba(0,0,0,0.5);z-index:50}
   .countdown.hidden{display:none}
   .toast{position:fixed;left:50%;transform:translateX(-50%);bottom:16px;background:#0d1536;border:1px solid #223063;border-radius:10px;padding:8px 12px;font-size:13px;opacity:0;transition:opacity .2s}
@@ -72,15 +72,15 @@
       </div>
     </div>
     <div class="userWrap">
-      <div class="hud">
-        <div class="panel"><strong>Time</strong><span id="time" class="timer">03:00</span></div>
-        <div class="panel scorePanel"><strong>Your score</strong><span id="myscore" class="score">0</span></div>
+      <div class="userHeader">
+        <img src="assets/icons/profile.svg" alt="" class="avatar" id="userAvatar"/>
+        <h3 id="username">PLAYER</h3>
+        <div class="hud">
+          <div class="panel"><strong>Time</strong><span id="time" class="timer">03:00</span></div>
+          <div class="panel scorePanel"><strong>Your score</strong><span id="myscore" class="score">0</span></div>
+        </div>
       </div>
       <canvas id="user"></canvas>
-      <div class="userFooter">
-        <h3 id="username">PLAYER</h3>
-        <img src="assets/icons/profile.svg" alt="" class="avatar" id="userAvatar"/>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Place player's avatar and name above the playfield in Tetris Royale
- Introduce header styling to match Bubble Pop Royale

## Testing
- `npm test` *(fails: should receive error when table not full)*

------
https://chatgpt.com/codex/tasks/task_e_689af658231c8329952e2f18368e012f