### PR TITLE
Disable Telegram pull-down during games

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -32,6 +32,7 @@
       html,
       body {
         height: 100dvh;
+        overscroll-behavior: none;
       }
       body {
         margin: 0;

--- a/webapp/public/bubble-pop-royale.html
+++ b/webapp/public/bubble-pop-royale.html
@@ -7,7 +7,7 @@
 <style>
   :root{ --bg:#0c1020; --panel:#11172a; --primary:#2563eb; --gold:#d4af37; --text:#e7eefc; --muted:#8fa1d2; --danger:#ff5a6b; }
   *{box-sizing:border-box;font-family:Inter,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
-  html,body{height:100dvh}
+  html,body{height:100dvh;overscroll-behavior:none}
   body{margin:0;background:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;color:var(--text);overflow:hidden}
   .app{height:100dvh;display:flex;flex-direction:column;padding:12px;gap:10px;max-width:1100px;margin:0 auto}
   .tetris-grid-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}

--- a/webapp/public/bubble-smash-royale.html
+++ b/webapp/public/bubble-smash-royale.html
@@ -7,7 +7,7 @@
 <style>
   :root{ --bg:#0c1020; --panel:#11172a; --primary:#2563eb; --gold:#d4af37; --text:#e7eefc; --muted:#8fa1d2; }
   *{box-sizing:border-box;font-family:Inter,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
-  html,body{height:100vh}
+  html,body{height:100vh;overscroll-behavior:none}
   body{margin:0;background:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;color:var(--text);overflow:hidden}
   .app{height:100vh;display:flex;flex-direction:column;padding:12px;gap:10px;max-width:1100px;margin:0 auto}
   .tetris-grid-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}

--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -9,7 +9,7 @@
   <title>TonPlaygram – Falling Ball PvP (SFX + Visuals)</title>
   <style>
     :root{ --bg:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%); --panel:#10172a; --ink:#e5e7eb; --muted:#10b981; --accent:#94a3b8; }
-    html,body{ height:100%; margin:0; }
+    html,body{ height:100%; margin:0; overscroll-behavior:none; }
     body{ background:var(--bg) fixed; background-color:#0c1020; color:var(--ink); font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif; }
     .app{ position:fixed; inset:0; overflow:hidden; }
     .tetris-grid-bg{

--- a/webapp/public/fruit-slice-royale.html
+++ b/webapp/public/fruit-slice-royale.html
@@ -7,7 +7,7 @@
 <style>
   :root{ --bg:#0c1020; --panel:#11172a; --primary:#2563eb; --gold:#d4af37; --text:#e7eefc; --muted:#8fa1d2; }
   *{box-sizing:border-box;font-family:Inter,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
-  html,body{height:100vh}
+  html,body{height:100vh;overscroll-behavior:none}
   body{margin:0;background:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;color:var(--text);overflow:hidden}
   .app{height:100vh;display:flex;flex-direction:column;padding:12px;gap:10px;max-width:1100px;margin:0 auto}
   .tetris-grid-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}

--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -15,7 +15,7 @@
       --puck:#e5e7eb;
     }
     *{box-sizing:border-box; -webkit-tap-highlight-color: transparent;}
-    html,body{height:100%;}
+    html,body{height:100%;overscroll-behavior:none;}
     body{margin:0;background:var(--bg);color:#e5e7eb;font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial;overflow:hidden}
     .ui{position:fixed;inset:0;}
     .scoreboard{position:absolute;top:0;left:0;right:0;height:40px;display:flex;align-items:center;justify-content:center;pointer-events:none;}

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -10,6 +10,7 @@
     <meta http-equiv="Expires" content="0" />
     <title>TonPlaygram</title>
     <link rel="icon" type="image/webp" href="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp" />
+    <style>html,body{overscroll-behavior:none}</style>
   </head>
   <body>
     <script>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -8,6 +8,11 @@
   --cell-height: 80px;
 }
 
+html,
+body {
+  overscroll-behavior: none;
+}
+
 body {
   font-family: 'Luckiest Guy', 'Comic Sans MS', cursive;
   margin: 0;


### PR DESCRIPTION
## Summary
- Prevent Telegram window from being pulled down by applying `overscroll-behavior: none` globally and across standalone game pages.

## Testing
- `npm test` (fails: module '/workspace/TonPlaygramWebApp/bot/node_modules/canvas/build/Release/canvas.node' was compiled against a different Node.js version)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e2dedb6388329bfdb53c989cef148