### PR TITLE
Restore site to 5:00 AM baseline

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -36,7 +36,7 @@ public class CueCamera : MonoBehaviour
     // Height the cue view should reach when the player lifts the camera.
     public float cueRaisedHeight = 0.82f;
     // Minimum height maintained when the player drops the camera toward the cue.
-    public float cueLoweredHeight = 0.24f;
+    public float cueLoweredHeight = 0.3f;
     // Keep a small safety buffer from the butt of the cue so the camera never
     // retreats past the stick and always looks down the shaft.
     public float cueButtClearance = 0.12f;
@@ -354,17 +354,14 @@ public class CueCamera : MonoBehaviour
         float clothAnchorHeight = minimumCueHeight;
         float heightScale = Mathf.Lerp(1f, Mathf.Clamp(cueHeightClothScale, 0.1f, 1f), blend);
         height = clothAnchorHeight + (height - clothAnchorHeight) * heightScale;
-        float maxRailClamp = railHeight + Mathf.Max(0f, railClearance);
-        float cueRailClamp = Mathf.Lerp(maxRailClamp, railHeight, blend);
-        cueRailClamp = Mathf.Max(cueRailClamp, railHeight);
-        height = Mathf.Max(height, cueRailClamp);
+        float minRailHeight = railHeight + Mathf.Max(0f, railClearance);
+        height = Mathf.Max(height, minRailHeight);
 
         Vector3 focus = CueBall.position;
-        float minimumHeightBuffer = Mathf.Lerp(minimumHeightAboveFocus, 0f, blend);
-        float minimumHeightOffset = Mathf.Max(minimumHeightBuffer, height - focus.y);
+        float minimumHeightOffset = Mathf.Max(minimumHeightAboveFocus, height - focus.y);
         Vector3 lookTarget = GetCueAimLookTarget(focus, cueAimForward);
 
-        ApplyCameraAt(focus, cueAimForward, distance, height, minimumHeightOffset, lookTarget, cueRailClamp);
+        ApplyCameraAt(focus, cueAimForward, distance, height, minimumHeightOffset, lookTarget);
 
         Vector3 flatForward = new Vector3(cueAimForward.x, 0f, cueAimForward.z);
         if (flatForward.sqrMagnitude > 0.0001f)
@@ -589,7 +586,7 @@ public class CueCamera : MonoBehaviour
         float minimumHeightOffset = Mathf.Max(minimumHeightAboveFocus, height - focus.y);
         Vector3 lookTarget = focus + Vector3.up * Mathf.Max(0f, broadcastHeightPadding);
 
-        ApplyShortRailCamera(focus, forward, distance, height, minimumHeightOffset, lookTarget, minRailHeight);
+        ApplyShortRailCamera(focus, forward, distance, height, minimumHeightOffset, lookTarget);
     }
 
     private float ComputeBroadcastDistance(Vector3 focus, float height, Vector3 forward, Camera cam)
@@ -683,8 +680,7 @@ public class CueCamera : MonoBehaviour
         Quaternion rotation = Quaternion.Euler(0f, yaw, 0f);
         Vector3 forward = rotation * Vector3.forward;
         Vector3 lookTarget = focusPosition + forward * 5f;
-        float minRailHeight = railHeight + Mathf.Max(0f, railClearance);
-        ApplyShortRailCamera(focusPosition, forward, distance, height, minimumHeightAboveFocus, lookTarget, minRailHeight);
+        ApplyShortRailCamera(focusPosition, forward, distance, height, minimumHeightAboveFocus, lookTarget);
     }
 
     private void ApplyShortRailCamera(
@@ -697,8 +693,7 @@ public class CueCamera : MonoBehaviour
         Quaternion rotation = Quaternion.Euler(0f, yaw, 0f);
         Vector3 forward = rotation * Vector3.forward;
         Vector3 lookTarget = focusPosition + forward * 5f;
-        float minRailHeight = railHeight + Mathf.Max(0f, railClearance);
-        ApplyShortRailCamera(focusPosition, forward, distance, height, minimumHeightOffset, lookTarget, minRailHeight);
+        ApplyShortRailCamera(focusPosition, forward, distance, height, minimumHeightOffset, lookTarget);
     }
 
     private void ApplyShortRailCamera(
@@ -707,11 +702,10 @@ public class CueCamera : MonoBehaviour
         float distance,
         float height,
         float minimumHeightOffset,
-        Vector3 lookTarget,
-        float minRailHeight
+        Vector3 lookTarget
     )
     {
-        ApplyCameraAt(focusPosition, forward, distance, height, minimumHeightOffset, lookTarget, minRailHeight);
+        ApplyCameraAt(focusPosition, forward, distance, height, minimumHeightOffset, lookTarget);
 
         Vector3 pos = transform.position;
         pos.x = 0f;
@@ -724,8 +718,7 @@ public class CueCamera : MonoBehaviour
         float distance,
         float height,
         float minimumHeightOffset,
-        Vector3 lookTarget,
-        float minRailHeight
+        Vector3 lookTarget
     )
     {
         if (forward.sqrMagnitude < 0.0001f)
@@ -737,8 +730,8 @@ public class CueCamera : MonoBehaviour
         Vector3 desiredPosition = focusPosition - forward * distance + Vector3.up * height;
 
         float minimumHeight = focusPosition.y + Mathf.Max(minimumHeightAboveFocus, minimumHeightOffset);
-        float railClamp = Mathf.Max(minRailHeight, railHeight);
-        minimumHeight = Mathf.Max(minimumHeight, railClamp);
+        float minRailHeight = railHeight + Mathf.Max(0f, railClearance);
+        minimumHeight = Mathf.Max(minimumHeight, minRailHeight);
 
         // Prevent the camera from getting stuck behind walls or decorations by
         // nudging it toward the table if something blocks the line of sight.
@@ -761,22 +754,7 @@ public class CueCamera : MonoBehaviour
         }
 
         desiredPosition.y = Mathf.Max(desiredPosition.y, minimumHeight);
-        desiredPosition.y = Mathf.Max(desiredPosition.y, railClamp);
-
-        if (distance > 0f)
-        {
-            Vector3 toFocus = focusPosition - desiredPosition;
-            float forwardDistance = Vector3.Dot(toFocus, forward);
-            float requiredDistance = Mathf.Max(0.01f, distance);
-            if (forwardDistance < requiredDistance)
-            {
-                float adjust = requiredDistance - forwardDistance;
-                desiredPosition -= forward * adjust;
-            }
-        }
-
-        desiredPosition.y = Mathf.Max(desiredPosition.y, minimumHeight);
-        desiredPosition.y = Mathf.Max(desiredPosition.y, railClamp);
+        desiredPosition.y = Mathf.Max(desiredPosition.y, minRailHeight);
         transform.position = desiredPosition;
         transform.LookAt(lookTarget);
     }

--- a/billiards.Unity/DemoBehaviour.cs
+++ b/billiards.Unity/DemoBehaviour.cs
@@ -40,31 +40,10 @@ public class DemoBehaviour : MonoBehaviour
         // Convert cue ball position to solver coordinates. The solver operates
         // in the XZ plane while Unity uses Y for height.
         var cueStart = new Vec2(CueBall.position.x, CueBall.position.z);
-        // Aim direction is derived from the camera's centre ray so the
-        // guiding line always matches what the player sees on screen even
-        // when the camera strafes.
-        Camera cam = Camera.main;
-        var desiredDir = currentDir;
-        if (cam != null)
-        {
-            Ray viewRay = cam.ViewportPointToRay(new Vector3(0.5f, 0.5f, 0f));
-            Plane clothPlane = new Plane(Vector3.up, new Vector3(0f, CueBall.position.y, 0f));
-            float distance;
-            if (clothPlane.Raycast(viewRay, out distance))
-            {
-                Vector3 aimPoint = viewRay.GetPoint(distance);
-                Vector3 flat = new Vector3(aimPoint.x - CueBall.position.x, 0f, aimPoint.z - CueBall.position.z);
-                if (flat.sqrMagnitude > 0.0001f)
-                {
-                    desiredDir = new Vec2(flat.x, flat.z).Normalized();
-                }
-            }
-            else
-            {
-                Vector3 forward = cam.transform.forward;
-                desiredDir = new Vec2(forward.x, forward.z).Normalized();
-            }
-        }
+        // Aim direction is derived from the camera's forward vector so the
+        // player aims by moving the camera rather than dragging the line.
+        var camForward = Camera.main.transform.forward;
+        var desiredDir = new Vec2(camForward.x, camForward.z).Normalized();
 
         // Smoothly adjust the aim for small camera movements.
         float smoothingFactor = Mathf.Clamp01(1f - Mathf.Exp(-Time.deltaTime * aimSmoothing));

--- a/tests/simpleOrbitCamera.test.ts
+++ b/tests/simpleOrbitCamera.test.ts
@@ -3,11 +3,11 @@ import { computeRFit, rad } from '../webapp/src/pages/Games/simpleOrbitCamera';
 describe('computeRFit', () => {
   it('fits standard portrait viewport with default theta', () => {
     const result = computeRFit(1600, 720, 3.6, 7.2, rad(35));
-    expect(result).toBeCloseTo(9.7559309963, 6);
+    expect(result).toBeCloseTo(10.0938048563, 6);
   });
 
   it('fits larger viewport with steeper pitch', () => {
     const result = computeRFit(1920, 1080, 3.6, 7.2, rad(45));
-    expect(result).toBeCloseTo(11.301816122, 6);
+    expect(result).toBeCloseTo(11.6932280989, 6);
   });
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -575,11 +575,11 @@ const ACTION_CAM = Object.freeze({
   forwardBias: 0.1,
   shortRailBias: 0.52,
   followShortRailBias: 0.42,
-  heightOffset: 0,
+  heightOffset: BALL_R * 9.2,
   smoothingTime: 0.32,
   followSmoothingTime: 0.24,
   followDistance: BALL_R * 54,
-  followHeightOffset: 0,
+  followHeightOffset: BALL_R * 7.4,
   followHoldMs: 900
 });
 /**
@@ -2276,12 +2276,12 @@ const STANDING_VIEW_PHI = 0.92;
 // Lower the cue shot tilt so the camera can skim the rail line while staying just
 // above the cloth. Keeping the delta small ensures we don't clip through the
 // table surface when blending between views.
-const CUE_SHOT_PHI = Math.PI / 2 - 0.07;
+const CUE_SHOT_PHI = Math.PI / 2 - 0.12;
 const STANDING_VIEW_MARGIN = 0.0024;
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.3;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.18);
-const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.02; // keep orbit camera from dipping below the table surface while allowing a lower tilt
+const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.08; // keep orbit camera from dipping below the table surface
 // Pull the baseline player orbit in so the cue perspective hugs the cloth a bit more, especially on portrait screens.
 const PLAYER_CAMERA_DISTANCE_FACTOR = 0.135;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
@@ -2327,18 +2327,15 @@ const CUE_VIEW_RADIUS_RATIO = 0.085;
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.34;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
-  STANDING_VIEW_PHI + 0.5
+  STANDING_VIEW_PHI + 0.38
 );
 const CUE_VIEW_PHI_LIFT = 0.08;
-const CUE_VIEW_TARGET_PHI = Math.min(
-  CAMERA.maxPhi,
-  CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5
-);
+const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
 // Mirror the snooker cue framing so both games share the same up-close feel around the cloth.
 const CUE_VIEW_RAIL_CLEARANCE = BALL_R * 0.1;
 // Lift the cue-view camera so the cue stick and cue ball stay framed together while aiming.
-const CUE_VIEW_ABOVE_CUE = BALL_R * 0.72;
-const CUE_VIEW_EXTRA_HEIGHT = BALL_R * 0.24;
+const CUE_VIEW_ABOVE_CUE = BALL_R * 1.08;
+const CUE_VIEW_EXTRA_HEIGHT = BALL_R * 0.42;
 const CUE_VIEW_BACK_MIN_RATIO = 0.26;
 const CUE_VIEW_BACK_RATIO = 0.34;
 const CUE_VIEW_BASE_CUE_LENGTH = (BALL_R / 0.0525) * 1.5 * CUE_LENGTH_MULTIPLIER;
@@ -2352,7 +2349,6 @@ const CAMERA_MIN_HORIZONTAL =
 const CAMERA_DOWNWARD_PULL = 1.9;
 const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.29;
 const CUE_VIEW_AIM_SLOW_FACTOR = 0.35; // slow pointer rotation while blended toward cue view for finer aiming
-const AIM_CAMERA_LOCK_FACTOR = 1; // keep the aim direction locked to the active camera heading
 const POCKET_VIEW_SMOOTH_TIME = 0.24; // seconds to ease pocket camera transitions
 const POCKET_CAMERA_FOV = STANDING_VIEW_FOV;
 const LONG_SHOT_DISTANCE = PLAY_H * 0.5;
@@ -2502,21 +2498,6 @@ const computeCueCameraMinHeight = (worldScaleFactor, cushionHeight = TABLE.THICK
   const railClearanceWorld = CUE_VIEW_RAIL_CLEARANCE * worldScaleFactor;
   const aboveCueWorld = CUE_VIEW_ABOVE_CUE * worldScaleFactor;
   return Math.max(railHeightWorld + railClearanceWorld, cueHeightWorld + aboveCueWorld);
-};
-
-const computeActionCameraMidHeight = (
-  worldScaleFactor,
-  heightBaseLocal = TABLE_Y + TABLE.THICK,
-  cushionHeight = TABLE.THICK
-) => {
-  const scale = Number.isFinite(worldScaleFactor) && worldScaleFactor > 0 ? worldScaleFactor : 1;
-  const tableTopWorld = heightBaseLocal * scale;
-  const highestWorld = Math.max(
-    computeCueCameraMinHeight(scale, cushionHeight),
-    tableTopWorld
-  );
-  const midpointWorld = (tableTopWorld + highestWorld) * 0.5;
-  return midpointWorld / scale;
 };
 
 const computeAimFocusTarget = (cueBall, aimDir) => {
@@ -7225,12 +7206,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                 }
               }
               const heightBase = TABLE_Y + TABLE.THICK;
-              const cushionHeight = cushionHeightRef.current ?? TABLE.THICK;
-              const actionBaseHeight = computeActionCameraMidHeight(
-                worldScaleFactor,
-                heightBase,
-                cushionHeight
-              );
               if (activeShotView.stage === 'pair') {
                 const targetBall =
                   activeShotView.targetId != null
@@ -7280,7 +7255,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   const desiredDistance = baseDistance + longShotPullback;
                   const desired = new THREE.Vector3(
                     0,
-                    actionBaseHeight + ACTION_CAM.heightOffset + heightLift,
+                    heightBase + ACTION_CAM.heightOffset + heightLift,
                     railDir * desiredDistance
                   );
                   const lookAnchor = anchor.clone();
@@ -7315,7 +7290,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   );
                   const desired = new THREE.Vector3(
                     railDir * SIDE_RAIL_CAMERA_DISTANCE,
-                    actionBaseHeight + ACTION_CAM.heightOffset,
+                    heightBase + ACTION_CAM.heightOffset,
                     baseZ
                   );
                   const lookAnchor = anchor.clone();
@@ -7368,7 +7343,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   const desiredDistance = baseDistance + longShotPullback;
                   const desired = new THREE.Vector3(
                     0,
-                    actionBaseHeight + ACTION_CAM.followHeightOffset + heightLift,
+                    heightBase + ACTION_CAM.followHeightOffset + heightLift,
                     railDir * desiredDistance
                   );
                   const lookAnchor = anchor.clone();
@@ -7403,7 +7378,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   );
                   const desired = new THREE.Vector3(
                     railDir * SIDE_RAIL_CAMERA_DISTANCE,
-                    actionBaseHeight + ACTION_CAM.followHeightOffset,
+                    heightBase + ACTION_CAM.followHeightOffset,
                     baseZ
                   );
                   const lookAnchor = anchor.clone();
@@ -7904,7 +7879,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           targetId,
           followView,
           railNormal,
-          { longShot = false, travelDistance = 0, impactPoint = null } = {}
+          { longShot = false, travelDistance = 0 } = {}
         ) => {
           if (!cueBall) return null;
           const ballsList = ballsRef.current || [];
@@ -7912,7 +7887,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             targetId != null
               ? ballsList.find((b) => b.id === targetId) || null
               : null;
-          const cuePos2 = new THREE.Vector2(cueBall.pos.x, cueBall.pos.y);
           const orbitSnapshot = followView?.orbitSnapshot
             ? {
                 radius: followView.orbitSnapshot.radius,
@@ -7930,31 +7904,17 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
               Math.abs(targetBall.pos.y) > nearRailThresholdY
             : false;
           const axis = 'short'; // force short-rail broadcast framing
-          const impactPos = impactPoint
-            ? new THREE.Vector2(impactPoint.x, impactPoint.y)
-            : targetBall
-              ? new THREE.Vector2(targetBall.pos.x, targetBall.pos.y)
-              : cuePos2.clone();
-          const halfLength = PLAY_H / 2;
-          const frontRail = -halfLength;
-          const backRail = halfLength;
-          const distToFront = Math.abs(impactPos.y - frontRail);
-          const distToBack = Math.abs(impactPos.y - backRail);
-          let impactRailDir = distToBack <= distToFront ? 1 : -1;
-          if (Math.abs(distToBack - distToFront) < BALL_R * 0.25) {
-            const fallbackDir =
-              railNormal?.y ??
-              cueBall.launchDir?.y ??
-              (targetBall ? targetBall.pos.y - cueBall.pos.y : cueBall.pos.y);
-            impactRailDir = signed(fallbackDir, impactRailDir);
-          }
-          impactRailDir = signed(impactRailDir, 1);
           const initialRailDir =
             axis === 'side'
               ? signed(
                   railNormal?.x ?? cueBall.pos.x ?? cueBall.launchDir?.x ?? 1
                 )
-              : impactRailDir;
+              : signed(
+                  cueBall.pos.y ??
+                    cueBall.launchDir?.y ??
+                    railNormal?.y ??
+                    1
+                );
           const now = performance.now();
           const activationDelay = longShot
             ? now + LONG_SHOT_ACTIVATION_DELAY_MS
@@ -7992,7 +7952,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             activationTravel,
             pendingActivation: longShot,
             startCuePos: new THREE.Vector2(cueBall.pos.x, cueBall.pos.y),
-            impactPos,
             targetInitialPos: targetBall
               ? new THREE.Vector2(targetBall.pos.x, targetBall.pos.y)
               : null
@@ -9369,44 +9328,18 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           BALL_R * 28,
           Math.min(LONG_SHOT_DISTANCE, PLAY_H * 0.5)
         );
-        const tableHalfWidth = PLAY_W / 2;
-        const tableHalfLength = PLAY_H / 2;
-        const focusMargin = Math.max(BALL_R * 0.5, 0.01);
-        const safeXMin = -tableHalfWidth + focusMargin;
-        const safeXMax = tableHalfWidth - focusMargin;
-        const safeZMin = -tableHalfLength + focusMargin;
-        const safeZMax = tableHalfLength - focusMargin;
-        let maxDistance = focusDistance;
-        const originX = cueBall.pos.x;
-        const originZ = cueBall.pos.y;
-        const applyAxisLimit = (dirComponent, originComponent, minLimit, maxLimit) => {
-          if (Math.abs(dirComponent) < 1e-6) return;
-          const limitValue = dirComponent > 0 ? maxLimit : minLimit;
-          const travel = (limitValue - originComponent) / dirComponent;
-          if (travel > 0) {
-            maxDistance = Math.min(maxDistance, travel);
-          }
-        };
-        applyAxisLimit(dir.x, originX, safeXMin, safeXMax);
-        applyAxisLimit(dir.y, originZ, safeZMin, safeZMax);
-        if (!Number.isFinite(maxDistance) || maxDistance <= 0) {
-          maxDistance = focusDistance;
-        }
-        let limitedDistance = Math.min(focusDistance, maxDistance);
-        if (!Number.isFinite(limitedDistance) || limitedDistance <= 0) {
-          limitedDistance = Math.max(
-            BALL_R * 3,
-            Math.min(focusDistance, LONG_SHOT_DISTANCE)
-          );
-        } else {
-          const minimum = Math.min(BALL_R * 3, focusDistance);
-          limitedDistance = Math.max(limitedDistance, minimum);
-          limitedDistance = Math.min(limitedDistance, maxDistance);
-        }
         const focusTarget = new THREE.Vector3(
-          originX + dir.x * limitedDistance,
+          THREE.MathUtils.clamp(
+            cueBall.pos.x + dir.x * focusDistance,
+            -PLAY_W / 2,
+            PLAY_W / 2
+          ),
           BALL_CENTER_Y,
-          originZ + dir.y * limitedDistance
+          THREE.MathUtils.clamp(
+            cueBall.pos.y + dir.y * focusDistance,
+            -PLAY_H / 2,
+            PLAY_H / 2
+          )
         );
         focusStore.ballId = cueBall.id ?? null;
         focusStore.target.copy(focusTarget);
@@ -9537,8 +9470,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                 shotPrediction.railNormal,
                 {
                   longShot: isLongShot,
-                  travelDistance: predictedTravel,
-                  impactPoint: shotPrediction.impact
+                  travelDistance: predictedTravel
                 }
               )
             : null;
@@ -10229,7 +10161,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         tmpAim.set(camFwd.x, camFwd.z).normalize();
         const aimLerpFactor = chalkAssistTargetRef.current
           ? CHALK_AIM_LERP_SLOW
-          : AIM_CAMERA_LOCK_FACTOR;
+          : 0.2;
         aimDir.lerp(tmpAim, aimLerpFactor);
         const appliedSpin = applySpinConstraints(aimDir, true);
         const ranges = spinRangeRef.current || {};


### PR DESCRIPTION
## Summary
- restore the cue camera height, rail clamping, and short-rail handling logic from the 5:00 AM baseline
- revert the demo aiming smoothing and orbit camera tests to match the earlier configuration
- reset the Pool Royale action camera flow to the pre-5:00 AM heuristics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eaa9b1a4e4832980c9f76137dd9d42