### PR TITLE
Improve UK 8-ball AI safety heuristics

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -99,6 +99,22 @@ function pathBlocked(a, b, balls, ignoreIds, radius) {
   );
 }
 
+function pocketBetween(cue, ball, pockets, radius) {
+  const dx = ball.x - cue.x;
+  const dy = ball.y - cue.y;
+  const len = Math.hypot(dx, dy) || 1;
+  const nx = dx / len;
+  const ny = dy / len;
+  for (const p of pockets) {
+    const t = (p.x - cue.x) * nx + (p.y - cue.y) * ny;
+    if (t > 0 && t < len) {
+      const perp = Math.abs((p.x - cue.x) * ny - (p.y - cue.y) * nx);
+      if (perp < radius * 1.5) return true;
+    }
+  }
+  return false;
+}
+
 // Returns angle between cue->ball and ball->pocket in radians
 function cutAngle(cue, target, pocket) {
   const v1 = { x: target.x - cue.x, y: target.y - cue.y };
@@ -117,9 +133,16 @@ function visibleOwnBalls(state, colour) {
   for (const ball of state.balls) {
     if (ball.pocketed) continue;
     if (ball.colour !== colour) continue;
-    if (!pathBlocked(cue, ball, state.balls, [cue.id], state.ballRadius)) {
-      res.push(ball);
-    }
+    if (pathBlocked(cue, ball, state.balls, [cue.id], state.ballRadius)) continue;
+    if (pocketBetween(cue, ball, state.pockets, state.ballRadius)) continue;
+    const crowded = state.balls.some(
+      other =>
+        !other.pocketed &&
+        other.id !== ball.id &&
+        dist(other, ball) < state.ballRadius * 2.2
+    );
+    if (crowded) continue;
+    res.push(ball);
   }
   return res;
 }

--- a/test/poolUkAdvancedAi.test.js
+++ b/test/poolUkAdvancedAi.test.js
@@ -93,3 +93,53 @@ test('prioritizes straight pots', () => {
   assert.equal(plan.aimPoint.y, 250);
 });
 
+test('avoids pockets on line to target', () => {
+  const state = {
+    balls: [
+      { id: 0, colour: 'cue', x: 50, y: 100 },
+      { id: 1, colour: 'yellow', x: 250, y: 100 },
+      { id: 2, colour: 'red', x: 150, y: 150 }
+    ],
+    pockets: [
+      { x: 150, y: 100, name: 'M' },
+      { x: 0, y: 0, name: 'TL' },
+      { x: 300, y: 0, name: 'TR' },
+      { x: 0, y: 200, name: 'BL' },
+      { x: 300, y: 200, name: 'BR' }
+    ],
+    width: 300,
+    height: 200,
+    ballRadius: 10,
+    ballOn: 'yellow',
+    isOpenTable: false,
+    shotsRemaining: 1
+  };
+  const plan = selectShot(state, {});
+  assert.equal(plan.actionType, 'safety');
+});
+
+test('avoids clustered targets', () => {
+  const state = {
+    balls: [
+      { id: 0, colour: 'cue', x: 50, y: 50 },
+      { id: 1, colour: 'yellow', x: 200, y: 100 },
+      { id: 3, colour: 'yellow', x: 215, y: 105 },
+      { id: 2, colour: 'red', x: 150, y: 150 }
+    ],
+    pockets: [
+      { x: 0, y: 0, name: 'TL' },
+      { x: 300, y: 0, name: 'TR' },
+      { x: 0, y: 200, name: 'BL' },
+      { x: 300, y: 200, name: 'BR' }
+    ],
+    width: 300,
+    height: 200,
+    ballRadius: 10,
+    ballOn: 'yellow',
+    isOpenTable: false,
+    shotsRemaining: 1
+  };
+  const plan = selectShot(state, {});
+  assert.equal(plan.actionType, 'safety');
+});
+


### PR DESCRIPTION
## Summary
- Teach 8-ball UK AI to ignore object balls that would send the cue toward a pocket
- Skip crowded targets so first contact stays on the intended ball
- Add tests for pocket and cluster avoidance

## Testing
- `node --test test/poolUkAdvancedAi.test.js`
- `npm test` *(fails to exit, server hangs; partial log shows all tests incl. new ones pass)*

------
https://chatgpt.com/codex/tasks/task_e_68af369053c48329a80de33ffd48d123