### PR TITLE
Fix tennis racket orientation and string color

### DIFF
--- a/webapp/src/pages/Games/TennisBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TennisBattleRoyal.jsx
@@ -349,13 +349,14 @@ function Tennis3D({ pAvatar }){
 
         // Position rackets
         racketP.group.position.set(player.x, 0, player.z);
-        racketP.group.rotation.y = Math.atan2( (player.aimX*60), 60 );
+        racketP.group.rotation.y = Math.PI / 2 + Math.atan2((player.aimX * 60), 60);
 
         // AI simple track
         ai.cooldown = Math.max(0, ai.cooldown - dt);
         const targetX = THREE.MathUtils.clamp(ball.pos.x, -COURT.W*0.3, COURT.W*0.3);
         ai.x += THREE.MathUtils.clamp(targetX - ai.x, -ai.speed*dt, ai.speed*dt);
         racketA.group.position.set(ai.x, 0, ai.z);
+        racketA.group.rotation.y = Math.PI / 2;
 
         // Ball physics
         if(phase==='serve' && keys.current['Space'] && !charging){ charging=true; }

--- a/webapp/src/utils/tennisGear.js
+++ b/webapp/src/utils/tennisGear.js
@@ -25,7 +25,7 @@ function overgripMaterial() {
 
 function stringMaterial() {
   return new THREE.MeshStandardMaterial({
-    color: 0xe8e8e8,
+    color: 0xffff00,
     roughness: 0.6,
     metalness: 0.0,
   });


### PR DESCRIPTION
## Summary
- Keep player racket horizontal like opponent and reset AI orientation each frame
- Use yellow material for tennis racket strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1292063288329b435c752a8c17d4c