### PR TITLE
fix: ensure pull handle overlays background

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -186,6 +186,7 @@
          only half of it is visible */
       transform: translate(20px, 48px);
       overflow: visible;
+      z-index: 7;
     }
 
     #cueRail {
@@ -217,6 +218,7 @@
       user-select: none;
       opacity: 1;
       visibility: visible;
+      z-index: 8;
     }
 
     #powerBox {


### PR DESCRIPTION
## Summary
- ensure Pool Royale "PULL" handle overlays background by adding z-index

## Testing
- `npm test` *(fails: The module '/workspace/TonPlaygramWebApp/bot/node_modules/canvas/build/Release/canvas.node' was compiled against a different Node.js version)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d80394a48329bf77a912396f9ad9