### PR TITLE
Adjust Pool Royale cue camera framing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2341,17 +2341,17 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.012;
-const CUE_VIEW_RADIUS_RATIO = 0.34;
+const CUE_VIEW_RADIUS_RATIO = 0.26;
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR;
 // Encourage the cue camera to sit higher above the cloth while staying within the
 // allowed orbit envelope.
-const CUE_VIEW_HEIGHT_OFFSET = 0.06;
+const CUE_VIEW_HEIGHT_OFFSET = 0.085;
 const CUE_VIEW_MIN_PHI = Math.max(
   CAMERA.minPhi,
   Math.min(CAMERA.maxPhi - CAMERA_RAIL_SAFETY, STANDING_VIEW_PHI + 0.22) -
     CUE_VIEW_HEIGHT_OFFSET
 );
-const CUE_VIEW_PHI_LIFT = 0.04;
+const CUE_VIEW_PHI_LIFT = 0.03;
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,


### PR DESCRIPTION
## Summary
- pull the Pool Royale cue camera closer to the table so it sits alongside the rails during shots
- raise the cue camera's baseline tilt to keep the cloth visible while standing nearer the action

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7f3392fc48329922a361d569f0965