### PR TITLE
Increase logo size and adjust header spacing

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -99,11 +99,11 @@ export default function Layout({ children }) {
   return (
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
       {showHeader && (
-        <header className="w-full bg-surface border-b-2 border-accent flex justify-center py-2">
+        <header className="w-full bg-surface border-b-2 border-accent flex justify-center py-1">
           <img
             src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp"
             alt="TonPlaygram logo"
-            className="h-40"
+            className="h-48"
           />
         </header>
       )}


### PR DESCRIPTION
## Summary
- Increase header logo height by 20%
- Halve vertical padding around the logo

## Testing
- `npm run lint`
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_689daf7b06308329994a9793abc91523