### PR TITLE
feat: unify title and card text styling

### DIFF
--- a/webapp/src/components/AvatarPickerModal.jsx
+++ b/webapp/src/components/AvatarPickerModal.jsx
@@ -27,7 +27,7 @@ export default function AvatarPickerModal({ open, onClose, onSave }) {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-4 rounded space-y-4 text-center text-text">
-        <h3 className="text-lg font-bold">Pick a Profile Avatar</h3>
+        <h3 className="text-lg font-bold text-red-600 drop-shadow-[0_0_2px_black]">Pick a Profile Avatar</h3>
         <div className="flex flex-wrap justify-center gap-2 max-h-60 overflow-auto">
           {AVATARS.map((src) => (
             <div

--- a/webapp/src/components/AvatarPromptModal.jsx
+++ b/webapp/src/components/AvatarPromptModal.jsx
@@ -6,7 +6,7 @@ export default function AvatarPromptModal({ open, onPick, onKeep }) {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80 text-center">
-        <h3 className="text-lg font-bold">Choose Your Avatar</h3>
+        <h3 className="text-lg font-bold text-red-600 drop-shadow-[0_0_2px_black]">Choose Your Avatar</h3>
         <p className="text-sm text-subtext">Would you like to pick a new avatar?</p>
         <button
           onClick={onPick}

--- a/webapp/src/components/DevNotifyModal.jsx
+++ b/webapp/src/components/DevNotifyModal.jsx
@@ -16,7 +16,7 @@ export default function DevNotifyModal({
   return createPortal(
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-6 rounded text-center space-y-4 text-text w-80">
-        <h3 className="text-lg font-bold">Send Notification</h3>
+        <h3 className="text-lg font-bold text-red-600 drop-shadow-[0_0_2px_black]">Send Notification</h3>
         <textarea
           placeholder="Message"
           value={notifyText}

--- a/webapp/src/components/DevTasksModal.jsx
+++ b/webapp/src/components/DevTasksModal.jsx
@@ -62,7 +62,7 @@ export default function DevTasksModal({ open, onClose }) {
   return createPortal(
     <div className="fixed inset-0 bg-black bg-opacity-70 z-50 overflow-auto flex flex-col">
       <div className="bg-surface text-text p-4 flex-1">
-        <h3 className="text-lg font-bold mb-4 text-center">Manage Tasks</h3>
+        <h3 className="text-lg font-bold mb-4 text-center text-red-600 drop-shadow-[0_0_2px_black]">Manage Tasks</h3>
         <div className="space-y-2 mb-4">
           <select
             value={platform}

--- a/webapp/src/components/FlagPickerModal.jsx
+++ b/webapp/src/components/FlagPickerModal.jsx
@@ -53,7 +53,7 @@ export default function FlagPickerModal({ open, onClose, count = 1, onSave, sele
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-4 rounded text-center text-text w-96 max-h-[90vh] flex flex-col space-y-4">
-        <h3 className="text-lg font-bold">Select your opponents</h3>
+        <h3 className="text-lg font-bold text-red-600 drop-shadow-[0_0_2px_black]">Select your opponents</h3>
         <div className="flex-1 min-h-0 overflow-y-auto space-y-2">
           <div className="flex flex-wrap justify-center gap-2">
             {continents.map(c => (

--- a/webapp/src/components/GameEndPopup.jsx
+++ b/webapp/src/components/GameEndPopup.jsx
@@ -6,7 +6,7 @@ export default function GameEndPopup({ open, ranking, onPlayAgain, onReturn }) {
   return createPortal(
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
-        <h3 className="text-lg font-bold text-center">Game Over</h3>
+        <h3 className="text-lg font-bold text-center text-red-600 drop-shadow-[0_0_2px_black]">Game Over</h3>
         <ol className="list-decimal list-inside space-y-1 text-center">
           {ranking.map((name, i) => (
             <li key={i}>{name}</li>

--- a/webapp/src/components/InfoPopup.jsx
+++ b/webapp/src/components/InfoPopup.jsx
@@ -15,7 +15,11 @@ export default function InfoPopup({
       <div
         className={`prism-box flex-col p-6 space-y-4 text-text relative ${widthClass}`}
       >
-        {title && <h3 className="text-lg font-bold text-center">{title}</h3>}
+        {title && (
+          <h3 className="text-lg font-bold text-center text-red-600 drop-shadow-[0_0_2px_black]">
+            {title}
+          </h3>
+        )}
         {info && <p className="text-sm text-subtext text-center">{info}</p>}
         {children}
         <button

--- a/webapp/src/components/PostsModal.jsx
+++ b/webapp/src/components/PostsModal.jsx
@@ -11,7 +11,7 @@ export default function PostsModal({ open, posts = [], onClose }) {
         className="bg-surface border border-border p-4 rounded space-y-2 w-80 text-text"
         onClick={(e) => e.stopPropagation()}
       >
-        <h3 className="text-lg font-bold text-center">Ready-Made Posts</h3>
+        <h3 className="text-lg font-bold text-center text-red-600 drop-shadow-[0_0_2px_black]">Ready-Made Posts</h3>
         {posts.map((p, i) => (
           <div
             key={i}

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -42,7 +42,9 @@ export default function RewardPopup({
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
       <div className="text-center space-y-4 text-text">
-        <h3 className="text-lg font-bold">Reward Earned</h3>
+        <h3 className="text-lg font-bold text-red-600 drop-shadow-[0_0_2px_black]">
+          Reward Earned
+        </h3>
         <div className="text-accent text-3xl flex items-center justify-center space-x-2">
           {reward === 'BONUS_X3' && (
             <>

--- a/webapp/src/components/RoomPopup.jsx
+++ b/webapp/src/components/RoomPopup.jsx
@@ -19,7 +19,7 @@ export default function RoomPopup({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
-        <h3 className="text-lg font-bold text-center">Join a Room</h3>
+        <h3 className="text-lg font-bold text-center text-red-600 drop-shadow-[0_0_2px_black]">Join a Room</h3>
         <p className="text-sm text-subtext text-center">Choose your token and amount</p>
         {tables && (
           <TableSelector

--- a/webapp/src/components/TablePopup.jsx
+++ b/webapp/src/components/TablePopup.jsx
@@ -6,7 +6,7 @@ export default function TablePopup({ open, tables, onSelect }) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
       <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
-        <h3 className="text-lg font-bold text-center">Select a Table</h3>
+        <h3 className="text-lg font-bold text-center text-red-600 drop-shadow-[0_0_2px_black]">Select a Table</h3>
         <TableSelector tables={tables} selected={null} onSelect={onSelect} />
       </div>
     </div>

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -120,7 +120,7 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
 
         </button>
 
-        <h3 className="text-lg font-bold text-center">TPC Statement Details</h3>
+        <h3 className="text-lg font-bold text-center text-red-600 drop-shadow-[0_0_2px_black]">TPC Statement Details</h3>
 
         <div className="flex flex-col items-center space-y-2">
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -2,6 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  h1,
+  h2 {
+    @apply text-red-600 drop-shadow-[0_0_2px_black];
+  }
+}
+
 :root {
   --cell-width: 135px;
   /* Slightly taller default height for snake board cells */

--- a/webapp/tailwind.config.js
+++ b/webapp/tailwind.config.js
@@ -13,7 +13,7 @@ export default {
           primary: '#00f7ff',           // Button base in electric blue
           'primary-hover': '#66fcff',   // Lighter hover effect
           text: '#00f7ff',              // Electric blue text
-          subtext: '#66fcff',           // Slightly dimmed blue
+          subtext: '#00f7ff',           // Match card text to Spin & Win message
           accent: '#00f7ff',            // Accent color
           brand: {
             gold: '#facc15',            // Yellow highlight


### PR DESCRIPTION
## Summary
- Align page titles and popup headings with the Spin & Win bonus style
- Match card text color to the Spin & Win message color

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689efaa3b6ec8329a0c10c28df0bfd6d