### PR TITLE
feat: add air hockey calibration tool

### DIFF
--- a/webapp/public/air-hockey.html
+++ b/webapp/public/air-hockey.html
@@ -61,6 +61,14 @@
     <div id="optionsPanel" class="panel right">
       <h3>Options</h3>
       <button id="muteBtn" style="margin:8px">Toggle Sound</button>
+      <h3>Calibration</h3>
+      <div style="margin:8px">
+        <label>Field Size: <input id="fieldScale" type="range" min="0.8" max="1.2" step="0.01" /></label>
+      </div>
+      <div style="margin:8px">
+        <label>Puck Size: <input id="puckScale" type="range" min="0.5" max="1.5" step="0.05" /></label>
+      </div>
+      <button id="saveCalibration" style="margin:8px">Save Calibration</button>
     </div>
   </div>
   <div class="hint" id="startHint"></div>
@@ -80,6 +88,9 @@
   const menuPanel = document.getElementById('menuPanel');
   const optionsPanel = document.getElementById('optionsPanel');
   const muteBtn = document.getElementById('muteBtn');
+  const fieldScaleInput = document.getElementById('fieldScale');
+  const puckScaleInput = document.getElementById('puckScale');
+  const saveCalBtn = document.getElementById('saveCalibration');
   const TOP_BAR = 40; // height of scoreboard bar
   const BOTTOM_GAP = 20; // gap below rink
 
@@ -115,6 +126,11 @@
   const oppParam = params.get('p2Avatar') || '';
   let p1Name = params.get('name') || 'P1';
   let p2Name = params.get('p2Name') || 'P2';
+  let fieldScale = 1, puckScale = 1;
+  try {
+    fieldScale = parseFloat(localStorage.getItem('fieldScale')) || 1;
+    puckScale = parseFloat(localStorage.getItem('puckScale')) || 1;
+  } catch {}
   const FLAG_DATA = [
     { emoji:'🇺🇸', name:'USA' },
     { emoji:'🇬🇧', name:'UK' },
@@ -152,6 +168,24 @@
   }
   p1NameEl.textContent = p1Name;
   p2NameEl.textContent = p2Name;
+  fieldScaleInput.value = fieldScale;
+  puckScaleInput.value = puckScale;
+  fieldScaleInput.addEventListener('input', () => {
+    fieldScale = parseFloat(fieldScaleInput.value);
+    fit();
+    resetPositions();
+  });
+  puckScaleInput.addEventListener('input', () => {
+    puckScale = parseFloat(puckScaleInput.value);
+    fit();
+    resetPositions();
+  });
+  saveCalBtn.addEventListener('click', () => {
+    try {
+      localStorage.setItem('fieldScale', fieldScale);
+      localStorage.setItem('puckScale', puckScale);
+    } catch {}
+  });
 
   async function awardTpc(accountId, amount){
     try{
@@ -248,13 +282,19 @@
     H = canvas.height = Math.floor(usableHeight * devicePixelRatio);
     canvas.style.width = window.innerWidth + 'px';
     canvas.style.height = usableHeight + 'px';
-    rink.x = Math.round(W*0.06); rink.w = Math.round(W*0.88);
-    rink.y = Math.round(H*0.04); rink.h = Math.round(H*0.92);
+    const baseW = W*0.88;
+    const baseH = H*0.92;
+    const maxFieldScale = Math.min(W/baseW, H/baseH);
+    const fs = Math.min(fieldScale, maxFieldScale);
+    rink.w = Math.round(baseW * fs);
+    rink.h = Math.round(baseH * fs);
+    rink.x = Math.round((W - rink.w) / 2);
+    rink.y = Math.round((H - rink.h) / 2);
     centerX = W/2; centerY = H/2;
-    goalWidth = Math.round(W*0.36);
-    const base = Math.max(24, Math.round(Math.min(W,H)*0.035));
+    goalWidth = Math.round(W*0.36*fs);
+    const base = Math.max(24, Math.round(Math.min(W,H)*0.035*fs));
     paddleRadius = base*3.4;
-    puck.r = Math.max(20, Math.round(base*1.0));
+    puck.r = Math.max(20, Math.round(base*1.0*puckScale));
     p1.r = paddleRadius; p2.r = paddleRadius;
   }
   window.addEventListener('resize', fit);


### PR DESCRIPTION
## Summary
- add calibration panel to adjust rink and puck sizes
- persist calibration settings in local storage
- scale rendering based on saved calibration values

## Testing
- `npm test` *(fails: ERR_DLOPEN_FAILED canvas bindings; snake API tests timed out)*

------
https://chatgpt.com/codex/tasks/task_e_689c24c4b5a08329856b677d1120a780