### PR TITLE
Prevent guide lines from touching pockets

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1636,7 +1636,8 @@
           ctx.lineTo(x0 + w, bottomRightY * sY);
 
           // Add small guide edges that bend toward the center of each pocket.
-          var guideLen = (ctx.lineWidth / scaleFactor) * 3;
+          // Keep them short so they stop before reaching the pocket rim.
+          var guideLen = Math.max(margin - 1, 0);
           function drawGuide(x1, y1, pocket) {
             var dx = pocket.x - x1;
             var dy = pocket.y - y1;


### PR DESCRIPTION
## Summary
- Keep pocket guide edges shorter so yellow lines stop before hitting pocket rims

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b14e26346c83299eb0eae313515a0e