### PR TITLE
Fix Texas Hold'em pot chip images and card dealing sound

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -160,8 +160,8 @@
     .chip.v10{ background-image:url('assets/icons/10chips.webp'); }
     .chip.v20{ background-image:url('assets/icons/20chips.webp'); }
     .chip.v50{ background-image:url('assets/icons/50chips.webp'); }
-    .chip.v100{ background-image:url('assets/icons/200chips.webp'); }
-    .chip.v200{ background-image:url('assets/icons/500chips.webp'); }
+    .chip.v200{ background-image:url('assets/icons/200chips.webp'); }
+    .chip.v500{ background-image:url('assets/icons/500chips.webp'); }
     .chip.v1000{ background-image:url('assets/icons/1000chips.webp'); }
     .moving-pot{ position:absolute; transition:left .5s ease, top .5s ease; display:flex; gap:6px; }
   </style>

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -86,7 +86,7 @@ async function loadAccountBalance() {
 }
 
 const SUIT_MAP = { H: '♥', D: '♦', C: '♣', S: '♠' };
-const CHIP_VALUES = [1000, 200, 100, 50, 20, 10, 5, 2, 1];
+const CHIP_VALUES = [1000, 500, 200, 50, 20, 10, 5, 2, 1];
 const ANTE = 10;
 const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
 function flagName(flag) {
@@ -399,7 +399,6 @@ function dealCardToPlayer(idx, card, showFace) {
     stage.appendChild(temp);
     const target = document.getElementById('cards-' + idx);
     const targetRect = target.getBoundingClientRect();
-    playFlipSound();
     requestAnimationFrame(() => {
       temp.style.left = targetRect.left - stageRect.left + 'px';
       temp.style.top = targetRect.top - stageRect.top + 'px';


### PR DESCRIPTION
## Summary
- correct chip denominations and add 500 chip so pot displays match the total
- remove flip sound when dealing cards so only deal sound plays

## Testing
- `npm test`
- `npm run lint` *(fails: 711 errors)*


------
https://chatgpt.com/codex/tasks/task_e_68a6064426b48329825ea6e109428830