### PR TITLE
Improve penalty kick responsiveness and audio

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -215,8 +215,8 @@
   let myScore = 0;
 
   const BALL_R = 42;
-  // much slower initial shot speed for clearer ball travel
-  const SHOT_SPEED = 12;
+  // increase shot speed for snappier gameplay
+  const SHOT_SPEED = 20;
   const ball = { x:0,y:0,r:BALL_R, vx:0,vy:0, moving:false, trail:[], spin:0, angle:0, netSounded:false, firstContact:false, tx:0, ty:0, prevDist:0 };
   const ballImg = new Image();
   ballImg.src = '/assets/icons/file_0000000061d4620aaf506adfa605e1f3.webp';
@@ -441,7 +441,7 @@
     ctx.lineTo(g.x+g.w, g.y);
     ctx.lineTo(g.x+g.w, g.y+g.h);
     ctx.stroke();
-    ctx.strokeStyle='rgba(255,255,255,0.5)'; ctx.lineWidth=6;
+    ctx.strokeStyle='#fff'; ctx.lineWidth=6;
     ctx.beginPath();
     ctx.moveTo(ix, iy+innerH);
     ctx.lineTo(ix, iy);
@@ -727,11 +727,9 @@ function endShot(hit,pts){
   // ===== WebAudio SFX (no files) =====
   let audioCtx=null, masterGain=null; function ensureAudio(){ if(audioCtx) return; try{ const AC = window.AudioContext || window.webkitAudioContext; audioCtx = new AC(); masterGain = audioCtx.createGain(); masterGain.gain.value = 0.18; masterGain.connect(audioCtx.destination); }catch{} }
   function tone(freq=440, dur=0.08, type='sine', gain=0.22){ if(!audioCtx) return; const o=audioCtx.createOscillator(); const g=audioCtx.createGain(); o.type=type; o.frequency.value=freq; o.connect(g); g.connect(masterGain); g.gain.setValueAtTime(gain, audioCtx.currentTime); g.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime+dur); o.start(); o.stop(audioCtx.currentTime+dur); }
-  let netHalf=0;
-  const netSound = new Audio('/assets/sounds/a-football-hits-the-net-goal-313216.mp3');
-  const kickSound = new Audio('/assets/sounds/a-football-hits-the-net-goal-313216.mp3');
-  netSound.addEventListener('loadedmetadata',()=>{ netHalf = netSound.duration/2; });
-  const sfxKick = ()=>{ try{ kickSound.pause(); kickSound.currentTime=0; const stop=netHalf?netHalf*1000:0; kickSound.play(); if(stop){ setTimeout(()=>kickSound.pause(), stop); } }catch{} };
+  const netSound = new Audio('/assets/sounds/football-game-sound-effects-359284.mp3');
+  const kickSound = new Audio('/assets/sounds/billiard-pool-hit-371618.mp3');
+  const sfxKick = ()=>{ try{ kickSound.currentTime=0; kickSound.play(); }catch{} };
     const sfxGoal = ()=>{tone(660,0.10,'triangle',0.30); setTimeout(()=>tone(880,0.12,'triangle',0.28),60);};
     const sfxMiss = ()=>tone(160,0.10,'square',0.25);
     const sfxRival= ()=>tone(520,0.06,'triangle',0.18);
@@ -740,7 +738,7 @@ function endShot(hit,pts){
   const sfxEnd  = ()=>{tone(300,0.12,'sine',0.18); setTimeout(()=>tone(220,0.16,'sine',0.16),60);};
   const rewardSound = new Audio('https://cdn.pixabay.com/audio/2022/03/15/audio_1d8839a382.mp3');
   const woodSound = new Audio('https://actions.google.com/sounds/v1/impacts/crash.ogg');
-  const sfxNet = ()=>{ try{ netSound.pause(); if(netHalf) netSound.currentTime = netHalf; netSound.play(); }catch{} };
+  const sfxNet = ()=>{ try{ netSound.currentTime = 0; netSound.play(); }catch{} };
   const sfxReward = ()=>{ try{ rewardSound.currentTime = 0; rewardSound.play(); }catch{} };
   const sfxWoodwork = ()=>{ try{ woodSound.currentTime = 0; woodSound.play(); }catch{} };
   function vibrate(ms){ if(navigator.vibrate) try{ navigator.vibrate(ms); }catch{} }


### PR DESCRIPTION
## Summary
- Speed up penalty kicks for a snappier feel
- Restore kick and net sound effects using existing audio assets
- Draw rear goal posts in solid white

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad9b5f174c8329ae31e62121ad6fd1