### PR TITLE
Add countdown and payouts to Penalty Kick

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -64,8 +64,22 @@
     bottom:env(safe-area-inset-bottom,10px);z-index:96}
   .ribbon{background:var(--panel);border:1px solid var(--panel-b);border-radius:12px;padding:8px 12px;text-align:center;font-size:14px}
 
-  /* tests */
-  .testbar{position:fixed;right:12px;bottom:12px;z-index:120;background:#0f172acc;color:#bfe1ff;border:1px solid #1c244a;border-radius:10px;padding:6px 10px;font:12px/1.2 monospace;max-width:64vw}
+  /* overlays */
+  .countdown{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;font-weight:bold;color:#fff;background:rgba(0,0,0,0.5);z-index:150}
+  .countdown.hidden{display:none}
+  .winnerOverlay{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.5);z-index:140}
+  .winnerOverlay.hidden{display:none}
+  .winnerOverlay img{width:120px;height:120px;border-radius:50%}
+  dialog{border:0;border-radius:12px;padding:0;background:transparent}
+  dialog::backdrop{background:rgba(0,0,0,0.5)}
+  .modal{background:var(--panel);border:1px solid var(--panel-b);border-radius:12px;padding:12px;width:260px;color:var(--txt)}
+  .grid{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+  .grid.two{grid-template-columns:1fr 1fr}
+  .kpi{text-align:center;background:#0f1a3a;border:1px solid var(--panel-b);border-radius:10px;padding:6px}
+  .kpi .v{font-weight:800}
+  .btn{background:var(--accent);color:#fff;border:none;border-radius:10px;padding:6px 10px;font-weight:800;flex:1}
+  .coin-confetti{position:fixed;top:-40px;width:32px;height:32px;pointer-events:none;animation:coin-fall var(--duration,3s) linear forwards}
+  @keyframes coin-fall{from{transform:translateY(-10vh) rotate(0deg);opacity:1}to{transform:translateY(100vh) rotate(360deg);opacity:0}}
 
   @media (max-width: 420px){
     .hud{grid-template-columns:1fr}
@@ -107,36 +121,43 @@
     </div>
   </div>
 
-  <div class="hud" id="hud">
-    <div class="panel"><div><div class="meta">You</div><div class="meta" id="time">Time: 00:30</div></div><div class="score" id="myScore">0</div></div>
-    <div class="panel">
-      <div><div class="meta">Arcade • 30s</div><div class="meta">Hold ball & flick upward. Curve adds spin.</div></div>
-      <div class="btns">
-        <button id="startBtn">Start</button>
-        <button class="ghost" id="regen">New Targets</button>
-        <button class="ghost" id="aimBtn">Aim: ON</button>
-        <button class="warn" id="pauseBtn">Pause</button>
-      </div>
-    </div>
-    <div class="panel"><div class="meta">Leader</div><div class="score" id="leaderScore">0</div></div>
-  </div>
-
   <div class="pbar" id="pbar">
     <div style="display:flex;align-items:center;gap:10px"><img class="avatar" id="userAvatar" alt="" /><div id="username">You</div></div>
     <div class="badge hearts">❤❤❤</div>
     <div class="badge">Time <span id="timeShort">30</span>s</div>
     <div class="badge">Pot <span class="pot">400</span></div>
+    <div class="badge">Score <span id="scoreShort">0</span></div>
   </div>
 
   <div class="stage"><div class="frame"></div><div class="label">Score: <span id="scoreLabel">0</span></div></div>
 
-  <div class="bottom"><div class="ribbon" id="status">Tap & hold the ball. Flick upward to shoot. Curve your swipe for spin. Highest score in 30s wins.</div></div>
+  <div class="bottom"><div class="ribbon" id="status">Tap & hold the ball. Flick upward to shoot. Curve your swipe for spin. Highest score wins.</div></div>
   <div class="power" aria-hidden="true"><div class="bar" id="powerBar"></div></div>
 
-  <div class="testbar" id="testbar">tests: (pending)</div>
+  <div id="countdown" class="countdown hidden"></div>
+  <dialog id="results">
+    <div class="modal">
+      <h2>Round results</h2>
+      <div class="grid two">
+        <div class="kpi"><div class="v" id="winner">-</div><div>Winner</div></div>
+        <div class="kpi"><div class="v" id="payout">0</div><div>Payout TPC</div></div>
+      </div>
+      <div class="grid" style="margin-top:10px">
+        <div class="kpi"><div class="v" id="fee">0</div><div>Fee 10%</div></div>
+        <div class="kpi"><div class="v" id="potFinal">0</div><div>Final Pot</div></div>
+      </div>
+      <div class="grid" id="scoreList" style="margin-top:10px"></div>
+      <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:8px">
+        <button class="btn" id="rematch">Play Again</button>
+        <button class="btn" id="lobby">Return to Lobby</button>
+      </div>
+    </div>
+  </dialog>
+  <div id="winnerOverlay" class="winnerOverlay hidden"></div>
 
   <canvas id="game" aria-label="Penalty field"></canvas>
 
+<script src="/falling-ball-api.js"></script>
 <script>
 (()=> {
   // ===== Canvas =====
@@ -153,36 +174,33 @@
   addEventListener('resize', resize);
 
   // ===== UI refs =====
-  const myScoreEl = document.getElementById('myScore');
-  const leaderEl  = document.getElementById('leaderScore');
-  const timeEl    = document.getElementById('time');
   const timeShort = document.getElementById('timeShort');
+  const scoreShort = document.getElementById('scoreShort');
   const scoreLbl  = document.getElementById('scoreLabel');
   const statusEl  = document.getElementById('status');
   const powerBar  = document.getElementById('powerBar');
-  const btnStart  = document.getElementById('startBtn');
-  const btnRegen  = document.getElementById('regen');
-  const btnAim    = document.getElementById('aimBtn');
-  const btnPause  = document.getElementById('pauseBtn');
-  const hudEl     = document.getElementById('hud');
   const previewsEl= document.getElementById('previews');
+  const pbarEl    = document.getElementById('pbar');
   const userAvatarEl = document.getElementById('userAvatar');
   const usernameEl = document.getElementById('username');
   const pvAvatars = [document.getElementById('pv0avatar'), document.getElementById('pv1avatar'), document.getElementById('pv2avatar')];
   const pvNames   = [document.getElementById('pv0name'), document.getElementById('pv1name'), document.getElementById('pv2name')];
-  const testbar   = document.getElementById('testbar');
 
   function positionLayout(){
     const pr = previewsEl.getBoundingClientRect();
-    hudEl.style.top = (pr.bottom + 8) + 'px';
-    const hr = hudEl.getBoundingClientRect();
-    document.getElementById('pbar').style.top = (hr.bottom + 16) + 'px';
-    document.querySelector('.stage').style.top = (hr.bottom + 16 + 56 + 10) + 'px';
+    pbarEl.style.top = (pr.bottom + 12) + 'px';
+    const br = pbarEl.getBoundingClientRect();
+    document.querySelector('.stage').style.top = (br.bottom + 16) + 'px';
   }
 
   const params = new URLSearchParams(location.search);
   const avatarParam = params.get('avatar') || '';
   let userName = params.get('name') || params.get('username') || '';
+  const stake = Math.max(0, parseInt(params.get('amount'),10)||100);
+  const durationParam = Math.max(10, parseInt(params.get('duration'),10)||30);
+  const n = 4;
+  const tgId = params.get('tgId');
+  const accountId = params.get('accountId');
 
   function emojiToDataUri(flag){
     return `data:image/svg+xml,${encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='64' height='64'><text x='50%' y='50%' font-size='48' text-anchor='middle' dominant-baseline='central'>${flag}</text></svg>`)}`;
@@ -192,6 +210,18 @@
     const pts = [...flag].map(c=>c.codePointAt(0)-127397);
     const code = String.fromCharCode(...pts);
     return regionNames.of(code) || flag;
+  }
+
+  function coinConfetti(count=50, iconSrc='/assets/icons/ezgif-54c96d8a9b9236.webp'){
+    for(let i=0;i<count;i++){
+      const img=document.createElement('img');
+      img.src=iconSrc;
+      img.className='coin-confetti';
+      img.style.left=Math.random()*100+'vw';
+      img.style.setProperty('--duration',(2+Math.random()*2)+'s');
+      document.body.appendChild(img);
+      setTimeout(()=>img.remove(),3000);
+    }
   }
 
   if(!userName){
@@ -216,7 +246,11 @@
     const flag = flags[(Math.random()*flags.length)|0];
     if(pvAvatars[i]) pvAvatars[i].src = emojiToDataUri(flag);
     if(pvNames[i]) pvNames[i].textContent = flagName(flag);
+    rivals[i].name = flagName(flag);
+    rivals[i].avatar = pvAvatars[i].src;
   }
+  document.querySelector('.pot').textContent = String(stake * n);
+  timeShort.textContent = durationParam;
   positionLayout();
 
   // ===== Geometry =====
@@ -230,7 +264,7 @@
   }
 
   // ===== Game state =====
-  const ROUND_TIME = 30_000;
+  const ROUND_TIME = durationParam * 1000;
   let roundStart = 0; let timeLeft = ROUND_TIME; let running=false; let paused=false; let ended=false;
   let myScore = 0;
 
@@ -240,9 +274,9 @@
   let holes=[]; let banners=[]; let cameras=[];
 
   const rivals=[
-    { i:0, wrap:document.querySelector('#pv0'), ptsEl:document.querySelector('#pv0pts'), cvs:null, ctx:null, score:0, next:0, acc:0.68, rate:[520,900] },
-    { i:1, wrap:document.querySelector('#pv1'), ptsEl:document.querySelector('#pv1pts'), cvs:null, ctx:null, score:0, next:0, acc:0.62, rate:[560,980] },
-    { i:2, wrap:document.querySelector('#pv2'), ptsEl:document.querySelector('#pv2pts'), cvs:null, ctx:null, score:0, next:0, acc:0.58, rate:[600,1050] },
+    { i:0, wrap:document.querySelector('#pv0'), ptsEl:document.querySelector('#pv0pts'), cvs:null, ctx:null, score:0, next:0, acc:0.68, rate:[520,900], name:'', avatar:'' },
+    { i:1, wrap:document.querySelector('#pv1'), ptsEl:document.querySelector('#pv1pts'), cvs:null, ctx:null, score:0, next:0, acc:0.62, rate:[560,980], name:'', avatar:'' },
+    { i:2, wrap:document.querySelector('#pv2'), ptsEl:document.querySelector('#pv2pts'), cvs:null, ctx:null, score:0, next:0, acc:0.58, rate:[600,1050], name:'', avatar:'' },
   ];
   const miniHolesCache=[[],[],[]];
   for(const r of rivals){ r.cvs = r.wrap.querySelector('canvas'); r.ctx = r.cvs.getContext('2d'); }
@@ -359,7 +393,7 @@
   }
 
   // ===== Aim guide =====
-  let aimOn=true; btnAim.addEventListener('click', ()=>{ aimOn=!aimOn; btnAim.textContent = `Aim: ${aimOn?'ON':'OFF'}`; });
+  let aimOn=true;
   function drawAimPath(vx,vy,spin){
     if(!aimOn) return;
     const steps=28; let x=ball.x, y=ball.y, vx1=vx, vy1=vy;
@@ -375,9 +409,49 @@
 
   // ===== Round / scoring =====
   function endShot(hit,pts){ ball.moving=false; if(hit){ myScore += pts; status('GOAL! +' + pts); sfxGoal(); vibrate(25);} else { status('Missed.'); sfxMiss(); vibrate(12);} updateHUD(); setTimeout(resetBall, 200); }
-  function updateHUD(){ myScoreEl.textContent = myScore; scoreLbl.textContent = myScore; const lead = Math.max(myScore, ...rivals.map(r=>r.score)); leaderEl.textContent = lead; timeEl.textContent = `Time: ${fmtTime(timeLeft)}`; timeShort.textContent = Math.ceil(timeLeft/1000); }
-  function fmtTime(ms){ const s=Math.max(0, Math.ceil(ms/1000)); const m=Math.floor(s/60); const ss=String(s%60).padStart(2,'0'); return `${m}:${ss}`; }
-  function finish(){ running=false; ended=true; const all=[{n:'You',s:myScore},{n:'Canada',s:rivals[0].score},{n:'France',s:rivals[1].score},{n:'Germany',s:rivals[2].score}].sort((a,b)=>b.s-a.s); status(`Winner: ${all[0].n} with ${all[0].s} pts. Tap Start to play again.`); sfxEnd(); }
+  function updateHUD(){ scoreLbl.textContent = myScore; scoreShort.textContent = myScore; timeShort.textContent = Math.ceil(timeLeft/1000); }
+  async function finish(){
+    running=false; ended=true;
+    const all=[{n:userName,s:myScore,avatar:userAvatar,accountId,tgId}];
+    for(const r of rivals){ all.push({n:r.name,s:r.score,avatar:r.avatar}); }
+    all.sort((a,b)=>b.s-a.s);
+    const gross = stake * n;
+    const fee = Math.round(gross*0.10);
+    const net = gross - fee;
+    const winners = all.filter(p=>p.s===all[0].s);
+    const payout = winners.length? Math.floor(net / winners.length) : 0;
+    const overlay = document.getElementById('winnerOverlay');
+    if(all[0].avatar){ overlay.innerHTML = `<img src="${all[0].avatar}"/>`; }
+    overlay.classList.remove('hidden');
+    coinConfetti(50);
+    if(winners.some(w=>w.n===userName) && accountId){
+      try{
+        await fbApi.depositAccount(accountId, payout, {game:'penaltykick-win'});
+        if(tgId) await fbApi.addTransaction(tgId, 0, 'win', {game:'penaltykick', players:n, accountId});
+      }catch{}
+    }
+    setTimeout(()=>{ overlay.classList.add('hidden'); showResults(all,payout,fee,net); },2000);
+    sfxEnd();
+  }
+
+  function showResults(all,payout,fee,net){
+    document.getElementById('winner').textContent = all[0].n;
+    document.getElementById('payout').textContent = String(payout);
+    document.getElementById('fee').textContent = String(fee);
+    document.getElementById('potFinal').textContent = String(net);
+    document.getElementById('scoreList').innerHTML = all.map(p=>`<div class="kpi"><div class="v">${p.n}: ${p.s}</div><div>—</div></div>`).join('');
+    document.getElementById('results').showModal();
+  }
+
+  function countdownAndStart(){
+    const cd = document.getElementById('countdown');
+    let c = 3; cd.textContent = c; cd.classList.remove('hidden');
+    const timer = setInterval(()=>{
+      c--;
+      if(c>0){ cd.textContent = c; }
+      else { clearInterval(timer); cd.classList.add('hidden'); startGame(); }
+    },1000);
+  }
   function status(msg){ statusEl.textContent = msg; }
 
   // ===== Input (swipe/flick + spin) =====
@@ -416,13 +490,10 @@
   function stepRivals(now){ if(!running||paused) return; const t = 1 - (timeLeft/ROUND_TIME); for(let i=0;i<rivals.length;i++){ const r=rivals[i]; if(now>r.next){ r.next = now + rnd(r.rate[0], r.rate[1]) * (1 - 0.45*t); const list = Array.isArray(miniHolesCache[i]) ? miniHolesCache[i] : []; if(list.length===0){ genMiniHolesForCard(i); continue; } const target = Math.random()<0.35 ? list.slice().sort((a,b)=>a.r-b.r)[0] : list[Math.floor(Math.random()*list.length)]; const acc = clamp(r.acc * (0.9 + 0.5*t), 0, 0.98); const chance = acc * (22/Math.max(10,target.r)); if(Math.random() < chance){ r.score += Math.max(5, Math.round(target.p)); sfxRival(); } } r.ptsEl.textContent = r.score; } }
 
   // ===== Timer + loop =====
-  function tick(now){ if(!running||paused) return; if(!roundStart) roundStart=now; timeLeft = Math.max(0, ROUND_TIME - (now - roundStart)); timeEl.textContent = `Time: ${fmtTime(timeLeft)}`; timeShort.textContent = Math.ceil(timeLeft/1000); if(timeLeft<=0){ finish(); } }
+  function tick(now){ if(!running||paused) return; if(!roundStart) roundStart=now; timeLeft = Math.max(0, ROUND_TIME - (now - roundStart)); timeShort.textContent = Math.ceil(timeLeft/1000); if(timeLeft<=0){ finish(); } }
   function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoal(); drawBall(); stepBall(); tick(now||performance.now()); stepRivals(now||performance.now()); updateHUD(); }
 
   // ===== Controls =====
-  btnStart.addEventListener('click', ()=> startGame());
-  btnRegen.addEventListener('click', ()=>{ generateHoles(); status('Targets regenerated.'); drawMiniBoards(true); });
-  btnPause.addEventListener('click', ()=>{ if(!running) return; paused=!paused; btnPause.textContent = paused? 'Resume' : 'Pause'; status(paused? 'Paused' : 'Go!'); });
 
   function resetBall(){ ball.x=geom.spot.x; ball.y=geom.spot.y; ball.vx=ball.vy=ball.spin=0; ball.moving=false; ball.trail=[]; }
   function startGame(){ running=true; paused=false; ended=false; roundStart=performance.now(); timeLeft=ROUND_TIME; myScore=0; for(const r of rivals){ r.score=0; r.next=0; } resetBall(); generateHoles(); drawMiniBoards(true); updateHUD(); ensureAudio(); sfxStart(); status('Go! Score as many as you can.'); }
@@ -440,10 +511,11 @@
 
   // ===== Static draw & tests =====
   function drawStaticOnce(){ drawField(); drawAds(); drawGoal(); resetBall(); drawBall(); drawMiniBoards(true); }
-  function runSmokeTests(){ const T=[]; const ok=(n,c)=>T.push(`${c?'✅':'❌'} ${n}`); ok('canvas present', !!canvas); ok('rivals length=3', rivals.length===3); ok('mini caches arrays', Array.isArray(miniHolesCache[0])&&Array.isArray(miniHolesCache[1])&&Array.isArray(miniHolesCache[2])); generateHoles(); ok('holes count >=6', holes.length>=6); ok('startGame sets running', (function(){ startGame(); return running; })()); ok('ball at spot', Math.abs(ball.x-geom.spot.x)<1 && Math.abs(ball.y-geom.spot.y)<1); document.getElementById('testbar').textContent = 'tests: ' + T.join('  |  '); }
 
   // ===== Boot =====
-  function boot(){ resize(); initBanners(); initCameras(); drawStaticOnce(); requestAnimationFrame(loop); canvas.addEventListener('pointerdown', ()=>{ if(!running||ended) startGame(); ensureAudio(); }, {once:false}); runSmokeTests(); }
+  function boot(){ resize(); initBanners(); initCameras(); drawStaticOnce(); requestAnimationFrame(loop); canvas.addEventListener('pointerdown', ensureAudio, {once:true}); countdownAndStart(); }
+  document.getElementById('rematch').addEventListener('click', ()=>{ document.getElementById('results').close(); countdownAndStart(); });
+  document.getElementById('lobby').addEventListener('click', ()=>{ document.getElementById('results').close(); location.href='/games/penaltykick/lobby'; });
   boot();
 })();
 </script>

--- a/webapp/src/pages/Games/PenaltyKickLobby.jsx
+++ b/webapp/src/pages/Games/PenaltyKickLobby.jsx
@@ -12,6 +12,7 @@ export default function PenaltyKickLobby() {
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState('ai');
   const [players, setPlayers] = useState(2);
+  const [duration, setDuration] = useState(30);
 
   const startGame = async () => {
     let tgId;
@@ -36,6 +37,7 @@ export default function PenaltyKickLobby() {
     if (mode === 'online') {
       params.set('players', players);
     }
+    if (duration) params.set('duration', duration);
     if (stake.token) params.set('token', stake.token);
     if (stake.amount) params.set('amount', stake.amount);
     if (tgId) params.set('tgId', tgId);
@@ -79,6 +81,20 @@ export default function PenaltyKickLobby() {
           </div>
         </div>
       )}
+      <div className="space-y-2">
+        <h3 className="font-semibold">Duration</h3>
+        <div className="flex gap-2">
+          {[30, 60, 180].map((d) => (
+            <button
+              key={d}
+              onClick={() => setDuration(d)}
+              className={`lobby-tile ${duration === d ? 'lobby-selected' : ''}`}
+            >
+              {d < 60 ? `${d}s` : d === 60 ? '1m' : '3m'}
+            </button>
+          ))}
+        </div>
+      </div>
       <div className="space-y-2">
         <h3 className="font-semibold">Stake</h3>
         <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />


### PR DESCRIPTION
## Summary
- allow players to select 30s, 1m, or 3m rounds in the Penalty Kick lobby
- restructure Penalty Kick layout with opponent row, player bar score, countdown, and winner popup
- credit winners via TPC payout using existing API

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, 'inc' is never reassigned...)*

------
https://chatgpt.com/codex/tasks/task_e_68ac69fb15288329b866bcbf21d65ce8