### PR TITLE
Refresh pool table finishes and cue textures

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25,6 +25,15 @@ import {
   createCueRackDisplay,
   CUE_RACK_PALETTE
 } from '../../utils/createCueRackDisplay.js';
+import {
+  WOOD_FINISH_PRESETS,
+  applyWoodTextures,
+  createWoodMaterial,
+  disposeMaterialWithWood,
+  hslToHexNumber,
+  shiftLightness,
+  shiftSaturation
+} from '../../utils/woodMaterials.js';
 
 function signedRingArea(ring) {
   let area = 0;
@@ -927,337 +936,97 @@ const makeColorPalette = ({ cloth, rail, base, markings = 0xffffff }) => ({
   ...BASE_BALL_COLORS
 });
 
-const DEFAULT_TABLE_FINISH_ID = 'matteGraphite';
 
-const TABLE_FINISHES = Object.freeze({
-  classicWood: {
-    id: 'classicWood',
-    label: 'Classic Wood',
-    colors: makeColorPalette({
-      cloth: 0x2b7e4f,
-      rail: 0x5e3d24,
-      base: 0x5e3d24
-    }),
-    createMaterials: () => {
-      const frameColor = new THREE.Color('#5e3d24');
-      const frame = new THREE.MeshPhysicalMaterial({
-        color: frameColor,
-        metalness: 0.18,
-        roughness: 0.32,
-        clearcoat: 0.28,
-        clearcoatRoughness: 0.18,
-        sheen: 0.12,
-        sheenRoughness: 0.52,
-        reflectivity: 0.42,
-        envMapIntensity: 0.7
-      });
-      const rail = new THREE.MeshPhysicalMaterial({
-        color: frameColor.clone().offsetHSL(0, 0.02, 0.08),
-        metalness: 0.2,
-        roughness: 0.34,
-        clearcoat: 0.3,
-        clearcoatRoughness: 0.22,
-        sheen: 0.14,
-        sheenRoughness: 0.5,
-        reflectivity: 0.45,
-        envMapIntensity: 0.74
-      });
-      const trim = new THREE.MeshPhysicalMaterial({
-        color: 0xcda87b,
-        metalness: 0.65,
-        roughness: 0.38,
-        clearcoat: 0.42,
-        clearcoatRoughness: 0.28,
-        envMapIntensity: 0.9
-      });
-      return {
-        frame,
-        rail,
-        leg: frame,
-        trim,
-        accent: null
-      };
-    }
-  },
-  goldenMaple: {
-    id: 'goldenMaple',
-    label: 'Golden Maple',
-    colors: makeColorPalette({
-      cloth: 0x2b7e4f,
-      rail: 0xc98738,
-      base: 0xc27a2f
-    }),
-    createMaterials: () => {
-      const frameColor = new THREE.Color('#c98738');
-      const frame = new THREE.MeshPhysicalMaterial({
-        color: frameColor,
-        metalness: 0.16,
-        roughness: 0.28,
-        clearcoat: 0.36,
-        clearcoatRoughness: 0.16,
-        sheen: 0.14,
-        sheenRoughness: 0.48,
-        reflectivity: 0.46,
-        envMapIntensity: 0.82
-      });
-      const rail = new THREE.MeshPhysicalMaterial({
-        color: frameColor.clone().offsetHSL(0.01, 0.06, 0.12),
-        metalness: 0.2,
-        roughness: 0.3,
-        clearcoat: 0.38,
-        clearcoatRoughness: 0.18,
-        sheen: 0.16,
-        sheenRoughness: 0.46,
-        reflectivity: 0.52,
-        envMapIntensity: 0.88
-      });
-      const trim = new THREE.MeshPhysicalMaterial({
-        color: 0xe8c387,
-        metalness: 0.68,
-        roughness: 0.34,
-        clearcoat: 0.44,
-        clearcoatRoughness: 0.24,
-        envMapIntensity: 1
-      });
-      return {
-        frame,
-        rail,
-        leg: frame,
-        trim,
-        accent: null
-      };
-    }
-  },
-  nordicBirch: {
-    id: 'nordicBirch',
-    label: 'Nordic Birch',
-    colors: makeColorPalette({
-      cloth: 0x2b7e4f,
-      rail: 0xd8b47c,
-      base: 0xd2a86a
-    }),
-    createMaterials: () => {
-      const frameColor = new THREE.Color('#d8b47c');
-      const frame = new THREE.MeshPhysicalMaterial({
-        color: frameColor,
-        metalness: 0.12,
-        roughness: 0.26,
-        clearcoat: 0.4,
-        clearcoatRoughness: 0.14,
-        sheen: 0.18,
-        sheenRoughness: 0.44,
-        reflectivity: 0.48,
-        envMapIntensity: 0.9
-      });
-      const rail = new THREE.MeshPhysicalMaterial({
-        color: frameColor.clone().offsetHSL(0.02, 0.04, 0.1),
-        metalness: 0.16,
-        roughness: 0.28,
-        clearcoat: 0.42,
-        clearcoatRoughness: 0.18,
-        sheen: 0.2,
-        sheenRoughness: 0.4,
-        reflectivity: 0.5,
-        envMapIntensity: 0.95
-      });
-      const trim = new THREE.MeshPhysicalMaterial({
-        color: 0xf4e0b8,
-        metalness: 0.6,
-        roughness: 0.32,
-        clearcoat: 0.46,
-        clearcoatRoughness: 0.22,
-        envMapIntensity: 1.05
-      });
-      return {
-        frame,
-        rail,
-        leg: frame,
-        trim,
-        accent: null
-      };
-    }
-  },
-  matteGraphite: {
-    id: 'matteGraphite',
-    label: 'Matte Graphite',
-    colors: makeColorPalette({
-      cloth: 0x2b7e4f,
-      rail: 0x2f2f2f,
-      base: 0x2b2b2b
-    }),
-    createMaterials: () => {
-      const frame = new THREE.MeshPhysicalMaterial({
-        color: 0x2b2b2b,
-        metalness: 0.22,
-        roughness: 0.6,
-        clearcoat: 0.08,
-        clearcoatRoughness: 0.46,
-        sheen: 0.05,
-        sheenRoughness: 0.72
-      });
-      const rail = new THREE.MeshPhysicalMaterial({
-        color: 0x303030,
-        metalness: 0.28,
-        roughness: 0.54,
-        clearcoat: 0.12,
-        clearcoatRoughness: 0.4,
-        sheen: 0.04,
-        sheenRoughness: 0.64
-      });
-      const leg = new THREE.MeshPhysicalMaterial({
-        color: 0x232323,
-        metalness: 0.26,
-        roughness: 0.58,
-        clearcoat: 0.08,
-        clearcoatRoughness: 0.44
-      });
-      const trim = new THREE.MeshPhysicalMaterial({
-        color: 0x2a2f34,
-        metalness: 0.82,
-        roughness: 0.34,
-        clearcoat: 0.24,
-        clearcoatRoughness: 0.32,
-        envMapIntensity: 1.1
-      });
-      return {
-        frame,
-        rail,
-        leg,
-        trim,
-        accent: null
-      };
-    }
-  },
-  matteGraphiteNeon: {
-    id: 'matteGraphiteNeon',
-    label: 'Matte Graphite Neon',
-    colors: makeColorPalette({
-      cloth: 0x2b7e4f,
-      rail: 0x2f2f2f,
-      base: 0x2b2b2b
-    }),
-    createMaterials: () => {
-      const frame = new THREE.MeshPhysicalMaterial({
-        color: 0x2b2b2b,
-        metalness: 0.22,
-        roughness: 0.6,
-        clearcoat: 0.08,
-        clearcoatRoughness: 0.46,
-        sheen: 0.05,
-        sheenRoughness: 0.72
-      });
-      const rail = new THREE.MeshPhysicalMaterial({
-        color: 0x303030,
-        metalness: 0.28,
-        roughness: 0.54,
-        clearcoat: 0.12,
-        clearcoatRoughness: 0.4,
-        sheen: 0.04,
-        sheenRoughness: 0.64
-      });
-      const leg = new THREE.MeshPhysicalMaterial({
-        color: 0x232323,
-        metalness: 0.26,
-        roughness: 0.58,
-        clearcoat: 0.08,
-        clearcoatRoughness: 0.44
-      });
-      const trim = new THREE.MeshPhysicalMaterial({
-        color: 0x11161c,
-        metalness: 0.78,
-        roughness: 0.32,
-        clearcoat: 0.22,
-        clearcoatRoughness: 0.34,
-        envMapIntensity: 1.1
-      });
-      const neon = new THREE.Color('#00c8ff');
-      const accentMaterial = new THREE.MeshStandardMaterial({
-        color: neon,
-        emissive: neon.clone().multiplyScalar(0.55),
-        emissiveIntensity: 1.4,
-        metalness: 0.32,
-        roughness: 0.34
-      });
-      return {
-        frame,
-        rail,
-        leg,
-        trim,
-        accent: {
-          material: accentMaterial,
-          thickness: 0.055,
-          height: 0.028,
-          inset: 0.045,
-          verticalOffset: 0.82
-        }
-      };
-    }
-  },
-  twoToneHybrid: {
-    id: 'twoToneHybrid',
-    label: 'Two-Tone Hybrid',
-    colors: makeColorPalette({
-      cloth: 0x2b7e4f,
-      rail: 0x151a1f,
-      base: 0x1c2026
-    }),
-    createMaterials: () => {
-      const frame = new THREE.MeshPhysicalMaterial({
-        color: 0x1c2026,
-        metalness: 0.58,
-        roughness: 0.38,
-        clearcoat: 0.26,
-        clearcoatRoughness: 0.32,
-        sheen: 0.08,
-        sheenRoughness: 0.52
-      });
-      const rail = new THREE.MeshPhysicalMaterial({
-        color: 0x13171d,
-        metalness: 0.72,
-        roughness: 0.32,
-        clearcoat: 0.3,
-        clearcoatRoughness: 0.28,
-        sheen: 0.06,
-        sheenRoughness: 0.46
-      });
-      const leg = new THREE.MeshPhysicalMaterial({
-        color: 0x302218,
-        metalness: 0.22,
-        roughness: 0.52,
-        clearcoat: 0.18,
-        clearcoatRoughness: 0.42
-      });
-      const trim = new THREE.MeshPhysicalMaterial({
-        color: 0xc9a65c,
-        metalness: 0.86,
-        roughness: 0.26,
-        clearcoat: 0.4,
-        clearcoatRoughness: 0.24,
-        envMapIntensity: 1.18
-      });
-      const accentMaterial = new THREE.MeshStandardMaterial({
-        color: 0xffd369,
-        emissive: new THREE.Color(0xffd369).multiplyScalar(0.22),
-        emissiveIntensity: 0.9,
-        metalness: 0.48,
-        roughness: 0.38
-      });
-      return {
-        frame,
-        rail,
-        leg,
-        trim,
-        accent: {
-          material: accentMaterial,
-          thickness: 0.05,
-          height: 0.024,
-          inset: 0.06,
-          verticalOffset: 0.74
-        }
-      };
-    }
-  }
-});
+const DEFAULT_TABLE_FINISH_ID = 'oak';
+
+const TABLE_FINISHES = Object.freeze(
+  WOOD_FINISH_PRESETS.reduce((acc, preset) => {
+    const frameSat = preset.sat;
+    const frameLight = preset.light;
+    const railSat = shiftSaturation(preset.sat, 0.05);
+    const railLight = shiftLightness(preset.light, -0.08);
+    const legSat = shiftSaturation(preset.sat, -0.04);
+    const legLight = shiftLightness(preset.light, -0.12);
+    const baseColor = hslToHexNumber(preset.hue, frameSat, frameLight);
+    const railColor = hslToHexNumber(preset.hue, railSat, railLight);
+    const finish = {
+      id: preset.id,
+      label: preset.label,
+      colors: makeColorPalette({
+        cloth: 0x2b7e4f,
+        rail: railColor,
+        base: baseColor
+      }),
+      createMaterials: () => {
+        const frame = createWoodMaterial({
+          hue: preset.hue,
+          sat: frameSat,
+          light: frameLight,
+          contrast: preset.contrast,
+          repeat: { x: 1.3, y: 0.9 },
+          roughnessBase: 0.18,
+          roughnessVariance: 0.22,
+          roughness: 0.32,
+          metalness: 0.2,
+          clearcoat: 0.46,
+          clearcoatRoughness: 0.18,
+          sheen: 0.18,
+          sheenRoughness: 0.5,
+          envMapIntensity: 1.2
+        });
+        const rail = createWoodMaterial({
+          hue: preset.hue,
+          sat: railSat,
+          light: railLight,
+          contrast: preset.contrast * 1.1,
+          repeat: { x: 1.8, y: 1.1 },
+          roughnessBase: 0.2,
+          roughnessVariance: 0.24,
+          roughness: 0.28,
+          metalness: 0.18,
+          clearcoat: 0.5,
+          clearcoatRoughness: 0.18,
+          sheen: 0.22,
+          sheenRoughness: 0.46,
+          envMapIntensity: 1.25
+        });
+        const leg = createWoodMaterial({
+          hue: preset.hue,
+          sat: legSat,
+          light: legLight,
+          contrast: preset.contrast * 1.18,
+          repeat: { x: 1.4, y: 1 },
+          roughnessBase: 0.22,
+          roughnessVariance: 0.28,
+          roughness: 0.34,
+          metalness: 0.18,
+          clearcoat: 0.42,
+          clearcoatRoughness: 0.2,
+          sheen: 0.16,
+          sheenRoughness: 0.52,
+          envMapIntensity: 1.15
+        });
+        const trim = new THREE.MeshPhysicalMaterial({
+          color: 0xf2f6fb,
+          metalness: 0.95,
+          roughness: 0.12,
+          clearcoat: 0.62,
+          clearcoatRoughness: 0.1,
+          envMapIntensity: 1.38
+        });
+        return {
+          frame,
+          rail,
+          leg,
+          trim,
+          accent: null
+        };
+      }
+    };
+    acc[preset.id] = Object.freeze(finish);
+    return acc;
+  }, {})
+);
 
 const TABLE_FINISH_OPTIONS = Object.freeze(Object.values(TABLE_FINISHES));
 
@@ -1267,37 +1036,37 @@ const CHROME_COLOR_OPTIONS = Object.freeze([
     id: 'chrome',
     label: 'Chrome',
     color: 0xc0c9d5,
-    metalness: 0.92,
-    roughness: 0.28,
-    clearcoat: 0.3,
-    clearcoatRoughness: 0.18
+    metalness: 0.98,
+    roughness: 0.12,
+    clearcoat: 0.68,
+    clearcoatRoughness: 0.08
   },
   {
     id: 'gold',
     label: 'Gold',
     color: 0xd4af37,
-    metalness: 0.88,
-    roughness: 0.35,
-    clearcoat: 0.26,
-    clearcoatRoughness: 0.2
+    metalness: 0.96,
+    roughness: 0.18,
+    clearcoat: 0.56,
+    clearcoatRoughness: 0.12
   },
   {
     id: 'matteBlack',
     label: 'Matte Black',
     color: 0x1a1a1a,
-    metalness: 0.64,
-    roughness: 0.58,
-    clearcoat: 0.12,
-    clearcoatRoughness: 0.4
+    metalness: 0.84,
+    roughness: 0.36,
+    clearcoat: 0.32,
+    clearcoatRoughness: 0.18
   },
   {
     id: 'brown',
     label: 'Brown',
     color: 0x6b4128,
-    metalness: 0.76,
-    roughness: 0.44,
-    clearcoat: 0.22,
-    clearcoatRoughness: 0.28
+    metalness: 0.88,
+    roughness: 0.28,
+    clearcoat: 0.48,
+    clearcoatRoughness: 0.16
   }
 ]);
 
@@ -4515,14 +4284,15 @@ function applyTableFinishToTable(table, finish) {
   }
 
   const disposed = new Set();
+  const disposeMaterial = (material) => {
+    if (!material || disposed.has(material)) return;
+    disposeMaterialWithWood(material);
+    disposed.add(material);
+  };
   const swapMaterial = (mesh, material) => {
     if (!mesh || !material) return;
     if (mesh.material !== material) {
-      const current = mesh.material;
-      if (current?.dispose && !disposed.has(current)) {
-        current.dispose();
-        disposed.add(current);
-      }
+      disposeMaterial(mesh.material);
       mesh.material = material;
     }
   };
@@ -4540,11 +4310,7 @@ function applyTableFinishToTable(table, finish) {
     if (accentMesh.geometry) {
       accentMesh.geometry.dispose();
     }
-    const accentMaterial = accentMesh.material;
-    if (accentMaterial?.dispose && !disposed.has(accentMaterial)) {
-      accentMaterial.dispose();
-      disposed.add(accentMaterial);
-    }
+    disposeMaterial(accentMesh.material);
     finishInfo.parts.accentMesh = null;
   }
   if (accentConfig && accentParent && dimensions) {
@@ -4659,7 +4425,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   const cueRackGroupsRef = useRef([]);
   const cueOptionGroupsRef = useRef([]);
   const cueRackMetaRef = useRef(new Map());
-  const cueMaterialsRef = useRef({ shaft: null });
+  const cueMaterialsRef = useRef({ shaft: null, styleIndex: null });
   const cueGalleryStateRef = useRef({
     active: false,
     rackId: null,
@@ -4714,11 +4480,37 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
 
   const applySelectedCueStyle = useCallback(
     (index) => {
-      const color = getCueColorFromIndex(index);
-      cueStyleIndexRef.current = index;
-      const shaftMaterial = cueMaterialsRef.current?.shaft;
-      if (shaftMaterial && typeof color === 'number') {
-        shaftMaterial.color.setHex(color);
+      const paletteLength = CUE_RACK_PALETTE.length || WOOD_FINISH_PRESETS.length || 1;
+      const normalized = ((index % paletteLength) + paletteLength) % paletteLength;
+      const preset = WOOD_FINISH_PRESETS[normalized % WOOD_FINISH_PRESETS.length];
+      const color = getCueColorFromIndex(normalized);
+      cueStyleIndexRef.current = normalized;
+      const materials = cueMaterialsRef.current ?? {};
+      const shaftMaterial = materials.shaft;
+      if (shaftMaterial && preset) {
+        if (materials.styleIndex !== normalized) {
+          applyWoodTextures(shaftMaterial, {
+            hue: preset.hue,
+            sat: preset.sat,
+            light: preset.light,
+            contrast: preset.contrast,
+            repeat: { x: 1, y: 5.5 },
+            roughnessBase: 0.16,
+            roughnessVariance: 0.22
+          });
+          shaftMaterial.roughness = 0.38;
+          shaftMaterial.metalness = 0.16;
+          shaftMaterial.clearcoat = 0.5;
+          shaftMaterial.clearcoatRoughness = 0.16;
+          shaftMaterial.sheen = 0.22;
+          shaftMaterial.sheenRoughness = 0.5;
+          shaftMaterial.envMapIntensity = 1.1;
+          materials.styleIndex = normalized;
+        }
+        shaftMaterial.userData = shaftMaterial.userData || {};
+        shaftMaterial.userData.isCueWood = true;
+        shaftMaterial.userData.cueOptionIndex = normalized;
+        shaftMaterial.userData.cueOptionColor = color;
         shaftMaterial.needsUpdate = true;
       }
       updateCueRackHighlights();
@@ -8379,11 +8171,35 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         length: cueLen
       };
 
-      const shaftMaterial = new THREE.MeshPhysicalMaterial({
-        color: 0xdeb887,
-        roughness: 0.6
+      const paletteLength = CUE_RACK_PALETTE.length || WOOD_FINISH_PRESETS.length || 1;
+      const initialIndexRaw = cueStyleIndexRef.current ?? cueStyleIndex ?? 0;
+      const initialIndex =
+        ((initialIndexRaw % paletteLength) + paletteLength) % paletteLength;
+      const initialPreset =
+        WOOD_FINISH_PRESETS[initialIndex % WOOD_FINISH_PRESETS.length] ??
+        WOOD_FINISH_PRESETS[0];
+      const shaftMaterial = createWoodMaterial({
+        hue: initialPreset.hue,
+        sat: initialPreset.sat,
+        light: initialPreset.light,
+        contrast: initialPreset.contrast,
+        repeat: { x: 1, y: 5.5 },
+        roughnessBase: 0.16,
+        roughnessVariance: 0.22,
+        roughness: 0.38,
+        metalness: 0.16,
+        clearcoat: 0.5,
+        clearcoatRoughness: 0.16,
+        sheen: 0.22,
+        sheenRoughness: 0.5,
+        envMapIntensity: 1.1
       });
+      shaftMaterial.userData = shaftMaterial.userData || {};
+      shaftMaterial.userData.isCueWood = true;
+      shaftMaterial.userData.cueOptionIndex = initialIndex;
+      shaftMaterial.userData.cueOptionColor = getCueColorFromIndex(initialIndex);
       cueMaterialsRef.current.shaft = shaftMaterial;
+      cueMaterialsRef.current.styleIndex = initialIndex;
       const frontLength = THREE.MathUtils.clamp(
         cueLen * CUE_FRONT_SECTION_RATIO,
         cueLen * 0.1,
@@ -10542,7 +10358,11 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           cueRackGroupsRef.current = [];
           cueOptionGroupsRef.current = [];
           cueRackMetaRef.current = new Map();
+          if (cueMaterialsRef.current?.shaft) {
+            disposeMaterialWithWood(cueMaterialsRef.current.shaft);
+          }
           cueMaterialsRef.current.shaft = null;
+          cueMaterialsRef.current.styleIndex = null;
           cueGalleryStateRef.current.active = false;
           cueGalleryStateRef.current.rackId = null;
           cueGalleryStateRef.current.prev = null;

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -1,0 +1,204 @@
+import * as THREE from 'three';
+
+const clamp01 = (value) => Math.min(1, Math.max(0, value));
+const normalizeHue = (h) => {
+  let hue = h % 360;
+  if (hue < 0) hue += 360;
+  return hue;
+};
+
+const hslString = (h, s, l) => {
+  const sat = clamp01(s);
+  const light = clamp01(l);
+  return `hsl(${normalizeHue(h)}, ${Math.round(sat * 100)}%, ${Math.round(light * 100)}%)`;
+};
+
+const makeNaturalWoodTexture = (width, height, hue, sat, light, contrast) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = hslString(hue, sat, light);
+  ctx.fillRect(0, 0, width, height);
+
+  for (let i = 0; i < 3000; i += 1) {
+    const x = Math.random() * width;
+    const y = Math.random() * height;
+    const grainLen = 50 + Math.random() * 200;
+    const curve = Math.sin(y / 40 + Math.random() * 2) * 10;
+    ctx.strokeStyle = hslString(hue, sat * 0.6, light - Math.random() * contrast);
+    ctx.lineWidth = 0.8 + Math.random() * 1.2;
+    ctx.globalAlpha = 0.25 + Math.random() * 0.3;
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    ctx.quadraticCurveTo(x + curve, y + grainLen / 2, x, y + grainLen);
+    ctx.stroke();
+  }
+
+  for (let i = 0; i < 40; i += 1) {
+    const kx = Math.random() * width;
+    const ky = Math.random() * height;
+    const r = 8 + Math.random() * 15;
+    const grad = ctx.createRadialGradient(kx, ky, 0, kx, ky, r);
+    grad.addColorStop(0, hslString(hue, sat * 0.9, light - 0.3));
+    grad.addColorStop(1, hslString(hue, sat * 0.4, light));
+    ctx.fillStyle = grad;
+    ctx.globalAlpha = 0.7;
+    ctx.beginPath();
+    ctx.arc(kx, ky, r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.anisotropy = 16;
+  return texture;
+};
+
+const makeRoughnessMap = (width, height, base, variance) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  const imageData = ctx.createImageData(width, height);
+  const data = imageData.data;
+  for (let i = 0; i < data.length; i += 4) {
+    const value = base + (Math.random() - 0.5) * variance;
+    const g = Math.max(0, Math.min(255, Math.floor(value * 255)));
+    data[i] = g;
+    data[i + 1] = g;
+    data[i + 2] = g;
+    data[i + 3] = 255;
+  }
+  ctx.putImageData(imageData, 0, 0);
+  return new THREE.CanvasTexture(canvas);
+};
+
+const disposeWoodTextures = (material) => {
+  if (!material) return;
+  const textures = material.userData?.__woodTextures;
+  if (textures) {
+    const { map, roughnessMap } = textures;
+    if (map?.dispose) map.dispose();
+    if (roughnessMap && roughnessMap !== map && roughnessMap.dispose) {
+      roughnessMap.dispose();
+    }
+    delete material.userData.__woodTextures;
+  }
+  if (material.map?.dispose) {
+    material.map.dispose();
+  }
+  if (material.roughnessMap && material.roughnessMap !== material.map && material.roughnessMap.dispose) {
+    material.roughnessMap.dispose();
+  }
+  material.map = null;
+  material.roughnessMap = null;
+};
+
+export const WOOD_FINISH_PRESETS = Object.freeze([
+  Object.freeze({ id: 'birch', label: 'Birch', hue: 38, sat: 0.25, light: 0.84, contrast: 0.42 }),
+  Object.freeze({ id: 'maple', label: 'Maple', hue: 35, sat: 0.22, light: 0.78, contrast: 0.44 }),
+  Object.freeze({ id: 'oak', label: 'Oak', hue: 32, sat: 0.34, light: 0.7, contrast: 0.52 }),
+  Object.freeze({ id: 'cherry', label: 'Cherry', hue: 14, sat: 0.42, light: 0.6, contrast: 0.58 }),
+  Object.freeze({ id: 'teak', label: 'Teak', hue: 28, sat: 0.4, light: 0.52, contrast: 0.6 }),
+  Object.freeze({ id: 'walnut', label: 'Walnut', hue: 22, sat: 0.4, light: 0.44, contrast: 0.64 }),
+  Object.freeze({ id: 'smokedOak', label: 'Smoked Oak', hue: 28, sat: 0.35, light: 0.28, contrast: 0.75 }),
+  Object.freeze({ id: 'wenge', label: 'Wenge', hue: 24, sat: 0.38, light: 0.22, contrast: 0.8 }),
+  Object.freeze({ id: 'ebony', label: 'Ebony', hue: 25, sat: 0.35, light: 0.18, contrast: 0.85 })
+]);
+
+export const DEFAULT_WOOD_TEXTURE_SIZE = 1024;
+export const DEFAULT_WOOD_ROUGHNESS_SIZE = 512;
+
+export const shiftLightness = (light, delta) => clamp01(light + delta);
+export const shiftSaturation = (sat, delta) => clamp01(sat + delta);
+
+export const hslToHexNumber = (h, s, l) => {
+  const color = new THREE.Color();
+  color.setHSL(normalizeHue(h) / 360, clamp01(s), clamp01(l));
+  return color.getHex();
+};
+
+export const applyWoodTextures = (
+  material,
+  {
+    hue,
+    sat,
+    light,
+    contrast,
+    repeat = { x: 1, y: 1 },
+    rotation = 0,
+    textureSize = DEFAULT_WOOD_TEXTURE_SIZE,
+    roughnessSize = DEFAULT_WOOD_ROUGHNESS_SIZE,
+    roughnessBase = 0.18,
+    roughnessVariance = 0.25
+  } = {}
+) => {
+  if (!material) return null;
+  disposeWoodTextures(material);
+  const map = makeNaturalWoodTexture(textureSize, textureSize, hue, sat, light, contrast);
+  const roughnessMap = makeRoughnessMap(roughnessSize, roughnessSize, roughnessBase, roughnessVariance);
+  map.wrapS = map.wrapT = THREE.RepeatWrapping;
+  roughnessMap.wrapS = roughnessMap.wrapT = THREE.RepeatWrapping;
+  const repeatX = repeat?.x ?? 1;
+  const repeatY = repeat?.y ?? 1;
+  map.repeat.set(repeatX, repeatY);
+  roughnessMap.repeat.set(repeatX, repeatY);
+  map.center.set(0.5, 0.5);
+  roughnessMap.center.set(0.5, 0.5);
+  if (rotation) {
+    map.rotation = rotation;
+    roughnessMap.rotation = rotation;
+  }
+  material.map = map;
+  material.roughnessMap = roughnessMap;
+  material.color.setHex(0xffffff);
+  material.needsUpdate = true;
+  material.map.needsUpdate = true;
+  material.roughnessMap.needsUpdate = true;
+  material.userData = material.userData || {};
+  material.userData.__woodTextures = { map, roughnessMap };
+  return { map, roughnessMap };
+};
+
+export const createWoodMaterial = ({
+  hue,
+  sat,
+  light,
+  contrast,
+  repeat,
+  rotation = 0,
+  textureSize = DEFAULT_WOOD_TEXTURE_SIZE,
+  roughnessSize = DEFAULT_WOOD_ROUGHNESS_SIZE,
+  roughnessBase = 0.18,
+  roughnessVariance = 0.25,
+  ...materialProps
+} = {}) => {
+  const material = new THREE.MeshPhysicalMaterial({
+    color: 0xffffff,
+    ...materialProps
+  });
+  applyWoodTextures(material, {
+    hue,
+    sat,
+    light,
+    contrast,
+    repeat,
+    rotation,
+    textureSize,
+    roughnessSize,
+    roughnessBase,
+    roughnessVariance
+  });
+  return material;
+};
+
+export const disposeMaterialWithWood = (material) => {
+  if (!material) return;
+  disposeWoodTextures(material);
+  if (material.dispose) {
+    material.dispose();
+  }
+};
+


### PR DESCRIPTION
## Summary
- replace the pool table finish catalogue with wood grain presets and shinier chrome trims
- rework cue selection to use the same generated wood materials in game and on the cue rack
- add a shared utility for creating natural wood textures and roughness maps

## Testing
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_68e3f2f36d348329a7eb43e8da576f9b