### PR TITLE
Replace snooker rails with adaptive frame geometry

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -17,6 +17,7 @@
     "emoji-name-map": "^2.0.3",
     "framer-motion": "^10.18.0",
     "lucide-react": "^0.525.0",
+    "polygon-clipping": "^0.15.7",
     "postcss": "^8.4.31",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary
- rebuild the snooker table rails with a polygon-clipping based frame that matches the table dimensions and pocket sizing
- add procedural rim tube arcs so the new frame aligns with existing pocket rims
- add the polygon-clipping dependency required for the new frame generation

## Testing
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_68d95d992678832987fcc7f471f9742c