### PR TITLE
Simplify snooker training table overlay

### DIFF
--- a/webapp/public/snooker-table.html
+++ b/webapp/public/snooker-table.html
@@ -3,53 +3,30 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Tavolinë Snooker – Canvas (Portret, Fullscreen)</title>
+  <title>Snooker Training Field</title>
   <style>
-    :root{
-      --felt:#0f6b3a;
-      --felt-light:#178a4b;
-      --felt-dark:#0d5a30;
-      --wood-1:#c86f2b;
-      --wood-2:#a6571e;
-      --wood-3:#de8a42;
-      --cushion:#1a7a42;
-      --line:#e8f7e9;
-      --pocket:#141414;
-    }
-    html,body{height:100%;margin:0;background:#0b0f1a}
+    html,body{height:100%;margin:0;background:transparent}
     .stage{position:relative;width:100vw;height:100vh}
-    #table,#markings{position:absolute;inset:0;width:100%;height:100%;display:block;border-radius:22px}
-    #markings{pointer-events:none}
+    #markings{position:absolute;inset:0;width:100%;height:100%;display:block;pointer-events:none}
   </style>
 </head>
 <body>
   <div class="stage">
-    <canvas id="table"></canvas>
     <canvas id="markings"></canvas>
   </div>
   <script>
-      const CONFIG = {
-        rail: 16,
-        cushion: 16,
-        sightSpacing: 120,
-        sightRadius: 3.5,
-        lineWidth: 2,
-        spotRadius: 3.2,
-        rotate90: false,
-        baulkFromCushion: 0.206,
-        pinkFromTop: 0.75,
-        blackFromTop: 0.89,
-        cornerCurve: 28,
-        sideCurve: 34
+    const CONFIG = {
+      rail: 16,
+      cushion: 16,
+      lineWidth: 2,
+      rotate90: false
     };
 
-    const canvas = document.getElementById('table');
+    const canvas = document.getElementById('markings');
     const ctx = canvas.getContext('2d');
-    const markCanvas = document.getElementById('markings');
-    const markCtx = markCanvas.getContext('2d');
     const BALL_R = 18;
     const POCKET_SHORTEN = 4;
-    const POCKET_R = BALL_R * 0.65; // half-size pockets for snooker training
+    const POCKET_R = BALL_R * 0.65;
     const SIDE_POCKET_R = POCKET_R;
 
     function resize(){
@@ -58,10 +35,7 @@
       const h = canvas.clientHeight;
       canvas.width  = Math.floor(w * dpr);
       canvas.height = Math.floor(h * dpr);
-      markCanvas.width  = Math.floor(w * dpr);
-      markCanvas.height = Math.floor(h * dpr);
       ctx.setTransform(dpr,0,0,dpr,0,0);
-      markCtx.setTransform(dpr,0,0,dpr,0,0);
       draw();
     }
 
@@ -70,16 +44,11 @@
       let H = canvas.clientHeight;
 
       ctx.save();
-      markCtx.save();
       ctx.translate(W, H);
-      markCtx.translate(W, H);
       ctx.rotate(Math.PI);
-      markCtx.rotate(Math.PI);
       if(CONFIG.rotate90){
         ctx.translate(W,0);
-        markCtx.translate(W,0);
         ctx.rotate(Math.PI/2);
-        markCtx.rotate(Math.PI/2);
         const tmp = W; W = H; H = tmp;
       }
 
@@ -91,97 +60,17 @@
       const ih = H - 2*(R + C);
 
       ctx.clearRect(0,0,W,H);
-      markCtx.clearRect(0,0,W,H);
-      drawShadow(W,H);
-      drawWoodRail(W,H,R);
-      drawCushions(ix, iy, iw, ih, R, C);
-      drawFelt(ix, iy, iw, ih);
-      drawPockets(W,H,R,C);
-      drawRailSights(W,H,R);
       drawSnookerMarkings(ix, iy, iw, ih);
-
-      markCtx.restore();
       ctx.restore();
     }
 
-    function drawShadow(W,H){
-      const g = ctx.createLinearGradient(0,0,0,H);
-      g.addColorStop(0,'rgba(0,0,0,.35)');
-      g.addColorStop(1,'rgba(0,0,0,.55)');
-      ctx.fillStyle = g;
-      roundRect(ctx, 6,6, W-12, H-12, 24);
-      ctx.fill();
-    }
+    function drawSnookerMarkings(ix, iy, iw, ih){
+      ctx.lineWidth = CONFIG.lineWidth;
+      // table boundary in green
+      ctx.strokeStyle = 'green';
+      ctx.strokeRect(ix, iy, iw, ih);
 
-    function drawWoodRail(W,H,R){
-      const g = ctx.createLinearGradient(0,0,0,H);
-      g.addColorStop(0, getVar('--wood-3'));
-      g.addColorStop(.5, getVar('--wood-1'));
-      g.addColorStop(1, getVar('--wood-2'));
-      ctx.fillStyle = g;
-      roundRect(ctx, 0,0, W, H, 20);
-      ctx.fill();
-
-      ctx.save();
-      ctx.globalCompositeOperation = 'destination-out';
-      roundRect(ctx, R, R, W-2*R, H-2*R, 15);
-      ctx.fill();
-      ctx.restore();
-    }
-
-    function drawCushions(ix,iy,iw,ih,R,C){
-      const x = R, y = R, w = (ix - R) + iw + C, h = (iy - R) + ih + C;
-      const g = ctx.createLinearGradient(0, y, 0, y+C);
-      g.addColorStop(0, '#0e4d2a');
-      g.addColorStop(1, getVar('--cushion'));
-      ctx.fillStyle = g;
-      roundRect(ctx, x, y, w, h, 12);
-      ctx.fill();
-
-      ctx.save();
-      ctx.globalCompositeOperation = 'destination-out';
-      ctx.beginPath();
-      moveInnerWithCurves(ctx, ix, iy, iw, ih);
-      ctx.fill();
-      ctx.restore();
-    }
-
-    function moveInnerWithCurves(c, x, y, w, h){
-      const top=y, bottom=y+h, left=x, right=x+w;
-      const midY = y + h/2;
-      const cornerR = CONFIG.cornerCurve;
-      const sideR = CONFIG.sideCurve;
-
-      c.moveTo(left+cornerR, top);
-      c.lineTo(right-cornerR, top);
-      c.quadraticCurveTo(right, top, right, top+cornerR);
-      c.lineTo(right, midY - sideR);
-      c.quadraticCurveTo(right, midY, right-sideR, midY);
-      c.quadraticCurveTo(right, midY, right, midY+sideR);
-      c.lineTo(right, bottom-cornerR);
-      c.quadraticCurveTo(right, bottom, right-cornerR, bottom);
-      c.lineTo(left+cornerR, bottom);
-      c.quadraticCurveTo(left, bottom, left, bottom-cornerR);
-      c.lineTo(left, midY+sideR);
-      c.quadraticCurveTo(left, midY, left+sideR, midY);
-      c.quadraticCurveTo(left, midY, left, midY-sideR);
-      c.lineTo(left, top+cornerR);
-      c.quadraticCurveTo(left, top, left+cornerR, top);
-      c.closePath();
-    }
-
-    function drawFelt(ix,iy,iw,ih){
-      const g = ctx.createRadialGradient(ix+iw*0.5, iy+ih*0.45, Math.min(iw,ih)*0.05, ix+iw*0.5, iy+ih*0.5, Math.max(iw,ih)*0.8);
-      g.addColorStop(0, getVar('--felt-light'));
-      g.addColorStop(0.6, getVar('--felt'));
-      g.addColorStop(1, getVar('--felt-dark'));
-      ctx.fillStyle = g;
-      ctx.fillRect(ix,iy,iw,ih);
-    }
-
-    function drawPockets(W,H,R,C){
-      const ix = R + C, iy = R + C, iw = W - 2 * (R + C), ih = H - 2 * (R + C);
-      ctx.fillStyle = getVar('--pocket');
+      // pocket outlines in red
       const midY = iy + ih / 2;
       const pockets = [
         { x: ix - POCKET_SHORTEN + 4, y: iy - POCKET_SHORTEN, r: POCKET_R },
@@ -191,61 +80,35 @@
         { x: ix - POCKET_SHORTEN, y: iy + ih + POCKET_SHORTEN, r: POCKET_R },
         { x: ix + iw + POCKET_SHORTEN, y: iy + ih + POCKET_SHORTEN, r: POCKET_R }
       ];
-      pockets.forEach((p) => {
+      ctx.strokeStyle = 'red';
+      pockets.forEach(p => {
         ctx.beginPath();
         ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
-        ctx.fill();
+        ctx.stroke();
       });
+
+      // connectors U and V in yellow
+      ctx.strokeStyle = 'yellow';
+      const inset = iw * 0.1;
+      // U connector
+      ctx.beginPath();
+      ctx.moveTo(ix + inset, iy);
+      ctx.lineTo(ix + inset, iy + ih);
+      ctx.lineTo(ix + iw - inset, iy + ih);
+      ctx.lineTo(ix + iw - inset, iy);
+      ctx.stroke();
+
+      // V connector
+      ctx.beginPath();
+      ctx.moveTo(ix + inset, iy + ih);
+      ctx.lineTo(ix + iw / 2, iy + inset);
+      ctx.lineTo(ix + iw - inset, iy + ih);
+      ctx.stroke();
     }
-
-    function drawRailSights(W,H,R){
-      const spacing = CONFIG.sightSpacing;
-      ctx.fillStyle = 'rgba(0,0,0,.7)';
-      for(let x = R + spacing; x <= W - R - spacing; x += spacing){
-        ctx.beginPath(); ctx.arc(x, R*0.55, CONFIG.sightRadius, 0, Math.PI*2); ctx.fill();
-        ctx.beginPath(); ctx.arc(x, H - R*0.55, CONFIG.sightRadius, 0, Math.PI*2); ctx.fill();
-      }
-      for(let y = R + spacing; y <= H - R - spacing; y += spacing){
-        ctx.beginPath(); ctx.arc(R*0.55, y, CONFIG.sightRadius, 0, Math.PI*2); ctx.fill();
-        ctx.beginPath(); ctx.arc(W - R*0.55, y, CONFIG.sightRadius, 0, Math.PI*2); ctx.fill();
-      }
-    }
-
-    function drawSnookerMarkings(ix,iy,iw,ih){
-      markCtx.strokeStyle = getVar('--line');
-      markCtx.lineWidth = CONFIG.lineWidth;
-      markCtx.strokeRect(ix, iy, iw, ih);
-
-      const midY = iy + ih / 2;
-      const pockets = [
-        { x: ix - POCKET_SHORTEN + 4, y: iy - POCKET_SHORTEN, r: POCKET_R },
-        { x: ix + iw + POCKET_SHORTEN - 4, y: iy - POCKET_SHORTEN, r: POCKET_R },
-        { x: ix - 16 - POCKET_SHORTEN, y: midY + BALL_R - 14, r: SIDE_POCKET_R },
-        { x: ix + iw + 16 + POCKET_SHORTEN, y: midY + BALL_R - 14, r: SIDE_POCKET_R },
-        { x: ix - POCKET_SHORTEN, y: iy + ih + POCKET_SHORTEN, r: POCKET_R },
-        { x: ix + iw + POCKET_SHORTEN, y: iy + ih + POCKET_SHORTEN, r: POCKET_R }
-      ];
-      pockets.forEach(p => {
-        markCtx.beginPath();
-        markCtx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
-        markCtx.stroke();
-      });
-    }
-
-    function roundRect(c, x,y,w,h,r){
-      c.beginPath();
-      c.moveTo(x+r, y);
-      c.arcTo(x+w, y,   x+w, y+h, r);
-      c.arcTo(x+w, y+h, x,   y+h, r);
-      c.arcTo(x,   y+h, x,   y,   r);
-      c.arcTo(x,   y,   x+w, y,   r);
-      c.closePath();
-    }
-
-    function getVar(name){return getComputedStyle(document.documentElement).getPropertyValue(name)}
 
     resize();
     window.addEventListener('resize', resize);
   </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Replace snooker training table with transparent overlay containing only field markings
- Draw table borders in green, pocket circles in red, and U/V connectors in yellow

## Testing
- `npm test`
- `npm run lint` *(fails: 964 problems, mainly existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb354f7df8832980b3c544e40ec9c4