### PR TITLE
Adjust Pool Royale background sizing

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -109,8 +109,8 @@
         background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
           center/cover no-repeat;
         /* Fine-tune background without affecting pool field */
-        background-size: calc(100% + 8px) calc(100% + 8px);
-        background-position: calc(50% - 4px) calc(50% + 2px);
+        background-size: 95% 105%;
+        background-position: left center;
       }
 
       :root {


### PR DESCRIPTION
## Summary
- expand Pool Royale background height by 5%
- crop 5% from the right edge of the Pool Royale background

## Testing
- `npm test` *(fails: The module '/workspace/TonPlaygramWebApp/bot/node_modules/canvas/build/Release/canvas.node' was compiled against a different Node.js version using NODE_MODULE_VERSION 115. This version requires NODE_MODULE_VERSION 127)*

------
https://chatgpt.com/codex/tasks/task_e_68a303e825048329838550a0f97e4aa4