### PR TITLE
fix: update pool royale gameplay

### DIFF
--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -138,7 +138,14 @@ export class UkPool {
       // can only pot black if own group cleared
       const ownSet = ownGroup ? s.ballsOnTable[ownGroup] : null;
       const hasOwn = ownSet && ownSet.size > 0;
-      if (hasOwn || s.isOpenTable) {
+      // On an open table, potting the black is only a foul if both
+      // colours remain. If one set is already cleared we implicitly
+      // treat the remaining colour as the player's group.
+      const openIllegal =
+        s.isOpenTable &&
+        s.ballsOnTable.yellow.size > 0 &&
+        s.ballsOnTable.red.size > 0;
+      if (hasOwn || openIllegal) {
         foul = true;
         reason = 'potted black early';
       }

--- a/test/poolUk8Ball.test.js
+++ b/test/poolUk8Ball.test.js
@@ -145,6 +145,22 @@ test('potting 8-ball legally after clearing group wins', () => {
   assert.equal(res.winner, 'A');
 });
 
+test('potting black when one colour cleared on open table is legal', () => {
+  const game = new UkPool();
+  game.state.ballsOnTable.yellow.clear();
+  game.state.isOpenTable = true;
+  const res = game.shotTaken({
+    contactOrder: ['black'],
+    potted: ['black'],
+    cueOffTable: false,
+    noCushionAfterContact: false,
+    placedFromHand: false
+  });
+  assert.equal(res.foul, false);
+  assert.equal(res.frameOver, true);
+  assert.equal(res.winner, 'A');
+});
+
 test('after foul cue must be played from baulk', () => {
   const game = new UkPool();
   game.shotTaken({

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1544,6 +1544,16 @@
               : Infinity;
             var nearPocket = nearest && newDist < nearest.r + BALL_R + 2;
             var approaching = nearest && newDist < prevDist;
+            if (
+              nearPocket &&
+              !approaching &&
+              (b === firstHit || (!firstHit && b.n === 0)) &&
+              !nearPocketEdgeHit &&
+              !pocketedAny
+            ) {
+              nearPocketEdgeHit = true;
+              playShock(1);
+            }
             if (!nearPocket || !approaching) {
               if (b.p.x < L) {
                 b.p.x = L;
@@ -1636,6 +1646,7 @@
                 d = Math.hypot(dx, dy);
               if (d < BALL_R * 2) {
                 var pairId = i + '-' + j;
+                var firstPairCollision = !newCollisions.has(pairId);
                 newCollisions.add(pairId);
                 var nx = dx / (d || 1),
                   ny = dy / (d || 1),
@@ -1657,10 +1668,14 @@
                   a.v.y *= BOUNCE;
                   bb.v.x *= BOUNCE;
                   bb.v.y *= BOUNCE;
-                    if (!this.prevCollisions.has(pairId)) {
+                    if (
+                      firstPairCollision &&
+                      !this.prevCollisions.has(pairId)
+                    ) {
                       // Scale collision volume by both impact impulse and the
                       // power of the shot that initiated the turn.
-                      var vol = clamp(imp / 4000, 0, 1) * lastShotPower * 0.5;
+                      var vol =
+                        clamp(imp / 4000, 0, 1) * lastShotPower * 0.5;
                       playBallHit(vol);
                     }
                   if (a.n === 0 || bb.n === 0) {
@@ -2172,7 +2187,7 @@
           function startTurnTimer() {
             clearTurnTimer();
             if (table.turn !== 1) return;
-            countdownRemaining = 15;
+            countdownRemaining = 30;
             if (timerDisplay) {
               timerDisplay.style.color = '#facc15';
               timerDisplay.textContent = countdownRemaining;
@@ -2187,14 +2202,14 @@
             }, 1000);
             warnTimer = setTimeout(function () {
               playTurnSound();
-            }, 10000);
+            }, 25000);
             turnTimer = setTimeout(function () {
               updateFooter(2, "Time's up! Turn passes to the opponent.");
               table.turn = 2;
               updateTurnIndicator(true);
               showTurnInfo();
               cpuTurn();
-            }, 15000);
+            }, 30000);
           }
 
           function startCpuTimer() {


### PR DESCRIPTION
## Summary
- allow legal black 8 pot when one colour cleared on open table
- extend turn timer to 30 seconds and improve near-pocket sounds
- prevent duplicate collision audio for ball hits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b325b6917483299dd4713b5e318139