### PR TITLE
Refine Bubble Smash Royale board and visuals

### DIFF
--- a/webapp/public/bubble-smash-royale.html
+++ b/webapp/public/bubble-smash-royale.html
@@ -110,7 +110,7 @@
 <script>
 (function(){
   // ===== Core config =====
-  const COLS=9, ROWS=9;
+  const COLS=8, ROWS=8;
   const COLORS=['#5aa2ff','#ff9d5a','#ff5a6b','#d4af37','#34d399','#a78bfa'];
   const SCORE_BASE=60, SCORE_EXTRA=30;
 
@@ -240,10 +240,7 @@
     ctx.stroke();
     ctx.fillStyle = 'rgba(255,255,255,0.6)';
     ctx.beginPath();
-    ctx.arc(x - r*0.3, y - r*0.3, r*0.25, 0, Math.PI*2);
-    ctx.fill();
-    ctx.beginPath();
-    ctx.arc(x - r*0.45, y - r*0.45, r*0.07, 0, Math.PI*2);
+    ctx.arc(x - r*0.1, y - r*0.1, r*0.8, 0, Math.PI*2);
     ctx.fill();
   }
   function createFX(canvas){
@@ -340,7 +337,7 @@
         fx.push({kind:'float',t0:performance.now(),dur:700,x:c.x,y:c.y,text:`+${pts}`});
       },
       fall(fromX,fromY,toX,toY,color){
-        fx.push({kind:'fall',t0:performance.now(),dur:260,from:{x:fromX,y:fromY},to:{x:toX,y:toY},color});
+        fx.push({kind:'fall',t0:performance.now(),dur:400,from:{x:fromX,y:fromY},to:{x:toX,y:toY},color});
       }
     };
   }
@@ -385,7 +382,7 @@
           fx.floatScore(mid.x, mid.y, pts);
         }
         game.score += res.gained;
-        setTimeout(step, 300);
+        setTimeout(step, 450);
       })();
     }
 


### PR DESCRIPTION
## Summary
- shrink Bubble Smash Royale board to 8x8 and enlarge bubble highlights
- smooth falling bubble animations for better visibility

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ce895af048329aef1e96a5d05867f