### PR TITLE
Shrink pocket joint markers in Pool Royale table

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2450,7 +2450,7 @@
                 ctx.strokeStyle = 'orange';
                 ctx.beginPath();
                 // further shorten orange pocket joint markers
-                var seal = lineW * 0.75;
+                var seal = lineW * 0.5;
                 // horizontal joints
                 ctx.moveTo(topStart - seal, topY);
                 ctx.lineTo(topStart + seal, topY);


### PR DESCRIPTION
## Summary
- Reduce size of orange pocket joint markers for a subtler look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc9f2d437c8329973533a4dd12d3a3