### PR TITLE
Adjust snooker cushion positioning

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2670,7 +2670,7 @@ function Table3D(parent) {
   }
 
   const CUSHION_RAIL_FLUSH = TABLE.THICK * 0.002; // keep cushions visually flush with the rail wood while avoiding z-fighting
-  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.01; // pull cushions a touch toward the playfield to avoid overlapping the rails
+  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.015; // pull cushions a touch toward the playfield to avoid overlapping the rails
 
   function addCushion(x, z, len, horizontal, flip = false) {
     const geo = cushionProfileAdvanced(len, horizontal);


### PR DESCRIPTION
## Summary
- increase the snooker cushion center nudge so all six cushions sit slightly closer to the playfield and avoid overlapping the rails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc25eb3060832998b67d7f550361e5