### PR TITLE
feat: update UK pool rules and AI

### DIFF
--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -1,6 +1,5 @@
 export const DEFAULT_RULES = {
   blackOnBreak: 're-rack',
-  freeBallFirstContact: 'anyBall',
   allowCombinations: false,
   requireCushionIfNoPot: true,
   twoVisitsCarryOnBlack: false,
@@ -88,30 +87,28 @@ export class UkPool {
 
     // first contact legality
     if (!foul) {
-      if (!(s.freeBallAvailable && this.rules.freeBallFirstContact === 'anyBall')) {
-        if (s.isOpenTable) {
-          if (first !== 'yellow' && first !== 'red') {
+      if (s.isOpenTable) {
+        if (first !== 'yellow' && first !== 'red') {
+          foul = true;
+          reason = 'wrong first contact';
+        }
+      } else {
+        if (ownGroup && first !== ownGroup) {
+          if (first === 'black') {
+            const ownSet = s.ballsOnTable[ownGroup];
+            if (ownSet.size > 0) {
+              foul = true;
+              reason = 'contacted black early';
+            }
+          } else {
             foul = true;
             reason = 'wrong first contact';
           }
-        } else {
-          if (ownGroup && first !== ownGroup) {
-            if (first === 'black') {
-              foul = true;
-              reason = 'contacted black early';
-            } else {
-              foul = true;
-              reason = 'wrong first contact';
-            }
-          }
-          if (!ownGroup && (first === 'black')) {
-            foul = true;
-            reason = 'contacted black early';
-          }
         }
-      } else if (this.rules.freeBallFirstContact === 'ownOnly' && ownGroup && first !== ownGroup) {
-        foul = true;
-        reason = 'wrong first contact';
+        if (!ownGroup && first === 'black') {
+          foul = true;
+          reason = 'contacted black early';
+        }
       }
     }
 
@@ -122,7 +119,7 @@ export class UkPool {
     }
 
     // potting opponent ball illegally
-    if (!foul && oppGroup && shot.potted.includes(oppGroup) && !(s.freeBallAvailable && this.rules.freeBallFirstContact === 'anyBall')) {
+    if (!foul && oppGroup && shot.potted.includes(oppGroup)) {
       foul = true;
       reason = 'potted opponent ball';
     }
@@ -155,6 +152,7 @@ export class UkPool {
     }
 
     // group assignment on open table
+    let choiceRequired = false;
     if (!foul && s.isOpenTable) {
       const colors = new Set(shot.potted.filter(c => c === 'yellow' || c === 'red'));
       if (colors.size === 1) {
@@ -162,8 +160,13 @@ export class UkPool {
         s.assignments[current] = chosen;
         s.assignments[opp] = chosen === 'yellow' ? 'red' : 'yellow';
         s.isOpenTable = false;
+      } else if (colors.size === 2) {
+        choiceRequired = true;
+        s.lastEvent = 'CHOICE_REQUIRED';
       }
     }
+
+    const groupAfter = s.assignments[current];
 
     // post-shot updates
     let nextPlayer = current;
@@ -175,10 +178,10 @@ export class UkPool {
     if (foul) {
       nextPlayer = opp;
       shotsNext = 2;
-      freeNext = true;
+      freeNext = false;
       s.currentPlayer = nextPlayer;
       s.shotsRemaining = shotsNext;
-      s.freeBallAvailable = true;
+      s.freeBallAvailable = false;
       s.lastEvent = 'FOUL';
       if (blackPotted) {
         frameOver = true;
@@ -207,7 +210,7 @@ export class UkPool {
         };
       }
 
-      const potOwn = ownGroup && shot.potted.includes(ownGroup);
+      const potOwn = groupAfter && shot.potted.includes(groupAfter);
       if (!potOwn) {
         shotsNext = s.shotsRemaining - 1;
       }
@@ -228,9 +231,20 @@ export class UkPool {
       nextPlayer,
       shotsRemainingNext: shotsNext,
       freeBallNext: freeNext,
+      choiceRequired,
       frameOver,
       winner: frameOver ? winner : undefined
     };
+  }
+
+  chooseColor (player, color) {
+    if (!this.state.isOpenTable) return false;
+    const opp = opponent(player);
+    this.state.assignments[player] = color;
+    this.state.assignments[opp] = color === 'yellow' ? 'red' : 'yellow';
+    this.state.isOpenTable = false;
+    this.state.lastEvent = 'COLOR_CHOSEN';
+    return true;
   }
 }
 

--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -103,21 +103,71 @@ function generatePotCandidates(state, colour) {
   const balls = visibleOwnBalls(state, colour);
   const shots = [];
   for (const ball of balls) {
+    let bestPocket = null;
+    let bestDist = Infinity;
     for (const pocket of state.pockets) {
-      if (pathBlocked(ball, pocket, state.balls, [cue.id, ball.id], state.ballRadius)) continue;
-      const angle = cutAngle(cue, ball, pocket);
+      const d = dist(ball, pocket);
+      if (d < bestDist) { bestDist = d; bestPocket = pocket; }
+    }
+    if (bestPocket && !pathBlocked(ball, bestPocket, state.balls, [cue.id, ball.id], state.ballRadius)) {
+      const angle = cutAngle(cue, ball, bestPocket);
       const distCT = dist(cue, ball);
-      const distTP = dist(ball, pocket);
+      const distTP = dist(ball, bestPocket);
       const shot = {
         actionType: 'pot',
         targetBall: ball,
-        pocket,
+        pocket: bestPocket,
         cueParams: { speed: 'med', spin: 'stun' },
         angle,
         distCT,
         distTP,
       };
       shots.push(shot);
+    }
+  }
+  return shots;
+}
+
+function mirrorPocket(pocket, width, height, rail) {
+  switch (rail) {
+    case 'left':
+      return { x: -pocket.x, y: pocket.y };
+    case 'right':
+      return { x: width * 2 - pocket.x, y: pocket.y };
+    case 'top':
+      return { x: pocket.x, y: -pocket.y };
+    case 'bottom':
+      return { x: pocket.x, y: height * 2 - pocket.y };
+    default:
+      return pocket;
+  }
+}
+
+function generateBankPotCandidates(state, colour) {
+  const cue = state.balls.find(b => b.colour === 'cue');
+  const balls = visibleOwnBalls(state, colour);
+  const shots = [];
+  for (const ball of balls) {
+    for (const pocket of state.pockets) {
+      for (const rail of ['left', 'right', 'top', 'bottom']) {
+        const mirror = mirrorPocket(pocket, state.width, state.height, rail);
+        if (pathBlocked(ball, mirror, state.balls, [cue.id, ball.id], state.ballRadius)) continue;
+        const angle = cutAngle(cue, ball, mirror);
+        const distCT = dist(cue, ball);
+        const distTP = dist(ball, pocket);
+        const shot = {
+          actionType: 'pot',
+          targetBall: ball,
+          pocket,
+          cueParams: { speed: 'med', spin: 'stun' },
+          angle,
+          distCT,
+          distTP,
+          isBank: true,
+          bankAnchor: mirror
+        };
+        shots.push(shot);
+      }
     }
   }
   return shots;
@@ -179,6 +229,7 @@ function estimatePotProbability(shot, state) {
   const maxD = Math.hypot(state.width, state.height);
   const distScore = 1 - Math.min((shot.distCT + shot.distTP) / maxD, 1);
   let P = angleScore * 0.7 + distScore * 0.3;
+  if (shot.isBank) P *= 0.5;
   // rail penalty
   const target = shot.targetBall;
   if (target && (Math.min(target.x, state.width - target.x) < state.ballRadius * 2 || Math.min(target.y, state.height - target.y) < state.ballRadius * 2)) {
@@ -301,7 +352,7 @@ function evaluateCandidates(state, colour, candidates) {
 }
 
 function chooseBestAction(state, colour) {
-  let candidates = generatePotCandidates(state, colour);
+  let candidates = generatePotCandidates(state, colour).concat(generateBankPotCandidates(state, colour));
   if (state.freeBallAvailable) {
     candidates = candidates.concat(generateFreeBallCandidates(state, colour));
   }
@@ -318,7 +369,7 @@ function chooseBestAction(state, colour) {
   if (!best) return null;
   const c = best.c;
   const cueBall = state.balls.find(b => b.colour === 'cue');
-  const aim = c.targetBall ? { x: c.targetBall.x, y: c.targetBall.y } : { x: cueBall.x, y: cueBall.y };
+  const aim = c.bankAnchor ? { x: c.bankAnchor.x, y: c.bankAnchor.y } : (c.targetBall ? { x: c.targetBall.x, y: c.targetBall.y } : { x: cueBall.x, y: cueBall.y });
   const posTarget = c.actionType === 'safety'
     ? { x: cueBall.x, y: cueBall.y }
     : simulateCueRollout(state, c);

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -2704,11 +2704,13 @@
         uk: {
           title: '8 Ball UK Rules',
           items: [
-            'Rack with the black in the middle. A legal break pots a ball or drives two balls to cushions.',
-            'Groups (red or yellow) are claimed by the first player to pot a ball after the break.',
-            'On each shot hit one of your balls first and either pot a ball or make any ball reach a cushion.',
-            "Fouls—such as potting the cue ball, striking the opponent's ball first or no cushion contact—give the opponent two visits.",
-            'Clear your group then pot the black cleanly to win. Potting the black early or on a foul loses the frame.'
+            'Game begins with a break shot. If both a yellow and a red are potted, the breaker may choose a colour.',
+            'After colours are chosen you must strike one of your balls first; failing to do so is a foul.',
+            'Every foul gives the opponent two shots.',
+            'After a foul the cue ball is placed behind the baulk line and must cross the line; there is no free ball.',
+            'Potting the cue ball is a foul and also grants two shots to the opponent.',
+            'Clear your group then pot the black to win; potting the black early loses the frame.',
+            'AI aims for its own balls closest to pockets or with best angles, using straight or bank target lines.'
           ],
           source: 'Rules based on World Eightball Pool Federation guidelines.'
         },


### PR DESCRIPTION
## Summary
- enforce UK 8-ball rules and colour choice logic
- expand advanced AI targeting with bank shots
- document updated Pool Royale rules

## Testing
- `node --test test/poolUk8Ball.test.js`
- `npm test` *(fails: claim-external route reverts balance on claim failure, snake API endpoints, seat/unseat endpoints, allows multiple users without telegramId, withdraw route reverts balance on claim failure)*
- `npm run lint` *(fails: 1168 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab19cc5f488329adfac583e7f3db1f