### PR TITLE
Fix Pool Royale ball numbering and label scale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -837,25 +837,27 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
     ],
     objectNumbers: [
       1,
-      10,
-      9,
-      3,
-      8,
-      6,
-      15,
-      13,
-      12,
-      11,
       2,
+      3,
       4,
       5,
+      6,
       7,
-      14
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
     ],
     objectPatterns: [
       'solid',
-      'stripe',
-      'stripe',
+      'solid',
+      'solid',
+      'solid',
+      'solid',
       'solid',
       'solid',
       'solid',
@@ -863,10 +865,8 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
       'stripe',
       'stripe',
       'stripe',
-      'solid',
-      'solid',
-      'solid',
-      'solid',
+      'stripe',
+      'stripe',
       'stripe'
     ]
   },
@@ -887,17 +887,17 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
       0x111111,
       0xffc52c
     ],
-    objectNumbers: [1, 2, 3, 4, 9, 5, 6, 7, 8],
+    objectNumbers: [1, 2, 3, 4, 5, 6, 7, 8, 9],
     objectPatterns: [
       'solid',
       'solid',
       'solid',
       'solid',
-      'stripe',
       'solid',
       'solid',
       'solid',
-      'solid'
+      'solid',
+      'stripe'
     ]
   }
 });

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -91,14 +91,14 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
   if (Number.isFinite(number)) {
     ctx.fillStyle = '#ffffff';
     ctx.beginPath();
-    ctx.arc(size * 0.5, size * 0.5, size * 0.18, 0, Math.PI * 2);
+    ctx.arc(size * 0.5, size * 0.5, size * 0.16, 0, Math.PI * 2);
     ctx.fill();
 
     ctx.fillStyle = '#000000';
-    ctx.font = `${size * 0.22}px Arial`;
+    ctx.font = `${size * 0.18}px Arial`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText(String(number), size * 0.5, size * 0.5);
+    ctx.fillText(String(number), size * 0.5, size * 0.5 + size * 0.0025);
   }
 }
 


### PR DESCRIPTION
## Summary
- correct the American 8-ball rack data so each color now carries its proper ball number and stripe pattern
- realign the 9-ball configuration with sequential numbering and the lone striped 9 ball
- shrink the rendered pool-ball number decals to better match the requested visual size

## Testing
- npm --prefix webapp run build *(emits existing sRGBEncoding warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68e1570736548329a49bfef6676bf924