### PR TITLE
Adjust snooker cushion placement and cloth coverage

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2305,7 +2305,7 @@ function Table3D(parent) {
   );
   const clothExtend =
     clothExtendBase +
-    Math.min(PLAY_W, PLAY_H) * 0.005; // extend the cloth further so rails meet the cloth with no gaps
+    Math.min(PLAY_W, PLAY_H) * 0.0075; // extend the cloth further so rails meet the cloth with no gaps
   const clothShape = new THREE.Shape();
   const halfWext = halfW + clothExtend;
   const halfHext = halfH + clothExtend;
@@ -2643,7 +2643,7 @@ function Table3D(parent) {
     return geo;
   }
 
-const CUSHION_RAIL_FLUSH = MICRO_EPS * 0.5; // slide cushions almost against the rails so there's no visible gap
+const CUSHION_RAIL_FLUSH = MICRO_EPS * 0.12; // nudge cushions closer to the rails so they kiss without overlapping
 
   function addCushion(x, z, len, horizontal, flip = false) {
     const geo = cushionProfileAdvanced(len, horizontal);


### PR DESCRIPTION
## Summary
- move snooker cushions slightly toward the rails so they sit flush without overlapping
- extend the snooker cloth coverage further so it touches the inner rails with no visible gaps

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbda5867dc8329b65ed2d5990367d3