### PR TITLE
Adjust Pool Royale power slider layout

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -186,6 +186,7 @@
       /* Allow the handle to overflow so only half of it is visible */
       overflow: visible;
       z-index: 7;
+      margin-right: 4px;
     }
 
     #cueRail {
@@ -204,14 +205,15 @@
       /* Position the pull button so that it's half outside the panel */
       left: calc(100% - 1px);
       transform: translateX(-50%);
-      width: 45px;
-      height: 45px;
+      width: 43px;
+      height: 43px;
       border-radius: 50%;
       background: #fff;
       color: #111;
       display: flex;
       align-items: center;
       justify-content: center;
+      font-size: 13px;
       font-weight: 700;
       box-shadow: 0 4px 10px rgba(0,0,0,.3);
       user-select: none;
@@ -245,7 +247,7 @@
         /* Align cue image with pull handle and power text along the right edge */
         left: calc(100% - 1px);
         top: 0;
-        transform: translate(-50%, 0);
+        transform: translate(-50%, 0) scale(1.05);
         transform-origin: top center;
         pointer-events: none;
         z-index: 6;
@@ -319,7 +321,7 @@
           <div id="pullHandle">PULL</div>
         </div>
 
-          <div style="display:flex;flex-direction:column;align-items:flex-end;gap:6px;">
+          <div style="margin-right:4px;display:flex;flex-direction:column;align-items:flex-end;gap:6px;">
             <div id="powerBox"><div id="powerFill"></div></div>
             <div id="powerTxt"><div>Power</div><div id="powerPercent">0%</div></div>
           </div>


### PR DESCRIPTION
## Summary
- Shift Pool Royale power slider elements slightly left
- Reduce pull handle size and enlarge cue image for improved alignment

## Testing
- `npm test` *(fails: assert.ok(events.includes('diceRolled')))*
- `npm run lint` *(fails: 712 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6da464c0c8329bbd33d645cb4a2d5