### PR TITLE
Refine penalty field and remove power bar

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -55,10 +55,7 @@
     bottom:env(safe-area-inset-bottom,72px);z-index:80;pointer-events:none}
   .stage .frame{position:absolute;inset:0;border-radius:18px;border:1px solid var(--panel-b);pointer-events:none}
 
-  /* ===== Power bar & bottom ribbon ===== */
-  .power{position:fixed;left:env(safe-area-inset-left,12px);top:50%;transform:translateY(-50%);
-    z-index:70;width:10px;height:40vh;background:#101942;border:1px solid #22306a;border-radius:999px;overflow:hidden;box-shadow:inset 0 0 0 1px #1b2559}
-  .power .bar{position:absolute;left:0;right:0;bottom:0;height:0%;background:linear-gradient(180deg,#7dd3fc,#22d3ee,#22c55e)}
+  /* ===== Bottom ribbon ===== */
   .bottom{position:fixed;left:env(safe-area-inset-left,12px);right:env(safe-area-inset-right,12px);
     bottom:env(safe-area-inset-bottom,10px);z-index:96}
   .ribbon{background:var(--panel);border:1px solid var(--panel-b);border-radius:12px;padding:8px 12px;text-align:center;font-size:14px}
@@ -112,7 +109,6 @@
   </div>
 
   <div class="stage"><div class="frame"></div></div>
-  <div class="power" aria-hidden="true"><div class="bar" id="powerBar"></div></div>
 
   <canvas id="game" aria-label="Penalty field"></canvas>
 
@@ -137,7 +133,6 @@
 
   // ===== UI refs =====
   const timeShort = document.getElementById('timeShort');
-  const powerBar  = document.getElementById('powerBar');
   const previewsEl= document.getElementById('previews');
   const userAvatarEl = document.getElementById('userAvatar');
   const usernameEl = document.getElementById('username');
@@ -193,14 +188,16 @@
   positionLayout();
 
   // ===== Geometry =====
-  const geom = { goal:{x:0,y:0,w:0,h:0,post:12}, spot:{x:0,y:0}, scale:1 };
+  const geom = { goal:{x:0,y:0,w:0,h:0,post:12}, spot:{x:0,y:0}, penaltySpot:{x:0,y:0}, scale:1, paDepth:0 };
   function layout(){
     const goalW = Math.min(W*0.92, 950);
     const goalH = Math.min(H*0.28, 260) * 0.95;
     const pbarBottom = document.getElementById('pbar').getBoundingClientRect().bottom;
     geom.goal = { x:(W-goalW)/2, y:pbarBottom + 20, w:goalW, h:goalH, post:12 };
-    geom.spot = { x:W/2, y:H - Math.min(100, H*0.10) };
     geom.scale = goalW / 860;
+    geom.paDepth = Math.min(320*geom.scale, H*0.34);
+    geom.penaltySpot = { x:W/2, y: geom.goal.y + geom.goal.h + geom.paDepth * (11/16.5) };
+    geom.spot = { x:W/2, y: geom.goal.y + geom.goal.h + geom.paDepth + BALL_R*geom.scale*0.5 };
     keeper.w = 40*geom.scale*4*0.85;
     keeper.h = 100*geom.scale*4*0.85;
     keeper.x = geom.goal.x + (geom.goal.w-keeper.w)/2;
@@ -343,13 +340,27 @@
     // ctx.lineWidth=2; ctx.beginPath(); ctx.moveTo(0,gl); ctx.lineTo(W,gl); ctx.stroke();
     ctx.lineWidth=4;
 
-    const paDepth=Math.min(320*geom.scale,H*0.34), pad=Math.max(120*geom.scale,(W-g.w)/4);
+    const paDepth=geom.paDepth, pad=Math.max(120*geom.scale,(W-g.w)/4);
     ctx.strokeRect(g.x-pad,gl,g.w+pad*2,paDepth);
     const sixDepth=Math.min(120*geom.scale,paDepth*0.45), sixPad=Math.max(140*geom.scale,pad*0.7);
     // Removed goal-area line close to the net
     // ctx.strokeRect(g.x-sixPad,gl,g.w+sixPad*2,sixDepth);
 
-    // removed penalty arc and spot circle
+    // penalty arc and spots
+    const pSpot = geom.penaltySpot;
+    const arcR = paDepth * (9.15/16.5);
+    const arcD = (gl + paDepth) - pSpot.y;
+    const arcA = Math.acos(arcD / arcR);
+    ctx.beginPath();
+    ctx.arc(pSpot.x, pSpot.y, arcR, Math.PI - arcA, Math.PI + arcA);
+    ctx.stroke();
+    ctx.fillStyle = '#fff';
+    ctx.beginPath();
+    ctx.arc(pSpot.x, pSpot.y, 3*geom.scale, 0, Math.PI*2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(geom.spot.x, geom.spot.y, 3*geom.scale, 0, Math.PI*2);
+    ctx.fill();
   }
 
   // ===== Ads behind goal =====
@@ -393,7 +404,17 @@
       }
     }
     ctx.restore();
-    ctx.strokeStyle=netColor; ctx.lineWidth=1.2;
+    ctx.save();
+    ctx.beginPath();
+    ctx.moveTo(g.x, g.y);
+    ctx.lineTo(ix, iy);
+    ctx.lineTo(ix+innerW, iy);
+    ctx.lineTo(g.x+g.w, g.y);
+    ctx.closePath();
+    ctx.clip();
+    ctx.clearRect(g.x-2, g.y-2, g.w+4, iy - g.y + 4);
+    ctx.restore();
+    ctx.strokeStyle='#fff'; ctx.lineWidth=2;
     ctx.beginPath();
     ctx.moveTo(g.x, g.y);
     ctx.lineTo(ix, iy);
@@ -412,6 +433,10 @@
     ctx.lineTo(ix+innerW, iy+innerH);
     ctx.moveTo(ix, iy+innerH);
     ctx.lineTo(ix+innerW, iy+innerH);
+    ctx.moveTo(ix, iy+innerH);
+    ctx.lineTo(ix, iy);
+    ctx.lineTo(ix+innerW, iy);
+    ctx.lineTo(ix+innerW, iy+innerH);
     ctx.stroke();
     ctx.strokeStyle='#fff'; ctx.lineWidth=12;
     ctx.beginPath();
@@ -419,13 +444,6 @@
     ctx.lineTo(g.x, g.y);
     ctx.lineTo(g.x+g.w, g.y);
     ctx.lineTo(g.x+g.w, g.y+g.h);
-    ctx.stroke();
-    ctx.strokeStyle='rgba(255,255,255,0.5)'; ctx.lineWidth=6;
-    ctx.beginPath();
-    ctx.moveTo(ix, iy+innerH);
-    ctx.lineTo(ix, iy);
-    ctx.lineTo(ix+innerW, iy);
-    ctx.lineTo(ix+innerW, iy+innerH);
     ctx.stroke();
     for(const c of cameras){ ctx.fillStyle='#111'; ctx.fillRect(c.x,c.y,c.w,c.h); ctx.fillStyle='#e10600'; ctx.beginPath(); ctx.arc(c.x+8,c.y+6,3,0,Math.PI*2); ctx.fill(); }
     for(const h of holes){ if(h.hit) continue; ctx.fillStyle='rgba(225,6,0,.9)'; ctx.beginPath(); ctx.arc(h.x,h.y,h.r,0,Math.PI*2); ctx.fill();
@@ -598,7 +616,7 @@ function endShot(hit,pts){
       drawAimPath(vx, vy, spin);
     }
   }
-  function onUp(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.active=false; if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; } const path=pointer.path; pointer.path=[]; if(path.length<3){ status('Swipe longer/faster.'); return; } const a=path[0], b=path[path.length-1]; const totalDy=b.y-a.y; if(totalDy>-10){ status('Swipe upward.'); return; } const endDx=b.x-ball.x, endDy=b.y-ball.y; const dist=Math.hypot(endDx,endDy), power=clamp(dist/150, 0.4, 3.0); const speed=SHOT_SPEED*power; const t=dist/speed; let curve=0; for(let i=2;i<path.length;i++){ const p0=path[i-2], p1=path[i-1], p2=path[i]; curve+=Math.atan2(p2.y-p1.y,p2.x-p1.x)-Math.atan2(p1.y-p0.y,p1.x-p0.x); } const spin = clamp((ball.x - a.x)/ball.r + curve*0.5, -5, 5); const adjDx=endDx - spin*0.125*t*t; ball.vx=adjDx/t; ball.vy=(endDy - 0.5*GRAVITY*t*t)/t; ball.spin=spin; ball.moving=true; ball.target={x:b.x,y:b.y}; ball.prevDist=Infinity; keeper.save=false; powerBar.style.height = Math.round(clamp(power/3.0,0,1)*100)+'%'; }
+  function onUp(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.active=false; if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; } const path=pointer.path; pointer.path=[]; if(path.length<3){ status('Swipe longer/faster.'); return; } const a=path[0], b=path[path.length-1]; const totalDy=b.y-a.y; if(totalDy>-10){ status('Swipe upward.'); return; } const endDx=b.x-ball.x, endDy=b.y-ball.y; const dist=Math.hypot(endDx,endDy), power=clamp(dist/150, 0.4, 3.0); const speed=SHOT_SPEED*power; const t=dist/speed; let curve=0; for(let i=2;i<path.length;i++){ const p0=path[i-2], p1=path[i-1], p2=path[i]; curve+=Math.atan2(p2.y-p1.y,p2.x-p1.x)-Math.atan2(p1.y-p0.y,p1.x-p0.x); } const spin = clamp((ball.x - a.x)/ball.r + curve*0.5, -5, 5); const adjDx=endDx - spin*0.125*t*t; ball.vx=adjDx/t; ball.vy=(endDy - 0.5*GRAVITY*t*t)/t; ball.spin=spin; ball.moving=true; ball.target={x:b.x,y:b.y}; ball.prevDist=Infinity; keeper.save=false; }
   canvas.addEventListener('pointerdown', onDown, {passive:true});
   canvas.addEventListener('pointermove', onMove, {passive:true});
   addEventListener('pointerup', onUp, {passive:true}); addEventListener('pointercancel', onUp, {passive:true});


### PR DESCRIPTION
## Summary
- Add penalty spot and arc, repositioning ball outside the box
- Remove unused power bar UI and wire
- Redraw goal as white 3D frame without roof net

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8dfba2708329b2a521bbd272ffe4