### PR TITLE
Refine Murlan Royale layout and add turn indicator sound

### DIFF
--- a/webapp/public/murlan-royale.html
+++ b/webapp/public/murlan-royale.html
@@ -66,7 +66,7 @@
       /* CENTER: community pile + pot */
       .center {
         position: absolute;
-        left: 52%;
+        left: 50%;
         top: 45%;
         transform: translate(-50%, -50%);
         display: flex;
@@ -108,14 +108,7 @@
         border: 2px solid rgba(255, 255, 255, 0.65);
       }
       .pot {
-        font-weight: 900;
-        letter-spacing: 0.3px;
-        color: #ffeaa7;
-        background: rgba(0, 0, 0, 0.28);
-        padding: 6px 12px;
-        border-radius: 12px;
-        border: 1px solid rgba(255, 255, 255, 0.12);
-        text-shadow: 0 2px 6px #000;
+        display: none;
       }
 
       /* PLAYERS ON TABLE PERIMETER  (user fixed bottom) */
@@ -452,12 +445,13 @@
       .seat.top .top-row {
         display: flex;
         align-items: center;
-        gap: 8px;
+        justify-content: space-between;
+        gap: 12px;
         padding: 0 6px;
       }
       .seat.top .seat-inner {
-        padding-left: 8px;
-        padding-right: 8px;
+        padding-left: 12px;
+        padding-right: 12px;
       }
       .seat.top .cards {
         gap: 0;
@@ -581,6 +575,10 @@
       id="sndTimer"
       src="https://cdn.jsdelivr.net/gh/naptha/tiny-sound@master/sounds/beep1.ogg"
     ></audio>
+    <audio
+      id="sndTurn"
+      src="/assets/sounds/wooden-door-knock-102902.mp3"
+    ></audio>
 
     <div class="top-controls">
       <button id="settingsBtn">⚙️</button>
@@ -630,6 +628,7 @@
         const sndChip = el('#sndChip');
         const sndCard = el('#sndCard');
         const sndTimer = el('#sndTimer');
+        const sndTurn = el('#sndTurn');
         const winnerOverlay = el('#winnerOverlay');
         const settingsBtn = el('#settingsBtn');
         const settingsPanel = el('#settingsPanel');
@@ -1200,7 +1199,7 @@
         function renderAll() {
           posSeats();
           renderPile();
-          potEl.textContent = comboLabel(state.lastPlayType);
+          if (potEl) potEl.textContent = '';
           updateTimerDisplay();
           adjustHandScale();
           setupZoom();
@@ -1228,6 +1227,8 @@
           });
         }
         function startTurnTimer() {
+          sndTurn.currentTime = 0;
+          sndTurn.play();
           state.turnTime = state.players[state.turn].isHuman ? 20 : 5;
           updateTimerDisplay();
           clearInterval(timerInterval);


### PR DESCRIPTION
## Summary
- Widen top player frame and add spacing between avatar and cards
- Center table pile and hide combo text next to cards
- Play wooden knock sound on each turn change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac3b2b5bac83298354ce1be61afa6c