### PR TITLE
Adjust snooker standing camera radius for portrait view

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -5514,12 +5514,19 @@ function SnookerGame() {
         };
         const fit = (m = STANDING_VIEW.margin) => {
           camera.aspect = host.clientWidth / host.clientHeight;
+          const aspect = camera.aspect;
           const standingRadiusRaw = fitRadius(camera, m);
           const cueBase = clampOrbitRadius(BREAK_VIEW.radius);
           const playerRadiusBase = Math.max(standingRadiusRaw, cueBase);
+          const shouldApplyBroadcastPullIn = aspect >= 1;
+          const broadcastBaseRadius = shouldApplyBroadcastPullIn
+            ? Math.max(
+                standingRadiusRaw,
+                playerRadiusBase * BROADCAST_DISTANCE_MULTIPLIER
+              )
+            : playerRadiusBase;
           const broadcastRadius =
-            playerRadiusBase * BROADCAST_DISTANCE_MULTIPLIER +
-            BROADCAST_RADIUS_PADDING;
+            broadcastBaseRadius + BROADCAST_RADIUS_PADDING;
           const standingRadius = clamp(
             broadcastRadius,
             CAMERA.minR,


### PR DESCRIPTION
## Summary
- ensure the standing camera radius never shrinks below the raw fitted distance
- apply the broadcast pull-in only for landscape aspect ratios so portrait preserves side props

## Testing
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_68df4cd5e454832988f2ef9da392d304