### PR TITLE
Increase snooker shot power and ball speed

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -133,8 +133,8 @@ const BALL_R = 2 * BALL_SCALE;
 const POCKET_R = BALL_R * 2; // pockets twice the ball radius
 // slightly larger visual radius so rails align with pocket rings
 const POCKET_VIS_R = POCKET_R / 0.85;
-// increase damping so balls settle quicker
-const FRICTION = 0.97;
+// reduce damping so balls retain speed and roll faster
+const FRICTION = 0.99;
 const STOP_EPS = 0.02;
 const CAPTURE_R = POCKET_R; // pocket capture radius
 const TABLE_Y = -2; // vertical offset to lower entire table
@@ -1161,7 +1161,7 @@ export default function NewSnookerGame() {
           .clone()
           // boost impulse to increase shot power by 50%
           .multiplyScalar(
-            4.2 * (0.48 + powerRef.current * 1.52) * 0.75 * 0.75
+            4.2 * (0.48 + powerRef.current * 1.52) * 0.75 * 0.75 * 1.5
           );
         cue.vel.copy(base);
       };


### PR DESCRIPTION
## Summary
- boost cue impulse by 50% for more powerful shots
- reduce table friction so balls keep moving longer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0fc1bc8708329bb6b75a8a6b9dff8