### PR TITLE
refactor: update texas holdem layout

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -20,21 +20,29 @@
     }
     .stage{ position:relative; width:100vw; height:100vh; display:grid; place-items:center; perspective:1100px; }
     .stage::before{ content:""; position:absolute; inset:0; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
-    .center{ position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2 }
-    .community .card{ width:var(--card-w); height:var(--card-h); background:#fff; border-radius:6px; display:grid; place-items:center; color:#000; }
-    .seats{ position:absolute; inset:0; z-index:2 }
-    .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px) }
-    .avatar{ width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%, #fff, #ddd 40%, #bbb 60%, #999 100%); color:#111; font-size:28px; border:4px solid rgba(255,255,255,.65); box-shadow:0 8px 20px var(--shadow); overflow:hidden }
-    .cards{ display:flex; gap:4px; }
-    .card{ width:var(--card-w); height:var(--card-h); background:#fff; border-radius:6px; display:grid; place-items:center; color:#000; position:relative; }
-    .card.back{ background:url('assets/icons/file_00000000bc2862439eecffff3730bbe4.webp') center/60% no-repeat, repeating-linear-gradient(45deg,#233,#233 6px,#122 6px,#122 12px); border:2px solid rgba(255,255,255,.5); color:transparent; }
-    .card.back::before{ content:""; position:absolute; inset:6px; border-radius:8px; border:2px dashed rgba(255,255,255,.35); }
-    .seat.bottom{ bottom:10%; left:50%; transform:translateX(-50%); }
-    .seat.top{ top:10%; left:50%; transform:translateX(-50%); }
-    .seat.left{ left:5%; top:50%; transform:translateY(-50%); }
-    .seat.right{ right:5%; top:50%; transform:translateY(-50%); }
-    .seat.bottom .cards{ gap:0 }
-    .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
+      .center{ position:absolute; left:50%; top:55%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2 }
+      .seats{ position:absolute; inset:0; z-index:2 }
+      .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px) }
+      .avatar{ width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%, #fff, #ddd 40%, #bbb 60%, #999 100%); color:#111; font-size:28px; border:4px solid rgba(255,255,255,.65); box-shadow:0 8px 20px var(--shadow); overflow:hidden }
+      .avatar-wrap{ position:relative; width:var(--avatar-size); height:var(--avatar-size); display:grid; place-items:center; }
+      .timer-ring{ position:absolute; inset:-6px; border-radius:50%; background:conic-gradient(#f5cc4e var(--progress,0deg), transparent 0); -webkit-mask:radial-gradient(farthest-side,transparent calc(100% - 6px),#000 calc(100% - 6px)); mask:radial-gradient(farthest-side,transparent calc(100% - 6px),#000 calc(100% - 6px)); pointer-events:none }
+      .cards{ display:flex; gap:6px; flex-wrap:nowrap }
+      .card{ width:var(--card-w); height:var(--card-h); border-radius:10px; position:relative; flex:0 0 auto; background:#fff; color:#111; font-weight:900; letter-spacing:.3px; box-shadow:0 10px 25px var(--shadow), inset 0 0 0 2px rgba(0,0,0,.08); touch-action:none }
+      .card .tl{ position:absolute; left:8px; top:6px; font-size:calc(var(--card-w)*0.28) }
+      .card .br{ position:absolute; right:8px; bottom:8px; font-size:calc(var(--card-w)*0.3) }
+      .card .big{ position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); font-size:calc(var(--card-w)*0.52); opacity:.9 }
+      .red{ color:#d12d2d }
+      .joker{ background:repeating-linear-gradient(45deg,#eee,#eee 6px,#ddd 6px,#ddd 12px); }
+      .selected{ outline:3px solid #0ea5e9; transform:translateY(-6px); }
+      .suggested{ outline:3px dashed #2563eb; }
+      .card.back{ background:url('assets/icons/file_00000000bc2862439eecffff3730bbe4.webp') center/60% no-repeat, repeating-linear-gradient(45deg,#233,#233 6px,#122 6px,#122 12px); border:2px solid rgba(255,255,255,.5); color:transparent; }
+      .card.back::before{ content:""; position:absolute; inset:6px; border-radius:8px; border:2px dashed rgba(255,255,255,.35); }
+      .seat.bottom{ bottom:5%; left:50%; transform:translateX(-50%); flex-direction:column-reverse; }
+      .seat.top{ top:5%; left:50%; transform:translateX(-50%); }
+      .seat.left{ left:5%; top:40%; transform:translateY(-50%); }
+      .seat.right{ right:5%; top:40%; transform:translateY(-50%); }
+      .seat.bottom .cards{ gap:0 }
+      .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
     .controls{ display:flex; gap:8px; margin-top:8px; }
     .controls button{ padding:6px 12px; border:none; border-radius:8px; background:#2563eb; color:#fff; font-weight:600; }
     #status{ position:absolute; top:50%; left:50%; transform:translate(-50%, -50%); font-weight:900; letter-spacing:.3px; color:#ffeaa7; background:rgba(0,0,0,.28); padding:6px 12px; border-radius:12px; border:1px solid rgba(255,255,255,.12); text-shadow:0 2px 6px #000 }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -71,15 +71,24 @@ function renderSeats() {
     const name = document.createElement('div');
     name.className = 'name';
     name.textContent = p.name;
-    const timer = document.createElement('div');
-    timer.className = 'timer';
-    timer.id = 'timer-' + i;
-    seat.append(avatar, cards, name, timer);
     if (i === 0) {
+      const wrap = document.createElement('div');
+      wrap.className = 'avatar-wrap';
+      wrap.style.order = -2;
+      const ring = document.createElement('div');
+      ring.className = 'timer-ring';
+      ring.id = 'timer-' + i;
+      wrap.append(ring, avatar);
       const controls = document.createElement('div');
       controls.className = 'controls';
       controls.id = 'controls';
-      seat.appendChild(controls);
+      controls.style.order = -1;
+      seat.append(wrap, cards, name, controls);
+    } else {
+      const timer = document.createElement('div');
+      timer.className = 'timer';
+      timer.id = 'timer-' + i;
+      seat.append(avatar, cards, name, timer);
     }
     seats.appendChild(seat);
   });
@@ -88,7 +97,17 @@ function renderSeats() {
 function cardEl(card) {
   const div = document.createElement('div');
   div.className = 'card';
-  div.textContent = card.rank + card.suit;
+  if (card.suit === '♥' || card.suit === '♦') div.classList.add('red');
+  const tl = document.createElement('div');
+  tl.className = 'tl';
+  tl.textContent = card.rank + card.suit;
+  const br = document.createElement('div');
+  br.className = 'br';
+  br.textContent = card.rank + card.suit;
+  const big = document.createElement('div');
+  big.className = 'big';
+  big.textContent = card.suit;
+  div.append(tl, br, big);
   return div;
 }
 
@@ -151,7 +170,13 @@ function startTurnTimer(onTimeout) {
 
 function updateTimer() {
   const t = document.getElementById('timer-' + state.turn);
-  if (t) t.textContent = state.turnTime > 0 ? state.turnTime : '';
+  if (!t) return;
+  if (state.turn === 0) {
+    const pct = (state.turnTime / 15) * 360;
+    t.style.setProperty('--progress', pct);
+  } else {
+    t.textContent = state.turnTime > 0 ? state.turnTime : '';
+  }
 }
 
 function playerFold() {


### PR DESCRIPTION
## Summary
- restyle Texas Hold'em cards to match Murlan Royale design
- reposition player avatars/cards and add timer ring around bottom avatar
- adjust table and seat positioning for clearer layout

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*
- `npm run lint` *(fails: arrow-spacing, comma-spacing, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cc3dad6483298a39b87e9fea6b4f