### PR TITLE
chore: crop pool table top and remove cue panel frame

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -156,14 +156,10 @@
       position: relative;
       width: 84px;
       height: 58%;
-      border-radius: 14px;
-      background: linear-gradient(180deg, rgba(0,0,0,.18), rgba(0,0,0,.28));
-      box-shadow: inset 0 0 0 1px rgba(255,255,255,.05),
-                  0 8px 24px rgba(0,0,0,.35);
+      /* Removed card background and frame so only the cue remains */
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: 8px;
     }
 
     #cueRail {
@@ -388,10 +384,20 @@
       var ar = TABLE_W / TABLE_H;
       var cw = w, ch = h;
       if (cw/ch > ar) cw = ch * ar; else ch = cw / ar;
-      canvas.width = cw; canvas.height = ch;
-      canvas.style.top = '0px';
+
+      // Preliminary scale to estimate ball size for top cropping
+      var tmpSX = cw / TABLE_W, tmpSY = ch / TABLE_H;
+      var tmpBallR = BALL_R * ((tmpSX + tmpSY) / 2);
+
+      // Extend canvas downward and shift up by one ball diameter
+      canvas.width = cw;
+      canvas.height = ch + tmpBallR * 2;
+      canvas.style.top = (-tmpBallR * 2) + 'px';
       canvas.style.left = '0px';
-      sX = cw / TABLE_W; sY = ch / TABLE_H;
+
+      // Final scale based on adjusted canvas size
+      sX = cw / TABLE_W;
+      sY = canvas.height / TABLE_H;
       pocketR = POCKET_R * ((sX + sY) / 2);
       ballR   = BALL_R   * ((sX + sY) / 2);
     }


### PR DESCRIPTION
## Summary
- Crop pool table canvas from the top by one ball diameter so the lower edge remains unchanged
- Remove background card beneath right-side cue control so only the cue is visible

## Testing
- `npm test` (fails: The expression evaluated to a falsy value)
- `npm run lint` (fails: 473 problems)

------
https://chatgpt.com/codex/tasks/task_e_68a3ff2382c08329ab263a187ac852ea