### PR TITLE
fix(pool): allow full cushion contact and clean stripe edges

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -952,14 +952,13 @@
         // Gropat pak me te vogla per t'u mbyllur me shume dhe jo per t'u zgjeruar
         var POCKET_R = isSnooker && playType === 'training' ? BALL_R * 0.65 : 32; // rrezja baze e gropave pak me e vogel nga jashte
         var SIDE_POCKET_R = isSnooker && playType === 'training' ? POCKET_R : 30; // gropat anesore gjithashtu pak me te vogla
-        // move pockets slightly closer to the center of the table
-        var POCKET_SHORTEN = isSnooker ? 2 : 4; // gropat snooker pak me brenda
+        // use full pocket extents so balls can reach the cushions
+        var POCKET_SHORTEN = isSnooker ? 2 : 0; // no shortening for pool variants
         var SHORT_DIST = BALL_R * 28;
         var MED_DIST = BALL_R * 56;
-        var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
-        // Raise only the bottom field line by the thickness of one green side
-        // marking so the table's lower boundary sits slightly higher.
-        var BORDER_BOTTOM = BORDER + 14; // anet e tjera mbeten te pandryshuara
+        // uniform borders so balls may contact the table edges
+        var BORDER_TOP = BORDER;
+        var BORDER_BOTTOM = BORDER;
         // Move the rack slightly upward on the table
         var SPOT_Y =
           BORDER_TOP +
@@ -2700,8 +2699,8 @@
               ctx.clip();
               ctx.fillStyle = stripeGrad;
               ctx.fillRect(-ballR, -ballR * 0.3, ballR * 2, ballR * 0.6);
-              // thin black lines at stripe edges
-              ctx.strokeStyle = '#000';
+              // white lines at stripe edges
+              ctx.strokeStyle = '#fff';
               ctx.lineWidth = ballR * 0.06;
               ctx.beginPath();
               ctx.moveTo(-ballR, -ballR * 0.3);
@@ -2963,7 +2962,7 @@
             ctx.clip();
             ctx.fillStyle = '#fff';
             ctx.fillRect(cx - r, cy - r * 0.3, r * 2, r * 0.6);
-            ctx.strokeStyle = '#000';
+            ctx.strokeStyle = '#fff';
             ctx.lineWidth = r * 0.15;
             ctx.beginPath();
             ctx.moveTo(cx - r, cy - r * 0.3);


### PR DESCRIPTION
## Summary
- remove pocket and border offsets so balls can reach table cushions
- draw white stripe edges for American balls

## Testing
- `npm test`
- `npm run lint` *(fails: eslint reports existing errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbc238a3c8329bb5a7c0632e2a71e