### PR TITLE
Add goal net sound effect

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -306,6 +306,7 @@
   const crowdSound = new Audio('/assets/sounds/football-crowd-3-69245.mp3');
   crowdSound.loop = true;
   const whistleSound = new Audio('/assets/sounds/metal-whistle-6121.mp3');
+  const goalNetSound = new Audio('/assets/sounds/a-football-hits-the-net-goal-313216.mp3');
   const crowdBaseVolume = 0.5;
   crowdSound.volume = crowdBaseVolume;
   let pendingWhistle = false;
@@ -349,6 +350,12 @@
     wall(){},
     goal(){
       if(!audioEnabled) return;
+      goalNetSound.currentTime = 0;
+      goalNetSound.play().catch(()=>{});
+      setTimeout(()=>{
+        goalNetSound.pause();
+        goalNetSound.currentTime = 0;
+      },2000);
       playWhistle();
     }
   };


### PR DESCRIPTION
## Summary
- Play goal net audio on each score in Goal Rush and stop after 2 seconds

## Testing
- `npm test` *(fails: ERR_ASSERTION)*

------
https://chatgpt.com/codex/tasks/task_e_689f90f3b8748329af181e501f7a120a