### PR TITLE
Shorten outer extensions of pool pockets

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -615,9 +615,11 @@
         var TABLE_H = 1216; // lartesi logjike e felt-it
         var BORDER = 57; // korniza e drurit pak me e ngushte anash
         // Make all pockets slightly smaller so openings sit closer to the field
-        var POCKET_R = 36; // rrezja baze e gropave pak me e vogel
-        var SIDE_POCKET_R = 34; // gropat anesore edhe me te vogla nga brenda
-        var POCKET_SHORTEN = 16; // zhvendos gropat pak me shume jashte per te ngushtuar me tej hapjet e drejta
+        // Make outer pocket extension slightly shorter while keeping the inner
+        // rounded edge (with yellow guides) fixed in place.
+        var POCKET_R = 32; // rrezja baze e gropave pak me e vogel nga jashte
+        var SIDE_POCKET_R = 30; // gropat anesore gjithashtu me te vogla nga jashte
+        var POCKET_SHORTEN = 12; // gropat zhvendosen me pak jashte per te ruajtur anen e brendshme
         var BALL_R = 22; // rrezja baze e topave pak me e madhe
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side


### PR DESCRIPTION
## Summary
- Trim outer side of all six Pool Royale pockets so rounded inner edge stays fixed

## Testing
- `npm test` *(fails: canvas.node built for older Node.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b0617fa0f48329a847525dad7df420