### PR TITLE
Shorten Pool Royale pocket joint markers

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2449,7 +2449,8 @@
                 ctx.stroke();
                 ctx.strokeStyle = 'orange';
                 ctx.beginPath();
-                var seal = lineW * 2;
+                // shorten orange joint markers slightly
+                var seal = lineW * 1.25;
                 // horizontal joints
                 ctx.moveTo(topStart - seal, topY);
                 ctx.lineTo(topStart + seal, topY);


### PR DESCRIPTION
## Summary
- Make the small orange joint markers near pockets shorter in Pool Royale canvas rendering

## Testing
- `npm test`
- `npm run lint` *(fails: 964 problems, mostly extra semicolons in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9741fbc88329a2e814cfca3456f3