### PR TITLE
fix: reveal Pool Royale power bar from top

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -293,7 +293,7 @@
       #powerFill {
         position: absolute;
         left: 0;
-        bottom: 0;
+        top: 0;
         width: 100%;
         height: 0%;
         background:


### PR DESCRIPTION
## Summary
- make Pool Royale power bar reveal from the top rather than from the bottom

## Testing
- `npm test` *(fails: test timed out)*
- `npm run lint` *(fails: 1146 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf608ed508329a0a349be4cd978fc