### PR TITLE
Remove text shadows from UI text

### DIFF
--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -25,7 +25,7 @@
     .row{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
     .chip{ padding:6px 10px; border-radius:12px; border:1px solid rgba(255,255,255,.15); color:#fff; background:transparent; cursor:pointer; }
     .chip.active{ border-color:#7dd3fc; }
-      .btn{ appearance:none; border:1px solid #00f7ff; background:rgba(0,0,0,.3); color:#00f7ff; padding:10px 14px; border-radius:14px; font-weight:600; font-size:14px; cursor:pointer; text-shadow:0 0 4px #00f7ff; }
+      .btn{ appearance:none; border:1px solid #00f7ff; background:rgba(0,0,0,.3); color:#00f7ff; padding:10px 14px; border-radius:14px; font-weight:600; font-size:14px; cursor:pointer; }
       .btn.primary{ background:#00f7ff; color:#fff; border:none; box-shadow:0 0 8px rgba(0,247,255,.5); }
       .btn.primary:hover{ background:#66fcff; }
     .btn:disabled{ opacity:.5; }

--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -36,7 +36,7 @@
     .coin-confetti{position:fixed;top:-40px;width:32px;height:32px;pointer-events:none;animation:coin-fall var(--duration,3s) linear forwards}
     @keyframes coin-fall{from{transform:translateY(-10vh) rotate(0deg);opacity:1}to{transform:translateY(100vh) rotate(360deg);opacity:0}}
 
-    .goal-text{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:48px;font-weight:800;color:var(--goal);text-align:center;display:none;pointer-events:none;text-shadow:2px 2px 0 #000;line-height:1.1}
+    .goal-text{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:48px;font-weight:800;color:var(--goal);text-align:center;display:none;pointer-events:none;line-height:1.1}
     .goal-text .score-line{display:block;font-size:32px;font-weight:600}
 
     @media (orientation:landscape){

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -14,10 +14,6 @@ body {
   @apply text-text overflow-x-hidden;
   background: radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;
   background-color: #0c1020;
-  text-shadow:
-    2px 2px 0 #000,
-    4px 4px 0 #333,
-    0 0 4px #00f7ff;
 }
 
 /* Neon theme elements */
@@ -35,12 +31,7 @@ body {
   box-shadow: inset 0 0 10px rgba(0, 247, 255, 0.4);
 }
 
-.text-text {
-  text-shadow:
-    2px 2px 0 #000,
-    4px 4px 0 #333,
-    0 0 4px #00f7ff;
-}
+
 
 button,
 input {
@@ -58,7 +49,6 @@ input:focus {
 /* Utility class for white text with a subtle black shadow */
 .text-white-shadow {
   color: #ffffff;
-  text-shadow: 0 0 2px #000;
 }
 
 .hexagon {
@@ -878,7 +868,6 @@ input:focus {
 .offset-text {
   font-size: 1.1rem;
   font-weight: bold;
-  text-shadow: 0 0 2px #000;
   transform: rotateX(calc(var(--board-angle, 58deg) * -1));
 }
 
@@ -964,7 +953,6 @@ input:focus {
   font-weight: bold;
   font-size: 1.3rem; /* slightly bigger numbers */
   line-height: 1;
-  text-shadow: 0 0 2px #000;
   transform: translateY(-10%);
 }
 
@@ -977,14 +965,12 @@ input:focus {
   font-weight: bold;
   font-size: 1.8rem;
   line-height: 1;
-  text-shadow: 0 0 2px #fff;
 }
 
 .roll-result {
   color: #ffffff;
   font-family: "Comic Sans MS", "Comic Sans", cursive;
   font-weight: bold;
-  text-shadow: 0 0 2px #000;
 }
 
 .crazy-dice-board .roll-result {
@@ -1151,7 +1137,6 @@ input:focus {
   font-size: 0.9rem;
   font-weight: bold;
   color: #3b82f6;
-  text-shadow: 0 0 2px #000;
   transform: rotateX(calc(var(--board-angle, 58deg) * -1));
 }
 


### PR DESCRIPTION
## Summary
- Remove all text-shadow declarations from global and game-specific styles
- Strip text shadow from goal rush and falling ball page elements

## Testing
- `npm test` (fails: canvas module compiled for older Node version)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dfd5274908329b6e55d3a47cf1c21