### PR TITLE
Make snooker table spots square and slightly larger

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -722,7 +722,8 @@ function Table3D(scene) {
   table.add(dMesh);
 
   const spots = spotPositions(baulkZ);
-  const spotGeom = new THREE.CircleGeometry(BALL_R * 0.3, 32);
+  const spotSize = BALL_R * 0.6;
+  const spotGeom = new THREE.PlaneGeometry(spotSize, spotSize);
   const spotMat = new THREE.MeshBasicMaterial({ color: COLORS.markings });
   Object.values(spots).forEach(([x, z]) => {
     const s = new THREE.Mesh(spotGeom, spotMat);


### PR DESCRIPTION
## Summary
- Render snooker table spots as slightly enlarged squares instead of small circles

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, prefer-const)*

------
https://chatgpt.com/codex/tasks/task_e_68c672c3d57c832990fdb89c5c035e53