### PR TITLE
Add ball kick sound effect

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -822,6 +822,7 @@ function onUp(e){
   ball.vy=shot.vy;
   ball.spin=shot.spin;
   ball.moving=true;
+  playBallKickSound();
   ball.target={x:ball.x+dx,y:ball.y+dy};
   ball.prevDist=Infinity;
 }
@@ -964,6 +965,28 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     src.onended=()=>{ if(postHitSource===src) postHitSource=null; };
   }
   const sfxPost = playPostHitSound;
+  // Ball kick sound
+  const BALL_KICK_SOUND = encodeURI('/assets/sounds/ball kick .mp3');
+  let ballKickSoundBuf = null;
+  async function loadBallKickSound(){
+    try{
+      const res = await fetch(BALL_KICK_SOUND);
+      const arr = await res.arrayBuffer();
+      ensureAudio(); if(!audioCtx) return;
+      ballKickSoundBuf = await audioCtx.decodeAudioData(arr);
+    }catch{}
+  }
+  loadBallKickSound();
+  function playBallKickSound(){
+    ensureAudio();
+    if(!audioCtx || !ballKickSoundBuf) return;
+    const src = audioCtx.createBufferSource();
+    src.buffer = ballKickSoundBuf;
+    src.connect(masterGain);
+    // Play only the first 0.003 seconds of the sound
+    src.start(0, 0, 0.003);
+  }
+  const sfxKick = playBallKickSound;
   let keeperSaveSoundBuf=null;
   async function loadKeeperSaveSound(){
       try{


### PR DESCRIPTION
## Summary
- play a "ball kick" sound when the ball is kicked in penalty kick
- load and play only the first 0.003 seconds of the kick audio file

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, missing space before function parentheses, prefer-const, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0486a9ae48329a21731458a6df2d8