### PR TITLE
Adjust poker raise controls and TPC balance placement

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -119,7 +119,7 @@
         }
         .slider-container{
           position:absolute;
-          bottom:0.5%;
+          bottom:6%;
           right:1%;
           z-index:5;
           display:flex;

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -503,6 +503,12 @@ function showControls() {
 
     sliderContainer.appendChild(sliderWrap);
 
+    const totalDiv = document.createElement('div');
+    totalDiv.className = 'tpc-total';
+    totalDiv.innerHTML =
+      'Total: <span id="tpcTotal">0</span> <img src="assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" />';
+    sliderContainer.appendChild(totalDiv);
+
     if (stage) stage.appendChild(sliderContainer);
   }
 
@@ -555,12 +561,6 @@ function showControls() {
     amountText.className = 'raise-amount';
     amountText.textContent = `0 ${state.token}`;
     infoRow.appendChild(amountText);
-
-    const totalDiv = document.createElement('div');
-    totalDiv.className = 'tpc-total';
-    totalDiv.innerHTML =
-      'Total: <span id="tpcTotal">0</span> <img src="assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" />';
-    infoRow.appendChild(totalDiv);
 
     raiseContainer.appendChild(infoRow);
 


### PR DESCRIPTION
## Summary
- Raise slider controls slightly higher on the screen
- Show Total TPC balance below the raise controls

## Testing
- `npm test`
- `npm run lint` *(fails: numerous lint errors in lib/texasHoldem.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a5faa6ea608329a889bf4edce2d821