### PR TITLE
Fix calibration panel interaction and live preview

### DIFF
--- a/webapp/src/components/PoolCalibrationModal.jsx
+++ b/webapp/src/components/PoolCalibrationModal.jsx
@@ -1,12 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { savePollRoyaleCalibration } from '../utils/api.js';
 
 const STORAGE_KEY = 'pollRoyaleCalibration';
 
-export default function PoolCalibrationModal({ open, onClose, onSave }) {
+export default function PoolCalibrationModal({ open, onClose, onSave, onChange }) {
   const [width, setWidth] = useState(1000);
   const [height, setHeight] = useState(2000);
+  const areaRef = useRef(null);
+  const [drag, setDrag] = useState(null);
 
   useEffect(() => {
     if (!open) return;
@@ -19,6 +21,37 @@ export default function PoolCalibrationModal({ open, onClose, onSave }) {
       }
     } catch {}
   }, [open]);
+
+  useEffect(() => {
+    if (onChange) onChange({ width, height });
+  }, [width, height, onChange]);
+
+  useEffect(() => {
+    if (!drag) return;
+    function handleMove(e) {
+      const rect = areaRef.current.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      if (drag === 'width') {
+        let w = Math.abs(e.clientX - centerX) * 2;
+        w = Math.min(2000, Math.max(100, Math.round(w)));
+        setWidth(w);
+      } else if (drag === 'height') {
+        let h = Math.abs(e.clientY - centerY) * 2;
+        h = Math.min(3000, Math.max(100, Math.round(h)));
+        setHeight(h);
+      }
+    }
+    function end() {
+      setDrag(null);
+    }
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', end);
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', end);
+    };
+  }, [drag]);
 
   const handleSave = async () => {
     const data = { width, height };
@@ -35,8 +68,8 @@ export default function PoolCalibrationModal({ open, onClose, onSave }) {
   if (!open) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-50 flex flex-col bg-black bg-opacity-50">
-      <div className="relative flex-1">
+    <div className="fixed inset-0 z-50 flex flex-col bg-black bg-opacity-50 pointer-events-auto">
+      <div ref={areaRef} className="relative flex-1">
         <div
           className="absolute border-2 border-red-500"
           style={{
@@ -46,7 +79,16 @@ export default function PoolCalibrationModal({ open, onClose, onSave }) {
             left: '50%',
             transform: 'translate(-50%, -50%)'
           }}
-        />
+        >
+          <div
+            className="absolute inset-y-0 -right-2 w-4 cursor-ew-resize"
+            onPointerDown={() => setDrag('width')}
+          />
+          <div
+            className="absolute -bottom-2 inset-x-0 h-4 cursor-ns-resize"
+            onPointerDown={() => setDrag('height')}
+          />
+        </div>
       </div>
       <div className="bg-surface text-text p-4 space-y-2">
         <label className="block text-sm">Width: {width}px</label>

--- a/webapp/src/pages/Games/PollRoyale.jsx
+++ b/webapp/src/pages/Games/PollRoyale.jsx
@@ -50,6 +50,7 @@ export default function PollRoyale() {
             open={showCal}
             onClose={() => setShowCal(false)}
             onSave={(c) => setCalibration(c)}
+            onChange={(c) => setCalibration(c)}
           />
         </>
       )}


### PR DESCRIPTION
## Summary
- Make calibration modal draggable for width/height adjustments and add live preview
- Update Poll Royale page to receive live calibration changes

## Testing
- `npm test` (fails: Claim transaction failed and 2 tests failing)
- `npm run lint` (fails: 471 errors, missing React package, spacing issues)


------
https://chatgpt.com/codex/tasks/task_e_68a1994d95c483298d9f4719a7c65187