### PR TITLE
Adjust Texas Hold'em layout and positioning

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -20,7 +20,7 @@
     }
     .stage{ position:relative; width:100vw; height:100vh; display:grid; place-items:center; perspective:1100px; }
     .stage::before{ content:""; position:absolute; top:0; bottom:0; left:1vw; right:1vw; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
-      .center{ position:absolute; left:50%; top:45%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.1; }
+      .center{ position:absolute; left:50%; top:48%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.1; }
       .seats{ position:absolute; inset:0; z-index:2 }
       .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px) }
       .seat.small{ --card-scale:.8; }
@@ -68,6 +68,11 @@
 .seat.bottom-left { left: 16%; top: 63%; transform: translate(-50%, -50%); --card-scale: .85; }
 
     .seat.bottom-right { left: 84%; top: 63%; transform: translate(-50%, -50%); }
+    .seat:not(.bottom){ border:2px solid rgba(255,255,255,0.3); border-radius:12px; padding:4px; }
+    .seat:not(.bottom) .avatar{ box-shadow:0 0 0 2px rgba(255,255,255,0.4); }
+    .seat:not(.bottom) .name{ padding:2px 6px; border:1px solid rgba(255,255,255,0.4); border-radius:6px; }
+    .seat:not(.bottom) .cards{ padding:4px; border:1px solid rgba(255,255,255,0.4); border-radius:8px; }
+    .seat:not(.bottom) .card{ border:1px solid rgba(255,255,255,0.4); }
       .seat.bottom .cards{ gap:0 }
       .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
     .controls{ display:flex; gap:8px; margin-top:8px; align-items:flex-end; position:relative; justify-content:center; z-index:5; }
@@ -101,13 +106,13 @@
     #raisePanel .max-label{ position:absolute; top:4px; left:50%; transform:translateX(-50%); font-size:10px; color:#fff; animation:pulse 1.5s infinite; }
     @keyframes pulse{0%,100%{opacity:0.6}50%{opacity:1}}
     @keyframes shimmer{from{background-position:0 0}to{background-position:100px 0}}
-    #status{ position:absolute; top:60%; left:50%; transform:translate(-50%, -50%); font-weight:900; letter-spacing:.3px; color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
+    #status{ position:absolute; top:55%; left:50%; transform:translate(-50%, -50%); font-weight:900; letter-spacing:.3px; color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
     .top-controls{position:absolute;top:8px;right:8px;display:flex;flex-direction:column;gap:8px;z-index:10}
     .top-controls button{width:44px;height:44px;padding:0;border:2px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#2563eb;color:#fff;font-weight:600}
     .top-controls button img{width:24px;height:24px}
     .seat.vacant .vacant-seat{width:var(--avatar-size);height:var(--avatar-size);border-radius:50%;border:4px solid #000;background:#facc15;color:#16a34a;font-weight:700;display:flex;align-items:center;justify-content:center}
 
-    .pot-wrap{ position:absolute; left:50%; top:35%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
+    .pot-wrap{ position:absolute; left:50%; top:38%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
     .pot{ display:flex; gap:6px; }
     .pot-total{ font-size:12px; }
     .chip-pile{ position:relative; width:calc(var(--avatar-size)/2); height:calc(var(--avatar-size)/2); }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -230,8 +230,8 @@ function renderSeats() {
       const timer = document.createElement('div');
       timer.className = 'timer';
       timer.id = 'timer-' + i;
-      if (positions[i] === 'top') seat.append(name, avatar, cards, action, timer);
-      else seat.append(avatar, cards, action, name, timer);
+      if (positions[i] === 'top') seat.append(avatar, name, cards, action, timer);
+      else seat.append(avatar, name, cards, action, timer);
     }
     seats.appendChild(seat);
   });


### PR DESCRIPTION
## Summary
- Place player names between avatars and cards for non-bottom seats
- Add frames around non-bottom players, avatars, names, and cards
- Shift community cards, pot, and status text down for improved spacing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a54d458d48832981ba1ef0451ce8fb