### PR TITLE
style: adjust texas hold'em visuals

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -75,8 +75,8 @@
       border:4px solid #000;
       border-radius:12px;
       padding:4px;
-      background:#16a34a;
-      box-shadow:4px 4px 0 #000;
+      background:#14532d;
+      box-shadow:4px 4px 0 #0c2e16;
     }
     .seat-inner .avatar{ box-shadow:0 0 0 4px #000; }
     .seat-inner .name{
@@ -148,7 +148,7 @@
     .tpc-total{ position:absolute; top:8px; left:8px; font-size:16px; display:flex; align-items:center; gap:4px; }
     .tpc-total img{ width:36px; height:36px; transform:translateY(-2px); }
     #status{ position:absolute; top:55%; left:50%; transform:translate(-50%, 0); z-index:2; font-weight:900; letter-spacing:.3px; white-space:nowrap; }
-    .status-default{ color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
+    .status-default{ color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1.5px #000 }
     .tpc-inline-icon{ width:1em; height:1em; margin-left:2px; transform:translateY(2px); }
     .top-controls{position:absolute;top:8px;right:8px;display:flex;flex-direction:column;gap:8px;z-index:10}
     .top-controls button{width:44px;height:44px;padding:0;border:2px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#2563eb;color:#fff;font-weight:600}


### PR DESCRIPTION
## Summary
- match player card panel green with table logo and use darker shadow
- thicken in-game status text for better visibility

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint` *(fails: 713 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a62f959208832990164b2ce5d40507