### PR TITLE
Refine Pool Royale pocket overlays

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -46,7 +46,11 @@
         const g   = svg.getElementById('nets');
 
         // Helper to create elements
-        const el = (name, attrs={}) => Object.assign(document.createElementNS('http://www.w3.org/2000/svg', name), attrs);
+        const el = (name, attrs = {}) =>
+          Object.assign(
+            document.createElementNS('http://www.w3.org/2000/svg', name),
+            attrs
+          );
 
         pockets.forEach(({x,y}, i) => {
           // Mask to clip funnel contents to the pocket rim
@@ -62,22 +66,12 @@
           // Dark grey pocket interior
           group.append(el('circle', {cx: x, cy: y, r: RIM_R, fill: '#333'}));
 
-          const innerR = RIM_R - 5;
-
-          // Yellow center guides inside the pocket
-          if (i === 1 || i === 4) {
-            // Middle pockets have a single vertical guide
-            group.append(el('line', {x1: x, y1: y - innerR, x2: x, y2: y + innerR, stroke: 'yellow', 'stroke-width': 2}));
-          } else {
-            // Corner pockets have crossing guides
-            group.append(el('line', {x1: x - innerR, y1: y, x2: x + innerR, y2: y, stroke: 'yellow', 'stroke-width': 2}));
-            group.append(el('line', {x1: x, y1: y - innerR, x2: x, y2: y + innerR, stroke: 'yellow', 'stroke-width': 2}));
-          }
-
           // Rim shaped like a U: rounded long sides, straight short sides
           const rimPath = `M${x - RIM_R} ${y - RIM_R} L${x + RIM_R} ${y - RIM_R} A ${RIM_R} ${RIM_R} 0 0 1 ${x + RIM_R} ${y + RIM_R} L${x - RIM_R} ${y + RIM_R} A ${RIM_R} ${RIM_R} 0 0 1 ${x - RIM_R} ${y - RIM_R}`;
-          group.append(el('path', {d: rimPath, fill: 'none', stroke: '#1a1a1a', 'stroke-width': 8, opacity: 0.9}));
-          group.append(el('path', {d: rimPath, fill: 'none', stroke: '#c2a44b', 'stroke-width': 3, opacity: 0.9}));
+          group.append(el('path', { d: rimPath, fill: 'none', stroke: '#1a1a1a', 'stroke-width': 8, opacity: 0.9 }));
+          group.append(el('path', { d: rimPath, fill: 'none', stroke: '#c2a44b', 'stroke-width': 3, opacity: 0.9 }));
+          // Yellow guide following the pocket opening so balls can enter
+          group.append(el('path', { d: rimPath, fill: 'none', stroke: 'yellow', 'stroke-width': 2 }));
 
           g.append(group);
         });


### PR DESCRIPTION
## Summary
- Replace blocking yellow cross lines in pockets with rim-shaped guides
- Keep rails straight while opening pockets for clear ball entry

## Testing
- `npm test` *(fails: process hangs after test 62)*
- `npm run lint` *(fails: 958 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b08863f60c83298d7cccd73d61cc6b