### PR TITLE
Raise snooker rail height

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -41,8 +41,8 @@ const FRICTION = 0.9925;
 const STOP_EPS = 0.02;
 const CAPTURE_R = POCKET_R; // pocket capture radius
 const TABLE_Y = -2; // vertical offset to lower entire table
-// raise side rails and frames slightly (half a ball height)
-const RAIL_LIFT = BALL_R / 2;
+// raise side rails and frames slightly (full ball height)
+const RAIL_LIFT = BALL_R;
 
 // slightly brighter colors for table and balls
 const COLORS = Object.freeze({
@@ -278,6 +278,7 @@ function Table3D(scene) {
   });
   const railH = TABLE.THICK;
   const railW = TABLE.WALL;
+  const railY = -TABLE.THICK + RAIL_LIFT;
   // Outer wooden frame around rails at same height
   // Make the side frame thicker so it lines up with the base
   const FRAME_W = railW * 2.5; // wider wooden frame
@@ -302,7 +303,7 @@ function Table3D(scene) {
   });
   const frame = new THREE.Mesh(frameGeo, railMat);
   frame.rotation.x = -Math.PI / 2;
-  frame.position.y = -TABLE.THICK + RAIL_LIFT;
+  frame.position.y = railY;
   frame.castShadow = true;
   frame.receiveShadow = true;
   table.add(frame);
@@ -340,7 +341,7 @@ function Table3D(scene) {
     const cloth = new THREE.Mesh(clothGeo, cushionMat);
     cloth.position.y = railH * 0.5;
     group.add(cloth);
-    group.position.set(x, -TABLE.THICK + RAIL_LIFT, z);
+    group.position.set(x, railY, z);
     if (!horizontal) group.rotation.y = Math.PI / 2;
     table.add(group);
   };


### PR DESCRIPTION
## Summary
- Increase snooker `RAIL_LIFT` to a full ball height for better clearance
- Centralize rail vertical offset via `railY` and apply to frame and rails

## Testing
- `npm --prefix webapp run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf0fc51bac83299e6b0f15d49b482b