### PR TITLE
feat: add background image for Murlan Royale

### DIFF
--- a/webapp/public/murlan-royale.html
+++ b/webapp/public/murlan-royale.html
@@ -18,7 +18,7 @@
     html,body{height:100%;margin:0}
     body{
       font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
-      background: radial-gradient(1200px 900px at 50% -10%, #1a2545 0, #0c1020 60%, #070a16 100%);
+      background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat;
       color:#fff; overflow:hidden; height:100vh; width:100vw;
     }
 


### PR DESCRIPTION
## Summary
- use uploaded graphic as full-screen backdrop for Murlan Royale page

## Testing
- `npm test` (fails: snake API endpoints and socket events)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a07a2aa0b48329bae4bf44edacd569