### PR TITLE
Add visible boundary and pocket markers to Pool Royale

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1388,7 +1388,20 @@
             w = (TABLE_W - 2 * BORDER) * sX,
             h = (TABLE_H - BORDER_TOP - BORDER_BOTTOM) * sY;
 
-          // Field boundary lines and pocket visuals removed
+          // Green boundary lines around the playing field
+          ctx.strokeStyle = '#22c55e';
+          ctx.lineWidth = 4 * scaleFactor;
+          ctx.strokeRect(x0, y0, w, h);
+
+          // Red circles marking the six pockets
+          ctx.strokeStyle = '#ff0000';
+          ctx.lineWidth = 3 * scaleFactor;
+          for (var i = 0; i < this.pockets.length; i++) {
+            var p = this.pockets[i];
+            ctx.beginPath();
+            ctx.arc(p.x * sX, p.y * sY, p.r * scaleFactor, 0, Math.PI * 2);
+            ctx.stroke();
+          }
 
           // Vija kufizuese e cueball-it dhe pika qendrore
           ctx.strokeStyle = '#fff';


### PR DESCRIPTION
## Summary
- draw green field boundaries on the Pool Royale canvas
- mark all six pockets with red circles

## Testing
- `npm test` (fails: server remains running; tests output included)
- `npm run lint` (fails: repo has 1207 lint errors)

------
https://chatgpt.com/codex/tasks/task_e_68af581c76f88329826bd74414be88d5