### PR TITLE
Improve raise slider in Texas Hold'em

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -62,8 +62,10 @@
       .seat.bottom .cards{ gap:0 }
       .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
     .controls{ display:flex; gap:8px; margin-top:8px; }
-    .controls button{ padding:6px 12px; border:none; border-radius:8px; background:#2563eb; color:#fff; font-weight:600; }
+    .controls button{ padding:4px 8px; border:none; border-radius:8px; background:#2563eb; color:#fff; font-weight:600; font-size:12px; }
     .raise-container{ display:flex; flex-direction:column; align-items:center; }
+    #raise{ padding:6px 12px; font-size:14px; }
+    .raise-amount{ font-size:10px; margin-top:2px; }
     #raisePanel{ position:relative; width:clamp(44px,5vw,88px); height:25vh; padding:12px; border-radius:14px; background:rgba(255,255,255,0.02); overflow:hidden; }
     #raisePanel::before{ content:""; position:absolute; left:50%; top:12px; bottom:12px; width:1px; background:rgba(230,237,247,0.2); }
     #raiseFill{ position:absolute; left:12px; right:12px; bottom:12px; height:0%; border-radius:8px; background:linear-gradient(to top,#10b981,#facc15,#ef4444); box-shadow:inset 0 -1px 0 rgba(0,0,0,0.2); }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -196,6 +196,11 @@ function showControls() {
   btn.addEventListener('click', playerRaise);
   if (state.pot >= state.maxPot) btn.disabled = true;
   raiseContainer.appendChild(btn);
+  const amountText = document.createElement('div');
+  amountText.id = 'raiseAmountText';
+  amountText.className = 'raise-amount';
+  amountText.textContent = `0 ${state.token}`;
+  raiseContainer.appendChild(amountText);
   controls.appendChild(raiseContainer);
   initRaiseSlider();
 }
@@ -214,6 +219,10 @@ function initRaiseSlider() {
     thumb.style.bottom = 'calc(12px + (100% - 24px) * ' + pct + ')';
     const maxAllowed = Math.min(state.stake, state.maxPot - state.pot);
     state.raiseAmount = Math.round(pct * maxAllowed);
+    const amtEl = document.getElementById('raiseAmountText');
+    if (amtEl) amtEl.textContent = `${state.raiseAmount} ${state.token}`;
+    const status = document.getElementById('status');
+    if (status) status.textContent = `Raise ${state.raiseAmount} ${state.token}`;
   }
   panel.addEventListener('pointerdown', function (e) {
     update(e);


### PR DESCRIPTION
## Summary
- Shrink fold/check/call buttons to previous size
- Display raise amount beneath the raise button and update live while sliding
- Show raise amount in status message during slider interaction

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1dbf55b30832997a5229fcddea5b4