### PR TITLE
Add Texas Hold'em game and lobby

### DIFF
--- a/webapp/public/assets/icons/poker.svg
+++ b/webapp/public/assets/icons/poker.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="10" y="10" width="80" height="80" rx="10" ry="10" fill="white" stroke="black" stroke-width="5"/>
+  <text x="50" y="65" font-size="60" text-anchor="middle">♠</text>
+</svg>

--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no" />
+  <title>Texas Hold'em – Billiard-Style Table (Portrait Fullscreen)</title>
+  <style>
+    :root{
+      --felt:#0a8f5e; --felt-d:#08714b; --rail-wood:#5a3b22; --rail-wood-d:#3f2a18; --gold:#f5cc4e;
+      --chip:#2f8af5; --chip2:#f5566c; --chip3:#7dd3fc; --chip4:#a78bfa; --shadow:rgba(0,0,0,.35);
+      --card-w: clamp(56px, 12vw, 90px);
+      --card-h: calc(var(--card-w) * 1.42);
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%;margin:0}
+    body{
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+      color:#fff; overflow:hidden; background:#0b1022;
+      background: radial-gradient(1100px 900px at 50% -10%, #1a2545 0, #0c1020 55%, #070a16 100%),
+                  radial-gradient(1000px 700px at 50% 110%, #142034 0, #0b111f 80%, #070a16 100%);
+    }
+    .wrap{ display:grid; place-items:center; height:100vh; width:100vw; perspective: 1100px; }
+.table-area{ position:relative; width:100vw; height:100vh; transform-style:preserve-3d; transform: rotateX(14deg); }
+
+.rail{ position:absolute; left:50%; top:50%; transform:translate(-50%,-50%);
+  width:min(92vw, 86vh); height:min(64vh, 70vw);
+  border-radius:22px; background:linear-gradient(180deg,var(--rail-wood),var(--rail-wood-d));
+  box-shadow: inset 0 5px 8px rgba(255,255,255,.25), inset 0 -10px 18px rgba(0,0,0,.6), 0 40px 70px var(--shadow);
+}
+.rail-plates{ position:absolute; inset:0; pointer-events:none; }
+.rail-plates::before, .rail-plates::after{ content:""; position:absolute; width:64px; height:16px; background:rgba(0,0,0,.25); border-radius:10px; }
+.rail-plates::before{ left:50%; transform:translateX(-50%); top:8px; }
+.rail-plates::after{ left:50%; transform:translateX(-50%); bottom:8px; }
+
+.table{ position:absolute; left:50%; top:50%; transform:translate(-50%,-50%);
+  width:calc(min(92vw, 86vh) - 30px); height:calc(min(64vh, 70vw) - 30px);
+  border-radius:18px;
+  background:
+    radial-gradient(closest-side at 50% 45%, rgba(255,255,255,.08), transparent 60%),
+    radial-gradient(closest-side at 50% 55%, rgba(0,0,0,.18), transparent 60%),
+    linear-gradient(180deg, var(--felt), var(--felt-d));
+  box-shadow: inset 0 0 0 10px rgba(0,0,0,.25);
+}
+.glow{ position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); width:calc(min(92vw, 86vh) - 30px); height:calc(min(64vh, 70vw) - 30px); border-radius:18px; box-shadow:0 0 140px 40px rgba(245,204,78,.08), inset 0 0 80px rgba(0,0,0,.35); pointer-events:none; }
+
+/* Center: community + pot */
+.center{ position:absolute; left:50%; top:50%; transform: translate(-50%,-50%); display:grid; gap:10px; place-items:center; z-index:2; }
+.community{ display:flex; gap:10px; align-items:center; justify-content:center; height:calc(var(--card-h) + 12px); }
+.pot{ font-weight:800; letter-spacing:.5px; color:#ffeaa7; text-shadow:0 2px 6px #000; background:rgba(0,0,0,.25); padding:6px 12px; border-radius:10px; border:1px solid rgba(255,255,255,.1); }
+.pot-stack{ display:flex; gap:4px; align-items:flex-end; }
+.pot-chip{ width:26px; height:26px; border-radius:50%; box-shadow:0 4px 10px rgba(0,0,0,.45), inset 0 0 0 3px rgba(255,255,255,.45); }
+
+/* Seats placed ON the table surface along its perimeter */
+.seats{ position:absolute; inset:0; }
+.seat{ position:absolute; width:clamp(140px, 30vw, 220px); display:grid; grid-template-rows:auto auto auto auto; gap:6px; place-items:center; transform-style:preserve-3d; z-index:2; }
+.avatar{ width:56px; height:56px; border-radius:50%; display:grid; place-items:center; background: radial-gradient(circle at 30% 30%, #fff, #ddd 40%, #bbb 60%, #999 100%); color:#111; font-size:30px; border:4px solid rgba(255,255,255,.6); box-shadow:0 8px 20px var(--shadow); overflow:hidden; }
+.name{ font-weight:800; text-shadow:0 2px 6px #000; font-size:14px }
+.hand{ display:flex; gap:8px; align-items:center; transform: translateZ(20px); }
+.table-chips{ display:flex; gap:4px; align-items:flex-end; transform: translateZ(12px); }
+.chips-text{ font-size:12px; opacity:.95 }
+
+.chip{ width:22px; height:22px; border-radius:50%; box-shadow:0 4px 8px rgba(0,0,0,.4), inset 0 0 0 3px rgba(255,255,255,.4); background:var(--chip); }
+.chip.alt{ background:var(--chip2) }
+.chip.c3{ background:var(--chip3) }
+.chip.c4{ background:var(--chip4) }
+
+.card{ width:var(--card-w); height:var(--card-h); border-radius:10px; position:relative; flex:0 0 auto; background:#fff; color:#111; font-weight:800; letter-spacing:.5px; box-shadow:0 10px 25px var(--shadow), inset 0 0 0 2px rgba(0,0,0,.08); transform: rotateZ(var(--r, 0deg)) translateZ(2px); transition: transform .3s ease, filter .3s ease; }
+.card.red{ color:#d12d2d }
+.card .rank{ position:absolute; left:8px; top:6px; font-size:calc(var(--card-w)*0.28) }
+.card .suit{ position:absolute; right:8px; bottom:8px; font-size:calc(var(--card-w)*0.3) }
+.card .big{ position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); font-size:calc(var(--card-w)*0.55); opacity:.85 }
+.back{ background: repeating-linear-gradient(45deg, #224, #224 6px, #112 6px, #112 12px); border:2px solid rgba(255,255,255,.5); }
+
+/* Controls: right-center vertical, avoid blocking table (narrow) */
+.controls{ position:absolute; right: max(10px, env(safe-area-inset-right)); top:50%; transform:translateY(-50%); display:flex; flex-direction:column; gap:8px; z-index:3; width:min(40vw, 180px); }
+.btn{ appearance:none; border:none; cursor:pointer; font-weight:800; padding:12px 14px; border-radius:12px; letter-spacing:.4px; background: linear-gradient(180deg, var(--gold), #e4b325); color:#412e02; box-shadow:0 6px 0 #b38e1f, 0 12px 24px var(--shadow); font-size:14px; white-space:nowrap; }
+.btn.secondary{ background:linear-gradient(180deg,#e0e7ff,#c7d2fe); color:#102a43; box-shadow:0 6px 0 #a5b4fc, 0 12px 24px var(--shadow); }
+
+.topbar{ position:absolute; top: calc(env(safe-area-inset-top) + 6px); left:50%; transform:translateX(-50%); display:flex; gap:8px; z-index:4 }
+
+.log{ position:absolute; left:10px; bottom:10px; width:min(340px, 44vw); height:34vh; overflow:auto; background:rgba(0,0,0,.25); border:1px solid rgba(255,255,255,.08); border-radius:12px; padding:10px; font-size:12px; z-index:3 }
+.log h3{ margin:6px 0 8px; font-size:13px }
+.log p{ margin:6px 0 }
+
+.badge{ position:absolute; top:-8px; right:-8px; background:#222; color:#ffeaa7; font-size:10px; padding:3px 6px; border-radius:8px; border:1px solid rgba(255,255,255,.15) }
+.dealer{ position:absolute; top:-8px; left:-8px; background:#fff; color:#111; font-size:10px; padding:3px 6px; border-radius:8px; border:1px solid rgba(0,0,0,.1); font-weight:900 }
+
+.toast{ position:absolute; left:50%; top:12%; transform:translateX(-50%); background:rgba(0,0,0,.6); border:1px solid rgba(255,255,255,.1); padding:8px 14px; border-radius:12px; font-weight:700; letter-spacing:.3px; z-index:5 }
+
+/* Bet rack sits under user's cards (auto-placed) */
+.bet-rack{ position:absolute; display:flex; gap:8px; z-index:4; }
+.rack-chip{ width:36px; height:36px; border-radius:50%; display:grid; place-items:center; font-weight:800; font-size:12px; color:#111; text-shadow:0 1px rgba(255,255,255,.4); box-shadow:0 6px 12px rgba(0,0,0,.5), inset 0 0 0 3px rgba(255,255,255,.55); cursor:pointer; user-select:none; }
+
+@media (max-width: 900px){ .log{ display:none } }
+
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="table-area">
+      <div class="rail"></div>
+      <div class="rail-plates"></div>
+      <div class="table"></div>
+      <div class="glow"></div><div class="center">
+    <div id="community" class="community"></div>
+    <div class="pot-stack" id="potStack"></div>
+    <div id="pot" class="pot">Pot: 0</div>
+  </div>
+
+  <div id="seats" class="seats"></div>
+
+  <div class="topbar">
+    <button id="sound" class="btn secondary">🔊 Sound: On</button>
+    <button id="fullscreen" class="btn secondary">⛶ Fullscreen</button>
+  </div>
+
+  <!-- Right-side controls (vertical) -->
+  <div class="controls">
+    <button id="newHand" class="btn">🔁 New Hand</button>
+    <button id="nextStage" class="btn">➡️ Next</button>
+    <button id="checkCall" class="btn">✅ Check / Call</button>
+    <button id="bet" class="btn">💰 Confirm Bet</button>
+    <button id="clearBet" class="btn secondary">🧹 Clear</button>
+    <button id="fold" class="btn">🚫 Fold</button>
+  </div>
+
+  <div class="log" id="log"><h3>Events</h3></div>
+  <div class="toast" id="toast" style="display:none"></div>
+
+  <!-- Bet rack auto positioned under the user's hand -->
+  <div class="bet-rack" id="betRack"></div>
+</div>
+
+  </div><script>
+(() => {
+  // ===== Audio (Web Audio API) =====
+  let soundOn = true; let actx = null;
+  function ensureAudio(){ if(!actx) actx = new (window.AudioContext||window.webkitAudioContext)(); if(actx.state==='suspended') actx.resume(); }
+  document.addEventListener('pointerdown', () => { ensureAudio(); }, {once:true});
+  function tone(freq=440, dur=0.08, type='sine', gain=0.06){ if(!soundOn) return; ensureAudio(); const t0 = actx.currentTime; const o = actx.createOscillator(); const g = actx.createGain(); o.type = type; o.frequency.setValueAtTime(freq, t0); g.gain.setValueAtTime(gain, t0); g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur); o.connect(g); g.connect(actx.destination); o.start(t0); o.stop(t0 + dur); }
+  function clicky(){ tone(700,0.045,'square',0.05); tone(280,0.06,'square',0.035); }
+  function chips(){ tone(520,0.06,'triangle',0.07); setTimeout(()=>tone(420,0.06,'triangle',0.06), 45); }
+  function win(){ tone(740,0.14,'sine',0.07); setTimeout(()=>tone(880,0.14,'sine',0.06),120); setTimeout(()=>tone(988,0.18,'sine',0.06),240); }
+  function foldS(){ tone(220,0.08,'sawtooth',0.05); }
+  function checkS(){ tone(330,0.06,'triangle',0.05); }
+
+  // ===== Game =====
+  const params = new URLSearchParams(location.search);
+  const userAvatar = params.get('avatar') || '🃏';
+  const avatarsParam = params.get('avatars');
+  const mode = params.get('mode') || 'local';
+  function flagName(flag){
+    const cp = Array.from(flag, c=>c.codePointAt(0));
+    if(cp.length===2){
+      const code = String.fromCharCode(cp[0]-127397) + String.fromCharCode(cp[1]-127397);
+      try {
+        const rn = new Intl.DisplayNames(['en'], {type:'region'});
+        return rn.of(code);
+      } catch {
+        return code;
+      }
+    }
+    return 'Player';
+  }
+
+  const SUITS = ['♠','♥','♦','♣'];
+  const RANKS = [2,3,4,5,6,7,8,9,10,11,12,13,14];
+  const el = sel => document.querySelector(sel);
+  const logEl = el('#log'); const seatsEl = el('#seats'); const commEl = el('#community'); const potEl = el('#pot'); const toastEl = el('#toast'); const potStackEl = el('#potStack'); const betRackEl = el('#betRack');
+
+  const state = { players: [], dealerIndex: 0, currentIndex: 0, stage: 'idle', deck: [], community: [], pot: 0, currentBet: 0, minBet: 50, pendingBet: 0 };
+  const N_PLAYERS = 6; const DENOMS = [10,20,50,100,200,500];
+
+  function makeDeck(){ const d = []; for(const s of SUITS) for(const r of RANKS) d.push({r,s}); for(let i=d.length-1;i>0;i--){ const j=Math.random()* (i+1)|0; [d[i],d[j]]=[d[j],d[i]];} return d; }
+  function rankStr(r){ return r===14?'A':r===13?'K':r===12?'Q':r===11?'J':String(r); }
+  function cardEl(card, faceDown=false){ const d=document.createElement('div'); d.className='card'+((card.s==='♥'||card.s==='♦')?' red':''); if(faceDown){ d.classList.add('back'); return d; } const rs=document.createElement('div'); rs.className='rank'; rs.textContent=rankStr(card.r); const su=document.createElement('div'); su.className='suit'; su.textContent=card.s; const big=document.createElement('div'); big.className='big'; big.textContent=card.s; d.append(rs,big,su); d.style.setProperty('--r',(Math.random()*4-2).toFixed(2)+'deg'); return d; }
+  function addLog(msg){ const p=document.createElement('p'); p.innerHTML=msg; logEl.appendChild(p); logEl.scrollTop = logEl.scrollHeight; }
+  function toast(msg){ toastEl.textContent = msg; toastEl.style.display='block'; setTimeout(()=> toastEl.style.display='none', 1600); }
+
+  // Position seats along the inner perimeter of the rectangular table
+  function layoutSeats(){
+    seatsEl.innerHTML='';
+    const tableRect = el('.table').getBoundingClientRect();
+    const padX = 30, padY = 22;
+    const x0 = tableRect.left + padX, y0 = tableRect.top + padY;
+    const w = tableRect.width - padX*2, h = tableRect.height - padY*2;
+    const perim = 2*(w+h);
+    const step = perim / N_PLAYERS;
+    let s0 = w + h + w/2;
+
+    for(let i=0;i<N_PLAYERS;i++){
+      const p = state.players[i];
+      const s = (s0 + i*step) % perim;
+      let x,y;
+      if(s < w){
+        x = x0 + s; y = y0; 
+      } else if(s < w+h){
+        x = x0 + w; y = y0 + (s - w);
+      } else if(s < w+h+w){
+        x = x0 + (w - (s - (w+h))); y = y0 + h;
+      } else {
+        x = x0; y = y0 + (h - (s - (w+h+w)));
+      }
+      const seat = document.createElement('div'); seat.className='seat';
+      const areaRect = el('.table-area').getBoundingClientRect();
+      seat.style.left=(x - areaRect.left - 70)+'px';
+      seat.style.top=(y - areaRect.top - 60)+'px';
+
+      const av=document.createElement('div'); av.className='avatar';
+      if(p.photo){
+        const img=document.createElement('img');
+        img.src=p.photo; img.alt='avatar'; img.style.width='100%'; img.style.height='100%';
+        av.appendChild(img);
+      } else {
+        av.textContent=p.emoji;
+      }
+      const name=document.createElement('div'); name.className='name'; name.textContent=p.isHuman? 'You' : p.name;
+      const hnd=document.createElement('div'); hnd.className='hand';
+      if(p.hand.length===2){ const show=p.isHuman || state.stage==='showdown'; hnd.appendChild(cardEl(p.hand[0], !show)); hnd.appendChild(cardEl(p.hand[1], !show)); }
+      const tableChips=document.createElement('div'); tableChips.className='table-chips';
+      const stackN = Math.min(4, Math.max(1, Math.round(p.chips/300)));
+      for(let sI=0;sI<stackN;sI++){ const c = document.createElement('div'); c.className='chip'+(sI%2?' alt': sI%3===0?' c3': ''); c.style.transform=`translateY(-${sI*3}px)`; tableChips.appendChild(c); }
+      const chipsText=document.createElement('div'); chipsText.className='chips-text'; chipsText.textContent=`Chips: ${p.chips}`;
+
+      if(state.players.indexOf(p)===state.dealerIndex){ const dd=document.createElement('div'); dd.className='dealer'; dd.textContent='D'; seat.appendChild(dd); }
+      if(p.folded){ const b=document.createElement('div'); b.className='badge'; b.textContent='FOLDED'; seat.appendChild(b); }
+
+      seat.append(av,name,hnd,tableChips,chipsText);
+      seatsEl.appendChild(seat);
+
+      if(p.isHuman){
+        const handRect = hnd.getBoundingClientRect();
+        betRackEl.style.left = (handRect.left + handRect.width/2) + 'px';
+        betRackEl.style.top = (handRect.bottom + 8) + 'px';
+        betRackEl.style.transform = 'translateX(-50%)';
+      }
+    }
+  }
+
+  function renderCommunity(){ commEl.innerHTML=''; state.community.forEach(c=> commEl.appendChild(cardEl(c)) ); }
+  function updatePot(){ potEl.textContent = `Pot: ${state.pot}`; potStackEl.innerHTML=''; const n = Math.min(6, Math.max(1, Math.round(state.pot/200))); for(let i=0;i<n;i++){ const pc=document.createElement('div'); pc.className='pot-chip'; pc.style.background = [ 'var(--chip)', 'var(--chip2)', 'var(--chip3)', 'var(--chip4)' ][i%4]; pc.style.transform=`translateY(-${i*3}px)`; potStackEl.appendChild(pc);} }
+
+  function newHand(){ state.deck=makeDeck(); state.community=[]; state.pot=0; state.currentBet=0; state.pendingBet=0; state.players.forEach(p=>{ p.hand=[]; p.folded=false; p.inRound=true; p.committed=0;}); const sb=(state.dealerIndex+1)%N_PLAYERS; const bb=(state.dealerIndex+2)%N_PLAYERS; betFrom(sb,10); betFrom(bb,20); state.currentBet=20; for(let r=0;r<2;r++) for(let i=0;i<N_PLAYERS;i++){ const idx=(state.dealerIndex+1+i)%N_PLAYERS; const p=state.players[idx]; p.hand.push(state.deck.pop()); } clicky(); state.stage='preflop'; state.currentIndex=(state.dealerIndex+3)%N_PLAYERS; renderAll(); addLog(`<b>New hand</b>: SB ${state.players[sb].name} 10, BB ${state.players[bb].name} 20`); promptTurn(); }
+  function nextStage(){ if(state.stage==='preflop'){ burn(); dealToCommunity(3); addLog('<b>FLOP</b>'); state.stage='flop'; state.currentBet=0; resetCommitted(); state.currentIndex=(state.dealerIndex+1)%N_PLAYERS; } else if(state.stage==='flop'){ burn(); dealToCommunity(1); addLog('<b>TURN</b>'); state.stage='turn'; state.currentBet=0; resetCommitted(); } else if(state.stage==='turn'){ burn(); dealToCommunity(1); addLog('<b>RIVER</b>'); state.stage='river'; state.currentBet=0; resetCommitted(); } else if(state.stage==='river'){ showdown(); return; } renderAll(); promptTurn(); }
+  function burn(){ state.deck.pop(); }
+  function dealToCommunity(n){ for(let i=0;i<n;i++){ state.community.push(state.deck.pop()); } renderCommunity(); clicky(); }
+  function resetCommitted(){ state.players.forEach(p=> p.committed=0); }
+  function activePlayers(){ return state.players.filter(p=> p.inRound && !p.folded); }
+  function betFrom(i, amount){ const p=state.players[i]; const a=Math.min(amount,p.chips); p.chips-=a; p.committed=(p.committed||0)+a; state.pot+=a; updatePot(); if(a>0) chips(); }
+
+  // Hand eval
+  function evaluateBest5(seven){ const ranks=seven.map(c=>c.r).sort((a,b)=>b-a); const suits={}; for(const c of seven){ suits[c.s]=(suits[c.s]||0)+1; } const byRank={}; for(const c of seven){ (byRank[c.r] ||= []).push(c); } function getFlush(){ const suit=Object.keys(suits).find(s=>suits[s]>=5); if(!suit) return null; return seven.filter(c=>c.s===suit).sort((a,b)=>b.r-a.r).slice(0,5);} function getStraight(arrRanks){ const uniq=[...new Set(arrRanks)].sort((a,b)=>b-a); if(uniq[0]===14) uniq.push(1); let run=[uniq[0]]; for(let i=1;i<uniq.length;i++){ if(uniq[i]===run[run.length-1]-1){ run.push(uniq[i]); if(run.length===5) return run[0]; } else run=[uniq[i]]; } return null;} const flush=getFlush(); if(flush){ const highSF=getStraight(flush.map(c=>c.r)); if(highSF) return {cat:8, tie:[highSF]}; } const fours=Object.keys(byRank).filter(r=>byRank[r].length===4).map(Number).sort((a,b)=>b-a); if(fours.length){ const kicker=ranks.find(r=>r!==fours[0]); return {cat:7, tie:[fours[0], kicker]}; } const trips=Object.keys(byRank).filter(r=>byRank[r].length===3).map(Number).sort((a,b)=>b-a); const pairs=Object.keys(byRank).filter(r=>byRank[r].length===2).map(Number).sort((a,b)=>b-a); if(trips.length && (pairs.length || trips.length>1)){ const three=trips[0]; const two=(trips.length>1)?trips[1]:pairs[0]; return {cat:6, tie:[three, two]}; } if(flush){ return {cat:5, tie: flush.map(c=>c.r)}; } const highSt=getStraight(ranks); if(highSt){ return {cat:4, tie:[highSt]}; } if(trips.length){ const kickers=ranks.filter(r=> r!==trips[0]).slice(0,2); return {cat:3, tie:[trips[0], ...kickers]}; } if(pairs.length>=2){ const [p1,p2]=pairs.slice(0,2); const kicker=ranks.find(r=> r!==p1 && r!==p2); return {cat:2, tie:[p1,p2,kicker]}; } if(pairs.length===1){ const p=pairs[0]; const kickers=ranks.filter(r=> r!==p).slice(0,3); return {cat:1, tie:[p, ...kickers]}; } return {cat:0, tie:ranks.slice(0,5)}; }
+  function compareEval(a,b){ if(a.cat!==b.cat) return a.cat-b.cat; const len=Math.max(a.tie.length,b.tie.length); for(let i=0;i<len;i++){ const ai=a.tie[i]||0, bi=b.tie[i]||0; if(ai!==bi) return ai-bi; } return 0; }
+  function showdown(){ state.stage='showdown'; renderAll(); const alive=activePlayers(); let best=null, winners=[]; alive.forEach(p=>{ const score=evaluateBest5([...state.community, ...p.hand]); p._score=score; if(!best || compareEval(score,best)<0){ best=score; winners=[p]; } else if(compareEval(score,best)===0){ winners.push(p); } }); const share=Math.floor(state.pot/Math.max(1,winners.length)); winners.forEach(p=> p.chips+=share); const names=winners.map(p=> p.isHuman? 'You' : p.name).join(', '); addLog(`<b>Showdown</b> → Winner: <b>${names}</b> (${handName(best)}) and gets ${share} each.`); toast(`Winner: ${names}! ${handName(best)}`); win(); state.dealerIndex=(state.dealerIndex+1)%N_PLAYERS; updatePot(); layoutSeats(); }
+  function handName(ev){ const map=['High Card','Pair','Two Pair','Three of a Kind','Straight','Flush','Full House','Four of a Kind','Straight Flush']; return map[ev.cat]; }
+
+  function promptTurn(){ if(state.stage==='showdown' || state.stage==='idle') return; const alive=activePlayers(); if(alive.length<=1){ showdown(); return; } const needAction=alive.some(p=> p.committed!==state.currentBet); if(!needAction && state.currentBet>0){ nextStage(); return; } const p=state.players[state.currentIndex]; if(p.folded || !p.inRound){ advanceTurn(); return; } if(p.isHuman){ toast(`Your turn${state.pendingBet>0? ' – pending: '+state.pendingBet: ''}`); return; } setTimeout(()=>{ const strength=estimateStrength(p); const toCall=state.currentBet - p.committed; let action='check'; if(toCall>0){ if(strength>0.55 || Math.random()<0.75){ betFrom(idxOf(p), toCall); action='call'; } else { p.folded=true; action='fold'; foldS(); } } else { if(Math.random()<0.15 && p.chips>=state.minBet){ betFrom(idxOf(p), state.minBet); state.currentBet=Math.max(state.currentBet, p.committed); action='bet'; } else { checkS(); } } addLog(`<b>${p.name}</b>: ${action.toUpperCase()}`); renderAll(); advanceTurn(); }, 600); }
+  function advanceTurn(){ do{ state.currentIndex=(state.currentIndex+1)%N_PLAYERS; if(state.stage==='preflop' && state.currentIndex===(state.dealerIndex+3)%N_PLAYERS) break; } while(state.players[state.currentIndex].folded); const alive=activePlayers(); const allMatched=alive.every(p=> p.committed===state.currentBet); if(allMatched){ nextStage(); } else { promptTurn(); } }
+  function idxOf(p){ return state.players.indexOf(p); }
+  function estimateStrength(p){ const score=evaluateBest5([...state.community, ...p.hand]); const catWeight=[0.1,0.25,0.35,0.48,0.62,0.72,0.85,0.94,0.98][score.cat]; const high=Math.max(...p.hand.map(c=>c.r)); const bonus=(high-10)/10*0.12; return Math.min(1, Math.max(0, catWeight+bonus)); }
+
+  // Bet rack logic
+  function renderRack(){ betRackEl.innerHTML=''; const palette=['#fef08a','#93c5fd','#fca5a5','#c4b5fd','#86efac','#fda4af']; DENOMS.forEach((v,i)=>{ const rc=document.createElement('div'); rc.className='rack-chip'; rc.style.background = palette[i%palette.length]; rc.textContent=v; rc.addEventListener('click', ()=>{ addPendingBet(v); }); betRackEl.appendChild(rc); }); const info = document.createElement('div'); info.className='rack-chip'; info.style.background='#fff'; info.style.fontSize='11px'; info.textContent = `Bet: ${state.pendingBet}`; betRackEl.appendChild(info); }
+  function addPendingBet(v){ state.pendingBet += v; chips(); renderRack(); }
+  function clearPending(){ state.pendingBet = 0; renderRack(); }
+  function confirmBet(){ const me = state.players.find(p=>p.isHuman); if(state.stage==='idle' || !me || me.folded) return; const toCall = Math.max(0, state.currentBet - me.committed); let total = state.pendingBet; if(state.currentBet===0 && total===0){ total = state.minBet; } const place = toCall + total; if(place<=0) return; betFrom(idxOf(me), place); state.currentBet = Math.max(state.currentBet, me.committed); addLog(`<b>You</b>: BET ${place}`); state.pendingBet = 0; renderRack(); renderAll(); advanceTurn(); }
+
+  // Buttons
+  el('#newHand').addEventListener('click', ()=>{ if(state.players.every(p=>p.chips<=0)) initPlayers(); newHand(); });
+  el('#nextStage').addEventListener('click', ()=>{ if(state.stage==='idle'){ toast('Hit New Hand first'); return; } nextStage(); });
+  el('#checkCall').addEventListener('click', ()=>{ const me=state.players.find(p=>p.isHuman); if(state.stage==='idle'||!me||me.folded) return; const toCall=state.currentBet - me.committed; if(toCall>0){ betFrom(idxOf(me), toCall); addLog('<b>You</b>: CALL'); } else { addLog('<b>You</b>: CHECK'); checkS(); } renderAll(); advanceTurn(); });
+  el('#bet').addEventListener('click', confirmBet);
+  el('#clearBet').addEventListener('click', ()=>{ clearPending(); addLog('<b>You</b>: Clear pending bet'); });
+  el('#fold').addEventListener('click', ()=>{ const me=state.players.find(p=>p.isHuman); if(state.stage==='idle'||!me||me.folded) return; me.folded=true; addLog('<b>You</b>: FOLD'); foldS(); renderAll(); advanceTurn(); });
+  el('#sound').addEventListener('click', ()=>{ soundOn=!soundOn; if(soundOn) ensureAudio(); el('#sound').textContent = (soundOn? '🔊 Sound: On' : '🔇 Sound: Off'); });
+  el('#fullscreen').addEventListener('click', ()=>{ const root = document.documentElement; const anyDoc = /** @type {any} */(document); if(!document.fullscreenElement){ (root.requestFullscreen||root.webkitRequestFullscreen||root.msRequestFullscreen).call(root); } else { (anyDoc.exitFullscreen||anyDoc.webkitExitFullscreen||anyDoc.msExitFullscreen).call(document); } });
+
+  function initPlayers(){
+    const pool=[];
+    const self = userAvatar.startsWith('http')||userAvatar.startsWith('/') ? {name:'You', photo:userAvatar, isHuman:true} : {name:'You', emoji:userAvatar, isHuman:true};
+    pool.push(self);
+    if(mode==='online' && avatarsParam){
+      avatarsParam.split(',').forEach(a=>{
+        if(!a) return; const [photo,name] = a.split('|');
+        pool.push({name: name||'Player', photo});
+      });
+    } else {
+      let flags = ['🇺🇸','🇬🇧','🇨🇦','🇦🇺','🇮🇹'];
+      if(avatarsParam && avatarsParam!=='flags') flags = avatarsParam.split(',');
+      flags.forEach(f=> pool.push({name: flagName(f), emoji:f}));
+    }
+    state.players = pool.slice(0,N_PLAYERS).map(p=> ({...p, chips: 1000, hand:[], folded:false, inRound:true, committed:0}));
+    state.dealerIndex = 0;
+  }
+  function renderAll(){ renderCommunity(); layoutSeats(); updatePot(); }
+
+  // boot
+  initPlayers(); renderAll(); renderRack(); addLog('Ready! Tap <b>New Hand</b>. Chips sit under cards; click rack chips to build your raise, then <b>Confirm Bet</b>.');
+})();
+</script></body>
+</html>

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -36,6 +36,8 @@ import BubblePopRoyale from './pages/Games/BubblePopRoyale.jsx';
 import BubblePopRoyaleLobby from './pages/Games/BubblePopRoyaleLobby.jsx';
 import BubbleSmashRoyale from './pages/Games/BubbleSmashRoyale.jsx';
 import BubbleSmashRoyaleLobby from './pages/Games/BubbleSmashRoyaleLobby.jsx';
+import TexasHoldem from './pages/Games/TexasHoldem.jsx';
+import TexasHoldemLobby from './pages/Games/TexasHoldemLobby.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -75,6 +77,8 @@ export default function App() {
             <Route path="/games/bubblepoproyale" element={<BubblePopRoyale />} />
             <Route path="/games/bubblesmashroyale/lobby" element={<BubbleSmashRoyaleLobby />} />
             <Route path="/games/bubblesmashroyale" element={<BubbleSmashRoyale />} />
+            <Route path="/games/texasholdem/lobby" element={<TexasHoldemLobby />} />
+            <Route path="/games/texasholdem" element={<TexasHoldem />} />
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />
             <Route path="/tasks" element={<Tasks />} />

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -118,6 +118,18 @@ export default function Games() {
                     Bubble Pop Royale
                   </h3>
                 </Link>
+                <Link
+                  to="/games/texasholdem/lobby"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+                >
+                  <img src="/assets/icons/poker.svg" alt="" className="h-20 w-20" />
+                  <h3
+                    className="text-sm font-semibold text-center text-yellow-400"
+                    style={{ WebkitTextStroke: '1px black' }}
+                  >
+                    Texas Hold'em
+                  </h3>
+                </Link>
             </div>
           </div>
         </div>

--- a/webapp/src/pages/Games/TexasHoldem.jsx
+++ b/webapp/src/pages/Games/TexasHoldem.jsx
@@ -1,0 +1,16 @@
+import { useLocation } from 'react-router-dom';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+
+export default function TexasHoldem() {
+  useTelegramBackButton();
+  const { search } = useLocation();
+  return (
+    <div className="relative w-full h-screen">
+      <iframe
+        src={`/texas-holdem.html${search}`}
+        title="Texas Hold'em"
+        className="w-full h-full border-0"
+      />
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { ensureAccountId, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+
+const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
+const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
+const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
+
+export default function TexasHoldemLobby() {
+  const navigate = useNavigate();
+  useTelegramBackButton();
+
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [mode, setMode] = useState('local');
+  const [avatar, setAvatar] = useState('');
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  const startGame = async () => {
+    let tgId;
+    let accountId;
+    try {
+      accountId = await ensureAccountId();
+      const balRes = await getAccountBalance(accountId);
+      if ((balRes.balance || 0) < stake.amount) {
+        alert('Insufficient balance');
+        return;
+      }
+      tgId = getTelegramId();
+      await addTransaction(tgId, -stake.amount, 'stake', {
+        game: 'texasholdem',
+        accountId,
+      });
+    } catch {}
+
+    const params = new URLSearchParams();
+    params.set('mode', mode);
+    if (stake.token) params.set('token', stake.token);
+    if (stake.amount) params.set('amount', stake.amount);
+    if (avatar) params.set('avatar', avatar);
+    if (mode === 'local') params.set('avatars', 'flags');
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    const initData = window.Telegram?.WebApp?.initData;
+    if (initData) params.set('init', encodeURIComponent(initData));
+    if (DEV_ACCOUNT) params.set('dev', DEV_ACCOUNT);
+    if (DEV_ACCOUNT_1) params.set('dev1', DEV_ACCOUNT_1);
+    if (DEV_ACCOUNT_2) params.set('dev2', DEV_ACCOUNT_2);
+    navigate(`/games/texasholdem?${params.toString()}`);
+  };
+
+  return (
+    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+      <h2 className="text-xl font-bold text-center">Texas Hold'em Lobby</h2>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Stake</h3>
+        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Mode</h3>
+        <div className="flex gap-2">
+          {[{ id: 'local', label: 'Local (AI)' }, { id: 'online', label: 'Online' }].map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setMode(id)}
+              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <button
+        onClick={startGame}
+        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
+      >
+        START
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Texas Hold'em lobby with TPC stake selection and mode options
- include Texas Hold'em game with avatar support and flag-based AI opponents
- wire new game into router and games list with custom poker icon

## Testing
- `npm test` (fails: test timed out)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a01568b73c83298649d17dee289379