### PR TITLE
Adjust cue camera framing for cue sports

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2328,8 +2328,8 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.0075;
-const CUE_VIEW_RADIUS_RATIO = 0.26; // double the cue distance so the zoom is 50% wider
-const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.675; // maintain the wider framing even when clamped to the minimum distance
+const CUE_VIEW_RADIUS_RATIO = 0.34; // pull the cue view back so the camera stops short of the cue ball
+const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.82; // keep additional distance to reveal more of the cue stick
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
   STANDING_VIEW_PHI + 0.4

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2381,8 +2381,8 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.0075;
-const CUE_VIEW_RADIUS_RATIO = 0.26; // double the cue distance so the zoom is 50% wider
-const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.675; // maintain the wider framing even when clamped to the minimum distance
+const CUE_VIEW_RADIUS_RATIO = 0.34; // pull the cue view back so the camera stops short of the cue ball
+const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.82; // keep additional distance to reveal more of the cue stick
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
   STANDING_VIEW_PHI + 0.4


### PR DESCRIPTION
## Summary
- pull the cue camera radius back in Pool Royale so it stops short of the cue ball and exposes more of the cue stick at low angles
- mirror the updated cue camera distance tuning in the Snooker implementation for consistent behaviour across both games

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebaf81c0908329bc675bf967819fbe