### PR TITLE
Adjust snooker cushion height to match rails

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -638,7 +638,7 @@ const POCKET_JAW_LIP_HEIGHT =
   CLOTH_LIFT -
   CLOTH_THICKNESS * 0.24; // recess the pocket lips so they sit almost flush with the cloth while staying visible
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
-const CUSHION_EXTRA_LIFT = BALL_R * 0.08; // lift cushions so their lip sits higher and matches the raised frame rails
+const CUSHION_EXTRA_LIFT = BALL_R * 0.14; // lift cushions so their lip aligns flush with the raised frame rails
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
 const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.18; // soften the exterior rail corners with a shallow curve


### PR DESCRIPTION
## Summary
- raise the snooker cushion lift so the green cushions sit flush with the surrounding rails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc10419bc48329a5c0494a62dd825d