### PR TITLE
Switch yellow text outlines to black and style titles

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -56,17 +56,29 @@ body {
 }
 
 .text-text {
-  /* Gold price-style text with electric blue outline */
-  -webkit-text-stroke-color: #00f7ff;
+  /* Gold price-style text with black outline */
+  -webkit-text-stroke-color: #000000;
 }
 
 [class*='text-yellow-'] {
-  /* Electric blue outline for yellow text */
-  -webkit-text-stroke-color: #00f7ff;
+  /* Black outline for yellow text */
+  -webkit-text-stroke-color: #000000;
 }
 
 [class*='text-white'] {
   /* Black outline for white text */
+  -webkit-text-stroke-color: #000000;
+  text-shadow: 0 0 4px #000000;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: #ffffff;
+  -webkit-text-stroke-width: 0.3px;
   -webkit-text-stroke-color: #000000;
   text-shadow: 0 0 4px #000000;
 }


### PR DESCRIPTION
## Summary
- Use black outlines for gold and yellow text instead of neon blue
- Style all page titles as white text with black outlines for contrast

## Testing
- `npm test` *(fails: snake API endpoints and socket events)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f085e5f6083299e2d67ea0efd2eb0