### PR TITLE
Adjust snooker rail diamond placement

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3148,6 +3148,7 @@ function Table3D(parent) {
     railsTopY - railDiamondThickness / 2 + TABLE.THICK * 0.012;
   const railDiamondSideShift = TABLE.THICK * 0.12;
   const railDiamondAdditionalSideShift = TABLE.THICK * 0.02;
+  const railDiamondRailCenterShift = TABLE.THICK * 0.04;
   const spreadRailDiamond = (value, limit) => {
     if (Math.abs(value) < MICRO_EPS) return value;
     const base = Math.abs(value);
@@ -3180,7 +3181,11 @@ function Table3D(parent) {
     const x = spreadRailDiamond((index * PLAY_W) / 8, longRailDiamondMaxX);
     [-1, 1].forEach((sz) => {
       const diamond = createRailDiamond();
-      diamond.position.set(x, railDiamondHeight, sz * longRailDiamondZ);
+      diamond.position.set(
+        x,
+        railDiamondHeight,
+        sz * (longRailDiamondZ + railDiamondRailCenterShift)
+      );
       railDiamonds.add(diamond);
     });
   });
@@ -3190,7 +3195,11 @@ function Table3D(parent) {
     [-1, 1].forEach((sx) => {
       const diamond = createRailDiamond();
       diamond.rotation.y = Math.PI / 2;
-      diamond.position.set(sx * shortRailDiamondX, railDiamondHeight, z);
+      diamond.position.set(
+        sx * (shortRailDiamondX + railDiamondRailCenterShift),
+        railDiamondHeight,
+        z
+      );
       railDiamonds.add(diamond);
     });
   });


### PR DESCRIPTION
## Summary
- shift the snooker table chrome rail diamonds slightly farther from the cushions so they sit closer to the rail centers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df8e602894832986305282c079ffbf