### PR TITLE
Fix Pool Royale pocket detection so balls can sink

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2415,7 +2415,7 @@
               if (b2.pocketed) continue;
               var ddx = b2.p.x - p.x,
                 ddy = b2.p.y - p.y;
-              if (Math.hypot(ddx, ddy) < p.r - BALL_R * 0.1) {
+              if (Math.hypot(ddx, ddy) < p.r + BALL_R * 0.1) {
                 var spd = Math.hypot(b2.v.x, b2.v.y);
                 playPocket(clamp(spd / 4000, 0, 1));
                 if (!shotPocketRecorded) {


### PR DESCRIPTION
## Summary
- adjust pool pocket capture radius so balls can properly sink in Pool Royale

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb43d2f30883298667e9c579ebb682