### PR TITLE
Add deterministic billiards physics core with CCD preview and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ artifacts/
 cache/
 *.abi
 *.bin
+
+# .NET build artifacts
+**/bin/
+**/obj/

--- a/billiards.Tests/Billiards.Tests.csproj
+++ b/billiards.Tests/Billiards.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\billiards\Billiards.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/billiards.Tests/GlobalUsings.cs
+++ b/billiards.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using Billiards;
+
+namespace Billiards.Tests;
+
+public class CcdRegressionTests
+{
+    [Test]
+    public void CircleCircleHeadOn()
+    {
+        var p0 = new Vec2(0, 0);
+        var v0 = new Vec2(1, 0);
+        var p1 = new Vec2(1, 0);
+        Assert.IsTrue(Ccd.CircleCircle(p0, v0, PhysicsConstants.BallRadius, p1, PhysicsConstants.BallRadius, out double t));
+        Assert.That(t, Is.EqualTo(1 - 2 * PhysicsConstants.BallRadius).Within(1e-6));
+    }
+
+    [Test]
+    public void CircleCircleGlancing()
+    {
+        var p0 = new Vec2(0, 0);
+        var v0 = new Vec2(1, 0);
+        // place second ball slightly offset in Y so cue ball barely clips it
+        var p1 = new Vec2(1, PhysicsConstants.BallRadius * 1.5);
+        Assert.IsTrue(Ccd.CircleCircle(p0, v0, PhysicsConstants.BallRadius, p1, PhysicsConstants.BallRadius, out double t));
+        Assert.Greater(t, 0);
+    }
+
+    [Test]
+    public void NearParallelCushion()
+    {
+        var p0 = new Vec2(0.5, 0.5);
+        var v0 = new Vec2(1e-3, 1);
+        Assert.IsTrue(Ccd.CircleAabb(p0, v0, PhysicsConstants.BallRadius, new Vec2(0,0), new Vec2(1,1), out double t, out Vec2 n));
+        Assert.Greater(t, 0);
+        Assert.That(Math.Abs(n.Y - (-1)), Is.LessThan(1e-6));
+    }
+}
+
+public class PreviewRuntimeTests
+{
+    [Test]
+    public void PreviewMatchesRuntime()
+    {
+        var solver = new BilliardsSolver();
+        var others = new List<BilliardsSolver.Ball> { new BilliardsSolver.Ball { Position = new Vec2(1.2, 0.5) } };
+        var start = new Vec2(0.2, 0.5);
+        var dir = new Vec2(1, 0);
+        double speed = 2.0;
+        var p = solver.PreviewShot(start, dir, speed, others);
+        var r = solver.SimulateFirstImpact(start, dir, speed, others);
+        Assert.That((p.ContactPoint - r.Point).Length, Is.LessThan(PhysicsConstants.BallRadius * 0.5));
+        var angP = Math.Atan2(p.CuePostVelocity.Y, p.CuePostVelocity.X);
+        var angR = Math.Atan2(r.CueVelocity.Y, r.CueVelocity.X);
+        Assert.That(Math.Abs(angP - angR) * 180 / Math.PI, Is.LessThan(0.5));
+    }
+}
+
+public class DeterminismTests
+{
+    [Test]
+    public void PreviewDeterministic()
+    {
+        var solver = new BilliardsSolver();
+        var others = new List<BilliardsSolver.Ball> { new BilliardsSolver.Ball { Position = new Vec2(1.2, 0.5) } };
+        var start = new Vec2(0.2, 0.5);
+        var dir = new Vec2(1, 0);
+        double speed = 2.0;
+        var a = solver.PreviewShot(start, dir, speed, others);
+        var b = solver.PreviewShot(start, dir, speed, others);
+        Assert.That((a.ContactPoint - b.ContactPoint).Length, Is.LessThan(1e-9));
+    }
+}

--- a/billiards.Unity/DemoBehaviour.cs
+++ b/billiards.Unity/DemoBehaviour.cs
@@ -1,0 +1,37 @@
+#if UNITY_5_3_OR_NEWER
+using UnityEngine;
+using System.Collections.Generic;
+using Billiards;
+
+/// <summary>Example MonoBehaviour wiring the solver to mouse input and a LineRenderer.</summary>
+public class DemoBehaviour : MonoBehaviour
+{
+    public LineRenderer Line;
+    private BilliardsSolver solver = new BilliardsSolver();
+    private List<BilliardsSolver.Ball> balls = new List<BilliardsSolver.Ball>();
+
+    private void Start()
+    {
+        Line.positionCount = 0;
+    }
+
+    private void Update()
+    {
+        if (Input.GetMouseButton(0))
+        {
+            var start = ScreenToWorld.FromScreen(Camera.main, Input.mousePosition);
+            var dir = new Vec2(1, 0); // placeholder, normally from cue direction
+            var preview = AimPreview.Build(solver, start, dir, 2.0, balls);
+            Line.positionCount = preview.Path.Length;
+            for (int i = 0; i < preview.Path.Length; i++)
+            {
+                Line.SetPosition(i, new Vector3((float)preview.Path[i].X, (float)preview.Path[i].Y, 0));
+            }
+        }
+        else
+        {
+            Line.positionCount = 0;
+        }
+    }
+}
+#endif

--- a/billiards/AimPreview.cs
+++ b/billiards/AimPreview.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace Billiards;
+
+/// <summary>High level preview builder converting solver output to polylines.</summary>
+public static class AimPreview
+{
+    public class Result
+    {
+        public Vec2[] Path;
+        public Vec2 ContactPoint;
+        public Vec2 CuePostVelocity;
+        public Vec2? TargetPostVelocity;
+    }
+
+    /// <summary>Runs the solver preview and formats the result.</summary>
+    public static Result Build(BilliardsSolver solver, Vec2 cueStart, Vec2 dir, double speed, List<BilliardsSolver.Ball> others)
+    {
+        var p = solver.PreviewShot(cueStart, dir, speed, others);
+        return new Result
+        {
+            Path = p.Path.ToArray(),
+            ContactPoint = p.ContactPoint,
+            CuePostVelocity = p.CuePostVelocity,
+            TargetPostVelocity = p.TargetPostVelocity
+        };
+    }
+}

--- a/billiards/Billiards.csproj
+++ b/billiards/Billiards.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+
+namespace Billiards;
+
+/// <summary>Main deterministic physics solver for billiards.</summary>
+public class BilliardsSolver
+{
+    public class Ball
+    {
+        public Vec2 Position;
+        public Vec2 Velocity;
+    }
+
+    public struct Preview
+    {
+        public List<Vec2> Path;
+        public Vec2 ContactPoint;
+        public Vec2 CuePostVelocity;
+        public Vec2? TargetPostVelocity;
+    }
+
+    public struct Impact
+    {
+        public Vec2 Point;
+        public Vec2 CueVelocity;
+        public Vec2? TargetVelocity;
+    }
+
+    /// <summary>Integrates positions and handles cushion reflections for one step.</summary>
+    public void Step(List<Ball> balls, double dt)
+    {
+        foreach (var b in balls)
+        {
+            if (b.Velocity.Length > 0)
+            {
+                b.Position += b.Velocity * dt;
+                // simple friction
+                var speed = b.Velocity.Length;
+                var newSpeed = Math.Max(0, speed - PhysicsConstants.Mu * dt);
+                b.Velocity = b.Velocity.Normalized() * newSpeed;
+                // cushion
+                Vec2 min = new Vec2(0, 0);
+                Vec2 max = new Vec2(PhysicsConstants.TableWidth, PhysicsConstants.TableHeight);
+                if (b.Position.X < min.X + PhysicsConstants.BallRadius)
+                {
+                    b.Position = new Vec2(min.X + PhysicsConstants.BallRadius, b.Position.Y);
+                    b.Velocity = Collision.Reflect(b.Velocity, new Vec2(1, 0));
+                }
+                else if (b.Position.X > max.X - PhysicsConstants.BallRadius)
+                {
+                    b.Position = new Vec2(max.X - PhysicsConstants.BallRadius, b.Position.Y);
+                    b.Velocity = Collision.Reflect(b.Velocity, new Vec2(-1, 0));
+                }
+                if (b.Position.Y < min.Y + PhysicsConstants.BallRadius)
+                {
+                    b.Position = new Vec2(b.Position.X, min.Y + PhysicsConstants.BallRadius);
+                    b.Velocity = Collision.Reflect(b.Velocity, new Vec2(0, 1));
+                }
+                else if (b.Position.Y > max.Y - PhysicsConstants.BallRadius)
+                {
+                    b.Position = new Vec2(b.Position.X, max.Y - PhysicsConstants.BallRadius);
+                    b.Velocity = Collision.Reflect(b.Velocity, new Vec2(0, -1));
+                }
+            }
+        }
+    }
+
+    /// <summary>Runs CCD to predict cue-ball path until first impact.</summary>
+    public Preview PreviewShot(Vec2 cueStart, Vec2 dir, double speed, List<Ball> others)
+    {
+        Vec2 velocity = dir * speed;
+        double bestT = double.PositiveInfinity;
+        Ball hitBall = null;
+        Vec2 hitNormal = new Vec2();
+        bool ballHit = false;
+
+        foreach (var b in others)
+        {
+            if (Ccd.CircleCircle(cueStart, velocity, PhysicsConstants.BallRadius, b.Position, PhysicsConstants.BallRadius, out double t))
+            {
+                if (t < bestT)
+                {
+                    bestT = t; hitBall = b; ballHit = true;
+                }
+            }
+        }
+
+        Vec2 min = new Vec2(0, 0);
+        Vec2 max = new Vec2(PhysicsConstants.TableWidth, PhysicsConstants.TableHeight);
+        if (Ccd.CircleAabb(cueStart, velocity, PhysicsConstants.BallRadius, min, max, out double tc, out Vec2 n))
+        {
+            if (tc < bestT)
+            {
+                bestT = tc; hitNormal = n; ballHit = false;
+            }
+        }
+
+        if (double.IsPositiveInfinity(bestT))
+        {
+            // no collision within preview window
+            return new Preview { Path = new List<Vec2> { cueStart, cueStart + velocity }, ContactPoint = cueStart + velocity, CuePostVelocity = velocity };
+        }
+
+        Vec2 contact = cueStart + velocity * bestT;
+        List<Vec2> path = new List<Vec2> { cueStart, contact };
+        Vec2 cuePost;
+        Vec2? targetPost = null;
+
+        if (ballHit && hitBall != null)
+        {
+            Collision.ResolveBallBall(contact - dir * PhysicsConstants.BallRadius, velocity, hitBall.Position, new Vec2(0, 0), out cuePost, out var target);
+            targetPost = target;
+            path.Add(contact + cuePost.Normalized() * PhysicsConstants.BallRadius);
+        }
+        else
+        {
+            cuePost = Collision.Reflect(velocity, hitNormal);
+            path.Add(contact + cuePost.Normalized() * PhysicsConstants.BallRadius);
+        }
+
+        return new Preview { Path = path, ContactPoint = contact, CuePostVelocity = cuePost, TargetPostVelocity = targetPost };
+    }
+
+    /// <summary>Deterministic stepper simulation to validate preview.</summary>
+    public Impact SimulateFirstImpact(Vec2 cueStart, Vec2 dir, double speed, List<Ball> others)
+    {
+        var cue = new Ball { Position = cueStart, Velocity = dir * speed };
+        var balls = new List<Ball>(others) { cue };
+        double time = 0;
+        while (time < PhysicsConstants.MaxPreviewTime)
+        {
+            // check collisions using CCD for the next dt
+            foreach (var b in others)
+            {
+                if (Ccd.CircleCircle(cue.Position, cue.Velocity, PhysicsConstants.BallRadius, b.Position, PhysicsConstants.BallRadius, out double t))
+                {
+                    if (t <= PhysicsConstants.FixedDt)
+                    {
+                        cue.Position += cue.Velocity * t;
+                        Collision.ResolveBallBall(cue.Position, cue.Velocity, b.Position, new Vec2(0, 0), out var cuePost, out var targetPost);
+                        return new Impact { Point = cue.Position, CueVelocity = cuePost, TargetVelocity = targetPost };
+                    }
+                }
+            }
+            if (Ccd.CircleAabb(cue.Position, cue.Velocity, PhysicsConstants.BallRadius, new Vec2(0, 0), new Vec2(PhysicsConstants.TableWidth, PhysicsConstants.TableHeight), out double tc, out Vec2 n) && tc <= PhysicsConstants.FixedDt)
+            {
+                cue.Position += cue.Velocity * tc;
+                var post = Collision.Reflect(cue.Velocity, n);
+                return new Impact { Point = cue.Position, CueVelocity = post };
+            }
+            Step(balls, PhysicsConstants.FixedDt);
+            time += PhysicsConstants.FixedDt;
+        }
+        return new Impact { Point = cue.Position, CueVelocity = cue.Velocity };
+    }
+}

--- a/billiards/Ccd.cs
+++ b/billiards/Ccd.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace Billiards;
+
+/// <summary>Continuous collision detection helpers.</summary>
+public static class Ccd
+{
+    /// <summary>Time of impact between a moving circle and static circle. Returns true if they collide.</summary>
+    public static bool CircleCircle(Vec2 p0, Vec2 v0, double r0, Vec2 p1, double r1, out double toi)
+    {
+        Vec2 rel = p0 - p1;
+        double r = r0 + r1;
+        double a = Vec2.Dot(v0, v0);
+        double b = 2 * Vec2.Dot(rel, v0);
+        double c = Vec2.Dot(rel, rel) - r * r;
+        double disc = b * b - 4 * a * c;
+        if (disc < 0 || Math.Abs(a) < PhysicsConstants.Epsilon)
+        {
+            toi = double.PositiveInfinity;
+            return false;
+        }
+        double sqrt = Math.Sqrt(disc);
+        double t = (-b - sqrt) / (2 * a);
+        if (t >= 0 && t <= PhysicsConstants.MaxPreviewTime)
+        {
+            toi = t;
+            return true;
+        }
+        toi = double.PositiveInfinity;
+        return false;
+    }
+
+    /// <summary>Time of impact between moving circle and axis-aligned bounding box edges.</summary>
+    public static bool CircleAabb(Vec2 p, Vec2 v, double r, Vec2 min, Vec2 max, out double toi, out Vec2 normal)
+    {
+        toi = double.PositiveInfinity;
+        normal = new Vec2(0, 0);
+        bool hit = false;
+
+        if (Math.Abs(v.X) > PhysicsConstants.Epsilon)
+        {
+            double tx = v.X > 0 ? (max.X - r - p.X) / v.X : (min.X + r - p.X) / v.X;
+            if (tx >= 0 && tx < toi)
+            {
+                double y = p.Y + v.Y * tx;
+                if (y >= min.Y + r && y <= max.Y - r)
+                {
+                    toi = tx;
+                    hit = true;
+                    normal = v.X > 0 ? new Vec2(-1, 0) : new Vec2(1, 0);
+                }
+            }
+        }
+        if (Math.Abs(v.Y) > PhysicsConstants.Epsilon)
+        {
+            double ty = v.Y > 0 ? (max.Y - r - p.Y) / v.Y : (min.Y + r - p.Y) / v.Y;
+            if (ty >= 0 && ty < toi)
+            {
+                double x = p.X + v.X * ty;
+                if (x >= min.X + r && x <= max.X - r)
+                {
+                    toi = ty;
+                    hit = true;
+                    normal = v.Y > 0 ? new Vec2(0, -1) : new Vec2(0, 1);
+                }
+            }
+        }
+        return hit;
+    }
+}

--- a/billiards/Collision.cs
+++ b/billiards/Collision.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Billiards;
+
+/// <summary>Post-impact velocity computations.</summary>
+public static class Collision
+{
+    /// <summary>Reflect velocity on a surface with given normal.</summary>
+    public static Vec2 Reflect(Vec2 v, Vec2 normal)
+    {
+        var n = normal.Normalized();
+        var dot = Vec2.Dot(v, n);
+        return v - n * (1 + PhysicsConstants.Restitution) * dot;
+    }
+
+    /// <summary>Resolve elastic collision between two equal-mass balls.</summary>
+    public static void ResolveBallBall(Vec2 p0, Vec2 v0, Vec2 p1, Vec2 v1, out Vec2 v0Out, out Vec2 v1Out)
+    {
+        var n = (p1 - p0).Normalized();
+        var relVel = v0 - v1;
+        var along = Vec2.Dot(relVel, n);
+        var j = n * along;
+        v0Out = (v0 - j) * PhysicsConstants.Restitution;
+        v1Out = (v1 + j) * PhysicsConstants.Restitution;
+    }
+}

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -1,0 +1,14 @@
+namespace Billiards;
+
+/// <summary>Holds all tunable physics constants for determinism and easy calibration.</summary>
+public static class PhysicsConstants
+{
+    public const double BallRadius = 0.028575;        // metres (57.15 mm diameter)
+    public const double Restitution = 0.98;            // elastic coefficient
+    public const double Mu = 0.2;                      // linear damping (m/s^2)
+    public const double TableWidth = 2.84;             // 9ft table internal size
+    public const double TableHeight = 1.42;
+    public const double FixedDt = 1.0 / 120.0;         // simulation step
+    public const double Epsilon = 1e-9;                // numerical epsilon
+    public const double MaxPreviewTime = 30.0;         // safeguard for CCD
+}

--- a/billiards/ScreenToWorld.cs
+++ b/billiards/ScreenToWorld.cs
@@ -1,0 +1,22 @@
+namespace Billiards;
+
+/// <summary>Utility converting screen coordinates to world space.</summary>
+public static class ScreenToWorld
+{
+#if UNITY_5_3_OR_NEWER
+    /// <summary>Unity wrapper using the active camera.</summary>
+    public static Vec2 FromScreen(UnityEngine.Camera cam, UnityEngine.Vector2 screen)
+    {
+        var p = cam.ScreenToWorldPoint(new UnityEngine.Vector3((float)screen.x, (float)screen.y, 0));
+        return new Vec2(p.x, p.y);
+    }
+#endif
+
+    /// <summary>Engine-agnostic orthographic conversion.</summary>
+    public static Vec2 Ortho(Vec2 screen, double screenWidth, double screenHeight)
+    {
+        double x = screen.X / screenWidth * PhysicsConstants.TableWidth;
+        double y = screen.Y / screenHeight * PhysicsConstants.TableHeight;
+        return new Vec2(x, y);
+    }
+}

--- a/billiards/Vec2.cs
+++ b/billiards/Vec2.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Billiards;
+
+/// <summary>Lightweight deterministic 2D vector using doubles.</summary>
+public readonly struct Vec2
+{
+    public readonly double X;
+    public readonly double Y;
+
+    public Vec2(double x, double y) { X = x; Y = y; }
+
+    public static Vec2 operator +(Vec2 a, Vec2 b) => new Vec2(a.X + b.X, a.Y + b.Y);
+    public static Vec2 operator -(Vec2 a, Vec2 b) => new Vec2(a.X - b.X, a.Y - b.Y);
+    public static Vec2 operator *(Vec2 a, double s) => new Vec2(a.X * s, a.Y * s);
+    public static Vec2 operator /(Vec2 a, double s) => new Vec2(a.X / s, a.Y / s);
+
+    public double Length => Math.Sqrt(X * X + Y * Y);
+    public double LengthSquared => X * X + Y * Y;
+
+    public Vec2 Normalized()
+    {
+        var l = Length;
+        return l < PhysicsConstants.Epsilon ? new Vec2(0, 0) : this / l;
+    }
+
+    public static double Dot(Vec2 a, Vec2 b) => a.X * b.X + a.Y * b.Y;
+
+    public override string ToString() => $"({X}, {Y})";
+}


### PR DESCRIPTION
## Summary
- implement deterministic 2D billiards physics engine with continuous collision detection
- add aim preview utility, screen-to-world helper and Unity demo behaviour
- provide NUnit tests for CCD, preview accuracy, and determinism

## Testing
- `dotnet test billiards.Tests/Billiards.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68ae9ce904308329bad5c78828e83176