### PR TITLE
Adjust Pool Royale camera framing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2355,7 +2355,7 @@ function applySnookerScaling({
 }
 
 // Kamera: ruaj kënd komod që mos shtrihet poshtë cloth-it, por lejo pak më shumë lartësi kur ngrihet
-const STANDING_VIEW_PHI = 0.86;
+const STANDING_VIEW_PHI = 0.9;
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.0026;
 const STANDING_VIEW_FOV = 66;
@@ -2363,10 +2363,10 @@ const CAMERA_ABS_MIN_PHI = 0.3;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.16);
 const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.24; // keep orbit camera from dipping below the table surface
 // Pull the baseline player orbit in so the cue perspective hugs the cloth a bit more.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.26;
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.22;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
-const BROADCAST_DISTANCE_MULTIPLIER = 0.22;
+const BROADCAST_DISTANCE_MULTIPLIER = 0.18;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.82;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.8;
@@ -2381,8 +2381,8 @@ const CAMERA = {
   // keep the camera slightly above the horizontal plane but allow a lower sweep
   maxPhi: CAMERA_MAX_PHI
 };
-const CAMERA_CUSHION_CLEARANCE = TABLE.THICK * 1.04; // keep standing orbit safely above cushion lip and align with pocket cam height
-const CUE_VIEW_CUSHION_CLEARANCE = TABLE.THICK * 0.6; // clamp cue view so the camera remains above the rail surface
+const CAMERA_CUSHION_CLEARANCE = TABLE.THICK * 0.82; // keep standing orbit safely above cushion lip and align with pocket cam height
+const CUE_VIEW_CUSHION_CLEARANCE = TABLE.THICK * 0.45; // clamp cue view so the camera remains above the rail surface
 const STANDING_VIEW = Object.freeze({
   phi: STANDING_VIEW_PHI,
   margin: STANDING_VIEW_MARGIN
@@ -2397,17 +2397,17 @@ let RAIL_LIMIT_X = DEFAULT_RAIL_LIMIT_X;
 let RAIL_LIMIT_Y = DEFAULT_RAIL_LIMIT_Y;
 const RAIL_LIMIT_PADDING = 0.1;
 const BREAK_VIEW = Object.freeze({
-  radius: CAMERA.minR + BALL_R * 12, // pull the opening view further back while keeping the table centred
+  radius: CAMERA.minR + BALL_R * 10, // pull the opening view further back while keeping the table centred
   phi: CAMERA.maxPhi - 0.01
 });
-const CAMERA_RAIL_SAFETY = 0.02;
+const CAMERA_RAIL_SAFETY = 0.012;
 const CUE_VIEW_RADIUS_RATIO = 0.4;
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
   STANDING_VIEW_PHI + 0.22
 );
-const CUE_VIEW_PHI_LIFT = 0.05;
+const CUE_VIEW_PHI_LIFT = 0.04;
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,


### PR DESCRIPTION
## Summary
- pull the Pool Royale standing and broadcast cameras closer to the rails so the table fills the frame
- lower cushion clearance and cue view lift so the player camera rides just above the cloth while angling slightly downward

## Testing
- npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68e2443ba8f083299c5a3183c4711ada