### PR TITLE
feat(pool-royale): enlarge power slider

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -169,7 +169,7 @@
       }
 
       :root {
-        --rpw: min(20vw, 100px);
+        --rpw: min(23vw, 115px);
       }
 
       /* Canvas i tavolines (mbulon gjithcka, pervec panelit djathtas) */
@@ -237,15 +237,15 @@
 
       #pullArea {
         position: relative;
-        width: 96px;
-        height: 58%;
-        border-radius: 14px;
+        width: 110px;
+        height: 67%;
+        border-radius: 16px;
         background: none;
         box-shadow: none;
         display: flex;
         align-items: center;
         justify-content: center;
-        padding: 8px;
+        padding: 9px;
         /* Allow the handle to overflow so only half of it is visible */
         overflow: visible;
         z-index: 7;
@@ -255,10 +255,10 @@
         position: absolute;
         left: 50%;
         transform: translateX(-50%);
-        width: 10px;
-        height: calc(100% - 24px);
+        width: 12px;
+        height: calc(100% - 28px);
         background: none;
-        border-radius: 8px;
+        border-radius: 9px;
         box-shadow: none;
       }
 
@@ -267,8 +267,8 @@
         /* Position the pull button so that it's half outside the panel */
         left: calc(100% - 1px);
         transform: translateX(-50%);
-        width: 50px;
-        height: 50px;
+        width: 58px;
+        height: 58px;
         border-radius: 50%;
         background: #fff;
         color: #111;
@@ -276,8 +276,8 @@
         align-items: center;
         justify-content: center;
         font-weight: 700;
-        font-size: 14px;
-        box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+        font-size: 16px;
+        box-shadow: 0 5px 12px rgba(0, 0, 0, 0.3);
         user-select: none;
         opacity: 1;
         visibility: visible;
@@ -285,10 +285,10 @@
       }
 
       #powerBox {
-        width: 10px;
-        height: 20%;
+        width: 12px;
+        height: 23%;
         background: rgba(0, 0, 0, 0.4);
-        border-radius: 8px;
+        border-radius: 9px;
         position: relative;
         overflow: hidden;
         border: 2px solid #fff;
@@ -316,8 +316,8 @@
       }
 
       #powerTxt {
-        margin-top: 8px;
-        font-size: 13px;
+        margin-top: 9px;
+        font-size: 15px;
         opacity: 0.85;
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
## Summary
- enlarge Pool Royale right panel power slider by 15%
- adjust handle, gauge and text sizes for improved visibility

## Testing
- `npm test` *(fails: The "options.agent" property must be one of Agent-like Object, undefined, or false. Received an instance of ProxyAgent)*
- `npm run lint` *(fails: 712 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a84360abe08329baf6ab9f0a09f830