### PR TITLE
Revamp Texas Hold'em table UI

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -141,9 +141,11 @@
     .slider-wrap{ width:100%; display:flex; flex-direction:column; align-items:center; gap:4px; }
     .slider-wrap input[type=range]{ width:100%; }
     #allIn{ background:#dc2626; padding:2px 8px; border:2px solid #000; border-radius:8px; font-weight:600; font-size:12px; }
-    .tpc-total{ position:absolute; top:8px; left:8px; font-size:14px; display:flex; align-items:center; gap:4px; }
-    .tpc-total img{ width:32px; height:32px; }
-    #status{ position:absolute; top:38%; left:50%; transform:translate(-50%, -50%); z-index:2; font-weight:900; letter-spacing:.3px; color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
+    .tpc-total{ position:absolute; top:8px; left:8px; font-size:16px; display:flex; align-items:center; gap:4px; }
+    .tpc-total img{ width:36px; height:36px; transform:translateY(-2px); }
+    #status{ position:absolute; top:58%; left:50%; transform:translate(-50%, -50%); z-index:2; font-weight:900; letter-spacing:.3px; white-space:nowrap; }
+    .status-default{ color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
+    .tpc-inline-icon{ width:1em; height:1em; margin-left:2px; transform:translateY(2px); }
     .top-controls{position:absolute;top:8px;right:8px;display:flex;flex-direction:column;gap:8px;z-index:10}
     .top-controls button{width:44px;height:44px;padding:0;border:2px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#2563eb;color:#fff;font-weight:600}
     .top-controls button img{width:24px;height:24px}
@@ -164,9 +166,7 @@
     .chip.v500{ background-image:url('assets/icons/500chips.webp'); }
     .chip.v1000{ background-image:url('assets/icons/1000chips.webp'); }
     .moving-pot{ position:absolute; transition:left .5s ease, top .5s ease; display:flex; gap:6px; }
-    .folded-area{ position:absolute; left:50%; top:60%; transform:translate(-50%,0); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
-    .folded-cards{ display:flex; gap:6px; }
-    .folded-label{ font-weight:700; color:#dc2626; text-shadow:-1px -1px 0 #fff,1px -1px 0 #fff,-1px 1px 0 #fff,1px 1px 0 #fff; }
+    .folded-area{ display:none; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- move folded cards off-screen so they no longer clutter the table
- show status text below the community cards with colored action styles and TPC icons for amounts
- enlarge TPC total display and attach icon to all reported amounts

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68a6126acc488329bf7f8e88f87a4435