### PR TITLE
Fine-tune Pool Royale background alignment

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -108,8 +108,9 @@
         overflow: hidden;
         background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
           center/cover no-repeat;
-        /* Expand pool field slightly without moving background */
-        background-size: calc(100% + 8px) calc(100% - 4px);
+        /* Fine-tune background without affecting pool field */
+        background-size: calc(100% + 8px) calc(100% + 8px);
+        background-position: calc(50% - 4px) calc(50% + 2px);
       }
 
       :root {


### PR DESCRIPTION
## Summary
- Tweak Pool Royale wrapper background to crop more on the right, shift slightly downward, and expand vertically while keeping the table unchanged

## Testing
- `npm test` *(fails: test timed out after 20000ms in snake API endpoints and socket events)*
- `npm run lint` *(fails: numerous lint errors in lib/texasHoldem.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fddd6da483298ba58a3f36291124