### PR TITLE
Improve camera limits and ball brightness

### DIFF
--- a/billiards.Unity/BilliardLighting.cs
+++ b/billiards.Unity/BilliardLighting.cs
@@ -10,9 +10,10 @@ public class BilliardLighting : MonoBehaviour
         plasticMat.color = Color.red;           // change color per ball as needed
         plasticMat.SetFloat("_Metallic", 0f);   // not metallic
         // Make the balls a bit shinier and brighter
-        plasticMat.color *= 1.15f;
-        plasticMat.SetFloat("_Glossiness", 0.95f);
-        plasticMat.SetColor("_SpecColor", Color.white * 1.3f);
+        // Slightly boost base colour and specular highlights for more sheen.
+        plasticMat.color *= 1.2f;
+        plasticMat.SetFloat("_Glossiness", 0.97f);
+        plasticMat.SetColor("_SpecColor", Color.white * 1.4f);
 
         // Apply material and attach small point lights to each ball
         GameObject[] balls = GameObject.FindGameObjectsWithTag("Ball");

--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -10,14 +10,17 @@ public class CameraController : MonoBehaviour
 {
     // Y position of the top of the table in world space.
     public float tableTopY = 0f;
-    // Height of the top of the wooden side rails in world space.
-    public float railTopY = 0.3f;
+    // Height of the top of the wooden side rails in world space.  Slightly raised
+    // to keep the camera from dipping too low relative to the table frame.
+    public float railTopY = 0.33f;
     // Small clearance so the camera always remains a little above the side rails.
-    public float railClearance = 0.05f;
+    // Increased slightly so the camera stops a bit sooner when moving down.
+    public float railClearance = 0.08f;
     // How far above the rails the camera is allowed to travel.
     public float maxHeightAboveTable = 2.2f;
-    // The closest distance the camera can zoom towards the centre.
-    public float minDistanceFromCenter = 5.5f;
+    // The closest distance the camera can zoom towards the centre.  Reduced
+    // to allow a touch more zoom when the user pulls the camera down.
+    public float minDistanceFromCenter = 5.2f;
     // Desired default distance of the camera from the table centre.
     public float distanceFromCenter = 6.5f;
     // Slight height offset so the camera looks just above the table centre


### PR DESCRIPTION
## Summary
- Allow camera to zoom slightly closer when pulled down and stop just above higher rails
- Raise rail height/clearance to keep camera from dipping too low
- Boost ball material brightness and gloss for shinier appearance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1506ea9fc8329aa65bdd6b6aef9c1