### PR TITLE
Expose Goal Rush calibration button via dev params

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -127,7 +127,7 @@
   const devAccount = params.get('dev');
   const devAccount1 = params.get('dev1');
   const devAccount2 = params.get('dev2');
-  if (devAccount === myAccountId) {
+  if (devAccount || devAccount1 || devAccount2) {
     saveCalibBtn.style.display = 'block';
     saveCalibBtn.addEventListener('click', saveCalibration);
   }


### PR DESCRIPTION
## Summary
- Show 'Save Calib' button whenever `dev`, `dev1`, or `dev2` query params are present
- Server validates developer account and saves calibration to goal-rush-calibration.json for global use

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac1a4549448329a3bb6a0216ceb3fa