### PR TITLE
docs: map routes and stub realtime layer

### DIFF
--- a/docs/ROUTES.md
+++ b/docs/ROUTES.md
@@ -1,0 +1,69 @@
+# Route Audit
+
+## Frontend Routes
+
+| Route | Component/Module | Params | Sample URL |
+|-------|------------------|--------|------------|
+| `/` | `Home` | – | `https://host/` |
+| `/mining` | `Mining` | – | `https://host/mining` |
+| `/games` | `Games` | – | `https://host/games` |
+| `/games/crazydice` | `CrazyDiceDuel` | – | `https://host/games/crazydice` |
+| `/games/crazydice/lobby` | `CrazyDiceLobby` | – | `https://host/games/crazydice/lobby` |
+| `/games/:game/lobby` | `Lobby` | `game` | `https://host/games/snake/lobby` |
+| `/games/horse` | `HorseRacing` | – | `https://host/games/horse` |
+| `/games/snake` | `SnakeAndLadder` | – | `https://host/games/snake` |
+| `/games/snake/mp` | `SnakeMultiplayer` | – | `https://host/games/snake/mp` |
+| `/games/snake/results` | `SnakeResults` | – | `https://host/games/snake/results` |
+| `/games/fallingball/lobby` | `FallingBallLobby` | – | `https://host/games/fallingball/lobby` |
+| `/games/fallingball` | `FallingBall` | – | `https://host/games/fallingball` |
+| `/games/airhockey/lobby` | `AirHockeyLobby` | – | `https://host/games/airhockey/lobby` |
+| `/games/airhockey` | `AirHockey` | – | `https://host/games/airhockey` |
+| `/games/brickbreaker/lobby` | `BrickBreakerLobby` | – | `https://host/games/brickbreaker/lobby` |
+| `/games/brickbreaker` | `BrickBreaker` | – | `https://host/games/brickbreaker` |
+| `/games/tetrisroyale/lobby` | `TetrisRoyaleLobby` | – | `https://host/games/tetrisroyale/lobby` |
+| `/games/tetrisroyale` | `TetrisRoyale` | – | `https://host/games/tetrisroyale` |
+| `/games/fruitsliceroyale/lobby` | `FruitSliceRoyaleLobby` | – | `https://host/games/fruitsliceroyale/lobby` |
+| `/games/fruitsliceroyale` | `FruitSliceRoyale` | – | `https://host/games/fruitsliceroyale` |
+| `/games/bubblepoproyale/lobby` | `BubblePopRoyaleLobby` | – | `https://host/games/bubblepoproyale/lobby` |
+| `/games/bubblepoproyale` | `BubblePopRoyale` | – | `https://host/games/bubblepoproyale` |
+| `/games/bubblesmashroyale/lobby` | `BubbleSmashRoyaleLobby` | – | `https://host/games/bubblesmashroyale/lobby` |
+| `/games/bubblesmashroyale` | `BubbleSmashRoyale` | – | `https://host/games/bubblesmashroyale` |
+| `/spin` | `SpinPage` | – | `https://host/spin` |
+| `/admin/influencer` | `InfluencerAdmin` | – | `https://host/admin/influencer` |
+| `/tasks` | `Tasks` | – | `https://host/tasks` |
+| `/store` | `Store` | – | `https://host/store` |
+| `/referral` | `Referral` | – | `https://host/referral` |
+| `/wallet` | `Wallet` | – | `https://host/wallet` |
+| `/messages` | `Messages` | – | `https://host/messages` |
+| `/notifications` | `Notifications` | – | `https://host/notifications` |
+| `/trending` | `Trending` | – | `https://host/trending` |
+| `/account` | `MyAccount` | – | `https://host/account` |
+
+## Backend API Routes (bot/server.js)
+
+| Route | Method | Module | Params | Sample URL |
+|-------|--------|--------|--------|------------|
+| `/api/ping` | GET | `bot/server.js` | – | `https://host/api/ping` |
+| `/api/stats` | GET | `bot/server.js` | – | `https://host/api/stats` |
+| `/api/snake/lobbies` | GET | `bot/server.js` | – | `https://host/api/snake/lobbies` |
+| `/api/snake/lobby/:id` | GET | `bot/server.js` | `id` | `https://host/api/snake/lobby/123` |
+| `/api/snake/board/:id` | GET | `bot/server.js` | `id` | `https://host/api/snake/board/123` |
+| `/api/watchers/count/:id` | GET | `bot/server.js` | `id` | `https://host/api/watchers/count/123` |
+| `/api/ludo/lobbies` | GET | `bot/server.js` | – | `https://host/api/ludo/lobbies` |
+| `/api/ludo/lobby/:id` | GET | `bot/server.js` | `id` | `https://host/api/ludo/lobby/123` |
+| `/api/checkers/lobbies` | GET | `bot/server.js` | – | `https://host/api/checkers/lobbies` |
+| `/api/checkers/lobby/:id` | GET | `bot/server.js` | `id` | `https://host/api/checkers/lobby/123` |
+| `/api/checkers/board/:id` | GET | `bot/server.js` | `id` | `https://host/api/checkers/board/123` |
+| `/api/snake/table/seat` | POST | `bot/server.js` | body `{accountId, gameType, stake, maxPlayers}` | `https://host/api/snake/table/seat` |
+| `/api/snake/table/unseat` | POST | `bot/server.js` | body `{accountId, tableId}` | `https://host/api/snake/table/unseat` |
+| `/api/snake/invite` | POST | `bot/server.js` | body `{fromAccount, toAccount, roomId, token, amount}` | `https://host/api/snake/invite` |
+| `/api/snake/results` | GET | `bot/server.js` | query `leaderboard?` | `https://host/api/snake/results` |
+| `*` | GET | `bot/server.js` | – | catch-all |
+
+## Invite URL Builders
+
+- `Layout.jsx` constructs invite links with a fallback to `snake` if `invite.game` is missing.
+- `bot/utils/notifications.js#getInviteUrl` builds invite URLs and defaults the `game` parameter to `snake`.
+
+These defaults are potential sources of `gameId` ambiguity.
+

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "refund-withdrawals": "node bot/scripts/refundPendingWithdrawals.js",
     "reset-tpc-balances": "node bot/scripts/resetTPCBalances.js",
     "reset-db": "node bot/scripts/resetDatabase.js",
-    "dev": "concurrently -k \"npm --prefix webapp run dev\" \"node bot/server.js\""
+    "dev": "concurrently -k \"npm --prefix webapp run dev\" \"node bot/server.js\"",
+    "realtime": "node realtime/server.js"
   },
   "engines": {
     "node": ">=18"

--- a/realtime/RoomService.js
+++ b/realtime/RoomService.js
@@ -1,0 +1,76 @@
+import { randomUUID } from 'crypto';
+
+export const RoomState = {
+  LOBBY: 'lobby',
+  READY: 'ready-check',
+  IN_GAME: 'in-game',
+  FINISHED: 'finished'
+};
+
+export class RoomService {
+  constructor(games = {}) {
+    this.games = games;
+    this.rooms = new Map();
+  }
+
+  create(slug, opts = {}) {
+    const game = this.games[slug];
+    if (!game) throw new Error('unknown game');
+    const room = {
+      id: randomUUID(),
+      slug,
+      state: RoomState.LOBBY,
+      maxPlayers: opts.maxPlayers || game.maxPlayers || 2,
+      players: new Map(),
+      ready: new Set(),
+      createdAt: Date.now(),
+      data: game.createState ? game.createState(opts) : {}
+    };
+    this.rooms.set(room.id, room);
+    return room;
+  }
+
+  join(roomId, playerId) {
+    const room = this.rooms.get(roomId);
+    if (!room || room.players.size >= room.maxPlayers) return null;
+    room.players.set(playerId, { id: playerId, connected: true });
+    return this.snapshot(room);
+  }
+
+  leave(roomId, playerId) {
+    const room = this.rooms.get(roomId);
+    if (!room) return;
+    room.players.delete(playerId);
+    room.ready.delete(playerId);
+    if (room.players.size === 0) this.rooms.delete(roomId);
+  }
+
+  ready(roomId, playerId) {
+    const room = this.rooms.get(roomId);
+    if (!room) return null;
+    room.ready.add(playerId);
+    if (room.ready.size === room.players.size && room.players.size > 0) {
+      room.state = RoomState.IN_GAME;
+      room.startTime = Date.now();
+    }
+    return this.snapshot(room);
+  }
+
+  input(roomId, playerId, payload) {
+    const room = this.rooms.get(roomId);
+    if (!room) return;
+    const game = this.games[room.slug];
+    if (room.state === RoomState.IN_GAME && game && game.onInput) {
+      game.onInput(room, playerId, payload);
+    }
+  }
+
+  snapshot(room) {
+    return {
+      id: room.id,
+      state: room.state,
+      players: Array.from(room.players.keys()),
+      ready: Array.from(room.ready)
+    };
+  }
+}

--- a/realtime/games/crazydice.js
+++ b/realtime/games/crazydice.js
@@ -1,0 +1,12 @@
+export const maxPlayers = 2;
+
+export function createState() {
+  return { rolls: {} };
+}
+
+export function onInput(room, playerId, _payload) {
+  const value = Math.floor(Math.random() * 6) + 1;
+  const arr = room.data.rolls[playerId] || [];
+  arr.push(value);
+  room.data.rolls[playerId] = arr;
+}

--- a/realtime/games/snake.js
+++ b/realtime/games/snake.js
@@ -1,0 +1,9 @@
+export const maxPlayers = 4;
+
+export function createState() {
+  return { scores: {} };
+}
+
+export function onInput(room, playerId, _payload) {
+  room.data.scores[playerId] = (room.data.scores[playerId] || 0) + 1;
+}

--- a/realtime/linkGuard.js
+++ b/realtime/linkGuard.js
@@ -1,0 +1,13 @@
+const VALID_SLUGS = new Set(['snake', 'crazydice']);
+
+export function linkGuard(req, res, next) {
+  const { slug } = req.params;
+  if (!VALID_SLUGS.has(slug)) {
+    return res.status(404).send('Unknown game');
+  }
+  next();
+}
+
+export function isValidSlug(slug) {
+  return VALID_SLUGS.has(slug);
+}

--- a/realtime/server.js
+++ b/realtime/server.js
@@ -1,0 +1,80 @@
+import express from 'express';
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+import { RoomService } from './RoomService.js';
+import { linkGuard, isValidSlug } from './linkGuard.js';
+import * as snake from './games/snake.js';
+import * as crazydice from './games/crazydice.js';
+
+const games = {
+  snake,
+  crazydice
+};
+
+const roomService = new RoomService(games);
+
+const app = express();
+app.use(express.json());
+
+// canonical routing guard
+app.use('/games/:slug', linkGuard, (req, res) => res.send('OK'));
+
+app.get('/healthz', (_req, res) => res.json({ ok: true }));
+app.get('/readyz', (_req, res) => res.json({ ok: true }));
+
+const httpServer = createServer(app);
+const io = new Server(httpServer, {
+  path: process.env.SOCKET_PATH || '/realtime'
+});
+
+io.of(/^\/rt\/\w+$/).on('connection', (socket) => {
+  const slug = socket.nsp.name.split('/').pop();
+  if (!isValidSlug(slug)) {
+    socket.disconnect(true);
+    return;
+  }
+
+  socket.on('room:create', (opts, cb) => {
+    try {
+      const room = roomService.create(slug, opts);
+      cb && cb({ success: true, roomId: room.id });
+    } catch (err) {
+      cb && cb({ success: false, error: err.message });
+    }
+  });
+
+  socket.on('room:join', ({ roomId, playerId }, cb) => {
+    const state = roomService.join(roomId, playerId);
+    if (!state) return cb && cb({ success: false });
+    socket.join(roomId);
+    cb && cb({ success: true, state });
+    socket.to(roomId).emit('room:state', state);
+  });
+
+  socket.on('room:ready', ({ roomId, playerId }) => {
+    const state = roomService.ready(roomId, playerId);
+    if (state) io.to(roomId).emit('room:state', state);
+  });
+
+  socket.on('room:leave', ({ roomId, playerId }) => {
+    roomService.leave(roomId, playerId);
+    socket.leave(roomId);
+    const room = roomService.rooms.get(roomId);
+    if (room) io.to(roomId).emit('room:state', roomService.snapshot(room));
+  });
+
+  socket.on('input', ({ roomId, playerId, data }) => {
+    roomService.input(roomId, playerId, data);
+    const room = roomService.rooms.get(roomId);
+    if (room) io.to(roomId).emit('room:state', roomService.snapshot(room));
+  });
+});
+
+const PORT = process.env.PORT || 8080;
+if (import.meta.url === `file://${process.argv[1]}`) {
+  httpServer.listen(PORT, () => {
+    console.log(`Realtime server listening on ${PORT}`);
+  });
+}
+
+export { app, httpServer };


### PR DESCRIPTION
## Summary
- document frontend and backend routes with sample URLs and invite builders
- add minimal RoomService, LinkGuard, and realtime server skeleton with snake and crazydice adapters

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b8d3f77108329adabb30bd9687423