### PR TITLE
Refine Pool Royale table boundaries and pockets

### DIFF
--- a/examples/pool-royale/royale-physics.js
+++ b/examples/pool-royale/royale-physics.js
@@ -15,17 +15,16 @@ const LINE_MAX_X = TABLE_WIDTH - BALL_RADIUS;
 const LINE_MIN_Y = BALL_RADIUS;
 const LINE_MAX_Y = TABLE_HEIGHT - BALL_RADIUS;
 
-// pocket centers
+// pocket centers moved slightly toward the table center
+const POCKET_INSET = 0.03;
 const POCKETS = [
-  [0, 0],
-  [TABLE_WIDTH / 2, 0],
-  [TABLE_WIDTH, 0],
-  [0, TABLE_HEIGHT],
-  [TABLE_WIDTH / 2, TABLE_HEIGHT],
-  [TABLE_WIDTH, TABLE_HEIGHT]
+  [POCKET_INSET, POCKET_INSET],
+  [TABLE_WIDTH / 2, POCKET_INSET],
+  [TABLE_WIDTH - POCKET_INSET, POCKET_INSET],
+  [POCKET_INSET, TABLE_HEIGHT - POCKET_INSET],
+  [TABLE_WIDTH / 2, TABLE_HEIGHT - POCKET_INSET],
+  [TABLE_WIDTH - POCKET_INSET, TABLE_HEIGHT - POCKET_INSET]
 ];
-const CONNECTOR_RADIUS = 0.09; // ~9 cm
-const CONNECTOR_RESTITUTION = -0.25; // keep 25% energy
 
 class Ball {
   constructor(x, y, vx, vy) {
@@ -41,7 +40,6 @@ class Ball {
     this.y += this.vy * dt;
     this.checkCushion();
     this.checkLine();
-    this.checkConnector();
   }
 
   checkCushion() {
@@ -95,18 +93,6 @@ class Ball {
     }
   }
 
-  checkConnector() {
-    for (const [px, py] of POCKETS) {
-      const dx = this.x - px;
-      const dy = this.y - py;
-      if (dx * dx + dy * dy <= CONNECTOR_RADIUS * CONNECTOR_RADIUS) {
-        this.vx *= CONNECTOR_RESTITUTION;
-        this.vy *= CONNECTOR_RESTITUTION;
-        this.touchedCushion = false;
-        break;
-      }
-    }
-  }
 }
 
 function simulate(balls, steps, dt) {

--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -938,7 +938,7 @@
           isSnooker && playType === 'training' ? POCKET_R : 32; // side pockets also a touch larger
         // move pockets slightly closer to the center of the table
         var POCKET_SHORTEN = isSnooker ? 2 : 4; // gropat snooker pak me brenda
-        var POCKET_INSET = 3; // additional inward shift for all pockets
+        var POCKET_INSET = 4; // additional inward shift for all pockets
         var SHORT_DIST = BALL_R * 28;
         var MED_DIST = BALL_R * 56;
         var BORDER_TOP =
@@ -2425,103 +2425,62 @@
 
           if (!isSnooker) {
             ctx.save();
-              ctx.fillStyle = 'rgba(255,255,0,0.05)';
-              ctx.fillRect(x0, y0, w, h);
-              ctx.strokeStyle = 'rgba(0,255,0,0.8)';
-              ctx.lineWidth = 3;
-              if (this.pockets) {
-                var p = this.pockets;
-                var lineW = ctx.lineWidth;
-                // Slightly extend the green boundary lines closer to the pockets
-                // Align boundary expansion exactly with pocket connectors
-                var cornerGap = lineW * 0.5;
-                var sideGap = lineW * 0.5;
-                ctx.beginPath();
-                // top boundary
-                var topY = y0;
-                var topStart = (p[0].x + p[0].r) * sX + cornerGap;
-                var topEnd = (p[1].x - p[1].r) * sX - cornerGap;
-                ctx.moveTo(topStart, topY);
-                ctx.lineTo(topEnd, topY);
-                // bottom boundary
-                var bottomY = (TABLE_H - BORDER_BOTTOM) * sY;
-                var bottomStart = (p[4].x + p[4].r) * sX + cornerGap;
-                var bottomEnd = (p[5].x - p[5].r) * sX - cornerGap;
-                ctx.moveTo(bottomStart, bottomY);
-                ctx.lineTo(bottomEnd, bottomY);
-                // left boundary with side pocket
-                var xLeft = x0;
-                var leftTop = (p[0].y + p[0].r) * sY + cornerGap;
-                var leftMidTop = (p[2].y - p[2].r) * sY - sideGap;
-                var leftMidBottom = (p[2].y + p[2].r) * sY + sideGap;
-                var leftBottom = (p[4].y - p[4].r) * sY - cornerGap;
-                ctx.moveTo(xLeft, leftTop);
-                ctx.lineTo(xLeft, leftMidTop);
-                ctx.moveTo(xLeft, leftMidBottom);
-                ctx.lineTo(xLeft, leftBottom);
-                // right boundary with side pocket
-                var xRight = (TABLE_W - BORDER) * sX;
-                var rightTop = (p[1].y + p[1].r) * sY + cornerGap;
-                var rightMidTop = (p[3].y - p[3].r) * sY - sideGap;
-                var rightMidBottom = (p[3].y + p[3].r) * sY + sideGap;
-                var rightBottom = (p[5].y - p[5].r) * sY - cornerGap;
-                ctx.moveTo(xRight, rightTop);
-                ctx.lineTo(xRight, rightMidTop);
-                ctx.moveTo(xRight, rightMidBottom);
-                ctx.lineTo(xRight, rightBottom);
-                // pocket connectors integrated into the boundary
-                drawVPocketGuide(p[2], 1, false);
-                drawVPocketGuide(p[3], -1, false);
-                drawUPocketGuide(p[0], 1, 1, false);
-                drawUPocketGuide(p[1], -1, 1, false);
-                drawUPocketGuide(p[4], 1, -1, false);
-                drawUPocketGuide(p[5], -1, -1, false);
-                ctx.stroke();
-                ctx.strokeStyle = 'orange';
-                ctx.beginPath();
-                // further shorten orange pocket joint markers
-                var seal = lineW * 0.5;
-                // horizontal joints
-                ctx.moveTo(topStart - seal, topY);
-                ctx.lineTo(topStart + seal, topY);
-                ctx.moveTo(topEnd - seal, topY);
-                ctx.lineTo(topEnd + seal, topY);
-                ctx.moveTo(bottomStart - seal, bottomY);
-                ctx.lineTo(bottomStart + seal, bottomY);
-                ctx.moveTo(bottomEnd - seal, bottomY);
-                ctx.lineTo(bottomEnd + seal, bottomY);
-                // left vertical joints
-                ctx.moveTo(xLeft, leftTop - seal);
-                ctx.lineTo(xLeft, leftTop + seal);
-                ctx.moveTo(xLeft, leftMidTop - seal);
-                ctx.lineTo(xLeft, leftMidTop + seal);
-                ctx.moveTo(xLeft, leftMidBottom - seal);
-                ctx.lineTo(xLeft, leftMidBottom + seal);
-                ctx.moveTo(xLeft, leftBottom - seal);
-                ctx.lineTo(xLeft, leftBottom + seal);
-                // right vertical joints
-                ctx.moveTo(xRight, rightTop - seal);
-                ctx.lineTo(xRight, rightTop + seal);
-                ctx.moveTo(xRight, rightMidTop - seal);
-                ctx.lineTo(xRight, rightMidTop + seal);
-                ctx.moveTo(xRight, rightMidBottom - seal);
-                ctx.lineTo(xRight, rightMidBottom + seal);
-                ctx.moveTo(xRight, rightBottom - seal);
-                ctx.lineTo(xRight, rightBottom + seal);
-                ctx.stroke();
-                ctx.strokeStyle = 'red';
-                ctx.lineWidth = 2;
-                var rScale = (sX + sY) / 2;
-                this.pockets.forEach(function(pk) {
+                ctx.fillStyle = 'rgba(255,255,0,0.05)';
+                ctx.fillRect(x0, y0, w, h);
+                ctx.strokeStyle = 'rgba(0,255,0,0.8)';
+                ctx.lineWidth = 3;
+                if (this.pockets) {
+                  var p = this.pockets;
+                  // Extend the green boundary lines to meet the pocket edges
+                  var cornerGap = 0;
+                  var sideGap = 0;
                   ctx.beginPath();
-                  ctx.arc(pk.x * sX, pk.y * sY, pk.r * rScale, 0, Math.PI * 2);
+                  // top boundary
+                  var topY = y0;
+                  var topStart = (p[0].x + p[0].r) * sX;
+                  var topEnd = (p[1].x - p[1].r) * sX;
+                  ctx.moveTo(topStart, topY);
+                  ctx.lineTo(topEnd, topY);
+                  // bottom boundary
+                  var bottomY = (TABLE_H - BORDER_BOTTOM) * sY;
+                  var bottomStart = (p[4].x + p[4].r) * sX;
+                  var bottomEnd = (p[5].x - p[5].r) * sX;
+                  ctx.moveTo(bottomStart, bottomY);
+                  ctx.lineTo(bottomEnd, bottomY);
+                  // left boundary with side pocket
+                  var xLeft = x0;
+                  var leftTop = (p[0].y + p[0].r) * sY;
+                  var leftMidTop = (p[2].y - p[2].r) * sY;
+                  var leftMidBottom = (p[2].y + p[2].r) * sY;
+                  var leftBottom = (p[4].y - p[4].r) * sY;
+                  ctx.moveTo(xLeft, leftTop);
+                  ctx.lineTo(xLeft, leftMidTop);
+                  ctx.moveTo(xLeft, leftMidBottom);
+                  ctx.lineTo(xLeft, leftBottom);
+                  // right boundary with side pocket
+                  var xRight = (TABLE_W - BORDER) * sX;
+                  var rightTop = (p[1].y + p[1].r) * sY;
+                  var rightMidTop = (p[3].y - p[3].r) * sY;
+                  var rightMidBottom = (p[3].y + p[3].r) * sY;
+                  var rightBottom = (p[5].y - p[5].r) * sY;
+                  ctx.moveTo(xRight, rightTop);
+                  ctx.lineTo(xRight, rightMidTop);
+                  ctx.moveTo(xRight, rightMidBottom);
+                  ctx.lineTo(xRight, rightBottom);
                   ctx.stroke();
-                });
-              } else {
-                ctx.strokeRect(x0, y0, w, h);
-              }
-              ctx.restore();
-          }
+                  ctx.strokeStyle = 'red';
+                  ctx.lineWidth = 2;
+                  var rScale = (sX + sY) / 2;
+                  this.pockets.forEach(function(pk) {
+                    ctx.beginPath();
+                    ctx.arc(pk.x * sX, pk.y * sY, pk.r * rScale, 0, Math.PI * 2);
+                    ctx.stroke();
+                  });
+                } else {
+                  ctx.strokeRect(x0, y0, w, h);
+                }
+                ctx.restore();
+            }
 
           // Vija kufizuese e cueball-it dhe pika qendrore
           ctx.strokeStyle = '#fff';
@@ -3677,44 +3636,6 @@
           ctx.closePath();
           if (fill) ctx.fill();
           ctx.stroke();
-          ctx.restore();
-        }
-
-        function drawVPocketGuide(p, dir, stroke = true) {
-          var R = p.r * ((sX + sY) / 2) * 1.2;
-          var x = p.x * sX - R * 0.5 * dir;
-          var y = p.y * sY;
-          var dx = R * 1.1 * dir;
-          var dy = R * 1.25;
-          // Remove trimming so lines meet the table boundary without gaps
-          var trim = 0;
-          if (stroke) ctx.beginPath();
-          ctx.moveTo(x - dx, y);
-          ctx.lineTo(x + dx, y - dy + trim);
-          ctx.moveTo(x - dx, y);
-          ctx.lineTo(x + dx, y + dy - trim);
-          if (stroke) ctx.stroke();
-        }
-
-        function drawUPocketGuide(p, sx, sy, stroke = true) {
-          var R = p.r * ((sX + sY) / 2);
-          var x = p.x * sX;
-          var y = p.y * sY;
-          ctx.save();
-          ctx.translate(x, y);
-          ctx.scale(sx, sy);
-          ctx.rotate(-Math.PI / 4);
-          if (stroke) ctx.beginPath();
-          ctx.moveTo(-R, 0);
-          ctx.arc(0, 0, R, Math.PI, 0);
-          // Extend legs to meet the boundary without gaps
-          var lineLen = R * 1.25;
-          var lineStart = 0;
-          ctx.moveTo(-R, lineStart);
-          ctx.lineTo(-R, lineLen);
-          ctx.moveTo(R, lineStart);
-          ctx.lineTo(R, lineLen);
-          if (stroke) ctx.stroke();
           ctx.restore();
         }
 


### PR DESCRIPTION
## Summary
- Extend and simplify Pool Royale table boundaries, removing connectors and orange joint markers
- Nudge all pockets slightly inward for a tighter layout in both web app and example physics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd73413a0883298821cb6380a9b7e0