### PR TITLE
Align snooker training wrapper with Pool Royale background

### DIFF
--- a/webapp/public/snooker-table.html
+++ b/webapp/public/snooker-table.html
@@ -7,11 +7,13 @@
   <style>
     html,body{height:100%;margin:0;background:transparent}
     .stage{position:relative;width:100vw;height:100vh}
+    #tableWrapper{position:absolute;inset:0;background:url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp') top center/calc(100% + 8px) calc(100% + 20px) no-repeat;pointer-events:none;z-index:-1}
     #markings{position:absolute;inset:0;width:100%;height:100%;display:block;pointer-events:none}
   </style>
 </head>
 <body>
   <div class="stage">
+    <div id="tableWrapper"></div>
     <canvas id="markings"></canvas>
   </div>
   <script>


### PR DESCRIPTION
## Summary
- Add table wrapper to snooker training HTML with same background sizing as Pool Royale

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, 'inc' is never reassigned. Use 'const' instead and more)*

------
https://chatgpt.com/codex/tasks/task_e_68bb52689a7c83299a147cd80fb6b24e