### PR TITLE
Enhance Blackjack UI with settings and endgame celebration

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -9,6 +9,10 @@
         --shadow: rgba(0,0,0,0.45);
         --card-w: clamp(44px, 9.6vw, 70px);
         --card-h: calc(var(--card-w)*1.45);
+        --avatar-size: 54px;
+        --seat-bg-color: #f5f5dc;
+        --card-back-color: #233;
+        --player-frame-color: #000;
       }
       * { box-sizing: border-box; }
       body, html { height:100%; margin:0; }
@@ -21,14 +25,25 @@
       }
       .seats { position:absolute; inset:0; z-index:2; }
       .seat { position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px,28vw,200px); }
-      .avatar { width:54px; height:54px; border-radius:50%; display:grid; place-items:center; background:#fff; color:#111; font-size:28px; border:2px solid #000; box-shadow:0 8px 20px var(--shadow); overflow:hidden; }
+      .avatar { width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%,#fff,#ddd 40%,#bbb 60%,#999 100%); color:#111; font-size:28px; border:2px solid var(--player-frame-color,#000); box-shadow:0 8px 20px var(--shadow); overflow:hidden; }
+      .frame-style-1 .avatar { border-style:solid; border-width:2px; }
+      .frame-style-2 .avatar { border-style:dashed; border-width:2px; }
+      .frame-style-3 .avatar { border-style:dotted; border-width:2px; }
+      .frame-style-4 .avatar { border-style:double; border-width:4px; }
+      .frame-style-5 .avatar { border-style:groove; border-width:4px; }
+      .frame-style-6 .avatar { border-style:ridge; border-width:4px; }
+      .frame-style-7 .avatar { border-style:inset; border-width:4px; }
+      .frame-style-8 .avatar { border-style:outset; border-width:4px; }
+      .frame-style-9 .avatar { border-style:solid; border-width:2px; box-shadow:0 8px 20px var(--shadow),0 0 0 2px var(--player-frame-color,#000); }
+      .frame-style-10 .avatar { border-style:dashed; border-width:2px; box-shadow:0 8px 20px var(--shadow),0 0 0 2px var(--player-frame-color,#000); }
       .seat.active .avatar { outline:3px solid #f5cc4e; outline-offset:2px; }
       .cards { display:flex; gap:6px; }
       .card { width:var(--card-w); height:var(--card-h); border-radius:10px; position:relative; flex:0 0 auto; background:#fff; color:#111; font-weight:900; box-shadow:0 10px 25px var(--shadow), inset 0 0 0 2px rgba(0,0,0,0.08); }
+      .seat.small .card { width:calc(var(--card-w)*0.72); height:calc(var(--card-h)*0.72); }
       .card.back {
         background:
           url('assets/icons/file_00000000bc2862439eecffff3730bbe4.webp') center/90% no-repeat,
-          repeating-linear-gradient(45deg,#233,#233 6px,#122 6px,#122 12px);
+          repeating-linear-gradient(45deg,var(--card-back-color,#233),var(--card-back-color,#233) 6px,#122 6px,#122 12px);
         border:2px solid rgba(255,255,255,0.5);
         color:transparent;
       }
@@ -51,15 +66,19 @@
       .player-controls button { padding:8px 16px; font-size:16px; border:none; border-radius:6px; cursor:pointer; }
       #status { position:absolute; top:10px; left:50%; transform:translateX(-50%); font-size:18px; font-weight:bold; z-index:3; text-shadow:0 2px 4px #000; }
       .folded { opacity:0.5; }
-      .pot-wrap { position:absolute; left:50%; top:32%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:3; }
+      .pot-wrap { position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:3; }
       .pot { display:flex; gap:4px; }
       .pot-total { font-size:16px; font-weight:700; }
-      .chip { width:40px; height:40px; border-radius:50%; background-size:cover; background-position:center; }
+      .chip { width:40px; height:40px; border-radius:50%; background-size:cover; background-position:center; background-repeat:no-repeat; box-shadow:0 2px 4px rgba(0,0,0,0.4); }
       .chip.v1 { background-image:url('assets/icons/1chips.webp'); }
+      .chip.v2 { background-image:url('assets/icons/20250820_071739.webp'); }
       .chip.v5 { background-image:url('assets/icons/5chips.webp'); }
       .chip.v10 { background-image:url('assets/icons/10chips.webp'); }
       .chip.v20 { background-image:url('assets/icons/20chips.webp'); }
       .chip.v50 { background-image:url('assets/icons/50chips.webp'); }
+      .chip.v200 { background-image:url('assets/icons/200chips.webp'); }
+      .chip.v500 { background-image:url('assets/icons/500chips.webp'); }
+      .chip.v1000 { background-image:url('assets/icons/1000chips.webp'); }
       .moving-pot { position:absolute; transition:left 0.5s ease, top 0.5s ease; display:flex; gap:4px; flex-wrap:nowrap; z-index:1100; }
       .raise-container { position:absolute; bottom:0; left:2%; z-index:5; display:flex; flex-direction:column; align-items:flex-start; gap:8px; }
       .chip-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:4px; }
@@ -68,23 +87,53 @@
       .slider-container { position:absolute; bottom:4%; right:1%; z-index:5; display:flex; flex-direction:column; align-items:center; gap:8px; }
       .raise-btn { width:54px; height:54px; padding:0; border:4px solid #000; border-radius:50%; background:#2563eb; color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
       .raise-amount { font-size:14px; }
+      .top-controls { position:absolute; top:4px; right:8px; display:flex; gap:4px; z-index:10; }
+      .top-controls button { width:32px; height:32px; padding:0; border:2px solid #000; border-radius:50%; display:flex; align-items:center; justify-content:center; background:#2563eb; color:#fff; font-weight:600; font-size:14px; line-height:1; }
+      .top-controls button img { width:16px; height:16px; }
+      #lobbyIcon { flex-direction:column; width:auto; height:auto; padding:2px 5px; border-radius:8px; }
+      #lobbyIcon .arrow { font-size:14px; }
+      #lobbyIcon .label { font-size:9px; }
+      .settings-panel { position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); background:#fff; color:#000; padding:16px; border:2px solid #000; border-radius:8px; z-index:20; display:none; min-width:200px; }
+      .settings-panel.active { display:block; }
+      .settings-panel label { display:flex; align-items:center; gap:6px; margin-top:8px; }
+      .settings-panel select, .settings-panel input[type='range'] { margin-left:6px; }
+      .settings-panel select option { color:#000; padding-left:24px; background-size:16px 100%; background-repeat:no-repeat; }
+      .settings-actions { display:flex; gap:8px; justify-content:flex-end; margin-top:8px; }
+      .popup { position:absolute; inset:0; background:none; display:flex; align-items:center; justify-content:center; }
+      .popup.hidden { display:none; }
+      .popup .box { background:none; border:none; box-shadow:none; padding:20px; border-radius:12px; text-align:center; color:#fff; }
+      .btn { appearance:none; border:1px solid #facc15; background:rgba(0,0,0,.3); color:#facc15; padding:10px 14px; border-radius:14px; font-weight:600; font-size:14px; cursor:pointer; }
+      .btn.primary { background:#00f7ff; color:#fff; border:none; box-shadow:0 0 8px rgba(0,247,255,.5); }
+      .winner-row { display:flex; align-items:center; gap:8px; margin-bottom:6px; }
+      .winner-row:last-child { margin-bottom:0; }
+      .winner-row .amount { margin-left:auto; }
+      .coin-confetti { position:fixed; top:-40px; width:48px; height:48px; pointer-events:none; animation:coin-fall var(--duration,3s) linear forwards; }
+      @keyframes coin-fall { from { transform:translateY(-10vh) rotate(0deg); opacity:1; } to { transform:translateY(100vh) rotate(360deg); opacity:0; } }
     </style>
   </head>
-  <body>
+  <body class="frame-style-1">
     <div class="stage">
+      <div class="top-controls">
+        <button id="settingsBtn">⚙️</button>
+        <button id="lobbyIcon"><span class="arrow">&#8592;</span><span class="label">Return Lobby</span></button>
+      </div>
       <div id="status"></div>
       <div class="seats" id="seats"></div>
-      <div class="pot-wrap">
+      <div class="pot-wrap" id="potWrap">
         <div class="pot" id="pot"></div>
         <div class="pot-total" id="potTotal"></div>
       </div>
       <div class="raise-container" id="raiseContainer">
         <div class="chip-grid">
-          <div class="chip v1" data-value="1"></div>
-          <div class="chip v5" data-value="5"></div>
-          <div class="chip v10" data-value="10"></div>
-          <div class="chip v20" data-value="20"></div>
+          <div class="chip v1000" data-value="1000"></div>
+          <div class="chip v500" data-value="500"></div>
+          <div class="chip v200" data-value="200"></div>
           <div class="chip v50" data-value="50"></div>
+          <div class="chip v20" data-value="20"></div>
+          <div class="chip v10" data-value="10"></div>
+          <div class="chip v5" data-value="5"></div>
+          <div class="chip v2" data-value="2"></div>
+          <div class="chip v1" data-value="1"></div>
         </div>
         <div class="raise-amount" id="chipAmount">0</div>
       </div>
@@ -97,6 +146,27 @@
       <div class="player-controls">
         <button onclick="hit()">Hit</button>
         <button onclick="stand()">Stand</button>
+      </div>
+      <div id="winnerPopup" class="popup hidden">
+        <div class="box">
+          <div id="winnerText"></div>
+          <button class="btn primary" id="lobbyBtn">Return Lobby</button>
+        </div>
+      </div>
+    </div>
+    <div id="settingsPanel" class="settings-panel">
+      <label><input type="checkbox" id="muteCards" /> Mute Cards</label>
+      <label>Card Volume<input type="range" id="cardVolume" min="0" max="1" step="0.1" /></label>
+      <label><input type="checkbox" id="muteChips" /> Mute Chips</label>
+      <label>Chip Volume<input type="range" id="chipVolume" min="0" max="1" step="0.1" /></label>
+      <label><input type="checkbox" id="muteOthers" /> Mute Other Sounds</label>
+      <label>Frame Style<select id="playerFrameStyle" class="style-select"></select></label>
+      <label>Frame Color<select id="playerColor" class="color-select"></select></label>
+      <label>Card Back<select id="cardBackColor" class="color-select"></select></label>
+      <div class="settings-actions">
+        <button id="resetSettings">Reset</button>
+        <button id="saveSettings">Save</button>
+        <button id="closeSettings">Close</button>
       </div>
     </div>
     <audio id="sndCallRaise" src="assets/sounds/Callraischip.mp3"></audio>


### PR DESCRIPTION
## Summary
- Center pot and display full chip denominations in a 3x3 grid with sound on click
- Add Texas Hold'em style settings menu, player frames, and top controls
- Show confetti winner popup and lobby return button at game end

## Testing
- `npm test` *(fails: snake API endpoints and socket events)*
- `npm run lint` *(fails: 712 style errors in existing lib/texasHoldem.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a855c34bd08329ae7e42f90fc31c24