### PR TITLE
Adjust snooker cloth and cushion shading

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -530,7 +530,7 @@ const UI_SCALE = SIZE_REDUCTION;
 const RAIL_WOOD_COLOR = 0x3a2a1a;
 const BASE_WOOD_COLOR = 0x8c5a33;
 const COLORS = Object.freeze({
-  cloth: 0x5ff5a6,
+  cloth: 0x157f46,
   rail: RAIL_WOOD_COLOR,
   base: BASE_WOOD_COLOR,
   markings: 0xffffff,
@@ -553,7 +553,7 @@ const createClothTextures = (() => {
     return mod < 0 ? mod + size : mod;
   };
   const TWO_PI = Math.PI * 2;
-  const BASE_COLOR = { r: 0x5f, g: 0xf5, b: 0xa6 };
+  const BASE_COLOR = { r: 0x15, g: 0x7f, b: 0x46 };
   const TWILL_PERIOD = 64;
   const periodicNoise = (x, y) => {
     const n1 = Math.sin((TWO_PI * (x + y)) / 16);
@@ -2068,7 +2068,7 @@ function Table3D(parent) {
         );
         shade = THREE.MathUtils.lerp(0.88, shade, lipBlend);
       }
-      shade = THREE.MathUtils.clamp(shade, 0.74, 0.94);
+      shade = THREE.MathUtils.clamp(shade, 0.7, 0.9);
       const idx = i * 3;
       colors[idx] = shade;
       colors[idx + 1] = shade;


### PR DESCRIPTION
## Summary
- darken the snooker cloth base color to eliminate overly bright cushions
- tune cushion vertex shading limits to keep highlight intensity consistent across rails

## Testing
- npx eslint webapp/src/pages/Games/Snooker.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d3f51297f483298fdbbde790754e0a