### PR TITLE
Update Pool Royale sound effects and volumes

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -794,7 +794,7 @@
             hitBuffer = buf;
           });
 
-        fetch('/assets/sounds/billiard-sound-05-288416.mp3')
+        fetch(encodeURI('/assets/sounds/billiard-sound newhit.mp3'))
           .then(function (r) {
             return r.arrayBuffer();
           })
@@ -875,7 +875,7 @@
           var src = audioCtx.createBufferSource();
           src.buffer = ballHitBuffer;
           var gain = audioCtx.createGain();
-          gain.gain.value = clamp(vol, 0, 1);
+          gain.gain.value = clamp(vol * 0.6, 0, 1);
           src.connect(gain).connect(audioCtx.destination);
           src.start(0);
         }
@@ -886,7 +886,7 @@
           var src = audioCtx.createBufferSource();
           src.buffer = pocketBuffer;
           var gain = audioCtx.createGain();
-          gain.gain.value = clamp(vol, 0, 1);
+          gain.gain.value = clamp(vol * 0.8, 0, 1);
           src.connect(gain).connect(audioCtx.destination);
           var d = pocketBuffer.duration;
           src.start(0, Math.max(0, d - 1), 1);


### PR DESCRIPTION
## Summary
- use new `billiard-sound newhit.mp3` asset for ball collisions
- reduce ball and pocket audio volumes for better balance

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, prefer-const, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ff4e8c6483299b7053ddf1efc554