### PR TITLE
Style profile username and TPC buttons

### DIFF
--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -297,7 +297,7 @@ export default function MyAccount() {
           <img src={getAvatarUrl(photoToShow)} alt="avatar" className="w-14 h-14 rounded-full object-cover" />
         )}
         <div>
-          <p className="font-semibold text-white-shadow">
+          <p className="font-semibold text-yellow-400 text-outline-black">
             {profile.firstName} {profile.lastName}
           </p>
           <div className="text-sm flex items-center space-x-1">

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -339,7 +339,7 @@ export default function Wallet({ hideClaim = false }) {
           />
           <button
             onClick={handleSendClick}
-            className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover text-background rounded"
+            className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow"
           >
             Send
           </button>
@@ -363,7 +363,7 @@ export default function Wallet({ hideClaim = false }) {
         </label>
           <button
             onClick={() => navigator.clipboard.writeText(String(accountId))}
-            className="mt-2 px-3 py-1 bg-primary hover:bg-primary-hover text-background rounded"
+            className="mt-2 px-3 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow"
           >
             Copy Account Number
           </button>


### PR DESCRIPTION
## Summary
- Highlight My Account username in yellow with black outline
- Match Send and Copy Account Number buttons with Change Avatar styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f4b953f508329a4fc2373249f30ea