### PR TITLE
Refine penalty kick visuals and gameplay

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -42,7 +42,7 @@
 
   /* ===== Player bar ===== */
   .pbar{position:fixed;left:env(safe-area-inset-left,12px);right:env(safe-area-inset-right,12px);
-    z-index:95;display:flex;flex-direction:column;align-items:flex-start;gap:4px;background:var(--panel);
+    z-index:95;display:flex;align-items:center;gap:8px;background:var(--panel);
     border:1px solid var(--panel-b);border-radius:16px;padding:10px 12px}
   .avatar{width:28px;height:28px;border-radius:50%;background:linear-gradient(135deg,#22c55e,#2563eb);box-shadow:0 0 0 2px #081027 inset}
   .badge{background:#0f1a3a;border:1px solid var(--panel-b);color:var(--txt);padding:6px 10px;border-radius:12px;font-weight:800;font-size:12px}
@@ -128,7 +128,11 @@
     W = Math.floor(window.innerWidth); H = Math.floor(window.innerHeight);
     canvas.width = Math.floor(W*DPR); canvas.height = Math.floor(H*DPR);
     ctx.setTransform(DPR,0,0,DPR,0,0);
-    layout(); positionLayout(); drawStaticOnce();
+    positionLayout();
+    layout();
+    initBanners();
+    initCameras();
+    drawStaticOnce();
   }
   addEventListener('resize', resize);
 
@@ -145,14 +149,14 @@
   function positionLayout(){
     const pr = previewsEl.getBoundingClientRect();
     const pbar = document.getElementById('pbar');
-    pbar.style.top = (pr.bottom + 16) + 'px';
+    pbar.style.top = (pr.bottom + 8) + 'px';
     document.querySelector('.stage').style.top = (pbar.getBoundingClientRect().bottom + 16) + 'px';
   }
 
   const params = new URLSearchParams(location.search);
   const avatarParam = params.get('avatar') || '';
   let userName = params.get('name') || params.get('username') || '';
-  const durationParam = parseInt(params.get('duration')) || 17;
+  const durationParam = parseInt(params.get('duration')) || 18;
   timeShort.textContent = durationParam;
 
   function emojiToDataUri(flag){
@@ -195,8 +199,9 @@
   function layout(){
     const goalW = Math.min(W*0.86, 900);
     const goalH = Math.min(H*0.36, 320);
-    geom.goal = { x:(W-goalW)/2, y:Math.max(58, H*0.085), w:goalW, h:goalH, post:12 };
-    geom.spot = { x:W/2, y:H - Math.min(120, H*0.12) };
+    const pbarBottom = document.getElementById('pbar').getBoundingClientRect().bottom;
+    geom.goal = { x:(W-goalW)/2, y:pbarBottom + 8, w:goalW, h:goalH, post:12 };
+    geom.spot = { x:W/2, y:H - Math.min(100, H*0.10) };
     geom.scale = goalW / 860;
   }
 
@@ -206,7 +211,7 @@
   let myScore = 0;
 
   const BALL_R = 32;
-  const ball = { x:0,y:0,r:BALL_R, vx:0,vy:0, moving:false, trail:[], spin:0 };
+  const ball = { x:0,y:0,r:BALL_R, vx:0,vy:0, moving:false, trail:[], spin:0, angle:0 };
 
   let holes=[]; let banners=[]; let cameras=[];
   const aimOn = true;
@@ -226,7 +231,7 @@
 
   // ===== Ads & Cameras =====
   function initBanners(){
-    banners=[]; const g=geom.goal; const trackY=g.y+g.h+22; const trackH=42;
+    banners=[]; const g=geom.goal; const trackH=42; const trackY=g.y+g.h-trackH-8;
     const texts=['SPONSOR','ULTRA BOOTS','MEGA SPORTS','FAIR PLAY','STADIO TECH','HYDRATE','CLEAN PLAY'];
     let x=-W*0.5;
     for(let i=0;i<10;i++){ const w=rnd(240,320); banners.push({x,y:trackY,w,h:trackH,speed:rnd(0.6,1.1),hue:Math.floor(rnd(200,320)),text:texts[i%texts.length]}); x+=w+rnd(80,140); }
@@ -250,6 +255,24 @@
     }
     for(let i=0;i<3;i++){ const cv=rivals[i].cvs; const g2={x:12,y:12,w:cv.width-24,h:cv.height-30}; miniHolesCache[i]=genMiniHoles(g2); }
   }
+  function replaceHole(old){
+    const idx=holes.indexOf(old);
+    if(idx===-1) return;
+    const g=geom.goal;
+    const minR=Math.max(ball.r*1.05,22*geom.scale); const maxR=Math.max(minR+6,50*geom.scale);
+    const pad=18; let tries=0;
+    while(tries<600){
+      tries++;
+      const r=rnd(minR,maxR);
+      const x=rnd(g.x+pad+r,g.x+g.w-pad-r);
+      const y=rnd(g.y+pad+r,g.y+g.h-pad-r);
+      if(holes.every(h=>h===old||Math.hypot(h.x-x,h.y-y)>h.r+r+12)){
+        const points=Math.max(10,Math.round(((maxR/r)*70)/5)*5);
+        holes[idx]={x,y,r,points};
+        break;
+      }
+    }
+  }
   function genMiniHoles(g){ const out=[]; const cnt=6+Math.floor(Math.random()*7); let tries=0;
     while(out.length<cnt && tries<600){ tries++; const r=8+Math.random()*14; const x=g.x+12+r+Math.random()*(g.w-24-2*r); const y=g.y+12+r+Math.random()*(g.h-24-2*r);
       if(out.every(h=>Math.hypot(h.x-x,h.y-y)>h.r+r+8)){ out.push({x,y,r,p:Math.max(5,Math.round((22/r)*30))}); } }
@@ -262,8 +285,9 @@
     }
     const vg=ctx.createRadialGradient(W/2,H,10,W/2,H,H/1.12); vg.addColorStop(0,'rgba(0,0,0,0)'); vg.addColorStop(1,'rgba(0,0,0,0.26)'); ctx.fillStyle=vg; ctx.fillRect(0,0,W,H);
 
-    const g=geom.goal; ctx.strokeStyle='#fff'; ctx.lineWidth=4; ctx.lineJoin='round';
-    const gl=g.y+g.h+2; ctx.beginPath(); ctx.moveTo(0,gl); ctx.lineTo(W,gl); ctx.stroke();
+    const g=geom.goal; ctx.strokeStyle='#fff'; ctx.lineJoin='round';
+    const gl=g.y+g.h+2; ctx.lineWidth=2; ctx.beginPath(); ctx.moveTo(0,gl); ctx.lineTo(W,gl); ctx.stroke();
+    ctx.lineWidth=4;
 
     const paDepth=Math.min(320*geom.scale,H*0.34), pad=Math.max(120*geom.scale,(W-g.w)/4);
     ctx.strokeRect(g.x-pad,gl,g.w+pad*2,paDepth);
@@ -276,7 +300,7 @@
 
   // ===== Ads behind goal =====
   function drawAds(){
-    const g=geom.goal, trackY=g.y+g.h+22, trackH=42;
+    const g=geom.goal, trackH=42, trackY=g.y+g.h-trackH-8;
     ctx.fillStyle='#0e1430'; ctx.fillRect(g.x-60,trackY,g.w+120,trackH);
     ctx.save(); ctx.beginPath(); ctx.rect(g.x-60,trackY,g.w+120,trackH); ctx.clip();
     for(const b of banners){
@@ -293,14 +317,29 @@
     const g=geom.goal;
     ctx.fillStyle='#0f1530'; ctx.fillRect(g.x-4,g.y-4,g.w+8,g.h+8);
     ctx.save(); ctx.beginPath(); ctx.rect(g.x,g.y,g.w,g.h); ctx.clip();
-    ctx.strokeStyle=getComputedStyle(document.documentElement).getPropertyValue('--net')||'#e6e6e6'; ctx.lineWidth=1.4;
-    for(let x=g.x;x<=g.x+g.w;x+=18){ ctx.beginPath(); ctx.moveTo(x,g.y); ctx.lineTo(x,g.y+g.h); ctx.stroke(); }
-    for(let y=g.y;y<=g.y+g.h;y+=18){ ctx.beginPath(); ctx.moveTo(g.x,y); ctx.lineTo(g.x+g.w,y); ctx.stroke(); }
+    const netColor=getComputedStyle(document.documentElement).getPropertyValue('--net')||'#e6e6e6';
+    ctx.strokeStyle=netColor; ctx.lineWidth=1.2;
+    const size=18; const h=size*Math.sqrt(3)/2;
+    for(let y=g.y-h; y<g.y+g.h+h; y+=h){
+      for(let x=g.x-size; x<g.x+g.w+size; x+=size*1.5){
+        const off = ((Math.round((y-g.y)/h))%2)*size*0.75;
+        const cx=x+off, cy=y;
+        ctx.beginPath();
+        for(let i=0;i<6;i++){ const a=Math.PI/3*i; const px=cx+size*Math.cos(a); const py=cy+size*Math.sin(a); if(i===0) ctx.moveTo(px,py); else ctx.lineTo(px,py); }
+        ctx.closePath(); ctx.stroke();
+      }
+    }
     ctx.restore();
-    ctx.strokeStyle='#fff'; ctx.lineWidth=12; ctx.strokeRect(g.x,g.y,g.w,g.h);
+    ctx.strokeStyle='#fff'; ctx.lineWidth=12;
+    ctx.beginPath();
+    ctx.moveTo(g.x, g.y+g.h);
+    ctx.lineTo(g.x, g.y);
+    ctx.lineTo(g.x+g.w, g.y);
+    ctx.lineTo(g.x+g.w, g.y+g.h);
+    ctx.stroke();
     for(const c of cameras){ ctx.fillStyle='#111'; ctx.fillRect(c.x,c.y,c.w,c.h); ctx.fillStyle='#e10600'; ctx.beginPath(); ctx.arc(c.x+8,c.y+6,3,0,Math.PI*2); ctx.fill(); }
-    for(const h of holes){ ctx.fillStyle='rgba(225,6,0,.9)'; ctx.beginPath(); ctx.arc(h.x,h.y,h.r,0,Math.PI*2); ctx.fill();
-      ctx.fillStyle='#ffd400'; ctx.font=`800 ${Math.max(12,h.r*0.9)}px system-ui`; ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillText(h.points,h.x,h.y); }
+    for(const h of holes){ ctx.fillStyle=h.hit?'#ffd400':'rgba(225,6,0,.9)'; ctx.beginPath(); ctx.arc(h.x,h.y,h.r,0,Math.PI*2); ctx.fill();
+      ctx.fillStyle=h.hit?'#e10600':'#ffd400'; ctx.font=`800 ${Math.max(12,h.r*0.9)}px system-ui`; ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillText(h.points,h.x,h.y); }
   }
 
   // ===== Ball & physics =====
@@ -309,6 +348,14 @@
     ctx.globalAlpha=0.10; for(const t of ball.trail){ ctx.beginPath(); ctx.arc(t.x,t.y,ball.r*0.72,0,Math.PI*2); ctx.fillStyle='#fff'; ctx.fill(); } ctx.globalAlpha=1;
     ctx.fillStyle='#fff'; ctx.beginPath(); ctx.arc(ball.x,ball.y,ball.r,0,Math.PI*2); ctx.fill();
     ctx.strokeStyle='rgba(0,0,0,.28)'; ctx.lineWidth=1.6; ctx.stroke();
+    ctx.save();
+    ctx.translate(ball.x,ball.y);
+    ctx.rotate(ball.angle);
+    ctx.fillStyle='#222';
+    const hex=r=>{ ctx.beginPath(); for(let i=0;i<6;i++){ const a=Math.PI/3*i; const x=r*Math.cos(a), y=r*Math.sin(a); if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y); } ctx.closePath(); };
+    hex(ball.r*0.45); ctx.fill();
+    for(let i=0;i<6;i++){ ctx.save(); ctx.rotate(i*Math.PI/3); ctx.translate(0,ball.r*0.9); hex(ball.r*0.2); ctx.fill(); ctx.restore(); }
+    ctx.restore();
   }
   const FRICTION=0.991, AIR_DRAG=0.0015, GRAVITY=0.20;
   function stepBall(){
@@ -316,16 +363,16 @@
     ball.trail.push({x:ball.x,y:ball.y}); if(ball.trail.length>10) ball.trail.shift();
     const speed=Math.hypot(ball.vx,ball.vy); const drag = 1 - AIR_DRAG*speed; const curve = ball.spin*0.085;
     ball.vx = (ball.vx + curve)*FRICTION*drag; ball.vy = (ball.vy + GRAVITY)*FRICTION*drag;
-    ball.x += ball.vx; ball.y += ball.vy;
+    ball.x += ball.vx; ball.y += ball.vy; ball.angle += ball.spin*0.15;
 
     const g=geom.goal;
     if(ball.x>g.x && ball.x<g.x+g.w && ball.y>g.y && ball.y<g.y+g.h){
-      for(const h of holes){ if(Math.hypot(h.x-ball.x,h.y-ball.y) <= Math.max(2,h.r-ball.r*0.6)){ endShot(true,h.points); return; } }
+      for(const h of holes){ if(Math.hypot(h.x-ball.x,h.y-ball.y) <= Math.max(2,h.r-ball.r*0.6)){ h.hit=true; endShot(true,h.points); setTimeout(()=>replaceHole(h),200); return; } }
       ball.vx*=0.86; ball.vy*=0.74;
     }
     const nearL=Math.abs(ball.x-g.x)<8, nearR=Math.abs(ball.x-(g.x+g.w))<8, nearB=Math.abs(ball.y-g.y)<8;
-    if((nearL||nearR) && ball.y>g.y-8 && ball.y<g.y+g.h+8) ball.vx*=-0.6;
-    if(nearB && ball.x>g.x-8 && ball.x<g.x+g.w+8) ball.vy*=-0.5;
+    if((nearL||nearR) && ball.y>g.y-8 && ball.y<g.y+g.h+8) ball.vx*=-0.8;
+    if(nearB && ball.x>g.x-8 && ball.x<g.x+g.w+8) ball.vy*=-0.7;
 
     if(ball.y < -80 || ball.x < -80 || ball.x > W+80 || ball.y > H+80 || Math.hypot(ball.vx,ball.vy)<0.3){ endShot(false,0); }
   }
@@ -346,7 +393,7 @@
   }
 
   // ===== Round / scoring =====
-  function endShot(hit,pts){ ball.moving=false; if(hit){ myScore += pts; status('GOAL! +' + pts); sfxGoal(); vibrate(25);} else { status('Missed.'); sfxMiss(); vibrate(12);} updateHUD(); setTimeout(resetBall, 200); }
+function endShot(hit,pts){ ball.moving=false; if(hit){ myScore += pts; status('GOAL! +' + pts); sfxGoal(); vibrate(25);} else { status('Missed.'); sfxMiss(); vibrate(12);} updateHUD(); setTimeout(resetBall, 100); }
   function updateHUD(){ scoreLbl.textContent = myScore; timeShort.textContent = Math.ceil(timeLeft/1000); }
   function fmtTime(ms){ const s=Math.max(0, Math.ceil(ms/1000)); const m=Math.floor(s/60); const ss=String(s%60).padStart(2,'0'); return `${m}:${ss}`; }
   function finish(){ running=false; ended=true; sfxEnd(); }
@@ -357,8 +404,8 @@
   function pos(e){ const r=canvas.getBoundingClientRect(); return {x:(e.clientX-r.left)*(W/r.width), y:(e.clientY-r.top)*(H/r.height)}; }
   function onDown(e){ if(!running||ended||paused) return; if(pointer.active) return; pointer.active=true; pointer.id=e.pointerId; const p=pos(e); pointer.path=[p]; pointer.t0=performance.now(); pointer.t1=pointer.t0; pointer.armed = Math.hypot(p.x-ball.x,p.y-ball.y) <= ball.r*1.25 && !ball.moving; if(pointer.armed){ status('Swipe upward. Curve for spin.'); sfxKick(); } }
   function onMove(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.path.push(pos(e)); pointer.t1=performance.now();
-    if(pointer.armed && aimOn && pointer.path.length>2){ const a=pointer.path[0], b=pointer.path[pointer.path.length-1]; const dx=b.x-a.x, dy=b.y-a.y, dt=Math.max(16,(pointer.t1-pointer.t0)); const dist=Math.hypot(dx,dy), power=clamp(dist/dt, 0.55, 3.0); const len=Math.max(1,Math.hypot(dx,dy)); const dirx=dx/len, diry=dy/len; let spin=0; for(let i=2;i<pointer.path.length;i++){ const u=pointer.path[i-2], v=pointer.path[i-1], w=pointer.path[i]; spin += (v.x-u.x)*(w.y-v.y) - (v.y-u.y)*(w.x-v.x); } spin = clamp(spin/(dist*40), -2.6, 2.6); const SPEED=28; drawAimPath(dirx*SPEED*power, diry*SPEED*power, spin); } }
-  function onUp(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.active=false; if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; } const path=pointer.path; pointer.path=[]; if(path.length<3){ status('Swipe longer/faster.'); return; } const dt=Math.max(16,(pointer.t1-pointer.t0)), a=path[0], b=path[path.length-1]; const dx=b.x-a.x, dy=b.y-a.y; if(dy>-10){ status('Swipe upward.'); return; } const dist=Math.hypot(dx,dy), power=clamp(dist/dt, 0.55, 3.0); const len=Math.max(1,Math.hypot(dx,dy)); const dirx=dx/len, diry=dy/len; let spin=0; for(let i=2;i<path.length;i++){ const u=path[i-2], v=path[i-1], w=path[i]; spin += (v.x-u.x)*(w.y-v.y) - (v.y-u.y)*(w.x-v.x); } spin = clamp(spin/(dist*40), -2.6, 2.6); const SPEED=28; ball.vx=dirx*SPEED*power; ball.vy=diry*SPEED*power; ball.spin=spin; ball.moving=true; powerBar.style.height = Math.round(clamp(power/3.0,0,1)*100)+'%'; }
+    if(pointer.armed && aimOn && pointer.path.length>2){ const a=pointer.path[0], b=pointer.path[pointer.path.length-1]; const dx=b.x-a.x, dy=b.y-a.y, dt=Math.max(16,(pointer.t1-pointer.t0)); const dist=Math.hypot(dx,dy), power=clamp(dist/dt, 0.55, 3.0); const len=Math.max(1,Math.hypot(dx,dy)); const dirx=dx/len, diry=dy/len; let spin=0; for(let i=2;i<pointer.path.length;i++){ const u=pointer.path[i-2], v=pointer.path[i-1], w=pointer.path[i]; spin += (v.x-u.x)*(w.y-v.y) - (v.y-u.y)*(w.x-v.x); } spin = clamp(spin/(dist*40), -2.6, 2.6); const SPEED=36; drawAimPath(dirx*SPEED*power, diry*SPEED*power, spin); } }
+  function onUp(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.active=false; if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; } const path=pointer.path; pointer.path=[]; if(path.length<3){ status('Swipe longer/faster.'); return; } const dt=Math.max(16,(pointer.t1-pointer.t0)), a=path[0], b=path[path.length-1]; const dx=b.x-a.x, dy=b.y-a.y; if(dy>-10){ status('Swipe upward.'); return; } const dist=Math.hypot(dx,dy), power=clamp(dist/dt, 0.55, 3.0); const len=Math.max(1,Math.hypot(dx,dy)); const dirx=dx/len, diry=dy/len; let spin=0; for(let i=2;i<path.length;i++){ const u=path[i-2], v=path[i-1], w=path[i]; spin += (v.x-u.x)*(w.y-v.y) - (v.y-u.y)*(w.x-v.x); } spin = clamp(spin/(dist*40), -2.6, 2.6); const SPEED=36; ball.vx=dirx*SPEED*power; ball.vy=diry*SPEED*power; ball.spin=spin; ball.moving=true; powerBar.style.height = Math.round(clamp(power/3.0,0,1)*100)+'%'; }
   canvas.addEventListener('pointerdown', onDown, {passive:true});
   canvas.addEventListener('pointermove', onMove, {passive:true});
   addEventListener('pointerup', onUp, {passive:true}); addEventListener('pointercancel', onUp, {passive:true});
@@ -394,7 +441,7 @@
   // ===== Controls =====
   // controls removed
 
-  function resetBall(){ ball.x=geom.spot.x; ball.y=geom.spot.y; ball.vx=ball.vy=ball.spin=0; ball.moving=false; ball.trail=[]; }
+function resetBall(){ ball.x=geom.spot.x; ball.y=geom.spot.y; ball.vx=ball.vy=ball.spin=0; ball.angle=0; ball.moving=false; ball.trail=[]; }
   function startGame(){ running=true; paused=false; ended=false; roundStart=performance.now(); timeLeft=ROUND_TIME; myScore=0; for(const r of rivals){ r.score=0; r.next=0; } resetBall(); generateHoles(); drawMiniBoards(true); updateHUD(); ensureAudio(); sfxStart(); status('Go! Score as many as you can.'); }
 
   // ===== WebAudio SFX (no files) =====
@@ -438,9 +485,6 @@
 
   function boot(){
     resize();
-    initBanners();
-    initCameras();
-    drawStaticOnce();
     requestAnimationFrame(loop);
     canvas.addEventListener('pointerdown', ()=>{ if(!running||ended) startCountdown(3); ensureAudio(); }, {once:false});
     startCountdown(3);


### PR DESCRIPTION
## Summary
- Layout HUD player bar horizontally and align goal positioning just beneath it
- Draw thinner goal line, hexagonal net, and recolor targets on hit with replacement
- Render spinning soccer ball with more power and quicker respawn; move ads behind goal

## Testing
- `npm test` (fails: server didn't terminate)
- `npm run lint` (fails: 1250 errors)


------
https://chatgpt.com/codex/tasks/task_e_68ac7f8b54688329b67bee49d91a17ea