### PR TITLE
Fix color space handling for 3D Snooker and Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -37,6 +37,20 @@ import {
 } from '../../utils/woodMaterials.js';
 import { MobilePortraitCameraRig, rad } from './simpleOrbitCamera';
 
+const LEGACY_SRGB_ENCODING = Reflect.get(THREE, 'sRGBEncoding');
+const LEGACY_LINEAR_ENCODING = Reflect.get(THREE, 'LinearEncoding');
+const applyTextureSRGB = (texture) => {
+  if (!texture) return;
+  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture) {
+    const fallbackEncoding = LEGACY_SRGB_ENCODING ?? LEGACY_LINEAR_ENCODING;
+    if (fallbackEncoding !== undefined) {
+      texture.encoding = fallbackEncoding;
+    }
+  }
+};
+
 function signedRingArea(ring) {
   let area = 0;
   for (let i = 0; i < ring.length - 1; i++) {
@@ -1330,8 +1344,7 @@ const createClothTextures = (() => {
     colorMap.generateMipmaps = true;
     colorMap.minFilter = THREE.LinearMipmapLinearFilter;
     colorMap.magFilter = THREE.LinearFilter;
-    if ('colorSpace' in colorMap) colorMap.colorSpace = THREE.SRGBColorSpace;
-    else colorMap.encoding = THREE.sRGBEncoding;
+    applyTextureSRGB(colorMap);
     colorMap.needsUpdate = true;
 
     const bumpCanvas = document.createElement('canvas');
@@ -1754,8 +1767,7 @@ const createCarpetTextures = (() => {
     texture.minFilter = THREE.LinearMipMapLinearFilter;
     texture.magFilter = THREE.LinearFilter;
     texture.generateMipmaps = true;
-    if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-    else texture.encoding = THREE.sRGBEncoding;
+    applyTextureSRGB(texture);
 
     // bump map: derive from red base with extra fiber noise
     const bumpCanvas = document.createElement('canvas');
@@ -2996,8 +3008,7 @@ function makeClothTexture(
   const repeatY = baseRepeat * (PLAY_H / TABLE.H);
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 48;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applyTextureSRGB(texture);
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
@@ -3088,8 +3099,7 @@ function makeWoodTexture({
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 8;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applyTextureSRGB(texture);
   texture.needsUpdate = true;
   return texture;
 }
@@ -5968,8 +5978,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 4;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        applyTextureSRGB(texture);
         let offset = 0;
         return {
           texture,
@@ -6007,8 +6016,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 8;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        applyTextureSRGB(texture);
         let pulse = 0;
         const createAvatarStore = () => ({
           image: null,

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -32,6 +32,20 @@ import {
   applyWoodTextures
 } from '../../utils/woodMaterials.js';
 
+const LEGACY_SRGB_ENCODING = Reflect.get(THREE, 'sRGBEncoding');
+const LEGACY_LINEAR_ENCODING = Reflect.get(THREE, 'LinearEncoding');
+const applyTextureSRGB = (texture) => {
+  if (!texture) return;
+  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture) {
+    const fallbackEncoding = LEGACY_SRGB_ENCODING ?? LEGACY_LINEAR_ENCODING;
+    if (fallbackEncoding !== undefined) {
+      texture.encoding = fallbackEncoding;
+    }
+  }
+};
+
 function signedRingArea(ring) {
   let area = 0;
   for (let i = 0; i < ring.length - 1; i++) {
@@ -1350,8 +1364,7 @@ const createClothTextures = (() => {
     colorMap.generateMipmaps = true;
     colorMap.minFilter = THREE.LinearMipmapLinearFilter;
     colorMap.magFilter = THREE.LinearFilter;
-    if ('colorSpace' in colorMap) colorMap.colorSpace = THREE.SRGBColorSpace;
-    else colorMap.encoding = THREE.sRGBEncoding;
+    applyTextureSRGB(colorMap);
     colorMap.needsUpdate = true;
 
     const bumpCanvas = document.createElement('canvas');
@@ -1789,8 +1802,7 @@ const createCarpetTextures = (() => {
     texture.minFilter = THREE.LinearMipMapLinearFilter;
     texture.magFilter = THREE.LinearFilter;
     texture.generateMipmaps = true;
-    if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-    else texture.encoding = THREE.sRGBEncoding;
+    applyTextureSRGB(texture);
 
     // bump map: derive from red base with extra fiber noise
     const bumpCanvas = document.createElement('canvas');
@@ -2908,8 +2920,7 @@ function makeClothTexture(
   const repeatY = baseRepeat * (PLAY_H / TABLE.H);
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 48;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applyTextureSRGB(texture);
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
@@ -3000,8 +3011,7 @@ function makeWoodTexture({
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 8;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applyTextureSRGB(texture);
   texture.needsUpdate = true;
   return texture;
 }
@@ -5819,8 +5829,7 @@ function SnookerGame() {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 4;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        applyTextureSRGB(texture);
         let offset = 0;
         return {
           texture,
@@ -5858,8 +5867,7 @@ function SnookerGame() {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 8;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        applyTextureSRGB(texture);
         let pulse = 0;
         const createAvatarStore = () => ({
           image: null,

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -1,5 +1,8 @@
 import * as THREE from 'three';
 
+const LEGACY_SRGB_ENCODING = Reflect.get(THREE, 'sRGBEncoding');
+const LEGACY_LINEAR_ENCODING = Reflect.get(THREE, 'LinearEncoding');
+
 const BALL_TEXTURE_SIZE = 1024;
 const BALL_TEXTURE_CACHE = new Map();
 const BALL_MATERIAL_CACHE = new Map();
@@ -247,8 +250,14 @@ function createBallTexture({ baseColor, pattern, number, variantKey }) {
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture) {
+    const fallbackEncoding = LEGACY_SRGB_ENCODING ?? LEGACY_LINEAR_ENCODING;
+    if (fallbackEncoding !== undefined) {
+      texture.encoding = fallbackEncoding;
+    }
+  }
   texture.needsUpdate = true;
 
   BALL_TEXTURE_CACHE.set(key, texture);


### PR DESCRIPTION
## Summary
- add reusable helpers to apply sRGB color space when available and fall back gracefully for legacy Three.js builds in the 3D Snooker and Pool Royale pages
- align billiard ball texture creation with the new Three.js colorSpace API so textures render again without runtime import errors

## Testing
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_68eb4615ba5c83299c9ca8a97ea4fbd8