### PR TITLE
style: adjust raise slider alignment

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -67,10 +67,10 @@
     #check{ background:#facc15; }
     #call{ background:#16a34a; }
     #fold{ background:#dc2626; }
-    .raise-container{ position:fixed; right:1vw; top:50%; transform:translateY(-50%); display:flex; flex-direction:column; align-items:center; gap:8px; }
+    .raise-container{ position:fixed; right:0.5vw; top:50%; transform:translateY(-50%); display:flex; flex-direction:column; align-items:center; gap:8px; }
     #raise{ padding:0; font-size:14px; border-radius:50%; }
     .raise-amount{ font-size:10px; margin-top:2px; }
-    #raisePanel{ position:relative; width:clamp(44px,5vw,88px); height:22vh; padding:12px; border-radius:14px; background:rgba(255,255,255,0.02); overflow:hidden; }
+    #raisePanel{ position:relative; width:clamp(44px,5vw,88px); height:18vh; padding:12px; border-radius:14px; background:rgba(255,255,255,0.02); overflow:hidden; }
     #raisePanel::before{ content:""; position:absolute; left:50%; top:12px; bottom:12px; width:1px; background:rgba(230,237,247,0.2); }
     #raiseFill{ position:absolute; left:12px; right:12px; bottom:12px; height:0%; border-radius:8px; background:rgba(255,255,255,0.2); box-shadow:inset 0 -1px 0 rgba(0,0,0,0.2); }
     #raiseFill::after{ content:""; position:absolute; top:0; left:0; right:0; height:2px; background:rgba(255,255,255,0.2); }


### PR DESCRIPTION
## Summary
- shift raise control container slightly further right
- shorten raise slider height for more compact layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2cdb25c3483298178b3eb8224b1a5