### PR TITLE
Ensure Pool Royale pocket markers visible

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -421,7 +421,10 @@
         height: 10px;
         transform: translate(-50%, -50%);
         pointer-events: none;
-        opacity: 0;
+        /* Ensure pocket markers are visible above table canvas */
+        background: #333;
+        border-radius: 50%;
+        z-index: 5;
       }
 
       .winnerOverlay {


### PR DESCRIPTION
## Summary
- style pocket markers with dark grey fill and border radius
- give pocket markers a higher z-index so they render above the table canvas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aec4a929448329bf2489f5298a814e