### PR TITLE
Fix corner boundary escape in billiards physics

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -49,6 +49,17 @@ public class CcdRegressionTests
         Assert.Greater(t, 0);
         Assert.That(Math.Abs(n.Y - (-1)), Is.LessThan(1e-6));
     }
+
+    [Test]
+    public void CornerCushionReflection()
+    {
+        var start = new Vec2(PhysicsConstants.BallRadius + 0.1, PhysicsConstants.BallRadius + 0.1);
+        var vel = new Vec2(-1, -1);
+        Assert.IsTrue(Ccd.CircleAabb(start, vel, PhysicsConstants.BallRadius, new Vec2(0, 0), new Vec2(1, 1), out double t, out Vec2 n));
+        Assert.Greater(t, 0);
+        Assert.That(Math.Abs(n.X - n.Y), Is.LessThan(1e-6));
+        Assert.That(n.X, Is.GreaterThan(0));
+    }
 }
 
 public class PreviewRuntimeTests
@@ -110,6 +121,19 @@ public class CushionStepTests
         solver.Step(new List<BilliardsSolver.Ball> { ball }, 0.1);
         Assert.That(ball.Position.X, Is.GreaterThanOrEqualTo(PhysicsConstants.BallRadius - 1e-9));
         Assert.That(ball.Velocity.X, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void BallReflectsInCornerWithoutCrossing()
+    {
+        var solver = new BilliardsSolver();
+        var start = new Vec2(PhysicsConstants.BallRadius + 0.1, PhysicsConstants.BallRadius + 0.1);
+        var ball = new BilliardsSolver.Ball { Position = start, Velocity = new Vec2(-5, -5) };
+        solver.Step(new List<BilliardsSolver.Ball> { ball }, 0.1);
+        Assert.That(ball.Position.X, Is.GreaterThanOrEqualTo(PhysicsConstants.BallRadius - 1e-9));
+        Assert.That(ball.Position.Y, Is.GreaterThanOrEqualTo(PhysicsConstants.BallRadius - 1e-9));
+        Assert.That(ball.Velocity.X, Is.GreaterThan(0));
+        Assert.That(ball.Velocity.Y, Is.GreaterThan(0));
     }
 }
 

--- a/billiards/Ccd.cs
+++ b/billiards/Ccd.cs
@@ -65,6 +65,28 @@ public static class Ccd
                 }
             }
         }
+
+        // handle corner impacts where neither vertical nor horizontal checks apply
+        // treat corners as stationary circles with radius equal to the ball radius
+        Vec2[] corners = new Vec2[]
+        {
+            new Vec2(min.X + r, min.Y + r),
+            new Vec2(max.X - r, min.Y + r),
+            new Vec2(min.X + r, max.Y - r),
+            new Vec2(max.X - r, max.Y - r)
+        };
+        foreach (var c in corners)
+        {
+            if (CircleCircle(p, v, 0, c, r, out double tCorner) && tCorner < toi)
+            {
+                toi = tCorner;
+                hit = true;
+                // normal points from corner center to impact point
+                var contact = p + v * tCorner;
+                normal = (contact - c).Normalized();
+            }
+        }
+
         return hit;
     }
 


### PR DESCRIPTION
## Summary
- prevent balls from slipping through table corners by treating each corner as a circular cushion
- add regression tests for corner collisions and corner reflections

## Testing
- `dotnet test billiards.Tests/Billiards.Tests.csproj`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd3d4a4498832996268abf8ff4f7ca