### PR TITLE
Add tournament mode to Goal Rush and Free Kick

### DIFF
--- a/webapp/public/free-kick-bracket.html
+++ b/webapp/public/free-kick-bracket.html
@@ -1,0 +1,489 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Free Kick Bracket</title>
+<style>
+  :root{
+    --bg:#0b1020;
+    --panel:#11172a;
+    --ink:#dbe7ff;
+    --accent:#2563eb;
+    --accent-2:#f97316;
+    --accent-3:#a855f7;
+    --muted:#8aa0d1;
+  }
+  *{box-sizing:border-box}
+  html,body{height:100%}
+  body{
+    margin:0;
+    font-family:system-ui,Segoe UI,Roboto,Arial,Helvetica,sans-serif;
+    background: radial-gradient(80% 60% at 50% 0%, #0f1735 0%, var(--bg) 60%);
+    color:var(--ink);
+    display:flex; flex-direction:column; gap:10px;
+  }
+  /* Original demo toolbar and notes are hidden */
+  header, .setup, .footer-note{display:none}
+  .canvas-wrap{
+    position:relative;
+    overflow:auto; /* allow horizontal scroll on phones */
+    border-top:1px solid rgba(255,255,255,.06);
+    border-bottom:1px solid rgba(255,255,255,.06);
+    background:
+      radial-gradient(1000px 300px at 50% -50px, rgba(37,99,235,.25), transparent 70%),
+      radial-gradient(800px 300px at 50% 100%, rgba(249,115,22,.15), transparent 70%);
+  }
+  canvas{ display:block; margin:0 auto; }
+  .footer-note{padding:8px 12px; text-align:center; color:var(--muted); font-size:.85rem}
+  details{margin-left:auto}
+  summary{cursor:pointer}
+  .pill {
+    display:inline-flex; align-items:center; gap:8px; padding:4px 8px; border-radius:999px;
+    background:rgba(37,99,235,.15); border:1px solid rgba(37,99,235,.35); color:#cfe0ff;
+    font-size:.8rem;
+  }
+</style>
+</head>
+<body>
+<div class="canvas-wrap">
+  <canvas id="board" width="1200" height="800" aria-label="Tournament bracket canvas"></canvas>
+</div>
+
+<button id="continueBtn" style="position:fixed;bottom:20px;left:50%;transform:translateX(-50%);padding:8px 16px;border:none;border-radius:6px;background:var(--accent);color:var(--ink);">Continue</button>
+
+<script>
+(function(){
+  const DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
+  const canvas = document.getElementById('board');
+  const ctx = canvas.getContext('2d');
+  const theme = {
+    bg:'#0b1020',
+    panel:'#11172a',
+    ink:'#dbe7ff',
+    muted:'#8aa0d1',
+    neonA:'#2563eb',
+    neonB:'#f97316',
+    neonC:'#a855f7',
+    line:'#233155'
+  };
+
+  let hitRegions = []; // {round, match, slot, x,y,w,h}
+
+  let state = {
+    players: [],
+    N: 0,
+    bracketN: 0,
+    rounds: [],
+    seedToPlayer: {},
+    pot: 0,
+    userSeed: 1,
+    currentRound: 0,
+    championSeed: 0,
+    complete: false
+  };
+
+  function nextPow2(n){ let p=1; while(p<n) p<<=1; return p; }
+
+  function seedOrder(N){
+    if(N===2) return [1,2];
+    const prev = seedOrder(N/2);
+    const mirror = prev.map(x => N + 1 - x);
+    return prev.concat(mirror);
+  }
+
+  function round0PairsFromSeeds(N){
+    const order = seedOrder(N);
+    const pairs = [];
+    for(let i=0;i<N;i+=2){
+      pairs.push([order[i], order[i+1]]);
+    }
+    return pairs;
+  }
+
+  function createBracket(players){
+    const Nrequested = players.length;
+    const pow2 = nextPow2(Nrequested);
+    state.N = Nrequested;
+    state.bracketN = pow2;
+    const seedToPlayer = {};
+    for(let s=1; s<=pow2; s++){
+      if(s<=Nrequested) seedToPlayer[s]=players[s-1];
+      else seedToPlayer[s]={name:'BYE'};
+    }
+    state.seedToPlayer = seedToPlayer;
+
+    const r0 = round0PairsFromSeeds(pow2);
+    state.rounds = [r0];
+    let matches = r0.length;
+    while(matches>1){
+      matches = Math.ceil(matches/2);
+      state.rounds.push(Array.from({length:matches}, _=>[0,0]));
+    }
+    layoutAndDraw();
+  }
+
+  function layoutAndDraw(){
+    const rounds = state.rounds.length;
+    const colW = 220;
+    const colGap = 64;
+    const padX = 24;
+    const padY = 24;
+    const widthCSS = padX*2 + rounds*colW + (rounds-1)*colGap;
+
+    const matches0 = state.rounds[0].length;
+
+    const boxH = 56;
+    const slotH = boxH/2;
+    const baseGap = 28;
+
+    const centers = [];
+    centers[0] = Array.from({length:matches0}, (_,i)=> padY + (boxH/2) + i*(boxH + baseGap));
+    for(let r=1; r<rounds; r++){
+      const prev = centers[r-1];
+      const arr=[];
+      for(let i=0;i<Math.ceil(prev.length/2);i++){
+        const c = (prev[2*i] + prev[2*i+1]) / 2;
+        arr.push(c);
+      }
+      centers[r]=arr;
+    }
+
+    const lastCenter = centers[rounds-1][0] || padY + boxH/2;
+    const heightCSS = Math.max(600, lastCenter + padY + boxH/2);
+
+    canvas.style.width = widthCSS + 'px';
+    canvas.style.height = heightCSS + 'px';
+    canvas.width = Math.floor(widthCSS * DPR);
+    canvas.height = Math.floor(heightCSS * DPR);
+    ctx.setTransform(DPR,0,0,DPR,0,0);
+
+    ctx.clearRect(0,0,widthCSS,heightCSS);
+    drawBackground(widthCSS, heightCSS);
+
+    hitRegions = [];
+    for(let r=0;r<rounds;r++){
+      const x = padX + r*(colW + colGap);
+      drawRoundTitle(r, x, 6 + (r==0? 10:0));
+
+      const matchesR = state.rounds[r].length;
+      for(let m=0;m<matchesR;m++){
+        const yCenter = centers[r][m];
+        drawMatchBox(r, m, x, yCenter - boxH/2, colW, boxH, slotH);
+      }
+
+      if(r>0){
+        const xPrev = padX + (r-1)*(colW + colGap) + colW;
+        const xConn = xPrev + 18;
+        ctx.lineWidth = 2;
+        ctx.strokeStyle = theme.line;
+        ctx.beginPath();
+        for(let m=0;m<state.rounds[r].length;m++){
+          const cy = centers[r][m];
+          const top = centers[r-1][2*m];
+          const bot = centers[r-1][2*m+1];
+          ctx.moveTo(xPrev, top);
+          ctx.lineTo(xConn, top);
+          ctx.moveTo(xPrev, bot);
+          ctx.lineTo(xConn, bot);
+          ctx.moveTo(xConn, top);
+          ctx.lineTo(xConn, bot);
+          ctx.moveTo(xConn, cy);
+          ctx.lineTo(x, cy);
+        }
+        ctx.stroke();
+      }
+    }
+
+    drawCenterLabels(widthCSS);
+  }
+
+  function drawBackground(w,h){
+    const g = ctx.createLinearGradient(0,0,w,0);
+    g.addColorStop(0,'rgba(168,85,247,.08)');
+    g.addColorStop(.5,'rgba(37,99,235,.10)');
+    g.addColorStop(1,'rgba(249,115,22,.08)');
+    ctx.fillStyle = g;
+    ctx.fillRect(0,0,w,h);
+  }
+
+  function drawRoundTitle(r, x, topPad){
+    ctx.save();
+    ctx.fillStyle = '#bcd0ff';
+    ctx.font = '600 12px system-ui,Segoe UI,Roboto,Arial';
+    ctx.textAlign = 'left';
+    let label = '';
+    const rounds = state.rounds.length;
+    if(r === 0) label = 'ROUND OF ' + state.bracketN;
+    else if(r === rounds-1) label = 'FINAL 🏆 🪙' + state.pot;
+    else if(r === rounds-2) label = 'SEMIFINAL';
+    else label = 'QUARTER / R' + (r+1);
+    ctx.fillText(label, x, topPad + 10);
+    ctx.restore();
+  }
+
+  function slotColor(r, slot){
+    const palettes = [theme.neonC, theme.neonA, theme.neonB];
+    const base = palettes[r % palettes.length];
+    const alpha = .22;
+    return hexToRgba(base, alpha);
+  }
+
+  function drawMatchBox(r, m, x, y, w, h, slotH){
+    const radius = 12;
+    roundRect(ctx, x, y, w, h, radius);
+    const grad = ctx.createLinearGradient(x, y, x, y+h);
+    grad.addColorStop(0, 'rgba(255,255,255,.04)');
+    grad.addColorStop(1, 'rgba(0,0,0,.25)');
+    ctx.fillStyle = grad;
+    ctx.fill();
+
+    ctx.fillStyle = slotColor(r,0);
+    roundRect(ctx, x+4, y+4, w-8, slotH-6, 8);
+    ctx.fill();
+    ctx.fillStyle = slotColor(r,1);
+    roundRect(ctx, x+4, y+slotH+2, w-8, slotH-6, 8);
+    ctx.fill();
+
+    ctx.strokeStyle = 'rgba(255,255,255,.06)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(x+8, y+slotH);
+    ctx.lineTo(x+w-8, y+slotH);
+    ctx.stroke();
+
+    ctx.fillStyle = '#e7efff';
+    ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
+    ctx.textAlign = 'left';
+
+    const players = matchPlayers(r,m);
+    renderPlayer(players[0], x+12, y+slotH/2+4, slotH);
+    renderPlayer(players[1], x+12, y+slotH + slotH/2+4, slotH);
+
+    hitRegions.push({round:r, match:m, slot:0, x:x+4, y:y+4, w:w-8, h:slotH-6});
+    hitRegions.push({round:r, match:m, slot:1, x:x+4, y:y+slotH+2, w:w-8, h:slotH-6});
+  }
+
+  function matchPlayers(r,m){
+    const [sA, sB] = state.rounds[r][m] || [];
+    const playerA = state.seedToPlayer[sA] || { name: 'TBD' };
+    const playerB = state.seedToPlayer[sB] || { name: 'TBD' };
+    return [playerA, playerB];
+  }
+
+  function renderPlayer(player, x, y, slotH){
+    const avatarSize = 20;
+    if(player.flag){
+      ctx.fillText(player.flag, x, y+1);
+      ctx.fillText(player.name, x+18, y);
+    }else{
+      ctx.save();
+      ctx.beginPath();
+      ctx.arc(x+avatarSize/2, y-8, avatarSize/2, 0, Math.PI*2);
+      ctx.fillStyle = '#233155';
+      ctx.fill();
+      ctx.fillStyle = '#e7efff';
+      ctx.font = '600 11px system-ui,Segoe UI,Roboto,Arial';
+      ctx.textAlign = 'center';
+      ctx.fillText((player.name||'')[0]||'', x+avatarSize/2, y-4);
+      ctx.restore();
+      ctx.textAlign = 'left';
+      ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
+      ctx.fillText(player.name, x+avatarSize+6, y);
+    }
+  }
+
+  function labelForSource(r,m){
+    if(r===0){
+      const [sA,sB]=state.rounds[0][m];
+      return `(${seedShort(sA)} vs ${seedShort(sB)})`;
+    }else{
+      return `R${r+1}-M${m+1}`;
+    }
+  }
+
+  function seedShort(s){
+    const n = state.seedToPlayer[s].name;
+    if(n==='BYE') return 'BYE';
+    if(/^Team \d+$/i.test(n)) return n.replace('Team ', '#');
+    return n.length>10? n.slice(0,10)+'…': n;
+  }
+
+  function drawCenterLabels(w){
+    ctx.save();
+    ctx.textAlign = 'center';
+    ctx.font = '700 20px system-ui,Segoe UI,Roboto,Arial';
+    ctx.fillStyle = '#e8f0ff';
+    ctx.fillText('THE PLAYOFFS', w/2, 34);
+    ctx.font = '600 12px system-ui,Segoe UI,Roboto,Arial';
+    ctx.fillStyle = '#9fb3de';
+    ctx.fillText('WORLD CHAMPIONSHIP', w/2, 54);
+    ctx.restore();
+  }
+
+  function hexToRgba(hex, a){
+    let c = hex.replace('#','');
+    if(c.length===3){ c = c.split('').map(x=>x+x).join(''); }
+    const num = parseInt(c,16);
+    const r = (num>>16)&255, g=(num>>8)&255, b=num&255;
+    return `rgba(${r},${g},${b},${a})`;
+  }
+
+  function roundRect(ctx, x, y, w, h, r){
+    const rr = Math.min(r, w/2, h/2);
+    ctx.beginPath();
+    ctx.moveTo(x+rr, y);
+    ctx.lineTo(x+w-rr, y);
+    ctx.quadraticCurveTo(x+w, y, x+w, y+rr);
+    ctx.lineTo(x+w, y+h-rr);
+    ctx.quadraticCurveTo(x+w, y+h, x+w-rr, y+h);
+    ctx.lineTo(x+rr, y+h);
+    ctx.quadraticCurveTo(x, y+h, x, y+h-rr);
+    ctx.lineTo(x, y+rr);
+    ctx.quadraticCurveTo(x, y, x+rr, y);
+    ctx.closePath();
+  }
+
+  canvas.addEventListener('click', ()=>{
+    // Name editing disabled in tournament view
+  });
+
+  function getNameAt(r,m,slot){
+    const [a,b] = matchPlayers(r,m);
+    return slot===0? a.name : b.name;
+  }
+
+  function setNameAt(r,m,slot,newName){
+    if(r===0){
+      const seed = state.rounds[0][m][slot];
+      state.seedToPlayer[seed].name = newName;
+    }else{
+      alert('Names in this round are auto-filled from previous matches.');
+    }
+  }
+
+  function simulateRoundAI(st, round){
+    const next = st.rounds[round+1];
+    const userSeed = st.userSeed;
+    st.rounds[round].forEach((pair, idx) => {
+      if(pair.includes(userSeed)) return;
+      if(next && next[Math.floor(idx/2)][idx%2]) return;
+      const s1 = pair[0];
+      const s2 = pair[1];
+      const p1 = st.seedToPlayer[s1];
+      const p2 = st.seedToPlayer[s2];
+      let w;
+      if(p1 && p1.name==='BYE') w = s2;
+      else if(p2 && p2.name==='BYE') w = s1;
+      else w = Math.random() < 0.5 ? s1 : s2;
+      if(next) next[Math.floor(idx/2)][idx%2] = w;
+      else { st.championSeed = w; st.complete = true; }
+    });
+  }
+
+  function getUserMatch(st){
+    const r = st.currentRound || 0;
+    const userSeed = st.userSeed;
+    const roundMatches = st.rounds[r] || [];
+    for(let i=0;i<roundMatches.length;i++){
+      const pair = roundMatches[i];
+      const next = st.rounds[r+1] && st.rounds[r+1][Math.floor(i/2)][i%2];
+      if(next) continue;
+      if(pair[0]===userSeed || pair[1]===userSeed){
+        const oppSeed = pair[0]===userSeed? pair[1]:pair[0];
+        const opp = st.seedToPlayer[oppSeed];
+        if(opp && opp.name==='BYE'){
+          if(st.rounds[r+1]) st.rounds[r+1][Math.floor(i/2)][i%2]=userSeed;
+          simulateRoundAI(st, r);
+          if(st.rounds[r].every((p,idx)=> st.rounds[r+1][Math.floor(idx/2)][idx%2])){
+            st.currentRound++;
+          }
+          localStorage.setItem('tournamentState', JSON.stringify(st));
+          layoutAndDraw();
+          return null;
+        }
+        return {round:r, match:i, pair};
+      }
+    }
+    return null;
+  }
+
+  function startNextMatch(){
+    const st = state;
+    const info = getUserMatch(st);
+    if(!info) return;
+    st.pendingMatch = info;
+    const opponentSeed = info.pair[0] === st.userSeed ? info.pair[1] : info.pair[0];
+    localStorage.setItem('tournamentOpponent', JSON.stringify(st.seedToPlayer[opponentSeed]));
+    localStorage.setItem('tournamentState', JSON.stringify(st));
+    window.location.href = '/free-kick.html' + window.location.search;
+  }
+
+  (function init(){
+    const params = new URLSearchParams(window.location.search);
+    const totalPlayers = parseInt(params.get('players') || '8', 10);
+    const saved = localStorage.getItem('tournamentState');
+    if(saved){
+      state = JSON.parse(saved);
+    } else {
+      const userName = params.get('name') || 'You';
+      const aiPool = [
+        { name: 'USA', flag: '🇺🇸' },
+        { name: 'UK', flag: '🇬🇧' },
+        { name: 'Germany', flag: '🇩🇪' },
+        { name: 'Brazil', flag: '🇧🇷' },
+        { name: 'Japan', flag: '🇯🇵' },
+        { name: 'France', flag: '🇫🇷' },
+        { name: 'Spain', flag: '🇪🇸' },
+        { name: 'Italy', flag: '🇮🇹' },
+        { name: 'Canada', flag: '🇨🇦' },
+        { name: 'India', flag: '🇮🇳' },
+        { name: 'China', flag: '🇨🇳' },
+        { name: 'Mexico', flag: '🇲🇽' },
+        { name: 'Australia', flag: '🇦🇺' },
+        { name: 'Russia', flag: '🇷🇺' },
+        { name: 'Netherlands', flag: '🇳🇱' },
+        { name: 'Sweden', flag: '🇸🇪' },
+        { name: 'Norway', flag: '🇳🇴' },
+        { name: 'Denmark', flag: '🇩🇰' },
+        { name: 'Poland', flag: '🇵🇱' },
+        { name: 'Switzerland', flag: '🇨🇭' },
+        { name: 'Greece', flag: '🇬🇷' },
+        { name: 'Turkey', flag: '🇹🇷' },
+        { name: 'Portugal', flag: '🇵🇹' },
+        { name: 'Belgium', flag: '🇧🇪' }
+      ];
+      const players = [{ name: userName, flag: params.get('flag') || '🏳️' }];
+      players.push(...aiPool.slice(0, totalPlayers - 1));
+      state.players = players;
+      createBracket(players);
+      state.userSeed = 1;
+      state.currentRound = 0;
+      state.championSeed = 0;
+      state.complete = false;
+      localStorage.setItem('tournamentState', JSON.stringify(state));
+    }
+    layoutAndDraw();
+    window.addEventListener('resize', ()=> layoutAndDraw());
+
+    const btn = document.getElementById('continueBtn');
+    if(state.complete){
+      const champ = state.seedToPlayer[state.championSeed] || {};
+      const info = document.createElement('div');
+      info.style.textAlign = 'center';
+      info.textContent = `Winner: ${champ.flag? champ.flag+' ' : ''}${champ.name || ''}`;
+      document.body.appendChild(info);
+      btn.textContent = 'Close';
+      btn.addEventListener('click', ()=>{
+        localStorage.removeItem('tournamentState');
+        localStorage.removeItem('tournamentOpponent');
+        window.location.href = '/games/pollroyale/lobby';
+      });
+    }else{
+      btn.addEventListener('click', startNextMatch);
+    }
+  })();
+})();
+</script>
+</body>
+</html>

--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -168,6 +168,11 @@
   }
 
   const params = new URLSearchParams(location.search);
+  const playType = params.get('type') || 'regular';
+  window.tournamentMode = playType === 'tournament';
+  window.tournamentPlayers = window.tournamentMode
+    ? parseInt(params.get('players') || '0', 10)
+    : 0;
   const avatarParam = params.get('avatar') || '';
   let userName = params.get('name') || params.get('username') || '';
   const durationParam = parseInt(params.get('duration')) || 60;
@@ -201,10 +206,23 @@
   userAvatarEl.src = userAvatar;
 
   const flags = ['🇨🇦','🇫🇷','🇩🇪','🇪🇸','🇧🇷','🇯🇵','🇺🇸','🇬🇧'];
-  for(let i=0;i<3;i++){
-    const flag = flags[(Math.random()*flags.length)|0];
-    if(pvAvatars[i]) pvAvatars[i].src = emojiToDataUri(flag);
-    if(pvNames[i]) pvNames[i].textContent = flagName(flag);
+  if(window.tournamentMode){
+    try{
+      const opp = JSON.parse(localStorage.getItem('tournamentOpponent') || '{}');
+      if(pvAvatars[0] && opp.flag) pvAvatars[0].src = emojiToDataUri(opp.flag);
+      if(pvNames[0]) pvNames[0].textContent = opp.name || flagName(opp.flag);
+    }catch{}
+    for(let i=1;i<3;i++){
+      const flag = flags[(Math.random()*flags.length)|0];
+      if(pvAvatars[i]) pvAvatars[i].src = emojiToDataUri(flag);
+      if(pvNames[i]) pvNames[i].textContent = flagName(flag);
+    }
+  } else {
+    for(let i=0;i<3;i++){
+      const flag = flags[(Math.random()*flags.length)|0];
+      if(pvAvatars[i]) pvAvatars[i].src = emojiToDataUri(flag);
+      if(pvNames[i]) pvNames[i].textContent = flagName(flag);
+    }
   }
   positionLayout();
 
@@ -1267,6 +1285,11 @@ function endShot(hit,pts,delay=SHOT_RESET_DELAY){
     for(const r of rivals){ scores.push({score:r.score,avatar:r.avatar}); }
     const max=Math.max(...scores.map(s=>s.score));
     const winner=scores.find(s=>s.score===max);
+    const winIdx = scores.indexOf(winner) === 0 ? 1 : 2;
+    if(window.tournamentMode && typeof window.handleTournamentResult === 'function'){
+      window.handleTournamentResult(winIdx);
+      return;
+    }
     const overlay=document.getElementById('winnerOverlay');
     const img=document.getElementById('winnerAvatar');
     if(img) img.src=winner.avatar || userAvatar;
@@ -1827,6 +1850,76 @@ function drawStaticOnce(){ drawField(); drawAds(); drawGoal(); resetBall(); draw
     canvas.addEventListener('pointerdown', ()=>{ if(!running||ended) startCountdown(3); ensureAudio(); crowdSound.play().catch(()=>{}); }, {once:false});
     startCountdown(3);
   }
+
+  if (params.get('type') === 'tournament') {
+    window.handleTournamentResult = function (winner) {
+      try {
+        var st = JSON.parse(localStorage.getItem('tournamentState') || '{}');
+        if (!st.pendingMatch) {
+          window.location.href = '/free-kick-bracket.html?' + window.location.search.slice(1);
+          return;
+        }
+        var r = st.pendingMatch.round;
+        var m = st.pendingMatch.match;
+        var oppSeed = st.pendingMatch.pair[0] === st.userSeed ? st.pendingMatch.pair[1] : st.pendingMatch.pair[0];
+        var winnerSeed = winner === 1 ? st.userSeed : oppSeed;
+        var next = st.rounds[r + 1];
+        if (next) {
+          next[Math.floor(m / 2)][m % 2] = winnerSeed;
+        } else {
+          st.championSeed = winnerSeed;
+          st.complete = true;
+        }
+        if (winnerSeed !== st.userSeed) {
+          simulateRemaining(st, r);
+        } else {
+          simulateRoundAI(st, r);
+          if (next && st.rounds[r].every(function(p, idx){ return next[Math.floor(idx/2)][idx%2]; })) {
+            st.currentRound++;
+          }
+        }
+        delete st.pendingMatch;
+        localStorage.setItem('tournamentState', JSON.stringify(st));
+        localStorage.removeItem('tournamentOpponent');
+      } catch (err) {
+        console.error(err);
+      }
+      window.location.href = '/free-kick-bracket.html?' + window.location.search.slice(1);
+    };
+
+    function simulateRoundAI(st, round){
+      var next = st.rounds[round + 1];
+      var userSeed = st.userSeed;
+      st.rounds[round].forEach(function(pair, idx){
+        if(pair.includes(userSeed)) return;
+        if(next && next[Math.floor(idx/2)][idx%2]) return;
+        var s1 = pair[0];
+        var s2 = pair[1];
+        var p1 = st.seedToPlayer[s1];
+        var p2 = st.seedToPlayer[s2];
+        var w;
+        if(p1 && p1.name === 'BYE') w = s2;
+        else if(p2 && p2.name === 'BYE') w = s1;
+        else w = Math.random() < 0.5 ? s1 : s2;
+        if(next){
+          next[Math.floor(idx/2)][idx%2] = w;
+        } else {
+          st.championSeed = w;
+          st.complete = true;
+        }
+      });
+    }
+
+    function simulateRemaining(st, startRound){
+      for(var r = startRound; r < st.rounds.length; r++){
+        simulateRoundAI(st, r);
+        if(st.complete) break;
+      }
+      st.currentRound = st.rounds.length - 1;
+      st.complete = true;
+    }
+  }
+
   boot();
   document.getElementById('lobbyBtn').addEventListener('click', ()=>{ location.href='/games/freekick/lobby'; });
 })();

--- a/webapp/public/goal-rush-bracket.html
+++ b/webapp/public/goal-rush-bracket.html
@@ -1,0 +1,489 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Goal Rush Bracket</title>
+<style>
+  :root{
+    --bg:#0b1020;
+    --panel:#11172a;
+    --ink:#dbe7ff;
+    --accent:#2563eb;
+    --accent-2:#f97316;
+    --accent-3:#a855f7;
+    --muted:#8aa0d1;
+  }
+  *{box-sizing:border-box}
+  html,body{height:100%}
+  body{
+    margin:0;
+    font-family:system-ui,Segoe UI,Roboto,Arial,Helvetica,sans-serif;
+    background: radial-gradient(80% 60% at 50% 0%, #0f1735 0%, var(--bg) 60%);
+    color:var(--ink);
+    display:flex; flex-direction:column; gap:10px;
+  }
+  /* Original demo toolbar and notes are hidden */
+  header, .setup, .footer-note{display:none}
+  .canvas-wrap{
+    position:relative;
+    overflow:auto; /* allow horizontal scroll on phones */
+    border-top:1px solid rgba(255,255,255,.06);
+    border-bottom:1px solid rgba(255,255,255,.06);
+    background:
+      radial-gradient(1000px 300px at 50% -50px, rgba(37,99,235,.25), transparent 70%),
+      radial-gradient(800px 300px at 50% 100%, rgba(249,115,22,.15), transparent 70%);
+  }
+  canvas{ display:block; margin:0 auto; }
+  .footer-note{padding:8px 12px; text-align:center; color:var(--muted); font-size:.85rem}
+  details{margin-left:auto}
+  summary{cursor:pointer}
+  .pill {
+    display:inline-flex; align-items:center; gap:8px; padding:4px 8px; border-radius:999px;
+    background:rgba(37,99,235,.15); border:1px solid rgba(37,99,235,.35); color:#cfe0ff;
+    font-size:.8rem;
+  }
+</style>
+</head>
+<body>
+<div class="canvas-wrap">
+  <canvas id="board" width="1200" height="800" aria-label="Tournament bracket canvas"></canvas>
+</div>
+
+<button id="continueBtn" style="position:fixed;bottom:20px;left:50%;transform:translateX(-50%);padding:8px 16px;border:none;border-radius:6px;background:var(--accent);color:var(--ink);">Continue</button>
+
+<script>
+(function(){
+  const DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
+  const canvas = document.getElementById('board');
+  const ctx = canvas.getContext('2d');
+  const theme = {
+    bg:'#0b1020',
+    panel:'#11172a',
+    ink:'#dbe7ff',
+    muted:'#8aa0d1',
+    neonA:'#2563eb',
+    neonB:'#f97316',
+    neonC:'#a855f7',
+    line:'#233155'
+  };
+
+  let hitRegions = []; // {round, match, slot, x,y,w,h}
+
+  let state = {
+    players: [],
+    N: 0,
+    bracketN: 0,
+    rounds: [],
+    seedToPlayer: {},
+    pot: 0,
+    userSeed: 1,
+    currentRound: 0,
+    championSeed: 0,
+    complete: false
+  };
+
+  function nextPow2(n){ let p=1; while(p<n) p<<=1; return p; }
+
+  function seedOrder(N){
+    if(N===2) return [1,2];
+    const prev = seedOrder(N/2);
+    const mirror = prev.map(x => N + 1 - x);
+    return prev.concat(mirror);
+  }
+
+  function round0PairsFromSeeds(N){
+    const order = seedOrder(N);
+    const pairs = [];
+    for(let i=0;i<N;i+=2){
+      pairs.push([order[i], order[i+1]]);
+    }
+    return pairs;
+  }
+
+  function createBracket(players){
+    const Nrequested = players.length;
+    const pow2 = nextPow2(Nrequested);
+    state.N = Nrequested;
+    state.bracketN = pow2;
+    const seedToPlayer = {};
+    for(let s=1; s<=pow2; s++){
+      if(s<=Nrequested) seedToPlayer[s]=players[s-1];
+      else seedToPlayer[s]={name:'BYE'};
+    }
+    state.seedToPlayer = seedToPlayer;
+
+    const r0 = round0PairsFromSeeds(pow2);
+    state.rounds = [r0];
+    let matches = r0.length;
+    while(matches>1){
+      matches = Math.ceil(matches/2);
+      state.rounds.push(Array.from({length:matches}, _=>[0,0]));
+    }
+    layoutAndDraw();
+  }
+
+  function layoutAndDraw(){
+    const rounds = state.rounds.length;
+    const colW = 220;
+    const colGap = 64;
+    const padX = 24;
+    const padY = 24;
+    const widthCSS = padX*2 + rounds*colW + (rounds-1)*colGap;
+
+    const matches0 = state.rounds[0].length;
+
+    const boxH = 56;
+    const slotH = boxH/2;
+    const baseGap = 28;
+
+    const centers = [];
+    centers[0] = Array.from({length:matches0}, (_,i)=> padY + (boxH/2) + i*(boxH + baseGap));
+    for(let r=1; r<rounds; r++){
+      const prev = centers[r-1];
+      const arr=[];
+      for(let i=0;i<Math.ceil(prev.length/2);i++){
+        const c = (prev[2*i] + prev[2*i+1]) / 2;
+        arr.push(c);
+      }
+      centers[r]=arr;
+    }
+
+    const lastCenter = centers[rounds-1][0] || padY + boxH/2;
+    const heightCSS = Math.max(600, lastCenter + padY + boxH/2);
+
+    canvas.style.width = widthCSS + 'px';
+    canvas.style.height = heightCSS + 'px';
+    canvas.width = Math.floor(widthCSS * DPR);
+    canvas.height = Math.floor(heightCSS * DPR);
+    ctx.setTransform(DPR,0,0,DPR,0,0);
+
+    ctx.clearRect(0,0,widthCSS,heightCSS);
+    drawBackground(widthCSS, heightCSS);
+
+    hitRegions = [];
+    for(let r=0;r<rounds;r++){
+      const x = padX + r*(colW + colGap);
+      drawRoundTitle(r, x, 6 + (r==0? 10:0));
+
+      const matchesR = state.rounds[r].length;
+      for(let m=0;m<matchesR;m++){
+        const yCenter = centers[r][m];
+        drawMatchBox(r, m, x, yCenter - boxH/2, colW, boxH, slotH);
+      }
+
+      if(r>0){
+        const xPrev = padX + (r-1)*(colW + colGap) + colW;
+        const xConn = xPrev + 18;
+        ctx.lineWidth = 2;
+        ctx.strokeStyle = theme.line;
+        ctx.beginPath();
+        for(let m=0;m<state.rounds[r].length;m++){
+          const cy = centers[r][m];
+          const top = centers[r-1][2*m];
+          const bot = centers[r-1][2*m+1];
+          ctx.moveTo(xPrev, top);
+          ctx.lineTo(xConn, top);
+          ctx.moveTo(xPrev, bot);
+          ctx.lineTo(xConn, bot);
+          ctx.moveTo(xConn, top);
+          ctx.lineTo(xConn, bot);
+          ctx.moveTo(xConn, cy);
+          ctx.lineTo(x, cy);
+        }
+        ctx.stroke();
+      }
+    }
+
+    drawCenterLabels(widthCSS);
+  }
+
+  function drawBackground(w,h){
+    const g = ctx.createLinearGradient(0,0,w,0);
+    g.addColorStop(0,'rgba(168,85,247,.08)');
+    g.addColorStop(.5,'rgba(37,99,235,.10)');
+    g.addColorStop(1,'rgba(249,115,22,.08)');
+    ctx.fillStyle = g;
+    ctx.fillRect(0,0,w,h);
+  }
+
+  function drawRoundTitle(r, x, topPad){
+    ctx.save();
+    ctx.fillStyle = '#bcd0ff';
+    ctx.font = '600 12px system-ui,Segoe UI,Roboto,Arial';
+    ctx.textAlign = 'left';
+    let label = '';
+    const rounds = state.rounds.length;
+    if(r === 0) label = 'ROUND OF ' + state.bracketN;
+    else if(r === rounds-1) label = 'FINAL 🏆 🪙' + state.pot;
+    else if(r === rounds-2) label = 'SEMIFINAL';
+    else label = 'QUARTER / R' + (r+1);
+    ctx.fillText(label, x, topPad + 10);
+    ctx.restore();
+  }
+
+  function slotColor(r, slot){
+    const palettes = [theme.neonC, theme.neonA, theme.neonB];
+    const base = palettes[r % palettes.length];
+    const alpha = .22;
+    return hexToRgba(base, alpha);
+  }
+
+  function drawMatchBox(r, m, x, y, w, h, slotH){
+    const radius = 12;
+    roundRect(ctx, x, y, w, h, radius);
+    const grad = ctx.createLinearGradient(x, y, x, y+h);
+    grad.addColorStop(0, 'rgba(255,255,255,.04)');
+    grad.addColorStop(1, 'rgba(0,0,0,.25)');
+    ctx.fillStyle = grad;
+    ctx.fill();
+
+    ctx.fillStyle = slotColor(r,0);
+    roundRect(ctx, x+4, y+4, w-8, slotH-6, 8);
+    ctx.fill();
+    ctx.fillStyle = slotColor(r,1);
+    roundRect(ctx, x+4, y+slotH+2, w-8, slotH-6, 8);
+    ctx.fill();
+
+    ctx.strokeStyle = 'rgba(255,255,255,.06)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(x+8, y+slotH);
+    ctx.lineTo(x+w-8, y+slotH);
+    ctx.stroke();
+
+    ctx.fillStyle = '#e7efff';
+    ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
+    ctx.textAlign = 'left';
+
+    const players = matchPlayers(r,m);
+    renderPlayer(players[0], x+12, y+slotH/2+4, slotH);
+    renderPlayer(players[1], x+12, y+slotH + slotH/2+4, slotH);
+
+    hitRegions.push({round:r, match:m, slot:0, x:x+4, y:y+4, w:w-8, h:slotH-6});
+    hitRegions.push({round:r, match:m, slot:1, x:x+4, y:y+slotH+2, w:w-8, h:slotH-6});
+  }
+
+  function matchPlayers(r,m){
+    const [sA, sB] = state.rounds[r][m] || [];
+    const playerA = state.seedToPlayer[sA] || { name: 'TBD' };
+    const playerB = state.seedToPlayer[sB] || { name: 'TBD' };
+    return [playerA, playerB];
+  }
+
+  function renderPlayer(player, x, y, slotH){
+    const avatarSize = 20;
+    if(player.flag){
+      ctx.fillText(player.flag, x, y+1);
+      ctx.fillText(player.name, x+18, y);
+    }else{
+      ctx.save();
+      ctx.beginPath();
+      ctx.arc(x+avatarSize/2, y-8, avatarSize/2, 0, Math.PI*2);
+      ctx.fillStyle = '#233155';
+      ctx.fill();
+      ctx.fillStyle = '#e7efff';
+      ctx.font = '600 11px system-ui,Segoe UI,Roboto,Arial';
+      ctx.textAlign = 'center';
+      ctx.fillText((player.name||'')[0]||'', x+avatarSize/2, y-4);
+      ctx.restore();
+      ctx.textAlign = 'left';
+      ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
+      ctx.fillText(player.name, x+avatarSize+6, y);
+    }
+  }
+
+  function labelForSource(r,m){
+    if(r===0){
+      const [sA,sB]=state.rounds[0][m];
+      return `(${seedShort(sA)} vs ${seedShort(sB)})`;
+    }else{
+      return `R${r+1}-M${m+1}`;
+    }
+  }
+
+  function seedShort(s){
+    const n = state.seedToPlayer[s].name;
+    if(n==='BYE') return 'BYE';
+    if(/^Team \d+$/i.test(n)) return n.replace('Team ', '#');
+    return n.length>10? n.slice(0,10)+'…': n;
+  }
+
+  function drawCenterLabels(w){
+    ctx.save();
+    ctx.textAlign = 'center';
+    ctx.font = '700 20px system-ui,Segoe UI,Roboto,Arial';
+    ctx.fillStyle = '#e8f0ff';
+    ctx.fillText('THE PLAYOFFS', w/2, 34);
+    ctx.font = '600 12px system-ui,Segoe UI,Roboto,Arial';
+    ctx.fillStyle = '#9fb3de';
+    ctx.fillText('WORLD CHAMPIONSHIP', w/2, 54);
+    ctx.restore();
+  }
+
+  function hexToRgba(hex, a){
+    let c = hex.replace('#','');
+    if(c.length===3){ c = c.split('').map(x=>x+x).join(''); }
+    const num = parseInt(c,16);
+    const r = (num>>16)&255, g=(num>>8)&255, b=num&255;
+    return `rgba(${r},${g},${b},${a})`;
+  }
+
+  function roundRect(ctx, x, y, w, h, r){
+    const rr = Math.min(r, w/2, h/2);
+    ctx.beginPath();
+    ctx.moveTo(x+rr, y);
+    ctx.lineTo(x+w-rr, y);
+    ctx.quadraticCurveTo(x+w, y, x+w, y+rr);
+    ctx.lineTo(x+w, y+h-rr);
+    ctx.quadraticCurveTo(x+w, y+h, x+w-rr, y+h);
+    ctx.lineTo(x+rr, y+h);
+    ctx.quadraticCurveTo(x, y+h, x, y+h-rr);
+    ctx.lineTo(x, y+rr);
+    ctx.quadraticCurveTo(x, y, x+rr, y);
+    ctx.closePath();
+  }
+
+  canvas.addEventListener('click', ()=>{
+    // Name editing disabled in tournament view
+  });
+
+  function getNameAt(r,m,slot){
+    const [a,b] = matchPlayers(r,m);
+    return slot===0? a.name : b.name;
+  }
+
+  function setNameAt(r,m,slot,newName){
+    if(r===0){
+      const seed = state.rounds[0][m][slot];
+      state.seedToPlayer[seed].name = newName;
+    }else{
+      alert('Names in this round are auto-filled from previous matches.');
+    }
+  }
+
+  function simulateRoundAI(st, round){
+    const next = st.rounds[round+1];
+    const userSeed = st.userSeed;
+    st.rounds[round].forEach((pair, idx) => {
+      if(pair.includes(userSeed)) return;
+      if(next && next[Math.floor(idx/2)][idx%2]) return;
+      const s1 = pair[0];
+      const s2 = pair[1];
+      const p1 = st.seedToPlayer[s1];
+      const p2 = st.seedToPlayer[s2];
+      let w;
+      if(p1 && p1.name==='BYE') w = s2;
+      else if(p2 && p2.name==='BYE') w = s1;
+      else w = Math.random() < 0.5 ? s1 : s2;
+      if(next) next[Math.floor(idx/2)][idx%2] = w;
+      else { st.championSeed = w; st.complete = true; }
+    });
+  }
+
+  function getUserMatch(st){
+    const r = st.currentRound || 0;
+    const userSeed = st.userSeed;
+    const roundMatches = st.rounds[r] || [];
+    for(let i=0;i<roundMatches.length;i++){
+      const pair = roundMatches[i];
+      const next = st.rounds[r+1] && st.rounds[r+1][Math.floor(i/2)][i%2];
+      if(next) continue;
+      if(pair[0]===userSeed || pair[1]===userSeed){
+        const oppSeed = pair[0]===userSeed? pair[1]:pair[0];
+        const opp = st.seedToPlayer[oppSeed];
+        if(opp && opp.name==='BYE'){
+          if(st.rounds[r+1]) st.rounds[r+1][Math.floor(i/2)][i%2]=userSeed;
+          simulateRoundAI(st, r);
+          if(st.rounds[r].every((p,idx)=> st.rounds[r+1][Math.floor(idx/2)][idx%2])){
+            st.currentRound++;
+          }
+          localStorage.setItem('tournamentState', JSON.stringify(st));
+          layoutAndDraw();
+          return null;
+        }
+        return {round:r, match:i, pair};
+      }
+    }
+    return null;
+  }
+
+  function startNextMatch(){
+    const st = state;
+    const info = getUserMatch(st);
+    if(!info) return;
+    st.pendingMatch = info;
+    const opponentSeed = info.pair[0] === st.userSeed ? info.pair[1] : info.pair[0];
+    localStorage.setItem('tournamentOpponent', JSON.stringify(st.seedToPlayer[opponentSeed]));
+    localStorage.setItem('tournamentState', JSON.stringify(st));
+    window.location.href = '/goal-rush.html' + window.location.search;
+  }
+
+  (function init(){
+    const params = new URLSearchParams(window.location.search);
+    const totalPlayers = parseInt(params.get('players') || '8', 10);
+    const saved = localStorage.getItem('tournamentState');
+    if(saved){
+      state = JSON.parse(saved);
+    } else {
+      const userName = params.get('name') || 'You';
+      const aiPool = [
+        { name: 'USA', flag: '🇺🇸' },
+        { name: 'UK', flag: '🇬🇧' },
+        { name: 'Germany', flag: '🇩🇪' },
+        { name: 'Brazil', flag: '🇧🇷' },
+        { name: 'Japan', flag: '🇯🇵' },
+        { name: 'France', flag: '🇫🇷' },
+        { name: 'Spain', flag: '🇪🇸' },
+        { name: 'Italy', flag: '🇮🇹' },
+        { name: 'Canada', flag: '🇨🇦' },
+        { name: 'India', flag: '🇮🇳' },
+        { name: 'China', flag: '🇨🇳' },
+        { name: 'Mexico', flag: '🇲🇽' },
+        { name: 'Australia', flag: '🇦🇺' },
+        { name: 'Russia', flag: '🇷🇺' },
+        { name: 'Netherlands', flag: '🇳🇱' },
+        { name: 'Sweden', flag: '🇸🇪' },
+        { name: 'Norway', flag: '🇳🇴' },
+        { name: 'Denmark', flag: '🇩🇰' },
+        { name: 'Poland', flag: '🇵🇱' },
+        { name: 'Switzerland', flag: '🇨🇭' },
+        { name: 'Greece', flag: '🇬🇷' },
+        { name: 'Turkey', flag: '🇹🇷' },
+        { name: 'Portugal', flag: '🇵🇹' },
+        { name: 'Belgium', flag: '🇧🇪' }
+      ];
+      const players = [{ name: userName, flag: params.get('flag') || '🏳️' }];
+      players.push(...aiPool.slice(0, totalPlayers - 1));
+      state.players = players;
+      createBracket(players);
+      state.userSeed = 1;
+      state.currentRound = 0;
+      state.championSeed = 0;
+      state.complete = false;
+      localStorage.setItem('tournamentState', JSON.stringify(state));
+    }
+    layoutAndDraw();
+    window.addEventListener('resize', ()=> layoutAndDraw());
+
+    const btn = document.getElementById('continueBtn');
+    if(state.complete){
+      const champ = state.seedToPlayer[state.championSeed] || {};
+      const info = document.createElement('div');
+      info.style.textAlign = 'center';
+      info.textContent = `Winner: ${champ.flag? champ.flag+' ' : ''}${champ.name || ''}`;
+      document.body.appendChild(info);
+      btn.textContent = 'Close';
+      btn.addEventListener('click', ()=>{
+        localStorage.removeItem('tournamentState');
+        localStorage.removeItem('tournamentOpponent');
+        window.location.href = '/games/pollroyale/lobby';
+      });
+    }else{
+      btn.addEventListener('click', startNextMatch);
+    }
+  })();
+})();
+</script>
+</body>
+</html>

--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -119,6 +119,11 @@
   puckImg.onerror = () => { puckImgLoaded = false; };
 
   const params = new URLSearchParams(location.search);
+  const playType = params.get('type') || 'regular';
+  window.tournamentMode = playType === 'tournament';
+  window.tournamentPlayers = window.tournamentMode
+    ? parseInt(params.get('players') || '0', 10)
+    : 0;
   const stake = Number(params.get('amount')) || 0;
   let myAccountId = params.get('accountId');
   if (!myAccountId) {
@@ -198,6 +203,13 @@
   if(oppParam){
     if(oppParam.startsWith('http') || oppParam.startsWith('/')){ p2AvatarImg = new Image(); p2AvatarImg.src = oppParam; p2AvatarEmoji=null; }
     else { p2AvatarEmoji = oppParam; }
+  }
+  if(window.tournamentMode){
+    try{
+      const opp = JSON.parse(localStorage.getItem('tournamentOpponent') || '{}');
+      if(opp.flag) p2AvatarEmoji = opp.flag;
+      if(opp.name) p2Name = opp.name;
+    }catch{}
   }
 
   if(mode==='ai'){
@@ -927,6 +939,10 @@
         recordWin(tgId, myAccountId);
       }
       if(stake>0) awardDevShare(pot);
+      if(window.tournamentMode && typeof window.handleTournamentResult === 'function'){
+        window.handleTournamentResult(1);
+        return;
+      }
       celebrate(p1Name, p1AvatarImg, p1AvatarEmoji);
     }
     if (score.p2>=score.target){
@@ -938,6 +954,10 @@
         recordWin(oppTgId, oppAccountId);
       }
       if(stake>0) awardDevShare(pot);
+      if(window.tournamentMode && typeof window.handleTournamentResult === 'function'){
+        window.handleTournamentResult(2);
+        return;
+      }
       celebrate(p2Name, p2AvatarImg, p2AvatarEmoji);
     }
   }
@@ -1022,6 +1042,75 @@
 
   function checkOrientation(){ landscapeBlock.style.display = (window.matchMedia('(orientation: landscape)').matches ? 'flex' : 'none'); }
   window.addEventListener('orientationchange', checkOrientation);
+
+  if (params.get('type') === 'tournament') {
+    window.handleTournamentResult = function (winner) {
+      try {
+        var st = JSON.parse(localStorage.getItem('tournamentState') || '{}');
+        if (!st.pendingMatch) {
+          window.location.href = '/goal-rush-bracket.html?' + window.location.search.slice(1);
+          return;
+        }
+        var r = st.pendingMatch.round;
+        var m = st.pendingMatch.match;
+        var oppSeed = st.pendingMatch.pair[0] === st.userSeed ? st.pendingMatch.pair[1] : st.pendingMatch.pair[0];
+        var winnerSeed = winner === 1 ? st.userSeed : oppSeed;
+        var next = st.rounds[r + 1];
+        if (next) {
+          next[Math.floor(m / 2)][m % 2] = winnerSeed;
+        } else {
+          st.championSeed = winnerSeed;
+          st.complete = true;
+        }
+        if (winnerSeed !== st.userSeed) {
+          simulateRemaining(st, r);
+        } else {
+          simulateRoundAI(st, r);
+          if (next && st.rounds[r].every(function (p, idx) { return next[Math.floor(idx / 2)][idx % 2]; })) {
+            st.currentRound++;
+          }
+        }
+        delete st.pendingMatch;
+        localStorage.setItem('tournamentState', JSON.stringify(st));
+        localStorage.removeItem('tournamentOpponent');
+      } catch (err) {
+        console.error(err);
+      }
+      window.location.href = '/goal-rush-bracket.html?' + window.location.search.slice(1);
+    };
+
+    function simulateRoundAI(st, round) {
+      var next = st.rounds[round + 1];
+      var userSeed = st.userSeed;
+      st.rounds[round].forEach(function (pair, idx) {
+        if (pair.includes(userSeed)) return;
+        if (next && next[Math.floor(idx / 2)][idx % 2]) return;
+        var s1 = pair[0];
+        var s2 = pair[1];
+        var p1 = st.seedToPlayer[s1];
+        var p2 = st.seedToPlayer[s2];
+        var w;
+        if (p1 && p1.name === 'BYE') w = s2;
+        else if (p2 && p2.name === 'BYE') w = s1;
+        else w = Math.random() < 0.5 ? s1 : s2;
+        if (next) {
+          next[Math.floor(idx / 2)][idx % 2] = w;
+        } else {
+          st.championSeed = w;
+          st.complete = true;
+        }
+      });
+    }
+
+    function simulateRemaining(st, startRound) {
+      for (var r = startRound; r < st.rounds.length; r++) {
+        simulateRoundAI(st, r);
+        if (st.complete) break;
+      }
+      st.currentRound = st.rounds.length - 1;
+      st.complete = true;
+    }
+  }
 
   fit(); checkOrientation(); resetPositions(); updateScore(); playWhistle();
   document.body.classList.add('loaded');

--- a/webapp/src/pages/Games/FreeKickLobby.jsx
+++ b/webapp/src/pages/Games/FreeKickLobby.jsx
@@ -1,9 +1,15 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import RoomSelector from '../../components/RoomSelector.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
-import { ensureAccountId, getTelegramId } from '../../utils/telegram.js';
+import {
+  ensureAccountId,
+  getTelegramId,
+  getTelegramPhotoUrl,
+  getTelegramFirstName
+} from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
 
 export default function FreeKickLobby() {
   const navigate = useNavigate();
@@ -12,60 +18,110 @@ export default function FreeKickLobby() {
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState('ai');
   const [players, setPlayers] = useState(2);
+  const [tPlayers, setTPlayers] = useState(8);
   const [duration, setDuration] = useState(60);
+  const [avatar, setAvatar] = useState('');
+  const [playType, setPlayType] = useState('regular');
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
 
   const startGame = async () => {
     let tgId;
     let accountId;
-    try {
-      accountId = await ensureAccountId();
-      const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
-        alert('Insufficient balance');
-        return;
-      }
-      tgId = getTelegramId();
-      await addTransaction(tgId, -stake.amount, 'stake', {
-        game: 'freekick',
-        players: mode === 'ai' ? 1 : players,
-        accountId,
-      });
-    } catch {}
+    if (playType !== 'training') {
+      try {
+        accountId = await ensureAccountId();
+        const balRes = await getAccountBalance(accountId);
+        if ((balRes.balance || 0) < stake.amount) {
+          alert('Insufficient balance');
+          return;
+        }
+        tgId = getTelegramId();
+        await addTransaction(tgId, -stake.amount, 'stake', {
+          game: 'freekick',
+          players:
+            playType === 'tournament' ? tPlayers : mode === 'ai' ? 1 : players,
+          accountId,
+        });
+      } catch {}
+    } else {
+      try {
+        tgId = getTelegramId();
+        accountId = await ensureAccountId();
+      } catch {}
+    }
 
     const params = new URLSearchParams();
-    params.set('mode', mode);
-    if (mode === 'online') {
-      params.set('players', players);
+    params.set('type', playType);
+    if (playType !== 'training') params.set('mode', mode);
+    if (playType === 'tournament') params.set('players', tPlayers);
+    else if (mode === 'online') params.set('players', players);
+    if (playType !== 'training') {
+      if (stake.token) params.set('token', stake.token);
+      if (stake.amount) params.set('amount', stake.amount);
     }
-    if (stake.token) params.set('token', stake.token);
-    if (stake.amount) params.set('amount', stake.amount);
     if (duration) params.set('duration', duration);
+    if (avatar) params.set('avatar', avatar);
     if (tgId) params.set('tgId', tgId);
     if (accountId) params.set('accountId', accountId);
-    navigate(`/games/freekick?${params.toString()}`);
+    const name = getTelegramFirstName();
+    if (name) params.set('name', name);
+    if (playType === 'tournament') {
+      window.location.href = `/free-kick-bracket.html?${params.toString()}`;
+    } else {
+      navigate(`/games/freekick?${params.toString()}`);
+    }
   };
 
   return (
     <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
       <h2 className="text-xl font-bold text-center">Free Kick Lobby</h2>
       <div className="space-y-2">
-        <h3 className="font-semibold">Mode</h3>
+        <h3 className="font-semibold">Type</h3>
         <div className="flex gap-2">
           {[
-            { id: 'ai', label: 'Vs AI' },
-            { id: 'online', label: 'Online' }
+            { id: 'regular', label: 'Regular' },
+            { id: 'training', label: 'Training' },
+            { id: 'tournament', label: 'Tournament' }
           ].map(({ id, label }) => (
             <button
               key={id}
-              onClick={() => setMode(id)}
-              className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
+              onClick={() => setPlayType(id)}
+              className={`lobby-tile ${playType === id ? 'lobby-selected' : ''}`}
             >
               {label}
             </button>
           ))}
         </div>
       </div>
-      {mode === 'online' && (
+      {playType !== 'training' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Mode</h3>
+          <div className="flex gap-2">
+            {[
+              { id: 'ai', label: 'Vs AI' },
+              { id: 'online', label: 'Online', disabled: playType === 'tournament' }
+            ].map(({ id, label, disabled }) => (
+              <button
+                key={id}
+                onClick={() => !disabled && setMode(id)}
+                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                  disabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+                disabled={disabled}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+      {playType !== 'tournament' && mode === 'online' && (
         <div className="space-y-2">
           <h3 className="font-semibold">Players</h3>
           <div className="flex gap-2">
@@ -79,6 +135,23 @@ export default function FreeKickLobby() {
               </button>
             ))}
           </div>
+        </div>
+      )}
+      {playType === 'tournament' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Players</h3>
+          <div className="flex gap-2">
+            {[8, 16, 24].map((n) => (
+              <button
+                key={n}
+                onClick={() => setTPlayers(n)}
+                className={`lobby-tile ${tPlayers === n ? 'lobby-selected' : ''}`}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs">Winner takes pot minus 10% developer fee.</p>
         </div>
       )}
       <div className="space-y-2">
@@ -95,10 +168,12 @@ export default function FreeKickLobby() {
           ))}
         </div>
       </div>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Stake</h3>
-        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
-      </div>
+      {playType !== 'training' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Stake</h3>
+          <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+        </div>
+      )}
       <button
         onClick={startGame}
         className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"

--- a/webapp/src/pages/Games/GoalRushLobby.jsx
+++ b/webapp/src/pages/Games/GoalRushLobby.jsx
@@ -1,19 +1,27 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import RoomSelector from '../../components/RoomSelector.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
-import { ensureAccountId, getTelegramId, getTelegramPhotoUrl, getTelegramFirstName } from '../../utils/telegram.js';
+import {
+  ensureAccountId,
+  getTelegramId,
+  getTelegramPhotoUrl,
+  getTelegramFirstName
+} from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 
 export default function GoalRushLobby() {
   const navigate = useNavigate();
+  const { search } = useLocation();
   useTelegramBackButton();
 
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState('ai');
   const [goal, setGoal] = useState(3);
   const [avatar, setAvatar] = useState('');
+  const [playType, setPlayType] = useState('regular');
+  const [players, setPlayers] = useState(8);
 
   useEffect(() => {
     try {
@@ -25,27 +33,38 @@ export default function GoalRushLobby() {
   const startGame = async () => {
     let tgId;
     let accountId;
-    try {
-      accountId = await ensureAccountId();
-      const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
-        alert('Insufficient balance');
-        return;
-      }
-      tgId = getTelegramId();
-      await addTransaction(tgId, -stake.amount, 'stake', {
-        game: 'goalrush',
-        players: 2,
-        accountId,
-      });
-    } catch {}
+    if (playType !== 'training') {
+      try {
+        accountId = await ensureAccountId();
+        const balRes = await getAccountBalance(accountId);
+        if ((balRes.balance || 0) < stake.amount) {
+          alert('Insufficient balance');
+          return;
+        }
+        tgId = getTelegramId();
+        await addTransaction(tgId, -stake.amount, 'stake', {
+          game: 'goalrush',
+          players: playType === 'tournament' ? players : 2,
+          accountId,
+        });
+      } catch {}
+    } else {
+      try {
+        tgId = getTelegramId();
+        accountId = await ensureAccountId();
+      } catch {}
+    }
 
     const params = new URLSearchParams();
-    params.set('mode', mode);
     params.set('target', goal);
+    params.set('type', playType);
+    if (playType !== 'training') params.set('mode', mode);
+    if (playType === 'tournament') params.set('players', players);
     const initData = window.Telegram?.WebApp?.initData;
-    if (stake.token) params.set('token', stake.token);
-    if (stake.amount) params.set('amount', stake.amount);
+    if (playType !== 'training') {
+      if (stake.token) params.set('token', stake.token);
+      if (stake.amount) params.set('amount', stake.amount);
+    }
     if (avatar) params.set('avatar', avatar);
     if (tgId) params.set('tgId', tgId);
     if (accountId) params.set('accountId', accountId);
@@ -58,42 +77,66 @@ export default function GoalRushLobby() {
     if (devAcc1) params.set('dev1', devAcc1);
     if (devAcc2) params.set('dev2', devAcc2);
     if (initData) params.set('init', encodeURIComponent(initData));
-    navigate(`/games/goalrush?${params.toString()}`);
+    if (playType === 'tournament') {
+      window.location.href = `/goal-rush-bracket.html?${params.toString()}`;
+    } else {
+      navigate(`/games/goalrush?${params.toString()}`);
+    }
   };
 
   return (
     <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
       <h2 className="text-xl font-bold text-center">Goal Rush Lobby</h2>
       <div className="space-y-2">
-        <h3 className="font-semibold">Mode</h3>
+        <h3 className="font-semibold">Type</h3>
         <div className="flex gap-2">
           {[
-            { id: 'ai', label: 'Vs AI' },
-            { id: 'online', label: '1v1 Online', disabled: true }
-          ].map(({ id, label, disabled }) => (
-            <div key={id} className="relative">
-              <button
-                onClick={() => !disabled && setMode(id)}
-                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
-                  disabled ? 'opacity-50 cursor-not-allowed' : ''
-                }`}
-                disabled={disabled}
-              >
-                {label}
-              </button>
-              {disabled && (
-                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
-                  Under development
-                </span>
-              )}
-            </div>
+            { id: 'regular', label: 'Regular' },
+            { id: 'training', label: 'Training' },
+            { id: 'tournament', label: 'Tournament' }
+          ].map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setPlayType(id)}
+              className={`lobby-tile ${playType === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
           ))}
         </div>
       </div>
+      {playType !== 'training' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Mode</h3>
+          <div className="flex gap-2">
+            {[
+              { id: 'ai', label: 'Vs AI' },
+              { id: 'online', label: '1v1 Online', disabled: true }
+            ].map(({ id, label, disabled }) => (
+              <div key={id} className="relative">
+                <button
+                  onClick={() => !disabled && setMode(id)}
+                  className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                    disabled ? 'opacity-50 cursor-not-allowed' : ''
+                  }`}
+                  disabled={disabled}
+                >
+                  {label}
+                </button>
+                {disabled && (
+                  <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                    Under development
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
       <div className="space-y-2">
         <h3 className="font-semibold">Goals</h3>
         <div className="flex gap-2">
-          {[3, 5, 10].map(g => (
+          {[3, 5, 10].map((g) => (
             <button
               key={g}
               onClick={() => setGoal(g)}
@@ -104,10 +147,29 @@ export default function GoalRushLobby() {
           ))}
         </div>
       </div>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Stake</h3>
-        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
-      </div>
+      {playType === 'tournament' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Players</h3>
+          <div className="flex gap-2">
+            {[8, 16, 24].map((p) => (
+              <button
+                key={p}
+                onClick={() => setPlayers(p)}
+                className={`lobby-tile ${players === p ? 'lobby-selected' : ''}`}
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs">Winner takes pot minus 10% developer fee.</p>
+        </div>
+      )}
+      {playType !== 'training' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Stake</h3>
+          <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+        </div>
+      )}
       <button
         onClick={startGame}
         className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"


### PR DESCRIPTION
## Summary
- Add tournament option with 8/16/24 players in Goal Rush lobby
- Enable tournaments in Free Kick with selectable brackets
- Support tournament flows in Goal Rush and Free Kick games

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b69f427434832997a10575c638eb26