### PR TITLE
Allow natural ball motion and reduce pocket bounce

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -134,6 +134,6 @@ public class PocketEdgeTests
         double dist = Vec2.Dot(ball.Position, n) - c;
         Assert.That(dist, Is.GreaterThanOrEqualTo(PhysicsConstants.BallRadius - 1e-6));
         Assert.That(Vec2.Dot(ball.Velocity, n), Is.GreaterThan(0));
-        Assert.That(ball.Velocity.Length, Is.InRange(preSpeed * 0.4, preSpeed * 0.7));
+        Assert.That(ball.Velocity.Length, Is.InRange(preSpeed * 0.2, preSpeed * 0.3));
     }
 }

--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -36,40 +36,6 @@ public class BilliardsSolver
         public Vec2? TargetVelocity;
     }
 
-    private static void ClampToTable(Ball b)
-    {
-        double minX = PhysicsConstants.BallRadius;
-        double maxX = PhysicsConstants.TableWidth - PhysicsConstants.BallRadius;
-        double minY = PhysicsConstants.BallRadius;
-        double maxY = PhysicsConstants.TableHeight - PhysicsConstants.BallRadius;
-
-        if (b.Position.X < minX)
-        {
-            b.Position = new Vec2(minX, b.Position.Y);
-            if (b.Velocity.X < 0)
-                b.Velocity = new Vec2(-b.Velocity.X * PhysicsConstants.CushionRestitution, b.Velocity.Y);
-        }
-        else if (b.Position.X > maxX)
-        {
-            b.Position = new Vec2(maxX, b.Position.Y);
-            if (b.Velocity.X > 0)
-                b.Velocity = new Vec2(-b.Velocity.X * PhysicsConstants.CushionRestitution, b.Velocity.Y);
-        }
-
-        if (b.Position.Y < minY)
-        {
-            b.Position = new Vec2(b.Position.X, minY);
-            if (b.Velocity.Y < 0)
-                b.Velocity = new Vec2(b.Velocity.X, -b.Velocity.Y * PhysicsConstants.CushionRestitution);
-        }
-        else if (b.Position.Y > maxY)
-        {
-            b.Position = new Vec2(b.Position.X, maxY);
-            if (b.Velocity.Y > 0)
-                b.Velocity = new Vec2(b.Velocity.X, -b.Velocity.Y * PhysicsConstants.CushionRestitution);
-        }
-    }
-
     /// <summary>Integrates positions and handles cushion reflections for one step.</summary>
     public void Step(List<Ball> balls, double dt)
     {
@@ -126,7 +92,6 @@ public class BilliardsSolver
                     }
                 }
             }
-            ClampToTable(b);
         }
     }
 

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -6,8 +6,8 @@ public static class PhysicsConstants
     public const double BallRadius = 0.028575;        // metres (57.15 mm diameter)
     public const double Restitution = 0.98;            // elastic coefficient
     public const double CushionRestitution = Restitution * 1.1; // extra bounce for table edges
-    // pocket edges are part of cushions but only lose ~40% of velocity
-    public const double PocketRestitution = Restitution * 0.6;
+    // pocket edges retain only a quarter of the cushion bounce (lose ~75% of speed)
+    public const double PocketRestitution = CushionRestitution * 0.25;
     public const double Mu = 0.2;                      // linear damping (m/s^2)
     public const double TableWidth = 2.84;             // 9ft table internal size
     public const double TableHeight = 1.42;


### PR DESCRIPTION
## Summary
- remove table clamping so balls can move naturally
- make pocket jaw collisions retain only 25% speed
- update physics tests for new pocket restitution

## Testing
- `npm test`
- `dotnet test billiards.Tests`


------
https://chatgpt.com/codex/tasks/task_e_68bc056856c083298144fc035c2cef7c