### PR TITLE
Adjust snooker cushions slightly inward

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2670,7 +2670,7 @@ function Table3D(parent) {
   }
 
   const CUSHION_RAIL_FLUSH = TABLE.THICK * 0.002; // keep cushions visually flush with the rail wood while avoiding z-fighting
-  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.015; // pull cushions a touch toward the playfield to avoid overlapping the rails
+const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.02; // pull cushions a touch toward the playfield to avoid overlapping the rails
 
   function addCushion(x, z, len, horizontal, flip = false) {
     const geo = cushionProfileAdvanced(len, horizontal);


### PR DESCRIPTION
## Summary
- increase the center nudge applied to all snooker cushions so they sit slightly further from the rails and avoid overlap

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc298d1e28832992655782e7dbbf5f