### PR TITLE
fix: shrink TPC icon in daily streak

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -137,7 +137,7 @@ export default function DailyCheckIn() {
 
         <span className="flex items-center">
           {formatReward(REWARDS[i])}
-          <img  src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-8 h-8 -ml-1" />
+          <img  src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-7 h-7 -ml-1" />
         </span>
 
         {i === streak - 1 && showPopup && (


### PR DESCRIPTION
## Summary
- Slightly reduce TPC icon size in daily streak display

## Testing
- `npm test` *(fails: ERR_DLOPEN_FAILED: canvas, snake API test timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a87656c2208329b2057e470ab1e6da