### PR TITLE
Add Texas Hold'em poker game

### DIFF
--- a/lib/texasHoldem.js
+++ b/lib/texasHoldem.js
@@ -1,0 +1,185 @@
+// Basic Texas Hold'em poker logic with simple AI
+// Card representation: { rank: 'A', suit: 'S' }
+
+export const RANKS = ['2','3','4','5','6','7','8','9','T','J','Q','K','A'];
+export const SUITS = ['H','D','C','S'];
+
+export function createDeck(){
+  const deck=[];
+  for(const r of RANKS){
+    for(const s of SUITS){
+      deck.push({rank:r,suit:s});
+    }
+  }
+  return deck;
+}
+
+export function shuffle(deck){
+  const d=[...deck];
+  for(let i=d.length-1;i>0;i--){
+    const j=Math.floor(Math.random()*(i+1));
+    [d[i],d[j]]=[d[j],d[i]];
+  }
+  return d;
+}
+
+export function dealHoleCards(deck, players){
+  const d=[...deck];
+  const hands=Array.from({length:players},()=>[]);
+  for(let r=0;r<2;r++){
+    for(let p=0;p<players;p++){
+      hands[p].push(d.pop());
+    }
+  }
+  return {hands, deck:d};
+}
+
+export function dealCommunity(deck){
+  const d=[...deck];
+  const burn=()=>d.pop();
+  burn();
+  const flop=[d.pop(),d.pop(),d.pop()];
+  burn();
+  const turn=[d.pop()];
+  burn();
+  const river=[d.pop()];
+  return {community:[...flop,...turn,...river], deck:d};
+}
+
+function rankValue(r){
+  return RANKS.indexOf(r)+2;
+}
+
+function countRanks(cards){
+  const counts={};
+  for(const c of cards) counts[c.rank]=(counts[c.rank]||0)+1;
+  return counts;
+}
+
+function isFlush(cards){
+  return cards.every(c=>c.suit===cards[0].suit);
+}
+
+function isStraight(values){
+  const v=[...new Set(values)].sort((a,b)=>a-b);
+  if(v.length<5) return false;
+  for(let i=0;i<=v.length-5;i++){
+    let ok=true;
+    for(let j=1;j<5;j++) if(v[i+j]!==v[i]+j) {ok=false;break;}
+    if(ok) return v[i+4];
+  }
+  // special wheel straight (A-2-3-4-5)
+  if(v.includes(14)&&v.slice(0,4).join()==='2,3,4,5') return 5;
+  return false;
+}
+
+function evaluate5(cards){
+  const values=cards.map(c=>rankValue(c.rank)).sort((a,b)=>b-a);
+  const counts=countRanks(cards);
+  const freq=Object.values(counts).sort((a,b)=>b-a);
+  const straightHigh=isStraight(values);
+  const flush=isFlush(cards);
+  let rank=0; let tiebreak=[];
+  if(straightHigh && flush){
+    rank=8; tiebreak=[straightHigh];
+  }else if(freq[0]===4){
+    rank=7;
+    const four=Object.keys(counts).find(r=>counts[r]===4);
+    const kicker=Object.keys(counts).find(r=>counts[r]===1);
+    tiebreak=[rankValue(four), rankValue(kicker)];
+  }else if(freq[0]===3 && freq[1]===2){
+    rank=6;
+    const triple=Object.keys(counts).find(r=>counts[r]===3);
+    const pair=Object.keys(counts).find(r=>counts[r]===2);
+    tiebreak=[rankValue(triple), rankValue(pair)];
+  }else if(flush){
+    rank=5; tiebreak=values;
+  }else if(straightHigh){
+    rank=4; tiebreak=[straightHigh];
+  }else if(freq[0]===3){
+    rank=3;
+    const triple=Object.keys(counts).find(r=>counts[r]===3);
+    const kickers=Object.keys(counts).filter(r=>counts[r]===1).sort((a,b)=>rankValue(b)-rankValue(a));
+    tiebreak=[rankValue(triple), ...kickers.map(rankValue)];
+  }else if(freq[0]===2 && freq[1]===2){
+    rank=2;
+    const pairs=Object.keys(counts).filter(r=>counts[r]===2).sort((a,b)=>rankValue(b)-rankValue(a));
+    const kicker=Object.keys(counts).find(r=>counts[r]===1);
+    tiebreak=[...pairs.map(rankValue), rankValue(kicker)];
+  }else if(freq[0]===2){
+    rank=1;
+    const pair=Object.keys(counts).find(r=>counts[r]===2);
+    const kickers=Object.keys(counts).filter(r=>counts[r]===1).sort((a,b)=>rankValue(b)-rankValue(a));
+    tiebreak=[rankValue(pair), ...kickers.map(rankValue)];
+  }else{
+    rank=0; tiebreak=values;
+  }
+  return {rank, tiebreak};
+}
+
+function combinations(cards, k){
+  const res=[]; const n=cards.length;
+  function rec(start,combo){
+    if(combo.length===k){res.push([...combo]); return;}
+    for(let i=start;i<n;i++){
+      combo.push(cards[i]);
+      rec(i+1,combo);
+      combo.pop();
+    }
+  }
+  rec(0,[]);
+  return res;
+}
+
+export function bestHand(cards){
+  let best=null;
+  for(const c of combinations(cards,5)){
+    const e=evaluate5(c);
+    if(!best||e.rank>best.rank|| (e.rank===best.rank && compareTiebreak(e.tiebreak,best.tiebreak)>0)){
+      best=e;
+    }
+  }
+  return best;
+}
+
+function compareTiebreak(a,b){
+  for(let i=0;i<Math.max(a.length,b.length);i++){
+    const av=a[i]||0, bv=b[i]||0;
+    if(av!==bv) return av-bv;
+  }
+  return 0;
+}
+
+export function compareHands(aCards,bCards){
+  const a=bestHand(aCards);
+  const b=bestHand(bCards);
+  if(a.rank!==b.rank) return a.rank-b.rank;
+  return compareTiebreak(a.tiebreak,b.tiebreak);
+}
+
+export function evaluateWinner(players, community){
+  let best=-Infinity, winner=null;
+  players.forEach((p,i)=>{
+    const score=bestHand([...p.hand,...community]);
+    if(score.rank>best || (score.rank===best && compareTiebreak(score.tiebreak,winner?.score.tiebreak)>0)){
+      best=score.rank; winner={index:i, score};
+    } else if(score.rank===winner?.score.rank && compareTiebreak(score.tiebreak,winner.score.tiebreak)===0){
+      winner=null; // tie
+    }
+  });
+  return winner;
+}
+
+export function aiChooseAction(hand, community=[]){
+  const stage=community.length; //0 preflop,3 flop,4 turn,5 river
+  const score=bestHand([...hand,...community]);
+  // very naive thresholds
+  if(stage<3){
+    // preflop
+    const hv=hand.map(c=>rankValue(c.rank)).sort((a,b)=>b-a);
+    if(hv[0]>=12 || hv[0]===hv[1]) return 'call';
+    return 'fold';
+  }
+  if(score.rank>=1) return 'call';
+  return 'fold';
+}

--- a/webapp/public/assets/icons/texas-holdem.svg
+++ b/webapp/public/assets/icons/texas-holdem.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="10" y="10" width="80" height="80" rx="10" ry="10" fill="white" stroke="black" stroke-width="5"/>
+  <text x="50" y="65" font-size="60" text-anchor="middle">♥</text>
+</svg>

--- a/webapp/public/lib/texasHoldem.js
+++ b/webapp/public/lib/texasHoldem.js
@@ -1,0 +1,185 @@
+// Basic Texas Hold'em poker logic with simple AI
+// Card representation: { rank: 'A', suit: 'S' }
+
+export const RANKS = ['2','3','4','5','6','7','8','9','T','J','Q','K','A'];
+export const SUITS = ['H','D','C','S'];
+
+export function createDeck(){
+  const deck=[];
+  for(const r of RANKS){
+    for(const s of SUITS){
+      deck.push({rank:r,suit:s});
+    }
+  }
+  return deck;
+}
+
+export function shuffle(deck){
+  const d=[...deck];
+  for(let i=d.length-1;i>0;i--){
+    const j=Math.floor(Math.random()*(i+1));
+    [d[i],d[j]]=[d[j],d[i]];
+  }
+  return d;
+}
+
+export function dealHoleCards(deck, players){
+  const d=[...deck];
+  const hands=Array.from({length:players},()=>[]);
+  for(let r=0;r<2;r++){
+    for(let p=0;p<players;p++){
+      hands[p].push(d.pop());
+    }
+  }
+  return {hands, deck:d};
+}
+
+export function dealCommunity(deck){
+  const d=[...deck];
+  const burn=()=>d.pop();
+  burn();
+  const flop=[d.pop(),d.pop(),d.pop()];
+  burn();
+  const turn=[d.pop()];
+  burn();
+  const river=[d.pop()];
+  return {community:[...flop,...turn,...river], deck:d};
+}
+
+function rankValue(r){
+  return RANKS.indexOf(r)+2;
+}
+
+function countRanks(cards){
+  const counts={};
+  for(const c of cards) counts[c.rank]=(counts[c.rank]||0)+1;
+  return counts;
+}
+
+function isFlush(cards){
+  return cards.every(c=>c.suit===cards[0].suit);
+}
+
+function isStraight(values){
+  const v=[...new Set(values)].sort((a,b)=>a-b);
+  if(v.length<5) return false;
+  for(let i=0;i<=v.length-5;i++){
+    let ok=true;
+    for(let j=1;j<5;j++) if(v[i+j]!==v[i]+j) {ok=false;break;}
+    if(ok) return v[i+4];
+  }
+  // special wheel straight (A-2-3-4-5)
+  if(v.includes(14)&&v.slice(0,4).join()==='2,3,4,5') return 5;
+  return false;
+}
+
+function evaluate5(cards){
+  const values=cards.map(c=>rankValue(c.rank)).sort((a,b)=>b-a);
+  const counts=countRanks(cards);
+  const freq=Object.values(counts).sort((a,b)=>b-a);
+  const straightHigh=isStraight(values);
+  const flush=isFlush(cards);
+  let rank=0; let tiebreak=[];
+  if(straightHigh && flush){
+    rank=8; tiebreak=[straightHigh];
+  }else if(freq[0]===4){
+    rank=7;
+    const four=Object.keys(counts).find(r=>counts[r]===4);
+    const kicker=Object.keys(counts).find(r=>counts[r]===1);
+    tiebreak=[rankValue(four), rankValue(kicker)];
+  }else if(freq[0]===3 && freq[1]===2){
+    rank=6;
+    const triple=Object.keys(counts).find(r=>counts[r]===3);
+    const pair=Object.keys(counts).find(r=>counts[r]===2);
+    tiebreak=[rankValue(triple), rankValue(pair)];
+  }else if(flush){
+    rank=5; tiebreak=values;
+  }else if(straightHigh){
+    rank=4; tiebreak=[straightHigh];
+  }else if(freq[0]===3){
+    rank=3;
+    const triple=Object.keys(counts).find(r=>counts[r]===3);
+    const kickers=Object.keys(counts).filter(r=>counts[r]===1).sort((a,b)=>rankValue(b)-rankValue(a));
+    tiebreak=[rankValue(triple), ...kickers.map(rankValue)];
+  }else if(freq[0]===2 && freq[1]===2){
+    rank=2;
+    const pairs=Object.keys(counts).filter(r=>counts[r]===2).sort((a,b)=>rankValue(b)-rankValue(a));
+    const kicker=Object.keys(counts).find(r=>counts[r]===1);
+    tiebreak=[...pairs.map(rankValue), rankValue(kicker)];
+  }else if(freq[0]===2){
+    rank=1;
+    const pair=Object.keys(counts).find(r=>counts[r]===2);
+    const kickers=Object.keys(counts).filter(r=>counts[r]===1).sort((a,b)=>rankValue(b)-rankValue(a));
+    tiebreak=[rankValue(pair), ...kickers.map(rankValue)];
+  }else{
+    rank=0; tiebreak=values;
+  }
+  return {rank, tiebreak};
+}
+
+function combinations(cards, k){
+  const res=[]; const n=cards.length;
+  function rec(start,combo){
+    if(combo.length===k){res.push([...combo]); return;}
+    for(let i=start;i<n;i++){
+      combo.push(cards[i]);
+      rec(i+1,combo);
+      combo.pop();
+    }
+  }
+  rec(0,[]);
+  return res;
+}
+
+export function bestHand(cards){
+  let best=null;
+  for(const c of combinations(cards,5)){
+    const e=evaluate5(c);
+    if(!best||e.rank>best.rank|| (e.rank===best.rank && compareTiebreak(e.tiebreak,best.tiebreak)>0)){
+      best=e;
+    }
+  }
+  return best;
+}
+
+function compareTiebreak(a,b){
+  for(let i=0;i<Math.max(a.length,b.length);i++){
+    const av=a[i]||0, bv=b[i]||0;
+    if(av!==bv) return av-bv;
+  }
+  return 0;
+}
+
+export function compareHands(aCards,bCards){
+  const a=bestHand(aCards);
+  const b=bestHand(bCards);
+  if(a.rank!==b.rank) return a.rank-b.rank;
+  return compareTiebreak(a.tiebreak,b.tiebreak);
+}
+
+export function evaluateWinner(players, community){
+  let best=-Infinity, winner=null;
+  players.forEach((p,i)=>{
+    const score=bestHand([...p.hand,...community]);
+    if(score.rank>best || (score.rank===best && compareTiebreak(score.tiebreak,winner?.score.tiebreak)>0)){
+      best=score.rank; winner={index:i, score};
+    } else if(score.rank===winner?.score.rank && compareTiebreak(score.tiebreak,winner.score.tiebreak)===0){
+      winner=null; // tie
+    }
+  });
+  return winner;
+}
+
+export function aiChooseAction(hand, community=[]){
+  const stage=community.length; //0 preflop,3 flop,4 turn,5 river
+  const score=bestHand([...hand,...community]);
+  // very naive thresholds
+  if(stage<3){
+    // preflop
+    const hv=hand.map(c=>rankValue(c.rank)).sort((a,b)=>b-a);
+    if(hv[0]>=12 || hv[0]===hv[1]) return 'call';
+    return 'fold';
+  }
+  if(score.rank>=1) return 'call';
+  return 'fold';
+}

--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no" />
+  <title>Texas Hold'em Royale</title>
+  <style>
+    :root{
+      --shadow:rgba(0,0,0,.45);
+      --card-scale:1; --avatar-scale:1;
+      --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale));
+      --card-h: calc(var(--card-w)*1.45);
+      --avatar-size: calc(54px * var(--avatar-scale));
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%;margin:0}
+    body{
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+      color:#fff; overflow:hidden; height:100vh; width:100vw;
+    }
+    .stage{ position:relative; width:100vw; height:100vh; display:grid; place-items:center; perspective:1100px; }
+    .stage::before{ content:""; position:absolute; inset:0; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
+    .center{ position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2 }
+    .community .card{ width:var(--card-w); height:var(--card-h); background:#fff; border-radius:6px; display:grid; place-items:center; color:#000; }
+    .seats{ position:absolute; inset:0; z-index:2 }
+    .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px) }
+    .avatar{ width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%, #fff, #ddd 40%, #bbb 60%, #999 100%); color:#111; font-size:28px; border:4px solid rgba(255,255,255,.65); box-shadow:0 8px 20px var(--shadow); }
+    .cards{ display:flex; gap:4px; }
+    .card{ width:var(--card-w); height:var(--card-h); background:#fff; border-radius:6px; display:grid; place-items:center; color:#000; }
+    .card.back{ background:#444 }
+    #ai-seat{ top:10%; left:50%; transform:translateX(-50%); }
+    #player-seat{ bottom:10%; left:50%; transform:translateX(-50%); }
+    #status{ position:absolute; top:50%; left:50%; transform:translate(-50%, -50%); font-weight:900; letter-spacing:.3px; color:#ffeaa7; background:rgba(0,0,0,.28); padding:6px 12px; border-radius:12px; border:1px solid rgba(255,255,255,.12); text-shadow:0 2px 6px #000 }
+  </style>
+</head>
+<body>
+  <div class="stage">
+    <div class="center community" id="community"></div>
+    <div class="seats">
+      <div class="seat" id="ai-seat">
+        <div class="avatar">AI</div>
+        <div class="cards" id="ai-cards"></div>
+        <div class="name">AI</div>
+      </div>
+      <div class="seat" id="player-seat">
+        <div class="avatar">You</div>
+        <div class="cards" id="player-cards"></div>
+        <div class="name">You</div>
+      </div>
+    </div>
+    <div id="status"></div>
+  </div>
+  <script type="module" src="/texas-holdem.js"></script>
+</body>
+</html>

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -1,0 +1,67 @@
+import { createDeck, shuffle, dealHoleCards, dealCommunity, evaluateWinner, aiChooseAction, bestHand } from './lib/texasHoldem.js';
+
+const state={};
+function init(){
+  const deck=shuffle(createDeck());
+  const {hands, deck:rest}=dealHoleCards(deck,2);
+  state.players=[{name:'You', hand:hands[0]},{name:'AI', hand:hands[1]}];
+  const comm=dealCommunity(rest);
+  state.community=comm.community;
+  state.stage=0;
+  renderHands();
+  setTimeout(()=>revealFlop(),500);
+}
+
+function cardEl(card){
+  const div=document.createElement('div');
+  div.className='card';
+  div.textContent=card.rank+card.suit;
+  return div;
+}
+
+function renderHands(){
+  const pc=document.getElementById('player-cards');
+  pc.innerHTML='';
+  state.players[0].hand.forEach(c=>pc.appendChild(cardEl(c)));
+  const ai=document.getElementById('ai-cards');
+  ai.innerHTML='';
+  if(state.stage<5){
+    state.players[1].hand.forEach(()=>{
+      const b=document.createElement('div'); b.className='card back'; ai.appendChild(b);
+    });
+  }else{
+    state.players[1].hand.forEach(c=>ai.appendChild(cardEl(c)));
+  }
+}
+
+function revealFlop(){
+  state.stage=3;
+  const comm=document.getElementById('community');
+  for(let i=0;i<3;i++) comm.appendChild(cardEl(state.community[i]));
+  const aiAction=aiChooseAction(state.players[1].hand, state.community.slice(0,3));
+  document.getElementById('status').textContent=`AI ${aiAction}s`;
+  setTimeout(()=>revealTurn(),800);
+}
+
+function revealTurn(){
+  state.stage=4;
+  const comm=document.getElementById('community');
+  comm.appendChild(cardEl(state.community[3]));
+  setTimeout(()=>revealRiver(),800);
+}
+
+function revealRiver(){
+  state.stage=5;
+  const comm=document.getElementById('community');
+  comm.appendChild(cardEl(state.community[4]));
+  renderHands();
+  showdown();
+}
+
+function showdown(){
+  const winner=evaluateWinner(state.players, state.community);
+  const text= winner? `${state.players[winner.index].name} wins!` : 'Tie';
+  document.getElementById('status').textContent=text;
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -38,6 +38,8 @@ import BubbleSmashRoyale from './pages/Games/BubbleSmashRoyale.jsx';
 import BubbleSmashRoyaleLobby from './pages/Games/BubbleSmashRoyaleLobby.jsx';
 import MurlanRoyale from './pages/Games/MurlanRoyale.jsx';
 import MurlanRoyaleLobby from './pages/Games/MurlanRoyaleLobby.jsx';
+import TexasHoldem from './pages/Games/TexasHoldem.jsx';
+import TexasHoldemLobby from './pages/Games/TexasHoldemLobby.jsx';
 import PollRoyale from './pages/Games/PollRoyale.jsx';
 import PollRoyaleLobby from './pages/Games/PollRoyaleLobby.jsx';
 
@@ -79,6 +81,8 @@ export default function App() {
             <Route path="/games/bubblepoproyale" element={<BubblePopRoyale />} />
             <Route path="/games/bubblesmashroyale/lobby" element={<BubbleSmashRoyaleLobby />} />
             <Route path="/games/bubblesmashroyale" element={<BubbleSmashRoyale />} />
+            <Route path="/games/texasholdem/lobby" element={<TexasHoldemLobby />} />
+            <Route path="/games/texasholdem" element={<TexasHoldem />} />
             <Route path="/games/murlanroyale/lobby" element={<MurlanRoyaleLobby />} />
             <Route path="/games/murlanroyale" element={<MurlanRoyale />} />
             <Route path="/games/pollroyale/lobby" element={<PollRoyaleLobby />} />

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -131,6 +131,18 @@ export default function Games() {
                   </h3>
                 </Link>
                 <Link
+                  to="/games/texasholdem/lobby"
+                  className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+                >
+                  <img src="/assets/icons/texas-holdem.svg" alt="" className="h-20 w-20" />
+                  <h3
+                    className="text-sm font-semibold text-center text-yellow-400"
+                    style={{ WebkitTextStroke: '1px black' }}
+                  >
+                    Texas Hold'em
+                  </h3>
+                </Link>
+                <Link
                   to="/games/pollroyale/lobby"
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >

--- a/webapp/src/pages/Games/TexasHoldem.jsx
+++ b/webapp/src/pages/Games/TexasHoldem.jsx
@@ -1,0 +1,16 @@
+import { useLocation } from 'react-router-dom';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+
+export default function TexasHoldem() {
+  useTelegramBackButton();
+  const { search } = useLocation();
+  return (
+    <div className="relative w-full h-screen">
+      <iframe
+        src={`/texas-holdem.html${search}`}
+        title="Texas Hold'em"
+        className="w-full h-full border-0"
+      />
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { ensureAccountId, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+
+const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
+const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
+const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
+
+export default function TexasHoldemLobby() {
+  const navigate = useNavigate();
+  useTelegramBackButton();
+
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [mode, setMode] = useState('local');
+  const [avatar, setAvatar] = useState('');
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  const startGame = async () => {
+    let tgId;
+    let accountId;
+    try {
+      accountId = await ensureAccountId();
+      const balRes = await getAccountBalance(accountId);
+      if ((balRes.balance || 0) < stake.amount) {
+        alert('Insufficient balance');
+        return;
+      }
+      tgId = getTelegramId();
+      await addTransaction(tgId, -stake.amount, 'stake', {
+        game: 'texasholdem',
+        accountId,
+      });
+    } catch {}
+
+    const params = new URLSearchParams();
+    params.set('mode', mode);
+    if (stake.token) params.set('token', stake.token);
+    if (stake.amount) params.set('amount', stake.amount);
+    if (avatar) params.set('avatar', avatar);
+    if (mode === 'local') params.set('avatars', 'flags');
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    const initData = window.Telegram?.WebApp?.initData;
+    if (initData) params.set('init', encodeURIComponent(initData));
+    if (DEV_ACCOUNT) params.set('dev', DEV_ACCOUNT);
+    if (DEV_ACCOUNT_1) params.set('dev1', DEV_ACCOUNT_1);
+    if (DEV_ACCOUNT_2) params.set('dev2', DEV_ACCOUNT_2);
+    navigate(`/games/texasholdem?${params.toString()}`);
+  };
+
+  return (
+    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+      <h2 className="text-xl font-bold text-center">Texas Hold'em Lobby</h2>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Stake</h3>
+        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Mode</h3>
+        <div className="flex gap-2">
+          {[{ id: 'local', label: 'Local (AI)' }, { id: 'online', label: 'Online' }].map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setMode(id)}
+              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <button
+        onClick={startGame}
+        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
+      >
+        START
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Implement core Texas Hold'em logic with hand evaluation and simple AI
- Add Texas Hold'em web assets and game script reusing Murlan Royale layout
- Expose Texas Hold'em lobby and routes in webapp with TPC stake options

## Testing
- `npm test` *(fails: snake API endpoints and socket events timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b04fdd6c8329a36e96611bb4d185