### PR TITLE
Remove joker prizes from Lucky Card spin wheel

### DIFF
--- a/webapp/src/components/CardSpinner.jsx
+++ b/webapp/src/components/CardSpinner.jsx
@@ -27,22 +27,6 @@ function PrizeItem({ value }) {
       </>
     );
   }
-  if (value === 'JOKER_BLACK') {
-    return (
-      <>
-        <span className="text-3xl">🃏</span>
-        <span className="font-bold text-black" style={{ WebkitTextStroke: '1px black' }}>5000</span>
-      </>
-    );
-  }
-  if (value === 'JOKER_RED') {
-    return (
-      <>
-        <span className="text-3xl text-red-500">🃏</span>
-        <span className="font-bold text-red-500" style={{ WebkitTextStroke: '1px black' }}>10000</span>
-      </>
-    );
-  }
   return (
     <>
       <img
@@ -90,8 +74,6 @@ export default function CardSpinner({ trigger = 0, onFinish }) {
       ...numericSegments,
       'FREE_SPIN',
       'BONUS_X3',
-      'JOKER_BLACK',
-      'JOKER_RED',
     ];
     const arr = [];
     for (let i = 0; i < 10; i++) {

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -88,10 +88,6 @@ export default function LuckyNumber() {
       else if (suit === 'spades') finalPrize = Math.floor(prize * 0.5);
       else if (suit === 'diamonds') finalPrize = Math.floor(prize * 1.5);
       else if (suit === 'clubs') finalPrize = Math.floor(prize * 0.75);
-    } else if (prize === 'JOKER_BLACK') {
-      finalPrize = 5000;
-    } else if (prize === 'JOKER_RED') {
-      finalPrize = 10000;
     }
 
     setCardPrize(finalPrize);
@@ -286,17 +282,7 @@ export default function LuckyNumber() {
                             alt="Bonus"
                             className="w-4 h-4"
                           />
-                          <span className="ml-1">X3</span>
-                        </>
-                      ) : cardPrize === 'JOKER_BLACK' ? (
-                        <>
-                          <span>🃏</span>
-                          <span className="ml-1">5000</span>
-                        </>
-                      ) : cardPrize === 'JOKER_RED' ? (
-                        <>
-                          <span className="text-red-500">🃏</span>
-                          <span className="ml-1 text-red-500">10000</span>
+                      <span className="ml-1">X3</span>
                         </>
                       ) : (
                         <>
@@ -327,16 +313,6 @@ export default function LuckyNumber() {
                             className="w-4 h-4"
                           />
                           <span className="ml-1">X3</span>
-                        </>
-                      ) : cardPrize === 'JOKER_BLACK' ? (
-                        <>
-                          <span>🃏</span>
-                          <span className="ml-1">5000</span>
-                        </>
-                      ) : cardPrize === 'JOKER_RED' ? (
-                        <>
-                          <span className="text-red-500">🃏</span>
-                          <span className="ml-1 text-red-500">10000</span>
                         </>
                       ) : (
                         <>

--- a/webapp/src/utils/rewardLogic.ts
+++ b/webapp/src/utils/rewardLogic.ts
@@ -3,9 +3,7 @@ export type Segment =
   | number
   | 'BONUS_X3'
   | 'FREE_SPIN'
-  | 'BOMB'
-  | 'JOKER_BLACK'
-  | 'JOKER_RED';
+  | 'BOMB';
 
 export const segments: Segment[] = [
   400,
@@ -17,8 +15,6 @@ export const segments: Segment[] = [
   1600,
   'FREE_SPIN',
   'BONUS_X3',
-  'JOKER_BLACK',
-  'JOKER_RED',
   'BOMB',
   'BOMB',
 ];
@@ -62,8 +58,6 @@ export function getLuckyReward(): Segment {
   const r = secureRandom();
   if (r < 0.15) return 'BONUS_X3';
   if (r < 0.3) return 'FREE_SPIN';
-  if (r < 0.32) return 'JOKER_BLACK';
-  if (r < 0.34) return 'JOKER_RED';
   const idx = Math.floor(secureRandom() * numericSegments.length);
   return numericSegments[idx] as number;
 }


### PR DESCRIPTION
## Summary
- eliminate Joker rewards from spin wheel logic
- clean up spinner and LuckyNumber components to exclude Joker prizes

## Testing
- `npm test` *(fails: assert.ok(events.includes('diceRolled')))*

------
https://chatgpt.com/codex/tasks/task_e_68a95b8795a083298918fa181e3d1286