### PR TITLE
feat: prioritize straight shots for pool AI

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -106,15 +106,23 @@ function generatePotCandidates(state, colour) {
   const shots = [];
   for (const ball of balls) {
     let bestPocket = null;
+    let bestAngle = Infinity;
     let bestDist = Infinity;
     for (const pocket of state.pockets) {
+      // prefer pockets that give the straightest line to the cue
+      if (pathBlocked(ball, pocket, state.balls, [cue.id, ball.id], state.ballRadius)) continue;
+      const angle = cutAngle(cue, ball, pocket);
       const d = dist(ball, pocket);
-      if (d < bestDist) { bestDist = d; bestPocket = pocket; }
+      if (angle < bestAngle - 1e-6 || (Math.abs(angle - bestAngle) <= 1e-6 && d < bestDist)) {
+        bestAngle = angle;
+        bestDist = d;
+        bestPocket = pocket;
+      }
     }
     if (bestPocket && !pathBlocked(ball, bestPocket, state.balls, [cue.id, ball.id], state.ballRadius)) {
-      const angle = cutAngle(cue, ball, bestPocket);
+      const angle = bestAngle;
       const distCT = dist(cue, ball);
-      const distTP = dist(ball, bestPocket);
+      const distTP = bestDist;
       const shot = {
         actionType: 'pot',
         targetBall: ball,
@@ -244,6 +252,9 @@ function estimatePotProbability(shot, state) {
     P -= 0.1;
   }
   if (state.shotsRemaining && state.shotsRemaining > 1) P += 0.05; // under pressure bonus
+  // bonus for near-straight shots
+  const straightBonus = Math.max(0, (10 - angleDeg) / 100);
+  P += straightBonus;
   return Math.max(0, Math.min(1, P));
 }
 
@@ -288,22 +299,33 @@ function generateFastCandidates(state, colour) {
   if (ownBalls.length === 0) return [];
   const ball = ownBalls.reduce((m, b) => dist(cue, b) < dist(cue, m) ? b : m, ownBalls[0]);
   let bestPocket = null;
+  let bestAngle = Infinity;
   let bestDist = Infinity;
   for (const p of state.pockets) {
     if (pathBlocked(ball, p, state.balls, [cue.id, ball.id], state.ballRadius)) continue;
+    const angle = cutAngle(cue, ball, p);
     const d = dist(ball, p);
-    if (d < bestDist) { bestDist = d; bestPocket = p; }
+    if (angle < bestAngle - 1e-6 || (Math.abs(angle - bestAngle) <= 1e-6 && d < bestDist)) {
+      bestAngle = angle;
+      bestDist = d;
+      bestPocket = p;
+    }
   }
   if (!bestPocket) return [];
-  return [{ actionType: 'pot', targetBall: ball, pocket: bestPocket, cueParams: { speed: 'med', spin: 'stun' }, angle: cutAngle(cue, ball, bestPocket), distCT: dist(cue, ball), distTP: bestDist }];
+  return [{ actionType: 'pot', targetBall: ball, pocket: bestPocket, cueParams: { speed: 'med', spin: 'stun' }, angle: bestAngle, distCT: dist(cue, ball), distTP: bestDist }];
 }
 
 function valueOfPositionAfter(nc, state, colour) {
   // simple heuristic: high if still have easy pot
   const P2 = estimatePotProbability(nc, state);
+  // reward straighter follow-up shots
+  const straightBonus =
+    typeof nc.angle === 'number'
+      ? Math.max(0, (Math.PI / 12 - nc.angle) / (Math.PI / 12)) * 0.2
+      : 0;
   const remaining = state.balls.filter(b => b.colour === colour && !b.pocketed).length;
   const base = remaining <= 1 ? 1.2 : 0.8; // higher when nearly finishing
-  return P2 * base;
+  return (P2 + straightBonus) * base;
 }
 
 function foulRisk(shot, state) {


### PR DESCRIPTION
## Summary
- Prefer pockets with minimal cut angle when selecting pot shots
- Reward near-straight shots in probability and position evaluation to keep cue ball aligned for follow-ups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad6389646c8329b36b045561153744