### PR TITLE
feat(snooker): add background wrapper

### DIFF
--- a/webapp/public/snooker-table.html
+++ b/webapp/public/snooker-table.html
@@ -7,11 +7,16 @@
   <style>
     html,body{height:100%;margin:0;background:transparent}
     .stage{position:relative;width:100vw;height:100vh}
+    .bg-wrapper{position:absolute;inset:0}
+    .bg-wrapper img{width:100%;height:100%;object-fit:cover;display:block}
     #markings{position:absolute;inset:0;width:100%;height:100%;display:block;pointer-events:none}
   </style>
 </head>
 <body>
   <div class="stage">
+    <div class="bg-wrapper">
+      <img src="/assets/icons/file_0000000010bc61f9923523eadfcfcf37.webp" alt="Snooker table background" />
+    </div>
     <canvas id="markings"></canvas>
   </div>
   <script>


### PR DESCRIPTION
## Summary
- add bg wrapper with snooker table image so canvas aligns like Pool Royale background

## Testing
- `npm test`
- `npm run lint` *(fails: 964 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4e60399883298768b56847cef2f4