### PR TITLE
Adjust Tetris Royale block highlight

### DIFF
--- a/webapp/public/tetris-royale.html
+++ b/webapp/public/tetris-royale.html
@@ -314,15 +314,15 @@ window.__TETRIS_ROYALE__ = true;
     ctx.beginPath();
     ctx.rect(x, y, w, h);
     ctx.clip();
-    // hard-edged rectangular highlights sized to the block (75% and 35%) positioned bottom-left
-    const sizeLargeW = Math.floor(w * 0.75);
-    const sizeLargeH = Math.floor(h * 0.75);
-    const sizeSmallW = Math.floor(w * 0.35);
-    const sizeSmallH = Math.floor(h * 0.35);
+    // hard-edged rectangular highlights sized to the block (70% and 30%) positioned bottom-left
+    const sizeLargeW = Math.floor(w * 0.7);
+    const sizeLargeH = Math.floor(h * 0.7);
+    const sizeSmallW = Math.floor(w * 0.3);
+    const sizeSmallH = Math.floor(h * 0.3);
     const extra = Math.floor(r * 0.03);
-    ctx.fillStyle = 'rgba(255,255,255,0.2)';
+    ctx.fillStyle = 'rgba(255,255,255,0.15)';
     ctx.fillRect(x, y + h - sizeLargeH, sizeLargeW + extra, sizeLargeH);
-    ctx.fillStyle = 'rgba(255,255,255,0.35)';
+    ctx.fillStyle = 'rgba(255,255,255,0.25)';
     ctx.fillRect(x, y + h - sizeSmallH, sizeSmallW + extra, sizeSmallH);
     ctx.restore();
   }


### PR DESCRIPTION
## Summary
- Reduce Tetris block highlight rectangles to 70%/30% of block size
- Lower highlight opacity for subtler appearance

## Testing
- `node --test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689de5c8bd608329a7ceca0958e8f88a