### PR TITLE
Improve snooker scoring and controls

### DIFF
--- a/billiards.Tests/SnookerGameStateTests.cs
+++ b/billiards.Tests/SnookerGameStateTests.cs
@@ -58,5 +58,22 @@ namespace Billiards.Tests
             state.Foul(7);
             Assert.That(state.GameOver, Is.True);
         }
+
+        [Test]
+        public void ClearingBallsDoesNotEndGameBeforeTargetScore()
+        {
+            var state = new SnookerGameState();
+            // Set a target higher than the available points on the table so
+            // the frame would normally be cleared without ending.
+            state.ResetGame(0, 100);
+
+            string[] order = {"yellow", "green", "brown", "blue", "pink", "black"};
+            foreach (var c in order)
+            {
+                state.PotBall(c);
+            }
+
+            Assert.That(state.GameOver, Is.False);
+        }
     }
 }

--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -32,6 +32,10 @@ public class CameraController : MonoBehaviour
     public float cornerXThreshold = 2.6f;
     public float cornerZThreshold = 1.3f;
     public float cornerPullback = 0.5f;
+    // Range beyond the thresholds where the pullback gradually reaches the
+    // maximum value.  This avoids a sudden jump in zoom when approaching a
+    // corner and gives a smoother transition.
+    public float cornerBlendRange = 0.4f;
     // Optional reference to the active player (usually the cue ball). When set,
     // corner pullback is based on the player's position instead of the camera
     // so that approaching a rail gives a better view of the shot.
@@ -57,7 +61,10 @@ public class CameraController : MonoBehaviour
         Vector3 cornerPos = player != null ? player.position : pos;
         if (Mathf.Abs(cornerPos.x) > cornerXThreshold && Mathf.Abs(cornerPos.z) > cornerZThreshold)
         {
-            currentDistance += cornerPullback;
+            float xFactor = Mathf.InverseLerp(cornerXThreshold, cornerXThreshold + cornerBlendRange, Mathf.Abs(cornerPos.x));
+            float zFactor = Mathf.InverseLerp(cornerZThreshold, cornerZThreshold + cornerBlendRange, Mathf.Abs(cornerPos.z));
+            float blend = Mathf.Min(xFactor, zFactor);
+            currentDistance += cornerPullback * Mathf.Clamp01(blend);
         }
 
         // Keep the camera at a fixed distance from the origin (assumed table

--- a/billiards.Unity/DemoBehaviour.cs
+++ b/billiards.Unity/DemoBehaviour.cs
@@ -9,9 +9,10 @@ public class DemoBehaviour : MonoBehaviour
     public LineRenderer Line;
     // Reference to the cue ball so the aim direction can be calculated
     public Transform CueBall;
-    // How quickly the aiming line follows the pointer. Lower values make
-    // smaller adjustments for more precise shots.
-    public float aimSmoothing = 8f;
+    // How quickly the aiming line follows the pointer.  Lower values make
+    // smaller adjustments for more precise shots so the player can line up
+    // accurate shots without the aim jumping in large steps.
+    public float aimSmoothing = 4f;
     public float previewSpeed = 2.0f;
 
     private BilliardsSolver solver = new BilliardsSolver();
@@ -47,7 +48,7 @@ public class DemoBehaviour : MonoBehaviour
         if (Input.GetMouseButton(0))
         {
             // Smoothly adjust the aim for small pointer movements.
-            float smoothingFactor = 1f - Mathf.Exp(-Time.deltaTime * aimSmoothing);
+            float smoothingFactor = Mathf.Clamp01(1f - Mathf.Exp(-Time.deltaTime * aimSmoothing));
             currentDir = (currentDir + (desiredDir - currentDir) * smoothingFactor).Normalized();
 
             var preview = AimPreview.Build(solver, cueStart, currentDir, previewSpeed, balls);

--- a/billiards/SnookerGameState.cs
+++ b/billiards/SnookerGameState.cs
@@ -39,10 +39,13 @@ namespace TonPlaygram.Billiards
         /// <summary>Index of the active player: 0 or 1.</summary>
         public int CurrentPlayer { get; private set; }
 
-        /// <summary>True once a player reaches the target score or all balls are cleared.</summary>
-        public bool GameOver =>
-            (_targetScore > 0 && (Scores[0] >= _targetScore || Scores[1] >= _targetScore)) ||
-            (_redsRemaining == 0 && _colourIndex >= _colourOrder.Length);
+        /// <summary>
+        /// True once a player reaches the target score. If no target score is
+        /// provided the frame ends only after all balls have been cleared.
+        /// </summary>
+        public bool GameOver => _targetScore > 0
+            ? (Scores[0] >= _targetScore || Scores[1] >= _targetScore)
+            : (_redsRemaining == 0 && _colourIndex >= _colourOrder.Length);
 
         /// <summary>Reset the match to its initial state.</summary>
         /// <param name="reds">Number of reds to begin with, normally 15.</param>


### PR DESCRIPTION
## Summary
- ensure frames only end when target score is reached
- smooth camera pullback near table corners
- refine aim preview for more precise shots

## Testing
- `dotnet test billiards.Tests/Billiards.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c17f144d7c8329a45fd8bfd6c3dd51