### PR TITLE
Adjust cue camera focus toward cue stick

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -359,12 +359,21 @@ public class CueCamera : MonoBehaviour
         cueRailClamp = Mathf.Max(cueRailClamp, railHeight);
         height = Mathf.Max(height, cueRailClamp);
 
-        Vector3 focus = CueBall.position;
-        float minimumHeightBuffer = Mathf.Lerp(minimumHeightAboveFocus, 0f, blend);
-        float minimumHeightOffset = Mathf.Max(minimumHeightBuffer, height - focus.y);
-        Vector3 lookTarget = GetCueAimLookTarget(focus, cueAimForward);
+        Vector3 cueFocus = CueBall.position;
+        if (cueSamplePoint.sqrMagnitude > 0.0001f)
+        {
+            // Blend the camera's focal point toward the sampled cue position so the
+            // portrait cue view slides above the stick similar to the snooker setup
+            // while keeping the existing distance and height limits intact.
+            float focusBlend = Mathf.Lerp(0.32f, 0.68f, blend);
+            cueFocus = Vector3.Lerp(CueBall.position, cueSamplePoint, Mathf.Clamp01(focusBlend));
+        }
 
-        ApplyCameraAt(focus, cueAimForward, distance, height, minimumHeightOffset, lookTarget, cueRailClamp);
+        float minimumHeightBuffer = Mathf.Lerp(minimumHeightAboveFocus, 0f, blend);
+        float minimumHeightOffset = Mathf.Max(minimumHeightBuffer, height - cueFocus.y);
+        Vector3 lookTarget = GetCueAimLookTarget(CueBall.position, cueAimForward);
+
+        ApplyCameraAt(cueFocus, cueAimForward, distance, height, minimumHeightOffset, lookTarget, cueRailClamp);
 
         Vector3 flatForward = new Vector3(cueAimForward.x, 0f, cueAimForward.z);
         if (flatForward.sqrMagnitude > 0.0001f)


### PR DESCRIPTION
## Summary
- blend the cue camera focus toward the sampled cue stick position so the portrait view sits above the stick similar to snooker
- keep the existing cue view distance/height limits while targeting the cue ball for look direction

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eb6496e88883299516eb46c1d5bd6c