### PR TITLE
Adjust snooker rail diamond spacing

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3146,7 +3146,7 @@ function Table3D(parent) {
   const railDiamonds = new THREE.Group();
   const railDiamondHeight =
     railsTopY - railDiamondThickness / 2 + TABLE.THICK * 0.012;
-  const railDiamondSideShift = TABLE.THICK * 0.1;
+  const railDiamondSideShift = TABLE.THICK * 0.12;
   const spreadRailDiamond = (value, limit) => {
     if (Math.abs(value) < MICRO_EPS) return value;
     const base = Math.abs(value);


### PR DESCRIPTION
## Summary
- shift the chrome rail diamond markers slightly further from the center to better align with the table sides

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df893fc5188329bf20b9ed1bd582e6