### PR TITLE
Improve pool AI target selection

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -193,7 +193,26 @@ export function planShot(req) {
       }
     }
   }
-  return best || {
+  if (best) return best;
+
+  // Fallback: aim at nearest legal target ball instead of shooting straight ahead
+  const reachable = targets.filter(t =>
+    !pathBlocked(cue, t, req.state.balls, [0, t.id], req.state.ballRadius)
+  );
+  const fallback = (reachable.length > 0 ? reachable : targets)[0];
+  if (fallback) {
+    const angle = Math.atan2(fallback.y - cue.y, fallback.x - cue.x);
+    return {
+      angleRad: angle,
+      power: 0.8,
+      spin: { top: 0, side: 0, back: 0 },
+      targetBallId: fallback.id,
+      quality: 0,
+      rationale: `safety to contact ball ${fallback.id}`
+    };
+  }
+
+  return {
     angleRad: 0,
     power: 0,
     spin: { top: 0, side: 0, back: 0 },

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -54,3 +54,26 @@ test('targets 8 ball after clearing group', () => {
   const decision = planShot(req);
   assert.equal(decision.targetBallId, 8);
 });
+
+test('aims at nearest ball when no pockets available', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 100, y: 100, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 200, y: 200, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      myGroup: 'SOLIDS'
+    },
+    timeBudgetMs: 50,
+    rngSeed: 2
+  };
+  const decision = planShot(req);
+  assert.equal(decision.targetBallId, 1);
+  assert(decision.angleRad > 0.7 && decision.angleRad < 0.9); // roughly 45 degrees
+});


### PR DESCRIPTION
## Summary
- keep AI from blindly shooting straight ahead when no pot exists
- verify fallback logic with new unit test

## Testing
- `npm test` *(fails: free ball allows any first contact and pots own color, potting 8-ball before clearing group loses the frame, two visits behaviour, potting 8-ball legally after clearing group wins)*
- `npm run lint` *(fails: 1104 problems (1104 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68aa99b62ee4832991125452b3a285fe