### PR TITLE
Calibrate penalty kick swipe to align with finger direction

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -213,8 +213,8 @@
   let myScore = 0;
 
   const BALL_R = 36;
-  // slightly faster initial shot speed
-  const SHOT_SPEED = 16;
+  // faster initial shot speed for wider coverage
+  const SHOT_SPEED = 20;
   const MIN_GOAL_POINTS = 5;
   const ball = { x:0,y:0,r:BALL_R, vx:0,vy:0, moving:false, trail:[], spin:0, angle:0, netSounded:false, firstContact:false, target:null, prevDist:null, points:0 };
   const ballImg = new Image();
@@ -776,8 +776,8 @@ function endShot(hit,pts){
     if(pointer.armed && aimOn && pointer.path.length>1){
       const path = pointer.path;
       const a = path[0], b = path[path.length - 1];
-      const endDx = b.x - ball.x, endDy = b.y - ball.y;
-      const dist = Math.hypot(endDx, endDy), power = clamp(dist / 150, 0.4, 3.0);
+      const dx = b.x - a.x, dy = b.y - a.y;
+      const dist = Math.hypot(dx, dy), power = clamp(dist / 150, 0.4, 5.0);
       const speed = SHOT_SPEED * power;
       const t = dist / speed;
       let curve = 0;
@@ -785,13 +785,39 @@ function endShot(hit,pts){
         const p0 = path[i-2], p1 = path[i-1], p2 = path[i];
         curve += Math.atan2(p2.y - p1.y, p2.x - p1.x) - Math.atan2(p1.y - p0.y, p1.x - p0.x);
       }
-      const spin = clamp((ball.x - a.x)/ball.r + curve*1.2, -25, 25);
-      const adjDx = endDx - spin * 0.125 * t * t;
-      const vx = adjDx / t, vy = (endDy - 0.5 * GRAVITY * t * t) / t;
+      const spin = clamp(curve*1.2, -25, 25);
+      const adjDx = dx - spin * 0.125 * t * t;
+      const vx = adjDx / t, vy = (dy - 0.5 * GRAVITY * t * t) / t;
       drawAimPath(vx, vy, spin);
     }
   }
-function onUp(e){ if(!pointer.active||e.pointerId!==pointer.id) return; pointer.active=false; if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; } const path=pointer.path; pointer.path=[]; if(path.length<3){ status('Swipe longer/faster.'); return; } const a=path[0], b=path[path.length-1]; const totalDy=b.y-a.y; if(totalDy>-10){ status('Swipe upward.'); return; } const endDx=b.x-ball.x, endDy=b.y-ball.y; const dist=Math.hypot(endDx,endDy), power=clamp(dist/150, 0.4, 3.0); const speed=SHOT_SPEED*power; const t=dist/speed; let curve=0; for(let i=2;i<path.length;i++){ const p0=path[i-2], p1=path[i-1], p2=path[i]; curve+=Math.atan2(p2.y-p1.y,p2.x-p1.x)-Math.atan2(p1.y-p0.y,p1.x-p0.x); } const spin = clamp((ball.x - a.x)/ball.r + curve*1.2, -45, 45); const adjDx=endDx - spin*0.125*t*t; ball.vx=adjDx/t; ball.vy=(endDy - 0.5*GRAVITY*t*t)/t; ball.spin=spin; ball.moving=true; ball.target={x:b.x,y:b.y}; ball.prevDist=Infinity; }
+function onUp(e){
+  if(!pointer.active||e.pointerId!==pointer.id) return;
+  pointer.active=false;
+  if(!pointer.armed||ball.moving||!running||paused){ pointer.path=[]; return; }
+  const path=pointer.path; pointer.path=[];
+  if(path.length<3){ status('Swipe longer/faster.'); return; }
+  const a=path[0], b=path[path.length-1];
+  const totalDy=b.y-a.y;
+  if(totalDy>-10){ status('Swipe upward.'); return; }
+  const dx=b.x-a.x, dy=b.y-a.y;
+  const dist=Math.hypot(dx,dy), power=clamp(dist/150, 0.4, 5.0);
+  const speed=SHOT_SPEED*power;
+  const t=dist/speed;
+  let curve=0;
+  for(let i=2;i<path.length;i++){
+    const p0=path[i-2], p1=path[i-1], p2=path[i];
+    curve+=Math.atan2(p2.y-p1.y,p2.x-p1.x)-Math.atan2(p1.y-p0.y,p1.x-p0.x);
+  }
+  const spin = clamp(curve*1.2, -45, 45);
+  const adjDx=dx - spin*0.125*t*t;
+  ball.vx=adjDx/t;
+  ball.vy=(dy - 0.5*GRAVITY*t*t)/t;
+  ball.spin=spin;
+  ball.moving=true;
+  ball.target={x:ball.x+dx,y:ball.y+dy};
+  ball.prevDist=Infinity;
+}
   canvas.addEventListener('pointerdown', onDown, {passive:true});
   canvas.addEventListener('pointermove', onMove, {passive:true});
   addEventListener('pointerup', onUp, {passive:true}); addEventListener('pointercancel', onUp, {passive:true});


### PR DESCRIPTION
## Summary
- Increase base shot speed to cover full goal and allow wider range
- Rework swipe handling so shot direction and aim use the finger's path with expanded power and cleaner spin

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b036275fe883298faabd5d9cdce9d8