### PR TITLE
Adjust snooker standing camera distance and long cushion reach

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1303,7 +1303,7 @@ const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.24; // keep orbit camera from dipping be
 const PLAYER_CAMERA_DISTANCE_FACTOR = 0.4;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant
-const BROADCAST_DISTANCE_MULTIPLIER = 0.95;
+const BROADCAST_DISTANCE_MULTIPLIER = 0.9;
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.18;
 const CAMERA = {
   fov: STANDING_VIEW_FOV,
@@ -2695,7 +2695,7 @@ function Table3D(parent) {
 
   const POCKET_GAP = POCKET_VIS_R * 0.92; // shorten cushions so they finish where the frame arcs begin
   const SHORT_CUSHION_EXTENSION = POCKET_VIS_R * 0.1; // extend short rail cushions slightly toward the corner pockets
-  const LONG_CUSHION_TRIM = POCKET_VIS_R * 0.9; // trim the straight rails so the long cushions end a bit sooner near the corners
+  const LONG_CUSHION_TRIM = POCKET_VIS_R * 0.6; // extend the long cushions so they stop right where the pocket arcs begin
   const SIDE_CUSHION_POCKET_CLEARANCE = POCKET_VIS_R * 0.05; // extend side cushions so they meet the pocket jaws cleanly
   const SIDE_CUSHION_CENTER_PULL = POCKET_VIS_R * 0.12; // push long rail cushions a touch closer to the middle pockets
   const SIDE_CUSHION_CORNER_TRIM = POCKET_VIS_R * 0.22; // shave a little length off the side cushions near the corner pockets


### PR DESCRIPTION
## Summary
- reduce the standing and broadcast orbit distance so the table fills more of the frame
- extend the long rail cushions so they terminate at the start of the pocket arcs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db9039e9a483299fc8ce2bddf34603