### PR TITLE
Refine pool collision audio and UK 8-ball AI

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -106,12 +106,17 @@ function nextTargetsAfter (targetId, req) {
     const solids = cloned.filter(b => b.id >= 1 && b.id <= 7)
     const stripes = cloned.filter(b => b.id >= 9 && b.id <= 15)
     const eight = cloned.find(b => b.id === 8)
-    if (req.state.myGroup === 'SOLIDS') {
+    let group = req.state.myGroup
+    if (!group || group === 'UNASSIGNED') {
+      if (targetId >= 1 && targetId <= 7) group = 'SOLIDS'
+      else if (targetId >= 9 && targetId <= 15) group = 'STRIPES'
+    }
+    if (group === 'SOLIDS') {
       if (solids.length > 0) return solids
       if (eight) return [eight]
       return []
     }
-    if (req.state.myGroup === 'STRIPES') {
+    if (group === 'STRIPES') {
       if (stripes.length > 0) return stripes
       if (eight) return [eight]
       return []

--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -96,7 +96,11 @@ export class UkPool {
     // first contact legality
     if (!foul) {
       if (s.isOpenTable) {
-        if (first !== 'yellow' && first !== 'red') {
+        const bothColours =
+          s.ballsOnTable.yellow.size > 0 && s.ballsOnTable.red.size > 0;
+        if (first === 'black' && !bothColours) {
+          // allowed: one colour already cleared
+        } else if (first !== 'yellow' && first !== 'red') {
           foul = true;
           reason = 'wrong first contact';
         }

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1557,10 +1557,8 @@
             if (!nearPocket || !approaching) {
               if (b.p.x < L) {
                 b.p.x = L;
-                var sx = Math.abs(b.v.x);
                 b.v.x *= -BOUNCE;
                 if (b.n === 0) b.spinApplied = true;
-                playCueHit(clamp(sx / 4000, 0, 1) * 0.5);
                 if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
                 var diffY = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
                 if (
@@ -1575,10 +1573,8 @@
               }
               if (b.p.x > R) {
                 b.p.x = R;
-                var sx2 = Math.abs(b.v.x);
                 b.v.x *= -BOUNCE;
                 if (b.n === 0) b.spinApplied = true;
-                playCueHit(clamp(sx2 / 4000, 0, 1) * 0.5);
                 if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
                 var diffY2 = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
                 if (
@@ -1593,10 +1589,8 @@
               }
               if (b.p.y < T) {
                 b.p.y = T;
-                var sy = Math.abs(b.v.y);
                 b.v.y *= -BOUNCE;
                 if (b.n === 0) b.spinApplied = true;
-                playCueHit(clamp(sy / 4000, 0, 1) * 0.5);
                 if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
                 var diffX = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
                 if (
@@ -1611,10 +1605,8 @@
               }
               if (b.p.y > B) {
                 b.p.y = B;
-                var sy2 = Math.abs(b.v.y);
                 b.v.y *= -BOUNCE;
                 if (b.n === 0) b.spinApplied = true;
-                playCueHit(clamp(sy2 / 4000, 0, 1) * 0.5);
                 if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
                 var diffX2 = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
                 if (
@@ -1671,7 +1663,7 @@
                       // Scale collision volume by both impact impulse and the
                       // power of the shot that initiated the turn.
                       var vol =
-                        clamp(imp / 4000, 0, 1) * lastShotPower * 0.5;
+                        clamp(imp / 4000, 0, 1) * Math.min(lastShotPower, 0.39) * 0.5;
                       playBallHit(vol);
                     }
                   if (a.n === 0 || bb.n === 0) {


### PR DESCRIPTION
## Summary
- cap ball-on-ball collision volume at 39% and remove cushion impact sounds
- update target selection to respect assigned groups in UK 8-ball
- allow black ball first contact when one colour cleared on open table

## Testing
- `npm test -- test/poolAi.test.js test/poolUkAdvancedAi.test.js test/poolUk8Ball.test.js`
- `npm run lint` *(fails: numerous pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b35763ee248329858c1fb1529ad678