### PR TITLE
Adjust snooker cameras and pocket geometry

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -395,7 +395,7 @@ const ORIGINAL_PLAY_W = TABLE.W - 2 * TABLE.WALL;
 const ORIGINAL_HALF_W = ORIGINAL_PLAY_W / 2;
 const PLAY_W = TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS;
 const PLAY_H = TABLE.H - 2 * TABLE.WALL;
-const ACTION_CAMERA_START_BLEND = 1;
+const ACTION_CAMERA_START_BLEND = 0;
 const BALL_R = 2 * BALL_SCALE;
 const CLOTH_TOP_LOCAL = FRAME_TOP_Y + BALL_R * 0.09523809523809523;
 const MICRO_EPS = BALL_R * 0.022857142857142857;
@@ -430,7 +430,7 @@ const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cus
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
 const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.18; // soften the exterior rail corners with a shallow curve
-const POCKET_RIM_LIFT = CLOTH_THICKNESS * 0.56; // maintain cloth cut alignment above the recess
+const POCKET_RIM_LIFT = CLOTH_THICKNESS * 0.64; // lift pocket rims slightly higher above the cloth plane
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
 const POCKET_CLOTH_TOP_RADIUS = POCKET_VIS_R * 0.84;
@@ -1849,8 +1849,8 @@ function Table3D(parent) {
   }
 
   const POCKET_GAP = POCKET_VIS_R * 0.68; // allow short-side cushions to reach a little closer to each corner
-  const LONG_CUSHION_TRIM = POCKET_VIS_R * 0.78; // trim long cushions slightly more so they clear the pocket entrances
-  const SIDE_CUSHION_POCKET_CLEARANCE = POCKET_VIS_R * 0.2; // shorten side cushions so they meet but do not intrude on the side pockets
+  const LONG_CUSHION_TRIM = POCKET_VIS_R * 0.86; // trim long cushions slightly more so they clear the pocket entrances
+  const SIDE_CUSHION_POCKET_CLEARANCE = POCKET_VIS_R * 0.26; // shorten side cushions so they meet but do not intrude on the side pockets
   const horizLen = PLAY_W - 2 * POCKET_GAP - LONG_CUSHION_TRIM;
   const vertSeg =
     PLAY_H / 2 - 2 * (POCKET_GAP + SIDE_CUSHION_POCKET_CLEARANCE);
@@ -2814,8 +2814,8 @@ function SnookerGame() {
             CAMERA.maxPhi - CAMERA_RAIL_SAFETY
           );
           cameraBoundsRef.current = {
-            cueShot: { phi: cuePhi, radius: cueRadius },
-            standing: { phi: standingPhi, radius: standingRadius }
+            cueShot: { phi: standingPhi, radius: standingRadius },
+            standing: { phi: cuePhi, radius: cueRadius }
           };
           applyCameraBlend();
           const cushionLimit = Math.max(


### PR DESCRIPTION
## Summary
- swap the snooker cue and standing camera presets so the player view now uses the previous action camera framing
- raise the rendered pocket rims slightly above the cloth to make them more prominent
- shorten the long and side cushions so they terminate before the pocket arcs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d535f95ec4832992ad3c47f7393fa7