### PR TITLE
Improve Texas Hold'em AI and winner evaluation

### DIFF
--- a/lib/texasHoldem.js
+++ b/lib/texasHoldem.js
@@ -169,41 +169,51 @@ export function compareHands(aCards,bCards){
 }
 
 export function evaluateWinner(players, community){
-  let best=-Infinity, winner=null;
+  let bestScore=null; const winners=[];
   players.forEach((p,i)=>{
     const score=bestHand([...p.hand,...community]);
-    if(score.rank>best || (score.rank===best && compareTiebreak(score.tiebreak,winner?.score.tiebreak)>0)){
-      best=score.rank; winner={index:i, score};
-    } else if(score.rank===winner?.score.rank && compareTiebreak(score.tiebreak,winner.score.tiebreak)===0){
-      winner=null; // tie
+    if(!bestScore||score.rank>bestScore.rank|| (score.rank===bestScore.rank && compareTiebreak(score.tiebreak,bestScore.tiebreak)>0)){
+      bestScore=score; winners.splice(0,winners.length,{index:i,score});
+    } else if(score.rank===bestScore.rank && compareTiebreak(score.tiebreak,bestScore.tiebreak)===0){
+      winners.push({index:i,score});
     }
   });
-  return winner;
+  return winners;
+}
+
+export function estimateWinProbability(hand, community = [], opponents = 1, simulations = 200){
+  const used=new Set([...hand,...community].map(c=>c.rank+c.suit));
+  const remaining=createDeck().filter(c=>!used.has(c.rank+c.suit));
+  let wins=0, ties=0;
+  for(let i=0;i<simulations;i++){
+    const d=shuffle([...remaining]);
+    const oppHands=Array.from({length:opponents},()=>[d.pop(),d.pop()]);
+    const needed=5-community.length;
+    const comm=[...community];
+    for(let j=0;j<needed;j++) comm.push(d.pop());
+    const myCards=[...hand,...comm];
+    const myScore=bestHand(myCards);
+    let outcome=1; //1 win,0.5 tie,0 lose
+    for(const oh of oppHands){
+      const oppScore=bestHand([...oh,...comm]);
+      let cmp=myScore.rank-oppScore.rank;
+      if(cmp===0) cmp=compareTiebreak(myScore.tiebreak,oppScore.tiebreak);
+      if(cmp<0){ outcome=0; break; }
+      if(cmp===0){ outcome=Math.min(outcome,0.5); }
+    }
+    if(outcome===1) wins++; else if(outcome===0.5) ties++;
+  }
+  return (wins+ties/2)/simulations;
 }
 
 export function aiChooseAction (hand, community = [], toCall = 0) {
-  const stage = community.length; // 0 preflop,3 flop,4 turn,5 river
-
-  // Preflop heuristic based solely on hole cards
-  if (stage < 3) {
-    const hv = hand.map((c) => rankValue(c.rank)).sort((a, b) => b - a);
-    if (toCall > 0) {
-      if (hv[0] === hv[1] && hv[0] >= 11) return 'raise';
-      if (hv[0] >= 12 || hv[0] === hv[1]) return 'call';
-      return 'fold';
-    }
-    if (hv[0] === hv[1] && hv[0] >= 12) return 'raise';
-    if (hv[0] >= 11) return 'check';
+  const winProb=estimateWinProbability(hand,community);
+  if(toCall>0){
+    if(winProb>0.7) return 'raise';
+    if(winProb>0.4) return 'call';
     return 'fold';
   }
-
-  const score = bestHand([...hand, ...community]);
-  if (toCall > 0) {
-    if (score && score.rank >= 5) return 'raise'; // flush or better
-    if (score && score.rank >= 2) return 'call'; // at least two pair
-    return 'fold';
-  }
-  if (score && score.rank >= 4) return 'raise'; // straight or better
-  if (score && score.rank >= 1) return 'check';
+  if(winProb>0.7) return 'raise';
+  if(winProb>0.4) return 'check';
   return 'fold';
 }

--- a/webapp/public/lib/texasHoldem.js
+++ b/webapp/public/lib/texasHoldem.js
@@ -169,40 +169,51 @@ export function compareHands(aCards,bCards){
 }
 
 export function evaluateWinner(players, community){
-  let best=-Infinity, winner=null;
+  let bestScore=null; const winners=[];
   players.forEach((p,i)=>{
     const score=bestHand([...p.hand,...community]);
-    if(score.rank>best || (score.rank===best && compareTiebreak(score.tiebreak,winner?.score.tiebreak)>0)){
-      best=score.rank; winner={index:i, score};
-    } else if(score.rank===winner?.score.rank && compareTiebreak(score.tiebreak,winner.score.tiebreak)===0){
-      winner=null; // tie
+    if(!bestScore||score.rank>bestScore.rank|| (score.rank===bestScore.rank && compareTiebreak(score.tiebreak,bestScore.tiebreak)>0)){
+      bestScore=score; winners.splice(0,winners.length,{index:i,score});
+    } else if(score.rank===bestScore.rank && compareTiebreak(score.tiebreak,bestScore.tiebreak)===0){
+      winners.push({index:i,score});
     }
   });
-  return winner;
+  return winners;
+}
+
+export function estimateWinProbability(hand, community = [], opponents = 1, simulations = 200){
+  const used=new Set([...hand,...community].map(c=>c.rank+c.suit));
+  const remaining=createDeck().filter(c=>!used.has(c.rank+c.suit));
+  let wins=0, ties=0;
+  for(let i=0;i<simulations;i++){
+    const d=shuffle([...remaining]);
+    const oppHands=Array.from({length:opponents},()=>[d.pop(),d.pop()]);
+    const needed=5-community.length;
+    const comm=[...community];
+    for(let j=0;j<needed;j++) comm.push(d.pop());
+    const myCards=[...hand,...comm];
+    const myScore=bestHand(myCards);
+    let outcome=1; //1 win,0.5 tie,0 lose
+    for(const oh of oppHands){
+      const oppScore=bestHand([...oh,...comm]);
+      let cmp=myScore.rank-oppScore.rank;
+      if(cmp===0) cmp=compareTiebreak(myScore.tiebreak,oppScore.tiebreak);
+      if(cmp<0){ outcome=0; break; }
+      if(cmp===0){ outcome=Math.min(outcome,0.5); }
+    }
+    if(outcome===1) wins++; else if(outcome===0.5) ties++;
+  }
+  return (wins+ties/2)/simulations;
 }
 
 export function aiChooseAction (hand, community = [], toCall = 0) {
-  const stage = community.length; //0 preflop,3 flop,4 turn,5 river
-
-  if (stage < 3) {
-    const hv = hand.map((c) => rankValue(c.rank)).sort((a, b) => b - a);
-    if (toCall > 0) {
-      if (hv[0] === hv[1] && hv[0] >= 11) return 'raise';
-      if (hv[0] >= 12 || hv[0] === hv[1]) return 'call';
-      return 'fold';
-    }
-    if (hv[0] === hv[1] && hv[0] >= 12) return 'raise';
-    if (hv[0] >= 11) return 'check';
+  const winProb=estimateWinProbability(hand,community);
+  if(toCall>0){
+    if(winProb>0.7) return 'raise';
+    if(winProb>0.4) return 'call';
     return 'fold';
   }
-
-  const score = bestHand([...hand, ...community]);
-  if (toCall > 0) {
-    if (score && score.rank >= 5) return 'raise';
-    if (score && score.rank >= 2) return 'call';
-    return 'fold';
-  }
-  if (score && score.rank >= 4) return 'raise';
-  if (score && score.rank >= 1) return 'check';
+  if(winProb>0.7) return 'raise';
+  if(winProb>0.4) return 'check';
   return 'fold';
 }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -553,13 +553,14 @@ async function showdown() {
     p.hand.forEach((c) => cards.appendChild(cardEl(c)));
   });
   const activePlayers = state.players.filter((p) => !p.vacant);
-  const winner = evaluateWinner(activePlayers, state.community);
+  const winners = evaluateWinner(activePlayers, state.community);
   const pot = state.pot;
-  const text = winner
-    ? `${activePlayers[winner.index].name} wins with ${HAND_RANK_NAMES[winner.score.rank]}!`
+  const text = winners.length === 1
+    ? `${activePlayers[winners[0].index].name} wins with ${HAND_RANK_NAMES[winners[0].score.rank]}!`
     : 'Tie';
   document.getElementById('status').textContent = text;
-  if (winner) {
+  if (winners.length === 1) {
+    const winner = winners[0];
     const winning = winner.score.cards;
     const commEl = document.getElementById('community');
     state.community.forEach((c, idx) => {


### PR DESCRIPTION
## Summary
- add win probability estimation and Monte Carlo decision making for AI players
- return all winners to properly handle ties
- update client showdown logic for new winner API

## Testing
- `npm test` (fails: assert.ok(events.includes('diceRolled')))
- `npm run lint` (fails: 556 problems)

------
https://chatgpt.com/codex/tasks/task_e_68a45bdf0d808329bbcc345748e21975