### PR TITLE
style: align Brick Breaker ball design with Bubble Pop

### DIFF
--- a/webapp/public/assets/icons/orange_ball.svg
+++ b/webapp/public/assets/icons/orange_ball.svg
@@ -1,3 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <circle cx="32" cy="32" r="28" fill="#ff9d5a"/>
+  <circle cx="32" cy="32" r="28" fill="#ff9d5a" stroke="#000" stroke-width="4"/>
+  <circle cx="22" cy="22" r="8" fill="#ffffff" fill-opacity="0.6"/>
+  <circle cx="18" cy="18" r="3" fill="#ffffff" fill-opacity="0.6"/>
 </svg>

--- a/webapp/public/assets/icons/white_ball.svg
+++ b/webapp/public/assets/icons/white_ball.svg
@@ -1,3 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <circle cx="32" cy="32" r="28" fill="#ffffff"/>
+  <circle cx="32" cy="32" r="28" fill="#5aa2ff" stroke="#000" stroke-width="4"/>
+  <circle cx="22" cy="22" r="8" fill="#ffffff" fill-opacity="0.6"/>
+  <circle cx="18" cy="18" r="3" fill="#ffffff" fill-opacity="0.6"/>
 </svg>

--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -402,7 +402,7 @@
             bg: '#ffffff',
             wall: '#000000',
             paddle: '#ff6b6b',
-            ball: '#ffd166',
+            ball: '#5aa2ff',
             text: '#ffffff',
             power: '#ffa600',
             danger: '#ef476f'


### PR DESCRIPTION
## Summary
- restyle Brick Breaker balls to match Bubble Pop bubble graphics
- set Brick Breaker default ball color to Bubble Pop blue

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689da91e50308329910fff17c242d7f0