### PR TITLE
Adjust pocket positions in Pool Royale

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -620,7 +620,8 @@
         var POCKET_R = 32; // rrezja baze e gropave pak me e vogel nga jashte
         var SIDE_POCKET_R = 30; // gropat anesore gjithashtu me te vogla nga jashte
         // move pockets slightly closer to the center of the table
-        var POCKET_SHORTEN = 8; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
+        // increase shortening to bring pockets a touch more inward
+        var POCKET_SHORTEN = 12; // gropat zhvendosen edhe me shume brenda per te ruajtur anen e brendshme
         var BALL_R = 20; // rrezja baze e topave pak me e vogel
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side


### PR DESCRIPTION
## Summary
- shift pool pockets slightly more toward the table center

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e3c847948329872ce28e831dc2df