### PR TITLE
Refine Texas Hold'em betting interactions and layout

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -20,7 +20,7 @@
     }
     .stage{ position:relative; width:100vw; height:100vh; display:grid; place-items:center; perspective:1100px; }
     .stage::before{ content:""; position:absolute; top:0; bottom:0; left:1vw; right:1vw; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
-      .center{ position:absolute; left:50%; top:45%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.1; }
+      .center{ position:absolute; left:50%; top:48%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.1; }
       .seats{ position:absolute; inset:0; z-index:2 }
       .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px) }
       .seat.small{ --card-scale:.8; }
@@ -101,13 +101,13 @@
     #raisePanel .max-label{ position:absolute; top:4px; left:50%; transform:translateX(-50%); font-size:10px; color:#fff; animation:pulse 1.5s infinite; }
     @keyframes pulse{0%,100%{opacity:0.6}50%{opacity:1}}
     @keyframes shimmer{from{background-position:0 0}to{background-position:100px 0}}
-    #status{ position:absolute; top:60%; left:50%; transform:translate(-50%, -50%); font-weight:900; letter-spacing:.3px; color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
+    #status{ position:absolute; top:62%; left:50%; transform:translate(-50%, -50%); font-weight:900; letter-spacing:.3px; color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
     .top-controls{position:absolute;top:8px;right:8px;display:flex;flex-direction:column;gap:8px;z-index:10}
     .top-controls button{width:44px;height:44px;padding:0;border:2px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#2563eb;color:#fff;font-weight:600}
     .top-controls button img{width:24px;height:24px}
     .seat.vacant .vacant-seat{width:var(--avatar-size);height:var(--avatar-size);border-radius:50%;border:4px solid #000;background:#facc15;color:#16a34a;font-weight:700;display:flex;align-items:center;justify-content:center}
 
-    .pot-wrap{ position:absolute; left:50%; top:35%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
+    .pot-wrap{ position:absolute; left:50%; top:38%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
     .pot{ display:flex; gap:6px; }
     .pot-total{ font-size:12px; }
     .chip-pile{ position:relative; width:calc(var(--avatar-size)/2); height:calc(var(--avatar-size)/2); }
@@ -122,6 +122,8 @@
     .chip.v500{ background:#fb923c; }
     .chip.v1000{ background:#eab308; }
     .moving-pot{ position:absolute; transition:left .5s ease, top .5s ease; }
+    .bet-move{ position:absolute; transition:left .5s ease, top .5s ease; display:flex; flex-direction:column; align-items:center; z-index:1000; }
+    .bet-text{ font-size:10px; margin-top:2px; text-shadow:0 1px 2px #000; }
   </style>
 </head>
 <body>

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -299,6 +299,69 @@ function updatePotDisplay() {
   if (textEl) textEl.textContent = `Total: ${state.pot} ${state.token}`;
 }
 
+function createChipPile(amount) {
+  const pile = document.createElement('div');
+  pile.className = 'chip-pile';
+  let remaining = amount;
+  CHIP_VALUES.forEach((val) => {
+    const count = Math.floor(remaining / val);
+    if (count > 0) {
+      remaining -= count * val;
+      for (let i = 0; i < count; i++) {
+        const chip = document.createElement('div');
+        chip.className = 'chip v' + val;
+        chip.textContent = val;
+        chip.style.top = -i * 4 + 'px';
+        pile.appendChild(chip);
+      }
+    }
+  });
+  return pile;
+}
+
+function animateBet(idx, amount) {
+  return new Promise((resolve) => {
+    const stage = document.querySelector('.stage');
+    const avatar = document.getElementById('avatar-' + idx);
+    const potWrap = document.getElementById('potWrap');
+    if (!stage || !avatar || !potWrap) {
+      resolve();
+      return;
+    }
+    const stageRect = stage.getBoundingClientRect();
+    const avatarRect = avatar.getBoundingClientRect();
+    const potRect = potWrap.getBoundingClientRect();
+
+    const container = document.createElement('div');
+    container.className = 'bet-move';
+    container.style.left = avatarRect.right - stageRect.left + 'px';
+    container.style.top = avatarRect.top - stageRect.top + 'px';
+
+    const pile = createChipPile(amount);
+    container.appendChild(pile);
+    const text = document.createElement('div');
+    text.className = 'bet-text';
+    text.textContent = amount + ' ' + state.token;
+    container.appendChild(text);
+    stage.appendChild(container);
+
+    requestAnimationFrame(() => {
+      container.style.left = potRect.left - stageRect.left + 'px';
+      container.style.top = potRect.top - stageRect.top + 'px';
+    });
+
+    container.addEventListener(
+      'transitionend',
+      () => {
+        text.remove();
+        stage.removeChild(container);
+        resolve();
+      },
+      { once: true }
+    );
+  });
+}
+
 async function dealInitialCards() {
   for (let r = 0; r < 2; r++) {
     for (let i = 0; i < state.players.length; i++) {
@@ -360,13 +423,16 @@ function setPlayerTurnIndicator(idx) {
 function showControls() {
   const controls = document.getElementById('controls');
   controls.innerHTML = '';
-  const baseActions = [{ id: 'fold', fn: playerFold }];
-  if (state.currentBet === 0) baseActions.push({ id: 'check', fn: playerCheck });
-  baseActions.push({ id: 'call', fn: playerCall });
+  const baseActions = [
+    { id: 'fold', fn: playerFold },
+    { id: 'check', fn: playerCheck, disabled: state.currentBet > 0 },
+    { id: 'call', fn: playerCall, disabled: state.currentBet === 0 }
+  ];
   baseActions.forEach((a) => {
     const btn = document.createElement('button');
     btn.id = a.id;
     btn.textContent = a.id;
+    if (a.disabled) btn.disabled = true;
     btn.addEventListener('click', a.fn);
     controls.appendChild(btn);
   });
@@ -487,20 +553,23 @@ function playerCheck() {
   proceedStage();
 }
 
-function playerCall() {
-  state.pot += state.currentBet;
+async function playerCall() {
+  const amount = state.currentBet;
+  await animateBet(0, amount);
+  state.pot += amount;
   updatePotDisplay();
   setActionText(0, 'call');
-  document.getElementById('status').textContent = `You call ${state.currentBet} ${state.token}`;
+  document.getElementById('status').textContent = `You call ${amount} ${state.token}`;
   if (state.pot >= state.maxPot) playAllInSound();
   else playCallRaiseSound();
   proceedStage();
 }
 
-function playerRaise() {
+async function playerRaise() {
   const maxAllowed = Math.min(state.stake, state.maxPot - state.pot);
   const amount = Math.min(state.raiseAmount, maxAllowed);
   if (amount <= 0) return;
+  await animateBet(0, amount);
   state.pot += amount;
   state.currentBet += amount;
   updatePotDisplay();
@@ -519,6 +588,7 @@ async function proceedStage() {
     const p = state.players[i];
     if (p.vacant || !p.active) continue;
     setPlayerTurnIndicator(i);
+    playKnockSound();
     document.getElementById('status').textContent = `${p.name}...`;
     await new Promise((r) => setTimeout(r, 2500));
     let action = aiChooseAction(
@@ -530,6 +600,7 @@ async function proceedStage() {
     if (action === 'raise') {
       const raiseBy = ANTE;
       const total = state.currentBet + raiseBy;
+      await animateBet(i, total);
       state.currentBet = total;
       state.pot += total;
       updatePotDisplay();
@@ -537,9 +608,11 @@ async function proceedStage() {
       if (state.pot >= state.maxPot) playAllInSound();
       else playCallRaiseSound();
     } else if (action === 'call') {
-      state.pot += state.currentBet;
+      const amount = state.currentBet;
+      await animateBet(i, amount);
+      state.pot += amount;
       updatePotDisplay();
-      document.getElementById('status').textContent = `${p.name} calls ${state.currentBet} ${state.token}`;
+      document.getElementById('status').textContent = `${p.name} calls ${amount} ${state.token}`;
       if (state.pot >= state.maxPot) playAllInSound();
       else playCallRaiseSound();
     } else if (action === 'fold') {


### PR DESCRIPTION
## Summary
- Disable Check when bets exist and disable Call when there are none
- Animate player chip bets to the pot and play turn sound for all players
- Reposition community cards, pot and status text for improved layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4e13c96048329b4b425cea2d285a3