### PR TITLE
Expand snooker table carpet area

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -235,8 +235,8 @@ function makeRugTexture(Wpx = 2048, Hpx = 1400) {
 function addRugUnderTable(scene, table) {
   const box = new THREE.Box3().setFromObject(table);
   const size = box.getSize(new THREE.Vector3());
-  const rugWidth = size.x * 2; // 100% larger than table width
-  const rugHeight = size.z * 2; // 100% larger than table length
+  const rugWidth = size.x * 4; // extends 150% beyond table width on each side
+  const rugHeight = size.z * 4; // extends 150% beyond table length on each side
   const tex = makeRugTexture();
   tex.wrapS = tex.wrapT = THREE.ClampToEdgeWrapping;
   tex.anisotropy = 8;


### PR DESCRIPTION
## Summary
- extend snooker scene's rug to stretch 150% beyond table on all sides

## Testing
- `npm test`
- `npm run lint` *(fails: 937 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c565e713a483299fe3dce9c2a484c4