### PR TITLE
chore: shrink blackjack pot info text

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -822,7 +822,7 @@
         top: calc(100% + 2px);
         left: 50%;
         transform: translateX(-50%);
-        font-size: 10px;
+        font-size: 9px;
         white-space: nowrap;
         text-align: center;
       }


### PR DESCRIPTION
## Summary
- reduce blackjack pot-info text to 9px so disclaimer appears smaller

## Testing
- `npm test` *(fails: process timed out/was interrupted after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68ad618160848329ac4e6cc9accff591