### PR TITLE
Add Pool Royale lobby and game stub

### DIFF
--- a/webapp/public/poolroyale/index.html
+++ b/webapp/public/poolroyale/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>8 Pool Royale</title>
+  <style>
+    body { margin:0; background:#0b1120; color:#fff; font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans"; }
+    #header { display:flex; justify-content:space-between; align-items:center; padding:8px 12px; background:#15203a; }
+    .player { display:flex; align-items:center; gap:8px; }
+    .avatar { width:36px; height:36px; border-radius:50%; background:#fff; color:#222; display:grid; place-items:center; font-weight:700; background-size:cover; }
+    #wrap { position:relative; width:100%; height:calc(100vh - 56px); }
+    canvas { background:#074120; width:100%; height:100%; display:block; }
+  </style>
+</head>
+<body>
+  <div id="header">
+    <div class="player"><div class="avatar" id="avatar1"></div><div class="name" id="name1"></div></div>
+    <div class="player"><div class="name" id="name2"></div><div class="avatar" id="avatar2"></div></div>
+  </div>
+  <div id="wrap">
+    <canvas id="table"></canvas>
+  </div>
+  <script type="text/javascript">
+  (function(){
+    var params=new URLSearchParams(location.search);
+    var pName=params.get('pname')||'Player';
+    var pAvatar=params.get('pavatar')||'';
+    var aiFlag=params.get('aiflag')||'🤖';
+    var aiName=params.get('ainame')||'CPU';
+    var variant=params.get('variant')||'8ball';
+    document.getElementById('name1').textContent=pName;
+    var av1=document.getElementById('avatar1');
+    if(pAvatar){
+      if(pAvatar.startsWith('http')||pAvatar.startsWith('/')){ av1.style.backgroundImage='url('+pAvatar+')'; av1.textContent=''; }
+      else{ av1.textContent=pAvatar; }
+    }
+    document.getElementById('avatar2').textContent=aiFlag;
+    document.getElementById('name2').textContent=aiName;
+    // Placeholder: game logic omitted for brevity.
+  })();
+  </script>
+</body>
+</html>

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -38,6 +38,8 @@ import BubbleSmashRoyale from './pages/Games/BubbleSmashRoyale.jsx';
 import BubbleSmashRoyaleLobby from './pages/Games/BubbleSmashRoyaleLobby.jsx';
 import MurlanRoyale from './pages/Games/MurlanRoyale.jsx';
 import MurlanRoyaleLobby from './pages/Games/MurlanRoyaleLobby.jsx';
+import PoolRoyale from './pages/Games/PoolRoyale.jsx';
+import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -79,6 +81,8 @@ export default function App() {
             <Route path="/games/bubblesmashroyale" element={<BubbleSmashRoyale />} />
             <Route path="/games/murlanroyale/lobby" element={<MurlanRoyaleLobby />} />
             <Route path="/games/murlanroyale" element={<MurlanRoyale />} />
+            <Route path="/games/poolroyale/lobby" element={<PoolRoyaleLobby />} />
+            <Route path="/games/poolroyale" element={<PoolRoyale />} />
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />
             <Route path="/tasks" element={<Tasks />} />

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -130,6 +130,18 @@ export default function Games() {
                     Murlan Royale
                   </h3>
                 </Link>
+                <Link
+                  to="/games/poolroyale/lobby"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+                >
+                  <span className="text-4xl" role="img" aria-label="8 ball">🎱</span>
+                  <h3
+                    className="text-sm font-semibold text-center text-yellow-400"
+                    style={{ WebkitTextStroke: '1px black' }}
+                  >
+                    8 Pool Royale
+                  </h3>
+                </Link>
             </div>
           </div>
         </div>

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1,0 +1,12 @@
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+
+export default function PoolRoyale() {
+  useTelegramBackButton();
+  const params = new URLSearchParams(window.location.search);
+  const src = `/poolroyale/index.html?${params.toString()}`;
+  return (
+    <div className="w-full h-full">
+      <iframe src={src} title="8 Pool Royale" className="w-full h-screen border-0" />
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -1,0 +1,114 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import TableSelector from '../../components/TableSelector.jsx';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { pingOnline, getOnlineCount, getAccountBalance, addTransaction } from '../../utils/api.js';
+import { ensureAccountId, getTelegramId, getTelegramFirstName, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import { loadAvatar, avatarToName } from '../../utils/avatarUtils.js';
+import { getAIOpponentFlag } from '../../utils/aiOpponentFlag.js';
+
+export default function PoolRoyaleLobby() {
+  const navigate = useNavigate();
+  useTelegramBackButton();
+
+  const TABLES = [
+    { id: 'single', label: 'Single Player vs AI', capacity: 1 },
+    { id: '1v1', label: '1v1 Online', capacity: 2 }
+  ];
+
+  const [table, setTable] = useState(TABLES[0]);
+  const [variant, setVariant] = useState('8ball');
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [online, setOnline] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    let id;
+    ensureAccountId()
+      .then(accountId => {
+        if (cancelled || !accountId) return;
+        function ping() {
+          const status = localStorage.getItem('onlineStatus') || 'online';
+          pingOnline(accountId, status).catch(() => {});
+          getOnlineCount().then(d => setOnline(d.count)).catch(() => {});
+        }
+        ping();
+        id = setInterval(ping, 30000);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+      if (id) clearInterval(id);
+    };
+  }, []);
+
+  const startGame = async () => {
+    let tgId;
+    let accountId;
+    try {
+      accountId = await ensureAccountId();
+      const balRes = await getAccountBalance(accountId);
+      if ((balRes.balance || 0) < stake.amount) {
+        alert('Insufficient balance');
+        return;
+      }
+      tgId = getTelegramId();
+      await addTransaction(tgId, -stake.amount, 'stake', {
+        game: 'poolroyale',
+        players: 2,
+        accountId
+      });
+    } catch {}
+
+    const params = new URLSearchParams();
+    params.set('variant', variant);
+    if (stake.token) params.set('token', stake.token);
+    if (stake.amount) params.set('amount', stake.amount);
+    const name = getTelegramFirstName() || 'Player';
+    params.set('pname', name);
+    const avatar = loadAvatar() || getTelegramPhotoUrl() || '';
+    if (avatar) params.set('pavatar', avatar);
+    if (table.id === 'single') {
+      params.set('mode', 'ai');
+      const flag = getAIOpponentFlag(avatar);
+      params.set('aiflag', flag);
+      params.set('ainame', avatarToName(flag));
+    } else {
+      params.set('mode', 'online');
+    }
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    navigate(`/games/poolroyale?${params.toString()}`);
+  };
+
+  const disabled = !stake.token || !stake.amount || !table || !variant;
+
+  return (
+    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+      <h2 className="text-xl font-bold text-center">8 Pool Royale Lobby</h2>
+      <p className="text-center text-sm">Online users: {online}</p>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Select Mode</h3>
+        <TableSelector tables={TABLES} selected={table} onSelect={setTable} />
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Game Variant</h3>
+        <div className="flex gap-2">
+          {[{id:'8ball',label:'8 Ball'},{id:'9ball',label:'9 Ball'}].map(v => (
+            <button key={v.id} onClick={()=>setVariant(v.id)} className={`lobby-tile ${variant===v.id ? 'lobby-selected' : ''}`}>
+              {v.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Select Stake</h3>
+        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+      </div>
+      <button onClick={startGame} disabled={disabled} className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded disabled:opacity-50">
+        Start Game
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Pool Royale lobby supporting TPC stakes, 1v1 vs AI or online, and 8/9 ball selection
- link Pool Royale in main games page and routing
- include placeholder Pool Royale game page parsing player avatars, names and AI flags

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a07657fe9c8329bbfdef1305dec638