### PR TITLE
Make Goal Rush field full-screen in browsers

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -21,14 +21,14 @@
     html,body{height:100vh;height:100dvh;overscroll-behavior:none;}
     body{margin:0;background:var(--bg);color:#e5e7eb;font-family:'Luckiest Guy','Comic Sans MS',cursive;overflow:hidden}
     .ui{position:fixed;inset:0;}
-    .scoreboard{position:absolute;top:0;left:0;right:0;height:40px;display:flex;align-items:center;justify-content:center;pointer-events:none;}
+    .scoreboard{position:absolute;top:0;left:0;right:0;height:40px;display:flex;align-items:center;justify-content:center;pointer-events:none;z-index:4;}
     .score{font-variant-numeric:tabular-nums;background:#0b1220;border:1px solid #233050;border-radius:12px;padding:6px 10px;display:flex;align-items:center;gap:8px;-webkit-text-stroke:0.3px #000;text-shadow:0 0 4px #000;color:#fff}
     .score span{-webkit-text-stroke:0.3px #000;text-shadow:0 0 4px #000;color:#fff}
     .badge{padding:2px 8px;border-radius:999px;font-weight:800;color:#fff;-webkit-text-stroke:0.3px #000;text-shadow:0 0 4px #000}
     .p1{background:var(--p1)}
     .p2{background:var(--p2)}
 
-    .canvasWrap{position:absolute;top:40px;bottom:20px;left:0;right:0;}
+    .canvasWrap{position:absolute;top:0;bottom:0;left:0;right:0;}
     canvas{position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none}
 
 
@@ -86,8 +86,8 @@
   const muteBtn = document.getElementById('muteBtn');
   const goalText = document.getElementById('goalText');
   const postText = document.getElementById('postText');
-  const TOP_BAR = 40; // height of scoreboard bar
-  const BOTTOM_GAP = 20; // gap below rink
+  const TOP_BAR = 0; // scoreboard overlays the field
+  const BOTTOM_GAP = 0; // no gap below rink
   const GOAL_PAUSE = 1500; // pause after a goal
   let fieldScaleActual = 1;
 


### PR DESCRIPTION
## Summary
- Remove fixed offsets so Goal Rush canvas fills the entire browser viewport
- Overlay scoreboard and remove unused top/bottom height calculations

## Testing
- `npm test`
- `npm run lint` *(fails: many existing style errors in lib files)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cd15e6948329b6384b0c3b002c4d