### PR TITLE
Increase snooker cloth texture scale

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1414,7 +1414,7 @@ function Table3D(parent) {
   const ballDiameter = BALL_R * 2;
   const ballsAcrossWidth = PLAY_W / ballDiameter;
   const threadsPerBallTarget = 8; // amplify cloth weave visibility (~8 crossings across one ball)
-  const clothTextureScale = 0.2; // enlarge weave pattern ~5x so the cloth reads softer
+  const clothTextureScale = 0.04; // enlarge weave pattern an additional 5x for clearer visibility
   const baseRepeat =
     ((threadsPerBallTarget * ballsAcrossWidth) / CLOTH_THREADS_PER_TILE) *
     clothTextureScale;


### PR DESCRIPTION
## Summary
- reduce the snooker cloth texture repeat to enlarge the weave pattern for improved visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d43c4967b88329a2462a53ba6903eb