### PR TITLE
feat: play sound on post hits

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -943,8 +943,8 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
   let postHitSource=null;
   async function loadPostHitSound(){
     try{
-      // Uses post-hit.mp3 from webapp/public/assets/sounds
-      const res=await fetch('/assets/sounds/post-hit.mp3');
+      // Uses frying-pan-over-the-head-89303.mp3 from webapp/public/assets/sounds
+      const res=await fetch('/assets/sounds/frying-pan-over-the-head-89303.mp3');
       const arr=await res.arrayBuffer();
       ensureAudio(); if(!audioCtx) return;
       postHitSoundBuf=await audioCtx.decodeAudioData(arr);


### PR DESCRIPTION
## Summary
- play sound effect when ball hits goalpost or crossbar in penalty kick game

## Testing
- `npm test`
- `npm run lint` *(fails: 958 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b1354e5fc88329a0185d8f7bdc233f