### PR TITLE
feat: add goal offset and ball speed config

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -75,6 +75,9 @@
       <label>Field Height<input type="range" id="cfgFieldHeight" min="0.5" max="1.5" step="0.01"></label>
       <label>Background Width<input type="range" id="cfgBgWidth" min="0.5" max="1.5" step="0.01"></label>
       <label>Background Height<input type="range" id="cfgBgHeight" min="0.5" max="1.5" step="0.01"></label>
+      <label>Goal Offset X<input type="range" id="cfgGoalOffsetX" min="-0.5" max="0.5" step="0.01"></label>
+      <label>Goal Offset Y<input type="range" id="cfgGoalOffsetY" min="-0.5" max="0.5" step="0.01"></label>
+      <label>Ball Speed<input type="range" id="cfgBallSpeed" min="0.5" max="2" step="0.05"></label>
       <button id="cfgSave" class="config-save">Save</button>
     </div>
   </div>
@@ -100,6 +103,9 @@
   const cfgFieldHeight = document.getElementById('cfgFieldHeight');
   const cfgBgWidth = document.getElementById('cfgBgWidth');
   const cfgBgHeight = document.getElementById('cfgBgHeight');
+  const cfgGoalOffsetX = document.getElementById('cfgGoalOffsetX');
+  const cfgGoalOffsetY = document.getElementById('cfgGoalOffsetY');
+  const cfgBallSpeed = document.getElementById('cfgBallSpeed');
   const cfgSave = document.getElementById('cfgSave');
   const TOP_BAR = 40; // height of scoreboard bar
   const BOTTOM_GAP = 20; // gap below rink
@@ -137,7 +143,7 @@
   const oppParam = params.get('p2Avatar') || '';
   let p1Name = params.get('name') || 'P1';
   let p2Name = params.get('p2Name') || 'P2';
-  let fieldScaleX = 1, fieldScaleY = 1, fieldImgScaleX = 1, fieldImgScaleY = 1, puckScale = 0.9, goalWidthPct = 0.36, goalOffsetPct = 0, paddleScale = 0.95, speedMul = 1;
+  let fieldScaleX = 1, fieldScaleY = 1, fieldImgScaleX = 1, fieldImgScaleY = 1, puckScale = 0.9, goalWidthPct = 0.36, goalOffsetXPct = 0, goalOffsetYPct = 0, paddleScale = 0.95, speedMul = 1;
   try {
     const oldFieldScale = parseFloat(localStorage.getItem('fieldScale')) || 1;
     fieldScaleX = parseFloat(localStorage.getItem('fieldScaleX')) || oldFieldScale;
@@ -147,7 +153,8 @@
     fieldImgScaleY = parseFloat(localStorage.getItem('fieldImgScaleY')) || oldImgScale;
     puckScale = parseFloat(localStorage.getItem('puckScale')) || 0.9;
     goalWidthPct = parseFloat(localStorage.getItem('goalWidthPct')) || 0.36;
-    goalOffsetPct = parseFloat(localStorage.getItem('goalOffsetPct')) || 0;
+    goalOffsetXPct = parseFloat(localStorage.getItem('goalOffsetXPct')) || 0;
+    goalOffsetYPct = parseFloat(localStorage.getItem('goalOffsetYPct')) || 0;
     paddleScale = parseFloat(localStorage.getItem('paddleScale')) || 0.95;
     speedMul = parseFloat(localStorage.getItem('speedMul')) || 1;
   } catch {}
@@ -276,7 +283,7 @@
     box.appendChild(btnLobby);box.appendChild(btnAgain);pop.appendChild(box);document.body.appendChild(pop);
   }
 
-  let W = 720, H = 1280, goalCenterX = 0;
+  let W = 720, H = 1280, goalCenterX = 0, goalTopY = 0, goalBottomY = 0;
   function fit(){
     W = canvas.width = Math.floor(window.innerWidth * devicePixelRatio);
     const usableHeight = window.innerHeight - TOP_BAR - BOTTOM_GAP;
@@ -295,7 +302,9 @@
     rink.x = Math.round((W - rink.w) / 2);
     rink.y = Math.round((H - rink.h) / 2);
     centerX = W/2; centerY = H/2;
-    goalCenterX = centerX + rink.w * goalOffsetPct;
+    goalCenterX = centerX + rink.w * goalOffsetXPct;
+    goalTopY = rink.y + rink.h * goalOffsetYPct;
+    goalBottomY = goalTopY + rink.h;
     goalWidth = Math.round(W*goalWidthPct*fsx);
     const base = Math.max(24, Math.round(Math.min(W,H)*0.035*fieldScaleActual));
     paddleRadius = base*3.4*paddleScale;
@@ -363,6 +372,9 @@
     cfgFieldHeight.value = fieldScaleY;
     cfgBgWidth.value = fieldImgScaleX;
     cfgBgHeight.value = fieldImgScaleY;
+    cfgGoalOffsetX.value = goalOffsetXPct;
+    cfgGoalOffsetY.value = goalOffsetYPct;
+    cfgBallSpeed.value = speedMul;
     configPopup.style.display = 'flex';
   });
   cfgGoalWidth.addEventListener('input', e=>{ goalWidthPct = parseFloat(e.target.value); fit(); });
@@ -372,6 +384,9 @@
   cfgFieldHeight.addEventListener('input', e=>{ fieldScaleY = parseFloat(e.target.value); fit(); });
   cfgBgWidth.addEventListener('input', e=>{ fieldImgScaleX = parseFloat(e.target.value); });
   cfgBgHeight.addEventListener('input', e=>{ fieldImgScaleY = parseFloat(e.target.value); });
+  cfgGoalOffsetX.addEventListener('input', e=>{ goalOffsetXPct = parseFloat(e.target.value); fit(); });
+  cfgGoalOffsetY.addEventListener('input', e=>{ goalOffsetYPct = parseFloat(e.target.value); fit(); });
+  cfgBallSpeed.addEventListener('input', e=>{ speedMul = parseFloat(e.target.value); });
   cfgSave.addEventListener('click', () => {
     try{
       localStorage.setItem('goalWidthPct', goalWidthPct);
@@ -381,6 +396,9 @@
       localStorage.setItem('fieldScaleY', fieldScaleY);
       localStorage.setItem('fieldImgScaleX', fieldImgScaleX);
       localStorage.setItem('fieldImgScaleY', fieldImgScaleY);
+      localStorage.setItem('goalOffsetXPct', goalOffsetXPct);
+      localStorage.setItem('goalOffsetYPct', goalOffsetYPct);
+      localStorage.setItem('speedMul', speedMul);
     }catch{}
     configPopup.style.display = 'none';
     fit();
@@ -449,17 +467,17 @@
       ctx.moveTo(centerX + Math.min(W,H)*0.09, H*0.75);
       ctx.arc(centerX, H*0.75, Math.min(W,H)*0.09, 0, Math.PI*2);
       ctx.stroke();
-      drawGoal(goalCenterX, rink.y, goalWidth, goalDepth, -1);
-      drawGoal(goalCenterX, rink.y + rink.h, goalWidth, goalDepth, 1);
+      drawGoal(goalCenterX, goalTopY, goalWidth, goalDepth, -1);
+      drawGoal(goalCenterX, goalBottomY, goalWidth, goalDepth, 1);
     }
     const lw = Math.max(3, W*0.004);
     ctx.lineWidth = lw;
     ctx.strokeStyle = getCSS('--goal');
     ctx.beginPath();
-    ctx.moveTo(goalCenterX - goalWidth / 2, rink.y);
-    ctx.lineTo(goalCenterX + goalWidth / 2, rink.y);
-    ctx.moveTo(goalCenterX - goalWidth / 2, rink.y + rink.h);
-    ctx.lineTo(goalCenterX + goalWidth / 2, rink.y + rink.h);
+    ctx.moveTo(goalCenterX - goalWidth / 2, goalTopY);
+    ctx.lineTo(goalCenterX + goalWidth / 2, goalTopY);
+    ctx.moveTo(goalCenterX - goalWidth / 2, goalBottomY);
+    ctx.lineTo(goalCenterX + goalWidth / 2, goalBottomY);
     ctx.stroke();
   }
   function drawGoal(cx, y, w, d, dir){
@@ -629,8 +647,8 @@
 
     const left = rink.x + 6 + puck.r;
     const right = rink.x + rink.w - 6 - puck.r;
-    const top = rink.y + 6 + puck.r;
-    const bottom = rink.y + rink.h - 6 - puck.r;
+    const top = goalTopY + 6 + puck.r;
+    const bottom = goalBottomY - 6 - puck.r;
 
     if (puck.x < left){ puck.x = left; puck.vx *= -1; sfx.wall(); }
     if (puck.x > right){ puck.x = right; puck.vx *= -1; sfx.wall(); }


### PR DESCRIPTION
## Summary
- allow shifting goals horizontally and vertically
- add ball speed multiplier

## Testing
- `npm test` *(fails: snake API endpoints and socket events: test timed out after 20000ms)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dc70f8cdc83299af842346b8dbcce