### PR TITLE
Add basic WebSocket syncing for shared games

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -714,6 +714,18 @@ io.on('connection', (socket) => {
     await registerConnection({ userId: String(playerId), socketId: socket.id });
   });
 
+  socket.on('joinGame', ({ roomId }) => {
+    if (roomId) {
+      socket.join(roomId);
+    }
+  });
+
+  socket.on('gameAction', ({ roomId, event, payload }) => {
+    if (roomId && event) {
+      socket.to(roomId).emit('gameAction', { event, payload });
+    }
+  });
+
   socket.on('createLobby', ({ roomId }, cb) => {
     const id = roomId || randomUUID();
     socket.join(id);

--- a/webapp/public/air-hockey.html
+++ b/webapp/public/air-hockey.html
@@ -67,6 +67,7 @@
   <div class="landscape-block" style="display:none">Please hold your phone in <b>portrait</b> for the best experience.</div>
 
 <script src="/falling-ball-api.js"></script>
+<script src="/game-sync.js"></script>
 <script>
 (() => {
   const canvas = document.getElementById('game');
@@ -147,6 +148,18 @@
   }
   p1NameEl.textContent = p1Name;
   p2NameEl.textContent = p2Name;
+
+  const myPlayer = !oppAccountId || myAccountId < oppAccountId ? 'p1' : 'p2';
+  const remotePlayer = myPlayer === 'p1' ? 'p2' : 'p1';
+  const isHost = myPlayer === 'p1';
+  if (window.gameSync) {
+    gameSync.on('paddleMove', ({ player, x, y, vx, vy }) => {
+      const target = player === 'p1' ? p1 : p2;
+      target.x = x; target.y = y; target.vx = vx; target.vy = vy;
+    });
+    gameSync.on('puckState', (state) => { puck.x = state.x; puck.y = state.y; puck.vx = state.vx; puck.vy = state.vy; });
+    gameSync.on('scoreState', (s) => { score.p1 = s.p1; score.p2 = s.p2; updateScore(); });
+  }
 
   async function awardTpc(accountId, amount){
     try{
@@ -556,6 +569,10 @@
     last = ts;
     update(dt);
     render();
+    if (isHost && window.gameSync) {
+      gameSync.send('puckState', { x: puck.x, y: puck.y, vx: puck.vx, vy: puck.vy });
+      gameSync.send('scoreState', { p1: score.p1, p2: score.p2 });
+    }
     requestAnimationFrame(loop);
   }
 
@@ -613,9 +630,13 @@
     const vx = (p.x - last.x) / dt * 16.67;
     const vy = (p.y - last.y) / dt * 16.67;
     touches.set(e.pointerId, {x:p.x, y:p.y, vx, vy, t:now});
-    const d1 = dist(p1.x,p1.y,p.x,p.y); const d2 = dist(p2.x,p2.y,p.x,p.y);
-    if (p.y > centerY && d1 < d2) { p1.vx = vx; p1.vy = vy; }
-    else if (p.y < centerY && d2 <= d1) { p2.vx = vx; p2.vy = vy; }
+    if (myPlayer === 'p1' && p.y > centerY) {
+      p1.vx = vx; p1.vy = vy;
+      if (window.gameSync) gameSync.send('paddleMove', { player:'p1', x:p1.x, y:p1.y, vx, vy });
+    } else if (myPlayer === 'p2' && p.y < centerY) {
+      p2.vx = vx; p2.vy = vy;
+      if (window.gameSync) gameSync.send('paddleMove', { player:'p2', x:p2.x, y:p2.y, vx, vy });
+    }
   });
   function clearTouch(id){ touches.delete(id); }
   canvas.addEventListener('pointerup', e=>clearTouch(e.pointerId));

--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -70,6 +70,7 @@
 
   <script src="/flag-emojis.js"></script>
   <script src="/falling-ball-api.js"></script>
+  <script src="/game-sync.js"></script>
   <script>
   // ========================= Canvas & Brand =========================
   const canvas = document.getElementById('scene');
@@ -177,6 +178,15 @@
   const accountsParam = params.get('accounts');
   const tgIdsParam = params.get('tgIds');
 
+  const accounts = accountsParam ? accountsParam.split(',') : [];
+  const tgIds = tgIdsParam ? tgIdsParam.split(',') : [];
+  const oppAccountId = accounts[1];
+  const isHost = !oppAccountId || myAccountId < oppAccountId;
+  if (window.gameSync) {
+    gameSync.on('ballState', (b) => { state.ball.x = b.x; state.ball.y = b.y; state.ball.vx = b.vx; state.ball.vy = b.vy; });
+    gameSync.on('obstacles', (obs) => { state.obstacles = obs; });
+  }
+
   async function awardDevShare(total){
     const ops=[];
     if(devAccountId1||devAccountId2){
@@ -201,8 +211,7 @@
   function buildPlayers(){
     const list=[]; const avatarsParam=params.get('avatars'); const namesParam=params.get('names');
     const profileAvatar = (()=>{ try{ return localStorage.getItem('profilePhoto'); }catch{return null;} })();
-    const accounts = accountsParam ? accountsParam.split(',') : [];
-    const tgIds = tgIdsParam ? tgIdsParam.split(',') : [];
+    // accounts and tgIds are defined globally
     if(state.mode==='online' && avatarsParam && namesParam){
       const names=namesParam.split(',').map(decodeURIComponent);
       const avatars=avatarsParam.split(',').map(decodeURIComponent);
@@ -438,13 +447,24 @@
   function drawSlotsGuide(){ const pad=30; const usable=W-2*pad; const w = usable / state.players; const bottom = H-120; const top = bottom-40; for(let i=0;i<state.players;i++){ const x1=pad+i*w; ctx.fillStyle='rgba(0,0,0,0.25)'; ctx.fillRect(x1, top, w-2, bottom-top); if (state.resultSlot===i){ ctx.fillStyle='rgba(250,204,21,0.4)'; ctx.fillRect(x1, top, w-2, bottom-top); ctx.strokeStyle='rgba(250,204,21,0.9)'; ctx.lineWidth=3; ctx.strokeRect(x1+1, top, w-4, bottom-top); } } }
   function drawBall(){ const b=state.ball; ctx.fillStyle='rgba(0,0,0,0.28)'; ctx.beginPath(); ctx.ellipse(b.x, b.y+b.r+6, b.r*1.2, b.r*0.5, 0,0,Math.PI*2); ctx.fill(); const grad = ctx.createRadialGradient(b.x-6,b.y-6,4, b.x,b.y,b.r+6); grad.addColorStop(0,'#fef08a'); grad.addColorStop(0.55,'#facc15'); grad.addColorStop(1,'#ca8a04'); ctx.fillStyle=grad; ctx.beginPath(); ctx.arc(b.x,b.y,b.r,0,Math.PI*2); ctx.fill(); ctx.globalAlpha=0.15; ctx.fillStyle='#fefce8'; ctx.beginPath(); ctx.ellipse(b.x-5,b.y-8,b.r*0.7,b.r*0.35,-0.2,0,Math.PI*2); ctx.fill(); ctx.globalAlpha=1; }
 
-  function frame(ts){ const dt = Math.min(33, ts - state.time); state.time=ts; step(dt/16.6667); ctx.clearRect(0,0,W,H); drawBackground(); drawObstacles(); drawSlotsGuide(); drawBall(); requestAnimationFrame(frame); }
+  function frame(ts){
+    const dt = Math.min(33, ts - state.time); state.time = ts;
+    if (isHost) step(dt/16.6667);
+    ctx.clearRect(0,0,W,H);
+    drawBackground();
+    drawObstacles();
+    drawSlotsGuide();
+    drawBall();
+    if (isHost && window.gameSync) gameSync.send('ballState', state.ball);
+    requestAnimationFrame(frame);
+  }
   requestAnimationFrame(frame);
 
   // ========================= Init =========================
   function init(){
     refreshSlots();
     genPegField();
+    if (isHost && window.gameSync) gameSync.send('obstacles', state.obstacles);
     carveCorridors();
     addStars();
     resetBall();

--- a/webapp/public/game-sync.js
+++ b/webapp/public/game-sync.js
@@ -1,0 +1,20 @@
+(function(){
+  const params = new URLSearchParams(location.search);
+  const roomId = params.get('roomId') || params.get('tableId');
+  if (!roomId) return;
+  const s = document.createElement('script');
+  s.src = '/socket.io/socket.io.js';
+  s.onload = () => {
+    const socket = io();
+    socket.emit('joinGame', { roomId });
+    const api = {
+      send(event, payload){ socket.emit('gameAction', { roomId, event, payload }); },
+      on(event, handler){ window.addEventListener(event, (e) => handler(e.detail)); }
+    };
+    window.gameSync = api;
+    socket.on('gameAction', ({ event, payload }) => {
+      window.dispatchEvent(new CustomEvent(event, { detail: payload }));
+    });
+  };
+  document.head.appendChild(s);
+})();


### PR DESCRIPTION
## Summary
- Broadcast game actions through socket.io on the server
- Load a reusable `game-sync` client helper
- Sync Air Hockey paddles, puck and score between players
- Sync Falling Ball obstacles and ball state via host client

## Testing
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_689b9e2479e88329aaaf272dde39323e