### PR TITLE
Fix corner pocket rail arcs orientation

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -316,16 +316,16 @@ function addPocketCuts(parent, clothPlane) {
     if (isCorner) {
       const sx = Math.sign(p.x) || 1;
       const sy = Math.sign(p.y) || 1;
-      const diag = new THREE.Vector2(sx, sy).normalize();
-      const inward = diag.clone().multiplyScalar(-1);
+      const outward = new THREE.Vector2(sx, sy).normalize();
+      const inward = outward.clone().multiplyScalar(-1);
       const radialOffset = POCKET_VIS_R * 0.58;
       const railInset = ORIGINAL_RAIL_WIDTH * 0.35;
-      mesh.scale.set(-1, 1, -1);
+      mesh.scale.set(sx < 0 ? -1 : 1, 1, sy < 0 ? -1 : 1);
       mesh.rotation.y = Math.atan2(inward.y, inward.x) + Math.PI / 2;
       mesh.position.set(
-        sx * (halfW + railInset) + diag.x * radialOffset,
+        sx * (halfW + railInset) + outward.x * radialOffset,
         clothPlane + POCKET_RIM_LIFT,
-        sy * (halfH + railInset) + diag.y * radialOffset
+        sy * (halfH + railInset) + outward.y * radialOffset
       );
     } else {
       const sy = Math.sign(p.y) || 1;


### PR DESCRIPTION
## Summary
- mirror the cloth cut meshes per-corner so each pocket jaw arc aligns with the outer diagonal of the corner pockets
- keep the radial offset logic consistent by renaming the direction vector for clarity

## Testing
- `npm run lint` *(fails: repository has pre-existing lint violations outside the changed file)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ee07a1808329861ac7d9fbf616da