### PR TITLE
feat(bot): optionally skip Telegram bot launch

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -199,7 +199,8 @@ function sendIndex(res) {
   } else {
     res.status(503).send('Webapp build not available');
   }
-  launchBotWithDelay();
+  if (process.env.SKIP_BOT_LAUNCH !== '1') launchBotWithDelay();
+  else console.log('Skipping Telegram bot launch');
 }
 
 let botLaunchTriggered = false;
@@ -224,7 +225,8 @@ function launchBotWithDelay() {
   }, 5000);
 }
 
-launchBotWithDelay();
+if (process.env.SKIP_BOT_LAUNCH !== '1') launchBotWithDelay();
+else console.log('Skipping Telegram bot launch');
 
 app.get('/', (req, res) => {
   sendIndex(res);


### PR DESCRIPTION
## Summary
- skip Telegram bot start when `SKIP_BOT_LAUNCH=1`

## Testing
- `SKIP_BOT_LAUNCH=1 npm test` *(failing: joinRoom clears lobby seat, snake API endpoints and socket events)*

------
https://chatgpt.com/codex/tasks/task_e_689d905c2bfc8329bc963ef0d95a24c4