### PR TITLE
Fix pool AI respecting ballOn when group unassigned

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -75,11 +75,16 @@ function pocketEntry (pocket, radius, width, height) {
 }
 
 function currentGroup (state) {
-  const g = state.myGroup ?? state.ballOn
+  let g = state.myGroup
+  if (!g || g === 'UNASSIGNED') {
+    g = state.ballOn
+  }
   if (!g) return undefined
-  if (g === 'yellow') return 'SOLIDS'
-  if (g === 'red') return 'STRIPES'
-  return g
+  const norm = g.toString().toUpperCase()
+  if (norm === 'YELLOW') return 'SOLIDS'
+  if (norm === 'RED') return 'STRIPES'
+  if (norm === 'SOLIDS' || norm === 'STRIPES') return norm
+  return undefined
 }
 
 function chooseTargets (req) {

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -134,6 +134,32 @@ test('respects group assignment in eight-ball', () => {
   assert.equal(decision.targetBallId, 1);
 });
 
+test('UNASSIGNED group defers to ballOn value', () => {
+  const req = {
+    game: 'EIGHT_POOL_UK',
+    state: {
+      balls: [
+        { id: 0, x: 100, y: 100, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 400, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 9, x: 600, y: 250, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      myGroup: 'UNASSIGNED',
+      ballOn: 'red'
+    },
+    timeBudgetMs: 50
+  };
+  const decision = planShot(req);
+  assert.equal(decision.targetBallId, 9);
+});
+
 test('prefers target with smallest cut angle', () => {
   const req = {
     game: 'AMERICAN_BILLIARDS',


### PR DESCRIPTION
## Summary
- Ensure pool AI respects `ballOn` when player group is unassigned and normalize group names
- Add regression test for `UNASSIGNED` group using `ballOn`

## Testing
- `npm test` *(fails: process did not exit, partial output shows tests running)*
- `node --test test/poolAi.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4458bc8a083299c50d2bc674d1c0a