### PR TITLE
Align Pool Royale bracket with Goal Rush

### DIFF
--- a/webapp/public/poll-royale-bracket.html
+++ b/webapp/public/poll-royale-bracket.html
@@ -228,7 +228,7 @@
       label = 'FINAL 🏆 ';
       ctx.fillText(label, x, topPad + 10);
       let imgX = x + ctx.measureText(label).width + 2;
-      if (tpcImg.complete){
+      if (tpcImg.complete) {
         ctx.drawImage(tpcImg, imgX, topPad, 12, 12);
         imgX += 16;
       }
@@ -284,13 +284,6 @@
     hitRegions.push({round:r, match:m, slot:1, x:x+4, y:y+slotH+2, w:w-8, h:slotH-6});
   }
 
-  function matchPlayers(r,m){
-    const [sA, sB] = state.rounds[r][m] || [];
-    const playerA = state.seedToPlayer[sA] || { name: 'TBD' };
-    const playerB = state.seedToPlayer[sB] || { name: 'TBD' };
-    return [playerA, playerB];
-  }
-
   function coinConfetti(count=20){
     const container=document.createElement('div');
     container.style.position='fixed';container.style.top='0';container.style.left='0';
@@ -306,6 +299,13 @@
       container.appendChild(img);
     }
     setTimeout(()=>container.remove(),5000);
+  }
+
+  function matchPlayers(r,m){
+    const [sA, sB] = state.rounds[r][m] || [];
+    const playerA = state.seedToPlayer[sA] || { name: 'TBD' };
+    const playerB = state.seedToPlayer[sB] || { name: 'TBD' };
+    return [playerA, playerB];
   }
 
   function renderPlayer(player, x, y, slotH){
@@ -433,7 +433,7 @@
         if(opp && opp.name==='BYE'){
           if(st.rounds[r+1]) st.rounds[r+1][Math.floor(i/2)][i%2]=userSeed;
           simulateRoundAI(st, r);
-          if(st.rounds[r].every(function(p,idx){ return st.rounds[r+1][Math.floor(idx/2)][idx%2]; })){
+          if(st.rounds[r].every((p,idx)=> st.rounds[r+1][Math.floor(idx/2)][idx%2])){
             st.currentRound++;
           }
           localStorage.setItem(STATE_KEY, JSON.stringify(st));
@@ -454,23 +454,15 @@
     const opponentSeed = info.pair[0] === st.userSeed ? info.pair[1] : info.pair[0];
     localStorage.setItem(OPP_KEY, JSON.stringify(st.seedToPlayer[opponentSeed]));
     localStorage.setItem(STATE_KEY, JSON.stringify(st));
-    const search = new URLSearchParams(window.location.search);
-    search.set('type', 'tournament');
-    window.location.href = '/poll-royale.html?' + search.toString();
+    window.location.href = '/poll-royale.html' + window.location.search;
   }
 
   (function init(){
     const totalPlayers = parseInt(params.get('players') || '8', 10);
     const saved = localStorage.getItem(STATE_KEY);
     if(saved){
-      try{
-        const parsed = JSON.parse(saved);
-        if(parsed.N === totalPlayers){
-          state = parsed;
-        }
-      }catch{}
-    }
-    if(!state.rounds.length){
+      state = JSON.parse(saved);
+    } else {
       const userName = params.get('name') || 'You';
       const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
       function flagToName(flag){
@@ -482,7 +474,7 @@
       shuffle(flags);
       const players = [{ name: userName, flag: params.get('flag') || '🏳️' }];
       for(let i=0;i<totalPlayers-1;i++){
-        const f = flags[i];
+        const f=flags[i];
         players.push({ name: flagToName(f), flag: f });
       }
       state.players = players;
@@ -539,13 +531,9 @@
       av.style.alignItems='center';av.style.justifyContent='center';av.style.fontSize='64px';
       av.textContent=champ.flag||'';overlay.appendChild(av);
       const last=JSON.parse(localStorage.getItem(`pollRoyaleLastResult_${tgKey}`)||'{}');
-      if(last.variant==='american'){
-        const res=document.createElement('div');res.style.color='#fff';res.style.marginTop='8px';res.textContent=`${last.scores?.[1]||0}-${last.scores?.[2]||0}`;
+      if(last.p1!=null && last.p2!=null){
+        const res=document.createElement('div');res.style.color='#fff';res.style.marginTop='8px';res.textContent=`${last.p1}-${last.p2}`;
         overlay.appendChild(res);
-      } else {
-        const img=document.createElement('img');img.style.width='40px';img.style.height='40px';img.style.marginTop='8px';
-        img.src = last.variant==='9ball'?'/assets/icons/Yellowball.webp':'/assets/icons/BlackBall.webp';
-        overlay.appendChild(img);
       }
       const prize=document.createElement('div');
       prize.style.display='flex';prize.style.alignItems='center';prize.style.gap='4px';prize.style.marginTop='8px';

--- a/webapp/public/poll-royale.html
+++ b/webapp/public/poll-royale.html
@@ -627,24 +627,6 @@
         border-radius: 4px;
       }
 
-      #tournamentOverlay {
-        position: fixed;
-        inset: 0;
-        background: #111;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        z-index: 400;
-      }
-      #tournamentOverlay.hidden {
-        display: none;
-      }
-      #tournamentOverlay canvas {
-        background: #fff;
-        width: 95vw;
-        height: 95vh;
-        border: 1px solid #000;
-      }
 
       #rulesModal {
         position: fixed;
@@ -3624,10 +3606,6 @@
         <button id="practiceAi">Practice vs AI</button>
         <button id="restartTraining">New Game</button>
       </div>
-    </div>
-
-    <div id="tournamentOverlay" class="hidden">
-      <canvas id="bracket"></canvas>
     </div>
 
     <script>


### PR DESCRIPTION
## Summary
- reuse Goal Rush bracket logic for Pool Royale
- remove in-game tournament overlay from Pool Royale

## Testing
- `npm test`
- `npm run lint` *(fails: 965 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b73f9db7b88329ad951f38d2178b68