### PR TITLE
feat(pool): add developer calibration overlay

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -427,8 +427,24 @@
         /* ==========================================================
        KONSTANTA TE LAYOUT-it DHE FIZIKES (sipas portrait)
        ========================================================= */
-        var TABLE_W = 1000; // gjeresi logjike e felt-it
-        var TABLE_H = TABLE_W * 2; // raport 2:1 (gjatesia dy here gjeresia)
+        var CAL = (function () {
+          try {
+            var p = new URLSearchParams(location.search);
+            var w = parseInt(p.get('cw'));
+            var h = parseInt(p.get('ch'));
+            if (w && h) return { w: w, h: h };
+          } catch {}
+          try {
+            var s = localStorage.getItem('pollRoyaleCalibration');
+            if (s) {
+              var c = JSON.parse(s);
+              if (c.width && c.height) return { w: c.width, h: c.height };
+            }
+          } catch {}
+          return { w: 1000, h: 2000 };
+        })();
+        var TABLE_W = CAL.w; // gjeresi logjike e felt-it
+        var TABLE_H = CAL.h; // gjatesia logjike e felt-it
         var BORDER = TABLE_W * 0.0625; // ~6.25% e gjeresise
         var POCKET_R = TABLE_W * 0.05; // ~5% e gjeresise
         var BALL_R = TABLE_W * 0.028125; // ~2.8% e gjeresise

--- a/webapp/src/components/PoolCalibrationModal.jsx
+++ b/webapp/src/components/PoolCalibrationModal.jsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { savePollRoyaleCalibration } from '../utils/api.js';
+
+const STORAGE_KEY = 'pollRoyaleCalibration';
+
+export default function PoolCalibrationModal({ open, onClose, onSave }) {
+  const [width, setWidth] = useState(1000);
+  const [height, setHeight] = useState(2000);
+
+  useEffect(() => {
+    if (!open) return;
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (parsed.width) setWidth(parsed.width);
+        if (parsed.height) setHeight(parsed.height);
+      }
+    } catch {}
+  }, [open]);
+
+  const handleSave = async () => {
+    const data = { width, height };
+    try {
+      await savePollRoyaleCalibration(width, height);
+    } catch {}
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch {}
+    if (onSave) onSave(data);
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex flex-col bg-black bg-opacity-50">
+      <div className="relative flex-1">
+        <div
+          className="absolute border-2 border-red-500"
+          style={{
+            width: `${width}px`,
+            height: `${height}px`,
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)'
+          }}
+        />
+      </div>
+      <div className="bg-surface text-text p-4 space-y-2">
+        <label className="block text-sm">Width: {width}px</label>
+        <input
+          type="range"
+          min="100"
+          max="2000"
+          value={width}
+          onChange={(e) => setWidth(Number(e.target.value))}
+          className="w-full"
+        />
+        <label className="block text-sm">Height: {height}px</label>
+        <input
+          type="range"
+          min="100"
+          max="3000"
+          value={height}
+          onChange={(e) => setHeight(Number(e.target.value))}
+          className="w-full"
+        />
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            onClick={onClose}
+            className="px-4 py-1 bg-border rounded text-text"
+          >
+            Exit
+          </button>
+          <button
+            onClick={handleSave}
+            className="px-4 py-1 bg-primary hover:bg-primary-hover text-background rounded"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/webapp/src/pages/Games/PollRoyale.jsx
+++ b/webapp/src/pages/Games/PollRoyale.jsx
@@ -1,16 +1,59 @@
+import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { DEV_INFO } from '../../utils/constants.js';
+import PoolCalibrationModal from '../../components/PoolCalibrationModal.jsx';
+import { getPollRoyaleCalibration } from '../../utils/api.js';
 
 export default function PollRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
+  const params = new URLSearchParams(search);
+  const accountId = params.get('accountId');
+  const isDev = accountId === DEV_INFO.account;
+  const [calibration, setCalibration] = useState(null);
+  const [showCal, setShowCal] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await getPollRoyaleCalibration();
+        if (!res.error && res.width && res.height) {
+          setCalibration(res);
+          return;
+        }
+      } catch {}
+      try {
+        const stored = localStorage.getItem('pollRoyaleCalibration');
+        if (stored) setCalibration(JSON.parse(stored));
+      } catch {}
+    }
+    load();
+  }, []);
+
+  const iframeParams = new URLSearchParams(search);
+  if (calibration?.width) iframeParams.set('cw', calibration.width);
+  if (calibration?.height) iframeParams.set('ch', calibration.height);
+  const src = `/poll-royale.html?${iframeParams.toString()}`;
+
   return (
     <div className="relative w-full h-screen">
-      <iframe
-        src={`/poll-royale.html${search}`}
-        title="8 Poll Royale"
-        className="w-full h-full border-0"
-      />
+      {isDev && (
+        <>
+          <button
+            onClick={() => setShowCal(true)}
+            className="absolute z-10 top-2 right-2 px-3 py-1 bg-primary hover:bg-primary-hover text-background rounded"
+          >
+            Calibrate
+          </button>
+          <PoolCalibrationModal
+            open={showCal}
+            onClose={() => setShowCal(false)}
+            onSave={(c) => setCalibration(c)}
+          />
+        </>
+      )}
+      <iframe src={src} title="8 Poll Royale" className="w-full h-full border-0" />
     </div>
   );
 }

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -564,3 +564,10 @@ export function getWatchCount(tableId) {
 export function getAppStats() {
   return get('/api/stats');
 }
+export function getPollRoyaleCalibration() {
+  return get('/api/pollroyale/calibration');
+}
+
+export function savePollRoyaleCalibration(width, height) {
+  return post('/api/pollroyale/calibration', { width, height }, API_AUTH_TOKEN || undefined);
+}


### PR DESCRIPTION
## Summary
- add developer-only calibration modal with adjustable width/height
- load and persist pool calibration via API/local storage
- apply saved calibration to Poll Royale iframe and table constants

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a19537f1548329aa4864b17c98dd1b