### PR TITLE
style: adjust blackjack player layout and avatars

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -24,18 +24,18 @@
         z-index:0;
       }
       .seats { position:absolute; inset:0; z-index:2; }
-      .seat { position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px,28vw,200px); padding:6px; border:2px solid var(--player-frame-color,#000); border-radius:8px; background:var(--seat-bg-color); box-shadow:0 8px 20px var(--shadow); }
+      .seat { position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px,28vw,200px); padding:6px; border:4px solid #000; border-radius:12px; background:var(--seat-bg-color); box-shadow:4px 4px 0 #d4ccb3; }
       .avatar { width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%,#fff,#ddd 40%,#bbb 60%,#999 100%); color:#111; font-size:28px; border:2px solid var(--player-frame-color,#000); box-shadow:0 8px 20px var(--shadow); overflow:hidden; }
-      .frame-style-1 .avatar, .frame-style-1 .seat { border-style:solid; border-width:2px; }
-      .frame-style-2 .avatar, .frame-style-2 .seat { border-style:dashed; border-width:2px; }
-      .frame-style-3 .avatar, .frame-style-3 .seat { border-style:dotted; border-width:2px; }
-      .frame-style-4 .avatar, .frame-style-4 .seat { border-style:double; border-width:4px; }
-      .frame-style-5 .avatar, .frame-style-5 .seat { border-style:groove; border-width:4px; }
-      .frame-style-6 .avatar, .frame-style-6 .seat { border-style:ridge; border-width:4px; }
-      .frame-style-7 .avatar, .frame-style-7 .seat { border-style:inset; border-width:4px; }
-      .frame-style-8 .avatar, .frame-style-8 .seat { border-style:outset; border-width:4px; }
-      .frame-style-9 .avatar, .frame-style-9 .seat { border-style:solid; border-width:2px; box-shadow:0 8px 20px var(--shadow),0 0 0 2px var(--player-frame-color,#000); }
-      .frame-style-10 .avatar, .frame-style-10 .seat { border-style:dashed; border-width:2px; box-shadow:0 8px 20px var(--shadow),0 0 0 2px var(--player-frame-color,#000); }
+      .frame-style-1 .avatar { border-style:solid; border-width:2px; }
+      .frame-style-2 .avatar { border-style:dashed; border-width:2px; }
+      .frame-style-3 .avatar { border-style:dotted; border-width:2px; }
+      .frame-style-4 .avatar { border-style:double; border-width:4px; }
+      .frame-style-5 .avatar { border-style:groove; border-width:4px; }
+      .frame-style-6 .avatar { border-style:ridge; border-width:4px; }
+      .frame-style-7 .avatar { border-style:inset; border-width:4px; }
+      .frame-style-8 .avatar { border-style:outset; border-width:4px; }
+      .frame-style-9 .avatar { border-style:solid; border-width:2px; box-shadow:0 8px 20px var(--shadow),0 0 0 2px var(--player-frame-color,#000); }
+      .frame-style-10 .avatar { border-style:dashed; border-width:2px; box-shadow:0 8px 20px var(--shadow),0 0 0 2px var(--player-frame-color,#000); }
       .seat.active .avatar { outline:3px solid #f5cc4e; outline-offset:2px; }
       .seat.winner .card { box-shadow:0 0 10px 2px #facc15; }
       .seat.winner .avatar { outline:3px solid #facc15; outline-offset:2px; }

--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -9,6 +9,11 @@ import {
 } from './lib/blackjack.js';
 
 const FLAG_EMOJIS = window.FLAG_EMOJIS || [];
+const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
+function flagName(flag) {
+  const codePoints = [...flag].map((c) => c.codePointAt(0) - 0x1f1e6 + 65);
+  return regionNames.of(String.fromCharCode(...codePoints));
+}
 
 const state = {
   players: [],
@@ -237,11 +242,11 @@ function render() {
   seats.innerHTML = '';
   const POS = [
     { left: '50%', top: '80%' },
-    { left: '80%', top: '60%' },
-    { left: '80%', top: '30%' },
+    { left: '80%', top: '64%' },
+    { left: '80%', top: '26%' },
     { left: '50%', top: '10%' },
-    { left: '20%', top: '30%' },
-    { left: '20%', top: '60%' }
+    { left: '20%', top: '26%' },
+    { left: '20%', top: '64%' }
   ];
   state.players.forEach((p, i) => {
     const seat = document.createElement('div');
@@ -253,7 +258,11 @@ function render() {
     seat.style.transform = 'translate(-50%, -50%)';
     const avatar = document.createElement('div');
     avatar.className = 'avatar';
-    avatar.textContent = p.avatar || p.name[0];
+    if (p.avatar && p.avatar.startsWith('http')) {
+      avatar.style.background = `url('${p.avatar}') center/cover no-repeat`;
+    } else {
+      avatar.textContent = p.avatar || p.name[0];
+    }
     const cards = document.createElement('div');
     cards.className = 'cards';
     p.hand.forEach((c, idx) => {
@@ -431,14 +440,31 @@ function init() {
   state.devAccountId = params.get('dev') || '';
   myAccountId = params.get('accountId') || '';
   myTelegramId = params.get('tgId') || '';
-  const avatar = params.get('avatar') || '';
-  const username = params.get('username') || 'You';
+  let avatar = params.get('avatar') || '';
+  let username = params.get('username') || '';
+
+  try {
+    if (!username) {
+      const initParam = params.get('init');
+      if (initParam) {
+        const data = new URLSearchParams(decodeURIComponent(initParam));
+        const user = JSON.parse(data.get('user') || '{}');
+        username = user.username || user.first_name || 'You';
+        avatar = user.photo_url || avatar;
+      } else if (window.Telegram?.WebApp?.initDataUnsafe?.user) {
+        const u = window.Telegram.WebApp.initDataUnsafe.user;
+        username = u.username || u.first_name || 'You';
+        avatar = u.photo_url || avatar;
+      }
+    }
+  } catch {}
+  if (!username) username = 'You';
 
   const playerCount = 6;
   for (let i = 0; i < playerCount; i++) {
     const ai = i !== 0;
-    const name = ai ? `AI ${i}` : username;
     const av = ai ? FLAG_EMOJIS[i % FLAG_EMOJIS.length] : avatar;
+    const name = ai ? flagName(av) : username;
     state.players.push({ hand: [], stood: false, bust: false, name, avatar: av, isHuman: !ai });
   }
 


### PR DESCRIPTION
## Summary
- Adjust Blackjack seat positions for better table layout
- Match Blackjack player frames to Texas Hold'em cartoon style
- Use flag names for AI players and load real user avatar/name

## Testing
- `cd webapp && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a861a590788329b6c8e73d9d243118