### PR TITLE
Fix cue overshoot in Pool Royale game

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -2372,7 +2372,7 @@
         function animateCueStrike(dt) {
           if (!cueStrike.active) return;
           cuePullVisual -= cueStrike.speed * dt;
-          if (cuePullVisual <= -BALL_R * 2) {
+          if (cuePullVisual <= 0) {
             cueStrike.active = false;
             cuePullVisual = 0;
             cueVisible = false;


### PR DESCRIPTION
## Summary
- prevent Pool Royale cue from moving past its initial position when striking the ball

## Testing
- `npm test` *(fails: snake API endpoints and socket events test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68ab50d2b3f883298999f7d7cc903bea