### PR TITLE
Adjust Murlan Royale layout and straight combo rules

### DIFF
--- a/lib/murlan.js
+++ b/lib/murlan.js
@@ -72,11 +72,45 @@ export function isFlush(cards) {
 export function isStraight(cards, config = DEFAULT_CONFIG) {
   const sorted = sortHand(cards, config);
   const ranks = sorted.map((c) => rankValue(c.rank, config));
+  let sequential = true;
   for (let i = 1; i < ranks.length; i++) {
-    if (ranks[i] !== ranks[i - 1] + 1) return false;
+    if (ranks[i] !== ranks[i - 1] + 1) {
+      sequential = false;
+      break;
+    }
+  }
+  if (sequential) {
+    if (config.STRAIGHTS_REQUIRE_SAME_SUIT && !isFlush(cards)) return false;
+    return sorted.length >= config.MIN_STRAIGHT_LENGTH;
+  }
+  const hasAce = ranks.includes(rankValue('A', config));
+  if (!hasAce) return false;
+  const alt = cards
+    .map((c) => {
+      if (c.rank === 'A') return -1;
+      if (c.rank === '2') return 0;
+      return rankValue(c.rank, config);
+    })
+    .sort((a, b) => a - b);
+  for (let i = 1; i < alt.length; i++) {
+    if (alt[i] !== alt[i - 1] + 1) return false;
   }
   if (config.STRAIGHTS_REQUIRE_SAME_SUIT && !isFlush(cards)) return false;
-  return sorted.length >= config.MIN_STRAIGHT_LENGTH;
+  return cards.length >= config.MIN_STRAIGHT_LENGTH;
+}
+
+function aceLowValue(card, config = DEFAULT_CONFIG) {
+  if (card.rank === 'A') return -1;
+  if (card.rank === '2') return 0;
+  return rankValue(card.rank, config);
+}
+
+export function straightHighCard(cards, config = DEFAULT_CONFIG) {
+  if (!isStraight(cards, config)) return null;
+  const sorted = [...cards].sort(
+    (a, b) => aceLowValue(a, config) - aceLowValue(b, config)
+  );
+  return sorted[sorted.length - 1].rank;
 }
 
 export function isFullHouse(cards) {
@@ -112,27 +146,61 @@ export function detectCombo(cards, config = DEFAULT_CONFIG) {
   }
   if (n === 5 && config.enableFiveCard) {
     if (isStraightFlush(cards, config)) {
-      const high = sortHand(cards, config)[n - 1].rank;
-      return { type: ComboType.STRAIGHT_FLUSH, cards, keyRank: high, strength: 880 + rankValue(high, config) };
+      const high = straightHighCard(cards, config);
+      return {
+        type: ComboType.STRAIGHT_FLUSH,
+        cards,
+        keyRank: high,
+        strength: 880 + rankValue(high, config)
+      };
     }
     const counts = {};
     for (const c of cards) counts[c.rank] = (counts[c.rank] || 0) + 1;
     const quadRank = Object.keys(counts).find((r) => counts[r] === 4);
     if (quadRank) {
-      return { type: ComboType.BOMB_4K, cards, keyRank: quadRank, strength: 860 + rankValue(quadRank, config) };
+      return {
+        type: ComboType.BOMB_4K,
+        cards,
+        keyRank: quadRank,
+        strength: 860 + rankValue(quadRank, config)
+      };
     }
     if (isFullHouse(cards)) {
       const tripleRank = Object.keys(counts).find((r) => counts[r] === 3);
-      return { type: ComboType.FULL_HOUSE, cards, keyRank: tripleRank, strength: 840 + rankValue(tripleRank, config) };
+      return {
+        type: ComboType.FULL_HOUSE,
+        cards,
+        keyRank: tripleRank,
+        strength: 840 + rankValue(tripleRank, config)
+      };
     }
     if (isFlush(cards)) {
       const high = sortHand(cards, config)[n - 1].rank;
-      return { type: ComboType.FLUSH, cards, keyRank: high, strength: 820 + rankValue(high, config) };
+      return {
+        type: ComboType.FLUSH,
+        cards,
+        keyRank: high,
+        strength: 820 + rankValue(high, config)
+      };
     }
     if (isStraight(cards, config)) {
-      const high = sortHand(cards, config)[n - 1].rank;
-      return { type: ComboType.STRAIGHT, cards, keyRank: high, strength: 800 + rankValue(high, config) };
+      const high = straightHighCard(cards, config);
+      return {
+        type: ComboType.STRAIGHT,
+        cards,
+        keyRank: high,
+        strength: 800 + rankValue(high, config)
+      };
     }
+  }
+  if (n >= config.MIN_STRAIGHT_LENGTH && isStraight(cards, config)) {
+    const high = straightHighCard(cards, config);
+    return {
+      type: ComboType.STRAIGHT,
+      cards,
+      keyRank: high,
+      strength: 800 + rankValue(high, config)
+    };
   }
   return null;
 }
@@ -153,7 +221,7 @@ export function canBeat(candidate, onTable, config = DEFAULT_CONFIG) {
 }
 
 
-function generateSubsets(hand, max = 5) {
+function generateSubsets(hand, max = hand.length) {
   const result = [];
   const n = hand.length;
   const recurse = (start, subset) => {
@@ -171,7 +239,7 @@ function generateSubsets(hand, max = 5) {
 
 export function legalCombosFromHand(hand, onTable, config = DEFAULT_CONFIG) {
   const all = [];
-  const subsets = generateSubsets(hand, 5);
+  const subsets = generateSubsets(hand, hand.length);
   for (const s of subsets) {
     const c = detectCombo(s, config);
     if (c && canBeat(c, onTable, config)) all.push(c);

--- a/webapp/public/murlan-royale.html
+++ b/webapp/public/murlan-royale.html
@@ -66,7 +66,7 @@
       /* CENTER: community pile + pot */
       .center {
         position: absolute;
-        left: 50%;
+        left: 52%;
         top: 45%;
         transform: translate(-50%, -50%);
         display: flex;
@@ -608,6 +608,7 @@
         const el = (s) => document.querySelector(s);
         const pileEl = el('#pile');
         const pilePlayerEl = el('#pilePlayer');
+        const centerEl = el('.center');
         const seatsEl = el('#seats');
         const potEl = el('#pot');
         const toastEl = el('#toast');
@@ -918,7 +919,7 @@
             } else if (side === 'top') {
               seat.style.left = '50%';
               seat.style.top = '8px';
-              seat.style.transform = 'translateX(-55%)';
+              seat.style.transform = 'translateX(-60%)';
               seat.style.width = 'auto';
             } else if (side === 'right') {
               seat.style.left = x - area.left - 20 + 'px';
@@ -1100,9 +1101,25 @@
           }
         }
 
+        function updateCenterPosition() {
+          const count = state.pile.length;
+          if (count > 3) {
+            const topSeat = document.querySelector('.seat.top');
+            const stageRect = el('.stage').getBoundingClientRect();
+            const seatRect = topSeat ? topSeat.getBoundingClientRect() : { bottom: 0 };
+            const gap = 10;
+            centerEl.style.top = seatRect.bottom - stageRect.top + gap + 'px';
+            centerEl.style.transform = 'translate(-50%, 0)';
+          } else {
+            centerEl.style.top = '45%';
+            centerEl.style.transform = 'translate(-50%, -50%)';
+          }
+        }
+
         function renderPile() {
           pileEl.innerHTML = '';
           pilePlayerEl.innerHTML = '';
+          updateCenterPosition();
           if (!state.pile.length) return;
           const scale = state.pile.length > 6 ? 1.1 : 1.3;
           state.pile.forEach((c) => {


### PR DESCRIPTION
## Summary
- Nudge top player avatar left and shift center pile right
- Move center pile upward when it holds more than three cards
- Support 5+ card straights with flexible Ace placement and update combo generation

## Testing
- `npm test`
- `npm run lint` *(fails: 1250 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2ca8b6f483298c83d5f02fd6ec6d