### PR TITLE
feat: add game layout with background component

### DIFF
--- a/webapp/src/components/GameLayoutWithBackground.jsx
+++ b/webapp/src/components/GameLayoutWithBackground.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function GameLayoutWithBackground({ imageUrl, aspectRatio = 16 / 9, children }) {
+  return (
+    <div className="relative w-full overflow-hidden" style={{ aspectRatio }}>
+      {imageUrl && (
+        <div
+          className="absolute inset-0 bg-cover bg-center pointer-events-none"
+          style={{ backgroundImage: `url(${imageUrl})` }}
+        />
+      )}
+      <div className="absolute inset-0">{children}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `GameLayoutWithBackground` to keep game areas at a fixed aspect ratio and scale background images uniformly

## Testing
- `npm test` (fails: test timed out)
- `cd webapp && npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a9bf5a77cc8329a933d62775cf6e1c