### PR TITLE
Restore site to Oct 12 09:15 baseline

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -2,80 +2,173 @@
 using UnityEngine;
 
 /// <summary>
-/// Adapter that reuses the snooker cue camera logic for Pool Royale while
-/// keeping the original distance-from-table and vertical travel limits.
+/// Simple camera controller that keeps the camera above the table while
+/// providing a slightly pulled back perspective. When the player drags the
+/// camera down toward the rails the controller eases the view closer to the
+/// cloth while ensuring the camera stays clear of the wooden frame. Pulling the
+/// camera up gives a wider overview of the table.
 /// </summary>
-[RequireComponent(typeof(CueCamera))]
 public class CameraController : MonoBehaviour
 {
-    [Header("Table setup")]
-    [Tooltip("Y position of the top of the table in world space.")]
+    // Y position of the top of the table in world space.
     public float tableTopY = 0f;
-
-    [Tooltip("Height of the top of the wooden side rails in world space.")]
+    // Height of the top of the wooden side rails in world space.  Slightly raised
+    // to keep the camera from dipping too low relative to the table frame.
     public float railTopY = 0.33f;
-
-    [Tooltip("Extra clearance to keep the camera slightly above the rails.")]
+    // Optional clearance so the camera can be kept slightly above the side rails
+    // while still preventing it from dipping below their top surface.
     public float railClearance = 0.08f;
-
-    [Header("Legacy Pool Royale distances")]
-    [Tooltip("Maximum height above the table the legacy camera allowed.")]
+    // Extra clearance used when clamping the camera height so it always remains
+    // above the cue stick and keeps the stick visible in frame.
+    public float cueStickHeightClearance = 0.05f;
+    // Minimum distance the camera should maintain when hugging the table so the
+    // framing ends up closer to the cue ball without drifting toward the butt of
+    // the cue stick.
+    public float minimumCueViewDistance = 1.45f;
+    // How far above the rails the camera is allowed to travel.
     public float maxHeightAboveTable = 1.9f;
-
-    [Tooltip("Default distance of the camera from the table centre when fully raised.")]
+    // Default distance of the camera from the table centre when fully raised to
+    // provide a broad overview of the action.
     public float distanceFromCenter = 3.8f;
-
-    [Tooltip("Closest distance from the table centre when the camera was pulled down.")]
+    // Minimum distance from the table centre allowed when the camera is pulled
+    // down toward the rails for a closer look.
     public float minDistanceFromCenter = 2.15f;
+    // Extra distance the camera is allowed to shed as it hugs the table so the
+    // cue ball fills more of the view during low-angle aiming.
+    public float lowHeightDistanceReduction = 0.45f;
+    // Extra pullback applied when the camera is raised to its maximum height so
+    // the player gets a slightly wider view while aiming.
+    public float zoomOutWhenRaised = 0.25f;
+    // Buffer that keeps the camera just outside the rails even at the closest
+    // zoom level.
+    public float railBuffer = 0.02f;
+    // Slight height offset so the camera looks just above the table centre
+    // to reduce the viewing angle and give a lower perspective.
+    public float lookAtHeightOffset = 0.08f;
+    // When the camera moves close to the table corners pull back slightly so
+    // the rails remain visible and aiming is easier.
+    public float cornerXThreshold = 2.6f;
+    public float cornerZThreshold = 1.3f;
+    public float cornerPullback = 0.5f;
+    // Range beyond the thresholds where the pullback gradually reaches the
+    // maximum value.  This avoids a sudden jump in zoom when approaching a
+    // corner and gives a smoother transition.
+    public float cornerBlendRange = 0.4f;
+    // Optional reference to the active player (usually the cue ball). When set,
+    // corner pullback is based on the player's position instead of the camera
+    // so that approaching a rail gives a better view of the shot.
+    public Transform player;
+    // How strongly the camera should favour the player's position as it drops
+    // toward the cloth.  A value of 1 makes the camera fully orbit the player at
+    // the lowest angle while 0 keeps the orbit centred on the table.
+    public float lowHeightPlayerFocus = 0.75f;
+    // Maximum fraction of the cue stick distance the camera is allowed to slide
+    // toward the butt when hugging the table.  Keeping this below 1 ensures the
+    // view settles closer to the middle of the cue instead of drifting all the
+    // way to the plastic cap at the end of the stick.
+    [Range(0f, 1f)]
+    public float cueViewMaxCueDistanceRatio = 0.65f;
 
-    private CueCamera cueCamera;
-
-    private void Awake()
+    private void LateUpdate()
     {
-        cueCamera = GetComponent<CueCamera>();
-        ApplyOverrides();
-    }
+        // Clamp vertical movement so the camera never dips below the side rails
+        // and doesn't fly too high above the table surface.
+        Vector3 pos = transform.position;
+        float minRailY = railTopY + Mathf.Max(0f, railClearance);
+        float cueStickMinY = player != null
+            ? player.position.y + Mathf.Max(0f, cueStickHeightClearance)
+            : minRailY;
+        float minY = Mathf.Max(minRailY, cueStickMinY, tableTopY + Mathf.Max(0f, cueStickHeightClearance));
+        float maxY = tableTopY + maxHeightAboveTable;
+        pos.y = Mathf.Clamp(pos.y, minY, maxY);
 
-    private void OnValidate()
-    {
-        if (cueCamera == null)
+        // As the camera is pulled downward toward the rails gradually move it
+        // closer to the table for an intimate view, while raising the camera
+        // pushes it back a little so more of the table stays in frame.
+        float heightBlend = Mathf.InverseLerp(maxY, minY, pos.y);
+
+        float minAllowedDistance = Mathf.Max(minDistanceFromCenter, Mathf.Max(cornerXThreshold, cornerZThreshold) + railBuffer);
+        float cueViewDistance = Mathf.Max(minAllowedDistance - Mathf.Max(0f, lowHeightDistanceReduction), minimumCueViewDistance);
+        float raisedDistance = Mathf.Max(minAllowedDistance, distanceFromCenter + zoomOutWhenRaised);
+        float closeViewBlend = Mathf.SmoothStep(0f, 1f, heightBlend);
+        float currentDistance = Mathf.Lerp(raisedDistance, cueViewDistance, closeViewBlend);
+
+        // If the player (or the camera if no player reference is set) moves
+        // close to a corner, increase the distance a little to give a clearer
+        // overview of the rails.
+        Vector3 cornerPos = player != null ? player.position : pos;
+        if (Mathf.Abs(cornerPos.x) > cornerXThreshold && Mathf.Abs(cornerPos.z) > cornerZThreshold)
         {
-            cueCamera = GetComponent<CueCamera>();
+            float xFactor = Mathf.InverseLerp(cornerXThreshold, cornerXThreshold + cornerBlendRange, Mathf.Abs(cornerPos.x));
+            float zFactor = Mathf.InverseLerp(cornerZThreshold, cornerZThreshold + cornerBlendRange, Mathf.Abs(cornerPos.z));
+            float blend = Mathf.Min(xFactor, zFactor);
+            currentDistance += cornerPullback * Mathf.Clamp01(blend);
         }
 
-        ApplyOverrides();
-    }
-
-    /// <summary>
-    /// Push the Pool Royale limits into the shared cue camera so the distance and
-    /// vertical travel match the previous behaviour.
-    /// </summary>
-    private void ApplyOverrides()
-    {
-        if (cueCamera == null)
+        Vector3 pivot = Vector3.zero;
+        float focusBlend = 0f;
+        if (player != null)
         {
-            return;
+            Vector3 playerFlat = new Vector3(player.position.x, 0f, player.position.z);
+            float desiredFocus = Mathf.Clamp01(lowHeightPlayerFocus);
+            float cueFocusBias = Mathf.SmoothStep(0f, 1f, heightBlend);
+            focusBlend = Mathf.Clamp01(Mathf.Lerp(0f, desiredFocus, cueFocusBias));
+            focusBlend = Mathf.Lerp(focusBlend, 1f, cueFocusBias);
+            pivot = Vector3.Lerp(Vector3.zero, playerFlat, focusBlend);
         }
 
-        // Ensure the cue camera respects the old vertical range by clamping the
-        // raised height and maintaining a minimum clearance above the rails.
-        float raisedHeight = tableTopY + Mathf.Max(0f, maxHeightAboveTable);
-        float railHeight = Mathf.Max(railTopY, tableTopY);
-        cueCamera.railHeight = railHeight;
-        cueCamera.railClearance = Mathf.Max(0f, railClearance);
-        cueCamera.cueRaisedHeight = raisedHeight;
-        cueCamera.cueLoweredHeight = Mathf.Min(cueCamera.cueLoweredHeight, raisedHeight);
+        Vector3 pivotFlat = new Vector3(pivot.x, 0f, pivot.z);
+        Vector3 flatOffset = new Vector3(pos.x - pivotFlat.x, 0f, pos.z - pivotFlat.z);
+        if (flatOffset.sqrMagnitude < 0.0001f)
+        {
+            Vector3 fallbackDir = new Vector3(transform.forward.x, 0f, transform.forward.z);
+            if (fallbackDir.sqrMagnitude < 0.0001f)
+            {
+                fallbackDir = Vector3.forward;
+            }
 
-        // Preserve the legacy distancing by mapping the previous centre distances
-        // onto the cue and broadcast framing ranges.
-        float clampedMin = Mathf.Max(0.01f, minDistanceFromCenter);
-        float clampedMax = Mathf.Max(clampedMin, distanceFromCenter);
+            flatOffset = -fallbackDir.normalized * currentDistance;
+        }
 
-        cueCamera.cueRaisedDistanceFromBall = clampedMax;
-        cueCamera.cueLoweredDistanceFromBall = Mathf.Min(cueCamera.cueLoweredDistanceFromBall, clampedMax);
-        cueCamera.broadcastDistance = distanceFromCenter;
-        cueCamera.broadcastMinDistance = clampedMin;
-        cueCamera.broadcastMaxDistance = Mathf.Max(cueCamera.broadcastMaxDistance, clampedMax);
+        Vector3 flatDir = flatOffset.normalized;
+        Vector3 desiredFlat = pivotFlat + flatDir * currentDistance;
+        if (player != null)
+        {
+            Vector3 playerFlat = new Vector3(player.position.x, 0f, player.position.z);
+            Vector3 cueAxis = pivotFlat - playerFlat;
+            float cueSlide = Mathf.SmoothStep(0f, 1f, heightBlend);
+            if (cueAxis.sqrMagnitude > 0.0001f && cueSlide > 0f)
+            {
+                Vector3 cueDir = cueAxis.normalized;
+                float maxCueViewDistance = currentDistance;
+                if (cueViewMaxCueDistanceRatio < 1f)
+                {
+                    float limitedDistance = Mathf.Lerp(
+                        currentDistance,
+                        currentDistance * Mathf.Max(0f, cueViewMaxCueDistanceRatio),
+                        cueSlide);
+                    maxCueViewDistance = Mathf.Min(maxCueViewDistance, limitedDistance);
+                }
+                Vector3 cueViewPos = playerFlat + cueDir * maxCueViewDistance;
+                desiredFlat = Vector3.Lerp(desiredFlat, cueViewPos, cueSlide);
+            }
+        }
+        pos = new Vector3(desiredFlat.x, pos.y, desiredFlat.z);
+
+        transform.position = pos;
+
+        // Maintain a slightly lower viewing angle by looking just above the table
+        // centre rather than straight down at it.
+        Vector3 tableFocus = new Vector3(0f, tableTopY + lookAtHeightOffset, 0f);
+        Vector3 lookTarget = tableFocus;
+        if (player != null)
+        {
+            float focusHeight = Mathf.Max(tableTopY + lookAtHeightOffset, player.position.y + Mathf.Max(0f, cueStickHeightClearance));
+            Vector3 playerFocus = new Vector3(player.position.x, focusHeight, player.position.z);
+            lookTarget = Vector3.Lerp(tableFocus, playerFocus, focusBlend);
+        }
+
+        transform.LookAt(lookTarget);
     }
 }
 #endif

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -354,35 +354,17 @@ public class CueCamera : MonoBehaviour
         float clothAnchorHeight = minimumCueHeight;
         float heightScale = Mathf.Lerp(1f, Mathf.Clamp(cueHeightClothScale, 0.1f, 1f), blend);
         height = clothAnchorHeight + (height - clothAnchorHeight) * heightScale;
-
-        // When the cue camera is lowered, blend the height toward the aiming line so the
-        // framing matches a real cue view instead of hovering noticeably above it.
-        if (blend > 0f)
-        {
-            float aimLineHeight = CueBall.position.y + cueBallLookOffset;
-            float desiredAimHeight = Mathf.Max(minimumCueHeight, aimLineHeight);
-            height = Mathf.Lerp(height, desiredAimHeight, blend);
-        }
         float maxRailClamp = railHeight + Mathf.Max(0f, railClearance);
         float cueRailClamp = Mathf.Lerp(maxRailClamp, railHeight, blend);
         cueRailClamp = Mathf.Max(cueRailClamp, railHeight);
         height = Mathf.Max(height, cueRailClamp);
 
-        Vector3 cueFocus = CueBall.position;
-        if (cueSamplePoint.sqrMagnitude > 0.0001f)
-        {
-            // Blend the camera's focal point toward the sampled cue position so the
-            // portrait cue view slides above the stick similar to the snooker setup
-            // while keeping the existing distance and height limits intact.
-            float focusBlend = Mathf.Lerp(0.32f, 0.68f, blend);
-            cueFocus = Vector3.Lerp(CueBall.position, cueSamplePoint, Mathf.Clamp01(focusBlend));
-        }
-
+        Vector3 focus = CueBall.position;
         float minimumHeightBuffer = Mathf.Lerp(minimumHeightAboveFocus, 0f, blend);
-        float minimumHeightOffset = Mathf.Max(minimumHeightBuffer, height - cueFocus.y);
-        Vector3 lookTarget = GetCueAimLookTarget(CueBall.position, cueAimForward);
+        float minimumHeightOffset = Mathf.Max(minimumHeightBuffer, height - focus.y);
+        Vector3 lookTarget = GetCueAimLookTarget(focus, cueAimForward);
 
-        ApplyCameraAt(cueFocus, cueAimForward, distance, height, minimumHeightOffset, lookTarget, cueRailClamp);
+        ApplyCameraAt(focus, cueAimForward, distance, height, minimumHeightOffset, lookTarget, cueRailClamp);
 
         Vector3 flatForward = new Vector3(cueAimForward.x, 0f, cueAimForward.z);
         if (flatForward.sqrMagnitude > 0.0001f)
@@ -896,23 +878,13 @@ public class CueCamera : MonoBehaviour
         float aimLineWeight = Mathf.Clamp01(cueAimLineFocusWeight);
         Vector3 lookPoint = Vector3.Lerp(extendedAim, aimLockedLook, aimLineWeight);
 
-        // Nudge the focus toward the pure aim direction as the camera lowers so the
-        // viewing axis lines up with the aiming guide.
-        if (lowering > 0f)
-        {
-            Vector3 aimAlignedPoint = focus + aimDirection * Mathf.Max(aimDistance + overshoot, 0.01f);
-            aimAlignedPoint = tableBounds.ClosestPoint(aimAlignedPoint);
-            lookPoint = Vector3.Lerp(lookPoint, aimAlignedPoint, lowering);
-        }
-
         float railTop = railHeight + Mathf.Max(0f, railClearance);
         float minimumLookHeight = focus.y + cueBallLookOffset;
         float railLookHeight = Mathf.Max(railTop, aimEnd.y) + cueBallLookOffset;
         float heightBias = Mathf.Clamp01(cueAimHeightFocus);
         float heightBlend = Mathf.Lerp(heightBias, 0.85f, Mathf.Clamp01(lowering));
         float desiredHeight = Mathf.Lerp(minimumLookHeight, railLookHeight, heightBlend);
-        float aimHeight = Mathf.Lerp(desiredHeight, minimumLookHeight, lowering);
-        lookPoint.y = Mathf.Max(aimHeight, minimumLookHeight);
+        lookPoint.y = Mathf.Max(desiredHeight, minimumLookHeight);
 
         return lookPoint;
     }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2290,12 +2290,7 @@ const CAMERA_ABS_MIN_PHI = 0.3;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.18);
 const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.02; // keep orbit camera from dipping below the table surface while allowing a lower tilt
 // Pull the baseline player orbit in so the cue perspective hugs the cloth a bit more, especially on portrait screens.
-// Keep the shared snooker/pool orbit at the same comfortable distance as the
-// previous builds. A mistaken decimal shift (0.135) placed the camera nearly on
-// top of the cloth which made the entire scene render as a dark void. Restoring
-// the 0.85 scale matches the snooker tuning and lets the cue/standing views
-// blend correctly again.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.85;
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.135;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
 const BROADCAST_DISTANCE_MULTIPLIER = 0.36;
@@ -5221,30 +5216,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   const startUserSuggestionRef = useRef(() => {});
   const autoAimRequestRef = useRef(false);
   const aiTelemetryRef = useRef({ key: null, countdown: 0 });
-  const computeRendererQualityPreset = useCallback(() => {
-    if (typeof window === 'undefined') {
-      return { pixelRatio: 1, enableShadows: true };
-    }
-    const width = window.innerWidth || 0;
-    const height = window.innerHeight || width;
-    const shortestEdge = Math.max(1, Math.min(width || 1, height || 1));
-    let pixelCap = 2;
-    if (shortestEdge <= 420) {
-      pixelCap = 1.1;
-    } else if (shortestEdge <= 768) {
-      pixelCap = 1.25;
-    } else if (shortestEdge <= 1024) {
-      pixelCap = 1.5;
-    } else if (width <= 1366) {
-      pixelCap = 1.75;
-    }
-    const deviceRatio = typeof window.devicePixelRatio === 'number'
-      ? window.devicePixelRatio
-      : 1;
-    const pixelRatio = Math.min(deviceRatio, pixelCap);
-    const enableShadows = pixelRatio > 1.3;
-    return { pixelRatio, enableShadows };
-  }, []);
   const [loading, setLoading] = useState(true);
   const [loadingProgress, setLoadingProgress] = useState(0);
   const loadingClearedRef = useRef(false);
@@ -5911,15 +5882,11 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       renderer.outputColorSpace = THREE.SRGBColorSpace;
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.2;
-      const applyRendererQuality = () => {
-        const { pixelRatio, enableShadows } = computeRendererQualityPreset();
-        renderer.setPixelRatio(pixelRatio);
-        renderer.shadowMap.enabled = enableShadows;
-        renderer.shadowMap.type = enableShadows
-          ? THREE.PCFSoftShadowMap
-          : THREE.BasicShadowMap;
-      };
-      applyRendererQuality();
+      const devicePixelRatio = window.devicePixelRatio || 1;
+      const mobilePixelCap = window.innerWidth <= 1366 ? 1.5 : 2;
+      renderer.setPixelRatio(Math.min(mobilePixelCap, devicePixelRatio));
+      renderer.shadowMap.enabled = true;
+      renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       // Ensure the canvas fills the host element so the table is centered and
       // scaled correctly on all view modes.
       renderer.setSize(host.clientWidth, host.clientHeight);
@@ -11133,7 +11100,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
 
       // Resize
         const onResize = () => {
-          applyRendererQuality();
           // Update canvas dimensions when the window size changes so the table
           // remains fully visible.
           renderer.setSize(host.clientWidth, host.clientHeight);
@@ -11220,7 +11186,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         setLoading(false);
         setLoadingProgress(100);
       }
-  }, [computeRendererQualityPreset]);
+  }, []);
 
   useEffect(() => {
     applyFinishRef.current?.(tableFinish);

--- a/webapp/src/pages/Games/simpleOrbitCamera.ts
+++ b/webapp/src/pages/Games/simpleOrbitCamera.ts
@@ -77,7 +77,7 @@ export class MobilePortraitCameraRig {
   private viewHeight: number;
   private tableWidth: number;
   private tableHeight: number;
-  private lastUpdate: number;
+  private lastUpdate = performance.now();
 
   constructor(camera: THREE.PerspectiveCamera, options: CameraOptions = {}) {
     this.camera = camera;
@@ -97,11 +97,6 @@ export class MobilePortraitCameraRig {
     this.tableHeight = 7.2;
     this.camera.up.copy(sharedUp);
     this.camera.lookAt(this.target);
-    const now =
-      typeof performance !== 'undefined' && typeof performance.now === 'function'
-        ? performance.now()
-        : Date.now();
-    this.lastUpdate = now;
   }
 
   setViewport(width: number, height: number) {
@@ -143,13 +138,8 @@ export class MobilePortraitCameraRig {
   }
 
   update(now: number) {
-    const safeNow = Number.isFinite(now)
-      ? now
-      : typeof performance !== 'undefined' && typeof performance.now === 'function'
-        ? performance.now()
-        : Date.now();
-    const dtMs = Math.min(safeNow - this.lastUpdate, MAX_SMOOTH_STEP * 1000);
-    this.lastUpdate = safeNow;
+    const dtMs = Math.min(now - this.lastUpdate, MAX_SMOOTH_STEP * 1000);
+    this.lastUpdate = now;
     const dt = dtMs / 1000;
 
     const fit = computeRFit(


### PR DESCRIPTION
## Summary
- restore the Pool Royale and Snooker front-end code to the Oct 12 09:15 baseline
- reinstate the previous Unity camera controller behaviours used before recent camera tweaks
- revert Three.js renderer configuration to the baseline pixel ratio and shadow settings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eca5d4326883298955f4efdf0b7fe3