### PR TITLE
Expand Pool Royale background 5% to bottom-right

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -92,9 +92,9 @@
       flex: 1 1 auto;
       display: flex;
       overflow: hidden;
-      background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp') center/cover no-repeat;
-      background-size: 95% 105%;
-      background-position: left center;
+      background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp') left top/cover no-repeat;
+      background-size: 100% 110%;
+      background-position: left top;
     }
 
     :root { --rpw: min(20vw, 100px); }


### PR DESCRIPTION
## Summary
- Anchor Pool Royale background to the top-left and enlarge 5% to the right and bottom for a fuller view

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a362e6bf408329bfe2f443f971c8c0