### PR TITLE
Ensure Goal Rush save button is visible

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -56,6 +56,21 @@
     .coin-confetti{position:fixed;top:-40px;width:32px;height:32px;pointer-events:none;animation:coin-fall var(--duration,3s) linear forwards}
     @keyframes coin-fall{from{transform:translateY(-10vh) rotate(0deg);opacity:1}to{transform:translateY(100vh) rotate(360deg);opacity:0}}
 
+    #saveCalib{
+      position:absolute;
+      top:50%;
+      left:50%;
+      transform:translate(-50%,-50%);
+      display:block;
+      padding:8px 16px;
+      background:#00f7ff;
+      color:#fff;
+      border:none;
+      border-radius:8px;
+      font-size:14px;
+      z-index:10;
+    }
+
       .goal-text{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:48px;font-weight:800;color:var(--goal);text-align:center;display:none;pointer-events:none;line-height:1.1;-webkit-text-stroke:2px #000;text-shadow:-2px -2px 0 #000,2px -2px 0 #000,-2px 2px 0 #000,2px 2px 0 #000}
       .goal-text.own-goal{color:#ff0000;-webkit-text-stroke:2px #fff;text-shadow:-2px -2px 0 #fff,2px -2px 0 #fff,-2px 2px 0 #fff,2px 2px 0 #fff}
       .goal-text .score-line{display:block;font-size:32px;font-weight:600}
@@ -78,7 +93,7 @@
       </div>
     </div>
     <button id="muteBtn" class="mute-btn" aria-label="Toggle sound">🔊</button>
-    <button id="saveCalib" style="display:none">Save Calib</button>
+    <button id="saveCalib">Save Calib</button>
     <div class="canvasWrap">
       <canvas id="game" width="720" height="1280" aria-label="Goal Rush Field"></canvas>
     </div>
@@ -127,10 +142,7 @@
   const devAccount = params.get('dev');
   const devAccount1 = params.get('dev1');
   const devAccount2 = params.get('dev2');
-  if (devAccount || devAccount1 || devAccount2) {
-    saveCalibBtn.style.display = 'block';
-    saveCalibBtn.addEventListener('click', saveCalibration);
-  }
+  saveCalibBtn.addEventListener('click', saveCalibration);
   const tgId = params.get('tgId');
   const initParam = params.get('init');
   if (initParam && !window.Telegram) {


### PR DESCRIPTION
## Summary
- Always display the Goal Rush calibration save button and center it on the screen
- Attach handler for saving calibration without relying on dev parameters

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac280133b0832989c02b012bc3fe2c