### PR TITLE
Prevent null telegramId from breaking unique index

### DIFF
--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -170,20 +170,21 @@ router.post('/updateBalance', async (req, res) => {
 
 router.post('/addTransaction', async (req, res) => {
   const { telegramId, accountId, amount, type, game, players } = req.body;
-  if ((!telegramId && !accountId) || amount === undefined || !type) {
+  if ((telegramId == null && !accountId) || amount === undefined || !type) {
     return res
       .status(400)
       .json({ error: 'telegramId or accountId, amount and type required' });
   }
   let user = null;
-  if (telegramId) user = await User.findOne({ telegramId });
+  if (telegramId != null) user = await User.findOne({ telegramId });
   if (!user && accountId) user = await User.findOne({ accountId });
   if (!user) {
-    user = new User({
-      telegramId,
+    const data = {
       accountId,
       referralCode: String(telegramId || accountId)
-    });
+    };
+    if (telegramId != null) data.telegramId = telegramId;
+    user = new User(data);
   }
   ensureTransactionArray(user);
   const tx = { amount, type, date: new Date() };

--- a/webapp/public/brick-breaker-api.js
+++ b/webapp/public/brick-breaker-api.js
@@ -36,7 +36,6 @@
       const res = await post('/api/account/deposit', { accountId, amount, ...extra });
       if (res && res.error) {
         return post('/api/profile/addTransaction', {
-          telegramId: null,
           amount,
           type: 'deposit',
           accountId,
@@ -46,12 +45,9 @@
       return res;
     },
     addTransaction(telegramId, amount, type, extra = {}) {
-      return post('/api/profile/addTransaction', {
-        telegramId,
-        amount,
-        type,
-        ...extra
-      });
+      const body = { amount, type, ...extra };
+      if (telegramId != null) body.telegramId = telegramId;
+      return post('/api/profile/addTransaction', body);
     }
   };
 })();

--- a/webapp/public/falling-ball-api.js
+++ b/webapp/public/falling-ball-api.js
@@ -36,7 +36,6 @@
       const res = await post('/api/account/deposit', { accountId, amount, ...extra });
       if (res && res.error) {
         return post('/api/profile/addTransaction', {
-          telegramId: null,
           amount,
           type: 'deposit',
           accountId,
@@ -46,12 +45,9 @@
       return res;
     },
     addTransaction(telegramId, amount, type, extra = {}) {
-      return post('/api/profile/addTransaction', {
-        telegramId,
-        amount,
-        type,
-        ...extra
-      });
+      const body = { amount, type, ...extra };
+      if (telegramId != null) body.telegramId = telegramId;
+      return post('/api/profile/addTransaction', body);
     }
   };
 })();

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -262,12 +262,13 @@ export function updateBalance(telegramId, balance) {
 }
 
 export function addTransaction(telegramId, amount, type, extra = {}) {
-  return post('/api/profile/addTransaction', {
-    telegramId,
+  const body = {
     amount,
     type,
     ...extra,
-  });
+  };
+  if (telegramId != null) body.telegramId = telegramId;
+  return post('/api/profile/addTransaction', body);
 }
 
 export function getProfileByAccount(accountId) {


### PR DESCRIPTION
## Summary
- skip saving `telegramId` when creating transactions if it's null
- update client helpers to omit `telegramId` in requests unless defined

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint` *(fails: 473 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a2442cd6288329a2935424587710bd