### PR TITLE
Refine Goal Rush field layout

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -517,25 +517,21 @@
 
     // center line
     ctx.beginPath();
-    ctx.moveTo(rink.x, centerY);
-    ctx.lineTo(rink.x + rink.w, centerY);
-    ctx.stroke();
-
     // center circle
     ctx.beginPath();
     ctx.arc(centerX, centerY, Math.min(W, H) * 0.11, 0, Math.PI * 2);
     ctx.stroke();
 
     // penalty areas
-    const penW = rink.w * 0.4;
-    const penH = rink.h * 0.16;
+    const penW = rink.w * 0.45;
+    const penH = rink.h * 0.18;
     ctx.beginPath();
     ctx.rect(centerX - penW / 2, rink.y, penW, penH);
     ctx.rect(centerX - penW / 2, rink.y + rink.h - penH, penW, penH);
     ctx.stroke();
 
     // goal areas (6-yard boxes)
-    const goalAreaW = rink.w * 0.2;
+    const goalAreaW = goalWidth * 1.1;
     const goalAreaH = rink.h * 0.06;
     ctx.beginPath();
     ctx.rect(centerX - goalAreaW / 2, rink.y, goalAreaW, goalAreaH);
@@ -543,10 +539,12 @@
     ctx.stroke();
 
     // penalty arcs
-    const arcR = penW * 0.32;
+    const arcR = penW / 2;
     ctx.beginPath();
-    ctx.arc(centerX, rink.y + penH, arcR, Math.PI * 1.1, Math.PI * 1.9);
-    ctx.arc(centerX, rink.y + rink.h - penH, arcR, Math.PI * 0.1, Math.PI * 0.9);
+    ctx.arc(centerX, rink.y + penH, arcR, 0, Math.PI);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(centerX, rink.y + rink.h - penH, arcR, Math.PI, 0, true);
     ctx.stroke();
 
     // penalty spots


### PR DESCRIPTION
## Summary
- remove mid-field line and redraw penalty arcs outside the box without connector line
- enlarge penalty and goal areas for better spacing

## Testing
- `npm test` *(fails to exit cleanly; last tests show success)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fa33ead48329a52695b7d0a5b737