### PR TITLE
Align penalty kick post hit sound timing

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -985,8 +985,8 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const gain=audioCtx.createGain();
     gain.gain.value=0.7; // 30% lower volume on post/crossbar hits
     src.connect(gain).connect(masterGain);
-    // Skip ~0.3s of initial silence so the clang matches contact
-    src.start(0, 0.3);
+    // Skip ~0.4s of initial silence so the clang matches contact
+    src.start(0, 0.4);
   }
   const sfxPost = playPostHitSound;
   // Ball kick sound


### PR DESCRIPTION
## Summary
- Start goal post/crossbar sound 0.4s into clip for better sync with impact

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2863113fc83298006284681213c84