### PR TITLE
Fine-tune Brick Breaker Royale highlights

### DIFF
--- a/examples/brick-breaker-royale/brick_breaker_royale.svg
+++ b/examples/brick-breaker-royale/brick_breaker_royale.svg
@@ -11,8 +11,8 @@
   <!-- Base brick -->
   <rect x="112" y="312" width="800" height="400" fill="url(#brickGradient)" stroke="#000" stroke-width="40" rx="40"/>
   <!-- Highlights in the top-right corner -->
-  <rect x="660" y="372" width="160" height="80" fill="#ffffff" fill-opacity="0.2" rx="24"/>
-  <rect x="720" y="432" width="96" height="48" fill="#ffffff" fill-opacity="0.35" rx="16"/>
+  <rect x="670" y="382" width="150" height="70" fill="#ffffff" fill-opacity="0.3" rx="24"/>
+  <rect x="730" y="438" width="86" height="42" fill="#ffffff" fill-opacity="0.45" rx="16"/>
   <!-- Subtle shadow in the bottom-left corner -->
   <rect x="112" y="612" width="200" height="80" fill="#000000" fill-opacity="0.15" rx="20"/>
 </svg>

--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -461,17 +461,17 @@
             ctx.beginPath();
             ctx.rect(x, y, w, h);
             ctx.clip();
-            const sizeLargeW = Math.floor(w * 0.55);
-            const sizeLargeH = Math.floor(h * 0.55);
-            const sizeSmallW = Math.floor(w * 0.25);
-            const sizeSmallH = Math.floor(h * 0.25);
-            const extra = Math.floor(r * 0.03);
-            ctx.fillStyle = 'rgba(255,255,255,0.2)';
-            ctx.fillRect(x, y + h - sizeLargeH, sizeLargeW + extra, sizeLargeH);
-            ctx.fillStyle = 'rgba(255,255,255,0.35)';
-            ctx.fillRect(x, y + h - sizeSmallH, sizeSmallW + extra, sizeSmallH);
-            ctx.restore();
-          };
+              const sizeLargeW = Math.floor(w * 0.5);
+              const sizeLargeH = Math.floor(h * 0.5);
+              const sizeSmallW = Math.floor(w * 0.22);
+              const sizeSmallH = Math.floor(h * 0.22);
+              const extra = Math.floor(r * 0.02);
+              ctx.fillStyle = 'rgba(255,255,255,0.3)';
+              ctx.fillRect(x, y + h - sizeLargeH, sizeLargeW + extra, sizeLargeH);
+              ctx.fillStyle = 'rgba(255,255,255,0.45)';
+              ctx.fillRect(x, y + h - sizeSmallH, sizeSmallW + extra, sizeSmallH);
+              ctx.restore();
+            };
 
           const state = {
             match: null,


### PR DESCRIPTION
## Summary
- Shrink and brighten the brick highlight SVG rectangles for a crisper look
- Adjust brick drawing logic to render smaller, brighter highlights

## Testing
- `npm test` *(fails: Failed to send Telegram notification: The "options.agent" property must be one of Agent-like Object, undefined, or false. Received an instance of ProxyAgent)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dea2577688329b946be5b19a310f9