### PR TITLE
Improve power slider and aim line for pool example

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -14,6 +14,7 @@
     .stage{position:relative;max-width:min(92vw, 760px);box-shadow:0 20px 60px rgba(0,0,0,.35);border-radius:12px;overflow:hidden}
     .bg{display:block;width:100%;height:auto}
     svg.overlay{position:absolute;inset:0;width:100%;height:100%;pointer-events:none}
+    .aim-line{position:absolute;top:50%;left:50%;width:2px;height:0;background:#fff;transform-origin:top center;transform:translate(-50%,-100%) rotate(0);pointer-events:none}
   </style>
 </head>
 <body>
@@ -100,6 +101,22 @@
         });
       </script>
     </svg>
+    <div id="aim-line" class="aim-line"></div>
   </div>
+  <script>
+    const stage = document.querySelector('.stage');
+    const aimLine = document.getElementById('aim-line');
+    stage.addEventListener('click', (e) => {
+      const rect = stage.getBoundingClientRect();
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      const dx = e.clientX - cx;
+      const dy = e.clientY - cy;
+      const angle = Math.atan2(dy, dx) * 180 / Math.PI + 90;
+      const length = Math.hypot(dx, dy);
+      aimLine.style.height = `${length}px`;
+      aimLine.style.transform = `translate(-50%,-100%) rotate(${angle}deg)`;
+    });
+  </script>
 </body>
 </html>

--- a/power-slider.css
+++ b/power-slider.css
@@ -107,7 +107,8 @@
   top: 0;
   left: 0;
   width: 100%;
-  height: 0%;
+  height: 100%;
+  clip-path: inset(0 0 100% 0);
   background:
     repeating-linear-gradient(
       to bottom,
@@ -144,7 +145,7 @@
 }
 
 .ps .ps-handle-text {
-  font-size: 12px;
+  font-size: 14px;
   color: #fff;
   line-height: 1;
   transform: translate(-1px, 0px);

--- a/power-slider.js
+++ b/power-slider.js
@@ -158,7 +158,8 @@ export class PowerSlider {
     this.handle.style.transform = `translate(0, ${y}px)`;
     const ttH = this.tooltip.offsetHeight;
     this.tooltip.style.transform = `translate(0, ${y - ttH - 8}px)`;
-    this.powerFill.style.height = `${ratio * 100}%`;
+    const pct = ratio * 100;
+    this.powerFill.style.clipPath = `inset(0 0 ${100 - pct}% 0)`;
     this._updateHandleColor(ratio);
     this.tooltip.textContent = `${Math.round(this.value)}%`;
     this.el.setAttribute('aria-valuenow', String(Math.round(this.value)));


### PR DESCRIPTION
## Summary
- enlarge pull label and adjust power bar fill to reveal from top
- add interactive aiming line pointing toward click location

## Testing
- `npm test` (fails: test timed out after 20000ms)
- `npm run lint` (fails: 1146 errors)

------
https://chatgpt.com/codex/tasks/task_e_68aaec70439883299035b75d41f34e78