### PR TITLE
Tweak Blackjack bottom player control layout

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -397,7 +397,7 @@
       }
 
       .seat.bottom {
-        bottom: 0.5%;
+        bottom: 0;
         left: 50%;
         transform: translateX(-50%);
         --card-scale: var(--bottom-card-scale);
@@ -513,8 +513,8 @@
       }
       .controls {
         display: flex;
-        gap: 8px;
-        margin-top: 8px;
+        gap: 4px;
+        margin-top: 4px;
         align-items: flex-end;
         justify-content: center;
         z-index: 5;
@@ -611,6 +611,7 @@
         flex-direction: column;
         align-items: center;
         gap: 4px;
+        margin-left: -4px;
       }
       .slider-wrap input[type='range'] {
         width: var(--avatar-size);


### PR DESCRIPTION
## Summary
- Anchor bottom player seat at viewport edge
- Bring action buttons closer together and align under player frame
- Shift raise slider slightly left toward the raise button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aab8c2831883298c3e9ddddfd958c2