### PR TITLE
Fix TableTennis3D canvas sizing for full table view

### DIFF
--- a/webapp/src/components/TableTennis3D.jsx
+++ b/webapp/src/components/TableTennis3D.jsx
@@ -34,7 +34,8 @@ export default function TableTennis3D({ player, ai }){
     // ---------- Renderer ----------
     const renderer = new THREE.WebGLRenderer({ antialias:true, powerPreference:'high-performance' });
     renderer.setPixelRatio(Math.min(2, window.devicePixelRatio||1));
-    const setSize = ()=> renderer.setSize(host.clientWidth, host.clientHeight, false);
+    // ensure canvas CSS size matches the host container
+    const setSize = () => renderer.setSize(host.clientWidth, host.clientHeight);
     setSize(); host.appendChild(renderer.domElement);
 
     // ---------- Scene & Lights ----------


### PR DESCRIPTION
## Summary
- Ensure the TableTennis3D renderer updates canvas CSS size so the entire table is visible on screen

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, prefer-const, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c2597d55d88329852322a3f4680eed