### PR TITLE
chore(texas-holdem): adjust status, avatar rings and card sound

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -27,7 +27,7 @@
       .seats{ position:absolute; inset:0; z-index:2 }
       .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px) }
       .seat.small{ --card-scale:.8; }
-      .avatar{ width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%, #fff, #ddd 40%, #bbb 60%, #999 100%); color:#111; font-size:28px; border:4px solid #000; box-shadow:0 8px 20px var(--shadow); overflow:hidden; position:relative }
+      .avatar{ width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%, #fff, #ddd 40%, #bbb 60%, #999 100%); color:#111; font-size:28px; border:2px solid #000; box-shadow:0 8px 20px var(--shadow); overflow:hidden; position:relative }
       .avatar-wrap{ position:relative; width:var(--avatar-size); height:var(--avatar-size); display:grid; place-items:center; }
       .timer-ring{ position:absolute; inset:-6px; border-radius:50%; background:conic-gradient(#f5cc4e var(--progress,0deg), transparent 0); -webkit-mask:radial-gradient(farthest-side,transparent calc(100% - 6px),#000 calc(100% - 6px)); mask:radial-gradient(farthest-side,transparent calc(100% - 6px),#000 calc(100% - 6px)); pointer-events:none }
       .cards{ display:flex; gap:6px; flex-wrap:nowrap }
@@ -85,7 +85,8 @@
       background:var(--seat-bg-color);
       box-shadow:4px 4px 0 #d4ccb3;
     }
-    .seat-inner .avatar{ box-shadow:0 0 0 4px #000; }
+    .seat-inner .avatar{ box-shadow:0 0 0 2px #000; }
+    .avatar.turn{ box-shadow:0 0 0 2px #facc15; border-color:#facc15; }
     .seat-inner .name{
       padding:2px 6px;
       border:2px solid #000;
@@ -154,7 +155,7 @@
     #allIn{ background:#dc2626; padding:2px 8px; border:2px solid #000; border-radius:8px; font-weight:600; font-size:12px; }
     .tpc-total{ position:absolute; top:8px; left:8px; font-size:16px; display:flex; align-items:center; gap:4px; }
     .tpc-total img{ width:36px; height:36px; transform:translateY(-2px); }
-    #status{ position:absolute; top:52%; left:50%; transform:translate(-50%, 0); z-index:2; font-weight:900; letter-spacing:.3px; white-space:nowrap; }
+    #status{ position:absolute; top:50%; left:50%; transform:translate(-50%, 0); z-index:2; font-weight:900; letter-spacing:.3px; white-space:nowrap; }
     .status-default{ color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
     .tpc-inline-icon{ width:1em; height:1em; margin-left:2px; transform:translateY(2px); }
       .top-controls{position:absolute;top:8px;right:8px;display:flex;gap:4px;z-index:10}
@@ -212,7 +213,7 @@
   <audio id="sndTimer" src="https://cdn.jsdelivr.net/gh/naptha/tiny-sound@master/sounds/beep1.ogg"></audio>
   <audio id="sndCallRaise" src="assets/sounds/Callraischip.mp3"></audio>
   <audio id="sndAllIn" src="assets/sounds/allinpushchips2-39133.mp3"></audio>
-  <audio id="sndFlip" src="assets/sounds/flipcard-91468.mp3"></audio>
+  <audio id="sndFlip" src="assets/sounds/billiard-pool-hit-371618.mp3"></audio>
   <audio id="sndKnock" src="assets/sounds/wooden-door-knock-102902.mp3"></audio>
     <div class="top-controls">
       <button id="settingsBtn">⚙️</button>

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -594,9 +594,12 @@ function moveCardsToFolded(idx) {
 
 function setPlayerTurnIndicator(idx) {
   document.querySelectorAll('.seat-inner .cards').forEach((c) => c.classList.remove('turn'));
+  document.querySelectorAll('.avatar').forEach((a) => a.classList.remove('turn'));
   if (idx === null || idx === undefined || idx < 0) return;
   const cards = document.getElementById('cards-' + idx);
   if (cards) cards.classList.add('turn');
+  const avatar = document.getElementById('avatar-' + idx);
+  if (avatar) avatar.classList.add('turn');
 }
 
 function showControls() {


### PR DESCRIPTION
## Summary
- lift end-of-game status text slightly
- slim avatar borders and highlight current player's turn
- restore original card deal sound

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e142160c8329998d4ad46280dddf