### PR TITLE
Shorten Pool Royale pocket openings

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -617,9 +617,9 @@
         // Make all pockets slightly smaller so openings sit closer to the field
         // Make outer pocket extension slightly shorter while keeping the inner
         // rounded edge (with yellow guides) fixed in place.
-        var POCKET_R = 32; // rrezja baze e gropave pak me e vogel nga jashte
-        var SIDE_POCKET_R = 30; // gropat anesore gjithashtu me te vogla nga jashte
-        var POCKET_SHORTEN = 12; // gropat zhvendosen me pak jashte per te ruajtur anen e brendshme
+        var POCKET_R = 30; // rrezja baze e gropave pak me e vogel nga jashte
+        var SIDE_POCKET_R = 28; // gropat anesore gjithashtu me te vogla nga jashte
+        var POCKET_SHORTEN = 10; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
         var BALL_R = 22; // rrezja baze e topave pak me e madhe
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side
@@ -2326,7 +2326,7 @@
           var R = r * scaleFactor;
           var halfHeight = R; // distance to straight short sides
           var halfWidth = R * 1.1; // width of rounded long sides
-          var w = halfWidth * 0.6; // shorten straight edges slightly more
+          var w = halfWidth * 0.58; // shorten straight edges a bit more on the outer side
           ctx.beginPath();
           // Top straight edge
           ctx.moveTo(-w, -halfHeight);


### PR DESCRIPTION
## Summary
- Reduce pocket radii and shift positions inward to trim straight edges while keeping inner rounded edges aligned with yellow guides
- Tweak pocket marker drawing to reflect shorter straight segments

## Testing
- `npm test` *(fails: The "options.agent" property must be one of Agent-like Object, undefined, or false. Received an instance of ProxyAgent)*
- `npm run lint` *(fails: 958 problems (958 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b0647f1af08329bfc96e59c24d69bb