### PR TITLE
Fix bottom player card positioning in Texas Hold'em

### DIFF
--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -234,11 +234,12 @@ function renderSeats() {
       wrap.append(ring, avatar);
       const inner = document.createElement('div');
       inner.className = 'seat-inner';
-      inner.append(wrap, name, cards);
+      // Move action text above the player's cards so the cards sit directly above the controls
+      inner.append(wrap, name, action, cards);
       const controls = document.createElement('div');
       controls.className = 'controls';
       controls.id = 'controls';
-      seat.append(inner, action, controls);
+      seat.append(inner, controls);
     } else {
       const timer = document.createElement('div');
       timer.className = 'timer';


### PR DESCRIPTION
## Summary
- Reordered elements for the bottom player's seat so action text sits above the cards
- Ensures player's cards render directly above the control buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a59c6e31988329b18a13960537b890