### PR TITLE
Tighten snooker cushion spacing around pockets

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1850,9 +1850,9 @@ function Table3D(parent) {
     table.userData.cushions.push(group);
   }
 
-  const POCKET_GAP = POCKET_VIS_R * 0.74; // stop cushions right as the corner pocket arcs begin
-  const LONG_CUSHION_TRIM = POCKET_VIS_R * 0.86; // trim long cushions so they clear the exposed pocket rims
-  const SIDE_CUSHION_POCKET_CLEARANCE = POCKET_VIS_R * 0.24; // shorten side cushions to end before the side pocket curves
+  const POCKET_GAP = POCKET_VIS_R * 0.64; // tighten gap so cushions meet pocket arcs sooner
+  const LONG_CUSHION_TRIM = POCKET_VIS_R * 0.72; // pull long cushions closer while keeping rim clearance
+  const SIDE_CUSHION_POCKET_CLEARANCE = POCKET_VIS_R * 0.18; // extend side cushions to meet the pocket arcs evenly
   const horizLen = PLAY_W - 2 * POCKET_GAP - LONG_CUSHION_TRIM;
   const vertSeg =
     PLAY_H / 2 - 2 * (POCKET_GAP + SIDE_CUSHION_POCKET_CLEARANCE);


### PR DESCRIPTION
## Summary
- tighten the pocket gap so cushions meet the arcs sooner and visually shrink the openings
- reduce the long cushion trim to bring all six cushions closer to the pocket lips
- decrease side cushion clearance so each side stops as soon as it touches the pocket curves

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d54ca70ed083298df1709175dd5d55