### PR TITLE
Refine Pool Royale pocket visuals

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1518,7 +1518,7 @@
             var dir = POCKET_DIRS[i];
             var angle = Math.atan2(dir.y, dir.x) - Math.PI / 2;
             drawUPocket(ctx, p.x, p.y, p.r, angle);
-            // Mirror the U pocket on the opposite side with minimal side lines
+            // Mirror the U pocket on the opposite side and extend its sides so the pair forms a single hole
             drawUPocket(ctx, p.x, p.y, p.r, angle + Math.PI, true);
           }
           ctx.restore();
@@ -2305,8 +2305,8 @@
           var R = r * scaleFactor;
           var halfHeight = R; // distance to straight short sides
           var halfWidth = R * 1.1; // width of rounded long sides
-          // when mirroring, keep the short sides very small
-          var w = shortSides ? halfWidth * 0.1 : halfWidth;
+          // when mirroring, only slightly shorten the sides so both U's join at the centre
+          var w = shortSides ? halfWidth * 0.9 : halfWidth;
           ctx.beginPath();
           // Top straight edge
           ctx.moveTo(-w, -halfHeight);
@@ -2856,11 +2856,11 @@
         }
       });
 
-      // Rotate all holes to the left once all six are present
+      // Rotate all holes 45° to the left once all six are present
       const allHoles = document.querySelectorAll('.hole');
       if (allHoles.length === 6) {
         allHoles.forEach((hole) => {
-          hole.style.transform = 'rotate(-90deg)';
+          hole.style.transform = 'rotate(-45deg)';
         });
       }
     </script>


### PR DESCRIPTION
## Summary
- Mirror pocket U-shapes with extended sides so each pair forms a single hole
- Rotate pocket elements 45° counter-clockwise when all six are present

## Testing
- `npm test`
- `npm run lint` *(fails: numerous "Extra semicolon" and spacing errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b036f06dd88329832e72257e68fe07