### PR TITLE
Move raise control next to call in Texas Hold'em

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -61,13 +61,13 @@
 .seat.bottom-right { left: 84%; top: 63%; transform: translate(-50%, -50%); }
       .seat.bottom .cards{ gap:0 }
       .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
-    .controls{ display:flex; gap:8px; margin-top:8px; }
+    .controls{ display:flex; gap:8px; margin-top:8px; align-items:flex-end; }
     .controls button{ width:var(--avatar-size); height:var(--avatar-size); padding:0; border:4px solid #000; border-radius:50%; background:#2563eb; color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
     #raise{ background:#2563eb; }
     #check{ background:#facc15; }
     #call{ background:#16a34a; }
     #fold{ background:#dc2626; }
-    .raise-container{ position:fixed; right:0; top:50%; transform:translateY(-50%); display:flex; flex-direction:column; align-items:center; gap:8px; }
+    .raise-container{ display:flex; flex-direction:column; align-items:center; gap:8px; }
     #raise{ padding:0; font-size:14px; border-radius:50%; }
     .raise-amount{ font-size:10px; margin-top:2px; }
     #raisePanel{ position:relative; width:clamp(44px,5vw,88px); height:18vh; padding:12px; border-radius:14px; background:rgba(255,255,255,0.02); overflow:hidden; }


### PR DESCRIPTION
## Summary
- Keep raise button & slider but integrate into control row next to call
- Align controls to bottom to match other actions

## Testing
- `npm test` *(fails: Error: The module '/workspace/TonPlaygramWebApp/bot/node_modules/canvas/build/Release/canvas.node' was compiled against a different Node.js version using NODE_MODULE_VERSION 115. This version of Node.js requires NODE_MODULE_VERSION 127. Please try re-compiling or re-installing)*
- `npm run lint` *(fails: 473 problems (473 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a2e40600808329ae7deea1a2df0813