### PR TITLE
Restrict Snooker game to mobile devices

### DIFF
--- a/webapp/src/hooks/useIsMobile.js
+++ b/webapp/src/hooks/useIsMobile.js
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+export function useIsMobile(maxWidth = 768) {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    const touch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    return touch && window.innerWidth <= maxWidth;
+  });
+
+  useEffect(() => {
+    const check = () => {
+      const touch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+      setIsMobile(touch && window.innerWidth <= maxWidth);
+    };
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, [maxWidth]);
+
+  return isMobile;
+}

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -17,6 +17,7 @@ import {
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { SnookerRules } from '../../../../src/rules/SnookerRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
+import { useIsMobile } from '../../hooks/useIsMobile.js';
 
 // --------------------------------------------------
 // Procedural emerald cloth texture utilities
@@ -905,7 +906,7 @@ function Table3D(scene) {
 // --------------------------------------------------
 // NEW Engine (no globals). Camera feels like standing at the side.
 // --------------------------------------------------
-export default function NewSnookerGame() {
+function SnookerGame() {
   const mountRef = useRef(null);
   const rafRef = useRef(null);
   const rules = useMemo(() => new SnookerRules(), []);
@@ -2035,4 +2036,18 @@ export default function NewSnookerGame() {
       </div>
     </div>
   );
+}
+
+export default function NewSnookerGame() {
+  const isMobile = useIsMobile();
+
+  if (!isMobile) {
+    return (
+      <div className="flex items-center justify-center w-full h-full p-4 text-center">
+        <p>This game is available on mobile devices only.</p>
+      </div>
+    );
+  }
+
+  return <SnookerGame />;
 }


### PR DESCRIPTION
## Summary
- Add `useIsMobile` hook to detect touch-based small screens
- Wrap snooker game to render only on mobile devices and show a message otherwise

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, prefer-const, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e830c8e48329a3cd4ea50ba8d9de