### PR TITLE
fix: prioritize pool table touches over slider

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -211,8 +211,8 @@
         gap: 8px;
         padding: 12px 0 0 8px;
         z-index: 10;
-        /* Capture touches so shots aren't triggered from the panel */
-        pointer-events: auto;
+        /* Let table receive touches except on interactive elements */
+        pointer-events: none;
       }
 
       #spinBox {


### PR DESCRIPTION
## Summary
- allow pool table to receive touch input over right panel, while keeping pull label interactive

## Testing
- `npm test` (fails: snake API endpoints and socket events)
- `npm run lint` (fails: lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68ab05d9f38c8329ac04c51c81c71410