### PR TITLE
Refine Texas Hold'em raise controls layout

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -70,7 +70,7 @@
     .raise-container{
       position:absolute;
       right:calc(var(--avatar-size) * -1.5);
-      bottom:calc(var(--avatar-size) * -1.4);
+      bottom:calc(var(--avatar-size) * -1.5);
       display:flex;
       flex-direction:column;
       align-items:center;
@@ -83,7 +83,7 @@
     #raise{ padding:0; font-size:14px; border-radius:50%; }
     .raise-amount{ font-size:10px; margin-top:2px; }
     #raisePanel{ position:relative; width:clamp(44px,5vw,88px); height:18vh; padding:12px; border-radius:14px; background:rgba(255,255,255,0.02); overflow:hidden; }
-    #raisePanel::before{ content:""; position:absolute; left:50%; top:12px; bottom:12px; width:1px; background:rgba(230,237,247,0.2); }
+    #raisePanel::before{ content:""; position:absolute; left:50%; top:14px; bottom:14px; width:1px; background:rgba(230,237,247,0.2); }
     #raiseFill{ position:absolute; left:12px; right:12px; bottom:12px; height:0%; border-radius:8px; background:rgba(255,255,255,0.2); box-shadow:inset 0 -1px 0 rgba(0,0,0,0.2); }
     #raiseFill::after{ content:""; position:absolute; top:0; left:0; right:0; height:2px; background:rgba(255,255,255,0.2); }
     #raiseThumb{ position:absolute; left:50%; transform:translate(-50%,50%); bottom:12px; width:28px; height:28px; border-radius:50%; background:#ffffff; border:4px solid #0b1224; box-shadow:0 2px 8px rgba(0,0,0,0.45); touch-action:none; }


### PR DESCRIPTION
## Summary
- Lower raise control card slightly for better alignment
- Shorten the raise panel's divider line to tighten spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a30475d0988329b72638ed030d346d