### PR TITLE
Raise snooker table side rails

### DIFF
--- a/examples/snooker-table/index.html
+++ b/examples/snooker-table/index.html
@@ -97,11 +97,13 @@ const feltTopY=Dim.tableH-Dim.slateT+Dim.feltT/2;meshes.push(new Mesh(xform(box(
 
 // --------------------- Rails ---------------------
 {
+  // lift side rails and frames by half a ball height (~26 mm)
+  const railLift=0.026;
   const rx=Dim.playX/2+Dim.railW/2,rz=Dim.playZ/2+Dim.railW/2;
-  meshes.push(new Mesh(xform(box(Dim.playX+Dim.railW*1.25,Dim.railH,Dim.railW),M.trans(0,Dim.tableH-0.05,rz)),Col.wood));
-  meshes.push(new Mesh(xform(box(Dim.playX+Dim.railW*1.25,Dim.railH,Dim.railW),M.trans(0,Dim.tableH-0.05,-rz)),Col.wood));
-  meshes.push(new Mesh(xform(box(Dim.railW,Dim.railH,Dim.playZ+Dim.railW*1.25),M.trans(rx,Dim.tableH-0.05,0)),Col.wood));
-  meshes.push(new Mesh(xform(box(Dim.railW,Dim.railH,Dim.playZ+Dim.railW*1.25),M.trans(-rx,Dim.tableH-0.05,0)),Col.wood));
+  meshes.push(new Mesh(xform(box(Dim.playX+Dim.railW*1.25,Dim.railH,Dim.railW),M.trans(0,Dim.tableH-0.05+railLift,rz)),Col.wood));
+  meshes.push(new Mesh(xform(box(Dim.playX+Dim.railW*1.25,Dim.railH,Dim.railW),M.trans(0,Dim.tableH-0.05+railLift,-rz)),Col.wood));
+  meshes.push(new Mesh(xform(box(Dim.railW,Dim.railH,Dim.playZ+Dim.railW*1.25),M.trans(rx,Dim.tableH-0.05+railLift,0)),Col.wood));
+  meshes.push(new Mesh(xform(box(Dim.railW,Dim.railH,Dim.playZ+Dim.railW*1.25),M.trans(-rx,Dim.tableH-0.05+railLift,0)),Col.wood));
 }
 
 // --------------------- Cushions REMOVED per request ---------------------

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -41,6 +41,8 @@ const FRICTION = 0.9925;
 const STOP_EPS = 0.02;
 const CAPTURE_R = POCKET_R; // pocket capture radius
 const TABLE_Y = -2; // vertical offset to lower entire table
+// raise side rails and frames slightly (half a ball height)
+const RAIL_LIFT = BALL_R / 2;
 
 // slightly brighter colors for table and balls
 const COLORS = Object.freeze({
@@ -300,7 +302,7 @@ function Table3D(scene) {
   });
   const frame = new THREE.Mesh(frameGeo, railMat);
   frame.rotation.x = -Math.PI / 2;
-  frame.position.y = -TABLE.THICK;
+  frame.position.y = -TABLE.THICK + RAIL_LIFT;
   frame.castShadow = true;
   frame.receiveShadow = true;
   table.add(frame);
@@ -338,7 +340,7 @@ function Table3D(scene) {
     const cloth = new THREE.Mesh(clothGeo, cushionMat);
     cloth.position.y = railH * 0.5;
     group.add(cloth);
-    group.position.set(x, -TABLE.THICK, z);
+    group.position.set(x, -TABLE.THICK + RAIL_LIFT, z);
     if (!horizontal) group.rotation.y = Math.PI / 2;
     table.add(group);
   };


### PR DESCRIPTION
## Summary
- Lift side rails in WebGL snooker table example by half-ball height
- Raise rails and outer frame in Snooker game component using new `RAIL_LIFT` constant

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bebad0aab08329827032fd762076e7