### PR TITLE
Adjust Snooker camera starting viewpoint

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -516,8 +516,8 @@ const fitRadius = (camera, margin = 1.1) => {
 };
 
 // preset spherical positions for standing, cue-shot and post-shot views
-// start a little closer and higher when the game loads
-const STAND_VIEW = { radius: 260 * TABLE_SCALE, phi: 0.9 };
+// position the initial camera slightly closer to the table and a bit higher
+const STAND_VIEW = { radius: 220 * TABLE_SCALE, phi: 0.8 };
 const CUE_VIEW = { radius: 120 * TABLE_SCALE, phi: 1.45 };
 // after a shot, zoom out and lower the camera to show the whole table
 const SHOT_VIEW = { phi: 1.15, margin: 1.4 };


### PR DESCRIPTION
## Summary
- Move default Snooker camera slightly closer to the table and raise its angle for a better initial view.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c8053973d48329949255456da509a0