### PR TITLE
Adjust air hockey speed and table size

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -51,7 +51,7 @@ export default function AirHockey3D({ player, ai }) {
     scene.add(dir);
 
     // table dims (slightly bigger for mobile screens)
-    const TABLE = { w: 1.6, h: 3.2, rim: 0.06, goalW: 0.8 };
+    const TABLE = { w: 2, h: 4, rim: 0.06, goalW: 1 };
 
     // camera
     const camera = new THREE.PerspectiveCamera(
@@ -194,7 +194,7 @@ export default function AirHockey3D({ player, ai }) {
     // physics state
     const S = {
       vel: new THREE.Vector3(0, 0, 0),
-      friction: 0.985,
+      friction: 0.98,
       lastTouch: 0
     };
 
@@ -228,8 +228,8 @@ export default function AirHockey3D({ player, ai }) {
       if (d2 < 0.12 * 0.12) {
         const nx = -dx;
         const nz = -dz;
-        S.vel.x += nx * 5e-3;
-        S.vel.z += nz * 5e-3;
+        S.vel.x += nx * 2.5e-3;
+        S.vel.z += nz * 2.5e-3;
         S.lastTouch = 0.15;
         playHit();
       }
@@ -261,15 +261,15 @@ export default function AirHockey3D({ player, ai }) {
       const dz = puck.position.z - aiMallet.position.z;
       const d2 = dx * dx + dz * dz;
       if (d2 < 0.12 * 0.12) {
-        S.vel.x += dx * 6e-3;
-        S.vel.z += dz * 6e-3;
+        S.vel.x += dx * 3e-3;
+        S.vel.z += dz * 3e-3;
         playHit();
       }
     };
 
     const reset = towardTop => {
       puck.position.set(0, 0.01, 0);
-      S.vel.set(0, 0, towardTop ? -0.4 : 0.4);
+      S.vel.set(0, 0, towardTop ? -0.2 : 0.2);
       you.position.set(0, 0, TABLE.h * 0.36);
       aiMallet.position.set(0, 0, -TABLE.h * 0.36);
     };


### PR DESCRIPTION
## Summary
- expand air hockey table dimensions by 25%
- slow puck by reducing acceleration and launch speed

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon and other pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d69a64708329a329ca2163550330