### PR TITLE
Adjust snooker cloth and widen play field

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -319,7 +319,7 @@ function addPocketCuts(parent, clothPlane) {
       const diag = new THREE.Vector2(sx, sy).normalize();
       const inward = diag.clone().multiplyScalar(-1);
       const radialOffset = POCKET_VIS_R * 0.58;
-      const railInset = TABLE.WALL * 0.35;
+      const railInset = SIDE_RAIL_INNER_THICKNESS * 0.35;
       mesh.scale.set(-1, 1, -1);
       mesh.rotation.y = Math.atan2(inward.y, inward.x) + Math.PI / 2;
       mesh.position.set(
@@ -374,7 +374,12 @@ const CLOTH_LIFT = (() => {
   const railH = TABLE.THICK * 1.82;
   return Math.max(0, railH - ballR - eps);
 })();
-const PLAY_W = TABLE.W - 2 * TABLE.WALL;
+const SIDE_RAIL_INNER_REDUCTION = 0.7;
+const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
+const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
+const ORIGINAL_PLAY_W = TABLE.W - 2 * TABLE.WALL;
+const ORIGINAL_HALF_W = ORIGINAL_PLAY_W / 2;
+const PLAY_W = TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS;
 const PLAY_H = TABLE.H - 2 * TABLE.WALL;
 const ACTION_CAMERA_START_BLEND = 1;
 const BALL_R = 2 * BALL_SCALE;
@@ -407,7 +412,7 @@ const CAPTURE_R = POCKET_R; // pocket capture radius
 const CLOTH_THICKNESS = TABLE.THICK * 0.12; // render a thinner cloth so the playing surface feels lighter
 const POCKET_JAW_LIP_HEIGHT =
   CLOTH_TOP_LOCAL + CLOTH_LIFT; // keep the pocket rims in contact with the cloth surface
-const CUSHION_OVERLAP = TABLE.WALL * 0.35; // overlap between cushions and rails to hide seams
+const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
 const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.18; // soften the exterior rail corners with a shallow curve
@@ -422,7 +427,7 @@ const POCKET_CLOTH_DEPTH = POCKET_RECESS_DEPTH * 1.05;
 const POCKET_CAM = Object.freeze({
   triggerDist: CAPTURE_R * 3.8,
   dotThreshold: 0.3,
-  minOutside: TABLE.WALL + POCKET_VIS_R * 0.95,
+  minOutside: SIDE_RAIL_INNER_THICKNESS + POCKET_VIS_R * 0.95,
   maxOutside: BALL_R * 32,
   heightOffset: BALL_R * 5.1
 });
@@ -482,7 +487,7 @@ const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.6;
 // angle for cushion cuts guiding balls into pockets
 const CUSHION_CUT_ANGLE = 32;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
-const CUSHION_FACE_INSET = TABLE.WALL * 0.09; // pull cushions slightly closer to centre for a tighter pocket entry
+const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.09; // pull cushions slightly closer to centre for a tighter pocket entry
 
 // shared UI reduction factor so overlays and controls shrink alongside the table
 const UI_SCALE = SIZE_REDUCTION;
@@ -492,7 +497,7 @@ const UI_SCALE = SIZE_REDUCTION;
 const RAIL_WOOD_COLOR = 0x3a2a1a;
 const BASE_WOOD_COLOR = 0x8c5a33;
 const COLORS = Object.freeze({
-  cloth: 0x2db85f,
+  cloth: 0x1f7f3c,
   rail: RAIL_WOOD_COLOR,
   base: BASE_WOOD_COLOR,
   markings: 0xffffff,
@@ -506,8 +511,17 @@ const COLORS = Object.freeze({
   black: 0x000000
 });
 
-const CLOTH_TEXTURE_SIZE = 1024;
-const CLOTH_THREAD_PITCH = 18;
+const ORIGINAL_RAIL_WIDTH = TABLE.WALL * 0.7;
+const ORIGINAL_FRAME_WIDTH = ORIGINAL_RAIL_WIDTH * 2.5;
+const ORIGINAL_OUTER_HALF_W =
+  ORIGINAL_HALF_W + ORIGINAL_RAIL_WIDTH * 2 + ORIGINAL_FRAME_WIDTH;
+const ORIGINAL_PLAY_H = TABLE.H - 2 * TABLE.WALL;
+const ORIGINAL_HALF_H = ORIGINAL_PLAY_H / 2;
+const ORIGINAL_OUTER_HALF_H =
+  ORIGINAL_HALF_H + ORIGINAL_RAIL_WIDTH * 2 + ORIGINAL_FRAME_WIDTH;
+
+const CLOTH_TEXTURE_SIZE = 2048;
+const CLOTH_THREAD_PITCH = 14;
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 
 const createClothTextures = (() => {
@@ -536,40 +550,42 @@ const createClothTextures = (() => {
 
     const image = ctx.createImageData(SIZE, SIZE);
     const data = image.data;
-    const shadow = { r: 0x19, g: 0x70, b: 0x3a };
-    const base = { r: 0x2a, g: 0xa3, b: 0x58 };
-    const accent = { r: 0x3f, g: 0xbd, b: 0x70 };
-    const highlight = { r: 0x5a, g: 0xd7, b: 0x86 };
+    const shadow = { r: 0x12, g: 0x4a, b: 0x28 };
+    const base = { r: 0x1e, g: 0x6f, b: 0x36 };
+    const accent = { r: 0x2d, g: 0x8c, b: 0x45 };
+    const highlight = { r: 0x4a, g: 0xb4, b: 0x68 };
     const hashNoise = (x, y, seedX, seedY, phase = 0) =>
       Math.sin((x * seedX + y * seedY + phase) * 0.02454369260617026) * 0.5 + 0.5;
     const fiberNoise = (x, y) =>
-      hashNoise(x, y, 12.9898, 78.233, 1.5) * 0.6 +
-      hashNoise(x, y, 32.654, 23.147, 15.73) * 0.3 +
+      hashNoise(x, y, 12.9898, 78.233, 1.5) * 0.7 +
+      hashNoise(x, y, 32.654, 23.147, 15.73) * 0.2 +
       hashNoise(x, y, 63.726, 12.193, -9.21) * 0.1;
     const microNoise = (x, y) =>
-      hashNoise(x, y, 41.12, 27.43, -4.5) * 0.7 +
-      hashNoise(x, y, 19.71, 55.83, 23.91) * 0.3;
+      hashNoise(x, y, 41.12, 27.43, -4.5) * 0.5 +
+      hashNoise(x, y, 19.71, 55.83, 23.91) * 0.5;
     const sparkleNoise = (x, y) =>
-      hashNoise(x, y, 73.19, 11.17, 7.2) * 0.5 +
-      hashNoise(x, y, 27.73, 61.91, -14.4) * 0.5;
+      hashNoise(x, y, 73.19, 11.17, 7.2) * 0.45 +
+      hashNoise(x, y, 27.73, 61.91, -14.4) * 0.55;
     for (let y = 0; y < SIZE; y++) {
       for (let x = 0; x < SIZE; x++) {
         const u = ((x * COS + y * SIN) / THREAD_PITCH) * TAU;
         const v = ((x * COS - y * SIN) / THREAD_PITCH) * TAU;
         const warp = 0.5 + 0.5 * Math.cos(u);
         const weft = 0.5 + 0.5 * Math.cos(v);
-        const weave = Math.pow((warp + weft) * 0.5, 1.65);
-        const cross = Math.pow(warp * weft, 0.9);
-        const diamond = Math.pow(Math.abs(Math.sin(u) * Math.sin(v)), 0.62);
+        const weave = Math.pow((warp + weft) * 0.5, 1.58);
+        const cross = Math.pow(warp * weft, 0.86);
+        const diamond = Math.pow(Math.abs(Math.sin(u) * Math.sin(v)), 0.58);
         const fiber = fiberNoise(x, y);
         const micro = microNoise(x + 31.8, y + 17.3);
         const sparkle = sparkleNoise(x * 0.6 + 11.8, y * 0.7 - 4.1);
+        const fuzz = Math.pow(fiber, 1.2);
         const tonal = THREE.MathUtils.clamp(
-          0.56 +
-            (weave - 0.5) * 0.5 +
-            (cross - 0.5) * 0.42 +
-            (diamond - 0.5) * 0.55 +
-            (fiber - 0.5) * 0.2 +
+          0.54 +
+            (weave - 0.5) * 0.52 +
+            (cross - 0.5) * 0.44 +
+            (diamond - 0.5) * 0.5 +
+            (fiber - 0.5) * 0.28 +
+            (fuzz - 0.5) * 0.18 +
             (micro - 0.5) * 0.16,
           0,
           1
@@ -580,20 +596,20 @@ const createClothTextures = (() => {
           1
         );
         const highlightMix = THREE.MathUtils.clamp(
-          0.35 +
-            (cross - 0.5) * 0.42 +
-            (diamond - 0.5) * 0.68 +
-            (sparkle - 0.5) * 0.34,
+          0.32 +
+            (cross - 0.5) * 0.4 +
+            (diamond - 0.5) * 0.62 +
+            (sparkle - 0.5) * 0.36,
           0,
           1
         );
         const accentMix = THREE.MathUtils.clamp(
-          0.42 + (diamond - 0.5) * 1.05 + (fiber - 0.5) * 0.24,
+          0.45 + (diamond - 0.5) * 1.02 + (fuzz - 0.5) * 0.22,
           0,
           1
         );
         const highlightEnhanced = THREE.MathUtils.clamp(
-          0.38 + (highlightMix - 0.5) * 1.5,
+          0.36 + (highlightMix - 0.5) * 1.56,
           0,
           1
         );
@@ -617,8 +633,8 @@ const createClothTextures = (() => {
 
     const colorMap = new THREE.CanvasTexture(canvas);
     colorMap.wrapS = colorMap.wrapT = THREE.RepeatWrapping;
-    colorMap.repeat.set(12, 48);
-    colorMap.anisotropy = 32;
+    colorMap.repeat.set(16, 64);
+    colorMap.anisotropy = 64;
     colorMap.generateMipmaps = true;
     colorMap.minFilter = THREE.LinearMipmapLinearFilter;
     colorMap.magFilter = THREE.LinearFilter;
@@ -641,18 +657,18 @@ const createClothTextures = (() => {
         const v = ((x * COS - y * SIN) / THREAD_PITCH) * TAU;
         const warp = 0.5 + 0.5 * Math.cos(u);
         const weft = 0.5 + 0.5 * Math.cos(v);
-        const weave = Math.pow((warp + weft) * 0.5, 1.4);
-        const cross = Math.pow(warp * weft, 0.92);
-        const diamond = Math.pow(Math.abs(Math.sin(u) * Math.sin(v)), 0.68);
+        const weave = Math.pow((warp + weft) * 0.5, 1.48);
+        const cross = Math.pow(warp * weft, 0.9);
+        const diamond = Math.pow(Math.abs(Math.sin(u) * Math.sin(v)), 0.64);
         const fiber = fiberNoise(x, y);
         const micro = microNoise(x + 31.8, y + 17.3);
         const bump = THREE.MathUtils.clamp(
           0.54 +
-            (weave - 0.5) * 0.78 +
-            (cross - 0.5) * 0.42 +
-            (diamond - 0.5) * 0.56 +
-            (fiber - 0.5) * 0.26 +
-            (micro - 0.5) * 0.2,
+            (weave - 0.5) * 0.82 +
+            (cross - 0.5) * 0.4 +
+            (diamond - 0.5) * 0.5 +
+            (fiber - 0.5) * 0.32 +
+            (micro - 0.5) * 0.22,
           0,
           1
         );
@@ -1413,13 +1429,13 @@ function Table3D(parent) {
   });
   const ballDiameter = BALL_R * 2;
   const ballsAcrossWidth = PLAY_W / ballDiameter;
-  const threadsPerBallTarget = 8; // amplify cloth weave visibility (~8 crossings across one ball)
-  const clothTextureScale = 0.04; // enlarge weave pattern an additional 5x for clearer visibility
+  const threadsPerBallTarget = 9; // tighten the weave slightly while keeping detail visible
+  const clothTextureScale = 0.036; // keep the weave legible after increasing texture resolution
   const baseRepeat =
     ((threadsPerBallTarget * ballsAcrossWidth) / CLOTH_THREADS_PER_TILE) *
     clothTextureScale;
   const repeatRatio = 3.15;
-  const baseBumpScale = 0.74;
+  const baseBumpScale = 0.88;
   if (clothMap) {
     clothMat.map = clothMap;
     clothMat.map.repeat.set(baseRepeat, baseRepeat * repeatRatio);
@@ -1454,7 +1470,10 @@ function Table3D(parent) {
     roughness: 0.8
   });
 
-  const clothExtend = Math.max(TABLE.WALL * 0.18, Math.min(PLAY_W, PLAY_H) * 0.0055);
+  const clothExtend = Math.max(
+    SIDE_RAIL_INNER_THICKNESS * 0.18,
+    Math.min(PLAY_W, PLAY_H) * 0.0055
+  );
   const clothShape = new THREE.Shape();
   const halfWext = halfW + clothExtend;
   const halfHext = halfH + clothExtend;
@@ -1485,7 +1504,7 @@ function Table3D(parent) {
   });
   const markingHeight = clothPlaneLocal + MICRO_EPS * 2;
   const lineThickness = Math.max(BALL_R * 0.08, 0.1);
-  const baulkLineLength = PLAY_W - TABLE.WALL * 0.4;
+  const baulkLineLength = PLAY_W - SIDE_RAIL_INNER_THICKNESS * 0.4;
   const baulkLineGeom = new THREE.PlaneGeometry(baulkLineLength, lineThickness);
   const baulkLine = new THREE.Mesh(baulkLineGeom, markingMat);
   baulkLine.rotation.x = -Math.PI / 2;
@@ -1552,18 +1571,27 @@ function Table3D(parent) {
     pocketMeshes.push(pocket);
   });
 
-  const railW = TABLE.WALL * 0.7;
   const railH = TABLE.THICK * 1.82;
-  const frameWidth = railW * 2.5;
-  const outerHalfW = halfW + 2 * railW + frameWidth;
-  const outerHalfH = halfH + 2 * railW + frameWidth;
-  const CUSHION_BACK = railW * 0.5;
+  const longRailW = ORIGINAL_RAIL_WIDTH * SIDE_RAIL_INNER_SCALE;
+  const endRailW = ORIGINAL_RAIL_WIDTH;
+  const frameWidthLong = Math.max(
+    0,
+    ORIGINAL_OUTER_HALF_W - halfW - 2 * longRailW
+  );
+  const frameWidthEnd = Math.max(
+    0,
+    ORIGINAL_OUTER_HALF_H - halfH - 2 * endRailW
+  );
+  const outerHalfW = halfW + 2 * longRailW + frameWidthLong;
+  const outerHalfH = halfH + 2 * endRailW + frameWidthEnd;
+  const cushionBackLong = longRailW * 0.5;
+  const cushionBackEnd = endRailW * 0.5;
   const railsGroup = new THREE.Group();
   const NOTCH_R = POCKET_TOP_R * 1.02;
-  const xInL = -(halfW + CUSHION_BACK - MICRO_EPS);
-  const xInR = halfW + CUSHION_BACK - MICRO_EPS;
-  const zInB = -(halfH + CUSHION_BACK - MICRO_EPS);
-  const zInT = halfH + CUSHION_BACK - MICRO_EPS;
+  const xInL = -(halfW + cushionBackLong - MICRO_EPS);
+  const xInR = halfW + cushionBackLong - MICRO_EPS;
+  const zInB = -(halfH + cushionBackEnd - MICRO_EPS);
+  const zInT = halfH + cushionBackEnd - MICRO_EPS;
 
   function addCornerArcLong(shape, signX, signZ) {
     const xIn = signX < 0 ? xInL : xInR;
@@ -1616,7 +1644,7 @@ function Table3D(parent) {
     const xOut = signX < 0 ? -outerHalfW : outerHalfW;
     const shape = new THREE.Shape();
     const edgeRadius = Math.min(
-      railW * RAIL_OUTER_EDGE_RADIUS_RATIO,
+      longRailW * RAIL_OUTER_EDGE_RADIUS_RATIO,
       Math.abs(outerHalfH) * 0.4
     );
     const radius = Math.max(edgeRadius, 0);
@@ -1673,7 +1701,7 @@ function Table3D(parent) {
     const zOut = signZ < 0 ? -outerHalfH : outerHalfH;
     const shape = new THREE.Shape();
     const edgeRadius = Math.min(
-      railW * RAIL_OUTER_EDGE_RADIUS_RATIO,
+      endRailW * RAIL_OUTER_EDGE_RADIUS_RATIO,
       Math.abs(outerHalfW) * 0.4
     );
     const radius = Math.max(edgeRadius, 0);
@@ -1728,8 +1756,9 @@ function Table3D(parent) {
   function cushionProfileAdvanced(len, horizontal) {
     const halfLen = len / 2;
     const thicknessScale = horizontal ? FACE_SHRINK_LONG : FACE_SHRINK_SHORT;
-    const baseThickness = TABLE.WALL * 0.7 * thicknessScale;
-    const backY = (TABLE.WALL * 0.7) / 2;
+    const baseRailWidth = horizontal ? longRailW : endRailW;
+    const baseThickness = baseRailWidth * thicknessScale;
+    const backY = baseRailWidth / 2;
     const noseThickness = baseThickness * NOSE_REDUCTION;
     const frontY = backY - noseThickness;
     const rad = THREE.MathUtils.degToRad(CUSHION_CUT_ANGLE);
@@ -1819,10 +1848,11 @@ function Table3D(parent) {
   addCushion(rightX, -halfH + POCKET_GAP + vertSeg / 2, vertSeg, false, true);
   addCushion(rightX, halfH - POCKET_GAP - vertSeg / 2, vertSeg, false, true);
 
-  const frameOuterX = halfW + 2 * railW + frameWidth;
-  const frameOuterZ = halfH + 2 * railW + frameWidth;
+  const frameOuterX = outerHalfW;
+  const frameOuterZ = outerHalfH;
   const skirtH = TABLE_H * 0.68 * SKIRT_DROP_MULTIPLIER;
-  const baseOverhang = railW * SKIRT_SIDE_OVERHANG;
+  const baseRailWidth = endRailW;
+  const baseOverhang = baseRailWidth * SKIRT_SIDE_OVERHANG;
   const skirtShape = new THREE.Shape();
   const outW = frameOuterX + baseOverhang;
   const outZ = frameOuterZ + baseOverhang;
@@ -1861,15 +1891,16 @@ function Table3D(parent) {
     TABLE_H * 0.85,
     maxSidePostHeight - SIDE_POST_CLEARANCE
   );
-  const sidePostThickness = railW * SIDE_POST_THICKNESS_SCALE;
-  const sidePostDepth = railW * SIDE_POST_DEPTH_SCALE;
+  const sidePostThickness = baseRailWidth * SIDE_POST_THICKNESS_SCALE;
+  const sidePostDepth = baseRailWidth * SIDE_POST_DEPTH_SCALE;
   const sidePostGeo = new THREE.BoxGeometry(
     sidePostThickness,
     sidePostHeight,
     sidePostDepth
   );
   const sidePostY = sidePostTopLocal - sidePostHeight / 2;
-  const sidePostOffsetX = frameOuterX - sidePostThickness / 2 - railW * 0.2;
+  const sidePostOffsetX =
+    frameOuterX - sidePostThickness / 2 - baseRailWidth * 0.2;
   const sidePostZ = frameOuterZ * SIDE_POST_SPREAD;
   [-sidePostZ, sidePostZ].forEach((zPos) => {
     [-1, 1].forEach((dir) => {
@@ -1881,7 +1912,7 @@ function Table3D(parent) {
     });
   });
   const legGeo = new THREE.CylinderGeometry(legR, legR, legH, 64);
-  const legInset = railW * 2.2;
+  const legInset = baseRailWidth * 2.2;
   const legPositions = [
     [-frameOuterX + legInset, -frameOuterZ + legInset],
     [frameOuterX - legInset, -frameOuterZ + legInset],
@@ -3858,8 +3889,10 @@ function SnookerGame() {
           }
           const fit = fitRef.current;
           if (fit && cue?.active && !shooting) {
-            const limX = PLAY_W / 2 - BALL_R - TABLE.WALL;
-            const limY = PLAY_H / 2 - BALL_R - TABLE.WALL;
+            const limX =
+              PLAY_W / 2 - BALL_R - SIDE_RAIL_INNER_THICKNESS;
+            const limY =
+              PLAY_H / 2 - BALL_R - SIDE_RAIL_INNER_THICKNESS;
             const edgeX = Math.max(0, Math.abs(cue.pos.x) - (limX - 5));
             const edgeY = Math.max(0, Math.abs(cue.pos.y) - (limY - 5));
             const edge = Math.min(1, Math.max(edgeX, edgeY) / 5);


### PR DESCRIPTION
## Summary
- enlarge the snooker play field by trimming the long rail thickness from the inside while preserving the outer frame geometry
- refresh the table cloth with a richer green palette, denser procedural weave, and higher-resolution bump mapping for sharper detail

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4d535b6dc83298105af9f7e520901