### PR TITLE
Add blackjack balance API and winner payouts

### DIFF
--- a/webapp/public/blackjack-api.js
+++ b/webapp/public/blackjack-api.js
@@ -1,0 +1,68 @@
+(function () {
+  const API_BASE_URL = window.API_BASE_URL || '';
+
+  async function post(path, body) {
+    const headers = { 'Content-Type': 'application/json' };
+    const initData = window?.Telegram?.WebApp?.initData;
+    if (initData) headers['X-Telegram-Init-Data'] = initData;
+    let res;
+    try {
+      res = await fetch(API_BASE_URL + path, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body)
+      });
+    } catch (err) {
+      return { error: 'Network request failed' };
+    }
+    let text;
+    try {
+      text = await res.text();
+    } catch {
+      return { error: 'Invalid server response' };
+    }
+    let data;
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      return { error: 'Invalid server response' };
+    }
+    if (!res.ok) {
+      return { error: data.error || res.statusText || 'Request failed' };
+    }
+    return data;
+  }
+
+  window.blackjackApi = {
+    async depositAccount(accountId, amount, extra = {}) {
+      const res = await post('/api/account/deposit', {
+        accountId,
+        amount,
+        ...extra
+      });
+      if (res && res.error) {
+        return post('/api/profile/addTransaction', {
+          amount,
+          type: 'deposit',
+          accountId,
+          ...extra
+        });
+      }
+      return res;
+    },
+    getAccountBalance(accountId) {
+      return post('/api/account/balance', { accountId });
+    },
+    addTransaction(telegramId, amount, type, extra = {}) {
+      const body = { amount, type, ...extra };
+      if (telegramId != null) body.telegramId = telegramId;
+      return post('/api/profile/addTransaction', body);
+    },
+    getUserInfo(params) {
+      return post('/api/profile/get', params);
+    }
+  };
+
+  // For backwards compatibility with existing games expecting fbApi
+  window.fbApi = window.blackjackApi;
+})();

--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -986,6 +986,7 @@
       </div>
     </div>
     <script src="/flag-emojis.js"></script>
+    <script src="/blackjack-api.js"></script>
     <script type="module" src="blackjack.js"></script>
   </body>
 </html>

--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -29,6 +29,7 @@ const state = {
 
 let myAccountId = '';
 let myTelegramId;
+const api = window.blackjackApi || window.fbApi;
 
 const CHIP_VALUES = [1000, 500, 200, 50, 20, 10, 5, 2, 1];
 let sndCallRaise;
@@ -61,9 +62,9 @@ function randomBalance() {
 }
 
 async function loadAccountBalance() {
-  if (!myAccountId || !window.fbApi?.getAccountBalance) return;
+  if (!myAccountId || !api?.getAccountBalance) return;
   try {
-    const res = await window.fbApi.getAccountBalance(myAccountId);
+    const res = await api.getAccountBalance(myAccountId);
     if (res && typeof res.balance === 'number') {
       state.accountBalance = res.balance;
       state.players.forEach((p) => {
@@ -257,9 +258,9 @@ function playFlipSound() {
 }
 
 async function awardDevShare(total) {
-  if (!state.devAccountId || !window.fbApi) return;
+  if (!state.devAccountId || !api) return;
   try {
-    await window.fbApi.depositAccount(state.devAccountId, Math.round(total * 0.1), {
+    await api.depositAccount(state.devAccountId, Math.round(total * 0.1), {
       game: 'blackjack-dev'
     });
   } catch {}
@@ -646,13 +647,13 @@ async function finish() {
     const player = state.players[i];
     player.balance = (player.balance || 0) + share;
     player.winner = true;
-    if (player.isHuman && myAccountId && window.fbApi) {
+    if (player.isHuman && myAccountId && api) {
       try {
-        await window.fbApi.depositAccount(myAccountId, share, {
+        await api.depositAccount(myAccountId, share, {
           game: 'blackjack-win'
         });
         if (myTelegramId) {
-          window.fbApi.addTransaction(myTelegramId, 0, 'win', {
+          api.addTransaction(myTelegramId, 0, 'win', {
             game: 'blackjack',
             accountId: myAccountId
           });
@@ -832,8 +833,8 @@ async function init() {
   let username = params.get('username') || 'You';
 
   try {
-    if (myAccountId && window.fbApi?.getUserInfo) {
-      const u = await window.fbApi.getUserInfo({ accountId: myAccountId, tgId: myTelegramId });
+    if (myAccountId && api?.getUserInfo) {
+      const u = await api.getUserInfo({ accountId: myAccountId, tgId: myTelegramId });
       if (u) {
         username = u.username || u.first_name || username;
         avatar = u.photo_url || avatar;


### PR DESCRIPTION
## Summary
- add frontend API wrapper to retrieve TPC balance and record blackjack payouts
- display balance under player frame via new API and deposit pot winnings

## Testing
- `npm test` (fails: test timed out after 20000ms)
- `npm run lint` (fails: 849 errors, see log)


------
https://chatgpt.com/codex/tasks/task_e_68aa0749d1a0832993d62a7e9306a0fd