### PR TITLE
Adjust UK pool ball styling

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -766,6 +766,9 @@ const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.09; // pull cushions sl
 const UI_SCALE = SIZE_REDUCTION;
 
 const DEFAULT_POOL_VARIANT = 'american';
+const UK_POOL_RED = 0xd12c2c;
+const UK_POOL_YELLOW = 0xffd700;
+const UK_POOL_BLACK = 0x000000;
 const POOL_VARIANT_COLOR_SETS = Object.freeze({
   uk: {
     id: 'uk',
@@ -774,21 +777,21 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
     rackLayout: 'triangle',
     disableSnookerMarkings: true,
     objectColors: [
-      0xffc52c,
-      0xffc52c,
-      0xd32232,
-      0xffc52c,
-      0x111111,
-      0xd32232,
-      0xd32232,
-      0xffc52c,
-      0xd32232,
-      0xffc52c,
-      0xd32232,
-      0xffc52c,
-      0xd32232,
-      0xffc52c,
-      0xd32232
+      UK_POOL_YELLOW,
+      UK_POOL_YELLOW,
+      UK_POOL_RED,
+      UK_POOL_YELLOW,
+      UK_POOL_BLACK,
+      UK_POOL_RED,
+      UK_POOL_RED,
+      UK_POOL_YELLOW,
+      UK_POOL_RED,
+      UK_POOL_YELLOW,
+      UK_POOL_RED,
+      UK_POOL_YELLOW,
+      UK_POOL_RED,
+      UK_POOL_YELLOW,
+      UK_POOL_RED
     ],
     objectNumbers: [
       null,

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -91,14 +91,14 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
   if (Number.isFinite(number)) {
     ctx.fillStyle = '#ffffff';
     ctx.beginPath();
-    ctx.arc(size * 0.5, size * 0.55, size * 0.16, 0, Math.PI * 2);
+    ctx.arc(size * 0.5, size * 0.5, size * 0.18, 0, Math.PI * 2);
     ctx.fill();
 
-    ctx.fillStyle = number === 8 ? '#ffffff' : '#000000';
+    ctx.fillStyle = '#000000';
     ctx.font = `${size * 0.22}px Arial`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText(String(number), size * 0.5, size * 0.56);
+    ctx.fillText(String(number), size * 0.5, size * 0.5);
   }
 }
 


### PR DESCRIPTION
## Summary
- update the UK 8-ball variant palette to use the official red, yellow, and black colours
- tweak the pool ball texture generator so number decals match the UK specification

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e14f25e5d883298ee95107676b6c96