### PR TITLE
Add snooker training table canvas

### DIFF
--- a/webapp/public/snooker-training.html
+++ b/webapp/public/snooker-training.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="sq">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tavolinë Snooker – Canvas (Portret, Fullscreen)</title>
+  <style>
+    :root {
+      --felt: #0f6b3a;
+      --felt-light: #178a4b;
+      --felt-dark: #0d5a30;
+      --wood-1: #c86f2b;
+      --wood-2: #a6571e;
+      --wood-3: #de8a42;
+      --cushion: #1a7a42;
+      --line: #e8f7e9;
+      --pocket: #141414;
+    }
+    html, body { height: 100%; margin: 0; background: #0b0f1a; }
+    #table {
+      width: 97vw;
+      height: 97vh;
+      display: block;
+      margin: auto;
+      border-radius: 22px;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="table"></canvas>
+  <script>
+    const CONFIG = {
+      rail: 48,
+      cushion: 22,
+      pocketRadius: 26,
+      sightSpacing: 120,
+      sightRadius: 3.5,
+      lineWidth: 2,
+      spotRadius: 3.2,
+      rotate90: false,
+      rotate180: true,
+      baulkFromCushion: 0.206,
+      pinkFromTop: 0.75,
+      blackFromTop: 0.89,
+      cornerCurve: 28, // radius i harkut te cepat
+      sideCurve: 34    // radius i harkut anësor
+    };
+
+    const canvas = document.getElementById('table');
+    const ctx = canvas.getContext('2d');
+
+    function resize() {
+      const dpr = Math.max(1, window.devicePixelRatio || 1);
+      const w = canvas.clientWidth;
+      const h = canvas.clientHeight;
+      canvas.width = Math.floor(w * dpr);
+      canvas.height = Math.floor(h * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      draw();
+    }
+
+    function draw() {
+      let W = canvas.clientWidth;
+      let H = canvas.clientHeight;
+
+      ctx.save();
+      if (CONFIG.rotate90) {
+        ctx.translate(W, 0);
+        ctx.rotate(Math.PI / 2);
+        const tmp = W; W = H; H = tmp;
+      }
+      if (CONFIG.rotate180) {
+        ctx.translate(W / 2, H / 2);
+        ctx.rotate(Math.PI);
+        ctx.translate(-W / 2, -H / 2);
+      }
+
+      const R = CONFIG.rail;
+      const C = CONFIG.cushion;
+      const ix = R + C;
+      const iy = R + C;
+      const iw = W - 2 * (R + C);
+      const ih = H - 2 * (R + C);
+
+      ctx.clearRect(0, 0, W, H);
+      drawShadow(W, H);
+      drawWoodRail(W, H, R);
+      drawCushions(ix, iy, iw, ih, R, C);
+      drawFelt(ix, iy, iw, ih);
+      drawPockets(W, H, R, C);
+      drawRailSights(W, H, R);
+      drawSnookerMarkings(ix, iy, iw, ih);
+
+      ctx.restore();
+    }
+
+    function drawShadow(W, H) {
+      const g = ctx.createLinearGradient(0, 0, 0, H);
+      g.addColorStop(0, 'rgba(0,0,0,.35)');
+      g.addColorStop(1, 'rgba(0,0,0,.55)');
+      ctx.fillStyle = g;
+      roundRect(ctx, 6, 6, W - 12, H - 12, 24);
+      ctx.fill();
+    }
+
+    function drawWoodRail(W, H, R) {
+      const g = ctx.createLinearGradient(0, 0, 0, H);
+      g.addColorStop(0, getVar('--wood-3'));
+      g.addColorStop(.5, getVar('--wood-1'));
+      g.addColorStop(1, getVar('--wood-2'));
+      ctx.fillStyle = g;
+      roundRect(ctx, 0, 0, W, H, 20);
+      ctx.fill();
+
+      ctx.save();
+      ctx.globalCompositeOperation = 'destination-out';
+      roundRect(ctx, R, R, W - 2 * R, H - 2 * R, 15);
+      ctx.fill();
+      ctx.restore();
+    }
+
+    function drawCushions(ix, iy, iw, ih, R, C) {
+      const x = R, y = R, w = (ix - R) + iw + C, h = (iy - R) + ih + C;
+      const g = ctx.createLinearGradient(0, y, 0, y + C);
+      g.addColorStop(0, '#0e4d2a');
+      g.addColorStop(1, getVar('--cushion'));
+      ctx.fillStyle = g;
+      roundRect(ctx, x, y, w, h, 12);
+      ctx.fill();
+
+      ctx.save();
+      ctx.globalCompositeOperation = 'destination-out';
+      ctx.beginPath();
+      moveInnerWithCurves(ctx, ix, iy, iw, ih);
+      ctx.fill();
+      ctx.restore();
+    }
+
+    function moveInnerWithCurves(c, x, y, w, h) {
+      const top = y, bottom = y + h, left = x, right = x + w;
+      const midY = y + h / 2;
+      const cornerR = CONFIG.cornerCurve;
+      const sideR = CONFIG.sideCurve;
+
+      c.moveTo(left + cornerR, top);
+      c.lineTo(right - cornerR, top);
+      c.quadraticCurveTo(right, top, right, top + cornerR);
+
+      c.lineTo(right, midY - sideR);
+      c.quadraticCurveTo(right, midY, right - sideR, midY);
+      c.quadraticCurveTo(right, midY, right, midY + sideR);
+
+      c.lineTo(right, bottom - cornerR);
+      c.quadraticCurveTo(right, bottom, right - cornerR, bottom);
+
+      c.lineTo(left + cornerR, bottom);
+      c.quadraticCurveTo(left, bottom, left, bottom - cornerR);
+
+      c.lineTo(left, midY + sideR);
+      c.quadraticCurveTo(left, midY, left + sideR, midY);
+      c.quadraticCurveTo(left, midY, left, midY - sideR);
+
+      c.lineTo(left, top + cornerR);
+      c.quadraticCurveTo(left, top, left + cornerR, top);
+      c.closePath();
+    }
+
+    function drawFelt(ix, iy, iw, ih) {
+      const g = ctx.createRadialGradient(
+        ix + iw * 0.5,
+        iy + ih * 0.45,
+        Math.min(iw, ih) * 0.05,
+        ix + iw * 0.5,
+        iy + ih * 0.5,
+        Math.max(iw, ih) * 0.8
+      );
+      g.addColorStop(0, getVar('--felt-light'));
+      g.addColorStop(0.6, getVar('--felt'));
+      g.addColorStop(1, getVar('--felt-dark'));
+      ctx.fillStyle = g;
+      ctx.fillRect(ix, iy, iw, ih);
+    }
+
+    function drawPockets(W, H, R, C) {
+      const ix = R + C, iy = R + C, iw = W - 2 * (R + C), ih = H - 2 * (R + C);
+      const pr = CONFIG.pocketRadius;
+      ctx.fillStyle = getVar('--pocket');
+      const midY = iy + ih / 2;
+      const pockets = [
+        { x: ix - 6, y: iy - 6 },
+        { x: ix + iw + 6, y: iy - 6 },
+        { x: ix - 6, y: iy + ih + 6 },
+        { x: ix + iw + 6, y: iy + ih + 6 },
+        { x: ix - 6, y: midY },
+        { x: ix + iw + 6, y: midY }
+      ];
+      pockets.forEach(p => { ctx.beginPath(); ctx.arc(p.x, p.y, pr, 0, Math.PI * 2); ctx.fill(); });
+    }
+
+    function drawRailSights(W, H, R) {
+      const spacing = CONFIG.sightSpacing;
+      ctx.fillStyle = 'rgba(0,0,0,.7)';
+      for (let x = R + spacing; x <= W - R - spacing; x += spacing) {
+        ctx.beginPath(); ctx.arc(x, R * 0.55, CONFIG.sightRadius, 0, Math.PI * 2); ctx.fill();
+        ctx.beginPath(); ctx.arc(x, H - R * 0.55, CONFIG.sightRadius, 0, Math.PI * 2); ctx.fill();
+      }
+      for (let y = R + spacing; y <= H - R - spacing; y += spacing) {
+        ctx.beginPath(); ctx.arc(R * 0.55, y, CONFIG.sightRadius, 0, Math.PI * 2); ctx.fill();
+        ctx.beginPath(); ctx.arc(W - R * 0.55, y, CONFIG.sightRadius, 0, Math.PI * 2); ctx.fill();
+      }
+    }
+
+    function drawSnookerMarkings(ix, iy, iw, ih) {
+      ctx.strokeStyle = getVar('--line');
+      ctx.fillStyle = getVar('--line');
+      ctx.lineWidth = CONFIG.lineWidth;
+      const fromTop = f => iy + ih * f; const cx = ix + iw / 2;
+      const baulkY = fromTop(CONFIG.baulkFromCushion);
+      const blueY = iy + ih / 2;
+      const pinkY = iy + ih * CONFIG.pinkFromTop;
+      const blackY = iy + ih * CONFIG.blackFromTop;
+
+      ctx.beginPath(); ctx.moveTo(ix, baulkY); ctx.lineTo(ix + iw, baulkY); ctx.stroke();
+      const Dr = iw * 0.18; ctx.beginPath(); ctx.arc(cx, baulkY, Dr, Math.PI, 2 * Math.PI, false); ctx.stroke();
+
+      const gy = baulkY; const greenX = ix + iw * 0.25, brownX = cx, yellowX = ix + iw * 0.75;
+      [[greenX, gy], [brownX, gy], [yellowX, gy]].forEach(([sx, sy]) => { ctx.beginPath(); ctx.arc(sx, sy, CONFIG.spotRadius, 0, Math.PI * 2); ctx.fill(); });
+      [[cx, blueY], [cx, pinkY], [cx, blackY]].forEach(([sx, sy]) => { ctx.beginPath(); ctx.arc(sx, sy, CONFIG.spotRadius, 0, Math.PI * 2); ctx.fill(); });
+    }
+
+    function roundRect(c, x, y, w, h, r) {
+      c.beginPath();
+      c.moveTo(x + r, y);
+      c.arcTo(x + w, y, x + w, y + h, r);
+      c.arcTo(x + w, y + h, x, y + h, r);
+      c.arcTo(x, y + h, x, y, r);
+      c.arcTo(x, y, x + w, y, r);
+      c.closePath();
+    }
+
+    function getVar(name) { return getComputedStyle(document.documentElement).getPropertyValue(name); }
+
+    resize();
+    window.addEventListener('resize', resize);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated snooker-training.html canvas page
- rotate table so baulk line and D are at bottom
- slightly shrink table to avoid full-screen fit

## Testing
- `npm test` *(fails: CLAIM_CONTRACT_ADDRESS and CLAIM_WALLET_MNEMONIC must be set, 5 failing tests)*
- `npm run lint` *(fails: 962 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1b3ecbc8329b7917031d40088e9