### PR TITLE
Ensure goal net sound plays on post or crossbar goals

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -216,7 +216,7 @@
   // faster initial shot speed for wider coverage
   const SHOT_SPEED = 20;
   const MIN_GOAL_POINTS = 5;
-  const ball = { x:0,y:0,r:BALL_R, vx:0,vy:0, moving:false, trail:[], spin:0, angle:0, netSounded:false, firstContact:false, target:null, prevDist:null, points:0 };
+  const ball = { x:0,y:0,r:BALL_R, vx:0,vy:0, moving:false, trail:[], spin:0, angle:0, netSounded:false, goalSounded:false, firstContact:false, target:null, prevDist:null, points:0 };
   const ballImg = new Image();
   ballImg.src = '/assets/icons/file_0000000061d4620aaf506adfa605e1f3.webp';
 
@@ -567,6 +567,7 @@
     if(nextX - ball.r <= g.x && nextY > g.y - postR && nextY < g.y + g.h + postR && ball.vx < 0){
       triggerNetHit(nextX, nextY);
       sfxPost();
+      if(!ball.goalSounded){ playGoalSound(); ball.goalSounded = true; }
       reflectBall(1,0,0.85);
       ball.x = g.x + ball.r;
       ball.y = nextY;
@@ -575,6 +576,7 @@
     if(nextX + ball.r >= g.x + g.w && nextY > g.y - postR && nextY < g.y + g.h + postR && ball.vx > 0){
       triggerNetHit(nextX, nextY);
       sfxPost();
+      if(!ball.goalSounded){ playGoalSound(); ball.goalSounded = true; }
       reflectBall(-1,0,0.85);
       ball.x = g.x + g.w - ball.r;
       ball.y = nextY;
@@ -583,6 +585,7 @@
     if(nextY - ball.r <= g.y && nextX > g.x - postR && nextX < g.x + g.w + postR && ball.vy < 0){
       triggerNetHit(nextX, nextY);
       sfxPost();
+      if(!ball.goalSounded){ playGoalSound(); ball.goalSounded = true; }
       reflectBall(0,1,0.85);
       ball.y = g.y + ball.r;
       ball.x = nextX;
@@ -935,7 +938,7 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
   // ===== Controls =====
   // controls removed
 
-  function resetBall(){ ball.x=geom.spot.x; ball.y=geom.spot.y; ball.vx=ball.vy=ball.spin=0; ball.angle=0; ball.moving=false; ball.netSounded=false; ball.trail=[]; ball.firstContact=false; ball.target=null; ball.prevDist=null; ball.points=0; netHit={x:0,y:0,t:0,shake:0}; keeper.vx=0; keeper.vy=0; keeper.a=0; keeper.dive=0; keeper.jumping=false; keeper.x = keeper.baseX; keeper.y = keeper.baseY; }
+  function resetBall(){ ball.x=geom.spot.x; ball.y=geom.spot.y; ball.vx=ball.vy=ball.spin=0; ball.angle=0; ball.moving=false; ball.netSounded=false; ball.goalSounded=false; ball.trail=[]; ball.firstContact=false; ball.target=null; ball.prevDist=null; ball.points=0; netHit={x:0,y:0,t:0,shake:0}; keeper.vx=0; keeper.vy=0; keeper.a=0; keeper.dive=0; keeper.jumping=false; keeper.x = keeper.baseX; keeper.y = keeper.baseY; }
   function startGame(){ running=true; paused=false; ended=false; roundStart=performance.now(); timeLeft=ROUND_TIME; myScore=0; looseBalls=[]; for(const r of rivals){ r.score=0; r.next=0; r.shots=[]; } resetBall(); generateHoles(); drawMiniBoards(true); updateHUD(); ensureAudio(); status('Go! Score as many as you can.'); }
 
   // ===== WebAudio SFX =====
@@ -1066,7 +1069,7 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
   }
   function celebrateGoal(x, y){
     triggerNetHit(x, y);
-    playGoalSound();
+    if(!ball.goalSounded){ playGoalSound(); ball.goalSounded = true; }
   }
   function showGoal(x, y){
     goalFlash = 1;


### PR DESCRIPTION
## Summary
- play goal-net audio in sync with post/crossbar hits that still score
- track and reset goal sound state to avoid duplicate playback

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b17a3250788329ac02a28b65cc15e0