### PR TITLE
Prompt email signup for non-Telegram users

### DIFF
--- a/webapp/src/components/EmailPopup.jsx
+++ b/webapp/src/components/EmailPopup.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { createAccount } from '../utils/api.js';
+import { socket } from '../utils/socket.js';
+
+export default function EmailPopup({ open, onSave }) {
+  const [email, setEmail] = useState('');
+  const [saving, setSaving] = useState(false);
+  if (!open) return null;
+
+  const handleSave = async () => {
+    if (!email) return;
+    setSaving(true);
+    try {
+      localStorage.setItem('email', email);
+      const googleId = localStorage.getItem('googleId');
+      const res = await createAccount(undefined, googleId, email);
+      if (res?.accountId) {
+        localStorage.setItem('accountId', res.accountId);
+        socket.emit('register', { playerId: res.accountId });
+      }
+      if (res?.walletAddress) {
+        localStorage.setItem('walletAddress', res.walletAddress);
+      }
+      onSave();
+    } catch (err) {
+      console.error('save email failed', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
+      <div className="prism-box p-6 space-y-4 text-text w-80">
+        <h3 className="text-lg font-bold text-center">Enter your email</h3>
+        <input
+          type="email"
+          placeholder="Email address"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full px-3 py-2 border border-border rounded bg-background"
+        />
+        <button
+          onClick={handleSave}
+          disabled={!email || saving}
+          className="w-full px-4 py-2 bg-primary hover:bg-primary-hover rounded text-white-shadow disabled:opacity-50"
+        >
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -3,10 +3,11 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { socket } from '../utils/socket.js';
 import { pingOnline } from '../utils/api.js';
-import { getPlayerId } from '../utils/telegram.js';
+import { getPlayerId, isTelegramWebView } from '../utils/telegram.js';
 import { isGameMuted, getGameVolume } from '../utils/sound.js';
 import { chatBeep as inviteBeep } from '../assets/soundData.js';
 import InvitePopup from './InvitePopup.jsx';
+import EmailPopup from './EmailPopup.jsx';
 
 import Navbar from './Navbar.jsx';
 
@@ -17,7 +18,16 @@ export default function Layout({ children }) {
   const location = useLocation();
   const navigate = useNavigate();
   const [invite, setInvite] = useState(null);
+  const [requireEmail, setRequireEmail] = useState(false);
   const inviteSoundRef = useRef(null);
+
+  useEffect(() => {
+    try {
+      if (!isTelegramWebView() && !localStorage.getItem('email')) {
+        setRequireEmail(true);
+      }
+    } catch {}
+  }, []);
 
   useEffect(() => {
     inviteSoundRef.current = new Audio(inviteBeep);
@@ -153,6 +163,8 @@ export default function Layout({ children }) {
         }}
         onReject={() => setInvite(null)}
       />
+
+      <EmailPopup open={requireEmail} onSave={() => setRequireEmail(false)} />
 
     </div>
   );


### PR DESCRIPTION
## Summary
- Add EmailPopup component prompting for an email address and creating account
- Trigger email popup on layout load when not inside Telegram and no email saved

## Testing
- `npm test`
- `npm run lint` *(fails: 958 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b16966e42883299de0a25a4e562e47