### PR TITLE
fix spin indicator alignment

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1491,6 +1491,9 @@
 
             // pika e spin-it te cue
             if (b.n === 0) {
+              ctx.save();
+              // Undo ball rotation so the spin indicator matches the controller
+              ctx.rotate(-b.a);
               ctx.fillStyle = '#e63';
               ctx.beginPath();
               ctx.arc(
@@ -1501,6 +1504,7 @@
                 Math.PI * 2
               );
               ctx.fill();
+              ctx.restore();
             }
             ctx.restore();
           }


### PR DESCRIPTION
## Summary
- prevent cue ball spin marker from rotating with ball orientation so spin controller and table align

## Testing
- `npm test` (fails: AssertionError in snakeApi.test)
- `npm run lint` (fails: 1243 errors)


------
https://chatgpt.com/codex/tasks/task_e_68ab3f8b0bd88329864707c86ad1d571