### PR TITLE
Refine Tetris block highlights

### DIFF
--- a/webapp/public/tetris-royale.html
+++ b/webapp/public/tetris-royale.html
@@ -314,15 +314,15 @@ window.__TETRIS_ROYALE__ = true;
     ctx.beginPath();
     ctx.rect(x, y, w, h);
     ctx.clip();
-    // hard-edged rectangular highlights sized to the block (70% and 30%) positioned bottom-left
-    const sizeLargeW = Math.floor(w * 0.7);
-    const sizeLargeH = Math.floor(h * 0.7);
-    const sizeSmallW = Math.floor(w * 0.3);
-    const sizeSmallH = Math.floor(h * 0.3);
-    const extra = Math.floor(r * 0.03);
-    ctx.fillStyle = 'rgba(255,255,255,0.15)';
+    // hard-edged rectangular highlights sized to the block (65% and 25%) positioned bottom-left
+    const sizeLargeW = Math.floor(w * 0.65);
+    const sizeLargeH = Math.floor(h * 0.65);
+    const sizeSmallW = Math.floor(w * 0.25);
+    const sizeSmallH = Math.floor(h * 0.25);
+    const extra = Math.floor(r * 0.02);
+    ctx.fillStyle = 'rgba(255,255,255,0.2)';
     ctx.fillRect(x, y + h - sizeLargeH, sizeLargeW + extra, sizeLargeH);
-    ctx.fillStyle = 'rgba(255,255,255,0.25)';
+    ctx.fillStyle = 'rgba(255,255,255,0.3)';
     ctx.fillRect(x, y + h - sizeSmallH, sizeSmallW + extra, sizeSmallH);
     ctx.restore();
   }


### PR DESCRIPTION
## Summary
- Decrease highlight rectangles for Tetris blocks for subtler effect
- Increase highlight brightness for clearer block contrast

## Testing
- `npm test` *(fails: test timed out for snake API endpoints and socket events)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689deafc77c083298d246a26ed17b90d