### PR TITLE
Fix pocket joint collisions in Pool Royale

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2160,7 +2160,7 @@
                 nearBottom = false;
               for (var pkIdx = 0; pkIdx < this.pockets.length; pkIdx++) {
                 var pp = this.pockets[pkIdx];
-                var thresh = pp.r + BALL_R;
+                var thresh = pp.r + BALL_R - GREEN_LINE;
                 if (Math.abs(b.p.y - pp.y) < thresh) {
                   if (pp.x < L) nearLeft = true;
                   if (pp.x > R) nearRight = true;
@@ -2217,34 +2217,34 @@
                 if (i === 0 && shotInProgress && !firstHit)
                   cueHitCushion = true;
               }
-          }
 
-          var pk = this.pockets;
-          var inv = INV_SQRT2;
-          handleConnectorCollision(this, b, pk[0], inv, inv, function (rx, ry) {
-            return rx >= 0 && ry >= 0;
-          });
-          handleConnectorCollision(this, b, pk[1], -inv, inv, function (rx, ry) {
-            return rx <= 0 && ry >= 0;
-          });
-          handleConnectorCollision(this, b, pk[4], inv, -inv, function (rx, ry) {
-            return rx >= 0 && ry <= 0;
-          });
-          handleConnectorCollision(this, b, pk[5], -inv, -inv, function (rx, ry) {
-            return rx <= 0 && ry <= 0;
-          });
-          handleConnectorCollision(this, b, pk[2], inv, inv, function (rx, ry) {
-            return rx >= 0 && ry <= 0;
-          });
-          handleConnectorCollision(this, b, pk[2], inv, -inv, function (rx, ry) {
-            return rx >= 0 && ry >= 0;
-          });
-          handleConnectorCollision(this, b, pk[3], -inv, inv, function (rx, ry) {
-            return rx <= 0 && ry <= 0;
-          });
-          handleConnectorCollision(this, b, pk[3], -inv, -inv, function (rx, ry) {
-            return rx <= 0 && ry >= 0;
-          });
+              var pk = this.pockets;
+              var inv = INV_SQRT2;
+              handleConnectorCollision(this, b, pk[0], inv, inv, function (rx, ry) {
+                return rx >= 0 && ry >= 0;
+              });
+              handleConnectorCollision(this, b, pk[1], -inv, inv, function (rx, ry) {
+                return rx <= 0 && ry >= 0;
+              });
+              handleConnectorCollision(this, b, pk[4], inv, -inv, function (rx, ry) {
+                return rx >= 0 && ry <= 0;
+              });
+              handleConnectorCollision(this, b, pk[5], -inv, -inv, function (rx, ry) {
+                return rx <= 0 && ry <= 0;
+              });
+              handleConnectorCollision(this, b, pk[2], inv, inv, function (rx, ry) {
+                return rx >= 0 && ry <= 0;
+              });
+              handleConnectorCollision(this, b, pk[2], inv, -inv, function (rx, ry) {
+                return rx >= 0 && ry >= 0;
+              });
+              handleConnectorCollision(this, b, pk[3], -inv, inv, function (rx, ry) {
+                return rx <= 0 && ry <= 0;
+              });
+              handleConnectorCollision(this, b, pk[3], -inv, -inv, function (rx, ry) {
+                return rx <= 0 && ry >= 0;
+              });
+          }
 
           // Perplasje ball-ball
           var N = this.balls.length;


### PR DESCRIPTION
## Summary
- prevent ball escape at pocket joints by reducing pocket proximity allowance
- apply pocket connector collision checks for each ball to make joint lines behave like cushions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd40a5ddf08329b258271af318c774