### PR TITLE
Refine Pool Royale pocket visuals and table alignment

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3568,7 +3568,7 @@
 
         function drawVPocketGuide(p, dir) {
           var R = p.r * ((sX + sY) / 2) * 1.2;
-          var x = p.x * sX - R * 0.15 * dir;
+          var x = p.x * sX - R * 0.25 * dir;
           var y = p.y * sY;
           var dx = R * 1.1 * dir;
           var dy = R * 1.25;
@@ -4284,14 +4284,12 @@
 
       // Tournament mode removed
 
-      // Rotate corner holes diagonally; keep side holes horizontal
+      // Rotate corner holes diagonally in the same direction; keep side holes horizontal
       const allHoles = document.querySelectorAll('.hole');
       if (allHoles.length === 6) {
         allHoles.forEach((hole, idx) => {
-          if (idx === 0 || idx === 5) {
+          if (idx === 0 || idx === 1 || idx === 4 || idx === 5) {
             hole.style.transform = 'rotate(-45deg)';
-          } else if (idx === 1 || idx === 4) {
-            hole.style.transform = 'rotate(45deg)';
           } else {
             hole.style.transform = 'rotate(0deg)';
           }

--- a/webapp/public/snooker-table.html
+++ b/webapp/public/snooker-table.html
@@ -26,7 +26,7 @@
       const CONFIG = {
         rail: 16,
         cushion: 16,
-      pocketRadius: 26,
+      pocketRadius: 20,
       sightSpacing: 120,
       sightRadius: 3.5,
       lineWidth: 2,
@@ -165,12 +165,12 @@
       ctx.fillStyle = getVar('--pocket');
       const midY = iy + ih/2;
       const pockets=[
-        {x: ix-6,    y: iy-6},
-        {x: ix+iw+6, y: iy-6},
-        {x: ix-6,    y: iy+ih+6},
-        {x: ix+iw+6, y: iy+ih+6},
-        {x: ix-6,    y: midY},
-        {x: ix+iw+6, y: midY}
+        {x: ix,       y: iy},
+        {x: ix+iw,    y: iy},
+        {x: ix,       y: iy+ih},
+        {x: ix+iw,    y: iy+ih},
+        {x: ix,       y: midY},
+        {x: ix+iw,    y: midY}
       ];
       pockets.forEach(p=>{ ctx.beginPath(); ctx.arc(p.x,p.y, pr, 0, Math.PI*2); ctx.fill(); });
     }


### PR DESCRIPTION
## Summary
- Rotate all corner pockets in the same diagonal direction
- Move side pocket V-guides outward for clearer alignment
- Resize and reposition canvas pockets to match the playfield

## Testing
- `npm test` *(fails: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bad881c5ac8329bb8e67fbe7459082