### PR TITLE
Curve pool connector edges

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2467,6 +2467,16 @@
                 drawUPocketGuide(p[4], 1, -1, false);
                 drawUPocketGuide(p[5], -1, -1, false);
                 ctx.stroke();
+                // highlight pocket connector curves
+                ctx.strokeStyle = 'orange';
+                ctx.lineWidth = 2;
+                drawVPocketGuide(p[2], 1);
+                drawVPocketGuide(p[3], -1);
+                drawUPocketGuide(p[0], 1, 1);
+                drawUPocketGuide(p[1], -1, 1);
+                drawUPocketGuide(p[4], 1, -1);
+                drawUPocketGuide(p[5], -1, -1);
+                // draw pocket outlines
                 ctx.strokeStyle = 'red';
                 ctx.lineWidth = 2;
                 var rScale = (sX + sY) / 2;
@@ -3636,10 +3646,15 @@
           var dx = R * 1.1 * dir;
           var dy = R * 1.25;
           var trim = R * 0.1;
+          var curve = R * 0.25;
           if (stroke) ctx.beginPath();
-          ctx.moveTo(x - dx, y);
+          // upper connector with small curve
+          ctx.moveTo(x - dx, y - curve);
+          ctx.arcTo(x - dx, y, x + dx, y - dy + trim, curve);
           ctx.lineTo(x + dx, y - dy + trim);
-          ctx.moveTo(x - dx, y);
+          // lower connector with small curve
+          ctx.moveTo(x - dx, y + curve);
+          ctx.arcTo(x - dx, y, x + dx, y + dy - trim, curve);
           ctx.lineTo(x + dx, y + dy - trim);
           if (stroke) ctx.stroke();
         }
@@ -3657,10 +3672,15 @@
           ctx.arc(0, 0, R, Math.PI, 0);
           var lineLen = R * 1.2;
           var lineStart = R * 0.1;
+          var curve = R * 0.25;
+          // left connector with curve
           ctx.moveTo(-R, lineStart);
-          ctx.lineTo(-R, lineLen);
+          ctx.lineTo(-R, lineLen - curve);
+          ctx.arcTo(-R, lineLen, -R + curve, lineLen, curve);
+          // right connector with curve
           ctx.moveTo(R, lineStart);
-          ctx.lineTo(R, lineLen);
+          ctx.lineTo(R, lineLen - curve);
+          ctx.arcTo(R, lineLen, R - curve, lineLen, curve);
           if (stroke) ctx.stroke();
           ctx.restore();
         }


### PR DESCRIPTION
## Summary
- Smooth pocket connector transitions in Pool Royale table using arcTo
- Highlight new curved connectors with orange guide strokes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc497a9a248329a2c18d0a4575f143