### PR TITLE
Align wood seams to right rail on 3D tables

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3757,16 +3757,7 @@ function Table3D(
   );
 
   const railsOuter = new THREE.Shape();
-  railsOuter.moveTo(-outerHalfW + outerCornerRadius, -outerHalfH);
-  railsOuter.lineTo(outerHalfW - outerCornerRadius, -outerHalfH);
-  railsOuter.absarc(
-    outerHalfW - outerCornerRadius,
-    -outerHalfH + outerCornerRadius,
-    outerCornerRadius,
-    -Math.PI / 2,
-    0,
-    false
-  );
+  railsOuter.moveTo(outerHalfW, -outerHalfH + outerCornerRadius);
   railsOuter.lineTo(outerHalfW, outerHalfH - outerCornerRadius);
   railsOuter.absarc(
     outerHalfW - outerCornerRadius,
@@ -3792,6 +3783,15 @@ function Table3D(
     outerCornerRadius,
     Math.PI,
     1.5 * Math.PI,
+    false
+  );
+  railsOuter.lineTo(outerHalfW - outerCornerRadius, -outerHalfH);
+  railsOuter.absarc(
+    outerHalfW - outerCornerRadius,
+    -outerHalfH + outerCornerRadius,
+    outerCornerRadius,
+    -Math.PI / 2,
+    0,
     false
   );
 
@@ -4051,16 +4051,7 @@ function Table3D(
     outerCornerRadius + baseOverhang * 0.4,
     Math.min(outW, outZ)
   );
-  skirtShape.moveTo(-outW + skirtOuterRadius, -outZ);
-  skirtShape.lineTo(outW - skirtOuterRadius, -outZ);
-  skirtShape.absarc(
-    outW - skirtOuterRadius,
-    -outZ + skirtOuterRadius,
-    skirtOuterRadius,
-    -Math.PI / 2,
-    0,
-    false
-  );
+  skirtShape.moveTo(outW, -outZ + skirtOuterRadius);
   skirtShape.lineTo(outW, outZ - skirtOuterRadius);
   skirtShape.absarc(
     outW - skirtOuterRadius,
@@ -4088,19 +4079,19 @@ function Table3D(
     1.5 * Math.PI,
     false
   );
+  skirtShape.lineTo(outW - skirtOuterRadius, -outZ);
+  skirtShape.absarc(
+    outW - skirtOuterRadius,
+    -outZ + skirtOuterRadius,
+    skirtOuterRadius,
+    -Math.PI / 2,
+    0,
+    false
+  );
   const inner = new THREE.Path();
   const skirtInnerRadius = Math.max(outerCornerRadius - baseOverhang, 0);
   if (skirtInnerRadius > 1e-4) {
-    inner.moveTo(-frameOuterX + skirtInnerRadius, -frameOuterZ);
-    inner.lineTo(frameOuterX - skirtInnerRadius, -frameOuterZ);
-    inner.absarc(
-      frameOuterX - skirtInnerRadius,
-      -frameOuterZ + skirtInnerRadius,
-      skirtInnerRadius,
-      -Math.PI / 2,
-      0,
-      false
-    );
+    inner.moveTo(frameOuterX, -frameOuterZ + skirtInnerRadius);
     inner.lineTo(frameOuterX, frameOuterZ - skirtInnerRadius);
     inner.absarc(
       frameOuterX - skirtInnerRadius,
@@ -4128,12 +4119,21 @@ function Table3D(
       1.5 * Math.PI,
       false
     );
+    inner.lineTo(frameOuterX - skirtInnerRadius, -frameOuterZ);
+    inner.absarc(
+      frameOuterX - skirtInnerRadius,
+      -frameOuterZ + skirtInnerRadius,
+      skirtInnerRadius,
+      -Math.PI / 2,
+      0,
+      false
+    );
   } else {
-    inner.moveTo(-frameOuterX, -frameOuterZ);
-    inner.lineTo(frameOuterX, -frameOuterZ);
+    inner.moveTo(frameOuterX, -frameOuterZ);
     inner.lineTo(frameOuterX, frameOuterZ);
     inner.lineTo(-frameOuterX, frameOuterZ);
     inner.lineTo(-frameOuterX, -frameOuterZ);
+    inner.lineTo(frameOuterX, -frameOuterZ);
   }
   skirtShape.holes.push(inner);
   const skirtGeo = new THREE.ExtrudeGeometry(skirtShape, {

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3859,16 +3859,7 @@ function Table3D(
   );
 
   const railsOuter = new THREE.Shape();
-  railsOuter.moveTo(-outerHalfW + outerCornerRadius, -outerHalfH);
-  railsOuter.lineTo(outerHalfW - outerCornerRadius, -outerHalfH);
-  railsOuter.absarc(
-    outerHalfW - outerCornerRadius,
-    -outerHalfH + outerCornerRadius,
-    outerCornerRadius,
-    -Math.PI / 2,
-    0,
-    false
-  );
+  railsOuter.moveTo(outerHalfW, -outerHalfH + outerCornerRadius);
   railsOuter.lineTo(outerHalfW, outerHalfH - outerCornerRadius);
   railsOuter.absarc(
     outerHalfW - outerCornerRadius,
@@ -3894,6 +3885,15 @@ function Table3D(
     outerCornerRadius,
     Math.PI,
     1.5 * Math.PI,
+    false
+  );
+  railsOuter.lineTo(outerHalfW - outerCornerRadius, -outerHalfH);
+  railsOuter.absarc(
+    outerHalfW - outerCornerRadius,
+    -outerHalfH + outerCornerRadius,
+    outerCornerRadius,
+    -Math.PI / 2,
+    0,
     false
   );
 
@@ -4153,16 +4153,7 @@ function Table3D(
     outerCornerRadius + baseOverhang * 0.4,
     Math.min(outW, outZ)
   );
-  skirtShape.moveTo(-outW + skirtOuterRadius, -outZ);
-  skirtShape.lineTo(outW - skirtOuterRadius, -outZ);
-  skirtShape.absarc(
-    outW - skirtOuterRadius,
-    -outZ + skirtOuterRadius,
-    skirtOuterRadius,
-    -Math.PI / 2,
-    0,
-    false
-  );
+  skirtShape.moveTo(outW, -outZ + skirtOuterRadius);
   skirtShape.lineTo(outW, outZ - skirtOuterRadius);
   skirtShape.absarc(
     outW - skirtOuterRadius,
@@ -4190,19 +4181,19 @@ function Table3D(
     1.5 * Math.PI,
     false
   );
+  skirtShape.lineTo(outW - skirtOuterRadius, -outZ);
+  skirtShape.absarc(
+    outW - skirtOuterRadius,
+    -outZ + skirtOuterRadius,
+    skirtOuterRadius,
+    -Math.PI / 2,
+    0,
+    false
+  );
   const inner = new THREE.Path();
   const skirtInnerRadius = Math.max(outerCornerRadius - baseOverhang, 0);
   if (skirtInnerRadius > 1e-4) {
-    inner.moveTo(-frameOuterX + skirtInnerRadius, -frameOuterZ);
-    inner.lineTo(frameOuterX - skirtInnerRadius, -frameOuterZ);
-    inner.absarc(
-      frameOuterX - skirtInnerRadius,
-      -frameOuterZ + skirtInnerRadius,
-      skirtInnerRadius,
-      -Math.PI / 2,
-      0,
-      false
-    );
+    inner.moveTo(frameOuterX, -frameOuterZ + skirtInnerRadius);
     inner.lineTo(frameOuterX, frameOuterZ - skirtInnerRadius);
     inner.absarc(
       frameOuterX - skirtInnerRadius,
@@ -4230,12 +4221,21 @@ function Table3D(
       1.5 * Math.PI,
       false
     );
+    inner.lineTo(frameOuterX - skirtInnerRadius, -frameOuterZ);
+    inner.absarc(
+      frameOuterX - skirtInnerRadius,
+      -frameOuterZ + skirtInnerRadius,
+      skirtInnerRadius,
+      -Math.PI / 2,
+      0,
+      false
+    );
   } else {
-    inner.moveTo(-frameOuterX, -frameOuterZ);
-    inner.lineTo(frameOuterX, -frameOuterZ);
+    inner.moveTo(frameOuterX, -frameOuterZ);
     inner.lineTo(frameOuterX, frameOuterZ);
     inner.lineTo(-frameOuterX, frameOuterZ);
     inner.lineTo(-frameOuterX, -frameOuterZ);
+    inner.lineTo(frameOuterX, -frameOuterZ);
   }
   skirtShape.holes.push(inner);
   const skirtGeo = new THREE.ExtrudeGeometry(skirtShape, {


### PR DESCRIPTION
## Summary
- rotate the rail and skirt outline paths so the wood seam originates from the right-hand rail in 3D Snooker
- apply the same seam orientation to Pool Royale so the rails, skirts, and inner cut-outs share the same texture direction

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4be7787508329a13ead1eec706f37