### PR TITLE
Ensure full tennis court is visible in Tennis Battle Royal

### DIFF
--- a/webapp/src/pages/Games/TennisBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TennisBattleRoyal.jsx
@@ -184,9 +184,18 @@ function Tennis3D({ pAvatar }){
         renderer.setSize(w, h, false);
         camera.aspect = w / h;
         camera.updateProjectionMatrix();
-        const needed = (COURT.L + COURT.BASE_MARGIN * 2) /
-          (2 * Math.tan(THREE.MathUtils.degToRad(CAM.fov) / 2));
-        sph.radius = Math.max(needed, sph.radius);
+
+        const fovRad = THREE.MathUtils.degToRad(CAM.fov);
+        const vNeeded = (COURT.L + COURT.BASE_MARGIN * 2) /
+          (2 * Math.tan(fovRad / 2));
+        const hFov = 2 * Math.atan(Math.tan(fovRad / 2) * camera.aspect);
+        const hNeeded = (COURT.W + COURT.BASE_MARGIN * 2) /
+          (2 * Math.tan(hFov / 2));
+        sph.radius = Math.min(
+          CAM.maxR,
+          Math.max(vNeeded, hNeeded, CAM.minR)
+        );
+
         camera.position.setFromSpherical(sph);
         camera.lookAt(camTarget);
       };


### PR DESCRIPTION
## Summary
- compute camera radius using both vertical and horizontal FOV so the entire court shows on all screens

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c02f757d648329931367851d422287