### PR TITLE
feat: enlarge stake cards in lobbies

### DIFF
--- a/webapp/src/components/RoomSelector.jsx
+++ b/webapp/src/components/RoomSelector.jsx
@@ -24,7 +24,7 @@ export default function RoomSelector({ selected, onSelect, tokens: allowed }) {
             <button
               key={`${id}-${amt}`}
               onClick={() => onSelect({ token: id, amount: amt })}
-              className={`lobby-tile w-[2.89rem] !px-[0.289rem] !py-[0.1445rem] flex flex-col items-center space-y-1 cursor-pointer text-[0.578rem] ${
+              className={`lobby-tile w-[3.3235rem] !px-[0.3324rem] !py-[0.1662rem] flex flex-col items-center space-y-1 cursor-pointer text-[0.6647rem] ${
                 token === id && amount === amt
                   ? 'lobby-selected'
                   : ''
@@ -35,8 +35,8 @@ export default function RoomSelector({ selected, onSelect, tokens: allowed }) {
                 alt={id}
                 className={
                   id === 'TPC'
-                    ? 'w-[0.8092rem] h-[0.8092rem]'
-                    : 'w-[1.156rem] h-[1.156rem]'
+                    ? 'w-[0.9306rem] h-[0.9306rem]'
+                    : 'w-[1.3294rem] h-[1.3294rem]'
                 }
               />
               <span>{amt.toLocaleString('en-US')}</span>


### PR DESCRIPTION
## Summary
- enlarge lobby stake selection tiles by 15%

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint` *(fails: 712 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a87cd75a90832989f33f75ac442331