### PR TITLE
Fix brick image sizing in Brick Breaker Royale

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -664,7 +664,19 @@
             ctx.fillText('♥'.repeat(b.lives), W - 40, 44);
             for (const br of b.bricks) {
               if (!br.alive) continue;
-              ctx.drawImage(br.img, br.x, br.y, br.w, br.h);
+              if (br.img?.complete && br.img.naturalWidth && br.img.naturalHeight) {
+                ctx.drawImage(
+                  br.img,
+                  0,
+                  0,
+                  br.img.naturalWidth,
+                  br.img.naturalHeight,
+                  br.x,
+                  br.y,
+                  br.w,
+                  br.h
+                );
+              }
               if (br.type === 'tough' && br.hits === 1) {
                 ctx.fillStyle = 'rgba(255,255,255,0.5)';
                 ctx.fillRect(br.x, br.y, br.w, br.h);


### PR DESCRIPTION
## Summary
- Ensure brick textures render at the exact brick dimensions by drawing them using their natural width and height

## Testing
- `npm test` *(fails: snake API endpoints and socket events - test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_689ca271c5988329a10ab2c45ea35dd0