### PR TITLE
Align pool royale tournament progression

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3711,37 +3711,15 @@
       if (params.get('type') === 'tournament') {
         window.handleTournamentResult = async function (winner) {
           try {
-            winner = Number(winner) === 1 ? 1 : 2;
             var st = JSON.parse(localStorage.getItem(STATE_KEY) || '{}');
             if (!st.pendingMatch) {
               window.location.href = '/pool-royale-bracket.html?' + window.location.search.slice(1);
               return;
             }
-            var r = Number(st.pendingMatch.round);
-            var m = Number(st.pendingMatch.match);
-            if (
-              typeof st.currentRound === 'number' &&
-              st.currentRound !== r
-            ) {
-              window.location.href = '/pool-royale-bracket.html?' + window.location.search.slice(1);
-              return;
-            }
-            var pair = st.rounds && st.rounds[r] && st.rounds[r][m];
-            if (
-              !pair ||
-              Number(pair[0]) !== Number(st.pendingMatch.pair[0]) ||
-              Number(pair[1]) !== Number(st.pendingMatch.pair[1])
-            ) {
-              window.location.href = '/pool-royale-bracket.html?' + window.location.search.slice(1);
-              return;
-            }
-            var userSeedNum = Number(st.userSeed);
-            var oppSeed = Number(
-              st.pendingMatch.pair[0] === st.userSeed
-                ? st.pendingMatch.pair[1]
-                : st.pendingMatch.pair[0]
-            );
-            var winnerSeed = winner === 1 ? userSeedNum : oppSeed;
+            var r = st.pendingMatch.round;
+            var m = st.pendingMatch.match;
+            var oppSeed = st.pendingMatch.pair[0] === st.userSeed ? st.pendingMatch.pair[1] : st.pendingMatch.pair[0];
+            var winnerSeed = winner === 1 ? st.userSeed : oppSeed;
             var next = st.rounds[r + 1];
             if (next) {
               next[Math.floor(m / 2)][m % 2] = winnerSeed;
@@ -3749,20 +3727,15 @@
               st.championSeed = winnerSeed;
               st.complete = true;
             }
-            if (winnerSeed !== userSeedNum) {
+            if (winnerSeed !== st.userSeed) {
               simulateRemaining(st, r);
             } else {
               simulateRoundAI(st, r);
-              if (
-                next &&
-                st.rounds[r].every(function (p, idx) {
-                  return next[Math.floor(idx / 2)][idx % 2];
-                })
-              ) {
+              if (next && st.rounds[r].every(function (p, idx) { return next[Math.floor(idx / 2)][idx % 2]; })) {
                 st.currentRound++;
               }
             }
-            if (st.complete && winnerSeed === userSeedNum && stake > 0 && accountId) {
+            if (st.complete && winnerSeed === st.userSeed && stake > 0 && accountId) {
               const total = stake * window.tournamentPlayers;
               const prize = Math.round(total * 0.91);
               try {


### PR DESCRIPTION
## Summary
- Replace Pool Royale tournament handlers with Goal Rush equivalents using STATE_KEY/OPP_KEY and prApi
- Drop round and pair validation for smoother progression
- Keep AI simulation helpers in sync with Goal Rush

## Testing
- `npm test`
- Node script simulating tournament progression

------
https://chatgpt.com/codex/tasks/task_e_68b81d464b488329beb46c15551b848d