### PR TITLE
Add paired hospitality tables to Snooker scene

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -4119,128 +4119,158 @@ function SnookerGame() {
         const mirror = Math.sign(side) || 1;
         const group = new THREE.Group();
 
-        const tableSet = new THREE.Group();
-        group.add(tableSet);
+        const createTableSet = () => {
+          const set = new THREE.Group();
 
-        const tableTop = new THREE.Mesh(
-          new THREE.CylinderGeometry(0.35, 0.35, 0.03, 24),
-          hospitalityMats.wood
-        );
-        tableTop.position.y = 0.75;
-        tableTop.castShadow = true;
-        tableSet.add(tableTop);
+          const tableTop = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.35, 0.35, 0.03, 24),
+            hospitalityMats.wood
+          );
+          tableTop.position.y = 0.75;
+          tableTop.castShadow = true;
+          set.add(tableTop);
 
-        const tableStem = new THREE.Mesh(
-          new THREE.CylinderGeometry(0.04, 0.06, 0.7, 16),
-          hospitalityMats.chrome
-        );
-        tableStem.position.y = 0.75 - 0.35;
-        tableStem.castShadow = true;
-        tableSet.add(tableStem);
+          const tableStem = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.04, 0.06, 0.7, 16),
+            hospitalityMats.chrome
+          );
+          tableStem.position.y = 0.75 - 0.35;
+          tableStem.castShadow = true;
+          set.add(tableStem);
 
-        const tableBaseRadius = 0.28;
-        const tableBase = new THREE.Mesh(
-          new THREE.CylinderGeometry(tableBaseRadius, tableBaseRadius, 0.04, 24),
-          hospitalityMats.chrome
-        );
-        tableBase.position.y = 0.02;
-        tableBase.receiveShadow = true;
-        tableSet.add(tableBase);
+          const tableBaseRadius = 0.28;
+          const tableBase = new THREE.Mesh(
+            new THREE.CylinderGeometry(tableBaseRadius, tableBaseRadius, 0.04, 24),
+            hospitalityMats.chrome
+          );
+          tableBase.position.y = 0.02;
+          tableBase.receiveShadow = true;
+          set.add(tableBase);
 
-        const bottle = new THREE.Group();
-        bottle.position.set(0.05, 0.875, -0.08);
-        tableSet.add(bottle);
-        bottle.add(
-          new THREE.Mesh(
-            new THREE.CylinderGeometry(0.045, 0.05, 0.22, 16),
+          const bottle = new THREE.Group();
+          bottle.position.set(0.05, 0.875, -0.08);
+          set.add(bottle);
+          bottle.add(
+            new THREE.Mesh(
+              new THREE.CylinderGeometry(0.045, 0.05, 0.22, 16),
+              hospitalityMats.glass
+            )
+          );
+          const bottleNeck = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.018, 0.022, 0.05, 12),
             hospitalityMats.glass
-          )
-        );
-        const bottleNeck = new THREE.Mesh(
-          new THREE.CylinderGeometry(0.018, 0.022, 0.05, 12),
-          hospitalityMats.glass
-        );
-        bottleNeck.position.y = 0.135;
-        bottle.add(bottleNeck);
-        const bottleCap = new THREE.Mesh(
-          new THREE.CylinderGeometry(0.022, 0.022, 0.02, 12),
-          hospitalityMats.chrome
-        );
-        bottleCap.position.y = 0.16;
-        bottle.add(bottleCap);
-        const water = new THREE.Mesh(
-          new THREE.CylinderGeometry(0.043, 0.043, 0.12, 16),
-          hospitalityMats.water
-        );
-        water.position.y = -0.05;
-        bottle.add(water);
+          );
+          bottleNeck.position.y = 0.135;
+          bottle.add(bottleNeck);
+          const bottleCap = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.022, 0.022, 0.02, 12),
+            hospitalityMats.chrome
+          );
+          bottleCap.position.y = 0.16;
+          bottle.add(bottleCap);
+          const water = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.043, 0.043, 0.12, 16),
+            hospitalityMats.water
+          );
+          water.position.y = -0.05;
+          bottle.add(water);
 
-        const glassOuter = new THREE.Mesh(
-          new THREE.CylinderGeometry(0.036, 0.032, 0.1, 16, 1, true),
-          hospitalityMats.glass
-        );
-        glassOuter.position.set(-0.12, 0.8, 0.05);
-        glassOuter.material.side = THREE.DoubleSide;
-        tableSet.add(glassOuter);
-        const glassBottom = new THREE.Mesh(
-          new THREE.CircleGeometry(0.032, 16),
-          hospitalityMats.glass
-        );
-        glassBottom.rotation.x = -Math.PI / 2;
-        glassBottom.position.set(-0.12, 0.75, 0.05);
-        tableSet.add(glassBottom);
-        const glassWater = new THREE.Mesh(
-          new THREE.CylinderGeometry(0.029, 0.029, 0.05, 16),
-          hospitalityMats.water
-        );
-        glassWater.position.set(-0.12, 0.775, 0.05);
-        tableSet.add(glassWater);
+          const glassOuterMat = hospitalityMats.glass.clone();
+          glassOuterMat.side = THREE.DoubleSide;
+          const glassOuter = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.036, 0.032, 0.1, 16, 1, true),
+            glassOuterMat
+          );
+          glassOuter.position.set(-0.12, 0.8, 0.05);
+          glassOuter.castShadow = true;
+          set.add(glassOuter);
+          const glassBottom = new THREE.Mesh(
+            new THREE.CircleGeometry(0.032, 16),
+            glassOuterMat
+          );
+          glassBottom.rotation.x = -Math.PI / 2;
+          glassBottom.position.set(-0.12, 0.75, 0.05);
+          glassBottom.receiveShadow = true;
+          set.add(glassBottom);
+          const glassWater = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.029, 0.029, 0.05, 16),
+            hospitalityMats.water
+          );
+          glassWater.position.set(-0.12, 0.775, 0.05);
+          set.add(glassWater);
 
-        const chair = new THREE.Group();
-        chair.position.set(mirror * 0.65, 0, 0.25);
-        chair.rotation.y = -Math.PI * 0.1 * mirror;
-        group.add(chair);
+          return set;
+        };
 
-        const chairLegGeom = new THREE.CylinderGeometry(0.022, 0.022, 0.42, 10);
-        [
-          [-0.22, -0.22],
-          [0.22, -0.22],
-          [-0.2, 0.22],
-          [0.2, 0.22]
-        ].forEach(([x, z]) => {
-          const leg = new THREE.Mesh(chairLegGeom, hospitalityMats.chrome);
-          leg.position.set(x, 0.21, z);
-          leg.castShadow = true;
-          chair.add(leg);
+        const createChair = () => {
+          const chair = new THREE.Group();
+          const chairLegGeom = new THREE.CylinderGeometry(0.022, 0.022, 0.42, 10);
+          [
+            [-0.22, -0.22],
+            [0.22, -0.22],
+            [-0.2, 0.22],
+            [0.2, 0.22]
+          ].forEach(([x, z]) => {
+            const leg = new THREE.Mesh(chairLegGeom, hospitalityMats.chrome);
+            leg.position.set(x, 0.21, z);
+            leg.castShadow = true;
+            chair.add(leg);
+          });
+
+          const seat = new THREE.Mesh(
+            new THREE.BoxGeometry(0.5, 0.06, 0.46),
+            hospitalityMats.fabric
+          );
+          seat.position.set(0, 0.46, 0);
+          seat.castShadow = true;
+          chair.add(seat);
+
+          const back = new THREE.Mesh(
+            new THREE.BoxGeometry(0.5, 0.5, 0.06),
+            hospitalityMats.fabric
+          );
+          back.position.set(0, 0.71, -0.23);
+          back.rotation.x = Math.PI * 0.05;
+          back.castShadow = true;
+          chair.add(back);
+
+          const armGeom = new THREE.BoxGeometry(0.06, 0.06, 0.46);
+          const armOffset = 0.28;
+          const armL = new THREE.Mesh(armGeom, hospitalityMats.fabric);
+          armL.position.set(-armOffset, 0.56, 0);
+          armL.castShadow = true;
+          chair.add(armL);
+          const armR = new THREE.Mesh(armGeom, hospitalityMats.fabric);
+          armR.position.set(armOffset, 0.56, 0);
+          armR.castShadow = true;
+          chair.add(armR);
+
+          return chair;
+        };
+
+        const arrangements = [
+          {
+            table: { x: -0.9, y: 0, z: 0.82 },
+            chair: { x: -1.55, y: 0, z: 1.05 },
+            chairYaw: -Math.PI * 0.1
+          },
+          {
+            table: { x: -0.9, y: 0, z: -0.82 },
+            chair: { x: -1.55, y: 0, z: -1.05 },
+            chairYaw: Math.PI * 0.1
+          }
+        ];
+
+        arrangements.forEach(({ table, chair: chairPos, chairYaw }) => {
+          const tableSet = createTableSet();
+          tableSet.position.set(mirror * table.x, table.y, table.z);
+          group.add(tableSet);
+
+          const chair = createChair();
+          chair.position.set(mirror * chairPos.x, chairPos.y, chairPos.z);
+          chair.rotation.y = chairYaw * mirror;
+          group.add(chair);
         });
-
-        const seat = new THREE.Mesh(
-          new THREE.BoxGeometry(0.5, 0.06, 0.46),
-          hospitalityMats.fabric
-        );
-        seat.position.set(0, 0.46, 0);
-        seat.castShadow = true;
-        chair.add(seat);
-
-        const back = new THREE.Mesh(
-          new THREE.BoxGeometry(0.5, 0.5, 0.06),
-          hospitalityMats.fabric
-        );
-        back.position.set(0, 0.71, -0.23);
-        back.rotation.x = Math.PI * 0.05;
-        back.castShadow = true;
-        chair.add(back);
-
-        const armGeom = new THREE.BoxGeometry(0.06, 0.06, 0.46);
-        const armOffset = 0.28;
-        const armL = new THREE.Mesh(armGeom, hospitalityMats.fabric);
-        armL.position.set(-armOffset, 0.56, 0);
-        armL.castShadow = true;
-        chair.add(armL);
-        const armR = new THREE.Mesh(armGeom, hospitalityMats.fabric);
-        armR.position.set(armOffset, 0.56, 0);
-        armR.castShadow = true;
-        chair.add(armR);
 
         return group;
       };


### PR DESCRIPTION
## Summary
- refactor the hospitality prop builder to reuse table/chair helpers
- place two full table-and-chair arrangements on each camera side in the snooker room

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea2b4b8108329b7bea85bfdfc836a