### PR TITLE
Refine power slider visuals

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -7,7 +7,7 @@
   --ps-gradient-low: #ffe066;
   --ps-gradient-mid: #ff8c00;
   --ps-gradient-high: #ff0033;
-  --ps-tick: rgba(0, 0, 0, 0.35);
+  --ps-tick: #000;
   --ps-glow: rgba(255, 0, 0, 0.6);
   --ps-tooltip-bg: rgba(0, 0, 0, 0.8);
   --ps-tooltip-color: #fff;
@@ -16,7 +16,7 @@
   width: var(--ps-width);
   height: var(--ps-height);
   border-radius: var(--ps-radius);
-  background: var(--ps-track-bg);
+  background: none;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
   overflow: visible;
   user-select: none;
@@ -27,8 +27,22 @@
 
 .ps .ps-track {
   position: absolute;
-  inset: 0;
-  border-radius: inherit;
+  top: 4px;
+  bottom: 4px;
+  right: 0;
+  width: 25%;
+  border: 1px solid #000;
+  border-radius: 4px;
+  background: transparent;
+  overflow: hidden;
+}
+
+.ps .ps-track-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 0;
   background: linear-gradient(
     to bottom,
     var(--ps-gradient-low) 0%,
@@ -37,60 +51,23 @@
   );
 }
 
-/* left gloss */
-.ps .ps-track::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 8px;
-  background: linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 0.5),
-    rgba(255, 255, 255, 0)
-  );
-  pointer-events: none;
-}
+.ps .ps-track::before { content: none; }
 
 /* ticks */
 .ps .ps-track::after {
   content: '';
   position: absolute;
   top: 0;
-  bottom: 0;
+  left: 0;
   right: 0;
-  width: 8px;
-  background:
-    repeating-linear-gradient(
+  bottom: 0;
+  background: repeating-linear-gradient(
       to bottom,
-      transparent 0 calc(10% - 1px),
-      var(--ps-tick) calc(10% - 1px) 10%
-    ),
-    linear-gradient(
-      to bottom,
-      transparent calc(25% - 1.5px),
-      var(--ps-tick) calc(25% - 1.5px) calc(25% + 1.5px),
-      transparent calc(25% + 1.5px)
-    ),
-    linear-gradient(
-      to bottom,
-      transparent calc(50% - 1.5px),
-      var(--ps-tick) calc(50% - 1.5px) calc(50% + 1.5px),
-      transparent calc(50% + 1.5px)
-    ),
-    linear-gradient(
-      to bottom,
-      transparent calc(75% - 1.5px),
-      var(--ps-tick) calc(75% - 1.5px) calc(75% + 1.5px),
-      transparent calc(75% + 1.5px)
-    ),
-    linear-gradient(
-      to bottom,
-      transparent calc(100% - 3px),
-      var(--ps-tick) calc(100% - 3px) 100%
-    ),
-    linear-gradient(to bottom, var(--ps-tick) 0 3px, transparent 3px);
+      var(--ps-tick) 0,
+      var(--ps-tick) 1px,
+      transparent 1px,
+      transparent 10%
+    );
   pointer-events: none;
 }
 
@@ -119,6 +96,8 @@
   color: #fff;
   line-height: 1;
   transform: translate(-1px, 0px);
+  position: relative;
+  z-index: 2;
 }
 
 .ps .ps-cue-img {
@@ -126,6 +105,8 @@
   width: 100%;
   height: auto;
   transform: translateX(9.6px);
+  position: relative;
+  z-index: 1;
 }
 
 .ps .ps-tooltip {

--- a/power-slider.js
+++ b/power-slider.js
@@ -32,6 +32,9 @@ export class PowerSlider {
 
     this.track = document.createElement('div');
     this.track.className = 'ps-track';
+    this.trackFill = document.createElement('div');
+    this.trackFill.className = 'ps-track-fill';
+    this.track.appendChild(this.trackFill);
     this.el.appendChild(this.track);
 
     this.handle = document.createElement('div');
@@ -143,6 +146,8 @@ export class PowerSlider {
     this.handle.style.transform = `translate(0, ${y}px)`;
     const ttH = this.tooltip.offsetHeight;
     this.tooltip.style.transform = `translate(0, ${y - ttH - 8}px)`;
+    this.trackFill.style.height = `${ratio * 100}%`;
+    this.track.style.opacity = ratio > 0 ? 1 : 0;
     this._updateHandleColor(ratio);
     this.tooltip.textContent = `${Math.round(this.value)}%`;
     this.el.setAttribute('aria-valuenow', String(Math.round(this.value)));
@@ -157,10 +162,7 @@ export class PowerSlider {
     const g = Math.round(low.g + (high.g - low.g) * ratio);
     const b = Math.round(low.b + (high.b - low.b) * ratio);
     const color = `rgb(${r},${g},${b})`;
-    const lowColor = `rgb(${low.r},${low.g},${low.b})`;
-    const pct = ratio * 100;
     this.handle.style.background = color;
-    this.track.style.background = `linear-gradient(to bottom, ${lowColor} 0%, ${color} ${pct}%, var(--ps-track-bg) ${pct}%, var(--ps-track-bg) 100%)`;
   }
 
   _updateFromClientY(y) {


### PR DESCRIPTION
## Summary
- Ensure power slider background only reveals on pull with 10% tick marks
- Keep "Pull" label above cue image
- Add thin black frame and right-side track that grows with slider value

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon … and more)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a0b5d6208329a166836c7d402c44