### PR TITLE
Align cue with guideline in Pool Royale

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -950,18 +950,27 @@
     }
 
     function drawCueOnTable(cuePos, aim, pull){
-      var start = {
-        x: cuePos.x,
-        y: cuePos.y + (BALL_R * 2.2 + pull)
+      // Align the cue with the guideline and keep the tip pointing toward the cue ball
+      var dx = aim.x - cuePos.x, dy = aim.y - cuePos.y;
+      var len = Math.hypot(dx, dy) || 1;
+      var dir = { x: dx / len, y: dy / len };
+
+      // Position the cue so its tip touches the cue ball
+      var offset = BALL_R * 2.2 + pull;
+      var center = {
+        x: cuePos.x - dir.x * offset,
+        y: cuePos.y - dir.y * offset
       };
+
       var length = BALL_R * 20;
       if (cueImg.complete) {
         var scale = (length * sX) / cueImg.width;
         var drawW = cueImg.width * scale;
         var drawH = cueImg.height * scale;
+
         ctx.save();
-        ctx.translate(start.x * sX, start.y * sY);
-        ctx.scale(1, -1);
+        ctx.translate(center.x * sX, center.y * sY);
+        ctx.rotate(Math.atan2(dir.y, dir.x) + Math.PI / 2);
         ctx.drawImage(cueImg, -drawW / 2, -drawH / 2, drawW, drawH);
         ctx.restore();
       }


### PR DESCRIPTION
## Summary
- Rotate and position cue image so it's always straight and aligned with the guideline

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint` *(fails: spacing and semicolon errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5912a63548329aefaa9a3dc10b96a