### PR TITLE
Add kick and prize audio to penalty kick game

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -535,7 +535,8 @@
       for(const h of holes){
         if(Math.hypot(h.x-ball.x,h.y-ball.y) <= Math.max(2,h.r-ball.r*0.6)){
           h.hit=true; createFragments(h); netHit={x:ball.x,y:ball.y,t:1,shake:1};
-          sfxPost();
+          sfxPrize();
+          if(!ball.netSounded){ ball.netSounded=true; playNetSound(); }
           ball.spin *= 0.6;
           endShot(true,h.points); setTimeout(()=>{replaceHole(h);},600); return;
         }
@@ -574,7 +575,7 @@
         ball.x=ball.target.x; ball.y=ball.target.y;
         ball.vx*=0.2; ball.vy=Math.max(0,ball.vy)*0.2; ball.spin*=0.2;
         netHit={x:ball.x,y:ball.y,t:1,shake:1};
-        if(!ball.netSounded){ ball.netSounded=true; }
+        if(!ball.netSounded){ ball.netSounded=true; playNetSound(); }
         endShot(true,0); ball.target=null; ball.prevDist=null; return;
       }
       ball.prevDist=dist;
@@ -732,7 +733,7 @@ function endShot(hit,pts){
       drawAimPath(vx, vy, spin);
     }
   }
-  function onUp(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.active=false; if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; } const path=pointer.path; pointer.path=[]; if(path.length<3){ status('Swipe longer/faster.'); return; } const a=path[0], b=path[path.length-1]; const totalDy=b.y-a.y; if(totalDy>-10){ status('Swipe upward.'); return; } const endDx=b.x-ball.x, endDy=b.y-ball.y; const dist=Math.hypot(endDx,endDy), power=clamp(dist/150, 0.4, 3.0); const speed=SHOT_SPEED*power; const t=dist/speed; let curve=0; for(let i=2;i<path.length;i++){ const p0=path[i-2], p1=path[i-1], p2=path[i]; curve+=Math.atan2(p2.y-p1.y,p2.x-p1.x)-Math.atan2(p1.y-p0.y,p1.x-p0.x); } const spin = clamp((ball.x - a.x)/ball.r + curve*0.5, -5, 5); const adjDx=endDx - spin*0.125*t*t; ball.vx=adjDx/t; ball.vy=(endDy - 0.5*GRAVITY*t*t)/t; ball.spin=spin; ball.moving=true; ball.target={x:b.x,y:b.y}; ball.prevDist=Infinity; keeper.save=false; }
+  function onUp(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.active=false; if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; } const path=pointer.path; pointer.path=[]; if(path.length<3){ status('Swipe longer/faster.'); return; } const a=path[0], b=path[path.length-1]; const totalDy=b.y-a.y; if(totalDy>-10){ status('Swipe upward.'); return; } const endDx=b.x-ball.x, endDy=b.y-ball.y; const dist=Math.hypot(endDx,endDy), power=clamp(dist/150, 0.4, 3.0); const speed=SHOT_SPEED*power; const t=dist/speed; let curve=0; for(let i=2;i<path.length;i++){ const p0=path[i-2], p1=path[i-1], p2=path[i]; curve+=Math.atan2(p2.y-p1.y,p2.x-p1.x)-Math.atan2(p1.y-p0.y,p1.x-p0.x); } const spin = clamp((ball.x - a.x)/ball.r + curve*0.5, -5, 5); const adjDx=endDx - spin*0.125*t*t; ball.vx=adjDx/t; ball.vy=(endDy - 0.5*GRAVITY*t*t)/t; ball.spin=spin; ball.moving=true; playKickSound(); ball.target={x:b.x,y:b.y}; ball.prevDist=Infinity; keeper.save=false; }
   canvas.addEventListener('pointerdown', onDown, {passive:true});
   canvas.addEventListener('pointermove', onMove, {passive:true});
   addEventListener('pointerup', onUp, {passive:true}); addEventListener('pointercancel', onUp, {passive:true});
@@ -846,6 +847,25 @@ function endShot(hit,pts){
     src.connect(masterGain);
   }
   const sfxReward = playRewardSound;
+  let prizeSoundBuf=null;
+  async function loadPrizeSound(){
+    try{
+      const res=await fetch('/assets/sounds/glass-bottle-breaking-351297.mp3');
+      const arr=await res.arrayBuffer();
+      ensureAudio(); if(!audioCtx) return;
+      prizeSoundBuf = await audioCtx.decodeAudioData(arr);
+    }catch{}
+  }
+  loadPrizeSound();
+  function playPrizeSound(){
+    ensureAudio();
+    if(!audioCtx || !prizeSoundBuf) return;
+    const src=audioCtx.createBufferSource();
+    src.buffer=prizeSoundBuf;
+    src.connect(masterGain);
+    src.start(0);
+  }
+  const sfxPrize = playPrizeSound;
   let postSoundBuf=null;
   async function loadPostSound(){
     try{
@@ -865,6 +885,35 @@ function endShot(hit,pts){
     src.start(0);
   }
   const sfxPost = playPostSound;
+  let kickNetSoundBuf=null;
+  async function loadKickNetSound(){
+    try{
+      const res=await fetch('/assets/sounds/a-football-hits-the-net-goal-313216-[AudioTrimmer.com].mp3');
+      const arr=await res.arrayBuffer();
+      ensureAudio(); if(!audioCtx) return;
+      kickNetSoundBuf = await audioCtx.decodeAudioData(arr);
+    }catch{}
+  }
+  loadKickNetSound();
+  function playKickSound(){
+    ensureAudio();
+    if(!audioCtx || !kickNetSoundBuf) return;
+    const src=audioCtx.createBufferSource();
+    src.buffer=kickNetSoundBuf;
+    const half=kickNetSoundBuf.duration/2;
+    src.connect(masterGain);
+    src.start(0,0,half);
+  }
+  function playNetSound(){
+    ensureAudio();
+    if(!audioCtx || !kickNetSoundBuf) return;
+    const src=audioCtx.createBufferSource();
+    src.buffer=kickNetSoundBuf;
+    const half=kickNetSoundBuf.duration/2;
+    const end=Math.max(half, kickNetSoundBuf.duration-0.2);
+    src.connect(masterGain);
+    src.start(0,half,end-half);
+  }
   function vibrate(ms){ if(navigator.vibrate) try{ navigator.vibrate(ms); }catch{} }
 
   // ===== Static draw & tests =====


### PR DESCRIPTION
## Summary
- play glass bottle breaking sound when hitting goal prizes
- split football net sound into kick and net playback
- trigger net sound on prize hits and direct goals

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aed656ae28832981ef19cf02985e57