### PR TITLE
Restore mini goal layout for top players

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -275,9 +275,9 @@
   const aimOn = true;
 
   const rivals=[
-    { i:0, wrap:document.querySelector('#pv0'), ptsEl:document.querySelector('#pv0pts'), cvs:null, ctx:null, score:0, next:0, acc:0.68, rate:[1180,2180], shots:[], kx:0, kw:0, kh:0, def:null, g:null, avatar:'' },
-    { i:1, wrap:document.querySelector('#pv1'), ptsEl:document.querySelector('#pv1pts'), cvs:null, ctx:null, score:0, next:0, acc:0.62, rate:[1275,2360], shots:[], kx:0, kw:0, kh:0, def:null, g:null, avatar:'' },
-    { i:2, wrap:document.querySelector('#pv2'), ptsEl:document.querySelector('#pv2pts'), cvs:null, ctx:null, score:0, next:0, acc:0.58, rate:[1350,2510], shots:[], kx:0, kw:0, kh:0, def:null, g:null, avatar:'' },
+    { i:0, wrap:document.querySelector('#pv0'), ptsEl:document.querySelector('#pv0pts'), cvs:null, ctx:null, score:0, next:0, acc:0.68, rate:[1180,2180], shots:[], kx:0, kw:0, kh:0, g:null, avatar:'' },
+    { i:1, wrap:document.querySelector('#pv1'), ptsEl:document.querySelector('#pv1pts'), cvs:null, ctx:null, score:0, next:0, acc:0.62, rate:[1275,2360], shots:[], kx:0, kw:0, kh:0, g:null, avatar:'' },
+    { i:2, wrap:document.querySelector('#pv2'), ptsEl:document.querySelector('#pv2pts'), cvs:null, ctx:null, score:0, next:0, acc:0.58, rate:[1350,2510], shots:[], kx:0, kw:0, kh:0, g:null, avatar:'' },
   ];
   for(let i=0;i<rivals.length;i++){ rivals[i].cvs = rivals[i].wrap.querySelector('canvas'); rivals[i].ctx = rivals[i].cvs.getContext('2d'); rivals[i].avatar = pvAvatars[i]?.src || ''; }
   const miniHolesCache=[[],[],[]];
@@ -1092,24 +1092,16 @@ function onUp(e){
       c.restore();
       c.strokeStyle='#fff'; c.lineWidth=6; roundRect(c,field.x,field.y,field.w,field.h,6,false,true);
       const kw = goal.w * 0.14, kh = kw * 2.2;
-      const dw = kw, dh = kh / 2;
       const centerX = goal.x + (goal.w - kw) / 2;
       const ky = goal.y + goal.h - kh + goal.h * 0.05;
-      const dy = field.y + field.h - dh;
       if(init){
         r.kx = centerX;
         r.kw = kw; r.kh = kh; r.g = goal;
-        r.def = {x:centerX - dw/2, y:dy, w:dw, h:dh, baseY:dy, vy:0, jumping:false};
         if(!Array.isArray(miniHolesCache[i])||!miniHolesCache[i].length){ miniHolesCache[i]=genMiniHoles(goal); }
       }
       const active = r.shots[0];
       const targetX = active ? clamp(active.x - kw/2, goal.x, goal.x + goal.w - kw) : centerX;
       r.kx += (targetX - r.kx) * 0.2;
-      const d = r.def;
-      if(d){
-        if(d.jumping){ d.vy += GRAVITY*0.5; d.y += d.vy; if(d.y >= d.baseY){ d.y = d.baseY; d.vy = 0; d.jumping = false; } }
-        c.drawImage(defendersImg, 0, 0, defendersImg.width, defendersImg.height/2, d.x, d.y, d.w, d.h);
-      }
       const list = Array.isArray(miniHolesCache[i]) ? miniHolesCache[i] : [];
       for(const h of list){
         c.fillStyle='rgba(225,6,0,.9)';
@@ -1152,7 +1144,7 @@ function onUp(e){
     miniHolesCache[i]=genMiniHoles(goal);
   }
   function roundRect(c,x,y,w,h,r,fill,stroke,fillColor){ c.beginPath(); c.moveTo(x+r,y); c.arcTo(x+w,y,x+w,y+h,r); c.arcTo(x+w,y+h,x,y+h,r); c.arcTo(x,y+h,x,y,r); c.arcTo(x,y,x+w,y,r); if(fill){ if(fillColor){ const old=c.fillStyle; c.fillStyle=fillColor; c.fill(); c.fillStyle=old; } else c.fill(); } if(stroke) c.stroke(); }
-    function stepRivals(now){
+  function stepRivals(now){
     if(!running||paused) return;
     const t = 1 - (timeLeft/ROUND_TIME);
     for(let i=0;i<rivals.length;i++){
@@ -1168,18 +1160,10 @@ function onUp(e){
           const saved = Math.random() < 0.5;
           if(!saved){ r.score += Math.max(5, Math.round(target.p)); }
           const g=r.g, kw=r.kw;
-          const d=r.def;
-          const startX = rnd(g.x + d.w/2, g.x + g.w - d.w/2);
-          d.x = clamp(startX - d.w/2, g.x, g.x + g.w - d.w);
-          d.y = d.baseY; d.vy = 0; d.jumping = Math.random() < 0.5;
-          if(d.jumping){ d.vy = -3; }
-          const wallCenter = d.x + d.w/2;
-          const goalCenter = g.x + g.w/2;
-          const gap = g.w * 0.02;
-          if(wallCenter < goalCenter - g.w*0.1) r.kx = g.x + g.w - kw - gap;
-          else if(wallCenter > goalCenter + g.w*0.1) r.kx = g.x + gap;
-          else r.kx = Math.random() < 0.5 ? g.x + gap : g.x + g.w - kw - gap;
-          r.shots.push({x:startX,y:g.y+g.h,vx:(target.x-startX)/15,vy:(target.y-(g.y+g.h))/15,life:1,saved});
+          const startX = rnd(g.x, g.x + g.w);
+          const vx = (target.x - startX) / 15;
+          const vy = (target.y - (g.y + g.h)) / 15;
+          r.shots.push({x:startX,y:g.y+g.h,vx,vy,life:1,saved});
         }
       }
       r.ptsEl.textContent = r.score;


### PR DESCRIPTION
## Summary
- remove defenders from Free Kick mini scoreboards
- simplify rival logic to focus on goal, net, keeper and prize targets

## Testing
- `npm test`
- `npm run lint` *(fails: 960 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b405f795348329943cea83abfa7362