### PR TITLE
Refine Pool Royale visuals and spin behavior

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -1637,8 +1637,9 @@
 
         function applySpinImpulse(ball) {
           if (!ball.spin) return;
-          ball.v.x += ball.spin.x * 65;
-          ball.v.y += ball.spin.y * 65;
+          // Increase spin impulse by 50% for more pronounced effects
+          ball.v.x += ball.spin.x * 97.5;
+          ball.v.y += ball.spin.y * 97.5;
           ball.spin.x *= 0.9;
           ball.spin.y *= 0.9;
         }
@@ -1944,6 +1945,9 @@
           // Track collisions in this frame so that audio for each
           // pair of balls is played only once per contact.
           var newCollisions = new Set();
+          // Defer spin impulses until after all collisions to keep target
+          // ball trajectories accurate regardless of cue spin or power
+          var spinQueue = new Set();
           // Levizje + ferkim + kufij
           for (i = 0; i < this.balls.length; i++) {
             var b = this.balls[i];
@@ -1990,7 +1994,7 @@
               if (b.p.x < L) {
                 b.p.x = L;
                 b.v.x *= -BOUNCE;
-                if (b.n === 0) applySpinImpulse(b);
+                if (b.n === 0) spinQueue.add(b);
                 if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
                 var diffY = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
                 if (
@@ -2006,7 +2010,7 @@
               if (b.p.x > R) {
                 b.p.x = R;
                 b.v.x *= -BOUNCE;
-                if (b.n === 0) applySpinImpulse(b);
+                if (b.n === 0) spinQueue.add(b);
                 if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
                 var diffY2 = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
                 if (
@@ -2022,7 +2026,7 @@
               if (b.p.y < T) {
                 b.p.y = T;
                 b.v.y *= -BOUNCE;
-                if (b.n === 0) applySpinImpulse(b);
+                if (b.n === 0) spinQueue.add(b);
                 if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
                 var diffX = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
                 if (
@@ -2038,7 +2042,7 @@
               if (b.p.y > B) {
                 b.p.y = B;
                 b.v.y *= -BOUNCE;
-                if (b.n === 0) applySpinImpulse(b);
+                if (b.n === 0) spinQueue.add(b);
                 if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
                 var diffX2 = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
                 if (
@@ -2125,12 +2129,15 @@
                         );
                       }
                     }
-                    if (a.n === 0) applySpinImpulse(a);
-                    if (bb.n === 0) applySpinImpulse(bb);
-                  }
+                    if (a.n === 0) spinQueue.add(a);
+                    if (bb.n === 0) spinQueue.add(bb);
                 }
               }
             }
+            }
+
+          // Apply accumulated spin impulses after all collisions
+          spinQueue.forEach(applySpinImpulse);
 
           // Kontroll i gropave
           for (i = 0; i < this.pockets.length; i++) {
@@ -2274,9 +2281,10 @@
               0,
               ballR * 1.2
             );
-            grad.addColorStop(0, 'rgba(255,255,255,0.6)');
+            // Slightly soften internal highlights and shadows
+            grad.addColorStop(0, 'rgba(255,255,255,0.5)');
             grad.addColorStop(0.6, BALL_BY_N[b.n].c);
-            grad.addColorStop(1, 'rgba(0,0,0,0.35)');
+            grad.addColorStop(1, 'rgba(0,0,0,0.25)');
             ctx.fillStyle = grad;
             ctx.beginPath();
             ctx.arc(0, 0, ballR, 0, Math.PI * 2);
@@ -2298,9 +2306,10 @@
                 0,
                 ballR * 1.2
               );
-              stripeGrad.addColorStop(0, 'rgba(255,255,255,0.6)');
+              // Slightly soften internal highlights and shadows of stripe
+              stripeGrad.addColorStop(0, 'rgba(255,255,255,0.5)');
               stripeGrad.addColorStop(0.6, '#fff');
-              stripeGrad.addColorStop(1, 'rgba(0,0,0,0.35)');
+              stripeGrad.addColorStop(1, 'rgba(0,0,0,0.25)');
               ctx.fillStyle = stripeGrad;
               ctx.fillRect(-ballR, -ballR * 0.3, ballR * 2, ballR * 0.6);
               ctx.restore();


### PR DESCRIPTION
## Summary
- Soften internal ball highlights and shadows
- Apply cue ball spin after collisions and boost its effect
- Queue spin impulses to keep target ball path stable

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, prefer-const, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b88fa12d448329a7897669df30fa6f