### PR TITLE
Add calibration panel for Pool Royale field and pockets

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -407,6 +407,7 @@
             var bh = parseInt(p.get('bh'));
             var bx = parseInt(p.get('bx'));
             var by = parseInt(p.get('by'));
+            var pr = parseInt(p.get('pr'));
             var pockets = [];
             for (var i = 1; i <= 6; i++) {
               var px = parseInt(p.get('p' + i + 'x'));
@@ -427,6 +428,7 @@
                 bh: bh,
                 bx: bx,
                 by: by,
+                pr: pr,
                 pockets: pockets,
                 anchors: anchors
               };
@@ -464,7 +466,7 @@
         var TABLE_W = CAL.w; // gjeresi logjike e felt-it
         var TABLE_H = CAL.h; // gjatesia logjike e felt-it
         var BORDER = TABLE_W * 0.0625; // ~6.25% e gjeresise
-        var POCKET_R = TABLE_W * 0.05; // ~5% e gjeresise
+        var POCKET_R = isNaN(CAL.pr) ? TABLE_W * 0.05 : CAL.pr; // ~5% e gjeresise
         var BALL_R = TABLE_W * 0.028125; // ~2.8% e gjeresise
         var PLAY_W = TABLE_W - 2 * BORDER; // fusha pa spondat
         var PLAY_H = TABLE_H - 2 * BORDER;

--- a/webapp/src/components/PoolRoyaleCalibrationPanel.jsx
+++ b/webapp/src/components/PoolRoyaleCalibrationPanel.jsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import { getPoolRoyaleCalibration, savePoolRoyaleCalibration } from '../utils/api.js';
+
+export default function PoolRoyaleCalibrationPanel({ initial, onClose, onSave }) {
+  const [dims, setDims] = useState({
+    width: 1000,
+    height: 2000,
+    bgWidth: 0,
+    bgHeight: 0,
+    bgX: 0,
+    bgY: 0,
+    pocketRadius: 50,
+    pockets: []
+  });
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await getPoolRoyaleCalibration();
+        if (!res.error) {
+          setDims((d) => ({
+            ...d,
+            ...res,
+            pocketRadius: res.pocketRadius || res.pr || d.pocketRadius,
+            pockets: Array.isArray(res.pockets) ? res.pockets : []
+          }));
+        }
+      } catch {}
+    }
+    if (initial) {
+      setDims((d) => ({
+        ...d,
+        ...initial,
+        pocketRadius: initial.pocketRadius || initial.pr || d.pocketRadius,
+        pockets: Array.isArray(initial.pockets) ? initial.pockets : []
+      }));
+    } else {
+      load();
+    }
+  }, [initial]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setDims((d) => ({ ...d, [name]: Number(value) }));
+  };
+
+  const handleSave = async () => {
+    try {
+      await savePoolRoyaleCalibration(
+        dims.width,
+        dims.height,
+        dims.bgWidth,
+        dims.bgHeight,
+        dims.bgX,
+        dims.bgY,
+        dims.pockets,
+        dims.pocketRadius
+      );
+      const payload = { ...dims };
+      if (onSave) onSave(payload);
+    } catch {}
+    onClose();
+  };
+
+  return (
+    <div className="absolute inset-0 z-50 flex flex-col items-center justify-center text-text bg-transparent">
+      <div className="flex flex-col items-center gap-4 p-4">
+        <label className="w-64">Field Width: {dims.width}
+          <input
+            type="range"
+            name="width"
+            min="500"
+            max="1500"
+            value={dims.width}
+            onChange={handleChange}
+            className="w-full"
+          />
+        </label>
+        <label className="w-64">Field Height: {dims.height}
+          <input
+            type="range"
+            name="height"
+            min="1000"
+            max="3000"
+            value={dims.height}
+            onChange={handleChange}
+            className="w-full"
+          />
+        </label>
+        <label className="w-64">Pocket Size: {dims.pocketRadius}
+          <input
+            type="range"
+            name="pocketRadius"
+            min="10"
+            max="200"
+            value={dims.pocketRadius}
+            onChange={handleChange}
+            className="w-full"
+          />
+        </label>
+        <div className="flex gap-2 pt-4">
+          <button
+            onClick={handleSave}
+            className="bg-primary text-background px-4 py-2 rounded"
+          >
+            Save
+          </button>
+          <button
+            onClick={onClose}
+            className="bg-gray-500 text-background px-4 py-2 rounded"
+          >
+            Exit
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2,11 +2,14 @@ import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { getPoolRoyaleCalibration } from '../../utils/api.js';
+import { getTelegramId } from '../../utils/telegram.js';
+import PoolRoyaleCalibrationPanel from '../../components/PoolRoyaleCalibrationPanel.jsx';
 
 export default function PoolRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
   const [calibration, setCalibration] = useState(null);
+  const [showPanel, setShowPanel] = useState(false);
 
   useEffect(() => {
     async function load() {
@@ -25,10 +28,10 @@ export default function PoolRoyale() {
   if (calibration?.height) iframeParams.set('ch', calibration.height);
   if (calibration?.bgWidth) iframeParams.set('bw', calibration.bgWidth);
   if (calibration?.bgHeight) iframeParams.set('bh', calibration.bgHeight);
-  if (typeof calibration?.bgX === 'number')
-    iframeParams.set('bx', calibration.bgX);
-  if (typeof calibration?.bgY === 'number')
-    iframeParams.set('by', calibration.bgY);
+  if (typeof calibration?.bgX === 'number') iframeParams.set('bx', calibration.bgX);
+  if (typeof calibration?.bgY === 'number') iframeParams.set('by', calibration.bgY);
+  if (typeof calibration?.pocketRadius === 'number')
+    iframeParams.set('pr', calibration.pocketRadius);
   if (Array.isArray(calibration?.pockets)) {
     calibration.pockets.forEach((p, i) => {
       if (typeof p.x === 'number') iframeParams.set(`p${i + 1}x`, p.x);
@@ -43,9 +46,35 @@ export default function PoolRoyale() {
   }
   const src = `/pool-royale.html?${iframeParams.toString()}`;
 
+  const tgId = getTelegramId();
+  const devIds = [
+    import.meta.env.VITE_DEV_ACCOUNT_ID,
+    import.meta.env.VITE_DEV_ACCOUNT_ID_1,
+    import.meta.env.VITE_DEV_ACCOUNT_ID_2
+  ]
+    .filter(Boolean)
+    .map((id) => Number(id));
+  const isDev = tgId && devIds.includes(Number(tgId));
+
   return (
     <div className="relative w-full h-screen">
+      {isDev && (
+        <button
+          onClick={() => setShowPanel(true)}
+          className="absolute top-2 right-2 z-10 text-2xl"
+          aria-label="Configure"
+        >
+          ⚙️
+        </button>
+      )}
       <iframe src={src} title="Pool Royale 🎱" className="w-full h-full border-0" />
+      {showPanel && (
+        <PoolRoyaleCalibrationPanel
+          initial={calibration}
+          onClose={() => setShowPanel(false)}
+          onSave={setCalibration}
+        />
+      )}
     </div>
   );
 }

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -576,11 +576,12 @@ export function savePoolRoyaleCalibration(
   bgHeight,
   bgX,
   bgY,
-  pockets
+  pockets,
+  pocketRadius
 ) {
   return post(
     '/api/poolroyale/calibration',
-    { width, height, bgWidth, bgHeight, bgX, bgY, pockets },
+    { width, height, bgWidth, bgHeight, bgX, bgY, pockets, pocketRadius },
     API_AUTH_TOKEN || undefined
   );
 }


### PR DESCRIPTION
## Summary
- add transparent calibration panel with sliders to tweak pool field and pocket size
- expose gear icon for developers to open the panel in Pool Royale
- persist pocket radius through API and apply it in pool-royale renderer

## Testing
- `npm test` *(fails: AssertionError in snakeApi.test.js)*
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_68a30d7c91208329ac8104f68c54966f