### PR TITLE
Make pool AI shot thresholds configurable

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -20,6 +20,8 @@
  * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'yellow'|'red'|null,ballInHand?:boolean}} state
  * @property {number} [timeBudgetMs]
  * @property {number} [rngSeed]
+ * @property {number} [maxCutAngle] maximum allowed cut angle in radians for a shot candidate
+ * @property {number} [minViewScore] minimum required pocket view score for a shot candidate
  */
 
 /**
@@ -144,6 +146,8 @@ function clearShotCandidates (req) {
   const cue = req.state.balls.find(b => b.id === 0)
   const targets = chooseTargets(req)
   const pockets = req.state.pockets
+  const maxCut = req.maxCutAngle ?? Math.PI / 4
+  const minView = req.minViewScore ?? 0.3
   const candidates = []
 
   for (const target of targets) {
@@ -183,7 +187,7 @@ function clearShotCandidates (req) {
       const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
 
       // require fairly central hit and open pocket view
-      if (cut <= Math.PI / 4 && viewScore >= 0.3) {
+      if (cut <= maxCut && viewScore >= minView) {
         candidates.push({ target, pocket, cut, view: viewScore })
       }
     }


### PR DESCRIPTION
## Summary
- Allow tuning clear shot cut-angle and view-score limits via AimRequest
- Use AimRequest's `maxCutAngle` and `minViewScore` in `clearShotCandidates`

## Testing
- `npm test`
- `npm run lint` *(fails: 962 problems)*
- `npx eslint lib/poolAi.js`


------
https://chatgpt.com/codex/tasks/task_e_68b42131f9e883298f264714dd327a2f