### PR TITLE
Adjust Pool Royale pocket geometry

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -617,9 +617,9 @@
         // Make all pockets slightly smaller so openings sit closer to the field
         // Make outer pocket extension slightly shorter while keeping the inner
         // rounded edge (with yellow guides) fixed in place.
-        var POCKET_R = 30; // rrezja baze e gropave pak me e vogel nga jashte
-        var SIDE_POCKET_R = 28; // gropat anesore gjithashtu me te vogla nga jashte
-        var POCKET_SHORTEN = 10; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
+        var POCKET_R = 32; // rrezja baze e gropave pak me e vogel nga jashte
+        var SIDE_POCKET_R = 30; // gropat anesore gjithashtu me te vogla nga jashte
+        var POCKET_SHORTEN = 12; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
         var BALL_R = 20; // rrezja baze e topave pak me e vogel
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side
@@ -2326,7 +2326,7 @@
           var R = r * scaleFactor;
           var halfHeight = R; // distance to straight short sides
           var halfWidth = R * 1.1; // width of rounded long sides
-          var w = halfWidth * 0.58; // shorten straight edges a bit more on the outer side
+          var w = halfWidth * 0.52; // shorten straight edges a bit more on the outer side
           ctx.beginPath();
           // Top straight edge
           ctx.moveTo(-w, -halfHeight);


### PR DESCRIPTION
## Summary
- Slightly widen pocket arcs and shrink straight edges in Pool Royale layout
- Tweak pocket rendering to shorten straight segments

## Testing
- `npm test`
- `npm run lint` *(fails: 958 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b0720a66d88329a344499f5f6c0e2e