### PR TITLE
Align billiards table wood textures with cue scale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -697,7 +697,7 @@ const UI_SCALE = SIZE_REDUCTION;
 
 const BASE_WOOD_COLOR = '#8b5e3c';
 const WOOD_REPEAT_UNIT = TABLE.THICK * 0.92;
-const TABLE_WOOD_TEXTURE_SCALE = 0.1; // Enlarge the wood grain on the table rails and skirts
+const CUE_WOOD_REPEAT = new THREE.Vector2(1, 5.5); // Mirror the cue butt wood repeat for table finishes
 
 const DEFAULT_POOL_VARIANT = 'american';
 const UK_POOL_RED = 0xd12c2c;
@@ -3462,10 +3462,19 @@ function Table3D(
   const outerHalfW = halfW + 2 * longRailW + frameWidthLong;
   const outerHalfH = halfH + 2 * endRailW + frameWidthEnd;
   finishParts.dimensions = { outerHalfW, outerHalfH, railH, frameTopY };
-  const woodRailRepeat = new THREE.Vector2(
-    Math.max(1, ((outerHalfW * 2 + outerHalfH * 2) / Math.max(1e-6, WOOD_REPEAT_UNIT))),
+  const woodRailRepeatBase = new THREE.Vector2(
+    Math.max(
+      1,
+      (outerHalfW * 2 + outerHalfH * 2) / Math.max(1e-6, WOOD_REPEAT_UNIT)
+    ),
     Math.max(1, railH / Math.max(1e-6, WOOD_REPEAT_UNIT))
-  ).multiplyScalar(TABLE_WOOD_TEXTURE_SCALE);
+  );
+  // Rescale so the visible grain matches the cue butt texture density.
+  const woodRailScale =
+    CUE_WOOD_REPEAT.y / Math.max(woodRailRepeatBase.y, 1e-6);
+  const woodRailRepeat = woodRailRepeatBase.multiplyScalar(woodRailScale);
+  woodRailRepeat.y = CUE_WOOD_REPEAT.y;
+  woodRailRepeat.x = Math.max(CUE_WOOD_REPEAT.x, woodRailRepeat.x);
   applyWoodTextureToMaterial(railMat, woodRailRepeat);
   finishParts.woodRepeats.rail = woodRailRepeat.clone();
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
@@ -4269,10 +4278,16 @@ function Table3D(
   ];
   const legY = legTopLocal + LEG_TOP_OVERLAP - legH / 2;
   const legCircumference = 2 * Math.PI * legR;
-  const woodFrameRepeat = new THREE.Vector2(
+  const woodFrameRepeatBase = new THREE.Vector2(
     Math.max(1, legCircumference / Math.max(1e-6, WOOD_REPEAT_UNIT)),
     Math.max(1, legH / Math.max(1e-6, WOOD_REPEAT_UNIT))
-  ).multiplyScalar(TABLE_WOOD_TEXTURE_SCALE);
+  );
+  // Rescale so the visible grain matches the cue butt texture density.
+  const woodFrameScale =
+    CUE_WOOD_REPEAT.y / Math.max(woodFrameRepeatBase.y, 1e-6);
+  const woodFrameRepeat = woodFrameRepeatBase.multiplyScalar(woodFrameScale);
+  woodFrameRepeat.y = CUE_WOOD_REPEAT.y;
+  woodFrameRepeat.x = Math.max(CUE_WOOD_REPEAT.x, woodFrameRepeat.x);
   applyWoodTextureToMaterial(frameMat, woodFrameRepeat);
   if (legMat !== frameMat) {
     applyWoodTextureToMaterial(legMat, woodFrameRepeat);

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -708,7 +708,7 @@ const makeColorPalette = ({ cloth, rail, base, markings = 0xffffff }) => ({
 });
 
 const CUE_WOOD_REPEAT = new THREE.Vector2(1, 5.5);
-const TABLE_WOOD_TEXTURE_SCALE = 0.1; // Enlarge the wood grain on the table rails and skirts
+const TABLE_WOOD_TEXTURE_SCALE = 1; // Match the cue butt wood grain scale on the table rails and skirts
 
 const DEFAULT_TABLE_FINISH_ID = 'matteGraphite';
 


### PR DESCRIPTION
## Summary
- match the snooker table wood texture scale to the cue butt finish
- rescale Pool Royale rail and frame textures to reuse the cue wood repeat so grain density stays consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e42150b97c83298188e4ad5b50266e