### PR TITLE
Brighten grid backgrounds and separate per page

### DIFF
--- a/webapp/public/brick-breaker.html
+++ b/webapp/public/brick-breaker.html
@@ -53,10 +53,10 @@
         display: flex;
         flex-direction: column;
       }
-      .tetris-grid-bg{
+      .brick-breaker-bg{
         background:
-          repeating-linear-gradient(45deg,rgba(255,255,255,0.05) 0 2px,transparent 2px 4px),
-          radial-gradient(circle at center,#243375 0%,#18234d 80%);
+          repeating-linear-gradient(45deg,rgba(255,255,255,0.1) 0 2px,transparent 2px 4px),
+          radial-gradient(circle at center,#2c3e91 0%,#1e2d64 80%);
         background-size:100px 100px,cover;
         background-position:0 0,center;
         animation:canvasDepthMove 30s linear infinite;
@@ -363,7 +363,7 @@
             </h3>
             <canvas
               id="userCanvas"
-              class="main tetris-grid-bg"
+              class="main brick-breaker-bg"
               width="720"
               height="1120"
             ></canvas>
@@ -695,7 +695,7 @@
             wrap.className = 'mini';
             wrap.innerHTML = `<h3><img class="avatar" src="${avatar}" alt="avatar"/>${label}</h3>`;
             const cv = document.createElement('canvas');
-            cv.className = 'tetris-grid-bg';
+            cv.className = 'brick-breaker-bg';
             cv.width = CANVAS_W;
             cv.height = CANVAS_H;
             const ctx = cv.getContext('2d');

--- a/webapp/public/bubble-pop-royale.html
+++ b/webapp/public/bubble-pop-royale.html
@@ -10,7 +10,7 @@
   html,body{height:100dvh;overscroll-behavior:none}
   body{margin:0;background:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;color:var(--text);overflow:hidden}
   .app{height:100dvh;display:flex;flex-direction:column;padding:12px;gap:10px;max-width:1100px;margin:0 auto}
-  .tetris-grid-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.05)0 2px,transparent 2px 4px), radial-gradient(circle at center,#243375 0%,#18234d 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}
+  .bubble-pop-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.1)0 2px,transparent 2px 4px), radial-gradient(circle at center,#2c3e91 0%,#1e2d64 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}
   header{display:flex;gap:12px;align-items:center;justify-content:space-between}
   .badge{background:#0f1736;border:1px solid #223063;border-radius:10px;padding:6px 10px;color:var(--muted);font-size:12px}
   .controls{display:grid;grid-template-columns:1fr 1fr 1fr auto;gap:8px}
@@ -91,17 +91,17 @@
       <div class="mini">
         <h3><img id="avatar1" src="assets/icons/profile.svg" alt="" class="flagInline"/><span id="name1">P1</span></h3>
         <div id="score1" class="aiScore">0</div>
-        <canvas id="opp1" class="tetris-grid-bg"></canvas>
+        <canvas id="opp1" class="bubble-pop-bg"></canvas>
       </div>
       <div class="mini">
         <h3><img id="avatar2" src="assets/icons/profile.svg" alt="" class="flagInline"/><span id="name2">P2</span></h3>
         <div id="score2" class="aiScore">0</div>
-        <canvas id="opp2" class="tetris-grid-bg"></canvas>
+        <canvas id="opp2" class="bubble-pop-bg"></canvas>
       </div>
       <div class="mini">
         <h3><img id="avatar3" src="assets/icons/profile.svg" alt="" class="flagInline"/><span id="name3">P3</span></h3>
         <div id="score3" class="aiScore">0</div>
-        <canvas id="opp3" class="tetris-grid-bg"></canvas>
+        <canvas id="opp3" class="bubble-pop-bg"></canvas>
       </div>
     </div>
     <div class="userWrap">
@@ -119,7 +119,7 @@
           </div>
         </div>
       </div>
-      <canvas id="user" class="tetris-grid-bg"></canvas>
+      <canvas id="user" class="bubble-pop-bg"></canvas>
       <div class="overlayButtons">
         <button id="swapBtn" class="small">Swap</button>
         <button id="soundBtn" class="small">🔊</button>

--- a/webapp/public/bubble-smash-royale.html
+++ b/webapp/public/bubble-smash-royale.html
@@ -10,7 +10,7 @@
   html,body{height:100vh;overscroll-behavior:none}
   body{margin:0;background:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;color:var(--text);overflow:hidden}
   .app{height:100vh;display:flex;flex-direction:column;padding:12px;gap:10px;max-width:1100px;margin:0 auto}
-  .tetris-grid-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.05)0 2px,transparent 2px 4px), radial-gradient(circle at center,#243375 0%,#18234d 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}
+  .bubble-smash-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.1)0 2px,transparent 2px 4px), radial-gradient(circle at center,#2c3e91 0%,#1e2d64 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}
 
   .hud{display:flex;gap:8px}
   .hud .panel{flex:1}
@@ -54,17 +54,17 @@
       <div class="mini">
         <h3><img id="avatar1" src="assets/icons/profile.svg" alt="" class="flagInline"/><span id="name1">P1</span></h3>
         <div id="score1" class="aiScore">0</div>
-        <canvas id="opp1" class="tetris-grid-bg"></canvas>
+        <canvas id="opp1" class="bubble-smash-bg"></canvas>
       </div>
       <div class="mini">
         <h3><img id="avatar2" src="assets/icons/profile.svg" alt="" class="flagInline"/><span id="name2">P2</span></h3>
         <div id="score2" class="aiScore">0</div>
-        <canvas id="opp2" class="tetris-grid-bg"></canvas>
+        <canvas id="opp2" class="bubble-smash-bg"></canvas>
       </div>
       <div class="mini">
         <h3><img id="avatar3" src="assets/icons/profile.svg" alt="" class="flagInline"/><span id="name3">P3</span></h3>
         <div id="score3" class="aiScore">0</div>
-        <canvas id="opp3" class="tetris-grid-bg"></canvas>
+        <canvas id="opp3" class="bubble-smash-bg"></canvas>
       </div>
     </div>
     <div class="userWrap">
@@ -82,7 +82,7 @@
           </div>
         </div>
       </div>
-      <canvas id="user" class="tetris-grid-bg"></canvas>
+      <canvas id="user" class="bubble-smash-bg"></canvas>
       <div class="overlayButtons">
         <button id="soundBtn" class="small">🔊</button>
       </div>

--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -12,10 +12,10 @@
     html,body{ height:100%; margin:0; overscroll-behavior:none; }
     body{ background:var(--bg) fixed; background-color:#0c1020; color:var(--ink); font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif; }
     .app{ position:fixed; inset:0; overflow:hidden; }
-    .tetris-grid-bg{
+    .falling-ball-bg{
       background:
-        repeating-linear-gradient(45deg,rgba(255,255,255,0.05)0 2px,transparent 2px 4px),
-        radial-gradient(circle at center,#243375 0%,#18234d 80%);
+        repeating-linear-gradient(45deg,rgba(255,255,255,0.1)0 2px,transparent 2px 4px),
+        radial-gradient(circle at center,#2c3e91 0%,#1e2d64 80%);
       background-size:100px 100px,cover;
       background-position:0 0,center;
       animation:canvasDepthMove 30s linear infinite;
@@ -70,7 +70,7 @@
       <div style="margin-top:6px; font-size:12px; color:#fff;">Pot: <b id="potVal">0</b> TPC (-10% dev fee at end)</div>
     </div>
 
-    <canvas id="scene" class="tetris-grid-bg"></canvas>
+    <canvas id="scene" class="falling-ball-bg"></canvas>
     <div id="winnerPopup" class="popup hidden">
       <div class="box">
         <div id="winnerText" style="margin-bottom:10px;"></div>

--- a/webapp/public/fruit-slice-royale.html
+++ b/webapp/public/fruit-slice-royale.html
@@ -10,7 +10,7 @@
   html,body{height:100vh;overscroll-behavior:none}
   body{margin:0;background:radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;color:var(--text);overflow:hidden}
   .app{height:100vh;display:flex;flex-direction:column;padding:12px;gap:10px;max-width:1100px;margin:0 auto}
-  .tetris-grid-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.05)0 2px,transparent 2px 4px), radial-gradient(circle at center,#243375 0%,#18234d 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}
+  .fruit-slice-bg{background: repeating-linear-gradient(45deg,rgba(255,255,255,0.1)0 2px,transparent 2px 4px), radial-gradient(circle at center,#2c3e91 0%,#1e2d64 80%); background-size:100px 100px,cover; background-position:0 0,center; animation:canvasDepthMove 30s linear infinite}
   header{display:flex;gap:12px;align-items:center;justify-content:space-between}
   .badge{background:#0f1736;border:1px solid #223063;border-radius:10px;padding:6px 10px;color:var(--muted);font-size:12px}
 
@@ -88,17 +88,17 @@
       <div class="mini">
         <h3><img id="avatar1" src="assets/icons/profile.svg" alt="" class="flagInline"/><span id="name1">P1</span></h3>
         <div id="score1" class="aiScore">0</div>
-        <canvas id="opp1" class="tetris-grid-bg"></canvas>
+        <canvas id="opp1" class="fruit-slice-bg"></canvas>
       </div>
       <div class="mini">
         <h3><img id="avatar2" src="assets/icons/profile.svg" alt="" class="flagInline"/><span id="name2">P2</span></h3>
         <div id="score2" class="aiScore">0</div>
-        <canvas id="opp2" class="tetris-grid-bg"></canvas>
+        <canvas id="opp2" class="fruit-slice-bg"></canvas>
       </div>
       <div class="mini">
         <h3><img id="avatar3" src="assets/icons/profile.svg" alt="" class="flagInline"/><span id="name3">P3</span></h3>
         <div id="score3" class="aiScore">0</div>
-        <canvas id="opp3" class="tetris-grid-bg"></canvas>
+        <canvas id="opp3" class="fruit-slice-bg"></canvas>
       </div>
     </div>
     <div class="userWrap">
@@ -111,7 +111,7 @@
           <div class="panel"><strong>Your score</strong><span id="myscore" class="score">0</span></div>
         </div>
       </div>
-      <canvas id="user" class="tetris-grid-bg"></canvas>
+      <canvas id="user" class="fruit-slice-bg"></canvas>
     </div>
   </div>
 </div>

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -15,63 +15,63 @@ export default function HomeGamesCard() {
         <div className="flex overflow-x-auto space-x-4 items-center pb-2">
           <Link
             to="/games/goalrush/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
           >
             <img src="/assets/icons/goal_rush_card_1200x675.webp" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Goal Rush</h3>
           </Link>
           <Link
             to="/games/snake/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
           >
             <img src="/assets/icons/snakes_and_ladders.webp" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Snake &amp; Ladder</h3>
           </Link>
           <Link
             to="/games/fallingball/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
           >
             <img src="/assets/icons/Falling Ball .png" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Falling Ball</h3>
           </Link>
           <Link
             to="/games/fruitsliceroyale/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
           >
             <img src="/assets/icons/Fruit Slice Royale .png" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Fruit Slice Royale</h3>
           </Link>
           <Link
             to="/games/brickbreaker/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
           >
             <img src="/assets/icons/Brick Breaker Royale .png" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Brick Breaker Royale</h3>
           </Link>
           <Link
             to="/games/tetrisroyale/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
           >
             <img src="/assets/icons/file_00000000240061f4abd28311d76970a5.png" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Tetris Royale</h3>
           </Link>
           <Link
             to="/games/bubblesmashroyale/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
           >
             <img src="/assets/icons/Bubble Smash Royale .png" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Bubble Smash Royale</h3>
           </Link>
           <Link
             to="/games/crazydice/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
           >
             <img src="/assets/icons/Crazy_Dice_Duel_Promo.webp" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Crazy Dice Duel</h3>
           </Link>
           <Link
             to="/games/bubblepoproyale/lobby"
-            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
           >
             <img src="/assets/icons/Bubble Pop Royale .png" alt="" className="h-20 w-20" />
             <h3 className="text-sm font-semibold text-center">Bubble Pop Royale</h3>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1669,10 +1669,11 @@ input:focus {
   }
 }
 
-.tetris-grid-bg {
+.game-page-bg,
+.game-card-bg {
   background:
-    repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.05) 0 2px, transparent 2px 4px),
-    radial-gradient(circle at center, #243375 0%, #18234d 80%);
+    repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.1) 0 2px, transparent 2px 4px),
+    radial-gradient(circle at center, #2c3e91 0%, #1e2d64 80%);
   background-size: 100px 100px, cover;
   background-position: 0 0, center;
   animation: canvasDepthMove 30s linear infinite;

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -12,63 +12,63 @@ export default function Games() {
             <div className="flex overflow-x-auto space-x-4 items-center pb-2">
                 <Link
                   to="/games/goalrush/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
                 >
                   <img src="/assets/icons/goal_rush_card_1200x675.webp" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Goal Rush</h3>
                 </Link>
                 <Link
                   to="/games/snake/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
                 >
                   <img src="/assets/icons/snakes_and_ladders.webp" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Snake &amp; Ladder</h3>
                 </Link>
                 <Link
                   to="/games/fallingball/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
                 >
                   <img src="/assets/icons/Falling Ball .png" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Falling Ball</h3>
                 </Link>
                 <Link
                   to="/games/fruitsliceroyale/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
                 >
                   <img src="/assets/icons/Fruit Slice Royale .png" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Fruit Slice Royale</h3>
                 </Link>
                 <Link
                   to="/games/brickbreaker/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
                 >
                   <img src="/assets/icons/Brick Breaker Royale .png" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Brick Breaker Royale</h3>
                 </Link>
                 <Link
                   to="/games/tetrisroyale/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
                 >
                   <img src="/assets/icons/file_00000000240061f4abd28311d76970a5.png" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Tetris Royale</h3>
                 </Link>
                 <Link
                   to="/games/bubblesmashroyale/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
                 >
                   <img src="/assets/icons/Bubble Smash Royale .png" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Bubble Smash Royale</h3>
                 </Link>
                 <Link
                   to="/games/crazydice/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
                 >
                   <img src="/assets/icons/Crazy_Dice_Duel_Promo.webp" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Crazy Dice Duel</h3>
                 </Link>
                 <Link
                   to="/games/bubblepoproyale/lobby"
-                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 game-card-bg"
                 >
                   <img src="/assets/icons/Bubble Pop Royale .png" alt="" className="h-20 w-20" />
                   <h3 className="text-sm font-semibold text-center">Bubble Pop Royale</h3>

--- a/webapp/src/pages/Games/BrickBreakerLobby.jsx
+++ b/webapp/src/pages/Games/BrickBreakerLobby.jsx
@@ -66,7 +66,7 @@ export default function BrickBreakerLobby() {
   };
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+    <div className="relative p-4 space-y-4 text-text min-h-screen game-page-bg">
       <h2 className="text-xl font-bold text-center">Brick Breaker Royale Lobby</h2>
       <div className="space-y-2">
         <h3 className="font-semibold">Players</h3>

--- a/webapp/src/pages/Games/BubblePopRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/BubblePopRoyaleLobby.jsx
@@ -63,7 +63,7 @@ export default function BubblePopRoyaleLobby() {
   };
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+    <div className="relative p-4 space-y-4 text-text min-h-screen game-page-bg">
       <h2 className="text-xl font-bold text-center">Bubble Pop Royale Lobby</h2>
       <div className="space-y-2">
         <h3 className="font-semibold">Players</h3>

--- a/webapp/src/pages/Games/BubbleSmashRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/BubbleSmashRoyaleLobby.jsx
@@ -63,7 +63,7 @@ export default function BubbleSmashRoyaleLobby() {
   };
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+    <div className="relative p-4 space-y-4 text-text min-h-screen game-page-bg">
       <h2 className="text-xl font-bold text-center">Bubble Smash Royale Lobby</h2>
       <div className="space-y-2">
         <h3 className="font-semibold">Players</h3>

--- a/webapp/src/pages/Games/CrazyDiceLobby.jsx
+++ b/webapp/src/pages/Games/CrazyDiceLobby.jsx
@@ -106,7 +106,7 @@ export default function CrazyDiceLobby() {
     (table.id === 'single' && aiType === 'flags' && flags.length !== aiCount);
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+    <div className="relative p-4 space-y-4 text-text min-h-screen game-page-bg">
       <h2 className="text-xl font-bold text-center">Crazy Dice Lobby</h2>
       <p className="text-center text-sm">Online users: {online}</p>
       <div className="space-y-2">

--- a/webapp/src/pages/Games/FallingBallLobby.jsx
+++ b/webapp/src/pages/Games/FallingBallLobby.jsx
@@ -64,7 +64,7 @@ export default function FallingBallLobby() {
   };
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+    <div className="relative p-4 space-y-4 text-text min-h-screen game-page-bg">
       <h2 className="text-xl font-bold text-center">Falling Ball Lobby</h2>
       <div className="space-y-2">
         <h3 className="font-semibold">Players</h3>

--- a/webapp/src/pages/Games/FruitSliceRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/FruitSliceRoyaleLobby.jsx
@@ -63,7 +63,7 @@ export default function FruitSliceRoyaleLobby() {
   };
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+    <div className="relative p-4 space-y-4 text-text min-h-screen game-page-bg">
       <h2 className="text-xl font-bold text-center">Fruit Slice Royale Lobby</h2>
       <div className="space-y-2">
         <h3 className="font-semibold">Players</h3>

--- a/webapp/src/pages/Games/GoalRushLobby.jsx
+++ b/webapp/src/pages/Games/GoalRushLobby.jsx
@@ -62,7 +62,7 @@ export default function GoalRushLobby() {
   };
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+    <div className="relative p-4 space-y-4 text-text min-h-screen game-page-bg">
       <h2 className="text-xl font-bold text-center">Goal Rush Lobby</h2>
       <div className="space-y-2">
         <h3 className="font-semibold">Mode</h3>

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -259,7 +259,7 @@ export default function Lobby() {
       flags.length !== aiCount);
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+    <div className="relative p-4 space-y-4 text-text min-h-screen game-page-bg">
       <h2 className="text-xl font-bold text-center capitalize">{game} Lobby</h2>
       <p className="text-center text-sm">Online users: {online}</p>
       {game === 'snake' && (

--- a/webapp/src/pages/Games/TetrisRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/TetrisRoyaleLobby.jsx
@@ -63,7 +63,7 @@ export default function TetrisRoyaleLobby() {
   };
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+    <div className="relative p-4 space-y-4 text-text min-h-screen game-page-bg">
       <h2 className="text-xl font-bold text-center">Tetris Royale Lobby</h2>
       <div className="space-y-2">
         <h3 className="font-semibold">Players</h3>


### PR DESCRIPTION
## Summary
- brighten tetris-style grid and split into distinct page and card background classes
- give each static game page its own brightened grid background class

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ebf2152348329a87c484c976f42c0