### PR TITLE
Refine Texas Hold'em controls and settings

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -157,15 +157,20 @@
     #status{ position:absolute; top:55%; left:50%; transform:translate(-50%, 0); z-index:2; font-weight:900; letter-spacing:.3px; white-space:nowrap; }
     .status-default{ color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
     .tpc-inline-icon{ width:1em; height:1em; margin-left:2px; transform:translateY(2px); }
-    .top-controls{position:absolute;top:8px;right:8px;display:flex;flex-direction:column;gap:8px;z-index:10}
-    .top-controls button{width:44px;height:44px;padding:0;border:2px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#2563eb;color:#fff;font-weight:600}
-    .top-controls button img{width:24px;height:24px}
+      .top-controls{position:absolute;top:8px;right:8px;display:flex;gap:4px;z-index:10}
+      .top-controls button{width:32px;height:32px;padding:0;border:2px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#2563eb;color:#fff;font-weight:600;font-size:14px;line-height:1}
+      .top-controls button img{width:16px;height:16px}
+      #lobbyIcon{flex-direction:column;width:auto;height:auto;padding:4px 6px;border-radius:8px}
+      #lobbyIcon .arrow{font-size:16px}
+      #lobbyIcon .label{font-size:10px;line-height:1;margin-top:2px}
     .seat.vacant .vacant-seat{width:var(--avatar-size);height:var(--avatar-size);border-radius:50%;border:4px solid #000;background:#facc15;color:#16a34a;font-weight:700;display:flex;align-items:center;justify-content:center}
 
     .settings-panel{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;color:#000;padding:16px;border:2px solid #000;border-radius:8px;z-index:20;display:none;min-width:200px;}
-    .settings-panel.active{display:block}
-    .settings-panel label{display:flex;align-items:center;gap:6px;margin-top:8px}
-    .settings-panel select,.settings-panel input[type=range]{margin-left:6px}
+      .settings-panel.active{display:block}
+      .settings-panel label{display:flex;align-items:center;gap:6px;margin-top:8px}
+      .settings-panel select,.settings-panel input[type=range]{margin-left:6px}
+      .settings-panel select option{color:transparent}
+      .settings-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:8px}
 
     .pot-wrap{ position:absolute; left:50%; top:33%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
     .pot{ display:flex; gap:4px; }
@@ -204,22 +209,24 @@
   <audio id="sndAllIn" src="assets/sounds/allinpushchips2-39133.mp3"></audio>
   <audio id="sndFlip" src="assets/sounds/flipcard-91468.mp3"></audio>
   <audio id="sndKnock" src="assets/sounds/wooden-door-knock-102902.mp3"></audio>
-  <div class="top-controls">
-    <button id="settingsBtn">⚙️</button>
-    <button id="lobbyIcon"><img src="assets/icons/texas-holdem.svg" alt="Lobby"/></button>
-    <button id="leaveSeatBtn">Leave</button>
-  </div>
-  <div id="settingsPanel" class="settings-panel">
-    <label><input type="checkbox" id="muteCards"/> Mute Cards</label>
-    <label>Card Volume<input type="range" id="cardVolume" min="0" max="1" step="0.1"/></label>
-    <label><input type="checkbox" id="muteChips"/> Mute Chips</label>
-    <label>Chip Volume<input type="range" id="chipVolume" min="0" max="1" step="0.1"/></label>
-    <label><input type="checkbox" id="muteOthers"/> Mute Other Sounds</label>
-    <label>Player Frame<select id="playerColor"></select></label>
-    <label>Card Back<select id="cardBackColor"></select></label>
-    <label>Card Front<select id="cardFrontColor"></select></label>
-    <button id="closeSettings">Close</button>
-  </div>
+    <div class="top-controls">
+      <button id="settingsBtn">⚙️</button>
+      <button id="lobbyIcon"><span class="arrow">&#8592;</span><span class="label">Return Lobby</span></button>
+    </div>
+    <div id="settingsPanel" class="settings-panel">
+      <label><input type="checkbox" id="muteCards"/> Mute Cards</label>
+      <label>Card Volume<input type="range" id="cardVolume" min="0" max="1" step="0.1"/></label>
+      <label><input type="checkbox" id="muteChips"/> Mute Chips</label>
+      <label>Chip Volume<input type="range" id="chipVolume" min="0" max="1" step="0.1"/></label>
+      <label><input type="checkbox" id="muteOthers"/> Mute Other Sounds</label>
+      <label>Player Frame<select id="playerColor" class="color-select"></select></label>
+      <label>Card Back<select id="cardBackColor" class="color-select"></select></label>
+      <div class="settings-actions">
+        <button id="resetSettings">Reset</button>
+        <button id="saveSettings">Save</button>
+        <button id="closeSettings">Close</button>
+      </div>
+    </div>
     <script src="/flag-emojis.js"></script>
     <script src="/falling-ball-api.js"></script>
     <script type="module" src="/texas-holdem.js"></script>

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -35,7 +35,6 @@ const DEFAULT_SETTINGS = {
   chipVolume: 1,
   playerColor: '#f5f5dc',
   cardBackColor: '#233',
-  cardFrontColor: '#fff',
 };
 const COLOR_OPTIONS = ['#f5f5dc','#f87171','#60a5fa','#a78bfa','#34d399','#fbbf24','#c084fc','#f472b6','#4ade80','#94a3b8'];
 
@@ -56,7 +55,6 @@ function saveSettings() {
 function applySettings() {
   document.documentElement.style.setProperty('--seat-bg-color', settings.playerColor);
   document.documentElement.style.setProperty('--card-back-color', settings.cardBackColor);
-  document.documentElement.style.setProperty('--card-front-color', settings.cardFrontColor);
   const flip = document.getElementById('sndFlip');
   if (flip) flip.volume = settings.muteCards ? 0 : settings.cardVolume;
   const callRaise = document.getElementById('sndCallRaise');
@@ -83,13 +81,14 @@ function initSettingsMenu() {
   const muteOthers = document.getElementById('muteOthers');
   const playerColor = document.getElementById('playerColor');
   const cardBackColor = document.getElementById('cardBackColor');
-  const cardFrontColor = document.getElementById('cardFrontColor');
+  const saveBtn = document.getElementById('saveSettings');
+  const resetBtn = document.getElementById('resetSettings');
 
   function populate(select, value) {
     COLOR_OPTIONS.forEach((c) => {
       const opt = document.createElement('option');
       opt.value = c;
-      opt.textContent = c;
+      opt.textContent = '';
       opt.style.backgroundColor = c;
       select.appendChild(opt);
     });
@@ -98,22 +97,38 @@ function initSettingsMenu() {
 
   populate(playerColor, settings.playerColor);
   populate(cardBackColor, settings.cardBackColor);
-  populate(cardFrontColor, settings.cardFrontColor);
 
-  muteCards.checked = settings.muteCards;
-  cardVolume.value = settings.cardVolume;
-  muteChips.checked = settings.muteChips;
-  chipVolume.value = settings.chipVolume;
-  muteOthers.checked = settings.muteOthers;
+  function updateControls() {
+    muteCards.checked = settings.muteCards;
+    cardVolume.value = settings.cardVolume;
+    muteChips.checked = settings.muteChips;
+    chipVolume.value = settings.chipVolume;
+    muteOthers.checked = settings.muteOthers;
+    playerColor.value = settings.playerColor;
+    cardBackColor.value = settings.cardBackColor;
+  }
 
-  muteCards.addEventListener('change', (e) => { settings.muteCards = e.target.checked; saveSettings(); applySettings(); });
-  cardVolume.addEventListener('input', (e) => { settings.cardVolume = parseFloat(e.target.value); saveSettings(); applySettings(); });
-  muteChips.addEventListener('change', (e) => { settings.muteChips = e.target.checked; saveSettings(); applySettings(); });
-  chipVolume.addEventListener('input', (e) => { settings.chipVolume = parseFloat(e.target.value); saveSettings(); applySettings(); });
-  muteOthers.addEventListener('change', (e) => { settings.muteOthers = e.target.checked; saveSettings(); applySettings(); });
-  playerColor.addEventListener('change', (e) => { settings.playerColor = e.target.value; saveSettings(); applySettings(); });
-  cardBackColor.addEventListener('change', (e) => { settings.cardBackColor = e.target.value; saveSettings(); applySettings(); });
-  cardFrontColor.addEventListener('change', (e) => { settings.cardFrontColor = e.target.value; saveSettings(); applySettings(); });
+  updateControls();
+
+  muteCards.addEventListener('change', (e) => { settings.muteCards = e.target.checked; applySettings(); });
+  cardVolume.addEventListener('input', (e) => { settings.cardVolume = parseFloat(e.target.value); applySettings(); });
+  muteChips.addEventListener('change', (e) => { settings.muteChips = e.target.checked; applySettings(); });
+  chipVolume.addEventListener('input', (e) => { settings.chipVolume = parseFloat(e.target.value); applySettings(); });
+  muteOthers.addEventListener('change', (e) => { settings.muteOthers = e.target.checked; applySettings(); });
+  playerColor.addEventListener('change', (e) => { settings.playerColor = e.target.value; applySettings(); });
+  cardBackColor.addEventListener('change', (e) => { settings.cardBackColor = e.target.value; applySettings(); });
+
+  saveBtn?.addEventListener('click', () => {
+    saveSettings();
+    panel.classList.remove('active');
+  });
+
+  resetBtn?.addEventListener('click', () => {
+    settings = { ...DEFAULT_SETTINGS };
+    updateControls();
+    saveSettings();
+    applySettings();
+  });
 }
 
 let myAccountId = '';
@@ -1086,10 +1101,6 @@ async function showdown() {
 
 document.getElementById('lobbyIcon')?.addEventListener('click', () => {
   location.href = '/games/texasholdem/lobby';
-});
-document.getElementById('leaveSeatBtn')?.addEventListener('click', () => {
-  state.seated = false;
-  init();
 });
 document.addEventListener('DOMContentLoaded', () => {
   initSettingsMenu();


### PR DESCRIPTION
## Summary
- Reduce and align top-right game controls horizontally; replace lobby button with back arrow and remove leave option.
- Settings dialog now shows color swatches, drops card-front customization, and includes Reset/Save actions.

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6c7188dbc832996acb674c83c59b0