### PR TITLE
Share arena camera defaults between chess and snake boards

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -5,6 +5,7 @@ import {
   createArenaCarpetMaterial,
   createArenaWallMaterial
 } from '../utils/arenaDecor.js';
+import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../utils/arenaCameraConfig.js';
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 
@@ -16,22 +17,18 @@ const WALL_PROXIMITY_FACTOR = 0.5;
 const WALL_HEIGHT_MULTIPLIER = 2;
 const CHAIR_SCALE = 4;
 const CHAIR_CLEARANCE = 0.52;
-const CAMERA_INITIAL_RADIUS_FACTOR = 1.35;
-const CAMERA_MIN_RADIUS_FACTOR = 0.95;
-const CAMERA_MAX_RADIUS_FACTOR = 2.4;
-const CAMERA_PHI_MIN = 0.92;
-const CAMERA_PHI_MAX = 1.22;
-const CAMERA_INITIAL_PHI_LERP = 0.35;
-const CAMERA_VERTICAL_SENSITIVITY = 0.003;
-const CAMERA_LEAN_STRENGTH = 0.0065;
-const CAMERA_CONFIG = {
-  fov: 52,
-  near: 0.1,
-  far: 5000
-};
 
 const SNAKE_BOARD_TILES = 10;
 const SNAKE_BOARD_SIZE = 3.4;
+
+const CAMERA_INITIAL_RADIUS_FACTOR = ARENA_CAMERA_DEFAULTS.initialRadiusFactor;
+const CAMERA_PHI_MIN = ARENA_CAMERA_DEFAULTS.phiMin;
+const CAMERA_PHI_MAX = ARENA_CAMERA_DEFAULTS.phiMax;
+const CAMERA_INITIAL_PHI_LERP = ARENA_CAMERA_DEFAULTS.initialPhiLerp;
+const CAMERA_VERTICAL_SENSITIVITY = ARENA_CAMERA_DEFAULTS.verticalSensitivity;
+const CAMERA_LEAN_STRENGTH = ARENA_CAMERA_DEFAULTS.leanStrength;
+const CAMERA_WHEEL_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
+const CAMERA_CONFIG = buildArenaCameraConfig(SNAKE_BOARD_SIZE);
 const TILE_GAP = 0.015;
 const TILE_SIZE = SNAKE_BOARD_SIZE / SNAKE_BOARD_TILES;
 const BOARD_BASE_EXTRA = 0.28;
@@ -448,8 +445,8 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
     CAMERA_CONFIG.near,
     CAMERA_CONFIG.far
   );
-  const minR = SNAKE_BOARD_SIZE * CAMERA_MIN_RADIUS_FACTOR;
-  const maxR = SNAKE_BOARD_SIZE * CAMERA_MAX_RADIUS_FACTOR;
+  const minR = CAMERA_CONFIG.minRadius;
+  const maxR = CAMERA_CONFIG.maxRadius;
   const initialRadius = Math.max(
     SNAKE_BOARD_SIZE * CAMERA_INITIAL_RADIUS_FACTOR,
     minR + 0.6
@@ -504,7 +501,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
   };
   const onWheel = (e) => {
     const r = sph.radius || initialRadius;
-    sph.radius = clamp(r + e.deltaY * 0.2, minR, maxR);
+    sph.radius = clamp(r + e.deltaY * CAMERA_WHEEL_FACTOR, minR, maxR);
     fit();
   };
   dom.addEventListener('mousedown', onDown);

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -13,6 +13,7 @@ import {
 } from '../../utils/telegram.js';
 import { bombSound } from '../../assets/soundData.js';
 import { getGameVolume } from '../../utils/sound.js';
+import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../../utils/arenaCameraConfig.js';
 
 /**
  * CHESS 3D — Procedural, Modern Look (no external models)
@@ -60,12 +61,11 @@ const WALL_PROXIMITY_FACTOR = 0.5; // Bring arena walls 50% closer
 const WALL_HEIGHT_MULTIPLIER = 2; // Double wall height
 const CHAIR_SCALE = 4; // Chairs are 4x larger
 const CHAIR_CLEARANCE = 0.52;
-const CAMERA_INITIAL_RADIUS_FACTOR = 1.35;
-const CAMERA_MIN_RADIUS_FACTOR = 0.95;
-const CAMERA_MAX_RADIUS_FACTOR = 2.4;
-const CAMERA_INITIAL_PHI_LERP = 0.35;
-const CAMERA_VERTICAL_SENSITIVITY = 0.003;
-const CAMERA_LEAN_STRENGTH = 0.0065;
+const CAMERA_INITIAL_RADIUS_FACTOR = ARENA_CAMERA_DEFAULTS.initialRadiusFactor;
+const CAMERA_INITIAL_PHI_LERP = ARENA_CAMERA_DEFAULTS.initialPhiLerp;
+const CAMERA_VERTICAL_SENSITIVITY = ARENA_CAMERA_DEFAULTS.verticalSensitivity;
+const CAMERA_LEAN_STRENGTH = ARENA_CAMERA_DEFAULTS.leanStrength;
+const CAMERA_WHEEL_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 
 const SNOOKER_TABLE_SCALE = 1.3;
 const SNOOKER_TABLE_W = 66 * SNOOKER_TABLE_SCALE;
@@ -82,14 +82,15 @@ const CHESS_ARENA = Object.freeze({
   depth: (SNOOKER_ROOM_DEPTH * SNOOKER_WORLD_SCALE) / 2
 });
 
+const CAM_RANGE = buildArenaCameraConfig(BOARD_DISPLAY_SIZE);
 const CAM = {
-  fov: 52,
-  near: 0.1,
-  far: 5000,
-  minR: BOARD_DISPLAY_SIZE * CAMERA_MIN_RADIUS_FACTOR,
-  maxR: BOARD_DISPLAY_SIZE * CAMERA_MAX_RADIUS_FACTOR,
-  phiMin: 0.92,
-  phiMax: 1.22
+  fov: CAM_RANGE.fov,
+  near: CAM_RANGE.near,
+  far: CAM_RANGE.far,
+  minR: CAM_RANGE.minRadius,
+  maxR: CAM_RANGE.maxRadius,
+  phiMin: ARENA_CAMERA_DEFAULTS.phiMin,
+  phiMax: ARENA_CAMERA_DEFAULTS.phiMax
 };
 
 // =============== Materials & simple builders ===============
@@ -1203,7 +1204,7 @@ function Chess3D({ avatar, username }) {
     };
     const onWheel = (e) => {
       const r = sph.radius || 88;
-      sph.radius = clamp(r + e.deltaY * 0.2, CAM.minR, CAM.maxR);
+      sph.radius = clamp(r + e.deltaY * CAMERA_WHEEL_FACTOR, CAM.minR, CAM.maxR);
       fit();
     };
     renderer.domElement.addEventListener('mousedown', onDown);

--- a/webapp/src/utils/arenaCameraConfig.js
+++ b/webapp/src/utils/arenaCameraConfig.js
@@ -1,0 +1,24 @@
+export const ARENA_CAMERA_DEFAULTS = Object.freeze({
+  fov: 52,
+  near: 0.1,
+  far: 5000,
+  initialRadiusFactor: 1.35,
+  minRadiusFactor: 0.95,
+  maxRadiusFactor: 2.4,
+  initialPhiLerp: 0.35,
+  phiMin: 0.92,
+  phiMax: 1.22,
+  verticalSensitivity: 0.003,
+  leanStrength: 0.0065,
+  wheelDeltaFactor: 0.2
+});
+
+export function buildArenaCameraConfig(boardSize) {
+  return Object.freeze({
+    fov: ARENA_CAMERA_DEFAULTS.fov,
+    near: ARENA_CAMERA_DEFAULTS.near,
+    far: ARENA_CAMERA_DEFAULTS.far,
+    minRadius: boardSize * ARENA_CAMERA_DEFAULTS.minRadiusFactor,
+    maxRadius: boardSize * ARENA_CAMERA_DEFAULTS.maxRadiusFactor
+  });
+}


### PR DESCRIPTION
## Summary
- extract the arena camera defaults into a shared utility
- update the chess battle royale and snake 3D boards to use the shared camera configuration
- align the snake board zoom handling with the chess arena settings

## Testing
- npm run lint *(fails: existing lint errors in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ac96578883299fe3375378a1f7b3