### PR TITLE
Darken Tetris shadows and align card backgrounds

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -53,7 +53,7 @@
         flex-direction: column;
       }
       .card {
-        background: linear-gradient(180deg, #11172a 0%, #0e1428 100%);
+        background: linear-gradient(180deg, #0f1530, #0a0f24);
         border: 1px solid #1f2a58;
         border-radius: 14px;
         padding: 14px;

--- a/webapp/public/bubble-pop-royale.html
+++ b/webapp/public/bubble-pop-royale.html
@@ -18,7 +18,7 @@
   .btn{background:linear-gradient(180deg,#2a6cf0,#2156c8);border:none;font-weight:700;cursor:pointer}
   .hud{display:flex;gap:8px}
   .hud .panel{flex:1}
-  .panel{border:1px solid #223063;background:#0b1228;border-radius:12px;padding:10px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:4px}
+.panel{border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:12px;padding:10px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:4px}
   .score{color:var(--gold);font-weight:800}
   .timer{font-variant-numeric:tabular-nums;font-weight:800}
   .layout{display:grid;grid-template-rows:25vh 1fr;gap:10px;flex:1;min-height:0}
@@ -41,7 +41,7 @@
   .modal{padding:16px;border:1px solid #223063;border-radius:16px;background:linear-gradient(180deg,#0f1736,#0b1126)}
   .grid{display:grid;gap:10px}
   .grid.two{grid-template-columns:1fr 1fr}
-  .kpi{background:#0b1228;border:1px solid #223063;border-radius:12px;padding:10px;text-align:center}
+.kpi{background:linear-gradient(180deg,#0f1530,#0a0f24);border:1px solid #223063;border-radius:12px;padding:10px;text-align:center}
   .kpi .v{font-size:22px;font-weight:800}
   .winner-celebration{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);z-index:70;display:flex;flex-direction:column;align-items:center;pointer-events:none}
   .winner-celebration img{width:80px;height:80px;border-radius:50%;margin-bottom:8px;border:2px solid var(--gold)}

--- a/webapp/public/bubble-smash-royale.html
+++ b/webapp/public/bubble-smash-royale.html
@@ -13,7 +13,7 @@
 
   .hud{display:flex;gap:8px}
   .hud .panel{flex:1}
-  .panel{border:1px solid #223063;background:#0b1228;border-radius:12px;padding:10px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:4px}
+.panel{border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:12px;padding:10px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:4px}
   .score{color:var(--gold);font-weight:800}
   .timer{font-variant-numeric:tabular-nums;font-weight:800}
 
@@ -40,7 +40,7 @@
   .modal{padding:16px;border:1px solid #223063;border-radius:16px;background:linear-gradient(180deg,#0f1736,#0b1126)}
   .grid{display:grid;gap:10px}
   .grid.two{grid-template-columns:1fr 1fr}
-  .kpi{background:#0b1228;border:1px solid #223063;border-radius:12px;padding:10px;text-align:center}
+.kpi{background:linear-gradient(180deg,#0f1530,#0a0f24);border:1px solid #223063;border-radius:12px;padding:10px;text-align:center}
   .kpi .v{font-size:22px;font-weight:800}
 </style>
 </head>

--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -21,7 +21,7 @@
       .btn.primary{ background:#00f7ff; color:#fff; border:none; box-shadow:0 0 8px rgba(0,247,255,.5); }
       .btn.primary:hover{ background:#66fcff; }
     .btn:disabled{ opacity:.5; }
-    .panel{ position:absolute; left:10px; bottom:10px; right:10px; background:transparent; border:none; border-radius:16px; padding:10px; }
+    .panel{ position:absolute; left:10px; bottom:10px; right:10px; background:linear-gradient(180deg,#0f1530,#0a0f24); border:1px solid #223063; border-radius:16px; padding:10px; }
     .grid{ display:grid; grid-template-columns:repeat(var(--cols,5),minmax(0,1fr)); gap:6px; }
     .slot{ text-align:center; font-size:12px; color:#fff; padding:6px 0; border-radius:10px; border:1px dashed rgba(255,255,255,.12); display:flex; flex-direction:column; align-items:center; gap:4px; }
     .slot.me{ border-color:#7dd3fc; color:#c7f3ff; }
@@ -32,7 +32,7 @@
     .sep{ opacity:.3; }
       .popup{ position:absolute; inset:0; background:rgba(0,0,0,.7); display:flex; align-items:center; justify-content:center; }
       .popup.hidden{ display:none; }
-      .popup .box{ background:linear-gradient(#081428,#102040); background-color:#0b1a2f; border:1px solid #00f7ff; box-shadow:0 0 8px #00f7ff, inset 0 0 10px rgba(0,247,255,.4); padding:20px; border-radius:12px; text-align:center; color:#00f7ff; }
+      .popup .box{ background:linear-gradient(180deg,#0f1530,#0a0f24); background-color:#0b1a2f; border:1px solid #00f7ff; box-shadow:0 0 8px #00f7ff, inset 0 0 10px rgba(0,247,255,.4); padding:20px; border-radius:12px; text-align:center; color:#00f7ff; }
     .countdown{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; font-size:48px; font-weight:bold; color:#fff; background:rgba(0,0,0,0.5); z-index:50; }
     .countdown.hidden{ display:none; }
   </style>

--- a/webapp/public/fruit-slice-royale.html
+++ b/webapp/public/fruit-slice-royale.html
@@ -19,7 +19,7 @@
   .btn{background:linear-gradient(180deg,#2a6cf0,#2156c8);border:none;font-weight:700;cursor:pointer}
 
   .hud{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
-  .panel{border:1px solid #223063;background:#0b1228;border-radius:12px;padding:10px;display:flex;align-items:center;justify-content:space-between}
+.panel{border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:12px;padding:10px;display:flex;align-items:center;justify-content:space-between}
   .score{color:var(--gold);font-weight:800}
   .timer{font-variant-numeric:tabular-nums;font-weight:800}
 
@@ -41,7 +41,7 @@
   .modal{padding:16px;border:1px solid #223063;border-radius:16px;background:linear-gradient(180deg,#0f1736,#0b1126)}
   .grid{display:grid;gap:10px}
   .grid.two{grid-template-columns:1fr 1fr}
-  .kpi{background:#0b1228;border:1px solid #223063;border-radius:12px;padding:10px;text-align:center}
+.kpi{background:linear-gradient(180deg,#0f1530,#0a0f24);border:1px solid #223063;border-radius:12px;padding:10px;text-align:center}
   .kpi .v{font-size:22px;font-weight:800}
 </style>
 </head>

--- a/webapp/public/tetris-royale.html
+++ b/webapp/public/tetris-royale.html
@@ -301,7 +301,7 @@ window.__TETRIS_ROYALE__ = true;
     ctx.fillStyle = color;
     ctx.fillRect(x, y, w, h);
     ctx.lineWidth = Math.max(2, r * 0.1);
-    ctx.strokeStyle = 'rgba(0,0,0,0.4)';
+    ctx.strokeStyle = 'rgba(0,0,0,0.6)';
     ctx.lineJoin = 'round';
     ctx.lineCap = 'round';
     ctx.strokeRect(x, y, w, h);
@@ -309,9 +309,9 @@ window.__TETRIS_ROYALE__ = true;
     ctx.beginPath();
     ctx.rect(x, y, w, h);
     ctx.clip();
-    // hard-edged square highlights sized to the block (85% and 45%) positioned bottom-left
-    const sizeLarge = Math.floor(r * 0.85);
-    const sizeSmall = Math.floor(r * 0.45);
+    // hard-edged square highlights sized to the block (90% and 50%) positioned bottom-left
+    const sizeLarge = Math.floor(r * 0.9);
+    const sizeSmall = Math.floor(r * 0.5);
     ctx.fillStyle = 'rgba(255,255,255,0.25)';
     ctx.fillRect(x, y + h - sizeLarge, sizeLarge, sizeLarge);
     ctx.fillStyle = 'rgba(255,255,255,0.5)';


### PR DESCRIPTION
## Summary
- darken block shadows and enlarge highlights in Tetris Royale
- apply countdown card background to game cards across Bubble Smash, Bubble Pop, Brick Breaker, Falling Ball, and Fruit Slice

## Testing
- `npm test` *(fails: AssertionError: assert.ok(events.includes('diceRolled')))*

------
https://chatgpt.com/codex/tasks/task_e_689d0185f1e88329b54007e04f3204c7