### PR TITLE
Restore snooker ball speed and cue power

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -134,8 +134,7 @@ const POCKET_R = BALL_R * 2; // pockets twice the ball radius
 // slightly larger visual radius so rails align with pocket rings
 const POCKET_VIS_R = POCKET_R / 0.85;
 // higher value -> less energy loss each frame for more realistic roll
-// reduced friction so balls retain more speed during play
-const FRICTION = 0.998;
+const FRICTION = 0.995;
 const STOP_EPS = 0.02;
 const CAPTURE_R = POCKET_R; // pocket capture radius
 const TABLE_Y = -2; // vertical offset to lower entire table
@@ -1151,8 +1150,8 @@ export default function NewSnookerGame() {
         clearInterval(timerRef.current);
         const base = aimDir
           .clone()
-          // reduce maximum cue power for a gentler shot
-          .multiplyScalar(2.1 * (0.48 + powerRef.current * 1.52));
+          // restore original shot impulse for consistent ball speed
+          .multiplyScalar(4.2 * (0.48 + powerRef.current * 1.52));
         cue.vel.copy(base);
       };
       fireRef.current = fire;


### PR DESCRIPTION
## Summary
- Revert snooker table friction to original 0.995 for natural rolling
- Restore cue impulse multiplier to 4.2 for consistent shot power

## Testing
- `npm test`
- `npm run lint` *(fails: 937 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0783b9d0883299ee4cc8bc1b7bffa