### PR TITLE
style: give white text black edges

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -62,8 +62,9 @@ body {
 }
 
 [class*='text-white'] {
-  /* Red outline for white text */
-  -webkit-text-stroke-color: #ff0000;
+  /* Black outline for white text */
+  -webkit-text-stroke-color: #000000;
+  text-shadow: 0 0 4px #000000;
 }
 
 /* Neon theme elements */


### PR DESCRIPTION
## Summary
- outline `text-white` elements with black stroke and shadow so white text stands out

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ef5a83fa88329b1703c7c19de8d7b