### PR TITLE
Improve tournament bracket clarity

### DIFF
--- a/webapp/public/free-kick-bracket.html
+++ b/webapp/public/free-kick-bracket.html
@@ -223,7 +223,7 @@
     ctx.textAlign = 'left';
     let label = '';
     const rounds = state.rounds.length;
-    if(r === 0) label = 'ROUND OF ' + state.bracketN;
+    if(r === 0) label = 'ROUND OF ' + state.N;
     else if(r === rounds-1){
       label = 'FINAL 🏆 ';
       ctx.fillText(label, x, topPad + 10);
@@ -309,6 +309,7 @@
   }
 
   function renderPlayer(player, x, y, slotH){
+    if(player.name === 'BYE') return;
     const avatarSize = 20;
     if(player.flag){
       ctx.fillText(player.flag, x, y+1);

--- a/webapp/public/goal-rush-bracket.html
+++ b/webapp/public/goal-rush-bracket.html
@@ -223,7 +223,7 @@
     ctx.textAlign = 'left';
     let label = '';
     const rounds = state.rounds.length;
-    if(r === 0) label = 'ROUND OF ' + state.bracketN;
+    if(r === 0) label = 'ROUND OF ' + state.N;
     else if(r === rounds-1){
       label = 'FINAL 🏆 ';
       ctx.fillText(label, x, topPad + 10);
@@ -309,6 +309,7 @@
   }
 
   function renderPlayer(player, x, y, slotH){
+    if(player.name === 'BYE') return;
     const avatarSize = 20;
     if(player.flag){
       ctx.fillText(player.flag, x, y+1);

--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -223,7 +223,7 @@
     ctx.textAlign = 'left';
     let label = '';
     const rounds = state.rounds.length;
-    if(r === 0) label = 'ROUND OF ' + state.bracketN;
+    if(r === 0) label = 'ROUND OF ' + state.N;
     else if(r === rounds-1){
       label = 'FINAL 🏆 ';
       ctx.fillText(label, x, topPad + 10);
@@ -309,6 +309,7 @@
   }
 
   function renderPlayer(player, x, y, slotH){
+    if(player.name === 'BYE') return;
     const avatarSize = 20;
     if(player.flag){
       ctx.fillText(player.flag, x, y+1);


### PR DESCRIPTION
## Summary
- Show the actual player count in first-round labels for Pool Royale, Goal Rush, and Free Kick tournaments
- Hide BYE placeholders so only real participants appear in brackets

## Testing
- `npm test`
- `npm run lint` *(fails: 965 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6caa50a84832983fe73ec2178b427