### PR TITLE
Increase AI shot frequency in Free Kick

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -1394,7 +1394,7 @@ function onUp(e){
         }
       }
       if(now>r.next){
-        r.next = now + rnd(r.rate[0], r.rate[1]) * (1 - 0.45*t) * 1.3;
+        r.next = now + rnd(r.rate[0], r.rate[1]) * (1 - 0.45*t) * 1.1;
         const g = r.g;
         const list = Array.isArray(miniHolesCache[i]) ? miniHolesCache[i] : [];
         if(list.length===0){ generateMiniHoles(); continue; }


### PR DESCRIPTION
## Summary
- Reduce rival shot cooldown multiplier so AI shoots more frequently in Free Kick

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b5806c9483298fad8edc9a12ebf8