### PR TITLE
Fix pool royale boundaries and stripe styling

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -962,10 +962,9 @@
         var POCKET_OFFSET = isSnooker ? 4 : 0;
         var SHORT_DIST = BALL_R * 28;
         var MED_DIST = BALL_R * 56;
-        var BORDER_TOP = BORDER + BALL_R * 2 - 4; // bordi i siperm pak me i holle per fushe me te gjate
-        // Raise only the bottom field line by the thickness of one green side
-        // marking so the table's lower boundary sits slightly higher.
-        var BORDER_BOTTOM = BORDER + 14; // anet e tjera mbeten te pandryshuara
+        // Use uniform borders so balls can travel freely to every cushion.
+        var BORDER_TOP = BORDER;
+        var BORDER_BOTTOM = BORDER;
         // Move the rack slightly upward on the table
         var SPOT_Y =
           BORDER_TOP +
@@ -2069,17 +2068,15 @@
                 BORDER_TOP - POCKET_SHORTEN + POCKET_OFFSET,
                 POCKET_R
               ),
-              // Lift middle pockets a touch more to align with the shifted field
-              // boundary, matching the green marking thickness, and nudge them
-              // slightly farther from center.
+              // Middle pockets centered on the table
               new Pocket(
                 BORDER - 16 - POCKET_SHORTEN + POCKET_OFFSET,
-                TABLE_H / 2 + BALL_R - 14,
+                TABLE_H / 2,
                 SIDE_POCKET_R
               ),
               new Pocket(
                 TABLE_W - BORDER + 16 + POCKET_SHORTEN - POCKET_OFFSET,
-                TABLE_H / 2 + BALL_R - 14,
+                TABLE_H / 2,
                 SIDE_POCKET_R
               ),
               new Pocket(
@@ -2706,8 +2703,8 @@
               ctx.clip();
               ctx.fillStyle = stripeGrad;
               ctx.fillRect(-ballR, -ballR * 0.3, ballR * 2, ballR * 0.6);
-              // thin black lines at stripe edges
-              ctx.strokeStyle = '#000';
+              // thin white lines at stripe edges
+              ctx.strokeStyle = '#fff';
               ctx.lineWidth = ballR * 0.06;
               ctx.beginPath();
               ctx.moveTo(-ballR, -ballR * 0.3);


### PR DESCRIPTION
## Summary
- allow balls to reach cushions by using uniform table borders
- center middle pockets for symmetrical playfield
- make stripe edge lines white to match American balls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbbde99d3c83299a5124edee40c799