### PR TITLE
Adjust snooker cushion positioning

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2670,8 +2670,8 @@ function Table3D(parent) {
   }
 
 const CUSHION_RAIL_FLUSH = TABLE.THICK * 0.002; // keep cushions visually flush with the rail wood while avoiding z-fighting
-const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.03; // pull cushions a touch toward the playfield to avoid overlapping the rails
-const SHORT_CUSHION_HEIGHT_SCALE = 1.02; // give the short rail cushions a subtle lift to meet the rail tops
+const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.045; // pull cushions a touch toward the playfield to avoid overlapping the rails
+const SHORT_CUSHION_HEIGHT_SCALE = 1.045; // give the short rail cushions a subtle lift to meet the rail tops
 
   function addCushion(x, z, len, horizontal, flip = false) {
     const geo = cushionProfileAdvanced(len, horizontal);
@@ -2707,7 +2707,7 @@ const SHORT_CUSHION_HEIGHT_SCALE = 1.02; // give the short rail cushions a subtl
   const LONG_CUSHION_TRIM = POCKET_VIS_R * 0.32; // extend the long cushions so they stop right where the pocket arcs begin
   const SIDE_CUSHION_POCKET_CLEARANCE = POCKET_VIS_R * 0.05; // extend side cushions so they meet the pocket jaws cleanly
   const SIDE_CUSHION_CENTER_PULL = POCKET_VIS_R * 0.2; // push long rail cushions a touch closer to the middle pockets
-  const SIDE_CUSHION_CORNER_TRIM = POCKET_VIS_R * 0.04; // extend side cushions toward the corner pockets for longer green rails
+  const SIDE_CUSHION_CORNER_TRIM = POCKET_VIS_R * 0.015; // extend side cushions toward the corner pockets for longer green rails
   const horizLen =
     PLAY_W - 2 * (POCKET_GAP - SHORT_CUSHION_EXTENSION) - LONG_CUSHION_TRIM;
   const vertSeg =


### PR DESCRIPTION
## Summary
- move all cushions slightly toward the table center to clear the rail overlap
- raise the short-rail cushions so their tops meet the rail height
- extend the long-side cushions toward the corner pockets for consistent pocket gaps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc36b0215c832995652709580f831b