### PR TITLE
chore: remove unused snooker code

### DIFF
--- a/demo/demo.json
+++ b/demo/demo.json
@@ -1,10 +1,10 @@
 [
   [
     {"type":"HIT","firstContact":"RED"},
-    {"type":"POTTED","ball":"RED","pocket":"TR"}
+    {"type":"POTTED","ball":"RED"}
   ],
   [
     {"type":"HIT","firstContact":"BLACK"},
-    {"type":"POTTED","ball":"BLACK","pocket":"TR"}
+    {"type":"POTTED","ball":"BLACK"}
   ]
 ]

--- a/src/rules/SnookerRules.ts
+++ b/src/rules/SnookerRules.ts
@@ -1,7 +1,6 @@
 import { Ball, BallColor, FrameState, Player } from '../types';
 
 export class SnookerRules {
-  constructor(private opts: { simplified?: boolean } = {}) {}
 
   getBallValues(): Record<BallColor, number> {
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,10 @@
 export type BallColor = 'RED'|'YELLOW'|'GREEN'|'BROWN'|'BLUE'|'PINK'|'BLACK'|'CUE';
-export type PocketId = 'TL'|'TM'|'TR'|'BL'|'BM'|'BR';
 
 export interface Ball {
   id: string;
   color: BallColor;
   onTable: boolean;
   potted: boolean;
-  position?: { x:number; y:number };
 }
 
 export interface Player { id:string; name:string; score:number; }
@@ -28,6 +26,4 @@ export interface FrameState {
 
 export type ShotEvent =
   | { type:'HIT'; firstContact:BallColor|null }
-  | { type:'POTTED'; ball:BallColor; pocket:PocketId }
-  | { type:'FOUL'; reason:string; ball?:BallColor }
-  | { type:'END_TURN' };
+  | { type:'POTTED'; ball:BallColor };

--- a/tests/snooker.test.ts
+++ b/tests/snooker.test.ts
@@ -1,8 +1,6 @@
 import { SnookerRules } from '../src/rules/SnookerRules';
 import { Referee } from '../src/core/Referee';
 
-const pocket = 'TR';
-
 describe('Snooker core', () => {
   test('basic rotation and colors order', () => {
     const rules = new SnookerRules();
@@ -15,26 +13,26 @@ describe('Snooker core', () => {
 
     state = ref.applyShot(state, [
       { type: 'HIT', firstContact: 'RED' },
-      { type: 'POTTED', ball: 'RED', pocket },
+      { type: 'POTTED', ball: 'RED' },
     ]);
     expect(state.redsRemaining).toBe(0);
     expect(state.ballOn).toEqual(['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK']);
 
     state = ref.applyShot(state, [
       { type: 'HIT', firstContact: 'BLACK' },
-      { type: 'POTTED', ball: 'BLACK', pocket },
+      { type: 'POTTED', ball: 'BLACK' },
     ]);
     expect(state.phase).toBe('COLORS_ORDER');
     expect(state.ballOn).toEqual(['YELLOW']);
 
     state = ref.applyShot(state, [
       { type: 'HIT', firstContact: 'YELLOW' },
-      { type: 'POTTED', ball: 'YELLOW', pocket },
+      { type: 'POTTED', ball: 'YELLOW' },
     ]);
     expect(state.ballOn).toEqual(['GREEN']);
     state = ref.applyShot(state, [
       { type: 'HIT', firstContact: 'GREEN' },
-      { type: 'POTTED', ball: 'GREEN', pocket },
+      { type: 'POTTED', ball: 'GREEN' },
     ]);
     expect(state.ballOn).toEqual(['BROWN']);
   });
@@ -45,11 +43,11 @@ describe('Snooker core', () => {
     let state = rules.getInitialFrame('p1', 'p2');
     state = ref.applyShot(state, [
       { type: 'HIT', firstContact: 'RED' },
-      { type: 'POTTED', ball: 'RED', pocket },
+      { type: 'POTTED', ball: 'RED' },
     ]);
     state = ref.applyShot(state, [
       { type: 'HIT', firstContact: 'BLACK' },
-      { type: 'POTTED', ball: 'BLACK', pocket },
+      { type: 'POTTED', ball: 'BLACK' },
     ]);
     expect(state.players.A.score).toBe(8);
   });
@@ -86,7 +84,7 @@ describe('Snooker core', () => {
     state = ref.setFreeBall(state, true);
     state = ref.applyShot(state, [
       { type: 'HIT', firstContact: 'YELLOW' },
-      { type: 'POTTED', ball: 'YELLOW', pocket },
+      { type: 'POTTED', ball: 'YELLOW' },
     ]);
     expect(state.players.B.score).toBe(5); // 4 + 1
     expect(state.ballOn).toEqual(['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK']);
@@ -98,11 +96,11 @@ describe('Snooker core', () => {
     let state = rules.getInitialFrame('p1', 'p2');
     state = ref.applyShot(state, [
       { type: 'HIT', firstContact: 'RED' },
-      { type: 'POTTED', ball: 'RED', pocket },
+      { type: 'POTTED', ball: 'RED' },
     ]);
     state = ref.applyShot(state, [
       { type: 'HIT', firstContact: 'BLACK' },
-      { type: 'POTTED', ball: 'BLACK', pocket },
+      { type: 'POTTED', ball: 'BLACK' },
     ]);
     const black = state.balls.find((b) => b.color === 'BLACK')!;
     expect(black.onTable).toBe(true);
@@ -113,7 +111,7 @@ describe('Snooker core', () => {
     state.ballOn = ['YELLOW'];
     state = ref.applyShot(state, [
       { type: 'HIT', firstContact: 'YELLOW' },
-      { type: 'POTTED', ball: 'YELLOW', pocket },
+      { type: 'POTTED', ball: 'YELLOW' },
     ]);
     const yellow = state.balls.find((b) => b.color === 'YELLOW')!;
     expect(yellow.onTable).toBe(false);
@@ -133,7 +131,7 @@ describe('Snooker core', () => {
     state.players.B.score = 5;
     state = ref.applyShot(state, [
       { type: 'HIT', firstContact: 'BLACK' },
-      { type: 'POTTED', ball: 'BLACK', pocket },
+      { type: 'POTTED', ball: 'BLACK' },
     ]);
     expect(state.frameOver).toBe(true);
     expect(state.winner).toBe('A');


### PR DESCRIPTION
## Summary
- simplify SnookerRules by dropping unused constructor options
- trim unused types and event fields in snooker logic
- adjust tests and demo data for streamlined shot events

## Testing
- `npm test`
- `npm run lint` *(fails: 937 problems, e.g., snooker-power-slider.js)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c05f64984483298deda775e7131d33