### PR TITLE
Add standalone 3D arenas for Pool Royale variants

### DIFF
--- a/webapp/src/pages/Games/American8.jsx
+++ b/webapp/src/pages/Games/American8.jsx
@@ -1,0 +1,34 @@
+import React, { useMemo, useState } from 'react';
+import AmericanEightArenaScene from './American8/ArenaScene.jsx';
+import TableConfig from './American8/TableConfig.jsx';
+import { createAmericanEightRules } from './American8/RulesAdapter.ts';
+
+const INITIAL_CONFIG = {
+  preset: 'us8ft',
+  clothColor: '#0f6130',
+  railColor: '#3b2416',
+  frameColor: '#6d4124',
+  metalColor: '#d7d0c6',
+  ballFinish: 'glossy'
+};
+
+export default function American8() {
+  const [config, setConfig] = useState(INITIAL_CONFIG);
+  const rules = useMemo(() => createAmericanEightRules(), []);
+  const [rulesState] = useState(() => rules.getState());
+
+  return (
+    <div className="relative w-full min-h-[100dvh] bg-[#04070d] text-white">
+      <AmericanEightArenaScene config={config} />
+      <header className="absolute top-0 left-0 right-0 z-20 px-4 py-3 bg-gradient-to-b from-black/60 to-transparent">
+        <div>
+          <h1 className="text-base font-semibold tracking-wide">Pool Royale · American 8-Ball</h1>
+          <p className="text-xs text-white/70">8 ft BCA table · 57.15 mm balls</p>
+        </div>
+      </header>
+      <div className="absolute inset-x-0 bottom-0 z-20">
+        <TableConfig config={config} onChange={setConfig} rulesState={rulesState} />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/American8/ArenaScene.jsx
+++ b/webapp/src/pages/Games/American8/ArenaScene.jsx
@@ -1,0 +1,374 @@
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import {
+  BALL_SET,
+  BALL_DIAMETER_MM,
+  TABLE_DIMENSIONS_MM,
+  POCKET_RADIUS_MM,
+  computeRackLayout,
+  createBallTexture,
+  getCueBallPosition,
+  mmToMeters
+} from './BallSet.ts';
+import { createTableMaterials } from './assets/materials/tableMaterials.js';
+
+const TABLE_SURFACE_Y = 0.83;
+const TABLE_TOP_THICKNESS = 0.042;
+const RAIL_HEIGHT = 0.1;
+const RAIL_THICKNESS = 0.13;
+const FRAME_DROP = 0.19;
+const LEG_HEIGHT = 0.74;
+const LEG_OFFSET = 0.52;
+const FLOOR_SIZE_MULTIPLIER = 3.1;
+
+const DEFAULT_CONFIG = {
+  preset: 'us8ft',
+  clothColor: '#0f6130',
+  railColor: '#3b2416',
+  frameColor: '#6d4124',
+  metalColor: '#d7d0c6',
+  ballFinish: 'glossy'
+};
+
+function makeControls(camera, domElement, focusY) {
+  const controls = new OrbitControls(camera, domElement);
+  controls.target.set(0, focusY, 0);
+  controls.enablePan = false;
+  controls.minDistance = 1.7;
+  controls.maxDistance = 6.6;
+  controls.maxPolarAngle = Math.PI / 2.12;
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.05;
+  controls.rotateSpeed = 0.55;
+  return controls;
+}
+
+function configureRenderer(renderer, width, height) {
+  renderer.setSize(width, height);
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.1;
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+}
+
+function addEnvironment(scene, floorMaterial, playWidth, playLength) {
+  const floor = new THREE.Mesh(
+    new THREE.PlaneGeometry(playWidth * FLOOR_SIZE_MULTIPLIER, playLength * FLOOR_SIZE_MULTIPLIER),
+    floorMaterial
+  );
+  floor.rotation.x = -Math.PI / 2;
+  floor.position.y = 0;
+  scene.add(floor);
+
+  const wallMaterial = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#0c101c'),
+    roughness: 0.84,
+    metalness: 0.05
+  });
+
+  const wallHeight = 4.7;
+  const wallThickness = 0.32;
+  const wallLength = playLength * FLOOR_SIZE_MULTIPLIER;
+  const wallWidth = playWidth * FLOOR_SIZE_MULTIPLIER;
+
+  const northWall = new THREE.Mesh(new THREE.BoxGeometry(wallWidth, wallHeight, wallThickness), wallMaterial);
+  northWall.position.set(0, wallHeight / 2, -wallLength / 2);
+  scene.add(northWall);
+  const southWall = northWall.clone();
+  southWall.position.z = wallLength / 2;
+  scene.add(southWall);
+
+  const eastWall = new THREE.Mesh(new THREE.BoxGeometry(wallThickness, wallHeight, wallLength), wallMaterial);
+  eastWall.position.set(wallWidth / 2, wallHeight / 2, 0);
+  scene.add(eastWall);
+  const westWall = eastWall.clone();
+  westWall.position.x = -wallWidth / 2;
+  scene.add(westWall);
+
+  const riserMaterial = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#1b2335'),
+    roughness: 0.7,
+    metalness: 0.09
+  });
+  const riserDepth = wallThickness * 2.1;
+  const riserHeight = 0.46;
+  for (let i = 0; i < 3; i++) {
+    const riser = new THREE.Mesh(
+      new THREE.BoxGeometry(wallWidth * 0.9 - i * 0.3, riserHeight, riserDepth),
+      riserMaterial
+    );
+    riser.position.set(0, riserHeight * (i + 0.5), -playLength / 2 - 0.65 - i * (riserDepth + 0.08));
+    scene.add(riser);
+
+    const back = riser.clone();
+    back.position.z = playLength / 2 + 0.65 + i * (riserDepth + 0.08);
+    scene.add(back);
+  }
+}
+
+function addLighting(scene, tableY) {
+  const hemi = new THREE.HemisphereLight(0xdde8ff, 0x0b0e16, 0.68);
+  scene.add(hemi);
+
+  const key = new THREE.DirectionalLight(0xffffff, 1.18);
+  key.position.set(-3.6, tableY + 4.8, 2.8);
+  scene.add(key);
+
+  const fill = new THREE.DirectionalLight(0x74b6ff, 0.42);
+  fill.position.set(3.8, tableY + 4.2, -3.1);
+  scene.add(fill);
+
+  const back = new THREE.DirectionalLight(0x1f2a40, 0.22);
+  back.position.set(0.5, tableY + 5.4, -5.2);
+  scene.add(back);
+
+  const spot = new THREE.SpotLight(0xffffff, 1.45, 14, THREE.MathUtils.degToRad(70), 0.45, 1.7);
+  spot.position.set(0.1, tableY + 4.3, 0.2);
+  spot.target.position.set(0, tableY, 0);
+  scene.add(spot);
+  scene.add(spot.target);
+}
+
+function buildTable(materials, playWidth, playLength) {
+  const table = new THREE.Group();
+
+  const cloth = new THREE.Mesh(new THREE.BoxGeometry(playWidth, TABLE_TOP_THICKNESS, playLength), materials.cloth);
+  cloth.position.y = TABLE_SURFACE_Y - TABLE_TOP_THICKNESS / 2;
+  table.add(cloth);
+
+  const longRailGeo = new THREE.BoxGeometry(playWidth + RAIL_THICKNESS * 2.2, RAIL_HEIGHT, RAIL_THICKNESS);
+  const northRail = new THREE.Mesh(longRailGeo, materials.rails);
+  northRail.position.set(0, TABLE_SURFACE_Y + RAIL_HEIGHT / 2, playLength / 2 + RAIL_THICKNESS / 2);
+  table.add(northRail);
+  const southRail = northRail.clone();
+  southRail.position.z = -playLength / 2 - RAIL_THICKNESS / 2;
+  table.add(southRail);
+
+  const shortRailGeo = new THREE.BoxGeometry(RAIL_THICKNESS, RAIL_HEIGHT, playLength + RAIL_THICKNESS * 0.6);
+  const eastRail = new THREE.Mesh(shortRailGeo, materials.rails);
+  eastRail.position.set(playWidth / 2 + RAIL_THICKNESS / 2, TABLE_SURFACE_Y + RAIL_HEIGHT / 2, 0);
+  table.add(eastRail);
+  const westRail = eastRail.clone();
+  westRail.position.x = -playWidth / 2 - RAIL_THICKNESS / 2;
+  table.add(westRail);
+
+  const frame = new THREE.Mesh(
+    new THREE.BoxGeometry(playWidth + RAIL_THICKNESS * 2.6, 0.2, playLength + RAIL_THICKNESS * 2.6),
+    materials.frame
+  );
+  frame.position.y = TABLE_SURFACE_Y - FRAME_DROP;
+  table.add(frame);
+
+  const trim = new THREE.Mesh(
+    new THREE.BoxGeometry(playWidth + RAIL_THICKNESS * 2.8, 0.045, playLength + RAIL_THICKNESS * 2.8),
+    materials.chrome
+  );
+  trim.position.y = TABLE_SURFACE_Y + RAIL_HEIGHT + 0.02;
+  table.add(trim);
+
+  const legGeo = new THREE.BoxGeometry(0.2, LEG_HEIGHT, 0.2);
+  const legPositions = [
+    [playWidth / 2 + LEG_OFFSET, LEG_HEIGHT / 2 - 0.18, playLength / 2 + LEG_OFFSET],
+    [-playWidth / 2 - LEG_OFFSET, LEG_HEIGHT / 2 - 0.18, playLength / 2 + LEG_OFFSET],
+    [playWidth / 2 + LEG_OFFSET, LEG_HEIGHT / 2 - 0.18, -playLength / 2 - LEG_OFFSET],
+    [-playWidth / 2 - LEG_OFFSET, LEG_HEIGHT / 2 - 0.18, -playLength / 2 - LEG_OFFSET]
+  ];
+  legPositions.forEach(([x, y, z]) => {
+    const leg = new THREE.Mesh(legGeo, materials.frame.clone());
+    leg.position.set(x, y, z);
+    table.add(leg);
+  });
+
+  const pocketGroup = new THREE.Group();
+  const cornerRadius = mmToMeters(POCKET_RADIUS_MM);
+  const sideRadius = cornerRadius * 0.95;
+  const pocketDepth = 0.2;
+  const cornerGeo = new THREE.CylinderGeometry(cornerRadius, cornerRadius * 0.72, pocketDepth, 28, 1, true);
+  const sideGeo = new THREE.CylinderGeometry(sideRadius, sideRadius * 0.7, pocketDepth, 24, 1, true);
+  const pocketMaterial = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color('#040506'),
+    roughness: 0.58,
+    metalness: 0.22,
+    side: THREE.DoubleSide
+  });
+  const cornerPositions = [
+    [-playWidth / 2, TABLE_SURFACE_Y, -playLength / 2],
+    [playWidth / 2, TABLE_SURFACE_Y, -playLength / 2],
+    [-playWidth / 2, TABLE_SURFACE_Y, playLength / 2],
+    [playWidth / 2, TABLE_SURFACE_Y, playLength / 2]
+  ];
+  cornerPositions.forEach(([x, y, z]) => {
+    const pocket = new THREE.Mesh(cornerGeo, pocketMaterial);
+    pocket.position.set(x, y - pocketDepth / 2, z);
+    pocket.rotation.x = Math.PI / 2;
+    pocketGroup.add(pocket);
+  });
+
+  const sidePositions = [
+    [0, TABLE_SURFACE_Y, -playLength / 2],
+    [0, TABLE_SURFACE_Y, playLength / 2]
+  ];
+  sidePositions.forEach(([x, y, z]) => {
+    const pocket = new THREE.Mesh(sideGeo, pocketMaterial);
+    pocket.position.set(x, y - pocketDepth / 2, z);
+    pocket.rotation.x = Math.PI / 2;
+    pocket.scale.set(0.9, 1, 1);
+    pocketGroup.add(pocket);
+  });
+  table.add(pocketGroup);
+
+  return { table, cloth, rails: [northRail, southRail, eastRail, westRail], frame, trim };
+}
+
+function createBalls(config, playLength) {
+  const ballDiameter = mmToMeters(BALL_DIAMETER_MM);
+  const rackLayout = computeRackLayout(ballDiameter, playLength);
+  const cuePosition = getCueBallPosition(ballDiameter, playLength);
+  const radius = ballDiameter / 2;
+  const geometry = new THREE.SphereGeometry(radius, 48, 32);
+  const finish = config.ballFinish ?? 'glossy';
+  const roughness = finish === 'matte' ? 0.44 : finish === 'satin' ? 0.24 : 0.11;
+  const clearcoat = finish === 'glossy' ? 0.88 : finish === 'satin' ? 0.62 : 0.28;
+  const clearcoatRoughness = finish === 'glossy' ? 0.05 : finish === 'satin' ? 0.12 : 0.3;
+
+  const group = new THREE.Group();
+  const entries = new Map();
+
+  BALL_SET.forEach((ball) => {
+    const texture = createBallTexture(ball);
+    const material = new THREE.MeshPhysicalMaterial({
+      map: texture,
+      roughness,
+      metalness: 0.0,
+      clearcoat,
+      clearcoatRoughness,
+      sheen: 0.27,
+      sheenRoughness: 0.4
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.y = TABLE_SURFACE_Y + radius;
+    if (ball.id === 'CUE') {
+      mesh.position.add(cuePosition);
+    } else {
+      const entry = rackLayout.find((layout) => layout.id === ball.id);
+      if (entry) {
+        mesh.position.x = entry.position.x;
+        mesh.position.z = entry.position.z;
+      }
+    }
+    group.add(mesh);
+    entries.set(ball.id, { mesh, material });
+  });
+
+  return { group, entries };
+}
+
+export default function AmericanEightArenaScene({ config }) {
+  const hostRef = useRef(null);
+  const rendererRef = useRef(null);
+  const materialsRef = useRef(null);
+  const ballRef = useRef(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return () => {};
+
+    const width = host.clientWidth;
+    const height = host.clientHeight;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' });
+    configureRenderer(renderer, width, height);
+    host.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color('#05090f');
+
+    const camera = new THREE.PerspectiveCamera(54, width / height, 0.1, 55);
+    camera.position.set(3.1, 2.2, 3.3);
+    camera.lookAt(0, TABLE_SURFACE_Y, 0);
+
+    const controls = makeControls(camera, renderer.domElement, TABLE_SURFACE_Y);
+
+    const playWidth = mmToMeters(TABLE_DIMENSIONS_MM.width);
+    const playLength = mmToMeters(TABLE_DIMENSIONS_MM.length);
+
+    const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+    const materials = createTableMaterials(mergedConfig);
+    materialsRef.current = materials;
+
+    addLighting(scene, TABLE_SURFACE_Y);
+    const { table, cloth, rails, frame, trim } = buildTable(materials, playWidth, playLength);
+    scene.add(table);
+
+    const { group: ballsGroup, entries } = createBalls(mergedConfig, playLength);
+    ballRef.current = { ballsGroup, entries };
+    scene.add(ballsGroup);
+
+    addEnvironment(scene, materials.floor, playWidth, playLength);
+
+    const resizeObserver = new ResizeObserver(() => {
+      const newWidth = host.clientWidth;
+      const newHeight = host.clientHeight;
+      camera.aspect = newWidth / newHeight;
+      camera.updateProjectionMatrix();
+      configureRenderer(renderer, newWidth, newHeight);
+    });
+    resizeObserver.observe(host);
+
+    renderer.setAnimationLoop(() => {
+      controls.update();
+      ballsGroup.children.forEach((mesh) => {
+        mesh.rotation.y += 0.002;
+      });
+      renderer.render(scene, camera);
+    });
+
+    rendererRef.current = { renderer, scene, cloth, rails, frame, trim, controls };
+
+    return () => {
+      resizeObserver.disconnect();
+      renderer.setAnimationLoop(null);
+      controls.dispose();
+      renderer.dispose();
+      scene.traverse((object) => {
+        if (object.isMesh) {
+          object.geometry?.dispose?.();
+          if (Array.isArray(object.material)) {
+            object.material.forEach((mat) => mat.dispose?.());
+          } else {
+            object.material?.dispose?.();
+          }
+        }
+      });
+      host.removeChild(renderer.domElement);
+    };
+  }, []);
+
+  useEffect(() => {
+    const rendererState = rendererRef.current;
+    const materials = materialsRef.current;
+    const ballState = ballRef.current;
+    if (!rendererState || !materials || !ballState) return;
+
+    const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+    materials.cloth.color.set(mergedConfig.clothColor);
+    materials.rails.color.set(mergedConfig.railColor);
+    materials.frame.color.set(mergedConfig.frameColor);
+    materials.chrome.color.set(mergedConfig.metalColor);
+
+    const finish = mergedConfig.ballFinish ?? 'glossy';
+    const roughness = finish === 'matte' ? 0.44 : finish === 'satin' ? 0.24 : 0.11;
+    const clearcoat = finish === 'glossy' ? 0.88 : finish === 'satin' ? 0.62 : 0.28;
+    const clearcoatRoughness = finish === 'glossy' ? 0.05 : finish === 'satin' ? 0.12 : 0.3;
+
+    ballState.entries.forEach(({ material }) => {
+      material.roughness = roughness;
+      material.clearcoat = clearcoat;
+      material.clearcoatRoughness = clearcoatRoughness;
+      material.needsUpdate = true;
+    });
+  }, [config]);
+
+  return <div ref={hostRef} className="absolute inset-0" />;
+}

--- a/webapp/src/pages/Games/American8/BallSet.ts
+++ b/webapp/src/pages/Games/American8/BallSet.ts
@@ -1,0 +1,164 @@
+import * as THREE from 'three';
+
+export const TABLE_DIMENSIONS_MM = Object.freeze({ length: 2240, width: 1120 });
+export const BALL_DIAMETER_MM = 57.15;
+export const POCKET_RADIUS_MM = 63;
+
+export type AmericanBallId =
+  | 'SOLID1'
+  | 'SOLID2'
+  | 'SOLID3'
+  | 'SOLID4'
+  | 'SOLID5'
+  | 'SOLID6'
+  | 'SOLID7'
+  | 'BLACK8'
+  | 'STRIPE9'
+  | 'STRIPE10'
+  | 'STRIPE11'
+  | 'STRIPE12'
+  | 'STRIPE13'
+  | 'STRIPE14'
+  | 'STRIPE15'
+  | 'CUE';
+
+export interface BallDefinition {
+  id: AmericanBallId;
+  number: number;
+  label: string;
+  type: 'solid' | 'stripe' | 'black' | 'cue';
+  color: string;
+}
+
+export const BALL_SET: ReadonlyArray<BallDefinition> = Object.freeze([
+  { id: 'SOLID1', number: 1, label: '1 Ball', type: 'solid', color: '#f7d21b' },
+  { id: 'SOLID2', number: 2, label: '2 Ball', type: 'solid', color: '#1d69d6' },
+  { id: 'SOLID3', number: 3, label: '3 Ball', type: 'solid', color: '#c8363c' },
+  { id: 'SOLID4', number: 4, label: '4 Ball', type: 'solid', color: '#7d4cb4' },
+  { id: 'SOLID5', number: 5, label: '5 Ball', type: 'solid', color: '#f07f1a' },
+  { id: 'SOLID6', number: 6, label: '6 Ball', type: 'solid', color: '#2b9c5a' },
+  { id: 'SOLID7', number: 7, label: '7 Ball', type: 'solid', color: '#7c3f2b' },
+  { id: 'BLACK8', number: 8, label: '8 Ball', type: 'black', color: '#111111' },
+  { id: 'STRIPE9', number: 9, label: '9 Ball', type: 'stripe', color: '#f7d21b' },
+  { id: 'STRIPE10', number: 10, label: '10 Ball', type: 'stripe', color: '#1d69d6' },
+  { id: 'STRIPE11', number: 11, label: '11 Ball', type: 'stripe', color: '#c8363c' },
+  { id: 'STRIPE12', number: 12, label: '12 Ball', type: 'stripe', color: '#7d4cb4' },
+  { id: 'STRIPE13', number: 13, label: '13 Ball', type: 'stripe', color: '#f07f1a' },
+  { id: 'STRIPE14', number: 14, label: '14 Ball', type: 'stripe', color: '#2b9c5a' },
+  { id: 'STRIPE15', number: 15, label: '15 Ball', type: 'stripe', color: '#7c3f2b' },
+  { id: 'CUE', number: 0, label: 'Cue Ball', type: 'cue', color: '#f8f8f6' }
+]);
+
+const BALL_MAP = new Map(BALL_SET.map((ball) => [ball.id, ball]));
+
+const TRIANGLE_ROWS: AmericanBallId[][] = [
+  ['SOLID1'],
+  ['STRIPE10', 'STRIPE15'],
+  ['SOLID2', 'BLACK8', 'SOLID3'],
+  ['STRIPE11', 'SOLID7', 'STRIPE14', 'SOLID6'],
+  ['SOLID4', 'STRIPE13', 'SOLID5', 'STRIPE12', 'STRIPE9']
+];
+
+export function mmToMeters(value: number): number {
+  return value / 1000;
+}
+
+export function getBallDefinition(id: AmericanBallId): BallDefinition {
+  const ball = BALL_MAP.get(id);
+  if (!ball) throw new Error(`Unknown American 8-ball id: ${id}`);
+  return ball;
+}
+
+function createCanvas(size = 512): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  return canvas;
+}
+
+function drawStripe(ctx: CanvasRenderingContext2D, color: string) {
+  const { width, height } = ctx.canvas;
+  const stripeHeight = height * 0.38;
+  const y = (height - stripeHeight) / 2;
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, width, height);
+  ctx.fillStyle = color;
+  ctx.fillRect(0, y, width, stripeHeight);
+}
+
+function drawSolid(ctx: CanvasRenderingContext2D, color: string) {
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+}
+
+function paintNumber(
+  ctx: CanvasRenderingContext2D,
+  number: number,
+  type: BallDefinition['type'],
+  accent: string
+) {
+  const { width } = ctx.canvas;
+  const radius = width * 0.22;
+  ctx.beginPath();
+  ctx.fillStyle = type === 'black' ? '#fdfdfd' : '#ffffff';
+  ctx.arc(width / 2, width / 2, radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.lineWidth = radius * 0.12;
+  ctx.strokeStyle = type === 'stripe' ? accent : type === 'black' ? '#fdfdfd' : 'rgba(255,255,255,0.45)';
+  ctx.stroke();
+  ctx.fillStyle = type === 'black' ? '#050505' : '#000000';
+  ctx.font = `bold ${radius * 1.4}px "Arial"`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(String(number), width / 2, width / 2);
+}
+
+export function createBallTexture(ball: BallDefinition): THREE.Texture {
+  const canvas = createCanvas();
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Unable to create canvas context');
+
+  if (ball.type === 'cue') {
+    ctx.fillStyle = '#f9f9f4';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  } else if (ball.type === 'stripe') {
+    drawStripe(ctx, ball.color);
+  } else {
+    drawSolid(ctx, ball.color);
+  }
+
+  if (ball.type !== 'cue') {
+    paintNumber(ctx, ball.number, ball.type, ball.color);
+  }
+
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.anisotropy = 8;
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+export interface RackPosition {
+  id: AmericanBallId;
+  position: THREE.Vector3;
+}
+
+export function computeRackLayout(ballDiameter: number, tableLength: number): RackPosition[] {
+  const spacing = ballDiameter;
+  const rowAdvance = spacing * Math.sin(Math.PI / 3);
+  const footSpot = tableLength / 2 - spacing * 1.5;
+  const positions: RackPosition[] = [];
+  TRIANGLE_ROWS.forEach((rowBalls, rowIndex) => {
+    const z = footSpot - rowIndex * rowAdvance;
+    const rowWidth = (rowBalls.length - 1) * spacing;
+    rowBalls.forEach((id, index) => {
+      const x = -rowWidth / 2 + index * spacing;
+      positions.push({ id, position: new THREE.Vector3(x, 0, z) });
+    });
+  });
+  return positions;
+}
+
+export function getCueBallPosition(ballDiameter: number, tableLength: number): THREE.Vector3 {
+  const headString = -tableLength / 4;
+  return new THREE.Vector3(0, 0, headString);
+}

--- a/webapp/src/pages/Games/American8/README.md
+++ b/webapp/src/pages/Games/American8/README.md
@@ -1,0 +1,15 @@
+# American 8-Ball 3D Arena
+
+Pool Royal arena built around an 8 ft American table. Dimensions follow BCA standards and are converted from millimetres to metres for the renderer.
+
+## Table geometry
+- **Playfield**: 2240 mm × 1120 mm (8 ft).
+- **Relative scale vs snooker**: X scale = 2240 / 3569 ≈ 0.628, Z scale = 1120 / 1778 ≈ 0.630.
+- **Pocket radius**: 63 mm visual mouth (corner), 60 mm side.
+
+## Balls
+- **Diameter**: 57.15 mm (0.05715 m).
+- **Set**: Solids 1–7, black 8, stripes 9–15, cue ball.
+
+## Rack layout
+Standard eight-ball triangle with the 1-ball on the apex, the 8-ball centred, and alternating solids/stripes on the back row corners.

--- a/webapp/src/pages/Games/American8/RulesAdapter.ts
+++ b/webapp/src/pages/Games/American8/RulesAdapter.ts
@@ -1,0 +1,23 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - american billiards logic is provided as plain JS
+import { AmericanBilliards } from '../../../../../lib/americanBilliards.js';
+
+export class AmericanEightRulesAdapter {
+  private readonly game: any;
+
+  constructor() {
+    this.game = new AmericanBilliards();
+  }
+
+  takeShot(shot: any) {
+    return this.game.shotTaken(shot);
+  }
+
+  getState() {
+    return this.game.state;
+  }
+}
+
+export function createAmericanEightRules() {
+  return new AmericanEightRulesAdapter();
+}

--- a/webapp/src/pages/Games/American8/TableConfig.jsx
+++ b/webapp/src/pages/Games/American8/TableConfig.jsx
@@ -1,0 +1,184 @@
+import React, { useMemo } from 'react';
+import {
+  TABLE_DIMENSIONS_MM,
+  BALL_DIAMETER_MM,
+  POCKET_RADIUS_MM,
+  mmToMeters
+} from './BallSet.ts';
+
+const PRESETS = Object.freeze({
+  us8ft: {
+    label: 'US 8 ft',
+    clothColor: '#0f6130',
+    railColor: '#3b2416',
+    frameColor: '#6d4124',
+    metalColor: '#d7d0c6'
+  },
+  vegas: {
+    label: 'Vegas Night',
+    clothColor: '#1a4c8b',
+    railColor: '#261913',
+    frameColor: '#4b3020',
+    metalColor: '#ced2db'
+  },
+  vintage: {
+    label: 'Vintage Walnut',
+    clothColor: '#0d512b',
+    railColor: '#442b1b',
+    frameColor: '#8a5a32',
+    metalColor: '#f1e8d6'
+  }
+});
+
+const BALL_FINISHES = [
+  { id: 'glossy', label: 'Glossy' },
+  { id: 'matte', label: 'Matte' },
+  { id: 'satin', label: 'Satin' }
+];
+
+export default function TableConfig({ config, onChange, rulesState }) {
+  const presetId = config?.preset ?? 'us8ft';
+  const activePreset = PRESETS[presetId] ?? PRESETS.us8ft;
+
+  const metrics = useMemo(() => {
+    const lengthM = mmToMeters(TABLE_DIMENSIONS_MM.length).toFixed(3);
+    const widthM = mmToMeters(TABLE_DIMENSIONS_MM.width).toFixed(3);
+    const ballM = mmToMeters(BALL_DIAMETER_MM).toFixed(3);
+    const pocketM = mmToMeters(POCKET_RADIUS_MM).toFixed(3);
+    return { lengthM, widthM, ballM, pocketM };
+  }, []);
+
+  const updateConfig = (patch) => {
+    onChange?.({ ...config, ...patch });
+  };
+
+  const handlePreset = (event) => {
+    const id = event.target.value;
+    const preset = PRESETS[id] ?? PRESETS.us8ft;
+    updateConfig({
+      preset: id,
+      clothColor: preset.clothColor,
+      railColor: preset.railColor,
+      frameColor: preset.frameColor,
+      metalColor: preset.metalColor
+    });
+  };
+
+  const scoreA = rulesState?.scores?.A ?? 0;
+  const scoreB = rulesState?.scores?.B ?? 0;
+  const nextBall = rulesState?.currentBall ?? '-';
+
+  return (
+    <div className="bg-[#05080f]/95 backdrop-blur text-white text-sm px-4 py-4 flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <label className="text-xs uppercase tracking-wide text-white/60">Table preset</label>
+        <select
+          value={presetId}
+          onChange={handlePreset}
+          className="bg-black/40 border border-white/10 rounded px-3 py-2"
+        >
+          {Object.entries(PRESETS).map(([id, preset]) => (
+            <option key={id} value={id}>
+              {preset.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <ColorInput
+          label="Cloth"
+          value={config?.clothColor ?? activePreset.clothColor}
+          onChange={(value) => updateConfig({ clothColor: value })}
+        />
+        <ColorInput
+          label="Rails"
+          value={config?.railColor ?? activePreset.railColor}
+          onChange={(value) => updateConfig({ railColor: value })}
+        />
+        <ColorInput
+          label="Frame"
+          value={config?.frameColor ?? activePreset.frameColor}
+          onChange={(value) => updateConfig({ frameColor: value })}
+        />
+        <ColorInput
+          label="Chrome"
+          value={config?.metalColor ?? activePreset.metalColor}
+          onChange={(value) => updateConfig({ metalColor: value })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-xs uppercase tracking-wide text-white/60">Ball finish</label>
+        <div className="flex gap-2">
+          {BALL_FINISHES.map((finish) => {
+            const active = (config?.ballFinish ?? 'glossy') === finish.id;
+            return (
+              <button
+                key={finish.id}
+                onClick={() => updateConfig({ ballFinish: finish.id })}
+                className={`flex-1 rounded px-3 py-2 border text-center transition-colors ${
+                  active ? 'border-white bg-white/10' : 'border-white/10 bg-black/30'
+                }`}
+                type="button"
+              >
+                {finish.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-white/80 text-xs">
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Playfield</dt>
+          <dd>
+            {metrics.lengthM} m × {metrics.widthM} m
+          </dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Ball diameter</dt>
+          <dd>{metrics.ballM} m</dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Pocket radius</dt>
+          <dd>{metrics.pocketM} m</dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Score A</dt>
+          <dd>{scoreA}</dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Score B</dt>
+          <dd>{scoreB}</dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Next ball</dt>
+          <dd>{nextBall}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function ColorInput({ label, value, onChange }) {
+  return (
+    <label className="flex flex-col gap-2 text-xs">
+      <span className="uppercase tracking-wide text-white/60">{label}</span>
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className="w-10 h-8 rounded border border-white/20 bg-transparent"
+        />
+        <input
+          type="text"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className="flex-1 bg-black/30 border border-white/10 rounded px-2 py-1"
+        />
+      </div>
+    </label>
+  );
+}

--- a/webapp/src/pages/Games/American8/assets/materials/tableMaterials.js
+++ b/webapp/src/pages/Games/American8/assets/materials/tableMaterials.js
@@ -1,0 +1,37 @@
+import * as THREE from 'three';
+
+export function createTableMaterials({ clothColor, railColor, frameColor, metalColor }) {
+  const cloth = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(clothColor),
+    roughness: 0.34,
+    metalness: 0.03,
+    sheen: 0.48,
+    sheenRoughness: 0.26
+  });
+
+  const rails = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(railColor),
+    roughness: 0.57,
+    metalness: 0.12
+  });
+
+  const frame = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(frameColor),
+    roughness: 0.52,
+    metalness: 0.07
+  });
+
+  const chrome = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(metalColor),
+    roughness: 0.17,
+    metalness: 0.86
+  });
+
+  const floor = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#121520'),
+    roughness: 0.82,
+    metalness: 0.04
+  });
+
+  return { cloth, rails, frame, chrome, floor };
+}

--- a/webapp/src/pages/Games/NineBall.jsx
+++ b/webapp/src/pages/Games/NineBall.jsx
@@ -1,0 +1,34 @@
+import React, { useMemo, useState } from 'react';
+import NineBallArenaScene from './NineBall/ArenaScene.jsx';
+import TableConfig from './NineBall/TableConfig.jsx';
+import { createNineBallRules } from './NineBall/RulesAdapter.ts';
+
+const INITIAL_CONFIG = {
+  preset: 'us9ft',
+  clothColor: '#12539a',
+  railColor: '#31211a',
+  frameColor: '#553521',
+  metalColor: '#d0d5df',
+  ballFinish: 'glossy'
+};
+
+export default function NineBall() {
+  const [config, setConfig] = useState(INITIAL_CONFIG);
+  const rules = useMemo(() => createNineBallRules(), []);
+  const [rulesState] = useState(() => rules.getState());
+
+  return (
+    <div className="relative w-full min-h-[100dvh] bg-[#03070f] text-white">
+      <NineBallArenaScene config={config} />
+      <header className="absolute top-0 left-0 right-0 z-20 px-4 py-3 bg-gradient-to-b from-black/60 to-transparent">
+        <div>
+          <h1 className="text-base font-semibold tracking-wide">Pool Royale · 9-Ball</h1>
+          <p className="text-xs text-white/70">9 ft diamond rack · 57.15 mm set</p>
+        </div>
+      </header>
+      <div className="absolute inset-x-0 bottom-0 z-20">
+        <TableConfig config={config} onChange={setConfig} rulesState={rulesState} />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/NineBall/ArenaScene.jsx
+++ b/webapp/src/pages/Games/NineBall/ArenaScene.jsx
@@ -1,0 +1,363 @@
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import {
+  BALL_SET,
+  BALL_DIAMETER_MM,
+  TABLE_DIMENSIONS_MM,
+  POCKET_RADIUS_MM,
+  computeRackLayout,
+  createBallTexture,
+  getCueBallPosition,
+  mmToMeters
+} from './BallSet.ts';
+import { createTableMaterials } from './assets/materials/tableMaterials.js';
+
+const TABLE_SURFACE_Y = 0.84;
+const TABLE_TOP_THICKNESS = 0.045;
+const RAIL_HEIGHT = 0.11;
+const RAIL_THICKNESS = 0.15;
+const FRAME_DROP = 0.2;
+const LEG_HEIGHT = 0.78;
+const LEG_OFFSET = 0.56;
+const FLOOR_SIZE_MULTIPLIER = 3.4;
+
+const DEFAULT_CONFIG = {
+  preset: 'us9ft',
+  clothColor: '#12539a',
+  railColor: '#31211a',
+  frameColor: '#553521',
+  metalColor: '#d0d5df',
+  ballFinish: 'glossy'
+};
+
+function setupControls(camera, domElement, focusY) {
+  const controls = new OrbitControls(camera, domElement);
+  controls.target.set(0, focusY, 0);
+  controls.enablePan = false;
+  controls.minDistance = 1.8;
+  controls.maxDistance = 7.2;
+  controls.maxPolarAngle = Math.PI / 2.15;
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.05;
+  controls.rotateSpeed = 0.52;
+  return controls;
+}
+
+function tuneRenderer(renderer, width, height) {
+  renderer.setSize(width, height);
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.08;
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+}
+
+function addArena(scene, floorMaterial, playWidth, playLength) {
+  const floor = new THREE.Mesh(
+    new THREE.PlaneGeometry(playWidth * FLOOR_SIZE_MULTIPLIER, playLength * FLOOR_SIZE_MULTIPLIER),
+    floorMaterial
+  );
+  floor.rotation.x = -Math.PI / 2;
+  floor.position.y = 0;
+  scene.add(floor);
+
+  const wallMat = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#0a101d'),
+    roughness: 0.82,
+    metalness: 0.06
+  });
+
+  const wallHeight = 5.2;
+  const wallThickness = 0.35;
+  const wallLength = playLength * FLOOR_SIZE_MULTIPLIER;
+  const wallWidth = playWidth * FLOOR_SIZE_MULTIPLIER;
+
+  const north = new THREE.Mesh(new THREE.BoxGeometry(wallWidth, wallHeight, wallThickness), wallMat);
+  north.position.set(0, wallHeight / 2, -wallLength / 2);
+  scene.add(north);
+  const south = north.clone();
+  south.position.z = wallLength / 2;
+  scene.add(south);
+
+  const east = new THREE.Mesh(new THREE.BoxGeometry(wallThickness, wallHeight, wallLength), wallMat);
+  east.position.set(wallWidth / 2, wallHeight / 2, 0);
+  scene.add(east);
+  const west = east.clone();
+  west.position.x = -wallWidth / 2;
+  scene.add(west);
+
+  const riserMaterial = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#1a2338'),
+    roughness: 0.68,
+    metalness: 0.1
+  });
+  const riserDepth = wallThickness * 2.4;
+  const riserHeight = 0.48;
+  for (let i = 0; i < 4; i++) {
+    const riser = new THREE.Mesh(
+      new THREE.BoxGeometry(wallWidth * 0.92 - i * 0.35, riserHeight, riserDepth),
+      riserMaterial
+    );
+    riser.position.set(0, riserHeight * (i + 0.5), -playLength / 2 - 0.75 - i * (riserDepth + 0.1));
+    scene.add(riser);
+
+    const back = riser.clone();
+    back.position.z = playLength / 2 + 0.75 + i * (riserDepth + 0.1);
+    scene.add(back);
+  }
+}
+
+function addLights(scene, tableY) {
+  const hemi = new THREE.HemisphereLight(0xddeaff, 0x0c0f18, 0.7);
+  scene.add(hemi);
+
+  const key = new THREE.DirectionalLight(0xffffff, 1.25);
+  key.position.set(-4.2, tableY + 5, 3.2);
+  scene.add(key);
+
+  const fill = new THREE.DirectionalLight(0x6ca7ff, 0.48);
+  fill.position.set(4.4, tableY + 4.6, -3.5);
+  scene.add(fill);
+
+  const rim = new THREE.DirectionalLight(0x223344, 0.25);
+  rim.position.set(0, tableY + 5.8, -6);
+  scene.add(rim);
+
+  const spot = new THREE.SpotLight(0xffffff, 1.55, 16, THREE.MathUtils.degToRad(68), 0.4, 1.8);
+  spot.position.set(0, tableY + 4.6, 0.4);
+  spot.target.position.set(0, tableY, 0);
+  scene.add(spot);
+  scene.add(spot.target);
+}
+
+function buildTable(materials, playWidth, playLength) {
+  const table = new THREE.Group();
+
+  const cloth = new THREE.Mesh(new THREE.BoxGeometry(playWidth, TABLE_TOP_THICKNESS, playLength), materials.cloth);
+  cloth.position.y = TABLE_SURFACE_Y - TABLE_TOP_THICKNESS / 2;
+  table.add(cloth);
+
+  const railGeoLong = new THREE.BoxGeometry(playWidth + RAIL_THICKNESS * 2.4, RAIL_HEIGHT, RAIL_THICKNESS);
+  const frontRail = new THREE.Mesh(railGeoLong, materials.rails);
+  frontRail.position.set(0, TABLE_SURFACE_Y + RAIL_HEIGHT / 2, playLength / 2 + RAIL_THICKNESS / 2);
+  table.add(frontRail);
+  const backRail = frontRail.clone();
+  backRail.position.z = -playLength / 2 - RAIL_THICKNESS / 2;
+  table.add(backRail);
+
+  const railGeoShort = new THREE.BoxGeometry(RAIL_THICKNESS, RAIL_HEIGHT, playLength + RAIL_THICKNESS * 0.8);
+  const leftRail = new THREE.Mesh(railGeoShort, materials.rails);
+  leftRail.position.set(playWidth / 2 + RAIL_THICKNESS / 2, TABLE_SURFACE_Y + RAIL_HEIGHT / 2, 0);
+  table.add(leftRail);
+  const rightRail = leftRail.clone();
+  rightRail.position.x = -playWidth / 2 - RAIL_THICKNESS / 2;
+  table.add(rightRail);
+
+  const frame = new THREE.Mesh(
+    new THREE.BoxGeometry(playWidth + RAIL_THICKNESS * 2.8, 0.22, playLength + RAIL_THICKNESS * 2.8),
+    materials.frame
+  );
+  frame.position.y = TABLE_SURFACE_Y - FRAME_DROP;
+  table.add(frame);
+
+  const trim = new THREE.Mesh(
+    new THREE.BoxGeometry(playWidth + RAIL_THICKNESS * 3, 0.05, playLength + RAIL_THICKNESS * 3),
+    materials.chrome
+  );
+  trim.position.y = TABLE_SURFACE_Y + RAIL_HEIGHT + 0.025;
+  table.add(trim);
+
+  const legGeo = new THREE.CylinderGeometry(0.17, 0.21, LEG_HEIGHT, 24);
+  const legPositions = [
+    [playWidth / 2 + LEG_OFFSET, LEG_HEIGHT / 2 - 0.2, playLength / 2 + LEG_OFFSET],
+    [-playWidth / 2 - LEG_OFFSET, LEG_HEIGHT / 2 - 0.2, playLength / 2 + LEG_OFFSET],
+    [playWidth / 2 + LEG_OFFSET, LEG_HEIGHT / 2 - 0.2, -playLength / 2 - LEG_OFFSET],
+    [-playWidth / 2 - LEG_OFFSET, LEG_HEIGHT / 2 - 0.2, -playLength / 2 - LEG_OFFSET]
+  ];
+  legPositions.forEach(([x, y, z]) => {
+    const leg = new THREE.Mesh(legGeo, materials.frame.clone());
+    leg.position.set(x, y, z);
+    table.add(leg);
+  });
+
+  const pocketGroup = new THREE.Group();
+  const pocketRadius = mmToMeters(POCKET_RADIUS_MM);
+  const pocketDepth = 0.22;
+  const pocketGeo = new THREE.CylinderGeometry(pocketRadius, pocketRadius * 0.75, pocketDepth, 28, 1, true);
+  const pocketMaterial = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color('#040607'),
+    roughness: 0.55,
+    metalness: 0.2,
+    side: THREE.DoubleSide
+  });
+  const positions = [
+    [-playWidth / 2, TABLE_SURFACE_Y, -playLength / 2],
+    [playWidth / 2, TABLE_SURFACE_Y, -playLength / 2],
+    [-playWidth / 2, TABLE_SURFACE_Y, playLength / 2],
+    [playWidth / 2, TABLE_SURFACE_Y, playLength / 2],
+    [0, TABLE_SURFACE_Y, -playLength / 2],
+    [0, TABLE_SURFACE_Y, playLength / 2]
+  ];
+  positions.forEach(([x, y, z], idx) => {
+    const pocket = new THREE.Mesh(pocketGeo, pocketMaterial);
+    pocket.position.set(x, y - pocketDepth / 2, z);
+    pocket.rotation.x = Math.PI / 2;
+    if (idx >= 4) pocket.scale.set(0.8, 1, 1);
+    pocketGroup.add(pocket);
+  });
+  table.add(pocketGroup);
+
+  return { table, cloth, rails: [frontRail, backRail, leftRail, rightRail], frame, trim };
+}
+
+function createBallGroup(config, playLength) {
+  const ballDiameter = mmToMeters(BALL_DIAMETER_MM);
+  const rackLayout = computeRackLayout(ballDiameter, playLength);
+  const cuePosition = getCueBallPosition(ballDiameter, playLength);
+  const radius = ballDiameter / 2;
+  const geometry = new THREE.SphereGeometry(radius, 48, 32);
+  const finish = config.ballFinish ?? 'glossy';
+  const resolvedRoughness = finish === 'matte' ? 0.46 : finish === 'satin' ? 0.26 : 0.1;
+  const clearcoat = finish === 'glossy' ? 0.9 : finish === 'satin' ? 0.62 : 0.25;
+  const clearcoatRoughness = finish === 'glossy' ? 0.04 : finish === 'satin' ? 0.12 : 0.32;
+
+  const group = new THREE.Group();
+  const entries = new Map();
+
+  BALL_SET.forEach((ball) => {
+    const texture = createBallTexture(ball);
+    const material = new THREE.MeshPhysicalMaterial({
+      map: texture,
+      roughness: resolvedRoughness,
+      metalness: 0.0,
+      clearcoat,
+      clearcoatRoughness,
+      sheen: 0.28,
+      sheenRoughness: 0.38
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.y = TABLE_SURFACE_Y + radius;
+    if (ball.id === 'CUE') {
+      mesh.position.add(cuePosition);
+    } else {
+      const entry = rackLayout.find((layout) => layout.id === ball.id);
+      if (entry) {
+        mesh.position.x = entry.position.x;
+        mesh.position.z = entry.position.z;
+      }
+    }
+    group.add(mesh);
+    entries.set(ball.id, { mesh, material });
+  });
+
+  return { group, entries };
+}
+
+export default function NineBallArenaScene({ config }) {
+  const hostRef = useRef(null);
+  const rendererRef = useRef(null);
+  const materialsRef = useRef(null);
+  const ballRef = useRef(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return () => {};
+
+    const width = host.clientWidth;
+    const height = host.clientHeight;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' });
+    tuneRenderer(renderer, width, height);
+    host.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color('#04080f');
+
+    const camera = new THREE.PerspectiveCamera(54, width / height, 0.1, 60);
+    camera.position.set(3.4, 2.4, 3.6);
+    camera.lookAt(0, TABLE_SURFACE_Y, 0);
+
+    const controls = setupControls(camera, renderer.domElement, TABLE_SURFACE_Y);
+
+    const playWidth = mmToMeters(TABLE_DIMENSIONS_MM.width);
+    const playLength = mmToMeters(TABLE_DIMENSIONS_MM.length);
+
+    const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+    const materials = createTableMaterials(mergedConfig);
+    materialsRef.current = materials;
+
+    addLights(scene, TABLE_SURFACE_Y);
+    const { table, cloth, rails, frame, trim } = buildTable(materials, playWidth, playLength);
+    scene.add(table);
+
+    const { group: ballsGroup, entries } = createBallGroup(mergedConfig, playLength);
+    ballRef.current = { ballsGroup, entries };
+    scene.add(ballsGroup);
+
+    addArena(scene, materials.floor, playWidth, playLength);
+
+    const resizeObserver = new ResizeObserver(() => {
+      const newWidth = host.clientWidth;
+      const newHeight = host.clientHeight;
+      camera.aspect = newWidth / newHeight;
+      camera.updateProjectionMatrix();
+      tuneRenderer(renderer, newWidth, newHeight);
+    });
+    resizeObserver.observe(host);
+
+    renderer.setAnimationLoop(() => {
+      controls.update();
+      ballsGroup.children.forEach((mesh) => {
+        mesh.rotation.y += 0.0022;
+      });
+      renderer.render(scene, camera);
+    });
+
+    rendererRef.current = { renderer, scene, cloth, rails, frame, trim, controls };
+
+    return () => {
+      resizeObserver.disconnect();
+      renderer.setAnimationLoop(null);
+      controls.dispose();
+      renderer.dispose();
+      scene.traverse((object) => {
+        if (object.isMesh) {
+          object.geometry?.dispose?.();
+          if (Array.isArray(object.material)) {
+            object.material.forEach((mat) => mat.dispose?.());
+          } else {
+            object.material?.dispose?.();
+          }
+        }
+      });
+      host.removeChild(renderer.domElement);
+    };
+  }, []);
+
+  useEffect(() => {
+    const rendererState = rendererRef.current;
+    const materials = materialsRef.current;
+    const ballState = ballRef.current;
+    if (!rendererState || !materials || !ballState) return;
+
+    const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+    materials.cloth.color.set(mergedConfig.clothColor);
+    materials.rails.color.set(mergedConfig.railColor);
+    materials.frame.color.set(mergedConfig.frameColor);
+    materials.chrome.color.set(mergedConfig.metalColor);
+
+    const finish = mergedConfig.ballFinish ?? 'glossy';
+    const roughness = finish === 'matte' ? 0.46 : finish === 'satin' ? 0.26 : 0.1;
+    const clearcoat = finish === 'glossy' ? 0.9 : finish === 'satin' ? 0.62 : 0.25;
+    const clearcoatRoughness = finish === 'glossy' ? 0.04 : finish === 'satin' ? 0.12 : 0.32;
+
+    ballState.entries.forEach(({ material }) => {
+      material.roughness = roughness;
+      material.clearcoat = clearcoat;
+      material.clearcoatRoughness = clearcoatRoughness;
+      material.needsUpdate = true;
+    });
+  }, [config]);
+
+  return <div ref={hostRef} className="absolute inset-0" />;
+}

--- a/webapp/src/pages/Games/NineBall/BallSet.ts
+++ b/webapp/src/pages/Games/NineBall/BallSet.ts
@@ -1,0 +1,153 @@
+import * as THREE from 'three';
+
+export const TABLE_DIMENSIONS_MM = Object.freeze({ length: 2540, width: 1270 });
+export const BALL_DIAMETER_MM = 57.15;
+export const POCKET_RADIUS_MM = 63;
+
+export type NineBallId =
+  | 'B1'
+  | 'B2'
+  | 'B3'
+  | 'B4'
+  | 'B5'
+  | 'B6'
+  | 'B7'
+  | 'B8'
+  | 'B9'
+  | 'CUE';
+
+export interface BallDefinition {
+  id: NineBallId;
+  number: number;
+  label: string;
+  type: 'solid' | 'stripe' | 'black' | 'cue';
+  color: string;
+}
+
+export const BALL_SET: ReadonlyArray<BallDefinition> = Object.freeze([
+  { id: 'B1', number: 1, label: '1 Ball', type: 'solid', color: '#f7d21b' },
+  { id: 'B2', number: 2, label: '2 Ball', type: 'solid', color: '#1d69d6' },
+  { id: 'B3', number: 3, label: '3 Ball', type: 'solid', color: '#c8363c' },
+  { id: 'B4', number: 4, label: '4 Ball', type: 'solid', color: '#7d4cb4' },
+  { id: 'B5', number: 5, label: '5 Ball', type: 'solid', color: '#f07f1a' },
+  { id: 'B6', number: 6, label: '6 Ball', type: 'solid', color: '#2b9c5a' },
+  { id: 'B7', number: 7, label: '7 Ball', type: 'solid', color: '#7c3f2b' },
+  { id: 'B8', number: 8, label: '8 Ball', type: 'black', color: '#111111' },
+  { id: 'B9', number: 9, label: '9 Ball', type: 'stripe', color: '#f7d21b' },
+  { id: 'CUE', number: 0, label: 'Cue Ball', type: 'cue', color: '#f8f8f6' }
+]);
+
+const BALL_MAP = new Map(BALL_SET.map((ball) => [ball.id, ball]));
+
+const DIAMOND_ROWS: NineBallId[][] = [
+  ['B1'],
+  ['B6', 'B7'],
+  ['B8', 'B9', 'B5'],
+  ['B2', 'B3'],
+  ['B4']
+];
+
+export function mmToMeters(value: number): number {
+  return value / 1000;
+}
+
+export function getBallDefinition(id: NineBallId): BallDefinition {
+  const ball = BALL_MAP.get(id);
+  if (!ball) throw new Error(`Unknown nine-ball id: ${id}`);
+  return ball;
+}
+
+function createCanvas(size = 512): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  return canvas;
+}
+
+function drawStripe(ctx: CanvasRenderingContext2D, color: string) {
+  const { width, height } = ctx.canvas;
+  const stripeHeight = height * 0.38;
+  const y = (height - stripeHeight) / 2;
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, width, height);
+  ctx.fillStyle = color;
+  ctx.fillRect(0, y, width, stripeHeight);
+}
+
+function drawSolid(ctx: CanvasRenderingContext2D, color: string) {
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+}
+
+function paintNumberLabel(
+  ctx: CanvasRenderingContext2D,
+  number: number,
+  type: BallDefinition['type'],
+  stripeColor: string
+) {
+  const { width } = ctx.canvas;
+  const radius = width * 0.22;
+  ctx.beginPath();
+  ctx.fillStyle = type === 'black' ? '#fdfdfd' : '#ffffff';
+  ctx.arc(width / 2, width / 2, radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.lineWidth = radius * 0.12;
+  ctx.strokeStyle =
+    type === 'stripe' ? stripeColor : type === 'black' ? '#fdfdfd' : 'rgba(255,255,255,0.45)';
+  ctx.stroke();
+  ctx.fillStyle = type === 'black' ? '#050505' : '#000000';
+  ctx.font = `bold ${radius * 1.4}px "Arial"`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(String(number), width / 2, width / 2);
+}
+
+export function createBallTexture(ball: BallDefinition): THREE.Texture {
+  const canvas = createCanvas();
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Unable to get canvas context');
+
+  if (ball.type === 'cue') {
+    ctx.fillStyle = '#f9f9f4';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  } else if (ball.type === 'stripe') {
+    drawStripe(ctx, ball.color);
+  } else {
+    drawSolid(ctx, ball.color);
+  }
+
+  if (ball.type !== 'cue') {
+    paintNumberLabel(ctx, ball.number, ball.type, ball.color);
+  }
+
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.anisotropy = 8;
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+export interface RackPosition {
+  id: NineBallId;
+  position: THREE.Vector3;
+}
+
+export function computeRackLayout(ballDiameter: number, tableLength: number): RackPosition[] {
+  const spacing = ballDiameter;
+  const rowAdvance = spacing * Math.sin(Math.PI / 3);
+  const footSpot = tableLength / 2 - spacing * 1.5;
+  const positions: RackPosition[] = [];
+  DIAMOND_ROWS.forEach((rowBalls, index) => {
+    const z = footSpot - index * rowAdvance;
+    const rowWidth = (rowBalls.length - 1) * spacing;
+    rowBalls.forEach((id, i) => {
+      const x = -rowWidth / 2 + i * spacing;
+      positions.push({ id, position: new THREE.Vector3(x, 0, z) });
+    });
+  });
+  return positions;
+}
+
+export function getCueBallPosition(ballDiameter: number, tableLength: number): THREE.Vector3 {
+  const headString = -tableLength / 4;
+  return new THREE.Vector3(0, 0, headString);
+}

--- a/webapp/src/pages/Games/NineBall/README.md
+++ b/webapp/src/pages/Games/NineBall/README.md
@@ -1,0 +1,15 @@
+# 9-Ball 3D Arena
+
+Official 9 ft pool table recreated in the Pool Royal arena. All numeric dimensions are converted from millimetres into metres for Three.js units.
+
+## Table geometry
+- **Playfield**: 2540 mm × 1270 mm (9 ft).
+- **Relative scale vs snooker**: X scale = 2540 / 3569 ≈ 0.712, Z scale = 1270 / 1778 ≈ 0.715.
+- **Pocket radius**: 63 mm visual mouth (larger corner cut compared to snooker).
+
+## Balls
+- **Diameter**: 57.15 mm (0.05715 m).
+- **Set**: Balls 1–9 with standard WPA colours (9 is a yellow stripe) plus cue ball.
+
+## Rack layout
+Diamond rack (four rows) with 1 at the apex, 9 centred, alternating colours left/right and the 2 and 3 on the back corners.

--- a/webapp/src/pages/Games/NineBall/RulesAdapter.ts
+++ b/webapp/src/pages/Games/NineBall/RulesAdapter.ts
@@ -1,0 +1,23 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - nine ball rule implementation is legacy JS
+import { NineBall } from '../../../../../lib/nineBall.js';
+
+export class NineBallRulesAdapter {
+  private readonly game: any;
+
+  constructor() {
+    this.game = new NineBall();
+  }
+
+  takeShot(shot: any) {
+    return this.game.shotTaken(shot);
+  }
+
+  getState() {
+    return this.game.state;
+  }
+}
+
+export function createNineBallRules() {
+  return new NineBallRulesAdapter();
+}

--- a/webapp/src/pages/Games/NineBall/TableConfig.jsx
+++ b/webapp/src/pages/Games/NineBall/TableConfig.jsx
@@ -1,0 +1,182 @@
+import React, { useMemo } from 'react';
+import {
+  TABLE_DIMENSIONS_MM,
+  BALL_DIAMETER_MM,
+  POCKET_RADIUS_MM,
+  mmToMeters
+} from './BallSet.ts';
+
+const PRESETS = Object.freeze({
+  us9ft: {
+    label: 'US 9 ft',
+    clothColor: '#12539a',
+    railColor: '#31211a',
+    frameColor: '#553521',
+    metalColor: '#d0d5df'
+  },
+  arena: {
+    label: 'Arena Midnight',
+    clothColor: '#1a3c63',
+    railColor: '#201511',
+    frameColor: '#3b2a1e',
+    metalColor: '#c4c8d2'
+  },
+  progreen: {
+    label: 'Pro Tour Green',
+    clothColor: '#0a5d3c',
+    railColor: '#2d1d15',
+    frameColor: '#4a3123',
+    metalColor: '#d8d0c2'
+  }
+});
+
+const BALL_FINISHES = [
+  { id: 'glossy', label: 'Glossy' },
+  { id: 'matte', label: 'Matte' }
+];
+
+export default function TableConfig({ config, onChange, rulesState }) {
+  const presetId = config?.preset ?? 'us9ft';
+  const activePreset = PRESETS[presetId] ?? PRESETS.us9ft;
+
+  const metrics = useMemo(() => {
+    const lengthM = mmToMeters(TABLE_DIMENSIONS_MM.length).toFixed(3);
+    const widthM = mmToMeters(TABLE_DIMENSIONS_MM.width).toFixed(3);
+    const ballM = mmToMeters(BALL_DIAMETER_MM).toFixed(3);
+    const pocketM = mmToMeters(POCKET_RADIUS_MM).toFixed(3);
+    return { lengthM, widthM, ballM, pocketM };
+  }, []);
+
+  const updateConfig = (patch) => {
+    onChange?.({ ...config, ...patch });
+  };
+
+  const handlePreset = (event) => {
+    const id = event.target.value;
+    const preset = PRESETS[id] ?? PRESETS.us9ft;
+    updateConfig({
+      preset: id,
+      clothColor: preset.clothColor,
+      railColor: preset.railColor,
+      frameColor: preset.frameColor,
+      metalColor: preset.metalColor
+    });
+  };
+
+  const lowestTarget = useMemo(() => {
+    if (!rulesState?.ballsOnTable) return '-';
+    const values = Array.from(rulesState.ballsOnTable);
+    if (values.length === 0) return '-';
+    return Math.min(...values);
+  }, [rulesState]);
+
+  return (
+    <div className="bg-[#05080f]/95 backdrop-blur text-white text-sm px-4 py-4 flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <label className="text-xs uppercase tracking-wide text-white/60">Table preset</label>
+        <select
+          value={presetId}
+          onChange={handlePreset}
+          className="bg-black/40 border border-white/10 rounded px-3 py-2"
+        >
+          {Object.entries(PRESETS).map(([id, preset]) => (
+            <option key={id} value={id}>
+              {preset.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <ColorInput
+          label="Cloth"
+          value={config?.clothColor ?? activePreset.clothColor}
+          onChange={(value) => updateConfig({ clothColor: value })}
+        />
+        <ColorInput
+          label="Rails"
+          value={config?.railColor ?? activePreset.railColor}
+          onChange={(value) => updateConfig({ railColor: value })}
+        />
+        <ColorInput
+          label="Frame"
+          value={config?.frameColor ?? activePreset.frameColor}
+          onChange={(value) => updateConfig({ frameColor: value })}
+        />
+        <ColorInput
+          label="Chrome"
+          value={config?.metalColor ?? activePreset.metalColor}
+          onChange={(value) => updateConfig({ metalColor: value })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-xs uppercase tracking-wide text-white/60">Ball finish</label>
+        <div className="flex gap-2">
+          {BALL_FINISHES.map((finish) => {
+            const active = (config?.ballFinish ?? 'glossy') === finish.id;
+            return (
+              <button
+                key={finish.id}
+                onClick={() => updateConfig({ ballFinish: finish.id })}
+                className={`flex-1 rounded px-3 py-2 border text-center transition-colors ${
+                  active ? 'border-white bg-white/10' : 'border-white/10 bg-black/30'
+                }`}
+                type="button"
+              >
+                {finish.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-white/80 text-xs">
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Playfield</dt>
+          <dd>
+            {metrics.lengthM} m × {metrics.widthM} m
+          </dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Ball diameter</dt>
+          <dd>{metrics.ballM} m</dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Pocket radius</dt>
+          <dd>{metrics.pocketM} m</dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Ball in hand</dt>
+          <dd>{rulesState?.ballInHand ? 'Yes' : 'No'}</dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Lowest target</dt>
+          <dd>{lowestTarget}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function ColorInput({ label, value, onChange }) {
+  return (
+    <label className="flex flex-col gap-2 text-xs">
+      <span className="uppercase tracking-wide text-white/60">{label}</span>
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className="w-10 h-8 rounded border border-white/20 bg-transparent"
+        />
+        <input
+          type="text"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className="flex-1 bg-black/30 border border-white/10 rounded px-2 py-1"
+        />
+      </div>
+    </label>
+  );
+}

--- a/webapp/src/pages/Games/NineBall/assets/materials/tableMaterials.js
+++ b/webapp/src/pages/Games/NineBall/assets/materials/tableMaterials.js
@@ -1,0 +1,37 @@
+import * as THREE from 'three';
+
+export function createTableMaterials({ clothColor, railColor, frameColor, metalColor }) {
+  const cloth = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(clothColor),
+    roughness: 0.32,
+    metalness: 0.02,
+    sheen: 0.45,
+    sheenRoughness: 0.28
+  });
+
+  const rails = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(railColor),
+    roughness: 0.58,
+    metalness: 0.08
+  });
+
+  const frame = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(frameColor),
+    roughness: 0.5,
+    metalness: 0.06
+  });
+
+  const chrome = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(metalColor),
+    roughness: 0.16,
+    metalness: 0.88
+  });
+
+  const floor = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#0c101c'),
+    roughness: 0.78,
+    metalness: 0.02
+  });
+
+  return { cloth, rails, frame, chrome, floor };
+}

--- a/webapp/src/pages/Games/PoolUK8.jsx
+++ b/webapp/src/pages/Games/PoolUK8.jsx
@@ -1,0 +1,34 @@
+import React, { useMemo, useState } from 'react';
+import PoolUK8ArenaScene from './PoolUK8/ArenaScene.jsx';
+import TableConfig from './PoolUK8/TableConfig.jsx';
+import { createPoolUk8Rules } from './PoolUK8/RulesAdapter.ts';
+
+const INITIAL_CONFIG = {
+  preset: 'uk7ft',
+  clothColor: '#0c5f31',
+  railColor: '#362219',
+  frameColor: '#6f4122',
+  metalColor: '#d3cec4',
+  ballFinish: 'glossy'
+};
+
+export default function PoolUK8() {
+  const [config, setConfig] = useState(INITIAL_CONFIG);
+  const rules = useMemo(() => createPoolUk8Rules(), []);
+  const [rulesState] = useState(() => rules.getState());
+
+  return (
+    <div className="relative w-full min-h-[100dvh] bg-[#04070d] text-white">
+      <PoolUK8ArenaScene config={config} />
+      <header className="absolute top-0 left-0 right-0 z-20 flex items-center justify-between px-4 py-3 bg-gradient-to-b from-black/60 to-transparent">
+        <div>
+          <h1 className="text-base font-semibold tracking-wide">Pool Royale · UK 8-Ball</h1>
+          <p className="text-xs text-white/70">Official 7 ft table with 50.8 mm balls</p>
+        </div>
+      </header>
+      <div className="absolute inset-x-0 bottom-0 z-20">
+        <TableConfig config={config} onChange={setConfig} rulesState={rulesState} />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/PoolUK8/ArenaScene.jsx
+++ b/webapp/src/pages/Games/PoolUK8/ArenaScene.jsx
@@ -1,0 +1,374 @@
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import {
+  BALL_SET,
+  BALL_DIAMETER_MM,
+  TABLE_DIMENSIONS_MM,
+  POCKET_RADIUS_MM,
+  computeRackLayout,
+  createBallTexture,
+  getCueBallPosition,
+  mmToMeters
+} from './BallSet.ts';
+import { createTableMaterials } from './assets/materials/tableMaterials.js';
+
+const TABLE_SURFACE_Y = 0.82;
+const TABLE_TOP_THICKNESS = 0.04;
+const RAIL_HEIGHT = 0.09;
+const RAIL_THICKNESS = 0.12;
+const FRAME_DROP = 0.18;
+const LEG_HEIGHT = 0.7;
+const LEG_OFFSET = 0.5;
+const FLOOR_SIZE_MULTIPLIER = 3;
+
+const DEFAULT_CONFIG = {
+  preset: 'uk7ft',
+  clothColor: '#0c5f31',
+  railColor: '#362219',
+  frameColor: '#6f4122',
+  metalColor: '#d3cec4',
+  ballFinish: 'glossy'
+};
+
+function createOrbitControls(camera, domElement, targetY) {
+  const controls = new OrbitControls(camera, domElement);
+  controls.target.set(0, targetY, 0);
+  controls.enablePan = false;
+  controls.minDistance = 1.6;
+  controls.maxDistance = 6.5;
+  controls.maxPolarAngle = Math.PI / 2.1;
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.05;
+  controls.rotateSpeed = 0.55;
+  return controls;
+}
+
+function configureRenderer(renderer, width, height) {
+  renderer.setSize(width, height);
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.1;
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+}
+
+function buildArenaEnvironment(scene, floorMaterial, playWidth, playLength) {
+  const floor = new THREE.Mesh(
+    new THREE.PlaneGeometry(playWidth * FLOOR_SIZE_MULTIPLIER, playLength * FLOOR_SIZE_MULTIPLIER),
+    floorMaterial
+  );
+  floor.rotation.x = -Math.PI / 2;
+  floor.position.y = 0;
+  scene.add(floor);
+
+  const wallMaterial = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#0d121f'),
+    roughness: 0.85,
+    metalness: 0.05
+  });
+
+  const wallHeight = 4.5;
+  const wallThickness = 0.3;
+  const wallLength = playLength * FLOOR_SIZE_MULTIPLIER;
+  const wallWidth = playWidth * FLOOR_SIZE_MULTIPLIER;
+
+  const northWall = new THREE.Mesh(new THREE.BoxGeometry(wallWidth, wallHeight, wallThickness), wallMaterial);
+  northWall.position.set(0, wallHeight / 2, -wallLength / 2);
+  scene.add(northWall);
+
+  const southWall = northWall.clone();
+  southWall.position.z = wallLength / 2;
+  scene.add(southWall);
+
+  const eastWall = new THREE.Mesh(new THREE.BoxGeometry(wallThickness, wallHeight, wallLength), wallMaterial);
+  eastWall.position.set(wallWidth / 2, wallHeight / 2, 0);
+  scene.add(eastWall);
+
+  const westWall = eastWall.clone();
+  westWall.position.x = -wallWidth / 2;
+  scene.add(westWall);
+
+  const seatingMaterial = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#192135'),
+    roughness: 0.7,
+    metalness: 0.08
+  });
+  const riserHeight = 0.45;
+  for (let i = 0; i < 3; i++) {
+    const riser = new THREE.Mesh(
+      new THREE.BoxGeometry(wallWidth * 0.92 - i * 0.4, riserHeight, wallThickness * 2.2),
+      seatingMaterial
+    );
+    riser.position.set(0, riserHeight * (i + 0.5), -playLength / 2 - 0.6 - i * (wallThickness * 1.2));
+    scene.add(riser);
+
+    const riserBack = riser.clone();
+    riserBack.position.z = playLength / 2 + 0.6 + i * (wallThickness * 1.2);
+    scene.add(riserBack);
+  }
+}
+
+function buildLightingRig(scene, tableY) {
+  const hemi = new THREE.HemisphereLight(0xdde6ff, 0x0a0c12, 0.65);
+  scene.add(hemi);
+
+  const key = new THREE.DirectionalLight(0xffffff, 1.1);
+  key.position.set(-3.5, tableY + 4.5, 2.5);
+  key.castShadow = false;
+  scene.add(key);
+
+  const fill = new THREE.DirectionalLight(0x7cb8ff, 0.45);
+  fill.position.set(4.2, tableY + 3.8, -2.8);
+  scene.add(fill);
+
+  const overhead = new THREE.SpotLight(0xffffff, 1.35, 12, THREE.MathUtils.degToRad(70), 0.45, 1.6);
+  overhead.position.set(0, tableY + 4.2, 0);
+  overhead.target.position.set(0, tableY, 0);
+  scene.add(overhead);
+  scene.add(overhead.target);
+}
+
+function buildTableGeometry(materials, playWidth, playLength) {
+  const table = new THREE.Group();
+
+  const cloth = new THREE.Mesh(new THREE.BoxGeometry(playWidth, TABLE_TOP_THICKNESS, playLength), materials.cloth);
+  cloth.position.y = TABLE_SURFACE_Y - TABLE_TOP_THICKNESS / 2;
+  cloth.receiveShadow = true;
+  table.add(cloth);
+
+  const railGeoLong = new THREE.BoxGeometry(playWidth + RAIL_THICKNESS * 2, RAIL_HEIGHT, RAIL_THICKNESS);
+  const railNorth = new THREE.Mesh(railGeoLong, materials.rails);
+  railNorth.position.set(0, TABLE_SURFACE_Y + RAIL_HEIGHT / 2, playLength / 2 + RAIL_THICKNESS / 2);
+  table.add(railNorth);
+
+  const railSouth = railNorth.clone();
+  railSouth.position.z = -playLength / 2 - RAIL_THICKNESS / 2;
+  table.add(railSouth);
+
+  const railGeoShort = new THREE.BoxGeometry(RAIL_THICKNESS, RAIL_HEIGHT, playLength);
+  const railEast = new THREE.Mesh(railGeoShort, materials.rails);
+  railEast.position.set(playWidth / 2 + RAIL_THICKNESS / 2, TABLE_SURFACE_Y + RAIL_HEIGHT / 2, 0);
+  table.add(railEast);
+
+  const railWest = railEast.clone();
+  railWest.position.x = -playWidth / 2 - RAIL_THICKNESS / 2;
+  table.add(railWest);
+
+  const frame = new THREE.Mesh(
+    new THREE.BoxGeometry(playWidth + RAIL_THICKNESS * 2.6, 0.2, playLength + RAIL_THICKNESS * 2.6),
+    materials.frame
+  );
+  frame.position.y = TABLE_SURFACE_Y - FRAME_DROP;
+  table.add(frame);
+
+  const chromeTrim = new THREE.Mesh(
+    new THREE.BoxGeometry(playWidth + RAIL_THICKNESS * 2.8, 0.04, playLength + RAIL_THICKNESS * 2.8),
+    materials.chrome
+  );
+  chromeTrim.position.y = TABLE_SURFACE_Y + RAIL_HEIGHT + 0.02;
+  table.add(chromeTrim);
+
+  const legGeo = new THREE.BoxGeometry(0.22, LEG_HEIGHT, 0.22);
+  const legPositions = [
+    [playWidth / 2 + LEG_OFFSET, LEG_HEIGHT / 2 - 0.15, playLength / 2 + LEG_OFFSET],
+    [-playWidth / 2 - LEG_OFFSET, LEG_HEIGHT / 2 - 0.15, playLength / 2 + LEG_OFFSET],
+    [playWidth / 2 + LEG_OFFSET, LEG_HEIGHT / 2 - 0.15, -playLength / 2 - LEG_OFFSET],
+    [-playWidth / 2 - LEG_OFFSET, LEG_HEIGHT / 2 - 0.15, -playLength / 2 - LEG_OFFSET]
+  ];
+  legPositions.forEach(([x, y, z]) => {
+    const leg = new THREE.Mesh(legGeo, materials.frame.clone());
+    leg.position.set(x, y, z);
+    table.add(leg);
+  });
+
+  const pocketGroup = new THREE.Group();
+  const pocketRadius = mmToMeters(POCKET_RADIUS_MM);
+  const pocketDepth = 0.18;
+  const pocketGeo = new THREE.CylinderGeometry(pocketRadius, pocketRadius * 0.7, pocketDepth, 24, 1, true);
+  const pocketMat = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color('#050608'),
+    roughness: 0.6,
+    metalness: 0.15,
+    side: THREE.DoubleSide
+  });
+  const positions = [
+    [-playWidth / 2, TABLE_SURFACE_Y, -playLength / 2],
+    [playWidth / 2, TABLE_SURFACE_Y, -playLength / 2],
+    [-playWidth / 2, TABLE_SURFACE_Y, playLength / 2],
+    [playWidth / 2, TABLE_SURFACE_Y, playLength / 2],
+    [0, TABLE_SURFACE_Y, -playLength / 2],
+    [0, TABLE_SURFACE_Y, playLength / 2]
+  ];
+  positions.forEach(([x, y, z], index) => {
+    const pocket = new THREE.Mesh(pocketGeo, pocketMat);
+    pocket.position.set(x, y - pocketDepth / 2, z);
+    pocket.rotation.x = Math.PI / 2;
+    if (index >= 4) {
+      pocket.scale.set(0.85, 1, 1);
+    }
+    pocketGroup.add(pocket);
+  });
+  table.add(pocketGroup);
+
+  return { table, cloth, rails: [railNorth, railSouth, railEast, railWest], frame, chromeTrim };
+}
+
+function buildBallMeshes(config, playLength) {
+  const ballDiameter = mmToMeters(BALL_DIAMETER_MM);
+  const rackLayout = computeRackLayout(ballDiameter, playLength);
+  const cuePosition = getCueBallPosition(ballDiameter, playLength);
+  const radius = ballDiameter / 2;
+  const geometry = new THREE.SphereGeometry(radius, 48, 32);
+  const finish = config.ballFinish ?? 'glossy';
+  const roughness = finish === 'matte' ? 0.45 : finish === 'satin' ? 0.25 : 0.12;
+  const clearcoat = finish === 'glossy' ? 0.9 : finish === 'satin' ? 0.6 : 0.2;
+  const clearcoatRoughness = finish === 'glossy' ? 0.05 : finish === 'satin' ? 0.12 : 0.35;
+
+  const balls = new Map();
+  const group = new THREE.Group();
+
+  BALL_SET.forEach((ball) => {
+    const texture = createBallTexture(ball);
+    const material = new THREE.MeshPhysicalMaterial({
+      map: texture,
+      roughness,
+      metalness: 0.0,
+      clearcoat,
+      clearcoatRoughness,
+      sheen: 0.25,
+      sheenRoughness: 0.4
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.castShadow = false;
+    mesh.receiveShadow = false;
+    mesh.position.y = TABLE_SURFACE_Y + radius;
+    if (ball.id === 'CUE') {
+      mesh.position.add(cuePosition);
+    } else {
+      const rackPos = rackLayout.find((entry) => entry.id === ball.id);
+      if (rackPos) {
+        mesh.position.x = rackPos.position.x;
+        mesh.position.z = rackPos.position.z;
+      }
+    }
+    balls.set(ball.id, { mesh, material });
+    group.add(mesh);
+  });
+
+  return { group, balls };
+}
+
+export default function PoolUK8ArenaScene({ config }) {
+  const hostRef = useRef(null);
+  const rendererRef = useRef(null);
+  const materialsRef = useRef(null);
+  const ballStateRef = useRef(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return () => {};
+
+    const width = host.clientWidth;
+    const height = host.clientHeight;
+
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      alpha: false,
+      powerPreference: 'high-performance'
+    });
+    configureRenderer(renderer, width, height);
+    host.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color('#05090f');
+
+    const camera = new THREE.PerspectiveCamera(55, width / height, 0.1, 50);
+    camera.position.set(2.8, 2.1, 3.1);
+    camera.lookAt(0, TABLE_SURFACE_Y, 0);
+
+    const controls = createOrbitControls(camera, renderer.domElement, TABLE_SURFACE_Y);
+
+    const playWidth = mmToMeters(TABLE_DIMENSIONS_MM.width);
+    const playLength = mmToMeters(TABLE_DIMENSIONS_MM.length);
+
+    const initialConfig = { ...DEFAULT_CONFIG, ...config };
+    const materials = createTableMaterials(initialConfig);
+    materialsRef.current = materials;
+
+    buildLightingRig(scene, TABLE_SURFACE_Y);
+    const { table, cloth, rails, frame, chromeTrim } = buildTableGeometry(
+      materials,
+      playWidth,
+      playLength
+    );
+    scene.add(table);
+
+    const { group: ballsGroup, balls } = buildBallMeshes(initialConfig, playLength);
+    ballStateRef.current = { ballsGroup, balls };
+    scene.add(ballsGroup);
+
+    buildArenaEnvironment(scene, materials.floor, playWidth, playLength);
+
+    const resizeObserver = new ResizeObserver(() => {
+      const newWidth = host.clientWidth;
+      const newHeight = host.clientHeight;
+      camera.aspect = newWidth / newHeight;
+      camera.updateProjectionMatrix();
+      configureRenderer(renderer, newWidth, newHeight);
+    });
+    resizeObserver.observe(host);
+
+    renderer.setAnimationLoop(() => {
+      controls.update();
+      ballsGroup.children.forEach((mesh) => {
+        mesh.rotation.y += 0.002;
+      });
+      renderer.render(scene, camera);
+    });
+
+    rendererRef.current = { renderer, scene, cloth, rails, frame, chromeTrim };
+    return () => {
+      resizeObserver.disconnect();
+      renderer.setAnimationLoop(null);
+      controls.dispose();
+      renderer.dispose();
+      scene.traverse((object) => {
+        if (object.isMesh) {
+          object.geometry?.dispose?.();
+          if (Array.isArray(object.material)) {
+            object.material.forEach((mat) => mat.dispose?.());
+          } else {
+            object.material?.dispose?.();
+          }
+        }
+      });
+      host.removeChild(renderer.domElement);
+    };
+  }, []);
+
+  useEffect(() => {
+    const state = rendererRef.current;
+    const materials = materialsRef.current;
+    const balls = ballStateRef.current;
+    if (!state || !materials || !balls) return;
+
+    const nextConfig = { ...DEFAULT_CONFIG, ...config };
+    materials.cloth.color.set(nextConfig.clothColor);
+    materials.rails.color.set(nextConfig.railColor);
+    materials.frame.color.set(nextConfig.frameColor);
+    materials.chrome.color.set(nextConfig.metalColor);
+
+    const finish = nextConfig.ballFinish ?? 'glossy';
+    const roughness = finish === 'matte' ? 0.45 : finish === 'satin' ? 0.25 : 0.12;
+    const clearcoat = finish === 'glossy' ? 0.9 : finish === 'satin' ? 0.6 : 0.2;
+    const clearcoatRoughness = finish === 'glossy' ? 0.05 : finish === 'satin' ? 0.12 : 0.35;
+    balls.balls.forEach(({ material }) => {
+      material.roughness = roughness;
+      material.clearcoat = clearcoat;
+      material.clearcoatRoughness = clearcoatRoughness;
+      material.needsUpdate = true;
+    });
+  }, [config]);
+
+  return <div ref={hostRef} className="absolute inset-0" />;
+}

--- a/webapp/src/pages/Games/PoolUK8/BallSet.ts
+++ b/webapp/src/pages/Games/PoolUK8/BallSet.ts
@@ -1,0 +1,150 @@
+import * as THREE from 'three';
+
+export const TABLE_DIMENSIONS_MM = Object.freeze({ length: 1981, width: 991 });
+export const BALL_DIAMETER_MM = 50.8;
+export const POCKET_RADIUS_MM = 60;
+
+export type UkBallId =
+  | 'Y1'
+  | 'Y2'
+  | 'Y3'
+  | 'Y4'
+  | 'Y5'
+  | 'Y6'
+  | 'Y7'
+  | 'R1'
+  | 'R2'
+  | 'R3'
+  | 'R4'
+  | 'R5'
+  | 'R6'
+  | 'R7'
+  | 'BLACK'
+  | 'CUE';
+
+export interface BallDefinition {
+  id: UkBallId;
+  number: number;
+  label: string;
+  type: 'yellow' | 'red' | 'black' | 'cue';
+  color: string;
+}
+
+export const BALL_SET: ReadonlyArray<BallDefinition> = Object.freeze([
+  { id: 'Y1', number: 1, label: 'Yellow 1', type: 'yellow', color: '#f6d000' },
+  { id: 'Y2', number: 2, label: 'Yellow 2', type: 'yellow', color: '#f6d000' },
+  { id: 'Y3', number: 3, label: 'Yellow 3', type: 'yellow', color: '#f6d000' },
+  { id: 'Y4', number: 4, label: 'Yellow 4', type: 'yellow', color: '#f6d000' },
+  { id: 'Y5', number: 5, label: 'Yellow 5', type: 'yellow', color: '#f6d000' },
+  { id: 'Y6', number: 6, label: 'Yellow 6', type: 'yellow', color: '#f6d000' },
+  { id: 'Y7', number: 7, label: 'Yellow 7', type: 'yellow', color: '#f6d000' },
+  { id: 'R1', number: 9, label: 'Red 1', type: 'red', color: '#c2272d' },
+  { id: 'R2', number: 10, label: 'Red 2', type: 'red', color: '#c2272d' },
+  { id: 'R3', number: 11, label: 'Red 3', type: 'red', color: '#c2272d' },
+  { id: 'R4', number: 12, label: 'Red 4', type: 'red', color: '#c2272d' },
+  { id: 'R5', number: 13, label: 'Red 5', type: 'red', color: '#c2272d' },
+  { id: 'R6', number: 14, label: 'Red 6', type: 'red', color: '#c2272d' },
+  { id: 'R7', number: 15, label: 'Red 7', type: 'red', color: '#c2272d' },
+  { id: 'BLACK', number: 8, label: 'Black 8', type: 'black', color: '#111111' },
+  { id: 'CUE', number: 0, label: 'Cue Ball', type: 'cue', color: '#f8f8f6' }
+]);
+
+const BALL_MAP = new Map(BALL_SET.map((ball) => [ball.id, ball]));
+
+const TRIANGLE_ROWS: UkBallId[][] = [
+  ['Y1'],
+  ['R1', 'Y2'],
+  ['Y3', 'BLACK', 'R2'],
+  ['R3', 'Y4', 'R4', 'Y5'],
+  ['Y6', 'R5', 'Y7', 'R6', 'R7']
+];
+
+export function mmToMeters(value: number): number {
+  return value / 1000;
+}
+
+export function getBallDefinition(id: UkBallId): BallDefinition {
+  const ball = BALL_MAP.get(id);
+  if (!ball) {
+    throw new Error(`Unknown UK ball id: ${id}`);
+  }
+  return ball;
+}
+
+function createCanvas(size = 512): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  return canvas;
+}
+
+function paintNumberedCircle(
+  ctx: CanvasRenderingContext2D,
+  number: number,
+  options: { fill: string; stroke: string; text: string }
+) {
+  const { fill, stroke, text } = options;
+  const { width, height } = ctx.canvas;
+  const radius = width * 0.22;
+  ctx.beginPath();
+  ctx.fillStyle = fill;
+  ctx.arc(width / 2, height / 2, radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.lineWidth = radius * 0.12;
+  ctx.strokeStyle = stroke;
+  ctx.stroke();
+  ctx.fillStyle = text;
+  ctx.font = `bold ${radius * 1.4}px "Arial"`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(String(number), width / 2, height / 2);
+}
+
+export function createBallTexture(ball: BallDefinition): THREE.Texture {
+  const canvas = createCanvas();
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Unable to acquire 2D context for ball texture');
+  ctx.fillStyle = ball.type === 'cue' ? '#f9f9f4' : ball.color;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  if (ball.type !== 'cue') {
+    const circleFill = ball.type === 'black' ? '#fefefe' : '#ffffff';
+    const textColor = ball.type === 'black' ? '#050505' : '#000000';
+    paintNumberedCircle(ctx, ball.number, {
+      fill: circleFill,
+      stroke: 'rgba(255,255,255,0.35)',
+      text: textColor
+    });
+  }
+
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.anisotropy = 8;
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+export interface RackPosition {
+  id: UkBallId;
+  position: THREE.Vector3;
+}
+
+export function computeRackLayout(ballDiameter: number, tableLength: number): RackPosition[] {
+  const spacing = ballDiameter;
+  const rowAdvance = spacing * Math.sin(Math.PI / 3);
+  const footSpot = tableLength / 2 - spacing * 1.5;
+  const result: RackPosition[] = [];
+  TRIANGLE_ROWS.forEach((rowBalls, rowIndex) => {
+    const z = footSpot - rowIndex * rowAdvance;
+    const rowWidth = (rowBalls.length - 1) * spacing;
+    rowBalls.forEach((id, index) => {
+      const x = -rowWidth / 2 + index * spacing;
+      result.push({ id, position: new THREE.Vector3(x, 0, z) });
+    });
+  });
+  return result;
+}
+
+export function getCueBallPosition(ballDiameter: number, tableLength: number): THREE.Vector3 {
+  const headString = -tableLength / 4;
+  return new THREE.Vector3(0, 0, headString);
+}

--- a/webapp/src/pages/Games/PoolUK8/README.md
+++ b/webapp/src/pages/Games/PoolUK8/README.md
@@ -1,0 +1,15 @@
+# Pool UK 8-Ball 3D Arena
+
+This variant reproduces the Pool Royal arena with the English pool table geometry. All lengths are converted from official millimetres to metres when constructing the Three.js scene.
+
+## Table geometry
+- **Playfield**: 1981 mm × 991 mm (7 ft).
+- **Relative scale vs snooker**: X scale = 1981 / 3569 ≈ 0.555, Z scale = 991 / 1778 ≈ 0.558.
+- **Pocket radius**: 60 mm visual mouth (scaled isotropically on X/Z with rail thickness preserved on Y).
+
+## Balls
+- **Diameter**: 50.8 mm (0.0508 m).
+- **Set**: 7 yellow, 7 red, 1 black, cue ball.
+
+## Rack layout
+Standard UK 8-ball triangle with the black centred on the third row and colours alternating by row while keeping yellows on the apex and rear corners.

--- a/webapp/src/pages/Games/PoolUK8/RulesAdapter.ts
+++ b/webapp/src/pages/Games/PoolUK8/RulesAdapter.ts
@@ -1,0 +1,27 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - legacy rule set ships as JS without type defs
+import { UkPool, DEFAULT_RULES as DEFAULT_UK_RULES } from '../../../../../lib/poolUk8Ball.js';
+
+export class PoolUk8RulesAdapter {
+  private readonly game: any;
+
+  constructor(rules = {}) {
+    this.game = new UkPool({ ...DEFAULT_UK_RULES, ...rules });
+  }
+
+  startBreak() {
+    this.game.startBreak();
+  }
+
+  takeShot(shot: any) {
+    return this.game.shotTaken(shot);
+  }
+
+  getState() {
+    return this.game.state;
+  }
+}
+
+export function createPoolUk8Rules(rules = {}) {
+  return new PoolUk8RulesAdapter(rules);
+}

--- a/webapp/src/pages/Games/PoolUK8/TableConfig.jsx
+++ b/webapp/src/pages/Games/PoolUK8/TableConfig.jsx
@@ -1,0 +1,171 @@
+import React, { useMemo } from 'react';
+import {
+  TABLE_DIMENSIONS_MM,
+  BALL_DIAMETER_MM,
+  POCKET_RADIUS_MM,
+  mmToMeters
+} from './BallSet.ts';
+
+const PRESETS = Object.freeze({
+  uk7ft: {
+    label: 'UK 7 ft',
+    clothColor: '#0c5f31',
+    railColor: '#362219',
+    frameColor: '#6f4122',
+    metalColor: '#d3cec4'
+  },
+  club: {
+    label: 'Club Warm Oak',
+    clothColor: '#0a4c28',
+    railColor: '#3c2419',
+    frameColor: '#8a5632',
+    metalColor: '#ede7dd'
+  },
+  tour: {
+    label: 'TV Tour Blue',
+    clothColor: '#1b5fa6',
+    railColor: '#2c1c14',
+    frameColor: '#4b3224',
+    metalColor: '#d7d9de'
+  }
+});
+
+const BALL_FINISHES = [
+  { id: 'glossy', label: 'Glossy' },
+  { id: 'satin', label: 'Satin' }
+];
+
+export default function TableConfig({ config, onChange, rulesState }) {
+  const presetId = config?.preset ?? 'uk7ft';
+  const activePreset = PRESETS[presetId] ?? PRESETS.uk7ft;
+
+  const metrics = useMemo(() => {
+    const lengthM = mmToMeters(TABLE_DIMENSIONS_MM.length).toFixed(3);
+    const widthM = mmToMeters(TABLE_DIMENSIONS_MM.width).toFixed(3);
+    const ballM = mmToMeters(BALL_DIAMETER_MM).toFixed(3);
+    const pocketM = mmToMeters(POCKET_RADIUS_MM).toFixed(3);
+    return { lengthM, widthM, ballM, pocketM };
+  }, []);
+
+  const updateConfig = (patch) => {
+    onChange?.({ ...config, ...patch });
+  };
+
+  const handlePreset = (event) => {
+    const id = event.target.value;
+    const preset = PRESETS[id] ?? PRESETS.uk7ft;
+    updateConfig({
+      preset: id,
+      clothColor: preset.clothColor,
+      railColor: preset.railColor,
+      frameColor: preset.frameColor,
+      metalColor: preset.metalColor
+    });
+  };
+
+  return (
+    <div className="bg-[#05080f]/95 backdrop-blur text-white text-sm px-4 py-4 flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <label className="text-xs uppercase tracking-wide text-white/60">Table preset</label>
+        <select
+          value={presetId}
+          onChange={handlePreset}
+          className="bg-black/40 border border-white/10 rounded px-3 py-2"
+        >
+          {Object.entries(PRESETS).map(([id, preset]) => (
+            <option key={id} value={id}>
+              {preset.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <ColorInput
+          label="Cloth"
+          value={config?.clothColor ?? activePreset.clothColor}
+          onChange={(value) => updateConfig({ clothColor: value })}
+        />
+        <ColorInput
+          label="Rails"
+          value={config?.railColor ?? activePreset.railColor}
+          onChange={(value) => updateConfig({ railColor: value })}
+        />
+        <ColorInput
+          label="Frame"
+          value={config?.frameColor ?? activePreset.frameColor}
+          onChange={(value) => updateConfig({ frameColor: value })}
+        />
+        <ColorInput
+          label="Chrome"
+          value={config?.metalColor ?? activePreset.metalColor}
+          onChange={(value) => updateConfig({ metalColor: value })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-xs uppercase tracking-wide text-white/60">Ball finish</label>
+        <div className="flex gap-2">
+          {BALL_FINISHES.map((finish) => {
+            const active = (config?.ballFinish ?? 'glossy') === finish.id;
+            return (
+              <button
+                key={finish.id}
+                onClick={() => updateConfig({ ballFinish: finish.id })}
+                className={`flex-1 rounded px-3 py-2 border text-center transition-colors ${
+                  active ? 'border-white bg-white/10' : 'border-white/10 bg-black/30'
+                }`}
+                type="button"
+              >
+                {finish.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-white/80 text-xs">
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Playfield</dt>
+          <dd>
+            {metrics.lengthM} m × {metrics.widthM} m
+          </dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Ball diameter</dt>
+          <dd>{metrics.ballM} m</dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Pocket radius</dt>
+          <dd>{metrics.pocketM} m</dd>
+        </div>
+        <div>
+          <dt className="uppercase tracking-wide text-[10px] text-white/50">Current player</dt>
+          <dd>{rulesState?.currentPlayer ?? 'A'}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function ColorInput({ label, value, onChange }) {
+  return (
+    <label className="flex flex-col gap-2 text-xs">
+      <span className="uppercase tracking-wide text-white/60">{label}</span>
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className="w-10 h-8 rounded border border-white/20 bg-transparent"
+        />
+        <input
+          type="text"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className="flex-1 bg-black/30 border border-white/10 rounded px-2 py-1"
+        />
+      </div>
+    </label>
+  );
+}

--- a/webapp/src/pages/Games/PoolUK8/assets/materials/tableMaterials.js
+++ b/webapp/src/pages/Games/PoolUK8/assets/materials/tableMaterials.js
@@ -1,0 +1,37 @@
+import * as THREE from 'three';
+
+export function createTableMaterials({ clothColor, railColor, frameColor, metalColor }) {
+  const cloth = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(clothColor),
+    roughness: 0.35,
+    metalness: 0.0,
+    sheen: 0.5,
+    sheenRoughness: 0.3
+  });
+
+  const rails = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(railColor),
+    roughness: 0.6,
+    metalness: 0.1
+  });
+
+  const frame = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(frameColor),
+    roughness: 0.55,
+    metalness: 0.05
+  });
+
+  const chrome = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(metalColor),
+    roughness: 0.18,
+    metalness: 0.85
+  });
+
+  const floor = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#10131c'),
+    roughness: 0.8,
+    metalness: 0.0
+  });
+
+  return { cloth, rails, frame, chrome, floor };
+}


### PR DESCRIPTION
## Summary
- add dedicated PoolUK8, NineBall, and American8 React pages that render standalone Pool Royale arenas with Three.js
- provide per-variant ball sets, table materials, rules adapters, and configuration panels tailored to official dimensions
- document playfield scales, ball diameters, pocket sizing, and rack layouts for each game

## Testing
- npm run lint *(fails: legacy lint errors in existing lib and config files)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f8d565c48329b18565b5561a297a