### PR TITLE
fix: remove unsupported bluff action

### DIFF
--- a/lib/texasHoldem.js
+++ b/lib/texasHoldem.js
@@ -191,14 +191,18 @@ export function aiChooseAction(hand, community=[], options={}){
       return {action:'raise', amount:Math.min(20, chips)};
     }
     if(rnd<0.1 && chips>20){
-      return {action:'bluff', amount:Math.min(20, chips)};
+      // Previously returned a special 'bluff' action which wasn't handled by all
+      // game flows. Treat this as a normal raise so the AI always makes a valid
+      // decision.
+      return {action:'raise', amount:Math.min(20, chips)};
     }
     return {action:'check'};
   }
   if(chips<=currentBet) return {action:'fold'};
   if(strength>=2 || (strength===1 && rnd>0.5)) return {action:'call'};
   if(rnd<0.1 && chips>currentBet*2){
-    return {action:'bluff', amount:Math.min(currentBet*2, chips)};
+    // Replace the unused 'bluff' action with a standard raise
+    return {action:'raise', amount:Math.min(currentBet*2, chips)};
   }
   return {action:'fold'};
 }

--- a/webapp/public/lib/texasHoldem.js
+++ b/webapp/public/lib/texasHoldem.js
@@ -191,14 +191,17 @@ export function aiChooseAction(hand, community=[], options={}){
       return {action:'raise', amount:Math.min(20, chips)};
     }
     if(rnd<0.1 && chips>20){
-      return {action:'bluff', amount:Math.min(20, chips)};
+      // Avoid returning the special 'bluff' action which wasn't universally
+      // supported. Use a standard raise instead.
+      return {action:'raise', amount:Math.min(20, chips)};
     }
     return {action:'check'};
   }
   if(chips<=currentBet) return {action:'fold'};
   if(strength>=2 || (strength===1 && rnd>0.5)) return {action:'call'};
   if(rnd<0.1 && chips>currentBet*2){
-    return {action:'bluff', amount:Math.min(currentBet*2, chips)};
+    // Replace bluff with raise to ensure the AI always returns valid actions
+    return {action:'raise', amount:Math.min(currentBet*2, chips)};
   }
   return {action:'fold'};
 }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -505,14 +505,13 @@ async function proceedStage() {
       updatePotDisplay();
       showActionOverlay(i, 'call');
       document.getElementById('status').textContent = `${p.name} calls ${amt} ${state.token}`;
-    } else if (act.action === 'raise' || act.action === 'bluff') {
+    } else if (act.action === 'raise') {
       const bet = deductChips(i, act.amount);
       state.pot += bet;
       state.currentBet = bet;
       updatePotDisplay();
       showActionOverlay(i, 'raise');
-      const prefix = act.action === 'bluff' ? 'bluffs and ' : '';
-      document.getElementById('status').textContent = `${p.name} ${prefix}raises ${bet} ${state.token}`;
+      document.getElementById('status').textContent = `${p.name} raises ${bet} ${state.token}`;
     } else if (act.action === 'check') {
       showActionOverlay(i, 'check');
       document.getElementById('status').textContent = `${p.name} checks`;


### PR DESCRIPTION
## Summary
- ensure Texas Hold'em AI only returns standard actions
- simplify stage logic to handle raises uniformly

## Testing
- `node --test test/userUtils.test.js`
- `node --test` *(fails: process did not exit due to server startup hanging)*

------
https://chatgpt.com/codex/tasks/task_e_68a361b8a3308329ab50f8eb4703eb7e