### PR TITLE
feat(pool): add curved connector guides

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -3642,6 +3642,26 @@
           ctx.moveTo(x - dx, y);
           ctx.lineTo(x + dx, y + dy - trim);
           if (stroke) ctx.stroke();
+
+          // orange guides that curve outward from the field edge
+          var baseX = x - dx;
+          var guideR = R * 0.3;
+          ctx.save();
+          ctx.strokeStyle = 'orange';
+          ctx.beginPath();
+          if (dir > 0) {
+            // left side pocket
+            ctx.arc(baseX - guideR, y - guideR, guideR, 0, Math.PI / 2);
+            ctx.moveTo(baseX, y + guideR);
+            ctx.arc(baseX - guideR, y + guideR, guideR, 0, -Math.PI / 2, true);
+          } else {
+            // right side pocket
+            ctx.arc(baseX + guideR, y - guideR, guideR, Math.PI, Math.PI / 2, true);
+            ctx.moveTo(baseX, y + guideR);
+            ctx.arc(baseX + guideR, y + guideR, guideR, Math.PI, 3 * Math.PI / 2);
+          }
+          ctx.stroke();
+          ctx.restore();
         }
 
         function drawUPocketGuide(p, sx, sy, stroke = true) {
@@ -3662,6 +3682,15 @@
           ctx.moveTo(R, lineStart);
           ctx.lineTo(R, lineLen);
           if (stroke) ctx.stroke();
+
+          // add small orange curves bending outside the field
+          var guideR2 = R * 0.3;
+          ctx.strokeStyle = 'orange';
+          ctx.beginPath();
+          ctx.arc(-R - guideR2, lineStart, guideR2, 0, Math.PI / 2);
+          ctx.moveTo(R, lineStart);
+          ctx.arc(R + guideR2, lineStart, guideR2, Math.PI / 2, Math.PI);
+          ctx.stroke();
           ctx.restore();
         }
 


### PR DESCRIPTION
## Summary
- curve pocket connectors and add orange guide arcs around table edges

## Testing
- `npm run lint` (fails: numerous existing lint errors)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5131fb7c83299c59dd3c1db67264