### PR TITLE
Simplify card faces for Texas Hold'em

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -39,7 +39,7 @@
       .joker{ background:repeating-linear-gradient(45deg,#eee,#eee 6px,#ddd 6px,#ddd 12px); }
       .selected{ outline:3px solid #0ea5e9; transform:translateY(-6px); }
       .suggested{ outline:3px dashed #2563eb; }
-      .card.back{ background:url('assets/icons/file_00000000bc2862439eecffff3730bbe4.webp') center/65% no-repeat, repeating-linear-gradient(45deg,#233,#233 6px,#122 6px,#122 12px); border:2px solid rgba(255,255,255,.5); color:transparent; }
+      .card.back{ background:url('assets/icons/file_00000000bc2862439eecffff3730bbe4.webp') center/90% no-repeat, repeating-linear-gradient(45deg,#233,#233 6px,#122 6px,#122 12px); border:2px solid rgba(255,255,255,.5); color:transparent; }
       .card.back::before{ content:""; position:absolute; inset:6px; border-radius:8px; border:2px dashed rgba(255,255,255,.35); }
 /* Winner highlight styles + seating layout */
 

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -124,27 +124,19 @@ function cardFaceEl(c) {
     ((c.r === 'RJ' || c.r === 'BJ') ? ' joker' : '');
 
   const rankText = c.r === 'BJ' ? 'JB' : c.r === 'RJ' ? 'JR' : c.r;
-  const suitText = c.s === '🃏' ? '' : c.s;
-
   const tl = document.createElement('div');
   tl.className = 'tl corner';
   const tlRank = document.createElement('div');
   tlRank.className = 'rank';
   tlRank.textContent = rankText;
-  const tlSuit = document.createElement('div');
-  tlSuit.className = 'suit';
-  tlSuit.textContent = suitText;
-  tl.append(tlRank, tlSuit);
+  tl.append(tlRank);
 
   const br = document.createElement('div');
   br.className = 'br corner';
   const brRank = document.createElement('div');
   brRank.className = 'rank';
   brRank.textContent = rankText;
-  const brSuit = document.createElement('div');
-  brSuit.className = 'suit';
-  brSuit.textContent = suitText;
-  br.append(brRank, brSuit);
+  br.append(brRank);
 
   const big = document.createElement('div');
   big.className = 'big';


### PR DESCRIPTION
## Summary
- Remove mini suit icons from card corners so only ranks show with a central suit
- Enlarge back-of-card logo for improved visibility

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors in lib/texasHoldem.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bbc472a483298d1b27cb09196269