### PR TITLE
fix: show snooker table background in training

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -191,10 +191,6 @@
           top center/calc(100% + 8px) calc(100% + 20px) no-repeat;
       }
 
-      /* Hide background table when Snooker training is active */
-      #wrap.snooker-training::before {
-        background: none;
-      }
 
       #snookerTable {
         position: absolute;


### PR DESCRIPTION
## Summary
- remove snooker training override that cleared table background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb488592008329ab28c4879110e373