### PR TITLE
Restore billiards games to morning baseline

### DIFF
--- a/lib/americanBilliards.d.ts
+++ b/lib/americanBilliards.d.ts
@@ -1,0 +1,5 @@
+export class AmericanBilliards {
+  state: any;
+  constructor();
+  shotTaken(shot: any): any;
+}

--- a/lib/nineBall.d.ts
+++ b/lib/nineBall.d.ts
@@ -1,0 +1,5 @@
+export class NineBall {
+  state: any;
+  constructor();
+  shotTaken(shot: any): any;
+}

--- a/lib/poolUk8Ball.d.ts
+++ b/lib/poolUk8Ball.d.ts
@@ -1,0 +1,6 @@
+export class UkPool {
+  constructor(rules?: any);
+  state: any;
+  shotTaken(shot: any): any;
+  startBreak(): void;
+}

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -38,18 +38,6 @@ import {
 import { MobilePortraitCameraRig, rad } from './simpleOrbitCamera';
 
 const LEGACY_SRGB_ENCODING = Reflect.get(THREE, 'sRGBEncoding');
-const LEGACY_LINEAR_ENCODING = Reflect.get(THREE, 'LinearEncoding');
-const applyTextureSRGB = (texture) => {
-  if (!texture) return;
-  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
-    texture.colorSpace = THREE.SRGBColorSpace;
-  } else if ('encoding' in texture) {
-    const fallbackEncoding = LEGACY_SRGB_ENCODING ?? LEGACY_LINEAR_ENCODING;
-    if (fallbackEncoding !== undefined) {
-      texture.encoding = fallbackEncoding;
-    }
-  }
-};
 
 function signedRingArea(ring) {
   let area = 0;
@@ -1344,7 +1332,11 @@ const createClothTextures = (() => {
     colorMap.generateMipmaps = true;
     colorMap.minFilter = THREE.LinearMipmapLinearFilter;
     colorMap.magFilter = THREE.LinearFilter;
-    applyTextureSRGB(colorMap);
+    if ('colorSpace' in colorMap && THREE.SRGBColorSpace) {
+      colorMap.colorSpace = THREE.SRGBColorSpace;
+    } else if ('encoding' in colorMap && LEGACY_SRGB_ENCODING !== undefined) {
+      colorMap.encoding = LEGACY_SRGB_ENCODING;
+    }
     colorMap.needsUpdate = true;
 
     const bumpCanvas = document.createElement('canvas');
@@ -1767,7 +1759,11 @@ const createCarpetTextures = (() => {
     texture.minFilter = THREE.LinearMipMapLinearFilter;
     texture.magFilter = THREE.LinearFilter;
     texture.generateMipmaps = true;
-    applyTextureSRGB(texture);
+    if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+      texture.colorSpace = THREE.SRGBColorSpace;
+    } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+      texture.encoding = LEGACY_SRGB_ENCODING;
+    }
 
     // bump map: derive from red base with extra fiber noise
     const bumpCanvas = document.createElement('canvas');
@@ -3008,7 +3004,11 @@ function makeClothTexture(
   const repeatY = baseRepeat * (PLAY_H / TABLE.H);
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 48;
-  applyTextureSRGB(texture);
+  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+    texture.encoding = LEGACY_SRGB_ENCODING;
+  }
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
@@ -3099,7 +3099,11 @@ function makeWoodTexture({
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 8;
-  applyTextureSRGB(texture);
+  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+    texture.encoding = LEGACY_SRGB_ENCODING;
+  }
   texture.needsUpdate = true;
   return texture;
 }
@@ -5978,7 +5982,11 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 4;
-        applyTextureSRGB(texture);
+        if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+          texture.colorSpace = THREE.SRGBColorSpace;
+        } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+          texture.encoding = LEGACY_SRGB_ENCODING;
+        }
         let offset = 0;
         return {
           texture,
@@ -6016,7 +6024,11 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 8;
-        applyTextureSRGB(texture);
+        if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+          texture.colorSpace = THREE.SRGBColorSpace;
+        } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+          texture.encoding = LEGACY_SRGB_ENCODING;
+        }
         let pulse = 0;
         const createAvatarStore = () => ({
           image: null,

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -33,18 +33,6 @@ import {
 } from '../../utils/woodMaterials.js';
 
 const LEGACY_SRGB_ENCODING = Reflect.get(THREE, 'sRGBEncoding');
-const LEGACY_LINEAR_ENCODING = Reflect.get(THREE, 'LinearEncoding');
-const applyTextureSRGB = (texture) => {
-  if (!texture) return;
-  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
-    texture.colorSpace = THREE.SRGBColorSpace;
-  } else if ('encoding' in texture) {
-    const fallbackEncoding = LEGACY_SRGB_ENCODING ?? LEGACY_LINEAR_ENCODING;
-    if (fallbackEncoding !== undefined) {
-      texture.encoding = fallbackEncoding;
-    }
-  }
-};
 
 function signedRingArea(ring) {
   let area = 0;
@@ -1364,7 +1352,11 @@ const createClothTextures = (() => {
     colorMap.generateMipmaps = true;
     colorMap.minFilter = THREE.LinearMipmapLinearFilter;
     colorMap.magFilter = THREE.LinearFilter;
-    applyTextureSRGB(colorMap);
+    if ('colorSpace' in colorMap && THREE.SRGBColorSpace) {
+      colorMap.colorSpace = THREE.SRGBColorSpace;
+    } else if ('encoding' in colorMap && LEGACY_SRGB_ENCODING !== undefined) {
+      colorMap.encoding = LEGACY_SRGB_ENCODING;
+    }
     colorMap.needsUpdate = true;
 
     const bumpCanvas = document.createElement('canvas');
@@ -1802,7 +1794,11 @@ const createCarpetTextures = (() => {
     texture.minFilter = THREE.LinearMipMapLinearFilter;
     texture.magFilter = THREE.LinearFilter;
     texture.generateMipmaps = true;
-    applyTextureSRGB(texture);
+    if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+      texture.colorSpace = THREE.SRGBColorSpace;
+    } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+      texture.encoding = LEGACY_SRGB_ENCODING;
+    }
 
     // bump map: derive from red base with extra fiber noise
     const bumpCanvas = document.createElement('canvas');
@@ -2920,7 +2916,11 @@ function makeClothTexture(
   const repeatY = baseRepeat * (PLAY_H / TABLE.H);
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 48;
-  applyTextureSRGB(texture);
+  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+    texture.encoding = LEGACY_SRGB_ENCODING;
+  }
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
@@ -3011,7 +3011,11 @@ function makeWoodTexture({
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 8;
-  applyTextureSRGB(texture);
+  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+    texture.encoding = LEGACY_SRGB_ENCODING;
+  }
   texture.needsUpdate = true;
   return texture;
 }
@@ -5829,7 +5833,11 @@ function SnookerGame() {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 4;
-        applyTextureSRGB(texture);
+        if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+          texture.colorSpace = THREE.SRGBColorSpace;
+        } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+          texture.encoding = LEGACY_SRGB_ENCODING;
+        }
         let offset = 0;
         return {
           texture,
@@ -5867,7 +5875,11 @@ function SnookerGame() {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 8;
-        applyTextureSRGB(texture);
+        if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+          texture.colorSpace = THREE.SRGBColorSpace;
+        } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+          texture.encoding = LEGACY_SRGB_ENCODING;
+        }
         let pulse = 0;
         const createAvatarStore = () => ({
           image: null,

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 
 const LEGACY_SRGB_ENCODING = Reflect.get(THREE, 'sRGBEncoding');
-const LEGACY_LINEAR_ENCODING = Reflect.get(THREE, 'LinearEncoding');
 
 const BALL_TEXTURE_SIZE = 1024;
 const BALL_TEXTURE_CACHE = new Map();
@@ -252,11 +251,8 @@ function createBallTexture({ baseColor, pattern, number, variantKey }) {
   texture.generateMipmaps = true;
   if ('colorSpace' in texture && THREE.SRGBColorSpace) {
     texture.colorSpace = THREE.SRGBColorSpace;
-  } else if ('encoding' in texture) {
-    const fallbackEncoding = LEGACY_SRGB_ENCODING ?? LEGACY_LINEAR_ENCODING;
-    if (fallbackEncoding !== undefined) {
-      texture.encoding = fallbackEncoding;
-    }
+  } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+    texture.encoding = LEGACY_SRGB_ENCODING;
   }
   texture.needsUpdate = true;
 


### PR DESCRIPTION
## Summary
- restore the Pool Royale and Snooker React pages to the morning baseline so they are playable on every device, while keeping the runtime-compatible sRGB configuration
- add lightweight TypeScript declaration stubs for the classic billiards rule engines so the project compiles cleanly

## Testing
- npm run build
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_68eb4ef2d9008329a87a29e0d10f6913