### PR TITLE
Adjust snooker table rails and remove legs

### DIFF
--- a/examples/snooker-table/index.html
+++ b/examples/snooker-table/index.html
@@ -70,7 +70,7 @@ function hex(hex){return[(hex>>16&255)/255,(hex>>8&255)/255,(hex&255)/255];}
 class Mesh{constructor(geom,color){this.geom=geom;this.color=hex(color);this.v=vbo(geom.pos);this.n=vbo(geom.nrm);this.i=ibo(geom.idx);this.count=geom.idx.length;this.model=M.ident();}draw(){attr(this.v,0,3);attr(this.n,1,3);gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER,this.i);gl.uniformMatrix4fv(U.model,false,this.model);gl.uniform3fv(U.col,new Float32Array(this.color));gl.drawElements(gl.TRIANGLES,this.count,gl.UNSIGNED_SHORT,0);}}
 
 // --------------------- Dimensions & palette ---------------------
-const Dim={playX:3.569,playZ:1.778,slateT:0.06,feltT:0.016,railW:0.12,railH:0.10,cushionH:0.06,cushionD:0.06,baseH:0.22,legH:0.82,legR:0.13,tableH:0.90,pocketR:0.105,pocketDepth:0.12};
+const Dim={playX:3.569,playZ:1.778,slateT:0.06,feltT:0.016,railW:0.12,railH:0.12,cushionH:0.06,cushionD:0.06,baseH:0.22,legH:0.82,legR:0.13,tableH:0.90,pocketR:0.105,pocketDepth:0.12};
 const Col={wood:0x704523,slate:0x3a3a3a,felt:0x148245,cushion:0x1b6c3f,pocket:0x0c0e12,rim:0xb8c4d6,floor:0x121938,line:0xffffff};
 
 const meshes=[];
@@ -85,11 +85,8 @@ meshes.push(new Mesh(xform(box(20,0.02,20),M.trans(0,-0.01,0)),Col.floor));
   meshes.push(base);
 }
 
-// --------------------- Legs (tucked inside for visible overhang) ---------------------
-{
-  const offX=(Dim.playX/2+Dim.railW*0.35),offZ=(Dim.playZ/2+Dim.railW*0.35);const leg=cylinder(Dim.legR,Dim.legH,48);
-  [[-offX,-offZ],[offX,-offZ],[-offX,offZ],[offX,offZ]].forEach(([x,z])=>{meshes.push(new Mesh(xform(leg,M.trans(x,Dim.tableH-Dim.slateT-0.41,z)),Col.wood));});
-}
+// --------------------- Legs removed ---------------------
+// (Table rendered without supporting legs for integration atop external surface.)
 
 // --------------------- Slate & Felt ---------------------
 meshes.push(new Mesh(xform(box(Dim.playX,Dim.slateT,Dim.playZ),M.trans(0,Dim.tableH-Dim.slateT/2,0)),Col.slate));
@@ -97,13 +94,12 @@ const feltTopY=Dim.tableH-Dim.slateT+Dim.feltT/2;meshes.push(new Mesh(xform(box(
 
 // --------------------- Rails ---------------------
 {
-  // lift side rails and frames by half a ball height (~26 mm)
-  const railLift=0.026;
   const rx=Dim.playX/2+Dim.railW/2,rz=Dim.playZ/2+Dim.railW/2;
-  meshes.push(new Mesh(xform(box(Dim.playX+Dim.railW*1.25,Dim.railH,Dim.railW),M.trans(0,Dim.tableH-0.05+railLift,rz)),Col.wood));
-  meshes.push(new Mesh(xform(box(Dim.playX+Dim.railW*1.25,Dim.railH,Dim.railW),M.trans(0,Dim.tableH-0.05+railLift,-rz)),Col.wood));
-  meshes.push(new Mesh(xform(box(Dim.railW,Dim.railH,Dim.playZ+Dim.railW*1.25),M.trans(rx,Dim.tableH-0.05+railLift,0)),Col.wood));
-  meshes.push(new Mesh(xform(box(Dim.railW,Dim.railH,Dim.playZ+Dim.railW*1.25),M.trans(-rx,Dim.tableH-0.05+railLift,0)),Col.wood));
+  const y=Dim.tableH-Dim.slateT-0.02+Dim.railH/2;
+  meshes.push(new Mesh(xform(box(Dim.playX+Dim.railW*1.25,Dim.railH,Dim.railW),M.trans(0,y,rz)),Col.wood));
+  meshes.push(new Mesh(xform(box(Dim.playX+Dim.railW*1.25,Dim.railH,Dim.railW),M.trans(0,y,-rz)),Col.wood));
+  meshes.push(new Mesh(xform(box(Dim.railW,Dim.railH,Dim.playZ+Dim.railW*1.25),M.trans(rx,y,0)),Col.wood));
+  meshes.push(new Mesh(xform(box(Dim.railW,Dim.railH,Dim.playZ+Dim.railW*1.25),M.trans(-rx,y,0)),Col.wood));
 }
 
 // --------------------- Cushions REMOVED per request ---------------------


### PR DESCRIPTION
## Summary
- Raise side rails so their inner edges sit higher while the outer faces meet the base without gaps
- Remove standalone leg meshes to allow placement on external surfaces

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bec076cfb08329a7524c88ef589604