### PR TITLE
fix: correct target ball direction

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1008,8 +1008,8 @@
         var tx = target.p.x, ty = target.p.y;
         var impactCueX = cue.p.x + dir.x * step * hitStep;
         var impactCueY = cue.p.y + dir.y * step * hitStep;
-        // Direction from cue ball to target ball at impact
-        var hitN = { x: tx - impactCueX, y: ty - impactCueY };
+        // Direction from cue ball to target ball
+        var hitN = { x: tx - cue.p.x, y: ty - cue.p.y };
         var nL = len(hitN.x, hitN.y) || 1;
         hitN.x /= nL; hitN.y /= nL;
 


### PR DESCRIPTION
## Summary
- fix target ball direction calculation so projected path aligns with cue ball position

## Testing
- `npm test` (fails: snake API endpoints and socket events)
- `npm run lint` (fails: 712 errors)

------
https://chatgpt.com/codex/tasks/task_e_68a6ff6190d08329965d8f8a930252d7