### PR TITLE
Remove penalty arc and adjust goal net

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -346,21 +346,7 @@
     // Removed goal-area line close to the net
     // ctx.strokeRect(g.x-sixPad,gl,g.w+sixPad*2,sixDepth);
 
-    // penalty arc and spots
-    const pSpot = geom.penaltySpot;
-    const arcR = paDepth * (9.15/16.5);
-    const arcD = (gl + paDepth) - pSpot.y;
-    const arcA = Math.acos(arcD / arcR);
-    ctx.beginPath();
-    ctx.arc(pSpot.x, pSpot.y, arcR, Math.PI - arcA, Math.PI + arcA);
-    ctx.stroke();
-    ctx.fillStyle = '#fff';
-    ctx.beginPath();
-    ctx.arc(pSpot.x, pSpot.y, 3*geom.scale, 0, Math.PI*2);
-    ctx.fill();
-    ctx.beginPath();
-    ctx.arc(geom.spot.x, geom.spot.y, 3*geom.scale, 0, Math.PI*2);
-    ctx.fill();
+    // Removed penalty arc and spot for simplified field
   }
 
   // ===== Ads behind goal =====
@@ -390,8 +376,6 @@
       for(let x=g.x-size; x<g.x+g.w+size; x+=size*1.5){
         const off = ((Math.round((y-g.y)/h))%2)*size*0.75;
         const cx=x+off, cy=y;
-        if((cy>=iy+innerH-h && cx>ix && cx<ix+innerW) ||
-           (cy>=g.y+g.h-h && cx>g.x && cx<g.x+g.w)) continue;
         ctx.beginPath();
         for(let i=0;i<6;i++){
           const a=Math.PI/3*i; let px=cx+size*Math.cos(a); let py=cy+size*Math.sin(a);
@@ -403,16 +387,6 @@
         ctx.closePath(); ctx.stroke();
       }
     }
-    ctx.restore();
-    ctx.save();
-    ctx.beginPath();
-    ctx.moveTo(g.x, g.y);
-    ctx.lineTo(ix, iy);
-    ctx.lineTo(ix+innerW, iy);
-    ctx.lineTo(g.x+g.w, g.y);
-    ctx.closePath();
-    ctx.clip();
-    ctx.clearRect(g.x-2, g.y-2, g.w+4, iy - g.y + 4);
     ctx.restore();
     ctx.strokeStyle='#fff'; ctx.lineWidth=2;
     ctx.beginPath();


### PR DESCRIPTION
## Summary
- remove penalty arc and penalty spot from field drawing
- draw goal net uniformly without skipping bottom or clearing top

## Testing
- `npm test` *(fails: process did not exit, logs show server startup and partial tests)*
- `npm run lint` *(fails: many lint errors, including extra semicolons)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9bca42a483298d81dd071117d376