### PR TITLE
Fix Pool Royale tournament progression

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3714,15 +3714,11 @@
             var oppSeed = st.pendingMatch.pair[0] === st.userSeed ? st.pendingMatch.pair[1] : st.pendingMatch.pair[0];
             var winnerSeed = winner === 1 ? st.userSeed : oppSeed;
             var next = st.rounds[r + 1];
-            if (!next && r < st.rounds.length - 1) {
-              st.rounds[r + 1] = Array.from({ length: Math.ceil(st.rounds[r].length / 2) }, () => [0, 0]);
-              next = st.rounds[r + 1];
-            }
-            if (r >= st.rounds.length - 1) {
+            if (next) {
+              next[Math.floor(m / 2)][m % 2] = winnerSeed;
+            } else {
               st.championSeed = winnerSeed;
               st.complete = true;
-            } else if (next) {
-              next[Math.floor(m / 2)][m % 2] = winnerSeed;
             }
             if (winnerSeed !== st.userSeed) {
               simulateRemaining(st, r);


### PR DESCRIPTION
## Summary
- ensure Pool Royale tournament bracket advances correctly without early completion

## Testing
- `npm test` *(fails: process did not exit - manual interruption)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ccad35d48329a24b3384153347e3