### PR TITLE
feat: outline text with contrasting edges

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -16,9 +16,35 @@ body {
 body {
   font-family: 'Luckiest Guy', 'Comic Sans MS', cursive;
   margin: 0;
-  @apply text-text overflow-x-hidden font-light;
+  @apply text-text overflow-x-hidden font-extralight;
   background: radial-gradient(1200px 800px at 70% -10%, #1a2450 0%, #0c1020 38%, #0c1020 100%) fixed;
   background-color: #0c1020;
+}
+
+/* Outline text with contrasting edges */
+[class*="text-blue-"],
+[class*="text-red-"],
+[class*="text-yellow-"],
+[class*="text-black"],
+[class*="text-green-"],
+[class*="text-white"] {
+  -webkit-text-stroke-width: 0.5px;
+}
+
+[class*="text-blue-"],
+[class*="text-red-"],
+[class*="text-yellow-"],
+[class*="text-black"] {
+  -webkit-text-stroke-color: #ffffff;
+}
+
+[class*="text-white"] {
+  -webkit-text-stroke-color: #000000;
+}
+
+[class*="text-green-"] {
+  -webkit-text-stroke-color: #22c55e;
+  color: #ffffff;
 }
 
 /* Neon theme elements */


### PR DESCRIPTION
## Summary
- lighten default body text weight
- add stroke outlines with color-specific edges

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ed1ef6288832984209319cee7df26