### PR TITLE
Align Pool Royale layout with snooker and remove smaller tables

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -841,8 +841,6 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
 });
 
 const TABLE_SIZE_OPTIONS = Object.freeze({
-  '7ft': { id: '7ft', label: '7 ft', scale: 0.78 },
-  '8ft': { id: '8ft', label: '8 ft', scale: 0.88 },
   '9ft': { id: '9ft', label: '9 ft', scale: 1 }
 });
 const DEFAULT_TABLE_SIZE_ID = '9ft';
@@ -6302,11 +6300,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       const furnitureScale = hospitalityScale * 1.18 * hospitalityUpscale;
       const hospitalitySizeMultiplier = 2.5;
       const toHospitalityUnits = (value = 0) => value * hospitalityScale;
-      const hospitalityTableHeightScale = 0.6; // drop the bistro table height by 40% so it sits lower on the carpet line
-      const hospitalityChairGap =
-        toHospitalityUnits(0.08) * hospitalityUpscale; // keep a slim clearance between each chair and table edge
-      const hospitalityCarpetPull =
-        toHospitalityUnits(0.18) * hospitalityUpscale; // shift hospitality props off the wall and onto the nearby carpet border
 
       const createTableSet = () => {
         const set = new THREE.Group();
@@ -6471,18 +6464,13 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         const scaledFurniture = furnitureScale * hospitalitySizeMultiplier;
 
         const tableSet = createTableSet();
-        tableSet.scale.set(
-          scaledFurniture,
-          scaledFurniture * hospitalityTableHeightScale,
-          scaledFurniture
-        );
+        tableSet.scale.setScalar(scaledFurniture);
         const chairVector = new THREE.Vector2(chairOffset[0], chairOffset[1]);
         const chairDistance = chairVector.length();
         if (chairDistance > 1e-6) {
-          const maxPull = Math.max(chairDistance - hospitalityChairGap, 0);
           const tablePull = Math.min(
-            maxPull,
-            toHospitalityUnits(0.2) * hospitalityUpscale
+            chairDistance * 0.35,
+            toHospitalityUnits(0.12) * hospitalityUpscale
           );
           const pullScale = tablePull / chairDistance;
           tableSet.position.set(
@@ -6504,16 +6492,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         chair.rotation.y = baseAngle + diagonalBias;
         group.add(chair);
 
-        const adjustForCarpet = (value) => {
-          const direction = Math.sign(value);
-          const magnitude = Math.max(Math.abs(value) - hospitalityCarpetPull, 0);
-          return direction * magnitude;
-        };
-        group.position.set(
-          adjustForCarpet(position[0]),
-          floorY,
-          adjustForCarpet(position[1])
-        );
+        group.position.set(position[0], floorY, position[1]);
         group.rotation.y = rotationY;
         ensureHospitalityVisibility(group);
         return group;
@@ -6530,8 +6509,8 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         rawCornerInset,
         Math.abs(backInterior) * 0.92
       );
-      const chairSideOffset = toHospitalityUnits(0.44) * hospitalityUpscale;
-      const chairForwardOffset = toHospitalityUnits(0.62) * hospitalityUpscale;
+      const chairSideOffset = toHospitalityUnits(0.56) * hospitalityUpscale;
+      const chairForwardOffset = toHospitalityUnits(0.74) * hospitalityUpscale;
 
       [
         {

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -156,11 +156,7 @@ export default function PoolRoyaleLobby() {
       <div className="space-y-2">
         <h3 className="font-semibold">Table Size</h3>
         <div className="flex gap-2">
-          {[
-            { id: '7ft', label: '7 ft' },
-            { id: '8ft', label: '8 ft' },
-            { id: '9ft', label: '9 ft' }
-          ].map(({ id, label }) => (
+          {[{ id: '9ft', label: '9 ft' }].map(({ id, label }) => (
             <button
               key={id}
               onClick={() => setTableSize(id)}


### PR DESCRIPTION
## Summary
- match the Pool Royale hospitality table placement to the snooker 3D layout by mirroring the scaling and positioning logic
- remove the 7 ft and 8 ft table-size options so the experience always uses the 9 ft configuration in both the game and lobby UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e630c75a3c8329a32f7e84b62f289e