### PR TITLE
Fix cue ball spin orientation in Pool Royale

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3334,9 +3334,11 @@
             };
             // rotate spin into table coordinates and adjust reflection
             var perp = { x: -dir.y, y: dir.x };
+            var forward = -spinVec.y;
+            var side = spinVec.x;
             var spinWorld = {
-              x: spinVec.x * perp.x + spinVec.y * dir.x,
-              y: spinVec.x * perp.y + spinVec.y * dir.y
+              x: side * perp.x + forward * dir.x,
+              y: side * perp.y + forward * dir.y
             };
             refl.x += spinWorld.x * 0.6;
             refl.y += spinWorld.y * 0.6;
@@ -3687,9 +3689,11 @@
           cue.v.x = d.x * base * (0.25 + 0.75 * p);
           cue.v.y = d.y * base * (0.25 + 0.75 * p);
           var perp = { x: -d.y, y: d.x };
+          var forward = -spinVec.y;
+          var side = spinVec.x;
           cue.spin = {
-            x: spinVec.x * perp.x + spinVec.y * d.x,
-            y: spinVec.x * perp.y + spinVec.y * d.y
+            x: side * perp.x + forward * d.x,
+            y: side * perp.y + forward * d.y
           };
           cue.impacted = false;
           cueBallFree = false;


### PR DESCRIPTION
## Summary
- Correct spin vector orientation for rail reflections
- Apply proper spin vector when cue ball struck

## Testing
- `npx jest --config jest.config.cjs` *(fails: Parameter 'c' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9a95f2b48329b4312f981f1fa1ef