### PR TITLE
Tighten standing camera gap to rails

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2284,9 +2284,9 @@ const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
 const BROADCAST_DISTANCE_MULTIPLIER = 0.48;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
-const STANDING_VIEW_MARGIN_LANDSCAPE = 1.02;
-const STANDING_VIEW_MARGIN_PORTRAIT = 1.0;
-const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.04;
+const STANDING_VIEW_MARGIN_LANDSCAPE = 1.006;
+const STANDING_VIEW_MARGIN_PORTRAIT = 1.004;
+const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_MARGIN_WIDTH = BALL_R * 6;
 const BROADCAST_MARGIN_LENGTH = BALL_R * 6;
 const CAMERA = {

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2342,9 +2342,9 @@ const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant
 const BROADCAST_DISTANCE_MULTIPLIER = 0.48;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
-const STANDING_VIEW_MARGIN_LANDSCAPE = 1.02;
-const STANDING_VIEW_MARGIN_PORTRAIT = 1.0;
-const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.04;
+const STANDING_VIEW_MARGIN_LANDSCAPE = 1.006;
+const STANDING_VIEW_MARGIN_PORTRAIT = 1.004;
+const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const CAMERA = {
   fov: STANDING_VIEW_FOV,
   near: 0.04,


### PR DESCRIPTION
## Summary
- nudge the Pool Royale and Snooker standing camera margins closer to the rails while preserving a slight clearance
- reduce the broadcast radius padding so default framing sits tightly along the table edges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9328068a8832982648d8a843d689b