### PR TITLE
feat: apply tetris grid background across games

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -140,7 +140,10 @@
         width: 100%;
         height: 100%;
         border-radius: 10px;
-        background: linear-gradient(0deg, #0a1026, #0c1430);
+        background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03) 0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%);
+        background-size: 100px 100px, cover;
+        background-position: 0 0, center;
+        animation: canvasDepthMove 30s linear infinite;
         display: block;
         image-rendering: pixelated;
         filter: saturate(1.2);
@@ -181,7 +184,10 @@
         height: 100%;
         display: block;
         border-radius: 10px;
-        background: linear-gradient(0deg, #0a1026, #0c1430);
+        background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03) 0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%);
+        background-size: 100px 100px, cover;
+        background-position: 0 0, center;
+        animation: canvasDepthMove 30s linear infinite;
         touch-action: none;
         image-rendering: pixelated;
         filter: saturate(1.2);
@@ -331,6 +337,8 @@
           opacity: 0;
         }
       }
+    
+      @keyframes canvasDepthMove{from{background-position:0 0,center}to{background-position:100px 100px,center}}
     </style>
   </head>
   <body>

--- a/webapp/public/bubble-pop-royale.html
+++ b/webapp/public/bubble-pop-royale.html
@@ -27,11 +27,11 @@
   .mini h3{margin:0;font-size:12px;color:var(--muted);display:flex;align-items:center;gap:4px}
   .mini .aiScore{font-size:12px;color:var(--muted);margin:2px 0 6px}
   .flagInline{width:16px;height:16px;border-radius:2px}
-  .mini canvas{flex:1;width:100%;height:100%;background:#0e1430;border-radius:8px}
+  .mini canvas{flex:1;width:100%;height:100%;background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite;border-radius:8px}
   .userWrap{position:relative;border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:14px;padding:10px;display:flex;flex-direction:column;min-height:0}
   .userHeader{display:flex;align-items:center;gap:8px;margin-bottom:8px}
   .userWrap h3{margin:0;font-size:13px;color:var(--muted)}
-  #user{flex:1;width:100%;height:100%;background:#0e1430;border-radius:10px;touch-action:none}
+  #user{flex:1;width:100%;height:100%;background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite;border-radius:10px;touch-action:none}
   .overlayButtons{position:absolute;left:10px;bottom:10px;display:flex;gap:8px}
   .small{padding:8px 10px;border-radius:10px;border:1px solid #223063;background:#15204a;color:#e7eefc;font-size:12px;cursor:pointer}
   .avatar{width:32px;height:32px;border-radius:50%}
@@ -48,6 +48,8 @@
   .coin-burst{position:fixed;left:50%;bottom:50%;width:0;height:0;z-index:60;pointer-events:none;overflow:visible}
   .coin-img{position:absolute;left:-16px;bottom:0;width:32px;height:32px;transform:translate(-50%,0);animation-name:coin-up;animation-duration:var(--dur);animation-delay:var(--delay);animation-timing-function:ease-out;animation-fill-mode:forwards;filter:brightness(1.5) drop-shadow(0 0 4px gold)}
   @keyframes coin-up{to{transform:translate(calc(-50% + var(--dx)),160px);opacity:0}}
+
+  @keyframes canvasDepthMove{from{background-position:0 0,center}to{background-position:100px 100px,center}}
 </style>
 </head>
 <body>

--- a/webapp/public/bubble-smash-royale.html
+++ b/webapp/public/bubble-smash-royale.html
@@ -23,13 +23,13 @@
   .mini h3{margin:0;font-size:12px;color:var(--muted);display:flex;align-items:center;gap:4px}
   .mini .aiScore{font-size:12px;color:var(--muted);margin:2px 0 6px}
   .flagInline{width:16px;height:16px;border-radius:2px}
-  .mini canvas{flex:1;width:100%;height:100%;background:#0e1430;border-radius:8px;image-rendering:pixelated}
+  .mini canvas{flex:1;width:100%;height:100%;background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite;border-radius:8px;image-rendering:pixelated}
 
   .userWrap{position:relative;border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:14px;padding:10px;display:flex;flex-direction:column;min-height:0}
   .userHeader{display:flex;align-items:center;gap:8px;margin-bottom:8px}
   .avatar{width:32px;height:32px;border-radius:50%}
   .userWrap h3{margin:0;font-size:13px;color:var(--muted)}
-  #user{flex:1;width:100%;height:100%;background:#0e1430;border-radius:10px;touch-action:none;image-rendering:pixelated}
+  #user{flex:1;width:100%;height:100%;background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite;border-radius:10px;touch-action:none;image-rendering:pixelated}
   .overlayButtons{position:absolute;left:10px;bottom:10px;display:flex;gap:8px}
   .small{padding:8px 10px;border-radius:10px;border:1px solid #223063;background:#15204a;color:#e7eefc;font-size:12px;cursor:pointer}
 
@@ -42,6 +42,8 @@
   .grid.two{grid-template-columns:1fr 1fr}
 .kpi{background:linear-gradient(180deg,#0f1530,#0a0f24);border:1px solid #223063;border-radius:12px;padding:10px;text-align:center}
   .kpi .v{font-size:22px;font-weight:800}
+
+  @keyframes canvasDepthMove{from{background-position:0 0,center}to{background-position:100px 100px,center}}
 </style>
 </head>
 <body>

--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -12,7 +12,12 @@
     html,body{ height:100%; margin:0; }
     body{ background:var(--bg) fixed; background-color:#0c1020; color:var(--ink); font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif; }
     .app{ position:fixed; inset:0; overflow:hidden; }
-    canvas{ display:block; width:100%; height:100%; }
+    canvas{ display:block; width:100%; height:100%; background:
+      repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px),
+      radial-gradient(circle at center,#1a2450 0%,#0e1430 80%);
+    background-size:100px 100px,cover;
+    background-position:0 0,center;
+    animation:canvasDepthMove 30s linear infinite; }
     .hudTop{ position:absolute; inset-inline:0; top:0; padding:4px 10px; display:flex; flex-wrap:wrap; gap:8px; align-items:center; justify-content:space-between; font-size:12px; color:#fff; }
     .row{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
     .chip{ padding:6px 10px; border-radius:12px; border:1px solid rgba(255,255,255,.15); color:#fff; background:transparent; cursor:pointer; }
@@ -35,6 +40,8 @@
       .popup .box{ background:linear-gradient(180deg,#0f1530,#0a0f24); background-color:#0b1a2f; border:1px solid #00f7ff; box-shadow:0 0 8px #00f7ff, inset 0 0 10px rgba(0,247,255,.4); padding:20px; border-radius:12px; text-align:center; color:#00f7ff; }
     .countdown{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; font-size:48px; font-weight:bold; color:#fff; background:rgba(0,0,0,0.5); z-index:50; }
     .countdown.hidden{ display:none; }
+  
+    @keyframes canvasDepthMove{from{background-position:0 0,center}to{background-position:100px 100px,center}}
   </style>
 </head>
 <body>

--- a/webapp/public/fruit-slice-royale.html
+++ b/webapp/public/fruit-slice-royale.html
@@ -29,12 +29,12 @@
   .mini h3{margin:0;font-size:12px;color:var(--muted);display:flex;align-items:center;gap:4px}
   .mini .aiScore{font-size:12px;color:var(--muted);margin:2px 0 6px}
   .flagInline{width:16px;height:16px;border-radius:2px}
-  .mini canvas{flex:1;width:100%;height:100%;background:#0e1430;border-radius:8px}
+  .mini canvas{flex:1;width:100%;height:100%;background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite;border-radius:8px}
 
   .userWrap{position:relative;border:1px solid #223063;background:linear-gradient(180deg,#0f1530,#0a0f24);border-radius:14px;padding:10px;display:flex;flex-direction:column;min-height:0}
   .userHeader{display:flex;align-items:center;gap:8px;margin-bottom:8px}
   .userHeader h3{margin:0;font-size:13px;color:var(--muted)}
-  #user{flex:1;width:100%;height:100%;background:#0e1430;border-radius:10px;touch-action:none}
+  #user{flex:1;width:100%;height:100%;background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite;border-radius:10px;touch-action:none}
   .avatar{width:32px;height:32px;border-radius:50%}
 
   dialog{border:none;border-radius:16px;background:#0d1330;color:#e7eefc;max-width:520px;width:calc(100% - 24px)}
@@ -43,6 +43,8 @@
   .grid.two{grid-template-columns:1fr 1fr}
 .kpi{background:linear-gradient(180deg,#0f1530,#0a0f24);border:1px solid #223063;border-radius:12px;padding:10px;text-align:center}
   .kpi .v{font-size:22px;font-weight:800}
+
+  @keyframes canvasDepthMove{from{background-position:0 0,center}to{background-position:100px 100px,center}}
 </style>
 </head>
 <body>

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -15,63 +15,63 @@ export default function HomeGamesCard() {
         <div className="flex overflow-x-auto space-x-4 items-center pb-2">
           <Link
             to="/games/goalrush/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/goal_rush_card_1200x675.webp" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Goal Rush</h3>
           </Link>
           <Link
             to="/games/snake/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/snakes_and_ladders.webp" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Snake &amp; Ladder</h3>
           </Link>
           <Link
             to="/games/fallingball/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/Falling Ball .png" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Falling Ball</h3>
           </Link>
           <Link
             to="/games/fruitsliceroyale/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/Fruit Slice Royale .png" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Fruit Slice Royale</h3>
           </Link>
           <Link
             to="/games/brickbreaker/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/Brick Breaker Royale .png" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Brick Breaker Royale</h3>
           </Link>
           <Link
             to="/games/tetrisroyale/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/file_00000000240061f4abd28311d76970a5.png" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Tetris Royale</h3>
           </Link>
           <Link
             to="/games/bubblesmashroyale/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/Bubble Smash Royale .png" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Bubble Smash Royale</h3>
           </Link>
           <Link
             to="/games/crazydice/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/Crazy_Dice_Duel_Promo.webp" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Crazy Dice Duel</h3>
           </Link>
           <Link
             to="/games/bubblepoproyale/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/Bubble Pop Royale .png" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Bubble Pop Royale</h3>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1677,3 +1677,20 @@ input:focus {
 .lucky-dice {
   transform: translate(0.75rem, 0.75rem);
 }
+@keyframes canvasDepthMove {
+  from {
+    background-position: 0 0, center;
+  }
+  to {
+    background-position: 100px 100px, center;
+  }
+}
+
+.tetris-grid-bg {
+  background:
+    repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.03) 0 2px, transparent 2px 4px),
+    radial-gradient(circle at center, #1a2450 0%, #0e1430 80%);
+  background-size: 100px 100px, cover;
+  background-position: 0 0, center;
+  animation: canvasDepthMove 30s linear infinite;
+}

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -12,63 +12,63 @@ export default function Games() {
             <div className="flex overflow-x-auto space-x-4 items-center pb-2">
                 <Link
                   to="/games/goalrush/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/goal_rush_card_1200x675.webp" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Goal Rush</h3>
                 </Link>
                 <Link
                   to="/games/snake/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/snakes_and_ladders.webp" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Snake &amp; Ladder</h3>
                 </Link>
                 <Link
                   to="/games/fallingball/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Falling Ball .png" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Falling Ball</h3>
                 </Link>
                 <Link
                   to="/games/fruitsliceroyale/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Fruit Slice Royale .png" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Fruit Slice Royale</h3>
                 </Link>
                 <Link
                   to="/games/brickbreaker/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Brick Breaker Royale .png" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Brick Breaker Royale</h3>
                 </Link>
                 <Link
                   to="/games/tetrisroyale/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/file_00000000240061f4abd28311d76970a5.png" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Tetris Royale</h3>
                 </Link>
                 <Link
                   to="/games/bubblesmashroyale/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Bubble Smash Royale .png" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Bubble Smash Royale</h3>
                 </Link>
                 <Link
                   to="/games/crazydice/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Crazy_Dice_Duel_Promo.webp" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Crazy Dice Duel</h3>
                 </Link>
                 <Link
                   to="/games/bubblepoproyale/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Bubble Pop Royale .png" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Bubble Pop Royale</h3>


### PR DESCRIPTION
## Summary
- add animated tetris-grid background style
- use grid background on all game cards
- apply grid background to Falling Ball, Fruit Slice Royale, Bubble Pop Royale, Bubble Smash Royale, and Brick Breaker game canvases

## Testing
- `npm test` *(fails: joinRoom clears lobby seat, snake API endpoints and socket events)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d7cbf7d1883298e0aa989bd49edcf