### PR TITLE
feat: adjust cue camera to follow aiming line

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -16,6 +16,11 @@ public class CueCamera : MonoBehaviour
     public float height = 0.5f;
     // Rotation speed in degrees per second for horizontal mouse movement.
     public float rotationSpeed = 90f;
+    // Speed at which the camera zooms in/out when dragging vertically.
+    public float zoomSpeed = 2f;
+    // Minimum and maximum distance from the cue ball.
+    public float minDistance = 1.5f;
+    public float maxDistance = 3f;
 
     private float yaw;
 
@@ -28,10 +33,15 @@ public class CueCamera : MonoBehaviour
 
         // Accumulate horizontal mouse movement to orbit around the cue ball.
         yaw += Input.GetAxis("Mouse X") * rotationSpeed * Time.deltaTime;
+
+        // Adjust distance based on vertical movement to provide a small zoom.
+        float zoom = Input.GetAxis("Mouse Y") * zoomSpeed * Time.deltaTime;
+        distance = Mathf.Clamp(distance + zoom, minDistance, maxDistance);
+
         Quaternion rotation = Quaternion.Euler(0f, yaw, 0f);
-        Vector3 offset = rotation * (Vector3.back * distance) + Vector3.up * height;
-        transform.position = CueBall.position + offset;
-        transform.LookAt(CueBall.position);
+        Vector3 forward = rotation * Vector3.forward;
+        transform.position = CueBall.position - forward * distance + Vector3.up * height;
+        transform.LookAt(CueBall.position + forward * 5f);
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- align cue camera with aiming direction rather than table center
- allow vertical drag to zoom the camera in and out slightly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1b121e17883299578f9991adea9dc