### PR TITLE
Make pool table full-screen and update cue overlay

### DIFF
--- a/webapp/public/assets/icons/white_ball.svg
+++ b/webapp/public/assets/icons/white_ball.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <circle cx="32" cy="32" r="28" fill="#ffffff" stroke="#000" stroke-width="4"/>
+  <circle cx="32" cy="32" r="28" fill="#ffffff"/>
   <circle cx="22" cy="22" r="8" fill="#ffffff" fill-opacity="0.6"/>
   <circle cx="18" cy="18" r="3" fill="#ffffff" fill-opacity="0.6"/>
 </svg>

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -76,9 +76,8 @@
     /* Canvas i tavolines (mbulon gjithcka, pervec panelit djathtas) */
     #table {
       position: absolute;
-      inset: 0 auto 0 0;
-      right: var(--rpw);
-      z-index: 4;
+      inset: 0;
+      z-index: 1;
       background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp') center/cover no-repeat;
       background-attachment: fixed;
       transform-origin: center;
@@ -97,7 +96,7 @@
       align-items: center;
       justify-content: space-between;
 
-      background: rgba(16,24,48,.76);
+      background: transparent;
       border-left: 2px solid #2c3d63;
       padding: 12px 8px;
       z-index: 6;
@@ -107,7 +106,7 @@
       width: 36px;
       height: 36px;
       border-radius: 50%;
-      background: url('/assets/icons/white_ball.svg') center/cover no-repeat;
+      background: transparent url('/assets/icons/white_ball.svg') center/cover no-repeat;
       position: relative;
       box-shadow: 0 4px 10px rgba(0,0,0,.4) inset,
                   0 0 0 2px rgba(0,0,0,.15);
@@ -131,7 +130,7 @@
       width: 96px;
       height: 58%;
       border-radius: 14px;
-      background: none;
+      background: transparent;
       box-shadow: inset 0 0 0 1px rgba(255,255,255,.05),
                   0 8px 24px rgba(0,0,0,.35);
       display: flex;
@@ -153,7 +152,7 @@
 
     #cueStick {
       position: absolute;
-      left: 50%;
+      left: calc(50% + 4px);
       transform: translateX(-50%);
       width: 4px;
       height: 60%;
@@ -165,7 +164,7 @@
 
     #tip {
       position: absolute;
-      left: 50%;
+      left: calc(50% + 4px);
       transform: translateX(-50%);
       width: 8px;
       height: 8px;
@@ -435,9 +434,8 @@
        ========================================================= */
     var sX = 1, sY = 1, pocketR = POCKET_R, ballR = BALL_R;
     function resize(){
-      var rpw = rightPanel.getBoundingClientRect().width;
       var wrap = document.getElementById('wrap');
-      var w = wrap.clientWidth - rpw;
+      var w = wrap.clientWidth;
       var h = wrap.clientHeight;
       var ar = TABLE_W / TABLE_H;
       var cw = w, ch = h;


### PR DESCRIPTION
## Summary
- make poll royale table canvas span the entire screen
- layer cue and controls transparently over the table and nudge cue slightly right
- remove dark border from white ball asset for a transparent edge

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0b1bcbe5483298464582678d91741