### PR TITLE
Reduce defender jump and tone down Free Kick AI

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -1128,7 +1128,7 @@ function onUp(e){
   keeper.targetX = centerX;
   keeper.targetY = keeper.baseY + geom.goal.h * 0.02;
   if(!defenders.jumping){
-    defenders.vy = -6*geom.scale;
+    defenders.vy = -3*geom.scale;
     defenders.jumping = true;
   }
   playBallKickSound();
@@ -1289,19 +1289,27 @@ function onUp(e){
         }
       }
       if(now>r.next){
-        r.next = now + rnd(r.rate[0], r.rate[1]) * (1 - 0.45*t);
+        r.next = now + rnd(r.rate[0], r.rate[1]) * (1 - 0.45*t) * 1.3;
+        const g = r.g;
         const list = Array.isArray(miniHolesCache[i]) ? miniHolesCache[i] : [];
         if(list.length===0){ generateMiniHoles(); continue; }
-        const target = Math.random()<0.35 ? list.slice().sort((a,b)=>a.r-b.r)[0] : list[Math.floor(Math.random()*list.length)];
+        let target;
+        const rand = Math.random();
+        if(rand < 0.3){
+          target = list.slice().sort((a,b)=>a.r-b.r)[0];
+        } else if(rand < 0.6){
+          target = list[Math.floor(Math.random()*list.length)];
+        } else {
+          target = { x: rnd(g.x, g.x + g.w), y: rnd(g.y, g.y + g.h), r: 40*r.scale, p: 0, t: 0 };
+        }
         const acc = clamp(r.acc * (0.9 + 0.5*t),0, 0.98);
-        const chance = acc * (22/Math.max(10,target.r));
+        const chance = acc * (22/Math.max(10,target.r)) * 0.8;
         if(Math.random() < chance){
           const saved = Math.random() < 0.5;
-          if(!saved && !target.t){ r.score += Math.max(5, Math.round(target.p)); }
-          const g=r.g, kw=r.kw;
+          if(!saved && !target.t && target.p){ r.score += Math.max(5, Math.round(target.p)); }
           const startX = rnd(g.x, g.x + g.w);
           r.defX = clamp(startX - r.defW/2, g.x, g.x + g.w - r.defW);
-          if(!r.defJump){ r.defVy = -4*r.scale; r.defJump = true; }
+          if(!r.defJump){ r.defVy = -2*r.scale; r.defJump = true; }
           const vx = (target.x - startX) / 15;
           const vy = (target.y - (g.y + g.h)) / 15;
           r.shots.push({x:startX,y:g.y+g.h,vx,vy,life:1,saved});


### PR DESCRIPTION
## Summary
- Halve defender jump height on the main field
- Slow down rival shot timing and add random, less accurate targeting
- Cut rival defenders' jump height for fairness

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b53b7209d08329ac86588ca29ffd90