### PR TITLE
Ensure snooker top view camera preserves fit radius

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2445,7 +2445,9 @@ function SnookerGame() {
             CAMERA.minPhi,
             CAMERA.maxPhi
           );
-          let radius = clampOrbitRadius(baseRadius);
+          let radius = topViewRef.current
+            ? standing.radius
+            : clampOrbitRadius(baseRadius);
           if (!topViewRef.current) {
             const scale = worldScaleFactor || 1;
             const sinPhi = Math.sin(phiForClamp);
@@ -2819,7 +2821,9 @@ function SnookerGame() {
           const cueBase = clampOrbitRadius(BREAK_VIEW.radius);
           const standingRadiusBase = Math.max(standingRadiusRaw, cueBase);
           const standingRadius = clampOrbitRadius(
-            Math.max(standingRadiusBase * STANDING_RADIUS_SCALE, cueBase)
+            topViewRef.current
+              ? standingRadiusBase
+              : Math.max(standingRadiusBase * STANDING_RADIUS_SCALE, cueBase)
           );
           const standingPhi = THREE.MathUtils.clamp(
             STANDING_VIEW.phi,


### PR DESCRIPTION
## Summary
- keep the standing camera radius at the fit-computed value when the top view is active so the overhead camera retains its full height
- guard camera blending so the stored top-view radius is respected and not reduced by rail clamping logic

## Testing
- npm --prefix webapp run build
- Manually verified the 2D mobile viewport shows the full table

------
https://chatgpt.com/codex/tasks/task_e_68d28d9d0dac8329bd53b2f6c59ae851