### PR TITLE
style: add stroke to leaderboard headers

### DIFF
--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -227,10 +227,25 @@ export default function LeaderboardCard() {
           <table className="w-full text-sm">
             <thead className="sticky top-0 bg-surface">
               <tr className="border-b border-border text-left">
-                <th className="p-2">#</th>
+                <th
+                  className="p-2 text-white"
+                  style={{ WebkitTextStroke: '1px black' }}
+                >
+                  #
+                </th>
                 <th className="p-2 w-14"></th>
-                <th className="p-2">User</th>
-                <th className="p-2 text-right">TPC</th>
+                <th
+                  className="p-2 text-white"
+                  style={{ WebkitTextStroke: '1px black' }}
+                >
+                  User
+                </th>
+                <th
+                  className="p-2 text-right text-white"
+                  style={{ WebkitTextStroke: '1px black' }}
+                >
+                  TPC
+                </th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
## Summary
- make leaderboard headers white text with black stroke for clarity

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f2336317c832989f839c0be4724b7