### PR TITLE
feat: add AI corner escape

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -542,6 +542,19 @@
       tx = centerX;
       ty = rink.y + rink.h * 0.2;
     }
+    // If puck and AI are stuck in a corner on the AI side, nudge the puck out
+    const cornerZone = 30; // area from walls to consider a corner
+    const puckSpeed = Math.hypot(puck.vx, puck.vy);
+    const puckInCorner = puck.y < minY + cornerZone && (puck.x < minX + cornerZone || puck.x > maxX - cornerZone);
+    if (puck.y < centerY && puckInCorner && puckSpeed < 6) {
+      const dir = puck.x < centerX ? 1 : -1;
+      const angle = 0.3 + Math.random() * 0.8; // 17°-66° downward
+      const power = 4 + Math.random() * 4;
+      puck.vx = Math.cos(angle) * dir * power;
+      puck.vy = Math.sin(angle) * power;
+      tx = centerX;
+      ty = rink.y + rink.h * 0.25;
+    }
     p2.x += (tx - p2.x) * reaction;
     p2.y += (ty - p2.y) * reaction;
     const maxStep = p2.max * speedMul;


### PR DESCRIPTION
## Summary
- handle Goal Rush AI getting trapped in corners by nudging puck out at varied angles and power

## Testing
- `npm test` *(fails: online routes reflect pinged users)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e08d0c38c8329aa59a7df96d37cfb