### PR TITLE
Apply price-style gold text across site

### DIFF
--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -25,7 +25,7 @@
     .row{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
     .chip{ padding:6px 10px; border-radius:12px; border:1px solid rgba(255,255,255,.15); color:#fff; background:transparent; cursor:pointer; }
     .chip.active{ border-color:#7dd3fc; }
-      .btn{ appearance:none; border:1px solid #00f7ff; background:rgba(0,0,0,.3); color:#00f7ff; -webkit-text-stroke-width:.3px; -webkit-text-stroke-color:#ff0000; text-shadow:0 0 4px #fff; padding:10px 14px; border-radius:14px; font-weight:600; font-size:14px; cursor:pointer; }
+      .btn{ appearance:none; border:1px solid #facc15; background:rgba(0,0,0,.3); color:#facc15; -webkit-text-stroke-width:.3px; -webkit-text-stroke-color:#00f7ff; padding:10px 14px; border-radius:14px; font-weight:600; font-size:14px; cursor:pointer; }
       .btn.primary{ background:#00f7ff; color:#fff; border:none; box-shadow:0 0 8px rgba(0,247,255,.5); }
       .btn.primary:hover{ background:#66fcff; }
     .btn:disabled{ opacity:.5; }
@@ -42,7 +42,7 @@
     .sep{ opacity:.3; }
       .popup{ position:absolute; inset:0; background:rgba(0,0,0,.7); display:flex; align-items:center; justify-content:center; }
       .popup.hidden{ display:none; }
-      .popup .box{ background:linear-gradient(180deg,#0f1530,#0a0f24); background-color:#0b1a2f; border:1px solid #00f7ff; box-shadow:0 0 8px #00f7ff, inset 0 0 10px rgba(0,247,255,.4); padding:20px; border-radius:12px; text-align:center; color:#00f7ff; -webkit-text-stroke-width:.3px; -webkit-text-stroke-color:#ff0000; text-shadow:0 0 4px #fff; }
+      .popup .box{ background:linear-gradient(180deg,#0f1530,#0a0f24); background-color:#0b1a2f; border:1px solid #facc15; box-shadow:0 0 8px #00f7ff, inset 0 0 10px rgba(0,247,255,.4); padding:20px; border-radius:12px; text-align:center; color:#facc15; -webkit-text-stroke-width:.3px; -webkit-text-stroke-color:#00f7ff; }
     .countdown{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; font-size:48px; font-weight:bold; color:#fff; background:rgba(0,0,0,0.5); z-index:50; }
     .countdown.hidden{ display:none; }
   

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -34,10 +34,10 @@ body {
 [class*='text-yellow-'],
 [class*='text-black'],
 [class*='text-green-'],
-.text-text,
 [class*='text-primary'],
 [class*='text-accent'],
-[class*='text-white'] {
+[class*='text-white'],
+.text-text {
   -webkit-text-stroke-width: 0.3px;
 }
 
@@ -50,10 +50,14 @@ body {
 
 [class*='text-blue-'],
 [class*='text-primary'],
-[class*='text-accent'],
-.text-text {
+[class*='text-accent'] {
   -webkit-text-stroke-color: #ff0000;
   text-shadow: 0 0 4px #ffffff;
+}
+
+.text-text {
+  /* Gold price-style text with electric blue outline */
+  -webkit-text-stroke-color: #00f7ff;
 }
 
 [class*='text-yellow-'] {
@@ -92,15 +96,15 @@ body {
 
 button,
 input {
-  border-color: #00f7ff;
-  color: #00f7ff;
-  box-shadow: 0 0 6px rgba(0, 247, 255, 0.6);
+  border-color: #facc15;
+  color: #facc15;
+  box-shadow: 0 0 6px rgba(250, 204, 21, 0.6);
 }
 
 button:focus,
 input:focus {
   outline: none;
-  box-shadow: 0 0 10px #00f7ff;
+  box-shadow: 0 0 10px #facc15;
 }
 
 /* Utility class for white text with a subtle black shadow */

--- a/webapp/tailwind.config.js
+++ b/webapp/tailwind.config.js
@@ -12,8 +12,8 @@ export default {
           border: '#00f7ff',            // Glowing cyan borders
           primary: '#00f7ff',           // Button base in electric blue
           'primary-hover': '#66fcff',   // Lighter hover effect
-          text: '#00f7ff',              // Electric blue text
-          subtext: '#66fcff',           // Slightly dimmed blue
+          text: '#facc15',              // Gold price-style text
+          subtext: '#fde047',           // Slightly dimmed gold
           accent: '#00f7ff',            // Accent color
           brand: {
             gold: '#facc15',            // Yellow highlight


### PR DESCRIPTION
## Summary
- switch default text color to gold, matching spin prizes
- update button and input styling to use gold with electric-blue outline
- adjust falling-ball mini-game text styling to gold

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_689f014b3acc8329bae566fea76f6331