### PR TITLE
Expand snooker chrome plates

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2773,7 +2773,7 @@ function Table3D(parent) {
 
   const chromePlateThickness = railH * 0.2;
   const chromePlateInset = TABLE.THICK * 0.02;
-  const chromePlateExpansion = TABLE.THICK * 0.12;
+  const chromePlateExpansion = TABLE.THICK * 0.2;
   const cushionInnerX = halfW - CUSHION_RAIL_FLUSH - CUSHION_CENTER_NUDGE;
   const cushionInnerZ = halfH - CUSHION_RAIL_FLUSH - CUSHION_CENTER_NUDGE;
   const chromePlateInnerLimitX = Math.max(0, cushionInnerX);


### PR DESCRIPTION
## Summary
- increase the chrome plate expansion factor on the snooker table rails to widen the metal caps without shifting their placement

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd36e2127483299c69830c8905b1c6