### PR TITLE
Add snooker aim masking utilities and overlay

### DIFF
--- a/aim/angleMask.js
+++ b/aim/angleMask.js
@@ -1,0 +1,194 @@
+const TWO_PI = Math.PI * 2;
+const EPS = 1e-9;
+
+function normalizeAngle(angle) {
+  let a = angle % TWO_PI;
+  if (a < 0) a += TWO_PI;
+  return a;
+}
+
+function angularWidth(start, end) {
+  return end - start;
+}
+
+function addWrappedInterval(target, start, end) {
+  const width = angularWidth(start, end);
+  if (width <= EPS) return;
+  if (width >= TWO_PI - EPS) {
+    target.push({ start: 0, end: TWO_PI });
+    return;
+  }
+  const normalizedStart = normalizeAngle(start);
+  const normalizedEnd = normalizedStart + width;
+  if (normalizedEnd <= TWO_PI + EPS) {
+    target.push({ start: normalizedStart, end: Math.min(normalizedEnd, TWO_PI) });
+  } else {
+    target.push({ start: normalizedStart, end: TWO_PI });
+    target.push({ start: 0, end: normalizedEnd - TWO_PI });
+  }
+}
+
+function mergeIntervals(intervals) {
+  if (intervals.length === 0) return [];
+  const sorted = intervals
+    .map((i) => ({ start: i.start, end: i.end }))
+    .sort((a, b) => a.start - b.start);
+  const merged = [sorted[0]];
+  for (let i = 1; i < sorted.length; i += 1) {
+    const current = sorted[i];
+    const last = merged[merged.length - 1];
+    if (current.start <= last.end + EPS) {
+      if (current.end > last.end) last.end = current.end;
+    } else {
+      merged.push(current);
+    }
+  }
+  // Collapse wrap-around if needed
+  if (
+    merged.length > 1 &&
+    merged[0].start <= EPS &&
+    merged[merged.length - 1].end >= TWO_PI - EPS
+  ) {
+    const first = merged.shift();
+    merged[merged.length - 1].end = TWO_PI;
+    merged.unshift({ start: 0, end: first.end });
+  }
+  // Clamp bounds to [0, 2π]
+  return merged.map((i) => ({
+    start: Math.max(0, Math.min(TWO_PI, i.start)),
+    end: Math.max(0, Math.min(TWO_PI, i.end))
+  }));
+}
+
+function computeIntervalsForBall(ball, params, meta) {
+  const { C, rBall, rShaft, epsilon, L } = params;
+  const R = rBall + rShaft + epsilon;
+  const dx = ball.pos.x - C.x;
+  const dz = ball.pos.z - C.z;
+  const rhoSq = dx * dx + dz * dz;
+  const rho = Math.sqrt(rhoSq);
+  if (rho <= EPS) {
+    meta.kind = 'degenerate';
+    meta.delta = Math.PI;
+    return [{ start: 0, end: TWO_PI }];
+  }
+
+  const alpha = Math.atan2(dz, dx);
+  const center = alpha + Math.PI;
+  const ratio = Math.min(1, R / Math.max(rho, EPS));
+  const delta = Math.asin(ratio);
+  meta.center = center;
+  meta.delta = delta;
+
+  const baseStart = center - delta;
+  const baseEnd = center + delta;
+  const cosDelta = Math.sqrt(Math.max(0, 1 - ratio * ratio));
+  const intervals = [];
+
+  if (L > EPS) {
+    const Lhat = L / rho;
+    if (Lhat >= 1) {
+      intervals.push({ start: baseStart, end: baseEnd, mode: 'interior-full' });
+    } else if (Lhat > cosDelta + EPS) {
+      const psi0 = Math.acos(Math.min(1, Lhat));
+      if (psi0 < delta - EPS) {
+        intervals.push({ start: baseStart, end: center - psi0, mode: 'interior-edge' });
+        intervals.push({ start: center + psi0, end: baseEnd, mode: 'interior-edge' });
+      }
+    }
+
+    const q = (rhoSq + L * L - R * R) / (2 * rho * L);
+    if (q <= -1 + EPS) {
+      intervals.push({ start: baseStart, end: baseEnd, mode: 'endpoint-full' });
+    } else if (q < 1 - EPS) {
+      const psiLimit = Math.acos(Math.max(-1, Math.min(1, q)));
+      const span = Math.min(psiLimit, delta);
+      if (span > EPS) {
+        intervals.push({ start: center - span, end: center + span, mode: 'endpoint' });
+      }
+    } else if (Math.abs(q - 1) <= 1e-6) {
+      intervals.push({ start: center, end: center, mode: 'endpoint-touch' });
+    }
+  } else {
+    if (rho <= R + EPS) {
+      intervals.push({ start: 0, end: TWO_PI, mode: 'degenerate' });
+    }
+  }
+
+  meta.intervals = intervals.map(({ start, end, mode }) => ({ start, end, mode }));
+  return intervals;
+}
+
+export function computeAngleMask(params) {
+  const blockedRaw = [];
+  const perBallMeta = [];
+  const { balls = [] } = params;
+  for (let i = 0; i < balls.length; i += 1) {
+    const meta = { index: i };
+    const intervals = computeIntervalsForBall(balls[i], params, meta);
+    perBallMeta.push(meta);
+    intervals.forEach(({ start, end }) => {
+      addWrappedInterval(blockedRaw, start, end);
+    });
+  }
+  const blocked = mergeIntervals(blockedRaw);
+  let allowed;
+  if (blocked.length === 0) {
+    allowed = [{ start: 0, end: TWO_PI }];
+  } else if (blocked.length === 1 && blocked[0].start <= EPS && blocked[0].end >= TWO_PI - EPS) {
+    allowed = [];
+  } else {
+    allowed = [];
+    let cursor = 0;
+    for (let i = 0; i < blocked.length; i += 1) {
+      const current = blocked[i];
+      if (current.start > cursor + EPS) {
+        allowed.push({ start: cursor, end: current.start });
+      }
+      cursor = Math.max(cursor, current.end);
+    }
+    if (cursor < TWO_PI - EPS) {
+      allowed.push({ start: cursor, end: TWO_PI });
+    }
+  }
+  return {
+    blocked,
+    allowed,
+    meta: { perBall: perBallMeta }
+  };
+}
+
+function angularDiff(a, b) {
+  let diff = b - a;
+  diff = ((diff + Math.PI) % TWO_PI) - Math.PI;
+  return diff;
+}
+
+export function chooseNearestAllowed(phi, allowed) {
+  const phiNorm = normalizeAngle(phi);
+  if (!allowed || allowed.length === 0) {
+    return { theta: phiNorm, distance: Infinity, hitInterval: null };
+  }
+  let bestDistance = Infinity;
+  let bestTheta = phiNorm;
+  let bestInterval = null;
+  for (let i = 0; i < allowed.length; i += 1) {
+    const interval = allowed[i];
+    if (interval.start - EPS <= phiNorm && phiNorm <= interval.end + EPS) {
+      return { theta: phiNorm, distance: 0, hitInterval: interval };
+    }
+    const diffStart = Math.abs(angularDiff(phiNorm, interval.start));
+    if (diffStart < bestDistance - EPS) {
+      bestDistance = diffStart;
+      bestTheta = interval.start;
+      bestInterval = interval;
+    }
+    const diffEnd = Math.abs(angularDiff(phiNorm, interval.end));
+    if (diffEnd < bestDistance - EPS) {
+      bestDistance = diffEnd;
+      bestTheta = interval.end;
+      bestInterval = interval;
+    }
+  }
+  return { theta: normalizeAngle(bestTheta), distance: bestDistance, hitInterval: bestInterval };
+}

--- a/aim/capsuleVerify.js
+++ b/aim/capsuleVerify.js
@@ -1,0 +1,27 @@
+import * as THREE from 'three';
+
+const tmpDiff = new THREE.Vector3();
+const tmpU = new THREE.Vector3();
+const closest = new THREE.Vector3();
+
+export function verifyCapsuleClear(theta, params) {
+  const { C, balls = [], rBall, rShaft, epsilon, L } = params;
+  const R = rBall + rShaft + epsilon;
+  tmpU.set(Math.cos(theta), 0, Math.sin(theta));
+  const offenders = [];
+  let minMargin = Infinity;
+
+  for (let i = 0; i < balls.length; i += 1) {
+    const pos = balls[i].pos;
+    tmpDiff.subVectors(pos, C);
+    const proj = tmpDiff.dot(tmpU);
+    const clamped = Math.min(0, Math.max(-L, proj));
+    closest.copy(tmpU).multiplyScalar(clamped).add(C);
+    const dist = pos.distanceTo(closest);
+    const margin = dist - R;
+    if (margin < minMargin) minMargin = margin;
+    if (margin < 0) offenders.push(i);
+  }
+
+  return { ok: offenders.length === 0, minMargin, offenders };
+}

--- a/demo/AimOverlay.jsx
+++ b/demo/AimOverlay.jsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+
+const TWO_PI = Math.PI * 2;
+const ARC_SEGMENTS = 48;
+const RADIUS_MIN = 0.25;
+
+function buildArcGeometry(start, end, radius) {
+  const clampedEnd = Math.max(start, end);
+  const points = [];
+  const span = clampedEnd - start;
+  const segments = Math.max(2, Math.ceil((ARC_SEGMENTS * span) / TWO_PI));
+  for (let i = 0; i <= segments; i += 1) {
+    const t = i / segments;
+    const angle = start + span * t;
+    points.push(new THREE.Vector3(Math.cos(angle) * radius, 0, Math.sin(angle) * radius));
+  }
+  const geometry = new THREE.BufferGeometry().setFromPoints(points);
+  return geometry;
+}
+
+function updateArcs(group, intervals, material, radius) {
+  const existing = group.children.slice();
+  existing.forEach((child) => {
+    if (child.geometry) child.geometry.dispose();
+    group.remove(child);
+  });
+  intervals.forEach((interval) => {
+    const { start, end } = interval;
+    if (end <= start) return;
+    const geometry = buildArcGeometry(start, end, radius);
+    const line = new THREE.Line(geometry, material);
+    group.add(line);
+  });
+}
+
+export function AimOverlay({ C, angleMask, phi, thetaChosen, L, table }) {
+  const containerRef = useRef(null);
+  const rendererRef = useRef(null);
+  const sceneRef = useRef(null);
+  const cameraRef = useRef(null);
+  const rootRef = useRef(null);
+  const blockedRef = useRef(null);
+  const allowedRef = useRef(null);
+  const shaftRef = useRef(null);
+  const materialsRef = useRef({});
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(window.devicePixelRatio || 1);
+    const { clientWidth, clientHeight } = container;
+    renderer.setSize(clientWidth, clientHeight, false);
+    container.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 50);
+    camera.position.set(0, 5, 0);
+    camera.up.set(0, 0, -1);
+    camera.lookAt(new THREE.Vector3(0, 0, 0));
+
+    const root = new THREE.Group();
+    scene.add(root);
+
+    const blockedGroup = new THREE.Group();
+    const allowedGroup = new THREE.Group();
+    const allowedMaterial = new THREE.LineBasicMaterial({ color: 0x3ed64c, linewidth: 2 });
+    const blockedMaterial = new THREE.LineBasicMaterial({ color: 0xd94141, linewidth: 2 });
+    materialsRef.current.allowed = allowedMaterial;
+    materialsRef.current.blocked = blockedMaterial;
+    root.add(blockedGroup);
+    root.add(allowedGroup);
+
+    const chosenMaterial = new THREE.LineBasicMaterial({ color: 0xffffff, linewidth: 3 });
+    const chosenGeo = new THREE.BufferGeometry().setFromPoints([
+      new THREE.Vector3(),
+      new THREE.Vector3(0, 0, -1)
+    ]);
+    const chosenLine = new THREE.Line(chosenGeo, chosenMaterial);
+    const phiMaterial = new THREE.LineBasicMaterial({ color: 0x4aa3ff, linewidth: 2 });
+    const phiGeo = new THREE.BufferGeometry().setFromPoints([
+      new THREE.Vector3(),
+      new THREE.Vector3(0, 0, -1)
+    ]);
+    const phiLine = new THREE.Line(phiGeo, phiMaterial);
+    root.add(phiLine);
+    root.add(chosenLine);
+
+    sceneRef.current = scene;
+    cameraRef.current = camera;
+    rendererRef.current = renderer;
+    rootRef.current = root;
+    blockedRef.current = blockedGroup;
+    allowedRef.current = allowedGroup;
+    shaftRef.current = {
+      chosen: { line: chosenLine, geometry: chosenGeo },
+      phi: { line: phiLine, geometry: phiGeo }
+    };
+
+    const handleResize = () => {
+      const { clientWidth: w, clientHeight: h } = container;
+      renderer.setSize(w, h, false);
+      const viewSize = 1;
+      const aspect = w / Math.max(h, 1);
+      camera.left = -viewSize * aspect;
+      camera.right = viewSize * aspect;
+      camera.top = viewSize;
+      camera.bottom = -viewSize;
+      camera.updateProjectionMatrix();
+      renderer.render(scene, camera);
+    };
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      Object.values(materialsRef.current).forEach((material) => material?.dispose?.());
+      if (shaftRef.current) {
+        Object.values(shaftRef.current).forEach((entry) => {
+          entry.line.material.dispose();
+          entry.geometry.dispose();
+        });
+      }
+      renderer.dispose();
+      container.removeChild(renderer.domElement);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!rootRef.current || !sceneRef.current || !cameraRef.current || !rendererRef.current)
+      return;
+    const root = rootRef.current;
+    root.position.set(C.x, C.y, C.z);
+
+    const intervalsAllowed = angleMask?.allowed || [];
+    const intervalsBlocked = angleMask?.blocked || [];
+    const radius = Math.max(L, RADIUS_MIN);
+    updateArcs(
+      allowedRef.current,
+      intervalsAllowed,
+      materialsRef.current.allowed,
+      radius
+    );
+    updateArcs(
+      blockedRef.current,
+      intervalsBlocked,
+      materialsRef.current.blocked,
+      radius
+    );
+
+    const shaft = shaftRef.current;
+    if (shaft?.chosen) {
+      const chosenPoints = shaft.chosen.geometry.attributes.position;
+      chosenPoints.setXYZ(0, 0, 0, 0);
+      const chosenEndX = Math.cos(thetaChosen) * -L;
+      const chosenEndZ = Math.sin(thetaChosen) * -L;
+      chosenPoints.setXYZ(1, chosenEndX, 0, chosenEndZ);
+      chosenPoints.needsUpdate = true;
+      shaft.chosen.geometry.computeBoundingSphere();
+    }
+
+    const renderer = rendererRef.current;
+    const camera = cameraRef.current;
+
+    if (table) {
+      const extent = Math.max(table.maxX - table.minX, table.maxZ - table.minZ, radius * 2);
+      const viewSize = extent > 0 ? extent * 0.6 : 1;
+      const canvas = renderer.domElement;
+      const aspect = canvas.clientWidth / Math.max(canvas.clientHeight, 1);
+      camera.left = -viewSize * aspect;
+      camera.right = viewSize * aspect;
+      camera.top = viewSize;
+      camera.bottom = -viewSize;
+      camera.updateProjectionMatrix();
+    }
+
+    renderer.render(sceneRef.current, camera);
+  }, [C, angleMask, thetaChosen, L, table]);
+
+  useEffect(() => {
+    if (!shaftRef.current || !rendererRef.current || !cameraRef.current || !sceneRef.current)
+      return;
+    const shaft = shaftRef.current;
+    if (!shaft?.phi) return;
+    const points = shaft.phi.geometry.attributes.position;
+    points.setXYZ(0, 0, 0, 0);
+    const endX = Math.cos(phi) * -L;
+    const endZ = Math.sin(phi) * -L;
+    points.setXYZ(1, endX, 0, endZ);
+    points.needsUpdate = true;
+    rendererRef.current.render(sceneRef.current, cameraRef.current);
+  }, [phi, L]);
+
+  return <div ref={containerRef} style={{ width: '100%', height: '100%' }} />;
+}

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,4 +2,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
+  testMatch: ['**/*.spec.js', '**/*.test.ts']
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node bot/server.js",
     "install-all": "npm install && npm install --prefix bot && npm install --prefix webapp",
     "build": "tsc -p tsconfig.snooker.json",
-    "test": "jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "demo": "node dist/demo.js demo/demo.json",
     "lint": "eslint .",
     "format": "prettier --write .",
@@ -35,7 +35,8 @@
     "ton": "^13.9.0",
     "ton-core": "^0.53.0",
     "ton-crypto": "^3.2.0",
-    "ton-x": "^2.1.0-preview"
+    "ton-x": "^2.1.0-preview",
+    "three": "^0.164.0"
   },
   "devDependencies": {
     "concurrently": "^8.2.2",

--- a/tests/aim.spec.js
+++ b/tests/aim.spec.js
@@ -1,0 +1,103 @@
+import assert from 'node:assert';
+import * as THREE from 'three';
+import { computeAngleMask, chooseNearestAllowed } from '../aim/angleMask.js';
+import { verifyCapsuleClear } from '../aim/capsuleVerify.js';
+
+const { Vector3 } = THREE;
+const TWO_PI = Math.PI * 2;
+
+function makeParams(overrides = {}) {
+  return {
+    C: new Vector3(0, 0, 0),
+    balls: [],
+    rBall: 0.028,
+    rShaft: 0.01,
+    epsilon: 0.003,
+    L: 0.6,
+    table: { minX: -1, maxX: 1, minZ: -1, maxZ: 1 },
+    ...overrides
+  };
+}
+
+describe('aim angle mask', () => {
+  test('no obstacles yields full freedom', () => {
+    const mask = computeAngleMask(makeParams());
+    assert.strictEqual(mask.blocked.length, 0);
+    assert.strictEqual(mask.allowed.length, 1);
+    assert.ok(Math.abs(mask.allowed[0].start) < 1e-9);
+    assert.ok(Math.abs(mask.allowed[0].end - TWO_PI) < 1e-9);
+  });
+
+  test('single ball behind cue merges around zero', () => {
+    const params = makeParams({
+      balls: [{ pos: new Vector3(-0.2, 0, 0) }],
+      L: 0.5
+    });
+    const mask = computeAngleMask(params);
+    const totalBlocked = mask.blocked.reduce((sum, interval) => sum + (interval.end - interval.start), 0);
+    const separation = 0.2;
+    const R = params.rBall + params.rShaft + params.epsilon;
+    const expectedDelta = Math.asin(Math.min(1, R / separation));
+    assert.ok(Math.abs(totalBlocked - expectedDelta * 2) < 1e-3);
+  });
+
+  test('short L trims blocked window', () => {
+    const params = makeParams({
+      balls: [{ pos: new Vector3(-0.2, 0, 0) }],
+      L: 0.16
+    });
+    const mask = computeAngleMask(params);
+    const centreAllowed = chooseNearestAllowed(0.35, mask.allowed);
+    assert.strictEqual(centreAllowed.distance, 0);
+    const zeroChoice = chooseNearestAllowed(0, mask.allowed);
+    assert.ok(zeroChoice.distance > 0.05);
+    assert.ok(zeroChoice.hitInterval);
+  });
+
+  test('chooseNearestAllowed picks closest edge', () => {
+    const allowed = [
+      { start: 1, end: 1.5 },
+      { start: 4, end: 5 }
+    ];
+    const result = chooseNearestAllowed(2, allowed);
+    assert.ok(Math.abs(result.theta - 1.5) < 1e-9);
+    assert.ok(Math.abs(result.distance - 0.5) < 1e-9);
+  });
+
+  test('capsule verification confirms clear aim', () => {
+    const params = makeParams({
+      balls: [{ pos: new Vector3(-0.2, 0, 0) }],
+      L: 0.6
+    });
+    const mask = computeAngleMask(params);
+    const allowedCentre = chooseNearestAllowed(Math.PI / 2, mask.allowed);
+    const verification = verifyCapsuleClear(allowedCentre.theta, params);
+    assert.ok(verification.ok);
+    assert.ok(verification.minMargin > -1e-6);
+  });
+
+  test('capsule verification rejects blocked angle', () => {
+    const params = makeParams({
+      balls: [{ pos: new Vector3(-0.2, 0, 0) }],
+      L: 0.6
+    });
+    const mask = computeAngleMask(params);
+    const blockedInterval = mask.blocked[0];
+    const midTheta = (blockedInterval.start + blockedInterval.end) / 2;
+    const verification = verifyCapsuleClear(midTheta, params);
+    assert.ok(!verification.ok);
+    assert.ok(verification.offenders.length >= 1);
+  });
+
+  test('no allowed angles when cue length vanishes near obstacle', () => {
+    const params = makeParams({
+      balls: [{ pos: new Vector3(-0.01, 0, 0) }],
+      L: 0
+    });
+    const mask = computeAngleMask(params);
+    assert.strictEqual(mask.allowed.length, 0);
+    const pick = chooseNearestAllowed(0, mask.allowed);
+    assert.strictEqual(pick.hitInterval, null);
+    assert.ok(!Number.isFinite(pick.distance));
+  });
+});


### PR DESCRIPTION
## Summary
- add cue angle masking helpers that compute blocked/allowed spans and choose nearest legal aim
- implement capsule-based collision verification and a React debug overlay for visualising masks
- update test configuration and add automated coverage for the new geometry helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc384d9408329886af5f7fbf176c9