### PR TITLE
fix: restore holdem action buttons

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -61,15 +61,14 @@
 .seat.bottom-right { left: 84%; top: 63%; transform: translate(-50%, -50%); }
       .seat.bottom .cards{ gap:0 }
       .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
-      .controls{ display:flex; gap:8px; margin-top:8px; align-self:flex-start; margin-left:-20px; }
+      .controls{ display:flex; gap:8px; margin-top:8px; }
       .controls button,
       .raise-container button{ width:var(--avatar-size); height:var(--avatar-size); padding:0; border:4px solid #000; border-radius:50%; background:#2563eb; color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; -webkit-text-stroke:1px #000; }
     #raise{ background:#2563eb; }
     #check{ background:#facc15; }
     #call{ background:#16a34a; }
     #fold{ background:#dc2626; }
-      .raise-container{ position:fixed; display:flex; flex-direction:column; align-items:center; gap:8px; right:16px; bottom:12px; }
-      .raise-btn-wrap{ display:flex; flex-direction:column; align-items:center; }
+      .raise-container{ display:flex; flex-direction:column; align-items:center; }
     #raise{ padding:0; font-size:14px; border-radius:50%; }
     .raise-amount{ font-size:10px; margin-top:2px; }
     #raisePanel{ position:relative; width:clamp(48px,6vw,96px); height:22vh; padding:12px; border-radius:14px; background:rgba(255,255,255,0.02); overflow:hidden; }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -185,7 +185,6 @@ function showControls() {
   });
   const raiseContainer = document.createElement('div');
   raiseContainer.className = 'raise-container';
-  raiseContainer.id = 'raiseContainer';
   const panel = document.createElement('div');
   panel.id = 'raisePanel';
   panel.innerHTML =
@@ -197,19 +196,14 @@ function showControls() {
   btn.id = 'raise';
   btn.addEventListener('click', playerRaise);
   if (state.pot >= state.maxPot) btn.disabled = true;
-  const btnWrap = document.createElement('div');
-  btnWrap.className = 'raise-btn-wrap';
-  btnWrap.appendChild(btn);
+  raiseContainer.appendChild(btn);
   const amountText = document.createElement('div');
   amountText.id = 'raiseAmountText';
   amountText.className = 'raise-amount';
   amountText.textContent = `0 ${state.token}`;
-  btnWrap.appendChild(amountText);
-  raiseContainer.appendChild(btnWrap);
-  document.body.appendChild(raiseContainer);
+  raiseContainer.appendChild(amountText);
+  controls.appendChild(raiseContainer);
   initRaiseSlider();
-  positionRaiseContainer();
-  window.addEventListener('resize', positionRaiseContainer);
 }
 
 function initRaiseSlider() {
@@ -243,28 +237,9 @@ function initRaiseSlider() {
   });
 }
 
-function positionRaiseContainer() {
-  const bottom = document.querySelector('.seat.bottom .avatar-wrap');
-  const right =
-    document.querySelector('.seat.bottom-right .avatar-wrap') ||
-    document.querySelector('.seat.right .avatar-wrap');
-  const container = document.getElementById('raiseContainer');
-  if (!bottom || !right || !container) return;
-  const bottomRect = bottom.getBoundingClientRect();
-  const rightRect = right.getBoundingClientRect();
-  const containerRect = container.getBoundingClientRect();
-  container.style.left =
-    rightRect.left + rightRect.width / 2 - containerRect.width / 2 + 'px';
-  container.style.top =
-    bottomRect.top + bottomRect.height / 2 - containerRect.height / 2 + 8 + 'px';
-}
-
 function hideControls() {
   const controls = document.getElementById('controls');
   if (controls) controls.innerHTML = '';
-  const raiseContainer = document.getElementById('raiseContainer');
-  if (raiseContainer) raiseContainer.remove();
-  window.removeEventListener('resize', positionRaiseContainer);
 }
 
 function startPlayerTurn() {


### PR DESCRIPTION
## Summary
- Ensure Call, Check, Fold and Raise buttons render together in Texas Hold'em
- Simplify controls CSS to keep raise slider within action group

## Testing
- `npm test` *(fails: snake API endpoints and socket events timed out)*
- `npm run lint` *(fails: lint reported 473 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a232dc45fc83299f2f5f2e6103f957