### PR TITLE
feat: support google account login on profile

### DIFF
--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -21,7 +21,7 @@ const router = Router();
 
 // Create or fetch account for a user
 router.post('/create', async (req, res) => {
-  const { telegramId } = req.body;
+  const { telegramId, googleId } = req.body;
 
   let user;
   if (telegramId) {
@@ -32,6 +32,32 @@ router.post('/create', async (req, res) => {
         telegramId,
         accountId: uuidv4(),
         referralCode: String(telegramId),
+        walletAddress: wallet.address,
+        walletPublicKey: wallet.publicKey
+      });
+      await user.save();
+    } else {
+      let updated = false;
+      if (!user.accountId) {
+        user.accountId = uuidv4();
+        updated = true;
+      }
+      if (!user.walletAddress) {
+        const wallet = await generateWalletAddress();
+        user.walletAddress = wallet.address;
+        user.walletPublicKey = wallet.publicKey;
+        updated = true;
+      }
+      if (updated) await user.save();
+    }
+  } else if (googleId) {
+    user = await User.findOne({ googleId });
+    if (!user) {
+      const wallet = await generateWalletAddress();
+      user = new User({
+        googleId,
+        accountId: uuidv4(),
+        referralCode: googleId,
         walletAddress: wallet.address,
         walletPublicKey: wallet.publicKey
       });

--- a/webapp/src/components/NftGiftCard.jsx
+++ b/webapp/src/components/NftGiftCard.jsx
@@ -21,7 +21,10 @@ export default function NftGiftCard({ accountId: propAccountId }) {
       let id = propAccountId || localStorage.getItem('accountId');
       if (!id) {
         try {
-          const acc = await createAccount(getTelegramId());
+          const acc = await createAccount(
+            getTelegramId(),
+            localStorage.getItem('googleId')
+          );
           if (acc?.accountId) {
             id = acc.accountId;
             localStorage.setItem('accountId', id);

--- a/webapp/src/hooks/useTokenBalances.js
+++ b/webapp/src/hooks/useTokenBalances.js
@@ -10,6 +10,7 @@ export default function useTokenBalances() {
   } catch (err) {
     telegramId = undefined;
   }
+  const googleId = telegramId ? null : localStorage.getItem('googleId');
 
   const [tpcBalance, setTpcBalance] = useState(null);
   const [tonBalance, setTonBalance] = useState(null);
@@ -19,9 +20,9 @@ export default function useTokenBalances() {
 
   useEffect(() => {
     async function loadTpc() {
-      if (!telegramId) return;
+      if (!telegramId && !googleId) return;
       try {
-        const acc = await createAccount(telegramId);
+        const acc = await createAccount(telegramId, googleId);
         if (acc?.error) throw new Error(acc.error);
         if (acc.walletAddress) {
           localStorage.setItem('walletAddress', acc.walletAddress);

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -55,6 +55,7 @@ export default function Wallet({ hideClaim = false }) {
   } catch (err) {
     telegramId = undefined;
   }
+  const googleId = telegramId ? null : localStorage.getItem('googleId');
 
   const [accountId, setAccountId] = useState('');
   const [tpcBalance, setTpcBalance] = useState(null);
@@ -96,7 +97,7 @@ export default function Wallet({ hideClaim = false }) {
     if (id) {
       acc = { accountId: id };
     } else {
-      acc = await createAccount(telegramId);
+      acc = await createAccount(telegramId, googleId);
       if (acc?.error) {
         console.error('Failed to load account:', acc.error);
         return null;

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -482,9 +482,10 @@ export function registerWalletPasskey(telegramId, passkeyId, publicKey) {
 
 // ----- Account based wallet -----
 
-export function createAccount(telegramId) {
+export function createAccount(telegramId, googleId) {
   const body = {};
   if (telegramId) body.telegramId = telegramId;
+  if (googleId) body.googleId = googleId;
   return post('/api/account/create', body);
 }
 


### PR DESCRIPTION
## Summary
- allow accounts to be created via Google ID
- load profile data using Google when Telegram is unavailable
- pass Google ID through hooks and components that create accounts

## Testing
- `npm test` *(fails: test timed out after 20000ms for snake API endpoints and socket events)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cd97ab908329a4dddac1fd4512e7