### PR TITLE
Tune pocket jaw physics to reduce bounce

### DIFF
--- a/src/core/poolPhysics.ts
+++ b/src/core/poolPhysics.ts
@@ -33,6 +33,15 @@ export interface JawParams {
   reboundThreshold: number
 }
 
+export const DEFAULT_JAW_PARAMS: JawParams = {
+  ballRadius: 0.028575,
+  eJaw: 0.25,
+  muJaw: 0,
+  dragJaw: 0.75,
+  captureSpeedMin: 0,
+  reboundThreshold: 0
+}
+
 // Reflect the ball off a pocket jaw with a reduced restitution. The normal
 // component of the velocity is inverted and scaled by `params.eJaw`, while the
 // tangential component is dampened by `params.muJaw` and `params.dragJaw`.

--- a/tests/pocketPhysics.test.ts
+++ b/tests/pocketPhysics.test.ts
@@ -8,12 +8,12 @@ import {
 } from '../src/core/poolPhysics'
 
 // Parameters configure pocket jaw physics. Jaws bounce with 75% less
-// restitution than cushions, so the eJaw coefficient is low.
+// restitution than cushions and collisions dampen speed by 75%.
 const params: JawParams = {
   ballRadius: 0.028575,
   eJaw: 0.25,
   muJaw: 0,
-  dragJaw: 0,
+  dragJaw: 0.75,
   captureSpeedMin: 0,
   reboundThreshold: 0
 }
@@ -26,11 +26,11 @@ const pocket: Pocket = {
 }
 
 describe('Pocket jaw physics', () => {
-  test('jaw collisions reflect velocity with reduced restitution', () => {
+  test('jaw collisions reflect velocity with reduced restitution and speed', () => {
     const ball: Ball = { position: { x: 0, y: 0.04 }, velocity: { x: -0.1, y: -0.2 }, omega: 0 }
     resolveJawCollision(ball, { x: 1, y: 0 }, params, 0)
-    expect(ball.velocity.x).toBeCloseTo(0.025)
-    expect(ball.velocity.y).toBeCloseTo(-0.2)
+    expect(ball.velocity.x).toBeCloseTo(0.00625)
+    expect(ball.velocity.y).toBeCloseTo(-0.05)
   })
 
   test('balls are always considered to enter the pocket', () => {


### PR DESCRIPTION
## Summary
- add `DEFAULT_JAW_PARAMS` with 25% bounce and 75% speed reduction for pocket edges
- adjust pocket physics tests to assert reduced speed after jaw collisions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbfab33f188329a93f821428799c7b