### PR TITLE
feat(pool): polish table visuals and shot physics

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -212,17 +212,8 @@
 
     #play:hover { background: #3c67a3; }
 
-    #aimGlow {
-      position: absolute;
-      width: 42px;
-      height: 42px;
-      border-radius: 50%;
-      pointer-events: none;
-      opacity: 0;
-      transition: opacity .15s ease;
-      box-shadow: 0 0 0 0 rgba(255,80,80,0);
-      z-index: 5;
-    }
+    /* Removed the round shadow from the aiming line */
+    #aimGlow { display: none; }
   </style>
 </head>
 <body>
@@ -260,7 +251,6 @@
       </aside>
 
       <button id="play">Play</button>
-      <div id="aimGlow"></div>
     </div>
 
     <div id="footer">
@@ -285,9 +275,9 @@
        ========================================================= */
     var TABLE_W = 768;      // gjeresi logjike e felt-it
     var TABLE_H = 1280;     // lartesi logjike e felt-it
-    var BORDER  = 36;       // korniza e drurit rreth e rrotull
-    var POCKET_R = 42;      // rrezja baze e gropave (50% me e madhe)
-    var BALL_R   = 27;      // rrezja baze e topave (50% me e madhe)
+    var BORDER  = 55;       // korniza e drurit e zgjeruar ~5%
+    var POCKET_R = 42;      // rrezja baze e gropave
+    var BALL_R   = 24.3;    // rrezja baze e topave (10% me e vegjel)
 
     var FRICTION = 0.985;   // ferkimi linear
     var BOUNCE   = 0.98;    // koeficienti i rikthimit
@@ -301,11 +291,12 @@
     var ctx       = canvas.getContext('2d');
     var rightPanel= document.getElementById('rightPanel');
     var playBtn   = document.getElementById('play');
-    var aimGlow   = document.getElementById('aimGlow');
     var capP1     = document.getElementById('capP1');
     var capP2     = document.getElementById('capP2');
     var spinBox   = document.getElementById('spinBox');
     var spinDot   = document.getElementById('spinDot');
+    var logoImg   = new Image();
+    logoImg.src   = '/assets/icons/pool-royale.svg';
     var pullArea  = document.getElementById('pullArea');
     var cueStickEl= document.getElementById('cueStick');
     var cueTipEl  = document.getElementById('tip');
@@ -412,6 +403,7 @@
       this.v = { x:0, y:0 }; // shpejtesia
       this.pocketed = false; // ne grope
       this.a = 0; // kendi per vizualizim rrotullimi
+      this.spin = { x:0, y:0 }; // spin aktiv
     }
 
     function Pocket(x,y){ this.x = x; this.y = y; }
@@ -450,9 +442,9 @@
           var x = cx - (count-1)*BALL_R*1.05 + j*colGap;
           var y = cy + r*rowGap;
           var num;
-          if (r===2 && j===1) num = 8;            // qendra e rreshtit 3
-          else if (r===4 && j===0) num = 1;       // qoshe e majte poshte solid
-          else if (r===4 && j===4) num = 11;      // qoshe e djathte poshte stripe
+          if (r===0 && j===0) num = 1;            // yellow ne maje
+          else if (r===2 && j===1) num = 8;       // qendra e rreshtit 3
+          else if (r===4 && j===4) num = 11;      // qoshe stripe
           else num = pool[cursor++];
           var info = BALL_BY_N[num];
           if (!info) { console.warn('Rack: numer i pape rcaktuar', num); continue; }
@@ -495,6 +487,12 @@
         b.p.x += b.v.x * dt;
         b.p.y += b.v.y * dt;
         b.v.x *= FRICTION; b.v.y *= FRICTION;
+        if (b.spin) {
+          b.v.x += b.spin.x * 20 * dt;
+          b.v.y += b.spin.y * 20 * dt;
+          b.spin.x *= 0.98;
+          b.spin.y *= 0.98;
+        }
         b.a   += Math.hypot(b.v.x, b.v.y) * dt / (BALL_R*0.6);
 
         var L = BORDER + BALL_R;
@@ -551,6 +549,17 @@
       var felt = ctx.createLinearGradient(0,y0,0,y0+h); felt.addColorStop(0,'#0d803c'); felt.addColorStop(1,'#074120');
       ctx.fillStyle = felt; ctx.fillRect(x0,y0,w,h);
 
+      // Logo ne qender
+      if (logoImg.complete) {
+        var sz = 160 * ((sX + sY) / 2);
+        ctx.save();
+        ctx.globalAlpha = 0.25;
+        ctx.shadowColor = 'rgba(0,0,0,0.3)';
+        ctx.shadowBlur = 10;
+        ctx.drawImage(logoImg, (TABLE_W*sX - sz)/2, (TABLE_H*sY - sz)/2, sz, sz);
+        ctx.restore();
+      }
+
       // Penalty dot dhe vija e "kitchen" per cue ball
       var playH = (TABLE_H - 2*BORDER);
       var footSpotY = BORDER + playH * 0.25;
@@ -572,6 +581,25 @@
       ctx.fillRect(0,(TABLE_H-BORDER)*sY,canvas.width,BORDER*sY);
       ctx.fillRect(0,0,BORDER*sX,canvas.height);
       ctx.fillRect((TABLE_W-BORDER)*sX,0,BORDER*sX,canvas.height);
+
+      // Dots ne kornizat
+      ctx.fillStyle = '#e0c18b';
+      var mark = 8 * ((sX + sY) / 2);
+      var pos = [0.25,0.5,0.75];
+      pos.forEach(function(p){
+        var x = BORDER*sX + (TABLE_W-2*BORDER)*p*sX;
+        var yT = BORDER*sY/2;
+        var yB = (TABLE_H - BORDER/2)*sY;
+        ctx.save(); ctx.translate(x,yT); ctx.rotate(Math.PI/4); ctx.fillRect(-mark/2,-mark/2,mark,mark); ctx.restore();
+        ctx.save(); ctx.translate(x,yB); ctx.rotate(Math.PI/4); ctx.fillRect(-mark/2,-mark/2,mark,mark); ctx.restore();
+      });
+      pos.forEach(function(p){
+        var y = BORDER*sY + (TABLE_H-2*BORDER)*p*sY;
+        var xL = BORDER*sX/2;
+        var xR = (TABLE_W - BORDER/2)*sX;
+        ctx.save(); ctx.translate(xL,y); ctx.rotate(Math.PI/4); ctx.fillRect(-mark/2,-mark/2,mark,mark); ctx.restore();
+        ctx.save(); ctx.translate(xR,y); ctx.rotate(Math.PI/4); ctx.fillRect(-mark/2,-mark/2,mark,mark); ctx.restore();
+      });
 
       // Gropat (4 qoshe + 2 ne mes anesore)
       for (var i=0;i<this.pockets.length;i++){
@@ -714,16 +742,7 @@
 
     canvas.addEventListener('pointerup', function(){ aiming = false; });
 
-    function placeAimGlow(t){
-      var r = canvas.getBoundingClientRect();
-      var gx = t.x/TABLE_W * r.width + r.left;
-      var gy = t.y/TABLE_H * r.height + r.top;
-      aimGlow.style.left = (gx-21) + 'px';
-      aimGlow.style.top  = (gy-21) + 'px';
-      var col = 'rgba(' + Math.round(120+power*135) + ',' + Math.round(60+power*20) + ',' + Math.round(60+power*80) + ',.45)';
-      aimGlow.style.boxShadow = '0 0 ' + (8+power*24) + 'px ' + (4+power*20) + 'px ' + col;
-      aimGlow.style.opacity   = showGuides ? 1 : 0;
-    }
+    function placeAimGlow(){ /* shadow removed */ }
 
     /* ==========================================================
        GUIDES + CUE ON TABLE
@@ -731,13 +750,21 @@
     function drawGuides(cue,aim){
       var dx = aim.x - cue.p.x, dy = aim.y - cue.p.y; var L = len(dx,dy) || 1; var dir = { x:dx/L, y:dy/L };
       var step = BALL_R * (.6 - .35*power + .05), dots = 60 + Math.round(power*60);
-      var x = cue.p.x, y = cue.p.y;
+      var x = cue.p.x, y = cue.p.y, target = null;
       ctx.fillStyle = power<.33 ? 'rgba(255,255,255,.7)' : power<.66 ? 'rgba(255,255,255,.85)' : 'rgba(255,255,255,1)';
       for (var i=0;i<dots;i++){
         x += dir.x * step; y += dir.y * step;
         if (x < BORDER+BALL_R || x > TABLE_W-BORDER-BALL_R || y < BORDER+BALL_R || y > TABLE_H-BORDER-BALL_R) break;
         ctx.beginPath(); ctx.arc(x*sX, y*sY, clamp(1.5+power*2.2, 1.5, 4), 0, Math.PI*2); ctx.fill();
-        for (var j=0;j<table.balls.length;j++){ var b=table.balls[j]; if (b===cue || b.pocketed) continue; if (d2({x:x,y:y}, b.p) < (BALL_R*2.05)*(BALL_R*2.05)) { i=dots; break; } }
+        for (var j=0;j<table.balls.length;j++){ var b=table.balls[j]; if (b===cue || b.pocketed) continue; if (d2({x:x,y:y}, b.p) < (BALL_R*2.05)*(BALL_R*2.05)) { target=b; i=dots; break; } }
+      }
+      if (target){
+        var x2 = target.p.x, y2 = target.p.y;
+        for (var k=0;k<dots;k++){
+          x2 += dir.x * step; y2 += dir.y * step;
+          if (x2 < BORDER+BALL_R || x2 > TABLE_W-BORDER-BALL_R || y2 < BORDER+BALL_R || y2 > TABLE_H-BORDER-BALL_R) break;
+          ctx.beginPath(); ctx.arc(x2*sX, y2*sY, clamp(1.2+power*2,1,3.5), 0, Math.PI*2); ctx.fill();
+        }
       }
     }
 
@@ -770,9 +797,10 @@
     pullArea.addEventListener('pointermove', function(e){ if (!pulling) return; var rect=pullArea.getBoundingClientRect(); power=clamp((e.clientY-pullStartY)/(rect.height*0.9),0,1); updatePowerUI(); var minY=rect.top+12, maxY=rect.bottom-12, y=minY+(maxY-minY)*power; cueStickEl.style.height=(60+30*power)+'%'; cueTipEl.style.top=(y-rect.top-6)+'px'; cueStickEl.style.top=(y-rect.top-(cueStickEl.getBoundingClientRect().height-12)/2)+'px'; cuePullVisual=power*(BALL_R*14); placeAimGlow(table.aim); });
     pullArea.addEventListener('pointerup', function(){ if (!pulling) return; pulling=false; shoot(power); power=0; updatePowerUI(); cuePullVisual=0; cueStickEl.style.height='60%'; });
 
-    function shoot(p){ if (!table.running || table.isMoving()) return; var cue=table.balls[0]; if (!cue || cue.pocketed) return; var d=norm(table.aim.x-cue.p.x,table.aim.y-cue.p.y); var base=950*2; // force doubled
+    function shoot(p){ if (!table.running || table.isMoving()) return; var cue=table.balls[0]; if (!cue || cue.pocketed) return; var d=norm(table.aim.x-cue.p.x,table.aim.y-cue.p.y); var base=950*3; // force tripled
       cue.v.x=d.x*base*(0.25+0.75*p)+spinVec.x*260*2*p;
       cue.v.y=d.y*base*(0.25+0.75*p)+spinVec.y*260*2*p;
+      cue.spin = { x:spinVec.x*5*p, y:spinVec.y*5*p };
       setSpin(0,0); showGuides=false; table.turn=2; }
 
     /* ==========================================================


### PR DESCRIPTION
## Summary
- shrink pool table field and expand rails with markings
- add center logo, smaller balls and stronger spin-aware shots
- show secondary aim line from target ball and remove aiming glow

## Testing
- `npm test` *(fails: process hung and produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_68a33dddaf688329850e945f7272968c