### PR TITLE
Fix Poll Royale tournament progression

### DIFF
--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -447,14 +447,18 @@
   }
 
   function startNextMatch(){
-    const st = state;
+    const st = JSON.parse(localStorage.getItem(STATE_KEY) || '{}');
+    if(!st.rounds || !st.rounds.length) return;
+    state = st;
     const info = getUserMatch(st);
     if(!info) return;
     st.pendingMatch = info;
     const opponentSeed = info.pair[0] === st.userSeed ? info.pair[1] : info.pair[0];
     localStorage.setItem(OPP_KEY, JSON.stringify(st.seedToPlayer[opponentSeed]));
     localStorage.setItem(STATE_KEY, JSON.stringify(st));
-    window.location.href = '/poll-royale.html' + window.location.search;
+    const search = new URLSearchParams(window.location.search);
+    search.set('type', 'tournament');
+    window.location.href = '/poll-royale.html?' + search.toString();
   }
 
   (function init(){
@@ -521,6 +525,8 @@
     window.addEventListener('popstate', (e)=>{ e.preventDefault(); showExitPopup(); history.pushState(null,'',location.href); });
 
     const btn = document.getElementById('continueBtn');
+    const savedState = JSON.parse(localStorage.getItem(STATE_KEY) || '{}');
+    if(savedState.rounds && savedState.rounds.length) state = savedState;
     if(state.complete){
       const champ = state.seedToPlayer[state.championSeed] || {};
       coinConfetti(30);

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -3736,11 +3736,15 @@
             var oppSeed = st.pendingMatch.pair[0] === st.userSeed ? st.pendingMatch.pair[1] : st.pendingMatch.pair[0];
             var winnerSeed = winner === 1 ? st.userSeed : oppSeed;
             var next = st.rounds[r + 1];
-            if (next) {
-              next[Math.floor(m / 2)][m % 2] = winnerSeed;
-            } else {
+            if (!next && r < st.rounds.length - 1) {
+              st.rounds[r + 1] = Array.from({ length: Math.ceil(st.rounds[r].length / 2) }, () => [0, 0]);
+              next = st.rounds[r + 1];
+            }
+            if (r >= st.rounds.length - 1) {
               st.championSeed = winnerSeed;
               st.complete = true;
+            } else if (next) {
+              next[Math.floor(m / 2)][m % 2] = winnerSeed;
             }
             if (winnerSeed !== st.userSeed) {
               simulateRemaining(st, r);


### PR DESCRIPTION
## Summary
- avoid marking Poll Royale tournaments complete after first round
- pass tournament flag to Poll Royale matches and reload existing state

## Testing
- `npm test`
- `cd webapp && npm test`
- `cd webapp && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7155c36c08329887989a6eed69f7a