### PR TITLE
Align power slider and cue image movement

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,12 @@
       color: #fff;
       font-family: sans-serif;
     }
+    #power {
+      position: fixed;
+      top: 50%;
+      right: 44px;
+      transform: translateY(-50%);
+    }
     #controls { display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; }
     button { padding: 4px 8px; }
   </style>

--- a/power-slider.css
+++ b/power-slider.css
@@ -122,6 +122,7 @@
 .ps-handle-img {
   width: 36px;
   height: auto;
+  transition: transform 0.15s ease;
 }
 
 .ps-tooltip {
@@ -149,7 +150,8 @@
 }
 
 .ps-no-animate .ps-handle,
-.ps-no-animate .ps-tooltip {
+.ps-no-animate .ps-tooltip,
+.ps-no-animate .ps-handle-img {
   transition: none !important;
 }
 

--- a/power-slider.js
+++ b/power-slider.js
@@ -138,6 +138,7 @@ export class PowerSlider {
     const handleH = this.handle.offsetHeight;
     const y = ratio * (trackH - handleH);
     this.handle.style.transform = `translate(0, ${y}px)`;
+    this.handleImg.style.transform = `translate(0, ${y}px)`;
     const ttH = this.tooltip.offsetHeight;
     this.tooltip.style.transform = `translate(0, ${y - ttH - 8}px)`;
     this._updateHandleColor(ratio);


### PR DESCRIPTION
## Summary
- Make cue image follow slider handle by translating it with power changes
- Fix slider position to top-right edge for mobile layout

## Testing
- `npm test` *(fails: test timed out after 20000ms for snake API endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_68a6091903408329a6e09de818dbcacd