### PR TITLE
Randomize Free Kick targets and animate top defenders

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -141,6 +141,7 @@
     ctx.setTransform(DPR,0,0,DPR,0,0);
     positionLayout();
     layout();
+    generateMiniHoles();
     initBanners();
     initCameras();
     drawStaticOnce();
@@ -277,9 +278,9 @@
   const aimOn = true;
 
   const rivals=[
-    { i:0, wrap:document.querySelector('#pv0'), ptsEl:document.querySelector('#pv0pts'), cvs:null, ctx:null, score:0, next:0, acc:0.68, rate:[1180,2180], shots:[], kx:0, kw:0, kh:0, g:null, avatar:'', flash:0, result:'' },
-    { i:1, wrap:document.querySelector('#pv1'), ptsEl:document.querySelector('#pv1pts'), cvs:null, ctx:null, score:0, next:0, acc:0.62, rate:[1275,2360], shots:[], kx:0, kw:0, kh:0, g:null, avatar:'', flash:0, result:'' },
-    { i:2, wrap:document.querySelector('#pv2'), ptsEl:document.querySelector('#pv2pts'), cvs:null, ctx:null, score:0, next:0, acc:0.58, rate:[1350,2510], shots:[], kx:0, kw:0, kh:0, g:null, avatar:'', flash:0, result:'' },
+    { i:0, wrap:document.querySelector('#pv0'), ptsEl:document.querySelector('#pv0pts'), cvs:null, ctx:null, score:0, next:0, acc:0.68, rate:[1180,2180], shots:[], kx:0, kw:0, kh:0, g:null, avatar:'', flash:0, result:'', defX:0, defY:0, defBaseY:0, defVy:0, defJump:false, defW:0, scale:1 },
+    { i:1, wrap:document.querySelector('#pv1'), ptsEl:document.querySelector('#pv1pts'), cvs:null, ctx:null, score:0, next:0, acc:0.62, rate:[1275,2360], shots:[], kx:0, kw:0, kh:0, g:null, avatar:'', flash:0, result:'', defX:0, defY:0, defBaseY:0, defVy:0, defJump:false, defW:0, scale:1 },
+    { i:2, wrap:document.querySelector('#pv2'), ptsEl:document.querySelector('#pv2pts'), cvs:null, ctx:null, score:0, next:0, acc:0.58, rate:[1350,2510], shots:[], kx:0, kw:0, kh:0, g:null, avatar:'', flash:0, result:'', defX:0, defY:0, defBaseY:0, defVy:0, defJump:false, defW:0, scale:1 },
   ];
   for(let i=0;i<rivals.length;i++){ rivals[i].cvs = rivals[i].wrap.querySelector('canvas'); rivals[i].ctx = rivals[i].cvs.getContext('2d'); rivals[i].avatar = pvAvatars[i]?.src || ''; }
   const miniHolesCache=[[],[],[]];
@@ -288,19 +289,55 @@
     const field={x:12,y:12,w:cv.width-24,h:cv.height-32};
     return {x:field.x+MINI_GOAL_PAD,y:field.y+MINI_GOAL_PAD,w:field.w-2*MINI_GOAL_PAD,h:field.h-2*MINI_GOAL_PAD};
   }
-  function syncMiniHoles(){
+
+  function createTimerHole(goal, scale, existing=[]){
+    const minR=Math.max(ball.r*1.05*scale,22*geom.scale*scale);
+    const maxR=Math.max(minR+6*scale,50*geom.scale*scale);
+    const pad=18*scale; let tries=0;
+    while(tries<600){
+      tries++;
+      const r=rnd(minR,maxR);
+      const x=rnd(goal.x+pad+r,goal.x+goal.w-pad-r);
+      const y=rnd(goal.y+pad+r,goal.y+goal.h-pad-r);
+      if(existing.every(h=>Math.hypot(h.x-x,h.y-y)>h.r+r+12*scale)){
+        return {x,y,r,points:0,timer:true};
+      }
+    }
+    return null;
+  }
+  function createHoleSet(goal, scale){
+    const list=[]; const cnt=6+Math.floor(Math.random()*7);
+    const minR=Math.max(ball.r*1.05*scale,22*geom.scale*scale);
+    const maxR=Math.max(minR+6*scale,50*geom.scale*scale);
+    const pad=18*scale; let tries=0;
+    while(list.length<cnt && tries<1600){
+      tries++;
+      const r=rnd(minR,maxR);
+      let x;
+      if(Math.random() < 0.6){
+        const side = Math.random() < 0.5 ? 'l' : 'r';
+        const range = goal.w * 0.2;
+        if(side === 'l') x = rnd(goal.x+pad+r, goal.x+pad+range);
+        else x = rnd(goal.x+goal.w-pad-range, goal.x+goal.w-pad-r);
+      } else {
+        x = rnd(goal.x+pad+r,goal.x+goal.w-pad-r);
+      }
+      const y=rnd(goal.y+pad+r,goal.y+goal.h-pad-r);
+      if(list.every(h=>Math.hypot(h.x-x,h.y-y)>h.r+r+12*scale)){
+        const points=Math.max(10,Math.round(((maxR/r)*70)/5)*5);
+        list.push({x,y,r,points});
+      }
+    }
+    const timer=createTimerHole(goal,scale,list); if(timer) list.push(timer);
+    return list;
+  }
+  function generateMiniHoles(){
     for(let i=0;i<rivals.length;i++){
       const cv=rivals[i].cvs;
       const goal=miniGoalRect(cv);
-      const scaleX=goal.w/geom.goal.w;
-      const scaleY=goal.h/geom.goal.h;
-      miniHolesCache[i]=holes.map(h=>({
-        x:goal.x+(h.x-geom.goal.x)*scaleX + rnd(-goal.w*0.1, goal.w*0.1),
-        y:goal.y+(h.y-geom.goal.y)*scaleY + rnd(-goal.h*0.1, goal.h*0.1),
-        r:h.r*scaleX,
-        p:h.points,
-        t:h.timer?1:0
-      }));
+      const scale=goal.w/geom.goal.w;
+      const set=createHoleSet(goal,scale);
+      miniHolesCache[i]=set.map(h=>({x:h.x,y:h.y,r:h.r,p:h.points,t:h.timer?1:0}));
     }
   }
 
@@ -367,51 +404,17 @@
 
   // ===== Targets =====
   function generateHoles(){
-    const g=geom.goal; holes=[]; const cnt=6+Math.floor(Math.random()*7);
-    const minR=Math.max(ball.r*1.05,22*geom.scale); const maxR=Math.max(minR+6,50*geom.scale);
-    const pad=18; let tries=0;
-    while(holes.length<cnt && tries<1600){
-      tries++;
-      const r=rnd(minR,maxR);
-      let x;
-      if(Math.random() < 0.6){
-        const side = Math.random() < 0.5 ? 'l' : 'r';
-        const range = g.w * 0.2;
-        if(side === 'l') x = rnd(g.x+pad+r, g.x+pad+range);
-        else x = rnd(g.x+g.w-pad-range, g.x+g.w-pad-r);
-      } else {
-        x = rnd(g.x+pad+r,g.x+g.w-pad-r);
-      }
-      const y=rnd(g.y+pad+r,g.y+g.h-pad-r);
-      if(holes.every(h=>Math.hypot(h.x-x,h.y-y)>h.r+r+12)){
-        const points=Math.max(10,Math.round(((maxR/r)*70)/5)*5);
-        holes.push({x,y,r,points});
-      }
-    }
-    generateTimerHole();
-    syncMiniHoles();
-  }
-  function generateTimerHole(){
-    const g=geom.goal; const minR=Math.max(ball.r*1.05,22*geom.scale); const maxR=Math.max(minR+6,50*geom.scale);
-    const pad=18; let tries=0;
-    while(tries<600){
-      tries++;
-      const r=rnd(minR,maxR);
-      const x=rnd(g.x+pad+r,g.x+g.w-pad-r);
-      const y=rnd(g.y+pad+r,g.y+g.h-pad-r);
-      if(holes.every(h=>Math.hypot(h.x-x,h.y-y)>h.r+r+12)){
-        holes.push({x,y,r,points:0,timer:true});
-        break;
-      }
-    }
+    holes = createHoleSet(geom.goal,1);
+    generateMiniHoles();
   }
   function replaceHole(old){
     const idx=holes.indexOf(old);
     if(idx===-1) return;
     if(old.timer){
       holes.splice(idx,1);
-      generateTimerHole();
-      syncMiniHoles();
+      const t=createTimerHole(geom.goal,1,holes);
+      if(t) holes.push(t);
+      generateMiniHoles();
       return;
     }
     const g=geom.goal;
@@ -436,7 +439,7 @@
         break;
       }
     }
-    syncMiniHoles();
+    generateMiniHoles();
   }
 
   function createFragments(h){
@@ -1175,9 +1178,17 @@ function onUp(e){
       c.stroke();
 
       const dw=defenders.w*scale, dh=(defenders.h*scale)/2;
-      if(init){ r.defX = goal.x + Math.random()*(goal.w - dw); }
+      if(init){
+        r.defW = dw;
+        r.defX = goal.x + Math.random()*(goal.w - dw);
+        r.defBaseY = goal.y+goal.h-dh+8*scale;
+        r.defY = r.defBaseY;
+        r.defVy = 0;
+        r.defJump = false;
+        r.scale = scale;
+      }
       const dx=r.defX;
-      const dy=goal.y+goal.h-dh+8*scale;
+      const dy=r.defY;
       const dRect={x:dx,y:dy,w:dw,h:dh};
 
       const list = Array.isArray(miniHolesCache[i]) ? miniHolesCache[i] : [];
@@ -1268,10 +1279,19 @@ function onUp(e){
     const t = 1 - (timeLeft/ROUND_TIME);
     for(let i=0;i<rivals.length;i++){
       const r=rivals[i];
+      if(r.defJump){
+        r.defVy += GRAVITY*0.5*r.scale;
+        r.defY += r.defVy;
+        if(r.defY >= r.defBaseY){
+          r.defY = r.defBaseY;
+          r.defVy = 0;
+          r.defJump = false;
+        }
+      }
       if(now>r.next){
         r.next = now + rnd(r.rate[0], r.rate[1]) * (1 - 0.45*t);
         const list = Array.isArray(miniHolesCache[i]) ? miniHolesCache[i] : [];
-        if(list.length===0){ syncMiniHoles(); continue; }
+        if(list.length===0){ generateMiniHoles(); continue; }
         const target = Math.random()<0.35 ? list.slice().sort((a,b)=>a.r-b.r)[0] : list[Math.floor(Math.random()*list.length)];
         const acc = clamp(r.acc * (0.9 + 0.5*t),0, 0.98);
         const chance = acc * (22/Math.max(10,target.r));
@@ -1280,6 +1300,8 @@ function onUp(e){
           if(!saved && !target.t){ r.score += Math.max(5, Math.round(target.p)); }
           const g=r.g, kw=r.kw;
           const startX = rnd(g.x, g.x + g.w);
+          r.defX = clamp(startX - r.defW/2, g.x, g.x + g.w - r.defW);
+          if(!r.defJump){ r.defVy = -4*r.scale; r.defJump = true; }
           const vx = (target.x - startX) / 15;
           const vy = (target.y - (g.y + g.h)) / 15;
           r.shots.push({x:startX,y:g.y+g.h,vx,vy,life:1,saved});


### PR DESCRIPTION
## Summary
- Generate independent point targets with random values and a timer icon for each Free Kick screen
- Add slight jumping movement for top defenders to mirror bottom defenders
- Recalculate mini goal targets on resize and after each replacement

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, prefer-const, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b534b3990c83299c1f888a86ae6409