### PR TITLE
feat(blackjack): add chip animations and sounds

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -22,6 +22,7 @@
       .seats { position:absolute; inset:0; z-index:2; }
       .seat { position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px,28vw,200px); }
       .avatar { width:54px; height:54px; border-radius:50%; display:grid; place-items:center; background:#fff; color:#111; font-size:28px; border:2px solid #000; box-shadow:0 8px 20px var(--shadow); overflow:hidden; }
+      .seat.active .avatar { outline:3px solid #f5cc4e; outline-offset:2px; }
       .cards { display:flex; gap:6px; }
       .card { width:var(--card-w); height:var(--card-h); border-radius:10px; position:relative; flex:0 0 auto; background:#fff; color:#111; font-weight:900; box-shadow:0 10px 25px var(--shadow), inset 0 0 0 2px rgba(0,0,0,0.08); }
       .card.back {
@@ -59,6 +60,7 @@
       .chip.v10 { background-image:url('assets/icons/10chips.webp'); }
       .chip.v20 { background-image:url('assets/icons/20chips.webp'); }
       .chip.v50 { background-image:url('assets/icons/50chips.webp'); }
+      .moving-pot { position:absolute; transition:left 0.5s ease, top 0.5s ease; display:flex; gap:4px; flex-wrap:nowrap; z-index:1100; }
       .raise-container { position:absolute; bottom:0; left:2%; z-index:5; display:flex; flex-direction:column; align-items:flex-start; gap:8px; }
       .chip-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:4px; }
       .raise-container .chip { cursor:pointer; border:2px solid transparent; width:36px; height:36px; }
@@ -97,6 +99,8 @@
         <button onclick="stand()">Stand</button>
       </div>
     </div>
+    <audio id="sndCallRaise" src="assets/sounds/Callraischip.mp3"></audio>
+    <audio id="sndFlip" src="assets/sounds/flipcard-91468.mp3"></audio>
     <script type="module" src="blackjack.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- highlight active blackjack player and add chip movement animation toward the pot
- play chip and card flip sounds during betting and dealing
- introduce simple AI betting logic with raising or folding

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a84bc87c948329a2119e5947f36575