### PR TITLE
feat(snooker): add snooker image wrapper

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -186,6 +186,11 @@
         z-index: -1;
       }
 
+      #wrap.snooker::before {
+        background: url('/assets/icons/file_0000000010bc61f9923523eadfcfcf37.webp')
+          top center/calc(100% + 8px) calc(100% + 20px) no-repeat;
+      }
+
       /* Hide background table when Snooker training is active */
       #wrap.snooker-training::before {
         background: none;
@@ -939,6 +944,9 @@
         window.playerName = params.get('name') || 'Player';
         if (isSnooker && playType === 'training') {
           document.getElementById('wrap').classList.add('snooker-training');
+        }
+        if (isSnooker) {
+          document.getElementById('wrap').classList.add('snooker');
         }
         const planShotPromise = import('/lib/poolAi.js');
 


### PR DESCRIPTION
## Summary
- use dedicated background image for Snooker table
- initialize Snooker class for game wrapper

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bb463438748329a4c7867b230f3230