### PR TITLE
Update pool and snooker ball materials

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20,6 +20,7 @@ import { UnitySnookerRules } from '../../../../src/rules/UnitySnookerRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { useIsMobile } from '../../hooks/useIsMobile.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
+import { getBallMaterial as getTexturedBallMaterial } from '../../three/ballMaterials.js';
 
 function signedRingArea(ring) {
   let area = 0;
@@ -568,9 +569,6 @@ const BALL_GEOMETRY = new THREE.SphereGeometry(
   BALL_SEGMENTS.width,
   BALL_SEGMENTS.height
 );
-const BALL_MATERIAL_CACHE = new Map();
-const BALL_NUMBER_TEXTURE_CACHE = new Map();
-const BALL_NUMBER_MATERIAL_CACHE = new Map();
 // Slightly faster surface to keep balls rolling realistically on the snooker cloth
 // Slightly reduce per-frame friction so rolls feel livelier on high refresh
 // rate displays (e.g. 90 Hz) instead of drifting into slow motion.
@@ -3208,112 +3206,13 @@ function calcTarget(cue, dir, balls) {
 // --------------------------------------------------
 // ONLY kept component: Guret (balls factory)
 // --------------------------------------------------
-function getBallMaterial(baseColor) {
-  const key = `base:${baseColor}`;
-  if (!BALL_MATERIAL_CACHE.has(key)) {
-    BALL_MATERIAL_CACHE.set(
-      key,
-      new THREE.MeshPhysicalMaterial({
-        color: baseColor,
-        roughness: 0.18,
-        clearcoat: 1,
-        clearcoatRoughness: 0.12
-      })
-    );
-  }
-  return BALL_MATERIAL_CACHE.get(key);
-}
-
-function addStripeOverlay(mesh, stripeColor) {
-  const stripeRadius = BALL_R * 1.0025;
-  const stripeThetaLength = THREE.MathUtils.degToRad(52);
-  const stripeGeo = new THREE.SphereGeometry(
-    stripeRadius,
-    96,
-    48,
-    0,
-    Math.PI * 2,
-    Math.PI / 2 - stripeThetaLength / 2,
-    stripeThetaLength
-  );
-  const stripeMat = new THREE.MeshBasicMaterial({
-    color: stripeColor,
-    transparent: true,
-    opacity: 0.95,
-    side: THREE.DoubleSide
-  });
-  stripeMat.depthWrite = false;
-  const stripe = new THREE.Mesh(stripeGeo, stripeMat);
-  stripe.renderOrder = 1;
-  stripe.castShadow = false;
-  stripe.receiveShadow = false;
-  mesh.add(stripe);
-}
-
-function getBallNumberMaterial(number) {
-  const key = `num:${number}`;
-  if (BALL_NUMBER_MATERIAL_CACHE.has(key)) {
-    return BALL_NUMBER_MATERIAL_CACHE.get(key);
-  }
-  const canvas = document.createElement('canvas');
-  canvas.width = canvas.height = 256;
-  const ctx = canvas.getContext('2d');
-  if (ctx) {
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.fillStyle = '#ffffff';
-    ctx.beginPath();
-    ctx.arc(canvas.width / 2, canvas.height / 2, canvas.width * 0.4, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.strokeStyle = 'rgba(0,0,0,0.2)';
-    ctx.lineWidth = canvas.width * 0.03;
-    ctx.stroke();
-    ctx.fillStyle = '#0b0b0b';
-    ctx.font = `bold ${canvas.width * 0.48}px "Segoe UI", "Helvetica Neue", sans-serif`;
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText(String(number), canvas.width / 2, canvas.height / 2 * 1.05);
-  }
-  const texture = new THREE.CanvasTexture(canvas);
-  texture.anisotropy = 4;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
-  BALL_NUMBER_TEXTURE_CACHE.set(key, texture);
-  const mat = new THREE.MeshBasicMaterial({ map: texture, transparent: true });
-  mat.depthWrite = false;
-  mat.side = THREE.DoubleSide;
-  BALL_NUMBER_MATERIAL_CACHE.set(key, mat);
-  return mat;
-}
-
-function addBallNumberMarkers(mesh, number) {
-  if (number == null) return;
-  const markerGeom = new THREE.CircleGeometry(BALL_R * 0.36, 48);
-  const markerMat = getBallNumberMaterial(number);
-  const markerOffset = BALL_R - BALL_R * 0.12;
-  const localForward = new THREE.Vector3(0, 0, 1);
-  const normals = [
-    new THREE.Vector3(1, 0, 0),
-    new THREE.Vector3(-1, 0, 0),
-    new THREE.Vector3(0, 1, 0),
-    new THREE.Vector3(0, -1, 0),
-    new THREE.Vector3(0, 0, 1),
-    new THREE.Vector3(0, 0, -1)
-  ];
-  normals.forEach((normal) => {
-    const marker = new THREE.Mesh(markerGeom, markerMat.clone());
-    marker.position.copy(normal).multiplyScalar(markerOffset);
-    marker.quaternion.setFromUnitVectors(localForward, normal);
-    marker.renderOrder = 2;
-    marker.castShadow = false;
-    marker.receiveShadow = false;
-    mesh.add(marker);
-  });
-}
-
 function Guret(parent, id, color, x, y, options = {}) {
   const pattern = options.pattern || 'solid';
-  const baseColor = pattern === 'stripe' ? 0xffffff : color;
-  const material = getBallMaterial(baseColor);
+  const material = getTexturedBallMaterial({
+    color,
+    pattern,
+    number: options.number
+  });
   const mesh = new THREE.Mesh(BALL_GEOMETRY, material);
   mesh.position.set(x, BALL_CENTER_Y, y);
   mesh.castShadow = true;
@@ -3347,13 +3246,6 @@ function Guret(parent, id, color, x, y, options = {}) {
       marker.renderOrder = 2;
       mesh.add(marker);
     });
-  } else {
-    if (pattern === 'stripe') {
-      addStripeOverlay(mesh, color);
-    }
-    if (options.number != null) {
-      addBallNumberMarkers(mesh, options.number);
-    }
   }
   mesh.traverse((node) => {
     node.userData = node.userData || {};

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -19,6 +19,7 @@ import { UnitySnookerRules } from '../../../../src/rules/UnitySnookerRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { useIsMobile } from '../../hooks/useIsMobile.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
+import { getBallMaterial as getTexturedBallMaterial } from '../../three/ballMaterials.js';
 
 function signedRingArea(ring) {
   let area = 0;
@@ -568,7 +569,6 @@ const BALL_GEOMETRY = new THREE.SphereGeometry(
   BALL_SEGMENTS.width,
   BALL_SEGMENTS.height
 );
-const BALL_MATERIAL_CACHE = new Map();
 // Slightly faster surface to keep balls rolling realistically on the snooker cloth
 // Slightly reduce per-frame friction so rolls feel livelier on high refresh
 // rate displays (e.g. 90 Hz) instead of drifting into slow motion.
@@ -2993,19 +2993,12 @@ function calcTarget(cue, dir, balls) {
 // --------------------------------------------------
 // ONLY kept component: Guret (balls factory)
 // --------------------------------------------------
-function Guret(parent, id, color, x, y) {
-  if (!BALL_MATERIAL_CACHE.has(color)) {
-    BALL_MATERIAL_CACHE.set(
-      color,
-      new THREE.MeshPhysicalMaterial({
-        color,
-        roughness: 0.18,
-        clearcoat: 1,
-        clearcoatRoughness: 0.12
-      })
-    );
-  }
-  const material = BALL_MATERIAL_CACHE.get(color);
+function Guret(parent, id, color, x, y, options = {}) {
+  const material = getTexturedBallMaterial({
+    color,
+    pattern: options.pattern || 'solid',
+    number: options.number
+  });
   const mesh = new THREE.Mesh(BALL_GEOMETRY, material);
   mesh.position.set(x, BALL_CENTER_Y, y);
   mesh.castShadow = true;

--- a/webapp/src/three/ballMaterials.js
+++ b/webapp/src/three/ballMaterials.js
@@ -1,0 +1,166 @@
+import * as THREE from 'three';
+
+const MATERIAL_CACHE = new Map();
+
+function normalizeColor(input) {
+  const color = new THREE.Color(input);
+  return {
+    color,
+    hex: color.getHexString(),
+    style: `#${color.getHexString()}`,
+    luminance: color.getLuminance()
+  };
+}
+
+function hashKey(str) {
+  let hash = 2166136261 >>> 0;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function mulberry32(seed) {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), t | 1);
+    r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function addSurfaceNoise(ctx, size, seedKey) {
+  const seed = hashKey(seedKey);
+  const rand = mulberry32(seed || 1);
+  const image = ctx.getImageData(0, 0, size, size);
+  const data = image.data;
+  for (let i = 0; i < data.length; i += 4) {
+    const noise = (rand() - 0.5) * 12;
+    data[i] = Math.max(0, Math.min(255, data[i] + noise));
+    data[i + 1] = Math.max(0, Math.min(255, data[i + 1] + noise * 0.8));
+    data[i + 2] = Math.max(0, Math.min(255, data[i + 2] + noise * 0.6));
+  }
+  ctx.putImageData(image, 0, 0);
+}
+
+function drawBallTexture({ color, pattern, number }) {
+  const { style, luminance } = normalizeColor(color);
+  const stripe = pattern === 'stripe';
+  const size = 1024;
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return canvas;
+
+  ctx.fillStyle = stripe ? '#ffffff' : style;
+  ctx.fillRect(0, 0, size, size);
+
+  if (stripe) {
+    const stripeHeight = size * 0.44;
+    const stripeY = (size - stripeHeight) / 2;
+    ctx.fillStyle = style;
+    ctx.fillRect(0, stripeY, size, stripeHeight);
+
+    const stripeEdge = ctx.createLinearGradient(0, stripeY, 0, stripeY + stripeHeight);
+    stripeEdge.addColorStop(0, 'rgba(255,255,255,0.18)');
+    stripeEdge.addColorStop(0.5, 'rgba(255,255,255,0)');
+    stripeEdge.addColorStop(1, 'rgba(0,0,0,0.2)');
+    ctx.fillStyle = stripeEdge;
+    ctx.fillRect(0, stripeY - size * 0.015, size, stripeHeight + size * 0.03);
+  }
+
+  addSurfaceNoise(ctx, size, `${pattern}:${style}:${number ?? 'none'}`);
+
+  const highlight = ctx.createRadialGradient(
+    size * 0.32,
+    size * 0.28,
+    size * 0.1,
+    size * 0.32,
+    size * 0.28,
+    size * 0.58
+  );
+  highlight.addColorStop(0, 'rgba(255,255,255,0.92)');
+  highlight.addColorStop(0.45, 'rgba(255,255,255,0.35)');
+  highlight.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = highlight;
+  ctx.beginPath();
+  ctx.arc(size * 0.32, size * 0.28, size * 0.58, 0, Math.PI * 2);
+  ctx.fill();
+
+  const shadow = ctx.createRadialGradient(
+    size * 0.72,
+    size * 0.74,
+    size * 0.25,
+    size * 0.72,
+    size * 0.74,
+    size * 0.78
+  );
+  shadow.addColorStop(0, 'rgba(0,0,0,0)');
+  shadow.addColorStop(1, 'rgba(0,0,0,0.42)');
+  ctx.fillStyle = shadow;
+  ctx.beginPath();
+  ctx.arc(size * 0.72, size * 0.74, size * 0.78, 0, Math.PI * 2);
+  ctx.fill();
+
+  const seam = ctx.createLinearGradient(0, size * 0.5 - size * 0.025, 0, size * 0.5 + size * 0.025);
+  seam.addColorStop(0, 'rgba(255,255,255,0.12)');
+  seam.addColorStop(0.5, 'rgba(0,0,0,0.2)');
+  seam.addColorStop(1, 'rgba(255,255,255,0.12)');
+  ctx.fillStyle = seam;
+  ctx.fillRect(0, size * 0.5 - size * 0.025, size, size * 0.05);
+
+  if (number != null) {
+    const circleRadius = size * 0.18;
+    ctx.beginPath();
+    ctx.arc(size * 0.5, size * 0.55, circleRadius, 0, Math.PI * 2);
+    ctx.fillStyle = stripe ? '#ffffff' : '#fefefe';
+    ctx.fill();
+    ctx.lineWidth = size * 0.02;
+    ctx.strokeStyle = 'rgba(0,0,0,0.2)';
+    ctx.stroke();
+
+    const textColor = number === 8 || luminance < 0.35 ? '#ffffff' : '#111111';
+    ctx.fillStyle = textColor;
+    ctx.font = `bold ${size * 0.26}px "Segoe UI", "Helvetica Neue", sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(String(number), size * 0.5, size * 0.55 + size * 0.01);
+  }
+
+  return canvas;
+}
+
+export function getBallMaterial({ color, pattern = 'solid', number = null } = {}) {
+  const { hex } = normalizeColor(color ?? 0xffffff);
+  const key = `${pattern}:${hex}:${number ?? 'none'}`;
+  if (MATERIAL_CACHE.has(key)) {
+    return MATERIAL_CACHE.get(key);
+  }
+  const canvas = typeof document !== 'undefined'
+    ? drawBallTexture({ color, pattern, number })
+    : null;
+  const texture = canvas
+    ? new THREE.CanvasTexture(canvas)
+    : null;
+  if (texture) {
+    texture.anisotropy = 16;
+    texture.minFilter = THREE.LinearMipMapLinearFilter;
+    texture.magFilter = THREE.LinearFilter;
+    texture.wrapS = texture.wrapT = THREE.ClampToEdgeWrapping;
+    if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
+    else texture.encoding = THREE.sRGBEncoding;
+    texture.needsUpdate = true;
+  }
+  const material = new THREE.MeshPhysicalMaterial({
+    color: 0xffffff,
+    map: texture || null,
+    roughness: 0.18,
+    metalness: 0.04,
+    clearcoat: 1,
+    clearcoatRoughness: 0.12
+  });
+  MATERIAL_CACHE.set(key, material);
+  return material;
+}


### PR DESCRIPTION
## Summary
- add a shared Three.js material factory that generates textured pool balls with highlights, stripes, and number decals
- switch the Pool Royale variants to the new textured materials so UK 8-ball uses red/yellow solids with the same styling as American and 9-ball
- update the Snooker game to reuse the shared ball materials while keeping snooker colours and sizing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e12b90ea508329a2241a767964c68a