### PR TITLE
Adjust pocket placement and cushion line length

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -618,7 +618,7 @@
         var POCKET_R = 32; // rrezja baze e gropave pak me e vogel nga jashte
         var SIDE_POCKET_R = 30; // gropat anesore gjithashtu pak me te vogla
         // move pockets slightly closer to the center of the table
-        var POCKET_SHORTEN = 8; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
+        var POCKET_SHORTEN = 4; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
         var BALL_R = 22; // rrezja baze e topave pak me e vogel
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
         // Raise only the bottom field line by the thickness of one green side
@@ -1474,7 +1474,7 @@
           ctx.strokeStyle = '#facc15';
           ctx.lineWidth = 2;
           ctx.beginPath();
-          var gap = 2;
+          var gap = 6;
           var tl = this.pockets[0];
           var tr = this.pockets[1];
           var ml = this.pockets[2];


### PR DESCRIPTION
## Summary
- Shorten cushion boundary lines so they stop further from the pockets
- Pull table pockets slightly toward the table's center for a tighter layout

## Testing
- `npm test` *(fails: claim-external route reverts balance on claim failure; configuration issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b20c30b4c08329b277ad5120875d80