### PR TITLE
Adjust pot layout and enlarge TPC icons

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -65,7 +65,7 @@
       .center {
         position: absolute;
         left: 50%;
-        top: 43%;
+        top: 44%;
         transform: translate(-50%, -50%);
         display: flex;
         gap: 10px;
@@ -566,6 +566,8 @@
       .tpc-total img {
         width: 36px;
         height: 36px;
+        min-width: 36px;
+        min-height: 36px;
         transform: translateY(-2px);
       }
       #status {
@@ -584,8 +586,10 @@
         -webkit-text-stroke: 1px #000;
       }
       .tpc-inline-icon {
-        width: 1em;
-        height: 1em;
+        width: 2em;
+        height: 2em;
+        min-width: 0;
+        min-height: 0;
         margin-left: 2px;
         transform: translateY(2px);
       }
@@ -687,7 +691,7 @@
       .pot-wrap {
         position: absolute;
         left: 50%;
-        top: 32%;
+        top: 34%;
         transform: translate(-50%, -50%);
         display: flex;
         flex-direction: column;

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -594,7 +594,7 @@ function updatePotDisplay() {
   potEl.appendChild(buildChipPiles(state.pot));
   const textEl = document.getElementById('potTotal');
   if (textEl)
-    textEl.innerHTML = `<strong>Total:</strong> ${formatAmount(state.pot)}`;
+    textEl.innerHTML = `<strong>Total Pot:</strong> ${formatAmount(state.pot)}`;
 }
 
 function animateChipsFromPlayer(index, amount) {
@@ -825,7 +825,7 @@ function showControls() {
     const totalDiv = document.createElement('div');
     totalDiv.className = 'tpc-total';
     totalDiv.innerHTML =
-      'Total: <span id="tpcTotal">0</span> <img src="assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" />';
+      'Total Pot: <span id="tpcTotal">0</span> <img src="assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" class="tpc-inline-icon" />';
 
     if (stage) {
       stage.appendChild(totalDiv);

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1823,6 +1823,6 @@ input:focus {
 
 /* Ensure TPC icon appears slightly larger across the site */
 img[alt="TPC"] {
-  min-width: 1.5rem;
-  min-height: 1.5rem;
+  min-width: 3rem;
+  min-height: 3rem;
 }


### PR DESCRIPTION
## Summary
- Nudge community cards and pot slightly lower and rename pot label to "Total Pot"
- Double TPC icon size across the app while keeping the top-left balance icon unchanged

## Testing
- `npm test` (fails: test timed out after 20000ms)
- `npm run lint` (fails: 712 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a82f25b9408329b5416e2138470de0