### PR TITLE
Adjust snooker spotlight positioning

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1364,8 +1364,9 @@ export default function NewSnookerGame() {
       dir.position.set(-2.5, 4, 2);
       scene.add(dir);
       const fullTableAngle = Math.PI / 2;
-      const lightHeight = TABLE_Y + 3.5;
-      const lightOffset = 20;
+      // Position spotlights slightly closer to the table center and surface
+      const lightHeight = TABLE_Y + 3.0;
+      const lightOffset = 25;
       const lightX = TABLE.W / 2 - lightOffset;
       const lightZ = TABLE.H / 2 - lightOffset;
 


### PR DESCRIPTION
## Summary
- Move Snooker table spotlights closer to the centre and surface for better lighting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c68a7798fc832990012b20e8ac8f76