### PR TITLE
Avoid post-frame foul and refine pool AI aiming

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -152,7 +152,14 @@ function evaluate(req, cue, target, pocket, power, spin) {
     nextScore = 1 - Math.min(dist(cueAfter, next) / maxD, 1);
   }
   const risk = req.state.pockets.some(p => dist(cueAfter, p) < r * 1.2) ? 1 : 0;
-  const quality = Math.max(0, Math.min(1, 0.7 * potChance + 0.3 * nextScore - 0.2 * risk));
+  const shotVec = { x: target.x - cue.x, y: target.y - cue.y };
+  const potVec = { x: pocket.x - target.x, y: pocket.y - target.y };
+  const cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x));
+  const centerAlign = 1 - Math.min(cutAngle / (Math.PI / 2), 1);
+  const quality = Math.max(
+    0,
+    Math.min(1, 0.6 * potChance + 0.2 * centerAlign + 0.2 * nextScore - 0.2 * risk)
+  );
   const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x);
   return {
     angleRad: angle,
@@ -161,7 +168,7 @@ function evaluate(req, cue, target, pocket, power, spin) {
     targetBallId: target.id,
     targetPocket: pocket,
     quality,
-    rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)}`
+    rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)}`
   };
 }
 

--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -54,7 +54,7 @@ export class UkPool {
     if (s.frameOver) {
       return {
         legal: false,
-        foul: true,
+        foul: false,
         reason: 'frame already over',
         potted: [],
         nextPlayer: s.currentPlayer,

--- a/test/poolUk8Ball.test.js
+++ b/test/poolUk8Ball.test.js
@@ -163,3 +163,26 @@ test('after foul cue must be played from baulk', () => {
   assert.equal(res.foul, true);
   assert.equal(res.reason, 'must play from baulk');
 });
+
+test('shots after frame end are not fouls', () => {
+  const game = new UkPool();
+  game.state.assignments = { A: 'yellow', B: 'red' };
+  game.state.isOpenTable = false;
+  game.state.ballsOnTable.yellow.clear();
+  game.shotTaken({
+    contactOrder: ['black'],
+    potted: ['black'],
+    cueOffTable: false,
+    noCushionAfterContact: false,
+    placedFromHand: false
+  });
+  const res = game.shotTaken({
+    contactOrder: ['yellow'],
+    potted: [],
+    cueOffTable: false,
+    noCushionAfterContact: false,
+    placedFromHand: false
+  });
+  assert.equal(res.foul, false);
+  assert.equal(res.frameOver, true);
+});


### PR DESCRIPTION
## Summary
- Prevent 8-ball UK logic from flagging a foul after the frame has ended.
- Enhance pool AI evaluation to prioritize shots striking target balls more centrally.
- Add regression test ensuring shots after frame completion are treated as non-fouls.

## Testing
- `node --test test/poolUk8Ball.test.js`
- `npm test` *(fails: snake API endpoints and socket events timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2e14a2248329a04641188323a7dc