### PR TITLE
Adjust pot overlay placement in Texas Hold'em

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -183,7 +183,7 @@
       }
       .settings-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:8px}
 
-    .pot-wrap{ position:absolute; left:50%; top:28%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:2; width:calc(clamp(44px, 9.6vw, 70px) * 1.083 * 3 + 20px); height:calc(clamp(44px, 9.6vw, 70px) * 1.083 * 1.45); }
+    .pot-wrap{ position:absolute; left:50%; top:32%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:5; pointer-events:none; background:none; width:calc(clamp(44px, 9.6vw, 70px) * 1.083 * 3 + 20px); height:calc(clamp(44px, 9.6vw, 70px) * 1.083 * 1.45); }
     .pot{ display:flex; gap:4px; flex-wrap:wrap; justify-content:center; width:100%; height:100%; overflow:hidden; }
     .pot-total{ font-size:16px; font-weight:700; }
     .chip-pile{ position:relative; display:grid; grid-template-columns:repeat(3,calc(var(--avatar-size)/1.6)); grid-auto-rows:calc(var(--avatar-size)/1.6); gap:2px; }


### PR DESCRIPTION
## Summary
- Move pot overlay slightly lower
- Ensure pot renders above community cards with transparent, non-blocking wrapper

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a80f182264832986512bdead01b904