### PR TITLE
Adjust Murlan Royale camera focus

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1192,10 +1192,7 @@ export default function MurlanRoyaleArena({ search }) {
         .addScaledVector(humanSeatConfig.forward, -retreatOffset)
         .addScaledVector(humanSeatConfig.right, lateralOffset);
       initialCameraPosition.y = stoolHeight + elevation;
-
-      target = humanSeatConfig.focus.clone();
-      target.y += 0.12 * MODEL_SCALE;
-      target.add(humanSeatConfig.right.clone().multiplyScalar(-0.16 * MODEL_SCALE));
+      target = new THREE.Vector3(0, TABLE_HEIGHT + targetHeightOffset + 0.12 * MODEL_SCALE, 0);
     } else {
       const humanSeatAngle = Math.PI / 2;
       const cameraBackOffset = isPortrait ? 1.65 : 1.05;


### PR DESCRIPTION
## Summary
- point the human player camera target at the table center in the Murlan Royale arena so the view looks toward the action

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5087a6dcc83298eb8b8fde1c87f54