### PR TITLE
Align pocket guides and standardize snooker table sizing

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3568,7 +3568,7 @@
 
         function drawVPocketGuide(p, dir) {
           var R = p.r * ((sX + sY) / 2) * 1.1;
-          var x = p.x * sX + R * 0.1 * dir;
+          var x = p.x * sX - R * 0.2 * dir;
           var y = p.y * sY;
           var dx = R * dir;
           var dy = R * 1.05;
@@ -3590,10 +3590,11 @@
           ctx.beginPath();
           ctx.arc(0, 0, R, Math.PI, 0);
           var lineLen = R * 1.2;
-          ctx.moveTo(-R, 0);
-          ctx.lineTo(-R, -lineLen);
-          ctx.moveTo(R, 0);
-          ctx.lineTo(R, -lineLen);
+          var lineInset = R * 0.25;
+          ctx.moveTo(-R + lineInset, 0);
+          ctx.lineTo(-R + lineInset, -lineLen);
+          ctx.moveTo(R - lineInset, 0);
+          ctx.lineTo(R - lineInset, -lineLen);
           ctx.stroke();
           ctx.restore();
         }

--- a/webapp/public/snooker-table.html
+++ b/webapp/public/snooker-table.html
@@ -16,12 +16,12 @@
       --line:#e8f7e9;
       --pocket:#141414;
     }
-    html,body{height:100%;margin:0;background:#0b0f1a}
-    #table{width:100vw;height:100vh;display:block;border-radius:22px}
+    html,body{height:100%;margin:0;background:#0b0f1a;display:grid;place-items:center}
+    #snookerTable{width:min(92vw,760px);height:auto;aspect-ratio:768/1216;display:block;border-radius:22px}
   </style>
 </head>
 <body>
-  <canvas id="table"></canvas>
+  <canvas id="snookerTable"></canvas>
   <script>
     const CONFIG = {
       rail: 48,
@@ -39,7 +39,7 @@
       sideCurve: 34
     };
 
-    const canvas = document.getElementById('table');
+    const canvas = document.getElementById('snookerTable');
     const ctx = canvas.getContext('2d');
 
     function resize(){


### PR DESCRIPTION
## Summary
- Shift corner pocket guide lines inward for cleaner alignment
- Offset side-pocket V guides left/right for visual centering
- Resize and rename snooker training table to match Pool Royale dimensions

## Testing
- `npm test` *(fails: ReferenceError: module is not defined)*
- `npm run lint` *(fails: 964 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bacbbc7068832997c17f9cc1c5fdc6