### PR TITLE
Simulate AI matches and finalize Pool Royale tournament

### DIFF
--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -53,6 +53,16 @@
     border-radius:4px;
     display:block;
   }
+  .hidden{display:none}
+  #championOverlay{
+    position:fixed;top:0;left:0;width:100%;height:100%;
+    background:rgba(0,0,0,.8);display:flex;flex-direction:column;
+    align-items:center;justify-content:center;gap:12px;z-index:1000;
+  }
+  #championOverlay img{width:120px;height:120px;border-radius:50%}
+  #championOverlay button{padding:8px 16px;background:var(--accent);color:#fff;border:none;border-radius:4px}
+  .coin-confetti{position:fixed;top:-40px;width:32px;height:32px;pointer-events:none;animation:coin-fall var(--duration,3s) linear forwards;z-index:999}
+  @keyframes coin-fall{from{transform:translateY(-10vh) rotate(0deg);opacity:1}to{transform:translateY(100vh) rotate(360deg);opacity:0}}
 </style>
 </head>
 <body>
@@ -61,6 +71,12 @@
 </div>
 
 <button id="continueBtn">Continue</button>
+
+<div id="championOverlay" class="hidden">
+  <img id="championAvatar" alt="winner" />
+  <div id="championName"></div>
+  <button id="lobbyBtn">Return to Lobby</button>
+</div>
 
 <script>
 (function(){
@@ -86,7 +102,14 @@
     bracketN: 0,
     rounds: [],
     seedToPlayer: {},
-    pot: 0
+    pot: 0,
+    amount: 0,
+    token: 'TPC',
+    tgId: null,
+    accountId: null,
+    dev: null,
+    dev1: null,
+    dev2: null
   };
 
   const STORAGE_KEY = 'poolTournament';
@@ -420,6 +443,7 @@
     if(state.finished){
       btn.disabled = true;
       btn.textContent = 'Tournament Finished';
+      showChampion();
       return;
     }
     const next = findNextMatch();
@@ -438,7 +462,8 @@
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
     const opponent = state.seedToPlayer[next.opponentSeed];
     const human = state.seedToPlayer[state.humanSeed];
-    location.href = `/poll-royale.html?type=tournament&round=${next.round}&match=${next.match}&players=${state.N}&name=${encodeURIComponent(human.name)}&opponent=${encodeURIComponent(opponent.name)}&flag=${encodeURIComponent(opponent.flag||'')}`;
+    const avatar = human.avatar ? `&avatar=${encodeURIComponent(human.avatar)}` : '';
+    location.href = `/poll-royale.html?type=tournament&round=${next.round}&match=${next.match}&players=${state.N}&name=${encodeURIComponent(human.name)}&opponent=${encodeURIComponent(opponent.name)}&flag=${encodeURIComponent(opponent.flag||'')}${avatar}`;
   }
 
   (function init(){
@@ -454,16 +479,59 @@
       const params = new URLSearchParams(location.search);
       const num = parseInt(params.get('players') || '8',10);
       const playerName = params.get('name') || 'Player';
+      const avatar = params.get('avatar');
+      const amount = parseInt(params.get('amount') || '0',10);
+      state.amount = amount;
+      state.token = params.get('token') || 'TPC';
+      state.tgId = params.get('tgId');
+      state.accountId = params.get('accountId');
+      state.dev = params.get('dev');
+      state.dev1 = params.get('dev1');
+      state.dev2 = params.get('dev2');
       const ai = AI_PLAYERS.slice(0, Math.max(0, num-1));
-      state.players = [{ name: playerName }].concat(ai);
+      state.players = [{ name: playerName, avatar }].concat(ai);
       createBracket(state.players);
       state.humanSeed = 1;
+      const gross = amount * num;
+      state.pot = gross - Math.round(gross * 0.10);
       localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
     }
     window.addEventListener('resize', ()=> layoutAndDraw());
     document.getElementById('continueBtn').addEventListener('click', continueTournament);
     updateButton();
   })();
+
+  function coinConfetti(count, iconSrc){
+    count = count || 50;
+    iconSrc = iconSrc || '/assets/icons/ezgif-54c96d8a9b9236.webp';
+    for(let i=0;i<count;i++){
+      const img = document.createElement('img');
+      img.src = iconSrc;
+      img.className = 'coin-confetti';
+      img.style.left = Math.random()*100 + 'vw';
+      img.style.setProperty('--duration', 2 + Math.random()*2 + 's');
+      document.body.appendChild(img);
+      setTimeout(()=>img.remove(),3000);
+    }
+  }
+
+  function showChampion(){
+    const overlay = document.getElementById('championOverlay');
+    if(!state.champion) return;
+    const champ = state.seedToPlayer[state.champion] || {};
+    const img = document.getElementById('championAvatar');
+    const nameEl = document.getElementById('championName');
+    if(champ.avatar){ img.src = champ.avatar; img.classList.remove('hidden'); }
+    else if(champ.flag){ img.src = ''; img.classList.add('hidden'); nameEl.textContent = champ.flag + ' ' + (champ.name||''); }
+    else { img.src = ''; img.classList.add('hidden'); nameEl.textContent = champ.name || ''; }
+    if(img.src) nameEl.textContent = champ.name || '';
+    overlay.classList.remove('hidden');
+    coinConfetti(80);
+    const lobbyBtn = document.getElementById('lobbyBtn');
+    const win = state.champion === state.humanSeed;
+    const lobbyUrl = win ? '/games/pollroyale/lobby?winner=1' : '/games/pollroyale/lobby?winner=0';
+    lobbyBtn.onclick = ()=>{ location.href = lobbyUrl; };
+  }
 })();
 </script>
 </body>

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -896,6 +896,7 @@
     </div>
 
     <script src="/flag-emojis.js"></script>
+    <script src="/falling-ball-api.js"></script>
 
     <!--
     Shenim: Perdorim script me type="text/javascript" per te shmangur
@@ -1201,7 +1202,7 @@
         }
 
         if (window.tournamentMode) {
-          window.handleTournamentResult = function (winner) {
+          window.handleTournamentResult = async function (winner) {
             var round = parseInt(urlParams.get('round') || '0', 10);
             var match = parseInt(urlParams.get('match') || '0', 10);
             var state = JSON.parse(localStorage.getItem('poolTournament') || '{}');
@@ -1215,6 +1216,15 @@
                 nextRound[idx][pos] = winnerSeed;
                 if (winner === 1) state.humanSeed = winnerSeed;
                 else state.humanLost = true;
+                for (var m = 0; m < state.rounds[round].length; m++) {
+                  var idx2 = Math.floor(m / 2);
+                  var pos2 = m % 2;
+                  if (nextRound[idx2][pos2] === 0) {
+                    var pair2 = state.rounds[round][m];
+                    var win = Math.random() < 0.5 ? pair2[0] : pair2[1];
+                    nextRound[idx2][pos2] = win;
+                  }
+                }
               } else {
                 state.champion = winnerSeed;
                 state.finished = true;
@@ -1223,6 +1233,53 @@
               delete state.currentMatch;
               delete state.nextMatch;
               localStorage.setItem('poolTournament', JSON.stringify(state));
+              if (state.finished) {
+                try {
+                  var gross = (state.amount || 0) * (state.N || 0);
+                  var fee = Math.round(gross * 0.1);
+                  var net = gross - fee;
+                  var ops = [];
+                  if (state.dev1 || state.dev2) {
+                    if (state.dev)
+                      ops.push(
+                        fbApi.depositAccount(state.dev, Math.round(gross * 0.09), {
+                          game: 'pollroyale-dev',
+                        })
+                      );
+                    if (state.dev1)
+                      ops.push(
+                        fbApi.depositAccount(state.dev1, Math.round(gross * 0.01), {
+                          game: 'pollroyale-dev1',
+                        })
+                      );
+                    if (state.dev2)
+                      ops.push(
+                        fbApi.depositAccount(state.dev2, Math.round(gross * 0.02), {
+                          game: 'pollroyale-dev2',
+                        })
+                      );
+                  } else if (state.dev) {
+                    ops.push(
+                      fbApi.depositAccount(state.dev, Math.round(gross * 0.1), {
+                        game: 'pollroyale-dev',
+                      })
+                    );
+                  }
+                  if (winner === 1 && state.accountId)
+                    ops.push(
+                      fbApi.depositAccount(state.accountId, net, {
+                        game: 'pollroyale-win',
+                      })
+                    );
+                  await Promise.all(ops);
+                  if (winner === 1 && state.tgId)
+                    await fbApi.addTransaction(state.tgId, 0, 'win', {
+                      game: 'pollroyale',
+                      players: state.N,
+                      accountId: state.accountId,
+                    });
+                } catch (e) {}
+              }
             }
             location.href = '/poll-royale-bracket.html';
           };


### PR DESCRIPTION
## Summary
- simulate remaining AI vs AI matches each round and process final payouts
- add champion overlay with coin celebration and lobby return

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon...)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ee8df6808329ad58b943be2d9ccb