### PR TITLE
Fix snooker table lighting

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1029,25 +1029,31 @@ export default function NewSnookerGame() {
       window.addEventListener('keydown', keyRot);
 
       // Lights
-      scene.add(new THREE.HemisphereLight(0xdde7ff, 0x0b1020, 0.6));
+      scene.add(new THREE.HemisphereLight(0xdde7ff, 0x0b1020, 0.8));
       const dir = new THREE.DirectionalLight(0xffffff, 0.8);
       dir.position.set(-2.5, 4, 2);
       scene.add(dir);
 
-      const spot = new THREE.SpotLight(0xffffff, 1.5, 0, Math.PI / 2, 0.8, 1);
+      // stronger ambient light so the entire table is evenly visible
+      const ambient = new THREE.AmbientLight(0xffffff, 0.6);
+      scene.add(ambient);
+
+      const spot = new THREE.SpotLight(0xffffff, 1.8, 0, Math.PI / 2, 0.8, 1);
       spot.position.set(0, 5, 0);
       spot.target.position.set(0, 0.75, 0);
       scene.add(spot, spot.target);
 
-      // widen point light so it covers the whole table
-      const point = new THREE.PointLight(0xffffff, 1.2, 1000);
-      point.position.set(-1.5, 2.2, -0.8);
+      // center point light provides broad illumination across cloth
+      const point = new THREE.PointLight(0xffffff, 2, 0);
+      point.position.set(0, 3.5, 0);
       scene.add(point);
 
-      // tiny helper light also needs a larger radius for even coverage
-      const tiny = new THREE.PointLight(0xffffff, 0.6, 500);
-      tiny.position.set(0.5, 1.8, 1.2);
-      scene.add(tiny);
+      // helper lights from opposite sides to soften shadows
+      const tiny = new THREE.PointLight(0xffffff, 1.2, 0);
+      tiny.position.set(0, 3, PLAY_W * 0.35);
+      const back = new THREE.PointLight(0xffffff, 1.2, 0);
+      back.position.set(0, 3, -PLAY_W * 0.35);
+      scene.add(tiny, back);
 
       // Table
       const { centers, baulkZ, group: table } = Table3D(scene);


### PR DESCRIPTION
## Summary
- Increase ambient and point light intensities and add a second helper point light so the entire snooker table stays bright

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3d676aa888329aa0598d7caadba5b