### PR TITLE
Adjust wallet card layout and icon sizes on home page

### DIFF
--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -170,20 +170,20 @@ export default function Home() {
 
               <div className="flex items-start justify-between">
                 <Link to="/wallet?mode=send" className="flex items-center space-x-1 -ml-1 pt-1">
-                  <div className="w-8 h-8 rounded-full bg-red-500 border-2 border-white flex items-center justify-center">
-                    <FaArrowUp className="text-white w-4 h-4" style={{ stroke: 'black', strokeWidth: '2px' }} />
+                  <span className="text-sm text-red-500" style={{ WebkitTextStroke: '1px white' }}>Send</span>
+                  <div className="w-9 h-9 rounded-full bg-red-500 border-2 border-white flex items-center justify-center">
+                    <FaArrowUp className="text-white w-5 h-5" style={{ stroke: 'black', strokeWidth: '2px' }} />
                   </div>
-                  <span className="text-xs text-red-500" style={{ WebkitTextStroke: '1px white' }}>Send</span>
                 </Link>
                 <div className="flex flex-col items-center space-y-1">
-                  <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-10 h-10" />
+                  <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-11 h-11" />
                   <span className="text-sm">{formatValue(tpcBalance ?? '...', 2)}</span>
                 </div>
                 <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">
-                  <div className="w-8 h-8 rounded-full bg-green-500 border-2 border-white flex items-center justify-center">
-                    <FaArrowDown className="text-white w-4 h-4" style={{ stroke: 'black', strokeWidth: '2px' }} />
+                  <div className="w-9 h-9 rounded-full bg-green-500 border-2 border-white flex items-center justify-center">
+                    <FaArrowDown className="text-white w-5 h-5" style={{ stroke: 'black', strokeWidth: '2px' }} />
                   </div>
-                  <span className="text-xs text-green-500" style={{ WebkitTextStroke: '1px white' }}>Receive</span>
+                  <span className="text-sm text-green-500" style={{ WebkitTextStroke: '1px white' }}>Receive</span>
                 </Link>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- move Send label to the left of its icon
- slightly enlarge send/receive buttons and TPC coin icon

## Testing
- `npm test` *(fails: snake API endpoints and socket events)*

------
https://chatgpt.com/codex/tasks/task_e_689f43344f708329be09e19a8ab5eeff