### PR TITLE
Adjust snooker cushion geometry

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -4222,7 +4222,10 @@ function Table3D(
     const noseThickness = baseThickness * NOSE_REDUCTION;
     const frontY = backY - noseThickness;
     const rad = THREE.MathUtils.degToRad(CUSHION_CUT_ANGLE);
-    const straightCut = Math.min(halfLen, Math.max(noseThickness / Math.tan(rad), baseThickness * 0.08));
+    const straightCut = Math.min(
+      halfLen,
+      Math.max(baseThickness * 0.25, noseThickness / Math.tan(rad))
+    );
 
     const shape = new THREE.Shape();
     shape.moveTo(-halfLen, backY);


### PR DESCRIPTION
## Summary
- Align the snooker cushion profile with the Pool Royale cut geometry while keeping the existing cushion dimensions.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7ea8efbb08329b8da8684225f9357