### PR TITLE
Adjust snooker spotlight positions and intensity

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -322,13 +322,13 @@ function addArenaWalls(scene, rug) {
   walls.add(north, south, west, east);
   scene.add(walls);
   const addSpot = (base) => {
-    const s = new THREE.SpotLight(0xffffff, 0.02, 0, Math.PI * 0.6, 0.5, 1);
+    const s = new THREE.SpotLight(0xffffff, 0.01, 0, Math.PI * 0.6, 0.5, 1);
     const dir = new THREE.Vector3()
       .subVectors(base, rug.position)
       .setY(0)
       .normalize();
-    const pos = base.clone().add(dir.multiplyScalar(20));
-    pos.y = rug.position.y + wallH + 25;
+    const pos = base.clone().add(dir.multiplyScalar(40));
+    pos.y = rug.position.y + wallH + 40;
     s.position.copy(pos);
     s.target.position.set(rug.position.x, 0, rug.position.z);
     scene.add(s);


### PR DESCRIPTION
## Summary
- reposition snooker spotlights farther from table
- raise spotlights and reduce their brightness

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, prefer-const, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fdf56d808329af13620a5215715c