### PR TITLE
feat: add card reward logic and deck generator

### DIFF
--- a/test/cardRewards.test.js
+++ b/test/cardRewards.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { calculateCardReward, buildDeck } from '../webapp/src/utils/cardRewards.js';
+
+test('calculates suit-based rewards', () => {
+  assert.equal(calculateCardReward('hearts', 10), 20);
+  assert.equal(calculateCardReward('spades', 8), 6); // 8 * 0.75 = 6
+  assert.equal(calculateCardReward('clubs', 8), 4); // 8 * 0.5 = 4
+  assert.equal(calculateCardReward('diamonds', 8), 12); // 8 * 1.5 = 12
+  assert.equal(calculateCardReward('joker_black'), 5000);
+  assert.equal(calculateCardReward('joker_red'), 1000);
+});
+
+test('deck contains specials', () => {
+  const deck = buildDeck();
+  assert.equal(deck.length, 50);
+  const freeSpins = deck.filter(c => c.special === 'FREE_SPIN').length;
+  const bonuses = deck.filter(c => c.special === 'BONUS_X3').length;
+  assert.equal(freeSpins, 5);
+  assert.equal(bonuses, 5);
+});

--- a/webapp/src/utils/cardRewards.js
+++ b/webapp/src/utils/cardRewards.js
@@ -1,0 +1,67 @@
+export const SUITS = ['hearts', 'spades', 'clubs', 'diamonds'];
+
+/**
+ * Calculate reward for a card based on its suit and rank.
+ * @param {string} suit - Card suit or joker type
+ * @param {number} [rank] - Card rank from 1-12
+ * @returns {number}
+ */
+export function calculateCardReward (suit, rank = 0) {
+  if (suit === 'joker_black') return 5000;
+  if (suit === 'joker_red') return 1000;
+  const base = rank;
+  switch (suit) {
+    case 'hearts':
+      return base * 2;
+    case 'spades':
+      return Math.round(base * 0.75);
+    case 'clubs':
+      return Math.round(base * 0.5);
+    case 'diamonds':
+      return Math.round(base * 1.5);
+    default:
+      return base;
+  }
+}
+
+function shuffle (arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+
+/**
+ * Build a deck of cards with rewards and random specials.
+ * Each suit has ranks 1-12. Two jokers are added. Five cards
+ * are marked as FREE_SPIN and five as BONUS_X3.
+ * @returns {Array}
+ */
+export function buildDeck () {
+  const deck = [];
+  for (const suit of SUITS) {
+    for (let rank = 1; rank <= 12; rank++) {
+      deck.push({
+        suit,
+        rank,
+        reward: calculateCardReward(suit, rank)
+      });
+    }
+  }
+  deck.push({ suit: 'joker_black', rank: null, reward: 5000 });
+  deck.push({ suit: 'joker_red', rank: null, reward: 1000 });
+
+  // assign specials
+  const indices = deck.map((_, i) => i);
+  shuffle(indices);
+  const specials = indices.filter(i => deck[i].suit !== 'joker_black' && deck[i].suit !== 'joker_red');
+
+  for (let i = 0; i < 5 && i < specials.length; i++) {
+    deck[specials[i]].special = 'FREE_SPIN';
+  }
+  for (let i = 5; i < 10 && i < specials.length; i++) {
+    deck[specials[i]].special = 'BONUS_X3';
+  }
+
+  return deck;
+}


### PR DESCRIPTION
## Summary
- add utility to compute card-based rewards and build deck with random bonuses
- add tests covering reward logic and deck generation

## Testing
- `npm test` *(fails: test timed out in snake API endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_68a887c6dc8883299fd86d8c776528b1