### PR TITLE
feat: add session orchestrator for match matchmaking

### DIFF
--- a/bot/orchestrator/models/Match.js
+++ b/bot/orchestrator/models/Match.js
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+
+const matchSchema = new mongoose.Schema({
+  matchId: { type: String, unique: true },
+  gameId: String,
+  roomId: String,
+  players: { type: [String], default: [] },
+  status: { type: String, default: 'pending' },
+  winner: String,
+  createdAt: { type: Date, default: Date.now }
+});
+
+export default mongoose.model('OrchMatch', matchSchema);

--- a/bot/orchestrator/models/Player.js
+++ b/bot/orchestrator/models/Player.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+
+const playerSchema = new mongoose.Schema({
+  playerId: { type: String, unique: true },
+  name: String,
+  rating: { type: Number, default: 0 }
+});
+
+export default mongoose.model('OrchPlayer', playerSchema);

--- a/bot/orchestrator/models/Room.js
+++ b/bot/orchestrator/models/Room.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const roomSchema = new mongoose.Schema({
+  roomId: { type: String, unique: true },
+  gameId: String,
+  players: { type: [String], default: [] },
+  status: { type: String, default: 'waiting' }
+});
+
+export default mongoose.model('OrchRoom', roomSchema);

--- a/bot/orchestrator/models/Ticket.js
+++ b/bot/orchestrator/models/Ticket.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const ticketSchema = new mongoose.Schema({
+  ticketId: { type: String, unique: true },
+  playerId: String,
+  gameId: String,
+  roomId: String,
+  createdAt: { type: Date, default: Date.now }
+});
+
+export default mongoose.model('OrchTicket', ticketSchema);

--- a/bot/orchestrator/orchestrator.js
+++ b/bot/orchestrator/orchestrator.js
@@ -1,0 +1,148 @@
+import { EventEmitter } from 'events';
+import { v4 as uuidv4 } from 'uuid';
+
+export class MatchmakingOrchestrator extends EventEmitter {
+  constructor({ matchSize = 2, afkTimeout = 30000 } = {}) {
+    super();
+    this.matchSize = matchSize;
+    this.afkTimeout = afkTimeout;
+    this.queue = new Map(); // gameId => [playerIds]
+    this.matches = new Map(); // matchId => match object
+    this.ticker = setInterval(() => this.tick(), 1000);
+  }
+
+  // Queue management
+  joinQueue(playerId, gameId) {
+    if (!playerId || !gameId) return { error: 'invalid' };
+    const q = this.queue.get(gameId) || [];
+    if (!q.includes(playerId)) q.push(playerId);
+    this.queue.set(gameId, q);
+    this.tryMatch(gameId);
+    return { queued: true, position: q.length };
+  }
+
+  leaveQueue(playerId, gameId) {
+    const q = this.queue.get(gameId);
+    if (!q) return { left: false };
+    const idx = q.indexOf(playerId);
+    if (idx !== -1) q.splice(idx, 1);
+    return { left: idx !== -1 };
+  }
+
+  tryMatch(gameId) {
+    const q = this.queue.get(gameId);
+    while (q && q.length >= this.matchSize) {
+      const players = q.splice(0, this.matchSize);
+      const matchId = uuidv4();
+      const match = {
+        id: matchId,
+        gameId,
+        status: 'ready',
+        players: players.map((id) => ({ id, claimed: false })),
+        moves: [],
+        turn: 0
+      };
+      this.matches.set(matchId, match);
+      this.emit('match_ready', match);
+    }
+  }
+
+  // Match lifecycle
+  claimMatch(matchId, playerId) {
+    const match = this.matches.get(matchId);
+    if (!match) return { error: 'not_found' };
+    const player = match.players.find((p) => p.id === playerId);
+    if (!player) return { error: 'not_in_match' };
+    player.claimed = true;
+    if (match.players.every((p) => p.claimed)) {
+      this.startMatch(matchId);
+    }
+    return { success: true };
+  }
+
+  startMatch(matchId) {
+    const match = this.matches.get(matchId);
+    if (!match) return { error: 'not_found' };
+    if (match.status !== 'ready') return { error: 'invalid_state' };
+    match.status = 'active';
+    match.players.forEach((p) => this.resetAfkTimer(match, p.id));
+    this.emit('match_started', match);
+    return { success: true };
+  }
+
+  resetAfkTimer(match, playerId) {
+    const player = match.players.find((p) => p.id === playerId);
+    if (!player) return;
+    clearTimeout(player.afkTimer);
+    player.deadline = Date.now() + this.afkTimeout;
+    player.afkTimer = setTimeout(() => {
+      this.forfeit(match.id, playerId);
+    }, this.afkTimeout);
+  }
+
+  submitMove(matchId, playerId, move) {
+    const match = this.matches.get(matchId);
+    if (!match || match.status !== 'active') return { error: 'not_active' };
+    const current = match.players[match.turn % match.players.length];
+    if (current.id !== playerId) {
+      return { error: 'not_your_turn' };
+    }
+    match.moves.push({ playerId, move });
+    match.turn++;
+    match.players.forEach((p) => this.resetAfkTimer(match, p.id));
+    this.emit('move', { match, playerId, move });
+    return { success: true };
+  }
+
+  endMatch(matchId, winnerId = null, reason = 'completed') {
+    const match = this.matches.get(matchId);
+    if (!match) return { error: 'not_found' };
+    match.status = 'ended';
+    match.winner = winnerId;
+    match.reason = reason;
+    match.players.forEach((p) => clearTimeout(p.afkTimer));
+    this.emit('match_ended', match);
+    this.matches.delete(matchId);
+    return { success: true };
+  }
+
+  forfeit(matchId, playerId) {
+    const match = this.matches.get(matchId);
+    if (!match || match.status !== 'active') return { error: 'not_active' };
+    const winner = match.players.find((p) => p.id !== playerId)?.id || null;
+    return this.endMatch(matchId, winner, 'forfeit');
+  }
+
+  rejoinMatch(matchId, playerId) {
+    const match = this.matches.get(matchId);
+    if (!match) return { error: 'not_found' };
+    this.resetAfkTimer(match, playerId);
+    return { success: true };
+  }
+
+  getState(matchId) {
+    const match = this.matches.get(matchId);
+    if (!match) return null;
+    return {
+      id: match.id,
+      gameId: match.gameId,
+      status: match.status,
+      turn: match.turn,
+      moves: match.moves,
+      players: match.players.map((p) => ({ id: p.id }))
+    };
+  }
+
+  tick() {
+    for (const match of this.matches.values()) {
+      if (match.status !== 'active') continue;
+      const current = match.players[match.turn % match.players.length];
+      const remaining = Math.max(0, current.deadline - Date.now());
+      this.emit('timer', {
+        matchId: match.id,
+        playerId: current.id,
+        remaining
+      });
+    }
+  }
+}

--- a/bot/orchestrator/socket.js
+++ b/bot/orchestrator/socket.js
@@ -1,0 +1,67 @@
+function playerRoom(id) {
+  return `player:${id}`;
+}
+
+export function initOrchestratorSocket(io, orchestrator) {
+  io.on('connection', (socket) => {
+    const { playerId } = socket.handshake.auth || {};
+    if (playerId) {
+      socket.join(playerRoom(playerId));
+    }
+
+    socket.on('match:move', ({ matchId, move }, cb) => {
+      const pid = playerId;
+      const res = orchestrator.submitMove(matchId, pid, move);
+      const event = res.error ? 'move.rejected' : 'move.accepted';
+      socket.emit(event, { matchId, move, error: res.error });
+      cb && cb(res);
+    });
+
+    socket.on('match:rejoin', ({ matchId }) => {
+      if (playerId) orchestrator.rejoinMatch(matchId, playerId);
+    });
+  });
+
+  orchestrator.on('match_ready', (match) => {
+    for (const p of match.players) {
+      io.to(playerRoom(p.id)).emit('match_ready', {
+        matchId: match.id,
+        gameId: match.gameId,
+        players: match.players.map((pl) => pl.id)
+      });
+    }
+  });
+
+  orchestrator.on('match_started', (match) => {
+    for (const p of match.players) {
+      io.to(playerRoom(p.id)).emit('match_started', { matchId: match.id });
+    }
+  });
+
+  orchestrator.on('move', ({ match, playerId, move }) => {
+    for (const p of match.players) {
+      io.to(playerRoom(p.id)).emit('state', {
+        matchId: match.id,
+        turn: match.turn,
+        lastMove: { playerId, move }
+      });
+    }
+  });
+
+  orchestrator.on('timer', ({ matchId, playerId, remaining }) => {
+    io.to(playerRoom(playerId)).emit('timer.tick', {
+      matchId,
+      remaining
+    });
+  });
+
+  orchestrator.on('match_ended', (match) => {
+    for (const p of match.players) {
+      io.to(playerRoom(p.id)).emit('match_end', {
+        matchId: match.id,
+        winner: match.winner,
+        reason: match.reason
+      });
+    }
+  });
+}

--- a/bot/routes/orchestrator.js
+++ b/bot/routes/orchestrator.js
@@ -1,0 +1,63 @@
+import express from 'express';
+
+export default function orchestratorRoutes(orchestrator) {
+  const router = express.Router();
+
+  router.get('/healthz', (req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  router.post('/queue/join', (req, res) => {
+    const { playerId, gameId } = req.body || {};
+    res.json(orchestrator.joinQueue(playerId, gameId));
+  });
+
+  router.post('/queue/leave', (req, res) => {
+    const { playerId, gameId } = req.body || {};
+    res.json(orchestrator.leaveQueue(playerId, gameId));
+  });
+
+  router.get('/queue/status/:gameId', (req, res) => {
+    const gameId = req.params.gameId;
+    const q = orchestrator.queue.get(gameId) || [];
+    res.json({ size: q.length });
+  });
+
+  router.post('/match/claim', (req, res) => {
+    const { matchId, playerId } = req.body || {};
+    res.json(orchestrator.claimMatch(matchId, playerId));
+  });
+
+  router.post('/match/start', (req, res) => {
+    const { matchId } = req.body || {};
+    res.json(orchestrator.startMatch(matchId));
+  });
+
+  router.get('/match/state/:matchId', (req, res) => {
+    const state = orchestrator.getState(req.params.matchId);
+    if (!state) return res.status(404).json({ error: 'not_found' });
+    res.json(state);
+  });
+
+  router.post('/match/move', (req, res) => {
+    const { matchId, playerId, move } = req.body || {};
+    res.json(orchestrator.submitMove(matchId, playerId, move));
+  });
+
+  router.post('/match/end', (req, res) => {
+    const { matchId, winnerId, reason } = req.body || {};
+    res.json(orchestrator.endMatch(matchId, winnerId, reason));
+  });
+
+  router.post('/match/forfeit', (req, res) => {
+    const { matchId, playerId } = req.body || {};
+    res.json(orchestrator.forfeit(matchId, playerId));
+  });
+
+  router.post('/match/rejoin', (req, res) => {
+    const { matchId, playerId } = req.body || {};
+    res.json(orchestrator.rejoinMatch(matchId, playerId));
+  });
+
+  return router;
+}

--- a/bot/server.js
+++ b/bot/server.js
@@ -38,6 +38,9 @@ import PostRecord from './models/PostRecord.js';
 import Task from './models/Task.js';
 import WatchRecord from './models/WatchRecord.js';
 import ActiveConnection from './models/ActiveConnection.js';
+import orchestratorRoutes from './routes/orchestrator.js';
+import { MatchmakingOrchestrator } from './orchestrator/orchestrator.js';
+import { initOrchestratorSocket } from './orchestrator/socket.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, writeFileSync } from 'fs';
@@ -106,6 +109,8 @@ const io = initSocket(httpServer, {
   pingInterval: 25000,
   pingTimeout: 60000
 });
+const orchestrator = new MatchmakingOrchestrator();
+initOrchestratorSocket(io, orchestrator);
 const gameManager = new GameRoomManager(io);
 
 // Expose socket.io instance and userSockets map for routes
@@ -149,6 +154,8 @@ app.use('/api/social', socialRoutes);
 app.use('/api/broadcast', broadcastRoutes);
 app.use('/api/store', storeRoutes);
 app.use('/api/online', onlineRoutes);
+app.use('/api/orchestrator', orchestratorRoutes(orchestrator));
+app.get('/healthz', (req, res) => res.json({ status: 'ok' }));
 
 app.post('/api/goal-rush/calibration', (req, res) => {
   const { accountId, calibration } = req.body || {};

--- a/test/orchestrator.test.js
+++ b/test/orchestrator.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { MatchmakingOrchestrator } from '../bot/orchestrator/orchestrator.js';
+
+function create() {
+  return new MatchmakingOrchestrator({ afkTimeout: 100 });
+}
+
+test('queue pairs players and emits match_ready', (t) => {
+  const orch = create();
+  let ready = 0;
+  orch.on('match_ready', (m) => {
+    ready++;
+    assert.equal(m.players.length, 2);
+  });
+  orch.joinQueue('p1', 'g');
+  orch.joinQueue('p2', 'g');
+  assert.equal(ready, 1);
+  const matchId = [...orch.matches.keys()][0];
+  assert.ok(matchId);
+  const match = orch.matches.get(matchId);
+  assert.equal(match.status, 'ready');
+});
+
+test('claims start the match', () => {
+  const orch = create();
+  orch.joinQueue('a', 'g');
+  orch.joinQueue('b', 'g');
+  const matchId = [...orch.matches.keys()][0];
+  orch.claimMatch(matchId, 'a');
+  orch.claimMatch(matchId, 'b');
+  const match = orch.matches.get(matchId);
+  assert.equal(match.status, 'active');
+});
+
+test('enforces turn order', () => {
+  const orch = create();
+  orch.joinQueue('p1', 'g');
+  orch.joinQueue('p2', 'g');
+  const matchId = [...orch.matches.keys()][0];
+  orch.claimMatch(matchId, 'p1');
+  orch.claimMatch(matchId, 'p2');
+  const resWrong = orch.submitMove(matchId, 'p2', { x: 1 });
+  assert.equal(resWrong.error, 'not_your_turn');
+  const resRight = orch.submitMove(matchId, 'p1', { x: 1 });
+  assert.equal(resRight.success, true);
+});
+
+test('afk player forfeits', async () => {
+  const orch = create();
+  orch.joinQueue('p1', 'g');
+  orch.joinQueue('p2', 'g');
+  const matchId = [...orch.matches.keys()][0];
+  orch.claimMatch(matchId, 'p1');
+  orch.claimMatch(matchId, 'p2');
+  await new Promise((r) => setTimeout(r, 150));
+  assert.equal(orch.matches.size, 0);
+});


### PR DESCRIPTION
## Summary
- add matchmaking orchestrator with queues, matches, AFK timers and event hooks
- expose orchestrator REST endpoints and websocket events
- provide unit tests for queue pairing, lifecycle, turn order and AFK forfeit

## Testing
- `node --test test/orchestrator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b72a5784648329acb8078300147884