### PR TITLE
Ensure power slider visible in Pool Royale

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -142,7 +142,7 @@
       align-items: center;
       justify-content: space-between;
       padding: 12px 8px;
-      z-index: 6;
+      z-index: 10;
     }
 
     #spinBox {
@@ -222,12 +222,13 @@
     }
 
     #powerBox {
-      width: 50px;
+      width: 8px;
       height: 18%;
-      background: none;
-      border-radius: 16px;
+      background: rgba(0,0,0,.4);
+      border-radius: 8px;
       position: relative;
       overflow: hidden;
+      border: 2px solid #fff;
       box-shadow: none;
     }
 


### PR DESCRIPTION
## Summary
- Raise Pool Royale power slider above table background and style it as a narrow vertical bar on the right side

## Testing
- `npm test` *(fails: process hung)*
- `npm run lint` *(fails: 696 problems in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e75315688329ad33e9bc3d422517