### PR TITLE
Fix card transfer flip in Murlan Royale

### DIFF
--- a/webapp/public/murlan-royale.html
+++ b/webapp/public/murlan-royale.html
@@ -1519,9 +1519,9 @@
             moving.addEventListener(
               'transitionend',
               (e) => {
-                if (e.propertyName === 'top') {
+                if (e.propertyName === 'left' || e.propertyName === 'top') {
                   moving.style.transform =
-                    'translate(-50%, -50%) rotateY(90deg)';
+                    'translate(-50%, -50%) rotateY(180deg)';
                   moving.addEventListener(
                     'transitionend',
                     () => {


### PR DESCRIPTION
## Summary
- Ensure transferred cards flip to hide their face and become usable for winners

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, 'inc' is never reassigned, Extra semicolon)*

------
https://chatgpt.com/codex/tasks/task_e_68b84ddc5acc8329950ff07e0b12242c