### PR TITLE
feat: refine snooker visuals

### DIFF
--- a/webapp/src/pages/Games/SnookerPowerSlider.css
+++ b/webapp/src/pages/Games/SnookerPowerSlider.css
@@ -98,7 +98,7 @@
 
 .ps .ps-power-bar {
   position: absolute;
-  border: 1px solid #000;
+  border: none;
   box-sizing: border-box;
   overflow: hidden;
   pointer-events: none;
@@ -150,7 +150,7 @@
   position: absolute;
   top: -20px;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translateX(-45%);
   font-size: 14px;
   color: #fff;
   line-height: 1;


### PR DESCRIPTION
## Summary
- replace snooker aiming line with pool-style guide and cue overlay
- remove power slider border and nudge pull label right
- drop arena billboards and keep only two walls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfabc0b87083298ab738bb175ced40