### PR TITLE
Hide Pool Royale pocket debug markers

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2522,7 +2522,7 @@
                 ctx.moveTo(xRight, rightBottom - seal);
                 ctx.lineTo(xRight, rightBottom + seal);
                 ctx.stroke();
-                ctx.strokeStyle = 'red';
+                ctx.strokeStyle = 'rgba(255,0,0,0)';
                 ctx.lineWidth = 2;
                 var rScale = (sX + sY) / 2;
                 this.pockets.forEach(function(pk) {


### PR DESCRIPTION
## Summary
- make pocket debug circles invisible in Pool Royale demo

## Testing
- `npm test`
- `npm run lint` *(fails: 964 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3a176be48329bd26ca89c05bc916