### PR TITLE
Align blackjack player frames with Texas Hold'em

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -7,9 +7,11 @@
     <style>
       :root {
         --shadow: rgba(0,0,0,0.45);
-        --card-w: clamp(44px, 9.6vw, 70px);
-        --card-h: calc(var(--card-w)*1.45);
-        --avatar-size: 54px;
+        --card-scale: 0.72;
+        --avatar-scale: 1;
+        --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale));
+        --card-h: calc(var(--card-w) * 1.45);
+        --avatar-size: calc(54px * var(--avatar-scale));
         --seat-bg-color: #f5f5dc;
         --card-back-color: #233;
         --player-frame-color: #000;
@@ -24,24 +26,25 @@
         z-index:0;
       }
       .seats { position:absolute; inset:0; z-index:2; }
-      .seat { position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px,28vw,200px); padding:6px; border:2px solid var(--player-frame-color,#000); border-radius:8px; background:var(--seat-bg-color); box-shadow:0 8px 20px var(--shadow); }
-      .avatar { width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%,#fff,#ddd 40%,#bbb 60%,#999 100%); color:#111; font-size:28px; border:2px solid var(--player-frame-color,#000); box-shadow:0 8px 20px var(--shadow); overflow:hidden; }
-      .frame-style-1 .avatar, .frame-style-1 .seat { border-style:solid; border-width:2px; }
-      .frame-style-2 .avatar, .frame-style-2 .seat { border-style:dashed; border-width:2px; }
-      .frame-style-3 .avatar, .frame-style-3 .seat { border-style:dotted; border-width:2px; }
-      .frame-style-4 .avatar, .frame-style-4 .seat { border-style:double; border-width:4px; }
-      .frame-style-5 .avatar, .frame-style-5 .seat { border-style:groove; border-width:4px; }
-      .frame-style-6 .avatar, .frame-style-6 .seat { border-style:ridge; border-width:4px; }
-      .frame-style-7 .avatar, .frame-style-7 .seat { border-style:inset; border-width:4px; }
-      .frame-style-8 .avatar, .frame-style-8 .seat { border-style:outset; border-width:4px; }
-      .frame-style-9 .avatar, .frame-style-9 .seat { border-style:solid; border-width:2px; box-shadow:0 8px 20px var(--shadow),0 0 0 2px var(--player-frame-color,#000); }
-      .frame-style-10 .avatar, .frame-style-10 .seat { border-style:dashed; border-width:2px; box-shadow:0 8px 20px var(--shadow),0 0 0 2px var(--player-frame-color,#000); }
+      .seat { position:absolute; display:flex; flex-direction:column; align-items:center; gap:6px; width:clamp(120px,28vw,200px); --card-scale:0.567; --avatar-scale:0.7; --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale)); --card-h: calc(var(--card-w) * 1.45); }
+      .seat-inner { display:flex; flex-direction:column; align-items:center; gap:6px; border:4px solid #000; border-radius:12px; padding:4px; background:var(--seat-bg-color); box-shadow:4px 4px 0 #d4ccb3; }
+      .seat-inner .avatar { box-shadow:0 0 0 2px #000; }
+      .avatar { width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; display:grid; place-items:center; background:radial-gradient(circle at 30% 30%,#fff,#ddd 40%,#bbb 60%,#999 100%); color:#111; font-size:28px; border-color:var(--player-frame-color,#000); box-shadow:0 8px 20px var(--shadow); overflow:hidden; position:relative; }
+      .frame-style-1 .avatar { border-style:solid; border-width:2px; }
+      .frame-style-2 .avatar { border-style:dashed; border-width:2px; }
+      .frame-style-3 .avatar { border-style:dotted; border-width:2px; }
+      .frame-style-4 .avatar { border-style:double; border-width:4px; }
+      .frame-style-5 .avatar { border-style:groove; border-width:4px; }
+      .frame-style-6 .avatar { border-style:ridge; border-width:4px; }
+      .frame-style-7 .avatar { border-style:inset; border-width:4px; }
+      .frame-style-8 .avatar { border-style:outset; border-width:4px; }
+      .frame-style-9 .avatar { border-style:solid; border-width:2px; box-shadow:0 8px 20px var(--shadow),0 0 0 2px var(--player-frame-color,#000); }
+      .frame-style-10 .avatar { border-style:dashed; border-width:2px; box-shadow:0 8px 20px var(--shadow),0 0 0 2px var(--player-frame-color,#000); }
       .seat.active .avatar { outline:3px solid #f5cc4e; outline-offset:2px; }
       .seat.winner .card { box-shadow:0 0 10px 2px #facc15; }
       .seat.winner .avatar { outline:3px solid #facc15; outline-offset:2px; }
-      .cards { display:flex; gap:6px; }
+      .cards { display:flex; gap:6px; flex-wrap:nowrap; }
       .card { width:var(--card-w); height:var(--card-h); border-radius:10px; position:relative; flex:0 0 auto; background:#fff; color:#111; font-weight:900; box-shadow:0 10px 25px var(--shadow), inset 0 0 0 2px rgba(0,0,0,0.08); }
-      .seat.small .card { width:calc(var(--card-w)*0.72); height:calc(var(--card-h)*0.72); }
       .card.back {
         background:
           url('assets/icons/file_00000000bc2862439eecffff3730bbe4.webp') center/90% no-repeat,
@@ -63,7 +66,17 @@
       .card .corner .suit { font-size:calc(var(--card-w)*0.18); line-height:1; }
       .card .big { position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); font-size:calc(var(--card-w)*0.52); opacity:0.9; filter:drop-shadow(0 0 2px rgba(0,0,0,0.4)); }
       .red { color:#d00; }
-      .seat-balance { font-size:14px; text-shadow:0 1px 2px #000; display:flex; align-items:center; gap:2px; }
+      .seat.bottom { bottom:0.5%; left:50%; transform:translateX(-50%); --card-scale:1.083; --avatar-scale:1; --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale)); --card-h: calc(var(--card-w) * 1.45); }
+      .seat.top { top:1%; left:50%; transform:translateX(-50%); }
+      .seat.left { left:16%; top:24%; transform:translate(-50%,-50%); }
+      .seat.right { left:84%; top:24%; transform:translate(-50%,-50%); }
+      .seat.bottom-left { left:16%; top:64%; transform:translate(-50%,-50%); }
+      .seat.bottom-right { left:84%; top:64%; transform:translate(-50%,-50%); }
+      .seat-inner .cards { padding:0; border:none; background:none; }
+      .seat-inner .card { border:none; }
+      .seat.bottom .cards { gap:0; }
+      .seat-balance { font-size:10px; color:#fff; display:flex; align-items:center; gap:2px; }
+      .seat.bottom .seat-balance { font-size:12px; }
       .player-controls { position:absolute; bottom:20px; left:50%; transform:translateX(-50%); display:flex; gap:12px; z-index:3; }
       .player-controls button { padding:8px 16px; font-size:16px; border:none; border-radius:6px; cursor:pointer; }
       #status { position:absolute; top:10px; left:50%; transform:translateX(-50%); font-size:18px; font-weight:bold; z-index:3; text-shadow:0 2px 4px #000; }

--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -235,22 +235,19 @@ function cardBackEl() {
 function render() {
   const seats = document.getElementById('seats');
   seats.innerHTML = '';
-  const POS = [
-    { left: '50%', top: '80%' },
-    { left: '80%', top: '60%' },
-    { left: '80%', top: '30%' },
-    { left: '50%', top: '10%' },
-    { left: '20%', top: '30%' },
-    { left: '20%', top: '60%' }
+  const positions = [
+    'bottom',
+    'bottom-right',
+    'right',
+    'top',
+    'left',
+    'bottom-left'
   ];
   state.players.forEach((p, i) => {
     const seat = document.createElement('div');
-    seat.className = 'seat';
-    if (i !== 0) seat.classList.add('small');
-    const pos = POS[i] || { left: '50%', top: '50%' };
-    seat.style.left = pos.left;
-    seat.style.top = pos.top;
-    seat.style.transform = 'translate(-50%, -50%)';
+    seat.className = 'seat ' + (positions[i] || 'bottom');
+    const inner = document.createElement('div');
+    inner.className = 'seat-inner';
     const avatar = document.createElement('div');
     avatar.className = 'avatar';
     avatar.textContent = p.avatar || p.name[0];
@@ -263,10 +260,19 @@ function render() {
         cards.appendChild(cardBackEl());
       }
     });
+    inner.append(avatar, cards);
     const bal = document.createElement('div');
     bal.className = 'seat-balance';
     bal.innerHTML = formatAmount(p.balance || 0);
-    seat.append(avatar, cards, bal);
+    seat.append(inner, bal);
+
+    const baseScale = i === 0 ? 1.083 : 0.567;
+    const maxCards = i === 0 ? 4 : 3;
+    const scale = p.hand.length > maxCards
+      ? (baseScale * maxCards) / p.hand.length
+      : baseScale;
+    seat.style.setProperty('--card-scale', scale);
+
     if (i === state.turn && !p.stood && !p.bust) seat.classList.add('active');
     if (p.bust) seat.classList.add('folded');
     if (p.winner) seat.classList.add('winner');


### PR DESCRIPTION
## Summary
- Style blackjack seats using the same frame layout and positioning as Texas Hold'em
- Dynamically scale card size when hands grow to keep frames fixed

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*

------
https://chatgpt.com/codex/tasks/task_e_68a8680c4a0c8329b737b51d9e4cc2a6