### PR TITLE
Align table wood grain with cue textures

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -441,6 +441,15 @@ const MM_TO_UNITS = innerLong / WIDTH_REF;
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
+const CUE_WOOD_WORLD_UNIT = (() => {
+  const cueLength = 1.5 * (BALL_R / 0.0525) * CUE_LENGTH_MULTIPLIER;
+  const repeats = SHARED_WOOD_REPEAT.y;
+  return repeats > 1e-6 ? cueLength / repeats : 0;
+})();
+const TABLE_WOOD_TEXTURE_SCALE =
+  CUE_WOOD_WORLD_UNIT > 1e-6
+    ? WOOD_REPEAT_UNIT / CUE_WOOD_WORLD_UNIT
+    : 1; // Match the cue butt grain density on table rails and skirts
 const CHALK_TOP_COLOR = 0x1f6d86;
 const CHALK_SIDE_COLOR = 0x162b36;
 const CHALK_SIDE_ACTIVE_COLOR = 0x1f4b5d;
@@ -697,7 +706,6 @@ const UI_SCALE = SIZE_REDUCTION;
 
 const BASE_WOOD_COLOR = '#8b5e3c';
 const WOOD_REPEAT_UNIT = TABLE.THICK * 0.92;
-const TABLE_WOOD_TEXTURE_SCALE = 0.1; // Enlarge the wood grain on the table rails and skirts
 
 const DEFAULT_POOL_VARIANT = 'american';
 const UK_POOL_RED = 0xd12c2c;

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -433,6 +433,15 @@ const MM_TO_UNITS = innerLong / WIDTH_REF;
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
+const CUE_WOOD_WORLD_UNIT = (() => {
+  const cueLength = 1.5 * (BALL_R / 0.0525) * CUE_LENGTH_MULTIPLIER;
+  const repeats = CUE_WOOD_REPEAT.y;
+  return repeats > 1e-6 ? cueLength / repeats : 0;
+})();
+const TABLE_WOOD_TEXTURE_SCALE =
+  CUE_WOOD_WORLD_UNIT > 1e-6
+    ? TABLE_WOOD_REPEAT_UNIT / CUE_WOOD_WORLD_UNIT
+    : 1; // Align rail grain with the cue butt texture scale
 const CHALK_TOP_COLOR = 0x1f6d86;
 const CHALK_SIDE_COLOR = 0x162b36;
 const CHALK_SIDE_ACTIVE_COLOR = 0x1f4b5d;
@@ -708,7 +717,7 @@ const makeColorPalette = ({ cloth, rail, base, markings = 0xffffff }) => ({
 });
 
 const CUE_WOOD_REPEAT = new THREE.Vector2(1, 5.5);
-const TABLE_WOOD_TEXTURE_SCALE = 0.1; // Enlarge the wood grain on the table rails and skirts
+const TABLE_WOOD_REPEAT_UNIT = TABLE.THICK * 0.92;
 
 const DEFAULT_TABLE_FINISH_ID = 'matteGraphite';
 


### PR DESCRIPTION
## Summary
- derive the pool table wood texture scale from the cue length so rail and skirt grain density matches the cue butt across 9-ball, UK 8-ball and American variants
- apply the same cue-aligned wood grain scaling to the 3D snooker table rails and skirts without altering the cue materials

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e41bb59eac8329b16e920f4e22fb14