### PR TITLE
feat: enlarge raise chips and move total

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -110,6 +110,8 @@
           align-items:center;
           gap:8px;
           padding:0;
+          padding-top:4px;
+          padding-right:4px;
           border:none;
           border-radius:0;
           background:none;
@@ -131,7 +133,7 @@
     .raise-btn{ width:var(--avatar-size); height:var(--avatar-size); padding:0; border:4px solid #000; border-radius:50%; background:#2563eb; color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
     .raise-amount{ font-size:10px; margin-top:2px; }
     .chip-grid{ display:grid; grid-template-columns:repeat(3,1fr); gap:4px; }
-      .raise-container .chip{ position:static; left:auto; top:auto; cursor:pointer; border:2px solid transparent; width:calc(var(--avatar-size)/1.8); height:calc(var(--avatar-size)/1.8); }
+      .raise-container .chip{ position:static; left:auto; top:auto; cursor:pointer; border:2px solid transparent; width:calc(var(--avatar-size)/1.5); height:calc(var(--avatar-size)/1.5); }
       .raise-container .chip.selected{ border-color:#0ea5e9; }
     .slider-wrap{ width:100%; display:flex; flex-direction:column; align-items:center; gap:4px; }
     .slider-wrap input[type=range]{ width:100%; }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -527,18 +527,17 @@ function showControls() {
     });
     raiseContainer.appendChild(grid);
 
-    const totalDiv = document.createElement('div');
-    totalDiv.className = 'tpc-total';
-    totalDiv.innerHTML =
-      'Total: <span id="tpcTotal">0</span> <img src="assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" />';
-    raiseContainer.appendChild(totalDiv);
-
-
     const amountText = document.createElement('div');
     amountText.id = 'raiseAmountText';
     amountText.className = 'raise-amount';
     amountText.textContent = `0 ${state.token}`;
     raiseContainer.appendChild(amountText);
+
+    const totalDiv = document.createElement('div');
+    totalDiv.className = 'tpc-total';
+    totalDiv.innerHTML =
+      'Total: <span id="tpcTotal">0</span> <img src="assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" />';
+    raiseContainer.appendChild(totalDiv);
 
     if (stage) stage.appendChild(raiseContainer);
   }


### PR DESCRIPTION
## Summary
- enlarge the Texas Hold'em raise chips and add top/right padding so they expand upward and right
- reposition the total TPC balance below the selected raise amount

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint` *(fails: 696 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e3c9706c8329a25446e48ffba3a6