### PR TITLE
Adjust snooker shot camera framing

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -15,10 +15,11 @@ public class CameraController : MonoBehaviour
     // Height of the top of the wooden side rails in world space.  Slightly raised
     // to keep the camera from dipping too low relative to the table frame.
     public float railTopY = 0.33f;
-    // Small clearance so the camera always remains a little above the side rails.
-    public float railClearance = 0.1f;
+    // Optional clearance so the camera can be kept slightly above the side rails
+    // while still preventing it from dipping below their top surface.
+    public float railClearance = 0f;
     // How far above the rails the camera is allowed to travel.
-    public float maxHeightAboveTable = 1.5f;
+    public float maxHeightAboveTable = 1.8f;
     // Default distance of the camera from the table centre when fully raised to
     // provide a broad overview of the action.
     public float distanceFromCenter = 4.2f;
@@ -53,7 +54,7 @@ public class CameraController : MonoBehaviour
         // Clamp vertical movement so the camera never dips below the side rails
         // and doesn't fly too high above the table surface.
         Vector3 pos = transform.position;
-        float minY = railTopY + railClearance;
+        float minY = railTopY + Mathf.Max(0f, railClearance);
         float maxY = tableTopY + maxHeightAboveTable;
         pos.y = Mathf.Clamp(pos.y, minY, maxY);
 

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -17,9 +17,9 @@ public class CueCamera : MonoBehaviour
     public Transform TargetBall;
 
     // Distance behind the ball when preparing a shot from the cue view.
-    public float cueAimDistance = 0.52f;
+    public float cueAimDistance = 0.45f;
     // Height of the camera above the table surface while aiming.
-    public float cueAimHeight = 0.36f;
+    public float cueAimHeight = 0.42f;
     // Distance and height for the short-rail broadcast view used once a shot begins.
     public float broadcastDistance = 1.05f;
     public float broadcastHeight = 0.5f;


### PR DESCRIPTION
## Summary
- bring the cue camera closer to the table while raising its aiming height for player shots
- clamp the orbit camera to the rail height and allow a higher overview when the player pulls back the view

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7fccd02f08329a8e013f252560905