### PR TITLE
feat: enhance pool ai pocket targeting

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -60,6 +60,16 @@ function pathBlocked (a, b, balls, ignoreIds, radius) {
   )
 }
 
+function pocketEntry (ball, pocket, radius) {
+  const dir = { x: ball.x - pocket.x, y: ball.y - pocket.y }
+  const len = Math.hypot(dir.x, dir.y) || 1
+  const offset = radius * 1.05
+  return {
+    x: pocket.x + (dir.x / len) * offset,
+    y: pocket.y + (dir.y / len) * offset
+  }
+}
+
 function chooseTargets (req) {
   const balls = req.state.balls.filter(b => !b.pocketed && b.id !== 0)
   if (req.game === 'NINE_BALL' || req.game === 'AMERICAN_BILLIARDS') {
@@ -134,9 +144,10 @@ function blocked (cue, ghost, balls, ignoreId, radius) {
 function evaluate (req, cue, target, pocket, power, spin, ballsOverride) {
   const r = req.state.ballRadius
   const balls = ballsOverride || req.state.balls
+  const entry = pocketEntry(target, pocket, r)
   const ghost = {
-    x: target.x - (pocket.x - target.x) * (r * 2 / dist(target, pocket)),
-    y: target.y - (pocket.y - target.y) * (r * 2 / dist(target, pocket))
+    x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
+    y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
   }
   // if ghost lies outside playable area, shot is impossible
   if (
@@ -149,14 +160,15 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride) {
   }
   if (
     blocked(cue, ghost, balls, target.id, r) ||
-    pathBlocked(target, pocket, balls, [0, target.id], r)
+    pathBlocked(target, entry, balls, [0, target.id], r) ||
+    balls.some(b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
   ) {
     return null
   }
   const maxD = Math.hypot(req.state.width, req.state.height)
-  const distShot = dist(cue, target) + dist(target, pocket)
+  const distShot = dist(cue, target) + dist(target, entry)
   const potChance = 1 - Math.min(distShot / maxD, 1)
-  const cueAfter = estimateCueAfterShot(cue, target, pocket, power, spin)
+  const cueAfter = estimateCueAfterShot(cue, target, entry, power, spin)
   const nextTargets = nextTargetsAfter(target.id, { ...req, state: { ...req.state, balls } })
   let nextScore = 0
   if (nextTargets.length > 0) {
@@ -165,10 +177,10 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride) {
   }
   const risk = req.state.pockets.some(p => dist(cueAfter, p) < r * 1.2) ? 1 : 0
   const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
-  const potVec = { x: pocket.x - target.x, y: pocket.y - target.y }
+  const potVec = { x: entry.x - target.x, y: entry.y - target.y }
   const cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
   const centerAlign = 1 - Math.min(cutAngle / (Math.PI / 2), 1)
-  const nearHole = 1 - Math.min(dist(target, pocket) / (r * 20), 1)
+  const nearHole = 1 - Math.min(dist(target, entry) / (r * 20), 1)
   const quality = Math.max(
     0,
     Math.min(
@@ -210,15 +222,16 @@ export function planShot (req) {
 
   for (const target of targets) {
     for (const pocket of pockets) {
+      const entry = pocketEntry(target, pocket, r)
       // ball in hand: sample cue placements along pocket-target line
       const placements = []
       if (req.state.ballInHand) {
-        const toPocket = { x: pocket.x - target.x, y: pocket.y - target.y }
+        const toPocket = { x: entry.x - target.x, y: entry.y - target.y }
         const distTP = Math.hypot(toPocket.x, toPocket.y) || 1
-        const dir = { x: target.x - pocket.x, y: target.y - pocket.y }
+        const dir = { x: target.x - entry.x, y: target.y - entry.y }
         const ghost = {
-          x: target.x - (pocket.x - target.x) * (r * 2 / dist(target, pocket)),
-          y: target.y - (pocket.y - target.y) * (r * 2 / dist(target, pocket))
+          x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
+          y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
         }
         const dists = [4, 6, 8, 10, 12].map(m => m * r)
         for (const d of dists) {

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -85,3 +85,25 @@ test('ball in hand aims for straight shot', () => {
   const diff = Math.abs(angle1 - angle2);
   assert(diff < 0.2);
 });
+
+test('avoids pocket with blocking ball at entrance', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 50, y: 100, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 220, y: 80, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 285, y: 15, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [ { x: 300, y: 0 } ],
+      width: 300,
+      height: 200,
+      ballRadius: 10,
+      friction: 0.01
+    },
+    timeBudgetMs: 50,
+    rngSeed: 3
+  };
+  const decision = planShot(req);
+  assert.equal(decision.quality, 0);
+});


### PR DESCRIPTION
## Summary
- account for pocket entrance size when aiming shots
- avoid pockets blocked by other balls during planning
- cover blocked-pocket scenario with a new unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af48ac32988329a853c1b464ad05cf