### PR TITLE
Use timestamp-based animation timing

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1721,7 +1721,10 @@ function SnookerGame() {
       }
 
       // Loop
-      const step = () => {
+      let lastTime = performance.now();
+      const step = (time) => {
+        const dt = (time - lastTime) / 1000;
+        lastTime = time;
         camera.getWorldDirection(camFwd);
         tmpAim.set(camFwd.x, camFwd.z).normalize();
         aimDir.lerp(tmpAim, 0.2);
@@ -1789,8 +1792,8 @@ function SnookerGame() {
         // Fizika
         balls.forEach((b) => {
           if (!b.active) return;
-          b.pos.add(b.vel);
-          b.vel.multiplyScalar(FRICTION);
+          b.pos.addScaledVector(b.vel, dt);
+          b.vel.multiplyScalar(Math.pow(FRICTION, dt * 60));
           const speed = b.vel.length();
           if (speed < STOP_EPS) b.vel.set(0, 0);
           reflectRails(b);
@@ -1867,7 +1870,7 @@ function SnookerGame() {
         renderer.render(scene, camera);
         rafRef.current = requestAnimationFrame(step);
       };
-      step();
+      rafRef.current = requestAnimationFrame(step);
 
       // Resize
       const onResize = () => {


### PR DESCRIPTION
## Summary
- Incorporate timestamp into snooker animation loop
- Scale ball updates and friction using delta time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6f36932748329bd1c22763d223e1f