### PR TITLE
Increase Pool Royale shot power slightly

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3703,9 +3703,9 @@
           shotPocketRecorded = false;
           cueHitCushion = false;
           var base = 950 * 3 * 1.6 * 1.5;
-          // Reduce the overall shot power by 60% to better match gameplay
-          base *= 0.4;
-          playCueHit(p * 0.4);
+          // Reduce the overall shot power by about 55% to better match gameplay
+          base *= 0.45;
+          playCueHit(p * 0.45);
           lastShotPower = p;
           currentShooter = table.turn;
           if (isNineBall || isAmerican) currentTarget = lowestBallOnTable();


### PR DESCRIPTION
## Summary
- boost Pool Royale shot speed by nudging the power scale up

## Testing
- `npm test` *(fails: ReferenceError: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68baba8903988329b80e4b0335ed974e