### PR TITLE
Refine 3D Snooker lighting

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1063,20 +1063,27 @@ export default function NewSnookerGame() {
       dir.position.set(-2.5, 4, 2);
       scene.add(dir);
       const fullTableAngle = Math.PI / 2;
+      const lightHeight = TABLE_Y + 0.3;
+      const lightX = TABLE.W / 2 - 5;
+      const lightZ = TABLE.H / 2 - 5;
+
       const spot = new THREE.SpotLight(0xffffff, 2, 0, fullTableAngle, 0.3, 1);
-      spot.position.set(10, -1, 10);
+      spot.position.set(lightX, lightHeight, lightZ);
       spot.target.position.set(0, TABLE_Y, 0);
       scene.add(spot, spot.target);
+
       const spotTop = new THREE.SpotLight(0xffffff, 1.8, 0, fullTableAngle, 0.4, 1);
-      spotTop.position.set(-10, -1, 10);
+      spotTop.position.set(-lightX, lightHeight, lightZ);
       spotTop.target.position.set(0, TABLE_Y, 0);
       scene.add(spotTop, spotTop.target);
+
       const spotBottom = new THREE.SpotLight(0xffffff, 1.8, 0, fullTableAngle, 0.4, 1);
-      spotBottom.position.set(-10, -1, -10);
+      spotBottom.position.set(-lightX, lightHeight, -lightZ);
       spotBottom.target.position.set(0, TABLE_Y, 0);
       scene.add(spotBottom, spotBottom.target);
+
       const spotExtra = new THREE.SpotLight(0xffffff, 1.5, 0, fullTableAngle, 0.4, 1);
-      spotExtra.position.set(10, -1, -10);
+      spotExtra.position.set(lightX, lightHeight, -lightZ);
       spotExtra.target.position.set(0, TABLE_Y, 0);
       scene.add(spotExtra, spotExtra.target);
 


### PR DESCRIPTION
## Summary
- Reposition snooker scene spotlights nearer the table and further apart for better coverage

## Testing
- `npm test`
- `npm run lint` *(fails: numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c576b4067c83299f7d762cdb439d8c