### PR TITLE
Disable online multiplayer mode

### DIFF
--- a/webapp/src/components/TableSelector.jsx
+++ b/webapp/src/components/TableSelector.jsx
@@ -5,14 +5,14 @@ export default function TableSelector({ tables, selected, onSelect }) {
     <div className="space-y-2">
       {tables.map((t, idx) => (
         <React.Fragment key={t.id}>
-          {idx === 1 && tables[0]?.id === 'single' && (
-            <div className="h-4" />
-          )}
+          {idx === 1 && tables[0]?.id === 'single' && <div className="h-4" />}
+          <div className="relative">
           <button
-            onClick={() => onSelect(t)}
+            onClick={() => !t.disabled && onSelect(t)}
+            disabled={t.disabled}
             className={`lobby-tile w-full flex justify-between ${
               selected?.id === t.id ? 'lobby-selected' : ''
-            }`}
+            } ${t.disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
           >
             <span>{t.label || `Table ${t.capacity}p`}</span>
             {t.capacity && (
@@ -21,6 +21,12 @@ export default function TableSelector({ tables, selected, onSelect }) {
               </span>
             )}
           </button>
+          {t.disabled && (
+            <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+              Under development
+            </span>
+          )}
+          </div>
         </React.Fragment>
       ))}
     </div>

--- a/webapp/src/pages/Games/BrickBreakerLobby.jsx
+++ b/webapp/src/pages/Games/BrickBreakerLobby.jsx
@@ -91,15 +91,24 @@ export default function BrickBreakerLobby() {
         <div className="flex gap-2">
           {[
             { id: 'local', label: 'Local (AI)' },
-            { id: 'online', label: 'Online' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setMode(id)}
-              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
+            { id: 'online', label: 'Online', disabled: true }
+          ].map(({ id, label, disabled }) => (
+            <div key={id} className="relative">
+              <button
+                onClick={() => !disabled && setMode(id)}
+                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                  disabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={disabled}
+              >
+                {label}
+              </button>
+              {disabled && (
+                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                  Under development
+                </span>
+              )}
+            </div>
           ))}
         </div>
       </div>

--- a/webapp/src/pages/Games/BubblePopRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/BubblePopRoyaleLobby.jsx
@@ -88,15 +88,24 @@ export default function BubblePopRoyaleLobby() {
         <div className="flex gap-2">
           {[
             { id: 'local', label: 'Local (AI)' },
-            { id: 'online', label: 'Online' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setMode(id)}
-              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
+            { id: 'online', label: 'Online', disabled: true }
+          ].map(({ id, label, disabled }) => (
+            <div key={id} className="relative">
+              <button
+                onClick={() => !disabled && setMode(id)}
+                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                  disabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={disabled}
+              >
+                {label}
+              </button>
+              {disabled && (
+                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                  Under development
+                </span>
+              )}
+            </div>
           ))}
         </div>
       </div>

--- a/webapp/src/pages/Games/BubbleSmashRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/BubbleSmashRoyaleLobby.jsx
@@ -88,15 +88,24 @@ export default function BubbleSmashRoyaleLobby() {
         <div className="flex gap-2">
           {[
             { id: 'local', label: 'Local (AI)' },
-            { id: 'online', label: 'Online' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setMode(id)}
-              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
+            { id: 'online', label: 'Online', disabled: true }
+          ].map(({ id, label, disabled }) => (
+            <div key={id} className="relative">
+              <button
+                onClick={() => !disabled && setMode(id)}
+                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                  disabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={disabled}
+              >
+                {label}
+              </button>
+              {disabled && (
+                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                  Under development
+                </span>
+              )}
+            </div>
           ))}
         </div>
       </div>

--- a/webapp/src/pages/Games/CrazyDiceLobby.jsx
+++ b/webapp/src/pages/Games/CrazyDiceLobby.jsx
@@ -13,9 +13,9 @@ export default function CrazyDiceLobby() {
 
   const TABLES = [
     { id: 'single', label: 'Single Player vs AI', capacity: 1 },
-    { id: '2p', label: 'Table 2p', capacity: 2 },
-    { id: '3p', label: 'Table 3p', capacity: 3 },
-    { id: '4p', label: 'Table 4p', capacity: 4 },
+    { id: '2p', label: 'Table 2p', capacity: 2, disabled: true },
+    { id: '3p', label: 'Table 3p', capacity: 3, disabled: true },
+    { id: '4p', label: 'Table 4p', capacity: 4, disabled: true },
   ];
 
   const [table, setTable] = useState(TABLES[0]);

--- a/webapp/src/pages/Games/FallingBallLobby.jsx
+++ b/webapp/src/pages/Games/FallingBallLobby.jsx
@@ -89,15 +89,24 @@ export default function FallingBallLobby() {
         <div className="flex gap-2">
           {[
             { id: 'local', label: 'Local (AI)' },
-            { id: 'online', label: 'Online' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setMode(id)}
-              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
+            { id: 'online', label: 'Online', disabled: true }
+          ].map(({ id, label, disabled }) => (
+            <div key={id} className="relative">
+              <button
+                onClick={() => !disabled && setMode(id)}
+                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                  disabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={disabled}
+              >
+                {label}
+              </button>
+              {disabled && (
+                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                  Under development
+                </span>
+              )}
+            </div>
           ))}
         </div>
       </div>

--- a/webapp/src/pages/Games/FruitSliceRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/FruitSliceRoyaleLobby.jsx
@@ -88,15 +88,24 @@ export default function FruitSliceRoyaleLobby() {
         <div className="flex gap-2">
           {[
             { id: 'local', label: 'Local (AI)' },
-            { id: 'online', label: 'Online' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setMode(id)}
-              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
+            { id: 'online', label: 'Online', disabled: true }
+          ].map(({ id, label, disabled }) => (
+            <div key={id} className="relative">
+              <button
+                onClick={() => !disabled && setMode(id)}
+                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                  disabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={disabled}
+              >
+                {label}
+              </button>
+              {disabled && (
+                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                  Under development
+                </span>
+              )}
+            </div>
           ))}
         </div>
       </div>

--- a/webapp/src/pages/Games/GoalRushLobby.jsx
+++ b/webapp/src/pages/Games/GoalRushLobby.jsx
@@ -69,15 +69,24 @@ export default function GoalRushLobby() {
         <div className="flex gap-2">
           {[
             { id: 'ai', label: 'Vs AI' },
-            { id: 'online', label: '1v1 Online' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setMode(id)}
-              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
+            { id: 'online', label: '1v1 Online', disabled: true }
+          ].map(({ id, label, disabled }) => (
+            <div key={id} className="relative">
+              <button
+                onClick={() => !disabled && setMode(id)}
+                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                  disabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={disabled}
+              >
+                {label}
+              </button>
+              {disabled && (
+                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                  Under development
+                </span>
+              )}
+            </div>
           ))}
         </div>
       </div>

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -93,9 +93,9 @@ export default function Lobby() {
     if (game === 'snake') {
       setTables([
         { id: 'single', label: 'Single Player vs AI', capacity: 1 },
-        { id: 'snake-2', label: 'Table 2 Players', capacity: 2 },
-        { id: 'snake-3', label: 'Table 3 Players', capacity: 3 },
-        { id: 'snake-4', label: 'Table 4 Players', capacity: 4 }
+        { id: 'snake-2', label: 'Table 2 Players', capacity: 2, disabled: true },
+        { id: 'snake-3', label: 'Table 3 Players', capacity: 3, disabled: true },
+        { id: 'snake-4', label: 'Table 4 Players', capacity: 4, disabled: true }
       ]);
     }
   }, [game]);

--- a/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
@@ -68,14 +68,26 @@ export default function MurlanRoyaleLobby() {
       <div className="space-y-2">
         <h3 className="font-semibold">Mode</h3>
         <div className="flex gap-2">
-          {[{ id: 'local', label: 'Local (AI)' }, { id: 'online', label: 'Online' }].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setMode(id)}
-              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
+          {[
+            { id: 'local', label: 'Local (AI)' },
+            { id: 'online', label: 'Online', disabled: true }
+          ].map(({ id, label, disabled }) => (
+            <div key={id} className="relative">
+              <button
+                onClick={() => !disabled && setMode(id)}
+                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                  disabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={disabled}
+              >
+                {label}
+              </button>
+              {disabled && (
+                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                  Under development
+                </span>
+              )}
+            </div>
           ))}
         </div>
       </div>

--- a/webapp/src/pages/Games/PollRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PollRoyaleLobby.jsx
@@ -67,15 +67,24 @@ export default function PollRoyaleLobby() {
         <div className="flex gap-2">
           {[
             { id: 'ai', label: 'Vs AI' },
-            { id: 'online', label: '1v1 Online' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setMode(id)}
-              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
+            { id: 'online', label: '1v1 Online', disabled: true }
+          ].map(({ id, label, disabled }) => (
+            <div key={id} className="relative">
+              <button
+                onClick={() => !disabled && setMode(id)}
+                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                  disabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={disabled}
+              >
+                {label}
+              </button>
+              {disabled && (
+                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                  Under development
+                </span>
+              )}
+            </div>
           ))}
         </div>
       </div>

--- a/webapp/src/pages/Games/TetrisRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/TetrisRoyaleLobby.jsx
@@ -88,15 +88,24 @@ export default function TetrisRoyaleLobby() {
         <div className="flex gap-2">
           {[
             { id: 'local', label: 'Local (AI)' },
-            { id: 'online', label: 'Online' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setMode(id)}
-              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
+            { id: 'online', label: 'Online', disabled: true }
+          ].map(({ id, label, disabled }) => (
+            <div key={id} className="relative">
+              <button
+                onClick={() => !disabled && setMode(id)}
+                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                  disabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={disabled}
+              >
+                {label}
+              </button>
+              {disabled && (
+                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                  Under development
+                </span>
+              )}
+            </div>
           ))}
         </div>
       </div>

--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -74,14 +74,26 @@ export default function TexasHoldemLobby() {
       <div className="space-y-2">
         <h3 className="font-semibold">Mode</h3>
         <div className="flex gap-2">
-          {[{ id: 'local', label: 'Local (AI)' }, { id: 'online', label: 'Online' }].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setMode(id)}
-              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
+          {[
+            { id: 'local', label: 'Local (AI)' },
+            { id: 'online', label: 'Online', disabled: true }
+          ].map(({ id, label, disabled }) => (
+            <div key={id} className="relative">
+              <button
+                onClick={() => !disabled && setMode(id)}
+                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                  disabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={disabled}
+              >
+                {label}
+              </button>
+              {disabled && (
+                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                  Under development
+                </span>
+              )}
+            </div>
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- disable online buttons across all lobbies and add "Under development" overlay
- prevent selecting online tables via TableSelector

## Testing
- `npm test` (fails: test timed out after 20000ms)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a70e167ff88329b652030735036fcc