### PR TITLE
Enlarge snooker table and pockets

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -926,16 +926,14 @@
         /* ==========================================================
        KONSTANTA TE LAYOUT-it DHE FIZIKES (sipas portrait)
        ========================================================= */
-        var TABLE_W = 768; // gjeresi logjike e felt-it
-        var TABLE_H = 1216; // lartesi logjike e felt-it
+        var TABLE_W = isSnooker ? 768 * 1.2 : 768; // gjeresi logjike e felt-it
+        var TABLE_H = isSnooker ? 1216 * 1.2 : 1216; // lartesi logjike e felt-it
         var BORDER = 57; // korniza e drurit pak me e ngushte anash
         var BALL_R = isSnooker && playType === 'training' ? 18 : 22; // snooker training uses smaller balls
         var GREEN_LINE = 16; // thickness of the green boundary lines
-        // Gropat pak me te vogla per t'u mbyllur me shume dhe jo per t'u zgjeruar
-        var POCKET_R =
-          isSnooker && playType === 'training' ? BALL_R * 0.68 : 34; // pockets slightly larger
-        var SIDE_POCKET_R =
-          isSnooker && playType === 'training' ? POCKET_R : 32; // side pockets also a touch larger
+        // Pockets twice the ball size for snooker
+        var POCKET_R = isSnooker ? BALL_R * 2 : 34; // pockets twice the ball radius
+        var SIDE_POCKET_R = isSnooker ? POCKET_R : 32; // side pockets also match size
         // move pockets slightly closer to the center of the table
         var POCKET_SHORTEN = isSnooker ? 2 : 4; // gropat snooker pak me brenda
         var POCKET_INSET = 5; // additional inward shift for all pockets

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -22,7 +22,7 @@ import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 // --------------------------------------------------
 // separate scales for table and balls
 const BALL_SCALE = 0.65; // keep balls same size
-const TABLE_SCALE = BALL_SCALE * 1.25; // table 25% larger
+const TABLE_SCALE = BALL_SCALE * 1.2; // table 20% larger
 const TABLE = {
   W: 66 * TABLE_SCALE,
   H: 132 * TABLE_SCALE,
@@ -32,7 +32,7 @@ const TABLE = {
 const BALL_R = 2 * BALL_SCALE;
 const FRICTION = 0.9925;
 const STOP_EPS = 0.02;
-const CAPTURE_R = 3.1 * TABLE_SCALE; // pocket capture radius aligned with Pool Royale
+const CAPTURE_R = BALL_R * 2; // pockets twice the ball radius
 
 // slightly brighter colors for table and balls
 const COLORS = Object.freeze({
@@ -181,7 +181,7 @@ function Guret(scene, id, color, x, y) {
 function Table3D(scene) {
   const halfW = TABLE.W / 2,
     halfH = TABLE.H / 2;
-  const POCKET_R_VIS = 3.6 * TABLE_SCALE; // slightly larger pocket visuals
+  const POCKET_R_VIS = BALL_R * 2; // pockets twice the size of the ball
   // Cloth me 6 vrima rrethore (holes)
   const shape = new THREE.Shape();
   shape.moveTo(-halfW, -halfH);
@@ -194,8 +194,8 @@ function Table3D(scene) {
     h.absellipse(
       p.x,
       p.y,
-      POCKET_R_VIS * 0.85,
-      POCKET_R_VIS * 0.85,
+      POCKET_R_VIS,
+      POCKET_R_VIS,
       0,
       Math.PI * 2,
       false,


### PR DESCRIPTION
## Summary
- Scale snooker table dimensions by 20% and resize pockets to twice the ball radius
- Widen web pocket capture logic and visuals for consistent ball sinking

## Testing
- `npm test`
- `npm run lint` *(warning: React version set to detect)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbc4321ac8329994fa85fd8ce286e