### PR TITLE
Adjust Pool Royale background image dimensions

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -108,9 +108,9 @@
         overflow: hidden;
         background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
           center/cover no-repeat;
-        /* Adjust pool field: moved slightly up and to the right; made wider and shorter */
-        background-position: calc(50% - 3px) calc(50% + 0px);
-        background-size: calc(100% + 8px) calc(100% - 6px);
+        /* Adjust pool field: shift to trim right side and extend height */
+        background-position: calc(50% + 2px) calc(50% - 2px);
+        background-size: calc(100% + 4px) calc(100% + 4px);
       }
 
       :root {


### PR DESCRIPTION
## Summary
- Refine Pool Royale background to trim the right side and make the playfield taller

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint` *(fails: 473 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c22791808329bb1a9cee836777c8