### PR TITLE
Adjust pot display and TPC icon sizing in Texas Hold'em UI

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -564,10 +564,10 @@
         gap: 4px;
       }
       .tpc-total img {
-        width: 36px;
-        height: 36px;
-        min-width: 36px;
-        min-height: 36px;
+        width: 32px;
+        height: 32px;
+        min-width: 32px;
+        min-height: 32px;
         transform: translateY(-2px);
       }
       #status {
@@ -586,12 +586,12 @@
         -webkit-text-stroke: 1px #000;
       }
       .tpc-inline-icon {
-        width: 2em;
-        height: 2em;
+        width: 1.8em;
+        height: 1.8em;
         min-width: 0;
         min-height: 0;
         margin-left: 2px;
-        transform: translateY(2px);
+        transform: translateY(0);
       }
       .top-controls {
         position: absolute;
@@ -691,7 +691,7 @@
       .pot-wrap {
         position: absolute;
         left: 50%;
-        top: 34%;
+        top: 32%;
         transform: translate(-50%, -50%);
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
## Summary
- raise pot and chip display slightly higher
- shrink top-left and pot TPC icons and align pot icon with balance

## Testing
- `npm test` *(fails: process hangs awaiting bot setup)*
- `npm run lint` *(fails: 712 lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_68a834606dc4832980645d4518f453af