### PR TITLE
style(texas-holdem): restore classic text and adjust visuals

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -12,9 +12,10 @@
       --card-h: calc(var(--card-w)*1.45);
       --avatar-size: calc(54px * var(--avatar-scale));
     }
-    *{box-sizing:border-box;font-family:'Luckiest Guy','Comic Sans MS',cursive;-webkit-text-stroke:.3px #000;text-shadow:0 0 4px #000}
+    *{box-sizing:border-box}
     html,body{height:100%;margin:0}
     body{
+      font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;
       color:#fff; overflow:hidden; height:100vh; width:100vw;
     }
     .stage{ position:relative; width:100vw; height:100vh; display:grid; place-items:center; perspective:1100px; }
@@ -38,7 +39,7 @@
       .joker{ background:repeating-linear-gradient(45deg,#eee,#eee 6px,#ddd 6px,#ddd 12px); }
       .selected{ outline:3px solid #0ea5e9; transform:translateY(-6px); }
       .suggested{ outline:3px dashed #2563eb; }
-      .card.back{ background:url('assets/icons/file_00000000bc2862439eecffff3730bbe4.webp') center/60% no-repeat, repeating-linear-gradient(45deg,#233,#233 6px,#122 6px,#122 12px); border:2px solid rgba(255,255,255,.5); color:transparent; }
+      .card.back{ background:url('assets/icons/file_00000000bc2862439eecffff3730bbe4.webp') center/65% no-repeat, repeating-linear-gradient(45deg,#233,#233 6px,#122 6px,#122 12px); border:2px solid rgba(255,255,255,.5); color:transparent; }
       .card.back::before{ content:""; position:absolute; inset:6px; border-radius:8px; border:2px dashed rgba(255,255,255,.35); }
 /* Winner highlight styles + seating layout */
 
@@ -151,7 +152,7 @@
     .tpc-total{ position:absolute; top:8px; left:8px; font-size:16px; display:flex; align-items:center; gap:4px; }
     .tpc-total img{ width:36px; height:36px; transform:translateY(-2px); }
     #status{ position:absolute; top:55%; left:50%; transform:translate(-50%, 0); z-index:2; font-weight:900; letter-spacing:.3px; white-space:nowrap; }
-    .status-default{ color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1.5px #000 }
+    .status-default{ color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
     .tpc-inline-icon{ width:1em; height:1em; margin-left:2px; transform:translateY(2px); }
     .top-controls{position:absolute;top:8px;right:8px;display:flex;flex-direction:column;gap:8px;z-index:10}
     .top-controls button{width:44px;height:44px;padding:0;border:2px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#2563eb;color:#fff;font-weight:600}
@@ -159,7 +160,7 @@
     .seat.vacant .vacant-seat{width:var(--avatar-size);height:var(--avatar-size);border-radius:50%;border:4px solid #000;background:#facc15;color:#16a34a;font-weight:700;display:flex;align-items:center;justify-content:center}
 
     .pot-wrap{ position:absolute; left:50%; top:33%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
-    .pot{ display:flex; gap:6px; }
+    .pot{ display:flex; gap:4px; }
     .pot-total{ font-size:14px; }
     .chip-pile{ position:relative; width:calc(var(--avatar-size)/1.7); height:calc(var(--avatar-size)/1.7); }
     .chip{ position:absolute; left:0; width:calc(var(--avatar-size)/1.7); height:calc(var(--avatar-size)/1.7); border-radius:50%; background-size:cover; background-position:center; background-repeat:no-repeat; box-shadow:0 2px 4px rgba(0,0,0,.4); }
@@ -172,7 +173,7 @@
     .chip.v200{ background-image:url('assets/icons/200chips.webp'); }
     .chip.v500{ background-image:url('assets/icons/500chips.webp'); }
     .chip.v1000{ background-image:url('assets/icons/1000chips.webp'); }
-    .moving-pot{ position:absolute; transition:left .5s ease, top .5s ease; display:flex; gap:6px; }
+    .moving-pot{ position:absolute; transition:left .5s ease, top .5s ease; display:flex; gap:4px; }
     .folded-area{ display:none; }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- revert Texas Hold'em page to standard sans-serif font
- slightly enlarge card back logo
- tighten chip spacing in pot

## Testing
- `npm test` *(fails: process hung due to missing Telegram bot configuration, terminated after proxy errors)*
- `npm run lint` *(fails: 712 lint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b0cc2d488329ab23b1e5217f474f