### PR TITLE
Adjust Pool Royale table alignment

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -108,9 +108,9 @@
         overflow: hidden;
         background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
           center/cover no-repeat;
-        /* Adjust pool field: slightly up, right, wider and shorter */
-        background-position: calc(50% - 6px) calc(50% + 2px);
-        background-size: calc(100% - 6px) calc(100% + 10px);
+        /* Adjust pool field: moved slightly up and to the right; made wider and shorter */
+        background-position: calc(50% - 3px) calc(50% + 0px);
+        background-size: calc(100% + 8px) calc(100% - 6px);
       }
 
       :root {
@@ -475,13 +475,13 @@
         if (CAL.bw && CAL.bh) {
           wrap.style.backgroundSize = CAL.bw + 'px ' + CAL.bh + 'px';
         } else {
-          wrap.style.backgroundSize = 'calc(100% - 25px) calc(100% + 10px)';
+          wrap.style.backgroundSize = 'calc(100% + 8px) calc(100% - 6px)';
         }
         var xPos = isNaN(CAL.bx)
-          ? 'calc(50% - 8px)'
+          ? 'calc(50% - 3px)'
           : 'calc(50% + ' + CAL.bx + 'px)';
         var yPos = isNaN(CAL.by)
-          ? 'calc(50% + 8px)'
+          ? 'calc(50% + 0px)'
           : 'calc(50% + ' + CAL.by + 'px)';
         wrap.style.backgroundPosition = xPos + ' ' + yPos;
         var canvas = document.getElementById('table');


### PR DESCRIPTION
## Summary
- Fine-tune Pool Royale table placement to nudge field and pockets slightly up and right
- Slightly widen and shorten the pool field to better fit the background image

## Testing
- `npm test` *(terminated after successful test run as server kept running)*

------
https://chatgpt.com/codex/tasks/task_e_68a20678ffcc8329a79ec1736fb6693e