### PR TITLE
Adjust penalty kick sound to play 0.01s snippet

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -983,8 +983,8 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const src = audioCtx.createBufferSource();
     src.buffer = ballKickSoundBuf;
     src.connect(masterGain);
-    // Play only the first 0.003 seconds of the sound
-    src.start(0, 0, 0.003);
+    // Play only the first 0.01 seconds of the sound
+    src.start(0, 0, 0.01);
   }
   const sfxKick = playBallKickSound;
   let keeperSaveSoundBuf=null;


### PR DESCRIPTION
## Summary
- truncate ball-kick sound effect to first 0.01 seconds when shooting

## Testing
- `npm test` *(fails: process did not complete, aborted)*
- `npm run lint` *(fails: 958 lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b04cbc263c8329b6611bda8d0172cb