### PR TITLE
Animate blackjack deal and track stands

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -311,6 +311,34 @@
         z-index: 1000;
         pointer-events: none;
       }
+      .stand-copy-wrapper {
+        position: absolute;
+        top: calc(-1 * var(--card-h) - 10px);
+        left: 50%;
+        transform: translateX(-50%) scale(0.5);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        pointer-events: none;
+      }
+      .stand-copy-wrapper .stand-name {
+        font-size: 10px;
+        color: #fff;
+        margin-top: 2px;
+        text-shadow: 0 0 2px #000;
+      }
+      .card.back .stand-names {
+        position: absolute;
+        inset: 4px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        font-size: 10px;
+        color: #fff;
+        text-align: center;
+        pointer-events: none;
+      }
       .seat-inner .cards.turn {
         box-shadow: 0 0 12px #facc15;
         border-color: #facc15;


### PR DESCRIPTION
## Summary
- Animate blackjack dealing from center using `dealCardToPlayer`
- Add unflipped community card that lists players who have stood
- Display small standing-card copies above player seats with names

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint` *(fails: Extra semicolon, prefer-const, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cd0d64708329a3eb4b7e1ffe7ea5