### PR TITLE
Require email for non-telegram users

### DIFF
--- a/webapp/src/components/LoginOptions.jsx
+++ b/webapp/src/components/LoginOptions.jsx
@@ -7,14 +7,21 @@ export default function LoginOptions() {
     (async () => {
       const accountId = await ensureAccountId();
       try {
-        const res = await createAccount(undefined, localStorage.getItem('googleId'));
-        if (res?.accountId) {
-          localStorage.setItem('accountId', res.accountId);
-        } else if (accountId) {
-          localStorage.setItem('accountId', accountId);
-        }
-        if (res?.walletAddress) {
-          localStorage.setItem('walletAddress', res.walletAddress);
+        const email = localStorage.getItem('email');
+        if (email) {
+          const res = await createAccount(
+            undefined,
+            localStorage.getItem('googleId'),
+            email
+          );
+          if (res?.accountId) {
+            localStorage.setItem('accountId', res.accountId);
+          } else if (accountId) {
+            localStorage.setItem('accountId', accountId);
+          }
+          if (res?.walletAddress) {
+            localStorage.setItem('walletAddress', res.walletAddress);
+          }
         }
       } catch (err) {
         console.error('Account setup failed', err);

--- a/webapp/src/components/NftGiftCard.jsx
+++ b/webapp/src/components/NftGiftCard.jsx
@@ -20,19 +20,21 @@ export default function NftGiftCard({ accountId: propAccountId }) {
     async function ensureAccount() {
       let id = propAccountId || localStorage.getItem('accountId');
       if (!id) {
-        try {
-          const acc = await createAccount(
-            getTelegramId(),
-            localStorage.getItem('googleId')
-          );
-          if (acc?.accountId) {
-            id = acc.accountId;
-            localStorage.setItem('accountId', id);
-            if (acc.walletAddress) {
-              localStorage.setItem('walletAddress', acc.walletAddress);
+        const tgId = getTelegramId();
+        const googleId = localStorage.getItem('googleId');
+        const email = tgId ? null : localStorage.getItem('email');
+        if (tgId || email) {
+          try {
+            const acc = await createAccount(tgId, googleId, email);
+            if (acc?.accountId) {
+              id = acc.accountId;
+              localStorage.setItem('accountId', id);
+              if (acc.walletAddress) {
+                localStorage.setItem('walletAddress', acc.walletAddress);
+              }
             }
-          }
-        } catch {}
+          } catch {}
+        }
       }
       if (id) setAccountId(id);
     }

--- a/webapp/src/hooks/useTelegramAuth.js
+++ b/webapp/src/hooks/useTelegramAuth.js
@@ -10,24 +10,29 @@ export default function useTelegramAuth() {
     if (user?.id) {
       localStorage.setItem('telegramId', user.id);
       socket.emit('register', { playerId: acc || user.id });
-      createAccount(user.id).catch(err => {
-        console.error('Failed to create account', err);
-      });
+      createAccount(user.id, undefined, localStorage.getItem('email')).catch(
+        err => {
+          console.error('Failed to create account', err);
+        }
+      );
     } else {
       (async () => {
         const accountId = acc || (await ensureAccountId());
         socket.emit('register', { playerId: accountId });
         const googleId = localStorage.getItem('googleId');
-        try {
-          const res = await createAccount(undefined, googleId);
-          if (res?.accountId) {
-            localStorage.setItem('accountId', res.accountId);
+        const email = localStorage.getItem('email');
+        if (email) {
+          try {
+            const res = await createAccount(undefined, googleId, email);
+            if (res?.accountId) {
+              localStorage.setItem('accountId', res.accountId);
+            }
+            if (res?.walletAddress) {
+              localStorage.setItem('walletAddress', res.walletAddress);
+            }
+          } catch (err) {
+            console.error('Failed to create account', err);
           }
-          if (res?.walletAddress) {
-            localStorage.setItem('walletAddress', res.walletAddress);
-          }
-        } catch (err) {
-          console.error('Failed to create account', err);
         }
       })();
     }

--- a/webapp/src/hooks/useTokenBalances.js
+++ b/webapp/src/hooks/useTokenBalances.js
@@ -11,6 +11,7 @@ export default function useTokenBalances() {
     telegramId = undefined;
   }
   const googleId = telegramId ? null : localStorage.getItem('googleId');
+  const email = telegramId ? null : localStorage.getItem('email');
 
   const [tpcBalance, setTpcBalance] = useState(null);
   const [tonBalance, setTonBalance] = useState(null);
@@ -20,9 +21,9 @@ export default function useTokenBalances() {
 
   useEffect(() => {
     async function loadTpc() {
-      if (!telegramId && !googleId) return;
+      if (!telegramId && !email) return;
       try {
-        const acc = await createAccount(telegramId, googleId);
+        const acc = await createAccount(telegramId, googleId, email);
         if (acc?.error) throw new Error(acc.error);
         if (acc.walletAddress) {
           localStorage.setItem('walletAddress', acc.walletAddress);

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -15,7 +15,6 @@ import {
   getTelegramLastName,
   getTelegramPhotoUrl
 } from '../utils/telegram.js';
-import LoginOptions from '../components/LoginOptions.jsx';
 import { DEV_INFO } from '../utils/constants.js';
 import BalanceSummary from '../components/BalanceSummary.jsx';
 import AvatarPickerModal from '../components/AvatarPickerModal.jsx';
@@ -55,7 +54,38 @@ export default function MyAccount() {
 
   if (!telegramId) {
     googleId = localStorage.getItem('googleId');
-    if (!googleId) return <LoginOptions />;
+  }
+
+  const [email, setEmail] = useState(localStorage.getItem('email') || '');
+  const [emailInput, setEmailInput] = useState('');
+  const [savingEmail, setSavingEmail] = useState(false);
+
+  if (!telegramId && !email) {
+    const handleSaveEmail = () => {
+      if (!emailInput) return;
+      setSavingEmail(true);
+      localStorage.setItem('email', emailInput);
+      setEmail(emailInput);
+      setSavingEmail(false);
+    };
+    return (
+      <div className="p-4 text-text space-y-2">
+        <input
+          type="email"
+          placeholder="Email address"
+          value={emailInput}
+          onChange={(e) => setEmailInput(e.target.value)}
+          className="w-full px-3 py-2 border border-border rounded bg-background"
+        />
+        <button
+          onClick={handleSaveEmail}
+          disabled={!emailInput || savingEmail}
+          className="px-4 py-2 bg-primary hover:bg-primary-hover rounded text-white-shadow disabled:opacity-50"
+        >
+          Save
+        </button>
+      </div>
+    );
   }
 
   const [profile, setProfile] = useState(null);
@@ -81,7 +111,7 @@ export default function MyAccount() {
 
   useEffect(() => {
     async function load() {
-      const acc = await createAccount(telegramId, googleId);
+      const acc = await createAccount(telegramId, googleId, email);
       if (acc?.error) {
         console.error('Failed to load account:', acc.error);
         return;
@@ -95,6 +125,12 @@ export default function MyAccount() {
 
       const data = await getAccountInfo(acc.accountId);
       let finalProfile = data;
+      if (email && data.email !== email) {
+        try {
+          await updateProfile({ accountId: acc.accountId, email });
+          finalProfile = { ...finalProfile, email };
+        } catch {}
+      }
 
       if (telegramId && (!data.photo || !data.firstName || !data.lastName)) {
         setAutoUpdating(true);
@@ -135,6 +171,7 @@ export default function MyAccount() {
       }
 
       setProfile(finalProfile);
+      setEmail(finalProfile.email || email);
       setTwitterLink(finalProfile.social?.twitter || '');
       const defaultPhoto = telegramId ? getTelegramPhotoUrl() : '';
       setPhotoUrl(loadAvatar() || finalProfile.photo || defaultPhoto);
@@ -154,7 +191,7 @@ export default function MyAccount() {
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [telegramId, googleId]);
+  }, [telegramId, googleId, email]);
 
   useEffect(() => {
     if (!telegramId) return;
@@ -190,6 +227,19 @@ export default function MyAccount() {
     } finally {
       setDevTopup('');
       setDevTopupSending(false);
+    }
+  };
+
+  const handleEmailSave = async () => {
+    if (!email) return;
+    try {
+      await updateProfile({ accountId: profile.accountId, email });
+      setShowSaved(true);
+      localStorage.setItem('email', email);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setShowSaved(false), 1500);
+    } catch (err) {
+      console.error('save email failed', err);
     }
   };
 
@@ -328,6 +378,24 @@ export default function MyAccount() {
               }
             />
           </div>
+          {!telegramId && (
+            <div className="mt-2 flex items-center space-x-2">
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="flex-grow px-3 py-2 border border-border rounded bg-background"
+                placeholder="Email address"
+              />
+              <button
+                onClick={handleEmailSave}
+                disabled={!email}
+                className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow disabled:opacity-50"
+              >
+                Save
+              </button>
+            </div>
+          )}
           <button
             onClick={() => setShowAvatarPicker(true)}
             className="mt-2 px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -56,6 +56,7 @@ export default function Wallet({ hideClaim = false }) {
     telegramId = undefined;
   }
   const googleId = telegramId ? null : localStorage.getItem('googleId');
+  const email = telegramId ? null : localStorage.getItem('email');
 
   const [accountId, setAccountId] = useState('');
   const [tpcBalance, setTpcBalance] = useState(null);
@@ -97,7 +98,10 @@ export default function Wallet({ hideClaim = false }) {
     if (id) {
       acc = { accountId: id };
     } else {
-      acc = await createAccount(telegramId, googleId);
+      if (!telegramId && !email) {
+        return null;
+      }
+      acc = await createAccount(telegramId, googleId, email);
       if (acc?.error) {
         console.error('Failed to load account:', acc.error);
         return null;

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -482,10 +482,14 @@ export function registerWalletPasskey(telegramId, passkeyId, publicKey) {
 
 // ----- Account based wallet -----
 
-export function createAccount(telegramId, googleId) {
+export function createAccount(telegramId, googleId, email) {
+  if (!telegramId && !email) {
+    return Promise.resolve({ error: 'Email required' });
+  }
   const body = {};
   if (telegramId) body.telegramId = telegramId;
   if (googleId) body.googleId = googleId;
+  if (email) body.email = email;
   return post('/api/account/create', body);
 }
 


### PR DESCRIPTION
## Summary
- add email capture step on profile page for users without Telegram
- enforce email requirement in account creation and propagate email to related hooks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b15b3b55088329af9417cfb61dd288