### PR TITLE
feat: prioritize pot chips overlay

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -693,7 +693,7 @@
         flex-direction: column;
         align-items: center;
         gap: 4px;
-        z-index: 5;
+        z-index: 1001;
         pointer-events: none;
         background: none;
         width: calc(clamp(44px, 9.6vw, 70px) * 1.083 * 3 + 20px);
@@ -763,6 +763,7 @@
         display: flex;
         gap: 4px;
         flex-wrap: nowrap;
+        z-index: 1001;
       }
       .folded-area {
         display: none;


### PR DESCRIPTION
## Summary
- ensure pot chips render above other game elements
- keep moving pot chip piles above table during animations

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68a821172f3c8329a92124c8ec9a1b67