### PR TITLE
Fix snooker table spot markers

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -183,7 +183,8 @@ const COLORS = Object.freeze({
   blue: 0x0000ff,
   pink: 0xff69b4,
   black: 0x000000,
-  mark: 0xffffff
+  mark: 0xffffff,
+  spot: 0x000000
 });
 
 // Kamera: lejojmë ulje më të madhe (phi më i vogël), por mos shko kurrë krejt në nivel (limit ~0.5rad)
@@ -667,7 +668,7 @@ function Table3D(scene) {
     const r = new THREE.Mesh(
       new THREE.RingGeometry(0.6, 1.0, 24),
       new THREE.MeshBasicMaterial({
-        color: COLORS.mark,
+        color: COLORS.spot,
         depthTest: false,
         depthWrite: false
       })


### PR DESCRIPTION
## Summary
- add separate color for snooker table spots
- render table spots with dark ring material to avoid bright spotlights

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f85602a48329bff7f52652042083