### PR TITLE
Tighten Murlan Royale side card stacks and pile overlap

### DIFF
--- a/webapp/public/murlan-royale.html
+++ b/webapp/public/murlan-royale.html
@@ -253,7 +253,7 @@
       }
       .seat.left .cards .card:not(:first-child),
       .seat.right .cards .card:not(:first-child) {
-        margin-top: calc(var(--card-w) * -0.5);
+        margin-top: calc(var(--card-h) * -0.88);
       }
       .seat.left .opp-fan .card {
         transform: rotate(calc(var(--rot, 0deg) - 90deg));
@@ -769,7 +769,7 @@
               '--card-w'
             )
           );
-          const gap = cardW * 0.3; // overlap similar to top opponent
+          const gap = cardW * 0.15; // tightly overlap like top player's stack
           pileEl.style.width = cardW + (state.pile.length - 1) * gap + 'px';
           const startAngle = (-8 * (state.pile.length - 1)) / 2;
           state.pile.forEach((c, idx) => {


### PR DESCRIPTION
## Summary
- Stack left/right players' cards vertically with tighter overlap
- Compact pile cards so multiple throws show only a sliver

## Testing
- `npm test`
- `npm run lint` *(fails: 1250 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abefc35840832997cc147e360db249