### PR TITLE
Enhance game transaction details

### DIFF
--- a/webapp/src/components/GameTransactionsCard.jsx
+++ b/webapp/src/components/GameTransactionsCard.jsx
@@ -15,10 +15,10 @@ export default function GameTransactionsCard() {
   const games = transactions.filter((t) => t.game);
   const totalGames = games.length;
   const totalDeposited = games
-    .filter((t) => t.type === 'deposit')
+    .filter((t) => t.amount < 0)
     .reduce((s, t) => s + Math.abs(t.amount || 0), 0);
   const totalPayouts = games
-    .filter((t) => t.type === 'payout')
+    .filter((t) => t.amount > 0)
     .reduce((s, t) => s + Math.abs(t.amount || 0), 0);
 
   const formatValue = (v) =>
@@ -44,6 +44,7 @@ export default function GameTransactionsCard() {
           <span>{formatValue(totalDeposited)}</span>
         </div>
       </div>
+      <div className="mt-2 text-xs text-center text-subtext">More Details</div>
     </section>
   );
 }

--- a/webapp/src/pages/GameTransactions.jsx
+++ b/webapp/src/pages/GameTransactions.jsx
@@ -1,6 +1,25 @@
 import { useEffect, useState } from 'react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { getGameTransactions } from '../utils/api.js';
+import { getAvatarUrl } from '../utils/avatarUtils.js';
+
+const GAME_NAME_MAP = {
+  snake: 'Snake & Ladder',
+  crazydice: 'Crazy Dice Duel',
+  tetris: 'Tetris Royale',
+  goalrush: 'Goal Rush',
+  bubblepop: 'Bubble Pop Royale',
+  bubblesmash: 'Bubble Smash Royale',
+  fruitslice: 'Fruit Slice Royale',
+  brickbreaker: 'Brick Breaker Royale',
+  fallingball: 'Falling Ball',
+  poll: '8 Poll Royale',
+};
+
+function getGameName(slug = '') {
+  const entry = Object.entries(GAME_NAME_MAP).find(([key]) => slug?.startsWith(key));
+  return entry ? entry[1] : slug;
+}
 
 export default function GameTransactions() {
   useTelegramBackButton();
@@ -20,25 +39,39 @@ export default function GameTransactions() {
       <h2 className="text-2xl font-bold text-center mt-4">Game Transactions</h2>
       <div className="space-y-1 text-sm max-h-[40rem] overflow-y-auto border border-border rounded">
         {transactions.length === 0 && <div className="p-2">No transactions yet.</div>}
-        {transactions.map((tx, i) => (
-          <div key={i} className="lobby-tile w-full flex justify-between items-center">
-            <div>
-              <div className="capitalize">{tx.type}</div>
-              <div className="text-xs text-subtext">
-                {tx.fromName || tx.fromAccount} → {tx.toName || tx.toAccount}
+        {transactions.map((tx, i) => {
+          const avatarSrc = tx.fromPhoto || tx.fromAvatar || tx.photo || '';
+          const avatarUrl = avatarSrc ? getAvatarUrl(avatarSrc) : '/assets/icons/profile.svg';
+          const gameName = getGameName(tx.game);
+          const token = (tx.token || 'TPC').toUpperCase();
+          const iconMap = {
+            TPC: '/assets/icons/ezgif-54c96d8a9b9236.webp',
+            TON: '/assets/icons/TON.webp',
+            USDT: '/assets/icons/Usdt.webp',
+          };
+          const icon = iconMap[token] || `/assets/icons/${token}.webp`;
+          return (
+            <div key={i} className="lobby-tile w-full flex justify-between items-center">
+              <div className="flex items-center space-x-2">
+                <img src={avatarUrl} alt="avatar" className="w-8 h-8 rounded-full" />
+                <div>
+                  <div className="font-semibold">{tx.fromName || tx.fromAccount}</div>
+                  {gameName && <div className="text-xs text-subtext">{gameName}</div>}
+                </div>
+              </div>
+              <div className="text-right">
+                <div className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
+                  {tx.amount > 0 ? '+' : ''}
+                  {formatValue(tx.amount)}
+                  <img src={icon} alt={token} className="inline w-4 h-4 ml-1" />
+                </div>
+                <div className="text-xs">
+                  {tx.date ? new Date(tx.date).toLocaleString(undefined, { hour12: false }) : ''}
+                </div>
               </div>
             </div>
-            <div className="text-right">
-              <div className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
-                {tx.amount > 0 ? '+' : ''}
-                {formatValue(tx.amount)} {(tx.token || 'TPC').toUpperCase()}
-              </div>
-              <div className="text-xs">
-                {tx.date ? new Date(tx.date).toLocaleString(undefined, { hour12: false }) : ''}
-              </div>
-            </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- compute total deposits and payouts based on transaction amounts and show "More Details" hint
- enrich game transactions list with player avatars, game names and token icons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a424a04bf48329afa9511686838d6c