### PR TITLE
feat: add game info to TPC statements

### DIFF
--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -11,6 +11,25 @@ import { getAvatarUrl } from '../utils/avatarUtils.js';
 import { NFT_GIFTS } from '../utils/nftGifts.js';
 import GiftIcon from './GiftIcon.jsx';
 
+const GAME_NAME_MAP = {
+  snake: 'Snake & Ladder',
+  crazydice: 'Crazy Dice Duel',
+  tetris: 'Tetris Royale',
+  goalrush: 'Goal Rush',
+  bubblepop: 'Bubble Pop Royale',
+  bubblesmash: 'Bubble Smash Royale',
+  fruitslice: 'Fruit Slice Royale',
+  brickbreaker: 'Brick Breaker Royale',
+  fallingball: 'Falling Ball'
+};
+
+function getGameName(slug = '') {
+  const entry = Object.entries(GAME_NAME_MAP).find(([key]) =>
+    slug.startsWith(key)
+  );
+  return entry ? entry[1] : slug;
+}
+
 export default function TransactionDetailsPopup({ tx, onClose }) {
 
   const [counterparty, setCounterparty] = useState(null);
@@ -74,6 +93,7 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
     counterparty?.nickname || `${counterparty?.firstName || ''} ${counterparty?.lastName || ''}`.trim();
 
   const displayName = nameOverride || nameFromProfile || '';
+  const gameName = tx.game ? getGameName(tx.game) : '';
 
   const gift = (isGiftSend || isGiftReceive) && tx.detail
 
@@ -235,16 +255,21 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
 
           )}
 
+          {tx.game && (
+            <div className="text-sm text-subtext">
+              {gameName}
+              {typeof tx.players === 'number' && (
+                <> vs {tx.players} {tx.players === 1 ? 'player' : 'players'}</>
+              )}
+            </div>
+          )}
+
           {!gift && tx.detail && (
-
             <div className="text-sm text-subtext">{tx.detail}</div>
-
           )}
 
           <div className="text-xs text-subtext">
-
-            {new Date(tx.date).toLocaleString()}
-
+            {new Date(tx.date).toLocaleString(undefined, { hour12: false })}
           </div>
 
         </div>

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -477,7 +477,9 @@ export default function Wallet({ hideClaim = false }) {
                   {sign}
                   {amt} {(tx.token || 'TPC').toUpperCase()}
                 </span>
-                <span className="text-xs">{new Date(tx.date).toLocaleString()}</span>
+                <span className="text-xs">
+                  {new Date(tx.date).toLocaleString(undefined, { hour12: false })}
+                </span>
                 <span className={`text-xs ${tx.status?.toLowerCase() === 'delivered' ? 'text-green-500' : ''}`}>{tx.status}</span>
               </div>
             );


### PR DESCRIPTION
## Summary
- show 24-hour timestamps without AM/PM in TPC statements
- include game name and player count in transaction details

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f45daeb408329b609caac2ebfd0d2