### PR TITLE
feat: expand air hockey field and puck

### DIFF
--- a/webapp/public/air-hockey.html
+++ b/webapp/public/air-hockey.html
@@ -24,7 +24,7 @@
     .p1{background:var(--p1);color:#052e12}
     .p2{background:var(--p2);color:#3a2600}
 
-    .canvasWrap{position:absolute;top:40px;bottom:20px;left:0;right:0;}
+    .canvasWrap{position:absolute;top:0;bottom:0;left:0;right:0;}
     canvas{position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none}
 
     .hint{position:fixed;inset:0;display:none;align-items:center;justify-content:center;margin:auto;max-width:680px;background:rgba(10,16,34,.6);backdrop-filter:blur(6px);border:1px solid #1f2944;border-radius:12px;padding:8px 12px;text-align:center;font-size:.9rem}
@@ -91,8 +91,8 @@
   const fieldScaleInput = document.getElementById('fieldScale');
   const puckScaleInput = document.getElementById('puckScale');
   const saveCalBtn = document.getElementById('saveCalibration');
-  const TOP_BAR = 40; // height of scoreboard bar
-  const BOTTOM_GAP = 20; // gap below rink
+  const TOP_BAR = 0; // scoreboard overlays field
+  const BOTTOM_GAP = 0; // no gap below rink
 
   const fieldImg = new Image();
   fieldImg.src = '/assets/icons/file_00000000becc620a8755badc01cfefca.webp';
@@ -282,8 +282,8 @@
     H = canvas.height = Math.floor(usableHeight * devicePixelRatio);
     canvas.style.width = window.innerWidth + 'px';
     canvas.style.height = usableHeight + 'px';
-    const baseW = W*0.88;
-    const baseH = H*0.92;
+    const baseW = W;
+    const baseH = H;
     const maxFieldScale = Math.min(W/baseW, H/baseH);
     const fs = Math.min(fieldScale, maxFieldScale);
     rink.w = Math.round(baseW * fs);
@@ -294,7 +294,7 @@
     goalWidth = Math.round(W*0.36*fs);
     const base = Math.max(24, Math.round(Math.min(W,H)*0.035*fs));
     paddleRadius = base*3.4;
-    puck.r = Math.max(20, Math.round(base*1.0*puckScale));
+    puck.r = Math.max(20, Math.round(base*1.2*puckScale));
     p1.r = paddleRadius; p2.r = paddleRadius;
   }
   window.addEventListener('resize', fit);


### PR DESCRIPTION
## Summary
- Make air hockey canvas stretch full-screen
- Slightly enlarge puck by default

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_689c29664f608329ad155c3d71716989