### PR TITLE
Remove calibration controls and set default field size

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -216,57 +216,6 @@
     }
 
     #play:hover { background: #3c67a3; }
-
-    #calibrateBtn {
-      background: none;
-      border: none;
-      color: #fff;
-      font-size: 24px;
-      cursor: pointer;
-    }
-
-    #calibrationPopup {
-      position: fixed;
-      inset: 0;
-      display: none;
-      align-items: center;
-      justify-content: center;
-      background: rgba(0,0,0,0.4);
-      z-index: 20;
-    }
-
-    #calibrationPanel {
-      background: rgba(16,24,48,0.9);
-      padding: 20px;
-      border-radius: 8px;
-      color: #fff;
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-      min-width: 240px;
-    }
-
-    #calibrationPanel label {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-      font-size: 14px;
-    }
-
-    #calibrationPanel .actions {
-      display: flex;
-      justify-content: space-between;
-      gap: 12px;
-    }
-
-    #calibrationPanel button {
-      padding: 8px 12px;
-      background: #1e293b;
-      color: #fff;
-      border: 1px solid #475569;
-      border-radius: 6px;
-      cursor: pointer;
-    }
   </style>
 </head>
 <body>
@@ -276,7 +225,6 @@
         <div class="avatar" id="userAvatar">A</div>
         <div class="name" id="userName">Artur</div>
       </div>
-      <button id="calibrateBtn" title="Calibrate">⚙️</button>
       <div class="player">
         <div class="name" id="aiName">CPU</div>
         <div class="avatar" id="aiAvatar">C</div>
@@ -307,29 +255,7 @@
       <button id="play">Play</button>
     </div>
 
-    <div id="calibrationPopup">
-      <div id="calibrationPanel">
-        <label>Zoom
-          <input type="range" id="zoomInput" min="0.5" max="2" step="0.1" value="1" />
-        </label>
-        <label>Ball Speed
-          <input type="range" id="speedInput" min="500" max="3000" step="100" value="1900" />
-        </label>
-        <label>Hole Size
-          <input type="range" id="holeInput" min="10" max="60" step="1" value="28" />
-        </label>
-        <label>Field Width <span id="widthVal">640</span>
-          <input type="range" id="widthInput" min="400" max="1000" step="10" value="640" />
-        </label>
-        <label>Field Height <span id="heightVal">1280</span>
-          <input type="range" id="heightInput" min="800" max="1600" step="10" value="1280" />
-        </label>
-        <div class="actions">
-          <button id="saveSettings">Save</button>
-          <button id="exitSettings">Exit</button>
-        </div>
-      </div>
-    </div>
+
 
     <div id="footer">
       <div id="capP1">Guret e marra (P1): —</div>
@@ -349,8 +275,8 @@
     /* ==========================================================
        KONSTANTA TE LAYOUT-it DHE FIZIKES (sipas portrait)
        ========================================================= */
-    var TABLE_W = 640;      // gjeresi logjike e felt-it
-    var TABLE_H = 1280;     // lartesi logjike e felt-it
+    var TABLE_W = 660;      // gjeresi logjike e felt-it
+    var TABLE_H = 1020;     // lartesi logjike e felt-it
     var BORDER  = 36;       // korniza e drurit rreth e rrotull
     var POCKET_R = 28;      // rrezja baze e gropave
     var BALL_R   = 18;      // rrezja baze e topave
@@ -360,7 +286,6 @@
 
     var MIN_V = 0.08;       // shpejtesia min. qe konsiderohet "ne levizje"
     var BASE_SPEED = 1900;  // shpejtesia baze e goditjes
-    var ZOOM = 1;           // zmadhimi i fushes
 
     /* ==========================================================
        ELEMENTET DOM
@@ -382,28 +307,6 @@
     var userNameEl= document.getElementById('userName');
     var aiAvatar  = document.getElementById('aiAvatar');
     var aiNameEl  = document.getElementById('aiName');
-    var calibrateBtn = document.getElementById('calibrateBtn');
-    var settingsPopup = document.getElementById('calibrationPopup');
-    var zoomInput = document.getElementById('zoomInput');
-    var speedInput = document.getElementById('speedInput');
-    var holeInput = document.getElementById('holeInput');
-    var widthInput = document.getElementById('widthInput');
-    var heightInput = document.getElementById('heightInput');
-    var widthVal   = document.getElementById('widthVal');
-    var heightVal  = document.getElementById('heightVal');
-    var saveSettings = document.getElementById('saveSettings');
-    var exitSettings = document.getElementById('exitSettings');
-    var savedSettings = JSON.parse(localStorage.getItem('pollRoyaleSettings') || '{}');
-    if (savedSettings.zoom) ZOOM = savedSettings.zoom;
-    if (savedSettings.baseSpeed) BASE_SPEED = savedSettings.baseSpeed;
-    if (savedSettings.pocketR) POCKET_R = savedSettings.pocketR;
-    if (savedSettings.tableW) TABLE_W = savedSettings.tableW;
-    if (savedSettings.tableH) TABLE_H = savedSettings.tableH;
-    if (savedSettings.zoom) calibrateBtn.style.display = 'none';
-    canvas.style.transform = 'scale(' + ZOOM + ')';
-
-    widthInput.addEventListener('input', function(){ widthVal.textContent = widthInput.value; });
-    heightInput.addEventListener('input', function(){ heightVal.textContent = heightInput.value; });
 
     document.addEventListener('touchmove', function(e){ e.preventDefault(); }, {passive:false});
 
@@ -742,41 +645,6 @@
     var cuePullVisual = 0;     // shfaqje e terheqjes ne felt
     var spinVec = { x:0, y:0 };// spini i zgjedhur
     var power = 0;             // fuqi [0..1]
-
-    calibrateBtn.addEventListener('click', function(){
-      settingsPopup.style.display = 'flex';
-      zoomInput.value = ZOOM;
-      speedInput.value = BASE_SPEED;
-      holeInput.value = POCKET_R;
-      widthInput.value = TABLE_W;
-      heightInput.value = TABLE_H;
-      widthVal.textContent = TABLE_W;
-      heightVal.textContent = TABLE_H;
-    });
-
-    exitSettings.addEventListener('click', function(){
-      settingsPopup.style.display = 'none';
-    });
-
-    saveSettings.addEventListener('click', function(){
-      ZOOM = parseFloat(zoomInput.value);
-      BASE_SPEED = parseFloat(speedInput.value);
-      POCKET_R = parseFloat(holeInput.value);
-      TABLE_W = parseFloat(widthInput.value);
-      TABLE_H = parseFloat(heightInput.value);
-      localStorage.setItem('pollRoyaleSettings', JSON.stringify({
-        zoom: ZOOM,
-        baseSpeed: BASE_SPEED,
-        pocketR: POCKET_R,
-        tableW: TABLE_W,
-        tableH: TABLE_H
-      }));
-      canvas.style.transform = 'scale(' + ZOOM + ')';
-      table.reset();
-      resize();
-      settingsPopup.style.display = 'none';
-      calibrateBtn.style.display = 'none';
-    });
 
     /* ==========================================================
        RENDER + UPDATE LOOP


### PR DESCRIPTION
## Summary
- drop calibration button and settings popup from Poll Royale
- default pool table dimensions updated to 660x1020

## Testing
- `npm test` *(fails: snake API endpoints and socket events)*
- `npm run lint` *(fails: existing lint errors in lib/texasHoldem.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c32cdd448329b20c7d0cff7f8c47