### PR TITLE
fix: handle missing Google IDs gracefully

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -41,9 +41,10 @@ const userSchema = new mongoose.Schema({
 
   telegramId: { type: Number, unique: true },
 
-  // Allow multiple users without a Google account by making the unique
-  // index sparse (documents missing googleId won't conflict)
-  googleId: { type: String, default: null },
+  // Allow multiple users without a Google account. By omitting the field when
+  // it isn't provided (default: undefined), the sparse unique index below will
+  // ignore these documents instead of treating `null` values as duplicates.
+  googleId: { type: String, default: undefined },
 
   googleEmail: { type: String, default: '' },
 


### PR DESCRIPTION
## Summary
- omit `googleId` field when not provided to avoid unique index conflicts

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ed32c03a4832986b4bfcd1e364157