### PR TITLE
Allow repeated chip selections for raises

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -134,7 +134,7 @@
     .raise-amount{ font-size:10px; margin-top:2px; }
     .chip-grid{ display:grid; grid-template-columns:repeat(3,1fr); gap:4px; }
       .raise-container .chip{ position:static; left:auto; top:auto; cursor:pointer; border:2px solid transparent; width:calc(var(--avatar-size)/1.5); height:calc(var(--avatar-size)/1.5); }
-      .raise-container .chip.selected{ border-color:#0ea5e9; }
+      .raise-container .chip:active{ border-color:#0ea5e9; }
     .slider-wrap{ width:100%; display:flex; flex-direction:column; align-items:center; gap:4px; }
     .slider-wrap input[type=range]{ width:100%; }
     #allIn{ background:#dc2626; padding:2px 8px; border:2px solid #000; border-radius:8px; font-weight:600; font-size:12px; }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -517,11 +517,15 @@ function showControls() {
       chip.className = 'chip v' + val;
       chip.dataset.value = val;
       chip.addEventListener('click', () => {
-        chip.classList.toggle('selected');
-        state.raiseAmount = Array.from(
-          grid.querySelectorAll('.chip.selected')
-        ).reduce((sum, c) => sum + parseInt(c.dataset.value, 10), 0);
-        updateRaiseAmount();
+        const maxAllowed = Math.min(
+          state.stake,
+          state.maxPot - state.pot,
+          state.tpcTotal
+        );
+        if (state.raiseAmount + val <= maxAllowed) {
+          state.raiseAmount += val;
+          updateRaiseAmount();
+        }
       });
       grid.appendChild(chip);
     });
@@ -542,9 +546,6 @@ function showControls() {
     if (stage) stage.appendChild(raiseContainer);
   }
 
-  document
-    .querySelectorAll('#raiseContainer .chip.selected')
-    .forEach((c) => c.classList.remove('selected'));
   state.raiseAmount = 0;
   updateRaiseAmount();
 
@@ -625,7 +626,6 @@ function hideControls() {
     .querySelectorAll('#raiseContainer .chip')
     .forEach((chip) => {
       chip.style.pointerEvents = 'none';
-      chip.classList.remove('selected');
     });
   state.raiseAmount = 0;
   updateRaiseAmount();


### PR DESCRIPTION
## Summary
- Let players increment raise amount by clicking the same chip multiple times
- Adjust chip UI style to use active highlight instead of single-selection

## Testing
- `npm test` (fails: process hung after starting server; most subtests passed)

------
https://chatgpt.com/codex/tasks/task_e_68a5ecbc07a4832982917ee78ba0614e