### PR TITLE
Adjust Pool Royale field proportions

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -441,6 +441,11 @@
           var yTop = tr.y;
           var yBottom = br.y;
           var yCenter = lm.y;
+          var width = xRight - xLeft;
+          var height = yBottom - yTop;
+          xRight = xLeft + width * 1.1;
+          yBottom = yTop + height * 0.9;
+          yCenter = (yTop + yBottom) / 2;
           CAL.anchors = [
             { x: xLeft, y: yCenter },
             { x: xRight, y: yTop },


### PR DESCRIPTION
## Summary
- widen Pool Royale field by 10% and shorten height by 10%

## Testing
- `npm test` *(fails: CLAIM_CONTRACT_ADDRESS and CLAIM_WALLET_MNEMONIC must be set)*
- `npm run lint` *(fails: 473 errors, first in lib/texasHoldem.js)*
- `npx eslint webapp/public/pool-royale.html` *(warn: file ignored)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f31dddb88329a164ac8dc62cbd20