### PR TITLE
Calibrate Pool Royale pocket positions

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -448,7 +448,22 @@
             if (w && h)
               return { w: w, h: h, bw: bw, bh: bh, bx: bx, by: by, pockets: pockets };
           } catch {}
-          return { w: 1000, h: 2000, bw: 0, bh: 0, bx: 0, by: 0 };
+          return {
+            w: 691,
+            h: 1536,
+            bw: 0,
+            bh: 0,
+            bx: 0,
+            by: 0,
+            pockets: [
+              { x: 48, y: 233 },
+              { x: 643, y: 233 },
+              { x: 48, y: 842 },
+              { x: 643, y: 842 },
+              { x: 48, y: 1450 },
+              { x: 643, y: 1450 }
+            ]
+          };
         })();
         var TABLE_W = CAL.w; // gjeresi logjike e felt-it
         var TABLE_H = CAL.h; // gjatesia logjike e felt-it

--- a/webapp/src/pages/Games/PoolRoyaleCalibration.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleCalibration.jsx
@@ -7,8 +7,22 @@ import {
 
 export default function PoolRoyaleCalibration() {
   useTelegramBackButton();
-  const [dims, setDims] = useState({ width: 1000, height: 2000, bgWidth: 0, bgHeight: 0, bgX: 0, bgY: 0 });
-  const [pockets, setPockets] = useState([]);
+  const [dims, setDims] = useState({
+    width: 691,
+    height: 1536,
+    bgWidth: 0,
+    bgHeight: 0,
+    bgX: 0,
+    bgY: 0
+  });
+  const [pockets, setPockets] = useState([
+    { x: 48, y: 233 },
+    { x: 643, y: 233 },
+    { x: 48, y: 842 },
+    { x: 643, y: 842 },
+    { x: 48, y: 1450 },
+    { x: 643, y: 1450 }
+  ]);
 
   useEffect(() => {
     async function load() {


### PR DESCRIPTION
## Summary
- set default table size to 691×1536 and align pockets to supplied coordinates
- preload same calibration values in PoolRoyaleCalibration page

## Testing
- `npm test` *(fails: snake API endpoints and socket events – test timed out)*
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1f41360748329b1211d34d5b1eaed