### PR TITLE
Reduce billiard ball reflection size

### DIFF
--- a/billiards.Unity/BilliardLighting.cs
+++ b/billiards.Unity/BilliardLighting.cs
@@ -78,7 +78,7 @@ public class BilliardLighting : MonoBehaviour
         Light spotLight = lightObj.AddComponent<Light>();
         spotLight.type = LightType.Spot;
         spotLight.cookie = Texture2D.whiteTexture; // square reflection
-        const float sizeMultiplier = 5f;            // enlarge highlight to 5x
+        const float sizeMultiplier = 0.2f;          // 5x smaller highlight
         spotLight.range = 2.5f * sizeMultiplier;
         spotLight.intensity = 3f;
         spotLight.spotAngle = 10f * sizeMultiplier;


### PR DESCRIPTION
## Summary
- shrink Unity highlight light on balls to make reflections 5x smaller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2d18e3de88329b0512eec6019cdf8