### PR TITLE
Expand Murlan Royale arena width

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -192,7 +192,7 @@ export default function MurlanRoyaleArena({ search }) {
     const boardSize = (TABLE_RADIUS * 2 + 1.2) * arenaScale;
     const camConfig = buildArenaCameraConfig(boardSize);
 
-    const arenaHalfWidth = boardSize;
+    const arenaHalfWidth = boardSize * 1.3;
     const arenaHalfDepth = boardSize * 1.05;
     const wallInset = 0.5;
     const wallProximity = 0.5;


### PR DESCRIPTION
## Summary
- expand the Murlan Royale arena footprint sideways by enlarging the half-width calculation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e43773ff208329bd9455f89b469d76