### PR TITLE
feat: cheer when potting balls

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -2064,20 +2064,19 @@
               setTimeout(showTurnInfo, 1500);
             }
           }
-          if (!foul && pottedThisShot.length >= 2) {
-            var vol = 0.7;
-            var firstType = BALL_BY_N[pottedThisShot[0]].t;
-            var sameColor = pottedThisShot.every(function (n) {
-              return BALL_BY_N[n].t === firstType;
-            });
-            if (sameColor) vol *= 1.3;
-            if (lastCueStart && lastShotAim) {
-              var dxShot = lastShotAim.x - lastCueStart.x;
-              var dyShot = lastShotAim.y - lastCueStart.y;
-              if (Math.hypot(dxShot, dyShot) > TABLE_H * 0.5) vol *= 1.3;
+          if (!foul) {
+            var pottedCount = pottedThisShot.length + (eightBallPotted ? 1 : 0);
+            if (pottedCount >= 1) {
+              var vol = 0.7;
+              if (pottedCount >= 2) vol *= 1.3;
+              if (lastCueStart && lastShotAim) {
+                var dxShot = lastShotAim.x - lastCueStart.x;
+                var dyShot = lastShotAim.y - lastCueStart.y;
+                if (Math.hypot(dxShot, dyShot) > TABLE_H * 0.5) vol *= 1.3;
+              }
+              if (cueHitCushion) vol *= 1.5;
+              playCheer(vol);
             }
-            if (cueHitCushion) vol *= 1.5;
-            playCheer(vol);
           }
           if (lastShotAim && lastPocketCenter) {
             var dx = lastPocketCenter.x - lastShotAim.x;


### PR DESCRIPTION
## Summary
- play crowd cheering sound on any successful pot
- scale volume for multiple pots, long shots, and cushion assists

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2ec414e688329802575ebf9b8bcfa