### PR TITLE
feat: replace pool table with static background

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -106,6 +106,8 @@
         flex: 1 1 auto;
         display: flex;
         overflow: hidden;
+        background: url('/assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp')
+          center/cover no-repeat;
       }
 
       :root {
@@ -121,109 +123,6 @@
         transform-origin: center;
       }
 
-      /* Dekor i tavolines – kornize druri dhe felt i gjelbert */
-      #tableSkin {
-        position: absolute;
-        inset: 0;
-        z-index: 0;
-        border-radius: 60px;
-        border: 40px solid transparent;
-        background:
-          radial-gradient(circle at 0% 0%, #000 0 4%, transparent 4%),
-          radial-gradient(circle at 100% 0%, #000 0 4%, transparent 4%),
-          radial-gradient(circle at 0% 50%, #000 0 4%, transparent 4%),
-          radial-gradient(circle at 100% 50%, #000 0 4%, transparent 4%),
-          radial-gradient(circle at 0% 100%, #000 0 4%, transparent 4%),
-          radial-gradient(circle at 100% 100%, #000 0 4%, transparent 4%),
-          linear-gradient(#2e8b57, #0d6130) padding-box,
-          linear-gradient(#caa471, #b78955) border-box;
-        background-clip:
-          padding-box, padding-box, padding-box, padding-box, padding-box,
-          padding-box, padding-box, border-box;
-        box-shadow: inset 0 8px rgba(255, 255, 255, 0.4);
-      }
-
-      #tableSkin::before,
-      #tableSkin::after {
-        content: '';
-        position: absolute;
-        inset: 0;
-        border-radius: inherit;
-        pointer-events: none;
-      }
-
-      #tableSkin::after {
-        background:
-          radial-gradient(circle at 25% 20px, #000 0 2px, transparent 2px),
-          radial-gradient(circle at 50% 20px, #000 0 2px, transparent 2px),
-          radial-gradient(circle at 75% 20px, #000 0 2px, transparent 2px),
-          radial-gradient(
-            circle at 25% calc(100% - 20px),
-            #000 0 2px,
-            transparent 2px
-          ),
-          radial-gradient(
-            circle at 50% calc(100% - 20px),
-            #000 0 2px,
-            transparent 2px
-          ),
-          radial-gradient(
-            circle at 75% calc(100% - 20px),
-            #000 0 2px,
-            transparent 2px
-          ),
-          radial-gradient(circle at 20px 25%, #000 0 2px, transparent 2px),
-          radial-gradient(circle at 20px 50%, #000 0 2px, transparent 2px),
-          radial-gradient(circle at 20px 75%, #000 0 2px, transparent 2px),
-          radial-gradient(
-            circle at calc(100% - 20px) 25%,
-            #000 0 2px,
-            transparent 2px
-          ),
-          radial-gradient(
-            circle at calc(100% - 20px) 50%,
-            #000 0 2px,
-            transparent 2px
-          ),
-          radial-gradient(
-            circle at calc(100% - 20px) 75%,
-            #000 0 2px,
-            transparent 2px
-          );
-      }
-
-      #tableSkin::before {
-        background:
-          linear-gradient(#8b5a2b, #8b5a2b) 25% 20px / 8% 2px no-repeat,
-          linear-gradient(#8b5a2b, #8b5a2b) 50% 20px / 8% 2px no-repeat,
-          linear-gradient(#8b5a2b, #8b5a2b) 75% 20px / 8% 2px no-repeat,
-          linear-gradient(#8b5a2b, #8b5a2b) 25% calc(100% - 20px) / 8% 2px
-            no-repeat,
-          linear-gradient(#8b5a2b, #8b5a2b) 50% calc(100% - 20px) / 8% 2px
-            no-repeat,
-          linear-gradient(#8b5a2b, #8b5a2b) 75% calc(100% - 20px) / 8% 2px
-            no-repeat,
-          linear-gradient(#8b5a2b, #8b5a2b) 20px 25% / 2px 8% no-repeat,
-          linear-gradient(#8b5a2b, #8b5a2b) 20px 50% / 2px 8% no-repeat,
-          linear-gradient(#8b5a2b, #8b5a2b) 20px 75% / 2px 8% no-repeat,
-          linear-gradient(#8b5a2b, #8b5a2b) calc(100% - 20px) 25% / 2px 8%
-            no-repeat,
-          linear-gradient(#8b5a2b, #8b5a2b) calc(100% - 20px) 50% / 2px 8%
-            no-repeat,
-          linear-gradient(#8b5a2b, #8b5a2b) calc(100% - 20px) 75% / 2px 8%
-            no-repeat;
-      }
-
-      #tableLogo {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        width: 40%;
-        opacity: 0.15;
-        pointer-events: none;
-        z-index: 0;
-      }
 
       /* Paneli djathtas – SPIN siper, STEKA poshte */
       #rightPanel {
@@ -477,12 +376,6 @@
       </div>
 
       <div id="wrap">
-        <div id="tableSkin"></div>
-        <img
-          id="tableLogo"
-          src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp"
-          alt="TonPlaygram"
-        />
         <canvas id="table"></canvas>
 
         <!-- Panel djathtas: power slider -->


### PR DESCRIPTION
## Summary
- remove dynamic table elements from 8 Poll Royale
- show previously used background image behind gameplay canvas

## Testing
- `npm test` (fails: test timed out after 20000ms)
- `npm run lint` (fails: 471 errors)

------
https://chatgpt.com/codex/tasks/task_e_68a1833bdec483298c283107617d7102