### PR TITLE
feat: add power slider force bar

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -94,6 +94,22 @@
   pointer-events: none;
 }
 
+.ps .ps-power-bar {
+  position: absolute;
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0 calc(10% - 1px),
+      var(--ps-tick) calc(10% - 1px) 10%
+    ),
+    linear-gradient(
+      to bottom,
+      var(--ps-gradient-low) 0%,
+      var(--ps-gradient-high) 100%
+    );
+  pointer-events: none;
+}
+
 .ps .ps-handle {
   position: absolute;
   top: 0;
@@ -112,6 +128,7 @@
   );
   padding: 7.2px 2.4px;
   pointer-events: auto;
+  z-index: 1;
 }
 
 .ps .ps-handle-text {

--- a/power-slider.js
+++ b/power-slider.js
@@ -34,6 +34,10 @@ export class PowerSlider {
     this.track.className = 'ps-track';
     this.el.appendChild(this.track);
 
+    this.powerBar = document.createElement('div');
+    this.powerBar.className = 'ps-power-bar';
+    this.el.appendChild(this.powerBar);
+
     this.handle = document.createElement('div');
     this.handle.className = 'ps-handle';
     this.handleText = document.createElement('span');
@@ -75,14 +79,22 @@ export class PowerSlider {
     this._onPointerUp = this._pointerUp.bind(this);
     this._onWheel = this._wheel.bind(this);
     this._onKeyDown = this._keyDown.bind(this);
-    this._onResize = () => this._update(false);
+    this._onResize = () => {
+      this._setupPowerBar();
+      this._update(false);
+    };
 
     this.el.addEventListener('pointerdown', this._onPointerDown);
     this.el.addEventListener('wheel', this._onWheel, { passive: false });
     this.el.addEventListener('keydown', this._onKeyDown);
     window.addEventListener('resize', this._onResize);
 
-    this.cueImg.addEventListener('load', () => this._update(false));
+    this.cueImg.addEventListener('load', () => {
+      this._setupPowerBar();
+      this._update(false);
+    });
+
+    this._setupPowerBar();
 
     this.set(value);
   }
@@ -161,6 +173,33 @@ export class PowerSlider {
     const pct = ratio * 100;
     this.handle.style.background = color;
     this.track.style.background = `linear-gradient(to bottom, ${lowColor} 0%, ${color} ${pct}%, var(--ps-track-bg) ${pct}%, var(--ps-track-bg) 100%)`;
+  }
+
+  _setupPowerBar() {
+    if (!this.powerBar) return;
+    const uWidth = this._measureCharWidth('u');
+    this.powerBar.style.width = `${uWidth}px`;
+    const left = this.el.clientWidth + this.handle.offsetWidth / 2 - uWidth / 2;
+    const handleRect = this.handle.getBoundingClientRect();
+    const textRect = this.handleText.getBoundingClientRect();
+    const imgRect = this.cueImg.getBoundingClientRect();
+    const topOffset = textRect.bottom - handleRect.top;
+    const height = imgRect.bottom - textRect.bottom;
+    this.powerBar.style.left = `${left}px`;
+    this.powerBar.style.top = `${topOffset}px`;
+    this.powerBar.style.height = `${height}px`;
+  }
+
+  _measureCharWidth(ch) {
+    const span = document.createElement('span');
+    span.textContent = ch;
+    span.className = this.handleText.className;
+    span.style.visibility = 'hidden';
+    span.style.position = 'absolute';
+    this.el.appendChild(span);
+    const width = span.getBoundingClientRect().width;
+    span.remove();
+    return width;
   }
 
   _updateFromClientY(y) {


### PR DESCRIPTION
## Summary
- add thin gradient power bar with 10% markers behind cue image
- position bar using letter "u" width and Pull label offset
- ensure handle renders above bar

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint` *(fails: 1140 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aabfa60100832983cdd423987481c2