### PR TITLE
Restore snooker ball speed to original scaling

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1150,8 +1150,8 @@ export default function NewSnookerGame() {
         clearInterval(timerRef.current);
         const base = aimDir
           .clone()
-          // increased impulse for more lifelike ball speed
-          .multiplyScalar(6 * (0.48 + powerRef.current * 1.52));
+          // restore original shot impulse for consistent ball speed
+          .multiplyScalar(4.2 * (0.48 + powerRef.current * 1.52));
         cue.vel.copy(base);
       };
       fireRef.current = fire;


### PR DESCRIPTION
## Summary
- revert snooker shot impulse multiplier to match earlier power and speed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c06a95fba88329a4a33ae184919aac