### PR TITLE
Split pool variants into dedicated experiences

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -61,6 +61,10 @@ import BlackJack from './pages/Games/BlackJack.jsx';
 import BlackJackLobby from './pages/Games/BlackJackLobby.jsx';
 import PoolRoyale from './pages/Games/PoolRoyale.jsx';
 import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
+import AmericanBilliards from './pages/Games/AmericanBilliards.jsx';
+import AmericanBilliardsLobby from './pages/Games/AmericanBilliardsLobby.jsx';
+import NineBall from './pages/Games/NineBall.jsx';
+import NineBallLobby from './pages/Games/NineBallLobby.jsx';
 import Snooker from './pages/Games/Snooker.jsx';
 
 import Layout from './components/Layout.jsx';
@@ -192,6 +196,16 @@ export default function App() {
               element={<PoolRoyaleLobby />}
             />
             <Route path="/games/pollroyale" element={<PoolRoyale />} />
+            <Route
+              path="/games/americanbilliards/lobby"
+              element={<AmericanBilliardsLobby />}
+            />
+            <Route
+              path="/games/americanbilliards"
+              element={<AmericanBilliards />}
+            />
+            <Route path="/games/nineball/lobby" element={<NineBallLobby />} />
+            <Route path="/games/nineball" element={<NineBall />} />
             <Route path="/games/snooker" element={<Snooker />} />
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -57,7 +57,39 @@ export default function Games() {
                 className="text-sm font-semibold text-center text-yellow-400"
                 style={{ WebkitTextStroke: '1px black' }}
               >
-                Pool Royale
+                Pool Royale - 8 Ball UK
+              </h3>
+            </Link>
+            <Link
+              to="/games/americanbilliards/lobby"
+              className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+            >
+              <img
+                src="/assets/icons/pool-royale.svg"
+                alt=""
+                className="h-20 w-20"
+              />
+              <h3
+                className="text-sm font-semibold text-center text-yellow-400"
+                style={{ WebkitTextStroke: '1px black' }}
+              >
+                American Billiards
+              </h3>
+            </Link>
+            <Link
+              to="/games/nineball/lobby"
+              className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+            >
+              <img
+                src="/assets/icons/pool-royale.svg"
+                alt=""
+                className="h-20 w-20"
+              />
+              <h3
+                className="text-sm font-semibold text-center text-yellow-400"
+                style={{ WebkitTextStroke: '1px black' }}
+              >
+                9-Ball Pool
               </h3>
             </Link>
             <Link

--- a/webapp/src/pages/Games/AmericanBilliards.jsx
+++ b/webapp/src/pages/Games/AmericanBilliards.jsx
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+import { PoolRoyaleGame, resolveTableSize } from './PoolRoyale.jsx';
+import { useIsMobile } from '../../hooks/useIsMobile.js';
+
+export default function AmericanBilliards() {
+  const isMobileOrTablet = useIsMobile(1366);
+  const location = useLocation();
+
+  const tableSizeKey = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('tableSize');
+    return resolveTableSize(requested).id;
+  }, [location.search]);
+
+  if (!isMobileOrTablet) {
+    return (
+      <div className="flex items-center justify-center w-full h-full p-4 text-center">
+        <p>This game is available on mobile phones and tablets only.</p>
+      </div>
+    );
+  }
+
+  return <PoolRoyaleGame variantKey="american" tableSizeKey={tableSizeKey} />;
+}

--- a/webapp/src/pages/Games/AmericanBilliardsLobby.jsx
+++ b/webapp/src/pages/Games/AmericanBilliardsLobby.jsx
@@ -11,7 +11,7 @@ import {
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 
-export default function PoolRoyaleLobby() {
+export default function AmericanBilliardsLobby() {
   const navigate = useNavigate();
   const { search } = useLocation();
   useTelegramBackButton();
@@ -42,7 +42,7 @@ export default function PoolRoyaleLobby() {
         }
         tgId = getTelegramId();
         await addTransaction(tgId, -stake.amount, 'stake', {
-          game: 'poolroyale',
+          game: 'americanbilliards',
           players: 2,
           accountId
         });
@@ -55,7 +55,7 @@ export default function PoolRoyaleLobby() {
     }
 
     const params = new URLSearchParams();
-    params.set('variant', 'uk');
+    params.set('variant', 'american');
     params.set('type', playType);
     if (playType !== 'training') params.set('mode', mode);
     const initData = window.Telegram?.WebApp?.initData;
@@ -76,7 +76,7 @@ export default function PoolRoyaleLobby() {
     if (devAcc1) params.set('dev1', devAcc1);
     if (devAcc2) params.set('dev2', devAcc2);
     if (initData) params.set('init', encodeURIComponent(initData));
-    navigate(`/games/pollroyale?${params.toString()}`);
+    navigate(`/games/americanbilliards?${params.toString()}`);
   };
 
   const winnerParam = new URLSearchParams(search).get('winner');
@@ -88,7 +88,7 @@ export default function PoolRoyaleLobby() {
           {winnerParam === '1' ? 'You won!' : 'CPU won!'}
         </div>
       )}
-      <h2 className="text-xl font-bold text-center">Pool Royale - 8 Ball UK Lobby</h2>
+      <h2 className="text-xl font-bold text-center">American Billiards Lobby</h2>
       <div className="space-y-2">
         <h3 className="font-semibold">Type</h3>
         <div className="flex gap-2">

--- a/webapp/src/pages/Games/NineBall.jsx
+++ b/webapp/src/pages/Games/NineBall.jsx
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+import { PoolRoyaleGame, resolveTableSize } from './PoolRoyale.jsx';
+import { useIsMobile } from '../../hooks/useIsMobile.js';
+
+export default function NineBall() {
+  const isMobileOrTablet = useIsMobile(1366);
+  const location = useLocation();
+
+  const tableSizeKey = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('tableSize');
+    return resolveTableSize(requested).id;
+  }, [location.search]);
+
+  if (!isMobileOrTablet) {
+    return (
+      <div className="flex items-center justify-center w-full h-full p-4 text-center">
+        <p>This game is available on mobile phones and tablets only.</p>
+      </div>
+    );
+  }
+
+  return <PoolRoyaleGame variantKey="9ball" tableSizeKey={tableSizeKey} />;
+}

--- a/webapp/src/pages/Games/NineBallLobby.jsx
+++ b/webapp/src/pages/Games/NineBallLobby.jsx
@@ -11,7 +11,7 @@ import {
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 
-export default function PoolRoyaleLobby() {
+export default function NineBallLobby() {
   const navigate = useNavigate();
   const { search } = useLocation();
   useTelegramBackButton();
@@ -42,7 +42,7 @@ export default function PoolRoyaleLobby() {
         }
         tgId = getTelegramId();
         await addTransaction(tgId, -stake.amount, 'stake', {
-          game: 'poolroyale',
+          game: 'nineball',
           players: 2,
           accountId
         });
@@ -55,7 +55,7 @@ export default function PoolRoyaleLobby() {
     }
 
     const params = new URLSearchParams();
-    params.set('variant', 'uk');
+    params.set('variant', '9ball');
     params.set('type', playType);
     if (playType !== 'training') params.set('mode', mode);
     const initData = window.Telegram?.WebApp?.initData;
@@ -76,7 +76,7 @@ export default function PoolRoyaleLobby() {
     if (devAcc1) params.set('dev1', devAcc1);
     if (devAcc2) params.set('dev2', devAcc2);
     if (initData) params.set('init', encodeURIComponent(initData));
-    navigate(`/games/pollroyale?${params.toString()}`);
+    navigate(`/games/nineball?${params.toString()}`);
   };
 
   const winnerParam = new URLSearchParams(search).get('winner');
@@ -88,7 +88,7 @@ export default function PoolRoyaleLobby() {
           {winnerParam === '1' ? 'You won!' : 'CPU won!'}
         </div>
       )}
-      <h2 className="text-xl font-bold text-center">Pool Royale - 8 Ball UK Lobby</h2>
+      <h2 className="text-xl font-bold text-center">9-Ball Pool Lobby</h2>
       <div className="space-y-2">
         <h3 className="font-semibold">Type</h3>
         <div className="flex gap-2">

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -703,7 +703,7 @@ const UI_SCALE = SIZE_REDUCTION;
 const CUE_WOOD_REPEAT = new THREE.Vector2(1, 5.5); // Mirror the cue butt wood repeat for table finishes
 const TABLE_WOOD_REPEAT = new THREE.Vector2(0.12, 0.66); // coarser grain so rails, skirts, and legs read at table scale
 
-const DEFAULT_POOL_VARIANT = 'american';
+const DEFAULT_POOL_VARIANT = 'uk';
 const UK_POOL_RED = 0xd12c2c;
 const UK_POOL_YELLOW = 0xffd700;
 const UK_POOL_BLACK = 0x000000;
@@ -847,12 +847,12 @@ const TABLE_SIZE_OPTIONS = Object.freeze({
 });
 const DEFAULT_TABLE_SIZE_ID = '9ft';
 
-function resolvePoolVariant(variantId) {
+export function resolvePoolVariant(variantId) {
   const key = typeof variantId === 'string' ? variantId.toLowerCase() : '';
   return POOL_VARIANT_COLOR_SETS[key] || POOL_VARIANT_COLOR_SETS[DEFAULT_POOL_VARIANT];
 }
 
-function resolveTableSize(sizeId) {
+export function resolveTableSize(sizeId) {
   const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';
   return TABLE_SIZE_OPTIONS[key] || TABLE_SIZE_OPTIONS[DEFAULT_TABLE_SIZE_ID];
 }
@@ -4569,7 +4569,7 @@ function applyTableFinishToTable(table, finish) {
 // --------------------------------------------------
 // NEW Engine (no globals). Camera feels like standing at the side.
 // --------------------------------------------------
-function PoolRoyaleGame({ variantKey, tableSizeKey }) {
+export function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   const mountRef = useRef(null);
   const rafRef = useRef(null);
   const rules = useMemo(() => new UnitySnookerRules(), []);
@@ -11169,11 +11169,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
 export default function PoolRoyale() {
   const isMobileOrTablet = useIsMobile(1366);
   const location = useLocation();
-  const variantKey = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    const requested = params.get('variant');
-    return resolvePoolVariant(requested).id;
-  }, [location.search]);
   const tableSizeKey = useMemo(() => {
     const params = new URLSearchParams(location.search);
     const requested = params.get('tableSize');
@@ -11188,5 +11183,5 @@ export default function PoolRoyale() {
     );
   }
 
-  return <PoolRoyaleGame variantKey={variantKey} tableSizeKey={tableSizeKey} />;
+  return <PoolRoyaleGame variantKey="uk" tableSizeKey={tableSizeKey} />;
 }


### PR DESCRIPTION
## Summary
- limit the Pool Royale game and lobby to the 8-Ball UK variant
- add standalone American Billiards and 9-Ball game and lobby pages wired into routing
- update the games list to surface the new pool variant entries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5f89a3a708329a73b8d658185da27