### PR TITLE
Adjust snooker cushion cut angle to 34 degrees

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -153,7 +153,7 @@ const TABLE_Y = -2 + (TABLE_H - 0.75) + TABLE_H;
 const CUE_TIP_GAP = BALL_R * 1.28; // pull cue stick slightly farther back for a more natural stance
 const CUE_Y = BALL_R; // keep cue stick level with the cue ball center
 // angle for cushion cuts guiding balls into pockets
-const CUSHION_CUT_ANGLE = 32.5;
+const CUSHION_CUT_ANGLE = 34;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
 const CUSHION_FACE_INSET = TABLE.WALL * 0.07; // align physics with cushion noses
 


### PR DESCRIPTION
## Summary
- update the cushion cut angle constant in the snooker game configuration to 34 degrees to match the desired cushion geometry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cac412f12c832980b0c464891809da