### PR TITLE
Fix aiming line vertical orientation

### DIFF
--- a/billiards.Tests/ScreenToWorldTests.cs
+++ b/billiards.Tests/ScreenToWorldTests.cs
@@ -1,0 +1,19 @@
+using Billiards;
+
+namespace Billiards.Tests;
+
+public class ScreenToWorldTests
+{
+    [Test]
+    public void OrthoFlipsYAxis()
+    {
+        double width = 100;
+        double height = 100;
+        var topLeft = ScreenToWorld.Ortho(new Vec2(0, 0), width, height);
+        Assert.That(topLeft.X, Is.EqualTo(0).Within(1e-9));
+        Assert.That(topLeft.Y, Is.EqualTo(PhysicsConstants.TableHeight).Within(1e-9));
+
+        var bottomLeft = ScreenToWorld.Ortho(new Vec2(0, height), width, height);
+        Assert.That(bottomLeft.Y, Is.EqualTo(0).Within(1e-9));
+    }
+}

--- a/billiards/ScreenToWorld.cs
+++ b/billiards/ScreenToWorld.cs
@@ -16,7 +16,7 @@ public static class ScreenToWorld
     public static Vec2 Ortho(Vec2 screen, double screenWidth, double screenHeight)
     {
         double x = screen.X / screenWidth * PhysicsConstants.TableWidth;
-        double y = screen.Y / screenHeight * PhysicsConstants.TableHeight;
+        double y = (screenHeight - screen.Y) / screenHeight * PhysicsConstants.TableHeight;
         return new Vec2(x, y);
     }
 }


### PR DESCRIPTION
## Summary
- Correct ScreenToWorld.Ortho to flip screen Y coordinates so aiming line matches cue ball direction
- Add tests confirming Y-axis conversion works as expected

## Testing
- `dotnet test billiards.Tests/Billiards.Tests.csproj`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d4494484832998aa6e9dee16f88c