### PR TITLE
style: unify game titles text style

### DIFF
--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -18,63 +18,63 @@ export default function HomeGamesCard() {
             className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/goal_rush_card_1200x675.webp" alt="" className="h-20 w-20" />
-            <h3 className="text-sm font-semibold text-center text-yellow-400">Goal Rush</h3>
+            <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">Goal Rush</h3>
           </Link>
           <Link
             to="/games/snake/lobby"
             className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/snakes_and_ladders.webp" alt="" className="h-20 w-20" />
-            <h3 className="text-sm font-semibold text-center text-yellow-400">Snake &amp; Ladder</h3>
+            <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">Snake &amp; Ladder</h3>
           </Link>
           <Link
             to="/games/fallingball/lobby"
             className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/Falling Ball .png" alt="" className="h-20 w-20" />
-            <h3 className="text-sm font-semibold text-center text-yellow-400">Falling Ball</h3>
+            <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">Falling Ball</h3>
           </Link>
           <Link
             to="/games/fruitsliceroyale/lobby"
             className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/Fruit Slice Royale .png" alt="" className="h-20 w-20" />
-            <h3 className="text-sm font-semibold text-center text-yellow-400">Fruit Slice Royale</h3>
+            <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">Fruit Slice Royale</h3>
           </Link>
           <Link
             to="/games/brickbreaker/lobby"
             className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/Brick Breaker Royale .png" alt="" className="h-20 w-20" />
-            <h3 className="text-sm font-semibold text-center text-yellow-400">Brick Breaker Royale</h3>
+            <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">Brick Breaker Royale</h3>
           </Link>
           <Link
             to="/games/tetrisroyale/lobby"
             className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/file_00000000240061f4abd28311d76970a5.png" alt="" className="h-20 w-20" />
-            <h3 className="text-sm font-semibold text-center text-yellow-400">Tetris Royale</h3>
+            <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">Tetris Royale</h3>
           </Link>
           <Link
             to="/games/bubblesmashroyale/lobby"
             className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/Bubble Smash Royale .png" alt="" className="h-20 w-20" />
-            <h3 className="text-sm font-semibold text-center text-yellow-400">Bubble Smash Royale</h3>
+            <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">Bubble Smash Royale</h3>
           </Link>
           <Link
             to="/games/crazydice/lobby"
             className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/Crazy_Dice_Duel_Promo.webp" alt="" className="h-20 w-20" />
-            <h3 className="text-sm font-semibold text-center text-yellow-400">Crazy Dice Duel</h3>
+            <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">Crazy Dice Duel</h3>
           </Link>
           <Link
             to="/games/bubblepoproyale/lobby"
             className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/Bubble Pop Royale .png" alt="" className="h-20 w-20" />
-            <h3 className="text-sm font-semibold text-center text-yellow-400">Bubble Pop Royale</h3>
+            <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">Bubble Pop Royale</h3>
           </Link>
         </div>
       <Link

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -15,10 +15,7 @@ export default function Games() {
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/goal_rush_card_1200x675.webp" alt="" className="h-20 w-20" />
-                  <h3
-                    className="text-sm font-semibold text-center text-yellow-400"
-                    style={{ WebkitTextStroke: '1px black' }}
-                  >
+                  <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">
                     Goal Rush
                   </h3>
                 </Link>
@@ -27,10 +24,7 @@ export default function Games() {
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/snakes_and_ladders.webp" alt="" className="h-20 w-20" />
-                  <h3
-                    className="text-sm font-semibold text-center text-yellow-400"
-                    style={{ WebkitTextStroke: '1px black' }}
-                  >
+                  <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">
                     Snake &amp; Ladder
                   </h3>
                 </Link>
@@ -39,10 +33,7 @@ export default function Games() {
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Falling Ball .png" alt="" className="h-20 w-20" />
-                  <h3
-                    className="text-sm font-semibold text-center text-yellow-400"
-                    style={{ WebkitTextStroke: '1px black' }}
-                  >
+                  <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">
                     Falling Ball
                   </h3>
                 </Link>
@@ -51,10 +42,7 @@ export default function Games() {
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Fruit Slice Royale .png" alt="" className="h-20 w-20" />
-                  <h3
-                    className="text-sm font-semibold text-center text-yellow-400"
-                    style={{ WebkitTextStroke: '1px black' }}
-                  >
+                  <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">
                     Fruit Slice Royale
                   </h3>
                 </Link>
@@ -63,10 +51,7 @@ export default function Games() {
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Brick Breaker Royale .png" alt="" className="h-20 w-20" />
-                  <h3
-                    className="text-sm font-semibold text-center text-yellow-400"
-                    style={{ WebkitTextStroke: '1px black' }}
-                  >
+                  <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">
                     Brick Breaker Royale
                   </h3>
                 </Link>
@@ -75,10 +60,7 @@ export default function Games() {
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/file_00000000240061f4abd28311d76970a5.png" alt="" className="h-20 w-20" />
-                  <h3
-                    className="text-sm font-semibold text-center text-yellow-400"
-                    style={{ WebkitTextStroke: '1px black' }}
-                  >
+                  <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">
                     Tetris Royale
                   </h3>
                 </Link>
@@ -87,10 +69,7 @@ export default function Games() {
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Bubble Smash Royale .png" alt="" className="h-20 w-20" />
-                  <h3
-                    className="text-sm font-semibold text-center text-yellow-400"
-                    style={{ WebkitTextStroke: '1px black' }}
-                  >
+                  <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">
                     Bubble Smash Royale
                   </h3>
                 </Link>
@@ -99,10 +78,7 @@ export default function Games() {
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Crazy_Dice_Duel_Promo.webp" alt="" className="h-20 w-20" />
-                  <h3
-                    className="text-sm font-semibold text-center text-yellow-400"
-                    style={{ WebkitTextStroke: '1px black' }}
-                  >
+                  <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">
                     Crazy Dice Duel
                   </h3>
                 </Link>
@@ -111,10 +87,7 @@ export default function Games() {
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/Bubble Pop Royale .png" alt="" className="h-20 w-20" />
-                  <h3
-                    className="text-sm font-semibold text-center text-yellow-400"
-                    style={{ WebkitTextStroke: '1px black' }}
-                  >
+                  <h3 className="text-sm font-semibold text-center text-yellow-400 text-outline-black">
                     Bubble Pop Royale
                   </h3>
                 </Link>


### PR DESCRIPTION
## Summary
- Ensure games page cards use shared `text-outline-black` class
- Apply the same outline style to home page game cards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f8c00374883298e27ee75ba674fc0