### PR TITLE
Replace arena TVs with wall signage

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6065,22 +6065,11 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         roughness: 0.5,
         metalness: 0.6
       });
-      const tvBezelMat = new THREE.MeshStandardMaterial({
-        color: 0x0b1323,
-        roughness: 0.35,
-        metalness: 0.55
-      });
       const signageScale = 3;
       const signageDepth = 0.8 * signageScale;
       const signageWidth = Math.min(roomWidth * 0.58, 52) * signageScale;
       const signageHeight = Math.min(wallHeight * 0.28, 12) * signageScale;
-      const tvSizeReduction = 0.7;
-      const tvScale = 10 * 1.3 * tvSizeReduction;
-      const tvWidth = 9 * tvScale;
-      const tvHeight = 5.4 * tvScale;
-      const tvDepth = 0.42 * tvScale;
-      const tvMountHeight = tvHeight * 0.32;
-      const tvMountOffset = tvHeight * 0.42;
+      const infoPanelDepth = signageDepth * 0.6;
       const makeScreenMaterial = (texture) => {
         const material = new THREE.MeshBasicMaterial({ toneMapped: false });
         if (texture) {
@@ -6089,29 +6078,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           material.color = new THREE.Color(0x0f172a);
         }
         return material;
-      };
-      const createTv = (texture) => {
-        const group = new THREE.Group();
-        const bezel = new THREE.Mesh(
-          new THREE.BoxGeometry(tvWidth, tvHeight, tvDepth),
-          tvBezelMat
-        );
-        bezel.castShadow = false;
-        bezel.receiveShadow = true;
-        group.add(bezel);
-        const screen = new THREE.Mesh(
-          new THREE.PlaneGeometry(tvWidth * 0.92, tvHeight * 0.88),
-          makeScreenMaterial(texture)
-        );
-        screen.position.z = tvDepth / 2 + 0.02;
-        group.add(screen);
-        const mount = new THREE.Mesh(
-          new THREE.BoxGeometry(tvWidth * 0.18, tvMountHeight, tvDepth * 0.3),
-          tvBezelMat
-        );
-        mount.position.set(0, -tvMountOffset, -tvDepth * 0.35);
-        group.add(mount);
-        return group;
       };
       const createBillboardAssembly = () => {
         const assembly = new THREE.Group();
@@ -6130,29 +6096,34 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         assembly.add(billboardScreen);
         return assembly;
       };
-      const createMatchTvAssembly = () => {
+      const createMatchInfoAssembly = () => {
         const assembly = new THREE.Group();
-        const tv = createTv(matchTexture);
-        assembly.add(tv);
+        const frame = new THREE.Mesh(
+          new THREE.BoxGeometry(signageWidth, signageHeight, infoPanelDepth),
+          signageFrameMat
+        );
+        frame.castShadow = false;
+        frame.receiveShadow = true;
+        assembly.add(frame);
+        const infoSurface = new THREE.Mesh(
+          new THREE.PlaneGeometry(signageWidth * 0.94, signageHeight * 0.82),
+          makeScreenMaterial(matchTexture)
+        );
+        infoSurface.position.z = infoPanelDepth / 2 + 0.02;
+        assembly.add(infoSurface);
         return assembly;
       };
       const signageGap = BALL_R * 3.2;
-      const tvAssemblyHalfHeight = Math.max(
-        tvHeight / 2,
-        tvMountOffset + tvMountHeight / 2
-      );
       const signageHalfHeight = signageHeight / 2;
       const signageY = floorY + signageGap + signageHalfHeight;
-      const signageBottomY = signageY - signageHalfHeight;
-      const tvY = signageBottomY + tvAssemblyHalfHeight;
       const wallInset = wallThickness / 2 + 0.2;
       const frontInterior = -roomDepth / 2 + wallInset;
       const backInterior = roomDepth / 2 - wallInset;
       const leftInterior = -roomWidth / 2 + wallInset;
       const rightInterior = roomWidth / 2 - wallInset;
       [
-        { position: [0, tvY, frontInterior], rotationY: 0, type: 'tv' },
-        { position: [0, tvY, backInterior], rotationY: Math.PI, type: 'tv' },
+        { position: [0, signageY, frontInterior], rotationY: 0, type: 'info' },
+        { position: [0, signageY, backInterior], rotationY: Math.PI, type: 'info' },
         {
           position: [leftInterior, signageY, 0],
           rotationY: Math.PI / 2,
@@ -6165,7 +6136,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         }
       ].forEach(({ position, rotationY, type }) => {
         const signage =
-          type === 'tv' ? createMatchTvAssembly() : createBillboardAssembly();
+          type === 'info' ? createMatchInfoAssembly() : createBillboardAssembly();
         signage.position.set(position[0], position[1], position[2]);
         signage.rotation.y = rotationY;
         world.add(signage);

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -6162,20 +6162,11 @@ function SnookerGame() {
         roughness: 0.5,
         metalness: 0.6
       });
-      const tvBezelMat = new THREE.MeshStandardMaterial({
-        color: 0x0b1323,
-        roughness: 0.35,
-        metalness: 0.55
-      });
       const signageScale = 3;
       const signageDepth = 0.8 * signageScale;
       const signageWidth = Math.min(roomWidth * 0.58, 52) * signageScale;
       const signageHeight = Math.min(wallHeight * 0.28, 12) * signageScale;
-      const tvSizeReduction = 0.7;
-      const tvScale = 10 * 1.3 * tvSizeReduction;
-      const tvWidth = 9 * tvScale;
-      const tvHeight = 5.4 * tvScale;
-      const tvDepth = 0.42 * tvScale;
+      const infoPanelDepth = signageDepth * 0.6;
       const makeScreenMaterial = (texture) => {
         const material = new THREE.MeshBasicMaterial({ toneMapped: false });
         if (texture) {
@@ -6184,29 +6175,6 @@ function SnookerGame() {
           material.color = new THREE.Color(0x0f172a);
         }
         return material;
-      };
-      const createTv = (texture) => {
-        const group = new THREE.Group();
-        const bezel = new THREE.Mesh(
-          new THREE.BoxGeometry(tvWidth, tvHeight, tvDepth),
-          tvBezelMat
-        );
-        bezel.castShadow = false;
-        bezel.receiveShadow = true;
-        group.add(bezel);
-        const screen = new THREE.Mesh(
-          new THREE.PlaneGeometry(tvWidth * 0.92, tvHeight * 0.88),
-          makeScreenMaterial(texture)
-        );
-        screen.position.z = tvDepth / 2 + 0.02;
-        group.add(screen);
-        const mount = new THREE.Mesh(
-          new THREE.BoxGeometry(tvWidth * 0.18, tvHeight * 0.6, tvDepth * 0.3),
-          tvBezelMat
-        );
-        mount.position.set(0, -tvHeight * 0.55, -tvDepth * 0.35);
-        group.add(mount);
-        return group;
       };
       const createBillboardAssembly = () => {
         const assembly = new THREE.Group();
@@ -6225,10 +6193,21 @@ function SnookerGame() {
         assembly.add(billboardScreen);
         return assembly;
       };
-      const createMatchTvAssembly = () => {
+      const createMatchInfoAssembly = () => {
         const assembly = new THREE.Group();
-        const tv = createTv(matchTexture);
-        assembly.add(tv);
+        const frame = new THREE.Mesh(
+          new THREE.BoxGeometry(signageWidth, signageHeight, infoPanelDepth),
+          signageFrameMat
+        );
+        frame.castShadow = false;
+        frame.receiveShadow = true;
+        assembly.add(frame);
+        const infoSurface = new THREE.Mesh(
+          new THREE.PlaneGeometry(signageWidth * 0.94, signageHeight * 0.82),
+          makeScreenMaterial(matchTexture)
+        );
+        infoSurface.position.z = infoPanelDepth / 2 + 0.02;
+        assembly.add(infoSurface);
         return assembly;
       };
       const signageY = floorY + wallHeight * 0.58;
@@ -6238,8 +6217,8 @@ function SnookerGame() {
       const leftInterior = -roomWidth / 2 + wallInset;
       const rightInterior = roomWidth / 2 - wallInset;
       [
-        { position: [0, signageY, frontInterior], rotationY: 0, type: 'tv' },
-        { position: [0, signageY, backInterior], rotationY: Math.PI, type: 'tv' },
+        { position: [0, signageY, frontInterior], rotationY: 0, type: 'info' },
+        { position: [0, signageY, backInterior], rotationY: Math.PI, type: 'info' },
         {
           position: [leftInterior, signageY, 0],
           rotationY: Math.PI / 2,
@@ -6252,7 +6231,7 @@ function SnookerGame() {
         }
       ].forEach(({ position, rotationY, type }) => {
         const signage =
-          type === 'tv' ? createMatchTvAssembly() : createBillboardAssembly();
+          type === 'info' ? createMatchInfoAssembly() : createBillboardAssembly();
         signage.position.set(position[0], position[1], position[2]);
         signage.rotation.y = rotationY;
         world.add(signage);

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -110,62 +110,6 @@ export const WOOD_FINISH_PRESETS = Object.freeze([
 
 export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
-    id: 'longRun',
-    label: 'Long Run',
-    rail: {
-      repeat: { x: 0.06, y: 0.86 },
-      rotation: Math.PI / 18,
-      textureSize: 2048
-    },
-    frame: {
-      repeat: { x: 0.16, y: 0.52 },
-      rotation: Math.PI / 2,
-      textureSize: 2048
-    }
-  }),
-  Object.freeze({
-    id: 'crossbanded',
-    label: 'Crossbanded',
-    rail: {
-      repeat: { x: 0.22, y: 0.54 },
-      rotation: Math.PI / 2,
-      textureSize: 2048
-    },
-    frame: {
-      repeat: { x: 0.34, y: 0.38 },
-      rotation: 0,
-      textureSize: 2048
-    }
-  }),
-  Object.freeze({
-    id: 'quarterSawn',
-    label: 'Quarter Sawn',
-    rail: {
-      repeat: { x: 0.12, y: 0.72 },
-      rotation: -Math.PI / 20,
-      textureSize: 2048
-    },
-    frame: {
-      repeat: { x: 0.2, y: 0.44 },
-      rotation: Math.PI / 2,
-      textureSize: 2048
-    }
-  }),
-  Object.freeze({
-    id: 'rusticBoards',
-    label: 'Rustic Boards',
-    rail: {
-      repeat: { x: 0.14, y: 0.68 },
-      rotation: -Math.PI / 12,
-      textureSize: 2048
-    },
-    frame: {
-      repeat: { x: 0.26, y: 0.5 },
-      rotation: Math.PI / 2,
-      textureSize: 2048
-    }
-  }),
-  Object.freeze({
     id: 'heritagePlanks',
     label: 'Heritage Planks',
     rail: {


### PR DESCRIPTION
## Summary
- remove the long run, crossbanded, quarter sawn, and rustic boards wood grain presets
- replace the TVs in the Snooker and Pool Royale arenas with framed wall info panels that reuse the existing match textures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6185f83ac8329983d734078ddf3b4