### PR TITLE
Tune Pool Royale shot and spin strength

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -1676,7 +1676,7 @@
         function applySpinImpulse(ball) {
           if (!ball.spin) return;
           // Apply stronger, immediate spin influence
-          var SPIN_STRENGTH = 150;
+          var SPIN_STRENGTH = 100;
           var SPIN_DECAY = 0.9;
           ball.v.x += ball.spin.x * SPIN_STRENGTH;
           ball.v.y += ball.spin.y * SPIN_STRENGTH;
@@ -3703,9 +3703,9 @@
           shotPocketRecorded = false;
           cueHitCushion = false;
           var base = 950 * 3 * 1.6 * 1.5;
-          // Reduce the overall shot power by 50%
-          base *= 0.5;
-          playCueHit(p * 0.5);
+          // Reduce the overall shot power by 60% to better match gameplay
+          base *= 0.4;
+          playCueHit(p * 0.4);
           lastShotPower = p;
           currentShooter = table.turn;
           if (isNineBall || isAmerican) currentTarget = lowestBallOnTable();


### PR DESCRIPTION
## Summary
- Reduce spin strength constant to calm cue ball spin
- Lower base shot force and cue-hit volume for gentler shots

## Testing
- `npm test` *(fails: ReferenceError: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bab771a9f88329a241df33f3c8a105