### PR TITLE
Adjust Poll Royale table bottom boundary

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -618,7 +618,9 @@
         var SIDE_POCKET_R = 36; // gropat anesore edhe me te vogla nga brenda
         var BALL_R = 21.5; // rrezja baze e topave akoma pak me e vogel
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
-        var BORDER_BOTTOM = BORDER; // anet e tjera mbeten te pandryshuara
+        // Lift the bottom field line slightly so only the lower boundary moves
+        // up by roughly the thickness of three green side markings.
+        var BORDER_BOTTOM = BORDER + 6; // anet e tjera mbeten te pandryshuara
         // Move the rack slightly upward on the table
         var SPOT_Y =
           BORDER_TOP +


### PR DESCRIPTION
## Summary
- lift bottom boundary of Poll Royale field by thickness of three green markings

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, 'inc' is never reassigned. Use 'const' instead, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aedb2b8df8832994ef2ee6a681f9b2