### PR TITLE
Make lobby backgrounds full-screen

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -88,10 +88,12 @@ export default function Layout({ children }) {
     !location.pathname.includes('/lobby')
   );
 
+  const isLobby = location.pathname.includes('/lobby');
+
   const showFooter = !location.pathname.startsWith('/games/');
   const showHeader =
     !location.pathname.startsWith('/games/') ||
-    location.pathname.includes('/lobby') ||
+    isLobby ||
     location.pathname.startsWith('/games/snake');
 
   return (
@@ -107,7 +109,11 @@ export default function Layout({ children }) {
       )}
       <main
         className={`flex-grow ${
-          showNavbar ? 'container mx-auto p-4 pb-24' : 'w-full p-0'
+          showNavbar
+            ? isLobby
+              ? 'w-full p-4 pb-24'
+              : 'container mx-auto p-4 pb-24'
+            : 'w-full p-0'
         }`}
       >
         {children}


### PR DESCRIPTION
## Summary
- Ensure lobby routes use full-width layout so their backgrounds cover the whole screen
- Identify lobby routes through new `isLobby` flag in Layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689da4ee5c108329a32caa2b4e9e0d9c