### PR TITLE
Calibrate Pool Royale aiming line

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1853,8 +1853,8 @@
           if (lastShotAim && lastPocketCenter) {
             var dx = lastPocketCenter.x - lastShotAim.x;
             var dy = lastPocketCenter.y - lastShotAim.y;
-            aimCalibration.x += dx * 0.1;
-            aimCalibration.y += dy * 0.1;
+            aimCalibration.x += dx;
+            aimCalibration.y += dy;
             shotsLog.push({
               aim: lastShotAim,
               pocket: lastPocketCenter,


### PR DESCRIPTION
## Summary
- refine aim calibration in Pool Royale by applying the full offset between target aim and pocket center

## Testing
- `npm test`
- `npm run lint` *(fails: 849 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68aa06503010832984b20c0551f6f8a0