### PR TITLE
feat: move raise slider to bottom right

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -114,6 +114,20 @@
         border-radius:16px;
         background:rgba(0,0,0,0.2);
       }
+      .slider-container{
+        position:absolute;
+        bottom:0.5%;
+        right:2%;
+        z-index:5;
+        display:flex;
+        flex-direction:column;
+        align-items:center;
+        gap:8px;
+        padding:8px;
+        border:2px solid rgba(255,255,255,0.2);
+        border-radius:16px;
+        background:rgba(0,0,0,0.2);
+      }
     #raise{ padding:0; font-size:14px; border-radius:50%; }
     .raise-btn{ width:var(--avatar-size); height:var(--avatar-size); padding:0; border:4px solid #000; border-radius:50%; background:#2563eb; color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
     .raise-amount{ font-size:10px; margin-top:2px; }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -444,11 +444,13 @@ function showControls() {
     controls.append(foldBtn, callBtn, checkBtn);
   }
 
-  let raiseContainer = document.getElementById('raiseContainer');
-  if (!raiseContainer) {
-    raiseContainer = document.createElement('div');
-    raiseContainer.className = 'raise-container';
-    raiseContainer.id = 'raiseContainer';
+  const stage = document.querySelector('.stage');
+
+  let sliderContainer = document.getElementById('sliderContainer');
+  if (!sliderContainer) {
+    sliderContainer = document.createElement('div');
+    sliderContainer.className = 'slider-container';
+    sliderContainer.id = 'sliderContainer';
 
     const sliderWrap = document.createElement('div');
     sliderWrap.className = 'slider-wrap';
@@ -468,7 +470,8 @@ function showControls() {
       if (amt) amt.textContent = `${slider.value} ${state.token}`;
       const status = document.getElementById('status');
       if (status)
-        status.textContent = slider.value > 0 ? `Raise ${slider.value} ${state.token}` : '';
+        status.textContent =
+          slider.value > 0 ? `Raise ${slider.value} ${state.token}` : '';
     });
     sliderWrap.appendChild(slider);
 
@@ -494,7 +497,16 @@ function showControls() {
       playerRaise(max);
     });
 
-    raiseContainer.appendChild(sliderWrap);
+    sliderContainer.appendChild(sliderWrap);
+
+    if (stage) stage.appendChild(sliderContainer);
+  }
+
+  let raiseContainer = document.getElementById('raiseContainer');
+  if (!raiseContainer) {
+    raiseContainer = document.createElement('div');
+    raiseContainer.className = 'raise-container';
+    raiseContainer.id = 'raiseContainer';
 
     const grid = document.createElement('div');
     grid.className = 'chip-grid';
@@ -532,7 +544,6 @@ function showControls() {
     amountText.textContent = `0 ${state.token}`;
     raiseContainer.appendChild(amountText);
 
-    const stage = document.querySelector('.stage');
     if (stage) stage.appendChild(raiseContainer);
   }
 


### PR DESCRIPTION
## Summary
- place raise slider and All-in control in a new bottom-right panel
- keep chip selection and raise button on the left

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a5d8d3d5a08329a02f5d6211ed59b0