### PR TITLE
Fix Air Hockey canvas sizing for full-screen display

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -25,7 +25,8 @@ export default function AirHockey3D({ player, ai }) {
       powerPreference: 'high-performance'
     });
     renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
-    renderer.setSize(host.clientWidth, host.clientHeight, false);
+    // ensure canvas CSS size matches the host container
+    renderer.setSize(host.clientWidth, host.clientHeight);
     host.appendChild(renderer.domElement);
 
     // scene & lights
@@ -58,7 +59,8 @@ export default function AirHockey3D({ player, ai }) {
       camera.position.set(cam.x, cam.y, cam.z);
       camera.lookAt(cam.tiltTarget);
       camera.updateProjectionMatrix();
-      renderer.setSize(host.clientWidth, host.clientHeight, false);
+      // keep canvas sized with the host on layout changes
+      renderer.setSize(host.clientWidth, host.clientHeight);
     };
 
     // build table


### PR DESCRIPTION
## Summary
- ensure AirHockey3D canvas resizes with its container so the full table renders on screen

## Testing
- `npm test`
- `npm run lint` *(fails: 937 errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d04dac7c8329a9c296a8e3998e64