### PR TITLE
Specify pocket cutout sizing in shared billiards spec

### DIFF
--- a/docs/3d-billiards-variants.md
+++ b/docs/3d-billiards-variants.md
@@ -6,6 +6,7 @@ These notes capture the shared expectations for the upcoming 3D billiards experi
 
 - **Camera & Controls** – Reuse the mobile-first three.js mappings defined in `mobile-3d-controls-prompt.md`. Players must be able to orbit, zoom, and line up shots comfortably while the device is held in portrait orientation.
 - **Physics Scale** – Keep cushions, pockets, and ball radii in real-world proportions so mode switching does not require reauthoring cues or aiming aids. Balls share the same rigid body settings across every variant.
+- **Pocket Cutouts** – Ensure the pocket openings carved into the wooden rails and chrome plates match the true pocket diameter so balls never snag on mismatched trims.
 - **Lighting** – Neutral three-point lighting with subtle rim highlights keeps all coloured balls readable, especially in portrait mode. Tone mapping should avoid clipping the cue ball or pink/blue balls.
 - **HUD Layout** – Score rails cling to the top/bottom edges of the portrait viewport. Toggle the rule card for the active mode on demand so newcomers can read the frame objective without leaving the table.
 


### PR DESCRIPTION
## Summary
- clarify that wooden rail and chrome plate pocket cutouts must match the pocket diameter to prevent ball snagging across 3D billiards modes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e74e76b4dc832984cf5928e510b879