### PR TITLE
Refactor Pool Royale controls and visuals

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -41,6 +41,8 @@
       background: linear-gradient(#15203a, #0b1120);
     }
 
+    #header { position: relative; }
+
     #header { border-bottom: 1px solid #24375f; }
     #footer { border-top: 1px solid #24375f; }
 
@@ -137,7 +139,10 @@
       height: 45px;
       border-radius: 50%;
       background: #f6f6f6;
-      position: relative;
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
       box-shadow: 0 4px 10px rgba(0,0,0,.4) inset,
                   0 0 0 2px rgba(0,0,0,.15);
       transform-origin: center;
@@ -179,28 +184,21 @@
       box-shadow: inset 0 0 0 2px rgba(0,0,0,.15);
     }
 
-    #cueStick {
+    #pullHandle {
       position: absolute;
       left: 50%;
       transform: translateX(-50%);
-      width: 8px;
-      height: 60%;
-      background: linear-gradient(#caa471, #9c7a4d);
-      border-radius: 6px;
-      box-shadow: 0 1px 0 rgba(255,255,255,.25) inset,
-                  0 4px 10px rgba(0,0,0,.35);
-    }
-
-    #tip {
-      position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
-      width: 12px;
-      height: 12px;
-      background: #5c3a21; /* ferrule */
+      width: 45px;
+      height: 45px;
       border-radius: 50%;
-      top: calc(50% - 6px);
-      box-shadow: 0 0 0 2px rgba(0,0,0,.25);
+      background: #fff;
+      color: #111;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      box-shadow: 0 4px 10px rgba(0,0,0,.3);
+      user-select: none;
     }
 
     #powerBox {
@@ -260,6 +258,9 @@
           <div class="potted" id="p1Potted"></div>
         </div>
       </div>
+      <div id="spinBox">
+        <div id="spinDot"></div>
+      </div>
       <div class="player">
         <div class="info">
           <div class="name">CPU</div>
@@ -273,16 +274,11 @@
       <canvas id="table"></canvas>
       <div id="cueHint">✋️</div>
 
-      <!-- Panel djathtas: SPIN siper, STEKA poshte -->
+      <!-- Panel djathtas: vetem slideri i fuqise -->
       <aside id="rightPanel">
-        <div id="spinBox">
-          <div id="spinDot"></div>
-        </div>
-
         <div id="pullArea">
           <div id="cueRail"></div>
-          <div id="cueStick"></div>
-          <div id="tip"></div>
+          <div id="pullHandle">PULL</div>
         </div>
 
         <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
@@ -344,11 +340,10 @@
     var spinDot   = document.getElementById('spinDot');
     var logoImg   = new Image();
     logoImg.src   = '/assets/icons/pool-royale.svg';
-    var pullArea  = document.getElementById('pullArea');
-    var cueStickEl= document.getElementById('cueStick');
-    var cueTipEl  = document.getElementById('tip');
-    var powerFill = document.getElementById('powerFill');
-    var powerTxt  = document.getElementById('powerTxt');
+    var pullArea   = document.getElementById('pullArea');
+    var pullHandle = document.getElementById('pullHandle');
+    var powerFill  = document.getElementById('powerFill');
+    var powerTxt   = document.getElementById('powerTxt');
 
     var avatarP1 = document.querySelector('#header .player:first-child .avatar');
     var nameP1   = document.querySelector('#header .player:first-child .name');
@@ -605,14 +600,11 @@
 
     Table.prototype.render = function(){
       ctx.clearRect(0,0,canvas.width,canvas.height);
-        // Field outline
+        // Field dimensions
         var x0 = BORDER * sX,
             y0 = BORDER_TOP * sY,
             w = (TABLE_W - 2 * BORDER) * sX,
             h = (TABLE_H - BORDER_TOP - BORDER_BOTTOM) * sY;
-        ctx.strokeStyle = '#0f0';
-        ctx.lineWidth = 2;
-        ctx.strokeRect(x0, y0, w, h);
 
       // Vija kufizuese e cueball-it dhe pika qendrore
       ctx.strokeStyle = '#fff';
@@ -625,24 +617,6 @@
       ctx.beginPath();
       ctx.arc((TABLE_W/2)*sX, SPOT_Y*sY, 5*((sX+sY)/2), 0, Math.PI*2);
       ctx.fill();
-
-        // Pocket markers with numbers
-        for (var i=0;i<this.pockets.length;i++){
-          var p=this.pockets[i], px=p.x*sX, py=p.y*sY;
-          ctx.beginPath();
-          ctx.lineWidth=2;
-          ctx.strokeStyle='#0f0';
-          ctx.fillStyle='rgba(0,255,0,0.2)';
-          ctx.arc(px, py, pocketR, 0, Math.PI*2);
-          ctx.fill();
-          ctx.stroke();
-          ctx.fillStyle='#fff';
-          ctx.font=(pocketR*0.8)+'px system-ui,sans-serif';
-          ctx.textAlign='center';
-          ctx.textBaseline='middle';
-          ctx.fillText(String(i+1), px, py);
-        }
-
       // Topat
       for (var j=0;j<this.balls.length;j++){
         var b = this.balls[j];
@@ -904,18 +878,58 @@
     function setSpin(nx,ny){ spinDot.style.left = (50+nx*50)+'%'; spinDot.style.top = (50+ny*50)+'%'; spinVec = { x:nx, y:ny }; }
     setSpin(0,0);
     function updateSpin(e){ var r=spinBox.getBoundingClientRect(); var x=(e.clientX-r.left)/r.width*2-1, y=(e.clientY-r.top)/r.height*2-1; var L=Math.hypot(x,y); x=(x/(L||1))*Math.min(1,L); y=(y/(L||1))*Math.min(1,L); setSpin(x,y); spinMoved=true; }
-    spinBox.addEventListener('pointerdown', function(e){ spinMoved=false; spinBox.style.transform='scale(1.4)'; clearTimeout(spinTimer); updateSpin(e); spinTimer=setTimeout(function(){ if(!spinMoved) spinBox.style.transform='scale(1)'; }, 1500); });
+    spinBox.addEventListener('pointerdown', function(e){
+      spinMoved=false;
+      spinBox.style.transform='translate(-50%, -50%) scale(1.4)';
+      clearTimeout(spinTimer);
+      updateSpin(e);
+      spinTimer=setTimeout(function(){
+        if(!spinMoved) spinBox.style.transform='translate(-50%, -50%) scale(1)';
+      }, 1500);
+    });
     spinBox.addEventListener('pointermove', updateSpin);
-    spinBox.addEventListener('pointerup', function(){ clearTimeout(spinTimer); setTimeout(function(){ spinBox.style.transform='scale(1)'; }, 50); });
+    spinBox.addEventListener('pointerup', function(){
+      clearTimeout(spinTimer);
+      setTimeout(function(){ spinBox.style.transform='translate(-50%, -50%) scale(1)'; }, 50);
+    });
 
     /* ==========================================================
        PULL & RELEASE – fuqi e goditjes
        ========================================================= */
-    var pulling=false, pullStartY=0;
-    function updatePowerUI(){ powerFill.style.height = Math.round(power*100)+'%'; powerTxt.textContent = 'FORCA '+Math.round(power*100)+'%'; }
-    pullArea.addEventListener('pointerdown', function(e){ if (!table.running || table.isMoving()) return; pulling=true; pullStartY=e.clientY; power=0; updatePowerUI(); });
-    pullArea.addEventListener('pointermove', function(e){ if (!pulling) return; var rect=pullArea.getBoundingClientRect(); power=clamp((e.clientY-pullStartY)/(rect.height*0.9),0,1); updatePowerUI(); var minY=rect.top+12, maxY=rect.bottom-12, y=minY+(maxY-minY)*power; cueStickEl.style.height=(60+30*power)+'%'; cueTipEl.style.top=(y-rect.top-6)+'px'; cueStickEl.style.top=(y-rect.top-(cueStickEl.getBoundingClientRect().height-12)/2)+'px'; cuePullVisual=power*(BALL_R*14); placeAimGlow(table.aim); });
-    pullArea.addEventListener('pointerup', function(){ if (!pulling) return; pulling=false; shoot(power); power=0; updatePowerUI(); cuePullVisual=0; cueStickEl.style.height='60%'; });
+    var pulling=false;
+    function updatePullHandle(){
+      var rect=pullArea.getBoundingClientRect();
+      var minY=0, maxY=rect.height-pullHandle.offsetHeight;
+      pullHandle.style.top=(minY+(maxY-minY)*power)+'px';
+    }
+    function updatePowerUI(){
+      powerFill.style.height = Math.round(power*100)+'%';
+      powerTxt.textContent = 'FORCA '+Math.round(power*100)+'%';
+      updatePullHandle();
+    }
+    function updateFromEvent(e){
+      var rect=pullArea.getBoundingClientRect();
+      power=clamp((e.clientY-rect.top)/rect.height,0,1);
+      updatePowerUI();
+      cuePullVisual=power*(BALL_R*14);
+      placeAimGlow(table.aim);
+    }
+    pullArea.addEventListener('pointerdown', function(e){
+      if (!table.running || table.isMoving()) return;
+      pulling=true;
+      updateFromEvent(e);
+    });
+    pullArea.addEventListener('pointermove', function(e){ if (!pulling) return; updateFromEvent(e); });
+    pullArea.addEventListener('pointerup', function(){
+      if (!pulling) return;
+      pulling=false;
+      shoot(power);
+      power=0;
+      updatePowerUI();
+      cuePullVisual=0;
+    });
+
+    updatePowerUI();
 
     function shoot(p){
       if (!table.running || table.isMoving()) return;


### PR DESCRIPTION
## Summary
- Remove green debugging outlines and pocket markers from Pool Royale table
- Move spin control to top center alongside player avatars
- Replace side cue with pull-to-shoot power slider

## Testing
- `npm test` *(fails: canvas.node was compiled against a different Node.js version)*
- `npm run lint` *(fails: 556 lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a49a74a55c83298474f06625877c84