### PR TITLE
Align cue image with guideline

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -951,17 +951,18 @@
     function drawCueOnTable(cuePos, aim, pull){
       var start = {
         x: cuePos.x,
-        y: cuePos.y + (BALL_R * 1.2 + pull)
+        // Move the cue further down while staying aligned with the guideline
+        y: cuePos.y + (BALL_R * 5 + pull)
       };
       var length = BALL_R * 20;
-      var angle = Math.PI;
       if (cueImg.complete) {
         var scale = (length * sX) / cueImg.width;
         var drawW = cueImg.width * scale;
         var drawH = cueImg.height * scale;
         ctx.save();
         ctx.translate(start.x * sX, start.y * sY);
-        ctx.rotate(angle);
+        // Flip vertically so the top becomes the bottom and vice versa
+        ctx.scale(1, -1);
         ctx.drawImage(cueImg, -drawW / 2, -drawH / 2, drawW, drawH);
         ctx.restore();
       }


### PR DESCRIPTION
## Summary
- Flip Pool Royale cue image vertically and shift it downward to maintain alignment with the guide line

## Testing
- `npm test`
- `npm run lint` *(fails: 556 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a56050c370832999ad79ea3f86ccc0