### PR TITLE
Widen Texas Hold'em pot and enlarge TPC balance icons

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -696,7 +696,7 @@
         z-index: 1100;
         pointer-events: none;
         background: none;
-        width: calc(clamp(44px, 9.6vw, 70px) * 1.083 * 3 + 20px);
+        width: calc(clamp(44px, 9.6vw, 70px) * 1.083 * 3 + 30px);
         height: calc(clamp(44px, 9.6vw, 70px) * 1.083 * 1.45);
       }
       .pot {

--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -22,8 +22,8 @@ export default function BalanceSummary({ className = '', showHeader = true }) {
       )}
       <div className="grid grid-cols-3 text-sm mt-4">
         <Token icon="/assets/icons/TON.webp" label="TON" value={tonBalance ?? '...'} />
-        <Token icon="/assets/icons/ezgif-54c96d8a9b9236.webp" label="TPC (App)" value={tpcBalance ?? 0} decimals={2} />
-        <Token icon="/assets/icons/ezgif-54c96d8a9b9236.webp" label="TPC" value={tpcWalletBalance ?? '...'} decimals={2} />
+        <Token icon="/assets/icons/ezgif-54c96d8a9b9236.webp" label="TPC (App)" value={tpcBalance ?? 0} decimals={2} iconClass="w-16 h-16" />
+        <Token icon="/assets/icons/ezgif-54c96d8a9b9236.webp" label="TPC" value={tpcWalletBalance ?? '...'} decimals={2} iconClass="w-16 h-16" />
       </div>
     </div>
   );
@@ -44,10 +44,10 @@ function formatValue(value, decimals = 4) {
   });
 }
 
-function Token({ icon, value, label, decimals }) {
+function Token({ icon, value, label, decimals, iconClass = 'w-8 h-8' }) {
   return (
     <div className="flex items-center justify-start space-x-1 w-full">
-      <img  src={icon} alt={label} className="w-8 h-8" />
+      <img src={icon} alt={label} className={iconClass} />
       <span>{formatValue(value, decimals)}</span>
     </div>
   );

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -176,7 +176,7 @@ export default function Home() {
                   </div>
                 </Link>
                 <div className="flex flex-col items-center space-y-1">
-                  <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-11 h-11" />
+                  <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-[5.5rem] h-[5.5rem]" />
                   <span className="text-sm">{formatValue(tpcBalance ?? '...', 2)}</span>
                 </div>
                 <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -290,7 +290,7 @@ export default function Wallet({ hideClaim = false }) {
           </span>
         </p>
         <div className="flex items-center space-x-1">
-          <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-8 h-8" />
+          <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-16 h-16" />
           <span className="text-lg font-medium text-white text-outline-black">
             TPC Balance
           </span>


### PR DESCRIPTION
## Summary
- Slightly widen the Texas Hold'em pot container for better chip fit
- Double TPC token icon size on balance displays while keeping the top-left icon unchanged

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint` *(fails: 712 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8299768bc8329a8fcda02bbdeace0