### PR TITLE
feat(pool-royale): tune shot power and pocket guides

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -328,7 +328,7 @@
       function shoot() {
         const power = Number(powerInput.value) / 100;
         playHit(power);
-        const speed = 4 + power * 8;
+        const speed = 4 + power * 9;
         let cuePos = { x: center.x, y: center.y };
         let cueVel = { x: shotDir.x * speed, y: shotDir.y * speed };
         let targetPos = {

--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3567,11 +3567,11 @@
         }
 
         function drawVPocketGuide(p, dir) {
-          var R = p.r * ((sX + sY) / 2) * 1.1;
-          var x = p.x * sX + R * 0.1 * dir;
+          var R = p.r * ((sX + sY) / 2) * 1.2;
+          var x = p.x * sX + R * 0.15 * dir;
           var y = p.y * sY;
-          var dx = R * dir;
-          var dy = R * 1.05;
+          var dx = R * 1.1 * dir;
+          var dy = R * 1.25;
           ctx.beginPath();
           ctx.moveTo(x + dx, y - dy);
           ctx.lineTo(x - dx, y);
@@ -3590,10 +3590,11 @@
           ctx.beginPath();
           ctx.arc(0, 0, R, Math.PI, 0);
           var lineLen = R * 1.2;
+          var sign = sx === sy ? 1 : -1;
           ctx.moveTo(-R, 0);
-          ctx.lineTo(-R, -lineLen);
+          ctx.lineTo(-R, sign * lineLen);
           ctx.moveTo(R, 0);
-          ctx.lineTo(R, -lineLen);
+          ctx.lineTo(R, sign * lineLen);
           ctx.stroke();
           ctx.restore();
         }
@@ -3778,8 +3779,8 @@
           cueHitCushion = false;
           var base = 950 * 3 * 1.6 * 1.5;
           // Reduce the overall shot power but keep it slightly stronger
-          base *= 0.5;
-          playCueHit(p * 0.5);
+          base *= 0.6;
+          playCueHit(p * 0.6);
           lastShotPower = p;
           currentShooter = table.turn;
           if (isNineBall || isAmerican) currentTarget = lowestBallOnTable();


### PR DESCRIPTION
## Summary
- boost cue force and volume for stronger shots
- widen and reposition middle-pocket V guides
- flip corner pocket lines inward for top-left and bottom-right

## Testing
- `npm test` *(fails: ReferenceError: module is not defined)*
- `npm run lint` *(fails: 964 problems (964 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68bad0cc58708329b2e3d7f9d531b8a9