### PR TITLE
Adjust standing camera framing for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2349,9 +2349,9 @@ function applySnookerScaling({
 }
 
 // Kamera: ruaj kënd komod që mos shtrihet poshtë cloth-it, por lejo pak më shumë lartësi kur ngrihet
-const STANDING_VIEW_PHI = 0.84;
+const STANDING_VIEW_PHI = 0.9;
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
-const STANDING_VIEW_MARGIN = 0.0032;
+const STANDING_VIEW_MARGIN = 0.0026;
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.3;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.18);
@@ -2361,9 +2361,9 @@ const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant
 const BROADCAST_DISTANCE_MULTIPLIER = 0.4;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
-const STANDING_VIEW_MARGIN_LANDSCAPE = 0.96;
-const STANDING_VIEW_MARGIN_PORTRAIT = 0.95;
-const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.025;
+const STANDING_VIEW_MARGIN_LANDSCAPE = 0.92;
+const STANDING_VIEW_MARGIN_PORTRAIT = 0.9;
+const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.015;
 const CAMERA = {
   fov: STANDING_VIEW_FOV,
   near: 0.04,


### PR DESCRIPTION
## Summary
- raise the standing camera's vertical angle so the table is viewed from slightly higher up in every Pool Royale variant
- tighten standing-view margins and broadcast padding to let the default framing sit closer to the cloth across 8-Ball UK, American, and 9-Ball modes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1f94a8b6c8329b78002fecbf34840