### PR TITLE
Add additional seats for Texas Hold'em

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -41,6 +41,8 @@
       .seat.top{ top:5%; left:50%; transform:translateX(-50%); }
       .seat.left{ left:5%; top:37%; transform:translateY(-50%); }
       .seat.right{ right:5%; top:37%; transform:translateY(-50%); }
+      .seat.bottom-left{ bottom:5%; left:20%; transform:translateX(-50%); }
+      .seat.bottom-right{ bottom:5%; left:80%; transform:translateX(-50%); }
       .seat.bottom .cards{ gap:0 }
       .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
     .controls{ display:flex; gap:8px; margin-top:8px; }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -60,8 +60,8 @@ function init() {
   } catch {}
 
     const deck = shuffle(createDeck());
-    const { hands, deck: rest } = dealHoleCards(deck, 4);
-    const flags = [...FLAG_EMOJIS].sort(() => 0.5 - Math.random()).slice(0, 3);
+    const { hands, deck: rest } = dealHoleCards(deck, 6);
+    const flags = [...FLAG_EMOJIS].sort(() => 0.5 - Math.random()).slice(0, 5);
     state.players = [
       { name, avatar, hand: hands[0], isHuman: true },
       ...flags.map((f, idx) => ({
@@ -79,7 +79,7 @@ function init() {
 function renderSeats() {
   const seats = document.getElementById('seats');
   seats.innerHTML = '';
-  const positions = ['bottom', 'right', 'top', 'left'];
+  const positions = ['bottom', 'bottom-right', 'right', 'top', 'left', 'bottom-left'];
   state.players.forEach((p, i) => {
     const seat = document.createElement('div');
     seat.className = 'seat ' + positions[i];


### PR DESCRIPTION
## Summary
- expand Texas Hold'em setup to handle six players
- place two extra seats under side players

## Testing
- `npm test` *(fails: Failed to launch Telegram bot)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dc4f7b048329adaaf3e3f6c72771