### PR TITLE
feat(snooker): add arena walls and slider tweaks

### DIFF
--- a/webapp/src/pages/Games/SnookerPowerSlider.css
+++ b/webapp/src/pages/Games/SnookerPowerSlider.css
@@ -17,8 +17,8 @@
   width: var(--ps-width);
   height: var(--ps-height);
   border-radius: var(--ps-radius);
-  background: var(--ps-track-bg);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  background: transparent;
+  box-shadow: none;
   overflow: visible;
   user-select: none;
   touch-action: none;


### PR DESCRIPTION
## Summary
- Surround snooker table with arena walls and scrolling ad boards, plus room lighting and shadows
- Remove black background from pull power slider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf1dddb8408329baa683deaf47cddd