### PR TITLE
Remove demo text and show players in Pool Royale bracket

### DIFF
--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Canvas Bracket (8 / 16 / 24)</title>
+<title>Pool Royale Bracket</title>
 <style>
   :root{
     --bg:#0b1020;
@@ -23,32 +23,8 @@
     color:var(--ink);
     display:flex; flex-direction:column; gap:10px;
   }
-  header{
-    position:sticky; top:0; z-index:2;
-    background:linear-gradient(180deg, rgba(17,23,42,.95) 0%, rgba(17,23,42,.85) 100%);
-    backdrop-filter: blur(8px);
-    border-bottom:1px solid rgba(255,255,255,.06);
-  }
-  .wrap{
-    max-width:1100px;
-    margin:0 auto;
-    padding:10px 12px;
-    display:flex; gap:10px; align-items:center; flex-wrap:wrap;
-  }
-  .title{font-weight:700; letter-spacing:.6px; margin-right:auto}
-  select,button,textarea,input{
-    background:var(--panel);
-    color:var(--ink);
-    border:1px solid rgba(255,255,255,.08);
-    border-radius:10px;
-    padding:10px 12px;
-    outline:none;
-  }
-  select,button{height:40px}
-  button{cursor:pointer}
-  button:hover{filter:brightness(1.05)}
-  .toolbar{display:flex; gap:10px; align-items:center; flex-wrap:wrap}
-  .notes{font-size:.86rem; color:var(--muted)}
+  /* Original demo toolbar and notes are hidden */
+  header, .setup, .footer-note{display:none}
   .canvas-wrap{
     position:relative;
     overflow:auto; /* allow horizontal scroll on phones */
@@ -70,51 +46,15 @@
 </style>
 </head>
 <body>
-<header>
-  <div class="wrap">
-    <div class="title">🏆 Canvas Bracket</div>
-    <div class="toolbar">
-      <label for="size">Teams:</label>
-      <select id="size">
-        <option value="8" selected>8</option>
-        <option value="16">16</option>
-        <option value="24">24</option>
-      </select>
-      <button id="gen">Generate</button>
-      <button id="shuffle" title="Shuffle seeded teams">Random</button>
-      <span class="pill">Mobile: horizontal scroll</span>
-    </div>
-  </div>
-</header>
-
-<div class="wrap" style="gap:16px">
-  <details>
-    <summary>📋 Enter team names (optional)</summary>
-    <div style="display:flex; gap:10px; flex-wrap:wrap; margin-top:8px">
-      <textarea id="names" rows="4" cols="40" placeholder="One team per line. If fewer than selected size, the rest will be BYE."></textarea>
-      <button id="apply">Apply names</button>
-    </div>
-  </details>
-  <div class="notes">Tip: Tap a team box in the first round to rename it. The entire bracket is drawn with <strong>Canvas</strong> only.</div>
-</div>
-
 <div class="canvas-wrap">
   <canvas id="board" width="1200" height="800" aria-label="Tournament bracket canvas"></canvas>
 </div>
-
-<div class="footer-note">© Canvas Bracket — no images / no binary files — responsive &lt;canvas&gt;.</div>
 
 <script>
 (function(){
   const DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
   const canvas = document.getElementById('board');
   const ctx = canvas.getContext('2d');
-  const sizeSel = document.getElementById('size');
-  const genBtn = document.getElementById('gen');
-  const shuffleBtn = document.getElementById('shuffle');
-  const applyBtn = document.getElementById('apply');
-  const namesTA = document.getElementById('names');
-
   const theme = {
     bg:'#0b1020',
     panel:'#11172a',
@@ -129,11 +69,12 @@
   let hitRegions = []; // {round, match, slot, x,y,w,h}
 
   let state = {
-    teams: [],
-    N: 8,
-    bracketN: 8,
+    players: [],
+    N: 0,
+    bracketN: 0,
     rounds: [],
-    seedToName: {}
+    seedToPlayer: {},
+    pot: 0
   };
 
   function nextPow2(n){ let p=1; while(p<n) p<<=1; return p; }
@@ -154,18 +95,17 @@
     return pairs;
   }
 
-  function createBracket(Nrequested, names){
+  function createBracket(players){
+    const Nrequested = players.length;
     const pow2 = nextPow2(Nrequested);
     state.N = Nrequested;
     state.bracketN = pow2;
-    const namesTrim = (names || []).map(s=>s.trim()).filter(Boolean);
-    const seedToName = {};
+    const seedToPlayer = {};
     for(let s=1; s<=pow2; s++){
-      if(s<=Nrequested && namesTrim[s-1]) seedToName[s]=namesTrim[s-1];
-      else if(s<=Nrequested) seedToName[s] = 'Team '+s;
-      else seedToName[s]='BYE';
+      if(s<=Nrequested) seedToPlayer[s]=players[s-1];
+      else seedToPlayer[s]={name:'BYE'};
     }
-    state.seedToName = seedToName;
+    state.seedToPlayer = seedToPlayer;
 
     const r0 = round0PairsFromSeeds(pow2);
     state.rounds = [r0];
@@ -269,7 +209,7 @@
     let label = '';
     const rounds = state.rounds.length;
     if(r === 0) label = 'ROUND OF ' + state.bracketN;
-    else if(r === rounds-1) label = 'FINAL';
+    else if(r === rounds-1) label = 'FINAL 🏆 🪙' + state.pot;
     else if(r === rounds-2) label = 'SEMIFINAL';
     else label = 'QUARTER / R' + (r+1);
     ctx.fillText(label, x, topPad + 10);
@@ -310,22 +250,44 @@
     ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
     ctx.textAlign = 'left';
 
-    const names = matchNames(r,m);
-    ctx.fillText(names[0], x+12, y+slotH/2+4);
-    ctx.fillText(names[1], x+12, y+slotH + slotH/2+4);
+    const players = matchPlayers(r,m);
+    renderPlayer(players[0], x+12, y+slotH/2+4, slotH);
+    renderPlayer(players[1], x+12, y+slotH + slotH/2+4, slotH);
 
     hitRegions.push({round:r, match:m, slot:0, x:x+4, y:y+4, w:w-8, h:slotH-6});
     hitRegions.push({round:r, match:m, slot:1, x:x+4, y:y+slotH+2, w:w-8, h:slotH-6});
   }
 
-  function matchNames(r,m){
+  function matchPlayers(r,m){
     if(r===0){
       const [sA, sB] = state.rounds[0][m];
-      return [state.seedToName[sA], state.seedToName[sB]];
+      return [state.seedToPlayer[sA], state.seedToPlayer[sB]];
     }
-    const nameA = 'Winner '+labelForSource(r-1, 2*m);
-    const nameB = 'Winner '+labelForSource(r-1, 2*m+1);
+    const nameA = { name: 'Winner '+labelForSource(r-1, 2*m) };
+    const nameB = { name: 'Winner '+labelForSource(r-1, 2*m+1) };
     return [nameA, nameB];
+  }
+
+  function renderPlayer(player, x, y, slotH){
+    const avatarSize = 20;
+    if(player.flag){
+      ctx.fillText(player.flag, x, y+1);
+      ctx.fillText(player.name, x+18, y);
+    }else{
+      ctx.save();
+      ctx.beginPath();
+      ctx.arc(x+avatarSize/2, y-8, avatarSize/2, 0, Math.PI*2);
+      ctx.fillStyle = '#233155';
+      ctx.fill();
+      ctx.fillStyle = '#e7efff';
+      ctx.font = '600 11px system-ui,Segoe UI,Roboto,Arial';
+      ctx.textAlign = 'center';
+      ctx.fillText((player.name||'')[0]||'', x+avatarSize/2, y-4);
+      ctx.restore();
+      ctx.textAlign = 'left';
+      ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
+      ctx.fillText(player.name, x+avatarSize+6, y);
+    }
   }
 
   function labelForSource(r,m){
@@ -338,7 +300,7 @@
   }
 
   function seedShort(s){
-    const n = state.seedToName[s];
+    const n = state.seedToPlayer[s].name;
     if(n==='BYE') return 'BYE';
     if(/^Team \d+$/i.test(n)) return n.replace('Team ', '#');
     return n.length>10? n.slice(0,10)+'…': n;
@@ -396,50 +358,34 @@
   });
 
   function getNameAt(r,m,slot){
-    const [a,b] = matchNames(r,m);
-    return slot===0? a:b;
+    const [a,b] = matchPlayers(r,m);
+    return slot===0? a.name : b.name;
   }
 
   function setNameAt(r,m,slot,newName){
     if(r===0){
       const seed = state.rounds[0][m][slot];
-      state.seedToName[seed] = newName;
+      state.seedToPlayer[seed].name = newName;
     }else{
       alert('Names in this round are auto-filled from previous matches.');
     }
   }
 
-  genBtn.addEventListener('click', ()=>{
-    const N = parseInt(sizeSel.value,10);
-    createBracket(N, state.teams);
-  });
-
-  shuffleBtn.addEventListener('click', ()=>{
-    const N = state.N;
-    const arr = [];
-    for(let s=1; s<=N; s++){
-      arr.push(state.seedToName[s]);
-    }
-    for(let i=arr.length-1;i>0;i--){
-      const j = Math.floor(Math.random()*(i+1));
-      [arr[i], arr[j]] = [arr[j], arr[i]];
-    }
-    for(let s=1; s<=state.bracketN; s++){
-      if(s<=N) state.seedToName[s]=arr[s-1];
-      else state.seedToName[s]='BYE';
-    }
-    layoutAndDraw();
-  });
-
-  applyBtn.addEventListener('click', ()=>{
-    const lines = (namesTA.value || '').split(/\r?\n/).map(s=>s.trim()).filter(Boolean);
-    state.teams = lines;
-    const N = parseInt(sizeSel.value,10);
-    createBracket(N, lines);
-  });
-
-  createBracket(8, []);
-  window.addEventListener('resize', ()=> layoutAndDraw());
+  (function init(){
+    const players = window.tournamentPlayers || [
+      { name: 'Player 1' },
+      { name: 'Player 2' },
+      { name: 'Player 3' },
+      { name: 'Player 4' },
+      { name: 'Player 5' },
+      { name: 'Player 6' },
+      { name: 'USA', flag: '🇺🇸' },
+      { name: 'UK', flag: '🇬🇧' }
+    ];
+    state.players = players;
+    createBracket(players);
+    window.addEventListener('resize', ()=> layoutAndDraw());
+  })();
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- strip demo toolbar/text from Pool Royale bracket page
- render player names with avatars/flags and show prize pot icon in Final round

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d12c23ac83299b54816247231edf