### PR TITLE
Remove lip-out and rattle options in Pool Royale

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -971,8 +971,6 @@
 
         var FRICTION = 0.985; // ferkimi linear, pak me i vogel per te ruajtur shpejtesine
         var BOUNCE = 0.99; // koeficienti i rikthimit pak me i madh
-        var EDGE_BOUNCE = BOUNCE * 0.15; // skajet e gropave rikthejne 85% me pak
-        var CONNECTOR_SLIDE_SPEED = 50; // shpejtesia njesoj me shume e ulet per te lejuar rreshqitjen ne konektore
         var INV_SQRT2 = 1 / Math.SQRT2;
 
         var MIN_V = 0.12; // shpejtesia min. qe konsiderohet "ne levizje"
@@ -1686,32 +1684,6 @@
           v.y = (v.y - 2 * dot * ny) * bounce;
         }
 
-        function handleConnectorCollision(tbl, b, pk, nx, ny, cond) {
-          var rx = b.p.x - pk.x;
-          var ry = b.p.y - pk.y;
-          if (!cond(rx, ry)) return;
-          var limit = pk.r + BALL_R;
-          var dist = rx * nx + ry * ny;
-          if (dist >= limit) return;
-          var pen = limit - dist;
-          b.p.x += nx * pen;
-          b.p.y += ny * pen;
-          var speed = Math.hypot(b.v.x, b.v.y);
-          if (speed < CONNECTOR_SLIDE_SPEED) {
-            var vn = b.v.x * nx + b.v.y * ny;
-            b.v.x -= vn * nx;
-            b.v.y -= vn * ny;
-          } else {
-            reflectVelocity(b.v, nx, ny, BOUNCE);
-          }
-          if (b.n === 0) {
-            b.impacted = true;
-            applySpinImpulse(b);
-          }
-          if (b === tbl.balls[0] && shotInProgress && !firstHit)
-            cueHitCushion = true;
-        }
-
         function brighten(hex, amt) {
           var c = hex.slice(1);
           if (c.length === 3)
@@ -2129,199 +2101,49 @@
             var R = TABLE_W - BORDER - BALL_R;
             var T = BORDER_TOP + BALL_R;
             var B = TABLE_H - BORDER_BOTTOM - BALL_R;
-            var nearest = null,
-              prevDist = Infinity;
-            for (var k = 0; k < this.pockets.length; k++) {
-              var pk = this.pockets[k];
-              var dPrev = Math.hypot(prevX - pk.x, prevY - pk.y);
-              if (dPrev < prevDist) {
-                prevDist = dPrev;
-                nearest = pk;
-              }
+            if (b.n === 0) {
+              if (b.p.x - L < BALL_R * 1.5 && b.v.x < 0) applySpinImpulse(b);
+              if (R - b.p.x < BALL_R * 1.5 && b.v.x > 0) applySpinImpulse(b);
+              if (b.p.y - T < BALL_R * 1.5 && b.v.y < 0) applySpinImpulse(b);
+              if (B - b.p.y < BALL_R * 1.5 && b.v.y > 0) applySpinImpulse(b);
             }
-            var newDist = nearest
-              ? Math.hypot(b.p.x - nearest.x, b.p.y - nearest.y)
-              : Infinity;
-            // Detect when a ball just grazes a pocket to trigger a crowd reaction
-            var nearPocket = nearest && newDist < nearest.r + BALL_R + 15;
-            var approaching = nearest && newDist < prevDist;
-            if (
-              nearPocket &&
-              !approaching &&
-              !nearPocketEdgeHit &&
-              !pocketedAny
-            ) {
-              nearPocketEdgeHit = true;
-              playShock(1);
-            }
-            if (!nearPocket || !approaching) {
+            if (b.p.x < L) {
+              b.p.x = L;
+              reflectVelocity(b.v, 1, 0, BOUNCE);
               if (b.n === 0) {
-                if (b.p.x - L < BALL_R * 1.5 && b.v.x < 0) applySpinImpulse(b);
-                if (R - b.p.x < BALL_R * 1.5 && b.v.x > 0) applySpinImpulse(b);
-                if (b.p.y - T < BALL_R * 1.5 && b.v.y < 0) applySpinImpulse(b);
-                if (B - b.p.y < BALL_R * 1.5 && b.v.y > 0) applySpinImpulse(b);
+                b.impacted = true;
+                applySpinImpulse(b);
               }
-                if (b.p.x < L) {
-                  b.p.x = L;
-                  var diffY = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
-                  if (nearPocket && diffY <= BALL_R * 3) {
-                    var speed = Math.hypot(b.v.x, b.v.y);
-                    if (diffY <= BALL_R * 1.5) {
-                      var dir = norm(nearest.x - b.p.x, nearest.y - b.p.y);
-                      b.v.x = dir.x * speed;
-                      b.v.y = dir.y * speed;
-                    } else {
-                      var ny = b.p.y < nearest.y ? -1 : 1;
-                      var inv = 1 / Math.SQRT2;
-                      reflectVelocity(b.v, inv, ny * inv, EDGE_BOUNCE);
-                    }
-                  } else {
-                    reflectVelocity(b.v, 1, 0, BOUNCE);
-                  }
-                  if (b.n === 0) {
-                    b.impacted = true;
-                    applySpinImpulse(b);
-                  }
-                  if (i === 0 && shotInProgress && !firstHit)
-                    cueHitCushion = true;
-                  if (
-                    nearPocket &&
-                    diffY <= BALL_R * 3 &&
-                    !nearPocketEdgeHit &&
-                    !pocketedAny
-                  ) {
-                    nearPocketEdgeHit = true;
-                    playShock(1);
-                  }
-                }
-                if (b.p.x > R) {
-                  b.p.x = R;
-                  var diffY2 = nearest ? Math.abs(b.p.y - nearest.y) : Infinity;
-                  if (nearPocket && diffY2 <= BALL_R * 3) {
-                    var speed2 = Math.hypot(b.v.x, b.v.y);
-                    if (diffY2 <= BALL_R * 1.5) {
-                      var dir2 = norm(nearest.x - b.p.x, nearest.y - b.p.y);
-                      b.v.x = dir2.x * speed2;
-                      b.v.y = dir2.y * speed2;
-                    } else {
-                      var ny2 = b.p.y < nearest.y ? -1 : 1;
-                      var inv2 = 1 / Math.SQRT2;
-                      reflectVelocity(b.v, -inv2, ny2 * inv2, EDGE_BOUNCE);
-                    }
-                  } else {
-                    reflectVelocity(b.v, -1, 0, BOUNCE);
-                  }
-                  if (b.n === 0) {
-                    b.impacted = true;
-                    applySpinImpulse(b);
-                  }
-                  if (i === 0 && shotInProgress && !firstHit)
-                    cueHitCushion = true;
-                  if (
-                    nearPocket &&
-                    diffY2 <= BALL_R * 3 &&
-                    !nearPocketEdgeHit &&
-                    !pocketedAny
-                  ) {
-                    nearPocketEdgeHit = true;
-                    playShock(1);
-                  }
-                }
-                if (b.p.y < T) {
-                  b.p.y = T;
-                  var diffX = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
-                  if (nearPocket && diffX <= BALL_R * 3) {
-                    var speed3 = Math.hypot(b.v.x, b.v.y);
-                    if (diffX <= BALL_R * 1.5) {
-                      var dir3 = norm(nearest.x - b.p.x, nearest.y - b.p.y);
-                      b.v.x = dir3.x * speed3;
-                      b.v.y = dir3.y * speed3;
-                    } else {
-                      var nx = nearest.x < TABLE_W / 2 ? 1 : -1;
-                      var inv3 = 1 / Math.SQRT2;
-                      reflectVelocity(b.v, nx * inv3, inv3, EDGE_BOUNCE);
-                    }
-                  } else {
-                    reflectVelocity(b.v, 0, 1, BOUNCE);
-                  }
-                  if (b.n === 0) {
-                    b.impacted = true;
-                    applySpinImpulse(b);
-                  }
-                  if (i === 0 && shotInProgress && !firstHit)
-                    cueHitCushion = true;
-                  if (
-                    nearPocket &&
-                    diffX <= BALL_R * 3 &&
-                    !nearPocketEdgeHit &&
-                    !pocketedAny
-                  ) {
-                    nearPocketEdgeHit = true;
-                    playShock(1);
-                  }
-                }
-                if (b.p.y > B) {
-                  b.p.y = B;
-                  var diffX2 = nearest ? Math.abs(b.p.x - nearest.x) : Infinity;
-                  if (nearPocket && diffX2 <= BALL_R * 3) {
-                    var speed4 = Math.hypot(b.v.x, b.v.y);
-                    if (diffX2 <= BALL_R * 1.5) {
-                      var dir4 = norm(nearest.x - b.p.x, nearest.y - b.p.y);
-                      b.v.x = dir4.x * speed4;
-                      b.v.y = dir4.y * speed4;
-                    } else {
-                      var nx2 = nearest.x < TABLE_W / 2 ? 1 : -1;
-                      var inv4 = 1 / Math.SQRT2;
-                      reflectVelocity(b.v, nx2 * inv4, -inv4, EDGE_BOUNCE);
-                    }
-                  } else {
-                    reflectVelocity(b.v, 0, -1, BOUNCE);
-                  }
-                  if (b.n === 0) {
-                    b.impacted = true;
-                    applySpinImpulse(b);
-                  }
-                  if (i === 0 && shotInProgress && !firstHit)
-                    cueHitCushion = true;
-                  if (
-                    nearPocket &&
-                    diffX2 <= BALL_R * 3 &&
-                    !nearPocketEdgeHit &&
-                    !pocketedAny
-                  ) {
-                    nearPocketEdgeHit = true;
-                    playShock(1);
-                  }
-                }
+              if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
+            }
+            if (b.p.x > R) {
+              b.p.x = R;
+              reflectVelocity(b.v, -1, 0, BOUNCE);
+              if (b.n === 0) {
+                b.impacted = true;
+                applySpinImpulse(b);
+              }
+              if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
+            }
+            if (b.p.y < T) {
+              b.p.y = T;
+              reflectVelocity(b.v, 0, 1, BOUNCE);
+              if (b.n === 0) {
+                b.impacted = true;
+                applySpinImpulse(b);
+              }
+              if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
+            }
+            if (b.p.y > B) {
+              b.p.y = B;
+              reflectVelocity(b.v, 0, -1, BOUNCE);
+              if (b.n === 0) {
+                b.impacted = true;
+                applySpinImpulse(b);
+              }
+              if (i === 0 && shotInProgress && !firstHit) cueHitCushion = true;
             }
           }
-
-          var pk = this.pockets;
-          var inv = INV_SQRT2;
-          handleConnectorCollision(this, b, pk[0], inv, inv, function (rx, ry) {
-            return rx > 0 && ry > 0;
-          });
-          handleConnectorCollision(this, b, pk[1], -inv, inv, function (rx, ry) {
-            return rx < 0 && ry > 0;
-          });
-          handleConnectorCollision(this, b, pk[4], inv, -inv, function (rx, ry) {
-            return rx > 0 && ry < 0;
-          });
-          handleConnectorCollision(this, b, pk[5], -inv, -inv, function (rx, ry) {
-            return rx < 0 && ry < 0;
-          });
-          handleConnectorCollision(this, b, pk[2], inv, inv, function (rx, ry) {
-            return rx > 0 && ry < 0;
-          });
-          handleConnectorCollision(this, b, pk[2], inv, -inv, function (rx, ry) {
-            return rx > 0 && ry > 0;
-          });
-          handleConnectorCollision(this, b, pk[3], -inv, inv, function (rx, ry) {
-            return rx < 0 && ry < 0;
-          });
-          handleConnectorCollision(this, b, pk[3], -inv, -inv, function (rx, ry) {
-            return rx < 0 && ry > 0;
-          });
 
           // Perplasje ball-ball
           var N = this.balls.length;
@@ -2875,7 +2697,6 @@
         var shotPocketRecorded = false;
         var lastCueStart = null;
         var cueHitCushion = false;
-        var nearPocketEdgeHit = false;
 
         function remainingPoints() {
           var sum = 0;
@@ -3193,7 +3014,6 @@
             foulShown = false;
             firstHit = null;
             cueHitCushion = false;
-            nearPocketEdgeHit = false;
             currentTarget = null;
             eightBallPotted = false;
             nineBallPotted = false;
@@ -3357,7 +3177,6 @@
           firstHit = null;
           lastCueStart = null;
           cueHitCushion = false;
-          nearPocketEdgeHit = false;
           currentTarget = null;
           eightBallPotted = false;
           nineBallPotted = false;


### PR DESCRIPTION
## Summary
- simplify pocket edge physics to eliminate lip-outs
- drop connector collision handling that caused rattle effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb50e7dfc883298d6cd862f31709d6