### PR TITLE
Restore Texas Hold'em game to earlier state

### DIFF
--- a/lib/texasHoldem.js
+++ b/lib/texasHoldem.js
@@ -169,28 +169,51 @@ export function compareHands(aCards,bCards){
 }
 
 export function evaluateWinner(players, community){
-  let best=-Infinity, winner=null;
+  let bestScore=null; const winners=[];
   players.forEach((p,i)=>{
     const score=bestHand([...p.hand,...community]);
-    if(score.rank>best || (score.rank===best && compareTiebreak(score.tiebreak,winner?.score.tiebreak)>0)){
-      best=score.rank; winner={index:i, score};
-    } else if(score.rank===winner?.score.rank && compareTiebreak(score.tiebreak,winner.score.tiebreak)===0){
-      winner=null; // tie
+    if(!bestScore||score.rank>bestScore.rank|| (score.rank===bestScore.rank && compareTiebreak(score.tiebreak,bestScore.tiebreak)>0)){
+      bestScore=score; winners.splice(0,winners.length,{index:i,score});
+    } else if(score.rank===bestScore.rank && compareTiebreak(score.tiebreak,bestScore.tiebreak)===0){
+      winners.push({index:i,score});
     }
   });
-  return winner;
+  return winners;
 }
 
-export function aiChooseAction(hand, community=[]){
-  const stage=community.length; //0 preflop,3 flop,4 turn,5 river
-  const score=bestHand([...hand,...community]);
-  // very naive thresholds
-  if(stage<3){
-    // preflop
-    const hv=hand.map(c=>rankValue(c.rank)).sort((a,b)=>b-a);
-    if(hv[0]>=12 || hv[0]===hv[1]) return 'call';
+export function estimateWinProbability(hand, community = [], opponents = 1, simulations = 200){
+  const used=new Set([...hand,...community].map(c=>c.rank+c.suit));
+  const remaining=createDeck().filter(c=>!used.has(c.rank+c.suit));
+  let wins=0, ties=0;
+  for(let i=0;i<simulations;i++){
+    const d=shuffle([...remaining]);
+    const oppHands=Array.from({length:opponents},()=>[d.pop(),d.pop()]);
+    const needed=5-community.length;
+    const comm=[...community];
+    for(let j=0;j<needed;j++) comm.push(d.pop());
+    const myCards=[...hand,...comm];
+    const myScore=bestHand(myCards);
+    let outcome=1; //1 win,0.5 tie,0 lose
+    for(const oh of oppHands){
+      const oppScore=bestHand([...oh,...comm]);
+      let cmp=myScore.rank-oppScore.rank;
+      if(cmp===0) cmp=compareTiebreak(myScore.tiebreak,oppScore.tiebreak);
+      if(cmp<0){ outcome=0; break; }
+      if(cmp===0){ outcome=Math.min(outcome,0.5); }
+    }
+    if(outcome===1) wins++; else if(outcome===0.5) ties++;
+  }
+  return (wins+ties/2)/simulations;
+}
+
+export function aiChooseAction (hand, community = [], toCall = 0) {
+  const winProb=estimateWinProbability(hand,community);
+  if(toCall>0){
+    if(winProb>0.7) return 'raise';
+    if(winProb>0.4) return 'call';
     return 'fold';
   }
-  if(score.rank>=1) return 'call';
+  if(winProb>0.7) return 'raise';
+  if(winProb>0.4) return 'check';
   return 'fold';
 }

--- a/lib/texasHoldemGame.js
+++ b/lib/texasHoldemGame.js
@@ -9,7 +9,7 @@ export class TexasHoldemGame {
       startingChips = 100,
       blinds = { small: 5, big: 10 },
       deck = shuffle(createDeck()),
-      actions = [] // array of functions(hand, community) -> 'fold'|'call'
+      actions = [] // array of functions(hand, community, toCall) -> 'fold'|'call'|'check'|'raise'
     } = options
 
     this.deck = [...deck]
@@ -21,7 +21,8 @@ export class TexasHoldemGame {
       totalBet: 0,
       folded: false,
       allIn: false,
-      action: actions[i] || ((hand, community) => aiChooseAction(hand, community))
+      action:
+        actions[i] || ((hand, community, toCall) => aiChooseAction(hand, community, toCall))
     }))
     this.blinds = blinds
     this.pot = 0
@@ -60,10 +61,25 @@ export class TexasHoldemGame {
       const p = this.players[idx]
       if (!p.folded && !p.allIn) {
         const toCall = this.currentBet - p.bet
-        const act = p.action(p.hand, this.community)
+        const act = p.action(p.hand, this.community, toCall)
         if (act === 'fold') {
           p.folded = true
           playersToAct--
+        } else if (act === 'raise') {
+          const raiseTo = toCall + this.blinds.big
+          const amount = Math.min(raiseTo, p.chips)
+          p.chips -= amount
+          p.bet += amount
+          p.totalBet += amount
+          this.pot += amount
+          if (p.chips === 0) {
+            p.allIn = true
+            playersToAct--
+          }
+          this.currentBet = p.bet
+          calls = 1
+        } else if (act === 'check' && toCall === 0) {
+          calls++
         } else {
           const amount = Math.min(toCall, p.chips)
           p.chips -= amount

--- a/test/texasHoldemGame.test.js
+++ b/test/texasHoldemGame.test.js
@@ -27,3 +27,14 @@ test('simulates a full hand and awards pot to best player', () => {
   assert.equal(game.players[0].chips, 110);
   assert.equal(game.players[1].chips, 90);
 });
+
+test('bettingRound handles raises correctly', () => {
+  const game = new TexasHoldemGame(2, { actions: [() => 'raise', () => 'call'] });
+  game.postBlinds();
+  game.bettingRound(0);
+  assert.equal(game.pot, 40);
+  assert.equal(game.players[0].chips, 80);
+  assert.equal(game.players[1].chips, 80);
+  assert.equal(game.players[0].totalBet, 20);
+  assert.equal(game.players[1].totalBet, 20);
+});

--- a/webapp/public/lib/texasHoldem.js
+++ b/webapp/public/lib/texasHoldem.js
@@ -169,28 +169,51 @@ export function compareHands(aCards,bCards){
 }
 
 export function evaluateWinner(players, community){
-  let best=-Infinity, winner=null;
+  let bestScore=null; const winners=[];
   players.forEach((p,i)=>{
     const score=bestHand([...p.hand,...community]);
-    if(score.rank>best || (score.rank===best && compareTiebreak(score.tiebreak,winner?.score.tiebreak)>0)){
-      best=score.rank; winner={index:i, score};
-    } else if(score.rank===winner?.score.rank && compareTiebreak(score.tiebreak,winner.score.tiebreak)===0){
-      winner=null; // tie
+    if(!bestScore||score.rank>bestScore.rank|| (score.rank===bestScore.rank && compareTiebreak(score.tiebreak,bestScore.tiebreak)>0)){
+      bestScore=score; winners.splice(0,winners.length,{index:i,score});
+    } else if(score.rank===bestScore.rank && compareTiebreak(score.tiebreak,bestScore.tiebreak)===0){
+      winners.push({index:i,score});
     }
   });
-  return winner;
+  return winners;
 }
 
-export function aiChooseAction(hand, community=[]){
-  const stage=community.length; //0 preflop,3 flop,4 turn,5 river
-  const score=bestHand([...hand,...community]);
-  // very naive thresholds
-  if(stage<3){
-    // preflop
-    const hv=hand.map(c=>rankValue(c.rank)).sort((a,b)=>b-a);
-    if(hv[0]>=12 || hv[0]===hv[1]) return 'call';
+export function estimateWinProbability(hand, community = [], opponents = 1, simulations = 200){
+  const used=new Set([...hand,...community].map(c=>c.rank+c.suit));
+  const remaining=createDeck().filter(c=>!used.has(c.rank+c.suit));
+  let wins=0, ties=0;
+  for(let i=0;i<simulations;i++){
+    const d=shuffle([...remaining]);
+    const oppHands=Array.from({length:opponents},()=>[d.pop(),d.pop()]);
+    const needed=5-community.length;
+    const comm=[...community];
+    for(let j=0;j<needed;j++) comm.push(d.pop());
+    const myCards=[...hand,...comm];
+    const myScore=bestHand(myCards);
+    let outcome=1; //1 win,0.5 tie,0 lose
+    for(const oh of oppHands){
+      const oppScore=bestHand([...oh,...comm]);
+      let cmp=myScore.rank-oppScore.rank;
+      if(cmp===0) cmp=compareTiebreak(myScore.tiebreak,oppScore.tiebreak);
+      if(cmp<0){ outcome=0; break; }
+      if(cmp===0){ outcome=Math.min(outcome,0.5); }
+    }
+    if(outcome===1) wins++; else if(outcome===0.5) ties++;
+  }
+  return (wins+ties/2)/simulations;
+}
+
+export function aiChooseAction (hand, community = [], toCall = 0) {
+  const winProb=estimateWinProbability(hand,community);
+  if(toCall>0){
+    if(winProb>0.7) return 'raise';
+    if(winProb>0.4) return 'call';
     return 'fold';
   }
-  if(score.rank>=1) return 'call';
+  if(winProb>0.7) return 'raise';
+  if(winProb>0.4) return 'check';
   return 'fold';
 }

--- a/webapp/public/lib/texasHoldemGame.js
+++ b/webapp/public/lib/texasHoldemGame.js
@@ -9,7 +9,7 @@ export class TexasHoldemGame {
       startingChips = 100,
       blinds = { small: 5, big: 10 },
       deck = shuffle(createDeck()),
-      actions = [] // array of functions(hand, community) -> 'fold'|'call'
+      actions = [] // array of functions(hand, community, toCall) -> 'fold'|'call'|'check'|'raise'
     } = options
 
     this.deck = [...deck]
@@ -21,7 +21,8 @@ export class TexasHoldemGame {
       totalBet: 0,
       folded: false,
       allIn: false,
-      action: actions[i] || ((hand, community) => aiChooseAction(hand, community))
+      action:
+        actions[i] || ((hand, community, toCall) => aiChooseAction(hand, community, toCall))
     }))
     this.blinds = blinds
     this.pot = 0
@@ -60,10 +61,25 @@ export class TexasHoldemGame {
       const p = this.players[idx]
       if (!p.folded && !p.allIn) {
         const toCall = this.currentBet - p.bet
-        const act = p.action(p.hand, this.community)
+        const act = p.action(p.hand, this.community, toCall)
         if (act === 'fold') {
           p.folded = true
           playersToAct--
+        } else if (act === 'raise') {
+          const raiseTo = toCall + this.blinds.big
+          const amount = Math.min(raiseTo, p.chips)
+          p.chips -= amount
+          p.bet += amount
+          p.totalBet += amount
+          this.pot += amount
+          if (p.chips === 0) {
+            p.allIn = true
+            playersToAct--
+          }
+          this.currentBet = p.bet
+          calls = 1
+        } else if (act === 'check' && toCall === 0) {
+          calls++
         } else {
           const amount = Math.min(toCall, p.chips)
           p.chips -= amount

--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -24,7 +24,7 @@
       .seats{ position:absolute; inset:0; z-index:2 }
       .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px) }
       .seat.small{ --card-scale:.8; }
-      .avatar{ width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%, #fff, #ddd 40%, #bbb 60%, #999 100%); color:#111; font-size:28px; border:4px solid rgba(255,255,255,.65); box-shadow:0 8px 20px var(--shadow); overflow:hidden }
+      .avatar{ width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%, #fff, #ddd 40%, #bbb 60%, #999 100%); color:#111; font-size:28px; border:4px solid rgba(255,255,255,.65); box-shadow:0 8px 20px var(--shadow); overflow:hidden; position:relative }
       .avatar-wrap{ position:relative; width:var(--avatar-size); height:var(--avatar-size); display:grid; place-items:center; }
       .timer-ring{ position:absolute; inset:-6px; border-radius:50%; background:conic-gradient(#f5cc4e var(--progress,0deg), transparent 0); -webkit-mask:radial-gradient(farthest-side,transparent calc(100% - 6px),#000 calc(100% - 6px)); mask:radial-gradient(farthest-side,transparent calc(100% - 6px),#000 calc(100% - 6px)); pointer-events:none }
       .cards{ display:flex; gap:6px; flex-wrap:nowrap }
@@ -50,6 +50,12 @@
 
 .moving-card{position:absolute;transition:left .3s ease, top .3s ease;z-index:1000;pointer-events:none;}
 .avatar.turn{box-shadow:0 0 12px #facc15;border-color:#facc15;}
+
+.action-text{font-weight:700;text-shadow:0 1px 2px #000;min-height:1em}
+.action-text.fold{color:#dc2626}
+.action-text.call{color:#16a34a}
+.action-text.check{color:#facc15}
+.action-text.raise{color:#2563eb}
 
 .seat.bottom { bottom: 0.5%; left: 50%; transform: translateX(-50%); }
 


### PR DESCRIPTION
## Summary
- Restore Texas Hold'em engine and front-end assets to pre-regression state
- Reinstate original winner evaluation, win probability, and AI decision logic

## Testing
- `npm test` *(fails: AssertionError: assert.ok(events.includes('diceRolled')) in snakeApi.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a48a8595fc8329820c773158ae6f1b