### PR TITLE
Outline electric blue text with white stroke

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -28,6 +28,7 @@ body {
 [class*="text-yellow-"],
 [class*="text-black"],
 [class*="text-green-"],
+.text-text,
 [class*="text-white"] {
   -webkit-text-stroke-width: 0.3px;
 }
@@ -37,7 +38,8 @@ body {
 [class*="text-red-"],
 [class*="text-yellow-"],
 [class*="text-black"],
-[class*="text-green-"] {
+[class*="text-green-"],
+.text-text {
   -webkit-text-stroke-color: #ffffff;
 }
 


### PR DESCRIPTION
## Summary
- add global CSS rule to outline electric-blue `text-text` elements with a subtle white stroke for better readability

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ee3b88ac083298383cddc896e6d6e