### PR TITLE
Improve pool AI targeting and display variant rules

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -56,6 +56,15 @@ function lineIntersectsBall(a, b, ball, radius) {
   return dist(closest, ball) < radius * 2;
 }
 
+function pathBlocked(a, b, balls, ignoreIds, radius) {
+  return balls.some(
+    ball =>
+      !ball.pocketed &&
+      !ignoreIds.includes(ball.id) &&
+      lineIntersectsBall(a, b, ball, radius)
+  );
+}
+
 function chooseTargets(req) {
   const balls = req.state.balls.filter(b => !b.pocketed && b.id !== 0);
   if (req.game === 'NINE_BALL') {
@@ -63,9 +72,20 @@ function chooseTargets(req) {
     return [lowest];
   }
   if (req.game === 'AMERICAN_BILLIARDS' || req.game === 'EIGHT_POOL_UK') {
-    if (req.state.myGroup === 'SOLIDS') return balls.filter(b => b.id >=1 && b.id <=7);
-    if (req.state.myGroup === 'STRIPES') return balls.filter(b => b.id >=9 && b.id <=15);
-    return balls;
+    const solids = balls.filter(b => b.id >= 1 && b.id <= 7);
+    const stripes = balls.filter(b => b.id >= 9 && b.id <= 15);
+    const eight = balls.find(b => b.id === 8);
+    if (req.state.myGroup === 'SOLIDS') {
+      if (solids.length > 0) return solids;
+      if (eight) return [eight];
+      return [];
+    }
+    if (req.state.myGroup === 'STRIPES') {
+      if (stripes.length > 0) return stripes;
+      if (eight) return [eight];
+      return [];
+    }
+    return balls.filter(b => b.id !== 8);
   }
   return balls;
 }
@@ -78,9 +98,20 @@ function nextTargetsAfter(targetId, req) {
     return [lowest];
   }
   if (req.game === 'AMERICAN_BILLIARDS' || req.game === 'EIGHT_POOL_UK') {
-    if (req.state.myGroup === 'SOLIDS') return cloned.filter(b => b.id >=1 && b.id <=7);
-    if (req.state.myGroup === 'STRIPES') return cloned.filter(b => b.id >=9 && b.id <=15);
-    return cloned;
+    const solids = cloned.filter(b => b.id >= 1 && b.id <= 7);
+    const stripes = cloned.filter(b => b.id >= 9 && b.id <= 15);
+    const eight = cloned.find(b => b.id === 8);
+    if (req.state.myGroup === 'SOLIDS') {
+      if (solids.length > 0) return solids;
+      if (eight) return [eight];
+      return [];
+    }
+    if (req.state.myGroup === 'STRIPES') {
+      if (stripes.length > 0) return stripes;
+      if (eight) return [eight];
+      return [];
+    }
+    return cloned.filter(b => b.id !== 8);
   }
   return cloned;
 }
@@ -104,14 +135,20 @@ function evaluate(req, cue, target, pocket, power, spin) {
     x: target.x - (pocket.x - target.x) * (r * 2 / dist(target, pocket)),
     y: target.y - (pocket.y - target.y) * (r * 2 / dist(target, pocket))
   };
-  if (blocked(cue, ghost, req.state.balls, target.id, r)) return null;
-  const potChance = 1;
+  if (
+    blocked(cue, ghost, req.state.balls, target.id, r) ||
+    pathBlocked(target, pocket, req.state.balls, [0, target.id], r)
+  ) {
+    return null;
+  }
+  const maxD = Math.hypot(req.state.width, req.state.height);
+  const distShot = dist(cue, target) + dist(target, pocket);
+  const potChance = 1 - Math.min(distShot / maxD, 1);
   const cueAfter = estimateCueAfterShot(cue, target, pocket, power);
   const nextTargets = nextTargetsAfter(target.id, req);
   let nextScore = 0;
   if (nextTargets.length > 0) {
     const next = nextTargets[0];
-    const maxD = Math.hypot(req.state.width, req.state.height);
     nextScore = 1 - Math.min(dist(cueAfter, next) / maxD, 1);
   }
   const risk = req.state.pockets.some(p => dist(cueAfter, p) < r * 1.2) ? 1 : 0;
@@ -124,7 +161,7 @@ function evaluate(req, cue, target, pocket, power, spin) {
     targetBallId: target.id,
     targetPocket: pocket,
     quality,
-    rationale: `angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)}`
+    rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)}`
   };
 }
 

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -29,3 +29,28 @@ test('planShot returns a shot decision', () => {
   assert(decision.quality >= 0 && decision.quality <= 1);
   assert(decision.rationale.length > 0);
 });
+
+test('targets 8 ball after clearing group', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 100, y: 100, vx: 0, vy: 0, pocketed: false },
+        { id: 8, x: 300, y: 100, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      myGroup: 'SOLIDS'
+    },
+    timeBudgetMs: 50,
+    rngSeed: 1
+  };
+  const decision = planShot(req);
+  assert.equal(decision.targetBallId, 8);
+});

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -551,32 +551,9 @@
     <div id="rulesModal" class="hidden" role="dialog" aria-modal="true">
       <div class="rules-content">
         <button id="closeRules" aria-label="Close">✖</button>
-        <h2>8 Ball UK Rules</h2>
-        <ul>
-          <li>
-            Rack with the black in the middle. A legal break pots a ball or
-            drives two balls to cushions.
-          </li>
-          <li>
-            Groups (red or yellow) are claimed by the first player to pot a ball
-            after the break.
-          </li>
-          <li>
-            On each shot hit one of your balls first and either pot a ball or
-            make any ball reach a cushion.
-          </li>
-          <li>
-            Fouls—such as potting the cue ball, striking the opponent's ball
-            first or no cushion contact—give the opponent two visits.
-          </li>
-          <li>
-            Clear your group then pot the black cleanly to win. Potting the
-            black early or on a foul loses the frame.
-          </li>
-        </ul>
-        <p class="rule-source">
-          Rules based on World Eightball Pool Federation guidelines.
-        </p>
+        <h2 id="rulesTitle"></h2>
+        <ul id="rulesList"></ul>
+        <p class="rule-source" id="rulesSource"></p>
       </div>
     </div>
 
@@ -2618,8 +2595,51 @@
       const rulesBtn = document.getElementById('rulesBtn');
       const rulesModal = document.getElementById('rulesModal');
       const closeRules = document.getElementById('closeRules');
+      const rulesTitle = document.getElementById('rulesTitle');
+      const rulesList = document.getElementById('rulesList');
+      const rulesSource = document.getElementById('rulesSource');
+
+      const ruleSets = {
+        uk: {
+          title: '8 Ball UK Rules',
+          items: [
+            'Rack with the black in the middle. A legal break pots a ball or drives two balls to cushions.',
+            'Groups (red or yellow) are claimed by the first player to pot a ball after the break.',
+            'On each shot hit one of your balls first and either pot a ball or make any ball reach a cushion.',
+            "Fouls—such as potting the cue ball, striking the opponent's ball first or no cushion contact—give the opponent two visits.",
+            'Clear your group then pot the black cleanly to win. Potting the black early or on a foul loses the frame.'
+          ],
+          source: 'Rules based on World Eightball Pool Federation guidelines.'
+        },
+        american: {
+          title: 'American 8-Ball Rules',
+          items: [
+            'Rack with the 8-ball in the center. A legal break pockets a ball or drives four balls to cushions.',
+            'Table is open after the break; groups are assigned when a player legally pots a ball.',
+            'Shoot your group first and either pocket a ball or drive any ball to a cushion.',
+            'Scratching or failing to hit your group first is a foul and gives ball-in-hand to the opponent.',
+            'After clearing your group, pot the 8-ball without fouling to win.'
+          ],
+          source: 'Simplified World Pool-Billiard Association 8-ball rules.'
+        },
+        '9ball': {
+          title: 'Nine Ball Rules',
+          items: [
+            'Balls are racked in a diamond with the 1 at the top and the 9 in the center.',
+            'Always strike the lowest numbered ball on the table first.',
+            'Combinations are allowed provided the lowest ball is struck first.',
+            'Legally pocketing the 9-ball at any time wins the rack.',
+            'Scratching gives the opponent ball-in-hand.'
+          ],
+          source: 'Based on World Pool-Billiard Association Nine-ball rules.'
+        }
+      };
 
       rulesBtn.addEventListener('click', () => {
+        const r = ruleSets[variant] || ruleSets.uk;
+        rulesTitle.textContent = r.title;
+        rulesList.innerHTML = r.items.map(i => `<li>${i}</li>`).join('');
+        rulesSource.textContent = r.source;
         rulesModal.classList.remove('hidden');
       });
 


### PR DESCRIPTION
## Summary
- Teach pool AI to respect ball groups, target the eight ball after clearing a set, and avoid blocked pocket paths
- Add variant-specific rule text for UK 8-ball, American 8-ball, and Nine Ball to the Pool Royale web page
- Expand unit tests for AI to cover eight-ball targeting

## Testing
- `npm test` *(fails: test timed out after 20000ms in snake API endpoints and socket events)*
- `npm test -- test/poolAi.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a9ff0753888329af8316f0e2a23a2a