### PR TITLE
Add goal net sound asset for Penalty Kick

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -949,8 +949,9 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
       src.connect(masterGain);
       src.start(0);
     }
-    // Sound effect for net impact when a goal is scored. Only the second half is played.
-    // Place "a-football-hits-the-net-goal-313216.mp3" in webapp/public/assets/sounds.
+    // Sound effect for the ball hitting the net when a goal is scored.
+    // Uses the existing “a-football-hits-the-net-goal-313216.mp3” asset in
+    // webapp/public/assets/sounds and plays only the second half of the clip.
     const KICK_NET_SOUND = '/assets/sounds/a-football-hits-the-net-goal-313216.mp3';
     let kickNetSoundBuf = null;
     let kickNetSource = null;


### PR DESCRIPTION
## Summary
- Use existing goal-net audio clip for scoring in Penalty Kick

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b02144c5948329bf08c84a46d69f7d