### PR TITLE
Refine snooker table visuals and camera behavior

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -150,7 +150,7 @@
   font-size: 14px;
   color: #fff;
   line-height: 1;
-  transform: translate(-1px, 0px);
+  transform: translate(-4px, 0px); /* shift label left over power bar */
 }
 
 .ps .ps-cue-img {

--- a/power-slider.js
+++ b/power-slider.js
@@ -184,13 +184,14 @@ export class PowerSlider {
     if (!this.powerBar) return;
     const uWidth = this._measureCharWidth('u');
     const pWidth = this._measureCharWidth('P');
-    this.powerBar.style.width = `${uWidth}px`;
+    const barW = uWidth * 0.7;
+    this.powerBar.style.width = `${barW}px`;
     const textRect = this.handleText.getBoundingClientRect();
     const imgRect = this.cueImg.getBoundingClientRect();
     const elRect = this.el.getBoundingClientRect();
-    const left = textRect.left - elRect.left + pWidth;
+    const left = textRect.left - elRect.left + pWidth - barW / 2;
     const top = textRect.bottom - elRect.top;
-    const height = imgRect.bottom - textRect.bottom;
+    const height = (imgRect.bottom - textRect.bottom) * 0.8;
     this.powerBar.style.left = `${left}px`;
     this.powerBar.style.top = `${top}px`;
     this.powerBar.style.height = `${height}px`;

--- a/src/core/Referee.ts
+++ b/src/core/Referee.ts
@@ -25,9 +25,7 @@ export class Referee {
     const values = this.rules.getBallValues();
 
     if (!this.rules.isBallOn(newState, first)) {
-      const valOn = Math.max(...newState.ballOn.map((c: BallColor) => values[c]));
-      const valFirst = first ? values[first] : 0;
-      const pts = Math.max(4, valOn, valFirst);
+      const pts = this.rules.getFoulValue(newState.ballOn, first);
       return this.awardFoul(newState, pts, 'wrong ball first');
     }
 
@@ -45,9 +43,7 @@ export class Referee {
           continue;
         }
         if (!newState.ballOn.includes(ev.ball)) {
-          const valOn = Math.max(...newState.ballOn.map((c: BallColor) => values[c]));
-          const valPot = values[ev.ball];
-          const pts = Math.max(4, valOn, valPot);
+          const pts = this.rules.getFoulValue(newState.ballOn, ev.ball);
           return this.awardFoul(newState, pts, 'wrong ball potted');
         }
         scored += values[ev.ball];

--- a/src/rules/SnookerRules.ts
+++ b/src/rules/SnookerRules.ts
@@ -64,4 +64,11 @@ export class SnookerRules {
     }
     return [];
   }
+
+  getFoulValue(ballOn: BallColor[], offending: BallColor | null): number {
+    const values = this.getBallValues();
+    const valOn = Math.max(...ballOn.map((c) => values[c]));
+    const valOff = offending ? values[offending] : 0;
+    return Math.max(4, valOn, valOff);
+  }
 }

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -277,7 +277,7 @@ function Table3D(scene) {
     metalness: 0.2,
     roughness: 0.9
   });
-  const railH = TABLE.THICK * 1.5; // raise rails and cushions a bit
+  const railH = TABLE.THICK * 1.6; // slightly taller rails
   const railW = TABLE.WALL * 0.5; // thinner side rails
   // Outer wooden frame around rails at same height
   // Make the side frame thicker so it lines up with the base
@@ -331,18 +331,11 @@ function Table3D(scene) {
   };
   const addRail = (x, z, len, horizontal) => {
     const group = new THREE.Group();
-    const wood = new THREE.Mesh(railGeometry(len), railMat);
-    wood.castShadow = true;
-    wood.receiveShadow = true;
-    wood.rotation.x = -Math.PI / 2; // lay wood horizontally
-    group.add(wood);
-    const clothGeo = railGeometry(len);
-    clothGeo.scale(1, 0.7, 0.7); // beefier cushion
-    const cloth = new THREE.Mesh(clothGeo, cushionMat);
-    cloth.rotation.x = -Math.PI / 2; // green faces play field
-    const clothOffset = TABLE.THICK - railH * 0.7;
-    cloth.position.y = clothOffset;
-    group.add(cloth);
+    const rail = new THREE.Mesh(railGeometry(len), cushionMat);
+    rail.castShadow = true;
+    rail.receiveShadow = true;
+    rail.rotation.x = -Math.PI / 2; // lay cushion horizontally
+    group.add(rail);
     group.position.set(x, -TABLE.THICK, z);
     if (!horizontal) group.rotation.y = Math.PI / 2;
     table.add(group);
@@ -644,6 +637,7 @@ export default function NewSnookerGame() {
       // Scene & Camera
       const scene = new THREE.Scene();
       scene.background = new THREE.Color(0x050505);
+      let cue;
       const camera = new THREE.PerspectiveCamera(
         CAMERA.fov,
         host.clientWidth / host.clientHeight,
@@ -652,13 +646,14 @@ export default function NewSnookerGame() {
       );
       // Start behind baulk colours
       const sph = new THREE.Spherical(
-        180 * TABLE_SCALE,
+        160 * TABLE_SCALE,
         1.0 /*phi ~57°*/,
         Math.PI
       );
+      const target = new THREE.Vector3();
       const fit = (m = 1.1) => {
         camera.aspect = host.clientWidth / host.clientHeight;
-        sph.radius = fitRadius(camera, m);
+        sph.radius = fitRadius(camera, m) * 0.9;
         const phiCap = Math.acos(
           THREE.MathUtils.clamp(-0.95 / sph.radius, -1, 1)
         );
@@ -667,9 +662,10 @@ export default function NewSnookerGame() {
           CAMERA.minPhi,
           Math.min(phiCap, Math.PI - CAMERA.phiMargin)
         );
-        const target = new THREE.Vector3(0, TABLE_Y, 0);
+        if (cue) target.set(cue.pos.x, BALL_R, cue.pos.y);
+        else target.set(0, TABLE_Y, 0);
         if (topViewRef.current) {
-          camera.position.set(0, sph.radius, 0);
+          camera.position.set(target.x, sph.radius, target.z);
           camera.lookAt(target);
         } else {
           camera.position.setFromSpherical(sph).add(target);
@@ -816,7 +812,8 @@ export default function NewSnookerGame() {
         balls.push(b);
         return b;
       };
-      let cue = add('cue', COLORS.cue, -BALL_R * 2, baulkZ);
+      cue = add('cue', COLORS.cue, -BALL_R * 2, baulkZ);
+      fit();
       // reds triangle toward top side
       let rid = 0;
       const bz = PLAY_H * 0.25,
@@ -959,7 +956,7 @@ export default function NewSnookerGame() {
         last.y = e.clientY || e.touches?.[0]?.clientY || 0;
         virt.x = last.x;
         virt.y = last.y;
-        onAimMove(e);
+        if (!hitBall) onAimMove(e); // avoid override when snapping to a ball
       };
       const onAimEnd = () => {
         aiming = false;
@@ -1124,6 +1121,11 @@ export default function NewSnookerGame() {
 
       // Loop
       const step = () => {
+        if (cue) {
+          target.set(cue.pos.x, BALL_R, cue.pos.y);
+          camera.position.setFromSpherical(sph).add(target);
+          camera.lookAt(target);
+        }
         // Aiming vizual
         if (allStopped(balls) && !hud.inHand && cue?.active && !hud.over) {
           const { impact, afterDir, targetBall, railNormal } = calcTarget(


### PR DESCRIPTION
## Summary
- raise cushion height and render rails fully green for a darker table edge
- shift power slider label and shrink its bar for clearer aiming control
- track cue ball with a closer default camera and fix aim snapping
- centralize snooker foul scoring rules in `SnookerRules` and use in `Referee`

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc56434008329a9f6771be0bd0d6e