### PR TITLE
Adjust power slider cue image alignment

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -101,7 +101,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 40px;
+  width: 44px;
   border-radius: 6px;
   background: linear-gradient(
     to bottom,
@@ -121,9 +121,9 @@
 
 .ps-cue-img {
   margin-top: 2px;
-  width: 40px;
+  width: 44px;
   height: auto;
-  transform: translateX(6px);
+  transform: translateX(8px);
 }
 
 .ps-tooltip {


### PR DESCRIPTION
## Summary
- shift cue image slightly right on power slider
- enlarge cue image for clearer appearance

## Testing
- `npm test` *(fails: process did not exit cleanly due to server handles; see log)*
- `npm run lint` *(fails: 712 lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cf92625883299f39474702d6bc5f