### PR TITLE
style: highlight pool pockets

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1438,11 +1438,12 @@
           );
           ctx.fill();
           // Draw pocket interiors before balls so they appear beneath them
-          ctx.fillStyle = '#333';
+          ctx.fillStyle = 'red';
           for (var i = 0; i < this.pockets.length; i++) {
             var p = this.pockets[i];
             ctx.beginPath();
-            ctx.arc(p.x * sX, p.y * sY, p.r * scaleFactor, 0, Math.PI * 2);
+            // Use the ball radius so pocket markers match the red aim marker
+            ctx.arc(p.x * sX, p.y * sY, ballR, 0, Math.PI * 2);
             ctx.fill();
           }
           // Topat


### PR DESCRIPTION
## Summary
- color pool pockets red
- size pockets to match red aim marker

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b12bbdec9483299e50dd8d61a77f79