### PR TITLE
Remove avatar action overlay and color action text

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -51,12 +51,11 @@
 .moving-card{position:absolute;transition:left .3s ease, top .3s ease;z-index:1000;pointer-events:none;}
 .avatar.turn{box-shadow:0 0 12px #facc15;border-color:#facc15;}
 
-.action-text{color:#ff0;font-weight:700;text-shadow:0 1px 2px #000;min-height:1em}
-.action-overlay{position:absolute;inset:0;opacity:.3;border:4px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:600;font-size:12px;transform:scaleX(-1);pointer-events:none}
-.action-overlay.fold{background:#dc2626;color:#fff}
-.action-overlay.call{background:#16a34a;color:#fff}
-.action-overlay.check{background:#facc15;color:#000}
-.action-overlay.raise{background:#2563eb;color:#fff}
+.action-text{font-weight:700;text-shadow:0 1px 2px #000;min-height:1em}
+.action-text.fold{color:#dc2626}
+.action-text.call{color:#16a34a}
+.action-text.check{color:#facc15}
+.action-text.raise{color:#2563eb}
 
 .seat.bottom { bottom: 0.5%; left: 50%; transform: translateX(-50%); }
 

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -206,26 +206,14 @@ function renderSeats() {
 
 function setActionText(idx, action) {
   const el = document.getElementById('action-' + idx);
-  if (el) el.textContent = action ? action.charAt(0).toUpperCase() + action.slice(1) : '';
-}
-
-function showActionOverlay(idx, action) {
-  const avatar = document.getElementById('avatar-' + idx);
-  if (!avatar) return;
-  const existing = avatar.querySelector('.action-overlay');
-  if (existing) existing.remove();
-  const overlay = document.createElement('div');
-  overlay.className = 'action-overlay ' + action;
-  overlay.textContent = action;
-  avatar.appendChild(overlay);
+  if (!el) return;
+  el.textContent = action ? action.charAt(0).toUpperCase() + action.slice(1) : '';
+  el.className = 'action-text';
+  if (action) el.classList.add(action);
 }
 
 function clearActionTexts() {
-  state.players.forEach((_, i) => {
-    setActionText(i, '');
-    const avatar = document.getElementById('avatar-' + i);
-    avatar?.querySelector('.action-overlay')?.remove();
-  });
+  state.players.forEach((_, i) => setActionText(i, ''));
 }
 
 function cardEl(card) {
@@ -454,14 +442,12 @@ function playerFold() {
   state.players[0].active = false;
   setPlayerTurnIndicator(null);
   setActionText(0, 'fold');
-  showActionOverlay(0, 'fold');
   document.getElementById('status').textContent = 'You folded';
   proceedStage();
 }
 
 function playerCheck() {
   setActionText(0, 'check');
-  showActionOverlay(0, 'check');
   document.getElementById('status').textContent = 'You check';
   proceedStage();
 }
@@ -470,7 +456,6 @@ function playerCall() {
   state.pot += state.currentBet;
   updatePotDisplay();
   setActionText(0, 'call');
-  showActionOverlay(0, 'call');
   document.getElementById('status').textContent = `You call ${state.currentBet} ${state.token}`;
   proceedStage();
 }
@@ -483,7 +468,6 @@ function playerRaise() {
   state.currentBet += amount;
   updatePotDisplay();
   setActionText(0, 'raise');
-  showActionOverlay(0, 'raise');
   document.getElementById('status').textContent = `You raise ${amount} ${state.token}`;
   proceedStage();
 }
@@ -522,7 +506,6 @@ async function proceedStage() {
       document.getElementById('status').textContent = `${p.name} checks`;
     }
     setActionText(i, action);
-    showActionOverlay(i, action);
   }
   setPlayerTurnIndicator(null);
   state.stage++;


### PR DESCRIPTION
## Summary
- drop mirrored action overlay from player avatars
- color action text based on action type matching button colors

## Testing
- `npm test` (fails: test timed out after 20000ms)
- `npm run lint` (fails: 556 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a4674da0448329bb12fb21968b438f