### PR TITLE
Adjust chrome plates for snooker table

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2737,18 +2737,31 @@ function Table3D(parent) {
     envMapIntensity: 1.25
   });
 
-  const chromePlateRadius = outerCornerRadius * 0.98;
-  const chromePlateExtra = Math.min(longRailW, endRailW) * 0.52;
-  const chromePlateWidth = chromePlateRadius * 2 + chromePlateExtra;
-  const chromePlateHeight = chromePlateRadius * 2 + chromePlateExtra * 0.9;
   const chromePlateThickness = railH * 0.2;
   const chromePlateInset = TABLE.THICK * 0.02;
+  const chromePlateWidth = Math.max(
+    MICRO_EPS,
+    outerHalfW - halfW - chromePlateInset
+  );
+  const chromePlateHeight = Math.max(
+    MICRO_EPS,
+    outerHalfH - halfH - chromePlateInset
+  );
+  const chromePlateRadius = Math.min(
+    outerCornerRadius * 0.98,
+    chromePlateWidth / 2,
+    chromePlateHeight / 2
+  );
   const chromePlateY =
     railsTopY - chromePlateThickness + MICRO_EPS * 2;
 
-  const sideChromePlateWidth = chromePlateWidth * 1.28;
-  const sideChromePlateHeight = chromePlateHeight * 0.76;
-  const sideChromePlateRadius = chromePlateRadius * 0.72;
+  const sideChromePlateWidth = chromePlateWidth;
+  const sideChromePlateHeight = chromePlateHeight * 1.18;
+  const sideChromePlateRadius = Math.min(
+    chromePlateRadius * 0.72,
+    sideChromePlateWidth / 2,
+    sideChromePlateHeight / 2
+  );
 
   const innerHalfW = halfWext;
   const innerHalfH = halfHext;
@@ -2800,13 +2813,18 @@ function Table3D(parent) {
     return polygonClipping.union(notchCircle, boxX, boxZ);
   };
 
-  const sideNotchMP = (sz) => {
-    const cz = sz * (innerHalfH - sideInset);
-    const circle = circlePoly(0, cz, sidePocketRadius);
-    const zInner = cz - sz * sidePocketRadius * 0.2;
-    const zOuter = cz + sz * sidePocketRadius * 1.6;
-    const xWidth = sidePocketRadius * 1.6;
-    const notchRect = boxPoly(-xWidth, Math.min(zInner, zOuter), xWidth, Math.max(zInner, zOuter));
+  const sideNotchMP = (sx) => {
+    const cx = sx * (innerHalfW - sideInset);
+    const circle = circlePoly(cx, 0, sidePocketRadius);
+    const xInner = cx - sx * sidePocketRadius * 0.2;
+    const xOuter = cx + sx * sidePocketRadius * 1.6;
+    const zWidth = sidePocketRadius * 1.6;
+    const notchRect = boxPoly(
+      Math.min(xInner, xOuter),
+      -zWidth,
+      Math.max(xInner, xOuter),
+      zWidth
+    );
     return polygonClipping.union(circle, notchRect);
   };
 
@@ -2844,12 +2862,12 @@ function Table3D(parent) {
   });
 
   [
-    { id: 'sideTop', sz: -1 },
-    { id: 'sideBottom', sz: 1 }
-  ].forEach(({ id, sz }) => {
-    const centerX = 0;
-    const centerZ = sz * (outerHalfH - sideChromePlateHeight / 2 - chromePlateInset);
-    const notchLocalMP = sideNotchMP(sz).map((poly) =>
+    { id: 'sideLeft', sx: -1 },
+    { id: 'sideRight', sx: 1 }
+  ].forEach(({ id, sx }) => {
+    const centerX = sx * (outerHalfW - sideChromePlateWidth / 2 - chromePlateInset);
+    const centerZ = 0;
+    const notchLocalMP = sideNotchMP(sx).map((poly) =>
       poly.map((ring) => ring.map(([x, z]) => [x - centerX, -(z - centerZ)]))
     );
     const plate = new THREE.Mesh(


### PR DESCRIPTION
## Summary
- extend corner chrome plates to span the full distance up to the cushions
- reposition the short-rail chrome plates onto the side rails at the side pockets and reuse the side pocket cutout
- update the shared chrome plate geometry so side plates inherit the correct dimensions and radii

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd0ef2acc083298533b805e2333594