### PR TITLE
Calibrate Pool Royale table dynamically

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -300,17 +300,23 @@
     /* ==========================================================
        KONSTANTA TE LAYOUT-it DHE FIZIKES (sipas portrait)
        ========================================================= */
-    var TABLE_W = 768;      // gjeresi logjike e felt-it
-    var TABLE_H = 1216;     // lartesi logjike e felt-it
-    var BORDER  = 57;       // korniza e drurit pak me e ngushte anash
-    var POCKET_R = 42;      // rrezja baze e gropave
-    var BALL_R   = 23.5;    // rrezja baze e topave pak me e vogel
-    var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
-    var BORDER_BOTTOM = BORDER;           // anet e tjera mbeten te pandryshuara
-      // Move the rack slightly upward on the table
-      var SPOT_Y  = BORDER_TOP + (TABLE_H - BORDER_TOP - BORDER_BOTTOM) * 0.25 - BALL_R * 0.5; // pika per trekendshin siper
-    var LINE_Y  = BORDER_TOP + (TABLE_H - BORDER_TOP - BORDER_BOTTOM) * 0.75; // vija e bardhe poshte
-    var CUE_START_Y = LINE_Y + (TABLE_H - BORDER_BOTTOM - LINE_Y - BALL_R*2) / 2; // pozicioni fillestar i cueball-it
+    var BASE_W = 768;
+    var BASE_H = 1216;
+    var BASE_BORDER = 57;
+    var BASE_POCKET_R = 42;
+    var BASE_BALL_R = 23.5;
+    var BASE_BORDER_OFFSET = 4;
+
+    var TABLE_W = BASE_W;
+    var TABLE_H = BASE_H;
+    var BORDER  = BASE_BORDER;
+    var POCKET_R = BASE_POCKET_R;
+    var BALL_R   = BASE_BALL_R;
+    var BORDER_TOP = BORDER + BALL_R * 2 - BASE_BORDER_OFFSET;
+    var BORDER_BOTTOM = BORDER;
+    var SPOT_Y  = BORDER_TOP + (TABLE_H - BORDER_TOP - BORDER_BOTTOM) * 0.25 - BALL_R * 0.5;
+    var LINE_Y  = BORDER_TOP + (TABLE_H - BORDER_TOP - BORDER_BOTTOM) * 0.75;
+    var CUE_START_Y = LINE_Y + (TABLE_H - BORDER_BOTTOM - LINE_Y - BALL_R*2) / 2;
 
     var FRICTION = 0.985;   // ferkimi linear
     var BOUNCE   = 0.98;    // koeficienti i rikthimit
@@ -331,6 +337,25 @@
     var logoImg   = new Image();
     logoImg.src   = '/assets/icons/pool-royale.svg';
     var tableImg  = new Image();
+    tableImg.onload = function(){
+      TABLE_W = tableImg.naturalWidth;
+      TABLE_H = tableImg.naturalHeight;
+      var scaleX = TABLE_W / BASE_W;
+      var scaleY = TABLE_H / BASE_H;
+      var scale = (scaleX + scaleY) / 2;
+      BORDER = BASE_BORDER * scale;
+      POCKET_R = BASE_POCKET_R * scale;
+      BALL_R = BASE_BALL_R * scale;
+      BORDER_TOP = BORDER + BALL_R * 2 - BASE_BORDER_OFFSET * scale;
+      BORDER_BOTTOM = BORDER;
+      SPOT_Y  = BORDER_TOP + (TABLE_H - BORDER_TOP - BORDER_BOTTOM) * 0.25 - BALL_R * 0.5;
+      LINE_Y  = BORDER_TOP + (TABLE_H - BORDER_TOP - BORDER_BOTTOM) * 0.75;
+      CUE_START_Y = LINE_Y + (TABLE_H - BORDER_BOTTOM - LINE_Y - BALL_R*2) / 2;
+      resize();
+      table = new Table();
+      table.render();
+      requestAnimationFrame(loop);
+    };
     tableImg.src  = '/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp';
     var pullArea  = document.getElementById('pullArea');
     var powerKnob = document.getElementById('powerKnob');
@@ -719,8 +744,7 @@
     /* ==========================================================
        GJENDJE GLOBALE E LOJES
        ========================================================= */
-    var table = new Table();
-    tableImg.onload = function(){ table.render(); };
+    var table;
     var last = 0;              // koha e frame te fundit
     var aiming = false;        // a po caktohet drejtimi
     var showGuides = false;    // a shfaqen pikat
@@ -814,8 +838,6 @@
       }
       requestAnimationFrame(loop);
     }
-    requestAnimationFrame(loop);
-
     /* ==========================================================
        INPUT – Aiming & Glow
        ========================================================= */


### PR DESCRIPTION
## Summary
- derive table and pocket dimensions from the table image's natural size
- initialize the pool table only after image load so layout scales correctly

## Testing
- `npm test` *(fails: test timed out - test timed out after 20000ms)*
- `npm run lint` *(fails: 473 errors, e.g., lib/texasHoldem.js:4:26 comma-spacing)*

------
https://chatgpt.com/codex/tasks/task_e_68a449d25e9483298674fbadc7f8ddde