### PR TITLE
feat: add TPC card backs and size-aware spinner

### DIFF
--- a/webapp/src/components/CardSpinner.jsx
+++ b/webapp/src/components/CardSpinner.jsx
@@ -2,8 +2,6 @@ import { useState, useEffect, useRef } from 'react';
 import { numericSegments, getLuckyReward } from '../utils/rewardLogic';
 import { getGameVolume } from '../utils/sound.js';
 
-const itemHeight = 96; // card height
-
 function PrizeItem({ value }) {
   if (value === 'FREE_SPIN') {
     return (
@@ -60,7 +58,9 @@ function PrizeItem({ value }) {
 export default function CardSpinner({ trigger = 0, onFinish }) {
   const [items, setItems] = useState([]);
   const [offset, setOffset] = useState(0);
+  const [itemHeight, setItemHeight] = useState(0);
   const spinSoundRef = useRef(null);
+  const containerRef = useRef(null);
 
   useEffect(() => {
     spinSoundRef.current = new Audio('/assets/sounds/spinning.mp3');
@@ -79,6 +79,8 @@ export default function CardSpinner({ trigger = 0, onFinish }) {
 
   useEffect(() => {
     if (!trigger) return;
+    const height = containerRef.current?.clientHeight || 0;
+    setItemHeight(height);
     const base = [
       ...numericSegments,
       'FREE_SPIN',
@@ -96,7 +98,7 @@ export default function CardSpinner({ trigger = 0, onFinish }) {
     setOffset(0);
     spinSoundRef.current?.play().catch(() => {});
     requestAnimationFrame(() => {
-      setOffset(-((arr.length - 1) * itemHeight));
+      setOffset(-((arr.length - 1) * height));
     });
     const timeout = setTimeout(() => {
       spinSoundRef.current?.pause();
@@ -106,7 +108,7 @@ export default function CardSpinner({ trigger = 0, onFinish }) {
   }, [trigger, onFinish]);
 
   return (
-    <div className="absolute inset-0 overflow-hidden rounded-md bg-white">
+    <div ref={containerRef} className="absolute inset-0 overflow-hidden rounded-md bg-white">
       <div
         className="transition-transform duration-[4000ms] ease-out flex flex-col"
         style={{ transform: `translateY(${offset}px)` }}
@@ -114,7 +116,7 @@ export default function CardSpinner({ trigger = 0, onFinish }) {
         {items.map((val, i) => (
           <div
             key={i}
-            className="h-24 w-full flex flex-col items-center justify-center"
+            className="w-full flex flex-col items-center justify-center"
             style={{ height: `${itemHeight}px` }}
           >
             <PrizeItem value={val} />

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -26,7 +26,7 @@ export default function LuckyNumber() {
   const [showAd, setShowAd] = useState(false);
   const [adWatched, setAdWatched] = useState(false);
   const [trigger, setTrigger] = useState(0);
-  const ranks = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q'];
+  const ranks = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q'];
   const suitTypes = ['hearts', 'spades', 'diamonds', 'clubs'];
   const [cards] = useState(() =>
     ranks.map((r) => ({ rank: r, suit: suitTypes[Math.floor(Math.random() * suitTypes.length)] }))
@@ -60,7 +60,7 @@ export default function LuckyNumber() {
   const handleRollEnd = (values) => {
     setRolling(false);
     const sum = values.reduce((acc, v) => acc + v, 0);
-    const idx = Math.min(Math.max(0, sum - 1), 11);
+    const idx = Math.min(Math.max(0, sum - 2), ranks.length - 1);
     setSelected(idx);
     setCardPrize(null);
     setSpinTrigger((t) => t + 1);
@@ -155,37 +155,76 @@ export default function LuckyNumber() {
               }}
             >
               <div
-                className="absolute inset-0 bg-white rounded-md flex flex-col items-center justify-center text-xl font-bold"
+                className="absolute inset-0 bg-white rounded-md flex items-center justify-center"
                 style={{ backfaceVisibility: 'hidden' }}
               >
-                <span className={`${
-                  card.suit === 'hearts' || card.suit === 'diamonds'
-                    ? 'text-red-500'
-                    : 'text-black'
-                }`}>{card.rank}</span>
-                <span className={`text-2xl ${
-                  card.suit === 'hearts' || card.suit === 'diamonds'
-                    ? 'text-red-500'
-                    : 'text-black'
-                }`}>
-                  {card.suit === 'hearts'
-                    ? '♥'
-                    : card.suit === 'spades'
-                    ? '♠'
-                    : card.suit === 'diamonds'
-                    ? '♦'
-                    : '♣'}
-                </span>
+                <img
+                  src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp"
+                  alt="Card Back"
+                  className="w-10 h-10"
+                />
               </div>
               <div
                 className="absolute inset-0 rounded-md flex items-center justify-center"
                 style={{ transform: 'rotateY(180deg)', backfaceVisibility: 'hidden' }}
               >
+                <div className="absolute inset-0 flex flex-col items-center justify-center text-xl font-bold">
+                  <span
+                    className={`${
+                      card.suit === 'hearts' || card.suit === 'diamonds'
+                        ? 'text-red-500'
+                        : 'text-black'
+                    }`}
+                  >
+                    {card.rank}
+                  </span>
+                  <span
+                    className={`text-2xl ${
+                      card.suit === 'hearts' || card.suit === 'diamonds'
+                        ? 'text-red-500'
+                        : 'text-black'
+                    }`}
+                  >
+                    {card.suit === 'hearts'
+                      ? '♥'
+                      : card.suit === 'spades'
+                      ? '♠'
+                      : card.suit === 'diamonds'
+                      ? '♦'
+                      : '♣'}
+                  </span>
+                </div>
                 {selected === i && !cardPrize && (
                   <CardSpinner trigger={spinTrigger} onFinish={handleSpinFinish} />
                 )}
                 {selected === i && cardPrize && (
-                  <div className="flex flex-col items-center justify-center w-full h-full bg-white rounded-md">
+                  <div className="flex flex-col items-center justify-center w-full h-full bg-white rounded-md relative">
+                    <div className="absolute top-1 left-1 text-sm font-bold">
+                      <span
+                        className={`${
+                          card.suit === 'hearts' || card.suit === 'diamonds'
+                            ? 'text-red-500'
+                            : 'text-black'
+                        }`}
+                      >
+                        {card.rank}
+                      </span>
+                      <span
+                        className={`ml-1 ${
+                          card.suit === 'hearts' || card.suit === 'diamonds'
+                            ? 'text-red-500'
+                            : 'text-black'
+                        }`}
+                      >
+                        {card.suit === 'hearts'
+                          ? '♥'
+                          : card.suit === 'spades'
+                          ? '♠'
+                          : card.suit === 'diamonds'
+                          ? '♦'
+                          : '♣'}
+                      </span>
+                    </div>
                     {cardPrize === 'FREE_SPIN' ? (
                       <>
                         <img


### PR DESCRIPTION
## Summary
- show TPC logo backs for Lucky Card deck and map dice rolls to cards 2–Q
- resize card spinner dynamically so rewards fit each card

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a94aa1464c83299c0b7ff231cf9aed