### PR TITLE
Adjust snooker standing camera and cue alignment

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -780,7 +780,7 @@ const CUE_Y = BALL_CENTER_Y; // keep cue stick level with the cue ball center
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
 const CUE_MARKER_RADIUS = CUE_TIP_RADIUS; // cue ball dots match the cue tip footprint
 const CUE_MARKER_DEPTH = CUE_TIP_RADIUS * 0.2;
-const CUE_BUTT_LIFT = BALL_R * 0.42;
+const CUE_BUTT_LIFT = BALL_R * 0.48;
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(8.5);
 const CUE_FRONT_SECTION_RATIO = 0.28;
 const MAX_SPIN_CONTACT_OFFSET = Math.max(0, BALL_R - CUE_TIP_RADIUS);
@@ -1293,7 +1293,7 @@ function applySnookerScaling({
 }
 
 // Kamera: ruaj kënd komod që mos shtrihet poshtë cloth-it, por lejo pak më shumë lartësi kur ngrihet
-const STANDING_VIEW_PHI = 0.96;
+const STANDING_VIEW_PHI = 0.9;
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.02;
 const STANDING_VIEW_FOV = 66;
@@ -1303,7 +1303,7 @@ const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.24; // keep orbit camera from dipping be
 const PLAYER_CAMERA_DISTANCE_FACTOR = 0.4;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant
-const BROADCAST_DISTANCE_MULTIPLIER = 0.68;
+const BROADCAST_DISTANCE_MULTIPLIER = 0.64;
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.08;
 const CAMERA = {
   fov: STANDING_VIEW_FOV,
@@ -2694,7 +2694,7 @@ function Table3D(parent) {
   }
 
   const POCKET_GAP = POCKET_VIS_R * 0.76; // tighten the cushion gap so the noses meet the pocket arcs without overlap
-  const SHORT_CUSHION_EXTENSION = POCKET_VIS_R * 0.04; // keep the short rail cushions tucked so their ends kiss the pocket arcs
+  const SHORT_CUSHION_EXTENSION = POCKET_VIS_R * 0.015; // shorten the short rail cushions so their corners meet the pocket arcs cleanly
   const LONG_CUSHION_TRIM = POCKET_VIS_R * 0.24; // let the long cushions finish right at the pocket curves
   const SIDE_CUSHION_POCKET_CLEARANCE = POCKET_VIS_R * 0.12; // push the side cushions toward the corner jaws without intersecting
   const SIDE_CUSHION_CENTER_PULL = POCKET_VIS_R * 0.14; // ease the side cushions inward so their seams stay tight


### PR DESCRIPTION
## Summary
- bring the standing camera closer to the table and slightly higher to match the requested framing
- shorten the short-rail cushions so their corners align cleanly with the pocket arcs
- raise the cue butt lift so the tip sits lower while the rear clears the rails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba8125ad483299469f2f68eeb46f8