### PR TITLE
Refine Pool Royale table layout

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -938,7 +938,7 @@
           isSnooker && playType === 'training' ? POCKET_R : 32; // side pockets also a touch larger
         // move pockets slightly closer to the center of the table
         var POCKET_SHORTEN = isSnooker ? 2 : 4; // gropat snooker pak me brenda
-        var POCKET_INSET = 3; // additional inward shift for all pockets
+        var POCKET_INSET = 5; // additional inward shift for all pockets
         var SHORT_DIST = BALL_R * 28;
         var MED_DIST = BALL_R * 56;
         var BORDER_TOP =
@@ -2431,11 +2431,9 @@
               ctx.lineWidth = 3;
               if (this.pockets) {
                 var p = this.pockets;
-                var lineW = ctx.lineWidth;
-                // Slightly extend the green boundary lines closer to the pockets
-                // Align boundary expansion exactly with pocket connectors
-                var cornerGap = lineW * 0.5;
-                var sideGap = lineW * 0.5;
+                // Extend the green boundary lines directly to the pockets
+                var cornerGap = 0;
+                var sideGap = 0;
                 ctx.beginPath();
                 // top boundary
                 var topY = y0;
@@ -2469,45 +2467,6 @@
                 ctx.lineTo(xRight, rightMidTop);
                 ctx.moveTo(xRight, rightMidBottom);
                 ctx.lineTo(xRight, rightBottom);
-                // pocket connectors integrated into the boundary
-                drawVPocketGuide(p[2], 1, false);
-                drawVPocketGuide(p[3], -1, false);
-                drawUPocketGuide(p[0], 1, 1, false);
-                drawUPocketGuide(p[1], -1, 1, false);
-                drawUPocketGuide(p[4], 1, -1, false);
-                drawUPocketGuide(p[5], -1, -1, false);
-                ctx.stroke();
-                ctx.strokeStyle = 'orange';
-                ctx.beginPath();
-                // further shorten orange pocket joint markers
-                var seal = lineW * 0.5;
-                // horizontal joints
-                ctx.moveTo(topStart - seal, topY);
-                ctx.lineTo(topStart + seal, topY);
-                ctx.moveTo(topEnd - seal, topY);
-                ctx.lineTo(topEnd + seal, topY);
-                ctx.moveTo(bottomStart - seal, bottomY);
-                ctx.lineTo(bottomStart + seal, bottomY);
-                ctx.moveTo(bottomEnd - seal, bottomY);
-                ctx.lineTo(bottomEnd + seal, bottomY);
-                // left vertical joints
-                ctx.moveTo(xLeft, leftTop - seal);
-                ctx.lineTo(xLeft, leftTop + seal);
-                ctx.moveTo(xLeft, leftMidTop - seal);
-                ctx.lineTo(xLeft, leftMidTop + seal);
-                ctx.moveTo(xLeft, leftMidBottom - seal);
-                ctx.lineTo(xLeft, leftMidBottom + seal);
-                ctx.moveTo(xLeft, leftBottom - seal);
-                ctx.lineTo(xLeft, leftBottom + seal);
-                // right vertical joints
-                ctx.moveTo(xRight, rightTop - seal);
-                ctx.lineTo(xRight, rightTop + seal);
-                ctx.moveTo(xRight, rightMidTop - seal);
-                ctx.lineTo(xRight, rightMidTop + seal);
-                ctx.moveTo(xRight, rightMidBottom - seal);
-                ctx.lineTo(xRight, rightMidBottom + seal);
-                ctx.moveTo(xRight, rightBottom - seal);
-                ctx.lineTo(xRight, rightBottom + seal);
                 ctx.stroke();
                 ctx.strokeStyle = 'red';
                 ctx.lineWidth = 2;
@@ -3677,44 +3636,6 @@
           ctx.closePath();
           if (fill) ctx.fill();
           ctx.stroke();
-          ctx.restore();
-        }
-
-        function drawVPocketGuide(p, dir, stroke = true) {
-          var R = p.r * ((sX + sY) / 2) * 1.2;
-          var x = p.x * sX - R * 0.5 * dir;
-          var y = p.y * sY;
-          var dx = R * 1.1 * dir;
-          var dy = R * 1.25;
-          // Remove trimming so lines meet the table boundary without gaps
-          var trim = 0;
-          if (stroke) ctx.beginPath();
-          ctx.moveTo(x - dx, y);
-          ctx.lineTo(x + dx, y - dy + trim);
-          ctx.moveTo(x - dx, y);
-          ctx.lineTo(x + dx, y + dy - trim);
-          if (stroke) ctx.stroke();
-        }
-
-        function drawUPocketGuide(p, sx, sy, stroke = true) {
-          var R = p.r * ((sX + sY) / 2);
-          var x = p.x * sX;
-          var y = p.y * sY;
-          ctx.save();
-          ctx.translate(x, y);
-          ctx.scale(sx, sy);
-          ctx.rotate(-Math.PI / 4);
-          if (stroke) ctx.beginPath();
-          ctx.moveTo(-R, 0);
-          ctx.arc(0, 0, R, Math.PI, 0);
-          // Extend legs to meet the boundary without gaps
-          var lineLen = R * 1.25;
-          var lineStart = 0;
-          ctx.moveTo(-R, lineStart);
-          ctx.lineTo(-R, lineLen);
-          ctx.moveTo(R, lineStart);
-          ctx.lineTo(R, lineLen);
-          if (stroke) ctx.stroke();
           ctx.restore();
         }
 


### PR DESCRIPTION
## Summary
- Extend green boundary lines to meet pockets directly and remove orange joint markers
- Slightly inset all six pockets toward the table center
- Drop unused pocket connector functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd82ee26a88329a3f90231094c5abf