### PR TITLE
Restore site to Oct 12 9:30 baseline

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -1,0 +1,81 @@
+#if UNITY_5_3_OR_NEWER
+using UnityEngine;
+
+/// <summary>
+/// Adapter that reuses the snooker cue camera logic for Pool Royale while
+/// keeping the original distance-from-table and vertical travel limits.
+/// </summary>
+[RequireComponent(typeof(CueCamera))]
+public class CameraController : MonoBehaviour
+{
+    [Header("Table setup")]
+    [Tooltip("Y position of the top of the table in world space.")]
+    public float tableTopY = 0f;
+
+    [Tooltip("Height of the top of the wooden side rails in world space.")]
+    public float railTopY = 0.33f;
+
+    [Tooltip("Extra clearance to keep the camera slightly above the rails.")]
+    public float railClearance = 0.08f;
+
+    [Header("Legacy Pool Royale distances")]
+    [Tooltip("Maximum height above the table the legacy camera allowed.")]
+    public float maxHeightAboveTable = 1.9f;
+
+    [Tooltip("Default distance of the camera from the table centre when fully raised.")]
+    public float distanceFromCenter = 3.8f;
+
+    [Tooltip("Closest distance from the table centre when the camera was pulled down.")]
+    public float minDistanceFromCenter = 2.15f;
+
+    private CueCamera cueCamera;
+
+    private void Awake()
+    {
+        cueCamera = GetComponent<CueCamera>();
+        ApplyOverrides();
+    }
+
+    private void OnValidate()
+    {
+        if (cueCamera == null)
+        {
+            cueCamera = GetComponent<CueCamera>();
+        }
+
+        ApplyOverrides();
+    }
+
+    /// <summary>
+    /// Push the Pool Royale limits into the shared cue camera so the distance and
+    /// vertical travel match the previous behaviour.
+    /// </summary>
+    private void ApplyOverrides()
+    {
+        if (cueCamera == null)
+        {
+            return;
+        }
+
+        // Ensure the cue camera respects the old vertical range by clamping the
+        // raised height and maintaining a minimum clearance above the rails.
+        float raisedHeight = tableTopY + Mathf.Max(0f, maxHeightAboveTable);
+        float railHeight = Mathf.Max(railTopY, tableTopY);
+        cueCamera.railHeight = railHeight;
+        cueCamera.railClearance = Mathf.Max(0f, railClearance);
+        cueCamera.cueRaisedHeight = raisedHeight;
+        cueCamera.cueLoweredHeight = Mathf.Min(cueCamera.cueLoweredHeight, raisedHeight);
+
+        // Preserve the legacy distancing by mapping the previous centre distances
+        // onto the cue and broadcast framing ranges.
+        float clampedMin = Mathf.Max(0.01f, minDistanceFromCenter);
+        float clampedMax = Mathf.Max(clampedMin, distanceFromCenter);
+
+        cueCamera.cueRaisedDistanceFromBall = clampedMax;
+        cueCamera.cueLoweredDistanceFromBall = Mathf.Min(cueCamera.cueLoweredDistanceFromBall, clampedMax);
+        cueCamera.broadcastDistance = distanceFromCenter;
+        cueCamera.broadcastMinDistance = clampedMin;
+        cueCamera.broadcastMaxDistance = Mathf.Max(cueCamera.broadcastMaxDistance, clampedMax);
+    }
+}
+#endif

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -115,10 +115,10 @@ export default function App() {
             />
             <Route path="/games/murlanroyale" element={<MurlanRoyale />} />
             <Route
-              path="/games/poolroyale/lobby"
+              path="/games/pollroyale/lobby"
               element={<PoolRoyaleLobby />}
             />
-            <Route path="/games/poolroyale" element={<PoolRoyale />} />
+            <Route path="/games/pollroyale" element={<PoolRoyale />} />
             <Route path="/games/snooker" element={<Snooker />} />
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -40,7 +40,7 @@ export default function HomeGamesCard() {
           </h3>
         </Link>
         <Link
-          to="/games/poolroyale/lobby"
+          to="/games/pollroyale/lobby"
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -64,7 +64,7 @@ export default function InvitePopup({
                     alt: 'Goal Rush',
                   },
                   {
-                    id: 'poolroyale',
+                    id: 'pollroyale',
                     src: '/assets/icons/pool-royale.svg',
                     alt: 'Pool Royale',
                   },

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -10,9 +10,14 @@ import { NFT_GIFTS } from '../utils/nftGifts.js';
 function getGameFromTableId(id) {
   if (!id) return 'snake';
   const prefix = id.split('-')[0];
-  if (prefix === 'pollroyale') return 'poolroyale';
   if (
-    ['snake', 'fallingball', 'goalrush', 'poolroyale'].includes(prefix)
+    [
+      'snake',
+      'fallingball',
+      'goalrush',
+      'pollroyale',
+      'poolroyale',
+    ].includes(prefix)
   )
     return prefix;
   return 'snake';
@@ -175,7 +180,7 @@ export default function PlayerInvitePopup({
                   alt: 'Goal Rush',
                 },
                 {
-                  id: 'poolroyale',
+                  id: 'pollroyale',
                   src: '/assets/icons/pool-royale.svg',
                   alt: 'Pool Royale',
                 },

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -45,7 +45,7 @@ export default function Games() {
               </h3>
             </Link>
             <Link
-              to="/games/poolroyale/lobby"
+              to="/games/pollroyale/lobby"
               className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
             >
               <img

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -493,9 +493,7 @@ const CLOTH_LIFT = (() => {
   const eps = ballR * microEpsRatio;
   return Math.max(0, RAIL_HEIGHT - ballR - eps);
 })();
-const ACTION_CAMERA_START_BLEND = 0;
-const ENABLE_ACTION_CAMERAS = false;
-const ENABLE_POCKET_CAMERAS = false;
+const ACTION_CAMERA_START_BLEND = 1;
 const CLOTH_DROP = BALL_R * 0.18; // lower the cloth surface slightly for added depth
 const CLOTH_TOP_LOCAL = FRAME_TOP_Y + BALL_R * 0.09523809523809523;
 const MICRO_EPS = BALL_R * 0.022857142857142857;
@@ -5868,13 +5866,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
     const cueRackDisposers = [];
     try {
       const updatePocketCameraState = (active) => {
-        if (!ENABLE_POCKET_CAMERAS) {
-          if (pocketCameraStateRef.current) {
-            pocketCameraStateRef.current = false;
-            setPocketCameraActive(false);
-          }
-          return;
-        }
         if (pocketCameraStateRef.current === active) return;
         pocketCameraStateRef.current = active;
         setPocketCameraActive(active);
@@ -7187,7 +7178,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             broadcastArgs.focusWorld =
               broadcastCamerasRef.current?.defaultFocusWorld ?? lookTarget;
             broadcastArgs.targetWorld = null;
-          } else if (ENABLE_ACTION_CAMERAS && activeShotView?.mode === 'action') {
+          } else if (activeShotView?.mode === 'action') {
             const ballsList = ballsRef.current || [];
             const cueBall = ballsList.find((b) => b.id === activeShotView.cueId);
             if (!cueBall?.active) {
@@ -7466,7 +7457,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                 renderCamera = camera;
               }
             }
-          } else if (ENABLE_POCKET_CAMERAS && activeShotView?.mode === 'pocket') {
+          } else if (activeShotView?.mode === 'pocket') {
             const ballsList = ballsRef.current || [];
             const focusBall = ballsList.find(
               (b) => b.id === activeShotView.ballId
@@ -7934,7 +7925,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           railNormal,
           { longShot = false, travelDistance = 0, impactPoint = null } = {}
         ) => {
-          if (!ENABLE_ACTION_CAMERAS) return null;
           if (!cueBall) return null;
           const ballsList = ballsRef.current || [];
           const targetBall =
@@ -8028,7 +8018,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           };
         };
         const makePocketCameraView = (ballId, followView, options = {}) => {
-          if (!ENABLE_POCKET_CAMERAS) return null;
           if (!followView) return null;
           const { forceEarly = false } = options;
           if (forceEarly && shotPrediction?.ballId !== ballId) return null;
@@ -10736,7 +10725,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             }
         }
         if (
-          ENABLE_ACTION_CAMERAS &&
           !activeShotView &&
           suspendedActionView?.mode === 'action' &&
           suspendedActionView.pendingActivation
@@ -10770,7 +10758,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             }
           }
         }
-        if (ENABLE_ACTION_CAMERAS && activeShotView?.mode === 'action') {
+        if (activeShotView?.mode === 'action') {
           const now = performance.now();
           const cueBall = balls.find((b) => b.id === activeShotView.cueId);
           if (!cueBall?.active) {
@@ -10820,7 +10808,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           }
         }
         if (
-          ENABLE_POCKET_CAMERAS &&
           shooting &&
           !topViewRef.current &&
           (activeShotView?.mode !== 'pocket' || !activeShotView)
@@ -10995,7 +10982,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             }
           }
         });
-        if (ENABLE_POCKET_CAMERAS && activeShotView?.mode === 'pocket') {
+        if (activeShotView?.mode === 'pocket') {
           const pocketView = activeShotView;
           const focusBall = balls.find((b) => b.id === pocketView.ballId);
           const now = performance.now();

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -77,7 +77,7 @@ export default function PoolRoyaleLobby() {
     if (devAcc1) params.set('dev1', devAcc1);
     if (devAcc2) params.set('dev2', devAcc2);
     if (initData) params.set('init', encodeURIComponent(initData));
-    navigate(`/games/poolroyale?${params.toString()}`);
+    navigate(`/games/pollroyale?${params.toString()}`);
   };
 
   const winnerParam = new URLSearchParams(search).get('winner');

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -496,9 +496,7 @@ const CLOTH_LIFT = (() => {
   const eps = ballR * microEpsRatio;
   return Math.max(0, RAIL_HEIGHT - ballR - eps);
 })();
-const ACTION_CAMERA_START_BLEND = 0;
-const ENABLE_ACTION_CAMERAS = false;
-const ENABLE_POCKET_CAMERAS = false;
+const ACTION_CAMERA_START_BLEND = 1;
 const CLOTH_DROP = BALL_R * 0.18; // lower the cloth surface slightly for added depth
 const CLOTH_TOP_LOCAL = FRAME_TOP_Y + BALL_R * 0.09523809523809523;
 const MICRO_EPS = BALL_R * 0.022857142857142857;
@@ -5720,13 +5718,6 @@ function SnookerGame() {
     const cueRackDisposers = [];
     try {
       const updatePocketCameraState = (active) => {
-        if (!ENABLE_POCKET_CAMERAS) {
-          if (pocketCameraStateRef.current) {
-            pocketCameraStateRef.current = false;
-            setPocketCameraActive(false);
-          }
-          return;
-        }
         if (pocketCameraStateRef.current === active) return;
         pocketCameraStateRef.current = active;
         setPocketCameraActive(active);
@@ -6939,7 +6930,7 @@ function SnookerGame() {
             broadcastArgs.focusWorld =
               broadcastCamerasRef.current?.defaultFocusWorld ?? lookTarget;
             broadcastArgs.targetWorld = null;
-          } else if (ENABLE_ACTION_CAMERAS && activeShotView?.mode === 'action') {
+          } else if (activeShotView?.mode === 'action') {
             const ballsList = ballsRef.current || [];
             const cueBall = ballsList.find((b) => b.id === activeShotView.cueId);
             if (!cueBall?.active) {
@@ -7192,7 +7183,7 @@ function SnookerGame() {
                 renderCamera = camera;
               }
             }
-          } else if (ENABLE_POCKET_CAMERAS && activeShotView?.mode === 'pocket') {
+          } else if (activeShotView?.mode === 'pocket') {
             const ballsList = ballsRef.current || [];
             const focusBall = ballsList.find(
               (b) => b.id === activeShotView.ballId
@@ -7611,7 +7602,6 @@ function SnookerGame() {
           railNormal,
           { longShot = false, travelDistance = 0 } = {}
         ) => {
-          if (!ENABLE_ACTION_CAMERAS) return null;
           if (!cueBall) return null;
           const ballsList = ballsRef.current || [];
           const targetBall =
@@ -7689,7 +7679,6 @@ function SnookerGame() {
           };
         };
         const makePocketCameraView = (ballId, followView, options = {}) => {
-          if (!ENABLE_POCKET_CAMERAS) return null;
           if (!followView) return null;
           const { forceEarly = false } = options;
           if (forceEarly && shotPrediction?.ballId !== ballId) return null;
@@ -10257,7 +10246,6 @@ function SnookerGame() {
             }
         }
         if (
-          ENABLE_ACTION_CAMERAS &&
           !activeShotView &&
           suspendedActionView?.mode === 'action' &&
           suspendedActionView.pendingActivation
@@ -10291,7 +10279,7 @@ function SnookerGame() {
             }
           }
         }
-        if (ENABLE_ACTION_CAMERAS && activeShotView?.mode === 'action') {
+        if (activeShotView?.mode === 'action') {
           const now = performance.now();
           const cueBall = balls.find((b) => b.id === activeShotView.cueId);
           if (!cueBall?.active) {
@@ -10335,7 +10323,6 @@ function SnookerGame() {
           }
         }
         if (
-          ENABLE_POCKET_CAMERAS &&
           shooting &&
           !topViewRef.current &&
           (activeShotView?.mode !== 'pocket' || !activeShotView)
@@ -10512,7 +10499,7 @@ function SnookerGame() {
             }
           }
         });
-        if (ENABLE_POCKET_CAMERAS && activeShotView?.mode === 'pocket') {
+        if (activeShotView?.mode === 'pocket') {
           const pocketView = activeShotView;
           const focusBall = balls.find((b) => b.id === pocketView.ballId);
           const now = performance.now();


### PR DESCRIPTION
## Summary
- revert the webapp routes and invite flows to the pollroyale baseline used at 9:30
- re-enable the Pool Royale and Snooker action/pocket camera behaviours from the prior build
- restore the Unity cue camera controller that matches the earlier camera limits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ec7ebdf530832986838c945ee5b5c6