### PR TITLE
feat: update snooker example balls

### DIFF
--- a/examples/snooker-balls/index.html
+++ b/examples/snooker-balls/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>3D Snooker – Fusha, Topat dhe Cue</title>
+  <title>3D Snooker – Vetëm Topat</title>
   <script type="importmap">
     {
       "imports": {
@@ -36,46 +36,12 @@
 
     const controls = new OrbitControls(camera, renderer.domElement);
     controls.enableDamping = true;
-    controls.dampingFactor = 0.07;
-    controls.maxPolarAngle = Math.PI*0.49;
-    controls.minDistance = 1.1;
-    controls.maxDistance = 6;
 
     // Lights
     scene.add(new THREE.HemisphereLight(0xdde7ff,0x0b1020,0.6));
     const dir = new THREE.DirectionalLight(0xffffff,0.8);
     dir.position.set(-2.5,4,2);
     scene.add(dir);
-
-    const spot = new THREE.SpotLight(0xffffff,1.5,0,Math.PI*0.2,0.3,1);
-    spot.position.set(1.3,2.6,0.5);
-    spot.target.position.set(0,0.75,0);
-    scene.add(spot,spot.target);
-
-    const point = new THREE.PointLight(0xffffff,1.2,10);
-    point.position.set(-1.5,2.2,-0.8);
-    scene.add(point);
-
-    const tiny = new THREE.PointLight(0xffffff,0.6,3);
-    tiny.position.set(0.5,1.8,1.2);
-    scene.add(tiny);
-
-    // Fusha (field) vetëm cloth normal pak më e errët
-    const PLAY_L = 3.57, PLAY_W = 1.78;
-    const TABLE_H = 0.75;
-
-    const baseCloth = new THREE.Mesh(
-      new THREE.PlaneGeometry(PLAY_L, PLAY_W),
-      new THREE.MeshPhysicalMaterial({
-        color:0x1a6d1a, // jeshile pak më e errët
-        roughness:0.95,
-        sheen:1.0,
-        sheenRoughness:0.8
-      })
-    );
-    baseCloth.rotation.x = -Math.PI/2;
-    baseCloth.position.set(0, TABLE_H, 0);
-    scene.add(baseCloth);
 
     // Snooker balls
     const BALL_R = 0.0525;
@@ -96,7 +62,7 @@
         clearcoat: 1, clearcoatRoughness:0.12
       });
       const b = new THREE.Mesh(new THREE.SphereGeometry(BALL_R,64,48), mat);
-      b.position.y = TABLE_H + BALL_R;
+      b.position.y = BALL_R;
       return b;
     }
 
@@ -107,7 +73,7 @@
         if(redIndex>=15) break;
         const ball = makeBall(SNOOKER_COLORS.red);
         ball.position.x = (i - row/2) * (BALL_R*2 + 0.002);
-        ball.position.z = -PLAY_W*0.15 + row*(BALL_R*1.9);
+        ball.position.z = row*(BALL_R*1.9);
         scene.add(ball);
         redIndex++;
       }
@@ -115,34 +81,33 @@
 
     // Topat me ngjyra speciale
     const yellow = makeBall(SNOOKER_COLORS.yellow);
-    yellow.position.set(-PLAY_L*0.35, TABLE_H+BALL_R, PLAY_W*0.35);
+    yellow.position.set(-0.6, BALL_R, 0.8);
     scene.add(yellow);
 
     const green = makeBall(SNOOKER_COLORS.green);
-    green.position.set(PLAY_L*0.35, TABLE_H+BALL_R, PLAY_W*0.35);
+    green.position.set(0.6, BALL_R, 0.8);
     scene.add(green);
 
     const brown = makeBall(SNOOKER_COLORS.brown);
-    brown.position.set(-0.2, TABLE_H+BALL_R, PLAY_W*0.35);
+    brown.position.set(-0.2, BALL_R, 0.8);
     scene.add(brown);
 
     const blue = makeBall(SNOOKER_COLORS.blue);
-    blue.position.set(-0.4, TABLE_H+BALL_R, 0);
+    blue.position.set(0, BALL_R, 0);
     scene.add(blue);
 
     const pink = makeBall(SNOOKER_COLORS.pink);
-    pink.position.set(0, TABLE_H+BALL_R, -PLAY_W*0.2);
+    pink.position.set(0, BALL_R, -0.8);
     scene.add(pink);
 
     const black = makeBall(SNOOKER_COLORS.black);
-    black.position.set(0, TABLE_H+BALL_R, -PLAY_W*0.45);
+    black.position.set(0, BALL_R, -1.2);
     scene.add(black);
 
-    // Cue ball
+    // Cue ball me pika të kuqe
     const cueBall = makeBall(SNOOKER_COLORS.cue);
-    cueBall.position.set(0, TABLE_H+BALL_R, PLAY_W*0.25);
+    cueBall.position.set(0, BALL_R, 1.2);
 
-    // Add 4 red dots on cue ball
     const dotSize = 0.008;
     const dotGeom = new THREE.SphereGeometry(dotSize, 16, 8);
     const dotMat = new THREE.MeshBasicMaterial({color:0xff0000});
@@ -159,56 +124,6 @@
     });
 
     scene.add(cueBall);
-
-    // Cue stick behind cueball
-    const cueStick = new THREE.Group();
-
-    const shaft = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.008, 0.025, 1.5, 32),
-      new THREE.MeshPhysicalMaterial({color:0xdeb887, roughness:0.6})
-    );
-    shaft.rotation.x = -Math.PI/2;
-    cueStick.add(shaft);
-
-    const tip = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.008, 0.008, 0.05, 32),
-      new THREE.MeshPhysicalMaterial({color:0x0000ff, roughness:0.4})
-    );
-    tip.rotation.x = -Math.PI/2;
-    tip.position.z = -0.75;
-    cueStick.add(tip);
-
-    const connector = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.009, 0.009, 0.015, 32),
-      new THREE.MeshPhysicalMaterial({color:0xcd7f32, metalness:0.8, roughness:0.5})
-    );
-    connector.rotation.x = -Math.PI/2;
-    connector.position.z = -0.748;
-    cueStick.add(connector);
-
-    const buttCap = new THREE.Mesh(
-      new THREE.SphereGeometry(0.03, 32, 16),
-      new THREE.MeshPhysicalMaterial({color:0x111111, roughness:0.5})
-    );
-    buttCap.position.z = 0.75;
-    cueStick.add(buttCap);
-
-    const stripeMat = new THREE.MeshBasicMaterial({color:0x000000});
-    for(let i=0;i<12;i++){
-      const stripe = new THREE.Mesh(
-        new THREE.BoxGeometry(0.01, 0.001, 0.35),
-        stripeMat
-      );
-      const angle = (i/12) * Math.PI*2;
-      stripe.position.x = Math.cos(angle)*0.02;
-      stripe.position.y = Math.sin(angle)*0.02;
-      stripe.position.z = 0.55;
-      stripe.rotation.z = angle;
-      cueStick.add(stripe);
-    }
-
-    cueStick.position.set(cueBall.position.x, TABLE_H+BALL_R, cueBall.position.z+0.9);
-    scene.add(cueStick);
 
     addEventListener('resize',()=>{
       camera.aspect = innerWidth/innerHeight;


### PR DESCRIPTION
## Summary
- replace old snooker balls + cue demo with simplified balls-only example
- define updated ball colors and layout for snooker balls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3110246108329892665a0b1c5c664