### PR TITLE
feat: enhance Texas Hold'em gameplay flow

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -48,6 +48,9 @@
 
 .seat.winner .name { color: #facc15; }
 
+.moving-card{position:absolute;transition:left .3s ease, top .3s ease;z-index:1000;pointer-events:none;}
+.avatar.turn{box-shadow:0 0 12px #facc15;border-color:#facc15;}
+
 .seat.bottom { bottom: 0; left: 50%; transform: translateX(-50%); }
 
 .seat.top { top: 1%; left: 50%; transform: translateX(-50%); }


### PR DESCRIPTION
## Summary
- animate card dealing from center to seats before each round
- highlight human turn and delay AI moves by 2.5s
- auto-restart game 5s after showdown

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*

------
https://chatgpt.com/codex/tasks/task_e_68a3159ecf3c8329acc8c05e18c18770