### PR TITLE
Fix Poll Royale edge marker visibility

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1388,21 +1388,6 @@
             w = (TABLE_W - 2 * BORDER) * sX,
             h = (TABLE_H - BORDER_TOP - BORDER_BOTTOM) * sY;
 
-          // Green boundary lines around the playing field
-          ctx.strokeStyle = '#22c55e';
-          ctx.lineWidth = 4 * scaleFactor;
-          ctx.strokeRect(x0, y0, w, h);
-
-          // Red circles marking the six pockets
-          ctx.strokeStyle = '#ff0000';
-          ctx.lineWidth = 3 * scaleFactor;
-          for (var i = 0; i < this.pockets.length; i++) {
-            var p = this.pockets[i];
-            ctx.beginPath();
-            ctx.arc(p.x * sX, p.y * sY, p.r * scaleFactor, 0, Math.PI * 2);
-            ctx.stroke();
-          }
-
           // Vija kufizuese e cueball-it dhe pika qendrore
           ctx.strokeStyle = '#fff';
           ctx.lineWidth = 2;
@@ -1510,6 +1495,21 @@
             }
             ctx.restore();
           }
+
+          // Yellow boundary lines and pocket markers above the table image
+          ctx.save();
+          ctx.strokeStyle = '#facc15';
+          ctx.lineWidth = 4 * scaleFactor;
+          ctx.strokeRect(x0, y0, w, h);
+          ctx.strokeStyle = '#ff0000';
+          ctx.lineWidth = 3 * scaleFactor;
+          for (var i = 0; i < this.pockets.length; i++) {
+            var p = this.pockets[i];
+            ctx.beginPath();
+            ctx.arc(p.x * sX, p.y * sY, p.r * scaleFactor, 0, Math.PI * 2);
+            ctx.stroke();
+          }
+          ctx.restore();
 
           // Steka mbi felt + guida
           if (


### PR DESCRIPTION
## Summary
- Render edge and pocket markers after balls and draw them in yellow so they sit above the table background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af6d32bfc4832982ddf972ad8eeac5