### PR TITLE
Straighten cushion edges and move pockets inward

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -614,12 +614,11 @@
         var TABLE_W = 768; // gjeresi logjike e felt-it
         var TABLE_H = 1216; // lartesi logjike e felt-it
         var BORDER = 57; // korniza e drurit pak me e ngushte anash
-        // Make all pockets slightly larger so openings are a touch wider
-        // while keeping the inner rounded edge (with yellow guides) fixed in place.
-        var POCKET_R = 34; // rrezja baze e gropave pak me e madhe nga jashte
-        var SIDE_POCKET_R = 32; // gropat anesore gjithashtu pak me te medha nga jashte
+        // Gropat pak me te vogla per t'u mbyllur me shume dhe jo per t'u zgjeruar
+        var POCKET_R = 30; // rrezja baze e gropave pak me e vogel nga jashte
+        var SIDE_POCKET_R = 28; // gropat anesore gjithashtu pak me te vogla
         // move pockets slightly closer to the center of the table
-        var POCKET_SHORTEN = 8; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
+        var POCKET_SHORTEN = 10; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
         var BALL_R = 20; // rrezja baze e topave pak me e vogel
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side
@@ -1500,26 +1499,6 @@
           // right edge - bottom segment
           ctx.moveTo(x0 + w, (mr.y + mr.r) * sY + gap);
           ctx.lineTo(x0 + w, (br.y - br.r) * sY - gap);
-          // add pocket guides that bend toward pocket centers
-          function pocketGuide(startX, startY, px, py) {
-            // Extend the guide slightly farther toward the pocket and
-            // pull the control point deeper into the pocket to increase
-            // the curvature of the guideline along its current direction.
-            var endX = startX + (px - startX) * 0.35;
-            var endY = startY + (py - startY) * 0.35;
-            var ctrlX = startX + (px - startX) * 0.7;
-            var ctrlY = startY + (py - startY) * 0.7;
-            ctx.moveTo(startX, startY);
-            ctx.quadraticCurveTo(ctrlX, ctrlY, endX, endY);
-          }
-          pocketGuide((tl.x + tl.r) * sX + gap, y0, tl.x * sX, tl.y * sY);
-          pocketGuide((tr.x - tr.r) * sX - gap, y0, tr.x * sX, tr.y * sY);
-          pocketGuide((bl.x + bl.r) * sX + gap, y0 + h, bl.x * sX, bl.y * sY);
-          pocketGuide((br.x - br.r) * sX - gap, y0 + h, br.x * sX, br.y * sY);
-          pocketGuide(x0, (ml.y - ml.r) * sY - gap, ml.x * sX, ml.y * sY);
-          pocketGuide(x0, (ml.y + ml.r) * sY + gap, ml.x * sX, ml.y * sY);
-          pocketGuide(x0 + w, (mr.y - mr.r) * sY - gap, mr.x * sX, mr.y * sY);
-          pocketGuide(x0 + w, (mr.y + mr.r) * sY + gap, mr.x * sX, mr.y * sY);
           ctx.stroke();
 
           // Outline pockets with a thin red line


### PR DESCRIPTION
## Summary
- reduce pocket radii and shift pockets slightly toward table center
- remove curved pocket guides so cushion lines stop at pocket edges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1f17e7c888329922f6d1159137bfa