### PR TITLE
feat(blackjack): enforce betting responses

### DIFF
--- a/examples/blackjack/README.md
+++ b/examples/blackjack/README.md
@@ -7,7 +7,9 @@ following stages:
 
 1. **Initial bet** – each player posts the stake into the pot.
 2. **Deal** – every player gets two private cards from a shuffled deck.
-3. **Betting round** – players may call, raise or fold.
+3. **Betting round** – players may call, raise or fold. When a player raises, all
+   remaining players must either call the new bet, re-raise or fold before the
+   round can end.
 4. **Hit / Stand** – active players choose to draw additional private cards or
    keep their current hand. Once a player stands or busts they cannot act
    again in this phase.
@@ -20,8 +22,9 @@ following stages:
 
 The core game logic lives in `gameLogic.js`. It manages the deck, betting
 state, community cards and winner calculation. It exposes helper methods for
-classic betting actions (`call`, `raise` and `fold`) as well as `finishRound()`
-for settling the pot and starting the next game.
+classic betting actions (`call`, `raise` and `fold`) as well as `allPlayersCalled()`
+to check whether everyone has matched the current bet, and `finishRound()` for
+settling the pot and starting the next game.
 
 This example focuses on the game mechanics and is intentionally minimal. It can
 be paired with a Socket.IO server and React client similar to the other

--- a/examples/blackjack/gameLogic.js
+++ b/examples/blackjack/gameLogic.js
@@ -45,7 +45,7 @@ export class BlackjackGame {
   addPlayer(id, name = 'Player') {
     if (this.phase !== 'waiting' || this.players.length >= this.maxPlayers) return null;
     if (this.players.find(p => p.id === id)) return null;
-    const player = { id, name, hand: [], folded: false, stood: false, bet: this.stake, chips: 0 };
+    const player = { id, name, hand: [], folded: false, stood: false, bet: this.stake, chips: 0, acted: false };
     this.players.push(player);
     this.pot += this.stake;
     return player;
@@ -58,6 +58,7 @@ export class BlackjackGame {
       p.hand = [this.draw(), this.draw()];
       p.folded = false;
       p.stood = false;
+      p.acted = false;
     }
     this.currentBet = this.stake;
     this.phase = 'betting';
@@ -79,6 +80,7 @@ export class BlackjackGame {
     if (diff <= 0) return false;
     player.bet += diff;
     this.pot += diff;
+    player.acted = true;
     return true;
   }
 
@@ -90,7 +92,11 @@ export class BlackjackGame {
     this.pot += amount;
     if (player.bet > this.currentBet) {
       this.currentBet = player.bet;
+      for (const p of this.players) {
+        if (p.id !== id && !p.folded) p.acted = false;
+      }
     }
+    player.acted = true;
     return true;
   }
 
@@ -99,6 +105,7 @@ export class BlackjackGame {
     const player = this.players.find(p => p.id === id && !p.folded);
     if (!player) return false;
     player.folded = true;
+    player.acted = true;
     return true;
   }
 
@@ -189,6 +196,7 @@ export class BlackjackGame {
       p.folded = false;
       p.stood = false;
       p.bet = this.stake;
+      p.acted = false;
     }
     this.currentBet = this.stake;
     this.pot = this.stake * this.players.length;
@@ -207,6 +215,10 @@ export class BlackjackGame {
       community: this.community,
       phase: this.phase
     };
+  }
+
+  allPlayersCalled() {
+    return this.players.every(p => p.folded || (p.bet === this.currentBet && p.acted));
   }
 }
 

--- a/test/blackjackGame.test.js
+++ b/test/blackjackGame.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { BlackjackGame } from '../examples/blackjack/gameLogic.js';
+
+test('raise forces other players to act', () => {
+  const game = new BlackjackGame('room');
+  game.addPlayer('a');
+  game.addPlayer('b');
+  game.start();
+
+  game.raise('a', 50);
+  const bob = game.players.find(p => p.id === 'b');
+  assert.equal(bob.acted, false);
+
+  game.call('b');
+  assert.equal(game.allPlayersCalled(), true);
+});
+
+test('player may re-raise after calling', () => {
+  const game = new BlackjackGame('room');
+  game.addPlayer('a');
+  game.addPlayer('b');
+  game.start();
+
+  game.raise('b', 50);
+  game.call('a');
+  game.raise('a', 50);
+
+  assert.equal(game.currentBet, 200);
+  const bob = game.players.find(p => p.id === 'b');
+  assert.equal(bob.acted, false);
+});
+


### PR DESCRIPTION
## Summary
- track player betting responses and reset them whenever a raise occurs
- document raise behavior and expose helper to check when all calls are made
- test blackjack betting flow including re-raises

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a99c862c0c8329ade7b4d8a7aacb7c