### PR TITLE
Use Tetris Royale card background across pages

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -119,9 +119,11 @@ input:focus {
   bottom: -160px;
   z-index: -1;
   pointer-events: none;
-  background: radial-gradient(circle at center, #164e63, #0f172a);
-  /* slightly brighter and scaled up */
-  filter: brightness(2.4);
+  background:
+    radial-gradient(2px 2px at 20% 30%, rgba(255, 255, 255, 0.15), transparent 40%),
+    radial-gradient(1.5px 1.5px at 80% 70%, rgba(255, 255, 255, 0.1), transparent 50%),
+    linear-gradient(#081428, #102040);
+  background-color: #0b1a2f;
   transform: translateY(90px) scale(1.2);
 }
 


### PR DESCRIPTION
## Summary
- swap cosmic radial gradient for the Tetris Royale card background in `background-behind-board`

## Testing
- `npm test` *(fails: ERR_ASSERTION in test/snakeApi.test.js:189:12)*

------
https://chatgpt.com/codex/tasks/task_e_689d6ef965908329b4b2204ad33d64d4