### PR TITLE
Align chess and snake arenas with shared decor

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 
+import {
+  createArenaCarpetMaterial,
+  createArenaWallMaterial
+} from '../utils/arenaDecor.js';
+
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 
 const TABLE_TOP_SIZE = 3.4 + 0.6; // Matches chess arena table top size
@@ -11,25 +16,18 @@ const WALL_PROXIMITY_FACTOR = 0.5;
 const WALL_HEIGHT_MULTIPLIER = 2;
 const CHAIR_SCALE = 4;
 const CHAIR_CLEARANCE = 0.52;
-const CAMERA_INITIAL_RADIUS_FACTOR = 1.6;
-const CAMERA_MIN_RADIUS_FACTOR = 1.05;
-const CAMERA_MAX_RADIUS_FACTOR = 3.2;
-const CAMERA_ABS_MIN_PHI = 0.3;
-const STANDING_VIEW_PHI = 0.9;
-const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
-const CAMERA_PHI_MIN = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.16);
-const CAMERA_PHI_MAX = CUE_SHOT_PHI - 0.24;
-const CAMERA_INITIAL_PHI_LERP = THREE.MathUtils.clamp(
-  (STANDING_VIEW_PHI - CAMERA_PHI_MIN) / (CAMERA_PHI_MAX - CAMERA_PHI_MIN || 1),
-  0,
-  1
-);
-const CAMERA_VERTICAL_SENSITIVITY = 0.0025;
-const CAMERA_LEAN_STRENGTH = 0.005;
+const CAMERA_INITIAL_RADIUS_FACTOR = 1.35;
+const CAMERA_MIN_RADIUS_FACTOR = 0.95;
+const CAMERA_MAX_RADIUS_FACTOR = 2.4;
+const CAMERA_PHI_MIN = 0.92;
+const CAMERA_PHI_MAX = 1.22;
+const CAMERA_INITIAL_PHI_LERP = 0.35;
+const CAMERA_VERTICAL_SENSITIVITY = 0.003;
+const CAMERA_LEAN_STRENGTH = 0.0065;
 const CAMERA_CONFIG = {
-  fov: 66,
-  near: 0.04,
-  far: 4000
+  fov: 52,
+  near: 0.1,
+  far: 5000
 };
 
 const SNAKE_BOARD_TILES = 10;
@@ -51,124 +49,6 @@ const TOKEN_RADIUS = TILE_SIZE * 0.2;
 const TOKEN_HEIGHT = TILE_SIZE * 0.32;
 
 const DEFAULT_COLORS = ['#f97316', '#22d3ee', '#22c55e', '#a855f7'];
-
-const createCarpetTextures = (() => {
-  let cache = null;
-  const clamp01 = (v) => Math.min(1, Math.max(0, v));
-  const prng = (seed) => {
-    let value = seed;
-    return () => {
-      value = (value * 1664525 + 1013904223) % 4294967296;
-      return value / 4294967296;
-    };
-  };
-  const drawRoundedRect = (ctx, x, y, w, h, r) => {
-    const radius = Math.max(0, Math.min(r, Math.min(w, h) / 2));
-    ctx.beginPath();
-    ctx.moveTo(x + radius, y);
-    ctx.lineTo(x + w - radius, y);
-    ctx.quadraticCurveTo(x + w, y, x + w, y + radius);
-    ctx.lineTo(x + w, y + h - radius);
-    ctx.quadraticCurveTo(x + w, y + h, x + w - radius, y + h);
-    ctx.lineTo(x + radius, y + h);
-    ctx.quadraticCurveTo(x, y + h, x, y + h - radius);
-    ctx.lineTo(x, y + radius);
-    ctx.quadraticCurveTo(x, y, x + radius, y);
-    ctx.closePath();
-  };
-  return () => {
-    if (cache) return cache;
-    if (typeof document === 'undefined') {
-      cache = { map: null, bump: null };
-      return cache;
-    }
-
-    const size = 1024;
-    const canvas = document.createElement('canvas');
-    canvas.width = canvas.height = size;
-    const ctx = canvas.getContext('2d');
-
-    const gradient = ctx.createLinearGradient(0, 0, size, size);
-    gradient.addColorStop(0, '#7a0a18');
-    gradient.addColorStop(1, '#5e0913');
-    ctx.fillStyle = gradient;
-    ctx.fillRect(0, 0, size, size);
-
-    const rand = prng(987654321);
-    const image = ctx.getImageData(0, 0, size, size);
-    const data = image.data;
-    for (let y = 0; y < size; y++) {
-      for (let x = 0; x < size; x++) {
-        const idx = (y * size + x) * 4;
-        const fiber = (Math.sin((x / size) * Math.PI * 18) + Math.cos((y / size) * Math.PI * 22)) * 0.12;
-        const grain = (rand() - 0.5) * 0.22;
-        const shade = clamp01(0.96 + fiber + grain);
-        data[idx] = clamp01((data[idx] / 255) * shade) * 255;
-        data[idx + 1] = clamp01((data[idx + 1] / 255) * (0.98 + grain * 0.35)) * 255;
-        data[idx + 2] = clamp01((data[idx + 2] / 255) * (0.95 + grain * 0.2)) * 255;
-      }
-    }
-    ctx.putImageData(image, 0, 0);
-
-    ctx.globalAlpha = 0.05;
-    ctx.fillStyle = '#000000';
-    for (let row = 0; row < size; row += 3) {
-      ctx.fillRect(0, row, size, 1);
-    }
-    ctx.globalAlpha = 1;
-
-    const insetRatio = 0.055;
-    const stripeInset = size * insetRatio;
-    const stripeRadius = size * 0.08;
-    const stripeWidth = size * 0.012;
-    ctx.lineWidth = stripeWidth;
-    ctx.strokeStyle = '#d4af37';
-    ctx.shadowColor = 'rgba(0,0,0,0.18)';
-    ctx.shadowBlur = stripeWidth * 0.8;
-    drawRoundedRect(
-      ctx,
-      stripeInset,
-      stripeInset,
-      size - stripeInset * 2,
-      size - stripeInset * 2,
-      stripeRadius
-    );
-    ctx.stroke();
-    ctx.shadowBlur = 0;
-
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.wrapS = texture.wrapT = THREE.ClampToEdgeWrapping;
-    texture.anisotropy = 8;
-    texture.minFilter = THREE.LinearMipMapLinearFilter;
-    texture.magFilter = THREE.LinearFilter;
-    texture.generateMipmaps = true;
-    if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-    else texture.encoding = THREE.sRGBEncoding;
-
-    const bumpCanvas = document.createElement('canvas');
-    bumpCanvas.width = bumpCanvas.height = size;
-    const bumpCtx = bumpCanvas.getContext('2d');
-    bumpCtx.drawImage(canvas, 0, 0);
-    const bumpImage = bumpCtx.getImageData(0, 0, size, size);
-    const bumpData = bumpImage.data;
-    for (let i = 0; i < bumpData.length; i += 4) {
-      const avg = (bumpData[i] + bumpData[i + 1] + bumpData[i + 2]) / 3;
-      const noise = (rand() - 0.5) * 32;
-      const value = clamp01((avg + noise) / 255) * 255;
-      bumpData[i] = bumpData[i + 1] = bumpData[i + 2] = value;
-    }
-    bumpCtx.putImageData(bumpImage, 0, 0);
-    const bump = new THREE.CanvasTexture(bumpCanvas);
-    bump.wrapS = bump.wrapT = THREE.ClampToEdgeWrapping;
-    bump.anisotropy = 4;
-    bump.minFilter = THREE.LinearMipMapLinearFilter;
-    bump.magFilter = THREE.LinearFilter;
-    bump.generateMipmaps = true;
-
-    cache = { map: texture, bump };
-    return cache;
-  };
-})();
 
 function createTileLabel(number) {
   const size = 128;
@@ -315,6 +195,12 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
   const rim = new THREE.PointLight(0xff7373, 0.4, 12, 2.0);
   rim.position.set(0, 2.1, 0);
   arena.add(rim);
+  const spot = new THREE.SpotLight(0xffffff, 1.05, 0, Math.PI / 4, 0.35, 1.1);
+  spot.position.set(0, 4.2, 4.6);
+  arena.add(spot);
+  const spotTarget = new THREE.Object3D();
+  arena.add(spotTarget);
+  spot.target = spotTarget;
 
   const arenaHalfWidth = 16.5; // Derived from chess arena footprint
   const arenaHalfDepth = 28;
@@ -335,23 +221,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
   floor.rotation.x = -Math.PI / 2;
   arena.add(floor);
 
-  const carpetTextures = createCarpetTextures();
-  const carpetMat = new THREE.MeshStandardMaterial({
-    color: 0xb01224,
-    roughness: 0.92,
-    metalness: 0.04
-  });
-  if (carpetTextures.map) {
-    carpetMat.map = carpetTextures.map;
-    carpetMat.map.repeat.set(1, 1);
-    carpetMat.map.needsUpdate = true;
-  }
-  if (carpetTextures.bump) {
-    carpetMat.bumpMap = carpetTextures.bump;
-    carpetMat.bumpMap.repeat.set(1, 1);
-    carpetMat.bumpScale = 0.24;
-    carpetMat.bumpMap.needsUpdate = true;
-  }
+  const carpetMat = createArenaCarpetMaterial();
   const carpet = new THREE.Mesh(
     new THREE.PlaneGeometry(roomHalfWidth * 1.2, roomHalfDepth * 1.2),
     carpetMat
@@ -362,12 +232,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
 
   const wallH = 3 * WALL_HEIGHT_MULTIPLIER;
   const wallT = 0.1;
-  const wallMat = new THREE.MeshStandardMaterial({
-    color: 0xeeeeee,
-    roughness: 0.88,
-    metalness: 0.06,
-    side: THREE.DoubleSide
-  });
+  const wallMat = createArenaWallMaterial();
   const backWall = new THREE.Mesh(new THREE.BoxGeometry(halfRoomX * 2, wallH, wallT), wallMat);
   backWall.position.set(0, wallH / 2, halfRoomZ);
   arena.add(backWall);
@@ -572,6 +437,8 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
   arena.add(boardGroup);
 
   const boardLookTarget = new THREE.Vector3(0, boardGroup.position.y + 0.45, 0);
+  spotTarget.position.copy(boardLookTarget);
+  spot.target.updateMatrixWorld();
   studioCamA.lookAt(boardLookTarget);
   studioCamB.lookAt(boardLookTarget);
 
@@ -581,9 +448,11 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
     CAMERA_CONFIG.near,
     CAMERA_CONFIG.far
   );
+  const minR = SNAKE_BOARD_SIZE * CAMERA_MIN_RADIUS_FACTOR;
+  const maxR = SNAKE_BOARD_SIZE * CAMERA_MAX_RADIUS_FACTOR;
   const initialRadius = Math.max(
     SNAKE_BOARD_SIZE * CAMERA_INITIAL_RADIUS_FACTOR,
-    SNAKE_BOARD_SIZE * CAMERA_MIN_RADIUS_FACTOR
+    minR + 0.6
   );
   const sph = new THREE.Spherical(
     initialRadius,
@@ -599,8 +468,6 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
     camera.updateProjectionMatrix();
     const needed =
       SNAKE_BOARD_SIZE / (2 * Math.tan(THREE.MathUtils.degToRad(CAMERA_CONFIG.fov) / 2));
-    const minR = SNAKE_BOARD_SIZE * CAMERA_MIN_RADIUS_FACTOR;
-    const maxR = SNAKE_BOARD_SIZE * CAMERA_MAX_RADIUS_FACTOR;
     sph.radius = clamp(Math.max(needed, sph.radius), minR, maxR);
     const offset = new THREE.Vector3().setFromSpherical(sph);
     camera.position.copy(boardLookTarget).add(offset);
@@ -629,8 +496,6 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
     const phiDelta = -dy * CAMERA_VERTICAL_SENSITIVITY;
     sph.phi = clamp(sph.phi + phiDelta, CAMERA_PHI_MIN, CAMERA_PHI_MAX);
     const leanDelta = dy * CAMERA_LEAN_STRENGTH;
-    const minR = SNAKE_BOARD_SIZE * CAMERA_MIN_RADIUS_FACTOR;
-    const maxR = SNAKE_BOARD_SIZE * CAMERA_MAX_RADIUS_FACTOR;
     sph.radius = clamp(sph.radius - leanDelta, minR, maxR);
     fit();
   };
@@ -638,9 +503,8 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
     drag.on = false;
   };
   const onWheel = (e) => {
-    const minR = SNAKE_BOARD_SIZE * CAMERA_MIN_RADIUS_FACTOR;
-    const maxR = SNAKE_BOARD_SIZE * CAMERA_MAX_RADIUS_FACTOR;
-    sph.radius = clamp(sph.radius + e.deltaY * 0.0025, minR, maxR);
+    const r = sph.radius || initialRadius;
+    sph.radius = clamp(r + e.deltaY * 0.2, minR, maxR);
     fit();
   };
   dom.addEventListener('mousedown', onDown);
@@ -890,8 +754,11 @@ function updateTokens(
 
     const basePos = indexToPosition.get(positionIndex);
     const worldPos = basePos
-      ? basePos.clone().add(new THREE.Vector3(offsetX, TOKEN_HEIGHT * 0.5, offsetZ))
-      : serpentineIndexToXZ(positionIndex).clone().setY(tokensGroup.position.y + TOKEN_HEIGHT * 0.5);
+      ? basePos.clone()
+      : serpentineIndexToXZ(positionIndex).clone().setY(tokensGroup.position.y);
+    worldPos.x += offsetX;
+    worldPos.z += offsetZ;
+    worldPos.y += TOKEN_HEIGHT * 0.02;
 
     token.position.copy(worldPos);
   });

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import * as THREE from 'three';
+import {
+  createArenaCarpetMaterial,
+  createArenaWallMaterial
+} from '../../utils/arenaDecor.js';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
   getTelegramFirstName,
@@ -532,7 +536,8 @@ function Chess3D({ avatar, username }) {
 
     scene = new THREE.Scene();
     scene.background = new THREE.Color(0x0c1020);
-    scene.add(new THREE.HemisphereLight(0xffffff, 0x1a1f2b, 0.95));
+    const hemi = new THREE.HemisphereLight(0xffffff, 0x1a1f2b, 0.95);
+    scene.add(hemi);
     const key = new THREE.DirectionalLight(0xffffff, 1.0);
     key.position.set(1.8, 2.6, 1.6);
     scene.add(key);
@@ -542,6 +547,12 @@ function Chess3D({ avatar, username }) {
     const rim = new THREE.PointLight(0xff7373, 0.4, 12, 2.0);
     rim.position.set(0, 2.1, 0);
     scene.add(rim);
+    const spot = new THREE.SpotLight(0xffffff, 1.05, 0, Math.PI / 4, 0.35, 1.1);
+    spot.position.set(0, 4.2, 4.6);
+    scene.add(spot);
+    const spotTarget = new THREE.Object3D();
+    scene.add(spotTarget);
+    spot.target = spotTarget;
 
     const arena = new THREE.Group();
     scene.add(arena);
@@ -565,13 +576,10 @@ function Chess3D({ avatar, username }) {
     floor.rotation.x = -Math.PI / 2;
     arena.add(floor);
 
+    const carpetMat = createArenaCarpetMaterial();
     const carpet = new THREE.Mesh(
       new THREE.PlaneGeometry(roomHalfWidth * 1.2, roomHalfDepth * 1.2),
-      new THREE.MeshStandardMaterial({
-        color: 0x9c0b18,
-        roughness: 0.8,
-        metalness: 0.05
-      })
+      carpetMat
     );
     carpet.rotation.x = -Math.PI / 2;
     carpet.position.y = 0.002;
@@ -579,12 +587,7 @@ function Chess3D({ avatar, username }) {
 
     const wallH = 3 * WALL_HEIGHT_MULTIPLIER;
     const wallT = 0.1;
-    const wallMat = new THREE.MeshStandardMaterial({
-      color: 0x273360,
-      roughness: 0.65,
-      metalness: 0.08,
-      side: THREE.DoubleSide
-    });
+    const wallMat = createArenaWallMaterial();
     const backWall = new THREE.Mesh(
       new THREE.BoxGeometry(halfRoomX * 2, wallH, wallT),
       wallMat
@@ -815,6 +818,8 @@ function Chess3D({ avatar, username }) {
       boardGroup.position.y + (BOARD.baseH + 0.12) * BOARD_SCALE,
       0
     );
+    spotTarget.position.copy(boardLookTarget);
+    spot.target.updateMatrixWorld();
     studioCamA.lookAt(boardLookTarget);
     studioCamB.lookAt(boardLookTarget);
 

--- a/webapp/src/utils/arenaDecor.js
+++ b/webapp/src/utils/arenaDecor.js
@@ -1,0 +1,153 @@
+import * as THREE from 'three';
+
+const clamp01 = (v) => Math.min(1, Math.max(0, v));
+
+let cachedCarpetTextures = null;
+
+function ensureCarpetTextures() {
+  if (cachedCarpetTextures) return cachedCarpetTextures;
+  if (typeof document === 'undefined') {
+    cachedCarpetTextures = { map: null, bump: null };
+    return cachedCarpetTextures;
+  }
+
+  const size = 1024;
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext('2d');
+
+  const gradient = ctx.createLinearGradient(0, 0, size, size);
+  gradient.addColorStop(0, '#7a0a18');
+  gradient.addColorStop(1, '#5e0913');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+
+  const prng = (seed) => {
+    let value = seed;
+    return () => {
+      value = (value * 1664525 + 1013904223) % 4294967296;
+      return value / 4294967296;
+    };
+  };
+
+  const rand = prng(987654321);
+  const image = ctx.getImageData(0, 0, size, size);
+  const data = image.data;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const idx = (y * size + x) * 4;
+      const fiber =
+        (Math.sin((x / size) * Math.PI * 18) +
+          Math.cos((y / size) * Math.PI * 22)) *
+        0.12;
+      const grain = (rand() - 0.5) * 0.22;
+      const shade = clamp01(0.96 + fiber + grain);
+      data[idx] = clamp01((data[idx] / 255) * shade) * 255;
+      data[idx + 1] = clamp01((data[idx + 1] / 255) * (0.98 + grain * 0.35)) * 255;
+      data[idx + 2] = clamp01((data[idx + 2] / 255) * (0.95 + grain * 0.2)) * 255;
+    }
+  }
+  ctx.putImageData(image, 0, 0);
+
+  ctx.globalAlpha = 0.05;
+  ctx.fillStyle = '#000000';
+  for (let row = 0; row < size; row += 3) {
+    ctx.fillRect(0, row, size, 1);
+  }
+  ctx.globalAlpha = 1;
+
+  const drawRoundedRect = (context, x, y, w, h, r) => {
+    const radius = Math.max(0, Math.min(r, Math.min(w, h) / 2));
+    context.beginPath();
+    context.moveTo(x + radius, y);
+    context.lineTo(x + w - radius, y);
+    context.quadraticCurveTo(x + w, y, x + w, y + radius);
+    context.lineTo(x + w, y + h - radius);
+    context.quadraticCurveTo(x + w, y + h, x + w - radius, y + h);
+    context.lineTo(x + radius, y + h);
+    context.quadraticCurveTo(x, y + h, x, y + h - radius);
+    context.lineTo(x, y + radius);
+    context.quadraticCurveTo(x, y, x + radius, y);
+    context.closePath();
+  };
+
+  const insetRatio = 0.055;
+  const stripeInset = size * insetRatio;
+  const stripeRadius = size * 0.08;
+  const stripeWidth = size * 0.012;
+  ctx.lineWidth = stripeWidth;
+  ctx.strokeStyle = '#d4af37';
+  ctx.shadowColor = 'rgba(0,0,0,0.18)';
+  ctx.shadowBlur = stripeWidth * 0.8;
+  drawRoundedRect(
+    ctx,
+    stripeInset,
+    stripeInset,
+    size - stripeInset * 2,
+    size - stripeInset * 2,
+    stripeRadius
+  );
+  ctx.stroke();
+  ctx.shadowBlur = 0;
+
+  const map = new THREE.CanvasTexture(canvas);
+  map.wrapS = map.wrapT = THREE.ClampToEdgeWrapping;
+  map.anisotropy = 8;
+  map.minFilter = THREE.LinearMipMapLinearFilter;
+  map.magFilter = THREE.LinearFilter;
+  map.generateMipmaps = true;
+  if ('colorSpace' in map) map.colorSpace = THREE.SRGBColorSpace;
+
+  const bumpCanvas = document.createElement('canvas');
+  bumpCanvas.width = bumpCanvas.height = size;
+  const bumpCtx = bumpCanvas.getContext('2d');
+  bumpCtx.drawImage(canvas, 0, 0);
+  const bumpImage = bumpCtx.getImageData(0, 0, size, size);
+  const bumpData = bumpImage.data;
+  for (let i = 0; i < bumpData.length; i += 4) {
+    const avg = (bumpData[i] + bumpData[i + 1] + bumpData[i + 2]) / 3;
+    const noise = (rand() - 0.5) * 32;
+    const value = clamp01((avg + noise) / 255) * 255;
+    bumpData[i] = bumpData[i + 1] = bumpData[i + 2] = value;
+  }
+  bumpCtx.putImageData(bumpImage, 0, 0);
+  const bump = new THREE.CanvasTexture(bumpCanvas);
+  bump.wrapS = bump.wrapT = THREE.ClampToEdgeWrapping;
+  bump.anisotropy = 4;
+  bump.minFilter = THREE.LinearMipMapLinearFilter;
+  bump.magFilter = THREE.LinearFilter;
+  bump.generateMipmaps = true;
+
+  cachedCarpetTextures = { map, bump };
+  return cachedCarpetTextures;
+}
+
+export function createArenaCarpetMaterial() {
+  const material = new THREE.MeshStandardMaterial({
+    color: 0xb01224,
+    roughness: 0.92,
+    metalness: 0.04
+  });
+  const textures = ensureCarpetTextures();
+  if (textures.map) {
+    material.map = textures.map;
+    material.map.repeat.set(1, 1);
+    material.map.needsUpdate = true;
+  }
+  if (textures.bump) {
+    material.bumpMap = textures.bump;
+    material.bumpMap.repeat.set(1, 1);
+    material.bumpScale = 0.24;
+    material.bumpMap.needsUpdate = true;
+  }
+  return material;
+}
+
+export function createArenaWallMaterial() {
+  return new THREE.MeshStandardMaterial({
+    color: 0xeeeeee,
+    roughness: 0.88,
+    metalness: 0.06,
+    side: THREE.DoubleSide
+  });
+}


### PR DESCRIPTION
## Summary
- synchronize the snake-and-ladder orbit camera parameters with the chess battle royal behaviour
- extract shared arena carpet and wall materials for reuse and apply them so both scenes share textures
- ensure snake tokens rest on the board surface and add a spotlight plus hemisphere light to both arenas

## Testing
- npm --prefix webapp run build *(warns about three.js sRGBEncoding exports in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68e39bfd84f083298b9c6394c733e27d