### PR TITLE
Adjust snooker cushions for proper alignment

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2912,8 +2912,8 @@ function Table3D(parent) {
   const outerHalfW = halfW + 2 * longRailW + frameWidthLong;
   const outerHalfH = halfH + 2 * endRailW + frameWidthEnd;
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
-  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.075; // nudge cushions a touch farther from the rails so the green lip never overlaps the wood
-  const SHORT_CUSHION_HEIGHT_SCALE = 0.985; // shave a hint off the short-rail cushions so their top edge sits perfectly level with the wooden caps
+  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.09; // nudge cushions slightly farther from the rails so the green lip never overlaps the wood
+  const SHORT_CUSHION_HEIGHT_SCALE = 0.97; // drop the short-rail cushions so their top edge sits flush with the wooden caps
   const railsGroup = new THREE.Group();
   const outerCornerRadius = Math.min(
     Math.min(longRailW, endRailW) * 1.6,
@@ -3361,15 +3361,15 @@ function Table3D(parent) {
   const SHORT_CUSHION_EXTENSION =
     POCKET_VIS_R * 0.12 * POCKET_VISUAL_EXPANSION; // extend short rail cushions slightly toward the corner pockets
   const LONG_CUSHION_TRIM =
-    POCKET_VIS_R * 0.36 * POCKET_VISUAL_EXPANSION; // trim the long cushions ever so slightly sooner so their ends align with the chrome plates
+    POCKET_VIS_R * 0.42 * POCKET_VISUAL_EXPANSION; // trim the long cushions ever so slightly sooner so their ends align with the chrome plates
   const LONG_CUSHION_CORNER_EXTENSION =
-    POCKET_VIS_R * 0.04 * POCKET_VISUAL_EXPANSION; // push the long cushions a touch further toward the corner pockets
+    POCKET_VIS_R * 0.06 * POCKET_VISUAL_EXPANSION; // push the long cushions a touch further toward the corner pockets
   const SIDE_CUSHION_POCKET_CLEARANCE =
     POCKET_VIS_R * 0.05 * POCKET_VISUAL_EXPANSION; // extend side cushions so they meet the pocket openings cleanly
   const SIDE_CUSHION_CENTER_PULL =
-    POCKET_VIS_R * 0.36 * POCKET_VISUAL_EXPANSION; // pull green side cushions slightly farther from the wooden rails
+    POCKET_VIS_R * 0.4 * POCKET_VISUAL_EXPANSION; // pull green side cushions slightly farther from the wooden rails
   const SIDE_CUSHION_CORNER_TRIM =
-    POCKET_VIS_R * 0.005 * POCKET_VISUAL_EXPANSION; // let the side cushions stretch a touch closer to the corner pockets without overrunning them
+    0; // eliminate the side-corner trim so there's no triangular filler between cushions and chrome plates
   const horizLen =
     PLAY_W -
     2 * (POCKET_GAP - SHORT_CUSHION_EXTENSION - LONG_CUSHION_CORNER_EXTENSION) -


### PR DESCRIPTION
## Summary
- pull the snooker cushions slightly toward the table center and corner pockets to eliminate rail overlap
- lower the short-rail cushions and remove the side-corner filler to match the rail height and chrome boundaries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dff92f7e7483298dab3284363b4cb4