### PR TITLE
fix: persist current page across reloads

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -19,6 +19,25 @@ export default function Layout({ children }) {
   const [invite, setInvite] = useState(null);
   const inviteSoundRef = useRef(null);
 
+  // Restore last visited path on initial load (helps with Telegram reloads)
+  useEffect(() => {
+    const stored = localStorage.getItem('lastVisitedPath');
+    const current = window.location.pathname + window.location.search;
+    if (
+      stored &&
+      stored !== current &&
+      (window.location.pathname === '/' || window.location.pathname === '')
+    ) {
+      navigate(stored, { replace: true });
+    }
+  }, [navigate]);
+
+  // Persist current path so reloads return to the same page
+  useEffect(() => {
+    const current = location.pathname + location.search;
+    localStorage.setItem('lastVisitedPath', current);
+  }, [location.pathname, location.search]);
+
   useEffect(() => {
     inviteSoundRef.current = new Audio(inviteBeep);
     inviteSoundRef.current.volume = getGameVolume();


### PR DESCRIPTION
## Summary
- remember last visited route and restore it on initial load so Telegram/browser reloads stay on the current page

## Testing
- `npm test` *(fails to fully complete due to long-running tests, but partial output confirms execution)*

------
https://chatgpt.com/codex/tasks/task_e_689f97e915548329b185708f5a2bdb6a