### PR TITLE
Relax frame scale clamp for snooker physics updates

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -160,6 +160,7 @@ const STOP_EPS = 0.05;
 const TARGET_FPS = 90;
 const TARGET_FRAME_TIME_MS = 1000 / TARGET_FPS;
 const MAX_FRAME_TIME_MS = TARGET_FRAME_TIME_MS * 3; // allow up to 3 frames of catch-up
+const MIN_FRAME_SCALE = 1e-6; // prevent zero-length frames from collapsing physics updates
 const CAPTURE_R = POCKET_R; // pocket capture radius
 const CLOTH_THICKNESS = TABLE.THICK * 0.12; // render a thinner cloth so the playing surface feels lighter
 const POCKET_JAW_LIP_HEIGHT =
@@ -2683,7 +2684,7 @@ function SnookerGame() {
         const rawDelta = Math.max(now - lastStepTime, 0);
         const deltaMs = Math.min(rawDelta, MAX_FRAME_TIME_MS);
         const frameScaleBase = deltaMs / TARGET_FRAME_TIME_MS || 1;
-        const frameScale = Math.max(frameScaleBase, 1);
+        const frameScale = Math.max(frameScaleBase, MIN_FRAME_SCALE);
         lastStepTime = now;
         camera.getWorldDirection(camFwd);
         tmpAim.set(camFwd.x, camFwd.z).normalize();


### PR DESCRIPTION
## Summary
- define a tiny minimum frame scale so zero-length frames still advance safely
- allow the frame scale to reflect real frame timings instead of clamping to 1
- confirmed physics paths continue to use the updated scale for integration, friction, and collision checks

## Testing
- not run (manual refresh-rate testing requires hardware that is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc324bc1248329a540f2a07e59067b