### PR TITLE
Adjust snooker camera and spin tuning

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -449,7 +449,7 @@ const POCKET_CAM = Object.freeze({
   distanceScale: 1.12,
   heightScale: 0.88
 });
-const SPIN_STRENGTH = BALL_R * 0.5;
+const SPIN_STRENGTH = BALL_R * 0.25;
 const SPIN_DECAY = 0.88;
 const SPIN_ROLL_STRENGTH = BALL_R * 0.035;
 const SPIN_ROLL_DECAY = 0.978;
@@ -820,7 +820,7 @@ const CAMERA = {
   // keep the camera slightly above the horizontal plane but allow a lower sweep
   maxPhi: CAMERA_MAX_PHI
 };
-const CAMERA_CUSHION_CLEARANCE = BALL_R * 0.42;
+const CAMERA_CUSHION_CLEARANCE = BALL_R * 0.9;
 const STANDING_VIEW = Object.freeze({
   phi: STANDING_VIEW_PHI,
   margin: STANDING_VIEW_MARGIN
@@ -831,7 +831,7 @@ let RAIL_LIMIT_X = DEFAULT_RAIL_LIMIT_X;
 let RAIL_LIMIT_Y = DEFAULT_RAIL_LIMIT_Y;
 const RAIL_LIMIT_PADDING = 0.1;
 const BREAK_VIEW = Object.freeze({
-  radius: 20 * TABLE_SCALE * GLOBAL_SIZE_FACTOR,
+  radius: 16 * TABLE_SCALE * GLOBAL_SIZE_FACTOR,
   phi: CAMERA.maxPhi - 0.005
 });
 const CAMERA_RAIL_SAFETY = 0.02;


### PR DESCRIPTION
## Summary
- bring the default snooker orbit camera closer to the table and raise the cushion clearance stop
- halve the cue ball spin strength to reduce applied english

## Testing
- npm run lint *(fails: existing lint errors in unrelated files such as jest.config.cjs and lib/*)*

------
https://chatgpt.com/codex/tasks/task_e_68d591969910832986e6ad6845cd0e71