### PR TITLE
test: use unique ports for integration tests

### DIFF
--- a/test/onlineRoutes.test.js
+++ b/test/onlineRoutes.test.js
@@ -27,7 +27,7 @@ test('online routes reflect pinged users', { concurrency: false }, async () => {
 
   const env = {
     ...process.env,
-    PORT: '3202',
+    PORT: '3205',
     MONGO_URI: 'memory',
     BOT_TOKEN: 'dummy',
     SKIP_WEBAPP_BUILD: '1',
@@ -35,7 +35,7 @@ test('online routes reflect pinged users', { concurrency: false }, async () => {
   };
   const server = await startServer(env);
   try {
-    const pingRes = await fetch('http://localhost:3202/api/online/ping', {
+    const pingRes = await fetch('http://localhost:3205/api/online/ping', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ playerId: 'player1', status: 'online' })
@@ -44,12 +44,12 @@ test('online routes reflect pinged users', { concurrency: false }, async () => {
     const ping = await pingRes.json();
     assert.equal(ping.success, true);
 
-    const countRes = await fetch('http://localhost:3202/api/online/count');
+    const countRes = await fetch('http://localhost:3205/api/online/count');
     assert.equal(countRes.status, 200);
     const count = await countRes.json();
     assert.equal(count.count, 1);
 
-    const listRes = await fetch('http://localhost:3202/api/online/list');
+    const listRes = await fetch('http://localhost:3205/api/online/list');
     assert.equal(listRes.status, 200);
     const list = await listRes.json();
     assert.deepEqual(list.users, [{ id: 'player1', status: 'online' }]);

--- a/test/snakeSeat.test.js
+++ b/test/snakeSeat.test.js
@@ -27,7 +27,7 @@ test('seat and unseat endpoints update lobby', { concurrency: false, timeout: 20
 
   const env = {
     ...process.env,
-    PORT: '3202',
+    PORT: '3206',
     MONGO_URI: 'memory',
     BOT_TOKEN: 'dummy',
     SKIP_WEBAPP_BUILD: '1'
@@ -35,26 +35,26 @@ test('seat and unseat endpoints update lobby', { concurrency: false, timeout: 20
 
   const server = await startServer(env);
   try {
-    let res = await fetch('http://localhost:3202/api/snake/table/seat', {
+    let res = await fetch('http://localhost:3206/api/snake/table/seat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ tableId: 'snake-2', playerId: 'p100', name: 'Tester' })
     });
     assert.equal(res.status, 200);
 
-    res = await fetch('http://localhost:3202/api/snake/lobby/snake-2');
+    res = await fetch('http://localhost:3206/api/snake/lobby/snake-2');
     assert.equal(res.status, 200);
     let lobby = await res.json();
     assert.ok(lobby.players.some(p => p.id === 'p100' && p.name === 'Tester'));
 
-    res = await fetch('http://localhost:3202/api/snake/table/unseat', {
+    res = await fetch('http://localhost:3206/api/snake/table/unseat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ tableId: 'snake-2', playerId: 'p100' })
     });
     assert.equal(res.status, 200);
 
-    res = await fetch('http://localhost:3202/api/snake/lobby/snake-2');
+    res = await fetch('http://localhost:3206/api/snake/lobby/snake-2');
     assert.equal(res.status, 200);
     lobby = await res.json();
     assert.ok(!lobby.players.some(p => p.id === 'p100'));

--- a/test/socialSearchFilterSelf.test.js
+++ b/test/socialSearchFilterSelf.test.js
@@ -26,7 +26,7 @@ test('search excludes requesting user', { concurrency: false }, async () => {
   fs.writeFileSync(new URL('index.html', distDir), '');
   const env = {
     ...process.env,
-    PORT: '3203',
+    PORT: '3208',
     MONGO_URI: 'memory',
     BOT_TOKEN: 'dummy',
     SKIP_WEBAPP_BUILD: '1',
@@ -34,17 +34,17 @@ test('search excludes requesting user', { concurrency: false }, async () => {
   };
   const server = await startServer(env);
   try {
-    await fetch('http://localhost:3203/api/profile/update', {
+    await fetch('http://localhost:3208/api/profile/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ telegramId: 1, firstName: 'Alice' })
     });
-    await fetch('http://localhost:3203/api/profile/update', {
+    await fetch('http://localhost:3208/api/profile/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ telegramId: 2, firstName: 'Alicia' })
     });
-    const res = await fetch('http://localhost:3203/api/social/search', {
+    const res = await fetch('http://localhost:3208/api/social/search', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query: 'Ali', telegramId: 1 })


### PR DESCRIPTION
## Summary
- assign unique ports to online routes, snake seat, and social search tests to avoid conflicts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d905c454c83299a68775ec231fe5d