### PR TITLE
Add poker sound effects

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -48,7 +48,7 @@
 
 .seat.winner .name { color: #facc15; }
 
-.moving-card{position:absolute;transition:left .3s ease, top .3s ease;z-index:1000;pointer-events:none;}
+.moving-card{position:absolute;transition:left .4s ease, top .4s ease;z-index:1000;pointer-events:none;}
 .avatar.turn{box-shadow:0 0 12px #facc15;border-color:#facc15;}
 
 .action-text{font-weight:700;text-shadow:0 1px 2px #000;min-height:1em}
@@ -135,6 +135,10 @@
       <div id="status"></div>
     </div>
   <audio id="sndTimer" src="https://cdn.jsdelivr.net/gh/naptha/tiny-sound@master/sounds/beep1.ogg"></audio>
+  <audio id="sndCallRaise" src="assets/sounds/Callraischip.mp3"></audio>
+  <audio id="sndAllIn" src="assets/sounds/allinpushchips2-39133.mp3"></audio>
+  <audio id="sndFlip" src="assets/sounds/flipcard-91468.mp3"></audio>
+  <audio id="sndKnock" src="assets/sounds/wooden-door-knock-102902.mp3"></audio>
   <div class="top-controls">
     <button id="lobbyIcon"><img src="assets/icons/texas-holdem.svg" alt="Lobby"/></button>
     <button id="leaveSeatBtn">Leave</button>

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -38,6 +38,39 @@ async function awardDevShare(total) {
   } catch {}
 }
 
+function playCallRaiseSound() {
+  const snd = document.getElementById('sndCallRaise');
+  if (snd) {
+    snd.currentTime = 0;
+    snd.play();
+  }
+}
+
+function playAllInSound() {
+  const snd = document.getElementById('sndAllIn');
+  if (snd) {
+    snd.currentTime = 0;
+    snd.play();
+  }
+}
+
+function playFlipSound() {
+  const snd = document.getElementById('sndFlip');
+  if (snd) {
+    snd.currentTime = 0;
+    snd.play();
+  }
+}
+
+function playKnockSound() {
+  const snd = document.getElementById('sndKnock');
+  if (snd) {
+    snd.currentTime = 1;
+    snd.play();
+    setTimeout(() => snd.pause(), 2000);
+  }
+}
+
 const SUIT_MAP = { H: '♥', D: '♦', C: '♣', S: '♠' };
 const CHIP_VALUES = [1000, 500, 200, 100, 50, 20, 10, 5, 1];
 const ANTE = 10;
@@ -297,6 +330,7 @@ function dealCardToPlayer(idx, card, showFace) {
     stage.appendChild(temp);
     const target = document.getElementById('cards-' + idx);
     const targetRect = target.getBoundingClientRect();
+    playFlipSound();
     requestAnimationFrame(() => {
       temp.style.left = targetRect.left - stageRect.left + 'px';
       temp.style.top = targetRect.top - stageRect.top + 'px';
@@ -399,6 +433,7 @@ function startPlayerTurn() {
   state.turn = 0;
   state.currentBet = 0;
   setPlayerTurnIndicator(0);
+  playKnockSound();
   showControls();
   startTurnTimer(() => {
     if (state.currentBet > 0) playerFold();
@@ -457,6 +492,8 @@ function playerCall() {
   updatePotDisplay();
   setActionText(0, 'call');
   document.getElementById('status').textContent = `You call ${state.currentBet} ${state.token}`;
+  if (state.pot >= state.maxPot) playAllInSound();
+  else playCallRaiseSound();
   proceedStage();
 }
 
@@ -469,6 +506,8 @@ function playerRaise() {
   updatePotDisplay();
   setActionText(0, 'raise');
   document.getElementById('status').textContent = `You raise ${amount} ${state.token}`;
+  if (state.pot >= state.maxPot) playAllInSound();
+  else playCallRaiseSound();
   proceedStage();
 }
 
@@ -495,10 +534,14 @@ async function proceedStage() {
       state.pot += total;
       updatePotDisplay();
       document.getElementById('status').textContent = `${p.name} raises to ${total} ${state.token}`;
+      if (state.pot >= state.maxPot) playAllInSound();
+      else playCallRaiseSound();
     } else if (action === 'call') {
       state.pot += state.currentBet;
       updatePotDisplay();
       document.getElementById('status').textContent = `${p.name} calls ${state.currentBet} ${state.token}`;
+      if (state.pot >= state.maxPot) playAllInSound();
+      else playCallRaiseSound();
     } else if (action === 'fold') {
       p.active = false;
       document.getElementById('status').textContent = `${p.name} folds`;
@@ -526,6 +569,7 @@ function movePotToWinner(idx) {
   const potEl = document.getElementById('pot');
   const stage = document.querySelector('.stage');
   if (!potEl || !stage) return;
+  playAllInSound();
   const stageRect = stage.getBoundingClientRect();
   const potRect = potEl.getBoundingClientRect();
   potEl.classList.add('moving-pot');
@@ -545,29 +589,35 @@ function movePotToWinner(idx) {
   });
 }
 
-function revealFlop() {
+async function revealFlop() {
   const comm = document.getElementById('community');
   for (let i = 0; i < 3; i++) {
     const card = cardEl(state.community[i]);
     if (comm.children[i]) comm.children[i].replaceWith(card);
     else comm.appendChild(card);
+    playFlipSound();
+    await new Promise((r) => setTimeout(r, 400));
   }
   clearActionTexts();
   if (state.players[0].active) startPlayerTurn();
   else proceedStage();
 }
 
-function revealTurn() {
+async function revealTurn() {
   const comm = document.getElementById('community');
   comm.appendChild(cardEl(state.community[3]));
+  playFlipSound();
+  await new Promise((r) => setTimeout(r, 400));
   clearActionTexts();
   if (state.players[0].active) startPlayerTurn();
   else proceedStage();
 }
 
-function revealRiver() {
+async function revealRiver() {
   const comm = document.getElementById('community');
   comm.appendChild(cardEl(state.community[4]));
+  playFlipSound();
+  await new Promise((r) => setTimeout(r, 400));
   clearActionTexts();
   if (state.players[0].active) startPlayerTurn();
   else proceedStage();


### PR DESCRIPTION
## Summary
- add audio cues for chip actions, card dealing, and player turns in Texas Hold'em game
- slow card movement animation slightly for better audio sync

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint` *(fails: 556 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a492e457fc832995bb11aec7f7d93f