### PR TITLE
fix: reposition Texas Hold'em bottom player

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -101,6 +101,10 @@
       #call{ background:#16a34a; }
       #fold{ background:#dc2626; }
       .raise-container{
+        position:absolute;
+        bottom:0.5%;
+        right:2%;
+        z-index:5;
         display:flex;
         flex-direction:column;
         align-items:center;

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -435,6 +435,7 @@ function showControls() {
 
   const raiseContainer = document.createElement('div');
   raiseContainer.className = 'raise-container';
+  raiseContainer.id = 'raiseContainer';
   const panel = document.createElement('div');
   panel.id = 'raisePanel';
   panel.innerHTML =
@@ -455,7 +456,8 @@ function showControls() {
 
   controls.append(foldBtn, callBtn);
   if (checkBtn) controls.appendChild(checkBtn);
-  controls.appendChild(raiseContainer);
+  const stage = document.querySelector('.stage');
+  if (stage) stage.appendChild(raiseContainer);
 
   initRaiseSlider();
 }
@@ -494,6 +496,8 @@ function initRaiseSlider() {
 function hideControls() {
   const controls = document.getElementById('controls');
   if (controls) controls.innerHTML = '';
+  const raiseContainer = document.getElementById('raiseContainer');
+  if (raiseContainer) raiseContainer.remove();
 }
 
 function startPlayerTurn() {


### PR DESCRIPTION
## Summary
- position raise controls independently so bottom player sits above call/check/fold
- anchor raise control panel to bottom-right of stage

## Testing
- `npm test` *(fails: ERR_DLOPEN_FAILED, snake API endpoints and socket events timed out)*
- `npm run lint` *(fails: 556 errors, Operator '>' must be spaced, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a5a585da708329b3ae2ff951bcbacd