### PR TITLE
Reduce Goal Rush puck curve and increase size

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -113,7 +113,7 @@
   const oppParam = params.get('p2Avatar') || '';
   let p1Name = params.get('name') || 'P1';
   let p2Name = params.get('p2Name') || 'P2';
-  let fieldScaleX = 1, fieldScaleY = 1, fieldImgScaleX = 1, fieldImgScaleY = 1, puckScale = 0.9, goalWidthPct = 0.36, goalOffsetXPct = 0, goalOffsetYPct = 0, paddleScale = 0.95, speedMul = 1;
+  let fieldScaleX = 1, fieldScaleY = 1, fieldImgScaleX = 1, fieldImgScaleY = 1, puckScale = 1.0, goalWidthPct = 0.36, goalOffsetXPct = 0, goalOffsetYPct = 0, paddleScale = 0.95, speedMul = 1;
   try {
     const oldFieldScale = parseFloat(localStorage.getItem('fieldScale')) || 1;
     fieldScaleX = parseFloat(localStorage.getItem('fieldScaleX')) || oldFieldScale;
@@ -121,7 +121,7 @@
     const oldImgScale = parseFloat(localStorage.getItem('fieldImgScale')) || 1;
     fieldImgScaleX = parseFloat(localStorage.getItem('fieldImgScaleX')) || oldImgScale;
     fieldImgScaleY = parseFloat(localStorage.getItem('fieldImgScaleY')) || oldImgScale;
-    puckScale = parseFloat(localStorage.getItem('puckScale')) || 0.9;
+    puckScale = parseFloat(localStorage.getItem('puckScale')) || 1.0;
     goalWidthPct = parseFloat(localStorage.getItem('goalWidthPct')) || 0.36;
     goalOffsetXPct = parseFloat(localStorage.getItem('goalOffsetXPct')) || 0;
     goalOffsetYPct = parseFloat(localStorage.getItem('goalOffsetYPct')) || 0;
@@ -691,7 +691,7 @@
 
     puck.x += puck.vx * dt * 60;
     puck.y += puck.vy * dt * 60;
-    const mag = puck.spin * dt;
+    const mag = puck.spin * dt * 0.5;
     const magVx = -puck.vy * mag;
     const magVy = puck.vx * mag;
     puck.vx += magVx;
@@ -699,7 +699,7 @@
     puck.vx *= Math.pow(friction, dt*60);
     puck.vy *= Math.pow(friction, dt*60);
     puck.angle += Math.hypot(puck.vx, puck.vy) * dt * 0.1;
-    puck.angle += puck.spin * dt * 30;
+    puck.angle += puck.spin * dt * 15;
     puck.spin *= Math.pow(0.99, dt*60);
 
     handleCollisions();


### PR DESCRIPTION
## Summary
- Shrink puck spin effect to reduce path curvature by 50%
- Slightly increase default puck size

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e0f8926b08329b4438d2afb15ca6b