### PR TITLE
Adjust header logo spacing

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -97,11 +97,11 @@ export default function Layout({ children }) {
   return (
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
       {showHeader && (
-        <header className="w-full bg-surface border-b-2 border-accent flex justify-center py-4">
+        <header className="w-full bg-surface border-b-2 border-accent flex justify-center py-2">
           <img
             src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp"
             alt="TonPlaygram logo"
-            className="h-36"
+            className="h-40"
           />
         </header>
       )}


### PR DESCRIPTION
## Summary
- enlarge header logo slightly for better visibility
- reduce header vertical padding to tighten layout

## Testing
- `npm test` *(fails: joinRoom clears lobby seat)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689da48889048329b849fb17482295ce