### PR TITLE
Increase snooker spotlight size and intensity

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2384,9 +2384,9 @@ function SnookerGame() {
         for (const { position, target } of SPOT_CONFIGS) {
           const spot = new THREE.SpotLight(
             0xffffff,
-            1.5 * 1.4,
+            1.5 * 1.4 * 1.5,
             0,
-            Math.PI * 0.2 * 1.4,
+            Math.PI * 0.2 * 1.4 * 1.5,
             0.3,
             1
           );


### PR DESCRIPTION
## Summary
- enlarge the mobile lighting rig's spotlights over the snooker table
- boost spotlight intensity to deliver brighter table illumination

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfb8ac75048329b35aaa8bdcc87972