### PR TITLE
feat(snooker): add arena rug and walls

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -547,6 +547,173 @@ function Table3D(scene) {
   scene.add(table);
   return { centers: pocketCenters(), baulkZ, group: table };
 }
+
+// --------------------------------------------------
+// Rug + Tiles + Arena Walls (decorated room)
+// --------------------------------------------------
+function addArena(scene) {
+  const Wpx = 2048, Hpx = 1400;
+
+  function hairStroke(ctx, x, y, len, ang, alpha) {
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.rotate(ang);
+    const w = 1 + Math.random() * 0.6;
+    const l = len * (0.6 + Math.random() * 0.8);
+    const grd = ctx.createLinearGradient(0, 0, l, 0);
+    grd.addColorStop(0, `rgba(30,0,8,0)`);
+    grd.addColorStop(0.25, `rgba(30,0,8,${alpha})`);
+    grd.addColorStop(0.75, `rgba(80,0,18,${alpha})`);
+    grd.addColorStop(1, `rgba(30,0,8,0)`);
+    ctx.fillStyle = grd;
+    ctx.fillRect(0, -w * 0.5, l, w);
+    ctx.restore();
+  }
+
+  function makeRugTexture(w, h) {
+    const c = document.createElement('canvas');
+    c.width = w;
+    c.height = h;
+    const ctx = c.getContext('2d');
+    const g = ctx.createLinearGradient(0, 0, w, h);
+    g.addColorStop(0, '#5a0014');
+    g.addColorStop(1, '#30000b');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, w, h);
+
+    for (let i = 0; i < 9000; i++)
+      hairStroke(
+        ctx,
+        Math.random() * w,
+        Math.random() * h,
+        10 + Math.random() * 22,
+        Math.random() * 0.6 - 0.3,
+        0.18
+      );
+    for (let i = 0; i < 6000; i++)
+      hairStroke(
+        ctx,
+        Math.random() * w,
+        Math.random() * h,
+        8 + Math.random() * 18,
+        Math.random() * 0.6 - 0.3 + 0.6,
+        0.12
+      );
+
+    ctx.lineJoin = 'miter';
+    ctx.strokeStyle = '#d4af37';
+    ctx.lineWidth = 16;
+    ctx.strokeRect(8, 8, w - 16, h - 16);
+    const inset = 28;
+    ctx.lineWidth = 8;
+    ctx.strokeRect(inset, inset, w - 2 * inset, h - 2 * inset);
+
+    return new THREE.CanvasTexture(c);
+  }
+
+  const tex = makeRugTexture(Wpx, Hpx);
+  tex.wrapS = tex.wrapT = THREE.ClampToEdgeWrapping;
+  tex.anisotropy = 8;
+  tex.needsUpdate = true;
+  const rugMat = new THREE.MeshStandardMaterial({
+    map: tex,
+    roughness: 0.96,
+    metalness: 0.05,
+  });
+
+  const scale = 1.2;
+  const rug = new THREE.Mesh(
+    new THREE.PlaneGeometry((Wpx / 100) * scale, (Hpx / 100) * scale),
+    rugMat
+  );
+  rug.rotation.x = -Math.PI / 2;
+  scene.add(rug);
+
+  const tileMat = new THREE.MeshStandardMaterial({
+    color: 0x2a2a2a,
+    roughness: 0.9,
+    metalness: 0.05,
+  });
+  const tileGeo = new THREE.PlaneGeometry(
+    (Wpx / 100) * (scale + 0.4),
+    (Hpx / 100) * (scale + 0.4)
+  );
+  const tiles = new THREE.Mesh(tileGeo, tileMat);
+  tiles.rotation.x = -Math.PI / 2;
+  tiles.position.y = -0.001;
+  scene.add(tiles);
+
+  // Tall decorated walls
+  const wallH = 6.0;
+  const wallT = 0.05;
+  const wallW = (Wpx / 100) * (scale + 0.4);
+  const wallL = (Hpx / 100) * (scale + 0.4);
+  const wallMat = new THREE.MeshStandardMaterial({
+    color: 0x8b8000,
+    roughness: 0.8,
+    metalness: 0.2,
+  });
+
+  const wallGeoX = new THREE.BoxGeometry(wallW, wallH, wallT);
+  const wallGeoZ = new THREE.BoxGeometry(wallT, wallH, wallL);
+  const walls = new THREE.Group();
+
+  const wall1 = new THREE.Mesh(wallGeoX, wallMat);
+  wall1.position.set(0, wallH / 2, -wallL / 2);
+  const wall2 = new THREE.Mesh(wallGeoX, wallMat);
+  wall2.position.set(0, wallH / 2, wallL / 2);
+  const wall3 = new THREE.Mesh(wallGeoZ, wallMat);
+  wall3.position.set(-wallW / 2, wallH / 2, 0);
+  const wall4 = new THREE.Mesh(wallGeoZ, wallMat);
+  wall4.position.set(wallW / 2, wallH / 2, 0);
+  walls.add(wall1, wall2, wall3, wall4);
+  scene.add(walls);
+
+  // Spotlights mounted on walls
+  const wallLights = new THREE.Group();
+  [wall1, wall2, wall3, wall4].forEach((wall, idx) => {
+    for (let i = 0; i < 3; i++) {
+      const s = new THREE.SpotLight(0xffffff, 0.6, 0, Math.PI * 0.25, 0.4, 1);
+      s.position.set(wall.position.x, wallH - 0.5, wall.position.z);
+      if (idx < 2) s.target.position.set(0, 0, wall.position.z * 0.5);
+      else s.target.position.set(wall.position.x * 0.5, 0, 0);
+      scene.add(s);
+      scene.add(s.target);
+      wallLights.add(s);
+    }
+  });
+
+  // Simple decor items: framed posters + trophies
+  const decoMat = new THREE.MeshStandardMaterial({
+    color: 0xffffff,
+    metalness: 0.3,
+    roughness: 0.6,
+  });
+  const frameGeo = new THREE.BoxGeometry(0.5, 0.7, 0.05);
+  for (let i = 0; i < 4; i++) {
+    const poster = new THREE.Mesh(frameGeo, decoMat);
+    poster.position.set(-wallW / 2 + 0.3 + i * 0.8, wallH / 2, -wallL / 2 + 0.05);
+    scene.add(poster);
+  }
+
+  const trophyGeo = new THREE.ConeGeometry(0.05, 0.2, 16);
+  const trophyMat = new THREE.MeshStandardMaterial({
+    color: 0xffd700,
+    metalness: 1,
+    roughness: 0.2,
+  });
+  for (let i = 0; i < 5; i++) {
+    const t = new THREE.Mesh(trophyGeo, trophyMat);
+    t.position.set(
+      (Math.random() - 0.5) * wallW * 0.6,
+      0.12,
+      (Math.random() - 0.5) * wallL * 0.6
+    );
+    scene.add(t);
+  }
+
+  return { rug, tiles, walls, wallLights };
+}
 // --------------------------------------------------
 // NEW Engine (no globals). Camera feels like standing at the side.
 // --------------------------------------------------
@@ -740,6 +907,11 @@ export default function NewSnookerGame() {
       // Scene & Camera
       const scene = new THREE.Scene();
       scene.background = new THREE.Color(0x050505);
+      scene.add(new THREE.HemisphereLight(0xdde7ff, 0x0b1020, 0.8));
+      const dir = new THREE.DirectionalLight(0xffffff, 1.2);
+      dir.position.set(-2.5, 4, 2);
+      scene.add(dir);
+      addArena(scene);
       let cue;
       let shooting = false; // track when a shot is in progress
       const camera = new THREE.PerspectiveCamera(


### PR DESCRIPTION
## Summary
- add addArena helper to create textured rug, tiles, walls and decor
- mount arena with hemisphere/directional lights in Snooker game

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, 'inc' is never reassigned, etc)*

------
https://chatgpt.com/codex/tasks/task_e_68c54c476d348329864a48e61d74446b