### PR TITLE
Tighten standing camera framing in snooker view

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1654,10 +1654,10 @@ const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.24; // keep orbit camera from dipping be
 const PLAYER_CAMERA_DISTANCE_FACTOR = 0.4;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant
-const BROADCAST_DISTANCE_MULTIPLIER = 0.54;
+const BROADCAST_DISTANCE_MULTIPLIER = 0.48;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
-const STANDING_VIEW_MARGIN_LANDSCAPE = 1.16;
-const STANDING_VIEW_MARGIN_PORTRAIT = 1.1;
+const STANDING_VIEW_MARGIN_LANDSCAPE = 1.08;
+const STANDING_VIEW_MARGIN_PORTRAIT = 1.04;
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.04;
 const CAMERA = {
   fov: STANDING_VIEW_FOV,


### PR DESCRIPTION
## Summary
- reduce the broadcast distance multiplier so the standing view sits closer to the table
- lower the landscape and portrait standing view margins for a tighter framing on all aspect ratios

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df72e50e008329b742ffad52270ede