### PR TITLE
Remove fake loading overlays from Snooker and Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5216,34 +5216,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   const startUserSuggestionRef = useRef(() => {});
   const autoAimRequestRef = useRef(false);
   const aiTelemetryRef = useRef({ key: null, countdown: 0 });
-  const [loading, setLoading] = useState(true);
-  const [loadingProgress, setLoadingProgress] = useState(0);
-  const loadingClearedRef = useRef(false);
-  useEffect(() => {
-    let raf = null;
-    let active = true;
-    if (!loading) {
-      setLoadingProgress(100);
-      return () => {};
-    }
-    const start = performance.now();
-    const duration = 2200;
-    const tick = (now) => {
-      if (!active) return;
-      const t = Math.min(1, (now - start) / duration);
-      const eased = 1 - Math.pow(1 - t, 3);
-      const next = Math.min(95, Math.max(0, Math.round(eased * 95)));
-      setLoadingProgress((prev) => (prev >= next ? prev : next));
-      if (loading) {
-        raf = requestAnimationFrame(tick);
-      }
-    };
-    raf = requestAnimationFrame(tick);
-    return () => {
-      active = false;
-      if (raf) cancelAnimationFrame(raf);
-    };
-  }, [loading]);
   const [hud, setHud] = useState({
     power: 0.65,
     A: 0,
@@ -5862,7 +5834,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   useEffect(() => {
     const host = mountRef.current;
     if (!host) return;
-    let loadTimer = null;
     const cueRackDisposers = [];
     try {
       const updatePocketCameraState = (active) => {
@@ -11087,13 +11058,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           }
           const frameCamera = updateCamera();
           renderer.render(scene, frameCamera ?? camera);
-          if (!loadingClearedRef.current) {
-            loadingClearedRef.current = true;
-            loadTimer = window.setTimeout(() => {
-              setLoading(false);
-              setLoadingProgress(100);
-            }, 120);
-          }
           rafRef.current = requestAnimationFrame(step);
         };
         step(performance.now());
@@ -11176,15 +11140,10 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           cueGalleryStateRef.current.prev = null;
           cueGalleryStateRef.current.position?.set(0, 0, 0);
           cueGalleryStateRef.current.target?.set(0, 0, 0);
-          if (loadTimer) {
-            clearTimeout(loadTimer);
-          }
         };
       } catch (e) {
         console.error(e);
         setErr(e?.message || String(e));
-        setLoading(false);
-        setLoadingProgress(100);
       }
   }, []);
 
@@ -11361,19 +11320,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
     };
   }, [updateSpinDotPosition]);
 
-  const displayedProgress = Math.min(
-    100,
-    Math.max(0, Math.round(loadingProgress))
-  );
-  const cueStrikeProgress = Math.min(1, displayedProgress / 12);
-  const cueBaseOffset = 16;
-  const cueDrawBack = 18;
-  const cueTrackWidth = 200;
-  const ballOffsetStart = cueBaseOffset + 28;
-  const cueBallRadius = 12;
-  const ballTravel = Math.max(0, Math.min(1, (displayedProgress - 12) / 88));
-  const cuePosition = cueBaseOffset - cueDrawBack * (1 - cueStrikeProgress);
-  const cueBallPosition = ballOffsetStart + cueTrackWidth * ballTravel;
   const bottomHudVisible = hud.turn === 0 && !hud.over && !shotActive;
 
   return (
@@ -11567,32 +11513,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           </div>
         )}
       </div>
-
-      {(loading || displayedProgress < 100) && (
-        <div className="absolute inset-0 z-[70] flex flex-col items-center justify-center gap-6 bg-gradient-to-b from-black via-black/95 to-black text-white">
-          <div className="relative w-64 h-24">
-            <div className="absolute left-0 top-1/2 h-1.5 w-full -translate-y-1/2 rounded-full bg-white/15" />
-            <div
-              className="absolute left-0 top-1/2 h-1.5 -translate-y-1/2 rounded-full bg-emerald-400/80 transition-all duration-150 ease-out"
-              style={{ width: `${displayedProgress}%` }}
-            />
-            <div
-              className="absolute left-0 top-1/2 h-2 w-28 rounded-r-full bg-amber-300 shadow-lg shadow-amber-500/40 transition-transform duration-150 ease-out"
-              style={{ transform: `translate(${cuePosition}px, -50%)` }}
-            />
-            <div
-              className="absolute left-0 top-1/2 h-6 w-6 rounded-full border border-emerald-200 bg-white shadow-[0_0_16px_rgba(74,222,128,0.5)] transition-transform duration-150 ease-out"
-              style={{
-                transform: `translate(${cueBallPosition - cueBallRadius}px, -50%)`
-              }}
-            />
-          </div>
-          <div className="text-sm tracking-[0.3em] uppercase text-emerald-200">
-            Loading {displayedProgress}%
-          </div>
-        </div>
-      )}
-
       {bottomHudVisible && (
         <div
           className={`absolute bottom-4 left-0 right-0 flex justify-center pointer-events-none z-50 transition-opacity duration-200 ${pocketCameraActive ? 'opacity-0' : 'opacity-100'}`}

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -5078,34 +5078,6 @@ function SnookerGame() {
   const startUserSuggestionRef = useRef(() => {});
   const autoAimRequestRef = useRef(false);
   const aiTelemetryRef = useRef({ key: null, countdown: 0 });
-  const [loading, setLoading] = useState(true);
-  const [loadingProgress, setLoadingProgress] = useState(0);
-  const loadingClearedRef = useRef(false);
-  useEffect(() => {
-    let raf = null;
-    let active = true;
-    if (!loading) {
-      setLoadingProgress(100);
-      return () => {};
-    }
-    const start = performance.now();
-    const duration = 2200;
-    const tick = (now) => {
-      if (!active) return;
-      const t = Math.min(1, (now - start) / duration);
-      const eased = 1 - Math.pow(1 - t, 3);
-      const next = Math.min(95, Math.max(0, Math.round(eased * 95)));
-      setLoadingProgress((prev) => (prev >= next ? prev : next));
-      if (loading) {
-        raf = requestAnimationFrame(tick);
-      }
-    };
-    raf = requestAnimationFrame(tick);
-    return () => {
-      active = false;
-      if (raf) cancelAnimationFrame(raf);
-    };
-  }, [loading]);
   const [hud, setHud] = useState({
     power: 0.65,
     A: 0,
@@ -5714,7 +5686,6 @@ function SnookerGame() {
   useEffect(() => {
     const host = mountRef.current;
     if (!host) return;
-    let loadTimer = null;
     const cueRackDisposers = [];
     try {
       const updatePocketCameraState = (active) => {
@@ -10604,13 +10575,6 @@ function SnookerGame() {
           }
           const frameCamera = updateCamera();
           renderer.render(scene, frameCamera ?? camera);
-          if (!loadingClearedRef.current) {
-            loadingClearedRef.current = true;
-            loadTimer = window.setTimeout(() => {
-              setLoading(false);
-              setLoadingProgress(100);
-            }, 120);
-          }
           rafRef.current = requestAnimationFrame(step);
         };
         step(performance.now());
@@ -10682,15 +10646,10 @@ function SnookerGame() {
           cueGalleryStateRef.current.prev = null;
           cueGalleryStateRef.current.position?.set(0, 0, 0);
           cueGalleryStateRef.current.target?.set(0, 0, 0);
-          if (loadTimer) {
-            clearTimeout(loadTimer);
-          }
         };
       } catch (e) {
         console.error(e);
         setErr(e?.message || String(e));
-        setLoading(false);
-        setLoadingProgress(100);
       }
   }, []);
 
@@ -10867,19 +10826,6 @@ function SnookerGame() {
     };
   }, [updateSpinDotPosition]);
 
-  const displayedProgress = Math.min(
-    100,
-    Math.max(0, Math.round(loadingProgress))
-  );
-  const cueStrikeProgress = Math.min(1, displayedProgress / 12);
-  const cueBaseOffset = 16;
-  const cueDrawBack = 18;
-  const cueTrackWidth = 200;
-  const ballOffsetStart = cueBaseOffset + 28;
-  const cueBallRadius = 12;
-  const ballTravel = Math.max(0, Math.min(1, (displayedProgress - 12) / 88));
-  const cuePosition = cueBaseOffset - cueDrawBack * (1 - cueStrikeProgress);
-  const cueBallPosition = ballOffsetStart + cueTrackWidth * ballTravel;
   const bottomHudVisible = hud.turn === 0 && !hud.over && !shotActive;
 
   return (
@@ -11073,32 +11019,6 @@ function SnookerGame() {
           </div>
         )}
       </div>
-
-      {(loading || displayedProgress < 100) && (
-        <div className="absolute inset-0 z-[70] flex flex-col items-center justify-center gap-6 bg-gradient-to-b from-black via-black/95 to-black text-white">
-          <div className="relative w-64 h-24">
-            <div className="absolute left-0 top-1/2 h-1.5 w-full -translate-y-1/2 rounded-full bg-white/15" />
-            <div
-              className="absolute left-0 top-1/2 h-1.5 -translate-y-1/2 rounded-full bg-emerald-400/80 transition-all duration-150 ease-out"
-              style={{ width: `${displayedProgress}%` }}
-            />
-            <div
-              className="absolute left-0 top-1/2 h-2 w-28 rounded-r-full bg-amber-300 shadow-lg shadow-amber-500/40 transition-transform duration-150 ease-out"
-              style={{ transform: `translate(${cuePosition}px, -50%)` }}
-            />
-            <div
-              className="absolute left-0 top-1/2 h-6 w-6 rounded-full border border-emerald-200 bg-white shadow-[0_0_16px_rgba(74,222,128,0.5)] transition-transform duration-150 ease-out"
-              style={{
-                transform: `translate(${cueBallPosition - cueBallRadius}px, -50%)`
-              }}
-            />
-          </div>
-          <div className="text-sm tracking-[0.3em] uppercase text-emerald-200">
-            Loading {displayedProgress}%
-          </div>
-        </div>
-      )}
-
       {bottomHudVisible && (
         <div
           className={`absolute bottom-4 left-0 right-0 flex justify-center pointer-events-none z-50 transition-opacity duration-200 ${pocketCameraActive ? 'opacity-0' : 'opacity-100'}`}


### PR DESCRIPTION
## Summary
- remove the artificial loading state and progress animation from the Snooker React page so the arena appears immediately
- apply the same direct render flow to Pool Royale and drop the unused loading overlay markup
- clean up leftover timeout and progress bookkeeping now that no placeholder screen is shown

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ec819624288329b38f8bba2e801c09