### PR TITLE
Adjust pool table layout and cue controls

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -78,7 +78,10 @@
     /* Canvas i tavolines (mbulon gjithcka, pervec panelit djathtas) */
     #table {
       position: absolute;
-      inset: 0;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 5%;
       z-index: 4;
     }
 
@@ -127,10 +130,6 @@
       position: relative;
       width: 84px;
       height: 58%;
-      border-radius: 14px;
-      background: linear-gradient(180deg, rgba(0,0,0,.18), rgba(0,0,0,.28));
-      box-shadow: inset 0 0 0 1px rgba(255,255,255,.05),
-                  0 8px 24px rgba(0,0,0,.35);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -345,12 +344,12 @@
     function resize(){
       var wrap = document.getElementById('wrap');
       var w = wrap.clientWidth;
-      var h = wrap.clientHeight;
+      var h = canvas.clientHeight;
       var ar = TABLE_W / TABLE_H;
       var cw = w, ch = h;
       if (cw/ch > ar) cw = ch * ar; else ch = cw / ar;
       canvas.width = cw; canvas.height = ch;
-      canvas.style.top = ((h - ch) / 2) + 'px';
+      canvas.style.top = '0px';
       canvas.style.left = '0px';
       sX = cw / TABLE_W; sY = ch / TABLE_H;
       pocketR = POCKET_R * ((sX + sY) / 2);
@@ -418,6 +417,7 @@
       this.turn = 1; // 1: P1, 2: CPU
       this.captured = { 1:[], 2:[] };
       this.aim = { x:TABLE_W/2, y:TABLE_H/3 };
+      this.canPlaceCue = true;
       this.reset();
     }
 
@@ -425,8 +425,9 @@
       var i, j;
       this.balls = [];
 
-      // Cue ball (right side, center vertically)
-      this.balls.push(new Ball(BALL_BY_N[0], TABLE_W - BORDER - BALL_R*2, TABLE_H/2));
+      // Cue ball (qender poshte)
+      this.canPlaceCue = true;
+      this.balls.push(new Ball(BALL_BY_N[0], TABLE_W/2, TABLE_H - BORDER - BALL_R*2));
 
       // Trekendshi siper me 15 topa (8-shi ne qender rreshti 3)
       var cx = TABLE_W/2;
@@ -467,6 +468,7 @@
 
       this.captured = { 1:[], 2:[] };
       this.turn = 1;
+      updateCursor();
 
       // TESTE TE INTEGRITETIT (console.assert)
       runSelfTests(this);
@@ -536,6 +538,8 @@
             if (b2.n === 0) {
               this.turn = this.turn===1 ? 2 : 1; // scratch => kalon radha
               b2.p.x = TABLE_W/2; b2.p.y = TABLE_H - BORDER - BALL_R*2; b2.v.x = 0; b2.v.y = 0;
+              this.canPlaceCue = true;
+              updateCursor();
             } else {
               b2.pocketed = true; this.captured[this.turn].push(b2.n);
             }
@@ -655,6 +659,12 @@
     var cuePullVisual = 0;     // shfaqje e terheqjes ne felt
     var spinVec = { x:0, y:0 };// spini i zgjedhur
     var power = 0;             // fuqi [0..1]
+    var draggingCue = false;   // levizja e topit te bardhe
+
+    function updateCursor(){
+      canvas.style.cursor = table.canPlaceCue ? (draggingCue ? 'grabbing' : 'grab') : 'default';
+    }
+    updateCursor();
 
     /* ==========================================================
        RENDER + UPDATE LOOP
@@ -680,16 +690,34 @@
       return { x:(x-r.left)/r.width*TABLE_W, y:(y-r.top)/r.height*TABLE_H };
     }
 
+    function placeCue(t){
+      var cue = table.balls[0];
+      var minX = TABLE_W*0.25 + BALL_R;
+      var maxX = TABLE_W*0.75 - BALL_R;
+      var minY = TABLE_H*0.5 + BALL_R;
+      var maxY = TABLE_H - BORDER - BALL_R*2;
+      cue.p.x = clamp(t.x, minX, maxX);
+      cue.p.y = clamp(t.y, minY, maxY);
+    }
+
     canvas.addEventListener('pointerdown', function(e){
       if (!table.running || table.isMoving()) return;
-      aiming = true; showGuides = true; var t = screenToTable(e.clientX,e.clientY); table.aim = t; placeAimGlow(t);
+      var t = screenToTable(e.clientX,e.clientY);
+      if (table.canPlaceCue && t.y > TABLE_H*0.5) {
+        var cue = table.balls[0];
+        if (Math.hypot(t.x - cue.p.x, t.y - cue.p.y) < BALL_R*2) {
+          draggingCue = true; placeCue(t); updateCursor(); return;
+        }
+      }
+      aiming = true; showGuides = true; table.aim = t; placeAimGlow(t);
     });
 
     canvas.addEventListener('pointermove', function(e){
+      if (draggingCue) { var t = screenToTable(e.clientX,e.clientY); placeCue(t); return; }
       if (!aiming || !table.running) return; var t = screenToTable(e.clientX,e.clientY); table.aim = t; placeAimGlow(t);
     });
 
-    canvas.addEventListener('pointerup', function(){ aiming = false; });
+    canvas.addEventListener('pointerup', function(){ if (draggingCue) { draggingCue=false; updateCursor(); return; } aiming = false; });
 
     function placeAimGlow(){ /* shadow removed */ }
 
@@ -706,14 +734,6 @@
         if (x < BORDER+BALL_R || x > TABLE_W-BORDER-BALL_R || y < BORDER+BALL_R || y > TABLE_H-BORDER-BALL_R) break;
         ctx.beginPath(); ctx.arc(x*sX, y*sY, clamp(1.5+power*2.2, 1.5, 4), 0, Math.PI*2); ctx.fill();
         for (var j=0;j<table.balls.length;j++){ var b=table.balls[j]; if (b===cue || b.pocketed) continue; if (d2({x:x,y:y}, b.p) < (BALL_R*2.05)*(BALL_R*2.05)) { target=b; i=dots; break; } }
-      }
-      if (target){
-        var x2 = target.p.x, y2 = target.p.y;
-        for (var k=0;k<dots;k++){
-          x2 += dir.x * step; y2 += dir.y * step;
-          if (x2 < BORDER+BALL_R || x2 > TABLE_W-BORDER-BALL_R || y2 < BORDER+BALL_R || y2 > TABLE_H-BORDER-BALL_R) break;
-          ctx.beginPath(); ctx.arc(x2*sX, y2*sY, clamp(1.2+power*2,1,3.5), 0, Math.PI*2); ctx.fill();
-        }
       }
     }
 
@@ -750,7 +770,7 @@
       cue.v.x=d.x*base*(0.25+0.75*p)+spinVec.x*260*2*p;
       cue.v.y=d.y*base*(0.25+0.75*p)+spinVec.y*260*2*p;
       cue.spin = { x:spinVec.x*5*p, y:spinVec.y*5*p };
-      setSpin(0,0); showGuides=false; table.turn=2; }
+      setSpin(0,0); showGuides=false; table.turn=2; table.canPlaceCue=false; updateCursor(); }
 
     /* ==========================================================
        CPU – turn i thjeshte (normal skill)


### PR DESCRIPTION
## Summary
- Shrink the billiards table canvas from the bottom and remove the pull strength frame
- Start cue ball at bottom center and allow draggable placement before shots or after scratches
- Drop secondary guide line and disable cue placement after shooting

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*
- `npm run lint` *(fails: 473 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a34b3317a48329a2a6fffa77ec1a53