### PR TITLE
Bring Pool Royale pockets closer to table center

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -619,7 +619,8 @@
         // rounded edge (with yellow guides) fixed in place.
         var POCKET_R = 32; // rrezja baze e gropave pak me e vogel nga jashte
         var SIDE_POCKET_R = 30; // gropat anesore gjithashtu me te vogla nga jashte
-        var POCKET_SHORTEN = 12; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
+        // move pockets slightly closer to the center of the table
+        var POCKET_SHORTEN = 10; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
         var BALL_R = 20; // rrezja baze e topave pak me e vogel
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side


### PR DESCRIPTION
## Summary
- slightly increase inward offset for Pool Royale pockets to tighten table

## Testing
- `npm test` *(fails: allows multiple users without telegramId, withdraw route reverts balance on claim failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b4cf84d8832999954fca13a53c9b