### PR TITLE
Fix blackjack round reset and betting flow

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -786,6 +786,18 @@
         background-repeat: no-repeat;
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
       }
+      .chip.small {
+        width: calc(var(--avatar-size) / 2.2);
+        height: calc(var(--avatar-size) / 2.2);
+      }
+      .chip.custom {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #fff;
+        color: #000;
+        font-weight: bold;
+      }
       .moving-pot .chip {
         width: calc(var(--avatar-size) / 1.7);
         height: calc(var(--avatar-size) / 1.7);


### PR DESCRIPTION
## Summary
- allow raising before hit/stand and enforce call/fold responses
- reset round timers and balances to prevent freeze
- show pot with up to four smaller value chips

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a974b314b48329af014f1d7a8a189a