### PR TITLE
Tweak Pool Royale controls and spin physics

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -141,7 +141,7 @@
       background: #f6f6f6;
       position: absolute;
       left: 50%;
-      top: 80%;
+      top: calc(80% + 45px);
       transform: translate(-50%, -50%);
       box-shadow: 0 4px 10px rgba(0,0,0,.4) inset,
                   0 0 0 2px rgba(0,0,0,.15);
@@ -171,7 +171,8 @@
       align-items: center;
       justify-content: center;
       padding: 8px;
-      transform: translate(12px, 32px);
+      transform: translate(16px, 40px);
+      overflow: hidden;
     }
 
     #cueRail {
@@ -200,6 +201,7 @@
       font-weight: 700;
       box-shadow: 0 4px 10px rgba(0,0,0,.3);
       user-select: none;
+      opacity: .4;
     }
 
     #powerBox {
@@ -322,6 +324,7 @@
       var SPOT_Y  = BORDER_TOP + (TABLE_H - BORDER_TOP - BORDER_BOTTOM) * 0.25 - BALL_R * 0.5; // pika per trekendshin siper
     var LINE_Y  = BORDER_TOP + (TABLE_H - BORDER_TOP - BORDER_BOTTOM) * 0.75; // vija e bardhe poshte
     var CUE_START_Y = LINE_Y + (TABLE_H - BORDER_BOTTOM - LINE_Y - BALL_R*2) / 2; // pozicioni fillestar i cueball-it
+    var CUE_START_X = TABLE_W/2 - BALL_R*10; // zhvendos cueball-in majtas sa pesë topa
 
     var FRICTION = 0.985;   // ferkimi linear
     var BOUNCE   = 0.98;    // koeficienti i rikthimit
@@ -514,7 +517,7 @@
       this.running = false;
       this.turn = 1; // 1: P1, 2: CPU
       this.captured = { 1:[], 2:[] };
-      this.aim = { x:TABLE_W/2, y:TABLE_H/3 };
+      this.aim = { x:CUE_START_X, y:TABLE_H/3 };
       this.reset();
     }
 
@@ -522,8 +525,8 @@
       var i, j;
       this.balls = [];
 
-      // Cue ball (center poshte vijes se bardhe)
-      this.balls.push(new Ball(BALL_BY_N[0], TABLE_W/2, CUE_START_Y));
+      // Cue ball (posicionuar pak majtas)
+      this.balls.push(new Ball(BALL_BY_N[0], CUE_START_X, CUE_START_Y));
       cueBallFree = true;
       aiming = false;
       cueHintTime = Date.now();
@@ -594,8 +597,6 @@
         b.p.y += b.v.y * dt;
         b.v.x *= FRICTION; b.v.y *= FRICTION;
         if (b.spin) {
-          b.v.x += b.spin.x * 40 * dt;
-          b.v.y += b.spin.y * 40 * dt;
           b.spin.x *= 0.98;
           b.spin.y *= 0.98;
         }
@@ -605,10 +606,18 @@
         var R = TABLE_W - BORDER - BALL_R;
         var T = BORDER_TOP + BALL_R;
         var B = TABLE_H - BORDER_BOTTOM - BALL_R;
-        if (b.p.x < L) { b.p.x = L; b.v.x *= -BOUNCE; }
-        if (b.p.x > R) { b.p.x = R; b.v.x *= -BOUNCE; }
-        if (b.p.y < T) { b.p.y = T; b.v.y *= -BOUNCE; }
-        if (b.p.y > B) { b.p.y = B; b.v.y *= -BOUNCE; }
+        if (b.p.x < L) {
+          b.p.x = L; b.v.x *= -BOUNCE; b.v.y += b.spin.x * 20;
+        }
+        if (b.p.x > R) {
+          b.p.x = R; b.v.x *= -BOUNCE; b.v.y -= b.spin.x * 20;
+        }
+        if (b.p.y < T) {
+          b.p.y = T; b.v.y *= -BOUNCE; b.v.x -= b.spin.y * 20;
+        }
+        if (b.p.y > B) {
+          b.p.y = B; b.v.y *= -BOUNCE; b.v.x += b.spin.y * 20;
+        }
       }
 
       // Perplasje ball-ball
@@ -625,6 +634,8 @@
             var imp = -vn;
             a.v.x -= imp*nx; a.v.y -= imp*ny; bb.v.x += imp*nx; bb.v.y += imp*ny;
             a.v.x *= BOUNCE; a.v.y *= BOUNCE; bb.v.x *= BOUNCE; bb.v.y *= BOUNCE;
+            a.v.x += a.spin.x * 20; a.v.y += a.spin.y * 20;
+            bb.v.x += bb.spin.x * 20; bb.v.y += bb.spin.y * 20;
             playBallHit(clamp(imp/4000,0,1));
           }
         }
@@ -644,7 +655,7 @@
               cueBallFree = true;
               aiming = false;
               cueHintTime = Date.now();
-              b2.p.x = TABLE_W/2; b2.p.y = CUE_START_Y; b2.v.x = 0; b2.v.y = 0;
+              b2.p.x = CUE_START_X; b2.p.y = CUE_START_Y; b2.v.x = 0; b2.v.y = 0;
             } else {
               b2.pocketed = true;
               pocketedAny = true;
@@ -935,10 +946,14 @@
 
       if (target){
         ctx.fillStyle = 'rgba(255,255,255,1)';
+        var n = norm(target.p.x - cue.p.x, target.p.y - cue.p.y);
+        var v = dir;
+        var dot = v.x*n.x + v.y*n.y;
+        var r = { x:v.x - 2*dot*n.x, y:v.y - 2*dot*n.y };
         var x2 = target.p.x, y2 = target.p.y;
         for (var k=0;k<dots;k++){
           ctx.beginPath(); ctx.arc(x2*sX, y2*sY, clamp(1.2+power*2,1,3.5), 0, Math.PI*2); ctx.fill();
-          x2 += dir.x * step; y2 += dir.y * step;
+          x2 += r.x * step; y2 += r.y * step;
           if (x2 < BORDER+BALL_R || x2 > TABLE_W-BORDER-BALL_R || y2 < BORDER_TOP+BALL_R || y2 > TABLE_H-BORDER_BOTTOM-BALL_R) break;
         }
       }


### PR DESCRIPTION
## Summary
- Shift cue ball start position and spin control for better alignment
- Refine pull handle placement and visibility
- Apply spin effects only on collision and fix guide reflection

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint` *(fails: 556 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4de408e848329ace44e16078ed13d