### PR TITLE
Fix chrome corner notch geometry on Snooker table

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3101,7 +3101,13 @@ function Table3D(parent) {
     const z3 = cz;
     const z4 = cz + sz * cornerChamfer;
     const boxZ = boxPoly(Math.min(x3, x4), Math.min(z3, z4), Math.max(x3, x4), Math.max(z3, z4));
-    const union = polygonClipping.union(notchCircle, boxX, boxZ);
+    const cornerWedge = [[[ 
+      [cx, cz],
+      [cx + sx * cornerChamfer, cz],
+      [cx, cz + sz * cornerChamfer],
+      [cx, cz]
+    ]]];
+    const union = polygonClipping.union(notchCircle, boxX, boxZ, cornerWedge);
     return adjustCornerNotchDepth(union, cz, sz);
   };
 


### PR DESCRIPTION
## Summary
- expand the snooker corner notch geometry to include the diagonal wedge between the box extensions
- ensure the chrome plate boolean subtraction removes the unintended triangular chrome piece at the pocket corner

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e022c012f0832990a2aaa00321f995