### PR TITLE
Match Brick Breaker assets with Bubble Pop style

### DIFF
--- a/webapp/public/assets/icons/orange_ball.svg
+++ b/webapp/public/assets/icons/orange_ball.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="28" fill="#ff9d5a"/>
+</svg>

--- a/webapp/public/assets/icons/white_ball.svg
+++ b/webapp/public/assets/icons/white_ball.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="28" fill="#ffffff"/>
+</svg>

--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -424,12 +424,12 @@
           const BALL_IMAGES = {
             normal: (() => {
               const img = new Image();
-              img.src = '/assets/icons/WhiteBall.webp';
+              img.src = '/assets/icons/white_ball.svg';
               return img;
             })(),
             fire: (() => {
               const img = new Image();
-              img.src = '/assets/icons/Orange (Glowing)Ball.webp';
+              img.src = '/assets/icons/orange_ball.svg';
               return img;
             })()
           };
@@ -448,19 +448,9 @@
           };
 
           const drawBlock = (ctx, x, y, w, h, color) => {
-            const grad = ctx.createLinearGradient(x, y, x, y + h);
-            grad.addColorStop(0, shade(color, 0.3));
-            grad.addColorStop(0.5, color);
-            grad.addColorStop(1, shade(color, -0.3));
-            ctx.fillStyle = grad;
+            ctx.fillStyle = color;
             ctx.fillRect(x, y, w, h);
-            const gloss = ctx.createLinearGradient(x, y, x, y + h);
-            gloss.addColorStop(0, 'rgba(255,255,255,0.4)');
-            gloss.addColorStop(0.3, 'rgba(255,255,255,0.1)');
-            gloss.addColorStop(0.5, 'rgba(255,255,255,0)');
-            ctx.fillStyle = gloss;
-            ctx.fillRect(x, y, w, h);
-            ctx.strokeStyle = shade(color, -0.5);
+            ctx.strokeStyle = shade(color, -0.4);
             ctx.lineWidth = OUTLINE;
             ctx.strokeRect(x + OUTLINE / 2, y + OUTLINE / 2, w - OUTLINE, h - OUTLINE);
           };


### PR DESCRIPTION
## Summary
- Replace photorealistic ball images with flat SVG assets at 64×64 resolution
- Simplify Brick Breaker block renderer to use flat colors for bricks and paddle

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_689cc540db608329a9812035fcaf5bb7