### PR TITLE
Restore store to 12:31 state

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -52,6 +52,11 @@ public class CueCamera : MonoBehaviour
     // lingering near the butt.
     [Range(0.05f, 1f)]
     public float cueLoweredBackFraction = 0.5f;
+    // Fraction of the cue that must remain visible between the camera and the
+    // cue ball. Ensures the aiming view stops with a comfortable gap instead of
+    // zooming directly into the ball.
+    [Range(0f, 1f)]
+    public float cueBallGapFraction = 0.4f;
     // Radius of the cue ball so the aiming view can remain above the cloth while
     // gliding toward the shot.
     public float cueBallRadius = 0.028575f;
@@ -307,16 +312,26 @@ public class CueCamera : MonoBehaviour
         float maxDistance = Mathf.Max(minDistance, cueRaisedDistanceFromBall);
 
         Vector3 cueSamplePoint;
-        float baseDistance = ResolveCueAimDistance(blend, cueAimForward, minDistance, maxDistance, out cueSamplePoint);
+        float minimumGapDistance;
+        float baseDistance = ResolveCueAimDistance(
+            blend,
+            cueAimForward,
+            minDistance,
+            maxDistance,
+            out cueSamplePoint,
+            out minimumGapDistance);
 
         float pullIn = Mathf.Max(0f, cueDistancePullIn);
         float minPulledDistance = Mathf.Max(minimumDistanceLimit, minDistance - pullIn);
+        minPulledDistance = Mathf.Max(minPulledDistance, minimumGapDistance);
         float distance = Mathf.Max(baseDistance - pullIn, minPulledDistance);
+        distance = Mathf.Max(distance, minimumGapDistance);
 
         float raisedScale = Mathf.Clamp(cueRaisedDistanceScale, 0.1f, 1f);
         float loweredScale = Mathf.Clamp(cueLoweredDistanceScale, 0.1f, raisedScale);
         float distanceScale = Mathf.Lerp(raisedScale, loweredScale, blend);
-        distance = Mathf.Max(distance * distanceScale, minimumDistanceLimit);
+        float minimumDistanceWithGap = Mathf.Max(minimumDistanceLimit, minimumGapDistance);
+        distance = Mathf.Max(distance * distanceScale, minimumDistanceWithGap);
 
         if (CueBall != null)
         {
@@ -429,7 +444,8 @@ public class CueCamera : MonoBehaviour
         Vector3 forward,
         float minDistance,
         float maxDistance,
-        out Vector3 cueSamplePoint)
+        out Vector3 cueSamplePoint,
+        out float minimumGapDistance)
     {
         float fractionBlend = Mathf.Clamp01(blend);
         float upperFraction = Mathf.Clamp01(cueBackFraction);
@@ -441,6 +457,7 @@ public class CueCamera : MonoBehaviour
 
         float distance = Mathf.Lerp(maxDistance, minDistance, fractionBlend);
         cueSamplePoint = CueBall != null ? CueBall.position : Vector3.zero;
+        minimumGapDistance = Mathf.Max(0f, minDistance);
 
         if (CueBall == null)
         {
@@ -448,6 +465,7 @@ public class CueCamera : MonoBehaviour
         }
 
         Vector3 cuePoint = CueBall.position;
+        float gapFraction = Mathf.Clamp01(cueBallGapFraction);
 
         if (CueButtReference != null)
         {
@@ -462,16 +480,11 @@ public class CueCamera : MonoBehaviour
                 limitDistance = Mathf.Clamp(limitDistance, 0f, usableLength);
 
                 float minClamp = usableLength >= minDistance ? Mathf.Min(minDistance, limitDistance) : 0f;
-                float maxClamp = Mathf.Max(limitDistance, minClamp);
-                distance = Mathf.Clamp(distance, minClamp, maxClamp);
-                if (limitDistance < minClamp)
-                {
-                    distance = limitDistance;
-                }
-                else
-                {
-                    distance = Mathf.Min(distance, limitDistance);
-                }
+                float gapDistance = Mathf.Clamp(projectedLength * gapFraction, 0f, limitDistance);
+                minimumGapDistance = Mathf.Max(minClamp, gapDistance);
+                float maxClamp = Mathf.Max(limitDistance, minimumGapDistance);
+                distance = Mathf.Clamp(distance, minimumGapDistance, maxClamp);
+                distance = Mathf.Min(distance, limitDistance);
 
                 float along = projectedLength > 0.0001f ? Mathf.Clamp01(distance / projectedLength) : 0f;
                 cuePoint = Vector3.Lerp(CueBall.position, CueButtReference.position, along);
@@ -486,15 +499,10 @@ public class CueCamera : MonoBehaviour
         float fallbackLimit = Mathf.Lerp(fallbackLength, fallbackLength * fallbackFraction, fractionBlend);
         fallbackLimit = Mathf.Clamp(fallbackLimit, 0f, fallbackLength);
         float fallbackMin = Mathf.Min(minDistance, fallbackLimit);
-        distance = Mathf.Clamp(distance, fallbackMin, Mathf.Max(fallbackLimit, fallbackMin));
-        if (fallbackLimit < fallbackMin)
-        {
-            distance = fallbackLimit;
-        }
-        else
-        {
-            distance = Mathf.Min(distance, fallbackLimit);
-        }
+        float fallbackGap = Mathf.Clamp(fallbackLength * gapFraction, 0f, fallbackLimit);
+        minimumGapDistance = Mathf.Max(fallbackMin, fallbackGap);
+        distance = Mathf.Clamp(distance, minimumGapDistance, Mathf.Max(fallbackLimit, minimumGapDistance));
+        distance = Mathf.Min(distance, fallbackLimit);
 
         cuePoint = CueBall.position - forward * Mathf.Max(distance, 0f);
         cuePoint.y = CueBall.position.y;

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -685,9 +685,6 @@ const CUE_MARKER_RADIUS = CUE_TIP_RADIUS; // cue ball dots match the cue tip foo
 const CUE_MARKER_DEPTH = CUE_TIP_RADIUS * 0.2;
 const CUE_BUTT_LIFT = BALL_R * 0.62; // raise the butt a little more so the rear clears rails while the tip stays aligned
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
-const CUE_HALF_LENGTH =
-  (BALL_R * 0.75 * CUE_LENGTH_MULTIPLIER) /
-  0.0525; // align cue-view framing with the physical shaft length
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(8.5);
 const CUE_FRONT_SECTION_RATIO = 0.28;
 const MAX_SPIN_CONTACT_OFFSET = Math.max(0, BALL_R - CUE_TIP_RADIUS);
@@ -2402,13 +2399,6 @@ const CAMERA_MIN_HORIZONTAL =
 const CAMERA_DOWNWARD_PULL = 2.3;
 const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.34;
 const CUE_VIEW_AIM_SLOW_FACTOR = 0.35; // slow pointer rotation while blended toward cue view for finer aiming
-const CUE_VIEW_FOCUS_MIN = CUE_HALF_LENGTH * 0.92;
-const CUE_VIEW_FOCUS_MAX = LONG_SHOT_DISTANCE;
-const CUE_VIEW_FOCUS_RATIO = 0.58;
-const CUE_VIEW_FOCUS_EXTRA = BALL_R * 6.2;
-const CUE_VIEW_FOCUS_BLEND_EXP = 0.65;
-const CUE_VIEW_THETA_LOCK_BASE = 0.12;
-const CUE_VIEW_THETA_BLEND_EXP = 1.4;
 const POCKET_VIEW_SMOOTH_TIME = 0.24; // seconds to ease pocket camera transitions
 const POCKET_CAMERA_FOV = STANDING_VIEW_FOV;
 const LONG_SHOT_DISTANCE = PLAY_H * 0.5;
@@ -5173,7 +5163,6 @@ function SnookerGame() {
   const sphRef = useRef(null);
   const initialOrbitRef = useRef(null);
   const aimFocusRef = useRef(null);
-  const aimTargetInfoRef = useRef(null);
   const [pocketCameraActive, setPocketCameraActive] = useState(false);
   const pocketCameraStateRef = useRef(false);
   const pocketCamerasRef = useRef(new Map());
@@ -6828,28 +6817,12 @@ function SnookerGame() {
                 ? Math.max(adjusted, minRadiusForRails)
                 : adjusted;
           }
-          const cueSnap = Math.pow(
-            THREE.MathUtils.clamp(1 - blend, 0, 1),
-            CUE_VIEW_THETA_BLEND_EXP
-          );
-          if (cueSnap > 1e-4) {
-            const aimVec = aimDirRef.current;
-            if (aimVec && aimVec.lengthSq() > 1e-6) {
-              const thetaTarget = Math.atan2(aimVec.x, aimVec.y) + Math.PI;
-              const thetaT = THREE.MathUtils.clamp(
-                cueSnap + (1 - blend) * CUE_VIEW_THETA_LOCK_BASE,
-                0,
-                1
-              );
-              sph.theta = lerpAngle(sph.theta, thetaTarget, thetaT);
-            }
-          }
           sph.phi = clampedPhi;
           sph.radius = clampOrbitRadius(finalRadius, cueMinRadius);
           if (cue?.active && !shooting) {
             const aimFocus =
               blend < 0.999
-                ? computeAimFocusTarget(cue, aimDirRef.current, { blend })
+                ? computeAimFocusTarget(cue, aimDirRef.current)
                 : null;
             aimFocusRef.current = aimFocus ? aimFocus.clone() : null;
           } else {
@@ -8996,74 +8969,28 @@ function SnookerGame() {
       let potted = [];
       let firstHit = null;
 
-      const computeAimFocusTarget = (cueBall, aimDir, options = {}) => {
+      const computeAimFocusTarget = (cueBall, aimDir) => {
         if (!cueBall || !aimDir) return null;
         const dir = aimDir.clone();
         if (dir.lengthSq() < 1e-6) return null;
         dir.normalize();
-        const blend = THREE.MathUtils.clamp(options.blend ?? 0, 0, 1);
-        const cuePos = new THREE.Vector3(
-          cueBall.pos.x,
-          BALL_CENTER_Y,
-          cueBall.pos.y
-        );
-        const aimForward = new THREE.Vector3(dir.x, 0, dir.y);
-        const aimInfo = aimTargetInfoRef.current;
-        const fallbackDistance = Math.max(
+        const focusDistance = Math.max(
           BALL_R * 32,
           Math.min(LONG_SHOT_DISTANCE, PLAY_H * 0.55)
         );
-        let desiredDistance = fallbackDistance;
-        let targetPoint = null;
-        if (aimInfo) {
-          const availableDistance =
-            aimInfo.cueToTarget != null
-              ? aimInfo.cueToTarget
-              : aimInfo.cueToImpact ?? null;
-          if (availableDistance != null && availableDistance > 1e-4) {
-            const maxFocus = Math.max(
-              availableDistance - BALL_R * 2.5,
-              CUE_VIEW_FOCUS_MIN
-            );
-            const baseTarget =
-              availableDistance * CUE_VIEW_FOCUS_RATIO + CUE_VIEW_FOCUS_EXTRA;
-            desiredDistance = THREE.MathUtils.clamp(
-              baseTarget,
-              CUE_VIEW_FOCUS_MIN,
-              Math.min(CUE_VIEW_FOCUS_MAX, maxFocus)
-            );
-          }
-          targetPoint =
-            aimInfo.targetPoint?.clone() ??
-            aimInfo.impactPoint?.clone() ??
-            null;
-        }
-        const cueBias = aimInfo
-          ? Math.pow(1 - blend, CUE_VIEW_FOCUS_BLEND_EXP)
-          : 0;
-        const focusDistance = THREE.MathUtils.clamp(
-          THREE.MathUtils.lerp(fallbackDistance, desiredDistance, cueBias),
-          CUE_VIEW_FOCUS_MIN,
-          CUE_VIEW_FOCUS_MAX
+        return new THREE.Vector3(
+          THREE.MathUtils.clamp(
+            cueBall.pos.x + dir.x * focusDistance,
+            -PLAY_W / 2,
+            PLAY_W / 2
+          ),
+          BALL_CENTER_Y,
+          THREE.MathUtils.clamp(
+            cueBall.pos.y + dir.y * focusDistance,
+            -PLAY_H / 2,
+            PLAY_H / 2
+          )
         );
-        const focusTarget = cuePos
-          .clone()
-          .add(aimForward.multiplyScalar(focusDistance));
-        if (targetPoint && cueBias > 1e-3) {
-          focusTarget.lerp(targetPoint, cueBias * 0.35);
-        }
-        focusTarget.y = BALL_CENTER_Y + BALL_R * 0.04;
-        focusTarget.x = THREE.MathUtils.clamp(
-          focusTarget.x,
-          -PLAY_W / 2,
-          PLAY_W / 2
-        );
-        focusTarget.z = THREE.MathUtils.clamp(
-          focusTarget.z,
-          -PLAY_H / 2,
-          PLAY_H / 2
-        );
-        return focusTarget;
       };
 
       const alignStandingCameraToAim = (cueBall, aimDir) => {
@@ -9086,7 +9013,7 @@ function SnookerGame() {
         sph.theta = aimTheta;
         syncBlendToSpherical();
         const focusStore = ensureOrbitFocus();
-        const focusTarget = computeAimFocusTarget(cueBall, dir, { blend: 0 });
+        const focusTarget = computeAimFocusTarget(cueBall, dir);
         if (!focusTarget) return;
         aimFocusRef.current = focusTarget.clone();
         focusStore.ballId = cueBall.id ?? null;
@@ -9982,20 +9909,6 @@ function SnookerGame() {
           }
           aimGeom.setFromPoints([start, end]);
           aim.visible = true;
-          aimTargetInfoRef.current = {
-            cueToImpact: start.distanceTo(end),
-            cueToTarget: targetBall
-              ? cue.pos.distanceTo(targetBall.pos)
-              : null,
-            impactPoint: end.clone(),
-            targetPoint: targetBall
-              ? new THREE.Vector3(
-                  targetBall.pos.x,
-                  BALL_CENTER_Y,
-                  targetBall.pos.y
-                )
-              : null
-          };
           const slowAssistEnabled = chalkAssistEnabledRef.current;
           const hasTarget = slowAssistEnabled && (targetBall || railNormal);
           shouldSlowAim = hasTarget;
@@ -10198,7 +10111,6 @@ function SnookerGame() {
           }
         } else {
           aimFocusRef.current = null;
-          aimTargetInfoRef.current = null;
           aim.visible = false;
           tick.visible = false;
           target.visible = false;


### PR DESCRIPTION
## Summary
- restore CueCamera cue view logic, including enforcing a minimum cue-ball gap and distance handling from the 12:31 snapshot
- revert snooker game aim focus logic to the earlier implementation without target info blending

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ebe9a0700483299f8cd4a44215e94e