### PR TITLE
Adjust Pool Royale pockets and ball size

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -620,7 +620,7 @@
         var POCKET_R = 30; // rrezja baze e gropave pak me e vogel nga jashte
         var SIDE_POCKET_R = 28; // gropat anesore gjithashtu me te vogla nga jashte
         var POCKET_SHORTEN = 10; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
-        var BALL_R = 22; // rrezja baze e topave pak me e madhe
+        var BALL_R = 20; // rrezja baze e topave pak me e vogel
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side
         // marking so the table's lower boundary sits slightly higher.
@@ -1168,12 +1168,12 @@
           // dhe gropat anesore shtyhen edhe pak me shume majtas/djathtas.
           this.pockets = [
             new Pocket(
-              BORDER - POCKET_SHORTEN,
+              BORDER - POCKET_SHORTEN + 4,
               BORDER_TOP - POCKET_SHORTEN,
               POCKET_R
             ),
             new Pocket(
-              TABLE_W - BORDER + POCKET_SHORTEN,
+              TABLE_W - BORDER + POCKET_SHORTEN - 4,
               BORDER_TOP - POCKET_SHORTEN,
               POCKET_R
             ),
@@ -1182,12 +1182,12 @@
             // slightly farther from center.
             new Pocket(
               BORDER - 16 - POCKET_SHORTEN,
-              TABLE_H / 2 + BALL_R - 12,
+              TABLE_H / 2 + BALL_R - 14,
               SIDE_POCKET_R
             ),
             new Pocket(
               TABLE_W - BORDER + 16 + POCKET_SHORTEN,
-              TABLE_H / 2 + BALL_R - 12,
+              TABLE_H / 2 + BALL_R - 14,
               SIDE_POCKET_R
             ),
             new Pocket(


### PR DESCRIPTION
## Summary
- Move top pockets slightly toward the table center
- Raise side pockets subtly and reduce ball radius for smaller balls

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon and formatting errors in lib files)*

------
https://chatgpt.com/codex/tasks/task_e_68b06c8925548329b467b6c7fb9c5246