### PR TITLE
Tweak pool pocket sizes and positions

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -614,8 +614,8 @@
         var TABLE_W = 768; // gjeresi logjike e felt-it
         var TABLE_H = 1216; // lartesi logjike e felt-it
         var BORDER = 57; // korniza e drurit pak me e ngushte anash
-        var POCKET_R = 44; // rrezja baze e gropave pak me e vogel
-        var SIDE_POCKET_R = 40; // gropat anesore edhe me te vogla nga brenda
+        var POCKET_R = 42; // rrezja baze e gropave pak me e vogel
+        var SIDE_POCKET_R = 38; // gropat anesore edhe me te vogla nga brenda
         var BALL_R = 22; // rrezja baze e topave pak me e madhe
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side
@@ -1156,9 +1156,9 @@
             new Pocket(TABLE_W - BORDER, BORDER_TOP, POCKET_R),
             // Lift middle pockets a touch more to align with the shifted field
             // boundary, matching the green marking thickness.
-            new Pocket(BORDER - 2, TABLE_H / 2 + BALL_R - 12, SIDE_POCKET_R),
+            new Pocket(BORDER - 6, TABLE_H / 2 + BALL_R - 12, SIDE_POCKET_R),
             new Pocket(
-              TABLE_W - BORDER + 2,
+              TABLE_W - BORDER + 6,
               TABLE_H / 2 + BALL_R - 12,
               SIDE_POCKET_R
             ),


### PR DESCRIPTION
## Summary
- make all pool pockets slightly smaller
- nudge left and right middle pockets farther outward

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af5c82813c83299e8a750819ad3135