### PR TITLE
Ensure GameTransactionsCard shows when account missing

### DIFF
--- a/webapp/src/components/GameTransactionsCard.jsx
+++ b/webapp/src/components/GameTransactionsCard.jsx
@@ -13,21 +13,26 @@ export default function GameTransactionsCard() {
       .then((res) => setTransactions(res.transactions || []))
       .catch(() => setTransactions([]));
   }, []);
-
-  if (!GAME_ACCOUNT) return null;
+  const Content = () => (
+    <ul className="mt-2 space-y-1 max-h-64 overflow-y-auto text-sm">
+      {transactions.length === 0 && <li>No transactions yet.</li>}
+      {transactions.map((t, i) => (
+        <li key={i} className="flex justify-between">
+          <span className="capitalize">{t.type}</span>
+          <span>{t.amount}</span>
+        </li>
+      ))}
+    </ul>
+  );
 
   return (
     <section className="relative bg-surface border border-border rounded-xl p-4 shadow-lg overflow-hidden wide-card">
       <h3 className="text-lg font-semibold text-center">Games Transactions</h3>
-      <ul className="mt-2 space-y-1 max-h-64 overflow-y-auto text-sm">
-        {transactions.length === 0 && <li>No transactions yet.</li>}
-        {transactions.map((t, i) => (
-          <li key={i} className="flex justify-between">
-            <span className="capitalize">{t.type}</span>
-            <span>{t.amount}</span>
-          </li>
-        ))}
-      </ul>
+      {GAME_ACCOUNT ? (
+        <Content />
+      ) : (
+        <p className="mt-2 text-sm text-center">Game account is not configured.</p>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Keep GameTransactionsCard visible even when no game account is configured
- Show placeholder message if account ID is unset

## Testing
- `npm test` *(fails: options.agent ProxyAgent errors, process terminated)*
- `npm run lint` *(fails: 473 lint errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68a40b0259088329958cb71fb239cf73