### PR TITLE
Remove dealer fee notice from blackjack multiplayer

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -939,7 +939,7 @@
         <div class="pot" id="pot"></div>
         <div class="pot-total" id="potTotal"></div>
         <div class="pot-info" id="potInfo">
-          No dealer: Highest hand wins. Dealer takes 10% from the winner.
+          No dealer: Highest hand wins.
         </div>
       </div>
       <div class="raise-container" id="raiseContainer">


### PR DESCRIPTION
## Summary
- remove note that dealer takes 10% from blackjack pot info

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad65056d808329b3fbf283453ea16f