### PR TITLE
Match aim marker circle to ball size

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -2204,7 +2204,7 @@
             // Draw marker circle with a plus at the contact point
             var hitSpotX = tx - hitN.x * BALL_R;
             var hitSpotY = ty - hitN.y * BALL_R;
-            var markerR = BALL_R * 0.4;
+            var markerR = BALL_R;
             ctx.save();
             ctx.strokeStyle = 'rgba(255,255,255,.8)';
             ctx.lineWidth = 1;


### PR DESCRIPTION
## Summary
- Use full ball radius for aim marker so contact circle matches ball size

## Testing
- `npm test`
- `npm run lint` *(fails: 1288 problems, existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0613e8108329aae497c8bce173cb