### PR TITLE
fix: clear pool royale pocket entrances

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1534,9 +1534,9 @@
           ctx.strokeStyle = '#facc15';
           ctx.lineWidth = 4 * scaleFactor;
           ctx.beginPath();
-          // leave a slightly larger gap so yellow rails stop at the pocket edge
-          // and never bleed into the red pocket markers
-          var margin = ctx.lineWidth; // gap equals stroke width for a clean edge
+          // leave a wider gap so yellow rails stop at the pocket edge and never
+          // bleed into the red pocket markers, keeping pocket entrances clear
+          var margin = ctx.lineWidth * 2; // generous gap ensures unobstructed holes
 
           // Top rail
           var pTL = this.pockets[0];


### PR DESCRIPTION
## Summary
- widen yellow rail gap around pockets so holes are unobstructed in Poll Royale

## Testing
- `npm test`
- `npm run lint` *(fails: 958 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a287337883299cd62a43784fc062