### PR TITLE
Add Table Tennis game with AI

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -28,6 +28,8 @@ import FallingBall from './pages/Games/FallingBall.jsx';
 import FallingBallLobby from './pages/Games/FallingBallLobby.jsx';
 import GoalRush from './pages/Games/GoalRush.jsx';
 import GoalRushLobby from './pages/Games/GoalRushLobby.jsx';
+import TableTennis from './pages/Games/TableTennis.jsx';
+import TableTennisLobby from './pages/Games/TableTennisLobby.jsx';
 import FreeKick from './pages/Games/FreeKick.jsx';
 import FreeKickLobby from './pages/Games/FreeKickLobby.jsx';
 import BrickBreaker from './pages/Games/BrickBreaker.jsx';
@@ -91,6 +93,8 @@ export default function App() {
             <Route path="/games/fallingball" element={<FallingBall />} />
             <Route path="/games/goalrush/lobby" element={<GoalRushLobby />} />
             <Route path="/games/goalrush" element={<GoalRush />} />
+            <Route path="/games/tabletennis/lobby" element={<TableTennisLobby />} />
+            <Route path="/games/tabletennis" element={<TableTennis />} />
             <Route path="/games/freekick/lobby" element={<FreeKickLobby />} />
             <Route path="/games/freekick" element={<FreeKick />} />
             <Route

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -65,6 +65,19 @@ export default function HomeGamesCard() {
             Goal Rush
           </h3>
         </Link>
+          <Link
+            to="/games/tabletennis/lobby"
+            className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+          >
+            <img
+              src="/assets/icons/air_hockey.svg"
+              alt=""
+              className="h-20 w-20"
+            />
+            <h3 className="text-sm font-semibold text-center text-yellow-400">
+              Table Tennis
+            </h3>
+          </Link>
         <Link
           to="/games/snake/lobby"
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"

--- a/webapp/src/components/TableTennis3D.jsx
+++ b/webapp/src/components/TableTennis3D.jsx
@@ -1,0 +1,210 @@
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
+
+/**
+ * Simple 3D table tennis game with basic AI.
+ * Mobile portrait friendly – always shows full table.
+ */
+
+const CAM = { fov: 60, near: 0.1, far: 5000 };
+const TABLE = { L: 2.74, W: 1.525, H: 0.76 };
+const SCALE = 48;
+const R = { ball: 0.02 * SCALE, paddleR: 0.095 * SCALE };
+const COLORS = Object.freeze({
+  bg: 0x0b0d11,
+  table: 0x0a5d9e,
+  edge: 0x0e3f69,
+  line: 0xf8fafc,
+  p1: 0x22c55e,
+  p2: 0xf59e0b,
+  ball: 0xffffff
+});
+
+const mat = (c) =>
+  new THREE.MeshStandardMaterial({ color: c, roughness: 0.9, metalness: 0.05 });
+
+export default function TableTennis3D({ turn, onPoint }) {
+  const hostRef = useRef(null);
+  const rafRef = useRef(0);
+  const stateRef = useRef({});
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(host.clientWidth, host.clientHeight);
+    host.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(COLORS.bg);
+    scene.add(new THREE.HemisphereLight(0xffffff, 0x223344, 1));
+
+    const L = TABLE.L * SCALE,
+      W = TABLE.W * SCALE,
+      H = TABLE.H * SCALE;
+
+    const cam = new THREE.PerspectiveCamera(
+      CAM.fov,
+      host.clientWidth / host.clientHeight,
+      CAM.near,
+      CAM.far
+    );
+    const controls = new OrbitControls(cam, renderer.domElement);
+    controls.enableDamping = true;
+    controls.minDistance = 200;
+    controls.maxDistance = 600;
+    controls.maxPolarAngle = Math.PI / 2.2;
+    controls.minPolarAngle = Math.PI / 4;
+
+    const fitCamera = () => {
+      cam.aspect = host.clientWidth / host.clientHeight;
+      cam.updateProjectionMatrix();
+      cam.position.set(0, 400, L * 0.7);
+      controls.target.set(0, H, 0);
+      controls.update();
+    };
+    fitCamera();
+
+    // Table
+    const top = new THREE.Mesh(new THREE.PlaneGeometry(W, L), mat(COLORS.table));
+    top.rotation.x = -Math.PI / 2;
+    top.position.y = H;
+    scene.add(top);
+    const edge = new THREE.Mesh(new THREE.PlaneGeometry(W * 1.02, L * 1.02), mat(COLORS.edge));
+    edge.rotation.x = -Math.PI / 2;
+    edge.position.y = H - 0.01;
+    scene.add(edge);
+
+    const line = new THREE.Mesh(
+      new THREE.PlaneGeometry(W * 1.02, 0.02 * SCALE),
+      mat(COLORS.line)
+    );
+    line.rotation.x = -Math.PI / 2;
+    line.position.set(0, H + 0.01, 0);
+    scene.add(line);
+
+    // Ball
+    const ball = new THREE.Mesh(
+      new THREE.SphereGeometry(R.ball, 16, 16),
+      mat(COLORS.ball)
+    );
+    ball.position.set(0, H + R.ball, 0);
+    scene.add(ball);
+
+    // Paddles
+    const paddleGeom = new THREE.CylinderGeometry(
+      R.paddleR,
+      R.paddleR,
+      0.02 * SCALE,
+      16
+    );
+    paddleGeom.rotateX(Math.PI / 2);
+    const player = new THREE.Mesh(paddleGeom, mat(COLORS.p1));
+    player.position.set(0, H + 0.01 * SCALE, L / 2 - R.paddleR * 1.5);
+    scene.add(player);
+    const ai = new THREE.Mesh(paddleGeom, mat(COLORS.p2));
+    ai.position.set(0, H + 0.01 * SCALE, -L / 2 + R.paddleR * 1.5);
+    scene.add(ai);
+
+    const ballVel = new THREE.Vector3();
+
+    const serve = (side) => {
+      ball.position.set(0, H + R.ball, side === 'player' ? L / 2 - 20 : -L / 2 + 20);
+      ballVel.set((Math.random() - 0.5) * 4, 0, side === 'player' ? -6 : 6);
+    };
+
+    stateRef.current = { ball, ballVel, player, ai, serve, L, W };
+
+    // Player control
+    const handleMove = (e) => {
+      const rect = renderer.domElement.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width - 0.5) * W * 0.9;
+      player.position.x = THREE.MathUtils.clamp(
+        x,
+        -W / 2 + R.paddleR,
+        W / 2 - R.paddleR
+      );
+    };
+    renderer.domElement.addEventListener('pointermove', handleMove);
+
+    serve(turn);
+
+    const step = () => {
+      controls.update();
+      const { ball, ballVel, player, ai, L, W } = stateRef.current;
+      ball.position.add(ballVel);
+
+      // Wall bounce
+      if (ball.position.x < -W / 2 + R.ball || ball.position.x > W / 2 - R.ball) {
+        ballVel.x *= -1;
+        ball.position.x = THREE.MathUtils.clamp(
+          ball.position.x,
+          -W / 2 + R.ball,
+          W / 2 - R.ball
+        );
+      }
+
+      // Paddle collisions
+      if (
+        ball.position.z > player.position.z - R.ball &&
+        Math.abs(ball.position.x - player.position.x) < R.paddleR
+      ) {
+        ballVel.z = -Math.abs(ballVel.z);
+        ballVel.x += (ball.position.x - player.position.x) * 0.1;
+        ball.position.z = player.position.z - R.ball;
+      } else if (
+        ball.position.z < ai.position.z + R.ball &&
+        Math.abs(ball.position.x - ai.position.x) < R.paddleR
+      ) {
+        ballVel.z = Math.abs(ballVel.z);
+        ballVel.x += (ball.position.x - ai.position.x) * 0.1;
+        ball.position.z = ai.position.z + R.ball;
+      }
+
+      // Scoring
+      if (ball.position.z > L / 2) {
+        onPoint?.('ai');
+        serve('player');
+      } else if (ball.position.z < -L / 2) {
+        onPoint?.('player');
+        serve('ai');
+      }
+
+      // AI movement
+      const targetX = THREE.MathUtils.clamp(
+        ball.position.x,
+        -W / 2 + R.paddleR,
+        W / 2 - R.paddleR
+      );
+      ai.position.x += (targetX - ai.position.x) * 0.1; // smooth follow
+
+      renderer.render(scene, cam);
+      rafRef.current = requestAnimationFrame(step);
+    };
+    step();
+
+    const onResize = () => {
+      renderer.setSize(host.clientWidth, host.clientHeight);
+      fitCamera();
+    };
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      window.removeEventListener('resize', onResize);
+      renderer.domElement.removeEventListener('pointermove', handleMove);
+      host.removeChild(renderer.domElement);
+    };
+  }, []);
+
+  useEffect(() => {
+    // serve when turn changes
+    stateRef.current.serve?.(turn);
+  }, [turn]);
+
+  return <div ref={hostRef} className="w-full h-[100vh]" />;
+}
+

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -92,6 +92,22 @@ export default function Games() {
                 Goal Rush
               </h3>
             </Link>
+              <Link
+                to="/games/tabletennis/lobby"
+                className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+              >
+                <img
+                  src="/assets/icons/air_hockey.svg"
+                  alt=""
+                  className="h-20 w-20"
+                />
+                <h3
+                  className="text-sm font-semibold text-center text-yellow-400"
+                  style={{ WebkitTextStroke: '1px black' }}
+                >
+                  Table Tennis
+                </h3>
+              </Link>
             <Link
               to="/games/freekick/lobby"
               className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"

--- a/webapp/src/pages/Games/TableTennis.jsx
+++ b/webapp/src/pages/Games/TableTennis.jsx
@@ -1,0 +1,44 @@
+import { useLocation } from 'react-router-dom';
+import { useState } from 'react';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import TableTennis3D from '../../components/TableTennis3D.jsx';
+
+export default function TableTennis() {
+  useTelegramBackButton();
+  const { search } = useLocation();
+  const params = new URLSearchParams(search);
+  const avatar = params.get('avatar') || '/assets/icons/profile.svg';
+  const name = params.get('name') || 'You';
+  const aiAvatar = '/assets/icons/air_hockey.svg';
+  const aiName = 'CPU';
+
+  const [score, setScore] = useState({ player: 0, ai: 0 });
+  const [turn, setTurn] = useState('player');
+
+  const handlePoint = (winner) => {
+    setScore((s) => ({ ...s, [winner]: s[winner] + 1 }));
+    setTurn(winner === 'player' ? 'ai' : 'player');
+  };
+
+  return (
+    <div className="relative w-full h-[100dvh]">
+      <div className="absolute top-0 left-0 right-0 flex justify-center z-10 pointer-events-none">
+        <div className="flex items-center gap-2 bg-black/60 text-white px-3 py-1 rounded-b">
+          <div className={`flex items-center gap-1 ${turn === 'player' ? 'opacity-100' : 'opacity-50'}`}>
+            <img src={avatar} alt="" className="w-6 h-6 rounded-full" />
+            <span>{name}</span>
+            <span className="font-bold">{score.player}</span>
+          </div>
+          <span>—</span>
+          <div className={`flex items-center gap-1 ${turn === 'ai' ? 'opacity-100' : 'opacity-50'}`}>
+            <span className="font-bold">{score.ai}</span>
+            <img src={aiAvatar} alt="" className="w-6 h-6 rounded-full" />
+            <span>{aiName}</span>
+          </div>
+        </div>
+      </div>
+      <TableTennis3D turn={turn} onPoint={handlePoint} />
+    </div>
+  );
+}
+

--- a/webapp/src/pages/Games/TableTennisLobby.jsx
+++ b/webapp/src/pages/Games/TableTennisLobby.jsx
@@ -1,0 +1,108 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import {
+  ensureAccountId,
+  getTelegramId,
+  getTelegramPhotoUrl,
+  getTelegramFirstName
+} from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+
+export default function TableTennisLobby() {
+  const navigate = useNavigate();
+  useTelegramBackButton();
+
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [playType, setPlayType] = useState('regular');
+  const [avatar, setAvatar] = useState('');
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  const startGame = async () => {
+    let tgId;
+    let accountId;
+    if (playType !== 'training') {
+      try {
+        accountId = await ensureAccountId();
+        const balRes = await getAccountBalance(accountId);
+        if ((balRes.balance || 0) < stake.amount) {
+          alert('Insufficient balance');
+          return;
+        }
+        tgId = getTelegramId();
+        await addTransaction(tgId, -stake.amount, 'stake', {
+          game: 'tabletennis',
+          players: 2,
+          accountId,
+        });
+      } catch {}
+    } else {
+      try {
+        tgId = getTelegramId();
+        accountId = await ensureAccountId();
+      } catch {}
+    }
+
+    const params = new URLSearchParams();
+    params.set('type', playType);
+    if (playType !== 'training') {
+      if (stake.token) params.set('token', stake.token);
+      if (stake.amount) params.set('amount', stake.amount);
+    }
+    if (avatar) params.set('avatar', avatar);
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    const name = getTelegramFirstName();
+    if (name) params.set('name', name);
+    navigate(`/games/tabletennis?${params.toString()}`);
+  };
+
+  return (
+    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+      <h2 className="text-xl font-bold text-center">Table Tennis Lobby</h2>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Type</h3>
+        <div className="flex gap-2">
+          {[{ id: 'regular', label: 'Regular' }, { id: 'training', label: 'Training' }].map(
+            ({ id, label }) => (
+              <button
+                key={id}
+                onClick={() => setPlayType(id)}
+                className={`lobby-tile ${playType === id ? 'lobby-selected' : ''}`}
+              >
+                {label}
+              </button>
+            )
+          )}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Mode</h3>
+        <div className="flex gap-2">
+          <button className="lobby-tile lobby-selected">Vs AI</button>
+        </div>
+      </div>
+      {playType !== 'training' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Stake</h3>
+          <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+        </div>
+      )}
+      <button
+        onClick={startGame}
+        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
+      >
+        Start Game
+      </button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Table Tennis 3D game with basic physics and AI opponent
- include lobby with TPC stakes and training mode
- integrate Table Tennis routes and links into game lists

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c03c8dd9108329900941315b01c42c