### PR TITLE
Fix Pool Royale pocket guides and entry

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -168,8 +168,8 @@
           const [tl, tm, tr, bl, bm, br] = pockets;
           const cutR = RIM_R - GUIDE_MARGIN;
           // Smaller values create a tighter bend so the guides tuck closer to the pocket rims
-          const TURN_CORNER = 7;
-          const TURN_MIDDLE = 6; // top and bottom centre pockets bend slightly more
+          const TURN_CORNER = 4;
+          const TURN_MIDDLE = 5; // side pockets bend slightly less
           const edgePaths = [
             // Corner pocket cuts
             `M0 ${tl.y - cutR} H${tl.x - cutR - TURN_CORNER} A${TURN_CORNER} ${TURN_CORNER} 0 0 1 ${tl.x - cutR} ${tl.y - cutR - TURN_CORNER} V0`,

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1262,33 +1262,43 @@
             var R = TABLE_W - BORDER - BALL_R;
             var T = BORDER_TOP + BALL_R;
             var B = TABLE_H - BORDER_BOTTOM - BALL_R;
-            if (b.p.x < L) {
-              b.p.x = L;
-              var sx = Math.abs(b.v.x);
-              b.v.x *= -BOUNCE;
-              if (b.n === 0) b.spinApplied = true;
-              playCueHit(clamp(sx / 4000, 0, 1) * 0.5);
+            var nearPocket = false;
+            for (var k = 0; k < this.pockets.length; k++) {
+              var pk = this.pockets[k];
+              if (Math.hypot(b.p.x - pk.x, b.p.y - pk.y) < pk.r + BALL_R) {
+                nearPocket = true;
+                break;
+              }
             }
-            if (b.p.x > R) {
-              b.p.x = R;
-              var sx2 = Math.abs(b.v.x);
-              b.v.x *= -BOUNCE;
-              if (b.n === 0) b.spinApplied = true;
-              playCueHit(clamp(sx2 / 4000, 0, 1) * 0.5);
-            }
-            if (b.p.y < T) {
-              b.p.y = T;
-              var sy = Math.abs(b.v.y);
-              b.v.y *= -BOUNCE;
-              if (b.n === 0) b.spinApplied = true;
-              playCueHit(clamp(sy / 4000, 0, 1) * 0.5);
-            }
-            if (b.p.y > B) {
-              b.p.y = B;
-              var sy2 = Math.abs(b.v.y);
-              b.v.y *= -BOUNCE;
-              if (b.n === 0) b.spinApplied = true;
-              playCueHit(clamp(sy2 / 4000, 0, 1) * 0.5);
+            if (!nearPocket) {
+              if (b.p.x < L) {
+                b.p.x = L;
+                var sx = Math.abs(b.v.x);
+                b.v.x *= -BOUNCE;
+                if (b.n === 0) b.spinApplied = true;
+                playCueHit(clamp(sx / 4000, 0, 1) * 0.5);
+              }
+              if (b.p.x > R) {
+                b.p.x = R;
+                var sx2 = Math.abs(b.v.x);
+                b.v.x *= -BOUNCE;
+                if (b.n === 0) b.spinApplied = true;
+                playCueHit(clamp(sx2 / 4000, 0, 1) * 0.5);
+              }
+              if (b.p.y < T) {
+                b.p.y = T;
+                var sy = Math.abs(b.v.y);
+                b.v.y *= -BOUNCE;
+                if (b.n === 0) b.spinApplied = true;
+                playCueHit(clamp(sy / 4000, 0, 1) * 0.5);
+              }
+              if (b.p.y > B) {
+                b.p.y = B;
+                var sy2 = Math.abs(b.v.y);
+                b.v.y *= -BOUNCE;
+                if (b.n === 0) b.spinApplied = true;
+                playCueHit(clamp(sy2 / 4000, 0, 1) * 0.5);
+              }
             }
           }
 
@@ -1646,7 +1656,14 @@
             var dy = pocket.y - y1;
             var dist = Math.hypot(dx, dy);
             if (dist === 0) return;
-            var g = Math.min(guideLen, dist - pocket.r - 1);
+            var extra =
+              pocket === pTL ||
+              pocket === pTR ||
+              pocket === pBL ||
+              pocket === pBR
+                ? 2
+                : 1;
+            var g = Math.min(guideLen + extra, dist - pocket.r - 1);
             if (g <= 0) return;
             var x2 = x1 + (dx / dist) * g;
             var y2 = y1 + (dy / dist) * g;


### PR DESCRIPTION
## Summary
- Bend yellow pocket guides further so corners curve tighter than side pockets
- Allow balls to pass rails near pockets by skipping rail collisions in pocket zones

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1653358588329bedbbca9adbbfa0f