### PR TITLE
Adjust zoom easing when lowering snooker camera

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -604,9 +604,10 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.12
 });
 const CAMERA_ZOOM_RANGE = Object.freeze({
-  near: 1.02,
+  near: 1,
   far: 1.075
 });
+const CAMERA_ZOOM_LOW_BLEND = 0.35;
 const CAMERA_RAIL_SAFETY = 0.06;
 const ACTION_VIEW = Object.freeze({
   phiOffset: 0,
@@ -2117,10 +2118,15 @@ function SnookerGame() {
             standing.radius,
             blend
           );
+          const zoomBlend =
+            blend <= CAMERA_ZOOM_LOW_BLEND
+              ? 0
+              : (blend - CAMERA_ZOOM_LOW_BLEND) /
+                (1 - CAMERA_ZOOM_LOW_BLEND);
           const zoomFactor = THREE.MathUtils.lerp(
             CAMERA_ZOOM_RANGE.near,
             CAMERA_ZOOM_RANGE.far,
-            blend
+            zoomBlend
           );
           const radius = clampOrbitRadius(baseRadius * zoomFactor);
           const cushionHeight = cushionHeightRef.current ?? TABLE.THICK;


### PR DESCRIPTION
## Summary
- ensure the snooker camera keeps its closest zoom level when the orbit is lowered
- ramp camera zooming only after the low-angle blend threshold for smoother transitions

## Testing
- npx eslint webapp/src/pages/Games/Snooker.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d0e33b5e588329b910631db6fe5126