### PR TITLE
Update snooker ball visuals to match reference design

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -768,11 +768,11 @@ const UI_SCALE = SIZE_REDUCTION;
 // Updated colors for dark cloth and standard balls
 const BASE_BALL_COLORS = Object.freeze({
   cue: 0xffffff,
-  red: 0xff0000,
-  yellow: 0xffff00,
-  green: 0x006400,
+  red: 0xd12c2c,
+  yellow: 0xffd700,
+  green: 0x0fa35a,
   brown: 0x8b4513,
-  blue: 0x0000ff,
+  blue: 0x1e50ff,
   pink: 0xff69b4,
   black: 0x000000
 });

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -206,7 +206,10 @@ function createBallTexture({ baseColor, pattern, number, variantKey }) {
   if (!ctx) return null;
 
   const size = BALL_TEXTURE_SIZE;
-  if (variantKey === 'pool') {
+  if (variantKey === 'snooker') {
+    ctx.fillStyle = toHexString(baseColor);
+    ctx.fillRect(0, 0, size, size);
+  } else if (variantKey === 'pool') {
     drawPoolBallTexture(ctx, size, baseColor, pattern, number);
   } else {
     drawDefaultBallTexture(ctx, size, baseColor, pattern, number);
@@ -244,15 +247,26 @@ export function getBallMaterial({
     variantKey
   });
 
-  const material = new THREE.MeshPhysicalMaterial({
-    color: 0xffffff,
-    map,
-    roughness: 0.16,
-    metalness: 0.04,
-    clearcoat: 1,
-    clearcoatRoughness: 0.08,
-    reflectivity: 0.9
-  });
+  const material =
+    variantKey === 'snooker'
+      ? new THREE.MeshPhysicalMaterial({
+          color: 0xffffff,
+          map,
+          clearcoat: 1,
+          clearcoatRoughness: 0.05,
+          metalness: 0.05,
+          roughness: 0.13,
+          reflectivity: 0.9
+        })
+      : new THREE.MeshPhysicalMaterial({
+          color: 0xffffff,
+          map,
+          roughness: 0.16,
+          metalness: 0.04,
+          clearcoat: 1,
+          clearcoatRoughness: 0.08,
+          reflectivity: 0.9
+        });
   material.needsUpdate = true;
   BALL_MATERIAL_CACHE.set(cacheKey, material);
   return material;


### PR DESCRIPTION
## Summary
- align the snooker ball color palette with the standalone reference values
- render snooker balls with flat textures and polished physical material settings to mirror the demo appearance

## Testing
- npm run lint -- webapp/src/utils/ballMaterialFactory.js webapp/src/pages/Games/Snooker.jsx *(fails: repository contains pre-existing lint errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e14e6b33248329ab5521fa11907f88