### PR TITLE
feat: brighten snooker lighting

### DIFF
--- a/billiards.Unity/BilliardLighting.cs
+++ b/billiards.Unity/BilliardLighting.cs
@@ -5,14 +5,15 @@ public class BilliardLighting : MonoBehaviour
 {
     void Start()
     {
-        // Create three spot lights in an arc so the balls show three tiny
-        // reflections. Each light is offset slightly to leave a small gap
-        // between highlights and is made a touch brighter than before.
+        // Create three spot lights in a very subtle arc so the balls show
+        // three tiny reflections. Each light is offset slightly to leave a
+        // small gap between highlights and is made a touch brighter than before.
         Vector3[] lightPositions =
         {
-            new Vector3(-0.5f, 5f, 0f),
+            // outer lights are pulled back a little on the Z axis to form the arc
+            new Vector3(-0.5f, 5f, -0.2f),
             new Vector3(0f, 5f, 0f),
-            new Vector3(0.5f, 5f, 0f)
+            new Vector3(0.5f, 5f, -0.2f)
         };
 
         foreach (Vector3 pos in lightPositions)
@@ -22,7 +23,7 @@ public class BilliardLighting : MonoBehaviour
             spotLight.type = LightType.Spot;
             spotLight.color = Color.white;
             // Slightly brighter spotlight to better illuminate the table
-            spotLight.intensity = 3.2f;
+            spotLight.intensity = 3.5f;
             spotLight.range = 15f;
             spotLight.spotAngle = 60f;
             spotLight.shadows = LightShadows.Soft;
@@ -38,6 +39,8 @@ public class BilliardLighting : MonoBehaviour
         plasticMat.SetFloat("_Metallic", 0f);   // not metallic
         // Increase glossiness so reflections on the balls appear brighter
         plasticMat.SetFloat("_Glossiness", 1f); // extremely shiny surface
+        // Slightly boost specular color so highlights appear a bit brighter
+        plasticMat.SetColor("_SpecColor", Color.white * 1.1f);
 
         // Apply material to all objects tagged "Ball"
         GameObject[] balls = GameObject.FindGameObjectsWithTag("Ball");


### PR DESCRIPTION
## Summary
- brighten snooker spotlights and arrange them in a subtle arc
- boost ball specular highlights for shinier reflections

## Testing
- `npm test`
- `npm run lint` *(fails: 937 problems, e.g., extra semicolon in snooker-power-slider.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c12e96345c832995a863a41d1417fe