### PR TITLE
Raise initial snooker camera

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -516,8 +516,9 @@ const fitRadius = (camera, margin = 1.1) => {
 };
 
 // preset spherical positions for standing, cue-shot and post-shot views
-// position the initial camera slightly closer to the table and a bit higher
-const STAND_VIEW = { radius: 220 * TABLE_SCALE, phi: 0.8 };
+// position the initial camera slightly closer to the table and higher
+// start the game with the camera raised a little for a better overview
+const STAND_VIEW = { radius: 220 * TABLE_SCALE, phi: 0.75 };
 const CUE_VIEW = { radius: 120 * TABLE_SCALE, phi: 1.45 };
 // after a shot, zoom out and lower the camera to show the whole table
 const SHOT_VIEW = { phi: 1.15, margin: 1.4 };


### PR DESCRIPTION
## Summary
- raise starting camera height in Snooker view for a better overview

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c8075f8d808329a810cdbbea64d214