### PR TITLE
feat: enhance goal rush field

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -523,11 +523,11 @@
 
     // center circle
     ctx.beginPath();
-    ctx.arc(centerX, centerY, Math.min(W, H) * 0.11, 0, Math.PI * 2);
+    ctx.arc(centerX, centerY, Math.min(W, H) * 0.13, 0, Math.PI * 2);
     ctx.stroke();
 
     // penalty areas
-    const penW = rink.w * 0.44;
+    const penW = rink.w * 0.5;
     const penH = rink.h * 0.18;
     ctx.beginPath();
     ctx.rect(centerX - penW / 2, rink.y, penW, penH);
@@ -564,6 +564,32 @@
     ctx.arc(centerX, rink.y + penH * 0.7, spotR, 0, Math.PI * 2);
     ctx.arc(centerX, rink.y + rink.h - penH * 0.7, spotR, 0, Math.PI * 2);
     ctx.fill();
+
+    // corner arcs
+    const cornerR = puck.r * 1.2;
+    ctx.beginPath();
+    ctx.arc(rink.x, rink.y, cornerR, 0, Math.PI / 2);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(rink.x + rink.w, rink.y, cornerR, Math.PI / 2, Math.PI);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(rink.x, rink.y + rink.h, cornerR, (3 * Math.PI) / 2, Math.PI * 2);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(rink.x + rink.w, rink.y + rink.h, cornerR, Math.PI, (3 * Math.PI) / 2);
+    ctx.stroke();
+
+    // corner flags
+    const flagSize = Math.max(16, cornerR * 1.2);
+    ctx.font = `${flagSize}px serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.fillText('🏁', rink.x, rink.y);
+    ctx.fillText('🏁', rink.x + rink.w, rink.y);
+    ctx.textBaseline = 'bottom';
+    ctx.fillText('🏁', rink.x, rink.y + rink.h);
+    ctx.fillText('🏁', rink.x + rink.w, rink.y + rink.h);
 
     // advertising billboards behind goals
     const billboardH = goalDepth * 1.2;


### PR DESCRIPTION
## Summary
- widen Goal Rush penalty area and enlarge center circle
- add corner arcs and flag emojis at each field corner

## Testing
- `npm test`
- `npm run lint` *(fails: numerous existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b705c7a3b4832988cd971dc2241f5a