### PR TITLE
Default Blackjack frame style and color

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -12,9 +12,9 @@
         --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale));
         --card-h: calc(var(--card-w) * 1.45);
         --avatar-size: calc(54px * var(--avatar-scale));
-        --seat-bg-color: #f5f5dc;
+        --seat-bg-color: #fbbf24;
         --card-back-color: #233;
-        --player-frame-color: #000;
+        --player-frame-color: #fbbf24;
       }
       * { box-sizing: border-box; }
       body, html { height:100%; margin:0; }
@@ -117,7 +117,7 @@
       .tpc-inline-icon { width:1.8em; height:1.8em; min-width:0; min-height:0; margin-left:2px; transform:translateY(2px); }
     </style>
   </head>
-  <body class="frame-style-1">
+  <body class="frame-style-6">
     <div class="stage">
       <div class="top-controls">
         <button id="settingsBtn">⚙️</button>

--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -42,9 +42,9 @@ const DEFAULT_SETTINGS = {
   muteOthers: false,
   cardVolume: 1,
   chipVolume: 1,
-  playerColor: '#f5f5dc',
+  playerColor: '#fbbf24',
   cardBackColor: '#233',
-  playerFrameStyle: '1'
+  playerFrameStyle: '6'
 };
 const COLOR_OPTIONS = [
   '#f5f5dc',


### PR DESCRIPTION
## Summary
- Use frame style 6 and color #fbbf24 as the default Blackjack appearance
- Update HTML to reflect new default frame styling

## Testing
- `npm test` (fails: ERR_ASSERTION - snake API endpoints and socket events)
- `npm run lint` (fails: 712 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a872d870ac8329a8c07532a2d3ae7a