### PR TITLE
Add corner spotlights and shadows to chess board

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -606,9 +606,15 @@ function Chess3D({ avatar, username }) {
     rim.position.set(80, 60, -40);
     scene.add(rim);
     const spotGroup = new THREE.Group();
-    [-10, 0, 10].forEach((x) => {
-      const spot = new THREE.SpotLight(0xffffff, 1.5, 200, Math.PI / 8, 0.4, 1);
-      spot.position.set(x, 120, 40);
+    const halfBoard = (BOARD.N * BOARD.tile) / 2;
+    [
+      [halfBoard, halfBoard],
+      [halfBoard, -halfBoard],
+      [-halfBoard, halfBoard],
+      [-halfBoard, -halfBoard]
+    ].forEach(([x, z]) => {
+      const spot = new THREE.SpotLight(0xffffff, 1.5, 300, Math.PI / 6, 0.45, 1);
+      spot.position.set(x, 120, z);
       spot.target.position.set(0, 0, 0);
       spot.castShadow = true;
       spot.shadow.mapSize.set(1024, 1024);


### PR DESCRIPTION
## Summary
- Illuminate chess board with four corner spotlights for a brighter battle arena
- Ensure pieces and tiles cast and receive shadows for enhanced depth

## Testing
- `npm test`
- `npm run lint` *(fails: 937 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c08de52b0083299097ba6dab97e7bd