### PR TITLE
Add tournament generation and round simulation for Pool Royale

### DIFF
--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -50,6 +50,8 @@
   <canvas id="board" width="1200" height="800" aria-label="Tournament bracket canvas"></canvas>
 </div>
 
+<button id="continueBtn" style="position:fixed;bottom:20px;left:50%;transform:translateX(-50%);padding:8px 16px;border:none;border-radius:6px;background:var(--accent);color:var(--ink);">Continue</button>
+
 <script>
 (function(){
   const DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
@@ -74,7 +76,11 @@
     bracketN: 0,
     rounds: [],
     seedToPlayer: {},
-    pot: 0
+    pot: 0,
+    userSeed: 1,
+    currentRound: 0,
+    championSeed: 0,
+    complete: false
   };
 
   function nextPow2(n){ let p=1; while(p<n) p<<=1; return p; }
@@ -259,13 +265,10 @@
   }
 
   function matchPlayers(r,m){
-    if(r===0){
-      const [sA, sB] = state.rounds[0][m];
-      return [state.seedToPlayer[sA], state.seedToPlayer[sB]];
-    }
-    const nameA = { name: 'Winner '+labelForSource(r-1, 2*m) };
-    const nameB = { name: 'Winner '+labelForSource(r-1, 2*m+1) };
-    return [nameA, nameB];
+    const [sA, sB] = state.rounds[r][m] || [];
+    const playerA = state.seedToPlayer[sA] || { name: 'TBD' };
+    const playerB = state.seedToPlayer[sB] || { name: 'TBD' };
+    return [playerA, playerB];
   }
 
   function renderPlayer(player, x, y, slotH){
@@ -341,20 +344,8 @@
     ctx.closePath();
   }
 
-  canvas.addEventListener('click', (ev)=>{
-    const rect = canvas.getBoundingClientRect();
-    const x = (ev.clientX - rect.left);
-    const y = (ev.clientY - rect.top);
-    for(const reg of hitRegions){
-      if(x>=reg.x && x<=reg.x+reg.w && y>=reg.y && y<=reg.y+reg.h){
-        const nm = prompt('Enter team name:', getNameAt(reg.round, reg.match, reg.slot));
-        if(nm && nm.trim()){
-          setNameAt(reg.round, reg.match, reg.slot, nm.trim());
-          layoutAndDraw();
-        }
-        break;
-      }
-    }
+  canvas.addEventListener('click', ()=>{
+    // Name editing disabled in tournament view
   });
 
   function getNameAt(r,m,slot){
@@ -371,20 +362,126 @@
     }
   }
 
+  function simulateRoundAI(st, round){
+    const next = st.rounds[round+1];
+    const userSeed = st.userSeed;
+    st.rounds[round].forEach((pair, idx) => {
+      if(pair.includes(userSeed)) return;
+      if(next && next[Math.floor(idx/2)][idx%2]) return;
+      const s1 = pair[0];
+      const s2 = pair[1];
+      const p1 = st.seedToPlayer[s1];
+      const p2 = st.seedToPlayer[s2];
+      let w;
+      if(p1 && p1.name==='BYE') w = s2;
+      else if(p2 && p2.name==='BYE') w = s1;
+      else w = Math.random() < 0.5 ? s1 : s2;
+      if(next) next[Math.floor(idx/2)][idx%2] = w;
+      else { st.championSeed = w; st.complete = true; }
+    });
+  }
+
+  function getUserMatch(st){
+    const r = st.currentRound || 0;
+    const userSeed = st.userSeed;
+    const roundMatches = st.rounds[r] || [];
+    for(let i=0;i<roundMatches.length;i++){
+      const pair = roundMatches[i];
+      const next = st.rounds[r+1] && st.rounds[r+1][Math.floor(i/2)][i%2];
+      if(next) continue;
+      if(pair[0]===userSeed || pair[1]===userSeed){
+        const oppSeed = pair[0]===userSeed? pair[1]:pair[0];
+        const opp = st.seedToPlayer[oppSeed];
+        if(opp && opp.name==='BYE'){
+          if(st.rounds[r+1]) st.rounds[r+1][Math.floor(i/2)][i%2]=userSeed;
+          simulateRoundAI(st, r);
+          if(st.rounds[r].every((p,idx)=> st.rounds[r+1][Math.floor(idx/2)][idx%2])){
+            st.currentRound++;
+          }
+          localStorage.setItem('tournamentState', JSON.stringify(st));
+          layoutAndDraw();
+          return null;
+        }
+        return {round:r, match:i, pair};
+      }
+    }
+    return null;
+  }
+
+  function startNextMatch(){
+    const st = state;
+    const info = getUserMatch(st);
+    if(!info) return;
+    st.pendingMatch = info;
+    const opponentSeed = info.pair[0] === st.userSeed ? info.pair[1] : info.pair[0];
+    localStorage.setItem('tournamentOpponent', JSON.stringify(st.seedToPlayer[opponentSeed]));
+    localStorage.setItem('tournamentState', JSON.stringify(st));
+    window.location.href = '/poll-royale.html' + window.location.search;
+  }
+
   (function init(){
-    const players = window.tournamentPlayers || [
-      { name: 'Player 1' },
-      { name: 'Player 2' },
-      { name: 'Player 3' },
-      { name: 'Player 4' },
-      { name: 'Player 5' },
-      { name: 'Player 6' },
-      { name: 'USA', flag: '🇺🇸' },
-      { name: 'UK', flag: '🇬🇧' }
-    ];
-    state.players = players;
-    createBracket(players);
+    const params = new URLSearchParams(window.location.search);
+    const totalPlayers = parseInt(params.get('players') || '8', 10);
+    const saved = localStorage.getItem('tournamentState');
+    if(saved){
+      state = JSON.parse(saved);
+    } else {
+      const userName = params.get('name') || 'You';
+      const aiPool = [
+        { name: 'USA', flag: '🇺🇸' },
+        { name: 'UK', flag: '🇬🇧' },
+        { name: 'Germany', flag: '🇩🇪' },
+        { name: 'Brazil', flag: '🇧🇷' },
+        { name: 'Japan', flag: '🇯🇵' },
+        { name: 'France', flag: '🇫🇷' },
+        { name: 'Spain', flag: '🇪🇸' },
+        { name: 'Italy', flag: '🇮🇹' },
+        { name: 'Canada', flag: '🇨🇦' },
+        { name: 'India', flag: '🇮🇳' },
+        { name: 'China', flag: '🇨🇳' },
+        { name: 'Mexico', flag: '🇲🇽' },
+        { name: 'Australia', flag: '🇦🇺' },
+        { name: 'Russia', flag: '🇷🇺' },
+        { name: 'Netherlands', flag: '🇳🇱' },
+        { name: 'Sweden', flag: '🇸🇪' },
+        { name: 'Norway', flag: '🇳🇴' },
+        { name: 'Denmark', flag: '🇩🇰' },
+        { name: 'Poland', flag: '🇵🇱' },
+        { name: 'Switzerland', flag: '🇨🇭' },
+        { name: 'Greece', flag: '🇬🇷' },
+        { name: 'Turkey', flag: '🇹🇷' },
+        { name: 'Portugal', flag: '🇵🇹' },
+        { name: 'Belgium', flag: '🇧🇪' }
+      ];
+      const players = [{ name: userName, flag: params.get('flag') || '🏳️' }];
+      players.push(...aiPool.slice(0, totalPlayers - 1));
+      state.players = players;
+      createBracket(players);
+      state.userSeed = 1;
+      state.currentRound = 0;
+      state.championSeed = 0;
+      state.complete = false;
+      localStorage.setItem('tournamentState', JSON.stringify(state));
+    }
+    layoutAndDraw();
     window.addEventListener('resize', ()=> layoutAndDraw());
+
+    const btn = document.getElementById('continueBtn');
+    if(state.complete){
+      const champ = state.seedToPlayer[state.championSeed] || {};
+      const info = document.createElement('div');
+      info.style.textAlign = 'center';
+      info.textContent = `Winner: ${champ.flag? champ.flag+' ' : ''}${champ.name || ''}`;
+      document.body.appendChild(info);
+      btn.textContent = 'Close';
+      btn.addEventListener('click', ()=>{
+        localStorage.removeItem('tournamentState');
+        localStorage.removeItem('tournamentOpponent');
+        window.location.href = '/games/pollroyale/lobby';
+      });
+    }else{
+      btn.addEventListener('click', startNextMatch);
+    }
   })();
 })();
 </script>

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1436,7 +1436,15 @@
             return 'AI';
           }
         }
-        if (window.FLAG_EMOJIS) {
+        if (window.tournamentMode) {
+          try {
+            var opp = JSON.parse(localStorage.getItem('tournamentOpponent') || '{}');
+            if (opp.flag) avatarCPU.textContent = opp.flag;
+            formatPlayerName(opp.name || 'CPU', nameCPU);
+          } catch (e) {
+            formatPlayerName('CPU', nameCPU);
+          }
+        } else if (window.FLAG_EMOJIS) {
           var flag = FLAG_EMOJIS[(Math.random() * FLAG_EMOJIS.length) | 0];
           avatarCPU.textContent = flag;
           formatPlayerName(flagToName(flag) || 'CPU', nameCPU);
@@ -3706,125 +3714,72 @@
       }
 
       if (params.get('type') === 'tournament') {
-        const overlay = document.getElementById('tournamentOverlay');
-        const canvas = document.getElementById('bracket');
-        const ctx = canvas.getContext('2d');
-        // Generate AI player names with country flags
-        const totalPlayers = window.tournamentPlayers || 16;
-        const aiPool = [
-          { name: 'USA', flag: '🇺🇸' },
-          { name: 'UK', flag: '🇬🇧' },
-          { name: 'Germany', flag: '🇩🇪' },
-          { name: 'Brazil', flag: '🇧🇷' },
-          { name: 'Japan', flag: '🇯🇵' },
-          { name: 'France', flag: '🇫🇷' },
-          { name: 'Spain', flag: '🇪🇸' },
-          { name: 'Italy', flag: '🇮🇹' },
-          { name: 'Canada', flag: '🇨🇦' },
-          { name: 'India', flag: '🇮🇳' },
-          { name: 'China', flag: '🇨🇳' },
-          { name: 'Mexico', flag: '🇲🇽' },
-          { name: 'Australia', flag: '🇦🇺' },
-          { name: 'Russia', flag: '🇷🇺' },
-          { name: 'Netherlands', flag: '🇳🇱' },
-          { name: 'Sweden', flag: '🇸🇪' },
-          { name: 'Norway', flag: '🇳🇴' },
-          { name: 'Denmark', flag: '🇩🇰' },
-          { name: 'Poland', flag: '🇵🇱' },
-          { name: 'Switzerland', flag: '🇨🇭' },
-          { name: 'Greece', flag: '🇬🇷' },
-          { name: 'Turkey', flag: '🇹🇷' },
-          { name: 'Portugal', flag: '🇵🇹' },
-          { name: 'Belgium', flag: '🇧🇪' }
-        ];
-        const players = aiPool.slice(0, totalPlayers - 1);
-        players.unshift({ name: 'You', flag: '🏳️' });
-        while (players.length < totalPlayers) {
-          players.push({ name: `AI ${players.length + 1}`, flag: '🏳️' });
-        }
-        const playerNames = players.map(p => `${p.flag} ${p.name}`);
-        const totalPot = window.potAmount || 0;
-
-        function resizeCanvas() {
-          canvas.width = window.innerWidth * 0.95;
-          canvas.height = window.innerHeight * 0.95;
-          drawBracket();
-        }
-
-        window.addEventListener('resize', resizeCanvas);
-
-        function drawBracket() {
-          ctx.clearRect(0, 0, canvas.width, canvas.height);
-          ctx.strokeStyle = '#000';
-          ctx.lineWidth = 2;
-          ctx.font = '14px Arial';
-          ctx.textBaseline = 'middle';
-
-          let size = playerNames.length;
-          if (![8, 16, 24].includes(size)) {
-            ctx.fillText('Only 8, 16 or 24 players supported', 20, 20);
-            return;
+        window.handleTournamentResult = function (winner) {
+          try {
+            var st = JSON.parse(localStorage.getItem('tournamentState') || '{}');
+            if (!st.pendingMatch) {
+              window.location.href = '/poll-royale-bracket.html?' + window.location.search.slice(1);
+              return;
+            }
+            var r = st.pendingMatch.round;
+            var m = st.pendingMatch.match;
+            var oppSeed = st.pendingMatch.pair[0] === st.userSeed ? st.pendingMatch.pair[1] : st.pendingMatch.pair[0];
+            var winnerSeed = winner === 1 ? st.userSeed : oppSeed;
+            var next = st.rounds[r + 1];
+            if (next) {
+              next[Math.floor(m / 2)][m % 2] = winnerSeed;
+            } else {
+              st.championSeed = winnerSeed;
+              st.complete = true;
+            }
+            if (winnerSeed !== st.userSeed) {
+              simulateRemaining(st, r);
+            } else {
+              simulateRoundAI(st, r);
+              if (next && st.rounds[r].every((p, idx) => next[Math.floor(idx / 2)][idx % 2])) {
+                st.currentRound++;
+              }
+            }
+            delete st.pendingMatch;
+            localStorage.setItem('tournamentState', JSON.stringify(st));
+            localStorage.removeItem('tournamentOpponent');
+          } catch (err) {
+            console.error(err);
           }
-
-          let effectivePlayers = [...playerNames];
-          if (size === 24) {
-            effectivePlayers = playerNames
-              .slice(0, 16)
-              .concat(playerNames.slice(16).map(p => p + ' (BYE)'));
-            size = 16;
-          }
-
-          const rounds = Math.log2(size);
-          const colWidth = canvas.width / (rounds * 2);
-          const rowHeight = canvas.height / effectivePlayers.length;
-
-          for (let i = 0; i < effectivePlayers.length / 2; i++) {
-            let y = rowHeight * (i * 2 + 1);
-            ctx.strokeRect(10, y - 12, colWidth - 20, 24);
-            ctx.fillText(effectivePlayers[i], 15, y);
-            ctx.beginPath();
-            ctx.moveTo(colWidth - 10, y);
-            ctx.lineTo(colWidth, y);
-            ctx.stroke();
-          }
-
-          for (let i = effectivePlayers.length / 2; i < effectivePlayers.length; i++) {
-            let idx = i - effectivePlayers.length / 2;
-            let y = rowHeight * (idx * 2 + 1);
-            ctx.strokeRect(canvas.width - colWidth + 10, y - 12, colWidth - 20, 24);
-            ctx.fillText(effectivePlayers[i], canvas.width - colWidth + 15, y);
-            ctx.beginPath();
-            ctx.moveTo(canvas.width - colWidth, y);
-            ctx.lineTo(canvas.width - colWidth + 10, y);
-            ctx.stroke();
-          }
-
-          ctx.beginPath();
-          ctx.arc(canvas.width / 2, canvas.height / 2, 40, 0, 2 * Math.PI);
-          ctx.stroke();
-
-          ctx.font = '16px Arial';
-          ctx.textAlign = 'center';
-          ctx.fillText(`POT: ${totalPot} TPC`, canvas.width / 2, canvas.height / 2 + 60);
-          ctx.textAlign = 'left';
-        }
-
-        resizeCanvas();
-        const continueBtn = document.createElement('button');
-        continueBtn.textContent = 'Continue';
-        continueBtn.style.position = 'absolute';
-        continueBtn.style.bottom = '20px';
-        continueBtn.style.left = '50%';
-        continueBtn.style.transform = 'translateX(-50%)';
-        overlay.appendChild(continueBtn);
-        continueBtn.addEventListener('click', () => {
-          overlay.classList.add('hidden');
-        });
-        window.handleTournamentResult = function () {
-          overlay.classList.remove('hidden');
-          drawBracket();
+          window.location.href = '/poll-royale-bracket.html?' + window.location.search.slice(1);
         };
-        overlay.classList.remove('hidden');
+
+        function simulateRoundAI(st, round) {
+          var next = st.rounds[round + 1];
+          var userSeed = st.userSeed;
+          st.rounds[round].forEach(function (pair, idx) {
+            if (pair.includes(userSeed)) return;
+            if (next && next[Math.floor(idx / 2)][idx % 2]) return;
+            var s1 = pair[0];
+            var s2 = pair[1];
+            var p1 = st.seedToPlayer[s1];
+            var p2 = st.seedToPlayer[s2];
+            var w;
+            if (p1 && p1.name === 'BYE') w = s2;
+            else if (p2 && p2.name === 'BYE') w = s1;
+            else w = Math.random() < 0.5 ? s1 : s2;
+            if (next) {
+              next[Math.floor(idx / 2)][idx % 2] = w;
+            } else {
+              st.championSeed = w;
+              st.complete = true;
+            }
+          });
+        }
+
+        function simulateRemaining(st, startRound) {
+          for (var r = startRound; r < st.rounds.length; r++) {
+            simulateRoundAI(st, r);
+            if (st.complete) break;
+          }
+          st.currentRound = st.rounds.length - 1;
+          st.complete = true;
+        }
       }
 
       // Rotate corner holes diagonally; keep side holes horizontal


### PR DESCRIPTION
## Summary
- generate tournament brackets with user and AI players
- simulate AI rounds and track progress between matches
- redirect matches back to bracket and show winners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b69523ea588329b9f803df5354e3e0