### PR TITLE
Tweak Texas Hold'em card scaling

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -25,11 +25,9 @@
     .stage{ position:relative; width:100vw; height:100vh; display:grid; place-items:center; perspective:1100px; }
       .stage::before{ content:""; position:absolute; top:0; bottom:0; left:1vw; right:1vw; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
       /* Community cards slightly larger */
-      .center{ position:absolute; left:50%; top:44%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.1; }
+      .center{ position:absolute; left:50%; top:44%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.2; }
       .seats{ position:absolute; inset:0; z-index:2 }
-      .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px) }
-      /* Non-human players use a smaller scale */
-      .seat.small{ --card-scale:.7; }
+      .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px); --card-scale:.7; --avatar-scale:.8; }
       .avatar{ width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%, #fff, #ddd 40%, #bbb 60%, #999 100%); color:#111; font-size:28px; border:2px solid #000; box-shadow:0 8px 20px var(--shadow); overflow:hidden; position:relative }
       .avatar-wrap{ position:relative; width:var(--avatar-size); height:var(--avatar-size); display:grid; place-items:center; }
       .timer-ring{ position:absolute; inset:-6px; border-radius:50%; background:conic-gradient(#f5cc4e var(--progress,0deg), transparent 0); -webkit-mask:radial-gradient(farthest-side,transparent calc(100% - 6px),#000 calc(100% - 6px)); mask:radial-gradient(farthest-side,transparent calc(100% - 6px),#000 calc(100% - 6px)); pointer-events:none }
@@ -66,15 +64,15 @@
 .action-text.check{color:#facc15;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000}
 .action-text.raise{color:#2563eb;text-shadow:-1px -1px 0 #fff,1px -1px 0 #fff,-1px 1px 0 #fff,1px 1px 0 #fff}
 
-.seat.bottom { bottom: 0.5%; left: 50%; transform: translateX(-50%); --card-scale:1.1; }
+.seat.bottom { bottom: 0.5%; left: 50%; transform: translateX(-50%); --card-scale:1.2; --avatar-scale:1; }
 
 .seat.top { top: 1%; left: 50%; transform: translateX(-50%); }
 
-.seat.left { left: 16%; top: 28%; transform: translate(-50%, -50%); --card-scale: .7; }
+.seat.left { left: 16%; top: 28%; transform: translate(-50%, -50%); }
 
 .seat.right { left: 84%; top: 28%; transform: translate(-50%, -50%); }
 
-    .seat.bottom-left { left: 16%; top: 62%; transform: translate(-50%, -50%); --card-scale: .7; }
+    .seat.bottom-left { left: 16%; top: 62%; transform: translate(-50%, -50%); }
 
     .seat.bottom-right { left: 84%; top: 62%; transform: translate(-50%, -50%); }
     .seat-inner{


### PR DESCRIPTION
## Summary
- Enlarge community cards and bottom player's cards by 20%
- Shrink other player card and avatar sizes for clearer hierarchy

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a74d9325188329ab2010475a76ced8