### PR TITLE
Adjust Murlan Royale table layout

### DIFF
--- a/webapp/public/murlan-royale.html
+++ b/webapp/public/murlan-royale.html
@@ -67,7 +67,7 @@
       .center {
         position: absolute;
         left: 50%;
-        top: 40%;
+        top: 36%;
         transform: translate(-50%, -50%);
         display: flex;
         gap: 10px;
@@ -433,6 +433,19 @@
       }
       .seat.right .opp-fan .card {
         transform: rotate(calc(var(--rot, 0deg) + 90deg));
+      }
+
+      /* Top opponent: avatar left of cards and tighter spacing */
+      .seat.top .top-row {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+      .seat.top .cards {
+        gap: 0;
+      }
+      .seat.top .cards .card:not(:first-child) {
+        margin-left: calc(var(--card-w) * -0.3);
       }
 
       /* ICON CONTROLS */
@@ -900,7 +913,7 @@
               seat.style.width = 'auto';
             } else if (side === 'top') {
               seat.style.left = '50%';
-              seat.style.top = 'calc(var(--avatar-size) + 8px)';
+              seat.style.top = '8px';
               seat.style.transform = 'translateX(-50%)';
             } else if (side === 'right') {
               seat.style.left = x - area.left - 20 + 'px';
@@ -930,6 +943,15 @@
             const name = document.createElement('div');
             name.className = 'name';
             name.textContent = p.name;
+            if (side === 'left' || side === 'right') {
+              const baseLen = 15;
+              const baseFont = 11;
+              const size = Math.max(
+                9,
+                Math.min(14, (baseLen / Math.max(p.name.length, 1)) * baseFont)
+              );
+              name.style.fontSize = size + 'px';
+            }
 
             const cards = document.createElement('div');
             cards.className = 'cards';
@@ -992,8 +1014,11 @@
               seatInner.append(controls, name, cards, timer);
             } else if (side === 'left' || side === 'right') {
               seatInner.append(av, cards, name, timer);
-            } else {
-              seatInner.append(av, name, cards, timer);
+            } else if (side === 'top') {
+              const topRow = document.createElement('div');
+              topRow.className = 'top-row';
+              topRow.append(av, cards);
+              seatInner.append(topRow, name, timer);
             }
             seat.appendChild(seatInner);
             seatsEl.appendChild(seat);


### PR DESCRIPTION
## Summary
- position top player's avatar beside cards and center top seat
- keep side seat frame size by scaling player names
- raise community card pile slightly

## Testing
- `timeout 30s npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac1876fb3c83299fe77254a4994614