### PR TITLE
Reduce lobby stake card size by 15%

### DIFF
--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -24,7 +24,7 @@ export default function RoomSelector({ selected, onSelect, tokens: allowed }) {
             <button
               key={`${id}-${amt}`}
               onClick={() => onSelect({ token: id, amount: amt })}
-              className={`lobby-tile w-20 px-4 py-2 flex flex-col items-center space-y-1 cursor-pointer ${
+              className={`lobby-tile w-[4.25rem] !px-[0.425rem] !py-[0.2125rem] flex flex-col items-center space-y-1 cursor-pointer text-[0.85rem] ${
                 token === id && amount === amt
                   ? 'lobby-selected'
                   : ''
@@ -33,7 +33,7 @@ export default function RoomSelector({ selected, onSelect, tokens: allowed }) {
               <img
                 src={icon}
                 alt={id}
-                className={id === 'TPC' ? 'w-[1.4rem] h-[1.4rem]' : 'w-8 h-8'}
+                className={id === 'TPC' ? 'w-[1.19rem] h-[1.19rem]' : 'w-[1.7rem] h-[1.7rem]'}
               />
               <span>{amt.toLocaleString('en-US')}</span>
             </button>


### PR DESCRIPTION
## Summary
- Shrink stake selection cards across lobbies by ~15%

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint` *(fails: 712 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a85fb2ce908329ba2aa63c31e8debb