### PR TITLE
Improve Texas Hold'em bottom controls layout

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -48,7 +48,7 @@
 
 .seat.winner .name { color: #facc15; }
 
-.seat.bottom { bottom: 1%; left: 50%; transform: translateX(-50%); }
+.seat.bottom { bottom: 0; left: 50%; transform: translateX(-50%); }
 
 .seat.top { top: 1%; left: 50%; transform: translateX(-50%); }
 
@@ -61,13 +61,16 @@
 .seat.bottom-right { left: 84%; top: 63%; transform: translate(-50%, -50%); }
       .seat.bottom .cards{ gap:0 }
       .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
-    .controls{ display:flex; gap:8px; margin-top:8px; align-items:flex-end; }
+    .controls{ display:flex; gap:8px; margin-top:8px; align-items:flex-end; position:relative; justify-content:center; }
     .controls button{ width:var(--avatar-size); height:var(--avatar-size); padding:0; border:4px solid #000; border-radius:50%; background:#2563eb; color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
     #raise{ background:#2563eb; }
     #check{ background:#facc15; }
     #call{ background:#16a34a; }
     #fold{ background:#dc2626; }
     .raise-container{
+      position:absolute;
+      right:calc(var(--avatar-size) * -0.8);
+      bottom:calc(var(--avatar-size) * -0.2);
       display:flex;
       flex-direction:column;
       align-items:center;


### PR DESCRIPTION
## Summary
- Keep player's cards above action buttons and anchor bottom seat lower
- Move raise button and slider down-right so they don't push cards upward

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*
- `npm run lint` *(fails: 473 errors, e.g., arrow-spacing, comma-spacing)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fa8924ac8329aad1a802711aa623