### PR TITLE
Rotate Snooker table vertically and match shot power to Pool Royal

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -279,7 +279,8 @@ export default function Snooker() {
     }
     function up(e) {
       if (!aiming) return; aiming = false; const dir = norm(sub(aimStart, aimCurrent));
-      const speed = 720 * shotPower;
+      const baseSpeed = 950 * 3 * 1.6 * 1.5 * 0.6;
+      const speed = baseSpeed * (0.25 + 0.75 * shotPower);
       cueBall.v = add(cueBall.v, mul(dir, speed / 60));
       if (shotPower > 0.02) { shotCount++; document.getElementById('shotCount').textContent = shotCount; }
       shotPower = 0; updatePowerBar();
@@ -318,7 +319,7 @@ export default function Snooker() {
           <button id="resetBtn" className="snooker-btn">Re-Spot Cue</button>
         </div>
       </div>
-      <canvas id="table" width="980" height="520"></canvas>
+      <canvas id="table" width="480" height="960"></canvas>
     </div>
   );
 }

--- a/webapp/src/snooker/snooker-table.css
+++ b/webapp/src/snooker/snooker-table.css
@@ -7,7 +7,7 @@
 }
 .snooker-wrap{display:grid;place-items:center;gap:16px;padding:14px}
 .snooker-wrap canvas{background:var(--felt);display:block;border-radius:18px;box-shadow:0 20px 50px rgba(0,0,0,.45)}
-.snooker-hud{width:min(980px,95vw);display:flex;flex-wrap:wrap;gap:8px;justify-content:space-between;align-items:center}
+.snooker-hud{width:min(480px,95vw);display:flex;flex-wrap:wrap;gap:8px;justify-content:space-between;align-items:center}
 .snooker-left{display:flex;align-items:center;gap:12px}
 .snooker-pill{background:#131a33;border:1px solid #263159;color:#cfe3ff;padding:8px 12px;border-radius:999px;font-size:14px}
 .snooker-btn{all:unset;background:linear-gradient(180deg,#2a335c,#1d2442);padding:10px 14px;border-radius:12px;border:1px solid #2f3c71;cursor:pointer;color:#fff}


### PR DESCRIPTION
## Summary
- orient Snooker canvas vertically and reduce size to better fit screens
- enlarge shot force using Pool Royal's base speed calculation
- scale HUD width to the new vertical table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc7383a31c8329922e6766dd3e19a0