### PR TITLE
Hide Pool Royale debug and connector lines

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -394,7 +394,7 @@
       }
       window.showDebugMarkers = () => setDebugVisible(true);
       window.hideDebugMarkers = () => setDebugVisible(false);
-      setDebugVisible(true);
+      setDebugVisible(false);
     </script>
   </body>
 </html>

--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2439,9 +2439,9 @@
 
           if (!isSnooker) {
             ctx.save();
-              ctx.fillStyle = 'rgba(255,255,0,0.05)';
+              ctx.fillStyle = 'rgba(255,255,0,0)';
               ctx.fillRect(x0, y0, w, h);
-              ctx.strokeStyle = 'rgba(0,255,0,0.8)';
+              ctx.strokeStyle = 'rgba(0,255,0,0)';
               ctx.lineWidth = 2;
               if (this.pockets) {
                 var p = this.pockets;
@@ -2490,7 +2490,7 @@
                 drawUPocketGuide(p[4], 1, -1, false);
                 drawUPocketGuide(p[5], -1, -1, false);
                 ctx.stroke();
-                ctx.strokeStyle = 'orange';
+                ctx.strokeStyle = 'rgba(255,165,0,0)';
                 ctx.beginPath();
                 // further shorten orange pocket joint markers
                 var seal = lineW * 0.5;


### PR DESCRIPTION
## Summary
- Hide debug markers in Pool Royale demo so they aren't visible by default.
- Make green boundary lines and orange pocket connectors in Pool Royale game fully transparent to keep them hidden from players.

## Testing
- `npm test`
- `npm run lint` *(fails: 964 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bd348d6b9883298b87461ee9770aec