### PR TITLE
feat: add vertical power slider component

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Power Slider Demo</title>
+  <link rel="stylesheet" href="./power-slider.css">
+  <style>
+    body {
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 20px;
+      background: #222;
+      color: #fff;
+      font-family: sans-serif;
+    }
+    #controls { display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; }
+    button { padding: 4px 8px; }
+  </style>
+</head>
+<body>
+  <div id="power"></div>
+  <div id="readout">Power: 0%</div>
+  <div id="controls">
+    <button data-set="25">Set 25%</button>
+    <button data-set="50">Set 50%</button>
+    <button data-set="75">Set 75%</button>
+    <button data-set="100">Set 100%</button>
+    <button id="lock">Lock</button>
+    <button id="unlock" style="display:none;">Unlock</button>
+  </div>
+  <script type="module">
+    import { PowerSlider } from './power-slider.js';
+    const slider = new PowerSlider({
+      mount: document.getElementById('power'),
+      value: 60,
+      cueSrc: './assets/cue.png',
+      onChange: v => document.getElementById('readout').textContent = `Power: ${v}%`
+    });
+
+    document.querySelectorAll('[data-set]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        slider.set(parseInt(btn.dataset.set, 10), { animate: true });
+      });
+    });
+
+    document.getElementById('lock').addEventListener('click', () => {
+      slider.lock();
+      document.getElementById('lock').style.display = 'none';
+      document.getElementById('unlock').style.display = 'inline-block';
+    });
+    document.getElementById('unlock').addEventListener('click', () => {
+      slider.unlock();
+      document.getElementById('unlock').style.display = 'none';
+      document.getElementById('lock').style.display = 'inline-block';
+    });
+  </script>
+</body>
+</html>

--- a/power-slider.css
+++ b/power-slider.css
@@ -1,0 +1,158 @@
+/* Power Slider component styles */
+.ps {
+  --ps-width: 56px;
+  --ps-height: 480px;
+  --ps-radius: 28px;
+  --ps-track-bg: rgba(255,255,255,0.15);
+  --ps-gradient-low: #ffe066;
+  --ps-gradient-mid: #ff8c00;
+  --ps-gradient-high: #ff0033;
+  --ps-tick: rgba(0,0,0,0.35);
+  --ps-glow: rgba(255,0,0,0.6);
+  --ps-tooltip-bg: rgba(0,0,0,0.8);
+  --ps-tooltip-color: #fff;
+
+  position: relative;
+  width: var(--ps-width);
+  height: var(--ps-height);
+  border-radius: var(--ps-radius);
+  background: var(--ps-track-bg);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.25);
+  overflow: hidden;
+  user-select: none;
+  touch-action: none;
+}
+
+.ps-track {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    to top,
+    var(--ps-gradient-low) 0%,
+    var(--ps-gradient-mid) 50%,
+    var(--ps-gradient-high) 100%
+  );
+}
+
+/* left gloss */
+.ps-track::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 8px;
+  background: linear-gradient(to bottom, rgba(255,255,255,0.5), rgba(255,255,255,0));
+  pointer-events: none;
+}
+
+/* ticks */
+.ps-track::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 8px;
+  background:
+    repeating-linear-gradient(
+      to top,
+      transparent 0 calc(10% - 1px),
+      var(--ps-tick) calc(10% - 1px) 10%
+    ),
+    linear-gradient(to top,
+      transparent calc(25% - 1.5px),
+      var(--ps-tick) calc(25% - 1.5px) calc(25% + 1.5px),
+      transparent calc(25% + 1.5px)
+    ),
+    linear-gradient(to top,
+      transparent calc(50% - 1.5px),
+      var(--ps-tick) calc(50% - 1.5px) calc(50% + 1.5px),
+      transparent calc(50% + 1.5px)
+    ),
+    linear-gradient(to top,
+      transparent calc(75% - 1.5px),
+      var(--ps-tick) calc(75% - 1.5px) calc(75% + 1.5px),
+      transparent calc(75% + 1.5px)
+    ),
+    linear-gradient(to top,
+      transparent calc(100% - 3px),
+      var(--ps-tick) calc(100% - 3px) 100%
+    ),
+    linear-gradient(to top,
+      var(--ps-tick) 0 3px,
+      transparent 3px
+    );
+  pointer-events: none;
+}
+
+.ps-handle {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, 0);
+  transition: transform .15s ease;
+  width: 36px;
+  height: auto;
+  pointer-events: none;
+}
+
+.ps-tooltip {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, 0);
+  background: var(--ps-tooltip-bg);
+  color: var(--ps-tooltip-color);
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+  transform-origin: 50% 100%;
+  transition: transform .15s ease, opacity .15s ease;
+  pointer-events: none;
+}
+
+.ps-hot {
+  box-shadow: 0 0 12px var(--ps-glow), 0 4px 12px rgba(0,0,0,0.25);
+}
+
+.ps-no-animate .ps-handle,
+.ps-no-animate .ps-tooltip {
+  transition: none !important;
+}
+
+.ps-locked {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.ps-label {
+  position: absolute;
+  right: 100%;
+  margin-right: 4px;
+  font-size: 12px;
+  color: var(--ps-tooltip-color);
+  user-select: none;
+}
+
+.ps-label-0 { bottom: 0; transform: translateY(50%); }
+.ps-label-50 { top: 50%; transform: translateY(-50%); }
+.ps-label-100 { top: 0; transform: translateY(-50%); }
+
+.ps:focus-visible {
+  outline: 2px solid var(--ps-tooltip-color);
+  outline-offset: 2px;
+}
+
+.ps-theme-dark {
+  --ps-track-bg: rgba(0,0,0,0.5);
+  --ps-tick: rgba(255,255,255,0.4);
+  --ps-tooltip-bg: rgba(255,255,255,0.9);
+  --ps-tooltip-color: #000;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ps-handle, .ps-tooltip { transition: none !important; }
+}


### PR DESCRIPTION
## Summary
- add production-ready vertical PowerSlider class with mouse/touch/wheel/keyboard input and callbacks
- provide default and dark themes, ticks, tooltip and glow for high power
- include minimal demo page showing usage and controls

## Testing
- `npm test` *(fails: AssertionError in snake API endpoints and socket events)*
- `npm run lint` *(fails: 696 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e297b0ac83299ddbee893b653ec9