### PR TITLE
Start post hit sound at 0.3s offset

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -962,7 +962,8 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const src=audioCtx.createBufferSource();
     src.buffer=postHitSoundBuf;
     src.connect(masterGain);
-    src.start(0);
+    // Skip initial silence so the sound starts at 0.3 seconds
+    src.start(0, 0.3);
     postHitSource=src;
     src.onended=()=>{ if(postHitSource===src) postHitSource=null; };
   }


### PR DESCRIPTION
## Summary
- begin goal post/crossbar sound at 0.3s to avoid initial silence in Penalty Kick game

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, 'inc' is never reassigned)*

------
https://chatgpt.com/codex/tasks/task_e_68b145f856fc83299ecbe442d160eeca