### PR TITLE
Reposition cue image under pull text in PowerSlider

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -119,13 +119,9 @@
 }
 
 .ps-cue-img {
-  position: absolute;
-  top: 0;
-  left: 100%;
-  margin-left: 2px;
+  margin-top: 2px;
   width: 36px;
   height: auto;
-  transition: transform 0.15s ease;
 }
 
 .ps-tooltip {
@@ -153,8 +149,7 @@
 }
 
 .ps-no-animate .ps-handle,
-.ps-no-animate .ps-tooltip,
-.ps-no-animate .ps-cue-img {
+.ps-no-animate .ps-tooltip {
   transition: none !important;
 }
 

--- a/power-slider.js
+++ b/power-slider.js
@@ -40,13 +40,14 @@ export class PowerSlider {
     this.handleText.className = 'ps-handle-text';
     this.handleText.textContent = 'Pull';
     this.handle.append(this.handleText);
-    this.el.appendChild(this.handle);
 
     this.cueImg = document.createElement('img');
     this.cueImg.className = 'ps-cue-img';
     this.cueImg.alt = '';
     if (cueSrc) this.cueImg.src = cueSrc;
-    this.el.appendChild(this.cueImg);
+    this.handle.append(this.cueImg);
+
+    this.el.appendChild(this.handle);
 
     this.tooltip = document.createElement('div');
     this.tooltip.className = 'ps-tooltip';
@@ -137,12 +138,11 @@ export class PowerSlider {
     const range = this.max - this.min || 1;
     const ratio = (this.value - this.min) / range;
     const trackH = this.el.clientHeight;
-    const imgH = this.cueImg.offsetHeight;
-    const y = ratio * (trackH - imgH);
-    this.cueImg.style.transform = `translate(0, ${y}px)`;
-    this.handle.style.transform = 'translate(0, 0)';
+    const handleH = this.handle.offsetHeight;
+    const y = ratio * (trackH - handleH);
+    this.handle.style.transform = `translate(0, ${y}px)`;
     const ttH = this.tooltip.offsetHeight;
-    this.tooltip.style.transform = `translate(0, ${-ttH - 8}px)`;
+    this.tooltip.style.transform = `translate(0, ${y - ttH - 8}px)`;
     this._updateHandleColor(ratio);
     this.tooltip.textContent = `${Math.round(this.value)}%`;
     this.el.setAttribute('aria-valuenow', String(Math.round(this.value)));


### PR DESCRIPTION
## Summary
- Move cue image into slider handle so it sits beneath the "Pull" label
- Animate handle instead of cue image and shift tooltip with handle
- Simplify cue image styling and remove absolute positioning

## Testing
- `npm test` (fails: test timed out - snake API endpoints)
- `npm run lint` (fails: 712 errors)

------
https://chatgpt.com/codex/tasks/task_e_68a62ff0e86883299b615e6dc3002e4e