### PR TITLE
Fix left corner short rail pocket arc

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1767,7 +1767,7 @@ function Table3D(parent) {
     const v = Math.abs(zIn - (signZ < 0 ? -halfH : halfH));
     const R = Math.max(NOTCH_R, v + 0.001);
     const dx = Math.sqrt(Math.max(0, R * R - v * v));
-    shape.lineTo(cxL - dx, zIn);
+    shape.lineTo(cxL + dx, zIn);
     addCornerArcEnd(shape, signZ, -1);
     shape.lineTo(-outerHalfW, zIn);
     if (radius > 0) {


### PR DESCRIPTION
## Summary
- correct the short-rail pocket arc alignment by using the proper mirrored offset when bridging between corner arcs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a8b4ffe483298f6a66c8858e4244