### PR TITLE
Enhance pool AI with safety fallback

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -279,6 +279,25 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   }
 }
 
+function safetyShot (req) {
+  const cue = req.state.balls.find(b => b.id === 0)
+  const corners = [
+    { x: 0, y: 0 },
+    { x: req.state.width, y: 0 },
+    { x: 0, y: req.state.height },
+    { x: req.state.width, y: req.state.height }
+  ]
+  const target = corners.reduce((best, c) => (dist(cue, c) > dist(cue, best) ? c : best), corners[0])
+  const angle = Math.atan2(target.y - cue.y, target.x - cue.x)
+  return {
+    angleRad: angle,
+    power: 0.5,
+    spin: { top: 0, side: 0, back: 0 },
+    quality: 0,
+    rationale: 'safety'
+  }
+}
+
 /**
  * @param {AimRequest} req
  * @returns {ShotDecision}
@@ -289,12 +308,16 @@ export function planShot (req) {
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity
   let best = null
 
-  const powers = [0.6, 0.8, 1.0]
+  const powers = [0.5, 0.7, 0.9, 1.0]
   const spins = [
     { top: 0, side: 0, back: 0 },
     { top: 0.3, side: 0, back: -0.3 },
     { top: -0.3, side: 0.3, back: 0 },
-    { top: -0.3, side: -0.3, back: 0 }
+    { top: -0.3, side: -0.3, back: 0 },
+    { top: 0.5, side: 0, back: -0.5 },
+    { top: -0.5, side: 0.5, back: 0 },
+    { top: -0.5, side: -0.5, back: 0 },
+    { top: 0, side: 0.5, back: 0 }
   ]
 
   // first, gather candidate target/pocket pairs meeting strict criteria
@@ -348,13 +371,7 @@ export function planShot (req) {
         for (const power of powers) {
           for (const spin of spins) {
             if (Date.now() > deadline) {
-              return best || {
-                angleRad: 0,
-                power: 0,
-                spin: { top: 0, side: 0, back: 0 },
-                quality: 0,
-                rationale: 'no shot'
-              }
+              return best && best.quality >= 0.1 ? best : safetyShot(req)
             }
             const cand = evaluate(req, cuePos, target, pocket, power, spin, balls, strict)
             if (cand && (!best || cand.quality > best.quality)) {
@@ -367,13 +384,7 @@ export function planShot (req) {
     if (best) break
   }
 
-  return best || {
-    angleRad: 0,
-    power: 0,
-    spin: { top: 0, side: 0, back: 0 },
-    quality: 0,
-    rationale: 'no shot'
-  }
+  return best && best.quality >= 0.1 ? best : safetyShot(req)
 }
 
 export default planShot

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -105,6 +105,7 @@ test('avoids pocket with blocking ball at entrance', () => {
     rngSeed: 3
   };
   const decision = planShot(req);
+  assert.equal(decision.rationale, 'safety');
   assert.equal(decision.quality, 0);
 });
 


### PR DESCRIPTION
## Summary
- Expand pool shot search with broader power and spin options
- Add safety-shot fallback so AI plays defensively when no pot is available
- Update pool AI tests for safety behaviour

## Testing
- `node --test test/poolAi.test.js`
- `npm test` *(fails: ERR_DLOPEN_FAILED in canvas bindings)*

------
https://chatgpt.com/codex/tasks/task_e_68b42cbe7ca083298a330006ee73b717