### PR TITLE
Adjust standing camera position for Snooker view

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1174,9 +1174,9 @@ function spotPositions(baulkZ) {
 }
 
 // Kamera: ruaj kënd komod që mos shtrihet poshtë cloth-it, por lejo pak më shumë lartësi kur ngrihet
-const STANDING_VIEW_PHI = 0.9;
+const STANDING_VIEW_PHI = 0.94;
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
-const STANDING_VIEW_MARGIN = 0.18;
+const STANDING_VIEW_MARGIN = 0.12;
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.3;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.18);


### PR DESCRIPTION
## Summary
- bring the Snooker standing camera closer to the table by reducing the framing margin
- lower the standing camera angle slightly to sit nearer to table height

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db717f47548329922459baa0d4136b