### PR TITLE
feat: add celebratory game end popup

### DIFF
--- a/webapp/src/components/GameEndPopup.jsx
+++ b/webapp/src/components/GameEndPopup.jsx
@@ -1,31 +1,80 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { createPortal } from 'react-dom';
+import coinConfetti from '../utils/coinConfetti';
 
-export default function GameEndPopup({ open, ranking, onPlayAgain, onReturn }) {
+export default function GameEndPopup({ open, ranking = [], onReturn }) {
   if (!open) return null;
+
+  const players = ranking.map((r) =>
+    typeof r === 'string'
+      ? { name: r, photoUrl: '/assets/icons/profile.svg', amount: 0 }
+      : r,
+  );
+
+  useEffect(() => {
+    coinConfetti();
+    const snd = new Audio('/assets/sounds/metal-whistle-6121.mp3');
+    snd.play().catch(() => {});
+    return () => snd.pause();
+  }, []);
+
+  const winner = players[0];
+  const others = players.slice(1);
+
   return createPortal(
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80">
-        <h3 className="text-lg font-bold text-center">Game Over</h3>
-        <ol className="list-decimal list-inside space-y-1 text-center">
-          {ranking.map((name, i) => (
-            <li key={i}>{name}</li>
+      <div className="bg-surface border border-border p-6 rounded space-y-4 text-text w-80 text-center">
+        <p
+          className="text-xl font-bold text-yellow-400"
+          style={{ WebkitTextStroke: '1px black' }}
+        >
+          Winner 🏅
+        </p>
+        {winner && (
+          <div className="flex items-center justify-center gap-2">
+            <img
+              src={winner.photoUrl}
+              alt={winner.name}
+              className="w-20 h-20 rounded-full"
+            />
+            <span className="flex items-center gap-1 font-semibold text-lg">
+              {winner.amount}
+              <img
+                src="/assets/icons/ezgif-54c96d8a9b9236.webp"
+                alt="TPC"
+                className="w-5 h-5"
+              />
+            </span>
+          </div>
+        )}
+        <ul className="space-y-2">
+          {others.map((p, i) => (
+            <li key={i} className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <img
+                  src={p.photoUrl}
+                  alt={p.name}
+                  className="w-8 h-8 rounded-full"
+                />
+                <span>{p.name}</span>
+              </div>
+              <span className="flex items-center gap-1">
+                {p.amount}
+                <img
+                  src="/assets/icons/ezgif-54c96d8a9b9236.webp"
+                  alt="TPC"
+                  className="w-4 h-4"
+                />
+              </span>
+            </li>
           ))}
-        </ol>
-        <div className="flex gap-2">
-          <button
-            onClick={onPlayAgain}
-            className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded"
-          >
-            Play Again
-          </button>
-          <button
-            onClick={onReturn}
-            className="flex-1 px-4 py-1 bg-primary hover:bg-primary-hover text-white rounded"
-          >
-            Return to Lobby
-          </button>
-        </div>
+        </ul>
+        <button
+          onClick={onReturn}
+          className="px-2 py-0.5 bg-primary hover:bg-primary-hover text-white-shadow text-sm rounded w-full"
+        >
+          Return to Lobby
+        </button>
       </div>
     </div>,
     document.body,

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -138,10 +138,10 @@ export default function CrazyDiceDuel() {
               : aiCount > 0
                 ? avatarToName(p.photoUrl) || `AI ${i}`
                 : `P${i + 1}`,
-          score: p.score,
+          photoUrl: p.photoUrl || '/assets/icons/profile.svg',
+          amount: p.score,
         }))
-        .sort((a, b) => b.score - a.score)
-        .map((p) => p.name),
+        .sort((a, b) => b.amount - a.amount),
     [players, aiCount],
   );
   const [showChat, setShowChat] = useState(false);
@@ -936,7 +936,6 @@ export default function CrazyDiceDuel() {
       <GameEndPopup
         open={winner != null}
         ranking={ranking}
-        onPlayAgain={() => window.location.reload()}
         onReturn={() => navigate('/games/crazydice/lobby')}
       />
       <InfoPopup


### PR DESCRIPTION
## Summary
- show winner avatar, rewards, and return button on game end
- add celebration sound and coin confetti when a match finishes
- update Crazy Dice Duel and Snake & Ladder to supply rankings with avatars and amounts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f56a3a3208329b57cd6d22b2d94b5