### PR TITLE
Refine Murlan Royale card layout and selection

### DIFF
--- a/lib/murlan.js
+++ b/lib/murlan.js
@@ -202,7 +202,7 @@ export function dealPlayers(numPlayers, deck) {
   }
   players.forEach((pl) => { pl.hand = sortHand(pl.hand); });
   const startIdx = players.findIndex((pl) =>
-    pl.hand.some((c) => c.rank === '3' && c.suit === '♣')
+    pl.hand.some((c) => c.rank === '3' && c.suit === '♠')
   );
   players.startingPlayer = startIdx;
   return players;
@@ -213,10 +213,10 @@ export function playTurn(state, action) {
   const player = state.players[state.turn.activePlayer];
   if (state.firstMove) {
     const startIdx = state.players.findIndex((p) =>
-      p.hand.some((c) => c.rank === '3' && c.suit === '♣')
+      p.hand.some((c) => c.rank === '3' && c.suit === '♠')
     );
     if (state.turn.activePlayer !== startIdx) {
-      throw new Error('3♣ player must start');
+      throw new Error('3♠ player must start');
     }
   }
   if (action.type === 'PASS') {
@@ -234,10 +234,10 @@ export function playTurn(state, action) {
   if (!combo) throw new Error('invalid combo');
   if (!canBeat(combo, state.turn.currentCombo, state.config)) throw new Error('cannot beat');
   if (state.firstMove) {
-    const hasThreeClub = action.cards.some(
-      (c) => c.rank === '3' && c.suit === '♣'
+    const hasThreeSpade = action.cards.some(
+      (c) => c.rank === '3' && c.suit === '♠'
     );
-    if (!hasThreeClub) throw new Error('first move must include 3♣');
+    if (!hasThreeSpade) throw new Error('first move must include 3♠');
     state.firstMove = false;
   }
   for (const card of action.cards) {

--- a/test/murlan.test.js
+++ b/test/murlan.test.js
@@ -53,7 +53,7 @@ test('straight rules', () => {
     card('K', '♦'),
     card('A', '♥'),
     card('2', '♠'),
-    card('3', '♣')
+    card('3', '♠')
   ], config);
   assert.equal(wrap, null);
 });
@@ -66,11 +66,11 @@ test('compare same type/size', () => {
   assert.equal(canBeat(cand2, table, DEFAULT_CONFIG), false);
 });
 
-test('starting player must open with 3♣', () => {
+test('starting player must open with 3♠', () => {
   const state = {
     players: [
-      { hand: [card('3', '♣'), card('7', '♦')], finished: false },
-      { hand: [card('4', '♣')], finished: false }
+      { hand: [card('3', '♠'), card('7', '♦')], finished: false },
+      { hand: [card('4', '♠')], finished: false }
     ],
     turn: { activePlayer: 0, currentCombo: null, passesInRow: 0 },
     config: DEFAULT_CONFIG,
@@ -80,17 +80,17 @@ test('starting player must open with 3♣', () => {
   assert.throws(() =>
     playTurn(state, { type: 'PLAY', cards: [card('7', '♦')] })
   );
-  playTurn(state, { type: 'PLAY', cards: [card('3', '♣')] });
+  playTurn(state, { type: 'PLAY', cards: [card('3', '♠')] });
   assert.equal(state.firstMove, false);
 });
 
 test('dealPlayers marks starting player', () => {
   const deck = [
-    card('3', '♣'), card('4', '♦'), card('5', '♠'), card('6', '♣')
+    card('3', '♠'), card('4', '♦'), card('5', '♠'), card('6', '♣')
   ];
   const players = dealPlayers(2, deck);
   const idx = players.findIndex((p) =>
-    p.hand.some((c) => c.rank === '3' && c.suit === '♣')
+    p.hand.some((c) => c.rank === '3' && c.suit === '♠')
   );
   assert.equal(players.startingPlayer, idx);
 });
@@ -98,8 +98,8 @@ test('dealPlayers marks starting player', () => {
 test('round closes after passes', () => {
   const state = {
     players: [
-      { hand: [card('3', '♣'), card('7', '♣')], finished: false },
-      { hand: [card('4', '♣')], finished: false },
+      { hand: [card('3', '♠'), card('7', '♣')], finished: false },
+      { hand: [card('4', '♠')], finished: false },
       { hand: [card('5', '♣')], finished: false },
       { hand: [card('6', '♣')], finished: false }
     ],
@@ -107,7 +107,7 @@ test('round closes after passes', () => {
     config: DEFAULT_CONFIG,
     lastWinner: 0
   };
-  playTurn(state, { type: 'PLAY', cards: [card('3', '♣')] });
+  playTurn(state, { type: 'PLAY', cards: [card('3', '♠')] });
   playTurn(state, { type: 'PASS' });
   playTurn(state, { type: 'PASS' });
   playTurn(state, { type: 'PASS' });
@@ -117,7 +117,7 @@ test('round closes after passes', () => {
 
 test('aiChooseAction avoids breaking bomb', () => {
   const hand = [
-    card('3', '♣'),
+    card('3', '♠'),
     card('4', '♦'),
     card('5', '♥'),
     card('9', '♣'),
@@ -142,7 +142,7 @@ test('bomb closes round immediately', () => {
           card('K', '♦'),
           card('K', '♥'),
           card('K', '♠'),
-          card('3', '♣')
+          card('3', '♠')
         ],
         finished: false
       },

--- a/webapp/public/murlan-royale.html
+++ b/webapp/public/murlan-royale.html
@@ -67,7 +67,7 @@
       .center {
         position: absolute;
         left: 50%;
-        top: 50%;
+        top: 45%;
         transform: translate(-50%, -50%);
         display: flex;
         gap: 10px;
@@ -92,6 +92,9 @@
       }
       .pile .card {
         transform: scale(1.3);
+      }
+      .pile .card:not(:first-child) {
+        margin-left: calc(var(--card-w) * -0.6);
       }
       .pile-player {
         display: flex;
@@ -439,13 +442,13 @@
       .seat.top .top-row {
         display: flex;
         align-items: center;
-        gap: 4px;
+        gap: 6px;
       }
       .seat.top .cards {
         gap: 0;
       }
       .seat.top .cards .card:not(:first-child) {
-        margin-left: calc(var(--card-w) * -0.4);
+        margin-left: calc(var(--card-w) * -0.6);
       }
 
       /* ICON CONTROLS */
@@ -805,7 +808,8 @@
           pot: 0,
           passesSincePlay: 0,
           lastPlayerToPlay: 0,
-          startPlayer: 0
+          startPlayer: 0,
+          selectedIndices: []
         };
 
         // create 4 players (user bottom)
@@ -835,7 +839,7 @@
 
         function findStartPlayer() {
           return state.players.findIndex((p) =>
-            p.hand.some((c) => c.r === 3 && c.s === '♣')
+            p.hand.some((c) => c.r === 3 && c.s === '♠')
           );
         }
 
@@ -962,8 +966,19 @@
               sorted.forEach((c, idx) => {
                 const face = cardFaceEl(c);
                 face.dataset.index = idx;
+                if (state.selectedIndices.includes(idx)) {
+                  face.classList.add('selected');
+                }
                 face.addEventListener('click', () => {
-                  face.classList.toggle('selected');
+                  const i = Number(face.dataset.index);
+                  const pos = state.selectedIndices.indexOf(i);
+                  if (pos > -1) {
+                    state.selectedIndices.splice(pos, 1);
+                    face.classList.remove('selected');
+                  } else {
+                    state.selectedIndices.push(i);
+                    face.classList.add('selected');
+                  }
                   sndChip.currentTime = 0;
                   sndChip.play();
                 });
@@ -1075,6 +1090,14 @@
           const arr = player.hand;
           const [c] = arr.splice(from, 1);
           arr.splice(to, 0, c);
+          if (player.isHuman) {
+            state.selectedIndices = state.selectedIndices.map((i) => {
+              if (i === from) return to;
+              if (from < to && i > from && i <= to) return i - 1;
+              if (from > to && i >= to && i < from) return i + 1;
+              return i;
+            });
+          }
         }
 
         function renderPile() {
@@ -1173,19 +1196,13 @@
 
         // ===== GAME FLOW (singles/pairs + simple AI) =====
         function collectSelected() {
-          const mySeat = seatsEl.querySelector('.seat.bottom .cards');
-          const faces = mySeat
-            ? Array.from(mySeat.querySelectorAll('.card:not(.back)'))
-            : [];
-          const sel = faces
-            .filter((f) => f.classList.contains('selected'))
-            .map((f) => ({
-              c: player(0).hand[Number(f.dataset.index)],
-              idx: Number(f.dataset.index)
-            }));
-          return sel;
+          return state.selectedIndices.map((i) => ({
+            c: player(0).hand[i],
+            idx: i
+          }));
         }
         function clearSelections() {
+          state.selectedIndices = [];
           seatsEl
             .querySelectorAll('.card.selected')
             .forEach((n) => n.classList.remove('selected'));


### PR DESCRIPTION
## Summary
- Tighten top player's card spacing and center table pile positioning
- Allow multi-card select/unselect for human player and remember selections
- Use 3♠ to determine starting player across UI and game logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac22eeb8f08329b951926df19390eb