### PR TITLE
Adjust snooker trim and camera positioning

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1785,7 +1785,7 @@ const fitRadius = (camera, margin = 1.1) => {
   const dzH = halfH / Math.tan(f / 2);
   const dzW = halfW / (Math.tan(f / 2) * a);
   // Keep a little more distance so rails remain visible while fitting the table
-  const r = Math.max(dzH, dzW) * 0.62 * GLOBAL_SIZE_FACTOR; // bring standing camera closer while keeping full table in frame
+  const r = Math.max(dzH, dzW) * 0.58 * GLOBAL_SIZE_FACTOR; // bring standing camera closer while keeping full table in frame
   return clamp(r, CAMERA.minR, CAMERA.maxR);
 };
 const lerpAngle = (start = 0, end = 0, t = 0.5) => {
@@ -2849,7 +2849,7 @@ function Table3D(parent) {
   const outerHalfH = halfH + 2 * endRailW + frameWidthEnd;
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
   const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.03; // push cushions a touch farther from the rails to avoid overlapping the trim
-  const SHORT_CUSHION_HEIGHT_SCALE = 1.085; // raise short rail cushions to match the remaining four rails
+  const SHORT_CUSHION_HEIGHT_SCALE = 1.12; // raise short rail cushions to match the remaining four rails
   const railsGroup = new THREE.Group();
   const outerCornerRadius = Math.min(
     Math.min(longRailW, endRailW) * 1.6,
@@ -2868,10 +2868,10 @@ function Table3D(parent) {
     envMapIntensity: 1.05
   });
 
-  const chromePlateThickness = railH * 0.16; // extend chrome trim downward to wrap pocket arches
+  const chromePlateThickness = railH * 0.24; // extend chrome trim farther downward so the pocket arches are fully wrapped
   const chromePlateInset = TABLE.THICK * 0.02;
-  const chromePlateExpansionX = TABLE.THICK * 0.6;
-  const chromePlateExpansionZ = TABLE.THICK * 0.62;
+  const chromePlateExpansionX = TABLE.THICK * 0.72;
+  const chromePlateExpansionZ = TABLE.THICK * 0.74;
   const cushionInnerX = halfW - CUSHION_RAIL_FLUSH - CUSHION_CENTER_NUDGE;
   const cushionInnerZ = halfH - CUSHION_RAIL_FLUSH - CUSHION_CENTER_NUDGE;
   const chromePlateInnerLimitX = Math.max(0, cushionInnerX);
@@ -2900,7 +2900,7 @@ function Table3D(parent) {
   );
   const sideChromePlateWidth = Math.max(
     MICRO_EPS,
-    Math.min(sidePlatePocketWidth, sidePlateMaxWidth) - TABLE.THICK * 0.05
+    Math.min(sidePlatePocketWidth, sidePlateMaxWidth) - TABLE.THICK * 0.12
   );
   const sidePlateHalfHeightLimit = Math.max(
     0,
@@ -2921,7 +2921,7 @@ function Table3D(parent) {
   const cornerPocketRadius = POCKET_VIS_R * 1.1 * POCKET_VISUAL_EXPANSION;
   const cornerChamfer = POCKET_VIS_R * 0.34 * POCKET_VISUAL_EXPANSION;
   const cornerInset = POCKET_VIS_R * 0.58 * POCKET_VISUAL_EXPANSION;
-  const sideInset = SIDE_POCKET_RADIUS * 0.84 * POCKET_VISUAL_EXPANSION;
+  const sideInset = SIDE_POCKET_RADIUS * 0.76 * POCKET_VISUAL_EXPANSION;
 
   const circlePoly = (cx, cz, r, seg = 96) => {
     const pts = [];
@@ -3303,7 +3303,7 @@ function Table3D(parent) {
   const SIDE_CUSHION_POCKET_CLEARANCE =
     POCKET_VIS_R * 0.05 * POCKET_VISUAL_EXPANSION; // extend side cushions so they meet the pocket openings cleanly
   const SIDE_CUSHION_CENTER_PULL =
-    POCKET_VIS_R * 0.24 * POCKET_VISUAL_EXPANSION; // pull green side cushions slightly farther from the wooden rails
+    POCKET_VIS_R * 0.3 * POCKET_VISUAL_EXPANSION; // pull green side cushions slightly farther from the wooden rails
   const SIDE_CUSHION_CORNER_TRIM =
     POCKET_VIS_R * 0.015 * POCKET_VISUAL_EXPANSION; // extend side cushions toward the corner pockets for longer green rails
   const horizLen =


### PR DESCRIPTION
## Summary
- extend the chrome rail plates to wrap the pocket arches more completely and slim side-rail plates to clear the cushions
- align short-rail cushion height with the wooden rails and pull the side cushions slightly toward the table center
- move the side pockets outward and bring the standing camera framing closer without affecting the cue view

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfd1bd6f5083299c14cc9f9a1f33f8