### PR TITLE
Widen Pool Royale corner pockets

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -168,7 +168,7 @@
           const [tl, tm, tr, bl, bm, br] = pockets;
           const cutR = RIM_R - GUIDE_MARGIN;
           // Smaller values create a tighter bend so the guides tuck closer to the pocket rims
-          const TURN_CORNER = 6; // widen corner pocket edges
+          const TURN_CORNER = 8; // widen corner pocket edges
           const TURN_MIDDLE = 5; // side pockets bend slightly less
           const edgePaths = [
             // Corner pocket cuts

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1659,12 +1659,13 @@
             var dy = pocket.y - y1;
             var dist = Math.hypot(dx, dy);
             if (dist === 0) return;
+            // Corner pockets get a little more guide length so their edges appear more open
             var extra =
               pocket === pTL ||
               pocket === pTR ||
               pocket === pBL ||
               pocket === pBR
-                ? 3
+                ? 5
                 : 1;
             var g = Math.min(guideLen + extra, dist - pocket.r - 1);
             if (g <= 0) return;


### PR DESCRIPTION
## Summary
- Relax corner pocket turn radius in Pool Royale example to open top and bottom pockets.
- Lengthen corner pocket guide lines in main Pool Royale page for wider openings while leaving side pockets unchanged.

## Testing
- `npm test` *(fails: ERR_DLOPEN_FAILED canvas bindings)*

------
https://chatgpt.com/codex/tasks/task_e_68b1778b08688329880d565693b59a1f