### PR TITLE
Fix blackjack stand handling

### DIFF
--- a/test/blackjackGame.test.js
+++ b/test/blackjackGame.test.js
@@ -31,3 +31,20 @@ test('player may re-raise after calling', () => {
   assert.equal(bob.acted, false);
 });
 
+test('standing keeps hand static when others hit', () => {
+  const game = new BlackjackGame('room');
+  game.addPlayer('a');
+  game.addPlayer('b');
+  game.start();
+  game.startHitPhase();
+  const alice = game.players.find(p => p.id === 'a');
+  alice.hand = [
+    { rank: 'J', suit: 'hearts' },
+    { rank: 'J', suit: 'spades' }
+  ];
+  game.stand('a');
+  const before = game.getBestValue(alice.hand);
+  game.hit('b');
+  assert.equal(game.getBestValue(alice.hand), before);
+});
+

--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -361,7 +361,7 @@ function render() {
     const cards = document.createElement('div');
     cards.className = 'cards';
     cards.id = 'cards-' + i;
-    p.hand.slice(0, 2).forEach((c) => {
+    p.hand.forEach((c) => {
       cards.appendChild(p.revealed || p.isHuman ? cardEl(c) : cardBackEl());
     });
     if (p.winner) {
@@ -534,8 +534,7 @@ function aiTurn() {
   if (act === 'hit') {
     const { card, deck } = hitCard(state.deck);
     state.deck = deck;
-    state.community.push(card);
-    state.players.forEach((pl) => pl.hand.push(card));
+    p.hand.push(card);
     playFlipSound();
     if (isBust(p.hand)) {
       p.bust = true;
@@ -554,8 +553,7 @@ window.hit = () => {
   if (!p || !p.isHuman || p.stood || p.bust) return;
   const { card, deck } = hitCard(state.deck);
   state.deck = deck;
-  state.community.push(card);
-  state.players.forEach((pl) => pl.hand.push(card));
+  p.hand.push(card);
   playFlipSound();
   if (isBust(p.hand) || handValue(p.hand) === 21) {
     p.bust = isBust(p.hand);


### PR DESCRIPTION
## Summary
- ensure hit action only affects acting player in blackjack
- render full player hands instead of using community cards
- add test to confirm standing player hands stay unchanged when others hit

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*
- `npm run lint` *(fails: 849 problems (849 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68aa16d9628c83299f17014e596c35f9