### PR TITLE
feat: add shadow to active tetris pieces

### DIFF
--- a/webapp/public/tetris-royale.html
+++ b/webapp/public/tetris-royale.html
@@ -311,11 +311,17 @@ window.__TETRIS_ROYALE__ = true;
         }
       }
       ctx.globalAlpha = 1;
+      ctx.shadowColor = 'rgba(0,0,0,0.25)';
+      ctx.shadowBlur = 4;
+      ctx.shadowOffsetY = 2;
       for(let y=0;y<piece.length;y++){
         for(let x=0;x<piece[y].length;x++){
           if(piece[y][x]) ctx.fillRect((pos.x+x)*bw, (pos.y+y)*bh, bw-1, bh-1);
         }
       }
+      ctx.shadowColor = 'rgba(0,0,0,0)';
+      ctx.shadowBlur = 0;
+      ctx.shadowOffsetY = 0;
     }
   }
   function createGame(canvas){


### PR DESCRIPTION
## Summary
- add shadow style to active blocks in Tetris Royale board and reset context

## Testing
- `npm test` (incomplete; appears to run but lacks final summary, see logs)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b764309c48329963071bc82c1b3d7