### PR TITLE
Fix Pool Royale tournament continuation flow

### DIFF
--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1220,6 +1220,8 @@
                 state.finished = true;
                 if (winner !== 1) state.humanLost = true;
               }
+              delete state.currentMatch;
+              delete state.nextMatch;
               localStorage.setItem('poolTournament', JSON.stringify(state));
             }
             location.href = '/poll-royale-bracket.html';
@@ -3735,7 +3737,7 @@
         });
       }
 
-      if (params.get('type') === 'tournament') {
+      if (params.get('type') === 'tournament' && !params.get('round')) {
         const overlay = document.getElementById('tournamentOverlay');
         const canvas = document.getElementById('bracket');
         const ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- Show Pool Royale matches during tournament instead of bracket overlay
- Reset tournament state and return to bracket after each match

## Testing
- `npm test` *(fails: Claim contract configuration missing, 5 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dc58086c8329a68ade2ab416a8bf