### PR TITLE
Adjust power slider cue and pull text alignment

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -202,7 +202,7 @@
     #pullHandle {
       position: absolute;
       /* Position the pull button so that it's half outside the panel */
-      left: 100%;
+      left: calc(100% - 1px);
       transform: translateX(-50%);
       width: 45px;
       height: 45px;
@@ -242,7 +242,7 @@
 
     #powerCue {
       position: absolute;
-      left: 50%;
+      left: calc(50% + 2px);
       top: 0;
       transform: translate(-50%, 0);
       transform-origin: top center;


### PR DESCRIPTION
## Summary
- nudge pull control left for better centering
- shift cue image slightly right on power slider

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint` *(fails: 712 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6aeb1226c8329ac522fb415ac661e