### PR TITLE
Fix Pool Royale tournament progression

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3711,37 +3711,15 @@
       if (params.get('type') === 'tournament') {
         window.handleTournamentResult = async function (winner) {
           try {
-            winner = Number(winner) === 1 ? 1 : 2;
             var st = JSON.parse(localStorage.getItem(STATE_KEY) || '{}');
             if (!st.pendingMatch) {
               window.location.href = '/pool-royale-bracket.html?' + window.location.search.slice(1);
               return;
             }
-            var r = Number(st.pendingMatch.round);
-            var m = Number(st.pendingMatch.match);
-            if (
-              typeof st.currentRound === 'number' &&
-              st.currentRound !== r
-            ) {
-              window.location.href = '/pool-royale-bracket.html?' + window.location.search.slice(1);
-              return;
-            }
-            var pair = st.rounds && st.rounds[r] && st.rounds[r][m];
-            if (
-              !pair ||
-              Number(pair[0]) !== Number(st.pendingMatch.pair[0]) ||
-              Number(pair[1]) !== Number(st.pendingMatch.pair[1])
-            ) {
-              window.location.href = '/pool-royale-bracket.html?' + window.location.search.slice(1);
-              return;
-            }
-            var userSeedNum = Number(st.userSeed);
-            var oppSeed = Number(
-              st.pendingMatch.pair[0] === st.userSeed
-                ? st.pendingMatch.pair[1]
-                : st.pendingMatch.pair[0]
-            );
-            var winnerSeed = winner === 1 ? userSeedNum : oppSeed;
+            var r = st.pendingMatch.round;
+            var m = st.pendingMatch.match;
+            var oppSeed = st.pendingMatch.pair[0] === st.userSeed ? st.pendingMatch.pair[1] : st.pendingMatch.pair[0];
+            var winnerSeed = winner === 1 ? st.userSeed : oppSeed;
             var next = st.rounds[r + 1];
             if (next) {
               next[Math.floor(m / 2)][m % 2] = winnerSeed;
@@ -3749,7 +3727,7 @@
               st.championSeed = winnerSeed;
               st.complete = true;
             }
-            if (winnerSeed !== userSeedNum) {
+            if (winnerSeed !== st.userSeed) {
               simulateRemaining(st, r);
             } else {
               simulateRoundAI(st, r);
@@ -3762,7 +3740,7 @@
                 st.currentRound++;
               }
             }
-            if (st.complete && winnerSeed === userSeedNum && stake > 0 && accountId) {
+            if (st.complete && winnerSeed === st.userSeed && stake > 0 && accountId) {
               const total = stake * window.tournamentPlayers;
               const prize = Math.round(total * 0.91);
               try {


### PR DESCRIPTION
## Summary
- Align Pool Royale tournament result handling with Goal Rush and Free Kick
- Remove extra validation that ended tournaments after first match

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b815def0f0832998e4585553fdc53a