### PR TITLE
Add effects for Free Kick prize impacts and faster AI

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -306,6 +306,7 @@
   ballImg.src = '/assets/icons/file_0000000061d4620aaf506adfa605e1f3.webp';
 
   let holes=[]; let banners=[]; let cameras=[]; let looseBalls=[]; let punchEffects=[];
+  let prizePieces=[]; let ballPieces=[]; let smokePuffs=[];
   let netHit={x:0,y:0,t:0,shake:0};
   let goalFlash=0;
   let missFlash=0;
@@ -329,7 +330,6 @@
       score:0,
       next:0,
       acc:0.68,
-      // shoot faster than before
       rate:[800,1650],
       shots:[],
       kx:0,
@@ -634,12 +634,14 @@
     const x=rect.left + (ball.x/W)*rect.width;
     const y=rect.top + (ball.y/H)*rect.height;
     const el=document.createElement('div');
-    el.textContent='💥';
+    el.textContent='💨';
     el.className='bomb-explosion';
     el.style.left=x+'px';
     el.style.top=y+'px';
     document.body.appendChild(el);
     setTimeout(()=>el.remove(),1000);
+    for(let i=0;i<10;i++){ ballPieces.push({x:ball.x,y:ball.y,vx:rnd(-3,3),vy:rnd(-3,3),life:1}); }
+    for(let i=0;i<12;i++){ smokePuffs.push({x:ball.x,y:ball.y,r:rnd(6,10),vx:rnd(-0.4,0.4),vy:rnd(-1.2,-0.6),life:1}); }
     ball.exploded = true;
     ball.moving = false;
     ball.path = null;
@@ -935,6 +937,45 @@
     ctx.restore();
   }
 
+  function drawPrizePieces(){
+    ctx.fillStyle='#e10600';
+    for(const p of prizePieces){
+      ctx.globalAlpha=p.life;
+      ctx.beginPath();
+      ctx.arc(p.x,p.y,2,0,Math.PI*2);
+      ctx.fill();
+      p.x+=p.vx; p.y+=p.vy; p.vy+=0.1; p.life-=0.02;
+    }
+    ctx.globalAlpha=1;
+    prizePieces=prizePieces.filter(p=>p.life>0);
+  }
+
+  function drawBallPieces(){
+    ctx.fillStyle='#fff';
+    for(const b of ballPieces){
+      ctx.globalAlpha=b.life;
+      ctx.beginPath();
+      ctx.arc(b.x,b.y,2,0,Math.PI*2);
+      ctx.fill();
+      b.x+=b.vx; b.y+=b.vy; b.vy+=0.2; b.life-=0.02;
+    }
+    ctx.globalAlpha=1;
+    ballPieces=ballPieces.filter(b=>b.life>0);
+  }
+
+  function drawSmoke(){
+    for(const s of smokePuffs){
+      ctx.globalAlpha=s.life*0.5;
+      ctx.fillStyle='#bbb';
+      ctx.beginPath();
+      ctx.arc(s.x,s.y,s.r,0,Math.PI*2);
+      ctx.fill();
+      s.x+=s.vx; s.y+=s.vy; s.r+=0.3; s.life-=0.02;
+    }
+    ctx.globalAlpha=1;
+    smokePuffs=smokePuffs.filter(s=>s.life>0);
+  }
+
   function drawPunchEffects(){
     for(const p of punchEffects){
       ctx.globalAlpha=p.life;
@@ -1099,6 +1140,7 @@
             updateHUD();
             popupText(`+${h.timer}s`,h.x,h.y,timeShort,'#22c55e');
             sfxTimer();
+            for(let i=0;i<8;i++){ prizePieces.push({x:h.x,y:h.y,vx:rnd(-2,2),vy:rnd(-2,2),life:1}); }
           } else if(h.bomb){
             roundStart += 15000;
             timeLeft = Math.max(0,timeLeft-15000);
@@ -1112,6 +1154,7 @@
           } else {
             ball.points += h.points;
             sfxPrize();
+            for(let i=0;i<8;i++){ prizePieces.push({x:h.x,y:h.y,vx:rnd(-2,2),vy:rnd(-2,2),life:1}); }
           }
           ball.spin *= 0.6;
           break;
@@ -1524,7 +1567,7 @@ function onUp(e){
         }
       }
       if(now>r.next){
-        r.next = now + rnd(r.rate[0], r.rate[1]) * (1 - 0.45*t) * 1.1;
+        r.next = now + rnd(r.rate[0], r.rate[1]) * (1 - 0.45*t) * 0.95;
         const g = r.g;
         const list = Array.isArray(miniHolesCache[i]) ? miniHolesCache[i] : [];
         if(list.length===0){ generateMiniHoles(); continue; }
@@ -1572,7 +1615,7 @@ function onUp(e){
 
   // ===== Timer + loop =====
   function tick(now){ if(!running||paused) return; if(!roundStart) roundStart=now; timeLeft = Math.max(0, ROUND_TIME - (now - roundStart)); timeShort.textContent = Math.ceil(timeLeft/1000); if(timeLeft<=0){ finish(); } }
-  function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoal(); drawBall(); drawDefenders(); drawPunchEffects(); stepBall(); stepLooseBalls(); stepDefenders(); stepKeeper(); drawMiniBoards(); tick(now||performance.now()); stepRivals(now||performance.now()); updateHUD(); netHit.t*=NET_DECAY; netHit.shake*=NET_DECAY; goalFlash*=0.92; missFlash*=0.92; }
+  function loop(now){ requestAnimationFrame(loop); drawField(); drawAds(); drawGoal(); drawBall(); drawPrizePieces(); drawBallPieces(); drawSmoke(); drawDefenders(); drawPunchEffects(); stepBall(); stepLooseBalls(); stepDefenders(); stepKeeper(); drawMiniBoards(); tick(now||performance.now()); stepRivals(now||performance.now()); updateHUD(); netHit.t*=NET_DECAY; netHit.shake*=NET_DECAY; goalFlash*=0.92; missFlash*=0.92; }
 
   // ===== Controls =====
   // controls removed


### PR DESCRIPTION
## Summary
- Break goal prizes into fragments when struck
- Explode ball into pieces with smoke when bomb is hit
- Slightly increase AI shooting rate

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon and related errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f985cbd0832989458efafaf9fe98