### PR TITLE
Disable vertical swipe closing in Telegram WebApp

### DIFF
--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -3,6 +3,11 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
 
+// Prevent Telegram in-app browser swipe-down from closing the game
+if (window.Telegram?.WebApp?.disableVerticalSwipes) {
+  window.Telegram.WebApp.disableVerticalSwipes();
+}
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
## Summary
- prevent Telegram in-app browser from closing the game when swiped downward

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c28adb8c108329a972e5b44cf6d703