### PR TITLE
feat: improve air hockey calibration

### DIFF
--- a/webapp/public/air-hockey.html
+++ b/webapp/public/air-hockey.html
@@ -33,8 +33,8 @@
     @keyframes coin-fall{from{transform:translateY(-10vh) rotate(0deg);opacity:1}to{transform:translateY(100vh) rotate(360deg);opacity:0}}
 
     #calibrationBtn{position:absolute;top:8px;right:8px;z-index:15;background:#0b1220;color:#e5e7eb;border:1px solid #233050;border-radius:8px;padding:6px 10px}
-    #calibrationPopup{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(10,16,34,.6);backdrop-filter:blur(6px);z-index:20}
-    #calibrationPopup .content{background:#0b1220;border:1px solid #1f2944;border-radius:12px;padding:16px;color:#e5e7eb;width:90%;max-width:300px}
+    #calibrationPopup{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:transparent;backdrop-filter:none;z-index:20}
+    #calibrationPopup .content{background:transparent;border-radius:12px;padding:24px;color:#e5e7eb;width:95%;max-width:400px}
     #calibrationPopup label{display:block;margin:8px 0}
     #calibrationPopup button{margin-top:8px}
 
@@ -59,8 +59,11 @@
     <div id="calibrationPopup">
       <div class="content">
         <h3>Calibration</h3>
-        <div>
+      <div>
           <label>Field Size: <input id="fieldScale" type="range" min="0.8" max="1.2" step="0.01" /></label>
+        </div>
+        <div>
+          <label>Field Image Size: <input id="fieldImgScale" type="range" min="0.8" max="1.2" step="0.01" /></label>
         </div>
         <div>
           <label>Puck Size: <input id="puckScale" type="range" min="0.5" max="1.5" step="0.05" /></label>
@@ -95,6 +98,7 @@
   const calibrationBtn = document.getElementById('calibrationBtn');
   const calibrationPopup = document.getElementById('calibrationPopup');
   const fieldScaleInput = document.getElementById('fieldScale');
+  const fieldImgScaleInput = document.getElementById('fieldImgScale');
   const puckScaleInput = document.getElementById('puckScale');
   const goalWidthInput = document.getElementById('goalWidth');
   const goalOffsetInput = document.getElementById('goalOffset');
@@ -102,6 +106,7 @@
   const saveCalBtn = document.getElementById('saveCalibration');
   const TOP_BAR = 40; // height of scoreboard bar
   const BOTTOM_GAP = 20; // gap below rink
+  let showCalOverlay = false;
 
   const fieldImg = new Image();
   fieldImg.src = '/assets/icons/file_00000000becc620a8755badc01cfefca.webp';
@@ -135,9 +140,10 @@
   const oppParam = params.get('p2Avatar') || '';
   let p1Name = params.get('name') || 'P1';
   let p2Name = params.get('p2Name') || 'P2';
-  let fieldScale = 1, puckScale = 1, goalWidthPct = 0.36, goalOffsetPct = 0, paddleScale = 1;
+  let fieldScale = 1, fieldImgScale = 1, puckScale = 1, goalWidthPct = 0.36, goalOffsetPct = 0, paddleScale = 1;
   try {
     fieldScale = parseFloat(localStorage.getItem('fieldScale')) || 1;
+    fieldImgScale = parseFloat(localStorage.getItem('fieldImgScale')) || 1;
     puckScale = parseFloat(localStorage.getItem('puckScale')) || 1;
     goalWidthPct = parseFloat(localStorage.getItem('goalWidthPct')) || 0.36;
     goalOffsetPct = parseFloat(localStorage.getItem('goalOffsetPct')) || 0;
@@ -181,16 +187,14 @@
   p1NameEl.textContent = p1Name;
   p2NameEl.textContent = p2Name;
   fieldScaleInput.value = fieldScale;
+  fieldImgScaleInput.value = fieldImgScale;
   puckScaleInput.value = puckScale;
   goalWidthInput.value = goalWidthPct;
   goalOffsetInput.value = goalOffsetPct;
   paddleScaleInput.value = paddleScale;
-  const showCal = params.has('showCal');
-  if(localStorage.getItem('calibrationDone')==='true' && !showCal){
-    calibrationBtn.style.display = 'none';
-  }
   calibrationBtn.addEventListener('click',()=>{
     calibrationPopup.style.display='flex';
+    showCalOverlay=true;
   });
   fieldScaleInput.addEventListener('input', () => {
     fieldScale = parseFloat(fieldScaleInput.value);
@@ -217,9 +221,15 @@
     fit();
     resetPositions();
   });
+  fieldImgScaleInput.addEventListener('input', () => {
+    fieldImgScale = parseFloat(fieldImgScaleInput.value);
+    fit();
+    resetPositions();
+  });
   saveCalBtn.addEventListener('click', () => {
     try {
       localStorage.setItem('fieldScale', fieldScale);
+      localStorage.setItem('fieldImgScale', fieldImgScale);
       localStorage.setItem('puckScale', puckScale);
       localStorage.setItem('goalWidthPct', goalWidthPct);
       localStorage.setItem('goalOffsetPct', goalOffsetPct);
@@ -227,7 +237,7 @@
       localStorage.setItem('calibrationDone','true');
     } catch {}
     calibrationPopup.style.display='none';
-    calibrationBtn.style.display='none';
+    showCalOverlay=false;
   });
 
   async function awardTpc(accountId, amount){
@@ -435,22 +445,26 @@
   }
   function drawRink(){
     if (fieldImg.complete) {
-      ctx.drawImage(fieldImg, rink.x, rink.y, rink.w, rink.h);
-      return;
+      const imgW = rink.w * fieldImgScale;
+      const imgH = rink.h * fieldImgScale;
+      const imgX = rink.x + (rink.w - imgW)/2;
+      const imgY = rink.y + (rink.h - imgH)/2;
+      ctx.drawImage(fieldImg, imgX, imgY, imgW, imgH);
+    } else {
+      rr(rink.x, rink.y, rink.w, rink.h, rink.r);
+      ctx.fillStyle = getCSS('--ice'); ctx.fill();
+      ctx.lineWidth = Math.max(2, W*0.003);
+      ctx.strokeStyle = getCSS('--line');
+      ctx.beginPath(); ctx.moveTo(rink.x+10, centerY); ctx.lineTo(rink.x+rink.w-10, centerY); ctx.stroke();
+      ctx.beginPath(); ctx.arc(centerX, centerY, Math.min(W,H)*0.11, 0, Math.PI*2); ctx.stroke();
+      ctx.beginPath();
+      ctx.arc(centerX, H*0.25, Math.min(W,H)*0.09, 0, Math.PI*2);
+      ctx.moveTo(centerX + Math.min(W,H)*0.09, H*0.75);
+      ctx.arc(centerX, H*0.75, Math.min(W,H)*0.09, 0, Math.PI*2);
+      ctx.stroke();
+      drawGoal(goalCenterX, rink.y, goalWidth, goalDepth, -1);
+      drawGoal(goalCenterX, rink.y + rink.h, goalWidth, goalDepth, 1);
     }
-    rr(rink.x, rink.y, rink.w, rink.h, rink.r);
-    ctx.fillStyle = getCSS('--ice'); ctx.fill();
-    ctx.lineWidth = Math.max(2, W*0.003);
-    ctx.strokeStyle = getCSS('--line');
-    ctx.beginPath(); ctx.moveTo(rink.x+10, centerY); ctx.lineTo(rink.x+rink.w-10, centerY); ctx.stroke();
-    ctx.beginPath(); ctx.arc(centerX, centerY, Math.min(W,H)*0.11, 0, Math.PI*2); ctx.stroke();
-    ctx.beginPath();
-    ctx.arc(centerX, H*0.25, Math.min(W,H)*0.09, 0, Math.PI*2);
-    ctx.moveTo(centerX + Math.min(W,H)*0.09, H*0.75);
-    ctx.arc(centerX, H*0.75, Math.min(W,H)*0.09, 0, Math.PI*2);
-    ctx.stroke();
-    drawGoal(goalCenterX, rink.y, goalWidth, goalDepth, -1);
-    drawGoal(goalCenterX, rink.y + rink.h, goalWidth, goalDepth, 1);
   }
   function drawGoal(cx, y, w, d, dir){
     ctx.save();
@@ -551,6 +565,19 @@
       p.vx *= 0.8; p.vy *= 0.8;
     }
   }
+  function drawCalibrationGuide(){
+    ctx.save();
+    ctx.strokeStyle = 'yellow';
+    ctx.lineWidth = Math.max(2, W*0.005);
+    ctx.fillStyle = 'rgba(255,255,0,0.15)';
+    ctx.fillRect(rink.x, rink.y, rink.w, rink.h);
+    ctx.strokeRect(rink.x, rink.y, rink.w, rink.h);
+    ctx.fillRect(goalCenterX - goalWidth/2, rink.y - goalDepth, goalWidth, goalDepth);
+    ctx.strokeRect(goalCenterX - goalWidth/2, rink.y - goalDepth, goalWidth, goalDepth);
+    ctx.fillRect(goalCenterX - goalWidth/2, rink.y + rink.h, goalWidth, goalDepth);
+    ctx.strokeRect(goalCenterX - goalWidth/2, rink.y + rink.h, goalWidth, goalDepth);
+    ctx.restore();
+  }
 
   function aiUpdate(){
     const reaction = {easy:0.05, normal:0.1, hard:0.18}[difficulty] || 0.1;
@@ -645,6 +672,7 @@
     drawPaddle(p2, getCSS('--p2'), p2AvatarImg, p2AvatarEmoji);
     drawPaddle(p1, getCSS('--p1'), p1AvatarImg, p1AvatarEmoji);
     drawPuck();
+    if (showCalOverlay) drawCalibrationGuide();
   }
 
   function loop(ts){


### PR DESCRIPTION
## Summary
- make calibration popup transparent and enlarge its controls
- add field image sizing and highlight rink and goals during calibration

## Testing
- `npm test` (fails: test timed out)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c369bb658832992688bfb378d3b08