### PR TITLE
feat: add background calibration controls

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -432,16 +432,29 @@
             var p = new URLSearchParams(location.search);
             var w = parseInt(p.get('cw'));
             var h = parseInt(p.get('ch'));
-            if (w && h) return { w: w, h: h };
+            var bw = parseInt(p.get('bw'));
+            var bh = parseInt(p.get('bh'));
+            var bx = parseInt(p.get('bx'));
+            var by = parseInt(p.get('by'));
+            if (w && h)
+              return { w: w, h: h, bw: bw, bh: bh, bx: bx, by: by };
           } catch {}
           try {
             var s = localStorage.getItem('pollRoyaleCalibration');
             if (s) {
               var c = JSON.parse(s);
-              if (c.width && c.height) return { w: c.width, h: c.height };
+              if (c.width && c.height)
+                return {
+                  w: c.width,
+                  h: c.height,
+                  bw: c.bgWidth,
+                  bh: c.bgHeight,
+                  bx: c.bgX,
+                  by: c.bgY
+                };
             }
           } catch {}
-          return { w: 1000, h: 2000 };
+          return { w: 1000, h: 2000, bw: 0, bh: 0, bx: 0, by: 0 };
         })();
         var TABLE_W = CAL.w; // gjeresi logjike e felt-it
         var TABLE_H = CAL.h; // gjatesia logjike e felt-it
@@ -463,6 +476,15 @@
         /* ==========================================================
        ELEMENTET DOM
        ========================================================= */
+        var wrap = document.getElementById('wrap');
+        if (CAL.bw && CAL.bh) {
+          wrap.style.backgroundSize = CAL.bw + 'px ' + CAL.bh + 'px';
+        } else {
+          wrap.style.backgroundSize = 'cover';
+        }
+        var xPos = isNaN(CAL.bx) ? '50%' : 'calc(50% + ' + CAL.bx + 'px)';
+        var yPos = isNaN(CAL.by) ? '50%' : 'calc(50% + ' + CAL.by + 'px)';
+        wrap.style.backgroundPosition = xPos + ' ' + yPos;
         var canvas = document.getElementById('table');
         var ctx = canvas.getContext('2d');
         var rightPanel = document.getElementById('rightPanel');
@@ -529,7 +551,6 @@
           pocketR = POCKET_R,
           ballR = BALL_R;
         function resize() {
-          var wrap = document.getElementById('wrap');
           var w = wrap.clientWidth;
           var h = wrap.clientHeight;
           var ar = TABLE_W / TABLE_H;

--- a/webapp/src/components/PoolCalibrationModal.jsx
+++ b/webapp/src/components/PoolCalibrationModal.jsx
@@ -7,6 +7,10 @@ const STORAGE_KEY = 'pollRoyaleCalibration';
 export default function PoolCalibrationModal({ open, onClose, onSave, onChange }) {
   const [width, setWidth] = useState(1000);
   const [height, setHeight] = useState(2000);
+  const [bgWidth, setBgWidth] = useState(1000);
+  const [bgHeight, setBgHeight] = useState(2000);
+  const [bgX, setBgX] = useState(0);
+  const [bgY, setBgY] = useState(0);
   const areaRef = useRef(null);
   const [drag, setDrag] = useState(null);
 
@@ -18,13 +22,18 @@ export default function PoolCalibrationModal({ open, onClose, onSave, onChange }
         const parsed = JSON.parse(stored);
         if (parsed.width) setWidth(parsed.width);
         if (parsed.height) setHeight(parsed.height);
+        if (parsed.bgWidth) setBgWidth(parsed.bgWidth);
+        if (parsed.bgHeight) setBgHeight(parsed.bgHeight);
+        if (typeof parsed.bgX === 'number') setBgX(parsed.bgX);
+        if (typeof parsed.bgY === 'number') setBgY(parsed.bgY);
       }
     } catch {}
   }, [open]);
 
   useEffect(() => {
-    if (onChange) onChange({ width, height });
-  }, [width, height, onChange]);
+    if (onChange)
+      onChange({ width, height, bgWidth, bgHeight, bgX, bgY });
+  }, [width, height, bgWidth, bgHeight, bgX, bgY, onChange]);
 
   useEffect(() => {
     if (!drag) return;
@@ -54,9 +63,9 @@ export default function PoolCalibrationModal({ open, onClose, onSave, onChange }
   }, [drag]);
 
   const handleSave = async () => {
-    const data = { width, height };
+    const data = { width, height, bgWidth, bgHeight, bgX, bgY };
     try {
-      await savePollRoyaleCalibration(width, height);
+      await savePollRoyaleCalibration(width, height, bgWidth, bgHeight, bgX, bgY);
     } catch {}
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
@@ -107,6 +116,42 @@ export default function PoolCalibrationModal({ open, onClose, onSave, onChange }
           max="3000"
           value={height}
           onChange={(e) => setHeight(Number(e.target.value))}
+          className="w-full"
+        />
+        <label className="block text-sm">Background Width: {bgWidth}px</label>
+        <input
+          type="range"
+          min="100"
+          max="4000"
+          value={bgWidth}
+          onChange={(e) => setBgWidth(Number(e.target.value))}
+          className="w-full"
+        />
+        <label className="block text-sm">Background Height: {bgHeight}px</label>
+        <input
+          type="range"
+          min="100"
+          max="4000"
+          value={bgHeight}
+          onChange={(e) => setBgHeight(Number(e.target.value))}
+          className="w-full"
+        />
+        <label className="block text-sm">Background X Offset: {bgX}px</label>
+        <input
+          type="range"
+          min="-1000"
+          max="1000"
+          value={bgX}
+          onChange={(e) => setBgX(Number(e.target.value))}
+          className="w-full"
+        />
+        <label className="block text-sm">Background Y Offset: {bgY}px</label>
+        <input
+          type="range"
+          min="-1000"
+          max="1000"
+          value={bgY}
+          onChange={(e) => setBgY(Number(e.target.value))}
           className="w-full"
         />
         <div className="flex justify-end gap-2 pt-2">

--- a/webapp/src/pages/Games/PollRoyale.jsx
+++ b/webapp/src/pages/Games/PollRoyale.jsx
@@ -34,6 +34,12 @@ export default function PollRoyale() {
   const iframeParams = new URLSearchParams(search);
   if (calibration?.width) iframeParams.set('cw', calibration.width);
   if (calibration?.height) iframeParams.set('ch', calibration.height);
+  if (calibration?.bgWidth) iframeParams.set('bw', calibration.bgWidth);
+  if (calibration?.bgHeight) iframeParams.set('bh', calibration.bgHeight);
+  if (typeof calibration?.bgX === 'number')
+    iframeParams.set('bx', calibration.bgX);
+  if (typeof calibration?.bgY === 'number')
+    iframeParams.set('by', calibration.bgY);
   const src = `/poll-royale.html?${iframeParams.toString()}`;
 
   return (

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -568,6 +568,10 @@ export function getPollRoyaleCalibration() {
   return get('/api/pollroyale/calibration');
 }
 
-export function savePollRoyaleCalibration(width, height) {
-  return post('/api/pollroyale/calibration', { width, height }, API_AUTH_TOKEN || undefined);
+export function savePollRoyaleCalibration(width, height, bgWidth, bgHeight, bgX, bgY) {
+  return post(
+    '/api/pollroyale/calibration',
+    { width, height, bgWidth, bgHeight, bgX, bgY },
+    API_AUTH_TOKEN || undefined
+  );
 }


### PR DESCRIPTION
## Summary
- add width, height and offset controls for Poll Royale background calibration
- persist extended calibration and pass to iframe
- apply saved values to game background

## Testing
- `npm test` *(fails: canvas.node was compiled against a different Node.js version)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1b07b7c948329a76ad02ba5b589be