### PR TITLE
Fix Pool Royale corner pocket guide orientation

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3586,7 +3586,7 @@
           ctx.save();
           ctx.translate(x, y);
           ctx.scale(sx, sy);
-          ctx.rotate(-sx * sy * Math.PI / 4);
+          ctx.rotate(-Math.PI / 4);
           ctx.beginPath();
           ctx.arc(0, 0, R, Math.PI, 0);
           var lineLen = R * 1.2;


### PR DESCRIPTION
## Summary
- Align corner pocket guide "U" shapes consistently by rotating them -45 degrees regardless of pocket side

## Testing
- `npm test` *(fails: ReferenceError: module is not defined in jest.config.js)*
- `npm run lint` *(fails: 964 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bae4c32b1c8329a7eab3a2620cde0d