### PR TITLE
Show pot and boost AI in tournament finals

### DIFF
--- a/webapp/public/free-kick-bracket.html
+++ b/webapp/public/free-kick-bracket.html
@@ -43,6 +43,8 @@
     background:rgba(37,99,235,.15); border:1px solid rgba(37,99,235,.35); color:#cfe0ff;
     font-size:.8rem;
   }
+  .coin-confetti{position:fixed;top:-40px;width:32px;height:32px;pointer-events:none;animation:coin-fall var(--duration,3s) linear forwards}
+  @keyframes coin-fall{from{transform:translateY(-10vh) rotate(0deg);opacity:1}to{transform:translateY(100vh) rotate(360deg);opacity:0}}
 </style>
 </head>
 <body>
@@ -71,6 +73,8 @@
     neonC:'#a855f7',
     line:'#233155'
   };
+  const tpcImg = new Image();
+  tpcImg.src = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 
   let hitRegions = []; // {round, match, slot, x,y,w,h}
 
@@ -219,7 +223,18 @@
     let label = '';
     const rounds = state.rounds.length;
     if(r === 0) label = 'ROUND OF ' + state.bracketN;
-    else if(r === rounds-1) label = 'FINAL 🏆 🪙' + state.pot;
+    else if(r === rounds-1){
+      label = 'FINAL 🏆 ';
+      ctx.fillText(label, x, topPad + 10);
+      let imgX = x + ctx.measureText(label).width + 2;
+      if (tpcImg.complete){
+        ctx.drawImage(tpcImg, imgX, topPad, 12, 12);
+        imgX += 16;
+      }
+      ctx.fillText(String(state.pot), imgX, topPad + 10);
+      ctx.restore();
+      return;
+    }
     else if(r === rounds-2) label = 'SEMIFINAL';
     else label = 'QUARTER / R' + (r+1);
     ctx.fillText(label, x, topPad + 10);
@@ -273,6 +288,23 @@
     const playerA = state.seedToPlayer[sA] || { name: 'TBD' };
     const playerB = state.seedToPlayer[sB] || { name: 'TBD' };
     return [playerA, playerB];
+  }
+
+  function coinConfetti(count=20){
+    const container=document.createElement('div');
+    container.style.position='fixed';container.style.top='0';container.style.left='0';
+    container.style.width='100%';container.style.height='0';container.style.pointerEvents='none';
+    container.style.zIndex='100';container.style.overflow='visible';
+    document.body.appendChild(container);
+    for(let i=0;i<count;i++){
+      const img=document.createElement('img');
+      img.src='/assets/icons/ezgif-54c96d8a9b9236.webp';
+      img.className='coin-confetti';
+      const left=Math.random()*100; const delay=Math.random()*3; const duration=2+Math.random()*2;
+      img.style.left=left+'vw'; img.style.animationDelay=delay+'s'; img.style.setProperty('--duration',duration+'s');
+      container.appendChild(img);
+    }
+    setTimeout(()=>container.remove(),5000);
   }
 
   function renderPlayer(player, x, y, slotH){
@@ -472,17 +504,36 @@
     const btn = document.getElementById('continueBtn');
     if(state.complete){
       const champ = state.seedToPlayer[state.championSeed] || {};
-      const info = document.createElement('div');
-      info.style.textAlign = 'center';
-      info.textContent = `Winner: ${champ.flag? champ.flag+' ' : ''}${champ.name || ''}`;
-      document.body.appendChild(info);
-      btn.textContent = 'Close';
+      coinConfetti(30);
+      const overlay=document.createElement('div');
+      overlay.style.position='fixed';overlay.style.inset='0';overlay.style.display='flex';overlay.style.flexDirection='column';
+      overlay.style.alignItems='center';overlay.style.justifyContent='center';overlay.style.background='rgba(0,0,0,0.6)';
+      const av=document.createElement('div');
+      av.style.width='120px';av.style.height='120px';av.style.borderRadius='50%';av.style.background='#fff';av.style.display='flex';
+      av.style.alignItems='center';av.style.justifyContent='center';av.style.fontSize='64px';
+      av.textContent=champ.flag||'';overlay.appendChild(av);
+      const last=JSON.parse(localStorage.getItem(`freeKickLastResult_${tgKey}`)||'{}');
+      if(last.p1!=null && last.p2!=null){
+        const res=document.createElement('div');res.style.color='#fff';res.style.marginTop='8px';res.textContent=`${last.p1}-${last.p2}`;
+        overlay.appendChild(res);
+      }
+      const prize=document.createElement('div');
+      prize.style.display='flex';prize.style.alignItems='center';prize.style.gap='4px';prize.style.marginTop='8px';
+      const icon=document.createElement('img');icon.src='/assets/icons/ezgif-54c96d8a9b9236.webp';icon.style.width='24px';icon.style.height='24px';
+      prize.appendChild(icon);
+      const amt=document.createElement('span');amt.textContent=String(state.pot);prize.appendChild(amt);
+      overlay.appendChild(prize);
+      btn.textContent='Return to Lobby';
+      btn.style.marginTop='12px';
       btn.addEventListener('click', ()=>{
         localStorage.removeItem(STATE_KEY);
         localStorage.removeItem(OPP_KEY);
-        window.location.href = '/games/pollroyale/lobby';
+        localStorage.removeItem(`freeKickLastResult_${tgKey}`);
+        window.location.href='/games/freekick/lobby';
       });
-    }else{
+      overlay.appendChild(btn);
+      document.body.appendChild(overlay);
+    } else {
       btn.addEventListener('click', startNextMatch);
     }
   })();

--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -188,6 +188,11 @@
   const durationParam = parseInt(params.get('duration')) || 60;
   timeShort.textContent = durationParam;
 
+  let currentRound = 0;
+  if(window.tournamentMode){
+    try{ const st = JSON.parse(localStorage.getItem(STATE_KEY) || '{}'); currentRound = st.currentRound || 0; }catch{}
+  }
+
   function emojiToDataUri(flag){
     return `data:image/svg+xml,${encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='64' height='64'><text x='50%' y='50%' font-size='48' text-anchor='middle' dominant-baseline='central'>${flag}</text></svg>`)}`;
   }
@@ -393,6 +398,9 @@
     },
   ];
   for(let i=0;i<rivals.length;i++){ rivals[i].cvs = rivals[i].wrap.querySelector('canvas'); rivals[i].ctx = rivals[i].cvs.getContext('2d'); rivals[i].avatar = pvAvatars[i]?.src || ''; }
+  if(window.tournamentMode && currentRound){
+    for(const r of rivals){ r.rate = r.rate.map(t=>Math.max(300, t - currentRound*50)); }
+  }
   const miniHolesCache=[[],[],[]];
   const MINI_GOAL_PAD = 8;
   function miniGoalRect(cv){
@@ -1297,12 +1305,20 @@ function endShot(hit,pts,delay=SHOT_RESET_DELAY){
     const winner=scores.find(s=>s.score===max);
     const winIdx = scores.indexOf(winner) === 0 ? 1 : 2;
     if(window.tournamentMode && typeof window.handleTournamentResult === 'function'){
+      try{localStorage.setItem(`freeKickLastResult_${tgKey}`, JSON.stringify({p1: myScore, p2: rivals[0]?.score || 0}));}catch{}
       window.handleTournamentResult(winIdx);
       return;
     }
     const overlay=document.getElementById('winnerOverlay');
     const img=document.getElementById('winnerAvatar');
     if(img) img.src=winner.avatar || userAvatar;
+    const container=overlay.firstElementChild;
+    if(container){
+      const scoreEl=document.createElement('div');
+      scoreEl.style.marginTop='8px';scoreEl.style.color='#fff';
+      scoreEl.textContent=`${myScore}-${rivals[0]?.score||0}`;
+      container.insertBefore(scoreEl, container.lastElementChild);
+    }
     overlay.classList.remove('hidden');
     coinConfetti(50);
     cheerSound.currentTime=0; cheerSound.play().catch(()=>{});

--- a/webapp/public/goal-rush-bracket.html
+++ b/webapp/public/goal-rush-bracket.html
@@ -43,6 +43,8 @@
     background:rgba(37,99,235,.15); border:1px solid rgba(37,99,235,.35); color:#cfe0ff;
     font-size:.8rem;
   }
+  .coin-confetti{position:fixed;top:-40px;width:32px;height:32px;pointer-events:none;animation:coin-fall var(--duration,3s) linear forwards}
+  @keyframes coin-fall{from{transform:translateY(-10vh) rotate(0deg);opacity:1}to{transform:translateY(100vh) rotate(360deg);opacity:0}}
 </style>
 </head>
 <body>
@@ -71,6 +73,8 @@
     neonC:'#a855f7',
     line:'#233155'
   };
+  const tpcImg = new Image();
+  tpcImg.src = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 
   let hitRegions = []; // {round, match, slot, x,y,w,h}
 
@@ -219,7 +223,18 @@
     let label = '';
     const rounds = state.rounds.length;
     if(r === 0) label = 'ROUND OF ' + state.bracketN;
-    else if(r === rounds-1) label = 'FINAL 🏆 🪙' + state.pot;
+    else if(r === rounds-1){
+      label = 'FINAL 🏆 ';
+      ctx.fillText(label, x, topPad + 10);
+      let imgX = x + ctx.measureText(label).width + 2;
+      if (tpcImg.complete) {
+        ctx.drawImage(tpcImg, imgX, topPad, 12, 12);
+        imgX += 16;
+      }
+      ctx.fillText(String(state.pot), imgX, topPad + 10);
+      ctx.restore();
+      return;
+    }
     else if(r === rounds-2) label = 'SEMIFINAL';
     else label = 'QUARTER / R' + (r+1);
     ctx.fillText(label, x, topPad + 10);
@@ -266,6 +281,23 @@
 
     hitRegions.push({round:r, match:m, slot:0, x:x+4, y:y+4, w:w-8, h:slotH-6});
     hitRegions.push({round:r, match:m, slot:1, x:x+4, y:y+slotH+2, w:w-8, h:slotH-6});
+  }
+
+  function coinConfetti(count=20){
+    const container=document.createElement('div');
+    container.style.position='fixed';container.style.top='0';container.style.left='0';
+    container.style.width='100%';container.style.height='0';container.style.pointerEvents='none';
+    container.style.zIndex='100';container.style.overflow='visible';
+    document.body.appendChild(container);
+    for(let i=0;i<count;i++){
+      const img=document.createElement('img');
+      img.src='/assets/icons/ezgif-54c96d8a9b9236.webp';
+      img.className='coin-confetti';
+      const left=Math.random()*100; const delay=Math.random()*3; const duration=2+Math.random()*2;
+      img.style.left=left+'vw'; img.style.animationDelay=delay+'s'; img.style.setProperty('--duration',duration+'s');
+      container.appendChild(img);
+    }
+    setTimeout(()=>container.remove(),5000);
   }
 
   function matchPlayers(r,m){
@@ -472,17 +504,36 @@
     const btn = document.getElementById('continueBtn');
     if(state.complete){
       const champ = state.seedToPlayer[state.championSeed] || {};
-      const info = document.createElement('div');
-      info.style.textAlign = 'center';
-      info.textContent = `Winner: ${champ.flag? champ.flag+' ' : ''}${champ.name || ''}`;
-      document.body.appendChild(info);
-      btn.textContent = 'Close';
+      coinConfetti(30);
+      const overlay=document.createElement('div');
+      overlay.style.position='fixed';overlay.style.inset='0';overlay.style.display='flex';overlay.style.flexDirection='column';
+      overlay.style.alignItems='center';overlay.style.justifyContent='center';overlay.style.background='rgba(0,0,0,0.6)';
+      const av=document.createElement('div');
+      av.style.width='120px';av.style.height='120px';av.style.borderRadius='50%';av.style.background='#fff';av.style.display='flex';
+      av.style.alignItems='center';av.style.justifyContent='center';av.style.fontSize='64px';
+      av.textContent=champ.flag||'';overlay.appendChild(av);
+      const last=JSON.parse(localStorage.getItem(`goalRushLastResult_${tgKey}`)||'{}');
+      if(last.p1!=null && last.p2!=null){
+        const res=document.createElement('div');res.style.color='#fff';res.style.marginTop='8px';res.textContent=`${last.p1}-${last.p2}`;
+        overlay.appendChild(res);
+      }
+      const prize=document.createElement('div');
+      prize.style.display='flex';prize.style.alignItems='center';prize.style.gap='4px';prize.style.marginTop='8px';
+      const icon=document.createElement('img');icon.src='/assets/icons/ezgif-54c96d8a9b9236.webp';icon.style.width='24px';icon.style.height='24px';
+      prize.appendChild(icon);
+      const amt=document.createElement('span');amt.textContent=String(state.pot);prize.appendChild(amt);
+      overlay.appendChild(prize);
+      btn.textContent='Return to Lobby';
+      btn.style.marginTop='12px';
       btn.addEventListener('click', ()=>{
         localStorage.removeItem(STATE_KEY);
         localStorage.removeItem(OPP_KEY);
-        window.location.href = '/games/pollroyale/lobby';
+        localStorage.removeItem(`goalRushLastResult_${tgKey}`);
+        window.location.href='/games/goalrush/lobby';
       });
-    }else{
+      overlay.appendChild(btn);
+      document.body.appendChild(overlay);
+    } else {
       btn.addEventListener('click', startNextMatch);
     }
   })();

--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -179,6 +179,15 @@
 
   await loadCalibration();
 
+  let currentRound = 0;
+  if(window.tournamentMode){
+    try{
+      const st = JSON.parse(localStorage.getItem(TOURN_STATE_KEY) || '{}');
+      currentRound = st.currentRound || 0;
+    }catch{}
+    speedMul += currentRound * 0.05;
+  }
+
   const FLAG_DATA = [
     { emoji:'🇺🇸', name:'USA' },
     { emoji:'🇬🇧', name:'UK' },
@@ -285,9 +294,11 @@
     av.style.alignItems='center';av.style.justifyContent='center';av.style.borderRadius='50%';av.style.background='#fff';
     if(avatarImg && avatarImg.complete){av.style.backgroundImage=`url(${avatarImg.src})`;av.style.backgroundSize='cover';av.textContent='';}
     else{av.textContent=avatarEmoji||'';}
+    const scoreLine=document.createElement('div');
+    scoreLine.textContent=`${score.p1}-${score.p2}`;scoreLine.style.color='#fff';scoreLine.style.marginTop='12px';scoreLine.style.fontSize='1.5rem';
     const txt=document.createElement('div');
-    txt.textContent=`${winner} Wins!`;txt.style.color='#fff';txt.style.fontSize='2rem';txt.style.marginTop='16px';txt.style.fontWeight='bold';
-    overlay.appendChild(av);overlay.appendChild(txt);document.body.appendChild(overlay);
+    txt.textContent=`${winner} Wins!`;txt.style.color='#fff';txt.style.fontSize='2rem';txt.style.marginTop='8px';txt.style.fontWeight='bold';
+    overlay.appendChild(av);overlay.appendChild(scoreLine);overlay.appendChild(txt);document.body.appendChild(overlay);
     setTimeout(()=>{overlay.remove();showEndPopup();if(audio) audio.pause();},2500);
   }
 
@@ -357,7 +368,7 @@
   let lastTouch = null;
   let cornerEscapeFrames = 0;
   const difficultySpeeds = { easy:14, normal:17, hard:24 };
-  p2.max = difficultySpeeds[difficulty] || 16;
+  p2.max = (difficultySpeeds[difficulty] || 16) + currentRound * 2;
 
   let audioEnabled = true;
   let audioStarted = false;
@@ -946,6 +957,7 @@
       }
 
       if(window.tournamentMode && typeof window.handleTournamentResult === 'function'){
+        try{localStorage.setItem(`goalRushLastResult_${tgKey}`, JSON.stringify({p1: score.p1, p2: score.p2}));}catch{}
         window.handleTournamentResult(1);
         return;
       }
@@ -964,6 +976,7 @@
       }
 
       if(window.tournamentMode && typeof window.handleTournamentResult === 'function'){
+        try{localStorage.setItem(`goalRushLastResult_${tgKey}`, JSON.stringify({p1: score.p1, p2: score.p2}));}catch{}
         window.handleTournamentResult(2);
         return;
       }

--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -43,6 +43,8 @@
     background:rgba(37,99,235,.15); border:1px solid rgba(37,99,235,.35); color:#cfe0ff;
     font-size:.8rem;
   }
+  .coin-confetti{position:fixed;top:-40px;width:32px;height:32px;pointer-events:none;animation:coin-fall var(--duration,3s) linear forwards}
+  @keyframes coin-fall{from{transform:translateY(-10vh) rotate(0deg);opacity:1}to{transform:translateY(100vh) rotate(360deg);opacity:0}}
 </style>
 </head>
 <body>
@@ -71,6 +73,8 @@
     neonC:'#a855f7',
     line:'#233155'
   };
+  const tpcImg = new Image();
+  tpcImg.src = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 
   let hitRegions = []; // {round, match, slot, x,y,w,h}
 
@@ -219,7 +223,18 @@
     let label = '';
     const rounds = state.rounds.length;
     if(r === 0) label = 'ROUND OF ' + state.bracketN;
-    else if(r === rounds-1) label = 'FINAL 🏆 🪙' + state.pot;
+    else if(r === rounds-1){
+      label = 'FINAL 🏆 ';
+      ctx.fillText(label, x, topPad + 10);
+      let imgX = x + ctx.measureText(label).width + 2;
+      if (tpcImg.complete){
+        ctx.drawImage(tpcImg, imgX, topPad, 12, 12);
+        imgX += 16;
+      }
+      ctx.fillText(String(state.pot), imgX, topPad + 10);
+      ctx.restore();
+      return;
+    }
     else if(r === rounds-2) label = 'SEMIFINAL';
     else label = 'QUARTER / R' + (r+1);
     ctx.fillText(label, x, topPad + 10);
@@ -273,6 +288,23 @@
     const playerA = state.seedToPlayer[sA] || { name: 'TBD' };
     const playerB = state.seedToPlayer[sB] || { name: 'TBD' };
     return [playerA, playerB];
+  }
+
+  function coinConfetti(count=20){
+    const container=document.createElement('div');
+    container.style.position='fixed';container.style.top='0';container.style.left='0';
+    container.style.width='100%';container.style.height='0';container.style.pointerEvents='none';
+    container.style.zIndex='100';container.style.overflow='visible';
+    document.body.appendChild(container);
+    for(let i=0;i<count;i++){
+      const img=document.createElement('img');
+      img.src='/assets/icons/ezgif-54c96d8a9b9236.webp';
+      img.className='coin-confetti';
+      const left=Math.random()*100; const delay=Math.random()*3; const duration=2+Math.random()*2;
+      img.style.left=left+'vw'; img.style.animationDelay=delay+'s'; img.style.setProperty('--duration',duration+'s');
+      container.appendChild(img);
+    }
+    setTimeout(()=>container.remove(),5000);
   }
 
   function renderPlayer(player, x, y, slotH){
@@ -472,17 +504,40 @@
     const btn = document.getElementById('continueBtn');
     if(state.complete){
       const champ = state.seedToPlayer[state.championSeed] || {};
-      const info = document.createElement('div');
-      info.style.textAlign = 'center';
-      info.textContent = `Winner: ${champ.flag? champ.flag+' ' : ''}${champ.name || ''}`;
-      document.body.appendChild(info);
-      btn.textContent = 'Close';
+      coinConfetti(30);
+      const overlay=document.createElement('div');
+      overlay.style.position='fixed';overlay.style.inset='0';overlay.style.display='flex';overlay.style.flexDirection='column';
+      overlay.style.alignItems='center';overlay.style.justifyContent='center';overlay.style.background='rgba(0,0,0,0.6)';
+      const av=document.createElement('div');
+      av.style.width='120px';av.style.height='120px';av.style.borderRadius='50%';av.style.background='#fff';av.style.display='flex';
+      av.style.alignItems='center';av.style.justifyContent='center';av.style.fontSize='64px';
+      av.textContent=champ.flag||'';overlay.appendChild(av);
+      const last=JSON.parse(localStorage.getItem(`pollRoyaleLastResult_${tgKey}`)||'{}');
+      if(last.variant==='american'){
+        const res=document.createElement('div');res.style.color='#fff';res.style.marginTop='8px';res.textContent=`${last.scores?.[1]||0}-${last.scores?.[2]||0}`;
+        overlay.appendChild(res);
+      } else {
+        const img=document.createElement('img');img.style.width='40px';img.style.height='40px';img.style.marginTop='8px';
+        img.src = last.variant==='9ball'?'/assets/icons/Yellowball.webp':'/assets/icons/BlackBall.webp';
+        overlay.appendChild(img);
+      }
+      const prize=document.createElement('div');
+      prize.style.display='flex';prize.style.alignItems='center';prize.style.gap='4px';prize.style.marginTop='8px';
+      const icon=document.createElement('img');icon.src='/assets/icons/ezgif-54c96d8a9b9236.webp';icon.style.width='24px';icon.style.height='24px';
+      prize.appendChild(icon);
+      const amt=document.createElement('span');amt.textContent=String(state.pot);prize.appendChild(amt);
+      overlay.appendChild(prize);
+      btn.textContent='Return to Lobby';
+      btn.style.marginTop='12px';
       btn.addEventListener('click', ()=>{
         localStorage.removeItem(STATE_KEY);
         localStorage.removeItem(OPP_KEY);
-        window.location.href = '/games/pollroyale/lobby';
+        localStorage.removeItem(`pollRoyaleLastResult_${tgKey}`);
+        window.location.href='/games/pollroyale/lobby';
       });
-    }else{
+      overlay.appendChild(btn);
+      document.body.appendChild(overlay);
+    } else {
       btn.addEventListener('click', startNextMatch);
     }
   })();

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -1236,6 +1236,7 @@
           table.running = false;
           shotInProgress = false;
           if (window.tournamentMode && typeof window.handleTournamentResult === 'function') {
+            try{localStorage.setItem(`pollRoyaleLastResult_${tgKey}`, JSON.stringify({scores, variant}));}catch{}
             window.handleTournamentResult(winner);
             return;
           }


### PR DESCRIPTION
## Summary
- Display TPC icon and total pot on tournament final brackets
- Show winner overlays with prize info for Pool Royale, Free Kick and Goal Rush
- Increase AI speed each round in Goal Rush and Free Kick tournaments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6aca84b488329a8c449fcf92d9124