### PR TITLE
Trim pool table rail lines at pockets

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1541,9 +1541,12 @@
           ctx.save();
           ctx.strokeStyle = '#facc15';
           ctx.lineWidth = 4 * scaleFactor;
+          ctx.lineCap = 'butt';
           ctx.beginPath();
-          // gaps between rails should match the pocket openings exactly
-          var margin = 0; // stop lines precisely at pocket edges
+          // Shorten rail lines by half the stroke width so they
+          // terminate exactly at the pocket edge without drawing
+          // inside the hole.
+          var margin = (ctx.lineWidth / scaleFactor) / 2;
 
           // Top rail
           var pTL = this.pockets[0];


### PR DESCRIPTION
## Summary
- prevent yellow rail guides from drawing into pockets by trimming rail lines based on stroke width

## Testing
- `npm test`
- `npm run lint` *(fails: 958 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0aca84cb8832986121e87ef87f5e5