### PR TITLE
Fix Snooker ball height offset

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -161,7 +161,7 @@ const PLAY_H = TABLE.H - 2 * TABLE.WALL;
 const TABLE_H = 0.75;
 let BALL_R = 0.055 * SCALE_INV;
 // bring balls slightly closer to the cloth so they appear level with the field
-const BALL_Y = TABLE_H + BALL_R * 0.98;
+const BALL_Y = BALL_R * 0.98;
 // slightly larger visual radius so rails align with pocket rings
 const POCKET_VIS_R = 2.1 * BALL_R;
 const POCKET_R = POCKET_VIS_R * 0.9;


### PR DESCRIPTION
## Summary
- keep ball centers relative to table by using radius offset only

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c51c8921148329956d845d44ab6764