### PR TITLE
Prioritize straight shots for pool AI

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -395,6 +395,13 @@ function chooseBestAction(state, colour) {
       candidates = candidates.concat(generateSafeties(state, colour));
     }
   }
+  const STRAIGHT_THRESHOLD = Math.PI / 12; // ~15 degrees
+  const straightShots = candidates.filter(
+    c => typeof c.angle === 'number' && c.angle <= STRAIGHT_THRESHOLD
+  );
+  if (straightShots.length > 0) {
+    candidates = straightShots;
+  }
   const best = evaluateCandidates(state, colour, candidates);
   if (!best) return null;
   const c = best.c;

--- a/test/poolUkAdvancedAi.test.js
+++ b/test/poolUkAdvancedAi.test.js
@@ -72,3 +72,24 @@ test('uses free ball when available', () => {
   assert.equal(plan.actionType, 'freeBallPot');
 });
 
+test('prioritizes straight pots', () => {
+  const state = {
+    balls: [
+      { id: 0, colour: 'cue', x: 100, y: 250 },
+      { id: 1, colour: 'yellow', x: 800, y: 250 }, // straight shot
+      { id: 2, colour: 'yellow', x: 200, y: 300 } // angled shot
+    ],
+    pockets: makePockets(),
+    width: 1000,
+    height: 500,
+    ballRadius: 10,
+    ballOn: 'yellow',
+    isOpenTable: false,
+    shotsRemaining: 1
+  };
+  const plan = selectShot(state, {});
+  assert.equal(plan.targetBall, 'yellow');
+  assert.equal(plan.aimPoint.x, 800);
+  assert.equal(plan.aimPoint.y, 250);
+});
+


### PR DESCRIPTION
## Summary
- teach pool AI to consider straight pot shots first
- add test verifying straight shot prioritization

## Testing
- `npm test` *(fails: ERR_DLOPEN_FAILED in canvas)*
- `node --test test/poolUkAdvancedAi.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad69b4c32c8329a8c6bc76881d14d8