### PR TITLE
feat: follow swipe path for penalty kicks

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -556,8 +556,24 @@ function endShot(hit,pts){
   function pos(e){ const r=canvas.getBoundingClientRect(); return {x:(e.clientX-r.left)*(W/r.width), y:(e.clientY-r.top)*(H/r.height)}; }
   function onDown(e){ if(!running||ended||paused) return; if(pointer.active) return; pointer.active=true; pointer.id=e.pointerId; const p=pos(e); pointer.path=[p]; pointer.t0=performance.now(); pointer.t1=pointer.t0; pointer.armed = Math.hypot(p.x-ball.x,p.y-ball.y) <= ball.r*1.8 && !ball.moving; if(pointer.armed){ status('Swipe upward. Curve for spin.'); sfxKick(); } }
   function onMove(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.path.push(pos(e)); pointer.t1=performance.now();
-    if(pointer.armed && aimOn && pointer.path.length>1){ const path=pointer.path; const a=path[0], b=path[path.length-1], c=path[path.length-2]; const totalDx=b.x-a.x, totalDy=b.y-a.y, dt=Math.max(16,(pointer.t1-pointer.t0)); const dist=Math.hypot(totalDx,totalDy), power=clamp(dist/dt, 0.55, 3.0); const segDx=b.x-c.x, segDy=b.y-c.y, len=Math.max(1,Math.hypot(segDx,segDy)); const dirx=segDx/len, diry=segDy/len; const mid=path[Math.floor(path.length/2)]; const curve=Math.atan2(b.y-mid.y, b.x-mid.x) - Math.atan2(mid.y-a.y, mid.x-a.x); const spin = clamp((ball.x - a.x)/ball.r + curve*0.5, -2, 2); drawAimPath(dirx*SHOT_SPEED*power*0.9, diry*SHOT_SPEED*power*0.9, spin); } }
-  function onUp(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.active=false; if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; } const path=pointer.path; pointer.path=[]; if(path.length<3){ status('Swipe longer/faster.'); return; } const dt=Math.max(16,(pointer.t1-pointer.t0)), a=path[0], b=path[path.length-1], c=path[path.length-2]; const totalDx=b.x-a.x, totalDy=b.y-a.y; if(totalDy>-10){ status('Swipe upward.'); return; } const dist=Math.hypot(totalDx,totalDy), power=clamp(dist/dt, 0.55, 3.0); const segDx=b.x-c.x, segDy=b.y-c.y, len=Math.max(1,Math.hypot(segDx,segDy)); const dirx=segDx/len, diry=segDy/len; const mid=path[Math.floor(path.length/2)]; const curve=Math.atan2(b.y-mid.y, b.x-mid.x) - Math.atan2(mid.y-a.y, mid.x-a.x); const spin = clamp((ball.x - a.x)/ball.r + curve*0.5, -2, 2); ball.vx=dirx*SHOT_SPEED*power*0.9; ball.vy=diry*SHOT_SPEED*power*0.9; ball.spin=spin; ball.moving=true; keeper.save=false; powerBar.style.height = Math.round(clamp(power/3.0,0,1)*100)+'%'; }
+    if(pointer.armed && aimOn && pointer.path.length>1){
+      const path = pointer.path;
+      const a = path[0], b = path[path.length - 1];
+      const totalDx = b.x - a.x, totalDy = b.y - a.y;
+      const dt = Math.max(16, (pointer.t1 - pointer.t0));
+      const dist = Math.hypot(totalDx, totalDy), power = clamp(dist / dt, 0.55, 3.0);
+      const len = Math.max(1, dist);
+      const dirx = totalDx / len, diry = totalDy / len;
+      let curve = 0;
+      for(let i = 2; i < path.length; i++){
+        const p0 = path[i-2], p1 = path[i-1], p2 = path[i];
+        curve += Math.atan2(p2.y - p1.y, p2.x - p1.x) - Math.atan2(p1.y - p0.y, p1.x - p0.x);
+      }
+      const spin = clamp((ball.x - a.x)/ball.r + curve*0.5, -2, 2);
+      drawAimPath(dirx*SHOT_SPEED*power*0.9, diry*SHOT_SPEED*power*0.9, spin);
+    }
+  }
+  function onUp(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.active=false; if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; } const path=pointer.path; pointer.path=[]; if(path.length<3){ status('Swipe longer/faster.'); return; } const dt=Math.max(16,(pointer.t1-pointer.t0)), a=path[0], b=path[path.length-1]; const totalDx=b.x-a.x, totalDy=b.y-a.y; if(totalDy>-10){ status('Swipe upward.'); return; } const dist=Math.hypot(totalDx,totalDy), power=clamp(dist/dt, 0.55, 3.0); const len=Math.max(1,dist); const dirx=totalDx/len, diry=totalDy/len; let curve=0; for(let i=2;i<path.length;i++){ const p0=path[i-2], p1=path[i-1], p2=path[i]; curve+=Math.atan2(p2.y-p1.y,p2.x-p1.x)-Math.atan2(p1.y-p0.y,p1.x-p0.x); } const spin = clamp((ball.x - a.x)/ball.r + curve*0.5, -2, 2); ball.vx=dirx*SHOT_SPEED*power*0.9; ball.vy=diry*SHOT_SPEED*power*0.9; ball.spin=spin; ball.moving=true; keeper.save=false; powerBar.style.height = Math.round(clamp(power/3.0,0,1)*100)+'%'; }
   canvas.addEventListener('pointerdown', onDown, {passive:true});
   canvas.addEventListener('pointermove', onMove, {passive:true});
   addEventListener('pointerup', onUp, {passive:true}); addEventListener('pointercancel', onUp, {passive:true});


### PR DESCRIPTION
## Summary
- base penalty kick direction on the full swipe
- derive spin from swipe path curvature for a matching curve

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad6b124b0c83298f378e053c87b265