### PR TITLE
Slim power slider and enlarge snooker table

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -22,9 +22,9 @@ import { SnookerRules } from '../../../../src/rules/SnookerRules.ts';
 // Config
 // --------------------------------------------------
 // separate scales for table and balls
-// Dimensions aligned with Pool Royale for consistent feel
+// Dimensions enlarged for a roomier snooker table
 const BALL_SCALE = 1;
-const TABLE_SCALE = 1.15;
+const TABLE_SCALE = 1.3;
 const TABLE = {
   W: 66 * TABLE_SCALE,
   H: 132 * TABLE_SCALE,
@@ -1191,7 +1191,7 @@ export default function NewSnookerGame() {
 
   return (
     <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
-      <div ref={mountRef} className="absolute inset-y-0 left-0 w-[75%]" />
+      <div ref={mountRef} className="absolute inset-y-0 left-0 w-[80%]" />
 
       {err && (
         <div className="absolute inset-0 bg-black/80 text-white text-xs flex items-center justify-center p-4 z-50">

--- a/webapp/src/pages/Games/SnookerPowerSlider.css
+++ b/webapp/src/pages/Games/SnookerPowerSlider.css
@@ -1,9 +1,9 @@
 /* Power Slider component styles */
 .ps {
-  /* resized to better match reference snooker slider */
-  --ps-width: 32px;
+  /* further slimmed slider for more table space */
+  --ps-width: 24px;
   --ps-height: 480px;
-  --ps-radius: 16px;
+  --ps-radius: 12px;
   --ps-track-bg: rgba(255, 255, 255, 0.15);
   --ps-gradient-low: #ffe066;
   --ps-gradient-mid: #ff8c00;
@@ -157,7 +157,7 @@
   margin-top: 12px;
   width: 100%;
   height: auto;
-  transform: translateX(6px);
+  transform: translateX(4px);
 }
 
 .ps .ps-tooltip {


### PR DESCRIPTION
## Summary
- Slim down snooker power slider and tweak cue alignment
- Enlarge snooker table scale and allocate more viewport width

## Testing
- `npm test`
- `npm run lint` *(fails: 964 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bef42f57b88329a844c146d8a30d26