### PR TITLE
Add 2.5D cartoon text styling

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -6,6 +6,9 @@
     <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
     <script src="https://telegram.org/js/telegram-web-app.js" defer></script>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Luckiest+Guy&display=swap" rel="stylesheet" />
     <link rel="preload" as="audio" href="/assets/sounds/spinning.mp3" />
     <link rel="preload" as="audio" href="/assets/sounds/successful.mp3" />
     <meta name="description" content="TonPlaygram is a TON based gaming platform on Telegram with integrated wallet and rewards." />

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -9,12 +9,15 @@
 }
 
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Luckiest Guy', 'Comic Sans MS', cursive;
   margin: 0;
   @apply text-text overflow-x-hidden;
   background: radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;
   background-color: #0c1020;
-  text-shadow: 0 0 4px #00f7ff;
+  text-shadow:
+    2px 2px 0 #000,
+    4px 4px 0 #333,
+    0 0 4px #00f7ff;
 }
 
 /* Neon theme elements */
@@ -33,7 +36,10 @@ body {
 }
 
 .text-text {
-  text-shadow: 0 0 4px #00f7ff;
+  text-shadow:
+    2px 2px 0 #000,
+    4px 4px 0 #333,
+    0 0 4px #00f7ff;
 }
 
 button,

--- a/webapp/tailwind.config.js
+++ b/webapp/tailwind.config.js
@@ -4,23 +4,26 @@ export default {
     './src/**/*.{js,jsx,ts,tsx}'
   ],
   theme: {
-    extend: {
-      colors: {
-        // Futuristic neon theme
-        background: '#050f1a',        // Dark navy background
-        surface: '#050f1a',           // Panels use same dark tone
-        border: '#00f7ff',            // Glowing cyan borders
-        primary: '#00f7ff',           // Button base in electric blue
-        'primary-hover': '#66fcff',   // Lighter hover effect
-        text: '#00f7ff',              // Electric blue text
-        subtext: '#66fcff',           // Slightly dimmed blue
-        accent: '#00f7ff',            // Accent color
-        brand: {
-          gold: '#facc15',            // Yellow highlight
-          black: '#000000'
+      extend: {
+        colors: {
+          // Futuristic neon theme
+          background: '#050f1a',        // Dark navy background
+          surface: '#050f1a',           // Panels use same dark tone
+          border: '#00f7ff',            // Glowing cyan borders
+          primary: '#00f7ff',           // Button base in electric blue
+          'primary-hover': '#66fcff',   // Lighter hover effect
+          text: '#00f7ff',              // Electric blue text
+          subtext: '#66fcff',           // Slightly dimmed blue
+          accent: '#00f7ff',            // Accent color
+          brand: {
+            gold: '#facc15',            // Yellow highlight
+            black: '#000000'
+          }
+        },
+        fontFamily: {
+          sans: ['"Luckiest Guy"', '"Comic Sans MS"', 'cursive']
         }
       }
-    }
-  },
-  plugins: []
-};
+    },
+    plugins: []
+  };


### PR DESCRIPTION
## Summary
- add Luckiest Guy Google font and set as default sans in Tailwind
- apply 2.5D cartoon text-shadow across the app

## Testing
- `npm test` *(fails: DuplicateKey error during MongoDB index build)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689df72c7b348329a03f34dcd172631d