### PR TITLE
Adjust snooker cloth visuals and pocket cutouts

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -161,6 +161,7 @@ const MAX_FRAME_TIME_MS = TARGET_FRAME_TIME_MS * 3; // allow up to 3 frames of c
 const MIN_FRAME_SCALE = 1e-6; // prevent zero-length frames from collapsing physics updates
 const CAPTURE_R = POCKET_R; // pocket capture radius
 const CLOTH_THICKNESS = TABLE.THICK * 0.12; // render a thinner cloth so the playing surface feels lighter
+const CLOTH_EDGE_GROWTH = TABLE.WALL * 0.18; // extend the visual cloth toward the rails to eliminate the outer gap
 const POCKET_JAW_LIP_HEIGHT =
   -TABLE.THICK + 0.025; // raise pocket rims so they sit level with the cushions
 const POCKET_RECESS_DEPTH =
@@ -217,7 +218,7 @@ const UI_SCALE = SIZE_REDUCTION;
 const RAIL_WOOD_COLOR = 0x4a2c18;
 const BASE_WOOD_COLOR = 0x2f1b11;
 const COLORS = Object.freeze({
-  cloth: 0x2f7c48,
+  cloth: 0x368f52,
   rail: RAIL_WOOD_COLOR,
   base: BASE_WOOD_COLOR,
   markings: 0xffffff,
@@ -459,37 +460,37 @@ function makeClothTexture() {
   const ctx = canvas.getContext('2d');
   if (!ctx) return null;
 
-  const baseCloth = '#2f7c48';
+  const baseCloth = '#368f52';
   ctx.fillStyle = baseCloth;
   ctx.fillRect(0, 0, size, size);
 
   const shading = ctx.createLinearGradient(0, 0, size, size);
-  shading.addColorStop(0, 'rgba(255,255,255,0.06)');
-  shading.addColorStop(0.6, 'rgba(0,0,0,0.18)');
-  shading.addColorStop(1, 'rgba(0,0,0,0.32)');
+  shading.addColorStop(0, 'rgba(255,255,255,0.09)');
+  shading.addColorStop(0.6, 'rgba(0,0,0,0.2)');
+  shading.addColorStop(1, 'rgba(0,0,0,0.34)');
   ctx.fillStyle = shading;
   ctx.fillRect(0, 0, size, size);
 
   const crossSheen = ctx.createLinearGradient(0, 0, size, 0);
-  crossSheen.addColorStop(0, 'rgba(255,255,255,0.03)');
-  crossSheen.addColorStop(0.5, 'rgba(0,0,0,0.12)');
-  crossSheen.addColorStop(1, 'rgba(255,255,255,0.02)');
+  crossSheen.addColorStop(0, 'rgba(255,255,255,0.05)');
+  crossSheen.addColorStop(0.5, 'rgba(0,0,0,0.14)');
+  crossSheen.addColorStop(1, 'rgba(255,255,255,0.04)');
   ctx.fillStyle = crossSheen;
   ctx.fillRect(0, 0, size, size);
 
   const spacing = 1;
-  const lightWeave = 'rgba(255,255,255,0.42)';
-  const darkWeave = 'rgba(0,0,0,0.34)';
+  const lightWeave = 'rgba(255,255,255,0.55)';
+  const darkWeave = 'rgba(0,0,0,0.46)';
   for (let y = 0; y < size; y += spacing) {
     for (let x = 0; x < size; x += spacing) {
       ctx.fillStyle = (x + y) % (spacing * 2) === 0 ? lightWeave : darkWeave;
       ctx.beginPath();
-      ctx.arc(x, y, 0.42, 0, Math.PI * 2);
+      ctx.arc(x, y, 0.55, 0, Math.PI * 2);
       ctx.fill();
     }
   }
 
-  ctx.strokeStyle = 'rgba(0,0,0,0.36)';
+  ctx.strokeStyle = 'rgba(0,0,0,0.4)';
   for (let i = 0; i < 600000; i++) {
     const x = Math.random() * size;
     const y = Math.random() * size;
@@ -501,7 +502,7 @@ function makeClothTexture() {
     ctx.stroke();
 
     if (i % 6 === 0) {
-      ctx.strokeStyle = 'rgba(255,255,255,0.18)';
+      ctx.strokeStyle = 'rgba(255,255,255,0.22)';
       ctx.beginPath();
       ctx.moveTo(x, y);
       ctx.lineTo(
@@ -509,12 +510,12 @@ function makeClothTexture() {
         y + Math.sin(angle + Math.PI / 2) * length * 0.6
       );
       ctx.stroke();
-      ctx.strokeStyle = 'rgba(0,0,0,0.36)';
+      ctx.strokeStyle = 'rgba(0,0,0,0.4)';
     }
   }
 
-  ctx.globalAlpha = 0.14;
-  ctx.fillStyle = 'rgba(0,0,0,0.45)';
+  ctx.globalAlpha = 0.18;
+  ctx.fillStyle = 'rgba(0,0,0,0.48)';
   for (let i = -size; i < size * 2; i += spacing * 48) {
     ctx.beginPath();
     ctx.moveTo(i, 0);
@@ -880,6 +881,8 @@ function Table3D(parent) {
   const clothBevel = CLOTH_THICKNESS * 0.45;
   const halfW = PLAY_W / 2 + clothBevel;
   const halfH = PLAY_H / 2 + clothBevel;
+  const clothHalfW = halfW + CLOTH_EDGE_GROWTH;
+  const clothHalfH = halfH + CLOTH_EDGE_GROWTH;
 
   const clothMat = new THREE.MeshStandardMaterial({
     color: COLORS.cloth,
@@ -893,14 +896,14 @@ function Table3D(parent) {
   if (clothTexture) {
     clothMat.map = clothTexture;
     clothMat.bumpMap = clothTexture;
-    clothMat.bumpScale = 0.26;
+    clothMat.bumpScale = 0.32;
     clothMat.needsUpdate = true;
   }
   const cushionMat = clothMat.clone();
   if (clothTexture) {
     cushionMat.map = clothTexture;
     cushionMat.bumpMap = clothTexture;
-    cushionMat.bumpScale = clothMat.bumpScale * 1.4;
+    cushionMat.bumpScale = clothMat.bumpScale * 1.35;
     cushionMat.needsUpdate = true;
   }
   cushionMat.color = new THREE.Color(COLORS.cloth).multiplyScalar(1.05);
@@ -952,18 +955,18 @@ function Table3D(parent) {
     woodMat.needsUpdate = true;
   }
 
-  const shape = new THREE.Shape();
-  shape.moveTo(-halfW, -halfH);
-  shape.lineTo(halfW, -halfH);
-  shape.lineTo(halfW, halfH);
-  shape.lineTo(-halfW, halfH);
-  shape.lineTo(-halfW, -halfH);
+  const clothShape = new THREE.Shape();
+  clothShape.moveTo(-clothHalfW, -clothHalfH);
+  clothShape.lineTo(clothHalfW, -clothHalfH);
+  clothShape.lineTo(clothHalfW, clothHalfH);
+  clothShape.lineTo(-clothHalfW, clothHalfH);
+  clothShape.lineTo(-clothHalfW, -clothHalfH);
   pocketCenters().forEach((p) => {
     const h = new THREE.Path();
     h.absellipse(p.x, p.y, POCKET_CLOTH_TOP_RADIUS, POCKET_CLOTH_TOP_RADIUS, 0, Math.PI * 2);
-    shape.holes.push(h);
+    clothShape.holes.push(h);
   });
-  const clothGeo = new THREE.ExtrudeGeometry(shape, {
+  const clothGeo = new THREE.ExtrudeGeometry(clothShape, {
     depth: CLOTH_THICKNESS,
     bevelEnabled: true,
     bevelThickness: clothBevel,
@@ -1089,12 +1092,17 @@ function Table3D(parent) {
     table.add(apron);
 
     const clothMask = new THREE.Mesh(
-      new THREE.CircleGeometry(POCKET_CLOTH_TOP_RADIUS * 0.99, 64),
+      new THREE.RingGeometry(
+        POCKET_CLOTH_TOP_RADIUS * 0.72,
+        POCKET_CLOTH_TOP_RADIUS * 0.99,
+        64,
+        1
+      ),
       new THREE.MeshBasicMaterial({
         color: 0x020202,
         side: THREE.DoubleSide,
         transparent: true,
-        opacity: 1,
+        opacity: 0.92,
         depthWrite: false
       })
     );
@@ -1327,8 +1335,8 @@ function Table3D(parent) {
     );
 
     const toCanvas = (p) => ({
-      x: ((p.x + halfW) / (halfW * 2)) * toneCanvas.width,
-      y: ((p.y + halfH) / (halfH * 2)) * toneCanvas.height
+      x: ((p.x + clothHalfW) / (clothHalfW * 2)) * toneCanvas.width,
+      y: ((p.y + clothHalfH) / (clothHalfH * 2)) * toneCanvas.height
     });
     const pocketRadius = Math.max(toneCanvas.width, toneCanvas.height) * 0.06;
     const pocketCore = pocketRadius * 0.3;
@@ -1404,7 +1412,7 @@ function Table3D(parent) {
     depthWrite: false
   });
 
-  const toneMesh = new THREE.Mesh(new THREE.ShapeGeometry(shape), toneMat);
+  const toneMesh = new THREE.Mesh(new THREE.ShapeGeometry(clothShape), toneMat);
   toneMesh.rotation.x = -Math.PI / 2;
   toneMesh.position.y = cloth.position.y + TABLE.THICK + 0.02;
   toneMesh.renderOrder = 1;


### PR DESCRIPTION
## Summary
- lighten the snooker cloth colour and intensify the generated weave texture for a brighter, more pronounced surface
- expand the cloth mesh beyond the cushions to remove the outer gap and increase cloth bump detail while reusing the existing pocket layout
- swap the filled pocket masks for slim rings so the six pocket openings stay fully cut out

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd71092f38832984e5cfeda3b108bd