### PR TITLE
Play kick sound only for player kicks

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -586,7 +586,7 @@
         }
         const v = Math.hypot(puck.vx,puck.vy); const maxV = puck.max*speedMul*1.25;
         if (v>maxV){ const s=maxV/v; puck.vx*=s; puck.vy*=s; }
-        sfx.hit();
+        if (p === p1 || mode !== 'ai') sfx.hit();
       }
     });
 


### PR DESCRIPTION
## Summary
- only play kick sound on avatar hits in Goal Rush to prevent AI collision noise

## Testing
- `npm test` *(fails: AssertionError in test/snakeApi.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689e02975d008329975659b4758e65c7