### PR TITLE
Widen corner pocket edges

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -168,7 +168,7 @@
           const [tl, tm, tr, bl, bm, br] = pockets;
           const cutR = RIM_R - GUIDE_MARGIN;
           // Smaller values create a tighter bend so the guides tuck closer to the pocket rims
-          const TURN_CORNER = 12; // widen corner pocket edges further for top/bottom pockets
+          const TURN_CORNER = 20; // widen corner pocket edges further for top/bottom pockets
           const TURN_MIDDLE = 5; // side pockets bend slightly less
           const edgePaths = [
             // Corner pocket cuts

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1594,7 +1594,8 @@
           // from the ball radius to keep proportions consistent across
           // different table sizes.
           var margin = BALL_R * 1.5;
-          var cornerMargin = BALL_R * 1.8; // extra gap for corner pockets
+          // widen corner pockets slightly more so their gap matches the side pockets
+          var cornerMargin = BALL_R * 2.1; // extra gap for corner pockets
 
           // Top rail
           var pTL = this.pockets[0];
@@ -1666,7 +1667,7 @@
               pocket === pTR ||
               pocket === pBL ||
               pocket === pBR
-                ? 8
+                ? 12
                 : 1;
             var g = Math.min(guideLen + extra, dist - pocket.r - 1);
             if (g <= 0) return;


### PR DESCRIPTION
## Summary
- widen top/bottom pocket gaps to match side pockets
- increase guide length for corner pockets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b17dfb69f88329ba5a1f9c0ad71080