### PR TITLE
Adjust snooker spotlights closer to table center

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1365,7 +1365,7 @@ export default function NewSnookerGame() {
       scene.add(dir);
       const fullTableAngle = Math.PI / 2;
       const lightHeight = TABLE_Y + 4.5;
-      const lightOffset = 20;
+      const lightOffset = 15;
       const lightX = TABLE.W / 2 - lightOffset;
       const lightZ = TABLE.H / 2 - lightOffset;
 


### PR DESCRIPTION
## Summary
- Move snooker table spotlights slightly closer to center

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c67f813e008329b166cb23b7ac5c19