### PR TITLE
feat: enhance pool spin and pocket guides

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -1684,7 +1684,7 @@
         function applySpinImpulse(ball) {
           if (!ball.spin) return;
           // Apply stronger, immediate spin influence
-          var SPIN_STRENGTH = 100;
+          var SPIN_STRENGTH = 120;
           var SPIN_DECAY = 0.9;
           ball.v.x += ball.spin.x * SPIN_STRENGTH;
           ball.v.y += ball.spin.y * SPIN_STRENGTH;
@@ -2392,19 +2392,14 @@
             ctx.strokeStyle = 'rgba(0,255,0,0.8)';
             ctx.lineWidth = 2;
             ctx.strokeRect(x0, y0, w, h);
-            ctx.strokeStyle = 'rgba(255,0,0,0.8)';
             if (this.pockets) {
-              this.pockets.forEach(function (p) {
-                ctx.beginPath();
-                ctx.arc(
-                  p.x * sX,
-                  p.y * sY,
-                  p.r * ((sX + sY) / 2),
-                  0,
-                  Math.PI * 2
-                );
-                ctx.stroke();
-              });
+              ctx.strokeStyle = '#ff0';
+              drawVPocketGuide(this.pockets[2], 1);
+              drawVPocketGuide(this.pockets[3], -1);
+              drawUPocketGuide(this.pockets[0], 1, 1);
+              drawUPocketGuide(this.pockets[1], -1, 1);
+              drawUPocketGuide(this.pockets[4], 1, -1);
+              drawUPocketGuide(this.pockets[5], -1, -1);
             }
             ctx.restore();
           }
@@ -3556,6 +3551,36 @@
           ctx.restore();
         }
 
+        function drawVPocketGuide(p, dir) {
+          var R = p.r * ((sX + sY) / 2) * 1.1;
+          var x = p.x * sX;
+          var y = p.y * sY;
+          var dx = R * dir;
+          var dy = R;
+          ctx.beginPath();
+          ctx.moveTo(x + dx, y - dy);
+          ctx.lineTo(x - dx, y);
+          ctx.lineTo(x + dx, y + dy);
+          ctx.stroke();
+        }
+
+        function drawUPocketGuide(p, sx, sy) {
+          var R = p.r * ((sX + sY) / 2) * 1.1;
+          var x = p.x * sX;
+          var y = p.y * sY;
+          ctx.save();
+          ctx.translate(x, y);
+          ctx.scale(sx, sy);
+          ctx.beginPath();
+          ctx.arc(0, 0, R, Math.PI, 0);
+          ctx.moveTo(-R, 0);
+          ctx.lineTo(-R, -R);
+          ctx.moveTo(R, 0);
+          ctx.lineTo(R, -R);
+          ctx.stroke();
+          ctx.restore();
+        }
+
         /* ==========================================================
        SPIN CONTROL – disk i bardhe me pike te kuqe
        ========================================================= */
@@ -3735,9 +3760,9 @@
           shotPocketRecorded = false;
           cueHitCushion = false;
           var base = 950 * 3 * 1.6 * 1.5;
-          // Reduce the overall shot power by about 55% to better match gameplay
-          base *= 0.45;
-          playCueHit(p * 0.45);
+          // Reduce the overall shot power but keep it slightly stronger
+          base *= 0.5;
+          playCueHit(p * 0.5);
           lastShotPower = p;
           currentShooter = table.turn;
           if (isNineBall || isAmerican) currentTarget = lowestBallOnTable();

--- a/webapp/public/snooker-table.html
+++ b/webapp/public/snooker-table.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="sq">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tavolinë Snooker – Canvas (Portret, Fullscreen)</title>
+  <style>
+    :root{
+      --felt:#0f6b3a;
+      --felt-light:#178a4b;
+      --felt-dark:#0d5a30;
+      --wood-1:#c86f2b;
+      --wood-2:#a6571e;
+      --wood-3:#de8a42;
+      --cushion:#1a7a42;
+      --line:#e8f7e9;
+      --pocket:#141414;
+    }
+    html,body{height:100%;margin:0;background:#0b0f1a}
+    #table{width:100vw;height:100vh;display:block;border-radius:22px}
+  </style>
+</head>
+<body>
+  <canvas id="table"></canvas>
+  <script>
+    const CONFIG = {
+      rail: 48,
+      cushion: 22,
+      pocketRadius: 26,
+      sightSpacing: 120,
+      sightRadius: 3.5,
+      lineWidth: 2,
+      spotRadius: 3.2,
+      rotate90: false,
+      baulkFromCushion: 0.206,
+      pinkFromTop: 0.75,
+      blackFromTop: 0.89,
+      cornerCurve: 28,
+      sideCurve: 34
+    };
+
+    const canvas = document.getElementById('table');
+    const ctx = canvas.getContext('2d');
+
+    function resize(){
+      const dpr = Math.max(1, window.devicePixelRatio || 1);
+      const w = canvas.clientWidth;
+      const h = canvas.clientHeight;
+      canvas.width  = Math.floor(w * dpr);
+      canvas.height = Math.floor(h * dpr);
+      ctx.setTransform(dpr,0,0,dpr,0,0);
+      draw();
+    }
+
+    function draw(){
+      let W = canvas.clientWidth;
+      let H = canvas.clientHeight;
+
+      ctx.save();
+      ctx.translate(W, H);
+      ctx.rotate(Math.PI);
+      if(CONFIG.rotate90){
+        ctx.translate(W,0);
+        ctx.rotate(Math.PI/2);
+        const tmp = W; W = H; H = tmp;
+      }
+
+      const R = CONFIG.rail;
+      const C = CONFIG.cushion;
+      const ix = R + C;
+      const iy = R + C;
+      const iw = W - 2*(R + C);
+      const ih = H - 2*(R + C);
+
+      ctx.clearRect(0,0,W,H);
+      drawShadow(W,H);
+      drawWoodRail(W,H,R);
+      drawCushions(ix, iy, iw, ih, R, C);
+      drawFelt(ix, iy, iw, ih);
+      drawPockets(W,H,R,C);
+      drawRailSights(W,H,R);
+      drawSnookerMarkings(ix, iy, iw, ih);
+
+      ctx.restore();
+    }
+
+    function drawShadow(W,H){
+      const g = ctx.createLinearGradient(0,0,0,H);
+      g.addColorStop(0,'rgba(0,0,0,.35)');
+      g.addColorStop(1,'rgba(0,0,0,.55)');
+      ctx.fillStyle = g;
+      roundRect(ctx, 6,6, W-12, H-12, 24);
+      ctx.fill();
+    }
+
+    function drawWoodRail(W,H,R){
+      const g = ctx.createLinearGradient(0,0,0,H);
+      g.addColorStop(0, getVar('--wood-3'));
+      g.addColorStop(.5, getVar('--wood-1'));
+      g.addColorStop(1, getVar('--wood-2'));
+      ctx.fillStyle = g;
+      roundRect(ctx, 0,0, W, H, 20);
+      ctx.fill();
+
+      ctx.save();
+      ctx.globalCompositeOperation = 'destination-out';
+      roundRect(ctx, R, R, W-2*R, H-2*R, 15);
+      ctx.fill();
+      ctx.restore();
+    }
+
+    function drawCushions(ix,iy,iw,ih,R,C){
+      const x = R, y = R, w = (ix - R) + iw + C, h = (iy - R) + ih + C;
+      const g = ctx.createLinearGradient(0, y, 0, y+C);
+      g.addColorStop(0, '#0e4d2a');
+      g.addColorStop(1, getVar('--cushion'));
+      ctx.fillStyle = g;
+      roundRect(ctx, x, y, w, h, 12);
+      ctx.fill();
+
+      ctx.save();
+      ctx.globalCompositeOperation = 'destination-out';
+      ctx.beginPath();
+      moveInnerWithCurves(ctx, ix, iy, iw, ih);
+      ctx.fill();
+      ctx.restore();
+    }
+
+    function moveInnerWithCurves(c, x, y, w, h){
+      const top=y, bottom=y+h, left=x, right=x+w;
+      const midY = y + h/2;
+      const cornerR = CONFIG.cornerCurve;
+      const sideR = CONFIG.sideCurve;
+
+      c.moveTo(left+cornerR, top);
+      c.lineTo(right-cornerR, top);
+      c.quadraticCurveTo(right, top, right, top+cornerR);
+      c.lineTo(right, midY - sideR);
+      c.quadraticCurveTo(right, midY, right-sideR, midY);
+      c.quadraticCurveTo(right, midY, right, midY+sideR);
+      c.lineTo(right, bottom-cornerR);
+      c.quadraticCurveTo(right, bottom, right-cornerR, bottom);
+      c.lineTo(left+cornerR, bottom);
+      c.quadraticCurveTo(left, bottom, left, bottom-cornerR);
+      c.lineTo(left, midY+sideR);
+      c.quadraticCurveTo(left, midY, left+sideR, midY);
+      c.quadraticCurveTo(left, midY, left, midY-sideR);
+      c.lineTo(left, top+cornerR);
+      c.quadraticCurveTo(left, top, left+cornerR, top);
+      c.closePath();
+    }
+
+    function drawFelt(ix,iy,iw,ih){
+      const g = ctx.createRadialGradient(ix+iw*0.5, iy+ih*0.45, Math.min(iw,ih)*0.05, ix+iw*0.5, iy+ih*0.5, Math.max(iw,ih)*0.8);
+      g.addColorStop(0, getVar('--felt-light'));
+      g.addColorStop(0.6, getVar('--felt'));
+      g.addColorStop(1, getVar('--felt-dark'));
+      ctx.fillStyle = g;
+      ctx.fillRect(ix,iy,iw,ih);
+    }
+
+    function drawPockets(W,H,R,C){
+      const ix = R+C, iy = R+C, iw = W-2*(R+C), ih = H-2*(R+C);
+      const pr = CONFIG.pocketRadius;
+      ctx.fillStyle = getVar('--pocket');
+      const midY = iy + ih/2;
+      const pockets=[
+        {x: ix-6,    y: iy-6},
+        {x: ix+iw+6, y: iy-6},
+        {x: ix-6,    y: iy+ih+6},
+        {x: ix+iw+6, y: iy+ih+6},
+        {x: ix-6,    y: midY},
+        {x: ix+iw+6, y: midY}
+      ];
+      pockets.forEach(p=>{ ctx.beginPath(); ctx.arc(p.x,p.y, pr, 0, Math.PI*2); ctx.fill(); });
+    }
+
+    function drawRailSights(W,H,R){
+      const spacing = CONFIG.sightSpacing;
+      ctx.fillStyle = 'rgba(0,0,0,.7)';
+      for(let x = R + spacing; x <= W - R - spacing; x += spacing){
+        ctx.beginPath(); ctx.arc(x, R*0.55, CONFIG.sightRadius, 0, Math.PI*2); ctx.fill();
+        ctx.beginPath(); ctx.arc(x, H - R*0.55, CONFIG.sightRadius, 0, Math.PI*2); ctx.fill();
+      }
+      for(let y = R + spacing; y <= H - R - spacing; y += spacing){
+        ctx.beginPath(); ctx.arc(R*0.55, y, CONFIG.sightRadius, 0, Math.PI*2); ctx.fill();
+        ctx.beginPath(); ctx.arc(W - R*0.55, y, CONFIG.sightRadius, 0, Math.PI*2); ctx.fill();
+      }
+    }
+
+    function drawSnookerMarkings(ix,iy,iw,ih){
+      ctx.strokeStyle = getVar('--line'); ctx.fillStyle = getVar('--line'); ctx.lineWidth = CONFIG.lineWidth;
+      const fromTop = (f)=> iy + ih*f; const cx = ix + iw/2;
+      const baulkY = fromTop(CONFIG.baulkFromCushion);
+      const blueY  = iy + ih/2;
+      const pinkY  = iy + ih*CONFIG.pinkFromTop;
+      const blackY = iy + ih*CONFIG.blackFromTop;
+
+      ctx.beginPath(); ctx.moveTo(ix, baulkY); ctx.lineTo(ix+iw, baulkY); ctx.stroke();
+      const Dr = iw*0.18; ctx.beginPath(); ctx.arc(cx, baulkY, Dr, Math.PI, 2*Math.PI, false); ctx.stroke();
+
+      const gy = baulkY; const greenX = ix + iw*0.25, brownX = cx, yellowX = ix + iw*0.75;
+      [[greenX,gy],[brownX,gy],[yellowX,gy]].forEach(([sx,sy])=>{ctx.beginPath();ctx.arc(sx,sy,CONFIG.spotRadius,0,Math.PI*2);ctx.fill();});
+      [[cx,blueY],[cx,pinkY],[cx,blackY]].forEach(([sx,sy])=>{ctx.beginPath();ctx.arc(sx,sy,CONFIG.spotRadius,0,Math.PI*2);ctx.fill();});
+    }
+
+    function roundRect(c, x,y,w,h,r){
+      c.beginPath();
+      c.moveTo(x+r, y);
+      c.arcTo(x+w, y,   x+w, y+h, r);
+      c.arcTo(x+w, y+h, x,   y+h, r);
+      c.arcTo(x,   y+h, x,   y,   r);
+      c.arcTo(x,   y,   x+w, y,   r);
+      c.closePath();
+    }
+
+    function getVar(name){return getComputedStyle(document.documentElement).getPropertyValue(name)}
+
+    resize();
+    window.addEventListener('resize', resize);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- boost cue spin response and slightly increase shot force
- overlay yellow V/U guides on pockets
- add standalone snooker table canvas

## Testing
- `npm test` *(fails: ReferenceError: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bac229321883298e66003e0973d964