### PR TITLE
Adjust power slider cue image alignment

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -123,7 +123,7 @@
   margin-top: 2px;
   width: 36px;
   height: auto;
-  transform: translateX(2px);
+  transform: translateX(4px);
 }
 
 .ps-tooltip {

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -240,15 +240,15 @@
       background: #fff;
     }
 
-    #powerCue {
-      position: absolute;
-      left: calc(50% + 4px);
-      top: 0;
-      transform: translate(-50%, 0);
-      transform-origin: top center;
-      pointer-events: none;
-      z-index: 6;
-    }
+      #powerCue {
+        position: absolute;
+        left: calc(50% + 6px);
+        top: 0;
+        transform: translate(-50%, 0);
+        transform-origin: top center;
+        pointer-events: none;
+        z-index: 6;
+      }
 
     #powerTxt {
       margin-top: 8px;


### PR DESCRIPTION
## Summary
- Nudge cue image a couple pixels right in power slider component
- Shift Pool Royale power slider cue slightly right for better centering

## Testing
- `npm test` *(fails: Failed to send Telegram notification: The "options.agent" property must be one of Agent-like Object, undefined, or false)*
- `npm run lint` *(fails: 712 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c37e6ce083298c0628adb60971ac