### PR TITLE
Clip pool table side rails for accurate field view

### DIFF
--- a/webapp/public/pool-royale.html
+++ b/webapp/public/pool-royale.html
@@ -169,19 +169,18 @@
         flex: 1 1 auto;
         display: flex;
         overflow: hidden;
-        /* Ensure background image covers the available space without
-         overlapping top or bottom elements. Extend the width slightly
-         so the thin green boundary line is fully visible while keeping
-         extra clearance at the bottom. The brightness filter is applied
-         to a pseudo-element so the balls and other children remain
+        /* Ensure background image fits exactly within the wrap so the
+         wooden rails are clipped by the viewport, matching the expected
+         field appearance. The brightness filter is applied to a
+         pseudo-element so the balls and other children remain
          unaffected. */
-      } 
+      }
       #wrap::before {
         content: '';
         position: absolute;
         inset: 0;
         background: url('/assets/icons/64e79228-35e3-4fdc-b914-fca635a40220.webp')
-          top center/calc(100% + 8px) calc(100% + 20px) no-repeat;
+          top center/100% 100% no-repeat;
         filter: brightness(var(--table-brightness));
         z-index: -1;
       }


### PR DESCRIPTION
## Summary
- restrict pool table background sizing so side rails are trimmed to match expected playing field

## Testing
- `npm test`
- `npm run lint` *(fails: numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf01b1c3488329817373ed08578458