### PR TITLE
Adjust pool pocket arch alignment

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -2303,8 +2303,9 @@
           ctx.translate(x * sX, y * sY);
           ctx.rotate(angle);
           var R = r * scaleFactor;
-          // Leave a small opening so U edges connect with yellow lines
-          var gap = shortSides ? -R + R * 0.05 : R * 0.25;
+          // Bring the arch closer above the pocket by narrowing the opening
+          // while keeping mirrored pockets with minimal side lines.
+          var gap = shortSides ? -R + R * 0.05 : -R * 0.05;
           ctx.beginPath();
           ctx.moveTo(-R, gap);
           ctx.lineTo(-R, -R);


### PR DESCRIPTION
## Summary
- Align U-shaped pocket arches closer to pocket centers for the Pool Royale table by narrowing the gap in `drawUPocket`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aff543001483299806433c98b89b8a