### PR TITLE
Restore Pool Royale pages to post-text-removal state

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -269,7 +269,7 @@
   const ballImg = new Image();
   ballImg.src = '/assets/icons/file_0000000061d4620aaf506adfa605e1f3.webp';
 
-  let holes=[]; let banners=[]; let cameras=[]; let looseBalls=[]; let punchEffects=[]; let prizePieces=[]; let ballPieces=[];
+  let holes=[]; let banners=[]; let cameras=[]; let looseBalls=[]; let punchEffects=[];
   let netHit={x:0,y:0,t:0,shake:0};
   let goalFlash=0;
   let missFlash=0;
@@ -293,8 +293,8 @@
       score:0,
       next:0,
       acc:0.68,
-      // base shot interval (50% faster)
-      rate:[533,1100],
+      // shoot faster than before
+      rate:[800,1650],
       shots:[],
       kx:0,
       kw:0,
@@ -320,7 +320,7 @@
       score:0,
       next:0,
       acc:0.62,
-      rate:[590,1203],
+      rate:[885,1805],
       shots:[],
       kx:0,
       kw:0,
@@ -346,7 +346,7 @@
       score:0,
       next:0,
       acc:0.58,
-      rate:[633,1290],
+      rate:[950,1935],
       shots:[],
       kx:0,
       kw:0,
@@ -591,7 +591,6 @@
   }
 
   function explodeBall(){
-    spawnBallPieces(ball.x, ball.y);
     const rect=canvas.getBoundingClientRect();
     const x=rect.left + (ball.x/W)*rect.width;
     const y=rect.top + (ball.y/H)*rect.height;
@@ -909,32 +908,6 @@
     ctx.globalAlpha=1;
     punchEffects=punchEffects.filter(p=>p.life>0);
   }
-
-  function drawPrizePieces(){
-    ctx.save();
-    for(const p of prizePieces){
-      ctx.globalAlpha=p.life;
-      ctx.fillStyle='#ffd400';
-      ctx.beginPath();
-      ctx.arc(p.x,p.y,p.r,0,Math.PI*2);
-      ctx.fill();
-    }
-    ctx.restore();
-    ctx.globalAlpha=1;
-  }
-
-  function drawBallPieces(){
-    ctx.save();
-    for(const p of ballPieces){
-      ctx.globalAlpha=p.life;
-      ctx.fillStyle='#fff';
-      ctx.beginPath();
-      ctx.arc(p.x,p.y,p.r,0,Math.PI*2);
-      ctx.fill();
-    }
-    ctx.restore();
-    ctx.globalAlpha=1;
-  }
   const FRICTION=0.995, AIR_DRAG=0.0006, GRAVITY=0.20; // reduce drag for smoother motion
   function stepBall(){
     if(!ball.moving) return;
@@ -1080,7 +1053,6 @@
         // break a prize once the ball overlaps roughly 30% of its radius
         if(Math.hypot(h.x-ball.x,h.y-ball.y) <= Math.max(2, h.r + ball.r * 0.3)){
           h.hit=true;
-          spawnPrizePieces(h.x,h.y,h.r);
           if(h.timer){
             const extra=h.timer*1000;
             roundStart -= extra;
@@ -1218,42 +1190,7 @@
     }
     looseBalls = looseBalls.filter(b => !b.remove);
   }
-  function stepPrizePieces(){
-    for(const p of prizePieces){
-      p.vy += GRAVITY*0.4;
-      p.x += p.vx;
-      p.y += p.vy;
-      p.life -= 0.02;
-    }
-    prizePieces = prizePieces.filter(p=>p.life>0);
-  }
 
-  function stepBallPieces(){
-    for(const p of ballPieces){
-      p.vy += GRAVITY*0.4;
-      p.x += p.vx;
-      p.y += p.vy;
-      p.life -= 0.02;
-    }
-    ballPieces = ballPieces.filter(p=>p.life>0);
-  }
-
-  function spawnPrizePieces(x,y,r){
-    for(let i=0;i<8;i++){
-      const ang=Math.random()*Math.PI*2;
-      const speed=rnd(1,4);
-      prizePieces.push({x,y,r:r*0.2,vx:Math.cos(ang)*speed,vy:Math.sin(ang)*speed-1,life:1});
-    }
-  }
-
-  function spawnBallPieces(x,y){
-    const baseR=Math.max(BALL_R*geom.scale,22)*0.3;
-    for(let i=0;i<10;i++){
-      const ang=Math.random()*Math.PI*2;
-      const speed=rnd(2,5);
-      ballPieces.push({x,y,r:baseR,vx:Math.cos(ang)*speed,vy:Math.sin(ang)*speed-1,life:1});
-    }
-  }
 
   function stepDefenders(){
     if(!defenders.jumping) return;
@@ -1572,8 +1509,8 @@ function onUp(e){
           const startX = rnd(g.x, g.x + g.w);
           r.defX = clamp(startX - r.defW/2, g.x, g.x + g.w - r.defW);
           if(!r.defJump){ r.defVy = -2*r.scale; r.defJump = true; }
-          const vx = (target.x - startX) / 10;
-          const vy = (target.y - (g.y + g.h)) / 10;
+          const vx = (target.x - startX) / 15;
+          const vy = (target.y - (g.y + g.h)) / 15;
           r.shots.push({x:startX,y:g.y+g.h,vx,vy,life:1,saved});
         }
       }
@@ -1583,7 +1520,7 @@ function onUp(e){
 
   // ===== Timer + loop =====
   function tick(now){ if(!running||paused) return; if(!roundStart) roundStart=now; timeLeft = Math.max(0, ROUND_TIME - (now - roundStart)); timeShort.textContent = Math.ceil(timeLeft/1000); if(timeLeft<=0){ finish(); } }
-function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoal(); drawBall(); drawDefenders(); drawPunchEffects(); drawPrizePieces(); drawBallPieces(); stepBall(); stepLooseBalls(); stepPrizePieces(); stepBallPieces(); stepDefenders(); stepKeeper(); drawMiniBoards(); tick(now||performance.now()); stepRivals(now||performance.now()); updateHUD(); netHit.t*=NET_DECAY; netHit.shake*=NET_DECAY; goalFlash*=0.92; missFlash*=0.92; }
+  function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoal(); drawBall(); drawDefenders(); drawPunchEffects(); stepBall(); stepLooseBalls(); stepDefenders(); stepKeeper(); drawMiniBoards(); tick(now||performance.now()); stepRivals(now||performance.now()); updateHUD(); netHit.t*=NET_DECAY; netHit.shake*=NET_DECAY; goalFlash*=0.92; missFlash*=0.92; }
 
   // ===== Controls =====
   // controls removed
@@ -1608,7 +1545,6 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     ball.pathIndex = 0;
     ball.pathSpeed = 0;
     ball.exploded = false;
-    ballPieces=[];
     defenders.x = clamp(ball.x - defenders.w/2, 0, W - defenders.w);
     defenders.y = defenders.baseY;
     defenders.vy = 0;
@@ -1649,8 +1585,6 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     timeLeft=ROUND_TIME;
     myScore=0;
     looseBalls=[];
-    prizePieces=[];
-    ballPieces=[];
     for(const r of rivals){ r.score=0; r.next=0; r.shots=[]; }
     resetBall();
     generateHoles();
@@ -1713,7 +1647,7 @@ function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoa
     const src=audioCtx.createBufferSource();
     src.buffer=postHitSoundBuf;
     const gain=audioCtx.createGain();
-    gain.gain.value=0.45; // slightly louder on post/crossbar hits
+    gain.gain.value=0.35; // further reduce volume on post/crossbar hits
     src.connect(gain).connect(masterGain);
     // Skip ~0.4s of initial silence so the clang matches contact
     src.start(0, 0.4);

--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -43,24 +43,12 @@
     background:rgba(37,99,235,.15); border:1px solid rgba(37,99,235,.35); color:#cfe0ff;
     font-size:.8rem;
   }
-
-  #continueBtn {
-    margin:8px auto 16px;
-    padding:8px 16px;
-    background:var(--accent);
-    color:#fff;
-    border:none;
-    border-radius:4px;
-    display:block;
-  }
 </style>
 </head>
 <body>
 <div class="canvas-wrap">
   <canvas id="board" width="1200" height="800" aria-label="Tournament bracket canvas"></canvas>
 </div>
-
-<button id="continueBtn">Continue</button>
 
 <script>
 (function(){
@@ -88,42 +76,6 @@
     seedToPlayer: {},
     pot: 0
   };
-
-  const STORAGE_KEY = 'poolTournament';
-  const AI_PLAYERS = [
-    { name: 'USA', flag: '🇺🇸' },
-    { name: 'UK', flag: '🇬🇧' },
-    { name: 'Brazil', flag: '🇧🇷' },
-    { name: 'France', flag: '🇫🇷' },
-    { name: 'Germany', flag: '🇩🇪' },
-    { name: 'Japan', flag: '🇯🇵' },
-    { name: 'Canada', flag: '🇨🇦' },
-    { name: 'Italy', flag: '🇮🇹' },
-    { name: 'Spain', flag: '🇪🇸' },
-    { name: 'Mexico', flag: '🇲🇽' },
-    { name: 'China', flag: '🇨🇳' },
-    { name: 'India', flag: '🇮🇳' },
-    { name: 'Australia', flag: '🇦🇺' },
-    { name: 'Russia', flag: '🇷🇺' },
-    { name: 'South Korea', flag: '🇰🇷' },
-    { name: 'Argentina', flag: '🇦🇷' },
-    { name: 'Netherlands', flag: '🇳🇱' },
-    { name: 'Sweden', flag: '🇸🇪' },
-    { name: 'Norway', flag: '🇳🇴' },
-    { name: 'Denmark', flag: '🇩🇰' },
-    { name: 'Belgium', flag: '🇧🇪' },
-    { name: 'Portugal', flag: '🇵🇹' },
-    { name: 'Poland', flag: '🇵🇱' },
-    { name: 'Turkey', flag: '🇹🇷' },
-    { name: 'Greece', flag: '🇬🇷' },
-    { name: 'Iran', flag: '🇮🇷' },
-    { name: 'Iraq', flag: '🇮🇶' },
-    { name: 'Egypt', flag: '🇪🇬' },
-    { name: 'South Africa', flag: '🇿🇦' },
-    { name: 'Nigeria', flag: '🇳🇬' },
-    { name: 'Kenya', flag: '🇰🇪' },
-    { name: 'Chile', flag: '🇨🇱' }
-  ];
 
   function nextPow2(n){ let p=1; while(p<n) p<<=1; return p; }
 
@@ -307,10 +259,13 @@
   }
 
   function matchPlayers(r,m){
-    const pair = state.rounds[r][m];
-    const pA = state.seedToPlayer[pair[0]] || { name: 'TBD' };
-    const pB = state.seedToPlayer[pair[1]] || { name: 'TBD' };
-    return [pA, pB];
+    if(r===0){
+      const [sA, sB] = state.rounds[0][m];
+      return [state.seedToPlayer[sA], state.seedToPlayer[sB]];
+    }
+    const nameA = { name: 'Winner '+labelForSource(r-1, 2*m) };
+    const nameB = { name: 'Winner '+labelForSource(r-1, 2*m+1) };
+    return [nameA, nameB];
   }
 
   function renderPlayer(player, x, y, slotH){
@@ -333,6 +288,22 @@
       ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
       ctx.fillText(player.name, x+avatarSize+6, y);
     }
+  }
+
+  function labelForSource(r,m){
+    if(r===0){
+      const [sA,sB]=state.rounds[0][m];
+      return `(${seedShort(sA)} vs ${seedShort(sB)})`;
+    }else{
+      return `R${r+1}-M${m+1}`;
+    }
+  }
+
+  function seedShort(s){
+    const n = state.seedToPlayer[s].name;
+    if(n==='BYE') return 'BYE';
+    if(/^Team \d+$/i.test(n)) return n.replace('Team ', '#');
+    return n.length>10? n.slice(0,10)+'…': n;
   }
 
   function drawCenterLabels(w){
@@ -370,99 +341,50 @@
     ctx.closePath();
   }
 
+  canvas.addEventListener('click', (ev)=>{
+    const rect = canvas.getBoundingClientRect();
+    const x = (ev.clientX - rect.left);
+    const y = (ev.clientY - rect.top);
+    for(const reg of hitRegions){
+      if(x>=reg.x && x<=reg.x+reg.w && y>=reg.y && y<=reg.y+reg.h){
+        const nm = prompt('Enter team name:', getNameAt(reg.round, reg.match, reg.slot));
+        if(nm && nm.trim()){
+          setNameAt(reg.round, reg.match, reg.slot, nm.trim());
+          layoutAndDraw();
+        }
+        break;
+      }
+    }
+  });
+
   function getNameAt(r,m,slot){
     const [a,b] = matchPlayers(r,m);
     return slot===0? a.name : b.name;
   }
 
   function setNameAt(r,m,slot,newName){
-    const seed = state.rounds[0][m][slot];
-    state.seedToPlayer[seed].name = newName;
-  }
-
-  function findNextMatch(){
-    for(let r=0; r<state.rounds.length-1; r++){
-      for(let m=0; m<state.rounds[r].length; m++){
-        const [sA,sB] = state.rounds[r][m];
-        if(sA===state.humanSeed || sB===state.humanSeed){
-          const nextRound = state.rounds[r+1];
-          const idx = Math.floor(m/2);
-          const pos = m%2;
-          if(nextRound[idx][pos] === 0){
-            return {round:r, match:m, opponentSeed: sA===state.humanSeed? sB : sA};
-          }
-        }
-      }
+    if(r===0){
+      const seed = state.rounds[0][m][slot];
+      state.seedToPlayer[seed].name = newName;
+    }else{
+      alert('Names in this round are auto-filled from previous matches.');
     }
-    return null;
-  }
-
-  function simulateRemaining(){
-    for(let r=0; r<state.rounds.length-1; r++){
-      for(let m=0; m<state.rounds[r].length; m++){
-        const nextRound = state.rounds[r+1];
-        const idx = Math.floor(m/2);
-        const pos = m%2;
-        if(nextRound[idx][pos] === 0){
-          const [sA,sB] = state.rounds[r][m];
-          const win = Math.random() < 0.5 ? sA : sB;
-          nextRound[idx][pos] = win;
-        }
-      }
-    }
-    const finalRound = state.rounds[state.rounds.length-1];
-    state.champion = finalRound[0][0];
-    state.finished = true;
-  }
-
-  function updateButton(){
-    const btn = document.getElementById('continueBtn');
-    if(state.finished){
-      btn.disabled = true;
-      btn.textContent = 'Tournament Finished';
-      return;
-    }
-    const next = findNextMatch();
-    state.nextMatch = next;
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-    if(!next){
-      btn.disabled = true;
-      btn.textContent = 'Tournament Finished';
-    }
-  }
-
-  function continueTournament(){
-    const next = state.nextMatch || findNextMatch();
-    if(!next) return;
-    state.currentMatch = next;
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-    const opponent = state.seedToPlayer[next.opponentSeed];
-    const human = state.seedToPlayer[state.humanSeed];
-    location.href = `/poll-royale.html?type=tournament&round=${next.round}&match=${next.match}&players=${state.N}&name=${encodeURIComponent(human.name)}&opponent=${encodeURIComponent(opponent.name)}&flag=${encodeURIComponent(opponent.flag||'')}`;
   }
 
   (function init(){
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if(saved){
-      Object.assign(state, JSON.parse(saved));
-      if(state.humanLost && !state.finished){
-        simulateRemaining();
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-      }
-      layoutAndDraw();
-    }else{
-      const params = new URLSearchParams(location.search);
-      const num = parseInt(params.get('players') || '8',10);
-      const playerName = params.get('name') || 'Player';
-      const ai = AI_PLAYERS.slice(0, Math.max(0, num-1));
-      state.players = [{ name: playerName }].concat(ai);
-      createBracket(state.players);
-      state.humanSeed = 1;
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-    }
+    const players = window.tournamentPlayers || [
+      { name: 'Player 1' },
+      { name: 'Player 2' },
+      { name: 'Player 3' },
+      { name: 'Player 4' },
+      { name: 'Player 5' },
+      { name: 'Player 6' },
+      { name: 'USA', flag: '🇺🇸' },
+      { name: 'UK', flag: '🇬🇧' }
+    ];
+    state.players = players;
+    createBracket(players);
     window.addEventListener('resize', ()=> layoutAndDraw());
-    document.getElementById('continueBtn').addEventListener('click', continueTournament);
-    updateButton();
   })();
 })();
 </script>

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -166,12 +166,6 @@
         flex: 1 1 auto;
         display: flex;
         overflow: hidden;
-      }
-
-      #wrap::before {
-        content: '';
-        position: absolute;
-        inset: 0;
         /* Ensure background image covers the available space without
          overlapping top or bottom elements. Extend the width slightly
          so the thin green boundary line is fully visible while keeping
@@ -179,7 +173,6 @@
         background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
           top center/calc(100% + 8px) calc(100% + 20px) no-repeat;
         filter: brightness(var(--table-brightness));
-        z-index: 0;
       }
 
       :root {
@@ -587,12 +580,12 @@
       #trainingMenuWrapper {
         position: fixed;
         left: 12px;
-        bottom: 48px;
+        bottom: 60px;
         z-index: 300;
       }
       #trainingMenuButton {
-        width: 36px;
-        height: 36px;
+        width: 40px;
+        height: 40px;
         border-radius: 8px;
         border: 1px solid #24375f;
         background: #20345a;
@@ -1200,32 +1193,6 @@
           avatarP1.textContent = '';
         }
 
-        if (window.tournamentMode) {
-          window.handleTournamentResult = function (winner) {
-            var round = parseInt(urlParams.get('round') || '0', 10);
-            var match = parseInt(urlParams.get('match') || '0', 10);
-            var state = JSON.parse(localStorage.getItem('poolTournament') || '{}');
-            if (state.rounds && state.rounds[round]) {
-              var pair = state.rounds[round][match];
-              var winnerSeed = winner === 1 ? pair[0] : pair[1];
-              var nextRound = state.rounds[round + 1];
-              if (nextRound) {
-                var idx = Math.floor(match / 2);
-                var pos = match % 2;
-                nextRound[idx][pos] = winnerSeed;
-                if (winner === 1) state.humanSeed = winnerSeed;
-                else state.humanLost = true;
-              } else {
-                state.champion = winnerSeed;
-                state.finished = true;
-                if (winner !== 1) state.humanLost = true;
-              }
-              localStorage.setItem('poolTournament', JSON.stringify(state));
-            }
-            location.href = '/poll-royale-bracket.html';
-          };
-        }
-
         function coinConfetti(count, iconSrc) {
           count = count || 50;
           iconSrc = iconSrc || '/assets/icons/ezgif-54c96d8a9b9236.webp';
@@ -1461,12 +1428,7 @@
             return 'AI';
           }
         }
-        var oppFlag = urlParams.get('flag');
-        var oppName = urlParams.get('opponent');
-        if (oppFlag && oppName) {
-          avatarCPU.textContent = oppFlag;
-          formatPlayerName(oppName, nameCPU);
-        } else if (window.FLAG_EMOJIS) {
+        if (window.FLAG_EMOJIS) {
           var flag = FLAG_EMOJIS[(Math.random() * FLAG_EMOJIS.length) | 0];
           avatarCPU.textContent = flag;
           formatPlayerName(flagToName(flag) || 'CPU', nameCPU);


### PR DESCRIPTION
## Summary
- Revert Pool Royale bracket and main page to the version right after top text removal
- Restore original Free Kick AI rates and remove later overlays

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, 'inc' is never reassigned. Use 'const' instead, and 962 more errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b67dfb8b1c8329ba8e48526e39a519