### PR TITLE
Disable pocket edge bounce for pockets

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -116,7 +116,7 @@ public class CushionStepTests
 public class PocketEdgeTests
 {
     [Test]
-    public void BallBouncesOffPocketEdgeWithReducedEnergy()
+    public void BallSlidesAlongPocketEdgeWithoutBouncing()
     {
         var solver = new BilliardsSolver();
         solver.PocketEdges.Add(new BilliardsSolver.Edge
@@ -133,7 +133,7 @@ public class PocketEdgeTests
         double c = Vec2.Dot(new Vec2(0, 0.1), n);
         double dist = Vec2.Dot(ball.Position, n) - c;
         Assert.That(dist, Is.GreaterThanOrEqualTo(PhysicsConstants.BallRadius - 1e-6));
-        Assert.That(Vec2.Dot(ball.Velocity, n), Is.GreaterThan(0));
-        Assert.That(ball.Velocity.Length, Is.LessThan(preSpeed * PhysicsConstants.PocketRestitution + 1e-3));
+        Assert.That(Math.Abs(Vec2.Dot(ball.Velocity, n)), Is.LessThan(1e-6));
+        Assert.That(ball.Velocity.Length, Is.LessThan(preSpeed));
     }
 }

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -5,7 +5,7 @@ public static class PhysicsConstants
 {
     public const double BallRadius = 0.028575;        // metres (57.15 mm diameter)
     public const double Restitution = 0.98;            // elastic coefficient
-    public const double PocketRestitution = Restitution * 0.2; // 80% less bounce on pocket edges
+    public const double PocketRestitution = 0;              // no bounce on pocket edges
     public const double Mu = 0.2;                      // linear damping (m/s^2)
     public const double TableWidth = 2.84;             // 9ft table internal size
     public const double TableHeight = 1.42;


### PR DESCRIPTION
## Summary
- Remove pocket edge restitution so balls don't bounce off pocket sides
- Update pocket edge test to verify sliding along pocket without bounce

## Testing
- `dotnet test billiards.Tests/Billiards.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b2b965b24c83298389a33ee14cb411