### PR TITLE
feat: add pinch zoom for player hand

### DIFF
--- a/webapp/public/murlan-royale.html
+++ b/webapp/public/murlan-royale.html
@@ -10,6 +10,7 @@
       --gold:#f5cc4e; --ui:#2563eb; --ui2:#0ea5e9;
       --card-scale:1;
       --avatar-scale:1;
+      --my-card-scale:1;
       --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale));
       --card-h: calc(var(--card-w)*1.45);
       --avatar-size: calc(54px * var(--avatar-scale));
@@ -52,6 +53,7 @@
     .seat.active .avatar{ border-color:var(--ui2); box-shadow:0 0 10px var(--ui2); }
     .seat.left .cards{ transform:rotate(90deg); transform-origin:center; }
     .seat.right .cards{ transform:rotate(-90deg); transform-origin:center; }
+    .seat.bottom .cards{ touch-action:none; transform:scale(var(--my-card-scale)); transform-origin:center bottom; }
 
     /* CARDS */
     .cards{ display:flex; gap:6px; flex-wrap:nowrap }
@@ -119,6 +121,43 @@
   const sndChip = el('#sndChip');
   const sndCard = el('#sndCard');
   const sndTimer = el('#sndTimer');
+
+  let userScale = 1;
+  let userAdjusted = false;
+  let pinchStartDist = null;
+  let pinchStartScale = 1;
+
+  function pinchDistance(touches){
+    const [a,b] = touches;
+    return Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+  }
+
+  function setupZoom(){
+    const hand = document.querySelector('.seat.bottom .cards');
+    if(!hand) return;
+    hand.addEventListener('touchstart', e => {
+      if(e.touches.length === 2){
+        pinchStartDist = pinchDistance(e.touches);
+        pinchStartScale = userScale;
+      }
+    }, {passive:false});
+    hand.addEventListener('touchmove', e => {
+      if(e.touches.length === 2 && pinchStartDist){
+        e.preventDefault();
+        const dist = pinchDistance(e.touches);
+        let scale = pinchStartScale * (dist / pinchStartDist);
+        scale = Math.max(0.5, Math.min(scale, 3));
+        userScale = scale;
+        userAdjusted = true;
+        document.documentElement.style.setProperty('--my-card-scale', scale.toFixed(2));
+      }
+    }, {passive:false});
+    hand.addEventListener('touchend', e => {
+      if(e.touches.length < 2){
+        pinchStartDist = null;
+      }
+    });
+  }
 
   function toast(msg){ toastEl.textContent = msg; toastEl.style.display='block'; setTimeout(()=> toastEl.style.display='none', 1400); }
 
@@ -286,19 +325,29 @@
   }
 
   function adjustHandScale(){
+    if(userAdjusted) return;
     const hand = document.querySelector('.seat.bottom .cards');
     if(!hand) return;
     const screen = window.innerWidth - 20;
-    const rect = hand.getBoundingClientRect();
-    if(rect.width > screen){
-      const scale = screen / rect.width;
-      document.documentElement.style.setProperty('--card-scale', scale.toFixed(2));
+    const natural = hand.scrollWidth;
+    if(natural > screen){
+      const scale = screen / natural;
+      userScale = scale;
+      document.documentElement.style.setProperty('--my-card-scale', scale.toFixed(2));
     } else {
-      document.documentElement.style.setProperty('--card-scale', 1);
+      userScale = 1;
+      document.documentElement.style.setProperty('--my-card-scale', 1);
     }
   }
 
-  function renderAll(){ posSeats(); renderPile(); potEl.textContent = `Pot: ${state.pot}`; updateTimerDisplay(); adjustHandScale(); }
+  function renderAll(){
+    posSeats();
+    renderPile();
+    potEl.textContent = `Pot: ${state.pot}`;
+    updateTimerDisplay();
+    adjustHandScale();
+    setupZoom();
+  }
 
   let timerInterval;
   function updateTimerDisplay(){


### PR DESCRIPTION
## Summary
- keep opponent and center card sizes constant
- allow user to pinch zoom their own hand
- isolate user card scaling from table cards

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_68a07e510244832992002c2584c20eb0