### PR TITLE
feat: add air hockey game

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -28,6 +28,8 @@ import FallingBall from './pages/Games/FallingBall.jsx';
 import FallingBallLobby from './pages/Games/FallingBallLobby.jsx';
 import GoalRush from './pages/Games/GoalRush.jsx';
 import GoalRushLobby from './pages/Games/GoalRushLobby.jsx';
+import AirHockey from './pages/Games/AirHockey.jsx';
+import AirHockeyLobby from './pages/Games/AirHockeyLobby.jsx';
 import FreeKick from './pages/Games/FreeKick.jsx';
 import FreeKickLobby from './pages/Games/FreeKickLobby.jsx';
 import BrickBreaker from './pages/Games/BrickBreaker.jsx';
@@ -91,6 +93,8 @@ export default function App() {
             <Route path="/games/fallingball" element={<FallingBall />} />
             <Route path="/games/goalrush/lobby" element={<GoalRushLobby />} />
             <Route path="/games/goalrush" element={<GoalRush />} />
+            <Route path="/games/airhockey/lobby" element={<AirHockeyLobby />} />
+            <Route path="/games/airhockey" element={<AirHockey />} />
             <Route path="/games/freekick/lobby" element={<FreeKickLobby />} />
             <Route path="/games/freekick" element={<FreeKick />} />
             <Route

--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -1,0 +1,383 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+
+/**
+ * AIR HOCKEY 3D — Mobile Portrait
+ * -------------------------------
+ * • Top‑down 3D air hockey table that fits portrait screens
+ * • Controls: drag bottom half to move mallet
+ * • AI opponent on top half with simple tracking logic
+ * • Scoreboard with avatars
+ */
+
+export default function AirHockey3D({ player, ai }) {
+  const hostRef = useRef(null);
+  const raf = useRef(0);
+  const [ui, setUi] = useState({ left: 0, right: 0 });
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    // renderer
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      powerPreference: 'high-performance'
+    });
+    renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
+    renderer.setSize(host.clientWidth, host.clientHeight, false);
+    host.appendChild(renderer.domElement);
+
+    // scene & lights
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x0b0e13);
+    const hemi = new THREE.HemisphereLight(0xffffff, 0x1a2330, 0.9);
+    scene.add(hemi);
+    const dir = new THREE.DirectionalLight(0xffffff, 0.8);
+    dir.position.set(-10, 20, 10);
+    scene.add(dir);
+
+    // table dims
+    const TABLE = { w: 1.4, h: 2.8, rim: 0.06, goalW: 0.7 };
+
+    // camera
+    const camera = new THREE.PerspectiveCamera(
+      58,
+      host.clientWidth / host.clientHeight,
+      0.05,
+      100
+    );
+    const cam = {
+      y: 4.5,
+      z: 3.8,
+      x: 0,
+      tiltTarget: new THREE.Vector3(0, 0, 0)
+    };
+    const fitCam = () => {
+      camera.aspect = host.clientWidth / host.clientHeight;
+      camera.position.set(cam.x, cam.y, cam.z);
+      camera.lookAt(cam.tiltTarget);
+      camera.updateProjectionMatrix();
+      renderer.setSize(host.clientWidth, host.clientHeight, false);
+    };
+
+    // build table
+    const group = new THREE.Group();
+    scene.add(group);
+
+    const floor = new THREE.Mesh(
+      new THREE.BoxGeometry(TABLE.w, 0.08, TABLE.h),
+      new THREE.MeshStandardMaterial({ color: 0x1d6fb8, roughness: 0.9 })
+    );
+    floor.position.y = -0.04;
+    group.add(floor);
+
+    // walls
+    const wallMat = new THREE.MeshStandardMaterial({
+      color: 0xdbe9ff,
+      transparent: true,
+      opacity: 0.3,
+      roughness: 0.2,
+      metalness: 0.1
+    });
+    const wallH = 0.25;
+    const wallT = 0.04;
+    const wallTop = new THREE.Mesh(
+      new THREE.BoxGeometry(TABLE.w, wallH, wallT),
+      wallMat
+    );
+    wallTop.position.set(0, wallH / 2, -TABLE.h / 2 - wallT / 2);
+    group.add(wallTop);
+    const wallBot = new THREE.Mesh(
+      new THREE.BoxGeometry(TABLE.w, wallH, wallT),
+      wallMat
+    );
+    wallBot.position.set(0, wallH / 2, TABLE.h / 2 + wallT / 2);
+    group.add(wallBot);
+    const wallL = new THREE.Mesh(
+      new THREE.BoxGeometry(wallT, wallH, TABLE.h),
+      wallMat
+    );
+    wallL.position.set(-TABLE.w / 2 - wallT / 2, wallH / 2, 0);
+    group.add(wallL);
+    const wallR = new THREE.Mesh(
+      new THREE.BoxGeometry(wallT, wallH, TABLE.h),
+      wallMat
+    );
+    wallR.position.set(TABLE.w / 2 + wallT / 2, wallH / 2, 0);
+    group.add(wallR);
+
+    // center line & circles
+    const lineMat = new THREE.MeshStandardMaterial({
+      color: 0xffffff,
+      roughness: 0.6
+    });
+    const midLine = new THREE.Mesh(
+      new THREE.BoxGeometry(TABLE.w, 0.01, 0.02),
+      lineMat
+    );
+    midLine.position.y = 0.005;
+    group.add(midLine);
+
+    const ring = (r, thick, z) => {
+      const g = new THREE.TorusGeometry(r, thick, 16, 60);
+      const m = new THREE.Mesh(
+        g,
+        new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.5 })
+      );
+      m.rotation.x = Math.PI / 2;
+      m.position.set(0, 0.01, z);
+      group.add(m);
+    };
+    ring(0.18, 0.008, -TABLE.h * 0.33);
+    ring(0.18, 0.008, TABLE.h * 0.33);
+
+    // goals
+    const goalGeom = new THREE.BoxGeometry(TABLE.goalW, 0.11, wallT * 0.6);
+    const goalMat = new THREE.MeshStandardMaterial({
+      color: 0x99ffd6,
+      emissive: 0x003322,
+      emissiveIntensity: 0.6
+    });
+    const goalTop = new THREE.Mesh(goalGeom, goalMat);
+    goalTop.position.set(0, 0.05, -TABLE.h / 2 - wallT * 0.7);
+    group.add(goalTop);
+    const goalBot = new THREE.Mesh(goalGeom, goalMat);
+    goalBot.position.set(0, 0.05, TABLE.h / 2 + wallT * 0.7);
+    group.add(goalBot);
+
+    // mallets
+    const makeMallet = c => {
+      const g = new THREE.Group();
+      const base = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.12, 0.12, 0.05, 24),
+        new THREE.MeshStandardMaterial({ color: c, roughness: 0.4, metalness: 0.2 })
+      );
+      const knob = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.06, 0.06, 0.08, 24),
+        new THREE.MeshStandardMaterial({ color: 0x222222 })
+      );
+      base.position.y = 0.025;
+      knob.position.y = 0.115;
+      g.add(base, knob);
+      return g;
+    };
+    const you = makeMallet(0xff5577);
+    you.position.set(0, 0, TABLE.h * 0.36);
+    group.add(you);
+    const aiMallet = makeMallet(0x66ddff);
+    aiMallet.position.set(0, 0, -TABLE.h * 0.36);
+    group.add(aiMallet);
+
+    // puck
+    const puck = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.06, 0.06, 0.02, 24),
+      new THREE.MeshStandardMaterial({ color: 0x111111 })
+    );
+    puck.position.y = 0.01;
+    group.add(puck);
+
+    // physics state
+    const S = {
+      vel: new THREE.Vector3(0, 0, 0),
+      friction: 0.992,
+      lastTouch: 0
+    };
+
+    const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+
+    // input mapping
+    const ray = new THREE.Raycaster();
+    const ndc = new THREE.Vector2();
+    const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+    const hit = new THREE.Vector3();
+
+    const touchToXZ = (clientX, clientY) => {
+      const r = renderer.domElement.getBoundingClientRect();
+      ndc.x = ((clientX - r.left) / r.width) * 2 - 1;
+      ndc.y = -((clientY - r.top) / r.height) * 2 + 1;
+      ray.setFromCamera(ndc, camera);
+      ray.ray.intersectPlane(plane, hit);
+      return {
+        x: clamp(hit.x, -TABLE.w / 2 + 0.12, TABLE.w / 2 - 0.12),
+        z: clamp(hit.z, 0, TABLE.h / 2 - 0.12)
+      };
+    };
+
+    const onMove = e => {
+      const t = e.touches ? e.touches[0] : e;
+      const { x, z } = touchToXZ(t.clientX, t.clientY);
+      you.position.set(x, 0, z);
+      const dx = puck.position.x - x;
+      const dz = puck.position.z - z;
+      const d2 = dx * dx + dz * dz;
+      if (d2 < 0.12 * 0.12) {
+        const nx = -dx;
+        const nz = -dz;
+        S.vel.x += nx * 8e-3;
+        S.vel.z += nz * 8e-3;
+        S.lastTouch = 0.15;
+      }
+    };
+
+    renderer.domElement.addEventListener('touchstart', onMove, {
+      passive: true
+    });
+    renderer.domElement.addEventListener('touchmove', onMove, {
+      passive: true
+    });
+    renderer.domElement.addEventListener('mousemove', onMove);
+
+    // AI logic
+    const aiUpdate = dt => {
+      const targetZ =
+        puck.position.z < 0
+          ? clamp(puck.position.z + 0.15, -TABLE.h / 2 + 0.12, 0 - 0.12)
+          : -TABLE.h * 0.36;
+      const targetX = clamp(
+        puck.position.x,
+        -TABLE.w / 2 + 0.12,
+        TABLE.w / 2 - 0.12
+      );
+      const k = 3.4;
+      aiMallet.position.x += (targetX - aiMallet.position.x) * k * dt;
+      aiMallet.position.z += (targetZ - aiMallet.position.z) * k * dt;
+      const dx = puck.position.x - aiMallet.position.x;
+      const dz = puck.position.z - aiMallet.position.z;
+      const d2 = dx * dx + dz * dz;
+      if (d2 < 0.12 * 0.12) {
+        S.vel.x += dx * 9e-3;
+        S.vel.z += dz * 9e-3;
+      }
+    };
+
+    const reset = towardTop => {
+      puck.position.set(0, 0.01, 0);
+      S.vel.set(0, 0, towardTop ? -0.6 : 0.6);
+      you.position.set(0, 0, TABLE.h * 0.36);
+      aiMallet.position.set(0, 0, -TABLE.h * 0.36);
+    };
+
+    // ensure table fits view
+    const corners = [
+      new THREE.Vector3(-TABLE.w / 2, 0, -TABLE.h / 2),
+      new THREE.Vector3(TABLE.w / 2, 0, -TABLE.h / 2),
+      new THREE.Vector3(-TABLE.w / 2, 0, TABLE.h / 2),
+      new THREE.Vector3(TABLE.w / 2, 0, TABLE.h / 2)
+    ];
+    const toNDC = v => v.clone().project(camera);
+    const ensureFit = () => {
+      camera.position.set(0, cam.y, cam.z);
+      camera.lookAt(0, 0, 0);
+      for (let i = 0; i < 16; i++) {
+        const over = corners.some(c => {
+          const p = toNDC(c);
+          return Math.abs(p.x) > 0.98 || Math.abs(p.y) > 0.98;
+        });
+        if (!over) break;
+        cam.z += 0.18;
+        camera.position.z = cam.z;
+        camera.updateProjectionMatrix();
+      }
+    };
+
+    // loop
+    const clock = new THREE.Clock();
+    reset();
+    fitCam();
+    ensureFit();
+
+    const tick = () => {
+      const dt = Math.min(0.033, clock.getDelta());
+
+      puck.position.x += S.vel.x;
+      puck.position.z += S.vel.z;
+      S.vel.multiplyScalar(0.992);
+
+      if (Math.abs(puck.position.x) > TABLE.w / 2 - 0.06) {
+        puck.position.x = clamp(
+          puck.position.x,
+          -TABLE.w / 2 + 0.06,
+          TABLE.w / 2 - 0.06
+        );
+        S.vel.x = -S.vel.x;
+      }
+
+      const goalHalf = TABLE.goalW / 2;
+      const atTop = puck.position.z < -TABLE.h / 2 + 0.06;
+      const atBot = puck.position.z > TABLE.h / 2 - 0.06;
+      if (atTop || atBot) {
+        if (Math.abs(puck.position.x) <= goalHalf) {
+          setUi(s => ({
+            left: s.left + (atBot ? 1 : 0),
+            right: s.right + (atTop ? 1 : 0)
+          }));
+          reset(!atBot);
+        } else {
+          S.vel.z = -S.vel.z;
+          puck.position.z = clamp(
+            puck.position.z,
+            -TABLE.h / 2 + 0.06,
+            TABLE.h / 2 - 0.06
+          );
+        }
+      }
+
+      aiUpdate(dt);
+      renderer.render(scene, camera);
+      raf.current = requestAnimationFrame(tick);
+    };
+
+    tick();
+
+    const onResize = () => {
+      fitCam();
+      ensureFit();
+    };
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      cancelAnimationFrame(raf.current);
+      window.removeEventListener('resize', onResize);
+      try {
+        host.removeChild(renderer.domElement);
+      } catch {}
+      renderer.dispose();
+    };
+  }, []);
+
+  return (
+    <div
+      ref={hostRef}
+      className="w-full h-[100dvh] bg-black relative overflow-hidden select-none"
+    >
+      <div className="absolute top-2 left-2 flex items-center space-x-2 text-white text-xs bg-white/10 rounded px-2 py-1">
+        <img
+          src={player.avatar}
+          alt=""
+          className="w-5 h-5 rounded-full object-cover"
+        />
+        <span>
+          {player.name}: {ui.left}
+        </span>
+      </div>
+      <div className="absolute top-2 right-2 flex items-center space-x-2 text-white text-xs bg-white/10 rounded px-2 py-1">
+        <span>
+          {ui.right}: {ai.name}
+        </span>
+        <img
+          src={ai.avatar}
+          alt=""
+          className="w-5 h-5 rounded-full object-cover"
+        />
+      </div>
+      <button
+        onClick={() => window.location.reload()}
+        className="absolute left-2 bottom-2 text-white text-xs bg-white/10 hover:bg-white/20 rounded px-2 py-1"
+      >
+        Reset
+      </button>
+    </div>
+  );
+}
+

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -93,6 +93,22 @@ export default function Games() {
               </h3>
             </Link>
             <Link
+              to="/games/airhockey/lobby"
+              className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+            >
+              <img
+                src="/assets/icons/white_ball.svg"
+                alt=""
+                className="h-20 w-20"
+              />
+              <h3
+                className="text-sm font-semibold text-center text-yellow-400"
+                style={{ WebkitTextStroke: '1px black' }}
+              >
+                Air Hockey
+              </h3>
+            </Link>
+            <Link
               to="/games/freekick/lobby"
               className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
             >

--- a/webapp/src/pages/Games/AirHockey.jsx
+++ b/webapp/src/pages/Games/AirHockey.jsx
@@ -1,0 +1,22 @@
+import { useLocation } from 'react-router-dom';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import AirHockey3D from '../../components/AirHockey3D.jsx';
+
+const AI_FLAGS = [
+  { name: 'France', avatar: '/assets/icons/FranceLeader.webp' },
+  { name: 'Germany', avatar: '/assets/icons/GermanyLeader.webp' },
+  { name: 'Italy', avatar: '/assets/icons/ItalyLeader.webp' },
+  { name: 'Canada', avatar: '/assets/icons/CanadaLeader.webp' }
+];
+
+export default function AirHockey() {
+  useTelegramBackButton();
+  const { search } = useLocation();
+  const params = new URLSearchParams(search);
+  const player = {
+    name: params.get('name') || 'You',
+    avatar: params.get('avatar') || '/assets/icons/profile.svg'
+  };
+  const ai = AI_FLAGS[Math.floor(Math.random() * AI_FLAGS.length)];
+  return <AirHockey3D player={player} ai={ai} />;
+}

--- a/webapp/src/pages/Games/AirHockeyLobby.jsx
+++ b/webapp/src/pages/Games/AirHockeyLobby.jsx
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import {
+  ensureAccountId,
+  getTelegramId,
+  getTelegramPhotoUrl,
+  getTelegramFirstName
+} from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+
+export default function AirHockeyLobby() {
+  const navigate = useNavigate();
+  const { search } = useLocation();
+  useTelegramBackButton();
+
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [avatar, setAvatar] = useState('');
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  const startGame = async () => {
+    let tgId;
+    let accountId;
+    try {
+      accountId = await ensureAccountId();
+      const balRes = await getAccountBalance(accountId);
+      if ((balRes.balance || 0) < stake.amount) {
+        alert('Insufficient balance');
+        return;
+      }
+      tgId = getTelegramId();
+      await addTransaction(tgId, -stake.amount, 'stake', {
+        game: 'airhockey',
+        players: 2,
+        accountId
+      });
+    } catch {}
+
+    const params = new URLSearchParams(search);
+    const initData = window.Telegram?.WebApp?.initData;
+    if (stake.token) params.set('token', stake.token);
+    if (stake.amount) params.set('amount', stake.amount);
+    if (avatar) params.set('avatar', avatar);
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    const name = getTelegramFirstName();
+    if (name) params.set('name', name);
+    if (initData) params.set('init', encodeURIComponent(initData));
+    navigate(`/games/airhockey?${params.toString()}`);
+  };
+
+  return (
+    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+      <h2 className="text-xl font-bold text-center">Air Hockey Lobby</h2>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Stake</h3>
+        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+      </div>
+      <button
+        onClick={startGame}
+        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
+      >
+        START
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Air Hockey 3D game with AI opponent and scoreboard
- include lobby with TPC staking support
- register routes and menu card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c6a8dce88329b63c4bedc692a178