### PR TITLE
Adjust power slider cue alignment and orientation

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -18,7 +18,7 @@
   border-radius: var(--ps-radius);
   background: var(--ps-track-bg);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
-  overflow: hidden;
+  overflow: visible;
   user-select: none;
   touch-action: none;
 }
@@ -28,7 +28,7 @@
   inset: 0;
   border-radius: inherit;
   background: linear-gradient(
-    to top,
+    to bottom,
     var(--ps-gradient-low) 0%,
     var(--ps-gradient-mid) 50%,
     var(--ps-gradient-high) 100%
@@ -61,34 +61,34 @@
   width: 8px;
   background:
     repeating-linear-gradient(
-      to top,
+      to bottom,
       transparent 0 calc(10% - 1px),
       var(--ps-tick) calc(10% - 1px) 10%
     ),
     linear-gradient(
-      to top,
+      to bottom,
       transparent calc(25% - 1.5px),
       var(--ps-tick) calc(25% - 1.5px) calc(25% + 1.5px),
       transparent calc(25% + 1.5px)
     ),
     linear-gradient(
-      to top,
+      to bottom,
       transparent calc(50% - 1.5px),
       var(--ps-tick) calc(50% - 1.5px) calc(50% + 1.5px),
       transparent calc(50% + 1.5px)
     ),
     linear-gradient(
-      to top,
+      to bottom,
       transparent calc(75% - 1.5px),
       var(--ps-tick) calc(75% - 1.5px) calc(75% + 1.5px),
       transparent calc(75% + 1.5px)
     ),
     linear-gradient(
-      to top,
+      to bottom,
       transparent calc(100% - 3px),
       var(--ps-tick) calc(100% - 3px) 100%
     ),
-    linear-gradient(to top, var(--ps-tick) 0 3px, transparent 3px);
+    linear-gradient(to bottom, var(--ps-tick) 0 3px, transparent 3px);
   pointer-events: none;
 }
 
@@ -96,7 +96,7 @@
   position: absolute;
   top: 0;
   left: 100%;
-  transform: translate(-100%, 0);
+  transform: translate(0, 0);
   transition: transform 0.15s ease;
   display: flex;
   flex-direction: column;
@@ -109,7 +109,7 @@
     var(--ps-gradient-high)
   );
   padding: 4px 2px;
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .ps-handle-text {
@@ -128,7 +128,7 @@
   position: absolute;
   top: 0;
   left: 100%;
-  transform: translate(-100%, 0);
+  transform: translate(0, 0);
   background: var(--ps-tooltip-bg);
   color: var(--ps-tooltip-color);
   font-size: 12px;

--- a/power-slider.js
+++ b/power-slider.js
@@ -136,10 +136,10 @@ export class PowerSlider {
     const ratio = (this.value - this.min) / range;
     const trackH = this.el.clientHeight;
     const handleH = this.handle.offsetHeight;
-    const y = (1 - ratio) * (trackH - handleH);
-    this.handle.style.transform = `translate(-100%, ${y}px)`;
+    const y = ratio * (trackH - handleH);
+    this.handle.style.transform = `translate(0, ${y}px)`;
     const ttH = this.tooltip.offsetHeight;
-    this.tooltip.style.transform = `translate(-100%, ${y - ttH - 8}px)`;
+    this.tooltip.style.transform = `translate(0, ${y - ttH - 8}px)`;
     this._updateHandleColor(ratio);
     this.tooltip.textContent = `${Math.round(this.value)}%`;
     this.el.setAttribute('aria-valuenow', String(Math.round(this.value)));
@@ -158,7 +158,7 @@ export class PowerSlider {
 
   _updateFromClientY(y) {
     const rect = this.el.getBoundingClientRect();
-    const pos = (rect.bottom - y) / rect.height; // 0 at bottom, 1 at top
+    const pos = (y - rect.top) / rect.height; // 0 at top, 1 at bottom
     const ratio = Math.min(Math.max(pos, 0), 1);
     const value = this.min + ratio * (this.max - this.min);
     this.set(value);
@@ -193,7 +193,7 @@ export class PowerSlider {
   _wheel(e) {
     if (this.locked) return;
     e.preventDefault();
-    const dir = e.deltaY < 0 ? 1 : -1;
+    const dir = e.deltaY > 0 ? 1 : -1;
     this.set(this.value + dir * this.step, { animate: true });
     if (typeof this.onCommit === 'function') this.onCommit(this.value);
   }
@@ -202,10 +202,10 @@ export class PowerSlider {
     if (this.locked) return;
     let handled = false;
     let inc = e.shiftKey ? this.step * 5 : this.step;
-    if (e.key === 'ArrowUp') {
+    if (e.key === 'ArrowDown') {
       this.set(this.value + inc);
       handled = true;
-    } else if (e.key === 'ArrowDown') {
+    } else if (e.key === 'ArrowUp') {
       this.set(this.value - inc);
       handled = true;
     } else if (e.key === 'Enter') {


### PR DESCRIPTION
## Summary
- Move cue handle and tooltip to the right side and allow dragging outside the track
- Reverse slider orientation to pull down for more power with proper color blending
- Update track gradient and tick direction to run from yellow (top) to red (bottom)

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68a60361b2d883298587d33026152d73