### PR TITLE
Make Pool Royale pull label follow cue

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -318,9 +318,9 @@
 
       #pullLabel {
         position: absolute;
-        right: 0;
+        top: 0;
         left: auto;
-        bottom: calc(100% + 8px);
+        right: -2px;
         transform: none;
         font-size: 12px;
         color: #fff;
@@ -2259,6 +2259,7 @@
           var maxY = rect.height - powerCue.offsetHeight * 0.4;
           var y = minY + (maxY - minY) * power;
           powerCue.style.top = y + 'px';
+          pullHandle.style.top = y + 'px';
           powerBg.style.width = powerCue.offsetWidth + 'px';
           powerBg.style.height = powerCue.offsetHeight + 'px';
           powerBg.style.top = minY + 'px';


### PR DESCRIPTION
## Summary
- Adjust pull label positioning to be controlled from top and offset slightly right
- Sync pull label vertical movement with cue so it follows pull actions

## Testing
- `npm test` *(fails: Failed to launch Telegram bot: The "options.agent" property must be one of Agent-like Object, undefined, or false)*
- `npm run lint` *(fails: 1109 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68aaba191ab08329b9c0467740180543