### PR TITLE
Refine penalty kick mechanics

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -215,7 +215,8 @@
   let myScore = 0;
 
   const BALL_R = 42;
-  const SHOT_SPEED = 35;
+  // slower shot speed for more realistic ball travel
+  const SHOT_SPEED = 24;
   const ball = { x:0,y:0,r:BALL_R, vx:0,vy:0, moving:false, trail:[], spin:0, angle:0, netSounded:false, firstContact:false };
   const ballImg = new Image();
   ballImg.src = '/assets/icons/file_0000000061d4620aaf506adfa605e1f3.webp';
@@ -432,7 +433,8 @@
     ball.r=baseR;
     const goalY=geom.goal.y+geom.goal.h;
     const progress = ball.moving ? clamp((ball.y-goalY)/(geom.spot.y-goalY),0,1) : 1;
-    const drawR=baseR*(1+0.4*progress);
+    // start larger and shrink towards the goal
+    const drawR = baseR * (1 + 2 * progress);
     ctx.globalAlpha=0.25; for(const t of ball.trail){ ctx.beginPath(); ctx.arc(t.x,t.y,drawR*0.9,0,Math.PI*2); ctx.fillStyle='#fff'; ctx.fill(); } ctx.globalAlpha=1;
     ctx.save();
     ctx.translate(ball.x,ball.y);
@@ -445,7 +447,7 @@
   function stepBall(){
     if(!ball.moving) return;
     ball.trail.push({x:ball.x,y:ball.y}); if(ball.trail.length>15) ball.trail.shift();
-    const speed=Math.hypot(ball.vx,ball.vy); const drag = 1 - AIR_DRAG*speed; const curve = ball.spin*0.12;
+    const speed=Math.hypot(ball.vx,ball.vy); const drag = 1 - AIR_DRAG*speed; const curve = ball.spin*0.2;
     ball.vx = (ball.vx + curve)*FRICTION*drag; ball.vy = (ball.vy + GRAVITY)*FRICTION*drag;
     ball.x += ball.vx; ball.y += ball.vy; ball.angle += ball.spin*0.25;
 
@@ -493,12 +495,13 @@
       const predicted = ball.x + ball.vx * t;
       const diff = predicted - (keeper.baseX + keeper.w/2);
       const targetA = clamp(diff / 200, -0.8, 0.8);
-      keeper.a += (targetA - keeper.a) * 0.2;
+      keeper.a += (targetA - keeper.a) * 0.1;
       const targetX = clamp(diff * 0.05, -keeper.w*0.3, keeper.w*0.3);
-      keeper.x += (keeper.baseX + targetX - keeper.x) * 0.2;
-      keeper.save = Math.abs(diff) < keeper.w*0.45;
+      keeper.x += (keeper.baseX + targetX - keeper.x) * 0.1;
+      // keeper only saves about half the shots
+      keeper.save = Math.abs(diff) < keeper.w*0.45 && Math.random() < 0.5;
       const targetDive = keeper.save ? 12 : 0;
-      keeper.dive += (targetDive - keeper.dive) * 0.2;
+      keeper.dive += (targetDive - keeper.dive) * 0.1;
     } else {
       keeper.a *= 0.9;
       keeper.x += (keeper.baseX - keeper.x) * 0.1;
@@ -572,21 +575,70 @@ function endShot(hit,pts){
       for(let y=g.y;y<=g.y+g.h;y+=14){ c.beginPath(); c.moveTo(g.x,y); c.lineTo(g.x+g.w,y); c.stroke(); }
       c.restore();
       c.strokeStyle='#fff'; c.lineWidth=6; roundRect(c,g.x,g.y,g.w,g.h,6,false,true);
-      const kw = g.w*0.16, kh = kw*2.5;
-      const kx = g.x + (g.w-kw)/2, ky = g.y + g.h - kh + g.h*0.05;
-      c.drawImage(keeperImg, kx, ky, kw, kh);
+      const kw = g.w * 0.16, kh = kw * 2.5;
+      const kx = g.x + (g.w - kw) / 2, ky = g.y + g.h - kh + g.h * 0.05;
       const local = Array.isArray(miniHolesCache[i]) ? miniHolesCache[i] : [];
       if(init && !local.length){ miniHolesCache[i]=genMiniHoles(g); }
-        const list = Array.isArray(miniHolesCache[i]) ? miniHolesCache[i] : [];
-        for(const h of list){ c.fillStyle='rgba(225,6,0,.9)'; c.beginPath(); c.arc(h.x,h.y,h.r,0,Math.PI*2); c.fill(); c.fillStyle='#ffd400'; c.font='bold 12px system-ui'; c.textAlign='center'; c.textBaseline='middle'; c.fillText(h.p,h.x,h.y); }
-        for(const s of r.shots){ s.x+=s.vx; s.y+=s.vy; s.vy+=0.25; s.life-=0.02; c.fillStyle='#fff'; c.beginPath(); c.arc(s.x,s.y,4,0,Math.PI*2); c.fill(); if(s.life<0.6 && !s.fragments){ s.fragments=[]; for(let k=0;k<5;k++){ s.fragments.push({x:s.x,y:s.y,vx:rnd(-2,2),vy:rnd(-2,2),life:0.4}); }} if(s.fragments){ for(const f of s.fragments){ f.x+=f.vx; f.y+=f.vy; f.life-=0.03; c.fillRect(f.x,f.y,2,2); }} }
-        r.shots = r.shots.filter(s=>s.life>0);
-        r.ptsEl.textContent = r.score;
+      const list = Array.isArray(miniHolesCache[i]) ? miniHolesCache[i] : [];
+      for(const h of list){
+        c.fillStyle='rgba(225,6,0,.9)';
+        c.beginPath();
+        c.arc(h.x,h.y,h.r,0,Math.PI*2);
+        c.fill();
+        c.fillStyle='#ffd400';
+        c.font='bold 12px system-ui';
+        c.textAlign='center';
+        c.textBaseline='middle';
+        c.fillText(h.p,h.x,h.y);
       }
+      for(const s of r.shots){
+        s.x+=s.vx; s.y+=s.vy; s.vy+=0.25; s.life-=0.02;
+        // if keeper saves, stop the shot when it reaches the keeper
+        if(s.saved && s.y <= ky + kh * 0.2){ s.life = 0; continue; }
+        c.fillStyle='#fff';
+        c.beginPath();
+        c.arc(s.x,s.y,4,0,Math.PI*2);
+        c.fill();
+        if(s.life<0.6 && !s.fragments){
+          s.fragments=[];
+          for(let k=0;k<5;k++){
+            s.fragments.push({x:s.x,y:s.y,vx:rnd(-2,2),vy:rnd(-2,2),life:0.4});
+          }
+        }
+        if(s.fragments){
+          for(const f of s.fragments){ f.x+=f.vx; f.y+=f.vy; f.life-=0.03; c.fillRect(f.x,f.y,2,2); }
+        }
+      }
+      c.drawImage(keeperImg, kx, ky, kw, kh);
+      r.shots = r.shots.filter(s=>s.life>0);
+      r.ptsEl.textContent = r.score;
     }
+  }
   function genMiniHolesForCard(i){ const cv=rivals[i].cvs; const g={x:12,y:12,w:cv.width-24,h:cv.height-30}; miniHolesCache[i]=genMiniHoles(g); }
   function roundRect(c,x,y,w,h,r,fill,stroke,fillColor){ c.beginPath(); c.moveTo(x+r,y); c.arcTo(x+w,y,x+w,y+h,r); c.arcTo(x+w,y+h,x,y+h,r); c.arcTo(x,y+h,x,y,r); c.arcTo(x,y,x+w,y,r); if(fill){ if(fillColor){ const old=c.fillStyle; c.fillStyle=fillColor; c.fill(); c.fillStyle=old; } else c.fill(); } if(stroke) c.stroke(); }
-    function stepRivals(now){ if(!running||paused) return; const t = 1 - (timeLeft/ROUND_TIME); for(let i=0;i<rivals.length;i++){ const r=rivals[i]; if(now>r.next){ r.next = now + rnd(r.rate[0], r.rate[1]) * (1 - 0.45*t); const list = Array.isArray(miniHolesCache[i]) ? miniHolesCache[i] : []; if(list.length===0){ genMiniHolesForCard(i); continue; } const target = Math.random()<0.35 ? list.slice().sort((a,b)=>a.r-b.r)[0] : list[Math.floor(Math.random()*list.length)]; const acc = clamp(r.acc * (0.9 + 0.5*t), 0, 0.98); const chance = acc * (22/Math.max(10,target.r)); if(Math.random() < chance){ r.score += Math.max(5, Math.round(target.p)); sfxRival(); const cv=r.cvs; const g={x:12,y:12,w:cv.width-24,h:cv.height-30}; r.shots.push({x:g.x+g.w/2,y:g.y+g.h,vx:(target.x-(g.x+g.w/2))/15,vy:(target.y-(g.y+g.h))/15,life:1}); } } r.ptsEl.textContent = r.score; } }
+    function stepRivals(now){
+    if(!running||paused) return;
+    const t = 1 - (timeLeft/ROUND_TIME);
+    for(let i=0;i<rivals.length;i++){
+      const r=rivals[i];
+      if(now>r.next){
+        r.next = now + rnd(r.rate[0], r.rate[1]) * (1 - 0.45*t);
+        const list = Array.isArray(miniHolesCache[i]) ? miniHolesCache[i] : [];
+        if(list.length===0){ genMiniHolesForCard(i); continue; }
+        const target = Math.random()<0.35 ? list.slice().sort((a,b)=>a.r-b.r)[0] : list[Math.floor(Math.random()*list.length)];
+        const acc = clamp(r.acc * (0.9 + 0.5*t),0, 0.98);
+        const chance = acc * (22/Math.max(10,target.r));
+        if(Math.random() < chance){
+          const saved = Math.random() < 0.5;
+          if(!saved){ r.score += Math.max(5, Math.round(target.p)); }
+          sfxRival();
+          const cv=r.cvs; const g={x:12,y:12,w:cv.width-24,h:cv.height-30};
+          r.shots.push({x:g.x+g.w/2,y:g.y+g.h,vx:(target.x-(g.x+g.w/2))/15,vy:(target.y-(g.y+g.h))/15,life:1,saved});
+        }
+      }
+      r.ptsEl.textContent = r.score;
+    }
+  }
 
   // ===== Timer + loop =====
   function tick(now){ if(!running||paused) return; if(!roundStart) roundStart=now; timeLeft = Math.max(0, ROUND_TIME - (now - roundStart)); timeShort.textContent = Math.ceil(timeLeft/1000); if(timeLeft<=0){ finish(); } }


### PR DESCRIPTION
## Summary
- Slow down shot speed and add stronger curve with progressive ball size for more realistic kicks
- Soften keeper reactions with 50% save chance and draw mini keepers in front
- Let rival shots be stopped by keepers, respecting a 50% success rate

## Testing
- `npm test` *(fails: process hung after starting server; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6072bdd08329a09330b97283aa9a