### PR TITLE
Stop yellow rails from bleeding into pockets

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -31,7 +31,8 @@
         // Configurable pocket centers in the SVG viewBox coordinate space (1000x1500)
         const RIM_R = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--pocket-r'));
         const DEPTH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--net-depth'));
-        const GUIDE_MARGIN = 3; // small gap so yellow guides don't enter pockets
+        // widen the offset so the yellow guides stop right at the pocket rims
+        const GUIDE_MARGIN = 5; // gap large enough to keep guides out of the red pockets
 
         const pockets = [
           {x: 60,   y: 56},      // top-left corner (slightly raised)

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1534,7 +1534,9 @@
           ctx.strokeStyle = '#facc15';
           ctx.lineWidth = 4 * scaleFactor;
           ctx.beginPath();
-          var margin = 2 * scaleFactor; // small gap so yellow lines don't enter pockets
+          // leave a slightly larger gap so yellow rails stop at the pocket edge
+          // and never bleed into the red pocket markers
+          var margin = ctx.lineWidth; // gap equals stroke width for a clean edge
 
           // Top rail
           var pTL = this.pockets[0];


### PR DESCRIPTION
## Summary
- ensure table rail guides stop at pocket edges by using a stroke-width margin
- widen example's guide margin so yellow paths never overlap red pockets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0979dbf5c8329b6a523c3af87bb54