### PR TITLE
Improve snooker table ambient lighting

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3862,13 +3862,29 @@ function SnookerGame() {
         lightingRig.add(spot);
         lightingRig.add(spot.target);
 
-        const ambient = new THREE.AmbientLight(0xffffff, 0.08);
+        const ambient = new THREE.AmbientLight(0xffffff, 0.26);
         ambient.position.set(
           0,
           tableSurfaceY + scaledHeight * 2.4 + lightHeightLift,
           0
         );
         lightingRig.add(ambient);
+
+        const fillLightHeight = tableSurfaceY + scaledHeight * 2.2 + lightHeightLift;
+        const fillLightDistance = Math.max(PLAY_W, PLAY_H) * 3.2;
+        const fillIntensity = 0.58;
+        const fillPositions = [
+          [spotOffsetX, fillLightHeight, spotOffsetZ],
+          [-spotOffsetX, fillLightHeight, spotOffsetZ],
+          [spotOffsetX, fillLightHeight, -spotOffsetZ],
+          [-spotOffsetX, fillLightHeight, -spotOffsetZ]
+        ];
+        for (const [x, y, z] of fillPositions) {
+          const fill = new THREE.PointLight(0xffffff, fillIntensity, fillLightDistance, 1.1);
+          fill.position.set(x, y, z);
+          fill.castShadow = false;
+          lightingRig.add(fill);
+        }
       };
 
       addMobileLighting();


### PR DESCRIPTION
## Summary
- increase the ambient light intensity over the snooker table to provide consistent baseline illumination
- add four evenly spaced fill point lights so the cloth and cushions receive balanced lighting from every side

## Testing
- npm run lint *(fails: repository currently has pre-existing lint violations outside the change)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e6540acc8329ba9384c4be49d001