### PR TITLE
Align cue camera during aiming

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2446,21 +2446,19 @@ function SnookerGame() {
               if (toCueLength > 1e-6) {
                 toCue.normalize();
                 const desiredTheta = Math.atan2(toCue.x, toCue.y);
-                const delta =
-                  THREE.MathUtils.euclideanModulo(
-                    desiredTheta - sph.theta + Math.PI,
-                    Math.PI * 2
-                  ) - Math.PI;
-                sph.theta += delta * 0.2;
+                sph.theta = lerpAngle(sph.theta, desiredTheta, 0.45);
               }
               const minBackLocal = Math.max(toCueLength + BALL_R * 10, BALL_R * 14);
-              desiredRadius = clampOrbitRadius(
-                Math.max(
-                  desiredRadius,
-                  minBackLocal * worldScaleFactor,
-                  ACTION_CAMERA_MIN_RADIUS
-                )
+              const targetRadiusWorld = clampOrbitRadius(
+                Math.max(minBackLocal * worldScaleFactor, ACTION_CAMERA_MIN_RADIUS)
               );
+              const blendedRadius = THREE.MathUtils.lerp(
+                sph.radius,
+                targetRadiusWorld,
+                0.4
+              );
+              sph.radius = blendedRadius;
+              desiredRadius = blendedRadius;
               const ballTopWorld =
                 (BALL_CENTER_Y + BALL_R + CAMERA_BALL_CLEARANCE) * worldScaleFactor;
               const phiLimit = Math.acos(
@@ -2480,7 +2478,8 @@ function SnookerGame() {
                 Math.max(CAMERA.minPhi, phiLimit - CAMERA_RAIL_SAFETY)
               );
               if (Number.isFinite(safePhi)) {
-                sph.phi = clamp(Math.min(sph.phi, safePhi), CAMERA.minPhi, CAMERA.maxPhi);
+                const nextPhi = THREE.MathUtils.lerp(sph.phi, safePhi, 0.35);
+                sph.phi = clamp(nextPhi, CAMERA.minPhi, CAMERA.maxPhi);
               }
               syncBlendToSpherical();
             }


### PR DESCRIPTION
## Summary
- smooth the aiming camera so it locks behind the cue when it's the player's turn
- ease the camera radius and height so the aiming line to the target ball stays in view

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0577dc9388329935120c45167e85e