### PR TITLE
Fix pocket entry by relaxing table clamp near pocket edges

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -137,3 +137,22 @@ public class PocketEdgeTests
         Assert.That(ball.Velocity.Length, Is.InRange(preSpeed * 0.4, preSpeed * 0.7));
     }
 }
+
+public class PocketEntryTests
+{
+    [Test]
+    public void BallCanEnterPocketWithoutReflection()
+    {
+        var solver = new BilliardsSolver();
+        solver.PocketEdges.Add(new BilliardsSolver.Edge
+        {
+            A = new Vec2(0, 0.1),
+            B = new Vec2(0.1, 0),
+            Normal = new Vec2(1, 1).Normalized()
+        });
+        var ball = new BilliardsSolver.Ball { Position = new Vec2(0.2, 0.2), Velocity = new Vec2(-2, -2) };
+        solver.Step(new List<BilliardsSolver.Ball> { ball }, 0.4);
+        Assert.That(ball.Position.X, Is.LessThan(0));
+        Assert.That(ball.Position.Y, Is.LessThan(0));
+    }
+}

--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -36,12 +36,28 @@ public class BilliardsSolver
         public Vec2? TargetVelocity;
     }
 
-    private static void ClampToTable(Ball b)
+    private bool IsBeyondPocketEdges(Vec2 position)
+    {
+        foreach (var e in PocketEdges)
+        {
+            var n = e.Normal.Normalized();
+            double dist = Vec2.Dot(position - e.A, n);
+            if (dist < -PhysicsConstants.BallRadius)
+                return true;
+        }
+        return false;
+    }
+
+    private void ClampToTable(Ball b)
     {
         double minX = PhysicsConstants.BallRadius;
         double maxX = PhysicsConstants.TableWidth - PhysicsConstants.BallRadius;
         double minY = PhysicsConstants.BallRadius;
         double maxY = PhysicsConstants.TableHeight - PhysicsConstants.BallRadius;
+
+        bool outOfBounds = b.Position.X < minX || b.Position.X > maxX || b.Position.Y < minY || b.Position.Y > maxY;
+        if (outOfBounds && IsBeyondPocketEdges(b.Position))
+            return;
 
         if (b.Position.X < minX)
         {


### PR DESCRIPTION
## Summary
- Stop clamping balls that have moved beyond pocket edges so they can fall into pockets
- Add regression test ensuring balls can travel into pocket funnels

## Testing
- `npm test`
- `dotnet test billiards.Tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3ec42da88329ba66f7c99224779a