### PR TITLE
Fix Blackjack folding freeze

### DIFF
--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -557,6 +557,12 @@ function nextTurn() {
   }
 
   state.turn++;
+  while (
+    state.turn < state.players.length &&
+    (state.players[state.turn].bust || state.players[state.turn].stood)
+  ) {
+    state.turn++;
+  }
   if (state.turn >= state.players.length) {
     finish();
     return;


### PR DESCRIPTION
## Summary
- Skip folded or stood players when advancing turns in Blackjack

## Testing
- `npm test` (fails: free ball allows any first contact and pots own color, potting 8-ball before clearing group loses the frame, two visits behaviour, potting 8-ball legally after clearing group wins)
- `npm run lint` (fails: 1145 errors)

------
https://chatgpt.com/codex/tasks/task_e_68aad70f44148329ad8da5e23caecc62