### PR TITLE
style: use cartoon block renderer for brick breaker

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -434,25 +434,24 @@
             })()
           };
 
-          const shade = (color, percent) => {
-            const num = parseInt(color.slice(1), 16);
-            let r = (num >> 16) + Math.round(255 * percent);
-            let g = ((num >> 8) & 0x00ff) + Math.round(255 * percent);
-            let b = (num & 0x0000ff) + Math.round(255 * percent);
-            r = Math.min(255, Math.max(0, r));
-            g = Math.min(255, Math.max(0, g));
-            b = Math.min(255, Math.max(0, b));
-            return `#${r.toString(16).padStart(2, '0')}${g
-              .toString(16)
-              .padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
-          };
-
           const drawBlock = (ctx, x, y, w, h, color) => {
+            const r = Math.min(w, h);
             ctx.fillStyle = color;
             ctx.fillRect(x, y, w, h);
-            ctx.strokeStyle = shade(color, -0.4);
-            ctx.lineWidth = OUTLINE;
-            ctx.strokeRect(x + OUTLINE / 2, y + OUTLINE / 2, w - OUTLINE, h - OUTLINE);
+            ctx.lineWidth = Math.max(2, r * 0.1);
+            ctx.strokeStyle = '#000';
+            ctx.lineJoin = 'round';
+            ctx.lineCap = 'round';
+            ctx.strokeRect(x, y, w, h);
+            ctx.save();
+            ctx.beginPath();
+            ctx.rect(x, y, w, h);
+            ctx.clip();
+            ctx.fillStyle = 'rgba(255,255,255,0.35)';
+            ctx.fillRect(x, y, w * 0.4, h * 0.4);
+            ctx.fillStyle = 'rgba(255,255,255,0.6)';
+            ctx.fillRect(x, y, w * 0.2, h * 0.2);
+            ctx.restore();
           };
 
           const state = {


### PR DESCRIPTION
## Summary
- Refactor Brick Breaker block renderer to use Tetris-style hard-edged highlights

## Testing
- `npm test` *(fails: The module '/workspace/TonPlaygramWebApp/bot/node_modules/canvas/build/Release/canvas.node' was compiled against a different Node.js version)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cdd2c6ea4832982bb1f9668bfc233