### PR TITLE
Replace Pool Royale page with 3D variant scenes

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1,24 +1,21 @@
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import PoolUK8 from './PoolUK8.jsx';
+import NineBall from './NineBall.jsx';
+import American8 from './American8.jsx';
+
+const VARIANT_COMPONENTS = {
+  uk: PoolUK8,
+  american: American8,
+  '9ball': NineBall
+};
 
 export default function PoolRoyale() {
   useTelegramBackButton();
   const { search } = useLocation();
   const params = new URLSearchParams(search);
-  const variant = params.get('variant') || 'uk';
-  params.set('variant', variant);
-  const type = params.get('type') || 'regular';
-  params.set('type', type);
-  const src = `/pool-royale.html?${params.toString()}`;
-  const title =
-    variant === '9ball'
-      ? '9-Ball'
-      : variant === 'american'
-        ? 'American Billiards'
-        : '8 Pool UK';
-  return (
-    <div className="relative w-full h-[100dvh]">
-      <iframe src={src} title={title} className="w-full h-full border-0" />
-    </div>
-  );
+  const variantKey = params.get('variant');
+  const VariantComponent = VARIANT_COMPONENTS[variantKey] || VARIANT_COMPONENTS.uk;
+
+  return <VariantComponent />;
 }


### PR DESCRIPTION
## Summary
- replace the Pool Royale page iframe with the new React scenes for UK 8-Ball, American 8-Ball, and 9-Ball variants

## Testing
- npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e1001a8ebc8329aad2350e9f01f5fa