### PR TITLE
Fix raise controller visibility in Texas Hold’em

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -61,7 +61,7 @@
 .seat.bottom-right { left: 84%; top: 63%; transform: translate(-50%, -50%); }
       .seat.bottom .cards{ gap:0 }
       .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
-    .controls{ display:flex; gap:8px; margin-top:8px; }
+    .controls{ position:fixed; bottom:16px; right:16px; display:flex; gap:8px; z-index:10; }
     .controls button{ padding:6px 12px; border:none; border-radius:8px; background:#2563eb; color:#fff; font-weight:600; }
     #status{ position:absolute; top:52%; left:50%; transform:translate(-50%, -50%); font-weight:900; letter-spacing:.3px; color:#ff0; background:rgba(0,0,0,.28); padding:6px 12px; border-radius:12px; border:1px solid rgba(255,255,255,.12); text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
     .winnerOverlay{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;background:rgba(0,0,0,0.6);z-index:60}


### PR DESCRIPTION
## Summary
- Position player action controls (fold, check, call, raise) at the bottom-right corner of the screen so the raise button is visible

## Testing
- `npm test` *(fails: canvas bindings missing; snake API test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b9d5ef3883298b0f5506ebd0f638