### PR TITLE
Improve Pool Royale table layout and controls

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -76,15 +76,10 @@
     }
 
     .potted .ball {
-      width: 10px;
-      height: 10px;
+      width: 14px;
+      height: 14px;
       border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 7px;
-      line-height: 10px;
-      color: #000;
+      display: block;
     }
 
     #wrap {
@@ -108,7 +103,16 @@
       left: 0;
       right: 0;
       bottom: 0;
+      transform: translateY(-4px);
       z-index: 4;
+    }
+
+    #cueHint {
+      position: absolute;
+      z-index: 7;
+      display: none;
+      font-size: 24px;
+      pointer-events: none;
     }
 
     /* Paneli djathtas – SPIN siper, STEKA poshte */
@@ -266,6 +270,7 @@
 
     <div id="wrap">
       <canvas id="table"></canvas>
+      <div id="cueHint">✋️</div>
 
       <!-- Panel djathtas: SPIN siper, STEKA poshte -->
       <aside id="rightPanel">
@@ -315,7 +320,7 @@
     var BALL_R   = 24.3;    // rrezja baze e topave (10% me e vegjel)
     var BORDER_TOP = BORDER + BALL_R * 2; // topi anes se siperm shkurtohet me diametrin e topit
     var BORDER_BOTTOM = BORDER;           // anet e tjera mbeten te pandryshuara
-    var HEAD_Y   = BORDER_TOP + (TABLE_H - BORDER_TOP - BORDER_BOTTOM) * 0.75; // vija e bardhe e kufirit te cueball-it
+    var HEAD_Y   = BORDER_TOP + (TABLE_H - BORDER_TOP - BORDER_BOTTOM) * 0.25; // vija e bardhe e kufirit te cueball-it
     var CUE_START_Y = HEAD_Y + (TABLE_H - BORDER_BOTTOM - HEAD_Y - BALL_R*2) / 2; // pozicioni fillestar i cueball-it
 
     var FRICTION = 0.985;   // ferkimi linear
@@ -348,6 +353,7 @@
     var nameCPU  = document.querySelector('#header .player:last-child .name');
     var pottedP1 = document.getElementById('p1Potted');
     var pottedP2 = document.getElementById('p2Potted');
+    var cueHint  = document.getElementById('cueHint');
 
     var tg = window.Telegram?.WebApp;
     var userData = tg?.initDataUnsafe?.user;
@@ -469,12 +475,12 @@
 
       // Trekendshi siper me 15 topa (8-shi ne qender rreshti 3)
       var cx = TABLE_W/2;
-      var cy = BORDER_TOP + BALL_R*2.2;
+      var cy = HEAD_Y;
       var rowGap = BALL_R*1.95;
       var colGap = BALL_R*2.1;
 
-      // Lista e numrave te tjere (pa 8) – do perdoren gradualisht
-      var pool = []; for (i=1;i<=15;i++){ if(i!==8) pool.push(i); }
+      // Lista e numrave te tjere – do perdoren gradualisht
+      var pool = []; for (i=1;i<=15;i++){ if(i!==1 && i!==2 && i!==8 && i!==11) pool.push(i); }
       var cursor = 0;
 
       // 5 rreshta (1..5) — ne total 15 topa
@@ -486,6 +492,7 @@
           var num;
           if (r===0 && j===0) num = 1;            // yellow ne maje
           else if (r===2 && j===1) num = 8;       // qendra e rreshtit 3
+          else if (r===4 && j===0) num = 2;       // qoshe solid
           else if (r===4 && j===4) num = 11;      // qoshe stripe
           else num = pool[cursor++];
           var info = BALL_BY_N[num];
@@ -719,6 +726,7 @@
     var spinVec = { x:0, y:0 };// spini i zgjedhur
     var power = 0;             // fuqi [0..1]
     var cueBallFree = true;    // a mund te vendoset cueball
+    var draggingCue = false;
     var shotInProgress = false;
     var currentShooter = 1;
     var pocketedAny = false;
@@ -726,22 +734,55 @@
     var scratch = false;
     var assignedTypes = {1:null,2:null};
 
+    function createMiniBall(n){
+      var info = BALL_BY_N[n];
+      var canv = document.createElement('canvas');
+      canv.className = 'ball';
+      canv.width = 20; canv.height = 20;
+      var ctx = canv.getContext('2d');
+      var r = 8, cx = 10, cy = 10;
+      ctx.fillStyle = info.c;
+      ctx.beginPath(); ctx.arc(cx, cy, r, 0, Math.PI*2); ctx.fill();
+      var hl = ctx.createRadialGradient(cx-r*0.4, cy-r*0.4, 2, cx-r*0.4, cy-r*0.4, r*1.2);
+      hl.addColorStop(0,'rgba(255,255,255,.55)'); hl.addColorStop(1,'rgba(255,255,255,0)');
+      ctx.fillStyle = hl; ctx.beginPath(); ctx.arc(cx, cy, r, 0, Math.PI*2); ctx.fill();
+      if (info.t === 'stripe') {
+        ctx.save(); ctx.beginPath(); ctx.arc(cx,cy,r,0,Math.PI*2); ctx.clip();
+        ctx.fillStyle = '#fff'; ctx.fillRect(cx-r, cy-r*0.3, r*2, r*0.6); ctx.restore();
+      }
+      if (n !== 0) {
+        ctx.fillStyle = (info.t==='stripe') ? info.c : '#fff';
+        ctx.beginPath(); ctx.arc(cx, cy, r*0.52, 0, Math.PI*2); ctx.fill();
+        ctx.fillStyle = (info.t==='stripe') ? '#fff' : '#111';
+        ctx.font = '8px system-ui,sans-serif';
+        ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+        ctx.fillText(String(n), cx, cy);
+      }
+      return canv;
+    }
+
     function updateCapturedUI(){
       function render(el, arr){
         el.innerHTML = '';
         arr.forEach(function(n){
-          var b = BALL_BY_N[n];
-          var d = document.createElement('div');
-          d.className = 'ball';
-          d.style.background = b.c;
-          d.textContent = n;
-          el.appendChild(d);
+          el.appendChild(createMiniBall(n));
         });
       }
       render(pottedP1, table.captured[1]);
       render(pottedP2, table.captured[2]);
       capP1.textContent = 'Guret e marra (P1): ' + (table.captured[1].join(', ') || '—');
       capP2.textContent = 'Guret e marra (CPU): ' + (table.captured[2].join(', ') || '—');
+    }
+
+    function updateCueHint(){
+      var cue = table.balls[0];
+      if (cueBallFree && cue && !cue.pocketed) {
+        cueHint.style.display = 'block';
+        cueHint.style.left = (cue.p.x*sX + ballR) + 'px';
+        cueHint.style.top  = (cue.p.y*sY - ballR*2) + 'px';
+      } else {
+        cueHint.style.display = 'none';
+      }
     }
 
     function endShot(){
@@ -763,6 +804,7 @@
         table.update(Math.min(dt, 0.033));
         table.render();
         updateCapturedUI();
+        updateCueHint();
         if (shotInProgress && !table.isMoving()) endShot();
         if (!table.isMoving() && table.turn===2 && !shotInProgress) setTimeout(cpuTurn, 400);
       }
@@ -782,24 +824,32 @@
       if (!table.running || table.isMoving()) return;
       var t = screenToTable(e.clientX,e.clientY);
       var cue = table.balls[0];
-      if (cueBallFree) {
-        var dist = Math.hypot(t.x - cue.p.x, t.y - cue.p.y);
-        if (dist > BALL_R*2) {
-          var minX = BORDER + BALL_R, maxX = TABLE_W - BORDER - BALL_R;
-          var minY = HEAD_Y + BALL_R, maxY = TABLE_H - BORDER_BOTTOM - BALL_R;
-          cue.p.x = clamp(t.x, minX, maxX);
-          cue.p.y = clamp(t.y, minY, maxY);
-          return;
-        }
+      var dist = Math.hypot(t.x - cue.p.x, t.y - cue.p.y);
+      if (cueBallFree && dist <= BALL_R*1.5) {
+        draggingCue = true;
+        return;
       }
+      if (cueBallFree) return;
       aiming = true; showGuides = true; table.aim = t; placeAimGlow(t);
     });
 
     canvas.addEventListener('pointermove', function(e){
-      if (!aiming || !table.running) return; var t = screenToTable(e.clientX,e.clientY); table.aim = t; placeAimGlow(t);
+      var t = screenToTable(e.clientX,e.clientY);
+      var cue = table.balls[0];
+      if (draggingCue && cueBallFree) {
+        var minX = BORDER + BALL_R, maxX = TABLE_W - BORDER - BALL_R;
+        var minY = HEAD_Y + BALL_R, maxY = TABLE_H - BORDER_BOTTOM - BALL_R;
+        cue.p.x = clamp(t.x, minX, maxX);
+        cue.p.y = clamp(t.y, minY, maxY);
+        return;
+      }
+      if (!aiming || !table.running) return; table.aim = t; placeAimGlow(t);
     });
 
-    canvas.addEventListener('pointerup', function(){ aiming = false; });
+    canvas.addEventListener('pointerup', function(){
+      if (draggingCue) { draggingCue = false; return; }
+      aiming = false;
+    });
 
     function placeAimGlow(){ /* shadow removed */ }
 
@@ -860,13 +910,13 @@
       if (!table.running || table.isMoving()) return;
       var cue = table.balls[0]; if (!cue || cue.pocketed) return;
       var d = norm(table.aim.x-cue.p.x, table.aim.y-cue.p.y);
-      var base = 950*3; // force tripled
+      var base = 950*3*1.5; // force increased 150%
       currentShooter = table.turn;
       shotInProgress = true;
       pocketedAny = false; pocketedOwn = false; scratch = false;
-      cue.v.x = d.x*base*(0.25+0.75*p)+spinVec.x*260*2*p;
-      cue.v.y = d.y*base*(0.25+0.75*p)+spinVec.y*260*2*p;
-      cue.spin = { x:spinVec.x*5*p, y:spinVec.y*5*p };
+      cue.v.x = d.x*base*(0.25+0.75*p)+spinVec.x*260*4*p;
+      cue.v.y = d.y*base*(0.25+0.75*p)+spinVec.y*260*4*p;
+      cue.spin = { x:spinVec.x*10*p, y:spinVec.y*10*p };
       cueBallFree = false;
       setSpin(0,0); showGuides=false;
     }


### PR DESCRIPTION
## Summary
- Shift table canvas upward so playfield sits higher without moving background
- Place rack and foot-spot correctly and balance corner balls
- Increase shot power and spin effects; add draggable cue ball with hand indicator
- Render pocketed balls with mini canvases matching table style

## Testing
- `npm test` *(fails: test timed out after 20000ms for snake API endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_68a411e2835c8329935df7e871659ca5