### PR TITLE
style: highlight games and leaderboard text

### DIFF
--- a/webapp/src/components/GameCard.jsx
+++ b/webapp/src/components/GameCard.jsx
@@ -15,7 +15,12 @@ export default function GameCard({ title, description, link, icon }) {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 shadow-lg space-y-2 text-center overflow-hidden wide-card">
       {iconNode}
-      <h3 className="text-lg font-bold text-text">{title}</h3>
+      <h3
+        className="text-lg font-bold text-yellow-400"
+        style={{ WebkitTextStroke: '1px black' }}
+      >
+        {title}
+      </h3>
       {description && <p className="text-subtext text-sm">{description}</p>}
       {link && (
         <Link

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -254,7 +254,12 @@ export default function LeaderboardCard() {
                     }
                   }}
                 >
-                  <td className="p-2">{idx + 1}</td>
+                  <td
+                    className={`p-2 ${idx < 3 ? 'text-white' : ''}`}
+                    style={idx < 3 ? { WebkitTextStroke: '1px black' } : {}}
+                  >
+                    {idx + 1}
+                  </td>
                   <td className="p-2 w-12 relative">
                     <img
                       src={getAvatarUrl(
@@ -267,7 +272,12 @@ export default function LeaderboardCard() {
                     />
                     {u.accountId !== accountId && null}
                   </td>
-                  <td className="p-2 flex flex-col items-start">
+                  <td
+                    className={`p-2 flex flex-col items-start ${
+                      idx < 3 ? 'text-white' : ''
+                    }`}
+                    style={idx < 3 ? { WebkitTextStroke: '1px black' } : {}}
+                  >
                     <div className="flex items-center">
                       {mode === 'group' && u.accountId !== accountId && (
                         <input
@@ -310,7 +320,12 @@ export default function LeaderboardCard() {
                       </div>
                     )}
                   </td>
-                  <td className="p-2 text-right flex items-center justify-end space-x-1">
+                  <td
+                    className={`p-2 text-right flex items-center justify-end space-x-1 ${
+                      idx < 3 ? 'text-white' : ''
+                    }`}
+                    style={idx < 3 ? { WebkitTextStroke: '1px black' } : {}}
+                  >
                     <span>{u.balance}</span>
                   </td>
                 </tr>
@@ -457,6 +472,13 @@ export default function LeaderboardCard() {
           setSelected([]);
         }}
       />
+      <button
+        onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+        className="fixed bottom-4 right-4 text-3xl"
+        aria-label="Back to top"
+      >
+        ☝️
+      </button>
     </>
   );
 }

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -15,63 +15,108 @@ export default function Games() {
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/goal_rush_card_1200x675.webp" alt="" className="h-20 w-20" />
-                  <h3 className="text-sm font-semibold text-center">Goal Rush</h3>
+                  <h3
+                    className="text-sm font-semibold text-center text-yellow-400"
+                    style={{ WebkitTextStroke: '1px black' }}
+                  >
+                    Goal Rush
+                  </h3>
                 </Link>
                 <Link
                   to="/games/snake/lobby"
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/snakes_and_ladders.webp" alt="" className="h-20 w-20" />
-                  <h3 className="text-sm font-semibold text-center">Snake &amp; Ladder</h3>
+                  <h3
+                    className="text-sm font-semibold text-center text-yellow-400"
+                    style={{ WebkitTextStroke: '1px black' }}
+                  >
+                    Snake &amp; Ladder
+                  </h3>
                 </Link>
                 <Link
                   to="/games/fallingball/lobby"
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Falling Ball .png" alt="" className="h-20 w-20" />
-                  <h3 className="text-sm font-semibold text-center">Falling Ball</h3>
+                  <h3
+                    className="text-sm font-semibold text-center text-yellow-400"
+                    style={{ WebkitTextStroke: '1px black' }}
+                  >
+                    Falling Ball
+                  </h3>
                 </Link>
                 <Link
                   to="/games/fruitsliceroyale/lobby"
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Fruit Slice Royale .png" alt="" className="h-20 w-20" />
-                  <h3 className="text-sm font-semibold text-center">Fruit Slice Royale</h3>
+                  <h3
+                    className="text-sm font-semibold text-center text-yellow-400"
+                    style={{ WebkitTextStroke: '1px black' }}
+                  >
+                    Fruit Slice Royale
+                  </h3>
                 </Link>
                 <Link
                   to="/games/brickbreaker/lobby"
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Brick Breaker Royale .png" alt="" className="h-20 w-20" />
-                  <h3 className="text-sm font-semibold text-center">Brick Breaker Royale</h3>
+                  <h3
+                    className="text-sm font-semibold text-center text-yellow-400"
+                    style={{ WebkitTextStroke: '1px black' }}
+                  >
+                    Brick Breaker Royale
+                  </h3>
                 </Link>
                 <Link
                   to="/games/tetrisroyale/lobby"
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/file_00000000240061f4abd28311d76970a5.png" alt="" className="h-20 w-20" />
-                  <h3 className="text-sm font-semibold text-center">Tetris Royale</h3>
+                  <h3
+                    className="text-sm font-semibold text-center text-yellow-400"
+                    style={{ WebkitTextStroke: '1px black' }}
+                  >
+                    Tetris Royale
+                  </h3>
                 </Link>
                 <Link
                   to="/games/bubblesmashroyale/lobby"
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Bubble Smash Royale .png" alt="" className="h-20 w-20" />
-                  <h3 className="text-sm font-semibold text-center">Bubble Smash Royale</h3>
+                  <h3
+                    className="text-sm font-semibold text-center text-yellow-400"
+                    style={{ WebkitTextStroke: '1px black' }}
+                  >
+                    Bubble Smash Royale
+                  </h3>
                 </Link>
                 <Link
                   to="/games/crazydice/lobby"
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Crazy_Dice_Duel_Promo.webp" alt="" className="h-20 w-20" />
-                  <h3 className="text-sm font-semibold text-center">Crazy Dice Duel</h3>
+                  <h3
+                    className="text-sm font-semibold text-center text-yellow-400"
+                    style={{ WebkitTextStroke: '1px black' }}
+                  >
+                    Crazy Dice Duel
+                  </h3>
                 </Link>
                 <Link
                   to="/games/bubblepoproyale/lobby"
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Bubble Pop Royale .png" alt="" className="h-20 w-20" />
-                  <h3 className="text-sm font-semibold text-center">Bubble Pop Royale</h3>
+                  <h3
+                    className="text-sm font-semibold text-center text-yellow-400"
+                    style={{ WebkitTextStroke: '1px black' }}
+                  >
+                    Bubble Pop Royale
+                  </h3>
                 </Link>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- make game card titles yellow with black outline
- highlight top three leaderboard entries in white with black outline
- add bottom-right ☝️ button to scroll back to the top

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f1e8f7b8c8329a6791c6a1f786753