### PR TITLE
feat: add ludo board and shared utilities

### DIFF
--- a/games/ludo/board.js
+++ b/games/ludo/board.js
@@ -1,0 +1,38 @@
+export const colorStartIndex = { red: 0, green: 13, yellow: 26, blue: 39 };
+export const safeRingIndices = [0, 6, 13, 19, 26, 32, 39, 45];
+
+export function buildLudoBoard() {
+  const W = 15, H = 15;
+  const board = Array.from({ length: H }, (_, y) =>
+    Array.from({ length: W }, (_, x) => ({ x, y, type: 'empty' }))
+  );
+  const ring = [];
+  for (let x = 1; x <= 13; x++) ring.push({ x, y: 0 });
+  for (let y = 1; y <= 13; y++) ring.push({ x: 14, y });
+  for (let x = 13; x >= 1; x--) ring.push({ x, y: 14 });
+  for (let y = 13; y >= 1; y--) ring.push({ x: 0, y });
+  ring.forEach(p => (board[p.y][p.x].type = 'ring'));
+
+  const lanes = {
+    red:   [{ x: 7, y: 1 }, { x: 7, y: 2 }, { x: 7, y: 3 }, { x: 7, y: 4 }, { x: 7, y: 5 }, { x: 7, y: 6 }],
+    green: [{ x: 13, y: 7 }, { x: 12, y: 7 }, { x: 11, y: 7 }, { x: 10, y: 7 }, { x: 9, y: 7 }, { x: 8, y: 7 }],
+    yellow:[{ x: 7, y: 13 }, { x: 7, y: 12 }, { x: 7, y: 11 }, { x: 7, y: 10 }, { x: 7, y: 9 }, { x: 7, y: 8 }],
+    blue:  [{ x: 1, y: 7 }, { x: 2, y: 7 }, { x: 3, y: 7 }, { x: 4, y: 7 }, { x: 5, y: 7 }, { x: 6, y: 7 }],
+  };
+  Object.entries(lanes).forEach(([c, cells]) =>
+    cells.forEach(p => (board[p.y][p.x].type = `lane:${c}`))
+  );
+  board[7][7].type = 'home';
+
+  const bases = {
+    red:   [{ x: 2, y: 2 }, { x: 3, y: 2 }, { x: 2, y: 3 }, { x: 3, y: 3 }],
+    green: [{ x: 11, y: 2 }, { x: 12, y: 2 }, { x: 11, y: 3 }, { x: 12, y: 3 }],
+    yellow:[{ x: 11, y: 11 }, { x: 12, y: 11 }, { x: 11, y: 12 }, { x: 12, y: 12 }],
+    blue:  [{ x: 2, y: 11 }, { x: 3, y: 11 }, { x: 2, y: 12 }, { x: 3, y: 12 }],
+  };
+  Object.entries(bases).forEach(([c, cells]) =>
+    cells.forEach(p => (board[p.y][p.x].type = `base:${c}`))
+  );
+
+  return { board, ring, lanes };
+}

--- a/games/ludo/stake.js
+++ b/games/ludo/stake.js
@@ -1,0 +1,5 @@
+export function computePayout(stake, players) {
+  const pot = stake * players;
+  const fee = Math.round(pot * 0.10);
+  return { pot, fee, net: pot - fee };
+}

--- a/games/ludo/validation.js
+++ b/games/ludo/validation.js
@@ -1,0 +1,10 @@
+export function validateLobby(mode, seats) {
+  if (mode === 'online') {
+    if (seats.some(s => s.kind === 'ai')) throw new Error('AI not allowed in online mode');
+    if (seats.length < 2) throw new Error('At least 2 humans required');
+  } else {
+    if (seats.some(s => s.kind === 'human' && !s.isLocal))
+      throw new Error('Remote humans not allowed in local mode');
+    if (seats.length < 2) throw new Error('At least 1 human + 1 AI required');
+  }
+}

--- a/shared/box-grid.js
+++ b/shared/box-grid.js
@@ -1,0 +1,11 @@
+export function createBoxGrid(width, height, init = () => ({})) {
+  return Array.from({ length: height }, (_, y) =>
+    Array.from({ length: width }, (_, x) => ({ x, y, ...init(x, y) }))
+  );
+}
+
+export function forEachCell(grid, fn) {
+  for (const row of grid) {
+    for (const cell of row) fn(cell);
+  }
+}

--- a/shared/dice.js
+++ b/shared/dice.js
@@ -1,0 +1,6 @@
+// Simple deterministic dice roller with optional seed
+export function rollDice(seed) {
+  const random = seed != null ? Math.abs(Math.sin(seed)) : Math.random();
+  const value = Math.floor(random * 6) + 1;
+  return Promise.resolve(value);
+}


### PR DESCRIPTION
## Summary
- scaffold initial Ludo game with board builder, lobby validation, and stake math
- add shared dice roller and box grid helpers copied from Snake & Ladder components

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*

------
https://chatgpt.com/codex/tasks/task_e_689ec2468160832986faf28cc9959dee