### PR TITLE
Add basic Pool Royale demo with spin control and volume adjustment

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -3,12 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>SVG Billiards Pocket Nets Overlay</title>
+    <title>Pool Royale Demo</title>
     <style>
       :root {
-        /* Tweakables */
-        --pocket-r: 54; /* rim radius in px at 1000px width */
-        --net-depth: 56; /* how far the net funnels inward */
+        --pocket-r: 54;
+        --net-depth: 56;
       }
       body {
         margin: 0;
@@ -20,7 +19,7 @@
       .stage {
         position: relative;
         max-width: min(92vw, 760px);
-        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+        box-shadow: 0 20px 60px rgba(0,0,0,0.35);
         border-radius: 12px;
         overflow: hidden;
       }
@@ -47,29 +46,71 @@
         transform: translate(-50%, -100%) rotate(0);
         pointer-events: none;
       }
+      .ball {
+        position: absolute;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        background: #fff;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      }
+      .target-ball {
+        background: #f33;
+      }
+      .spin-dot {
+        position: absolute;
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: #000;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        pointer-events: none;
+      }
+      #spin-controller {
+        position: absolute;
+        bottom: 10px;
+        right: 10px;
+        width: 60px;
+        height: 60px;
+        border-radius: 50%;
+        background: rgba(255,255,255,0.25);
+        cursor: crosshair;
+      }
+      #spin-controller .spin-dot {
+        pointer-events: none;
+      }
+      #controls {
+        position: absolute;
+        bottom: 10px;
+        left: 10px;
+        color: #fff;
+        font-family: sans-serif;
+      }
+      #controls input[type="range"] {
+        width: 120px;
+      }
     </style>
   </head>
   <body>
     <div class="stage">
-      <!-- Embedded green table background as inline SVG to keep this file standalone -->
       <img
         class="bg"
         src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAwIDE1MDAiPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9IiMwMDgwMDAiLz48L3N2Zz4="
         alt="Pool table"
       />
-      <!-- Color-coded overlay showing field, edges and pockets -->
       <svg class="overlay" viewBox="0 0 1000 1500">
-        <!-- Playing field -->
         <rect x="80" y="80" width="840" height="1340"
           fill="rgba(0,255,0,0.15)"
           stroke="rgba(0,255,0,0.9)"
           stroke-width="20" />
-        <!-- Table edges -->
         <rect x="20" y="20" width="960" height="1460"
           fill="none"
           stroke="rgba(255,0,0,0.7)"
           stroke-width="40" />
-        <!-- Pockets -->
         <circle cx="40" cy="40" r="40" fill="rgba(0,0,255,0.9)" />
         <circle cx="960" cy="40" r="40" fill="rgba(255,0,255,0.9)" />
         <circle cx="40" cy="750" r="40" fill="rgba(255,255,0,0.9)" />
@@ -78,21 +119,123 @@
         <circle cx="960" cy="1460" r="40" fill="rgba(255,128,0,0.9)" />
       </svg>
       <div id="aim-line" class="aim-line"></div>
+      <div id="cue-ball" class="ball">
+        <div id="cue-spin-dot" class="spin-dot"></div>
+      </div>
+      <div id="target-ball" class="ball target-ball"></div>
+      <div id="controls">
+        <input id="power" type="range" min="0" max="100" value="40" />
+        <button id="shoot">Shoot</button>
+      </div>
+      <div id="spin-controller">
+        <div id="spin-controller-dot" class="spin-dot"></div>
+      </div>
     </div>
     <script>
       const stage = document.querySelector('.stage');
       const aimLine = document.getElementById('aim-line');
+      const cueBall = document.getElementById('cue-ball');
+      const targetBall = document.getElementById('target-ball');
+      const powerInput = document.getElementById('power');
+      const shootBtn = document.getElementById('shoot');
+      const spinController = document.getElementById('spin-controller');
+      const spinControllerDot = document.getElementById('spin-controller-dot');
+      const cueSpinDot = document.getElementById('cue-spin-dot');
+
+      let shotDir = { x: 0, y: -1 };
+      let shotLength = 0;
+      let spin = { x: 0, y: 0 };
+
+      const rect = stage.getBoundingClientRect();
+      const center = { x: rect.width / 2, y: rect.height / 2 };
+
+      cueBall.style.left = `${center.x}px`;
+      cueBall.style.top = `${center.y}px`;
+      targetBall.style.left = `${center.x}px`;
+      targetBall.style.top = `${center.y}px`;
+
       stage.addEventListener('click', (e) => {
-        const rect = stage.getBoundingClientRect();
-        const cx = rect.left + rect.width / 2;
-        const cy = rect.top + rect.height / 2;
+        const r = stage.getBoundingClientRect();
+        const cx = r.left + r.width / 2;
+        const cy = r.top + r.height / 2;
         const dx = e.clientX - cx;
         const dy = e.clientY - cy;
         const angle = (Math.atan2(dy, dx) * 180) / Math.PI + 90;
         const length = Math.hypot(dx, dy);
+        shotDir = { x: dx / length, y: dy / length };
+        shotLength = length;
         aimLine.style.height = `${length}px`;
         aimLine.style.transform = `translate(-50%,-100%) rotate(${angle}deg)`;
+
+        const tbx = center.x + shotDir.x * 200;
+        const tby = center.y + shotDir.y * 200;
+        targetBall.style.left = `${tbx}px`;
+        targetBall.style.top = `${tby}px`;
       });
+
+      spinController.addEventListener('click', (e) => {
+        const r = spinController.getBoundingClientRect();
+        const cx = r.width / 2;
+        const cy = r.height / 2;
+        const dx = e.clientX - r.left - cx;
+        const dy = e.clientY - r.top - cy;
+        const nx = Math.max(Math.min(dx / cx, 1), -1);
+        const ny = Math.max(Math.min(dy / cy, 1), -1);
+        spin = { x: nx, y: ny };
+        const translate = (sx, sy) => `translate(${sx * 50 - 50}%, ${sy * 50 - 50}%)`;
+        spinControllerDot.style.transform = translate(nx, ny);
+        cueSpinDot.style.transform = translate(nx, ny);
+      });
+
+      function playHit(power) {
+        const ctx = new (window.AudioContext || window.webkitAudioContext)();
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.frequency.value = 400;
+        gain.gain.value = power > 0.4 ? 0.3 : 0.8;
+        osc.connect(gain).connect(ctx.destination);
+        osc.start();
+        osc.stop(ctx.currentTime + 0.1);
+      }
+
+      function shoot() {
+        const power = Number(powerInput.value) / 100;
+        playHit(power);
+        const speed = 4 + power * 8;
+        let cuePos = { x: center.x, y: center.y };
+        let targetPos = {
+          x: parseFloat(targetBall.style.left),
+          y: parseFloat(targetBall.style.top)
+        };
+        let collided = false;
+        let targetTravel = 0;
+
+        function frame() {
+          if (!collided) {
+            cuePos.x += shotDir.x * speed;
+            cuePos.y += shotDir.y * speed;
+            cueBall.style.left = `${cuePos.x}px`;
+            cueBall.style.top = `${cuePos.y}px`;
+            const dx = cuePos.x - targetPos.x;
+            const dy = cuePos.y - targetPos.y;
+            if (Math.hypot(dx, dy) <= 40) {
+              collided = true;
+            }
+          } else if (targetTravel < 200) {
+            targetPos.x += shotDir.x * speed;
+            targetPos.y += shotDir.y * speed;
+            targetBall.style.left = `${targetPos.x}px`;
+            targetBall.style.top = `${targetPos.y}px`;
+            targetTravel += speed;
+          } else {
+            return;
+          }
+          requestAnimationFrame(frame);
+        }
+        requestAnimationFrame(frame);
+      }
+
+      shootBtn.addEventListener('click', shoot);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- build Pool Royale example showing aiming line, spin control, and cue/target balls
- lower hit sound volume when shot power exceeds 40%
- animate cue and target balls along the aiming line for accurate direction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b344760e788329be2f4a0f30740d03