### PR TITLE
Rename Blackjack game and adjust raise controls

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no"
     />
-    <title>Black Jack</title>
+    <title>Black Jack Multiplayer</title>
     <style>
       :root {
         --shadow: rgba(0, 0, 0, 0.45);
@@ -568,7 +568,7 @@
       }
       .slider-container {
         position: absolute;
-        bottom: 4%;
+        bottom: 3%;
         right: 1%;
         z-index: 5;
         display: flex;
@@ -585,6 +585,7 @@
       .raise-btn {
         width: var(--avatar-size);
         height: var(--avatar-size);
+        margin-top: 4px;
         padding: 0;
         border: 4px solid #000;
         border-radius: 50%;
@@ -636,17 +637,16 @@
         cursor: pointer;
       }
       .slider-wrap {
-        width: calc(var(--avatar-size) * 2.5);
+        width: calc(var(--avatar-size) * 2.2);
         display: flex;
         flex-direction: column;
         align-items: center;
         gap: 4px;
       }
       .slider-wrap input[type='range'] {
-        width: var(--avatar-size);
-        height: calc(var(--avatar-size) * 2.5);
-        writing-mode: bt-lr;
-        -webkit-appearance: slider-vertical;
+        width: calc(var(--avatar-size) * 2);
+        height: var(--avatar-size);
+        -webkit-appearance: none;
       }
       #allIn {
         background: #dc2626;
@@ -928,7 +928,6 @@
             id="raiseSlider"
             min="0"
             value="0"
-            orient="vertical"
           />
           <div class="raise-amount" id="raiseSliderAmount">0</div>
         </div>

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -36,7 +36,7 @@ export default function HomeGamesCard() {
             className="h-20 w-20"
           />
           <h3 className="text-sm font-semibold text-center text-yellow-400">
-            Black Jack
+            Black Jack Multiplayer
           </h3>
         </Link>
         <Link

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -40,7 +40,7 @@ export default function Games() {
                 className="text-sm font-semibold text-center text-yellow-400"
                 style={{ WebkitTextStroke: '1px black' }}
               >
-                Black Jack
+                Black Jack Multiplayer
               </h3>
             </Link>
             <Link

--- a/webapp/src/pages/Games/BlackJack.jsx
+++ b/webapp/src/pages/Games/BlackJack.jsx
@@ -8,7 +8,7 @@ export default function BlackJack() {
     <div className="relative w-full h-screen">
       <iframe
         src={`/blackjack.html${search}`}
-        title="Black Jack"
+        title="Black Jack Multiplayer"
         className="w-full h-full border-0"
       />
     </div>

--- a/webapp/src/pages/Games/BlackJackLobby.jsx
+++ b/webapp/src/pages/Games/BlackJackLobby.jsx
@@ -63,7 +63,7 @@ export default function BlackJackLobby() {
 
   return (
     <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
-      <h2 className="text-xl font-bold text-center">Black Jack Lobby</h2>
+      <h2 className="text-xl font-bold text-center">Black Jack Multiplayer Lobby</h2>
       <div className="space-y-2">
         <h3 className="font-semibold">Stake</h3>
         <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />


### PR DESCRIPTION
## Summary
- Rename Blackjack game to "Black Jack Multiplayer" throughout the webapp.
- Tweak the raise control layout: move raise button slightly lower and make the slider horizontal and smaller.

## Testing
- `npm test` *(fails: 7 failed tests)*
- `npm run lint` *(fails: 1109 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aabdb420ec8329bf04564ccf9e7955