### PR TITLE
feat: add advanced pool aim guide logic

### DIFF
--- a/webapp/src/utils/aimGuides.js
+++ b/webapp/src/utils/aimGuides.js
@@ -1,8 +1,8 @@
-// Utility functions and class for drawing aim guides in 8 Pool Royale
-// Implements dotted lines with fade-out and simple trajectory simulation
-// respecting table boundaries and up to two bounces.
+// Advanced aim guide calculations for 8 Pool Royale
+// Implements dotted guide lines for cue and object balls taking into account
+// power, spin and simple reflections on a rectangular table with pockets.
 
-// Basic vector helpers
+// ---------------- Vector helpers ----------------
 function add(a, b) {
   return { x: a.x + b.x, y: a.y + b.y };
 }
@@ -28,6 +28,25 @@ function perp(a) {
   return { x: -a.y, y: a.x };
 }
 
+function dot(a, b) {
+  return a.x * b.x + a.y * b.y;
+}
+
+function rotate(v, angle) {
+  const c = Math.cos(angle);
+  const s = Math.sin(angle);
+  return { x: v.x * c - v.y * s, y: v.x * s + v.y * c };
+}
+
+function clamp(v, min, max) {
+  return Math.max(min, Math.min(max, v));
+}
+
+// simple ease-out curve (quadratic)
+function easeOut(t) {
+  return 1 - (1 - t) * (1 - t);
+}
+
 // Convert hex color to rgba string with given alpha
 function hexToRgba(hex, alpha) {
   const n = parseInt(hex.slice(1), 16);
@@ -37,17 +56,16 @@ function hexToRgba(hex, alpha) {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
-// Draw dotted line with optional fade-out
-export function drawDottedLine(ctx, start, end, color, dotSize = 3, gap = 8, fade = true) {
+// ---------------- Drawing helpers ----------------
+export function drawDottedLine(ctx, start, end, color, dotSize, gap) {
   const dir = sub(end, start);
   const len = length(dir);
-  const step = gap;
   const unit = normalize(dir);
-  const steps = Math.floor(len / step);
+  const steps = Math.floor(len / gap);
 
   for (let i = 0; i <= steps; i++) {
-    const p = add(start, scale(unit, i * step));
-    const alpha = fade ? 1 - i / steps : 1;
+    const p = add(start, scale(unit, i * gap));
+    const alpha = 1 - i / steps;
     ctx.fillStyle = hexToRgba(color, alpha);
     ctx.beginPath();
     ctx.arc(p.x, p.y, dotSize / 2, 0, Math.PI * 2);
@@ -61,64 +79,118 @@ function drawSegmented(ctx, points, color, dotSize, gap) {
   }
 }
 
-// Simulate a path within rectangular table boundaries with reflections
-function simulatePath(start, direction, table, maxBounces = 2) {
+// -------------- Physics helpers --------------
+// Ray-circle intersection, returns distance t or Infinity
+function rayCircle(pos, dir, center, radius) {
+  const oc = sub(pos, center);
+  const b = 2 * dot(oc, dir);
+  const c = dot(oc, oc) - radius * radius;
+  const disc = b * b - 4 * c; // dir normalized -> a=1
+  if (disc < 0) return Infinity;
+  const t = (-b - Math.sqrt(disc)) / 2;
+  return t >= 0 ? t : Infinity;
+}
+
+// Cast path within rectangular table with pockets and reflections
+function castPath(start, direction, table, maxBounces, maxLength) {
   const points = [start];
   let pos = { ...start };
   let dir = normalize(direction);
+  let remaining = maxLength;
   let bounces = 0;
 
-  while (bounces < maxBounces) {
+  while (remaining > 0 && bounces <= maxBounces) {
     const tX = dir.x > 0 ? (table.width - pos.x) / dir.x : (0 - pos.x) / dir.x;
     const tY = dir.y > 0 ? (table.height - pos.y) / dir.y : (0 - pos.y) / dir.y;
     let t = Math.min(tX, tY);
-    if (!isFinite(t)) break;
-    const end = add(pos, scale(dir, t));
-    points.push(end);
-    if (end.x <= 0 || end.x >= table.width) dir.x = -dir.x;
-    if (end.y <= 0 || end.y >= table.height) dir.y = -dir.y;
-    pos = end;
+    let hitWall = t === tX ? 'x' : 'y';
+
+    // check pockets along the ray
+    if (Array.isArray(table.pockets)) {
+      for (const p of table.pockets) {
+        const d = rayCircle(pos, dir, p, p.captureRadius || p.r || 0);
+        if (d < t) {
+          t = d;
+          hitWall = 'pocket';
+          break;
+        }
+      }
+    }
+
+    if (t > remaining) {
+      points.push(add(pos, scale(dir, remaining)));
+      break;
+    }
+
+    pos = add(pos, scale(dir, t));
+    points.push(pos);
+    remaining -= t;
+
+    if (hitWall === 'pocket') break;
+
+    if (hitWall === 'x') dir.x = -dir.x;
+    else if (hitWall === 'y') dir.y = -dir.y;
     bounces++;
   }
 
   return points;
 }
 
-// Main AimGuide class
+// -------------- AimGuide main class --------------
 export class AimGuide {
   constructor(ctx, table, options = {}) {
     this.ctx = ctx;
-    this.table = table; // { width, height, ballRadius }
+    this.table = table; // { width, height, ballRadius, pockets? }
     this.options = options;
-    this.lines = { aim: [], cue: [], object: [] };
-    this.gap = 8;
-    this.dotSize = options.dotSize || 3;
+    this.lines = { pre: [], cue: [], object: [] };
+    this.step = 8;
+    this.dotSize = 2;
+    this.maxBounces = options.maxBounces ?? 2;
   }
 
   update({ cueBall, targetBall, power = 0, spin = { side: 0, top: 0 } }) {
     const R = this.table.ballRadius;
-    const n = normalize(sub(targetBall, cueBall));
-    const contact = add(cueBall, scale(n, 2 * R));
-    const t = perp(n);
+    const u = normalize(sub(targetBall, cueBall));
+    const P = sub(targetBall, scale(u, R));
+    const G = sub(targetBall, scale(u, 2 * R));
 
-    // Scale gap with power (assumes power 0..1)
-    this.gap = 6 + 4 * Math.min(Math.max(power, 0), 1);
+    // visual parameters
+    this.step = 8 + 6 * clamp(power, 0, 1);
+    this.dotSize = 2 + 1 * clamp(power, 0, 1);
+    const pf = Math.max(this.table.width, this.table.height);
+    const Lmin = pf * 0.35;
+    const Lmax = pf * 0.9;
+    const lineLen = Lmin + (Lmax - Lmin) * easeOut(clamp(power, 0, 1));
 
-    const cueDir = normalize({
-      x: t.x + spin.side * 0.5,
-      y: t.y + spin.top * 0.5,
-    });
+    // object ball path (with throw from side spin)
+    const thetaThrow = (Math.PI / 180) *
+      (0.5 + 1.5 * (1 - power)) * clamp(spin.side, -1, 1) * (this.options.kThrow ?? 1);
+    const uObj = rotate(u, thetaThrow);
+    const objPath = castPath(P, uObj, this.table, this.maxBounces, lineLen);
 
-    this.lines.aim = [cueBall, contact];
-    this.lines.cue = simulatePath(contact, cueDir, this.table, 2);
-    this.lines.object = simulatePath(contact, n, this.table, 2);
+    // cue ball direction after impact
+    const t = perp(u);
+    const alpha = 1 - 0.55 * Math.abs(spin.top);
+    const beta = 0.65 * spin.top;
+    let dCue = normalize(add(scale(t, alpha), scale(u, beta)));
+    const phiSwerve = (Math.PI / 180) *
+      (0.3 + 2.0 * (1 - power)) * clamp(spin.side, -1, 1) * (this.options.kSwerve ?? 1);
+    dCue = rotate(dCue, phiSwerve);
+    const cuePath = castPath(P, dCue, this.table, this.maxBounces, lineLen);
+
+    this.lines = {
+      pre: [cueBall, P],
+      cue: cuePath,
+      object: objPath,
+      ghost: { center: G, r: R },
+    };
   }
 
   draw() {
     const ctx = this.ctx;
-    drawSegmented(ctx, this.lines.aim, '#ffffff', this.dotSize, this.gap);
-    drawSegmented(ctx, this.lines.cue, '#ffffff', this.dotSize, this.gap);
-    drawSegmented(ctx, this.lines.object, '#facc15', this.dotSize, this.gap);
+    drawSegmented(ctx, this.lines.pre, '#ffffff', this.dotSize, this.step);
+    drawSegmented(ctx, this.lines.cue, '#ffffff', this.dotSize, this.step);
+    drawSegmented(ctx, this.lines.object, '#facc15', this.dotSize, this.step);
   }
 }
 


### PR DESCRIPTION
## Summary
- implement full cue/object trajectory simulation with pockets, spin and reflections
- scale dotted guide visuals with shot power

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1978ce8b88329aab6e8feebb19b02