### PR TITLE
Use snooker table and add center logo for Pool Royale

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -177,10 +177,22 @@
         content: '';
         position: absolute;
         inset: 0;
-        background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
+        background: url('/assets/icons/Pool%20table%20.webp')
           top center/calc(100% + 8px) calc(100% + 20px) no-repeat;
         filter: brightness(var(--table-brightness));
+        z-index: -2;
+      }
+
+      #wrap::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: url('/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp')
+          center/30% no-repeat;
+        opacity: 0.2;
+        mix-blend-mode: multiply;
         z-index: -1;
+        pointer-events: none;
       }
 
       :root {


### PR DESCRIPTION
## Summary
- Replace Pool Royale table background with snooker-training table image
- Overlay TonPlaygram logo at table center with subtle shadow

## Testing
- `npm test`
- `npm run lint` *(fails: 962 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9580c1e748329902d72094b1a5754