### PR TITLE
Adjust Pool Royale collision sounds

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -421,7 +421,7 @@
       var gain = audioCtx.createGain();
       gain.gain.value = clamp(vol, 0, 1);
       src.connect(gain).connect(audioCtx.destination);
-      var half = hitBuffer.duration / 2;
+      var half = 0.5;
       src.start(0, 0, half);
     }
 
@@ -433,17 +433,17 @@
       var gain = audioCtx.createGain();
       gain.gain.value = clamp(vol, 0, 1);
       src.connect(gain).connect(audioCtx.destination);
-      var half = hitBuffer.duration / 2;
+      var half = 0.5;
       src.start(0, half, half);
     }
 
-    function playPocket() {
+    function playPocket(vol) {
       audioCtx.resume();
       if (!pocketBuffer) return;
       var src = audioCtx.createBufferSource();
       src.buffer = pocketBuffer;
       var gain = audioCtx.createGain();
-      gain.gain.value = 1;
+      gain.gain.value = clamp(vol, 0, 1);
       src.connect(gain).connect(audioCtx.destination);
       var d = pocketBuffer.duration;
       src.start(0, Math.max(0, d - 1), 1);
@@ -649,10 +649,34 @@
         var R = TABLE_W - BORDER - BALL_R;
         var T = BORDER_TOP + BALL_R;
         var B = TABLE_H - BORDER_BOTTOM - BALL_R;
-        if (b.p.x < L) { b.p.x = L; b.v.x *= -BOUNCE; if (b.n === 0) b.spinApplied = true; }
-        if (b.p.x > R) { b.p.x = R; b.v.x *= -BOUNCE; if (b.n === 0) b.spinApplied = true; }
-        if (b.p.y < T) { b.p.y = T; b.v.y *= -BOUNCE; if (b.n === 0) b.spinApplied = true; }
-        if (b.p.y > B) { b.p.y = B; b.v.y *= -BOUNCE; if (b.n === 0) b.spinApplied = true; }
+        if (b.p.x < L) {
+          var spd = Math.hypot(b.v.x, b.v.y);
+          b.p.x = L;
+          b.v.x *= -BOUNCE;
+          if (b.n === 0) b.spinApplied = true;
+          playCueHit(clamp(spd / 4000, 0, 1) * 0.3);
+        }
+        if (b.p.x > R) {
+          var spd = Math.hypot(b.v.x, b.v.y);
+          b.p.x = R;
+          b.v.x *= -BOUNCE;
+          if (b.n === 0) b.spinApplied = true;
+          playCueHit(clamp(spd / 4000, 0, 1) * 0.3);
+        }
+        if (b.p.y < T) {
+          var spd = Math.hypot(b.v.x, b.v.y);
+          b.p.y = T;
+          b.v.y *= -BOUNCE;
+          if (b.n === 0) b.spinApplied = true;
+          playCueHit(clamp(spd / 4000, 0, 1) * 0.3);
+        }
+        if (b.p.y > B) {
+          var spd = Math.hypot(b.v.x, b.v.y);
+          b.p.y = B;
+          b.v.y *= -BOUNCE;
+          if (b.n === 0) b.spinApplied = true;
+          playCueHit(clamp(spd / 4000, 0, 1) * 0.3);
+        }
       }
 
       // Perplasje ball-ball
@@ -684,7 +708,8 @@
           if (b2.pocketed) continue;
           var ddx = b2.p.x - p.x, ddy = b2.p.y - p.y;
           if (Math.hypot(ddx,ddy) < POCKET_R*0.9) {
-            playPocket();
+            var spd = Math.hypot(b2.v.x, b2.v.y);
+            playPocket(clamp(spd/4000,0,1));
             if (b2.n === 0) {
               scratch = true;
               cueBallFree = true;


### PR DESCRIPTION
## Summary
- split billiard hit audio at 0.5s; first half for cue & rails, second for ball collisions
- scale wall- and pocket-hit volumes based on impact speed

## Testing
- `npm test` *(fails: ERR_DLOPEN_FAILED and test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ffdb1158832998f98d653efdb4c8