### PR TITLE
Refine Pool Royale table boundaries and connectors

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2402,8 +2402,9 @@
               if (this.pockets) {
                 var p = this.pockets;
                 var lineW = ctx.lineWidth;
-                var cornerGap = lineW * 4;
-                var sideGap = lineW * 2;
+                // Slightly extend the green boundary lines closer to the pockets
+                var cornerGap = lineW * 3.5;
+                var sideGap = lineW * 1.5;
                 ctx.beginPath();
                 // top boundary
                 var topY = y0;
@@ -3613,7 +3614,8 @@
           var y = p.y * sY;
           var dx = R * 1.1 * dir;
           var dy = R * 1.25;
-          var trim = R * 0.1;
+          // Shorten the straight segments slightly to keep them within the green boundary
+          var trim = R * 0.15;
           if (stroke) ctx.beginPath();
           ctx.moveTo(x - dx, y);
           ctx.lineTo(x + dx, y - dy + trim);
@@ -3633,7 +3635,8 @@
           if (stroke) ctx.beginPath();
           ctx.moveTo(-R, 0);
           ctx.arc(0, 0, R, Math.PI, 0);
-          var lineLen = R * 1.2;
+          // Slightly reduce straight leg length so U connector doesn't overlap boundary
+          var lineLen = R * 1.15;
           var lineStart = R * 0.1;
           ctx.moveTo(-R, lineStart);
           ctx.lineTo(-R, lineLen);


### PR DESCRIPTION
## Summary
- extend green boundary lines slightly closer to pockets for smoother edge alignment
- shorten U and V connector straight segments to fit within the adjusted boundaries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc7dd46e048329b41b4a7ff796cbe0