### PR TITLE
feat: enlarge header logo

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -111,7 +111,7 @@ export default function Layout({ children }) {
           <img
             src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp"
             alt="TonPlaygram logo"
-            className="h-28"
+            className="h-[190px]"
           />
         </header>
       )}


### PR DESCRIPTION
## Summary
- enlarge header logo size by ~70%

## Testing
- `npm test` *(fails: canvas.node compiled against different NODE_MODULE_VERSION; joinRoom clears lobby seat etc.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f4a8dfee4832988e714b7947578f5