### PR TITLE
fix: allow multiple users without telegramId

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -39,7 +39,11 @@ nftTokenId: String
 
 const userSchema = new mongoose.Schema({
 
-  telegramId: { type: Number, unique: true },
+  // Allow multiple users without a Telegram account. The sparse unique index
+  // defined below ensures that only defined telegramId values must be unique,
+  // while documents without one can coexist without triggering duplicate key
+  // errors.
+  telegramId: { type: Number },
 
   // Allow multiple users without a Google account. By omitting the field when
   // it isn't provided (default: undefined), the sparse unique index below will
@@ -117,6 +121,8 @@ const userSchema = new mongoose.Schema({
 
 // Index commonly queried fields
 userSchema.index({ nickname: 1 });
+// Enforce uniqueness of telegramId only when the field exists
+userSchema.index({ telegramId: 1 }, { unique: true, sparse: true });
 // Enforce uniqueness of googleId only when the field exists
 userSchema.index({ googleId: 1 }, { unique: true, sparse: true });
 // Ensure walletAddress remains unique when present

--- a/test/telegramSparseIndex.test.js
+++ b/test/telegramSparseIndex.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import User from '../bot/models/User.js';
+
+// Regression test: inserting multiple users without a telegramId should not
+// trigger a duplicate key error on the telegramId index.
+test('allows multiple users without telegramId', async () => {
+  const mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  try {
+    await User.create({ walletAddress: 'addr1' });
+    await User.create({ walletAddress: 'addr2' });
+    const count = await User.countDocuments();
+    assert.equal(count, 2);
+  } finally {
+    await mongoose.disconnect();
+    await mongo.stop();
+  }
+});


### PR DESCRIPTION
## Summary
- allow multiple users without a telegramId by using a sparse unique index
- add regression test ensuring inserting two wallet-only users does not collide

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*


------
https://chatgpt.com/codex/tasks/task_e_68a1b484c2948329bdf309b8112f67aa