### PR TITLE
Enhance snooker table visuals and power slider

### DIFF
--- a/snooker-power-slider.css
+++ b/snooker-power-slider.css
@@ -2,20 +2,22 @@
 
 .ps.ps-theme-snooker {
   --ps-width: 28px;
-  --ps-height: 320px;
+  --ps-height: 416px;
   --ps-radius: 14px;
 }
 
 .ps.ps-theme-snooker .ps-handle {
   width: calc(var(--ps-width) * 1.3);
-  padding: 10px 4px 8px;
+  padding: 12px 6px 10px;
   left: 50% !important;
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.28);
+  gap: 6px;
 }
 
 .ps.ps-theme-snooker .ps-handle-text {
   font-size: 16px;
   letter-spacing: 0.08em;
+  margin-top: 6px;
 }
 
 .ps.ps-theme-snooker .ps-tooltip {
@@ -41,4 +43,17 @@
   top: auto;
   bottom: 0;
   transform: translate(-50%, 50%);
+}
+
+.ps.ps-theme-snooker .ps-power-bar {
+  margin-top: 10px;
+}
+
+.ps.ps-theme-snooker .ps-cue-img {
+  margin: 0;
+  margin-bottom: 4px;
+  width: 120%;
+  max-width: none;
+  transform-origin: 50% 0%;
+  filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.25));
 }


### PR DESCRIPTION
## Summary
- deepen the cloth texture and bump detail, add dark cloth cutouts and plastic jaws around pockets, and tighten cushion geometry so rails meet each pocket edge
- increase shot power and refine pre-impact spin so the cue ball tracks the aiming line while still carrying its spin
- stretch and restyle the snooker power slider with an animated cue overlay and auto-reset behaviour after pull-and-release shots

## Testing
- `npm run lint` *(fails: repository contains numerous pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8a5af9988329b600cffd161db976