### PR TITLE
style: update profile and wallet text colors

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -43,9 +43,14 @@ body {
 
 [class*='text-sky-'],
 [class*='text-red-'],
-[class*='text-black'],
 [class*='text-green-'] {
   -webkit-text-stroke-color: #ffffff;
+}
+
+[class*='text-black'] {
+  /* Black text with black outline */
+  -webkit-text-stroke-color: #000000;
+  text-shadow: 0 0 4px #000000;
 }
 
 [class*='text-blue-'],

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -300,7 +300,7 @@ export default function MyAccount() {
           <p className="font-semibold">
             {profile.firstName} {profile.lastName}
           </p>
-          <div className="text-sm text-subtext flex items-center space-x-1">
+          <div className="text-sm flex items-center space-x-1 text-white">
             <span>Account: {profile.accountId}</span>
             <FiCopy
               className="w-4 h-4 cursor-pointer"
@@ -309,7 +309,7 @@ export default function MyAccount() {
           </div>
           <button
             onClick={() => setShowAvatarPicker(true)}
-            className="mt-2 px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"
+            className="mt-2 px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-black"
           >
             Change Avatar
           </button>
@@ -323,7 +323,7 @@ export default function MyAccount() {
               setTimeout(() => setShowSaved(false), 1500);
               window.dispatchEvent(new Event('profilePhotoUpdated'));
             }}
-            className="mt-2 ml-2 px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"
+            className="mt-2 ml-2 px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-black"
           >
             Use Telegram Photo
           </button>
@@ -341,7 +341,7 @@ export default function MyAccount() {
             </a>
           </div>
           {profile.social?.twitter && (
-            <p className="text-sm mt-2">
+            <p className="text-sm mt-2 text-white">
               Linked X: @{profile.social.twitter}{' '}
               <button
                 onClick={handleClearTwitter}
@@ -361,13 +361,13 @@ export default function MyAccount() {
             />
             <button
               onClick={handleSaveTwitter}
-              className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow text-sm"
+              className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-black text-sm"
             >
               Save
             </button>
             <button
               onClick={handleConnectTwitter}
-              className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow text-sm"
+              className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-black text-sm"
             >
               Connect
             </button>
@@ -390,7 +390,7 @@ export default function MyAccount() {
             <button
               onClick={handleDevTopup}
               disabled={devTopupSending}
-              className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background"
+              className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
             >
               {devTopupSending ? 'Processing...' : 'Top Up'}
             </button>
@@ -399,7 +399,7 @@ export default function MyAccount() {
           <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
             <button
               onClick={() => setShowNotifyModal(true)}
-              className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background w-full"
+              className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black w-full"
             >
               Notify
             </button>
@@ -408,7 +408,7 @@ export default function MyAccount() {
           <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
             <button
               onClick={() => setShowTasksModal(true)}
-              className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background w-full"
+              className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black w-full"
             >
               Manage Tasks
             </button>

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -283,8 +283,8 @@ export default function Wallet({ hideClaim = false }) {
     <div className="relative p-4 space-y-4 text-text wide-card">
       <h2 className="text-xl font-bold text-center">TPC Account Wallet</h2>
       <div className="prism-box p-6 space-y-2 min-h-40 flex flex-col items-start wide-card mx-auto">
-        <p className="text-xs break-all w-full text-left">Account: {accountId || '...'}</p>
-        <div className="flex items-center space-x-1">
+        <p className="text-xs break-all w-full text-left text-white">Account: {accountId || '...'}</p>
+        <div className="flex items-center space-x-1 text-white">
           <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-8 h-8" />
           <span className="text-lg font-medium">TPC Balance</span>
         </div>
@@ -305,7 +305,7 @@ export default function Wallet({ hideClaim = false }) {
       {/* TPC account section */}
       <div className="space-y-4">
         <div className="prism-box p-6 space-y-3 text-center flex flex-col items-center min-h-40 wide-card mx-auto">
-          <label className="block font-semibold">Send TPC</label>
+          <label className="block font-semibold text-white">Send TPC</label>
           <input
             type="text"
             placeholder="Receiver Account Number"
@@ -330,7 +330,7 @@ export default function Wallet({ hideClaim = false }) {
           />
           <button
             onClick={handleSendClick}
-            className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover text-background rounded"
+            className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover text-black rounded"
           >
             Send
           </button>
@@ -349,10 +349,10 @@ export default function Wallet({ hideClaim = false }) {
         </div>
 
       <div className="prism-box p-6 space-y-3 text-center mt-4 flex flex-col items-center wide-card mx-auto">
-        <label className="block font-semibold">Receive TPC</label>
+        <label className="block font-semibold text-white">Receive TPC</label>
           <button
             onClick={() => navigator.clipboard.writeText(String(accountId))}
-            className="mt-2 px-3 py-1 bg-primary hover:bg-primary-hover text-background rounded"
+            className="mt-2 px-3 py-1 bg-primary hover:bg-primary-hover text-black rounded"
           >
             Copy Account Number
           </button>
@@ -378,7 +378,7 @@ export default function Wallet({ hideClaim = false }) {
           />
           <button
             onClick={handleTopup}
-            className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover text-background rounded"
+            className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover text-black rounded"
             disabled={topupSending}
           >
             {topupSending ? 'Processing...' : 'Top Up'}


### PR DESCRIPTION
## Summary
- highlight account and X linkage with white outlined text on profile page
- style wallet headings and send/receive sections with white text and black-outlined buttons
- ensure black text renders with a dark outline across the app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f1ba86438832980b5e947cfc3e4ad