### PR TITLE
Revert Pool Royale to earlier morning state

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -121,7 +121,7 @@
       flex-direction: column;
       align-items: center;
       justify-content: space-between;
-      padding: 12px 8px;
+      padding: 0 8px 12px;
       z-index: 6;
     }
 
@@ -163,7 +163,7 @@
 
     #cueRail {
       position: absolute;
-      left: 50%;
+      left: 54%;
       transform: translateX(-50%);
       width: 10px;
       height: calc(100% - 24px);
@@ -174,7 +174,7 @@
 
     #cueStick {
       position: absolute;
-      left: 50%;
+      left: 54%;
       transform: translateX(-50%);
       width: 8px;
       height: 60%;
@@ -186,7 +186,7 @@
 
     #tip {
       position: absolute;
-      left: 50%;
+      left: 54%;
       transform: translateX(-50%);
       width: 12px;
       height: 12px;


### PR DESCRIPTION
## Summary
- Restore Pool Royale HTML layout to morning version with original cue positioning and padding

## Testing
- `npm test` *(fails: AssertionError in snakeApi.test.js)*
- `npm run lint` *(fails: 556 errors in lib/texasHoldem.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a475e2f18c8329bee21feacfb458bc