### PR TITLE
Fix Pool Royale tournament result handling

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -1224,7 +1224,8 @@
                 JSON.stringify({ scores, variant })
               );
             } catch {}
-            window.handleTournamentResult(Number(winner));
+            const result = Number(winner) === 1 ? 1 : 2;
+            window.handleTournamentResult(result);
             return;
           }
           var overlay = document.getElementById('winnerOverlay');
@@ -3709,19 +3710,37 @@
       if (params.get('type') === 'tournament') {
         window.handleTournamentResult = async function (winner) {
           try {
-            winner = Number(winner);
+            winner = Number(winner) === 1 ? 1 : 2;
             var st = JSON.parse(localStorage.getItem(STATE_KEY) || '{}');
             if (!st.pendingMatch) {
               window.location.href = '/pool-royale-bracket.html?' + window.location.search.slice(1);
               return;
             }
-            var r = st.pendingMatch.round;
-            var m = st.pendingMatch.match;
-            var oppSeed =
+            var r = Number(st.pendingMatch.round);
+            var m = Number(st.pendingMatch.match);
+            if (
+              typeof st.currentRound === 'number' &&
+              st.currentRound !== r
+            ) {
+              window.location.href = '/pool-royale-bracket.html?' + window.location.search.slice(1);
+              return;
+            }
+            var pair = st.rounds && st.rounds[r] && st.rounds[r][m];
+            if (
+              !pair ||
+              Number(pair[0]) !== Number(st.pendingMatch.pair[0]) ||
+              Number(pair[1]) !== Number(st.pendingMatch.pair[1])
+            ) {
+              window.location.href = '/pool-royale-bracket.html?' + window.location.search.slice(1);
+              return;
+            }
+            var userSeedNum = Number(st.userSeed);
+            var oppSeed = Number(
               st.pendingMatch.pair[0] === st.userSeed
                 ? st.pendingMatch.pair[1]
-                : st.pendingMatch.pair[0];
-            var winnerSeed = winner === 1 ? st.userSeed : oppSeed;
+                : st.pendingMatch.pair[0]
+            );
+            var winnerSeed = winner === 1 ? userSeedNum : oppSeed;
             var next = st.rounds[r + 1];
             if (next) {
               next[Math.floor(m / 2)][m % 2] = winnerSeed;
@@ -3729,7 +3748,7 @@
               st.championSeed = winnerSeed;
               st.complete = true;
             }
-            if (Number(winnerSeed) !== Number(st.userSeed)) {
+            if (winnerSeed !== userSeedNum) {
               simulateRemaining(st, r);
             } else {
               simulateRoundAI(st, r);
@@ -3742,7 +3761,7 @@
                 st.currentRound++;
               }
             }
-            if (st.complete && winnerSeed === st.userSeed && stake > 0 && accountId) {
+            if (st.complete && winnerSeed === userSeedNum && stake > 0 && accountId) {
               const total = stake * window.tournamentPlayers;
               const prize = Math.round(total * 0.91);
               try {


### PR DESCRIPTION
## Summary
- sanitize winner inputs and validate round before applying Pool Royale tournament results
- run remaining simulations only when the player loses and advance user rounds reliably

## Testing
- `node - <<'NODE'...` (8/16/24 players champion after final: true)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7f8a6dfb08329a0a25a0678897b3d