### PR TITLE
Fix snooker aiming and slider layout

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -96,12 +96,17 @@
   pointer-events: none;
 }
 
+
 .ps .ps-power-bar {
-  position: absolute;
+  width: 8px;
+  flex: 1;
+  margin-top: 4px;
+  margin-bottom: 12px;
   border: 1px solid #000;
   box-sizing: border-box;
   overflow: hidden;
   pointer-events: none;
+  position: relative;
 }
 
 .ps .ps-power-bar-fill {
@@ -154,10 +159,9 @@
 }
 
 .ps .ps-cue-img {
-  margin-top: 12px;
+  margin-top: 4px;
   width: 100%;
   height: auto;
-  transform: translateX(9.6px);
 }
 
 .ps .ps-tooltip {

--- a/power-slider.js
+++ b/power-slider.js
@@ -34,26 +34,24 @@ export class PowerSlider {
     this.track.className = 'ps-track';
     this.el.appendChild(this.track);
 
-    this.powerBar = document.createElement('div');
-    this.powerBar.className = 'ps-power-bar';
-    this.powerFill = document.createElement('div');
-    this.powerFill.className = 'ps-power-bar-fill';
-    this.powerBar.appendChild(this.powerFill);
-    this.el.appendChild(this.powerBar);
-
     this.handle = document.createElement('div');
     this.handle.className = 'ps-handle';
     this.handleText = document.createElement('span');
     this.handleText.className = 'ps-handle-text';
     this.handleText.textContent = 'Pull';
-    this.handle.append(this.handleText);
+
+    this.powerBar = document.createElement('div');
+    this.powerBar.className = 'ps-power-bar';
+    this.powerFill = document.createElement('div');
+    this.powerFill.className = 'ps-power-bar-fill';
+    this.powerBar.appendChild(this.powerFill);
 
     this.cueImg = document.createElement('img');
     this.cueImg.className = 'ps-cue-img';
     this.cueImg.alt = '';
     if (cueSrc) this.cueImg.src = cueSrc;
-    this.handle.append(this.cueImg);
 
+    this.handle.append(this.handleText, this.powerBar, this.cueImg);
     this.el.appendChild(this.handle);
 
     this.tooltip = document.createElement('div');
@@ -82,22 +80,13 @@ export class PowerSlider {
     this._onPointerUp = this._pointerUp.bind(this);
     this._onWheel = this._wheel.bind(this);
     this._onKeyDown = this._keyDown.bind(this);
-    this._onResize = () => {
-      this._setupPowerBar();
-      this._update(false);
-    };
-
     this.el.addEventListener('pointerdown', this._onPointerDown);
     this.el.addEventListener('wheel', this._onWheel, { passive: false });
     this.el.addEventListener('keydown', this._onKeyDown);
-    window.addEventListener('resize', this._onResize);
 
     this.cueImg.addEventListener('load', () => {
-      this._setupPowerBar();
       this._update(false);
     });
-
-    this._setupPowerBar();
 
     this.set(value);
   }
@@ -135,7 +124,6 @@ export class PowerSlider {
     this.el.removeEventListener('pointerdown', this._onPointerDown);
     this.el.removeEventListener('wheel', this._onWheel);
     this.el.removeEventListener('keydown', this._onKeyDown);
-    window.removeEventListener('resize', this._onResize);
     this.el.remove();
   }
 
@@ -180,32 +168,10 @@ export class PowerSlider {
     this.track.style.background = `linear-gradient(to bottom, ${lowColor} 0%, ${color} ${pct}%, var(--ps-track-bg) ${pct}%, var(--ps-track-bg) 100%)`;
   }
 
-  _setupPowerBar() {
-    if (!this.powerBar) return;
-    const uWidth = this._measureCharWidth('u');
-    const pWidth = this._measureCharWidth('P');
-    this.powerBar.style.width = `${uWidth}px`;
-    const textRect = this.handleText.getBoundingClientRect();
-    const imgRect = this.cueImg.getBoundingClientRect();
-    const elRect = this.el.getBoundingClientRect();
-    const left = textRect.left - elRect.left + pWidth;
-    const top = textRect.bottom - elRect.top;
-    const height = imgRect.bottom - textRect.bottom;
-    this.powerBar.style.left = `${left}px`;
-    this.powerBar.style.top = `${top}px`;
-    this.powerBar.style.height = `${height}px`;
-  }
+  _setupPowerBar() {}
 
-  _measureCharWidth(ch) {
-    const span = document.createElement('span');
-    span.textContent = ch;
-    span.className = this.handleText.className;
-    span.style.visibility = 'hidden';
-    span.style.position = 'absolute';
-    this.el.appendChild(span);
-    const width = span.getBoundingClientRect().width;
-    span.remove();
-    return width;
+  _measureCharWidth() {
+    return 0;
   }
 
   _updateFromClientY(y) {

--- a/webapp/src/hooks/useAimCalibration.js
+++ b/webapp/src/hooks/useAimCalibration.js
@@ -27,6 +27,16 @@ export function useAimCalibration() {
   }));
 
   useEffect(() => {
+    const auto = () => {
+      const portrait = window.innerHeight > window.innerWidth;
+      setCfg((c) => ({ ...c, swap: portrait, invertX: false, invertY: false }));
+    };
+    auto();
+    window.addEventListener('resize', auto);
+    return () => window.removeEventListener('resize', auto);
+  }, []);
+
+  useEffect(() => {
     saveFlag('invertX', cfg.invertX);
     saveFlag('invertY', cfg.invertY);
     saveFlag('swap', cfg.swap);

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -368,7 +368,7 @@ function Table3D(scene) {
       .multiplyScalar(railW / 2);
     const jaw = new THREE.Mesh(jawGeo, jawMat);
     jaw.rotation.x = Math.PI / 2;
-    jaw.position.set(p.x + dir.x, -TABLE.THICK + railH / 2, p.y + dir.y);
+    jaw.position.set(p.x - dir.x, -TABLE.THICK + railH / 2, p.y - dir.y);
     table.add(jaw);
   });
   // Base slab under the rails (keeps original footprint while top grew 20%)
@@ -538,7 +538,7 @@ export default function NewSnookerGame() {
   const [timer, setTimer] = useState(60);
   const timerRef = useRef(null);
   const [player, setPlayer] = useState({ name: '', avatar: '' });
-  const { cfg: calib, setCfg, mapDelta } = useAimCalibration();
+  const { mapDelta } = useAimCalibration();
   useEffect(() => {
     document.title = '3D Snooker';
   }, []);
@@ -887,7 +887,7 @@ export default function NewSnookerGame() {
 
       // Cue image
       const cueTex = new THREE.TextureLoader().load(
-        '/assets/icons/file_0000000019d86243a2f7757076cd7869.webp'
+        '/assets/snooker/cue.webp'
       );
       const cueLen = BALL_R * 20;
       const cueMesh = new THREE.Mesh(
@@ -937,7 +937,7 @@ export default function NewSnookerGame() {
         last.y = y;
         const mapped = mapDelta(dx, dy, camera);
         virt.add(mapped);
-        const dir = cue.pos.clone().sub(virt);
+        const dir = virt.clone().sub(cue.pos);
         if (dir.length() > 1e-3) {
           aimDir.set(dir.x, dir.y).normalize();
         }
@@ -1019,7 +1019,7 @@ export default function NewSnookerGame() {
         clearInterval(timerRef.current);
         const base = aimDir
           .clone()
-          .multiplyScalar(4.2 * (0.48 + powerRef.current * 1.52));
+          .multiplyScalar(4.2 * (0.48 + powerRef.current * 1.52) * 0.5);
         cue.vel.copy(base);
       };
       fireRef.current = fire;
@@ -1148,7 +1148,7 @@ export default function NewSnookerGame() {
             end.clone().add(perp.clone().multiplyScalar(-1.4))
           ]);
           tick.visible = true;
-          const pull = powerRef.current * BALL_R * 10;
+          const pull = powerRef.current * BALL_R * 10 * 0.5;
           cueMesh.position.set(
             cue.pos.x - dir.x * (cueLen / 2 + pull + BALL_R),
             BALL_R,
@@ -1292,7 +1292,7 @@ export default function NewSnookerGame() {
     const slider = new SnookerPowerSlider({
       mount,
       value: powerRef.current * 100,
-      cueSrc: '/assets/icons/file_0000000019d86243a2f7757076cd7869.webp',
+      cueSrc: '/assets/snooker/cue.webp',
       labels: true,
       onChange: (v) => setHud((s) => ({ ...s, power: v / 100 })),
       onCommit: () => fireRef.current?.()
@@ -1307,33 +1307,6 @@ export default function NewSnookerGame() {
     <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
-
-      <div className="absolute top-2 right-2 bg-black/50 p-2 text-xs z-50">
-        <label className="mr-2">
-          <input
-            type="checkbox"
-            checked={calib.swap}
-            onChange={(e) => setCfg({ ...calib, swap: e.target.checked })}
-          />
-          swap
-        </label>
-        <label className="mr-2">
-          <input
-            type="checkbox"
-            checked={calib.invertX}
-            onChange={(e) => setCfg({ ...calib, invertX: e.target.checked })}
-          />
-          flipX
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            checked={calib.invertY}
-            onChange={(e) => setCfg({ ...calib, invertY: e.target.checked })}
-          />
-          flipY
-        </label>
-      </div>
 
       {err && (
         <div className="absolute inset-0 bg-black/80 text-white text-xs flex items-center justify-center p-4 z-50">


### PR DESCRIPTION
## Summary
- Correct pocket rim offsets and aiming direction
- Halve shot power and adjust cue pullback
- Move power bar inside slider handle and add dedicated snooker cue asset
- Auto-detect aim calibration instead of manual swap/flip controls
- Remove committed cue image; reference existing asset instead

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bff4ebef108329b4840f82b490983d