### PR TITLE
Remove split layout corner icons

### DIFF
--- a/webapp/src/components/GameFrame.jsx
+++ b/webapp/src/components/GameFrame.jsx
@@ -24,23 +24,7 @@ export default function GameFrame({ src, title, info, layout = 'default', player
   return (
     <div className="relative w-full h-screen">
       <iframe src={src} title={title} className="w-full h-full border-0" />
-      {layout === 'split' ? (
-        <>
-          <BottomLeftIcons
-            onInfo={() => setShowInfo(true)}
-            className="fixed left-1 top-1 flex flex-col items-center space-y-2 z-20"
-            showChat={false}
-            showGift={false}
-          />
-          <BottomLeftIcons
-            onChat={() => setShowChat(true)}
-            onGift={() => setShowGift(true)}
-            className="fixed right-1 top-1 flex flex-col items-center space-y-2 z-20"
-            showInfo={false}
-            showMute={false}
-          />
-        </>
-      ) : (
+      {layout === 'split' ? null : (
         <BottomLeftIcons
           onInfo={() => setShowInfo(true)}
           onChat={() => setShowChat(true)}

--- a/webapp/src/pages/Games/CrazyDiceDuel.jsx
+++ b/webapp/src/pages/Games/CrazyDiceDuel.jsx
@@ -841,21 +841,7 @@ export default function CrazyDiceDuel() {
           <img src={b.photoUrl} className="w-5 h-5 rounded-full" />
         </div>
       ))}
-      {playerCount === 2 ? (
-        <>
-          <BottomLeftIcons
-            onInfo={() => {}}
-            className="fixed left-1 top-1 flex flex-col items-center space-y-2 z-20"
-          />
-          <BottomLeftIcons
-            onChat={() => setShowChat(true)}
-            onGift={() => setShowGift(true)}
-            className="fixed right-1 top-1 flex flex-col items-center space-y-2 z-20"
-            showInfo={false}
-            showMute={false}
-          />
-        </>
-      ) : (
+      {playerCount === 2 ? null : (
         <BottomLeftIcons
           onInfo={() => {}}
           onChat={() => setShowChat(true)}


### PR DESCRIPTION
## Summary
- Hide info/mute buttons for split layout, removing top-left icons
- Remove chat/gift buttons from split layout top-right region

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f7a3995ac8329b42e239e38e77690