### PR TITLE
Enhance Texas Hold'em gameplay with AI betting and chip animations

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -20,7 +20,7 @@
     }
     .stage{ position:relative; width:100vw; height:100vh; display:grid; place-items:center; perspective:1100px; }
     .stage::before{ content:""; position:absolute; top:0; bottom:0; left:1vw; right:1vw; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
-      .center{ position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.1; }
+      .center{ position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:5; --card-scale:1.1; }
       .seats{ position:absolute; inset:0; z-index:2 }
       .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px) }
       .seat.small{ --card-scale:.8; }
@@ -72,8 +72,9 @@
     #fold{ background:#dc2626; }
     .raise-container{
       position:absolute;
-      right:calc(var(--avatar-size) * -1.5);
-      bottom:calc(var(--avatar-size) * -1.5);
+      right:0;
+      bottom:calc(var(--avatar-size) * -2.5);
+      z-index:3;
       display:flex;
       flex-direction:column;
       align-items:center;
@@ -114,6 +115,8 @@
     .chip.v500{ background:#fb923c; }
     .chip.v1000{ background:#eab308; }
     .moving-pot{ position:absolute; transition:left .5s ease, top .5s ease; }
+    .moving-chip{ position:absolute; transition:left .3s ease, top .3s ease; z-index:1000; pointer-events:none; }
+    .prob{ font-size:10px; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Keep community cards visible and move raise controls below the table
- Animate chip transfers, add win probability display, and add Web Audio based sound effects
- Introduce probabilistic AI with raising, calling, checking, folding and bluffing

## Testing
- `npm test` *(fails: snake API endpoints and socket events)*
- `npm --prefix webapp test` *(fails: Missing script "test")*
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_68a321934818832993ac5373dbabbc3d