### PR TITLE
Use emoji flags for Air Hockey AI

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { getGameVolume } from '../utils/sound.js';
+import { getAvatarUrl } from '../utils/avatarUtils.js';
 
 /**
  * AIR HOCKEY 3D — Mobile Portrait
@@ -78,8 +79,8 @@ export default function AirHockey3D({ player, ai }) {
 
     // build table
     const group = new THREE.Group();
-    // nudge the whole field slightly downward on screen
-    group.position.z = 0.2;
+    // slightly closer to the top
+    group.position.z = 0.1;
     scene.add(group);
 
     const floor = new THREE.Mesh(
@@ -370,9 +371,9 @@ export default function AirHockey3D({ player, ai }) {
       ref={hostRef}
       className="w-full h-[100dvh] bg-black relative overflow-hidden select-none"
     >
-      <div className="absolute top-2 left-2 flex items-center space-x-2 text-white text-xs bg-white/10 rounded px-2 py-1">
+      <div className="absolute top-1 left-2 flex items-center space-x-2 text-white text-xs bg-white/10 rounded px-2 py-1">
         <img
-          src={player.avatar}
+          src={getAvatarUrl(player.avatar)}
           alt=""
           className="w-5 h-5 rounded-full object-cover"
         />
@@ -380,12 +381,12 @@ export default function AirHockey3D({ player, ai }) {
           {player.name}: {ui.left}
         </span>
       </div>
-      <div className="absolute top-2 right-2 flex items-center space-x-2 text-white text-xs bg-white/10 rounded px-2 py-1">
+      <div className="absolute top-1 right-2 flex items-center space-x-2 text-white text-xs bg-white/10 rounded px-2 py-1">
         <span>
           {ui.right}: {ai.name}
         </span>
         <img
-          src={ai.avatar}
+          src={getAvatarUrl(ai.avatar)}
           alt=""
           className="w-5 h-5 rounded-full object-cover"
         />

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -104,6 +104,17 @@ export default function Layout({ children }) {
     }
   }, [location.pathname]);
 
+  useEffect(() => {
+    const isGamePage =
+      location.pathname.startsWith('/games/') &&
+      !location.pathname.includes('/lobby');
+    if (isGamePage) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+  }, [location.pathname]);
+
   return (
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
       {showHeader && (

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -11,6 +11,7 @@
 html,
 body {
   overscroll-behavior: none;
+  height: 100%;
 }
 
 body {

--- a/webapp/src/pages/Games/AirHockey.jsx
+++ b/webapp/src/pages/Games/AirHockey.jsx
@@ -1,13 +1,8 @@
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import AirHockey3D from '../../components/AirHockey3D.jsx';
-
-const AI_FLAGS = [
-  { name: 'France', avatar: '/assets/icons/FranceLeader.webp' },
-  { name: 'Germany', avatar: '/assets/icons/GermanyLeader.webp' },
-  { name: 'Italy', avatar: '/assets/icons/ItalyLeader.webp' },
-  { name: 'Canada', avatar: '/assets/icons/CanadaLeader.webp' }
-];
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { avatarToName } from '../../utils/avatarUtils.js';
 
 export default function AirHockey() {
   useTelegramBackButton();
@@ -17,6 +12,7 @@ export default function AirHockey() {
     name: params.get('name') || 'You',
     avatar: params.get('avatar') || '/assets/icons/profile.svg'
   };
-  const ai = AI_FLAGS[Math.floor(Math.random() * AI_FLAGS.length)];
+  const flag = FLAG_EMOJIS[Math.floor(Math.random() * FLAG_EMOJIS.length)];
+  const ai = { name: avatarToName(flag) || 'AI', avatar: flag };
   return <AirHockey3D player={player} ai={ai} />;
 }


### PR DESCRIPTION
## Summary
- Display AI opponents in Air Hockey with random emoji flags and move the table slightly upward
- Disable body scrolling on active game screens to prevent pull-to-refresh
- Ensure full-height layout with no vertical bounce

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c246b353888329855a081f7a21da7f