### PR TITLE
Fix AI raise limit in blackjack

### DIFF
--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -507,17 +507,20 @@ function aiRespondToRaise() {
   playCallRaise();
   renderPot();
   if (act === 'raise') {
-    const raiseAmt = Math.min(state.currentBet, p.balance || state.currentBet);
-    state.pot += raiseAmt;
-    p.balance -= raiseAmt;
-    p.bet += raiseAmt;
-    state.currentBet = p.bet;
-    state.raiseInitiator = state.turn;
-    animateChipsFromPlayer(state.turn, raiseAmt);
-    playCallRaise();
-    renderPot();
-    nextTurn();
-    return;
+    const maxRaise = Math.max(0, state.stake - state.currentBet);
+    const raiseAmt = Math.min(state.currentBet, p.balance || state.currentBet, maxRaise);
+    if (raiseAmt > 0) {
+      state.pot += raiseAmt;
+      p.balance -= raiseAmt;
+      p.bet += raiseAmt;
+      state.currentBet = p.bet;
+      state.raiseInitiator = state.turn;
+      animateChipsFromPlayer(state.turn, raiseAmt);
+      playCallRaise();
+      renderPot();
+      nextTurn();
+      return;
+    }
   }
   render();
   nextTurn();


### PR DESCRIPTION
## Summary
- clamp AI raises to remaining stake to prevent infinite raising
- skip raise when max stake is reached and treat as call

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon; config issues)*

------
https://chatgpt.com/codex/tasks/task_e_68aad0b0f4fc8329a9a29aa23f7d9a05