### PR TITLE
fix pool pocket orientation and remove mirrored arc

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1516,10 +1516,8 @@
           for (var i = 0; i < this.pockets.length; i++) {
             var p = this.pockets[i];
             var dir = POCKET_DIRS[i];
-            var angle = Math.atan2(dir.y, dir.x) - Math.PI / 2;
+            var angle = Math.atan2(dir.y, dir.x) + Math.PI / 2;
             drawUPocket(ctx, p.x, p.y, p.r, angle);
-            // Mirror the U pocket on the opposite side with minimal side lines
-            drawUPocket(ctx, p.x, p.y, p.r, angle + Math.PI, true);
           }
           ctx.restore();
 
@@ -2298,25 +2296,23 @@
           }
         }
 
-        function drawUPocket(ctx, x, y, r, angle, shortSides) {
+        function drawUPocket(ctx, x, y, r, angle) {
           ctx.save();
           ctx.translate(x * sX, y * sY);
           ctx.rotate(angle);
           var R = r * scaleFactor;
           var halfHeight = R; // distance to straight short sides
           var halfWidth = R * 1.1; // width of rounded long sides
-          // when mirroring, keep the short sides very small
-          var w = shortSides ? halfWidth * 0.1 : halfWidth;
           ctx.beginPath();
           // Top straight edge
-          ctx.moveTo(-w, -halfHeight);
-          ctx.lineTo(w, -halfHeight);
+          ctx.moveTo(-halfWidth, -halfHeight);
+          ctx.lineTo(halfWidth, -halfHeight);
           // Rounded right side
-          ctx.arc(w, 0, halfHeight, -Math.PI / 2, Math.PI / 2);
+          ctx.arc(halfWidth, 0, halfHeight, -Math.PI / 2, Math.PI / 2);
           // Bottom straight edge
-          ctx.lineTo(-w, halfHeight);
+          ctx.lineTo(-halfWidth, halfHeight);
           // Rounded left side
-          ctx.arc(-w, 0, halfHeight, Math.PI / 2, -Math.PI / 2);
+          ctx.arc(-halfWidth, 0, halfHeight, Math.PI / 2, -Math.PI / 2);
           ctx.stroke();
           ctx.restore();
         }


### PR DESCRIPTION
## Summary
- rotate drawn U-shaped pockets so they face inward
- drop mirrored pocket rendering to eliminate extra side arches

## Testing
- `npm test` *(fails: Operation `users.insertOne()` buffering timed out; Expected 500 but got 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b0263a880083299b70086688c2c373