### PR TITLE
Adjust cue camera framing for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2341,11 +2341,15 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.012;
-const CUE_VIEW_RADIUS_RATIO = 0.4;
+const CUE_VIEW_RADIUS_RATIO = 0.34;
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR;
-const CUE_VIEW_MIN_PHI = Math.min(
-  CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
-  STANDING_VIEW_PHI + 0.22
+// Encourage the cue camera to sit higher above the cloth while staying within the
+// allowed orbit envelope.
+const CUE_VIEW_HEIGHT_OFFSET = 0.06;
+const CUE_VIEW_MIN_PHI = Math.max(
+  CAMERA.minPhi,
+  Math.min(CAMERA.maxPhi - CAMERA_RAIL_SAFETY, STANDING_VIEW_PHI + 0.22) -
+    CUE_VIEW_HEIGHT_OFFSET
 );
 const CUE_VIEW_PHI_LIFT = 0.04;
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;


### PR DESCRIPTION
## Summary
- reduce the cue camera orbit radius factor so the aim view sits closer to the table in Pool Royale
- raise the cue camera minimum phi by introducing a height offset that keeps the view comfortably above the cloth

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e7ee72bf0c83298463eb90f593d91c