### PR TITLE
Refine pocket edges for pool royale

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2133,114 +2133,110 @@
                 if (b.p.y - T < BALL_R * 1.5 && b.v.y < 0) applySpinImpulse(b);
                 if (B - b.p.y < BALL_R * 1.5 && b.v.y > 0) applySpinImpulse(b);
               }
-              if (b.p.x < L) {
-                b.p.x = L;
-                var diffY = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
-                if (nearPocket && diffY <= BALL_R * 3) {
-                  var nx = b.p.x - nearest.x;
-                  var ny = b.p.y - nearest.y;
-                  var nL = Math.hypot(nx, ny) || 1;
-                  reflectVelocity(b.v, nx / nL, ny / nL, EDGE_BOUNCE);
-                } else {
-                  reflectVelocity(b.v, 1, 0, BOUNCE);
+                if (b.p.x < L) {
+                  b.p.x = L;
+                  var diffY = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
+                  if (nearPocket && diffY <= BALL_R * 3) {
+                    var ny = b.p.y < nearest.y ? -1 : 1;
+                    var inv = 1 / Math.SQRT2;
+                    reflectVelocity(b.v, inv, ny * inv, EDGE_BOUNCE);
+                  } else {
+                    reflectVelocity(b.v, 1, 0, BOUNCE);
+                  }
+                  if (b.n === 0) {
+                    b.impacted = true;
+                    applySpinImpulse(b);
+                  }
+                  if (i === 0 && shotInProgress && !firstHit)
+                    cueHitCushion = true;
+                  if (
+                    nearPocket &&
+                    diffY <= BALL_R * 3 &&
+                    !nearPocketEdgeHit &&
+                    !pocketedAny
+                  ) {
+                    nearPocketEdgeHit = true;
+                    playShock(1);
+                  }
                 }
-                if (b.n === 0) {
-                  b.impacted = true;
-                  applySpinImpulse(b);
+                if (b.p.x > R) {
+                  b.p.x = R;
+                  var diffY2 = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
+                  if (nearPocket && diffY2 <= BALL_R * 3) {
+                    var ny2 = b.p.y < nearest.y ? -1 : 1;
+                    var inv2 = 1 / Math.SQRT2;
+                    reflectVelocity(b.v, -inv2, ny2 * inv2, EDGE_BOUNCE);
+                  } else {
+                    reflectVelocity(b.v, -1, 0, BOUNCE);
+                  }
+                  if (b.n === 0) {
+                    b.impacted = true;
+                    applySpinImpulse(b);
+                  }
+                  if (i === 0 && shotInProgress && !firstHit)
+                    cueHitCushion = true;
+                  if (
+                    nearPocket &&
+                    diffY2 <= BALL_R * 3 &&
+                    !nearPocketEdgeHit &&
+                    !pocketedAny
+                  ) {
+                    nearPocketEdgeHit = true;
+                    playShock(1);
+                  }
                 }
-                if (i === 0 && shotInProgress && !firstHit)
-                  cueHitCushion = true;
-                if (
-                  nearPocket &&
-                  diffY <= BALL_R * 3 &&
-                  !nearPocketEdgeHit &&
-                  !pocketedAny
-                ) {
-                  nearPocketEdgeHit = true;
-                  playShock(1);
+                if (b.p.y < T) {
+                  b.p.y = T;
+                  var diffX = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
+                  if (nearPocket && diffX <= BALL_R * 3) {
+                    var nx = nearest.x < TABLE_W / 2 ? 1 : -1;
+                    var inv3 = 1 / Math.SQRT2;
+                    reflectVelocity(b.v, nx * inv3, inv3, EDGE_BOUNCE);
+                  } else {
+                    reflectVelocity(b.v, 0, 1, BOUNCE);
+                  }
+                  if (b.n === 0) {
+                    b.impacted = true;
+                    applySpinImpulse(b);
+                  }
+                  if (i === 0 && shotInProgress && !firstHit)
+                    cueHitCushion = true;
+                  if (
+                    nearPocket &&
+                    diffX <= BALL_R * 3 &&
+                    !nearPocketEdgeHit &&
+                    !pocketedAny
+                  ) {
+                    nearPocketEdgeHit = true;
+                    playShock(1);
+                  }
                 }
-              }
-              if (b.p.x > R) {
-                b.p.x = R;
-                var diffY2 = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
-                if (nearPocket && diffY2 <= BALL_R * 3) {
-                  var nx2 = b.p.x - nearest.x;
-                  var ny2 = b.p.y - nearest.y;
-                  var nL2 = Math.hypot(nx2, ny2) || 1;
-                  reflectVelocity(b.v, nx2 / nL2, ny2 / nL2, EDGE_BOUNCE);
-                } else {
-                  reflectVelocity(b.v, -1, 0, BOUNCE);
+                if (b.p.y > B) {
+                  b.p.y = B;
+                  var diffX2 = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
+                  if (nearPocket && diffX2 <= BALL_R * 3) {
+                    var nx2 = nearest.x < TABLE_W / 2 ? 1 : -1;
+                    var inv4 = 1 / Math.SQRT2;
+                    reflectVelocity(b.v, nx2 * inv4, -inv4, EDGE_BOUNCE);
+                  } else {
+                    reflectVelocity(b.v, 0, -1, BOUNCE);
+                  }
+                  if (b.n === 0) {
+                    b.impacted = true;
+                    applySpinImpulse(b);
+                  }
+                  if (i === 0 && shotInProgress && !firstHit)
+                    cueHitCushion = true;
+                  if (
+                    nearPocket &&
+                    diffX2 <= BALL_R * 3 &&
+                    !nearPocketEdgeHit &&
+                    !pocketedAny
+                  ) {
+                    nearPocketEdgeHit = true;
+                    playShock(1);
+                  }
                 }
-                if (b.n === 0) {
-                  b.impacted = true;
-                  applySpinImpulse(b);
-                }
-                if (i === 0 && shotInProgress && !firstHit)
-                  cueHitCushion = true;
-                if (
-                  nearPocket &&
-                  diffY2 <= BALL_R * 3 &&
-                  !nearPocketEdgeHit &&
-                  !pocketedAny
-                ) {
-                  nearPocketEdgeHit = true;
-                  playShock(1);
-                }
-              }
-              if (b.p.y < T) {
-                b.p.y = T;
-                var diffX = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
-                if (nearPocket && diffX <= BALL_R * 3) {
-                  var nx3 = b.p.x - nearest.x;
-                  var ny3 = b.p.y - nearest.y;
-                  var nL3 = Math.hypot(nx3, ny3) || 1;
-                  reflectVelocity(b.v, nx3 / nL3, ny3 / nL3, EDGE_BOUNCE);
-                } else {
-                  reflectVelocity(b.v, 0, 1, BOUNCE);
-                }
-                if (b.n === 0) {
-                  b.impacted = true;
-                  applySpinImpulse(b);
-                }
-                if (i === 0 && shotInProgress && !firstHit)
-                  cueHitCushion = true;
-                if (
-                  nearPocket &&
-                  diffX <= BALL_R * 3 &&
-                  !nearPocketEdgeHit &&
-                  !pocketedAny
-                ) {
-                  nearPocketEdgeHit = true;
-                  playShock(1);
-                }
-              }
-              if (b.p.y > B) {
-                b.p.y = B;
-                var diffX2 = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
-                if (nearPocket && diffX2 <= BALL_R * 3) {
-                  var nx4 = b.p.x - nearest.x;
-                  var ny4 = b.p.y - nearest.y;
-                  var nL4 = Math.hypot(nx4, ny4) || 1;
-                  reflectVelocity(b.v, nx4 / nL4, ny4 / nL4, EDGE_BOUNCE);
-                } else {
-                  reflectVelocity(b.v, 0, -1, BOUNCE);
-                }
-                if (b.n === 0) {
-                  b.impacted = true;
-                  applySpinImpulse(b);
-                }
-                if (i === 0 && shotInProgress && !firstHit)
-                  cueHitCushion = true;
-                if (
-                  nearPocket &&
-                  diffX2 <= BALL_R * 3 &&
-                  !nearPocketEdgeHit &&
-                  !pocketedAny
-                ) {
-                  nearPocketEdgeHit = true;
-                  playShock(1);
-                }
-              }
             }
           }
 
@@ -2437,57 +2433,60 @@
 
           if (!isSnooker) {
             ctx.save();
-            ctx.fillStyle = 'rgba(255,255,0,0.05)';
-            ctx.fillRect(x0, y0, w, h);
-            ctx.strokeStyle = 'rgba(0,255,0,0.8)';
-            ctx.lineWidth = 2;
-            if (this.pockets) {
-              var p = this.pockets;
-              ctx.beginPath();
-              // top boundary
-              var topY = y0;
-              var topStart = (p[0].x + p[0].r * 1.1) * sX;
-              var topEnd = (p[1].x - p[1].r * 1.1) * sX;
-              ctx.moveTo(topStart, topY);
-              ctx.lineTo(topEnd, topY);
-              // bottom boundary
-              var bottomY = (TABLE_H - BORDER_BOTTOM) * sY;
-              var bottomStart = (p[4].x + p[4].r * 1.1) * sX;
-              var bottomEnd = (p[5].x - p[5].r * 1.1) * sX;
-              ctx.moveTo(bottomStart, bottomY);
-              ctx.lineTo(bottomEnd, bottomY);
-              // left boundary with side pocket
-              var xLeft = x0;
-              var leftTop = (p[0].y + p[0].r * 1.1) * sY;
-              var leftMidTop = (p[2].y - p[2].r * 1.1) * sY;
-              var leftMidBottom = (p[2].y + p[2].r * 1.1) * sY;
-              var leftBottom = (p[4].y - p[4].r * 1.1) * sY;
-              ctx.moveTo(xLeft, leftTop);
-              ctx.lineTo(xLeft, leftMidTop);
-              ctx.moveTo(xLeft, leftMidBottom);
-              ctx.lineTo(xLeft, leftBottom);
-              // right boundary with side pocket
-              var xRight = (TABLE_W - BORDER) * sX;
-              var rightTop = (p[1].y + p[1].r * 1.1) * sY;
-              var rightMidTop = (p[3].y - p[3].r * 1.1) * sY;
-              var rightMidBottom = (p[3].y + p[3].r * 1.1) * sY;
-              var rightBottom = (p[5].y - p[5].r * 1.1) * sY;
-              ctx.moveTo(xRight, rightTop);
-              ctx.lineTo(xRight, rightMidTop);
-              ctx.moveTo(xRight, rightMidBottom);
-              ctx.lineTo(xRight, rightBottom);
-              ctx.stroke();
-              ctx.strokeStyle = '#ff0';
-              drawVPocketGuide(this.pockets[2], 1);
-              drawVPocketGuide(this.pockets[3], -1);
-              drawUPocketGuide(this.pockets[0], 1, 1);
-              drawUPocketGuide(this.pockets[1], -1, 1);
-              drawUPocketGuide(this.pockets[4], 1, -1);
-              drawUPocketGuide(this.pockets[5], -1, -1);
-            } else {
-              ctx.strokeRect(x0, y0, w, h);
-            }
-            ctx.restore();
+              ctx.fillStyle = 'rgba(255,255,0,0.05)';
+              ctx.fillRect(x0, y0, w, h);
+              ctx.strokeStyle = 'rgba(0,255,0,0.8)';
+              ctx.lineWidth = 2;
+              if (this.pockets) {
+                var p = this.pockets;
+                var lineW = ctx.lineWidth;
+                var cornerGap = lineW * 4;
+                var sideGap = lineW * 2;
+                ctx.beginPath();
+                // top boundary
+                var topY = y0;
+                var topStart = (p[0].x + p[0].r) * sX + cornerGap;
+                var topEnd = (p[1].x - p[1].r) * sX - cornerGap;
+                ctx.moveTo(topStart, topY);
+                ctx.lineTo(topEnd, topY);
+                // bottom boundary
+                var bottomY = (TABLE_H - BORDER_BOTTOM) * sY;
+                var bottomStart = (p[4].x + p[4].r) * sX + cornerGap;
+                var bottomEnd = (p[5].x - p[5].r) * sX - cornerGap;
+                ctx.moveTo(bottomStart, bottomY);
+                ctx.lineTo(bottomEnd, bottomY);
+                // left boundary with side pocket
+                var xLeft = x0;
+                var leftTop = (p[0].y + p[0].r) * sY + cornerGap;
+                var leftMidTop = (p[2].y - p[2].r) * sY - sideGap;
+                var leftMidBottom = (p[2].y + p[2].r) * sY + sideGap;
+                var leftBottom = (p[4].y - p[4].r) * sY - cornerGap;
+                ctx.moveTo(xLeft, leftTop);
+                ctx.lineTo(xLeft, leftMidTop);
+                ctx.moveTo(xLeft, leftMidBottom);
+                ctx.lineTo(xLeft, leftBottom);
+                // right boundary with side pocket
+                var xRight = (TABLE_W - BORDER) * sX;
+                var rightTop = (p[1].y + p[1].r) * sY + cornerGap;
+                var rightMidTop = (p[3].y - p[3].r) * sY - sideGap;
+                var rightMidBottom = (p[3].y + p[3].r) * sY + sideGap;
+                var rightBottom = (p[5].y - p[5].r) * sY - cornerGap;
+                ctx.moveTo(xRight, rightTop);
+                ctx.lineTo(xRight, rightMidTop);
+                ctx.moveTo(xRight, rightMidBottom);
+                ctx.lineTo(xRight, rightBottom);
+                ctx.stroke();
+                ctx.strokeStyle = '#ff0';
+                drawVPocketGuide(this.pockets[2], 1);
+                drawVPocketGuide(this.pockets[3], -1);
+                drawUPocketGuide(this.pockets[0], 1, 1);
+                drawUPocketGuide(this.pockets[1], -1, 1);
+                drawUPocketGuide(this.pockets[4], 1, -1);
+                drawUPocketGuide(this.pockets[5], -1, -1);
+              } else {
+                ctx.strokeRect(x0, y0, w, h);
+              }
+              ctx.restore();
           }
 
           // Vija kufizuese e cueball-it dhe pika qendrore


### PR DESCRIPTION
## Summary
- Integrate yellow U and V pocket connectors into the playing field and trim green boundary lines for side and corner pockets.
- Update rail collision logic so balls striking near pocket edges deflect along 45° guides toward pockets.

## Testing
- `npm test` *(fails: ReferenceError: module is not defined in jest.config.js)*
- `npm run lint` *(fails: 964 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bafc919de88329b1aa5161250dddce