### PR TITLE
Add games transactions card

### DIFF
--- a/webapp/src/components/GameTransactionsCard.jsx
+++ b/webapp/src/components/GameTransactionsCard.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { getAccountTransactions } from '../utils/api.js';
+
+const GAME_ACCOUNT =
+  import.meta.env.VITE_GAME_ACCOUNT_ID || import.meta.env.VITE_DEV_ACCOUNT_ID;
+
+export default function GameTransactionsCard() {
+  const [transactions, setTransactions] = useState([]);
+
+  useEffect(() => {
+    if (!GAME_ACCOUNT) return;
+    getAccountTransactions(GAME_ACCOUNT)
+      .then((res) => setTransactions(res.transactions || []))
+      .catch(() => setTransactions([]));
+  }, []);
+
+  if (!GAME_ACCOUNT) return null;
+
+  return (
+    <section className="relative bg-surface border border-border rounded-xl p-4 shadow-lg overflow-hidden wide-card">
+      <h3 className="text-lg font-semibold text-center">Games Transactions</h3>
+      <ul className="mt-2 space-y-1 max-h-64 overflow-y-auto text-sm">
+        {transactions.length === 0 && <li>No transactions yet.</li>}
+        {transactions.map((t, i) => (
+          <li key={i} className="flex justify-between">
+            <span className="capitalize">{t.type}</span>
+            <span>{t.amount}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LeaderboardCard from '../components/LeaderboardCard.jsx';
+import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
 
 export default function Games() {
   useTelegramBackButton();
@@ -157,6 +158,7 @@ export default function Games() {
             </div>
           </div>
         </div>
+        <GameTransactionsCard />
         <LeaderboardCard />
       </div>
   );


### PR DESCRIPTION
## Summary
- show public GameTransactionsCard on games page
- fetch and list transactions from configured game account

## Testing
- `npm run lint` *(fails: Extra semicolon and other lint errors)*
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68a406d1c76c8329a170189ed9b3d51f