### PR TITLE
Add defender wall and reposition penalty spot

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -118,6 +118,7 @@
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d', { alpha:true });
   let DPR=1, W=0, H=0;
+  const STRIPE = 44;
   function resize(){
     DPR = Math.max(1, Math.min(2.5, window.devicePixelRatio||1));
     W = Math.floor(window.innerWidth); H = Math.floor(window.innerHeight);
@@ -197,7 +198,7 @@
     geom.goal = { x:(W-goalW)/2, y:pbarBottom + 10, w:goalW, h:goalH, post:12 };
     geom.scale = goalW / 860;
     geom.paDepth = Math.min(320*geom.scale, H*0.34) * goalScale;
-    geom.penaltySpot = { x:W/2, y: geom.goal.y + geom.goal.h + geom.paDepth * (11/16.5) };
+    geom.penaltySpot = { x:W/2, y: geom.goal.y + geom.goal.h + geom.paDepth * (11/16.5) + STRIPE*3 };
     // position the ball a bit higher near the bottom edge
     geom.spot = { x: W/2, y: H - BALL_R*geom.scale*1.8 };
     keeper.w = 40*geom.scale*4*0.85;
@@ -206,6 +207,10 @@
     keeper.y = geom.goal.y + geom.goal.h - keeper.h + geom.goal.h*0.05;
     keeper.baseY = keeper.y;
     keeper.baseX = keeper.x;
+    defenders.w = keeper.w;
+    defenders.h = keeper.h;
+    defenders.x = (W - defenders.w)/2;
+    defenders.y = geom.penaltySpot.y + STRIPE/2;
   }
 
   // ===== Game state =====
@@ -229,6 +234,9 @@
   const keeper={x:0,y:0,w:40,h:100,vx:0,vy:0,a:0,baseY:0,baseX:0,dive:0,jumping:false,dir:1};
   const keeperImg = new Image();
   keeperImg.src = '/assets/icons/file_00000000945461f8bb9a2974fb9ee402.webp';
+  const defenders={x:0,y:0,w:40,h:100};
+  const defendersImg = new Image();
+  defendersImg.src = '/assets/icons/file_0000000091b0624395c9e8d8acf66e69.webp';
   const aimOn = false;
 
   const rivals=[
@@ -341,12 +349,12 @@
 
   // ===== Drawing: Field & lines =====
   function drawField(){
-    const stripe=44; for(let y=0;y<H;y+=stripe){
-      ctx.fillStyle=(Math.floor(y/stripe)%2?getComputedStyle(document.documentElement).getPropertyValue('--turf2')||'#0a6c1d':'#0c7a23'); ctx.fillRect(0,y,W,stripe);
+    for(let y=0;y<H;y+=STRIPE){
+      ctx.fillStyle=(Math.floor(y/STRIPE)%2?getComputedStyle(document.documentElement).getPropertyValue('--turf2')||'#0a6c1d':'#0c7a23'); ctx.fillRect(0,y,W,STRIPE);
     }
     const vg=ctx.createRadialGradient(W/2,H,10,W/2,H,H/1.12); vg.addColorStop(0,'rgba(0,0,0,0)'); vg.addColorStop(1,'rgba(0,0,0,0.26)'); ctx.fillStyle=vg; ctx.fillRect(0,0,W,H);
 
-    const kickerLineY = H - stripe*3;
+    const kickerLineY = H - STRIPE*3;
     ctx.strokeStyle = '#fff';
     ctx.lineWidth = 4;
     ctx.beginPath();
@@ -528,6 +536,11 @@
     ctx.translate(-k.w/2, -k.h + k.dive);
     ctx.drawImage(keeperImg, 0, 0, k.w, k.h);
     ctx.restore();
+  }
+
+  function drawDefenders(){
+    const d=defenders;
+    ctx.drawImage(defendersImg, d.x, d.y, d.w, d.h);
   }
 
   // ===== Ball & physics =====
@@ -941,7 +954,7 @@ function onUp(e){
 
   // ===== Timer + loop =====
   function tick(now){ if(!running||paused) return; if(!roundStart) roundStart=now; timeLeft = Math.max(0, ROUND_TIME - (now - roundStart)); timeShort.textContent = Math.ceil(timeLeft/1000); if(timeLeft<=0){ finish(); } }
-function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoal(); drawBall(); drawPunchEffects(); stepBall(); stepLooseBalls(); stepFragments(); stepKeeper(); drawMiniBoards(); tick(now||performance.now()); stepRivals(now||performance.now()); updateHUD(); netHit.t*=NET_DECAY; netHit.shake*=NET_DECAY; goalFlash*=0.92; missFlash*=0.92; }
+function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoal(); drawDefenders(); drawBall(); drawPunchEffects(); stepBall(); stepLooseBalls(); stepFragments(); stepKeeper(); drawMiniBoards(); tick(now||performance.now()); stepRivals(now||performance.now()); updateHUD(); netHit.t*=NET_DECAY; netHit.shake*=NET_DECAY; goalFlash*=0.92; missFlash*=0.92; }
 
   // ===== Controls =====
   // controls removed
@@ -1098,7 +1111,7 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
   function vibrate(ms){ if(navigator.vibrate) try{ navigator.vibrate(ms); }catch{} }
 
   // ===== Static draw & tests =====
-  function drawStaticOnce(){ drawField(); drawAds(); drawGoal(); resetBall(); drawBall(); drawMiniBoards(true); }
+function drawStaticOnce(){ drawField(); drawAds(); drawGoal(); drawDefenders(); resetBall(); drawBall(); drawMiniBoards(true); }
 
   // ===== Boot =====
   function startCountdown(n){


### PR DESCRIPTION
## Summary
- shift penalty spot three turf lines downward for longer kicks
- add defenders wall beneath the spot using existing asset and keeper dimensions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2d13747448329ae73307a5412757f