### PR TITLE
Remove obsolete social tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,6 @@ To move from the start you must roll at least one six when rolling two dice. Any
 
 **Influencer admin shows "No submissions"** – Ensure your developer token is set in `bot/.env` via `AIRDROP_ADMIN_TOKENS` and in `webapp/.env` through `VITE_API_AUTH_TOKEN` so the webapp can fetch pending submissions.
 
-**Telegram reaction not detected** – The `/api/tasks/verify-telegram-reaction` endpoint relies on `BOT_TOKEN`. If this token is missing the check is skipped and the task automatically succeeds. Configure it only if you require strict validation.
 
 ### Banning a user
 

--- a/bot/utils/tasksData.js
+++ b/bot/utils/tasksData.js
@@ -1,4 +1,4 @@
-export const TASKS_VERSION = 6;
+export const TASKS_VERSION = 7;
 
 export const TASKS = [
 
@@ -41,91 +41,5 @@ export const TASKS = [
     icon: 'tiktok',
 
   link: 'https://www.tiktok.com/@tonplaygram?_t=ZS-8xxPL1nbD9U&_r=1'
-  },
-
-  {
-    id: 'boost_tiktok',
-    description: 'Like & repost our TikTok',
-    reward: 800,
-    icon: 'tiktok',
-    link: 'https://vt.tiktok.com/ZSBXkX8pu/'
-  },
-
-  {
-    id: 'boost_tiktok_1',
-    description: 'Like, share & comment on TikTok',
-    reward: 800,
-    icon: 'tiktok',
-    link: 'https://vt.tiktok.com/ZSBnaAGTQ/'
-  },
-
-  {
-    id: 'boost_tiktok_2',
-    description: 'Like, share & comment on TikTok',
-    reward: 800,
-    icon: 'tiktok',
-    link: 'https://vt.tiktok.com/ZSBnagc3g/'
-  },
-
-  {
-    id: 'boost_tiktok_3',
-    description: 'Like, comment & repost on TikTok',
-    reward: 800,
-    icon: 'tiktok',
-    link: 'https://vt.tiktok.com/ZSBngGPdy/',
-    hideOnHome: true
-  },
-
-  {
-    id: 'boost_tiktok_4',
-    description: 'Like, comment & repost on TikTok',
-    reward: 800,
-    icon: 'tiktok',
-    link: 'https://vt.tiktok.com/ZSBngp3GD/',
-    hideOnHome: true
-  },
-
-  {
-    id: 'boost_tiktok_5',
-    description: 'Like, comment & repost on TikTok',
-    reward: 800,
-    icon: 'tiktok',
-    link: 'https://vt.tiktok.com/ZSBngWDnQ/',
-    hideOnHome: true
-  },
-
-  {
-    id: 'boost_tiktok_6',
-    description: 'Like, comment & repost on TikTok',
-    reward: 800,
-    icon: 'tiktok',
-    link: 'https://vt.tiktok.com/ZSBnpkW5v/',
-    hideOnHome: true
-  },
-
-  {
-    id: 'react_tg_post',
-    description: 'React to our group post',
-    reward: 1000,
-    icon: 'telegram',
-    link: 'https://t.me/TonPlaygram/1/16'
-  },
-
-  {
-    id: 'react_tg_post_2',
-    description: 'React to our group post',
-    reward: 1000,
-    icon: 'telegram',
-    link: 'https://t.me/TonPlaygram/19'
-  },
-
-  {
-    id: 'engage_tweet',
-    description: 'Like, comment & repost on X',
-    reward: 1000,
-    icon: 'x',
-    link: 'https://x.com/TonPlaygram/status/1943907328652402954?t=bG-Ps1S8rbJ-afx2OwcZhA&s=19'
-  },
-
-
+  }
 ];

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -4,7 +4,6 @@ import {
   listTasks,
   completeTask,
   verifyPost,
-  verifyTelegramReaction,
   getAdStatus,
   watchAd,
   getQuestStatus,
@@ -12,7 +11,7 @@ import {
   dailyCheckIn,
   getProfile,
 } from '../utils/api.js';
-import { getTelegramId, parseTelegramPostLink } from '../utils/telegram.js';
+import { getTelegramId } from '../utils/telegram.js';
 import LoginOptions from './LoginOptions.jsx';
 
 
@@ -38,17 +37,7 @@ const ICONS = {
   join_twitter: xIcon,
   join_telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
   follow_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-  boost_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-  boost_tiktok_1: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-  boost_tiktok_2: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-  boost_tiktok_3: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-  boost_tiktok_4: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-  boost_tiktok_5: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-  boost_tiktok_6: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
   post_tweet: xIcon,
-  react_tg_post: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
-  react_tg_post_2: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
-  engage_tweet: xIcon,
   watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />,
   tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
   x: xIcon,
@@ -150,21 +139,12 @@ export default function TasksCard() {
   }, []);
 
   const handleClaim = async (task) => {
-    if (['join_twitter', 'engage_tweet'].includes(task.id) && !profile?.social?.twitter) {
+    if (task.id === 'join_twitter' && !profile?.social?.twitter) {
       setShowTwitterInfo(true);
       return;
     }
 
     window.open(task.link, '_blank');
-
-    if (task.id.startsWith('react_tg_post')) {
-      const { messageId, threadId } = parseTelegramPostLink(task.link || '');
-      const res = await verifyTelegramReaction(telegramId, messageId, threadId);
-      if (res.error || !res.reacted) {
-        alert(res.error || 'Reaction not verified');
-        return;
-      }
-    }
 
     await completeTask(telegramId, task.id);
 

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -4,7 +4,6 @@ import {
   listTasks,
   completeTask,
   verifyPost,
-  verifyTelegramReaction,
   getAdStatus,
   watchAd,
   getQuestStatus,
@@ -14,8 +13,7 @@ import {
   submitInfluencerVideo,
   myInfluencerVideos,
 } from '../utils/api.js';
-
-import { getTelegramId, parseTelegramPostLink } from '../utils/telegram.js';
+import { getTelegramId } from '../utils/telegram.js';
 import LoginOptions from '../components/LoginOptions.jsx';
 
 import { IoLogoTiktok } from 'react-icons/io5';
@@ -137,20 +135,12 @@ export default function Tasks() {
   }, []);
 
   const handleClaim = async (task) => {
-    if (['join_twitter', 'engage_tweet'].includes(task.id) && !profile?.social?.twitter) {
+    if (task.id === 'join_twitter' && !profile?.social?.twitter) {
       setShowTwitterInfo(true);
       return;
     }
     if (task.link) {
       window.open(task.link, '_blank');
-    }
-    if (task.id.startsWith('react_tg_post')) {
-      const { messageId, threadId } = parseTelegramPostLink(task.link || '');
-      const res = await verifyTelegramReaction(telegramId, messageId, threadId);
-      if (res.error || !res.reacted) {
-        alert(res.error || 'Reaction not verified');
-        return;
-      }
     }
     await completeTask(telegramId, task.id);
     load();
@@ -226,17 +216,7 @@ export default function Tasks() {
     join_twitter: xIcon,
     join_telegram: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
     follow_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-    boost_tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-    boost_tiktok_1: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-    boost_tiktok_2: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-    boost_tiktok_3: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-    boost_tiktok_4: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-    boost_tiktok_5: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
-    boost_tiktok_6: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
     post_tweet: xIcon,
-    react_tg_post: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
-    react_tg_post_2: <RiTelegramFill className="text-sky-400 w-5 h-5" />,
-    engage_tweet: xIcon,
     watch_ad: <FiVideo className="text-yellow-500 w-5 h-5" />,
     tiktok: <IoLogoTiktok className="text-pink-500 w-5 h-5" />,
     x: xIcon,

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -153,10 +153,6 @@ export function verifyPost(telegramId, tweetUrl) {
   return post('/api/tasks/verify-post', { telegramId, tweetUrl });
 }
 
-export function verifyTelegramReaction(telegramId, messageId, threadId) {
-  return post('/api/tasks/verify-telegram-reaction', { telegramId, messageId, threadId });
-}
-
 export function adminListTasks() {
   return post('/api/tasks/admin/list', {}, API_AUTH_TOKEN || undefined);
 }


### PR DESCRIPTION
## Summary
- drop deprecated social engagement tasks and related verification logic
- simplify task icons and client-side handling of removed tasks
- bump task version and prune unused API helpers

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ee7a216a0832992b36d71a8608e32