### PR TITLE
Show call amounts in Blackjack and remove stand mini-cards

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -335,25 +335,6 @@
         z-index: 1000;
         pointer-events: none;
       }
-      .stand-copy-wrapper {
-        position: absolute;
-        top: calc(-1 * var(--card-h) - 10px);
-        left: 50%;
-        transform: translateX(-50%) scale(0.5);
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        pointer-events: none;
-      }
-      .stand-copy-wrapper .stand-name {
-        font-size: 10px;
-        color: #fff;
-        margin-top: 2px;
-        text-shadow: 0 0 2px #000;
-      }
-      .stand-copy-wrapper .stand-name.small {
-        font-size: 8px;
-      }
       .seat-inner .cards.turn {
         box-shadow: 0 0 12px #facc15;
         border-color: #facc15;

--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -434,7 +434,8 @@ function render() {
         foldBtn.addEventListener('click', playerFold);
         const callBtn = document.createElement('button');
         callBtn.id = 'call';
-        callBtn.textContent = 'Call';
+        const callAmt = Math.max(0, state.currentBet - (p.bet || 0));
+        callBtn.innerHTML = `Call ${formatAmount(callAmt)}`;
         callBtn.addEventListener('click', playerCall);
         controls.append(foldBtn, callBtn);
         seat.append(inner, bal, controls);
@@ -453,15 +454,6 @@ function render() {
       action.className = 'action-label';
       action.textContent = 'STAND';
       seat.appendChild(action);
-      const wrap = document.createElement('div');
-      wrap.className = 'stand-copy-wrapper';
-      wrap.appendChild(cardBackEl());
-      const nm = document.createElement('div');
-      nm.className = 'stand-name';
-      nm.textContent = p.name;
-      adjustNameSize(nm);
-      wrap.appendChild(nm);
-      seat.appendChild(wrap);
     }
     seats.appendChild(seat);
   });


### PR DESCRIPTION
## Summary
- Show the call amount on the call button so players know how much to match
- Remove mini card indicator above player frames when standing

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68aae1eed3948329a7caf1c5b3455be2