### PR TITLE
Improve Snooker camera aiming and cue rendering

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -20,9 +20,12 @@ function makeFbmHeightCanvas(size = 512, octaves = 5) {
   const ctx = c.getContext('2d');
   const img = ctx.createImageData(size, size);
   function valueNoise(grid, x, y) {
-    const x0 = Math.floor(x), y0 = Math.floor(y);
-    const x1 = x0 + 1, y1 = y0 + 1;
-    const sx = x - x0, sy = y - y0;
+    const x0 = Math.floor(x),
+      y0 = Math.floor(y);
+    const x1 = x0 + 1,
+      y1 = y0 + 1;
+    const sx = x - x0,
+      sy = y - y0;
     const v00 = grid[(y0 & 255) * 256 + (x0 & 255)];
     const v10 = grid[(y0 & 255) * 256 + (x1 & 255)];
     const v01 = grid[(y1 & 255) * 256 + (x0 & 255)];
@@ -39,11 +42,18 @@ function makeFbmHeightCanvas(size = 512, octaves = 5) {
   const gain = 0.52;
   for (let y = 0; y < size; y++) {
     for (let x = 0; x < size; x++) {
-      let amp = 1, freq = 1 / 24, sum = 0, norm = 0;
+      let amp = 1,
+        freq = 1 / 24,
+        sum = 0,
+        norm = 0;
       for (let o = 0; o < octaves; o++) {
-        const nx = x * freq, ny = y * freq;
+        const nx = x * freq,
+          ny = y * freq;
         const v = valueNoise(grid, nx, ny);
-        sum += v * amp; norm += amp; amp *= gain; freq *= lacunarity;
+        sum += v * amp;
+        norm += amp;
+        amp *= gain;
+        freq *= lacunarity;
       }
       let h = sum / norm;
       h = Math.pow(h, 1.25);
@@ -57,22 +67,30 @@ function makeFbmHeightCanvas(size = 512, octaves = 5) {
 }
 
 function heightToNormalCanvas(heightCanvas, strength = 2.0) {
-  const w = heightCanvas.width, h = heightCanvas.height;
+  const w = heightCanvas.width,
+    h = heightCanvas.height;
   const src = heightCanvas.getContext('2d').getImageData(0, 0, w, h).data;
   const c = document.createElement('canvas');
-  c.width = w; c.height = h;
+  c.width = w;
+  c.height = h;
   const ctx = c.getContext('2d');
   const out = ctx.createImageData(w, h);
-  const get = (x, y) => src[((((y + h) % h) * w + ((x + w) % w)) << 2)];
+  const get = (x, y) => src[(((y + h) % h) * w + ((x + w) % w)) << 2];
   for (let y = 0; y < h; y++) {
     for (let x = 0; x < w; x++) {
-      const hL = get(x - 1, y), hR = get(x + 1, y);
-      const hD = get(x, y + 1), hU = get(x, y - 1);
-      const dx = (hR - hL) / 255 * strength;
-      const dy = (hD - hU) / 255 * strength;
-      let nx = -dx, ny = -dy, nz = 1.0;
+      const hL = get(x - 1, y),
+        hR = get(x + 1, y);
+      const hD = get(x, y + 1),
+        hU = get(x, y - 1);
+      const dx = ((hR - hL) / 255) * strength;
+      const dy = ((hD - hU) / 255) * strength;
+      let nx = -dx,
+        ny = -dy,
+        nz = 1.0;
       const invLen = 1.0 / Math.sqrt(nx * nx + ny * ny + nz * nz);
-      nx *= invLen; ny *= invLen; nz *= invLen;
+      nx *= invLen;
+      ny *= invLen;
+      nz *= invLen;
       const i = (y * w + x) * 4;
       out.data[i + 0] = Math.floor((nx * 0.5 + 0.5) * 255);
       out.data[i + 1] = Math.floor((ny * 0.5 + 0.5) * 255);
@@ -84,17 +102,28 @@ function heightToNormalCanvas(heightCanvas, strength = 2.0) {
   return c;
 }
 
-function makeColorCanvasFromHeight(heightCanvas, c0 = '#1a8f2f', c1 = '#23b043', variation = 0.08) {
-  const w = heightCanvas.width, h = heightCanvas.height;
+function makeColorCanvasFromHeight(
+  heightCanvas,
+  c0 = '#1a8f2f',
+  c1 = '#23b043',
+  variation = 0.08
+) {
+  const w = heightCanvas.width,
+    h = heightCanvas.height;
   const src = heightCanvas.getContext('2d').getImageData(0, 0, w, h).data;
   const c = document.createElement('canvas');
-  c.width = w; c.height = h;
+  c.width = w;
+  c.height = h;
   const ctx = c.getContext('2d');
   const out = ctx.createImageData(w, h);
-  const ca = new THREE.Color(c0), cb = new THREE.Color(c1);
+  const ca = new THREE.Color(c0),
+    cb = new THREE.Color(c1);
   for (let i = 0; i < w * h; i++) {
     const v = src[i * 4] / 255;
-    const t = Math.min(1, Math.max(0, v * (1 + (Math.random() - 0.5) * variation)));
+    const t = Math.min(
+      1,
+      Math.max(0, v * (1 + (Math.random() - 0.5) * variation))
+    );
     const col = ca.clone().lerp(cb, t);
     out.data[i * 4 + 0] = Math.floor(col.r * 255);
     out.data[i * 4 + 1] = Math.floor(col.g * 255);
@@ -347,7 +376,10 @@ function Table3D(scene) {
     depth: TABLE.THICK,
     bevelEnabled: false
   });
-  extrude.setAttribute('uv2', new THREE.BufferAttribute(extrude.attributes.uv.array, 2));
+  extrude.setAttribute(
+    'uv2',
+    new THREE.BufferAttribute(extrude.attributes.uv.array, 2)
+  );
   const cloth = new THREE.Mesh(extrude, clothMat);
   cloth.rotation.x = -Math.PI / 2;
   cloth.position.y = -TABLE.THICK;
@@ -448,7 +480,10 @@ function Table3D(scene) {
     wood.rotation.x = -Math.PI / 2; // lay wood horizontally
     group.add(wood);
     const clothGeo = railGeometry(len);
-    clothGeo.setAttribute('uv2', new THREE.BufferAttribute(clothGeo.attributes.uv.array, 2));
+    clothGeo.setAttribute(
+      'uv2',
+      new THREE.BufferAttribute(clothGeo.attributes.uv.array, 2)
+    );
     // full-size cushion so all side faces remain green
     const cloth = new THREE.Mesh(clothGeo, cushionMat);
     cloth.rotation.x = -Math.PI / 2; // green faces play field
@@ -467,7 +502,12 @@ function Table3D(scene) {
   addRail(rightX, halfH - POCKET_VIS_R - vertSeg / 2, vertSeg, false);
 
   // Plastic pocket jaws around the pockets (outside the cloth)
-  const jawGeo = new THREE.TorusGeometry(POCKET_VIS_R * 0.85, railW * 0.3, 16, 32);
+  const jawGeo = new THREE.TorusGeometry(
+    POCKET_VIS_R * 0.85,
+    railW * 0.3,
+    16,
+    32
+  );
   const jawMat = new THREE.MeshStandardMaterial({
     color: 0xffffff,
     metalness: 0.2,
@@ -786,29 +826,32 @@ export default function NewSnookerGame() {
         Math.PI
       );
       const updateCamera = () => {
-        const target = new THREE.Vector3(
-          playerOffsetRef.current,
+        const cuePos = cue?.pos ?? new THREE.Vector2(0, 0);
+        const base = new THREE.Vector3(
+          cuePos.x + playerOffsetRef.current,
           TABLE_Y + 0.05,
-          0
+          cuePos.y
         );
         if (topViewRef.current) {
           camera.position.set(0, sph.radius, 0);
-          camera.lookAt(target);
+          camera.lookAt(base);
         } else {
-          camera.position.setFromSpherical(sph).add(target);
-          camera.lookAt(target);
+          camera.position.setFromSpherical(sph).add(base);
+          const look = base
+            .clone()
+            .add(
+              new THREE.Vector3(aimDirRef.current.x, 0, aimDirRef.current.y)
+            );
+          camera.lookAt(look);
         }
       };
       const fit = (m = 1.1) => {
         camera.aspect = host.clientWidth / host.clientHeight;
         const baseR = fitRadius(camera, m);
-        let t =
-          (sph.phi - CAMERA.minPhi) / (CAMERA.maxPhi - CAMERA.minPhi);
+        let t = (sph.phi - CAMERA.minPhi) / (CAMERA.maxPhi - CAMERA.minPhi);
         let r = baseR * (1 - 0.12 * t);
         const railLimit = TABLE.THICK + 0.4; // stay above side rails
-        const phiCap = Math.acos(
-          THREE.MathUtils.clamp(railLimit / r, -1, 1)
-        );
+        const phiCap = Math.acos(THREE.MathUtils.clamp(railLimit / r, -1, 1));
         sph.phi = clamp(
           sph.phi,
           CAMERA.minPhi,
@@ -879,11 +922,7 @@ export default function NewSnookerGame() {
           drag.x = x;
           drag.y = y;
           sph.theta -= dx * 0.005;
-          sph.radius = clamp(
-            sph.radius - dy * 0.5,
-            CAMERA.minR,
-            CAMERA.maxR
-          );
+          sph.radius = clamp(sph.radius - dy * 0.5, CAMERA.minR, CAMERA.maxR);
           updateCamera();
         }
       };
@@ -913,17 +952,9 @@ export default function NewSnookerGame() {
         if (e.code === 'ArrowLeft') sph.theta += step;
         else if (e.code === 'ArrowRight') sph.theta -= step;
         else if (e.code === 'ArrowUp')
-          sph.phi = clamp(
-          sph.phi - step,
-          CAMERA.minPhi,
-          CAMERA.maxPhi
-        );
+          sph.phi = clamp(sph.phi - step, CAMERA.minPhi, CAMERA.maxPhi);
         else if (e.code === 'ArrowDown')
-          sph.phi = clamp(
-          sph.phi + step,
-          CAMERA.minPhi,
-          CAMERA.maxPhi
-        );
+          sph.phi = clamp(sph.phi + step, CAMERA.minPhi, CAMERA.maxPhi);
         else return;
         fit(window.innerHeight > window.innerWidth ? 1.2 : 1.0);
       };
@@ -1022,7 +1053,7 @@ export default function NewSnookerGame() {
 
       // Cue image
       const cueTex = new THREE.TextureLoader().load(
-        '/assets/cue.png'
+        '/assets/icons/file_0000000019d86243a2f7757076cd7869.webp'
       );
       const cueLen = BALL_R * 20;
       const cueMesh = new THREE.Mesh(
@@ -1055,9 +1086,9 @@ export default function NewSnookerGame() {
         return new THREE.Vector2(pt.x, pt.z);
       };
 
-        const aimDir = aimDirRef.current;
-        const camFwd = new THREE.Vector3();
-        const tmpAim = new THREE.Vector2();
+      const aimDir = aimDirRef.current;
+      const camFwd = new THREE.Vector3();
+      const tmpAim = new THREE.Vector2();
 
       // In-hand placement
       const free = (x, z) =>
@@ -1214,12 +1245,12 @@ export default function NewSnookerGame() {
       }
 
       // Loop
-        const step = () => {
-          camera.getWorldDirection(camFwd);
-          tmpAim.set(camFwd.x, camFwd.z).normalize();
-          aimDir.lerp(tmpAim, 0.2);
-          // Aiming vizual
-          if (allStopped(balls) && !hud.inHand && cue?.active && !hud.over) {
+      const step = () => {
+        camera.getWorldDirection(camFwd);
+        tmpAim.set(-camFwd.x, -camFwd.z).normalize();
+        aimDir.lerp(tmpAim, 0.2);
+        // Aiming vizual
+        if (allStopped(balls) && !hud.inHand && cue?.active && !hud.over) {
           const { impact, afterDir, targetBall, railNormal } = calcTarget(
             cue,
             aimDir,
@@ -1341,6 +1372,7 @@ export default function NewSnookerGame() {
           const edge = Math.min(1, Math.max(edgeX, edgeY) / 5);
           fit(1 + edge * 0.08);
         }
+        updateCamera();
         renderer.render(scene, camera);
         rafRef.current = requestAnimationFrame(step);
       };
@@ -1466,7 +1498,6 @@ export default function NewSnookerGame() {
         ref={sliderRef}
         className="absolute right-3 top-1/2 -translate-y-1/2"
       />
-
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Pivot camera around cue ball and align look direction with aiming line
- Allow vertical drag to zoom relative to cue ball and render cue texture

## Testing
- `npm test`
- `npm run lint` *(fails: React version detect, many semicolon errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a90cc0b08329be2514f84e1ae5f6