### PR TITLE
Rotate Pool Royale holes when six present

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -2855,6 +2855,14 @@
           rulesModal.classList.add('hidden');
         }
       });
+
+      // Rotate all holes to the left once all six are present
+      const allHoles = document.querySelectorAll('.hole');
+      if (allHoles.length === 6) {
+        allHoles.forEach((hole) => {
+          hole.style.transform = 'rotate(-90deg)';
+        });
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Rotate Pool Royale pockets 90° to the left once all six hole elements exist.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0308d5ef083298d28711905cfe9b2