### PR TITLE
Add decorative rug and walls to snooker arena

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -892,6 +892,160 @@ export default function NewSnookerGame() {
       const dir = new THREE.DirectionalLight(0xffffff, 1.4);
       dir.position.set(-2.5, 4, 2);
       scene.add(dir);
+      // --- Rug + Tiles + Arena Walls ---
+      (function addArena() {
+        const Wpx = 2048,
+          Hpx = 1400;
+        function hairStroke(ctx, x, y, len, ang, alpha) {
+          ctx.save();
+          ctx.translate(x, y);
+          ctx.rotate(ang);
+          const w = 1 + Math.random() * 0.6;
+          const l = len * (0.6 + Math.random() * 0.8);
+          const grd = ctx.createLinearGradient(0, 0, l, 0);
+          grd.addColorStop(0, `rgba(30,0,8,0)`);
+          grd.addColorStop(0.25, `rgba(30,0,8,${alpha})`);
+          grd.addColorStop(0.75, `rgba(80,0,18,${alpha})`);
+          grd.addColorStop(1, `rgba(30,0,8,0)`);
+          ctx.fillStyle = grd;
+          ctx.fillRect(0, -w * 0.5, l, w);
+          ctx.restore();
+        }
+        function makeRugTexture(w, h) {
+          const c = document.createElement('canvas');
+          c.width = w;
+          c.height = h;
+          const ctx = c.getContext('2d');
+          const g = ctx.createLinearGradient(0, 0, w, h);
+          g.addColorStop(0, '#5a0014');
+          g.addColorStop(1, '#30000b');
+          ctx.fillStyle = g;
+          ctx.fillRect(0, 0, w, h);
+          for (let i = 0; i < 9000; i++)
+            hairStroke(
+              ctx,
+              Math.random() * w,
+              Math.random() * h,
+              10 + Math.random() * 22,
+              Math.random() * 0.6 - 0.3,
+              0.18
+            );
+          for (let i = 0; i < 6000; i++)
+            hairStroke(
+              ctx,
+              Math.random() * w,
+              Math.random() * h,
+              8 + Math.random() * 18,
+              Math.random() * 0.6 - 0.3 + 0.6,
+              0.12
+            );
+          ctx.lineJoin = 'miter';
+          ctx.strokeStyle = '#d4af37';
+          ctx.lineWidth = 16;
+          ctx.strokeRect(8, 8, w - 16, h - 16);
+          const inset = 28;
+          ctx.lineWidth = 8;
+          ctx.strokeRect(inset, inset, w - 2 * inset, h - 2 * inset);
+          return new THREE.CanvasTexture(c);
+        }
+        const tex = makeRugTexture(Wpx, Hpx);
+        tex.wrapS = tex.wrapT = THREE.ClampToEdgeWrapping;
+        tex.anisotropy = 8;
+        tex.needsUpdate = true;
+        const rugMat = new THREE.MeshStandardMaterial({
+          map: tex,
+          roughness: 0.96,
+          metalness: 0.05
+        });
+        const scale = 1.2;
+        const floorY = TABLE_Y - TABLE.THICK - TABLE_H - 0.05;
+        const arena = new THREE.Group();
+        arena.position.y = floorY;
+        const rug = new THREE.Mesh(
+          new THREE.PlaneGeometry((Wpx / 100) * scale, (Hpx / 100) * scale),
+          rugMat
+        );
+        rug.rotation.x = -Math.PI / 2;
+        arena.add(rug);
+        const tileMat = new THREE.MeshStandardMaterial({
+          color: 0x2a2a2a,
+          roughness: 0.9,
+          metalness: 0.05
+        });
+        const tileGeo = new THREE.PlaneGeometry(
+          (Wpx / 100) * (scale + 0.4),
+          (Hpx / 100) * (scale + 0.4)
+        );
+        const tiles = new THREE.Mesh(tileGeo, tileMat);
+        tiles.rotation.x = -Math.PI / 2;
+        tiles.position.y = -0.001;
+        arena.add(tiles);
+        const wallH = 6.0;
+        const wallT = 0.05;
+        const wallW = (Wpx / 100) * (scale + 0.4);
+        const wallL = (Hpx / 100) * (scale + 0.4);
+        const wallMat = new THREE.MeshStandardMaterial({
+          color: 0x8b8000,
+          roughness: 0.8,
+          metalness: 0.2
+        });
+        const wallGeoX = new THREE.BoxGeometry(wallW, wallH, wallT);
+        const wallGeoZ = new THREE.BoxGeometry(wallT, wallH, wallL);
+        const walls = new THREE.Group();
+        const wall1 = new THREE.Mesh(wallGeoX, wallMat);
+        wall1.position.set(0, wallH / 2, -wallL / 2);
+        const wall2 = new THREE.Mesh(wallGeoX, wallMat);
+        wall2.position.set(0, wallH / 2, wallL / 2);
+        const wall3 = new THREE.Mesh(wallGeoZ, wallMat);
+        wall3.position.set(-wallW / 2, wallH / 2, 0);
+        const wall4 = new THREE.Mesh(wallGeoZ, wallMat);
+        wall4.position.set(wallW / 2, wallH / 2, 0);
+        walls.add(wall1, wall2, wall3, wall4);
+        arena.add(walls);
+        [wall1, wall2, wall3, wall4].forEach((wall, idx) => {
+          for (let i = 0; i < 3; i++) {
+            const s = new THREE.SpotLight(
+              0xffffff,
+              0.6,
+              0,
+              Math.PI * 0.25,
+              0.4,
+              1
+            );
+            s.position.set(wall.position.x, wallH - 0.5, wall.position.z);
+            if (idx < 2) s.target.position.set(0, 0, wall.position.z * 0.5);
+            else s.target.position.set(wall.position.x * 0.5, 0, 0);
+            arena.add(s, s.target);
+          }
+        });
+        const decoMat = new THREE.MeshStandardMaterial({
+          color: 0xffffff,
+          metalness: 0.3,
+          roughness: 0.6
+        });
+        const frameGeo = new THREE.BoxGeometry(0.5, 0.7, 0.05);
+        for (let i = 0; i < 4; i++) {
+          const poster = new THREE.Mesh(frameGeo, decoMat);
+          poster.position.set(-wallW / 2 + 0.3 + i * 0.8, wallH / 2, -wallL / 2 + 0.05);
+          arena.add(poster);
+        }
+        const trophyGeo = new THREE.ConeGeometry(0.05, 0.2, 16);
+        const trophyMat = new THREE.MeshStandardMaterial({
+          color: 0xffd700,
+          metalness: 1,
+          roughness: 0.2
+        });
+        for (let i = 0; i < 5; i++) {
+          const t = new THREE.Mesh(trophyGeo, trophyMat);
+          t.position.set(
+            (Math.random() - 0.5) * wallW * 0.6,
+            0.12,
+            (Math.random() - 0.5) * wallL * 0.6
+          );
+          arena.add(t);
+        }
+        scene.add(arena);
+      })();
       const fullTableAngle = Math.PI / 2;
       const spot = new THREE.SpotLight(0xffffff, 2, 0, fullTableAngle, 0.3, 1);
       spot.position.set(1.3, 3.2, 0.5);


### PR DESCRIPTION
## Summary
- add Arena IIFE to generate rug, tiled floor, and gold walls around snooker table
- mount wall spotlights and simple decor (posters, trophies)

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, prefer-const etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c55024db748329a8991cd5a1414fa0