### PR TITLE
fix: show commentary on mobile browsers

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"
+      content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no,viewport-fit=cover"
     />
     <title>Deluxe Billiards • 2.5D Cartoon (Portrait)</title>
     <style>
@@ -69,6 +69,8 @@
       #footer {
         border-top: 1px solid #24375f;
         justify-content: center;
+        height: calc(56px + env(safe-area-inset-bottom));
+        padding-bottom: env(safe-area-inset-bottom);
       }
 
       .player {
@@ -196,7 +198,7 @@
         position: absolute;
         top: 56px;
         right: 0;
-        bottom: 56px;
+        bottom: calc(56px + env(safe-area-inset-bottom));
         width: var(--rpw);
 
         display: flex;

--- a/webapp/src/pages/Games/PollRoyale.jsx
+++ b/webapp/src/pages/Games/PollRoyale.jsx
@@ -15,7 +15,7 @@ export default function PollRoyale() {
         ? 'American Billiards'
         : '8 Pool UK';
   return (
-    <div className="relative w-full h-screen">
+    <div className="relative w-full h-[100dvh]">
       <iframe src={src} title={title} className="w-full h-full border-0" />
     </div>
   );


### PR DESCRIPTION
## Summary
- use dynamic viewport units to size Poll Royale iframe
- account for mobile safe area so commentary footer remains visible

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint` *(fails: 758 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c33378fc83299e144eed8217575a