### PR TITLE
Add bomb explosion effects to Fruit Slice Royale

### DIFF
--- a/webapp/public/fruit-slice-royale.html
+++ b/webapp/public/fruit-slice-royale.html
@@ -176,15 +176,12 @@
     g.gain.setValueAtTime(0,t); g.gain.linearRampToValueAtTime(vol,t+0.01); g.gain.exponentialRampToValueAtTime(0.0001,t+dur);
     o.connect(g); g.connect(audioCtx.destination); o.start(t); o.stop(t+dur+0.02);
   }
+  const bombAudio=new Audio('/assets/sounds/a-bomb-139689.mp3');
+  bombAudio.volume=0.6;
   function explosionSound(){
-    if(!audioCtx||muted) return;
-    const t=audioCtx.currentTime;
-    const buffer=audioCtx.createBuffer(1, audioCtx.sampleRate*0.45, audioCtx.sampleRate);
-    const data=buffer.getChannelData(0);
-    for(let i=0;i<data.length;i++){ data[i]=(Math.random()*2-1)*Math.exp(-i/(audioCtx.sampleRate*0.12)); }
-    const noise=audioCtx.createBufferSource(); noise.buffer=buffer;
-    const ng=audioCtx.createGain(); ng.gain.setValueAtTime(0.6,t); ng.gain.exponentialRampToValueAtTime(0.0001,t+0.45);
-    noise.connect(ng).connect(audioCtx.destination); noise.start(t);
+    if(muted) return;
+    bombAudio.currentTime=0;
+    bombAudio.play().catch(()=>{});
   }
 
   const loadImage=src=>{ const i=new Image(); i.src=src; return i; };
@@ -216,7 +213,7 @@
     const ctx=canvas.getContext('2d'); fitCanvas(canvas);
     const W=()=>canvas.width, H=()=>canvas.height;
 
-    const fruits=[], halves=[], splats=[], smokeRings=[], slices=[], texts=[];
+    const fruits=[], halves=[], splats=[], smokeRings=[], explosions=[], slices=[], texts[];
     const game={ isUser, score:0, dragging:false, lastPt:null, nextAi: performance.now()+1000+Math.random()*400 };
 
     // Spawner
@@ -290,16 +287,21 @@
         ctx.font='bold 18px system-ui'; ctx.textAlign='center'; ctx.fillText(t.text, t.x, t.y - p*28);
       }
     }
-    function spawnRing(x,y){
+    function spawnRing(x,y,r){
       smokeRings.push({x,y,t:0,dur:520,max:Math.max(W(),H())*0.12});
+      explosions.push({x,y,life:300,size:r*3});
       explosionSound();
     }
-    function drawRings(dt){
-      for(let i=smokeRings.length-1;i>=0;i--){
-        const e=smokeRings[i]; e.t+=dt; const p=Math.min(1,e.t/e.dur), rr=p*e.max;
-        ctx.strokeStyle=`rgba(255,220,120,${1-p})`; ctx.lineWidth=3;
-        ctx.beginPath(); ctx.arc(e.x,e.y,rr,0,Math.PI*2); ctx.stroke();
-        if(p>=1) smokeRings.splice(i,1);
+    function drawExplosions(){
+      for(const e of explosions){
+        const p=e.life/300;
+        ctx.save();
+        ctx.globalAlpha=p;
+        ctx.font=`${e.size}px system-ui`;
+        ctx.textAlign='center';
+        ctx.textBaseline='middle';
+        ctx.fillText('💥',e.x,e.y);
+        ctx.restore();
       }
     }
 
@@ -351,7 +353,7 @@
           if(f._gone) continue;
           if(segHit(lp.x,lp.y,x,y,f.x,f.y,f.r*0.9)){
             f._gone=true; // VANISH
-            if(f.type==='bomb'){ spawnRing(f.x,f.y); /* bombs just explode & vanish */ }
+            if(f.type==='bomb'){ spawnRing(f.x,f.y,f.r); /* bombs just explode & vanish */ }
             else { pop(900+Math.random()*200,0.07,0.22); burstJuice(f.x,f.y,f.data.juice); spawnHalves(f, ang); game.score+=f.data.score; }
           }
         }
@@ -394,6 +396,9 @@
         const h=halves[i]; h.life-=dt; if(h.life<=0 || h.y>H()+60){ halves.splice(i,1); continue; }
         h.vy+=h.ay*(dt*0.01); h.x+=h.vx*(dt*0.06); h.y+=h.vy*(dt*0.06); h.rot+=h.spin*(dt*0.06);
       }
+      for(let i=explosions.length-1;i>=0;i--){
+        const e=explosions[i]; e.life-=dt; if(e.life<=0) explosions.splice(i,1);
+      }
     }
     function draw(){
       ctx.clearRect(0,0,W(),H());
@@ -424,6 +429,7 @@
         ctx.strokeStyle=`rgba(255,220,120,${1-p})`; ctx.lineWidth=3; ctx.beginPath(); ctx.arc(e.x,e.y,rr,0,Math.PI*2); ctx.stroke();
         if(p>=1) smokeRings.splice(i,1);
       }
+      drawExplosions();
       // swipe + texts
       for(let i=slices.length-1;i>=0;i--){
         const s=slices[i]; s.life-=16; if(s.life<=0){ slices.splice(i,1); continue; }


### PR DESCRIPTION
## Summary
- add explosion emoji animation and sound when slicing bombs in Fruit Slice Royale
- track and fade explosions to sync with game speed

## Testing
- `npm test` (fails: test timed out)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0072f6d848329943399ba4cad3bd7