### PR TITLE
feat(snooker): calibrate aim to camera orientation

### DIFF
--- a/webapp/src/hooks/useAimCalibration.js
+++ b/webapp/src/hooks/useAimCalibration.js
@@ -1,40 +1,55 @@
 import { useCallback, useEffect, useState } from 'react';
+import * as THREE from 'three';
 
-const KEY = 'snooker-aim-calibration';
+const PREFIX = 'snooker.calib.';
 
-function load() {
+function loadFlag(key, def) {
   try {
-    return JSON.parse(localStorage.getItem(KEY) || '{}');
+    const v = localStorage.getItem(PREFIX + key);
+    return v === null ? def : JSON.parse(v);
   } catch {
-    return {};
+    return def;
   }
 }
 
-function save(cfg) {
+function saveFlag(key, value) {
   try {
-    localStorage.setItem(KEY, JSON.stringify(cfg));
+    localStorage.setItem(PREFIX + key, JSON.stringify(value));
   } catch {}
 }
 
 export function useAimCalibration() {
   const [cfg, setCfg] = useState(() => ({
-    invertX: false,
-    invertY: false,
-    swap: false,
-    ...load()
+    invertX: loadFlag('invertX', false),
+    invertY: loadFlag('invertY', false),
+    swap: loadFlag('swap', false),
+    sens: loadFlag('sens', 1)
   }));
 
   useEffect(() => {
-    save(cfg);
+    saveFlag('invertX', cfg.invertX);
+    saveFlag('invertY', cfg.invertY);
+    saveFlag('swap', cfg.swap);
+    saveFlag('sens', cfg.sens);
   }, [cfg]);
 
   const mapDelta = useCallback(
-    (dx, dy) => {
+    (dx, dy, camera) => {
       let x = cfg.swap ? dy : dx;
       let y = cfg.swap ? dx : dy;
       if (cfg.invertX) x = -x;
       if (cfg.invertY) y = -y;
-      return { dx: x, dy: y };
+      x *= cfg.sens;
+      y *= cfg.sens;
+      if (!camera) return new THREE.Vector2(x, y);
+      const right = new THREE.Vector3(1, 0, 0).applyQuaternion(camera.quaternion);
+      const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(camera.quaternion);
+      right.y = 0;
+      forward.y = 0;
+      if (right.lengthSq()) right.normalize();
+      if (forward.lengthSq()) forward.normalize();
+      const delta = right.multiplyScalar(x).add(forward.multiplyScalar(-y));
+      return new THREE.Vector2(delta.x, delta.z);
     },
     [cfg]
   );

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -922,7 +922,7 @@ export default function NewSnookerGame() {
       const aimDir = aimDirRef.current;
       let aiming = false;
       const last = { x: 0, y: 0 };
-      const virt = { x: 0, y: 0 };
+      const virt = new THREE.Vector2();
       const onAimMove = (e) => {
         if (!aiming) return;
         if (hud.inHand || hud.over) return;
@@ -933,11 +933,9 @@ export default function NewSnookerGame() {
         const dy = y - last.y;
         last.x = x;
         last.y = y;
-        const mapped = mapDelta(dx, dy);
-        virt.x += mapped.dx;
-        virt.y += mapped.dy;
-        const hit = project({ clientX: virt.x, clientY: virt.y });
-        const dir = cue.pos.clone().sub(hit);
+        const mapped = mapDelta(dx, dy, camera);
+        virt.add(mapped);
+        const dir = cue.pos.clone().sub(virt);
         if (dir.length() > 1e-3) {
           aimDir.set(dir.x, dir.y).normalize();
         }
@@ -957,8 +955,7 @@ export default function NewSnookerGame() {
         aiming = true;
         last.x = e.clientX || e.touches?.[0]?.clientX || 0;
         last.y = e.clientY || e.touches?.[0]?.clientY || 0;
-        virt.x = last.x;
-        virt.y = last.y;
+        virt.copy(p);
         onAimMove(e);
       };
       const onAimEnd = () => {


### PR DESCRIPTION
## Summary
- map touch deltas to world-space aim using camera forward/right vectors with invert, swap and sensitivity flags
- persist calibration options separately in localStorage and apply them when aiming in Snooker game

## Testing
- `npm test`
- `npm run lint` *(fails: numerous existing style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd6a26f808329a01b564a14ff4d96