### PR TITLE
Brighten snooker ball highlights

### DIFF
--- a/billiards.Unity/BilliardLighting.cs
+++ b/billiards.Unity/BilliardLighting.cs
@@ -38,10 +38,12 @@ public class BilliardLighting : MonoBehaviour
             {
                 Material source = renderer.material;
                 Material mat = new Material(standard);
-                mat.color = source.color * 1.2f;        // slightly brighter
+                mat.color = source.color * 1.5f;        // brighter base colour
                 mat.SetFloat("_Metallic", 0f);
-                mat.SetFloat("_Glossiness", 0.8f);
+                mat.SetFloat("_Glossiness", 0.5f);     // wider specular highlight
                 mat.SetColor("_SpecColor", Color.white * 1.4f);
+                mat.EnableKeyword("_EMISSION");
+                mat.SetColor("_EmissionColor", source.color * 0.25f);
                 renderer.material = mat;
             }
 
@@ -74,8 +76,8 @@ public class BilliardLighting : MonoBehaviour
 
         Light pointLight = lightObj.AddComponent<Light>();
         pointLight.type = LightType.Point;
-        pointLight.range = 1.5f;  // keep small so highlights don't overlap
-        pointLight.intensity = 2f;
+        pointLight.range = 2.5f;  // allow larger reflection area
+        pointLight.intensity = 3f; // stronger highlight
         pointLight.shadows = LightShadows.None;
         pointLight.color = Color.white;
         pointLight.renderMode = LightRenderMode.ForcePixel;


### PR DESCRIPTION
## Summary
- Widen specular highlights and brighten snooker balls with lower glossiness and emission
- Strengthen per-ball point lights for larger reflections

## Testing
- `npm test`
- `dotnet test billiards.Tests/Billiards.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c2c5e31a448329b98b23cc8b303133