### PR TITLE
Tighten Pool Royale pocket openings

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -617,7 +617,7 @@
         // Make all pockets slightly smaller so openings sit closer to the field
         var POCKET_R = 36; // rrezja baze e gropave pak me e vogel
         var SIDE_POCKET_R = 34; // gropat anesore edhe me te vogla nga brenda
-        var POCKET_SHORTEN = 12; // zhvendos gropat pak me shume jashte per te ngushtuar me tej hapjet e drejta
+        var POCKET_SHORTEN = 16; // zhvendos gropat pak me shume jashte per te ngushtuar me tej hapjet e drejta
         var BALL_R = 22; // rrezja baze e topave pak me e madhe
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side


### PR DESCRIPTION
## Summary
- Shift billiard table pockets further outward to shorten their straight-edge openings

## Testing
- `npm test`
- `npm run lint` *(fails: 958 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b05e97eab083299285f5006b9dffe6