### PR TITLE
Fix ball sticking in goal corners for Free Kick game

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -654,9 +654,14 @@
       triggerNetHit(nextX, nextY);
       sfxPost();
       reflectBall(1,0,0.85);
+      if(nextY - ball.r <= g.y && ball.vy < 0){
+        ball.vy *= -1;
+        ball.y = g.y + ball.r + 1;
+      } else {
+        ball.y = nextY;
+      }
       ball.spin *= -0.5;
       ball.x = g.x + ball.r + 1;
-      ball.y = nextY;
       ball.path = null;
       ball.pathIndex = 0;
       ball.pathSpeed = 0;
@@ -666,9 +671,14 @@
       triggerNetHit(nextX, nextY);
       sfxPost();
       reflectBall(-1,0,0.85);
+      if(nextY - ball.r <= g.y && ball.vy < 0){
+        ball.vy *= -1;
+        ball.y = g.y + ball.r + 1;
+      } else {
+        ball.y = nextY;
+      }
       ball.spin *= -0.5;
       ball.x = g.x + g.w - ball.r - 1;
-      ball.y = nextY;
       ball.path = null;
       ball.pathIndex = 0;
       ball.pathSpeed = 0;
@@ -679,9 +689,17 @@
       sfxPost();
       if(!ball.goalSounded){ playGoalSound(); ball.goalSounded = true; }
       reflectBall(0,1,0.85);
+      if(nextX - ball.r <= g.x && ball.vx < 0){
+        ball.vx *= -1;
+        ball.x = g.x + ball.r + 1;
+      } else if(nextX + ball.r >= g.x + g.w && ball.vx > 0){
+        ball.vx *= -1;
+        ball.x = g.x + g.w - ball.r - 1;
+      } else {
+        ball.x = nextX;
+      }
       ball.spin *= 0.5;
       ball.y = g.y + ball.r + 1;
-      ball.x = nextX;
       ball.path = null;
       ball.pathIndex = 0;
       ball.pathSpeed = 0;


### PR DESCRIPTION
## Summary
- adjust collision handling for goal posts and crossbar to prevent ball from getting stuck in corners
- nudge ball away from posts when it hits top corners so it continues downward

## Testing
- `npm test`
- `npm run lint` *(fails: 959 errors, existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b33e9db0848329b9c18cba5cb5a1fc