### PR TITLE
feat: support call raise and fold in blackjack betting

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -148,6 +148,8 @@
         <div class="raise-amount" id="raiseSliderAmount">0</div>
         <button class="raise-btn" id="raiseBtn">Raise</button>
         <button class="raise-btn" id="allInBtn">All In</button>
+        <button class="raise-btn" id="callBtn">Call</button>
+        <button class="raise-btn" id="foldBtn">Fold</button>
       </div>
       <div class="player-controls">
         <button onclick="hit()">Hit</button>


### PR DESCRIPTION
## Summary
- add call and fold controls so players can react to bets
- track current bet and prompt each player to call, raise, or fold
- update AI logic to respond to raises and re-prompt players

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*

------
https://chatgpt.com/codex/tasks/task_e_68a86fd018e88329bdc3199a848eedd4