### PR TITLE
Clamp camera height and tune lighting for snooker

### DIFF
--- a/billiards.Unity/BilliardLighting.cs
+++ b/billiards.Unity/BilliardLighting.cs
@@ -10,7 +10,8 @@ public class BilliardLighting : MonoBehaviour
         Light spotLight = lightObj.AddComponent<Light>();
         spotLight.type = LightType.Spot;
         spotLight.color = Color.white;
-        spotLight.intensity = 2.5f;
+        // Slightly brighter spotlight to better illuminate the table
+        spotLight.intensity = 3.0f;
         spotLight.range = 15f;
         spotLight.spotAngle = 60f;
         spotLight.shadows = LightShadows.Soft;
@@ -23,7 +24,8 @@ public class BilliardLighting : MonoBehaviour
         Material plasticMat = new Material(Shader.Find("Standard"));
         plasticMat.color = Color.red;           // change color per ball as needed
         plasticMat.SetFloat("_Metallic", 0f);   // not metallic
-        plasticMat.SetFloat("_Glossiness", 0.9f); // very shiny surface
+        // Increase glossiness so reflections on the balls appear a touch brighter
+        plasticMat.SetFloat("_Glossiness", 0.95f); // very shiny surface
 
         // Apply material to all objects tagged "Ball"
         GameObject[] balls = GameObject.FindGameObjectsWithTag("Ball");

--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -1,0 +1,37 @@
+#if UNITY_5_3_OR_NEWER
+using UnityEngine;
+
+/// <summary>
+/// Simple camera controller clamping the camera to stay above the table
+/// and limiting how high it can travel.  The camera is also kept a fixed
+/// distance from the table centre so it sits a little closer to the action.
+/// </summary>
+public class CameraController : MonoBehaviour
+{
+    // Y position of the top of the table in world space.
+    public float tableTopY = 0f;
+    // Maximum height the camera is allowed to move above the table.
+    public float maxHeightAboveTable = 3f;
+    // Desired distance of the camera from the table centre.
+    public float distanceFromCenter = 8f;
+
+    private void LateUpdate()
+    {
+        // Clamp vertical movement so the camera never goes below the table
+        // and doesn't fly too high above it.
+        Vector3 pos = transform.position;
+        float minY = tableTopY;
+        float maxY = tableTopY + maxHeightAboveTable;
+        pos.y = Mathf.Clamp(pos.y, minY, maxY);
+
+        // Pull the camera slightly closer to the table by keeping it at a
+        // fixed distance from the origin (assumed table centre).
+        Vector3 flatDir = new Vector3(pos.x, 0f, pos.z).normalized;
+        pos = new Vector3(flatDir.x * distanceFromCenter,
+                          pos.y,
+                          flatDir.z * distanceFromCenter);
+
+        transform.position = pos;
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add camera controller to keep camera above table, limit height, and maintain closer distance to the table
- Brighten spotlight and increase ball glossiness for shinier reflections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1252f1014832985d466b6eb28c8ce