### PR TITLE
Adjust pool pocket boundaries and bounce

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -971,7 +971,7 @@
 
         var FRICTION = 0.985; // ferkimi linear, pak me i vogel per te ruajtur shpejtesine
         var BOUNCE = 0.99; // koeficienti i rikthimit pak me i madh
-        var EDGE_BOUNCE = BOUNCE * 0.1; // skajet e gropave rikthejne 90% me pak
+        var EDGE_BOUNCE = BOUNCE * 0.2; // skajet e gropave rikthejne 80% me pak
 
         var MIN_V = 0.12; // shpejtesia min. qe konsiderohet "ne levizje"
 
@@ -2420,52 +2420,32 @@
               ctx.beginPath();
               // top boundary
               var topY = y0;
-              var dyTL = BORDER_TOP - p[0].y;
-              var dxTL = Math.sqrt(Math.max(0, p[0].r * p[0].r - dyTL * dyTL));
-              var topStart = (p[0].x + dxTL) * sX;
-              var dyTR = BORDER_TOP - p[1].y;
-              var dxTR = Math.sqrt(Math.max(0, p[1].r * p[1].r - dyTR * dyTR));
-              var topEnd = (p[1].x - dxTR) * sX;
+              var topStart = (p[0].x + p[0].r * 1.1) * sX;
+              var topEnd = (p[1].x - p[1].r * 1.1) * sX;
               ctx.moveTo(topStart, topY);
               ctx.lineTo(topEnd, topY);
               // bottom boundary
               var bottomY = (TABLE_H - BORDER_BOTTOM) * sY;
-              var dyBL = p[4].y - (TABLE_H - BORDER_BOTTOM);
-              var dxBL = Math.sqrt(Math.max(0, p[4].r * p[4].r - dyBL * dyBL));
-              var bottomStart = (p[4].x + dxBL) * sX;
-              var dyBR = p[5].y - (TABLE_H - BORDER_BOTTOM);
-              var dxBR = Math.sqrt(Math.max(0, p[5].r * p[5].r - dyBR * dyBR));
-              var bottomEnd = (p[5].x - dxBR) * sX;
+              var bottomStart = (p[4].x + p[4].r * 1.1) * sX;
+              var bottomEnd = (p[5].x - p[5].r * 1.1) * sX;
               ctx.moveTo(bottomStart, bottomY);
               ctx.lineTo(bottomEnd, bottomY);
               // left boundary with side pocket
               var xLeft = x0;
-              var dxTL2 = BORDER - p[0].x;
-              var dyTL2 = Math.sqrt(Math.max(0, p[0].r * p[0].r - dxTL2 * dxTL2));
-              var leftTop = (p[0].y + dyTL2) * sY;
-              var dxSL = BORDER - p[2].x;
-              var dySL = Math.sqrt(Math.max(0, p[2].r * p[2].r - dxSL * dxSL));
-              var leftMidTop = (p[2].y - dySL) * sY;
-              var leftMidBottom = (p[2].y + dySL) * sY;
-              var dxBL2 = BORDER - p[4].x;
-              var dyBL2 = Math.sqrt(Math.max(0, p[4].r * p[4].r - dxBL2 * dxBL2));
-              var leftBottom = (p[4].y - dyBL2) * sY;
+              var leftTop = (p[0].y + p[0].r * 1.1) * sY;
+              var leftMidTop = (p[2].y - p[2].r * 1.1) * sY;
+              var leftMidBottom = (p[2].y + p[2].r * 1.1) * sY;
+              var leftBottom = (p[4].y - p[4].r * 1.1) * sY;
               ctx.moveTo(xLeft, leftTop);
               ctx.lineTo(xLeft, leftMidTop);
               ctx.moveTo(xLeft, leftMidBottom);
               ctx.lineTo(xLeft, leftBottom);
               // right boundary with side pocket
               var xRight = (TABLE_W - BORDER) * sX;
-              var dxTR2 = p[1].x - (TABLE_W - BORDER);
-              var dyTR2 = Math.sqrt(Math.max(0, p[1].r * p[1].r - dxTR2 * dxTR2));
-              var rightTop = (p[1].y + dyTR2) * sY;
-              var dxSR = p[3].x - (TABLE_W - BORDER);
-              var dySR = Math.sqrt(Math.max(0, p[3].r * p[3].r - dxSR * dxSR));
-              var rightMidTop = (p[3].y - dySR) * sY;
-              var rightMidBottom = (p[3].y + dySR) * sY;
-              var dxBR2 = p[5].x - (TABLE_W - BORDER);
-              var dyBR2 = Math.sqrt(Math.max(0, p[5].r * p[5].r - dxBR2 * dxBR2));
-              var rightBottom = (p[5].y - dyBR2) * sY;
+              var rightTop = (p[1].y + p[1].r * 1.1) * sY;
+              var rightMidTop = (p[3].y - p[3].r * 1.1) * sY;
+              var rightMidBottom = (p[3].y + p[3].r * 1.1) * sY;
+              var rightBottom = (p[5].y - p[5].r * 1.1) * sY;
               ctx.moveTo(xRight, rightTop);
               ctx.lineTo(xRight, rightMidTop);
               ctx.moveTo(xRight, rightMidBottom);


### PR DESCRIPTION
## Summary
- Trim green cushion lines so they end at pocket entrance guides, removing overhang into U/V openings
- Raise pocket edge bounce to 20% of standard cushion response for stronger rebounds

## Testing
- `npm test` *(fails: ReferenceError: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68baf230535c8329a1dac6fe8a08b61a