### PR TITLE
Refine pool table layout and add center logo

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -97,10 +97,10 @@
       border: 24px solid transparent;
       background:
         radial-gradient(circle at 0% 0%, #000 0 3%, transparent 3%),
-        radial-gradient(circle at 50% 0%, #000 0 3%, transparent 3%),
         radial-gradient(circle at 100% 0%, #000 0 3%, transparent 3%),
+        radial-gradient(circle at 0% 50%, #000 0 3%, transparent 3%),
+        radial-gradient(circle at 100% 50%, #000 0 3%, transparent 3%),
         radial-gradient(circle at 0% 100%, #000 0 3%, transparent 3%),
-        radial-gradient(circle at 50% 100%, #000 0 3%, transparent 3%),
         radial-gradient(circle at 100% 100%, #000 0 3%, transparent 3%),
         linear-gradient(#2e8b57, #0d6130) padding-box,
         linear-gradient(#caa471, #9c7a4d) border-box;
@@ -114,6 +114,17 @@
         padding-box,
         border-box;
       box-shadow: inset 0 8px rgba(255, 255, 255, 0.4);
+    }
+
+    #tableLogo {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 40%;
+      opacity: 0.15;
+      pointer-events: none;
+      z-index: 0;
     }
 
     /* Paneli djathtas – SPIN siper, STEKA poshte */
@@ -167,8 +178,7 @@
       height: 50vh;
       border-radius: 14px;
       background: transparent;
-      box-shadow: inset 0 0 0 1px rgba(255,255,255,.05),
-                  0 8px 24px rgba(0,0,0,.35);
+      box-shadow: none;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -266,6 +276,7 @@
 
     <div id="wrap">
       <div id="tableSkin"></div>
+      <img id="tableLogo" src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp" alt="TonPlaygram" />
       <canvas id="table"></canvas>
 
         <!-- Panel djathtas: STEKA poshte -->
@@ -304,10 +315,10 @@
     /* ==========================================================
        KONSTANTA TE LAYOUT-it DHE FIZIKES (sipas portrait)
        ========================================================= */
-    var TABLE_W = 660;      // gjeresi logjike e felt-it
-    var TABLE_H = 1020;     // lartesi logjike e felt-it
+    var TABLE_W = 640;      // gjeresi logjike e felt-it (pak me e vogel)
+    var TABLE_H = 1000;     // lartesi logjike e felt-it (pak me e vogel)
     var BORDER  = 36;       // korniza e drurit rreth e rrotull
-    var POCKET_R = 28;      // rrezja baze e gropave
+    var POCKET_R = 26;      // rrezja baze e gropave per perputhje me dekorin
     var BALL_R   = 18;      // rrezja baze e topave
 
     var FRICTION = 0.985;   // ferkimi linear


### PR DESCRIPTION
## Summary
- Align table pocket visuals with physics and shrink play field
- Remove cue pull area's frame
- Add translucent TonPlaygram logo at table center

## Testing
- `npm test` *(fails: AssertionError: The expression evaluated to a falsy value)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ee0d28f88329a22939457f8cc2f1