### PR TITLE
fix: adjust pocket guides and snooker canvas

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3568,7 +3568,7 @@
 
         function drawVPocketGuide(p, dir) {
           var R = p.r * ((sX + sY) / 2) * 1.2;
-          var x = p.x * sX + R * 0.15 * dir;
+          var x = p.x * sX - R * 0.15 * dir;
           var y = p.y * sY;
           var dx = R * 1.1 * dir;
           var dy = R * 1.25;
@@ -4288,10 +4288,12 @@
       const allHoles = document.querySelectorAll('.hole');
       if (allHoles.length === 6) {
         allHoles.forEach((hole, idx) => {
-          if (idx === 2 || idx === 3) {
-            hole.style.transform = 'rotate(0deg)';
-          } else {
+          if (idx === 0 || idx === 5) {
             hole.style.transform = 'rotate(-45deg)';
+          } else if (idx === 1 || idx === 4) {
+            hole.style.transform = 'rotate(45deg)';
+          } else {
+            hole.style.transform = 'rotate(0deg)';
           }
         });
       }

--- a/webapp/public/snooker-table.html
+++ b/webapp/public/snooker-table.html
@@ -23,9 +23,9 @@
 <body>
   <canvas id="table"></canvas>
   <script>
-    const CONFIG = {
-      rail: 48,
-      cushion: 22,
+      const CONFIG = {
+        rail: 16,
+        cushion: 16,
       pocketRadius: 26,
       sightSpacing: 120,
       sightRadius: 3.5,
@@ -189,19 +189,7 @@
     }
 
     function drawSnookerMarkings(ix,iy,iw,ih){
-      ctx.strokeStyle = getVar('--line'); ctx.fillStyle = getVar('--line'); ctx.lineWidth = CONFIG.lineWidth;
-      const fromTop = (f)=> iy + ih*f; const cx = ix + iw/2;
-      const baulkY = fromTop(CONFIG.baulkFromCushion);
-      const blueY  = iy + ih/2;
-      const pinkY  = iy + ih*CONFIG.pinkFromTop;
-      const blackY = iy + ih*CONFIG.blackFromTop;
-
-      ctx.beginPath(); ctx.moveTo(ix, baulkY); ctx.lineTo(ix+iw, baulkY); ctx.stroke();
-      const Dr = iw*0.18; ctx.beginPath(); ctx.arc(cx, baulkY, Dr, Math.PI, 2*Math.PI, false); ctx.stroke();
-
-      const gy = baulkY; const greenX = ix + iw*0.25, brownX = cx, yellowX = ix + iw*0.75;
-      [[greenX,gy],[brownX,gy],[yellowX,gy]].forEach(([sx,sy])=>{ctx.beginPath();ctx.arc(sx,sy,CONFIG.spotRadius,0,Math.PI*2);ctx.fill();});
-      [[cx,blueY],[cx,pinkY],[cx,blackY]].forEach(([sx,sy])=>{ctx.beginPath();ctx.arc(sx,sy,CONFIG.spotRadius,0,Math.PI*2);ctx.fill();});
+      // Removed snooker-specific markings to match the pool field
     }
 
     function roundRect(c, x,y,w,h,r){


### PR DESCRIPTION
## Summary
- adjust V-pocket guides to align toward table edges
- rotate corner holes so top-right and bottom-left pockets open diagonally
- align snooker training canvas with pool field and remove snooker markings

## Testing
- `npm test` *(fails: ReferenceError: module is not defined)*
- `npm run lint` *(fails: 964 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bad492c3a48329ac3778c111a710fd