### PR TITLE
Reduce TPC stake icon size

### DIFF
--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -30,7 +30,11 @@ export default function RoomSelector({ selected, onSelect, tokens: allowed }) {
                   : ''
               }`}
             >
-              <img  src={icon} alt={id} className="w-8 h-8" />
+              <img
+                src={icon}
+                alt={id}
+                className={id === 'TPC' ? 'w-[1.4rem] h-[1.4rem]' : 'w-8 h-8'}
+              />
               <span>{amt.toLocaleString('en-US')}</span>
             </button>
           ))}


### PR DESCRIPTION
## Summary
- shrink TPC icon inside lobby stake cards to original proportion

## Testing
- `npm test` *(hangs after starting server; aborted)*
- `npm run lint` *(fails: multiple lint errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68a85352ae688329a6485daf1322810f