### PR TITLE
Add black outline to pool pockets

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1469,6 +1469,15 @@
             var angle = Math.atan2(dir.y, dir.x);
             drawUPocket(ctx, p.x, p.y, p.r, angle, true);
           }
+          // Add a thin black outline around each pocket
+          ctx.strokeStyle = '#000';
+          ctx.lineWidth = 1 * scaleFactor;
+          for (var i = 0; i < this.pockets.length; i++) {
+            var p = this.pockets[i];
+            var dir = POCKET_DIRS[i];
+            var angle = Math.atan2(dir.y, dir.x);
+            drawUPocket(ctx, p.x, p.y, p.r, angle, false);
+          }
           // Topat
           for (var j = 0; j < this.balls.length; j++) {
             var b = this.balls[j];


### PR DESCRIPTION
## Summary
- add thin black stroke around each pocket while keeping the red fill

## Testing
- `npm test` *(fails: The "options.agent" property must be one of Agent-like Object, undefined, or false)*

------
https://chatgpt.com/codex/tasks/task_e_68b147242cfc832999d739dea59a95f6