### PR TITLE
Align Pool Royale bracket with Free Kick logic

### DIFF
--- a/webapp/public/pool-royale-bracket.html
+++ b/webapp/public/pool-royale-bracket.html
@@ -400,11 +400,13 @@
     }
   }
 
+
   function simulateRoundAI(st, round){
-    let next = st.rounds[round+1];
+    const next = st.rounds[round+1];
     const userSeed = st.userSeed;
     st.rounds[round].forEach((pair, idx) => {
       if(pair.includes(userSeed)) return;
+      if(next && next[Math.floor(idx/2)][idx%2]) return;
       const s1 = pair[0];
       const s2 = pair[1];
       const p1 = st.seedToPlayer[s1];
@@ -413,19 +415,11 @@
       if(p1 && p1.name==='BYE') w = s2;
       else if(p2 && p2.name==='BYE') w = s1;
       else w = Math.random() < 0.5 ? s1 : s2;
-
-      if(round === st.rounds.length - 1){
-        st.championSeed = w;
-        st.complete = true;
-      } else {
-        if(!next){
-          const matches = Math.ceil(st.rounds[round].length / 2);
-          next = st.rounds[round+1] = Array.from({length:matches}, () => [0,0]);
-        }
-        next[Math.floor(idx/2)][idx%2] = w;
-      }
+      if(next) next[Math.floor(idx/2)][idx%2] = w;
+      else { st.championSeed = w; st.complete = true; }
     });
   }
+
 
   function getUserMatch(st){
     const r = st.currentRound || 0;


### PR DESCRIPTION
## Summary
- Update Pool Royale bracket HTML to match Free Kick bracket's bracket generation and AI simulation logic

## Testing
- `npm test` *(fails: server process did not exit, last output shows tests running)*
- `npm run lint` *(fails: 965 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b82ee67a3883299d020164cf5c62ae