### PR TITLE
Adjust Texas Hold'em layout and chip controls

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -20,7 +20,7 @@
     }
     .stage{ position:relative; width:100vw; height:100vh; display:grid; place-items:center; perspective:1100px; }
     .stage::before{ content:""; position:absolute; top:0; bottom:0; left:1vw; right:1vw; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
-      .center{ position:absolute; left:50%; top:48%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.1; }
+      .center{ position:absolute; left:50%; top:43%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.1; }
       .seats{ position:absolute; inset:0; z-index:2 }
       .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px) }
       .seat.small{ --card-scale:.8; }
@@ -107,7 +107,8 @@
           z-index:5;
           display:flex;
           flex-direction:column;
-          align-items:center;
+          align-items:flex-start;
+          justify-content:flex-end;
           gap:8px;
           padding:0;
           padding-top:4px;
@@ -133,20 +134,22 @@
     .raise-btn{ width:var(--avatar-size); height:var(--avatar-size); padding:0; border:4px solid #000; border-radius:50%; background:#2563eb; color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
     .raise-amount{ font-size:10px; margin-top:2px; }
     .chip-grid{ display:grid; grid-template-columns:repeat(3,1fr); gap:4px; }
-      .raise-container .chip{ position:static; left:auto; top:auto; cursor:pointer; border:2px solid transparent; width:calc(var(--avatar-size)/1.5); height:calc(var(--avatar-size)/1.5); }
+      .raise-container .chip{ position:static; left:auto; top:auto; cursor:pointer; border:2px solid transparent; width:calc(var(--avatar-size)/1.35); height:calc(var(--avatar-size)/1.35); }
       .raise-container .chip:active{ border-color:#0ea5e9; }
+    .raise-info{ display:flex; align-items:center; gap:4px; }
+      .undo-chip{ width:calc(var(--avatar-size)/1.3); height:calc(var(--avatar-size)/1.3); border:2px solid #000; border-radius:4px; display:flex; align-items:center; justify-content:center; background:#facc15; color:#000; font-weight:700; cursor:pointer; }
     .slider-wrap{ width:100%; display:flex; flex-direction:column; align-items:center; gap:4px; }
     .slider-wrap input[type=range]{ width:100%; }
     #allIn{ background:#dc2626; padding:2px 8px; border:2px solid #000; border-radius:8px; font-weight:600; font-size:12px; }
     .tpc-total{ font-size:12px; display:flex; align-items:center; gap:4px; }
     .tpc-total img{ width:16px; height:16px; }
-    #status{ position:absolute; top:43%; left:50%; transform:translate(-50%, -50%); z-index:2; font-weight:900; letter-spacing:.3px; color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
+    #status{ position:absolute; top:38%; left:50%; transform:translate(-50%, -50%); z-index:2; font-weight:900; letter-spacing:.3px; color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
     .top-controls{position:absolute;top:8px;right:8px;display:flex;flex-direction:column;gap:8px;z-index:10}
     .top-controls button{width:44px;height:44px;padding:0;border:2px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#2563eb;color:#fff;font-weight:600}
     .top-controls button img{width:24px;height:24px}
     .seat.vacant .vacant-seat{width:var(--avatar-size);height:var(--avatar-size);border-radius:50%;border:4px solid #000;background:#facc15;color:#16a34a;font-weight:700;display:flex;align-items:center;justify-content:center}
 
-    .pot-wrap{ position:absolute; left:50%; top:38%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
+    .pot-wrap{ position:absolute; left:50%; top:33%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
     .pot{ display:flex; gap:6px; }
     .pot-total{ font-size:12px; }
     .chip-pile{ position:relative; width:calc(var(--avatar-size)/2); height:calc(var(--avatar-size)/2); }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -22,6 +22,7 @@ const state = {
   pot: 0,
   maxPot: 0,
   raiseAmount: 0,
+  selectedChips: [],
   tpcTotal: 0,
   seated: true,
 };
@@ -172,6 +173,7 @@ function init() {
   state.turn = 0;
   state.currentBet = 0;
   state.raiseAmount = 0;
+  state.selectedChips = [];
   state.pot = 0;
   state.maxPot = state.stake * state.players.filter((p) => p.active).length;
   const potEl = document.getElementById('pot');
@@ -523,6 +525,7 @@ function showControls() {
           state.tpcTotal
         );
         if (state.raiseAmount + val <= maxAllowed) {
+          state.selectedChips.push(val);
           state.raiseAmount += val;
           updateRaiseAmount();
         }
@@ -531,22 +534,41 @@ function showControls() {
     });
     raiseContainer.appendChild(grid);
 
+    const infoRow = document.createElement('div');
+    infoRow.className = 'raise-info';
+
+    const undoBtn = document.createElement('button');
+    undoBtn.id = 'undoChip';
+    undoBtn.className = 'undo-chip';
+    undoBtn.textContent = '⌫';
+    undoBtn.addEventListener('click', () => {
+      const removed = state.selectedChips.pop();
+      if (removed) {
+        state.raiseAmount = Math.max(0, state.raiseAmount - removed);
+        updateRaiseAmount();
+      }
+    });
+    infoRow.appendChild(undoBtn);
+
     const amountText = document.createElement('div');
     amountText.id = 'raiseAmountText';
     amountText.className = 'raise-amount';
     amountText.textContent = `0 ${state.token}`;
-    raiseContainer.appendChild(amountText);
+    infoRow.appendChild(amountText);
 
     const totalDiv = document.createElement('div');
     totalDiv.className = 'tpc-total';
     totalDiv.innerHTML =
       'Total: <span id="tpcTotal">0</span> <img src="assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" />';
-    raiseContainer.appendChild(totalDiv);
+    infoRow.appendChild(totalDiv);
+
+    raiseContainer.appendChild(infoRow);
 
     if (stage) stage.appendChild(raiseContainer);
   }
 
   state.raiseAmount = 0;
+  state.selectedChips = [];
   updateRaiseAmount();
 
   const slider = document.getElementById('raiseSlider');
@@ -628,6 +650,7 @@ function hideControls() {
       chip.style.pointerEvents = 'none';
     });
   state.raiseAmount = 0;
+  state.selectedChips = [];
   updateRaiseAmount();
   const amt = document.getElementById('raiseSliderAmount');
   if (amt) amt.textContent = `0 ${state.token}`;


### PR DESCRIPTION
## Summary
- Move community cards, pot info and status text slightly higher on table
- Enlarge betting chips and add undo button for mistaken chip selections

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*
- `npm run lint` *(fails: 696 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f4282b448329bfb8557166616f72