### PR TITLE
Improve Texas Hold'em betting logic and AI decisions

### DIFF
--- a/lib/texasHoldem.js
+++ b/lib/texasHoldem.js
@@ -181,16 +181,35 @@ export function evaluateWinner(players, community){
   return winner;
 }
 
-export function aiChooseAction(hand, community=[]){
-  const stage=community.length; //0 preflop,3 flop,4 turn,5 river
-  const score=bestHand([...hand,...community]);
-  // very naive thresholds
-  if(stage<3){
-    // preflop
-    const hv=hand.map(c=>rankValue(c.rank)).sort((a,b)=>b-a);
-    if(hv[0]>=12 || hv[0]===hv[1]) return 'call';
-    return 'fold';
+export function aiChooseAction(hand, community=[], canCheck=true){
+  const stage = community.length; //0 preflop,3 flop,4 turn,5 river
+  const rand = Math.random();
+  const score = bestHand([...hand, ...community]).rank;
+
+  if (stage < 3) {
+    // preflop logic based on simple hand groups
+    const hv = hand.map(c => rankValue(c.rank)).sort((a,b)=>b-a);
+    const pair = hv[0] === hv[1];
+    const suited = hand[0].suit === hand[1].suit;
+    const high = hv[0] >= 12; // Q+
+    if (pair && hv[0] >= 11) return 'raise'; // premium pair JJ+
+    if (pair || (high && hv[1] >= 10)) {
+      if (!canCheck) return rand < 0.7 ? 'call' : 'raise';
+      return rand < 0.5 ? 'raise' : 'check';
+    }
+    if (canCheck) {
+      return rand < 0.1 ? 'raise' : 'check'; // occasional bluff
+    }
+    return rand < 0.1 ? 'call' : 'fold';
   }
-  if(score.rank>=1) return 'call';
-  return 'fold';
+
+  // post-flop decisions
+  if (score >= 5) return 'raise'; // flush or better
+  if (score >= 2) {
+    if (!canCheck) return rand < 0.8 ? 'call' : 'raise';
+    return rand < 0.5 ? 'raise' : 'check';
+  }
+  if (score >= 1) return canCheck ? 'check' : 'call';
+  if (canCheck) return rand < 0.05 ? 'raise' : 'check'; // rare bluff
+  return rand < 0.1 ? 'call' : 'fold';
 }

--- a/webapp/public/lib/texasHoldem.js
+++ b/webapp/public/lib/texasHoldem.js
@@ -181,16 +181,35 @@ export function evaluateWinner(players, community){
   return winner;
 }
 
-export function aiChooseAction(hand, community=[]){
-  const stage=community.length; //0 preflop,3 flop,4 turn,5 river
-  const score=bestHand([...hand,...community]);
-  // very naive thresholds
-  if(stage<3){
-    // preflop
-    const hv=hand.map(c=>rankValue(c.rank)).sort((a,b)=>b-a);
-    if(hv[0]>=12 || hv[0]===hv[1]) return 'call';
-    return 'fold';
+export function aiChooseAction(hand, community=[], canCheck=true){
+  const stage = community.length; //0 preflop,3 flop,4 turn,5 river
+  const rand = Math.random();
+  const score = bestHand([...hand, ...community]).rank;
+
+  if (stage < 3) {
+    // preflop logic based on simple hand groups
+    const hv = hand.map(c => rankValue(c.rank)).sort((a,b)=>b-a);
+    const pair = hv[0] === hv[1];
+    const suited = hand[0].suit === hand[1].suit;
+    const high = hv[0] >= 12; // Q+
+    if (pair && hv[0] >= 11) return 'raise'; // premium pair JJ+
+    if (pair || (high && hv[1] >= 10)) {
+      if (!canCheck) return rand < 0.7 ? 'call' : 'raise';
+      return rand < 0.5 ? 'raise' : 'check';
+    }
+    if (canCheck) {
+      return rand < 0.1 ? 'raise' : 'check'; // occasional bluff
+    }
+    return rand < 0.1 ? 'call' : 'fold';
   }
-  if(score.rank>=1) return 'call';
-  return 'fold';
+
+  // post-flop decisions
+  if (score >= 5) return 'raise'; // flush or better
+  if (score >= 2) {
+    if (!canCheck) return rand < 0.8 ? 'call' : 'raise';
+    return rand < 0.5 ? 'raise' : 'check';
+  }
+  if (score >= 1) return canCheck ? 'check' : 'call';
+  if (canCheck) return rand < 0.05 ? 'raise' : 'check'; // rare bluff
+  return rand < 0.1 ? 'call' : 'fold';
 }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -311,11 +311,11 @@ function setPlayerTurnIndicator(idx) {
 function showControls() {
   const controls = document.getElementById('controls');
   controls.innerHTML = '';
-  const baseActions = [
-    { id: 'fold', fn: playerFold },
-    { id: 'check', fn: playerCheck },
-    { id: 'call', fn: playerCall },
-  ];
+  const baseActions = [{ id: 'fold', fn: playerFold }];
+  if (state.currentBet === 0) {
+    baseActions.push({ id: 'check', fn: playerCheck });
+  }
+  baseActions.push({ id: 'call', fn: playerCall });
   baseActions.forEach((a) => {
     const btn = document.createElement('button');
     btn.id = a.id;
@@ -431,6 +431,7 @@ function playerFold() {
 }
 
 function playerCheck() {
+  if (state.currentBet > 0) return; // cannot check against a bet
   document.getElementById('status').textContent = 'You check';
   proceedStage();
 }
@@ -463,8 +464,18 @@ async function proceedStage() {
     setPlayerTurnIndicator(i);
     document.getElementById('status').textContent = `${p.name}...`;
     await new Promise((r) => setTimeout(r, 2500));
-    const action = aiChooseAction(p.hand, state.community.slice(0, stageCommunityCount()));
-    if (action === 'call') {
+    const action = aiChooseAction(
+      p.hand,
+      state.community.slice(0, stageCommunityCount()),
+      state.currentBet === 0
+    );
+    if (action === 'raise') {
+      const amount = Math.min(ANTE, state.maxPot - state.pot);
+      state.pot += amount;
+      state.currentBet += amount;
+      updatePotDisplay();
+      document.getElementById('status').textContent = `${p.name} raises ${amount} ${state.token}`;
+    } else if (action === 'call') {
       state.pot += state.currentBet;
       updatePotDisplay();
       document.getElementById('status').textContent = `${p.name} calls ${state.currentBet} ${state.token}`;


### PR DESCRIPTION
## Summary
- Disallow check after a raise and update AI players to respect bet amounts
- Expand Texas Hold'em AI logic with basic pre/post-flop hand evaluation and bluffing
- Integrate raise handling in game loop and hide check option when facing a bet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3fd5ad9488329b7e53773c68f4d00