### PR TITLE
feat: enlarge header logo

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -101,7 +101,7 @@ export default function Layout({ children }) {
           <img
             src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp"
             alt="TonPlaygram logo"
-            className="h-12"
+            className="h-36"
           />
         </header>
       )}


### PR DESCRIPTION
## Summary
- triple header logo size for greater visibility

## Testing
- `npm test` *(fails: joinRoom clears lobby seat)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d99e349808329af8186caa411ce29