### PR TITLE
feat: add texas holdem room support

### DIFF
--- a/bot/logic/texasHoldemGame.js
+++ b/bot/logic/texasHoldemGame.js
@@ -1,0 +1,230 @@
+import { createDeck, shuffle, dealCommunity, compareHands } from '../../lib/texasHoldem.js';
+
+// Interactive Texas Hold'em engine used by TexasHoldemRoom.
+// Tracks deck, betting rounds, pots and winners.
+export class TexasHoldemGame {
+  constructor(playerIds, options = {}) {
+    const {
+      startingChips = 100,
+      blinds = { small: 5, big: 10 }
+    } = options;
+    this.players = playerIds.map((id, idx) => ({
+      id,
+      index: idx,
+      hand: [],
+      chips: startingChips,
+      bet: 0,
+      totalBet: 0,
+      folded: false,
+      allIn: false
+    }));
+    this.blinds = blinds;
+    this.startingChips = startingChips;
+    this.resetHand();
+  }
+
+  // Prepare a new hand
+  resetHand() {
+    this.deck = shuffle(createDeck());
+    this.community = [];
+    this.pot = 0;
+    this.currentBet = 0;
+    this.round = 'preflop';
+    this.dealer = 0; // for now dealer is player 0
+    this.turn = 0;
+    this.calls = 0;
+    this.players.forEach((p) => {
+      p.hand = [];
+      p.bet = 0;
+      p.totalBet = 0;
+      p.folded = false;
+      p.allIn = false;
+    });
+    this.dealHole();
+    this.postBlinds();
+    this.turn = this.nextActive((this.dealer + 3) % this.players.length);
+  }
+
+  // Deal two cards to each player
+  dealHole() {
+    for (let r = 0; r < 2; r++) {
+      for (const p of this.players) {
+        p.hand.push(this.deck.pop());
+      }
+    }
+  }
+
+  // Post blinds from players 1 and 2
+  postBlinds() {
+    const sb = this.players[(this.dealer + 1) % this.players.length];
+    const bb = this.players[(this.dealer + 2) % this.players.length];
+    sb.chips -= this.blinds.small;
+    sb.bet = this.blinds.small;
+    sb.totalBet = this.blinds.small;
+    bb.chips -= this.blinds.big;
+    bb.bet = this.blinds.big;
+    bb.totalBet = this.blinds.big;
+    this.pot = this.blinds.small + this.blinds.big;
+    this.currentBet = this.blinds.big;
+    this.calls = 0;
+  }
+
+  // Find next player who hasn't folded or gone all-in
+  nextActive(start) {
+    let i = start;
+    const len = this.players.length;
+    while (true) {
+      const p = this.players[i];
+      if (!p.folded && !p.allIn) return i;
+      i = (i + 1) % len;
+    }
+  }
+
+  // Handle a player's action: fold/call/check/raise
+  playerAction(playerId, action) {
+    const idx = this.players.findIndex((p) => p.id === playerId);
+    if (idx !== this.turn) return { error: 'Not your turn' };
+    const p = this.players[idx];
+    const toCall = this.currentBet - p.bet;
+    if (action === 'fold') {
+      p.folded = true;
+    } else if (action === 'raise') {
+      const raiseTo = toCall + this.blinds.big;
+      const amount = Math.min(raiseTo, p.chips);
+      p.chips -= amount;
+      p.bet += amount;
+      p.totalBet += amount;
+      this.pot += amount;
+      if (p.chips === 0) p.allIn = true;
+      this.currentBet = p.bet;
+      this.calls = 1; // raiser counts as call
+    } else if (action === 'call') {
+      const amount = Math.min(toCall, p.chips);
+      p.chips -= amount;
+      p.bet += amount;
+      p.totalBet += amount;
+      this.pot += amount;
+      if (p.chips === 0) p.allIn = true;
+      if (amount === toCall) this.calls++;
+      else {
+        // partial call treated as raise to all-in
+        this.currentBet = p.bet;
+        this.calls = 1;
+      }
+    } else if (action === 'check') {
+      if (toCall > 0) return { error: 'Cannot check' };
+      this.calls++;
+    } else {
+      return { error: 'Invalid action' };
+    }
+
+    // Move turn to next player
+    const remaining = this.players.filter((pl) => !pl.folded && !pl.allIn);
+    if (remaining.length <= 1) {
+      return { showdown: this.showdown() };
+    }
+
+    if (this.calls >= remaining.length) {
+      this.advanceRound();
+    } else {
+      this.turn = this.nextActive((this.turn + 1) % this.players.length);
+    }
+    return { success: true };
+  }
+
+  advanceRound() {
+    this.players.forEach((p) => (p.bet = 0));
+    this.currentBet = 0;
+    this.calls = 0;
+    this.turn = this.nextActive((this.dealer + 1) % this.players.length);
+    if (this.round === 'preflop') {
+      const { community, deck } = dealCommunity(this.deck);
+      this.community = community.slice(0, 3);
+      this.deck = deck;
+      this.round = 'flop';
+    } else if (this.round === 'flop') {
+      this.community = this.community.concat(this.deck.splice(-1));
+      this.round = 'turn';
+    } else if (this.round === 'turn') {
+      this.community = this.community.concat(this.deck.splice(-1));
+      this.round = 'river';
+    } else {
+      return this.showdown();
+    }
+    this.turn = this.nextActive((this.dealer + 1) % this.players.length);
+    return { round: this.round };
+  }
+
+  buildPots() {
+    const active = this.players.filter((p) => p.totalBet > 0);
+    if (active.length === 0) return [];
+    const bets = [...new Set(active.map((p) => p.totalBet))].sort((a, b) => a - b);
+    let prev = 0;
+    const pots = [];
+    bets.forEach((b) => {
+      const elig = this.players.filter((p) => p.totalBet >= b);
+      const amount = (b - prev) * elig.length;
+      pots.push({ amount, players: elig.map((p) => p.index) });
+      prev = b;
+    });
+    return pots;
+  }
+
+  determineWinners(indices) {
+    let winners = [];
+    indices.forEach((i) => {
+      if (winners.length === 0) {
+        winners = [i];
+        return;
+      }
+      const cmp = compareHands(
+        [...this.players[i].hand, ...this.community],
+        [...this.players[winners[0]].hand, ...this.community]
+      );
+      if (cmp > 0) {
+        winners = [i];
+      } else if (cmp === 0) {
+        winners.push(i);
+      }
+    });
+    return winners;
+  }
+
+  showdown() {
+    const contenders = this.players.filter((p) => !p.folded).map((p) => p.index);
+    const pots = this.buildPots();
+    const results = [];
+    pots.forEach((pot) => {
+      const eligible = pot.players.filter((i) => contenders.includes(i));
+      const winners = this.determineWinners(eligible);
+      const share = pot.amount / winners.length;
+      winners.forEach((i) => {
+        this.players[i].chips += share;
+      });
+      results.push({ pot: pot.amount, winners });
+    });
+    this.round = 'showdown';
+    return results;
+  }
+
+  stateFor(playerId) {
+    return {
+      community: this.community,
+      pot: this.pot,
+      round: this.round,
+      turn: this.players[this.turn]?.id,
+      players: this.players.map((p) => ({
+        id: p.id,
+        chips: p.chips,
+        bet: p.bet,
+        totalBet: p.totalBet,
+        folded: p.folded,
+        allIn: p.allIn,
+        hand: playerId === p.id ? p.hand : []
+      }))
+    };
+  }
+}
+
+export default TexasHoldemGame;
+

--- a/bot/models/TexasHoldemRoom.js
+++ b/bot/models/TexasHoldemRoom.js
@@ -1,0 +1,34 @@
+import mongoose from 'mongoose';
+
+const cardSchema = new mongoose.Schema({ rank: String, suit: String }, { _id: false });
+
+const playerSchema = new mongoose.Schema(
+  {
+    playerId: String,
+    name: String,
+    chips: Number,
+    bet: Number,
+    totalBet: Number,
+    folded: Boolean,
+    disconnected: { type: Boolean, default: false }
+  },
+  { _id: false }
+);
+
+const texasHoldemRoomSchema = new mongoose.Schema({
+  roomId: { type: String, unique: true },
+  capacity: { type: Number, default: 6 },
+  status: { type: String, default: 'waiting' },
+  dealer: { type: Number, default: 0 },
+  currentPlayer: { type: Number, default: 0 },
+  blinds: {
+    small: { type: Number, default: 5 },
+    big: { type: Number, default: 10 }
+  },
+  pot: { type: Number, default: 0 },
+  deck: { type: [cardSchema], default: [] },
+  community: { type: [cardSchema], default: [] },
+  players: { type: [playerSchema], default: [] }
+});
+
+export default mongoose.model('TexasHoldemRoom', texasHoldemRoomSchema);

--- a/bot/texasHoldemEngine.js
+++ b/bot/texasHoldemEngine.js
@@ -1,0 +1,232 @@
+import TexasHoldemRoomModel from './models/TexasHoldemRoom.js';
+import { TexasHoldemGame } from './logic/texasHoldemGame.js';
+
+export class TexasHoldemRoom {
+  constructor(id, io, capacity = 6, options = {}) {
+    this.id = id;
+    this.io = io;
+    this.capacity = capacity;
+    this.options = options;
+    this.players = [];
+    this.status = 'waiting';
+    this.game = null;
+    this.turnTimer = null;
+  }
+
+  addPlayer(playerId, name, socket) {
+    const existing = this.players.find((p) => p.playerId === playerId);
+    if (existing) {
+      existing.socketId = socket.id;
+      existing.disconnected = false;
+      socket.join(this.id);
+      socket.emit('joined', { roomId: this.id });
+      return { success: true };
+    }
+    if (this.players.length >= this.capacity || this.status !== 'waiting') {
+      return { error: 'Room full or game in progress' };
+    }
+    this.players.push({
+      playerId,
+      name,
+      socketId: socket.id,
+      chips: this.options.startingChips || 100,
+      bet: 0,
+      totalBet: 0,
+      folded: false,
+      disconnected: false
+    });
+    socket.join(this.id);
+    this.io.to(this.id).emit('playerJoined', { playerId, name });
+    if (this.players.length === this.capacity) {
+      this.startGame();
+    }
+    return { success: true };
+  }
+
+  startGame() {
+    if (this.status !== 'waiting') return;
+    this.status = 'playing';
+    this.game = new TexasHoldemGame(this.players.map((p) => p.playerId), this.options);
+    // deal hands privately
+    this.players.forEach((p) => {
+      const sock = this.io.sockets.sockets.get(p.socketId);
+      if (sock) sock.emit('holeCards', this.game.players[p.index].hand);
+    });
+    this.emitState();
+  }
+
+  emitState() {
+    const state = this.game.stateFor();
+    this.io.to(this.id).emit('state', state);
+  }
+
+  handleAction(socket, action) {
+    if (this.status !== 'playing') return;
+    const player = this.players.find((p) => p.socketId === socket.id);
+    if (!player) return;
+    const result = this.game.playerAction(player.playerId, action);
+    this.emitState();
+    if (result && result.showdown) {
+      this.io.to(this.id).emit('showdown', result.showdown);
+      this.status = 'waiting';
+      clearTimeout(this.turnTimer);
+    }
+    return result;
+  }
+
+  handleDisconnect(socket) {
+    const player = this.players.find((p) => p.socketId === socket.id);
+    if (player) {
+      player.disconnected = true;
+      if (this.status === 'playing') {
+        this.game.playerAction(player.playerId, 'fold');
+        this.emitState();
+      }
+    }
+  }
+
+  toDoc() {
+    return {
+      roomId: this.id,
+      capacity: this.capacity,
+      status: this.status,
+      dealer: this.game ? this.game.dealer : 0,
+      currentPlayer: this.game ? this.game.turn : 0,
+      blinds: this.game ? this.game.blinds : { small: 5, big: 10 },
+      pot: this.game ? this.game.pot : 0,
+      deck: this.game ? this.game.deck : [],
+      community: this.game ? this.game.community : [],
+      players: this.players.map((p, idx) => ({
+        playerId: p.playerId,
+        name: p.name,
+        chips: this.game ? this.game.players[idx].chips : p.chips,
+        bet: this.game ? this.game.players[idx].bet : p.bet,
+        totalBet: this.game ? this.game.players[idx].totalBet : p.totalBet,
+        folded: this.game ? this.game.players[idx].folded : p.folded,
+        disconnected: p.disconnected
+      }))
+    };
+  }
+}
+
+export class TexasHoldemRoomManager {
+  constructor(io) {
+    this.io = io;
+    this.rooms = new Map();
+  }
+
+  async loadRooms() {
+    const docs = await TexasHoldemRoomModel.find({});
+    for (const doc of docs) {
+      const room = new TexasHoldemRoom(doc.roomId, this.io, doc.capacity, {
+        startingChips: doc.players[0]?.chips || 100,
+        blinds: doc.blinds
+      });
+      room.status = doc.status;
+      room.players = doc.players.map((p, idx) => ({
+        playerId: p.playerId,
+        name: p.name,
+        socketId: null,
+        chips: p.chips,
+        bet: p.bet,
+        totalBet: p.totalBet,
+        folded: p.folded,
+        disconnected: true
+      }));
+      if (doc.status === 'playing') {
+        room.game = new TexasHoldemGame(room.players.map((p) => p.playerId), {
+          startingChips: doc.players[0]?.chips || 100,
+          blinds: doc.blinds
+        });
+        room.game.deck = doc.deck;
+        room.game.community = doc.community;
+        room.game.pot = doc.pot;
+        room.game.dealer = doc.dealer;
+        room.game.turn = doc.currentPlayer;
+        room.game.players.forEach((gp, i) => {
+          gp.chips = doc.players[i].chips;
+          gp.bet = doc.players[i].bet;
+          gp.totalBet = doc.players[i].totalBet;
+          gp.folded = doc.players[i].folded;
+        });
+      }
+      this.rooms.set(room.id, room);
+    }
+  }
+
+  async saveRoom(room) {
+    await TexasHoldemRoomModel.findOneAndUpdate({ roomId: room.id }, room.toDoc(), {
+      upsert: true
+    });
+  }
+
+  async getRoom(id, capacity = 6, options = {}) {
+    let room = this.rooms.get(id);
+    if (!room) {
+      const record = await TexasHoldemRoomModel.findOne({ roomId: id });
+      if (record) {
+        room = new TexasHoldemRoom(record.roomId, this.io, record.capacity, {
+          startingChips: record.players[0]?.chips || 100,
+          blinds: record.blinds
+        });
+        room.status = record.status;
+        room.players = record.players.map((p) => ({
+          playerId: p.playerId,
+          name: p.name,
+          socketId: null,
+          chips: p.chips,
+          bet: p.bet,
+          totalBet: p.totalBet,
+          folded: p.folded,
+          disconnected: true
+        }));
+      } else {
+        room = new TexasHoldemRoom(id, this.io, capacity, options);
+        await this.saveRoom(room);
+      }
+      this.rooms.set(id, room);
+    }
+    return room;
+  }
+
+  async joinRoom(roomId, playerId, name, socket) {
+    const room = await this.getRoom(roomId);
+    const result = room.addPlayer(playerId, name, socket);
+    await this.saveRoom(room);
+    return result;
+  }
+
+  async handleAction(socket, action) {
+    const room = this.findRoomBySocket(socket.id);
+    if (room) {
+      const res = room.handleAction(socket, action);
+      await this.saveRoom(room);
+      if (room.players.every((p) => p.disconnected)) {
+        this.rooms.delete(room.id);
+        await TexasHoldemRoomModel.deleteOne({ roomId: room.id });
+      }
+      return res;
+    }
+  }
+
+  async handleDisconnect(socket) {
+    const room = this.findRoomBySocket(socket.id);
+    if (room) {
+      room.handleDisconnect(socket);
+      await this.saveRoom(room);
+      if (room.players.every((p) => p.disconnected)) {
+        this.rooms.delete(room.id);
+        await TexasHoldemRoomModel.deleteOne({ roomId: room.id });
+      }
+    }
+  }
+
+  findRoomBySocket(socketId) {
+    for (const room of this.rooms.values()) {
+      if (room.players.some((p) => p.socketId === socketId)) return room;
+    }
+    return null;
+  }
+}
+
+export default { TexasHoldemRoom, TexasHoldemRoomManager };


### PR DESCRIPTION
## Summary
- add TexasHoldemGame module for deck, betting rounds, pots and winners
- create TexasHoldemRoom and manager with MongoDB persistence
- persist room state using TexasHoldemRoom model

## Testing
- `npm test` *(fails: AssertionError in snakeApi.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a73bb79b088329b92464b5c6b8dd91