### PR TITLE
Adjust Pool Royale cue rotation and control positions

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -141,7 +141,7 @@
       background: #f6f6f6;
       position: absolute;
       left: 50%;
-      top: 84%;
+      top: 86%;
       transform: translate(-50%, -50%);
       box-shadow: 0 4px 10px rgba(0,0,0,.4) inset,
                   0 0 0 2px rgba(0,0,0,.15);
@@ -171,7 +171,7 @@
       align-items: center;
       justify-content: center;
       padding: 8px;
-      transform: translate(12px, 40px);
+      transform: translate(16px, 48px);
     }
 
     #cueRail {
@@ -954,7 +954,7 @@
         y: cuePos.y + (BALL_R * 1.2 + pull)
       };
       var length = BALL_R * 20;
-      var angle = Math.PI / 2;
+      var angle = Math.PI;
       if (cueImg.complete) {
         var scale = (length * sX) / cueImg.width;
         var drawW = cueImg.width * scale;


### PR DESCRIPTION
## Summary
- Rotate cue graphic left for Pool Royale
- Lower spin control slightly
- Nudge pull slider further down and to the right

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*

------
https://chatgpt.com/codex/tasks/task_e_68a5586cf4cc83299262a0dd703b4f87