### PR TITLE
Tune snooker physics and slider layout

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -155,7 +155,7 @@
   font-size: 14px;
   color: #fff;
   line-height: 1;
-  transform: translate(-1px, 0px);
+  transform: translate(-3px, 0px);
 }
 
 .ps .ps-cue-img {

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -133,8 +133,8 @@ const BALL_R = 2 * BALL_SCALE;
 const POCKET_R = BALL_R * 2; // pockets twice the ball radius
 // slightly larger visual radius so rails align with pocket rings
 const POCKET_VIS_R = POCKET_R / 0.85;
-// lower coefficient so balls retain speed but settle sooner
-const FRICTION = 0.99;
+// stronger damping so balls settle quicker
+const FRICTION = 0.985;
 const STOP_EPS = 0.02;
 const CAPTURE_R = POCKET_R; // pocket capture radius
 const TABLE_Y = -2; // vertical offset to lower entire table
@@ -782,6 +782,8 @@ export default function NewSnookerGame() {
       const fit = (m = 1.1) => {
         camera.aspect = host.clientWidth / host.clientHeight;
         sph.radius = fitRadius(camera, m);
+        // when viewing from the long sides, bring camera slightly closer
+        sph.radius *= 1 - 0.1 * Math.abs(Math.sin(sph.theta));
         const phiCap = Math.acos(
           THREE.MathUtils.clamp(-0.95 / sph.radius, -1, 1)
         );
@@ -1150,8 +1152,8 @@ export default function NewSnookerGame() {
         clearInterval(timerRef.current);
         const base = aimDir
           .clone()
-          // boost initial impulse for snappier ball response
-          .multiplyScalar(4.2 * (0.48 + powerRef.current * 1.52) * 1.5);
+          // halve impulse so ball speed matches power gauge better
+          .multiplyScalar(4.2 * (0.48 + powerRef.current * 1.52) * 0.75);
         cue.vel.copy(base);
       };
       fireRef.current = fire;


### PR DESCRIPTION
## Summary
- Increase damping and halve shot impulse so snooker balls move realistically
- Nudge camera closer on long sides for consistent table distance
- Slightly shift pull label left above power bar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c084e5d3a48329bcb155348f6133f9