### PR TITLE
Adjust pocket positions on Pool Royale table

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -938,7 +938,7 @@
           isSnooker && playType === 'training' ? POCKET_R : 32; // side pockets also a touch larger
         // move pockets slightly closer to the center of the table
         var POCKET_SHORTEN = isSnooker ? 2 : 4; // gropat snooker pak me brenda
-        var POCKET_INSET = 5; // additional inward shift for all pockets
+        var POCKET_INSET = GREEN_LINE + 5; // move pockets inward by one extra green line
         var SHORT_DIST = BALL_R * 28;
         var MED_DIST = BALL_R * 56;
         var BORDER_TOP =


### PR DESCRIPTION
## Summary
- nudge all Pool Royale pockets inward by one green-line thickness

## Testing
- `npm test`
- `npm run lint` *(fails: 964 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8b11ea2883298f92d8fc4f16173e