### PR TITLE
Adjust middle pocket alignment for Pool Royale

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1154,11 +1154,15 @@
           this.pockets = [
             new Pocket(BORDER, BORDER_TOP, POCKET_R),
             new Pocket(TABLE_W - BORDER, BORDER_TOP, POCKET_R),
-            // Lift middle pockets slightly to align with field markings
-            new Pocket(BORDER - 2, TABLE_H / 2 + BALL_R - 10, SIDE_POCKET_R),
+            // Lift middle pockets a bit further up (two green line widths)
+            new Pocket(
+              BORDER - 2,
+              TABLE_H / 2 + BALL_R - 18,
+              SIDE_POCKET_R
+            ),
             new Pocket(
               TABLE_W - BORDER + 2,
-              TABLE_H / 2 + BALL_R - 10,
+              TABLE_H / 2 + BALL_R - 18,
               SIDE_POCKET_R
             ),
             new Pocket(BORDER, TABLE_H - BORDER_BOTTOM, POCKET_R),


### PR DESCRIPTION
## Summary
- Shift middle table pockets slightly upward to better align with field markings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef82fd4648329a8139fb470ae5955