### PR TITLE
Scale power slider dimensions

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -1,8 +1,8 @@
 /* Power Slider component styles */
 .ps {
-  --ps-width: 56px;
-  --ps-height: 480px;
-  --ps-radius: 28px;
+  --ps-width: 67px;
+  --ps-height: 576px;
+  --ps-radius: 34px;
   --ps-track-bg: rgba(255, 255, 255, 0.15);
   --ps-gradient-low: #ffe066;
   --ps-gradient-mid: #ff8c00;
@@ -101,14 +101,14 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 48px;
+  width: 58px;
   border-radius: 6px;
   background: linear-gradient(
     to bottom,
     var(--ps-gradient-low),
     var(--ps-gradient-high)
   );
-  padding: 6px 2px;
+  padding: 7.2px 2.4px;
   pointer-events: auto;
 }
 
@@ -116,14 +116,14 @@
   font-size: 12px;
   color: #fff;
   line-height: 1;
-  transform: translate(-2px, 2px);
+  transform: translate(-2.4px, 2.4px);
 }
 
 .ps-cue-img {
   margin-top: 4px;
-  width: 48px;
+  width: 58px;
   height: auto;
-  transform: translateX(8px);
+  transform: translateX(9.6px);
 }
 
 .ps-tooltip {
@@ -163,7 +163,7 @@
 .ps-label {
   position: absolute;
   right: 100%;
-  margin-right: 4px;
+  margin-right: 5px;
   font-size: 12px;
   color: var(--ps-tooltip-color);
   user-select: none;


### PR DESCRIPTION
## Summary
- enlarge power slider variables to 120% size
- widen handle and cue image with proportional padding and offsets
- adjust label spacing for scaled layout

## Testing
- `npm test` *(fails: test timed out for snake API endpoints and socket events)*
- `npm run lint` *(fails: 712 errors, pre-existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a7663fb89c8329810829b197e4a7d1