### PR TITLE
Adjust snooker pocket height and trim cloth overlap

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -203,7 +203,7 @@ function addPocketJaws(parent, playW, playH) {
   const jawTopLocal = POCKET_JAW_LIP_HEIGHT;
   const jawDepthTarget = CLOTH_THICKNESS;
   const capHeight = CLOTH_THICKNESS * 0.36;
-  const capLift = CLOTH_THICKNESS * 0.36; // lift jaw caps a bit more so pocket lips clear the cloth plane
+  const capLift = CLOTH_THICKNESS * 0.42; // lift jaw caps a touch more so pocket lips stay safely above the cloth
   const cornerJawGeo = makeJawSector();
   const sideJawGeo = makeJawSector(
     POCKET_VIS_R * 0.94,
@@ -584,7 +584,7 @@ const MICRO_EPS = BALL_R * 0.022857142857142857;
 const POCKET_R = BALL_R * 1.82; // pockets tightened for a smaller opening
 // slightly larger visual radius so rails align with pocket rings
 const POCKET_VIS_R = POCKET_R / 0.985;
-const POCKET_CUT_EXPANSION = 1.04; // widen cloth openings so the pockets stay fully visible
+const POCKET_CUT_EXPANSION = 1.07; // widen cloth openings a little further to trim stray cloth around the pockets
 const POCKET_HOLE_R =
   POCKET_VIS_R * 1.3 * POCKET_CUT_EXPANSION; // cloth cutout radius for pocket openings
 const BALL_CENTER_Y = CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R; // rest balls directly on the cloth plane
@@ -611,12 +611,12 @@ const CLOTH_THICKNESS = TABLE.THICK * 0.12; // render a thinner cloth so the pla
 const POCKET_JAW_LIP_HEIGHT =
   CLOTH_TOP_LOCAL +
   CLOTH_LIFT +
-  BALL_R * 0.0725; // lift the pocket rims slightly higher so they sit more prominently above the cloth
+  BALL_R * 0.09; // raise the pocket rims a little more so they clear the cloth surface cleanly
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
 const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.18; // soften the exterior rail corners with a shallow curve
-const POCKET_RIM_LIFT = CLOTH_THICKNESS * 1.18; // lift pockets slightly more so the rims stay clearly above the cloth plane
+const POCKET_RIM_LIFT = CLOTH_THICKNESS * 1.28; // lift pockets slightly more so the rims sit clear of the cloth edge
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
 const POCKET_CLOTH_TOP_RADIUS = POCKET_VIS_R * 0.84;


### PR DESCRIPTION
## Summary
- raise the snooker pocket jaws and caps so the rims sit slightly higher than the cloth
- widen the cloth cutouts to remove the small strip of cloth protruding into the pockets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8b983ebf083298773b6c53d78d5f3