### PR TITLE
feat: prioritize straight and near-pocket shots

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -30,6 +30,7 @@
  * @property {number} [targetBallId]
  * @property {{x:number,y:number}} [targetPocket]
  * @property {number} quality
+ * @property {'CENTRAL'|'NEAR_POCKET'|'THIN'|'EXTREME'} category
  * @property {string} rationale
  */
 
@@ -156,10 +157,26 @@ function evaluate(req, cue, target, pocket, power, spin) {
   const potVec = { x: pocket.x - target.x, y: pocket.y - target.y };
   const cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x));
   const centerAlign = 1 - Math.min(cutAngle / (Math.PI / 2), 1);
-  const quality = Math.max(
+  const baseQuality = Math.max(
     0,
     Math.min(1, 0.6 * potChance + 0.2 * centerAlign + 0.2 * nextScore - 0.2 * risk)
   );
+  let category = 'EXTREME';
+  if (cutAngle < 0.05) {
+    category = 'CENTRAL';
+  } else if (dist(target, pocket) < r * 8 && cutAngle < 0.35) {
+    category = 'NEAR_POCKET';
+  } else if (cutAngle < Math.PI / 4) {
+    category = 'THIN';
+  }
+  const quality =
+    category === 'CENTRAL'
+      ? baseQuality
+      : category === 'NEAR_POCKET'
+        ? baseQuality * 0.9
+        : category === 'THIN'
+          ? baseQuality * 0.7
+          : baseQuality * 0.4;
   const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x);
   return {
     angleRad: angle,
@@ -168,6 +185,7 @@ function evaluate(req, cue, target, pocket, power, spin) {
     targetBallId: target.id,
     targetPocket: pocket,
     quality,
+    category,
     rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)}`
   };
 }
@@ -182,7 +200,7 @@ export function planShot(req) {
   const targets = chooseTargets(req);
   const start = Date.now();
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity;
-  let best = null;
+  const bestByCat = { CENTRAL: null, NEAR_POCKET: null, THIN: null, EXTREME: null };
   outer: for (const target of targets) {
     for (const pocket of pockets) {
       const powers = [0.6, 0.8, 1.0];
@@ -195,16 +213,24 @@ export function planShot(req) {
         for (const spin of spins) {
           if (Date.now() > deadline) break outer;
           const cand = evaluate(req, cue, target, pocket, power, spin);
-          if (cand && (!best || cand.quality > best.quality)) best = cand;
+          if (cand) {
+            const b = bestByCat[cand.category];
+            if (!b || cand.quality > b.quality) bestByCat[cand.category] = cand;
+          }
         }
       }
     }
   }
-  return best || {
+  const ordered = ['CENTRAL', 'NEAR_POCKET', 'THIN', 'EXTREME'];
+  for (const cat of ordered) {
+    if (bestByCat[cat]) return bestByCat[cat];
+  }
+  return {
     angleRad: 0,
     power: 0,
     spin: { top: 0, side: 0, back: 0 },
     quality: 0,
+    category: 'EXTREME',
     rationale: 'no shot'
   };
 }

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -53,3 +53,57 @@ test('eight ball is treated as normal', () => {
   const decision = planShot(req);
   assert.equal(decision.targetBallId, 8);
 });
+
+test('straight shots are prioritised over near-pocket shots', () => {
+  const req = {
+    game: 'EIGHT_POOL_UK',
+    state: {
+      balls: [
+        { id: 0, x: 100, y: 100, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 300, y: 300, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 940, y: 460, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      myGroup: 'UNASSIGNED'
+    },
+    timeBudgetMs: 50,
+    rngSeed: 1
+  };
+  const decision = planShot(req);
+  assert.equal(decision.targetBallId, 1);
+  assert.equal(decision.category, 'CENTRAL');
+});
+
+test('near-pocket shots are prioritised over thin cuts when no straight shot', () => {
+  const req = {
+    game: 'EIGHT_POOL_UK',
+    state: {
+      balls: [
+        { id: 0, x: 100, y: 100, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 940, y: 460, vx: 0, vy: 0, pocketed: false },
+        { id: 3, x: 400, y: 300, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      myGroup: 'UNASSIGNED'
+    },
+    timeBudgetMs: 50,
+    rngSeed: 1
+  };
+  const decision = planShot(req);
+  assert.equal(decision.targetBallId, 2);
+  assert.equal(decision.category, 'NEAR_POCKET');
+});


### PR DESCRIPTION
## Summary
- rank candidate shots by angle, proximity to pocket, and thinness
- choose highest priority shot category before evaluating quality
- add tests for straight, near-pocket, and thin shot selection

## Testing
- `node --test test/poolAi.test.js`
- `npm run lint` *(fails: 1302 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8ce9f26c8329a8220ad7ff1c504d