### PR TITLE
feat: restore goal rush lobby background

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1821,6 +1821,18 @@ input:focus {
   animation: canvasDepthMove 30s linear infinite;
 }
 
+/* Shared lobby background tweaks */
+.game-lobby {
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 110%;
+}
+
+/* Individual lobby backgrounds */
+.goalrush-lobby-bg {
+  background-image: radial-gradient(circle at center, #facc15 0%, #ca8a04 80%);
+}
+
 /* Ensure TPC icon appears slightly larger across the site */
 img[alt="TPC"] {
   min-width: 1.25rem;

--- a/webapp/src/pages/Games/GoalRushLobby.jsx
+++ b/webapp/src/pages/Games/GoalRushLobby.jsx
@@ -62,7 +62,7 @@ export default function GoalRushLobby() {
   };
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+    <div className="relative p-4 space-y-4 text-text min-h-screen game-lobby goalrush-lobby-bg">
       <h2 className="text-xl font-bold text-center">Goal Rush Lobby</h2>
       <div className="space-y-2">
         <h3 className="font-semibold">Mode</h3>


### PR DESCRIPTION
## Summary
- restore dedicated lobby background for Goal Rush

## Testing
- `npm test` (fails: FAIL 2, PASS 30)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f62ae9b7883299e82f16a43791ef7