### PR TITLE
fix(pool-royale): restore pull slider position

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -174,7 +174,7 @@
       padding: 8px;
       /* Shift slightly right and allow the handle to overflow so
          only half of it is visible */
-      transform: translate(-20px, 48px);
+      transform: translate(20px, 48px);
       overflow: visible;
     }
 
@@ -192,7 +192,7 @@
     #pullHandle {
       position: absolute;
       /* Position the pull button so that it's half outside the panel */
-      left: 0;
+      left: 100%;
       transform: translateX(-50%);
       width: 45px;
       height: 45px;


### PR DESCRIPTION
## Summary
- move Pool Royale pull slider back to its original right-aligned spot for visibility

## Testing
- `npm test` *(fails: testTimeoutFailure in snake API endpoints and socket events)*
- `npm run lint` *(fails: 556 problems in lib/texasHoldem.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c5d1342c8329a71f0a6999a45c01