### PR TITLE
Adjust snooker pocket camera positioning

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -451,14 +451,15 @@ const POCKET_CAM = Object.freeze({
   triggerDist: CAPTURE_R * 3.8,
   dotThreshold: 0.3,
   minOutside:
-    Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) +
-    POCKET_VIS_R * 2.1 +
-    BALL_R * 1.6,
+    Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.25 +
+    POCKET_VIS_R * 2.85 +
+    BALL_R * 2.4,
   maxOutside: BALL_R * 28,
   heightOffset: BALL_R * 10.8,
   outwardOffset:
-    Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.95 +
-    POCKET_VIS_R * 1.45,
+    Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.45 +
+    POCKET_VIS_R * 2.3 +
+    BALL_R * 1.8,
   heightDrop: BALL_R * 1.2,
   distanceScale: 1.08,
   heightScale: 1.22


### PR DESCRIPTION
## Summary
- increase the snooker pocket camera minimum outside distance so the view originates beyond the table edge
- extend the outward offset applied to pocket camera placement to keep the pocket visible at the bottom of the frame

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e43ef8e08329ab79a395cc74c663