### PR TITLE
Restrict snooker game to touch devices

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1955,12 +1955,12 @@ function SnookerGame() {
 }
 
 export default function NewSnookerGame() {
-  const isMobile = useIsMobile();
+  const isMobileOrTablet = useIsMobile(1366);
 
-  if (!isMobile) {
+  if (!isMobileOrTablet) {
     return (
       <div className="flex items-center justify-center w-full h-full p-4 text-center">
-        <p>This game is available on mobile devices only.</p>
+        <p>This game is available on mobile phones and tablets only.</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- allow the snooker page to render the 3D canvas only on touch devices up to tablet widths
- update the desktop fallback message to clarify the game targets phones and tablets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c877624a088329b87c6e5775b05ff5