### PR TITLE
Use sprite sheet for Fruit Slice Royale fruits

### DIFF
--- a/webapp/public/fruit-slice-royale.html
+++ b/webapp/public/fruit-slice-royale.html
@@ -181,21 +181,40 @@
     noise.connect(ng).connect(audioCtx.destination); noise.start(t);
   }
 
-  // ===== Fruits (more types + size factors) =====
+  // ===== Fruits (sprite-based) =====
+  // Sprite frames extracted from the provided sheet
+  const FRUIT_FRAMES={
+    apple:{x:0,y:0,w:256,h:256},
+    cherry:{x:256,y:0,w:256,h:256},
+    banana:{x:512,y:0,w:256,h:256},
+    pineapple:{x:0,y:256,w:256,h:256},
+    green_grape:{x:256,y:256,w:256,h:256},
+    strawberry:{x:512,y:256,w:256,h:256},
+    green_apple:{x:0,y:512,w:256,h:256},
+    lime_grape:{x:256,y:512,w:256,h:256},
+    watermelon:{x:512,y:512,w:256,h:256},
+    blueberry:{x:0,y:768,w:256,h:256},
+    kiwi:{x:256,y:768,w:256,h:256},
+    mango:{x:512,y:768,w:256,h:256},
+  };
+  const FRUIT_SPRITES=new Image();
+  let SPRITES_READY=false;
+  FRUIT_SPRITES.onload=()=>{SPRITES_READY=true;};
+  FRUIT_SPRITES.src='assets/icons/file_000000003f7861f481d50537fb031e13.png';
   // sf = size factor relative to base (so cherry < apple)
   const FRUITS=[
-    {k:'apple',    col:'#ff5a6b', juice:'#ff8aa0', score:12, sf:1.00},
-    {k:'orange',   col:'#ff9d5a', juice:'#ffbf8f', score:12, sf:1.00},
-    {k:'lemon',    col:'#f6d74a', juice:'#ffe179', score:11, sf:0.90},
-    {k:'lime',     col:'#34d399', juice:'#7ff0c3', score:11, sf:0.90},
-    {k:'pear',     col:'#9bd27d', juice:'#c9f4b1', score:13, sf:1.05},
-    {k:'banana',   col:'#f8e36a', juice:'#ffef91', score:14, sf:1.20},
-    {k:'grape',    col:'#a78bfa', juice:'#c7b7ff', score:16, sf:0.95},
-    {k:'cherry',   col:'#ff4b5c', juice:'#ff94a1', score:10, sf:0.60},
-    {k:'strawberry',col:'#ff5577', juice:'#ff97ad', score:15, sf:0.85},
-    {k:'watermelon',col:'#e94b5b', juice:'#ff9fb0', score:18, sf:1.25},
-    {k:'kiwi',     col:'#8bd36a', juice:'#c9f7a9', score:14, sf:0.95},
-    {k:'pineapple',col:'#f1c14b', juice:'#ffe08a', score:17, sf:1.15}
+    {k:'apple',       col:'#ff5a6b', juice:'#ff8aa0', score:12, sf:1.00, frame:FRUIT_FRAMES.apple},
+    {k:'cherry',      col:'#ff4b5c', juice:'#ff94a1', score:10, sf:0.60, frame:FRUIT_FRAMES.cherry},
+    {k:'banana',      col:'#f8e36a', juice:'#ffef91', score:14, sf:1.20, frame:FRUIT_FRAMES.banana},
+    {k:'pineapple',   col:'#f1c14b', juice:'#ffe08a', score:17, sf:1.15, frame:FRUIT_FRAMES.pineapple},
+    {k:'green_grape', col:'#9bd27d', juice:'#c9f4b1', score:16, sf:0.95, frame:FRUIT_FRAMES.green_grape},
+    {k:'strawberry',  col:'#ff5577', juice:'#ff97ad', score:15, sf:0.85, frame:FRUIT_FRAMES.strawberry},
+    {k:'green_apple', col:'#8ede45', juice:'#bdf481', score:12, sf:1.00, frame:FRUIT_FRAMES.green_apple},
+    {k:'lime_grape',  col:'#34d399', juice:'#7ff0c3', score:11, sf:0.90, frame:FRUIT_FRAMES.lime_grape},
+    {k:'watermelon',  col:'#e94b5b', juice:'#ff9fb0', score:18, sf:1.25, frame:FRUIT_FRAMES.watermelon},
+    {k:'blueberry',   col:'#5a6bff', juice:'#9aa9ff', score:16, sf:0.95, frame:FRUIT_FRAMES.blueberry},
+    {k:'kiwi',        col:'#8bd36a', juice:'#c9f7a9', score:14, sf:0.95, frame:FRUIT_FRAMES.kiwi},
+    {k:'mango',       col:'#ff9d5a', juice:'#ffbf8f', score:12, sf:1.00, frame:FRUIT_FRAMES.mango},
   ];
   const BOMB={k:'bomb', shell:'#2a303d', fuse:'#ffdd55'};
 
@@ -226,83 +245,20 @@
       spawnNext=450+Math.random()*350;
     }
 
-    // Painters (cartoon fruits)
-    function drawFruit(f){
-      const k=f.data.k, r=f.r;
-      ctx.save(); ctx.translate(f.x,f.y); ctx.rotate(f.rot||0);
-
-      if(k==='apple'||k==='orange'||k==='kiwi'){
-        const g=ctx.createRadialGradient(-r*0.3,-r*0.5,r*0.1, 0,0,r);
-        g.addColorStop(0,'#ffffff66'); g.addColorStop(0.25,f.data.col); g.addColorStop(1,'#00000055');
-        ctx.fillStyle=g; ctx.beginPath(); ctx.arc(0,0,r,0,Math.PI*2); ctx.fill();
-        if(k==='kiwi'){ // seeds ring
-          ctx.globalAlpha=0.7; ctx.fillStyle='#1f2b15';
-          for(let i=0;i<18;i++){ const a=i*(Math.PI*2/18); ctx.beginPath(); ctx.arc(Math.cos(a)*r*0.55, Math.sin(a)*r*0.55, 1.2, 0, Math.PI*2); ctx.fill(); }
-          ctx.globalAlpha=1;
-        }
-      } else if(k==='lemon'||k==='lime'){
-        const g=ctx.createRadialGradient(-r*0.5,0,r*0.2, 0,0,r*1.1);
-        g.addColorStop(0,'#ffffff66'); g.addColorStop(0.25,f.data.col); g.addColorStop(1,'#00000055');
-        ctx.fillStyle=g; ctx.beginPath(); ctx.moveTo(-r,0); ctx.quadraticCurveTo(0,-r, r,0); ctx.quadraticCurveTo(0,r, -r,0); ctx.fill();
-      } else if(k==='banana'){
-        ctx.fillStyle=f.data.col; ctx.beginPath();
-        ctx.moveTo(-r*1.1,0);
-        ctx.quadraticCurveTo(0,-r*0.9, r*1.2,0.2*r);
-        ctx.quadraticCurveTo(0,r*0.9, -r*1.1,0);
-        ctx.fill();
-      } else if(k==='grape'){
-        for(let i=0;i<7;i++){
-          const ax=((i%3)-1)*r*0.55, ay=(Math.floor(i/3)-0.6)*r*0.6;
-          const rr=r*0.45;
-          const g=ctx.createRadialGradient(ax-rr*0.3,ay-rr*0.4,rr*0.1, ax,ay,rr);
+      // Painters (sprite fruits)
+      function drawFruit(f){
+        const r=f.r;
+        ctx.save(); ctx.translate(f.x,f.y); ctx.rotate(f.rot||0);
+        const frame=f.data.frame;
+        if(frame && SPRITES_READY){
+          ctx.drawImage(FRUIT_SPRITES, frame.x, frame.y, frame.w, frame.h, -r, -r, r*2, r*2);
+        } else {
+          const g=ctx.createRadialGradient(-r*0.3,-r*0.5,r*0.1, 0,0,r);
           g.addColorStop(0,'#ffffff66'); g.addColorStop(0.25,f.data.col); g.addColorStop(1,'#00000055');
-          ctx.fillStyle=g; ctx.beginPath(); ctx.arc(ax,ay,rr,0,Math.PI*2); ctx.fill();
+          ctx.fillStyle=g; ctx.beginPath(); ctx.arc(0,0,r,0,Math.PI*2); ctx.fill();
         }
-      } else if(k==='cherry'){
-        // double cherries
-        const rr=r*0.55;
-        ['L','R'].forEach((side,idx)=>{
-          const dx=idx? rr*0.9 : -rr*0.9, dy=rr*0.2;
-          const g=ctx.createRadialGradient(dx-rr*0.3,dy-rr*0.4,rr*0.1, dx,dy,rr);
-          g.addColorStop(0,'#ffffff66'); g.addColorStop(0.25,f.data.col); g.addColorStop(1,'#00000055');
-          ctx.fillStyle=g; ctx.beginPath(); ctx.arc(dx,dy,rr,0,Math.PI*2); ctx.fill();
-        });
-        // stems
-        ctx.strokeStyle='#2a8f3a'; ctx.lineWidth=2;
-        ctx.beginPath(); ctx.moveTo(-rr*0.9,rr*0.2); ctx.quadraticCurveTo(0,-r*0.8, rr*0.9,rr*0.2); ctx.stroke();
-      } else if(k==='strawberry'){
-        // heart/teardrop
-        ctx.fillStyle=f.data.col; ctx.beginPath();
-        ctx.moveTo(0,r*0.9); ctx.bezierCurveTo(r,-r*0.3, r*0.6,-r, 0,-r*0.7); ctx.bezierCurveTo(-r*0.6,-r, -r,-r*0.3, 0,r*0.9); ctx.fill();
-        // seeds
-        ctx.globalAlpha=0.8; ctx.fillStyle='#ffd67a';
-        for(let i=0;i<16;i++){ const a=i*(Math.PI*2/16); ctx.beginPath(); ctx.ellipse(Math.cos(a)*r*0.45, Math.sin(a)*r*0.3, 1.3,0.9, a,0,Math.PI*2); ctx.fill(); }
-        ctx.globalAlpha=1;
-      } else if(k==='watermelon'){
-        // semi‑circle slice
-        ctx.fillStyle=f.data.col; ctx.beginPath();
-        ctx.moveTo(-r,0); ctx.arc(0,0,r,Math.PI,0); ctx.closePath(); ctx.fill();
-        // rind
-        ctx.fillStyle='#2ecc71'; ctx.beginPath();
-        ctx.moveTo(-r,0); ctx.arc(0,0,r,Math.PI,0); ctx.lineTo(r, r*0.18); ctx.arc(0, r*0.18, r*1.0, 0, Math.PI, true); ctx.closePath(); ctx.fill();
-        // seeds
-        ctx.fillStyle='#2b1b1b';
-        for(let i=0;i<10;i++){ const a=Math.PI + (i/9)*Math.PI; ctx.beginPath(); ctx.ellipse(Math.cos(a)*r*0.6, Math.sin(a)*r*0.5, 1.4, 2.2, a,0,Math.PI*2); ctx.fill(); }
-      } else if(k==='pear'){
-        ctx.fillStyle=f.data.col; ctx.beginPath();
-        ctx.moveTo(0,-r*0.9); ctx.quadraticCurveTo(r*0.9,-r*0.3, r*0.6,r*0.6);
-        ctx.quadraticCurveTo(0,r*1.0, -r*0.6,r*0.6); ctx.quadraticCurveTo(-r*0.9,-r*0.3, 0,-r*0.9); ctx.fill();
-      } else if(k==='pineapple'){
-        // body
-        ctx.fillStyle=f.data.col; ctx.beginPath(); ctx.ellipse(0,0,r*0.9,r*1.1,0,0,Math.PI*2); ctx.fill();
-        // crosshatch
-        ctx.strokeStyle='#c39b34'; ctx.lineWidth=1.5; for(let i=-4;i<=4;i++){ ctx.beginPath(); ctx.moveTo(-r*1.2, i*4); ctx.lineTo(r*1.2, -i*4); ctx.stroke(); ctx.beginPath(); ctx.moveTo(-r*1.2, -i*4); ctx.lineTo(r*1.2, i*4); ctx.stroke(); }
-        // crown
-        ctx.fillStyle='#2ecc71'; ctx.beginPath(); ctx.moveTo(-r*0.3,-r*1.2); ctx.lineTo(0,-r*2.0); ctx.lineTo(r*0.3,-r*1.2); ctx.closePath(); ctx.fill();
+        ctx.restore();
       }
-
-      ctx.restore();
-    }
 
     function drawBomb(f){
       const r=f.r;


### PR DESCRIPTION
## Summary
- integrate fruit sprite sheet and frame data
- render fruits using sprite images with fallback

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*

------
https://chatgpt.com/codex/tasks/task_e_689c4cf4a3588329ac033ca8c3379a88