### PR TITLE
Narrow snooker side rails to match long cushions

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -388,7 +388,8 @@ const CLOTH_LIFT = (() => {
   const railH = TABLE.THICK * 1.82;
   return Math.max(0, railH - ballR - eps);
 })();
-const SIDE_RAIL_INNER_REDUCTION = 0.7;
+// Halve the short-end side rails so all aprons match the long cushions and extend play length
+const SIDE_RAIL_INNER_REDUCTION = 0.85;
 const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
 const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
 const ORIGINAL_PLAY_W = TABLE.W - 2 * TABLE.WALL;


### PR DESCRIPTION
## Summary
- halve the short-end side rail inset so the playfield extends evenly along the long axis

## Testing
- npm run lint *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d558f9d5f48329ba23b8ca43bdca8f