### PR TITLE
Adjust power slider cue positioning

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -244,9 +244,8 @@
       position: absolute;
       left: 50%;
       top: 0;
-      width: 60px;
-      transform: translate(-50%, 0) rotate(-90deg);
-      transform-origin: center;
+      transform: translate(-50%, 0);
+      transform-origin: top center;
       pointer-events: none;
       z-index: 6;
     }
@@ -1122,7 +1121,7 @@
       var maxY=rect.height-pullHandle.offsetHeight*0.4;
       var y=minY+(maxY-minY)*power;
       pullHandle.style.top=y+'px';
-      powerCue.style.top=y+'px';
+      powerCue.style.top=(y + pullHandle.offsetHeight)+'px';
     }
     function updatePowerUI(){
         powerFill.style.height = Math.round(power*100)+'%';


### PR DESCRIPTION
## Summary
- Show cue image vertically under the pull handle in Poll Royale power slider.
- Offset cue positioning so it sits beneath the pull text when the slider moves.

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint` *(fails: lib/texasHoldem.js has 712 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6aaf887748329a391f76d9e052d39