### PR TITLE
Tune snooker pockets, camera, and controls

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -15,6 +15,7 @@ export class PowerSlider {
 
     if (!mount) throw new Error('mount required');
 
+    this.theme = theme;
     this.min = min;
     this.max = max;
     this.step = step;
@@ -57,6 +58,11 @@ export class PowerSlider {
     this.tooltip = document.createElement('div');
     this.tooltip.className = 'ps-tooltip';
     this.el.appendChild(this.tooltip);
+
+    if (this.theme === 'snooker') {
+      this.handle.style.left = '50%';
+      this.tooltip.style.left = '50%';
+    }
 
     if (labels) {
       const wrap = document.createElement('div');
@@ -143,9 +149,10 @@ export class PowerSlider {
     const trackH = this.el.clientHeight;
     const handleH = this.handle.offsetHeight;
     const y = ratio * (trackH - handleH);
-    this.handle.style.transform = `translate(0, ${y}px)`;
+    const translateX = this.theme === 'snooker' ? '-50%' : '0';
+    this.handle.style.transform = `translate(${translateX}, ${y}px)`;
     const ttH = this.tooltip.offsetHeight;
-    this.tooltip.style.transform = `translate(0, ${y - ttH - 8}px)`;
+    this.tooltip.style.transform = `translate(${translateX}, ${y - ttH - 8}px)`;
     const pct = ratio * 100;
     this.powerFill.style.clipPath = `inset(0 0 ${100 - pct}% 0)`;
     this._updateHandleColor(ratio);

--- a/snooker-power-slider.css
+++ b/snooker-power-slider.css
@@ -1,7 +1,44 @@
 @import './power-slider.css';
 
 .ps.ps-theme-snooker {
-  --ps-width: 23px;
-  --ps-height: 288px;
-  --ps-radius: 11.5px;
+  --ps-width: 28px;
+  --ps-height: 320px;
+  --ps-radius: 14px;
+}
+
+.ps.ps-theme-snooker .ps-handle {
+  width: calc(var(--ps-width) * 1.3);
+  padding: 10px 4px 8px;
+  left: 50% !important;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.28);
+}
+
+.ps.ps-theme-snooker .ps-handle-text {
+  font-size: 16px;
+  letter-spacing: 0.08em;
+}
+
+.ps.ps-theme-snooker .ps-tooltip {
+  left: 50% !important;
+}
+
+.ps.ps-theme-snooker .ps-label {
+  right: auto;
+  left: 50%;
+  margin-right: 0;
+  transform: translate(-50%, -50%);
+}
+
+.ps.ps-theme-snooker .ps-label-0 {
+  top: 0;
+}
+
+.ps.ps-theme-snooker .ps-label-50 {
+  top: 50%;
+}
+
+.ps.ps-theme-snooker .ps-label-100 {
+  top: auto;
+  bottom: 0;
+  transform: translate(-50%, 50%);
 }


### PR DESCRIPTION
## Summary
- sink pocket visuals into the cloth while keeping the rings just above the surface and raise ball centers for better contact visibility
- tighten camera limits and shot follow view fit so the table remains framed when orbiting or zooming
- double the spin control size with Pool Royale-style interactions, enlarge the snooker power slider, and align its labels and handle vertically

## Testing
- `npm run lint` *(fails: legacy lint violations in unrelated billiards files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb031d1ec083299a27b9ab53cf52a3