### PR TITLE
Improve defender behavior in Free Kick game

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -207,8 +207,8 @@
     keeper.y = geom.goal.y + geom.goal.h - keeper.h + geom.goal.h*0.05;
     keeper.baseY = keeper.y;
     keeper.baseX = keeper.x;
-    defenders.w = keeper.w * 2.7;
-    defenders.h = keeper.h * 2.3;
+    defenders.w = keeper.w * 2.8;
+    defenders.h = keeper.h * 2.1;
     defenders.x = (W - defenders.w)/2;
     defenders.y = geom.penaltySpot.y + STRIPE/2 - STRIPE*7.5;
     defenders.baseY = defenders.y;
@@ -275,9 +275,11 @@
     const left = d.x, right = d.x + d.w;
     const top = d.y, bottom = d.y + d.h;
     if(ball.x + ball.r < left || ball.x - ball.r > right || ball.y + ball.r < top || ball.y - ball.r > bottom) return null;
-    const centerX = d.x + d.w/2;
-    const nx = ball.x < centerX ? -0.3 : 0.3;
-    return { nx };
+    const centerX = d.x + d.w / 2;
+    const nx = ball.x < centerX ? -0.6 : 0.6;
+    let ny = 0;
+    if(ball.y - ball.r < top + d.h * 0.25) ny = -1;
+    return { nx, ny };
   }
   function ballScale(y){
     const g=geom.goal;
@@ -637,8 +639,12 @@
     const dHit = ballHitsDefenders();
     if(dHit){
       ball.trailStopped = true;
-      reflectBall(dHit.nx,1,0.7);
-      ball.y = defenders.y + defenders.h + ball.r;
+      reflectBall(dHit.nx, dHit.ny, 0.7);
+      if(dHit.ny < 0){
+        ball.y = defenders.y - ball.r;
+      } else {
+        ball.x = dHit.nx < 0 ? defenders.x - ball.r : defenders.x + defenders.w + ball.r;
+      }
       missFlash = 1;
       return;
     }
@@ -988,7 +994,7 @@ function onUp(e){
 
   // ===== Timer + loop =====
   function tick(now){ if(!running||paused) return; if(!roundStart) roundStart=now; timeLeft = Math.max(0, ROUND_TIME - (now - roundStart)); timeShort.textContent = Math.ceil(timeLeft/1000); if(timeLeft<=0){ finish(); } }
-function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoal(); drawDefenders(); drawBall(); drawPunchEffects(); stepBall(); stepLooseBalls(); stepFragments(); stepDefenders(); stepKeeper(); drawMiniBoards(); tick(now||performance.now()); stepRivals(now||performance.now()); updateHUD(); netHit.t*=NET_DECAY; netHit.shake*=NET_DECAY; goalFlash*=0.92; missFlash*=0.92; }
+function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoal(); drawBall(); drawDefenders(); drawPunchEffects(); stepBall(); stepLooseBalls(); stepFragments(); stepDefenders(); stepKeeper(); drawMiniBoards(); tick(now||performance.now()); stepRivals(now||performance.now()); updateHUD(); netHit.t*=NET_DECAY; netHit.shake*=NET_DECAY; goalFlash*=0.92; missFlash*=0.92; }
 
   // ===== Controls =====
   // controls removed
@@ -1173,7 +1179,7 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
   function vibrate(ms){ if(navigator.vibrate) try{ navigator.vibrate(ms); }catch{} }
 
   // ===== Static draw & tests =====
-function drawStaticOnce(){ drawField(); drawAds(); drawGoal(); resetBall(); drawDefenders(); drawBall(); drawMiniBoards(true); }
+function drawStaticOnce(){ drawField(); drawAds(); drawGoal(); resetBall(); drawBall(); drawDefenders(); drawMiniBoards(true); }
 
   // ===== Boot =====
   function startCountdown(n){


### PR DESCRIPTION
## Summary
- Widened and shortened defenders to better match wall proportions
- Updated defender collision logic so balls deflect sideways or upward instead of dropping straight down
- Render defenders after the ball so scored shots don't overlap the wall

## Testing
- `npm test`
- `npm run lint` *(fails: 958 problems, existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ea5d92cc832983ccc272362ed714