### PR TITLE
Tighten cue cameras for snooker and pool

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -22,15 +22,15 @@ public class CueCamera : MonoBehaviour
 
     [Header("Cue aim view")]
     // Distance from the cue ball when the camera is fully raised above the cue.
-    public float cueRaisedDistanceFromBall = 1.05f;
+    public float cueRaisedDistanceFromBall = 0.82f;
     // Distance from the cue ball used for the lowest aiming view.  This keeps the
     // camera hovering over the mid–upper portion of the cue rather than slipping
     // all the way back to the plastic end.
-    public float cueLoweredDistanceFromBall = 0.22f;
+    public float cueLoweredDistanceFromBall = 0.18f;
     // Height the cue view should reach when the player lifts the camera.
-    public float cueRaisedHeight = 1.0f;
+    public float cueRaisedHeight = 0.82f;
     // Minimum height maintained when the player drops the camera toward the cue.
-    public float cueLoweredHeight = 0.38f;
+    public float cueLoweredHeight = 0.3f;
     // Keep a small safety buffer from the butt of the cue so the camera never
     // retreats past the stick and always looks down the shaft.
     public float cueButtClearance = 0.12f;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2327,11 +2327,12 @@ const CUE_VIEW_MIN_PHI = Math.min(
 );
 const CUE_VIEW_PHI_LIFT = 0.08;
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
-const CUE_VIEW_RAIL_CLEARANCE = BALL_R * 0.12;
-const CUE_VIEW_ABOVE_CUE = BALL_R * 0.65;
-const CUE_VIEW_EXTRA_HEIGHT = BALL_R * 0.2;
-const CUE_VIEW_BACK_MIN_RATIO = 0.34;
-const CUE_VIEW_BACK_RATIO = 0.46;
+// Mirror the snooker cue framing so both games share the same up-close feel around the cloth.
+const CUE_VIEW_RAIL_CLEARANCE = BALL_R * 0.1;
+const CUE_VIEW_ABOVE_CUE = BALL_R * 0.54;
+const CUE_VIEW_EXTRA_HEIGHT = BALL_R * 0.14;
+const CUE_VIEW_BACK_MIN_RATIO = 0.28;
+const CUE_VIEW_BACK_RATIO = 0.42;
 const CUE_VIEW_BASE_CUE_LENGTH = (BALL_R / 0.0525) * 1.5 * CUE_LENGTH_MULTIPLIER;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,


### PR DESCRIPTION
## Summary
- bring the Unity snooker cue camera closer to the cloth by reducing the default raise/lower offsets
- align Pool Royale's cue camera clearances and offsets with the snooker tuning so both games share the same close framing

## Testing
- npm run lint *(fails: existing style violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e91b5934c483299c25cf04ee72f117