### PR TITLE
Reduce Pool Royale ball speed

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -313,7 +313,7 @@
       function shoot() {
         const power = Number(powerInput.value) / 100;
         playHit(power);
-        const speed = 4 + power * 8;
+        const speed = 2 + power * 4;
         let cuePos = { x: center.x, y: center.y };
         let cueVel = { x: shotDir.x * speed, y: shotDir.y * speed };
         let targetPos = {

--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3686,8 +3686,8 @@
           shotPocketRecorded = false;
           cueHitCushion = false;
           var base = 950 * 3 * 1.6 * 1.5;
-          // Reduce the overall shot power by 50%
-          base *= 0.5;
+          // Reduce the overall shot power by 75% for a more realistic speed
+          base *= 0.25;
           playCueHit(p * 0.5);
           lastShotPower = p;
           currentShooter = table.turn;


### PR DESCRIPTION
## Summary
- slow down cue shot velocity for realistic ball speed
- adjust Pool Royale example to use matching slower speed

## Testing
- `npm test` *(fails: ReferenceError: module is not defined)*
- `npm run lint` *(fails: 964 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ba876c6ef883299b6f6bbd8a38efcc