### PR TITLE
Isolate tournament state and add per-game payout APIs

### DIFF
--- a/webapp/public/free-kick-api.js
+++ b/webapp/public/free-kick-api.js
@@ -1,0 +1,53 @@
+(function(){
+  const API_BASE_URL = window.API_BASE_URL || '';
+  async function post(path, body){
+    const headers = { 'Content-Type': 'application/json' };
+    const initData = window?.Telegram?.WebApp?.initData;
+    if (initData) headers['X-Telegram-Init-Data'] = initData;
+    let res;
+    try {
+      res = await fetch(API_BASE_URL + path, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body)
+      });
+    } catch (err) {
+      return { error: 'Network request failed' };
+    }
+    let text;
+    try {
+      text = await res.text();
+    } catch {
+      return { error: 'Invalid server response' };
+    }
+    let data;
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      return { error: 'Invalid server response' };
+    }
+    if (!res.ok) {
+      return { error: data.error || res.statusText || 'Request failed' };
+    }
+    return data;
+  }
+  window.fkApi = {
+    async depositAccount(accountId, amount, extra = {}) {
+      const res = await post('/api/account/deposit', { accountId, amount, ...extra });
+      if (res && res.error) {
+        return post('/api/profile/addTransaction', {
+          amount,
+          type: 'deposit',
+          accountId,
+          ...extra,
+        });
+      }
+      return res;
+    },
+    addTransaction(telegramId, amount, type, extra = {}) {
+      const body = { amount, type, ...extra };
+      if (telegramId != null) body.telegramId = telegramId;
+      return post('/api/profile/addTransaction', body);
+    }
+  };
+})();

--- a/webapp/public/free-kick-bracket.html
+++ b/webapp/public/free-kick-bracket.html
@@ -57,6 +57,10 @@
   const DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
   const canvas = document.getElementById('board');
   const ctx = canvas.getContext('2d');
+  const params = new URLSearchParams(window.location.search);
+  const tgKey = params.get("tgId") || "anon";
+  const STATE_KEY = `freeKickTournamentState_${tgKey}`;
+  const OPP_KEY = `freeKickTournamentOpponent_${tgKey}`;
   const theme = {
     bg:'#0b1020',
     panel:'#11172a',
@@ -398,7 +402,7 @@
           if(st.rounds[r].every((p,idx)=> st.rounds[r+1][Math.floor(idx/2)][idx%2])){
             st.currentRound++;
           }
-          localStorage.setItem('tournamentState', JSON.stringify(st));
+          localStorage.setItem(STATE_KEY, JSON.stringify(st));
           layoutAndDraw();
           return null;
         }
@@ -414,15 +418,14 @@
     if(!info) return;
     st.pendingMatch = info;
     const opponentSeed = info.pair[0] === st.userSeed ? info.pair[1] : info.pair[0];
-    localStorage.setItem('tournamentOpponent', JSON.stringify(st.seedToPlayer[opponentSeed]));
-    localStorage.setItem('tournamentState', JSON.stringify(st));
+    localStorage.setItem(OPP_KEY, JSON.stringify(st.seedToPlayer[opponentSeed]));
+    localStorage.setItem(STATE_KEY, JSON.stringify(st));
     window.location.href = '/free-kick.html' + window.location.search;
   }
 
   (function init(){
-    const params = new URLSearchParams(window.location.search);
     const totalPlayers = parseInt(params.get('players') || '8', 10);
-    const saved = localStorage.getItem('tournamentState');
+    const saved = localStorage.getItem(STATE_KEY);
     if(saved){
       state = JSON.parse(saved);
     } else {
@@ -461,7 +464,7 @@
       state.currentRound = 0;
       state.championSeed = 0;
       state.complete = false;
-      localStorage.setItem('tournamentState', JSON.stringify(state));
+      localStorage.setItem(STATE_KEY, JSON.stringify(state));
     }
     layoutAndDraw();
     window.addEventListener('resize', ()=> layoutAndDraw());
@@ -475,8 +478,8 @@
       document.body.appendChild(info);
       btn.textContent = 'Close';
       btn.addEventListener('click', ()=>{
-        localStorage.removeItem('tournamentState');
-        localStorage.removeItem('tournamentOpponent');
+        localStorage.removeItem(STATE_KEY);
+        localStorage.removeItem(OPP_KEY);
         window.location.href = '/games/pollroyale/lobby';
       });
     }else{

--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -130,6 +130,7 @@
     </div>
   </div>
 
+<script src="/free-kick-api.js"></script>
 <script>
 (()=> {
   // ===== Canvas =====
@@ -168,6 +169,15 @@
   }
 
   const params = new URLSearchParams(location.search);
+  const tgKey = params.get("tgId") || "anon";
+  const STATE_KEY = `freeKickTournamentState_${tgKey}`;
+  const OPP_KEY = `freeKickTournamentOpponent_${tgKey}`;
+  const stake = Number(params.get("amount") || "0");
+  const accountId = params.get("accountId");
+  const tgId = params.get("tgId");
+  const devAccount = params.get("dev");
+  const devAccount1 = params.get("dev1");
+  const devAccount2 = params.get("dev2");
   const playType = params.get('type') || 'regular';
   window.tournamentMode = playType === 'tournament';
   window.tournamentPlayers = window.tournamentMode
@@ -208,7 +218,7 @@
   const flags = ['🇨🇦','🇫🇷','🇩🇪','🇪🇸','🇧🇷','🇯🇵','🇺🇸','🇬🇧'];
   if(window.tournamentMode){
     try{
-      const opp = JSON.parse(localStorage.getItem('tournamentOpponent') || '{}');
+      const opp = JSON.parse(localStorage.getItem(OPP_KEY) || '{}');
       if(pvAvatars[0] && opp.flag) pvAvatars[0].src = emojiToDataUri(opp.flag);
       if(pvNames[0]) pvNames[0].textContent = opp.name || flagName(opp.flag);
     }catch{}
@@ -1852,9 +1862,9 @@ function drawStaticOnce(){ drawField(); drawAds(); drawGoal(); resetBall(); draw
   }
 
   if (params.get('type') === 'tournament') {
-    window.handleTournamentResult = function (winner) {
+    window.handleTournamentResult = async function (winner) {
       try {
-        var st = JSON.parse(localStorage.getItem('tournamentState') || '{}');
+        var st = JSON.parse(localStorage.getItem(STATE_KEY) || '{}');
         if (!st.pendingMatch) {
           window.location.href = '/free-kick-bracket.html?' + window.location.search.slice(1);
           return;
@@ -1878,9 +1888,26 @@ function drawStaticOnce(){ drawField(); drawAds(); drawGoal(); resetBall(); draw
             st.currentRound++;
           }
         }
+        if (st.complete && winnerSeed === st.userSeed && stake > 0 && accountId) {
+        const total = stake * window.tournamentPlayers;
+        const prize = Math.round(total * 0.91);
+        try {
+          await fkApi.depositAccount(accountId, prize, { game: 'freekick-win' });
+          if (tgId) await fkApi.addTransaction(tgId, 0, 'win', { game: 'freekick', players: window.tournamentPlayers, accountId });
+          const ops = [];
+          if (devAccount1 || devAccount2) {
+            if (devAccount) ops.push(fkApi.depositAccount(devAccount, Math.round(total*0.09), { game: 'freekick-dev' }));
+            if (devAccount1) ops.push(fkApi.depositAccount(devAccount1, Math.round(total*0.01), { game: 'freekick-dev1' }));
+            if (devAccount2) ops.push(fkApi.depositAccount(devAccount2, Math.round(total*0.02), { game: 'freekick-dev2' }));
+          } else if (devAccount) {
+            ops.push(fkApi.depositAccount(devAccount, Math.round(total*0.1), { game: 'freekick-dev' }));
+          }
+          if (ops.length) await Promise.all(ops);
+        } catch {}
+        }
         delete st.pendingMatch;
-        localStorage.setItem('tournamentState', JSON.stringify(st));
-        localStorage.removeItem('tournamentOpponent');
+        localStorage.setItem(STATE_KEY, JSON.stringify(st));
+        localStorage.removeItem(OPP_KEY);
       } catch (err) {
         console.error(err);
       }

--- a/webapp/public/goal-rush-api.js
+++ b/webapp/public/goal-rush-api.js
@@ -1,0 +1,53 @@
+(function(){
+  const API_BASE_URL = window.API_BASE_URL || '';
+  async function post(path, body){
+    const headers = { 'Content-Type': 'application/json' };
+    const initData = window?.Telegram?.WebApp?.initData;
+    if (initData) headers['X-Telegram-Init-Data'] = initData;
+    let res;
+    try {
+      res = await fetch(API_BASE_URL + path, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body)
+      });
+    } catch (err) {
+      return { error: 'Network request failed' };
+    }
+    let text;
+    try {
+      text = await res.text();
+    } catch {
+      return { error: 'Invalid server response' };
+    }
+    let data;
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      return { error: 'Invalid server response' };
+    }
+    if (!res.ok) {
+      return { error: data.error || res.statusText || 'Request failed' };
+    }
+    return data;
+  }
+  window.grApi = {
+    async depositAccount(accountId, amount, extra = {}) {
+      const res = await post('/api/account/deposit', { accountId, amount, ...extra });
+      if (res && res.error) {
+        return post('/api/profile/addTransaction', {
+          amount,
+          type: 'deposit',
+          accountId,
+          ...extra,
+        });
+      }
+      return res;
+    },
+    addTransaction(telegramId, amount, type, extra = {}) {
+      const body = { amount, type, ...extra };
+      if (telegramId != null) body.telegramId = telegramId;
+      return post('/api/profile/addTransaction', body);
+    }
+  };
+})();

--- a/webapp/public/goal-rush-bracket.html
+++ b/webapp/public/goal-rush-bracket.html
@@ -57,6 +57,10 @@
   const DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
   const canvas = document.getElementById('board');
   const ctx = canvas.getContext('2d');
+  const params = new URLSearchParams(window.location.search);
+  const tgKey = params.get("tgId") || "anon";
+  const STATE_KEY = `goalRushTournamentState_${tgKey}`;
+  const OPP_KEY = `goalRushTournamentOpponent_${tgKey}`;
   const theme = {
     bg:'#0b1020',
     panel:'#11172a',
@@ -398,7 +402,7 @@
           if(st.rounds[r].every((p,idx)=> st.rounds[r+1][Math.floor(idx/2)][idx%2])){
             st.currentRound++;
           }
-          localStorage.setItem('tournamentState', JSON.stringify(st));
+          localStorage.setItem(STATE_KEY, JSON.stringify(st));
           layoutAndDraw();
           return null;
         }
@@ -414,15 +418,14 @@
     if(!info) return;
     st.pendingMatch = info;
     const opponentSeed = info.pair[0] === st.userSeed ? info.pair[1] : info.pair[0];
-    localStorage.setItem('tournamentOpponent', JSON.stringify(st.seedToPlayer[opponentSeed]));
-    localStorage.setItem('tournamentState', JSON.stringify(st));
+    localStorage.setItem(OPP_KEY, JSON.stringify(st.seedToPlayer[opponentSeed]));
+    localStorage.setItem(STATE_KEY, JSON.stringify(st));
     window.location.href = '/goal-rush.html' + window.location.search;
   }
 
   (function init(){
-    const params = new URLSearchParams(window.location.search);
     const totalPlayers = parseInt(params.get('players') || '8', 10);
-    const saved = localStorage.getItem('tournamentState');
+    const saved = localStorage.getItem(STATE_KEY);
     if(saved){
       state = JSON.parse(saved);
     } else {
@@ -461,7 +464,7 @@
       state.currentRound = 0;
       state.championSeed = 0;
       state.complete = false;
-      localStorage.setItem('tournamentState', JSON.stringify(state));
+      localStorage.setItem(STATE_KEY, JSON.stringify(state));
     }
     layoutAndDraw();
     window.addEventListener('resize', ()=> layoutAndDraw());
@@ -475,8 +478,8 @@
       document.body.appendChild(info);
       btn.textContent = 'Close';
       btn.addEventListener('click', ()=>{
-        localStorage.removeItem('tournamentState');
-        localStorage.removeItem('tournamentOpponent');
+        localStorage.removeItem(STATE_KEY);
+        localStorage.removeItem(OPP_KEY);
         window.location.href = '/games/pollroyale/lobby';
       });
     }else{

--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -93,7 +93,7 @@
   <div class="landscape-block" style="display:none">Please hold your phone in <b>portrait</b> for the best experience.</div>
 
 
-<script src="/falling-ball-api.js"></script>
+<script src="/goal-rush-api.js"></script>
 <script>
 (async () => {
   const canvas = document.getElementById('game');
@@ -119,6 +119,9 @@
   puckImg.onerror = () => { puckImgLoaded = false; };
 
   const params = new URLSearchParams(location.search);
+  const tgKey = params.get("tgId") || "anon";
+  const TOURN_STATE_KEY = `goalRushTournamentState_${tgKey}`;
+  const TOURN_OPP_KEY = `goalRushTournamentOpponent_${tgKey}`;
   const playType = params.get('type') || 'regular';
   window.tournamentMode = playType === 'tournament';
   window.tournamentPlayers = window.tournamentMode
@@ -206,7 +209,7 @@
   }
   if(window.tournamentMode){
     try{
-      const opp = JSON.parse(localStorage.getItem('tournamentOpponent') || '{}');
+      const opp = JSON.parse(localStorage.getItem(TOURN_OPP_KEY) || '{}');
       if(opp.flag) p2AvatarEmoji = opp.flag;
       if(opp.name) p2Name = opp.name;
     }catch{}
@@ -223,23 +226,23 @@
 
   async function awardTpc(accountId, amount){
     try{
-      await fbApi.depositAccount(accountId, amount, { game: 'goalrush-win' });
+      await grApi.depositAccount(accountId, amount, { game: 'goalrush-win' });
     }catch(err){ console.warn('Failed to award TPC',err); }
   }
   async function recordWin(tgId, accountId){
     if(!tgId) return;
     try{
-      await fbApi.addTransaction(tgId, 0, 'win', { game:'goalrush', players:2, accountId });
+      await grApi.addTransaction(tgId, 0, 'win', { game:'goalrush', players:2, accountId });
     }catch{}
   }
   async function awardDevShare(total){
     const ops=[];
     if(devAccount1||devAccount2){
-      if(devAccount) ops.push(fbApi.depositAccount(devAccount, Math.round(total*0.09), {game:'goalrush-dev'}));
-      if(devAccount1) ops.push(fbApi.depositAccount(devAccount1, Math.round(total*0.01), {game:'goalrush-dev1'}));
-      if(devAccount2) ops.push(fbApi.depositAccount(devAccount2, Math.round(total*0.02), {game:'goalrush-dev2'}));
+      if(devAccount) ops.push(grApi.depositAccount(devAccount, Math.round(total*0.09), {game:'goalrush-dev'}));
+      if(devAccount1) ops.push(grApi.depositAccount(devAccount1, Math.round(total*0.01), {game:'goalrush-dev1'}));
+      if(devAccount2) ops.push(grApi.depositAccount(devAccount2, Math.round(total*0.02), {game:'goalrush-dev2'}));
     }else if(devAccount){
-      ops.push(fbApi.depositAccount(devAccount, Math.round(total*0.1), {game:'goalrush-dev'}));
+      ops.push(grApi.depositAccount(devAccount, Math.round(total*0.1), {game:'goalrush-dev'}));
     }
     if(ops.length){ try{ await Promise.all(ops); }catch{} }
   }
@@ -263,7 +266,7 @@
   async function chargeStake(){
     if(!tgId || stake<=0) return;
     try{
-      await fbApi.addTransaction(tgId, -stake, 'stake', { game:'goalrush', players:2, accountId: myAccountId });
+      await grApi.addTransaction(tgId, -stake, 'stake', { game:'goalrush', players:2, accountId: myAccountId });
     }catch{}
   }
 
@@ -933,12 +936,15 @@
     if (score.p1>=score.target){
       running=false;
       const pot = stake*2;
-      if (stake>0 && myAccountId){
-        const prize = Math.round(pot*0.91);
-        awardTpc(myAccountId, prize);
-        recordWin(tgId, myAccountId);
+      if(!window.tournamentMode){
+        if (stake>0 && myAccountId){
+          const prize = Math.round(pot*0.91);
+          awardTpc(myAccountId, prize);
+          recordWin(tgId, myAccountId);
+        }
+        if(stake>0) awardDevShare(pot);
       }
-      if(stake>0) awardDevShare(pot);
+
       if(window.tournamentMode && typeof window.handleTournamentResult === 'function'){
         window.handleTournamentResult(1);
         return;
@@ -948,12 +954,15 @@
     if (score.p2>=score.target){
       running=false;
       const pot = stake*2;
-      if(stake>0 && oppAccountId){
-        const prize = Math.round(pot*0.91);
-        awardTpc(oppAccountId, prize);
-        recordWin(oppTgId, oppAccountId);
+      if(!window.tournamentMode){
+        if(stake>0 && oppAccountId){
+          const prize = Math.round(pot*0.91);
+          awardTpc(oppAccountId, prize);
+          recordWin(oppTgId, oppAccountId);
+        }
+        if(stake>0) awardDevShare(pot);
       }
-      if(stake>0) awardDevShare(pot);
+
       if(window.tournamentMode && typeof window.handleTournamentResult === 'function'){
         window.handleTournamentResult(2);
         return;
@@ -1044,9 +1053,9 @@
   window.addEventListener('orientationchange', checkOrientation);
 
   if (params.get('type') === 'tournament') {
-    window.handleTournamentResult = function (winner) {
+    window.handleTournamentResult = async function (winner) {
       try {
-        var st = JSON.parse(localStorage.getItem('tournamentState') || '{}');
+        var st = JSON.parse(localStorage.getItem(TOURN_STATE_KEY) || '{}');
         if (!st.pendingMatch) {
           window.location.href = '/goal-rush-bracket.html?' + window.location.search.slice(1);
           return;
@@ -1070,9 +1079,18 @@
             st.currentRound++;
           }
         }
+        if (st.complete && winnerSeed === st.userSeed && stake > 0 && myAccountId) {
+          const total = stake * window.tournamentPlayers;
+          const prize = Math.round(total * 0.91);
+          try {
+            await awardTpc(myAccountId, prize);
+            if (tgId) await recordWin(tgId, myAccountId);
+            await awardDevShare(total);
+          } catch {}
+        }
         delete st.pendingMatch;
-        localStorage.setItem('tournamentState', JSON.stringify(st));
-        localStorage.removeItem('tournamentOpponent');
+        localStorage.setItem(TOURN_STATE_KEY, JSON.stringify(st));
+        localStorage.removeItem(TOURN_OPP_KEY);
       } catch (err) {
         console.error(err);
       }

--- a/webapp/public/poll-royale-api.js
+++ b/webapp/public/poll-royale-api.js
@@ -1,0 +1,53 @@
+(function(){
+  const API_BASE_URL = window.API_BASE_URL || '';
+  async function post(path, body){
+    const headers = { 'Content-Type': 'application/json' };
+    const initData = window?.Telegram?.WebApp?.initData;
+    if (initData) headers['X-Telegram-Init-Data'] = initData;
+    let res;
+    try {
+      res = await fetch(API_BASE_URL + path, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body)
+      });
+    } catch (err) {
+      return { error: 'Network request failed' };
+    }
+    let text;
+    try {
+      text = await res.text();
+    } catch {
+      return { error: 'Invalid server response' };
+    }
+    let data;
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      return { error: 'Invalid server response' };
+    }
+    if (!res.ok) {
+      return { error: data.error || res.statusText || 'Request failed' };
+    }
+    return data;
+  }
+  window.prApi = {
+    async depositAccount(accountId, amount, extra = {}) {
+      const res = await post('/api/account/deposit', { accountId, amount, ...extra });
+      if (res && res.error) {
+        return post('/api/profile/addTransaction', {
+          amount,
+          type: 'deposit',
+          accountId,
+          ...extra,
+        });
+      }
+      return res;
+    },
+    addTransaction(telegramId, amount, type, extra = {}) {
+      const body = { amount, type, ...extra };
+      if (telegramId != null) body.telegramId = telegramId;
+      return post('/api/profile/addTransaction', body);
+    }
+  };
+})();

--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -57,6 +57,10 @@
   const DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
   const canvas = document.getElementById('board');
   const ctx = canvas.getContext('2d');
+  const params = new URLSearchParams(window.location.search);
+  const tgKey = params.get("tgId") || "anon";
+  const STATE_KEY = `pollRoyaleTournamentState_${tgKey}`;
+  const OPP_KEY = `pollRoyaleTournamentOpponent_${tgKey}`;
   const theme = {
     bg:'#0b1020',
     panel:'#11172a',
@@ -398,7 +402,7 @@
           if(st.rounds[r].every((p,idx)=> st.rounds[r+1][Math.floor(idx/2)][idx%2])){
             st.currentRound++;
           }
-          localStorage.setItem('tournamentState', JSON.stringify(st));
+          localStorage.setItem(STATE_KEY, JSON.stringify(st));
           layoutAndDraw();
           return null;
         }
@@ -414,15 +418,14 @@
     if(!info) return;
     st.pendingMatch = info;
     const opponentSeed = info.pair[0] === st.userSeed ? info.pair[1] : info.pair[0];
-    localStorage.setItem('tournamentOpponent', JSON.stringify(st.seedToPlayer[opponentSeed]));
-    localStorage.setItem('tournamentState', JSON.stringify(st));
+    localStorage.setItem(OPP_KEY, JSON.stringify(st.seedToPlayer[opponentSeed]));
+    localStorage.setItem(STATE_KEY, JSON.stringify(st));
     window.location.href = '/poll-royale.html' + window.location.search;
   }
 
   (function init(){
-    const params = new URLSearchParams(window.location.search);
     const totalPlayers = parseInt(params.get('players') || '8', 10);
-    const saved = localStorage.getItem('tournamentState');
+    const saved = localStorage.getItem(STATE_KEY);
     if(saved){
       state = JSON.parse(saved);
     } else {
@@ -461,7 +464,7 @@
       state.currentRound = 0;
       state.championSeed = 0;
       state.complete = false;
-      localStorage.setItem('tournamentState', JSON.stringify(state));
+      localStorage.setItem(STATE_KEY, JSON.stringify(state));
     }
     layoutAndDraw();
     window.addEventListener('resize', ()=> layoutAndDraw());
@@ -475,8 +478,8 @@
       document.body.appendChild(info);
       btn.textContent = 'Close';
       btn.addEventListener('click', ()=>{
-        localStorage.removeItem('tournamentState');
-        localStorage.removeItem('tournamentOpponent');
+        localStorage.removeItem(STATE_KEY);
+        localStorage.removeItem(OPP_KEY);
         window.location.href = '/games/pollroyale/lobby';
       });
     }else{

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -897,6 +897,7 @@
     </div>
 
     <script src="/flag-emojis.js"></script>
+    <script src="/poll-royale-api.js"></script>
 
     <!--
     Shenim: Perdorim script me type="text/javascript" per te shmangur
@@ -916,6 +917,15 @@
         );
 
         var params = new URLSearchParams(location.search);
+        var tgKey = params.get("tgId") || "anon";
+        var STATE_KEY = `pollRoyaleTournamentState_${tgKey}`;
+        var OPP_KEY = `pollRoyaleTournamentOpponent_${tgKey}`;
+        var stake = parseInt(params.get("amount") || "0", 10);
+        var accountId = params.get("accountId");
+        var tgId = params.get("tgId");
+        var devAccount = params.get("dev");
+        var devAccount1 = params.get("dev1");
+        var devAccount2 = params.get("dev2");
         var variant = params.get('variant') || 'uk';
         var isAmerican = variant === 'american';
         var isNineBall = variant === '9ball';
@@ -1438,7 +1448,7 @@
         }
         if (window.tournamentMode) {
           try {
-            var opp = JSON.parse(localStorage.getItem('tournamentOpponent') || '{}');
+            var opp = JSON.parse(localStorage.getItem(OPP_KEY) || '{}');
             if (opp.flag) avatarCPU.textContent = opp.flag;
             formatPlayerName(opp.name || 'CPU', nameCPU);
           } catch (e) {
@@ -3688,7 +3698,6 @@
         }
       });
 
-      const params = new URLSearchParams(window.location.search);
       if (params.get('type') === 'training') {
         const wrapper = document.getElementById('trainingMenuWrapper');
         const menuBtn = document.getElementById('trainingMenuButton');
@@ -3714,9 +3723,9 @@
       }
 
       if (params.get('type') === 'tournament') {
-        window.handleTournamentResult = function (winner) {
+        window.handleTournamentResult = async function (winner) {
           try {
-            var st = JSON.parse(localStorage.getItem('tournamentState') || '{}');
+            var st = JSON.parse(localStorage.getItem(STATE_KEY) || '{}');
             if (!st.pendingMatch) {
               window.location.href = '/poll-royale-bracket.html?' + window.location.search.slice(1);
               return;
@@ -3740,9 +3749,26 @@
                 st.currentRound++;
               }
             }
+            if (st.complete && winnerSeed === st.userSeed && stake > 0 && accountId) {
+            const total = stake * window.tournamentPlayers;
+            const prize = Math.round(total * 0.91);
+            try {
+              await prApi.depositAccount(accountId, prize, { game: 'pollroyale-win' });
+              if (tgId) await prApi.addTransaction(tgId, 0, 'win', { game: 'pollroyale', players: window.tournamentPlayers, accountId });
+              const ops = [];
+              if (devAccount1 || devAccount2) {
+                if (devAccount) ops.push(prApi.depositAccount(devAccount, Math.round(total*0.09), { game: 'pollroyale-dev' }));
+                if (devAccount1) ops.push(prApi.depositAccount(devAccount1, Math.round(total*0.01), { game: 'pollroyale-dev1' }));
+                if (devAccount2) ops.push(prApi.depositAccount(devAccount2, Math.round(total*0.02), { game: 'pollroyale-dev2' }));
+              } else if (devAccount) {
+                ops.push(prApi.depositAccount(devAccount, Math.round(total*0.1), { game: 'pollroyale-dev' }));
+              }
+              if (ops.length) await Promise.all(ops);
+            } catch {}
+            }
             delete st.pendingMatch;
-            localStorage.setItem('tournamentState', JSON.stringify(st));
-            localStorage.removeItem('tournamentOpponent');
+            localStorage.setItem(STATE_KEY, JSON.stringify(st));
+            localStorage.removeItem(OPP_KEY);
           } catch (err) {
             console.error(err);
           }


### PR DESCRIPTION
## Summary
- Add dedicated API wrappers for Pool Royale, Free Kick, and Goal Rush
- Store tournament progress with per-game, per-user keys
- Pay out tournament winnings only after final win and simulate bracket on loss

## Testing
- `npm test` *(fails: The module '/workspace/TonPlaygramWebApp/bot/node_modules/canvas/build/Release/canvas.node' was compiled against a different Node.js version)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a3387940832994c0163e768a86cd