### PR TITLE
Tweak Pool Royale pocket calibration

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -762,12 +762,12 @@
 
           // Pockets (4 qoshe + 2 te mesit anesore)
           var defPockets = [
-            { x: BORDER, y: BORDER },
-            { x: TABLE_W - BORDER, y: BORDER },
-            { x: BORDER, y: TABLE_H / 2 },
-            { x: TABLE_W - BORDER, y: TABLE_H / 2 },
-            { x: BORDER, y: TABLE_H - BORDER },
-            { x: TABLE_W - BORDER, y: TABLE_H - BORDER }
+            { x: BORDER, y: BORDER + 5 },
+            { x: TABLE_W - BORDER + 10, y: BORDER },
+            { x: BORDER, y: TABLE_H / 2 + 2 },
+            { x: TABLE_W - BORDER + 10, y: TABLE_H / 2 },
+            { x: BORDER, y: TABLE_H - BORDER - 5 },
+            { x: TABLE_W - BORDER + 10, y: TABLE_H - BORDER }
           ];
           var calPockets = (CAL.pockets || []).length === 6 ? CAL.pockets : defPockets;
           this.pockets = calPockets.map(function (p, idx) {


### PR DESCRIPTION
## Summary
- nudge pockets 1, 3, and 5 vertically for better alignment
- move pockets 2, 4, and 6 slightly right to line up with table markings

## Testing
- `npm test` *(fails: test timed out after 20000ms due to missing Telegram bot configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a2de5ad4788329bd582a8ac3413b53