### PR TITLE
Adjust penalty kick layout

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -33,8 +33,8 @@
 
   /* ===== Rivals row ===== */
   .previews{position:fixed;left:env(safe-area-inset-left,12px);right:env(safe-area-inset-right,12px);
-    top:env(safe-area-inset-top,10px);z-index:90;display:grid;grid-template-columns:repeat(3,1fr);gap:12px}
-  .pcard{background:var(--panel);border:1px solid var(--panel-b);border-radius:18px;padding:10px;min-height:120px;display:grid;gap:8px}
+    top:env(safe-area-inset-top,10px);z-index:90;display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+  .pcard{background:var(--panel);border:1px solid var(--panel-b);border-radius:18px;padding:6px;min-height:80px;display:grid;gap:6px}
   .phead{display:flex;align-items:center;justify-content:space-between;font-weight:800;gap:6px}
   .phead .avatar{width:20px;height:14px;border-radius:2px;object-fit:cover}
   .ppts{color:var(--pts);font-weight:900}
@@ -42,7 +42,7 @@
 
   /* ===== Player bar ===== */
   .pbar{position:fixed;left:env(safe-area-inset-left,12px);right:env(safe-area-inset-right,12px);
-    z-index:95;display:flex;align-items:center;gap:12px;background:var(--panel);
+    z-index:95;display:flex;flex-direction:column;align-items:flex-start;gap:4px;background:var(--panel);
     border:1px solid var(--panel-b);border-radius:16px;padding:10px 12px}
   .avatar{width:28px;height:28px;border-radius:50%;background:linear-gradient(135deg,#22c55e,#2563eb);box-shadow:0 0 0 2px #081027 inset}
   .badge{background:#0f1a3a;border:1px solid var(--panel-b);color:var(--txt);padding:6px 10px;border-radius:12px;font-weight:800;font-size:12px}
@@ -52,8 +52,8 @@
   /* ===== Stage label area (visual only) ===== */
   .stage{position:fixed;left:env(safe-area-inset-left,12px);right:env(safe-area-inset-right,12px);
     top:calc(env(safe-area-inset-top,10px) + 70px + 128px + 16px + 56px + 10px);
-    bottom:env(safe-area-inset-bottom,72px);z-index:80}
-  .stage .frame{position:absolute;inset:0;border-radius:18px;border:1px solid var(--panel-b);background:var(--panel)}
+    bottom:env(safe-area-inset-bottom,72px);z-index:80;pointer-events:none}
+  .stage .frame{position:absolute;inset:0;border-radius:18px;border:1px solid var(--panel-b);pointer-events:none}
   .stage .label{position:absolute;left:18px;top:14px;font-weight:800}
 
   /* ===== Power bar & bottom ribbon ===== */
@@ -68,7 +68,6 @@
 
   @media (max-width: 420px){
     .hud{grid-template-columns:1fr}
-    .previews{grid-template-columns:1fr 1fr}
   }
 </style>
 </head>
@@ -109,7 +108,7 @@
   <div class="pbar" id="pbar">
     <div style="display:flex;align-items:center;gap:10px"><img class="avatar" id="userAvatar" alt="" /><div id="username">You</div></div>
     <div class="badge hearts">❤❤❤</div>
-    <div class="badge">Time <span id="timeShort">30</span>s</div>
+      <div class="badge">Time <span id="timeShort">17</span>s</div>
     <div class="badge">Pot <span class="pot">400</span></div>
   </div>
 
@@ -153,7 +152,7 @@
   const params = new URLSearchParams(location.search);
   const avatarParam = params.get('avatar') || '';
   let userName = params.get('name') || params.get('username') || '';
-  const durationParam = parseInt(params.get('duration')) || 30;
+  const durationParam = parseInt(params.get('duration')) || 17;
   timeShort.textContent = durationParam;
 
   function emojiToDataUri(flag){


### PR DESCRIPTION
## Summary
- Shrink rival preview cards so three fit on one row
- Stack player info vertically below rivals and show 17s default timer
- Make playfield frame transparent and non-blocking

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, 'inc' is never reassigned. Use 'const' instead)*

------
https://chatgpt.com/codex/tasks/task_e_68ac79062918832993f0f0997be82b51