### PR TITLE
Brick Breaker: smaller highlights and board reset

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -461,10 +461,10 @@
             ctx.beginPath();
             ctx.rect(x, y, w, h);
             ctx.clip();
-            const sizeLargeW = Math.floor(w * 0.65);
-            const sizeLargeH = Math.floor(h * 0.65);
-            const sizeSmallW = Math.floor(w * 0.3);
-            const sizeSmallH = Math.floor(h * 0.3);
+            const sizeLargeW = Math.floor(w * 0.55);
+            const sizeLargeH = Math.floor(h * 0.55);
+            const sizeSmallW = Math.floor(w * 0.25);
+            const sizeSmallH = Math.floor(h * 0.25);
             const extra = Math.floor(r * 0.03);
             ctx.fillStyle = 'rgba(255,255,255,0.2)';
             ctx.fillRect(x, y + h - sizeLargeH, sizeLargeW + extra, sizeLargeH);
@@ -944,6 +944,9 @@
               if (pu.y > VIEW_H + 10) {
                 b.powerups = b.powerups.filter((x) => x !== pu);
               }
+            }
+            if (b.bricks.every((br) => !br.alive)) {
+              b.bricks = genBricks(settings.density);
             }
           }
 


### PR DESCRIPTION
## Summary
- Reduce size of brick highlight overlays for cleaner appearance
- Repopulate bricks when board cleared so play can continue

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689de5329cac83298080424d94fd362a