### PR TITLE
feat: slightly enlarge pool royale pockets

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -7,7 +7,7 @@
     <style>
       :root {
         /* Tweakables */
-        --pocket-r: 50; /* rim radius in px at 1000px width */
+        --pocket-r: 52; /* rim radius in px at 1000px width */
         --net-depth: 56; /* how far the net funnels inward */
       }
       body {

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -614,11 +614,10 @@
         var TABLE_W = 768; // gjeresi logjike e felt-it
         var TABLE_H = 1216; // lartesi logjike e felt-it
         var BORDER = 57; // korniza e drurit pak me e ngushte anash
-        // Make all pockets slightly smaller so openings sit closer to the field
-        // Make outer pocket extension slightly shorter while keeping the inner
-        // rounded edge (with yellow guides) fixed in place.
-        var POCKET_R = 32; // rrezja baze e gropave pak me e vogel nga jashte
-        var SIDE_POCKET_R = 30; // gropat anesore gjithashtu me te vogla nga jashte
+        // Make all pockets slightly larger so openings are a touch wider
+        // while keeping the inner rounded edge (with yellow guides) fixed in place.
+        var POCKET_R = 34; // rrezja baze e gropave pak me e madhe nga jashte
+        var SIDE_POCKET_R = 32; // gropat anesore gjithashtu pak me te medha nga jashte
         // move pockets slightly closer to the center of the table
         var POCKET_SHORTEN = 8; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
         var BALL_R = 20; // rrezja baze e topave pak me e vogel


### PR DESCRIPTION
## Summary
- widen pocket radii in Pool Royale to make all six pockets slightly larger
- increase example pocket rim radius for consistent visuals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ec6592488329a5c62e33add540d3