### PR TITLE
Adjust poker controls layout and styling

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -61,13 +61,14 @@
 .seat.bottom-right { left: 84%; top: 63%; transform: translate(-50%, -50%); }
       .seat.bottom .cards{ gap:0 }
       .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
-    .controls{ display:flex; gap:8px; margin-top:8px; }
-    .controls button{ width:var(--avatar-size); height:var(--avatar-size); padding:0; border:4px solid #000; border-radius:50%; background:#2563eb; color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
+      .controls{ display:flex; gap:8px; margin-top:8px; align-self:flex-start; margin-left:-20px; }
+      .controls button,
+      .raise-container button{ width:var(--avatar-size); height:var(--avatar-size); padding:0; border:4px solid #000; border-radius:50%; background:#2563eb; color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; -webkit-text-stroke:1px #000; }
     #raise{ background:#2563eb; }
     #check{ background:#facc15; }
     #call{ background:#16a34a; }
     #fold{ background:#dc2626; }
-    .raise-container{ position:fixed; right:2vw; top:50%; transform:translateY(-50%); display:flex; flex-direction:column; align-items:center; gap:8px; }
+      .raise-container{ position:fixed; display:flex; flex-direction:column; align-items:center; gap:8px; }
     #raise{ padding:0; font-size:14px; border-radius:50%; }
     .raise-amount{ font-size:10px; margin-top:2px; }
     #raisePanel{ position:relative; width:clamp(44px,5vw,88px); height:25vh; padding:12px; border-radius:14px; background:rgba(255,255,255,0.02); overflow:hidden; }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -179,12 +179,13 @@ function showControls() {
   baseActions.forEach((a) => {
     const btn = document.createElement('button');
     btn.id = a.id;
-    btn.textContent = a.id;
+    btn.textContent = a.id.charAt(0).toUpperCase() + a.id.slice(1);
     btn.addEventListener('click', a.fn);
     controls.appendChild(btn);
   });
   const raiseContainer = document.createElement('div');
   raiseContainer.className = 'raise-container';
+  raiseContainer.id = 'raiseContainer';
   const panel = document.createElement('div');
   panel.id = 'raisePanel';
   panel.innerHTML =
@@ -192,7 +193,7 @@ function showControls() {
     '<div id="raiseFill"></div><div id="raiseThumb"></div>';
   raiseContainer.appendChild(panel);
   const btn = document.createElement('button');
-  btn.textContent = 'raise';
+  btn.textContent = 'Raise';
   btn.id = 'raise';
   btn.addEventListener('click', playerRaise);
   if (state.pot >= state.maxPot) btn.disabled = true;
@@ -202,8 +203,10 @@ function showControls() {
   amountText.className = 'raise-amount';
   amountText.textContent = `0 ${state.token}`;
   raiseContainer.appendChild(amountText);
-  controls.appendChild(raiseContainer);
+  document.body.appendChild(raiseContainer);
   initRaiseSlider();
+  positionRaiseContainer();
+  window.addEventListener('resize', positionRaiseContainer);
 }
 
 function initRaiseSlider() {
@@ -237,9 +240,29 @@ function initRaiseSlider() {
   });
 }
 
+function positionRaiseContainer() {
+  const bottom = document.querySelector('.seat.bottom .avatar-wrap');
+  const right =
+    document.querySelector('.seat.right .avatar-wrap') ||
+    document.querySelector('.seat.bottom-right .avatar-wrap');
+  const container = document.getElementById('raiseContainer');
+  const btn = document.getElementById('raise');
+  if (!bottom || !right || !container || !btn) return;
+  const bottomRect = bottom.getBoundingClientRect();
+  const rightRect = right.getBoundingClientRect();
+  const btnRect = btn.getBoundingClientRect();
+  container.style.left =
+    rightRect.left + rightRect.width / 2 - btnRect.width / 2 + 'px';
+  container.style.top =
+    bottomRect.top + bottomRect.height / 2 - btnRect.height / 2 + 'px';
+}
+
 function hideControls() {
   const controls = document.getElementById('controls');
   if (controls) controls.innerHTML = '';
+  const raiseContainer = document.getElementById('raiseContainer');
+  if (raiseContainer) raiseContainer.remove();
+  window.removeEventListener('resize', positionRaiseContainer);
 }
 
 function startPlayerTurn() {


### PR DESCRIPTION
## Summary
- Shift Fold/Check/Call controls slightly left with white text and black stroke
- Move Raise slider and button to right side of screen and align with player avatars
- Capitalize all action button labels and support dynamic positioning on resize

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*
- `npm run lint` *(fails: 473 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e8a87a5c8329bce2908894f5571b