### PR TITLE
Fix task panel to show and sync tasks

### DIFF
--- a/webapp/src/components/DevTasksModal.jsx
+++ b/webapp/src/components/DevTasksModal.jsx
@@ -18,7 +18,7 @@ export default function DevTasksModal({ open, onClose }) {
 
   const load = async () => {
     const data = await adminListTasks();
-    if (!data.error) setTasks(data);
+    if (!data.error) setTasks(data.tasks || data);
   };
 
   useEffect(() => {
@@ -39,6 +39,7 @@ export default function DevTasksModal({ open, onClose }) {
     setDescription('');
     setEditing(null);
     load();
+    window.dispatchEvent(new Event('tasksUpdated'));
   };
 
   const handleEdit = (task) => {
@@ -53,6 +54,7 @@ export default function DevTasksModal({ open, onClose }) {
     if (!window.confirm('Are you sure you want to delete this task?')) return;
     await adminDeleteTask(id);
     load();
+    window.dispatchEvent(new Event('tasksUpdated'));
   };
 
   if (!open) return null;

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -123,9 +123,10 @@ export default function TasksCard() {
   };
 
   useEffect(() => {
-
     load();
-
+    const handler = () => load();
+    window.addEventListener('tasksUpdated', handler);
+    return () => window.removeEventListener('tasksUpdated', handler);
   }, []);
 
   useEffect(() => {

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -111,6 +111,9 @@ export default function Tasks() {
   useEffect(() => {
     load();
     loadInfluencer();
+    const handler = () => load();
+    window.addEventListener('tasksUpdated', handler);
+    return () => window.removeEventListener('tasksUpdated', handler);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fix DevTasksModal to parse API response and dispatch global update events
- refresh Tasks page and TasksCard when tasks are added or removed

## Testing
- `npm test` *(fails: snake API endpoints and socket events)*

------
https://chatgpt.com/codex/tasks/task_e_689ee2094f108329b271b09ae82a4c9b