### PR TITLE
Improve aiming line precision in Pool Royale

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -2080,96 +2080,82 @@
             dy = aim.y - cue.p.y;
           var L = len(dx, dy) || 1;
           var dir = { x: dx / L, y: dy / L };
-          // Use a smaller step and more dots for denser and more precise guides
-          var step = BALL_R * 0.1,
-            dots = 300;
-          // precompute ball diameter squared for collision checks
-          var r = BALL_R * 2,
-            r2 = r * r;
-          var x = cue.p.x,
-            y = cue.p.y,
-            target = null,
-            hitStep = dots,
-            railNormal = null;
+          var step = BALL_R * 0.1;
+          var tHit = Infinity;
+          var target = null;
+          var railNormal = null;
 
-          for (var i = 0; i < dots; i++) {
-            var prevX = x,
-              prevY = y;
-            x += dir.x * step;
-            y += dir.y * step;
-            if (x < BORDER + BALL_R) {
-              railNormal = { x: 1, y: 0 };
-            } else if (x > TABLE_W - BORDER - BALL_R) {
-              railNormal = { x: -1, y: 0 };
-            } else if (y < BORDER_TOP + BALL_R) {
-              railNormal = { x: 0, y: 1 };
-            } else if (y > TABLE_H - BORDER_BOTTOM - BALL_R) {
-              railNormal = { x: 0, y: -1 };
+          function checkRail(t, normal) {
+            if (t >= 0 && t < tHit) {
+              tHit = t;
+              railNormal = normal;
+              target = null;
             }
-            if (railNormal) {
-              // include the collision step so the guide reaches impact
-              hitStep = i + 1;
-              break;
-            }
-            for (var j = 0; j < table.balls.length; j++) {
-              var b = table.balls[j];
-              if (b === cue || b.pocketed) continue;
-              // Detect precise impact by interpolating between steps
-              var dCurr2 = d2({ x: x, y: y }, b.p);
-              if (dCurr2 < r2) {
-                var dPrev2 = d2({ x: prevX, y: prevY }, b.p);
-                var dPrev = Math.sqrt(dPrev2);
-                var dCurr = Math.sqrt(dCurr2);
-                var tHit = (dPrev - r) / (dPrev - dCurr);
-                hitStep = i + tHit;
-                target = b;
-                break;
-              }
-            }
-            if (target) break;
           }
 
-          // Only highlight the aiming line when a collision with a ball is guaranteed
+          if (dir.x < 0)
+            checkRail((BORDER + BALL_R - cue.p.x) / dir.x, { x: 1, y: 0 });
+          if (dir.x > 0)
+            checkRail(
+              (TABLE_W - BORDER - BALL_R - cue.p.x) / dir.x,
+              { x: -1, y: 0 }
+            );
+          if (dir.y < 0)
+            checkRail(
+              (BORDER_TOP + BALL_R - cue.p.y) / dir.y,
+              { x: 0, y: 1 }
+            );
+          if (dir.y > 0)
+            checkRail(
+              (TABLE_H - BORDER_BOTTOM - BALL_R - cue.p.y) / dir.y,
+              { x: 0, y: -1 }
+            );
+
+          var diam = BALL_R * 2;
+          var diam2 = diam * diam;
+          for (var j = 0; j < table.balls.length; j++) {
+            var b = table.balls[j];
+            if (b === cue || b.pocketed) continue;
+            var v = { x: b.p.x - cue.p.x, y: b.p.y - cue.p.y };
+            var proj = v.x * dir.x + v.y * dir.y;
+            if (proj <= 0) continue;
+            var perp2 = v.x * v.x + v.y * v.y - proj * proj;
+            if (perp2 > diam2) continue;
+            var thc = Math.sqrt(diam2 - perp2);
+            var t = proj - thc;
+            if (t >= 0 && t < tHit) {
+              tHit = t;
+              target = b;
+              railNormal = null;
+            }
+          }
+
+          var x = cue.p.x,
+            y = cue.p.y;
+          var steps = Math.floor(tHit / step);
           const guaranteedHit = target && !railNormal;
           ctx.fillStyle = guaranteedHit
             ? 'rgba(255,255,0,1)'
             : 'rgba(255,255,255,.7)';
-          x = cue.p.x;
-          y = cue.p.y;
-          var fullSteps = Math.floor(hitStep);
-          for (var i = 0; i < fullSteps; i++) {
+          for (var i = 0; i < steps; i++) {
             x += dir.x * step;
             y += dir.y * step;
-            if (
-              x < BORDER + BALL_R ||
-              x > TABLE_W - BORDER - BALL_R ||
-              y < BORDER_TOP + BALL_R ||
-              y > TABLE_H - BORDER_BOTTOM - BALL_R
-            )
-              break;
             ctx.beginPath();
             ctx.arc(x * sX, y * sY, 1.5, 0, Math.PI * 2);
             ctx.fill();
           }
-          var frac = hitStep - fullSteps;
-          if (frac > 0) {
-            x += dir.x * step * frac;
-            y += dir.y * step * frac;
-            if (
-              x >= BORDER + BALL_R &&
-              x <= TABLE_W - BORDER - BALL_R &&
-              y >= BORDER_TOP + BALL_R &&
-              y <= TABLE_H - BORDER_BOTTOM - BALL_R
-            ) {
-              ctx.beginPath();
-              ctx.arc(x * sX, y * sY, 1.5, 0, Math.PI * 2);
-              ctx.fill();
-            }
+          var remaining = tHit - steps * step;
+          if (remaining > 0) {
+            x += dir.x * remaining;
+            y += dir.y * remaining;
+            ctx.beginPath();
+            ctx.arc(x * sX, y * sY, 1.5, 0, Math.PI * 2);
+            ctx.fill();
           }
 
           if (!target && railNormal) {
-            var impactX = x,
-              impactY = y;
+            var impactX = cue.p.x + dir.x * tHit,
+              impactY = cue.p.y + dir.y * tHit;
             var dotIn = dir.x * railNormal.x + dir.y * railNormal.y;
             var refl = {
               x: dir.x - 2 * dotIn * railNormal.x,
@@ -2197,8 +2183,8 @@
           if (target) {
             var tx = target.p.x,
               ty = target.p.y;
-            var impactCueX = cue.p.x + dir.x * step * hitStep;
-            var impactCueY = cue.p.y + dir.y * step * hitStep;
+            var impactCueX = cue.p.x + dir.x * tHit;
+            var impactCueY = cue.p.y + dir.y * tHit;
             // Direction from cue ball to target ball at impact
             var hitN = { x: tx - impactCueX, y: ty - impactCueY };
             var nL = len(hitN.x, hitN.y) || 1;


### PR DESCRIPTION
## Summary
- compute exact ball and rail intersections for aiming line in poll-royale

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8be3664c83298223b4db1842b39f