### PR TITLE
Adjust standing camera margin for closer framing

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1654,6 +1654,9 @@ const PLAYER_CAMERA_DISTANCE_FACTOR = 0.4;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant
 const BROADCAST_DISTANCE_MULTIPLIER = 0.58;
+// Allow portrait/landscape standing camera framing to pull in closer without clipping the table
+const STANDING_VIEW_MARGIN_LANDSCAPE = 1.24;
+const STANDING_VIEW_MARGIN_PORTRAIT = 1.18;
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.04;
 const CAMERA = {
   fov: STANDING_VIEW_FOV,
@@ -5808,8 +5811,8 @@ function SnookerGame() {
           topViewRef.current
             ? 1.05
             : window.innerHeight > window.innerWidth
-              ? 1.45
-              : 1.32
+              ? STANDING_VIEW_MARGIN_PORTRAIT
+              : STANDING_VIEW_MARGIN_LANDSCAPE
         );
         fit(margin);
         syncBlendToSpherical();


### PR DESCRIPTION
## Summary
- add dedicated portrait and landscape standing camera margins to tighten the framing around the snooker table
- use the new margins when calculating the standing camera fit so the view sits closer to the cloth on mobile and desktop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df5387ee5c8329b1fc172f9ab00ab5