### PR TITLE
Remove extra white frame from Poll Royale power slider

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -281,7 +281,6 @@
         border-radius: 9px;
         position: absolute;
         overflow: hidden;
-        border: 2px solid #fff;
         box-shadow: none;
         left: calc(100% - 16px);
         top: 0;


### PR DESCRIPTION
## Summary
- Remove unintended white border around power slider container in Poll Royale to leave only the thin strip under the pull label

## Testing
- `npm test` *(fails: The expression evaluated to a falsy value: assert.ok(events.includes('diceRolled')))*
- `npm run lint` *(fails: 1145 errors, including extra semicolons and prefer-const)*

------
https://chatgpt.com/codex/tasks/task_e_68aad7c69e1883299392fa640ba5ef4b