### PR TITLE
Update Lucky Card spinner and card layout

### DIFF
--- a/webapp/src/components/CardSpinner.jsx
+++ b/webapp/src/components/CardSpinner.jsx
@@ -58,8 +58,9 @@ function PrizeItem({ value }) {
 export default function CardSpinner({ trigger = 0, onFinish }) {
   const [items, setItems] = useState([]);
   const [offset, setOffset] = useState(0);
-  const [itemWidth, setItemWidth] = useState(0);
+  const [itemHeight, setItemHeight] = useState(0);
   const spinSoundRef = useRef(null);
+  const successSoundRef = useRef(null);
   const containerRef = useRef(null);
 
   useEffect(() => {
@@ -67,8 +68,12 @@ export default function CardSpinner({ trigger = 0, onFinish }) {
     spinSoundRef.current.preload = 'auto';
     spinSoundRef.current.loop = true;
     spinSoundRef.current.volume = getGameVolume();
+    successSoundRef.current = new Audio('/assets/sounds/successful.mp3');
+    successSoundRef.current.preload = 'auto';
+    successSoundRef.current.volume = getGameVolume();
     const handler = () => {
       if (spinSoundRef.current) spinSoundRef.current.volume = getGameVolume();
+      if (successSoundRef.current) successSoundRef.current.volume = getGameVolume();
     };
     window.addEventListener('gameVolumeChanged', handler);
     return () => {
@@ -79,8 +84,8 @@ export default function CardSpinner({ trigger = 0, onFinish }) {
 
   useEffect(() => {
     if (!trigger) return;
-    const width = containerRef.current?.clientWidth || 0;
-    setItemWidth(width);
+    const height = containerRef.current?.clientHeight || 0;
+    setItemHeight(height);
     const base = [
       ...numericSegments,
       'FREE_SPIN',
@@ -98,30 +103,33 @@ export default function CardSpinner({ trigger = 0, onFinish }) {
     setOffset(0);
     spinSoundRef.current?.play().catch(() => {});
     requestAnimationFrame(() => {
-      setOffset(-((arr.length - 1) * width));
+      setOffset(-((arr.length - 1) * height));
     });
     const timeout = setTimeout(() => {
       spinSoundRef.current?.pause();
+      successSoundRef.current?.play().catch(() => {});
       onFinish(finalReward);
-    }, 4000);
+    }, 3000);
     return () => clearTimeout(timeout);
   }, [trigger, onFinish]);
 
   return (
-    <div ref={containerRef} className="absolute inset-0 overflow-hidden rounded-md bg-white">
-      <div
-        className="transition-transform duration-[4000ms] ease-out flex flex-row h-full"
-        style={{ transform: `translateX(${offset}px)` }}
-      >
-        {items.map((val, i) => (
-          <div
-            key={i}
-            className="h-full flex flex-col items-center justify-center"
-            style={{ width: `${itemWidth}px` }}
-          >
-            <PrizeItem value={val} />
-          </div>
-        ))}
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div ref={containerRef} className="overflow-hidden rounded-md bg-white" style={{ height: '160px', width: '80px' }}>
+        <div
+          className="transition-transform duration-[3000ms] ease-out flex flex-col"
+          style={{ transform: `translateY(${offset}px)` }}
+        >
+          {items.map((val, i) => (
+            <div
+              key={i}
+              className="flex flex-col items-center justify-center"
+              style={{ height: `${itemHeight}px` }}
+            >
+              <PrizeItem value={val} />
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -29,7 +29,7 @@ export default function LuckyNumber() {
   const [showAd, setShowAd] = useState(false);
   const [adWatched, setAdWatched] = useState(false);
   const [trigger, setTrigger] = useState(0);
-  const ranks = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J'];
+  const ranks = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q'];
   const suitTypes = ['hearts', 'spades', 'diamonds', 'clubs'];
   const [cards] = useState(() =>
     ranks.map((r) => ({ rank: r, suit: suitTypes[Math.floor(Math.random() * suitTypes.length)] }))
@@ -201,8 +201,8 @@ export default function LuckyNumber() {
                   <CardSpinner trigger={spinTrigger} onFinish={handleSpinFinish} />
                 )}
                 {selected === i && cardPrize && (
-                  <div className="flex flex-col items-center justify-center w-full h-full bg-white rounded-md relative">
-                    <div className="absolute top-1 left-1 text-sm font-bold">
+                  <div className="w-full h-full bg-white rounded-md relative">
+                    <div className="absolute top-1 left-1 text-sm font-bold flex items-center">
                       <span
                         className={`${
                           card.suit === 'hearts' || card.suit === 'diamonds'
@@ -228,34 +228,127 @@ export default function LuckyNumber() {
                           : '♣'}
                       </span>
                     </div>
-                    {cardPrize === 'FREE_SPIN' ? (
-                      <>
-                        <img
-                          src="/assets/icons/file_00000000ae68620a96d269fe76d158e5_256x256.webp"
-                          alt="Free Spin"
-                          className="w-10 h-10"
-                        />
-                        <span className="font-bold text-white" style={{ WebkitTextStroke: '1px black' }}>+2</span>
-                      </>
-                    ) : cardPrize === 'BONUS_X3' ? (
-                      <>
-                        <img
-                          src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp"
-                          alt="Bonus"
-                          className="w-10 h-10"
-                        />
-                        <span className="font-bold text-white" style={{ WebkitTextStroke: '1px black' }}>X3</span>
-                      </>
-                    ) : (
-                      <>
-                        <img
-                          src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp"
-                          alt="TonPlaygram"
-                          className="w-10 h-10"
-                        />
-                        <span className="font-bold text-white" style={{ WebkitTextStroke: '1px black' }}>{cardPrize}</span>
-                      </>
-                    )}
+                    <div className="absolute bottom-1 right-1 text-sm font-bold flex items-center">
+                      <span
+                        className={`${
+                          card.suit === 'hearts' || card.suit === 'diamonds'
+                            ? 'text-red-500'
+                            : 'text-black'
+                        }`}
+                      >
+                        {card.rank}
+                      </span>
+                      <span
+                        className={`ml-1 ${
+                          card.suit === 'hearts' || card.suit === 'diamonds'
+                            ? 'text-red-500'
+                            : 'text-black'
+                        }`}
+                      >
+                        {card.suit === 'hearts'
+                          ? '♥'
+                          : card.suit === 'spades'
+                          ? '♠'
+                          : card.suit === 'diamonds'
+                          ? '♦'
+                          : '♣'}
+                      </span>
+                    </div>
+                    <div
+                      className={`absolute inset-0 flex items-center justify-center text-2xl ${
+                        card.suit === 'hearts' || card.suit === 'diamonds'
+                          ? 'text-red-500'
+                          : 'text-black'
+                      }`}
+                    >
+                      {card.suit === 'hearts'
+                        ? '♥'
+                        : card.suit === 'spades'
+                        ? '♠'
+                        : card.suit === 'diamonds'
+                        ? '♦'
+                        : '♣'}
+                    </div>
+                    <div className="absolute top-1 right-1 text-xs font-bold flex items-center">
+                      {cardPrize === 'FREE_SPIN' ? (
+                        <>
+                          <img
+                            src="/assets/icons/file_00000000ae68620a96d269fe76d158e5_256x256.webp"
+                            alt="Free Spin"
+                            className="w-4 h-4"
+                          />
+                          <span className="ml-1">+2</span>
+                        </>
+                      ) : cardPrize === 'BONUS_X3' ? (
+                        <>
+                          <img
+                            src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp"
+                            alt="Bonus"
+                            className="w-4 h-4"
+                          />
+                          <span className="ml-1">X3</span>
+                        </>
+                      ) : cardPrize === 'JOKER_BLACK' ? (
+                        <>
+                          <span>🃏</span>
+                          <span className="ml-1">5000</span>
+                        </>
+                      ) : cardPrize === 'JOKER_RED' ? (
+                        <>
+                          <span className="text-red-500">🃏</span>
+                          <span className="ml-1 text-red-500">10000</span>
+                        </>
+                      ) : (
+                        <>
+                          <img
+                            src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp"
+                            alt="TonPlaygram"
+                            className="w-4 h-4"
+                          />
+                          <span className="ml-1">{cardPrize}</span>
+                        </>
+                      )}
+                    </div>
+                    <div className="absolute bottom-1 left-1 text-xs font-bold flex items-center">
+                      {cardPrize === 'FREE_SPIN' ? (
+                        <>
+                          <img
+                            src="/assets/icons/file_00000000ae68620a96d269fe76d158e5_256x256.webp"
+                            alt="Free Spin"
+                            className="w-4 h-4"
+                          />
+                          <span className="ml-1">+2</span>
+                        </>
+                      ) : cardPrize === 'BONUS_X3' ? (
+                        <>
+                          <img
+                            src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp"
+                            alt="Bonus"
+                            className="w-4 h-4"
+                          />
+                          <span className="ml-1">X3</span>
+                        </>
+                      ) : cardPrize === 'JOKER_BLACK' ? (
+                        <>
+                          <span>🃏</span>
+                          <span className="ml-1">5000</span>
+                        </>
+                      ) : cardPrize === 'JOKER_RED' ? (
+                        <>
+                          <span className="text-red-500">🃏</span>
+                          <span className="ml-1 text-red-500">10000</span>
+                        </>
+                      ) : (
+                        <>
+                          <img
+                            src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp"
+                            alt="TonPlaygram"
+                            className="w-4 h-4"
+                          />
+                          <span className="ml-1">{cardPrize}</span>
+                        </>
+                      )}
+                    </div>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- center Lucky Card spin in a vertical popup with faster animation and success sound
- show playing card details with diagonally placed rank/suit and prize
- extend ranks to include Queen for 12 card set

## Testing
- `npm test` *(fails: 3, pass: 48)*

------
https://chatgpt.com/codex/tasks/task_e_68a95505ff908329b39fcbde6c7d370a