### PR TITLE
Reduce header logo spacing

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -107,11 +107,11 @@ export default function Layout({ children }) {
   return (
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
       {showHeader && (
-        <header className="w-full bg-surface border-b-2 border-accent flex justify-center py-1">
+        <header className="w-full bg-surface border-b-2 border-accent flex justify-center py-0.5">
           <img
             src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp"
             alt="TonPlaygram logo"
-            className="h-56"
+            className="h-28"
           />
         </header>
       )}


### PR DESCRIPTION
## Summary
- cut top logo padding and height by 50% to remove excess gap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f437f068c8329a18fa680302bf49d