### PR TITLE
Allow calibration saving without dev accounts

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -157,7 +157,10 @@ app.post('/api/goal-rush/calibration', (req, res) => {
     process.env.DEV_ACCOUNT_ID_1 || process.env.VITE_DEV_ACCOUNT_ID_1,
     process.env.DEV_ACCOUNT_ID_2 || process.env.VITE_DEV_ACCOUNT_ID_2
   ].filter(Boolean);
-  if (!accountId || !devAccounts.includes(accountId)) {
+  if (
+    devAccounts.length &&
+    (!accountId || !devAccounts.includes(accountId))
+  ) {
     return res.status(403).json({ error: 'unauthorized' });
   }
   if (!calibration || typeof calibration !== 'object') {


### PR DESCRIPTION
## Summary
- allow Goal Rush calibration saving when no dev accounts configured

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, prefer-const)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2d46cc2c8329900d8962bc6ec3e4