### PR TITLE
Align power slider cue with pull and power text

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -242,7 +242,8 @@
 
       #powerCue {
         position: absolute;
-        left: calc(50% + 6px);
+        /* Align cue image with pull handle and power text along the right edge */
+        left: calc(100% - 1px);
         top: 0;
         transform: translate(-50%, 0);
         transform-origin: top center;


### PR DESCRIPTION
## Summary
- Align cue image of Pool Royale power slider with pull handle and power display by moving cue to right edge

## Testing
- `npm test` (fails: snake API endpoints and socket events timed out)

------
https://chatgpt.com/codex/tasks/task_e_68a6d5ada1f083299b8e23f9b3ad4d0a