### PR TITLE
Adjust Texas Hold'em layout

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -7,7 +7,7 @@
   <style>
     :root{
       --shadow:rgba(0,0,0,.45);
-      --card-scale:0.9; --avatar-scale:1;
+      --card-scale:0.85; --avatar-scale:1;
       --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale));
       --card-h: calc(var(--card-w)*1.45);
       --avatar-size: calc(54px * var(--avatar-scale));
@@ -19,8 +19,8 @@
       color:#fff; overflow:hidden; height:100vh; width:100vw;
     }
     .stage{ position:relative; width:100vw; height:100vh; display:grid; place-items:center; perspective:1100px; }
-    .stage::before{ content:""; position:absolute; inset:0; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
-      .center{ position:absolute; left:50%; top:46%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.05; }
+    .stage::before{ content:""; position:absolute; top:0; bottom:0; left:1vw; right:1vw; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
+      .center{ position:absolute; left:50%; top:46%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.1; }
       .seats{ position:absolute; inset:0; z-index:2 }
       .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px) }
       .seat.small{ --card-scale:.8; }
@@ -38,17 +38,17 @@
       .suggested{ outline:3px dashed #2563eb; }
       .card.back{ background:url('assets/icons/file_00000000bc2862439eecffff3730bbe4.webp') center/60% no-repeat, repeating-linear-gradient(45deg,#233,#233 6px,#122 6px,#122 12px); border:2px solid rgba(255,255,255,.5); color:transparent; }
       .card.back::before{ content:""; position:absolute; inset:6px; border-radius:8px; border:2px dashed rgba(255,255,255,.35); }
-      .seat.bottom{ bottom:1%; left:50%; transform:translateX(-50%); }
-      .seat.top{ top:1%; left:50%; transform:translateX(-50%); }
-      .seat.left{ left:16%; top:28%; transform:translate(-50%,-50%); --card-scale:.85; }
-      .seat.right{ left:84%; top:28%; transform:translate(-50%,-50%); }
-      .seat.bottom-left{ left:16%; top:63%; transform:translate(-50%,-50%); --card-scale:.85; }
-      .seat.bottom-right{ left:84%; top:63%; transform:translate(-50%,-50%); }
+      .seat.bottom{ bottom:1%; left:50%; transform:translateX(-50%); --card-scale:1; }
+      .seat.top{ top:1%; left:50%; transform:translateX(-50%); --card-scale:.8; }
+      .seat.left{ left:16%; top:28%; transform:translate(-50%,-50%); --card-scale:.8; }
+      .seat.right{ left:84%; top:28%; transform:translate(-50%,-50%); --card-scale:.8; }
+      .seat.bottom-left{ left:16%; top:65%; transform:translate(-50%,-50%); --card-scale:.8; }
+      .seat.bottom-right{ left:84%; top:65%; transform:translate(-50%,-50%); --card-scale:.8; }
       .seat.bottom .cards{ gap:0 }
       .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
     .controls{ display:flex; gap:8px; margin-top:8px; }
     .controls button{ padding:6px 12px; border:none; border-radius:8px; background:#2563eb; color:#fff; font-weight:600; }
-    #status{ position:absolute; top:50%; left:50%; transform:translate(-50%, -50%); font-weight:900; letter-spacing:.3px; color:#ffeaa7; background:rgba(0,0,0,.28); padding:6px 12px; border-radius:12px; border:1px solid rgba(255,255,255,.12); text-shadow:0 2px 6px #000 }
+    #status{ position:absolute; top:52%; left:50%; transform:translate(-50%, -50%); font-weight:900; letter-spacing:.3px; color:#ff0; background:rgba(0,0,0,.28); padding:6px 12px; border-radius:12px; border:1px solid rgba(255,255,255,.12); text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- narrow poker table background
- tweak card scaling and player positions
- restyle center status text

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1632db4b483299b6ba884352f010f