### PR TITLE
feat: add game transaction overview

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -21,6 +21,7 @@ import CrazyDiceDuel from './pages/Games/CrazyDiceDuel.jsx';
 import CrazyDiceLobby from './pages/Games/CrazyDiceLobby.jsx';
 import Lobby from './pages/Games/Lobby.jsx';
 import Games from './pages/Games.jsx';
+import GameTransactions from './pages/GameTransactions.jsx';
 import SpinPage from './pages/spin.tsx';
 import FallingBall from './pages/Games/FallingBall.jsx';
 import FallingBallLobby from './pages/Games/FallingBallLobby.jsx';
@@ -61,6 +62,7 @@ export default function App() {
             <Route path="/" element={<Home />} />
             <Route path="/mining" element={<Mining />} />
             <Route path="/games" element={<Games />} />
+            <Route path="/games/transactions" element={<GameTransactions />} />
             <Route path="/games/crazydice" element={<CrazyDiceDuel />} />
             <Route path="/games/crazydice/lobby" element={<CrazyDiceLobby />} />
             <Route path="/games/:game/lobby" element={<Lobby />} />

--- a/webapp/src/components/GameTransactionsCard.jsx
+++ b/webapp/src/components/GameTransactionsCard.jsx
@@ -1,30 +1,49 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { getGameTransactions } from '../utils/api.js';
 
 export default function GameTransactionsCard() {
   const [transactions, setTransactions] = useState([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     getGameTransactions()
       .then((res) => setTransactions(res.transactions || []))
       .catch(() => setTransactions([]));
   }, []);
-  const Content = () => (
-    <ul className="mt-2 space-y-1 max-h-64 overflow-y-auto text-sm">
-      {transactions.length === 0 && <li>No transactions yet.</li>}
-      {transactions.map((t, i) => (
-        <li key={i} className="flex justify-between">
-          <span className="capitalize">{t.type}</span>
-          <span>{t.amount}</span>
-        </li>
-      ))}
-    </ul>
-  );
+
+  const games = transactions.filter((t) => t.game);
+  const totalGames = games.length;
+  const totalDeposited = games
+    .filter((t) => t.type === 'deposit')
+    .reduce((s, t) => s + Math.abs(t.amount || 0), 0);
+  const totalPayouts = games
+    .filter((t) => t.type === 'payout')
+    .reduce((s, t) => s + Math.abs(t.amount || 0), 0);
+
+  const formatValue = (v) =>
+    v.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 2 });
 
   return (
-    <section className="relative bg-surface border border-border rounded-xl p-4 shadow-lg overflow-hidden wide-card">
+    <section
+      className="relative bg-surface border border-border rounded-xl p-4 shadow-lg overflow-hidden wide-card cursor-pointer"
+      onClick={() => navigate('/games/transactions')}
+    >
       <h3 className="text-lg font-semibold text-center">Games Transactions</h3>
-      <Content />
+      <div className="mt-2 space-y-1 text-sm">
+        <div className="flex justify-between">
+          <span>Total games played</span>
+          <span>{totalGames}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Total payouts</span>
+          <span>{formatValue(totalPayouts)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Total deposited</span>
+          <span>{formatValue(totalDeposited)}</span>
+        </div>
+      </div>
     </section>
   );
 }

--- a/webapp/src/pages/GameTransactions.jsx
+++ b/webapp/src/pages/GameTransactions.jsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
+import { getGameTransactions } from '../utils/api.js';
+
+export default function GameTransactions() {
+  useTelegramBackButton();
+  const [transactions, setTransactions] = useState([]);
+
+  useEffect(() => {
+    getGameTransactions()
+      .then((res) => setTransactions(res.transactions || []))
+      .catch(() => setTransactions([]));
+  }, []);
+
+  const formatValue = (v) =>
+    Number(v).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+  return (
+    <div className="relative space-y-4 text-text">
+      <h2 className="text-2xl font-bold text-center mt-4">Game Transactions</h2>
+      <div className="space-y-1 text-sm max-h-[40rem] overflow-y-auto border border-border rounded">
+        {transactions.length === 0 && <div className="p-2">No transactions yet.</div>}
+        {transactions.map((tx, i) => (
+          <div key={i} className="lobby-tile w-full flex justify-between items-center">
+            <div>
+              <div className="capitalize">{tx.type}</div>
+              <div className="text-xs text-subtext">
+                {tx.fromName || tx.fromAccount} → {tx.toName || tx.toAccount}
+              </div>
+            </div>
+            <div className="text-right">
+              <div className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
+                {tx.amount > 0 ? '+' : ''}
+                {formatValue(tx.amount)} {(tx.token || 'TPC').toUpperCase()}
+              </div>
+              <div className="text-xs">
+                {tx.date ? new Date(tx.date).toLocaleString(undefined, { hour12: false }) : ''}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add summary card with game totals and navigation
- add game transaction listing page
- wire new page into router

## Testing
- `npm test` *(fails: The "options.agent" property must be one of Agent-like Object, undefined, or false. Received an instance of ProxyAgent)*
- `npm run lint` *(fails: 473 problems (473 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a41a84ae508329a761a916099d597a