### PR TITLE
Configure Render env vars from secrets

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,9 @@ services:
     startCommand: npm start
     envVars:
       - key: MONGO_URI
-        value: mongodb://localhost:27017/tonplaygram
+        fromSecret: MONGO_URI
+      - key: BOT_TOKEN
+        fromSecret: BOT_TOKEN
 
   - type: web
     runtime: static


### PR DESCRIPTION
## Summary
- Configure Render web service to read `MONGO_URI` and `BOT_TOKEN` from secrets instead of hard-coding values

## Testing
- `npm test` *(hangs after tests complete; see log)*


------
https://chatgpt.com/codex/tasks/task_e_689b6396f3c883298b60365dc71c3d7b