### PR TITLE
Improve billiard ball highlight lighting

### DIFF
--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!47 &1
+QualitySettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 5
+  m_CurrentQuality: 0
+  m_QualitySettings:
+  - serializedVersion: 5
+    name: Default
+    pixelLightCount: 3
+    shadowDistance: 40
+    shadowmaskMode: 0
+    blendWeights: 2
+    textureQuality: 0
+    anisotropicTextures: 1
+    antiAliasing: 0
+    softParticles: 0
+    softVegetation: 1
+    realtimeReflectionProbes: 1
+    billboardsFaceCameraPosition: 1
+    vSyncCount: 1
+    lodBias: 2
+    maximumLODLevel: 0
+    streamingMipmapsActive: 0
+    streamingMipmapsMemoryBudget: 512
+    streamingMipmapsRenderersPerFrame: 512
+    streamingMipmapsMaxLevelReduction: 2
+    particleRaycastBudget: 4
+    asyncUploadTimeSlice: 2
+    asyncUploadBufferSize: 16
+    resolutionScalingFixedDPIFactor: 1
+    excludedTargetPlatforms: []
+  m_PerPlatformDefaultQuality: {}

--- a/billiards.Unity/BilliardLighting.cs
+++ b/billiards.Unity/BilliardLighting.cs
@@ -40,7 +40,7 @@ public class BilliardLighting : MonoBehaviour
                 Material mat = new Material(standard);
                 mat.color = source.color * 1.2f;        // slightly brighter
                 mat.SetFloat("_Metallic", 0f);
-                mat.SetFloat("_Glossiness", 0.97f);
+                mat.SetFloat("_Glossiness", 0.8f);
                 mat.SetColor("_SpecColor", Color.white * 1.4f);
                 renderer.material = mat;
             }
@@ -74,10 +74,11 @@ public class BilliardLighting : MonoBehaviour
 
         Light pointLight = lightObj.AddComponent<Light>();
         pointLight.type = LightType.Point;
-        pointLight.range = 0.75f;  // keep small so highlights don't overlap
-        pointLight.intensity = 3f;
+        pointLight.range = 1.5f;  // keep small so highlights don't overlap
+        pointLight.intensity = 2f;
         pointLight.shadows = LightShadows.None;
         pointLight.color = Color.white;
+        pointLight.renderMode = LightRenderMode.ForcePixel;
     }
 
     // Create a tiny red sphere on the cue ball to help players judge spin


### PR DESCRIPTION
## Summary
- enhance ball material highlights by widening specular gloss
- force per-pixel rendering and larger radius on highlight lights
- raise pixel light count for quality settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c71ed61483299f8c626c196224d8