### PR TITLE
feat: expand poll royale background

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -93,8 +93,8 @@
       display: flex;
       overflow: hidden;
       background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp') center/cover no-repeat;
-      background-size: 95% 105%;
-      background-position: left center;
+      background-size: 97% 107%;
+      background-position: left top;
     }
 
     :root { --rpw: min(20vw, 100px); }


### PR DESCRIPTION
## Summary
- expand Poll Royale background image 2% toward bottom and right while keeping pool field stationary

## Testing
- `npm test` *(fails: AssertionError in snakeApi.test.js)*
- `npm run lint` *(fails: 473 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a368b0662c832982ce11c9809199ad