### PR TITLE
feat: enhance penalty kick game visuals and audio

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -276,27 +276,23 @@
 
   // ===== Targets =====
   function generateHoles(){
-    const g=geom.goal; holes=[]; const cnt=6+Math.floor(Math.random()*7);
+    const g=geom.goal; holes=[];
     const minR=Math.max(ball.r*1.05,22*geom.scale); const maxR=Math.max(minR+6,50*geom.scale);
-    const pad=18; let tries=0;
-    while(holes.length<cnt && tries<1600){
-      tries++;
-      const r=rnd(minR,maxR);
-      let x;
-      if(Math.random() < 0.6){
-        const side = Math.random() < 0.5 ? 'l' : 'r';
-        const range = g.w * 0.2;
-        if(side === 'l') x = rnd(g.x+pad+r, g.x+pad+range);
-        else x = rnd(g.x+g.w-pad-range, g.x+g.w-pad-r);
-      } else {
-        x = rnd(g.x+pad+r,g.x+g.w-pad-r);
-      }
-      const y=rnd(g.y+pad+r,g.y+g.h-pad-r);
-      if(holes.every(h=>Math.hypot(h.x-x,h.y-y)>h.r+r+12)){
-        const points=Math.max(10,Math.round(((maxR/r)*70)/5)*5);
-        holes.push({x,y,r,points});
-      }
-    }
+    const pad=18;
+    const corners=[
+      {x:g.x+pad+minR,y:g.y+pad+minR},
+      {x:g.x+g.w-pad-minR,y:g.y+pad+minR},
+      {x:g.x+pad+minR,y:g.y+g.h-pad-minR},
+      {x:g.x+g.w-pad-minR,y:g.y+g.h-pad-minR}
+    ];
+    const usedR=[];
+    corners.forEach((c,i)=>{
+      let r;
+      do{ r=rnd(minR,maxR); }while(usedR.some(v=>Math.abs(v-r)<1));
+      usedR.push(r);
+      const points=Math.max(10,Math.round(((maxR/r)*70)/5)*5);
+      holes.push({x:c.x,y:c.y,r,points,corner:i});
+    });
     for(let i=0;i<3;i++){ const cv=rivals[i].cvs; const g2={x:12,y:12,w:cv.width-24,h:cv.height-30}; miniHolesCache[i]=genMiniHoles(g2); }
   }
   function replaceHole(old){
@@ -304,19 +300,26 @@
     if(idx===-1) return;
     const g=geom.goal;
     const minR=Math.max(ball.r*1.05,22*geom.scale); const maxR=Math.max(minR+6,50*geom.scale);
-    const pad=18; let tries=0;
+    const pad=18;
+    if(old.corner!==undefined){
+      const corners=[
+        {x:g.x+pad+minR,y:g.y+pad+minR},
+        {x:g.x+g.w-pad-minR,y:g.y+pad+minR},
+        {x:g.x+pad+minR,y:g.y+g.h-pad-minR},
+        {x:g.x+g.w-pad-minR,y:g.y+g.h-pad-minR}
+      ];
+      const used=holes.filter(h=>h.corner!==undefined && h!==old).map(h=>h.r);
+      let r;
+      do{ r=rnd(minR,maxR); }while(used.some(v=>Math.abs(v-r)<1));
+      const points=Math.max(10,Math.round(((maxR/r)*70)/5)*5);
+      holes[idx]={x:corners[old.corner].x,y:corners[old.corner].y,r,points,corner:old.corner};
+      return;
+    }
+    let tries=0;
     while(tries<600){
       tries++;
       const r=rnd(minR,maxR);
-      let x;
-      if(Math.random() < 0.6){
-        const side = Math.random() < 0.5 ? 'l' : 'r';
-        const range = g.w * 0.2;
-        if(side === 'l') x = rnd(g.x+pad+r, g.x+pad+range);
-        else x = rnd(g.x+g.w-pad-range, g.x+g.w-pad-r);
-      } else {
-        x = rnd(g.x+pad+r,g.x+g.w-pad-r);
-      }
+      let x=rnd(g.x+pad+r,g.x+g.w-pad-r);
       const y=rnd(g.y+pad+r,g.y+g.h-pad-r);
       if(holes.every(h=>h===old||Math.hypot(h.x-x,h.y-y)>h.r+r+12)){
         const points=Math.max(10,Math.round(((maxR/r)*70)/5)*5);
@@ -377,29 +380,45 @@
     const g=geom.goal;
     const innerW=g.w*0.8, innerH=g.h*0.8;
     const ix=g.x+(g.w-innerW)/2, iy=g.y+(g.h-innerH)/2;
-    ctx.save();
-    ctx.beginPath();
-    ctx.rect(ix,iy,innerW,innerH);
-    ctx.clip();
     const netColor=getComputedStyle(document.documentElement).getPropertyValue('--net')||'#e6e6e6';
     ctx.strokeStyle=netColor; ctx.lineWidth=1.2;
-    const size=18; const h=size*Math.sqrt(3)/2;
-    for(let y=iy-h; y<iy+innerH+h; y+=h){
-      for(let x=ix-size; x<ix+innerW+size; x+=size*1.5){
-        const off = ((Math.round((y-iy)/h))%2)*size*0.75;
-        const cx=x+off, cy=y;
-        ctx.beginPath();
-        for(let i=0;i<6;i++){
-          const a=Math.PI/3*i; let px=cx+size*Math.cos(a); let py=cy+size*Math.sin(a);
-          const dx=netHit.x-px, dy=netHit.y-py; const dist=Math.hypot(dx,dy);
-          if(netHit.t>0){ const pull=Math.exp(-dist/80)*14*netHit.t; px+=dx/dist*pull; py+=dy/dist*pull; }
-          if(netHit.shake>0){ py+=Math.sin((px+py+i)*0.3+performance.now()*0.02)*netHit.shake*3; }
-          if(i===0) ctx.moveTo(px,py); else ctx.lineTo(px,py);
+
+    function drawHexNet(){
+      const size=18; const h=size*Math.sqrt(3)/2;
+      const minX=ix-g.w, maxX=ix+innerW+g.w;
+      const minY=iy-g.h, maxY=iy+innerH+g.h;
+      for(let y=minY-h; y<maxY+h; y+=h){
+        for(let x=minX-size; x<maxX+size; x+=size*1.5){
+          const off=((Math.round((y-iy)/h))%2)*size*0.75;
+          const cx=x+off, cy=y;
+          ctx.beginPath();
+          for(let i=0;i<6;i++){
+            const a=Math.PI/3*i; let px=cx+size*Math.cos(a); let py=cy+size*Math.sin(a);
+            const dx=netHit.x-px, dy=netHit.y-py; const dist=Math.hypot(dx,dy);
+            if(netHit.t>0){ const pull=Math.exp(-dist/80)*14*netHit.t; px+=dx/dist*pull; py+=dy/dist*pull; }
+            if(netHit.shake>0){ py+=Math.sin((px+py+i)*0.3+performance.now()*0.02)*netHit.shake*3; }
+            if(i===0) ctx.moveTo(px,py); else ctx.lineTo(px,py);
+          }
+          ctx.closePath(); ctx.stroke();
         }
-        ctx.closePath(); ctx.stroke();
       }
     }
-    ctx.restore();
+
+    function drawNetPoly(points){
+      ctx.save();
+      ctx.beginPath();
+      ctx.moveTo(points[0][0],points[0][1]);
+      for(let i=1;i<points.length;i++){ ctx.lineTo(points[i][0],points[i][1]); }
+      ctx.closePath();
+      ctx.clip();
+      drawHexNet();
+      ctx.restore();
+    }
+
+    drawNetPoly([[ix,iy],[ix+innerW,iy],[ix+innerW,iy+innerH],[ix,iy+innerH]]); // back
+    drawNetPoly([[g.x,g.y],[ix,iy],[ix,iy+innerH],[g.x,g.y+g.h]]); // left
+    drawNetPoly([[g.x+g.w,g.y],[ix+innerW,iy],[ix+innerW,iy+innerH],[g.x+g.w,g.y+g.h]]); // right
+    drawNetPoly([[g.x,g.y],[g.x+g.w,g.y],[ix+innerW,iy],[ix,iy]]); // top
     ctx.strokeStyle='#fff'; ctx.lineWidth=4;
     ctx.beginPath();
     ctx.moveTo(g.x, g.y+g.h);
@@ -451,7 +470,20 @@
     const baseR=Math.max(BALL_R*geom.scale*1.08,22);
     ball.r=baseR;
     const drawR = baseR;
-    ctx.globalAlpha=0.25; for(const t of ball.trail){ ctx.beginPath(); ctx.arc(t.x,t.y,drawR*0.9,0,Math.PI*2); ctx.fillStyle='#fff'; ctx.fill(); } ctx.globalAlpha=1;
+    ctx.save();
+    ctx.filter='blur(2px)';
+    for(let i=1;i<ball.trail.length;i++){
+      const p0=ball.trail[i-1], p1=ball.trail[i];
+      const alpha=i/ball.trail.length;
+      ctx.strokeStyle=`rgba(255,255,255,${0.25*alpha})`;
+      ctx.lineWidth=drawR*0.6*(1-i/ball.trail.length);
+      ctx.lineCap='round';
+      ctx.beginPath();
+      ctx.moveTo(p0.x,p0.y);
+      ctx.lineTo(p1.x,p1.y);
+      ctx.stroke();
+    }
+    ctx.restore();
     ctx.save();
     ctx.translate(ball.x,ball.y);
     ctx.rotate(ball.angle);
@@ -462,7 +494,7 @@
   const FRICTION=0.985, AIR_DRAG=0.0015, GRAVITY=0.20;
   function stepBall(){
     if(!ball.moving) return;
-    ball.trail.push({x:ball.x,y:ball.y}); if(ball.trail.length>15) ball.trail.shift();
+    ball.trail.push({x:ball.x,y:ball.y}); if(ball.trail.length>20) ball.trail.shift();
     const speed=Math.hypot(ball.vx,ball.vy); const drag = 1 - AIR_DRAG*speed; const curve = ball.spin*0.18;
     ball.vx = (ball.vx + curve)*FRICTION*drag; ball.vy = (ball.vy + GRAVITY)*FRICTION*drag;
     ball.x += ball.vx; ball.y += ball.vy; ball.angle += ball.spin;
@@ -471,7 +503,7 @@
     if(ball.x>g.x && ball.x<g.x+g.w && ball.y>g.y && ball.y<g.y+g.h){
       for(const h of holes){
         if(Math.hypot(h.x-ball.x,h.y-ball.y) <= Math.max(2,h.r-ball.r*0.6)){
-          h.hit=true; createFragments(h); netHit={x:ball.x,y:ball.y,t:1,shake:1}; sfxBreak(); ball.moving=false; setTimeout(()=>{endShot(true,h.points); replaceHole(h);},600); return;
+          h.hit=true; createFragments(h); netHit={x:ball.x,y:ball.y,t:1,shake:1}; sfxBreak(); ball.moving=false; replaceHole(h); endShot(true,h.points); return;
         }
       }
       ball.vx*=0.86; ball.vy*=0.74; netHit={x:ball.x,y:ball.y,t:1,shake:1};
@@ -484,10 +516,10 @@
     const postR = g.post;
     const left={x:g.x, y:g.y+g.h}, right={x:g.x+g.w, y:g.y+g.h};
     let d=Math.hypot(ball.x-left.x, ball.y-left.y);
-    if(d < ball.r + postR){ const nx=(ball.x-left.x)/d, ny=(ball.y-left.y)/d; reflectBall(nx,ny); sfxWoodwork(); }
+    if(d < ball.r + postR){ const nx=(ball.x-left.x)/d, ny=(ball.y-left.y)/d; reflectBall(nx,ny); sfxReward(); }
     d=Math.hypot(ball.x-right.x, ball.y-right.y);
-    if(d < ball.r + postR){ const nx=(ball.x-right.x)/d, ny=(ball.y-right.y)/d; reflectBall(nx,ny); sfxWoodwork(); }
-    if(ball.y - ball.r <= g.y && ball.x > g.x - postR && ball.x < g.x + g.w + postR){ if(ball.vy < 0){ reflectBall(0,1); ball.y = g.y + ball.r; sfxWoodwork(); }}
+    if(d < ball.r + postR){ const nx=(ball.x-right.x)/d, ny=(ball.y-right.y)/d; reflectBall(nx,ny); sfxReward(); }
+    if(ball.y - ball.r <= g.y && ball.x > g.x - postR && ball.x < g.x + g.w + postR){ if(ball.vy < 0){ reflectBall(0,1); ball.y = g.y + ball.r; sfxReward(); }}
 
     if(ball.tx || ball.ty){
       const dToTarget = Math.hypot(ball.tx - ball.x, ball.ty - ball.y);
@@ -558,7 +590,7 @@ function endShot(hit,pts){
     myScore += pts;
     status('GOAL! +' + pts);
     sfxGoal();
-    sfxReward();
+    if(pts>0) sfxWoodwork(); else sfxReward();
     vibrate(25);
   } else {
     status('Missed.');
@@ -580,7 +612,7 @@ function endShot(hit,pts){
   // ===== Input (swipe/flick + spin) =====
   let pointer={id:null,path:[],active:false,armed:false,t0:0,t1:0};
   function pos(e){ const r=canvas.getBoundingClientRect(); return {x:(e.clientX-r.left)*(W/r.width), y:(e.clientY-r.top)*(H/r.height)}; }
-  function onDown(e){ if(!running||ended||paused) return; if(pointer.active) return; pointer.active=true; pointer.id=e.pointerId; const p=pos(e); pointer.path=[p]; pointer.t0=performance.now(); pointer.t1=pointer.t0; pointer.armed = Math.hypot(p.x-ball.x,p.y-ball.y) <= ball.r*2.4 && !ball.moving; if(pointer.armed){ status('Swipe upward. Curve for spin.'); sfxKick(); } }
+  function onDown(e){ if(!running||ended||paused) return; if(pointer.active) return; pointer.active=true; pointer.id=e.pointerId; const p=pos(e); pointer.path=[p]; pointer.t0=performance.now(); pointer.t1=pointer.t0; pointer.armed = Math.hypot(p.x-ball.x,p.y-ball.y) <= ball.r*2.4 && !ball.moving; if(pointer.armed){ status('Swipe upward. Curve for spin.'); } }
   function onMove(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.path.push(pos(e)); pointer.t1=performance.now();
     if(pointer.armed && aimOn && pointer.path.length>1){
       const path = pointer.path;
@@ -599,7 +631,7 @@ function endShot(hit,pts){
       drawAimPath(dirx*SHOT_SPEED*power, diry*SHOT_SPEED*power, spin);
     }
   }
-  function onUp(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.active=false; if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; } const path=pointer.path; pointer.path=[]; if(path.length<3){ status('Swipe longer/faster.'); return; } const dt=Math.max(16,(pointer.t1-pointer.t0)), a=path[0], b=path[path.length-1]; const totalDx=b.x-a.x, totalDy=b.y-a.y; if(totalDy>-10){ status('Swipe upward.'); return; } const endDx=b.x-ball.x, endDy=b.y-ball.y; const dist=Math.hypot(endDx,endDy), power=clamp(dist/dt, 0.3, 3.0); let dirx=endDx/dist, diry=endDy/dist; const norm=Math.hypot(dirx,diry)||1; dirx/=norm; diry/=norm; let curve=0; for(let i=2;i<path.length;i++){ const p0=path[i-2], p1=path[i-1], p2=path[i]; curve+=Math.atan2(p2.y-p1.y,p2.x-p1.x)-Math.atan2(p1.y-p0.y,p1.x-p0.x); } const spin = clamp((ball.x - a.x)/ball.r + curve*0.5, -3, 3); ball.vx=dirx*SHOT_SPEED*power; ball.vy=diry*SHOT_SPEED*power; ball.tx=b.x; ball.ty=b.y; ball.prevDist=Math.hypot(ball.tx-ball.x, ball.ty-ball.y); ball.spin=spin; ball.moving=true; keeper.save=false; powerBar.style.height = Math.round(clamp(power/3.0,0,1)*100)+'%'; }
+  function onUp(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.active=false; if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; } const path=pointer.path; pointer.path=[]; if(path.length<3){ status('Swipe longer/faster.'); return; } const dt=Math.max(16,(pointer.t1-pointer.t0)), a=path[0], b=path[path.length-1]; const totalDx=b.x-a.x, totalDy=b.y-a.y; if(totalDy>-10){ status('Swipe upward.'); return; } const endDx=b.x-ball.x, endDy=b.y-ball.y; const dist=Math.hypot(endDx,endDy), power=clamp(dist/dt, 0.3, 3.0); let dirx=endDx/dist, diry=endDy/dist; const norm=Math.hypot(dirx,diry)||1; dirx/=norm; diry/=norm; let curve=0; for(let i=2;i<path.length;i++){ const p0=path[i-2], p1=path[i-1], p2=path[i]; curve+=Math.atan2(p2.y-p1.y,p2.x-p1.x)-Math.atan2(p1.y-p0.y,p1.x-p0.x); } const spin = clamp((ball.x - a.x)/ball.r + curve*0.5, -3, 3); ball.vx=dirx*SHOT_SPEED*power; ball.vy=diry*SHOT_SPEED*power; ball.tx=b.x; ball.ty=b.y; ball.prevDist=Math.hypot(ball.tx-ball.x, ball.ty-ball.y); ball.spin=spin; ball.moving=true; sfxKick(); keeper.save=false; powerBar.style.height = Math.round(clamp(power/3.0,0,1)*100)+'%'; }
   canvas.addEventListener('pointerdown', onDown, {passive:true});
   canvas.addEventListener('pointermove', onMove, {passive:true});
   addEventListener('pointerup', onUp, {passive:true}); addEventListener('pointercancel', onUp, {passive:true});
@@ -695,17 +727,20 @@ function endShot(hit,pts){
   // ===== WebAudio SFX (no files) =====
   let audioCtx=null, masterGain=null; function ensureAudio(){ if(audioCtx) return; try{ const AC = window.AudioContext || window.webkitAudioContext; audioCtx = new AC(); masterGain = audioCtx.createGain(); masterGain.gain.value = 0.18; masterGain.connect(audioCtx.destination); }catch{} }
   function tone(freq=440, dur=0.08, type='sine', gain=0.22){ if(!audioCtx) return; const o=audioCtx.createOscillator(); const g=audioCtx.createGain(); o.type=type; o.frequency.value=freq; o.connect(g); g.connect(masterGain); g.gain.setValueAtTime(gain, audioCtx.currentTime); g.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime+dur); o.start(); o.stop(audioCtx.currentTime+dur); }
-  const sfxKick = ()=>tone(220,0.04,'sawtooth',0.25);
+  let netHalf=0;
+  const netSound = new Audio('/assets/sounds/a-football-hits-the-net-goal-313216.mp3');
+  const kickSound = new Audio('/assets/sounds/a-football-hits-the-net-goal-313216.mp3');
+  netSound.addEventListener('loadedmetadata',()=>{ netHalf = netSound.duration/2; });
+  const sfxKick = ()=>{ try{ kickSound.pause(); kickSound.currentTime=0; const stop=netHalf?netHalf*1000:0; kickSound.play(); if(stop){ setTimeout(()=>kickSound.pause(), stop); } }catch{} };
     const sfxGoal = ()=>{tone(660,0.10,'triangle',0.30); setTimeout(()=>tone(880,0.12,'triangle',0.28),60);};
     const sfxMiss = ()=>tone(160,0.10,'square',0.25);
     const sfxRival= ()=>tone(520,0.06,'triangle',0.18);
     const sfxBreak = ()=>{ if(!audioCtx) return; const len=audioCtx.sampleRate*0.25; const buf=audioCtx.createBuffer(1,len,audioCtx.sampleRate); const data=buf.getChannelData(0); for(let i=0;i<len;i++){ data[i]=(Math.random()*2-1)*(1-i/len); } const src=audioCtx.createBufferSource(); src.buffer=buf; const g=audioCtx.createGain(); g.gain.value=0.6; src.connect(g); g.connect(masterGain); src.start(); };
     const sfxStart= ()=>{tone(500,0.08,'triangle',0.25); setTimeout(()=>tone(650,0.08,'triangle',0.22),80);};
   const sfxEnd  = ()=>{tone(300,0.12,'sine',0.18); setTimeout(()=>tone(220,0.16,'sine',0.16),60);};
-  const netHitSound = new Audio('/assets/sounds/a-football-hits-the-net-goal-313216.mp3');
   const rewardSound = new Audio('https://cdn.pixabay.com/audio/2022/03/15/audio_1d8839a382.mp3');
   const woodSound = new Audio('https://actions.google.com/sounds/v1/impacts/crash.ogg');
-  const sfxNet = ()=>{ try{ netHitSound.currentTime = 0; netHitSound.play(); }catch{} };
+  const sfxNet = ()=>{ try{ netSound.pause(); if(netHalf) netSound.currentTime = netHalf; netSound.play(); }catch{} };
   const sfxReward = ()=>{ try{ rewardSound.currentTime = 0; rewardSound.play(); }catch{} };
   const sfxWoodwork = ()=>{ try{ woodSound.currentTime = 0; woodSound.play(); }catch{} };
   function vibrate(ms){ if(navigator.vibrate) try{ navigator.vibrate(ms); }catch{} }


### PR DESCRIPTION
## Summary
- Extend goal net to cover sides and roof for a fuller goal cage
- Swap post and prize sounds and split net sound between kick and net hit
- Add smoky trajectory trail and corner prizes that regenerate instantly

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon ... )*


------
https://chatgpt.com/codex/tasks/task_e_68ad95fb1e2c8329843ef41b1a7953dd