### PR TITLE
Remove pocket jaw physics

### DIFF
--- a/src/core/poolPhysics.ts
+++ b/src/core/poolPhysics.ts
@@ -33,36 +33,21 @@ export interface JawParams {
   reboundThreshold: number
 }
 
-export function reflectWithFrictionAndSpin(v: Vec2, n: Vec2, eJaw: number, muJaw: number, dragJaw: number, omega: number) {
-  const nN = normalize(n)
-  const vn = dot(v, nN)
-  const vt = sub(v, scale(nN, vn))
-  let vPrime = sub(scale(vt, 1 - muJaw), scale(nN, eJaw * vn))
-  vPrime = scale(vPrime, 1 - dragJaw)
-  const omegaPrime = omega + muJaw * vn
-  return { v: vPrime, omega: omegaPrime }
+// Jaw physics has been disabled; collisions with pocket openings are ignored.
+// These helpers now act as no-ops or unconditional passes so that balls do not
+// bounce off invisible pocket jaws.
+export function resolveJawCollision(_ball: Ball, _normal: Vec2, _params: JawParams, _time: number) {
+  // no-op: allow the ball to continue on its path
 }
 
-export function resolveJawCollision(ball: Ball, normal: Vec2, params: JawParams, _time: number) {
-  const res = reflectWithFrictionAndSpin(ball.velocity, normal, params.eJaw, params.muJaw, params.dragJaw, ball.omega)
-  ball.velocity = res.v
-  ball.omega = res.omega
+export function centerPathIntersectsFunnel(_ball: Ball, _pocket: Pocket, _params: JawParams): boolean {
+  // without jaws, any trajectory is considered valid for pocket entry
+  return true
 }
 
-export function centerPathIntersectsFunnel(ball: Ball, pocket: Pocket, params: JawParams): boolean {
-  const dir = normalize(ball.velocity)
-  if (length(dir) === 0) return false
-  const toCenter = sub(pocket.center, ball.position)
-  const dist = Math.abs(crossZ(toCenter, dir))
-  return dist < pocket.mouthWidth / 2 - params.ballRadius
-}
-
-export function willEnterPocket(vPrime: Vec2, pocket: Pocket, params: JawParams): boolean {
-  const speed = length(vPrime)
-  const toPocket = dot(vPrime, pocket.uPocket)
-  if (toPocket > params.captureSpeedMin) return true
-  if (speed < params.reboundThreshold) return true
-  return false
+export function willEnterPocket(_vPrime: Vec2, _pocket: Pocket, _params: JawParams): boolean {
+  // without jaws, balls always enter the pocket once inside the mouth
+  return true
 }
 
 export function sinkIntoPocket(ball: Ball) {

--- a/tests/pocketPhysics.test.ts
+++ b/tests/pocketPhysics.test.ts
@@ -1,30 +1,40 @@
-import { Ball, Pocket, JawParams, resolveJawCollision, centerPathIntersectsFunnel, willEnterPocket } from '../src/core/poolPhysics';
+import {
+  Ball,
+  Pocket,
+  JawParams,
+  resolveJawCollision,
+  centerPathIntersectsFunnel,
+  willEnterPocket
+} from '../src/core/poolPhysics'
 
+// Parameters remain for API compatibility but have no effect with jaws disabled
 const params: JawParams = {
   ballRadius: 0.028575,
-  eJaw: 0.85,
-  muJaw: 0.12,
-  dragJaw: 0.02,
-  captureSpeedMin: 0.15,
-  reboundThreshold: 0.08,
+  eJaw: 0,
+  muJaw: 0,
+  dragJaw: 0,
+  captureSpeedMin: 0,
+  reboundThreshold: 0
 }
 
 const pocket: Pocket = {
   center: { x: 0, y: 0 },
   uPocket: { x: 0, y: -1 },
   mouthWidth: 0.1,
-  funnelDepth: 0.0714375,
+  funnelDepth: 0.0714375
 }
 
-describe('Pocket jaw physics', () => {
-  test('moderate shot near jaw falls into pocket', () => {
+describe('Pocket jaw physics disabled', () => {
+  test('jaw collisions do not alter ball trajectory', () => {
     const ball: Ball = { position: { x: 0, y: 0.04 }, velocity: { x: -0.1, y: -0.2 }, omega: 0 }
+    const prevVel = { ...ball.velocity }
+    const prevOmega = ball.omega
     resolveJawCollision(ball, { x: 1, y: 0 }, params, 0)
-    expect(centerPathIntersectsFunnel(ball, pocket, params)).toBe(true)
-    expect(willEnterPocket(ball.velocity, pocket, params)).toBe(true)
+    expect(ball.velocity).toEqual(prevVel)
+    expect(ball.omega).toBe(prevOmega)
   })
 
-  test('strong shot through mouth drops straight in', () => {
+  test('balls are always considered to enter the pocket', () => {
     const ball: Ball = { position: { x: 0, y: 0.2 }, velocity: { x: 0, y: -0.5 }, omega: 0 }
     expect(centerPathIntersectsFunnel(ball, pocket, params)).toBe(true)
     expect(willEnterPocket(ball.velocity, pocket, params)).toBe(true)


### PR DESCRIPTION
## Summary
- disable pocket jaw collision helpers so shots no longer bounce off invisible jaws
- adjust pocket physics tests to reflect always-enter behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbc979a8388329be34108a77226b31