### PR TITLE
Refine penalty kick audio handling

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -710,7 +710,7 @@ function endShot(hit,pts){
     const src=audioCtx.createBufferSource();
     src.buffer=goalSoundBuf;
     const half=goalSoundBuf.duration/2;
-    if(part==='first') src.start(0,0,half); else src.start(0,half);
+    if(part==='first') src.start(0,0,half); else src.start(0,half,goalSoundBuf.duration-half-0.2);
     src.connect(masterGain);
   }
   const sfxKick = ()=>playGoalSound('first');


### PR DESCRIPTION
## Summary
- Trim second-half playback of the goal sound by 0.2 seconds to avoid trailing noise
- Reuse first half of the same sound for kick effects in penalty kick mode

## Testing
- `npm test` *(fails: Claim transaction failed, 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0a1659cc8329924bf8221c96490f