### PR TITLE
Fix cushion nose orientation around pockets

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -592,6 +592,13 @@ function Table3D(parent) {
     const geo = cushionProfile(len, horizontal);
     const mesh = new THREE.Mesh(geo, cushionMat);
     mesh.rotation.x = -Math.PI / 2;
+    if (horizontal) {
+      // Flip the cushion face so its thin "nose" always points toward the play field
+      mesh.rotation.y = Math.PI;
+    } else if (x < 0) {
+      // Left-hand cushions need the same flip; right-hand ones already face inward
+      mesh.rotation.y = Math.PI;
+    }
     const g = new THREE.Group();
     g.add(mesh);
     g.position.set(x, cushionRaiseY, z);


### PR DESCRIPTION
## Summary
- ensure each cushion section flips its nose toward the play field so pocket entries stay unobstructed

## Testing
- npm run lint -- webapp/src/pages/Games/Snooker.jsx *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca4c2634cc832988b9c5ef546778ff