### PR TITLE
Ensure tgId persists across Poll Royale flow

### DIFF
--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -61,7 +61,20 @@
   const canvas = document.getElementById('board');
   const ctx = canvas.getContext('2d');
   const params = new URLSearchParams(window.location.search);
-  const tgKey = params.get("tgId") || "anon";
+  let tgId =
+    params.get("tgId") ||
+    localStorage.getItem("pollRoyaleTgId") ||
+    "anon";
+  if (!params.get("tgId")) {
+    params.set("tgId", tgId);
+    window.history.replaceState(
+      null,
+      "",
+      `${location.pathname}?${params.toString()}`
+    );
+  }
+  localStorage.setItem("pollRoyaleTgId", tgId);
+  const tgKey = tgId;
   const STATE_KEY = `pollRoyaleTournamentState_${tgKey}`;
   const OPP_KEY = `pollRoyaleTournamentOpponent_${tgKey}`;
   const theme = {

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -917,12 +917,24 @@
         );
 
         var params = new URLSearchParams(location.search);
-        var tgKey = params.get("tgId") || "anon";
+        var tgId =
+          params.get("tgId") ||
+          localStorage.getItem("pollRoyaleTgId") ||
+          "anon";
+        if (!params.get("tgId")) {
+          params.set("tgId", tgId);
+          window.history.replaceState(
+            null,
+            "",
+            `${location.pathname}?${params.toString()}`
+          );
+        }
+        localStorage.setItem("pollRoyaleTgId", tgId);
+        var tgKey = tgId;
         var STATE_KEY = `pollRoyaleTournamentState_${tgKey}`;
         var OPP_KEY = `pollRoyaleTournamentOpponent_${tgKey}`;
         var stake = parseInt(params.get("amount") || "0", 10);
         var accountId = params.get("accountId");
-        var tgId = params.get("tgId");
         var devAccount = params.get("dev");
         var devAccount1 = params.get("dev1");
         var devAccount2 = params.get("dev2");
@@ -3728,7 +3740,12 @@
           try {
             var st = JSON.parse(localStorage.getItem(STATE_KEY) || '{}');
             if (!st.pendingMatch) {
-              window.location.href = '/poll-royale-bracket.html?' + window.location.search.slice(1);
+              console.warn('handleTournamentResult: pendingMatch missing', {
+                stateKey: STATE_KEY,
+                state: st
+              });
+              window.location.href =
+                '/poll-royale-bracket.html?' + window.location.search.slice(1);
               return;
             }
             var r = st.pendingMatch.round;

--- a/webapp/src/pages/Games/PollRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PollRoyaleLobby.jsx
@@ -66,7 +66,9 @@ export default function PollRoyaleLobby() {
       if (stake.amount) params.set('amount', stake.amount);
     }
     if (avatar) params.set('avatar', avatar);
-    if (tgId) params.set('tgId', tgId);
+    const tgIdParam = tgId || localStorage.getItem('pollRoyaleTgId') || 'anon';
+    params.set('tgId', tgIdParam);
+    localStorage.setItem('pollRoyaleTgId', tgIdParam);
     if (accountId) params.set('accountId', accountId);
     const name = getTelegramFirstName();
     if (name) params.set('name', name);


### PR DESCRIPTION
## Summary
- Preserve `tgId` across Poll Royale pages by storing and re-appending it to URLs
- Warn when tournament match state is missing to surface key mismatches
- Always include a `tgId` parameter when launching the Poll Royale bracket from the lobby

## Testing
- `npm test -- test`
- `npm run lint` *(fails: 965 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b71c8a462c8329b575e0f531fbb49b