### PR TITLE
Adjust Pool Royale field positioning

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -108,9 +108,9 @@
         overflow: hidden;
         background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
           center/cover no-repeat;
-        /* Tweak pool field dimensions and position a bit more */
-        background-position: calc(50% - 8px) calc(50% + 4px);
-        background-size: calc(100% - 10px) calc(100% + 20px);
+        /* Adjust pool field: slightly up, right, wider and shorter */
+        background-position: calc(50% - 6px) calc(50% + 2px);
+        background-size: calc(100% - 6px) calc(100% + 10px);
       }
 
       :root {


### PR DESCRIPTION
## Summary
- nudge Pool Royale table background slightly upward and to the right
- widen and shorten the table background for better fit

## Testing
- `npm run lint` *(fails: 473 errors)*
- `npm test` *(fails: snake API endpoints and socket events timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a2019b9fa883299c8a98b816d849aa