### PR TITLE
Reduce unnecessary spin/power in pool AI

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -280,7 +280,9 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const cueAfter = estimateCueAfterShot(cue, target, entry, power, spin, req.state)
   const nextTargets = nextTargetsAfter(target.id, { ...req, state: { ...req.state, balls } })
   let nextScore = 0
+  let hasNext = false
   if (nextTargets.length > 0) {
+    hasNext = true
     const next = nextTargets[0]
     nextScore = 1 - Math.min(dist(cueAfter, next) / maxD, 1)
   }
@@ -311,7 +313,9 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     targetPocket: entry,
     aimPoint: ghost,
     quality,
-    rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} nh=${nearHole.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)}`
+    rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} nh=${nearHole.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)}`,
+    nextScore,
+    hasNext
   }
 }
 
@@ -404,14 +408,31 @@ export function planShot (req) {
         const balls = req.state.balls.map(b =>
           b.id === 0 ? { ...b, x: cuePos.x, y: cuePos.y } : b
         )
+
+        const baseCand = evaluate(req, cuePos, target, pocket, powers[0], spins[0], balls, strict)
+        if (baseCand) {
+          const { nextScore, hasNext, ...rest } = baseCand
+          if (!best || rest.quality > best.quality) {
+            best = { ...rest, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
+          }
+          // Only explore additional power/spin if next position is poor and there is a next target
+          if (!hasNext || nextScore >= 0.5) {
+            continue
+          }
+        }
+
         for (const power of powers) {
           for (const spin of spins) {
+            if (power === powers[0] && spin === spins[0]) continue
             if (Date.now() > deadline) {
               return best && best.quality >= 0.1 ? best : safetyShot(req)
             }
             const cand = evaluate(req, cuePos, target, pocket, power, spin, balls, strict)
-            if (cand && (!best || cand.quality > best.quality)) {
-              best = { ...cand, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
+            if (cand) {
+              const { nextScore, hasNext, ...rest } = cand
+              if (!best || rest.quality > best.quality) {
+                best = { ...rest, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
+              }
             }
           }
         }

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -202,3 +202,25 @@ test('cue ball remains within table bounds for varied power and spin', () => {
     }
   }
 });
+
+test('avoids unnecessary spin when natural position is good', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 200, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 400, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 700, y: 350, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [{ x: 1000, y: 250 }],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01
+    },
+    timeBudgetMs: 50
+  };
+  const decision = planShot(req);
+  assert.equal(decision.power, 0.5);
+  assert.deepEqual(decision.spin, { top: 0, side: 0, back: 0 });
+});


### PR DESCRIPTION
## Summary
- Skip exploring spin and high power when a baseline shot already sets up the next ball
- Expose next-score info from evaluation to decide if extra spin/power is needed
- Add regression test preventing unwanted spin in simple layouts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b53efc1d5883298c71b611945eb0a5