### PR TITLE
Adjust Pool Royale table background

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -93,9 +93,10 @@
       display: flex;
       overflow: hidden;
       /* Ensure background image covers the available space without
-         overlapping top or bottom elements */
+         overlapping top or bottom elements. Extend only the bottom
+         edge by roughly half a ball's height for extra clearance. */
       background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
-        center/100% calc(100% + 48px) no-repeat;
+        top center/100% calc(100% + 24px) no-repeat;
     }
 
     :root { --rpw: min(20vw, 100px); }


### PR DESCRIPTION
## Summary
- Extend Pool Royale board background downward by half a ball to prevent clipping.

## Testing
- `npm test`
- `npm run lint` *(fails: 473 errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fac4b4288329bfa72d57608e770d