### PR TITLE
Fix foul call on 8-ball win and improve AI cushion strategy

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -55,121 +55,121 @@
  * Map keyed by discretised angle and distance storing shot outcomes.
  * Each entry: { success:number, attempts:number }
  */
-const shotMemory = new Map();
+const shotMemory = new Map()
 
-export function recordShotOutcome(plan, success) {
-  if (!plan || typeof plan.angle !== 'number' || typeof plan.distToPocket !== 'number') return;
-  const angleBucket = Math.round((plan.angle * 180 / Math.PI) / 10); // 10° buckets
-  const distBucket = Math.round(plan.distToPocket / 50); // 50px buckets
-  const key = `${angleBucket}:${distBucket}`;
-  const stats = shotMemory.get(key) || { success: 0, attempts: 0 };
-  stats.attempts += 1;
-  if (success) stats.success += 1;
-  shotMemory.set(key, stats);
+export function recordShotOutcome (plan, success) {
+  if (!plan || typeof plan.angle !== 'number' || typeof plan.distToPocket !== 'number') return
+  const angleBucket = Math.round((plan.angle * 180 / Math.PI) / 10) // 10° buckets
+  const distBucket = Math.round(plan.distToPocket / 50) // 50px buckets
+  const key = `${angleBucket}:${distBucket}`
+  const stats = shotMemory.get(key) || { success: 0, attempts: 0 }
+  stats.attempts += 1
+  if (success) stats.success += 1
+  shotMemory.set(key, stats)
 }
 
-export function __resetShotMemory() {
-  shotMemory.clear();
+export function __resetShotMemory () {
+  shotMemory.clear()
 }
 
 // ----------------- geometry helpers -----------------
-function dist(a, b) {
-  const dx = a.x - b.x;
-  const dy = a.y - b.y;
-  return Math.hypot(dx, dy);
+function dist (a, b) {
+  const dx = a.x - b.x
+  const dy = a.y - b.y
+  return Math.hypot(dx, dy)
 }
 
-function lineIntersectsBall(a, b, ball, radius) {
-  const apx = ball.x - a.x;
-  const apy = ball.y - a.y;
-  const abx = b.x - a.x;
-  const aby = b.y - a.y;
-  const t = (apx * abx + apy * aby) / (abx * abx + aby * aby);
-  if (t <= 0 || t >= 1) return false;
-  const closest = { x: a.x + abx * t, y: a.y + aby * t };
-  return dist(closest, ball) < radius * 2;
+function lineIntersectsBall (a, b, ball, radius) {
+  const apx = ball.x - a.x
+  const apy = ball.y - a.y
+  const abx = b.x - a.x
+  const aby = b.y - a.y
+  const t = (apx * abx + apy * aby) / (abx * abx + aby * aby)
+  if (t <= 0 || t >= 1) return false
+  const closest = { x: a.x + abx * t, y: a.y + aby * t }
+  return dist(closest, ball) < radius * 2
 }
 
-function pathBlocked(a, b, balls, ignoreIds, radius) {
+function pathBlocked (a, b, balls, ignoreIds, radius) {
   return balls.some(
     ball =>
       !ball.pocketed &&
       !ignoreIds.includes(ball.id) &&
       lineIntersectsBall(a, b, ball, radius)
-  );
+  )
 }
 
-function pocketBetween(cue, ball, pockets, radius) {
-  const dx = ball.x - cue.x;
-  const dy = ball.y - cue.y;
-  const len = Math.hypot(dx, dy) || 1;
-  const nx = dx / len;
-  const ny = dy / len;
+function pocketBetween (cue, ball, pockets, radius) {
+  const dx = ball.x - cue.x
+  const dy = ball.y - cue.y
+  const len = Math.hypot(dx, dy) || 1
+  const nx = dx / len
+  const ny = dy / len
   for (const p of pockets) {
-    const t = (p.x - cue.x) * nx + (p.y - cue.y) * ny;
+    const t = (p.x - cue.x) * nx + (p.y - cue.y) * ny
     if (t > 0 && t < len) {
-      const perp = Math.abs((p.x - cue.x) * ny - (p.y - cue.y) * nx);
-      if (perp < radius * 1.5) return true;
+      const perp = Math.abs((p.x - cue.x) * ny - (p.y - cue.y) * nx)
+      if (perp < radius * 1.5) return true
     }
   }
-  return false;
+  return false
 }
 
 // Returns angle between cue->ball and ball->pocket in radians
-function cutAngle(cue, target, pocket) {
-  const v1 = { x: target.x - cue.x, y: target.y - cue.y };
-  const v2 = { x: pocket.x - target.x, y: pocket.y - target.y };
-  const dot = v1.x * v2.x + v1.y * v2.y;
-  const mag1 = Math.hypot(v1.x, v1.y);
-  const mag2 = Math.hypot(v2.x, v2.y);
-  const cos = Math.min(Math.max(dot / (mag1 * mag2), -1), 1);
-  return Math.acos(cos);
+function cutAngle (cue, target, pocket) {
+  const v1 = { x: target.x - cue.x, y: target.y - cue.y }
+  const v2 = { x: pocket.x - target.x, y: pocket.y - target.y }
+  const dot = v1.x * v2.x + v1.y * v2.y
+  const mag1 = Math.hypot(v1.x, v1.y)
+  const mag2 = Math.hypot(v2.x, v2.y)
+  const cos = Math.min(Math.max(dot / (mag1 * mag2), -1), 1)
+  return Math.acos(cos)
 }
 
 // ----------------- candidate generation -----------------
-function visibleOwnBalls(state, colour) {
-  const cue = state.balls.find(b => b.colour === 'cue');
-  const res = [];
+function visibleOwnBalls (state, colour) {
+  const cue = state.balls.find(b => b.colour === 'cue')
+  const res = []
   for (const ball of state.balls) {
-    if (ball.pocketed) continue;
-    if (ball.colour !== colour) continue;
-    if (pathBlocked(cue, ball, state.balls, [cue.id], state.ballRadius)) continue;
-    if (pocketBetween(cue, ball, state.pockets, state.ballRadius)) continue;
+    if (ball.pocketed) continue
+    if (ball.colour !== colour) continue
+    if (pathBlocked(cue, ball, state.balls, [cue.id], state.ballRadius)) continue
+    if (pocketBetween(cue, ball, state.pockets, state.ballRadius)) continue
     const crowded = state.balls.some(
       other =>
         !other.pocketed &&
         other.id !== ball.id &&
         dist(other, ball) < state.ballRadius * 2.2
-    );
-    if (crowded) continue;
-    res.push(ball);
+    )
+    if (crowded) continue
+    res.push(ball)
   }
-  return res;
+  return res
 }
 
-function generatePotCandidates(state, colour) {
-  const cue = state.balls.find(b => b.colour === 'cue');
-  const balls = visibleOwnBalls(state, colour);
-  const shots = [];
+function generatePotCandidates (state, colour) {
+  const cue = state.balls.find(b => b.colour === 'cue')
+  const balls = visibleOwnBalls(state, colour)
+  const shots = []
   for (const ball of balls) {
-    let bestPocket = null;
-    let bestAngle = Infinity;
-    let bestDist = Infinity;
+    let bestPocket = null
+    let bestAngle = Infinity
+    let bestDist = Infinity
     for (const pocket of state.pockets) {
       // prefer pockets that give the straightest line to the cue
-      if (pathBlocked(ball, pocket, state.balls, [cue.id, ball.id], state.ballRadius)) continue;
-      const angle = cutAngle(cue, ball, pocket);
-      const d = dist(ball, pocket);
+      if (pathBlocked(ball, pocket, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+      const angle = cutAngle(cue, ball, pocket)
+      const d = dist(ball, pocket)
       if (angle < bestAngle - 1e-6 || (Math.abs(angle - bestAngle) <= 1e-6 && d < bestDist)) {
-        bestAngle = angle;
-        bestDist = d;
-        bestPocket = pocket;
+        bestAngle = angle
+        bestDist = d
+        bestPocket = pocket
       }
     }
     if (bestPocket && !pathBlocked(ball, bestPocket, state.balls, [cue.id, ball.id], state.ballRadius)) {
-      const angle = bestAngle;
-      const distCT = dist(cue, ball);
-      const distTP = bestDist;
+      const angle = bestAngle
+      const distCT = dist(cue, ball)
+      const distTP = bestDist
       const shot = {
         actionType: 'pot',
         targetBall: ball,
@@ -177,41 +177,41 @@ function generatePotCandidates(state, colour) {
         cueParams: { speed: 'med', spin: 'stun' },
         angle,
         distCT,
-        distTP,
-      };
-      shots.push(shot);
+        distTP
+      }
+      shots.push(shot)
     }
   }
-  return shots;
+  return shots
 }
 
-function mirrorPocket(pocket, width, height, rail) {
+function mirrorPocket (pocket, width, height, rail) {
   switch (rail) {
     case 'left':
-      return { x: -pocket.x, y: pocket.y };
+      return { x: -pocket.x, y: pocket.y }
     case 'right':
-      return { x: width * 2 - pocket.x, y: pocket.y };
+      return { x: width * 2 - pocket.x, y: pocket.y }
     case 'top':
-      return { x: pocket.x, y: -pocket.y };
+      return { x: pocket.x, y: -pocket.y }
     case 'bottom':
-      return { x: pocket.x, y: height * 2 - pocket.y };
+      return { x: pocket.x, y: height * 2 - pocket.y }
     default:
-      return pocket;
+      return pocket
   }
 }
 
-function generateBankPotCandidates(state, colour) {
-  const cue = state.balls.find(b => b.colour === 'cue');
-  const balls = visibleOwnBalls(state, colour);
-  const shots = [];
+function generateBankPotCandidates (state, colour) {
+  const cue = state.balls.find(b => b.colour === 'cue')
+  const balls = visibleOwnBalls(state, colour)
+  const shots = []
   for (const ball of balls) {
     for (const pocket of state.pockets) {
       for (const rail of ['left', 'right', 'top', 'bottom']) {
-        const mirror = mirrorPocket(pocket, state.width, state.height, rail);
-        if (pathBlocked(ball, mirror, state.balls, [cue.id, ball.id], state.ballRadius)) continue;
-        const angle = cutAngle(cue, ball, mirror);
-        const distCT = dist(cue, ball);
-        const distTP = dist(ball, pocket);
+        const mirror = mirrorPocket(pocket, state.width, state.height, rail)
+        if (pathBlocked(ball, mirror, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+        const angle = cutAngle(cue, ball, mirror)
+        const distCT = dist(cue, ball)
+        const distTP = dist(ball, pocket)
         const shot = {
           actionType: 'pot',
           targetBall: ball,
@@ -222,30 +222,117 @@ function generateBankPotCandidates(state, colour) {
           distTP,
           isBank: true,
           bankAnchor: mirror
-        };
-        shots.push(shot);
+        }
+        shots.push(shot)
       }
     }
   }
-  return shots;
+  return shots
 }
 
-function generateFreeBallCandidates(state, colour) {
+function mirrorPoint (pt, width, height, rail) {
+  switch (rail) {
+    case 'left':
+      return { x: -pt.x, y: pt.y }
+    case 'right':
+      return { x: width * 2 - pt.x, y: pt.y }
+    case 'top':
+      return { x: pt.x, y: -pt.y }
+    case 'bottom':
+      return { x: pt.x, y: height * 2 - pt.y }
+    default:
+      return pt
+  }
+}
+
+function intersectionWithRail (cue, target, rail, width, height) {
+  const dx = target.x - cue.x
+  const dy = target.y - cue.y
+  switch (rail) {
+    case 'left': {
+      const x = 0
+      const t = (x - cue.x) / dx
+      const y = cue.y + dy * t
+      return { x, y }
+    }
+    case 'right': {
+      const x = width
+      const t = (x - cue.x) / dx
+      const y = cue.y + dy * t
+      return { x, y }
+    }
+    case 'top': {
+      const y = 0
+      const t = (y - cue.y) / dy
+      const x = cue.x + dx * t
+      return { x, y }
+    }
+    case 'bottom': {
+      const y = height
+      const t = (y - cue.y) / dy
+      const x = cue.x + dx * t
+      return { x, y }
+    }
+    default:
+      return { x: cue.x, y: cue.y }
+  }
+}
+
+function generateKickCandidates (state, colour, maxRails = 4) {
+  const cue = state.balls.find(b => b.colour === 'cue')
+  const balls = state.balls.filter(b => b.colour === colour && !b.pocketed)
+  const shots = []
+  const rails = ['left', 'right', 'top', 'bottom']
+  for (const ball of balls) {
+    if (!pathBlocked(cue, ball, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+    const queue = [{ point: ball, seq: [] }]
+    const seen = new Set()
+    while (queue.length > 0) {
+      const { point, seq } = queue.shift()
+      if (seq.length >= maxRails) continue
+      for (const rail of rails) {
+        const mirrored = mirrorPoint(point, state.width, state.height, rail)
+        const key = `${mirrored.x},${mirrored.y},${seq.length + 1}`
+        if (seen.has(key)) continue
+        seen.add(key)
+        const newSeq = seq.concat(rail)
+        if (!pathBlocked(cue, mirrored, state.balls, [cue.id, ball.id], state.ballRadius)) {
+          const anchor = intersectionWithRail(cue, mirrored, newSeq[0], state.width, state.height)
+          shots.push({
+            actionType: 'safety',
+            targetBall: ball,
+            pocket: null,
+            cueParams: { speed: 'med', spin: 'stun' },
+            bankAnchor: anchor,
+            angle: 0,
+            distCT: dist(cue, ball),
+            distTP: 0
+          })
+        } else {
+          queue.push({ point: mirrored, seq: newSeq })
+        }
+      }
+    }
+  }
+  return shots
+}
+
+function generateFreeBallCandidates (state, colour) {
   // simple anchors: place cue on line from ball to nearest pocket
-  const shots = [];
+  const shots = []
   for (const ball of state.balls) {
-    if (ball.pocketed || ball.colour !== colour) continue;
-    let bestPocket = null;
-    let bestDist = Infinity;
+    if (ball.pocketed || ball.colour !== colour) continue
+    let bestPocket = null
+    let bestDist = Infinity
     for (const pocket of state.pockets) {
-      const d = dist(ball, pocket);
-      if (d < bestDist) { bestDist = d; bestPocket = pocket; }
+      const d = dist(ball, pocket)
+      if (d < bestDist) { bestDist = d; bestPocket = pocket }
     }
     if (bestPocket) {
-      let anchor = { x: ball.x - (bestPocket.x - ball.x), y: ball.y - (bestPocket.y - ball.y) };
+      const anchor = { x: ball.x - (bestPocket.x - ball.x), y: ball.y - (bestPocket.y - ball.y) }
       if (state.mustPlayFromBaulk && typeof state.baulkLineX === 'number') {
-        const maxX = state.baulkLineX - state.ballRadius;
-        if (anchor.x > maxX) anchor.x = maxX;
+        const maxX = state.baulkLineX - state.ballRadius
+        if (anchor.x > maxX) anchor.x = maxX
       }
       const shot = {
         actionType: 'freeBallPot',
@@ -256,20 +343,20 @@ function generateFreeBallCandidates(state, colour) {
         distCT: dist(anchor, ball),
         distTP: bestDist,
         anchor
-      };
-      shots.push(shot);
+      }
+      shots.push(shot)
     }
   }
-  return shots;
+  return shots
 }
 
-function generateSafeties(state, colour) {
-  const cue = state.balls.find(b => b.colour === 'cue');
-  const oppColour = colour === 'yellow' ? 'red' : 'yellow';
-  const oppBalls = state.balls.filter(b => b.colour === oppColour && !b.pocketed);
-  if (oppBalls.length === 0) return [];
+function generateSafeties (state, colour) {
+  const cue = state.balls.find(b => b.colour === 'cue')
+  const oppColour = colour === 'yellow' ? 'red' : 'yellow'
+  const oppBalls = state.balls.filter(b => b.colour === oppColour && !b.pocketed)
+  if (oppBalls.length === 0) return []
   // simple safety: thin off first opponent ball to rail
-  const target = oppBalls[0];
+  const target = oppBalls[0]
   return [{
     actionType: 'safety',
     targetBall: target,
@@ -278,202 +365,208 @@ function generateSafeties(state, colour) {
     isSafety: true,
     angle: Math.PI / 4,
     distCT: dist(cue, target),
-    distTP: 0,
-  }];
+    distTP: 0
+  }]
 }
 
 // ----------------- evaluation heuristics -----------------
-function estimatePotProbability(shot, state) {
-  const angleDeg = shot.angle * 180 / Math.PI;
-  const pocketViewDeg = Math.atan2(state.ballRadius * 2, shot.distTP || 1) * 180 / Math.PI;
-  const cutRatio = angleDeg / (pocketViewDeg + 1e-6);
-  let angleScore = 0.3;
-  if (cutRatio <= 1) angleScore = 0.9; else if (cutRatio <= 1.5) angleScore = 0.6;
-  const maxD = Math.hypot(state.width, state.height);
-  const distScore = 1 - Math.min((shot.distCT + shot.distTP) / maxD, 1);
+function estimatePotProbability (shot, state) {
+  const angleDeg = shot.angle * 180 / Math.PI
+  const pocketViewDeg = Math.atan2(state.ballRadius * 2, shot.distTP || 1) * 180 / Math.PI
+  const cutRatio = angleDeg / (pocketViewDeg + 1e-6)
+  let angleScore = 0.3
+  if (cutRatio <= 1) angleScore = 0.9; else if (cutRatio <= 1.5) angleScore = 0.6
+  const maxD = Math.hypot(state.width, state.height)
+  const distScore = 1 - Math.min((shot.distCT + shot.distTP) / maxD, 1)
   // prioritise minimal angles for safer pots
-  let P = angleScore * 0.8 + distScore * 0.2;
-  if (shot.isBank) P *= 0.5;
+  let P = angleScore * 0.8 + distScore * 0.2
+  if (shot.isBank) P *= 0.5
   // adjust by learnt success rates
-  const angleBucket = Math.round(angleDeg / 10);
-  const distBucket = Math.round((shot.distTP || 0) / 50);
-  const stats = shotMemory.get(`${angleBucket}:${distBucket}`);
+  const angleBucket = Math.round(angleDeg / 10)
+  const distBucket = Math.round((shot.distTP || 0) / 50)
+  const stats = shotMemory.get(`${angleBucket}:${distBucket}`)
   if (stats && stats.attempts > 0) {
-    const rate = stats.success / stats.attempts;
-    P = (P + rate) / 2;
+    const rate = stats.success / stats.attempts
+    P = (P + rate) / 2
   }
   // rail penalty
-  const target = shot.targetBall;
+  const target = shot.targetBall
   if (target && (Math.min(target.x, state.width - target.x) < state.ballRadius * 2 || Math.min(target.y, state.height - target.y) < state.ballRadius * 2)) {
-    P -= 0.1;
+    P -= 0.1
   }
-  if (state.shotsRemaining && state.shotsRemaining > 1) P += 0.05; // under pressure bonus
+  if (state.shotsRemaining && state.shotsRemaining > 1) P += 0.05 // under pressure bonus
   // bonus for near-straight shots
-  const straightBonus = Math.max(0, (10 - angleDeg) / 100);
-  P += straightBonus;
+  const straightBonus = Math.max(0, (10 - angleDeg) / 100)
+  P += straightBonus
   // encourage cue ball to remain central after pot
-  const cueAfter = simulateCueRollout(state, shot);
-  const center = { x: state.width / 2, y: state.height / 2 };
-  const centerScore = 1 - Math.min(dist(cueAfter, center) / maxD, 1);
-  P = P * 0.9 + centerScore * 0.1;
-  return Math.max(0, Math.min(1, P));
+  const cueAfter = simulateCueRollout(state, shot)
+  const center = { x: state.width / 2, y: state.height / 2 }
+  const centerScore = 1 - Math.min(dist(cueAfter, center) / maxD, 1)
+  P = P * 0.9 + centerScore * 0.1
+  return Math.max(0, Math.min(1, P))
 }
 
-function simulateCueRollout(state, shot) {
-  const cue = state.balls.find(b => b.colour === 'cue');
-  const ball = shot.targetBall;
-  let pos = { x: ball.x, y: ball.y };
-  const toPocket = { x: shot.pocket.x - ball.x, y: shot.pocket.y - ball.y };
-  const toPocketLen = Math.hypot(toPocket.x, toPocket.y) || 1;
-  const dirPocket = { x: toPocket.x / toPocketLen, y: toPocket.y / toPocketLen };
-  const toCue = { x: ball.x - cue.x, y: ball.y - cue.y };
-  const toCueLen = Math.hypot(toCue.x, toCue.y) || 1;
-  const dirCue = { x: toCue.x / toCueLen, y: toCue.y / toCueLen };
+function simulateCueRollout (state, shot) {
+  const cue = state.balls.find(b => b.colour === 'cue')
+  const ball = shot.targetBall
+  let pos = { x: ball.x, y: ball.y }
+  const toPocket = { x: shot.pocket.x - ball.x, y: shot.pocket.y - ball.y }
+  const toPocketLen = Math.hypot(toPocket.x, toPocket.y) || 1
+  const dirPocket = { x: toPocket.x / toPocketLen, y: toPocket.y / toPocketLen }
+  const toCue = { x: ball.x - cue.x, y: ball.y - cue.y }
+  const toCueLen = Math.hypot(toCue.x, toCue.y) || 1
+  const dirCue = { x: toCue.x / toCueLen, y: toCue.y / toCueLen }
   switch (shot.cueParams.spin) {
     case 'followS':
-      pos = { x: pos.x + dirPocket.x * 30, y: pos.y + dirPocket.y * 30 }; break;
+      pos = { x: pos.x + dirPocket.x * 30, y: pos.y + dirPocket.y * 30 }; break
     case 'followL':
-      pos = { x: pos.x + dirPocket.x * 60, y: pos.y + dirPocket.y * 60 }; break;
+      pos = { x: pos.x + dirPocket.x * 60, y: pos.y + dirPocket.y * 60 }; break
     case 'drawS':
-      pos = { x: pos.x + dirCue.x * 20, y: pos.y + dirCue.y * 20 }; break;
+      pos = { x: pos.x + dirCue.x * 20, y: pos.y + dirCue.y * 20 }; break
     case 'drawL':
-      pos = { x: pos.x + dirCue.x * 40, y: pos.y + dirCue.y * 40 }; break;
+      pos = { x: pos.x + dirCue.x * 40, y: pos.y + dirCue.y * 40 }; break
     case 'sideL': {
-      const angle = Math.atan2(dirPocket.y, dirPocket.x) - Math.PI / 12;
-      pos = { x: pos.x + Math.cos(angle) * 40, y: pos.y + Math.sin(angle) * 40 }; break;
+      const angle = Math.atan2(dirPocket.y, dirPocket.x) - Math.PI / 12
+      pos = { x: pos.x + Math.cos(angle) * 40, y: pos.y + Math.sin(angle) * 40 }; break
     }
     case 'sideR': {
-      const angle = Math.atan2(dirPocket.y, dirPocket.x) + Math.PI / 12;
-      pos = { x: pos.x + Math.cos(angle) * 40, y: pos.y + Math.sin(angle) * 40 }; break;
+      const angle = Math.atan2(dirPocket.y, dirPocket.x) + Math.PI / 12
+      pos = { x: pos.x + Math.cos(angle) * 40, y: pos.y + Math.sin(angle) * 40 }; break
     }
     default: // stun
       // cue stops near target
-      pos = { x: pos.x, y: pos.y };
+      pos = { x: pos.x, y: pos.y }
   }
-  return { x: pos.x, y: pos.y };
+  return { x: pos.x, y: pos.y }
 }
 
-function generateFastCandidates(state, colour) {
+function generateFastCandidates (state, colour) {
   // only consider straight pots for nearest ball
-  const cue = state.balls.find(b => b.colour === 'cue');
-  const ownBalls = visibleOwnBalls(state, colour);
-  if (ownBalls.length === 0) return [];
-  const ball = ownBalls.reduce((m, b) => dist(cue, b) < dist(cue, m) ? b : m, ownBalls[0]);
-  let bestPocket = null;
-  let bestAngle = Infinity;
-  let bestDist = Infinity;
+  const cue = state.balls.find(b => b.colour === 'cue')
+  const ownBalls = visibleOwnBalls(state, colour)
+  if (ownBalls.length === 0) return []
+  const ball = ownBalls.reduce((m, b) => dist(cue, b) < dist(cue, m) ? b : m, ownBalls[0])
+  let bestPocket = null
+  let bestAngle = Infinity
+  let bestDist = Infinity
   for (const p of state.pockets) {
-    if (pathBlocked(ball, p, state.balls, [cue.id, ball.id], state.ballRadius)) continue;
-    const angle = cutAngle(cue, ball, p);
-    const d = dist(ball, p);
+    if (pathBlocked(ball, p, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+    const angle = cutAngle(cue, ball, p)
+    const d = dist(ball, p)
     if (angle < bestAngle - 1e-6 || (Math.abs(angle - bestAngle) <= 1e-6 && d < bestDist)) {
-      bestAngle = angle;
-      bestDist = d;
-      bestPocket = p;
+      bestAngle = angle
+      bestDist = d
+      bestPocket = p
     }
   }
-  if (!bestPocket) return [];
-  return [{ actionType: 'pot', targetBall: ball, pocket: bestPocket, cueParams: { speed: 'med', spin: 'stun' }, angle: bestAngle, distCT: dist(cue, ball), distTP: bestDist }];
+  if (!bestPocket) return []
+  return [{ actionType: 'pot', targetBall: ball, pocket: bestPocket, cueParams: { speed: 'med', spin: 'stun' }, angle: bestAngle, distCT: dist(cue, ball), distTP: bestDist }]
 }
 
-function valueOfPositionAfter(nc, state, colour) {
+function valueOfPositionAfter (nc, state, colour) {
   // simple heuristic: high if still have easy pot
-  const P2 = estimatePotProbability(nc, state);
+  const P2 = estimatePotProbability(nc, state)
   // reward straighter follow-up shots
   const straightBonus =
     typeof nc.angle === 'number'
       ? Math.max(0, (Math.PI / 12 - nc.angle) / (Math.PI / 12)) * 0.2
-      : 0;
-  const remaining = state.balls.filter(b => b.colour === colour && !b.pocketed).length;
-  const base = remaining <= 1 ? 1.2 : 0.8; // higher when nearly finishing
-  const cueAfter = simulateCueRollout(state, nc);
-  const center = { x: state.width / 2, y: state.height / 2 };
-  const centerBonus = 0.1 * (1 - Math.min(dist(cueAfter, center) / Math.hypot(state.width, state.height), 1));
-  return (P2 + straightBonus) * base + centerBonus;
+      : 0
+  const remaining = state.balls.filter(b => b.colour === colour && !b.pocketed).length
+  const base = remaining <= 1 ? 1.2 : 0.8 // higher when nearly finishing
+  const cueAfter = simulateCueRollout(state, nc)
+  const center = { x: state.width / 2, y: state.height / 2 }
+  const centerBonus = 0.1 * (1 - Math.min(dist(cueAfter, center) / Math.hypot(state.width, state.height), 1))
+  return (P2 + straightBonus) * base + centerBonus
 }
 
-function foulRisk(shot, state) {
+function foulRisk (shot, state) {
   // basic scratch risk if cue after shot near pocket
-  const cueAfter = simulateCueRollout(state, shot);
-  return state.pockets.some(p => dist(cueAfter, p) < state.ballRadius * 1.2) ? 0.4 : 0;
+  const cueAfter = simulateCueRollout(state, shot)
+  return state.pockets.some(p => dist(cueAfter, p) < state.ballRadius * 1.2) ? 0.4 : 0
 }
 
-function riskPenalty(risk) {
-  return risk; // linear for simplicity
+function riskPenalty (risk) {
+  return risk // linear for simplicity
 }
 
-function safetyEV(state, colour) {
+function safetyEV (state, colour) {
   // heuristic: leaving opponent far gives low EV for them
-  const oppColour = colour === 'yellow' ? 'red' : 'yellow';
-  const cue = state.balls.find(b => b.colour === 'cue');
-  const oppBalls = state.balls.filter(b => b.colour === oppColour && !b.pocketed);
-  if (oppBalls.length === 0) return 0.5;
-  const oppNearest = oppBalls.reduce((m, b) => dist(cue, b) < dist(cue, m) ? b : m, oppBalls[0]);
-  const d = dist(cue, oppNearest);
-  const maxD = Math.hypot(state.width, state.height);
-  return 0.3 + 0.4 * (d / maxD);
+  const oppColour = colour === 'yellow' ? 'red' : 'yellow'
+  const cue = state.balls.find(b => b.colour === 'cue')
+  const oppBalls = state.balls.filter(b => b.colour === oppColour && !b.pocketed)
+  if (oppBalls.length === 0) return 0.5
+  const oppNearest = oppBalls.reduce((m, b) => dist(cue, b) < dist(cue, m) ? b : m, oppBalls[0])
+  const d = dist(cue, oppNearest)
+  const maxD = Math.hypot(state.width, state.height)
+  return 0.3 + 0.4 * (d / maxD)
 }
 
-function evaluateCandidates(state, colour, candidates) {
-  let best = null;
+function evaluateCandidates (state, colour, candidates) {
+  let best = null
   for (const c of candidates) {
-    let EV = 0;
+    let EV = 0
     if (c.actionType === 'safety') {
-      EV = safetyEV(state, colour);
+      EV = safetyEV(state, colour)
     } else {
-      const Ppot = estimatePotProbability(c, state);
-      const nextState = { ...state, balls: state.balls.map(b => ({ ...b })) };
-      const target = nextState.balls.find(b => b.id === c.targetBall.id);
-      target.pocketed = true;
-      const cue = nextState.balls.find(b => b.colour === 'cue');
-      const cuePos = simulateCueRollout(state, c);
-      cue.x = cuePos.x; cue.y = cuePos.y;
-      const nextCands = generateFastCandidates(nextState, colour);
-      let nextBest = 0;
+      const Ppot = estimatePotProbability(c, state)
+      const nextState = { ...state, balls: state.balls.map(b => ({ ...b })) }
+      const target = nextState.balls.find(b => b.id === c.targetBall.id)
+      target.pocketed = true
+      const cue = nextState.balls.find(b => b.colour === 'cue')
+      const cuePos = simulateCueRollout(state, c)
+      cue.x = cuePos.x; cue.y = cuePos.y
+      const nextCands = generateFastCandidates(nextState, colour)
+      let nextBest = 0
       for (const nc of nextCands) {
-        const EV2 = valueOfPositionAfter(nc, nextState, colour);
-        if (EV2 > nextBest) nextBest = EV2;
+        const EV2 = valueOfPositionAfter(nc, nextState, colour)
+        if (EV2 > nextBest) nextBest = EV2
       }
-      const baseValue = 1;
-      const risk = foulRisk(c, state);
-      EV = Ppot * (baseValue + nextBest) - riskPenalty(risk);
+      const baseValue = 1
+      const risk = foulRisk(c, state)
+      EV = Ppot * (baseValue + nextBest) - riskPenalty(risk)
     }
     if (!best || EV > best.EV) {
-      best = { c, EV };
+      best = { c, EV }
     }
   }
-  return best;
+  return best
 }
 
-function chooseBestAction(state, colour) {
-  let candidates = generatePotCandidates(state, colour).concat(generateBankPotCandidates(state, colour));
+function chooseBestAction (state, colour) {
+  let candidates = generatePotCandidates(state, colour)
+    .concat(generateBankPotCandidates(state, colour))
+    .concat(generateKickCandidates(state, colour))
   if (state.freeBallAvailable) {
-    candidates = candidates.concat(generateFreeBallCandidates(state, colour));
+    candidates = candidates.concat(generateFreeBallCandidates(state, colour))
   }
   if (candidates.length === 0) {
-    candidates = generateSafeties(state, colour);
+    candidates = generateSafeties(state, colour)
   } else {
-    const scored = candidates.map(c => estimatePotProbability(c, state));
-    const maxPot = scored.reduce((m, p) => Math.max(m, p), 0);
+    const scored = candidates.map(c =>
+      c.actionType === 'pot' || c.actionType === 'freeBallPot'
+        ? estimatePotProbability(c, state)
+        : 0
+    )
+    const maxPot = scored.reduce((m, p) => Math.max(m, p), 0)
     if (maxPot < 0.25) {
-      candidates = candidates.concat(generateSafeties(state, colour));
+      candidates = candidates.concat(generateSafeties(state, colour))
     }
   }
-  const STRAIGHT_THRESHOLD = Math.PI / 12; // ~15 degrees
+  const STRAIGHT_THRESHOLD = Math.PI / 12 // ~15 degrees
   const straightShots = candidates.filter(
     c => typeof c.angle === 'number' && c.angle <= STRAIGHT_THRESHOLD
-  );
+  )
   if (straightShots.length > 0) {
-    candidates = straightShots;
+    candidates = straightShots
   }
-  const best = evaluateCandidates(state, colour, candidates);
-  if (!best) return null;
-  const c = best.c;
-  const cueBall = state.balls.find(b => b.colour === 'cue');
-  const aim = c.bankAnchor ? { x: c.bankAnchor.x, y: c.bankAnchor.y } : (c.targetBall ? { x: c.targetBall.x, y: c.targetBall.y } : { x: cueBall.x, y: cueBall.y });
+  const best = evaluateCandidates(state, colour, candidates)
+  if (!best) return null
+  const c = best.c
+  const cueBall = state.balls.find(b => b.colour === 'cue')
+  const aim = c.bankAnchor ? { x: c.bankAnchor.x, y: c.bankAnchor.y } : (c.targetBall ? { x: c.targetBall.x, y: c.targetBall.y } : { x: cueBall.x, y: cueBall.y })
   const posTarget = c.actionType === 'safety'
     ? { x: cueBall.x, y: cueBall.y }
-    : simulateCueRollout(state, c);
+    : simulateCueRollout(state, c)
   return {
     actionType: c.actionType,
     targetBall: c.targetBall ? c.targetBall.colour : null,
@@ -485,25 +578,24 @@ function chooseBestAction(state, colour) {
     notes: c.actionType === 'safety' ? 'safety play' : `pot ${c.targetBall?.colour ?? ''}`,
     angle: typeof c.angle === 'number' ? c.angle : undefined,
     distToPocket: typeof c.distTP === 'number' ? c.distTP : undefined
-  };
+  }
 }
 
 // Public entry
-export function selectShot(state, rules = {}) {
-  let colour = state.ballOn;
+export function selectShot (state, rules = {}) {
+  let colour = state.ballOn
   if (!state.isOpenTable && colour) {
-    const hasOwn = state.balls.some(b => b.colour === colour && !b.pocketed);
-    if (!hasOwn) colour = 'black';
+    const hasOwn = state.balls.some(b => b.colour === colour && !b.pocketed)
+    if (!hasOwn) colour = 'black'
   }
   if (state.isOpenTable) {
-    const planY = chooseBestAction({ ...state, ballOn: 'yellow', isOpenTable: false }, 'yellow');
-    const planR = chooseBestAction({ ...state, ballOn: 'red', isOpenTable: false }, 'red');
-    if (!planY) return planR;
-    if (!planR) return planY;
-    return planY.EV >= planR.EV ? planY : planR;
+    const planY = chooseBestAction({ ...state, ballOn: 'yellow', isOpenTable: false }, 'yellow')
+    const planR = chooseBestAction({ ...state, ballOn: 'red', isOpenTable: false }, 'red')
+    if (!planY) return planR
+    if (!planR) return planY
+    return planY.EV >= planR.EV ? planY : planR
   }
-  return chooseBestAction(state, colour);
+  return chooseBestAction(state, colour)
 }
 
-export default selectShot;
-
+export default selectShot

--- a/test/poolUk8Ball.test.js
+++ b/test/poolUk8Ball.test.js
@@ -215,6 +215,35 @@ test('AI targets black when own balls cleared', () => {
   assert.equal(plan.targetBall, 'black');
 });
 
+test('AI uses cushions to reach own ball when blocked', () => {
+  __resetShotMemory();
+  const state = {
+    balls: [
+      { id: 0, colour: 'cue', x: 50, y: 150 },
+      { id: 1, colour: 'yellow', x: 250, y: 150 },
+      { id: 2, colour: 'red', x: 150, y: 150 }
+    ],
+    pockets: [
+      { name: 'TL', x: 0, y: 0 },
+      { name: 'TR', x: 300, y: 0 },
+      { name: 'ML', x: 0, y: 150 },
+      { name: 'MR', x: 300, y: 150 },
+      { name: 'BL', x: 0, y: 300 },
+      { name: 'BR', x: 300, y: 300 }
+    ],
+    width: 300,
+    height: 300,
+    ballRadius: 5,
+    ballOn: 'yellow',
+    isOpenTable: false,
+    freeBallAvailable: false,
+    shotsRemaining: 1
+  };
+  const plan = selectShot(state);
+  assert.equal(plan.targetBall, 'yellow');
+  assert.notEqual(plan.aimPoint.x, state.balls[1].x);
+});
+
 test('AI increases EV after learning from success', () => {
   __resetShotMemory();
   const state = {

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1806,11 +1806,10 @@
             }
             return false;
           }
-          if (firstHit.t === 'eight') {
-            return shooterType && hasBallsLeft(shooterType);
+          var ownLeft = shooterType && hasBallsLeft(shooterType);
+          if (firstHit.t === 'eight' || eightBallPotted) {
+            return ownLeft;
           }
-          if (eightBallPotted && shooterType && hasBallsLeft(shooterType))
-            return true;
           if (shooterType && firstHit.t !== shooterType) return true;
           return false;
         }


### PR DESCRIPTION
## Summary
- prevent false fouls when potting the black after clearing all balls
- allow AI to bank off up to four cushions to reach target balls
- test AI's use of cushions to avoid first-touch fouls

## Testing
- `node --test`
- `npm run lint` *(fails: Extra semicolon errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68af53bfa5088329853bb97a89377ffb