### PR TITLE
Add portrait camera rig utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "dependencies": {
     "dotenv": "^16.3.1",
     "emoji-name-map": "^2.0.3",
+    "express": "^4.19.2",
     "geoip-lite": "^1.4.10",
     "mongoose": "^7.6.0",
-    "express": "^4.19.2",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.8.1",
     "ton": "^13.9.0",
@@ -38,6 +38,8 @@
     "ton-x": "^2.1.0-preview"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.11",
+    "@types/three": "^0.180.0",
     "concurrently": "^8.2.2",
     "eslint": "^8.57.1",
     "eslint-config-standard": "^17.1.0",
@@ -46,12 +48,12 @@
     "eslint-plugin-promise": "^6.6.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "prettier": "^3.6.2",
-    "mongodb-memory-server": "^10.1.4",
-    "vitest": "^1.5.0",
-    "typescript": "^5.6.3",
     "jest": "^29.7.0",
+    "mongodb-memory-server": "^10.1.4",
+    "prettier": "^3.6.2",
+    "three": "^0.180.0",
     "ts-jest": "^29.2.5",
-    "@types/jest": "^29.5.11"
+    "typescript": "^5.6.3",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/camera/PortraitCameraRig.ts
+++ b/src/camera/PortraitCameraRig.ts
@@ -1,0 +1,349 @@
+import * as THREE from 'three';
+
+export interface CameraRigConfig {
+  camera: THREE.PerspectiveCamera;
+  tableWidth: number;
+  tableHeight: number;
+  padding?: number;
+  verticalFovDeg?: number;
+  minPitchDeg?: number;
+  maxPitchDeg?: number;
+  minRadius?: number;
+  maxRadius?: number;
+  smoothingTime?: number;
+  target?: THREE.Vector3;
+}
+
+export interface SpinVector {
+  x: number;
+  y: number;
+}
+
+export interface CueRigConfig {
+  cueLength: number;
+  cueTipClearance: number;
+  ballRadius: number;
+  maxOffsetRatio?: number;
+}
+
+export interface CueTransform {
+  buttPosition: THREE.Vector3;
+  tipPosition: THREE.Vector3;
+  direction: THREE.Vector3;
+  quaternion: THREE.Quaternion;
+}
+
+const DEFAULT_PADDING = 0.05;
+const DEFAULT_V_FOV = 50;
+const DEFAULT_MIN_PITCH = THREE.MathUtils.degToRad(20);
+const DEFAULT_MAX_PITCH = THREE.MathUtils.degToRad(65);
+const DEFAULT_SMOOTH_TIME = 0.12;
+const SAFETY_RADIUS_SCALE = 1.02;
+
+export function computeFitRadius(options: {
+  tableWidth: number;
+  tableHeight: number;
+  padding?: number;
+  verticalFovDeg?: number;
+  aspect: number;
+  pitchRad: number;
+}): number {
+  const {
+    tableWidth,
+    tableHeight,
+    aspect,
+    padding = DEFAULT_PADDING,
+    verticalFovDeg = DEFAULT_V_FOV,
+    pitchRad
+  } = options;
+  const halfWidth = (tableWidth * 0.5) * (1 + padding);
+  const halfHeight = (tableHeight * 0.5) * (1 + padding);
+  const vFov = THREE.MathUtils.degToRad(verticalFovDeg);
+  const hFov = 2 * Math.atan(Math.tan(vFov / 2) * (1 / aspect));
+  const rWidth = halfWidth / Math.tan(hFov / 2);
+  const denom = Math.tan(vFov / 2);
+  const safePitch = THREE.MathUtils.clamp(pitchRad, 1e-3, Math.PI / 2 - 1e-3);
+  const verticalExtent = halfHeight / Math.cos(safePitch);
+  const rHeight = verticalExtent / denom;
+  return Math.max(rWidth, rHeight) * SAFETY_RADIUS_SCALE;
+}
+
+interface SmoothDampState {
+  current: number;
+  velocity: number;
+}
+
+function smoothDamp(
+  state: SmoothDampState,
+  target: number,
+  dt: number,
+  smoothTime: number,
+  maxSpeed = Infinity
+): number {
+  const omega = 2 / Math.max(0.0001, smoothTime);
+  const x = omega * dt;
+  const exp = 1 / (1 + x + 0.48 * x * x + 0.235 * x * x * x);
+  let change = state.current - target;
+  const originalTo = target;
+  const maxChange = maxSpeed * smoothTime;
+  change = THREE.MathUtils.clamp(change, -maxChange, maxChange);
+  target = state.current - change;
+  const temp = (state.velocity + omega * change) * dt;
+  state.velocity = (state.velocity - omega * temp) * exp;
+  let output = target + (change + temp) * exp;
+  if ((originalTo - state.current > 0) === (output > originalTo)) {
+    output = originalTo;
+    state.velocity = (output - originalTo) / dt;
+  }
+  state.current = output;
+  return output;
+}
+
+function smoothDampAngle(
+  state: SmoothDampState,
+  target: number,
+  dt: number,
+  smoothTime: number
+): number {
+  const delta = Math.atan2(Math.sin(target - state.current), Math.cos(target - state.current));
+  const newTarget = state.current + delta;
+  return smoothDamp(state, newTarget, dt, smoothTime);
+}
+
+export class PortraitCameraRig {
+  private readonly camera: THREE.PerspectiveCamera;
+  private readonly target: THREE.Vector3;
+  private readonly smoothingTime: number;
+  private readonly minPitch: number;
+  private readonly maxPitch: number;
+  private readonly minRadius: number;
+  private readonly maxRadius: number;
+  private readonly padding: number;
+  private readonly verticalFovDeg: number;
+
+  private pitchState: SmoothDampState;
+  private yawState: SmoothDampState;
+  private radiusState: SmoothDampState;
+  private targetState: {
+    current: THREE.Vector3;
+    velocity: THREE.Vector3;
+  };
+
+  private viewportAspect = 16 / 9;
+  private tableWidth: number;
+  private tableHeight: number;
+
+  constructor(config: CameraRigConfig) {
+    const {
+      camera,
+      tableWidth,
+      tableHeight,
+      padding = DEFAULT_PADDING,
+      verticalFovDeg = DEFAULT_V_FOV,
+      minPitchDeg = 20,
+      maxPitchDeg = 65,
+      minRadius,
+      maxRadius,
+      smoothingTime = DEFAULT_SMOOTH_TIME,
+      target
+    } = config;
+    this.camera = camera;
+    this.tableWidth = tableWidth;
+    this.tableHeight = tableHeight;
+    this.padding = padding;
+    this.verticalFovDeg = verticalFovDeg;
+    this.smoothingTime = smoothingTime;
+    this.minPitch = THREE.MathUtils.degToRad(minPitchDeg);
+    this.maxPitch = THREE.MathUtils.degToRad(maxPitchDeg);
+    this.minRadius = Math.max(0.1, minRadius ?? 0.1);
+    this.maxRadius = Math.max(this.minRadius, maxRadius ?? this.minRadius * 1.8);
+    this.target = target ? target.clone() : new THREE.Vector3();
+
+    this.pitchState = { current: (this.minPitch + this.maxPitch) * 0.5, velocity: 0 };
+    this.yawState = { current: 0, velocity: 0 };
+    const initialRadius = this.computeFitRadius();
+    const clampedRadius = THREE.MathUtils.clamp(initialRadius, this.minRadius, this.maxRadius);
+    this.radiusState = { current: clampedRadius, velocity: 0 };
+    this.targetState = {
+      current: this.target.clone(),
+      velocity: new THREE.Vector3()
+    };
+    this.camera.up.set(0, 1, 0);
+    this.camera.near = Math.max(0.01, this.camera.near);
+  }
+
+  setViewport(width: number, height: number): void {
+    if (width <= 0 || height <= 0) return;
+    this.viewportAspect = height / width;
+    this.camera.aspect = width / height;
+    this.camera.updateProjectionMatrix();
+  }
+
+  setTableDimensions(width: number, height: number): void {
+    if (width > 0) this.tableWidth = width;
+    if (height > 0) this.tableHeight = height;
+  }
+
+  setPitchTarget(pitchRad: number): void {
+    const clamped = THREE.MathUtils.clamp(pitchRad, this.minPitch, this.maxPitch);
+    this.pitchState.current = clamped;
+  }
+
+  setYawTarget(yawRad: number): void {
+    this.yawState.current = yawRad;
+  }
+
+  setRadiusTarget(radius: number): void {
+    const fit = this.computeFitRadius();
+    const min = Math.max(fit, this.minRadius);
+    const max = Math.max(min, this.maxRadius);
+    const clamped = THREE.MathUtils.clamp(radius, min, max);
+    this.radiusState.current = clamped;
+  }
+
+  setTarget(target: THREE.Vector3): void {
+    this.target.copy(target);
+    this.targetState.current.copy(target);
+  }
+
+  pan(delta: THREE.Vector3): void {
+    const next = this.target.clone().add(delta);
+    this.target.copy(next);
+  }
+
+  rotate(deltaYaw: number, deltaPitch: number): void {
+    const nextYaw = this.yawState.current + deltaYaw;
+    const nextPitch = THREE.MathUtils.clamp(
+      this.pitchState.current + deltaPitch,
+      this.minPitch,
+      this.maxPitch
+    );
+    this.yawState.current = nextYaw;
+    this.pitchState.current = nextPitch;
+  }
+
+  zoom(multiplier: number): void {
+    const fit = this.computeFitRadius();
+    const current = this.radiusState.current;
+    const target = THREE.MathUtils.clamp(
+      current * multiplier,
+      Math.max(fit, this.minRadius),
+      Math.max(fit, this.maxRadius)
+    );
+    this.radiusState.current = target;
+  }
+
+  computeFitRadius(pitchRad = this.pitchState.current): number {
+    return computeFitRadius({
+      tableWidth: this.tableWidth,
+      tableHeight: this.tableHeight,
+      padding: this.padding,
+      verticalFovDeg: this.verticalFovDeg,
+      aspect: this.viewportAspect,
+      pitchRad
+    });
+  }
+
+  update(dt: number): void {
+    const smoothTime = this.smoothingTime;
+    const fit = this.computeFitRadius();
+    const minRadius = Math.max(fit, this.minRadius);
+    const maxRadius = Math.max(minRadius, this.maxRadius);
+
+    this.radiusState.current = THREE.MathUtils.clamp(this.radiusState.current, minRadius, maxRadius);
+    this.pitchState.current = THREE.MathUtils.clamp(this.pitchState.current, this.minPitch, this.maxPitch);
+
+    this.radiusState.velocity = this.radiusState.velocity || 0;
+    this.pitchState.velocity = this.pitchState.velocity || 0;
+    this.yawState.velocity = this.yawState.velocity || 0;
+
+    const targetYaw = this.yawState.current;
+    const targetPitch = this.pitchState.current;
+    const targetRadius = THREE.MathUtils.clamp(this.radiusState.current, minRadius, maxRadius);
+
+    const pitch = smoothDamp(
+      this.pitchState,
+      targetPitch,
+      dt,
+      smoothTime
+    );
+    const yaw = smoothDampAngle(
+      this.yawState,
+      targetYaw,
+      dt,
+      smoothTime
+    );
+    const radius = smoothDamp(
+      this.radiusState,
+      targetRadius,
+      dt,
+      smoothTime
+    );
+
+    const offset = new THREE.Vector3(
+      radius * Math.cos(pitch) * Math.sin(yaw),
+      radius * Math.sin(pitch),
+      radius * Math.cos(pitch) * Math.cos(yaw)
+    );
+
+    const targetPos = this.target.clone();
+    const targetState = this.targetState;
+    const spring = THREE.MathUtils.clamp(dt / Math.max(smoothTime, 1e-3), 0, 1);
+    targetState.current.lerp(targetPos, spring);
+
+    const position = targetState.current.clone().add(offset);
+    this.camera.position.copy(position);
+    this.camera.lookAt(targetState.current);
+    this.camera.up.set(0, 1, 0);
+  }
+}
+
+export function computeCueTransform(
+  cueConfig: CueRigConfig,
+  camera: THREE.Camera,
+  cueBallPosition: THREE.Vector3,
+  cueDirection: THREE.Vector3,
+  spin: SpinVector
+): CueTransform {
+  const { cueLength, cueTipClearance, ballRadius, maxOffsetRatio = 0.6 } = cueConfig;
+  const sx = THREE.MathUtils.clamp(spin.x, -1, 1);
+  const sy = THREE.MathUtils.clamp(spin.y, -1, 1);
+  const offsetScale = Math.min(Math.max(maxOffsetRatio, 0), 0.7) * ballRadius;
+  const offsetX = sx * offsetScale;
+  const offsetY = sy * offsetScale;
+  const radiusSq = ballRadius * ballRadius;
+  const planarSq = offsetX * offsetX + offsetY * offsetY;
+  const nz = -Math.sqrt(Math.max(0, radiusSq - planarSq));
+
+  const tangentX = new THREE.Vector3(1, 0, 0);
+  const tangentZ = new THREE.Vector3(0, 0, 1);
+  const normal = new THREE.Vector3(0, 1, 0);
+
+  const contactPoint = cueBallPosition
+    .clone()
+    .addScaledVector(tangentX, offsetX)
+    .addScaledVector(tangentZ, offsetY)
+    .addScaledVector(normal, nz);
+
+  const aimDir = cueDirection.clone().normalize();
+  const tipPosition = contactPoint.clone();
+  const buttPosition = tipPosition.clone().addScaledVector(aimDir, -(cueLength + cueTipClearance));
+  const forward = aimDir.clone();
+  const up = new THREE.Vector3(0, 1, 0);
+  const side = new THREE.Vector3().crossVectors(up, forward);
+  if (side.lengthSq() < 1e-6) {
+    side.set(1, 0, 0);
+  }
+  side.normalize();
+  up.copy(new THREE.Vector3().crossVectors(forward, side)).normalize();
+  const forwardForBasis = forward.clone().negate();
+  const matrix = new THREE.Matrix4().makeBasis(side, up, forwardForBasis);
+  const quaternion = new THREE.Quaternion().setFromRotationMatrix(matrix);
+
+  return {
+    buttPosition,
+    tipPosition,
+    direction: forward,
+    quaternion
+  };
+}

--- a/tests/camera/PortraitCameraRig.test.ts
+++ b/tests/camera/PortraitCameraRig.test.ts
@@ -1,0 +1,68 @@
+import * as THREE from 'three';
+import {
+  computeFitRadius,
+  computeCueTransform,
+  PortraitCameraRig
+} from '../../src/camera/PortraitCameraRig';
+
+describe('computeFitRadius', () => {
+  it('matches reference framing for portrait aspect', () => {
+    const tableWidth = 3.569;
+    const tableHeight = 1.778;
+    const aspect = 1600 / 720;
+    const pitch = THREE.MathUtils.degToRad(45);
+    const radius = computeFitRadius({
+      tableWidth,
+      tableHeight,
+      aspect,
+      pitchRad: pitch,
+      padding: 0.05,
+      verticalFovDeg: 50
+    });
+    const expected = 9.107956787165353;
+    expect(radius).toBeCloseTo(expected, 6);
+  });
+});
+
+describe('PortraitCameraRig', () => {
+  it('maintains no-crop invariant when zooming', () => {
+    const camera = new THREE.PerspectiveCamera(50, 0.45, 0.05, 1000);
+    const rig = new PortraitCameraRig({
+      camera,
+      tableWidth: 3.569,
+      tableHeight: 1.778,
+      minRadius: 1,
+      maxRadius: 6,
+      padding: 0.05,
+      verticalFovDeg: 50
+    });
+    rig.setViewport(720, 1600);
+    rig.zoom(0.2);
+    rig.update(1 / 60);
+    const radiusAfter = camera.position.length();
+    const fit = rig.computeFitRadius();
+    expect(radiusAfter).toBeGreaterThanOrEqual(fit - 1e-5);
+  });
+});
+
+describe('computeCueTransform', () => {
+  it('maps spin extremes to valid contact points', () => {
+    const cueConfig = {
+      cueLength: 1.4,
+      cueTipClearance: 0.05,
+      ballRadius: 0.0285,
+      maxOffsetRatio: 0.6
+    };
+    const camera = new THREE.PerspectiveCamera();
+    const ballPos = new THREE.Vector3();
+    const cueDir = new THREE.Vector3(0, 0, -1);
+    const spin = { x: 1, y: 1 };
+    const result = computeCueTransform(cueConfig, camera, ballPos, cueDir, spin);
+    const tipDistance = result.tipPosition.distanceTo(ballPos);
+    expect(tipDistance).toBeCloseTo(cueConfig.ballRadius, 3);
+    const forward = result.direction.clone().normalize();
+    expect(forward.z).toBeLessThan(0);
+    const buttDistance = result.buttPosition.distanceTo(result.tipPosition);
+    expect(buttDistance).toBeCloseTo(cueConfig.cueLength + cueConfig.cueTipClearance, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable Three.js portrait camera rig helper with auto-fit and cue transform logic
- expose TypeScript utilities for deterministic radius fitting and cue/spin coupling
- cover the new helpers with targeted Jest tests for radius fitting, crop invariants, and cue contact math

## Testing
- npm test -- --runTestsByPath tests/camera/PortraitCameraRig.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e9689b0a1c8329863c86f3acb3ae6e