### PR TITLE
Adjust snooker cushion geometry

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -579,7 +579,7 @@ function Table3D(parent) {
   const LONG_CUSHION_TRIM = 2.25; // shave a touch from the long rails so they sit tighter to the pocket jaw
   const SIDE_RAIL_OUTWARD = TABLE.WALL * 0.05; // keep a slight jut without pulling cushions off the playfield
   const LONG_CUSHION_FACE_SHRINK = 0.97; // make the long cushions just a touch slimmer toward the play field
-  const CUSHION_UNDERCUT_FRONT_REMOVAL = 0.5; // remove the lower 50% of the cushion toward the play field side
+  const CUSHION_FRONT_GAP = 0.5; // lift the cushion underside toward the play field to leave a triangular void
   function cushionProfile(len, horizontal) {
     const L = len + cushionExtend + 6;
     const half = L / 2;
@@ -615,14 +615,20 @@ function Table3D(parent) {
     }
     const depth = Math.max(maxZ - minZ, 1e-6);
     const frontSpan = Math.max(backY - frontY, 1e-6);
+    const topThreshold = maxZ - depth * 0.02;
+    const topHeight = maxZ;
     for (let i = 0; i < arr.length; i += stride) {
       const y = arr[i + 1];
       const z = arr[i + 2];
+      if (z >= topThreshold) {
+        arr[i + 2] = topHeight;
+        continue;
+      }
       const frontFactor = THREE.MathUtils.clamp((backY - y) / frontSpan, 0, 1);
-      if (frontFactor <= 0) continue;
-      const maxAllowedZ = maxZ - depth * CUSHION_UNDERCUT_FRONT_REMOVAL * frontFactor;
-      if (z > maxAllowedZ) {
-        arr[i + 2] = maxAllowedZ;
+      if (frontFactor <= 1e-4) continue;
+      const minAllowedZ = minZ + depth * CUSHION_FRONT_GAP * frontFactor;
+      if (z < minAllowedZ) {
+        arr[i + 2] = minAllowedZ;
       }
     }
     positions.needsUpdate = true;


### PR DESCRIPTION
## Summary
- keep snooker cushion tops level by flattening their extruded geometry
- reshape the cushion underside so the front lifts away from the cloth and leaves a triangular void

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cab5e76c34832988a51c8df703f6b3