### PR TITLE
Add Unity billiard lighting script

### DIFF
--- a/billiards.Unity/BilliardLighting.cs
+++ b/billiards.Unity/BilliardLighting.cs
@@ -1,0 +1,40 @@
+#if UNITY_5_3_OR_NEWER
+using UnityEngine;
+
+public class BilliardLighting : MonoBehaviour
+{
+    void Start()
+    {
+        // Create Spot Light
+        GameObject lightObj = new GameObject("BilliardSpotLight");
+        Light spotLight = lightObj.AddComponent<Light>();
+        spotLight.type = LightType.Spot;
+        spotLight.color = Color.white;
+        spotLight.intensity = 2.5f;
+        spotLight.range = 15f;
+        spotLight.spotAngle = 60f;
+        spotLight.shadows = LightShadows.Soft;
+
+        // Position the light above the table
+        lightObj.transform.position = new Vector3(0, 5, 0);
+        lightObj.transform.rotation = Quaternion.Euler(90, 0, 0);
+
+        // Create a shiny plastic (PBR) material
+        Material plasticMat = new Material(Shader.Find("Standard"));
+        plasticMat.color = Color.red;           // change color per ball as needed
+        plasticMat.SetFloat("_Metallic", 0f);   // not metallic
+        plasticMat.SetFloat("_Glossiness", 0.9f); // very shiny surface
+
+        // Apply material to all objects tagged "Ball"
+        GameObject[] balls = GameObject.FindGameObjectsWithTag("Ball");
+        foreach (GameObject ball in balls)
+        {
+            Renderer renderer = ball.GetComponent<Renderer>();
+            if (renderer != null)
+            {
+                renderer.material = plasticMat;
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add `BilliardLighting` MonoBehaviour to create a spotlight and shiny plastic material for balls in the Unity demo

## Testing
- `npm test`
- `dotnet test billiards.Tests/Billiards.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c03fbfa35c83299ad15937ea891cf4