### PR TITLE
chore: extend snooker table background

### DIFF
--- a/webapp/public/snooker-table.html
+++ b/webapp/public/snooker-table.html
@@ -7,7 +7,7 @@
   <style>
     html,body{height:100%;margin:0;background:transparent}
     .stage{position:relative;width:100vw;height:100vh}
-    #tableWrapper{position:absolute;inset:0;background:url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp') top center/calc(100% + 8px) calc(100% + 16px) no-repeat;pointer-events:none;z-index:-1}
+    #tableWrapper{position:absolute;inset:0;background:url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp') top center/calc(100% + 8px) calc(100% + 20px) no-repeat;pointer-events:none;z-index:-1}
     #markings{position:absolute;inset:0;width:100%;height:100%;display:block;pointer-events:none}
   </style>
 </head>


### PR DESCRIPTION
## Summary
- extend snooker table background image slightly at bottom to prevent cropping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbb4a8342c8329876614338c0b7c8b