### PR TITLE
Adjust snooker pocket rims and add chrome reference overlay

### DIFF
--- a/webapp/src/assets/snooker/current-rims-reference.svg
+++ b/webapp/src/assets/snooker/current-rims-reference.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640">
+  <defs>
+    <linearGradient id="cloth" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1f5a37" />
+      <stop offset="100%" stop-color="#266c43" />
+    </linearGradient>
+    <linearGradient id="wood" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7f4925" />
+      <stop offset="100%" stop-color="#5d3018" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="640" fill="#101417" />
+  <g transform="translate(80 80)">
+    <rect width="480" height="480" rx="36" fill="url(#wood)" />
+    <rect x="56" y="56" width="368" height="368" rx="12" fill="url(#cloth)" />
+    <g fill="#0d0d0d">
+      <circle cx="56" cy="56" r="32" />
+      <circle cx="424" cy="56" r="32" />
+      <circle cx="56" cy="424" r="32" />
+      <circle cx="424" cy="424" r="32" />
+      <circle cx="240" cy="56" r="28" />
+      <circle cx="240" cy="424" r="28" />
+    </g>
+    <g fill="none" stroke="#0d0d0d" stroke-width="22" stroke-linecap="round">
+      <path d="M56 56 L120 56" />
+      <path d="M424 56 L360 56" />
+      <path d="M56 424 L120 424" />
+      <path d="M424 424 L360 424" />
+      <path d="M240 56 L240 112" />
+      <path d="M240 424 L240 368" />
+    </g>
+  </g>
+  <text x="50%" y="600" fill="#f4f4f4" font-family="'Inter', sans-serif" font-size="42" text-anchor="middle">
+    Current in-game table
+  </text>
+</svg>

--- a/webapp/src/assets/snooker/target-rims-reference.svg
+++ b/webapp/src/assets/snooker/target-rims-reference.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640">
+  <defs>
+    <linearGradient id="brightCloth" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#2d8a4b" />
+      <stop offset="100%" stop-color="#38a55b" />
+    </linearGradient>
+    <linearGradient id="richWood" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#9c5d2d" />
+      <stop offset="100%" stop-color="#6e3f1c" />
+    </linearGradient>
+    <linearGradient id="chrome" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f2f4f9" />
+      <stop offset="50%" stop-color="#c8d2e1" />
+      <stop offset="100%" stop-color="#ffffff" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="640" fill="#101417" />
+  <g transform="translate(80 80)">
+    <rect width="480" height="480" rx="38" fill="url(#richWood)" />
+    <rect x="52" y="52" width="376" height="376" rx="16" fill="url(#brightCloth)" />
+    <g fill="#0b0b0b">
+      <circle cx="52" cy="52" r="30" />
+      <circle cx="428" cy="52" r="30" />
+      <circle cx="52" cy="428" r="30" />
+      <circle cx="428" cy="428" r="30" />
+      <circle cx="240" cy="52" r="26" />
+      <circle cx="240" cy="428" r="26" />
+    </g>
+    <g fill="none" stroke="#0b0b0b" stroke-width="18" stroke-linecap="round">
+      <path d="M52 52 L148 52" />
+      <path d="M428 52 L332 52" />
+      <path d="M52 428 L148 428" />
+      <path d="M428 428 L332 428" />
+    </g>
+    <g fill="none" stroke="#0b0b0b" stroke-width="14" stroke-linecap="round">
+      <path d="M240 52 L240 112" />
+      <path d="M240 428 L240 368" />
+    </g>
+    <g fill="url(#chrome)">
+      <path d="M36 52 a16 16 0 0 1 16 -16 h56 v32 h-56 a16 16 0 0 1 -16 -16z" />
+      <path d="M444 52 a16 16 0 0 0 -16 -16 h-56 v32 h56 a16 16 0 0 0 16 -16z" />
+      <path d="M36 428 a16 16 0 0 0 16 16 h56 v-32 h-56 a16 16 0 0 0 -16 16z" />
+      <path d="M444 428 a16 16 0 0 1 -16 16 h-56 v-32 h56 a16 16 0 0 1 16 16z" />
+      <rect x="188" y="36" width="104" height="28" rx="12" />
+      <rect x="188" y="436" width="104" height="28" rx="12" />
+    </g>
+  </g>
+  <text x="50%" y="600" fill="#fdfdfd" font-family="'Inter', sans-serif" font-size="42" text-anchor="middle">
+    Desired chrome & rim layout
+  </text>
+</svg>

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -18,6 +18,8 @@ import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { UnitySnookerRules } from '../../../../src/rules/UnitySnookerRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { useIsMobile } from '../../hooks/useIsMobile.js';
+import currentRimsReference from '../../assets/snooker/current-rims-reference.svg';
+import targetRimsReference from '../../assets/snooker/target-rims-reference.svg';
 
 // --------------------------------------------------
 // Pocket jaws
@@ -261,8 +263,8 @@ function addPocketJaws(parent, playW, playH) {
     capHeight
   );
   const cornerRimGeo = makeJawSector(
-    POCKET_VIS_R * 1.12,
-    JAW_T * 0.82,
+    POCKET_VIS_R * 1.2,
+    JAW_T * 1.04,
     SECTOR_START,
     SECTOR_END,
     rimDeckHeight
@@ -276,8 +278,8 @@ function addPocketJaws(parent, playW, playH) {
   cornerRimGeo.computeBoundingSphere();
   cornerRimGeo.computeVertexNormals();
   const cornerRimTopGeo = makeJawSector(
-    POCKET_VIS_R * 1.16,
-    JAW_T * 0.92,
+    POCKET_VIS_R * 1.24,
+    JAW_T * 1.12,
     SECTOR_START,
     SECTOR_END,
     rimLipHeight
@@ -291,8 +293,8 @@ function addPocketJaws(parent, playW, playH) {
   cornerRimTopGeo.computeBoundingSphere();
   cornerRimTopGeo.computeVertexNormals();
   const sideRimBaseGeo = makeJawSector(
-    POCKET_VIS_R * 1.02,
-    JAW_T * 0.48,
+    POCKET_VIS_R * 0.96,
+    JAW_T * 0.36,
     -SIDE_SECTOR_SWEEP,
     SIDE_SECTOR_SWEEP,
     rimDeckHeight * 0.92
@@ -306,8 +308,8 @@ function addPocketJaws(parent, playW, playH) {
   sideRimBaseGeo.computeBoundingSphere();
   sideRimBaseGeo.computeVertexNormals();
   const sideRimTopGeo = makeJawSector(
-    POCKET_VIS_R * 1.04,
-    JAW_T * 0.54,
+    POCKET_VIS_R * 0.98,
+    JAW_T * 0.4,
     -SIDE_SECTOR_SWEEP,
     SIDE_SECTOR_SWEEP,
     rimLipHeight * 0.9
@@ -321,8 +323,8 @@ function addPocketJaws(parent, playW, playH) {
   sideRimTopGeo.computeBoundingSphere();
   sideRimTopGeo.computeVertexNormals();
   const cornerSurfaceRimGeo = makeJawSector(
-    POCKET_VIS_R * 1.18,
-    JAW_T * 0.58,
+    POCKET_VIS_R * 1.26,
+    JAW_T * 0.78,
     SECTOR_START,
     SECTOR_END,
     surfaceRimThickness
@@ -336,8 +338,8 @@ function addPocketJaws(parent, playW, playH) {
   cornerSurfaceRimGeo.computeBoundingSphere();
   cornerSurfaceRimGeo.computeVertexNormals();
   const sideSurfaceRimGeo = makeJawSector(
-    POCKET_VIS_R * 0.95,
-    JAW_T * 0.22,
+    POCKET_VIS_R * 0.88,
+    JAW_T * 0.16,
     -SIDE_SECTOR_SWEEP,
     SIDE_SECTOR_SWEEP,
     surfaceRimThickness * 0.82
@@ -375,15 +377,15 @@ function addPocketJaws(parent, playW, playH) {
   });
   const sideChromeGeo = makeSideChromePlateGeometry({
     innerRadius: sidePocketRadius + surfaceRimThickness * 0.9,
-    halfSpan: POCKET_VIS_R * 1.64,
-    extension: longRailW * 0.98,
+    halfSpan: POCKET_VIS_R * 1.48,
+    extension: longRailW * 1.05,
     endFillet: longRailW * 0.42,
     thickness: chromePlateThickness
   });
   const chromeGroup = new THREE.Group();
   parent.add(chromeGroup);
   // Keep the chrome caps sitting on top of the rail surface so that all six plates remain visible.
-  const chromeLift = rimSurfaceLift + chromePlateThickness * 0.12 + MICRO_EPS * 12;
+  const chromeLift = rimSurfaceLift + chromePlateThickness * 0.45 + MICRO_EPS * 12;
   const chromeTopY = TABLE_RAIL_TOP_Y + chromeLift;
   for (const entry of POCKET_MAP) {
     const p = new THREE.Vector2(entry.pos[0], entry.pos[1]);
@@ -441,8 +443,8 @@ function addPocketJaws(parent, playW, playH) {
       const width = adjustedBox
         ? adjustedBox.max.x - adjustedBox.min.x
         : POCKET_VIS_R * 1.2;
-      const segmentScale = 0.62;
-      const offset = width * 0.24;
+      const segmentScale = 0.56;
+      const offset = width * 0.18;
       for (const dir of [-1, 1]) {
         const segmentGeom = geom.clone();
         segmentGeom.scale(segmentScale, 1, 1);
@@ -960,7 +962,7 @@ const CLOTH_TEXTURE_INTENSITY = 0.56;
 const CLOTH_BUMP_INTENSITY = 0.48;
 
 const COLORS = Object.freeze({
-  cloth: 0x2c7d4f,
+  cloth: 0x339a5a,
   rail: RAIL_WOOD_COLOR,
   base: BASE_WOOD_COLOR,
   markings: 0xffffff,
@@ -1013,10 +1015,10 @@ const createClothTextures = (() => {
 
     const image = ctx.createImageData(SIZE, SIZE);
     const data = image.data;
-    const shadow = { r: 0x14, g: 0x52, b: 0x2d };
-    const base = { r: 0x24, g: 0x7a, b: 0x3b };
-    const accent = { r: 0x33, g: 0x93, b: 0x49 };
-    const highlight = { r: 0x52, g: 0xba, b: 0x6f };
+    const shadow = { r: 0x1a, g: 0x5b, b: 0x36 };
+    const base = { r: 0x2c, g: 0x86, b: 0x45 };
+    const accent = { r: 0x3b, g: 0x9d, b: 0x52 };
+    const highlight = { r: 0x5d, g: 0xc8, b: 0x79 };
     const hashNoise = (x, y, seedX, seedY, phase = 0) =>
       Math.sin((x * seedX + y * seedY + phase) * 0.02454369260617026) * 0.5 + 0.5;
     const fiberNoise = (x, y) =>
@@ -6251,6 +6253,25 @@ function SnookerGame() {
   const ballTravel = Math.max(0, Math.min(1, (displayedProgress - 12) / 88));
   const cuePosition = cueBaseOffset - cueDrawBack * (1 - cueStrikeProgress);
   const cueBallPosition = ballOffsetStart + cueTrackWidth * ballTravel;
+  const referenceImages = useMemo(
+    () => [
+      {
+        key: 'current',
+        src: currentRimsReference,
+        alt: 'Pamja aktuale e tavolinës në lojë',
+        caption:
+          'Aktualisht xhepat anësorë janë më të ngushtë dhe pllakat e kromit nuk dallohen.'
+      },
+      {
+        key: 'target',
+        src: targetRimsReference,
+        alt: 'Pamja e dëshiruar e tavolinës me krom',
+        caption:
+          'Synimi: rime të hapura në cepat dhe pllakat e kromit të ekspozuara mbi rail.'
+      }
+    ],
+    []
+  );
 
   return (
     <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
@@ -6318,6 +6339,24 @@ function SnookerGame() {
             </div>
           </div>
           <div className="mt-1 text-sm">Time: {timer}</div>
+        </div>
+      </div>
+
+      <div
+        className={`absolute top-20 left-0 right-0 z-40 flex justify-center px-4 transition-opacity duration-300 ${pocketCameraActive ? 'opacity-0' : 'opacity-100'}`}
+      >
+        <div className="pointer-events-none w-full max-w-sm flex flex-col gap-3">
+          {referenceImages.map(({ key, src, alt, caption }) => (
+            <figure
+              key={key}
+              className="pointer-events-none overflow-hidden rounded-xl border border-white/15 bg-black/70 backdrop-blur-sm shadow-lg shadow-black/40"
+            >
+              <img src={src} alt={alt} className="w-full h-auto object-cover" loading="lazy" />
+              <figcaption className="px-3 py-2 text-xs leading-relaxed text-emerald-100">
+                {caption}
+              </figcaption>
+            </figure>
+          ))}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- widen the corner pocket rims while tightening the mid-table rims so they align with the cloth edges and exposed chrome plates
- slightly brighten the table cloth and lift the chrome geometry so all six plates are visible on the rails
- add an in-game overlay with before/after reference images for the snooker rim and chrome layout

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68da0e0d74f0832980afd1321cde29a7