### PR TITLE
Add chat, gift, info, and mute overlays to HTML games

### DIFF
--- a/webapp/src/pages/Games/BrickBreaker.jsx
+++ b/webapp/src/pages/Games/BrickBreaker.jsx
@@ -1,14 +1,71 @@
+import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
 
 export default function BrickBreaker() {
+  useTelegramBackButton();
   const { search } = useLocation();
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
+  const [muted, setMuted] = useState(isGameMuted());
+  const photoUrl = loadAvatar() || '/assets/icons/profile.svg';
+
+  useEffect(() => {
+    const handler = () => setMuted(isGameMuted());
+    window.addEventListener('gameMuteChanged', handler);
+    return () => window.removeEventListener('gameMuteChanged', handler);
+  }, []);
+
   return (
-    <iframe
-      src={`/brick-breaker.html${search}`}
-      title="Brick Breaker Royale"
-      className="w-screen h-screen border-0"
-      allow="fullscreen"
-      allowFullScreen
-    />
+    <>
+      <iframe
+        src={`/brick-breaker.html${search}`}
+        title="Brick Breaker Royale"
+        className="w-screen h-screen border-0"
+        allow="fullscreen"
+        allowFullScreen
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl }]);
+          if (!muted) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(
+            () => setChatBubbles((b) => b.filter((bb) => bb.id !== id)),
+            3000,
+          );
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={[]}
+        senderIndex={0}
+      />
+    </>
   );
 }

--- a/webapp/src/pages/Games/BubblePopRoyale.jsx
+++ b/webapp/src/pages/Games/BubblePopRoyale.jsx
@@ -1,14 +1,69 @@
+import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
 
 export default function BubblePopRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
+  const [muted, setMuted] = useState(isGameMuted());
+  const photoUrl = loadAvatar() || '/assets/icons/profile.svg';
+
+  useEffect(() => {
+    const handler = () => setMuted(isGameMuted());
+    window.addEventListener('gameMuteChanged', handler);
+    return () => window.removeEventListener('gameMuteChanged', handler);
+  }, []);
+
   return (
-    <iframe
-      src={`/bubble-pop-royale.html${search}`}
-      title="Bubble Pop Royale"
-      className="w-full h-[100dvh] border-0"
-    />
+    <>
+      <iframe
+        src={`/bubble-pop-royale.html${search}`}
+        title="Bubble Pop Royale"
+        className="w-full h-[100dvh] border-0"
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl }]);
+          if (!muted) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(
+            () => setChatBubbles((b) => b.filter((bb) => bb.id !== id)),
+            3000,
+          );
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={[]}
+        senderIndex={0}
+      />
+    </>
   );
 }

--- a/webapp/src/pages/Games/BubbleSmashRoyale.jsx
+++ b/webapp/src/pages/Games/BubbleSmashRoyale.jsx
@@ -1,14 +1,69 @@
+import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
 
 export default function BubbleSmashRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
+  const [muted, setMuted] = useState(isGameMuted());
+  const photoUrl = loadAvatar() || '/assets/icons/profile.svg';
+
+  useEffect(() => {
+    const handler = () => setMuted(isGameMuted());
+    window.addEventListener('gameMuteChanged', handler);
+    return () => window.removeEventListener('gameMuteChanged', handler);
+  }, []);
+
   return (
-    <iframe
-      src={`/bubble-smash-royale.html${search}`}
-      title="Bubble Smash Royale"
-      className="w-full h-[100dvh] border-0"
-    />
+    <>
+      <iframe
+        src={`/bubble-smash-royale.html${search}`}
+        title="Bubble Smash Royale"
+        className="w-full h-[100dvh] border-0"
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl }]);
+          if (!muted) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(
+            () => setChatBubbles((b) => b.filter((bb) => bb.id !== id)),
+            3000,
+          );
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={[]}
+        senderIndex={0}
+      />
+    </>
   );
 }

--- a/webapp/src/pages/Games/FallingBall.jsx
+++ b/webapp/src/pages/Games/FallingBall.jsx
@@ -1,14 +1,69 @@
+import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
 
 export default function FallingBall() {
   useTelegramBackButton();
   const { search } = useLocation();
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
+  const [muted, setMuted] = useState(isGameMuted());
+  const photoUrl = loadAvatar() || '/assets/icons/profile.svg';
+
+  useEffect(() => {
+    const handler = () => setMuted(isGameMuted());
+    window.addEventListener('gameMuteChanged', handler);
+    return () => window.removeEventListener('gameMuteChanged', handler);
+  }, []);
+
   return (
-    <iframe
-      src={`/falling-ball.html${search}`}
-      title="Falling Ball"
-      className="w-full h-screen border-0"
-    />
+    <>
+      <iframe
+        src={`/falling-ball.html${search}`}
+        title="Falling Ball"
+        className="w-full h-screen border-0"
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl }]);
+          if (!muted) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(
+            () => setChatBubbles((b) => b.filter((bb) => bb.id !== id)),
+            3000,
+          );
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={[]}
+        senderIndex={0}
+      />
+    </>
   );
 }

--- a/webapp/src/pages/Games/FruitSliceRoyale.jsx
+++ b/webapp/src/pages/Games/FruitSliceRoyale.jsx
@@ -1,14 +1,69 @@
+import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
 
 export default function FruitSliceRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
+  const [muted, setMuted] = useState(isGameMuted());
+  const photoUrl = loadAvatar() || '/assets/icons/profile.svg';
+
+  useEffect(() => {
+    const handler = () => setMuted(isGameMuted());
+    window.addEventListener('gameMuteChanged', handler);
+    return () => window.removeEventListener('gameMuteChanged', handler);
+  }, []);
+
   return (
-    <iframe
-      src={`/fruit-slice-royale.html${search}`}
-      title="Fruit Slice Royale"
-      className="w-full h-[100dvh] border-0"
-    />
+    <>
+      <iframe
+        src={`/fruit-slice-royale.html${search}`}
+        title="Fruit Slice Royale"
+        className="w-full h-[100dvh] border-0"
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl }]);
+          if (!muted) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(
+            () => setChatBubbles((b) => b.filter((bb) => bb.id !== id)),
+            3000,
+          );
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={[]}
+        senderIndex={0}
+      />
+    </>
   );
 }

--- a/webapp/src/pages/Games/GoalRush.jsx
+++ b/webapp/src/pages/Games/GoalRush.jsx
@@ -1,15 +1,76 @@
+import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
 
 export default function GoalRush() {
   useTelegramBackButton();
   const { search } = useLocation();
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
+  const [muted, setMuted] = useState(isGameMuted());
+  const photoUrl = loadAvatar() || '/assets/icons/profile.svg';
+
+  useEffect(() => {
+    const handler = () => setMuted(isGameMuted());
+    window.addEventListener('gameMuteChanged', handler);
+    return () => window.removeEventListener('gameMuteChanged', handler);
+  }, []);
+
   return (
-    <iframe
-      src={`/goal-rush.html${search}`}
-      title="Goal Rush"
-      className="w-full h-screen border-0"
-    />
+    <>
+      <iframe
+        src={`/goal-rush.html${search}`}
+        title="Goal Rush"
+        className="w-full h-screen border-0"
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        className="fixed left-1 top-1 flex flex-col items-center space-y-2 z-20"
+      />
+      <BottomLeftIcons
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+        className="fixed right-1 top-1 flex flex-col items-center space-y-2 z-20"
+        showInfo={false}
+        showMute={false}
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl }]);
+          if (!muted) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(
+            () => setChatBubbles((b) => b.filter((bb) => bb.id !== id)),
+            3000,
+          );
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={[]}
+        senderIndex={0}
+      />
+    </>
   );
 }
 

--- a/webapp/src/pages/Games/TetrisRoyale.jsx
+++ b/webapp/src/pages/Games/TetrisRoyale.jsx
@@ -1,14 +1,69 @@
+import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
 
 export default function TetrisRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
+  const [muted, setMuted] = useState(isGameMuted());
+  const photoUrl = loadAvatar() || '/assets/icons/profile.svg';
+
+  useEffect(() => {
+    const handler = () => setMuted(isGameMuted());
+    window.addEventListener('gameMuteChanged', handler);
+    return () => window.removeEventListener('gameMuteChanged', handler);
+  }, []);
+
   return (
-    <iframe
-      src={`/tetris-royale.html${search}`}
-      title="Tetris Royale"
-      className="w-full h-screen border-0"
-    />
+    <>
+      <iframe
+        src={`/tetris-royale.html${search}`}
+        title="Tetris Royale"
+        className="w-full h-screen border-0"
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl }]);
+          if (!muted) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(
+            () => setChatBubbles((b) => b.filter((bb) => bb.id !== id)),
+            3000,
+          );
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={[]}
+        senderIndex={0}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Overlay chat, gift, info, and mute controls on Falling Ball, Goal Rush, Brick Breaker, Tetris Royale, Bubble Smash Royale, Bubble Pop Royale, and Fruit Slice Royale
- Hook up QuickMessagePopup and GiftPopup with chat bubbles and sound handling
- Special layout for Goal Rush with info/mute on left and chat/gift on right

## Testing
- `npm test` *(fails: MongooseError buffering timed out, snake API test timed out)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689f61faa3fc832996a0bcec50d46120