### PR TITLE
Refine pool game audio behavior

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -421,8 +421,7 @@
       var gain = audioCtx.createGain();
       gain.gain.value = clamp(vol, 0, 1);
       src.connect(gain).connect(audioCtx.destination);
-      var half = hitBuffer.duration / 2;
-      src.start(0, 0, half);
+      src.start(0, 0, 0.5);
     }
 
     function playBallHit(vol) {
@@ -433,17 +432,16 @@
       var gain = audioCtx.createGain();
       gain.gain.value = clamp(vol, 0, 1);
       src.connect(gain).connect(audioCtx.destination);
-      var half = hitBuffer.duration / 2;
-      src.start(0, half, half);
+      src.start(0, 0.5, 0.5);
     }
 
-    function playPocket() {
+    function playPocket(vol) {
       audioCtx.resume();
       if (!pocketBuffer) return;
       var src = audioCtx.createBufferSource();
       src.buffer = pocketBuffer;
       var gain = audioCtx.createGain();
-      gain.gain.value = 1;
+      gain.gain.value = clamp(vol, 0, 1);
       src.connect(gain).connect(audioCtx.destination);
       var d = pocketBuffer.duration;
       src.start(0, Math.max(0, d - 1), 1);
@@ -649,10 +647,34 @@
         var R = TABLE_W - BORDER - BALL_R;
         var T = BORDER_TOP + BALL_R;
         var B = TABLE_H - BORDER_BOTTOM - BALL_R;
-        if (b.p.x < L) { b.p.x = L; b.v.x *= -BOUNCE; if (b.n === 0) b.spinApplied = true; }
-        if (b.p.x > R) { b.p.x = R; b.v.x *= -BOUNCE; if (b.n === 0) b.spinApplied = true; }
-        if (b.p.y < T) { b.p.y = T; b.v.y *= -BOUNCE; if (b.n === 0) b.spinApplied = true; }
-        if (b.p.y > B) { b.p.y = B; b.v.y *= -BOUNCE; if (b.n === 0) b.spinApplied = true; }
+        if (b.p.x < L) {
+          b.p.x = L;
+          var sx = Math.abs(b.v.x);
+          b.v.x *= -BOUNCE;
+          if (b.n === 0) b.spinApplied = true;
+          playCueHit(clamp(sx/4000,0,1)*0.5);
+        }
+        if (b.p.x > R) {
+          b.p.x = R;
+          var sx2 = Math.abs(b.v.x);
+          b.v.x *= -BOUNCE;
+          if (b.n === 0) b.spinApplied = true;
+          playCueHit(clamp(sx2/4000,0,1)*0.5);
+        }
+        if (b.p.y < T) {
+          b.p.y = T;
+          var sy = Math.abs(b.v.y);
+          b.v.y *= -BOUNCE;
+          if (b.n === 0) b.spinApplied = true;
+          playCueHit(clamp(sy/4000,0,1)*0.5);
+        }
+        if (b.p.y > B) {
+          b.p.y = B;
+          var sy2 = Math.abs(b.v.y);
+          b.v.y *= -BOUNCE;
+          if (b.n === 0) b.spinApplied = true;
+          playCueHit(clamp(sy2/4000,0,1)*0.5);
+        }
       }
 
       // Perplasje ball-ball
@@ -684,7 +706,8 @@
           if (b2.pocketed) continue;
           var ddx = b2.p.x - p.x, ddy = b2.p.y - p.y;
           if (Math.hypot(ddx,ddy) < POCKET_R*0.9) {
-            playPocket();
+            var spd = Math.hypot(b2.v.x, b2.v.y);
+            playPocket(clamp(spd/4000,0,1));
             if (b2.n === 0) {
               scratch = true;
               cueBallFree = true;


### PR DESCRIPTION
## Summary
- Split cue hit sound into fixed 0.5s halves and reuse for ball and rail impacts
- Scale rail and pocket sound volumes based on impact speed

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*
- `npm run lint` *(fails: 712 problems (712 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a70a4d210c83298207c47cf90ca5e6