### PR TITLE
Restore site to Oct 12 19:09 baseline

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -22,21 +22,21 @@ public class CueCamera : MonoBehaviour
 
     [Header("Cue aim view")]
     // Distance from the cue ball when the camera is fully raised above the cue.
-    public float cueRaisedDistanceFromBall = 0.82f;
+    public float cueRaisedDistanceFromBall = 0.76f;
     // Distance from the cue ball used for the lowest aiming view.  This keeps the
     // camera hovering over the mid–upper portion of the cue rather than slipping
     // all the way back to the plastic end.
-    public float cueLoweredDistanceFromBall = 0.06f;
+    public float cueLoweredDistanceFromBall = 0.045f;
     // Additional pull-in applied to the cue camera so the portrait framing hugs
     // the cloth like a player leaning over the shot.
-    public float cueDistancePullIn = 0.32f;
+    public float cueDistancePullIn = 0.42f;
     // Minimum separation we allow once the pull-in is applied. Prevents the
     // camera from intersecting the cue or cloth when the player drops in tight.
     public float cueMinimumDistance = 0.02f;
     // Height the cue view should reach when the player lifts the camera.
-    public float cueRaisedHeight = 0.82f;
+    public float cueRaisedHeight = 1.04f;
     // Minimum height maintained when the player drops the camera toward the cue.
-    public float cueLoweredHeight = 0.24f;
+    public float cueLoweredHeight = 0.275f;
     // Keep a small safety buffer from the butt of the cue so the camera never
     // retreats past the stick and always looks down the shaft.
     public float cueButtClearance = 0.12f;
@@ -46,12 +46,17 @@ public class CueCamera : MonoBehaviour
     // Keeps the framing over the upper half of the cue rather than drifting to
     // the plastic cap.
     [Range(0.1f, 1f)]
-    public float cueBackFraction = 0.32f;
+    public float cueBackFraction = 0.6f;
     // When the camera is fully lowered we further tighten the clamp so that the
     // framing slides forward along the cue toward the cue ball instead of
     // lingering near the butt.
     [Range(0.05f, 1f)]
-    public float cueLoweredBackFraction = 0.18f;
+    public float cueLoweredBackFraction = 0.5f;
+    // Fraction of the cue that must remain visible between the camera and the
+    // cue ball. Ensures the aiming view stops with a comfortable gap instead of
+    // zooming directly into the ball.
+    [Range(0f, 1f)]
+    public float cueBallGapFraction = 0.4f;
     // Radius of the cue ball so the aiming view can remain above the cloth while
     // gliding toward the shot.
     public float cueBallRadius = 0.028575f;
@@ -69,11 +74,11 @@ public class CueCamera : MonoBehaviour
     // Scale applied to the cue distance when the camera is raised. Values below
     // 1 slide the camera closer to the cloth even before the player lowers it.
     [Range(0.1f, 1f)]
-    public float cueRaisedDistanceScale = 0.9f;
+    public float cueRaisedDistanceScale = 0.82f;
     // Scale applied once the camera is fully lowered toward the cue. Lower
     // values bring the framing tighter to the cue ball and aiming line.
     [Range(0.1f, 1f)]
-    public float cueLoweredDistanceScale = 0.55f;
+    public float cueLoweredDistanceScale = 0.5f;
     // Bias used when lowering the camera to keep it hovering just above the cue
     // instead of drifting upward toward the player's face.
     [Range(0.1f, 1f)]
@@ -307,16 +312,53 @@ public class CueCamera : MonoBehaviour
         float maxDistance = Mathf.Max(minDistance, cueRaisedDistanceFromBall);
 
         Vector3 cueSamplePoint;
-        float baseDistance = ResolveCueAimDistance(blend, cueAimForward, minDistance, maxDistance, out cueSamplePoint);
+        float minimumGapDistance;
+        float raisedBaseDistance = ResolveCueAimDistance(
+            0f,
+            cueAimForward,
+            minDistance,
+            maxDistance,
+            out _,
+            out float raisedGapDistance,
+            out float raisedMaxDistance);
+
+        float baseDistance = ResolveCueAimDistance(
+            blend,
+            cueAimForward,
+            minDistance,
+            maxDistance,
+            out cueSamplePoint,
+            out minimumGapDistance,
+            out float loweredMaxDistance);
+
+        float combinedGapDistance = Mathf.Max(minimumGapDistance, raisedGapDistance);
+        minimumGapDistance = combinedGapDistance;
 
         float pullIn = Mathf.Max(0f, cueDistancePullIn);
         float minPulledDistance = Mathf.Max(minimumDistanceLimit, minDistance - pullIn);
-        float distance = Mathf.Max(baseDistance - pullIn, minPulledDistance);
+        minPulledDistance = Mathf.Max(minPulledDistance, combinedGapDistance);
+
+        float loweredDistance = Mathf.Max(baseDistance - pullIn, minPulledDistance);
+        loweredDistance = Mathf.Max(loweredDistance, combinedGapDistance);
+
+        float raisedDistance = Mathf.Max(raisedBaseDistance - pullIn, minPulledDistance);
+        raisedDistance = Mathf.Max(raisedDistance, combinedGapDistance);
 
         float raisedScale = Mathf.Clamp(cueRaisedDistanceScale, 0.1f, 1f);
         float loweredScale = Mathf.Clamp(cueLoweredDistanceScale, 0.1f, raisedScale);
         float distanceScale = Mathf.Lerp(raisedScale, loweredScale, blend);
-        distance = Mathf.Max(distance * distanceScale, minimumDistanceLimit);
+        float minimumDistanceWithGap = Mathf.Max(minimumDistanceLimit, combinedGapDistance);
+
+        float loweredScaledDistance = Mathf.Max(loweredDistance * distanceScale, minimumDistanceWithGap);
+        float loweredClampMax = Mathf.Max(loweredMaxDistance, minimumDistanceWithGap);
+        loweredScaledDistance = Mathf.Clamp(loweredScaledDistance, minimumDistanceWithGap, loweredClampMax);
+
+        float raisedScaledDistance = Mathf.Max(raisedDistance * raisedScale, minimumDistanceWithGap);
+        float raisedClampMax = Mathf.Min(raisedMaxDistance, loweredClampMax);
+        raisedClampMax = Mathf.Max(raisedClampMax, minimumDistanceWithGap);
+        raisedScaledDistance = Mathf.Clamp(raisedScaledDistance, minimumDistanceWithGap, raisedClampMax);
+
+        float distance = Mathf.Max(loweredScaledDistance, raisedScaledDistance);
 
         if (CueBall != null)
         {
@@ -354,17 +396,45 @@ public class CueCamera : MonoBehaviour
         float clothAnchorHeight = minimumCueHeight;
         float heightScale = Mathf.Lerp(1f, Mathf.Clamp(cueHeightClothScale, 0.1f, 1f), blend);
         height = clothAnchorHeight + (height - clothAnchorHeight) * heightScale;
+
+        // Blend the camera height toward the cue plane when lowering so we stay just
+        // above the stick instead of drifting into a top-down view. This mimics the
+        // way a player brings their head down to the cue in real life.
+        float cuePlane = Mathf.Max(minimumCueHeight, cueSamplePoint.y + Mathf.Max(0f, cueHeightClearance));
+        height = Mathf.Lerp(height, cuePlane, Mathf.SmoothStep(0f, 1f, blend));
+
+        // When the cue camera is lowered, blend the height toward the aiming line so the
+        // framing matches a real cue view instead of hovering noticeably above it.
+        if (blend > 0f)
+        {
+            float aimLineHeight = CueBall.position.y + cueBallLookOffset;
+            float desiredAimHeight = Mathf.Max(minimumCueHeight, aimLineHeight);
+            height = Mathf.Lerp(height, desiredAimHeight, blend);
+        }
         float maxRailClamp = railHeight + Mathf.Max(0f, railClearance);
         float cueRailClamp = Mathf.Lerp(maxRailClamp, railHeight, blend);
         cueRailClamp = Mathf.Max(cueRailClamp, railHeight);
         height = Mathf.Max(height, cueRailClamp);
 
-        Vector3 focus = CueBall.position;
-        float minimumHeightBuffer = Mathf.Lerp(minimumHeightAboveFocus, 0f, blend);
-        float minimumHeightOffset = Mathf.Max(minimumHeightBuffer, height - focus.y);
-        Vector3 lookTarget = GetCueAimLookTarget(focus, cueAimForward);
+        Vector3 cueFocus = CueBall.position;
+        if (cueSamplePoint.sqrMagnitude > 0.0001f)
+        {
+            // Keep roughly forty percent of the cue visible from the cue ball toward the
+            // player's side so the aiming view mirrors the perspective of a player with
+            // their chin on the cue. Raised views still favour the table but never fully
+            // abandon that visibility requirement.
+            float cueVisibility = Mathf.Clamp01(cueBallGapFraction);
+            float raisedFocusBlend = Mathf.Clamp01(Mathf.Lerp(0.2f, 0.35f, cueVisibility));
+            float loweredFocusBlend = Mathf.Max(cueVisibility, 0.5f);
+            float focusBlend = Mathf.Lerp(raisedFocusBlend, loweredFocusBlend, Mathf.Clamp01(blend));
+            cueFocus = Vector3.Lerp(CueBall.position, cueSamplePoint, focusBlend);
+        }
 
-        ApplyCameraAt(focus, cueAimForward, distance, height, minimumHeightOffset, lookTarget, cueRailClamp);
+        float minimumHeightBuffer = Mathf.Lerp(minimumHeightAboveFocus, 0f, blend);
+        float minimumHeightOffset = Mathf.Max(minimumHeightBuffer, height - cueFocus.y);
+        Vector3 lookTarget = GetCueAimLookTarget(CueBall.position, cueAimForward);
+
+        ApplyCameraAt(cueFocus, cueAimForward, distance, height, minimumHeightOffset, lookTarget, cueRailClamp);
 
         Vector3 flatForward = new Vector3(cueAimForward.x, 0f, cueAimForward.z);
         if (flatForward.sqrMagnitude > 0.0001f)
@@ -411,7 +481,9 @@ public class CueCamera : MonoBehaviour
         Vector3 forward,
         float minDistance,
         float maxDistance,
-        out Vector3 cueSamplePoint)
+        out Vector3 cueSamplePoint,
+        out float minimumGapDistance,
+        out float maxAllowedDistance)
     {
         float fractionBlend = Mathf.Clamp01(blend);
         float upperFraction = Mathf.Clamp01(cueBackFraction);
@@ -421,8 +493,12 @@ public class CueCamera : MonoBehaviour
             loweredFraction = upperFraction;
         }
 
+        float midpointWeight = Mathf.SmoothStep(0f, 1f, fractionBlend);
+
         float distance = Mathf.Lerp(maxDistance, minDistance, fractionBlend);
+        maxAllowedDistance = Mathf.Max(0f, maxDistance);
         cueSamplePoint = CueBall != null ? CueBall.position : Vector3.zero;
+        minimumGapDistance = Mathf.Max(0f, minDistance);
 
         if (CueBall == null)
         {
@@ -430,6 +506,7 @@ public class CueCamera : MonoBehaviour
         }
 
         Vector3 cuePoint = CueBall.position;
+        float gapFraction = Mathf.Clamp01(cueBallGapFraction);
 
         if (CueButtReference != null)
         {
@@ -444,21 +521,21 @@ public class CueCamera : MonoBehaviour
                 limitDistance = Mathf.Clamp(limitDistance, 0f, usableLength);
 
                 float minClamp = usableLength >= minDistance ? Mathf.Min(minDistance, limitDistance) : 0f;
-                float maxClamp = Mathf.Max(limitDistance, minClamp);
-                distance = Mathf.Clamp(distance, minClamp, maxClamp);
-                if (limitDistance < minClamp)
-                {
-                    distance = limitDistance;
-                }
-                else
-                {
-                    distance = Mathf.Min(distance, limitDistance);
-                }
+                float gapDistance = Mathf.Clamp(projectedLength * gapFraction, 0f, limitDistance);
+                minimumGapDistance = Mathf.Max(minClamp, gapDistance);
+                float maxClamp = Mathf.Max(limitDistance, minimumGapDistance);
+                distance = Mathf.Clamp(distance, minimumGapDistance, maxClamp);
+
+                float midpointDistance = Mathf.Clamp(usableLength * 0.5f, minimumGapDistance, usableLength);
+                distance = Mathf.Lerp(distance, midpointDistance, midpointWeight);
+                distance = Mathf.Clamp(distance, minimumGapDistance, maxClamp);
+                distance = Mathf.Min(distance, limitDistance);
 
                 float along = projectedLength > 0.0001f ? Mathf.Clamp01(distance / projectedLength) : 0f;
                 cuePoint = Vector3.Lerp(CueBall.position, CueButtReference.position, along);
 
                 cueSamplePoint = cuePoint;
+                maxAllowedDistance = Mathf.Max(usableLength, 0f);
                 return Mathf.Max(distance, 0f);
             }
         }
@@ -468,19 +545,20 @@ public class CueCamera : MonoBehaviour
         float fallbackLimit = Mathf.Lerp(fallbackLength, fallbackLength * fallbackFraction, fractionBlend);
         fallbackLimit = Mathf.Clamp(fallbackLimit, 0f, fallbackLength);
         float fallbackMin = Mathf.Min(minDistance, fallbackLimit);
-        distance = Mathf.Clamp(distance, fallbackMin, Mathf.Max(fallbackLimit, fallbackMin));
-        if (fallbackLimit < fallbackMin)
-        {
-            distance = fallbackLimit;
-        }
-        else
-        {
-            distance = Mathf.Min(distance, fallbackLimit);
-        }
+        float fallbackGap = Mathf.Clamp(fallbackLength * gapFraction, 0f, fallbackLimit);
+        minimumGapDistance = Mathf.Max(fallbackMin, fallbackGap);
+        float fallbackClampMax = Mathf.Max(fallbackLimit, minimumGapDistance);
+        distance = Mathf.Clamp(distance, minimumGapDistance, fallbackClampMax);
+
+        float fallbackMidpoint = Mathf.Clamp(fallbackLimit * 0.5f, minimumGapDistance, fallbackLimit);
+        distance = Mathf.Lerp(distance, fallbackMidpoint, midpointWeight);
+        distance = Mathf.Clamp(distance, minimumGapDistance, fallbackClampMax);
+        distance = Mathf.Min(distance, fallbackLimit);
 
         cuePoint = CueBall.position - forward * Mathf.Max(distance, 0f);
         cuePoint.y = CueBall.position.y;
         cueSamplePoint = cuePoint;
+        maxAllowedDistance = Mathf.Max(fallbackLimit, 0f);
 
         return Mathf.Max(distance, 0f);
     }
@@ -876,15 +954,43 @@ public class CueCamera : MonoBehaviour
         Vector3 aimLockedLook = focus + aimDirection * lookDistance;
 
         float aimLineWeight = Mathf.Clamp01(cueAimLineFocusWeight);
+        float minimumLookHeight = focus.y + cueBallLookOffset;
         Vector3 lookPoint = Vector3.Lerp(extendedAim, aimLockedLook, aimLineWeight);
 
+        // Nudge the focus toward the pure aim direction as the camera lowers so the
+        // viewing axis lines up with the aiming guide.
+        if (lowering > 0f)
+        {
+            Vector3 aimAlignedPoint = focus + aimDirection * Mathf.Max(aimDistance + overshoot, 0.01f);
+            aimAlignedPoint = tableBounds.ClosestPoint(aimAlignedPoint);
+            aimAlignedPoint.y = Mathf.Max(aimAlignedPoint.y, minimumLookHeight);
+            lookPoint = Vector3.Lerp(lookPoint, aimAlignedPoint, lowering);
+        }
+
+        if (lowering > 0f)
+        {
+            // When the cue camera is dropped into the player's chin position we bias the
+            // look target along the aiming line so the view stays level with the cue ball
+            // rather than tilting down from above. This keeps the cue ball, object ball,
+            // and cue visible together without introducing a zoom effect.
+            float cueVisibility = Mathf.Clamp01(cueBallGapFraction);
+            float forwardFraction = Mathf.Lerp(1f - cueVisibility, 1f - cueVisibility * 0.5f, lowering);
+            float minForwardDistance = aimDistance * (1f - cueVisibility);
+            float forwardDistance = Mathf.Clamp(aimDistance * forwardFraction, minForwardDistance, aimDistance);
+            forwardDistance = Mathf.Max(forwardDistance, cueBallRadius * 2f);
+            Vector3 chinTarget = focus + aimDirection * forwardDistance;
+            chinTarget = tableBounds.ClosestPoint(chinTarget);
+            chinTarget.y = Mathf.Max(chinTarget.y, minimumLookHeight);
+            lookPoint = Vector3.Lerp(lookPoint, chinTarget, Mathf.SmoothStep(0f, 1f, lowering));
+        }
+
         float railTop = railHeight + Mathf.Max(0f, railClearance);
-        float minimumLookHeight = focus.y + cueBallLookOffset;
         float railLookHeight = Mathf.Max(railTop, aimEnd.y) + cueBallLookOffset;
         float heightBias = Mathf.Clamp01(cueAimHeightFocus);
         float heightBlend = Mathf.Lerp(heightBias, 0.85f, Mathf.Clamp01(lowering));
         float desiredHeight = Mathf.Lerp(minimumLookHeight, railLookHeight, heightBlend);
-        lookPoint.y = Mathf.Max(desiredHeight, minimumLookHeight);
+        float aimHeight = Mathf.Lerp(desiredHeight, minimumLookHeight, lowering);
+        lookPoint.y = Mathf.Max(aimHeight, minimumLookHeight);
 
         return lookPoint;
     }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -35,7 +35,6 @@ import {
   disposeMaterialWithWood,
   hslToHexNumber
 } from '../../utils/woodMaterials.js';
-import { MobilePortraitCameraRig, rad } from './simpleOrbitCamera';
 
 const LEGACY_SRGB_ENCODING = Reflect.get(THREE, 'sRGBEncoding');
 
@@ -2283,21 +2282,21 @@ const STANDING_VIEW_PHI = 0.92;
 // Lower the cue shot tilt so the camera can skim the rail line while staying just
 // above the cloth. Keeping the delta small ensures we don't clip through the
 // table surface when blending between views.
-const CUE_SHOT_PHI = Math.PI / 2 - 0.07;
-const STANDING_VIEW_MARGIN = 0.0024;
+const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
+const STANDING_VIEW_MARGIN = 0.0035;
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.3;
-const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.18);
-const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.02; // keep orbit camera from dipping below the table surface while allowing a lower tilt
+const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.26);
+const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.01; // allow the cue view to settle right on the aiming line while keeping a safety margin
 // Pull the baseline player orbit in so the cue perspective hugs the cloth a bit more, especially on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.135;
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.15;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
-const BROADCAST_DISTANCE_MULTIPLIER = 0.36;
+const BROADCAST_DISTANCE_MULTIPLIER = 0.48;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
-const STANDING_VIEW_MARGIN_LANDSCAPE = 1.006;
-const STANDING_VIEW_MARGIN_PORTRAIT = 1.004;
-const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
+const STANDING_VIEW_MARGIN_LANDSCAPE = 1.02;
+const STANDING_VIEW_MARGIN_PORTRAIT = 1.0;
+const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.04;
 const BROADCAST_MARGIN_WIDTH = BALL_R * 6;
 const BROADCAST_MARGIN_LENGTH = BALL_R * 6;
 const CAMERA = {
@@ -2310,8 +2309,7 @@ const CAMERA = {
   // keep the camera slightly above the horizontal plane but allow a lower sweep
   maxPhi: CAMERA_MAX_PHI
 };
-const CAMERA_CUSHION_CLEARANCE = TABLE.THICK * 0.92; // keep standing orbit safely above cushion lip and align with pocket cam height
-const CUE_VIEW_CUSHION_CLEARANCE = CAMERA_CUSHION_CLEARANCE; // match the snooker cue clearance so transitions stay consistent
+const CAMERA_CUSHION_CLEARANCE = TABLE.THICK * 0.6; // keep standing orbit safely above cushion lip and align with pocket cam height
 const STANDING_VIEW = Object.freeze({
   phi: STANDING_VIEW_PHI,
   margin: STANDING_VIEW_MARGIN
@@ -2329,26 +2327,15 @@ const BREAK_VIEW = Object.freeze({
   radius: CAMERA.minR, // start the intro framing closer to the table surface
   phi: CAMERA.maxPhi - 0.01
 });
-const CAMERA_RAIL_SAFETY = 0.02;
-const CUE_VIEW_RADIUS_RATIO = 0.085;
-const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.34;
+const CAMERA_RAIL_SAFETY = 0.0075;
+const CUE_VIEW_RADIUS_RATIO = 0.28; // keep the lowered camera nearer the cue ball so we only travel halfway down the stick
+const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.74; // allow a closer orbit while still revealing the cue midpoint
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
-  STANDING_VIEW_PHI + 0.5
+  STANDING_VIEW_PHI + 0.28
 );
-const CUE_VIEW_PHI_LIFT = 0.08;
-const CUE_VIEW_TARGET_PHI = Math.min(
-  CAMERA.maxPhi,
-  CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5
-);
-// Mirror the snooker cue framing so both games share the same up-close feel around the cloth.
-const CUE_VIEW_RAIL_CLEARANCE = BALL_R * 0.1;
-// Lift the cue-view camera so the cue stick and cue ball stay framed together while aiming.
-const CUE_VIEW_ABOVE_CUE = BALL_R * 0.72;
-const CUE_VIEW_EXTRA_HEIGHT = BALL_R * 0.24;
-const CUE_VIEW_BACK_MIN_RATIO = 0.26;
-const CUE_VIEW_BACK_RATIO = 0.34;
-const CUE_VIEW_BASE_CUE_LENGTH = (BALL_R / 0.0525) * 1.5 * CUE_LENGTH_MULTIPLIER;
+const CUE_VIEW_PHI_LIFT = 0.035; // hover a touch higher so the camera remains above the cue stick
+const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,
   CAMERA_MAX_PHI - 0.02
@@ -2356,10 +2343,10 @@ const CAMERA_RAIL_APPROACH_PHI = Math.min(
 const CAMERA_MIN_HORIZONTAL =
   ((Math.max(PLAY_W, PLAY_H) / 2 + SIDE_RAIL_INNER_THICKNESS) * WORLD_SCALE) +
   CAMERA_RAIL_SAFETY;
-const CAMERA_DOWNWARD_PULL = 1.9;
-const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.29;
+const CAMERA_DOWNWARD_PULL = 1.6;
+const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.34;
 const CUE_VIEW_AIM_SLOW_FACTOR = 0.35; // slow pointer rotation while blended toward cue view for finer aiming
-const AIM_CAMERA_LOCK_FACTOR = 1; // keep the aim direction locked to the active camera heading
+const AIM_CAMERA_LOCK_FACTOR = 0.2; // match the snooker aim smoothing so the cue settles naturally
 const POCKET_VIEW_SMOOTH_TIME = 0.24; // seconds to ease pocket camera transitions
 const POCKET_CAMERA_FOV = STANDING_VIEW_FOV;
 const LONG_SHOT_DISTANCE = PLAY_H * 0.5;
@@ -2424,9 +2411,6 @@ const TMP_VEC2_LIMIT = new THREE.Vector2();
 const TMP_VEC2_AXIS = new THREE.Vector2();
 const TMP_VEC2_VIEW = new THREE.Vector2();
 const TMP_VEC3_A = new THREE.Vector3();
-const TMP_VEC3_B = new THREE.Vector3();
-const TMP_VEC3_CAMERA = new THREE.Vector3();
-const TMP_VEC3_DIR = new THREE.Vector3();
 const TMP_VEC3_BUTT = new THREE.Vector3();
 const TMP_VEC3_CHALK = new THREE.Vector3();
 const TMP_VEC3_CHALK_DELTA = new THREE.Vector3();
@@ -2499,104 +2483,6 @@ const computeCueViewVector = (cueBall, camera) => {
   TMP_VEC2_VIEW.set(cx, cz);
   if (TMP_VEC2_VIEW.lengthSq() < 1e-8) return null;
   return TMP_VEC2_VIEW.clone().normalize();
-};
-
-const computeCueCameraMinHeight = (worldScaleFactor, cushionHeight = TABLE.THICK) => {
-  const cushion = Number.isFinite(cushionHeight) ? cushionHeight : TABLE.THICK;
-  const railHeightLocal = TABLE_Y + cushion;
-  const railHeightWorld = railHeightLocal * worldScaleFactor;
-  const cueHeightWorld = CUE_Y * worldScaleFactor;
-  const railClearanceWorld = CUE_VIEW_RAIL_CLEARANCE * worldScaleFactor;
-  const aboveCueWorld = CUE_VIEW_ABOVE_CUE * worldScaleFactor;
-  return Math.max(railHeightWorld + railClearanceWorld, cueHeightWorld + aboveCueWorld);
-};
-
-const computeActionCameraMidHeight = (
-  worldScaleFactor,
-  heightBaseLocal = TABLE_Y + TABLE.THICK,
-  cushionHeight = TABLE.THICK
-) => {
-  const scale = Number.isFinite(worldScaleFactor) && worldScaleFactor > 0 ? worldScaleFactor : 1;
-  const tableTopWorld = heightBaseLocal * scale;
-  const highestWorld = Math.max(
-    computeCueCameraMinHeight(scale, cushionHeight),
-    tableTopWorld
-  );
-  const midpointWorld = (tableTopWorld + highestWorld) * 0.5;
-  return midpointWorld / scale;
-};
-
-const computeAimFocusTarget = (cueBall, aimDir) => {
-  if (!cueBall?.pos || !aimDir) return null;
-  const dir = new THREE.Vector2(aimDir.x ?? 0, aimDir.y ?? 0);
-  if (dir.lengthSq() < 1e-6) return null;
-  dir.normalize();
-  const focusDistance = Math.max(
-    BALL_R * 32,
-    Math.min(LONG_SHOT_DISTANCE, PLAY_H * 0.48)
-  );
-  return new THREE.Vector3(
-    THREE.MathUtils.clamp(
-      cueBall.pos.x + dir.x * focusDistance,
-      -PLAY_W / 2,
-      PLAY_W / 2
-    ),
-    BALL_CENTER_Y,
-    THREE.MathUtils.clamp(
-      cueBall.pos.y + dir.y * focusDistance,
-      -PLAY_H / 2,
-      PLAY_H / 2
-    )
-  );
-};
-
-const computeCueAimCameraOffset = ({
-  cueBall,
-  aimDir,
-  focusWorld,
-  worldScaleFactor,
-  cushionHeight,
-  orbitOffset
-}) => {
-  if (!cueBall || !aimDir || !focusWorld) return null;
-  const aimX = Number.isFinite(aimDir.x) ? aimDir.x : 0;
-  const aimY = Number.isFinite(aimDir.y) ? aimDir.y : 0;
-  TMP_VEC3_DIR.set(-aimX, 0, -aimY);
-  if (TMP_VEC3_DIR.lengthSq() < 1e-6) return null;
-  TMP_VEC3_DIR.normalize();
-  const cueLengthWorld = CUE_VIEW_BASE_CUE_LENGTH * worldScaleFactor;
-  const tipGapWorld = CUE_TIP_GAP * worldScaleFactor;
-  const minBackWorld = Math.max(
-    cueLengthWorld * CUE_VIEW_BACK_MIN_RATIO,
-    BALL_R * 10 * worldScaleFactor
-  );
-  const maxBackWorld = Math.max(
-    cueLengthWorld + tipGapWorld - BALL_R * 2.2 * worldScaleFactor,
-    minBackWorld
-  );
-  const targetBackWorld = THREE.MathUtils.clamp(
-    cueLengthWorld * CUE_VIEW_BACK_RATIO,
-    minBackWorld,
-    maxBackWorld
-  );
-  TMP_VEC3_B.copy(TMP_VEC3_DIR).multiplyScalar(targetBackWorld);
-  const cueBallWorldY = focusWorld.y;
-  const minCameraY = computeCueCameraMinHeight(worldScaleFactor, cushionHeight);
-  const desiredY = Math.max(
-    minCameraY,
-    cueBallWorldY + CUE_VIEW_EXTRA_HEIGHT * worldScaleFactor
-  );
-  TMP_VEC3_B.y = desiredY - cueBallWorldY;
-  if (orbitOffset) {
-    const orbitHorizontal = Math.hypot(orbitOffset.x, orbitOffset.z);
-    const cueHorizontal = Math.hypot(TMP_VEC3_B.x, TMP_VEC3_B.z);
-    if (cueHorizontal > orbitHorizontal && orbitHorizontal > 1e-3) {
-      const scale = orbitHorizontal / cueHorizontal;
-      TMP_VEC3_B.x *= scale;
-      TMP_VEC3_B.z *= scale;
-    }
-  }
-  return TMP_VEC3_B.clone();
 };
 
 const computeShortRailBroadcastDistance = (camera) => {
@@ -6803,13 +6689,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         CAMERA.near,
         CAMERA.far
       );
-      const mobileCameraRig = new MobilePortraitCameraRig(camera, {
-        theta: rad(35),
-        phi: Math.PI,
-        radius: fitRadius(camera, 1.6)
-      });
-      mobileCameraRig.setViewport(host.clientWidth, host.clientHeight);
-      mobileCameraRigRef.current = mobileCameraRig;
+      mobileCameraRigRef.current = null;
         const standingPhi = THREE.MathUtils.clamp(
           STANDING_VIEW.phi,
           CAMERA.minPhi,
@@ -6940,15 +6820,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           return clamp(value, min, maxRadius);
         };
 
-        const getCameraClearance = (blend = cameraBlendRef.current ?? 1) => {
-          const normalized = THREE.MathUtils.clamp(blend ?? 1, 0, 1);
-          return THREE.MathUtils.lerp(
-            CUE_VIEW_CUSHION_CLEARANCE,
-            CAMERA_CUSHION_CLEARANCE,
-            normalized
-          );
-        };
-
         const syncBlendToSpherical = () => {
           const bounds = cameraBoundsRef.current;
           if (!bounds) return;
@@ -6997,7 +6868,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           const cushionHeight = cushionHeightRef.current ?? TABLE.THICK;
           const minHeightFromTarget = Math.max(
             TABLE.THICK,
-            cushionHeight + getCameraClearance(blend)
+            cushionHeight + CAMERA_CUSHION_CLEARANCE
           );
           const phiRailLimit = Math.acos(
             THREE.MathUtils.clamp(minHeightFromTarget / Math.max(radius, 1e-3), -1, 1)
@@ -7038,6 +6909,15 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           }
           sph.phi = clampedPhi;
           sph.radius = clampOrbitRadius(finalRadius, cueMinRadius);
+          if (cue?.active && !shooting) {
+            const aimFocus =
+              blend < 0.999
+                ? computeAimFocusTarget(cue, aimDirRef.current)
+                : null;
+            aimFocusRef.current = aimFocus ? aimFocus.clone() : null;
+          } else {
+            aimFocusRef.current = null;
+          }
           syncBlendToSpherical();
         };
 
@@ -7096,31 +6976,28 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           );
         };
 
-        const updateCamera = () => {
-          const mobileRig = mobileCameraRigRef.current;
-          if (
-            mobileRig &&
-            !topViewRef.current &&
-            !(cueGalleryStateRef.current?.active ?? false) &&
-            !(activeShotView && activeShotView.mode === 'action') &&
-            !pocketCameraStateRef.current
-          ) {
-            const now = performance.now();
-            lastCameraTickRef.current = now;
-            mobileRig.setViewport(host.clientWidth, host.clientHeight);
-            mobileRig.update(now);
-            const state = mobileRig.getState();
-            const currentSph = sphRef.current;
-            if (currentSph) {
-              currentSph.radius = state.radius;
-              currentSph.theta = state.phi;
-              currentSph.phi = Math.max(1e-3, Math.PI / 2 - state.theta);
-            }
-            camera.up.set(0, 1, 0);
-            camera.lookAt(0, 0, 0);
-            activeRenderCameraRef.current = camera;
-            return camera;
+        const clampCameraAboveRails = (focusTarget, spherical) => {
+          if (!focusTarget) return false;
+          const minRailWorldY = (TABLE_Y + TABLE_RAIL_TOP_Y) * worldScaleFactor;
+          const minOffsetY = minRailWorldY - focusTarget.y;
+          if (!Number.isFinite(minOffsetY)) return false;
+          TMP_VEC3_A.copy(camera.position).sub(focusTarget);
+          if (TMP_VEC3_A.y >= minOffsetY - 1e-4) return false;
+          TMP_VEC3_A.y = minOffsetY;
+          const horizontalSq = TMP_VEC3_A.x * TMP_VEC3_A.x + TMP_VEC3_A.z * TMP_VEC3_A.z;
+          const newRadius = Math.sqrt(horizontalSq + TMP_VEC3_A.y * TMP_VEC3_A.y);
+          const newPhi = Math.acos(
+            THREE.MathUtils.clamp(TMP_VEC3_A.y / Math.max(newRadius, 1e-6), -1, 1)
+          );
+          camera.position.copy(focusTarget).add(TMP_VEC3_A);
+          if (spherical) {
+            spherical.radius = newRadius;
+            spherical.phi = THREE.MathUtils.clamp(newPhi, CAMERA.minPhi, CAMERA.maxPhi);
           }
+          return true;
+        };
+
+        const updateCamera = () => {
           let renderCamera = camera;
           let lookTarget = null;
           let broadcastArgs = {
@@ -7173,6 +7050,9 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
               worldScaleFactor
             );
             camera.position.set(lookTarget.x, sph.radius, lookTarget.z);
+            if (clampCameraAboveRails(lookTarget, sph)) {
+              syncBlendToSpherical();
+            }
             camera.lookAt(lookTarget);
             renderCamera = camera;
             broadcastArgs.focusWorld =
@@ -7244,12 +7124,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                 }
               }
               const heightBase = TABLE_Y + TABLE.THICK;
-              const cushionHeight = cushionHeightRef.current ?? TABLE.THICK;
-              const actionBaseHeight = computeActionCameraMidHeight(
-                worldScaleFactor,
-                heightBase,
-                cushionHeight
-              );
               if (activeShotView.stage === 'pair') {
                 const targetBall =
                   activeShotView.targetId != null
@@ -7299,7 +7173,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   const desiredDistance = baseDistance + longShotPullback;
                   const desired = new THREE.Vector3(
                     0,
-                    actionBaseHeight + ACTION_CAM.heightOffset + heightLift,
+                    heightBase + ACTION_CAM.heightOffset + heightLift,
                     railDir * desiredDistance
                   );
                   const lookAnchor = anchor.clone();
@@ -7334,7 +7208,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   );
                   const desired = new THREE.Vector3(
                     railDir * SIDE_RAIL_CAMERA_DISTANCE,
-                    actionBaseHeight + ACTION_CAM.heightOffset,
+                    heightBase + ACTION_CAM.heightOffset,
                     baseZ
                   );
                   const lookAnchor = anchor.clone();
@@ -7387,7 +7261,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   const desiredDistance = baseDistance + longShotPullback;
                   const desired = new THREE.Vector3(
                     0,
-                    actionBaseHeight + ACTION_CAM.followHeightOffset + heightLift,
+                    heightBase + ACTION_CAM.followHeightOffset + heightLift,
                     railDir * desiredDistance
                   );
                   const lookAnchor = anchor.clone();
@@ -7422,7 +7296,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   );
                   const desired = new THREE.Vector3(
                     railDir * SIDE_RAIL_CAMERA_DISTANCE,
-                    actionBaseHeight + ACTION_CAM.followHeightOffset,
+                    heightBase + ACTION_CAM.followHeightOffset,
                     baseZ
                   );
                   const lookAnchor = anchor.clone();
@@ -7695,14 +7569,8 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             ) {
               focusTarget = aimFocus.clone();
             } else if (cue?.active && !shooting) {
-              const aimFocus = computeAimFocusTarget(cue, aimDirRef.current);
-              if (aimFocus) {
-                aimFocusRef.current = aimFocus.clone();
-                focusTarget = aimFocus;
-              } else {
-                aimFocusRef.current = null;
-                focusTarget = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
-              }
+              aimFocusRef.current = null;
+              focusTarget = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
             } else {
               aimFocusRef.current = null;
               const store = ensureOrbitFocus();
@@ -7725,48 +7593,11 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             focusTarget.multiplyScalar(worldScaleFactor);
             lookTarget = focusTarget;
             TMP_SPH.copy(sph);
-            TMP_VEC3_A.setFromSpherical(TMP_SPH);
-            let finalOffset = TMP_VEC3_A;
-            const cueBlend = THREE.MathUtils.clamp(
-              cameraBlendRef.current ?? 1,
-              0,
-              1
-            );
-            const cueWeight = Math.pow(1 - cueBlend, 0.85);
-            if (
-              cueWeight > 1e-4 &&
-              cue?.active &&
-              !shooting &&
-              aimDirRef.current &&
-              Number.isFinite(aimDirRef.current.x) &&
-              Number.isFinite(aimDirRef.current.y)
-            ) {
-              TMP_VEC2_A.copy(aimDirRef.current);
-              if (TMP_VEC2_A.lengthSq() > 1e-6) {
-                TMP_VEC2_A.normalize();
-                const cueOffset = computeCueAimCameraOffset({
-                  cueBall: cue,
-                  aimDir: TMP_VEC2_A,
-                  focusWorld: lookTarget,
-                  worldScaleFactor,
-                  cushionHeight: cushionHeightRef.current ?? TABLE.THICK,
-                  orbitOffset: TMP_VEC3_A
-                });
-                if (cueOffset) {
-                  TMP_VEC3_B.copy(TMP_VEC3_A).lerp(cueOffset, cueWeight);
-                  finalOffset = TMP_VEC3_B;
-                }
-              }
+            camera.position.setFromSpherical(TMP_SPH).add(lookTarget);
+            if (clampCameraAboveRails(lookTarget, sph)) {
+              TMP_SPH.copy(sph);
+              syncBlendToSpherical();
             }
-            TMP_VEC3_CAMERA.copy(lookTarget).add(finalOffset);
-            const minCameraHeight = computeCueCameraMinHeight(
-              worldScaleFactor,
-              cushionHeightRef.current ?? TABLE.THICK
-            );
-            if (TMP_VEC3_CAMERA.y < minCameraHeight) {
-              TMP_VEC3_CAMERA.y = minCameraHeight;
-            }
-            camera.position.copy(TMP_VEC3_CAMERA);
             camera.lookAt(lookTarget);
             renderCamera = camera;
             broadcastArgs.focusWorld =
@@ -7868,7 +7699,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           const theta = orbit.theta ?? sph.theta;
           const cushionLimit = Math.max(
             TABLE.THICK * 0.5,
-            (cushionHeightRef.current ?? TABLE.THICK) + getCameraClearance()
+            (cushionHeightRef.current ?? TABLE.THICK) + CAMERA_CUSHION_CLEARANCE
           );
           const phiCap = Math.acos(
             THREE.MathUtils.clamp(cushionLimit / radius, -1, 1)
@@ -8180,7 +8011,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           orbitRadiusLimitRef.current = standingRadius;
           const cushionLimit = Math.max(
             TABLE.THICK * 0.5,
-            (cushionHeightRef.current ?? TABLE.THICK) + getCameraClearance()
+            (cushionHeightRef.current ?? TABLE.THICK) + CAMERA_CUSHION_CLEARANCE
           );
           const phiCap = Math.acos(
             THREE.MathUtils.clamp(cushionLimit / sph.radius, -1, 1)
@@ -9364,29 +9195,14 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       let potted = [];
       let firstHit = null;
 
-      const alignStandingCameraToAim = (cueBall, aimDir) => {
-        if (!cueBall || !aimDir) return;
+      const computeAimFocusTarget = (cueBall, aimDir) => {
+        if (!cueBall || !aimDir) return null;
         const dir = aimDir.clone();
-        if (dir.lengthSq() < 1e-6) return;
+        if (dir.lengthSq() < 1e-6) return null;
         dir.normalize();
-        const sph = sphRef.current;
-        if (!sph) return;
-        const standingBounds = cameraBoundsRef.current?.standing;
-        if (standingBounds) {
-          sph.radius = clampOrbitRadius(standingBounds.radius);
-          sph.phi = THREE.MathUtils.clamp(
-            standingBounds.phi,
-            CAMERA.minPhi,
-            CAMERA.maxPhi
-          );
-        }
-        const aimTheta = Math.atan2(dir.x, dir.y) + Math.PI;
-        sph.theta = aimTheta;
-        syncBlendToSpherical();
-        const focusStore = ensureOrbitFocus();
         const focusDistance = Math.max(
-          BALL_R * 28,
-          Math.min(LONG_SHOT_DISTANCE, PLAY_H * 0.5)
+          BALL_R * 32,
+          Math.min(LONG_SHOT_DISTANCE, PLAY_H * 0.55)
         );
         const tableHalfWidth = PLAY_W / 2;
         const tableHalfLength = PLAY_H / 2;
@@ -9422,11 +9238,36 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           limitedDistance = Math.max(limitedDistance, minimum);
           limitedDistance = Math.min(limitedDistance, maxDistance);
         }
-        const focusTarget = new THREE.Vector3(
+        return new THREE.Vector3(
           originX + dir.x * limitedDistance,
           BALL_CENTER_Y,
           originZ + dir.y * limitedDistance
         );
+      };
+
+      const alignStandingCameraToAim = (cueBall, aimDir) => {
+        if (!cueBall || !aimDir) return;
+        const dir = aimDir.clone();
+        if (dir.lengthSq() < 1e-6) return;
+        dir.normalize();
+        const sph = sphRef.current;
+        if (!sph) return;
+        const standingBounds = cameraBoundsRef.current?.standing;
+        if (standingBounds) {
+          sph.radius = clampOrbitRadius(standingBounds.radius);
+          sph.phi = THREE.MathUtils.clamp(
+            standingBounds.phi,
+            CAMERA.minPhi,
+            CAMERA.maxPhi
+          );
+        }
+        const aimTheta = Math.atan2(dir.x, dir.y) + Math.PI;
+        sph.theta = aimTheta;
+        syncBlendToSpherical();
+        const focusStore = ensureOrbitFocus();
+        const focusTarget = computeAimFocusTarget(cueBall, dir);
+        if (!focusTarget) return;
+        aimFocusRef.current = focusTarget.clone();
         focusStore.ballId = cueBall.id ?? null;
         focusStore.target.copy(focusTarget);
         lastCameraTargetRef.current.copy(

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -2338,20 +2338,20 @@ function applySnookerScaling({
 // Kamera: ruaj kënd komod që mos shtrihet poshtë cloth-it, por lejo pak më shumë lartësi kur ngrihet
 const STANDING_VIEW_PHI = 0.92;
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
-const STANDING_VIEW_MARGIN = 0.0024;
+const STANDING_VIEW_MARGIN = 0.0035;
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.3;
-const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.18);
-const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.24; // keep orbit camera from dipping below the table surface
+const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.26);
+const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.01; // allow the cue view to settle right on the aiming line while keeping a safety margin
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.085;
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.15;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant
-const BROADCAST_DISTANCE_MULTIPLIER = 0.36;
+const BROADCAST_DISTANCE_MULTIPLIER = 0.48;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
-const STANDING_VIEW_MARGIN_LANDSCAPE = 1.006;
-const STANDING_VIEW_MARGIN_PORTRAIT = 1.004;
-const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
+const STANDING_VIEW_MARGIN_LANDSCAPE = 1.02;
+const STANDING_VIEW_MARGIN_PORTRAIT = 1.0;
+const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.04;
 const CAMERA = {
   fov: STANDING_VIEW_FOV,
   near: 0.04,
@@ -2380,14 +2380,14 @@ const BREAK_VIEW = Object.freeze({
   radius: CAMERA.minR, // start the intro framing closer to the table surface
   phi: CAMERA.maxPhi - 0.01
 });
-const CAMERA_RAIL_SAFETY = 0.006;
-const CUE_VIEW_RADIUS_RATIO = 0.085;
-const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.35;
+const CAMERA_RAIL_SAFETY = 0.0075;
+const CUE_VIEW_RADIUS_RATIO = 0.28; // keep the lowered camera nearer the cue ball so we only travel halfway down the stick
+const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.74; // allow a closer orbit while still revealing the cue midpoint
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
-  STANDING_VIEW_PHI + 0.22
+  STANDING_VIEW_PHI + 0.28
 );
-const CUE_VIEW_PHI_LIFT = 0.08;
+const CUE_VIEW_PHI_LIFT = 0.035; // hover a touch higher so the camera remains above the cue stick
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,
@@ -2396,8 +2396,8 @@ const CAMERA_RAIL_APPROACH_PHI = Math.min(
 const CAMERA_MIN_HORIZONTAL =
   ((Math.max(PLAY_W, PLAY_H) / 2 + SIDE_RAIL_INNER_THICKNESS) * WORLD_SCALE) +
   CAMERA_RAIL_SAFETY;
-const CAMERA_DOWNWARD_PULL = 1.9;
-const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.29;
+const CAMERA_DOWNWARD_PULL = 1.6;
+const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.34;
 const CUE_VIEW_AIM_SLOW_FACTOR = 0.35; // slow pointer rotation while blended toward cue view for finer aiming
 const POCKET_VIEW_SMOOTH_TIME = 0.24; // seconds to ease pocket camera transitions
 const POCKET_CAMERA_FOV = STANDING_VIEW_FOV;
@@ -6819,6 +6819,15 @@ function SnookerGame() {
           }
           sph.phi = clampedPhi;
           sph.radius = clampOrbitRadius(finalRadius, cueMinRadius);
+          if (cue?.active && !shooting) {
+            const aimFocus =
+              blend < 0.999
+                ? computeAimFocusTarget(cue, aimDirRef.current)
+                : null;
+            aimFocusRef.current = aimFocus ? aimFocus.clone() : null;
+          } else {
+            aimFocusRef.current = null;
+          }
           syncBlendToSpherical();
         };
 
@@ -6870,6 +6879,27 @@ function SnookerGame() {
           idleUnits.forEach((unit) =>
             applyFocus(unit, 0, Math.min(1, lerpFactor * 0.6), idleFocus)
           );
+        };
+
+        const clampCameraAboveRails = (focusTarget, spherical) => {
+          if (!focusTarget) return false;
+          const minRailWorldY = (TABLE_Y + TABLE_RAIL_TOP_Y) * worldScaleFactor;
+          const minOffsetY = minRailWorldY - focusTarget.y;
+          if (!Number.isFinite(minOffsetY)) return false;
+          TMP_VEC3_A.copy(camera.position).sub(focusTarget);
+          if (TMP_VEC3_A.y >= minOffsetY - 1e-4) return false;
+          TMP_VEC3_A.y = minOffsetY;
+          const horizontalSq = TMP_VEC3_A.x * TMP_VEC3_A.x + TMP_VEC3_A.z * TMP_VEC3_A.z;
+          const newRadius = Math.sqrt(horizontalSq + TMP_VEC3_A.y * TMP_VEC3_A.y);
+          const newPhi = Math.acos(
+            THREE.MathUtils.clamp(TMP_VEC3_A.y / Math.max(newRadius, 1e-6), -1, 1)
+          );
+          camera.position.copy(focusTarget).add(TMP_VEC3_A);
+          if (spherical) {
+            spherical.radius = newRadius;
+            spherical.phi = THREE.MathUtils.clamp(newPhi, CAMERA.minPhi, CAMERA.maxPhi);
+          }
+          return true;
         };
 
         const updateCamera = () => {
@@ -6925,6 +6955,9 @@ function SnookerGame() {
               worldScaleFactor
             );
             camera.position.set(lookTarget.x, sph.radius, lookTarget.z);
+            if (clampCameraAboveRails(lookTarget, sph)) {
+              syncBlendToSpherical();
+            }
             camera.lookAt(lookTarget);
             renderCamera = camera;
             broadcastArgs.focusWorld =
@@ -7444,6 +7477,10 @@ function SnookerGame() {
             lookTarget = focusTarget;
             TMP_SPH.copy(sph);
             camera.position.setFromSpherical(TMP_SPH).add(lookTarget);
+            if (clampCameraAboveRails(lookTarget, sph)) {
+              TMP_SPH.copy(sph);
+              syncBlendToSpherical();
+            }
             camera.lookAt(lookTarget);
             renderCamera = camera;
             broadcastArgs.focusWorld =
@@ -8932,6 +8969,30 @@ function SnookerGame() {
       let potted = [];
       let firstHit = null;
 
+      const computeAimFocusTarget = (cueBall, aimDir) => {
+        if (!cueBall || !aimDir) return null;
+        const dir = aimDir.clone();
+        if (dir.lengthSq() < 1e-6) return null;
+        dir.normalize();
+        const focusDistance = Math.max(
+          BALL_R * 32,
+          Math.min(LONG_SHOT_DISTANCE, PLAY_H * 0.55)
+        );
+        return new THREE.Vector3(
+          THREE.MathUtils.clamp(
+            cueBall.pos.x + dir.x * focusDistance,
+            -PLAY_W / 2,
+            PLAY_W / 2
+          ),
+          BALL_CENTER_Y,
+          THREE.MathUtils.clamp(
+            cueBall.pos.y + dir.y * focusDistance,
+            -PLAY_H / 2,
+            PLAY_H / 2
+          )
+        );
+      };
+
       const alignStandingCameraToAim = (cueBall, aimDir) => {
         if (!cueBall || !aimDir) return;
         const dir = aimDir.clone();
@@ -8952,23 +9013,9 @@ function SnookerGame() {
         sph.theta = aimTheta;
         syncBlendToSpherical();
         const focusStore = ensureOrbitFocus();
-        const focusDistance = Math.max(
-          BALL_R * 28,
-          Math.min(LONG_SHOT_DISTANCE, PLAY_H * 0.5)
-        );
-        const focusTarget = new THREE.Vector3(
-          THREE.MathUtils.clamp(
-            cueBall.pos.x + dir.x * focusDistance,
-            -PLAY_W / 2,
-            PLAY_W / 2
-          ),
-          BALL_CENTER_Y,
-          THREE.MathUtils.clamp(
-            cueBall.pos.y + dir.y * focusDistance,
-            -PLAY_H / 2,
-            PLAY_H / 2
-          )
-        );
+        const focusTarget = computeAimFocusTarget(cueBall, dir);
+        if (!focusTarget) return;
+        aimFocusRef.current = focusTarget.clone();
         focusStore.ballId = cueBall.id ?? null;
         focusStore.target.copy(focusTarget);
         lastCameraTargetRef.current.copy(


### PR DESCRIPTION
## Summary
- restore cue camera tuning to the Oct 12 19:09 baseline values across Unity and webapp targets
- revert pool and snooker game pages to the Oct 12 19:09 configuration, including camera parameters and behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eca97c318883298ab58b29bc5437ce