### PR TITLE
Replace cue power control with slider

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -149,8 +149,7 @@
       top: 50%;
       transform: translate(-50%, -50%);
     }
-
-    #pullArea {
+    #powerSlider {
       position: relative;
       width: 84px;
       height: 58%;
@@ -158,55 +157,7 @@
       background: linear-gradient(180deg, rgba(0,0,0,.18), rgba(0,0,0,.28));
       box-shadow: inset 0 0 0 1px rgba(255,255,255,.05),
                   0 8px 24px rgba(0,0,0,.35);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 8px;
-    }
-
-    #cueRail {
-      position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
-      width: 10px;
-      height: calc(100% - 24px);
-      background: #3a2a17;
-      border-radius: 8px;
-      box-shadow: inset 0 0 0 2px rgba(0,0,0,.15);
-    }
-
-    #cueStick {
-      position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
-      width: 8px;
-      height: 60%;
-      background: linear-gradient(#caa471, #9c7a4d);
-      border-radius: 6px;
-      box-shadow: 0 1px 0 rgba(255,255,255,.25) inset,
-                  0 4px 10px rgba(0,0,0,.35);
-    }
-
-    #tip {
-      position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
-      width: 12px;
-      height: 12px;
-      background: #5c3a21; /* ferrule */
-      border-radius: 50%;
-      top: calc(50% - 6px);
-      box-shadow: 0 0 0 2px rgba(0,0,0,.25);
-    }
-
-    #powerBox {
-      width: 50px;
-      height: 18%;
-      background: #333;
-      border-radius: 16px;
-      position: relative;
       overflow: hidden;
-      box-shadow: inset 0 0 0 2px rgba(0,0,0,.25);
     }
 
     #powerFill {
@@ -274,16 +225,8 @@
           <div id="spinDot"></div>
         </div>
 
-        <div id="pullArea">
-          <div id="cueRail"></div>
-          <div id="cueStick"></div>
-          <div id="tip"></div>
-        </div>
-
-        <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
-          <div id="powerBox"><div id="powerFill"></div></div>
-          <div id="powerTxt">FORCA 0%</div>
-        </div>
+        <div id="powerSlider"><div id="powerFill"></div></div>
+        <div id="powerTxt">FORCA 0%</div>
       </aside>
 
       <button id="play">Play</button>
@@ -335,9 +278,7 @@
     var spinDot   = document.getElementById('spinDot');
     var logoImg   = new Image();
     logoImg.src   = '/assets/icons/pool-royale.svg';
-    var pullArea  = document.getElementById('pullArea');
-    var cueStickEl= document.getElementById('cueStick');
-    var cueTipEl  = document.getElementById('tip');
+    var powerSlider= document.getElementById('powerSlider');
     var powerFill = document.getElementById('powerFill');
     var powerTxt  = document.getElementById('powerTxt');
 
@@ -846,11 +787,19 @@
     /* ==========================================================
        PULL & RELEASE – fuqi e goditjes
        ========================================================= */
-    var pulling=false, pullStartY=0;
+    var pulling=false;
     function updatePowerUI(){ powerFill.style.height = Math.round(power*100)+'%'; powerTxt.textContent = 'FORCA '+Math.round(power*100)+'%'; }
-    pullArea.addEventListener('pointerdown', function(e){ if (!table.running || table.isMoving()) return; pulling=true; pullStartY=e.clientY; power=0; updatePowerUI(); });
-    pullArea.addEventListener('pointermove', function(e){ if (!pulling) return; var rect=pullArea.getBoundingClientRect(); power=clamp((e.clientY-pullStartY)/(rect.height*0.9),0,1); updatePowerUI(); var minY=rect.top+12, maxY=rect.bottom-12, y=minY+(maxY-minY)*power; cueStickEl.style.height=(60+30*power)+'%'; cueTipEl.style.top=(y-rect.top-6)+'px'; cueStickEl.style.top=(y-rect.top-(cueStickEl.getBoundingClientRect().height-12)/2)+'px'; cuePullVisual=power*(BALL_R*14); placeAimGlow(table.aim); });
-    pullArea.addEventListener('pointerup', function(){ if (!pulling) return; pulling=false; shoot(power); power=0; updatePowerUI(); cuePullVisual=0; cueStickEl.style.height='60%'; });
+    function updatePower(e){
+      var rect=powerSlider.getBoundingClientRect();
+      power=clamp(1 - (e.clientY-rect.top)/(rect.height*0.9),0,1);
+      updatePowerUI();
+      cuePullVisual=power*(BALL_R*14);
+      placeAimGlow(table.aim);
+    }
+    powerSlider.addEventListener('pointerdown', function(e){ if (!table.running || table.isMoving()) return; pulling=true; updatePower(e); });
+    powerSlider.addEventListener('pointermove', function(e){ if (!pulling) return; updatePower(e); });
+    powerSlider.addEventListener('pointerup', function(){ if (!pulling) return; pulling=false; shoot(power); power=0; updatePowerUI(); cuePullVisual=0; });
+    powerSlider.addEventListener('pointerleave', function(){ if (!pulling) return; pulling=false; shoot(power); power=0; updatePowerUI(); cuePullVisual=0; });
 
     function shoot(p){
       if (!table.running || table.isMoving()) return;


### PR DESCRIPTION
## Summary
- replace cue-based power control with vertical slider in Pool Royale
- handle slider input to set shot power

## Testing
- `npm test`
- `npm run lint` (fails: many eslint errors in lib/texasHoldem.js)


------
https://chatgpt.com/codex/tasks/task_e_68a372fd77348329b016777c1573f96a