### PR TITLE
Adjust Pool Royale cushion clearance

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3591,13 +3591,13 @@ function Table3D(
   const LONG_CUSHION_TRIM =
     POCKET_VIS_R * 0.32 * POCKET_VISUAL_EXPANSION; // keep the long cushions tidy while preserving pocket clearance
   const LONG_CUSHION_CORNER_EXTENSION =
-    POCKET_VIS_R * 0.02 * POCKET_VISUAL_EXPANSION; // let the long cushions meet the chrome arches without leaving gaps
+    POCKET_VIS_R * -0.015 * POCKET_VISUAL_EXPANSION; // pull the long cushions slightly back so they clear the corner pocket mouths
   const SIDE_CUSHION_POCKET_CLEARANCE =
     POCKET_VIS_R * 0.1 * POCKET_VISUAL_EXPANSION; // keep clearance around the pockets while allowing longer cushions
   const SIDE_CUSHION_CENTER_PULL =
     POCKET_VIS_R * 0.26 * POCKET_VISUAL_EXPANSION; // push the long-side cushions a touch more toward the middle pockets
   const SIDE_CUSHION_CORNER_TRIM =
-    POCKET_VIS_R * 0.082 * POCKET_VISUAL_EXPANSION; // stop the green cushions right where the chrome arches finish
+    POCKET_VIS_R * 0.11 * POCKET_VISUAL_EXPANSION; // trim back the short cushions a touch more to keep them out of the corner pockets
   const horizLen =
     PLAY_W -
     2 * (POCKET_GAP - SHORT_CUSHION_EXTENSION - LONG_CUSHION_CORNER_EXTENSION) -


### PR DESCRIPTION
## Summary
- reduce the Pool Royale corner cushion extensions so the green rails no longer intrude into the pocket openings
- increase the short cushion corner trim to maintain clean separation from the corner pockets while leaving side pockets untouched

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e78666282c8329bd63b14106e76e30