### PR TITLE
Adjust button widths on home page

### DIFF
--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -79,7 +79,7 @@ export default function HomeGamesCard() {
         </div>
       <Link
         to="/games"
-        className="mx-auto block px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow"
+        className="mx-auto block w-48 px-3 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow"
       >
         Open Games
       </Link>

--- a/webapp/src/components/NftGiftCard.jsx
+++ b/webapp/src/components/NftGiftCard.jsx
@@ -84,7 +84,7 @@ export default function NftGiftCard({ accountId: propAccountId }) {
       </div>
       <button
         onClick={() => setOpen(true)}
-        className="mt-auto px-3 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow w-full max-w-xs"
+        className="mt-auto w-48 mx-auto px-3 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow"
       >
         Buy / Send Gift
       </button>


### PR DESCRIPTION
## Summary
- Reduce "Buy / Send Gift" button width and center it
- Match "Open Games" button width to gift button for consistent sizing

## Testing
- `npm test` *(fails: test timed out)\n- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f26423e388329adecd4a9b87f249f