### PR TITLE
Fix pot chip z-index

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -693,7 +693,7 @@
         flex-direction: column;
         align-items: center;
         gap: 4px;
-        z-index: 1001;
+        z-index: 1100;
         pointer-events: none;
         background: none;
         width: calc(clamp(44px, 9.6vw, 70px) * 1.083 * 3 + 20px);
@@ -727,6 +727,7 @@
       .moving-pot .chip {
         width: calc(var(--avatar-size) / 1.7);
         height: calc(var(--avatar-size) / 1.7);
+        z-index: 1100;
       }
       .chip.v1 {
         background-image: url('assets/icons/1chips.webp');
@@ -763,7 +764,7 @@
         display: flex;
         gap: 4px;
         flex-wrap: nowrap;
-        z-index: 1001;
+        z-index: 1100;
       }
       .folded-area {
         display: none;


### PR DESCRIPTION
## Summary
- ensure Texas Hold'em pot chips always render above player cards and avatars

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*

------
https://chatgpt.com/codex/tasks/task_e_68a82497a62c83299bd0b2a3b5ea450d