### PR TITLE
Add additional hemisphere light to snooker rig

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2991,6 +2991,14 @@ function SnookerGame() {
         );
         lightingRig.add(hemisphere);
 
+        const hemisphereRig = new THREE.HemisphereLight(0xdde7ff, 0x0b1020, 0.65);
+        hemisphereRig.position.set(
+          0,
+          tableSurfaceY + 6.6 * scaledHeight + lightHeightLift,
+          0
+        );
+        lightingRig.add(hemisphereRig);
+
         const dirLight = new THREE.DirectionalLight(0xffffff, 1.05);
         dirLight.position.set(
           -1.25 * fixtureScale,


### PR DESCRIPTION
## Summary
- add a secondary hemisphere light to the snooker lighting rig at the same height as the main fixtures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d52ffdbabc8329afd8e9446fe7e77f