### PR TITLE
Update fruit images for Fruit Slice Royale

### DIFF
--- a/webapp/public/fruit-slice-royale.html
+++ b/webapp/public/fruit-slice-royale.html
@@ -189,9 +189,9 @@
   // ===== Fruits =====
   // sf = size factor relative to base
   const FRUITS=[
-    {k:'lemon',      col:'#f7e34c', juice:'#fff28a', score:10, sf:1.00, img:loadImage('assets/icons/Lemon.jpg')},
-    {k:'kiwi',       col:'#a9d16c', juice:'#d5f28c', score:13, sf:0.90, img:loadImage('assets/icons/Kiwi.jpg')},
-    {k:'pear',       col:'#d8f27f', juice:'#eaff9f', score:12, sf:1.00, img:loadImage('assets/icons/Pear.jpg')},
+    {k:'lemon',      col:'#f7e34c', juice:'#fff28a', score:10, sf:1.00, img:loadImage('assets/icons/ezgif-230f375955aea3.webp')},
+    {k:'kiwi',       col:'#a9d16c', juice:'#d5f28c', score:13, sf:0.90, img:loadImage('assets/icons/ezgif-6d8bc8c590be4b.webp')},
+    {k:'pear',       col:'#d8f27f', juice:'#eaff9f', score:12, sf:1.00, img:loadImage('assets/icons/ezgif-6ae76a227b5720.webp')},
     {k:'apple',      col:'#ff5a6b', juice:'#ff8aa0', score:12, sf:1.00, img:loadImage('assets/icons/Apple.webp')},
     {k:'cherry',     col:'#ff4f4f', juice:'#ff8aa0', score:11, sf:0.85, img:loadImage('assets/icons/Cherry%20.webp')},
     {k:'orange',     col:'#ff9d5a', juice:'#ffbf8f', score:12, sf:1.00, img:loadImage('assets/icons/Orange.webp')},


### PR DESCRIPTION
## Summary
- use new webp icons for lemon, kiwi, and pear in Fruit Slice Royale

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e22120bec8329a27f95b58ecefc08