### PR TITLE
feat: outline cushions and pockets

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1471,8 +1471,20 @@
             Math.PI * 2
           );
           ctx.fill();
-          // Pockets and field markings removed; skip drawing red pocket interiors
-          // and outlines so the table renders without visual hole markers.
+          // Draw a thin yellow line along the cushions
+          ctx.strokeStyle = '#facc15';
+          ctx.lineWidth = 2;
+          ctx.strokeRect(x0, y0, w, h);
+
+          // Outline pockets with a thin red line
+          ctx.strokeStyle = '#ff0000';
+          ctx.lineWidth = 2;
+          for (var i = 0; i < this.pockets.length; i++) {
+            var p = this.pockets[i];
+            ctx.beginPath();
+            ctx.arc(p.x * sX, p.y * sY, p.r * scaleFactor, 0, Math.PI * 2);
+            ctx.stroke();
+          }
           // Topat
           for (var j = 0; j < this.balls.length; j++) {
             var b = this.balls[j];


### PR DESCRIPTION
## Summary
- highlight table cushions with a thin yellow rectangle
- outline pockets using red rings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1a71b2a948329ba1062f58e14e0d6