### PR TITLE
Fix snooker cushion profile geometry

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -4222,9 +4222,9 @@ function Table3D(
     const noseThickness = baseThickness * NOSE_REDUCTION;
     const frontY = backY - noseThickness;
     const rad = THREE.MathUtils.degToRad(CUSHION_CUT_ANGLE);
-    const straightCut = Math.min(
-      halfLen,
-      Math.max(baseThickness * 0.25, noseThickness / Math.tan(rad))
+    const straightCut = Math.max(
+      baseThickness * 0.25,
+      noseThickness / Math.tan(rad)
     );
 
     const shape = new THREE.Shape();


### PR DESCRIPTION
## Summary
- restore the snooker cushion profile so the 29° cuts no longer include the recently added extra section

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7f61408c88329b633b1572384e1e8