### PR TITLE
Adjust air hockey scaling and puck speed

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -61,8 +61,8 @@ export default function AirHockey3D({ player, ai }) {
       100
     );
     const cam = {
-      y: 4.5,
-      z: 3.8,
+      y: 3.2,
+      z: 2.6,
       x: 0,
       tiltTarget: new THREE.Vector3(0, 0, 0)
     };
@@ -194,7 +194,7 @@ export default function AirHockey3D({ player, ai }) {
     // physics state
     const S = {
       vel: new THREE.Vector3(0, 0, 0),
-      friction: 0.98,
+      friction: 0.97,
       lastTouch: 0
     };
 
@@ -228,8 +228,8 @@ export default function AirHockey3D({ player, ai }) {
       if (d2 < 0.12 * 0.12) {
         const nx = -dx;
         const nz = -dz;
-        S.vel.x += nx * 2.5e-3;
-        S.vel.z += nz * 2.5e-3;
+        S.vel.x += nx * 1.5e-3;
+        S.vel.z += nz * 1.5e-3;
         S.lastTouch = 0.15;
         playHit();
       }
@@ -261,15 +261,15 @@ export default function AirHockey3D({ player, ai }) {
       const dz = puck.position.z - aiMallet.position.z;
       const d2 = dx * dx + dz * dz;
       if (d2 < 0.12 * 0.12) {
-        S.vel.x += dx * 3e-3;
-        S.vel.z += dz * 3e-3;
+        S.vel.x += dx * 2e-3;
+        S.vel.z += dz * 2e-3;
         playHit();
       }
     };
 
     const reset = towardTop => {
       puck.position.set(0, 0.01, 0);
-      S.vel.set(0, 0, towardTop ? -0.2 : 0.2);
+      S.vel.set(0, 0, towardTop ? -0.12 : 0.12);
       you.position.set(0, 0, TABLE.h * 0.36);
       aiMallet.position.set(0, 0, -TABLE.h * 0.36);
     };


### PR DESCRIPTION
## Summary
- Move camera closer so the air hockey table fills more of the screen
- Reduce puck acceleration, initial speed, and increase friction for slower gameplay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d95e6a4c832987b39862cb5f1697