### PR TITLE
feat: enhance poker gameplay

### DIFF
--- a/webapp/public/lib/texasHoldem.js
+++ b/webapp/public/lib/texasHoldem.js
@@ -181,16 +181,14 @@ export function evaluateWinner(players, community){
   return winner;
 }
 
-export function aiChooseAction(hand, community=[]){
-  const stage=community.length; //0 preflop,3 flop,4 turn,5 river
+export function aiChooseAction(hand, community = [], currentBet = 0){
   const score=bestHand([...hand,...community]);
-  // very naive thresholds
-  if(stage<3){
-    // preflop
-    const hv=hand.map(c=>rankValue(c.rank)).sort((a,b)=>b-a);
-    if(hv[0]>=12 || hv[0]===hv[1]) return 'call';
-    return 'fold';
+  if(currentBet===0){
+    if(score.rank>=3) return 'raise';
+    if(score.rank>=1) return 'check';
+    return Math.random()<0.2 ? 'raise' : 'check';
   }
+  if(score.rank>=2) return 'raise';
   if(score.rank>=1) return 'call';
   return 'fold';
 }

--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -101,7 +101,8 @@
     .top-controls button img{width:24px;height:24px}
     .seat.vacant .vacant-seat{width:var(--avatar-size);height:var(--avatar-size);border-radius:50%;border:4px solid #000;background:#facc15;color:#16a34a;font-weight:700;display:flex;align-items:center;justify-content:center}
 
-    .pot{ position:absolute; left:50%; top:35%; transform:translate(-50%,-50%); display:flex; gap:6px; z-index:2; }
+    .pot{ position:absolute; left:50%; top:35%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:6px; z-index:2; }
+    .pot-amount{font-size:12px;color:#fff;margin-top:2px;}
     .chip-pile{ position:relative; width:calc(var(--avatar-size)/2); height:calc(var(--avatar-size)/2); }
     .chip{ position:absolute; left:0; width:calc(var(--avatar-size)/2); height:calc(var(--avatar-size)/2); border-radius:50%; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:calc(var(--avatar-size)/4); color:#000; box-shadow:0 2px 4px rgba(0,0,0,.4); }
     .chip.v1{ background:#ffffff; }
@@ -114,6 +115,20 @@
     .chip.v500{ background:#fb923c; }
     .chip.v1000{ background:#eab308; }
     .moving-pot{ position:absolute; transition:left .5s ease, top .5s ease; }
+    .moving-chip{ position:absolute; transition:left .5s ease, top .5s ease; z-index:1000; }
+    .action-text{position:absolute;font-weight:700;font-size:12px;}
+    .action-fold{color:#dc2626;-webkit-text-stroke:1px #fff;}
+    .action-call{color:#16a34a;-webkit-text-stroke:1px #fff;}
+    .action-check{color:#facc15;-webkit-text-stroke:1px #000;}
+    .action-raise{color:#2563eb;-webkit-text-stroke:1px #fff;}
+    .seat.bottom .action-text{left:calc(100% + 4px);top:50%;transform:translateY(-50%);}
+    .seat.bottom-right .action-text{left:calc(100% + 4px);top:50%;transform:translateY(-50%);}
+    .seat.right .action-text{left:calc(100% + 4px);top:50%;transform:translateY(-50%);}
+    .seat.top .action-text{top:calc(100% + 4px);left:50%;transform:translateX(-50%);}
+    .seat.left .action-text{right:calc(100% + 4px);top:50%;transform:translateY(-50%);}
+    .seat.bottom-left .action-text{right:calc(100% + 4px);top:50%;transform:translateY(-50%);}
+    #controls button:disabled{opacity:.5;}
+    .win-prob{font-size:12px;color:#fff;margin-top:2px;}
   </style>
 </head>
 <body>

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -105,9 +105,12 @@ function init() {
   state.maxPot = state.stake * state.players.filter((p) => p.active).length;
   setupFlopBacks();
   renderSeats();
+  showControls();
+  hideControls();
   collectAntes();
   updatePotDisplay();
   dealInitialCards();
+  document.getElementById('status').textContent = '';
 }
 
 function renderSeats() {
@@ -154,13 +157,22 @@ function renderSeats() {
       const controls = document.createElement('div');
       controls.className = 'controls';
       controls.id = 'controls';
-      seat.append(cards, controls, wrap, name);
+      const prob = document.createElement('div');
+      prob.id = 'winProb';
+      prob.className = 'win-prob';
+      const action = document.createElement('div');
+      action.id = 'action-' + i;
+      action.className = 'action-text';
+      seat.append(cards, prob, controls, wrap, name, action);
     } else {
       const timer = document.createElement('div');
       timer.className = 'timer';
       timer.id = 'timer-' + i;
-      if (positions[i] === 'top') seat.append(name, avatar, cards, timer);
-      else seat.append(avatar, cards, name, timer);
+      const action = document.createElement('div');
+      action.id = 'action-' + i;
+      action.className = 'action-text';
+      if (positions[i] === 'top') seat.append(name, avatar, cards, timer, action);
+      else seat.append(avatar, cards, name, timer, action);
     }
     seats.appendChild(seat);
   });
@@ -212,6 +224,71 @@ function updatePotDisplay() {
       potEl.appendChild(pile);
     }
   });
+  const amt = document.createElement('div');
+  amt.className = 'pot-amount';
+  amt.textContent = `${state.pot} ${state.token}`;
+  potEl.appendChild(amt);
+}
+
+function animateChips(idx, amount) {
+  return new Promise((resolve) => {
+    const stage = document.querySelector('.stage');
+    const potEl = document.getElementById('pot');
+    const fromCards = document.getElementById('cards-' + idx);
+    if (!stage || !potEl || !fromCards) {
+      resolve();
+      return;
+    }
+    const stageRect = stage.getBoundingClientRect();
+    const fromRect = fromCards.getBoundingClientRect();
+    const potRect = potEl.getBoundingClientRect();
+    const chip = document.createElement('div');
+    chip.className = 'chip v1 moving-chip';
+    chip.textContent = amount;
+    chip.style.left = fromRect.left - stageRect.left + 'px';
+    chip.style.top = fromRect.top - stageRect.top + 'px';
+    stage.appendChild(chip);
+    requestAnimationFrame(() => {
+      chip.style.left = potRect.left - stageRect.left + potRect.width / 2 - chip.offsetWidth / 2 + 'px';
+      chip.style.top = potRect.top - stageRect.top + potRect.height / 2 - chip.offsetHeight / 2 + 'px';
+    });
+    chip.addEventListener('transitionend', () => {
+      chip.remove();
+      resolve();
+    }, { once: true });
+  });
+}
+
+function calculateWinProbability(samples = 200) {
+  const known = state.community.slice(0, stageCommunityCount());
+  const used = [...state.players[0].hand, ...known];
+  const deck = createDeck().filter(
+    (c) => !used.some((u) => u.rank === c.rank && u.suit === c.suit)
+  );
+  let wins = 0;
+  let ties = 0;
+  const opponents = state.players.filter((p, i) => i !== 0 && !p.vacant).length;
+  for (let i = 0; i < samples; i++) {
+    const d = shuffle(deck);
+    const commNeeded = 5 - known.length;
+    const community = [...known, ...d.splice(0, commNeeded)];
+    const hands = [];
+    for (let j = 0; j < opponents; j++) {
+      hands.push([d.pop(), d.pop()]);
+    }
+    const players = [{ hand: state.players[0].hand }, ...hands.map((h) => ({ hand: h }))];
+    const res = evaluateWinner(players, community);
+    if (res && res.index === 0) wins++;
+    else if (!res) ties++;
+  }
+  const pct = ((wins + ties * 0.5) / samples) * 100;
+  return pct.toFixed(1);
+}
+
+function updateWinProbability() {
+  const el = document.getElementById('winProb');
+  if (!el) return;
+  el.textContent = calculateWinProbability() + '%';
 }
 
 async function dealInitialCards() {
@@ -222,6 +299,7 @@ async function dealInitialCards() {
       await dealCardToPlayer(i, p.hand[r], !!p.isHuman);
     }
   }
+  updateWinProbability();
   if (state.seated) startPlayerTurn();
   else proceedStage();
 }
@@ -273,40 +351,42 @@ function setPlayerTurnIndicator(idx) {
 
 function showControls() {
   const controls = document.getElementById('controls');
-  controls.innerHTML = '';
-  const baseActions = [
-    { id: 'fold', fn: playerFold },
-    { id: 'check', fn: playerCheck },
-    { id: 'call', fn: playerCall },
-  ];
-  baseActions.forEach((a) => {
+  if (!controls) return;
+  if (!controls.children.length) {
+    const baseActions = [
+      { id: 'fold', fn: playerFold },
+      { id: 'check', fn: playerCheck },
+      { id: 'call', fn: playerCall },
+    ];
+    baseActions.forEach((a) => {
+      const btn = document.createElement('button');
+      btn.id = a.id;
+      btn.textContent = a.id;
+      btn.addEventListener('click', a.fn);
+      controls.appendChild(btn);
+    });
+    const raiseContainer = document.createElement('div');
+    raiseContainer.className = 'raise-container';
+    const panel = document.createElement('div');
+    panel.id = 'raisePanel';
+    panel.innerHTML =
+      '<div class="max-zone"><div class="max-label">MAX</div></div>' +
+      '<div id="raiseFill"></div><div id="raiseThumb"></div>';
+    raiseContainer.appendChild(panel);
     const btn = document.createElement('button');
-    btn.id = a.id;
-    btn.textContent = a.id;
-    btn.addEventListener('click', a.fn);
-    controls.appendChild(btn);
-  });
-  const raiseContainer = document.createElement('div');
-  raiseContainer.className = 'raise-container';
-  const panel = document.createElement('div');
-  panel.id = 'raisePanel';
-  panel.innerHTML =
-    '<div class="max-zone"><div class="max-label">MAX</div></div>' +
-    '<div id="raiseFill"></div><div id="raiseThumb"></div>';
-  raiseContainer.appendChild(panel);
-  const btn = document.createElement('button');
-  btn.textContent = 'raise';
-  btn.id = 'raise';
-  btn.addEventListener('click', playerRaise);
-  if (state.pot >= state.maxPot) btn.disabled = true;
-  raiseContainer.appendChild(btn);
-  const amountText = document.createElement('div');
-  amountText.id = 'raiseAmountText';
-  amountText.className = 'raise-amount';
-  amountText.textContent = `0 ${state.token}`;
-  raiseContainer.appendChild(amountText);
-  controls.appendChild(raiseContainer);
-  initRaiseSlider();
+    btn.textContent = 'raise';
+    btn.id = 'raise';
+    btn.addEventListener('click', playerRaise);
+    raiseContainer.appendChild(btn);
+    const amountText = document.createElement('div');
+    amountText.id = 'raiseAmountText';
+    amountText.className = 'raise-amount';
+    amountText.textContent = `0 ${state.token}`;
+    raiseContainer.appendChild(amountText);
+    controls.appendChild(raiseContainer);
+    initRaiseSlider();
+  }
+  controls.querySelectorAll('button').forEach((b) => (b.disabled = false));
 }
 
 function initRaiseSlider() {
@@ -325,8 +405,6 @@ function initRaiseSlider() {
     state.raiseAmount = Math.round(pct * maxAllowed);
     const amtEl = document.getElementById('raiseAmountText');
     if (amtEl) amtEl.textContent = `${state.raiseAmount} ${state.token}`;
-    const status = document.getElementById('status');
-    if (status) status.textContent = `Raise ${state.raiseAmount} ${state.token}`;
   }
   panel.addEventListener('pointerdown', function (e) {
     update(e);
@@ -342,7 +420,8 @@ function initRaiseSlider() {
 
 function hideControls() {
   const controls = document.getElementById('controls');
-  if (controls) controls.innerHTML = '';
+  if (!controls) return;
+  controls.querySelectorAll('button').forEach((b) => (b.disabled = true));
 }
 
 function startPlayerTurn() {
@@ -386,33 +465,46 @@ function updateTimer() {
   }
 }
 
+function showAction(idx, action, amount = 0) {
+  const el = document.getElementById('action-' + idx);
+  if (!el) return;
+  el.className = 'action-text action-' + action;
+  el.textContent = action + (amount ? ' ' + amount : '');
+  setTimeout(() => {
+    el.textContent = '';
+  }, 2000);
+}
+
 function playerFold() {
   clearInterval(state.timerInterval);
   hideControls();
   setPlayerTurnIndicator(null);
-  document.getElementById('status').textContent = 'You folded';
+  showAction(0, 'fold');
+  proceedStage();
 }
 
 function playerCheck() {
-  document.getElementById('status').textContent = 'You check';
+  showAction(0, 'check');
   proceedStage();
 }
 
-function playerCall() {
+async function playerCall() {
   state.pot += state.currentBet;
+  showAction(0, 'call', state.currentBet);
+  await animateChips(0, state.currentBet);
   updatePotDisplay();
-  document.getElementById('status').textContent = `You call ${state.currentBet} ${state.token}`;
   proceedStage();
 }
 
-function playerRaise() {
+async function playerRaise() {
   const maxAllowed = Math.min(state.stake, state.maxPot - state.pot);
   const amount = Math.min(state.raiseAmount, maxAllowed);
   if (amount <= 0) return;
   state.pot += amount;
   state.currentBet += amount;
+  showAction(0, 'raise', amount);
+  await animateChips(0, amount);
   updatePotDisplay();
-  document.getElementById('status').textContent = `You raise ${amount} ${state.token}`;
   proceedStage();
 }
 
@@ -424,14 +516,29 @@ async function proceedStage() {
     const p = state.players[i];
     if (p.vacant) continue;
     setPlayerTurnIndicator(i);
-    document.getElementById('status').textContent = `${p.name}...`;
     await new Promise((r) => setTimeout(r, 2500));
-    const action = aiChooseAction(p.hand, state.community.slice(0, stageCommunityCount()));
+    const action = aiChooseAction(
+      p.hand,
+      state.community.slice(0, stageCommunityCount()),
+      state.currentBet
+    );
     if (action === 'call') {
       state.pot += state.currentBet;
+      showAction(i, 'call', state.currentBet);
+      await animateChips(i, state.currentBet);
       updatePotDisplay();
+    } else if (action === 'raise') {
+      const raiseAmt = Math.min(20, state.maxPot - state.pot);
+      state.currentBet += raiseAmt;
+      state.pot += raiseAmt;
+      showAction(i, 'raise', raiseAmt);
+      await animateChips(i, raiseAmt);
+      updatePotDisplay();
+    } else if (action === 'fold') {
+      showAction(i, 'fold');
+    } else {
+      showAction(i, 'check');
     }
-    document.getElementById('status').textContent = `${p.name} ${action}s`;
   }
   setPlayerTurnIndicator(null);
   state.stage++;
@@ -478,18 +585,21 @@ function revealFlop() {
     if (comm.children[i]) comm.children[i].replaceWith(card);
     else comm.appendChild(card);
   }
+  updateWinProbability();
   startPlayerTurn();
 }
 
 function revealTurn() {
   const comm = document.getElementById('community');
   comm.appendChild(cardEl(state.community[3]));
+  updateWinProbability();
   startPlayerTurn();
 }
 
 function revealRiver() {
   const comm = document.getElementById('community');
   comm.appendChild(cardEl(state.community[4]));
+  updateWinProbability();
   startPlayerTurn();
 }
 
@@ -504,7 +614,7 @@ function showdown() {
   const winner = evaluateWinner(activePlayers, state.community);
   const pot = state.pot;
   const text = winner
-    ? `${activePlayers[winner.index].name} wins with ${HAND_RANK_NAMES[winner.score.rank]}!`
+    ? `${activePlayers[winner.index].name} wins ${pot} ${state.token} with ${HAND_RANK_NAMES[winner.score.rank]}!`
     : 'Tie';
   document.getElementById('status').textContent = text;
   if (winner) {


### PR DESCRIPTION
## Summary
- keep player controls visible and show action prompts beside avatars
- animate chip movements, display pot total, and estimate win odds
- expand AI decision making for call/check/raise/fold

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint` *(fails: 473 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a338c3f1688329aff177211e62ea40