### PR TITLE
Raise middle pockets and align connectors in Pool Royale

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2089,16 +2089,16 @@
                 POCKET_R
               ),
               // Lift middle pockets a touch more to align with the shifted field
-              // boundary, matching the green marking thickness, and nudge them
-              // slightly farther from center.
+              // boundary and keep the V connectors in sync, nudging them slightly
+              // farther from center.
               new Pocket(
                 BORDER - 14 - POCKET_SHORTEN,
-                TABLE_H / 2 + BALL_R - 16,
+                TABLE_H / 2 + BALL_R - 20,
                 SIDE_POCKET_R
               ),
               new Pocket(
                 TABLE_W - BORDER + 14 + POCKET_SHORTEN,
-                TABLE_H / 2 + BALL_R - 16,
+                TABLE_H / 2 + BALL_R - 20,
                 SIDE_POCKET_R
               ),
               new Pocket(


### PR DESCRIPTION
## Summary
- Nudge middle side pockets slightly upward in Pool Royale layout to keep top/bottom pockets fixed
- Update comment to clarify V-connector alignment and movement

## Testing
- `npm test`
- `npm run lint` *(fails: 964 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1ae7a12c8329bb4cddf8157777d0