### PR TITLE
Replace pool sound effect in Texas Hold'em

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -213,7 +213,7 @@
   <audio id="sndTimer" src="https://cdn.jsdelivr.net/gh/naptha/tiny-sound@master/sounds/beep1.ogg"></audio>
   <audio id="sndCallRaise" src="assets/sounds/Callraischip.mp3"></audio>
   <audio id="sndAllIn" src="assets/sounds/allinpushchips2-39133.mp3"></audio>
-  <audio id="sndFlip" src="assets/sounds/billiard-pool-hit-371618.mp3"></audio>
+  <audio id="sndFlip" src="assets/sounds/flipcard-91468.mp3"></audio>
   <audio id="sndKnock" src="assets/sounds/wooden-door-knock-102902.mp3"></audio>
     <div class="top-controls">
       <button id="settingsBtn">⚙️</button>


### PR DESCRIPTION
## Summary
- use proper card flip sound for Texas Hold'em instead of pool shot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6ea249b98832983a0fb33d439a328