### PR TITLE
Ensure cue ball travels straight before spin effects

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -210,18 +210,28 @@ export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
   const toPocket = { x: pocket.x - target.x, y: pocket.y - target.y }
   const dir = { x: toTarget.x - toPocket.x, y: toTarget.y - toPocket.y }
   const len = Math.hypot(dir.x, dir.y) || 1
-  let scale = (power * 120) / len
-  // very rough spin model – top/back alter distance, side imparts lateral offset
-  scale *= 1 + spin.top - spin.back
-  const perp = { x: -dir.y / len, y: dir.x / len }
+
+  // Base travel of the cue ball after striking the target – this is the
+  // straight path with no spin influence. Power only affects distance.
+  const baseDist = (power * 120) / len
+  const result = {
+    x: target.x + dir.x * baseDist,
+    y: target.y + dir.y * baseDist
+  }
+  // Apply spin after the straight path has been established. Top/back spin
+  // extend or reduce travel along the shot line while side spin adds a
+  // perpendicular offset after impact.
+  const distScale = 1 + spin.top - spin.back
+  result.x += dir.x * baseDist * (distScale - 1)
+  result.y += dir.y * baseDist * (distScale - 1)
+
   const tableScale = Math.max(table.width, table.height) * 0.04
   const sideOffset = spin.side * power * tableScale
-  return {
-    x: target.x + dir.x * scale + perp.x * sideOffset,
-    y: target.y + dir.y * scale + perp.y * sideOffset
-  }
+  const perp = { x: -dir.y / len, y: dir.x / len }
+  result.x += perp.x * sideOffset
+  result.y += perp.y * sideOffset
+  return result
 }
-
 
 // Rough Monte Carlo estimate of potting probability by jittering the cue
 // aim slightly and checking if paths remain clear. This models human
@@ -249,7 +259,6 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
   return success / samples
 }
 
-
 function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict = false) {
   const r = req.state.ballRadius
   const balls = ballsOverride || req.state.balls
@@ -275,7 +284,6 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     return null
   }
   const maxD = Math.hypot(req.state.width, req.state.height)
-  const distShot = dist(cue, target) + dist(target, entry)
   const potChance = monteCarloPotChance(req, cue, target, entry, ghost, balls)
   const cueAfter = estimateCueAfterShot(cue, target, entry, power, spin, req.state)
   const nextTargets = nextTargetsAfter(target.id, { ...req, state: { ...req.state, balls } })

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -203,6 +203,19 @@ test('cue ball remains within table bounds for varied power and spin', () => {
   }
 });
 
+test('straight shots stay on line regardless of power', () => {
+  const cue = { id: 0, x: 500, y: 250, vx: 0, vy: 0, pocketed: false };
+  const target = { id: 1, x: 600, y: 250, vx: 0, vy: 0, pocketed: false };
+  const pocket = { x: 1000, y: 250 };
+  const table = { width: 1000, height: 500 };
+  const powers = [0.2, 0.5, 1];
+
+  for (const power of powers) {
+    const next = estimateCueAfterShot(cue, target, pocket, power, { top: 0, side: 0, back: 0 }, table);
+    assert.equal(next.y, target.y);
+  }
+});
+
 test('avoids unnecessary spin when natural position is good', () => {
   const req = {
     game: 'AMERICAN_BILLIARDS',

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -203,16 +203,27 @@ export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
   const toPocket = { x: pocket.x - target.x, y: pocket.y - target.y }
   const dir = { x: toTarget.x - toPocket.x, y: toTarget.y - toPocket.y }
   const len = Math.hypot(dir.x, dir.y) || 1
-  let scale = (power * 120) / len
-  // very rough spin model – top/back alter distance, side imparts lateral offset
-  scale *= 1 + spin.top - spin.back
-  const perp = { x: -dir.y / len, y: dir.x / len }
+
+  // Base travel after striking the target – no spin influence yet so the cue
+  // ball runs straight regardless of power.
+  const baseDist = (power * 120) / len
+  const result = {
+    x: target.x + dir.x * baseDist,
+    y: target.y + dir.y * baseDist
+  }
+
+  // Spin effects applied after impact.
+  const distScale = 1 + spin.top - spin.back
+  result.x += dir.x * baseDist * (distScale - 1)
+  result.y += dir.y * baseDist * (distScale - 1)
+
   const tableScale = Math.max(table.width, table.height) * 0.04
   const sideOffset = spin.side * power * tableScale
-  return {
-    x: target.x + dir.x * scale + perp.x * sideOffset,
-    y: target.y + dir.y * scale + perp.y * sideOffset
-  }
+  const perp = { x: -dir.y / len, y: dir.x / len }
+  result.x += perp.x * sideOffset
+  result.y += perp.y * sideOffset
+
+  return result
 }
 
 


### PR DESCRIPTION
## Summary
- keep cue ball on a straight line to the target before any spin effects
- apply spin adjustments only after contact in physics model
- test straight shots stay on target line regardless of power

## Testing
- `npm test`
- `npx eslint lib/poolAi.js webapp/public/lib/poolAi.js test/poolAi.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b8762e06448329ad00f763048f7f19