### PR TITLE
Adjust snooker camera angles

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1622,7 +1622,7 @@ function applySnookerScaling({
 }
 
 // Kamera: ruaj kënd komod që mos shtrihet poshtë cloth-it, por lejo pak më shumë lartësi kur ngrihet
-const STANDING_VIEW_PHI = 0.9;
+const STANDING_VIEW_PHI = 0.93;
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.005;
 const STANDING_VIEW_FOV = 66;
@@ -1667,11 +1667,11 @@ const CUE_APPROACH_MIN_RADIUS = Math.max(CUE_CAMERA_MIN_RADIUS, CAMERA.minR * 0.
 const CUE_VIEW_RADIUS_RATIO = 0.3;
 const CUE_VIEW_MIN_RADIUS = Math.max(CUE_APPROACH_MIN_RADIUS, CAMERA.minR * 0.85);
 const CUE_VIEW_MIN_PHI = THREE.MathUtils.clamp(
-  STANDING_VIEW_PHI - 0.14,
+  STANDING_VIEW_PHI - 0.1,
   CAMERA.minPhi + 0.04,
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY
 );
-const CUE_VIEW_PHI_LIFT = 0.24;
+const CUE_VIEW_PHI_LIFT = 0.25;
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.55;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,


### PR DESCRIPTION
## Summary
- raise the standing view tilt so the broadcast framing sits slightly higher above the cloth
- lift the cue camera baseline and target tilt to keep the full aiming line within the frame

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de6870677c8329a4d012233eb1f492