### PR TITLE
Adjust snooker side chrome plate width

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3759,7 +3759,7 @@ function Table3D(
   );
   const sideChromePlateWidth = Math.max(
     MICRO_EPS,
-    Math.min(sidePlatePocketWidth, sidePlateMaxWidth) - TABLE.THICK * 0.05
+    Math.min(sidePlatePocketWidth, sidePlateMaxWidth) - TABLE.THICK * 0.06
   );
   const sidePlateHalfHeightLimit = Math.max(
     0,


### PR DESCRIPTION
## Summary
- slightly reduce the side chrome plate width on the 3D snooker table to tone down the trim

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5775d85008329bbbcc798c354421e