### PR TITLE
Improve Bubble Smash Royale touch controls and animations

### DIFF
--- a/webapp/public/bubble-smash-royale.html
+++ b/webapp/public/bubble-smash-royale.html
@@ -192,23 +192,36 @@
     return any?{marks,clusters}:null;
   }
 
-  function applyMatches(board, match, addFX){
+  function applyMatches(board, match, addFX, fallFX){
     let removed=0;
     for(let y=0;y<ROWS;y++){
       for(let x=0;x<COLS;x++){
         if(match.marks[y][x]){
-          if(addFX) addFX(x,y);
+          if(addFX) addFX(x,y, board[y][x].c);
           board[y][x]=null; removed++;
         }
       }
     }
-    // gravity
+    // gravity with animation support
     for(let x=0;x<COLS;x++){
-      let ptr=ROWS-1;
+      const col=[];
       for(let y=ROWS-1;y>=0;y--){
-        if(board[y][x]){ board[ptr][x]=board[y][x]; if(ptr!==y) board[y][x]=null; ptr--; }
+        const cell=board[y][x];
+        if(cell) col.push({cell,y});
       }
-      for(let y=ptr;y>=0;y--) board[y][x]=makeCell(randColor());
+      let ptr=ROWS-1;
+      for(const {cell,y} of col){
+        board[ptr][x]=cell;
+        if(fallFX && y!==ptr) fallFX(x,y,ptr,cell.c);
+        if(ptr!==y) board[y][x]=null;
+        ptr--;
+      }
+      while(ptr>=0){
+        const cell=makeCell(randColor());
+        board[ptr][x]=cell;
+        if(fallFX) fallFX(x,ptr-ROWS,ptr,cell.c);
+        ptr--;
+      }
     }
     const gained = removed>=3 ? (SCORE_BASE + (removed-3)*SCORE_EXTRA) : 0;
     return {removed,gained};
@@ -245,8 +258,18 @@
       ctx.clearRect(0,0,w,h);
       ctx.fillStyle='#0e1430'; ctx.fillRect(0,0,w,h);
 
+      const now=performance.now();
+      const skip=new Set();
+      for(const f of fx){
+        if(f.kind==='fall'){
+          const p=(now-f.t0)/f.dur;
+          if(p<1) skip.add(`${f.to.x},${f.to.y}`);
+        }
+      }
+
       for(let y=0;y<ROWS;y++){
         for(let x=0;x<COLS;x++){
+          if(skip.has(`${x},${y}`)) continue;
           const t=board[y][x]; if(!t) continue;
           const cx=o.x+x*csize+csize/2, cy=o.y+y*csize+csize/2, r=csize*0.38;
           drawCartoonBubble(ctx, cx, cy, r, t.c);
@@ -259,7 +282,6 @@
       }
 
       // FX
-      const now=performance.now();
       for(let i=fx.length-1;i>=0;i--){
         const f=fx[i], p=(now-f.t0)/f.dur;
         if(p>=1){ fx.splice(i,1); continue; }
@@ -278,6 +300,19 @@
           ctx.font=`bold ${Math.max(12, Math.floor(csize*0.4))}px system-ui`;
           ctx.textAlign='center';
           ctx.fillText(f.text, f.x, y);
+        } else if(f.kind==='fall'){
+          const from=centerOfCell(f.from.x,f.from.y);
+          const to=centerOfCell(f.to.x,f.to.y);
+          const e=1-Math.pow(1-p,3);
+          const x=from.x+(to.x-from.x)*e;
+          const y=from.y+(to.y-from.y)*e;
+          drawCartoonBubble(ctx, x, y, csize*0.38, f.color);
+        } else if(f.kind==='pop'){
+          ctx.save();
+          ctx.globalAlpha = 1 - p;
+          const r = f.r * (1 + 0.2*p);
+          drawCartoonBubble(ctx, f.x, f.y, r, f.color);
+          ctx.restore();
         }
       }
     }
@@ -290,7 +325,7 @@
     return {
       list:fx,
       draw:drawBoard,
-      burstAt(cx,cy){
+      burstAt(cx,cy,color){
         const c=centerOfCell(cx,cy); const parts=[];
         const csize=cell();
         for(let i=0;i<10;i++){
@@ -298,10 +333,14 @@
           parts.push({x:c.x,y:c.y,vx:Math.cos(a)*sp,vy:Math.sin(a)*sp,g:csize*0.8,r:Math.max(2,csize*0.08)});
         }
         fx.push({kind:'burst',t0:performance.now(),dur:260,parts});
+        fx.push({kind:'pop',t0:performance.now(),dur:200,x:c.x,y:c.y,r:csize*0.38,color});
       },
       floatScore(cx,cy,pts){
         const c=centerOfCell(cx,cy);
         fx.push({kind:'float',t0:performance.now(),dur:700,x:c.x,y:c.y,text:`+${pts}`});
+      },
+      fall(fromX,fromY,toX,toY,color){
+        fx.push({kind:'fall',t0:performance.now(),dur:260,from:{x:fromX,y:fromY},to:{x:toX,y:toY},color});
       }
     };
   }
@@ -338,7 +377,7 @@
         if(!match){ game.busy=false; return; }
         chain++;
         if(isUser){ pop(700+chain*80, 0.06, 0.2); }
-        const res=applyMatches(game.board, match, (cx,cy)=>fx.burstAt(cx,cy));
+        const res=applyMatches(game.board, match, (cx,cy,c)=>fx.burstAt(cx,cy,c), (x,fy,ty,c)=>fx.fall(x,fy,ty,c));
         if(match.clusters && match.clusters.length){
           const biggest = match.clusters.reduce((a,b)=> b.length>a.length?b:a, match.clusters[0]);
           const mid = biggest[(biggest.length/2)|0];
@@ -346,7 +385,7 @@
           fx.floatScore(mid.x, mid.y, pts);
         }
         game.score += res.gained;
-        setTimeout(step, 90);
+        setTimeout(step, 300);
       })();
     }
 
@@ -363,15 +402,16 @@
 
     // Touch-only input (finger drag)
     if(isUser){
-      ['pointerdown','touchstart','mousedown'].forEach(ev=>canvas.addEventListener(ev,()=>{ensureAudio();},{once:true}));
+      canvas.addEventListener('pointerdown', e=>{ if(e.pointerType==='touch'){ ensureAudio(); } }, {once:true});
       let start=null; let dragging=false;
       canvas.addEventListener('pointerdown', e=>{
+        if(e.pointerType!=='touch') return;
         const cell=evtToCell(canvas,e); if(!cell) return;
         start=cell; dragging=true; game.selected=cell; game.draw();
         canvas.setPointerCapture(e.pointerId);
       });
       canvas.addEventListener('pointermove', e=>{
-        if(!dragging||!start) return;
+        if(e.pointerType!=='touch'||!dragging||!start) return;
         const r=canvas.getBoundingClientRect();
         const x=e.clientX-r.left, y=e.clientY-r.top;
         const c=Math.min(canvas.width/COLS,canvas.height/ROWS);
@@ -389,10 +429,14 @@
         try{ canvas.releasePointerCapture(e.pointerId); }catch(_){}
       });
       canvas.addEventListener('pointerup', e=>{
+        if(e.pointerType!=='touch') return;
         dragging=false; start=null; game.selected=null; game.draw();
-        try{ canvas.releasePointerCapture(e.pointerId); }catch(_){}}
-      );
-      canvas.addEventListener('pointercancel', ()=>{ dragging=false; start=null; game.selected=null; game.draw(); });
+        try{ canvas.releasePointerCapture(e.pointerId); }catch(_){ }
+      });
+      canvas.addEventListener('pointercancel', e=>{
+        if(e.pointerType!=='touch') return;
+        dragging=false; start=null; game.selected=null; game.draw();
+      });
     }
 
     // safety
@@ -429,8 +473,8 @@
     (function resolve(){
       const m=findMatches(bot.board);
       if(!m){ return; }
-      const res=applyMatches(bot.board,m); bot.score+=res.gained;
-      setTimeout(resolve, 90);
+      const res=applyMatches(bot.board,m, (cx,cy,c)=>bot.fx.burstAt(cx,cy,c), (x,fy,ty,c)=>bot.fx.fall(x,fy,ty,c)); bot.score+=res.gained;
+      setTimeout(resolve, 300);
     })();
     return true;
   }


### PR DESCRIPTION
## Summary
- restrict Bubble Smash Royale movement to touch swipes only
- add animated falling and popping effects for smoother bubble transitions
- slow cascade timing to allow new animations and adjust bot logic

## Testing
- `npm test` *(fails: The module '/workspace/TonPlaygramWebApp/bot/node_modules/canvas/build/Release/canvas.node' was compiled against a different Node.js version)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689ccc6fa9d08329bf57d923b2cf676e