### PR TITLE
Adjust home page UI elements

### DIFF
--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -79,7 +79,7 @@ export default function HomeGamesCard() {
         </div>
       <Link
         to="/games"
-        className="mx-auto block w-48 px-3 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow"
+        className="mx-auto block w-48 px-3 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow text-center"
       >
         Open Games
       </Link>

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -247,7 +247,10 @@ export default function TasksCard() {
         }}
       />
 
-      <h3 className="text-lg font-bold text-text flex items-center justify-center space-x-1"><AiOutlineCheckSquare className="text-accent" /><span>Tasks</span></h3>
+      <h3 className="text-lg font-bold flex items-center justify-center space-x-1">
+        <AiOutlineCheckSquare className="text-accent" />
+        <span className="text-white-shadow">Tasks</span>
+      </h3>
 
       <ul className="space-y-2">
         <li className="lobby-tile w-full">

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -180,7 +180,7 @@ export default function Home() {
                   <span className="text-sm">{formatValue(tpcBalance ?? '...', 2)}</span>
                 </div>
                 <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">
-                  <div className="w-8 h-8 rounded-full bg-red-500 border-2 border-white flex items-center justify-center">
+                  <div className="w-8 h-8 rounded-full bg-green-500 border-2 border-white flex items-center justify-center">
                     <FaArrowDown className="text-white w-4 h-4" style={{ stroke: 'black', strokeWidth: '2px' }} />
                   </div>
                   <span className="text-xs text-green-500" style={{ WebkitTextStroke: '1px white' }}>Receive</span>


### PR DESCRIPTION
## Summary
- Color the Wallet receive icon green
- Center the "Open Games" button text
- Outline Tasks card title in black with white text

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f338322b4832993360d15acdda2ba