### PR TITLE
Tweak Pool Royale pocket geometry

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -932,8 +932,10 @@
         var BALL_R = isSnooker && playType === 'training' ? 18 : 22; // snooker training uses smaller balls
         var GREEN_LINE = 14; // thickness of the green boundary lines
         // Gropat pak me te vogla per t'u mbyllur me shume dhe jo per t'u zgjeruar
-        var POCKET_R = isSnooker && playType === 'training' ? BALL_R * 0.65 : 32; // rrezja baze e gropave pak me e vogel nga jashte
-        var SIDE_POCKET_R = isSnooker && playType === 'training' ? POCKET_R : 30; // gropat anesore gjithashtu pak me te vogla
+        var POCKET_R =
+          isSnooker && playType === 'training' ? BALL_R * 0.68 : 34; // pockets slightly larger
+        var SIDE_POCKET_R =
+          isSnooker && playType === 'training' ? POCKET_R : 32; // side pockets also a touch larger
         // move pockets slightly closer to the center of the table
         var POCKET_SHORTEN = isSnooker ? 2 : 4; // gropat snooker pak me brenda
         var SHORT_DIST = BALL_R * 28;
@@ -2022,7 +2024,7 @@
             var wrapRect = document
               .getElementById('wrap')
               .getBoundingClientRect();
-            this.pockets = Array.prototype.map.call(holeEls, function (el) {
+            var pockets = Array.prototype.map.call(holeEls, function (el) {
               var r = el.getBoundingClientRect();
               var cx =
                 ((r.left + r.width / 2 - wrapRect.left) / wrapRect.width) *
@@ -2030,9 +2032,14 @@
               var cy =
                 ((r.top + r.height / 2 - wrapRect.top) / wrapRect.height) *
                 TABLE_H;
-              var pr = (r.width / 2 / wrapRect.width) * TABLE_W;
+              var pr = (r.width / 2 / wrapRect.width) * TABLE_W + 2;
               return new Pocket(cx, cy, pr);
             });
+            // Adjust specific pocket positions slightly
+            pockets[2].y -= 2; // lift left middle pocket
+            pockets[4].y += 2; // lower bottom pockets
+            pockets[5].y += 2;
+            this.pockets = pockets;
           } else {
             this.pockets = [
               new Pocket(
@@ -2050,7 +2057,7 @@
               // slightly farther from center.
               new Pocket(
                 BORDER - 16 - POCKET_SHORTEN,
-                TABLE_H / 2 + BALL_R - 14,
+                TABLE_H / 2 + BALL_R - 16,
                 SIDE_POCKET_R
               ),
               new Pocket(
@@ -2060,12 +2067,12 @@
               ),
               new Pocket(
                 BORDER - POCKET_SHORTEN,
-                TABLE_H - BORDER_BOTTOM + POCKET_SHORTEN,
+                TABLE_H - BORDER_BOTTOM + POCKET_SHORTEN + 2,
                 POCKET_R
               ),
               new Pocket(
                 TABLE_W - BORDER + POCKET_SHORTEN,
-                TABLE_H - BORDER_BOTTOM + POCKET_SHORTEN,
+                TABLE_H - BORDER_BOTTOM + POCKET_SHORTEN + 2,
                 POCKET_R
               )
             ];


### PR DESCRIPTION
## Summary
- Slightly enlarge pocket radii for all six pockets
- Raise the left side pocket a bit and lower both bottom pockets
- Apply same adjustments when DOM-based pockets are used

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected trailing comma etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bd076190f883298bb7d2b7e48ccd0f