### PR TITLE
Adjust Murlan Royale layout and turn UX

### DIFF
--- a/webapp/public/murlan-royale.html
+++ b/webapp/public/murlan-royale.html
@@ -67,7 +67,7 @@
       .center {
         position: absolute;
         left: 50%;
-        top: 50%;
+        top: 40%;
         transform: translate(-50%, -50%);
         display: flex;
         gap: 10px;
@@ -88,6 +88,7 @@
         border-radius: 12px;
         background: var(--seat-bg-color);
         box-shadow: 4px 4px 0 #d4ccb3;
+        justify-content: center;
       }
       .pile .card {
         transform: scale(1.3);
@@ -126,6 +127,21 @@
         place-items: center;
         gap: 6px;
         width: clamp(120px, 28vw, 200px);
+      }
+      .seat .turn-indicator {
+        display: none;
+        position: absolute;
+        top: -14px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 0;
+        height: 0;
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        border-bottom: 8px solid var(--ui2);
+      }
+      .seat.active .turn-indicator {
+        display: block;
       }
       .seat-inner {
         display: flex;
@@ -305,6 +321,11 @@
         align-items: center;
         gap: 0;
       }
+      .seat.left .cards .card,
+      .seat.right .cards .card {
+        transform: scale(1.05);
+        transform-origin: center;
+      }
       .seat.bottom .cards {
         touch-action: none;
         transform: scale(var(--my-card-scale));
@@ -405,7 +426,7 @@
       }
       .seat.left .cards .card:not(:first-child),
       .seat.right .cards .card:not(:first-child) {
-        margin-top: calc(var(--card-h) * -0.88);
+        margin-top: calc(var(--card-h) * -0.92);
       }
       .seat.left .opp-fan .card {
         transform: rotate(calc(var(--rot, 0deg) - 90deg));
@@ -868,6 +889,9 @@
 
             const seat = document.createElement('div');
             seat.className = 'seat ' + side;
+            const indicator = document.createElement('div');
+            indicator.className = 'turn-indicator';
+            seat.appendChild(indicator);
             const area = el('.stage').getBoundingClientRect();
             if (side === 'bottom') {
               seat.style.left = '50%';
@@ -876,8 +900,8 @@
               seat.style.width = 'auto';
             } else if (side === 'top') {
               seat.style.left = '50%';
-              seat.style.top = '8px';
-              seat.style.transform = 'translateX(-60%)';
+              seat.style.top = 'calc(var(--avatar-size) + 8px)';
+              seat.style.transform = 'translateX(-50%)';
             } else if (side === 'right') {
               seat.style.left = x - area.left - 20 + 'px';
               seat.style.top = y - area.top + 20 + 'px';
@@ -1123,7 +1147,7 @@
 
         // ===== GAME FLOW (singles/pairs + simple AI) =====
         function collectSelected() {
-          const mySeat = seatsEl.querySelector('.seat .cards');
+          const mySeat = seatsEl.querySelector('.seat.bottom .cards');
           const faces = mySeat
             ? Array.from(mySeat.querySelectorAll('.card:not(.back)'))
             : [];


### PR DESCRIPTION
## Summary
- Align top player's avatar with side cards and add visual turn indicator
- Enlarge side players' cards and center community pile above them
- Fix selection logic so users can play multiple cards on their turn

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac137bee8483299bee675f7f34ff11