### PR TITLE
feat(snooker): track break statistics

### DIFF
--- a/src/core/Referee.ts
+++ b/src/core/Referee.ts
@@ -84,11 +84,19 @@ export class Referee {
     }
 
     newState.players[newState.activePlayer].score += scored;
+    if (scored > 0) {
+      newState.currentBreak = (newState.currentBreak || 0) + scored;
+      const p = newState.players[newState.activePlayer];
+      if ((p.highestBreak || 0) < newState.currentBreak) {
+        p.highestBreak = newState.currentBreak;
+      }
+    }
 
     // update next balls
     newState.ballOn = this.rules.computeLegalNext(newState);
 
     if (scored === 0) {
+      newState.currentBreak = 0;
       // turn over
       newState.activePlayer = newState.activePlayer === 'A' ? 'B' : 'A';
       if (newState.phase === 'REDS_AND_COLORS') {
@@ -120,6 +128,7 @@ export class Referee {
     newState.players[opponent].score += points;
     newState.activePlayer = opponent;
     newState.freeBall = false;
+    newState.currentBreak = 0;
     if (newState.phase === 'REDS_AND_COLORS') newState.colorOnAfterRed = false;
     newState.ballOn = this.rules.computeLegalNext(newState);
     return newState;

--- a/src/rules/SnookerRules.ts
+++ b/src/rules/SnookerRules.ts
@@ -27,13 +27,14 @@ export class SnookerRules {
       balls.push({ id: c, color: c, onTable: true, potted: false });
     }
     const players: { A: Player; B: Player } = {
-      A: { id: 'A', name: pA, score: 0 },
-      B: { id: 'B', name: pB, score: 0 },
+      A: { id: 'A', name: pA, score: 0, highestBreak: 0 },
+      B: { id: 'B', name: pB, score: 0, highestBreak: 0 },
     };
     return {
       balls,
       activePlayer: 'A',
       players,
+      currentBreak: 0,
       phase: 'REDS_AND_COLORS',
       redsRemaining: 15,
       colorOnAfterRed: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,13 +9,19 @@ export interface Ball {
   position?: { x:number; y:number };
 }
 
-export interface Player { id:string; name:string; score:number; }
+export interface Player {
+  id:string;
+  name:string;
+  score:number;
+  highestBreak?:number;
+}
 export type Phase = 'OPENING'|'REDS_AND_COLORS'|'COLORS_ORDER';
 
 export interface FrameState {
   balls: Ball[];
   activePlayer: 'A'|'B';
   players: { A:Player; B:Player };
+  currentBreak?: number;
   phase: Phase;
   redsRemaining: number;
   colorOnAfterRed?: boolean;

--- a/tests/snooker.test.ts
+++ b/tests/snooker.test.ts
@@ -54,6 +54,28 @@ describe('Snooker core', () => {
     expect(state.players.A.score).toBe(8);
   });
 
+  test('tracks current and highest break', () => {
+    const rules = new SnookerRules();
+    const ref = new Referee(rules);
+    let state = rules.getInitialFrame('p1', 'p2');
+    state = ref.applyShot(state, [
+      { type: 'HIT', firstContact: 'RED' },
+      { type: 'POTTED', ball: 'RED', pocket },
+    ]);
+    state = ref.applyShot(state, [
+      { type: 'HIT', firstContact: 'BLACK' },
+      { type: 'POTTED', ball: 'BLACK', pocket },
+    ]);
+    expect(state.currentBreak).toBe(8);
+    expect(state.players.A.highestBreak).toBe(8);
+    state = ref.applyShot(state, [
+      { type: 'HIT', firstContact: 'RED' },
+    ]);
+    expect(state.currentBreak).toBe(0);
+    expect(state.activePlayer).toBe('B');
+    expect(state.players.A.highestBreak).toBe(8);
+  });
+
   test('foul minimum four when red on', () => {
     const rules = new SnookerRules();
     const ref = new Referee(rules);


### PR DESCRIPTION
## Summary
- track current and highest breaks in snooker frame state and players
- update referee to maintain break stats and reset on fouls or misses
- cover break tracking with new unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c156750b908329971fba292f61c6f4