### PR TITLE
Adjust defender preview spacing for free kick

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -16,7 +16,7 @@
   *{box-sizing:border-box}
   html,body{height:100%;margin:0;background:var(--bg);color:var(--txt);
     font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;overflow:hidden}
-  #game{position:fixed;inset:0;width:100vw;height:100svh;display:block;touch-action:none;z-index:1}
+  #game{position:fixed;inset:0;width:100vw;height:100svh;display:block;touch-action:none;z-index:1;transform:scale(0.95);transform-origin:bottom center}
 
   /* ===== HUD ===== */
   .hud{position:fixed;left:env(safe-area-inset-left,12px);right:env(safe-area-inset-right,12px);
@@ -1140,7 +1140,7 @@ function onUp(e){
       drawMiniGoal(c,goal,r.flash>0?'#ffd400':undefined);
       const dw=defenders.w*scale, dh=(defenders.h*scale)/2;
       const dx=goal.x+(defenders.x-geom.goal.x)*scale;
-      const dy=goal.y+(defenders.y-geom.goal.y)*scale;
+      const dy=goal.y+goal.h-dh;
       c.save();
       c.beginPath();
       c.rect(field.x,field.y,field.w,field.h);


### PR DESCRIPTION
## Summary
- Scale main game canvas slightly smaller to free space for defender previews
- Position defenders in mini boards so only top half appears above goal line

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b44668e54c8329b3947d26b5d95ad3