### PR TITLE
Adjust snooker cushion undercut shaping

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3308,10 +3308,18 @@ function Table3D(parent) {
       const z = arr[i + 2];
       const frontFactor = THREE.MathUtils.clamp((backY - y) / frontSpan, 0, 1);
       if (frontFactor <= 0) continue;
-      const taperedLift = CUSHION_UNDERCUT_FRONT_REMOVAL * frontFactor;
-      const lift = Math.min(CUSHION_UNDERCUT_BASE_LIFT + taperedLift, 0.94);
-      const minAllowedZ = minZ + depth * lift;
-      if (z < minAllowedZ) arr[i + 2] = minAllowedZ;
+      const taperedRemoval = THREE.MathUtils.clamp(
+        CUSHION_UNDERCUT_FRONT_REMOVAL * frontFactor,
+        0,
+        1
+      );
+      const undercutRatio = THREE.MathUtils.clamp(
+        CUSHION_UNDERCUT_BASE_LIFT + taperedRemoval,
+        0,
+        1
+      );
+      const targetZ = Math.max(minZ, maxZ - depth * undercutRatio);
+      if (z > targetZ) arr[i + 2] = targetZ;
     }
     pos.needsUpdate = true;
     geo.computeVertexNormals();


### PR DESCRIPTION
## Summary
- change the advanced cushion profile adjustment to carve an undercut by pulling the front face back along the extrusion depth
- clamp the undercut ratio controls so the base and front removal constants stay within the 0-1 range

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0af5f38f883299f8026eeff8c1335