### PR TITLE
Fix Goal Rush canvas sizing on Chrome

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -30,8 +30,8 @@
 
     .canvasWrap{
       position:absolute;
-      top:40px;
-      bottom:20px;
+      top:0;
+      bottom:0;
       left:0;
       right:0;
       display:flex;
@@ -287,7 +287,7 @@
   function fit(){
     const ratio = 1280 / 720;
     const maxWidth = window.innerWidth;
-    const maxHeight = window.innerHeight - TOP_BAR - BOTTOM_GAP;
+    const maxHeight = Math.max(window.innerHeight, window.screen.height) - TOP_BAR - BOTTOM_GAP;
     let width = maxWidth;
     let height = width * ratio;
     if (height > maxHeight) {


### PR DESCRIPTION
## Summary
- allow Goal Rush canvas to use full viewport height and width
- compute game area using screen height to reduce side bars on mobile Chrome

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, 'inc' is never reassigned. Use 'const' instead)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3c53334c832997ebb7923e7b970b