### PR TITLE
Show color codes and swatches in Texas Hold'em settings

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -169,7 +169,12 @@
       .settings-panel.active{display:block}
       .settings-panel label{display:flex;align-items:center;gap:6px;margin-top:8px}
       .settings-panel select,.settings-panel input[type=range]{margin-left:6px}
-      .settings-panel select option{color:transparent}
+      .settings-panel select option{
+        color:#000;
+        padding-left:24px;
+        background-size:16px 100%;
+        background-repeat:no-repeat;
+      }
       .settings-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:8px}
 
     .pot-wrap{ position:absolute; left:50%; top:33%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -88,8 +88,8 @@ function initSettingsMenu() {
     COLOR_OPTIONS.forEach((c) => {
       const opt = document.createElement('option');
       opt.value = c;
-      opt.textContent = '';
-      opt.style.backgroundColor = c;
+      opt.textContent = c;
+      opt.style.background = `linear-gradient(to right, ${c} 0 16px, #fff 16px)`;
       select.appendChild(opt);
     });
     select.value = value;


### PR DESCRIPTION
## Summary
- Display hex codes for player frame and card back colors in Texas Hold'em setup
- Add inline color swatch preview for each option

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*
- `npm run lint` *(fails: 712 lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d0b23ad48329897221b5c1a8c986