### PR TITLE
Adjust Pool Royale pockets and boundary lines

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -938,7 +938,7 @@
           isSnooker && playType === 'training' ? POCKET_R : 32; // side pockets also a touch larger
         // move pockets slightly closer to the center of the table
         var POCKET_SHORTEN = isSnooker ? 2 : 4; // gropat snooker pak me brenda
-        var POCKET_INSET = 3; // additional inward shift for all pockets
+        var POCKET_INSET = 5; // bring all pockets slightly closer to center
         var SHORT_DIST = BALL_R * 28;
         var MED_DIST = BALL_R * 56;
         var BORDER_TOP =
@@ -2429,94 +2429,32 @@
               ctx.fillRect(x0, y0, w, h);
               ctx.strokeStyle = 'rgba(0,255,0,0.8)';
               ctx.lineWidth = 3;
+              ctx.lineJoin = 'miter';
+              ctx.lineCap = 'butt';
               if (this.pockets) {
                 var p = this.pockets;
-                var lineW = ctx.lineWidth;
-                // Slightly extend the green boundary lines closer to the pockets
-                // Align boundary expansion exactly with pocket connectors
-                var cornerGap = lineW * 0.5;
-                var sideGap = lineW * 0.5;
                 ctx.beginPath();
                 // top boundary
                 var topY = y0;
-                var topStart = (p[0].x + p[0].r) * sX + cornerGap;
-                var topEnd = (p[1].x - p[1].r) * sX - cornerGap;
-                ctx.moveTo(topStart, topY);
-                ctx.lineTo(topEnd, topY);
+                ctx.moveTo((p[0].x + p[0].r) * sX, topY);
+                ctx.lineTo((p[1].x - p[1].r) * sX, topY);
                 // bottom boundary
                 var bottomY = (TABLE_H - BORDER_BOTTOM) * sY;
-                var bottomStart = (p[4].x + p[4].r) * sX + cornerGap;
-                var bottomEnd = (p[5].x - p[5].r) * sX - cornerGap;
-                ctx.moveTo(bottomStart, bottomY);
-                ctx.lineTo(bottomEnd, bottomY);
+                ctx.moveTo((p[4].x + p[4].r) * sX, bottomY);
+                ctx.lineTo((p[5].x - p[5].r) * sX, bottomY);
                 // left boundary with side pocket
                 var xLeft = x0;
-                var leftTop = (p[0].y + p[0].r) * sY + cornerGap;
-                var leftMidTop = (p[2].y - p[2].r) * sY - sideGap;
-                var leftMidBottom = (p[2].y + p[2].r) * sY + sideGap;
-                var leftBottom = (p[4].y - p[4].r) * sY - cornerGap;
-                ctx.moveTo(xLeft, leftTop);
-                ctx.lineTo(xLeft, leftMidTop);
-                ctx.moveTo(xLeft, leftMidBottom);
-                ctx.lineTo(xLeft, leftBottom);
+                ctx.moveTo(xLeft, (p[0].y + p[0].r) * sY);
+                ctx.lineTo(xLeft, (p[2].y - p[2].r) * sY);
+                ctx.moveTo(xLeft, (p[2].y + p[2].r) * sY);
+                ctx.lineTo(xLeft, (p[4].y - p[4].r) * sY);
                 // right boundary with side pocket
                 var xRight = (TABLE_W - BORDER) * sX;
-                var rightTop = (p[1].y + p[1].r) * sY + cornerGap;
-                var rightMidTop = (p[3].y - p[3].r) * sY - sideGap;
-                var rightMidBottom = (p[3].y + p[3].r) * sY + sideGap;
-                var rightBottom = (p[5].y - p[5].r) * sY - cornerGap;
-                ctx.moveTo(xRight, rightTop);
-                ctx.lineTo(xRight, rightMidTop);
-                ctx.moveTo(xRight, rightMidBottom);
-                ctx.lineTo(xRight, rightBottom);
-                // pocket connectors integrated into the boundary
-                drawVPocketGuide(p[2], 1, false);
-                drawVPocketGuide(p[3], -1, false);
-                drawUPocketGuide(p[0], 1, 1, false);
-                drawUPocketGuide(p[1], -1, 1, false);
-                drawUPocketGuide(p[4], 1, -1, false);
-                drawUPocketGuide(p[5], -1, -1, false);
+                ctx.moveTo(xRight, (p[1].y + p[1].r) * sY);
+                ctx.lineTo(xRight, (p[3].y - p[3].r) * sY);
+                ctx.moveTo(xRight, (p[3].y + p[3].r) * sY);
+                ctx.lineTo(xRight, (p[5].y - p[5].r) * sY);
                 ctx.stroke();
-                ctx.strokeStyle = 'orange';
-                ctx.beginPath();
-                // further shorten orange pocket joint markers
-                var seal = lineW * 0.5;
-                // horizontal joints
-                ctx.moveTo(topStart - seal, topY);
-                ctx.lineTo(topStart + seal, topY);
-                ctx.moveTo(topEnd - seal, topY);
-                ctx.lineTo(topEnd + seal, topY);
-                ctx.moveTo(bottomStart - seal, bottomY);
-                ctx.lineTo(bottomStart + seal, bottomY);
-                ctx.moveTo(bottomEnd - seal, bottomY);
-                ctx.lineTo(bottomEnd + seal, bottomY);
-                // left vertical joints
-                ctx.moveTo(xLeft, leftTop - seal);
-                ctx.lineTo(xLeft, leftTop + seal);
-                ctx.moveTo(xLeft, leftMidTop - seal);
-                ctx.lineTo(xLeft, leftMidTop + seal);
-                ctx.moveTo(xLeft, leftMidBottom - seal);
-                ctx.lineTo(xLeft, leftMidBottom + seal);
-                ctx.moveTo(xLeft, leftBottom - seal);
-                ctx.lineTo(xLeft, leftBottom + seal);
-                // right vertical joints
-                ctx.moveTo(xRight, rightTop - seal);
-                ctx.lineTo(xRight, rightTop + seal);
-                ctx.moveTo(xRight, rightMidTop - seal);
-                ctx.lineTo(xRight, rightMidTop + seal);
-                ctx.moveTo(xRight, rightMidBottom - seal);
-                ctx.lineTo(xRight, rightMidBottom + seal);
-                ctx.moveTo(xRight, rightBottom - seal);
-                ctx.lineTo(xRight, rightBottom + seal);
-                ctx.stroke();
-                ctx.strokeStyle = 'red';
-                ctx.lineWidth = 2;
-                var rScale = (sX + sY) / 2;
-                this.pockets.forEach(function(pk) {
-                  ctx.beginPath();
-                  ctx.arc(pk.x * sX, pk.y * sY, pk.r * rScale, 0, Math.PI * 2);
-                  ctx.stroke();
-                });
               } else {
                 ctx.strokeRect(x0, y0, w, h);
               }
@@ -3677,44 +3615,6 @@
           ctx.closePath();
           if (fill) ctx.fill();
           ctx.stroke();
-          ctx.restore();
-        }
-
-        function drawVPocketGuide(p, dir, stroke = true) {
-          var R = p.r * ((sX + sY) / 2) * 1.2;
-          var x = p.x * sX - R * 0.5 * dir;
-          var y = p.y * sY;
-          var dx = R * 1.1 * dir;
-          var dy = R * 1.25;
-          // Remove trimming so lines meet the table boundary without gaps
-          var trim = 0;
-          if (stroke) ctx.beginPath();
-          ctx.moveTo(x - dx, y);
-          ctx.lineTo(x + dx, y - dy + trim);
-          ctx.moveTo(x - dx, y);
-          ctx.lineTo(x + dx, y + dy - trim);
-          if (stroke) ctx.stroke();
-        }
-
-        function drawUPocketGuide(p, sx, sy, stroke = true) {
-          var R = p.r * ((sX + sY) / 2);
-          var x = p.x * sX;
-          var y = p.y * sY;
-          ctx.save();
-          ctx.translate(x, y);
-          ctx.scale(sx, sy);
-          ctx.rotate(-Math.PI / 4);
-          if (stroke) ctx.beginPath();
-          ctx.moveTo(-R, 0);
-          ctx.arc(0, 0, R, Math.PI, 0);
-          // Extend legs to meet the boundary without gaps
-          var lineLen = R * 1.25;
-          var lineStart = 0;
-          ctx.moveTo(-R, lineStart);
-          ctx.lineTo(-R, lineLen);
-          ctx.moveTo(R, lineStart);
-          ctx.lineTo(R, lineLen);
-          if (stroke) ctx.stroke();
           ctx.restore();
         }
 


### PR DESCRIPTION
## Summary
- Extend Pool Royale table boundary lines to meet cleanly at right angles and remove orange connector markers
- Shift all pockets slightly toward the table center

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd7e7ef91c8329b00cbd6fa53a4669