### PR TITLE
Adjust Murlan Royale layout and show card counts

### DIFF
--- a/webapp/public/murlan-royale.html
+++ b/webapp/public/murlan-royale.html
@@ -178,6 +178,7 @@
         padding: 0;
         border: none;
         background: none;
+        position: relative;
       }
       .seat-inner .card {
         border: none;
@@ -459,6 +460,27 @@
       .seat.top .cards .card:not(:first-child) {
         margin-left: calc(var(--card-w) * -0.6);
       }
+      .seat.top .top-row .avatar {
+        margin-left: -8px;
+      }
+      .seat.top .top-row .cards {
+        margin-right: -8px;
+      }
+
+      .card-count {
+        position: absolute;
+        top: -6px;
+        right: -6px;
+        background: var(--gold);
+        color: #000;
+        font-size: 10px;
+        font-weight: 700;
+        line-height: 1;
+        padding: 2px 4px;
+        border-radius: 50%;
+        box-shadow: 0 0 0 2px #000;
+        z-index: 2;
+      }
 
       /* ICON CONTROLS */
       .icon-btn {
@@ -499,7 +521,7 @@
       .auto-btn {
         position: fixed;
         left: 8px;
-        bottom: calc(var(--card-h) * var(--my-card-scale) + 8px);
+        bottom: calc(var(--card-h) * var(--my-card-scale) + 24px);
         z-index: 5;
       }
       .lobby-btn {
@@ -1046,6 +1068,10 @@
                 b.style.setProperty('--rot', (k - show / 2) * 2 + 'deg');
                 cards.appendChild(b);
               }
+              const countEl = document.createElement('div');
+              countEl.className = 'card-count';
+              countEl.textContent = count;
+              cards.appendChild(countEl);
             }
 
             const timer = document.createElement('div');


### PR DESCRIPTION
## Summary
- Tweak top player layout so avatar and cards have better spacing
- Lift auto-arrange button slightly above player cards
- Show a small yellow badge on opponents' card stacks indicating remaining cards

## Testing
- `node --test`
- `npm run lint` *(fails: React version warning and many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac53251c788329822e057d7f21552d