### PR TITLE
Increase snooker table leg thickness

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -365,11 +365,11 @@ function Table3D(scene) {
 
   // Legs supporting the table (cylindrical, tucked under base)
   const legH = baseH * 4;
-  const legR = TABLE.WALL * 0.8;
+  const legR = TABLE.WALL * 2.4;
   const legGeo = new THREE.CylinderGeometry(legR, legR, legH, 24);
   const legY = -TABLE.THICK - baseH - legH / 2;
-  const legOffsetX = baseW / 2 - legR * 1.2;
-  const legOffsetZ = baseD / 2 - legR * 1.2;
+  const legOffsetX = baseW / 2 - legR - TABLE.WALL * 0.16;
+  const legOffsetZ = baseD / 2 - legR - TABLE.WALL * 0.16;
   [
     [-legOffsetX, -legOffsetZ],
     [legOffsetX, -legOffsetZ],


### PR DESCRIPTION
## Summary
- triple snooker table leg radius and adjust offsets so thicker legs stay aligned with the base

## Testing
- `npm --prefix webapp run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf0fc3f5648329a6862911f951a9b6