### PR TITLE
Refine cue camera framing for snooker and pool

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2344,7 +2344,7 @@ const CAMERA_ABS_MIN_PHI = 0.3;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.26);
 const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.32; // clamp cue sweep so the lens never drops beneath the rail tops
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.17;
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.15;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant
 const BROADCAST_DISTANCE_MULTIPLIER = 0.48;
@@ -2380,14 +2380,14 @@ const BREAK_VIEW = Object.freeze({
   radius: CAMERA.minR, // start the intro framing closer to the table surface
   phi: CAMERA.maxPhi - 0.01
 });
-const CAMERA_RAIL_SAFETY = 0.02;
-const CUE_VIEW_RADIUS_RATIO = 0.16;
-const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.52;
+const CAMERA_RAIL_SAFETY = 0.0075;
+const CUE_VIEW_RADIUS_RATIO = 0.13;
+const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.45;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
-  STANDING_VIEW_PHI + 0.22
+  STANDING_VIEW_PHI + 0.2
 );
-const CUE_VIEW_PHI_LIFT = 0.08;
+const CUE_VIEW_PHI_LIFT = 0.06;
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,
@@ -2396,8 +2396,8 @@ const CAMERA_RAIL_APPROACH_PHI = Math.min(
 const CAMERA_MIN_HORIZONTAL =
   ((Math.max(PLAY_W, PLAY_H) / 2 + SIDE_RAIL_INNER_THICKNESS) * WORLD_SCALE) +
   CAMERA_RAIL_SAFETY;
-const CAMERA_DOWNWARD_PULL = 1.9;
-const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.29;
+const CAMERA_DOWNWARD_PULL = 2.3;
+const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.34;
 const CUE_VIEW_AIM_SLOW_FACTOR = 0.35; // slow pointer rotation while blended toward cue view for finer aiming
 const POCKET_VIEW_SMOOTH_TIME = 0.24; // seconds to ease pocket camera transitions
 const POCKET_CAMERA_FOV = STANDING_VIEW_FOV;
@@ -6819,6 +6819,15 @@ function SnookerGame() {
           }
           sph.phi = clampedPhi;
           sph.radius = clampOrbitRadius(finalRadius, cueMinRadius);
+          if (cue?.active && !shooting) {
+            const aimFocus =
+              blend < 0.999
+                ? computeAimFocusTarget(cue, aimDirRef.current)
+                : null;
+            aimFocusRef.current = aimFocus ? aimFocus.clone() : null;
+          } else {
+            aimFocusRef.current = null;
+          }
           syncBlendToSpherical();
         };
 
@@ -8960,6 +8969,30 @@ function SnookerGame() {
       let potted = [];
       let firstHit = null;
 
+      const computeAimFocusTarget = (cueBall, aimDir) => {
+        if (!cueBall || !aimDir) return null;
+        const dir = aimDir.clone();
+        if (dir.lengthSq() < 1e-6) return null;
+        dir.normalize();
+        const focusDistance = Math.max(
+          BALL_R * 32,
+          Math.min(LONG_SHOT_DISTANCE, PLAY_H * 0.55)
+        );
+        return new THREE.Vector3(
+          THREE.MathUtils.clamp(
+            cueBall.pos.x + dir.x * focusDistance,
+            -PLAY_W / 2,
+            PLAY_W / 2
+          ),
+          BALL_CENTER_Y,
+          THREE.MathUtils.clamp(
+            cueBall.pos.y + dir.y * focusDistance,
+            -PLAY_H / 2,
+            PLAY_H / 2
+          )
+        );
+      };
+
       const alignStandingCameraToAim = (cueBall, aimDir) => {
         if (!cueBall || !aimDir) return;
         const dir = aimDir.clone();
@@ -8980,23 +9013,9 @@ function SnookerGame() {
         sph.theta = aimTheta;
         syncBlendToSpherical();
         const focusStore = ensureOrbitFocus();
-        const focusDistance = Math.max(
-          BALL_R * 28,
-          Math.min(LONG_SHOT_DISTANCE, PLAY_H * 0.5)
-        );
-        const focusTarget = new THREE.Vector3(
-          THREE.MathUtils.clamp(
-            cueBall.pos.x + dir.x * focusDistance,
-            -PLAY_W / 2,
-            PLAY_W / 2
-          ),
-          BALL_CENTER_Y,
-          THREE.MathUtils.clamp(
-            cueBall.pos.y + dir.y * focusDistance,
-            -PLAY_H / 2,
-            PLAY_H / 2
-          )
-        );
+        const focusTarget = computeAimFocusTarget(cueBall, dir);
+        if (!focusTarget) return;
+        aimFocusRef.current = focusTarget.clone();
         focusStore.ballId = cueBall.id ?? null;
         focusStore.target.copy(focusTarget);
         lastCameraTargetRef.current.copy(


### PR DESCRIPTION
## Summary
- bring the cue-view orbit closer to the cue ball and rails in both snooker and Pool Royale
- ensure the lowered cue camera tracks the aim line instead of the cloth by sharing an aim-focus helper
- update cue-alignment routines to reuse the helper so camera focus stays locked on the target line

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eb9474ff4c8329b64ad9bf7728d4f7