### PR TITLE
Adjust Texas Hold'em bottom player and raise controls

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -48,7 +48,7 @@
 
 .seat.winner .name { color: #facc15; }
 
-.seat.bottom { bottom: 1%; left: 50%; transform: translateX(-50%); }
+.seat.bottom { bottom: 10%; left: 50%; transform: translateX(-50%); }
 
 .seat.top { top: 1%; left: 50%; transform: translateX(-50%); }
 
@@ -76,6 +76,8 @@
       border:2px solid rgba(255,255,255,0.2);
       border-radius:16px;
       background:rgba(0,0,0,0.2);
+      margin-left:8px;
+      transform:translate(8px,8px);
     }
     #raise{ padding:0; font-size:14px; border-radius:50%; }
     .raise-amount{ font-size:10px; margin-top:2px; }


### PR DESCRIPTION
## Summary
- Lift bottom player's seat so cards sit above action buttons
- Nudge raise controls to the right and downward for better spacing

## Testing
- `npm test` (fails: Missing script: test)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2f3b9abe883298c042066911b2ac3