### PR TITLE
chore: avoid reinstalling deps during tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-
 
-      - name: Install dependencies
+      - name: Setup system dependencies
         run: bash scripts/setup-tests.sh
+
+      - name: Install Node dependencies
+        run: |
+          npm ci
+          npm ci --prefix bot
+          npm ci --prefix webapp
 
       - name: Run ESLint
         run: npm run lint

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "start": "node bot/server.js",
     "install-all": "npm install && npm install --prefix bot && npm install --prefix webapp",
     "build": "npm --prefix webapp run build",
-    "pretest": "npm run install-all",
     "test": "node --test",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-# Install dependencies for the root package, bot and webapp. Run this before
-# executing `npm test` when setting up a fresh environment so required modules
-# like `express` and `socket.io-client` are available. Also installs OS level
-# packages needed to compile optional native modules such as `canvas`.
+# Install OS level dependencies required for optional native modules such as
+# `canvas`. Package installation (via `npm ci` in each package) is handled
+# separately in the CI workflow.
 set -e
 
 # Update apt and install build tools required for the `canvas` package
@@ -14,4 +13,3 @@ sudo apt-get install -y \
   libgif-dev \
   build-essential
 
-npm run install-all


### PR DESCRIPTION
## Summary
- remove `pretest` hook that reinstalled packages before running tests
- run `npm ci` for each package in CI and stop re-installing in test workflow
- limit `setup-tests.sh` to OS packages only

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*

------
https://chatgpt.com/codex/tasks/task_e_689d905bc93c8329909b072f45801ed0