### PR TITLE
fix: adjust cue image position in power slider

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -122,7 +122,7 @@
 }
 
 .ps .ps-cue-img {
-  margin-top: 4px;
+  margin-top: 12px;
   width: 100%;
   height: auto;
   transform: translateX(9.6px);


### PR DESCRIPTION
## Summary
- lower cue image inside power slider so it's positioned slightly lower

## Testing
- `npm test`
- `npm run lint` *(fails: 754 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a95d5a7f6c8329bb3cbee7dd4d4fe8