### PR TITLE
Add shared cue gallery selection to Snooker and Pool

### DIFF
--- a/webapp/src/data/cueStyles.js
+++ b/webapp/src/data/cueStyles.js
@@ -1,0 +1,61 @@
+import * as THREE from 'three';
+
+const BASE_WOOD_STYLES = [
+  { id: 'heritage-maple', label: 'Heritage Maple', woodColor: 0xcaa472, accentColor: 0x3a2f27 },
+  { id: 'burnt-walnut', label: 'Burnt Walnut', woodColor: 0xb17d56, accentColor: 0x2b1d16 },
+  { id: 'rich-mahogany', label: 'Rich Mahogany', woodColor: 0x8d5a34, accentColor: 0x3c2514 },
+  { id: 'blonde-ash', label: 'Blonde Ash', woodColor: 0xd7b17e, accentColor: 0x403326 },
+  { id: 'amber-oak', label: 'Amber Oak', woodColor: 0x9b633b, accentColor: 0x2f1e13 },
+  { id: 'desert-beech', label: 'Desert Beech', woodColor: 0xdeb887, accentColor: 0x473120 },
+  { id: 'espresso-ebony', label: 'Espresso Ebony', woodColor: 0x6e3b1f, accentColor: 0x211108 },
+  { id: 'satin-chestnut', label: 'Satin Chestnut', woodColor: 0xa47551, accentColor: 0x34251a }
+];
+
+const withDefaults = (style, overrides) => ({
+  tipColor: 0xffffff,
+  tipTextureColor: '#1b3f75',
+  tipCapColor: 0x1f3f73,
+  jointColor: 0xcd7f32,
+  ...style,
+  ...overrides
+});
+
+export const SNOOKER_CUE_STYLES = BASE_WOOD_STYLES.map((style, index) =>
+  withDefaults(style, {
+    id: `snooker-${style.id}`,
+    tipColor: 0xf5f5f5,
+    tipTextureColor: '#ede6d7',
+    tipCapColor: 0xcd7f32,
+    jointColor: 0xcd7f32,
+    accentColor: style.accentColor ?? 0x2a1c10,
+    order: index
+  })
+);
+
+export const POOL_CUE_STYLES = BASE_WOOD_STYLES.map((style, index) =>
+  withDefaults(style, {
+    id: `pool-${style.id}`,
+    tipColor: 0x1f3f73,
+    tipTextureColor: '#1b3f75',
+    tipCapColor: 0x1f3f73,
+    jointColor: 0xcd7f32,
+    accentColor: style.accentColor ?? 0x1a1a1a,
+    order: index
+  })
+);
+
+export const DEFAULT_SNOOKER_CUE_STYLE_ID = SNOOKER_CUE_STYLES[0].id;
+export const DEFAULT_POOL_CUE_STYLE_ID = POOL_CUE_STYLES[0].id;
+
+export const getCueStyleById = (id, list = []) => {
+  if (!id) return list[0] ?? null;
+  return list.find((style) => style.id === id) ?? list[0] ?? null;
+};
+
+export const toCueStylePalette = (styles) =>
+  styles.map((style) => ({
+    id: style.id,
+    label: style.label,
+    woodColor: new THREE.Color(style.woodColor),
+    accentColor: new THREE.Color(style.accentColor ?? 0x222222)
+  }));

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -20,6 +20,15 @@ import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { useIsMobile } from '../../hooks/useIsMobile.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { getBallMaterial as getBilliardBallMaterial } from '../../utils/ballMaterialFactory.js';
+import {
+  SNOOKER_CUE_STYLES,
+  DEFAULT_SNOOKER_CUE_STYLE_ID,
+  getCueStyleById
+} from '../../data/cueStyles.js';
+import {
+  createCueDisplayFrame,
+  getCueTipTexture
+} from '../../three/createCueDisplayFrame.js';
 
 function signedRingArea(ring) {
   let area = 0;
@@ -4508,6 +4517,77 @@ function SnookerGame() {
   const chalkAssistEnabledRef = useRef(false);
   const chalkAssistTargetRef = useRef(false);
   const visibleChalkIndexRef = useRef(null);
+  const cueGalleryControlsRef = useRef({
+    focus: () => false,
+    restore: () => {},
+    setSelection: () => {},
+    interactives: []
+  });
+  const cueGalleryStateRef = useRef({
+    open: false,
+    lastOrbit: null,
+    lastFocus: null,
+    side: 'right'
+  });
+  const cueGalleryOpenRef = useRef(false);
+  const [cueGalleryOpen, setCueGalleryOpen] = useState(false);
+  useEffect(() => {
+    cueGalleryOpenRef.current = cueGalleryOpen;
+    cueGalleryStateRef.current.open = cueGalleryOpen;
+  }, [cueGalleryOpen]);
+  const [activeCueStyleId, setActiveCueStyleId] = useState(
+    DEFAULT_SNOOKER_CUE_STYLE_ID
+  );
+  const [pendingCueStyleId, setPendingCueStyleId] = useState(
+    DEFAULT_SNOOKER_CUE_STYLE_ID
+  );
+  const activeCueStyleRef = useRef(activeCueStyleId);
+  useEffect(() => {
+    activeCueStyleRef.current = activeCueStyleId;
+  }, [activeCueStyleId]);
+  const pendingCueStyleRef = useRef(pendingCueStyleId);
+  useEffect(() => {
+    pendingCueStyleRef.current = pendingCueStyleId;
+  }, [pendingCueStyleId]);
+  const applyCueStyleRef = useRef(() => {});
+  const updateCueDisplaySelectionRef = useRef(() => {});
+  const worldScaleRef = useRef(1);
+  const cueAssetsRef = useRef({
+    shaftMaterial: null,
+    tipMaterial: null,
+    connectorMaterial: null,
+    tipCapMaterial: null,
+    accentMaterial: null
+  });
+  useEffect(() => {
+    updateCueDisplaySelectionRef.current?.(pendingCueStyleId);
+  }, [pendingCueStyleId]);
+  useEffect(() => {
+    applyCueStyleRef.current?.(activeCueStyleId);
+  }, [activeCueStyleId]);
+  const handleCueStyleSelect = useCallback((styleId) => {
+    if (!styleId) return;
+    setPendingCueStyleId(styleId);
+  }, []);
+  const handleCueGalleryClose = useCallback(
+    (restoreSelection = true) => {
+      cueGalleryControlsRef.current.restore?.();
+      if (restoreSelection) {
+        cueGalleryControlsRef.current.setSelection?.(activeCueStyleRef.current);
+        setPendingCueStyleId(activeCueStyleRef.current);
+      }
+      setCueGalleryOpen(false);
+    },
+    [setCueGalleryOpen]
+  );
+  const handleCueGalleryConfirm = useCallback(() => {
+    const nextId = pendingCueStyleRef.current;
+    setActiveCueStyleId(nextId);
+    handleCueGalleryClose(false);
+  }, [handleCueGalleryClose]);
+  const handleCueGalleryCancel = useCallback(() => {
+    handleCueGalleryClose(true);
+  }, [handleCueGalleryClose]);
 
   const highlightChalks = useCallback(
     (activeIndex, suggestedIndex = visibleChalkIndexRef.current) => {
@@ -4774,9 +4854,26 @@ function SnookerGame() {
   useEffect(() => {
     applySliderLock();
   }, [applySliderLock, hud.turn, hud.over, shotActive]);
+  useEffect(() => {
+    const slider = sliderInstanceRef.current;
+    if (!slider) return;
+    if (cueGalleryOpen) slider.lock();
+    else applySliderLock();
+  }, [cueGalleryOpen, applySliderLock]);
   const [err, setErr] = useState(null);
   const fireRef = useRef(() => {}); // set from effect so slider can trigger fire()
   const cameraRef = useRef(null);
+  const handleCueGalleryOpen = useCallback(() => {
+    if (cueGalleryOpenRef.current) return;
+    const controls = cueGalleryControlsRef.current;
+    const camera = cameraRef.current;
+    const side = camera?.position?.x >= 0 ? 'right' : 'left';
+    const success = controls.focus?.(side);
+    if (!success) return;
+    controls.setSelection?.(activeCueStyleRef.current);
+    setPendingCueStyleId(activeCueStyleRef.current);
+    setCueGalleryOpen(true);
+  }, []);
   const sphRef = useRef(null);
   const initialOrbitRef = useRef(null);
   const aimFocusRef = useRef(null);
@@ -5374,6 +5471,24 @@ function SnookerGame() {
       let cue;
       let clothMat;
       let cushionMat;
+      const cueDisplayEntries = [];
+      const cueInteractiveMeshes = [];
+      const registerCueDisplay = (entry, side) => {
+        if (!entry) return;
+        const item = { ...entry, side };
+        cueDisplayEntries.push(item);
+        if (Array.isArray(entry.interactiveObjects)) {
+          cueInteractiveMeshes.push(...entry.interactiveObjects);
+        }
+        entry.group.userData.cueGallerySide = side;
+      };
+      const updateCueDisplaySelection = (styleId) => {
+        cueDisplayEntries.forEach((entry) => {
+          entry.setSelected?.(styleId);
+        });
+      };
+      updateCueDisplaySelectionRef.current = updateCueDisplaySelection;
+      const cueGalleryState = cueGalleryStateRef.current;
       const tableSurfaceY = TABLE_Y - TABLE.THICK + 0.01;
       let shooting = false; // track when a shot is in progress
       const setShootingState = (value) => {
@@ -5879,6 +5994,41 @@ function SnookerGame() {
         signage.rotation.y = rotationY;
         world.add(signage);
       });
+
+      const cueFrameLength = 1.5 * (BALL_R / 0.0525) * CUE_LENGTH_MULTIPLIER;
+      const cueFrameSpacing = Math.max(
+        BALL_R * 8,
+        Math.min(signageHeight * 0.65, roomDepth * 0.32)
+      );
+      const cueFrameXInset = wallThickness * 0.25;
+      const cueFrameY = signageY - signageHeight * 0.08;
+      const cueFrameCloth = ['#4a0f19', '#821c2a'];
+      const cueStyles = SNOOKER_CUE_STYLES;
+      [
+        { side: 'left', baseX: leftInterior, rotation: Math.PI / 2 },
+        { side: 'right', baseX: rightInterior, rotation: -Math.PI / 2 }
+      ].forEach(({ side, baseX, rotation }) => {
+        [-cueFrameSpacing, cueFrameSpacing].forEach((offsetZ) => {
+          const frame = createCueDisplayFrame({
+            styles: cueStyles,
+            cueLength: cueFrameLength,
+            clothColors: cueFrameCloth
+          });
+          if (!frame?.group) return;
+          frame.setSelected(activeCueStyleRef.current);
+          const xAdjust = side === 'right' ? -cueFrameXInset : cueFrameXInset;
+          frame.group.position.set(baseX + xAdjust, cueFrameY, offsetZ);
+          frame.group.rotation.y = rotation;
+          frame.group.traverse((child) => {
+            if (child.isMesh) child.castShadow = false;
+          });
+          world.add(frame.group);
+          registerCueDisplay(frame, side);
+        });
+      });
+      cueGalleryControlsRef.current.interactives = cueInteractiveMeshes;
+      cueGalleryControlsRef.current.setSelection = updateCueDisplaySelection;
+      updateCueDisplaySelection(activeCueStyleRef.current);
 
       const broadcastClearance = wallThickness * 1.1 + BALL_R * 4;
       const shortRailTarget = Math.max(
@@ -7041,6 +7191,71 @@ function SnookerGame() {
           };
           requestAnimationFrame(step);
         };
+        const focusCueGallery = (side = 'right') => {
+          const entries = cueDisplayEntries.filter((entry) => entry.side === side);
+          if (entries.length === 0) return false;
+          const worldScale = Math.max(worldScaleRef.current || 1, 1e-6);
+          const combined = new THREE.Box3();
+          entries.forEach((entry) => {
+            const bounds = entry.getBoundingBox?.();
+            if (bounds && !bounds.isEmpty()) combined.union(bounds);
+          });
+          if (combined.isEmpty()) return false;
+          const centerWorld = combined.getCenter(new THREE.Vector3());
+          const sizeWorld = combined.getSize(new THREE.Vector3());
+          const centerLocal = centerWorld.clone().divideScalar(worldScale);
+          const store = ensureOrbitFocus();
+          cueGalleryState.lastFocus = store.target.clone();
+          cueGalleryState.lastOrbit = {
+            radius: sph.radius,
+            phi: sph.phi,
+            theta: sph.theta
+          };
+          cueGalleryState.side = side;
+          store.ballId = null;
+          store.target.copy(centerLocal);
+          const horizontal = Math.max(sizeWorld.x, sizeWorld.z) / worldScale;
+          const vertical = sizeWorld.y / worldScale;
+          const radiusBase = Math.max(horizontal, vertical) * 0.75 + BALL_R * 12;
+          const desiredRadius = clampOrbitRadius(
+            Math.max(radiusBase, CAMERA.minR + 0.5)
+          );
+          const desiredPhi = clamp(
+            Math.PI / 3,
+            CAMERA.minPhi + 0.05,
+            CAMERA.maxPhi - 0.05
+          );
+          const desiredTheta = side === 'right' ? -Math.PI / 2 : Math.PI / 2;
+          animateCamera({
+            radius: desiredRadius,
+            phi: desiredPhi,
+            theta: desiredTheta,
+            duration: 600
+          });
+          return true;
+        };
+        const restoreCueGalleryCamera = () => {
+          const store = ensureOrbitFocus();
+          if (cueGalleryState.lastFocus) {
+            store.ballId = null;
+            store.target.copy(cueGalleryState.lastFocus);
+          } else {
+            setOrbitFocusToDefault();
+          }
+          if (cueGalleryState.lastOrbit) {
+            const { radius, phi, theta } = cueGalleryState.lastOrbit;
+            animateCamera({
+              radius: clampOrbitRadius(radius),
+              phi: clamp(phi, CAMERA.minPhi, CAMERA.maxPhi),
+              theta,
+              duration: 500
+            });
+          }
+          cueGalleryState.lastOrbit = null;
+          cueGalleryState.lastFocus = null;
+        };
+        cueGalleryControlsRef.current.focus = focusCueGallery;
+        cueGalleryControlsRef.current.restore = restoreCueGalleryCamera;
         const restoreOrbitCamera = (view, immediate = false) => {
           if (!view) return;
           const sph = sphRef.current;
@@ -7450,7 +7665,43 @@ function SnookerGame() {
         const registerInteraction = () => {
           lastInteraction = performance.now();
         };
+        const attemptCueSelect = (ev) => {
+          if (!cueGalleryOpenRef.current) return false;
+          if (cueInteractiveMeshes.length === 0) return false;
+          if (ev.touches?.length && ev.touches.length > 1) return false;
+          const rect = dom.getBoundingClientRect();
+          const clientX = ev.clientX ?? ev.touches?.[0]?.clientX;
+          const clientY = ev.clientY ?? ev.touches?.[0]?.clientY;
+          if (clientX == null || clientY == null) return false;
+          if (
+            clientX < rect.left ||
+            clientX > rect.right ||
+            clientY < rect.top ||
+            clientY > rect.bottom
+          ) {
+            return false;
+          }
+          const nx = ((clientX - rect.left) / rect.width) * 2 - 1;
+          const ny = -(((clientY - rect.top) / rect.height) * 2 - 1);
+          pointer.set(nx, ny);
+          const currentCamera = activeRenderCameraRef.current ?? camera;
+          ray.setFromCamera(pointer, currentCamera);
+          const intersects = ray.intersectObjects(cueInteractiveMeshes, true);
+          if (intersects.length === 0) return false;
+          let hit = intersects[0].object;
+          let styleId = hit.userData?.cueStyleId;
+          while (!styleId && hit.parent) {
+            hit = hit.parent;
+            styleId = hit.userData?.cueStyleId;
+          }
+          if (!styleId) return false;
+          updateCueDisplaySelection(styleId);
+          cueGalleryControlsRef.current.setSelection?.(styleId);
+          setPendingCueStyleId(styleId);
+          return true;
+        };
         const attemptChalkPress = (ev) => {
+          if (cueGalleryOpenRef.current) return false;
           const meshes = chalkMeshesRef.current;
           if (!meshes || meshes.length === 0) return false;
           if (ev.touches?.length && ev.touches.length > 1) return false;
@@ -7483,6 +7734,10 @@ function SnookerGame() {
         };
         const down = (e) => {
           registerInteraction();
+          if (cueGalleryOpenRef.current) {
+            attemptCueSelect(e);
+            return;
+          }
           if (attemptChalkPress(e)) return;
           const currentHud = hudRef.current;
           if (currentHud?.turn === 1 || currentHud?.inHand || shooting) return;
@@ -7494,6 +7749,7 @@ function SnookerGame() {
           drag.y = e.clientY || e.touches?.[0]?.clientY || 0;
         };
         const move = (e) => {
+          if (cueGalleryOpenRef.current) return;
           if (topViewRef.current || !drag.on) return;
           const currentHud = hudRef.current;
           if (currentHud?.turn === 1) return;
@@ -7684,6 +7940,7 @@ function SnookerGame() {
       sph.radius = clampOrbitRadius(sph.radius);
       worldScaleFactor = WORLD_SCALE;
       world.scale.setScalar(worldScaleFactor);
+      worldScaleRef.current = worldScaleFactor;
       if (broadcastCamerasRef.current) {
         const rig = broadcastCamerasRef.current;
         const focusWorld = rig.defaultFocus
@@ -7842,9 +8099,15 @@ function SnookerGame() {
         length: cueLen
       };
 
+      const initialCueStyle =
+        getCueStyleById(activeCueStyleRef.current, SNOOKER_CUE_STYLES) ??
+        SNOOKER_CUE_STYLES[0];
       const shaftMaterial = new THREE.MeshPhysicalMaterial({
-        color: 0xdeb887,
-        roughness: 0.6
+        color: initialCueStyle.woodColor,
+        roughness: 0.6,
+        metalness: 0.1,
+        clearcoat: 0.7,
+        clearcoatRoughness: 0.15
       });
       const frontLength = THREE.MathUtils.clamp(
         cueLen * CUE_FRONT_SECTION_RATIO,
@@ -7884,48 +8147,21 @@ function SnookerGame() {
         tipGroup.add(frontShaft);
       }
 
-      // subtle leather-like texture for the tip
-      const tipCanvas = document.createElement('canvas');
-      tipCanvas.width = tipCanvas.height = 64;
-      const tipCtx = tipCanvas.getContext('2d');
-      tipCtx.fillStyle = '#1b3f75';
-      tipCtx.fillRect(0, 0, 64, 64);
-      tipCtx.strokeStyle = 'rgba(255,255,255,0.08)';
-      tipCtx.lineWidth = 2;
-      for (let i = 0; i < 64; i += 8) {
-        tipCtx.beginPath();
-        tipCtx.moveTo(i, 0);
-        tipCtx.lineTo(i, 64);
-        tipCtx.stroke();
-      }
-      tipCtx.globalAlpha = 0.2;
-      tipCtx.fillStyle = 'rgba(12, 24, 60, 0.65)';
-      for (let i = 0; i < 80; i++) {
-        const x = Math.random() * 64;
-        const y = Math.random() * 64;
-        const w = 6 + Math.random() * 10;
-        const h = 2 + Math.random() * 4;
-        tipCtx.beginPath();
-        tipCtx.ellipse(x, y, w, h, Math.random() * Math.PI, 0, Math.PI * 2);
-        tipCtx.fill();
-      }
-      tipCtx.globalAlpha = 1;
-      const tipTex = new THREE.CanvasTexture(tipCanvas);
-
       const connectorHeight = 0.015 * SCALE;
       const tipRadius = CUE_TIP_RADIUS;
       const tipLen = 0.015 * SCALE * 1.5;
       const tipCylinderLen = Math.max(0, tipLen - tipRadius * 2);
+      const tipMaterial = new THREE.MeshStandardMaterial({
+        color: initialCueStyle.tipColor ?? 0xffffff,
+        roughness: 1,
+        metalness: 0,
+        map: getCueTipTexture(initialCueStyle.tipTextureColor)
+      });
       const tip = new THREE.Mesh(
         tipCylinderLen > 0
           ? new THREE.CapsuleGeometry(tipRadius, tipCylinderLen, 8, 16)
           : new THREE.SphereGeometry(tipRadius, 16, 16),
-        new THREE.MeshStandardMaterial({
-          color: 0x1f3f73,
-          roughness: 1,
-          metalness: 0,
-          map: tipTex
-        })
+        tipMaterial
       );
       tip.rotation.x = -Math.PI / 2;
       tip.position.z = -(tipCylinderLen / 2 + tipRadius + connectorHeight);
@@ -7939,7 +8175,7 @@ function SnookerGame() {
           32
         ),
         new THREE.MeshPhysicalMaterial({
-          color: 0xcd7f32,
+          color: initialCueStyle.jointColor ?? 0xcd7f32,
           metalness: 0.8,
           roughness: 0.5
         })
@@ -7955,7 +8191,9 @@ function SnookerGame() {
       buttCap.position.z = cueLen / 2;
       cueBody.add(buttCap);
 
-      const stripeMat = new THREE.MeshBasicMaterial({ color: 0x000000 });
+      const stripeMat = new THREE.MeshBasicMaterial({
+        color: initialCueStyle.accentColor ?? 0x222222
+      });
       for (let i = 0; i < 12; i++) {
         const stripe = new THREE.Mesh(
           new THREE.BoxGeometry(0.01 * SCALE, 0.001 * SCALE, 0.35 * SCALE),
@@ -7968,6 +8206,31 @@ function SnookerGame() {
         stripe.rotation.z = angle;
         cueBody.add(stripe);
       }
+
+      const connectorMaterial = connector.material;
+      cueAssetsRef.current = {
+        shaftMaterial,
+        tipMaterial,
+        connectorMaterial,
+        tipCapMaterial: tipMaterial,
+        accentMaterial: stripeMat
+      };
+      const applyCueStyle = (styleId) => {
+        const style =
+          getCueStyleById(styleId, SNOOKER_CUE_STYLES) ?? initialCueStyle;
+        const assets = cueAssetsRef.current;
+        if (!assets) return;
+        assets.shaftMaterial?.color?.set(style.woodColor);
+        if (assets.tipMaterial) {
+          assets.tipMaterial.color.set(style.tipColor ?? 0xffffff);
+          assets.tipMaterial.map = getCueTipTexture(style.tipTextureColor);
+          assets.tipMaterial.needsUpdate = true;
+        }
+        assets.connectorMaterial?.color?.set(style.jointColor ?? 0xcd7f32);
+        assets.accentMaterial?.color?.set(style.accentColor ?? 0x222222);
+      };
+      applyCueStyleRef.current = applyCueStyle;
+      applyCueStyle(initialCueStyle.id);
 
       cueStick.position.set(cue.pos.x, CUE_Y, cue.pos.y + 1.2 * SCALE);
       applyCueButtTilt(cueStick);
@@ -9781,6 +10044,17 @@ function SnookerGame() {
           window.removeEventListener('pointerup', endInHandDrag);
           dom.removeEventListener('pointercancel', endInHandDrag);
           window.removeEventListener('pointercancel', endInHandDrag);
+          cueGalleryControlsRef.current = {
+            focus: () => false,
+            restore: () => {},
+            setSelection: () => {},
+            interactives: []
+          };
+          updateCueDisplaySelectionRef.current = () => {};
+          applyCueStyleRef.current = () => {};
+          worldScaleRef.current = 1;
+          cueGalleryState.lastOrbit = null;
+          cueGalleryState.lastFocus = null;
           applyFinishRef.current = () => {};
           chalkMeshesRef.current = [];
           chalkAreaRef.current = null;
@@ -10216,14 +10490,27 @@ function SnookerGame() {
         </div>
       )}
       {/* Power Slider */}
-      <div className="absolute right-3 top-1/2 -translate-y-1/2">
+      <div className="absolute right-3 top-1/2 -translate-y-1/2 flex flex-col items-end gap-3 pointer-events-none">
         <div
           ref={sliderRef}
+          className="pointer-events-auto"
           style={{
             transform: `scale(${UI_SCALE})`,
             transformOrigin: 'top right'
           }}
         />
+        <button
+          type="button"
+          onClick={handleCueGalleryOpen}
+          disabled={cueGalleryOpen}
+          className={`pointer-events-auto rounded-full px-4 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] shadow-lg transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 ${
+            cueGalleryOpen
+              ? 'border border-emerald-400/70 bg-emerald-500/20 text-emerald-200'
+              : 'border border-white/30 bg-black/70 text-white/80 hover:border-emerald-400 hover:text-white'
+          }`}
+        >
+          Cue
+        </button>
       </div>
 
       {/* Spin controller */}
@@ -10250,6 +10537,65 @@ function SnookerGame() {
           ></div>
         </div>
       </div>
+      {cueGalleryOpen && (
+        <div className="absolute inset-0 z-[75] flex flex-col items-center justify-end pb-24 pointer-events-none">
+          <div className="pointer-events-auto w-[88%] max-w-sm rounded-3xl border border-white/15 bg-black/85 p-6 text-white shadow-[0_18px_48px_rgba(0,0,0,0.65)] backdrop-blur">
+            <div className="mb-4 text-center">
+              <h2 className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                Change Cue Stick
+              </h2>
+              <p className="mt-2 text-[11px] text-white/70">
+                Focused on the cue display. Tap a cue or select below, then confirm.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              {SNOOKER_CUE_STYLES.map((style) => {
+                const selected = pendingCueStyleId === style.id;
+                const woodHex = `#${style.woodColor.toString(16).padStart(6, '0')}`;
+                const accentHex = `#${(style.accentColor ?? 0x222222)
+                  .toString(16)
+                  .padStart(6, '0')}`;
+                return (
+                  <button
+                    key={style.id}
+                    type="button"
+                    onClick={() => handleCueStyleSelect(style.id)}
+                    className={`flex items-center gap-3 rounded-2xl border px-3 py-2 text-left text-xs font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 ${
+                      selected
+                        ? 'border-emerald-400 bg-emerald-400/15 text-white'
+                        : 'border-white/20 bg-white/5 text-white/75 hover:border-emerald-300 hover:text-white'
+                    }`}
+                  >
+                    <span
+                      className="h-8 w-2 rounded-full"
+                      style={{
+                        background: `linear-gradient(180deg, ${woodHex}, ${accentHex})`
+                      }}
+                    ></span>
+                    <span>{style.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+            <div className="mt-6 flex justify-between gap-3">
+              <button
+                type="button"
+                onClick={handleCueGalleryCancel}
+                className="flex-1 rounded-full border border-white/30 px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-white/70 transition hover:border-white/60 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleCueGalleryConfirm}
+                className="flex-1 rounded-full border border-emerald-400/70 bg-emerald-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-emerald-200 transition hover:border-emerald-300 hover:bg-emerald-400/25 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+              >
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/webapp/src/three/createCueDisplayFrame.js
+++ b/webapp/src/three/createCueDisplayFrame.js
@@ -1,0 +1,296 @@
+import * as THREE from 'three';
+
+const BASE_CUE_LENGTH = 2.5;
+const BASE_TIP_RADIUS = 0.007;
+const BASE_BUTT_RADIUS = 0.028;
+const BASE_SHAFT_RATIO = 0.74;
+const FRAME_WIDTH = 6;
+const FRAME_HEIGHT = 3;
+const FRAME_DEPTH = 0.15;
+const CLOTH_WIDTH = 5.6;
+const CLOTH_HEIGHT = 2.6;
+const CLOTH_OFFSET = 0.081;
+const CUE_Y = 1.17;
+const CUE_Z = 0.09;
+const INNER_WIDTH = 5.2;
+
+const tipTextureCache = new Map();
+
+const toHex = (value) => {
+  if (typeof value === 'number') {
+    return `#${value.toString(16).padStart(6, '0')}`;
+  }
+  return value;
+};
+
+export const getCueTipTexture = (color = '#1b3f75') => {
+  const key = toHex(color).toLowerCase();
+  if (tipTextureCache.has(key)) {
+    return tipTextureCache.get(key);
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = 64;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = key;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.strokeStyle = 'rgba(255,255,255,0.08)';
+  ctx.lineWidth = 2;
+  for (let i = 0; i < canvas.width; i += 8) {
+    ctx.beginPath();
+    ctx.moveTo(i, 0);
+    ctx.lineTo(i, canvas.height);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 0.18;
+  ctx.fillStyle = 'rgba(12, 24, 60, 0.65)';
+  for (let i = 0; i < 80; i += 1) {
+    const x = Math.random() * canvas.width;
+    const y = Math.random() * canvas.height;
+    const w = 6 + Math.random() * 10;
+    const h = 2 + Math.random() * 4;
+    ctx.beginPath();
+    ctx.ellipse(x, y, w, h, Math.random() * Math.PI, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  tipTextureCache.set(key, texture);
+  return texture;
+};
+
+const defaultClothTexture = (colors) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = 512;
+  const ctx = canvas.getContext('2d');
+  const gradient = ctx.createLinearGradient(0, 0, canvas.width, canvas.height);
+  gradient.addColorStop(0, colors[0]);
+  gradient.addColorStop(1, colors[1]);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  return texture;
+};
+
+export function createCueDisplayFrame({
+  styles = [],
+  cueLength = BASE_CUE_LENGTH,
+  tipRadius = BASE_TIP_RADIUS,
+  buttRadius = BASE_BUTT_RADIUS,
+  frameColor = 0x6a4b2f,
+  clothColors = ['#4a0f19', '#821c2a']
+} = {}) {
+  const frameGroup = new THREE.Group();
+  frameGroup.name = 'CueDisplayFrame';
+
+  const frameMat = new THREE.MeshPhysicalMaterial({
+    color: frameColor,
+    roughness: 0.55,
+    metalness: 0.12,
+    clearcoat: 0.5
+  });
+  const frame = new THREE.Mesh(
+    new THREE.BoxGeometry(FRAME_WIDTH, FRAME_HEIGHT, FRAME_DEPTH),
+    frameMat
+  );
+  frame.castShadow = false;
+  frame.receiveShadow = true;
+  frameGroup.add(frame);
+
+  const clothMat = new THREE.MeshPhysicalMaterial({
+    map: defaultClothTexture(clothColors),
+    roughness: 0.75,
+    clearcoat: 0.5,
+    metalness: 0.05
+  });
+  const cloth = new THREE.Mesh(
+    new THREE.PlaneGeometry(CLOTH_WIDTH, CLOTH_HEIGHT),
+    clothMat
+  );
+  cloth.position.z = FRAME_DEPTH / 2 + CLOTH_OFFSET;
+  cloth.receiveShadow = false;
+  frameGroup.add(cloth);
+
+  const cueEntries = [];
+
+  const makeCue = (style, index) => {
+    const cueGroup = new THREE.Group();
+    cueGroup.name = `CueStyle_${style.id}`;
+    const shaftLength = cueLength * BASE_SHAFT_RATIO;
+    const buttLength = Math.max(cueLength - shaftLength, 0);
+
+    const woodMaterial = new THREE.MeshPhysicalMaterial({
+      color: style.woodColor,
+      roughness: 0.25,
+      metalness: 0.12,
+      clearcoat: 0.8,
+      clearcoatRoughness: 0.12
+    });
+
+    const shaft = new THREE.Mesh(
+      new THREE.CylinderGeometry(tipRadius, buttRadius * 0.86, shaftLength, 48, 1, false),
+      woodMaterial
+    );
+    shaft.rotation.x = Math.PI / 2;
+    shaft.position.z = -shaftLength / 2;
+    cueGroup.add(shaft);
+
+    const jointMaterial = new THREE.MeshPhysicalMaterial({
+      color: style.jointColor ?? 0xcd7f32,
+      metalness: 1,
+      roughness: 0.25,
+      clearcoat: 0.8
+    });
+    const joint = new THREE.Mesh(
+      new THREE.CylinderGeometry(buttRadius * 0.9, buttRadius * 0.9, 0.04, 48),
+      jointMaterial
+    );
+    joint.rotation.x = Math.PI / 2;
+    joint.position.z = -shaftLength * 0.74;
+    cueGroup.add(joint);
+
+    const tipMaterial = new THREE.MeshStandardMaterial({
+      color: style.tipColor ?? 0xffffff,
+      roughness: 1,
+      metalness: 0,
+      map: getCueTipTexture(style.tipTextureColor)
+    });
+
+    const whiteTip = new THREE.Mesh(
+      new THREE.CylinderGeometry(tipRadius, tipRadius, 0.02, 32),
+      new THREE.MeshStandardMaterial({
+        color: style.tipColor ?? 0xffffff,
+        roughness: 0.6,
+        metalness: 0.05
+      })
+    );
+    whiteTip.rotation.x = Math.PI / 2;
+    whiteTip.position.z = 0.01;
+    cueGroup.add(whiteTip);
+
+    const tipCapMaterial = new THREE.MeshPhysicalMaterial({
+      color: style.tipCapColor ?? style.tipColor ?? 0xffffff,
+      roughness: 0.35,
+      metalness: 0.3,
+      clearcoat: 1
+    });
+    const tipCap = new THREE.Mesh(
+      new THREE.SphereGeometry(tipRadius * 1.15, 32, 16, 0, Math.PI * 2, 0, Math.PI / 2),
+      tipCapMaterial
+    );
+    tipCap.rotation.x = Math.PI / 2;
+    tipCap.position.z = 0.018;
+    cueGroup.add(tipCap);
+
+    const tip = new THREE.Mesh(
+      new THREE.CylinderGeometry(tipRadius * 1.02, tipRadius * 1.02, 0.018, 32),
+      tipMaterial
+    );
+    tip.rotation.x = Math.PI / 2;
+    tip.position.z = -0.01;
+    cueGroup.add(tip);
+
+    const butt = new THREE.Mesh(
+      new THREE.CylinderGeometry(buttRadius * 0.86, buttRadius, buttLength, 48, 1, false),
+      woodMaterial
+    );
+    butt.rotation.x = Math.PI / 2;
+    butt.position.z = -(shaftLength + buttLength / 2);
+    cueGroup.add(butt);
+
+    const accentMaterial = new THREE.MeshStandardMaterial({
+      color: style.accentColor ?? 0x222222,
+      roughness: 0.5,
+      metalness: 0.35
+    });
+    const accent = new THREE.Mesh(
+      new THREE.TorusKnotGeometry(buttRadius * 0.7, 0.0025, 64, 8, 2 + index, 3),
+      accentMaterial
+    );
+    accent.rotation.x = Math.PI / 2;
+    accent.position.z = -(shaftLength + buttLength * 0.5);
+    cueGroup.add(accent);
+
+    const buttCap = new THREE.Mesh(
+      new THREE.SphereGeometry(buttRadius * 1.1, 32, 16),
+      new THREE.MeshPhysicalMaterial({
+        color: 0x050505,
+        roughness: 0.35,
+        metalness: 0.6,
+        clearcoat: 0.9
+      })
+    );
+    buttCap.rotation.x = Math.PI / 2;
+    buttCap.position.z = -(shaftLength + buttLength);
+    cueGroup.add(buttCap);
+
+    cueGroup.rotation.x = -Math.PI / 2;
+
+    cueGroup.traverse((child) => {
+      if (child.isMesh) {
+        child.userData.cueStyleId = style.id;
+        child.userData.isCueDisplay = true;
+      }
+    });
+
+    cueEntries.push({
+      group: cueGroup,
+      style,
+      woodMaterial,
+      accentMaterial
+    });
+
+    return cueGroup;
+  };
+
+  const count = styles.length;
+  if (count === 0) {
+    return {
+      group: frameGroup,
+      setSelected: () => {},
+      interactiveObjects: [],
+      getBoundingBox: () => new THREE.Box3().setFromObject(frameGroup)
+    };
+  }
+
+  const startX = count > 1 ? -INNER_WIDTH / 2 : 0;
+  const step = count > 1 ? INNER_WIDTH / (count - 1) : 0;
+
+  styles.forEach((style, index) => {
+    const cue = makeCue(style, index);
+    cue.position.set(count > 1 ? startX + index * step : 0, CUE_Y, CUE_Z);
+    frameGroup.add(cue);
+  });
+
+  const scale = cueLength / BASE_CUE_LENGTH;
+  frameGroup.scale.setScalar(scale);
+
+  const selectedEmissive = new THREE.Color(0xf59e0b);
+  const setSelected = (styleId) => {
+    cueEntries.forEach((entry) => {
+      const active = entry.style.id === styleId;
+      entry.woodMaterial.emissive = active
+        ? selectedEmissive
+        : new THREE.Color(0x000000);
+      entry.woodMaterial.emissiveIntensity = active ? 0.4 : 0;
+      entry.accentMaterial.emissive = active
+        ? selectedEmissive
+        : new THREE.Color(0x000000);
+      entry.accentMaterial.emissiveIntensity = active ? 0.6 : 0;
+    });
+  };
+
+  const getBoundingBox = () => {
+    frameGroup.updateWorldMatrix(true, true);
+    const box = new THREE.Box3();
+    return box.setFromObject(frameGroup);
+  };
+
+  return {
+    group: frameGroup,
+    setSelected,
+    interactiveObjects: cueEntries.map((entry) => entry.group),
+    getBoundingBox
+  };
+}


### PR DESCRIPTION
## Summary
- introduce shared cue style definitions and a reusable cue display frame helper for in-arena galleries
- wire Snooker to the cue gallery system with camera focus/restore helpers, style-driven cue materials, and a cue button plus selection overlay
- extend Pool Royale with the same gallery experience, including reduced-length cues, material swapping, camera integration, pointer guards, and matching UI controls

## Testing
- npx eslint webapp/src/pages/Games/PoolRoyale.jsx *(warnings: file ignored by project eslint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b8443b20832989e0d3706787c0c6