### PR TITLE
Expand Tetris block highlights

### DIFF
--- a/webapp/public/tetris-royale.html
+++ b/webapp/public/tetris-royale.html
@@ -309,9 +309,9 @@ window.__TETRIS_ROYALE__ = true;
     ctx.beginPath();
     ctx.rect(x, y, w, h);
     ctx.clip();
-    // hard-edged square highlights sized to the block
-    const sizeLarge = Math.floor(r * 0.6);
-    const sizeSmall = Math.floor(r * 0.3);
+    // hard-edged square highlights sized to the block (80% and 40%)
+    const sizeLarge = Math.floor(r * 0.8);
+    const sizeSmall = Math.floor(r * 0.4);
     ctx.fillStyle = 'rgba(255,255,255,0.35)';
     ctx.fillRect(x, y, sizeLarge, sizeLarge);
     ctx.fillStyle = 'rgba(255,255,255,0.6)';


### PR DESCRIPTION
## Summary
- widen Tetris block highlight squares to cover 80% of each block for a brighter look

## Testing
- `npm test` *(fails: DuplicateKey error in Mongo index build)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ce72bf530832981faa5c270d9b6c5