### PR TITLE
feat: add basic tournament flow

### DIFF
--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -1,392 +1,113 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Pool Royale Bracket</title>
-<style>
-  :root{
-    --bg:#0b1020;
-    --panel:#11172a;
-    --ink:#dbe7ff;
-    --accent:#2563eb;
-    --accent-2:#f97316;
-    --accent-3:#a855f7;
-    --muted:#8aa0d1;
-  }
-  *{box-sizing:border-box}
-  html,body{height:100%}
-  body{
-    margin:0;
-    font-family:system-ui,Segoe UI,Roboto,Arial,Helvetica,sans-serif;
-    background: radial-gradient(80% 60% at 50% 0%, #0f1735 0%, var(--bg) 60%);
-    color:var(--ink);
-    display:flex; flex-direction:column; gap:10px;
-  }
-  /* Original demo toolbar and notes are hidden */
-  header, .setup, .footer-note{display:none}
-  .canvas-wrap{
-    position:relative;
-    overflow:auto; /* allow horizontal scroll on phones */
-    border-top:1px solid rgba(255,255,255,.06);
-    border-bottom:1px solid rgba(255,255,255,.06);
-    background:
-      radial-gradient(1000px 300px at 50% -50px, rgba(37,99,235,.25), transparent 70%),
-      radial-gradient(800px 300px at 50% 100%, rgba(249,115,22,.15), transparent 70%);
-  }
-  canvas{ display:block; margin:0 auto; }
-  .footer-note{padding:8px 12px; text-align:center; color:var(--muted); font-size:.85rem}
-  details{margin-left:auto}
-  summary{cursor:pointer}
-  .pill {
-    display:inline-flex; align-items:center; gap:8px; padding:4px 8px; border-radius:999px;
-    background:rgba(37,99,235,.15); border:1px solid rgba(37,99,235,.35); color:#cfe0ff;
-    font-size:.8rem;
-  }
-</style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Pool Royale Tournament</title>
+  <style>
+    body{margin:0;background:#0b1020;color:#dbe7ff;font-family:system-ui;padding:16px;}
+    h2{text-align:center;margin-top:0;}
+    #bracket{display:flex;gap:16px;justify-content:center;flex-wrap:wrap;}
+    .round{display:flex;flex-direction:column;gap:8px;}
+    .match{background:#11172a;border:1px solid #233155;padding:4px 8px;border-radius:4px;min-width:140px;text-align:center;}
+    .winner{font-weight:bold;color:#f97316;}
+    #continueBtn{margin-top:20px;padding:8px 16px;background:#2563eb;border:none;color:#fff;border-radius:4px;}
+  </style>
 </head>
 <body>
-<div class="canvas-wrap">
-  <canvas id="board" width="1200" height="800" aria-label="Tournament bracket canvas"></canvas>
-</div>
-
-<script>
-(function(){
-  const DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
-  const canvas = document.getElementById('board');
-  const ctx = canvas.getContext('2d');
-  const theme = {
-    bg:'#0b1020',
-    panel:'#11172a',
-    ink:'#dbe7ff',
-    muted:'#8aa0d1',
-    neonA:'#2563eb',
-    neonB:'#f97316',
-    neonC:'#a855f7',
-    line:'#233155'
-  };
-
-  let hitRegions = []; // {round, match, slot, x,y,w,h}
-
-  let state = {
-    players: [],
-    N: 0,
-    bracketN: 0,
-    rounds: [],
-    seedToPlayer: {},
-    pot: 0
-  };
-
-  function nextPow2(n){ let p=1; while(p<n) p<<=1; return p; }
-
-  function seedOrder(N){
-    if(N===2) return [1,2];
-    const prev = seedOrder(N/2);
-    const mirror = prev.map(x => N + 1 - x);
-    return prev.concat(mirror);
-  }
-
-  function round0PairsFromSeeds(N){
-    const order = seedOrder(N);
-    const pairs = [];
-    for(let i=0;i<N;i+=2){
-      pairs.push([order[i], order[i+1]]);
+  <h2>Tournament Bracket</h2>
+  <div id="bracket"></div>
+  <div style="text-align:center"><button id="continueBtn">Continue</button></div>
+  <script src="/tournament.js"></script>
+  <script>
+  (function(){
+    const params = new URLSearchParams(location.search);
+    const totalPlayers = parseInt(params.get('players') || '8', 10);
+    const playerName = params.get('name') || 'Player';
+    let state = Tournament.load();
+    if(!state){
+      const aiPool = [
+        { name: 'USA', flag: '🇺🇸' },
+        { name: 'UK', flag: '🇬🇧' },
+        { name: 'Germany', flag: '🇩🇪' },
+        { name: 'Brazil', flag: '🇧🇷' },
+        { name: 'Japan', flag: '🇯🇵' },
+        { name: 'France', flag: '🇫🇷' },
+        { name: 'Spain', flag: '🇪🇸' },
+        { name: 'Italy', flag: '🇮🇹' },
+        { name: 'Canada', flag: '🇨🇦' },
+        { name: 'India', flag: '🇮🇳' },
+        { name: 'China', flag: '🇨🇳' },
+        { name: 'Mexico', flag: '🇲🇽' },
+        { name: 'Australia', flag: '🇦🇺' },
+        { name: 'Russia', flag: '🇷🇺' },
+        { name: 'Netherlands', flag: '🇳🇱' },
+        { name: 'Sweden', flag: '🇸🇪' },
+        { name: 'Norway', flag: '🇳🇴' },
+        { name: 'Denmark', flag: '🇩🇰' },
+        { name: 'Poland', flag: '🇵🇱' },
+        { name: 'Switzerland', flag: '🇨🇭' },
+        { name: 'Greece', flag: '🇬🇷' },
+        { name: 'Turkey', flag: '🇹🇷' },
+        { name: 'Portugal', flag: '🇵🇹' },
+        { name: 'Belgium', flag: '🇧🇪' }
+      ];
+      const players = [{ name: playerName, flag: '🏳️' }];
+      for(let i=0;i<totalPlayers-1;i++) players.push(aiPool[i]);
+      state = Tournament.createTournament(players);
+      Tournament.save(state);
     }
-    return pairs;
-  }
+    draw();
 
-  function createBracket(players){
-    const Nrequested = players.length;
-    const pow2 = nextPow2(Nrequested);
-    state.N = Nrequested;
-    state.bracketN = pow2;
-    const seedToPlayer = {};
-    for(let s=1; s<=pow2; s++){
-      if(s<=Nrequested) seedToPlayer[s]=players[s-1];
-      else seedToPlayer[s]={name:'BYE'};
-    }
-    state.seedToPlayer = seedToPlayer;
-
-    const r0 = round0PairsFromSeeds(pow2);
-    state.rounds = [r0];
-    let matches = r0.length;
-    while(matches>1){
-      matches = Math.ceil(matches/2);
-      state.rounds.push(Array.from({length:matches}, _=>[0,0]));
-    }
-    layoutAndDraw();
-  }
-
-  function layoutAndDraw(){
-    const rounds = state.rounds.length;
-    const colW = 220;
-    const colGap = 64;
-    const padX = 24;
-    const padY = 24;
-    const widthCSS = padX*2 + rounds*colW + (rounds-1)*colGap;
-
-    const matches0 = state.rounds[0].length;
-
-    const boxH = 56;
-    const slotH = boxH/2;
-    const baseGap = 28;
-
-    const centers = [];
-    centers[0] = Array.from({length:matches0}, (_,i)=> padY + (boxH/2) + i*(boxH + baseGap));
-    for(let r=1; r<rounds; r++){
-      const prev = centers[r-1];
-      const arr=[];
-      for(let i=0;i<Math.ceil(prev.length/2);i++){
-        const c = (prev[2*i] + prev[2*i+1]) / 2;
-        arr.push(c);
+    document.getElementById('continueBtn').addEventListener('click', () => {
+      state = Tournament.load();
+      if(state.finished){
+        sessionStorage.removeItem('pollroyaleTournament');
+        const win = state.champion === state.userIndex ? 1 : 2;
+        location.href = `/games/pollroyale/lobby?winner=${win}`;
+        return;
       }
-      centers[r]=arr;
-    }
-
-    const lastCenter = centers[rounds-1][0] || padY + boxH/2;
-    const heightCSS = Math.max(600, lastCenter + padY + boxH/2);
-
-    canvas.style.width = widthCSS + 'px';
-    canvas.style.height = heightCSS + 'px';
-    canvas.width = Math.floor(widthCSS * DPR);
-    canvas.height = Math.floor(heightCSS * DPR);
-    ctx.setTransform(DPR,0,0,DPR,0,0);
-
-    ctx.clearRect(0,0,widthCSS,heightCSS);
-    drawBackground(widthCSS, heightCSS);
-
-    hitRegions = [];
-    for(let r=0;r<rounds;r++){
-      const x = padX + r*(colW + colGap);
-      drawRoundTitle(r, x, 6 + (r==0? 10:0));
-
-      const matchesR = state.rounds[r].length;
-      for(let m=0;m<matchesR;m++){
-        const yCenter = centers[r][m];
-        drawMatchBox(r, m, x, yCenter - boxH/2, colW, boxH, slotH);
+      const nm = Tournament.getNextUserMatch(state);
+      Tournament.save(state);
+      if(!nm){
+        // user eliminated and tournament still running? simulate to end
+        Tournament.simulateRemaining(state, 0);
+        state.finished = true;
+        Tournament.save(state);
+        draw();
+      }else{
+        location.href = `/poll-royale.html?${params.toString()}`;
       }
+    });
 
-      if(r>0){
-        const xPrev = padX + (r-1)*(colW + colGap) + colW;
-        const xConn = xPrev + 18;
-        ctx.lineWidth = 2;
-        ctx.strokeStyle = theme.line;
-        ctx.beginPath();
-        for(let m=0;m<state.rounds[r].length;m++){
-          const cy = centers[r][m];
-          const top = centers[r-1][2*m];
-          const bot = centers[r-1][2*m+1];
-          ctx.moveTo(xPrev, top);
-          ctx.lineTo(xConn, top);
-          ctx.moveTo(xPrev, bot);
-          ctx.lineTo(xConn, bot);
-          ctx.moveTo(xConn, top);
-          ctx.lineTo(xConn, bot);
-          ctx.moveTo(xConn, cy);
-          ctx.lineTo(x, cy);
-        }
-        ctx.stroke();
+    function draw(){
+      state = Tournament.load();
+      const bracketEl = document.getElementById('bracket');
+      bracketEl.innerHTML = '';
+      state.rounds.forEach((round) => {
+        const col = document.createElement('div');
+        col.className = 'round';
+        round.forEach((match) => {
+          const p1 = state.players[match.p1];
+          const p2 = state.players[match.p2];
+          const div = document.createElement('div');
+          div.className = 'match';
+          let html = `${p1.flag} ${p1.name}<br/>${p2.flag} ${p2.name}`;
+          if(match.winner === match.p1) html = `<span class="winner">${p1.flag} ${p1.name}</span><br/>${p2.flag} ${p2.name}`;
+          else if(match.winner === match.p2) html = `${p1.flag} ${p1.name}<br/><span class="winner">${p2.flag} ${p2.name}</span>`;
+          div.innerHTML = html;
+          col.appendChild(div);
+        });
+        bracketEl.appendChild(col);
+      });
+      if(state.finished){
+        const champ = state.players[state.champion];
+        const title = document.querySelector('h2');
+        title.textContent = `Winner: ${champ.flag} ${champ.name}`;
+        document.getElementById('continueBtn').textContent = 'Close';
       }
     }
-
-    drawCenterLabels(widthCSS);
-  }
-
-  function drawBackground(w,h){
-    const g = ctx.createLinearGradient(0,0,w,0);
-    g.addColorStop(0,'rgba(168,85,247,.08)');
-    g.addColorStop(.5,'rgba(37,99,235,.10)');
-    g.addColorStop(1,'rgba(249,115,22,.08)');
-    ctx.fillStyle = g;
-    ctx.fillRect(0,0,w,h);
-  }
-
-  function drawRoundTitle(r, x, topPad){
-    ctx.save();
-    ctx.fillStyle = '#bcd0ff';
-    ctx.font = '600 12px system-ui,Segoe UI,Roboto,Arial';
-    ctx.textAlign = 'left';
-    let label = '';
-    const rounds = state.rounds.length;
-    if(r === 0) label = 'ROUND OF ' + state.bracketN;
-    else if(r === rounds-1) label = 'FINAL 🏆 🪙' + state.pot;
-    else if(r === rounds-2) label = 'SEMIFINAL';
-    else label = 'QUARTER / R' + (r+1);
-    ctx.fillText(label, x, topPad + 10);
-    ctx.restore();
-  }
-
-  function slotColor(r, slot){
-    const palettes = [theme.neonC, theme.neonA, theme.neonB];
-    const base = palettes[r % palettes.length];
-    const alpha = .22;
-    return hexToRgba(base, alpha);
-  }
-
-  function drawMatchBox(r, m, x, y, w, h, slotH){
-    const radius = 12;
-    roundRect(ctx, x, y, w, h, radius);
-    const grad = ctx.createLinearGradient(x, y, x, y+h);
-    grad.addColorStop(0, 'rgba(255,255,255,.04)');
-    grad.addColorStop(1, 'rgba(0,0,0,.25)');
-    ctx.fillStyle = grad;
-    ctx.fill();
-
-    ctx.fillStyle = slotColor(r,0);
-    roundRect(ctx, x+4, y+4, w-8, slotH-6, 8);
-    ctx.fill();
-    ctx.fillStyle = slotColor(r,1);
-    roundRect(ctx, x+4, y+slotH+2, w-8, slotH-6, 8);
-    ctx.fill();
-
-    ctx.strokeStyle = 'rgba(255,255,255,.06)';
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.moveTo(x+8, y+slotH);
-    ctx.lineTo(x+w-8, y+slotH);
-    ctx.stroke();
-
-    ctx.fillStyle = '#e7efff';
-    ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
-    ctx.textAlign = 'left';
-
-    const players = matchPlayers(r,m);
-    renderPlayer(players[0], x+12, y+slotH/2+4, slotH);
-    renderPlayer(players[1], x+12, y+slotH + slotH/2+4, slotH);
-
-    hitRegions.push({round:r, match:m, slot:0, x:x+4, y:y+4, w:w-8, h:slotH-6});
-    hitRegions.push({round:r, match:m, slot:1, x:x+4, y:y+slotH+2, w:w-8, h:slotH-6});
-  }
-
-  function matchPlayers(r,m){
-    if(r===0){
-      const [sA, sB] = state.rounds[0][m];
-      return [state.seedToPlayer[sA], state.seedToPlayer[sB]];
-    }
-    const nameA = { name: 'Winner '+labelForSource(r-1, 2*m) };
-    const nameB = { name: 'Winner '+labelForSource(r-1, 2*m+1) };
-    return [nameA, nameB];
-  }
-
-  function renderPlayer(player, x, y, slotH){
-    const avatarSize = 20;
-    if(player.flag){
-      ctx.fillText(player.flag, x, y+1);
-      ctx.fillText(player.name, x+18, y);
-    }else{
-      ctx.save();
-      ctx.beginPath();
-      ctx.arc(x+avatarSize/2, y-8, avatarSize/2, 0, Math.PI*2);
-      ctx.fillStyle = '#233155';
-      ctx.fill();
-      ctx.fillStyle = '#e7efff';
-      ctx.font = '600 11px system-ui,Segoe UI,Roboto,Arial';
-      ctx.textAlign = 'center';
-      ctx.fillText((player.name||'')[0]||'', x+avatarSize/2, y-4);
-      ctx.restore();
-      ctx.textAlign = 'left';
-      ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
-      ctx.fillText(player.name, x+avatarSize+6, y);
-    }
-  }
-
-  function labelForSource(r,m){
-    if(r===0){
-      const [sA,sB]=state.rounds[0][m];
-      return `(${seedShort(sA)} vs ${seedShort(sB)})`;
-    }else{
-      return `R${r+1}-M${m+1}`;
-    }
-  }
-
-  function seedShort(s){
-    const n = state.seedToPlayer[s].name;
-    if(n==='BYE') return 'BYE';
-    if(/^Team \d+$/i.test(n)) return n.replace('Team ', '#');
-    return n.length>10? n.slice(0,10)+'…': n;
-  }
-
-  function drawCenterLabels(w){
-    ctx.save();
-    ctx.textAlign = 'center';
-    ctx.font = '700 20px system-ui,Segoe UI,Roboto,Arial';
-    ctx.fillStyle = '#e8f0ff';
-    ctx.fillText('THE PLAYOFFS', w/2, 34);
-    ctx.font = '600 12px system-ui,Segoe UI,Roboto,Arial';
-    ctx.fillStyle = '#9fb3de';
-    ctx.fillText('WORLD CHAMPIONSHIP', w/2, 54);
-    ctx.restore();
-  }
-
-  function hexToRgba(hex, a){
-    let c = hex.replace('#','');
-    if(c.length===3){ c = c.split('').map(x=>x+x).join(''); }
-    const num = parseInt(c,16);
-    const r = (num>>16)&255, g=(num>>8)&255, b=num&255;
-    return `rgba(${r},${g},${b},${a})`;
-  }
-
-  function roundRect(ctx, x, y, w, h, r){
-    const rr = Math.min(r, w/2, h/2);
-    ctx.beginPath();
-    ctx.moveTo(x+rr, y);
-    ctx.lineTo(x+w-rr, y);
-    ctx.quadraticCurveTo(x+w, y, x+w, y+rr);
-    ctx.lineTo(x+w, y+h-rr);
-    ctx.quadraticCurveTo(x+w, y+h, x+w-rr, y+h);
-    ctx.lineTo(x+rr, y+h);
-    ctx.quadraticCurveTo(x, y+h, x, y+h-rr);
-    ctx.lineTo(x, y+rr);
-    ctx.quadraticCurveTo(x, y, x+rr, y);
-    ctx.closePath();
-  }
-
-  canvas.addEventListener('click', (ev)=>{
-    const rect = canvas.getBoundingClientRect();
-    const x = (ev.clientX - rect.left);
-    const y = (ev.clientY - rect.top);
-    for(const reg of hitRegions){
-      if(x>=reg.x && x<=reg.x+reg.w && y>=reg.y && y<=reg.y+reg.h){
-        const nm = prompt('Enter team name:', getNameAt(reg.round, reg.match, reg.slot));
-        if(nm && nm.trim()){
-          setNameAt(reg.round, reg.match, reg.slot, nm.trim());
-          layoutAndDraw();
-        }
-        break;
-      }
-    }
-  });
-
-  function getNameAt(r,m,slot){
-    const [a,b] = matchPlayers(r,m);
-    return slot===0? a.name : b.name;
-  }
-
-  function setNameAt(r,m,slot,newName){
-    if(r===0){
-      const seed = state.rounds[0][m][slot];
-      state.seedToPlayer[seed].name = newName;
-    }else{
-      alert('Names in this round are auto-filled from previous matches.');
-    }
-  }
-
-  (function init(){
-    const players = window.tournamentPlayers || [
-      { name: 'Player 1' },
-      { name: 'Player 2' },
-      { name: 'Player 3' },
-      { name: 'Player 4' },
-      { name: 'Player 5' },
-      { name: 'Player 6' },
-      { name: 'USA', flag: '🇺🇸' },
-      { name: 'UK', flag: '🇬🇧' }
-    ];
-    state.players = players;
-    createBracket(players);
-    window.addEventListener('resize', ()=> layoutAndDraw());
   })();
-})();
-</script>
+  </script>
 </body>
 </html>

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -627,24 +627,6 @@
         border-radius: 4px;
       }
 
-      #tournamentOverlay {
-        position: fixed;
-        inset: 0;
-        background: #111;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        z-index: 400;
-      }
-      #tournamentOverlay.hidden {
-        display: none;
-      }
-      #tournamentOverlay canvas {
-        background: #fff;
-        width: 95vw;
-        height: 95vh;
-        border: 1px solid #000;
-      }
 
       #rulesModal {
         position: fixed;
@@ -897,6 +879,7 @@
     </div>
 
     <script src="/flag-emojis.js"></script>
+    <script src="/tournament.js"></script>
 
     <!--
     Shenim: Perdorim script me type="text/javascript" per te shmangur
@@ -926,6 +909,19 @@
         window.tournamentPlayers = parseInt(params.get('players') || '0', 10);
         window.potAmount = parseInt(params.get('amount') || '0', 10);
         window.playerName = params.get('name') || 'Player';
+        var tournamentState, currentMatchInfo;
+        if (window.tournamentMode) {
+          tournamentState = Tournament.load();
+          currentMatchInfo = Tournament.getNextUserMatch(tournamentState);
+          Tournament.save(tournamentState);
+          if (!currentMatchInfo) {
+            location.href = '/poll-royale-bracket.html?' + params.toString();
+            return;
+          }
+          var match = tournamentState.rounds[currentMatchInfo.round][currentMatchInfo.match];
+          var oppSeed = match.p1 === tournamentState.userIndex ? match.p2 : match.p1;
+          window.currentMatch = { round: currentMatchInfo.round, match: currentMatchInfo.match, opponent: oppSeed };
+        }
         const planShotPromise = import('/lib/poolAi.js');
 
         /* ==========================================================
@@ -1436,7 +1432,11 @@
             return 'AI';
           }
         }
-        if (window.FLAG_EMOJIS) {
+        if (window.tournamentMode) {
+          var opp = tournamentState.players[window.currentMatch.opponent];
+          avatarCPU.textContent = opp.flag || '';
+          formatPlayerName(opp.name || 'AI', nameCPU);
+        } else if (window.FLAG_EMOJIS) {
           var flag = FLAG_EMOJIS[(Math.random() * FLAG_EMOJIS.length) | 0];
           avatarCPU.textContent = flag;
           formatPlayerName(flagToName(flag) || 'CPU', nameCPU);
@@ -3607,10 +3607,6 @@
       </div>
     </div>
 
-    <div id="tournamentOverlay" class="hidden">
-      <canvas id="bracket"></canvas>
-    </div>
-
     <script>
       const rulesBtn = document.getElementById('rulesBtn');
       const rulesModal = document.getElementById('rulesModal');
@@ -3705,127 +3701,20 @@
         });
       }
 
-      if (params.get('type') === 'tournament') {
-        const overlay = document.getElementById('tournamentOverlay');
-        const canvas = document.getElementById('bracket');
-        const ctx = canvas.getContext('2d');
-        // Generate AI player names with country flags
-        const totalPlayers = window.tournamentPlayers || 16;
-        const aiPool = [
-          { name: 'USA', flag: '🇺🇸' },
-          { name: 'UK', flag: '🇬🇧' },
-          { name: 'Germany', flag: '🇩🇪' },
-          { name: 'Brazil', flag: '🇧🇷' },
-          { name: 'Japan', flag: '🇯🇵' },
-          { name: 'France', flag: '🇫🇷' },
-          { name: 'Spain', flag: '🇪🇸' },
-          { name: 'Italy', flag: '🇮🇹' },
-          { name: 'Canada', flag: '🇨🇦' },
-          { name: 'India', flag: '🇮🇳' },
-          { name: 'China', flag: '🇨🇳' },
-          { name: 'Mexico', flag: '🇲🇽' },
-          { name: 'Australia', flag: '🇦🇺' },
-          { name: 'Russia', flag: '🇷🇺' },
-          { name: 'Netherlands', flag: '🇳🇱' },
-          { name: 'Sweden', flag: '🇸🇪' },
-          { name: 'Norway', flag: '🇳🇴' },
-          { name: 'Denmark', flag: '🇩🇰' },
-          { name: 'Poland', flag: '🇵🇱' },
-          { name: 'Switzerland', flag: '🇨🇭' },
-          { name: 'Greece', flag: '🇬🇷' },
-          { name: 'Turkey', flag: '🇹🇷' },
-          { name: 'Portugal', flag: '🇵🇹' },
-          { name: 'Belgium', flag: '🇧🇪' }
-        ];
-        const players = aiPool.slice(0, totalPlayers - 1);
-        players.unshift({ name: 'You', flag: '🏳️' });
-        while (players.length < totalPlayers) {
-          players.push({ name: `AI ${players.length + 1}`, flag: '🏳️' });
+        if (params.get('type') === 'tournament') {
+          window.handleTournamentResult = function (winner) {
+            var state = Tournament.load();
+            var info = window.currentMatch;
+            var winSeed = winner === 1 ? state.userIndex : info.opponent;
+            Tournament.propagateWinner(state, info.round, info.match, winSeed);
+            Tournament.simulateRound(state, info.round);
+            if (winner !== 1) {
+              Tournament.simulateRemaining(state, info.round + 1);
+            }
+            Tournament.save(state);
+            location.href = '/poll-royale-bracket.html?' + params.toString();
+          };
         }
-        const playerNames = players.map(p => `${p.flag} ${p.name}`);
-        const totalPot = window.potAmount || 0;
-
-        function resizeCanvas() {
-          canvas.width = window.innerWidth * 0.95;
-          canvas.height = window.innerHeight * 0.95;
-          drawBracket();
-        }
-
-        window.addEventListener('resize', resizeCanvas);
-
-        function drawBracket() {
-          ctx.clearRect(0, 0, canvas.width, canvas.height);
-          ctx.strokeStyle = '#000';
-          ctx.lineWidth = 2;
-          ctx.font = '14px Arial';
-          ctx.textBaseline = 'middle';
-
-          let size = playerNames.length;
-          if (![8, 16, 24].includes(size)) {
-            ctx.fillText('Only 8, 16 or 24 players supported', 20, 20);
-            return;
-          }
-
-          let effectivePlayers = [...playerNames];
-          if (size === 24) {
-            effectivePlayers = playerNames
-              .slice(0, 16)
-              .concat(playerNames.slice(16).map(p => p + ' (BYE)'));
-            size = 16;
-          }
-
-          const rounds = Math.log2(size);
-          const colWidth = canvas.width / (rounds * 2);
-          const rowHeight = canvas.height / effectivePlayers.length;
-
-          for (let i = 0; i < effectivePlayers.length / 2; i++) {
-            let y = rowHeight * (i * 2 + 1);
-            ctx.strokeRect(10, y - 12, colWidth - 20, 24);
-            ctx.fillText(effectivePlayers[i], 15, y);
-            ctx.beginPath();
-            ctx.moveTo(colWidth - 10, y);
-            ctx.lineTo(colWidth, y);
-            ctx.stroke();
-          }
-
-          for (let i = effectivePlayers.length / 2; i < effectivePlayers.length; i++) {
-            let idx = i - effectivePlayers.length / 2;
-            let y = rowHeight * (idx * 2 + 1);
-            ctx.strokeRect(canvas.width - colWidth + 10, y - 12, colWidth - 20, 24);
-            ctx.fillText(effectivePlayers[i], canvas.width - colWidth + 15, y);
-            ctx.beginPath();
-            ctx.moveTo(canvas.width - colWidth, y);
-            ctx.lineTo(canvas.width - colWidth + 10, y);
-            ctx.stroke();
-          }
-
-          ctx.beginPath();
-          ctx.arc(canvas.width / 2, canvas.height / 2, 40, 0, 2 * Math.PI);
-          ctx.stroke();
-
-          ctx.font = '16px Arial';
-          ctx.textAlign = 'center';
-          ctx.fillText(`POT: ${totalPot} TPC`, canvas.width / 2, canvas.height / 2 + 60);
-          ctx.textAlign = 'left';
-        }
-
-        resizeCanvas();
-        const continueBtn = document.createElement('button');
-        continueBtn.textContent = 'Continue';
-        continueBtn.style.position = 'absolute';
-        continueBtn.style.bottom = '20px';
-        continueBtn.style.left = '50%';
-        continueBtn.style.transform = 'translateX(-50%)';
-        overlay.appendChild(continueBtn);
-        continueBtn.addEventListener('click', () => {
-          overlay.classList.add('hidden');
-        });
-        window.handleTournamentResult = function () {
-          overlay.classList.remove('hidden');
-          drawBracket();
-        };
-        overlay.classList.remove('hidden');
-      }
 
       // Rotate corner holes diagonally; keep side holes horizontal
       const allHoles = document.querySelectorAll('.hole');

--- a/webapp/public/tournament.js
+++ b/webapp/public/tournament.js
@@ -1,0 +1,95 @@
+(function(){
+  function nextPow2(n){ let p=1; while(p<n) p<<=1; return p; }
+
+  function createTournament(players){
+    const N = players.length;
+    const pow2 = nextPow2(N);
+    const seeded = players.slice();
+    for(let i=N;i<pow2;i++) seeded.push({ name:'BYE', flag:'' });
+    const rounds = [];
+    let current = seeded.map((_,i)=>i);
+    while(current.length>1){
+      const round=[];
+      for(let i=0;i<current.length;i+=2){
+        round.push({ p1: current[i], p2: current[i+1], winner:null });
+      }
+      rounds.push(round);
+      current = round.map(()=>null);
+    }
+    const state = { players: seeded, rounds, userIndex:0, finished:false, champion:null };
+    autoAdvanceByes(state);
+    return state;
+  }
+
+  function propagateWinner(state, r, m, winner){
+    const match = state.rounds[r][m];
+    match.winner = winner;
+    if(r+1 < state.rounds.length){
+      const next = state.rounds[r+1][Math.floor(m/2)];
+      if(m%2===0) next.p1 = winner; else next.p2 = winner;
+    } else {
+      state.champion = winner;
+      state.finished = true;
+    }
+  }
+
+  function autoAdvanceByes(state){
+    for(let r=0;r<state.rounds.length;r++){
+      for(let m=0;m<state.rounds[r].length;m++){
+        const match = state.rounds[r][m];
+        if(match.winner!==null) continue;
+        const p1 = state.players[match.p1];
+        const p2 = state.players[match.p2];
+        if(p1.name==='BYE' && p2.name==='BYE'){
+          propagateWinner(state,r,m,match.p1);
+        } else if(p1.name==='BYE'){
+          propagateWinner(state,r,m,match.p2);
+        } else if(p2.name==='BYE'){
+          propagateWinner(state,r,m,match.p1);
+        }
+      }
+    }
+  }
+
+  function getNextUserMatch(state){
+    const u = state.userIndex;
+    for(let r=0;r<state.rounds.length;r++){
+      for(let m=0;m<state.rounds[r].length;m++){
+        const match = state.rounds[r][m];
+        if(match.winner!==null) continue;
+        if(match.p1===u || match.p2===u){
+          const p1 = state.players[match.p1];
+          const p2 = state.players[match.p2];
+          if(p1.name==='BYE' || p2.name==='BYE'){
+            const winner = p1.name==='BYE'? match.p2 : match.p1;
+            propagateWinner(state,r,m,winner);
+            return getNextUserMatch(state);
+          }
+          return { round:r, match:m };
+        }
+      }
+    }
+    return null;
+  }
+
+  function simulateRound(state,r){
+    for(let m=0;m<state.rounds[r].length;m++){
+      const match = state.rounds[r][m];
+      if(match.winner!==null) continue;
+      if(match.p1===state.userIndex || match.p2===state.userIndex) continue;
+      const winner = Math.random()<0.5 ? match.p1 : match.p2;
+      propagateWinner(state,r,m,winner);
+    }
+  }
+
+  function simulateRemaining(state,startRound){
+    for(let r=startRound;r<state.rounds.length;r++){
+      simulateRound(state,r);
+    }
+  }
+
+  function save(state){ sessionStorage.setItem('pollroyaleTournament', JSON.stringify(state)); }
+  function load(){ const s=sessionStorage.getItem('pollroyaleTournament'); return s? JSON.parse(s):null; }
+
+  window.Tournament = { createTournament, getNextUserMatch, simulateRound, simulateRemaining, save, load, propagateWinner };
+})();


### PR DESCRIPTION
## Summary
- add tournament state manager for bracket generation and AI simulation
- implement new bracket page listing players with flags and continue flow
- wire Pool Royale game to tournament state so user plays own matches and AI rounds auto-simulated

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b690f3b8bc832983c743aca6105789