### PR TITLE
Tweak Brick Breaker Royale brick highlight size

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -461,10 +461,10 @@
             ctx.beginPath();
             ctx.rect(x, y, w, h);
             ctx.clip();
-            const sizeLargeW = Math.floor(w * 0.75);
-            const sizeLargeH = Math.floor(h * 0.75);
-            const sizeSmallW = Math.floor(w * 0.35);
-            const sizeSmallH = Math.floor(h * 0.35);
+            const sizeLargeW = Math.floor(w * 0.65);
+            const sizeLargeH = Math.floor(h * 0.65);
+            const sizeSmallW = Math.floor(w * 0.3);
+            const sizeSmallH = Math.floor(h * 0.3);
             const extra = Math.floor(r * 0.03);
             ctx.fillStyle = 'rgba(255,255,255,0.2)';
             ctx.fillRect(x, y + h - sizeLargeH, sizeLargeW + extra, sizeLargeH);


### PR DESCRIPTION
## Summary
- Reduce highlight rectangles on bricks to make them smaller and less overpowering

## Testing
- `npm test` *(fails: Failed to launch Telegram bot: The "options.agent" property must be one of Agent-like Object, undefined, or false. Received an instance of ProxyAgent)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ddf3b2bfc8329ba3da7adc9252b4a