### PR TITLE
style: add white outline to task buttons

### DIFF
--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -260,7 +260,7 @@ export default function TasksCard() {
             ) : (
               <button
                 onClick={handleDailyCheck}
-                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-black text-sm rounded"
+                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
               >
                 Claim
               </button>
@@ -303,7 +303,7 @@ export default function TasksCard() {
               ) : (
                 <button
                   onClick={() => handleClaim(t)}
-                  className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-black text-sm rounded"
+                  className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
                 >
                   Claim
                 </button>
@@ -321,7 +321,7 @@ export default function TasksCard() {
             ) : (
               <button
                 onClick={() => setShowAd(true)}
-                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-black text-sm rounded"
+                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
               >
                 Watch
               </button>
@@ -338,7 +338,7 @@ export default function TasksCard() {
             ) : (
               <button
                 onClick={() => setShowQuestAd(true)}
-                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-black text-sm rounded"
+                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
               >
                 Watch
               </button>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -119,6 +119,13 @@ input:focus {
   box-shadow: 0 0 10px #facc15;
 }
 
+/* Black text with a white outline */
+.text-outline-white {
+  color: #000000 !important;
+  -webkit-text-stroke-width: 0.5px;
+  -webkit-text-stroke-color: #ffffff;
+}
+
 /* Utility class for white text with a subtle black shadow */
 .text-white-shadow {
   color: #ffffff;

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -275,7 +275,7 @@ export default function Tasks() {
                   ) : (
                     <button
                       onClick={handleDailyCheck}
-                      className="px-2 py-1 bg-primary hover:bg-primary-hover text-background text-sm rounded"
+                      className="px-2 py-1 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
                     >
                       Claim
                     </button>
@@ -313,7 +313,7 @@ export default function Tasks() {
                 ) : (
                   <button
                     onClick={() => handleClaim(t)}
-                    className="px-2 py-1 bg-primary hover:bg-primary-hover text-background text-sm rounded"
+                    className="px-2 py-1 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
                   >
                     Claim
                   </button>
@@ -331,7 +331,7 @@ export default function Tasks() {
               ) : (
                 <button
                   onClick={() => setShowAd(true)}
-                  className="px-2 py-1 bg-primary hover:bg-primary-hover text-background text-sm rounded"
+                  className="px-2 py-1 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
                 >
                   Watch
                 </button>
@@ -348,7 +348,7 @@ export default function Tasks() {
               ) : (
                 <button
                   onClick={() => setShowQuestAd(true)}
-                  className="px-2 py-1 bg-primary hover:bg-primary-hover text-background text-sm rounded"
+                  className="px-2 py-1 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
                 >
                   Watch
                 </button>


### PR DESCRIPTION
## Summary
- add reusable `text-outline-white` class for black text with white edge
- apply outline style to Claim and Watch buttons on Tasks screens

## Testing
- `npm test` (fails: test timed out)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f1a388754832999a3f2abf12e0c83