### PR TITLE
feat(snooker): add dedicated power slider and pocket detailing

### DIFF
--- a/snooker-power-slider.css
+++ b/snooker-power-slider.css
@@ -1,0 +1,236 @@
+/* Snooker-specific Power Slider component styles */
+.sps {
+  /* make snooker slider shorter and thinner */
+  --sps-width: 36px;
+  --sps-height: 420px;
+  --sps-radius: 18px;
+  --sps-track-bg: rgba(255, 255, 255, 0.15);
+  --sps-gradient-low: #ffe066;
+  --sps-gradient-mid: #ff8c00;
+  --sps-gradient-high: #ff0033;
+  --sps-tick: rgba(0, 0, 0, 0.35);
+  --sps-glow: rgba(255, 0, 0, 0.6);
+  --sps-tooltip-bg: rgba(0, 0, 0, 0.8);
+  --sps-tooltip-color: #fff;
+
+  position: relative;
+  width: var(--sps-width);
+  height: var(--sps-height);
+  border-radius: var(--sps-radius);
+  background: var(--sps-track-bg);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  overflow: visible;
+  user-select: none;
+  touch-action: none;
+  /* removed extra scale so dimensions match pool game */
+  transform: scale(1);
+  transform-origin: top left;
+}
+
+.sps .sps-track {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    to bottom,
+    var(--sps-gradient-low) 0%,
+    var(--sps-gradient-mid) 50%,
+    var(--sps-gradient-high) 100%
+  );
+}
+
+/* left gloss */
+.sps .sps-track::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 8px;
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.5),
+    rgba(255, 255, 255, 0)
+  );
+  pointer-events: none;
+}
+
+/* ticks */
+.sps .sps-track::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 8px;
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0 calc(10% - 1px),
+      var(--sps-tick) calc(10% - 1px) 10%
+    ),
+    linear-gradient(
+      to bottom,
+      transparent calc(25% - 1.5px),
+      var(--sps-tick) calc(25% - 1.5px) calc(25% + 1.5px),
+      transparent calc(25% + 1.5px)
+    ),
+    linear-gradient(
+      to bottom,
+      transparent calc(50% - 1.5px),
+      var(--sps-tick) calc(50% - 1.5px) calc(50% + 1.5px),
+      transparent calc(50% + 1.5px)
+    ),
+    linear-gradient(
+      to bottom,
+      transparent calc(75% - 1.5px),
+      var(--sps-tick) calc(75% - 1.5px) calc(75% + 1.5px),
+      transparent calc(75% + 1.5px)
+    ),
+    linear-gradient(
+      to bottom,
+      transparent calc(100% - 3px),
+      var(--sps-tick) calc(100% - 3px) 100%
+    ),
+    linear-gradient(to bottom, var(--sps-tick) 0 3px, transparent 3px);
+  pointer-events: none;
+}
+
+.sps .sps-power-bar {
+  position: absolute;
+  border: 1px solid #000;
+  box-sizing: border-box;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.sps .sps-power-bar-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  clip-path: inset(0 0 100% 0);
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0 calc(10% - 1px),
+      #000 calc(10% - 1px) 10%
+    ),
+    linear-gradient(
+      to bottom,
+      var(--sps-gradient-low) 0%,
+      var(--sps-gradient-high) 100%
+    );
+  pointer-events: none;
+}
+
+.sps .sps-handle {
+  position: absolute;
+  top: 0;
+  left: 100%;
+  transform: translate(0, 0);
+  transition: transform 0.15s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: calc(var(--sps-width) * 0.8657);
+  border-radius: 6px;
+  background: linear-gradient(
+    to bottom,
+    var(--sps-gradient-low),
+    var(--sps-gradient-high)
+  );
+  padding: 7.2px 2.4px;
+  pointer-events: auto;
+  z-index: 1;
+}
+
+.sps .sps-handle-text {
+  font-size: 14px;
+  color: #fff;
+  line-height: 1;
+  transform: translate(-1px, 0px);
+}
+
+.sps .sps-cue-img {
+  margin-top: 12px;
+  width: 100%;
+  height: auto;
+  transform: translateX(9.6px);
+}
+
+.sps .sps-tooltip {
+  position: absolute;
+  top: 0;
+  left: 100%;
+  transform: translate(0, 0);
+  background: var(--sps-tooltip-bg);
+  color: var(--sps-tooltip-color);
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+  transform-origin: 50% 100%;
+  transition:
+    transform 0.15s ease,
+    opacity 0.15s ease;
+  pointer-events: none;
+}
+
+.sps.sps-hot {
+  box-shadow:
+    0 0 12px var(--sps-glow),
+    0 4px 12px rgba(0, 0, 0, 0.25);
+}
+
+.sps.sps-no-animate .sps-handle,
+.sps.sps-no-animate .sps-tooltip {
+  transition: none !important;
+}
+
+.sps.sps-locked {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.sps .sps-label {
+  position: absolute;
+  right: 100%;
+  margin-right: calc(var(--sps-width) * 0.0746);
+  font-size: 12px;
+  color: var(--sps-tooltip-color);
+  user-select: none;
+}
+
+.sps .sps-label-0 {
+  bottom: 0;
+  transform: translateY(50%);
+}
+.sps .sps-label-50 {
+  top: 50%;
+  transform: translateY(-50%);
+}
+.sps .sps-label-100 {
+  top: 0;
+  transform: translateY(-50%);
+}
+
+.sps:focus-visible {
+  outline: 2px solid var(--sps-tooltip-color);
+  outline-offset: 2px;
+}
+
+.sps.sps-theme-dark {
+  --sps-track-bg: rgba(0, 0, 0, 0.5);
+  --sps-tick: rgba(255, 255, 255, 0.4);
+  --sps-tooltip-bg: rgba(255, 255, 255, 0.9);
+  --sps-tooltip-color: #000;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sps .sps-handle,
+  .sps .sps-tooltip {
+    transition: none !important;
+  }
+}

--- a/snooker-power-slider.js
+++ b/snooker-power-slider.js
@@ -1,0 +1,270 @@
+// Dedicated power slider for Snooker game (shorter & thinner)
+export class SnookerPowerSlider {
+  constructor(opts = {}) {
+    const {
+      mount,
+      value = 0,
+      min = 0,
+      max = 100,
+      step = 1,
+      cueSrc = '',
+      onChange,
+      onCommit,
+      theme = 'default',
+      labels = false
+    } = opts;
+
+    if (!mount) throw new Error('mount required');
+
+    this.min = min;
+    this.max = max;
+    this.step = step;
+    this.onChange = onChange;
+    this.onCommit = onCommit;
+    this.locked = false;
+
+    this.el = document.createElement('div');
+    this.el.className = `sps sps-theme-${theme}`;
+    this.el.tabIndex = 0;
+    this.el.setAttribute('role', 'slider');
+    this.el.setAttribute('aria-orientation', 'vertical');
+    this.el.setAttribute('aria-valuemin', String(this.min));
+    this.el.setAttribute('aria-valuemax', String(this.max));
+
+    this.track = document.createElement('div');
+    this.track.className = 'sps-track';
+    this.el.appendChild(this.track);
+
+    this.powerBar = document.createElement('div');
+    this.powerBar.className = 'sps-power-bar';
+    this.powerFill = document.createElement('div');
+    this.powerFill.className = 'sps-power-bar-fill';
+    this.powerBar.appendChild(this.powerFill);
+    this.el.appendChild(this.powerBar);
+
+    this.handle = document.createElement('div');
+    this.handle.className = 'sps-handle';
+    this.handleText = document.createElement('span');
+    this.handleText.className = 'sps-handle-text';
+    this.handleText.textContent = 'Pull';
+    this.handle.append(this.handleText);
+
+    this.cueImg = document.createElement('img');
+    this.cueImg.className = 'sps-cue-img';
+    this.cueImg.alt = '';
+    if (cueSrc) this.cueImg.src = cueSrc;
+    this.handle.append(this.cueImg);
+
+    this.el.appendChild(this.handle);
+
+    this.tooltip = document.createElement('div');
+    this.tooltip.className = 'sps-tooltip';
+    this.el.appendChild(this.tooltip);
+
+    if (labels) {
+      const wrap = document.createElement('div');
+      const l0 = document.createElement('span');
+      l0.className = 'sps-label sps-label-0';
+      l0.textContent = '0';
+      const l50 = document.createElement('span');
+      l50.className = 'sps-label sps-label-50';
+      l50.textContent = '50';
+      const l100 = document.createElement('span');
+      l100.className = 'sps-label sps-label-100';
+      l100.textContent = '100';
+      wrap.append(l0, l50, l100);
+      this.el.appendChild(wrap);
+    }
+
+    mount.appendChild(this.el);
+
+    this._onPointerDown = this._pointerDown.bind(this);
+    this._onPointerMove = this._pointerMove.bind(this);
+    this._onPointerUp = this._pointerUp.bind(this);
+    this._onWheel = this._wheel.bind(this);
+    this._onKeyDown = this._keyDown.bind(this);
+    this._onResize = () => {
+      this._setupPowerBar();
+      this._update(false);
+    };
+
+    this.el.addEventListener('pointerdown', this._onPointerDown);
+    this.el.addEventListener('wheel', this._onWheel, { passive: false });
+    this.el.addEventListener('keydown', this._onKeyDown);
+    window.addEventListener('resize', this._onResize);
+
+    this.cueImg.addEventListener('load', () => {
+      this._setupPowerBar();
+      this._update(false);
+    });
+
+    this._setupPowerBar();
+
+    this.set(value);
+  }
+
+  get() {
+    return this.value;
+  }
+
+  set(v, { animate = false } = {}) {
+    const value = this._clamp(this._step(v));
+    this.value = value;
+    if (!animate) this.el.classList.add('sps-no-animate');
+    else this.el.classList.remove('sps-no-animate');
+    this._update(animate);
+    if (!animate)
+      requestAnimationFrame(() => this.el.classList.remove('sps-no-animate'));
+    if (typeof this.onChange === 'function') this.onChange(value);
+  }
+
+  lock() {
+    this.locked = true;
+    this.el.classList.add('sps-locked');
+    this.el.tabIndex = -1;
+    this.el.setAttribute('aria-disabled', 'true');
+  }
+
+  unlock() {
+    this.locked = false;
+    this.el.classList.remove('sps-locked');
+    this.el.tabIndex = 0;
+    this.el.setAttribute('aria-disabled', 'false');
+  }
+
+  destroy() {
+    this.el.removeEventListener('pointerdown', this._onPointerDown);
+    this.el.removeEventListener('wheel', this._onWheel);
+    this.el.removeEventListener('keydown', this._onKeyDown);
+    window.removeEventListener('resize', this._onResize);
+    this.el.remove();
+  }
+
+  /* internal methods */
+  _clamp(v) {
+    return Math.min(this.max, Math.max(this.min, v));
+  }
+
+  _step(v) {
+    const s = this.step;
+    return Math.round((v - this.min) / s) * s + this.min;
+  }
+
+  _update(animate = true) {
+    const range = this.max - this.min || 1;
+    const ratio = (this.value - this.min) / range;
+    const trackH = this.el.clientHeight;
+    const handleH = this.handle.offsetHeight;
+    const y = ratio * (trackH - handleH);
+    this.handle.style.transform = `translate(0, ${y}px)`;
+    const ttH = this.tooltip.offsetHeight;
+    this.tooltip.style.transform = `translate(0, ${y - ttH - 8}px)`;
+    const pct = ratio * 100;
+    this.powerFill.style.clipPath = `inset(0 0 ${100 - pct}% 0)`;
+    this._updateHandleColor(ratio);
+    this.tooltip.textContent = `${Math.round(this.value)}%`;
+    this.el.setAttribute('aria-valuenow', String(Math.round(this.value)));
+    if (ratio >= 0.9) this.el.classList.add('sps-hot');
+    else this.el.classList.remove('sps-hot');
+  }
+
+  _updateHandleColor(ratio) {
+    const low = { r: 255, g: 224, b: 102 }; // #ffe066
+    const high = { r: 255, g: 0, b: 51 }; // #ff0033
+    const r = Math.round(low.r + (high.r - low.r) * ratio);
+    const g = Math.round(low.g + (high.g - low.g) * ratio);
+    const b = Math.round(low.b + (high.b - low.b) * ratio);
+    const color = `rgb(${r},${g},${b})`;
+    const lowColor = `rgb(${low.r},${low.g},${low.b})`;
+    const pct = ratio * 100;
+    this.handle.style.background = color;
+    this.track.style.background = `linear-gradient(to bottom, ${lowColor} 0%, ${color} ${pct}%, var(--sps-track-bg) ${pct}%, var(--sps-track-bg) 100%)`;
+  }
+
+  _setupPowerBar() {
+    if (!this.powerBar) return;
+    const uWidth = this._measureCharWidth('u');
+    const pWidth = this._measureCharWidth('P');
+    this.powerBar.style.width = `${uWidth}px`;
+    const textRect = this.handleText.getBoundingClientRect();
+    const imgRect = this.cueImg.getBoundingClientRect();
+    const elRect = this.el.getBoundingClientRect();
+    const left = textRect.left - elRect.left + pWidth;
+    const top = textRect.bottom - elRect.top;
+    const height = imgRect.bottom - textRect.bottom;
+    this.powerBar.style.left = `${left}px`;
+    this.powerBar.style.top = `${top}px`;
+    this.powerBar.style.height = `${height}px`;
+  }
+
+  _measureCharWidth(ch) {
+    const span = document.createElement('span');
+    span.textContent = ch;
+    span.className = this.handleText.className;
+    span.style.visibility = 'hidden';
+    span.style.position = 'absolute';
+    this.el.appendChild(span);
+    const width = span.getBoundingClientRect().width;
+    span.remove();
+    return width;
+  }
+
+  _updateFromClientY(y) {
+    const rect = this.el.getBoundingClientRect();
+    const pos = (y - rect.top) / rect.height; // 0 at top, 1 at bottom
+    const ratio = Math.min(Math.max(pos, 0), 1);
+    const value = this.min + ratio * (this.max - this.min);
+    this.set(value);
+  }
+
+  _pointerDown(e) {
+    if (this.locked) return;
+    e.preventDefault();
+    this.dragging = true;
+    this.el.classList.add('sps-no-animate');
+    this.el.setPointerCapture(e.pointerId);
+    this._updateFromClientY(e.clientY);
+    this.el.addEventListener('pointermove', this._onPointerMove);
+    this.el.addEventListener('pointerup', this._onPointerUp);
+  }
+
+  _pointerMove(e) {
+    if (!this.dragging) return;
+    this._updateFromClientY(e.clientY);
+  }
+
+  _pointerUp(e) {
+    if (!this.dragging) return;
+    this.dragging = false;
+    this.el.releasePointerCapture(e.pointerId);
+    this.el.removeEventListener('pointermove', this._onPointerMove);
+    this.el.removeEventListener('pointerup', this._onPointerUp);
+    this.el.classList.remove('sps-no-animate');
+    if (typeof this.onCommit === 'function') this.onCommit(this.value);
+  }
+
+  _wheel(e) {
+    if (this.locked) return;
+    e.preventDefault();
+    const dir = e.deltaY > 0 ? 1 : -1;
+    this.set(this.value + dir * this.step, { animate: true });
+    if (typeof this.onCommit === 'function') this.onCommit(this.value);
+  }
+
+  _keyDown(e) {
+    if (this.locked) return;
+    let handled = false;
+    let inc = e.shiftKey ? this.step * 5 : this.step;
+    if (e.key === 'ArrowDown') {
+      this.set(this.value + inc);
+      handled = true;
+    } else if (e.key === 'ArrowUp') {
+      this.set(this.value - inc);
+      handled = true;
+    } else if (e.key === 'Enter') {
+      if (typeof this.onCommit === 'function') this.onCommit(this.value);
+      handled = true;
+    }
+    if (handled) e.preventDefault();
+  }
+}


### PR DESCRIPTION
## Summary
- add snooker-only power slider with compact dimensions
- cut rails around pockets and add plastic jaws with aluminium plates

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, 'inc' is never reassigned. Use 'const' instead)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe9696d2c8329bd72298554896fdf