### PR TITLE
Adjust cue camera proximity

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -22,15 +22,15 @@ public class CueCamera : MonoBehaviour
 
     [Header("Cue aim view")]
     // Distance from the cue ball when the camera is fully raised above the cue.
-    public float cueRaisedDistanceFromBall = 1.35f;
+    public float cueRaisedDistanceFromBall = 1.05f;
     // Distance from the cue ball used for the lowest aiming view.  This keeps the
     // camera hovering over the mid–upper portion of the cue rather than slipping
     // all the way back to the plastic end.
-    public float cueLoweredDistanceFromBall = 0.52f;
+    public float cueLoweredDistanceFromBall = 0.22f;
     // Height the cue view should reach when the player lifts the camera.
-    public float cueRaisedHeight = 1.1f;
+    public float cueRaisedHeight = 1.0f;
     // Minimum height maintained when the player drops the camera toward the cue.
-    public float cueLoweredHeight = 0.48f;
+    public float cueLoweredHeight = 0.38f;
     // Keep a small safety buffer from the butt of the cue so the camera never
     // retreats past the stick and always looks down the shaft.
     public float cueButtClearance = 0.12f;


### PR DESCRIPTION
## Summary
- pull the cue camera closer to the table by reducing its default distances from the cue ball
- lower the default cue aim heights to keep the view tight on the cloth while retaining the same raise/lower travel range

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8e773bff48329be4ceb5888b1c2c1