### PR TITLE
Enlarge snooker table legs

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -364,8 +364,9 @@ function Table3D(scene) {
   table.add(base);
 
   // Legs supporting the table (cylindrical, tucked under base)
-  const legH = baseH * 4;
-  const legR = (TABLE.WALL * 0.8) / 4; // legs four times thinner
+  const LEG_SCALE = 10;
+  const legH = baseH * 4 * LEG_SCALE;
+  const legR = ((TABLE.WALL * 0.8) / 4) * LEG_SCALE; // legs enlarged 10×
   const legGeo = new THREE.CylinderGeometry(legR, legR, legH, 24);
   const legY = -TABLE.THICK - baseH - legH / 2;
   const legOffsetX = baseW / 2 - legR * 1.2;


### PR DESCRIPTION
## Summary
- Scale snooker table legs to 10× their original size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf2de9f2ec832989453cf59f0726fa