### PR TITLE
Align tennis court camera for straight view

### DIFF
--- a/webapp/src/pages/Games/TennisBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TennisBattleRoyal.jsx
@@ -181,7 +181,7 @@ function Tennis3D({ pAvatar }){
 
       // Camera orbit
       camera = new THREE.PerspectiveCamera(CAM.fov, 1, CAM.near, CAM.far);
-      sph = new THREE.Spherical(160, (CAM.phiMin + CAM.phiMax) / 2, Math.PI * 0.12);
+      sph = new THREE.Spherical(160, (CAM.phiMin + CAM.phiMax) / 2, Math.PI * 0.5);
       const camTarget = new THREE.Vector3(0, 0, 0);
       const fit = () => {
         let w = host.clientWidth;


### PR DESCRIPTION
## Summary
- Orient tennis battle camera directly along the court to remove skewed perspective.

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon and prefer-const errors, existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c044869fd083299e521d0f2bd6cab4