### PR TITLE
feat: update poker and blackjack game cards

### DIFF
--- a/webapp/public/assets/icons/blackjack.svg
+++ b/webapp/public/assets/icons/blackjack.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Blackjack hand: Ace and King -->
+  <rect x="15" y="20" width="50" height="70" rx="5" ry="5" fill="white" stroke="black" stroke-width="3"/>
+  <text x="40" y="65" font-size="32" text-anchor="middle" fill="red">A♥</text>
+  <rect x="35" y="10" width="50" height="70" rx="5" ry="5" fill="white" stroke="black" stroke-width="3"/>
+  <text x="60" y="55" font-size="32" text-anchor="middle" fill="black">K♠</text>
+</svg>

--- a/webapp/public/assets/icons/texas-holdem.svg
+++ b/webapp/public/assets/icons/texas-holdem.svg
@@ -1,4 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect x="10" y="10" width="80" height="80" rx="10" ry="10" fill="white" stroke="black" stroke-width="5"/>
-  <text x="50" y="65" font-size="60" text-anchor="middle">♥</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 100">
+  <!-- Straight flush 10 to Ace of hearts -->
+  <g>
+    <rect x="5" y="40" width="25" height="40" rx="3" ry="3" fill="white" stroke="black" stroke-width="2"/>
+    <text x="17.5" y="68" font-size="18" text-anchor="middle" fill="red">10♥</text>
+  </g>
+  <g>
+    <rect x="25" y="32" width="25" height="40" rx="3" ry="3" fill="white" stroke="black" stroke-width="2"/>
+    <text x="37.5" y="60" font-size="18" text-anchor="middle" fill="red">J♥</text>
+  </g>
+  <g>
+    <rect x="45" y="24" width="25" height="40" rx="3" ry="3" fill="white" stroke="black" stroke-width="2"/>
+    <text x="57.5" y="52" font-size="18" text-anchor="middle" fill="red">Q♥</text>
+  </g>
+  <g>
+    <rect x="65" y="16" width="25" height="40" rx="3" ry="3" fill="white" stroke="black" stroke-width="2"/>
+    <text x="77.5" y="44" font-size="18" text-anchor="middle" fill="red">K♥</text>
+  </g>
+  <g>
+    <rect x="85" y="8" width="25" height="40" rx="3" ry="3" fill="white" stroke="black" stroke-width="2"/>
+    <text x="97.5" y="36" font-size="18" text-anchor="middle" fill="red">A♥</text>
+  </g>
 </svg>

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -31,11 +31,11 @@ export default function HomeGamesCard() {
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img
-            src="/assets/icons/texas-holdem.svg"
+            src="/assets/icons/blackjack.svg"
             alt=""
             className="h-20 w-20"
           />
-          <h3 className="text-sm font-semibold text-center text-yellow-400">
+          <h3 className="text-xs font-semibold text-center text-yellow-400">
             Black Jack Multiplayer
           </h3>
         </Link>

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -32,12 +32,12 @@ export default function Games() {
               className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
             >
               <img
-                src="/assets/icons/texas-holdem.svg"
+                src="/assets/icons/blackjack.svg"
                 alt=""
                 className="h-20 w-20"
               />
               <h3
-                className="text-sm font-semibold text-center text-yellow-400"
+                className="text-xs font-semibold text-center text-yellow-400"
                 style={{ WebkitTextStroke: '1px black' }}
               >
                 Black Jack Multiplayer


### PR DESCRIPTION
## Summary
- depict a straight flush in hearts for the Texas Hold'em card image
- add a two-card blackjack icon and shrink its title text

## Testing
- `npm test` *(fails: open table chooses easier colour; snake API endpoints and socket events timeout)*
- `npm run lint` *(fails: 1243 errors, e.g., numerous extra semicolons)*

------
https://chatgpt.com/codex/tasks/task_e_68ab32ade8d48329802f17572f35da76