### PR TITLE
Refine Tetris Royale block highlight styling

### DIFF
--- a/webapp/public/tetris-royale.html
+++ b/webapp/public/tetris-royale.html
@@ -314,15 +314,15 @@ window.__TETRIS_ROYALE__ = true;
     ctx.beginPath();
     ctx.rect(x, y, w, h);
     ctx.clip();
-    // hard-edged rectangular highlights sized to the block (80% and 40%) positioned bottom-left
-    const sizeLargeW = Math.floor(w * 0.8);
-    const sizeLargeH = Math.floor(h * 0.8);
-    const sizeSmallW = Math.floor(w * 0.4);
-    const sizeSmallH = Math.floor(h * 0.4);
+    // hard-edged rectangular highlights sized to the block (75% and 35%) positioned bottom-left
+    const sizeLargeW = Math.floor(w * 0.75);
+    const sizeLargeH = Math.floor(h * 0.75);
+    const sizeSmallW = Math.floor(w * 0.35);
+    const sizeSmallH = Math.floor(h * 0.35);
     const extra = Math.floor(r * 0.03);
-    ctx.fillStyle = 'rgba(255,255,255,0.25)';
+    ctx.fillStyle = 'rgba(255,255,255,0.2)';
     ctx.fillRect(x, y + h - sizeLargeH, sizeLargeW + extra, sizeLargeH);
-    ctx.fillStyle = 'rgba(255,255,255,0.5)';
+    ctx.fillStyle = 'rgba(255,255,255,0.35)';
     ctx.fillRect(x, y + h - sizeSmallH, sizeSmallW + extra, sizeSmallH);
     ctx.restore();
   }


### PR DESCRIPTION
## Summary
- Reduce block highlight size to 75%/35% for subtler effect
- Lower highlight opacity for softer appearance

## Testing
- `npm test` (fails: CLAIM_CONTRACT_ADDRESS and CLAIM_WALLET_MNEMONIC must be set)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dd9e15a54832994f9369fc776dd8a