### PR TITLE
Refine Texas Hold'em chip pile and long-name rendering

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -184,7 +184,7 @@
     .pot-wrap{ position:absolute; left:50%; top:33%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
     .pot{ display:flex; gap:4px; }
     .pot-total{ font-size:16px; font-weight:700; }
-    .chip-pile{ position:relative; display:grid; grid-template-columns:repeat(3,calc(var(--avatar-size)/1.35)); grid-template-rows:repeat(2,calc(var(--avatar-size)/1.35)); gap:4px; }
+    .chip-pile{ position:relative; display:grid; grid-template-columns:repeat(3,calc(var(--avatar-size)/1.45)); grid-auto-rows:calc(var(--avatar-size)/1.45); gap:2px; }
     .chip{ position:relative; width:100%; height:100%; border-radius:50%; background-size:cover; background-position:center; background-repeat:no-repeat; box-shadow:0 2px 4px rgba(0,0,0,.4); }
     .chip.v1{ background-image:url('assets/icons/1chips.webp'); }
     .chip.v2{ background-image:url('assets/icons/20250820_071739.webp'); }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -349,21 +349,12 @@ function init() {
 }
 
 function adjustNameSize(el) {
-  let name = el.textContent;
-  if (name.length > 15) {
-    const parts = name.trim().split(/\s+/);
-    if (parts.length > 1) {
-      name = parts.map((p) => p[0]).join('').toUpperCase();
-    } else {
-      name = name.slice(0, 3).toUpperCase();
-    }
-    el.textContent = name;
-  }
-  const base = 12;
+  const name = el.textContent;
+  const base = parseInt(getComputedStyle(el).fontSize) || 12;
   const min = 8;
   const len = name.length;
-  if (len > 12) {
-    el.style.fontSize = Math.max(min, base - (len - 12)) + 'px';
+  if (len > 10) {
+    el.style.fontSize = Math.max(min, base - (len - 10)) + 'px';
   }
 }
 
@@ -476,17 +467,21 @@ function buildChipPiles(amount) {
   wrap.style.gap = '4px';
   let remaining = amount;
   CHIP_VALUES.forEach((val) => {
-    const count = Math.floor(remaining / val);
+    let count = Math.floor(remaining / val);
     if (count > 0) {
       remaining -= count * val;
-      const pile = document.createElement('div');
-      pile.className = 'chip-pile';
-      for (let i = 0; i < count; i++) {
-        const chip = document.createElement('div');
-        chip.className = 'chip v' + val;
-        pile.appendChild(chip);
+      while (count > 0) {
+        const pile = document.createElement('div');
+        pile.className = 'chip-pile';
+        const pileCount = Math.min(count, 9);
+        for (let i = 0; i < pileCount; i++) {
+          const chip = document.createElement('div');
+          chip.className = 'chip v' + val;
+          pile.appendChild(chip);
+        }
+        wrap.appendChild(pile);
+        count -= pileCount;
       }
-      wrap.appendChild(pile);
     }
   });
   return wrap;


### PR DESCRIPTION
## Summary
- shrink pot chip pile into 3x3 grid with tighter spacing
- prevent seat cards from widening by scaling font for names over 10 characters
- split pot chip piles into groups of nine to match new layout

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*
- `npm run lint` *(fails: 712 problems (712 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a7fc3a4e6c832996fe68706cba8a47