### PR TITLE
Reduce snooker spotlight sizes

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2973,7 +2973,7 @@ function SnookerGame() {
       // Lights
       // Pull the pot lights higher and stretch them so each fixture floods half the table
       const lightHeight = TABLE_Y + 150; // raise spotlights further from the table
-      const spotlightScale = 0.5;
+      const spotlightScale = 0.25;
       const rectWidth = PLAY_W * 0.88 * spotlightScale;
       const rectHeight = PLAY_H * 0.48 * spotlightScale;
       const baseRectIntensity = 18;


### PR DESCRIPTION
## Summary
- halve the RectAreaLight scale for the snooker table spotlights to shrink each fixture

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce968cd2648329b194bbf1e3a27e7e