### PR TITLE
Enforce American billiards turn order and scoring

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -953,10 +953,18 @@
               pocketedAny = true;
               this.captured[currentShooter].push(b2.n);
               if (isAmerican) {
-                scores[currentShooter] += b2.n;
-                updateScoresUI();
-                pocketedOwn = true;
-                updateFooter(currentShooter, 'He sinks the ' + b2.n + '-ball for ' + b2.n + ' points.');
+                var opponent = currentShooter===1 ? 2 : 1;
+                if (b2.n === currentTarget) {
+                  scores[currentShooter] += b2.n;
+                  updateScoresUI();
+                  pocketedOwn = true;
+                  lastPocketedBall = b2.n;
+                } else {
+                  scores[opponent] += b2.n;
+                  updateScoresUI();
+                  wrongBallPocketed = b2.n;
+                  lastPocketedBall = null;
+                }
               } else {
                 var tType = BALL_BY_N[b2.n].t;
                 if (!assignedTypes[1] && tType !== 'eight') {
@@ -968,8 +976,8 @@
                   if (assignedTypes[currentShooter] === tType) pocketedOwn = true;
                   updateFooter(currentShooter, 'He sinks a ' + tType + '.');
                 }
+                lastPocketedBall = b2.n;
               }
-              lastPocketedBall = b2.n;
             }
           }
         }
@@ -1097,6 +1105,7 @@
     var pocketedAny = false;
     var pocketedOwn = false;
     var scratch = false;
+    var wrongBallPocketed = 0;
     var foulShown = false;
     var assignedTypes = {1:null,2:null};
     var freeShots = {1:0,2:0};
@@ -1221,6 +1230,7 @@
       var foul = false;
       if (isAmerican) {
         if (!firstHit || firstHit.n !== currentTarget) foul = true;
+        if (wrongBallPocketed) foul = true;
       } else {
         var shooterType = assignedTypes[currentShooter];
         if (!firstHit) {
@@ -1246,10 +1256,16 @@
           if (bb && !bb.pocketed && bb.n>highest) highest=bb.n;
         }
         if (isAmerican) {
-          scores[opponent] += highest;
-          updateScoresUI();
-          cueBallFree = true;
-          updateFooter(opponent, "That\u2019s a foul – the cue ball went in, opponent gets " + highest + " points.");
+          if (!wrongBallPocketed) {
+            scores[opponent] += highest;
+            updateScoresUI();
+            cueBallFree = true;
+            var foulMsg = scratch ? 'the cue ball went in' : 'wrong first contact';
+            updateFooter(opponent, "That\u2019s a foul – " + foulMsg + ", opponent gets " + highest + " points.");
+          } else {
+            cueBallFree = true;
+            updateFooter(opponent, "That\u2019s a foul – the " + wrongBallPocketed + "-ball was out of order. Opponent gets " + wrongBallPocketed + " points.");
+          }
         } else {
           updateFooter(opponent, 'Foul – opponent gets two shots.');
         }
@@ -1294,6 +1310,7 @@
       pocketedAny = false;
       pocketedOwn = false;
       scratch = false;
+      wrongBallPocketed = 0;
       foulShown = false;
       firstHit = null;
       currentTarget = null;


### PR DESCRIPTION
## Summary
- Track wrong-ball pocketing in American mode
- Award points to the correct player and flag fouls when balls are pocketed out of order
- Extend end-of-shot logic to handle new foul type and messaging

## Testing
- `npm test` *(fails to exit; server kept running but tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68a81f2c135083298257691a82d56268