### PR TITLE
feat: add shared in-game overlay icons

### DIFF
--- a/webapp/src/components/GameFrame.jsx
+++ b/webapp/src/components/GameFrame.jsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import BottomLeftIcons from './BottomLeftIcons.jsx';
+import QuickMessagePopup from './QuickMessagePopup.jsx';
+import GiftPopup from './GiftPopup.jsx';
+import InfoPopup from './InfoPopup.jsx';
+import { getTelegramPhotoUrl, getTelegramFirstName } from '../utils/telegram.js';
+
+export default function GameFrame({ src, title, info, layout = 'default', players = [] }) {
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
+
+  const defaultPlayers = players.length
+    ? players
+    : [
+        {
+          index: 0,
+          name: getTelegramFirstName() || 'You',
+          photoUrl: getTelegramPhotoUrl(),
+        },
+      ];
+
+  return (
+    <div className="relative w-full h-screen">
+      <iframe src={src} title={title} className="w-full h-full border-0" />
+      {layout === 'split' ? (
+        <>
+          <BottomLeftIcons
+            onInfo={() => setShowInfo(true)}
+            className="fixed left-1 top-1 flex flex-col items-center space-y-2 z-20"
+            showChat={false}
+            showGift={false}
+          />
+          <BottomLeftIcons
+            onChat={() => setShowChat(true)}
+            onGift={() => setShowGift(true)}
+            className="fixed right-1 top-1 flex flex-col items-center space-y-2 z-20"
+            showInfo={false}
+            showMute={false}
+          />
+        </>
+      ) : (
+        <BottomLeftIcons
+          onInfo={() => setShowInfo(true)}
+          onChat={() => setShowChat(true)}
+          onGift={() => setShowGift(true)}
+        />
+      )}
+      {chatBubbles.map((b) => (
+        <div key={b.id} className="chat-bubble">
+          <span>{b.text}</span>
+          {b.photoUrl && <img src={b.photoUrl} className="w-5 h-5 rounded-full" />}
+        </div>
+      ))}
+      <QuickMessagePopup
+        open={showChat}
+        onClose={() => setShowChat(false)}
+        onSend={(text) => {
+          const id = Date.now();
+          const photo = defaultPlayers[0]?.photoUrl;
+          setChatBubbles((b) => [...b, { id, text, photoUrl: photo }]);
+          setTimeout(() => setChatBubbles((b) => b.filter((bb) => bb.id !== id)), 3000);
+        }}
+      />
+      <GiftPopup
+        open={showGift}
+        onClose={() => setShowGift(false)}
+        players={defaultPlayers}
+        senderIndex={0}
+        onGiftSent={() => {}}
+      />
+      <InfoPopup
+        open={showInfo}
+        onClose={() => setShowInfo(false)}
+        title={title}
+        info={info}
+      />
+    </div>
+  );
+}
+

--- a/webapp/src/pages/Games/BrickBreaker.jsx
+++ b/webapp/src/pages/Games/BrickBreaker.jsx
@@ -1,14 +1,15 @@
 import { useLocation } from 'react-router-dom';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import GameFrame from '../../components/GameFrame.jsx';
 
 export default function BrickBreaker() {
+  useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <iframe
+    <GameFrame
       src={`/brick-breaker.html${search}`}
       title="Brick Breaker Royale"
-      className="w-screen h-screen border-0"
-      allow="fullscreen"
-      allowFullScreen
+      info="Break all the bricks and outlast opponents to win the round."
     />
   );
 }

--- a/webapp/src/pages/Games/BubblePopRoyale.jsx
+++ b/webapp/src/pages/Games/BubblePopRoyale.jsx
@@ -1,14 +1,15 @@
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import GameFrame from '../../components/GameFrame.jsx';
 
 export default function BubblePopRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <iframe
+    <GameFrame
       src={`/bubble-pop-royale.html${search}`}
       title="Bubble Pop Royale"
-      className="w-full h-[100dvh] border-0"
+      info="Pop bubbles against the clock and rack up the highest score."
     />
   );
 }

--- a/webapp/src/pages/Games/BubbleSmashRoyale.jsx
+++ b/webapp/src/pages/Games/BubbleSmashRoyale.jsx
@@ -1,14 +1,15 @@
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import GameFrame from '../../components/GameFrame.jsx';
 
 export default function BubbleSmashRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <iframe
+    <GameFrame
       src={`/bubble-smash-royale.html${search}`}
       title="Bubble Smash Royale"
-      className="w-full h-[100dvh] border-0"
+      info="Match bubbles quickly and climb to the top of the scoreboard."
     />
   );
 }

--- a/webapp/src/pages/Games/FallingBall.jsx
+++ b/webapp/src/pages/Games/FallingBall.jsx
@@ -1,14 +1,16 @@
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import GameFrame from '../../components/GameFrame.jsx';
 
 export default function FallingBall() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <iframe
+    <GameFrame
       src={`/falling-ball.html${search}`}
       title="Falling Ball"
-      className="w-full h-screen border-0"
+      info="Keep the ball in play and score points without letting it drop."
+      layout="split"
     />
   );
 }

--- a/webapp/src/pages/Games/FruitSliceRoyale.jsx
+++ b/webapp/src/pages/Games/FruitSliceRoyale.jsx
@@ -1,14 +1,15 @@
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import GameFrame from '../../components/GameFrame.jsx';
 
 export default function FruitSliceRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <iframe
+    <GameFrame
       src={`/fruit-slice-royale.html${search}`}
       title="Fruit Slice Royale"
-      className="w-full h-[100dvh] border-0"
+      info="Slice the flying fruit and avoid the bombs to climb the rankings."
     />
   );
 }

--- a/webapp/src/pages/Games/GoalRush.jsx
+++ b/webapp/src/pages/Games/GoalRush.jsx
@@ -1,14 +1,16 @@
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import GameFrame from '../../components/GameFrame.jsx';
 
 export default function GoalRush() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <iframe
+    <GameFrame
       src={`/goal-rush.html${search}`}
       title="Goal Rush"
-      className="w-full h-screen border-0"
+      info="Score goals and defeat your opponent in this fast paced match."
+      layout="split"
     />
   );
 }

--- a/webapp/src/pages/Games/TetrisRoyale.jsx
+++ b/webapp/src/pages/Games/TetrisRoyale.jsx
@@ -1,14 +1,15 @@
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import GameFrame from '../../components/GameFrame.jsx';
 
 export default function TetrisRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <iframe
+    <GameFrame
       src={`/tetris-royale.html${search}`}
       title="Tetris Royale"
-      className="w-full h-screen border-0"
+      info="Clear lines and survive longer than everyone else in this block-dropping battle."
     />
   );
 }


### PR DESCRIPTION
## Summary
- add reusable GameFrame component with chat, gift, info and mute overlays
- integrate GameFrame into Falling Ball, Goal Rush, Brick Breaker, Tetris Royale, Bubble Smash Royale, Bubble Pop Royale and Fruit Slice Royale

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f70cf61e883298e86eb0764be9836