### PR TITLE
Delay poker celebration and adjust raise card positioning

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -69,8 +69,8 @@
     #fold{ background:#dc2626; }
     .raise-container{
       position:absolute;
-      right:calc(var(--avatar-size) * -0.8);
-      bottom:calc(var(--avatar-size) * -0.2);
+      right:calc(var(--avatar-size) * -1.5);
+      bottom:calc(var(--avatar-size) * -1.4);
       display:flex;
       flex-direction:column;
       align-items:center;

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -381,13 +381,15 @@ function showdown() {
     } else {
       overlay.innerHTML = `<div class="avatar">${winnerPlayer.name[0] || '?'}</div><div>${amountText}</div>`;
     }
-    overlay.classList.remove('hidden');
-    coinConfetti(50);
     setTimeout(() => {
-      overlay.classList.add('hidden');
-      document.getElementById('resultText').textContent = `${winnerPlayer.name} won ${amountText}`;
-      document.getElementById('results').showModal();
-    }, 2000);
+      overlay.classList.remove('hidden');
+      coinConfetti(50);
+      setTimeout(() => {
+        overlay.classList.add('hidden');
+        document.getElementById('resultText').textContent = `${winnerPlayer.name} won ${amountText}`;
+        document.getElementById('results').showModal();
+      }, 2000);
+    }, 7000);
   } else {
     document.getElementById('resultText').textContent = 'Tie';
     document.getElementById('results').showModal();


### PR DESCRIPTION
## Summary
- Delay winner celebration overlay by 7 seconds so players can view the winning hand before confetti and results show.
- Move raise card UI further right and lower to align token text with the bottom-center player name.

## Testing
- `npm test` *(fails: The "options.agent" property must be one of Agent-like Object, undefined, or false. Received an instance of ProxyAgent)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ff105d8883299516ff0cbdb4fc5d