### PR TITLE
Adjust pool table pocket positions

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -617,6 +617,7 @@
         // Make all pockets slightly smaller so openings sit closer to the field
         var POCKET_R = 36; // rrezja baze e gropave pak me e vogel
         var SIDE_POCKET_R = 34; // gropat anesore edhe me te vogla nga brenda
+        var POCKET_SHORTEN = 4; // sa zhvendosen gropat jashte per t'i ngushtuar hapjet e drejta
         var BALL_R = 22; // rrezja baze e topave pak me e madhe
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side
@@ -1161,22 +1162,40 @@
           }
 
           // Pockets (4 qoshe + 2 te mesit anesore)
+          // Shift all pockets pak jashte per t'i bere hapjet e drejta me te shkurtra,
+          // dhe gropat anesore shtyhen edhe pak me shume majtas/djathtas.
           this.pockets = [
-            new Pocket(BORDER, BORDER_TOP, POCKET_R),
-            new Pocket(TABLE_W - BORDER, BORDER_TOP, POCKET_R),
+            new Pocket(
+              BORDER - POCKET_SHORTEN,
+              BORDER_TOP - POCKET_SHORTEN,
+              POCKET_R
+            ),
+            new Pocket(
+              TABLE_W - BORDER + POCKET_SHORTEN,
+              BORDER_TOP - POCKET_SHORTEN,
+              POCKET_R
+            ),
             // Lift middle pockets a touch more to align with the shifted field
             // boundary, matching the green marking thickness, and nudge them
             // slightly farther from center.
-            new Pocket(BORDER - 12, TABLE_H / 2 + BALL_R - 12, SIDE_POCKET_R),
             new Pocket(
-              TABLE_W - BORDER + 12,
+              BORDER - 12 - POCKET_SHORTEN,
               TABLE_H / 2 + BALL_R - 12,
               SIDE_POCKET_R
             ),
-            new Pocket(BORDER, TABLE_H - BORDER_BOTTOM, POCKET_R),
             new Pocket(
-              TABLE_W - BORDER,
-              TABLE_H - BORDER_BOTTOM,
+              TABLE_W - BORDER + 12 + POCKET_SHORTEN,
+              TABLE_H / 2 + BALL_R - 12,
+              SIDE_POCKET_R
+            ),
+            new Pocket(
+              BORDER - POCKET_SHORTEN,
+              TABLE_H - BORDER_BOTTOM + POCKET_SHORTEN,
+              POCKET_R
+            ),
+            new Pocket(
+              TABLE_W - BORDER + POCKET_SHORTEN,
+              TABLE_H - BORDER_BOTTOM + POCKET_SHORTEN,
               POCKET_R
             )
           ];


### PR DESCRIPTION
## Summary
- shorten straight edges of all pockets by moving them slightly outward
- push side pockets further left/right to better center them on the rails

## Testing
- `npm test` *(fails: ERR_DLOPEN_FAILED / canvas)*

------
https://chatgpt.com/codex/tasks/task_e_68b0465b16f08329867aa843fc662cdb