### PR TITLE
Improve AI pocket aiming

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -60,8 +60,9 @@ function pathBlocked (a, b, balls, ignoreIds, radius) {
   )
 }
 
-function pocketEntry (ball, pocket, radius) {
-  const dir = { x: ball.x - pocket.x, y: ball.y - pocket.y }
+function pocketEntry (pocket, radius, width, height) {
+  const center = { x: width / 2, y: height / 2 }
+  const dir = { x: center.x - pocket.x, y: center.y - pocket.y }
   const len = Math.hypot(dir.x, dir.y) || 1
   const offset = radius * 1.05
   return {
@@ -71,7 +72,7 @@ function pocketEntry (ball, pocket, radius) {
 }
 
 function currentGroup (state) {
-  let g = state.myGroup ?? state.ballOn
+  const g = state.myGroup ?? state.ballOn
   if (!g) return undefined
   if (g === 'yellow') return 'SOLIDS'
   if (g === 'red') return 'STRIPES'
@@ -164,7 +165,7 @@ function blocked (cue, ghost, balls, ignoreId, radius) {
 function evaluate (req, cue, target, pocket, power, spin, ballsOverride) {
   const r = req.state.ballRadius
   const balls = ballsOverride || req.state.balls
-  const entry = pocketEntry(target, pocket, r)
+  const entry = pocketEntry(pocket, r, req.state.width, req.state.height)
   const ghost = {
     x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
     y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
@@ -201,11 +202,13 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride) {
   const cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
   const centerAlign = 1 - Math.min(cutAngle / (Math.PI / 2), 1)
   const nearHole = 1 - Math.min(dist(target, entry) / (r * 20), 1)
+  const viewAngle = Math.atan2(r * 2, dist(target, entry))
+  const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
   const quality = Math.max(
     0,
     Math.min(
       1,
-      0.4 * potChance + 0.3 * centerAlign + 0.2 * nextScore + 0.1 * nearHole - 0.2 * risk
+      0.35 * potChance + 0.25 * centerAlign + 0.2 * viewScore + 0.1 * nextScore + 0.1 * nearHole - 0.2 * risk
     )
   )
   const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
@@ -214,7 +217,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride) {
     power,
     spin,
     targetBallId: target.id,
-    targetPocket: pocket,
+    targetPocket: entry,
     quality,
     rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} nh=${nearHole.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)}`
   }
@@ -242,7 +245,7 @@ export function planShot (req) {
 
   for (const target of targets) {
     for (const pocket of pockets) {
-      const entry = pocketEntry(target, pocket, r)
+      const entry = pocketEntry(pocket, r, req.state.width, req.state.height)
       // ball in hand: sample cue placements along pocket-target line
       const placements = []
       if (req.state.ballInHand) {

--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -131,6 +131,14 @@ function pocketBetween (cue, ball, pockets, radius) {
   return false
 }
 
+function pocketEntry (pocket, state) {
+  const center = { x: state.width / 2, y: state.height / 2 }
+  const dir = { x: center.x - pocket.x, y: center.y - pocket.y }
+  const len = Math.hypot(dir.x, dir.y) || 1
+  const offset = state.ballRadius * 1.05
+  return { x: pocket.x + (dir.x / len) * offset, y: pocket.y + (dir.y / len) * offset, name: pocket.name }
+}
+
 // Returns angle between cue->ball and ball->pocket in radians
 function cutAngle (cue, target, pocket) {
   const v1 = { x: target.x - cue.x, y: target.y - cue.y }
@@ -169,17 +177,23 @@ function generatePotCandidates (state, colour) {
   const shots = []
   for (const ball of balls) {
     let bestPocket = null
+    let bestView = -Infinity
     let bestAngle = Infinity
     let bestDist = Infinity
     for (const pocket of state.pockets) {
-      // prefer pockets that give the straightest line to the cue
-      if (pathBlocked(ball, pocket, state.balls, [cue.id, ball.id], state.ballRadius)) continue
-      const angle = cutAngle(cue, ball, pocket)
-      const d = dist(ball, pocket)
-      if (angle < bestAngle - 1e-6 || (Math.abs(angle - bestAngle) <= 1e-6 && d < bestDist)) {
+      const entry = pocketEntry(pocket, state)
+      if (pathBlocked(ball, entry, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+      const angle = cutAngle(cue, ball, entry)
+      const d = dist(ball, entry)
+      const view = Math.atan2(state.ballRadius * 2, d)
+      if (
+        view > bestView + 1e-6 ||
+        (Math.abs(view - bestView) <= 1e-6 && angle < bestAngle)
+      ) {
+        bestView = view
         bestAngle = angle
         bestDist = d
-        bestPocket = pocket
+        bestPocket = entry
       }
     }
     if (bestPocket && !pathBlocked(ball, bestPocket, state.balls, [cue.id, ball.id], state.ballRadius)) {
@@ -226,14 +240,15 @@ function generateBankPotCandidates (state, colour) {
       for (const rail of ['left', 'right', 'top', 'bottom']) {
         const mirror = mirrorPocket(pocket, state.width, state.height, rail)
         if (pathBlocked(ball, mirror, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+        const entry = pocketEntry(pocket, state)
         const angle = cutAngle(cue, ball, mirror)
         const distCT = dist(cue, ball)
-        const distTP = dist(ball, pocket)
+        const distTP = dist(ball, entry)
         for (const params of CUE_VARIATIONS) {
           shots.push({
             actionType: 'pot',
             targetBall: ball,
-            pocket,
+            pocket: entry,
             cueParams: params,
             angle,
             distCT,
@@ -342,9 +357,16 @@ function generateFreeBallCandidates (state, colour) {
     if (ball.pocketed || ball.colour !== colour) continue
     let bestPocket = null
     let bestDist = Infinity
+    let bestView = -Infinity
     for (const pocket of state.pockets) {
-      const d = dist(ball, pocket)
-      if (d < bestDist) { bestDist = d; bestPocket = pocket }
+      const entry = pocketEntry(pocket, state)
+      const d = dist(ball, entry)
+      const view = Math.atan2(state.ballRadius * 2, d)
+      if (view > bestView + 1e-6) {
+        bestView = view
+        bestDist = d
+        bestPocket = entry
+      }
     }
     if (bestPocket) {
       const anchor = { x: ball.x - (bestPocket.x - ball.x), y: ball.y - (bestPocket.y - ball.y) }
@@ -467,14 +489,21 @@ function generateFastCandidates (state, colour) {
   let bestPocket = null
   let bestAngle = Infinity
   let bestDist = Infinity
+  let bestView = -Infinity
   for (const p of state.pockets) {
-    if (pathBlocked(ball, p, state.balls, [cue.id, ball.id], state.ballRadius)) continue
-    const angle = cutAngle(cue, ball, p)
-    const d = dist(ball, p)
-    if (angle < bestAngle - 1e-6 || (Math.abs(angle - bestAngle) <= 1e-6 && d < bestDist)) {
+    const entry = pocketEntry(p, state)
+    if (pathBlocked(ball, entry, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+    const angle = cutAngle(cue, ball, entry)
+    const d = dist(ball, entry)
+    const view = Math.atan2(state.ballRadius * 2, d)
+    if (
+      view > bestView + 1e-6 ||
+      (Math.abs(view - bestView) <= 1e-6 && angle < bestAngle)
+    ) {
       bestAngle = angle
       bestDist = d
-      bestPocket = p
+      bestView = view
+      bestPocket = entry
     }
   }
   if (!bestPocket) return []


### PR DESCRIPTION
## Summary
- Aim at pocket entrances using table-centred orientation for better line-up
- Prefer pockets with wider entrance angle when selecting shots
- Weigh pocket view angle in shot evaluation for smarter targeting

## Testing
- `node --test test/poolAi.test.js test/poolUkAdvancedAi.test.js test/poolUk8Ball.test.js`
- `npx eslint lib/poolAi.js lib/poolUkAdvancedAi.js`
- `npm run lint` *(fails: 961 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b400f09aa083298aa8aa26f4488b63