### PR TITLE
Improve snooker game logic and controls

### DIFF
--- a/billiards.Tests/SnookerGameStateTests.cs
+++ b/billiards.Tests/SnookerGameStateTests.cs
@@ -45,5 +45,18 @@ namespace Billiards.Tests
 
             Assert.That(state.GameOver, Is.True);
         }
+
+        [Test]
+        public void GameEndsWhenTargetScoreReached()
+        {
+            var state = new SnookerGameState();
+            state.ResetGame(0, 10);
+
+            state.Foul(7);
+            Assert.That(state.GameOver, Is.False);
+
+            state.Foul(7);
+            Assert.That(state.GameOver, Is.True);
+        }
     }
 }

--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -32,6 +32,10 @@ public class CameraController : MonoBehaviour
     public float cornerXThreshold = 2.6f;
     public float cornerZThreshold = 1.3f;
     public float cornerPullback = 0.5f;
+    // Optional reference to the active player (usually the cue ball). When set,
+    // corner pullback is based on the player's position instead of the camera
+    // so that approaching a rail gives a better view of the shot.
+    public Transform player;
 
     private void LateUpdate()
     {
@@ -47,9 +51,11 @@ public class CameraController : MonoBehaviour
         float t = Mathf.InverseLerp(maxY, minY, pos.y);
         float currentDistance = distanceFromCenter + pullbackWhenLow * t;
 
-        // If the camera is near a corner, increase the distance a little to
-        // give the player a better view of the shot.
-        if (Mathf.Abs(pos.x) > cornerXThreshold && Mathf.Abs(pos.z) > cornerZThreshold)
+        // If the player (or the camera if no player reference is set) moves
+        // close to a corner, increase the distance a little to give a clearer
+        // overview of the rails.
+        Vector3 cornerPos = player != null ? player.position : pos;
+        if (Mathf.Abs(cornerPos.x) > cornerXThreshold && Mathf.Abs(cornerPos.z) > cornerZThreshold)
         {
             currentDistance += cornerPullback;
         }

--- a/billiards.Unity/SnookerGameManager.cs
+++ b/billiards.Unity/SnookerGameManager.cs
@@ -12,6 +12,9 @@ public class SnookerGameManager : MonoBehaviour
 {
     // Number of reds to begin a frame with.
     public int redsInFrame = 15;
+    // Optional winning score for the match. A value of zero means the frame
+    // ends when all balls are cleared.
+    public int targetScore = 0;
 
     public SnookerGameState State { get; private set; } = new SnookerGameState();
 
@@ -21,7 +24,7 @@ public class SnookerGameManager : MonoBehaviour
 
     private void Awake()
     {
-        State.ResetGame(redsInFrame);
+        State.ResetGame(redsInFrame, targetScore);
     }
 
     /// <summary>Call when a ball has been legally potted.</summary>
@@ -36,7 +39,7 @@ public class SnookerGameManager : MonoBehaviour
     /// <summary>Reset the frame back to its initial state.</summary>
     public void ResetGame()
     {
-        State.ResetGame(redsInFrame);
+        State.ResetGame(redsInFrame, targetScore);
     }
 }
 #endif

--- a/billiards/ScreenToWorld.cs
+++ b/billiards/ScreenToWorld.cs
@@ -4,11 +4,23 @@ namespace Billiards;
 public static class ScreenToWorld
 {
 #if UNITY_5_3_OR_NEWER
-    /// <summary>Unity wrapper using the active camera.</summary>
-    public static Vec2 FromScreen(UnityEngine.Camera cam, UnityEngine.Vector2 screen)
+    /// <summary>Unity wrapper that projects the pointer onto the table plane.</summary>
+    /// <param name="cam">Camera used for the projection.</param>
+    /// <param name="screen">Screen position in pixels.</param>
+    /// <param name="planeY">Y position of the table plane in world units.</param>
+    public static Vec2 FromScreen(UnityEngine.Camera cam, UnityEngine.Vector2 screen, float planeY = 0f)
     {
-        var p = cam.ScreenToWorldPoint(new UnityEngine.Vector3((float)screen.x, (float)screen.y, 0));
-        return new Vec2(p.x, p.y);
+        var ray = cam.ScreenPointToRay(new UnityEngine.Vector3(screen.x, screen.y, 0f));
+        var plane = new UnityEngine.Plane(UnityEngine.Vector3.up, new UnityEngine.Vector3(0f, planeY, 0f));
+        if (plane.Raycast(ray, out float enter))
+        {
+            var hit = ray.GetPoint(enter);
+            // In Unity the table lies on the XZ plane, so map to Vec2 accordingly.
+            return new Vec2(hit.x, hit.z);
+        }
+        // Fallback to old behaviour if the ray does not intersect the plane.
+        var p = cam.ScreenToWorldPoint(new UnityEngine.Vector3(screen.x, screen.y, cam.nearClipPlane));
+        return new Vec2(p.x, p.z);
     }
 #endif
 

--- a/billiards/SnookerGameState.cs
+++ b/billiards/SnookerGameState.cs
@@ -28,25 +28,33 @@ namespace TonPlaygram.Billiards
         private int _redsRemaining;
         private bool _expectingColour;
         private int _colourIndex;
+        private int _targetScore;
 
         /// <summary>Scores for the two players.</summary>
         public int[] Scores { get; } = new int[2];
 
+        /// <summary>Optional score limit that must be reached to win the game.</summary>
+        public int TargetScore => _targetScore;
+
         /// <summary>Index of the active player: 0 or 1.</summary>
         public int CurrentPlayer { get; private set; }
 
-        /// <summary>True once all balls have been correctly potted.</summary>
-        public bool GameOver => _redsRemaining == 0 && _colourIndex >= _colourOrder.Length;
+        /// <summary>True once a player reaches the target score or all balls are cleared.</summary>
+        public bool GameOver =>
+            (_targetScore > 0 && (Scores[0] >= _targetScore || Scores[1] >= _targetScore)) ||
+            (_redsRemaining == 0 && _colourIndex >= _colourOrder.Length);
 
         /// <summary>Reset the match to its initial state.</summary>
         /// <param name="reds">Number of reds to begin with, normally 15.</param>
-        public void ResetGame(int reds = 15)
+        /// <param name="targetScore">Optional score to reach before the game ends.</param>
+        public void ResetGame(int reds = 15, int targetScore = 0)
         {
             Scores[0] = Scores[1] = 0;
             CurrentPlayer = 0;
             _redsRemaining = reds;
             _expectingColour = false;
             _colourIndex = 0;
+            _targetScore = targetScore;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Add optional target score to snooker game state and manager
- Adjust camera to pull back when player nears corners
- Fix aim handling by projecting screen clicks to table plane

## Testing
- `dotnet test billiards.Tests/Billiards.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c17a4b8d588329961699ebb8bd8e52