### PR TITLE
feat: highlight winning cards in Texas Hold'em

### DIFF
--- a/lib/texasHoldem.js
+++ b/lib/texasHoldem.js
@@ -136,7 +136,7 @@ export function bestHand(cards){
   for(const c of combinations(cards,5)){
     const e=evaluate5(c);
     if(!best||e.rank>best.rank|| (e.rank===best.rank && compareTiebreak(e.tiebreak,best.tiebreak)>0)){
-      best=e;
+      best={...e,cards:c};
     }
   }
   return best;

--- a/webapp/public/lib/texasHoldem.js
+++ b/webapp/public/lib/texasHoldem.js
@@ -136,7 +136,7 @@ export function bestHand(cards){
   for(const c of combinations(cards,5)){
     const e=evaluate5(c);
     if(!best||e.rank>best.rank|| (e.rank===best.rank && compareTiebreak(e.tiebreak,best.tiebreak)>0)){
-      best=e;
+      best={...e,cards:c};
     }
   }
   return best;

--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -38,6 +38,10 @@
       .suggested{ outline:3px dashed #2563eb; }
       .card.back{ background:url('assets/icons/file_00000000bc2862439eecffff3730bbe4.webp') center/60% no-repeat, repeating-linear-gradient(45deg,#233,#233 6px,#122 6px,#122 12px); border:2px solid rgba(255,255,255,.5); color:transparent; }
       .card.back::before{ content:""; position:absolute; inset:6px; border-radius:8px; border:2px dashed rgba(255,255,255,.35); }
+      .card.winning{ outline:3px solid #facc15; background:#fef08a; }
+      .community .card.winning{ transform:translateY(-12px); }
+      .seat.winner .avatar{ box-shadow:0 0 12px #facc15; border-color:#facc15; }
+      .seat.winner .name{ color:#facc15; }
       .seat.bottom{ bottom:1%; left:50%; transform:translateX(-50%); }
       .seat.top{ top:1%; left:50%; transform:translateX(-50%); }
       .seat.left{ left:16%; top:28%; transform:translate(-50%,-50%); --card-scale:.85; }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -268,6 +268,20 @@ function showdown() {
   const winner = evaluateWinner(state.players, state.community);
   const text = winner ? `${state.players[winner.index].name} wins!` : 'Tie';
   document.getElementById('status').textContent = text;
+  if (winner) {
+    const winning = winner.score.cards;
+    const commEl = document.getElementById('community');
+    state.community.forEach((c, idx) => {
+      if (winning.includes(c)) commEl.children[idx].classList.add('winning');
+    });
+    const playerCardsEl = document.getElementById('cards-' + winner.index);
+    state.players[winner.index].hand.forEach((c, idx) => {
+      const el = playerCardsEl.children[idx];
+      el.classList.add('winning');
+    });
+    const seat = playerCardsEl.closest('.seat');
+    if (seat) seat.classList.add('winner');
+  }
 }
 
 document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- track the best five-card combination in poker logic
- raise and highlight winning hand and player at showdown
- style winner's cards and seat with a yellow outline

## Testing
- `npm test` *(fails: test timed out snake API endpoints)*
- `npm run lint` *(fails: 471 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1641ad17483299c4a1deb3809e546