### PR TITLE
Move cue controls lower

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -446,7 +446,8 @@
 
       #cueOptions {
         position: absolute;
-        bottom: calc(56px + env(safe-area-inset-bottom) + 4px);
+        /* Move cue controls down by the height of two buttons (72px) */
+        bottom: calc(env(safe-area-inset-bottom) - 12px);
         left: 50%;
         transform: translateX(-50%);
         display: flex;


### PR DESCRIPTION
## Summary
- Lower Pool Royale cue controls by two button heights to adjust layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a88e801883298950919f2f1bc7bb