### PR TITLE
Fix AI ball group tracking in Pool Royale

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -81,8 +81,10 @@ function currentGroup (state) {
   }
   if (!g) return undefined
   const norm = g.toString().toUpperCase()
-  if (norm === 'YELLOW') return 'SOLIDS'
-  if (norm === 'RED') return 'STRIPES'
+  // In UK 8-ball, balls 1-7 are red (solids) and 9-15 are yellow (stripes).
+  // Map the textual colour assignment to the corresponding group.
+  if (norm === 'RED') return 'SOLIDS'
+  if (norm === 'YELLOW') return 'STRIPES'
   if (norm === 'SOLIDS' || norm === 'STRIPES') return norm
   return undefined
 }

--- a/test/poolUk8Ball.test.js
+++ b/test/poolUk8Ball.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { UkPool } from '../lib/poolUk8Ball.js';
 import { selectShot, recordShotOutcome, __resetShotMemory } from '../lib/poolUkAdvancedAi.js';
+import planShot from '../lib/poolAi.js';
 
 test('scratch on break gives opponent two visits without free ball', () => {
   const game = new UkPool();
@@ -320,4 +321,34 @@ test('AI increases EV after learning from success', () => {
   recordShotOutcome(plan1, true);
   const plan2 = selectShot(state);
   assert.ok(plan2.EV >= ev1);
+});
+
+test('basic AI targets its assigned colour', () => {
+  const req = {
+    game: 'EIGHT_POOL_UK',
+    state: {
+      balls: [
+        { id: 0, x: 50, y: 150, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 150, y: 150, vx: 0, vy: 0, pocketed: false },
+        { id: 9, x: 250, y: 150, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 },
+        { x: 300, y: 0 },
+        { x: 0, y: 150 },
+        { x: 300, y: 150 },
+        { x: 0, y: 300 },
+        { x: 300, y: 300 }
+      ],
+      width: 300,
+      height: 300,
+      ballRadius: 5,
+      friction: 0.015,
+      ballOn: 'red',
+      myGroup: 'UNASSIGNED',
+      ballInHand: false
+    }
+  };
+  const shot = planShot(req);
+  assert.ok(shot && shot.targetBallId >= 1 && shot.targetBallId <= 7);
 });

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -2997,9 +2997,9 @@
               friction: 0.015,
               ballOn: assignedTypes[2] || null,
               myGroup:
-                assignedTypes[2] === 'yellow'
+                assignedTypes[2] === 'red'
                   ? 'SOLIDS'
-                  : assignedTypes[2] === 'red'
+                  : assignedTypes[2] === 'yellow'
                   ? 'STRIPES'
                   : 'UNASSIGNED',
               ballInHand: cueBallFree
@@ -3017,8 +3017,8 @@
                     : b.id === 8
                     ? 'black'
                     : b.id >= 1 && b.id <= 7
-                    ? 'yellow'
-                    : 'red',
+                    ? 'red'
+                    : 'yellow',
                 x: b.x,
                 y: b.y,
                 pocketed: b.pocketed


### PR DESCRIPTION
## Summary
- Correct AI group mapping by treating red balls as solids and yellow as stripes
- Align CPU shot planning with proper colour mapping when building advanced AI state
- Add regression test ensuring basic AI targets its assigned colour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b527fd1c648329adcb3b36d0db2920