### PR TITLE
Increase snooker lighting intensity

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3873,7 +3873,7 @@ function SnookerGame() {
         const scaledHeight = heightScale * LIGHT_HEIGHT_SCALE;
 
         const lightHeightLift = scaledHeight * LIGHT_HEIGHT_LIFT_MULTIPLIER; // lift the lighting rig higher above the table
-        const spotIntensity = 6.2 * 1.4;
+        const spotIntensity = 6.2 * 1.4 * 1.5;
         const spot = new THREE.SpotLight(
           0xffffff,
           spotIntensity,
@@ -3911,7 +3911,7 @@ function SnookerGame() {
         lightingRig.add(counterSpot);
         lightingRig.add(counterSpot.target);
 
-        const ambient = new THREE.AmbientLight(0xffffff, 0.26);
+        const ambient = new THREE.AmbientLight(0xffffff, 0.26 * 1.5);
         ambient.position.set(
           0,
           tableSurfaceY + scaledHeight * 2.4 + lightHeightLift,


### PR DESCRIPTION
## Summary
- boost the snooker table spotlights by 50% to brighten the playing surface
- raise ambient light intensity to complement the stronger key lights

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3fd8d00b88329a2264861c30f38f9