### PR TITLE
Tighten pool pockets and clear pocket markers

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -617,7 +617,9 @@
         // Make all pockets slightly smaller so openings sit closer to the field
         var POCKET_R = 36; // rrezja baze e gropave pak me e vogel
         var SIDE_POCKET_R = 34; // gropat anesore edhe me te vogla nga brenda
-        var POCKET_SHORTEN = 8; // sa zhvendosen gropat jashte per t'i ngushtuar me shume hapjet e drejta
+        // Shift pocket centers further outward so the straight mouth is
+        // just a bit smaller than the diameter of a pool ball.
+        var POCKET_SHORTEN = 15;
         var BALL_R = 22; // rrezja baze e topave pak me e madhe
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side
@@ -1531,15 +1533,7 @@
           ctx.strokeStyle = '#facc15';
           ctx.lineWidth = 4 * scaleFactor;
           ctx.strokeRect(x0, y0, w, h);
-          ctx.strokeStyle = '#ff0000';
-          ctx.lineWidth = 3 * scaleFactor;
-            for (var i = 0; i < this.pockets.length; i++) {
-              var p = this.pockets[i];
-              var dir = POCKET_DIRS[i];
-              // Rotate so the rounded side faces the table interior
-              var angle = Math.atan2(dir.y, dir.x);
-              drawUPocket(ctx, p.x, p.y, p.r, angle);
-            }
+          // Pocket marker lines removed so holes appear clean.
           ctx.restore();
 
           // Steka mbi felt + guida
@@ -2317,27 +2311,8 @@
           }
         }
 
-        function drawUPocket(ctx, x, y, r, angle) {
-          ctx.save();
-          ctx.translate(x * sX, y * sY);
-          ctx.rotate(angle);
-          var R = r * scaleFactor;
-          var halfHeight = R; // distance to straight short sides
-          var halfWidth = R * 1.1; // width of rounded long sides
-          var w = halfWidth * 0.6; // shorten straight edges slightly more
-          ctx.beginPath();
-          // Top straight edge
-          ctx.moveTo(-w, -halfHeight);
-          ctx.lineTo(w, -halfHeight);
-          // Rounded right side
-          ctx.arc(w, 0, halfHeight, -Math.PI / 2, Math.PI / 2);
-          // Bottom straight edge
-          ctx.lineTo(-w, halfHeight);
-          // Rounded left side
-          ctx.arc(-w, 0, halfHeight, Math.PI / 2, -Math.PI / 2);
-          ctx.stroke();
-          ctx.restore();
-        }
+        // drawUPocket previously rendered pocket marker outlines. With markers
+        // removed, this helper is no longer required.
 
         /* ==========================================================
        SPIN CONTROL – disk i bardhe me pike te kuqe


### PR DESCRIPTION
## Summary
- Shrink pocket openings by extending pocket offsets so the straight edge is slightly smaller than a ball
- Remove yellow pocket marker lines and associated helper

## Testing
- `npm test`
- `npm run lint` *(fails: 958 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b0504cc1fc8329b572fe9eb2e3fbd1