### PR TITLE
feat: add additional spotlights for chess board

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -607,13 +607,19 @@ function Chess3D({ avatar, username }) {
     scene.add(rim);
     const spotGroup = new THREE.Group();
     const halfBoard = (BOARD.N * BOARD.tile) / 2;
-    [
+    const spotPositions = [
       [halfBoard, halfBoard],
       [halfBoard, -halfBoard],
       [-halfBoard, halfBoard],
-      [-halfBoard, -halfBoard]
-    ].forEach(([x, z]) => {
-      const spot = new THREE.SpotLight(0xffffff, 1.5, 300, Math.PI / 6, 0.45, 1);
+      [-halfBoard, -halfBoard],
+      [0, halfBoard],
+      [0, -halfBoard],
+      [halfBoard, 0],
+      [-halfBoard, 0],
+      [0, 0]
+    ];
+    spotPositions.forEach(([x, z]) => {
+      const spot = new THREE.SpotLight(0xffffff, 1.2, 300, Math.PI / 6, 0.45, 1);
       spot.position.set(x, 120, z);
       spot.target.position.set(0, 0, 0);
       spot.castShadow = true;


### PR DESCRIPTION
## Summary
- brighten chess board by adding central and edge spotlights

## Testing
- `npm test`
- `npm run lint` *(fails: existing lint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c10d4b2a6c832980ea8708d0037166