### PR TITLE
Move middle pockets to table sides

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -1716,8 +1716,8 @@
           drawPocket(TABLE_W - BORDER, BORDER_TOP, POCKET_R);
           drawPocket(BORDER, TABLE_H - BORDER_BOTTOM, POCKET_R);
           drawPocket(TABLE_W - BORDER, TABLE_H - BORDER_BOTTOM, POCKET_R);
-          drawPocket(TABLE_W / 2, BORDER_TOP, SIDE_POCKET_R);
-          drawPocket(TABLE_W / 2, TABLE_H - BORDER_BOTTOM, SIDE_POCKET_R);
+          drawPocket(BORDER, TABLE_H / 2 + BALL_R - 14, SIDE_POCKET_R);
+          drawPocket(TABLE_W - BORDER, TABLE_H / 2 + BALL_R - 14, SIDE_POCKET_R);
         }
 
         function drawPocket(x, y, r) {


### PR DESCRIPTION
## Summary
- Draw side pockets on the middle left and right rails instead of top/bottom centers in Pool Royale table rendering.

## Testing
- `npm test` *(passes; server process ends after tests)*
- `npm run lint` *(fails: 962 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b96b110c34832993a7647681f01853