### PR TITLE
Adjust short rail cushions for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3577,7 +3577,7 @@ function Table3D(
   const POCKET_GAP =
     POCKET_VIS_R * 0.88 * POCKET_VISUAL_EXPANSION; // pull the cushions a touch closer so they land right at the pocket arcs
   const SHORT_CUSHION_EXTENSION =
-    POCKET_VIS_R * -0.055 * POCKET_VISUAL_EXPANSION; // pull short rail cushions back slightly so they clear the pocket arcs and align with the rounded rail cut
+    POCKET_VIS_R * -0.09 * POCKET_VISUAL_EXPANSION; // pull short rail cushions farther back so the green bumpers stop short of the pocket mouths while keeping the rounded rail cut alignment
   const LONG_CUSHION_TRIM =
     POCKET_VIS_R * 0.32 * POCKET_VISUAL_EXPANSION; // keep the long cushions tidy while preserving pocket clearance
   const LONG_CUSHION_CORNER_EXTENSION =


### PR DESCRIPTION
## Summary
- shorten the Pool Royale short-rail cushions so the green bumpers no longer intrude into the corner pockets
- keep existing height scaling while slightly pulling the cushions back to preserve the rounded rail cut alignment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e57cbca0d08329bb27af9391f1fc6c