### PR TITLE
Adjust Pool Royale arena signage proportions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6038,10 +6038,13 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       const signageDepth = 0.8 * signageScale;
       const signageWidth = Math.min(roomWidth * 0.58, 52) * signageScale;
       const signageHeight = Math.min(wallHeight * 0.28, 12) * signageScale;
-      const tvScale = 10 * 1.3;
+      const tvSizeReduction = 0.7;
+      const tvScale = 10 * 1.3 * tvSizeReduction;
       const tvWidth = 9 * tvScale;
       const tvHeight = 5.4 * tvScale;
       const tvDepth = 0.42 * tvScale;
+      const tvMountHeight = tvHeight * 0.32;
+      const tvMountOffset = tvHeight * 0.42;
       const makeScreenMaterial = (texture) => {
         const material = new THREE.MeshBasicMaterial({ toneMapped: false });
         if (texture) {
@@ -6067,10 +6070,10 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         screen.position.z = tvDepth / 2 + 0.02;
         group.add(screen);
         const mount = new THREE.Mesh(
-          new THREE.BoxGeometry(tvWidth * 0.18, tvHeight * 0.6, tvDepth * 0.3),
+          new THREE.BoxGeometry(tvWidth * 0.18, tvMountHeight, tvDepth * 0.3),
           tvBezelMat
         );
-        mount.position.set(0, -tvHeight * 0.55, -tvDepth * 0.35);
+        mount.position.set(0, -tvMountOffset, -tvDepth * 0.35);
         group.add(mount);
         return group;
       };
@@ -6098,11 +6101,14 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         return assembly;
       };
       const signageGap = BALL_R * 3.2;
-      const tvGap = BALL_R * 3.2;
-      const tvAssemblyHalfHeight = tvHeight * 0.85;
+      const tvAssemblyHalfHeight = Math.max(
+        tvHeight / 2,
+        tvMountOffset + tvMountHeight / 2
+      );
       const signageHalfHeight = signageHeight / 2;
       const signageY = floorY + signageGap + signageHalfHeight;
-      const tvY = floorY + tvGap + tvAssemblyHalfHeight;
+      const signageBottomY = signageY - signageHalfHeight;
+      const tvY = signageBottomY + tvAssemblyHalfHeight;
       const wallInset = wallThickness / 2 + 0.2;
       const frontInterior = -roomDepth / 2 + wallInset;
       const backInterior = roomDepth / 2 - wallInset;
@@ -6173,7 +6179,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         cueRackHalfWidth,
         Math.min(availableHalfDepth, desiredOffset)
       );
-      const cueRackGap = BALL_R * 0.6;
+      const cueRackGap = signageGap;
       const cueRackY = floorY + cueRackGap + cueRackDimensions.height / 2;
       const cueRackPlacements = [
         { x: leftInterior, z: cueRackOffset, rotationY: Math.PI / 2 },

--- a/webapp/src/utils/createCueRackDisplay.js
+++ b/webapp/src/utils/createCueRackDisplay.js
@@ -63,10 +63,10 @@ export function createCueRackDisplay({
   const disposables = [];
 
   const frameMat = new THREE.MeshPhysicalMaterial({
-    color: 0x6a4b2f,
-    roughness: 0.55,
-    metalness: 0.12,
-    clearcoat: 0.6
+    color: 0x7d5b3a,
+    roughness: 0.52,
+    metalness: 0.14,
+    clearcoat: 0.65
   });
   const frameGeom = new THREE.BoxGeometry(frameWidth, frameHeight, frameDepth);
   const frameMesh = new THREE.Mesh(frameGeom, frameMat);
@@ -81,14 +81,14 @@ export function createCueRackDisplay({
   clothCanvas.height = 1024;
   const ctx = clothCanvas.getContext('2d');
   if (ctx) {
-    ctx.fillStyle = '#15345f';
+    ctx.fillStyle = '#1c4a85';
     ctx.fillRect(0, 0, clothCanvas.width, clothCanvas.height);
 
     const grad = ctx.createLinearGradient(0, 0, clothCanvas.width, clothCanvas.height);
-    grad.addColorStop(0, '#1a467b');
-    grad.addColorStop(0.5, '#1f4f8a');
-    grad.addColorStop(1, '#133a66');
-    ctx.globalAlpha = 0.85;
+    grad.addColorStop(0, '#215b9d');
+    grad.addColorStop(0.5, '#2a66aa');
+    grad.addColorStop(1, '#194979');
+    ctx.globalAlpha = 0.78;
     ctx.fillStyle = grad;
     ctx.fillRect(0, 0, clothCanvas.width, clothCanvas.height);
     ctx.globalAlpha = 1;
@@ -109,12 +109,12 @@ export function createCueRackDisplay({
     }
     ctx.putImageData(imageData, 0, 0);
 
-    ctx.globalAlpha = 0.08;
+    ctx.globalAlpha = 0.06;
     ctx.fillStyle = '#ffffff';
     for (let y = 0; y < clothCanvas.height; y += 8) {
       ctx.fillRect(0, y, clothCanvas.width, 1);
     }
-    ctx.globalAlpha = 0.04;
+    ctx.globalAlpha = 0.03;
     for (let x = 0; x < clothCanvas.width; x += 8) {
       ctx.fillRect(x, 0, 1, clothCanvas.height);
     }
@@ -299,16 +299,18 @@ export function createCueRackDisplay({
 
   const startX = -cueRailWidth / 2;
   const stepX = cueCount > 1 ? cueRailWidth / (cueCount - 1) : 0;
-  const verticalPadding = clothHeight * 0.035;
-  const cueVerticalBoost = clothHeight * 0.18;
+  const verticalPadding = clothHeight * 0.03;
+  const cueVerticalBoost = clothHeight * 0.24;
 
   for (let i = 0; i < cueCount; i += 1) {
     const color = CUE_RACK_PALETTE[i % CUE_RACK_PALETTE.length];
     const cue = makeCue(color, i);
     const halfHeight = cue.userData?.cueHalfHeight ?? clothHeight / 2;
     const maxLift = clothHeight / 2 - halfHeight;
-    const boostedLift = clothHeight / 2 - halfHeight - verticalPadding + cueVerticalBoost;
-    const cueLift = Math.min(maxLift, boostedLift);
+    const boostedLift =
+      clothHeight / 2 - halfHeight - verticalPadding + cueVerticalBoost;
+    const liftBase = Math.min(maxLift, boostedLift);
+    const cueLift = Math.min(maxLift, liftBase + clothHeight * 0.04);
     cue.position.set(startX + i * stepX, cueLift, cueDepth);
     group.add(cue);
   }


### PR DESCRIPTION
## Summary
- shrink the Pool Royale TVs, soften their mounts, and drop them toward the carpet so they sit in line with the billboards
- raise the cue rack display to the same carpet clearance, brighten the frame and cloth, and lift the cues so they sit cleanly inside the frame

## Testing
- npm --prefix webapp run build


------
https://chatgpt.com/codex/tasks/task_e_68e3927f2d30832986569f51065d39b7