### PR TITLE
Ensure penalty kick goal sound plays

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -1036,9 +1036,13 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
   }
   loadGoalSound();
 
-  function playGoalSound(){
+  async function playGoalSound(){
     ensureAudio();
-    if(!audioCtx || !goalSoundBuf) return;
+    if(!audioCtx) return;
+    if(!goalSoundBuf){
+      await loadGoalSound();
+      if(!goalSoundBuf) return;
+    }
     const src = audioCtx.createBufferSource();
     src.buffer = goalSoundBuf;
     src.connect(masterGain);


### PR DESCRIPTION
## Summary
- load goal sound buffer on demand to guarantee playback

## Testing
- `npm test` *(fails: 82 passed, 3 failed)*
- `npm run lint` *(fails: 958 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b166b773cc8329b07744539690ee2b