### PR TITLE
Add interactive cue galleries to 3D pool modes

### DIFF
--- a/webapp/src/constants/cueStyles.js
+++ b/webapp/src/constants/cueStyles.js
@@ -1,0 +1,72 @@
+export const CUE_STYLE_PRESETS = [
+  {
+    id: 'heritage-maple',
+    name: 'Heritage Maple',
+    shaftColor: 0xdeb887,
+    stripeColor: 0x1f2937,
+    connectorColor: 0xcd7f32,
+    buttColor: 0x111111,
+    tipColor: 0x1b3f75,
+    rackShaftColor: 0xcaa472,
+    rackAccentColor: 0x1f2937
+  },
+  {
+    id: 'midnight-onyx',
+    name: 'Midnight Onyx',
+    shaftColor: 0x2b3542,
+    stripeColor: 0x38bdf8,
+    connectorColor: 0x94a3b8,
+    buttColor: 0x0f172a,
+    tipColor: 0x1d4ed8,
+    rackShaftColor: 0x3b4758,
+    rackAccentColor: 0x38bdf8
+  },
+  {
+    id: 'arctic-ice',
+    name: 'Arctic Ice',
+    shaftColor: 0xe2e8f0,
+    stripeColor: 0x2563eb,
+    connectorColor: 0x94a3b8,
+    buttColor: 0x1f2937,
+    tipColor: 0x2563eb,
+    rackShaftColor: 0xcbd5f5,
+    rackAccentColor: 0x2563eb
+  },
+  {
+    id: 'ember-flame',
+    name: 'Ember Flame',
+    shaftColor: 0x7c2d12,
+    stripeColor: 0xf97316,
+    connectorColor: 0xf59e0b,
+    buttColor: 0x1b1b1b,
+    tipColor: 0xf97316,
+    rackShaftColor: 0x9a3412,
+    rackAccentColor: 0xf97316
+  },
+  {
+    id: 'forest-guardian',
+    name: 'Forest Guardian',
+    shaftColor: 0x14532d,
+    stripeColor: 0x10b981,
+    connectorColor: 0x22c55e,
+    buttColor: 0x052e16,
+    tipColor: 0x0d9488,
+    rackShaftColor: 0x1c7c42,
+    rackAccentColor: 0x10b981
+  },
+  {
+    id: 'royal-indigo',
+    name: 'Royal Indigo',
+    shaftColor: 0x312e81,
+    stripeColor: 0xa855f7,
+    connectorColor: 0x7c3aed,
+    buttColor: 0x1e1b4b,
+    tipColor: 0x6366f1,
+    rackShaftColor: 0x4338ca,
+    rackAccentColor: 0xa855f7
+  }
+];
+
+export function getCueStyleById(id) {
+  return CUE_STYLE_PRESETS.find((style) => style.id === id) ?? CUE_STYLE_PRESETS[0];
+}

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22,6 +22,7 @@ import { useIsMobile } from '../../hooks/useIsMobile.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { getBallMaterial as getBilliardBallMaterial } from '../../utils/ballMaterialFactory.js';
 import { createCueRackDisplay } from '../../utils/createCueRackDisplay.js';
+import { CUE_STYLE_PRESETS, getCueStyleById } from '../../constants/cueStyles.js';
 
 function signedRingArea(ring) {
   let area = 0;
@@ -4729,6 +4730,29 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
     () => CLOTH_COLOR_OPTIONS.find((opt) => opt.id === clothColorId) ?? CLOTH_COLOR_OPTIONS[0],
     [clothColorId]
   );
+  const cueStyles = useMemo(() => CUE_STYLE_PRESETS, []);
+  const [cueStyleId, setCueStyleId] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem('poolRoyaleCueStyle');
+      if (stored && cueStyles.some((style) => style.id === stored)) {
+        return stored;
+      }
+    }
+    return cueStyles[0]?.id ?? 'heritage-maple';
+  });
+  const cueStyleRef = useRef(cueStyleId);
+  const applyCueStyleRef = useRef(() => {});
+  const updateRackHighlightRef = useRef(() => {});
+  const cueGalleryRef = useRef({
+    active: false,
+    entries: [],
+    entry: null,
+    selection: cueStyleId,
+    smoothedPos: null,
+    smoothedTarget: null,
+    lastUpdate: null,
+    previous: null
+  });
   const [configOpen, setConfigOpen] = useState(false);
   const configPanelRef = useRef(null);
   const configButtonRef = useRef(null);
@@ -4739,6 +4763,20 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   const chalkAssistEnabledRef = useRef(false);
   const chalkAssistTargetRef = useRef(false);
   const visibleChalkIndexRef = useRef(null);
+
+  useEffect(() => {
+    cueStyleRef.current = cueStyleId;
+    const state = cueGalleryRef.current;
+    if (state) state.selection = cueStyleId;
+    applyCueStyleRef.current?.(cueStyleId);
+    updateRackHighlightRef.current?.(cueStyleId);
+  }, [cueStyleId]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('poolRoyaleCueStyle', cueStyleId);
+    }
+  }, [cueStyleId]);
 
   const highlightChalks = useCallback(
     (activeIndex, suggestedIndex = visibleChalkIndexRef.current) => {
@@ -5609,6 +5647,15 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       scene.background = new THREE.Color(0x050505);
       const world = new THREE.Group();
       scene.add(world);
+      const cueGalleryState = cueGalleryRef.current;
+      cueGalleryState.active = false;
+      cueGalleryState.entries = [];
+      cueGalleryState.entry = null;
+      cueGalleryState.smoothedPos = null;
+      cueGalleryState.smoothedTarget = null;
+      cueGalleryState.lastUpdate = null;
+      cueGalleryState.previous = null;
+      cueGalleryState.selection = cueStyleRef.current;
       let worldScaleFactor = 1;
       let cue;
       let clothMat;
@@ -6098,6 +6145,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       const backInterior = roomDepth / 2 - wallInset;
       const leftInterior = -roomWidth / 2 + wallInset;
       const rightInterior = roomWidth / 2 - wallInset;
+      const billboardSignage = [];
       [
         { position: [0, signageY, frontInterior], rotationY: 0, type: 'tv' },
         { position: [0, signageY, backInterior], rotationY: Math.PI, type: 'tv' },
@@ -6116,6 +6164,17 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           type === 'tv' ? createMatchTvAssembly() : createBillboardAssembly();
         signage.position.set(position[0], position[1], position[2]);
         signage.rotation.y = rotationY;
+        if (type === 'billboard') {
+          signage.userData = signage.userData || {};
+          signage.userData.isCueBillboard = true;
+          signage.userData.billboardRoot = signage;
+          signage.traverse((child) => {
+            child.userData = child.userData || {};
+            child.userData.billboardRoot = signage;
+            child.userData.isCueBillboard = true;
+          });
+          billboardSignage.push(signage);
+        }
         world.add(signage);
       });
 
@@ -6124,29 +6183,96 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           THREE,
           ballRadius: BALL_R,
           cueLengthMultiplier: CUE_LENGTH_MULTIPLIER,
-          cueTipRadius: CUE_TIP_RADIUS
+          cueTipRadius: CUE_TIP_RADIUS,
+          cueStyles
         });
       const cueRackHalfWidth = cueRackDimensions.width / 2;
-      const availableHalfDepth =
-        roomDepth / 2 - wallThickness - cueRackHalfWidth - BALL_R * 2;
-      const desiredSpacing =
-        signageWidth / 2 + cueRackHalfWidth + BALL_R * 6;
-      const cueRackSpacing = Math.max(
-        cueRackHalfWidth,
-        Math.min(availableHalfDepth, desiredSpacing)
-      );
+      const cueRackDepthHalf = cueRackDimensions.depth / 2;
       const cueRackY = signageY;
-      [
-        { x: leftInterior, z: -cueRackSpacing, rotationY: Math.PI / 2 },
-        { x: leftInterior, z: cueRackSpacing, rotationY: Math.PI / 2 },
-        { x: rightInterior, z: -cueRackSpacing, rotationY: -Math.PI / 2 },
-        { x: rightInterior, z: cueRackSpacing, rotationY: -Math.PI / 2 }
-      ].forEach((placement, index) => {
-        const rack = index === 0 ? cueRackPrototype : cueRackPrototype.clone();
-        rack.position.set(placement.x, cueRackY, placement.z);
-        rack.rotation.y = placement.rotationY;
+
+      billboardSignage.forEach((signage, index) => {
+        const rack = index === 0 ? cueRackPrototype : cueRackPrototype.clone(true);
+        const face = new THREE.Vector3(0, 0, 1)
+          .applyQuaternion(signage.quaternion)
+          .setY(0);
+        if (face.lengthSq() < 1e-6) face.set(0, 0, 1);
+        face.normalize();
+        const right = new THREE.Vector3(1, 0, 0)
+          .applyQuaternion(signage.quaternion)
+          .setY(0);
+        if (right.lengthSq() < 1e-6) right.set(0, 0, 1);
+        right.normalize();
+        const lateralTarget = signageWidth / 2 + cueRackHalfWidth + BALL_R * 6;
+        const maxLateral =
+          roomDepth / 2 - wallThickness - cueRackHalfWidth - BALL_R * 2;
+        const lateral = Math.min(maxLateral, lateralTarget);
+        const rackPos = signage.position
+          .clone()
+          .add(right.clone().multiplyScalar(lateral));
+        rack.position.set(rackPos.x, cueRackY, rackPos.z);
+        rack.rotation.y = signage.rotation.y;
         world.add(rack);
+
+        const cueGroups = [];
+        rack.traverse((child) => {
+          if (child.isGroup && child.userData?.cueStyleId) {
+            cueGroups.push(child);
+          }
+        });
+
+        const focusTarget = rack.position
+          .clone()
+          .add(face.clone().multiplyScalar(cueRackDepthHalf + 0.2));
+        focusTarget.y = cueRackY;
+        const viewDistance = cueRackDimensions.depth * 6 + BALL_R * 60;
+        const cameraHeightOffset = cueRackDimensions.height * 0.45;
+        const viewPosition = focusTarget
+          .clone()
+          .add(face.clone().multiplyScalar(viewDistance))
+          .add(new THREE.Vector3(0, cameraHeightOffset, 0));
+
+        cueGalleryState.entries.push({
+          signage,
+          rack,
+          cueGroups,
+          face,
+          right,
+          focusTarget,
+          viewPosition
+        });
       });
+
+      const updateRackHighlight = (styleId) => {
+        const state = cueGalleryRef.current;
+        if (!state?.entries) return;
+        state.entries.forEach((entry) => {
+          entry.cueGroups.forEach((group) => {
+            const baseY = group.userData?.baseY ?? group.position.y;
+            const lift = group.userData?.highlightLift ?? 0;
+            const isActive = group.userData?.cueStyleId === styleId;
+            group.position.y = isActive ? baseY + lift : baseY;
+            const mats = group.userData?.highlightMaterials;
+            if (Array.isArray(mats)) {
+              mats.forEach((mat) => {
+                if (!mat) return;
+                if (mat.emissive == null) {
+                  mat.emissive = new THREE.Color(0x000000);
+                }
+                mat.emissiveIntensity = isActive ? 0.32 : 0.08;
+                if (isActive && group.userData?.highlightEmissiveColor != null) {
+                  mat.emissive.setHex(group.userData.highlightEmissiveColor);
+                } else if (!isActive) {
+                  mat.emissive.setHex(0x000000);
+                }
+                mat.needsUpdate = true;
+              });
+            }
+          });
+        });
+      };
+
+      updateRackHighlightRef.current = updateRackHighlight;
+      updateRackHighlight(cueStyleRef.current);
 
       const broadcastClearance = wallThickness * 1.1 + BALL_R * 4;
       const shortRailTarget = Math.max(
@@ -6723,21 +6849,24 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         } = {}) => {
           const rig = broadcastCamerasRef.current;
           if (!rig || !rig.cameras) return;
+          const limit = rig.slideLimit ?? CAMERA_LATERAL_CLAMP.short;
           const lerpFactor = THREE.MathUtils.clamp(lerp ?? 0, 0, 1);
           const focusTarget =
-            focusWorld ??
-            targetWorld ??
-            rig.defaultFocusWorld ??
-            rig.defaultFocus ??
-            null;
-          const applyFocus = (unit, lookAt, t) => {
+            focusWorld ?? rig.defaultFocusWorld ?? rig.defaultFocus ?? null;
+          const clampX = (value) =>
+            THREE.MathUtils.clamp(value, -limit, limit);
+          const scale = Math.max(worldScaleFactor ?? 1, 1e-6);
+          const nextX =
+            targetWorld && Number.isFinite(targetWorld.x)
+              ? clampX(targetWorld.x / scale)
+              : 0;
+          const applyFocus = (unit, target, t, lookAt) => {
             if (!unit) return;
             if (unit.slider) {
-              const settle = Math.max(THREE.MathUtils.clamp(t ?? 0, 0, 1), 0.5);
               unit.slider.position.x = THREE.MathUtils.lerp(
                 unit.slider.position.x,
-                0,
-                settle
+                target,
+                t
               );
             }
             if (lookAt && unit.head) {
@@ -6755,11 +6884,11 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           const activeUnits = railDir >= 0 ? backUnits : frontUnits;
           const idleUnits = railDir >= 0 ? frontUnits : backUnits;
           activeUnits.forEach((unit) =>
-            applyFocus(unit, focusTarget, lerpFactor)
+            applyFocus(unit, nextX, lerpFactor, focusTarget)
           );
           const idleFocus = rig.defaultFocusWorld ?? focusTarget;
           idleUnits.forEach((unit) =>
-            applyFocus(unit, idleFocus, Math.min(1, lerpFactor * 0.6))
+            applyFocus(unit, 0, Math.min(1, lerpFactor * 0.6), idleFocus)
           );
         };
 
@@ -6772,6 +6901,37 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             focusWorld: broadcastCamerasRef.current?.defaultFocusWorld ?? null,
             lerp: 0.18
           };
+          const galleryState = cueGalleryRef.current;
+          if (galleryState?.active && galleryState.entry) {
+            const now = performance.now();
+            const last = galleryState.lastUpdate ?? now;
+            const dt = Math.min(0.25, Math.max(0, (now - last) / 1000));
+            galleryState.lastUpdate = now;
+            const smooth = 1 - Math.exp(-dt / 0.22);
+            const desiredTarget = galleryState.entry.focusTarget
+              .clone()
+              .multiplyScalar(worldScaleFactor);
+            const desiredPos = galleryState.entry.viewPosition
+              .clone()
+              .multiplyScalar(worldScaleFactor);
+            if (!galleryState.smoothedPos) {
+              galleryState.smoothedPos = desiredPos.clone();
+            }
+            if (!galleryState.smoothedTarget) {
+              galleryState.smoothedTarget = desiredTarget.clone();
+            }
+            galleryState.smoothedPos.lerp(desiredPos, smooth);
+            galleryState.smoothedTarget.lerp(desiredTarget, smooth);
+            camera.position.copy(galleryState.smoothedPos);
+            camera.lookAt(galleryState.smoothedTarget);
+            lastCameraTargetRef.current.copy(galleryState.smoothedTarget);
+            renderCamera = camera;
+            broadcastArgs.focusWorld = galleryState.smoothedTarget.clone();
+            broadcastArgs.targetWorld = galleryState.smoothedTarget.clone();
+            broadcastArgs.lerp = 0.12;
+            updateBroadcastCameras(broadcastArgs);
+            return renderCamera;
+          }
           if (topViewRef.current) {
             lookTarget = getDefaultOrbitTarget().multiplyScalar(
               worldScaleFactor
@@ -7783,7 +7943,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           spinAppliedRef.current = { ...result, magnitude, mode };
           return result;
         };
-        const drag = { on: false, x: 0, y: 0, moved: false };
+        const drag = { on: false, x: 0, y: 0, moved: false, skipUpFocus: false };
         let lastInteraction = performance.now();
         const registerInteraction = () => {
           lastInteraction = performance.now();
@@ -7822,6 +7982,13 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         const down = (e) => {
           registerInteraction();
           if (attemptChalkPress(e)) return;
+          drag.skipUpFocus = false;
+          if (attemptCueGalleryInteraction(e)) {
+            drag.skipUpFocus = true;
+            e.preventDefault?.();
+            return;
+          }
+          if (cueGalleryRef.current?.active) return;
           const currentHud = hudRef.current;
           if (currentHud?.turn === 1 || currentHud?.inHand || shooting) return;
           if (e.touches?.length === 2) return;
@@ -7832,7 +7999,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           drag.y = e.clientY || e.touches?.[0]?.clientY || 0;
         };
         const move = (e) => {
-          if (topViewRef.current || !drag.on) return;
+          if (topViewRef.current || cueGalleryRef.current?.active || !drag.on) return;
           const currentHud = hudRef.current;
           if (currentHud?.turn === 1) return;
           const x = e.clientX || e.touches?.[0]?.clientX || drag.x;
@@ -7875,8 +8042,11 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           const moved = drag.moved;
           drag.on = false;
           drag.moved = false;
+          const skipFocus = drag.skipUpFocus;
+          drag.skipUpFocus = false;
           if (
             !moved &&
+            !skipFocus &&
             !topViewRef.current &&
             !(hudRef.current?.inHand ?? false) &&
             !shooting
@@ -7892,6 +8062,10 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         dom.addEventListener('touchmove', move, { passive: true });
         window.addEventListener('touchend', up);
         const keyRot = (e) => {
+          if (e.key === 'Escape' && cueGalleryRef.current?.active) {
+            exitCueGallery();
+            return;
+          }
           if (topViewRef.current) return;
           const currentHud = hudRef.current;
           if (currentHud?.turn === 1 || currentHud?.inHand || shooting) return;
@@ -8332,6 +8506,35 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         cueBody.add(stripe);
       }
 
+      const tipMaterial = tip.material;
+      const connectorMaterial = connector.material;
+      const buttCapMaterial = buttCap.material;
+
+      const applyCueStyle = (styleId) => {
+        const style = getCueStyleById(styleId);
+        if (!style) return;
+        const shaftColor = style.shaftColor ?? style.rackShaftColor ?? 0xdeb887;
+        shaftMaterial.color.setHex(shaftColor);
+        shaftMaterial.needsUpdate = true;
+        const connectorColor = style.connectorColor ?? 0xcd7f32;
+        connectorMaterial.color.setHex(connectorColor);
+        connectorMaterial.needsUpdate = true;
+        const buttColor = style.buttColor ?? 0x111111;
+        buttCapMaterial.color.setHex(buttColor);
+        buttCapMaterial.needsUpdate = true;
+        const stripeColor = style.stripeColor ?? style.rackAccentColor ?? 0x000000;
+        stripeMat.color.setHex(stripeColor);
+        stripeMat.needsUpdate = true;
+        if (style.tipColor != null) {
+          tipMaterial.color.setHex(style.tipColor);
+          tipMaterial.needsUpdate = true;
+        }
+        cueGalleryRef.current.selection = style.id;
+      };
+
+      applyCueStyleRef.current = applyCueStyle;
+      applyCueStyle(cueStyleRef.current);
+
       cueStick.position.set(cue.pos.x, CUE_Y, cue.pos.y + 1.2 * SCALE);
       applyCueButtTilt(cueStick);
       // thin side already faces the cue ball so no extra rotation
@@ -8352,6 +8555,116 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         new THREE.Vector3(0, 1, 0),
         -TABLE_Y * worldScaleFactor
       );
+
+      const exitCueGallery = (restore = true) => {
+        const state = cueGalleryRef.current;
+        if (!state?.active) return;
+        state.active = false;
+        state.entry = null;
+        state.smoothedPos = null;
+        state.smoothedTarget = null;
+        state.lastUpdate = null;
+        if (restore) {
+          const prev = state.previous;
+          if (prev) {
+            const store = ensureOrbitFocus();
+            store.ballId = prev.ballId;
+            store.target.copy(prev.target);
+            topViewRef.current = prev.topView;
+            sph.radius = clampOrbitRadius(prev.sph.radius);
+            sph.phi = prev.sph.phi;
+            sph.theta = prev.sph.theta;
+            cameraBlendRef.current = prev.cameraBlend;
+            if (prev.lastTarget) {
+              lastCameraTargetRef.current.copy(prev.lastTarget);
+            }
+            syncBlendToSpherical();
+          }
+          state.previous = null;
+          updateCamera();
+        } else {
+          state.previous = null;
+        }
+      };
+
+      const enterCueGallery = (entry) => {
+        if (!entry) return false;
+        const state = cueGalleryRef.current;
+        if (!state) return false;
+        if (state.active && state.entry === entry) return true;
+        const store = ensureOrbitFocus();
+        state.previous = {
+          topView: topViewRef.current,
+          ballId: store.ballId,
+          target: store.target.clone(),
+          sph: { radius: sph.radius, phi: sph.phi, theta: sph.theta },
+          cameraBlend: cameraBlendRef.current ?? 1,
+          lastTarget: lastCameraTargetRef.current?.clone()
+        };
+        topViewRef.current = false;
+        state.active = true;
+        state.entry = entry;
+        state.smoothedPos = camera.position.clone();
+        state.smoothedTarget = entry.focusTarget.clone().multiplyScalar(worldScaleFactor);
+        state.lastUpdate = performance.now();
+        cueGalleryRef.current.selection = cueStyleRef.current;
+        updateCamera();
+        return true;
+      };
+
+      const attemptCueGalleryInteraction = (ev) => {
+        const state = cueGalleryRef.current;
+        if (!state) return false;
+        if (state.entries.length === 0) return false;
+        const rect = dom.getBoundingClientRect();
+        const primaryTouch = ev?.changedTouches?.[0] ?? ev?.touches?.[0] ?? null;
+        const clientX = ev?.clientX ?? primaryTouch?.clientX;
+        const clientY = ev?.clientY ?? primaryTouch?.clientY;
+        if (clientX == null || clientY == null) return false;
+        if (
+          clientX < rect.left ||
+          clientX > rect.right ||
+          clientY < rect.top ||
+          clientY > rect.bottom
+        ) {
+          return false;
+        }
+        const nx = ((clientX - rect.left) / rect.width) * 2 - 1;
+        const ny = -(((clientY - rect.top) / rect.height) * 2 - 1);
+        pointer.set(nx, ny);
+        const currentCamera = activeRenderCameraRef.current ?? camera;
+        ray.setFromCamera(pointer, currentCamera);
+        if (state.active && state.entry) {
+          const intersects = ray.intersectObjects(state.entry.cueGroups, true);
+          if (intersects.length === 0) return false;
+          let hit = intersects[0].object;
+          while (hit && !hit.userData?.cueStyleId && hit.parent) {
+            hit = hit.parent;
+          }
+          const styleId = hit?.userData?.cueStyleId;
+          if (!styleId) return false;
+          setCueStyleId(styleId);
+          exitCueGallery();
+          return true;
+        }
+        const signageObjects = state.entries.map((item) => item.signage);
+        const intersects = ray.intersectObjects(signageObjects, true);
+        if (intersects.length === 0) return false;
+        let hit = intersects[0].object;
+        let signage = null;
+        while (hit) {
+          if (hit.userData?.billboardRoot) {
+            signage = hit.userData.billboardRoot;
+            break;
+          }
+          hit = hit.parent;
+        }
+        if (!signage) return false;
+        const entry = state.entries.find((item) => item.signage === signage);
+        if (!entry) return false;
+        return enterCueGallery(entry);
+      };
+
       project = (ev) => {
         const r = dom.getBoundingClientRect();
         const cx =
@@ -10135,6 +10448,13 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           activeRenderCameraRef.current = null;
           cueBodyRef.current = null;
           tipGroupRef.current = null;
+          cueGalleryRef.current.active = false;
+          cueGalleryRef.current.entries = [];
+          cueGalleryRef.current.entry = null;
+          cueGalleryRef.current.previous = null;
+          cueGalleryRef.current.smoothedPos = null;
+          cueGalleryRef.current.smoothedTarget = null;
+          cueGalleryRef.current.lastUpdate = null;
           try {
             host.removeChild(renderer.domElement);
           } catch {}

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -21,6 +21,7 @@ import { useIsMobile } from '../../hooks/useIsMobile.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { getBallMaterial as getBilliardBallMaterial } from '../../utils/ballMaterialFactory.js';
 import { createCueRackDisplay } from '../../utils/createCueRackDisplay.js';
+import { CUE_STYLE_PRESETS, getCueStyleById } from '../../constants/cueStyles.js';
 
 function signedRingArea(ring) {
   let area = 0;
@@ -4499,6 +4500,29 @@ function SnookerGame() {
     () => CLOTH_COLOR_OPTIONS.find((opt) => opt.id === clothColorId) ?? CLOTH_COLOR_OPTIONS[0],
     [clothColorId]
   );
+  const cueStyles = useMemo(() => CUE_STYLE_PRESETS, []);
+  const [cueStyleId, setCueStyleId] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem('snookerCueStyle');
+      if (stored && cueStyles.some((style) => style.id === stored)) {
+        return stored;
+      }
+    }
+    return cueStyles[0]?.id ?? 'heritage-maple';
+  });
+  const cueStyleRef = useRef(cueStyleId);
+  const applyCueStyleRef = useRef(() => {});
+  const updateRackHighlightRef = useRef(() => {});
+  const cueGalleryRef = useRef({
+    active: false,
+    entries: [],
+    entry: null,
+    selection: cueStyleId,
+    smoothedPos: null,
+    smoothedTarget: null,
+    lastUpdate: null,
+    previous: null
+  });
   const [configOpen, setConfigOpen] = useState(false);
   const configPanelRef = useRef(null);
   const configButtonRef = useRef(null);
@@ -4509,6 +4533,20 @@ function SnookerGame() {
   const chalkAssistEnabledRef = useRef(false);
   const chalkAssistTargetRef = useRef(false);
   const visibleChalkIndexRef = useRef(null);
+
+  useEffect(() => {
+    cueStyleRef.current = cueStyleId;
+    const state = cueGalleryRef.current;
+    if (state) state.selection = cueStyleId;
+    applyCueStyleRef.current?.(cueStyleId);
+    updateRackHighlightRef.current?.(cueStyleId);
+  }, [cueStyleId]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('snookerCueStyle', cueStyleId);
+    }
+  }, [cueStyleId]);
 
   const highlightChalks = useCallback(
     (activeIndex, suggestedIndex = visibleChalkIndexRef.current) => {
@@ -5371,6 +5409,15 @@ function SnookerGame() {
       scene.background = new THREE.Color(0x050505);
       const world = new THREE.Group();
       scene.add(world);
+      const cueGalleryState = cueGalleryRef.current;
+      cueGalleryState.active = false;
+      cueGalleryState.entries = [];
+      cueGalleryState.entry = null;
+      cueGalleryState.smoothedPos = null;
+      cueGalleryState.smoothedTarget = null;
+      cueGalleryState.lastUpdate = null;
+      cueGalleryState.previous = null;
+      cueGalleryState.selection = cueStyleRef.current;
       let worldScaleFactor = 1;
       let cue;
       let clothMat;
@@ -5860,6 +5907,7 @@ function SnookerGame() {
       const backInterior = roomDepth / 2 - wallInset;
       const leftInterior = -roomWidth / 2 + wallInset;
       const rightInterior = roomWidth / 2 - wallInset;
+      const billboardSignage = [];
       [
         { position: [0, signageY, frontInterior], rotationY: 0, type: 'tv' },
         { position: [0, signageY, backInterior], rotationY: Math.PI, type: 'tv' },
@@ -5878,6 +5926,17 @@ function SnookerGame() {
           type === 'tv' ? createMatchTvAssembly() : createBillboardAssembly();
         signage.position.set(position[0], position[1], position[2]);
         signage.rotation.y = rotationY;
+        if (type === 'billboard') {
+          signage.userData = signage.userData || {};
+          signage.userData.isCueBillboard = true;
+          signage.userData.billboardRoot = signage;
+          signage.traverse((child) => {
+            child.userData = child.userData || {};
+            child.userData.billboardRoot = signage;
+            child.userData.isCueBillboard = true;
+          });
+          billboardSignage.push(signage);
+        }
         world.add(signage);
       });
 
@@ -5886,29 +5945,96 @@ function SnookerGame() {
           THREE,
           ballRadius: BALL_R,
           cueLengthMultiplier: CUE_LENGTH_MULTIPLIER,
-          cueTipRadius: CUE_TIP_RADIUS
+          cueTipRadius: CUE_TIP_RADIUS,
+          cueStyles
         });
       const cueRackHalfWidth = cueRackDimensions.width / 2;
-      const availableHalfDepth =
-        roomDepth / 2 - wallThickness - cueRackHalfWidth - BALL_R * 2;
-      const desiredSpacing =
-        signageWidth / 2 + cueRackHalfWidth + BALL_R * 6;
-      const cueRackSpacing = Math.max(
-        cueRackHalfWidth,
-        Math.min(availableHalfDepth, desiredSpacing)
-      );
+      const cueRackDepthHalf = cueRackDimensions.depth / 2;
       const cueRackY = signageY;
-      [
-        { x: leftInterior, z: -cueRackSpacing, rotationY: Math.PI / 2 },
-        { x: leftInterior, z: cueRackSpacing, rotationY: Math.PI / 2 },
-        { x: rightInterior, z: -cueRackSpacing, rotationY: -Math.PI / 2 },
-        { x: rightInterior, z: cueRackSpacing, rotationY: -Math.PI / 2 }
-      ].forEach((placement, index) => {
-        const rack = index === 0 ? cueRackPrototype : cueRackPrototype.clone();
-        rack.position.set(placement.x, cueRackY, placement.z);
-        rack.rotation.y = placement.rotationY;
+
+      billboardSignage.forEach((signage, index) => {
+        const rack = index === 0 ? cueRackPrototype : cueRackPrototype.clone(true);
+        const face = new THREE.Vector3(0, 0, 1)
+          .applyQuaternion(signage.quaternion)
+          .setY(0);
+        if (face.lengthSq() < 1e-6) face.set(0, 0, 1);
+        face.normalize();
+        const right = new THREE.Vector3(1, 0, 0)
+          .applyQuaternion(signage.quaternion)
+          .setY(0);
+        if (right.lengthSq() < 1e-6) right.set(0, 0, 1);
+        right.normalize();
+        const lateralTarget = signageWidth / 2 + cueRackHalfWidth + BALL_R * 6;
+        const maxLateral =
+          roomDepth / 2 - wallThickness - cueRackHalfWidth - BALL_R * 2;
+        const lateral = Math.min(maxLateral, lateralTarget);
+        const rackPos = signage.position
+          .clone()
+          .add(right.clone().multiplyScalar(lateral));
+        rack.position.set(rackPos.x, cueRackY, rackPos.z);
+        rack.rotation.y = signage.rotation.y;
         world.add(rack);
+
+        const cueGroups = [];
+        rack.traverse((child) => {
+          if (child.isGroup && child.userData?.cueStyleId) {
+            cueGroups.push(child);
+          }
+        });
+
+        const focusTarget = rack.position
+          .clone()
+          .add(face.clone().multiplyScalar(cueRackDepthHalf + 0.2));
+        focusTarget.y = cueRackY;
+        const viewDistance = cueRackDimensions.depth * 6 + BALL_R * 60;
+        const cameraHeightOffset = cueRackDimensions.height * 0.45;
+        const viewPosition = focusTarget
+          .clone()
+          .add(face.clone().multiplyScalar(viewDistance))
+          .add(new THREE.Vector3(0, cameraHeightOffset, 0));
+
+        cueGalleryState.entries.push({
+          signage,
+          rack,
+          cueGroups,
+          face,
+          right,
+          focusTarget,
+          viewPosition
+        });
       });
+
+      const updateRackHighlight = (styleId) => {
+        const state = cueGalleryRef.current;
+        if (!state?.entries) return;
+        state.entries.forEach((entry) => {
+          entry.cueGroups.forEach((group) => {
+            const baseY = group.userData?.baseY ?? group.position.y;
+            const lift = group.userData?.highlightLift ?? 0;
+            const isActive = group.userData?.cueStyleId === styleId;
+            group.position.y = isActive ? baseY + lift : baseY;
+            const mats = group.userData?.highlightMaterials;
+            if (Array.isArray(mats)) {
+              mats.forEach((mat) => {
+                if (!mat) return;
+                if (mat.emissive == null) {
+                  mat.emissive = new THREE.Color(0x000000);
+                }
+                mat.emissiveIntensity = isActive ? 0.32 : 0.08;
+                if (isActive && group.userData?.highlightEmissiveColor != null) {
+                  mat.emissive.setHex(group.userData.highlightEmissiveColor);
+                } else if (!isActive) {
+                  mat.emissive.setHex(0x000000);
+                }
+                mat.needsUpdate = true;
+              });
+            }
+          });
+        });
+      };
+
+      updateRackHighlightRef.current = updateRackHighlight;
+      updateRackHighlight(cueStyleRef.current);
 
       const broadcastClearance = wallThickness * 1.1 + BALL_R * 4;
       const shortRailTarget = Math.max(
@@ -6474,6 +6600,37 @@ function SnookerGame() {
             focusWorld: broadcastCamerasRef.current?.defaultFocusWorld ?? null,
             lerp: 0.18
           };
+          const galleryState = cueGalleryRef.current;
+          if (galleryState?.active && galleryState.entry) {
+            const now = performance.now();
+            const last = galleryState.lastUpdate ?? now;
+            const dt = Math.min(0.25, Math.max(0, (now - last) / 1000));
+            galleryState.lastUpdate = now;
+            const smooth = 1 - Math.exp(-dt / 0.22);
+            const desiredTarget = galleryState.entry.focusTarget
+              .clone()
+              .multiplyScalar(worldScaleFactor);
+            const desiredPos = galleryState.entry.viewPosition
+              .clone()
+              .multiplyScalar(worldScaleFactor);
+            if (!galleryState.smoothedPos) {
+              galleryState.smoothedPos = desiredPos.clone();
+            }
+            if (!galleryState.smoothedTarget) {
+              galleryState.smoothedTarget = desiredTarget.clone();
+            }
+            galleryState.smoothedPos.lerp(desiredPos, smooth);
+            galleryState.smoothedTarget.lerp(desiredTarget, smooth);
+            camera.position.copy(galleryState.smoothedPos);
+            camera.lookAt(galleryState.smoothedTarget);
+            lastCameraTargetRef.current.copy(galleryState.smoothedTarget);
+            renderCamera = camera;
+            broadcastArgs.focusWorld = galleryState.smoothedTarget.clone();
+            broadcastArgs.targetWorld = galleryState.smoothedTarget.clone();
+            broadcastArgs.lerp = 0.12;
+            updateBroadcastCameras(broadcastArgs);
+            return renderCamera;
+          }
           if (topViewRef.current) {
             lookTarget = getDefaultOrbitTarget().multiplyScalar(
               worldScaleFactor
@@ -7475,7 +7632,7 @@ function SnookerGame() {
           spinAppliedRef.current = { ...result, magnitude, mode };
           return result;
         };
-        const drag = { on: false, x: 0, y: 0, moved: false };
+        const drag = { on: false, x: 0, y: 0, moved: false, skipUpFocus: false };
         let lastInteraction = performance.now();
         const registerInteraction = () => {
           lastInteraction = performance.now();
@@ -7514,6 +7671,13 @@ function SnookerGame() {
         const down = (e) => {
           registerInteraction();
           if (attemptChalkPress(e)) return;
+          drag.skipUpFocus = false;
+          if (attemptCueGalleryInteraction(e)) {
+            drag.skipUpFocus = true;
+            e.preventDefault?.();
+            return;
+          }
+          if (cueGalleryRef.current?.active) return;
           const currentHud = hudRef.current;
           if (currentHud?.turn === 1 || currentHud?.inHand || shooting) return;
           if (e.touches?.length === 2) return;
@@ -7524,7 +7688,7 @@ function SnookerGame() {
           drag.y = e.clientY || e.touches?.[0]?.clientY || 0;
         };
         const move = (e) => {
-          if (topViewRef.current || !drag.on) return;
+          if (topViewRef.current || cueGalleryRef.current?.active || !drag.on) return;
           const currentHud = hudRef.current;
           if (currentHud?.turn === 1) return;
           const x = e.clientX || e.touches?.[0]?.clientX || drag.x;
@@ -7567,8 +7731,11 @@ function SnookerGame() {
           const moved = drag.moved;
           drag.on = false;
           drag.moved = false;
+          const skipFocus = drag.skipUpFocus;
+          drag.skipUpFocus = false;
           if (
             !moved &&
+            !skipFocus &&
             !topViewRef.current &&
             !(hudRef.current?.inHand ?? false) &&
             !shooting
@@ -7584,6 +7751,10 @@ function SnookerGame() {
         dom.addEventListener('touchmove', move, { passive: true });
         window.addEventListener('touchend', up);
         const keyRot = (e) => {
+          if (e.key === 'Escape' && cueGalleryRef.current?.active) {
+            exitCueGallery();
+            return;
+          }
           if (topViewRef.current) return;
           const currentHud = hudRef.current;
           if (currentHud?.turn === 1 || currentHud?.inHand || shooting) return;
@@ -7946,16 +8117,17 @@ function SnookerGame() {
       const tipRadius = CUE_TIP_RADIUS;
       const tipLen = 0.015 * SCALE * 1.5;
       const tipCylinderLen = Math.max(0, tipLen - tipRadius * 2);
+      const tipMaterial = new THREE.MeshStandardMaterial({
+        color: 0x1f3f73,
+        roughness: 1,
+        metalness: 0,
+        map: tipTex
+      });
       const tip = new THREE.Mesh(
         tipCylinderLen > 0
           ? new THREE.CapsuleGeometry(tipRadius, tipCylinderLen, 8, 16)
           : new THREE.SphereGeometry(tipRadius, 16, 16),
-        new THREE.MeshStandardMaterial({
-          color: 0x1f3f73,
-          roughness: 1,
-          metalness: 0,
-          map: tipTex
-        })
+        tipMaterial
       );
       tip.rotation.x = -Math.PI / 2;
       tip.position.z = -(tipCylinderLen / 2 + tipRadius + connectorHeight);
@@ -7999,6 +8171,34 @@ function SnookerGame() {
         cueBody.add(stripe);
       }
 
+      const connectorMaterial = connector.material;
+      const buttCapMaterial = buttCap.material;
+
+      const applyCueStyle = (styleId) => {
+        const style = getCueStyleById(styleId);
+        if (!style) return;
+        const shaftColor = style.shaftColor ?? style.rackShaftColor ?? 0xdeb887;
+        shaftMaterial.color.setHex(shaftColor);
+        shaftMaterial.needsUpdate = true;
+        const connectorColor = style.connectorColor ?? 0xcd7f32;
+        connectorMaterial.color.setHex(connectorColor);
+        connectorMaterial.needsUpdate = true;
+        const buttColor = style.buttColor ?? 0x111111;
+        buttCapMaterial.color.setHex(buttColor);
+        buttCapMaterial.needsUpdate = true;
+        const stripeColor = style.stripeColor ?? style.rackAccentColor ?? 0x000000;
+        stripeMat.color.setHex(stripeColor);
+        stripeMat.needsUpdate = true;
+        if (style.tipColor != null) {
+          tipMaterial.color.setHex(style.tipColor);
+          tipMaterial.needsUpdate = true;
+        }
+        cueGalleryRef.current.selection = style.id;
+      };
+
+      applyCueStyleRef.current = applyCueStyle;
+      applyCueStyle(cueStyleRef.current);
+
       cueStick.position.set(cue.pos.x, CUE_Y, cue.pos.y + 1.2 * SCALE);
       applyCueButtTilt(cueStick);
       // thin side already faces the cue ball so no extra rotation
@@ -8019,6 +8219,116 @@ function SnookerGame() {
         new THREE.Vector3(0, 1, 0),
         -TABLE_Y * worldScaleFactor
       );
+
+      const exitCueGallery = (restore = true) => {
+        const state = cueGalleryRef.current;
+        if (!state?.active) return;
+        state.active = false;
+        state.entry = null;
+        state.smoothedPos = null;
+        state.smoothedTarget = null;
+        state.lastUpdate = null;
+        if (restore) {
+          const prev = state.previous;
+          if (prev) {
+            const store = ensureOrbitFocus();
+            store.ballId = prev.ballId;
+            store.target.copy(prev.target);
+            topViewRef.current = prev.topView;
+            sph.radius = clampOrbitRadius(prev.sph.radius);
+            sph.phi = prev.sph.phi;
+            sph.theta = prev.sph.theta;
+            cameraBlendRef.current = prev.cameraBlend;
+            if (prev.lastTarget) {
+              lastCameraTargetRef.current.copy(prev.lastTarget);
+            }
+            syncBlendToSpherical();
+          }
+          state.previous = null;
+          updateCamera();
+        } else {
+          state.previous = null;
+        }
+      };
+
+      const enterCueGallery = (entry) => {
+        if (!entry) return false;
+        const state = cueGalleryRef.current;
+        if (!state) return false;
+        if (state.active && state.entry === entry) return true;
+        const store = ensureOrbitFocus();
+        state.previous = {
+          topView: topViewRef.current,
+          ballId: store.ballId,
+          target: store.target.clone(),
+          sph: { radius: sph.radius, phi: sph.phi, theta: sph.theta },
+          cameraBlend: cameraBlendRef.current ?? 1,
+          lastTarget: lastCameraTargetRef.current?.clone()
+        };
+        topViewRef.current = false;
+        state.active = true;
+        state.entry = entry;
+        state.smoothedPos = camera.position.clone();
+        state.smoothedTarget = entry.focusTarget.clone().multiplyScalar(worldScaleFactor);
+        state.lastUpdate = performance.now();
+        cueGalleryRef.current.selection = cueStyleRef.current;
+        updateCamera();
+        return true;
+      };
+
+      const attemptCueGalleryInteraction = (ev) => {
+        const state = cueGalleryRef.current;
+        if (!state) return false;
+        if (state.entries.length === 0) return false;
+        const rect = dom.getBoundingClientRect();
+        const primaryTouch = ev?.changedTouches?.[0] ?? ev?.touches?.[0] ?? null;
+        const clientX = ev?.clientX ?? primaryTouch?.clientX;
+        const clientY = ev?.clientY ?? primaryTouch?.clientY;
+        if (clientX == null || clientY == null) return false;
+        if (
+          clientX < rect.left ||
+          clientX > rect.right ||
+          clientY < rect.top ||
+          clientY > rect.bottom
+        ) {
+          return false;
+        }
+        const nx = ((clientX - rect.left) / rect.width) * 2 - 1;
+        const ny = -(((clientY - rect.top) / rect.height) * 2 - 1);
+        pointer.set(nx, ny);
+        const currentCamera = activeRenderCameraRef.current ?? camera;
+        ray.setFromCamera(pointer, currentCamera);
+        if (state.active && state.entry) {
+          const intersects = ray.intersectObjects(state.entry.cueGroups, true);
+          if (intersects.length === 0) return false;
+          let hit = intersects[0].object;
+          while (hit && !hit.userData?.cueStyleId && hit.parent) {
+            hit = hit.parent;
+          }
+          const styleId = hit?.userData?.cueStyleId;
+          if (!styleId) return false;
+          setCueStyleId(styleId);
+          exitCueGallery();
+          return true;
+        }
+        const signageObjects = state.entries.map((item) => item.signage);
+        const intersects = ray.intersectObjects(signageObjects, true);
+        if (intersects.length === 0) return false;
+        let hit = intersects[0].object;
+        let signage = null;
+        while (hit) {
+          if (hit.userData?.billboardRoot) {
+            signage = hit.userData.billboardRoot;
+            break;
+          }
+          hit = hit.parent;
+        }
+        if (!signage) return false;
+        const entry = state.entries.find((item) => item.signage === signage);
+        if (!entry) return false;
+        return enterCueGallery(entry);
+      };
+
       project = (ev) => {
         const r = dom.getBoundingClientRect();
         const cx =
@@ -9796,6 +10106,12 @@ function SnookerGame() {
           activeRenderCameraRef.current = null;
           cueBodyRef.current = null;
           tipGroupRef.current = null;
+          cueGalleryRef.current.active = false;
+          cueGalleryRef.current.entries = [];
+          cueGalleryRef.current.entry = null;
+          cueGalleryRef.current.previous = null;
+          cueGalleryRef.current.smoothedPos = null;
+          cueGalleryRef.current.smoothedTarget = null;
           try {
             host.removeChild(renderer.domElement);
           } catch {}


### PR DESCRIPTION
## Summary
- add reusable cue style presets and enhanced rack generation so each display exposes per-style metadata
- update the 3D Snooker arena to highlight the active cue, focus cameras on billboards, and support selecting cues from the gallery
- extend Pool Royale with the same cue gallery experience, applying the chosen style to the in-game cue and persisting the selection

## Testing
- npm run lint *(fails: existing lint violations in legacy library files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cf98fb90832986ac83b460c24039