### PR TITLE
Shorten snooker short rail cushions

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3679,7 +3679,7 @@ function Table3D(
   const POCKET_GAP =
     POCKET_VIS_R * 0.88 * POCKET_VISUAL_EXPANSION; // pull the cushions a touch closer so they land right at the pocket arcs
   const SHORT_CUSHION_EXTENSION =
-    POCKET_VIS_R * 0.16 * POCKET_VISUAL_EXPANSION; // extend short rail cushions slightly toward the corner pockets
+    POCKET_VIS_R * 0.12 * POCKET_VISUAL_EXPANSION; // trim short rail cushions so they finish right where the pocket cuts begin
   const LONG_CUSHION_TRIM =
     POCKET_VIS_R * 0.28 * POCKET_VISUAL_EXPANSION; // extend the long cushions so they stop right where the pocket arcs begin
   const LONG_CUSHION_CORNER_EXTENSION =


### PR DESCRIPTION
## Summary
- shorten the snooker short rail cushions so their ends align with the pocket cuts
- update the inline documentation to describe the new alignment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e533aff6488329b2c1c5ec39e19116