### PR TITLE
chore: adjust texas holdem ui behaviors

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -94,12 +94,13 @@
       font-weight:700;
       text-shadow:-1px -1px 0 #fff,1px -1px 0 #fff,-1px 1px 0 #fff,1px 1px 0 #fff;
     }
-    .seat-inner .cards{ padding:4px; border:2px solid #000; border-radius:8px; background:#fff; }
+    .seat-inner .cards{ padding:4px; border:2px solid #000; border-radius:8px; background:#16a34a; }
     .seat-inner .card{ border:2px solid #000; }
       .seat.bottom .cards{ gap:0 }
       .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
       .controls{ display:flex; gap:8px; margin-top:8px; align-items:flex-end; justify-content:center; z-index:5; }
       .controls button{ width:var(--avatar-size); height:var(--avatar-size); padding:0; border:4px solid #000; border-radius:50%; background:#2563eb; color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
+      button:disabled{ background:#d1d5db !important; color:#9ca3af !important; }
       #raise{ background:#2563eb; }
       #check{ background:#facc15; }
       #call{ background:#16a34a; }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -108,8 +108,12 @@ function updateBalancePreview(preview = 0) {
 function setStatus(action, text) {
   const status = document.getElementById('status');
   if (!status) return;
-  status.className = action ? `action-text ${action}` : 'status-default';
-  status.innerHTML = text;
+  if (text && (text.includes('wins with') || text === 'Tie')) {
+    status.className = 'status-default';
+    status.innerHTML = text;
+  } else {
+    status.innerHTML = '';
+  }
 }
 
 function cardFaceEl(c) {


### PR DESCRIPTION
## Summary
- match player card area with table logo green
- gray out controls when disabled
- show only final winning hand message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a622cf601883299b5af16613aaaff7