### PR TITLE
Match Brick Breaker blocks to Tetris Royale styling

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -461,17 +461,17 @@
             ctx.beginPath();
             ctx.rect(x, y, w, h);
             ctx.clip();
-              const sizeLargeW = Math.floor(w * 0.5);
-              const sizeLargeH = Math.floor(h * 0.5);
-              const sizeSmallW = Math.floor(w * 0.22);
-              const sizeSmallH = Math.floor(h * 0.22);
-              const extra = Math.floor(r * 0.02);
-              ctx.fillStyle = 'rgba(255,255,255,0.3)';
-              ctx.fillRect(x, y + h - sizeLargeH, sizeLargeW + extra, sizeLargeH);
-              ctx.fillStyle = 'rgba(255,255,255,0.45)';
-              ctx.fillRect(x, y + h - sizeSmallH, sizeSmallW + extra, sizeSmallH);
-              ctx.restore();
-            };
+            const sizeLargeW = Math.floor(w * 0.65);
+            const sizeLargeH = Math.floor(h * 0.65);
+            const sizeSmallW = Math.floor(w * 0.25);
+            const sizeSmallH = Math.floor(h * 0.25);
+            const extra = Math.floor(r * 0.02);
+            ctx.fillStyle = 'rgba(255,255,255,0.2)';
+            ctx.fillRect(x, y + h - sizeLargeH, sizeLargeW + extra, sizeLargeH);
+            ctx.fillStyle = 'rgba(255,255,255,0.3)';
+            ctx.fillRect(x, y + h - sizeSmallH, sizeSmallW + extra, sizeSmallH);
+            ctx.restore();
+          };
 
           const state = {
             match: null,


### PR DESCRIPTION
## Summary
- Align Brick Breaker block rendering with Tetris Royale blocks to unify visual style

## Testing
- `npm test` (fails: snake API endpoints and socket events)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689df4bc514083298069ffb084e5b41d