### PR TITLE
feat: improve pocket interaction and guides

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2137,9 +2137,16 @@
                   b.p.x = L;
                   var diffY = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
                   if (nearPocket && diffY <= BALL_R * 3) {
-                    var ny = b.p.y < nearest.y ? -1 : 1;
-                    var inv = 1 / Math.SQRT2;
-                    reflectVelocity(b.v, inv, ny * inv, EDGE_BOUNCE);
+                    var speed = Math.hypot(b.v.x, b.v.y);
+                    if (diffY <= BALL_R * 1.5) {
+                      var dir = norm(nearest.x - b.p.x, nearest.y - b.p.y);
+                      b.v.x = dir.x * speed;
+                      b.v.y = dir.y * speed;
+                    } else {
+                      var ny = b.p.y < nearest.y ? -1 : 1;
+                      var inv = 1 / Math.SQRT2;
+                      reflectVelocity(b.v, inv, ny * inv, EDGE_BOUNCE);
+                    }
                   } else {
                     reflectVelocity(b.v, 1, 0, BOUNCE);
                   }
@@ -2163,9 +2170,16 @@
                   b.p.x = R;
                   var diffY2 = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
                   if (nearPocket && diffY2 <= BALL_R * 3) {
-                    var ny2 = b.p.y < nearest.y ? -1 : 1;
-                    var inv2 = 1 / Math.SQRT2;
-                    reflectVelocity(b.v, -inv2, ny2 * inv2, EDGE_BOUNCE);
+                    var speed2 = Math.hypot(b.v.x, b.v.y);
+                    if (diffY2 <= BALL_R * 1.5) {
+                      var dir2 = norm(nearest.x - b.p.x, nearest.y - b.p.y);
+                      b.v.x = dir2.x * speed2;
+                      b.v.y = dir2.y * speed2;
+                    } else {
+                      var ny2 = b.p.y < nearest.y ? -1 : 1;
+                      var inv2 = 1 / Math.SQRT2;
+                      reflectVelocity(b.v, -inv2, ny2 * inv2, EDGE_BOUNCE);
+                    }
                   } else {
                     reflectVelocity(b.v, -1, 0, BOUNCE);
                   }
@@ -2189,9 +2203,16 @@
                   b.p.y = T;
                   var diffX = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
                   if (nearPocket && diffX <= BALL_R * 3) {
-                    var nx = nearest.x < TABLE_W / 2 ? 1 : -1;
-                    var inv3 = 1 / Math.SQRT2;
-                    reflectVelocity(b.v, nx * inv3, inv3, EDGE_BOUNCE);
+                    var speed3 = Math.hypot(b.v.x, b.v.y);
+                    if (diffX <= BALL_R * 1.5) {
+                      var dir3 = norm(nearest.x - b.p.x, nearest.y - b.p.y);
+                      b.v.x = dir3.x * speed3;
+                      b.v.y = dir3.y * speed3;
+                    } else {
+                      var nx = nearest.x < TABLE_W / 2 ? 1 : -1;
+                      var inv3 = 1 / Math.SQRT2;
+                      reflectVelocity(b.v, nx * inv3, inv3, EDGE_BOUNCE);
+                    }
                   } else {
                     reflectVelocity(b.v, 0, 1, BOUNCE);
                   }
@@ -2215,9 +2236,16 @@
                   b.p.y = B;
                   var diffX2 = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
                   if (nearPocket && diffX2 <= BALL_R * 3) {
-                    var nx2 = nearest.x < TABLE_W / 2 ? 1 : -1;
-                    var inv4 = 1 / Math.SQRT2;
-                    reflectVelocity(b.v, nx2 * inv4, -inv4, EDGE_BOUNCE);
+                    var speed4 = Math.hypot(b.v.x, b.v.y);
+                    if (diffX2 <= BALL_R * 1.5) {
+                      var dir4 = norm(nearest.x - b.p.x, nearest.y - b.p.y);
+                      b.v.x = dir4.x * speed4;
+                      b.v.y = dir4.y * speed4;
+                    } else {
+                      var nx2 = nearest.x < TABLE_W / 2 ? 1 : -1;
+                      var inv4 = 1 / Math.SQRT2;
+                      reflectVelocity(b.v, nx2 * inv4, -inv4, EDGE_BOUNCE);
+                    }
                   } else {
                     reflectVelocity(b.v, 0, -1, BOUNCE);
                   }
@@ -2483,6 +2511,14 @@
                 drawUPocketGuide(this.pockets[1], -1, 1);
                 drawUPocketGuide(this.pockets[4], 1, -1);
                 drawUPocketGuide(this.pockets[5], -1, -1);
+                ctx.strokeStyle = 'red';
+                ctx.lineWidth = 2;
+                var rScale = (sX + sY) / 2;
+                this.pockets.forEach(function(pk) {
+                  ctx.beginPath();
+                  ctx.arc(pk.x * sX, pk.y * sY, pk.r * rScale, 0, Math.PI * 2);
+                  ctx.stroke();
+                });
               } else {
                 ctx.strokeRect(x0, y0, w, h);
               }

--- a/webapp/public/snooker-training.html
+++ b/webapp/public/snooker-training.html
@@ -87,7 +87,8 @@
       drawWoodRail(W, H, R);
       drawCushions(ix, iy, iw, ih, R, C);
       drawFelt(ix, iy, iw, ih);
-      drawPockets(W, H, R, C);
+      const pockets = drawPockets(W, H, R, C);
+      drawPocketGuides(pockets, ix, iy, iw, ih);
       drawRailSights(W, H, R);
       drawSnookerMarkings(ix, iy, iw, ih);
 
@@ -187,14 +188,19 @@
       ctx.fillStyle = getVar('--pocket');
       const midY = iy + ih / 2;
       const pockets = [
-        { x: ix - 6, y: iy - 6 },
-        { x: ix + iw + 6, y: iy - 6 },
-        { x: ix - 6, y: iy + ih + 6 },
-        { x: ix + iw + 6, y: iy + ih + 6 },
-        { x: ix - 6, y: midY },
-        { x: ix + iw + 6, y: midY }
+        { x: ix - 6, y: iy - 6, r: pr },
+        { x: ix + iw + 6, y: iy - 6, r: pr },
+        { x: ix - 6, y: iy + ih + 6, r: pr },
+        { x: ix + iw + 6, y: iy + ih + 6, r: pr },
+        { x: ix - 6, y: midY, r: pr },
+        { x: ix + iw + 6, y: midY, r: pr }
       ];
-      pockets.forEach(p => { ctx.beginPath(); ctx.arc(p.x, p.y, pr, 0, Math.PI * 2); ctx.fill(); });
+      pockets.forEach(p => {
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+        ctx.fill();
+      });
+      return pockets;
     }
 
     function drawRailSights(W, H, R) {
@@ -211,21 +217,74 @@
     }
 
     function drawSnookerMarkings(ix, iy, iw, ih) {
-      ctx.strokeStyle = getVar('--line');
-      ctx.fillStyle = getVar('--line');
-      ctx.lineWidth = CONFIG.lineWidth;
-      const fromTop = f => iy + ih * f; const cx = ix + iw / 2;
-      const baulkY = fromTop(CONFIG.baulkFromCushion);
-      const blueY = iy + ih / 2;
-      const pinkY = iy + ih * CONFIG.pinkFromTop;
-      const blackY = iy + ih * CONFIG.blackFromTop;
+      // Snooker-specific markings are omitted to match the pool-style field
+    }
 
-      ctx.beginPath(); ctx.moveTo(ix, baulkY); ctx.lineTo(ix + iw, baulkY); ctx.stroke();
-      const Dr = iw * 0.18; ctx.beginPath(); ctx.arc(cx, baulkY, Dr, Math.PI, 2 * Math.PI, false); ctx.stroke();
+    function drawPocketGuides(pockets, ix, iy, iw, ih) {
+      ctx.strokeStyle = 'rgba(0,255,0,0.8)';
+      ctx.lineWidth = 2;
+      const cornerGap = ctx.lineWidth * 4;
+      const sideGap = ctx.lineWidth * 2;
+      const topY = iy;
+      const bottomY = iy + ih;
+      const xLeft = ix;
+      const xRight = ix + iw;
+      ctx.beginPath();
+      ctx.moveTo(pockets[0].x + pockets[0].r + cornerGap, topY);
+      ctx.lineTo(pockets[1].x - pockets[1].r - cornerGap, topY);
+      ctx.moveTo(pockets[2].x + pockets[2].r + cornerGap, bottomY);
+      ctx.lineTo(pockets[3].x - pockets[3].r - cornerGap, bottomY);
+      ctx.moveTo(xLeft, pockets[0].y + pockets[0].r + cornerGap);
+      ctx.lineTo(xLeft, pockets[4].y - pockets[4].r - sideGap);
+      ctx.moveTo(xLeft, pockets[4].y + pockets[4].r + sideGap);
+      ctx.lineTo(xLeft, pockets[2].y - pockets[2].r - cornerGap);
+      ctx.moveTo(xRight, pockets[1].y + pockets[1].r + cornerGap);
+      ctx.lineTo(xRight, pockets[5].y - pockets[5].r - sideGap);
+      ctx.moveTo(xRight, pockets[5].y + pockets[5].r + sideGap);
+      ctx.lineTo(xRight, pockets[3].y - pockets[3].r - cornerGap);
+      ctx.stroke();
+      ctx.strokeStyle = '#ff0';
+      drawVPocketGuide(pockets[4], 1);
+      drawVPocketGuide(pockets[5], -1);
+      drawUPocketGuide(pockets[0], 1, 1);
+      drawUPocketGuide(pockets[1], -1, 1);
+      drawUPocketGuide(pockets[2], 1, -1);
+      drawUPocketGuide(pockets[3], -1, -1);
+      ctx.strokeStyle = 'red';
+      pockets.forEach(p => { ctx.beginPath(); ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2); ctx.stroke(); });
+    }
 
-      const gy = baulkY; const greenX = ix + iw * 0.25, brownX = cx, yellowX = ix + iw * 0.75;
-      [[greenX, gy], [brownX, gy], [yellowX, gy]].forEach(([sx, sy]) => { ctx.beginPath(); ctx.arc(sx, sy, CONFIG.spotRadius, 0, Math.PI * 2); ctx.fill(); });
-      [[cx, blueY], [cx, pinkY], [cx, blackY]].forEach(([sx, sy]) => { ctx.beginPath(); ctx.arc(sx, sy, CONFIG.spotRadius, 0, Math.PI * 2); ctx.fill(); });
+    function drawVPocketGuide(p, dir) {
+      const R = p.r * 1.2;
+      const x = p.x - R * 0.5 * dir;
+      const y = p.y;
+      const dx = R * 1.1 * dir;
+      const dy = R * 1.25;
+      const trim = R * 0.1;
+      ctx.beginPath();
+      ctx.moveTo(x - dx, y);
+      ctx.lineTo(x + dx, y - dy + trim);
+      ctx.moveTo(x - dx, y);
+      ctx.lineTo(x + dx, y + dy - trim);
+      ctx.stroke();
+    }
+
+    function drawUPocketGuide(p, sx, sy) {
+      const R = p.r * 1.1;
+      ctx.save();
+      ctx.translate(p.x, p.y);
+      ctx.scale(sx, sy);
+      ctx.rotate(-Math.PI / 4);
+      ctx.beginPath();
+      ctx.arc(0, 0, R, Math.PI, 0);
+      const lineLen = R * 1.2;
+      const lineStart = R * 0.1;
+      ctx.moveTo(-R, lineStart);
+      ctx.lineTo(-R, lineLen);
+      ctx.moveTo(R, lineStart);
+      ctx.lineTo(R, lineLen);
+      ctx.stroke();
+      ctx.restore();
     }
 
     function roundRect(c, x, y, w, h, r) {


### PR DESCRIPTION
## Summary
- refine pocket-edge physics so balls are directed into pockets unless striking the outer lip
- overlay red circles marking pockets on Pool Royale
- render Pool Royale-style pocket guides and red circles for snooker training canvas

## Testing
- `npm run lint` *(fails: Extra semicolon, spacing, etc.)*
- `npm test` *(fails: ReferenceError: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0ccf46d48329858c2ffe28a89283