### PR TITLE
Adjust short rail cushions to align with pocket arcs

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2694,7 +2694,7 @@ function Table3D(parent) {
   }
 
   const POCKET_GAP = POCKET_VIS_R * 0.76; // tighten the cushion gap so the noses meet the pocket arcs without overlap
-  const SHORT_CUSHION_TRIM = POCKET_VIS_R * 0.05; // trim the short rail cushions slightly so their corners meet the pocket arcs cleanly
+  const SHORT_CUSHION_TRIM = POCKET_VIS_R * 0.08; // trim the short rail cushions slightly so their corners meet the pocket arcs cleanly
   const LONG_CUSHION_TRIM = POCKET_VIS_R * 0.24; // let the long cushions finish right at the pocket curves
   const SIDE_CUSHION_POCKET_CLEARANCE = POCKET_VIS_R * 0.12; // push the side cushions toward the corner jaws without intersecting
   const SIDE_CUSHION_CENTER_PULL = POCKET_VIS_R * 0.14; // ease the side cushions inward so their seams stay tight


### PR DESCRIPTION
## Summary
- increase the short-rail cushion trim factor so the cushion corners align with the pocket arcs without changing their height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb2c0ab10832994bc2ad5a06732c6