### PR TITLE
fix: play goal sound from start

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -1057,8 +1057,10 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const gain = audioCtx.createGain();
     gain.gain.value = 1.5; // goal sound 50% louder
     src.connect(gain).connect(masterGain);
-    const startAt = goalSoundBuf.duration/2;
-    src.start(0, startAt);
+    // Play the goal sound from the start of the clip so the net swoosh is always heard
+    // regardless of the file's duration. Starting mid‑clip occasionally skipped the
+    // audible portion, resulting in no sound on successful goals.
+    src.start(0);
   }
 
   function triggerNetHit(x, y){


### PR DESCRIPTION
## Summary
- ensure goal audio plays from the beginning so net swoosh is heard on every score

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b183be13bc8329b670b1171dfc0526