### PR TITLE
Adjust power slider offset

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     #power {
       position: fixed;
       top: 50%;
-      right: 44px;
+      right: 60px;
       transform: translateY(-50%);
     }
     #controls { display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; }


### PR DESCRIPTION
## Summary
- Shift demo power slider left by increasing its `right` offset from 44px to 60px

## Testing
- `npm test` *(fails: ERR_DLOPEN_FAILED, test timed out)*
- `npm run lint` *(fails: 712 errors)*
- `python3 -m http.server 8123` then `curl -s http://localhost:8123/index.html | grep -n "right"`


------
https://chatgpt.com/codex/tasks/task_e_68a7663f40d88329a897fa5d657bfd48