### PR TITLE
Brighten tetris backgrounds and enlarge logo

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -55,8 +55,8 @@
       }
       .tetris-grid-bg{
         background:
-          repeating-linear-gradient(45deg,rgba(255,255,255,0.03) 0 2px,transparent 2px 4px),
-          radial-gradient(circle at center,#1a2450 0%,#0e1430 80%);
+          repeating-linear-gradient(45deg,rgba(255,255,255,0.05) 0 2px,transparent 2px 4px),
+          radial-gradient(circle at center,#243375 0%,#18234d 80%);
         background-size:100px 100px,cover;
         background-position:0 0,center;
         animation:canvasDepthMove 30s linear infinite;

--- a/webapp/public/bubble-pop-royale.html
+++ b/webapp/public/bubble-pop-royale.html
@@ -10,7 +10,7 @@
   html,body{height:100dvh;overscroll-behavior:none}
   body{margin:0;background:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;color:var(--text);overflow:hidden}
   .app{height:100dvh;display:flex;flex-direction:column;padding:12px;gap:10px;max-width:1100px;margin:0 auto}
-  .tetris-grid-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}
+  .tetris-grid-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.05)0 2px,transparent 2px 4px), radial-gradient(circle at center,#243375 0%,#18234d 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}
   header{display:flex;gap:12px;align-items:center;justify-content:space-between}
   .badge{background:#0f1736;border:1px solid #223063;border-radius:10px;padding:6px 10px;color:var(--muted);font-size:12px}
   .controls{display:grid;grid-template-columns:1fr 1fr 1fr auto;gap:8px}

--- a/webapp/public/bubble-smash-royale.html
+++ b/webapp/public/bubble-smash-royale.html
@@ -10,7 +10,7 @@
   html,body{height:100vh;overscroll-behavior:none}
   body{margin:0;background:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;color:var(--text);overflow:hidden}
   .app{height:100vh;display:flex;flex-direction:column;padding:12px;gap:10px;max-width:1100px;margin:0 auto}
-  .tetris-grid-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}
+  .tetris-grid-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.05)0 2px,transparent 2px 4px), radial-gradient(circle at center,#243375 0%,#18234d 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}
 
   .hud{display:flex;gap:8px}
   .hud .panel{flex:1}

--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -14,8 +14,8 @@
     .app{ position:fixed; inset:0; overflow:hidden; }
     .tetris-grid-bg{
       background:
-        repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px),
-        radial-gradient(circle at center,#1a2450 0%,#0e1430 80%);
+        repeating-linear-gradient(45deg,rgba(255,255,255,0.05)0 2px,transparent 2px 4px),
+        radial-gradient(circle at center,#243375 0%,#18234d 80%);
       background-size:100px 100px,cover;
       background-position:0 0,center;
       animation:canvasDepthMove 30s linear infinite;

--- a/webapp/public/fruit-slice-royale.html
+++ b/webapp/public/fruit-slice-royale.html
@@ -10,7 +10,7 @@
   html,body{height:100vh;overscroll-behavior:none}
   body{margin:0;background:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;color:var(--text);overflow:hidden}
   .app{height:100vh;display:flex;flex-direction:column;padding:12px;gap:10px;max-width:1100px;margin:0 auto}
-  .tetris-grid-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px), radial-gradient(circle at center,#1a2450 0%,#0e1430 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}
+  .tetris-grid-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.05)0 2px,transparent 2px 4px), radial-gradient(circle at center,#243375 0%,#18234d 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}
   header{display:flex;gap:12px;align-items:center;justify-content:space-between}
   .badge{background:#0f1736;border:1px solid #223063;border-radius:10px;padding:6px 10px;color:var(--muted);font-size:12px}
 

--- a/webapp/public/tetris-royale.html
+++ b/webapp/public/tetris-royale.html
@@ -31,8 +31,8 @@
     flex:1;width:100%;height:100%;
     image-rendering:crisp-edges;
     background:
-      repeating-linear-gradient(45deg,rgba(255,255,255,0.03)0 2px,transparent 2px 4px),
-      radial-gradient(circle at center,#1a2450 0%,#0e1430 80%);
+      repeating-linear-gradient(45deg,rgba(255,255,255,0.05)0 2px,transparent 2px 4px),
+      radial-gradient(circle at center,#243375 0%,#18234d 80%);
     background-size:100px 100px,cover;
     background-position:0 0,center;
     animation:canvasDepthMove 30s linear infinite;

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -103,7 +103,7 @@ export default function Layout({ children }) {
           <img
             src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp"
             alt="TonPlaygram logo"
-            className="h-48"
+            className="h-56"
           />
         </header>
       )}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1671,8 +1671,8 @@ input:focus {
 
 .tetris-grid-bg {
   background:
-    repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.03) 0 2px, transparent 2px 4px),
-    radial-gradient(circle at center, #1a2450 0%, #0e1430 80%);
+    repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.05) 0 2px, transparent 2px 4px),
+    radial-gradient(circle at center, #243375 0%, #18234d 80%);
   background-size: 100px 100px, cover;
   background-position: 0 0, center;
   animation: canvasDepthMove 30s linear infinite;


### PR DESCRIPTION
## Summary
- Increase header logo size for better visibility
- Lighten the reusable Tetris grid background across games

## Testing
- `npm test` *(fails: CLAIM_CONTRACT_ADDRESS and CLAIM_WALLET_MNEMONIC must be set)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689eb58ff62083299606e48a3946e2cf