### PR TITLE
chore: raise Texas Hold'em status text

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -154,7 +154,7 @@
     #allIn{ background:#dc2626; padding:2px 8px; border:2px solid #000; border-radius:8px; font-weight:600; font-size:12px; }
     .tpc-total{ position:absolute; top:8px; left:8px; font-size:16px; display:flex; align-items:center; gap:4px; }
     .tpc-total img{ width:36px; height:36px; transform:translateY(-2px); }
-    #status{ position:absolute; top:55%; left:50%; transform:translate(-50%, 0); z-index:2; font-weight:900; letter-spacing:.3px; white-space:nowrap; }
+    #status{ position:absolute; top:52%; left:50%; transform:translate(-50%, 0); z-index:2; font-weight:900; letter-spacing:.3px; white-space:nowrap; }
     .status-default{ color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
     .tpc-inline-icon{ width:1em; height:1em; margin-left:2px; transform:translateY(2px); }
       .top-controls{position:absolute;top:8px;right:8px;display:flex;gap:4px;z-index:10}


### PR DESCRIPTION
## Summary
- nudge Texas Hold'em end-of-game status text slightly higher

## Testing
- `npm test` *(fails: snake API endpoints and socket events)*
- `npm run lint` *(fails: 712 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dad6582883298c4458659560400e