### PR TITLE
style: highlight tetris buttons

### DIFF
--- a/webapp/public/tetris-royale.html
+++ b/webapp/public/tetris-royale.html
@@ -15,7 +15,8 @@
   .controls{display:grid;grid-template-columns:1fr 1fr 1fr auto;gap:8px}
   label{font-size:12px;color:var(--muted);display:block;margin-bottom:6px}
   select,button,input{width:100%;padding:10px 12px;border-radius:10px;border:1px solid #223063;background:#0e1430;color:#e7eefc}
-  .btn{background:linear-gradient(180deg,#2a6cf0,#2156c8);border:none;font-weight:700;cursor:pointer}
+  .btn{position:relative;background:linear-gradient(180deg,#5aa2ff,#2563eb);border:none;font-weight:700;cursor:pointer}
+  .btn::after{content:'';position:absolute;inset:2px 2px auto 2px;height:40%;border-radius:inherit;background:linear-gradient(180deg,#fff6,transparent);pointer-events:none}
   .hud{display:flex;gap:8px}
   .panel{border:1px solid #223063;background:#0b1228;border-radius:12px;padding:10px;display:flex;align-items:center;justify-content:space-between}
   .score{color:var(--gold);font-weight:800}


### PR DESCRIPTION
## Summary
- add top highlight pseudo-element to `.btn` in Tetris Royale
- adjust button gradient to tetromino blue and make it positioned for overlay

## Testing
- `npm test` *(partially ran; produced subtest logs)*

------
https://chatgpt.com/codex/tasks/task_e_689b76454da8832992574ca4f48e4eae