### PR TITLE
Offset pool pocket guides to stop before holes

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -31,6 +31,7 @@
         // Configurable pocket centers in the SVG viewBox coordinate space (1000x1500)
         const RIM_R = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--pocket-r'));
         const DEPTH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--net-depth'));
+        const GUIDE_MARGIN = 3; // small gap so yellow guides don't enter pockets
 
         const pockets = [
           {x: 60,   y: 56},      // top-left corner (slightly raised)
@@ -70,8 +71,10 @@
           const rimPath = `M${x - RIM_R} ${y - RIM_R} L${x + RIM_R} ${y - RIM_R} A ${RIM_R} ${RIM_R} 0 0 1 ${x + RIM_R} ${y + RIM_R} L${x - RIM_R} ${y + RIM_R} A ${RIM_R} ${RIM_R} 0 0 1 ${x - RIM_R} ${y - RIM_R}`;
           group.append(el('path', { d: rimPath, fill: 'none', stroke: '#1a1a1a', 'stroke-width': 8, opacity: 0.9 }));
           group.append(el('path', { d: rimPath, fill: 'none', stroke: '#c2a44b', 'stroke-width': 3, opacity: 0.9 }));
-          // Yellow guide following the pocket opening so balls can enter
-          group.append(el('path', { d: rimPath, fill: 'none', stroke: 'yellow', 'stroke-width': 2 }));
+          // Yellow guide following the pocket opening so balls can enter, offset slightly from rim
+          const guideR = RIM_R + GUIDE_MARGIN;
+          const guidePath = `M${x - guideR} ${y - guideR} L${x + guideR} ${y - guideR} A ${guideR} ${guideR} 0 0 1 ${x + guideR} ${y + guideR} L${x - guideR} ${y + guideR} A ${guideR} ${guideR} 0 0 1 ${x - guideR} ${y - guideR}`;
+          group.append(el('path', { d: guidePath, fill: 'none', stroke: 'yellow', 'stroke-width': 2 }));
 
           g.append(group);
         });
@@ -81,21 +84,22 @@
         svg.append(edgesG);
 
         const [tl, tm, tr, bl, bm, br] = pockets;
+        const cutR = RIM_R - GUIDE_MARGIN;
         const edgePaths = [
           // Corner pocket cuts
-          `M0 ${tl.y - RIM_R} L${tl.x - RIM_R} 0`,
-          `M1000 ${tr.y - RIM_R} L${tr.x + RIM_R} 0`,
-          `M0 ${bl.y + RIM_R} L${bl.x - RIM_R} 1500`,
-          `M1000 ${br.y + RIM_R} L${br.x + RIM_R} 1500`,
+          `M0 ${tl.y - cutR} L${tl.x - cutR} 0`,
+          `M1000 ${tr.y - cutR} L${tr.x + cutR} 0`,
+          `M0 ${bl.y + cutR} L${bl.x - cutR} 1500`,
+          `M1000 ${br.y + cutR} L${br.x + cutR} 1500`,
           // Side pocket cuts
-          `M${tm.x - RIM_R} 0 L${tm.x - RIM_R} ${tm.y - RIM_R}`,
-          `M${tm.x + RIM_R} 0 L${tm.x + RIM_R} ${tm.y - RIM_R}`,
-          `M${bm.x - RIM_R} 1500 L${bm.x - RIM_R} ${bm.y + RIM_R}`,
-          `M${bm.x + RIM_R} 1500 L${bm.x + RIM_R} ${bm.y + RIM_R}`,
+          `M${tm.x - cutR} 0 L${tm.x - cutR} ${tm.y - cutR}`,
+          `M${tm.x + cutR} 0 L${tm.x + cutR} ${tm.y - cutR}`,
+          `M${bm.x - cutR} 1500 L${bm.x - cutR} ${bm.y + cutR}`,
+          `M${bm.x + cutR} 1500 L${bm.x + cutR} ${bm.y + cutR}`,
         ];
 
         edgePaths.forEach(d => {
-          edgesG.append(el('path', { d, stroke: 'yellow', 'stroke-width': 2, fill: 'none' }));
+          edgesG.append(el('path', { d, stroke: 'yellow', 'stroke-width': 2, fill: 'none', 'stroke-linecap': 'round' }));
         });
       </script>
     </svg>


### PR DESCRIPTION
## Summary
- add small guide margin so yellow pocket guides stop before holes
- shift straight-edge guide paths to end at offset distance

## Testing
- `npm test` *(fails: Promise resolution is still pending but the event loop has already resolved)*
- `npm run lint` *(fails: 958 problems (958 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b08c1f70bc8329b9817e5c6f59b3d7