### PR TITLE
Shorten pool pocket markers

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2450,7 +2450,7 @@
                 ctx.strokeStyle = 'orange';
                 ctx.beginPath();
                 // further shorten orange pocket joint markers
-                var seal = lineW;
+                var seal = lineW * 0.75;
                 // horizontal joints
                 ctx.moveTo(topStart - seal, topY);
                 ctx.lineTo(topStart + seal, topY);


### PR DESCRIPTION
## Summary
- shorten orange pocket joint markers in pool-royale.html for smaller pocket-side guides

## Testing
- `npm test`
- `npm run lint` *(fails: 964 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9c74a1948329906396206e35e7a6