### PR TITLE
chore: lighten global text weight

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -16,7 +16,7 @@ body {
 body {
   font-family: 'Luckiest Guy', 'Comic Sans MS', cursive;
   margin: 0;
-  @apply text-text overflow-x-hidden;
+  @apply text-text overflow-x-hidden font-light;
   background: radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;
   background-color: #0c1020;
 }


### PR DESCRIPTION
## Summary
- lighten default font weight across the webapp for thinner text

## Testing
- `npm test` *(fails: test timed out; BOT_TOKEN not configured)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ec77fc6288329a386398fd23c3e50