### PR TITLE
Align Pool Royale shot physics with 2D tuning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -636,8 +636,8 @@ const SPIN_AIR_DECAY = 0.997; // hold spin energy while the cue ball travels str
 const SWERVE_THRESHOLD = 0.85; // outer 15% of the spin control activates swerve behaviour
 const SWERVE_TRAVEL_MULTIPLIER = 0.55; // dampen sideways drift while swerve is active so it stays believable
 const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the cue ball is rolling after impact
-// Base shot speed tuned for livelier pace while keeping slider sensitivity manageable.
-const SHOT_FORCE_BOOST = 1.8; // boost strike strength by 50%
+// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) so identical slider values feel the same.
+const SHOT_FORCE_BOOST = 1;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
 const SHOT_POWER_RANGE = 0.75;
@@ -679,16 +679,17 @@ const CUE_TIP_GAP = BALL_R * 1.45; // pull cue stick slightly farther back for a
 const CUE_PULL_BASE = BALL_R * 10 * 0.65 * 1.2;
 const CUE_Y = BALL_CENTER_Y - BALL_R * 0.05; // drop cue height slightly so the tip lines up with the cue ball centre
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
-const CUE_MARKER_RADIUS = CUE_TIP_RADIUS; // cue ball dots match the cue tip footprint
-const CUE_MARKER_DEPTH = CUE_TIP_RADIUS * 0.2;
+const CUE_MARKER_RADIUS = CUE_TIP_RADIUS * 1.2; // slightly larger than the cue tip to stand out on the ball
+const CUE_MARKER_DEPTH = CUE_TIP_RADIUS * 0.25;
 const CUE_BUTT_LIFT = BALL_R * 0.62; // raise the butt a little more so the rear clears rails while the tip stays aligned
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(8.5);
 const CUE_FRONT_SECTION_RATIO = 0.28;
-const MAX_SPIN_CONTACT_OFFSET = Math.max(0, BALL_R - CUE_TIP_RADIUS);
-const MAX_SPIN_FORWARD = BALL_R * 0.88;
-const MAX_SPIN_SIDE = BALL_R * 0.62;
-const MAX_SPIN_VERTICAL = Math.min(BALL_R * 0.48, MAX_SPIN_CONTACT_OFFSET);
+// Match the 2D aiming configuration: tip offset max = 0.85R and side/top spin amounts = 0.35R.
+const MAX_SPIN_CONTACT_OFFSET = BALL_R * 0.85;
+const MAX_SPIN_FORWARD = BALL_R * 0.35;
+const MAX_SPIN_SIDE = BALL_R * 0.35;
+const MAX_SPIN_VERTICAL = Math.min(BALL_R * 0.35, MAX_SPIN_CONTACT_OFFSET);
 const SPIN_BOX_FILL_RATIO =
   BALL_R > 0
     ? THREE.MathUtils.clamp(
@@ -3180,15 +3181,12 @@ function Guret(parent, id, color, x, y, options = {}) {
   mesh.receiveShadow = true;
   if (id === 'cue') {
     const markerGeom = new THREE.CircleGeometry(CUE_MARKER_RADIUS, 48);
-    const markerMat = new THREE.MeshStandardMaterial({
-      color: 0xff2f2f,
-      emissive: 0x550000,
-      roughness: 0.28,
-      metalness: 0.05,
+    const markerMat = new THREE.MeshBasicMaterial({
+      color: 0xff3b3b,
       side: THREE.DoubleSide
     });
     markerMat.depthWrite = false;
-    markerMat.needsUpdate = true;
+    markerMat.toneMapped = false;
     const markerOffset = BALL_R - CUE_MARKER_DEPTH * 0.5;
     const localForward = new THREE.Vector3(0, 0, 1);
     [


### PR DESCRIPTION
## Summary
- brighten the cue-ball marker material and enlarge the decal so the red dots pop against table lighting
- restore shot force and spin limit constants to match the legacy 2D aiming configuration

## Testing
- npm run lint *(fails: repository has pre-existing lint errors in legacy libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68e7e5590d588329b53ec87cd0d853c1