### PR TITLE
Shorten snooker short rail cushions to avoid pocket overlap

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3679,7 +3679,7 @@ function Table3D(
   const POCKET_GAP =
     POCKET_VIS_R * 0.88 * POCKET_VISUAL_EXPANSION; // pull the cushions a touch closer so they land right at the pocket arcs
   const SHORT_CUSHION_EXTENSION =
-    POCKET_VIS_R * 0.16 * POCKET_VISUAL_EXPANSION; // extend short rail cushions slightly toward the corner pockets
+    POCKET_VIS_R * 0.12 * POCKET_VISUAL_EXPANSION; // stop the short rail cushions right at the chrome so the 32° chamfers just kiss it
   const LONG_CUSHION_TRIM =
     POCKET_VIS_R * 0.28 * POCKET_VISUAL_EXPANSION; // extend the long cushions so they stop right where the pocket arcs begin
   const LONG_CUSHION_CORNER_EXTENSION =


### PR DESCRIPTION
## Summary
- reduce the snooker short-rail cushion extension so the 32° chamfers meet the chrome plates without protruding into the pockets
- update the inline comment to document the new target alignment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5177f13e08329a6be3e27da9f4b48