### PR TITLE
Adjust snooker lighting layout and carpet footprint

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1287,9 +1287,8 @@ function SnookerGame() {
       const wallThickness = 1.2;
       const wallHeight = legHeight + TABLE.THICK + 40;
       const carpetThickness = 1.2;
-      const carpetInset = wallThickness * 0.02;
-      const carpetWidth = roomWidth - wallThickness + carpetInset;
-      const carpetDepth = roomDepth - wallThickness + carpetInset;
+      const carpetWidth = roomWidth + wallThickness;
+      const carpetDepth = roomDepth + wallThickness;
       const carpet = new THREE.Mesh(
         new THREE.BoxGeometry(carpetWidth, carpetThickness, carpetDepth),
         new THREE.MeshStandardMaterial({
@@ -1785,10 +1784,11 @@ function SnookerGame() {
         window.addEventListener('keydown', keyRot);
 
       // Lights
-      // Place three pot lights above the table with a slightly tighter footprint for a focused beam
+      // Place four pot lights above the table corners with a slightly tighter footprint for a focused beam
       const lightHeight = TABLE_Y + 100; // raise spotlights slightly higher
       const rectSizeBase = 21;
-      const rectSize = rectSizeBase * 0.72 * 0.7 * 0.7 * 0.8; // reduce spotlight footprint and shrink fixtures by another 20%
+      const rectSize =
+        rectSizeBase * 0.72 * 0.7 * 0.7 * 0.8 * 0.8; // reduce spotlight footprint and shrink fixtures by another 20%
       const lightIntensity = 31.68 * 1.3 * 1.3 * 1.35 * 1.25; // push more light down onto the cloth
 
       const makeLight = (x, z) => {
@@ -1803,10 +1803,17 @@ function SnookerGame() {
         world.add(rect);
       };
 
-      // evenly space the three pot lights along the table center line
-      const lightPositions = [-TABLE.H * 0.38, 0, TABLE.H * 0.38];
-      for (const z of lightPositions) {
-        makeLight(0, z);
+      // anchor the four pot lights above the inner corners of the surrounding walls
+      const halfRoomWidth = roomWidth / 2 - wallThickness * 0.5;
+      const halfRoomDepth = roomDepth / 2 - wallThickness * 0.5;
+      const lightPositions = [
+        [-halfRoomWidth, -halfRoomDepth],
+        [halfRoomWidth, -halfRoomDepth],
+        [-halfRoomWidth, halfRoomDepth],
+        [halfRoomWidth, halfRoomDepth]
+      ];
+      for (const [x, z] of lightPositions) {
+        makeLight(x, z);
       }
 
       // Table


### PR DESCRIPTION
## Summary
- expand the carpet mesh so it fills the room footprint alongside the walls
- reposition the snooker spotlights to the four room corners and shrink each fixture by 20%

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9703e12483299242ae0c976383e4