### PR TITLE
refactor: adjust pool holes

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -74,8 +74,8 @@
             group.append(el('line', {x1: x, y1: y - innerR, x2: x, y2: y + innerR, stroke: 'yellow', 'stroke-width': 2}));
           }
 
-          // Rim built from two U-shaped arcs forming an O
-          const rimPath = `M${x - RIM_R} ${y} A ${RIM_R} ${RIM_R} 0 0 1 ${x + RIM_R} ${y} A ${RIM_R} ${RIM_R} 0 0 1 ${x - RIM_R} ${y}`;
+          // Rim shaped like a U: rounded long sides, straight short sides
+          const rimPath = `M${x - RIM_R} ${y - RIM_R} L${x + RIM_R} ${y - RIM_R} A ${RIM_R} ${RIM_R} 0 0 1 ${x + RIM_R} ${y + RIM_R} L${x - RIM_R} ${y + RIM_R} A ${RIM_R} ${RIM_R} 0 0 1 ${x - RIM_R} ${y - RIM_R}`;
           group.append(el('path', {d: rimPath, fill: 'none', stroke: '#1a1a1a', 'stroke-width': 8, opacity: 0.9}));
           group.append(el('path', {d: rimPath, fill: 'none', stroke: '#c2a44b', 'stroke-width': 3, opacity: 0.9}));
 

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -2303,16 +2303,20 @@
           ctx.translate(x * sX, y * sY);
           ctx.rotate(angle);
           var R = r * scaleFactor;
-          var archR = R * 1.1; // slightly wider arch reaching table sides
-          var raise = R * 0.2; // lift arch a bit above pocket centre
-          // Leave a small opening so U edges connect with yellow lines
-          var gap = shortSides ? -archR + archR * 0.05 : -raise;
-          var centerY = -R - raise;
+          var halfHeight = R; // distance to straight short sides
+          var halfWidth = R * 1.1; // width of rounded long sides
+          // when mirroring, keep the short sides very small
+          var w = shortSides ? halfWidth * 0.1 : halfWidth;
           ctx.beginPath();
-          ctx.moveTo(-archR, gap);
-          ctx.lineTo(-archR, centerY);
-          ctx.arc(0, centerY, archR, Math.PI, 0);
-          ctx.lineTo(archR, gap);
+          // Top straight edge
+          ctx.moveTo(-w, -halfHeight);
+          ctx.lineTo(w, -halfHeight);
+          // Rounded right side
+          ctx.arc(w, 0, halfHeight, -Math.PI / 2, Math.PI / 2);
+          // Bottom straight edge
+          ctx.lineTo(-w, halfHeight);
+          // Rounded left side
+          ctx.arc(-w, 0, halfHeight, Math.PI / 2, -Math.PI / 2);
           ctx.stroke();
           ctx.restore();
         }


### PR DESCRIPTION
## Summary
- redraw pocket overlays in Pool Royale as U-shapes with rounded long sides and straight short sides
- update Pool Royale example to match new pocket rim style

## Testing
- `npm test` *(fails: process hangs after tests; see logs)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b01e31ac188329a39e703951d51e33