### PR TITLE
fix: correct pool royale variant rules

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1251,7 +1251,7 @@
                   b2.p.y = CUE_START_Y;
                   b2.v.x = 0;
                   b2.v.y = 0;
-                } else if (b2.n === 8 && !isAmerican) {
+                } else if (b2.n === 8 && !isAmerican && !isNineBall) {
                   b2.pocketed = true;
                   pocketedAny = true;
                   handleEightBall();
@@ -1682,8 +1682,7 @@
         }
 
         function handleEightBall() {
-          var winner = currentShooter === 1 ? 2 : 1;
-          endGame(winner);
+          endGame(currentShooter);
         }
 
         function endShot() {


### PR DESCRIPTION
## Summary
- ensure UK 8-ball wins for the shooter
- avoid premature loss on 9-ball when the 8-ball is pocketed

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a875776f88832980dc141df3188c7a