### PR TITLE
Fix pocket cutouts and adjust snooker short cushions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3826,7 +3826,7 @@ function Table3D(
 
     const circle = circlePoly(cx, 0, radius, 256);
     const throat = roundedRectPoly(
-      cx + (sx * throatLength) / 2,
+      cx - (sx * throatLength) / 2,
       0,
       Math.abs(throatLength),
       throatHeight,
@@ -3916,8 +3916,8 @@ function Table3D(
   const sidePocketCutRadius = sidePocketRadius * RAIL_POCKET_CUT_SCALE;
   let openingMP = polygonClipping.union(
     rectPoly(innerHalfW * 2, innerHalfH * 2),
-    ...circlePoly(-(innerHalfW - sideInset), 0, sidePocketCutRadius),
-    ...circlePoly(innerHalfW - sideInset, 0, sidePocketCutRadius)
+    ...shrinkRailCut(sideNotchMP(-1)),
+    ...shrinkRailCut(sideNotchMP(1))
   );
   openingMP = polygonClipping.union(
     openingMP,

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3695,7 +3695,7 @@ function Table3D(
   const POCKET_GAP =
     POCKET_VIS_R * 0.88 * POCKET_VISUAL_EXPANSION; // pull the cushions a touch closer so they land right at the pocket arcs
   const SHORT_CUSHION_EXTENSION =
-    POCKET_VIS_R * 0.045 * POCKET_VISUAL_EXPANSION; // pull short rail cushions back slightly so they sit a touch away from the pocket mouths
+    POCKET_VIS_R * 0.07 * POCKET_VISUAL_EXPANSION; // pull short rail cushions back further so the short-rail cushions stay clear of the pocket mouths
   const LONG_CUSHION_TRIM =
     POCKET_VIS_R * 0.28 * POCKET_VISUAL_EXPANSION; // extend the long cushions so they stop right where the pocket arcs begin
   const LONG_CUSHION_CORNER_EXTENSION =


### PR DESCRIPTION
## Summary
- point the Pool Royale side pocket throats toward the playfield so chrome plates and rail cutouts share the same geometry
- reuse the refined side-pocket notch shape when carving the wooden rails to keep the side openings consistent with the trim
- pull the snooker short-rail cushions back a little more so they no longer intrude into the pocket mouths

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7606b97e08329b98ef191c2b9b94b