### PR TITLE
fix: aim at ghost ball

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -318,7 +318,22 @@ function chooseBestAction(state, colour) {
   if (!best) return null;
   const c = best.c;
   const cueBall = state.balls.find(b => b.colour === 'cue');
-  const aim = c.targetBall ? { x: c.targetBall.x, y: c.targetBall.y } : { x: cueBall.x, y: cueBall.y };
+  let aim;
+  if (c.targetBall && c.pocket) {
+    const toPocket = {
+      x: c.pocket.x - c.targetBall.x,
+      y: c.pocket.y - c.targetBall.y
+    };
+    const lenTP = Math.hypot(toPocket.x, toPocket.y) || 1;
+    aim = {
+      x: c.targetBall.x - (toPocket.x / lenTP) * state.ballRadius * 2,
+      y: c.targetBall.y - (toPocket.y / lenTP) * state.ballRadius * 2
+    };
+  } else if (c.targetBall) {
+    aim = { x: c.targetBall.x, y: c.targetBall.y };
+  } else {
+    aim = { x: cueBall.x, y: cueBall.y };
+  }
   const posTarget = c.actionType === 'safety'
     ? { x: cueBall.x, y: cueBall.y }
     : simulateCueRollout(state, c);
@@ -327,6 +342,7 @@ function chooseBestAction(state, colour) {
     targetBall: c.targetBall ? c.targetBall.colour : null,
     pocket: c.pocket ? c.pocket.name : null,
     aimPoint: aim,
+    aim, // backwards compatibility for older code expecting `aim`
     cueParams: c.cueParams,
     positionTarget: { x: posTarget.x, y: posTarget.y, radius: 40 },
     EV: best.EV,


### PR DESCRIPTION
## Summary
- adjust advanced pool AI to aim at ghost ball contact when selecting shots
- expose `aim` alias on plan for compatibility

## Testing
- `npm test` (fails: poolUk8Ball.test.js, snakeApi.test.js)
- `npm run lint` (fails: 1109 problems)

------
https://chatgpt.com/codex/tasks/task_e_68aaa197e0248329b50724d93ea44e05