### PR TITLE
Add new wood grain presets for billiards tables

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3229,6 +3229,18 @@ function Table3D(
   table.userData = table.userData || {};
   table.userData.cushions = [];
 
+  const finishParts = {
+    frameMeshes: [],
+    legMeshes: [],
+    railMeshes: [],
+    trimMeshes: [],
+    accentParent: null,
+    accentMesh: null,
+    dimensions: null,
+    woodSurfaces: { frame: null, rail: null },
+    woodTextureId: null
+  };
+
   const halfW = PLAY_W / 2;
   const halfH = PLAY_H / 2;
   const baulkLineZ = -PLAY_H / 2 + BAULK_FROM_BAULK;
@@ -3276,18 +3288,6 @@ function Table3D(
   if (accentConfig?.material) {
     accentConfig.material.needsUpdate = true;
   }
-
-  const finishParts = {
-    frameMeshes: [],
-    legMeshes: [],
-    railMeshes: [],
-    trimMeshes: [],
-    accentParent: null,
-    accentMesh: null,
-    dimensions: null,
-    woodSurfaces: { frame: null, rail: null },
-    woodTextureId: null
-  };
 
   const { map: clothMap, bump: clothBump } = createClothTextures();
   const clothPrimary = new THREE.Color(palette.cloth);
@@ -10899,7 +10899,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Wood Grain
                 </h3>
-                <div className="mt-2 grid gap-2">
+                <div className="mt-2 grid max-h-48 gap-2 overflow-y-auto pr-1">
                   {WOOD_GRAIN_OPTIONS.map((option) => {
                     const active = option.id === woodTextureId;
                     return (

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3334,6 +3334,18 @@ function Table3D(
   table.userData = table.userData || {};
   table.userData.cushions = [];
 
+  const finishParts = {
+    frameMeshes: [],
+    legMeshes: [],
+    railMeshes: [],
+    trimMeshes: [],
+    accentParent: null,
+    accentMesh: null,
+    dimensions: null,
+    woodSurfaces: { frame: null, rail: null },
+    woodTextureId: null
+  };
+
   const halfW = PLAY_W / 2;
   const halfH = PLAY_H / 2;
   const baulkLineZ = -PLAY_H / 2 + BAULK_FROM_BAULK;
@@ -3381,18 +3393,6 @@ function Table3D(
   if (accentConfig?.material) {
     accentConfig.material.needsUpdate = true;
   }
-
-  const finishParts = {
-    frameMeshes: [],
-    legMeshes: [],
-    railMeshes: [],
-    trimMeshes: [],
-    accentParent: null,
-    accentMesh: null,
-    dimensions: null,
-    woodSurfaces: { frame: null, rail: null },
-    woodTextureId: null
-  };
 
   const { map: clothMap, bump: clothBump } = createClothTextures();
   const clothPrimary = new THREE.Color(palette.cloth);
@@ -10827,7 +10827,7 @@ function SnookerGame() {
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Wood Grain
                 </h3>
-                <div className="mt-2 grid gap-2">
+                <div className="mt-2 grid max-h-48 gap-2 overflow-y-auto pr-1">
                   {WOOD_GRAIN_OPTIONS.map((option) => {
                     const active = option.id === woodTextureId;
                     return (

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -220,6 +220,90 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       rotation: Math.PI / 2,
       textureSize: 2048
     }
+  }),
+  Object.freeze({
+    id: 'heritagePlanks',
+    label: 'Heritage Planks',
+    rail: {
+      repeat: { x: 0.09, y: 0.5 },
+      rotation: Math.PI / 28,
+      textureSize: 3072
+    },
+    frame: {
+      repeat: { x: 0.18, y: 0.34 },
+      rotation: Math.PI / 2,
+      textureSize: 3072
+    }
+  }),
+  Object.freeze({
+    id: 'atelierChevron',
+    label: 'Atelier Chevron',
+    rail: {
+      repeat: { x: 0.16, y: 0.62 },
+      rotation: Math.PI / 9,
+      textureSize: 3072
+    },
+    frame: {
+      repeat: { x: 0.28, y: 0.46 },
+      rotation: -Math.PI / 8,
+      textureSize: 3072
+    }
+  }),
+  Object.freeze({
+    id: 'cathedralSweep',
+    label: 'Cathedral Sweep',
+    rail: {
+      repeat: { x: 0.07, y: 0.48 },
+      rotation: -Math.PI / 20,
+      textureSize: 3072
+    },
+    frame: {
+      repeat: { x: 0.22, y: 0.36 },
+      rotation: Math.PI / 2,
+      textureSize: 3072
+    }
+  }),
+  Object.freeze({
+    id: 'estateBands',
+    label: 'Estate Bands',
+    rail: {
+      repeat: { x: 0.12, y: 0.68 },
+      rotation: Math.PI / 2,
+      textureSize: 3072
+    },
+    frame: {
+      repeat: { x: 0.32, y: 0.4 },
+      rotation: 0,
+      textureSize: 3072
+    }
+  }),
+  Object.freeze({
+    id: 'studioVeins',
+    label: 'Studio Veins',
+    rail: {
+      repeat: { x: 0.1, y: 0.56 },
+      rotation: Math.PI / 14,
+      textureSize: 3072
+    },
+    frame: {
+      repeat: { x: 0.24, y: 0.38 },
+      rotation: Math.PI / 2,
+      textureSize: 3072
+    }
+  }),
+  Object.freeze({
+    id: 'grandArc',
+    label: 'Grand Arc',
+    rail: {
+      repeat: { x: 0.06, y: 0.6 },
+      rotation: -Math.PI / 12,
+      textureSize: 3072
+    },
+    frame: {
+      repeat: { x: 0.2, y: 0.44 },
+      rotation: Math.PI / 2,
+      textureSize: 3072
+    }
   })
 ]);
 


### PR DESCRIPTION
## Summary
- add six additional wood grain presets with natural scaling and rotation for rails, skirts, and legs
- initialize table finish state before use to avoid setup errors in Snooker and Pool Royale
- enable scrolling inside the wood grain selector list in the table setup panel

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e4e07da9ec8329bf2006390deb8e18