### PR TITLE
Fix corner pocket cut mirroring

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -335,6 +335,9 @@ function addPocketCuts(parent, clothPlane) {
       // rotate the base profile so every corner cut follows the rail tangents symmetrically
       const cornerYaw = Math.atan2(outward.y, outward.x) - Math.PI / 4;
       mesh.rotation.y = cornerYaw;
+      const mirrorX = sx >= 0 ? 1 : -1;
+      const mirrorY = sy >= 0 ? 1 : -1;
+      mesh.scale.set(mirrorX, mirrorY, 1);
       mesh.position.set(
         sx * (halfW + railInset) + outward.x * radialOffset,
         clothPlane + POCKET_RIM_LIFT,


### PR DESCRIPTION
## Summary
- mirror the corner pocket cloth cut meshes per quadrant so every pocket arc aligns with its rail angles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d67f6962e48329b146efbf56af2ba7