### PR TITLE
Add Tetris Royale to game invites

### DIFF
--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -88,6 +88,11 @@ export default function InvitePopup({
                   src: '/assets/icons/Air Hockey .png',
                   alt: 'Air Hockey',
                 },
+                {
+                  id: 'tetrisroyale',
+                  src: '/assets/icons/file_00000000240061f4abd28311d76970a5.png',
+                  alt: 'Tetris Royale',
+                },
               ].map((g) => (
                   <img
                     key={g.id}

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -19,7 +19,22 @@ import PlayerInvitePopup from './PlayerInvitePopup.jsx';
 function getGameFromTableId(id) {
   if (!id) return 'snake';
   const prefix = id.split('-')[0];
-  if (['snake', 'ludo', 'crazydice', 'horse'].includes(prefix)) return prefix;
+  if (
+    [
+      'snake',
+      'ludo',
+      'crazydice',
+      'horse',
+      'fallingball',
+      'airhockey',
+      'brickbreaker',
+      'fruitsliceroyale',
+      'bubblepoproyale',
+      'bubblesmashroyale',
+      'tetrisroyale',
+    ].includes(prefix)
+  )
+    return prefix;
   return 'snake';
 }
 

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -11,7 +11,22 @@ import AchievementsCard from './AchievementsCard.jsx';
 function getGameFromTableId(id) {
   if (!id) return 'snake';
   const prefix = id.split('-')[0];
-  if (['snake', 'ludo', 'crazydice', 'horse'].includes(prefix)) return prefix;
+  if (
+    [
+      'snake',
+      'ludo',
+      'crazydice',
+      'horse',
+      'fallingball',
+      'airhockey',
+      'brickbreaker',
+      'fruitsliceroyale',
+      'bubblepoproyale',
+      'bubblesmashroyale',
+      'tetrisroyale',
+    ].includes(prefix)
+  )
+    return prefix;
   return 'snake';
 }
 
@@ -189,6 +204,11 @@ export default function PlayerInvitePopup({
                   id: 'airhockey',
                   src: '/assets/icons/Air Hockey .png',
                   alt: 'Air Hockey',
+                },
+                {
+                  id: 'tetrisroyale',
+                  src: '/assets/icons/file_00000000240061f4abd28311d76970a5.png',
+                  alt: 'Tetris Royale',
                 },
               ].map((g) => (
                 <img


### PR DESCRIPTION
## Summary
- include Tetris Royale in game selection for player and group invites
- update game detection logic to recognize all available games

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b959b5f548329ac9bc48be41266db