### PR TITLE
Double snooker pocket and connector size

### DIFF
--- a/webapp/public/snooker-table.html
+++ b/webapp/public/snooker-table.html
@@ -22,8 +22,8 @@
     const TABLE_W = 768;
     const TABLE_H = 1216;
     const BALL_R = 18;
-    const POCKET_SHORTEN = 4;
-    const POCKET_R = BALL_R * 0.65;
+    const POCKET_SHORTEN = 8;
+    const POCKET_R = BALL_R * 1.3;
     const SIDE_POCKET_R = POCKET_R;
     const BORDER = 57;
     const BORDER_TOP = BORDER + BALL_R * 2 - 4;

--- a/webapp/public/snooker-training.html
+++ b/webapp/public/snooker-training.html
@@ -32,7 +32,7 @@
     const CONFIG = {
       rail: 48,
       cushion: 22,
-      pocketRadius: 26,
+      pocketRadius: 52,
       sightSpacing: 120,
       sightRadius: 3.5,
       lineWidth: 2,
@@ -42,8 +42,8 @@
       baulkFromCushion: 0.206,
       pinkFromTop: 0.75,
       blackFromTop: 0.89,
-      cornerCurve: 28, // radius i harkut te cepat
-      sideCurve: 34    // radius i harkut anësor
+      cornerCurve: 56, // radius i harkut te cepat
+      sideCurve: 68    // radius i harkut anësor
     };
 
     const canvas = document.getElementById('table');


### PR DESCRIPTION
## Summary
- enlarge snooker table pockets and side connectors by doubling their dimensions
- increase pocket radius and corner/side curve connectors in snooker training canvas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3f5dae6c83299a909d2a41183240