### PR TITLE
fix: disable poll royale interactions during calibration

### DIFF
--- a/webapp/src/pages/Games/PollRoyale.jsx
+++ b/webapp/src/pages/Games/PollRoyale.jsx
@@ -54,7 +54,12 @@ export default function PollRoyale() {
           />
         </>
       )}
-      <iframe src={src} title="8 Poll Royale" className="w-full h-full border-0" />
+      <iframe
+        src={src}
+        title="8 Poll Royale"
+        className="w-full h-full border-0"
+        style={{ pointerEvents: showCal ? 'none' : 'auto' }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- disable pointer events on Poll Royale iframe while calibration is open so only the overlay is interactive

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1a19d86dc832991ce7d406cace196