### PR TITLE
Refine Texas Hold'em table visuals

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -12,15 +12,14 @@
       --card-h: calc(var(--card-w)*1.45);
       --avatar-size: calc(54px * var(--avatar-scale));
     }
-    *{box-sizing:border-box}
+    *{box-sizing:border-box;font-family:'Luckiest Guy','Comic Sans MS',cursive;-webkit-text-stroke:.3px #000;text-shadow:0 0 4px #000}
     html,body{height:100%;margin:0}
     body{
-      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
       color:#fff; overflow:hidden; height:100vh; width:100vw;
     }
     .stage{ position:relative; width:100vw; height:100vh; display:grid; place-items:center; perspective:1100px; }
-    .stage::before{ content:""; position:absolute; top:0; bottom:0; left:1vw; right:1vw; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
-      .center{ position:absolute; left:50%; top:43%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.1; }
+      .stage::before{ content:""; position:absolute; top:0; bottom:0; left:1vw; right:1vw; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
+      .center{ position:absolute; left:50%; top:44%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.1; }
       .seats{ position:absolute; inset:0; z-index:2 }
       .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px) }
       .seat.small{ --card-scale:.8; }
@@ -49,7 +48,7 @@
 .seat.winner .name { color: #facc15; }
 
 .moving-card{position:absolute;transition:left .4s ease, top .4s ease;z-index:1000;pointer-events:none;}
-.avatar.turn{box-shadow:0 0 12px #facc15;border-color:#facc15;}
+.seat-inner .cards.turn{box-shadow:0 0 12px #facc15;border-color:#facc15;}
 
 .action-text{font-weight:700;min-height:1em}
 .action-text.fold{color:#dc2626;text-shadow:-1px -1px 0 #fff,1px -1px 0 #fff,-1px 1px 0 #fff,1px 1px 0 #fff}
@@ -76,7 +75,7 @@
       border:4px solid #000;
       border-radius:12px;
       padding:4px;
-      background:#fef08a;
+      background:#16a34a;
       box-shadow:4px 4px 0 #000;
     }
     .seat-inner .avatar{ box-shadow:0 0 0 4px #000; }
@@ -94,7 +93,7 @@
       font-weight:700;
       text-shadow:-1px -1px 0 #fff,1px -1px 0 #fff,-1px 1px 0 #fff,1px 1px 0 #fff;
     }
-    .seat-inner .cards{ padding:4px; border:2px solid #000; border-radius:8px; background:#16a34a; }
+    .seat-inner .cards{ padding:4px; border:2px solid #000; border-radius:8px; background:#fef08a; }
     .seat-inner .card{ border:2px solid #000; }
       .seat.bottom .cards{ gap:0 }
       .timer{ font-weight:800; background:rgba(0,0,0,.5); padding:2px 6px; border-radius:8px; }
@@ -158,9 +157,9 @@
 
     .pot-wrap{ position:absolute; left:50%; top:33%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
     .pot{ display:flex; gap:6px; }
-    .pot-total{ font-size:12px; }
-    .chip-pile{ position:relative; width:calc(var(--avatar-size)/2); height:calc(var(--avatar-size)/2); }
-    .chip{ position:absolute; left:0; width:calc(var(--avatar-size)/2); height:calc(var(--avatar-size)/2); border-radius:50%; background-size:cover; background-position:center; background-repeat:no-repeat; box-shadow:0 2px 4px rgba(0,0,0,.4); }
+    .pot-total{ font-size:14px; }
+    .chip-pile{ position:relative; width:calc(var(--avatar-size)/1.7); height:calc(var(--avatar-size)/1.7); }
+    .chip{ position:absolute; left:0; width:calc(var(--avatar-size)/1.7); height:calc(var(--avatar-size)/1.7); border-radius:50%; background-size:cover; background-position:center; background-repeat:no-repeat; box-shadow:0 2px 4px rgba(0,0,0,.4); }
     .chip.v1{ background-image:url('assets/icons/1chips.webp'); }
     .chip.v2{ background-image:url('assets/icons/20250820_071739.webp'); }
     .chip.v5{ background-image:url('assets/icons/5chips.webp'); }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -476,10 +476,10 @@ function moveCardsToFolded(idx) {
 }
 
 function setPlayerTurnIndicator(idx) {
-  document.querySelectorAll('.avatar').forEach((a) => a.classList.remove('turn'));
+  document.querySelectorAll('.seat-inner .cards').forEach((c) => c.classList.remove('turn'));
   if (idx === null || idx === undefined || idx < 0) return;
-  const avatar = document.getElementById('avatar-' + idx);
-  if (avatar) avatar.classList.add('turn');
+  const cards = document.getElementById('cards-' + idx);
+  if (cards) cards.classList.add('turn');
 }
 
 function showControls() {


### PR DESCRIPTION
## Summary
- Align Texas Hold'em text styles with sitewide fonts and effects
- Highlight active player's card frame instead of avatar and swap seat colors
- Enlarge pot display and slightly lower community cards

## Testing
- `npm test` *(fails: assert.ok(events.includes('diceRolled')))*
- `npm run lint` *(fails: 711 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a62acaf8548329b6ddb110f183e25e