### PR TITLE
Remove corner chrome wedge from snooker table

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3101,13 +3101,7 @@ function Table3D(parent) {
     const z3 = cz;
     const z4 = cz + sz * cornerChamfer;
     const boxZ = boxPoly(Math.min(x3, x4), Math.min(z3, z4), Math.max(x3, x4), Math.max(z3, z4));
-    const cornerWedge = [[[ 
-      [cx, cz],
-      [cx + sx * cornerChamfer, cz],
-      [cx, cz + sz * cornerChamfer],
-      [cx, cz]
-    ]]];
-    const union = polygonClipping.union(notchCircle, boxX, boxZ, cornerWedge);
+    const union = polygonClipping.union(notchCircle, boxX, boxZ);
     return adjustCornerNotchDepth(union, cz, sz);
   };
 


### PR DESCRIPTION
## Summary
- remove the extra wedge geometry from the snooker chrome plate corner notch so the triangular chrome piece no longer renders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0915553208329a0c075dac955bf75