### PR TITLE
Align side spotlights with center light

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1090,13 +1090,13 @@ export default function NewSnookerGame() {
       );
 
       // additional spotlights for specific table areas
-      // wider penumbra to brighten the rack / black ball area
+      // match central spotlight penumbra to brighten the rack / black ball area
       const spotBlack = new THREE.SpotLight(
         0xffffff,
         1.8,
         0,
         Math.PI / 2,
-        1,
+        0.8,
         1
       );
       const blackZ = SPOTS.black[1];
@@ -1104,13 +1104,13 @@ export default function NewSnookerGame() {
       spotBlack.target.position.set(0, 0.75, blackZ);
       scene.add(spotBlack, spotBlack.target);
 
-      // wider penumbra to better illuminate the D area
+      // match central spotlight penumbra to better illuminate the D area
       const spotD = new THREE.SpotLight(
         0xffffff,
         1.8,
         0,
         Math.PI / 2,
-        1,
+        0.8,
         1
       );
       spotD.position.set(0, 5, baulkZ);


### PR DESCRIPTION
## Summary
- Adjust D area and rack spotlights to use the same penumbra as the central light for more even illumination on the table.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3ee8915bc832987079f3c6d114f32