### PR TITLE
Adjust snooker camera and table details

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -430,7 +430,7 @@ const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cus
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
 const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.18; // soften the exterior rail corners with a shallow curve
-const POCKET_RIM_LIFT = CLOTH_THICKNESS * 0.56; // maintain cloth cut alignment above the recess
+const POCKET_RIM_LIFT = CLOTH_THICKNESS * 0.64; // lift pocket rims slightly higher above the cloth
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
 const POCKET_CLOTH_TOP_RADIUS = POCKET_VIS_R * 0.84;
@@ -1848,9 +1848,9 @@ function Table3D(parent) {
     table.userData.cushions.push(group);
   }
 
-  const POCKET_GAP = POCKET_VIS_R * 0.68; // allow short-side cushions to reach a little closer to each corner
-  const LONG_CUSHION_TRIM = POCKET_VIS_R * 0.78; // trim long cushions slightly more so they clear the pocket entrances
-  const SIDE_CUSHION_POCKET_CLEARANCE = POCKET_VIS_R * 0.2; // shorten side cushions so they meet but do not intrude on the side pockets
+  const POCKET_GAP = POCKET_VIS_R * 0.74; // pull cushions back so they stop at the pocket arc transition
+  const LONG_CUSHION_TRIM = POCKET_VIS_R * 0.9; // trim long cushions further so they clear the pocket entrances cleanly
+  const SIDE_CUSHION_POCKET_CLEARANCE = POCKET_VIS_R * 0.28; // shorten side cushions to avoid overhanging the pocket throat
   const horizLen = PLAY_W - 2 * POCKET_GAP - LONG_CUSHION_TRIM;
   const vertSeg =
     PLAY_H / 2 - 2 * (POCKET_GAP + SIDE_CUSHION_POCKET_CLEARANCE);
@@ -2051,9 +2051,11 @@ function SnookerGame() {
     CAMERA.maxPhi
   );
   const initialCueRadius = Math.max(BREAK_VIEW.radius, CUE_VIEW_MIN_RADIUS);
+  const initialStandingPhi = CAMERA.minPhi;
+  const initialStandingRadius = BREAK_VIEW.radius;
   const cameraBoundsRef = useRef({
-    cueShot: { phi: initialCuePhi, radius: initialCueRadius },
-    standing: { phi: CAMERA.minPhi, radius: BREAK_VIEW.radius }
+    cueShot: { phi: initialStandingPhi, radius: initialStandingRadius },
+    standing: { phi: initialCuePhi, radius: initialCueRadius }
   });
   const rendererRef = useRef(null);
   const last3DRef = useRef({ phi: CAMERA.maxPhi, theta: Math.PI });
@@ -2814,8 +2816,8 @@ function SnookerGame() {
             CAMERA.maxPhi - CAMERA_RAIL_SAFETY
           );
           cameraBoundsRef.current = {
-            cueShot: { phi: cuePhi, radius: cueRadius },
-            standing: { phi: standingPhi, radius: standingRadius }
+            cueShot: { phi: standingPhi, radius: standingRadius },
+            standing: { phi: cuePhi, radius: cueRadius }
           };
           applyCameraBlend();
           const cushionLimit = Math.max(


### PR DESCRIPTION
## Summary
- swap the snooker player and action camera bounds so the player view matches the former action framing while the action cam inherits the old standing configuration
- raise the pocket rims slightly higher above the cloth surface
- shorten the cushion runs so the green rails finish where the pocket arcs begin

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d53a5dc8888329b55c2150540815e7