### PR TITLE
Adjust defenders layout in penalty kick

### DIFF
--- a/webapp/public/penalty-kick.html
+++ b/webapp/public/penalty-kick.html
@@ -207,10 +207,10 @@
     keeper.y = geom.goal.y + geom.goal.h - keeper.h + geom.goal.h*0.05;
     keeper.baseY = keeper.y;
     keeper.baseX = keeper.x;
-    defenders.w = keeper.w * 3;
-    defenders.h = keeper.h * 3;
+    defenders.w = keeper.w * 2.5;
+    defenders.h = keeper.h * 2.5;
     defenders.x = (W - defenders.w)/2;
-    defenders.y = geom.penaltySpot.y + STRIPE/2 - STRIPE*2;
+    defenders.y = geom.penaltySpot.y + STRIPE/2 - STRIPE*7;
     defenders.baseY = defenders.y;
   }
 


### PR DESCRIPTION
## Summary
- position defenders higher on the field and shrink their size

## Testing
- `npm test`
- `npm run lint` (fails: 958 errors in unrelated files)

------
https://chatgpt.com/codex/tasks/task_e_68b2dd454a7083298f3e201031d1435b