### PR TITLE
Expand AI tournament flags in Goal Rush and Free Kick

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -131,6 +131,7 @@
   </div>
 
 <script src="/free-kick-api.js"></script>
+<script src="/flag-emojis.js"></script>
 <script>
 (()=> {
   // ===== Canvas =====
@@ -220,7 +221,9 @@
   }
   userAvatarEl.src = userAvatar;
 
-  const flags = ['🇨🇦','🇫🇷','🇩🇪','🇪🇸','🇧🇷','🇯🇵','🇺🇸','🇬🇧'];
+  function shuffle(arr){ for(let i=arr.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); [arr[i],arr[j]]=[arr[j],arr[i]]; } }
+  const flags = [...(window.FLAG_EMOJIS || [])];
+  shuffle(flags);
   if(window.tournamentMode){
     try{
       const opp = JSON.parse(localStorage.getItem(OPP_KEY) || '{}');
@@ -228,13 +231,13 @@
       if(pvNames[0]) pvNames[0].textContent = opp.name || flagName(opp.flag);
     }catch{}
     for(let i=1;i<3;i++){
-      const flag = flags[(Math.random()*flags.length)|0];
+      const flag = flags[i];
       if(pvAvatars[i]) pvAvatars[i].src = emojiToDataUri(flag);
       if(pvNames[i]) pvNames[i].textContent = flagName(flag);
     }
   } else {
     for(let i=0;i<3;i++){
-      const flag = flags[(Math.random()*flags.length)|0];
+      const flag = flags[i];
       if(pvAvatars[i]) pvAvatars[i].src = emojiToDataUri(flag);
       if(pvNames[i]) pvNames[i].textContent = flagName(flag);
     }

--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -94,6 +94,7 @@
 
 
 <script src="/goal-rush-api.js"></script>
+<script src="/flag-emojis.js"></script>
 <script>
 (async () => {
   const canvas = document.getElementById('game');
@@ -188,23 +189,19 @@
     speedMul += currentRound * 0.05;
   }
 
-  const FLAG_DATA = [
-    { emoji:'🇺🇸', name:'USA' },
-    { emoji:'🇬🇧', name:'UK' },
-    { emoji:'🇫🇷', name:'France' },
-    { emoji:'🇩🇪', name:'Germany' },
-    { emoji:'🇨🇦', name:'Canada' },
-    { emoji:'🇯🇵', name:'Japan' },
-    { emoji:'🇮🇳', name:'India' },
-    { emoji:'🇰🇷', name:'South Korea' },
-    { emoji:'🇧🇷', name:'Brazil' },
-    { emoji:'🇲🇽', name:'Mexico' },
-    { emoji:'🇨🇳', name:'China' },
-    { emoji:'🇦🇺', name:'Australia' },
-    { emoji:'🇮🇹', name:'Italy' },
-    { emoji:'🇪🇸', name:'Spain' },
-    { emoji:'🇷🇺', name:'Russia' }
-  ];
+  const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
+  function flagToName(flag){
+    try{
+      const codes = Array.from(flag).map(c => c.codePointAt(0) - 0x1F1E6 + 65);
+      return regionNames.of(String.fromCharCode(...codes)) || 'CPU';
+    }catch{
+      return 'CPU';
+    }
+  }
+  const FLAG_DATA = (window.FLAG_EMOJIS || []).map(f => ({
+    emoji: f,
+    name: flagToName(f)
+  }));
 
   let p1AvatarImg=null, p1AvatarEmoji=null;
   if(avatarParam){
@@ -225,7 +222,7 @@
   }
 
   if(mode==='ai'){
-    const ai = FLAG_DATA[Math.floor(Math.random()*FLAG_DATA.length)];
+    const ai = FLAG_DATA[Math.floor(Math.random()*FLAG_DATA.length)] || { emoji: '🤖', name: 'CPU' };
     p2AvatarImg = null;
     p2AvatarEmoji = ai.emoji;
     p2Name = ai.name;


### PR DESCRIPTION
## Summary
- load global flag assets in Goal Rush and Free Kick
- randomize AI player flags and names using full world list

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6c4d39a688329b8fd0b60987ca2ac