### PR TITLE
Scale snooker cloth texture for softer look

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1414,8 +1414,10 @@ function Table3D(parent) {
   const ballDiameter = BALL_R * 2;
   const ballsAcrossWidth = PLAY_W / ballDiameter;
   const threadsPerBallTarget = 8; // amplify cloth weave visibility (~8 crossings across one ball)
+  const clothTextureScale = 0.2; // enlarge weave pattern ~5x so the cloth reads softer
   const baseRepeat =
-    (threadsPerBallTarget * ballsAcrossWidth) / CLOTH_THREADS_PER_TILE;
+    ((threadsPerBallTarget * ballsAcrossWidth) / CLOTH_THREADS_PER_TILE) *
+    clothTextureScale;
   const repeatRatio = 3.15;
   const baseBumpScale = 0.74;
   if (clothMap) {


### PR DESCRIPTION
## Summary
- reduce the base repeat value of the snooker cloth material to enlarge the weave by roughly five times for a softer green surface appearance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d43a53e2dc8329bada5a11566b2429