### PR TITLE
feat: add chip selector for raises

### DIFF
--- a/webapp/public/falling-ball-api.js
+++ b/webapp/public/falling-ball-api.js
@@ -44,6 +44,9 @@
       }
       return res;
     },
+    getAccountBalance(accountId) {
+      return post('/api/account/balance', { accountId });
+    },
     addTransaction(telegramId, amount, type, extra = {}) {
       const body = { amount, type, ...extra };
       if (telegramId != null) body.telegramId = telegramId;

--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -103,7 +103,7 @@
       .raise-container{
         position:absolute;
         bottom:0.5%;
-        right:2%;
+        left:2%;
         z-index:5;
         display:flex;
         flex-direction:column;
@@ -116,16 +116,11 @@
       }
     #raise{ padding:0; font-size:14px; border-radius:50%; }
     .raise-amount{ font-size:10px; margin-top:2px; }
-    #raisePanel{ position:relative; width:clamp(44px,5vw,88px); height:18vh; padding:12px; border-radius:14px; background:rgba(255,255,255,0.02); overflow:hidden; }
-    #raisePanel::before{ content:""; position:absolute; left:50%; top:14px; bottom:14px; width:1px; background:rgba(230,237,247,0.2); }
-    #raiseFill{ position:absolute; left:12px; right:12px; bottom:12px; height:0%; border-radius:8px; background:rgba(255,255,255,0.2); box-shadow:inset 0 -1px 0 rgba(0,0,0,0.2); }
-    #raiseFill::after{ content:""; position:absolute; top:0; left:0; right:0; height:2px; background:rgba(255,255,255,0.2); }
-    #raiseThumb{ position:absolute; left:50%; transform:translate(-50%,50%); bottom:12px; width:28px; height:28px; border-radius:50%; background:#ffffff; border:4px solid #0b1224; box-shadow:0 2px 8px rgba(0,0,0,0.45); touch-action:none; }
-    #raiseThumb::before{ content:""; position:absolute; inset:2px; border-radius:50%; background:radial-gradient(circle at 30% 30%,#ffffff,#d1d5db); }
-    #raisePanel .max-zone{ position:absolute; top:0; left:12px; right:12px; height:15%; background:rgba(255,255,255,0.08); animation:shimmer 2s linear infinite; pointer-events:none; }
-    #raisePanel .max-label{ position:absolute; top:4px; left:50%; transform:translateX(-50%); font-size:10px; color:#fff; animation:pulse 1.5s infinite; }
-    @keyframes pulse{0%,100%{opacity:0.6}50%{opacity:1}}
-    @keyframes shimmer{from{background-position:0 0}to{background-position:100px 0}}
+    .chip-grid{ display:grid; grid-template-columns:repeat(3,1fr); gap:4px; }
+    .raise-container .chip{ position:static; left:auto; top:auto; cursor:pointer; border:2px solid transparent; }
+    .raise-container .chip.selected{ border-color:#0ea5e9; }
+    .tpc-total{ font-size:12px; display:flex; align-items:center; gap:4px; }
+    .tpc-total img{ width:16px; height:16px; }
     #status{ position:absolute; top:43%; left:50%; transform:translate(-50%, -50%); z-index:2; font-weight:900; letter-spacing:.3px; color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
     .top-controls{position:absolute;top:8px;right:8px;display:flex;flex-direction:column;gap:8px;z-index:10}
     .top-controls button{width:44px;height:44px;padding:0;border:2px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#2563eb;color:#fff;font-weight:600}


### PR DESCRIPTION
## Summary
- show 3x3 chip selector at bottom left for raising
- display total TPC balance beneath chips
- expose account balance API helper for chip selector

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint` *(fails: 556 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c870ec5083298bfec4c2f7cdd3f5