### PR TITLE
Enable non-Telegram access without Google sign-in

### DIFF
--- a/webapp/src/components/LoginOptions.jsx
+++ b/webapp/src/components/LoginOptions.jsx
@@ -1,54 +1,30 @@
 import React, { useEffect } from 'react';
-import { RiTelegramFill } from 'react-icons/ri';
-import { BOT_USERNAME } from '../utils/constants.js';
-
-const TG_LINK = `https://t.me/${BOT_USERNAME}`;
+import { createAccount } from '../utils/api.js';
+import { ensureAccountId } from '../utils/telegram.js';
 
 export default function LoginOptions() {
   useEffect(() => {
-    function handleCredential(res) {
+    (async () => {
+      const accountId = await ensureAccountId();
       try {
-        const data = JSON.parse(atob(res.credential.split('.')[1]));
-        if (data.sub) localStorage.setItem('googleId', data.sub);
-      } catch {}
-    }
-
-    function renderButton() {
-      if (window.google && import.meta.env.VITE_GOOGLE_CLIENT_ID) {
-        window.google.accounts.id.initialize({
-          client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
-          callback: handleCredential
-        });
-        window.google.accounts.id.renderButton(
-          document.getElementById('g_id_button'),
-          { theme: 'outline', size: 'large' }
-        );
-        return true;
+        const res = await createAccount(undefined, localStorage.getItem('googleId'));
+        if (res?.accountId) {
+          localStorage.setItem('accountId', res.accountId);
+        } else if (accountId) {
+          localStorage.setItem('accountId', accountId);
+        }
+        if (res?.walletAddress) {
+          localStorage.setItem('walletAddress', res.walletAddress);
+        }
+      } catch (err) {
+        console.error('Account setup failed', err);
       }
-      return false;
-    }
-
-    if (!renderButton()) {
-      const id = setInterval(() => {
-        if (renderButton()) clearInterval(id);
-      }, 500);
-      return () => clearInterval(id);
-    }
+    })();
   }, []);
 
   return (
     <div className="p-4 text-text">
-      <p>Sign in with Google or open the WebApp in Telegram.</p>
-      <div className="mt-2 flex items-center space-x-2">
-        <div id="g_id_button"></div>
-        <a
-          href={TG_LINK}
-          className="inline-flex items-center space-x-1 px-3 py-1 bg-primary hover:bg-primary-hover text-background rounded"
-        >
-          <RiTelegramFill className="w-4 h-4" />
-          <span>Open in Telegram</span>
-        </a>
-      </div>
+      <p>Loading...</p>
     </div>
   );
 }

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -16,10 +16,16 @@ export function getTelegramId() {
     const urlId = params.get('tg') || params.get('telegramId');
     if (urlId) {
       localStorage.setItem('telegramId', urlId);
-      return Number(urlId);
+      const n = Number(urlId);
+      return Number.isNaN(n) ? urlId : n;
     }
     const stored = localStorage.getItem('telegramId');
-    if (stored) return Number(stored);
+    if (stored) {
+      const n = Number(stored);
+      return Number.isNaN(n) ? stored : n;
+    }
+    const acc = localStorage.getItem('accountId');
+    if (acc) return acc;
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- Allow `getTelegramId` to fall back to a stored account ID so the app works without Telegram or Google
- Auto-create and register a wallet for unauthenticated visitors in `useTelegramAuth`
- Replace login prompt with simple loader that initializes an account and wallet

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9de9bd1b88329b0232d76352fa08c