### PR TITLE
Hide debug markers in Pool Royale

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -2427,7 +2427,7 @@
             ctx.save();
               ctx.fillStyle = 'rgba(255,255,0,0.05)';
               ctx.fillRect(x0, y0, w, h);
-              ctx.strokeStyle = 'rgba(0,255,0,0.8)';
+              ctx.strokeStyle = 'rgba(0,255,0,0)';
               ctx.lineWidth = 3;
               if (this.pockets) {
                 var p = this.pockets;
@@ -2468,7 +2468,7 @@
                 ctx.moveTo(xRight, rightMidBottom);
                 ctx.lineTo(xRight, rightBottom);
                 ctx.stroke();
-                ctx.strokeStyle = 'red';
+                ctx.strokeStyle = 'rgba(255,0,0,0)';
                 ctx.lineWidth = 2;
                 var rScale = (sX + sY) / 2;
                 this.pockets.forEach(function(pk) {


### PR DESCRIPTION
## Summary
- hide green boundary lines on Pool Royale table by setting stroke style transparent
- hide red pocket guide circles with transparent stroke

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd906e85ac83298ff5f404a49c415c