### PR TITLE
feat: add aim calibration with persistence

### DIFF
--- a/webapp/src/hooks/useAimCalibration.js
+++ b/webapp/src/hooks/useAimCalibration.js
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const KEY = 'snooker-aim-calibration';
+
+function load() {
+  try {
+    return JSON.parse(localStorage.getItem(KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function save(cfg) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(cfg));
+  } catch {}
+}
+
+export function useAimCalibration() {
+  const [cfg, setCfg] = useState(() => ({
+    invertX: false,
+    invertY: false,
+    swap: false,
+    ...load()
+  }));
+
+  useEffect(() => {
+    save(cfg);
+  }, [cfg]);
+
+  const mapDelta = useCallback(
+    (dx, dy) => {
+      let x = cfg.swap ? dy : dx;
+      let y = cfg.swap ? dx : dy;
+      if (cfg.invertX) x = -x;
+      if (cfg.invertY) y = -y;
+      return { dx: x, dy: y };
+    },
+    [cfg]
+  );
+
+  return { cfg, setCfg, mapDelta };
+}


### PR DESCRIPTION
## Summary
- add hook for mapping pointer deltas with invert and swap options persisted in localStorage
- integrate aim calibration into Snooker game and expose simple UI toggles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf3512301c8329a4501059f5bac284