### PR TITLE
Adjust pocket layout and orientation

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1513,14 +1513,12 @@
           ctx.strokeRect(x0, y0, w, h);
           ctx.strokeStyle = '#ff0000';
           ctx.lineWidth = 3 * scaleFactor;
-          for (var i = 0; i < this.pockets.length; i++) {
-            var p = this.pockets[i];
-            var dir = POCKET_DIRS[i];
-            var angle = Math.atan2(dir.y, dir.x) - Math.PI / 2;
-            drawUPocket(ctx, p.x, p.y, p.r, angle);
-            // Mirror the U pocket on the opposite side and extend its sides so the pair forms a single hole
-            drawUPocket(ctx, p.x, p.y, p.r, angle + Math.PI, true);
-          }
+            for (var i = 0; i < this.pockets.length; i++) {
+              var p = this.pockets[i];
+              var dir = POCKET_DIRS[i];
+              var angle = dir.y === 0 ? 0 : Math.atan2(dir.y, dir.x) - Math.PI / 2;
+              drawUPocket(ctx, p.x, p.y, p.r, angle);
+            }
           ctx.restore();
 
           // Steka mbi felt + guida
@@ -2298,15 +2296,14 @@
           }
         }
 
-        function drawUPocket(ctx, x, y, r, angle, shortSides) {
+        function drawUPocket(ctx, x, y, r, angle) {
           ctx.save();
           ctx.translate(x * sX, y * sY);
           ctx.rotate(angle);
           var R = r * scaleFactor;
           var halfHeight = R; // distance to straight short sides
           var halfWidth = R * 1.1; // width of rounded long sides
-          // when mirroring, only slightly shorten the sides so both U's join at the centre
-          var w = shortSides ? halfWidth * 0.9 : halfWidth;
+          var w = halfWidth * 0.7; // shorten straight edges, keep rounded sides
           ctx.beginPath();
           // Top straight edge
           ctx.moveTo(-w, -halfHeight);
@@ -2856,11 +2853,15 @@
         }
       });
 
-      // Rotate all holes 45° to the left once all six are present
+      // Rotate corner holes diagonally; keep side holes horizontal
       const allHoles = document.querySelectorAll('.hole');
       if (allHoles.length === 6) {
-        allHoles.forEach((hole) => {
-          hole.style.transform = 'rotate(-45deg)';
+        allHoles.forEach((hole, idx) => {
+          if (idx === 2 || idx === 3) {
+            hole.style.transform = 'rotate(0deg)';
+          } else {
+            hole.style.transform = 'rotate(-45deg)';
+          }
         });
       }
     </script>


### PR DESCRIPTION
## Summary
- Draw each pool table pocket once so only six holes are present
- Shorten pocket straight edges and keep rounded sides untouched
- Rotate only corner pockets diagonally and keep side pockets horizontal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b03d1458c08329865d71d0f9fb85ce