### PR TITLE
feat: add mining transactions overview

### DIFF
--- a/bot/routes/mining.js
+++ b/bot/routes/mining.js
@@ -98,4 +98,34 @@ router.post('/leaderboard', async (req, res) => {
   res.json({ users, rank });
 });
 
+router.get('/transactions', async (req, res) => {
+  const limitParam = Number(req.query.limit) || 100;
+  const limit = Math.min(Math.max(limitParam, 1), 1000);
+  const transactions = await User.aggregate([
+    { $unwind: '$transactions' },
+    {
+      $match: {
+        'transactions.type': { $in: ['daily', 'spin', 'lucky', 'task'] },
+        'transactions.amount': { $gt: 0 }
+      }
+    },
+    {
+      $project: {
+        _id: 0,
+        accountId: '$accountId',
+        amount: '$transactions.amount',
+        type: '$transactions.type',
+        date: '$transactions.date',
+        token: { $ifNull: ['$transactions.token', 'TPC'] },
+        fromAccount: '$accountId',
+        fromName: { $ifNull: ['$nickname', '$firstName'] },
+        fromPhoto: '$photo'
+      }
+    },
+    { $sort: { date: -1 } },
+    { $limit: limit }
+  ]);
+  res.json({ transactions });
+});
+
 export default router;

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -22,6 +22,7 @@ import CrazyDiceLobby from './pages/Games/CrazyDiceLobby.jsx';
 import Lobby from './pages/Games/Lobby.jsx';
 import Games from './pages/Games.jsx';
 import GameTransactions from './pages/GameTransactions.jsx';
+import MiningTransactions from './pages/MiningTransactions.jsx';
 import SpinPage from './pages/spin.tsx';
 import FallingBall from './pages/Games/FallingBall.jsx';
 import FallingBallLobby from './pages/Games/FallingBallLobby.jsx';
@@ -61,6 +62,7 @@ export default function App() {
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/mining" element={<Mining />} />
+            <Route path="/mining/transactions" element={<MiningTransactions />} />
             <Route path="/games" element={<Games />} />
             <Route path="/games/transactions" element={<GameTransactions />} />
             <Route path="/games/crazydice" element={<CrazyDiceDuel />} />

--- a/webapp/src/components/MiningTransactionsCard.jsx
+++ b/webapp/src/components/MiningTransactionsCard.jsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getMiningTransactions } from '../utils/api.js';
+
+export default function MiningTransactionsCard() {
+  const [transactions, setTransactions] = useState([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    getMiningTransactions(1000)
+      .then((res) => setTransactions(res.transactions || []))
+      .catch(() => setTransactions([]));
+  }, []);
+
+  const totalPayouts = transactions.reduce((s, t) => s + Math.abs(t.amount || 0), 0);
+  const dailyPayouts = transactions
+    .filter((t) => t.type === 'daily')
+    .reduce((s, t) => s + Math.abs(t.amount || 0), 0);
+  const spinPayouts = transactions
+    .filter((t) => t.type === 'spin' || t.type === 'lucky')
+    .reduce((s, t) => s + Math.abs(t.amount || 0), 0);
+  const taskPayouts = transactions
+    .filter((t) => t.type === 'task')
+    .reduce((s, t) => s + Math.abs(t.amount || 0), 0);
+
+  const formatValue = (v) =>
+    v.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 2 });
+
+  return (
+    <section
+      className="relative bg-surface border border-border rounded-xl p-4 shadow-lg overflow-hidden wide-card cursor-pointer"
+      onClick={() => navigate('/mining/transactions')}
+    >
+      <h3 className="text-lg font-semibold text-center">Mining Transactions</h3>
+      <div className="mt-2 space-y-1 text-sm">
+        <div className="flex justify-between">
+          <span>Total payouts</span>
+          <span>{formatValue(totalPayouts)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Daily streaks</span>
+          <span>{formatValue(dailyPayouts)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Spin &amp; Win</span>
+          <span>{formatValue(spinPayouts)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Tasks</span>
+          <span>{formatValue(taskPayouts)}</span>
+        </div>
+      </div>
+      <div className="mt-2 text-xs text-center text-subtext">More Details</div>
+    </section>
+  );
+}

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -8,6 +8,7 @@ import DailyCheckIn from '../components/DailyCheckIn.jsx';
 import SpinGame from '../components/SpinGame.jsx';
 import MiningCard from '../components/MiningCard.tsx';
 import LuckyNumber from '../components/LuckyNumber.jsx';
+import MiningTransactionsCard from '../components/MiningTransactionsCard.jsx';
 import {
   getLeaderboard,
   getReferralInfo,
@@ -135,6 +136,7 @@ export default function Mining() {
     <SpinGame />
     <LuckyNumber />
     <MiningCard />
+    <MiningTransactionsCard />
 
       <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-text overflow-hidden wide-card">
       <img

--- a/webapp/src/pages/MiningTransactions.jsx
+++ b/webapp/src/pages/MiningTransactions.jsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
+import { getMiningTransactions } from '../utils/api.js';
+import { getAvatarUrl } from '../utils/avatarUtils.js';
+
+const TYPE_NAME_MAP = {
+  daily: 'Daily Streak',
+  spin: 'Spin & Win',
+  lucky: 'Lucky Card',
+  task: 'Task'
+};
+
+export default function MiningTransactions() {
+  useTelegramBackButton();
+  const [transactions, setTransactions] = useState([]);
+
+  useEffect(() => {
+    getMiningTransactions(1000)
+      .then((res) => setTransactions(res.transactions || []))
+      .catch(() => setTransactions([]));
+  }, []);
+
+  const formatValue = (v) =>
+    Number(v).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+  const totalPayouts = transactions.reduce((s, t) => s + Math.abs(t.amount || 0), 0);
+  const dailyPayouts = transactions
+    .filter((t) => t.type === 'daily')
+    .reduce((s, t) => s + Math.abs(t.amount || 0), 0);
+  const spinPayouts = transactions
+    .filter((t) => t.type === 'spin' || t.type === 'lucky')
+    .reduce((s, t) => s + Math.abs(t.amount || 0), 0);
+  const taskPayouts = transactions
+    .filter((t) => t.type === 'task')
+    .reduce((s, t) => s + Math.abs(t.amount || 0), 0);
+
+  return (
+    <div className="relative space-y-4 text-text">
+      <h2 className="text-2xl font-bold text-center mt-4">Mining Transactions</h2>
+      <div className="bg-surface border border-border rounded-xl p-4 shadow-lg space-y-1 text-sm">
+        <div className="flex justify-between">
+          <span>Total payouts</span>
+          <span>{formatValue(totalPayouts)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Daily streaks</span>
+          <span>{formatValue(dailyPayouts)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Spin &amp; Win</span>
+          <span>{formatValue(spinPayouts)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Tasks</span>
+          <span>{formatValue(taskPayouts)}</span>
+        </div>
+      </div>
+      <div className="space-y-1 text-sm max-h-[40rem] overflow-y-auto border border-border rounded">
+        {transactions.length === 0 && <div className="p-2">No transactions yet.</div>}
+        {transactions.map((tx, i) => {
+          const avatarSrc = tx.fromPhoto || tx.photo || '';
+          const avatarUrl = avatarSrc ? getAvatarUrl(avatarSrc) : '/assets/icons/profile.svg';
+          const category = TYPE_NAME_MAP[tx.type] || tx.type;
+          const token = (tx.token || 'TPC').toUpperCase();
+          const iconMap = {
+            TPC: '/assets/icons/ezgif-54c96d8a9b9236.webp',
+            TON: '/assets/icons/TON.webp',
+            USDT: '/assets/icons/Usdt.webp'
+          };
+          const icon = iconMap[token] || `/assets/icons/${token}.webp`;
+          return (
+            <div key={i} className="lobby-tile w-full flex justify-between items-center">
+              <div className="flex items-center space-x-2">
+                <img src={avatarUrl} alt="avatar" className="w-8 h-8 rounded-full" />
+                <div>
+                  <div className="font-semibold">{tx.fromName || tx.accountId}</div>
+                  {category && <div className="text-xs text-subtext">{category}</div>}
+                </div>
+              </div>
+              <div className="text-right">
+                <div className="text-green-500">
+                  +{formatValue(tx.amount)}
+                  <img src={icon} alt={token} className="inline w-4 h-4 ml-1" />
+                </div>
+                <div className="text-xs">
+                  {tx.date ? new Date(tx.date).toLocaleString(undefined, { hour12: false }) : ''}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -510,6 +510,10 @@ export function getGameTransactions(limit = 1000) {
   return get(`/api/account/transactions/public?limit=${limit}`);
 }
 
+export function getMiningTransactions(limit = 1000) {
+  return get(`/api/mining/transactions?limit=${limit}`);
+}
+
 export function depositAccount(accountId, amount, extra = {}) {
   return post(
     '/api/account/deposit',


### PR DESCRIPTION
## Summary
- expose public mining payout transactions via new API route
- show mining transaction summary card and detailed view
- wire mining transactions into app navigation

## Testing
- ❌ `npm test` (fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))
- ❌ `npm run lint` (473 errors)
- ⚠️ `npm --prefix webapp test` (missing script: test)
- ✅ `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_68a444923f5c83299c8ad211e97d7273