### PR TITLE
feat(snooker): add scoring and improve camera & aiming

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -26,6 +26,11 @@ public class CameraController : MonoBehaviour
     // Slight height offset so the camera looks just above the table centre
     // to reduce the viewing angle and give a lower perspective.
     public float lookAtHeightOffset = 0.05f;
+    // When the camera moves close to the table corners pull back slightly so
+    // the rails remain visible and aiming is easier.
+    public float cornerXThreshold = 2.6f;
+    public float cornerZThreshold = 1.3f;
+    public float cornerPullback = 0.5f;
 
     private void LateUpdate()
     {
@@ -41,6 +46,13 @@ public class CameraController : MonoBehaviour
         // the centre, revealing the rails at the bottom of the screen.
         float t = Mathf.InverseLerp(maxY, minY, pos.y);
         float currentDistance = Mathf.Lerp(distanceFromCenter, minDistanceFromCenter, t);
+
+        // If the camera is near a corner, increase the distance a little to
+        // give the player a better view of the shot.
+        if (Mathf.Abs(pos.x) > cornerXThreshold && Mathf.Abs(pos.z) > cornerZThreshold)
+        {
+            currentDistance += cornerPullback;
+        }
 
         // Keep the camera at a fixed distance from the origin (assumed table
         // centre) while applying the calculated zoom factor.

--- a/billiards.Unity/DemoBehaviour.cs
+++ b/billiards.Unity/DemoBehaviour.cs
@@ -7,8 +7,15 @@ using Billiards;
 public class DemoBehaviour : MonoBehaviour
 {
     public LineRenderer Line;
+    // Reference to the cue ball so the aim direction can be calculated
+    public Transform CueBall;
+    // How quickly the aiming line follows the pointer (higher is snappier)
+    public float aimSmoothing = 12f;
+    public float previewSpeed = 2.0f;
+
     private BilliardsSolver solver = new BilliardsSolver();
     private List<BilliardsSolver.Ball> balls = new List<BilliardsSolver.Ball>();
+    private Vec2 currentDir = new Vec2(1, 0);
 
     private void Start()
     {
@@ -18,11 +25,17 @@ public class DemoBehaviour : MonoBehaviour
 
     private void Update()
     {
-        if (Input.GetMouseButton(0))
+        if (Input.GetMouseButton(0) && CueBall != null)
         {
-            var start = ScreenToWorld.FromScreen(Camera.main, Input.mousePosition);
-            var dir = new Vec2(1, 0); // placeholder, normally from cue direction
-            var preview = AimPreview.Build(solver, start, dir, 2.0, balls);
+            // Convert cue ball and target positions to solver coordinates
+            var cueStart = new Vec2(CueBall.position.x, CueBall.position.y);
+            var target = ScreenToWorld.FromScreen(Camera.main, Input.mousePosition);
+
+            // Smoothly adjust the aiming direction towards the chosen target
+            var desiredDir = (target - cueStart).Normalized();
+            currentDir = (currentDir + (desiredDir - currentDir) * Time.deltaTime * aimSmoothing).Normalized();
+
+            var preview = AimPreview.Build(solver, cueStart, currentDir, previewSpeed, balls);
             Line.positionCount = preview.Path.Length;
             for (int i = 0; i < preview.Path.Length; i++)
             {

--- a/billiards.Unity/SnookerGameManager.cs
+++ b/billiards.Unity/SnookerGameManager.cs
@@ -1,0 +1,51 @@
+#if UNITY_5_3_OR_NEWER
+using UnityEngine;
+using System.Collections.Generic;
+
+/// <summary>
+/// Basic snooker scoring and game state manager. Keeps track of the
+/// player's score and only ends the game when the target score has been
+/// reached. Ball values roughly match standard snooker rules.
+/// </summary>
+public class SnookerGameManager : MonoBehaviour
+{
+    public int targetScore = 50;
+    public int CurrentScore { get; private set; }
+    public bool GameOver => CurrentScore >= targetScore;
+
+    private readonly Dictionary<string, int> ballValues = new Dictionary<string, int>
+    {
+        {"red", 1},
+        {"yellow", 2},
+        {"green", 3},
+        {"brown", 4},
+        {"blue", 5},
+        {"pink", 6},
+        {"black", 7}
+    };
+
+    /// <summary>
+    /// Call when a ball has been potted. The colour name is matched to the
+    /// standard snooker point table. The game continues until the target
+    /// score is reached.
+    /// </summary>
+    public void PotBall(string colour)
+    {
+        if (GameOver) return;
+        if (ballValues.TryGetValue(colour.ToLowerInvariant(), out int value))
+        {
+            CurrentScore += value;
+        }
+        if (GameOver)
+        {
+            Debug.Log("Game over - target score reached");
+        }
+    }
+
+    /// <summary>Reset score so a new match can begin.</summary>
+    public void ResetGame()
+    {
+        CurrentScore = 0;
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- implement snooker scoring manager that tracks points until target score
- tweak camera controller to pull back slightly at table corners
- refine aiming behaviour to point at clicked ball and smooth adjustments

## Testing
- `dotnet test billiards.Tests`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17349d65c8329940d5b3add409b50