### PR TITLE
Adjust penalty kick sounds

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -985,8 +985,8 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const gain=audioCtx.createGain();
     gain.gain.value=0.7; // 30% lower volume on post/crossbar hits
     src.connect(gain).connect(masterGain);
-    // Skip ~0.15s of initial silence so the clang matches contact
-    src.start(0, 0.15);
+    // Skip ~0.3s of initial silence so the clang matches contact
+    src.start(0, 0.3);
   }
   const sfxPost = playPostHitSound;
   // Ball kick sound
@@ -1058,7 +1058,7 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const src = audioCtx.createBufferSource();
     src.buffer = goalSoundBuf;
     const gain = audioCtx.createGain();
-    gain.gain.value = 1.8; // goal sound 80% louder
+    gain.gain.value = 2.16; // goal sound volume increased by 20%
     src.connect(gain).connect(masterGain);
     // Play the goal sound from the start of the clip so the net swoosh is always heard
     // regardless of the file's duration. Starting mid‑clip occasionally skipped the


### PR DESCRIPTION
## Summary
- start post and crossbar hit sound at 0.3s
- boost goal net sound volume by 20%

## Testing
- `npm test` *(fails: 3 failing, 82 passing)*
- `npm run lint` *(fails: 958 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a7ba9ed083298f8c5b9cef5c7c9f