### PR TITLE
Style mining page texts and update lucky card icon

### DIFF
--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -131,7 +131,7 @@ export default function LuckyNumber() {
           >
             {(i !== 0 && selected !== i) ? (
               <>
-                <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-8 h-8" />
+                <img src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp" alt="TonPlaygram" className="w-8 h-8" />
                 <span className="text-text text-xl font-bold">{i + 1}</span>
               </>
             ) : (
@@ -156,7 +156,7 @@ export default function LuckyNumber() {
                   </>
                 ) : (
                   <>
-                    <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-8 h-8" />
+                    <img src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp" alt="TonPlaygram" className="w-8 h-8" />
                     <span className="font-bold text-text">{val}</span>
                     {i === 0 && <span className="text-red-500 text-xs">FREE</span>}
                   </>

--- a/webapp/src/components/MiningCard.tsx
+++ b/webapp/src/components/MiningCard.tsx
@@ -133,7 +133,7 @@ export default function MiningCard() {
       />
       <div className="flex justify-center items-center space-x-1">
         <GiMining className="w-5 h-5 text-accent" />
-        <span className="text-lg font-bold text-text">Mining</span>
+        <span className="text-lg font-bold text-white text-outline-black">Mining</span>
       </div>
 
       <button

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -136,6 +136,12 @@ input:focus {
   color: #ffffff;
 }
 
+/* Utility class for text with a black outline */
+.text-outline-black {
+  -webkit-text-stroke-width: 0.5px;
+  -webkit-text-stroke-color: #000000;
+}
+
 .hexagon {
   /* perfect hexagon with equal inner distances */
   clip-path: polygon(50% 0%, 93% 25%, 93% 75%, 50% 100%, 7% 75%, 7% 25%);

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -167,8 +167,8 @@ export default function Mining() {
 
       <section className="space-y-1">
         <h3 className="text-lg font-semibold">Friends</h3>
-        <p className="text-white">Invited friends: {referral.referralCount}</p>
-        <p className="text-white">Mining boost: +{referral.bonusMiningRate * 100}%</p>
+        <p className="text-brand-gold text-outline-black">Invited friends: {referral.referralCount}</p>
+        <p className="text-brand-gold text-outline-black">Mining boost: +{referral.bonusMiningRate * 100}%</p>
         {referral.storeMiningRate && referral.storeMiningExpiresAt && (
           <p className="text-sm text-subtext">
             Boost ends in {Math.max(0, Math.floor((new Date(referral.storeMiningExpiresAt).getTime() - Date.now()) / 86400000))}d


### PR DESCRIPTION
## Summary
- Outline mining title text in black and switch friend count and boost to yellow with black edges.
- Show site logo on Lucky Card instead of token icon.
- Add reusable `text-outline-black` utility for outlined text.

## Testing
- `npm test` *(fails: missing Telegram config, process hung)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f1fca6da0832998409154120c1a7e