### PR TITLE
Handle raise availability and chip placement in blackjack

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -884,7 +884,7 @@
         <div class="pot" id="pot"></div>
         <div class="pot-total" id="potTotal"></div>
       </div>
-      <div class="raise-container" id="raiseContainer">
+      <div class="raise-container" id="raiseContainer" style="display: none">
         <div class="chip-grid">
           <div class="chip v1000" data-value="1000"></div>
           <div class="chip v500" data-value="500"></div>
@@ -898,7 +898,7 @@
         </div>
         <div class="raise-amount" id="chipAmount">0</div>
       </div>
-      <div class="slider-container">
+      <div class="slider-container" style="display: none">
         <input type="range" id="raiseSlider" min="0" value="0" />
         <div class="raise-amount" id="raiseSliderAmount">0</div>
         <div class="raise-buttons">


### PR DESCRIPTION
## Summary
- track when the player may raise and only show raise controls when eligible
- deduct chips on call and raise, updating pot and awaiting call state for other players
- hide raise controls by default in the blackjack HTML

## Testing
- `npm test` *(fails: test timed out after 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a1e5a840832981ad4a73a7381d4f