### PR TITLE
feat(pool): add pocket calibration

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -439,8 +439,14 @@
             var bh = parseInt(p.get('bh'));
             var bx = parseInt(p.get('bx'));
             var by = parseInt(p.get('by'));
+            var pockets = [];
+            for (var i = 1; i <= 6; i++) {
+              var px = parseInt(p.get('p' + i + 'x'));
+              var py = parseInt(p.get('p' + i + 'y'));
+              if (!isNaN(px) && !isNaN(py)) pockets.push({ x: px, y: py });
+            }
             if (w && h)
-              return { w: w, h: h, bw: bw, bh: bh, bx: bx, by: by };
+              return { w: w, h: h, bw: bw, bh: bh, bx: bx, by: by, pockets: pockets };
           } catch {}
           return { w: 1000, h: 2000, bw: 0, bh: 0, bx: 0, by: 0 };
         })();
@@ -756,14 +762,21 @@
           }
 
           // Pockets (4 qoshe + 2 te mesit anesore)
-          this.pockets = [
-            new Pocket(BORDER, BORDER),
-            new Pocket(TABLE_W - BORDER, BORDER),
-            new Pocket(BORDER, TABLE_H / 2),
-            new Pocket(TABLE_W - BORDER, TABLE_H / 2),
-            new Pocket(BORDER, TABLE_H - BORDER),
-            new Pocket(TABLE_W - BORDER, TABLE_H - BORDER)
+          var defPockets = [
+            { x: BORDER, y: BORDER },
+            { x: TABLE_W - BORDER, y: BORDER },
+            { x: BORDER, y: TABLE_H / 2 },
+            { x: TABLE_W - BORDER, y: TABLE_H / 2 },
+            { x: BORDER, y: TABLE_H - BORDER },
+            { x: TABLE_W - BORDER, y: TABLE_H - BORDER }
           ];
+          var calPockets = (CAL.pockets || []).length === 6 ? CAL.pockets : defPockets;
+          this.pockets = calPockets.map(function (p, idx) {
+            var def = defPockets[idx];
+            var x = typeof p.x === 'number' ? p.x : def.x;
+            var y = typeof p.y === 'number' ? p.y : def.y;
+            return new Pocket(x, y);
+          });
 
           // TESTE TE INTEGRITETIT (console.assert)
           runSelfTests(this);

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -42,6 +42,7 @@ import TexasHoldem from './pages/Games/TexasHoldem.jsx';
 import TexasHoldemLobby from './pages/Games/TexasHoldemLobby.jsx';
 import PoolRoyale from './pages/Games/PoolRoyale.jsx';
 import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
+import PoolRoyaleCalibration from './pages/Games/PoolRoyaleCalibration.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -87,6 +88,7 @@ export default function App() {
             <Route path="/games/murlanroyale" element={<MurlanRoyale />} />
             <Route path="/games/poolroyale/lobby" element={<PoolRoyaleLobby />} />
             <Route path="/games/poolroyale" element={<PoolRoyale />} />
+            <Route path="/games/poolroyale/calibrate" element={<PoolRoyaleCalibration />} />
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />
             <Route path="/tasks" element={<Tasks />} />

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { getPoolRoyaleCalibration } from '../../utils/api.js';
 
@@ -29,11 +29,23 @@ export default function PoolRoyale() {
     iframeParams.set('bx', calibration.bgX);
   if (typeof calibration?.bgY === 'number')
     iframeParams.set('by', calibration.bgY);
+  if (Array.isArray(calibration?.pockets)) {
+    calibration.pockets.forEach((p, i) => {
+      if (typeof p.x === 'number') iframeParams.set(`p${i + 1}x`, p.x);
+      if (typeof p.y === 'number') iframeParams.set(`p${i + 1}y`, p.y);
+    });
+  }
   const src = `/pool-royale.html?${iframeParams.toString()}`;
 
   return (
     <div className="relative w-full h-screen">
       <iframe src={src} title="Pool Royale 🎱" className="w-full h-full border-0" />
+      <Link
+        to="/games/poolroyale/calibrate"
+        className="absolute top-2 right-2 bg-background/70 text-text p-2 rounded-full"
+      >
+        ⚙️
+      </Link>
     </div>
   );
 }

--- a/webapp/src/pages/Games/PoolRoyaleCalibration.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleCalibration.jsx
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useState } from 'react';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import {
+  getPoolRoyaleCalibration,
+  savePoolRoyaleCalibration
+} from '../../utils/api.js';
+
+export default function PoolRoyaleCalibration() {
+  useTelegramBackButton();
+  const [dims, setDims] = useState({ width: 1000, height: 2000, bgWidth: 0, bgHeight: 0, bgX: 0, bgY: 0 });
+  const [pockets, setPockets] = useState([
+    { x: 0.05, y: 0.05 },
+    { x: 0.95, y: 0.05 },
+    { x: 0.05, y: 0.5 },
+    { x: 0.95, y: 0.5 },
+    { x: 0.05, y: 0.95 },
+    { x: 0.95, y: 0.95 }
+  ]);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await getPoolRoyaleCalibration();
+        if (!res.error) {
+          if (res.width) {
+            setDims({
+              width: res.width,
+              height: res.height,
+              bgWidth: res.bgWidth,
+              bgHeight: res.bgHeight,
+              bgX: res.bgX,
+              bgY: res.bgY
+            });
+          }
+          if (Array.isArray(res.pockets)) {
+            const np = res.pockets.map(p => ({
+              x: p.x / res.width,
+              y: p.y / res.height
+            }));
+            if (np.length === 6) setPockets(np);
+          }
+        }
+      } catch {}
+    }
+    load();
+  }, []);
+
+  function updatePocket(i, clientX, clientY) {
+    const rect = containerRef.current.getBoundingClientRect();
+    const x = (clientX - rect.left) / rect.width;
+    const y = (clientY - rect.top) / rect.height;
+    setPockets(prev => prev.map((p, idx) => (idx === i ? { x, y } : p)));
+  }
+
+  function handlePointerDown(i, e) {
+    e.preventDefault();
+    const move = ev => updatePocket(i, ev.clientX, ev.clientY);
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  }
+
+  async function save() {
+    const numeric = pockets.map(p => ({ x: Math.round(p.x * dims.width), y: Math.round(p.y * dims.height) }));
+    try {
+      await savePoolRoyaleCalibration(
+        dims.width,
+        dims.height,
+        dims.bgWidth,
+        dims.bgHeight,
+        dims.bgX,
+        dims.bgY,
+        numeric
+      );
+      alert('Calibration saved');
+    } catch {}
+  }
+
+  return (
+    <div ref={containerRef} className="relative w-full h-screen bg-black">
+      <img
+        src="/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp"
+        className="w-full h-full object-cover pointer-events-none"
+        alt="table"
+      />
+      <svg className="absolute inset-0 w-full h-full pointer-events-none" viewBox="0 0 1 1" preserveAspectRatio="none">
+        <polygon
+          points={pockets.map(p => `${p.x},${p.y}`).join(' ')}
+          fill="none"
+          stroke="lime"
+          strokeWidth="0.005"
+        />
+      </svg>
+      {pockets.map((p, i) => (
+        <div
+          key={i}
+          className="absolute w-4 h-4 bg-green-500 rounded-full border-2 border-white"
+          style={{
+            left: `${p.x * 100}%`,
+            top: `${p.y * 100}%`,
+            transform: 'translate(-50%, -50%)'
+          }}
+          onPointerDown={e => handlePointerDown(i, e)}
+        />
+      ))}
+      <button
+        onClick={save}
+        className="absolute bottom-4 right-4 bg-primary text-background px-4 py-2 rounded"
+      >
+        Save
+      </button>
+    </div>
+  );
+}
+

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -568,10 +568,18 @@ export function getPoolRoyaleCalibration() {
   return get('/api/poolroyale/calibration');
 }
 
-export function savePoolRoyaleCalibration(width, height, bgWidth, bgHeight, bgX, bgY) {
+export function savePoolRoyaleCalibration(
+  width,
+  height,
+  bgWidth,
+  bgHeight,
+  bgX,
+  bgY,
+  pockets
+) {
   return post(
     '/api/poolroyale/calibration',
-    { width, height, bgWidth, bgHeight, bgX, bgY },
+    { width, height, bgWidth, bgHeight, bgX, bgY, pockets },
     API_AUTH_TOKEN || undefined
   );
 }


### PR DESCRIPTION
## Summary
- add calibration interface for Pool Royale pockets
- expose pockets in API and game query parameters
- allow adjusting pocket positions in Pool Royale game via calibration icon

## Testing
- `npm test` *(fails: Failed to launch Telegram bot: The "options.agent" property must be one of Agent-like Object, undefined, or false. Received an instance of ProxyAgent)*
- `npm run lint` *(fails: 473 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e025fc7c8329b04b08722f8afa4b