### PR TITLE
Scale pool AI side-spin by table size

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -193,7 +193,7 @@ function clearShotCandidates (req) {
   return candidates
 }
 
-function estimateCueAfterShot (cue, target, pocket, power, spin) {
+export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
   const toTarget = { x: target.x - cue.x, y: target.y - cue.y }
   const toPocket = { x: pocket.x - target.x, y: pocket.y - target.y }
   const dir = { x: toTarget.x - toPocket.x, y: toTarget.y - toPocket.y }
@@ -202,7 +202,8 @@ function estimateCueAfterShot (cue, target, pocket, power, spin) {
   // very rough spin model – top/back alter distance, side imparts lateral offset
   scale *= 1 + spin.top - spin.back
   const perp = { x: -dir.y / len, y: dir.x / len }
-  const sideOffset = spin.side * 40 // arbitrary side spin strength
+  const tableScale = Math.max(table.width, table.height) * 0.04
+  const sideOffset = spin.side * power * tableScale
   return {
     x: target.x + dir.x * scale + perp.x * sideOffset,
     y: target.y + dir.y * scale + perp.y * sideOffset
@@ -246,7 +247,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const maxD = Math.hypot(req.state.width, req.state.height)
   const distShot = dist(cue, target) + dist(target, entry)
   const potChance = 1 - Math.min(distShot / maxD, 1)
-  const cueAfter = estimateCueAfterShot(cue, target, entry, power, spin)
+  const cueAfter = estimateCueAfterShot(cue, target, entry, power, spin, req.state)
   const nextTargets = nextTargetsAfter(target.id, { ...req, state: { ...req.state, balls } })
   let nextScore = 0
   if (nextTargets.length > 0) {

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { planShot } from '../lib/poolAi.js';
+import { planShot, estimateCueAfterShot } from '../lib/poolAi.js';
 
 test('planShot targets lowest numbered ball', () => {
   const req = {
@@ -152,4 +152,26 @@ test('prefers target with smallest cut angle', () => {
   };
   const decision = planShot(req);
   assert.equal(decision.targetBallId, 1);
+});
+
+test('cue ball remains within table bounds for varied power and spin', () => {
+  const cue = { id: 0, x: 500, y: 250, vx: 0, vy: 0, pocketed: false };
+  const target = { id: 1, x: 600, y: 250, vx: 0, vy: 0, pocketed: false };
+  const pocket = { x: 1000, y: 250 };
+  const table = { width: 1000, height: 500 };
+  const powers = [0.5, 1];
+  const spins = [
+    { top: 0, side: -1, back: 0 },
+    { top: 0, side: 0, back: 0 },
+    { top: 0, side: 1, back: 0 },
+    { top: 0.3, side: 0.5, back: -0.3 }
+  ];
+
+  for (const power of powers) {
+    for (const spin of spins) {
+      const next = estimateCueAfterShot(cue, target, pocket, power, spin, table);
+      assert(next.x >= 0 && next.x <= table.width, `x out of bounds: ${next.x}`);
+      assert(next.y >= 0 && next.y <= table.height, `y out of bounds: ${next.y}`);
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- scale cue side-spin displacement with table dimensions and shot power in `estimateCueAfterShot`
- test cue-ball bounds across varying power and spin combinations

## Testing
- `npm test test/poolAi.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4212f8138832992ec7a828d5e3175