### PR TITLE
chore: widen pool royale pocket edges

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1590,15 +1590,15 @@
           ctx.lineWidth = lineWidth;
           ctx.lineCap = 'butt';
           ctx.beginPath();
-          // Shorten rail lines and leave a gap roughly 20% wider than the
-          // ball diameter so pockets stay easy to enter.  Include one
+          // Shorten rail lines and leave a gap roughly 30% wider than the
+          // ball diameter so pockets stay easy to enter. Include one
           // yellow line's width so rail edges start slightly farther out
           // for a more open pocket shape. The margin scales from the ball
           // radius to keep proportions consistent across different table sizes.
-          var margin = BALL_R * 1.5 + lineWidth;
+          var margin = BALL_R * 1.65 + lineWidth;
           // widen corner pockets slightly so their gap matches the side pockets
           // with a slightly tighter bend toward the rails
-          var cornerMargin = BALL_R * 1.9 + lineWidth; // extra gap for corner pockets
+          var cornerMargin = BALL_R * 2.1 + lineWidth; // extra gap for corner pockets
 
           // Top rail
           var pTL = this.pockets[0];


### PR DESCRIPTION
## Summary
- increase yellow rail gaps around pockets to be ~30% wider than a ball

## Testing
- `npm test` *(fails: Failed to store game result: Operation `gameresults.insertOne()` buffering timed out after 10000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68b18b2ac438832987a25c3b8ea4f8ac