### PR TITLE
Adjust snooker training ball size

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -926,7 +926,7 @@
         var SIDE_POCKET_R = 30; // gropat anesore gjithashtu pak me te vogla
         // move pockets slightly closer to the center of the table
         var POCKET_SHORTEN = 4; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
-        var BALL_R = 22; // rrezja baze e topave pak me e vogel
+        var BALL_R = isSnooker && playType === 'training' ? 20 : 22; // snooker training uses smaller balls
         var SHORT_DIST = BALL_R * 28;
         var MED_DIST = BALL_R * 56;
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate


### PR DESCRIPTION
## Summary
- Reduce billiard ball radius in snooker training variant to better match expected dimensions.

## Testing
- `npm test` *(fails: respects group assignment in eight-ball, UNASSIGNED group defers to ballOn value)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c8557e3c8329b5be5d55361dfce3