### PR TITLE
Align pool pockets with red markers

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -614,13 +614,11 @@
         var TABLE_W = 768; // gjeresi logjike e felt-it
         var TABLE_H = 1216; // lartesi logjike e felt-it
         var BORDER = 57; // korniza e drurit pak me e ngushte anash
-        // Make all pockets slightly smaller so openings sit closer to the field
-        // Make outer pocket extension slightly shorter while keeping the inner
-        // rounded edge (with yellow guides) fixed in place.
-        var POCKET_R = 32; // rrezja baze e gropave pak me e vogel nga jashte
-        var SIDE_POCKET_R = 30; // gropat anesore gjithashtu me te vogla nga jashte
-        var POCKET_SHORTEN = 12; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
         var BALL_R = 20; // rrezja baze e topave pak me e vogel
+        // Make pocket radius match the red markers so holes align with visuals
+        var POCKET_R = BALL_R; // rrezja baze e gropave
+        var SIDE_POCKET_R = BALL_R; // gropat anesore gjithashtu me te njejten rreze
+        var POCKET_SHORTEN = 12; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side
         // marking so the table's lower boundary sits slightly higher.
@@ -1442,8 +1440,8 @@
           for (var i = 0; i < this.pockets.length; i++) {
             var p = this.pockets[i];
             ctx.beginPath();
-            // Use the ball radius so pocket markers match the red aim marker
-            ctx.arc(p.x * sX, p.y * sY, ballR, 0, Math.PI * 2);
+            // Use the pocket radius so markers reflect actual pocket size
+            ctx.arc(p.x * sX, p.y * sY, p.r * scaleFactor, 0, Math.PI * 2);
             ctx.fill();
           }
           // Topat


### PR DESCRIPTION
## Summary
- Match pocket radius to red marker holes for accurate Pool Royale pockets
- Render pocket interiors using pocket radius so visuals align with gameplay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b12f9a2f2c8329b4799192ff1cdc80