### PR TITLE
Adjust Texas Hold'em seat positioning

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -39,10 +39,10 @@
       .card.back::before{ content:""; position:absolute; inset:6px; border-radius:8px; border:2px dashed rgba(255,255,255,.35); }
       .seat.bottom{ bottom:5%; left:50%; transform:translateX(-50%); }
       .seat.top{ top:5%; left:50%; transform:translateX(-50%); }
-      .seat.left{ left:5%; top:37%; transform:translateY(-50%); }
-      .seat.right{ right:5%; top:37%; transform:translateY(-50%); }
-      .seat.bottom-left{ bottom:5%; left:20%; transform:translateX(-50%); }
-      .seat.bottom-right{ bottom:5%; left:80%; transform:translateX(-50%); }
+      .seat.left{ left:18%; top:37%; transform:translate(-50%,-50%); }
+      .seat.right{ left:82%; top:37%; transform:translate(-50%,-50%); }
+      .seat.bottom-left{ bottom:8%; left:18%; transform:translateX(-50%); }
+      .seat.bottom-right{ bottom:8%; left:82%; transform:translateX(-50%); }
       .seat.bottom .cards{ gap:0 }
       .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
     .controls{ display:flex; gap:8px; margin-top:8px; }


### PR DESCRIPTION
## Summary
- Align side seats with their bottom counterparts in Texas Hold'em layout
- Raise and horizontally adjust bottom-left and bottom-right seats for better symmetry

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e21f781083299f44c26cdf372960