### PR TITLE
feat: enhance lucky card visuals and flow

### DIFF
--- a/webapp/src/components/CardSpinner.jsx
+++ b/webapp/src/components/CardSpinner.jsx
@@ -58,7 +58,7 @@ function PrizeItem({ value }) {
 export default function CardSpinner({ trigger = 0, onFinish }) {
   const [items, setItems] = useState([]);
   const [offset, setOffset] = useState(0);
-  const [itemHeight, setItemHeight] = useState(0);
+  const [itemWidth, setItemWidth] = useState(0);
   const spinSoundRef = useRef(null);
   const containerRef = useRef(null);
 
@@ -79,8 +79,8 @@ export default function CardSpinner({ trigger = 0, onFinish }) {
 
   useEffect(() => {
     if (!trigger) return;
-    const height = containerRef.current?.clientHeight || 0;
-    setItemHeight(height);
+    const width = containerRef.current?.clientWidth || 0;
+    setItemWidth(width);
     const base = [
       ...numericSegments,
       'FREE_SPIN',
@@ -98,7 +98,7 @@ export default function CardSpinner({ trigger = 0, onFinish }) {
     setOffset(0);
     spinSoundRef.current?.play().catch(() => {});
     requestAnimationFrame(() => {
-      setOffset(-((arr.length - 1) * height));
+      setOffset(-((arr.length - 1) * width));
     });
     const timeout = setTimeout(() => {
       spinSoundRef.current?.pause();
@@ -110,14 +110,14 @@ export default function CardSpinner({ trigger = 0, onFinish }) {
   return (
     <div ref={containerRef} className="absolute inset-0 overflow-hidden rounded-md bg-white">
       <div
-        className="transition-transform duration-[4000ms] ease-out flex flex-col"
-        style={{ transform: `translateY(${offset}px)` }}
+        className="transition-transform duration-[4000ms] ease-out flex flex-row h-full"
+        style={{ transform: `translateX(${offset}px)` }}
       >
         {items.map((val, i) => (
           <div
             key={i}
-            className="w-full flex flex-col items-center justify-center"
-            style={{ height: `${itemHeight}px` }}
+            className="h-full flex flex-col items-center justify-center"
+            style={{ width: `${itemWidth}px` }}
           >
             <PrizeItem value={val} />
           </div>

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -3,6 +3,7 @@ import DiceRoller from './DiceRoller.jsx';
 import RewardPopup from './RewardPopup.tsx';
 import AdModal from './AdModal.tsx';
 import CardSpinner from './CardSpinner.jsx';
+import WinningCardPopup from './WinningCardPopup.jsx';
 import { getTelegramId } from '../utils/telegram.js';
 import LoginOptions from './LoginOptions.jsx';
 import { getWalletBalance, updateBalance, addTransaction } from '../utils/api.js';
@@ -19,6 +20,8 @@ export default function LuckyNumber() {
 
   const [selected, setSelected] = useState(null);
   const [reward, setReward] = useState(null);
+  const [pendingPrize, setPendingPrize] = useState(null);
+  const [winningCard, setWinningCard] = useState(null);
   const [cardPrize, setCardPrize] = useState(null);
   const [spinTrigger, setSpinTrigger] = useState(0);
   const [canRoll, setCanRoll] = useState(false);
@@ -26,7 +29,7 @@ export default function LuckyNumber() {
   const [showAd, setShowAd] = useState(false);
   const [adWatched, setAdWatched] = useState(false);
   const [trigger, setTrigger] = useState(0);
-  const ranks = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q'];
+  const ranks = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J'];
   const suitTypes = ['hearts', 'spades', 'diamonds', 'clubs'];
   const [cards] = useState(() =>
     ranks.map((r) => ({ rank: r, suit: suitTypes[Math.floor(Math.random() * suitTypes.length)] }))
@@ -109,7 +112,13 @@ export default function LuckyNumber() {
       window.dispatchEvent(new Event('bonusX3Awarded'));
       document.getElementById('spin-game')?.scrollIntoView({ behavior: 'smooth' });
     }
-    setReward(finalPrize);
+    setPendingPrize(finalPrize);
+    setWinningCard(cards[selected]);
+  };
+
+  const handleWinningCardClose = () => {
+    setWinningCard(null);
+    setReward(pendingPrize);
   };
 
   const handleRollClick = () => {
@@ -155,15 +164,9 @@ export default function LuckyNumber() {
               }}
             >
               <div
-                className="absolute inset-0 bg-white rounded-md flex items-center justify-center"
+                className="absolute inset-0 lucky-card-back rounded-md"
                 style={{ backfaceVisibility: 'hidden' }}
-              >
-                <img
-                  src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp"
-                  alt="Card Back"
-                  className="w-10 h-10"
-                />
-              </div>
+              ></div>
               <div
                 className="absolute inset-0 rounded-md flex items-center justify-center"
                 style={{ transform: 'rotateY(180deg)', backfaceVisibility: 'hidden' }}
@@ -306,12 +309,14 @@ export default function LuckyNumber() {
         onComplete={handleAdComplete}
         onClose={() => setShowAd(false)}
       />
+      <WinningCardPopup card={winningCard} onClose={handleWinningCardClose} />
       <RewardPopup
         reward={reward}
         onClose={() => {
           setReward(null);
           setSelected(null);
           setCardPrize(null);
+          setPendingPrize(null);
         }}
       />
     </div>

--- a/webapp/src/components/WinningCardPopup.jsx
+++ b/webapp/src/components/WinningCardPopup.jsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+
+export default function WinningCardPopup({ card, onClose, duration = 1500 }) {
+  if (!card) return null;
+  useEffect(() => {
+    const t = setTimeout(onClose, duration);
+    return () => clearTimeout(t);
+  }, [onClose, duration]);
+
+  const isRed = card.suit === 'hearts' || card.suit === 'diamonds';
+  const suitSymbol =
+    card.suit === 'hearts'
+      ? '♥'
+      : card.suit === 'spades'
+      ? '♠'
+      : card.suit === 'diamonds'
+      ? '♦'
+      : '♣';
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
+      <div className="w-32 h-48 bg-white rounded-md flex flex-col items-center justify-center relative">
+        <div className="absolute top-1 left-1 text-sm font-bold">
+          <span className={isRed ? 'text-red-500' : 'text-black'}>{card.rank}</span>
+          <span className={`ml-1 ${isRed ? 'text-red-500' : 'text-black'}`}>{suitSymbol}</span>
+        </div>
+        <span className={`text-5xl ${isRed ? 'text-red-500' : 'text-black'}`}>{suitSymbol}</span>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -216,6 +216,20 @@ input:focus {
   transform: translateY(90px) scale(1.2);
 }
 
+.lucky-card-back {
+  background:
+    url('/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp')
+      center/90% no-repeat,
+    repeating-linear-gradient(
+      45deg,
+      #233,
+      #233 6px,
+      #122 6px,
+      #122 12px
+    );
+  border: 2px solid rgba(255, 255, 255, 0.5);
+}
+
 /* Adjusted placement for Crazy Dice Duel */
 .crazy-dice-bg {
   top: 0;


### PR DESCRIPTION
## Summary
- start Lucky Card deck with an Ace and show winning card popup before reward
- style card backs with Texas Hold'em pattern
- spin reward reel horizontally instead of vertically

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68a94f1e737883299a0d4e1473b1ab0e