### PR TITLE
Adjust Pool Royale pocket sizes and positions

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -614,8 +614,8 @@
         var TABLE_W = 768; // gjeresi logjike e felt-it
         var TABLE_H = 1216; // lartesi logjike e felt-it
         var BORDER = 57; // korniza e drurit pak me e ngushte anash
-        var POCKET_R = 42; // rrezja baze e gropave pak me e vogel
-        var SIDE_POCKET_R = 38; // gropat anesore edhe me te vogla nga brenda
+        var POCKET_R = 40; // rrezja baze e gropave pak me e vogel
+        var SIDE_POCKET_R = 36; // gropat anesore edhe me te vogla nga brenda
         var BALL_R = 22; // rrezja baze e topave pak me e madhe
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side
@@ -1156,9 +1156,9 @@
             new Pocket(TABLE_W - BORDER, BORDER_TOP, POCKET_R),
             // Lift middle pockets a touch more to align with the shifted field
             // boundary, matching the green marking thickness.
-            new Pocket(BORDER - 6, TABLE_H / 2 + BALL_R - 12, SIDE_POCKET_R),
+            new Pocket(BORDER - 8, TABLE_H / 2 + BALL_R - 12, SIDE_POCKET_R),
             new Pocket(
-              TABLE_W - BORDER + 6,
+              TABLE_W - BORDER + 8,
               TABLE_H / 2 + BALL_R - 12,
               SIDE_POCKET_R
             ),


### PR DESCRIPTION
## Summary
- shrink all six pool pockets slightly for a tighter fit
- move the two middle pockets outward for better alignment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af64b09a6c8329bfabb3fa06859edc