### PR TITLE
Align Pool Royale table with side markings

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -167,10 +167,10 @@
         overflow: hidden;
         /* Ensure background image covers the available space without
          overlapping top or bottom elements. Extend the width slightly
-         so the thin green boundary line is fully visible while keeping
-         extra clearance at the bottom. */
+         so the thin green boundary line is fully visible while matching
+         the bottom clearance to the side markings. */
         background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
-          top center/calc(100% + 8px) calc(100% + 20px) no-repeat;
+          top center/calc(100% + 8px) calc(100% + 8px) no-repeat;
       }
 
       :root {


### PR DESCRIPTION
## Summary
- Trim extra bottom padding on the Pool Royale table background so the play field matches the green side markings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aed7486a00832990a3b681d569e07b