### PR TITLE
Fix nine-ball foul handling

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1259,11 +1259,11 @@
                   pocketedAny = true;
                   this.captured[currentShooter].push(b2.n);
                   if (isNineBall && b2.n === 9) {
+                    nineBallPotted = true;
                     lastPocketedBall = b2.n;
-                    endGame(currentShooter);
-                    return;
-                  }
-                  if (isAmerican || isNineBall) {
+                    pottedThisShot.push(b2.n);
+                    pocketedOwn = true;
+                  } else if (isAmerican || isNineBall) {
                     pottedThisShot.push(b2.n);
                     pocketedOwn = true;
                     lastPocketedBall = b2.n;
@@ -1491,6 +1491,7 @@
         var lastPocketedBall = null;
         var currentTarget = null;
         var pottedThisShot = [];
+        var nineBallPotted = false;
 
         function remainingPoints() {
           var sum = 0;
@@ -1753,11 +1754,19 @@
               showCenterPopup('Foul', 'foul', 1500);
               foulShown = true;
             }
+            if (nineBallPotted) {
+              endGame(opponent);
+              return;
+            }
             freeShots[opponent] = isAmerican || isNineBall ? 1 : 2;
             freeShots[currentShooter] = 0;
             table.turn = opponent;
             setTimeout(showTurnInfo, 1500);
           } else {
+            if (nineBallPotted) {
+              endGame(currentShooter);
+              return;
+            }
             if (shotPoints > 0 && isAmerican) {
               scores[currentShooter] += shotPoints;
               updateScoresUI();
@@ -1813,6 +1822,7 @@
           foulShown = false;
           firstHit = null;
           currentTarget = null;
+          nineBallPotted = false;
         }
 
         /* ==========================================================
@@ -2167,6 +2177,7 @@
           scratch = false;
           firstHit = null;
           pottedThisShot = [];
+          nineBallPotted = false;
           cue.v.x = d.x * base * (0.25 + 0.75 * p);
           cue.v.y = d.y * base * (0.25 + 0.75 * p);
           // Double the spin effect in all directions


### PR DESCRIPTION
## Summary
- track nine-ball pots and defer victory check until shot ends
- award opponent the win when the 9 ball is pocketed on a foul
- reset nine-ball tracking between shots

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*
- `npm run lint` *(fails: 712 lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a85ef4963083299ed7562f16b842cf