### PR TITLE
Restore original ball physics

### DIFF
--- a/billiards.Unity/BilliardLighting.cs
+++ b/billiards.Unity/BilliardLighting.cs
@@ -5,9 +5,6 @@ public class BilliardLighting : MonoBehaviour
 {
     void Start()
     {
-        // Ensure normal game speed in case other scripts altered it
-        Time.timeScale = 1f;
-
         // Create Spot Light
         GameObject lightObj = new GameObject("BilliardSpotLight");
         Light spotLight = lightObj.AddComponent<Light>();
@@ -28,15 +25,7 @@ public class BilliardLighting : MonoBehaviour
         plasticMat.SetFloat("_Metallic", 0f);   // not metallic
         plasticMat.SetFloat("_Glossiness", 0.9f); // very shiny surface
 
-        // Create low-friction physics material for natural rolling
-        PhysicMaterial physicsMat = new PhysicMaterial();
-        physicsMat.dynamicFriction = 0f;
-        physicsMat.staticFriction = 0f;
-        physicsMat.bounciness = 0.9f;
-        physicsMat.frictionCombine = PhysicMaterialCombine.Minimum;
-        physicsMat.bounceCombine = PhysicMaterialCombine.Maximum;
-
-        // Apply materials to all objects tagged "Ball"
+        // Apply material to all objects tagged "Ball"
         GameObject[] balls = GameObject.FindGameObjectsWithTag("Ball");
         foreach (GameObject ball in balls)
         {
@@ -44,20 +33,6 @@ public class BilliardLighting : MonoBehaviour
             if (renderer != null)
             {
                 renderer.material = plasticMat;
-            }
-
-            // Assign low-friction physics material and reduce drag
-            Collider col = ball.GetComponent<Collider>();
-            if (col != null)
-            {
-                col.material = physicsMat;
-            }
-
-            Rigidbody rb = ball.GetComponent<Rigidbody>();
-            if (rb != null)
-            {
-                rb.drag = 0f;
-                rb.angularDrag = 0.05f;
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove timeScale, friction, and drag overrides from Unity lighting script so balls roll like before

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0670f89d88329b5e6f4c33cf6a246