### PR TITLE
feat: add view toggle and pinch zoom to snooker game

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -1,8 +1,9 @@
 /* Power Slider component styles */
 .ps {
-  --ps-width: 67px;
+  /* slimmer slider to match pool game styling */
+  --ps-width: 46px;
   --ps-height: 576px;
-  --ps-radius: 34px;
+  --ps-radius: 23px;
   --ps-track-bg: rgba(255, 255, 255, 0.15);
   --ps-gradient-low: #ffe066;
   --ps-gradient-mid: #ff8c00;
@@ -21,7 +22,8 @@
   overflow: visible;
   user-select: none;
   touch-action: none;
-  transform: scale(1.2);
+  /* removed extra scale so dimensions match pool game */
+  transform: scale(1);
   transform-origin: top left;
 }
 


### PR DESCRIPTION
## Summary
- slim power slider styling and remove extra scale
- add 2D/3D camera view toggle and pinch zoom on snooker table
- start camera from baulk side and use cue image for slider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd631327308329a7047a6b9e4183c4