### PR TITLE
feat: add Texas Hold'em sound cues for folds and flips

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -213,6 +213,7 @@
   <audio id="sndTimer" src="https://cdn.jsdelivr.net/gh/naptha/tiny-sound@master/sounds/beep1.ogg"></audio>
   <audio id="sndCallRaise" src="assets/sounds/Callraischip.mp3"></audio>
   <audio id="sndAllIn" src="assets/sounds/allinpushchips2-39133.mp3"></audio>
+  <audio id="sndFold" src="assets/sounds/pounding-cards-on-table-99355.mp3"></audio>
   <audio id="sndFlip" src="assets/sounds/flipcard-91468.mp3"></audio>
   <audio id="sndKnock" src="assets/sounds/wooden-door-knock-102902.mp3"></audio>
     <div class="top-controls">

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -61,6 +61,8 @@ function applySettings() {
   if (callRaise) callRaise.volume = settings.muteChips ? 0 : settings.chipVolume;
   const allIn = document.getElementById('sndAllIn');
   if (allIn) allIn.volume = settings.muteChips ? 0 : settings.chipVolume;
+  const fold = document.getElementById('sndFold');
+  if (fold) fold.volume = settings.muteChips ? 0 : settings.chipVolume;
   const timer = document.getElementById('sndTimer');
   if (timer) timer.volume = settings.muteOthers ? 0 : 1;
   const knock = document.getElementById('sndKnock');
@@ -155,6 +157,15 @@ function playCallRaiseSound() {
 
 function playAllInSound() {
   const snd = document.getElementById('sndAllIn');
+  if (snd && !settings.muteChips) {
+    snd.volume = settings.chipVolume;
+    snd.currentTime = 0;
+    snd.play();
+  }
+}
+
+function playFoldSound() {
+  const snd = document.getElementById('sndFold');
   if (snd && !settings.muteChips) {
     snd.volume = settings.chipVolume;
     snd.currentTime = 0;
@@ -589,7 +600,7 @@ function moveCardsToFolded(idx) {
       { once: true }
     );
   });
-  playFlipSound();
+  playFoldSound();
 }
 
 function setPlayerTurnIndicator(idx) {


### PR DESCRIPTION
## Summary
- play new folding sound effect when a player folds
- limit card flip sound to dealing and community flips only

## Testing
- `npm test` *(fails: pass 44, fail 4)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f4d055108329823859165416254f