### PR TITLE
Fix racket orientation in Tennis Battle Royale

### DIFF
--- a/webapp/src/pages/Games/TennisBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TennisBattleRoyal.jsx
@@ -112,6 +112,7 @@ function makeBall(scene) {
 function makeRacket(scene, color) {
   const group = buildDetailedRacket();
   group.rotation.y = Math.PI / 2;
+  group.rotation.x = -Math.PI / 2; // stand racket upright
   const box0 = new THREE.Box3().setFromObject(group);
   const scale = 7.65 / box0.getSize(new THREE.Vector3()).x;
   group.scale.setScalar(scale * 3); // triple-size rackets


### PR DESCRIPTION
## Summary
- Rotate 3D tennis rackets upright so they are oriented for hitting the ball

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1181300cc8329a49747a1a0e6eb91