### PR TITLE
feat: add developer task management panel

### DIFF
--- a/bot/models/CustomTask.js
+++ b/bot/models/CustomTask.js
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose';
+
+const customTaskSchema = new mongoose.Schema({
+  platform: {
+    type: String,
+    enum: ['tiktok', 'x', 'telegram', 'discord', 'youtube', 'facebook', 'instagram'],
+    required: true
+  },
+  reward: { type: Number, required: true },
+  link: { type: String, required: true },
+  description: { type: String }
+});
+
+export default mongoose.model('CustomTask', customTaskSchema);

--- a/webapp/src/components/DevTasksModal.jsx
+++ b/webapp/src/components/DevTasksModal.jsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  adminListTasks,
+  adminCreateTask,
+  adminUpdateTask,
+  adminDeleteTask
+} from '../utils/api.js';
+
+export default function DevTasksModal({ open, onClose }) {
+  const [tasks, setTasks] = useState([]);
+  const [platform, setPlatform] = useState('tiktok');
+  const [reward, setReward] = useState('');
+  const [link, setLink] = useState('');
+  const [editing, setEditing] = useState(null);
+
+  const load = async () => {
+    const data = await adminListTasks();
+    if (!data.error) setTasks(data);
+  };
+
+  useEffect(() => {
+    if (open) load();
+  }, [open]);
+
+  const handleAdd = async () => {
+    const r = parseInt(reward, 10);
+    if (!platform || !r || !link) return;
+    if (editing) {
+      await adminUpdateTask(editing, platform, r, link);
+    } else {
+      await adminCreateTask(platform, r, link);
+    }
+    setPlatform('tiktok');
+    setReward('');
+    setLink('');
+    setEditing(null);
+    load();
+  };
+
+  const handleEdit = (task) => {
+    setPlatform(task.platform);
+    setReward(String(task.reward));
+    setLink(task.link);
+    setEditing(task._id);
+  };
+
+  const handleDelete = async (id) => {
+    await adminDeleteTask(id);
+    load();
+  };
+
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 bg-black bg-opacity-70 z-50 overflow-auto flex flex-col">
+      <div className="bg-surface text-text p-4 flex-1">
+        <h3 className="text-lg font-bold mb-4 text-center">Manage Tasks</h3>
+        <div className="space-y-2 mb-4">
+          <select
+            value={platform}
+            onChange={(e) => setPlatform(e.target.value)}
+            className="border p-1 rounded w-full text-black"
+          >
+            <option value="tiktok">TikTok</option>
+            <option value="x">X</option>
+            <option value="telegram">Telegram</option>
+            <option value="discord">Discord</option>
+            <option value="youtube">YouTube</option>
+            <option value="facebook">Facebook</option>
+            <option value="instagram">Instagram</option>
+          </select>
+          <input
+            type="number"
+            placeholder="Reward (TPC)"
+            value={reward}
+            onChange={(e) => setReward(e.target.value)}
+            className="border p-1 rounded w-full text-black"
+          />
+          <input
+            type="text"
+            placeholder="Link"
+            value={link}
+            onChange={(e) => setLink(e.target.value)}
+            className="border p-1 rounded w-full text-black"
+          />
+          <button
+            onClick={handleAdd}
+            className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background w-full"
+          >
+            {editing ? 'Save Task' : 'Add Task'}
+          </button>
+          {editing && (
+            <button
+              onClick={() => {
+                setEditing(null);
+                setPlatform('tiktok');
+                setReward('');
+                setLink('');
+              }}
+              className="px-3 py-1 bg-red-600 text-background rounded w-full"
+            >
+              Cancel Edit
+            </button>
+          )}
+        </div>
+        <ul className="space-y-2">
+          {tasks.map((t) => (
+            <li key={t._id} className="lobby-tile space-y-1">
+              <div className="text-sm break-all">
+                {t.platform} - {t.reward} TPC
+              </div>
+              <div className="text-xs break-all">{t.link}</div>
+              <div className="flex gap-2 mt-1">
+                <button
+                  onClick={() => handleEdit(t)}
+                  className="px-2 py-1 bg-primary hover:bg-primary-hover text-background rounded text-xs"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => handleDelete(t._id)}
+                  className="px-2 py-1 bg-red-600 text-background rounded text-xs"
+                >
+                  Remove
+                </button>
+              </div>
+            </li>
+          ))}
+          {tasks.length === 0 && (
+            <p className="text-center text-subtext text-sm">No tasks.</p>
+          )}
+        </ul>
+        <button
+          onClick={onClose}
+          className="mt-4 px-3 py-1 bg-primary hover:bg-primary-hover text-background rounded w-full"
+        >
+          Close
+        </button>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -19,7 +19,8 @@ import LoginOptions from './LoginOptions.jsx';
 import { IoLogoTiktok } from 'react-icons/io5';
 
 import { RiTelegramFill } from 'react-icons/ri';
-import { FiVideo } from 'react-icons/fi';
+import { FiVideo, FiLink } from 'react-icons/fi';
+import { FaDiscord, FaYoutube, FaFacebook, FaInstagram } from 'react-icons/fa';
 import AdModal from './AdModal.tsx';
 import PostsModal from './PostsModal.jsx';
 import InfoPopup from './InfoPopup.jsx';
@@ -34,11 +35,8 @@ const xIcon = (
 );
 
 const ICONS = {
-
   join_twitter: xIcon,
-
   join_telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
-  
   follow_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
   boost_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
   boost_tiktok_1: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
@@ -51,8 +49,14 @@ const ICONS = {
   react_tg_post: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
   react_tg_post_2: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
   engage_tweet: xIcon,
-  watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />
-
+  watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />,
+  tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
+  x: xIcon,
+  telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
+  discord: <FaDiscord className="text-indigo-500 w-5 h-5" />,
+  youtube: <FaYoutube className="text-red-600 w-5 h-5" />,
+  facebook: <FaFacebook className="text-blue-600 w-5 h-5" />,
+  instagram: <FaInstagram className="text-pink-400 w-5 h-5" />
 };
 
 const REWARDS = Array.from({ length: 30 }, (_, i) => 100 + i * 20);
@@ -265,7 +269,7 @@ export default function TasksCard() {
         {tasks.map((t) => (
           <li key={t.id} className="lobby-tile w-full">
             <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
-              {ICONS[t.id]}
+              {ICONS[t.id] || ICONS[t.icon] || <FiLink className="w-5 h-5" />}
               <span className="text-sm">{t.description}</span>
               <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-4 h-4" /></span>
               {t.completed && t.id === 'post_tweet' && t.cooldown > 0 ? (

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -24,6 +24,7 @@ import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
 import InfoPopup from '../components/InfoPopup.jsx';
 import DevNotifyModal from '../components/DevNotifyModal.jsx';
 import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
+import DevTasksModal from '../components/DevTasksModal.jsx';
 import Wallet from './Wallet.jsx';
 
 import { FiCopy } from 'react-icons/fi';
@@ -67,6 +68,7 @@ export default function MyAccount() {
   const [notifySending, setNotifySending] = useState(false);
   const [notifyStatus, setNotifyStatus] = useState('');
   const [showNotifyModal, setShowNotifyModal] = useState(false);
+  const [showTasksModal, setShowTasksModal] = useState(false);
   const [twitterError, setTwitterError] = useState('');
   const [twitterLink, setTwitterLink] = useState('');
   const [unread, setUnread] = useState(0);
@@ -403,6 +405,15 @@ export default function MyAccount() {
             </button>
           </div>
 
+          <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
+            <button
+              onClick={() => setShowTasksModal(true)}
+              className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background w-full"
+            >
+              Manage Tasks
+            </button>
+          </div>
+
           <InfluencerClaimsCard />
         </>
       )}
@@ -420,6 +431,10 @@ export default function MyAccount() {
         setNotifyPhoto={setNotifyPhoto}
         notifySending={notifySending}
         onSend={handleDevNotify}
+      />
+      <DevTasksModal
+        open={showTasksModal}
+        onClose={() => setShowTasksModal(false)}
       />
       <InfoPopup
         open={showSaved}

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -21,7 +21,8 @@ import LoginOptions from '../components/LoginOptions.jsx';
 import { IoLogoTiktok } from 'react-icons/io5';
 
 import { RiTelegramFill } from 'react-icons/ri';
-import { FiVideo } from 'react-icons/fi';
+import { FiVideo, FiLink } from 'react-icons/fi';
+import { FaDiscord, FaYoutube, FaFacebook, FaInstagram } from 'react-icons/fa';
 import { AiOutlineCheck } from 'react-icons/ai';
 import AdModal from '../components/AdModal.tsx';
 import PostsModal from '../components/PostsModal.jsx';
@@ -233,7 +234,14 @@ export default function Tasks() {
     react_tg_post: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
     react_tg_post_2: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
     engage_tweet: xIcon,
-    watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />
+    watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />,
+    tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
+    x: xIcon,
+    telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
+    discord: <FaDiscord className="text-indigo-500 w-5 h-5" />,
+    youtube: <FaYoutube className="text-red-600 w-5 h-5" />,
+    facebook: <FaFacebook className="text-blue-600 w-5 h-5" />,
+    instagram: <FaInstagram className="text-pink-400 w-5 h-5" />
   };
 
   return (
@@ -274,7 +282,7 @@ export default function Tasks() {
           {tasks.map((t) => (
             <li key={t.id} className="lobby-tile w-full">
               <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
-                {ICONS[t.id]}
+                {ICONS[t.id] || ICONS[t.icon] || <FiLink className="w-5 h-5" />}
                 <span className="text-sm">{t.description}</span>
                 <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-4 h-4" /></span>
                 {t.completed && t.id === 'post_tweet' && t.cooldown > 0 ? (

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -157,6 +157,22 @@ export function verifyTelegramReaction(telegramId, messageId, threadId) {
   return post('/api/tasks/verify-telegram-reaction', { telegramId, messageId, threadId });
 }
 
+export function adminListTasks() {
+  return post('/api/tasks/admin/list', {}, API_AUTH_TOKEN || undefined);
+}
+
+export function adminCreateTask(platform, reward, link) {
+  return post('/api/tasks/admin/create', { platform, reward, link }, API_AUTH_TOKEN || undefined);
+}
+
+export function adminUpdateTask(id, platform, reward, link) {
+  return post('/api/tasks/admin/update', { id, platform, reward, link }, API_AUTH_TOKEN || undefined);
+}
+
+export function adminDeleteTask(id) {
+  return post('/api/tasks/admin/delete', { id }, API_AUTH_TOKEN || undefined);
+}
+
 export function listVideos(telegramId) {
 
   return post('/api/watch/list', { telegramId });


### PR DESCRIPTION
## Summary
- allow API to create, update, delete and list custom tasks
- add dev-only modal to manage tasks from the profile page
- show custom task icons on task lists and home page card

## Testing
- `npm run lint`
- `npm test` *(fails: test timed out and telegram bot not configured)*

------
https://chatgpt.com/codex/tasks/task_e_689ed6d09ef0832990b1ad5603ce5e02