### PR TITLE
style: darken and widen game lobby background

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -111,7 +111,7 @@ export default function Layout({ children }) {
         className={`flex-grow ${
           showNavbar
             ? isLobby
-              ? 'w-full p-4 pb-24'
+              ? 'w-full p-0 pb-24'
               : 'container mx-auto p-4 pb-24'
             : 'w-full p-0'
         }`}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1697,9 +1697,13 @@ input:focus {
 
 .tetris-grid-bg {
   background:
-    repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.05) 0 2px, transparent 2px 4px),
-    radial-gradient(circle at center, #243375 0%, #18234d 80%);
-  background-size: 100px 100px, cover;
+    repeating-linear-gradient(
+      45deg,
+      rgba(255, 255, 255, 0.03) 0 2px,
+      transparent 2px 4px
+    ),
+    radial-gradient(circle at center, #050f1a 0%, #03070f 80%);
+  background-size: 150px 150px, cover;
   background-position: 0 0, center;
   animation: canvasDepthMove 30s linear infinite;
 }


### PR DESCRIPTION
## Summary
- align lobby background brightness with logo theme
- widen lobby background to cover full screen width

## Testing
- `npm run lint`
- `npm test` *(fails: snake API endpoints and socket events)*

------
https://chatgpt.com/codex/tasks/task_e_689ee9a7ce248329b4f98039c360552d