### PR TITLE
fix(pool-royale): allow balls to enter pockets

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -1694,6 +1694,10 @@
           var rx = b.p.x - pk.x;
           var ry = b.p.y - pk.y;
           if (!cond(rx, ry)) return;
+          // Allow the ball to pass into the pocket once its center
+          // reaches the pocket circle. This avoids balls getting
+          // stuck halfway through the connector edge.
+          if (Math.hypot(rx, ry) <= pk.r) return;
           var limit = pk.r + BALL_R;
           var dist = rx * nx + ry * ny;
           if (dist >= limit) return;


### PR DESCRIPTION
## Summary
- allow balls to pass connector edges once their center crosses the pocket

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb4af78c808329960faa75231d5b97