### PR TITLE
Adjust snooker table spotlights

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -322,20 +322,20 @@ function addArenaWalls(scene, rug) {
   walls.add(north, south, west, east);
   scene.add(walls);
   const addSpot = (base) => {
-    const s = new THREE.SpotLight(0xffffff, 0.01, 0, Math.PI * 0.6, 0.5, 1);
+    const s = new THREE.SpotLight(0xffffff, 0.005, 0, Math.PI * 0.6, 0.5, 1);
     const dir = new THREE.Vector3()
       .subVectors(base, rug.position)
       .setY(0)
       .normalize();
-    const pos = base.clone().add(dir.multiplyScalar(40));
-    pos.y = rug.position.y + wallH + 40;
+    const pos = base.clone().add(dir.multiplyScalar(60));
+    pos.y = rug.position.y + wallH + 60;
     s.position.copy(pos);
     s.target.position.set(rug.position.x, 0, rug.position.z);
     scene.add(s);
     scene.add(s.target);
   };
 
-  const sideOffset = rugWidth * 1.1;
+  const sideOffset = rugWidth * 1.3;
   [-1, 1].forEach((sign) => {
     addSpot(
       new THREE.Vector3(
@@ -352,7 +352,7 @@ function addArenaWalls(scene, rug) {
       )
     );
   });
-  const endOffset = rugHeight * 0.55;
+  const endOffset = rugHeight * 0.75;
   [-1, 1].forEach((sign) => {
     addSpot(
       new THREE.Vector3(


### PR DESCRIPTION
## Summary
- move snooker table spotlights further from the playfield perimeter
- elevate lights and reduce intensity for subtler effect

## Testing
- `npm test`
- `npm run lint` *(fails: Extra semicolon, Missing space before function parentheses, 'inc' is never reassigned...)*

------
https://chatgpt.com/codex/tasks/task_e_68c700055f048329a2c914ad531b18fb