### PR TITLE
Adjust spin wheel and update Pool Royale rules

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -259,8 +259,8 @@
       #turnTimerText {
         position: absolute;
         left: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
+        top: -10px;
+        transform: translateX(-50%);
         font-weight: 700;
         pointer-events: none;
         -webkit-text-stroke: 1px #000;
@@ -2343,6 +2343,7 @@
                       assignedTypes[currentShooter] = tType;
                       assignedTypes[currentShooter === 1 ? 2 : 1] =
                         tType === 'red' ? 'blue' : 'red';
+                      assignedThisShot = true;
                       pocketedOwn = true;
                       updateFooter(
                         currentShooter,
@@ -2628,6 +2629,7 @@
         var scratch = false;
         var foulShown = false;
         var assignedTypes = { 1: null, 2: null };
+        var assignedThisShot = false;
         var freeShots = { 1: 0, 2: 0 };
         var firstHit = null;
         var lastTurn = table.turn;
@@ -2927,7 +2929,12 @@
           } else if (isSnooker) {
             if (!firstHit || scratch) return true;
             if (snookerExpectColor && firstHit.t === 'red') return true;
-            if (!snookerExpectColor && firstHit.t !== 'red') return true;
+            if (!snookerExpectColor && firstHit.t !== 'red') {
+              var redLeft = table.balls.some(function (bb, idx) {
+                return idx > 0 && bb && !bb.pocketed && BALL_BY_N[bb.n].t === 'red';
+              });
+              if (redLeft) return true;
+            }
             return false;
           }
           if (!firstHit || scratch) return true;
@@ -2936,7 +2943,7 @@
           if (firstHit.t === 'eight' || eightBallPotted) {
             return ownLeft;
           }
-          if (shooterType && firstHit.t !== shooterType) return true;
+          if (shooterType && firstHit.t !== shooterType && !assignedThisShot) return true;
           return false;
         }
 
@@ -3684,6 +3691,7 @@
           scratch = false;
           firstHit = null;
           pottedThisShot = [];
+          assignedThisShot = false;
           eightBallPotted = false;
           nineBallPotted = false;
           cue.v.x = d.x * base * (0.25 + 0.75 * p);

--- a/webapp/src/components/SpinWheel.tsx
+++ b/webapp/src/components/SpinWheel.tsx
@@ -26,7 +26,7 @@ const visibleRows = 7; // Always display 7 rows
 
 const winningRow = 2;  // Index of the row that marks the winner (3rd row)
 
-const loops = 8;       // How many times the list repeats while spinning
+const loops = 6;       // How many times the list repeats while spinning
 const maxSpins = 50;    // Pre-generated spins to allow continuous play
 
 export default forwardRef<SpinWheelHandle, SpinWheelProps>(function SpinWheel(


### PR DESCRIPTION
## Summary
- Tweak spin wheel speed for a more realistic feel
- Align shot timer with player names
- Enforce red-ball start in snooker training and fix UK break fouls

## Testing
- `npm test` *(fails: ReferenceError module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68baa3865b088329af6797e6c0885803