### PR TITLE
Reduce stake card size by 15%

### DIFF
--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -24,7 +24,7 @@ export default function RoomSelector({ selected, onSelect, tokens: allowed }) {
             <button
               key={`${id}-${amt}`}
               onClick={() => onSelect({ token: id, amount: amt })}
-              className={`lobby-tile w-[4.25rem] !px-[0.425rem] !py-[0.2125rem] flex flex-col items-center space-y-1 cursor-pointer text-[0.85rem] ${
+              className={`lobby-tile w-[3.6125rem] !px-[0.36125rem] !py-[0.180625rem] flex flex-col items-center space-y-1 cursor-pointer text-[0.7225rem] ${
                 token === id && amount === amt
                   ? 'lobby-selected'
                   : ''
@@ -33,7 +33,11 @@ export default function RoomSelector({ selected, onSelect, tokens: allowed }) {
               <img
                 src={icon}
                 alt={id}
-                className={id === 'TPC' ? 'w-[1.19rem] h-[1.19rem]' : 'w-[1.7rem] h-[1.7rem]'}
+                className={
+                  id === 'TPC'
+                    ? 'w-[1.0115rem] h-[1.0115rem]'
+                    : 'w-[1.445rem] h-[1.445rem]'
+                }
               />
               <span>{amt.toLocaleString('en-US')}</span>
             </button>


### PR DESCRIPTION
## Summary
- Shrink stake selection cards by 15% across all lobbies

## Testing
- `npm test` *(fails: module '/workspace/TonPlaygramWebApp/bot/node_modules/canvas/build/Release/canvas.node' was compiled against a different Node.js version)*
- `npm run lint` *(fails: 712 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a8671d0f7c8329aabac317d7031af8