### PR TITLE
Raise snooker lighting rig height

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2377,7 +2377,7 @@ function SnookerGame() {
         const heightScale = Math.max(0.001, TABLE_H / SAMPLE_TABLE_HEIGHT);
 
         const hemisphere = new THREE.HemisphereLight(0xdde7ff, 0x0b1020, 0.95);
-        const lightHeightLift = heightScale * 1.8;
+        const lightHeightLift = heightScale * 2.6;
         hemisphere.position.set(
           0,
           tableSurfaceY + heightScale * 1.4 + lightHeightLift,


### PR DESCRIPTION
## Summary
- raise the additional lift applied to the snooker lighting rig so fixtures sit higher above the table

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cff2b4da208329aceab61738a6c3bb