### PR TITLE
Align corner pockets with table boundaries

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1162,8 +1162,8 @@
 
           // Pockets (4 qoshe + 2 te mesit anesore)
           this.pockets = [
-            new Pocket(BORDER, BORDER_TOP, POCKET_R),
-            new Pocket(TABLE_W - BORDER, BORDER_TOP, POCKET_R),
+            new Pocket(BORDER - 8, BORDER_TOP - 8, POCKET_R),
+            new Pocket(TABLE_W - BORDER + 8, BORDER_TOP - 8, POCKET_R),
             // Lift middle pockets a touch more to align with the shifted field
             // boundary, matching the green marking thickness.
             new Pocket(BORDER - 8, TABLE_H / 2 + BALL_R - 12, SIDE_POCKET_R),
@@ -1172,10 +1172,10 @@
               TABLE_H / 2 + BALL_R - 12,
               SIDE_POCKET_R
             ),
-            new Pocket(BORDER, TABLE_H - BORDER_BOTTOM, POCKET_R),
+            new Pocket(BORDER - 8, TABLE_H - BORDER_BOTTOM + 8, POCKET_R),
             new Pocket(
-              TABLE_W - BORDER,
-              TABLE_H - BORDER_BOTTOM,
+              TABLE_W - BORDER + 8,
+              TABLE_H - BORDER_BOTTOM + 8,
               POCKET_R
             )
           ];


### PR DESCRIPTION
## Summary
- shift top and bottom corner pockets closer to field so red pocket guides meet table border

## Testing
- `npm test` *(fails: process hung after tests completed)*

------
https://chatgpt.com/codex/tasks/task_e_68afeb097aec83298b7f93b4bc6f72c4