### PR TITLE
Improve Pool Royale AI pocket targeting

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -23,6 +23,7 @@
  * @property {number} width
  * @property {number} height
  * @property {number} ballRadius
+ * @property {number} [pocketRadius]          // radius of pocket opening
  * @property {'yellow'|'red'|null} [ballOn]   // group of current player; null on open table
  * @property {boolean} [isOpenTable]
  * @property {boolean} [freeBallAvailable]
@@ -34,6 +35,7 @@
  * @property {'pot'|'safety'|'freeBallPot'} actionType
  * @property {Ball|null} targetBall
  * @property {Pocket|null} pocket
+ * @property {{x:number,y:number}} [pocketPos]
  * @property {{speed:'soft'|'med'|'firm',spin:'stun'|'followS'|'followL'|'drawS'|'drawL'|'sideL'|'sideR'}} cueParams
  * @property {boolean} [isSafety]
  *
@@ -110,6 +112,26 @@ function cutAngle(cue, target, pocket) {
   return Math.acos(cos);
 }
 
+// Compute the visible pocket entry point from a given object ball.
+// Returns null if the ball cannot fit through the mouth from this angle.
+function pocketEntry(ball, pocket, ballRadius, pocketRadius) {
+  const R = pocketRadius - ballRadius;
+  if (R <= 0) return null;
+  const dx = ball.x - pocket.x;
+  const dy = ball.y - pocket.y;
+  const d2 = dx * dx + dy * dy;
+  if (d2 <= R * R) return null;
+  const l = (R * R) / d2;
+  const m = Math.sqrt(d2 - R * R) / d2 * R;
+  const ex1 = pocket.x + l * dx + m * (-dy);
+  const ey1 = pocket.y + l * dy + m * dx;
+  const ex2 = pocket.x + l * dx - m * (-dy);
+  const ey2 = pocket.y + l * dy - m * dx;
+  const gap = Math.hypot(ex1 - ex2, ey1 - ey2);
+  if (gap < ballRadius * 2) return null;
+  return { mid: { x: (ex1 + ex2) / 2, y: (ey1 + ey2) / 2 } };
+}
+
 // ----------------- candidate generation -----------------
 function visibleOwnBalls(state, colour) {
   const cue = state.balls.find(b => b.colour === 'cue');
@@ -128,22 +150,27 @@ function generatePotCandidates(state, colour) {
   const cue = state.balls.find(b => b.colour === 'cue');
   const balls = visibleOwnBalls(state, colour);
   const shots = [];
+  const pocketRadius = state.pocketRadius || state.ballRadius * 2;
   for (const ball of balls) {
     let bestPocket = null;
     let bestAngle = Infinity;
     let bestDist = Infinity;
+    let bestEntry = null;
     for (const pocket of state.pockets) {
+      const entry = pocketEntry(ball, pocket, state.ballRadius, pocketRadius);
+      if (!entry) continue;
       // prefer pockets that give the straightest line to the cue
-      if (pathBlocked(ball, pocket, state.balls, [cue.id, ball.id], state.ballRadius)) continue;
-      const angle = cutAngle(cue, ball, pocket);
-      const d = dist(ball, pocket);
+      if (pathBlocked(ball, entry.mid, state.balls, [cue.id, ball.id], state.ballRadius)) continue;
+      const angle = cutAngle(cue, ball, entry.mid);
+      const d = dist(ball, entry.mid);
       if (angle < bestAngle - 1e-6 || (Math.abs(angle - bestAngle) <= 1e-6 && d < bestDist)) {
         bestAngle = angle;
         bestDist = d;
         bestPocket = pocket;
+        bestEntry = entry.mid;
       }
     }
-    if (bestPocket && !pathBlocked(ball, bestPocket, state.balls, [cue.id, ball.id], state.ballRadius)) {
+    if (bestPocket && bestEntry && !pathBlocked(ball, bestEntry, state.balls, [cue.id, ball.id], state.ballRadius)) {
       const angle = bestAngle;
       const distCT = dist(cue, ball);
       const distTP = bestDist;
@@ -151,6 +178,7 @@ function generatePotCandidates(state, colour) {
         actionType: 'pot',
         targetBall: ball,
         pocket: bestPocket,
+        pocketPos: bestEntry,
         cueParams: { speed: 'med', spin: 'stun' },
         angle,
         distCT,
@@ -181,18 +209,22 @@ function generateBankPotCandidates(state, colour) {
   const cue = state.balls.find(b => b.colour === 'cue');
   const balls = visibleOwnBalls(state, colour);
   const shots = [];
+  const pocketRadius = state.pocketRadius || state.ballRadius * 2;
   for (const ball of balls) {
     for (const pocket of state.pockets) {
+      const entry = pocketEntry(ball, pocket, state.ballRadius, pocketRadius);
+      if (!entry) continue;
       for (const rail of ['left', 'right', 'top', 'bottom']) {
-        const mirror = mirrorPocket(pocket, state.width, state.height, rail);
+        const mirror = mirrorPocket(entry.mid, state.width, state.height, rail);
         if (pathBlocked(ball, mirror, state.balls, [cue.id, ball.id], state.ballRadius)) continue;
         const angle = cutAngle(cue, ball, mirror);
         const distCT = dist(cue, ball);
-        const distTP = dist(ball, pocket);
+        const distTP = dist(ball, entry.mid);
         const shot = {
           actionType: 'pot',
           targetBall: ball,
           pocket,
+          pocketPos: entry.mid,
           cueParams: { speed: 'med', spin: 'stun' },
           angle,
           distCT,
@@ -210,16 +242,20 @@ function generateBankPotCandidates(state, colour) {
 function generateFreeBallCandidates(state, colour) {
   // simple anchors: place cue on line from ball to nearest pocket
   const shots = [];
+  const pocketRadius = state.pocketRadius || state.ballRadius * 2;
   for (const ball of state.balls) {
     if (ball.pocketed || ball.colour !== colour) continue;
     let bestPocket = null;
     let bestDist = Infinity;
+    let bestEntry = null;
     for (const pocket of state.pockets) {
-      const d = dist(ball, pocket);
-      if (d < bestDist) { bestDist = d; bestPocket = pocket; }
+      const entry = pocketEntry(ball, pocket, state.ballRadius, pocketRadius);
+      if (!entry) continue;
+      const d = dist(ball, entry.mid);
+      if (d < bestDist) { bestDist = d; bestPocket = pocket; bestEntry = entry.mid; }
     }
-    if (bestPocket) {
-      let anchor = { x: ball.x - (bestPocket.x - ball.x), y: ball.y - (bestPocket.y - ball.y) };
+    if (bestPocket && bestEntry) {
+      let anchor = { x: ball.x - (bestEntry.x - ball.x), y: ball.y - (bestEntry.y - ball.y) };
       if (state.mustPlayFromBaulk && typeof state.baulkLineX === 'number') {
         const maxX = state.baulkLineX - state.ballRadius;
         if (anchor.x > maxX) anchor.x = maxX;
@@ -228,6 +264,7 @@ function generateFreeBallCandidates(state, colour) {
         actionType: 'freeBallPot',
         targetBall: ball,
         pocket: bestPocket,
+        pocketPos: bestEntry,
         cueParams: { speed: 'med', spin: 'stun' },
         angle: 0,
         distCT: dist(anchor, ball),
@@ -300,7 +337,8 @@ function simulateCueRollout(state, shot) {
   const cue = state.balls.find(b => b.colour === 'cue');
   const ball = shot.targetBall;
   let pos = { x: ball.x, y: ball.y };
-  const toPocket = { x: shot.pocket.x - ball.x, y: shot.pocket.y - ball.y };
+  const pocketPos = shot.pocketPos || shot.pocket;
+  const toPocket = { x: pocketPos.x - ball.x, y: pocketPos.y - ball.y };
   const toPocketLen = Math.hypot(toPocket.x, toPocket.y) || 1;
   const dirPocket = { x: toPocket.x / toPocketLen, y: toPocket.y / toPocketLen };
   const toCue = { x: ball.x - cue.x, y: ball.y - cue.y };
@@ -339,18 +377,23 @@ function generateFastCandidates(state, colour) {
   let bestPocket = null;
   let bestAngle = Infinity;
   let bestDist = Infinity;
+  let bestEntry = null;
+  const pocketRadius = state.pocketRadius || state.ballRadius * 2;
   for (const p of state.pockets) {
-    if (pathBlocked(ball, p, state.balls, [cue.id, ball.id], state.ballRadius)) continue;
-    const angle = cutAngle(cue, ball, p);
-    const d = dist(ball, p);
+    const entry = pocketEntry(ball, p, state.ballRadius, pocketRadius);
+    if (!entry) continue;
+    if (pathBlocked(ball, entry.mid, state.balls, [cue.id, ball.id], state.ballRadius)) continue;
+    const angle = cutAngle(cue, ball, entry.mid);
+    const d = dist(ball, entry.mid);
     if (angle < bestAngle - 1e-6 || (Math.abs(angle - bestAngle) <= 1e-6 && d < bestDist)) {
       bestAngle = angle;
       bestDist = d;
       bestPocket = p;
+      bestEntry = entry.mid;
     }
   }
-  if (!bestPocket) return [];
-  return [{ actionType: 'pot', targetBall: ball, pocket: bestPocket, cueParams: { speed: 'med', spin: 'stun' }, angle: bestAngle, distCT: dist(cue, ball), distTP: bestDist }];
+  if (!bestPocket || !bestEntry) return [];
+  return [{ actionType: 'pot', targetBall: ball, pocket: bestPocket, pocketPos: bestEntry, cueParams: { speed: 'med', spin: 'stun' }, angle: bestAngle, distCT: dist(cue, ball), distTP: bestDist }];
 }
 
 function valueOfPositionAfter(nc, state, colour) {


### PR DESCRIPTION
## Summary
- account for ball and pocket sizes when choosing shots
- aim at pocket mouth center between visible edges
- support bank and free-ball shots using refined pocket entry points

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, 'inc' is never reassigned)*

------
https://chatgpt.com/codex/tasks/task_e_68adb6c44e8883298b6b4d9ce0148607