### PR TITLE
feat(pool): number pockets for calibration

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -910,6 +910,11 @@
             ctx.strokeStyle = '#00ff00';
             ctx.lineWidth = 4;
             ctx.stroke();
+            ctx.fillStyle = '#00ff00';
+            ctx.font = pocketR + 'px sans-serif';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(i + 1, pk.x * sX, pk.y * sY);
           }
 
           // Vizat orientuese mbi spondat


### PR DESCRIPTION
## Summary
- show pocket numbers inside green circles in Pool Royale table for easier calibration

## Testing
- `npm test` *(fails: The module '/workspace/TonPlaygramWebApp/bot/node_modules/canvas/build/Release/canvas.node' was compiled against a different Node.js version)*
- `npm run lint` *(fails: 473 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a2daa40e7c8329a71210413dcaaaf6