### PR TITLE
Adjust Snooker camera distance

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -77,7 +77,7 @@ const fitRadius = (camera, margin = 1.1) => {
     halfH = (TABLE.H / 2) * margin;
   const dzH = halfH / Math.tan(f / 2);
   const dzW = halfW / (Math.tan(f / 2) * a);
-  const r = Math.max(dzH, dzW) * 0.95; // slightly closer to the action
+  const r = Math.max(dzH, dzW) * 0.9; // nudge camera slightly closer
   return clamp(r, CAMERA.minR, CAMERA.maxR);
 };
 


### PR DESCRIPTION
## Summary
- Nudge Snooker camera slightly closer to the table for a more immersive view.

## Testing
- `npm test`
- `npm run lint` *(fails: existing 937 lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0452646e483299b050d2082297eff