### PR TITLE
Adjust snooker cushions clearance

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2658,7 +2658,7 @@ function Table3D(parent) {
     return geo;
   }
 
-const CUSHION_RAIL_FLUSH = 0; // keep cushions flush with the rails without overlap
+const CUSHION_RAIL_FLUSH = SIDE_RAIL_INNER_THICKNESS * 0.03; // pull cushions slightly toward the centre so they clear the rails
 
   function addCushion(x, z, len, horizontal, flip = false) {
     const geo = cushionProfileAdvanced(len, horizontal);


### PR DESCRIPTION
## Summary
- shift the snooker table cushions slightly toward the playfield centre to avoid overlapping the rails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc0293831c8329b3d870b5b84b95dc