### PR TITLE
Reduce TPC icon on wallet cards

### DIFF
--- a/webapp/src/components/BalanceSummary.jsx
+++ b/webapp/src/components/BalanceSummary.jsx
@@ -23,7 +23,7 @@ export default function BalanceSummary({ className = '', showHeader = true }) {
       <div className="grid grid-cols-3 text-sm mt-4">
         <Token icon="/assets/icons/TON.webp" label="TON" value={tonBalance ?? '...'} />
         <Token icon="/assets/icons/ezgif-54c96d8a9b9236.webp" label="TPC (App)" value={tpcBalance ?? 0} decimals={2} iconClass="w-16 h-16" />
-        <Token icon="/assets/icons/ezgif-54c96d8a9b9236.webp" label="TPC" value={tpcWalletBalance ?? '...'} decimals={2} iconClass="w-16 h-16" />
+        <Token icon="/assets/icons/ezgif-54c96d8a9b9236.webp" label="TPC" value={tpcWalletBalance ?? '...'} decimals={2} iconClass="w-[3.2rem] h-[3.2rem]" />
       </div>
     </div>
   );

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -177,7 +177,7 @@ export default function Home() {
                   </div>
                 </Link>
                 <div className="flex flex-col items-center space-y-1">
-              <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-[5rem] h-[5rem]" />
+              <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-[4rem] h-[4rem]" />
                   <span className="text-sm">{formatValue(tpcBalance ?? '...', 2)}</span>
                 </div>
                 <Link to="/wallet?mode=receive" className="flex items-center space-x-1 -mr-1 pt-1">


### PR DESCRIPTION
## Summary
- shrink TPC wallet icon on Home wallet card for a cleaner look
- reduce TPC wallet icon size in profile BalanceSummary

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a877d73cfc8329a5dc5a9d7a04dfba