### PR TITLE
feat: enlarge brick breaker highlights

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -447,10 +447,11 @@
             ctx.beginPath();
             ctx.rect(x, y, w, h);
             ctx.clip();
+            // hard-edged square highlights sized to the block (80% and 40%)
             ctx.fillStyle = 'rgba(255,255,255,0.35)';
-            ctx.fillRect(x, y, w * 0.4, h * 0.4);
+            ctx.fillRect(x, y, w * 0.8, h * 0.8);
             ctx.fillStyle = 'rgba(255,255,255,0.6)';
-            ctx.fillRect(x, y, w * 0.2, h * 0.2);
+            ctx.fillRect(x, y, w * 0.4, h * 0.4);
             ctx.restore();
           };
 


### PR DESCRIPTION
## Summary
- enlarge hard-edged highlight squares in Brick Breaker blocks to 80%/40%

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE test timed out; BOT_TOKEN not configured)*

------
https://chatgpt.com/codex/tasks/task_e_689ce9295b8c832984b46c9cbc40076a