### PR TITLE
Remove Pool Royale calibration icon

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useLocation, Link } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { getPoolRoyaleCalibration } from '../../utils/api.js';
 
@@ -40,12 +40,6 @@ export default function PoolRoyale() {
   return (
     <div className="relative w-full h-screen">
       <iframe src={src} title="Pool Royale 🎱" className="w-full h-full border-0" />
-      <Link
-        to="/games/poolroyale/calibrate"
-        className="absolute top-2 right-2 bg-background/70 text-text p-2 rounded-full"
-      >
-        ⚙️
-      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove gear link from Pool Royale so calibration page is no longer accessible in the UI

## Testing
- `npm test` *(fails: tests hang with server still running)*
- `npm run lint` *(fails: 473 errors in lib/texasHoldem.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f0f1c2908329992750988764727b