### PR TITLE
Increase pocket edge bounce in Pool Royale

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -971,7 +971,7 @@
 
         var FRICTION = 0.985; // ferkimi linear, pak me i vogel per te ruajtur shpejtesine
         var BOUNCE = 0.99; // koeficienti i rikthimit pak me i madh
-        var EDGE_BOUNCE = BOUNCE * 0.05; // skajet e gropave rikthejne 95% me pak
+        var EDGE_BOUNCE = BOUNCE * 0.15; // skajet e gropave rikthejne 85% me pak
 
         var MIN_V = 0.12; // shpejtesia min. qe konsiderohet "ne levizje"
 


### PR DESCRIPTION
## Summary
- make pocket edges more bouncy by tripling edge bounce coefficient

## Testing
- `npm test` *(fails: ReferenceError: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bb099b1e88832992bd400bbecabfc2