### PR TITLE
Align preview defenders with goalkeeper

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -1052,9 +1052,9 @@ function onUp(e){
       c.restore();
       c.strokeStyle='#fff'; c.lineWidth=6; roundRect(c,g.x,g.y,g.w,g.h,6,false,true);
       const kw = g.w * 0.14, kh = kw * 2.2;
-      const dw = kw * 2.8, dh = kh * 1.2;
+      const dw = kw, dh = kh;
       const centerX = g.x + (g.w - kw) / 2, ky = g.y + g.h - kh + g.h * 0.05;
-      const dy = ky - dh - g.h * 0.02;
+      const dy = ky;
       if(init){
         r.kx = centerX;
         r.kw = kw; r.kh = kh; r.g = g;


### PR DESCRIPTION
## Summary
- match rival mini-board defenders to goalkeeper size
- position defenders at bottom of preview frames

## Testing
- `npm test`
- `npm run lint` *(fails: 961 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e457685c8329bc7d4ca1741037ca