### PR TITLE
Fix snooker cushion chamfers and side rail alignment

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -497,7 +497,8 @@ function Table3D(parent) {
   const cushionW = TABLE.WALL * 0.9 * 1.08;
   const cushionExtend = 6 * 0.85;
   const cushionInward = TABLE.WALL * 0.15;
-  const SIDE_RAIL_OUTWARD = TABLE.WALL * 0.05;
+  // push the vertical rail groups slightly outward so angled cuts meet cleanly without overlap
+  const SIDE_RAIL_OUTWARD = TABLE.WALL * 0.075;
   function cushionProfile(len) {
     const L = len + cushionExtend + 6;
     const half = L / 2;
@@ -557,6 +558,9 @@ function Table3D(parent) {
     const frontRange = backY - frontY;
     const undercutLift = railH * 0.95;
     const undercutInset = cushionInward + cushionW * 0.3;
+    const tipStart = half - cut; // region where the 32° cushion chamfer begins
+    const tipSpan = cut;
+    const tipSlope = tipSpan !== 0 ? frontRange / tipSpan : 0;
     for (let i = 0; i < arr.length; i += 3) {
       const y = arr[i + 1];
       const z = arr[i + 2];
@@ -567,6 +571,16 @@ function Table3D(parent) {
         arr[i + 2] = z + lift;
         const targetY = THREE.MathUtils.lerp(y, frontY - undercutInset, frontFactor);
         arr[i + 1] = targetY;
+      }
+      const x = arr[i];
+      const currentY = arr[i + 1];
+      const absX = Math.abs(x);
+      if (absX >= tipStart - 1e-4) {
+        // clamp vertices within the chamfer to the ideal straight 32° plane
+        const dist = Math.min(tipSpan, Math.max(0, absX - tipStart));
+        const cutY = frontY + dist * tipSlope;
+        const clampedY = Math.min(backY, Math.max(currentY, cutY));
+        arr[i + 1] = clampedY;
       }
     }
     pos.needsUpdate = true;


### PR DESCRIPTION
## Summary
- clamp cushion vertices to the ideal 32° chamfer plane so the side cuts stay perfectly straight
- move the vertical side rail groups outward slightly to remove overlap while keeping them flush with the cushions

## Testing
- npm run lint -- webapp/src/pages/Games/Snooker.jsx *(fails: repository has pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a7717a4883298834c8917766162b