### PR TITLE
Streamline Pool Royale bracket UI

### DIFF
--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Canvas Bracket (8 / 16 / 24)</title>
+<title>Pool Royale Bracket</title>
 <style>
   :root{
     --bg:#0b1020;
@@ -36,19 +36,6 @@
     display:flex; gap:10px; align-items:center; flex-wrap:wrap;
   }
   .title{font-weight:700; letter-spacing:.6px; margin-right:auto}
-  select,button,textarea,input{
-    background:var(--panel);
-    color:var(--ink);
-    border:1px solid rgba(255,255,255,.08);
-    border-radius:10px;
-    padding:10px 12px;
-    outline:none;
-  }
-  select,button{height:40px}
-  button{cursor:pointer}
-  button:hover{filter:brightness(1.05)}
-  .toolbar{display:flex; gap:10px; align-items:center; flex-wrap:wrap}
-  .notes{font-size:.86rem; color:var(--muted)}
   .canvas-wrap{
     position:relative;
     overflow:auto; /* allow horizontal scroll on phones */
@@ -59,61 +46,29 @@
       radial-gradient(800px 300px at 50% 100%, rgba(249,115,22,.15), transparent 70%);
   }
   canvas{ display:block; margin:0 auto; }
-  .footer-note{padding:8px 12px; text-align:center; color:var(--muted); font-size:.85rem}
-  details{margin-left:auto}
-  summary{cursor:pointer}
-  .pill {
-    display:inline-flex; align-items:center; gap:8px; padding:4px 8px; border-radius:999px;
-    background:rgba(37,99,235,.15); border:1px solid rgba(37,99,235,.35); color:#cfe0ff;
-    font-size:.8rem;
-  }
 </style>
 </head>
 <body>
 <header>
   <div class="wrap">
-    <div class="title">🏆 Canvas Bracket</div>
-    <div class="toolbar">
-      <label for="size">Teams:</label>
-      <select id="size">
-        <option value="8" selected>8</option>
-        <option value="16">16</option>
-        <option value="24">24</option>
-      </select>
-      <button id="gen">Generate</button>
-      <button id="shuffle" title="Shuffle seeded teams">Random</button>
-      <span class="pill">Mobile: horizontal scroll</span>
-    </div>
+    <div class="title">🏆 Pool Royale Bracket</div>
   </div>
 </header>
-
-<div class="wrap" style="gap:16px">
-  <details>
-    <summary>📋 Enter team names (optional)</summary>
-    <div style="display:flex; gap:10px; flex-wrap:wrap; margin-top:8px">
-      <textarea id="names" rows="4" cols="40" placeholder="One team per line. If fewer than selected size, the rest will be BYE."></textarea>
-      <button id="apply">Apply names</button>
-    </div>
-  </details>
-  <div class="notes">Tip: Tap a team box in the first round to rename it. The entire bracket is drawn with <strong>Canvas</strong> only.</div>
-</div>
 
 <div class="canvas-wrap">
   <canvas id="board" width="1200" height="800" aria-label="Tournament bracket canvas"></canvas>
 </div>
-
-<div class="footer-note">© Canvas Bracket — no images / no binary files — responsive &lt;canvas&gt;.</div>
 
 <script>
 (function(){
   const DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
   const canvas = document.getElementById('board');
   const ctx = canvas.getContext('2d');
-  const sizeSel = document.getElementById('size');
-  const genBtn = document.getElementById('gen');
-  const shuffleBtn = document.getElementById('shuffle');
-  const applyBtn = document.getElementById('apply');
-  const namesTA = document.getElementById('names');
+  const players = window.bracketPlayers || [];
+  const potTotal = window.bracketPot || 0;
+  const tpcImage = new Image();
+  tpcImage.src = 'assets/icons/ezgif-54c96d8a9b9236.webp';
+  tpcImage.onload = () => layoutAndDraw();
 
   const theme = {
     bg:'#0b1020',
@@ -126,14 +81,12 @@
     line:'#233155'
   };
 
-  let hitRegions = []; // {round, match, slot, x,y,w,h}
-
   let state = {
-    teams: [],
-    N: 8,
+    N: players.length,
     bracketN: 8,
     rounds: [],
-    seedToName: {}
+    seedToName: {},
+    seedToPlayer: {}
   };
 
   function nextPow2(n){ let p=1; while(p<n) p<<=1; return p; }
@@ -154,18 +107,24 @@
     return pairs;
   }
 
-  function createBracket(Nrequested, names){
+  function createBracket(players){
+    const Nrequested = players.length;
     const pow2 = nextPow2(Nrequested);
     state.N = Nrequested;
     state.bracketN = pow2;
-    const namesTrim = (names || []).map(s=>s.trim()).filter(Boolean);
     const seedToName = {};
+    const seedToPlayer = {};
     for(let s=1; s<=pow2; s++){
-      if(s<=Nrequested && namesTrim[s-1]) seedToName[s]=namesTrim[s-1];
-      else if(s<=Nrequested) seedToName[s] = 'Team '+s;
-      else seedToName[s]='BYE';
+      if(s<=Nrequested){
+        const p = players[s-1];
+        seedToName[s] = p.name;
+        seedToPlayer[s] = p;
+      }else{
+        seedToName[s]='BYE';
+      }
     }
     state.seedToName = seedToName;
+    state.seedToPlayer = seedToPlayer;
 
     const r0 = round0PairsFromSeeds(pow2);
     state.rounds = [r0];
@@ -215,7 +174,6 @@
     ctx.clearRect(0,0,widthCSS,heightCSS);
     drawBackground(widthCSS, heightCSS);
 
-    hitRegions = [];
     for(let r=0;r<rounds;r++){
       const x = padX + r*(colW + colGap);
       drawRoundTitle(r, x, 6 + (r==0? 10:0));
@@ -311,11 +269,34 @@
     ctx.textAlign = 'left';
 
     const names = matchNames(r,m);
-    ctx.fillText(names[0], x+12, y+slotH/2+4);
-    ctx.fillText(names[1], x+12, y+slotH + slotH/2+4);
+    if(r===0){
+      const [sA, sB] = state.rounds[0][m];
+      const pA = state.seedToPlayer[sA];
+      const pB = state.seedToPlayer[sB];
+      drawPlayerSlot(x, y, slotH, names[0], pA);
+      drawPlayerSlot(x, y+slotH, slotH, names[1], pB);
+    }else{
+      drawPlayerSlot(x, y, slotH, names[0]);
+      drawPlayerSlot(x, y+slotH, slotH, names[1]);
+    }
 
-    hitRegions.push({round:r, match:m, slot:0, x:x+4, y:y+4, w:w-8, h:slotH-6});
-    hitRegions.push({round:r, match:m, slot:1, x:x+4, y:y+slotH+2, w:w-8, h:slotH-6});
+  }
+
+  function drawPlayerSlot(x, y, slotH, name, player){
+    const textX = x + 40;
+    ctx.fillText(name, textX, y + slotH/2 + 4);
+    if(player){
+      if(player.flag){
+        ctx.font = '20px system-ui,Segoe UI,Roboto,Arial';
+        ctx.fillText(player.flag, x+12, y + slotH/2 + 6);
+        ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
+      } else if(player.avatar){
+        const img = new Image();
+        img.src = player.avatar;
+        img.onload = () => ctx.drawImage(img, x+8, y + slotH/2 - 12, 24, 24);
+        if(img.complete) ctx.drawImage(img, x+8, y + slotH/2 - 12, 24, 24);
+      }
+    }
   }
 
   function matchNames(r,m){
@@ -379,66 +360,101 @@
     ctx.closePath();
   }
 
-  canvas.addEventListener('click', (ev)=>{
-    const rect = canvas.getBoundingClientRect();
-    const x = (ev.clientX - rect.left);
-    const y = (ev.clientY - rect.top);
-    for(const reg of hitRegions){
-      if(x>=reg.x && x<=reg.x+reg.w && y>=reg.y && y<=reg.y+reg.h){
-        const nm = prompt('Enter team name:', getNameAt(reg.round, reg.match, reg.slot));
-        if(nm && nm.trim()){
-          setNameAt(reg.round, reg.match, reg.slot, nm.trim());
-          layoutAndDraw();
+  let finalBox = null;
+
+  function drawPlayerPot(){
+    if(!finalBox) return;
+    const centerY = finalBox.y + finalBox.h/2;
+    const x = finalBox.x + finalBox.w + 10;
+    ctx.textAlign = 'left';
+    ctx.font = '20px system-ui,Segoe UI,Roboto,Arial';
+    ctx.fillText('🏆', x, centerY+7);
+    if(tpcImage.complete){
+      ctx.drawImage(tpcImage, x+28, centerY-12, 24, 24);
+    }
+    ctx.fillText(String(potTotal), x+56, centerY+7);
+  }
+
+  function layoutAndDraw(){
+    const rounds = state.rounds.length;
+    const colW = 220;
+    const colGap = 64;
+    const padX = 24;
+    const padY = 24;
+    const widthCSS = padX*2 + rounds*colW + (rounds-1)*colGap;
+
+    const matches0 = state.rounds[0].length;
+
+    const boxH = 56;
+    const slotH = boxH/2;
+    const baseGap = 28;
+
+    const centers = [];
+    centers[0] = Array.from({length:matches0}, (_,i)=> padY + (boxH/2) + i*(boxH + baseGap));
+    for(let r=1; r<rounds; r++){
+      const prev = centers[r-1];
+      const arr=[];
+      for(let i=0;i<Math.ceil(prev.length/2);i++){
+        const c = (prev[2*i] + prev[2*i+1]) / 2;
+        arr.push(c);
+      }
+      centers[r]=arr;
+    }
+
+    const lastCenter = centers[rounds-1][0] || padY + boxH/2;
+    const heightCSS = Math.max(600, lastCenter + padY + boxH/2);
+
+    canvas.style.width = widthCSS + 'px';
+    canvas.style.height = heightCSS + 'px';
+    canvas.width = Math.floor(widthCSS * DPR);
+    canvas.height = Math.floor(heightCSS * DPR);
+    ctx.setTransform(DPR,0,0,DPR,0,0);
+
+    ctx.clearRect(0,0,widthCSS,heightCSS);
+    drawBackground(widthCSS, heightCSS);
+
+    finalBox = null;
+    for(let r=0;r<rounds;r++){
+      const x = padX + r*(colW + colGap);
+      drawRoundTitle(r, x, 6 + (r==0? 10:0));
+
+      const matchesR = state.rounds[r].length;
+      for(let m=0;m<matchesR;m++){
+        const yCenter = centers[r][m];
+        drawMatchBox(r, m, x, yCenter - boxH/2, colW, boxH, slotH);
+        if(r===rounds-1 && m===0){
+          finalBox = {x, y:yCenter - boxH/2, w:colW, h:boxH};
         }
-        break;
+      }
+
+      if(r>0){
+        const xPrev = padX + (r-1)*(colW + colGap) + colW;
+        const xConn = xPrev + 18;
+        ctx.lineWidth = 2;
+        ctx.strokeStyle = theme.line;
+        ctx.beginPath();
+        for(let m=0;m<state.rounds[r].length;m++){
+          const cy = centers[r][m];
+          const top = centers[r-1][2*m];
+          const bot = centers[r-1][2*m+1];
+          ctx.moveTo(xPrev, top);
+          ctx.lineTo(xConn, top);
+          ctx.moveTo(xPrev, bot);
+          ctx.lineTo(xConn, bot);
+          ctx.moveTo(xConn, top);
+          ctx.lineTo(xConn, bot);
+          ctx.moveTo(xConn, cy);
+          ctx.lineTo(x, cy);
+        }
+        ctx.stroke();
       }
     }
-  });
 
-  function getNameAt(r,m,slot){
-    const [a,b] = matchNames(r,m);
-    return slot===0? a:b;
+    drawCenterLabels(widthCSS);
+    drawPlayerPot();
   }
 
-  function setNameAt(r,m,slot,newName){
-    if(r===0){
-      const seed = state.rounds[0][m][slot];
-      state.seedToName[seed] = newName;
-    }else{
-      alert('Names in this round are auto-filled from previous matches.');
-    }
-  }
-
-  genBtn.addEventListener('click', ()=>{
-    const N = parseInt(sizeSel.value,10);
-    createBracket(N, state.teams);
-  });
-
-  shuffleBtn.addEventListener('click', ()=>{
-    const N = state.N;
-    const arr = [];
-    for(let s=1; s<=N; s++){
-      arr.push(state.seedToName[s]);
-    }
-    for(let i=arr.length-1;i>0;i--){
-      const j = Math.floor(Math.random()*(i+1));
-      [arr[i], arr[j]] = [arr[j], arr[i]];
-    }
-    for(let s=1; s<=state.bracketN; s++){
-      if(s<=N) state.seedToName[s]=arr[s-1];
-      else state.seedToName[s]='BYE';
-    }
-    layoutAndDraw();
-  });
-
-  applyBtn.addEventListener('click', ()=>{
-    const lines = (namesTA.value || '').split(/\r?\n/).map(s=>s.trim()).filter(Boolean);
-    state.teams = lines;
-    const N = parseInt(sizeSel.value,10);
-    createBracket(N, lines);
-  });
-
-  createBracket(8, []);
+  createBracket(players);
   window.addEventListener('resize', ()=> layoutAndDraw());
 })();
 </script>


### PR DESCRIPTION
## Summary
- remove manual bracket controls from tournament page
- show player names with avatars or flags and add final pot icons

## Testing
- `npm test`
- `npm run lint` *(fails: 965 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ccba04208329bc5af0825d31024f