### PR TITLE
Refine Texas Hold'em raise controls layout

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -100,40 +100,39 @@
       #check{ background:#facc15; }
       #call{ background:#16a34a; }
       #fold{ background:#dc2626; }
-      .raise-container{
-        position:absolute;
-        bottom:0.5%;
-        left:2%;
-        z-index:5;
-        display:flex;
-        flex-direction:column;
-        align-items:center;
-        gap:8px;
-        padding:8px;
-        border:2px solid rgba(255,255,255,0.2);
-        border-radius:16px;
-        background:rgba(0,0,0,0.2);
-      }
-      .slider-container{
-        position:absolute;
-        bottom:0.5%;
-        right:2%;
-        z-index:5;
-        display:flex;
-        flex-direction:column;
-        align-items:center;
-        gap:8px;
-        padding:8px;
-        border:2px solid rgba(255,255,255,0.2);
-        border-radius:16px;
-        background:rgba(0,0,0,0.2);
-      }
-    #raise{ padding:0; font-size:14px; border-radius:50%; }
+        .raise-container{
+          position:absolute;
+          bottom:0;
+          left:2%;
+          z-index:5;
+          display:flex;
+          flex-direction:column;
+          align-items:center;
+          gap:8px;
+          padding:0;
+          border:none;
+          border-radius:0;
+          background:none;
+        }
+        .slider-container{
+          position:absolute;
+          bottom:0.5%;
+          right:1%;
+          z-index:5;
+          display:flex;
+          flex-direction:column;
+          align-items:center;
+          gap:8px;
+          padding:0;
+          border:none;
+          border-radius:0;
+          background:none;
+        }
     .raise-btn{ width:var(--avatar-size); height:var(--avatar-size); padding:0; border:4px solid #000; border-radius:50%; background:#2563eb; color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
     .raise-amount{ font-size:10px; margin-top:2px; }
     .chip-grid{ display:grid; grid-template-columns:repeat(3,1fr); gap:4px; }
-    .raise-container .chip{ position:static; left:auto; top:auto; cursor:pointer; border:2px solid transparent; }
-    .raise-container .chip.selected{ border-color:#0ea5e9; }
+      .raise-container .chip{ position:static; left:auto; top:auto; cursor:pointer; border:2px solid transparent; width:calc(var(--avatar-size)/1.8); height:calc(var(--avatar-size)/1.8); }
+      .raise-container .chip.selected{ border-color:#0ea5e9; }
     .slider-wrap{ width:100%; display:flex; flex-direction:column; align-items:center; gap:4px; }
     .slider-wrap input[type=range]{ width:100%; }
     #allIn{ background:#dc2626; padding:2px 8px; border:2px solid #000; border-radius:8px; font-weight:600; font-size:12px; }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -479,9 +479,11 @@ function showControls() {
     sliderRaise.id = 'sliderRaise';
     sliderRaise.textContent = 'raise';
     sliderRaise.className = 'raise-btn';
-    sliderRaise.addEventListener('click', () =>
-      playerRaise(parseInt(slider.value, 10))
-    );
+    sliderRaise.addEventListener('click', () => {
+      const sliderVal = parseInt(slider.value, 10);
+      const amount = state.raiseAmount > 0 ? state.raiseAmount : sliderVal;
+      playerRaise(amount);
+    });
     sliderWrap.appendChild(sliderRaise);
 
     const sliderAmt = document.createElement('div');
@@ -531,12 +533,6 @@ function showControls() {
       'Total: <span id="tpcTotal">0</span> <img src="assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" />';
     raiseContainer.appendChild(totalDiv);
 
-    const raiseBtn = document.createElement('button');
-    raiseBtn.textContent = 'raise';
-    raiseBtn.id = 'raise';
-    raiseBtn.className = 'raise-btn';
-    raiseBtn.addEventListener('click', () => playerRaise());
-    raiseContainer.appendChild(raiseBtn);
 
     const amountText = document.createElement('div');
     amountText.id = 'raiseAmountText';
@@ -560,7 +556,7 @@ function showControls() {
     if (amt) amt.textContent = `0 ${state.token}`;
   }
 
-  ['fold', 'call', 'check', 'raise', 'sliderRaise', 'allIn'].forEach((id) => {
+  ['fold', 'call', 'check', 'sliderRaise', 'allIn'].forEach((id) => {
     const el = document.getElementById(id);
     if (el) el.disabled = false;
   });
@@ -573,7 +569,7 @@ function showControls() {
   if (checkBtn) checkBtn.disabled = state.currentBet > 0;
 
   const maxAllowed = Math.min(state.stake, state.maxPot - state.pot, state.tpcTotal);
-  ['raise', 'sliderRaise', 'allIn'].forEach((id) => {
+  ['sliderRaise', 'allIn'].forEach((id) => {
     const el = document.getElementById(id);
     if (el) el.disabled = maxAllowed <= 0;
   });
@@ -606,7 +602,7 @@ function updateSliderRange() {
   const maxAllowed = Math.min(state.stake, state.maxPot - state.pot, state.tpcTotal);
   slider.max = Math.max(0, maxAllowed);
   const disable = maxAllowed <= 0;
-  ['raise', 'sliderRaise', 'allIn'].forEach((id) => {
+  ['sliderRaise', 'allIn'].forEach((id) => {
     const el = document.getElementById(id);
     if (el) el.disabled = disable;
   });
@@ -617,7 +613,7 @@ function updateSliderRange() {
 }
 
 function hideControls() {
-  ['fold', 'call', 'check', 'raise', 'sliderRaise', 'allIn'].forEach((id) => {
+  ['fold', 'call', 'check', 'sliderRaise', 'allIn'].forEach((id) => {
     const el = document.getElementById(id);
     if (el) el.disabled = true;
   });


### PR DESCRIPTION
## Summary
- Simplify raise controls by removing the extra raise button from the chip panel and routing chip selection through the main raise button.
- Reposition and restyle the raise slider and chip panels with no background or borders and slightly larger chips.

## Testing
- `npm test` *(fails: snake API test timed out)*
- `npm run lint` *(fails: numerous lint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a5dd96178c8329ad522820b5f45e4f