### PR TITLE
feat: expand pool royale icon canvas

### DIFF
--- a/webapp/public/assets/icons/pool-royale.svg
+++ b/webapp/public/assets/icons/pool-royale.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 105 105" width="105" height="105">
   <circle cx="50" cy="50" r="48" fill="#111" stroke="#fff" stroke-width="4"/>
   <circle cx="50" cy="50" r="20" fill="#fff"/>
   <text x="50" y="57" font-size="24" text-anchor="middle" fill="#111" font-family="Arial" font-weight="bold">8</text>


### PR DESCRIPTION
## Summary
- expand Pool Royale icon viewbox and dimensions by 5% on bottom and right

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68a35db68b348329ba25ed968cede940