### PR TITLE
Adjust rail guides to stop before pockets

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1543,10 +1543,9 @@
           ctx.lineWidth = 4 * scaleFactor;
           ctx.lineCap = 'butt';
           ctx.beginPath();
-          // Shorten rail lines by half the stroke width so they
-          // terminate exactly at the pocket edge without drawing
-          // inside the hole.
-          var margin = (ctx.lineWidth / scaleFactor) / 2;
+          // Shorten rail lines by half the stroke width plus a small
+          // buffer so they stop just before reaching the pocket edge.
+          var margin = (ctx.lineWidth / scaleFactor) / 2 + 2;
 
           // Top rail
           var pTL = this.pockets[0];


### PR DESCRIPTION
## Summary
- Prevent rail guide lines from overlapping pockets by adding a small buffer

## Testing
- `npm test`
- `npm run lint` *(fails: React version not installed; numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b074714883298243db1d16c67f8c