### PR TITLE
feat: dark grey pockets

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -73,6 +73,15 @@
           // Subtle drop shadow under rim
           group.append(el('circle', {cx: x+3, cy: y+3, r: RIM_R+2, fill: 'black', opacity: 0.18}));
 
+          // Dark pocket base for visibility
+          group.append(el('circle', {
+            cx: x,
+            cy: y,
+            r: RIM_R,
+            fill: '#3a3a3a',
+            mask: `url(#pocket-mask-${i})`
+          }));
+
           // Mesh funnel: approximate by scaling a circle down to mimic depth
           group.append(el('ellipse', {
             cx: x,

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -421,7 +421,9 @@
         height: 10px;
         transform: translate(-50%, -50%);
         pointer-events: none;
-        opacity: 0;
+        opacity: 1;
+        background: #3a3a3a;
+        border-radius: 50%;
       }
 
       .winnerOverlay {


### PR DESCRIPTION
## Summary
- make pocket markers visible with a dark grey fill
- shade pocket interiors dark grey in the Pool Royale example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeb4f8dae88329ae50eee0c33287bb