### PR TITLE
Link raise values with balance preview in poker

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -160,9 +160,9 @@
       .top-controls{position:absolute;top:8px;right:8px;display:flex;gap:4px;z-index:10}
       .top-controls button{width:32px;height:32px;padding:0;border:2px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#2563eb;color:#fff;font-weight:600;font-size:14px;line-height:1}
       .top-controls button img{width:16px;height:16px}
-      #lobbyIcon{flex-direction:column;width:auto;height:auto;padding:4px 6px;border-radius:8px}
-      #lobbyIcon .arrow{font-size:16px}
-      #lobbyIcon .label{font-size:10px;line-height:1;margin-top:2px}
+      #lobbyIcon{flex-direction:column;width:auto;height:auto;padding:2px 5px;border-radius:8px}
+      #lobbyIcon .arrow{font-size:14px}
+      #lobbyIcon .label{font-size:9px;line-height:1;margin-top:2px}
     .seat.vacant .vacant-seat{width:var(--avatar-size);height:var(--avatar-size);border-radius:50%;border:4px solid #000;background:#facc15;color:#16a34a;font-weight:700;display:flex;align-items:center;justify-content:center}
 
     .settings-panel{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;color:#000;padding:16px;border:2px solid #000;border-radius:8px;z-index:20;display:none;min-width:200px;}

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -643,6 +643,8 @@ function showControls() {
     slider.addEventListener('input', () => {
       const amt = document.getElementById('raiseSliderAmount');
       if (amt) amt.innerHTML = formatAmount(slider.value);
+      const text = document.getElementById('raiseAmountText');
+      if (text && state.raiseAmount === 0) text.innerHTML = formatAmount(slider.value);
       setStatus(
         'raise',
         slider.value > 0 ? `Raise ${formatAmount(slider.value)}` : ''
@@ -789,6 +791,12 @@ function showControls() {
 function updateRaiseAmount() {
   const amtEl = document.getElementById('raiseAmountText');
   if (amtEl) amtEl.innerHTML = formatAmount(state.raiseAmount);
+  const slider = document.getElementById('raiseSlider');
+  if (slider) {
+    slider.value = state.raiseAmount;
+    const sliderAmt = document.getElementById('raiseSliderAmount');
+    if (sliderAmt) sliderAmt.innerHTML = formatAmount(state.raiseAmount);
+  }
   setStatus(
     'raise',
     state.raiseAmount > 0 ? `Raise ${formatAmount(state.raiseAmount)}` : ''


### PR DESCRIPTION
## Summary
- Shrink Texas Hold'em lobby button for a more compact layout
- Sync chip and slider raise inputs so both display the same amount and update balance

## Testing
- `npm test` *(fails: snake API endpoints and socket events timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d70b871c8329b5fe7faf481dcddf