### PR TITLE
Adjust chess arena camera ergonomics

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -55,10 +55,13 @@ const TABLE_LEG_INSET = 0.45;
 const WALL_PROXIMITY_FACTOR = 0.5; // Bring arena walls 50% closer
 const WALL_HEIGHT_MULTIPLIER = 2; // Double wall height
 const CHAIR_SCALE = 4; // Chairs are 4x larger
-const CHAIR_CLEARANCE = 0.4;
+const CHAIR_CLEARANCE = 0.52;
 const CAMERA_INITIAL_RADIUS_FACTOR = 1.35;
 const CAMERA_MIN_RADIUS_FACTOR = 0.95;
 const CAMERA_MAX_RADIUS_FACTOR = 2.4;
+const CAMERA_INITIAL_PHI_LERP = 0.35;
+const CAMERA_VERTICAL_SENSITIVITY = 0.003;
+const CAMERA_LEAN_STRENGTH = 0.0065;
 
 const SNOOKER_TABLE_SCALE = 1.3;
 const SNOOKER_TABLE_W = 66 * SNOOKER_TABLE_SCALE;
@@ -81,8 +84,8 @@ const CAM = {
   far: 5000,
   minR: BOARD_DISPLAY_SIZE * CAMERA_MIN_RADIUS_FACTOR,
   maxR: BOARD_DISPLAY_SIZE * CAMERA_MAX_RADIUS_FACTOR,
-  phiMin: 1.05,
-  phiMax: 1.25
+  phiMin: 0.92,
+  phiMax: 1.22
 };
 
 // =============== Materials & simple builders ===============
@@ -823,7 +826,7 @@ function Chess3D({ avatar, username }) {
     );
     sph = new THREE.Spherical(
       initialRadius,
-      (CAM.phiMin + CAM.phiMax) / 2,
+      THREE.MathUtils.lerp(CAM.phiMin, CAM.phiMax, CAMERA_INITIAL_PHI_LERP),
       Math.PI * 0.25
     );
     const fit = () => {
@@ -1184,7 +1187,10 @@ function Chess3D({ avatar, username }) {
       drag.x = x;
       drag.y = y;
       sph.theta -= dx * 0.004;
-      sph.phi = clamp(sph.phi + dy * 0.003, CAM.phiMin, CAM.phiMax);
+      const phiDelta = -dy * CAMERA_VERTICAL_SENSITIVITY;
+      sph.phi = clamp(sph.phi + phiDelta, CAM.phiMin, CAM.phiMax);
+      const leanDelta = dy * CAMERA_LEAN_STRENGTH;
+      sph.radius = clamp(sph.radius - leanDelta, CAM.minR, CAM.maxR);
       fit();
     };
     const onUp = () => {


### PR DESCRIPTION
## Summary
- increase the chess arena chair clearance to pull the seats back slightly
- raise the default chess camera angle for a higher, downward look at the board
- add a subtle forward lean effect when dragging downward to mimic leaning toward the board

## Testing
- npm --prefix webapp run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68e14936fbcc8329805228567f51700b