### PR TITLE
Adjust ball kick sound snippet

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -983,8 +983,8 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const src = audioCtx.createBufferSource();
     src.buffer = ballKickSoundBuf;
     src.connect(masterGain);
-    // Play only the first 0.01 seconds of the sound
-    src.start(0, 0, 0.01);
+    // Play only the first 0.03 seconds of the sound
+    src.start(0, 0, 0.03);
   }
   const sfxKick = playBallKickSound;
   let keeperSaveSoundBuf=null;


### PR DESCRIPTION
## Summary
- Extend penalty kick sound effect playback to first 0.03 seconds

## Testing
- `node --test test/snakeGame.test.js` *(fails: Failed to store game result: Operation `gameresults.insertOne()` buffering timed out after 10000ms)*
- `npm run lint` *(fails: 958 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b04f2c6f6c83298698627443f3c95a