### PR TITLE
Fix tournament player count persistence for Free Kick and Pool Royale

### DIFF
--- a/webapp/public/free-kick-bracket.html
+++ b/webapp/public/free-kick-bracket.html
@@ -461,8 +461,14 @@
     const totalPlayers = parseInt(params.get('players') || '8', 10);
     const saved = localStorage.getItem(STATE_KEY);
     if(saved){
-      state = JSON.parse(saved);
-    } else {
+      try{
+        const parsed = JSON.parse(saved);
+        if(parsed.N === totalPlayers){
+          state = parsed;
+        }
+      }catch{}
+    }
+    if(!state.rounds.length){
       const userName = params.get('name') || 'You';
       const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
       function flagToName(flag){

--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -461,8 +461,14 @@
     const totalPlayers = parseInt(params.get('players') || '8', 10);
     const saved = localStorage.getItem(STATE_KEY);
     if(saved){
-      state = JSON.parse(saved);
-    } else {
+      try{
+        const parsed = JSON.parse(saved);
+        if(parsed.N === totalPlayers){
+          state = parsed;
+        }
+      }catch{}
+    }
+    if(!state.rounds.length){
       const userName = params.get('name') || 'You';
       const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
       function flagToName(flag){


### PR DESCRIPTION
## Summary
- reset free kick tournament state when player count changes
- reset pool royale tournament state when player count changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6e3e76c708329942d644ac9b05da4