### PR TITLE
Fix chess board canvas positioning

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -366,6 +366,12 @@ function Chess3D() {
       powerPreference: 'high-performance'
     });
     renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
+    // Ensure the canvas covers the entire host element so the board is centered
+    renderer.domElement.style.position = 'absolute';
+    renderer.domElement.style.top = '0';
+    renderer.domElement.style.left = '0';
+    renderer.domElement.style.width = '100%';
+    renderer.domElement.style.height = '100%';
     host.appendChild(renderer.domElement);
 
     scene = new THREE.Scene();


### PR DESCRIPTION
## Summary
- ensure chess board canvas covers entire screen so board stays centered

## Testing
- `npm test`
- `npm run lint` *(fails: 937 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c02f3b65a08329a9344bd47bb81910