### PR TITLE
Widen corner pocket edges in Pool Royale example

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -168,7 +168,7 @@
           const [tl, tm, tr, bl, bm, br] = pockets;
           const cutR = RIM_R - GUIDE_MARGIN;
           // Smaller values create a tighter bend so the guides tuck closer to the pocket rims
-          const TURN_CORNER = 4;
+          const TURN_CORNER = 6; // widen corner pocket edges
           const TURN_MIDDLE = 5; // side pockets bend slightly less
           const edgePaths = [
             // Corner pocket cuts


### PR DESCRIPTION
## Summary
- Increase `TURN_CORNER` in Pool Royale overlay to open top and bottom pocket edges while leaving side pockets unchanged.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1741552848329abe309457d05075b