### PR TITLE
Tweak Pool Royale field boundary and pockets

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -618,9 +618,9 @@
         var SIDE_POCKET_R = 38; // gropat anesore edhe me te vogla nga brenda
         var BALL_R = 21.5; // rrezja baze e topave akoma pak me e vogel
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
-        // Lift the bottom field line slightly so only the lower boundary moves
-        // up by roughly the thickness of three green side markings.
-        var BORDER_BOTTOM = BORDER + 12; // anet e tjera mbeten te pandryshuara
+        // Raise only the bottom field line by the thickness of one green side
+        // marking so the table's lower boundary sits slightly higher.
+        var BORDER_BOTTOM = BORDER + 14; // anet e tjera mbeten te pandryshuara
         // Move the rack slightly upward on the table
         var SPOT_Y =
           BORDER_TOP +
@@ -1154,11 +1154,12 @@
           this.pockets = [
             new Pocket(BORDER, BORDER_TOP, POCKET_R),
             new Pocket(TABLE_W - BORDER, BORDER_TOP, POCKET_R),
-            // Lift middle pockets slightly to align with field markings
-            new Pocket(BORDER - 2, TABLE_H / 2 + BALL_R - 10, SIDE_POCKET_R),
+            // Lift middle pockets a touch more to align with the shifted field
+            // boundary, matching the green marking thickness.
+            new Pocket(BORDER - 2, TABLE_H / 2 + BALL_R - 12, SIDE_POCKET_R),
             new Pocket(
               TABLE_W - BORDER + 2,
-              TABLE_H / 2 + BALL_R - 10,
+              TABLE_H / 2 + BALL_R - 12,
               SIDE_POCKET_R
             ),
             new Pocket(BORDER, TABLE_H - BORDER_BOTTOM, POCKET_R),


### PR DESCRIPTION
## Summary
- Raise bottom field boundary slightly to reduce playfield height
- Nudge middle pockets upward to align with field markings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aefc89c1608329b9aa180a3468143c