### PR TITLE
Randomize tournament brackets and add exit confirmation

### DIFF
--- a/webapp/public/free-kick-bracket.html
+++ b/webapp/public/free-kick-bracket.html
@@ -488,6 +488,7 @@
         { name: 'Portugal', flag: '🇵🇹' },
         { name: 'Belgium', flag: '🇧🇪' }
       ];
+      aiPool.sort(() => Math.random() - 0.5);
       const players = [{ name: userName, flag: params.get('flag') || '🏳️' }];
       players.push(...aiPool.slice(0, totalPlayers - 1));
       state.players = players;
@@ -500,6 +501,36 @@
     }
     layoutAndDraw();
     window.addEventListener('resize', ()=> layoutAndDraw());
+
+    const tg = window.Telegram?.WebApp;
+    if (tg) {
+      tg.BackButton.show();
+      tg.onEvent('backButtonClicked', showExitPopup);
+    }
+
+    function showExitPopup() {
+      const overlay = document.createElement('div');
+      overlay.style.position = 'fixed';
+      overlay.style.inset = '0';
+      overlay.style.background = 'rgba(0,0,0,0.6)';
+      overlay.style.display = 'flex';
+      overlay.style.alignItems = 'center';
+      overlay.style.justifyContent = 'center';
+      overlay.innerHTML = `<div style="background:#11172a;padding:20px;border-radius:8px;text-align:center;"><p style="margin-bottom:12px;">If you quit the tournament your funds will be lost.</p><div style="display:flex;gap:8px;justify-content:center;"><button id="quitTournament">Quit Tournament</button><button id="returnLobby">Return Lobby</button></div></div>`;
+      document.body.appendChild(overlay);
+      document.getElementById('quitTournament').onclick = () => {
+        try {
+          localStorage.removeItem(STATE_KEY);
+          localStorage.removeItem(OPP_KEY);
+        } catch {}
+        tg.BackButton.hide();
+        window.location.href = '/games/freekick/lobby';
+      };
+      document.getElementById('returnLobby').onclick = () => {
+        tg.BackButton.hide();
+        window.location.href = '/games/freekick/lobby';
+      };
+    }
 
     const btn = document.getElementById('continueBtn');
     if(state.complete){

--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -188,6 +188,36 @@
   const durationParam = parseInt(params.get('duration')) || 60;
   timeShort.textContent = durationParam;
 
+  const tg = window.Telegram?.WebApp;
+  if (tg) {
+    tg.BackButton.show();
+    tg.onEvent('backButtonClicked', showExitPopup);
+  }
+
+  function showExitPopup() {
+    const overlay = document.createElement('div');
+    overlay.style.position = 'fixed';
+    overlay.style.inset = '0';
+    overlay.style.background = 'rgba(0,0,0,0.6)';
+    overlay.style.display = 'flex';
+    overlay.style.alignItems = 'center';
+    overlay.style.justifyContent = 'center';
+    overlay.innerHTML = `<div style="background:#11172a;padding:20px;border-radius:8px;text-align:center;"><p style="margin-bottom:12px;">If you quit the tournament your funds will be lost.</p><div style="display:flex;gap:8px;justify-content:center;"><button id="quitTournament">Quit Tournament</button><button id="returnLobby">Return Lobby</button></div></div>`;
+    document.body.appendChild(overlay);
+    document.getElementById('quitTournament').onclick = () => {
+      try {
+        localStorage.removeItem(STATE_KEY);
+        localStorage.removeItem(OPP_KEY);
+      } catch {}
+      tg.BackButton.hide();
+      window.location.href = '/games/freekick/lobby';
+    };
+    document.getElementById('returnLobby').onclick = () => {
+      tg.BackButton.hide();
+      window.location.href = '/games/freekick/lobby';
+    };
+  }
+
   let currentRound = 0;
   if(window.tournamentMode){
     try{ const st = JSON.parse(localStorage.getItem(STATE_KEY) || '{}'); currentRound = st.currentRound || 0; }catch{}

--- a/webapp/public/goal-rush-bracket.html
+++ b/webapp/public/goal-rush-bracket.html
@@ -488,6 +488,7 @@
         { name: 'Portugal', flag: '🇵🇹' },
         { name: 'Belgium', flag: '🇧🇪' }
       ];
+      aiPool.sort(() => Math.random() - 0.5);
       const players = [{ name: userName, flag: params.get('flag') || '🏳️' }];
       players.push(...aiPool.slice(0, totalPlayers - 1));
       state.players = players;
@@ -500,6 +501,36 @@
     }
     layoutAndDraw();
     window.addEventListener('resize', ()=> layoutAndDraw());
+
+    const tg = window.Telegram?.WebApp;
+    if (tg) {
+      tg.BackButton.show();
+      tg.onEvent('backButtonClicked', showExitPopup);
+    }
+
+    function showExitPopup() {
+      const overlay = document.createElement('div');
+      overlay.style.position = 'fixed';
+      overlay.style.inset = '0';
+      overlay.style.background = 'rgba(0,0,0,0.6)';
+      overlay.style.display = 'flex';
+      overlay.style.alignItems = 'center';
+      overlay.style.justifyContent = 'center';
+      overlay.innerHTML = `<div style="background:#11172a;padding:20px;border-radius:8px;text-align:center;"><p style="margin-bottom:12px;">If you quit the tournament your funds will be lost.</p><div style="display:flex;gap:8px;justify-content:center;"><button id="quitTournament">Quit Tournament</button><button id="returnLobby">Return Lobby</button></div></div>`;
+      document.body.appendChild(overlay);
+      document.getElementById('quitTournament').onclick = () => {
+        try {
+          localStorage.removeItem(STATE_KEY);
+          localStorage.removeItem(OPP_KEY);
+        } catch {}
+        tg.BackButton.hide();
+        window.location.href = '/games/goalrush/lobby';
+      };
+      document.getElementById('returnLobby').onclick = () => {
+        tg.BackButton.hide();
+        window.location.href = '/games/goalrush/lobby';
+      };
+    }
 
     const btn = document.getElementById('continueBtn');
     if(state.complete){

--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -139,6 +139,36 @@
   const devAccount = params.get('dev');
   const devAccount1 = params.get('dev1');
   const devAccount2 = params.get('dev2');
+
+  const tg = window.Telegram?.WebApp;
+  if (tg) {
+    tg.BackButton.show();
+    tg.onEvent('backButtonClicked', showExitPopup);
+  }
+
+  function showExitPopup() {
+    const overlay = document.createElement('div');
+    overlay.style.position = 'fixed';
+    overlay.style.inset = '0';
+    overlay.style.background = 'rgba(0,0,0,0.6)';
+    overlay.style.display = 'flex';
+    overlay.style.alignItems = 'center';
+    overlay.style.justifyContent = 'center';
+    overlay.innerHTML = `<div style="background:#11172a;padding:20px;border-radius:8px;text-align:center;"><p style="margin-bottom:12px;">If you quit the tournament your funds will be lost.</p><div style="display:flex;gap:8px;justify-content:center;"><button id="quitTournament">Quit Tournament</button><button id="returnLobby">Return Lobby</button></div></div>`;
+    document.body.appendChild(overlay);
+    document.getElementById('quitTournament').onclick = () => {
+      try {
+        localStorage.removeItem(TOURN_STATE_KEY);
+        localStorage.removeItem(TOURN_OPP_KEY);
+      } catch {}
+      tg.BackButton.hide();
+      window.location.href = '/games/goalrush/lobby';
+    };
+    document.getElementById('returnLobby').onclick = () => {
+      tg.BackButton.hide();
+      window.location.href = '/games/goalrush/lobby';
+    };
+  }
   const tgId = params.get('tgId');
   const initParam = params.get('init');
   if (initParam && !window.Telegram) {

--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -488,6 +488,7 @@
         { name: 'Portugal', flag: '🇵🇹' },
         { name: 'Belgium', flag: '🇧🇪' }
       ];
+      aiPool.sort(() => Math.random() - 0.5);
       const players = [{ name: userName, flag: params.get('flag') || '🏳️' }];
       players.push(...aiPool.slice(0, totalPlayers - 1));
       state.players = players;
@@ -500,6 +501,36 @@
     }
     layoutAndDraw();
     window.addEventListener('resize', ()=> layoutAndDraw());
+
+    const tg = window.Telegram?.WebApp;
+    if (tg) {
+      tg.BackButton.show();
+      tg.onEvent('backButtonClicked', showExitPopup);
+    }
+
+    function showExitPopup() {
+      const overlay = document.createElement('div');
+      overlay.style.position = 'fixed';
+      overlay.style.inset = '0';
+      overlay.style.background = 'rgba(0,0,0,0.6)';
+      overlay.style.display = 'flex';
+      overlay.style.alignItems = 'center';
+      overlay.style.justifyContent = 'center';
+      overlay.innerHTML = `<div style="background:#11172a;padding:20px;border-radius:8px;text-align:center;"><p style="margin-bottom:12px;">If you quit the tournament your funds will be lost.</p><div style="display:flex;gap:8px;justify-content:center;"><button id="quitTournament">Quit Tournament</button><button id="returnLobby">Return Lobby</button></div></div>`;
+      document.body.appendChild(overlay);
+      document.getElementById('quitTournament').onclick = () => {
+        try {
+          localStorage.removeItem(STATE_KEY);
+          localStorage.removeItem(OPP_KEY);
+        } catch {}
+        tg.BackButton.hide();
+        window.location.href = '/games/pollroyale/lobby';
+      };
+      document.getElementById('returnLobby').onclick = () => {
+        tg.BackButton.hide();
+        window.location.href = '/games/pollroyale/lobby';
+      };
+    }
 
     const btn = document.getElementById('continueBtn');
     if(state.complete){

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -938,6 +938,36 @@
         window.playerName = params.get('name') || 'Player';
         const planShotPromise = import('/lib/poolAi.js');
 
+        var tg = window.Telegram?.WebApp;
+        if (tg) {
+          tg.BackButton.show();
+          tg.onEvent('backButtonClicked', showExitPopup);
+        }
+
+        function showExitPopup() {
+          var overlay = document.createElement('div');
+          overlay.style.position = 'fixed';
+          overlay.style.inset = '0';
+          overlay.style.background = 'rgba(0,0,0,0.6)';
+          overlay.style.display = 'flex';
+          overlay.style.alignItems = 'center';
+          overlay.style.justifyContent = 'center';
+          overlay.innerHTML = '<div style="background:#11172a;padding:20px;border-radius:8px;text-align:center;"><p style="margin-bottom:12px;">If you quit the tournament your funds will be lost.</p><div style="display:flex;gap:8px;justify-content:center;"><button id="quitTournament">Quit Tournament</button><button id="returnLobby">Return Lobby</button></div></div>';
+          document.body.appendChild(overlay);
+          document.getElementById('quitTournament').onclick = function () {
+            try {
+              localStorage.removeItem(STATE_KEY);
+              localStorage.removeItem(OPP_KEY);
+            } catch {}
+            tg.BackButton.hide();
+            window.location.href = '/games/pollroyale/lobby';
+          };
+          document.getElementById('returnLobby').onclick = function () {
+            tg.BackButton.hide();
+            window.location.href = '/games/pollroyale/lobby';
+          };
+        }
+
         /* ==========================================================
        KONSTANTA TE LAYOUT-it DHE FIZIKES (sipas portrait)
        ========================================================= */


### PR DESCRIPTION
## Summary
- randomize AI opponents when generating tournament brackets
- add back-button exit confirmation with options to quit or return to lobby

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b58623548329acbf62870c37d39e