### PR TITLE
style(pool): align background with raised bottom line

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -167,10 +167,10 @@
         overflow: hidden;
         /* Ensure background image covers the available space without
          overlapping top or bottom elements. Extend the width slightly
-         so the thin green boundary line is fully visible while keeping
-         extra clearance at the bottom. */
+         so the thin green boundary line remains visible while trimming
+         the bottom by roughly three side-marking widths. */
         background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
-          top center/calc(100% + 8px) calc(100% + 20px) no-repeat;
+          top center/calc(100% + 8px) calc(100% + 14px) no-repeat;
       }
 
       :root {


### PR DESCRIPTION
## Summary
- trim Pool Royale background height so the bottom boundary sits higher and matches side markings

## Testing
- `npm test` *(server left running; tests reported ok)*
- `npm run lint` *(fails: 1288 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aee03e8338832981a8e6275868f1cf