### PR TITLE
feat(pool-royale): refine pocket placement and boundary lines

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -930,7 +930,7 @@
         var TABLE_H = 1216; // lartesi logjike e felt-it
         var BORDER = 57; // korniza e drurit pak me e ngushte anash
         var BALL_R = isSnooker && playType === 'training' ? 18 : 22; // snooker training uses smaller balls
-        var GREEN_LINE = 14; // thickness of the green boundary lines
+        var GREEN_LINE = 16; // thickness of the green boundary lines
         // Gropat pak me te vogla per t'u mbyllur me shume dhe jo per t'u zgjeruar
         var POCKET_R =
           isSnooker && playType === 'training' ? BALL_R * 0.68 : 34; // pockets slightly larger
@@ -938,7 +938,7 @@
           isSnooker && playType === 'training' ? POCKET_R : 32; // side pockets also a touch larger
         // move pockets slightly closer to the center of the table
         var POCKET_SHORTEN = isSnooker ? 2 : 4; // gropat snooker pak me brenda
-        var POCKET_INSET = 2; // additional inward shift for all pockets
+        var POCKET_INSET = 3; // additional inward shift for all pockets
         var SHORT_DIST = BALL_R * 28;
         var MED_DIST = BALL_R * 56;
         var BORDER_TOP =
@@ -2428,7 +2428,7 @@
               ctx.fillStyle = 'rgba(255,255,0,0.05)';
               ctx.fillRect(x0, y0, w, h);
               ctx.strokeStyle = 'rgba(0,255,0,0.8)';
-              ctx.lineWidth = 2;
+              ctx.lineWidth = 3;
               if (this.pockets) {
                 var p = this.pockets;
                 var lineW = ctx.lineWidth;


### PR DESCRIPTION
## Summary
- Move pocket centers slightly inward for better alignment
- Thicken green boundary lines to emphasize table edges

## Testing
- `npm test`
- `npm run lint` (fails: 964 problems)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd5e2117548329ae1476ceb75e964e