### PR TITLE
Align raise controls with bottom avatars

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -68,7 +68,8 @@
     #check{ background:#facc15; }
     #call{ background:#16a34a; }
     #fold{ background:#dc2626; }
-      .raise-container{ position:fixed; display:flex; flex-direction:column; align-items:center; gap:8px; }
+      .raise-container{ position:fixed; display:flex; align-items:center; gap:8px; }
+      .raise-btn-wrap{ display:flex; flex-direction:column; align-items:center; }
     #raise{ padding:0; font-size:14px; border-radius:50%; }
     .raise-amount{ font-size:10px; margin-top:2px; }
     #raisePanel{ position:relative; width:clamp(44px,5vw,88px); height:25vh; padding:12px; border-radius:14px; background:rgba(255,255,255,0.02); overflow:hidden; }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -197,12 +197,15 @@ function showControls() {
   btn.id = 'raise';
   btn.addEventListener('click', playerRaise);
   if (state.pot >= state.maxPot) btn.disabled = true;
-  raiseContainer.appendChild(btn);
+  const btnWrap = document.createElement('div');
+  btnWrap.className = 'raise-btn-wrap';
+  btnWrap.appendChild(btn);
   const amountText = document.createElement('div');
   amountText.id = 'raiseAmountText';
   amountText.className = 'raise-amount';
   amountText.textContent = `0 ${state.token}`;
-  raiseContainer.appendChild(amountText);
+  btnWrap.appendChild(amountText);
+  raiseContainer.appendChild(btnWrap);
   document.body.appendChild(raiseContainer);
   initRaiseSlider();
   positionRaiseContainer();
@@ -243,18 +246,17 @@ function initRaiseSlider() {
 function positionRaiseContainer() {
   const bottom = document.querySelector('.seat.bottom .avatar-wrap');
   const right =
-    document.querySelector('.seat.right .avatar-wrap') ||
-    document.querySelector('.seat.bottom-right .avatar-wrap');
+    document.querySelector('.seat.bottom-right .avatar-wrap') ||
+    document.querySelector('.seat.right .avatar-wrap');
   const container = document.getElementById('raiseContainer');
-  const btn = document.getElementById('raise');
-  if (!bottom || !right || !container || !btn) return;
+  if (!bottom || !right || !container) return;
   const bottomRect = bottom.getBoundingClientRect();
   const rightRect = right.getBoundingClientRect();
-  const btnRect = btn.getBoundingClientRect();
+  const containerRect = container.getBoundingClientRect();
   container.style.left =
-    rightRect.left + rightRect.width / 2 - btnRect.width / 2 + 'px';
+    rightRect.left + rightRect.width / 2 - containerRect.width / 2 + 'px';
   container.style.top =
-    bottomRect.top + bottomRect.height / 2 - btnRect.height / 2 + 'px';
+    bottomRect.top + bottomRect.height / 2 - containerRect.height / 2 + 'px';
 }
 
 function hideControls() {


### PR DESCRIPTION
## Summary
- Position Texas Hold'em raise slider and button along bottom avatar's horizontal line and bottom-right avatar's vertical line.
- Display raise slider beside a vertically stacked raise button and amount label.

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*

------
https://chatgpt.com/codex/tasks/task_e_68a1ef6276a08329a30b51c21e818668