### PR TITLE
Add 32-degree cushion bevel physics for snooker table

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -111,6 +111,22 @@ public class CushionStepTests
         Assert.That(ball.Position.X, Is.GreaterThanOrEqualTo(PhysicsConstants.BallRadius - 1e-9));
         Assert.That(ball.Velocity.X, Is.GreaterThan(0));
     }
+
+    [Test]
+    public void CornerCutRedirectsAtBevelAngle()
+    {
+        var solver = new BilliardsSolver();
+        var start = new Vec2(0.2, 0.2);
+        var velocity = new Vec2(-1, -1).Normalized() * 2.0;
+        var ball = new BilliardsSolver.Ball { Position = start, Velocity = velocity };
+        solver.Step(new List<BilliardsSolver.Ball> { ball }, 0.5);
+
+        var impactNormal = new Vec2(PhysicsConstants.CornerCutShortOffset, PhysicsConstants.CornerCutLongOffset).Normalized();
+        var expectedDir = Collision.Reflect(velocity, impactNormal, PhysicsConstants.CushionRestitution).Normalized();
+        var actualDir = ball.Velocity.Normalized();
+        Assert.That(actualDir.X, Is.EqualTo(expectedDir.X).Within(1e-4));
+        Assert.That(actualDir.Y, Is.EqualTo(expectedDir.Y).Within(1e-4));
+    }
 }
 
 public class PocketEdgeTests

--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -60,7 +60,7 @@ public class BilliardsSolver
                     if (Ccd.CircleAabb(b.Position, b.Velocity, PhysicsConstants.BallRadius, min, max, out double tBox, out Vec2 nBox) && tBox <= remaining)
                     {
                         tHit = tBox;
-                        normal = nBox;
+                        normal = ResolveCushionNormal(b.Position + b.Velocity * tBox, nBox);
                         restitution = PhysicsConstants.CushionRestitution;
                         hit = true;
                     }
@@ -144,7 +144,7 @@ public class BilliardsSolver
         {
             if (tc < bestT)
             {
-                bestT = tc; hitNormal = n; ballHit = false; pocketHit = false;
+                bestT = tc; hitNormal = ResolveCushionNormal(cueStart + velocity * tc, n); ballHit = false; pocketHit = false;
             }
         }
 
@@ -251,12 +251,70 @@ public class BilliardsSolver
             if (Ccd.CircleAabb(cue.Position, cue.Velocity, PhysicsConstants.BallRadius, new Vec2(0, 0), new Vec2(PhysicsConstants.TableWidth, PhysicsConstants.TableHeight), out double tc, out Vec2 n) && tc <= PhysicsConstants.FixedDt)
             {
                 cue.Position += cue.Velocity * tc;
-                var post = Collision.Reflect(cue.Velocity, n);
+                var post = Collision.Reflect(cue.Velocity, ResolveCushionNormal(cue.Position, n));
                 return new Impact { Point = cue.Position, CueVelocity = post };
             }
             Step(balls, PhysicsConstants.FixedDt);
             time += PhysicsConstants.FixedDt;
         }
         return new Impact { Point = cue.Position, CueVelocity = cue.Velocity };
+    }
+
+    private static Vec2 ResolveCushionNormal(Vec2 contactPoint, Vec2 fallbackNormal)
+    {
+        if (TryGetCornerCutNormal(contactPoint, out var cornerNormal))
+        {
+            return cornerNormal;
+        }
+        return fallbackNormal;
+    }
+
+    private static bool TryGetCornerCutNormal(Vec2 contactPoint, out Vec2 normal)
+    {
+        normal = default;
+        double longOffset = PhysicsConstants.CornerCutLongOffset;
+        double shortOffset = PhysicsConstants.CornerCutShortOffset;
+
+        if (longOffset <= 0 || shortOffset <= 0)
+        {
+            return false;
+        }
+
+        double radius = PhysicsConstants.BallRadius;
+        double width = PhysicsConstants.TableWidth;
+        double height = PhysicsConstants.TableHeight;
+
+        double leftLimit = radius + longOffset;
+        double rightLimit = width - (radius + longOffset);
+        double topLimit = radius + shortOffset;
+        double bottomLimit = height - (radius + shortOffset);
+
+        bool nearLeft = contactPoint.X <= leftLimit + PhysicsConstants.Epsilon;
+        bool nearRight = contactPoint.X >= rightLimit - PhysicsConstants.Epsilon;
+        bool nearTop = contactPoint.Y <= topLimit + PhysicsConstants.Epsilon;
+        bool nearBottom = contactPoint.Y >= bottomLimit - PhysicsConstants.Epsilon;
+
+        if (nearTop && nearLeft)
+        {
+            normal = new Vec2(shortOffset, longOffset).Normalized();
+            return true;
+        }
+        if (nearTop && nearRight)
+        {
+            normal = new Vec2(-shortOffset, longOffset).Normalized();
+            return true;
+        }
+        if (nearBottom && nearLeft)
+        {
+            normal = new Vec2(shortOffset, -longOffset).Normalized();
+            return true;
+        }
+        if (nearBottom && nearRight)
+        {
+            normal = new Vec2(-shortOffset, -longOffset).Normalized();
+            return true;
+        }
+
+        return false;
     }
 }

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Billiards;
 
 /// <summary>Holds all tunable physics constants for determinism and easy calibration.</summary>
@@ -16,4 +18,23 @@ public static class PhysicsConstants
     public const double FixedDt = 1.0 / 120.0;         // simulation step
     public const double Epsilon = 1e-9;                // numerical epsilon
     public const double MaxPreviewTime = 30.0;         // safeguard for CCD
+
+    /// <summary>
+    /// Snooker corner cushions are bevelled at 32 degrees.  The cut begins a
+    /// short distance away from the actual corner along the long rail so that
+    /// balls entering the pocket do not bounce straight back out.
+    /// </summary>
+    public const double CornerCutAngleDegrees = 32.0;
+
+    /// <summary>Distance along the long cushion before the bevel begins (metres).</summary>
+    public const double CornerCutLongOffset = 0.095;
+
+    /// <summary>Corner cut angle in radians.</summary>
+    public static readonly double CornerCutAngleRadians = CornerCutAngleDegrees * Math.PI / 180.0;
+
+    /// <summary>
+    /// Depth of the bevel measured along the short cushion so that the surface
+    /// meets the 32 degree requirement.
+    /// </summary>
+    public static readonly double CornerCutShortOffset = CornerCutLongOffset * Math.Tan(CornerCutAngleRadians);
 }


### PR DESCRIPTION
## Summary
- add corner cut constants describing the 32° snooker cushion bevel
- adjust cushion collision handling to swap normals near pockets for the bevelled reflection
- add a regression test confirming the cue ball reflects along the bevel angle

## Testing
- `dotnet test billiards.Tests/Billiards.Tests.csproj` *(fails: `dotnet` CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e634e461748329a63abd891ab6a03e