### PR TITLE
Ensure snooker chrome plates sit above rail surface

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -382,7 +382,8 @@ function addPocketJaws(parent, playW, playH) {
   });
   const chromeGroup = new THREE.Group();
   parent.add(chromeGroup);
-  const chromeLift = capLift + capHeight * 0.85 + chromePlateThickness * 0.1 + MICRO_EPS * 8;
+  // Keep the chrome caps sitting on top of the rail surface so that all six plates remain visible.
+  const chromeLift = rimSurfaceLift + MICRO_EPS * 12;
   const chromeTopY = TABLE_RAIL_TOP_Y + chromeLift;
   for (const entry of POCKET_MAP) {
     const p = new THREE.Vector2(entry.pos[0], entry.pos[1]);


### PR DESCRIPTION
## Summary
- adjust the snooker chrome plate lift so the plates render on top of the rail surface
- document the reason for the new lift height to keep all six chrome plates visible

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173`

------
https://chatgpt.com/codex/tasks/task_e_68da025253588329aa5b327e3e51610b