### PR TITLE
Fix snooker corner pocket cut orientation

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -330,11 +330,11 @@ function addPocketCuts(parent, clothPlane) {
       const sx = Math.sign(p.x) || 1;
       const sy = Math.sign(p.y) || 1;
       const outward = new THREE.Vector2(sx, sy).normalize();
-      const inward = outward.clone().multiplyScalar(-1);
       const radialOffset = POCKET_VIS_R * 0.58;
       const railInset = ORIGINAL_RAIL_WIDTH * 0.35;
+      // mirror the base shape across the table axes so the pocket lip hugs the rails
+      // without rotating the arc away from the rail tangents
       mesh.scale.set(sx < 0 ? -1 : 1, 1, sy < 0 ? -1 : 1);
-      mesh.rotation.y = Math.atan2(inward.y, inward.x) + Math.PI / 2;
       mesh.position.set(
         sx * (halfW + railInset) + outward.x * radialOffset,
         clothPlane + POCKET_RIM_LIFT,


### PR DESCRIPTION
## Summary
- keep corner pocket cloth cuts aligned to the rail axes by mirroring the base geometry instead of rotating it off-axis

## Testing
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_68d676c7398c8329b8c67dfc0577c228