### PR TITLE
Align Pool Royale camera with aiming line and broadcast side

### DIFF
--- a/tests/simpleOrbitCamera.test.ts
+++ b/tests/simpleOrbitCamera.test.ts
@@ -3,11 +3,11 @@ import { computeRFit, rad } from '../webapp/src/pages/Games/simpleOrbitCamera';
 describe('computeRFit', () => {
   it('fits standard portrait viewport with default theta', () => {
     const result = computeRFit(1600, 720, 3.6, 7.2, rad(35));
-    expect(result).toBeCloseTo(10.0938048563, 6);
+    expect(result).toBeCloseTo(9.7559309963, 6);
   });
 
   it('fits larger viewport with steeper pitch', () => {
     const result = computeRFit(1920, 1080, 3.6, 7.2, rad(45));
-    expect(result).toBeCloseTo(11.6932280989, 6);
+    expect(result).toBeCloseTo(11.301816122, 6);
   });
 });


### PR DESCRIPTION
## Summary
- lower the cue-view orbit and lock the aiming direction to the active camera so the aiming guide stays centered
- keep action broadcast cameras on the nearer short rail and use the mid-table eye level for their height
- refresh the simple orbit camera test expectations to reflect the retuned camera geometry

## Testing
- npm test -- simpleOrbitCamera

------
https://chatgpt.com/codex/tasks/task_e_68ea09dd3af08329bff622a664506564