### PR TITLE
feat(pool-ai): enhance spin and positioning logic

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -72,6 +72,22 @@ export function __resetShotMemory () {
   shotMemory.clear()
 }
 
+// Common cue parameter variations used by the planner.  By exploring
+// different spin and speed combinations for each candidate pot the AI can
+// better control cue ball positioning, enabling more competitive and
+// precision play similar to expert level snooker players.
+const CUE_VARIATIONS = [
+  { speed: 'soft', spin: 'stun' },
+  { speed: 'med', spin: 'stun' },
+  { speed: 'firm', spin: 'stun' },
+  { speed: 'med', spin: 'followS' },
+  { speed: 'firm', spin: 'followL' },
+  { speed: 'med', spin: 'drawS' },
+  { speed: 'firm', spin: 'drawL' },
+  { speed: 'med', spin: 'sideL' },
+  { speed: 'med', spin: 'sideR' }
+]
+
 // ----------------- geometry helpers -----------------
 function dist (a, b) {
   const dx = a.x - b.x
@@ -170,16 +186,17 @@ function generatePotCandidates (state, colour) {
       const angle = bestAngle
       const distCT = dist(cue, ball)
       const distTP = bestDist
-      const shot = {
-        actionType: 'pot',
-        targetBall: ball,
-        pocket: bestPocket,
-        cueParams: { speed: 'med', spin: 'stun' },
-        angle,
-        distCT,
-        distTP
+      for (const params of CUE_VARIATIONS) {
+        shots.push({
+          actionType: 'pot',
+          targetBall: ball,
+          pocket: bestPocket,
+          cueParams: params,
+          angle,
+          distCT,
+          distTP
+        })
       }
-      shots.push(shot)
     }
   }
   return shots
@@ -212,18 +229,19 @@ function generateBankPotCandidates (state, colour) {
         const angle = cutAngle(cue, ball, mirror)
         const distCT = dist(cue, ball)
         const distTP = dist(ball, pocket)
-        const shot = {
-          actionType: 'pot',
-          targetBall: ball,
-          pocket,
-          cueParams: { speed: 'med', spin: 'stun' },
-          angle,
-          distCT,
-          distTP,
-          isBank: true,
-          bankAnchor: mirror
+        for (const params of CUE_VARIATIONS) {
+          shots.push({
+            actionType: 'pot',
+            targetBall: ball,
+            pocket,
+            cueParams: params,
+            angle,
+            distCT,
+            distTP,
+            isBank: true,
+            bankAnchor: mirror
+          })
         }
-        shots.push(shot)
       }
     }
   }
@@ -480,9 +498,15 @@ function valueOfPositionAfter (nc, state, colour) {
 }
 
 function foulRisk (shot, state) {
-  // basic scratch risk if cue after shot near pocket
+  // assess scratch risk and other foul tendencies such as leaving the cue
+  // ball hanging over a pocket.  Experts heavily avoid these scenarios so we
+  // apply a stronger penalty when detected.
   const cueAfter = simulateCueRollout(state, shot)
-  return state.pockets.some(p => dist(cueAfter, p) < state.ballRadius * 1.2) ? 0.4 : 0
+  let risk = 0
+  if (state.pockets.some(p => dist(cueAfter, p) < state.ballRadius * 1.1)) {
+    risk += 0.6
+  }
+  return risk
 }
 
 function riskPenalty (risk) {


### PR DESCRIPTION
## Summary
- expand candidate generation with multiple spin and speed variations for expert-level shot planning
- penalize high-risk cue ball positions to avoid scratches

## Testing
- `npm test` *(fails: The module '/workspace/TonPlaygramWebApp/bot/node_modules/canvas/build/Release/canvas.node' was compiled against a different Node.js version)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fd8d8fe083299adceee735753c65