### PR TITLE
Improve blackjack UI with hand values and betting flow

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -195,6 +195,24 @@
         display: flex;
         gap: 6px;
         flex-wrap: nowrap;
+        position: relative;
+      }
+      .hand-total {
+        position: absolute;
+        top: -8px;
+        right: -8px;
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        background: #ff0;
+        color: #000;
+        border: 2px solid #000;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 12px;
+        font-weight: 700;
+        z-index: 3;
       }
       .card {
         width: var(--card-w);


### PR DESCRIPTION
## Summary
- show winning hand totals in a circular badge on cards
- display yellow status messages beneath the community cards
- add raise/call/fold betting logic with 15s auto-fold timer and no check during bets

## Testing
- `npm test` *(fails: no output, process terminated)*
- `npm run lint` *(fails: 754 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a964a538ac8329a67717b58820be11