### PR TITLE
Remove cushion undercut deformation

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -602,24 +602,6 @@ function Table3D(parent) {
       depth: railH,
       bevelEnabled: false
     });
-    const pos = geo.attributes.position;
-    const arr = pos.array;
-    const frontRange = backY - frontY;
-    const undercutLift = railH * 0.95;
-    const undercutInset = cushionInward + cushionW * 0.3;
-    for (let i = 0; i < arr.length; i += 3) {
-      const y = arr[i + 1];
-      const z = arr[i + 2];
-      if (z <= 0.001) {
-        const t = frontRange !== 0 ? THREE.MathUtils.clamp((y - frontY) / frontRange, 0, 1) : 1;
-        const frontFactor = 1 - t;
-        const lift = frontFactor * undercutLift;
-        arr[i + 2] = z + lift;
-        const targetY = THREE.MathUtils.lerp(y, frontY - undercutInset, frontFactor);
-        arr[i + 1] = targetY;
-      }
-    }
-    pos.needsUpdate = true;
     geo.computeVertexNormals();
     geo.computeBoundingBox();
     geo.computeBoundingSphere();


### PR DESCRIPTION
## Summary
- remove the vertex deformation that previously bent the snooker cushion undercut so the profile remains a straight cut up to the 32.5° chamfer

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68caa2997e708329989ba5bf8fcecc55