### PR TITLE
Adjust Free Kick AI shot timing

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -293,8 +293,8 @@
       score:0,
       next:0,
       acc:0.68,
-      // shoot a little quicker than before
-      rate:[1000,1850],
+      // shoot a bit quicker than before
+      rate:[900,1750],
       shots:[],
       kx:0,
       kw:0,
@@ -320,7 +320,7 @@
       score:0,
       next:0,
       acc:0.62,
-      rate:[1085,2005],
+      rate:[985,1905],
       shots:[],
       kx:0,
       kw:0,
@@ -346,7 +346,7 @@
       score:0,
       next:0,
       acc:0.58,
-      rate:[1150,2135],
+      rate:[1050,2035],
       shots:[],
       kx:0,
       kw:0,


### PR DESCRIPTION
## Summary
- speed up rival shot cadence in Free Kick by lowering AI shot intervals

## Testing
- `npm test` (fails: 5 failing tests)
- `npm run lint` (fails: 965 lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68b5c8958e808329a4f350e851b59e34