### PR TITLE
Refine Texas Hold'em table UI

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -69,9 +69,9 @@
 
 .seat.top { top: 1%; left: 50%; transform: translateX(-50%); }
 
-.seat.left { left: 16%; top: 26%; transform: translate(-50%, -50%); }
+  .seat.left { left: 16%; top: 24%; transform: translate(-50%, -50%); }
 
-.seat.right { left: 84%; top: 26%; transform: translate(-50%, -50%); }
+  .seat.right { left: 84%; top: 24%; transform: translate(-50%, -50%); }
 
     .seat.bottom-left { left: 16%; top: 64%; transform: translate(-50%, -50%); }
 
@@ -183,8 +183,8 @@
 
     .pot-wrap{ position:absolute; left:50%; top:33%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
     .pot{ display:flex; gap:4px; }
-    .pot-total{ font-size:14px; }
-    .chip-pile{ position:relative; display:grid; grid-template-columns:repeat(3,1fr); grid-template-rows:repeat(2,1fr); gap:2px; width:calc(var(--avatar-size)/1.2); height:calc(var(--avatar-size)/1.8); }
+    .pot-total{ font-size:16px; font-weight:700; }
+    .chip-pile{ position:relative; display:grid; grid-template-columns:repeat(3,calc(var(--avatar-size)/1.35)); grid-template-rows:repeat(2,calc(var(--avatar-size)/1.35)); gap:4px; }
     .chip{ position:relative; width:100%; height:100%; border-radius:50%; background-size:cover; background-position:center; background-repeat:no-repeat; box-shadow:0 2px 4px rgba(0,0,0,.4); }
     .chip.v1{ background-image:url('assets/icons/1chips.webp'); }
     .chip.v2{ background-image:url('assets/icons/20250820_071739.webp'); }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -349,11 +349,21 @@ function init() {
 }
 
 function adjustNameSize(el) {
+  let name = el.textContent;
+  if (name.length > 15) {
+    const parts = name.trim().split(/\s+/);
+    if (parts.length > 1) {
+      name = parts.map((p) => p[0]).join('').toUpperCase();
+    } else {
+      name = name.slice(0, 3).toUpperCase();
+    }
+    el.textContent = name;
+  }
   const base = 12;
   const min = 8;
-  const len = el.textContent.length;
-  if (len > 10) {
-    el.style.fontSize = Math.max(min, base - (len - 10)) + 'px';
+  const len = name.length;
+  if (len > 12) {
+    el.style.fontSize = Math.max(min, base - (len - 12)) + 'px';
   }
 }
 
@@ -463,7 +473,7 @@ function collectAntes() {
 function buildChipPiles(amount) {
   const wrap = document.createElement('div');
   wrap.style.display = 'flex';
-  wrap.style.gap = '6px';
+  wrap.style.gap = '4px';
   let remaining = amount;
   CHIP_VALUES.forEach((val) => {
     const count = Math.floor(remaining / val);
@@ -488,7 +498,7 @@ function updatePotDisplay() {
   potEl.innerHTML = '';
   potEl.appendChild(buildChipPiles(state.pot));
   const textEl = document.getElementById('potTotal');
-  if (textEl) textEl.innerHTML = `Total: ${formatAmount(state.pot)}`;
+  if (textEl) textEl.innerHTML = `<strong>Total:</strong> ${formatAmount(state.pot)}`;
 }
 
 function animateChipsFromPlayer(index, amount) {


### PR DESCRIPTION
## Summary
- Standardize pot chip size and spacing with betting chips and bold the pot total
- Abbreviate or shrink player names based on length
- Lift top-left and top-right seats slightly higher

## Testing
- `npm test` (fails: test timed out)
- `npm run lint` (fails: 712 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a7f70eb55c8329a499c16eeef7a4c8