### PR TITLE
Fix Pool Royale routing and leaderboard links

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -115,10 +115,10 @@ export default function App() {
             />
             <Route path="/games/murlanroyale" element={<MurlanRoyale />} />
             <Route
-              path="/games/pollroyale/lobby"
+              path="/games/poolroyale/lobby"
               element={<PoolRoyaleLobby />}
             />
-            <Route path="/games/pollroyale" element={<PoolRoyale />} />
+            <Route path="/games/poolroyale" element={<PoolRoyale />} />
             <Route path="/games/snooker" element={<Snooker />} />
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -40,7 +40,7 @@ export default function HomeGamesCard() {
           </h3>
         </Link>
         <Link
-          to="/games/pollroyale/lobby"
+          to="/games/poolroyale/lobby"
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -64,7 +64,7 @@ export default function InvitePopup({
                     alt: 'Goal Rush',
                   },
                   {
-                    id: 'pollroyale',
+                    id: 'poolroyale',
                     src: '/assets/icons/pool-royale.svg',
                     alt: 'Pool Royale',
                   },

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -19,12 +19,14 @@ import PlayerInvitePopup from './PlayerInvitePopup.jsx';
 function getGameFromTableId(id) {
   if (!id) return 'snake';
   const prefix = id.split('-')[0];
+  if (prefix === 'pollroyale') return 'poolroyale';
   if (
     [
       'snake',
       'fallingball',
       'goalrush',
       'poolroyale',
+      'snooker',
     ].includes(prefix)
   )
     return prefix;

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -10,13 +10,14 @@ import { NFT_GIFTS } from '../utils/nftGifts.js';
 function getGameFromTableId(id) {
   if (!id) return 'snake';
   const prefix = id.split('-')[0];
+  if (prefix === 'pollroyale') return 'poolroyale';
   if (
     [
       'snake',
       'fallingball',
       'goalrush',
-      'pollroyale',
       'poolroyale',
+      'snooker',
     ].includes(prefix)
   )
     return prefix;
@@ -180,7 +181,7 @@ export default function PlayerInvitePopup({
                   alt: 'Goal Rush',
                 },
                 {
-                  id: 'pollroyale',
+                  id: 'poolroyale',
                   src: '/assets/icons/pool-royale.svg',
                   alt: 'Pool Royale',
                 },

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -45,7 +45,7 @@ export default function Games() {
               </h3>
             </Link>
             <Link
-              to="/games/pollroyale/lobby"
+              to="/games/poolroyale/lobby"
               className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
             >
               <img

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -77,7 +77,7 @@ export default function PoolRoyaleLobby() {
     if (devAcc1) params.set('dev1', devAcc1);
     if (devAcc2) params.set('dev2', devAcc2);
     if (initData) params.set('init', encodeURIComponent(initData));
-    navigate(`/games/pollroyale?${params.toString()}`);
+    navigate(`/games/poolroyale?${params.toString()}`);
   };
 
   const winnerParam = new URLSearchParams(search).get('winner');


### PR DESCRIPTION
## Summary
- standardize the Pool Royale route slug to `/games/poolroyale` across the router, navigation cards, lobby redirects, and invite popups
- make leaderboard and invite utilities remap legacy `pollroyale` table ids and include snooker so watch links land on the correct 3D games

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ecb02732fc8329a76e405eaa94ff26