### PR TITLE
style: outline white button text

### DIFF
--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -260,7 +260,7 @@ export default function TasksCard() {
             ) : (
               <button
                 onClick={handleDailyCheck}
-                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
+                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-white-shadow text-sm rounded"
               >
                 Claim
               </button>
@@ -303,7 +303,7 @@ export default function TasksCard() {
               ) : (
                 <button
                   onClick={() => handleClaim(t)}
-                  className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
+                  className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-white-shadow text-sm rounded"
                 >
                   Claim
                 </button>
@@ -321,7 +321,7 @@ export default function TasksCard() {
             ) : (
               <button
                 onClick={() => setShowAd(true)}
-                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
+                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-white-shadow text-sm rounded"
               >
                 Watch
               </button>
@@ -338,7 +338,7 @@ export default function TasksCard() {
             ) : (
               <button
                 onClick={() => setShowQuestAd(true)}
-                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
+                className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-white-shadow text-sm rounded"
               >
                 Watch
               </button>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -107,7 +107,7 @@ h6 {
 }
 
 button {
-  @apply px-2 py-1 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded;
+  @apply px-2 py-1 bg-primary hover:bg-primary-hover text-white text-outline-black text-sm rounded;
 }
 
 body.mining-page button {
@@ -126,16 +126,16 @@ input:focus {
   box-shadow: 0 0 10px #facc15;
 }
 
-/* Black text with a white outline */
-.text-outline-white {
-  color: #000000 !important;
-  -webkit-text-stroke-width: 0.5px;
-  -webkit-text-stroke-color: #ffffff;
-}
-
-/* Utility class for white text with a subtle black shadow */
+/* Utility class for white text with a black outline */
 .text-white-shadow {
   color: #ffffff;
+  -webkit-text-stroke-width: 0.5px;
+  -webkit-text-stroke-color: #000000;
+  text-shadow:
+    -1px -1px 0 #000,
+    1px -1px 0 #000,
+    -1px 1px 0 #000,
+    1px 1px 0 #000;
 }
 
 /* Utility class for text with a black outline */

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -275,7 +275,7 @@ export default function Tasks() {
                   ) : (
                     <button
                       onClick={handleDailyCheck}
-                      className="px-2 py-1 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
+                      className="px-2 py-1 bg-primary hover:bg-primary-hover text-white-shadow text-sm rounded"
                     >
                       Claim
                     </button>
@@ -313,7 +313,7 @@ export default function Tasks() {
                 ) : (
                   <button
                     onClick={() => handleClaim(t)}
-                    className="px-2 py-1 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
+                    className="px-2 py-1 bg-primary hover:bg-primary-hover text-white-shadow text-sm rounded"
                   >
                     Claim
                   </button>
@@ -331,7 +331,7 @@ export default function Tasks() {
               ) : (
                 <button
                   onClick={() => setShowAd(true)}
-                  className="px-2 py-1 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
+                  className="px-2 py-1 bg-primary hover:bg-primary-hover text-white-shadow text-sm rounded"
                 >
                   Watch
                 </button>
@@ -348,7 +348,7 @@ export default function Tasks() {
               ) : (
                 <button
                   onClick={() => setShowQuestAd(true)}
-                  className="px-2 py-1 bg-primary hover:bg-primary-hover text-outline-white text-sm rounded"
+                  className="px-2 py-1 bg-primary hover:bg-primary-hover text-white-shadow text-sm rounded"
                 >
                   Watch
                 </button>


### PR DESCRIPTION
## Summary
- add black outline to white button text globally via utility class
- update task buttons to use outlined white text

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f2b41230c83299e20fb21936ad2ec