### PR TITLE
feat: update American billiards rules and AI

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -67,11 +67,11 @@ function pathBlocked(a, b, balls, ignoreIds, radius) {
 
 function chooseTargets(req) {
   const balls = req.state.balls.filter(b => !b.pocketed && b.id !== 0);
-  if (req.game === 'NINE_BALL') {
-    const lowest = balls.reduce((m, b) => b.id < m.id ? b : m, balls[0]);
-    return [lowest];
+  if (req.game === 'NINE_BALL' || req.game === 'AMERICAN_BILLIARDS') {
+    const lowest = balls.reduce((m, b) => (b.id < m.id ? b : m), balls[0]);
+    return lowest ? [lowest] : [];
   }
-  if (req.game === 'AMERICAN_BILLIARDS' || req.game === 'EIGHT_POOL_UK') {
+  if (req.game === 'EIGHT_POOL_UK') {
     const solids = balls.filter(b => b.id >= 1 && b.id <= 7);
     const stripes = balls.filter(b => b.id >= 9 && b.id <= 15);
     const eight = balls.find(b => b.id === 8);
@@ -92,12 +92,12 @@ function chooseTargets(req) {
 
 function nextTargetsAfter(targetId, req) {
   const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== 0);
-  if (req.game === 'NINE_BALL') {
+  if (req.game === 'NINE_BALL' || req.game === 'AMERICAN_BILLIARDS') {
     if (cloned.length === 0) return [];
-    const lowest = cloned.reduce((m, b) => b.id < m.id ? b : m, cloned[0]);
-    return [lowest];
+    const lowest = cloned.reduce((m, b) => (b.id < m.id ? b : m), cloned[0]);
+    return lowest ? [lowest] : [];
   }
-  if (req.game === 'AMERICAN_BILLIARDS' || req.game === 'EIGHT_POOL_UK') {
+  if (req.game === 'EIGHT_POOL_UK') {
     const solids = cloned.filter(b => b.id >= 1 && b.id <= 7);
     const stripes = cloned.filter(b => b.id >= 9 && b.id <= 15);
     const eight = cloned.find(b => b.id === 8);

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -2,13 +2,14 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { planShot } from '../lib/poolAi.js';
 
-test('planShot returns a shot decision', () => {
+test('planShot targets lowest numbered ball', () => {
   const req = {
     game: 'AMERICAN_BILLIARDS',
     state: {
       balls: [
         { id: 0, x: 300, y: 250, vx: 0, vy: 0, pocketed: false },
-        { id: 1, x: 500, y: 250, vx: 0, vy: 0, pocketed: false }
+        { id: 3, x: 500, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 5, x: 700, y: 250, vx: 0, vy: 0, pocketed: false }
       ],
       pockets: [
         { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
@@ -17,20 +18,19 @@ test('planShot returns a shot decision', () => {
       width: 1000,
       height: 500,
       ballRadius: 10,
-      friction: 0.01,
-      myGroup: 'SOLIDS'
+      friction: 0.01
     },
     timeBudgetMs: 50,
     rngSeed: 1
   };
   const decision = planShot(req);
-  assert.equal(decision.targetBallId, 1);
+  assert.equal(decision.targetBallId, 3);
   assert(decision.targetPocket);
   assert(decision.quality >= 0 && decision.quality <= 1);
   assert(decision.rationale.length > 0);
 });
 
-test('targets 8 ball after clearing group', () => {
+test('eight ball is treated as normal', () => {
   const req = {
     game: 'AMERICAN_BILLIARDS',
     state: {
@@ -45,8 +45,7 @@ test('targets 8 ball after clearing group', () => {
       width: 1000,
       height: 500,
       ballRadius: 10,
-      friction: 0.01,
-      myGroup: 'SOLIDS'
+      friction: 0.01
     },
     timeBudgetMs: 50,
     rngSeed: 1

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -2713,15 +2713,15 @@
           source: 'Rules based on World Eightball Pool Federation guidelines.'
         },
         american: {
-          title: 'American 8-Ball Rules',
+          title: 'American Billiards Rules',
           items: [
-            'Rack with the 8-ball in the center. A legal break pockets a ball or drives four balls to cushions.',
-            'Table is open after the break; groups are assigned when a player legally pots a ball.',
-            'Shoot your group first and either pocket a ball or drive any ball to a cushion.',
-            'Scratching or failing to hit your group first is a foul and gives ball-in-hand to the opponent.',
-            'After clearing your group, pot the 8-ball without fouling to win.'
+            'Balls must be struck in numerical order; failing to contact the lowest numbered ball first is a foul.',
+            'Pocketed balls score their face value, but points from a fouled shot go to the opponent.',
+            'Pocketing the cue ball awards any points from that shot to the opponent.',
+            'When in hand, the cue ball must remain behind the head string.',
+            'The 8-ball is a normal scoring ball with no special effect.'
           ],
-          source: 'Simplified World Pool-Billiard Association 8-ball rules.'
+          source: 'Based on traditional 15-ball rotation guidelines.'
         },
         '9ball': {
           title: 'Nine Ball Rules',


### PR DESCRIPTION
## Summary
- define American Billiards as a rotation game and target balls in numerical order
- clarify American Billiards rules in Pool Royale page
- adjust AI tests for sequential ball play

## Testing
- `npm test` *(fails: ERR_DLOPEN_FAILED in canvas bindings and snake API test timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68ab17c82dec83298cac44cf6a36871e