### PR TITLE
Raise snooker table lighting rig height

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2377,13 +2377,18 @@ function SnookerGame() {
         const heightScale = Math.max(0.001, TABLE_H / SAMPLE_TABLE_HEIGHT);
 
         const hemisphere = new THREE.HemisphereLight(0xdde7ff, 0x0b1020, 0.95);
-        hemisphere.position.set(0, tableSurfaceY + heightScale * 1.4, 0);
+        const lightHeightLift = heightScale * 0.6;
+        hemisphere.position.set(
+          0,
+          tableSurfaceY + heightScale * 1.4 + lightHeightLift,
+          0
+        );
         lightingRig.add(hemisphere);
 
         const dirLight = new THREE.DirectionalLight(0xffffff, 1.15);
         dirLight.position.set(
           -2.5 * widthScale,
-          tableSurfaceY + 6.1 * heightScale,
+          tableSurfaceY + 6.1 * heightScale + lightHeightLift,
           2 * lengthScale
         );
         dirLight.target.position.set(0, tableSurfaceY, 0);
@@ -2400,7 +2405,7 @@ function SnookerGame() {
         );
         spot.position.set(
           1.3 * widthScale,
-          tableSurfaceY + 4.1 * heightScale,
+          tableSurfaceY + 4.1 * heightScale + lightHeightLift,
           0.5 * lengthScale
         );
         spot.target.position.set(0, tableSurfaceY + TABLE_H * 0.03, 0);
@@ -2412,7 +2417,11 @@ function SnookerGame() {
         lightingRig.add(spot.target);
 
         const ambient = new THREE.AmbientLight(0xffffff, 0.08);
-        ambient.position.set(0, tableSurfaceY + heightScale * 1.95, 0);
+        ambient.position.set(
+          0,
+          tableSurfaceY + heightScale * 1.95 + lightHeightLift,
+          0
+        );
         lightingRig.add(ambient);
       };
 


### PR DESCRIPTION
## Summary
- increase the snooker lighting rig height by introducing a shared lift offset for all light positions so fixtures sit higher above the table surface

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfec12ae8883298a61ea48f14f6424