### PR TITLE
feat: add raise and check logic to holdem AI

### DIFF
--- a/lib/texasHoldem.js
+++ b/lib/texasHoldem.js
@@ -181,16 +181,29 @@ export function evaluateWinner(players, community){
   return winner;
 }
 
-export function aiChooseAction(hand, community=[]){
-  const stage=community.length; //0 preflop,3 flop,4 turn,5 river
-  const score=bestHand([...hand,...community]);
-  // very naive thresholds
-  if(stage<3){
-    // preflop
-    const hv=hand.map(c=>rankValue(c.rank)).sort((a,b)=>b-a);
-    if(hv[0]>=12 || hv[0]===hv[1]) return 'call';
+export function aiChooseAction (hand, community = [], toCall = 0) {
+  const stage = community.length; // 0 preflop,3 flop,4 turn,5 river
+
+  // Preflop heuristic based solely on hole cards
+  if (stage < 3) {
+    const hv = hand.map((c) => rankValue(c.rank)).sort((a, b) => b - a);
+    if (toCall > 0) {
+      if (hv[0] === hv[1] && hv[0] >= 11) return 'raise';
+      if (hv[0] >= 12 || hv[0] === hv[1]) return 'call';
+      return 'fold';
+    }
+    if (hv[0] === hv[1] && hv[0] >= 12) return 'raise';
+    if (hv[0] >= 11) return 'check';
     return 'fold';
   }
-  if(score.rank>=1) return 'call';
+
+  const score = bestHand([...hand, ...community]);
+  if (toCall > 0) {
+    if (score && score.rank >= 5) return 'raise'; // flush or better
+    if (score && score.rank >= 2) return 'call'; // at least two pair
+    return 'fold';
+  }
+  if (score && score.rank >= 4) return 'raise'; // straight or better
+  if (score && score.rank >= 1) return 'check';
   return 'fold';
 }

--- a/lib/texasHoldemGame.js
+++ b/lib/texasHoldemGame.js
@@ -9,7 +9,7 @@ export class TexasHoldemGame {
       startingChips = 100,
       blinds = { small: 5, big: 10 },
       deck = shuffle(createDeck()),
-      actions = [] // array of functions(hand, community) -> 'fold'|'call'
+      actions = [] // array of functions(hand, community, toCall) -> 'fold'|'call'|'check'|'raise'
     } = options
 
     this.deck = [...deck]
@@ -21,7 +21,8 @@ export class TexasHoldemGame {
       totalBet: 0,
       folded: false,
       allIn: false,
-      action: actions[i] || ((hand, community) => aiChooseAction(hand, community))
+      action:
+        actions[i] || ((hand, community, toCall) => aiChooseAction(hand, community, toCall))
     }))
     this.blinds = blinds
     this.pot = 0
@@ -60,10 +61,25 @@ export class TexasHoldemGame {
       const p = this.players[idx]
       if (!p.folded && !p.allIn) {
         const toCall = this.currentBet - p.bet
-        const act = p.action(p.hand, this.community)
+        const act = p.action(p.hand, this.community, toCall)
         if (act === 'fold') {
           p.folded = true
           playersToAct--
+        } else if (act === 'raise') {
+          const raiseTo = toCall + this.blinds.big
+          const amount = Math.min(raiseTo, p.chips)
+          p.chips -= amount
+          p.bet += amount
+          p.totalBet += amount
+          this.pot += amount
+          if (p.chips === 0) {
+            p.allIn = true
+            playersToAct--
+          }
+          this.currentBet = p.bet
+          calls = 1
+        } else if (act === 'check' && toCall === 0) {
+          calls++
         } else {
           const amount = Math.min(toCall, p.chips)
           p.chips -= amount

--- a/test/texasHoldemAICore.test.js
+++ b/test/texasHoldemAICore.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { aiChooseAction } from '../lib/texasHoldem.js'
+
+test('ai does not check when facing a bet', () => {
+  const hand = [
+    { rank: '2', suit: 'H' },
+    { rank: '7', suit: 'D' }
+  ]
+  const action = aiChooseAction(hand, [], 5)
+  assert.notEqual(action, 'check')
+})
+
+test('ai raises with strong pocket pair', () => {
+  const hand = [
+    { rank: 'A', suit: 'S' },
+    { rank: 'A', suit: 'H' }
+  ]
+  const action = aiChooseAction(hand, [], 5)
+  assert.equal(action, 'raise')
+})

--- a/test/texasHoldemGame.test.js
+++ b/test/texasHoldemGame.test.js
@@ -27,3 +27,14 @@ test('simulates a full hand and awards pot to best player', () => {
   assert.equal(game.players[0].chips, 110);
   assert.equal(game.players[1].chips, 90);
 });
+
+test('bettingRound handles raises correctly', () => {
+  const game = new TexasHoldemGame(2, { actions: [() => 'raise', () => 'call'] });
+  game.postBlinds();
+  game.bettingRound(0);
+  assert.equal(game.pot, 40);
+  assert.equal(game.players[0].chips, 80);
+  assert.equal(game.players[1].chips, 80);
+  assert.equal(game.players[0].totalBet, 20);
+  assert.equal(game.players[1].totalBet, 20);
+});

--- a/webapp/public/lib/texasHoldem.js
+++ b/webapp/public/lib/texasHoldem.js
@@ -181,16 +181,28 @@ export function evaluateWinner(players, community){
   return winner;
 }
 
-export function aiChooseAction(hand, community=[]){
-  const stage=community.length; //0 preflop,3 flop,4 turn,5 river
-  const score=bestHand([...hand,...community]);
-  // very naive thresholds
-  if(stage<3){
-    // preflop
-    const hv=hand.map(c=>rankValue(c.rank)).sort((a,b)=>b-a);
-    if(hv[0]>=12 || hv[0]===hv[1]) return 'call';
+export function aiChooseAction (hand, community = [], toCall = 0) {
+  const stage = community.length; //0 preflop,3 flop,4 turn,5 river
+
+  if (stage < 3) {
+    const hv = hand.map((c) => rankValue(c.rank)).sort((a, b) => b - a);
+    if (toCall > 0) {
+      if (hv[0] === hv[1] && hv[0] >= 11) return 'raise';
+      if (hv[0] >= 12 || hv[0] === hv[1]) return 'call';
+      return 'fold';
+    }
+    if (hv[0] === hv[1] && hv[0] >= 12) return 'raise';
+    if (hv[0] >= 11) return 'check';
     return 'fold';
   }
-  if(score.rank>=1) return 'call';
+
+  const score = bestHand([...hand, ...community]);
+  if (toCall > 0) {
+    if (score && score.rank >= 5) return 'raise';
+    if (score && score.rank >= 2) return 'call';
+    return 'fold';
+  }
+  if (score && score.rank >= 4) return 'raise';
+  if (score && score.rank >= 1) return 'check';
   return 'fold';
 }

--- a/webapp/public/lib/texasHoldemGame.js
+++ b/webapp/public/lib/texasHoldemGame.js
@@ -9,7 +9,7 @@ export class TexasHoldemGame {
       startingChips = 100,
       blinds = { small: 5, big: 10 },
       deck = shuffle(createDeck()),
-      actions = [] // array of functions(hand, community) -> 'fold'|'call'
+      actions = [] // array of functions(hand, community, toCall) -> 'fold'|'call'|'check'|'raise'
     } = options
 
     this.deck = [...deck]
@@ -21,7 +21,8 @@ export class TexasHoldemGame {
       totalBet: 0,
       folded: false,
       allIn: false,
-      action: actions[i] || ((hand, community) => aiChooseAction(hand, community))
+      action:
+        actions[i] || ((hand, community, toCall) => aiChooseAction(hand, community, toCall))
     }))
     this.blinds = blinds
     this.pot = 0
@@ -60,10 +61,25 @@ export class TexasHoldemGame {
       const p = this.players[idx]
       if (!p.folded && !p.allIn) {
         const toCall = this.currentBet - p.bet
-        const act = p.action(p.hand, this.community)
+        const act = p.action(p.hand, this.community, toCall)
         if (act === 'fold') {
           p.folded = true
           playersToAct--
+        } else if (act === 'raise') {
+          const raiseTo = toCall + this.blinds.big
+          const amount = Math.min(raiseTo, p.chips)
+          p.chips -= amount
+          p.bet += amount
+          p.totalBet += amount
+          this.pot += amount
+          if (p.chips === 0) {
+            p.allIn = true
+            playersToAct--
+          }
+          this.currentBet = p.bet
+          calls = 1
+        } else if (act === 'check' && toCall === 0) {
+          calls++
         } else {
           const amount = Math.min(toCall, p.chips)
           p.chips -= amount

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -463,8 +463,19 @@ async function proceedStage() {
     setPlayerTurnIndicator(i);
     document.getElementById('status').textContent = `${p.name}...`;
     await new Promise((r) => setTimeout(r, 2500));
-    const action = aiChooseAction(p.hand, state.community.slice(0, stageCommunityCount()));
-    if (action === 'call') {
+    const action = aiChooseAction(
+      p.hand,
+      state.community.slice(0, stageCommunityCount()),
+      state.currentBet
+    );
+    if (action === 'raise') {
+      const raiseBy = ANTE;
+      const total = state.currentBet + raiseBy;
+      state.currentBet = total;
+      state.pot += total;
+      updatePotDisplay();
+      document.getElementById('status').textContent = `${p.name} raises to ${total} ${state.token}`;
+    } else if (action === 'call') {
       state.pot += state.currentBet;
       updatePotDisplay();
       document.getElementById('status').textContent = `${p.name} calls ${state.currentBet} ${state.token}`;


### PR DESCRIPTION
## Summary
- allow poker AI to raise, call, check or fold based on hand strength
- support raises and checks in the Hold'em game engine and frontend
- add tests for AI decisions and raise handling

## Testing
- `npm test` *(fails: snake API endpoints and socket events timed out)*
- `node --test test/texasHoldemGame.test.js test/texasHoldemAICore.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a44ea5c8a08329b6647218a37bcb04