### PR TITLE
Adjust penalty kick sound effect volumes

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -988,7 +988,7 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const src=audioCtx.createBufferSource();
     src.buffer=postHitSoundBuf;
     const gain=audioCtx.createGain();
-    gain.gain.value=0.6; // 40% lower volume on post/crossbar hits
+    gain.gain.value=0.5; // 50% lower volume on post/crossbar hits
     src.connect(gain).connect(masterGain);
     // Skip ~0.4s of initial silence so the clang matches contact
     src.start(0, 0.4);
@@ -1034,7 +1034,7 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
       const src=audioCtx.createBufferSource();
       src.buffer=keeperSaveSoundBuf;
       const gain=audioCtx.createGain();
-      gain.gain.value=0.4; // slightly lower volume for keeper saves
+      gain.gain.value=0.3; // lower volume for keeper saves
       src.connect(gain).connect(masterGain);
       src.start(0);
     }
@@ -1063,7 +1063,7 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const src = audioCtx.createBufferSource();
     src.buffer = goalSoundBuf;
     const gain = audioCtx.createGain();
-    gain.gain.value = 2.4; // goal sound volume boosted further
+    gain.gain.value = 4.0; // goal sound volume boosted significantly
     src.connect(gain).connect(masterGain);
     // Play the goal sound from the start of the clip so the net swoosh is always heard
     // regardless of the file's duration. Starting mid‑clip occasionally skipped the


### PR DESCRIPTION
## Summary
- Lower post/crossbar clang volume for Penalty Kick
- Lower goalkeeper save volume
- Boost net goal sound volume significantly

## Testing
- `npm test` *(fails: The "options.agent" property must be one of Agent-like Object, undefined, or false; exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68b29a800f288329a5782770fe0e7e3f