### PR TITLE
feat: rotate pool pockets

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1517,9 +1517,8 @@
             var p = this.pockets[i];
             var dir = POCKET_DIRS[i];
             var angle = Math.atan2(dir.y, dir.x) - Math.PI / 2;
-            drawUPocket(ctx, p.x, p.y, p.r, angle);
-            // Mirror the U pocket on the opposite side with minimal side lines
-            drawUPocket(ctx, p.x, p.y, p.r, angle + Math.PI, true);
+            // Draw pocket rotated to the opposite side only
+            drawUPocket(ctx, p.x, p.y, p.r, angle + Math.PI);
           }
           ctx.restore();
 


### PR DESCRIPTION
## Summary
- rotate U-pocket renderings so holes display on opposite side

## Testing
- `npm run lint` (fails: Extra semicolon, prefer-const, etc.)
- `npm test` (aborted: process hung after partial output)


------
https://chatgpt.com/codex/tasks/task_e_68b0222049cc8329b02c407ab0d875ef