### PR TITLE
Raise snooker cushions to align with frame rails

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -600,6 +600,7 @@ const POCKET_JAW_LIP_HEIGHT =
   CLOTH_LIFT -
   CLOTH_THICKNESS * 0.24; // recess the pocket lips so they sit almost flush with the cloth while staying visible
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
+const CUSHION_EXTRA_LIFT = BALL_R * 0.08; // lift cushions so their lip sits higher and matches the raised frame rails
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
 const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.18; // soften the exterior rail corners with a shallow curve
@@ -2453,7 +2454,7 @@ function Table3D(parent) {
   const NOSE_REDUCTION = 0.75;
   const CUSHION_UNDERCUT_BASE_LIFT = 0.32;
   const CUSHION_UNDERCUT_FRONT_REMOVAL = 0.54;
-  const cushionRaiseY = CLOTH_TOP_LOCAL - MICRO_EPS;
+  const cushionRaiseY = CLOTH_TOP_LOCAL - MICRO_EPS + CUSHION_EXTRA_LIFT;
 
   function cushionProfileAdvanced(len, horizontal) {
     const halfLen = len / 2;


### PR DESCRIPTION
## Summary
- introduce a cushion lift constant so the snooker cushions sit higher and stay flush with the frame rails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daecc190748329a1c291da35b9f056