### PR TITLE
Fix target ball direction and dynamic pool sounds

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -437,13 +437,13 @@
       src.start(0, half, half);
     }
 
-    function playPocket() {
+    function playPocket(vol) {
       audioCtx.resume();
       if (!pocketBuffer) return;
       var src = audioCtx.createBufferSource();
       src.buffer = pocketBuffer;
       var gain = audioCtx.createGain();
-      gain.gain.value = 1;
+      gain.gain.value = clamp(vol, 0, 1);
       src.connect(gain).connect(audioCtx.destination);
       var d = pocketBuffer.duration;
       src.start(0, Math.max(0, d - 1), 1);
@@ -649,10 +649,30 @@
         var R = TABLE_W - BORDER - BALL_R;
         var T = BORDER_TOP + BALL_R;
         var B = TABLE_H - BORDER_BOTTOM - BALL_R;
-        if (b.p.x < L) { b.p.x = L; b.v.x *= -BOUNCE; if (b.n === 0) b.spinApplied = true; }
-        if (b.p.x > R) { b.p.x = R; b.v.x *= -BOUNCE; if (b.n === 0) b.spinApplied = true; }
-        if (b.p.y < T) { b.p.y = T; b.v.y *= -BOUNCE; if (b.n === 0) b.spinApplied = true; }
-        if (b.p.y > B) { b.p.y = B; b.v.y *= -BOUNCE; if (b.n === 0) b.spinApplied = true; }
+        if (b.p.x < L) {
+          b.p.x = L;
+          playCueHit(clamp(Math.abs(b.v.x)/4000,0,1)*0.5);
+          b.v.x *= -BOUNCE;
+          if (b.n === 0) b.spinApplied = true;
+        }
+        if (b.p.x > R) {
+          b.p.x = R;
+          playCueHit(clamp(Math.abs(b.v.x)/4000,0,1)*0.5);
+          b.v.x *= -BOUNCE;
+          if (b.n === 0) b.spinApplied = true;
+        }
+        if (b.p.y < T) {
+          b.p.y = T;
+          playCueHit(clamp(Math.abs(b.v.y)/4000,0,1)*0.5);
+          b.v.y *= -BOUNCE;
+          if (b.n === 0) b.spinApplied = true;
+        }
+        if (b.p.y > B) {
+          b.p.y = B;
+          playCueHit(clamp(Math.abs(b.v.y)/4000,0,1)*0.5);
+          b.v.y *= -BOUNCE;
+          if (b.n === 0) b.spinApplied = true;
+        }
       }
 
       // Perplasje ball-ball
@@ -684,7 +704,8 @@
           if (b2.pocketed) continue;
           var ddx = b2.p.x - p.x, ddy = b2.p.y - p.y;
           if (Math.hypot(ddx,ddy) < POCKET_R*0.9) {
-            playPocket();
+            var pocketVol = clamp(Math.hypot(b2.v.x, b2.v.y)/4000, 0, 1);
+            playPocket(pocketVol);
             if (b2.n === 0) {
               scratch = true;
               cueBallFree = true;
@@ -1006,12 +1027,8 @@
 
       if (target) {
         var tx = target.p.x, ty = target.p.y;
-        var impactCueX = cue.p.x + dir.x * step * hitStep;
-        var impactCueY = cue.p.y + dir.y * step * hitStep;
-        // Direction from cue ball to target ball at impact
-        var hitN = { x: tx - impactCueX, y: ty - impactCueY };
-        var nL = len(hitN.x, hitN.y) || 1;
-        hitN.x /= nL; hitN.y /= nL;
+        // Direction the target ball will travel after impact
+        var hitN = norm(tx - cue.p.x, ty - cue.p.y);
 
         // Draw contact spot on the target ball
         var hitSpotX = tx - hitN.x * BALL_R;


### PR DESCRIPTION
## Summary
- Correct target ball projection to use normalized cue-to-target vector
- Trigger reduced-volume cue hit sound on cushion impacts and scale pocket sounds by impact speed

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint` *(fails: 712 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f889b72c83299029fc539b708752