### PR TITLE
Fix Goal Rush height to match Telegram display

### DIFF
--- a/webapp/src/pages/Games/GoalRush.jsx
+++ b/webapp/src/pages/Games/GoalRush.jsx
@@ -4,7 +4,7 @@ export default function GoalRush() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <div className="relative w-full h-screen">
+    <div className="relative w-full h-[100dvh]">
       <iframe
         src={`/goal-rush.html${search}`}
         title="Goal Rush"


### PR DESCRIPTION
## Summary
- use dynamic viewport height in GoalRush page to match mobile browsers

## Testing
- `npm test` *(fails: test timed out after 20000ms)*
- `npm run lint` *(fails: 758 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9edb4990083298ef18c478716debc