### PR TITLE
Align raise button and slider in blackjack UI

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -566,36 +566,6 @@
         transform: scale(var(--ui-scale));
         transform-origin: bottom left;
       }
-      .slider-container {
-        position: absolute;
-        bottom: 4%;
-        right: 1%;
-        z-index: 5;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 8px;
-        padding: 0;
-        border: none;
-        border-radius: 0;
-        background: none;
-        transform: scale(var(--ui-scale));
-        transform-origin: bottom right;
-      }
-      .raise-btn {
-        width: var(--avatar-size);
-        height: var(--avatar-size);
-        padding: 0;
-        border: 4px solid #000;
-        border-radius: 50%;
-        background: #2563eb;
-        color: #fff;
-        font-weight: 600;
-        font-size: 12px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
       .raise-amount {
         font-size: 10px;
         margin-top: 2px;
@@ -920,19 +890,6 @@
           <div class="chip v1" data-value="1"></div>
         </div>
         <div class="raise-amount" id="chipAmount">0</div>
-      </div>
-      <div class="slider-container">
-        <div class="slider-wrap">
-          <input
-            type="range"
-            id="raiseSlider"
-            min="0"
-            value="0"
-            orient="vertical"
-          />
-          <div class="raise-amount" id="raiseSliderAmount">0</div>
-        </div>
-        <button class="raise-btn" id="raiseBtn">Raise</button>
       </div>
       <div class="folded-area" id="foldedArea">
         <div id="foldedLabel" class="folded-label" style="display: none">

--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -346,7 +346,6 @@ function dealCardToPlayer(idx, card, showFace) {
 }
 
 function render() {
-  updateRaiseAmount();
   const seats = document.getElementById('seats');
   seats.innerHTML = '';
   const positions = [
@@ -436,7 +435,27 @@ function render() {
         callBtn.id = 'call';
         callBtn.textContent = 'Call';
         callBtn.addEventListener('click', playerCall);
-        controls.append(foldBtn, callBtn);
+        const raiseBtn = document.createElement('button');
+        raiseBtn.id = 'raise';
+        raiseBtn.textContent = 'Raise';
+        raiseBtn.addEventListener('click', commitRaise);
+        const sliderWrap = document.createElement('div');
+        sliderWrap.className = 'slider-wrap';
+        const slider = document.createElement('input');
+        slider.type = 'range';
+        slider.id = 'raiseSlider';
+        slider.min = '0';
+        slider.value = '0';
+        slider.setAttribute('orient', 'vertical');
+        slider.addEventListener('input', () => {
+          state.raiseAmount = parseInt(slider.value, 10);
+          updateRaiseAmount();
+        });
+        const sliderAmt = document.createElement('div');
+        sliderAmt.className = 'raise-amount';
+        sliderAmt.id = 'raiseSliderAmount';
+        sliderWrap.append(slider, sliderAmt);
+        controls.append(foldBtn, callBtn, raiseBtn, sliderWrap);
         seat.append(inner, bal, controls);
       } else {
         seat.append(inner, bal);
@@ -468,6 +487,7 @@ function render() {
   adjustPlayerScaling();
   updateBalanceDisplay();
   renderCommunity();
+  updateRaiseAmount();
 }
 
 function adjustPlayerScaling() {
@@ -952,18 +972,6 @@ async function init() {
       playCallRaise();
     });
   });
-
-  const slider = document.getElementById('raiseSlider');
-  if (slider) {
-    slider.max = Math.max(0, state.stake - state.currentBet).toString();
-    slider.addEventListener('input', () => {
-      state.raiseAmount = parseInt(slider.value, 10);
-      updateRaiseAmount();
-    });
-  }
-
-  const raiseBtn = document.getElementById('raiseBtn');
-  if (raiseBtn) raiseBtn.addEventListener('click', commitRaise);
   const statusEl = document.getElementById('status');
   sndCallRaise = document.getElementById('sndCallRaise');
   sndFlip = document.getElementById('sndFlip');


### PR DESCRIPTION
## Summary
- Add a blue Raise button next to Call/Fold in the blackjack controls
- Attach raise amount slider to the right of the Raise button and align bottom edges

## Testing
- `npm test` (fails: test timed out)
- `npm run lint` (fails: 1109 errors)

------
https://chatgpt.com/codex/tasks/task_e_68aab038f5608329be73f8668cb99326