### PR TITLE
Refocus cue camera on short-rail broadcast view

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -2,12 +2,11 @@
 using UnityEngine;
 
 /// <summary>
-/// Simple orbital camera that stays behind the cue ball. Horizontal drag
-/// rotates the camera around the ball so the player can aim by moving the
-/// camera rather than the aiming line.  Pulling the view downward blends to a
-/// close‑up shot of the cue ball, while dragging upward restores the normal
-/// overview.  The camera always looks along the aiming line so it follows the
-/// shot direction wherever the ball is on the table.
+/// Broadcast-oriented cue camera that stays locked to the short rails. The
+/// pre-shot framing hugs the cloth from the player's chosen end of the table
+/// while the moment a shot is triggered the view automatically cuts to the
+/// opposite short rail to follow the action. The framing keeps the cue ball and
+/// target in view without showing a standing orbit or aiming guide.
 /// </summary>
 public class CueCamera : MonoBehaviour
 {
@@ -17,43 +16,35 @@ public class CueCamera : MonoBehaviour
     // can immediately frame the action around it.
     public Transform TargetBall;
 
-    // Distance behind the ball in the normal overview.
-    public float normalDistance = 1.45f;
-    // Height of the camera above the table surface in the normal overview.
-    public float normalHeight = 0.48f;
-    // Distance and height when pulling the camera down for a close-up view.
-    public float closeDistance = 0.55f;
-    public float closeHeight = 0.33f;
-    // Additional offsets applied while the action camera is following a shot.
-    public float actionDistanceOffset = 0.1f;
-    public float actionHeightOffset = 0f;
-    // Rotation speed in degrees per second for horizontal mouse movement.
-    public float rotationSpeed = 90f;
-    // Speed at which the view blends between normal and close-up when dragging vertically.
-    public float zoomSpeed = 2f;
+    // Distance behind the ball when preparing a shot from the cue view.
+    public float cueAimDistance = 0.7f;
+    // Height of the camera above the table surface while aiming.
+    public float cueAimHeight = 0.36f;
+    // Distance and height for the short-rail broadcast view used once a shot begins.
+    public float broadcastDistance = 1.05f;
+    public float broadcastHeight = 0.5f;
     // Minimum squared velocity to consider a ball as moving.
     public float velocityThreshold = 0.01f;
-
-    [Header("Shot view settings")]
-    // Distance and height used when cutting to the targeted ball camera.
-    public float targetViewDistance = 1.8f;
-    public float targetViewHeight = 0.35f;
     // How quickly the camera aligns to the stored shot angle.
     public float shotSnapSpeed = 6f;
-    // Speed used when returning to the player's standing view.
+    // Speed used when easing between cue and broadcast framing while balls roll.
     public float returnSpeed = 3f;
+    // Choose which short rail the player view should favour before a shot begins.
+    public bool startLookingTowardPositiveZ = true;
 
     private float yaw;
-    // Blend value: 0 for normal view, 1 for close-up view.
-    private float viewBlend;
+    // Blend value retained for compatibility with existing animation logic.
+    private float viewBlend = 1f;
     // The ball the camera is currently following.
     private Transform currentBall;
     private bool shotInProgress;
     private bool usingTargetCamera;
-    private float preShotYaw;
-    private float preShotViewBlend;
     private float targetViewYaw;
     private Vector3 targetViewFocus;
+    private int defaultShortRailSign = 1;
+    private int cueAimSideSign = 1;
+    private int broadcastSideSign = -1;
+    private bool nextShotIsAi;
     [Header("Occlusion settings")]
     // Layers that should be considered when preventing the camera from getting
     // blocked by level geometry (walls, scoreboards, etc.). Defaults to all
@@ -80,37 +71,38 @@ public class CueCamera : MonoBehaviour
     {
         TargetBall = target;
         currentBall = CueBall;
-        preShotYaw = yaw;
-        preShotViewBlend = viewBlend;
         shotInProgress = true;
         usingTargetCamera = target != null;
 
-        Vector3 forward = Quaternion.Euler(0f, yaw, 0f) * Vector3.forward;
-        if (CueBall != null)
+        int aimSide = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
+        cueAimSideSign = aimSide;
+        broadcastSideSign = -aimSide;
+
+        Vector3 focus = CueBall != null ? CueBall.position : Vector3.zero;
+        if (target != null && target.gameObject.activeInHierarchy)
         {
-            targetViewFocus = CueBall.position;
+            focus = target.position;
+            currentBall = target;
         }
 
-        if (target != null && CueBall != null)
-        {
-            Vector3 dir = target.position - CueBall.position;
-            dir.y = 0f;
-            if (dir.sqrMagnitude > 0.0001f)
-            {
-                dir.Normalize();
-                forward = dir;
-            }
-            targetViewFocus = target.position;
-        }
-
-        targetViewYaw = Mathf.Atan2(forward.x, forward.z) * Mathf.Rad2Deg;
+        targetViewFocus = focus;
+        targetViewYaw = GetShortRailYaw(broadcastSideSign);
         yaw = targetViewYaw;
-        currentBall = usingTargetCamera && target != null ? target : CueBall;
+        viewBlend = 1f;
+
+        nextShotIsAi = false;
     }
 
     private void Awake()
     {
         cachedCamera = GetComponent<Camera>();
+        defaultShortRailSign = startLookingTowardPositiveZ ? 1 : -1;
+        cueAimSideSign = defaultShortRailSign;
+        broadcastSideSign = -cueAimSideSign;
+        yaw = GetShortRailYaw(cueAimSideSign);
+        targetViewYaw = GetShortRailYaw(broadcastSideSign);
+        currentBall = CueBall;
+        viewBlend = 1f;
     }
 
     private void LateUpdate()
@@ -122,8 +114,7 @@ public class CueCamera : MonoBehaviour
 
         if (!shotInProgress)
         {
-            HandlePlayerInput();
-            ApplyStandardCamera();
+            UpdateCueAimCamera();
             return;
         }
 
@@ -133,39 +124,54 @@ public class CueCamera : MonoBehaviour
         }
         else
         {
-            UpdateStandingCameraDuringShot();
+            UpdateBroadcastCamera();
         }
     }
 
-    private void HandlePlayerInput()
+    private void UpdateCueAimCamera()
     {
-        // Normal orbiting around the cue ball under player control.
-        bool dragging = Input.GetMouseButton(0);
-
-        // Support both mouse dragging and single‑finger touch.
-        if (Input.touchCount == 1)
+        if (CueBall == null)
         {
-            Touch t = Input.GetTouch(0);
-            if (t.phase == TouchPhase.Moved)
-            {
-                Vector2 d = t.deltaPosition;
-                yaw += d.x * rotationSpeed * Time.deltaTime * 0.1f;
-                viewBlend = Mathf.Clamp01(viewBlend - d.y * zoomSpeed * Time.deltaTime * 0.01f);
-            }
-        }
-        else if (dragging)
-        {
-            // Accumulate horizontal movement to orbit around the cue ball.
-            yaw += Input.GetAxis("Mouse X") * rotationSpeed * Time.deltaTime;
-
-            // Vertical dragging blends between the normal overview and a close‑up
-            // shot.  Dragging down increases the blend; dragging up restores the
-            // default view.
-            float yInput = Input.GetAxis("Mouse Y");
-            viewBlend = Mathf.Clamp01(viewBlend - yInput * zoomSpeed * Time.deltaTime);
+            return;
         }
 
+        int desiredSide = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
+        if (cueAimSideSign != desiredSide)
+        {
+            cueAimSideSign = desiredSide;
+        }
+
+        float desiredYaw = GetShortRailYaw(cueAimSideSign);
+        yaw = Mathf.LerpAngle(yaw, desiredYaw, Time.deltaTime * returnSpeed);
+        viewBlend = 1f;
         currentBall = CueBall;
+        ApplyShortRailCamera(CueBall.position, cueAimDistance, cueAimHeight);
+    }
+
+    private void UpdateBroadcastCamera()
+    {
+        currentBall = CueBall;
+        yaw = Mathf.LerpAngle(yaw, targetViewYaw, Time.deltaTime * shotSnapSpeed);
+        ApplyShortRailCamera(CueBall.position, broadcastDistance, broadcastHeight);
+
+        bool cueMoving = IsMoving(CueBall);
+        bool targetMoving = TargetBall != null && IsMoving(TargetBall);
+        if (!cueMoving && !targetMoving)
+        {
+            EndShot();
+            UpdateCueAimCamera();
+        }
+    }
+
+    public void SetNextShooterIsAi(bool value)
+    {
+        nextShotIsAi = value;
+        if (!shotInProgress)
+        {
+            cueAimSideSign = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
+            yaw = GetShortRailYaw(cueAimSideSign);
+            ApplyStandardCamera();
+        }
     }
 
     private void UpdateTargetCamera()
@@ -178,7 +184,7 @@ public class CueCamera : MonoBehaviour
 
         yaw = Mathf.LerpAngle(yaw, targetViewYaw, Time.deltaTime * shotSnapSpeed);
 
-        ApplyCameraAt(targetViewFocus, targetViewDistance, targetViewHeight);
+        ApplyShortRailCamera(targetViewFocus, broadcastDistance, broadcastHeight);
 
         bool targetSettled = TargetBall == null || !TargetBall.gameObject.activeInHierarchy || !IsMoving(TargetBall);
         if (!targetSettled)
@@ -196,41 +202,32 @@ public class CueCamera : MonoBehaviour
         if (!IsMoving(CueBall))
         {
             EndShot();
-            ApplyStandardCamera();
-        }
-    }
-
-    private void UpdateStandingCameraDuringShot()
-    {
-        currentBall = CueBall;
-        yaw = Mathf.LerpAngle(yaw, preShotYaw, Time.deltaTime * returnSpeed);
-        viewBlend = Mathf.MoveTowards(viewBlend, preShotViewBlend, Time.deltaTime * returnSpeed);
-
-        float distance = Mathf.Lerp(normalDistance, closeDistance, viewBlend) + actionDistanceOffset;
-        float height = Mathf.Max(0.05f, Mathf.Lerp(normalHeight, closeHeight, viewBlend) + actionHeightOffset);
-
-        ApplyCameraAt(CueBall.position, distance, height);
-
-        bool cueMoving = IsMoving(CueBall);
-        bool targetMoving = TargetBall != null && IsMoving(TargetBall);
-        if (!cueMoving && !targetMoving)
-        {
-            EndShot();
-            ApplyStandardCamera();
+            UpdateCueAimCamera();
         }
     }
 
     private void ApplyStandardCamera()
     {
-        Transform focus = currentBall != null ? currentBall : CueBall;
-        if (focus == null)
+        if (CueBall == null)
         {
             return;
         }
 
-        float distance = Mathf.Lerp(normalDistance, closeDistance, viewBlend);
-        float height = Mathf.Lerp(normalHeight, closeHeight, viewBlend);
-        ApplyCameraAt(focus.position, distance, height);
+        ApplyShortRailCamera(CueBall.position, cueAimDistance, cueAimHeight);
+    }
+
+    private void ApplyShortRailCamera(Vector3 focusPosition, float distance, float height)
+    {
+        ApplyCameraAt(focusPosition, distance, height);
+
+        Vector3 pos = transform.position;
+        pos.x = 0f;
+        transform.position = pos;
+
+        Quaternion rotation = Quaternion.Euler(0f, yaw, 0f);
+        Vector3 forward = rotation * Vector3.forward;
+        Vector3 lookTarget = focusPosition + forward * 5f;
+        transform.LookAt(lookTarget);
     }
 
     private void ApplyCameraAt(Vector3 focusPosition, float distance, float height)
@@ -268,10 +265,18 @@ public class CueCamera : MonoBehaviour
     {
         shotInProgress = false;
         usingTargetCamera = false;
-        yaw = preShotYaw;
-        viewBlend = preShotViewBlend;
         currentBall = CueBall;
         TargetBall = null;
+        cueAimSideSign = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
+        broadcastSideSign = -cueAimSideSign;
+        yaw = GetShortRailYaw(cueAimSideSign);
+        targetViewYaw = GetShortRailYaw(broadcastSideSign);
+        viewBlend = 1f;
+    }
+
+    private static float GetShortRailYaw(int sideSign)
+    {
+        return sideSign >= 0 ? 0f : 180f;
     }
 
     private bool CueBallInView()

--- a/billiards.Unity/DemoBehaviour.cs
+++ b/billiards.Unity/DemoBehaviour.cs
@@ -16,6 +16,8 @@ public class DemoBehaviour : MonoBehaviour
     // accurate shots without the aim jumping in large steps.
     public float aimSmoothing = 4f;
     public float previewSpeed = 2.0f;
+    // Toggle whether the aiming guide should be visible. Defaults to off for broadcast play.
+    public bool showAimingLine = false;
 
     private BilliardsSolver solver = new BilliardsSolver();
     private List<BilliardsSolver.Ball> balls = new List<BilliardsSolver.Ball>();
@@ -24,22 +26,14 @@ public class DemoBehaviour : MonoBehaviour
     private void Start()
     {
         solver.InitStandardTable();
-        Line.positionCount = 0;
-        if (Circle != null)
-        {
-            Circle.positionCount = 0;
-        }
+        ClearRenderers();
     }
 
     private void Update()
     {
         if (CueBall == null)
         {
-            Line.positionCount = 0;
-            if (Circle != null)
-            {
-                Circle.positionCount = 0;
-            }
+            ClearRenderers();
             return;
         }
 
@@ -56,34 +50,53 @@ public class DemoBehaviour : MonoBehaviour
         currentDir = (currentDir + (desiredDir - currentDir) * smoothingFactor).Normalized();
 
         var preview = AimPreview.Build(solver, cueStart, currentDir, previewSpeed, balls);
-        Line.positionCount = preview.Path.Length;
-        for (int i = 0; i < preview.Path.Length; i++)
+        if (!showAimingLine || Line == null)
         {
-            Line.SetPosition(i, new Vector3((float)preview.Path[i].X, CueBall.position.y, (float)preview.Path[i].Y));
+            ClearRenderers();
         }
-
-        if (Circle != null)
+        else
         {
-            if (preview.Path.Length > 0)
+            Line.positionCount = preview.Path.Length;
+            for (int i = 0; i < preview.Path.Length; i++)
             {
-                // Draw a circle at the end of the aiming line sized to match the ball.
-                const int segments = 32;
-                Circle.positionCount = segments + 1;
-                var endPoint = preview.Path[preview.Path.Length - 1];
-                Vector3 centre = new Vector3((float)endPoint.X, CueBall.position.y, (float)endPoint.Y);
-                float radius = (float)PhysicsConstants.BallRadius;
-                for (int i = 0; i <= segments; i++)
+                Line.SetPosition(i, new Vector3((float)preview.Path[i].X, CueBall.position.y, (float)preview.Path[i].Y));
+            }
+
+            if (Circle != null)
+            {
+                if (preview.Path.Length > 0)
                 {
-                    float angle = (float)i / segments * Mathf.PI * 2f;
-                    float x = Mathf.Cos(angle) * radius;
-                    float z = Mathf.Sin(angle) * radius;
-                    Circle.SetPosition(i, centre + new Vector3(x, 0f, z));
+                    // Draw a circle at the end of the aiming line sized to match the ball.
+                    const int segments = 32;
+                    Circle.positionCount = segments + 1;
+                    var endPoint = preview.Path[preview.Path.Length - 1];
+                    Vector3 centre = new Vector3((float)endPoint.X, CueBall.position.y, (float)endPoint.Y);
+                    float radius = (float)PhysicsConstants.BallRadius;
+                    for (int i = 0; i <= segments; i++)
+                    {
+                        float angle = (float)i / segments * Mathf.PI * 2f;
+                        float x = Mathf.Cos(angle) * radius;
+                        float z = Mathf.Sin(angle) * radius;
+                        Circle.SetPosition(i, centre + new Vector3(x, 0f, z));
+                    }
+                }
+                else
+                {
+                    Circle.positionCount = 0;
                 }
             }
-            else
-            {
-                Circle.positionCount = 0;
-            }
+        }
+    }
+
+    private void ClearRenderers()
+    {
+        if (Line != null)
+        {
+            Line.positionCount = 0;
+        }
+        if (Circle != null)
+        {
+            Circle.positionCount = 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- anchor the cue camera to short-rail broadcast framing and alternate ends automatically on each shot
- add AI-hand-off support so upcoming turns can request the opposite pre-shot view and keep the camera close to the cloth
- default the demo aiming overlay to hidden with an inspector toggle for broadcast-style play

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68e7bccda9d88329970680e181c5e2ca