### PR TITLE
Lift bottom pool field boundary

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -620,7 +620,7 @@
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Lift the bottom field line slightly so only the lower boundary moves
         // up by roughly the thickness of three green side markings.
-        var BORDER_BOTTOM = BORDER + 6; // anet e tjera mbeten te pandryshuara
+        var BORDER_BOTTOM = BORDER + 12; // anet e tjera mbeten te pandryshuara
         // Move the rack slightly upward on the table
         var SPOT_Y =
           BORDER_TOP +


### PR DESCRIPTION
## Summary
- raise Pool Royale field's bottom boundary so only the lower edge shifts upward, revealing more of the background without moving the top or sides

## Testing
- `npm test`
- `npm run lint` *(fails: many existing style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aee401cc008329a26511de828013d9