### PR TITLE
Fix Pool Royale tournament winner handling

### DIFF
--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -464,7 +464,6 @@
 
   function startNextMatch(){
     const st = state;
-    recalcCurrentRound(st);
     const info = getUserMatch(st);
     if(!info) return;
     st.pendingMatch = info;

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -3734,7 +3734,7 @@
             var r = st.pendingMatch.round;
             var m = st.pendingMatch.match;
             var oppSeed = st.pendingMatch.pair[0] === st.userSeed ? st.pendingMatch.pair[1] : st.pendingMatch.pair[0];
-            var winnerSeed = Number(winner) === 1 ? st.userSeed : oppSeed;
+            var winnerSeed = winner === 1 ? st.userSeed : oppSeed;
             var next = st.rounds[r + 1];
             if (next) {
               next[Math.floor(m / 2)][m % 2] = winnerSeed;


### PR DESCRIPTION
## Summary
- Correct winner determination in Pool Royale tournament matches
- Align Pool Royale bracket flow with Goal Rush by simplifying startNextMatch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b707821ea08329842c238e62c660f7