### PR TITLE
Adjust power slider cue position and size

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -121,9 +121,9 @@
 
 .ps-cue-img {
   margin-top: 2px;
-  width: 36px;
+  width: 40px;
   height: auto;
-  transform: translateX(4px);
+  transform: translateX(6px);
 }
 
 .ps-tooltip {


### PR DESCRIPTION
## Summary
- nudge cue image slightly right and enlarge for better visibility

## Testing
- `npm test` *(fails: process hangs after server start)*
- `npm run lint` *(fails: existing lint errors in lib/texasHoldem.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c8b72fd08329bae6d503c46393f6