### PR TITLE
feat: add social icons to pvp games

### DIFF
--- a/webapp/src/pages/Games/BrickBreaker.jsx
+++ b/webapp/src/pages/Games/BrickBreaker.jsx
@@ -1,14 +1,59 @@
 import { useLocation } from 'react-router-dom';
+import { useState, useMemo } from 'react';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
+import { parsePlayersFromSearch } from '../../utils/playerParams.js';
 
 export default function BrickBreaker() {
   const { search } = useLocation();
+  const players = useMemo(() => parsePlayersFromSearch(search), [search]);
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
   return (
-    <iframe
-      src={`/brick-breaker.html${search}`}
-      title="Brick Breaker Royale"
-      className="w-screen h-screen border-0"
-      allow="fullscreen"
-      allowFullScreen
-    />
+    <>
+      <iframe
+        src={`/brick-breaker.html${search}`}
+        title="Brick Breaker Royale"
+        className="w-screen h-screen border-0"
+        allow="fullscreen"
+        allowFullScreen
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+        className="fixed right-1 top-1/2 -translate-y-1/2 flex flex-col items-center space-y-2 z-20"
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl: players[0]?.photoUrl }]);
+          if (!isGameMuted()) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(() => setChatBubbles((b) => b.filter((bb) => bb.id !== id)), 3000);
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={players}
+        senderIndex={0}
+      />
+    </>
   );
 }

--- a/webapp/src/pages/Games/BubblePopRoyale.jsx
+++ b/webapp/src/pages/Games/BubblePopRoyale.jsx
@@ -1,14 +1,59 @@
 import { useLocation } from 'react-router-dom';
+import { useState, useMemo } from 'react';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
+import { parsePlayersFromSearch } from '../../utils/playerParams.js';
 
 export default function BubblePopRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
+  const players = useMemo(() => parsePlayersFromSearch(search), [search]);
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
   return (
-    <iframe
-      src={`/bubble-pop-royale.html${search}`}
-      title="Bubble Pop Royale"
-      className="w-full h-[100dvh] border-0"
-    />
+    <>
+      <iframe
+        src={`/bubble-pop-royale.html${search}`}
+        title="Bubble Pop Royale"
+        className="w-full h-[100dvh] border-0"
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+        className="fixed right-1 top-1/2 -translate-y-1/2 flex flex-col items-center space-y-2 z-20"
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl: players[0]?.photoUrl }]);
+          if (!isGameMuted()) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(() => setChatBubbles((b) => b.filter((bb) => bb.id !== id)), 3000);
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={players}
+        senderIndex={0}
+      />
+    </>
   );
 }

--- a/webapp/src/pages/Games/BubbleSmashRoyale.jsx
+++ b/webapp/src/pages/Games/BubbleSmashRoyale.jsx
@@ -1,14 +1,59 @@
 import { useLocation } from 'react-router-dom';
+import { useState, useMemo } from 'react';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
+import { parsePlayersFromSearch } from '../../utils/playerParams.js';
 
 export default function BubbleSmashRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
+  const players = useMemo(() => parsePlayersFromSearch(search), [search]);
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
   return (
-    <iframe
-      src={`/bubble-smash-royale.html${search}`}
-      title="Bubble Smash Royale"
-      className="w-full h-[100dvh] border-0"
-    />
+    <>
+      <iframe
+        src={`/bubble-smash-royale.html${search}`}
+        title="Bubble Smash Royale"
+        className="w-full h-[100dvh] border-0"
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+        className="fixed right-1 top-1/2 -translate-y-1/2 flex flex-col items-center space-y-2 z-20"
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl: players[0]?.photoUrl }]);
+          if (!isGameMuted()) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(() => setChatBubbles((b) => b.filter((bb) => bb.id !== id)), 3000);
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={players}
+        senderIndex={0}
+      />
+    </>
   );
 }

--- a/webapp/src/pages/Games/FallingBall.jsx
+++ b/webapp/src/pages/Games/FallingBall.jsx
@@ -1,14 +1,73 @@
 import { useLocation } from 'react-router-dom';
+import { useState, useMemo } from 'react';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
+import { parsePlayersFromSearch } from '../../utils/playerParams.js';
 
 export default function FallingBall() {
   useTelegramBackButton();
   const { search } = useLocation();
+  const players = useMemo(() => parsePlayersFromSearch(search), [search]);
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
   return (
-    <iframe
-      src={`/falling-ball.html${search}`}
-      title="Falling Ball"
-      className="w-full h-screen border-0"
-    />
+    <>
+      <iframe
+        src={`/falling-ball.html${search}`}
+        title="Falling Ball"
+        className="w-full h-screen border-0"
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        showChat={false}
+        showGift={false}
+        showMute={false}
+        className="fixed left-1 top-1 flex flex-col items-center space-y-2 z-20"
+      />
+      <BottomLeftIcons
+        showInfo={false}
+        showChat={false}
+        showGift={false}
+        className="fixed right-1 top-1 flex flex-col items-center space-y-2 z-20"
+      />
+      <BottomLeftIcons
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+        showInfo={false}
+        showMute={false}
+        className="fixed right-1 top-1/2 -translate-y-1/2 flex flex-col items-center space-y-2 z-20"
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl: players[0]?.photoUrl }]);
+          if (!isGameMuted()) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(() => setChatBubbles((b) => b.filter((bb) => bb.id !== id)), 3000);
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={players}
+        senderIndex={0}
+      />
+    </>
   );
 }

--- a/webapp/src/pages/Games/FruitSliceRoyale.jsx
+++ b/webapp/src/pages/Games/FruitSliceRoyale.jsx
@@ -1,14 +1,59 @@
 import { useLocation } from 'react-router-dom';
+import { useState, useMemo } from 'react';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
+import { parsePlayersFromSearch } from '../../utils/playerParams.js';
 
 export default function FruitSliceRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
+  const players = useMemo(() => parsePlayersFromSearch(search), [search]);
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
   return (
-    <iframe
-      src={`/fruit-slice-royale.html${search}`}
-      title="Fruit Slice Royale"
-      className="w-full h-[100dvh] border-0"
-    />
+    <>
+      <iframe
+        src={`/fruit-slice-royale.html${search}`}
+        title="Fruit Slice Royale"
+        className="w-full h-[100dvh] border-0"
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+        className="fixed right-1 top-1/2 -translate-y-1/2 flex flex-col items-center space-y-2 z-20"
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl: players[0]?.photoUrl }]);
+          if (!isGameMuted()) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(() => setChatBubbles((b) => b.filter((bb) => bb.id !== id)), 3000);
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={players}
+        senderIndex={0}
+      />
+    </>
   );
 }

--- a/webapp/src/pages/Games/GoalRush.jsx
+++ b/webapp/src/pages/Games/GoalRush.jsx
@@ -1,15 +1,74 @@
 import { useLocation } from 'react-router-dom';
+import { useState, useMemo } from 'react';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
+import { parsePlayersFromSearch } from '../../utils/playerParams.js';
 
 export default function GoalRush() {
   useTelegramBackButton();
   const { search } = useLocation();
+  const players = useMemo(() => parsePlayersFromSearch(search), [search]);
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
   return (
-    <iframe
-      src={`/goal-rush.html${search}`}
-      title="Goal Rush"
-      className="w-full h-screen border-0"
-    />
+    <>
+      <iframe
+        src={`/goal-rush.html${search}`}
+        title="Goal Rush"
+        className="w-full h-screen border-0"
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        showChat={false}
+        showGift={false}
+        showMute={false}
+        className="fixed left-1 top-1 flex flex-col items-center space-y-2 z-20"
+      />
+      <BottomLeftIcons
+        showInfo={false}
+        showChat={false}
+        showGift={false}
+        className="fixed right-1 top-1 flex flex-col items-center space-y-2 z-20"
+      />
+      <BottomLeftIcons
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+        showInfo={false}
+        showMute={false}
+        className="fixed right-1 top-1/2 -translate-y-1/2 flex flex-col items-center space-y-2 z-20"
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl: players[0]?.photoUrl }]);
+          if (!isGameMuted()) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(() => setChatBubbles((b) => b.filter((bb) => bb.id !== id)), 3000);
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={players}
+        senderIndex={0}
+      />
+    </>
   );
 }
 

--- a/webapp/src/pages/Games/TetrisRoyale.jsx
+++ b/webapp/src/pages/Games/TetrisRoyale.jsx
@@ -1,14 +1,59 @@
 import { useLocation } from 'react-router-dom';
+import { useState, useMemo } from 'react';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { chatBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
+import { parsePlayersFromSearch } from '../../utils/playerParams.js';
 
 export default function TetrisRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
+  const players = useMemo(() => parsePlayersFromSearch(search), [search]);
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
   return (
-    <iframe
-      src={`/tetris-royale.html${search}`}
-      title="Tetris Royale"
-      className="w-full h-screen border-0"
-    />
+    <>
+      <iframe
+        src={`/tetris-royale.html${search}`}
+        title="Tetris Royale"
+        className="w-full h-screen border-0"
+      />
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <BottomLeftIcons
+        onInfo={() => {}}
+        onChat={() => setShowChat(true)}
+        onGift={() => setShowGift(true)}
+        className="fixed right-1 top-1/2 -translate-y-1/2 flex flex-col items-center space-y-2 z-20"
+      />
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          setChatBubbles((b) => [...b, { id, text, photoUrl: players[0]?.photoUrl }]);
+          if (!isGameMuted()) {
+            const a = new Audio(chatBeep);
+            a.volume = getGameVolume();
+            a.play().catch(() => {});
+          }
+          setTimeout(() => setChatBubbles((b) => b.filter((bb) => bb.id !== id)), 3000);
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={players}
+        senderIndex={0}
+      />
+    </>
   );
 }

--- a/webapp/src/utils/playerParams.js
+++ b/webapp/src/utils/playerParams.js
@@ -1,0 +1,19 @@
+export function parsePlayersFromSearch(search) {
+  const params = new URLSearchParams(search);
+  const count = parseInt(params.get('players')) || 2;
+  const avatarsParam = params.get('avatars');
+  const namesParam = params.get('names');
+  const tgIdsParam = params.get('tgIds');
+  const accountsParam = params.get('accounts');
+  const avatars = avatarsParam ? avatarsParam.split(',').map(decodeURIComponent) : [];
+  const names = namesParam ? namesParam.split(',').map(decodeURIComponent) : [];
+  const ids = tgIdsParam ? tgIdsParam.split(',') : [];
+  const accounts = accountsParam ? accountsParam.split(',') : [];
+  return Array.from({ length: count }, (_, i) => ({
+    index: i,
+    name: names[i] || `P${i + 1}`,
+    photoUrl: avatars[i] || '/assets/icons/profile.svg',
+    id: ids[i] || null,
+    accountId: accounts[i] || null,
+  }));
+}


### PR DESCRIPTION
## Summary
- add chat, gift, info, and mute controls to HTML-based games
- parse player parameters to drive gift and chat overlays

## Testing
- `npm test` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_689f67ce48388329a507e33f3803cce5