### PR TITLE
feat(pool): improve guideline rendering

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -937,7 +937,47 @@
         ctx.beginPath(); ctx.arc(x*sX, y*sY, clamp(1.5+power*2.2, 1.5, 4), 0, Math.PI*2); ctx.fill();
       }
 
-      // Removed the secondary guideline that extended from the target ball.
+      if (target) {
+        var tx = target.p.x, ty = target.p.y;
+        var tMax = Infinity;
+        if (dir.x > 0) tMax = Math.min(tMax, (TABLE_W - BORDER - BALL_R - tx) / dir.x);
+        if (dir.x < 0) tMax = Math.min(tMax, (BORDER + BALL_R - tx) / dir.x);
+        if (dir.y > 0) tMax = Math.min(tMax, (TABLE_H - BORDER_BOTTOM - BALL_R - ty) / dir.y);
+        if (dir.y < 0) tMax = Math.min(tMax, (BORDER_TOP + BALL_R - ty) / dir.y);
+        var ex = tx + dir.x * tMax;
+        var ey = ty + dir.y * tMax;
+
+        ctx.save();
+        ctx.strokeStyle = 'rgba(255,255,255,.3)';
+        ctx.lineWidth = clamp(1.5+power*1.5, 1.5, 3);
+        ctx.beginPath();
+        ctx.moveTo(tx*sX, ty*sY);
+        ctx.lineTo(ex*sX, ey*sY);
+        ctx.stroke();
+        ctx.restore();
+
+        var hitN = { x: tx - cue.p.x, y: ty - cue.p.y };
+        var nL = len(hitN.x, hitN.y) || 1;
+        hitN.x /= nL; hitN.y /= nL;
+        var dot = dir.x*hitN.x + dir.y*hitN.y;
+        var cbDir = { x: dir.x - hitN.x * dot, y: dir.y - hitN.y * dot };
+        var cbL = len(cbDir.x, cbDir.y);
+        if (cbL > 0.0001) {
+          cbDir.x /= cbL; cbDir.y /= cbL;
+          var impactX = tx - hitN.x * BALL_R * 2;
+          var impactY = ty - hitN.y * BALL_R * 2;
+          var cbEndX = impactX + cbDir.x * BALL_R * 4;
+          var cbEndY = impactY + cbDir.y * BALL_R * 4;
+          ctx.save();
+          ctx.strokeStyle = 'rgba(255,255,255,.5)';
+          ctx.lineWidth = clamp(1.5+power*1.5, 1.5, 3);
+          ctx.beginPath();
+          ctx.moveTo(impactX*sX, impactY*sY);
+          ctx.lineTo(cbEndX*sX, cbEndY*sY);
+          ctx.stroke();
+          ctx.restore();
+        }
+      }
     }
 
     function drawCueOnTable(cuePos, aim, pull){


### PR DESCRIPTION
## Summary
- extend aiming guideline from target ball toward pocket
- show brief cue ball deflection line after impact

## Testing
- `npm test` *(fails: ERR_DLOPEN_FAILED in canvas bindings; snake API test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b4c46b2c8329a7f6f0208f2bc325