### PR TITLE
feat: add 13 fruit images to Fruit Slice Royale

### DIFF
--- a/webapp/public/fruit-slice-royale.html
+++ b/webapp/public/fruit-slice-royale.html
@@ -181,24 +181,24 @@
     noise.connect(ng).connect(audioCtx.destination); noise.start(t);
   }
 
-  const SPRITE_SHEET=new Image();
-  SPRITE_SHEET.src='assets/icons/file_000000007fac620a91e9509e4640cb99.png';
+  const loadImage=src=>{ const i=new Image(); i.src=src; return i; };
 
-  // ===== Fruits (sprite sheet) =====
+  // ===== Fruits =====
   // sf = size factor relative to base
   const FRUITS=[
-    {k:'apple',      col:'#ff5a6b', juice:'#ff8aa0', score:12, sf:1.00, sx:0,   sy:0,   sw:256, sh:256},
-    {k:'cherry',     col:'#ff4f4f', juice:'#ff8aa0', score:11, sf:0.85, sx:256, sy:0,   sw:256, sh:256},
-    {k:'orange',     col:'#ff9d5a', juice:'#ffbf8f', score:12, sf:1.00, sx:512, sy:0,   sw:256, sh:256},
-    {k:'banana',     col:'#f8e36a', juice:'#ffef91', score:14, sf:1.20, sx:768, sy:0,   sw:256, sh:256},
-    {k:'pineapple',  col:'#f1c14b', juice:'#ffe08a', score:17, sf:1.15, sx:0,   sy:256, sw:256, sh:256},
-    {k:'grapes',     col:'#a78bfa', juice:'#c7b7ff', score:16, sf:0.95, sx:256, sy:256, sw:256, sh:256},
-    {k:'strawberry', col:'#ff5a6b', juice:'#ff8aa0', score:12, sf:0.90, sx:512, sy:256, sw:256, sh:256},
-    {k:'watermelon', col:'#e94b5b', juice:'#ff9fb0', score:18, sf:1.25, sx:768, sy:256, sw:256, sh:256},
-    {k:'green_apple',col:'#b7ff5a', juice:'#dcff8a', score:12, sf:1.00, sx:0,   sy:512, sw:256, sh:256},
-    {k:'blueberry',  col:'#5a5aff', juice:'#8a8aff', score:12, sf:0.85, sx:256, sy:512, sw:256, sh:256},
-    {k:'kiwi',       col:'#a9d16c', juice:'#d5f28c', score:13, sf:0.90, sx:512, sy:512, sw:256, sh:256},
-    {k:'mango',      col:'#ffa53b', juice:'#ffd18f', score:15, sf:1.10, sx:768, sy:512, sw:256, sh:256}
+    {k:'lemon',      col:'#f7e34c', juice:'#fff28a', score:10, sf:1.00, img:loadImage('assets/icons/Lemon.jpg')},
+    {k:'kiwi',       col:'#a9d16c', juice:'#d5f28c', score:13, sf:0.90, img:loadImage('assets/icons/Kiwi.jpg')},
+    {k:'pear',       col:'#d8f27f', juice:'#eaff9f', score:12, sf:1.00, img:loadImage('assets/icons/Pear.jpg')},
+    {k:'apple',      col:'#ff5a6b', juice:'#ff8aa0', score:12, sf:1.00, img:loadImage('assets/icons/Apple.webp')},
+    {k:'cherry',     col:'#ff4f4f', juice:'#ff8aa0', score:11, sf:0.85, img:loadImage('assets/icons/Cherry%20.webp')},
+    {k:'orange',     col:'#ff9d5a', juice:'#ffbf8f', score:12, sf:1.00, img:loadImage('assets/icons/Orange.webp')},
+    {k:'banana',     col:'#f8e36a', juice:'#ffef91', score:14, sf:1.20, img:loadImage('assets/icons/Banana%20.webp')},
+    {k:'pineapple',  col:'#f1c14b', juice:'#ffe08a', score:17, sf:1.15, img:loadImage('assets/icons/Pineapple%20.webp')},
+    {k:'grape',      col:'#a78bfa', juice:'#c7b7ff', score:16, sf:0.95, img:loadImage('assets/icons/Grape.webp')},
+    {k:'strawberry', col:'#ff5a6b', juice:'#ff8aa0', score:12, sf:0.90, img:loadImage('assets/icons/Strawberry%20.webp')},
+    {k:'watermelon', col:'#e94b5b', juice:'#ff9fb0', score:18, sf:1.25, img:loadImage('assets/icons/Watermelon%20.webp')},
+    {k:'mango',      col:'#ffa53b', juice:'#ffd18f', score:15, sf:1.10, img:loadImage('assets/icons/Mango.webp')},
+    {k:'plums',      col:'#b55af9', juice:'#d59fff', score:14, sf:0.95, img:loadImage('assets/icons/Plums.webp')}
   ];
   const BOMB={k:'bomb', shell:'#2a303d', fuse:'#ffdd55'};
 
@@ -229,14 +229,14 @@
       spawnNext=450+Math.random()*350;
     }
 
-    // Painters (sprite fruits)
+    // Painters
     function drawFruit(f){
       const r=f.r;
-      const {sx,sy,sw,sh}=f.data;
+      const img=f.data.img;
       ctx.save();
       ctx.translate(f.x,f.y);
       ctx.rotate(f.rot||0);
-      ctx.drawImage(SPRITE_SHEET, sx, sy, sw, sh, -r, -r, r*2, r*2);
+      if(img) ctx.drawImage(img, -r, -r, r*2, r*2);
       ctx.restore();
     }
 


### PR DESCRIPTION
## Summary
- Load individual fruit images from assets/icons
- Expand fruit list to 13 entries and draw them directly

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c819457e483299f47d98974659807