### PR TITLE
feat: add top-center logo to layout

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -92,6 +92,13 @@ export default function Layout({ children }) {
 
   return (
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
+      <header className="w-full bg-surface border-b-2 border-accent flex justify-center py-4">
+        <img
+          src="/assets/icons/TON.webp"
+          alt="TonPlaygram logo"
+          className="h-12"
+        />
+      </header>
       <main
         className={`flex-grow ${
           showNavbar ? 'container mx-auto p-4 pb-24' : 'w-full p-0'


### PR DESCRIPTION
## Summary
- display TonPlaygram logo centered at the top of every page

## Testing
- `npm test` *(fails: joinRoom clears lobby seat, snake API endpoints and socket events)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d8cba5a3c83299bfb2fb8dd222a99