### PR TITLE
Add undercut geometry to snooker cushions

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -537,6 +537,27 @@ function Table3D(parent) {
       depth: railH,
       bevelEnabled: false
     });
+    const pos = geo.attributes.position;
+    const arr = pos.array;
+    const frontRange = backY - frontY;
+    const undercutLift = railH * 0.95;
+    const undercutInset = cushionInward + cushionW * 0.3;
+    for (let i = 0; i < arr.length; i += 3) {
+      const y = arr[i + 1];
+      const z = arr[i + 2];
+      if (z <= 0.001) {
+        const t = frontRange !== 0 ? THREE.MathUtils.clamp((y - frontY) / frontRange, 0, 1) : 1;
+        const frontFactor = 1 - t;
+        const lift = frontFactor * undercutLift;
+        arr[i + 2] = z + lift;
+        const targetY = THREE.MathUtils.lerp(y, frontY - undercutInset, frontFactor);
+        arr[i + 1] = targetY;
+      }
+    }
+    pos.needsUpdate = true;
+    geo.computeVertexNormals();
+    geo.computeBoundingBox();
+    geo.computeBoundingSphere();
     return geo;
   }
   function addCushion(x, z, len, horizontal, flip = false) {


### PR DESCRIPTION
## Summary
- carve the snooker cushion geometry after extrusion to introduce a diagonal undercut while preserving the top surface and rail-facing edges
- update cushion vertices and bounding data so the mesh keeps accurate normals and bounds after the cut

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9808072cc8329a767e27b8baf1acd