### PR TITLE
Align table wood textures with cue finish

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -696,7 +696,6 @@ const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.09; // pull cushions sl
 const UI_SCALE = SIZE_REDUCTION;
 
 const BASE_WOOD_COLOR = '#8b5e3c';
-const WOOD_REPEAT_UNIT = TABLE.THICK * 0.92;
 const CUE_WOOD_REPEAT = new THREE.Vector2(1, 5.5); // Mirror the cue butt wood repeat for table finishes
 
 const DEFAULT_POOL_VARIANT = 'american';
@@ -3462,19 +3461,9 @@ function Table3D(
   const outerHalfW = halfW + 2 * longRailW + frameWidthLong;
   const outerHalfH = halfH + 2 * endRailW + frameWidthEnd;
   finishParts.dimensions = { outerHalfW, outerHalfH, railH, frameTopY };
-  const woodRailRepeatBase = new THREE.Vector2(
-    Math.max(
-      1,
-      (outerHalfW * 2 + outerHalfH * 2) / Math.max(1e-6, WOOD_REPEAT_UNIT)
-    ),
-    Math.max(1, railH / Math.max(1e-6, WOOD_REPEAT_UNIT))
-  );
-  // Rescale so the visible grain matches the cue butt texture density.
-  const woodRailScale =
-    CUE_WOOD_REPEAT.y / Math.max(woodRailRepeatBase.y, 1e-6);
-  const woodRailRepeat = woodRailRepeatBase.multiplyScalar(woodRailScale);
-  woodRailRepeat.y = CUE_WOOD_REPEAT.y;
-  woodRailRepeat.x = Math.max(CUE_WOOD_REPEAT.x, woodRailRepeat.x);
+  // Force the table rails to reuse the exact cue butt wood scale so the grain
+  // is just as visible as it is on the stick finish in cue view.
+  const woodRailRepeat = CUE_WOOD_REPEAT.clone();
   applyWoodTextureToMaterial(railMat, woodRailRepeat);
   finishParts.woodRepeats.rail = woodRailRepeat.clone();
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
@@ -4278,16 +4267,9 @@ function Table3D(
   ];
   const legY = legTopLocal + LEG_TOP_OVERLAP - legH / 2;
   const legCircumference = 2 * Math.PI * legR;
-  const woodFrameRepeatBase = new THREE.Vector2(
-    Math.max(1, legCircumference / Math.max(1e-6, WOOD_REPEAT_UNIT)),
-    Math.max(1, legH / Math.max(1e-6, WOOD_REPEAT_UNIT))
-  );
-  // Rescale so the visible grain matches the cue butt texture density.
-  const woodFrameScale =
-    CUE_WOOD_REPEAT.y / Math.max(woodFrameRepeatBase.y, 1e-6);
-  const woodFrameRepeat = woodFrameRepeatBase.multiplyScalar(woodFrameScale);
-  woodFrameRepeat.y = CUE_WOOD_REPEAT.y;
-  woodFrameRepeat.x = Math.max(CUE_WOOD_REPEAT.x, woodFrameRepeat.x);
+  // Match the skirt/apron wood grain with the cue butt so the pattern reads
+  // clearly from the player perspective.
+  const woodFrameRepeat = CUE_WOOD_REPEAT.clone();
   applyWoodTextureToMaterial(frameMat, woodFrameRepeat);
   if (legMat !== frameMat) {
     applyWoodTextureToMaterial(legMat, woodFrameRepeat);


### PR DESCRIPTION
## Summary
- match the pool table rail and skirt wood texture scale to the cue butt repeat so the grain is clearly visible
- ensure shared wood repeat data for rails, frame, and legs clones the cue repeat for consistent rendering

## Testing
- npm run lint *(fails: repo currently has pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e42d48db748329ba98024efdd636d6