### PR TITLE
docs: add calibration paragraph to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,46 @@
+Ky duhet te jet paragrafi i pare ne read me . KY ËSHTË PARAGRAFI I KALIBRIMIT – LEXOJE PARA ÇDO DETYRE.
+
+Platforma & Orientimi:
+- Target gjithmonë: MOBILE (orientim PORTRAIT), përveç kur e specifikoj ndryshe.
+- Nëse përmendet landscape, shkruaj qartë “ORIENTIM: landscape” dhe zbato të njëjtat rregulla.
+
+Sistemi i Koordinatave & Drejtimet (nga perspektiva ime si përdoruesi që shoh ekranin):
+- Origjina (0,0) = këndi SIPËRMAJTAS i ekranit.
+- “sipër”  = drejtimi -Y (lart në ekran).
+- “poshtë” = drejtimi +Y (poshtë në ekran).
+- “majtas” = drejtimi -X (skaji i majtë i ekranit).
+- “djathtas”= drejtimi +X (skaji i djathtë i ekranit).
+- MOS e pasqyro/flip kanavacën, imazhet apo layout-in NË ASNJË RAST pa kërkesë eksplicite.
+
+Vendosja e elementeve (pa UI shtesë):
+- “vendose sipër”  = ankorim në pjesën e sipërme brenda SAFE AREA (respekto notchin).
+- “vendose poshtë” = ankorim në fund të ekranit brenda SAFE AREA.
+- “majtas/djathtas” = skajet përkatëse me margin minimal 16px (ose 4% të gjerësisë).
+- “qendra” = qendër horizontale/vertikale të ekranit, jo të container-it nëntesor.
+- MOS shto butona/overlay/prompt-e në UI për kalibrim; asnjë kontroll shtesë vizual pa kërkesë.
+
+Ndriçim/Ngjyra:
+- “ndriçoje” = rrit vetëm BRIGHTNESS/EXPOSURE (jo hue, jo saturation, jo contrast).
+- “erresoje” = ul vetëm BRIGHTNESS.
+- Çdo transformim tjetër i ngjyrave bëhet vetëm nëse kërkohet qartë.
+
+Responsivitet & Safe Areas:
+- Përdor njësi responsive (%, vw, vh) ose Flex/Grid; respekto padding: env(safe-area-inset-*) në iOS dhe ekuivalentët në Android.
+- Mos e ngatërro “lart/poshtë” me “para/mbrapa”; punojmë vetëm në plan 2D të ekranit.
+
+Kontroll Vetë-verifikimi (vetëm në tekst, JO UI):
+- Fillon çdo përgjigje me një rresht të vetëm: 
+  “CHECK: orientim=portrait | hartë: sipër=-Y, poshtë=+Y, majtas=-X, djathtas=+X | no-flip | no-extra-UI”.
+- Pastaj jep zgjidhjen. Në landscape, deklaro: “CHECK: orientim=landscape | …”.
+
+International/RTL:
+- Pavarësisht gjuhës së përmbajtjes, komanda në shqip nënkupton LTR për vendosje teksti, përveç nëse e kërkoj ndryshe.
+
+Përmbledhje detyruese:
+- Zbato fiks këto rregulla të orientimit/koordinatave.
+- MOS krye-interpretim i drejtimit; asnjë pasqyrim/mirroring pa urdhër.
+- Asnjë buton apo element UI shtesë pa kërkesë eksplicite.
+
 # System Prompt (for Codex)
 
 You are a developer of the highest rank in the fields of:


### PR DESCRIPTION
## Summary
- add calibration and orientation instructions to README

## Testing
- `npm test`
- `npm run lint` *(fails: 937 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a25b12408329b674ac23a56de6a9