### PR TITLE
feat: add pocket jaw collision and capture logic

### DIFF
--- a/tests/pocketPhysics.test.ts
+++ b/tests/pocketPhysics.test.ts
@@ -1,4 +1,4 @@
-import { Ball, Pocket, JawParams, resolveJawCollision, centerPathIntersectsFunnel, willEnterPocket } from '../src/core/poolPhysics';
+import { Ball, Pocket, JawParams, Jaw, resolveJawCollision, centerPathIntersectsFunnel, willEnterPocket } from '../src/core/poolPhysics';
 
 const params: JawParams = {
   ballRadius: 0.028575,
@@ -7,19 +7,35 @@ const params: JawParams = {
   dragJaw: 0.02,
   captureSpeedMin: 0.15,
   reboundThreshold: 0.08,
+  lipOutAngle: 40,
+  lipOutSpeed: 0.35,
+}
+
+const jawRadius = params.ballRadius * 1.2
+const jaw: Jaw = {
+  center: { x: jawRadius, y: 0 },
+  radius: jawRadius,
+  startAngle: -Math.PI / 2,
+  endAngle: Math.PI / 2,
 }
 
 const pocket: Pocket = {
   center: { x: 0, y: 0 },
   uPocket: { x: 0, y: -1 },
-  mouthWidth: 0.1,
-  funnelDepth: 0.0714375,
+  mouthWidth: 0.2,
+  funnelDepth: jawRadius * 2,
+  jaws: [jaw],
 }
 
 describe('Pocket jaw physics', () => {
   test('moderate shot near jaw falls into pocket', () => {
-    const ball: Ball = { position: { x: 0, y: 0.04 }, velocity: { x: -0.1, y: -0.2 }, omega: 0 }
-    resolveJawCollision(ball, { x: 1, y: 0 }, params, 0)
+    const ball: Ball = {
+      position: { x: jaw.center.x + params.ballRadius, y: 0 },
+      velocity: { x: -0.1, y: -0.2 },
+      omega: 0,
+    }
+    const collided = resolveJawCollision(ball, jaw, params, 0)
+    expect(collided).toBe(true)
     expect(centerPathIntersectsFunnel(ball, pocket, params)).toBe(true)
     expect(willEnterPocket(ball.velocity, pocket, params)).toBe(true)
   })
@@ -28,6 +44,17 @@ describe('Pocket jaw physics', () => {
     const ball: Ball = { position: { x: 0, y: 0.2 }, velocity: { x: 0, y: -0.5 }, omega: 0 }
     expect(centerPathIntersectsFunnel(ball, pocket, params)).toBe(true)
     expect(willEnterPocket(ball.velocity, pocket, params)).toBe(true)
+  })
+
+  test('fast edge shot lips out and returns to table', () => {
+    const ball: Ball = {
+      position: { x: jaw.center.x + params.ballRadius, y: 0 },
+      velocity: { x: -0.5, y: -0.1 },
+      omega: 0,
+    }
+    const collided = resolveJawCollision(ball, jaw, params, 0)
+    expect(collided).toBe(true)
+    expect(willEnterPocket(ball.velocity, pocket, params)).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary
- model pocket jaws as arcs with normals
- compute jaw collisions with friction, spin, and lip-out checks
- add tests covering pocket captures and lip-outs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb569443b88329962aecfa5293d8aa