### PR TITLE
feat: add tournament bracket logic for pool royale

### DIFF
--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -23,11 +23,10 @@
     color:var(--ink);
     display:flex; flex-direction:column; gap:10px;
   }
-  /* Original demo toolbar and notes are hidden */
   header, .setup, .footer-note{display:none}
   .canvas-wrap{
     position:relative;
-    overflow:auto; /* allow horizontal scroll on phones */
+    overflow:auto;
     border-top:1px solid rgba(255,255,255,.06);
     border-bottom:1px solid rgba(255,255,255,.06);
     background:
@@ -35,357 +34,226 @@
       radial-gradient(800px 300px at 50% 100%, rgba(249,115,22,.15), transparent 70%);
   }
   canvas{ display:block; margin:0 auto; }
-  .footer-note{padding:8px 12px; text-align:center; color:var(--muted); font-size:.85rem}
-  details{margin-left:auto}
-  summary{cursor:pointer}
-  .pill {
-    display:inline-flex; align-items:center; gap:8px; padding:4px 8px; border-radius:999px;
-    background:rgba(37,99,235,.15); border:1px solid rgba(37,99,235,.35); color:#cfe0ff;
-    font-size:.8rem;
-  }
+  .players{display:flex;flex-wrap:wrap;gap:8px;padding:10px;justify-content:center}
+  .players .p{background:var(--panel);border:1px solid rgba(255,255,255,.06);padding:4px 8px;border-radius:6px;font-size:12px}
+  #continueBtn{margin:10px auto 20px;padding:8px 16px;background:var(--accent);border:none;border-radius:8px;color:#fff;font-weight:600;cursor:pointer;display:block}
+  #continueBtn.hidden{display:none}
 </style>
 </head>
 <body>
+<div id="playerList" class="players"></div>
 <div class="canvas-wrap">
   <canvas id="board" width="1200" height="800" aria-label="Tournament bracket canvas"></canvas>
 </div>
-
+<button id="continueBtn" class="hidden">Continue</button>
+<script src="flag-emojis.js"></script>
 <script>
 (function(){
   const DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
   const canvas = document.getElementById('board');
   const ctx = canvas.getContext('2d');
-  const theme = {
-    bg:'#0b1020',
-    panel:'#11172a',
-    ink:'#dbe7ff',
-    muted:'#8aa0d1',
-    neonA:'#2563eb',
-    neonB:'#f97316',
-    neonC:'#a855f7',
-    line:'#233155'
-  };
-
-  let hitRegions = []; // {round, match, slot, x,y,w,h}
-
-  let state = {
-    players: [],
-    N: 0,
-    bracketN: 0,
-    rounds: [],
-    seedToPlayer: {},
-    pot: 0
-  };
+  const theme = { bg:'#0b1020', panel:'#11172a', ink:'#dbe7ff', muted:'#8aa0d1', neonA:'#2563eb', neonB:'#f97316', neonC:'#a855f7', line:'#233155' };
+  let state = null;
+  const regionNames = new Intl.DisplayNames(['en'], {type:'region'});
+  function flagName(flag){ try{ const code=[...flag].map(c=>String.fromCharCode(c.codePointAt(0)-127397)).join(''); return regionNames.of(code)||'AI'; }catch{return 'AI';} }
 
   function nextPow2(n){ let p=1; while(p<n) p<<=1; return p; }
+  function seedOrder(N){ if(N===2) return [1,2]; const prev=seedOrder(N/2); const mirror=prev.map(x=>N+1-x); return prev.concat(mirror); }
+  function round0PairsFromSeeds(N){ const order=seedOrder(N); const pairs=[]; for(let i=0;i<N;i+=2){ pairs.push([order[i],order[i+1]]); } return pairs; }
 
-  function seedOrder(N){
-    if(N===2) return [1,2];
-    const prev = seedOrder(N/2);
-    const mirror = prev.map(x => N + 1 - x);
-    return prev.concat(mirror);
+  function createState(players){
+    const N=players.length; const pow2=nextPow2(N);
+    const seedToPlayer={}; for(let s=1;s<=pow2;s++){ const pl=s<=N? players[s-1]:{name:'BYE'}; seedToPlayer[s]=pl; pl.seed=s; }
+    const r0=round0PairsFromSeeds(pow2); const rounds=[r0.map(p=>p.slice())]; const winners=[Array(r0.length).fill(0)];
+    let matches=r0.length; while(matches>1){ matches=Math.ceil(matches/2); rounds.push(Array.from({length:matches},_=>[0,0])); winners.push(Array(matches).fill(0)); }
+    state={players,N,bracketN:pow2,seedToPlayer,rounds,winners,userSeed:1,currentRound:0,nextMatch:null,status:'ongoing',pot:0};
+    autoAdvanceByes(); state.nextMatch=findNextMatch(); return state;
   }
 
-  function round0PairsFromSeeds(N){
-    const order = seedOrder(N);
-    const pairs = [];
-    for(let i=0;i<N;i+=2){
-      pairs.push([order[i], order[i+1]]);
-    }
-    return pairs;
-  }
-
-  function createBracket(players){
-    const Nrequested = players.length;
-    const pow2 = nextPow2(Nrequested);
-    state.N = Nrequested;
-    state.bracketN = pow2;
-    const seedToPlayer = {};
-    for(let s=1; s<=pow2; s++){
-      if(s<=Nrequested) seedToPlayer[s]=players[s-1];
-      else seedToPlayer[s]={name:'BYE'};
-    }
-    state.seedToPlayer = seedToPlayer;
-
-    const r0 = round0PairsFromSeeds(pow2);
-    state.rounds = [r0];
-    let matches = r0.length;
-    while(matches>1){
-      matches = Math.ceil(matches/2);
-      state.rounds.push(Array.from({length:matches}, _=>[0,0]));
-    }
-    layoutAndDraw();
-  }
-
-  function layoutAndDraw(){
-    const rounds = state.rounds.length;
-    const colW = 220;
-    const colGap = 64;
-    const padX = 24;
-    const padY = 24;
-    const widthCSS = padX*2 + rounds*colW + (rounds-1)*colGap;
-
-    const matches0 = state.rounds[0].length;
-
-    const boxH = 56;
-    const slotH = boxH/2;
-    const baseGap = 28;
-
-    const centers = [];
-    centers[0] = Array.from({length:matches0}, (_,i)=> padY + (boxH/2) + i*(boxH + baseGap));
-    for(let r=1; r<rounds; r++){
-      const prev = centers[r-1];
-      const arr=[];
-      for(let i=0;i<Math.ceil(prev.length/2);i++){
-        const c = (prev[2*i] + prev[2*i+1]) / 2;
-        arr.push(c);
+  function autoAdvanceByes(){
+    for(let r=0;r<state.rounds.length-1;r++){
+      for(let m=0;m<state.rounds[r].length;m++){
+        if(state.winners[r][m]) continue;
+        const [a,b]=state.rounds[r][m];
+        const pA=state.seedToPlayer[a], pB=state.seedToPlayer[b];
+        let winner=0;
+        if(pA.name==='BYE' && pB.name!=='BYE') winner=b;
+        else if(pB.name==='BYE' && pA.name!=='BYE') winner=a;
+        if(winner) setMatchWinner(r,m,winner);
       }
-      centers[r]=arr;
     }
+  }
 
-    const lastCenter = centers[rounds-1][0] || padY + boxH/2;
-    const heightCSS = Math.max(600, lastCenter + padY + boxH/2);
+  function setMatchWinner(r,m,seed){
+    state.winners[r][m]=seed;
+    if(state.rounds[r+1]){
+      const idx=Math.floor(m/2); const slot=m%2;
+      state.rounds[r+1][idx][slot]=seed;
+    }
+  }
 
-    canvas.style.width = widthCSS + 'px';
-    canvas.style.height = heightCSS + 'px';
-    canvas.width = Math.floor(widthCSS * DPR);
-    canvas.height = Math.floor(heightCSS * DPR);
-    ctx.setTransform(DPR,0,0,DPR,0,0);
-
-    ctx.clearRect(0,0,widthCSS,heightCSS);
-    drawBackground(widthCSS, heightCSS);
-
-    hitRegions = [];
-    for(let r=0;r<rounds;r++){
-      const x = padX + r*(colW + colGap);
-      drawRoundTitle(r, x, 6 + (r==0? 10:0));
-
-      const matchesR = state.rounds[r].length;
-      for(let m=0;m<matchesR;m++){
-        const yCenter = centers[r][m];
-        drawMatchBox(r, m, x, yCenter - boxH/2, colW, boxH, slotH);
+  function simulateRoundAI(r){
+    for(let m=0;m<state.rounds[r].length;m++){
+      if(state.winners[r][m]) continue;
+      const [a,b]=state.rounds[r][m];
+      const pA=state.seedToPlayer[a], pB=state.seedToPlayer[b];
+      if(pA.name==='BYE'){ setMatchWinner(r,m,b); continue; }
+      if(pB.name==='BYE'){ setMatchWinner(r,m,a); continue; }
+      if(a!==state.userSeed && b!==state.userSeed){
+        const win=Math.random()<0.5? a:b;
+        setMatchWinner(r,m,win);
       }
+    }
+  }
 
-      if(r>0){
-        const xPrev = padX + (r-1)*(colW + colGap) + colW;
-        const xConn = xPrev + 18;
-        ctx.lineWidth = 2;
-        ctx.strokeStyle = theme.line;
-        ctx.beginPath();
-        for(let m=0;m<state.rounds[r].length;m++){
-          const cy = centers[r][m];
-          const top = centers[r-1][2*m];
-          const bot = centers[r-1][2*m+1];
-          ctx.moveTo(xPrev, top);
-          ctx.lineTo(xConn, top);
-          ctx.moveTo(xPrev, bot);
-          ctx.lineTo(xConn, bot);
-          ctx.moveTo(xConn, top);
-          ctx.lineTo(xConn, bot);
-          ctx.moveTo(xConn, cy);
-          ctx.lineTo(x, cy);
+  function simulateRemainingTournament(startRound){
+    for(let r=startRound;r<state.rounds.length;r++){ simulateRoundAI(r); }
+  }
+
+  function findNextMatch(){
+    const seed=state.userSeed;
+    for(let r=0;r<state.rounds.length;r++){
+      for(let m=0;m<state.rounds[r].length;m++){
+        if(!state.winners[r][m]){
+          const [a,b]=state.rounds[r][m];
+          if(a===seed || b===seed) return {round:r,match:m};
         }
-        ctx.stroke();
       }
     }
-
-    drawCenterLabels(widthCSS);
-  }
-
-  function drawBackground(w,h){
-    const g = ctx.createLinearGradient(0,0,w,0);
-    g.addColorStop(0,'rgba(168,85,247,.08)');
-    g.addColorStop(.5,'rgba(37,99,235,.10)');
-    g.addColorStop(1,'rgba(249,115,22,.08)');
-    ctx.fillStyle = g;
-    ctx.fillRect(0,0,w,h);
-  }
-
-  function drawRoundTitle(r, x, topPad){
-    ctx.save();
-    ctx.fillStyle = '#bcd0ff';
-    ctx.font = '600 12px system-ui,Segoe UI,Roboto,Arial';
-    ctx.textAlign = 'left';
-    let label = '';
-    const rounds = state.rounds.length;
-    if(r === 0) label = 'ROUND OF ' + state.bracketN;
-    else if(r === rounds-1) label = 'FINAL 🏆 🪙' + state.pot;
-    else if(r === rounds-2) label = 'SEMIFINAL';
-    else label = 'QUARTER / R' + (r+1);
-    ctx.fillText(label, x, topPad + 10);
-    ctx.restore();
-  }
-
-  function slotColor(r, slot){
-    const palettes = [theme.neonC, theme.neonA, theme.neonB];
-    const base = palettes[r % palettes.length];
-    const alpha = .22;
-    return hexToRgba(base, alpha);
-  }
-
-  function drawMatchBox(r, m, x, y, w, h, slotH){
-    const radius = 12;
-    roundRect(ctx, x, y, w, h, radius);
-    const grad = ctx.createLinearGradient(x, y, x, y+h);
-    grad.addColorStop(0, 'rgba(255,255,255,.04)');
-    grad.addColorStop(1, 'rgba(0,0,0,.25)');
-    ctx.fillStyle = grad;
-    ctx.fill();
-
-    ctx.fillStyle = slotColor(r,0);
-    roundRect(ctx, x+4, y+4, w-8, slotH-6, 8);
-    ctx.fill();
-    ctx.fillStyle = slotColor(r,1);
-    roundRect(ctx, x+4, y+slotH+2, w-8, slotH-6, 8);
-    ctx.fill();
-
-    ctx.strokeStyle = 'rgba(255,255,255,.06)';
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.moveTo(x+8, y+slotH);
-    ctx.lineTo(x+w-8, y+slotH);
-    ctx.stroke();
-
-    ctx.fillStyle = '#e7efff';
-    ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
-    ctx.textAlign = 'left';
-
-    const players = matchPlayers(r,m);
-    renderPlayer(players[0], x+12, y+slotH/2+4, slotH);
-    renderPlayer(players[1], x+12, y+slotH + slotH/2+4, slotH);
-
-    hitRegions.push({round:r, match:m, slot:0, x:x+4, y:y+4, w:w-8, h:slotH-6});
-    hitRegions.push({round:r, match:m, slot:1, x:x+4, y:y+slotH+2, w:w-8, h:slotH-6});
+    return null;
   }
 
   function matchPlayers(r,m){
-    if(r===0){
-      const [sA, sB] = state.rounds[0][m];
-      return [state.seedToPlayer[sA], state.seedToPlayer[sB]];
-    }
-    const nameA = { name: 'Winner '+labelForSource(r-1, 2*m) };
-    const nameB = { name: 'Winner '+labelForSource(r-1, 2*m+1) };
-    return [nameA, nameB];
+    const [sA,sB]=state.rounds[r][m];
+    return [state.seedToPlayer[sA]||{name:'TBD'}, state.seedToPlayer[sB]||{name:'TBD'}];
   }
 
-  function renderPlayer(player, x, y, slotH){
-    const avatarSize = 20;
+  function renderPlayer(player,x,y,slotH){
+    const avatarSize=20;
     if(player.flag){
-      ctx.fillText(player.flag, x, y+1);
-      ctx.fillText(player.name, x+18, y);
+      ctx.fillText(player.flag,x,y+1);
+      ctx.fillText(player.name,x+18,y);
     }else{
       ctx.save();
       ctx.beginPath();
-      ctx.arc(x+avatarSize/2, y-8, avatarSize/2, 0, Math.PI*2);
-      ctx.fillStyle = '#233155';
-      ctx.fill();
-      ctx.fillStyle = '#e7efff';
-      ctx.font = '600 11px system-ui,Segoe UI,Roboto,Arial';
-      ctx.textAlign = 'center';
-      ctx.fillText((player.name||'')[0]||'', x+avatarSize/2, y-4);
+      ctx.arc(x+avatarSize/2,y-8,avatarSize/2,0,Math.PI*2);
+      ctx.fillStyle='#233155'; ctx.fill();
+      ctx.fillStyle='#e7efff'; ctx.font='600 11px system-ui,Segoe UI,Roboto,Arial'; ctx.textAlign='center';
+      ctx.fillText((player.name||'')[0]||'',x+avatarSize/2,y-4);
       ctx.restore();
-      ctx.textAlign = 'left';
-      ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
-      ctx.fillText(player.name, x+avatarSize+6, y);
+      ctx.textAlign='left'; ctx.font='600 13px system-ui,Segoe UI,Roboto,Arial'; ctx.fillText(player.name,x+avatarSize+6,y);
     }
   }
 
   function labelForSource(r,m){
-    if(r===0){
-      const [sA,sB]=state.rounds[0][m];
-      return `(${seedShort(sA)} vs ${seedShort(sB)})`;
+    if(r===0){ const [sA,sB]=state.rounds[0][m]; return `(${seedShort(sA)} vs ${seedShort(sB)})`; }
+    return `R${r+1}-M${m+1}`;
+  }
+  function seedShort(s){ const n=state.seedToPlayer[s].name; if(n==='BYE') return 'BYE'; if(/^Team \d+$/i.test(n)) return n.replace('Team ','#'); return n.length>10? n.slice(0,10)+'…': n; }
+
+  function layoutAndDraw(){
+    const rounds=state.rounds.length, colW=220, colGap=64, padX=24, padY=24;
+    const widthCSS=padX*2 + rounds*colW + (rounds-1)*colGap;
+    const matches0=state.rounds[0].length;
+    const boxH=56, slotH=boxH/2, baseGap=28;
+    const centers=[]; centers[0]=Array.from({length:matches0},(_,i)=>padY+(boxH/2)+i*(boxH+baseGap));
+    for(let r=1;r<rounds;r++){ const prev=centers[r-1]; const arr=[]; for(let i=0;i<Math.ceil(prev.length/2);i++){ arr.push((prev[2*i]+prev[2*i+1])/2); } centers[r]=arr; }
+    const lastCenter=centers[rounds-1][0]||padY+boxH/2; const heightCSS=Math.max(600,lastCenter+padY+boxH/2);
+    canvas.style.width=widthCSS+'px'; canvas.style.height=heightCSS+'px'; canvas.width=Math.floor(widthCSS*DPR); canvas.height=Math.floor(heightCSS*DPR); ctx.setTransform(DPR,0,0,DPR,0,0);
+    ctx.clearRect(0,0,widthCSS,heightCSS); drawBackground(widthCSS,heightCSS);
+    for(let r=0;r<rounds;r++){ const x=padX+r*(colW+colGap); drawRoundTitle(r,x,6+(r==0?10:0));
+      const matchesR=state.rounds[r].length;
+      for(let m=0;m<matchesR;m++){ const yCenter=centers[r][m]; drawMatchBox(r,m,x,yCenter-boxH/2,colW,boxH,slotH); }
+      if(r>0){ const xPrev=padX+(r-1)*(colW+colGap)+colW; const xConn=xPrev+18; ctx.lineWidth=2; ctx.strokeStyle=theme.line; ctx.beginPath();
+        for(let m=0;m<state.rounds[r].length;m++){ const cy=centers[r][m]; const top=centers[r-1][2*m]; const bot=centers[r-1][2*m+1];
+          ctx.moveTo(xPrev,top); ctx.lineTo(xConn,top); ctx.moveTo(xPrev,bot); ctx.lineTo(xConn,bot); ctx.moveTo(xConn,top); ctx.lineTo(xConn,bot); ctx.moveTo(xConn,cy); ctx.lineTo(x,cy);
+        } ctx.stroke(); }
+    }
+    drawCenterLabels(widthCSS);
+  }
+
+  function drawBackground(w,h){
+    const g=ctx.createLinearGradient(0,0,w,0); g.addColorStop(0,'rgba(168,85,247,.08)'); g.addColorStop(.5,'rgba(37,99,235,.10)'); g.addColorStop(1,'rgba(249,115,22,.08)'); ctx.fillStyle=g; ctx.fillRect(0,0,w,h);
+  }
+
+  function drawRoundTitle(r,x,topPad){
+    ctx.save(); ctx.fillStyle='#bcd0ff'; ctx.font='600 12px system-ui,Segoe UI,Roboto,Arial'; ctx.textAlign='left';
+    let label=''; const rounds=state.rounds.length;
+    if(r===0) label='ROUND OF '+state.bracketN;
+    else if(r===rounds-1) label='FINAL 🏆 🪙'+state.pot;
+    else if(r===rounds-2) label='SEMIFINAL';
+    else label='QUARTER / R'+(r+1);
+    ctx.fillText(label,x,topPad+10); ctx.restore();
+  }
+
+  function slotColor(r,slot){ const palettes=[theme.neonC,theme.neonA,theme.neonB]; const base=palettes[r%palettes.length]; return hexToRgba(base,.22); }
+  function drawMatchBox(r,m,x,y,w,h,slotH){
+    roundRect(ctx,x,y,w,h,12);
+    const grad=ctx.createLinearGradient(x,y,x,y+h); grad.addColorStop(0,'rgba(255,255,255,.04)'); grad.addColorStop(1,'rgba(0,0,0,.25)'); ctx.fillStyle=grad; ctx.fill();
+    ctx.fillStyle=slotColor(r,0); roundRect(ctx,x+4,y+4,w-8,slotH-6,8); ctx.fill();
+    ctx.fillStyle=slotColor(r,1); roundRect(ctx,x+4,y+slotH+2,w-8,slotH-6,8); ctx.fill();
+    ctx.strokeStyle='rgba(255,255,255,.06)'; ctx.lineWidth=1; ctx.beginPath(); ctx.moveTo(x+8,y+slotH); ctx.lineTo(x+w-8,y+slotH); ctx.stroke();
+    ctx.fillStyle='#e7efff'; ctx.font='600 13px system-ui,Segoe UI,Roboto,Arial'; ctx.textAlign='left';
+    const players=matchPlayers(r,m); renderPlayer(players[0],x+12,y+slotH/2+4,slotH); renderPlayer(players[1],x+12,y+slotH+slotH/2+4,slotH);
+  }
+
+  function hexToRgba(hex,a){ let c=hex.replace('#',''); if(c.length===3){c=c.split('').map(x=>x+x).join('');} const num=parseInt(c,16); const r=(num>>16)&255,g=(num>>8)&255,b=num&255; return `rgba(${r},${g},${b},${a})`; }
+  function roundRect(ctx,x,y,w,h,r){ const rr=Math.min(r,w/2,h/2); ctx.beginPath(); ctx.moveTo(x+rr,y); ctx.lineTo(x+w-rr,y); ctx.quadraticCurveTo(x+w,y,x+w,y+rr); ctx.lineTo(x+w,y+h-rr); ctx.quadraticCurveTo(x+w,y+h,x+w-rr,y+h); ctx.lineTo(x+rr,y+h); ctx.quadraticCurveTo(x,y+h,x,y+h-rr); ctx.lineTo(x,y+rr); ctx.quadraticCurveTo(x,y,x+rr,y); ctx.closePath(); }
+
+  function renderPlayerList(){ const el=document.getElementById('playerList'); el.innerHTML=''; state.players.forEach(p=>{ const d=document.createElement('div'); d.className='p'; d.textContent=(p.flag? p.flag+' ':'')+p.name; el.appendChild(d); }); }
+
+  function startNextMatch(){
+    const {round,match}=state.nextMatch;
+    const [a,b]=state.rounds[round][match];
+    const oppSeed=a===state.userSeed? b:a;
+    const opp=state.seedToPlayer[oppSeed];
+    localStorage.setItem('poolRoyaleTournamentState', JSON.stringify(state));
+    const params=new URLSearchParams(location.search);
+    if(opp.flag) params.set('oppFlag',opp.flag); else params.delete('oppFlag');
+    params.set('oppName',opp.name);
+    window.location.href='/poll-royale.html?'+params.toString();
+  }
+
+  const params = new URLSearchParams(location.search);
+  const saved = localStorage.getItem('poolRoyaleTournamentState');
+  if(saved){ state=JSON.parse(saved); }
+  else{
+    const count=parseInt(params.get('players')||'8',10);
+    const userName=params.get('name')||'You';
+    const players=[{name:userName, flag:params.get('flag')||''}];
+    for(let i=1;i<count;i++){ const flag=FLAG_EMOJIS[(Math.random()*FLAG_EMOJIS.length)|0]; players.push({name:flagName(flag),flag}); }
+    state=createState(players);
+    localStorage.setItem('poolRoyaleTournamentState', JSON.stringify(state));
+  }
+
+  const res = localStorage.getItem('pollRoyaleLastResult');
+  if(res && state.nextMatch){
+    const result=JSON.parse(res); const {round,match}=state.nextMatch; const [a,b]=state.rounds[round][match];
+    const winnerSeed = result.winner===1 ? (a===state.userSeed? a:b) : (a===state.userSeed? b:a);
+    setMatchWinner(round,match,winnerSeed);
+    if(winnerSeed===state.userSeed){
+      simulateRoundAI(round);
+      state.currentRound=round+1;
+      const nm=findNextMatch();
+      if(nm) state.nextMatch=nm; else state.status='finished';
     }else{
-      return `R${r+1}-M${m+1}`;
+      simulateRoundAI(round);
+      simulateRemainingTournament(round+1);
+      state.status='finished';
+      state.nextMatch=null;
     }
+    localStorage.removeItem('pollRoyaleLastResult');
+    localStorage.setItem('poolRoyaleTournamentState', JSON.stringify(state));
   }
 
-  function seedShort(s){
-    const n = state.seedToPlayer[s].name;
-    if(n==='BYE') return 'BYE';
-    if(/^Team \d+$/i.test(n)) return n.replace('Team ', '#');
-    return n.length>10? n.slice(0,10)+'…': n;
-  }
+  renderPlayerList();
+  layoutAndDraw();
+  window.addEventListener('resize', layoutAndDraw);
 
-  function drawCenterLabels(w){
-    ctx.save();
-    ctx.textAlign = 'center';
-    ctx.font = '700 20px system-ui,Segoe UI,Roboto,Arial';
-    ctx.fillStyle = '#e8f0ff';
-    ctx.fillText('THE PLAYOFFS', w/2, 34);
-    ctx.font = '600 12px system-ui,Segoe UI,Roboto,Arial';
-    ctx.fillStyle = '#9fb3de';
-    ctx.fillText('WORLD CHAMPIONSHIP', w/2, 54);
-    ctx.restore();
-  }
-
-  function hexToRgba(hex, a){
-    let c = hex.replace('#','');
-    if(c.length===3){ c = c.split('').map(x=>x+x).join(''); }
-    const num = parseInt(c,16);
-    const r = (num>>16)&255, g=(num>>8)&255, b=num&255;
-    return `rgba(${r},${g},${b},${a})`;
-  }
-
-  function roundRect(ctx, x, y, w, h, r){
-    const rr = Math.min(r, w/2, h/2);
-    ctx.beginPath();
-    ctx.moveTo(x+rr, y);
-    ctx.lineTo(x+w-rr, y);
-    ctx.quadraticCurveTo(x+w, y, x+w, y+rr);
-    ctx.lineTo(x+w, y+h-rr);
-    ctx.quadraticCurveTo(x+w, y+h, x+w-rr, y+h);
-    ctx.lineTo(x+rr, y+h);
-    ctx.quadraticCurveTo(x, y+h, x, y+h-rr);
-    ctx.lineTo(x, y+rr);
-    ctx.quadraticCurveTo(x, y, x+rr, y);
-    ctx.closePath();
-  }
-
-  canvas.addEventListener('click', (ev)=>{
-    const rect = canvas.getBoundingClientRect();
-    const x = (ev.clientX - rect.left);
-    const y = (ev.clientY - rect.top);
-    for(const reg of hitRegions){
-      if(x>=reg.x && x<=reg.x+reg.w && y>=reg.y && y<=reg.y+reg.h){
-        const nm = prompt('Enter team name:', getNameAt(reg.round, reg.match, reg.slot));
-        if(nm && nm.trim()){
-          setNameAt(reg.round, reg.match, reg.slot, nm.trim());
-          layoutAndDraw();
-        }
-        break;
-      }
-    }
-  });
-
-  function getNameAt(r,m,slot){
-    const [a,b] = matchPlayers(r,m);
-    return slot===0? a.name : b.name;
-  }
-
-  function setNameAt(r,m,slot,newName){
-    if(r===0){
-      const seed = state.rounds[0][m][slot];
-      state.seedToPlayer[seed].name = newName;
-    }else{
-      alert('Names in this round are auto-filled from previous matches.');
-    }
-  }
-
-  (function init(){
-    const players = window.tournamentPlayers || [
-      { name: 'Player 1' },
-      { name: 'Player 2' },
-      { name: 'Player 3' },
-      { name: 'Player 4' },
-      { name: 'Player 5' },
-      { name: 'Player 6' },
-      { name: 'USA', flag: '🇺🇸' },
-      { name: 'UK', flag: '🇬🇧' }
-    ];
-    state.players = players;
-    createBracket(players);
-    window.addEventListener('resize', ()=> layoutAndDraw());
-  })();
+  const btn=document.getElementById('continueBtn');
+  if(state.status==='finished' || !state.nextMatch) btn.classList.add('hidden');
+  else btn.classList.remove('hidden');
+  btn.addEventListener('click', startNextMatch);
 })();
 </script>
 </body>

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1437,9 +1437,12 @@
           }
         }
         if (window.FLAG_EMOJIS) {
-          var flag = FLAG_EMOJIS[(Math.random() * FLAG_EMOJIS.length) | 0];
+          var oppFlag = params.get('oppFlag');
+          var oppNameParam = params.get('oppName');
+          var flag = oppFlag || FLAG_EMOJIS[(Math.random() * FLAG_EMOJIS.length) | 0];
           avatarCPU.textContent = flag;
-          formatPlayerName(flagToName(flag) || 'CPU', nameCPU);
+          var oppName = oppNameParam || flagToName(flag) || 'CPU';
+          formatPlayerName(oppName, nameCPU);
         }
 
         /* ==========================================================
@@ -3706,125 +3709,13 @@
       }
 
       if (params.get('type') === 'tournament') {
-        const overlay = document.getElementById('tournamentOverlay');
-        const canvas = document.getElementById('bracket');
-        const ctx = canvas.getContext('2d');
-        // Generate AI player names with country flags
-        const totalPlayers = window.tournamentPlayers || 16;
-        const aiPool = [
-          { name: 'USA', flag: '🇺🇸' },
-          { name: 'UK', flag: '🇬🇧' },
-          { name: 'Germany', flag: '🇩🇪' },
-          { name: 'Brazil', flag: '🇧🇷' },
-          { name: 'Japan', flag: '🇯🇵' },
-          { name: 'France', flag: '🇫🇷' },
-          { name: 'Spain', flag: '🇪🇸' },
-          { name: 'Italy', flag: '🇮🇹' },
-          { name: 'Canada', flag: '🇨🇦' },
-          { name: 'India', flag: '🇮🇳' },
-          { name: 'China', flag: '🇨🇳' },
-          { name: 'Mexico', flag: '🇲🇽' },
-          { name: 'Australia', flag: '🇦🇺' },
-          { name: 'Russia', flag: '🇷🇺' },
-          { name: 'Netherlands', flag: '🇳🇱' },
-          { name: 'Sweden', flag: '🇸🇪' },
-          { name: 'Norway', flag: '🇳🇴' },
-          { name: 'Denmark', flag: '🇩🇰' },
-          { name: 'Poland', flag: '🇵🇱' },
-          { name: 'Switzerland', flag: '🇨🇭' },
-          { name: 'Greece', flag: '🇬🇷' },
-          { name: 'Turkey', flag: '🇹🇷' },
-          { name: 'Portugal', flag: '🇵🇹' },
-          { name: 'Belgium', flag: '🇧🇪' }
-        ];
-        const players = aiPool.slice(0, totalPlayers - 1);
-        players.unshift({ name: 'You', flag: '🏳️' });
-        while (players.length < totalPlayers) {
-          players.push({ name: `AI ${players.length + 1}`, flag: '🏳️' });
-        }
-        const playerNames = players.map(p => `${p.flag} ${p.name}`);
-        const totalPot = window.potAmount || 0;
-
-        function resizeCanvas() {
-          canvas.width = window.innerWidth * 0.95;
-          canvas.height = window.innerHeight * 0.95;
-          drawBracket();
-        }
-
-        window.addEventListener('resize', resizeCanvas);
-
-        function drawBracket() {
-          ctx.clearRect(0, 0, canvas.width, canvas.height);
-          ctx.strokeStyle = '#000';
-          ctx.lineWidth = 2;
-          ctx.font = '14px Arial';
-          ctx.textBaseline = 'middle';
-
-          let size = playerNames.length;
-          if (![8, 16, 24].includes(size)) {
-            ctx.fillText('Only 8, 16 or 24 players supported', 20, 20);
-            return;
-          }
-
-          let effectivePlayers = [...playerNames];
-          if (size === 24) {
-            effectivePlayers = playerNames
-              .slice(0, 16)
-              .concat(playerNames.slice(16).map(p => p + ' (BYE)'));
-            size = 16;
-          }
-
-          const rounds = Math.log2(size);
-          const colWidth = canvas.width / (rounds * 2);
-          const rowHeight = canvas.height / effectivePlayers.length;
-
-          for (let i = 0; i < effectivePlayers.length / 2; i++) {
-            let y = rowHeight * (i * 2 + 1);
-            ctx.strokeRect(10, y - 12, colWidth - 20, 24);
-            ctx.fillText(effectivePlayers[i], 15, y);
-            ctx.beginPath();
-            ctx.moveTo(colWidth - 10, y);
-            ctx.lineTo(colWidth, y);
-            ctx.stroke();
-          }
-
-          for (let i = effectivePlayers.length / 2; i < effectivePlayers.length; i++) {
-            let idx = i - effectivePlayers.length / 2;
-            let y = rowHeight * (idx * 2 + 1);
-            ctx.strokeRect(canvas.width - colWidth + 10, y - 12, colWidth - 20, 24);
-            ctx.fillText(effectivePlayers[i], canvas.width - colWidth + 15, y);
-            ctx.beginPath();
-            ctx.moveTo(canvas.width - colWidth, y);
-            ctx.lineTo(canvas.width - colWidth + 10, y);
-            ctx.stroke();
-          }
-
-          ctx.beginPath();
-          ctx.arc(canvas.width / 2, canvas.height / 2, 40, 0, 2 * Math.PI);
-          ctx.stroke();
-
-          ctx.font = '16px Arial';
-          ctx.textAlign = 'center';
-          ctx.fillText(`POT: ${totalPot} TPC`, canvas.width / 2, canvas.height / 2 + 60);
-          ctx.textAlign = 'left';
-        }
-
-        resizeCanvas();
-        const continueBtn = document.createElement('button');
-        continueBtn.textContent = 'Continue';
-        continueBtn.style.position = 'absolute';
-        continueBtn.style.bottom = '20px';
-        continueBtn.style.left = '50%';
-        continueBtn.style.transform = 'translateX(-50%)';
-        overlay.appendChild(continueBtn);
-        continueBtn.addEventListener('click', () => {
-          overlay.classList.add('hidden');
-        });
-        window.handleTournamentResult = function () {
-          overlay.classList.remove('hidden');
-          drawBracket();
+        window.handleTournamentResult = function (winner) {
+          try {
+            localStorage.setItem('pollRoyaleLastResult', JSON.stringify({ winner }));
+          } catch {}
+          const params = new URLSearchParams(window.location.search);
+          window.location.href = '/poll-royale-bracket.html?' + params.toString();
         };
-        overlay.classList.remove('hidden');
       }
 
       // Rotate corner holes diagonally; keep side holes horizontal


### PR DESCRIPTION
## Summary
- build dedicated Pool Royale tournament bracket page with AI fill-ins
- update game to route results back to bracket and preselect opponents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b68b2a1aa88329a82dbafb57fcafe9