### PR TITLE
Move tennis field toward top-left

### DIFF
--- a/webapp/src/pages/Games/TennisBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TennisBattleRoyal.jsx
@@ -167,8 +167,12 @@ function Tennis3D({ pAvatar }){
     try{
       // Renderer & scene
       renderer = new THREE.WebGLRenderer({ antialias:true, alpha:false, powerPreference:'high-performance' });
-      renderer.setPixelRatio(Math.min(2, window.devicePixelRatio||1));
-      renderer.setSize(host.clientWidth, host.clientHeight, false);
+      renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
+      const canvasOffset = 40;
+      renderer.setSize(host.clientWidth + canvasOffset, host.clientHeight + canvasOffset, false);
+      renderer.domElement.style.position = 'absolute';
+      renderer.domElement.style.left = `-${canvasOffset}px`;
+      renderer.domElement.style.top = `-${canvasOffset}px`;
       host.appendChild(renderer.domElement);
 
       scene = new THREE.Scene(); scene.background = new THREE.Color(COLORS.crowd);


### PR DESCRIPTION
## Summary
- Shift Tennis Battle Royal canvas 40px up and left so the court sits nearer the top-left of the page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c022a9d5148329a858ff17ac3beb39