### PR TITLE
Adjust snooker table frame and leg proportions

### DIFF
--- a/examples/snooker-table/index.html
+++ b/examples/snooker-table/index.html
@@ -75,13 +75,13 @@ const Dim={
   playZ:1.778,
   slateT:0.06,
   feltT:0.016,
-  railW:0.06,
+  railW:0.03,
   railH:0.06,
   cushionH:0.06,
   cushionD:0.06,
   baseH:0.44,
   legH:0.82,
-  legR:0.39,
+  legR:0.675,
   tableH:0.90,
   pocketR:0.105,
   pocketDepth:0.12
@@ -157,7 +157,7 @@ const feltTopY=Dim.tableH-Dim.slateT+Dim.feltT/2;meshes.push(new Mesh(xform(box(
   const topX=Dim.playX*FactorTop, topZ=Dim.playZ*FactorTop;
   const baseX=Dim.playX+0.24, baseZ=Dim.playZ+0.24;
   meshes.push(new Mesh(xform(box(baseX,Dim.baseH,baseZ),M.trans(0,Dim.tableH-Dim.slateT-(Dim.baseH/2)-0.02,0)),Col.wood));
-  const margin=0.25;
+  const margin=0.30;
   const offX=baseX/2-(Dim.legR+margin), offZ=baseZ/2-(Dim.legR+margin);
   const leg=cylinder(Dim.legR,Dim.legH,48);
   [[-offX,-offZ],[offX,-offZ],[-offX,offZ],[offX,offZ]].forEach(([x,z])=>{


### PR DESCRIPTION
## Summary
- Slim the snooker table frame by halving rail width
- Thicken table legs and move them slightly toward the center

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bedf7e9ea48329940d018b79ab29be