### PR TITLE
feat: add basic texas holdem ai logic

### DIFF
--- a/bot/logic/texasHoldemAI.js
+++ b/bot/logic/texasHoldemAI.js
@@ -1,0 +1,41 @@
+// Basic Texas Hold'em decision helpers based on simplified EV rules.
+// The goal is to provide a lightweight guide for an AI player to choose
+// between fold/call/check/raise using hand groups and percentages.
+
+// 1. Pot odds helper
+export function potOdds(toCall, pot) {
+  return toCall / (pot + toCall);
+}
+
+// 2. Pre-flop strategy using four hand groups (A–D)
+// Frequencies are derived from the provided guide.
+const PREFLOP_GROUPS = {
+  A: { raise: 0.85, call: 0.15, fold: 0 }, // Premium
+  B: { raise: 0.6, call: 0.35, fold: 0.05 }, // Strong
+  C: { raise: 0.2, call: 0.6, fold: 0.2 }, // Speculative suited
+  D: { raise: 0.1, call: 0.1, fold: 0.8 }, // Weak offsuit
+};
+
+export function preflopAction(group, rng = Math.random()) {
+  const freqs = PREFLOP_GROUPS[group] || PREFLOP_GROUPS.D;
+  if (rng < freqs.raise) return 'raise';
+  if (rng < freqs.raise + freqs.call) return 'call';
+  return 'fold';
+}
+
+// 3. Post-flop decision based on equity vs. pot odds.
+// Position adjusts thresholds: OOP is tighter (+0.02), IP looser (-0.02).
+export function postflopDecision({ equity, potOdds, position = 'IP', free = false }) {
+  const adjust = position === 'OOP' ? 0.02 : position === 'IP' ? -0.02 : 0;
+  const foldThresh = potOdds - 0.03 + adjust;
+  const raiseThresh = potOdds + 0.06 + adjust;
+  if (equity < foldThresh) return free ? 'check' : 'fold';
+  if (equity > raiseThresh) return 'raise';
+  return free ? 'check' : 'call';
+}
+
+export default {
+  potOdds,
+  preflopAction,
+  postflopDecision,
+};

--- a/test/texasHoldemAI.test.js
+++ b/test/texasHoldemAI.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { potOdds, preflopAction, postflopDecision } from '../bot/logic/texasHoldemAI.js';
+
+test('pot odds calculation', () => {
+  assert.equal(potOdds(10, 30), 0.25);
+});
+
+test('preflop action follows frequencies', () => {
+  assert.equal(preflopAction('A', 0.5), 'raise');
+  assert.equal(preflopAction('B', 0.65), 'call');
+  assert.equal(preflopAction('C', 0.95), 'fold');
+});
+
+test('postflop decision uses equity and position', () => {
+  assert.equal(postflopDecision({ equity: 0.4, potOdds: 0.5 }), 'fold');
+  assert.equal(postflopDecision({ equity: 0.52, potOdds: 0.5, free: true }), 'check');
+  assert.equal(postflopDecision({ equity: 0.7, potOdds: 0.5, position: 'IP' }), 'raise');
+});


### PR DESCRIPTION
## Summary
- add EV-based Texas Hold'em decision helpers
- cover pot odds, preflop frequencies and postflop logic
- add targeted tests for poker logic

## Testing
- `npm test` *(fails: snakeApi.test.js assertion `assert.ok(events.includes('diceRolled'))`)*
- `node --test test/texasHoldemAI.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a379275b308329bb60b6e29f6f5384