### PR TITLE
fix: rotate 9-ball rack orientation

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1029,13 +1029,13 @@
               }
             }
           } else if (isNineBall) {
-            // Rregullimi per 9-ball (diamant)
+            // Rregullimi per 9-ball (diamant), i rrotulluar qe topi i verdhe te jete perballe cue ball-it
             var pattern9 = [
-              [1],
-              [2, 3],
-              [4, 9, 5],
-              [6, 7],
-              [8]
+              [8],
+              [7, 6],
+              [5, 9, 4],
+              [3, 2],
+              [1]
             ];
             for (var r9 = 0; r9 < pattern9.length; r9++) {
               var cnt9 = pattern9[r9].length;


### PR DESCRIPTION
## Summary
- rotate 9-ball rack so yellow 1-ball faces cue and black 8-ball anchors back

## Testing
- `npm test` *(fails: snake API endpoints and socket events)*
- `npm run lint` *(fails: 712 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a853bc690c832999b0a3b8d5fc9147