### PR TITLE
Restore site to Oct 10 9pm baseline

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -26,13 +26,13 @@ public class CueCamera : MonoBehaviour
     // Distance from the cue ball used for the lowest aiming view.  This keeps the
     // camera hovering over the mid–upper portion of the cue rather than slipping
     // all the way back to the plastic end.
-    public float cueLoweredDistanceFromBall = 0.06f;
+    public float cueLoweredDistanceFromBall = 0.12f;
     // Additional pull-in applied to the cue camera so the portrait framing hugs
     // the cloth like a player leaning over the shot.
-    public float cueDistancePullIn = 0.32f;
+    public float cueDistancePullIn = 0.18f;
     // Minimum separation we allow once the pull-in is applied. Prevents the
     // camera from intersecting the cue or cloth when the player drops in tight.
-    public float cueMinimumDistance = 0.02f;
+    public float cueMinimumDistance = 0.05f;
     // Height the cue view should reach when the player lifts the camera.
     public float cueRaisedHeight = 0.82f;
     // Minimum height maintained when the player drops the camera toward the cue.
@@ -64,36 +64,6 @@ public class CueCamera : MonoBehaviour
     // high above the cue, 1 drops it to the closest permitted view.
     [Range(0f, 1f)]
     public float defaultCueAimLowering = 0.35f;
-
-    [Header("Cue aim framing")]
-    // Scale applied to the cue distance when the camera is raised. Values below
-    // 1 slide the camera closer to the cloth even before the player lowers it.
-    [Range(0.1f, 1f)]
-    public float cueRaisedDistanceScale = 0.9f;
-    // Scale applied once the camera is fully lowered toward the cue. Lower
-    // values bring the framing tighter to the cue ball and aiming line.
-    [Range(0.1f, 1f)]
-    public float cueLoweredDistanceScale = 0.55f;
-    // Bias used when lowering the camera to keep it hovering just above the cue
-    // instead of drifting upward toward the player's face.
-    [Range(0.1f, 1f)]
-    public float cueHeightClothScale = 0.65f;
-    // Weight controlling how much of the look target should favour the aiming
-    // line (0) versus the cue butt (1). Lower values keep the focus locked on
-    // the target ball.
-    [Range(0f, 1f)]
-    public float cueAimLineFocusWeight = 0.4f;
-    // Base overshoot distance applied past the aim end so the guiding line stays
-    // visible and centred when framing the shot.
-    public float cueAimTargetOvershoot = 0.18f;
-    // Look distance fraction used when the camera is fully raised. Keeps the
-    // look target anchored closer to the object ball instead of the cue butt.
-    [Range(0f, 1f)]
-    public float cueAimLookFraction = 0.85f;
-    // Height bias for the look target when the camera is raised. Larger values
-    // lift the view toward the rails, smaller values hug the cloth.
-    [Range(0f, 1f)]
-    public float cueAimHeightFocus = 0.55f;
 
     [Header("Table & rails")]
     // Height of the wooden rails so we can clamp the camera above them.
@@ -313,36 +283,11 @@ public class CueCamera : MonoBehaviour
         float minPulledDistance = Mathf.Max(minimumDistanceLimit, minDistance - pullIn);
         float distance = Mathf.Max(baseDistance - pullIn, minPulledDistance);
 
-        float raisedScale = Mathf.Clamp(cueRaisedDistanceScale, 0.1f, 1f);
-        float loweredScale = Mathf.Clamp(cueLoweredDistanceScale, 0.1f, raisedScale);
-        float distanceScale = Mathf.Lerp(raisedScale, loweredScale, blend);
-        distance = Mathf.Max(distance * distanceScale, minimumDistanceLimit);
-
-        if (CueBall != null)
+        if (!Mathf.Approximately(distance, baseDistance) && CueBall != null)
         {
-            if (CueButtReference != null)
-            {
-                Vector3 buttToBall = CueBall.position - CueButtReference.position;
-                float projectedLength = Mathf.Abs(Vector3.Dot(buttToBall, cueAimForward));
-                if (projectedLength > 0.0001f)
-                {
-                    float along = Mathf.Clamp01(distance / projectedLength);
-                    Vector3 desiredCuePoint = Vector3.Lerp(CueBall.position, CueButtReference.position, along);
-                    cueSamplePoint = desiredCuePoint;
-                }
-                else
-                {
-                    Vector3 adjustedCuePoint = CueBall.position - cueAimForward * Mathf.Max(distance, 0f);
-                    adjustedCuePoint.y = CueBall.position.y;
-                    cueSamplePoint = adjustedCuePoint;
-                }
-            }
-            else
-            {
-                Vector3 adjustedCuePoint = CueBall.position - cueAimForward * Mathf.Max(distance, 0f);
-                adjustedCuePoint.y = CueBall.position.y;
-                cueSamplePoint = adjustedCuePoint;
-            }
+            Vector3 adjustedCuePoint = CueBall.position - cueAimForward * Mathf.Max(distance, 0f);
+            adjustedCuePoint.y = CueBall.position.y;
+            cueSamplePoint = adjustedCuePoint;
         }
 
         float minimumCueHeight = CueBall.position.y + cueBallRadius + Mathf.Max(0f, cueHeightClearance);
@@ -351,9 +296,6 @@ public class CueCamera : MonoBehaviour
         float raisedHeight = Mathf.Max(minimumCueHeight, cueRaisedHeight);
         float loweredHeight = Mathf.Max(minimumCueHeight, cueLoweredHeight);
         float height = Mathf.Lerp(raisedHeight, loweredHeight, blend);
-        float clothAnchorHeight = minimumCueHeight;
-        float heightScale = Mathf.Lerp(1f, Mathf.Clamp(cueHeightClothScale, 0.1f, 1f), blend);
-        height = clothAnchorHeight + (height - clothAnchorHeight) * heightScale;
         float minRailHeight = railHeight + Mathf.Max(0f, railClearance);
         height = Mathf.Max(height, minRailHeight);
 
@@ -843,24 +785,21 @@ public class CueCamera : MonoBehaviour
 
         Vector3 aimDirection = aimVector / aimDistance;
 
-        float overshootBase = Mathf.Max(0f, cueAimTargetOvershoot);
-        float overshoot = Mathf.Lerp(overshootBase, overshootBase * 0.5f, Mathf.Clamp01(lowering));
+        float overshootBlend = 1f - lowering;
+        float overshoot = Mathf.Lerp(0.05f, 0.25f, lowering) * overshootBlend;
         Vector3 extendedAim = aimEnd + aimDirection * overshoot;
         extendedAim = tableBounds.ClosestPoint(extendedAim);
 
-        float baseLookFraction = Mathf.Clamp01(cueAimLookFraction);
-        float lookFraction = Mathf.Lerp(baseLookFraction, 1f, Mathf.Clamp01(lowering));
+        float lookFraction = Mathf.Lerp(0.55f, 1f, lowering);
         float lookDistance = Mathf.Clamp(aimDistance * lookFraction, 0f, aimDistance);
         Vector3 aimLockedLook = focus + aimDirection * lookDistance;
 
-        float aimLineWeight = Mathf.Clamp01(cueAimLineFocusWeight);
-        Vector3 lookPoint = Vector3.Lerp(extendedAim, aimLockedLook, aimLineWeight);
+        Vector3 lookPoint = Vector3.Lerp(extendedAim, aimLockedLook, lowering);
 
         float railTop = railHeight + Mathf.Max(0f, railClearance);
         float minimumLookHeight = focus.y + cueBallLookOffset;
         float railLookHeight = Mathf.Max(railTop, aimEnd.y) + cueBallLookOffset;
-        float heightBias = Mathf.Clamp01(cueAimHeightFocus);
-        float heightBlend = Mathf.Lerp(heightBias, 0.85f, Mathf.Clamp01(lowering));
+        float heightBlend = Mathf.Lerp(0.35f, 0.85f, lowering);
         float desiredHeight = Mathf.Lerp(minimumLookHeight, railLookHeight, heightBlend);
         lookPoint.y = Mathf.Max(desiredHeight, minimumLookHeight);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2319,8 +2319,8 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.02;
-const CUE_VIEW_RADIUS_RATIO = 0.095;
-const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.45;
+const CUE_VIEW_RADIUS_RATIO = 0.12;
+const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.5;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
   STANDING_VIEW_PHI + 0.22
@@ -2329,11 +2329,10 @@ const CUE_VIEW_PHI_LIFT = 0.08;
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
 // Mirror the snooker cue framing so both games share the same up-close feel around the cloth.
 const CUE_VIEW_RAIL_CLEARANCE = BALL_R * 0.1;
-// Lift the cue-view camera so the cue stick and cue ball stay framed together while aiming.
-const CUE_VIEW_ABOVE_CUE = BALL_R * 1.08;
-const CUE_VIEW_EXTRA_HEIGHT = BALL_R * 0.42;
-const CUE_VIEW_BACK_MIN_RATIO = 0.26;
-const CUE_VIEW_BACK_RATIO = 0.34;
+const CUE_VIEW_ABOVE_CUE = BALL_R * 0.54;
+const CUE_VIEW_EXTRA_HEIGHT = BALL_R * 0.14;
+const CUE_VIEW_BACK_MIN_RATIO = 0.28;
+const CUE_VIEW_BACK_RATIO = 0.42;
 const CUE_VIEW_BASE_CUE_LENGTH = (BALL_R / 0.0525) * 1.5 * CUE_LENGTH_MULTIPLIER;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,
@@ -2494,30 +2493,6 @@ const computeCueCameraMinHeight = (worldScaleFactor, cushionHeight = TABLE.THICK
   const railClearanceWorld = CUE_VIEW_RAIL_CLEARANCE * worldScaleFactor;
   const aboveCueWorld = CUE_VIEW_ABOVE_CUE * worldScaleFactor;
   return Math.max(railHeightWorld + railClearanceWorld, cueHeightWorld + aboveCueWorld);
-};
-
-const computeAimFocusTarget = (cueBall, aimDir) => {
-  if (!cueBall?.pos || !aimDir) return null;
-  const dir = new THREE.Vector2(aimDir.x ?? 0, aimDir.y ?? 0);
-  if (dir.lengthSq() < 1e-6) return null;
-  dir.normalize();
-  const focusDistance = Math.max(
-    BALL_R * 32,
-    Math.min(LONG_SHOT_DISTANCE, PLAY_H * 0.48)
-  );
-  return new THREE.Vector3(
-    THREE.MathUtils.clamp(
-      cueBall.pos.x + dir.x * focusDistance,
-      -PLAY_W / 2,
-      PLAY_W / 2
-    ),
-    BALL_CENTER_Y,
-    THREE.MathUtils.clamp(
-      cueBall.pos.y + dir.y * focusDistance,
-      -PLAY_H / 2,
-      PLAY_H / 2
-    )
-  );
 };
 
 const computeCueAimCameraOffset = ({
@@ -7612,16 +7587,8 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             ) {
               focusTarget = aimFocus.clone();
             } else if (cue?.active && !shooting) {
-              const aimFocus = computeAimFocusTarget(cue, aimDirRef.current);
-              if (aimFocus) {
-                aimFocusRef.current = aimFocus.clone();
-                focusTarget = aimFocus;
-              } else {
-                aimFocusRef.current = null;
-                focusTarget = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
-              }
+              focusTarget = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
             } else {
-              aimFocusRef.current = null;
               const store = ensureOrbitFocus();
               if (store.ballId) {
                 const ballsList =

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2337,7 +2337,7 @@ const CAMERA_ABS_MIN_PHI = 0.3;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.18);
 const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.24; // keep orbit camera from dipping below the table surface
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.085;
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.135;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant
 const BROADCAST_DISTANCE_MULTIPLIER = 0.36;
@@ -2355,7 +2355,7 @@ const CAMERA = {
   // keep the camera slightly above the horizontal plane but allow a lower sweep
   maxPhi: CAMERA_MAX_PHI
 };
-const CAMERA_CUSHION_CLEARANCE = TABLE.THICK * 0.6; // keep orbit height safely above cushion lip while hugging the rail
+const CAMERA_CUSHION_CLEARANCE = TABLE.THICK * 0.92; // keep orbit height safely above cushion lip
 const STANDING_VIEW = Object.freeze({
   phi: STANDING_VIEW_PHI,
   margin: STANDING_VIEW_MARGIN
@@ -2373,9 +2373,9 @@ const BREAK_VIEW = Object.freeze({
   radius: CAMERA.minR, // start the intro framing closer to the table surface
   phi: CAMERA.maxPhi - 0.01
 });
-const CAMERA_RAIL_SAFETY = 0.006;
-const CUE_VIEW_RADIUS_RATIO = 0.085;
-const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.35;
+const CAMERA_RAIL_SAFETY = 0.02;
+const CUE_VIEW_RADIUS_RATIO = 0.12;
+const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.5;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
   STANDING_VIEW_PHI + 0.22


### PR DESCRIPTION
## Summary
- revert the cue camera configuration to the Oct 10 9pm snapshot
- align the Pool Royale cue view constants with the restored baseline
- bring Snooker cue framing constants back in sync with the snapshot

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb34d1cd1c832999c8f21cefcba7b5