### PR TITLE
Handle pocket edge collisions with reduced bounce

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -99,3 +99,28 @@ public class CushionStepTests
         Assert.That(ball.Velocity.X, Is.GreaterThan(0));
     }
 }
+
+public class PocketEdgeTests
+{
+    [Test]
+    public void BallBouncesOffPocketEdgeWithReducedEnergy()
+    {
+        var solver = new BilliardsSolver();
+        solver.PocketEdges.Add(new BilliardsSolver.Edge
+        {
+            A = new Vec2(0, 0.1),
+            B = new Vec2(0.1, 0),
+            Normal = new Vec2(1, 1).Normalized()
+        });
+        var v = new Vec2(-1, -1).Normalized();
+        var ball = new BilliardsSolver.Ball { Position = new Vec2(0.2, 0.2), Velocity = v };
+        double preSpeed = ball.Velocity.Length;
+        solver.Step(new List<BilliardsSolver.Ball> { ball }, 0.3);
+        var n = new Vec2(1, 1).Normalized();
+        double c = Vec2.Dot(new Vec2(0, 0.1), n);
+        double dist = Vec2.Dot(ball.Position, n) - c;
+        Assert.That(dist, Is.GreaterThanOrEqualTo(PhysicsConstants.BallRadius - 1e-6));
+        Assert.That(Vec2.Dot(ball.Velocity, n), Is.GreaterThan(0));
+        Assert.That(ball.Velocity.Length, Is.LessThan(preSpeed * PhysicsConstants.PocketRestitution + 1e-3));
+    }
+}

--- a/billiards/Ccd.cs
+++ b/billiards/Ccd.cs
@@ -67,4 +67,33 @@ public static class Ccd
         }
         return hit;
     }
+
+    /// <summary>Time of impact between moving circle and line segment with given normal.
+    /// The normal should point into the playable area.</summary>
+    public static bool CircleSegment(Vec2 p, Vec2 v, double r, Vec2 a, Vec2 b, Vec2 normal, out double toi)
+    {
+        toi = double.PositiveInfinity;
+        var n = normal.Normalized();
+        double denom = Vec2.Dot(v, n);
+        if (denom >= -PhysicsConstants.Epsilon)
+            return false;
+
+        double dist = Vec2.Dot(p - a, n);
+        double t = (r - dist) / denom;
+        if (t < 0 || t > PhysicsConstants.MaxPreviewTime)
+            return false;
+
+        var hitPoint = p + v * t - n * r;
+        var seg = b - a;
+        double len = seg.Length;
+        if (len < PhysicsConstants.Epsilon)
+            return false;
+        var dir = seg / len;
+        double proj = Vec2.Dot(hitPoint - a, dir);
+        if (proj < 0 || proj > len)
+            return false;
+
+        toi = t;
+        return true;
+    }
 }

--- a/billiards/Collision.cs
+++ b/billiards/Collision.cs
@@ -5,12 +5,18 @@ namespace Billiards;
 /// <summary>Post-impact velocity computations.</summary>
 public static class Collision
 {
-    /// <summary>Reflect velocity on a surface with given normal.</summary>
-    public static Vec2 Reflect(Vec2 v, Vec2 normal)
+    /// <summary>Reflect velocity on a surface with given normal and restitution.</summary>
+    public static Vec2 Reflect(Vec2 v, Vec2 normal, double restitution)
     {
         var n = normal.Normalized();
         var dot = Vec2.Dot(v, n);
-        return v - n * (1 + PhysicsConstants.Restitution) * dot;
+        return v - n * (1 + restitution) * dot;
+    }
+
+    /// <summary>Reflect velocity on a surface with default table restitution.</summary>
+    public static Vec2 Reflect(Vec2 v, Vec2 normal)
+    {
+        return Reflect(v, normal, PhysicsConstants.Restitution);
     }
 
     /// <summary>Resolve elastic collision between two equal-mass balls.</summary>

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -5,6 +5,7 @@ public static class PhysicsConstants
 {
     public const double BallRadius = 0.028575;        // metres (57.15 mm diameter)
     public const double Restitution = 0.98;            // elastic coefficient
+    public const double PocketRestitution = Restitution * 0.2; // 80% less bounce on pocket edges
     public const double Mu = 0.2;                      // linear damping (m/s^2)
     public const double TableWidth = 2.84;             // 9ft table internal size
     public const double TableHeight = 1.42;


### PR DESCRIPTION
## Summary
- support pocket-edge segments with 80% reduced restitution
- extend physics solver and preview to bounce off pocket edges
- add test covering pocket-edge reflection

## Testing
- `dotnet test billiards.Tests`


------
https://chatgpt.com/codex/tasks/task_e_68b2af3e67ac8329a096f64893000087