### PR TITLE
feat: add bombs and timers to AI free kick goals

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -284,9 +284,85 @@
   const aimOn = true;
 
   const rivals=[
-    { i:0, wrap:document.querySelector('#pv0'), ptsEl:document.querySelector('#pv0pts'), cvs:null, ctx:null, score:0, next:0, acc:0.68, rate:[1180,2180], shots:[], kx:0, kw:0, kh:0, g:null, avatar:'', flash:0, result:'', defX:0, defY:0, defBaseY:0, defVy:0, defJump:false, defW:0, scale:1 },
-    { i:1, wrap:document.querySelector('#pv1'), ptsEl:document.querySelector('#pv1pts'), cvs:null, ctx:null, score:0, next:0, acc:0.62, rate:[1275,2360], shots:[], kx:0, kw:0, kh:0, g:null, avatar:'', flash:0, result:'', defX:0, defY:0, defBaseY:0, defVy:0, defJump:false, defW:0, scale:1 },
-    { i:2, wrap:document.querySelector('#pv2'), ptsEl:document.querySelector('#pv2pts'), cvs:null, ctx:null, score:0, next:0, acc:0.58, rate:[1350,2510], shots:[], kx:0, kw:0, kh:0, g:null, avatar:'', flash:0, result:'', defX:0, defY:0, defBaseY:0, defVy:0, defJump:false, defW:0, scale:1 },
+    {
+      i:0,
+      wrap:document.querySelector('#pv0'),
+      ptsEl:document.querySelector('#pv0pts'),
+      cvs:null,
+      ctx:null,
+      score:0,
+      next:0,
+      acc:0.68,
+      // shoot a little quicker than before
+      rate:[1000,1850],
+      shots:[],
+      kx:0,
+      kw:0,
+      kh:0,
+      g:null,
+      avatar:'',
+      flash:0,
+      result:'',
+      defX:0,
+      defY:0,
+      defBaseY:0,
+      defVy:0,
+      defJump:false,
+      defW:0,
+      scale:1
+    },
+    {
+      i:1,
+      wrap:document.querySelector('#pv1'),
+      ptsEl:document.querySelector('#pv1pts'),
+      cvs:null,
+      ctx:null,
+      score:0,
+      next:0,
+      acc:0.62,
+      rate:[1085,2005],
+      shots:[],
+      kx:0,
+      kw:0,
+      kh:0,
+      g:null,
+      avatar:'',
+      flash:0,
+      result:'',
+      defX:0,
+      defY:0,
+      defBaseY:0,
+      defVy:0,
+      defJump:false,
+      defW:0,
+      scale:1
+    },
+    {
+      i:2,
+      wrap:document.querySelector('#pv2'),
+      ptsEl:document.querySelector('#pv2pts'),
+      cvs:null,
+      ctx:null,
+      score:0,
+      next:0,
+      acc:0.58,
+      rate:[1150,2135],
+      shots:[],
+      kx:0,
+      kw:0,
+      kh:0,
+      g:null,
+      avatar:'',
+      flash:0,
+      result:'',
+      defX:0,
+      defY:0,
+      defBaseY:0,
+      defVy:0,
+      defJump:false,
+      defW:0,
+      scale:1
+    },
   ];
   for(let i=0;i<rivals.length;i++){ rivals[i].cvs = rivals[i].wrap.querySelector('canvas'); rivals[i].ctx = rivals[i].cvs.getContext('2d'); rivals[i].avatar = pvAvatars[i]?.src || ''; }
   const miniHolesCache=[[],[],[]];
@@ -1281,7 +1357,9 @@ function onUp(e){
       c.lineTo(field.x+field.w,goal.y+goal.h);
       c.stroke();
 
-      const dw=defenders.w*scale, dh=(defenders.h*scale)/2;
+      const DEFENDER_PREVIEW_SCALE=0.7;
+      const dw=defenders.w*scale*DEFENDER_PREVIEW_SCALE;
+      const dh=(defenders.h*scale*DEFENDER_PREVIEW_SCALE)/2;
       if(init){
         r.defW = dw;
         r.defX = goal.x + Math.random()*(goal.w - dw);
@@ -1411,7 +1489,23 @@ function onUp(e){
         const chance = acc * (22/Math.max(10,target.r)) * 0.8;
         if(Math.random() < chance){
           const saved = Math.random() < 0.5;
-          if(!saved && !target.t && target.p){ r.score += Math.max(5, Math.round(target.p)); }
+          if(!saved){
+            if(target.t){
+              const extra=target.t*1000;
+              roundStart -= extra;
+              timeLeft += extra;
+              updateHUD();
+              sfxTimer();
+            } else if(target.b){
+              roundStart += 15000;
+              timeLeft = Math.max(0,timeLeft-15000);
+              r.score = Math.max(0,r.score-50);
+              updateHUD();
+              sfxExplosion();
+            } else if(target.p){
+              r.score += Math.max(5, Math.round(target.p));
+            }
+          }
           const startX = rnd(g.x, g.x + g.w);
           r.defX = clamp(startX - r.defW/2, g.x, g.x + g.w - r.defW);
           if(!r.defJump){ r.defVy = -2*r.scale; r.defJump = true; }


### PR DESCRIPTION
## Summary
- make Free Kick rivals shoot more often
- shrink rival defenders in previews
- apply timer and bomb effects to rival goals

## Testing
- `npm test` (fails: respects group assignment in eight-ball)
- `npm run lint` (fails: 965 errors)


------
https://chatgpt.com/codex/tasks/task_e_68b5b945feb8832985613ba5df669095