### PR TITLE
Improve 8-ball UK rules and AI cushion play

### DIFF
--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -27,7 +27,6 @@ export class UkPool {
       assignments: { A: null, B: null },
       currentPlayer: 'A',
       shotsRemaining: 1,
-      freeBallAvailable: false,
       isOpenTable: true,
       lastEvent: null,
       frameOver: false,
@@ -59,7 +58,6 @@ export class UkPool {
         potted: [],
         nextPlayer: s.currentPlayer,
         shotsRemainingNext: 0,
-        freeBallNext: false,
         frameOver: true,
         winner: s.winner
       };
@@ -95,7 +93,7 @@ export class UkPool {
     }
 
     // first contact legality
-    if (!foul && !s.freeBallAvailable) {
+    if (!foul) {
       if (s.isOpenTable) {
         const bothColours =
           s.ballsOnTable.yellow.size > 0 && s.ballsOnTable.red.size > 0;
@@ -144,7 +142,7 @@ export class UkPool {
     }
 
     // potting opponent ball illegally
-    if (!foul && !s.freeBallAvailable && oppGroup && shot.potted.includes(oppGroup)) {
+    if (!foul && oppGroup && shot.potted.includes(oppGroup)) {
       foul = true;
       reason = 'potted opponent ball';
     }
@@ -203,17 +201,14 @@ export class UkPool {
     // post-shot updates
     let nextPlayer = current;
     let shotsNext = s.shotsRemaining;
-    let freeNext = false;
     let frameOver = false;
     let winner = null;
 
     if (foul) {
       nextPlayer = opp;
       shotsNext = 2;
-      freeNext = !isBreak;
       s.currentPlayer = nextPlayer;
       s.shotsRemaining = shotsNext;
-      s.freeBallAvailable = freeNext;
       s.mustPlayFromBaulk = true;
       s.lastEvent = 'FOUL';
       if (blackPotted) {
@@ -223,7 +218,7 @@ export class UkPool {
         s.winner = winner;
       }
     } else {
-      s.freeBallAvailable = false;
+      // free ball option removed
       // check 8-ball legal pot
       if (blackPotted) {
         frameOver = true;
@@ -237,7 +232,6 @@ export class UkPool {
           potted: shot.potted,
           nextPlayer: current,
           shotsRemainingNext: 0,
-          freeBallNext: false,
           frameOver: true,
           winner
         };
@@ -263,7 +257,6 @@ export class UkPool {
       potted: shot.potted,
       nextPlayer,
       shotsRemainingNext: shotsNext,
-      freeBallNext: freeNext,
       choiceRequired,
       frameOver,
       winner: frameOver ? winner : undefined

--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -25,20 +25,19 @@
  * @property {number} ballRadius
  * @property {'yellow'|'red'|null} [ballOn]   // group of current player; null on open table
  * @property {boolean} [isOpenTable]
- * @property {boolean} [freeBallAvailable]
  * @property {number} [shotsRemaining]
  * @property {boolean} [mustPlayFromBaulk]    // cue ball must be placed behind baulk line
  * @property {number} [baulkLineX]            // x coordinate of baulk line for ball in hand
  *
  * @typedef {Object} CandidateShot
- * @property {'pot'|'safety'|'freeBallPot'} actionType
+ * @property {'pot'|'safety'} actionType
  * @property {Ball|null} targetBall
  * @property {Pocket|null} pocket
  * @property {{speed:'soft'|'med'|'firm',spin:'stun'|'followS'|'followL'|'drawS'|'drawL'|'sideL'|'sideR'}} cueParams
  * @property {boolean} [isSafety]
  *
  * @typedef {Object} Plan
- * @property {'pot'|'safety'|'freeBallPot'} actionType
+ * @property {'pot'|'safety'} actionType
  * @property {'yellow'|'red'|'black'|null} targetBall
  * @property {'TL'|'TR'|'ML'|'MR'|'BL'|'BR'|null} pocket
  * @property {{x:number,y:number}} aimPoint
@@ -350,46 +349,6 @@ function generateKickCandidates (state, colour, maxRails = 4) {
   return shots
 }
 
-function generateFreeBallCandidates (state, colour) {
-  // simple anchors: place cue on line from ball to nearest pocket
-  const shots = []
-  for (const ball of state.balls) {
-    if (ball.pocketed || ball.colour !== colour) continue
-    let bestPocket = null
-    let bestDist = Infinity
-    let bestView = -Infinity
-    for (const pocket of state.pockets) {
-      const entry = pocketEntry(pocket, state)
-      const d = dist(ball, entry)
-      const view = Math.atan2(state.ballRadius * 2, d)
-      if (view > bestView + 1e-6) {
-        bestView = view
-        bestDist = d
-        bestPocket = entry
-      }
-    }
-    if (bestPocket) {
-      const anchor = { x: ball.x - (bestPocket.x - ball.x), y: ball.y - (bestPocket.y - ball.y) }
-      if (state.mustPlayFromBaulk && typeof state.baulkLineX === 'number') {
-        const maxX = state.baulkLineX - state.ballRadius
-        if (anchor.x > maxX) anchor.x = maxX
-      }
-      const shot = {
-        actionType: 'freeBallPot',
-        targetBall: ball,
-        pocket: bestPocket,
-        cueParams: { speed: 'med', spin: 'stun' },
-        angle: 0,
-        distCT: dist(anchor, ball),
-        distTP: bestDist,
-        anchor
-      }
-      shots.push(shot)
-    }
-  }
-  return shots
-}
-
 function generateSafeties (state, colour) {
   const cue = state.balls.find(b => b.colour === 'cue')
   const ownBalls = state.balls.filter(b => b.colour === colour && !b.pocketed)
@@ -589,15 +548,18 @@ function chooseBestAction (state, colour) {
   // intentionally excluded so that they are only considered if absolutely
   // nothing else is available.
   let candidates = generatePotCandidates(state, colour)
-  if (state.freeBallAvailable) {
-    candidates = candidates.concat(generateFreeBallCandidates(state, colour))
+  if (candidates.length === 0) {
+    const kicks = generateKickCandidates(state, colour, 4)
+    if (kicks.length > 0) {
+      candidates = kicks
+    }
   }
   if (candidates.length === 0) {
     // No clear potting opportunity – fall back to defensive play.
     candidates = generateSafeties(state, colour)
   } else {
     const scored = candidates.map(c =>
-      c.actionType === 'pot' || c.actionType === 'freeBallPot'
+      c.actionType === 'pot'
         ? estimatePotProbability(c, state)
         : 0
     )

--- a/test/poolUk8Ball.test.js
+++ b/test/poolUk8Ball.test.js
@@ -16,7 +16,6 @@ test('scratch on break gives opponent two visits without free ball', () => {
   assert.equal(res.foul, true);
   assert.equal(res.nextPlayer, 'B');
   assert.equal(res.shotsRemainingNext, 2);
-  assert.equal(res.freeBallNext, false);
 });
 
 test('after foul player must hit a valid colour first', () => {
@@ -50,6 +49,21 @@ test('no pot and no cushion is foul', () => {
   });
   assert.equal(res.foul, true);
   assert.equal(res.reason, 'no cushion');
+});
+
+test('potting opponent ball is foul', () => {
+  const game = new UkPool();
+  game.state.assignments = { A: 'yellow', B: 'red' };
+  game.state.isOpenTable = false;
+  const res = game.shotTaken({
+    contactOrder: ['yellow'],
+    potted: ['red'],
+    cueOffTable: false,
+    noCushionAfterContact: false,
+    placedFromHand: false
+  });
+  assert.equal(res.foul, true);
+  assert.equal(res.reason, 'potted opponent ball');
 });
 
 test('potting 8-ball before clearing group loses the frame', () => {
@@ -179,6 +193,21 @@ test('potting 8-ball legally after clearing group wins', () => {
   assert.equal(res.winner, 'A');
 });
 
+test('hitting black after clearing group without pot is legal', () => {
+  const game = new UkPool();
+  game.state.assignments = { A: 'yellow', B: 'red' };
+  game.state.isOpenTable = false;
+  game.state.ballsOnTable.yellow.clear();
+  const res = game.shotTaken({
+    contactOrder: ['black'],
+    potted: [],
+    cueOffTable: false,
+    noCushionAfterContact: false,
+    placedFromHand: false
+  });
+  assert.equal(res.foul, false);
+});
+
 test('potting black when one colour cleared on open table is legal', () => {
   const game = new UkPool();
   game.state.ballsOnTable.yellow.clear();
@@ -258,7 +287,6 @@ test('AI targets black when own balls cleared', () => {
     ballRadius: 5,
     ballOn: 'yellow',
     isOpenTable: false,
-    freeBallAvailable: false,
     shotsRemaining: 1
   };
   const plan = selectShot(state);
@@ -286,7 +314,6 @@ test('AI plays safety when own ball is blocked', () => {
     ballRadius: 5,
     ballOn: 'yellow',
     isOpenTable: false,
-    freeBallAvailable: false,
     shotsRemaining: 1
   };
   const plan = selectShot(state);
@@ -313,7 +340,6 @@ test('AI increases EV after learning from success', () => {
     ballRadius: 5,
     ballOn: 'yellow',
     isOpenTable: false,
-    freeBallAvailable: false,
     shotsRemaining: 1
   };
   const plan1 = selectShot(state);

--- a/test/poolUkAdvancedAi.test.js
+++ b/test/poolUkAdvancedAi.test.js
@@ -52,24 +52,29 @@ test('falls back to safety when pot not viable', () => {
   assert.equal(plan.actionType, 'safety');
 });
 
-test('uses free ball when available', () => {
+test('uses cushion escapes when direct path blocked', () => {
   const state = {
     balls: [
       { id: 0, colour: 'cue', x: 50, y: 50 },
-      { id: 1, colour: 'yellow', x: 400, y: 250 },
-      { id: 2, colour: 'red', x: 300, y: 250 }
+      { id: 1, colour: 'yellow', x: 250, y: 50 },
+      { id: 2, colour: 'red', x: 150, y: 50 }
     ],
-    pockets: makePockets(),
-    width: 1000,
-    height: 500,
-    ballRadius: 10,
+    pockets: [
+      { x: 0, y: 0, name: 'TL' },
+      { x: 300, y: 0, name: 'TR' },
+      { x: 0, y: 100, name: 'BL' },
+      { x: 300, y: 100, name: 'BR' }
+    ],
+    width: 300,
+    height: 100,
+    ballRadius: 5,
     ballOn: 'yellow',
     isOpenTable: false,
-    freeBallAvailable: true,
     shotsRemaining: 1
   };
   const plan = selectShot(state, {});
-  assert.equal(plan.actionType, 'freeBallPot');
+  assert.equal(plan.actionType, 'safety');
+  assert.ok(plan.aimPoint.x === 0 || plan.aimPoint.x === state.width || plan.aimPoint.y === 0 || plan.aimPoint.y === state.height);
 });
 
 test('prioritizes straight pots', () => {


### PR DESCRIPTION
## Summary
- Remove free ball mechanic from UK 8-ball rules and flag opponent pots as fouls
- Teach advanced AI to attempt multi-rail cushion shots when direct paths are blocked
- Add tests for opponent-ball fouls, legal black-ball contact, and cushion escape logic

## Testing
- `node --test test/poolUk8Ball.test.js test/poolUkAdvancedAi.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b533bc79748329b920d877e888be6e