### PR TITLE
feat: refresh on pull-down

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -83,6 +83,43 @@ export default function Layout({ children }) {
     return () => clearInterval(id);
   }, []);
 
+  useEffect(() => {
+    if (location.pathname.startsWith('/games/')) return;
+
+    let startY = 0;
+    let active = false;
+
+    const onTouchStart = (e) => {
+      if (window.scrollY === 0) {
+        startY = e.touches[0].clientY;
+        active = true;
+      }
+    };
+
+    const onTouchMove = (e) => {
+      if (!active) return;
+      const currentY = e.touches[0].clientY;
+      if (currentY - startY > 80) {
+        active = false;
+        window.location.reload();
+      }
+      e.preventDefault();
+    };
+
+    const onTouchEnd = () => {
+      active = false;
+    };
+
+    window.addEventListener('touchstart', onTouchStart, { passive: true });
+    window.addEventListener('touchmove', onTouchMove, { passive: false });
+    window.addEventListener('touchend', onTouchEnd);
+    return () => {
+      window.removeEventListener('touchstart', onTouchStart);
+      window.removeEventListener('touchmove', onTouchMove);
+      window.removeEventListener('touchend', onTouchEnd);
+    };
+  }, [location.pathname]);
+
   const showNavbar = !(
     location.pathname.startsWith('/games/') &&
     !location.pathname.includes('/lobby')


### PR DESCRIPTION
## Summary
- refresh page on downward pull for non-game routes while blocking overscroll

## Testing
- `npm test` *(fails: test timed out for snake API endpoints and socket events)*
- `npm --prefix webapp test` *(fails: Missing script "test")*
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_689efcb3a7048329889b4ff1e92614c9