### PR TITLE
Extend side cushions toward corner pockets

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2698,7 +2698,7 @@ function Table3D(parent) {
   const LONG_CUSHION_TRIM = POCKET_VIS_R * 0.32; // extend the long cushions so they stop right where the pocket arcs begin
   const SIDE_CUSHION_POCKET_CLEARANCE = POCKET_VIS_R * 0.05; // extend side cushions so they meet the pocket jaws cleanly
   const SIDE_CUSHION_CENTER_PULL = POCKET_VIS_R * 0.2; // push long rail cushions a touch closer to the middle pockets
-  const SIDE_CUSHION_CORNER_TRIM = POCKET_VIS_R * 0.18; // shave a little length off the side cushions near the corner pockets
+  const SIDE_CUSHION_CORNER_TRIM = POCKET_VIS_R * 0.08; // extend side cushions toward the corner pockets for longer green rails
   const horizLen =
     PLAY_W - 2 * (POCKET_GAP - SHORT_CUSHION_EXTENSION) - LONG_CUSHION_TRIM;
   const vertSeg =


### PR DESCRIPTION
## Summary
- reduce the side cushion corner trim so the long rails reach closer to the corner pockets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc15a9bc3c8329878acba2e8c099bd