### PR TITLE
Raise snooker lighting rig

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2377,7 +2377,7 @@ function SnookerGame() {
         const heightScale = Math.max(0.001, TABLE_H / SAMPLE_TABLE_HEIGHT);
 
         const hemisphere = new THREE.HemisphereLight(0xdde7ff, 0x0b1020, 0.95);
-        const lightHeightLift = heightScale * 2.6;
+        const lightHeightLift = heightScale * 3.4; // lift the lighting rig higher above the table
         hemisphere.position.set(
           0,
           tableSurfaceY + heightScale * 1.4 + lightHeightLift,


### PR DESCRIPTION
## Summary
- raise the snooker lighting rig higher above the table by increasing the shared height lift
- document the increased height to clarify why the lift value changed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cff48596ac83298e5aa9503efe4020