### PR TITLE
refactor: unify pool AI path blocking

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -51,12 +51,12 @@ function lineIntersectsBall (a, b, ball, radius) {
   return dist(closest, ball) < radius * 2
 }
 
-function pathBlocked (a, b, balls, ignoreIds, radius) {
+function pathBlocked (a, b, balls, ignoreIds, radius, margin = 1) {
   return balls.some(
     ball =>
       !ball.pocketed &&
       !ignoreIds.includes(ball.id) &&
-      lineIntersectsBall(a, b, ball, radius)
+      lineIntersectsBall(a, b, ball, radius * margin)
   )
 }
 
@@ -166,7 +166,7 @@ function clearShotCandidates (req) {
 
       // check paths from cue->ghost and target->pocket are unobstructed
       if (
-        blocked(cue, ghost, req.state.balls, target.id, r) ||
+        pathBlocked(cue, ghost, req.state.balls, [0, target.id], r, 1.1) ||
         pathBlocked(target, entry, req.state.balls, [0, target.id], r) ||
         req.state.balls.some(
           b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
@@ -209,15 +209,6 @@ function estimateCueAfterShot (cue, target, pocket, power, spin) {
   }
 }
 
-function blocked (cue, ghost, balls, ignoreId, radius) {
-  return balls.some(
-    b =>
-      b.id !== 0 &&
-      b.id !== ignoreId &&
-      !b.pocketed &&
-      lineIntersectsBall(cue, ghost, b, radius * 1.1)
-  )
-}
 
 function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict = false) {
   const r = req.state.ballRadius
@@ -237,7 +228,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     return null
   }
   if (
-    blocked(cue, ghost, balls, target.id, r) ||
+    pathBlocked(cue, ghost, balls, [0, target.id], r, 1.1) ||
     pathBlocked(target, entry, balls, [0, target.id], r) ||
     balls.some(b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
   ) {


### PR DESCRIPTION
## Summary
- consolidate `blocked` and `pathBlocked` into one helper
- update shot candidate and evaluation logic to use unified path-blocking utility

## Testing
- `npm test` *(fails: canvas native module built for different Node version)*

------
https://chatgpt.com/codex/tasks/task_e_68b42130d410832990b85e5c363f253e