### PR TITLE
Tighten Pool Royale pocket placement

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -618,7 +618,7 @@
         var POCKET_R = 30; // rrezja baze e gropave pak me e vogel nga jashte
         var SIDE_POCKET_R = 28; // gropat anesore gjithashtu pak me te vogla
         // move pockets slightly closer to the center of the table
-        var POCKET_SHORTEN = 10; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
+        var POCKET_SHORTEN = 8; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
         var BALL_R = 20; // rrezja baze e topave pak me e vogel
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side


### PR DESCRIPTION
## Summary
- move Pool Royale pockets slightly closer to table center by reducing shorten offset

## Testing
- `npm test`
- `npm run lint` *(fails: 958 errors, existing code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b2037548748329acfb5e9e2b5e4c21