### PR TITLE
Refine Pool Royale board background and pocket guides

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -179,7 +179,10 @@
       #wrap::before {
         content: '';
         position: absolute;
-        inset: 0;
+        top: 8px;
+        left: 0;
+        right: 0;
+        bottom: -20px;
         background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
           top center/calc(100% + 8px) calc(100% + 20px) no-repeat;
         filter: brightness(var(--table-brightness));
@@ -3622,7 +3625,7 @@
         }
 
         function drawUPocketGuide(p, sx, sy, stroke = true) {
-          var R = p.r * ((sX + sY) / 2) * 1.1;
+          var R = p.r * ((sX + sY) / 2) * 1.05;
           var x = p.x * sX;
           var y = p.y * sY;
           ctx.save();
@@ -3632,7 +3635,7 @@
           if (stroke) ctx.beginPath();
           ctx.moveTo(-R, 0);
           ctx.arc(0, 0, R, Math.PI, 0);
-          var lineLen = R * 1.2;
+          var lineLen = R * 1.15;
           var lineStart = R * 0.1;
           ctx.moveTo(-R, lineStart);
           ctx.lineTo(-R, lineLen);


### PR DESCRIPTION
## Summary
- Trim table background overlay slightly from the top for better alignment
- Reduce U-shaped pocket guide size for tighter fit to boundaries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc6813c3cc83299666e99245ad9761