### PR TITLE
Prioritize central open shots in pool AI

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -162,7 +162,7 @@ function blocked (cue, ghost, balls, ignoreId, radius) {
   )
 }
 
-function evaluate (req, cue, target, pocket, power, spin, ballsOverride) {
+function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict = false) {
   const r = req.state.ballRadius
   const balls = ballsOverride || req.state.balls
   const entry = pocketEntry(pocket, r, req.state.width, req.state.height)
@@ -204,6 +204,9 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride) {
   const nearHole = 1 - Math.min(dist(target, entry) / (r * 20), 1)
   const viewAngle = Math.atan2(r * 2, dist(target, entry))
   const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
+  if (strict && (centerAlign < 0.5 || viewScore < 0.3)) {
+    return null
+  }
   const quality = Math.max(
     0,
     Math.min(
@@ -243,64 +246,67 @@ export function planShot (req) {
     { top: -0.3, side: -0.3, back: 0 }
   ]
 
-  for (const target of targets) {
-    for (const pocket of pockets) {
-      const entry = pocketEntry(pocket, r, req.state.width, req.state.height)
-      // ball in hand: sample cue placements along pocket-target line
-      const placements = []
-      if (req.state.ballInHand) {
-        const toPocket = { x: entry.x - target.x, y: entry.y - target.y }
-        const distTP = Math.hypot(toPocket.x, toPocket.y) || 1
-        const dir = { x: target.x - entry.x, y: target.y - entry.y }
-        const ghost = {
-          x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
-          y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
-        }
-        const dists = [4, 6, 8, 10, 12].map(m => m * r)
-        for (const d of dists) {
-          const cand = { x: ghost.x + (dir.x / distTP) * d, y: ghost.y + (dir.y / distTP) * d }
-          if (
-            cand.x < r ||
-            cand.x > req.state.width - r ||
-            cand.y < r ||
-            cand.y > req.state.height - r
-          ) {
-            continue
+  for (const strict of [true, false]) {
+    for (const target of targets) {
+      for (const pocket of pockets) {
+        const entry = pocketEntry(pocket, r, req.state.width, req.state.height)
+        // ball in hand: sample cue placements along pocket-target line
+        const placements = []
+        if (req.state.ballInHand) {
+          const toPocket = { x: entry.x - target.x, y: entry.y - target.y }
+          const distTP = Math.hypot(toPocket.x, toPocket.y) || 1
+          const dir = { x: target.x - entry.x, y: target.y - entry.y }
+          const ghost = {
+            x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
+            y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
           }
-          const overlap = req.state.balls.some(
-            b => b.id !== 0 && !b.pocketed && dist(cand, b) < r * 2
-          )
-          if (overlap) continue
-          placements.push(cand)
-        }
-      } else {
-        const cue = req.state.balls.find(b => b.id === 0)
-        placements.push({ x: cue.x, y: cue.y })
-      }
-
-      for (const cuePos of placements) {
-        const balls = req.state.balls.map(b =>
-          b.id === 0 ? { ...b, x: cuePos.x, y: cuePos.y } : b
-        )
-        for (const power of powers) {
-          for (const spin of spins) {
-            if (Date.now() > deadline) {
-              return best || {
-                angleRad: 0,
-                power: 0,
-                spin: { top: 0, side: 0, back: 0 },
-                quality: 0,
-                rationale: 'no shot'
-              }
+          const dists = [4, 6, 8, 10, 12].map(m => m * r)
+          for (const d of dists) {
+            const cand = { x: ghost.x + (dir.x / distTP) * d, y: ghost.y + (dir.y / distTP) * d }
+            if (
+              cand.x < r ||
+              cand.x > req.state.width - r ||
+              cand.y < r ||
+              cand.y > req.state.height - r
+            ) {
+              continue
             }
-            const cand = evaluate(req, cuePos, target, pocket, power, spin, balls)
-            if (cand && (!best || cand.quality > best.quality)) {
-              best = { ...cand, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
+            const overlap = req.state.balls.some(
+              b => b.id !== 0 && !b.pocketed && dist(cand, b) < r * 2
+            )
+            if (overlap) continue
+            placements.push(cand)
+          }
+        } else {
+          const cue = req.state.balls.find(b => b.id === 0)
+          placements.push({ x: cue.x, y: cue.y })
+        }
+
+        for (const cuePos of placements) {
+          const balls = req.state.balls.map(b =>
+            b.id === 0 ? { ...b, x: cuePos.x, y: cuePos.y } : b
+          )
+          for (const power of powers) {
+            for (const spin of spins) {
+              if (Date.now() > deadline) {
+                return best || {
+                  angleRad: 0,
+                  power: 0,
+                  spin: { top: 0, side: 0, back: 0 },
+                  quality: 0,
+                  rationale: 'no shot'
+                }
+              }
+              const cand = evaluate(req, cuePos, target, pocket, power, spin, balls, strict)
+              if (cand && (!best || cand.quality > best.quality)) {
+                best = { ...cand, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
+              }
             }
           }
         }
       }
     }
+    if (best) break
   }
 
   return best || {


### PR DESCRIPTION
## Summary
- Ignore shots with thin cut angles or blocked pocket entries on the first evaluation pass
- Evaluate candidate shots twice, prioritizing central open routes before fallback options

## Testing
- `npm test`
- `npx eslint lib/poolAi.js`


------
https://chatgpt.com/codex/tasks/task_e_68b405442858832995540a53fa309fae