### PR TITLE
style: enhance poker seat visuals

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -68,9 +68,28 @@
     .seat.bottom-left { left: 16%; top: 65%; transform: translate(-50%, -50%); --card-scale: .85; }
 
     .seat.bottom-right { left: 84%; top: 65%; transform: translate(-50%, -50%); }
-    .seat-inner{ display:flex; flex-direction:column; align-items:center; gap:6px; border:2px solid rgba(255,255,255,0.3); border-radius:12px; padding:4px; }
+    .seat-inner{
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      gap:6px;
+      border:2px solid rgba(255,255,255,0.3);
+      border-radius:12px;
+      padding:4px;
+      background:rgba(0,0,0,0.1);
+      box-shadow:0 4px 8px var(--shadow);
+    }
     .seat-inner .avatar{ box-shadow:0 0 0 2px rgba(255,255,255,0.4); }
-    .seat-inner .name{ padding:2px 6px; border:1px solid rgba(255,255,255,0.4); border-radius:6px; }
+    .seat-inner .name{
+      padding:2px 6px;
+      border:1px solid rgba(255,255,255,0.4);
+      border-radius:6px;
+      font-size:12px;
+      max-width:100%;
+      white-space:nowrap;
+      overflow:hidden;
+      text-align:center;
+    }
     .seat-inner .cards{ padding:4px; border:1px solid rgba(255,255,255,0.4); border-radius:8px; }
     .seat-inner .card{ border:1px solid rgba(255,255,255,0.4); }
       .seat.bottom .cards{ gap:0 }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -178,6 +178,15 @@ function init() {
   dealInitialCards();
 }
 
+function adjustNameSize(el) {
+  const base = 12;
+  const min = 8;
+  const len = el.textContent.length;
+  if (len > 10) {
+    el.style.fontSize = Math.max(min, base - (len - 10)) + 'px';
+  }
+}
+
 function renderSeats() {
   const seats = document.getElementById('seats');
   seats.innerHTML = '';
@@ -215,6 +224,7 @@ function renderSeats() {
     const name = document.createElement('div');
     name.className = 'name';
     name.textContent = p.name;
+    adjustNameSize(name);
     if (i === 0) {
       const wrap = document.createElement('div');
       wrap.className = 'avatar-wrap';


### PR DESCRIPTION
## Summary
- add subtle shadow background to player frames
- shrink player name font size to fit long names

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5927692dc8329a124e58db97e3d3e