### PR TITLE
Adjust billiards cameras for closer table perspective

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -16,21 +16,21 @@ public class CameraController : MonoBehaviour
     // to keep the camera from dipping too low relative to the table frame.
     public float railTopY = 0.33f;
     // Small clearance so the camera always remains a little above the side rails.
-    public float railClearance = 0.12f;
+    public float railClearance = 0.1f;
     // How far above the rails the camera is allowed to travel.
-    public float maxHeightAboveTable = 2.2f;
+    public float maxHeightAboveTable = 2f;
     // Default distance of the camera from the table centre when fully raised to
     // provide a broad overview of the action.
-    public float distanceFromCenter = 6.2f;
+    public float distanceFromCenter = 5.2f;
     // Minimum distance from the table centre allowed when the camera is pulled
     // down toward the rails for a closer look.
-    public float minDistanceFromCenter = 5.6f;
+    public float minDistanceFromCenter = 3.1f;
     // Extra pullback applied when the camera is raised to its maximum height so
     // the player gets a slightly wider view while aiming.
-    public float zoomOutWhenRaised = 0.4f;
+    public float zoomOutWhenRaised = 0.25f;
     // Buffer that keeps the camera just outside the rails even at the closest
     // zoom level.
-    public float railBuffer = 0.1f;
+    public float railBuffer = 0.05f;
     // Slight height offset so the camera looks just above the table centre
     // to reduce the viewing angle and give a lower perspective.
     public float lookAtHeightOffset = 0.05f;

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -18,15 +18,15 @@ public class CueCamera : MonoBehaviour
     public Transform TargetBall;
 
     // Distance behind the ball in the normal overview.
-    public float normalDistance = 2f;
+    public float normalDistance = 1.45f;
     // Height of the camera above the table surface in the normal overview.
-    public float normalHeight = 0.5f;
+    public float normalHeight = 0.48f;
     // Distance and height when pulling the camera down for a close-up view.
-    public float closeDistance = 0.7f;
-    public float closeHeight = 0.15f;
+    public float closeDistance = 0.55f;
+    public float closeHeight = 0.33f;
     // Additional offsets applied while the action camera is following a shot.
-    public float actionDistanceOffset = 0.25f;
-    public float actionHeightOffset = -0.05f;
+    public float actionDistanceOffset = 0.1f;
+    public float actionHeightOffset = 0f;
     // Rotation speed in degrees per second for horizontal mouse movement.
     public float rotationSpeed = 90f;
     // Speed at which the view blends between normal and close-up when dragging vertically.


### PR DESCRIPTION
## Summary
- bring the main table camera closer by reducing its default orbit distance and clearance values
- refine cue camera distances and heights so the close-up view aligns with the rail height while keeping shots framed tightly

## Testing
- not run (Unity camera configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68e247f7a45883299037179a3d721f63