### PR TITLE
Improve orientation handling for 3D Snooker and Pool games

### DIFF
--- a/webapp/src/hooks/useOrientationLock.js
+++ b/webapp/src/hooks/useOrientationLock.js
@@ -1,0 +1,63 @@
+import { useEffect } from 'react';
+
+const ORIENTATION_FALLBACK_SEPARATOR = '-';
+
+export default function useOrientationLock(target = 'portrait-primary') {
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const orientation = window.screen?.orientation;
+    if (!orientation || typeof orientation.lock !== 'function') {
+      return undefined;
+    }
+
+    let isLocked = false;
+    let cancelled = false;
+
+    const tryLock = async (mode) => {
+      if (!mode || cancelled) return false;
+      try {
+        await orientation.lock(mode);
+        if (!cancelled) {
+          isLocked = true;
+          return true;
+        }
+      } catch (err) {
+        console.warn('Orientation lock failed', err);
+      }
+      return false;
+    };
+
+    const lock = async () => {
+      if (cancelled) return;
+      isLocked = false;
+      if (await tryLock(target)) return;
+      if (target.includes(ORIENTATION_FALLBACK_SEPARATOR)) {
+        const fallback = target.split(ORIENTATION_FALLBACK_SEPARATOR)[0];
+        if (fallback && fallback !== target) {
+          await tryLock(fallback);
+        }
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (!orientation.unlock) return;
+      if (document.visibilityState !== 'visible' && isLocked) {
+        orientation.unlock();
+        isLocked = false;
+      } else if (document.visibilityState === 'visible' && !isLocked) {
+        lock();
+      }
+    };
+
+    lock();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      if (orientation.unlock && isLocked) {
+        orientation.unlock();
+      }
+    };
+  }, [target]);
+}

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18,6 +18,7 @@ import {
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { PoolRoyaleRules } from '../../../../src/rules/PoolRoyaleRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
+import useOrientationLock from '../../hooks/useOrientationLock.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { getBallMaterial as getBilliardBallMaterial } from '../../utils/ballMaterialFactory.js';
 import {
@@ -4814,6 +4815,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   const mountRef = useRef(null);
   const rafRef = useRef(null);
   const rules = useMemo(() => new PoolRoyaleRules(variantKey), [variantKey]);
+  useOrientationLock('portrait-primary');
   const activeVariant = useMemo(
     () => resolvePoolVariant(variantKey),
     [variantKey]
@@ -5870,7 +5872,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         setPocketCameraActive(active);
       };
       updatePocketCameraState(false);
-      screen.orientation?.lock?.('portrait').catch(() => {});
       // Renderer
       const renderer = new THREE.WebGLRenderer({
         antialias: true,

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -17,6 +17,7 @@ import {
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { UnitySnookerRules } from '../../../../src/rules/UnitySnookerRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
+import useOrientationLock from '../../hooks/useOrientationLock.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { getBallMaterial as getBilliardBallMaterial } from '../../utils/ballMaterialFactory.js';
 import {
@@ -4729,6 +4730,7 @@ function SnookerGame() {
   const mountRef = useRef(null);
   const rafRef = useRef(null);
   const rules = useMemo(() => new UnitySnookerRules(), []);
+  useOrientationLock('portrait-primary');
   const [tableFinishId, setTableFinishId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem('snookerTableFinish');
@@ -5723,7 +5725,6 @@ function SnookerGame() {
         setPocketCameraActive(active);
       };
       updatePocketCameraState(false);
-      screen.orientation?.lock?.('portrait').catch(() => {});
       // Renderer
       const renderer = new THREE.WebGLRenderer({
         antialias: true,


### PR DESCRIPTION
## Summary
- add a reusable orientation lock hook that safely restores the previous state when the view changes
- update the snooker and pool royale pages to rely on the hook instead of directly locking the orientation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ecbcc29218832992f8546f14ecb0fe