### PR TITLE
Reduce snooker world scale

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -118,7 +118,9 @@ function addPocketJaws(parent, playW, playH) {
 // Dimensions enlarged for a roomier snooker table but globally reduced by 30%
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION; // apply uniform 30% shrink from previous tuning
-const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR;
+// shrink the entire 3D world to ~70% of its previous footprint while preserving
+// the HUD scale and gameplay math that rely on worldScaleFactor conversions
+const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7;
 const BALL_SCALE = 1;
 const TABLE_SCALE = 1.3;
 const TABLE = {


### PR DESCRIPTION
## Summary
- reduce the Three.js snooker world scale so the full table and room render at roughly 70% of their previous footprint
- document why the world scale multiplier changed while keeping the HUD scaling untouched

## Testing
- npm run lint *(fails: pre-existing repository lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cadda14ae08329a008fbb2109ab0f5