### PR TITLE
Align blackjack controls and add betting options

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -66,7 +66,7 @@
       .card .corner .suit { font-size:calc(var(--card-w)*0.18); line-height:1; }
       .card .big { position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); font-size:calc(var(--card-w)*0.52); opacity:0.9; filter:drop-shadow(0 0 2px rgba(0,0,0,0.4)); }
       .red { color:#d00; }
-      .seat.bottom { bottom:0.5%; left:50%; transform:translateX(-50%); --card-scale:1.083; --avatar-scale:1; --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale)); --card-h: calc(var(--card-w) * 1.45); }
+      .seat.bottom { top:64%; left:50%; transform:translate(-50%,-50%); --card-scale:1.083; --avatar-scale:1; --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale)); --card-h: calc(var(--card-w) * 1.45); }
       .seat.top { top:1%; left:50%; transform:translateX(-50%); }
       .seat.left { left:16%; top:24%; transform:translate(-50%,-50%); }
       .seat.right { left:84%; top:24%; transform:translate(-50%,-50%); }
@@ -77,8 +77,15 @@
       .seat.bottom .cards { gap:0; }
       .seat-balance { font-size:10px; color:#fff; display:flex; align-items:center; gap:2px; }
       .seat.bottom .seat-balance { font-size:12px; }
-      .player-controls { position:absolute; bottom:20px; left:50%; transform:translateX(-50%); display:flex; gap:12px; z-index:3; }
-      .player-controls button { padding:8px 16px; font-size:16px; border:none; border-radius:6px; cursor:pointer; }
+      .controls { position:absolute; bottom:20px; left:50%; transform:translateX(-50%); display:flex; gap:8px; align-items:flex-end; justify-content:center; z-index:5; }
+      .controls button { width:var(--avatar-size); height:var(--avatar-size); padding:0; border:4px solid #000; border-radius:50%; background:#2563eb; color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
+      #check { background:#facc15; }
+      #call { background:#16a34a; }
+      #fold { background:#dc2626; }
+      .hit-stand { display:flex; gap:12px; margin-top:8px; }
+      .hit-stand button { padding:8px 16px; font-size:16px; border:2px solid #000; border-radius:6px; cursor:pointer; color:#fff; }
+      #hitBtn { background:#16a34a; }
+      #standBtn { background:#dc2626; }
       #status { position:absolute; top:10px; left:50%; transform:translateX(-50%); font-size:18px; font-weight:bold; z-index:3; text-shadow:0 2px 4px #000; }
       .folded { opacity:0.5; }
       .pot-wrap { position:absolute; left:50%; top:45%; transform:translate(-50%,-50%); display:flex; flex-direction:column; align-items:center; gap:4px; z-index:3; }
@@ -100,7 +107,9 @@
       .raise-container .chip { cursor:pointer; border:2px solid transparent; width:36px; height:36px; }
       .raise-container .chip:active { border-color:#0ea5e9; }
       .slider-container { position:absolute; bottom:4%; right:1%; z-index:5; display:flex; flex-direction:column; align-items:center; gap:8px; }
+      .raise-buttons { display:flex; gap:8px; }
       .raise-btn { width:54px; height:54px; padding:0; border:4px solid #000; border-radius:50%; background:#2563eb; color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
+      .all-in-btn { background:#16a34a; }
       .raise-amount { font-size:14px; }
       .top-controls { position:absolute; top:4px; right:8px; display:flex; gap:4px; z-index:10; }
       .top-controls button { width:32px; height:32px; padding:0; border:2px solid #000; border-radius:50%; display:flex; align-items:center; justify-content:center; background:#2563eb; color:#fff; font-weight:600; font-size:14px; line-height:1; }
@@ -146,12 +155,15 @@
       <div class="slider-container">
         <input type="range" id="raiseSlider" min="0" value="0" />
         <div class="raise-amount" id="raiseSliderAmount">0</div>
-        <button class="raise-btn" id="raiseBtn">Raise</button>
-        <button class="raise-btn" id="allInBtn">All In</button>
+        <div class="raise-buttons">
+          <button class="raise-btn" id="raiseBtn">Raise</button>
+          <button class="raise-btn all-in-btn" id="allInBtn">All In</button>
+        </div>
       </div>
-      <div class="player-controls">
-        <button onclick="hit()">Hit</button>
-        <button onclick="stand()">Stand</button>
+      <div class="controls" id="controls">
+        <button id="check">check</button>
+        <button id="call">call</button>
+        <button id="fold">fold</button>
       </div>
     </div>
     <div id="settingsPanel" class="settings-panel">

--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -261,6 +261,20 @@ function render() {
       }
     });
     inner.append(avatar, cards);
+    if (i === 0) {
+      const hs = document.createElement('div');
+      hs.className = 'hit-stand';
+      const hitBtn = document.createElement('button');
+      hitBtn.id = 'hitBtn';
+      hitBtn.textContent = 'Hit';
+      hitBtn.addEventListener('click', () => window.hit());
+      const standBtn = document.createElement('button');
+      standBtn.id = 'standBtn';
+      standBtn.textContent = 'Stand';
+      standBtn.addEventListener('click', () => window.stand());
+      hs.append(hitBtn, standBtn);
+      inner.appendChild(hs);
+    }
     const bal = document.createElement('div');
     bal.className = 'seat-balance';
     bal.innerHTML = formatAmount(p.balance || 0);
@@ -504,6 +518,22 @@ function init() {
     allInBtn.addEventListener('click', () => {
       state.raiseAmount = state.stake * 10;
       commitRaise();
+    });
+  const checkBtn = document.getElementById('check');
+  const callBtn = document.getElementById('call');
+  const foldBtn = document.getElementById('fold');
+  const statusEl = document.getElementById('status');
+  if (checkBtn)
+    checkBtn.addEventListener('click', () => {
+      if (statusEl) statusEl.textContent = 'You check';
+    });
+  if (callBtn)
+    callBtn.addEventListener('click', () => {
+      if (statusEl) statusEl.textContent = 'You call';
+    });
+  if (foldBtn)
+    foldBtn.addEventListener('click', () => {
+      if (statusEl) statusEl.textContent = 'You fold';
     });
   sndCallRaise = document.getElementById('sndCallRaise');
   sndFlip = document.getElementById('sndFlip');


### PR DESCRIPTION
## Summary
- Align bottom seat with other players and adjust hit/stand controls
- Add poker-style check/call/fold buttons and horizontal raise/all-in layout

## Testing
- `npm test` *(fails: ERR_DLOPEN_FAILED and test timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a883bbe7b4832990b21ba1b6a076a1