### PR TITLE
feat: adjust pot and handle long names

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -181,8 +181,8 @@
       }
       .settings-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:8px}
 
-    .pot-wrap{ position:absolute; left:50%; top:33%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; }
-    .pot{ display:flex; gap:4px; }
+    .pot-wrap{ position:absolute; left:50%; top:33%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; width:calc(clamp(44px, 9.6vw, 70px) * 1.083 * 3 + 20px); height:calc(clamp(44px, 9.6vw, 70px) * 1.083 * 1.45); }
+    .pot{ display:flex; gap:4px; flex-wrap:wrap; justify-content:center; width:100%; height:100%; overflow:hidden; }
     .pot-total{ font-size:16px; font-weight:700; }
     .chip-pile{ position:relative; display:grid; grid-template-columns:repeat(3,calc(var(--avatar-size)/1.45)); grid-auto-rows:calc(var(--avatar-size)/1.45); gap:2px; }
     .chip{ position:relative; width:100%; height:100%; border-radius:50%; background-size:cover; background-position:center; background-repeat:no-repeat; box-shadow:0 2px 4px rgba(0,0,0,.4); }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -349,13 +349,17 @@ function init() {
 }
 
 function adjustNameSize(el) {
-  const name = el.textContent;
-  const base = parseInt(getComputedStyle(el).fontSize) || 12;
-  const min = 8;
-  const len = name.length;
-  if (len > 10) {
-    el.style.fontSize = Math.max(min, base - (len - 10)) + 'px';
+  let name = el.textContent || '';
+  if (name.length > 12) {
+    const parts = name.split(/\s+/).filter(Boolean);
+    if (parts.length > 1) {
+      name = parts.map((p) => p[0].toUpperCase()).join('');
+    }
   }
+  if (name.length > 10) {
+    name = name.slice(0, 10);
+  }
+  el.textContent = name;
 }
 
 function renderSeats() {
@@ -465,6 +469,9 @@ function buildChipPiles(amount) {
   const wrap = document.createElement('div');
   wrap.style.display = 'flex';
   wrap.style.gap = '4px';
+  wrap.style.flexWrap = 'wrap';
+  wrap.style.justifyContent = 'center';
+  wrap.style.width = '100%';
   let remaining = amount;
   CHIP_VALUES.forEach((val) => {
     let count = Math.floor(remaining / val);


### PR DESCRIPTION
## Summary
- limit pot display to space of three community cards and wrap chips inside
- shorten long player names to initials and cap at ten characters

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8021584088329adb6b6fc4ff4b312