### PR TITLE
Use Goal Rush victory effects

### DIFF
--- a/webapp/public/falling-ball.html
+++ b/webapp/public/falling-ball.html
@@ -108,10 +108,14 @@
   let audioCtx = null; let sfxOn = true;
   function ensureAudio(){ if(!audioCtx){ try{ audioCtx = new (window.AudioContext||window.webkitAudioContext)(); }catch(e){} } }
   function playTone(f=440, t=0.06, type='sine', gain=0.04){ if(!sfxOn) return; ensureAudio(); if(!audioCtx) return; const o=audioCtx.createOscillator(); const g=audioCtx.createGain(); o.type=type; o.frequency.setValueAtTime(f, audioCtx.currentTime); g.gain.value=gain; o.connect(g).connect(audioCtx.destination); o.start(); o.stop(audioCtx.currentTime+t); }
-  const SFX = { bounce(){ playTone(520+Math.random()*120, 0.05, 'triangle', 0.05); }, spinner(){ playTone(740,0.08,'square',0.04); }, win(){ playTone(660,0.12,'sine',0.06); setTimeout(()=>playTone(880,0.18,'sine',0.06), 90); } };
+  const victoryAudio = new Audio('/assets/sounds/11l-victory_sound_with_t-1749487412779-357604.mp3');
+  const SFX = {
+    bounce(){ playTone(520+Math.random()*120, 0.05, 'triangle', 0.05); },
+    spinner(){ playTone(740,0.08,'square',0.04); },
+    win(){ if(!sfxOn) return; victoryAudio.currentTime=0; victoryAudio.play().catch(()=>{}); }
+  };
 
-  function coinConfetti(_count=50, iconSrc='/assets/icons/ezgif-54c96d8a9b9236.webp'){
-      const count=25;
+  function coinConfetti(count=50, iconSrc='/assets/icons/ezgif-54c96d8a9b9236.webp'){
       const container=document.createElement('div');
       container.style.position='fixed';
       container.style.top='0';

--- a/webapp/src/components/RewardPopup.tsx
+++ b/webapp/src/components/RewardPopup.tsx
@@ -29,7 +29,9 @@ export default function RewardPopup({
         icon = '/assets/icons/file_00000000ae68620a96d269fe76d158e5_256x256.webp';
       }
       coinConfetti(50, icon);
-      audio = new Audio('/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3');
+      audio = new Audio(
+        '/assets/sounds/11l-victory_sound_with_t-1749487412779-357604.mp3',
+      );
       audio.volume = getGameVolume();
       audio.play().catch(() => {});
     }

--- a/webapp/src/utils/coinConfetti.ts
+++ b/webapp/src/utils/coinConfetti.ts
@@ -1,5 +1,7 @@
-export default function coinConfetti(_count: number = 0, iconSrc: string = '/assets/icons/ezgif-54c96d8a9b9236.webp') {
-  const count = 25;
+export default function coinConfetti(
+  count: number = 50,
+  iconSrc: string = '/assets/icons/ezgif-54c96d8a9b9236.webp',
+) {
   const container = document.createElement('div');
   container.style.position = 'fixed';
   container.style.top = '0';


### PR DESCRIPTION
## Summary
- Play Goal Rush victory sound and confetti in Spin & Win rewards
- Match Goal Rush sound and coin burst in Falling Ball
- Allow confetti helper to spawn 50 coins by default

## Testing
- `npm test` *(fails: Claim transaction failed: CLAIM_CONTRACT_ADDRESS and CLAIM_WALLET_MNEMONIC must be set)*

------
https://chatgpt.com/codex/tasks/task_e_689f665b9f288329acaaf71418f6e2be