### PR TITLE
Improve pool AI target selection

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -17,7 +17,7 @@
 /**
  * @typedef {Object} AimRequest
  * @property {GameType} game
- * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballInHand?:boolean}} state
+ * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'yellow'|'red'|null,ballInHand?:boolean}} state
  * @property {number} [timeBudgetMs]
  * @property {number} [rngSeed]
  */
@@ -70,6 +70,14 @@ function pocketEntry (ball, pocket, radius) {
   }
 }
 
+function currentGroup (state) {
+  let g = state.myGroup ?? state.ballOn
+  if (!g) return undefined
+  if (g === 'yellow') return 'SOLIDS'
+  if (g === 'red') return 'STRIPES'
+  return g
+}
+
 function chooseTargets (req) {
   const balls = req.state.balls.filter(b => !b.pocketed && b.id !== 0)
   if (req.game === 'NINE_BALL' || req.game === 'AMERICAN_BILLIARDS') {
@@ -80,12 +88,13 @@ function chooseTargets (req) {
     const solids = balls.filter(b => b.id >= 1 && b.id <= 7)
     const stripes = balls.filter(b => b.id >= 9 && b.id <= 15)
     const eight = balls.find(b => b.id === 8)
-    if (req.state.myGroup === 'SOLIDS') {
+    const group = currentGroup(req.state)
+    if (group === 'SOLIDS') {
       if (solids.length > 0) return solids
       if (eight) return [eight]
       return []
     }
-    if (req.state.myGroup === 'STRIPES') {
+    if (group === 'STRIPES') {
       if (stripes.length > 0) return stripes
       if (eight) return [eight]
       return []
@@ -106,7 +115,7 @@ function nextTargetsAfter (targetId, req) {
     const solids = cloned.filter(b => b.id >= 1 && b.id <= 7)
     const stripes = cloned.filter(b => b.id >= 9 && b.id <= 15)
     const eight = cloned.find(b => b.id === 8)
-    let group = req.state.myGroup
+    let group = currentGroup(req.state)
     if (!group || group === 'UNASSIGNED') {
       if (targetId >= 1 && targetId <= 7) group = 'SOLIDS'
       else if (targetId >= 9 && targetId <= 15) group = 'STRIPES'
@@ -143,7 +152,13 @@ function estimateCueAfterShot (cue, target, pocket, power, spin) {
 }
 
 function blocked (cue, ghost, balls, ignoreId, radius) {
-  return balls.some(b => b.id !== 0 && b.id !== ignoreId && !b.pocketed && lineIntersectsBall(cue, ghost, b, radius))
+  return balls.some(
+    b =>
+      b.id !== 0 &&
+      b.id !== ignoreId &&
+      !b.pocketed &&
+      lineIntersectsBall(cue, ghost, b, radius * 1.1)
+  )
 }
 
 function evaluate (req, cue, target, pocket, power, spin, ballsOverride) {

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -107,3 +107,28 @@ test('avoids pocket with blocking ball at entrance', () => {
   const decision = planShot(req);
   assert.equal(decision.quality, 0);
 });
+
+test('respects group assignment in eight-ball', () => {
+  const req = {
+    game: 'EIGHT_POOL_UK',
+    state: {
+      balls: [
+        { id: 0, x: 100, y: 100, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 400, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 9, x: 600, y: 250, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      ballOn: 'yellow'
+    },
+    timeBudgetMs: 50
+  };
+  const decision = planShot(req);
+  assert.equal(decision.targetBallId, 1);
+});


### PR DESCRIPTION
## Summary
- respect group assignment and `ballOn` flag in pool AI
- increase collision margin to avoid fouls
- add test ensuring eight-ball AI avoids opponent balls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3dc9e89148329b65b3643d796a9ac