### PR TITLE
chore: enforce table boundary

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -930,6 +930,7 @@
         var TABLE_H = 1216; // lartesi logjike e felt-it
         var BORDER = 57; // korniza e drurit pak me e ngushte anash
         var BALL_R = isSnooker && playType === 'training' ? 18 : 22; // snooker training uses smaller balls
+        var GREEN_LINE = 14; // thickness of the green boundary lines
         // Gropat pak me te vogla per t'u mbyllur me shume dhe jo per t'u zgjeruar
         var POCKET_R = isSnooker && playType === 'training' ? BALL_R * 0.65 : 32; // rrezja baze e gropave pak me e vogel nga jashte
         var SIDE_POCKET_R = isSnooker && playType === 'training' ? POCKET_R : 30; // gropat anesore gjithashtu pak me te vogla
@@ -938,10 +939,10 @@
         var SHORT_DIST = BALL_R * 28;
         var MED_DIST = BALL_R * 56;
         var BORDER_TOP =
-          BORDER + BALL_R * 2 - 4 - 14; // extend field upward by two green lines
+          BORDER + BALL_R * 2 - 4 - GREEN_LINE; // extend field upward by two green lines
         // Raise only the bottom field line by the thickness of one green side
         // marking so the table's lower boundary sits slightly higher.
-        var BORDER_BOTTOM = BORDER + 14; // anet e tjera mbeten te pandryshuara
+        var BORDER_BOTTOM = BORDER + GREEN_LINE; // anet e tjera mbeten te pandryshuara
         // Move the rack slightly upward on the table
         var SPOT_Y =
           BORDER_TOP +
@@ -1672,7 +1673,7 @@
           var rx = b.p.x - pk.x;
           var ry = b.p.y - pk.y;
           if (!cond(rx, ry)) return;
-          var limit = pk.r + BALL_R;
+          var limit = pk.r + BALL_R - GREEN_LINE;
           var dist = rx * nx + ry * ny;
           if (dist >= limit) return;
           var vn = b.v.x * nx + b.v.y * ny;
@@ -2104,10 +2105,10 @@
               // spin is applied directly during collisions
               b.a += (Math.hypot(b.v.x, b.v.y) * dt) / (BALL_R * 0.6);
 
-              var L = BORDER + BALL_R;
-              var R = TABLE_W - BORDER - BALL_R;
-              var T = BORDER_TOP + BALL_R;
-              var B = TABLE_H - BORDER_BOTTOM - BALL_R;
+                var L = BORDER + GREEN_LINE + BALL_R;
+                var R = TABLE_W - BORDER - GREEN_LINE - BALL_R;
+                var T = BORDER_TOP + BALL_R;
+                var B = TABLE_H - BORDER_BOTTOM - BALL_R;
 
               // Determine whether the ball is in the vicinity of any pocket.
               var nearLeft = false,
@@ -2116,7 +2117,7 @@
                 nearBottom = false;
               for (var pkIdx = 0; pkIdx < this.pockets.length; pkIdx++) {
                 var pp = this.pockets[pkIdx];
-                var thresh = pp.r + BALL_R;
+                var thresh = pp.r + BALL_R - GREEN_LINE;
                 if (Math.abs(b.p.y - pp.y) < thresh) {
                   if (pp.x < L) nearLeft = true;
                   if (pp.x > R) nearRight = true;
@@ -3343,8 +3344,8 @@
           var t = screenToTable(e.clientX, e.clientY);
           var cue = table.balls[0];
           if (draggingCue && cueBallFree) {
-            var minX = BORDER + BALL_R,
-              maxX = TABLE_W - BORDER - BALL_R;
+            var minX = BORDER + GREEN_LINE + BALL_R,
+              maxX = TABLE_W - BORDER - GREEN_LINE - BALL_R;
             var minY = LINE_Y + BALL_R,
               maxY = TABLE_H - BORDER_BOTTOM - BALL_R;
             var nx = clamp(t.x, minX, maxX);
@@ -3412,9 +3413,12 @@
           }
 
           if (dir.x < 0)
-            checkRail((BORDER + BALL_R - cue.p.x) / dir.x, { x: 1, y: 0 });
+            checkRail((BORDER + GREEN_LINE + BALL_R - cue.p.x) / dir.x, {
+              x: 1,
+              y: 0
+            });
           if (dir.x > 0)
-            checkRail((TABLE_W - BORDER - BALL_R - cue.p.x) / dir.x, {
+            checkRail((TABLE_W - BORDER - GREEN_LINE - BALL_R - cue.p.x) / dir.x, {
               x: -1,
               y: 0
             });
@@ -3535,9 +3539,15 @@
             // Project the target ball's path along the line of centers
             var tMax = Infinity;
             if (hitN.x > 0)
-              tMax = Math.min(tMax, (TABLE_W - BORDER - BALL_R - tx) / hitN.x);
+              tMax = Math.min(
+                tMax,
+                (TABLE_W - BORDER - GREEN_LINE - BALL_R - tx) / hitN.x
+              );
             if (hitN.x < 0)
-              tMax = Math.min(tMax, (BORDER + BALL_R - tx) / hitN.x);
+              tMax = Math.min(
+                tMax,
+                (BORDER + GREEN_LINE + BALL_R - tx) / hitN.x
+              );
             if (hitN.y > 0)
               tMax = Math.min(
                 tMax,
@@ -4020,8 +4030,8 @@
           if (shot.cueBallPosition) {
             var nx = clamp(
               shot.cueBallPosition.x,
-              BORDER + BALL_R,
-              TABLE_W - BORDER - BALL_R
+              BORDER + GREEN_LINE + BALL_R,
+              TABLE_W - BORDER - GREEN_LINE - BALL_R
             );
             var ny = clamp(
               shot.cueBallPosition.y,


### PR DESCRIPTION
## Summary
- keep balls within the green-lined field by adding a `GREEN_LINE` margin and clamping movement
- collide balls against pocket connectors using green line offset

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected trailing comma, Extra semicolon, A space is required after ',' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bc937aebc48329bb999fdcf47ea901