### PR TITLE
Improve post-hit sound timing and volume

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -351,6 +351,7 @@
   const whistleSound = new Audio('/assets/sounds/metal-whistle-6121.mp3');
   const goalNetSound = new Audio('/assets/sounds/a-football-hits-the-net-goal-313216.mp3');
   const postHitSound = new Audio('/assets/sounds/frying-pan-over-the-head-89303.mp3');
+  postHitSound.volume = 0.7; // 30% lower volume on post/crossbar hits
   const crowdBaseVolume = 0.5;
   crowdSound.volume = crowdBaseVolume;
   let pendingWhistle = false;
@@ -394,11 +395,12 @@
     wall(){},
     post(){
       if(!audioEnabled) return;
-      postHitSound.currentTime = 0;
+      // Skip ~0.15s of initial silence so the clang matches contact
+      postHitSound.currentTime = 0.15;
       postHitSound.play().catch(()=>{});
       setTimeout(()=>{
         postHitSound.pause();
-        postHitSound.currentTime = 0;
+        postHitSound.currentTime = 0.15;
       },1000);
     },
     goal(){

--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -985,8 +985,8 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const gain=audioCtx.createGain();
     gain.gain.value=0.7; // 30% lower volume on post/crossbar hits
     src.connect(gain).connect(masterGain);
-    // Skip initial silence so the sound starts at 0.3 seconds
-    src.start(0, 0.3);
+    // Skip ~0.15s of initial silence so the clang matches contact
+    src.start(0, 0.15);
   }
   const sfxPost = playPostHitSound;
   // Ball kick sound


### PR DESCRIPTION
## Summary
- Start goal-post clang immediately after contact in penalty-kick by skipping initial silence
- Trim silence and drop volume for goal-post hits in goal-rush variant

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1a0c9f7e88329a4652d5973316745