### PR TITLE
Adjust Pool Royale background size

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -95,7 +95,7 @@
       /* Ensure background image covers the available space without
          overlapping top or bottom elements */
       background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
-        center/100% 102% no-repeat;
+        center/100% calc(100% + 48px) no-repeat;
     }
 
     :root { --rpw: min(20vw, 100px); }


### PR DESCRIPTION
## Summary
- Slightly increase Pool Royale canvas background height to avoid clipping

## Testing
- `npm test` *(fails: The module '/workspace/TonPlaygramWebApp/bot/node_modules/canvas/... canvas.node' was compiled against a different Node.js version)*
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3f507c0c883298716e0629cb94ae2