### PR TITLE
Improve Pool Royale aiming and power slider

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -275,10 +275,10 @@
       }
 
       #powerBox {
-        width: 6px;
+        width: 12px;
         height: 100%;
         background: none;
-        border-radius: 3px;
+        border-radius: 6px;
         position: absolute;
         overflow: hidden;
         border: none;
@@ -327,7 +327,7 @@
         left: calc(100% - 16px);
         top: 0;
         transform: translate(-50%, 0);
-        width: 6px;
+        width: 12px;
         height: 100%;
         background:
           repeating-linear-gradient(
@@ -341,7 +341,7 @@
             #f97316 50%,
             #dc2626 100%
           );
-        border-radius: 3px;
+        border-radius: 6px;
         pointer-events: none;
         opacity: 0.25;
         z-index: 5;
@@ -372,13 +372,14 @@
       }
 
       #powerTxt {
-        margin-top: 0;
+        position: absolute;
+        right: -2px;
+        top: -30px;
         font-size: 15px;
         opacity: 0.85;
-        display: flex;
-        flex-direction: column;
-        align-items: flex-end;
-        text-align: right;
+        width: 44px;
+        text-align: center;
+        pointer-events: none;
       }
 
       #play {
@@ -553,21 +554,8 @@
               alt="Cue"
             />
             <div id="cueRail"></div>
+            <div id="powerTxt"><div id="powerPercent">0%</div></div>
             <div id="pullLabel">Pull<br />⬇</div>
-          </div>
-
-          <div
-            style="
-              display: flex;
-              flex-direction: column;
-              align-items: flex-end;
-              gap: 6px;
-            "
-          >
-            <div id="powerTxt">
-              <div>Power</div>
-              <div id="powerPercent">0%</div>
-            </div>
           </div>
         </aside>
 
@@ -1982,7 +1970,17 @@
             cueHint.style.display = 'none';
             return;
           }
-          // Allow aiming anywhere by clicking on the table
+          // If a ball is tapped, aim at its center
+          for (var i = 1; i < table.balls.length; i++) {
+            var b = table.balls[i];
+            if (b.pocketed) continue;
+            if (Math.hypot(t.x - b.p.x, t.y - b.p.y) <= BALL_R) {
+              t.x = b.p.x;
+              t.y = b.p.y;
+              break;
+            }
+          }
+          // Allow aiming anywhere by clicking on the table or balls
           aiming = true;
           aimMoved = false;
           showGuides = true;
@@ -2293,12 +2291,13 @@
           var y = minY + (maxY - minY) * power;
           powerCue.style.top = y + 'px';
           pullHandle.style.top = y + 'px';
-          var barWidth = 6;
+          var barWidth = 12;
+          var barHeight = maxY - minY;
           powerBg.style.width = barWidth + 'px';
-          powerBg.style.height = powerCue.offsetHeight + 'px';
+          powerBg.style.height = barHeight + 'px';
           powerBg.style.top = minY + 'px';
           powerBox.style.width = barWidth + 'px';
-          powerBox.style.height = powerCue.offsetHeight + 'px';
+          powerBox.style.height = barHeight + 'px';
           powerBox.style.top = minY + 'px';
         }
         function updatePowerUI() {


### PR DESCRIPTION
## Summary
- Aim line now snaps to a ball when tapped, letting players quickly target shots.
- Power slider widened and scaled so 10% markers align with pull strength.
- Power percentage display moved above the pull handle for easier visibility.

## Testing
- `npm test` *(fails: snake API endpoints and socket events)*

------
https://chatgpt.com/codex/tasks/task_e_68aae61be5a48329a505944636b29d21