### PR TITLE
Add red outline and white glow to electric blue text

### DIFF
--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -25,7 +25,7 @@
     .row{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
     .chip{ padding:6px 10px; border-radius:12px; border:1px solid rgba(255,255,255,.15); color:#fff; background:transparent; cursor:pointer; }
     .chip.active{ border-color:#7dd3fc; }
-      .btn{ appearance:none; border:1px solid #00f7ff; background:rgba(0,0,0,.3); color:#00f7ff; padding:10px 14px; border-radius:14px; font-weight:600; font-size:14px; cursor:pointer; }
+      .btn{ appearance:none; border:1px solid #00f7ff; background:rgba(0,0,0,.3); color:#00f7ff; -webkit-text-stroke-width:.3px; -webkit-text-stroke-color:#ff0000; text-shadow:0 0 4px #fff; padding:10px 14px; border-radius:14px; font-weight:600; font-size:14px; cursor:pointer; }
       .btn.primary{ background:#00f7ff; color:#fff; border:none; box-shadow:0 0 8px rgba(0,247,255,.5); }
       .btn.primary:hover{ background:#66fcff; }
     .btn:disabled{ opacity:.5; }
@@ -42,7 +42,7 @@
     .sep{ opacity:.3; }
       .popup{ position:absolute; inset:0; background:rgba(0,0,0,.7); display:flex; align-items:center; justify-content:center; }
       .popup.hidden{ display:none; }
-      .popup .box{ background:linear-gradient(180deg,#0f1530,#0a0f24); background-color:#0b1a2f; border:1px solid #00f7ff; box-shadow:0 0 8px #00f7ff, inset 0 0 10px rgba(0,247,255,.4); padding:20px; border-radius:12px; text-align:center; color:#00f7ff; }
+      .popup .box{ background:linear-gradient(180deg,#0f1530,#0a0f24); background-color:#0b1a2f; border:1px solid #00f7ff; box-shadow:0 0 8px #00f7ff, inset 0 0 10px rgba(0,247,255,.4); padding:20px; border-radius:12px; text-align:center; color:#00f7ff; -webkit-text-stroke-width:.3px; -webkit-text-stroke-color:#ff0000; text-shadow:0 0 4px #fff; }
     .countdown{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; font-size:48px; font-weight:bold; color:#fff; background:rgba(0,0,0,0.5); z-index:50; }
     .countdown.hidden{ display:none; }
   

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -41,7 +41,6 @@ body {
   -webkit-text-stroke-width: 0.3px;
 }
 
-[class*='text-blue-'],
 [class*='text-sky-'],
 [class*='text-red-'],
 [class*='text-black'],
@@ -49,15 +48,17 @@ body {
   -webkit-text-stroke-color: #ffffff;
 }
 
-[class*='text-yellow-'] {
-  /* Electric blue outline for yellow text */
-  -webkit-text-stroke-color: #00f7ff;
-}
-
+[class*='text-blue-'],
 [class*='text-primary'],
 [class*='text-accent'],
 .text-text {
-  -webkit-text-stroke-color: #facc15;
+  -webkit-text-stroke-color: #ff0000;
+  text-shadow: 0 0 4px #ffffff;
+}
+
+[class*='text-yellow-'] {
+  /* Electric blue outline for yellow text */
+  -webkit-text-stroke-color: #00f7ff;
 }
 
 [class*='text-white'] {


### PR DESCRIPTION
## Summary
- Outline electric blue text in red with a white glow across the app
- Apply the same effect to buttons and popups in the falling-ball game

## Testing
- `npm test` (fails: SyntaxError in bot/routes/tasks.js)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ef12dac5c8329ab80f64528978fef