### PR TITLE
feat: enhance texas holdem UI turn and pot

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -20,7 +20,7 @@
     }
     .stage{ position:relative; width:100vw; height:100vh; display:grid; place-items:center; perspective:1100px; }
     .stage::before{ content:""; position:absolute; top:0; bottom:0; left:1vw; right:1vw; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
-      .center{ position:absolute; left:50%; top:46%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.1; }
+      .center{ position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.1; }
       .seats{ position:absolute; inset:0; z-index:2 }
       .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px) }
       .seat.small{ --card-scale:.8; }
@@ -51,7 +51,7 @@
 .moving-card{position:absolute;transition:left .3s ease, top .3s ease;z-index:1000;pointer-events:none;}
 .avatar.turn{box-shadow:0 0 12px #facc15;border-color:#facc15;}
 
-.seat.bottom { bottom: 0; left: 50%; transform: translateX(-50%); }
+.seat.bottom { bottom: 2%; left: 50%; transform: translateX(-50%); }
 
 .seat.top { top: 1%; left: 50%; transform: translateX(-50%); }
 
@@ -61,7 +61,7 @@
 
 .seat.bottom-left { left: 16%; top: 63%; transform: translate(-50%, -50%); --card-scale: .85; }
 
-.seat.bottom-right { left: 84%; top: 63%; transform: translate(-50%, -50%); }
+    .seat.bottom-right { left: 84%; top: 63%; transform: translate(-50%, -50%); }
       .seat.bottom .cards{ gap:0 }
       .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
     .controls{ display:flex; gap:8px; margin-top:8px; align-items:flex-end; position:relative; justify-content:center; }
@@ -100,11 +100,26 @@
     .top-controls button{width:44px;height:44px;padding:0;border:2px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#2563eb;color:#fff;font-weight:600}
     .top-controls button img{width:24px;height:24px}
     .seat.vacant .vacant-seat{width:var(--avatar-size);height:var(--avatar-size);border-radius:50%;border:4px solid #000;background:#facc15;color:#16a34a;font-weight:700;display:flex;align-items:center;justify-content:center}
+
+    .pot{ position:absolute; left:50%; top:40%; transform:translate(-50%,-50%); display:flex; gap:6px; z-index:2; }
+    .chip-pile{ position:relative; width:calc(var(--avatar-size)/2); height:calc(var(--avatar-size)/2); }
+    .chip{ position:absolute; left:0; width:calc(var(--avatar-size)/2); height:calc(var(--avatar-size)/2); border-radius:50%; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:calc(var(--avatar-size)/4); color:#000; box-shadow:0 2px 4px rgba(0,0,0,.4); }
+    .chip.v1{ background:#ffffff; }
+    .chip.v5{ background:#f87171; }
+    .chip.v10{ background:#fde047; }
+    .chip.v20{ background:#60a5fa; }
+    .chip.v50{ background:#34d399; }
+    .chip.v100{ background:#a78bfa; }
+    .chip.v200{ background:#f472b6; }
+    .chip.v500{ background:#fb923c; }
+    .chip.v1000{ background:#eab308; }
+    .moving-pot{ position:absolute; transition:left .5s ease, top .5s ease; }
   </style>
 </head>
 <body>
   <div class="stage">
     <div class="center community" id="community"></div>
+    <div class="pot" id="pot"></div>
     <div class="seats" id="seats"></div>
     <div id="status"></div>
   </div>


### PR DESCRIPTION
## Summary
- ensure bottom player controls stay visible and center cards slightly lowered
- add animated chip pot that moves to round winner
- highlight avatar of current player including AI turns

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68a31b395dbc83298a8d66cd6c3ac3de