### PR TITLE
Enlarge wood grain on 3D billiards tables

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -697,6 +697,7 @@ const UI_SCALE = SIZE_REDUCTION;
 
 const BASE_WOOD_COLOR = '#8b5e3c';
 const WOOD_REPEAT_UNIT = TABLE.THICK * 0.92;
+const TABLE_WOOD_TEXTURE_SCALE = 0.1; // Enlarge the wood grain on the table rails and skirts
 
 const DEFAULT_POOL_VARIANT = 'american';
 const UK_POOL_RED = 0xd12c2c;
@@ -3464,7 +3465,7 @@ function Table3D(
   const woodRailRepeat = new THREE.Vector2(
     Math.max(1, ((outerHalfW * 2 + outerHalfH * 2) / Math.max(1e-6, WOOD_REPEAT_UNIT))),
     Math.max(1, railH / Math.max(1e-6, WOOD_REPEAT_UNIT))
-  );
+  ).multiplyScalar(TABLE_WOOD_TEXTURE_SCALE);
   applyWoodTextureToMaterial(railMat, woodRailRepeat);
   finishParts.woodRepeats.rail = woodRailRepeat.clone();
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
@@ -4271,7 +4272,7 @@ function Table3D(
   const woodFrameRepeat = new THREE.Vector2(
     Math.max(1, legCircumference / Math.max(1e-6, WOOD_REPEAT_UNIT)),
     Math.max(1, legH / Math.max(1e-6, WOOD_REPEAT_UNIT))
-  );
+  ).multiplyScalar(TABLE_WOOD_TEXTURE_SCALE);
   applyWoodTextureToMaterial(frameMat, woodFrameRepeat);
   if (legMat !== frameMat) {
     applyWoodTextureToMaterial(legMat, woodFrameRepeat);

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -708,6 +708,7 @@ const makeColorPalette = ({ cloth, rail, base, markings = 0xffffff }) => ({
 });
 
 const CUE_WOOD_REPEAT = new THREE.Vector2(1, 5.5);
+const TABLE_WOOD_TEXTURE_SCALE = 0.1; // Enlarge the wood grain on the table rails and skirts
 
 const DEFAULT_TABLE_FINISH_ID = 'matteGraphite';
 
@@ -3518,7 +3519,7 @@ function Table3D(
   const outerHalfW = halfW + 2 * longRailW + frameWidthLong;
   const outerHalfH = halfH + 2 * endRailW + frameWidthEnd;
   finishParts.dimensions = { outerHalfW, outerHalfH, railH, frameTopY };
-  const woodRailRepeat = CUE_WOOD_REPEAT.clone();
+  const woodRailRepeat = CUE_WOOD_REPEAT.clone().multiplyScalar(TABLE_WOOD_TEXTURE_SCALE);
   applyWoodTextureToMaterial(railMat, woodRailRepeat);
   finishParts.woodRepeats.rail = woodRailRepeat.clone();
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
@@ -4326,7 +4327,7 @@ function Table3D(
     [frameOuterX - legInset, frameOuterZ - legInset]
   ];
   const legY = legTopLocal + LEG_TOP_OVERLAP - legH / 2;
-  const woodFrameRepeat = CUE_WOOD_REPEAT.clone();
+  const woodFrameRepeat = CUE_WOOD_REPEAT.clone().multiplyScalar(TABLE_WOOD_TEXTURE_SCALE);
   applyWoodTextureToMaterial(frameMat, woodFrameRepeat);
   if (legMat !== frameMat) {
     applyWoodTextureToMaterial(legMat, woodFrameRepeat);


### PR DESCRIPTION
## Summary
- scale the 3D snooker table rail and skirt wood textures to show a coarser grain
- apply the same wood grain enlargement to the Pool Royale rails and frame to cover all 3D billiards modes

## Testing
- npm test -- --runTestsByPath tests/snooker.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e40f7ce394832982cdd2d6a35d181e