### PR TITLE
Adjust standing camera distance for Snooker view

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1302,8 +1302,9 @@ const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.18);
 const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.24; // keep orbit camera from dipping below the table surface
 const PLAYER_CAMERA_DISTANCE_FACTOR = 0.4;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
-const BROADCAST_DISTANCE_MULTIPLIER = 1.02;
-const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.26;
+// Bring the standing/broadcast framing closer to the cloth so the table feels less distant
+const BROADCAST_DISTANCE_MULTIPLIER = 0.95;
+const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.18;
 const CAMERA = {
   fov: STANDING_VIEW_FOV,
   near: 0.04,


### PR DESCRIPTION
## Summary
- bring the snooker standing/broadcast camera closer to the table by tightening radius calculations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db8f145e8883298efc3b57773a15a5