### PR TITLE
Fix snooker camera orientation and reposition hospitality seating

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1353,6 +1353,7 @@ function createBroadcastCameras({ floorY, cameraHeight, shortRailZ, slideLimit }
     headPivot.add(grip);
 
     headPivot.lookAt(defaultFocus);
+    headPivot.rotateY(Math.PI);
 
     return { base, slider, head: headPivot, assembly: cameraAssembly, direction };
   };
@@ -4118,6 +4119,7 @@ function SnookerGame() {
         tripodGroup.updateWorldMatrix(true, false);
         headPivot.up.set(0, 1, 0);
         headPivot.lookAt(tripodTarget);
+        headPivot.rotateY(Math.PI);
         headPivot.rotateX(tripodTilt);
       });
 
@@ -4303,8 +4305,10 @@ function SnookerGame() {
       const hospitalityZOffset = Math.max(hospitalityZMin, shortRailTarget - BALL_R * 5);
 
       [
-        { mirror: -1, x: 0, z: hospitalityZOffset },
-        { mirror: 1, x: 0, z: -hospitalityZOffset }
+        { mirror: -1, x: hospitalityXOffset, z: hospitalityZOffset },
+        { mirror: 1, x: -hospitalityXOffset, z: hospitalityZOffset },
+        { mirror: -1, x: hospitalityXOffset, z: -hospitalityZOffset },
+        { mirror: 1, x: -hospitalityXOffset, z: -hospitalityZOffset }
       ].forEach(({ mirror, x, z }) => {
         const hospitalitySet = createCameraSideHospitalitySet(mirror);
         hospitalitySet.position.set(x, floorY, z);


### PR DESCRIPTION
## Summary
- flip the broadcast and tripod camera pivots so the lenses face the table
- duplicate the hospitality table and chair sets so each short rail has seating on both sides and position them on the carpet edge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec0963e6483298033cb5090dd6ef4