### PR TITLE
feat: make home games card horizontally scrollable

### DIFF
--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -12,48 +12,62 @@ export default function HomeGamesCard() {
         }}
       />
       <h3 className="text-lg font-bold text-center">Games</h3>
-        <div className="flex justify-center space-x-4">
-          <Link to="/games/snake/lobby" className="flex-shrink-0">
-            <img
-              src="/assets/icons/snakes_and_ladders.webp"
-              alt="Snake & Ladder"
-              className="w-24 h-24"
-            />
+        <div className="flex overflow-x-auto space-x-4 items-center pb-2">
+          <Link
+            to="/games/snake/lobby"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+          >
+            <img src="/assets/icons/snakes_and_ladders.webp" alt="" className="h-20 w-20" />
+            <h3 className="text-sm font-semibold text-center">Snake &amp; Ladder</h3>
           </Link>
-          <Link to="/games/crazydice/lobby" className="flex-shrink-0">
-            <img
-              src="/assets/icons/Crazy_Dice_Duel_Promo.webp"
-              alt="Crazy Dice Duel"
-              className="w-24 h-24"
-            />
+          <Link
+            to="/games/crazydice/lobby"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+          >
+            <img src="/assets/icons/Crazy_Dice_Duel_Promo.webp" alt="" className="h-20 w-20" />
+            <h3 className="text-sm font-semibold text-center">Crazy Dice Duel</h3>
           </Link>
-          <Link to="/games/fallingball" className="flex-shrink-0">
-            <img
-              src="/assets/icons/falling_ball.svg"
-              alt="Falling Ball"
-              className="w-24 h-24"
-            />
+          <Link
+            to="/games/fallingball/lobby"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+          >
+            <img src="/assets/icons/falling_ball.svg" alt="" className="h-20 w-20" />
+            <h3 className="text-sm font-semibold text-center">Falling Ball</h3>
           </Link>
-          <Link to="/games/brickbreaker/lobby" className="flex-shrink-0">
-            <img
-              src="/assets/icons/brick_breaker.svg"
-              alt="Brick Breaker Royale"
-              className="w-24 h-24"
-            />
+          <Link
+            to="/games/airhockey/lobby"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+          >
+            <img src="/assets/icons/air_hockey.svg" alt="" className="h-20 w-20" />
+            <h3 className="text-sm font-semibold text-center">Air Hockey</h3>
           </Link>
-          <Link to="/games/bubblepoproyale/lobby" className="flex-shrink-0">
-            <img
-              src="/assets/icons/bubble_pop.svg"
-              alt="Bubble Pop Royale"
-              className="w-24 h-24"
-            />
+          <Link
+            to="/games/brickbreaker/lobby"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+          >
+            <img src="/assets/icons/brick_breaker.svg" alt="" className="h-20 w-20" />
+            <h3 className="text-sm font-semibold text-center">Brick Breaker Royale</h3>
           </Link>
-          <Link to="/games/bubblesmashroyale/lobby" className="flex-shrink-0">
-            <img
-              src="/assets/icons/bubble_smash.svg"
-              alt="Bubble Smash Royale"
-              className="w-24 h-24"
-            />
+          <Link
+            to="/games/bubblepoproyale/lobby"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+          >
+            <img src="/assets/icons/bubble_pop.svg" alt="" className="h-20 w-20" />
+            <h3 className="text-sm font-semibold text-center">Bubble Pop Royale</h3>
+          </Link>
+          <Link
+            to="/games/bubblesmashroyale/lobby"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+          >
+            <img src="/assets/icons/bubble_smash.svg" alt="" className="h-20 w-20" />
+            <h3 className="text-sm font-semibold text-center">Bubble Smash Royale</h3>
+          </Link>
+          <Link
+            to="/games/tetrisroyale/lobby"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+          >
+            <img src="/assets/icons/tetris.svg" alt="" className="h-20 w-20" />
+            <h3 className="text-sm font-semibold text-center">Tetris Royale</h3>
           </Link>
         </div>
       <Link


### PR DESCRIPTION
## Summary
- match home page games card to games page with horizontally scrollable list of game links

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b21bc99fc8329ad6c8d86c5ac7874