### PR TITLE
Add Goal Rush configuration popup

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -33,6 +33,13 @@
     .mute-btn{position:absolute;top:6px;right:6px;z-index:5;background:#0b1220;border:1px solid #233050;color:#e5e7eb;border-radius:8px;padding:4px 8px;font-size:14px}
     .mute-btn.muted::after{content:'';position:absolute;top:50%;left:20%;width:60%;height:2px;background:#ff3b3b;transform:rotate(-45deg)}
 
+    .config-btn{position:absolute;top:6px;right:40px;z-index:5;background:#0b1220;border:1px solid #233050;color:#e5e7eb;border-radius:8px;padding:4px 8px;font-size:14px}
+    .config-popup{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;z-index:10;background:transparent}
+    .config-box{background:#0b1220;border:1px solid #233050;border-radius:12px;padding:16px;color:#e5e7eb;display:flex;flex-direction:column;gap:8px}
+    .config-box label{display:flex;align-items:center;gap:8px;font-size:14px}
+    .config-box input[type=range]{flex:1}
+    .config-save{margin-top:8px;padding:6px 12px;background:#233050;color:#e5e7eb;border:1px solid #455a88;border-radius:8px}
+
     .coin-confetti{position:fixed;top:-40px;width:32px;height:32px;pointer-events:none;animation:coin-fall var(--duration,3s) linear forwards}
     @keyframes coin-fall{from{transform:translateY(-10vh) rotate(0deg);opacity:1}to{transform:translateY(100vh) rotate(360deg);opacity:0}}
 
@@ -51,12 +58,26 @@
       </div>
     </div>
     <button id="muteBtn" class="mute-btn" aria-label="Toggle sound">🔊</button>
+    <button id="configBtn" class="config-btn" aria-label="Game settings">⚙️</button>
     <div class="canvasWrap">
       <canvas id="game" width="720" height="1280" aria-label="Goal Rush Field"></canvas>
     </div>
   </div>
   <div class="hint" id="startHint"></div>
   <div class="landscape-block" style="display:none">Please hold your phone in <b>portrait</b> for the best experience.</div>
+
+  <div id="configPopup" class="config-popup" style="display:none">
+    <div class="config-box">
+      <label>Goal Width<input type="range" id="cfgGoalWidth" min="0.2" max="0.6" step="0.01"></label>
+      <label>Avatar Size<input type="range" id="cfgAvatarSize" min="0.5" max="1.5" step="0.01"></label>
+      <label>Ball Size<input type="range" id="cfgBallSize" min="0.5" max="1.5" step="0.01"></label>
+      <label>Field Width<input type="range" id="cfgFieldWidth" min="0.5" max="1.5" step="0.01"></label>
+      <label>Field Height<input type="range" id="cfgFieldHeight" min="0.5" max="1.5" step="0.01"></label>
+      <label>Background Width<input type="range" id="cfgBgWidth" min="0.5" max="1.5" step="0.01"></label>
+      <label>Background Height<input type="range" id="cfgBgHeight" min="0.5" max="1.5" step="0.01"></label>
+      <button id="cfgSave" class="config-save">Save</button>
+    </div>
+  </div>
 
 <script src="/falling-ball-api.js"></script>
 <script>
@@ -70,6 +91,16 @@
   const startHint = document.getElementById('startHint');
   const landscapeBlock = document.querySelector('.landscape-block');
   const muteBtn = document.getElementById('muteBtn');
+  const configBtn = document.getElementById('configBtn');
+  const configPopup = document.getElementById('configPopup');
+  const cfgGoalWidth = document.getElementById('cfgGoalWidth');
+  const cfgAvatarSize = document.getElementById('cfgAvatarSize');
+  const cfgBallSize = document.getElementById('cfgBallSize');
+  const cfgFieldWidth = document.getElementById('cfgFieldWidth');
+  const cfgFieldHeight = document.getElementById('cfgFieldHeight');
+  const cfgBgWidth = document.getElementById('cfgBgWidth');
+  const cfgBgHeight = document.getElementById('cfgBgHeight');
+  const cfgSave = document.getElementById('cfgSave');
   const TOP_BAR = 40; // height of scoreboard bar
   const BOTTOM_GAP = 20; // gap below rink
   let fieldScaleActual = 1;
@@ -106,10 +137,14 @@
   const oppParam = params.get('p2Avatar') || '';
   let p1Name = params.get('name') || 'P1';
   let p2Name = params.get('p2Name') || 'P2';
-  let fieldScale = 1, fieldImgScale = 1, puckScale = 0.9, goalWidthPct = 0.36, goalOffsetPct = 0, paddleScale = 0.95, speedMul = 1;
+  let fieldScaleX = 1, fieldScaleY = 1, fieldImgScaleX = 1, fieldImgScaleY = 1, puckScale = 0.9, goalWidthPct = 0.36, goalOffsetPct = 0, paddleScale = 0.95, speedMul = 1;
   try {
-    fieldScale = parseFloat(localStorage.getItem('fieldScale')) || 1;
-    fieldImgScale = parseFloat(localStorage.getItem('fieldImgScale')) || 1;
+    const oldFieldScale = parseFloat(localStorage.getItem('fieldScale')) || 1;
+    fieldScaleX = parseFloat(localStorage.getItem('fieldScaleX')) || oldFieldScale;
+    fieldScaleY = parseFloat(localStorage.getItem('fieldScaleY')) || oldFieldScale;
+    const oldImgScale = parseFloat(localStorage.getItem('fieldImgScale')) || 1;
+    fieldImgScaleX = parseFloat(localStorage.getItem('fieldImgScaleX')) || oldImgScale;
+    fieldImgScaleY = parseFloat(localStorage.getItem('fieldImgScaleY')) || oldImgScale;
     puckScale = parseFloat(localStorage.getItem('puckScale')) || 0.9;
     goalWidthPct = parseFloat(localStorage.getItem('goalWidthPct')) || 0.36;
     goalOffsetPct = parseFloat(localStorage.getItem('goalOffsetPct')) || 0;
@@ -250,17 +285,19 @@
     canvas.style.height = usableHeight + 'px';
     const baseW = W*0.88;
     const baseH = H*0.92;
-    const maxFieldScale = Math.min(W/baseW, H/baseH);
-    const fs = Math.min(fieldScale, maxFieldScale);
-    fieldScaleActual = fs;
-    rink.w = Math.round(baseW * fs);
-    rink.h = Math.round(baseH * fs);
+    const maxFieldScaleX = W/baseW;
+    const maxFieldScaleY = H/baseH;
+    const fsx = Math.min(fieldScaleX, maxFieldScaleX);
+    const fsy = Math.min(fieldScaleY, maxFieldScaleY);
+    fieldScaleActual = Math.min(fsx, fsy);
+    rink.w = Math.round(baseW * fsx);
+    rink.h = Math.round(baseH * fsy);
     rink.x = Math.round((W - rink.w) / 2);
     rink.y = Math.round((H - rink.h) / 2);
     centerX = W/2; centerY = H/2;
     goalCenterX = centerX + rink.w * goalOffsetPct;
-    goalWidth = Math.round(W*goalWidthPct*fs);
-    const base = Math.max(24, Math.round(Math.min(W,H)*0.035*fs));
+    goalWidth = Math.round(W*goalWidthPct*fsx);
+    const base = Math.max(24, Math.round(Math.min(W,H)*0.035*fieldScaleActual));
     paddleRadius = base*3.4*paddleScale;
     puck.r = Math.max(20, Math.round(base*1.0*puckScale));
     p1.r = paddleRadius; p2.r = paddleRadius;
@@ -318,6 +355,37 @@
     }
   });
 
+  configBtn.addEventListener('click', () => {
+    cfgGoalWidth.value = goalWidthPct;
+    cfgAvatarSize.value = paddleScale;
+    cfgBallSize.value = puckScale;
+    cfgFieldWidth.value = fieldScaleX;
+    cfgFieldHeight.value = fieldScaleY;
+    cfgBgWidth.value = fieldImgScaleX;
+    cfgBgHeight.value = fieldImgScaleY;
+    configPopup.style.display = 'flex';
+  });
+  cfgGoalWidth.addEventListener('input', e=>{ goalWidthPct = parseFloat(e.target.value); fit(); });
+  cfgAvatarSize.addEventListener('input', e=>{ paddleScale = parseFloat(e.target.value); fit(); });
+  cfgBallSize.addEventListener('input', e=>{ puckScale = parseFloat(e.target.value); fit(); });
+  cfgFieldWidth.addEventListener('input', e=>{ fieldScaleX = parseFloat(e.target.value); fit(); });
+  cfgFieldHeight.addEventListener('input', e=>{ fieldScaleY = parseFloat(e.target.value); fit(); });
+  cfgBgWidth.addEventListener('input', e=>{ fieldImgScaleX = parseFloat(e.target.value); });
+  cfgBgHeight.addEventListener('input', e=>{ fieldImgScaleY = parseFloat(e.target.value); });
+  cfgSave.addEventListener('click', () => {
+    try{
+      localStorage.setItem('goalWidthPct', goalWidthPct);
+      localStorage.setItem('paddleScale', paddleScale);
+      localStorage.setItem('puckScale', puckScale);
+      localStorage.setItem('fieldScaleX', fieldScaleX);
+      localStorage.setItem('fieldScaleY', fieldScaleY);
+      localStorage.setItem('fieldImgScaleX', fieldImgScaleX);
+      localStorage.setItem('fieldImgScaleY', fieldImgScaleY);
+    }catch{}
+    configPopup.style.display = 'none';
+    fit();
+  });
+
   const sfx = {
     hit(){
       if(!audioEnabled) return;
@@ -364,8 +432,8 @@
   }
   function drawRink(){
     if (fieldImg.complete) {
-      const imgW = rink.w * fieldImgScale;
-      const imgH = rink.h * fieldImgScale;
+      const imgW = rink.w * fieldImgScaleX;
+      const imgH = rink.h * fieldImgScaleY;
       const imgX = rink.x + (rink.w - imgW)/2;
       const imgY = rink.y + (rink.h - imgH)/2;
       ctx.drawImage(fieldImg, imgX, imgY, imgW, imgH);


### PR DESCRIPTION
## Summary
- Add in-game settings gear button opening transparent popup
- Allow adjusting goal width, avatar, ball, field and background dimensions with live preview
- Persist settings to localStorage via Save button

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_689dbfccfb28832988236d6968c5ef76