### PR TITLE
Simulate tournament rounds and display final champion

### DIFF
--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -53,6 +53,36 @@
     border-radius:4px;
     display:block;
   }
+
+  #winnerOverlay {
+    position:fixed;
+    inset:0;
+    background:rgba(0,0,0,.8);
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    justify-content:center;
+    gap:16px;
+    z-index:100;
+  }
+  #winnerOverlay.hidden{display:none}
+  #winnerOverlay img{
+    width:120px;
+    height:120px;
+    border-radius:50%;
+    border:4px solid var(--accent);
+    object-fit:cover;
+  }
+  #winnerName{font-size:1.5rem; text-align:center}
+  #winnerOverlay button{
+    padding:8px 16px;
+    background:var(--accent);
+    color:#fff;
+    border:none;
+    border-radius:4px;
+  }
+  .coin-confetti{position:fixed;top:-40px;width:32px;height:32px;pointer-events:none;animation:coin-fall var(--duration,3s) linear forwards;z-index:120}
+  @keyframes coin-fall{from{transform:translateY(-10vh) rotate(0deg);opacity:1}to{transform:translateY(100vh) rotate(360deg);opacity:0}}
 </style>
 </head>
 <body>
@@ -62,6 +92,12 @@
 
 <button id="continueBtn">Continue</button>
 
+<div id="winnerOverlay" class="hidden">
+  <img id="winnerAvatar" alt="Winner Avatar" />
+  <div id="winnerName"></div>
+  <button id="lobbyBtn">Return to Lobby</button>
+</div>
+<script src="/brick-breaker-api.js"></script>
 <script>
 (function(){
   const DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
@@ -86,7 +122,8 @@
     bracketN: 0,
     rounds: [],
     seedToPlayer: {},
-    pot: 0
+    pot: 0,
+    paid: false
   };
 
   const STORAGE_KEY = 'poolTournament';
@@ -398,21 +435,26 @@
   }
 
   function simulateRemaining(){
+    if(state.finished) return;
     for(let r=0; r<state.rounds.length-1; r++){
       for(let m=0; m<state.rounds[r].length; m++){
+        const [sA,sB] = state.rounds[r][m];
+        if(sA===state.humanSeed || sB===state.humanSeed) continue;
         const nextRound = state.rounds[r+1];
         const idx = Math.floor(m/2);
         const pos = m%2;
         if(nextRound[idx][pos] === 0){
-          const [sA,sB] = state.rounds[r][m];
           const win = Math.random() < 0.5 ? sA : sB;
           nextRound[idx][pos] = win;
         }
       }
     }
     const finalRound = state.rounds[state.rounds.length-1];
-    state.champion = finalRound[0][0];
-    state.finished = true;
+    const [fA,fB] = finalRound[0] || [];
+    if(fA && fB && fA!==state.humanSeed && fB!==state.humanSeed){
+      state.champion = Math.random() < 0.5 ? fA : fB;
+      state.finished = true;
+    }
   }
 
   function updateButton(){
@@ -438,31 +480,80 @@
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
     const opponent = state.seedToPlayer[next.opponentSeed];
     const human = state.seedToPlayer[state.humanSeed];
-    location.href = `/poll-royale.html?type=tournament&round=${next.round}&match=${next.match}&players=${state.N}&name=${encodeURIComponent(human.name)}&opponent=${encodeURIComponent(opponent.name)}&flag=${encodeURIComponent(opponent.flag||'')}`;
+    const params = new URLSearchParams();
+    params.set('type','tournament');
+    params.set('round', next.round);
+    params.set('match', next.match);
+    params.set('players', state.N);
+    params.set('name', human.name);
+    if(human.avatar) params.set('avatar', human.avatar);
+    if(state.pot) params.set('amount', state.pot);
+    params.set('opponent', opponent.name);
+    if(opponent.flag) params.set('flag', opponent.flag);
+    location.href = `/poll-royale.html?${params.toString()}`;
+  }
+
+  function coinConfetti(count=50, iconSrc='/assets/icons/ezgif-54c96d8a9b9236.webp'){
+    for(let i=0;i<count;i++){
+      const img=document.createElement('img');
+      img.src=iconSrc;
+      img.className='coin-confetti';
+      img.style.left=Math.random()*100+'vw';
+      img.style.setProperty('--duration', 2 + Math.random()*2 + 's');
+      document.body.appendChild(img);
+      setTimeout(()=>img.remove(),3000);
+    }
+  }
+
+  function showChampion(){
+    const champ = state.seedToPlayer[state.champion];
+    if(!champ) return;
+    const overlay = document.getElementById('winnerOverlay');
+    const avatarEl = document.getElementById('winnerAvatar');
+    const nameEl = document.getElementById('winnerName');
+    avatarEl.src = champ.avatar || '/assets/icons/ezgif-54c96d8a9b9236.webp';
+    nameEl.textContent = `${champ.name} Wins!`;
+    overlay.classList.remove('hidden');
+    coinConfetti();
+    if(!state.paid && champ.accountId){
+      const amt = state.pot || 0;
+      bbApi.depositAccount(champ.accountId, amt, { game: 'pollroyale-tournament-win' });
+      if(champ.tgId){
+        bbApi.addTransaction(champ.tgId, amt, 'win', { game: 'pollroyale-tournament', players: state.N, accountId: champ.accountId });
+      }
+      state.paid = true;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    }
+    document.getElementById('lobbyBtn').addEventListener('click', ()=>{
+      location.href = '/games/pollroyale/lobby';
+    });
   }
 
   (function init(){
     const saved = localStorage.getItem(STORAGE_KEY);
     if(saved){
       Object.assign(state, JSON.parse(saved));
-      if(state.humanLost && !state.finished){
-        simulateRemaining();
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-      }
-      layoutAndDraw();
     }else{
       const params = new URLSearchParams(location.search);
       const num = parseInt(params.get('players') || '8',10);
       const playerName = params.get('name') || 'Player';
+      const avatar = params.get('avatar') || '';
+      const accountId = params.get('accountId') || '';
+      const tgId = params.get('tgId') || '';
+      const amount = parseInt(params.get('amount') || '0',10);
       const ai = AI_PLAYERS.slice(0, Math.max(0, num-1));
-      state.players = [{ name: playerName }].concat(ai);
+      state.players = [{ name: playerName, avatar, accountId, tgId }].concat(ai);
       createBracket(state.players);
       state.humanSeed = 1;
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      state.pot = amount;
     }
+    simulateRemaining();
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    layoutAndDraw();
     window.addEventListener('resize', ()=> layoutAndDraw());
     document.getElementById('continueBtn').addEventListener('click', continueTournament);
     updateButton();
+    if(state.finished) showChampion();
   })();
 })();
 </script>


### PR DESCRIPTION
## Summary
- Simulate AI vs AI match results each round so brackets advance automatically
- Enable tournament progression by passing pot and avatar data when continuing
- Add final champion overlay with coin celebration and deposit the prize to winner

## Testing
- `npm test`
- `npm run lint` *(fails: numerous style violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e96665c48329955716e858715788