### PR TITLE
Add emerald green cloth option for billiards tables

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1400,7 +1400,12 @@ const DEFAULT_CLOTH_COLOR_ID = 'proDark';
 const CLOTH_COLOR_OPTIONS = Object.freeze([
   { id: 'proDark', label: 'Tournament Dark', color: 0x2b7e4f },
   { id: 'freshGreen', label: 'Fresh Green', color: 0x379a5f },
-  { id: 'brightMint', label: 'Bright Mint', color: 0x45b974 }
+  { id: 'brightMint', label: 'Bright Mint', color: 0x45b974 },
+  {
+    id: 'emeraldClassic',
+    label: 'Rrobë Jeshile',
+    color: 0x19a34a
+  }
 ]);
 
 const toHexColor = (value) => {

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1180,7 +1180,12 @@ const DEFAULT_CLOTH_COLOR_ID = 'proDark';
 const CLOTH_COLOR_OPTIONS = Object.freeze([
   { id: 'proDark', label: 'Tournament Dark', color: 0x2b7e4f },
   { id: 'freshGreen', label: 'Fresh Green', color: 0x379a5f },
-  { id: 'brightMint', label: 'Bright Mint', color: 0x45b974 }
+  { id: 'brightMint', label: 'Bright Mint', color: 0x45b974 },
+  {
+    id: 'emeraldClassic',
+    label: 'Rrobë Jeshile',
+    color: 0x19a34a
+  }
 ]);
 
 const toHexColor = (value) => {


### PR DESCRIPTION
## Summary
- add the new "Rrobë Jeshile" cloth color selection for the 3D Snooker table
- expose the same emerald cloth color choice across Pool Royale game modes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2612e55f08329a72dedd49da0639b