### PR TITLE
Implement payout and UI tweaks for Texas Hold'em

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -95,13 +95,15 @@
     #raisePanel .max-label{ position:absolute; top:4px; left:50%; transform:translateX(-50%); font-size:10px; color:#fff; animation:pulse 1.5s infinite; }
     @keyframes pulse{0%,100%{opacity:0.6}50%{opacity:1}}
     @keyframes shimmer{from{background-position:0 0}to{background-position:100px 0}}
-    #status{ position:absolute; top:60%; left:50%; transform:translate(-50%, -50%); font-weight:900; letter-spacing:.3px; color:#ff0; background:rgba(0,0,0,.28); padding:6px 12px; border-radius:12px; border:1px solid rgba(255,255,255,.12); text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
+    #status{ position:absolute; top:60%; left:50%; transform:translate(-50%, -50%); font-weight:900; letter-spacing:.3px; color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
     .top-controls{position:absolute;top:8px;right:8px;display:flex;flex-direction:column;gap:8px;z-index:10}
     .top-controls button{width:44px;height:44px;padding:0;border:2px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#2563eb;color:#fff;font-weight:600}
     .top-controls button img{width:24px;height:24px}
     .seat.vacant .vacant-seat{width:var(--avatar-size);height:var(--avatar-size);border-radius:50%;border:4px solid #000;background:#facc15;color:#16a34a;font-weight:700;display:flex;align-items:center;justify-content:center}
 
-    .pot{ position:absolute; left:50%; top:35%; transform:translate(-50%,-50%); display:flex; gap:6px; z-index:2; }
+    .pot-wrap{ position:absolute; left:50%; top:35%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
+    .pot{ display:flex; gap:6px; }
+    .pot-total{ font-size:12px; }
     .chip-pile{ position:relative; width:calc(var(--avatar-size)/2); height:calc(var(--avatar-size)/2); }
     .chip{ position:absolute; left:0; width:calc(var(--avatar-size)/2); height:calc(var(--avatar-size)/2); border-radius:50%; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:calc(var(--avatar-size)/4); color:#000; box-shadow:0 2px 4px rgba(0,0,0,.4); }
     .chip.v1{ background:#ffffff; }
@@ -117,18 +119,22 @@
   </style>
 </head>
 <body>
-  <div class="stage">
-    <div class="center community" id="community"></div>
-    <div class="pot" id="pot"></div>
-    <div class="seats" id="seats"></div>
-    <div id="status"></div>
-  </div>
+    <div class="stage">
+      <div class="center community" id="community"></div>
+      <div class="pot-wrap" id="potWrap">
+        <div class="pot" id="pot"></div>
+        <div class="pot-total" id="potTotal"></div>
+      </div>
+      <div class="seats" id="seats"></div>
+      <div id="status"></div>
+    </div>
   <audio id="sndTimer" src="https://cdn.jsdelivr.net/gh/naptha/tiny-sound@master/sounds/beep1.ogg"></audio>
   <div class="top-controls">
     <button id="lobbyIcon"><img src="assets/icons/texas-holdem.svg" alt="Lobby"/></button>
     <button id="leaveSeatBtn">Leave</button>
   </div>
-  <script src="/flag-emojis.js"></script>
-  <script type="module" src="/texas-holdem.js"></script>
+    <script src="/flag-emojis.js"></script>
+    <script src="/falling-ball-api.js"></script>
+    <script type="module" src="/texas-holdem.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- pay winner 90% of pot while sending 10% to dev account
- show pot total and reset pot each game
- clean up status banner and show action messages

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68a350c6c68c8329a444735f82a0c081