### PR TITLE
Add Pool Royale pocket net overlay example

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SVG Billiards Pocket Nets Overlay</title>
+  <style>
+    :root{
+      /* Tweakables */
+      --pocket-r: 48;       /* rim radius in px at 1000px width */
+      --net-depth: 56;      /* how far the net funnels inward */
+    }
+    body{margin:0;background:#0c1020;display:grid;place-items:center;height:100vh}
+    .stage{position:relative;max-width:min(92vw, 760px);box-shadow:0 20px 60px rgba(0,0,0,.35);border-radius:12px;overflow:hidden}
+    .bg{display:block;width:100%;height:auto}
+    svg.overlay{position:absolute;inset:0;width:100%;height:100%;pointer-events:none}
+  </style>
+</head>
+<body>
+  <div class="stage">
+    <!-- Embedded green table background as inline SVG to keep this file standalone -->
+    <img class="bg" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAwIDE1MDAiPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9IiMwMDgwMDAiLz48L3N2Zz4=" alt="Pool table" />
+    <!-- Vector-only overlay for nets -->
+    <svg class="overlay" viewBox="0 0 1000 1500" preserveAspectRatio="xMidYMid slice">
+      <defs>
+        <!-- Diamond mesh pattern built with both <line> and <path> elements -->
+        <pattern id="mesh" width="12" height="12" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+          <!-- Horizontal line drawn with <line> -->
+          <line x1="0" y1="0" x2="12" y2="0" stroke="white" stroke-width="1.2" opacity="0.55"/>
+          <!-- Vertical line drawn with <path> to satisfy element variety -->
+          <path d="M0 0v12" stroke="white" stroke-width="1.2" opacity="0.55"/>
+        </pattern>
+
+        <!-- Soft vignette to make the net look deep -->
+        <radialGradient id="shade" cx="50%" cy="50%" r="60%">
+          <stop offset="65%" stop-color="#000" stop-opacity=".18"/>
+          <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+        </radialGradient>
+      </defs>
+
+      <g id="nets"></g>
+
+      <script>
+        // Configurable pocket centers in the SVG viewBox coordinate space (1000x1500)
+        const RIM_R = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--pocket-r'));
+        const DEPTH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--net-depth'));
+
+        const pockets = [
+          {x: 60,   y: 60},      // top-left corner
+          {x: 500,  y: 60},      // top-middle
+          {x: 940,  y: 60},      // top-right corner
+          {x: 60,   y: 1440},    // bottom-left corner
+          {x: 500,  y: 1440},    // bottom-middle
+          {x: 940,  y: 1440},    // bottom-right corner
+        ];
+
+        const svg = document.currentScript.ownerSVGElement;
+        const defs = svg.querySelector('defs');
+        const g   = svg.getElementById('nets');
+
+        // Helper to create elements
+        const el = (name, attrs={}) => Object.assign(document.createElementNS('http://www.w3.org/2000/svg', name), attrs);
+
+        pockets.forEach(({x,y}, i) => {
+          // Mask to clip funnel contents to the pocket rim
+          const m = el('mask', { id: `pocket-mask-${i}` });
+          m.append(el('circle', { cx: x, cy: y, r: RIM_R, fill: 'white' }));
+          defs.append(m);
+
+          const group = el('g');
+
+          // Subtle drop shadow under rim
+          group.append(el('circle', {cx: x+3, cy: y+3, r: RIM_R+2, fill: 'black', opacity: 0.18}));
+
+          // Mesh funnel: approximate by scaling a circle down to mimic depth
+          group.append(el('ellipse', {
+            cx: x,
+            cy: y + DEPTH * 0.35,
+            rx: RIM_R * 0.85,
+            ry: RIM_R * 0.55,
+            fill: 'url(#mesh)',
+            opacity: 0.85,
+            mask: `url(#pocket-mask-${i})`
+          }));
+
+          // Inner shade for depth
+          group.append(el('circle', {
+            cx: x,
+            cy: y + DEPTH * 0.25,
+            r: RIM_R * 0.95,
+            fill: 'url(#shade)',
+            mask: `url(#pocket-mask-${i})`
+          }));
+
+          // Rim
+          group.append(el('circle', {cx: x, cy: y, r: RIM_R, fill: 'none', stroke: '#1a1a1a', 'stroke-width': 8, opacity: 0.9}));
+          group.append(el('circle', {cx: x, cy: y, r: RIM_R-5, fill: 'none', stroke: '#c2a44b', 'stroke-width': 3, opacity: 0.9}));
+
+          g.append(group);
+        });
+      </script>
+    </svg>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone HTML example demonstrating SVG pocket nets over a pool table background

## Testing
- `npm test` *(fails: snake API endpoints and socket events)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dfad16ec8329b2e8d6578a27a107