### PR TITLE
Widen corner pocket edges for Pool Royale

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -168,7 +168,7 @@
           const [tl, tm, tr, bl, bm, br] = pockets;
           const cutR = RIM_R - GUIDE_MARGIN;
           // Smaller values create a tighter bend so the guides tuck closer to the pocket rims
-          const TURN_CORNER = 8; // widen corner pocket edges
+          const TURN_CORNER = 12; // widen corner pocket edges further for top/bottom pockets
           const TURN_MIDDLE = 5; // side pockets bend slightly less
           const edgePaths = [
             // Corner pocket cuts

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1594,14 +1594,15 @@
           // from the ball radius to keep proportions consistent across
           // different table sizes.
           var margin = BALL_R * 1.5;
+          var cornerMargin = BALL_R * 1.8; // extra gap for corner pockets
 
           // Top rail
           var pTL = this.pockets[0];
           var pTR = this.pockets[1];
           var topLeftX =
-            pTL.x + Math.sqrt(pTL.r * pTL.r - Math.pow(BORDER_TOP - pTL.y, 2)) + margin;
+            pTL.x + Math.sqrt(pTL.r * pTL.r - Math.pow(BORDER_TOP - pTL.y, 2)) + cornerMargin;
           var topRightX =
-            pTR.x - Math.sqrt(pTR.r * pTR.r - Math.pow(BORDER_TOP - pTR.y, 2)) - margin;
+            pTR.x - Math.sqrt(pTR.r * pTR.r - Math.pow(BORDER_TOP - pTR.y, 2)) - cornerMargin;
           ctx.moveTo(topLeftX * sX, y0);
           ctx.lineTo(topRightX * sX, y0);
 
@@ -1611,10 +1612,10 @@
           var bottomY = TABLE_H - BORDER_BOTTOM;
           var bottomLeftX =
             pBL.x +
-            Math.sqrt(pBL.r * pBL.r - Math.pow(pBL.y - bottomY, 2)) + margin;
+            Math.sqrt(pBL.r * pBL.r - Math.pow(pBL.y - bottomY, 2)) + cornerMargin;
           var bottomRightX =
             pBR.x -
-            Math.sqrt(pBR.r * pBR.r - Math.pow(pBR.y - bottomY, 2)) - margin;
+            Math.sqrt(pBR.r * pBR.r - Math.pow(pBR.y - bottomY, 2)) - cornerMargin;
           ctx.moveTo(bottomLeftX * sX, y0 + h);
           ctx.lineTo(bottomRightX * sX, y0 + h);
 
@@ -1665,7 +1666,7 @@
               pocket === pTR ||
               pocket === pBL ||
               pocket === pBR
-                ? 5
+                ? 8
                 : 1;
             var g = Math.min(guideLen + extra, dist - pocket.r - 1);
             if (g <= 0) return;


### PR DESCRIPTION
## Summary
- widen corner pocket edges for top and bottom pockets in Pool Royale example
- expand corner gap and guide length in webapp to open top and bottom pocket edges

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolons and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b17a8ab6b883299da71ac88ab48a6e