### PR TITLE
Refine Pool Royale table and power slider

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -108,9 +108,9 @@
         overflow: hidden;
         background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
           center/cover no-repeat;
-        /* Adjust pool field: shift to trim right side and extend height */
-        background-position: calc(50% + 2px) calc(50% - 2px);
-        background-size: calc(100% + 4px) calc(100% + 4px);
+        /* Adjust pool field: expand slightly right and shorten vertically */
+        background-position: calc(50% - 2px) calc(50% + 2px);
+        background-size: calc(100% + 8px) calc(100% - 4px);
       }
 
       :root {
@@ -207,7 +207,7 @@
         top: 12px;
         bottom: 12px;
         width: 1px;
-        background: rgba(230, 237, 247, 0.2);
+        background: rgba(255, 255, 255, 0.4);
       }
       #sliderTrack::after {
         content: '';
@@ -222,7 +222,7 @@
         left: 50%;
         width: 8px;
         height: 1px;
-        background: rgba(230, 237, 247, 0.6);
+        background: rgba(255, 255, 255, 0.9);
         transform: translateX(-50%);
       }
       #sliderTrack .tick span {
@@ -231,7 +231,7 @@
         top: 50%;
         transform: translateY(-50%);
         font-size: 9px;
-        color: rgba(230, 237, 247, 0.6);
+        color: rgba(255, 255, 255, 0.9);
       }
       #sliderTrack .tick.mid {
         width: 12px;
@@ -244,16 +244,16 @@
         width: 3px;
         height: 3px;
         border-radius: 50%;
-        background: rgba(230, 237, 247, 0.6);
+        background: rgba(255, 255, 255, 0.9);
       }
       #powerFill {
         position: absolute;
         left: 12px;
         right: 12px;
-        bottom: 12px;
+        top: 12px;
         height: 0%;
         border-radius: 8px;
-        background: linear-gradient(to top, #10b981, #facc15, #ef4444);
+        background: linear-gradient(to bottom, #10b981, #facc15, #ef4444);
         box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.2);
       }
       #powerFill::after {
@@ -268,10 +268,10 @@
       #thumb {
         position: absolute;
         left: 50%;
-        transform: translate(-50%, 50%);
-        bottom: 12px;
-        width: 28px;
-        height: 28px;
+        top: 12px;
+        transform: translate(-50%, -50%);
+        width: 32px;
+        height: 32px;
         border-radius: 50%;
         background: #ffffff;
         border: 4px solid #0b1224;
@@ -288,7 +288,7 @@
       #thumb.pressed {
         border-color: #60a5fa;
         box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.7), 0 2px 8px rgba(0, 0, 0, 0.45);
-        transform: translate(-50%, 50%) scale(1.1);
+        transform: translate(-50%, -50%) scale(1.1);
       }
       #rightPanel .power-label {
         position: absolute;
@@ -300,7 +300,7 @@
       }
       #sliderTrack .max-zone {
         position: absolute;
-        top: 0;
+        bottom: 0;
         left: 12px;
         right: 12px;
         height: 15%;
@@ -310,7 +310,7 @@
       }
       #sliderTrack .max-label {
         position: absolute;
-        top: 4px;
+        bottom: 4px;
         left: 50%;
         transform: translateX(-50%);
         font-size: 10px;
@@ -388,30 +388,30 @@
               <div class="max-label">MAX</div>
             </div>
             <div id="powerFill"></div>
-            <div class="tick" style="bottom:12px"><span>0</span></div>
+            <div class="tick" style="top:12px"><span>0</span></div>
             <div
               class="tick"
-              style="bottom:calc(12px + (100% - 24px) * 0.25)"
+              style="top:calc(12px + (100% - 24px) * 0.25)"
             >
               <span>25</span>
             </div>
             <div
               class="tick mid"
-              style="bottom:calc(12px + (100% - 24px) * 0.5)"
+              style="top:calc(12px + (100% - 24px) * 0.5)"
             >
               <span>50</span>
               <div class="dot"></div>
             </div>
             <div
               class="tick"
-              style="bottom:calc(12px + (100% - 24px) * 0.75)"
+              style="top:calc(12px + (100% - 24px) * 0.75)"
             >
               <span>75</span>
             </div>
-            <div class="tick" style="top:12px"><span>100</span></div>
+            <div class="tick" style="bottom:12px"><span>100</span></div>
           </div>
           <div id="thumb"></div>
-          <div class="power-label">Power</div>
+          <div class="power-label">Pull</div>
         </aside>
 
         <button id="play">Play</button>
@@ -472,18 +472,18 @@
        ELEMENTET DOM
        ========================================================= */
         var wrap = document.getElementById('wrap');
-        if (CAL.bw && CAL.bh) {
-          wrap.style.backgroundSize = CAL.bw + 'px ' + CAL.bh + 'px';
-        } else {
-          wrap.style.backgroundSize = 'calc(100% + 8px) calc(100% - 6px)';
-        }
-        var xPos = isNaN(CAL.bx)
-          ? 'calc(50% - 3px)'
-          : 'calc(50% + ' + CAL.bx + 'px)';
-        var yPos = isNaN(CAL.by)
-          ? 'calc(50% + 0px)'
-          : 'calc(50% + ' + CAL.by + 'px)';
-        wrap.style.backgroundPosition = xPos + ' ' + yPos;
+          if (CAL.bw && CAL.bh) {
+            wrap.style.backgroundSize = CAL.bw + 'px ' + CAL.bh + 'px';
+          } else {
+            wrap.style.backgroundSize = 'calc(100% + 8px) calc(100% - 4px)';
+          }
+          var xPos = isNaN(CAL.bx)
+            ? 'calc(50% - 2px)'
+            : 'calc(50% + ' + CAL.bx + 'px)';
+          var yPos = isNaN(CAL.by)
+            ? 'calc(50% + 2px)'
+            : 'calc(50% + ' + CAL.by + 'px)';
+          wrap.style.backgroundPosition = xPos + ' ' + yPos;
         var canvas = document.getElementById('table');
         var ctx = canvas.getContext('2d');
         var rightPanel = document.getElementById('rightPanel');
@@ -1459,11 +1459,11 @@
         function updatePowerUI() {
           var pct = Math.round(power * 100);
           powerFill.style.height = pct + '%';
-          thumb.style.bottom = 'calc(12px + (100% - 24px) * ' + power + ')';
+          thumb.style.top = 'calc(12px + (100% - 24px) * ' + power + ')';
         }
         function updatePower(e) {
           var rect = rightPanel.getBoundingClientRect();
-          power = clamp((rect.bottom - e.clientY) / (rect.height * 0.9), 0, 1);
+          power = clamp((e.clientY - rect.top) / (rect.height * 0.9), 0, 1);
           updatePowerUI();
           cuePullVisual = power * (BALL_R * 14);
         }


### PR DESCRIPTION
## Summary
- Expand Pool Royale table background to expose more right edge and reduce height
- Flip power slider so players pull down to shoot, enlarge handle, and brighten tick marks

## Testing
- `npm test` *(incomplete: process did not exit)*
- `npm run lint` *(fails: numerous style errors in lib/texasHoldem.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c78cefa08329bccf997055fe4d78