### PR TITLE
Bend side table lines toward pockets

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2404,7 +2404,9 @@
                 var lineW = ctx.lineWidth;
                 // Slightly extend the green boundary lines closer to the pockets
                 var cornerGap = lineW * 3.5;
-                var sideGap = lineW * 1.5;
+                // use a much smaller gap on the sides so the lines reach toward the
+                // pockets and can bend along the connector shape
+                var sideGap = lineW * 0.5;
                 ctx.beginPath();
                 // top boundary
                 var topY = y0;
@@ -2418,25 +2420,27 @@
                 var bottomEnd = (p[5].x - p[5].r) * sX - cornerGap;
                 ctx.moveTo(bottomStart, bottomY);
                 ctx.lineTo(bottomEnd, bottomY);
-                // left boundary with side pocket
+                // left boundary with side pocket – bend toward pocket
                 var xLeft = x0;
                 var leftTop = (p[0].y + p[0].r) * sY + cornerGap;
-                var leftMidTop = (p[2].y - p[2].r) * sY - sideGap;
-                var leftMidBottom = (p[2].y + p[2].r) * sY + sideGap;
                 var leftBottom = (p[4].y - p[4].r) * sY - cornerGap;
+                var leftPocketY = p[2].y * sY;
+                var leftPocketR = p[2].r * sY;
                 ctx.moveTo(xLeft, leftTop);
-                ctx.lineTo(xLeft, leftMidTop);
-                ctx.moveTo(xLeft, leftMidBottom);
+                ctx.lineTo(xLeft, leftPocketY - leftPocketR - sideGap);
+                ctx.lineTo(p[2].x * sX, leftPocketY);
+                ctx.lineTo(xLeft, leftPocketY + leftPocketR + sideGap);
                 ctx.lineTo(xLeft, leftBottom);
-                // right boundary with side pocket
+                // right boundary with side pocket – bend toward pocket
                 var xRight = (TABLE_W - BORDER) * sX;
                 var rightTop = (p[1].y + p[1].r) * sY + cornerGap;
-                var rightMidTop = (p[3].y - p[3].r) * sY - sideGap;
-                var rightMidBottom = (p[3].y + p[3].r) * sY + sideGap;
                 var rightBottom = (p[5].y - p[5].r) * sY - cornerGap;
+                var rightPocketY = p[3].y * sY;
+                var rightPocketR = p[3].r * sY;
                 ctx.moveTo(xRight, rightTop);
-                ctx.lineTo(xRight, rightMidTop);
-                ctx.moveTo(xRight, rightMidBottom);
+                ctx.lineTo(xRight, rightPocketY - rightPocketR - sideGap);
+                ctx.lineTo(p[3].x * sX, rightPocketY);
+                ctx.lineTo(xRight, rightPocketY + rightPocketR + sideGap);
                 ctx.lineTo(xRight, rightBottom);
                 // pocket connectors integrated into the boundary
                 drawVPocketGuide(p[2], 1, false);


### PR DESCRIPTION
## Summary
- Extend green boundary lines toward side pockets on Pool Royale table
- Bend side lines through pocket centers to match connector shape

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc84a1de8483299f34ecafc5bfa748