### PR TITLE
Align Pool Royale pocket arches with U holes

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -2303,8 +2303,11 @@
           ctx.translate(x * sX, y * sY);
           ctx.rotate(angle);
           var R = r * scaleFactor;
-          // Leave a small opening so U edges connect with yellow lines
-          var gap = shortSides ? -R + R * 0.05 : R * 0.25;
+          // When drawing the mirrored arch, lift it slightly so it sits just above
+          // the pocket "U" and bring both styles closer to the side lines so they
+          // visually connect with the table edges.
+          if (shortSides) ctx.translate(0, -R * 0.1);
+          var gap = shortSides ? -R + R * 0.05 : R * 0.1;
           ctx.beginPath();
           ctx.moveTo(-R, gap);
           ctx.lineTo(-R, -R);


### PR DESCRIPTION
## Summary
- Adjust pocket arch rendering so mirrored arches sit slightly above U-shaped pockets and connect to table edges

## Testing
- `npm test` *(fails: Claim transaction failed and 3 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b00154fc7c832980498b7130755a55