### PR TITLE
feat(goal-rush): tone down AI defense

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -643,6 +643,9 @@
     if (puck.y < centerY) {
       // attack: chase puck when it's on AI side
       ty = clamp(puck.y, minY, maxY);
+    } else {
+      // defend: react a bit slower to make AI less perfect
+      reaction *= 0.85;
     }
     if (cornerEscapeFrames > 0) {
       cornerEscapeFrames--;


### PR DESCRIPTION
## Summary
- slow AI reaction while defending in Goal Rush to make matches less one-sided

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac8162689c8329ad8c50800e8e7ce4