### PR TITLE
feat: replace penalty kick goal sound

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -1008,8 +1008,8 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
       src.start(0);
     }
     // Sound effect for the ball hitting the net when a goal is scored.
-    // Uses the new "net sound goal ..mp3" asset in webapp/public/assets/sounds.
-    const GOAL_SOUND = encodeURI('/assets/sounds/net sound goal ..mp3');
+    // Uses the "goal net.mp3" asset in webapp/public/assets/sounds.
+    const GOAL_SOUND = encodeURI('/assets/sounds/goal net.mp3');
     let goalSoundBuf = null;
     let goalSoundSource = null;
 


### PR DESCRIPTION
## Summary
- use `goal net.mp3` for penalty kick goal audio

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b143ff0b208329b9fb2a6cad6aa20e