### PR TITLE
Add Fruit Slice Royale game and lobby

### DIFF
--- a/webapp/public/assets/icons/fruit_slice.svg
+++ b/webapp/public/assets/icons/fruit_slice.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#0e1430"/>
+  <circle cx="20" cy="20" r="12" fill="#5aa2ff"/>
+  <circle cx="44" cy="24" r="10" fill="#ff5a6b"/>
+  <circle cx="24" cy="44" r="8" fill="#34d399"/>
+</svg>

--- a/webapp/public/fruit-slice-royale.html
+++ b/webapp/public/fruit-slice-royale.html
@@ -1,0 +1,521 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
+<title>Fruit Slice Royale — More Fruits, Sizes, Split & Vanish</title>
+<style>
+  :root{ --bg:#0c1020; --panel:#11172a; --primary:#2563eb; --gold:#d4af37; --text:#e7eefc; --muted:#8fa1d2; }
+  *{box-sizing:border-box;font-family:Inter,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+  html,body{height:100vh}
+  body{margin:0;background:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;color:var(--text);overflow:hidden}
+  .app{height:100vh;display:flex;flex-direction:column;padding:12px;gap:10px;max-width:1100px;margin:0 auto}
+  header{display:flex;gap:12px;align-items:center;justify-content:space-between}
+  .badge{background:#0f1736;border:1px solid #223063;border-radius:10px;padding:6px 10px;color:var(--muted);font-size:12px}
+
+  .controls{display:grid;grid-template-columns:1fr 1fr 1fr auto;gap:8px}
+  label{font-size:12px;color:var(--muted);display:block;margin-bottom:6px}
+  select,button,input{width:100%;padding:10px 12px;border-radius:10px;border:1px solid #223063;background:#0e1430;color:#e7eefc}
+  .btn{background:linear-gradient(180deg,#2a6cf0,#2156c8);border:none;font-weight:700;cursor:pointer}
+
+  .hud{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+  .panel{border:1px solid #223063;background:#0b1228;border-radius:12px;padding:10px;display:flex;align-items:center;justify-content:space-between}
+  .score{color:var(--gold);font-weight:800}
+  .timer{font-variant-numeric:tabular-nums;font-weight:800}
+
+  .layout{display:grid;grid-template-rows:25vh 1fr;gap:10px;flex:1;min-height:0}
+  .top{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;min-height:0}
+  .mini{position:relative;border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:12px;padding:8px;display:flex;flex-direction:column;min-height:0}
+  .mini h3{margin:0 0 6px 0;font-size:12px;color:var(--muted)}
+  .mini canvas{flex:1;width:100%;height:100%;background:#0e1430;border-radius:8px}
+
+  .userWrap{position:relative;border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:14px;padding:10px;display:flex;flex-direction:column;min-height:0}
+  .userWrap h3{margin:0 0 8px 0;font-size:13px;color:var(--muted);display:flex;align-items:center;gap:8px}
+  #user{flex:1;width:100%;height:100%;background:#0e1430;border-radius:10px;touch-action:none}
+
+  .mute{position:fixed;right:12px;bottom:12px;background:#0f1736;border:1px solid #223063;border-radius:10px;padding:8px 10px;cursor:pointer}
+  dialog{border:none;border-radius:16px;background:#0d1330;color:#e7eefc;max-width:520px;width:calc(100% - 24px)}
+  .modal{padding:16px;border:1px solid #223063;border-radius:16px;background:linear-gradient(180deg,#0f1736,#0b1126)}
+  .grid{display:grid;gap:10px}
+  .grid.two{grid-template-columns:1fr 1fr}
+  .kpi{background:#0b1228;border:1px solid #223063;border-radius:12px;padding:10px;text-align:center}
+  .kpi .v{font-size:22px;font-weight:800}
+</style>
+</head>
+<body>
+<div class="app">
+  <header>
+    <div style="display:flex;align-items:center;gap:10px">
+      <h1 style="margin:0;font-size:18px">Fruit Slice Royale</h1>
+      <span class="badge">Local test • TPC only</span>
+    </div>
+    <button id="mute" class="mute">🔊</button>
+  </header>
+
+  <div class="controls">
+    <div>
+      <label>Players</label>
+      <select id="players">
+        <option value="2">2 players</option>
+        <option value="3">3 players</option>
+        <option value="4" selected>4 players</option>
+      </select>
+    </div>
+    <div>
+      <label>Duration</label>
+      <select id="duration">
+        <option value="60">1 min</option>
+        <option value="180" selected>3 min</option>
+        <option value="300">5 min</option>
+      </select>
+    </div>
+    <div>
+      <label>Stake per player (TPC)</label>
+      <input id="stake" type="number" value="300" min="0" step="50"/>
+    </div>
+    <div>
+      <button id="start" class="btn">Start Match</button>
+    </div>
+  </div>
+
+  <div class="hud">
+    <div class="panel"><strong>Time</strong><span id="time" class="timer">03:00</span></div>
+    <div class="panel"><strong>Pot (TPC)</strong><span id="pot" class="score">0</span></div>
+    <div class="panel"><strong>Your score</strong><span id="myscore" class="score">0</span></div>
+  </div>
+
+  <div class="layout">
+    <div class="top">
+      <div class="mini"><h3>P1</h3><canvas id="opp1"></canvas></div>
+      <div class="mini"><h3>P2</h3><canvas id="opp2"></canvas></div>
+      <div class="mini"><h3>P3</h3><canvas id="opp3"></canvas></div>
+    </div>
+    <div class="userWrap">
+      <h3>USER</h3>
+      <canvas id="user"></canvas>
+    </div>
+  </div>
+</div>
+
+<dialog id="results">
+  <div class="modal">
+    <h2>Round results</h2>
+    <div class="grid two">
+      <div class="kpi"><div class="v" id="winner">-</div><div>Winner</div></div>
+      <div class="kpi"><div class="v" id="payout">0</div><div>Payout TPC</div></div>
+    </div>
+    <div class="grid" style="margin-top:10px">
+      <div class="kpi"><div class="v" id="fee">0</div><div>Fee 10%</div></div>
+      <div class="kpi"><div class="v" id="potFinal">0</div><div>Final Pot</div></div>
+    </div>
+    <div class="grid" id="scoreList" style="margin-top:10px"></div>
+    <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:8px">
+      <button class="btn" id="rematch">Rematch</button>
+      <button class="btn" id="change">Change settings</button>
+    </div>
+  </div>
+</dialog>
+
+<script>
+(function(){
+  const $=s=>document.querySelector(s);
+  const canvases={ user:$('#user'), opp1:$('#opp1'), opp2:$('#opp2'), opp3:$('#opp3') };
+  function fitCanvas(c){ const r=c.getBoundingClientRect(); c.width=Math.max(10,r.width); c.height=Math.max(10,r.height); }
+
+  // ===== Audio =====
+  let audioCtx=null, muted=false;
+  function ensureAudio(){ if(!audioCtx){ audioCtx=new (window.AudioContext||window.webkitAudioContext)(); } }
+  function pop(freq=850, dur=0.08, vol=0.22){
+    if(!audioCtx||muted) return;
+    const t=audioCtx.currentTime, o=audioCtx.createOscillator(), g=audioCtx.createGain();
+    o.type='triangle'; o.frequency.value=freq;
+    g.gain.setValueAtTime(0,t); g.gain.linearRampToValueAtTime(vol,t+0.01); g.gain.exponentialRampToValueAtTime(0.0001,t+dur);
+    o.connect(g); g.connect(audioCtx.destination); o.start(t); o.stop(t+dur+0.02);
+  }
+  function explosionSound(){
+    if(!audioCtx||muted) return;
+    const t=audioCtx.currentTime;
+    const buffer=audioCtx.createBuffer(1, audioCtx.sampleRate*0.45, audioCtx.sampleRate);
+    const data=buffer.getChannelData(0);
+    for(let i=0;i<data.length;i++){ data[i]=(Math.random()*2-1)*Math.exp(-i/(audioCtx.sampleRate*0.12)); }
+    const noise=audioCtx.createBufferSource(); noise.buffer=buffer;
+    const ng=audioCtx.createGain(); ng.gain.setValueAtTime(0.6,t); ng.gain.exponentialRampToValueAtTime(0.0001,t+0.45);
+    noise.connect(ng).connect(audioCtx.destination); noise.start(t);
+  }
+
+  // ===== Fruits (more types + size factors) =====
+  // sf = size factor relative to base (so cherry < apple)
+  const FRUITS=[
+    {k:'apple',    col:'#ff5a6b', juice:'#ff8aa0', score:12, sf:1.00},
+    {k:'orange',   col:'#ff9d5a', juice:'#ffbf8f', score:12, sf:1.00},
+    {k:'lemon',    col:'#f6d74a', juice:'#ffe179', score:11, sf:0.90},
+    {k:'lime',     col:'#34d399', juice:'#7ff0c3', score:11, sf:0.90},
+    {k:'pear',     col:'#9bd27d', juice:'#c9f4b1', score:13, sf:1.05},
+    {k:'banana',   col:'#f8e36a', juice:'#ffef91', score:14, sf:1.20},
+    {k:'grape',    col:'#a78bfa', juice:'#c7b7ff', score:16, sf:0.95},
+    {k:'cherry',   col:'#ff4b5c', juice:'#ff94a1', score:10, sf:0.60},
+    {k:'strawberry',col:'#ff5577', juice:'#ff97ad', score:15, sf:0.85},
+    {k:'watermelon',col:'#e94b5b', juice:'#ff9fb0', score:18, sf:1.25},
+    {k:'kiwi',     col:'#8bd36a', juice:'#c9f7a9', score:14, sf:0.95},
+    {k:'pineapple',col:'#f1c14b', juice:'#ffe08a', score:17, sf:1.15}
+  ];
+  const BOMB={k:'bomb', shell:'#2a303d', fuse:'#ffdd55'};
+
+  const rnd=(a,b)=>Math.random()*(b-a)+a;
+  const hexToRgba=(hex,a)=>{const c=hex.replace('#',''); const r=parseInt(c.slice(0,2),16), g=parseInt(c.slice(2,4),16), b=parseInt(c.slice(4,6),16); return `rgba(${r},${g},${b},${a})`;};
+
+  // ===== Single board =====
+  function createGame(canvas, isUser){
+    const ctx=canvas.getContext('2d'); fitCanvas(canvas);
+    const W=()=>canvas.width, H=()=>canvas.height;
+
+    const fruits=[], halves=[], splats=[], smokeRings=[], slices=[], texts=[];
+    const game={ isUser, score:0, dragging:false, lastPt:null, nextAi: performance.now()+1000+Math.random()*400 };
+
+    // Spawner
+    let spawnAcc=0, spawnNext=500;
+    function spawnWave(){
+      const n=2+(Math.random()<0.6?1:0);
+      for(let i=0;i<n;i++){
+        const isBomb=Math.random()<0.15;
+        const data=isBomb?BOMB: FRUITS[(Math.random()*FRUITS.length)|0];
+        const x=rnd(W()*0.15, W()*0.85), y=H()+30;
+        const speed=rnd(7.2,9.8), vx=rnd(-1.6,1.6), vy=-speed, ay=0.18+Math.random()*0.08;
+        const base=Math.max(16, Math.min(W(),H())*0.04);
+        const r=base*(isBomb?1.05:data.sf*rnd(0.95,1.1));
+        fruits.push({x,y,vx,vy,ay,r,data,type:isBomb?'bomb':'fruit',rot:rnd(0,Math.PI),spin:rnd(-0.08,0.08)});
+      }
+      spawnNext=650+Math.random()*450;
+    }
+
+    // Painters (cartoon fruits)
+    function drawFruit(f){
+      const k=f.data.k, r=f.r;
+      ctx.save(); ctx.translate(f.x,f.y); ctx.rotate(f.rot||0);
+
+      if(k==='apple'||k==='orange'||k==='kiwi'){
+        const g=ctx.createRadialGradient(-r*0.3,-r*0.5,r*0.1, 0,0,r);
+        g.addColorStop(0,'#ffffff66'); g.addColorStop(0.25,f.data.col); g.addColorStop(1,'#00000055');
+        ctx.fillStyle=g; ctx.beginPath(); ctx.arc(0,0,r,0,Math.PI*2); ctx.fill();
+        if(k==='kiwi'){ // seeds ring
+          ctx.globalAlpha=0.7; ctx.fillStyle='#1f2b15';
+          for(let i=0;i<18;i++){ const a=i*(Math.PI*2/18); ctx.beginPath(); ctx.arc(Math.cos(a)*r*0.55, Math.sin(a)*r*0.55, 1.2, 0, Math.PI*2); ctx.fill(); }
+          ctx.globalAlpha=1;
+        }
+      } else if(k==='lemon'||k==='lime'){
+        const g=ctx.createRadialGradient(-r*0.5,0,r*0.2, 0,0,r*1.1);
+        g.addColorStop(0,'#ffffff66'); g.addColorStop(0.25,f.data.col); g.addColorStop(1,'#00000055');
+        ctx.fillStyle=g; ctx.beginPath(); ctx.moveTo(-r,0); ctx.quadraticCurveTo(0,-r, r,0); ctx.quadraticCurveTo(0,r, -r,0); ctx.fill();
+      } else if(k==='banana'){
+        ctx.fillStyle=f.data.col; ctx.beginPath();
+        ctx.moveTo(-r*1.1,0);
+        ctx.quadraticCurveTo(0,-r*0.9, r*1.2,0.2*r);
+        ctx.quadraticCurveTo(0,r*0.9, -r*1.1,0);
+        ctx.fill();
+      } else if(k==='grape'){
+        for(let i=0;i<7;i++){
+          const ax=((i%3)-1)*r*0.55, ay=(Math.floor(i/3)-0.6)*r*0.6;
+          const rr=r*0.45;
+          const g=ctx.createRadialGradient(ax-rr*0.3,ay-rr*0.4,rr*0.1, ax,ay,rr);
+          g.addColorStop(0,'#ffffff66'); g.addColorStop(0.25,f.data.col); g.addColorStop(1,'#00000055');
+          ctx.fillStyle=g; ctx.beginPath(); ctx.arc(ax,ay,rr,0,Math.PI*2); ctx.fill();
+        }
+      } else if(k==='cherry'){
+        // double cherries
+        const rr=r*0.55;
+        ['L','R'].forEach((side,idx)=>{
+          const dx=idx? rr*0.9 : -rr*0.9, dy=rr*0.2;
+          const g=ctx.createRadialGradient(dx-rr*0.3,dy-rr*0.4,rr*0.1, dx,dy,rr);
+          g.addColorStop(0,'#ffffff66'); g.addColorStop(0.25,f.data.col); g.addColorStop(1,'#00000055');
+          ctx.fillStyle=g; ctx.beginPath(); ctx.arc(dx,dy,rr,0,Math.PI*2); ctx.fill();
+        });
+        // stems
+        ctx.strokeStyle='#2a8f3a'; ctx.lineWidth=2;
+        ctx.beginPath(); ctx.moveTo(-rr*0.9,rr*0.2); ctx.quadraticCurveTo(0,-r*0.8, rr*0.9,rr*0.2); ctx.stroke();
+      } else if(k==='strawberry'){
+        // heart/teardrop
+        ctx.fillStyle=f.data.col; ctx.beginPath();
+        ctx.moveTo(0,r*0.9); ctx.bezierCurveTo(r,-r*0.3, r*0.6,-r, 0,-r*0.7); ctx.bezierCurveTo(-r*0.6,-r, -r,-r*0.3, 0,r*0.9); ctx.fill();
+        // seeds
+        ctx.globalAlpha=0.8; ctx.fillStyle='#ffd67a';
+        for(let i=0;i<16;i++){ const a=i*(Math.PI*2/16); ctx.beginPath(); ctx.ellipse(Math.cos(a)*r*0.45, Math.sin(a)*r*0.3, 1.3,0.9, a,0,Math.PI*2); ctx.fill(); }
+        ctx.globalAlpha=1;
+      } else if(k==='watermelon'){
+        // semi‑circle slice
+        ctx.fillStyle=f.data.col; ctx.beginPath();
+        ctx.moveTo(-r,0); ctx.arc(0,0,r,Math.PI,0); ctx.closePath(); ctx.fill();
+        // rind
+        ctx.fillStyle='#2ecc71'; ctx.beginPath();
+        ctx.moveTo(-r,0); ctx.arc(0,0,r,Math.PI,0); ctx.lineTo(r, r*0.18); ctx.arc(0, r*0.18, r*1.0, 0, Math.PI, true); ctx.closePath(); ctx.fill();
+        // seeds
+        ctx.fillStyle='#2b1b1b';
+        for(let i=0;i<10;i++){ const a=Math.PI + (i/9)*Math.PI; ctx.beginPath(); ctx.ellipse(Math.cos(a)*r*0.6, Math.sin(a)*r*0.5, 1.4, 2.2, a,0,Math.PI*2); ctx.fill(); }
+      } else if(k==='pear'){
+        ctx.fillStyle=f.data.col; ctx.beginPath();
+        ctx.moveTo(0,-r*0.9); ctx.quadraticCurveTo(r*0.9,-r*0.3, r*0.6,r*0.6);
+        ctx.quadraticCurveTo(0,r*1.0, -r*0.6,r*0.6); ctx.quadraticCurveTo(-r*0.9,-r*0.3, 0,-r*0.9); ctx.fill();
+      } else if(k==='pineapple'){
+        // body
+        ctx.fillStyle=f.data.col; ctx.beginPath(); ctx.ellipse(0,0,r*0.9,r*1.1,0,0,Math.PI*2); ctx.fill();
+        // crosshatch
+        ctx.strokeStyle='#c39b34'; ctx.lineWidth=1.5; for(let i=-4;i<=4;i++){ ctx.beginPath(); ctx.moveTo(-r*1.2, i*4); ctx.lineTo(r*1.2, -i*4); ctx.stroke(); ctx.beginPath(); ctx.moveTo(-r*1.2, -i*4); ctx.lineTo(r*1.2, i*4); ctx.stroke(); }
+        // crown
+        ctx.fillStyle='#2ecc71'; ctx.beginPath(); ctx.moveTo(-r*0.3,-r*1.2); ctx.lineTo(0,-r*2.0); ctx.lineTo(r*0.3,-r*1.2); ctx.closePath(); ctx.fill();
+      }
+
+      ctx.restore();
+    }
+
+    function drawBomb(f){
+      const r=f.r;
+      ctx.save(); ctx.translate(f.x,f.y); ctx.rotate(f.rot||0);
+      ctx.fillStyle=BOMB.shell; ctx.beginPath(); ctx.arc(0,0,r,0,Math.PI*2); ctx.fill();
+      ctx.fillStyle='#3a4152'; ctx.beginPath(); ctx.ellipse(0,-r*0.55,r*0.5,r*0.25,0,0,Math.PI*2); ctx.fill();
+      ctx.strokeStyle=BOMB.fuse; ctx.lineWidth=2.5; ctx.beginPath();
+      ctx.moveTo(0,-r*0.8); ctx.quadraticCurveTo(r*0.3,-r*1.2,r*0.6,-r*1.1); ctx.stroke();
+      ctx.restore();
+    }
+
+    // FX helpers
+    function addSlice(x,y){ slices.push({x,y,life:220,r:8}); }
+    function drawSlices(dt){
+      for(let i=slices.length-1;i>=0;i--){
+        const s=slices[i]; s.life-=dt; if(s.life<=0){ slices.splice(i,1); continue; }
+        ctx.fillStyle=`rgba(231,238,252,${Math.max(0,s.life/220)})`;
+        ctx.beginPath(); ctx.arc(s.x,s.y, s.r*(s.life/220), 0, Math.PI*2); ctx.fill();
+      }
+    }
+    function burstJuice(x,y,color){
+      const parts=[];
+      for(let i=0;i<14;i++){ const a=Math.random()*Math.PI*2, sp=rnd(1.5,4); parts.push({x,y,vx:Math.cos(a)*sp,vy:Math.sin(a)*sp,life:420,r:rnd(2,4)}); }
+      splats.push({color, parts});
+    }
+    function drawSplats(dt){
+      for(let i=splats.length-1;i>=0;i--){
+        const s=splats[i];
+        for(let j=s.parts.length-1;j>=0;j--){
+          const p=s.parts[j]; p.life-=dt; if(p.life<=0){ s.parts.splice(j,1); continue; }
+          p.x+=p.vx*(dt*0.04); p.y+=p.vy*(dt*0.04)+0.05;
+          const a=Math.max(0,p.life/420);
+          ctx.fillStyle=hexToRgba(s.color,a); ctx.beginPath(); ctx.arc(p.x,p.y,p.r,0,Math.PI*2); ctx.fill();
+        }
+        if(!s.parts.length) splats.splice(i,1);
+      }
+    }
+    function floatText(x,y,str,col='#d4af37'){ texts.push({x,y,text:str,life:800,col}); }
+    function drawTexts(dt){
+      for(let i=texts.length-1;i>=0;i--){
+        const t=texts[i]; t.life-=dt; if(t.life<=0){ texts.splice(i,1); continue; }
+        const p=1-t.life/800; ctx.fillStyle=`rgba(212,175,55,${1-p})`;
+        ctx.font='bold 18px system-ui'; ctx.textAlign='center'; ctx.fillText(t.text, t.x, t.y - p*28);
+      }
+    }
+    function spawnRing(x,y){
+      smokeRings.push({x,y,t:0,dur:520,max:Math.max(W(),H())*0.12});
+      explosionSound();
+    }
+    function drawRings(dt){
+      for(let i=smokeRings.length-1;i>=0;i--){
+        const e=smokeRings[i]; e.t+=dt; const p=Math.min(1,e.t/e.dur), rr=p*e.max;
+        ctx.strokeStyle=`rgba(255,220,120,${1-p})`; ctx.lineWidth=3;
+        ctx.beginPath(); ctx.arc(e.x,e.y,rr,0,Math.PI*2); ctx.stroke();
+        if(p>=1) smokeRings.splice(i,1);
+      }
+    }
+
+    // Halves (generic split wedges so every fruit can split & vanish)
+    function spawnHalves(f, ang){
+      const nx=Math.cos(ang+Math.PI/2), ny=Math.sin(ang+Math.PI/2);
+      const vK=1.8, r=f.r;
+      halves.push({k:f.data.k,col:f.data.col,x:f.x-nx*4,y:f.y-ny*4,vx:f.vx-nx*vK,vy:f.vy-ny*vK,ay:f.ay,r,rot:f.rot-0.2,spin:f.spin-0.04,life:650});
+      halves.push({k:f.data.k,col:f.data.col,x:f.x+nx*4,y:f.y+ny*4,vx:f.vx+nx*vK,vy:f.vy+ny*vK,ay:f.ay,r,rot:f.rot+0.2,spin:f.spin+0.04,life:650});
+    }
+    function drawHalf(h){
+      const r=h.r;
+      ctx.save(); ctx.translate(h.x,h.y); ctx.rotate(h.rot||0);
+      // clip wedge
+      ctx.save();
+      ctx.beginPath(); ctx.moveTo(0,0); ctx.arc(0,0,r,-Math.PI*0.1,Math.PI*1.1); ctx.closePath(); ctx.clip();
+      const g=ctx.createRadialGradient(-r*0.3,-r*0.5,r*0.1,0,0,r);
+      g.addColorStop(0,'#ffffff66'); g.addColorStop(0.25,h.col); g.addColorStop(1,'#00000055');
+      ctx.fillStyle=g; ctx.beginPath(); ctx.arc(0,0,r,0,Math.PI*2); ctx.fill();
+      ctx.restore();
+      // cut edge
+      ctx.strokeStyle='rgba(255,255,255,.35)'; ctx.lineWidth=2;
+      ctx.beginPath(); ctx.arc(0,0,r,-Math.PI*0.1,Math.PI*1.1); ctx.stroke();
+      ctx.restore();
+    }
+
+    // Collision segment-circle
+    function segHit(x1,y1,x2,y2,cx,cy,r){
+      const dx=x2-x1, dy=y2-y1, fx=x1-cx, fy=y1-cy;
+      const a=dx*dx+dy*dy, b=2*(fx*dx+fy*dy), c=fx*fx+fy*fy-r*r;
+      let d=b*b-4*a*c; if(d<0) return false; d=Math.sqrt(d);
+      const t1=(-b-d)/(2*a), t2=(-b+d)/(2*a); return (t1>=0&&t1<=1)||(t2>=0&&t2<=1);
+    }
+
+    // Input
+    if(isUser){
+      ['pointerdown','touchstart','mousedown'].forEach(ev=>canvas.addEventListener(ev,()=>{ensureAudio();},{once:true}));
+      canvas.addEventListener('pointerdown',e=>{
+        game.dragging=true;
+        const r=canvas.getBoundingClientRect(); game.lastPt={x:e.clientX-r.left, y:e.clientY-r.top};
+      });
+      canvas.addEventListener('pointermove',e=>{
+        if(!game.dragging) return;
+        const r=canvas.getBoundingClientRect(); const x=e.clientX-r.left, y=e.clientY-r.top;
+        const lp=game.lastPt; if(!lp){ game.lastPt={x,y}; return; }
+        addSlice(x,y);
+        const ang=Math.atan2(y-lp.y,x-lp.x);
+        for(const f of fruits){
+          if(f._gone) continue;
+          if(segHit(lp.x,lp.y,x,y,f.x,f.y,f.r*0.9)){
+            f._gone=true; // VANISH
+            if(f.type==='bomb'){ spawnRing(f.x,f.y); /* bombs just explode & vanish */ }
+            else { pop(900+Math.random()*200,0.07,0.22); burstJuice(f.x,f.y,f.data.juice); spawnHalves(f, ang); game.score+=f.data.score; }
+          }
+        }
+        game.lastPt={x,y};
+      });
+      canvas.addEventListener('pointerup',()=>{ game.dragging=false; game.lastPt=null; });
+      canvas.addEventListener('pointercancel',()=>{ game.dragging=false; game.lastPt=null; });
+    }
+
+    // AI (human pace)
+    function aiThink(now){
+      if(isUser || now<game.nextAi) return;
+      const cands=fruits.filter(f=>!f._gone && f.type==='fruit' && f.y>H()*0.15 && f.y<H()*0.85);
+      if(!cands.length){ game.nextAi=now+350; return; }
+      cands.sort((a,b)=>Math.abs(a.vy)-Math.abs(b.vy));
+      const t=cands[0];
+      const len=Math.max(80,Math.min(W(),H())*0.25);
+      const ang=Math.atan2(t.vy,t.vx)+(Math.random()*0.6-0.3);
+      const x1=t.x-Math.cos(ang)*len*0.5, y1=t.y-Math.sin(ang)*len*0.5;
+      const x2=t.x+Math.cos(ang)*len*0.5, y2=t.y+Math.sin(ang)*len*0.5;
+      for(const f of fruits){
+        if(f._gone) continue;
+        if(segHit(x1,y1,x2,y2,f.x,f.y,f.r*0.9)){
+          f._gone=true;
+          if(f.type!=='bomb'){ spawnHalves(f, ang); game.score+=f.data.score; }
+        }
+      }
+      game.nextAi=now+1000+Math.random()*600;
+    }
+
+    // Update/Draw
+    function update(dt){
+      spawnAcc+=dt; if(spawnAcc>spawnNext){ spawnAcc=0; spawnWave(); }
+      for(let i=fruits.length-1;i>=0;i--){
+        const f=fruits[i];
+        f.vy+=f.ay*(dt*0.01); f.x+=f.vx*(dt*0.06); f.y+=f.vy*(dt*0.06); f.rot+=f.spin*(dt*0.06);
+        if(f._gone || f.y>H()+60) fruits.splice(i,1);
+      }
+      for(let i=halves.length-1;i>=0;i--){
+        const h=halves[i]; h.life-=dt; if(h.life<=0 || h.y>H()+60){ halves.splice(i,1); continue; }
+        h.vy+=h.ay*(dt*0.01); h.x+=h.vx*(dt*0.06); h.y+=h.vy*(dt*0.06); h.rot+=h.spin*(dt*0.06);
+      }
+    }
+    function draw(){
+      ctx.clearRect(0,0,W(),H());
+      // subtle grid bg
+      ctx.strokeStyle='#162047'; ctx.lineWidth=1; ctx.globalAlpha=0.25;
+      for(let x=0;x<W();x+=24){ ctx.beginPath(); ctx.moveTo(x,0); ctx.lineTo(x,H()); ctx.stroke(); }
+      for(let y=0;y<H();y+=24){ ctx.beginPath(); ctx.moveTo(0,y); ctx.lineTo(W(),y); ctx.stroke(); }
+      ctx.globalAlpha=1;
+
+      for(const f of fruits){ f.type==='bomb'?drawBomb(f):drawFruit(f); }
+      for(const h of halves){ drawHalf(h); }
+
+      // FX
+      // juice
+      for(let i=splats.length-1;i>=0;i--){
+        const s=splats[i];
+        for(let j=s.parts.length-1;j>=0;j--){
+          const p=s.parts[j]; p.life-=16; if(p.life<=0){ s.parts.splice(j,1); continue; }
+          p.x+=p.vx*(16*0.04); p.y+=p.vy*(16*0.04)+0.05;
+          const a=Math.max(0,p.life/420);
+          ctx.fillStyle=hexToRgba(s.color,a); ctx.beginPath(); ctx.arc(p.x,p.y,p.r,0,Math.PI*2); ctx.fill();
+        }
+        if(!s.parts.length) splats.splice(i,1);
+      }
+      // rings
+      for(let i=smokeRings.length-1;i>=0;i--){
+        const e=smokeRings[i]; e.t+=16; const p=Math.min(1,e.t/e.dur), rr=p*e.max;
+        ctx.strokeStyle=`rgba(255,220,120,${1-p})`; ctx.lineWidth=3; ctx.beginPath(); ctx.arc(e.x,e.y,rr,0,Math.PI*2); ctx.stroke();
+        if(p>=1) smokeRings.splice(i,1);
+      }
+      // swipe + texts
+      for(let i=slices.length-1;i>=0;i--){
+        const s=slices[i]; s.life-=16; if(s.life<=0){ slices.splice(i,1); continue; }
+        ctx.fillStyle=`rgba(231,238,252,${Math.max(0,s.life/220)})`; ctx.beginPath(); ctx.arc(s.x,s.y, s.r*(s.life/220), 0, Math.PI*2); ctx.fill();
+      }
+      for(let i=texts.length-1;i>=0;i--){
+        const t=texts[i]; t.life-=16; if(t.life<=0){ texts.splice(i,1); continue; }
+        const p=1-t.life/800; ctx.fillStyle=`rgba(212,175,55,${1-p})`; ctx.font='bold 18px system-ui'; ctx.textAlign='center'; ctx.fillText(t.text, t.x, t.y - p*28);
+      }
+    }
+
+    return {update, draw, aiThink, get score(){return game.score;}};
+  }
+
+  // Orchestrator
+  const games=[]; let raf=null, running=false, endAt=0, last=performance.now();
+  function layout(){ Object.values(canvases).forEach(c=>{ if(c) fitCanvas(c); }); }
+  const fmt=s=>{ const m=String((s/60)|0).padStart(2,'0'); const ss=String(Math.max(0,s%60)).padStart(2,'0'); return `${m}:${ss}`; };
+
+  function startMatch(){
+    layout();
+    const n=Math.max(2,Math.min(4,parseInt($('#players').value,10)||4));
+    const stake=Math.max(0,parseInt($('#stake').value||'0',10));
+    const durSec=Math.max(10,parseInt($('#duration').value,10)||180);
+    $('#pot').textContent=String(stake*n);
+    $('#time').textContent=fmt(durSec);
+
+    games.length=0;
+    const opp=[$('#opp1'),$('#opp2'),$('#opp3')];
+    for(let i=0;i<n-1;i++) games.push(createGame(opp[i],false));
+    games.push(createGame($('#user'),true));
+
+    endAt=performance.now()+durSec*1000;
+    running=true; last=performance.now(); loop();
+  }
+
+  function updateTimer(){
+    const remain=Math.max(0,Math.ceil((endAt-performance.now())/1000));
+    $('#time').textContent=fmt(remain);
+    if(remain<=0) finish();
+  }
+  function loop(){
+    if(!running) return;
+    const now=performance.now(), dt=now-last; last=now;
+    for(const g of games){ g.update(dt); g.draw(); g.aiThink(now); }
+    $('#myscore').textContent=String(games[games.length-1].score);
+    updateTimer(); raf=requestAnimationFrame(loop);
+  }
+  function finish(){
+    if(!running) return; running=false; if(raf) cancelAnimationFrame(raf);
+    const n=games.length; const stake=Math.max(0,parseInt($('#stake').value||'0',10));
+    const gross=stake*n; const fee=Math.round(gross*0.10); const net=gross-fee;
+    const scores=games.map((g,i)=>({i,score:g.score}));
+    const max=Math.max(...scores.map(s=>s.score));
+    const winners=scores.filter(s=>s.score===max);
+    const payout=winners.length?Math.floor(net/winners.length):0;
+
+    $('#winner').textContent = winners.length>1 ? `Tie (${winners.map(w=>'P'+(w.i+1)).join(', ')})` : `P${winners[0].i+1}`;
+    $('#payout').textContent=String(payout); $('#fee').textContent=String(fee); $('#potFinal').textContent=String(net);
+    $('#scoreList').innerHTML = scores.sort((a,b)=>b.score-a.score).map(s=>`<div class="kpi"><div class="v">P${s.i+1}: ${s.score}</div><div>—</div></div>`).join('');
+    if(!$('#results').open) $('#results').showModal();
+  }
+
+  // Bindings
+  $('#start').addEventListener('click', startMatch);
+  $('#rematch').addEventListener('click', ()=>{ $('#results').close(); startMatch(); });
+  $('#change').addEventListener('click', ()=>{ $('#results').close(); location.href='/games/fruitsliceroyale/lobby'; });
+  $('#mute').addEventListener('click', ()=>{ muted=!muted; $('#mute').textContent=muted?'🔇':'🔊'; if(!muted) ensureAudio(); });
+
+  window.addEventListener('resize', layout);
+  layout();
+})();
+</script>
+</body>
+</html>

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -31,6 +31,8 @@ import BrickBreaker from './pages/Games/BrickBreaker.jsx';
 import BrickBreakerLobby from './pages/Games/BrickBreakerLobby.jsx';
 import TetrisRoyale from './pages/Games/TetrisRoyale.jsx';
 import TetrisRoyaleLobby from './pages/Games/TetrisRoyaleLobby.jsx';
+import FruitSliceRoyale from './pages/Games/FruitSliceRoyale.jsx';
+import FruitSliceRoyaleLobby from './pages/Games/FruitSliceRoyaleLobby.jsx';
 import BubblePopRoyale from './pages/Games/BubblePopRoyale.jsx';
 import BubblePopRoyaleLobby from './pages/Games/BubblePopRoyaleLobby.jsx';
 import BubbleSmashRoyale from './pages/Games/BubbleSmashRoyale.jsx';
@@ -69,6 +71,8 @@ export default function App() {
             <Route path="/games/brickbreaker" element={<BrickBreaker />} />
             <Route path="/games/tetrisroyale/lobby" element={<TetrisRoyaleLobby />} />
             <Route path="/games/tetrisroyale" element={<TetrisRoyale />} />
+            <Route path="/games/fruitsliceroyale/lobby" element={<FruitSliceRoyaleLobby />} />
+            <Route path="/games/fruitsliceroyale" element={<FruitSliceRoyale />} />
             <Route path="/games/bubblepoproyale/lobby" element={<BubblePopRoyaleLobby />} />
             <Route path="/games/bubblepoproyale" element={<BubblePopRoyale />} />
             <Route path="/games/bubblesmashroyale/lobby" element={<BubbleSmashRoyaleLobby />} />

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -49,6 +49,13 @@ export default function HomeGamesCard() {
             <h3 className="text-sm font-semibold text-center">Brick Breaker Royale</h3>
           </Link>
           <Link
+            to="/games/fruitsliceroyale/lobby"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+          >
+            <img src="/assets/icons/fruit_slice.svg" alt="" className="h-20 w-20" />
+            <h3 className="text-sm font-semibold text-center">Fruit Slice Royale</h3>
+          </Link>
+          <Link
             to="/games/bubblepoproyale/lobby"
             className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
           >

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -69,6 +69,11 @@ export default function InvitePopup({
                     alt: 'Brick Breaker Royale',
                   },
                   {
+                    id: 'fruitsliceroyale',
+                    src: '/assets/icons/fruit_slice.svg',
+                    alt: 'Fruit Slice Royale',
+                  },
+                  {
                     id: 'bubblepoproyale',
                     src: '/assets/icons/bubble_pop.svg',
                     alt: 'Bubble Pop Royale',

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -171,6 +171,11 @@ export default function PlayerInvitePopup({
                   alt: 'Brick Breaker Royale',
                 },
                 {
+                  id: 'fruitsliceroyale',
+                  src: '/assets/icons/fruit_slice.svg',
+                  alt: 'Fruit Slice Royale',
+                },
+                {
                   id: 'bubblepoproyale',
                   src: '/assets/icons/bubble_pop.svg',
                   alt: 'Bubble Pop Royale',

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -46,6 +46,13 @@ export default function Games() {
                 <h3 className="text-sm font-semibold text-center">Brick Breaker Royale</h3>
               </Link>
               <Link
+                to="/games/fruitsliceroyale/lobby"
+                className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+              >
+                <img src="/assets/icons/fruit_slice.svg" alt="" className="h-20 w-20" />
+                <h3 className="text-sm font-semibold text-center">Fruit Slice Royale</h3>
+              </Link>
+              <Link
                 to="/games/bubblepoproyale/lobby"
                 className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
               >

--- a/webapp/src/pages/Games/FruitSliceRoyale.jsx
+++ b/webapp/src/pages/Games/FruitSliceRoyale.jsx
@@ -1,0 +1,14 @@
+import { useLocation } from 'react-router-dom';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+
+export default function FruitSliceRoyale() {
+  useTelegramBackButton();
+  const { search } = useLocation();
+  return (
+    <iframe
+      src={`/fruit-slice-royale.html${search}`}
+      title="Fruit Slice Royale"
+      className="w-full h-[100dvh] border-0"
+    />
+  );
+}

--- a/webapp/src/pages/Games/FruitSliceRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/FruitSliceRoyaleLobby.jsx
@@ -1,0 +1,125 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { ensureAccountId, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+
+const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
+const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
+const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
+
+export default function FruitSliceRoyaleLobby() {
+  const navigate = useNavigate();
+  useTelegramBackButton();
+
+  const [players, setPlayers] = useState(2);
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [mode, setMode] = useState('local');
+  const [duration, setDuration] = useState(1);
+  const [avatar, setAvatar] = useState('');
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  const startGame = async () => {
+    let tgId;
+    let accountId;
+    try {
+      accountId = await ensureAccountId();
+      const balRes = await getAccountBalance(accountId);
+      if ((balRes.balance || 0) < stake.amount) {
+        alert('Insufficient balance');
+        return;
+      }
+      tgId = getTelegramId();
+      await addTransaction(tgId, -stake.amount, 'stake', {
+        game: 'fruitslice',
+        players,
+        accountId,
+      });
+    } catch {}
+
+    const params = new URLSearchParams();
+    params.set('players', players);
+    params.set('mode', mode);
+    params.set('duration', duration * 60);
+    const initData = window.Telegram?.WebApp?.initData;
+    if (stake.token) params.set('token', stake.token);
+    if (stake.amount) params.set('amount', stake.amount);
+    if (avatar) params.set('avatar', avatar);
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    if (DEV_ACCOUNT) params.set('dev', DEV_ACCOUNT);
+    if (DEV_ACCOUNT_1) params.set('dev1', DEV_ACCOUNT_1);
+    if (DEV_ACCOUNT_2) params.set('dev2', DEV_ACCOUNT_2);
+    if (initData) params.set('init', encodeURIComponent(initData));
+    navigate(`/games/fruitsliceroyale?${params.toString()}`);
+  };
+
+  return (
+    <div className="relative p-4 space-y-4 text-text">
+      <h2 className="text-xl font-bold text-center">Fruit Slice Royale Lobby</h2>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Players</h3>
+        <div className="flex gap-2 flex-wrap">
+          {[2,3,4].map((n) => (
+            <button
+              key={n}
+              onClick={() => setPlayers(n)}
+              className={`lobby-tile ${players === n ? 'lobby-selected' : ''}`}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Stake</h3>
+        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Mode</h3>
+        <div className="flex gap-2">
+          {[
+            { id: 'local', label: 'Local (AI)' },
+            { id: 'online', label: 'Online' }
+          ].map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setMode(id)}
+              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Duration (minutes)</h3>
+        <div className="flex gap-2">
+          {[1,3,5].map((m) => (
+            <button
+              key={m}
+              onClick={() => setDuration(m)}
+              className={`lobby-tile ${duration === m ? 'lobby-selected' : ''}`}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+      </div>
+      <button
+        onClick={startGame}
+        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
+      >
+        START
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Fruit Slice Royale HTML game implementation
- wire Fruit Slice Royale lobby and game routes
- expose Fruit Slice Royale in game selectors and home listings

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b3f26785c8329a66e6fd863b587c1