### PR TITLE
Normalize cue direction in billiards solver

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -72,3 +72,17 @@ public class DeterminismTests
         Assert.That((a.ContactPoint - b.ContactPoint).Length, Is.LessThan(1e-9));
     }
 }
+
+public class DirectionNormalizationTests
+{
+    [Test]
+    public void PreviewShotNormalizesDirection()
+    {
+        var solver = new BilliardsSolver();
+        var start = new Vec2(0.2, 0.5);
+        double speed = 2.0;
+        var p1 = solver.PreviewShot(start, new Vec2(1, 0), speed, new List<BilliardsSolver.Ball>());
+        var p2 = solver.PreviewShot(start, new Vec2(2, 0), speed, new List<BilliardsSolver.Ball>());
+        Assert.That((p1.Path[1] - p2.Path[1]).Length, Is.LessThan(1e-9));
+    }
+}

--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -69,7 +69,8 @@ public class BilliardsSolver
     /// <summary>Runs CCD to predict cue-ball path until first impact.</summary>
     public Preview PreviewShot(Vec2 cueStart, Vec2 dir, double speed, List<Ball> others)
     {
-        Vec2 velocity = dir * speed;
+        var nDir = dir.Normalized();
+        Vec2 velocity = nDir * speed;
         double bestT = double.PositiveInfinity;
         Ball hitBall = null;
         Vec2 hitNormal = new Vec2();
@@ -109,7 +110,7 @@ public class BilliardsSolver
 
         if (ballHit && hitBall != null)
         {
-            Collision.ResolveBallBall(contact - dir * PhysicsConstants.BallRadius, velocity, hitBall.Position, new Vec2(0, 0), out cuePost, out var target);
+            Collision.ResolveBallBall(contact - nDir * PhysicsConstants.BallRadius, velocity, hitBall.Position, new Vec2(0, 0), out cuePost, out var target);
             targetPost = target;
             path.Add(contact + cuePost.Normalized() * PhysicsConstants.BallRadius);
         }
@@ -125,7 +126,8 @@ public class BilliardsSolver
     /// <summary>Deterministic stepper simulation to validate preview.</summary>
     public Impact SimulateFirstImpact(Vec2 cueStart, Vec2 dir, double speed, List<Ball> others)
     {
-        var cue = new Ball { Position = cueStart, Velocity = dir * speed };
+        var nDir = dir.Normalized();
+        var cue = new Ball { Position = cueStart, Velocity = nDir * speed };
         var balls = new List<Ball>(others) { cue };
         double time = 0;
         while (time < PhysicsConstants.MaxPreviewTime)


### PR DESCRIPTION
## Summary
- Normalize shot direction before predicting or simulating cue ball path
- Cover direction normalization with a unit test

## Testing
- `npm test`
- ❌ `dotnet test billiards.Tests` *(dotnet command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeab883c0483299e6ca42f122173ef