### PR TITLE
Add adaptive aiming engine with strategies and tests

### DIFF
--- a/Assets/Editor/AimingConfigCreator.cs
+++ b/Assets/Editor/AimingConfigCreator.cs
@@ -1,0 +1,18 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Aiming.EditorTools
+{
+    public static class AimingConfigCreator
+    {
+        [MenuItem("Aiming/Create Default Config")]
+        public static void CreateAsset()
+        {
+            var asset = ScriptableObject.CreateInstance<Aiming.AimingConfig>();
+            AssetDatabase.CreateAsset(asset, "Assets/Resources/AimingConfig.asset");
+            AssetDatabase.SaveAssets();
+            EditorUtility.FocusProjectWindow();
+            Selection.activeObject = asset;
+        }
+    }
+}

--- a/Assets/Resources/AimingConfig.asset
+++ b/Assets/Resources/AimingConfig.asset
@@ -1,0 +1,26 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 3}
+  m_Name: AimingConfig
+  m_EditorClassIdentifier: 
+  straightAngleDeg: 5
+  ctePivotDeg: 3
+  shortDist: 0.8
+  mediumDist: 1.6
+  sideSpinAmount: 0.35
+  verticalSpinAmount: 0.35
+  tipOffsetMax: 0.85
+  elevationForPower: 4
+  showDebugDefault: 1
+  lineColor: {r: 0.1, g: 0.9, b: 0.9, a: 0.9}
+  lineWidth: 0.01
+  collisionMask: 0

--- a/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
+++ b/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
@@ -1,0 +1,136 @@
+using UnityEngine;
+using System.Runtime.CompilerServices;
+
+namespace Aiming
+{
+    public struct ShotContext
+    {
+        public Vector3 cueBallPos, objectBallPos;
+        public Vector3 pocketPos;
+        public float ballRadius;
+        public Bounds tableBounds;
+        public bool requiresPower;
+        public bool highSpin;
+        public LayerMask collisionMask;
+    }
+
+    public struct AimSolution
+    {
+        public bool isValid;
+        public string strategyUsed;
+        public Vector3 aimStart;
+        public Vector3 aimEnd;
+        public float recommendedPower01;
+        public Vector2 tipOffset;
+        public float cueElevationDeg;
+        public string debugNote;
+    }
+
+    [DisallowMultipleComponent]
+    public class AdaptiveAimingEngine : MonoBehaviour
+    {
+        public AimingConfig config;
+        public bool showDebug = true;
+
+        LineRenderer lr;
+        IAimingStrategy ghost, contact, fractional, cte;
+        ShotClassifier classifier;
+        AimingDebugOverlay overlay;
+
+        void Awake()
+        {
+            if (config == null) config = Resources.Load<AimingConfig>("AimingConfig");
+            ghost = new Strategies.GhostBallStrategy();
+            contact = new Strategies.ContactPointStrategy();
+            fractional = new Strategies.FractionalStrategy();
+            cte = new Strategies.CTEApproxStrategy();
+            classifier = new ShotClassifier();
+            overlay = GetComponent<AimingDebugOverlay>();
+            if (overlay == null) overlay = gameObject.AddComponent<AimingDebugOverlay>();
+            overlay.Init(config);
+            showDebug = config ? config.showDebugDefault : showDebug;
+            lr = GetComponent<LineRenderer>();
+            if (lr == null)
+            {
+                lr = gameObject.AddComponent<LineRenderer>();
+                lr.positionCount = 2;
+                lr.material = new Material(Shader.Find("Sprites/Default"));
+                lr.widthMultiplier = config ? config.lineWidth : 0.01f;
+                lr.startColor = lr.endColor = config ? config.lineColor : Color.cyan;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public AimSolution GetAimSolution(in ShotContext ctx)
+        {
+            var info = classifier.Classify(ctx, config);
+            if (!info.losCueToObj || !info.losObjToPocket)
+            {
+                return new AimSolution
+                {
+                    isValid = false,
+                    strategyUsed = "None",
+                    aimStart = ctx.cueBallPos,
+                    aimEnd = ctx.objectBallPos,
+                    recommendedPower01 = 0f,
+                    tipOffset = Vector2.zero,
+                    cueElevationDeg = 0f,
+                    debugNote = !info.losCueToObj ? "Blocked: cue→object" : "Blocked: object→pocket"
+                };
+            }
+
+            IAimingStrategy strat;
+            if (info.isStraight)
+            {
+                strat = ghost;
+            }
+            else if (info.isRailShot || info.angleDeg < 30f)
+            {
+                strat = contact;
+            }
+            else if (info.angleDeg <= 45f)
+            {
+                bool longOrSpin = (info.distBucket == ShotClassifier.DistBucket.Long) || ctx.highSpin;
+                strat = longOrSpin ? cte : ghost;
+            }
+            else
+            {
+                strat = fractional;
+            }
+            if ((ctx.requiresPower || ctx.highSpin) && info.distBucket != ShotClassifier.DistBucket.Short) strat = cte;
+
+            var sol = strat.Solve(ctx, info, config);
+            sol.recommendedPower01 = RecommendPower(info.distBucket, ctx.requiresPower);
+            if (ctx.highSpin)
+            {
+                float side = Mathf.Sign(Vector3.Cross(info.vOP, info.vOC).y) * config.sideSpinAmount;
+                float vert = config.verticalSpinAmount * (ctx.requiresPower ? 1f : 0.7f);
+                sol.tipOffset = new Vector2(Mathf.Clamp(side, -config.tipOffsetMax, config.tipOffsetMax),
+                    Mathf.Clamp(vert, -config.tipOffsetMax, config.tipOffsetMax));
+                sol.cueElevationDeg = (ctx.requiresPower && info.isRailShot) ? config.elevationForPower : 0f;
+            }
+            sol.strategyUsed = strat.Name;
+
+            if (showDebug)
+            {
+                lr.enabled = true;
+                lr.SetPosition(0, sol.aimStart);
+                lr.SetPosition(1, sol.aimEnd);
+                overlay.UpdateOverlay(ctx, info, sol);
+            }
+            else lr.enabled = false;
+
+            return sol;
+        }
+
+        float RecommendPower(ShotClassifier.DistBucket b, bool requiresPower)
+        {
+            switch (b)
+            {
+                case ShotClassifier.DistBucket.Short: return requiresPower ? 0.55f : 0.35f;
+                case ShotClassifier.DistBucket.Medium: return requiresPower ? 0.70f : 0.50f;
+                default: return requiresPower ? 0.90f : 0.70f;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Aiming/AimingConfig.cs
+++ b/Assets/Scripts/Aiming/AimingConfig.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+
+namespace Aiming
+{
+    [CreateAssetMenu(fileName = "AimingConfig", menuName = "Aiming/Config")]
+    public class AimingConfig : ScriptableObject
+    {
+        [Header("Angles (deg)")]
+        public float straightAngleDeg = 5f;
+        public float ctePivotDeg = 3f;
+
+        [Header("Distances (m)")]
+        public float shortDist = 0.8f;
+        public float mediumDist = 1.6f;
+
+        [Header("Spin")]
+        public float sideSpinAmount = 0.35f;
+        public float verticalSpinAmount = 0.35f;
+        public float tipOffsetMax = 0.85f;
+        public float elevationForPower = 4f;
+
+        [Header("Debug")]
+        public bool showDebugDefault = true;
+        public Color lineColor = new Color(0.1f, 0.9f, 0.9f, 0.9f);
+        public float lineWidth = 0.01f;
+
+        [Header("Physics")]
+        public LayerMask collisionMask;
+    }
+}

--- a/Assets/Scripts/Aiming/Debug/AimingDebugOverlay.cs
+++ b/Assets/Scripts/Aiming/Debug/AimingDebugOverlay.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Aiming
+{
+    [RequireComponent(typeof(LineRenderer))]
+    public class AimingDebugOverlay : MonoBehaviour
+    {
+        AimingConfig cfg;
+        ShotContext lastCtx;
+        ShotInfo lastInfo;
+        AimSolution lastSol;
+        bool hasData = false;
+
+        public void Init(AimingConfig config) { cfg = config; }
+
+        public void UpdateOverlay(in ShotContext ctx, in ShotInfo info, in AimSolution sol)
+        {
+            lastCtx = ctx;
+            lastInfo = info;
+            lastSol = sol;
+            hasData = true;
+        }
+
+        void OnDrawGizmos()
+        {
+            if (!hasData || cfg == null) return;
+            Gizmos.color = cfg.lineColor;
+            Gizmos.DrawSphere(lastSol.aimEnd, lastCtx.ballRadius * 0.3f);
+            Gizmos.DrawLine(lastCtx.objectBallPos, lastCtx.pocketPos);
+            Gizmos.DrawLine(lastCtx.cueBallPos, lastSol.aimEnd);
+#if UNITY_EDITOR
+            Handles.Label(lastSol.aimEnd + Vector3.up * 0.02f, $"{lastSol.strategyUsed}: {lastSol.debugNote}");
+#endif
+        }
+    }
+}

--- a/Assets/Scripts/Aiming/ShotClassifier.cs
+++ b/Assets/Scripts/Aiming/ShotClassifier.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+
+namespace Aiming
+{
+    public struct ShotInfo
+    {
+        public float angleDeg;
+        public bool isStraight;
+        public bool isRailShot;
+        public bool losCueToObj, losObjToPocket;
+        public ShotClassifier.DistBucket distBucket;
+        public Vector3 vOP;
+        public Vector3 vOC;
+    }
+
+    public class ShotClassifier
+    {
+        public enum DistBucket { Short, Medium, Long }
+
+        public ShotInfo Classify(in ShotContext ctx, AimingConfig cfg)
+        {
+            var vOP = (ctx.pocketPos - ctx.objectBallPos).normalized;
+            var vOC = (ctx.cueBallPos - ctx.objectBallPos).normalized;
+            float dot = Mathf.Clamp(Vector3.Dot(vOP, vOC), -1f, 1f);
+            float angle = Mathf.Acos(dot) * Mathf.Rad2Deg;
+            bool isStraight = angle <= cfg.straightAngleDeg;
+
+            float d = Vector3.Distance(ctx.cueBallPos, ctx.objectBallPos);
+            DistBucket bucket =
+                d <= cfg.shortDist ? DistBucket.Short :
+                (d <= cfg.mediumDist ? DistBucket.Medium : DistBucket.Long);
+
+            bool rail = MathUtil.ClosestRailDistance(ctx.tableBounds, ctx.objectBallPos) <= (ctx.ballRadius * 2f)
+                || MathUtil.ClosestRailDistance(ctx.tableBounds, ctx.pocketPos) <= (ctx.ballRadius * 2f);
+
+            bool losCO = PhysicsUtil.SphereLineClear(ctx.cueBallPos, ctx.objectBallPos, ctx.ballRadius * 0.98f, ctx.collisionMask);
+            bool losOP = PhysicsUtil.SphereLineClear(ctx.objectBallPos, ctx.pocketPos, ctx.ballRadius * 0.98f, ctx.collisionMask);
+
+            return new ShotInfo
+            {
+                angleDeg = angle,
+                isStraight = isStraight,
+                isRailShot = rail,
+                losCueToObj = losCO,
+                losObjToPocket = losOP,
+                distBucket = bucket,
+                vOP = vOP,
+                vOC = vOC
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Aiming/Strategies/CTEApproxStrategy.cs
+++ b/Assets/Scripts/Aiming/Strategies/CTEApproxStrategy.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace Aiming.Strategies
+{
+    public class CTEApproxStrategy : IAimingStrategy
+    {
+        public string Name => "CTEApprox";
+
+        public AimSolution Solve(in ShotContext ctx, in ShotInfo info, AimingConfig cfg)
+        {
+            Vector3 perp = MathUtil.OrthoAround(info.vOP, Vector3.up);
+            float side = Mathf.Sign(Vector3.Dot(perp, (ctx.cueBallPos - ctx.objectBallPos)));
+            Vector3 edge = ctx.objectBallPos + perp * side * ctx.ballRadius;
+
+            Quaternion pivot = Quaternion.AngleAxis(cfg.ctePivotDeg * side, Vector3.up);
+            Vector3 pivoted = ctx.objectBallPos + pivot * (edge - ctx.objectBallPos);
+
+            return new AimSolution
+            {
+                isValid = true,
+                strategyUsed = Name,
+                aimStart = ctx.cueBallPos,
+                aimEnd = pivoted,
+                recommendedPower01 = 0.7f,
+                tipOffset = Vector2.zero,
+                cueElevationDeg = 0f,
+                debugNote = "CTE approx with small pivot."
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Aiming/Strategies/ContactPointStrategy.cs
+++ b/Assets/Scripts/Aiming/Strategies/ContactPointStrategy.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+namespace Aiming.Strategies
+{
+    public class ContactPointStrategy : IAimingStrategy
+    {
+        public string Name => "ContactPoint";
+
+        public AimSolution Solve(in ShotContext ctx, in ShotInfo info, AimingConfig cfg)
+        {
+            Vector3 cpObj = ctx.objectBallPos - info.vOP * ctx.ballRadius;
+            return new AimSolution
+            {
+                isValid = true,
+                strategyUsed = Name,
+                aimStart = ctx.cueBallPos,
+                aimEnd = cpObj,
+                recommendedPower01 = 0.5f,
+                tipOffset = Vector2.zero,
+                cueElevationDeg = 0f,
+                debugNote = "Aim through object-ball contact point."
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Aiming/Strategies/FractionalStrategy.cs
+++ b/Assets/Scripts/Aiming/Strategies/FractionalStrategy.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+namespace Aiming.Strategies
+{
+    public class FractionalStrategy : IAimingStrategy
+    {
+        public string Name => "Fractional";
+
+        float MapAngleToFraction(float angle)
+        {
+            if (angle <= 30f) return 0.5f;
+            if (angle >= 60f) return 0.125f;
+            if (angle <= 48f)
+            {
+                float t = (angle - 30f) / 18f;
+                return Mathf.Lerp(0.5f, 0.25f, t);
+            }
+            else
+            {
+                float t = (angle - 48f) / 12f;
+                return Mathf.Lerp(0.25f, 0.125f, t);
+            }
+        }
+
+        public AimSolution Solve(in ShotContext ctx, in ShotInfo info, AimingConfig cfg)
+        {
+            float f = MapAngleToFraction(info.angleDeg);
+            Vector3 perp = MathUtil.OrthoAround(info.vOP, Vector3.up);
+            float sign = Mathf.Sign(Vector3.Dot(perp, (ctx.cueBallPos - ctx.objectBallPos)));
+            Vector3 cpRing = ctx.objectBallPos - info.vOP * ctx.ballRadius + (perp * sign * f * ctx.ballRadius);
+            return new AimSolution
+            {
+                isValid = true,
+                strategyUsed = Name,
+                aimStart = ctx.cueBallPos,
+                aimEnd = cpRing,
+                recommendedPower01 = 0.6f,
+                tipOffset = Vector2.zero,
+                cueElevationDeg = 0f,
+                debugNote = $"Fraction={f:0.###}"
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Aiming/Strategies/GhostBallStrategy.cs
+++ b/Assets/Scripts/Aiming/Strategies/GhostBallStrategy.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace Aiming.Strategies
+{
+    public class GhostBallStrategy : IAimingStrategy
+    {
+        public string Name => "GhostBall";
+
+        public AimSolution Solve(in ShotContext ctx, in ShotInfo info, AimingConfig cfg)
+        {
+            Vector3 cpObj = ctx.objectBallPos - info.vOP * ctx.ballRadius;
+            Vector3 toObj = (cpObj - ctx.objectBallPos).normalized;
+            Vector3 ghost = cpObj - toObj * (ctx.ballRadius * 2f);
+            return new AimSolution
+            {
+                isValid = true,
+                strategyUsed = Name,
+                aimStart = ctx.cueBallPos,
+                aimEnd = ghost,
+                recommendedPower01 = 0.5f,
+                tipOffset = Vector2.zero,
+                cueElevationDeg = 0f,
+                debugNote = "Ghost point computed."
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Aiming/Strategies/IAimingStrategy.cs
+++ b/Assets/Scripts/Aiming/Strategies/IAimingStrategy.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace Aiming
+{
+    public interface IAimingStrategy
+    {
+        string Name { get; }
+        AimSolution Solve(in ShotContext ctx, in ShotInfo info, AimingConfig cfg);
+    }
+}

--- a/Assets/Scripts/Common/MathUtil.cs
+++ b/Assets/Scripts/Common/MathUtil.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace Aiming
+{
+    public static class MathUtil
+    {
+        public static Vector3 Ortho(Vector3 v)
+        {
+            return new Vector3(-v.z, 0f, v.x).normalized;
+        }
+
+        public static Vector3 OrthoAround(Vector3 v, Vector3 up)
+        {
+            Vector3 proj = Vector3.ProjectOnPlane(v, up).normalized;
+            Vector3 o = Vector3.Cross(up, proj).normalized;
+            if (o.sqrMagnitude < 1e-6f) o = new Vector3(-proj.z, 0f, proj.x).normalized;
+            return o;
+        }
+
+        public static float ClosestRailDistance(Bounds table, Vector3 p)
+        {
+            float dx = Mathf.Min(Mathf.Abs(p.x - table.min.x), Mathf.Abs(table.max.x - p.x));
+            float dz = Mathf.Min(Mathf.Abs(p.z - table.min.z), Mathf.Abs(table.max.z - p.z));
+            return Mathf.Min(dx, dz);
+        }
+    }
+}

--- a/Assets/Scripts/Common/PhysicsUtil.cs
+++ b/Assets/Scripts/Common/PhysicsUtil.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Aiming
+{
+    public static class PhysicsUtil
+    {
+        public static bool SphereLineClear(Vector3 a, Vector3 b, float radius, LayerMask mask)
+        {
+            Vector3 dir = b - a;
+            float dist = dir.magnitude;
+            if (dist < 1e-4f) return true;
+            dir /= dist;
+            return !Physics.SphereCast(a, radius, dir, out _, dist, mask, QueryTriggerInteraction.Ignore);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+namespace Aiming
+{
+    public class CueController : MonoBehaviour
+    {
+        public AdaptiveAimingEngine aiming;
+        public Transform cueTip;
+        public Transform cueBall, objectBall, pocket;
+        public Bounds tableBounds;
+        public float ballRadius = 0.028575f;
+
+        void Update()
+        {
+            if (aiming == null || cueBall == null || objectBall == null || pocket == null) return;
+            ShotContext ctx = new ShotContext
+            {
+                cueBallPos = cueBall.position,
+                objectBallPos = objectBall.position,
+                pocketPos = pocket.position,
+                ballRadius = ballRadius,
+                tableBounds = tableBounds,
+                requiresPower = false,
+                highSpin = false,
+                collisionMask = aiming.config ? aiming.config.collisionMask : default
+            };
+            var sol = aiming.GetAimSolution(ctx);
+            if (sol.isValid && cueTip != null)
+            {
+                Vector3 dir = (sol.aimEnd - sol.aimStart);
+                if (dir.sqrMagnitude > 1e-6f)
+                {
+                    dir.Normalize();
+                    transform.position = sol.aimStart;
+                    transform.rotation = Quaternion.LookRotation(dir, Vector3.up);
+                    cueTip.position = sol.aimStart + dir * 0.1f;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/DecisionTreeTests.cs
+++ b/Assets/Tests/PlayMode/DecisionTreeTests.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Aiming.Tests
+{
+    public class DecisionTreeTests
+    {
+        [Test]
+        public void PicksContactPointForThin()
+        {
+            var go = new GameObject("engine");
+            var eng = go.AddComponent<Aiming.AdaptiveAimingEngine>();
+            eng.config = ScriptableObject.CreateInstance<AimingConfig>();
+            var ctx = new ShotContext
+            {
+                cueBallPos = new Vector3(0, 0, 0),
+                objectBallPos = new Vector3(0, 0, 1),
+                pocketPos = new Vector3(1, 0, 3),
+                ballRadius = 0.028f,
+                tableBounds = new Bounds(Vector3.zero, new Vector3(2.54f, 0.5f, 1.27f)),
+                collisionMask = ~0
+            };
+            var sol = eng.GetAimSolution(ctx);
+            Assert.IsTrue(sol.isValid);
+            Assert.IsNotEmpty(sol.strategyUsed);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/ShotClassifierTests.cs
+++ b/Assets/Tests/PlayMode/ShotClassifierTests.cs
@@ -1,0 +1,34 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Aiming.Tests
+{
+    public class ShotClassifierTests
+    {
+        AimingConfig cfg;
+        ShotClassifier clf;
+
+        [SetUp]
+        public void Setup()
+        {
+            cfg = ScriptableObject.CreateInstance<AimingConfig>();
+            clf = new ShotClassifier();
+        }
+
+        [Test]
+        public void StraightDetection()
+        {
+            var ctx = new ShotContext
+            {
+                cueBallPos = Vector3.zero,
+                objectBallPos = new Vector3(0, 0, 1),
+                pocketPos = new Vector3(0, 0, 2),
+                ballRadius = 0.028f,
+                tableBounds = new Bounds(Vector3.zero, new Vector3(2.54f, 0.5f, 1.27f)),
+                collisionMask = ~0
+            };
+            var info = clf.Classify(ctx, cfg);
+            Assert.IsTrue(info.isStraight);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/StrategiesTests.cs
+++ b/Assets/Tests/PlayMode/StrategiesTests.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Aiming.Tests
+{
+    public class StrategiesTests
+    {
+        [Test]
+        public void GhostBallProducesPoint()
+        {
+            var s = new Strategies.GhostBallStrategy();
+            var info = new ShotInfo { vOP = Vector3.forward };
+            var sol = s.Solve(new ShotContext
+            {
+                cueBallPos = Vector3.zero,
+                objectBallPos = new Vector3(0, 0, 1),
+                pocketPos = new Vector3(0, 0, 3),
+                ballRadius = 0.028f
+            }, info, null);
+            Assert.IsTrue(sol.isValid);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable adaptive aiming engine with decision tree and multiple shot strategies
- include debug overlay, physics and math utilities, and cue controller integration
- provide NUnit playmode tests for classifier, strategies, and decision logic

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68b35f61f6b083298fbc12cddec4d8a6