### PR TITLE
feat: render snooker table on canvas

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -173,23 +173,33 @@
          to a pseudo-element so the balls and other children remain
          unaffected. */
       }
-      #wrap::before {
-        content: '';
-        position: absolute;
-        inset: 0;
-        background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
-          top center/calc(100% + 8px) calc(100% + 20px) no-repeat;
-        filter: brightness(var(--table-brightness));
-        z-index: -1;
-      }
+      /* Remove static background image; table is drawn on canvas */
+
 
       :root {
         --rpw: min(23vw, 115px);
         --player-frame-color: #000;
         --table-brightness: 1.1;
+        --felt: #0f6b3a;
+        --felt-light: #178a4b;
+        --felt-dark: #0d5a30;
+        --wood-1: #c86f2b;
+        --wood-2: #a6571e;
+        --wood-3: #de8a42;
+        --cushion: #1a7a42;
+        --line: #e8f7e9;
+        --pocket: #141414;
       }
 
       /* Canvas i tavolines (mbulon gjithcka, pervec panelit djathtas) */
+      #snookerCanvas {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 3;
+      }
       #table {
         position: absolute;
         top: 0;
@@ -770,6 +780,7 @@
       </div>
 
       <div id="wrap">
+        <canvas id="snookerCanvas"></canvas>
         <canvas id="table"></canvas>
         <div id="cueHint">✋️</div>
 
@@ -873,6 +884,269 @@
 
     <script src="/flag-emojis.js"></script>
     <script src="/pool-royale-api.js"></script>
+
+    <script>
+      (function () {
+        const CONFIG = {
+          rail: 48,
+          cushion: 22,
+          pocketRadius: 26,
+          sightSpacing: 120,
+          sightRadius: 3.5,
+          lineWidth: 2,
+          spotRadius: 3.2,
+          rotate90: false,
+          baulkFromCushion: 0.206,
+          pinkFromTop: 0.75,
+          blackFromTop: 0.89,
+          cornerCurve: 28,
+          sideCurve: 34,
+        };
+
+        const canvasBg = document.getElementById('snookerCanvas');
+        const ctxBg = canvasBg.getContext('2d');
+
+        function resize() {
+          const dpr = Math.max(1, window.devicePixelRatio || 1);
+          const w = canvasBg.clientWidth;
+          const h = canvasBg.clientHeight;
+          canvasBg.width = Math.floor(w * dpr);
+          canvasBg.height = Math.floor(h * dpr);
+          ctxBg.setTransform(dpr, 0, 0, dpr, 0, 0);
+          draw();
+        }
+
+        function draw() {
+          let W = canvasBg.clientWidth;
+          let H = canvasBg.clientHeight;
+
+          ctxBg.save();
+          if (CONFIG.rotate90) {
+            ctxBg.translate(W, 0);
+            ctxBg.rotate(Math.PI / 2);
+            const tmp = W;
+            W = H;
+            H = tmp;
+          }
+
+          const R = CONFIG.rail;
+          const C = CONFIG.cushion;
+          const ix = R + C;
+          const iy = R + C;
+          const iw = W - 2 * (R + C);
+          const ih = H - 2 * (R + C);
+
+          ctxBg.clearRect(0, 0, W, H);
+          drawShadow(W, H);
+          drawWoodRail(W, H, R);
+          drawCushions(ix, iy, iw, ih, R, C);
+          drawFelt(ix, iy, iw, ih);
+          drawPockets(W, H, R, C);
+          drawRailSights(W, H, R);
+          drawSnookerMarkings(ix, iy, iw, ih);
+
+          ctxBg.restore();
+        }
+
+        function drawShadow(W, H) {
+          const g = ctxBg.createLinearGradient(0, 0, 0, H);
+          g.addColorStop(0, 'rgba(0,0,0,.35)');
+          g.addColorStop(1, 'rgba(0,0,0,.55)');
+          ctxBg.fillStyle = g;
+          roundRect(ctxBg, 6, 6, W - 12, H - 12, 24);
+          ctxBg.fill();
+        }
+
+        function drawWoodRail(W, H, R) {
+          const g = ctxBg.createLinearGradient(0, 0, 0, H);
+          g.addColorStop(0, getVar('--wood-3'));
+          g.addColorStop(0.5, getVar('--wood-1'));
+          g.addColorStop(1, getVar('--wood-2'));
+          ctxBg.fillStyle = g;
+          roundRect(ctxBg, 0, 0, W, H, 20);
+          ctxBg.fill();
+
+          ctxBg.save();
+          ctxBg.globalCompositeOperation = 'destination-out';
+          roundRect(ctxBg, R, R, W - 2 * R, H - 2 * R, 15);
+          ctxBg.fill();
+          ctxBg.restore();
+        }
+
+        function drawCushions(ix, iy, iw, ih, R, C) {
+          const x = R,
+            y = R,
+            w = ix - R + iw + C,
+            h = iy - R + ih + C;
+          const g = ctxBg.createLinearGradient(0, y, 0, y + C);
+          g.addColorStop(0, '#0e4d2a');
+          g.addColorStop(1, getVar('--cushion'));
+          ctxBg.fillStyle = g;
+          roundRect(ctxBg, x, y, w, h, 12);
+          ctxBg.fill();
+
+          ctxBg.save();
+          ctxBg.globalCompositeOperation = 'destination-out';
+          ctxBg.beginPath();
+          moveInnerWithCurves(ctxBg, ix, iy, iw, ih);
+          ctxBg.fill();
+          ctxBg.restore();
+        }
+
+        function moveInnerWithCurves(c, x, y, w, h) {
+          const top = y,
+            bottom = y + h,
+            left = x,
+            right = x + w;
+          const midY = y + h / 2;
+          const cornerR = CONFIG.cornerCurve;
+          const sideR = CONFIG.sideCurve;
+
+          c.moveTo(left + cornerR, top);
+          c.lineTo(right - cornerR, top);
+          c.quadraticCurveTo(right, top, right, top + cornerR);
+
+          c.lineTo(right, midY - sideR);
+          c.quadraticCurveTo(right, midY, right - sideR, midY);
+          c.quadraticCurveTo(right, midY, right, midY + sideR);
+
+          c.lineTo(right, bottom - cornerR);
+          c.quadraticCurveTo(right, bottom, right - cornerR, bottom);
+
+          c.lineTo(left + cornerR, bottom);
+          c.quadraticCurveTo(left, bottom, left, bottom - cornerR);
+
+          c.lineTo(left, midY + sideR);
+          c.quadraticCurveTo(left, midY, left + sideR, midY);
+          c.quadraticCurveTo(left, midY, left, midY - sideR);
+
+          c.lineTo(left, top + cornerR);
+          c.quadraticCurveTo(left, top, left + cornerR, top);
+          c.closePath();
+        }
+
+        function drawFelt(ix, iy, iw, ih) {
+          const g = ctxBg.createRadialGradient(
+            ix + iw * 0.5,
+            iy + ih * 0.45,
+            Math.min(iw, ih) * 0.05,
+            ix + iw * 0.5,
+            iy + ih * 0.5,
+            Math.max(iw, ih) * 0.8
+          );
+          g.addColorStop(0, getVar('--felt-light'));
+          g.addColorStop(0.6, getVar('--felt'));
+          g.addColorStop(1, getVar('--felt-dark'));
+          ctxBg.fillStyle = g;
+          ctxBg.fillRect(ix, iy, iw, ih);
+        }
+
+        function drawPockets(W, H, R, C) {
+          const ix = R + C,
+            iy = R + C,
+            iw = W - 2 * (R + C),
+            ih = H - 2 * (R + C);
+          const pr = CONFIG.pocketRadius;
+          ctxBg.fillStyle = getVar('--pocket');
+          const midY = iy + ih / 2;
+          const pockets = [
+            { x: ix - 6, y: iy - 6 },
+            { x: ix + iw + 6, y: iy - 6 },
+            { x: ix - 6, y: iy + ih + 6 },
+            { x: ix + iw + 6, y: iy + ih + 6 },
+            { x: ix - 6, y: midY },
+            { x: ix + iw + 6, y: midY },
+          ];
+          pockets.forEach((p) => {
+            ctxBg.beginPath();
+            ctxBg.arc(p.x, p.y, pr, 0, Math.PI * 2);
+            ctxBg.fill();
+          });
+        }
+
+        function drawRailSights(W, H, R) {
+          const spacing = CONFIG.sightSpacing;
+          ctxBg.fillStyle = 'rgba(0,0,0,.7)';
+          for (let x = R + spacing; x <= W - R - spacing; x += spacing) {
+            ctxBg.beginPath();
+            ctxBg.arc(x, R * 0.55, CONFIG.sightRadius, 0, Math.PI * 2);
+            ctxBg.fill();
+            ctxBg.beginPath();
+            ctxBg.arc(x, H - R * 0.55, CONFIG.sightRadius, 0, Math.PI * 2);
+            ctxBg.fill();
+          }
+          for (let y = R + spacing; y <= H - R - spacing; y += spacing) {
+            ctxBg.beginPath();
+            ctxBg.arc(R * 0.55, y, CONFIG.sightRadius, 0, Math.PI * 2);
+            ctxBg.fill();
+            ctxBg.beginPath();
+            ctxBg.arc(W - R * 0.55, y, CONFIG.sightRadius, 0, Math.PI * 2);
+            ctxBg.fill();
+          }
+        }
+
+        function drawSnookerMarkings(ix, iy, iw, ih) {
+          ctxBg.strokeStyle = getVar('--line');
+          ctxBg.fillStyle = getVar('--line');
+          ctxBg.lineWidth = CONFIG.lineWidth;
+          const fromTop = (f) => iy + ih * f;
+          const cx = ix + iw / 2;
+          const baulkY = fromTop(CONFIG.baulkFromCushion);
+          const blueY = iy + ih / 2;
+          const pinkY = iy + ih * CONFIG.pinkFromTop;
+          const blackY = iy + ih * CONFIG.blackFromTop;
+
+          ctxBg.beginPath();
+          ctxBg.moveTo(ix, baulkY);
+          ctxBg.lineTo(ix + iw, baulkY);
+          ctxBg.stroke();
+          const Dr = iw * 0.18;
+          ctxBg.beginPath();
+          ctxBg.arc(cx, baulkY, Dr, Math.PI, 2 * Math.PI, false);
+          ctxBg.stroke();
+
+          const gy = baulkY;
+          const greenX = ix + iw * 0.25,
+            brownX = cx,
+            yellowX = ix + iw * 0.75;
+          [
+            [greenX, gy],
+            [brownX, gy],
+            [yellowX, gy],
+          ].forEach(([sx, sy]) => {
+            ctxBg.beginPath();
+            ctxBg.arc(sx, sy, CONFIG.spotRadius, 0, Math.PI * 2);
+            ctxBg.fill();
+          });
+          [
+            [cx, blueY],
+            [cx, pinkY],
+            [cx, blackY],
+          ].forEach(([sx, sy]) => {
+            ctxBg.beginPath();
+            ctxBg.arc(sx, sy, CONFIG.spotRadius, 0, Math.PI * 2);
+            ctxBg.fill();
+          });
+        }
+
+        function roundRect(c, x, y, w, h, r) {
+          c.beginPath();
+          c.moveTo(x + r, y);
+          c.arcTo(x + w, y, x + w, y + h, r);
+          c.arcTo(x + w, y + h, x, y + h, r);
+          c.arcTo(x, y + h, x, y, r);
+          c.arcTo(x, y, x + w, y, r);
+          c.closePath();
+        }
+
+        function getVar(name) {
+          return getComputedStyle(document.documentElement).getPropertyValue(name);
+        }
+
+        resize();
+        window.addEventListener('resize', resize);
+      })();
+    </script>
 
     <!--
     Shenim: Perdorim script me type="text/javascript" per te shmangur


### PR DESCRIPTION
## Summary
- replace background table image with canvas
- draw snooker table using dedicated script

## Testing
- `npm test`
- `npm run lint` (fails: Extra semicolon and spacing errors)


------
https://chatgpt.com/codex/tasks/task_e_68ba65b89d688329b892e60ec544b5b0