### PR TITLE
fix: AI follows colour on safety shots

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -392,11 +392,10 @@ function generateFreeBallCandidates (state, colour) {
 
 function generateSafeties (state, colour) {
   const cue = state.balls.find(b => b.colour === 'cue')
-  const oppColour = colour === 'yellow' ? 'red' : 'yellow'
-  const oppBalls = state.balls.filter(b => b.colour === oppColour && !b.pocketed)
-  if (oppBalls.length === 0) return []
-  // simple safety: thin off first opponent ball to rail
-  const target = oppBalls[0]
+  const ownBalls = state.balls.filter(b => b.colour === colour && !b.pocketed)
+  if (ownBalls.length === 0) return []
+  // choose nearest own ball and play a gentle safety off it
+  const target = ownBalls.reduce((m, b) => dist(cue, b) < dist(cue, m) ? b : m, ownBalls[0])
   return [{
     actionType: 'safety',
     targetBall: target,


### PR DESCRIPTION
## Summary
- ensure pool AI hits its own group when playing a safety to avoid fouls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b44ef773c08329a9bd82372e29c66b