### PR TITLE
Trim snooker cushion backside

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -134,6 +134,8 @@ const CUE_TIP_GAP = BALL_R * 1.28; // pull cue stick slightly farther back for a
 const CUE_Y = BALL_R; // keep cue stick level with the cue ball center
 // angle for cushion cuts guiding balls into pockets
 const CUSHION_CUT_ANGLE = 32;
+// remove a percentage of the cushion depth from the rail-facing backside
+const CUSHION_BACK_TRIM = 0.35;
 
 // shared UI reduction factor so overlays and controls shrink alongside the table
 const UI_SCALE = SIZE_REDUCTION;
@@ -502,9 +504,12 @@ function Table3D(parent) {
   function cushionProfile(len) {
     const L = len + cushionExtend + 6;
     const half = L / 2;
-    const thickness = cushionW + cushionInward;
-    const backY = cushionW / 2;
-    const frontY = backY - thickness;
+    const rawThickness = cushionW + cushionInward;
+    const trimmedThickness = rawThickness * (1 - CUSHION_BACK_TRIM);
+    const originalBackY = cushionW / 2;
+    const frontY = originalBackY - rawThickness;
+    const backY = frontY + trimmedThickness;
+    const thickness = trimmedThickness;
     const rad = THREE.MathUtils.degToRad(CUSHION_CUT_ANGLE);
     const cut = thickness / Math.tan(rad);
     const tipLeft = -half + cut;


### PR DESCRIPTION
## Summary
- add a configuration constant to control cushion backside trimming
- shrink the snooker cushion profile by 35% on the rail-facing side while keeping the rail positions unchanged

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9af40534083299c7843c4cdce65e2