### PR TITLE
chore: replace snooker spotlights with area lights

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
+import { RectAreaLightUniformsLib } from 'three/examples/jsm/lights/RectAreaLightUniformsLib.js';
 // Snooker uses its own slimmer power slider
 import { SnookerPowerSlider } from '../../../../snooker-power-slider.js';
 import '../../../../snooker-power-slider.css';
@@ -1029,6 +1030,7 @@ export default function NewSnookerGame() {
       window.addEventListener('keydown', keyRot);
 
       // Lights
+      RectAreaLightUniformsLib.init();
       scene.add(new THREE.HemisphereLight(0xdde7ff, 0x0b1020, 0.8));
       const dir = new THREE.DirectionalLight(0xffffff, 0.8);
       dir.position.set(-2.5, 4, 2);
@@ -1038,22 +1040,14 @@ export default function NewSnookerGame() {
       const ambient = new THREE.AmbientLight(0xffffff, 0.6);
       scene.add(ambient);
 
-      const spot = new THREE.SpotLight(0xffffff, 1.8, 0, Math.PI / 2, 0.8, 1);
-      spot.position.set(0, 5, 0);
-      spot.target.position.set(0, 0.75, 0);
-      scene.add(spot, spot.target);
-
-      // center point light provides broad illumination across cloth
-      const point = new THREE.PointLight(0xffffff, 2, 0);
-      point.position.set(0, 3.5, 0);
-      scene.add(point);
-
-      // helper lights from opposite sides to soften shadows
-      const tiny = new THREE.PointLight(0xffffff, 1.2, 0);
-      tiny.position.set(0, 3, PLAY_W * 0.35);
-      const back = new THREE.PointLight(0xffffff, 1.2, 0);
-      back.position.set(0, 3, -PLAY_W * 0.35);
-      scene.add(tiny, back);
+      // evenly distributed overhead area lights
+      const third = PLAY_H / 3;
+      [-third, 0, third].forEach((z) => {
+        const rect = new THREE.RectAreaLight(0xffffff, 40, PLAY_W, PLAY_W);
+        rect.position.set(0, 5, z);
+        rect.rotation.x = -Math.PI / 2;
+        scene.add(rect);
+      });
 
       // Table
       const { centers, baulkZ, group: table } = Table3D(scene);
@@ -1088,34 +1082,6 @@ export default function NewSnookerGame() {
       const colors = Object.fromEntries(
         Object.entries(SPOTS).map(([k, [x, z]]) => [k, add(k, COLORS[k], x, z)])
       );
-
-      // additional spotlights for specific table areas
-      // match central spotlight penumbra to brighten the rack / black ball area
-      const spotBlack = new THREE.SpotLight(
-        0xffffff,
-        1.8,
-        0,
-        Math.PI / 2,
-        0.8,
-        1
-      );
-      const blackZ = SPOTS.black[1];
-      spotBlack.position.set(0, 5, blackZ);
-      spotBlack.target.position.set(0, 0.75, blackZ);
-      scene.add(spotBlack, spotBlack.target);
-
-      // match central spotlight penumbra to better illuminate the D area
-      const spotD = new THREE.SpotLight(
-        0xffffff,
-        1.8,
-        0,
-        Math.PI / 2,
-        0.8,
-        1
-      );
-      spotD.position.set(0, 5, baulkZ);
-      spotD.target.position.set(0, 0.75, baulkZ);
-      scene.add(spotD, spotD.target);
 
       cueRef.current = cue;
       ballsRef.current = balls;


### PR DESCRIPTION
## Summary
- use RectAreaLightUniformsLib and three RectAreaLights to light snooker table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3f3dbeff483299eb98d79447ea11f