### PR TITLE
Adjust chrome pocket trims for pool and snooker tables

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -189,8 +189,8 @@ const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.82;
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85;
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1;
-const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.68; // trim the inner chrome wedge without pulling the entire plate back
-const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 0.94; // extend the notch deeper along the short rail to remove the triangular sliver
+const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.9; // widen the field-side trim to scoop out the lingering chrome wedge
+const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.1; // push the trim deeper along the short rail so the notch fully clears the plate
 
 function buildChromePlateGeometry({
   width,

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -181,6 +181,8 @@ const CHROME_CORNER_EXPANSION_SCALE = 1.02;
 const CHROME_CORNER_SIDE_EXPANSION_SCALE = 1;
 const CHROME_CORNER_FIELD_TRIM_SCALE = 0;
 const CHROME_CORNER_NOTCH_WEDGE_SCALE = 0;
+const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.9; // widen the field-side trim to scoop out the lingering chrome wedge
+const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.1; // push the trim deeper along the short rail so the notch fully clears the plate
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015;
 const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.82;
@@ -3883,7 +3885,19 @@ function Table3D(
     const z4 = cz + sz * cornerChamfer;
     const boxZ = boxPoly(Math.min(x3, x4), Math.min(z3, z4), Math.max(x3, x4), Math.max(z3, z4));
     const wedgeDepth = cornerChamfer * Math.max(0, CHROME_CORNER_NOTCH_WEDGE_SCALE);
+    const fieldClipWidth = cornerChamfer * CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE;
+    const fieldClipDepth = cornerChamfer * CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE;
     const unionParts = [notchCircle, boxX, boxZ];
+    if (fieldClipWidth > MICRO_EPS && fieldClipDepth > MICRO_EPS) {
+      unionParts.push([
+        [
+          [cx, cz],
+          [cx + sx * fieldClipWidth, cz],
+          [cx, cz + sz * fieldClipDepth],
+          [cx, cz]
+        ]
+      ]);
+    }
     if (wedgeDepth > MICRO_EPS) {
       unionParts.push([
         [


### PR DESCRIPTION
## Summary
- widen the chrome corner field clip in Pool Royale so pocket cutouts remove the leftover chrome wedge
- add a matching field-side clip for Snooker chrome corners to ensure the short-rail trim is cleared as well

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e54c775c9483298927b63eea5600b6