### PR TITLE
Narrow pocket openings on pool table

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -617,7 +617,7 @@
         // Make all pockets slightly smaller so openings sit closer to the field
         var POCKET_R = 36; // rrezja baze e gropave pak me e vogel
         var SIDE_POCKET_R = 34; // gropat anesore edhe me te vogla nga brenda
-        var POCKET_SHORTEN = 6; // sa zhvendosen gropat jashte per t'i ngushtuar hapjet e drejta
+        var POCKET_SHORTEN = 8; // sa zhvendosen gropat jashte per t'i ngushtuar me shume hapjet e drejta
         var BALL_R = 22; // rrezja baze e topave pak me e madhe
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side


### PR DESCRIPTION
## Summary
- Shift all six pockets further outward to shorten straight-side openings while keeping rounded edges unchanged

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b04c1aec7c8329be56e3b9c543327c