### PR TITLE
Adjust cue camera framing

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -17,9 +17,9 @@ public class CueCamera : MonoBehaviour
     public Transform TargetBall;
 
     // Distance behind the ball when preparing a shot from the cue view.
-    public float cueAimDistance = 0.62f;
+    public float cueAimDistance = 0.52f;
     // Height of the camera above the table surface while aiming.
-    public float cueAimHeight = 0.32f;
+    public float cueAimHeight = 0.36f;
     // Distance and height for the short-rail broadcast view used once a shot begins.
     public float broadcastDistance = 1.05f;
     public float broadcastHeight = 0.5f;


### PR DESCRIPTION
## Summary
- bring the cue camera in closer to the table during aiming
- raise the cue camera height slightly so the view sits higher over the cloth

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7eb6c87588329a6e9dac698f3ee76