### PR TITLE
Align cue controls to screen edge in Pool Royale

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -447,10 +447,10 @@
       #cueOptions {
         position: absolute;
         top: 15%;
-        left: 8px;
+        left: 0;
         display: flex;
         flex-direction: column;
-        align-items: center;
+        align-items: flex-start;
         gap: 4px;
         z-index: 8;
         pointer-events: auto;
@@ -760,7 +760,7 @@
         <div id="cueHint">✋️</div>
 
         <div id="cueOptions">
-          <div class="cue-label">Cue Distances</div>
+          <div class="cue-label">Cue</div>
           <button class="cue-btn" data-cue="short">Short</button>
           <button class="cue-btn" data-cue="medium">Medium</button>
           <button class="cue-btn" data-cue="long">Long</button>


### PR DESCRIPTION
## Summary
- Simplify cue options label to "Cue"
- Move cue options to left edge to avoid overlapping playfield

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, 'inc' is never reassigned. Use 'const' instead, and more)*

------
https://chatgpt.com/codex/tasks/task_e_68b574fb407883298b4ab04dbd7640cf