### PR TITLE
Tune pool table background and fix rack orientation

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -84,7 +84,7 @@
       position: absolute;
       inset: 0;
       z-index: 1;
-      background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp') center/99% 99% no-repeat;
+      background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp') center/103% 95% no-repeat;
       background-attachment: fixed;
       transform-origin: center;
     }
@@ -465,12 +465,15 @@
 
       // Trekendshi siper me 15 topa (8-shi ne qender rreshti 3)
       var cx = TABLE_W/2;
-      var cy = TABLE_H * 0.25;
+      var cy = TABLE_H * 0.23;
       var rowGap = BALL_R*1.95;
       var colGap = BALL_R*2.1;
 
-      // Lista e numrave te tjere (pa 8) – do perdoren gradualisht
-      var pool = []; for (i=1;i<=15;i++){ if(i!==8) pool.push(i); }
+      // Lista e numrave te tjere (pa 1,2,8,11) – do perdoren gradualisht
+      var pool = [];
+      for (i = 1; i <= 15; i++) {
+        if (i !== 8 && i !== 1 && i !== 2 && i !== 11) pool.push(i);
+      }
       var cursor = 0;
 
       // 5 rreshta (1..5) — ne total 15 topa
@@ -480,8 +483,9 @@
           var x = cx - (count-1)*BALL_R*1.05 + j*colGap;
           var y = cy + r*rowGap;
           var num;
-          if (r===2 && j===1) num = 8;            // qendra e rreshtit 3
-          else if (r===4 && j===0) num = 1;       // qoshe e majte poshte solid
+          if (r===0 && j===0) num = 1;            // maja (siper) – topi i verdhe
+          else if (r===2 && j===1) num = 8;       // qendra e rreshtit 3
+          else if (r===4 && j===0) num = 2;       // qoshe e majte poshte solid
           else if (r===4 && j===4) num = 11;      // qoshe e djathte poshte stripe
           else num = pool[cursor++];
           var info = BALL_BY_N[num];


### PR DESCRIPTION
## Summary
- widen and shorten pool table background
- place yellow ball at apex, move rack slightly upward

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*

------
https://chatgpt.com/codex/tasks/task_e_68a0dbd4bfdc8329a2605fbe22cb8cd2