### PR TITLE
Adjust Pool Royale pocket positions inward

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -620,7 +620,7 @@
         var POCKET_R = 32; // rrezja baze e gropave pak me e vogel nga jashte
         var SIDE_POCKET_R = 30; // gropat anesore gjithashtu me te vogla nga jashte
         // move pockets slightly closer to the center of the table
-        var POCKET_SHORTEN = 10; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
+        var POCKET_SHORTEN = 8; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
         var BALL_R = 20; // rrezja baze e topave pak me e vogel
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side


### PR DESCRIPTION
## Summary
- Move pockets slightly closer to the table center in Pool Royale by reducing inward offset

## Testing
- `npm test` *(fails: seat and unseat endpoints update lobby; allows multiple users without telegramId; withdraw route reverts balance on claim failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d94d724883298eb746c654cb8c2b