### PR TITLE
Fix Free Kick ball bouncing at goal posts

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -653,13 +653,17 @@
     if(soundX - ball.r <= g.x && soundY > g.y - postR && soundY < g.y + g.h + postR && ball.vx < 0){
       sfxPost();
       ball.trailStopped = true;
-      ball.x = nextX; ball.y = nextY;
+      reflectBall(1,0,0.85);
+      ball.x = g.x + ball.r;
+      ball.y = nextY;
       return;
     }
     if(soundX + ball.r >= g.x + g.w && soundY > g.y - postR && soundY < g.y + g.h + postR && ball.vx > 0){
       sfxPost();
       ball.trailStopped = true;
-      ball.x = nextX; ball.y = nextY;
+      reflectBall(1,0,0.85);
+      ball.x = g.x + g.w - ball.r;
+      ball.y = nextY;
       return;
     }
     if(soundY - ball.r <= g.y && soundX > g.x - postR && soundX < g.x + g.w + postR && ball.vy < 0){


### PR DESCRIPTION
## Summary
- make Free Kick ball bounce off posts instead of sticking

## Testing
- `npm test` *(fails: Failed to store game result: Operation gameresults.insertOne() buffering timed out after 10000ms)*
- `npm run lint` *(fails: 958 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3057f6c4c83299f976a59f26d3d84