### PR TITLE
Use Tetris Royale background across lobbies and games

### DIFF
--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -8,9 +8,9 @@
   <meta http-equiv="Expires" content="0" />
   <title>TonPlaygram – Falling Ball PvP (SFX + Visuals)</title>
   <style>
-    :root{ --bg:linear-gradient(#081428,#102040); --panel:#10172a; --ink:#e5e7eb; --muted:#10b981; --accent:#94a3b8; }
+    :root{ --bg:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%); --panel:#10172a; --ink:#e5e7eb; --muted:#10b981; --accent:#94a3b8; }
     html,body{ height:100%; margin:0; }
-    body{ background:var(--bg); background-color:#0b1a2f; color:var(--ink); font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif; }
+    body{ background:var(--bg) fixed; background-color:#0c1020; color:var(--ink); font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif; }
     .app{ position:fixed; inset:0; overflow:hidden; }
     canvas{ display:block; width:100%; height:100%; }
     .hudTop{ position:absolute; inset-inline:0; top:0; padding:4px 10px; display:flex; flex-wrap:wrap; gap:8px; align-items:center; justify-content:space-between; font-size:12px; color:#fff; }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -11,7 +11,9 @@
 body {
   font-family: Arial, Helvetica, sans-serif;
   margin: 0;
-  @apply bg-background text-text overflow-x-hidden;
+  @apply text-text overflow-x-hidden;
+  background: radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;
+  background-color: #0c1020;
   text-shadow: 0 0 4px #00f7ff;
   scrollbar-color: #ffd700 transparent;
 }


### PR DESCRIPTION
## Summary
- Apply Tetris Royale radial gradient to global web app body so all lobbies share the same background
- Align Falling Ball HTML with Tetris Royale background

## Testing
- `npm test --ignore-scripts` *(fails: joinRoom clears lobby seat)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d6a334ec48329a06ebf6bf5c6e779