### PR TITLE
Adjust Texas Hold'em layout spacing

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -26,6 +26,7 @@
       .stage::before{ content:""; position:absolute; top:0; bottom:0; left:1vw; right:1vw; background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp') center/cover no-repeat; z-index:0 }
       /* Community cards slightly larger */
       .center{ position:absolute; left:50%; top:44%; transform:translate(-50%,-50%); display:flex; gap:10px; z-index:2; --card-scale:1.083; --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale)); --card-h: calc(var(--card-w)*1.45); }
+      .community{ padding:4px; border:4px solid #000; border-radius:12px; background:var(--seat-bg-color); box-shadow:4px 4px 0 #d4ccb3; }
       .seats{ position:absolute; inset:0; z-index:2 }
       .seat{ position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px, 28vw, 200px); --card-scale:.567; --avatar-scale:.7; --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale)); --card-h: calc(var(--card-w)*1.45); }
       .avatar{ width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%, #fff, #ddd 40%, #bbb 60%, #999 100%); color:#111; font-size:28px; border:2px solid #000; box-shadow:0 8px 20px var(--shadow); overflow:hidden; position:relative }
@@ -68,13 +69,13 @@
 
 .seat.top { top: 1%; left: 50%; transform: translateX(-50%); }
 
-.seat.left { left: 16%; top: 28%; transform: translate(-50%, -50%); }
+.seat.left { left: 16%; top: 26%; transform: translate(-50%, -50%); }
 
-.seat.right { left: 84%; top: 28%; transform: translate(-50%, -50%); }
+.seat.right { left: 84%; top: 26%; transform: translate(-50%, -50%); }
 
-    .seat.bottom-left { left: 16%; top: 62%; transform: translate(-50%, -50%); }
+    .seat.bottom-left { left: 16%; top: 64%; transform: translate(-50%, -50%); }
 
-    .seat.bottom-right { left: 84%; top: 62%; transform: translate(-50%, -50%); }
+    .seat.bottom-right { left: 84%; top: 64%; transform: translate(-50%, -50%); }
     .seat-inner{
       display:flex;
       flex-direction:column;
@@ -133,7 +134,7 @@
         }
         .slider-container{
           position:absolute;
-          bottom:6%;
+          bottom:4%;
           right:1%;
           z-index:5;
           display:flex;
@@ -154,13 +155,13 @@
       .undo-chip{ width:calc(var(--avatar-size)/1.3); height:calc(var(--avatar-size)/1.3); border:2px solid #000; border-radius:4px; display:flex; align-items:center; justify-content:center; background:#facc15; color:#000; font-weight:700; cursor:pointer; }
     .slider-wrap{ width:calc(var(--avatar-size)*2.5); display:flex; flex-direction:column; align-items:center; gap:4px; }
       .slider-wrap input[type=range]{ width:85%; }
-    #allIn{ background:#dc2626; padding:2px 8px; border:2px solid #000; border-radius:8px; font-weight:600; font-size:12px; }
-    .tpc-total{ position:absolute; top:8px; left:8px; font-size:16px; display:flex; align-items:center; gap:4px; }
+    #allIn{ background:#dc2626; padding:2px 8px; border:2px solid #000; border-radius:8px; font-weight:600; font-size:12px; margin-bottom:4px; }
+    .tpc-total{ position:absolute; top:4px; left:8px; font-size:16px; display:flex; align-items:center; gap:4px; }
     .tpc-total img{ width:36px; height:36px; transform:translateY(-2px); }
     #status{ position:absolute; top:50%; left:50%; transform:translate(-50%, 0); z-index:2; font-weight:900; letter-spacing:.3px; white-space:nowrap; }
     .status-default{ color:#ff0; text-shadow:0 2px 6px #000; -webkit-text-stroke:1px #000 }
     .tpc-inline-icon{ width:1em; height:1em; margin-left:2px; transform:translateY(2px); }
-      .top-controls{position:absolute;top:8px;right:8px;display:flex;gap:4px;z-index:10}
+      .top-controls{position:absolute;top:4px;right:8px;display:flex;gap:4px;z-index:10}
       .top-controls button{width:32px;height:32px;padding:0;border:2px solid #000;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#2563eb;color:#fff;font-weight:600;font-size:14px;line-height:1}
       .top-controls button img{width:16px;height:16px}
       #lobbyIcon{flex-direction:column;width:auto;height:auto;padding:2px 5px;border-radius:8px}
@@ -183,8 +184,8 @@
     .pot-wrap{ position:absolute; left:50%; top:33%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
     .pot{ display:flex; gap:4px; }
     .pot-total{ font-size:14px; }
-    .chip-pile{ position:relative; width:calc(var(--avatar-size)/1.7); height:calc(var(--avatar-size)/1.7); }
-    .chip{ position:absolute; left:0; width:calc(var(--avatar-size)/1.7); height:calc(var(--avatar-size)/1.7); border-radius:50%; background-size:cover; background-position:center; background-repeat:no-repeat; box-shadow:0 2px 4px rgba(0,0,0,.4); }
+    .chip-pile{ position:relative; display:grid; grid-template-columns:repeat(3,1fr); grid-template-rows:repeat(2,1fr); gap:2px; width:calc(var(--avatar-size)/1.2); height:calc(var(--avatar-size)/1.8); }
+    .chip{ position:relative; width:100%; height:100%; border-radius:50%; background-size:cover; background-position:center; background-repeat:no-repeat; box-shadow:0 2px 4px rgba(0,0,0,.4); }
     .chip.v1{ background-image:url('assets/icons/1chips.webp'); }
     .chip.v2{ background-image:url('assets/icons/20250820_071739.webp'); }
     .chip.v5{ background-image:url('assets/icons/5chips.webp'); }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -474,7 +474,6 @@ function buildChipPiles(amount) {
       for (let i = 0; i < count; i++) {
         const chip = document.createElement('div');
         chip.className = 'chip v' + val;
-        chip.style.top = -i * 4 + 'px';
         pile.appendChild(chip);
       }
       wrap.appendChild(pile);


### PR DESCRIPTION
## Summary
- Add frame to community cards and rework pot chip piles into 3x2 grid
- Tweak seat and control positions for better spacing
- Adjust slider spacing and move top HUD elements up

## Testing
- `npm test`
- `npm run lint` *(fails: 712 errors, existing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f03176dc83299e699dffc9a0159d