### PR TITLE
Shorten pocket joint markers for Pool Royale table

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2449,8 +2449,8 @@
                 ctx.stroke();
                 ctx.strokeStyle = 'orange';
                 ctx.beginPath();
-                // shorten orange joint markers slightly
-                var seal = lineW * 1.25;
+                // further shorten orange pocket joint markers
+                var seal = lineW;
                 // horizontal joints
                 ctx.moveTo(topStart - seal, topY);
                 ctx.lineTo(topStart + seal, topY);


### PR DESCRIPTION
## Summary
- reduce length of orange pocket joint markers so they appear smaller

## Testing
- `npm test`
- `npm run lint` *(fails: 964 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9a8cad848329b4af19656c508b0f