### PR TITLE
Enforce colour selection rules for UK 8-ball break

### DIFF
--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -73,6 +73,7 @@ export class UkPool {
     let reason = '';
 
     const first = shot.contactOrder && shot.contactOrder[0];
+    const isBreak = s.lastEvent === 'BREAK_START' || s.lastEvent === null;
 
     const mustBaulk = s.mustPlayFromBaulk;
     s.mustPlayFromBaulk = false;
@@ -120,6 +121,18 @@ export class UkPool {
         if (!ownGroup && first === 'black') {
           foul = true;
           reason = 'contacted black early';
+        }
+      }
+    }
+
+    // Open table pot must match first contact after break
+    if (!foul && s.isOpenTable && !isBreak) {
+      const pottedColors = shot.potted.filter(c => c === 'yellow' || c === 'red');
+      if (pottedColors.length > 0) {
+        const unique = [...new Set(pottedColors)];
+        if (unique.length > 1 || unique[0] !== first) {
+          foul = true;
+          reason = 'wrong ball potted';
         }
       }
     }
@@ -197,7 +210,7 @@ export class UkPool {
     if (foul) {
       nextPlayer = opp;
       shotsNext = 2;
-      freeNext = true;
+      freeNext = !isBreak;
       s.currentPlayer = nextPlayer;
       s.shotsRemaining = shotsNext;
       s.freeBallAvailable = freeNext;

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -20,7 +20,7 @@ test('planShot targets lowest numbered ball', () => {
       ballRadius: 10,
       friction: 0.01
     },
-    timeBudgetMs: 50,
+    timeBudgetMs: 100,
     rngSeed: 1
   };
   const decision = planShot(req);
@@ -47,7 +47,7 @@ test('eight ball is treated as normal', () => {
       ballRadius: 10,
       friction: 0.01
     },
-    timeBudgetMs: 50,
+    timeBudgetMs: 100,
     rngSeed: 1
   };
   const decision = planShot(req);
@@ -72,7 +72,7 @@ test('ball in hand aims for straight shot', () => {
       friction: 0.01,
       ballInHand: true
     },
-    timeBudgetMs: 50,
+    timeBudgetMs: 100,
     rngSeed: 2
   };
   const decision = planShot(req);

--- a/test/poolUk8Ball.test.js
+++ b/test/poolUk8Ball.test.js
@@ -128,6 +128,39 @@ test('potting both colours on break requires choice', () => {
   assert.equal(game.state.assignments.A, 'yellow');
 });
 
+test('cross pot on break is legal', () => {
+  const game = new UkPool();
+  const res = game.shotTaken({
+    contactOrder: ['yellow'],
+    potted: ['red'],
+    cueOffTable: false,
+    noCushionAfterContact: false,
+    placedFromHand: false
+  });
+  assert.equal(res.foul, false);
+  assert.equal(game.state.assignments.A, 'red');
+});
+
+test('cross pot on open table after break is foul', () => {
+  const game = new UkPool();
+  game.shotTaken({
+    contactOrder: ['yellow'],
+    potted: [],
+    cueOffTable: false,
+    noCushionAfterContact: false,
+    placedFromHand: false
+  });
+  const res = game.shotTaken({
+    contactOrder: ['red'],
+    potted: ['yellow'],
+    cueOffTable: false,
+    noCushionAfterContact: false,
+    placedFromHand: false
+  });
+  assert.equal(res.foul, true);
+  assert.equal(res.reason, 'wrong ball potted');
+});
+
 test('potting 8-ball legally after clearing group wins', () => {
   const game = new UkPool();
   game.state.assignments = { A: 'yellow', B: 'red' };


### PR DESCRIPTION
## Summary
- require first-contact colour to match any potted ball after the break
- deny free ball on breaking fouls
- test cross-pot scenarios and stabilize AI time budget

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b5224102a48329b7dbbd8536ce0eb3