### PR TITLE
style: unify button appearance

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -96,6 +96,14 @@ export default function Layout({ children }) {
     isLobby ||
     location.pathname.startsWith('/games/snake');
 
+  useEffect(() => {
+    if (location.pathname === '/mining') {
+      document.body.classList.add('mining-page');
+    } else {
+      document.body.classList.remove('mining-page');
+    }
+  }, [location.pathname]);
+
   return (
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
       {showHeader && (

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -106,7 +106,14 @@ h6 {
   box-shadow: inset 0 0 10px rgba(0, 247, 255, 0.4);
 }
 
-button,
+button {
+  @apply px-2 py-1 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded;
+}
+
+body.mining-page button {
+  @apply text-white-shadow;
+}
+
 input {
   border-color: #facc15;
   color: #facc15;


### PR DESCRIPTION
## Summary
- add global button styling matching tasks claim button
- preserve mining page button appearance

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_689f24893bf48329adc96350813715ee