### PR TITLE
Adjust side rail span near corner pockets

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2311,7 +2311,7 @@ function Table3D(parent) {
   const innerHalfH = halfHext;
   const cornerPocketRadius = POCKET_VIS_R * 1.08;
   const cornerChamfer = POCKET_VIS_R * 0.42;
-  const cornerInset = POCKET_VIS_R * 0.5;
+  const cornerInset = POCKET_VIS_R * 0.56;
   const sidePocketRadius = POCKET_VIS_R * 0.92;
   const sideInset = POCKET_VIS_R * 0.42;
 


### PR DESCRIPTION
## Summary
- nudge the corner pocket inset so the long rails finish slightly farther from the corners

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dadfdbef54832987d39a0bd492c3e2