### PR TITLE
Refine roulette wheel spacing and visuals

### DIFF
--- a/webapp/public/roulette.html
+++ b/webapp/public/roulette.html
@@ -35,14 +35,15 @@
 
     .wheel-wrap{position:relative;width:92%;max-width:600px;transform:rotateX(22deg) rotateZ(0deg);transform-style:preserve-3d;}
     .wheel{position:relative;aspect-ratio:1;border-radius:50%;background:#222;box-shadow:inset 0 0 40px #000,inset 0 0 120px #0008,0 30px 80px #000c;overflow:hidden}
-    .rim{position:absolute;inset:0;border-radius:50%;border:20px solid #2b2b2b;box-shadow:inset 0 0 12px #000,inset 0 0 0 8px #3b3b3b,0 6px 16px #0007}
+    .rim{position:absolute;inset:0;border-radius:50%;border:16px solid #2b2b2b;box-shadow:inset 0 0 12px #000,inset 0 0 0 8px #3b3b3b,0 6px 16px #0007}
     .pockets{position:absolute;inset:0;border-radius:50%}
-    .label{position:absolute;left:50%;top:8%;transform-origin:50% 230px;text-shadow:0 1px 2px #0009;font-weight:800;font-size:12px;letter-spacing:.4px;color:#eee}
+    .label{position:absolute;left:50%;top:11%;transform-origin:50% 225px;text-shadow:0 1px 2px #0009;font-weight:800;font-size:12px;letter-spacing:.4px;color:#eee}
     .spokes{position:absolute;inset:12%;border-radius:50%;background:repeating-conic-gradient(from 0deg, #d9d9d91a 0 6deg, transparent 6deg 18deg);box-shadow:inset 0 0 12px #0007}
     .hub{position:absolute;inset:38%;border-radius:50%;background:radial-gradient(120px 90px at 40% 40%, #666 0%, #222 60%, #000 100%);box-shadow:inset 0 0 10px #000}
     .pin{position:absolute;left:50%;top:16px;transform:translateX(-50%);width:14px;height:14px;border-radius:50%;background:radial-gradient(circle at 40% 40%,#ffe793,#d5a300);border:2px solid #926800;box-shadow:0 2px 6px #000a}
 
-    .ball{position:absolute;width:14px;height:14px;border-radius:50%;background:radial-gradient(circle at 30% 30%,#fff,#d6d6d6 60%,#bdbdbd 100%);box-shadow:0 2px 6px #000a;transform:translate(-50%,-50%);}
+    .ball{position:absolute;width:14px;height:14px;border-radius:50%;background:radial-gradient(circle at 35% 35%,#fff,#e6e6e6 40%,#cfcfcf 70%,#b0b0b0 100%);box-shadow:inset -2px -2px 4px #0004,inset 2px 2px 4px #fff6,0 2px 6px #000a;transform:translate(-50%,-50%);}
+    .ball::before{content:"";position:absolute;inset:0;border-radius:50%;background:radial-gradient(circle at 30% 30%,#ffffffcc,#ffffff00 40%);}
 
     .arrow{position:absolute;top:8px;left:50%;transform:translateX(-50%);width:0;height:0;border-left:10px solid transparent;border-right:10px solid transparent;border-top:16px solid var(--gold);filter:drop-shadow(0 4px 6px #000a)}
 
@@ -179,10 +180,12 @@
         parts.push(`${col} ${acc}deg ${acc+seg}deg`);
         acc += seg;
       }
-      return `conic-gradient(${parts.join(',')})`;
+      const sep = 0.5; // separator width in degrees
+      const gap = seg - sep;
+      return `repeating-conic-gradient(#0000 0deg ${gap}deg,#000 ${gap}deg ${seg}deg), conic-gradient(${parts.join(',')})`;
     }
     function buildLabels(){
-      const radius = 230; // for transform-origin
+      const radius = 225; // for transform-origin
       order.forEach((n, i)=>{
         const ang = (i*seg);
         const label = document.createElement('div');


### PR DESCRIPTION
## Summary
- lower roulette number labels and widen wheel edge
- add pocket separators and spherical shading for ball

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon and prefer-const errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0792ce02c83298f157dc5426dd304