### PR TITLE
Refine penalty kick gameplay and visuals

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -203,10 +203,12 @@
     geom.goal = { x:(W-goalW)/2, y:pbarBottom + 20, w:goalW, h:goalH, post:12 };
     geom.spot = { x:W/2, y:H - Math.min(100, H*0.10) };
     geom.scale = goalW / 860;
-    keeper.w = 40*geom.scale*4*1.1; keeper.h = 100*geom.scale*4*1.1;
+    keeper.w = 40*geom.scale*4;
+    keeper.h = 100*geom.scale*4;
     keeper.x = geom.goal.x + (geom.goal.w-keeper.w)/2;
-    keeper.y = geom.goal.y + geom.goal.h - keeper.h - geom.goal.h*0.05;
+    keeper.y = geom.goal.y + geom.goal.h - keeper.h - geom.goal.h*0.02;
     keeper.baseY = keeper.y;
+    keeper.baseX = keeper.x;
   }
 
   // ===== Game state =====
@@ -215,13 +217,14 @@
   let myScore = 0;
 
   const BALL_R = 36;
+  const SHOT_SPEED = 38;
   const ball = { x:0,y:0,r:BALL_R, vx:0,vy:0, moving:false, trail:[], spin:0, angle:0, netSounded:false, firstContact:false };
   const ballImg = new Image();
   ballImg.src = '/assets/icons/file_0000000061d4620aaf506adfa605e1f3.webp';
 
   let holes=[]; let banners=[]; let cameras=[]; let fragments=[];
   let netHit={x:0,y:0,t:0,shake:0};
-  const keeper={x:0,y:0,w:40,h:100,vx:0,vy:0,active:false,save:false,a:0,side:1,baseY:0};
+  const keeper={x:0,y:0,w:40,h:100,vx:0,vy:0,active:false,save:false,a:0,side:1,baseY:0,baseX:0};
   const keeperImg = new Image();
   keeperImg.src = '/assets/icons/file_00000000945461f8bb9a2974fb9ee402.webp';
   const aimOn = false;
@@ -238,6 +241,23 @@
   const clamp=(v,a,b)=>Math.max(a,Math.min(b,v));
   const rnd=(a,b)=>a+Math.random()*(b-a);
   function roundedRect(x,y,w,h,r){ ctx.beginPath(); ctx.moveTo(x+r,y); ctx.arcTo(x+w,y,x+w,y+h,r); ctx.arcTo(x+w,y+h,x,y+h,r); ctx.arcTo(x,y+h,x,y,r); ctx.arcTo(x,y,x+w,y,r); ctx.closePath(); }
+
+  function reflectBall(nx,ny,damp=0.8){
+    const dot = ball.vx*nx + ball.vy*ny;
+    ball.vx -= 2*dot*nx;
+    ball.vy -= 2*dot*ny;
+    ball.vx *= damp;
+    ball.vy *= damp;
+  }
+  function ballHitsKeeper(){
+    const k=keeper;
+    const px=k.x+k.w/2, py=k.y+k.h;
+    const cos=Math.cos(-k.a), sin=Math.sin(-k.a);
+    const dx=ball.x-px, dy=ball.y-py;
+    const lx=dx*cos - dy*sin;
+    const ly=dx*sin + dy*cos;
+    return lx>-k.w/2-ball.r && lx<k.w/2+ball.r && ly>-k.h-ball.r && ly<ball.r;
+  }
 
   // ===== Ads & Cameras =====
   function initBanners(){
@@ -256,7 +276,15 @@
     while(holes.length<cnt && tries<1600){
       tries++;
       const r=rnd(minR,maxR);
-      const x=rnd(g.x+pad+r,g.x+g.w-pad-r);
+      let x;
+      if(Math.random() < 0.6){
+        const side = Math.random() < 0.5 ? 'l' : 'r';
+        const range = g.w * 0.2;
+        if(side === 'l') x = rnd(g.x+pad+r, g.x+pad+range);
+        else x = rnd(g.x+g.w-pad-range, g.x+g.w-pad-r);
+      } else {
+        x = rnd(g.x+pad+r,g.x+g.w-pad-r);
+      }
       const y=rnd(g.y+pad+r,g.y+g.h-pad-r);
       if(holes.every(h=>Math.hypot(h.x-x,h.y-y)>h.r+r+12)){
         const points=Math.max(10,Math.round(((maxR/r)*70)/5)*5);
@@ -274,7 +302,15 @@
     while(tries<600){
       tries++;
       const r=rnd(minR,maxR);
-      const x=rnd(g.x+pad+r,g.x+g.w-pad-r);
+      let x;
+      if(Math.random() < 0.6){
+        const side = Math.random() < 0.5 ? 'l' : 'r';
+        const range = g.w * 0.2;
+        if(side === 'l') x = rnd(g.x+pad+r, g.x+pad+range);
+        else x = rnd(g.x+g.w-pad-range, g.x+g.w-pad-r);
+      } else {
+        x = rnd(g.x+pad+r,g.x+g.w-pad-r);
+      }
       const y=rnd(g.y+pad+r,g.y+g.h-pad-r);
       if(holes.every(h=>h===old||Math.hypot(h.x-x,h.y-y)>h.r+r+12)){
         const points=Math.max(10,Math.round(((maxR/r)*70)/5)*5);
@@ -344,14 +380,28 @@
         for(let i=0;i<6;i++){
           const a=Math.PI/3*i; let px=cx+size*Math.cos(a); let py=cy+size*Math.sin(a);
           const dx=netHit.x-px, dy=netHit.y-py; const dist=Math.hypot(dx,dy);
-          if(netHit.t>0){ const pull=Math.exp(-dist/80)*8*netHit.t; px+=dx/dist*pull; py+=dy/dist*pull; }
-          if(netHit.shake>0){ py+=Math.sin((px+py+i)*0.3+performance.now()*0.02)*netHit.shake*2; }
+          if(netHit.t>0){ const pull=Math.exp(-dist/80)*14*netHit.t; px+=dx/dist*pull; py+=dy/dist*pull; }
+          if(netHit.shake>0){ py+=Math.sin((px+py+i)*0.3+performance.now()*0.02)*netHit.shake*3; }
           if(i===0) ctx.moveTo(px,py); else ctx.lineTo(px,py);
         }
         ctx.closePath(); ctx.stroke();
       }
     }
     ctx.restore();
+    const depth = g.h*0.35;
+    ctx.strokeStyle='rgba(255,255,255,0.4)'; ctx.lineWidth=4;
+    ctx.beginPath();
+    ctx.moveTo(g.x, g.y);
+    ctx.lineTo(g.x - depth, g.y - depth*0.1);
+    ctx.lineTo(g.x - depth, g.y+g.h - depth*0.1);
+    ctx.lineTo(g.x, g.y+g.h);
+    ctx.moveTo(g.x+g.w, g.y);
+    ctx.lineTo(g.x+g.w+depth, g.y - depth*0.1);
+    ctx.lineTo(g.x+g.w+depth, g.y+g.h - depth*0.1);
+    ctx.lineTo(g.x+g.w, g.y+g.h);
+    ctx.moveTo(g.x - depth, g.y+g.h - depth*0.1);
+    ctx.lineTo(g.x+g.w+depth, g.y+g.h - depth*0.1);
+    ctx.stroke();
     ctx.strokeStyle='#fff'; ctx.lineWidth=12;
     ctx.beginPath();
     ctx.moveTo(g.x, g.y+g.h);
@@ -369,9 +419,9 @@
   function drawKeeper(){
     const k=keeper;
     ctx.save();
-    ctx.translate(k.x + k.w/2, k.y + k.h/2);
+    ctx.translate(k.x + k.w/2, k.y + k.h);
     ctx.rotate(k.a||0);
-    ctx.translate(-k.w/2, -k.h/2);
+    ctx.translate(-k.w/2, -k.h);
     ctx.drawImage(keeperImg, 0, 0, k.w, k.h);
     ctx.restore();
   }
@@ -387,13 +437,13 @@
     ctx.drawImage(ballImg, -size/2, -size/2, size, size);
     ctx.restore();
   }
-  const FRICTION=0.991, AIR_DRAG=0.0015, GRAVITY=0.20;
+  const FRICTION=0.989, AIR_DRAG=0.0015, GRAVITY=0.20;
   function stepBall(){
     if(!ball.moving) return;
     ball.trail.push({x:ball.x,y:ball.y}); if(ball.trail.length>10) ball.trail.shift();
-    const speed=Math.hypot(ball.vx,ball.vy); const drag = 1 - AIR_DRAG*speed; const curve = ball.spin*0.06;
+    const speed=Math.hypot(ball.vx,ball.vy); const drag = 1 - AIR_DRAG*speed; const curve = ball.spin*0.08;
     ball.vx = (ball.vx + curve)*FRICTION*drag; ball.vy = (ball.vy + GRAVITY)*FRICTION*drag;
-    ball.x += ball.vx; ball.y += ball.vy; ball.angle += ball.spin*0.15;
+    ball.x += ball.vx; ball.y += ball.vy; ball.angle += ball.spin*0.25;
 
     const g=geom.goal;
     if(ball.x>g.x && ball.x<g.x+g.w && ball.y>g.y && ball.y<g.y+g.h){
@@ -405,14 +455,16 @@
       ball.vx*=0.86; ball.vy*=0.74; netHit={x:ball.x,y:ball.y,t:1,shake:1};
       if(!ball.netSounded){ sfxNet(); ball.netSounded=true; }
     }
-    if(keeper.save){
-      if(ball.x+ball.r>keeper.x && ball.x-ball.r<keeper.x+keeper.w && ball.y+ball.r>keeper.y && ball.y-ball.r<keeper.y+keeper.h){
-        keeper.active=false; keeper.save=false; endShot(false,0); return;
-      }
+    if(keeper.save && ballHitsKeeper()){
+      keeper.save=false; endShot(false,0); return;
     }
-    const nearL=Math.abs(ball.x-g.x)<8, nearR=Math.abs(ball.x-(g.x+g.w))<8, nearB=Math.abs(ball.y-g.y)<8;
-    if((nearL||nearR) && ball.y>g.y-8 && ball.y<g.y+g.h+8) ball.vx*=-0.8;
-    if(nearB && ball.x>g.x-8 && ball.x<g.x+g.w+8) ball.vy*=-0.7;
+    const postR = g.post;
+    const left={x:g.x, y:g.y+g.h}, right={x:g.x+g.w, y:g.y+g.h};
+    let d=Math.hypot(ball.x-left.x, ball.y-left.y);
+    if(d < ball.r + postR){ const nx=(ball.x-left.x)/d, ny=(ball.y-left.y)/d; reflectBall(nx,ny); sfxWoodwork(); }
+    d=Math.hypot(ball.x-right.x, ball.y-right.y);
+    if(d < ball.r + postR){ const nx=(ball.x-right.x)/d, ny=(ball.y-right.y)/d; reflectBall(nx,ny); sfxWoodwork(); }
+    if(ball.y - ball.r <= g.y && ball.x > g.x - postR && ball.x < g.x + g.w + postR){ if(ball.vy < 0){ reflectBall(0,1); ball.y = g.y + ball.r; sfxWoodwork(); }}
 
     if(!ball.firstContact && ball.y >= geom.spot.y && ball.vy > 0){ ball.firstContact=true; endShot(false,0); return; }
     if(ball.y < -80 || ball.x < -80 || ball.x > W+80 || ball.y > H+80 || Math.hypot(ball.vx,ball.vy)<0.3){ endShot(false,0); }
@@ -424,27 +476,20 @@
   }
 
   function stepKeeper(){
-    if(ball.moving && !keeper.active){
-      const t = ball.vy !== 0 ? (keeper.y - ball.y) / ball.vy : Infinity;
-      if(t > 0 && t < 120){
-        const predicted = ball.x + ball.vx * t;
-        const target = clamp(predicted - keeper.w/2, geom.goal.x, geom.goal.x+geom.goal.w-keeper.w);
-        const dist = target - keeper.x;
-        keeper.side = Math.sign(dist) || 1;
-        keeper.vx = clamp(dist / t, -12, 12);
-        keeper.vy = -7;
-        keeper.a = keeper.side * -0.3;
-        keeper.active = true;
-        keeper.save = true;
-      }
+    if(!ball.moving){
+      keeper.a *= 0.9; keeper.save=false; return;
     }
-    if(!keeper.active) return;
-    keeper.x += keeper.vx;
-    keeper.y += keeper.vy; keeper.vy += 0.6; keeper.vx *= 0.95;
-    if(keeper.y >= keeper.baseY){
-      keeper.y = keeper.baseY; keeper.vy=0; keeper.vx=0; keeper.a=0; keeper.active=false; keeper.save=false;
+    const t = ball.vy !== 0 ? (keeper.y - ball.y) / ball.vy : Infinity;
+    if(t > 0 && t < 120){
+      const predicted = ball.x + ball.vx * t;
+      const diff = predicted - (keeper.x + keeper.w/2);
+      const targetA = clamp(diff / 200, -0.8, 0.8);
+      keeper.a += (targetA - keeper.a) * 0.15;
+      keeper.save = Math.abs(diff) < keeper.w*0.6;
+    } else {
+      keeper.a *= 0.9;
+      keeper.save=false;
     }
-    keeper.x = clamp(keeper.x, geom.goal.x, geom.goal.x+geom.goal.w-keeper.w);
   }
 
   // ===== Aim guide =====
@@ -455,7 +500,7 @@
     ctx.beginPath();
     for(let i=0;i<steps;i++){
       const speed=Math.hypot(vx1,vy1); const drag=1-AIR_DRAG*speed;
-      vx1=(vx1+spin*0.085)*FRICTION*drag; vy1=(vy1+GRAVITY)*FRICTION*drag;
+      vx1=(vx1+spin*0.11)*FRICTION*drag; vy1=(vy1+GRAVITY)*FRICTION*drag;
       x+=vx1; y+=vy1; if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
       if(y<geom.goal.y-40) break;
     }
@@ -494,8 +539,8 @@ function endShot(hit,pts){
   function pos(e){ const r=canvas.getBoundingClientRect(); return {x:(e.clientX-r.left)*(W/r.width), y:(e.clientY-r.top)*(H/r.height)}; }
   function onDown(e){ if(!running||ended||paused) return; if(pointer.active) return; pointer.active=true; pointer.id=e.pointerId; const p=pos(e); pointer.path=[p]; pointer.t0=performance.now(); pointer.t1=pointer.t0; pointer.armed = Math.hypot(p.x-ball.x,p.y-ball.y) <= ball.r*1.25 && !ball.moving; if(pointer.armed){ status('Swipe upward. Curve for spin.'); sfxKick(); } }
   function onMove(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.path.push(pos(e)); pointer.t1=performance.now();
-    if(pointer.armed && aimOn && pointer.path.length>2){ const a=pointer.path[0], b=pointer.path[pointer.path.length-1]; const dx=b.x-a.x, dy=b.y-a.y, dt=Math.max(16,(pointer.t1-pointer.t0)); const dist=Math.hypot(dx,dy), power=clamp(dist/dt, 0.55, 3.0); const len=Math.max(1,Math.hypot(dx,dy)); const dirx=dx/len, diry=dy/len; let spin=0; for(let i=2;i<pointer.path.length;i++){ const u=pointer.path[i-2], v=pointer.path[i-1], w=pointer.path[i]; spin += (v.x-u.x)*(w.y-v.y) - (v.y-u.y)*(w.x-v.x); } spin = clamp(spin/(dist*40), -1.5, 1.5); const SPEED=45; drawAimPath(dirx*SPEED*power, diry*SPEED*power, spin); } }
-  function onUp(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.active=false; if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; } const path=pointer.path; pointer.path=[]; if(path.length<3){ status('Swipe longer/faster.'); return; } const dt=Math.max(16,(pointer.t1-pointer.t0)), a=path[0], b=path[path.length-1]; const dx=b.x-a.x, dy=b.y-a.y; if(dy>-10){ status('Swipe upward.'); return; } const dist=Math.hypot(dx,dy), power=clamp(dist/dt, 0.55, 3.0); const len=Math.max(1,Math.hypot(dx,dy)); const dirx=dx/len, diry=dy/len; let spin=0; for(let i=2;i<path.length;i++){ const u=path[i-2], v=path[i-1], w=path[i]; spin += (v.x-u.x)*(w.y-v.y) - (v.y-u.y)*(w.x-v.x); } spin = clamp(spin/(dist*40), -1.5, 1.5); const SPEED=45; ball.vx=dirx*SPEED*power; ball.vy=diry*SPEED*power; ball.spin=spin; ball.moving=true; keeper.save=false; keeper.active=false; powerBar.style.height = Math.round(clamp(power/3.0,0,1)*100)+'%'; }
+    if(pointer.armed && aimOn && pointer.path.length>2){ const a=pointer.path[0], b=pointer.path[pointer.path.length-1]; const dx=b.x-a.x, dy=b.y-a.y, dt=Math.max(16,(pointer.t1-pointer.t0)); const dist=Math.hypot(dx,dy), power=clamp(dist/dt, 0.55, 3.0); const len=Math.max(1,Math.hypot(dx,dy)); const dirx=dx/len, diry=dy/len; let spin=0; for(let i=2;i<pointer.path.length;i++){ const u=pointer.path[i-2], v=pointer.path[i-1], w=pointer.path[i]; spin += (v.x-u.x)*(w.y-v.y) - (v.y-u.y)*(w.x-v.x); } spin = clamp(spin/(dist*40), -1.5, 1.5); drawAimPath(dirx*SHOT_SPEED*power, diry*SHOT_SPEED*power, spin*1.2); } }
+  function onUp(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.active=false; if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; } const path=pointer.path; pointer.path=[]; if(path.length<3){ status('Swipe longer/faster.'); return; } const dt=Math.max(16,(pointer.t1-pointer.t0)), a=path[0], b=path[path.length-1]; const dx=b.x-a.x, dy=b.y-a.y; if(dy>-10){ status('Swipe upward.'); return; } const dist=Math.hypot(dx,dy), power=clamp(dist/dt, 0.55, 3.0); const len=Math.max(1,Math.hypot(dx,dy)); const dirx=dx/len, diry=dy/len; let spin=0; for(let i=2;i<path.length;i++){ const u=path[i-2], v=path[i-1], w=path[i]; spin += (v.x-u.x)*(w.y-v.y) - (v.y-u.y)*(w.x-v.x); } spin = clamp(spin/(dist*40), -1.5, 1.5); ball.vx=dirx*SHOT_SPEED*power; ball.vy=diry*SHOT_SPEED*power; ball.spin=spin*1.2; ball.moving=true; keeper.save=false; powerBar.style.height = Math.round(clamp(power/3.0,0,1)*100)+'%'; }
   canvas.addEventListener('pointerdown', onDown, {passive:true});
   canvas.addEventListener('pointermove', onMove, {passive:true});
   addEventListener('pointerup', onUp, {passive:true}); addEventListener('pointercancel', onUp, {passive:true});
@@ -533,7 +578,7 @@ function endShot(hit,pts){
   // ===== Controls =====
   // controls removed
 
-  function resetBall(){ ball.x=geom.spot.x; ball.y=geom.spot.y; ball.vx=ball.vy=ball.spin=0; ball.angle=0; ball.moving=false; ball.netSounded=false; ball.trail=[]; ball.firstContact=false; netHit={x:0,y:0,t:0,shake:0}; keeper.active=false; keeper.save=false; keeper.vx=0; keeper.vy=0; keeper.a=0; keeper.x = geom.goal.x + (geom.goal.w-keeper.w)/2; keeper.y = keeper.baseY; }
+  function resetBall(){ ball.x=geom.spot.x; ball.y=geom.spot.y; ball.vx=ball.vy=ball.spin=0; ball.angle=0; ball.moving=false; ball.netSounded=false; ball.trail=[]; ball.firstContact=false; netHit={x:0,y:0,t:0,shake:0}; keeper.save=false; keeper.vx=0; keeper.vy=0; keeper.a=0; keeper.x = keeper.baseX; keeper.y = keeper.baseY; }
   function startGame(){ running=true; paused=false; ended=false; roundStart=performance.now(); timeLeft=ROUND_TIME; myScore=0; for(const r of rivals){ r.score=0; r.next=0; r.shots=[]; } resetBall(); generateHoles(); drawMiniBoards(true); updateHUD(); ensureAudio(); sfxStart(); status('Go! Score as many as you can.'); }
 
   // ===== WebAudio SFX (no files) =====
@@ -548,8 +593,10 @@ function endShot(hit,pts){
   const sfxEnd  = ()=>{tone(300,0.12,'sine',0.18); setTimeout(()=>tone(220,0.16,'sine',0.16),60);};
   const netHitSound = new Audio('/assets/sounds/a-football-hits-the-net-goal-313216.mp3');
   const rewardSound = new Audio('https://cdn.pixabay.com/audio/2022/03/15/audio_1d8839a382.mp3');
+  const woodSound = new Audio('https://actions.google.com/sounds/v1/impacts/crash.ogg');
   const sfxNet = ()=>{ try{ netHitSound.currentTime = 0; netHitSound.play(); }catch{} };
   const sfxReward = ()=>{ try{ rewardSound.currentTime = 0; rewardSound.play(); }catch{} };
+  const sfxWoodwork = ()=>{ try{ woodSound.currentTime = 0; woodSound.play(); }catch{} };
   function vibrate(ms){ if(navigator.vibrate) try{ navigator.vibrate(ms); }catch{} }
 
   // ===== Static draw & tests =====


### PR DESCRIPTION
## Summary
- Slow down shots and amplify spin for a more visible curved ball trajectory
- Keep goalkeeper grounded and tilt in an arc to track the shot, with smaller sizing
- Random targets favor goal posts, add looser 3D net and woodwork bounce with sound

## Testing
- `npm test` (failed: server kept running; tests logged until interrupted)
- `npm run lint` (failed: 1250 lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68acc8955d288329afcd271b53e42f34