### PR TITLE
Refine pot chip size and raise chip sound

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -723,6 +723,11 @@
         background-repeat: no-repeat;
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
       }
+      .pot .chip,
+      .moving-pot .chip {
+        width: calc(var(--avatar-size) / 1.7);
+        height: calc(var(--avatar-size) / 1.7);
+      }
       .chip.v1 {
         background-image: url('assets/icons/1chips.webp');
       }

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -855,6 +855,7 @@ function showControls() {
           state.selectedChips.push(val);
           state.raiseAmount += val;
           updateRaiseAmount();
+          playCallRaiseSound();
         }
       });
       grid.appendChild(chip);


### PR DESCRIPTION
## Summary
- slightly shrink chip size for pot displays
- play chip stack sound when selecting raise chips

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a81da5b2b48329aef62f2a16dd2ec7