### PR TITLE
Resize snooker table and boost shot power

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -28,14 +28,14 @@ export default function Snooker() {
 
     const tableRect = { x: rail, y: rail, w: W - rail * 2, h: H - rail * 2 };
 
-    const pockets = [
-      vec(tableRect.x, tableRect.y),
-      vec(tableRect.x + tableRect.w / 2, tableRect.y - 2),
-      vec(tableRect.x + tableRect.w, tableRect.y),
-      vec(tableRect.x, tableRect.y + tableRect.h),
-      vec(tableRect.x + tableRect.w / 2, tableRect.y + tableRect.h + 2),
-      vec(tableRect.x + tableRect.w, tableRect.y + tableRect.h)
-    ];
+      const pockets = [
+        vec(tableRect.x, tableRect.y),
+        vec(tableRect.x + tableRect.w, tableRect.y),
+        vec(tableRect.x, tableRect.y + tableRect.h),
+        vec(tableRect.x + tableRect.w, tableRect.y + tableRect.h),
+        vec(tableRect.x - 2, tableRect.y + tableRect.h / 2),
+        vec(tableRect.x + tableRect.w + 2, tableRect.y + tableRect.h / 2)
+      ];
 
     const colors = {
       cue: '#ffffff',
@@ -279,8 +279,8 @@ export default function Snooker() {
     }
     function up(e) {
       if (!aiming) return; aiming = false; const dir = norm(sub(aimStart, aimCurrent));
-      const baseSpeed = 950 * 3 * 1.6 * 1.5 * 0.6;
-      const speed = baseSpeed * (0.25 + 0.75 * shotPower);
+        const baseSpeed = 950 * 3 * 1.6 * 1.5 * 0.6;
+        const speed = baseSpeed * (0.25 + 0.75 * shotPower) * 2;
       cueBall.v = add(cueBall.v, mul(dir, speed / 60));
       if (shotPower > 0.02) { shotCount++; document.getElementById('shotCount').textContent = shotCount; }
       shotPower = 0; updatePowerBar();
@@ -319,7 +319,7 @@ export default function Snooker() {
           <button id="resetBtn" className="snooker-btn">Re-Spot Cue</button>
         </div>
       </div>
-      <canvas id="table" width="480" height="960"></canvas>
+        <canvas id="table" width="360" height="720"></canvas>
     </div>
   );
 }

--- a/webapp/src/snooker/snooker-table.css
+++ b/webapp/src/snooker/snooker-table.css
@@ -7,7 +7,7 @@
 }
 .snooker-wrap{display:grid;place-items:center;gap:16px;padding:14px}
 .snooker-wrap canvas{background:var(--felt);display:block;border-radius:18px;box-shadow:0 20px 50px rgba(0,0,0,.45)}
-.snooker-hud{width:min(480px,95vw);display:flex;flex-wrap:wrap;gap:8px;justify-content:space-between;align-items:center}
+.snooker-hud{width:min(360px,95vw);display:flex;flex-wrap:wrap;gap:8px;justify-content:space-between;align-items:center}
 .snooker-left{display:flex;align-items:center;gap:12px}
 .snooker-pill{background:#131a33;border:1px solid #263159;color:#cfe3ff;padding:8px 12px;border-radius:999px;font-size:14px}
 .snooker-btn{all:unset;background:linear-gradient(180deg,#2a335c,#1d2442);padding:10px 14px;border-radius:12px;border:1px solid #2f3c71;cursor:pointer;color:#fff}


### PR DESCRIPTION
## Summary
- shrink snooker HUD width and canvas dimensions for a smaller table
- reposition pockets to middle left/right and table corners
- double shot speed to make shots 200% more powerful

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc9852b5d883299664893c4da07e90