### PR TITLE
Use sprite sheet for Fruit Slice Royale

### DIFF
--- a/webapp/public/fruit-slice-royale.html
+++ b/webapp/public/fruit-slice-royale.html
@@ -182,17 +182,23 @@
   }
 
   const SPRITE_SHEET=new Image();
-  SPRITE_SHEET.src='assets/icons/file_00000000cfc86243901b312a08cb80fe.png';
+  SPRITE_SHEET.src='assets/icons/file_000000007fac620a91e9509e4640cb99.png';
 
   // ===== Fruits (sprite sheet) =====
   // sf = size factor relative to base
   const FRUITS=[
     {k:'apple',      col:'#ff5a6b', juice:'#ff8aa0', score:12, sf:1.00, sx:0,   sy:0,   sw:256, sh:256},
-    {k:'banana',     col:'#f8e36a', juice:'#ffef91', score:14, sf:1.20, sx:256, sy:0,   sw:256, sh:256},
+    {k:'cherry',     col:'#ff4f4f', juice:'#ff8aa0', score:11, sf:0.85, sx:256, sy:0,   sw:256, sh:256},
     {k:'orange',     col:'#ff9d5a', juice:'#ffbf8f', score:12, sf:1.00, sx:512, sy:0,   sw:256, sh:256},
+    {k:'banana',     col:'#f8e36a', juice:'#ffef91', score:14, sf:1.20, sx:768, sy:0,   sw:256, sh:256},
     {k:'pineapple',  col:'#f1c14b', juice:'#ffe08a', score:17, sf:1.15, sx:0,   sy:256, sw:256, sh:256},
-    {k:'watermelon', col:'#e94b5b', juice:'#ff9fb0', score:18, sf:1.25, sx:256, sy:256, sw:256, sh:256},
-    {k:'grapes',     col:'#a78bfa', juice:'#c7b7ff', score:16, sf:0.95, sx:512, sy:256, sw:256, sh:256}
+    {k:'grapes',     col:'#a78bfa', juice:'#c7b7ff', score:16, sf:0.95, sx:256, sy:256, sw:256, sh:256},
+    {k:'strawberry', col:'#ff5a6b', juice:'#ff8aa0', score:12, sf:0.90, sx:512, sy:256, sw:256, sh:256},
+    {k:'watermelon', col:'#e94b5b', juice:'#ff9fb0', score:18, sf:1.25, sx:768, sy:256, sw:256, sh:256},
+    {k:'green_apple',col:'#b7ff5a', juice:'#dcff8a', score:12, sf:1.00, sx:0,   sy:512, sw:256, sh:256},
+    {k:'blueberry',  col:'#5a5aff', juice:'#8a8aff', score:12, sf:0.85, sx:256, sy:512, sw:256, sh:256},
+    {k:'kiwi',       col:'#a9d16c', juice:'#d5f28c', score:13, sf:0.90, sx:512, sy:512, sw:256, sh:256},
+    {k:'mango',      col:'#ffa53b', juice:'#ffd18f', score:15, sf:1.10, sx:768, sy:512, sw:256, sh:256}
   ];
   const BOMB={k:'bomb', shell:'#2a303d', fuse:'#ffdd55'};
 


### PR DESCRIPTION
## Summary
- render fruits via sprite sheet image
- add 12 fruit frame mappings for the new sheet

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c9e072c8329b2c6cb2e700d9f93