### PR TITLE
Improve cue rack presentation and gallery controls

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8550,14 +8550,16 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         const depth = (dims.depth ?? 0.2) * worldScaleFactor;
         const distance = Math.max(
           depth * 12,
-          width * 0.85,
-          BALL_R * worldScaleFactor * 22
+          width * 0.95,
+          BALL_R * worldScaleFactor * 24
         );
         const position = rackPos
           .clone()
           .add(forward.clone().multiplyScalar(distance))
-          .add(upVec.clone().multiplyScalar(height * 0.18));
-        const target = rackPos.clone().add(upVec.clone().multiplyScalar(height * 0.06));
+          .add(upVec.clone().multiplyScalar(height * 0.24));
+        const target = rackPos.clone().add(
+          upVec.clone().multiplyScalar(height * 0.12)
+        );
         const focusStore = ensureOrbitFocus();
         state.active = true;
         state.rackId = rackId;
@@ -8580,10 +8582,13 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         state.target.copy(target);
         state.right.copy(rightVec);
         state.up.copy(upVec);
-        const lateralAllowance = Math.max(width * 0.18, BALL_R * worldScaleFactor * 2);
+        const lateralAllowance = Math.max(
+          width * 0.4,
+          BALL_R * worldScaleFactor * 3.5
+        );
         state.maxLateral = Number.isFinite(lateralAllowance) ? lateralAllowance : 0;
         state.lateralOffset = 0;
-        state.lateralFocusScale = 0.35;
+        state.lateralFocusScale = 0.5;
         topViewRef.current = false;
         applyCameraBlend(cameraBlendRef.current);
         updateCamera();

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -8216,14 +8216,16 @@ function SnookerGame() {
         const depth = (dims.depth ?? 0.2) * worldScaleFactor;
         const distance = Math.max(
           depth * 12,
-          width * 0.85,
-          BALL_R * worldScaleFactor * 22
+          width * 0.95,
+          BALL_R * worldScaleFactor * 24
         );
         const position = rackPos
           .clone()
           .add(forward.clone().multiplyScalar(distance))
-          .add(upVec.clone().multiplyScalar(height * 0.18));
-        const target = rackPos.clone().add(upVec.clone().multiplyScalar(height * 0.06));
+          .add(upVec.clone().multiplyScalar(height * 0.24));
+        const target = rackPos.clone().add(
+          upVec.clone().multiplyScalar(height * 0.12)
+        );
         const focusStore = ensureOrbitFocus();
         state.active = true;
         state.rackId = rackId;
@@ -8246,10 +8248,13 @@ function SnookerGame() {
         state.target.copy(target);
         state.right.copy(rightVec);
         state.up.copy(upVec);
-        const lateralAllowance = Math.max(width * 0.18, BALL_R * worldScaleFactor * 2);
+        const lateralAllowance = Math.max(
+          width * 0.4,
+          BALL_R * worldScaleFactor * 3.5
+        );
         state.maxLateral = Number.isFinite(lateralAllowance) ? lateralAllowance : 0;
         state.lateralOffset = 0;
-        state.lateralFocusScale = 0.35;
+        state.lateralFocusScale = 0.5;
         topViewRef.current = false;
         applyCameraBlend(cameraBlendRef.current);
         updateCamera();


### PR DESCRIPTION
## Summary
- restyle the cue rack display with a blue cloth texture, flush cue rings, and full-height pick volumes for easier selection
- align the ornamental cues with the top of the frame so they sit level with the display trim
- expand the cue gallery camera framing and lateral range in Snooker and Pool Royale so all cues are reachable

## Testing
- npm run lint -- webapp/src/utils/createCueRackDisplay.js webapp/src/pages/Games/Snooker.jsx webapp/src/pages/Games/PoolRoyale.jsx *(fails: repository has pre-existing lint violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e34bcbca248329a45f02beb2f9e252