### PR TITLE
Fix snooker pocket guides and canvas alignment

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3568,7 +3568,7 @@
 
         function drawVPocketGuide(p, dir) {
           var R = p.r * ((sX + sY) / 2) * 1.2;
-          var x = p.x * sX - R * 0.25 * dir;
+          var x = p.x * sX - R * 0.5 * dir;
           var y = p.y * sY;
           var dx = R * 1.1 * dir;
           var dy = R * 1.25;
@@ -3590,11 +3590,10 @@
           ctx.beginPath();
           ctx.arc(0, 0, R, Math.PI, 0);
           var lineLen = R * 1.2;
-          var sign = sx === sy ? 1 : -1;
           ctx.moveTo(-R, 0);
-          ctx.lineTo(-R, sign * lineLen);
+          ctx.lineTo(-R, lineLen);
           ctx.moveTo(R, 0);
-          ctx.lineTo(R, sign * lineLen);
+          ctx.lineTo(R, lineLen);
           ctx.stroke();
           ctx.restore();
         }

--- a/webapp/public/snooker-table.html
+++ b/webapp/public/snooker-table.html
@@ -26,21 +26,24 @@
       const CONFIG = {
         rail: 16,
         cushion: 16,
-      pocketRadius: 20,
-      sightSpacing: 120,
-      sightRadius: 3.5,
-      lineWidth: 2,
-      spotRadius: 3.2,
-      rotate90: false,
-      baulkFromCushion: 0.206,
-      pinkFromTop: 0.75,
-      blackFromTop: 0.89,
-      cornerCurve: 28,
-      sideCurve: 34
+        sightSpacing: 120,
+        sightRadius: 3.5,
+        lineWidth: 2,
+        spotRadius: 3.2,
+        rotate90: false,
+        baulkFromCushion: 0.206,
+        pinkFromTop: 0.75,
+        blackFromTop: 0.89,
+        cornerCurve: 28,
+        sideCurve: 34
     };
 
     const canvas = document.getElementById('table');
     const ctx = canvas.getContext('2d');
+    const BALL_R = 18;
+    const POCKET_SHORTEN = 4;
+    const POCKET_R = BALL_R * 1.3;
+    const SIDE_POCKET_R = POCKET_R;
 
     function resize(){
       const dpr = Math.max(1, window.devicePixelRatio || 1);
@@ -160,19 +163,22 @@
     }
 
     function drawPockets(W,H,R,C){
-      const ix = R+C, iy = R+C, iw = W-2*(R+C), ih = H-2*(R+C);
-      const pr = CONFIG.pocketRadius;
+      const ix = R + C, iy = R + C, iw = W - 2 * (R + C), ih = H - 2 * (R + C);
       ctx.fillStyle = getVar('--pocket');
-      const midY = iy + ih/2;
-      const pockets=[
-        {x: ix,       y: iy},
-        {x: ix+iw,    y: iy},
-        {x: ix,       y: iy+ih},
-        {x: ix+iw,    y: iy+ih},
-        {x: ix,       y: midY},
-        {x: ix+iw,    y: midY}
+      const midY = iy + ih / 2;
+      const pockets = [
+        { x: ix - POCKET_SHORTEN + 4, y: iy - POCKET_SHORTEN, r: POCKET_R },
+        { x: ix + iw + POCKET_SHORTEN - 4, y: iy - POCKET_SHORTEN, r: POCKET_R },
+        { x: ix - 16 - POCKET_SHORTEN, y: midY + BALL_R - 14, r: SIDE_POCKET_R },
+        { x: ix + iw + 16 + POCKET_SHORTEN, y: midY + BALL_R - 14, r: SIDE_POCKET_R },
+        { x: ix - POCKET_SHORTEN, y: iy + ih + POCKET_SHORTEN, r: POCKET_R },
+        { x: ix + iw + POCKET_SHORTEN, y: iy + ih + POCKET_SHORTEN, r: POCKET_R }
       ];
-      pockets.forEach(p=>{ ctx.beginPath(); ctx.arc(p.x,p.y, pr, 0, Math.PI*2); ctx.fill(); });
+      pockets.forEach((p) => {
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+        ctx.fill();
+      });
     }
 
     function drawRailSights(W,H,R){


### PR DESCRIPTION
## Summary
- Align top-right and bottom-left corner pocket guides into U-shapes
- Move middle pocket V guides outward toward table edges
- Match snooker canvas pocket sizes and positions to field with ball radius +30%

## Testing
- `npm test` *(fails: ReferenceError: module is not defined)*
- `npm run lint` *(fails: 964 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bade4110c483298bc46cb3cb08ef77