### PR TITLE
Improve Murlan Royale dealing and AI strategy

### DIFF
--- a/lib/murlan.js
+++ b/lib/murlan.js
@@ -350,13 +350,38 @@ function breaksBomb(combo, hand) {
   return false;
 }
 
-export function aiChooseAction(hand, onTable, config = DEFAULT_CONFIG) {
-  const moves = legalCombosFromHand(hand, onTable, config);
+export function aiChooseAction(hand, onTable, config = DEFAULT_CONFIG, info = {}) {
+  let moves = legalCombosFromHand(hand, onTable, config);
   if (moves.length === 0) return { type: 'PASS' };
+  const opponents = info.opponents || [];
+  const played = info.playedCards || [];
+  const opponentHasSingle = opponents.some((p) => p.hand && p.hand.length === 1);
+  const playedRanks = played.map((c) => c.rank);
+  const jokersOut = playedRanks.includes('JR') && playedRanks.includes('JB');
+
+  if (!onTable && opponentHasSingle) {
+    const nonSingles = moves.filter((m) => m.type !== ComboType.SINGLE);
+    if (nonSingles.length > 0) moves = nonSingles;
+  }
+
+  if (onTable && onTable.type === ComboType.SINGLE && !jokersOut) {
+    const nonTwo = moves.filter(
+      (m) => !(m.type === ComboType.SINGLE && m.keyRank === '2')
+    );
+    if (nonTwo.length === 0 && moves.some((m) => m.type === ComboType.SINGLE)) {
+      return { type: 'PASS' };
+    }
+    if (nonTwo.length > 0) moves = nonTwo;
+  }
+
+  if (moves.length === 0) return { type: 'PASS' };
+
   const value = (c) => {
     let base = onTable ? c.strength : -c.cards.length;
     base += usesJoker(c.cards) * 0.1;
     if (breaksBomb(c, hand)) base += 100;
+    base += rankValue(c.keyRank, config) * 0.01;
+    if (opponentHasSingle && c.type === ComboType.SINGLE && !onTable) base += 50;
     return base;
   };
   moves.sort((a, b) => value(a) - value(b));

--- a/test/murlan.test.js
+++ b/test/murlan.test.js
@@ -186,3 +186,24 @@ test('bomb finishing hand passes lead', () => {
   assert.equal(state.turn.activePlayer, 1);
 });
 
+test('ai avoids single when opponent has one card', () => {
+  const hand = [card('3', '♠'), card('3', '♥'), card('5', '♣')];
+  const opponents = [{ hand: [card('7', '♦')] }];
+  const action = aiChooseAction(hand, null, DEFAULT_CONFIG, { opponents });
+  const ranks = action.cards.map((c) => c.rank);
+  assert.equal(ranks.length, 2);
+  assert(ranks.every((r) => r === '3'));
+});
+
+test('ai saves two until jokers out', () => {
+  const hand = [card('2', '♠')];
+  const onTable = detectCombo([card('A', '♣')], DEFAULT_CONFIG);
+  let action = aiChooseAction(hand, onTable, DEFAULT_CONFIG, { playedCards: [] });
+  assert.equal(action.type, 'PASS');
+  action = aiChooseAction(hand, onTable, DEFAULT_CONFIG, {
+    playedCards: [card('JR'), card('JB')]
+  });
+  assert.equal(action.type, 'PLAY');
+  assert.equal(action.cards[0].rank, '2');
+});
+

--- a/webapp/public/murlan-royale.html
+++ b/webapp/public/murlan-royale.html
@@ -986,6 +986,7 @@
           turn: 0,
           turnTime: 15,
           pile: [], // last played cards
+          playedCards: [], // all cards placed on the table
           arrangeMode: false,
           lastPlayLen: 0,
           lastPlayType: null,
@@ -1030,14 +1031,18 @@
 
         async function deal() {
           const deck = makeDeck();
+          state.playedCards = [];
+          renderAll();
           for (let i = 0; i < 13; i++) {
             for (let p = 0; p < state.players.length; p++) {
-              state.players[p].hand.push(deck.pop());
-              renderAll();
+              const card = deck.pop();
               if (sndCard) {
                 sndCard.currentTime = 0;
                 sndCard.play();
               }
+              await animateDealCard(p, card);
+              state.players[p].hand.push(card);
+              renderAll();
               await new Promise((r) => setTimeout(r, 120));
             }
           }
@@ -1443,6 +1448,41 @@
           }
         }
 
+        function animateDealCard(toIdx, card) {
+          return new Promise((resolve) => {
+            const stage = el('.stage');
+            const seats = seatsEl.querySelectorAll('.seat');
+            const toSeat = seats[toIdx];
+            if (!stage || !toSeat) {
+              resolve();
+              return;
+            }
+            const stageRect = stage.getBoundingClientRect();
+            const toRect = toSeat.getBoundingClientRect();
+            const centerRect = centerEl.getBoundingClientRect();
+            const moving = cardBackEl();
+            moving.classList.add('moving-card');
+            stage.appendChild(moving);
+            moving.style.left = centerRect.left - stageRect.left + 'px';
+            moving.style.top = centerRect.top - stageRect.top + 'px';
+            moving.style.transform = 'translate(-50%, -50%)';
+            requestAnimationFrame(() => {
+              moving.style.left =
+                toRect.left - stageRect.left + toRect.width / 2 + 'px';
+              moving.style.top =
+                toRect.top - stageRect.top + toRect.height / 2 + 'px';
+            });
+            moving.addEventListener(
+              'transitionend',
+              () => {
+                moving.remove();
+                resolve();
+              },
+              { once: true }
+            );
+          });
+        }
+
         function animateCardsFromAvatar(idx, cards) {
           return new Promise((resolve) => {
             const stage = el('.stage');
@@ -1803,14 +1843,31 @@
           const hand = [...p.hand].sort(
             (a, b) => rankValue(a.r) - rankValue(b.r)
           );
+          const myIdx = state.players.indexOf(p);
+          const oppSingle = state.players.some(
+            (pl, idx) => idx !== myIdx && !pl.finished && pl.hand.length === 1
+          );
+          const playedRanks = state.playedCards.map((c) => c.r);
+          const jokersOut =
+            playedRanks.includes('JB') && playedRanks.includes('JR');
+          const counts = countByRank(hand);
           if (state.lastPlayLen === 0) {
-            // Start round: prefer lowest pair, else lowest single
-            const counts = countByRank(hand);
+            if (oppSingle) {
+              const pairRank = Object.keys(counts)
+                .map(Number)
+                .filter((k) => counts[k] >= 2)
+                .sort((a, b) => a - b)[0];
+              if (pairRank !== undefined) {
+                return hand
+                  .filter((c) => rankValue(c.r) === pairRank)
+                  .slice(0, 2);
+              }
+            }
             const pairRank = Object.keys(counts)
               .map(Number)
               .filter((k) => counts[k] >= 2)
               .sort((a, b) => a - b)[0];
-            if (pairRank) {
+            if (pairRank !== undefined) {
               return hand
                 .filter((c) => rankValue(c.r) === pairRank)
                 .slice(0, 2);
@@ -1818,19 +1875,38 @@
             return [hand[0]];
           }
           if (state.lastPlayLen === 1) {
-            const lastHigh = Math.max(...state.pile.map((c) => rankValue(c.r)));
-            const cand = hand.find((c) => rankValue(c.r) > lastHigh);
-            return cand ? [cand] : [];
+            const lastHigh = Math.max(
+              ...state.pile.map((c) => rankValue(c.r))
+            );
+            let cands = hand.filter((c) => rankValue(c.r) > lastHigh);
+            if (!jokersOut) {
+              cands = cands.filter((c) => c.r !== '2');
+            }
+            if (cands.length === 0 && jokersOut) {
+              const two = hand.find((c) => c.r === '2');
+              return two ? [two] : [];
+            }
+            return cands.length ? [cands[0]] : [];
           }
           if (state.lastPlayLen === 2) {
-            const counts = countByRank(hand);
-            const lastHigh = Math.max(...state.pile.map((c) => rankValue(c.r)));
-            const pair = Object.keys(counts)
+            const lastHigh = Math.max(
+              ...state.pile.map((c) => rankValue(c.r))
+            );
+            let pairRanks = Object.keys(counts)
               .map(Number)
               .filter((k) => counts[k] >= 2 && k > lastHigh)
-              .sort((a, b) => a - b)[0];
-            if (pair) {
-              return hand.filter((c) => rankValue(c.r) === pair).slice(0, 2);
+              .sort((a, b) => a - b);
+            if (!jokersOut) {
+              pairRanks = pairRanks.filter((k) => k !== rankValue('2'));
+            }
+            if (pairRanks.length === 0 && jokersOut && counts[rankValue('2')] >= 2) {
+              return hand.filter((c) => c.r === '2').slice(0, 2);
+            }
+            if (pairRanks.length > 0) {
+              const r = pairRanks[0];
+              return hand
+                .filter((c) => rankValue(c.r) === r)
+                .slice(0, 2);
             }
             return [];
           }
@@ -1950,6 +2026,7 @@
             renderAll();
             await animateCardsFromAvatar(i, chosen);
             state.pile.push(...chosen);
+            state.playedCards.push(...chosen);
             state.lastPlayLen = chosen.length;
             state.lastPlayType = combo;
             state.passesSincePlay = 0;


### PR DESCRIPTION
## Summary
- animate dealing from the center and track all played cards in Murlan Royale
- enhance Murlan AI to avoid risky singles, prefer low cards, and count seen cards
- cover new AI logic with tests and expose extra decision parameters

## Testing
- `node --test test/murlan.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b959f5387c8329b7b50d3188fe87b2