### PR TITLE
Expand Pool Royale background image

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -93,8 +93,8 @@
       display: flex;
       overflow: hidden;
       background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp') center/cover no-repeat;
-      background-size: 95% 105%;
-      background-position: left center;
+      background-size: 98% 108%;
+      background-position: left top;
     }
 
     :root { --rpw: min(20vw, 100px); }


### PR DESCRIPTION
## Summary
- Enlarge Pool Royale page background by 3% on right and bottom
- Anchor background at top-left so table layout remains unaffected

## Testing
- `npm test` *(fails to exit; logs show tests executing before hanging)*

------
https://chatgpt.com/codex/tasks/task_e_68a36ee428408329a062b277c07ff519