### PR TITLE
Adjust snooker pocket heights and rail arches

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -203,7 +203,7 @@ function addPocketJaws(parent, playW, playH) {
   const jawTopLocal = POCKET_JAW_LIP_HEIGHT;
   const jawDepthTarget = CLOTH_THICKNESS;
   const capHeight = CLOTH_THICKNESS * 0.36;
-  const capLift = CLOTH_THICKNESS * 0.42; // lift jaw caps a touch more so pocket lips stay safely above the cloth
+  const capLift = CLOTH_THICKNESS * 0.24; // keep jaw caps hovering slightly above the lowered cloth level
   const rimDeckHeight = capHeight * 0.46;
   const rimLipHeight = capHeight * 0.28;
   const surfaceRimThickness = capHeight * 0.22;
@@ -739,13 +739,13 @@ const CAPTURE_R = POCKET_R; // pocket capture radius
 const CLOTH_THICKNESS = TABLE.THICK * 0.12; // render a thinner cloth so the playing surface feels lighter
 const POCKET_JAW_LIP_HEIGHT =
   CLOTH_TOP_LOCAL +
-  CLOTH_LIFT +
-  BALL_R * 0.0075; // drop the pocket rims almost flush with the cloth so the lip sits lower on the rails
+  CLOTH_LIFT -
+  CLOTH_THICKNESS * 0.08; // sink the pocket lips to ride nearly level with the cloth without dipping below it
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
 const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.18; // soften the exterior rail corners with a shallow curve
-const POCKET_RIM_LIFT = CLOTH_THICKNESS * 0.36; // sink the pocket rims nearer to the cloth while keeping them above the surface
+const POCKET_RIM_LIFT = CLOTH_THICKNESS * 0.18; // drop the visible pocket rims almost flush with the surrounding cloth surface
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
 const POCKET_CLOTH_TOP_RADIUS = POCKET_VIS_R * 0.84;
@@ -2310,21 +2310,24 @@ function Table3D(parent) {
     if (signZ < 0) {
       // Add a mirrored pair of decorative arches on the baulk (D-line) short rail
       const innerSpanStart = rightArc.end.x;
-      const archCenterOffset = innerSpanStart * 0.42;
-      const archHalfWidth = innerSpanStart * 0.18;
+      const mirrorSpan = Math.min(innerSpanStart, Math.abs(leftArcData.start.x));
       const archDepth = END_RAIL_INNER_THICKNESS * 1.35;
-      const firstArchStart = archCenterOffset + archHalfWidth;
-      const firstArchEnd = archCenterOffset - archHalfWidth;
+      const archOuter = mirrorSpan * 0.92;
+      const archGapHalf = mirrorSpan * 0.08;
+      const firstArchCenter = (archOuter + archGapHalf) * 0.5;
+      const secondArchCenter = -firstArchCenter;
+      const firstArchStart = archOuter;
+      const firstArchEnd = archGapHalf;
+      const secondArchStart = -archGapHalf;
+      const secondArchEnd = -archOuter;
       shape.lineTo(firstArchStart, zIn);
       shape.quadraticCurveTo(
-        archCenterOffset,
+        firstArchCenter,
         zIn - archDepth,
         firstArchEnd,
         zIn
       );
-      const secondArchCenter = -archCenterOffset;
-      const secondArchStart = secondArchCenter + archHalfWidth;
-      const secondArchEnd = secondArchCenter - archHalfWidth;
+      // keep a short straight run between the mirrored arches so they don't overlap
       shape.lineTo(secondArchStart, zIn);
       shape.quadraticCurveTo(
         secondArchCenter,


### PR DESCRIPTION
## Summary
- lower the snooker pocket jaw and rim heights so the lips sit nearly level with the cloth
- retune baulk end rail decorative arches to form a mirrored pair with a short straight segment between them

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8dcf2b60483299ca0220acdddd8be