### PR TITLE
Adjust snooker ambient lighting

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2357,8 +2357,12 @@ function SnookerGame() {
 
         const tableSurfaceY = TABLE_Y - TABLE.THICK + 0.01;
         const hemisphere = new THREE.HemisphereLight(0xdde7ff, 0x0b1020, 0.6 * 1.4);
-        hemisphere.position.set(0, tableSurfaceY + PLAY_W * 0.23, 0);
+        hemisphere.position.set(0, tableSurfaceY + PLAY_W * 0.18, 0);
         lightingRig.add(hemisphere);
+
+        const ambient = new THREE.AmbientLight(0xffffff, 0.22);
+        ambient.position.set(0, tableSurfaceY + PLAY_W * 0.14, 0);
+        lightingRig.add(ambient);
 
         const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
         dirLight.position.set(-PLAY_W * 0.35, tableSurfaceY + PLAY_W * 0.6, PLAY_H * 0.3);


### PR DESCRIPTION
## Summary
- lower the snooker hemisphere light so it sits closer to the table surface
- add a subtle ambient light fill near the table to soften the lighting

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb62956f88329acf965e10f770257