### PR TITLE
Show snooker table and tweak pocket guides

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -191,6 +191,20 @@
         background: none;
       }
 
+      #snookerTable {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        border: 0;
+        display: none;
+        z-index: 1;
+      }
+
+      #wrap.snooker-training #snookerTable {
+        display: block;
+      }
+
       :root {
         --rpw: min(23vw, 115px);
         --player-frame-color: #000;
@@ -779,6 +793,7 @@
       </div>
 
       <div id="wrap">
+        <iframe id="snookerTable" src="snooker-table.html"></iframe>
         <canvas id="table"></canvas>
         <div id="cueHint">✋️</div>
 
@@ -3553,10 +3568,10 @@
 
         function drawVPocketGuide(p, dir) {
           var R = p.r * ((sX + sY) / 2) * 1.1;
-          var x = p.x * sX;
+          var x = p.x * sX + R * 0.1 * dir;
           var y = p.y * sY;
           var dx = R * dir;
-          var dy = R;
+          var dy = R * 1.05;
           ctx.beginPath();
           ctx.moveTo(x + dx, y - dy);
           ctx.lineTo(x - dx, y);
@@ -3571,12 +3586,14 @@
           ctx.save();
           ctx.translate(x, y);
           ctx.scale(sx, sy);
+          ctx.rotate(-sx * sy * Math.PI / 4);
           ctx.beginPath();
           ctx.arc(0, 0, R, Math.PI, 0);
+          var lineLen = R * 1.2;
           ctx.moveTo(-R, 0);
-          ctx.lineTo(-R, -R);
+          ctx.lineTo(-R, -lineLen);
           ctx.moveTo(R, 0);
-          ctx.lineTo(R, -R);
+          ctx.lineTo(R, -lineLen);
           ctx.stroke();
           ctx.restore();
         }


### PR DESCRIPTION
## Summary
- Make side pocket V guides slightly wider and shifted outward
- Rotate and extend corner pocket U guides to align with cushions
- Display the snooker table background during snooker training

## Testing
- `npm test` *(fails: ReferenceError: module is not defined)*
- `npm run lint` *(fails: 964 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bac67997188329931468e74f3142b0