### PR TITLE
Adjust snooker hospitality props along side rails

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -4120,7 +4120,7 @@ function SnookerGame() {
         const dir = mirrorX ? -1 : 1;
 
         const tableSet = new THREE.Group();
-        tableSet.position.set(-0.9 * dir, 0, 0.8);
+        tableSet.position.set(-0.75 * dir, 0, 0.65);
         group.add(tableSet);
 
         const tableTop = new THREE.Mesh(
@@ -4198,7 +4198,7 @@ function SnookerGame() {
         tableSet.add(glassWater);
 
         const chair = new THREE.Group();
-        chair.position.set(-1.55 * dir, 0, 1.05);
+        chair.position.set(-1.45 * dir, 0, 0.95);
         chair.rotation.y = -Math.PI * 0.1 * dir;
         group.add(chair);
 
@@ -4246,36 +4246,34 @@ function SnookerGame() {
         return group;
       };
 
-      const hospitalityCameraGap = BALL_R * 10;
-      const hospitalityOffsetZ = Math.max(
-        PLAY_H / 2 + BALL_R * 6,
-        shortRailTarget - hospitalityCameraGap
-      );
-      const hospitalityOffsetX = shortRailSlideLimit + BALL_R * 6;
       const hospitalityLookY = TABLE_Y + TABLE.THICK * 0.5;
+      const hospitalityWallGap = BALL_R * 4;
+      const hospitalityOffsetX =
+        SIDE_RAIL_CAMERA_DISTANCE - hospitalityWallGap;
+      const hospitalityOffsetZ = BALL_R * 6.5;
+      const hospitalityLookTarget = new THREE.Vector3(
+        0,
+        hospitalityLookY,
+        0
+      );
 
-      const hospitalityTargets = {
-        near: new THREE.Vector3(
-          -shortRailSlideLimit * 0.28,
-          hospitalityLookY,
-          PLAY_H / 2 + BALL_R * 2
-        ),
-        far: new THREE.Vector3(
-          shortRailSlideLimit * 0.28,
-          hospitalityLookY,
-          -PLAY_H / 2 - BALL_R * 2
-        )
-      };
+      const leftHospitality = createHospitalitySet({ mirrorX: false });
+      leftHospitality.position.set(
+        -hospitalityOffsetX,
+        floorY,
+        hospitalityOffsetZ
+      );
+      leftHospitality.lookAt(hospitalityLookTarget);
+      world.add(leftHospitality);
 
-      const nearHospitality = createHospitalitySet({ mirrorX: false });
-      nearHospitality.position.set(-hospitalityOffsetX, floorY, hospitalityOffsetZ);
-      nearHospitality.lookAt(hospitalityTargets.near);
-      world.add(nearHospitality);
-
-      const farHospitality = createHospitalitySet({ mirrorX: true });
-      farHospitality.position.set(hospitalityOffsetX, floorY, -hospitalityOffsetZ);
-      farHospitality.lookAt(hospitalityTargets.far);
-      world.add(farHospitality);
+      const rightHospitality = createHospitalitySet({ mirrorX: true });
+      rightHospitality.position.set(
+        hospitalityOffsetX,
+        floorY,
+        -hospitalityOffsetZ
+      );
+      rightHospitality.lookAt(hospitalityLookTarget);
+      world.add(rightHospitality);
 
       const aspect = host.clientWidth / host.clientHeight;
       const camera = new THREE.PerspectiveCamera(


### PR DESCRIPTION
## Summary
- reposition the hospitality table, bottle, glass, and chair groups so that mirrored sets sit along the side rails between the table and walls
- tune local offsets so the furniture aligns naturally with the rail-side walkway while remaining visible from the table cameras

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de907545648329a81f75b129d7da50