### PR TITLE
fix: stretch pool royale background

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -92,9 +92,10 @@
       flex: 1 1 auto;
       display: flex;
       overflow: hidden;
-      background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp') center/cover no-repeat;
-      background-size: 98% 108%;
-      background-position: left top;
+      /* Ensure background image covers the available space without
+         overlapping top or bottom elements */
+      background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
+        center/cover no-repeat;
     }
 
     :root { --rpw: min(20vw, 100px); }


### PR DESCRIPTION
## Summary
- ensure Pool Royale background scales to full game area without overlapping top/bottom cards

## Testing
- `npm test` *(fails: seat and unseat endpoints update lobby; allows multiple users without telegramId; withdraw route reverts balance on claim failure)*
- `npm run lint` *(fails: 473 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a3726e5da48329a95005b8c309ea0f