### PR TITLE
Align power slider cue and pull text

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -116,14 +116,14 @@
   font-size: 10px;
   color: #fff;
   line-height: 1;
-  transform: translateX(-1px);
+  transform: translateX(-2px);
 }
 
 .ps-cue-img {
   margin-top: 2px;
   width: 36px;
   height: auto;
-  transform: translateX(1px);
+  transform: translateX(2px);
 }
 
 .ps-tooltip {


### PR DESCRIPTION
## Summary
- Nudge handle text slightly left for improved centering
- Shift cue image right for balanced spacing

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*
- `npm run lint` *(fails: 712 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bae8c97c8329b76763cfe1c83c07