### PR TITLE
Show start bet and pot limit in Texas Hold'em lobby

### DIFF
--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -31,7 +31,7 @@ export default function RoomSelector({ selected, onSelect, tokens: allowed }) {
               }`}
             >
               <img  src={icon} alt={id} className="w-8 h-8" />
-              <span>{amt}</span>
+              <span>{amt.toLocaleString('en-US')}</span>
             </button>
           ))}
         </div>

--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -17,6 +17,7 @@ export default function TexasHoldemLobby() {
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState('local');
   const [avatar, setAvatar] = useState('');
+  const startBet = stake.amount / 100;
 
   useEffect(() => {
     try {
@@ -66,6 +67,9 @@ export default function TexasHoldemLobby() {
       <div className="space-y-2">
         <h3 className="font-semibold">Stake</h3>
         <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+        <p className="text-sm text-center">
+          Start bet: {startBet.toLocaleString('en-US')} TPC • Pot max: {stake.amount.toLocaleString('en-US')} TPC
+        </p>
       </div>
       <div className="space-y-2">
         <h3 className="font-semibold">Mode</h3>


### PR DESCRIPTION
## Summary
- show start bet and pot max below Texas Hold'em stake buttons
- format stake amounts with locale-specific separators

## Testing
- `npm test` *(fails: BOT_TOKEN not configured, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a1a911af3c83299360a3e7ba1bea34