### PR TITLE
Adjust snooker cloth and pocket rim height

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -616,7 +616,7 @@ const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cus
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
 const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.18; // soften the exterior rail corners with a shallow curve
-const POCKET_RIM_LIFT = CLOTH_THICKNESS * 0.8; // lift pockets slightly higher so the rims sit more prominently above the cloth and clear the surrounding cloth
+const POCKET_RIM_LIFT = CLOTH_THICKNESS * 1.05; // lift pockets so the rims stay clearly above the cloth plane
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
 const POCKET_CLOTH_TOP_RADIUS = POCKET_VIS_R * 0.84;
@@ -1898,10 +1898,11 @@ function Table3D(parent) {
     roughness: 0.8
   });
 
-  const clothExtend = Math.max(
+  const clothExtendBase = Math.max(
     SIDE_RAIL_INNER_THICKNESS * 0.3,
     Math.min(PLAY_W, PLAY_H) * 0.008
   );
+  const clothExtend = clothExtendBase + Math.min(PLAY_W, PLAY_H) * 0.0025; // extend the cloth to eliminate gaps beside the rails
   const clothShape = new THREE.Shape();
   const halfWext = halfW + clothExtend;
   const halfHext = halfH + clothExtend;


### PR DESCRIPTION
## Summary
- raise the snooker pocket rims slightly so they stay clear of the cloth surface
- extend the table cloth geometry a little further so it meets the rails without gaps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8b535fbcc8329a4a6fbd6131b6caf