### PR TITLE
Shrink snooker training pockets

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -948,12 +948,12 @@
         var TABLE_W = 768; // gjeresi logjike e felt-it
         var TABLE_H = 1216; // lartesi logjike e felt-it
         var BORDER = 57; // korniza e drurit pak me e ngushte anash
+        var BALL_R = isSnooker && playType === 'training' ? 18 : 22; // snooker training uses smaller balls
         // Gropat pak me te vogla per t'u mbyllur me shume dhe jo per t'u zgjeruar
-        var POCKET_R = 32; // rrezja baze e gropave pak me e vogel nga jashte
-        var SIDE_POCKET_R = 30; // gropat anesore gjithashtu pak me te vogla
+        var POCKET_R = isSnooker && playType === 'training' ? BALL_R * 0.65 : 32; // rrezja baze e gropave pak me e vogel nga jashte
+        var SIDE_POCKET_R = isSnooker && playType === 'training' ? POCKET_R : 30; // gropat anesore gjithashtu pak me te vogla
         // move pockets slightly closer to the center of the table
         var POCKET_SHORTEN = 4; // gropat zhvendosen pak me brenda per te ruajtur anen e brendshme
-        var BALL_R = isSnooker && playType === 'training' ? 18 : 22; // snooker training uses smaller balls
         var SHORT_DIST = BALL_R * 28;
         var MED_DIST = BALL_R * 56;
         var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate

--- a/webapp/public/snooker-table.html
+++ b/webapp/public/snooker-table.html
@@ -42,7 +42,7 @@
     const ctx = canvas.getContext('2d');
     const BALL_R = 18;
     const POCKET_SHORTEN = 4;
-    const POCKET_R = BALL_R * 1.3;
+    const POCKET_R = BALL_R * 0.65; // half-size pockets for snooker training
     const SIDE_POCKET_R = POCKET_R;
 
     function resize(){


### PR DESCRIPTION
## Summary
- Set snooker training canvas pockets to half-size
- Match game logic pocket radii to new canvas values for snooker training only

## Testing
- `npm test`
- `npm run lint` *(fails: 964 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2bf08bf883298739fb05b07d93ab