### PR TITLE
Align pocket guides and canvas dimensions

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -948,12 +948,12 @@
         var TABLE_W = 768; // gjeresi logjike e felt-it
         var TABLE_H = 1216; // lartesi logjike e felt-it
         var BORDER = 57; // korniza e drurit pak me e ngushte anash
-        // Gropat pak me te vogla per t'u mbyllur me shume dhe jo per t'u zgjeruar
-        var POCKET_R = 32; // rrezja baze e gropave pak me e vogel nga jashte
-        var SIDE_POCKET_R = 30; // gropat anesore gjithashtu pak me te vogla
+        var BALL_R = isSnooker && playType === 'training' ? 18 : 22; // snooker training uses smaller balls
+        // Pockets are sized to be the ball radius plus 30% for easier entry
+        var POCKET_R = BALL_R * 1.3;
+        var SIDE_POCKET_R = POCKET_R;
         // move pockets slightly closer to the center of the table
         var POCKET_SHORTEN = 4; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
-        var BALL_R = isSnooker && playType === 'training' ? 18 : 22; // snooker training uses smaller balls
         var SHORT_DIST = BALL_R * 28;
         var MED_DIST = BALL_R * 56;
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
@@ -3568,7 +3568,8 @@
 
         function drawVPocketGuide(p, dir) {
           var R = p.r * ((sX + sY) / 2) * 1.2;
-          var x = p.x * sX - R * 0.25 * dir;
+          // Shift guides further toward table edges instead of the center
+          var x = p.x * sX - R * 0.5 * dir;
           var y = p.y * sY;
           var dx = R * 1.1 * dir;
           var dy = R * 1.25;
@@ -3586,15 +3587,15 @@
           ctx.save();
           ctx.translate(x, y);
           ctx.scale(sx, sy);
-          ctx.rotate(-sx * sy * Math.PI / 4);
+          // Use a consistent rotation so all corner pockets form a proper "U"
+          ctx.rotate(-Math.PI / 4);
           ctx.beginPath();
           ctx.arc(0, 0, R, Math.PI, 0);
           var lineLen = R * 1.2;
-          var sign = sx === sy ? 1 : -1;
           ctx.moveTo(-R, 0);
-          ctx.lineTo(-R, sign * lineLen);
+          ctx.lineTo(-R, lineLen);
           ctx.moveTo(R, 0);
-          ctx.lineTo(R, sign * lineLen);
+          ctx.lineTo(R, lineLen);
           ctx.stroke();
           ctx.restore();
         }

--- a/webapp/public/snooker-table.html
+++ b/webapp/public/snooker-table.html
@@ -26,18 +26,20 @@
       const CONFIG = {
         rail: 16,
         cushion: 16,
-      pocketRadius: 20,
-      sightSpacing: 120,
-      sightRadius: 3.5,
-      lineWidth: 2,
-      spotRadius: 3.2,
-      rotate90: false,
-      baulkFromCushion: 0.206,
-      pinkFromTop: 0.75,
-      blackFromTop: 0.89,
-      cornerCurve: 28,
-      sideCurve: 34
-    };
+        ballRadius: 15,
+        // Pockets are 30% larger than the ball to match the field size
+        pocketRadius: 15 * 1.3,
+        sightSpacing: 120,
+        sightRadius: 3.5,
+        lineWidth: 2,
+        spotRadius: 3.2,
+        rotate90: false,
+        baulkFromCushion: 0.206,
+        pinkFromTop: 0.75,
+        blackFromTop: 0.89,
+        cornerCurve: 28,
+        sideCurve: 34
+      };
 
     const canvas = document.getElementById('table');
     const ctx = canvas.getContext('2d');

--- a/webapp/public/snooker-training.html
+++ b/webapp/public/snooker-training.html
@@ -32,7 +32,9 @@
     const CONFIG = {
       rail: 48,
       cushion: 22,
-      pocketRadius: 26,
+      ballRadius: 18,
+      // Keep pockets 30% larger than the ball for easier shots
+      pocketRadius: 18 * 1.3,
       sightSpacing: 120,
       sightRadius: 3.5,
       lineWidth: 2,


### PR DESCRIPTION
## Summary
- Size pockets 30% larger than balls and unify corner U guides
- Shift side-pocket V guides toward table edges
- Match snooker canvas pocket sizes with field dimensions

## Testing
- `npm test` *(fails: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68badc74f0f483299e0bdd2c79a69a6e