### PR TITLE
Handle pocket jaw collisions using segment-based CCD

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -116,10 +116,9 @@ public class CushionStepTests
 public class PocketJawTests
 {
     [Test]
-    public void JawCollisionsAreIgnored()
+    public void BallReflectsOffJaw()
     {
         var solver = new BilliardsSolver();
-        // Jaws are added but have no effect when disabled.
         solver.PocketJaws.Add(new BilliardsSolver.Jaw
         {
             A = new Vec2(0, 0.1),
@@ -128,12 +127,12 @@ public class PocketJawTests
         });
         var v = new Vec2(-1, -1).Normalized();
         var ball = new BilliardsSolver.Ball { Position = new Vec2(0.2, 0.2), Velocity = v };
-        // step far enough to cross the jaw but not reach the cushion
+        // step long enough to reach the jaw but not the far cushion
         solver.Step(new List<BilliardsSolver.Ball> { ball }, 0.23);
         var n = new Vec2(1, 1).Normalized();
         double jawLine = Vec2.Dot(new Vec2(0, 0.1), n);
         double dist = Vec2.Dot(ball.Position, n) - jawLine;
-        Assert.That(dist, Is.LessThan(0)); // ball has passed the jaw line
-        Assert.That(Vec2.Dot(ball.Velocity.Normalized(), v), Is.GreaterThan(0.999));
+        Assert.That(dist, Is.GreaterThanOrEqualTo(-1e-9));
+        Assert.That(Vec2.Dot(ball.Velocity, n), Is.GreaterThan(0));
     }
 }

--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -36,6 +36,71 @@ public class BilliardsSolver
         public Vec2? TargetVelocity;
     }
 
+    private const double PocketGapThreshold = 0.2;
+
+    private List<(Jaw jaw, bool isJaw)> BuildSegments()
+    {
+        var segments = new List<(Jaw, bool)>();
+        double w = PhysicsConstants.TableWidth;
+        double h = PhysicsConstants.TableHeight;
+
+        List<double> left = new List<double> { 0, h };
+        List<double> right = new List<double> { 0, h };
+        List<double> bottom = new List<double> { 0, w };
+        List<double> top = new List<double> { 0, w };
+
+        foreach (var j in PocketJaws)
+        {
+            if (Math.Abs(j.A.X) < PhysicsConstants.Epsilon) left.Add(j.A.Y);
+            if (Math.Abs(j.B.X) < PhysicsConstants.Epsilon) left.Add(j.B.Y);
+            if (Math.Abs(j.A.X - w) < PhysicsConstants.Epsilon) right.Add(j.A.Y);
+            if (Math.Abs(j.B.X - w) < PhysicsConstants.Epsilon) right.Add(j.B.Y);
+            if (Math.Abs(j.A.Y) < PhysicsConstants.Epsilon) bottom.Add(j.A.X);
+            if (Math.Abs(j.B.Y) < PhysicsConstants.Epsilon) bottom.Add(j.B.X);
+            if (Math.Abs(j.A.Y - h) < PhysicsConstants.Epsilon) top.Add(j.A.X);
+            if (Math.Abs(j.B.Y - h) < PhysicsConstants.Epsilon) top.Add(j.B.X);
+        }
+
+        left.Sort();
+        right.Sort();
+        bottom.Sort();
+        top.Sort();
+
+        for (int i = 0; i < left.Count - 1; i++)
+        {
+            double a = left[i];
+            double b = left[i + 1];
+            if (b - a > PocketGapThreshold)
+                segments.Add((new Jaw { A = new Vec2(0, a), B = new Vec2(0, b), Normal = new Vec2(1, 0) }, false));
+        }
+        for (int i = 0; i < right.Count - 1; i++)
+        {
+            double a = right[i];
+            double b = right[i + 1];
+            if (b - a > PocketGapThreshold)
+                segments.Add((new Jaw { A = new Vec2(w, a), B = new Vec2(w, b), Normal = new Vec2(-1, 0) }, false));
+        }
+        for (int i = 0; i < bottom.Count - 1; i++)
+        {
+            double a = bottom[i];
+            double b = bottom[i + 1];
+            if (b - a > PocketGapThreshold)
+                segments.Add((new Jaw { A = new Vec2(a, 0), B = new Vec2(b, 0), Normal = new Vec2(0, 1) }, false));
+        }
+        for (int i = 0; i < top.Count - 1; i++)
+        {
+            double a = top[i];
+            double b = top[i + 1];
+            if (b - a > PocketGapThreshold)
+                segments.Add((new Jaw { A = new Vec2(a, h), B = new Vec2(b, h), Normal = new Vec2(0, -1) }, false));
+        }
+
+        foreach (var j in PocketJaws)
+            segments.Add((j, true));
+
+        return segments;
+    }
+
     /// <summary>Integrates positions and handles cushion reflections for one step.</summary>
     public void Step(List<Ball> balls, double dt)
     {
@@ -44,32 +109,34 @@ public class BilliardsSolver
             if (b.Velocity.Length > 0)
             {
                 double remaining = dt;
+                var segments = BuildSegments();
                 while (remaining > PhysicsConstants.Epsilon && b.Velocity.Length > 0)
                 {
-                    Vec2 min = new Vec2(0, 0);
-                    Vec2 max = new Vec2(PhysicsConstants.TableWidth, PhysicsConstants.TableHeight);
-
                     double tHit = double.PositiveInfinity;
                     Vec2 normal = new Vec2();
-                    double restitution = PhysicsConstants.Restitution;
+                    bool jaw = false;
                     bool hit = false;
 
-                    if (Ccd.CircleAabb(b.Position, b.Velocity, PhysicsConstants.BallRadius, min, max, out double tBox, out Vec2 nBox) && tBox <= remaining)
+                    foreach (var seg in segments)
                     {
-                        tHit = tBox;
-                        normal = nBox;
-                        restitution = PhysicsConstants.CushionRestitution;
-                        hit = true;
+                        if (Ccd.CircleSegment(b.Position, b.Velocity, PhysicsConstants.BallRadius, seg.jaw.A, seg.jaw.B, seg.jaw.Normal, out double tSeg) && tSeg <= remaining && tSeg < tHit)
+                        {
+                            tHit = tSeg;
+                            normal = seg.jaw.Normal;
+                            jaw = seg.isJaw;
+                            hit = true;
+                        }
                     }
 
-                    // Pocket jaw collisions are ignored, so only cushion interactions are considered.
                     if (hit)
                     {
                         b.Position += b.Velocity * tHit;
                         var speed = b.Velocity.Length;
                         var newSpeed = Math.Max(0, speed - PhysicsConstants.Mu * tHit);
                         b.Velocity = newSpeed > 0 ? b.Velocity.Normalized() * newSpeed : new Vec2(0, 0);
-                        b.Velocity = Collision.Reflect(b.Velocity, normal, restitution);
+                        b.Velocity = jaw
+                            ? Collision.ReflectWithFriction(b.Velocity, normal, PhysicsConstants.JawRestitution, PhysicsConstants.JawFriction, PhysicsConstants.JawDrag)
+                            : Collision.Reflect(b.Velocity, normal, PhysicsConstants.CushionRestitution);
                         remaining -= tHit;
                     }
                     else
@@ -106,13 +173,19 @@ public class BilliardsSolver
             }
         }
 
-        Vec2 min = new Vec2(0, 0);
-        Vec2 max = new Vec2(PhysicsConstants.TableWidth, PhysicsConstants.TableHeight);
-        if (Ccd.CircleAabb(cueStart, velocity, PhysicsConstants.BallRadius, min, max, out double tc, out Vec2 n))
+        bool jawHit = false;
+        var segments = BuildSegments();
+        foreach (var seg in segments)
         {
-            if (tc < bestT)
+            if (Ccd.CircleSegment(cueStart, velocity, PhysicsConstants.BallRadius, seg.jaw.A, seg.jaw.B, seg.jaw.Normal, out double tSeg))
             {
-                bestT = tc; hitNormal = n; ballHit = false;
+                if (tSeg < bestT)
+                {
+                    bestT = tSeg;
+                    hitNormal = seg.jaw.Normal;
+                    ballHit = false;
+                    jawHit = seg.isJaw;
+                }
             }
         }
 
@@ -135,7 +208,9 @@ public class BilliardsSolver
         }
         else
         {
-            cuePost = Collision.Reflect(velocity, hitNormal, PhysicsConstants.Restitution);
+            cuePost = jawHit
+                ? Collision.ReflectWithFriction(velocity, hitNormal, PhysicsConstants.JawRestitution, PhysicsConstants.JawFriction, PhysicsConstants.JawDrag)
+                : Collision.Reflect(velocity, hitNormal, PhysicsConstants.CushionRestitution);
             path.Add(contact + cuePost.Normalized() * PhysicsConstants.BallRadius);
         }
 
@@ -164,10 +239,26 @@ public class BilliardsSolver
                     }
                 }
             }
-            if (Ccd.CircleAabb(cue.Position, cue.Velocity, PhysicsConstants.BallRadius, new Vec2(0, 0), new Vec2(PhysicsConstants.TableWidth, PhysicsConstants.TableHeight), out double tc, out Vec2 n) && tc <= PhysicsConstants.FixedDt)
+
+            double tHit = double.PositiveInfinity;
+            Vec2 normal = new Vec2();
+            bool jaw = false;
+            var segments = BuildSegments();
+            foreach (var seg in segments)
             {
-                cue.Position += cue.Velocity * tc;
-                var post = Collision.Reflect(cue.Velocity, n);
+                if (Ccd.CircleSegment(cue.Position, cue.Velocity, PhysicsConstants.BallRadius, seg.jaw.A, seg.jaw.B, seg.jaw.Normal, out double tSeg) && tSeg <= PhysicsConstants.FixedDt && tSeg < tHit)
+                {
+                    tHit = tSeg;
+                    normal = seg.jaw.Normal;
+                    jaw = seg.isJaw;
+                }
+            }
+            if (tHit < double.PositiveInfinity)
+            {
+                cue.Position += cue.Velocity * tHit;
+                var post = jaw
+                    ? Collision.ReflectWithFriction(cue.Velocity, normal, PhysicsConstants.JawRestitution, PhysicsConstants.JawFriction, PhysicsConstants.JawDrag)
+                    : Collision.Reflect(cue.Velocity, normal, PhysicsConstants.CushionRestitution);
                 return new Impact { Point = cue.Position, CueVelocity = post };
             }
             Step(balls, PhysicsConstants.FixedDt);


### PR DESCRIPTION
## Summary
- Replace AABB collision checks with per-segment CCD for cushions and pocket jaws
- Allow balls to enter pocket openings and reflect using segment normals
- Add unit test for pocket jaw reflection

## Testing
- `dotnet test billiards.Tests/Billiards.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bbf11fdfe4832993e715d24700841e