### PR TITLE
Increase square highlight size in Tetris Royale

### DIFF
--- a/webapp/public/tetris-royale.html
+++ b/webapp/public/tetris-royale.html
@@ -310,8 +310,8 @@ window.__TETRIS_ROYALE__ = true;
     ctx.rect(x, y, w, h);
     ctx.clip();
     // hard-edged square highlights sized to the block
-    const sizeLarge = Math.floor(r * 0.4);
-    const sizeSmall = Math.floor(r * 0.2);
+    const sizeLarge = Math.floor(r * 0.6);
+    const sizeSmall = Math.floor(r * 0.3);
     ctx.fillStyle = 'rgba(255,255,255,0.35)';
     ctx.fillRect(x, y, sizeLarge, sizeLarge);
     ctx.fillStyle = 'rgba(255,255,255,0.6)';


### PR DESCRIPTION
## Summary
- Enlarge hard-edged square highlight to better match Tetris block

## Testing
- `npm test` (fails: assert.ok(events.includes('diceRolled')))
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ce1fd3b008329985d82dc4b7af154