### PR TITLE
Adjust Texas Hold'em slider and card scales

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -25,9 +25,9 @@
     .stage{ position:relative; width:100vw; height:100vh; display:grid; place-items:center; perspective:1100px; }
       .stage::before{ content:""; position:absolute; top:0; bottom:0; left:1vw; right:1vw; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
       /* Community cards slightly larger */
-      .center{ position:absolute; left:50%; top:44%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.14; --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale)); --card-h: calc(var(--card-w)*1.45); }
+      .center{ position:absolute; left:50%; top:44%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.083; --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale)); --card-h: calc(var(--card-w)*1.45); }
       .seats{ position:absolute; inset:0; z-index:2 }
-      .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px); --card-scale:.63; --avatar-scale:.8; --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale)); --card-h: calc(var(--card-w)*1.45); }
+      .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px); --card-scale:.567; --avatar-scale:.8; --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale)); --card-h: calc(var(--card-w)*1.45); }
       .avatar{ width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%, #fff, #ddd 40%, #bbb 60%, #999 100%); color:#111; font-size:28px; border:2px solid #000; box-shadow:0 8px 20px var(--shadow); overflow:hidden; position:relative }
       .avatar-wrap{ position:relative; width:var(--avatar-size); height:var(--avatar-size); display:grid; place-items:center; }
       .timer-ring{ position:absolute; inset:-6px; border-radius:50%; background:conic-gradient(#f5cc4e var(--progress,0deg), transparent 0); -webkit-mask:radial-gradient(farthest-side,transparent calc(100% - 6px),#000 calc(100% - 6px)); mask:radial-gradient(farthest-side,transparent calc(100% - 6px),#000 calc(100% - 6px)); pointer-events:none }
@@ -64,7 +64,7 @@
 .action-text.check{color:#facc15;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000}
 .action-text.raise{color:#2563eb;text-shadow:-1px -1px 0 #fff,1px -1px 0 #fff,-1px 1px 0 #fff,1px 1px 0 #fff}
 
-.seat.bottom { bottom: 0.5%; left: 50%; transform: translateX(-50%); --card-scale:1.14; --avatar-scale:1; --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale)); --card-h: calc(var(--card-w)*1.45); }
+.seat.bottom { bottom: 0.5%; left: 50%; transform: translateX(-50%); --card-scale:1.083; --avatar-scale:1; --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale)); --card-h: calc(var(--card-w)*1.45); }
 
 .seat.top { top: 1%; left: 50%; transform: translateX(-50%); }
 
@@ -152,7 +152,7 @@
     .raise-info{ display:flex; align-items:center; gap:4px; }
       .undo-chip{ width:calc(var(--avatar-size)/1.3); height:calc(var(--avatar-size)/1.3); border:2px solid #000; border-radius:4px; display:flex; align-items:center; justify-content:center; background:#facc15; color:#000; font-weight:700; cursor:pointer; }
     .slider-wrap{ width:calc(var(--avatar-size)*2.5); display:flex; flex-direction:column; align-items:center; gap:4px; }
-    .slider-wrap input[type=range]{ width:90%; }
+      .slider-wrap input[type=range]{ width:85%; }
     #allIn{ background:#dc2626; padding:2px 8px; border:2px solid #000; border-radius:8px; font-weight:600; font-size:12px; }
     .tpc-total{ position:absolute; top:8px; left:8px; font-size:16px; display:flex; align-items:center; gap:4px; }
     .tpc-total img{ width:36px; height:36px; transform:translateY(-2px); }


### PR DESCRIPTION
## Summary
- Shrink raise slider for Texas Hold'em for a shorter adjustment line
- Reduce opponent card size by 10% and scale down player/community cards by 5%

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint` *(fails: 712 errors, see log for details)*

------
https://chatgpt.com/codex/tasks/task_e_68a76117c90083298b2c603fd45a45c0