### PR TITLE
Adjust cue camera aim focus while lowering view

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -735,9 +735,11 @@ public class CueCamera : MonoBehaviour
             return defaultTarget;
         }
 
-        Vector3 midpoint = Vector3.Lerp(focus, aimEnd, 0.5f);
-        midpoint.y = Mathf.Max(midpoint.y, focus.y) + cueBallLookOffset;
-        return midpoint;
+        float lowering = Mathf.Clamp01(cueAimLowering);
+        float lookFraction = Mathf.Lerp(0.5f, 0.9f, lowering);
+        Vector3 lookPoint = Vector3.LerpUnclamped(focus, aimEnd, lookFraction);
+        lookPoint.y = Mathf.Max(lookPoint.y, focus.y) + cueBallLookOffset;
+        return lookPoint;
     }
 
     private bool TryGetAimLineEndPoint(Vector3 forward, out Vector3 aimEnd)


### PR DESCRIPTION
## Summary
- retune the cue aiming camera look target so it follows more of the aiming line when the view is lowered
- keep the cue stick near the bottom of the frame while ensuring the target ball remains visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e8e293d1c88329ab82e408041f7231