### PR TITLE
Adjust snooker table visuals and controls

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -42,8 +42,8 @@ const FRICTION = 0.9925;
 const STOP_EPS = 0.02;
 const CAPTURE_R = POCKET_R; // pocket capture radius
 const TABLE_Y = -2; // vertical offset to lower entire table
-// raise side rails and frames slightly (half a ball height)
-const RAIL_LIFT = BALL_R / 2;
+// raise side rails and frames slightly higher than before
+const RAIL_LIFT = BALL_R * 0.6;
 
 // slightly brighter colors for table and balls
 const COLORS = Object.freeze({
@@ -366,7 +366,7 @@ function Table3D(scene) {
 
   // Legs supporting the table (cylindrical, tucked under base)
   const legH = baseH * 4;
-  const legR = (TABLE.WALL * 0.8) / 4; // legs four times thinner
+  const legR = ((TABLE.WALL * 0.8) / 4) * 8; // legs eight times wider
   const legGeo = new THREE.CylinderGeometry(legR, legR, legH, 24);
   const legY = -TABLE.THICK - baseH - legH / 2;
   const legOffsetX = baseW / 2 - legR * 1.2;
@@ -424,8 +424,8 @@ function Table3D(scene) {
     const ad = new THREE.Mesh(new THREE.PlaneGeometry(w, wallH / 2), adMat);
     ad.position.y = -wallH / 4;
     g.add(top, ad);
-    // drop walls below the floor level
-    g.position.y = floor.position.y - wallH / 2;
+    // place walls on top of the floor so they are visible
+    g.position.y = floor.position.y + wallH / 2;
     return g;
   };
 

--- a/webapp/src/pages/Games/SnookerPowerSlider.css
+++ b/webapp/src/pages/Games/SnookerPowerSlider.css
@@ -1,7 +1,7 @@
 /* Power Slider component styles */
 .ps {
   /* further slimmed slider for more table space */
-  --ps-width: 24px;
+  --ps-width: 20px;
   --ps-height: 480px;
   --ps-radius: 12px;
   --ps-track-bg: rgba(255, 255, 255, 0.15);
@@ -147,14 +147,17 @@
 }
 
 .ps .ps-handle-text {
+  position: absolute;
+  top: -20px;
+  left: 50%;
+  transform: translateX(-50%);
   font-size: 14px;
   color: #fff;
   line-height: 1;
-  transform: translate(-1px, 0px);
 }
 
 .ps .ps-cue-img {
-  margin-top: 12px;
+  margin-top: 0;
   width: 100%;
   height: auto;
   transform: translateX(4px);


### PR DESCRIPTION
## Summary
- widen snooker table legs and slightly raise rails/cushions
- position arena walls above the floor for visibility
- slim power slider and move "Pull" label above the handle

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon ... )*

------
https://chatgpt.com/codex/tasks/task_e_68bf374f67bc8329988ba4118097f04c