### PR TITLE
Shorten Pool Royale pocket straight edges

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -619,7 +619,7 @@
         // rounded edge (with yellow guides) fixed in place.
         var POCKET_R = 30; // rrezja baze e gropave pak me e vogel nga jashte
         var SIDE_POCKET_R = 28; // gropat anesore gjithashtu me te vogla nga jashte
-        var POCKET_SHORTEN = 10; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
+        var POCKET_SHORTEN = 14; // gropat zhvendosen me shume jashte per te ruajtur anen e brendshme
         var BALL_R = 22; // rrezja baze e topave pak me e madhe
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side
@@ -2326,7 +2326,7 @@
           var R = r * scaleFactor;
           var halfHeight = R; // distance to straight short sides
           var halfWidth = R * 1.1; // width of rounded long sides
-          var w = halfWidth * 0.58; // shorten straight edges a bit more on the outer side
+          var w = halfWidth * 0.52; // shorten straight edges even more on the outer side
           ctx.beginPath();
           // Top straight edge
           ctx.moveTo(-w, -halfHeight);


### PR DESCRIPTION
## Summary
- Further reduce Pool Royale pocket length on straight sides while keeping inner rounded edges fixed
- Adjust U-pocket drawing routine so straight segments render shorter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b067bba2e88329ad379b6896d408fd