### PR TITLE
Fix spin behavior and equalize collision volume

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1517,12 +1517,6 @@
             b.p.y += b.v.y * dt;
             b.v.x *= FRICTION;
             b.v.y *= FRICTION;
-            if (b.spin && b.spinApplied) {
-              b.v.x += b.spin.x * 58.5 * dt;
-              b.v.y += b.spin.y * 58.5 * dt;
-              b.spin.x *= 0.98;
-              b.spin.y *= 0.98;
-            }
             b.a += (Math.hypot(b.v.x, b.v.y) * dt) / (BALL_R * 0.6);
 
             var L = BORDER + BALL_R;
@@ -1560,7 +1554,7 @@
                 var sx = Math.abs(b.v.x);
                 b.v.x *= -BOUNCE;
                 if (b.n === 0) b.spinApplied = true;
-                playCueHit(clamp(sx / 4000, 0, 1) * 0.5);
+                playCueHit(0.5);
                 if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
                 var diffY = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
                 if (
@@ -1578,7 +1572,7 @@
                 var sx2 = Math.abs(b.v.x);
                 b.v.x *= -BOUNCE;
                 if (b.n === 0) b.spinApplied = true;
-                playCueHit(clamp(sx2 / 4000, 0, 1) * 0.5);
+                playCueHit(0.5);
                 if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
                 var diffY2 = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
                 if (
@@ -1596,7 +1590,7 @@
                 var sy = Math.abs(b.v.y);
                 b.v.y *= -BOUNCE;
                 if (b.n === 0) b.spinApplied = true;
-                playCueHit(clamp(sy / 4000, 0, 1) * 0.5);
+                playCueHit(0.5);
                 if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
                 var diffX = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
                 if (
@@ -1614,7 +1608,7 @@
                 var sy2 = Math.abs(b.v.y);
                 b.v.y *= -BOUNCE;
                 if (b.n === 0) b.spinApplied = true;
-                playCueHit(clamp(sy2 / 4000, 0, 1) * 0.5);
+                playCueHit(0.5);
                 if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
                 var diffX2 = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
                 if (
@@ -1668,11 +1662,8 @@
                       firstPairCollision &&
                       !this.prevCollisions.has(pairId)
                     ) {
-                      // Scale collision volume by both impact impulse and the
-                      // power of the shot that initiated the turn.
-                      var vol =
-                        clamp(imp / 4000, 0, 1) * lastShotPower * 0.5;
-                      playBallHit(vol);
+                      // Play collision sound at a constant volume.
+                      playBallHit(0.5);
                     }
                   if (a.n === 0 || bb.n === 0) {
                     var other = a.n === 0 ? bb : a;
@@ -1706,6 +1697,18 @@
                 }
               }
             }
+
+          // Apply spin to balls after resolving collisions
+          for (i = 0; i < this.balls.length; i++) {
+            var sb = this.balls[i];
+            if (sb.pocketed) continue;
+            if (sb.spin && sb.spinApplied) {
+              sb.v.x += sb.spin.x * 58.5 * dt;
+              sb.v.y += sb.spin.y * 58.5 * dt;
+              sb.spin.x *= 0.98;
+              sb.spin.y *= 0.98;
+            }
+          }
 
           // Kontroll i gropave
           for (i = 0; i < this.pockets.length; i++) {
@@ -2977,7 +2980,7 @@
           var base = 950 * 3 * 1.6 * 1.5;
           // Reduce the overall shot power by 50%
           base *= 0.5;
-            playCueHit(p * 0.5);
+            playCueHit(0.5);
             lastShotPower = p;
             currentShooter = table.turn;
             if (isNineBall || isAmerican)


### PR DESCRIPTION
## Summary
- Play cue and ball collision sounds at a constant volume
- Apply cue ball spin only after it contacts a cushion or another ball

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b33a354d90832994e0aeeb7ccbd87a