### PR TITLE
feat(blackjack): scale UI after multiple hits and handle long names

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -20,6 +20,8 @@
         --card-back-color: #233;
         --card-front-color: #fff;
         --player-frame-color: #000;
+        --ui-scale: 1;
+        --bottom-card-scale: 1.083;
       }
       * {
         box-sizing: border-box;
@@ -214,6 +216,10 @@
         font-weight: 700;
         z-index: 3;
       }
+      .hand-total.bust {
+        background: #dc2626;
+        color: #000;
+      }
       .card {
         width: var(--card-w);
         height: var(--card-h);
@@ -345,6 +351,9 @@
         margin-top: 2px;
         text-shadow: 0 0 2px #000;
       }
+      .stand-copy-wrapper .stand-name.small {
+        font-size: 8px;
+      }
       .seat-inner .cards.turn {
         box-shadow: 0 0 12px #facc15;
         border-color: #facc15;
@@ -391,7 +400,7 @@
         bottom: 0.5%;
         left: 50%;
         transform: translateX(-50%);
-        --card-scale: 1.083;
+        --card-scale: var(--bottom-card-scale);
         --avatar-scale: 1;
         --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale));
         --card-h: calc(var(--card-w) * 1.45);
@@ -464,6 +473,12 @@
       }
       .seat.bottom .name {
         font-size: 12px;
+      }
+      .seat-inner .name.small {
+        font-size: 9px;
+      }
+      .seat.bottom .name.small {
+        font-size: 10px;
       }
       .seat-inner .cards {
         padding: 0;
@@ -567,6 +582,8 @@
         border: none;
         border-radius: 0;
         background: none;
+        transform: scale(var(--ui-scale));
+        transform-origin: bottom left;
       }
       .slider-container {
         position: absolute;
@@ -581,6 +598,8 @@
         border: none;
         border-radius: 0;
         background: none;
+        transform: scale(var(--ui-scale));
+        transform-origin: bottom right;
       }
       .raise-btn {
         width: var(--avatar-size);

--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -90,6 +90,23 @@ function updateBalanceDisplay() {
   }
 }
 
+function adjustNameSize(el) {
+  let name = el.textContent || '';
+  if (name.length > 12) {
+    const parts = name.split(/\s+/).filter(Boolean);
+    if (parts.length > 1) {
+      name = parts.map((p) => p[0].toUpperCase()).join('');
+    }
+  }
+  if (name.length > 10) {
+    el.classList.add('small');
+    name = name.slice(0, 10);
+  } else {
+    el.classList.remove('small');
+  }
+  el.textContent = name;
+}
+
 const DEFAULT_SETTINGS = {
   muteCards: false,
   muteChips: false,
@@ -356,6 +373,7 @@ function render() {
     const name = document.createElement('div');
     name.className = 'name';
     name.textContent = p.name;
+    adjustNameSize(name);
     inner.appendChild(name);
 
     const cards = document.createElement('div');
@@ -367,10 +385,11 @@ function render() {
     if (p.winner) {
       Array.from(cards.children).forEach((card) => card.classList.add('winning'));
     }
-    if (p.isHuman || p.winner) {
+    if (p.isHuman || p.winner || p.revealed) {
       const total = document.createElement('div');
       total.className = 'hand-total';
       total.textContent = handValue(p.hand).toString();
+      if (p.bust) total.classList.add('bust');
       cards.appendChild(total);
     }
     inner.appendChild(cards);
@@ -438,13 +457,33 @@ function render() {
       const nm = document.createElement('div');
       nm.className = 'stand-name';
       nm.textContent = p.name;
+      adjustNameSize(nm);
       wrap.appendChild(nm);
       seat.appendChild(wrap);
     }
     seats.appendChild(seat);
   });
+  adjustPlayerScaling();
   updateBalanceDisplay();
   renderCommunity();
+}
+
+function adjustPlayerScaling() {
+  const player = state.players[0];
+  if (!player) return;
+  const count = player.hand.length;
+  const baseCard = 1.083;
+  const baseUi = 1;
+  if (count <= 3) {
+    document.documentElement.style.setProperty('--bottom-card-scale', baseCard);
+    document.documentElement.style.setProperty('--ui-scale', '1');
+    return;
+  }
+  const extra = count - 3;
+  const cardScale = Math.max(0.6, baseCard - 0.1 * extra);
+  const uiScale = Math.max(0.6, baseUi - 0.1 * extra);
+  document.documentElement.style.setProperty('--bottom-card-scale', cardScale.toString());
+  document.documentElement.style.setProperty('--ui-scale', uiScale.toString());
 }
 
 function aiRespondToRaise() {


### PR DESCRIPTION
## Summary
- highlight busted hands with red totals
- shrink bottom player's cards and controls as more cards are drawn
- abbreviate or resize player names over 10 characters

## Testing
- `npm test` *(fails: snake API endpoints and socket events - test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68aa94ed4240832998d4f8e8dcabd97f