### PR TITLE
Fix Poll Royale background behavior and assets

### DIFF
--- a/webapp/public/assets/icons/white_ball.svg
+++ b/webapp/public/assets/icons/white_ball.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <circle cx="32" cy="32" r="28" fill="#5aa2ff" stroke="#000" stroke-width="4"/>
+  <circle cx="32" cy="32" r="28" fill="#ffffff" stroke="#000" stroke-width="4"/>
   <circle cx="22" cy="22" r="8" fill="#ffffff" fill-opacity="0.6"/>
   <circle cx="18" cy="18" r="3" fill="#ffffff" fill-opacity="0.6"/>
 </svg>

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -80,6 +80,7 @@
       right: var(--rpw);
       z-index: 4;
       background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp') center/cover no-repeat;
+      background-attachment: fixed;
       transform-origin: center;
     }
 
@@ -106,7 +107,7 @@
       width: 36px;
       height: 36px;
       border-radius: 50%;
-      background: #f6f6f6;
+      background: url('/assets/icons/white_ball.svg') center/cover no-repeat;
       position: relative;
       box-shadow: 0 4px 10px rgba(0,0,0,.4) inset,
                   0 0 0 2px rgba(0,0,0,.15);
@@ -130,7 +131,7 @@
       width: 96px;
       height: 58%;
       border-radius: 14px;
-      background: linear-gradient(180deg, rgba(0,0,0,.18), rgba(0,0,0,.28));
+      background: none;
       box-shadow: inset 0 0 0 1px rgba(255,255,255,.05),
                   0 8px 24px rgba(0,0,0,.35);
       display: flex;


### PR DESCRIPTION
## Summary
- Keep Poll Royale table background fixed during field calibration
- Use transparent white ball icon and remove pull area background

## Testing
- `npm test` *(fails: Failed to delete existing webhook / launch Telegram bot)*
- `npm run lint` *(fails: ESLint reported 151 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ac33db088329b0f6a0b2e1d8d3c4