### PR TITLE
Fix long rail pocket arch alignment

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1699,21 +1699,23 @@ function Table3D(parent) {
     addCornerArcLong(shape, signX, 1);
     (function () {
       const cx = signX < 0 ? -halfW : halfW;
+      const cz = signZ < 0 ? -halfH : halfH;
       const u = Math.abs(xIn - cx);
       const R = Math.max(NOTCH_R, u + 0.001);
       const dz = Math.sqrt(Math.max(0, R * R - u * u));
       const zTop = dz;
       const zBot = -dz;
-      shape.lineTo(xIn, zTop);
+      shape.lineTo(xIn, cz + zTop);
       const steps = 40;
       for (let i = 0; i <= steps; i++) {
         const t = i / steps;
-        const z = zTop + (zBot - zTop) * t;
-        const xDelta = Math.sqrt(Math.max(0, R * R - z * z));
+        const zRel = zTop + (zBot - zTop) * t;
+        const xDelta = Math.sqrt(Math.max(0, R * R - zRel * zRel));
         const x = cx + (signX > 0 ? xDelta : -xDelta);
-        shape.lineTo(x, z);
+        const zWorld = cz + zRel;
+        shape.lineTo(x, zWorld);
       }
-      shape.lineTo(xIn, zBot);
+      shape.lineTo(xIn, cz + zBot);
     })();
     addCornerArcLong(shape, signX, -1);
     shape.lineTo(xIn, -outerHalfH);


### PR DESCRIPTION
## Summary
- align the long-rail pocket arches with the pocket centers so the rails meet the arcs correctly
- offset the inner notch sampling for the long rails by the pocket center to keep all three misaligned arches in place

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63ecc4ec083298241e4ce15569ae4