### PR TITLE
feat: add shared pot mode to falling ball game

### DIFF
--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -156,7 +156,10 @@
     slots:[],
     obstacles:[], // {x,y,r,type,angle,spin}
     density:'High', // Low|Med|High
-    ball:{ x:0, y:0, vx:0, vy:0, r:12 },
+    shared:false,
+    ballValues:[],
+    currentBall:0,
+    ball:{ x:0, y:0, vx:0, vy:0, r:12, value:0, color:'#facc15' },
     gravity:0.58,
     bounce:0.78,
     fric:0.003,
@@ -171,6 +174,7 @@
   if (p >= 2 && p <= 10) state.players = p;
   const m = params.get('mode');
   if (m === 'local' || m === 'online') state.mode = m;
+  state.shared = params.get('shared') === '1';
   const amt = Number(params.get('amount'));
   if (amt > 0) state.stake = amt;
   let myAccountId = params.get('accountId');
@@ -208,6 +212,15 @@
   startBtn.onclick = startMatch;
   function setStatus(t){ document.getElementById('statusBox').textContent=t; }
   function showWinnerPopup(name){ document.getElementById('winnerText').textContent = `${name} wins!`; document.getElementById('winnerPopup').classList.remove('hidden'); }
+  function showResultsPopup(){
+    const lines = state.slots
+      .filter(s => (s.win||0) > 0)
+      .sort((a,b)=> (b.win||0)-(a.win||0))
+      .map(s => `${s.name}: ${s.win||0} TPC`)
+      .join('<br/>');
+    document.getElementById('winnerText').innerHTML = lines || 'No winnings';
+    document.getElementById('winnerPopup').classList.remove('hidden');
+  }
   document.getElementById('lobbyBtn').onclick=()=>{ location.href='/games/fallingball/lobby'; };
 
   function emojiToDataUrl(emoji){ const svg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'><text y='96' font-size='96'>${emoji}</text></svg>`; return `data:image/svg+xml,${encodeURIComponent(svg)}`; }
@@ -243,7 +256,7 @@
 
 
   state.pot = state.players * state.stake;
-  document.getElementById('potVal').textContent = state.pot;
+  document.getElementById('potVal').textContent = state.shared ? Math.round(state.pot*0.9) : state.pot;
 
   // ========================= Obstacles =========================
   function randomBetween(a,b){ return a + Math.random()*(b-a); }
@@ -318,11 +331,51 @@
 
   function resetBall(){ state.ball.x=W*0.5; state.ball.y=60; state.ball.vx=(Math.random()*2-1)*1.8; state.ball.vy=0; state.resultSlot=null; state.stuckCounter=0; }
 
+  const COLORS=['#f87171','#34d399','#60a5fa','#fbbf24','#a78bfa','#f472b6','#38bdf8','#facc15'];
+  function generateBallValues(total,count){
+    const weights=[]; for(let i=0;i<count;i++) weights.push(Math.random());
+    const sum=weights.reduce((a,b)=>a+b,0);
+    const values=[];
+    let acc=0;
+    for(let i=0;i<count;i++){
+      const val=Math.round(weights[i]/sum*total);
+      values.push(val); acc+=val;
+    }
+    let diff=total-acc; let idx=0;
+    while(diff!==0){
+      if(diff>0){ values[idx%count]++; diff--; }
+      else if(values[idx%count]>0){ values[idx%count]--; diff++; }
+      idx++;
+    }
+    return values;
+  }
+  function setupSharedBall(){
+    const value = state.ballValues[state.currentBall];
+    const maxVal = state.ballValuesMax;
+    const minR=8, maxR=12;
+    state.ball.value=value;
+    state.ball.r=minR + (maxR-minR)*(value/maxVal);
+    state.ball.color=COLORS[state.currentBall % COLORS.length];
+    resetBall();
+  }
+
   function startMatch(){
     refreshSlots();
     document.getElementById('winnerPopup').classList.add('hidden');
-    state.started=true; state.time=0; genPegField(); carveCorridors(); addStars(); resetBall();
-    state.pot=state.players*state.stake; document.getElementById('potVal').textContent=state.pot; document.getElementById('winnerVal').textContent='—';
+    state.started=true; state.time=0; genPegField(); carveCorridors(); addStars();
+    state.pot=state.players*state.stake;
+    document.getElementById('winnerVal').textContent='—';
+    if(state.shared){
+      state.ballValues=generateBallValues(Math.round(state.pot*0.9),20);
+      state.ballValuesMax=Math.max(...state.ballValues);
+      state.currentBall=0;
+      state.slots.forEach(s=>s.win=0);
+      document.getElementById('potVal').textContent=state.ballValues.reduce((a,b)=>a+b,0);
+      setupSharedBall();
+    }else{
+      document.getElementById('potVal').textContent=state.pot;
+      resetBall();
+    }
     setStatus('Game started! Obstacles regenerate randomly.');
     if(state.mode==='local') startBtn.style.display='none';
   }
@@ -382,21 +435,41 @@
       if (Math.abs(b.vy) < 1.1){
         const idx = pickSlotFromX(b.x);
         state.resultSlot = idx;
-        const winAmt = Math.round(state.pot*0.91);
-        const fee = state.pot - winAmt;
         const winner = state.slots[idx];
-        document.getElementById('winnerVal').textContent = `${winner.name} +${winAmt} TPC`;
-        setStatus(`Winner: ${winner.name}. Payout ${winAmt} TPC (-${fee} dev)`);
-        state.slots.forEach(s=>s.el.classList.remove('winner'));
-        winner.el.classList.add('winner');
-        SFX.win();
-        coinConfetti(50);
-        if(winner.accountId){
-          fbApi.depositAccount(winner.accountId, winAmt, { game: 'fallingball-win' });
-          if(winner.telegramId) fbApi.addTransaction(winner.telegramId, 0, 'win', { game: 'fallingball', players: state.players, accountId: winner.accountId });
+        if(state.shared){
+          const winAmt = state.ball.value;
+          winner.win = (winner.win||0) + winAmt;
+          document.getElementById('winnerVal').textContent = `${winner.name} +${winAmt} TPC`;
+          setStatus(`Ball ${state.currentBall+1}/${state.ballValues.length}: ${winner.name} +${winAmt} TPC`);
+          SFX.win();
+          coinConfetti(20);
+          if(winner.accountId){
+            fbApi.depositAccount(winner.accountId, winAmt, { game: 'fallingball-win' });
+            if(winner.telegramId) fbApi.addTransaction(winner.telegramId, 0, 'win', { game: 'fallingball', players: state.players, accountId: winner.accountId });
+          }
+          state.currentBall++;
+          if(state.currentBall < state.ballValues.length){
+            setupSharedBall();
+          }else{
+            awardDevShare(state.pot);
+            setTimeout(()=>showResultsPopup(),2000);
+          }
+        }else{
+          const winAmt = Math.round(state.pot*0.91);
+          const fee = state.pot - winAmt;
+          document.getElementById('winnerVal').textContent = `${winner.name} +${winAmt} TPC`;
+          setStatus(`Winner: ${winner.name}. Payout ${winAmt} TPC (-${fee} dev)`);
+          state.slots.forEach(s=>s.el.classList.remove('winner'));
+          winner.el.classList.add('winner');
+          SFX.win();
+          coinConfetti(50);
+          if(winner.accountId){
+            fbApi.depositAccount(winner.accountId, winAmt, { game: 'fallingball-win' });
+            if(winner.telegramId) fbApi.addTransaction(winner.telegramId, 0, 'win', { game: 'fallingball', players: state.players, accountId: winner.accountId });
+          }
+          awardDevShare(state.pot);
+          setTimeout(()=>showWinnerPopup(winner.name),2000);
         }
-        awardDevShare(state.pot);
-        setTimeout(()=>showWinnerPopup(winner.name),2000);
       }
     }
   }
@@ -451,7 +524,24 @@
     }
   }
   function drawSlotsGuide(){ const pad=30; const usable=W-2*pad; const w = usable / state.players; const bottom = H-10; const top = bottom-40; for(let i=0;i<state.players;i++){ const x1=pad+i*w; ctx.fillStyle='rgba(0,0,0,0.25)'; ctx.fillRect(x1, top, w-2, bottom-top); if (state.resultSlot===i){ ctx.fillStyle='rgba(250,204,21,0.4)'; ctx.fillRect(x1, top, w-2, bottom-top); ctx.strokeStyle='rgba(250,204,21,0.9)'; ctx.lineWidth=3; ctx.strokeRect(x1+1, top, w-4, bottom-top); } } }
-  function drawBall(){ const b=state.ball; ctx.fillStyle='rgba(0,0,0,0.28)'; ctx.beginPath(); ctx.ellipse(b.x, b.y+b.r+6, b.r*1.2, b.r*0.5, 0,0,Math.PI*2); ctx.fill(); const grad = ctx.createRadialGradient(b.x-6,b.y-6,4, b.x,b.y,b.r+6); grad.addColorStop(0,'#fef08a'); grad.addColorStop(0.55,'#facc15'); grad.addColorStop(1,'#ca8a04'); ctx.fillStyle=grad; ctx.beginPath(); ctx.arc(b.x,b.y,b.r,0,Math.PI*2); ctx.fill(); ctx.globalAlpha=0.15; ctx.fillStyle='#fefce8'; ctx.beginPath(); ctx.ellipse(b.x-5,b.y-8,b.r*0.7,b.r*0.35,-0.2,0,Math.PI*2); ctx.fill(); ctx.globalAlpha=1; }
+  function drawBall(){
+    const b=state.ball;
+    ctx.fillStyle='rgba(0,0,0,0.28)';
+    ctx.beginPath();
+    ctx.ellipse(b.x, b.y+b.r+6, b.r*1.2, b.r*0.5, 0,0,Math.PI*2);
+    ctx.fill();
+    ctx.fillStyle=b.color;
+    ctx.beginPath();
+    ctx.arc(b.x,b.y,b.r,0,Math.PI*2);
+    ctx.fill();
+    if(b.value){
+      ctx.fillStyle='#000';
+      ctx.font=`${Math.max(10,b.r)}px sans-serif`;
+      ctx.textAlign='center';
+      ctx.textBaseline='middle';
+      ctx.fillText(b.value, b.x, b.y);
+    }
+  }
 
   function frame(ts){ const dt = Math.min(33, ts - state.time); state.time=ts; step(dt/16.6667); ctx.clearRect(0,0,W,H); drawObstacles(); drawSlotsGuide(); drawBall(); requestAnimationFrame(frame); }
   requestAnimationFrame(frame);

--- a/webapp/src/pages/Games/FallingBallLobby.jsx
+++ b/webapp/src/pages/Games/FallingBallLobby.jsx
@@ -17,6 +17,7 @@ export default function FallingBallLobby() {
   const [players, setPlayers] = useState(2);
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState('local');
+  const [payout, setPayout] = useState('single');
   const [avatar, setAvatar] = useState('');
 
   useEffect(() => {
@@ -48,6 +49,7 @@ export default function FallingBallLobby() {
     params.set('players', players);
     params.set('density', 'high');
     params.set('mode', mode);
+    if (payout === 'shared') params.set('shared', '1');
     const initData = window.Telegram?.WebApp?.initData;
     if (stake.token) params.set('token', stake.token);
     if (stake.amount) params.set('amount', stake.amount);
@@ -93,6 +95,23 @@ export default function FallingBallLobby() {
               key={id}
               onClick={() => setMode(id)}
               className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Payout</h3>
+        <div className="flex gap-2">
+          {[
+            { id: 'single', label: 'Winner Takes All' },
+            { id: 'shared', label: 'Shared Pot' }
+          ].map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setPayout(id)}
+              className={`lobby-tile ${payout === id ? 'lobby-selected' : ''}`}
             >
               {label}
             </button>


### PR DESCRIPTION
## Summary
- add payout mode selector to Falling Ball lobby
- introduce shared pot gameplay with 20 value-labeled balls
- show post-game popup summarizing each player's winnings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dedab65288329b6bb9925dc107111