### PR TITLE
Refine Pool Royale pocket geometry and placement

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1165,10 +1165,11 @@
             new Pocket(BORDER, BORDER_TOP, POCKET_R),
             new Pocket(TABLE_W - BORDER, BORDER_TOP, POCKET_R),
             // Lift middle pockets a touch more to align with the shifted field
-            // boundary, matching the green marking thickness.
-            new Pocket(BORDER - 8, TABLE_H / 2 + BALL_R - 12, SIDE_POCKET_R),
+            // boundary, matching the green marking thickness, and nudge them
+            // slightly farther from center.
+            new Pocket(BORDER - 12, TABLE_H / 2 + BALL_R - 12, SIDE_POCKET_R),
             new Pocket(
-              TABLE_W - BORDER + 8,
+              TABLE_W - BORDER + 12,
               TABLE_H / 2 + BALL_R - 12,
               SIDE_POCKET_R
             ),
@@ -1516,7 +1517,8 @@
             for (var i = 0; i < this.pockets.length; i++) {
               var p = this.pockets[i];
               var dir = POCKET_DIRS[i];
-              var angle = dir.y === 0 ? 0 : Math.atan2(dir.y, dir.x) - Math.PI / 2;
+              // Rotate so the rounded side faces the table interior
+              var angle = Math.atan2(dir.y, dir.x);
               drawUPocket(ctx, p.x, p.y, p.r, angle);
             }
           ctx.restore();
@@ -2303,7 +2305,7 @@
           var R = r * scaleFactor;
           var halfHeight = R; // distance to straight short sides
           var halfWidth = R * 1.1; // width of rounded long sides
-          var w = halfWidth * 0.7; // shorten straight edges, keep rounded sides
+          var w = halfWidth * 0.6; // shorten straight edges slightly more
           ctx.beginPath();
           // Top straight edge
           ctx.moveTo(-w, -halfHeight);


### PR DESCRIPTION
## Summary
- rotate pocket markers so rounded side forms the entrance
- shorten straight edges of all pockets
- nudge middle pockets outward for better alignment

## Testing
- `npm test`
- `npm run lint` *(fails: 958 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0419ca7988329a9a1e78b1657c2b9