### PR TITLE
Handle green connectors as damped cushions

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -133,3 +133,27 @@ public class PocketEdgeTests
         Assert.That(balls, Is.Empty);
     }
 }
+
+public class ConnectorEdgeTests
+{
+    [Test]
+    public void BallBouncesOffConnectorWithReducedSpeed()
+    {
+        var solver = new BilliardsSolver();
+        solver.ConnectorEdges.Add(new BilliardsSolver.Edge
+        {
+            A = new Vec2(0, 0.1),
+            B = new Vec2(0.1, 0),
+            Normal = new Vec2(1, 1).Normalized()
+        });
+        var v = new Vec2(-1, -1).Normalized();
+        var ball = new BilliardsSolver.Ball { Position = new Vec2(0.2, 0.2), Velocity = v };
+        var balls = new List<BilliardsSolver.Ball> { ball };
+        solver.Step(balls, 0.3);
+        Assert.That(ball.Pocketed, Is.False);
+        Assert.That(balls, Has.Count.EqualTo(1));
+        Assert.That(ball.Velocity.X, Is.GreaterThan(0));
+        Assert.That(ball.Velocity.Y, Is.GreaterThan(0));
+        Assert.That(ball.Velocity.Length, Is.LessThan(0.5));
+    }
+}

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -6,8 +6,10 @@ public static class PhysicsConstants
     public const double BallRadius = 0.028575;        // metres (57.15 mm diameter)
     public const double Restitution = 0.98;            // elastic coefficient
     public const double CushionRestitution = Restitution * 1.1; // extra bounce for table edges
-    // pocket edges retain only a quarter of the cushion bounce (lose ~75% of speed)
-    public const double PocketRestitution = CushionRestitution * 0.25;
+    // connectors retain only a quarter of the cushion bounce (lose ~75% of speed)
+    public const double ConnectorRestitution = CushionRestitution * 0.25;
+    // pocket edges fully absorb balls (no bounce)
+    public const double PocketRestitution = 0.0;
     public const double Mu = 0.2;                      // linear damping (m/s^2)
     public const double TableWidth = 2.84;             // 9ft table internal size
     public const double TableHeight = 1.42;


### PR DESCRIPTION
## Summary
- Treat green connector lines as cushion edges that reduce bounce and speed
- Keep pocket edges absorbing and prevent crossing table boundaries
- Add regression test ensuring balls reflect off connectors with reduced velocity

## Testing
- `dotnet test billiards.Tests/Billiards.Tests.csproj`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd64f3b2488329934d03df8ff3e850