### PR TITLE
Expose public game transactions

### DIFF
--- a/webapp/src/components/GameTransactionsCard.jsx
+++ b/webapp/src/components/GameTransactionsCard.jsx
@@ -1,15 +1,11 @@
 import { useEffect, useState } from 'react';
-import { getAccountTransactions } from '../utils/api.js';
-
-const GAME_ACCOUNT =
-  import.meta.env.VITE_GAME_ACCOUNT_ID || import.meta.env.VITE_DEV_ACCOUNT_ID;
+import { getGameTransactions } from '../utils/api.js';
 
 export default function GameTransactionsCard() {
   const [transactions, setTransactions] = useState([]);
 
   useEffect(() => {
-    if (!GAME_ACCOUNT) return;
-    getAccountTransactions(GAME_ACCOUNT)
+    getGameTransactions()
       .then((res) => setTransactions(res.transactions || []))
       .catch(() => setTransactions([]));
   }, []);
@@ -28,12 +24,7 @@ export default function GameTransactionsCard() {
   return (
     <section className="relative bg-surface border border-border rounded-xl p-4 shadow-lg overflow-hidden wide-card">
       <h3 className="text-lg font-semibold text-center">Games Transactions</h3>
-      {GAME_ACCOUNT ? (
-        <Content />
-      ) : (
-        <p className="mt-2 text-sm text-center">Game account is not configured.</p>
-      )}
+      <Content />
     </section>
   );
 }
-

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -106,27 +106,19 @@ async function get(path, token) {
 }
 
 export function getMiningStatus(telegramId) {
-
   return post('/api/mining/status', { telegramId });
-
 }
 
 export function startMining(telegramId) {
-
   return post('/api/mining/start', { telegramId });
-
 }
 
 export function stopMining(telegramId) {
-
   return post('/api/mining/stop', { telegramId });
-
 }
 
 export function claimMining(telegramId) {
-
   return post('/api/mining/claim', { telegramId });
-
 }
 
 export function getLeaderboard(id) {
@@ -134,19 +126,15 @@ export function getLeaderboard(id) {
   if (typeof id === 'object') body = id;
   else if (typeof id === 'string' && id.includes('-')) body = { accountId: id };
   else body = { telegramId: id };
-  return post("/api/mining/leaderboard", body);
+  return post('/api/mining/leaderboard', body);
 }
 
 export function listTasks(telegramId) {
-
   return post('/api/tasks/list', { telegramId });
-
 }
 
 export function completeTask(telegramId, taskId) {
-
   return post('/api/tasks/complete', { telegramId, taskId });
-
 }
 
 export function verifyPost(telegramId, tweetUrl) {
@@ -154,7 +142,11 @@ export function verifyPost(telegramId, tweetUrl) {
 }
 
 export function verifyTelegramReaction(telegramId, messageId, threadId) {
-  return post('/api/tasks/verify-telegram-reaction', { telegramId, messageId, threadId });
+  return post('/api/tasks/verify-telegram-reaction', {
+    telegramId,
+    messageId,
+    threadId
+  });
 }
 
 export function adminListTasks() {
@@ -182,15 +174,11 @@ export function adminDeleteTask(id) {
 }
 
 export function listVideos(telegramId) {
-
   return post('/api/watch/list', { telegramId });
-
 }
 
 export function watchVideo(telegramId, videoId) {
-
   return post('/api/watch/watch', { telegramId, videoId });
-
 }
 
 export function getAdStatus(telegramId) {
@@ -244,28 +232,22 @@ export function verifyInfluencer(id, status, views) {
 }
 
 export function getProfile(telegramId) {
-
   return post('/api/profile/get', { telegramId });
-
 }
 
 export function updateProfile(data) {
-
   return post('/api/profile/update', data);
-
 }
 
 export function updateBalance(telegramId, balance) {
-
   return post('/api/profile/updateBalance', { telegramId, balance });
-
 }
 
 export function addTransaction(telegramId, amount, type, extra = {}) {
   const body = {
     amount,
     type,
-    ...extra,
+    ...extra
   };
   if (telegramId != null) body.telegramId = telegramId;
   return post('/api/profile/addTransaction', body);
@@ -276,21 +258,15 @@ export function getProfileByAccount(accountId) {
 }
 
 export function linkSocial(data) {
-
   return post('/api/profile/link-social', data);
-
 }
 
 export function fetchTelegramInfo(telegramId) {
-
   return post('/api/profile/telegram-info', { telegramId });
-
 }
 
 export function getWalletBalance(telegramId) {
-
   return post('/api/wallet/balance', { telegramId });
-
 }
 
 export function getTonBalance(address) {
@@ -301,16 +277,13 @@ export function getUsdtBalance(address) {
   return post('/api/wallet/usdt-balance', { address });
 }
 export function sendTpc(fromId, toId, amount, note) {
-
   const body = { fromId, toId, amount };
   if (note) body.note = note;
-  return post("/api/wallet/send", body);
+  return post('/api/wallet/send', body);
 }
 
 export function getTransactions(telegramId) {
-
   return post('/api/wallet/transactions', { telegramId });
-
 }
 
 export function getDepositAddress() {
@@ -330,31 +303,23 @@ export function claimExternal(telegramId, address, amount) {
 }
 
 export function getReferralInfo(telegramId) {
-
   return post('/api/referral/code', { telegramId });
-
 }
 
 export function claimReferral(telegramId, code) {
-
   return post('/api/referral/claim', { telegramId, code });
-
 }
 
 // ✅ Daily check-in (user-facing)
 
 export function dailyCheckIn(telegramId) {
-
   return post('/api/checkin/check-in', { telegramId });
-
 }
 
 // ✅ Admin-only airdrop grant
 
 export function grantAirdrop(token, telegramId, amount, reason = '') {
-
   return post('/api/airdrop/grant', { telegramId, amount, reason }, token);
-
 }
 
 export function grantAirdropAll(token, amount, reason = '') {
@@ -430,7 +395,11 @@ export function sendMessage(fromId, toId, text) {
 }
 
 export function sendGift(fromId, toId, gift) {
-  return post('/api/account/gift', { fromAccount: fromId, toAccount: toId, gift });
+  return post('/api/account/gift', {
+    fromAccount: fromId,
+    toAccount: toId,
+    gift
+  });
 }
 
 export function convertGifts(accountId, giftIds, action = 'burn', toAccount) {
@@ -507,7 +476,6 @@ export function resetTpcWallet(telegramId) {
   return post('/api/wallet/reset', { telegramId });
 }
 
-
 export function registerWalletPasskey(telegramId, passkeyId, publicKey) {
   return post('/api/wallet/passkey', { telegramId, passkeyId, publicKey });
 }
@@ -536,6 +504,10 @@ export function sendAccountTpc(fromAccount, toAccount, amount, note) {
 
 export function getAccountTransactions(accountId) {
   return post('/api/account/transactions', { accountId });
+}
+
+export function getGameTransactions() {
+  return get('/api/account/transactions/public');
 }
 
 export function depositAccount(accountId, amount, extra = {}) {


### PR DESCRIPTION
## Summary
- add public endpoint for game-related transactions
- show public game transactions in games page without requiring account ID

## Testing
- `npm test` *(fails: snake API endpoints and socket events timed out)*
- `npm run lint` *(fails: numerous errors in lib/texasHoldem.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a40f8a218c83299a2f534a11ae74b2