### PR TITLE
Improve pocket edge collision handling

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -28,6 +28,19 @@ public class CcdRegressionTests
     }
 
     [Test]
+    public void CircleSegmentEndpointTolerance()
+    {
+        // construct a scenario where the impact point lies marginally beyond the segment end
+        var p = new Vec2(0.22020557697951237, 0.12020557556529882);
+        var v = new Vec2(-1, -1);
+        var a = new Vec2(0, 0.1);
+        var b = new Vec2(0.1, 0);
+        var n = new Vec2(1, 1);
+        Assert.IsTrue(Ccd.CircleSegment(p, v, PhysicsConstants.BallRadius, a, b, n, out double t));
+        Assert.Greater(t, 0);
+    }
+
+    [Test]
     public void NearParallelCushion()
     {
         var p0 = new Vec2(0.5, 0.5);

--- a/billiards/Ccd.cs
+++ b/billiards/Ccd.cs
@@ -90,7 +90,7 @@ public static class Ccd
             return false;
         var dir = seg / len;
         double proj = Vec2.Dot(hitPoint - a, dir);
-        if (proj < 0 || proj > len)
+        if (proj < -PhysicsConstants.Epsilon || proj > len + PhysicsConstants.Epsilon)
             return false;
 
         toi = t;


### PR DESCRIPTION
## Summary
- avoid missing pocket-edge collisions when the ball hits near a segment endpoint
- add regression test covering near-endpoint circle-segment collision

## Testing
- `dotnet test billiards.Tests`
- `npm test` *(fails to exit automatically; manual stop after tests complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b2cc27a483298dab7862ba5eeec4