### PR TITLE
Fix cue tilt orientation on side rails

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -4567,6 +4567,9 @@ function SnookerGame() {
       const SCALE = BALL_R / 0.0525;
       const cueLen = 1.5 * SCALE;
       const cueStick = new THREE.Group();
+      cueStick.rotation.order = 'YXZ';
+      // Yaw the cue toward the aim direction before pitching so side-rail shots
+      // lower the butt the same way as short-rail setups.
       const cueBody = new THREE.Group();
       cueStick.add(cueBody);
       cueStick.userData.body = cueBody;


### PR DESCRIPTION
## Summary
- ensure the cue group's rotation order yaws before pitching so tilting behaves consistently on side rails
- document the reason for the new rotation order to keep cue butt lowering aligned with the spin controller

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d92f8db59c8329af1de7649e52dd2b