### PR TITLE
Slim down snooker chrome rail covers

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -169,9 +169,9 @@ const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.74;
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.76;
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 0.7;
 const CHROME_CORNER_LINER_INNER_SCALE = 0.78;
-const CHROME_CORNER_LINER_DEPTH_SCALE = 0.84;
+const CHROME_CORNER_LINER_DEPTH_SCALE = 0.62;
 const CHROME_SIDE_LINER_INNER_SCALE = 0.76;
-const CHROME_SIDE_LINER_DEPTH_SCALE = 0.8;
+const CHROME_SIDE_LINER_DEPTH_SCALE = 0.6;
 const CHROME_NOTCH_LINER_TOP_OFFSET_SCALE = 0.06;
 const CHROME_NOTCH_LINER_SEGMENTS = 96;
 
@@ -2909,10 +2909,10 @@ function Table3D(parent) {
     envMapIntensity: 1.05
   });
 
-  const chromePlateThickness = railH * 0.08;
+  const chromePlateThickness = railH * 0.045;
   const chromePlateInset = TABLE.THICK * 0.02;
-  const chromePlateExpansionX = TABLE.THICK * 0.6;
-  const chromePlateExpansionZ = TABLE.THICK * 0.62;
+  const chromePlateExpansionX = TABLE.THICK * 0.25;
+  const chromePlateExpansionZ = TABLE.THICK * 0.28;
   const cushionInnerX = halfW - CUSHION_RAIL_FLUSH - CUSHION_CENTER_NUDGE;
   const cushionInnerZ = halfH - CUSHION_RAIL_FLUSH - CUSHION_CENTER_NUDGE;
   const chromePlateInnerLimitX = Math.max(0, cushionInnerX);


### PR DESCRIPTION
## Summary
- reduce the chrome plate thickness and footprint so the rail trim appears slimmer
- decrease chrome notch liner depth to keep the metal only on the wooden rail surfaces

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68dfb8ef6b1c8329ae5a975338add596