### PR TITLE
Reduce broadcast camera clearance in snooker scene

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3888,7 +3888,7 @@ function SnookerGame() {
 
       const broadcastClearance = wallThickness * 1.1 + BALL_R * 4;
       const shortRailTarget = Math.max(
-        PLAY_H / 2 + BALL_R * 12,
+        PLAY_H / 2 + BALL_R * 8, // keep a modest clearance so the broadcast cameras sit closer to the table
         roomDepth / 2 - wallThickness - broadcastClearance
       );
       const broadcastRig = createBroadcastCameras({


### PR DESCRIPTION
## Summary
- reduce the short-rail clearance so the broadcast camera rigs sit closer to the snooker table

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de58fa090c8329a703044cf306993f