### PR TITLE
Add pocket spotlights and simplify snooker cloth

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -12,129 +12,6 @@ import { SnookerRules } from '../../../../src/rules/SnookerRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 
 // --------------------------------------------------
-// Procedural emerald cloth texture utilities
-// --------------------------------------------------
-function makeFbmHeightCanvas(size = 512, octaves = 5) {
-  const c = document.createElement('canvas');
-  c.width = c.height = size;
-  const ctx = c.getContext('2d');
-  const img = ctx.createImageData(size, size);
-  function valueNoise(grid, x, y) {
-    const x0 = Math.floor(x),
-      y0 = Math.floor(y);
-    const x1 = x0 + 1,
-      y1 = y0 + 1;
-    const sx = x - x0,
-      sy = y - y0;
-    const v00 = grid[(y0 & 255) * 256 + (x0 & 255)];
-    const v10 = grid[(y0 & 255) * 256 + (x1 & 255)];
-    const v01 = grid[(y1 & 255) * 256 + (x0 & 255)];
-    const v11 = grid[(y1 & 255) * 256 + (x1 & 255)];
-    const cx = (1 - Math.cos(sx * Math.PI)) * 0.5;
-    const cy = (1 - Math.cos(sy * Math.PI)) * 0.5;
-    const ix0 = v00 * (1 - cx) + v10 * cx;
-    const ix1 = v01 * (1 - cx) + v11 * cx;
-    return ix0 * (1 - cy) + ix1 * cy;
-  }
-  const grid = new Float32Array(256 * 256);
-  for (let i = 0; i < grid.length; i++) grid[i] = Math.random();
-  const lacunarity = 2.2;
-  const gain = 0.52;
-  for (let y = 0; y < size; y++) {
-    for (let x = 0; x < size; x++) {
-      let amp = 1,
-        freq = 1 / 24,
-        sum = 0,
-        norm = 0;
-      for (let o = 0; o < octaves; o++) {
-        const nx = x * freq,
-          ny = y * freq;
-        const v = valueNoise(grid, nx, ny);
-        sum += v * amp;
-        norm += amp;
-        amp *= gain;
-        freq *= lacunarity;
-      }
-      let h = sum / norm;
-      h = Math.pow(h, 1.25);
-      const i = (y * size + x) * 4;
-      img.data[i + 0] = img.data[i + 1] = img.data[i + 2] = Math.floor(h * 255);
-      img.data[i + 3] = 255;
-    }
-  }
-  ctx.putImageData(img, 0, 0);
-  return c;
-}
-
-function heightToNormalCanvas(heightCanvas, strength = 2.0) {
-  const w = heightCanvas.width,
-    h = heightCanvas.height;
-  const src = heightCanvas.getContext('2d').getImageData(0, 0, w, h).data;
-  const c = document.createElement('canvas');
-  c.width = w;
-  c.height = h;
-  const ctx = c.getContext('2d');
-  const out = ctx.createImageData(w, h);
-  const get = (x, y) => src[(((y + h) % h) * w + ((x + w) % w)) << 2];
-  for (let y = 0; y < h; y++) {
-    for (let x = 0; x < w; x++) {
-      const hL = get(x - 1, y),
-        hR = get(x + 1, y);
-      const hD = get(x, y + 1),
-        hU = get(x, y - 1);
-      const dx = ((hR - hL) / 255) * strength;
-      const dy = ((hD - hU) / 255) * strength;
-      let nx = -dx,
-        ny = -dy,
-        nz = 1.0;
-      const invLen = 1.0 / Math.sqrt(nx * nx + ny * ny + nz * nz);
-      nx *= invLen;
-      ny *= invLen;
-      nz *= invLen;
-      const i = (y * w + x) * 4;
-      out.data[i + 0] = Math.floor((nx * 0.5 + 0.5) * 255);
-      out.data[i + 1] = Math.floor((ny * 0.5 + 0.5) * 255);
-      out.data[i + 2] = Math.floor((nz * 0.5 + 0.5) * 255);
-      out.data[i + 3] = 255;
-    }
-  }
-  ctx.putImageData(out, 0, 0);
-  return c;
-}
-
-function makeColorCanvasFromHeight(
-  heightCanvas,
-  c0 = '#1a8f2f',
-  c1 = '#23b043',
-  variation = 0.08
-) {
-  const w = heightCanvas.width,
-    h = heightCanvas.height;
-  const src = heightCanvas.getContext('2d').getImageData(0, 0, w, h).data;
-  const c = document.createElement('canvas');
-  c.width = w;
-  c.height = h;
-  const ctx = c.getContext('2d');
-  const out = ctx.createImageData(w, h);
-  const ca = new THREE.Color(c0),
-    cb = new THREE.Color(c1);
-  for (let i = 0; i < w * h; i++) {
-    const v = src[i * 4] / 255;
-    const t = Math.min(
-      1,
-      Math.max(0, v * (1 + (Math.random() - 0.5) * variation))
-    );
-    const col = ca.clone().lerp(cb, t);
-    out.data[i * 4 + 0] = Math.floor(col.r * 255);
-    out.data[i * 4 + 1] = Math.floor(col.g * 255);
-    out.data[i * 4 + 2] = Math.floor(col.b * 255);
-    out.data[i * 4 + 3] = 255;
-  }
-  ctx.putImageData(out, 0, 0);
-  return c;
-}
-
-// --------------------------------------------------
 // Procedural rug texture and floor helper
 // --------------------------------------------------
 function makeRugTexture(Wpx = 2048, Hpx = 1400) {
@@ -947,7 +824,7 @@ export default function NewSnookerGame() {
           sph.phi,
           CAMERA.minPhi,
           Math.min(phiCap, CAMERA.maxPhi)
-        );
+      );
         t = (sph.phi - CAMERA.minPhi) / (CAMERA.maxPhi - CAMERA.minPhi);
         sph.radius = clamp(baseR * (1 - 0.8 * t), CAMERA.minR, CAMERA.maxR);
         updateCamera();
@@ -1063,29 +940,13 @@ export default function NewSnookerGame() {
       dir.position.set(-2.5, 4, 2);
       scene.add(dir);
       const fullTableAngle = Math.PI / 2;
-      const lightHeight = TABLE_Y + 0.3;
-      const lightX = TABLE.W / 2 - 5;
-      const lightZ = TABLE.H / 2 - 5;
-
-      const spot = new THREE.SpotLight(0xffffff, 2, 0, fullTableAngle, 0.3, 1);
-      spot.position.set(lightX, lightHeight, lightZ);
-      spot.target.position.set(0, TABLE_Y, 0);
-      scene.add(spot, spot.target);
-
-      const spotTop = new THREE.SpotLight(0xffffff, 1.8, 0, fullTableAngle, 0.4, 1);
-      spotTop.position.set(-lightX, lightHeight, lightZ);
-      spotTop.target.position.set(0, TABLE_Y, 0);
-      scene.add(spotTop, spotTop.target);
-
-      const spotBottom = new THREE.SpotLight(0xffffff, 1.8, 0, fullTableAngle, 0.4, 1);
-      spotBottom.position.set(-lightX, lightHeight, -lightZ);
-      spotBottom.target.position.set(0, TABLE_Y, 0);
-      scene.add(spotBottom, spotBottom.target);
-
-      const spotExtra = new THREE.SpotLight(0xffffff, 1.5, 0, fullTableAngle, 0.4, 1);
-      spotExtra.position.set(lightX, lightHeight, -lightZ);
-      spotExtra.target.position.set(0, TABLE_Y, 0);
-      scene.add(spotExtra, spotExtra.target);
+      const spotHeight = TABLE_Y + 0.15;
+      pocketCenters().forEach((c) => {
+        const s = new THREE.SpotLight(0xffffff, 1.5, 0, fullTableAngle, 0.4, 1);
+        s.position.set(c.x, spotHeight, c.y);
+        s.target.position.set(c.x, TABLE_Y, c.y);
+        scene.add(s, s.target);
+      });
 
       // Table
       const { centers, baulkZ, group: table } = Table3D(scene);
@@ -1345,7 +1206,7 @@ export default function NewSnookerGame() {
         if (cameraRef.current && sphRef.current && fitRef.current) {
           topViewRef.current = false;
           const cam = cameraRef.current;
-          const sph = sphRef.current;
+        const sph = sphRef.current;
           sph.theta = Math.PI;
           sph.phi = 0.9;
           fitRef.current(1.6);
@@ -1448,7 +1309,7 @@ export default function NewSnookerGame() {
         shooting = false;
         if (cameraRef.current && sphRef.current && fitRef.current) {
           const cam = cameraRef.current;
-          const sph = sphRef.current;
+        const sph = sphRef.current;
           sph.radius = fitRadius(cam, 1.25);
           sph.phi = 0.9;
           fitRef.current(1.25);
@@ -1471,7 +1332,7 @@ export default function NewSnookerGame() {
             aimDir,
             balls
           );
-          const start = new THREE.Vector3(cue.pos.x, BALL_R, cue.pos.y);
+        const start = new THREE.Vector3(cue.pos.x, BALL_R, cue.pos.y);
           let end = new THREE.Vector3(impact.x, BALL_R, impact.y);
           const dir = new THREE.Vector3(aimDir.x, 0, aimDir.y).normalize();
           if (start.distanceTo(end) < 1e-4) {
@@ -1489,9 +1350,9 @@ export default function NewSnookerGame() {
           ]);
           tick.visible = true;
           const pull = powerRef.current * BALL_R * 10 * 0.5;
-          const side = spinRef.current.x * spinRangeRef.current;
+        const side = spinRef.current.x * spinRangeRef.current;
           const vert = -spinRef.current.y * spinRangeRef.current;
-          const spinWorld = new THREE.Vector3(
+        const spinWorld = new THREE.Vector3(
             perp.x * side,
             vert,
             perp.z * side
@@ -1530,7 +1391,7 @@ export default function NewSnookerGame() {
           if (!b.active) return;
           b.pos.add(b.vel);
           b.vel.multiplyScalar(FRICTION);
-          const speed = b.vel.length();
+        const speed = b.vel.length();
           if (speed < STOP_EPS) b.vel.set(0, 0);
           reflectRails(b);
           b.mesh.position.set(b.pos.x, BALL_R, b.pos.y);


### PR DESCRIPTION
## Summary
- Add looped spotlights for all six pockets and lower them closer to the table surface
- Remove unused procedural cloth texture utilities, keeping cloth a plain material

## Testing
- `npm test`
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c579c6c7b883299df507a24815858e