### PR TITLE
Improve snooker pocket openings and camera framing

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -200,7 +200,7 @@ const CAMERA = {
   far: 4000,
   minR: 32 * TABLE_SCALE * GLOBAL_SIZE_FACTOR,
   maxR: 200 * TABLE_SCALE * GLOBAL_SIZE_FACTOR,
-  minPhi: 0.5,
+  minPhi: 0.56,
   // keep the camera slightly above the horizontal plane but allow a lower sweep
   maxPhi: Math.PI / 2 - 0.04
 };
@@ -214,10 +214,11 @@ const BREAK_VIEW = Object.freeze({
   phi: 1.12
 });
 const ACTION_VIEW = Object.freeze({
-  phiOffset: 0.08,
-  radiusFactor: 1.05,
-  followWeight: 0.35,
-  maxOffset: PLAY_W * 0.18
+  phiOffset: 0.04,
+  radiusFactor: 1.15,
+  followWeight: 0.28,
+  maxOffset: PLAY_W * 0.18,
+  lookCenterBlend: 0.3
 });
 const POCKET_IDLE_SWITCH_MS = 1600;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
@@ -691,6 +692,7 @@ function Table3D(parent) {
     linewidth: 2
   });
   const baulkZ = -PLAY_H / 4;
+  const SPOTS = spotPositions(baulkZ);
   const baulkGeom = new THREE.BufferGeometry().setFromPoints([
     new THREE.Vector3(-halfW, 0.02, baulkZ),
     new THREE.Vector3(halfW, 0.02, baulkZ)
@@ -913,20 +915,73 @@ function Table3D(parent) {
   table.userData.cushionTopLocal = cushionTopLocal;
 
   if (!table.userData.pockets) table.userData.pockets = [];
+  if (!table.userData.pocketRims) table.userData.pocketRims = [];
   const pocketLipTop = cushionTopLocal - 0.002;
-  pocketCenters().forEach((p) => {
+  const rimMat = new THREE.MeshStandardMaterial({
+    color: 0x362515,
+    metalness: 0.2,
+    roughness: 0.45,
+    side: THREE.DoubleSide
+  });
+  const entryTargets = [
+    new THREE.Vector2(...SPOTS.brown),
+    new THREE.Vector2(...SPOTS.brown),
+    new THREE.Vector2(...SPOTS.pink),
+    new THREE.Vector2(...SPOTS.pink),
+    new THREE.Vector2(...SPOTS.blue),
+    new THREE.Vector2(...SPOTS.blue)
+  ];
+  pocketCenters().forEach((p, idx) => {
+    const target = entryTargets[idx] ?? new THREE.Vector2(0, 0);
+    const entryDir = p.clone().sub(target);
+    if (entryDir.lengthSq() < 1e-4) {
+      entryDir.set(p.x, p.y);
+    }
+    entryDir.normalize();
+    const entryAngle = Math.atan2(entryDir.y, entryDir.x);
+    const thetaStart = entryAngle + Math.PI / 2;
     const cutHeight = railH * 3.0;
+    const cutGeo = new THREE.CylinderGeometry(
+      6.2,
+      6.2,
+      cutHeight,
+      48,
+      1,
+      true,
+      thetaStart,
+      Math.PI
+    );
     const cut = new THREE.Mesh(
-      new THREE.CylinderGeometry(6.2, 6.2, cutHeight, 48),
+      cutGeo,
       new THREE.MeshBasicMaterial({ color: 0x0b0f1a, side: THREE.DoubleSide })
     );
-    cut.rotation.set(0, 0, 0);
     const scaleY = 1.15;
     cut.scale.set(0.5, scaleY, 0.5);
     const half = (cutHeight * scaleY) / 2;
     cut.position.set(p.x, pocketLipTop - half, p.y);
     table.add(cut);
     table.userData.pockets.push(cut);
+
+    const rimInner = POCKET_VIS_R * 0.82;
+    const rimOuter = POCKET_VIS_R * 1.05;
+    const rimArc = Math.PI * 1.35;
+    const backAngle = entryAngle + Math.PI;
+    const rimStart = backAngle - rimArc / 2;
+    const rimGeo = new THREE.RingGeometry(
+      rimInner,
+      rimOuter,
+      48,
+      1,
+      rimStart,
+      rimArc
+    );
+    rimGeo.rotateX(-Math.PI / 2);
+    const rim = new THREE.Mesh(rimGeo, rimMat);
+    rim.position.set(p.x, pocketLipTop + 0.01, p.y);
+    rim.castShadow = true;
+    rim.receiveShadow = true;
+    table.add(rim);
+    table.userData.pocketRims.push(rim);
   });
 
   alignRailsToCushions(table, frame);
@@ -1333,11 +1388,27 @@ function SnookerGame() {
                 TABLE_Y + 0.05,
                 baseTarget.y + offsetVec.y
               ).multiplyScalar(worldScaleFactor);
-              const focusTarget = new THREE.Vector3(
+              const focusTargetLocal = new THREE.Vector3(
                 cue.pos.x,
                 BALL_R,
                 cue.pos.y
-              ).multiplyScalar(worldScaleFactor);
+              );
+              const centerTargetLocal = new THREE.Vector3(
+                baseTarget.x,
+                BALL_R,
+                baseTarget.y
+              );
+              const lookBlend = THREE.MathUtils.clamp(
+                activeShotView.lookCenterBlend ?? ACTION_VIEW.lookCenterBlend ?? 0,
+                0,
+                1
+              );
+              const blendedLocal = lookBlend
+                ? focusTargetLocal.clone().lerp(centerTargetLocal, lookBlend)
+                : focusTargetLocal;
+              const focusTarget = blendedLocal.clone().multiplyScalar(
+                worldScaleFactor
+              );
               camera.position.setFromSpherical(shotSph).add(anchor);
               camera.lookAt(focusTarget);
               lookTarget = focusTarget;
@@ -1399,20 +1470,46 @@ function SnookerGame() {
             lookTarget = focusTarget;
           } else {
             const followCue = cue?.mesh && cue.active && !shooting;
-            let focusTarget;
+            let focusTargetLocal;
             if (shooting && followViewRef.current?.lastBallPos) {
               const last = followViewRef.current.lastBallPos;
-              focusTarget = new THREE.Vector3(last.x, BALL_R, last.y);
+              focusTargetLocal = new THREE.Vector3(last.x, BALL_R, last.y);
             } else if (followCue) {
-              focusTarget = new THREE.Vector3(cue.pos.x, BALL_R, cue.pos.y);
+              focusTargetLocal = new THREE.Vector3(
+                cue.pos.x,
+                BALL_R,
+                cue.pos.y
+              );
             } else {
-              focusTarget = new THREE.Vector3(
+              focusTargetLocal = new THREE.Vector3(
                 playerOffsetRef.current,
                 TABLE_Y + 0.05,
                 0
               );
             }
-            focusTarget.multiplyScalar(worldScaleFactor);
+            if (!shooting) {
+              const zoomRange = CAMERA.maxR - CAMERA.minR;
+              const zoomT =
+                zoomRange > 0
+                  ? (sph.radius - CAMERA.minR) / zoomRange
+                  : 0;
+              if (zoomT > 0.92) {
+                const blend = THREE.MathUtils.clamp(
+                  (zoomT - 0.92) / 0.08,
+                  0,
+                  1
+                );
+                const centerLocal = new THREE.Vector3(
+                  playerOffsetRef.current,
+                  focusTargetLocal.y,
+                  0
+                );
+                focusTargetLocal.lerp(centerLocal, blend);
+              }
+            }
+            const focusTarget = focusTargetLocal.multiplyScalar(
+              worldScaleFactor
+            );
             lookTarget = focusTarget;
             camera.position.setFromSpherical(sph).add(lookTarget);
             camera.lookAt(lookTarget);
@@ -1781,7 +1878,6 @@ function SnookerGame() {
         return b;
       };
       cue = add('cue', COLORS.cue, -BALL_R * 2, baulkZ);
-      const SPOTS = spotPositions(baulkZ);
 
       // 15 red balls arranged in triangle behind the pink
       const startZ = SPOTS.pink[1] + BALL_R * 2;
@@ -2076,8 +2172,12 @@ function SnookerGame() {
               CAMERA.maxPhi
             );
             const baseRadius = clamp(baseOrbit.radius, CAMERA.minR, CAMERA.maxR);
+            const cameraForFit = cameraRef.current;
+            const fullTableRadius = cameraForFit
+              ? fitRadius(cameraForFit, 1.08)
+              : baseRadius;
             const followRadius = clamp(
-              baseRadius * ACTION_VIEW.radiusFactor,
+              Math.max(baseRadius * ACTION_VIEW.radiusFactor, fullTableRadius),
               CAMERA.minR,
               CAMERA.maxR
             );
@@ -2093,6 +2193,7 @@ function SnookerGame() {
               offset: new THREE.Vector2(),
               followWeight: ACTION_VIEW.followWeight,
               maxOffset: ACTION_VIEW.maxOffset,
+              lookCenterBlend: ACTION_VIEW.lookCenterBlend,
               lastBallPos: new THREE.Vector2(cue.pos.x, cue.pos.y),
               orbitSnapshot,
               pendingPocket: null,


### PR DESCRIPTION
## Summary
- open each snooker pocket toward the correct ball spot, cutting the pocket cylinder in half and adding a visible rim
- store pocket rims and targets while keeping baulk spot lookup shared across table construction
- raise the orbit camera floor, recentre the view when zoomed out, and widen the action camera framing to keep the full table in shot

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files such as lib/americanBilliards.js)*

------
https://chatgpt.com/codex/tasks/task_e_68caf224d9c483299928a4cbed3d429c