### PR TITLE
feat: centralize tournament logic

### DIFF
--- a/webapp/public/README.md
+++ b/webapp/public/README.md
@@ -1,0 +1,34 @@
+# Tournament utilities
+
+`tournament-utils.js` centralizes logic shared by tournament game pages.
+
+## Exports
+- `handleTournamentResult(winner, options)` – updates bracket state and performs payouts.
+- `simulateRoundAI(state, round)` – advances non-player matches for a round.
+- `simulateRemaining(state, startRound)` – simulates the rest of the bracket.
+
+## Basic use
+```html
+<script type="module">
+import { handleTournamentResult } from './tournament-utils.js';
+
+if (window.tournamentMode) {
+  window.handleTournamentResult = (winner) =>
+    handleTournamentResult(winner, {
+      stateKey: STATE_KEY,
+      oppKey: OPP_KEY,
+      bracketPage: '/pool-royale-bracket.html',
+      stake: window.stake,
+      players: window.tournamentPlayers,
+      accountId: window.accountId,
+      awardPrize: async (total) => {
+        // game specific payout logic
+      }
+    });
+}
+</script>
+```
+
+`awardPrize` receives the total pot (`stake * players`) and should deposit
+winnings and developer shares as required by the game. Import the other
+utilities directly if bracket pages need to simulate matches.

--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -1923,98 +1923,70 @@ function drawStaticOnce(){ drawField(); drawAds(); drawGoal(); resetBall(); draw
     startCountdown(3);
   }
 
-  if (params.get('type') === 'tournament') {
-    window.handleTournamentResult = async function (winner) {
-      try {
-        var st = JSON.parse(localStorage.getItem(STATE_KEY) || '{}');
-        if (!st.pendingMatch) {
-          window.location.href = '/free-kick-bracket.html?' + window.location.search.slice(1);
-          return;
-        }
-        var r = st.pendingMatch.round;
-        var m = st.pendingMatch.match;
-        var oppSeed = st.pendingMatch.pair[0] === st.userSeed ? st.pendingMatch.pair[1] : st.pendingMatch.pair[0];
-        var winnerSeed = winner === 1 ? st.userSeed : oppSeed;
-        var next = st.rounds[r + 1];
-        if (next) {
-          next[Math.floor(m / 2)][m % 2] = winnerSeed;
-        } else {
-          st.championSeed = winnerSeed;
-          st.complete = true;
-        }
-        if (winnerSeed !== st.userSeed) {
-          simulateRemaining(st, r);
-        } else {
-          simulateRoundAI(st, r);
-          if (next && st.rounds[r].every(function(p, idx){ return next[Math.floor(idx/2)][idx%2]; })) {
-            st.currentRound++;
-          }
-        }
-        if (st.complete && winnerSeed === st.userSeed && stake > 0 && accountId) {
-        const total = stake * window.tournamentPlayers;
-        const prize = Math.round(total * 0.91);
-        try {
-          await fkApi.depositAccount(accountId, prize, { game: 'freekick-win' });
-          if (tgId) await fkApi.addTransaction(tgId, 0, 'win', { game: 'freekick', players: window.tournamentPlayers, accountId });
-          const ops = [];
-          if (devAccount1 || devAccount2) {
-            if (devAccount) ops.push(fkApi.depositAccount(devAccount, Math.round(total*0.09), { game: 'freekick-dev' }));
-            if (devAccount1) ops.push(fkApi.depositAccount(devAccount1, Math.round(total*0.01), { game: 'freekick-dev1' }));
-            if (devAccount2) ops.push(fkApi.depositAccount(devAccount2, Math.round(total*0.02), { game: 'freekick-dev2' }));
-          } else if (devAccount) {
-            ops.push(fkApi.depositAccount(devAccount, Math.round(total*0.1), { game: 'freekick-dev' }));
-          }
-          if (ops.length) await Promise.all(ops);
-        } catch {}
-        }
-        delete st.pendingMatch;
-        localStorage.setItem(STATE_KEY, JSON.stringify(st));
-        localStorage.removeItem(OPP_KEY);
-      } catch (err) {
-        console.error(err);
-      }
-      window.location.href = '/free-kick-bracket.html?' + window.location.search.slice(1);
-    };
-
-    function simulateRoundAI(st, round){
-      var next = st.rounds[round + 1];
-      var userSeed = st.userSeed;
-      st.rounds[round].forEach(function(pair, idx){
-        if(pair.includes(userSeed)) return;
-        if(next && next[Math.floor(idx/2)][idx%2]) return;
-        var s1 = pair[0];
-        var s2 = pair[1];
-        var p1 = st.seedToPlayer[s1];
-        var p2 = st.seedToPlayer[s2];
-        var w;
-        if(p1 && p1.name === 'BYE') w = s2;
-        else if(p2 && p2.name === 'BYE') w = s1;
-        else w = Math.random() < 0.5 ? s1 : s2;
-        if(next){
-          next[Math.floor(idx/2)][idx%2] = w;
-        } else {
-          st.championSeed = w;
-          st.complete = true;
-        }
-      });
+    if (params.get('type') === 'tournament') {
+      // Tournament utilities loaded below
     }
-
-    function simulateRemaining(st, startRound){
-      for(var r = startRound; r < st.rounds.length; r++){
-        simulateRoundAI(st, r);
-        if(st.complete) break;
-      }
-      st.currentRound = st.rounds.length - 1;
-      st.complete = true;
-    }
-  }
 
   boot();
   document.getElementById('lobbyBtn').addEventListener('click', ()=>{ location.href='/games/freekick/lobby'; });
 })();
-</script>
-<script>
-if(window.tournamentMode){
+  </script>
+  <script type="module">
+  import { handleTournamentResult } from './tournament-utils.js';
+  if (window.tournamentMode) {
+    window.handleTournamentResult = (winner) =>
+      handleTournamentResult(winner, {
+        stateKey: STATE_KEY,
+        oppKey: OPP_KEY,
+        bracketPage: '/free-kick-bracket.html',
+        stake: window.stake,
+        players: window.tournamentPlayers,
+        accountId: accountId,
+        awardPrize: async (total) => {
+          const prize = Math.round(total * 0.91);
+          try {
+            await fkApi.depositAccount(accountId, prize, { game: 'freekick-win' });
+            if (tgId)
+              await fkApi.addTransaction(tgId, 0, 'win', {
+                game: 'freekick',
+                players: window.tournamentPlayers,
+                accountId
+              });
+            const ops = [];
+            if (devAccount1 || devAccount2) {
+              if (devAccount)
+                ops.push(
+                  fkApi.depositAccount(devAccount, Math.round(total * 0.09), {
+                    game: 'freekick-dev'
+                  })
+                );
+              if (devAccount1)
+                ops.push(
+                  fkApi.depositAccount(devAccount1, Math.round(total * 0.01), {
+                    game: 'freekick-dev1'
+                  })
+                );
+              if (devAccount2)
+                ops.push(
+                  fkApi.depositAccount(devAccount2, Math.round(total * 0.02), {
+                    game: 'freekick-dev2'
+                  })
+                );
+            } else if (devAccount) {
+              ops.push(
+                fkApi.depositAccount(devAccount, Math.round(total * 0.1), {
+                  game: 'freekick-dev'
+                })
+              );
+            }
+            if (ops.length) await Promise.all(ops);
+          } catch {}
+        }
+      });
+  }
+  </script>
+  <script>
+  if(window.tournamentMode){
   const tg = window.Telegram?.WebApp;
   function showExitPopup(){
     if(document.getElementById('tournExit')) return;

--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -1097,87 +1097,35 @@
   window.addEventListener('orientationchange', checkOrientation);
 
   if (params.get('type') === 'tournament') {
-    window.handleTournamentResult = async function (winner) {
-      try {
-        var st = JSON.parse(localStorage.getItem(TOURN_STATE_KEY) || '{}');
-        if (!st.pendingMatch) {
-          window.location.href = '/goal-rush-bracket.html?' + window.location.search.slice(1);
-          return;
-        }
-        var r = st.pendingMatch.round;
-        var m = st.pendingMatch.match;
-        var oppSeed = st.pendingMatch.pair[0] === st.userSeed ? st.pendingMatch.pair[1] : st.pendingMatch.pair[0];
-        var winnerSeed = winner === 1 ? st.userSeed : oppSeed;
-        var next = st.rounds[r + 1];
-        if (next) {
-          next[Math.floor(m / 2)][m % 2] = winnerSeed;
-        } else {
-          st.championSeed = winnerSeed;
-          st.complete = true;
-        }
-        if (winnerSeed !== st.userSeed) {
-          simulateRemaining(st, r);
-        } else {
-          simulateRoundAI(st, r);
-          if (next && st.rounds[r].every(function (p, idx) { return next[Math.floor(idx / 2)][idx % 2]; })) {
-            st.currentRound++;
-          }
-        }
-        if (st.complete && winnerSeed === st.userSeed && stake > 0 && myAccountId) {
-          const total = stake * window.tournamentPlayers;
-          const prize = Math.round(total * 0.91);
-          try {
-            await awardTpc(myAccountId, prize);
-            if (tgId) await recordWin(tgId, myAccountId);
-            await awardDevShare(total);
-          } catch {}
-        }
-        delete st.pendingMatch;
-        localStorage.setItem(TOURN_STATE_KEY, JSON.stringify(st));
-        localStorage.removeItem(TOURN_OPP_KEY);
-      } catch (err) {
-        console.error(err);
-      }
-      window.location.href = '/goal-rush-bracket.html?' + window.location.search.slice(1);
-    };
-
-    function simulateRoundAI(st, round) {
-      var next = st.rounds[round + 1];
-      var userSeed = st.userSeed;
-      st.rounds[round].forEach(function (pair, idx) {
-        if (pair.includes(userSeed)) return;
-        if (next && next[Math.floor(idx / 2)][idx % 2]) return;
-        var s1 = pair[0];
-        var s2 = pair[1];
-        var p1 = st.seedToPlayer[s1];
-        var p2 = st.seedToPlayer[s2];
-        var w;
-        if (p1 && p1.name === 'BYE') w = s2;
-        else if (p2 && p2.name === 'BYE') w = s1;
-        else w = Math.random() < 0.5 ? s1 : s2;
-        if (next) {
-          next[Math.floor(idx / 2)][idx % 2] = w;
-        } else {
-          st.championSeed = w;
-          st.complete = true;
-        }
-      });
-    }
-
-    function simulateRemaining(st, startRound) {
-      for (var r = startRound; r < st.rounds.length; r++) {
-        simulateRoundAI(st, r);
-        if (st.complete) break;
-      }
-      st.currentRound = st.rounds.length - 1;
-      st.complete = true;
-    }
+    // Tournament utilities loaded below
   }
 
   fit(); checkOrientation(); resetPositions(); updateScore(); playWhistle();
   document.body.classList.add('loaded');
   requestAnimationFrame(loop);
   })();
+</script>
+<script type="module">
+import { handleTournamentResult } from './tournament-utils.js';
+if (window.tournamentMode) {
+  window.handleTournamentResult = (winner) =>
+    handleTournamentResult(winner, {
+      stateKey: TOURN_STATE_KEY,
+      oppKey: TOURN_OPP_KEY,
+      bracketPage: '/goal-rush-bracket.html',
+      stake: window.stake,
+      players: window.tournamentPlayers,
+      accountId: myAccountId,
+      awardPrize: async (total) => {
+        const prize = Math.round(total * 0.91);
+        try {
+          await awardTpc(myAccountId, prize);
+          if (tgId) await recordWin(tgId, myAccountId);
+          await awardDevShare(total);
+        } catch {}
+      }
+    });
+}
 </script>
 <script>
 if(window.tournamentMode){

--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3709,116 +3709,7 @@
       }
 
       if (params.get('type') === 'tournament') {
-        window.handleTournamentResult = async function (winner) {
-          try {
-            winner = Number(winner) === 1 ? 1 : 2;
-            var st = JSON.parse(localStorage.getItem(STATE_KEY) || '{}');
-            if (!st.pendingMatch) {
-              window.location.href = '/pool-royale-bracket.html?' + window.location.search.slice(1);
-              return;
-            }
-            var r = Number(st.pendingMatch.round);
-            var m = Number(st.pendingMatch.match);
-            if (
-              typeof st.currentRound === 'number' &&
-              st.currentRound !== r
-            ) {
-              window.location.href = '/pool-royale-bracket.html?' + window.location.search.slice(1);
-              return;
-            }
-            var pair = st.rounds && st.rounds[r] && st.rounds[r][m];
-            if (
-              !pair ||
-              Number(pair[0]) !== Number(st.pendingMatch.pair[0]) ||
-              Number(pair[1]) !== Number(st.pendingMatch.pair[1])
-            ) {
-              window.location.href = '/pool-royale-bracket.html?' + window.location.search.slice(1);
-              return;
-            }
-            var userSeedNum = Number(st.userSeed);
-            var oppSeed = Number(
-              st.pendingMatch.pair[0] === st.userSeed
-                ? st.pendingMatch.pair[1]
-                : st.pendingMatch.pair[0]
-            );
-            var winnerSeed = winner === 1 ? userSeedNum : oppSeed;
-            var next = st.rounds[r + 1];
-            if (next) {
-              next[Math.floor(m / 2)][m % 2] = winnerSeed;
-            } else {
-              st.championSeed = winnerSeed;
-              st.complete = true;
-            }
-            if (winnerSeed !== userSeedNum) {
-              simulateRemaining(st, r);
-            } else {
-              simulateRoundAI(st, r);
-              if (
-                next &&
-                st.rounds[r].every(function (p, idx) {
-                  return next[Math.floor(idx / 2)][idx % 2];
-                })
-              ) {
-                st.currentRound++;
-              }
-            }
-            if (st.complete && winnerSeed === userSeedNum && stake > 0 && accountId) {
-              const total = stake * window.tournamentPlayers;
-              const prize = Math.round(total * 0.91);
-              try {
-                await prApi.depositAccount(accountId, prize, { game: 'poolroyale-win' });
-                if (tgId) await prApi.addTransaction(tgId, 0, 'win', { game: 'poolroyale', players: window.tournamentPlayers, accountId });
-                const ops = [];
-                if (devAccount1 || devAccount2) {
-                  if (devAccount) ops.push(prApi.depositAccount(devAccount, Math.round(total * 0.09), { game: 'poolroyale-dev' }));
-                  if (devAccount1) ops.push(prApi.depositAccount(devAccount1, Math.round(total * 0.01), { game: 'poolroyale-dev1' }));
-                  if (devAccount2) ops.push(prApi.depositAccount(devAccount2, Math.round(total * 0.02), { game: 'poolroyale-dev2' }));
-                } else if (devAccount) {
-                  ops.push(prApi.depositAccount(devAccount, Math.round(total * 0.1), { game: 'poolroyale-dev' }));
-                }
-                if (ops.length) await Promise.all(ops);
-              } catch {}
-            }
-            delete st.pendingMatch;
-            localStorage.setItem(STATE_KEY, JSON.stringify(st));
-            localStorage.removeItem(OPP_KEY);
-          } catch (err) {
-            console.error(err);
-          }
-          window.location.href = '/pool-royale-bracket.html?' + window.location.search.slice(1);
-        };
-
-        function simulateRoundAI(st, round) {
-          var next = st.rounds[round + 1];
-          var userSeed = st.userSeed;
-          st.rounds[round].forEach(function (pair, idx) {
-            if (pair.includes(userSeed)) return;
-            if (next && next[Math.floor(idx / 2)][idx % 2]) return;
-            var s1 = pair[0];
-            var s2 = pair[1];
-            var p1 = st.seedToPlayer[s1];
-            var p2 = st.seedToPlayer[s2];
-            var w;
-            if (p1 && p1.name === 'BYE') w = s2;
-            else if (p2 && p2.name === 'BYE') w = s1;
-            else w = Math.random() < 0.5 ? s1 : s2;
-            if (next) {
-              next[Math.floor(idx / 2)][idx % 2] = w;
-            } else {
-              st.championSeed = w;
-              st.complete = true;
-            }
-          });
-        }
-
-        function simulateRemaining(st, startRound) {
-          for (var r = startRound; r < st.rounds.length; r++) {
-            simulateRoundAI(st, r);
-            if (st.complete) break;
-          }
-          st.currentRound = st.rounds.length - 1;
-          st.complete = true;
-        }
+        // Tournament utilities loaded below
       }
 
       // Rotate corner holes diagonally; keep side holes horizontal
@@ -3832,6 +3723,60 @@
           }
         });
       }
+</script>
+<script type="module">
+import { handleTournamentResult } from './tournament-utils.js';
+if (window.tournamentMode) {
+  window.handleTournamentResult = (winner) =>
+    handleTournamentResult(winner, {
+      stateKey: STATE_KEY,
+      oppKey: OPP_KEY,
+      bracketPage: '/pool-royale-bracket.html',
+      stake: window.stake,
+      players: window.tournamentPlayers,
+      accountId: window.accountId,
+      awardPrize: async (total) => {
+        const prize = Math.round(total * 0.91);
+        try {
+          await prApi.depositAccount(window.accountId, prize, { game: 'poolroyale-win' });
+          if (tgId)
+            await prApi.addTransaction(tgId, 0, 'win', {
+              game: 'poolroyale',
+              players: window.tournamentPlayers,
+              accountId: window.accountId
+            });
+          const ops = [];
+          if (devAccount1 || devAccount2) {
+            if (devAccount)
+              ops.push(
+                prApi.depositAccount(devAccount, Math.round(total * 0.09), {
+                  game: 'poolroyale-dev'
+                })
+              );
+            if (devAccount1)
+              ops.push(
+                prApi.depositAccount(devAccount1, Math.round(total * 0.01), {
+                  game: 'poolroyale-dev1'
+                })
+              );
+            if (devAccount2)
+              ops.push(
+                prApi.depositAccount(devAccount2, Math.round(total * 0.02), {
+                  game: 'poolroyale-dev2'
+                })
+              );
+          } else if (devAccount) {
+            ops.push(
+              prApi.depositAccount(devAccount, Math.round(total * 0.1), {
+                game: 'poolroyale-dev'
+              })
+            );
+          }
+          if (ops.length) await Promise.all(ops);
+        } catch {}
+      }
+    });
+}
 </script>
 <script>
 if(window.tournamentMode){

--- a/webapp/public/tournament-utils.js
+++ b/webapp/public/tournament-utils.js
@@ -1,0 +1,106 @@
+export function simulateRoundAI(st, round) {
+  const next = st.rounds[round + 1];
+  const userSeed = st.userSeed;
+  st.rounds[round].forEach((pair, idx) => {
+    if (pair.includes(userSeed)) return;
+    if (next && next[Math.floor(idx / 2)][idx % 2]) return;
+    const s1 = pair[0];
+    const s2 = pair[1];
+    const p1 = st.seedToPlayer[s1];
+    const p2 = st.seedToPlayer[s2];
+    let w;
+    if (p1 && p1.name === 'BYE') w = s2;
+    else if (p2 && p2.name === 'BYE') w = s1;
+    else w = Math.random() < 0.5 ? s1 : s2;
+    if (next) {
+      next[Math.floor(idx / 2)][idx % 2] = w;
+    } else {
+      st.championSeed = w;
+      st.complete = true;
+    }
+  });
+}
+
+export function simulateRemaining(st, startRound) {
+  for (let r = startRound; r < st.rounds.length; r++) {
+    simulateRoundAI(st, r);
+    if (st.complete) break;
+  }
+  st.currentRound = st.rounds.length - 1;
+  st.complete = true;
+}
+
+export async function handleTournamentResult(winner, opts) {
+  const {
+    stateKey,
+    oppKey,
+    bracketPage,
+    stake = 0,
+    players = 0,
+    accountId,
+    awardPrize
+  } = opts;
+  try {
+    const st = JSON.parse(localStorage.getItem(stateKey) || '{}');
+    if (!st.pendingMatch) {
+      window.location.href = `${bracketPage}?${window.location.search.slice(1)}`;
+      return;
+    }
+    const r = Number(st.pendingMatch.round);
+    const m = Number(st.pendingMatch.match);
+    if (typeof st.currentRound === 'number' && st.currentRound !== r) {
+      window.location.href = `${bracketPage}?${window.location.search.slice(1)}`;
+      return;
+    }
+    const pair = st.rounds && st.rounds[r] && st.rounds[r][m];
+    if (
+      !pair ||
+      Number(pair[0]) !== Number(st.pendingMatch.pair[0]) ||
+      Number(pair[1]) !== Number(st.pendingMatch.pair[1])
+    ) {
+      window.location.href = `${bracketPage}?${window.location.search.slice(1)}`;
+      return;
+    }
+    const userSeedNum = Number(st.userSeed);
+    const oppSeed = Number(
+      st.pendingMatch.pair[0] === st.userSeed
+        ? st.pendingMatch.pair[1]
+        : st.pendingMatch.pair[0]
+    );
+    const winnerSeed = Number(winner) === 1 ? userSeedNum : oppSeed;
+    const next = st.rounds[r + 1];
+    if (next) {
+      next[Math.floor(m / 2)][m % 2] = winnerSeed;
+    } else {
+      st.championSeed = winnerSeed;
+      st.complete = true;
+    }
+    if (winnerSeed !== userSeedNum) {
+      simulateRemaining(st, r);
+    } else {
+      simulateRoundAI(st, r);
+      if (
+        next &&
+        st.rounds[r].every((p, idx) => next[Math.floor(idx / 2)][idx % 2])
+      ) {
+        st.currentRound++;
+      }
+    }
+    if (st.complete && winnerSeed === userSeedNum && stake > 0 && accountId) {
+      const total = stake * players;
+      if (typeof awardPrize === 'function') {
+        try {
+          await awardPrize(total);
+        } catch {
+          // ignore payout errors
+        }
+      }
+    }
+    delete st.pendingMatch;
+    localStorage.setItem(stateKey, JSON.stringify(st));
+    if (oppKey) localStorage.removeItem(oppKey);
+  } catch (err) {
+    console.error(err);
+  }
+  window.location.href = `${bracketPage}?${window.location.search.slice(1)}`;
+}


### PR DESCRIPTION
## Summary
- add shared tournament utilities for bracket progression and payouts
- refactor pool-royale, goal-rush, and free-kick to consume new helpers
- document usage for future games

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b81d3a04708329ad7b151ead546b82