### PR TITLE
fix: correct snooker pocket positions and baulk D orientation

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -78,11 +78,11 @@ const fitRadius = (camera, margin = 1.1) => {
 // --------------------------------------------------
 const pocketCenters = () => [
   new THREE.Vector2(-TABLE.W / 2, -TABLE.H / 2),
-  new THREE.Vector2(0, -TABLE.H / 2),
   new THREE.Vector2(TABLE.W / 2, -TABLE.H / 2),
   new THREE.Vector2(-TABLE.W / 2, TABLE.H / 2),
-  new THREE.Vector2(0, TABLE.H / 2),
-  new THREE.Vector2(TABLE.W / 2, TABLE.H / 2)
+  new THREE.Vector2(TABLE.W / 2, TABLE.H / 2),
+  new THREE.Vector2(-TABLE.W / 2, 0),
+  new THREE.Vector2(TABLE.W / 2, 0)
 ];
 const allStopped = (balls) => balls.every((b) => b.vel.length() < STOP_EPS);
 function reflectRails(ball) {
@@ -276,7 +276,7 @@ function Table3D(scene) {
   for (let i = 0; i <= 64; i++) {
     const t = Math.PI * (i / 64);
     dPts.push(
-      new THREE.Vector3(Math.sin(t) * D_R, 0.01, baulkZ + Math.cos(t) * D_R)
+      new THREE.Vector3(Math.cos(t) * D_R, 0.01, baulkZ - Math.sin(t) * D_R)
     );
   }
   scene.add(


### PR DESCRIPTION
## Summary
- place middle pockets on side cushions instead of short rails
- draw baulk line D facing the bottom cushion

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: 964 errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd3710eec83299df836c9be8eeed6