### PR TITLE
Add Ping Pong game and lobby

### DIFF
--- a/webapp/public/ping-pong.html
+++ b/webapp/public/ping-pong.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="sq">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+  <title>Ping Pong Minimal</title>
+  <style>
+    :root{
+      --bg:#0b1022; --felt1:#0f1b3e; --felt2:#0e1732; --edge:#1a2754; --white:#f5f8ff;
+      --pink:#ff4db8; --blue:#3aa7ff;
+    }
+    html,body{margin:0;height:100%;background:var(--bg);overflow:hidden}
+    canvas{display:block;width:100vw;height:100vh;touch-action:none}
+  </style>
+</head>
+<body>
+  <canvas id="game"></canvas>
+<script>
+(()=>{
+  'use strict';
+  const cvs=document.getElementById('game');
+  const ctx=cvs.getContext('2d');
+  function fit(){cvs.width=innerWidth;cvs.height=innerHeight;}addEventListener('resize',fit);fit();
+
+  // perspektiva: poshtë e gjerë, sipër pak më e ngushtë
+  const MARGIN_X=40,MARGIN_Y=50;
+  function T(){return {x:MARGIN_X,y:MARGIN_Y,w:cvs.width-2*MARGIN_X,h:cvs.height-2*MARGIN_Y};}
+  const FAR_SCALE=0.9; // sipër gati po aq e gjerë sa poshtë
+  function scaleAt(v){return FAR_SCALE+(1-FAR_SCALE)*v;}
+  function leftEdge(v,t){const s=scaleAt(v);return t.x+(1-s)*t.w/2;}
+  function widthAt(v,t){return t.w*scaleAt(v);}
+  function project(u,v,t){return{x:leftEdge(v,t)+u*widthAt(v,t),y:t.y+v*t.h};}
+
+  const BLADE_R=36*2.5;
+  const HANDLE_W=16*2.5,HANDLE_L=28*2.5;
+  const BALL_R=9*4;
+  const NET_H=24;
+  const NET_Z=28;
+
+  const G=0.75,COR=0.52,AIR=0.0006,FRIC_T=0.985;
+
+  const top={x:0,y:0,vx:0,vy:0};
+  const bot={x:0,y:0,vx:0,vy:0};
+  const ball={x:0,y:0,vx:0,vy:0,z:0,vz:0};
+
+  function reset(){const t=T();
+    top.x=t.x+t.w/2; top.y=project(0.5,0.16,t).y;
+    bot.x=t.x+t.w/2; bot.y=project(0.5,0.84,t).y;
+    ball.x=t.x+t.w*0.5; ball.y=project(0.5,0.5,t).y;
+    ball.vx=(Math.random()<0.5?-1:1)*6; ball.vy=-8;
+    ball.z=2; ball.vz=10;
+  }reset();
+
+  const touches=new Map();
+  function onDown(e){const pts=e.changedTouches?e.changedTouches:[e];const r=cvs.getBoundingClientRect();for(const p of pts){const x=p.clientX-r.left,y=p.clientY-r.top;const side=(y<r.height/2?'top':'bot');touches.set(p.identifier||'mouse',{side,x,y,lastX:x,lastY:y});}e.preventDefault();}
+  function onMove(e){const pts=e.changedTouches?e.changedTouches:[e];const r=cvs.getBoundingClientRect();for(const p of pts){const id=p.identifier||'mouse';const TCH=touches.get(id);if(!TCH)continue;const x=p.clientX-r.left,y=p.clientY-r.top;TCH.lastX=x;TCH.lastY=y;TCH.x=x;TCH.y=y;}e.preventDefault();}
+  function onUp(e){const pts=e.changedTouches?e.changedTouches:[e];for(const p of pts)touches.delete(p.identifier||'mouse');e.preventDefault();}
+  cvs.addEventListener('mousedown',onDown);addEventListener('mousemove',onMove);addEventListener('mouseup',onUp);
+  cvs.addEventListener('touchstart',onDown,{passive:false});cvs.addEventListener('touchmove',onMove,{passive:false});cvs.addEventListener('touchend',onUp);
+
+  function control(){const t=T();const mid=t.y+t.h/2;
+    const areas={top:{x:t.x,y:t.y,w:t.w,h:t.h/2-NET_H/2},bot:{x:t.x,y:mid+NET_H/2,w:t.w,h:t.h/2-NET_H/2}};
+    for(const TCH of touches.values()){
+      const P=TCH.side==='top'?top:bot;const a=areas[TCH.side];
+      P.x=clamp(TCH.x,a.x+BLADE_R,a.x+a.w-BLADE_R);
+      P.y=clamp(TCH.y,a.y+BLADE_R,a.y+a.h-BLADE_R);
+    }
+  }
+  function clamp(v,a,b){return Math.max(a,Math.min(b,v));}
+
+  function collide(P){const dx=ball.x-P.x,dy=ball.y-P.y;const d=Math.hypot(dx,dy);
+    if(d<BALL_R+BLADE_R){const nx=dx/(d||1),ny=dy/(d||1);
+      // vetëm shtyj topin jashtë paddle
+      const overlap=BALL_R+BLADE_R-d;ball.x+=nx*overlap;ball.y+=ny*overlap;
+      ball.vx=-ball.vx*0.9+nx*3; ball.vy=-ball.vy*0.9+ny*3;
+      ball.vz=8; // kërcim
+    }
+  }
+
+  function applyNet(){const t=T();const mid=t.y+t.h/2;const netTop=mid-NET_H/2,netBot=mid+NET_H/2;
+    if(ball.z<NET_Z && ball.y+BALL_R>netTop && ball.y-BALL_R<netBot){ball.vy=-ball.vy*0.7;}
+  }
+
+  let last=performance.now();
+  function step(dt){control();
+    const t=T();
+    // z
+    ball.vz-=G*dt;ball.z+=ball.vz*dt;if(ball.z<0){ball.z=0;ball.vz=-ball.vz*COR;if(Math.abs(ball.vz)<1)ball.vz=0;}
+    // xy
+    ball.x+=ball.vx*dt;ball.y+=ball.vy*dt;
+    if(ball.x-BALL_R<t.x){ball.x=t.x+BALL_R;ball.vx=Math.abs(ball.vx);} 
+    if(ball.x+BALL_R>t.x+t.w){ball.x=t.x+t.w-BALL_R;ball.vx=-Math.abs(ball.vx);} 
+    if(ball.y<t.y-20||ball.y>t.y+t.h+20){reset();}
+    applyNet();
+    if(ball.z<22){collide(top);collide(bot);}
+    draw();
+  }
+
+  function loop(now){const dtms=Math.min(32,now-last);last=now;const dt=dtms/16;step(dt);requestAnimationFrame(loop);}requestAnimationFrame(loop);
+
+  function draw(){const t=T();ctx.clearRect(0,0,cvs.width,cvs.height);
+    // sfond
+    const g=ctx.createLinearGradient(0,0,0,cvs.height);g.addColorStop(0,'#0a1024');g.addColorStop(1,'#0b1430');ctx.fillStyle=g;ctx.fillRect(0,0,cvs.width,cvs.height);
+    // tavolina
+    const bl=project(0,1,t),br=project(1,1,t),tr=project(1,0,t),tl=project(0,0,t);
+    ctx.beginPath();ctx.moveTo(bl.x,bl.y);ctx.lineTo(br.x,br.y);ctx.lineTo(tr.x,tr.y);ctx.lineTo(tl.x,tl.y);ctx.closePath();
+    const felt=ctx.createLinearGradient(bl.x,bl.y,tl.x,tl.y);felt.addColorStop(0,'#0f1b3e');felt.addColorStop(1,'#0e1732');ctx.fillStyle=felt;ctx.fill();
+    // rrjetë
+    const v1=0.5-(NET_H/2)/t.h,v2=0.5+(NET_H/2)/t.h;const A=project(0,v1,t),B=project(1,v1,t),C=project(1,v2,t),D=project(0,v2,t);
+    ctx.beginPath();ctx.moveTo(A.x,A.y);ctx.lineTo(B.x,B.y);ctx.lineTo(C.x,C.y);ctx.lineTo(D.x,D.y);ctx.closePath();ctx.fillStyle='#f5f8ff';ctx.fill();
+    // paddles
+    drawPaddle(top,true);drawPaddle(bot,false);
+    // top
+    drawBall(ball);
+  }
+
+  function drawPaddle(P,isTop){const t=T();const v=(P.y-t.y)/t.h;const s=scaleAt(v);const p=project((P.x-t.x)/t.w,v,t);const R=BLADE_R*s;
+    ctx.fillStyle=isTop?'#3aa7ff':'#ff4db8';ctx.beginPath();ctx.arc(p.x,p.y,R,0,Math.PI*2);ctx.fill();
+    // dorezë horizontale
+    ctx.fillStyle='#11172a';const hw=HANDLE_W*s,hl=HANDLE_L*s;ctx.fillRect(p.x+R,p.y-hw/2,hl,hw);
+  }
+
+  function drawBall(b){const t=T();const v=(b.y-t.y)/t.h;const s=scaleAt(v);const p=project((b.x-t.x)/t.w,v,t);const R=BALL_R*s;
+    ctx.fillStyle='#ff4db8';ctx.beginPath();ctx.arc(p.x,p.y,R,0,Math.PI*2);ctx.fill();}
+})();
+</script>
+</body>
+</html>

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -48,6 +48,8 @@ import BlackJack from './pages/Games/BlackJack.jsx';
 import BlackJackLobby from './pages/Games/BlackJackLobby.jsx';
 import PollRoyale from './pages/Games/PollRoyale.jsx';
 import PollRoyaleLobby from './pages/Games/PollRoyaleLobby.jsx';
+import PingPong from './pages/Games/PingPong.jsx';
+import PingPongLobby from './pages/Games/PingPongLobby.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -91,6 +93,8 @@ export default function App() {
             <Route path="/games/bubblepoproyale" element={<BubblePopRoyale />} />
             <Route path="/games/bubblesmashroyale/lobby" element={<BubbleSmashRoyaleLobby />} />
             <Route path="/games/bubblesmashroyale" element={<BubbleSmashRoyale />} />
+            <Route path="/games/pingpong/lobby" element={<PingPongLobby />} />
+            <Route path="/games/pingpong" element={<PingPong />} />
             <Route path="/games/texasholdem/lobby" element={<TexasHoldemLobby />} />
             <Route path="/games/texasholdem" element={<TexasHoldem />} />
             <Route path="/games/blackjack/lobby" element={<BlackJackLobby />} />

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -232,6 +232,18 @@ export default function Games() {
                 Murlan Royale
               </h3>
             </Link>
+            <Link
+              to="/games/pingpong/lobby"
+              className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+            >
+              <div className="h-20 w-20 flex items-center justify-center text-5xl">🏓</div>
+              <h3
+                className="text-sm font-semibold text-center text-yellow-400"
+                style={{ WebkitTextStroke: '1px black' }}
+              >
+                Ping Pong
+              </h3>
+            </Link>
           </div>
         </div>
       </div>

--- a/webapp/src/pages/Games/PingPong.jsx
+++ b/webapp/src/pages/Games/PingPong.jsx
@@ -1,0 +1,16 @@
+import { useLocation } from 'react-router-dom';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+
+export default function PingPong() {
+  useTelegramBackButton();
+  const { search } = useLocation();
+  return (
+    <div className="relative w-full h-screen">
+      <iframe
+        src={`/ping-pong.html${search}`}
+        title="Ping Pong"
+        className="w-full h-full border-0"
+      />
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/PingPongLobby.jsx
+++ b/webapp/src/pages/Games/PingPongLobby.jsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { ensureAccountId, getTelegramId } from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+
+export default function PingPongLobby() {
+  const navigate = useNavigate();
+  useTelegramBackButton();
+
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [mode, setMode] = useState('ai');
+  const [points, setPoints] = useState(11);
+
+  const startGame = async () => {
+    let tgId;
+    let accountId;
+    try {
+      accountId = await ensureAccountId();
+      const balRes = await getAccountBalance(accountId);
+      if ((balRes.balance || 0) < stake.amount) {
+        alert('Insufficient balance');
+        return;
+      }
+      tgId = getTelegramId();
+      await addTransaction(tgId, -stake.amount, 'stake', {
+        game: 'pingpong',
+        players: 2,
+        accountId,
+      });
+    } catch {}
+
+    const params = new URLSearchParams();
+    params.set('mode', mode);
+    if (stake.token) params.set('token', stake.token);
+    if (stake.amount) params.set('amount', stake.amount);
+    if (points) params.set('points', points);
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    navigate(`/games/pingpong?${params.toString()}`);
+  };
+
+  return (
+    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+      <h2 className="text-xl font-bold text-center">Ping Pong Lobby</h2>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Mode</h3>
+        <div className="flex gap-2">
+          {[
+            { id: 'ai', label: 'Vs AI' },
+            { id: 'online', label: 'Online', disabled: true }
+          ].map(({ id, label, disabled }) => (
+            <div key={id} className="relative">
+              <button
+                onClick={() => !disabled && setMode(id)}
+                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                  disabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={disabled}
+              >
+                {label}
+              </button>
+              {disabled && (
+                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                  Under development
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Points</h3>
+        <div className="flex gap-2">
+          {[11, 22, 33].map((p) => (
+            <button
+              key={p}
+              onClick={() => setPoints(p)}
+              className={`lobby-tile ${points === p ? 'lobby-selected' : ''}`}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Stake</h3>
+        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+      </div>
+      <button
+        onClick={startGame}
+        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
+      >
+        Start Game
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add minimal Ping Pong HTML game
- create PingPong React page and lobby with stake and point selection
- wire Ping Pong routes and entry in games list

## Testing
- `npm test`
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_68acc9966a5c8329a08fb3c81520ac05