### PR TITLE
Enhance pool AI targeting to prefer central open shots

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -136,6 +136,63 @@ function nextTargetsAfter (targetId, req) {
   return cloned
 }
 
+// Identify target/pocket pairs that satisfy core aiming criteria:
+// minimal cut angle and clear pocket entry. Returns sorted candidates,
+// preferring smaller cut angles and wider pocket views.
+function clearShotCandidates (req) {
+  const r = req.state.ballRadius
+  const cue = req.state.balls.find(b => b.id === 0)
+  const targets = chooseTargets(req)
+  const pockets = req.state.pockets
+  const candidates = []
+
+  for (const target of targets) {
+    for (const pocket of pockets) {
+      const entry = pocketEntry(pocket, r, req.state.width, req.state.height)
+      const ghost = {
+        x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
+        y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
+      }
+
+      // ensure ghost is within table bounds
+      if (
+        ghost.x < r ||
+        ghost.x > req.state.width - r ||
+        ghost.y < r ||
+        ghost.y > req.state.height - r
+      ) {
+        continue
+      }
+
+      // check paths from cue->ghost and target->pocket are unobstructed
+      if (
+        blocked(cue, ghost, req.state.balls, target.id, r) ||
+        pathBlocked(target, entry, req.state.balls, [0, target.id], r) ||
+        req.state.balls.some(
+          b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
+        )
+      ) {
+        continue
+      }
+
+      const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
+      const potVec = { x: entry.x - target.x, y: entry.y - target.y }
+      let cut = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
+      if (cut > Math.PI) cut = Math.abs(cut - Math.PI * 2)
+      const viewAngle = Math.atan2(r * 2, dist(target, entry))
+      const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
+
+      // require fairly central hit and open pocket view
+      if (cut <= Math.PI / 4 && viewScore >= 0.3) {
+        candidates.push({ target, pocket, cut, view: viewScore })
+      }
+    }
+  }
+
+  candidates.sort((a, b) => a.cut - b.cut || b.view - a.view)
+  return candidates
+}
+
 function estimateCueAfterShot (cue, target, pocket, power, spin) {
   const toTarget = { x: target.x - cue.x, y: target.y - cue.y }
   const toPocket = { x: pocket.x - target.x, y: pocket.y - target.y }
@@ -231,11 +288,9 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
  * @returns {ShotDecision}
  */
 export function planShot (req) {
-  const pockets = req.state.pockets
-  const targets = chooseTargets(req)
+  const r = req.state.ballRadius
   const start = Date.now()
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity
-  const r = req.state.ballRadius
   let best = null
 
   const powers = [0.6, 0.8, 1.0]
@@ -246,61 +301,68 @@ export function planShot (req) {
     { top: -0.3, side: -0.3, back: 0 }
   ]
 
-  for (const strict of [true, false]) {
-    for (const target of targets) {
-      for (const pocket of pockets) {
-        const entry = pocketEntry(pocket, r, req.state.width, req.state.height)
-        // ball in hand: sample cue placements along pocket-target line
-        const placements = []
-        if (req.state.ballInHand) {
-          const toPocket = { x: entry.x - target.x, y: entry.y - target.y }
-          const distTP = Math.hypot(toPocket.x, toPocket.y) || 1
-          const dir = { x: target.x - entry.x, y: target.y - entry.y }
-          const ghost = {
-            x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
-            y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
-          }
-          const dists = [4, 6, 8, 10, 12].map(m => m * r)
-          for (const d of dists) {
-            const cand = { x: ghost.x + (dir.x / distTP) * d, y: ghost.y + (dir.y / distTP) * d }
-            if (
-              cand.x < r ||
-              cand.x > req.state.width - r ||
-              cand.y < r ||
-              cand.y > req.state.height - r
-            ) {
-              continue
-            }
-            const overlap = req.state.balls.some(
-              b => b.id !== 0 && !b.pocketed && dist(cand, b) < r * 2
-            )
-            if (overlap) continue
-            placements.push(cand)
-          }
-        } else {
-          const cue = req.state.balls.find(b => b.id === 0)
-          placements.push({ x: cue.x, y: cue.y })
-        }
+  // first, gather candidate target/pocket pairs meeting strict criteria
+  let candidatePairs = clearShotCandidates(req)
+  if (candidatePairs.length === 0) {
+    // fallback: evaluate all target/pocket combinations
+    const pockets = req.state.pockets
+    const targets = chooseTargets(req)
+    candidatePairs = targets.flatMap(t => pockets.map(p => ({ target: t, pocket: p })))
+  }
 
-        for (const cuePos of placements) {
-          const balls = req.state.balls.map(b =>
-            b.id === 0 ? { ...b, x: cuePos.x, y: cuePos.y } : b
+  for (const strict of [true, false]) {
+    for (const { target, pocket } of candidatePairs) {
+      const entry = pocketEntry(pocket, r, req.state.width, req.state.height)
+      // ball in hand: sample cue placements along pocket-target line
+      const placements = []
+      if (req.state.ballInHand) {
+        const toPocket = { x: entry.x - target.x, y: entry.y - target.y }
+        const distTP = Math.hypot(toPocket.x, toPocket.y) || 1
+        const dir = { x: target.x - entry.x, y: target.y - entry.y }
+        const ghost = {
+          x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
+          y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
+        }
+        const dists = [4, 6, 8, 10, 12].map(m => m * r)
+        for (const d of dists) {
+          const cand = { x: ghost.x + (dir.x / distTP) * d, y: ghost.y + (dir.y / distTP) * d }
+          if (
+            cand.x < r ||
+            cand.x > req.state.width - r ||
+            cand.y < r ||
+            cand.y > req.state.height - r
+          ) {
+            continue
+          }
+          const overlap = req.state.balls.some(
+            b => b.id !== 0 && !b.pocketed && dist(cand, b) < r * 2
           )
-          for (const power of powers) {
-            for (const spin of spins) {
-              if (Date.now() > deadline) {
-                return best || {
-                  angleRad: 0,
-                  power: 0,
-                  spin: { top: 0, side: 0, back: 0 },
-                  quality: 0,
-                  rationale: 'no shot'
-                }
+          if (overlap) continue
+          placements.push(cand)
+        }
+      } else {
+        const cue = req.state.balls.find(b => b.id === 0)
+        placements.push({ x: cue.x, y: cue.y })
+      }
+
+      for (const cuePos of placements) {
+        const balls = req.state.balls.map(b =>
+          b.id === 0 ? { ...b, x: cuePos.x, y: cuePos.y } : b
+        )
+        for (const power of powers) {
+          for (const spin of spins) {
+            if (Date.now() > deadline) {
+              return best || {
+                angleRad: 0,
+                power: 0,
+                spin: { top: 0, side: 0, back: 0 },
+                quality: 0,
+                rationale: 'no shot'
               }
-              const cand = evaluate(req, cuePos, target, pocket, power, spin, balls, strict)
-              if (cand && (!best || cand.quality > best.quality)) {
-                best = { ...cand, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
-              }
+            }
+            const cand = evaluate(req, cuePos, target, pocket, power, spin, balls, strict)
+            if (cand && (!best || cand.quality > best.quality)) {
+              best = { ...cand, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
             }
           }
         }

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -132,3 +132,24 @@ test('respects group assignment in eight-ball', () => {
   const decision = planShot(req);
   assert.equal(decision.targetBallId, 1);
 });
+
+test('prefers target with smallest cut angle', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 100, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 600, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 600, y: 150, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [ { x: 1000, y: 250 } ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01
+    },
+    timeBudgetMs: 50
+  };
+  const decision = planShot(req);
+  assert.equal(decision.targetBallId, 1);
+});


### PR DESCRIPTION
## Summary
- add `clearShotCandidates` to filter shots needing minimal cut and open pocket
- update `planShot` to prioritise these candidates
- test that AI selects the most central target when options exist

## Testing
- `npm test` (fails: seat/unseat, multiple users without telegramId, withdraw route reverts balance)
- `node --test test/poolAi.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b412b1c5988329802db9df1a061604