### PR TITLE
Fix corner pocket connector orientation

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1524,7 +1524,11 @@
               my + r * Math.sin(mid2) - centerY
             );
             ctx.moveTo(x1, y1);
-            ctx.arc(mx, my, r, sa, ea, dist2 < dist1);
+            // Invert the arc direction so the rounded portion of the U
+            // sits behind the pocket rather than spilling onto the table.
+            // Using the midpoint that lies farther from the table centre
+            // ensures the connector curves outward around the pocket.
+            ctx.arc(mx, my, r, sa, ea, dist2 > dist1);
           }
 
           // corner pocket connectors (U)


### PR DESCRIPTION
## Summary
- Draw corner pocket U-connectors behind pockets by flipping arc direction

## Testing
- `npm test` *(fails: fail 3)*
- `npm run lint` *(fails: 958 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b292c2be688329b963e30d447f022a