### PR TITLE
Add American Billiards and 9-Ball rule engines

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -1,0 +1,71 @@
+export class AmericanBilliards {
+  constructor () {
+    this.state = {
+      ballsOnTable: new Set(Array.from({ length: 15 }, (_, i) => i + 1)),
+      currentPlayer: 'A',
+      scores: { A: 0, B: 0 },
+      ballInHand: false
+    };
+  }
+
+  shotTaken (shot) {
+    const s = this.state;
+    const current = s.currentPlayer;
+    const opp = current === 'A' ? 'B' : 'A';
+    const lowest = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
+    let foul = false;
+    let reason = '';
+
+    if (s.ballInHand && !shot.placedFromHand) {
+      foul = true;
+      reason = 'must place cue ball';
+    }
+
+    const first = shot.contactOrder && shot.contactOrder[0];
+    if (!foul && first !== lowest) {
+      foul = true;
+      reason = 'wrong first contact';
+    }
+
+    if (!foul && (shot.potted.includes(0) || shot.cueOffTable)) {
+      foul = true;
+      reason = 'scratch';
+    }
+
+    const pottedBalls = shot.potted.filter(id => id !== 0);
+    const points = pottedBalls.reduce((a, b) => a + b, 0);
+
+    let nextPlayer = current;
+    let ballInHandNext = false;
+
+    if (foul) {
+      s.scores[opp] += points;
+      nextPlayer = opp;
+      s.currentPlayer = opp;
+      ballInHandNext = true;
+    } else {
+      for (const id of pottedBalls) s.ballsOnTable.delete(id);
+      s.scores[current] += points;
+      if (pottedBalls.length === 0) {
+        nextPlayer = opp;
+        s.currentPlayer = opp;
+      }
+    }
+
+    s.ballInHand = ballInHandNext;
+    const nextBall = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
+
+    return {
+      legal: !foul,
+      foul,
+      reason: foul ? reason : undefined,
+      potted: shot.potted,
+      nextPlayer,
+      ballInHandNext,
+      scores: { ...s.scores },
+      currentBall: nextBall
+    };
+  }
+}
+
+export default AmericanBilliards;

--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -1,0 +1,85 @@
+function opponent (p) {
+  return p === 'A' ? 'B' : 'A';
+}
+
+export class NineBall {
+  constructor () {
+    this.state = {
+      ballsOnTable: new Set([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+      currentPlayer: 'A',
+      ballInHand: false,
+      gameOver: false,
+      winner: null
+    };
+  }
+
+  shotTaken (shot) {
+    const s = this.state;
+    if (s.gameOver) {
+      return { legal: false, foul: true, reason: 'game over', potted: [], nextPlayer: s.currentPlayer, ballInHandNext: false, frameOver: true, winner: s.winner };
+    }
+    const current = s.currentPlayer;
+    const opp = opponent(current);
+    const lowest = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
+    let foul = false;
+    let reason = '';
+
+    if (s.ballInHand && !shot.placedFromHand) {
+      foul = true;
+      reason = 'must place cue ball';
+    }
+
+    const first = shot.contactOrder && shot.contactOrder[0];
+    if (!foul && first !== lowest) {
+      foul = true;
+      reason = 'wrong first contact';
+    }
+
+    if (!foul && (shot.potted.includes(0) || shot.cueOffTable)) {
+      foul = true;
+      reason = 'scratch';
+    }
+
+    const pottedBalls = shot.potted.filter(id => id !== 0);
+
+    let nextPlayer = current;
+    let ballInHandNext = false;
+    let frameOver = false;
+    let winner = null;
+
+    if (foul) {
+      nextPlayer = opp;
+      ballInHandNext = true;
+      s.currentPlayer = opp;
+      s.ballInHand = true;
+    } else {
+      for (const id of pottedBalls) s.ballsOnTable.delete(id);
+      if (pottedBalls.includes(9)) {
+        frameOver = true;
+        winner = current;
+        s.gameOver = true;
+        s.winner = winner;
+      }
+      if (frameOver) {
+        nextPlayer = current;
+      } else if (pottedBalls.length === 0) {
+        nextPlayer = opp;
+        s.currentPlayer = opp;
+      }
+      s.ballInHand = false;
+    }
+
+    return {
+      legal: !foul,
+      foul,
+      reason: foul ? reason : undefined,
+      potted: shot.potted,
+      nextPlayer,
+      ballInHandNext,
+      frameOver,
+      winner
+    };
+  }
+}
+
+export default NineBall;

--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -31,7 +31,8 @@ export class UkPool {
       isOpenTable: true,
       lastEvent: null,
       frameOver: false,
-      winner: null
+      winner: null,
+      mustPlayFromBaulk: false
     };
   }
 
@@ -73,8 +74,15 @@ export class UkPool {
 
     const first = shot.contactOrder && shot.contactOrder[0];
 
+    const mustBaulk = s.mustPlayFromBaulk;
+    s.mustPlayFromBaulk = false;
+    if (mustBaulk && !shot.placedFromHand) {
+      foul = true;
+      reason = 'must play from baulk';
+    }
+
     // no contact
-    if (!first) {
+    if (!foul && !first) {
       foul = true;
       reason = 'no contact';
     }
@@ -182,6 +190,7 @@ export class UkPool {
       s.currentPlayer = nextPlayer;
       s.shotsRemaining = shotsNext;
       s.freeBallAvailable = false;
+      s.mustPlayFromBaulk = true;
       s.lastEvent = 'FOUL';
       if (blackPotted) {
         frameOver = true;

--- a/test/americanBilliards.test.js
+++ b/test/americanBilliards.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { AmericanBilliards } from '../lib/americanBilliards.js';
+
+test('hitting wrong ball first is foul and points to opponent', () => {
+  const game = new AmericanBilliards();
+  const res = game.shotTaken({
+    contactOrder: [2],
+    potted: [2],
+    cueOffTable: false,
+    placedFromHand: false
+  });
+  assert.equal(res.foul, true);
+  assert.equal(res.reason, 'wrong first contact');
+  assert.equal(res.nextPlayer, 'B');
+  assert.equal(res.ballInHandNext, true);
+  assert.equal(res.scores.B, 2);
+  assert.equal(game.state.ballsOnTable.has(2), true);
+});
+
+test('legal pot adds points and keeps turn', () => {
+  const game = new AmericanBilliards();
+  const res1 = game.shotTaken({
+    contactOrder: [1],
+    potted: [1],
+    cueOffTable: false,
+    placedFromHand: false
+  });
+  assert.equal(res1.foul, false);
+  assert.equal(res1.nextPlayer, 'A');
+  assert.equal(res1.scores.A, 1);
+  const res2 = game.shotTaken({
+    contactOrder: [2],
+    potted: [],
+    cueOffTable: false,
+    placedFromHand: false
+  });
+  assert.equal(res2.nextPlayer, 'B');
+});
+
+test('scratch gives opponent points and ball in hand', () => {
+  const game = new AmericanBilliards();
+  const res = game.shotTaken({
+    contactOrder: [1],
+    potted: [1, 0],
+    cueOffTable: false,
+    placedFromHand: false
+  });
+  assert.equal(res.foul, true);
+  assert.equal(res.reason, 'scratch');
+  assert.equal(res.nextPlayer, 'B');
+  assert.equal(res.ballInHandNext, true);
+  assert.equal(res.scores.B, 1);
+  assert.equal(game.state.ballsOnTable.has(1), true);
+});
+
+test('eight ball is treated as normal', () => {
+  const game = new AmericanBilliards();
+  game.shotTaken({ contactOrder: [1], potted: [1], cueOffTable: false, placedFromHand: false });
+  const res = game.shotTaken({
+    contactOrder: [2],
+    potted: [2, 8],
+    cueOffTable: false,
+    placedFromHand: false
+  });
+  assert.equal(res.foul, false);
+  assert.equal(res.scores.A, 1 + 2 + 8);
+});

--- a/test/nineBall.test.js
+++ b/test/nineBall.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { NineBall } from '../lib/nineBall.js';
+
+test('must hit lowest ball first or foul', () => {
+  const game = new NineBall();
+  const res = game.shotTaken({
+    contactOrder: [2],
+    potted: [],
+    cueOffTable: false,
+    placedFromHand: false
+  });
+  assert.equal(res.foul, true);
+  assert.equal(res.reason, 'wrong first contact');
+  assert.equal(res.ballInHandNext, true);
+  assert.equal(res.nextPlayer, 'B');
+});
+
+test('potting nine after legal contact wins', () => {
+  const game = new NineBall();
+  const res = game.shotTaken({
+    contactOrder: [1],
+    potted: [9],
+    cueOffTable: false,
+    placedFromHand: false
+  });
+  assert.equal(res.foul, false);
+  assert.equal(res.frameOver, true);
+  assert.equal(res.winner, 'A');
+});
+
+test('scratch gives opponent ball in hand', () => {
+  const game = new NineBall();
+  const res1 = game.shotTaken({
+    contactOrder: [1],
+    potted: [0],
+    cueOffTable: false,
+    placedFromHand: false
+  });
+  assert.equal(res1.foul, true);
+  assert.equal(res1.reason, 'scratch');
+  assert.equal(res1.ballInHandNext, true);
+  const res2 = game.shotTaken({
+    contactOrder: [1],
+    potted: [],
+    cueOffTable: false,
+    placedFromHand: false
+  });
+  assert.equal(res2.foul, true);
+  assert.equal(res2.reason, 'must place cue ball');
+});

--- a/test/poolUk8Ball.test.js
+++ b/test/poolUk8Ball.test.js
@@ -143,3 +143,23 @@ test('potting 8-ball legally after clearing group wins', () => {
   assert.equal(res.frameOver, true);
   assert.equal(res.winner, 'A');
 });
+
+test('after foul cue must be played from baulk', () => {
+  const game = new UkPool();
+  game.shotTaken({
+    contactOrder: ['yellow'],
+    potted: ['cue'],
+    cueOffTable: false,
+    noCushionAfterContact: false,
+    placedFromHand: false
+  });
+  const res = game.shotTaken({
+    contactOrder: ['yellow'],
+    potted: [],
+    cueOffTable: false,
+    noCushionAfterContact: false,
+    placedFromHand: false
+  });
+  assert.equal(res.foul, true);
+  assert.equal(res.reason, 'must play from baulk');
+});


### PR DESCRIPTION
## Summary
- require playing from baulk after fouls in UK 8-Ball
- implement American Billiards scoring and foul logic
- implement 9-Ball sequential play and win conditions
- add unit tests for new rule modules

## Testing
- `npm test` *(fails: open table chooses easier colour; snake API endpoints and socket events)*
- `node --test test/americanBilliards.test.js test/nineBall.test.js test/poolUk8Ball.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ab26249d4883299fa29f9d53622286