### PR TITLE
Allow hitting after raising and export AI betting

### DIFF
--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -5,7 +5,8 @@ import {
   handValue,
   isBust,
   evaluateWinners,
-  aiAction
+  aiAction,
+  aiBetAction
 } from './lib/blackjack.js';
 
 const FLAG_EMOJIS = window.FLAG_EMOJIS || [];
@@ -450,7 +451,7 @@ function aiRespondToRaise() {
     state.currentBet = callAmt + raiseAmt;
     state.raiseInitiator = state.turn;
     render();
-    nextTurn();
+    delay(aiTurn, 500);
     return;
   }
   render();
@@ -706,7 +707,6 @@ function commitRaise() {
   state.raiseInitiator = state.turn;
   clearCallTimer();
   render();
-  nextTurn();
 }
 
 async function startNewRound() {
@@ -950,13 +950,6 @@ function animateChipsFromPlayer(index, amount) {
   }, 500);
 }
 
-function aiBetAction(hand) {
-  const val = handValue(hand);
-  if (val >= 18) return 'raise';
-  if (val <= 11) return 'fold';
-  return 'call';
-}
-
 function aiBettingRound() {
   for (let i = 0; i < state.players.length; i++) {
     const p = state.players[i];
@@ -974,7 +967,7 @@ function aiBettingRound() {
       state.turn = i;
       renderPot();
       render();
-      nextTurn();
+      delay(aiTurn, 500);
       return;
     } else if (act === 'fold') {
       p.bust = true;

--- a/webapp/public/lib/blackjack.js
+++ b/webapp/public/lib/blackjack.js
@@ -69,3 +69,10 @@ export function evaluateWinners(players){
 export function aiAction(hand){
   return handValue(hand)<17? 'hit':'stand';
 }
+
+export function aiBetAction(hand){
+  const val=handValue(hand);
+  if(val>=18) return 'raise';
+  if(val<=11) return 'fold';
+  return 'call';
+}


### PR DESCRIPTION
## Summary
- keep player on turn after raising so hit/stand remain available
- add aiBetAction to shared blackjack library for AI raise/fold/call decisions

## Testing
- `npm test` *(fails: The "options.agent" property must be one of Agent-like Object, undefined, or false)*

------
https://chatgpt.com/codex/tasks/task_e_68a98fa9dbbc83298fd96f123096c13c