### PR TITLE
feat: prioritize central pool shots

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -423,26 +423,42 @@ function evaluateCandidates(state, colour, candidates) {
 }
 
 function chooseBestAction(state, colour) {
-  let candidates = generatePotCandidates(state, colour).concat(generateBankPotCandidates(state, colour));
+  let potCandidates = generatePotCandidates(state, colour).concat(generateBankPotCandidates(state, colour));
   if (state.freeBallAvailable) {
-    candidates = candidates.concat(generateFreeBallCandidates(state, colour));
+    potCandidates = potCandidates.concat(generateFreeBallCandidates(state, colour));
   }
+
+  const THIN_MAX_ANGLE = Math.PI / 3; // ~60 degrees
+  potCandidates = potCandidates.filter(c => typeof c.angle !== 'number' || c.angle <= THIN_MAX_ANGLE);
+
+  const CENTER_ANGLE = Math.PI / 18; // ~10 degrees
+  const STRAIGHT_VIEW_ANGLE = Math.PI / 9; // ~20 degrees
+  const NEAR_POCKET_DIST = state.ballRadius * 6;
+  const centerShots = potCandidates.filter(c => !c.isBank && typeof c.angle === 'number' && c.angle <= CENTER_ANGLE);
+  if (centerShots.length > 0) {
+    potCandidates = centerShots;
+  } else {
+    const nearPocketShots = potCandidates.filter(
+      c =>
+        !c.isBank &&
+        typeof c.angle === 'number' &&
+        c.angle <= STRAIGHT_VIEW_ANGLE &&
+        typeof c.distTP === 'number' &&
+        c.distTP <= NEAR_POCKET_DIST
+    );
+    if (nearPocketShots.length > 0) potCandidates = nearPocketShots;
+  }
+
+  let candidates = potCandidates;
   if (candidates.length === 0) {
     candidates = generateSafeties(state, colour);
   } else {
-    const scored = candidates.map(c => estimatePotProbability(c, state));
-    const maxPot = scored.reduce((m, p) => Math.max(m, p), 0);
+    const maxPot = candidates.reduce((m, c) => Math.max(m, estimatePotProbability(c, state)), 0);
     if (maxPot < 0.25) {
       candidates = candidates.concat(generateSafeties(state, colour));
     }
   }
-  const STRAIGHT_THRESHOLD = Math.PI / 12; // ~15 degrees
-  const straightShots = candidates.filter(
-    c => typeof c.angle === 'number' && c.angle <= STRAIGHT_THRESHOLD
-  );
-  if (straightShots.length > 0) {
-    candidates = straightShots;
-  }
+
   const best = evaluateCandidates(state, colour, candidates);
   if (!best) return null;
   const c = best.c;
@@ -464,7 +480,6 @@ function chooseBestAction(state, colour) {
     distToPocket: typeof c.distTP === 'number' ? c.distTP : undefined
   };
 }
-
 // Public entry
 export function selectShot(state, rules = {}) {
   let colour = state.ballOn;

--- a/test/poolUkAdvancedAi.test.js
+++ b/test/poolUkAdvancedAi.test.js
@@ -93,3 +93,44 @@ test('prioritizes straight pots', () => {
   assert.equal(plan.aimPoint.y, 250);
 });
 
+test('prefers near-pocket shots when no straight option', () => {
+  const state = {
+    balls: [
+      { id: 0, colour: 'cue', x: 400, y: 250 },
+      { id: 1, colour: 'yellow', x: 950, y: 260 }, // near pocket, small angle
+      { id: 2, colour: 'yellow', x: 500, y: 400 } // farther thin cut
+    ],
+    pockets: makePockets(),
+    width: 1000,
+    height: 500,
+    ballRadius: 10,
+    ballOn: 'yellow',
+    isOpenTable: false,
+    shotsRemaining: 1
+  };
+  const plan = selectShot(state, {});
+  assert.equal(plan.targetBall, 'yellow');
+  assert.equal(plan.aimPoint.x, 950);
+  assert.equal(plan.aimPoint.y, 260);
+});
+
+test('avoids very thin shots and plays safety', () => {
+  const state = {
+    balls: [
+      { id: 0, colour: 'cue', x: 100, y: 250 },
+      { id: 1, colour: 'yellow', x: 200, y: 150 },
+      { id: 2, colour: 'red', x: 500, y: 188 }, // blocks path to MR
+      { id: 3, colour: 'red', x: 500, y: 90 } // blocks path to TR
+    ],
+    pockets: makePockets(),
+    width: 1000,
+    height: 500,
+    ballRadius: 10,
+    ballOn: 'yellow',
+    isOpenTable: false,
+    shotsRemaining: 1
+  };
+  const plan = selectShot(state, {});
+  assert.equal(plan.actionType, 'safety');
+});
+


### PR DESCRIPTION
## Summary
- prioritize straight-on shots and avoid extreme edge hits in UK pool AI
- add tests for near-pocket preference and thin-shot safety fallback

## Testing
- `npm test` *(fails to exit, but all tests including new ones pass)*
- `npm run lint` *(fails: 1294 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ad82414a288329a7e37d9e476b5728