### PR TITLE
Shift Pool Royale pockets inward

### DIFF
--- a/examples/pool-royale/royale-physics.js
+++ b/examples/pool-royale/royale-physics.js
@@ -16,7 +16,8 @@ const LINE_MIN_Y = BALL_RADIUS;
 const LINE_MAX_Y = TABLE_HEIGHT - BALL_RADIUS;
 
 // pocket centers moved slightly toward the table center
-const POCKET_INSET = 0.03;
+// moved a touch further inward for tighter pocket alignment
+const POCKET_INSET = 0.04;
 const POCKETS = [
   [POCKET_INSET, POCKET_INSET],
   [TABLE_WIDTH / 2, POCKET_INSET],

--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -938,7 +938,7 @@
           isSnooker && playType === 'training' ? POCKET_R : 32; // side pockets also a touch larger
         // move pockets slightly closer to the center of the table
         var POCKET_SHORTEN = isSnooker ? 2 : 4; // gropat snooker pak me brenda
-        var POCKET_INSET = 4; // additional inward shift for all pockets
+        var POCKET_INSET = 5; // additional inward shift for all pockets
         var SHORT_DIST = BALL_R * 28;
         var MED_DIST = BALL_R * 56;
         var BORDER_TOP =


### PR DESCRIPTION
## Summary
- bring all six Pool Royale pockets slightly closer to table center
- reflect updated pocket inset in example physics code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd75dee84483298a6e7039f3241255