### PR TITLE
Enhance Free Kick timer and audio cues

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -150,7 +150,7 @@
   const params = new URLSearchParams(location.search);
   const avatarParam = params.get('avatar') || '';
   let userName = params.get('name') || params.get('username') || '';
-  const durationParam = parseInt(params.get('duration')) || 18;
+  const durationParam = parseInt(params.get('duration')) || 60;
   timeShort.textContent = durationParam;
 
   function emojiToDataUri(flag){
@@ -1132,13 +1132,37 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     keeper.y = keeper.baseY;
     keeper.baseX = keeper.x;
   }
-  function startGame(){ running=true; paused=false; ended=false; roundStart=performance.now(); timeLeft=ROUND_TIME; myScore=0; looseBalls=[]; for(const r of rivals){ r.score=0; r.next=0; r.shots=[]; } resetBall(); generateHoles(); drawMiniBoards(true); updateHUD(); ensureAudio(); crowdSound.play().catch(()=>{}); status('Go! Score as many as you can.'); }
+  function startGame(){
+    playWhistle();
+    running=true;
+    paused=false;
+    ended=false;
+    roundStart=performance.now();
+    timeLeft=ROUND_TIME;
+    myScore=0;
+    looseBalls=[];
+    for(const r of rivals){ r.score=0; r.next=0; r.shots=[]; }
+    resetBall();
+    generateHoles();
+    drawMiniBoards(true);
+    updateHUD();
+    ensureAudio();
+    crowdSound.play().catch(()=>{});
+    status('Go! Score as many as you can.');
+  }
 
   // ===== WebAudio SFX =====
   let audioCtx=null, masterGain=null; function ensureAudio(){ try{ if(!audioCtx){ const AC = window.AudioContext || window.webkitAudioContext; audioCtx = new AC(); masterGain = audioCtx.createGain(); masterGain.gain.value = 0.18; masterGain.connect(audioCtx.destination); } if(audioCtx.state==='suspended') audioCtx.resume(); }catch{} }
   const crowdSound = new Audio('/assets/sounds/football-crowd-3-69245.mp3');
   crowdSound.loop = true;
   crowdSound.volume = 0.5;
+  const whistleSound = new Audio('/assets/sounds/metal-whistle-6121.mp3');
+  function playWhistle(){
+    ensureAudio();
+    whistleSound.currentTime = 0;
+    whistleSound.play().catch(()=>{});
+    setTimeout(()=>{ whistleSound.pause(); whistleSound.currentTime = 0; },2000);
+  }
   // Prize break sound
   let prizeSoundBuf=null;
   async function loadPrizeSound(){
@@ -1178,7 +1202,7 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const src=audioCtx.createBufferSource();
     src.buffer=postHitSoundBuf;
     const gain=audioCtx.createGain();
-    gain.gain.value=0.5; // 50% lower volume on post/crossbar hits
+    gain.gain.value=0.35; // further reduce volume on post/crossbar hits
     src.connect(gain).connect(masterGain);
     // Skip ~0.4s of initial silence so the clang matches contact
     src.start(0, 0.4);
@@ -1202,7 +1226,7 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const src = audioCtx.createBufferSource();
     src.buffer = ballKickSoundBuf;
     const gain = audioCtx.createGain();
-    gain.gain.value = 1.3; // boost volume 30% on kick
+    gain.gain.value = 1.6; // boost volume 60% on kick
     src.connect(gain).connect(masterGain);
     // Play only the first 0.03 seconds of the sound
     src.start(0, 0, 0.03);
@@ -1253,7 +1277,7 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const src = audioCtx.createBufferSource();
     src.buffer = goalSoundBuf;
     const gain = audioCtx.createGain();
-    gain.gain.value = 4.0; // goal sound volume boosted significantly
+    gain.gain.value = 5.0; // goal sound volume boosted further
     src.connect(gain).connect(masterGain);
     // Play the goal sound from the start of the clip so the net swoosh is always heard
     // regardless of the file's duration. Starting mid‑clip occasionally skipped the

--- a/webapp/src/pages/Games/FreeKickLobby.jsx
+++ b/webapp/src/pages/Games/FreeKickLobby.jsx
@@ -12,7 +12,7 @@ export default function FreeKickLobby() {
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState('ai');
   const [players, setPlayers] = useState(2);
-  const [duration, setDuration] = useState(30);
+  const [duration, setDuration] = useState(60);
 
   const startGame = async () => {
     let tgId;
@@ -84,13 +84,13 @@ export default function FreeKickLobby() {
       <div className="space-y-2">
         <h3 className="font-semibold">Duration</h3>
         <div className="flex gap-2">
-          {[30, 60, 180].map((t) => (
+          {[60, 120, 180].map((t) => (
             <button
               key={t}
               onClick={() => setDuration(t)}
               className={`lobby-tile ${duration === t ? 'lobby-selected' : ''}`}
             >
-              {t === 30 ? '30s' : t === 60 ? '1m' : '3m'}
+              {t === 60 ? '1m' : t === 120 ? '2m' : '3m'}
             </button>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Update Free Kick lobby to offer 1, 2, or 3 minute rounds and default to 1 minute
- Lower post/crossbar clang volume and boost goal and kick sounds
- Play Goal Rush whistle after a 3‑2‑1 countdown when each round begins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3da951fe883299acba1dc5e4d1fa6