### PR TITLE
Adjust snooker ambient lighting placement

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3754,12 +3754,15 @@ function SnookerGame() {
         );
         lightingRig.add(ambient);
 
-        const secondaryAmbient = new THREE.AmbientLight(0xffffff, 0.08);
-        secondaryAmbient.position.set(
-          0,
-          tableSurfaceY + scaledHeight * 1.95 + lightHeightLift,
-          0
+        const spotReplacementAmbientIntensity = 0.08 * 1.33; // boost brightness by 33%
+        const spotOffsetX = 1.6 * fixtureScale;
+        const spotOffsetZ = 0.95 * fixtureScale;
+        const spotHeight = tableSurfaceY + 7 * scaledHeight + lightHeightLift;
+        const secondaryAmbient = new THREE.AmbientLight(
+          0xffffff,
+          spotReplacementAmbientIntensity
         );
+        secondaryAmbient.position.set(spotOffsetX, spotHeight, spotOffsetZ);
         lightingRig.add(secondaryAmbient);
       };
 


### PR DESCRIPTION
## Summary
- move the replacement ambient light to the former spotlight coordinates in the Snooker lighting rig
- increase the replacement ambient light intensity by 33%

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d40b37b07083299261e929c20856db