### PR TITLE
Fix tournament flow for Pool Royale

### DIFF
--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -478,7 +478,9 @@
   }
 
   (function init(){
-    const saved = localStorage.getItem(STORAGE_KEY);
+    const params = new URLSearchParams(location.search);
+    const newTournament = params.has('players');
+    const saved = newTournament ? null : localStorage.getItem(STORAGE_KEY);
     if(saved){
       Object.assign(state, JSON.parse(saved));
       if(state.humanLost && !state.finished){
@@ -487,7 +489,7 @@
       }
       layoutAndDraw();
     }else{
-      const params = new URLSearchParams(location.search);
+      if(newTournament) localStorage.removeItem(STORAGE_KEY);
       const num = parseInt(params.get('players') || '8',10);
       const playerName = params.get('name') || 'Player';
       const avatar = params.get('avatar');
@@ -527,6 +529,7 @@
   }
 
   function showChampion(){
+    localStorage.removeItem(STORAGE_KEY);
     const overlay = document.getElementById('championOverlay');
     if(!state.champion) return;
     const champ = state.seedToPlayer[state.champion] || {};


### PR DESCRIPTION
## Summary
- Reset stored tournament state when starting a new Pool Royale tournament
- Clear saved tournament data once a champion is shown so a fresh tournament can begin

## Testing
- `npm test`
- `npm run lint` *(fails: 965 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fb0acc608329a9e46484e012df71