### PR TITLE
fix: restore Free Kick AI target selection

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -1416,17 +1416,18 @@ function onUp(e){
         const g = r.g;
         const list = Array.isArray(miniHolesCache[i]) ? miniHolesCache[i] : [];
         if(list.length===0){ generateMiniHoles(); continue; }
-        const positives = list.filter(h=>!h.b && !h.t);
         const bombs = list.filter(h=>h.b);
         const timers = list.filter(h=>h.t);
         let target;
         const rand = Math.random();
-        if(rand < 0.1 && timers.length){
+        if(rand < 0.2 && timers.length){
           target = timers[Math.floor(Math.random()*timers.length)];
-        } else if(rand < 0.2 && bombs.length){
+        } else if(rand < 0.4 && bombs.length){
           target = bombs[Math.floor(Math.random()*bombs.length)];
-        } else if(positives.length){
-          target = positives[Math.floor(Math.random()*positives.length)];
+        } else if(rand < 0.7){
+          target = list.slice().sort((a,b)=>a.r-b.r)[0];
+        } else if(rand < 0.9){
+          target = list[Math.floor(Math.random()*list.length)];
         } else {
           target = { x: rnd(g.x, g.x + g.w), y: rnd(g.y, g.y + g.h), r: 40*r.scale, p: 0, t: 0 };
         }


### PR DESCRIPTION
## Summary
- revert Free Kick top rival target selection to previous logic so AI can score again

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a38397c48329b66b15e5018d26d2