### PR TITLE
Add exit confirmation for game back button

### DIFF
--- a/webapp/src/components/ConfirmPopup.jsx
+++ b/webapp/src/components/ConfirmPopup.jsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
 
-export default function ConfirmPopup({ open, message, onConfirm, onCancel }) {
+export default function ConfirmPopup({
+  open,
+  message,
+  onConfirm,
+  onCancel,
+  confirmLabel = 'Yes',
+  cancelLabel = 'No',
+}) {
   if (!open) return null;
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
@@ -13,14 +20,14 @@ export default function ConfirmPopup({ open, message, onConfirm, onCancel }) {
             onClick={onConfirm}
             className="flex-1 lobby-tile text-sm cursor-pointer"
           >
-            Yes
+            {confirmLabel}
           </button>
           <button
             type="button"
             onClick={onCancel}
             className="flex-1 lobby-tile text-sm cursor-pointer"
           >
-            No
+            {cancelLabel}
           </button>
         </div>
       </div>

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -948,9 +948,11 @@ export default function CrazyDiceDuel() {
       />
       <ConfirmPopup
         open={showLobbyConfirm}
-        message="Quit the game? If you leave, your funds will be lost and you'll be placed last."
+        message="Your funds will be lost if you quit the game."
+        confirmLabel="Return to Lobby"
+        cancelLabel="Games"
         onConfirm={() => navigate('/games/crazydice/lobby')}
-        onCancel={() => setShowLobbyConfirm(false)}
+        onCancel={() => navigate('/games')}
       />
       </div>
     </div>

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -524,7 +524,7 @@ function Board({
 export default function SnakeAndLadder() {
   const [showLobbyConfirm, setShowLobbyConfirm] = useState(false);
   const [showQuitInfo, setShowQuitInfo] = useState(true);
-  useTelegramBackButton();
+  useTelegramBackButton(() => setShowLobbyConfirm(true));
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -2566,12 +2566,17 @@ export default function SnakeAndLadder() {
       {!watchOnly && (
       <ConfirmPopup
         open={showLobbyConfirm}
-        message="Quit the game? If you leave, your funds will be lost and you'll be placed last."
+        message="Your funds will be lost if you quit the game."
+        confirmLabel="Return to Lobby"
+        cancelLabel="Games"
         onConfirm={() => {
           localStorage.removeItem(`snakeGameState_${ai}`);
           navigate("/games/snake/lobby");
         }}
-        onCancel={() => setShowLobbyConfirm(false)}
+        onCancel={() => {
+          localStorage.removeItem(`snakeGameState_${ai}`);
+          navigate("/games");
+        }}
       />
       )}
     </div>


### PR DESCRIPTION
## Summary
- support custom labels in `ConfirmPopup`
- show exit confirmation when leaving Snake and Ladder or Crazy Dice Duel via back button

## Testing
- `npm test` (webapp) *(fails: Missing script "test")*
- `npm test --ignore-scripts`


------
https://chatgpt.com/codex/tasks/task_e_689b863527d48329b9248a2d1e9ecd15