### PR TITLE
Adjust pull label position and show power gradient

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -118,7 +118,7 @@
   font-size: 12px;
   color: #fff;
   line-height: 1;
-  transform: translate(-2.4px, 2.4px);
+  transform: translate(-1px, 0px);
 }
 
 .ps .ps-cue-img {

--- a/power-slider.js
+++ b/power-slider.js
@@ -156,7 +156,11 @@ export class PowerSlider {
     const r = Math.round(low.r + (high.r - low.r) * ratio);
     const g = Math.round(low.g + (high.g - low.g) * ratio);
     const b = Math.round(low.b + (high.b - low.b) * ratio);
-    this.handle.style.background = `rgb(${r},${g},${b})`;
+    const color = `rgb(${r},${g},${b})`;
+    const lowColor = `rgb(${low.r},${low.g},${low.b})`;
+    const pct = ratio * 100;
+    this.handle.style.background = color;
+    this.track.style.background = `linear-gradient(to bottom, ${lowColor} 0%, ${color} ${pct}%, var(--ps-track-bg) ${pct}%, var(--ps-track-bg) 100%)`;
   }
 
   _updateFromClientY(y) {


### PR DESCRIPTION
## Summary
- Nudge pull label slightly right and up
- Color cue slider track based on power percentage with yellow-to-red gradient

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68a994c3bfd483299593dd2c1d476f96