### PR TITLE
Remove wallet info from transaction pages

### DIFF
--- a/webapp/src/components/ProjectAchievementsCard.jsx
+++ b/webapp/src/components/ProjectAchievementsCard.jsx
@@ -1,5 +1,3 @@
-import { GAME_TX_WALLET_1, GAME_TX_WALLET_2, MINING_REWARDS_WALLET } from '../utils/constants.js';
-
 export default function ProjectAchievementsCard() {
   const achievements = [
     '🧾 Wallet transaction history works',
@@ -28,9 +26,8 @@ export default function ProjectAchievementsCard() {
     '🎡 Spin & Win wheel',
     '🍀 Lucky Card prizes',
     '🎁 NFT Gifts marketplace',
-    `🏦 Game transactions wallet 1: ${GAME_TX_WALLET_1}`,
-    `🏦 Game transactions wallet 2: ${GAME_TX_WALLET_2}`,
-    `⛏️ Mining rewards wallet: ${MINING_REWARDS_WALLET}`,
+    '🏦 Game transactions are public',
+    '⛏️ Mining transactions are public',
   ];
 
   return (

--- a/webapp/src/pages/GameTransactions.jsx
+++ b/webapp/src/pages/GameTransactions.jsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { getGameTransactions } from '../utils/api.js';
 import { getAvatarUrl } from '../utils/avatarUtils.js';
-import { GAME_TX_WALLET_1, GAME_TX_WALLET_2 } from '../utils/constants.js';
 
 const GAME_NAME_MAP = {
   snake: 'Snake & Ladder',
@@ -51,10 +50,6 @@ export default function GameTransactions() {
   return (
     <div className="relative space-y-4 text-text">
       <h2 className="text-2xl font-bold text-center mt-4">Game Transactions</h2>
-      <div className="bg-surface border border-border rounded-xl p-4 shadow-lg text-xs space-y-1 break-all">
-        <div>Public wallet 1: {GAME_TX_WALLET_1}</div>
-        <div>Public wallet 2: {GAME_TX_WALLET_2}</div>
-      </div>
       <div className="bg-surface border border-border rounded-xl p-4 shadow-lg space-y-1 text-sm">
         <div className="flex justify-between">
           <span>Total games played</span>

--- a/webapp/src/pages/MiningTransactions.jsx
+++ b/webapp/src/pages/MiningTransactions.jsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { getMiningTransactions } from '../utils/api.js';
 import { getAvatarUrl } from '../utils/avatarUtils.js';
-import { MINING_REWARDS_WALLET } from '../utils/constants.js';
 
 const TYPE_NAME_MAP = {
   daily: 'Daily Streak',
@@ -38,9 +37,6 @@ export default function MiningTransactions() {
   return (
     <div className="relative space-y-4 text-text">
       <h2 className="text-2xl font-bold text-center mt-4">Mining Transactions</h2>
-      <div className="bg-surface border border-border rounded-xl p-4 shadow-lg text-xs break-all">
-        Mining rewards wallet: {MINING_REWARDS_WALLET}
-      </div>
       <div className="bg-surface border border-border rounded-xl p-4 shadow-lg space-y-1 text-sm">
         <div className="flex justify-between">
           <span>Total payouts</span>

--- a/webapp/src/utils/constants.js
+++ b/webapp/src/utils/constants.js
@@ -7,11 +7,6 @@ export const DEV_INFO = {
 
 // TON wallet used for store purchases and Adsgram payouts
 export const ADSGRAM_WALLET = 'UQAPwsGyKzA4MuBnCflTVwEcTLcGS9yV6okJWQGzO5VxVYD1';
-// Public wallets for game transactions
-export const GAME_TX_WALLET_1 = 'REPLACE_WITH_GAME_WALLET_1'; // TODO: set real address
-export const GAME_TX_WALLET_2 = 'REPLACE_WITH_GAME_WALLET_2'; // TODO: set real address
-// Mining rewards wallet
-export const MINING_REWARDS_WALLET = 'REPLACE_WITH_MINING_WALLET'; // TODO: set real address
 
 // Address of the Snake & Ladder smart contract used for TON bets
 export const SNAKE_CONTRACT_ADDRESS =


### PR DESCRIPTION
## Summary
- remove public wallet display from game and mining transactions
- note public game and mining transactions in achievements
- drop unused wallet constants

## Testing
- `npm test`
- `npm run lint` *(fails: numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac97351b48832989a5bd9c2e03851d