### PR TITLE
Rename Poll Royale to Pool Royale

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"
     />
-    <title>Deluxe Billiards • 2.5D Cartoon (Portrait)</title>
+    <title>Pool Royale 🎱</title>
     <style>
       /* ------------------------------------------------------------------
        DELUXE BILLIARDS 2.5D CARTOON (PORTRAIT)
@@ -108,8 +108,8 @@
         overflow: hidden;
         background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
           center/cover no-repeat;
-        background-position: calc(50% - 5px) calc(50% + 5px);
-        background-size: calc(100% - 20px) auto;
+        background-position: calc(50% - 10px) calc(50% - 5px);
+        background-size: calc(100% - 20px) calc(100% + 20px);
       }
 
       :root {
@@ -714,15 +714,21 @@
             new Ball(BALL_BY_N[0], TABLE_W / 2, CUE_START_Y)
           );
 
-          // Trekendshi poshte me 15 topa (8-shi ne qender rreshti 3)
+          // Trekendshi siper me 15 topa (8-shi ne qender rreshti 3)
           var cx = TABLE_W / 2;
-          var cy = TABLE_H - FOOT_SPOT_Y;
+          var cy = FOOT_SPOT_Y;
           var rowGap = BALL_R * 1.95;
           var colGap = BALL_R * 2.1;
 
           // Rregullimi i topave ne trekendesh:
-          // 1 ne maje, 8 ne qender, 2 dhe 11 ne cepat poshte
-          var layout = [[1], [0, 0], [0, 8, 0], [0, 0, 0, 0], [2, 0, 0, 0, 11]];
+          // 1 ne fund, 8 ne qender, 2 dhe 11 ne cepat siper
+          var layout = [
+            [2, 0, 0, 0, 11],
+            [0, 0, 0, 0],
+            [0, 8, 0],
+            [0, 0],
+            [1]
+          ];
 
           // Numrat e mbetur per mbushjen e trekendeshit
           var pool = [];
@@ -737,7 +743,7 @@
             var count = r + 1;
             for (j = 0; j < count; j++) {
               var x = cx - (count - 1) * BALL_R * 1.05 + j * colGap;
-              var y = cy - r * rowGap;
+              var y = cy + r * rowGap;
               var num = layout[r][j] || pool[cursor++];
               var info = BALL_BY_N[num];
               if (!info) {

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -40,8 +40,8 @@ import MurlanRoyale from './pages/Games/MurlanRoyale.jsx';
 import MurlanRoyaleLobby from './pages/Games/MurlanRoyaleLobby.jsx';
 import TexasHoldem from './pages/Games/TexasHoldem.jsx';
 import TexasHoldemLobby from './pages/Games/TexasHoldemLobby.jsx';
-import PollRoyale from './pages/Games/PollRoyale.jsx';
-import PollRoyaleLobby from './pages/Games/PollRoyaleLobby.jsx';
+import PoolRoyale from './pages/Games/PoolRoyale.jsx';
+import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -85,8 +85,8 @@ export default function App() {
             <Route path="/games/texasholdem" element={<TexasHoldem />} />
             <Route path="/games/murlanroyale/lobby" element={<MurlanRoyaleLobby />} />
             <Route path="/games/murlanroyale" element={<MurlanRoyale />} />
-            <Route path="/games/pollroyale/lobby" element={<PollRoyaleLobby />} />
-            <Route path="/games/pollroyale" element={<PollRoyale />} />
+            <Route path="/games/poolroyale/lobby" element={<PoolRoyaleLobby />} />
+            <Route path="/games/poolroyale" element={<PoolRoyale />} />
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />
             <Route path="/tasks" element={<Tasks />} />

--- a/webapp/src/components/AimGuideOverlay.jsx
+++ b/webapp/src/components/AimGuideOverlay.jsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { AimGuide } from '../utils/aimGuides';
 
 /**
- * React canvas overlay that renders aim guides for the 8 Pool Royale table.
+ * React canvas overlay that renders aim guides for the Pool Royale 🎱 table.
  * Expects cueBall and targetBall objects with {x, y}, a power value 0..1 and
  * optional spin object {side, top}. Table should define width, height and
  * ballRadius in canvas pixels.

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -77,11 +77,11 @@ export default function HomeGamesCard() {
             <h3 className="text-sm font-semibold text-center text-yellow-400">Bubble Pop Royale</h3>
           </Link>
           <Link
-            to="/games/pollroyale/lobby"
+            to="/games/poolroyale/lobby"
             className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
           >
             <img src="/assets/icons/pool-royale.svg" alt="" className="h-20 w-20" />
-            <h3 className="text-sm font-semibold text-center text-yellow-400">8 Poll Royale</h3>
+            <h3 className="text-sm font-semibold text-center text-yellow-400">Pool Royale 🎱</h3>
           </Link>
         </div>
       <Link

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -94,9 +94,9 @@ export default function InvitePopup({
                   alt: 'Tetris Royale',
                 },
                 {
-                  id: 'pollroyale',
+                  id: 'poolroyale',
                   src: '/assets/icons/pool-royale.svg',
-                  alt: '8 Poll Royale',
+                  alt: 'Pool Royale 🎱',
                 },
               ].map((g) => (
                   <img

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -30,7 +30,7 @@ function getGameFromTableId(id) {
       'bubblepoproyale',
       'bubblesmashroyale',
       'tetrisroyale',
-      'pollroyale',
+      'poolroyale',
     ].includes(prefix)
   )
     return prefix;

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -214,9 +214,9 @@ export default function PlayerInvitePopup({
                   alt: 'Tetris Royale',
                 },
                 {
-                  id: 'pollroyale',
+                  id: 'poolroyale',
                   src: '/assets/icons/pool-royale.svg',
-                  alt: '8 Poll Royale',
+                  alt: 'Pool Royale 🎱',
                 },
               ].map((g) => (
                 <img

--- a/webapp/src/components/ProjectAchievementsCard.jsx
+++ b/webapp/src/components/ProjectAchievementsCard.jsx
@@ -13,7 +13,7 @@ export default function ProjectAchievementsCard() {
     '🫧 Bubble Pop Royale',
     '💥 Bubble Smash Royale',
     '🧩 Tetris Royale',
-    '🎱 8 Poll Royale',
+    '🎱 Pool Royale 🎱',
     '🔄 Daily Check-In rewards',
     '⛏️ Mining system active',
     '📺 Ad watch rewards',

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -21,7 +21,7 @@ const GAME_NAME_MAP = {
   fruitslice: 'Fruit Slice Royale',
   brickbreaker: 'Brick Breaker Royale',
   fallingball: 'Falling Ball',
-  poll: '8 Poll Royale'
+  pool: 'Pool Royale 🎱'
 };
 
 function getGameName(slug = '') {

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -143,7 +143,7 @@ export default function Games() {
                   </h3>
                 </Link>
                 <Link
-                  to="/games/pollroyale/lobby"
+                  to="/games/poolroyale/lobby"
                   className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
                 >
                   <img src="/assets/icons/pool-royale.svg" alt="" className="h-20 w-20" />
@@ -151,7 +151,7 @@ export default function Games() {
                     className="text-sm font-semibold text-center text-yellow-400"
                     style={{ WebkitTextStroke: '1px black' }}
                   >
-                    8 Poll Royale
+                    Pool Royale 🎱
                   </h3>
                 </Link>
             </div>

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
-import { getPollRoyaleCalibration } from '../../utils/api.js';
+import { getPoolRoyaleCalibration } from '../../utils/api.js';
 
-export default function PollRoyale() {
+export default function PoolRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
   const [calibration, setCalibration] = useState(null);
@@ -11,7 +11,7 @@ export default function PollRoyale() {
   useEffect(() => {
     async function load() {
       try {
-        const res = await getPollRoyaleCalibration();
+        const res = await getPoolRoyaleCalibration();
         if (!res.error && res.width && res.height) {
           setCalibration(res);
         }
@@ -29,11 +29,11 @@ export default function PollRoyale() {
     iframeParams.set('bx', calibration.bgX);
   if (typeof calibration?.bgY === 'number')
     iframeParams.set('by', calibration.bgY);
-  const src = `/poll-royale.html?${iframeParams.toString()}`;
+  const src = `/pool-royale.html?${iframeParams.toString()}`;
 
   return (
     <div className="relative w-full h-screen">
-      <iframe src={src} title="8 Poll Royale" className="w-full h-full border-0" />
+      <iframe src={src} title="Pool Royale 🎱" className="w-full h-full border-0" />
     </div>
   );
 }

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -6,7 +6,7 @@ import { ensureAccountId, getTelegramId, getTelegramPhotoUrl, getTelegramFirstNa
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 
-export default function PollRoyaleLobby() {
+export default function PoolRoyaleLobby() {
   const navigate = useNavigate();
   useTelegramBackButton();
 
@@ -33,7 +33,7 @@ export default function PollRoyaleLobby() {
       }
       tgId = getTelegramId();
       await addTransaction(tgId, -stake.amount, 'stake', {
-        game: 'pollroyale',
+        game: 'poolroyale',
         players: 2,
         accountId,
       });
@@ -56,12 +56,12 @@ export default function PollRoyaleLobby() {
     if (devAcc1) params.set('dev1', devAcc1);
     if (devAcc2) params.set('dev2', devAcc2);
     if (initData) params.set('init', encodeURIComponent(initData));
-    navigate(`/games/pollroyale?${params.toString()}`);
+    navigate(`/games/poolroyale?${params.toString()}`);
   };
 
   return (
     <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
-      <h2 className="text-xl font-bold text-center">8 Poll Royale Lobby</h2>
+      <h2 className="text-xl font-bold text-center">Pool Royale 🎱 Lobby</h2>
       <div className="space-y-2">
         <h3 className="font-semibold">Mode</h3>
         <div className="flex gap-2">

--- a/webapp/src/utils/aimGuides.js
+++ b/webapp/src/utils/aimGuides.js
@@ -1,4 +1,4 @@
-// Advanced aim guide calculations for 8 Pool Royale
+// Advanced aim guide calculations for Pool Royale 🎱
 // Implements dotted guide lines for cue and object balls taking into account
 // power, spin and simple reflections on a rectangular table with pockets.
 

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -564,13 +564,13 @@ export function getWatchCount(tableId) {
 export function getAppStats() {
   return get('/api/stats');
 }
-export function getPollRoyaleCalibration() {
-  return get('/api/pollroyale/calibration');
+export function getPoolRoyaleCalibration() {
+  return get('/api/poolroyale/calibration');
 }
 
-export function savePollRoyaleCalibration(width, height, bgWidth, bgHeight, bgX, bgY) {
+export function savePoolRoyaleCalibration(width, height, bgWidth, bgHeight, bgX, bgY) {
   return post(
-    '/api/pollroyale/calibration',
+    '/api/poolroyale/calibration',
     { width, height, bgWidth, bgHeight, bgX, bgY },
     API_AUTH_TOKEN || undefined
   );


### PR DESCRIPTION
## Summary
- rename Poll Royale assets and routes to Pool Royale 🎱
- adjust Pool Royale background and rack layout
- update references and utility APIs for new Pool Royale name

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint` *(fails: 473 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c6afb3a883299a7ccc326d9fc706