### PR TITLE
Restore snooker and pool royale post camera-controller removal

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18,7 +18,6 @@ import {
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { PoolRoyaleRules } from '../../../../src/rules/PoolRoyaleRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
-import { useIsMobile } from '../../hooks/useIsMobile.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { getBallMaterial as getBilliardBallMaterial } from '../../utils/ballMaterialFactory.js';
 import {
@@ -36,6 +35,8 @@ import {
   disposeMaterialWithWood,
   hslToHexNumber
 } from '../../utils/woodMaterials.js';
+
+const LEGACY_SRGB_ENCODING = Reflect.get(THREE, 'sRGBEncoding');
 
 function signedRingArea(ring) {
   let area = 0;
@@ -574,11 +575,11 @@ const ACTION_CAM = Object.freeze({
   forwardBias: 0.1,
   shortRailBias: 0.52,
   followShortRailBias: 0.42,
-  heightOffset: BALL_R * 9.2,
+  heightOffset: 0,
   smoothingTime: 0.32,
   followSmoothingTime: 0.24,
   followDistance: BALL_R * 54,
-  followHeightOffset: BALL_R * 7.4,
+  followHeightOffset: 0,
   followHoldMs: 900
 });
 /**
@@ -1330,8 +1331,11 @@ const createClothTextures = (() => {
     colorMap.generateMipmaps = true;
     colorMap.minFilter = THREE.LinearMipmapLinearFilter;
     colorMap.magFilter = THREE.LinearFilter;
-    if ('colorSpace' in colorMap) colorMap.colorSpace = THREE.SRGBColorSpace;
-    else colorMap.encoding = THREE.sRGBEncoding;
+    if ('colorSpace' in colorMap && THREE.SRGBColorSpace) {
+      colorMap.colorSpace = THREE.SRGBColorSpace;
+    } else if ('encoding' in colorMap && LEGACY_SRGB_ENCODING !== undefined) {
+      colorMap.encoding = LEGACY_SRGB_ENCODING;
+    }
     colorMap.needsUpdate = true;
 
     const bumpCanvas = document.createElement('canvas');
@@ -1754,8 +1758,11 @@ const createCarpetTextures = (() => {
     texture.minFilter = THREE.LinearMipMapLinearFilter;
     texture.magFilter = THREE.LinearFilter;
     texture.generateMipmaps = true;
-    if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-    else texture.encoding = THREE.sRGBEncoding;
+    if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+      texture.colorSpace = THREE.SRGBColorSpace;
+    } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+      texture.encoding = LEGACY_SRGB_ENCODING;
+    }
 
     // bump map: derive from red base with extra fiber noise
     const bumpCanvas = document.createElement('canvas');
@@ -2272,12 +2279,15 @@ function applySnookerScaling({
 
 // Kamera: ruaj kënd komod që mos shtrihet poshtë cloth-it, por lejo pak më shumë lartësi kur ngrihet
 const STANDING_VIEW_PHI = 0.92;
-const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
+// Lower the cue shot tilt so the camera can skim the rail line while staying just
+// above the cloth. Keeping the delta small ensures we don't clip through the
+// table surface when blending between views.
+const CUE_SHOT_PHI = Math.PI / 2 - 0.07;
 const STANDING_VIEW_MARGIN = 0.0024;
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.3;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.18);
-const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.24; // keep orbit camera from dipping below the table surface
+const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.02; // keep orbit camera from dipping below the table surface while allowing a lower tilt
 // Pull the baseline player orbit in so the cue perspective hugs the cloth a bit more, especially on portrait screens.
 const PLAYER_CAMERA_DISTANCE_FACTOR = 0.135;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
@@ -2319,19 +2329,22 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.02;
-const CUE_VIEW_RADIUS_RATIO = 0.095;
-const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.45;
+const CUE_VIEW_RADIUS_RATIO = 0.085;
+const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.34;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
-  STANDING_VIEW_PHI + 0.22
+  STANDING_VIEW_PHI + 0.5
 );
 const CUE_VIEW_PHI_LIFT = 0.08;
-const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
+const CUE_VIEW_TARGET_PHI = Math.min(
+  CAMERA.maxPhi,
+  CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5
+);
 // Mirror the snooker cue framing so both games share the same up-close feel around the cloth.
 const CUE_VIEW_RAIL_CLEARANCE = BALL_R * 0.1;
 // Lift the cue-view camera so the cue stick and cue ball stay framed together while aiming.
-const CUE_VIEW_ABOVE_CUE = BALL_R * 1.08;
-const CUE_VIEW_EXTRA_HEIGHT = BALL_R * 0.42;
+const CUE_VIEW_ABOVE_CUE = BALL_R * 0.72;
+const CUE_VIEW_EXTRA_HEIGHT = BALL_R * 0.24;
 const CUE_VIEW_BACK_MIN_RATIO = 0.26;
 const CUE_VIEW_BACK_RATIO = 0.34;
 const CUE_VIEW_BASE_CUE_LENGTH = (BALL_R / 0.0525) * 1.5 * CUE_LENGTH_MULTIPLIER;
@@ -2345,6 +2358,7 @@ const CAMERA_MIN_HORIZONTAL =
 const CAMERA_DOWNWARD_PULL = 1.9;
 const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.29;
 const CUE_VIEW_AIM_SLOW_FACTOR = 0.35; // slow pointer rotation while blended toward cue view for finer aiming
+const AIM_CAMERA_LOCK_FACTOR = 1; // keep the aim direction locked to the active camera heading
 const POCKET_VIEW_SMOOTH_TIME = 0.24; // seconds to ease pocket camera transitions
 const POCKET_CAMERA_FOV = STANDING_VIEW_FOV;
 const LONG_SHOT_DISTANCE = PLAY_H * 0.5;
@@ -2494,6 +2508,21 @@ const computeCueCameraMinHeight = (worldScaleFactor, cushionHeight = TABLE.THICK
   const railClearanceWorld = CUE_VIEW_RAIL_CLEARANCE * worldScaleFactor;
   const aboveCueWorld = CUE_VIEW_ABOVE_CUE * worldScaleFactor;
   return Math.max(railHeightWorld + railClearanceWorld, cueHeightWorld + aboveCueWorld);
+};
+
+const computeActionCameraMidHeight = (
+  worldScaleFactor,
+  heightBaseLocal = TABLE_Y + TABLE.THICK,
+  cushionHeight = TABLE.THICK
+) => {
+  const scale = Number.isFinite(worldScaleFactor) && worldScaleFactor > 0 ? worldScaleFactor : 1;
+  const tableTopWorld = heightBaseLocal * scale;
+  const highestWorld = Math.max(
+    computeCueCameraMinHeight(scale, cushionHeight),
+    tableTopWorld
+  );
+  const midpointWorld = (tableTopWorld + highestWorld) * 0.5;
+  return midpointWorld / scale;
 };
 
 const computeAimFocusTarget = (cueBall, aimDir) => {
@@ -2974,8 +3003,11 @@ function makeClothTexture(
   const repeatY = baseRepeat * (PLAY_H / TABLE.H);
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 48;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+    texture.encoding = LEGACY_SRGB_ENCODING;
+  }
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
@@ -3066,8 +3098,11 @@ function makeWoodTexture({
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 8;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+    texture.encoding = LEGACY_SRGB_ENCODING;
+  }
   texture.needsUpdate = true;
   return texture;
 }
@@ -5262,6 +5297,10 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   const [err, setErr] = useState(null);
   const fireRef = useRef(() => {}); // set from effect so slider can trigger fire()
   const cameraRef = useRef(null);
+  const mobileCameraRigRef = useRef(null);
+  const lastCameraTickRef = useRef(
+    typeof performance !== 'undefined' ? performance.now() : 0
+  );
   const sphRef = useRef(null);
   const initialOrbitRef = useRef(null);
   const aimFocusRef = useRef(null);
@@ -5942,8 +5981,11 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 4;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+          texture.colorSpace = THREE.SRGBColorSpace;
+        } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+          texture.encoding = LEGACY_SRGB_ENCODING;
+        }
         let offset = 0;
         return {
           texture,
@@ -5981,8 +6023,11 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 8;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+          texture.colorSpace = THREE.SRGBColorSpace;
+        } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+          texture.encoding = LEGACY_SRGB_ENCODING;
+        }
         let pulse = 0;
         const createAvatarStore = () => ({
           image: null,
@@ -6754,9 +6799,10 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       const camera = new THREE.PerspectiveCamera(
         CAMERA.fov,
         aspect,
-          CAMERA.near,
-          CAMERA.far
-        );
+        CAMERA.near,
+        CAMERA.far
+      );
+      mobileCameraRigRef.current = null;
         const standingPhi = THREE.MathUtils.clamp(
           STANDING_VIEW.phi,
           CAMERA.minPhi,
@@ -7167,6 +7213,12 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                 }
               }
               const heightBase = TABLE_Y + TABLE.THICK;
+              const cushionHeight = cushionHeightRef.current ?? TABLE.THICK;
+              const actionBaseHeight = computeActionCameraMidHeight(
+                worldScaleFactor,
+                heightBase,
+                cushionHeight
+              );
               if (activeShotView.stage === 'pair') {
                 const targetBall =
                   activeShotView.targetId != null
@@ -7216,7 +7268,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   const desiredDistance = baseDistance + longShotPullback;
                   const desired = new THREE.Vector3(
                     0,
-                    heightBase + ACTION_CAM.heightOffset + heightLift,
+                    actionBaseHeight + ACTION_CAM.heightOffset + heightLift,
                     railDir * desiredDistance
                   );
                   const lookAnchor = anchor.clone();
@@ -7251,7 +7303,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   );
                   const desired = new THREE.Vector3(
                     railDir * SIDE_RAIL_CAMERA_DISTANCE,
-                    heightBase + ACTION_CAM.heightOffset,
+                    actionBaseHeight + ACTION_CAM.heightOffset,
                     baseZ
                   );
                   const lookAnchor = anchor.clone();
@@ -7304,7 +7356,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   const desiredDistance = baseDistance + longShotPullback;
                   const desired = new THREE.Vector3(
                     0,
-                    heightBase + ACTION_CAM.followHeightOffset + heightLift,
+                    actionBaseHeight + ACTION_CAM.followHeightOffset + heightLift,
                     railDir * desiredDistance
                   );
                   const lookAnchor = anchor.clone();
@@ -7339,7 +7391,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   );
                   const desired = new THREE.Vector3(
                     railDir * SIDE_RAIL_CAMERA_DISTANCE,
-                    heightBase + ACTION_CAM.followHeightOffset,
+                    actionBaseHeight + ACTION_CAM.followHeightOffset,
                     baseZ
                   );
                   const lookAnchor = anchor.clone();
@@ -7643,15 +7695,10 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             lookTarget = focusTarget;
             TMP_SPH.copy(sph);
             TMP_VEC3_A.setFromSpherical(TMP_SPH);
+            cameraBlendRef.current = 0;
             let finalOffset = TMP_VEC3_A;
-            const cueBlend = THREE.MathUtils.clamp(
-              cameraBlendRef.current ?? 1,
-              0,
-              1
-            );
-            const cueWeight = Math.pow(1 - cueBlend, 0.85);
+            let cueOffset = null;
             if (
-              cueWeight > 1e-4 &&
               cue?.active &&
               !shooting &&
               aimDirRef.current &&
@@ -7661,7 +7708,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
               TMP_VEC2_A.copy(aimDirRef.current);
               if (TMP_VEC2_A.lengthSq() > 1e-6) {
                 TMP_VEC2_A.normalize();
-                const cueOffset = computeCueAimCameraOffset({
+                cueOffset = computeCueAimCameraOffset({
                   cueBall: cue,
                   aimDir: TMP_VEC2_A,
                   focusWorld: lookTarget,
@@ -7669,11 +7716,10 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   cushionHeight: cushionHeightRef.current ?? TABLE.THICK,
                   orbitOffset: TMP_VEC3_A
                 });
-                if (cueOffset) {
-                  TMP_VEC3_B.copy(TMP_VEC3_A).lerp(cueOffset, cueWeight);
-                  finalOffset = TMP_VEC3_B;
-                }
               }
+            }
+            if (cueOffset) {
+              finalOffset = cueOffset;
             }
             TMP_VEC3_CAMERA.copy(lookTarget).add(finalOffset);
             const minCameraHeight = computeCueCameraMinHeight(
@@ -7840,7 +7886,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           targetId,
           followView,
           railNormal,
-          { longShot = false, travelDistance = 0 } = {}
+          { longShot = false, travelDistance = 0, impactPoint = null } = {}
         ) => {
           if (!cueBall) return null;
           const ballsList = ballsRef.current || [];
@@ -7848,6 +7894,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             targetId != null
               ? ballsList.find((b) => b.id === targetId) || null
               : null;
+          const cuePos2 = new THREE.Vector2(cueBall.pos.x, cueBall.pos.y);
           const orbitSnapshot = followView?.orbitSnapshot
             ? {
                 radius: followView.orbitSnapshot.radius,
@@ -7865,17 +7912,31 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
               Math.abs(targetBall.pos.y) > nearRailThresholdY
             : false;
           const axis = 'short'; // force short-rail broadcast framing
+          const impactPos = impactPoint
+            ? new THREE.Vector2(impactPoint.x, impactPoint.y)
+            : targetBall
+              ? new THREE.Vector2(targetBall.pos.x, targetBall.pos.y)
+              : cuePos2.clone();
+          const halfLength = PLAY_H / 2;
+          const frontRail = -halfLength;
+          const backRail = halfLength;
+          const distToFront = Math.abs(impactPos.y - frontRail);
+          const distToBack = Math.abs(impactPos.y - backRail);
+          let impactRailDir = distToBack <= distToFront ? 1 : -1;
+          if (Math.abs(distToBack - distToFront) < BALL_R * 0.25) {
+            const fallbackDir =
+              railNormal?.y ??
+              cueBall.launchDir?.y ??
+              (targetBall ? targetBall.pos.y - cueBall.pos.y : cueBall.pos.y);
+            impactRailDir = signed(fallbackDir, impactRailDir);
+          }
+          impactRailDir = signed(impactRailDir, 1);
           const initialRailDir =
             axis === 'side'
               ? signed(
                   railNormal?.x ?? cueBall.pos.x ?? cueBall.launchDir?.x ?? 1
                 )
-              : signed(
-                  cueBall.pos.y ??
-                    cueBall.launchDir?.y ??
-                    railNormal?.y ??
-                    1
-                );
+              : impactRailDir;
           const now = performance.now();
           const activationDelay = longShot
             ? now + LONG_SHOT_ACTIVATION_DELAY_MS
@@ -7913,6 +7974,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             activationTravel,
             pendingActivation: longShot,
             startCuePos: new THREE.Vector2(cueBall.pos.x, cueBall.pos.y),
+            impactPos,
             targetInitialPos: targetBall
               ? new THREE.Vector2(targetBall.pos.x, targetBall.pos.y)
               : null
@@ -8163,6 +8225,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           return result;
         };
         const drag = { on: false, x: 0, y: 0, moved: false };
+        const pinch = { active: false, distance: 0 };
         const galleryDrag = {
           active: false,
           startX: 0,
@@ -8222,7 +8285,17 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           if (attemptChalkPress(e)) return;
           const currentHud = hudRef.current;
           if (currentHud?.turn === 1 || currentHud?.inHand || shooting) return;
-          if (e.touches?.length === 2) return;
+          if (e.touches?.length === 2) {
+            const t0 = e.touches[0];
+            const t1 = e.touches[1];
+            if (t0 && t1) {
+              const dx = t0.clientX - t1.clientX;
+              const dy = t0.clientY - t1.clientY;
+              pinch.active = true;
+              pinch.distance = Math.hypot(dx, dy);
+            }
+            return;
+          }
           if (topViewRef.current) return;
           drag.on = true;
           drag.moved = false;
@@ -8282,6 +8355,24 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             registerInteraction();
             return;
           }
+          if (pinch.active && e.touches?.length === 2) {
+            const t0 = e.touches[0];
+            const t1 = e.touches[1];
+            if (t0 && t1) {
+              const dx = t0.clientX - t1.clientX;
+              const dy = t0.clientY - t1.clientY;
+              const dist = Math.hypot(dx, dy);
+              if (dist > 0 && pinch.distance > 0 && mobileCameraRigRef.current) {
+                const scale = dist / pinch.distance;
+                if (Math.abs(scale - 1) > 1e-3) {
+                  mobileCameraRigRef.current.zoomBy(scale);
+                }
+              }
+              pinch.distance = dist;
+            }
+            registerInteraction();
+            return;
+          }
           if (topViewRef.current || !drag.on) return;
           const currentHud = hudRef.current;
           if (currentHud?.turn === 1) return;
@@ -8310,6 +8401,11 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                 ? CHALK_PRECISION_SLOW_MULTIPLIER
                 : 1;
             const precisionScale = basePrecisionScale * slowScale;
+            if (mobileCameraRigRef.current) {
+              const yawDelta = -dx * 0.005 * precisionScale;
+              const pitchDelta = -dy * 0.003 * precisionScale;
+              mobileCameraRigRef.current.orbit(yawDelta, pitchDelta);
+            }
             sph.theta -= dx * 0.0035 * precisionScale;
             const phiRange = CAMERA.maxPhi - CAMERA.minPhi;
             const phiDelta = dy * 0.0025 * precisionScale;
@@ -8337,6 +8433,8 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           const moved = drag.moved;
           drag.on = false;
           drag.moved = false;
+          pinch.active = false;
+          pinch.distance = 0;
           if (
             !moved &&
             !topViewRef.current &&
@@ -8365,14 +8463,17 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           const step = baseStep * slowScale;
           if (e.code === 'ArrowLeft') {
             sph.theta += step;
+            mobileCameraRigRef.current?.orbit(step, 0);
           } else if (e.code === 'ArrowRight') {
             sph.theta -= step;
+            mobileCameraRigRef.current?.orbit(-step, 0);
           } else if (e.code === 'ArrowUp' || e.code === 'ArrowDown') {
             const phiRange = CAMERA.maxPhi - CAMERA.minPhi;
             const dir = e.code === 'ArrowUp' ? -1 : 1;
             const blendDelta =
               phiRange > 1e-5 ? (step * dir) / phiRange : 0;
             applyCameraBlend(cameraBlendRef.current - blendDelta);
+            mobileCameraRigRef.current?.orbit(0, step * dir * 0.6);
           } else return;
           registerInteraction();
           updateCamera();
@@ -8484,6 +8585,12 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       sph.radius = clampOrbitRadius(sph.radius);
       const tableScale = tableSizeRef.current?.scale ?? 1;
       worldScaleFactor = WORLD_SCALE * tableScale;
+      if (mobileCameraRigRef.current) {
+        mobileCameraRigRef.current.setTableDimensions(
+          PLAY_W * worldScaleFactor,
+          PLAY_H * worldScaleFactor
+        );
+      }
       world.scale.setScalar(worldScaleFactor);
       const surfaceOffset = baseSurfaceWorldY - tableSurfaceY * worldScaleFactor;
       world.position.y = surfaceOffset;
@@ -9244,18 +9351,44 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           BALL_R * 28,
           Math.min(LONG_SHOT_DISTANCE, PLAY_H * 0.5)
         );
+        const tableHalfWidth = PLAY_W / 2;
+        const tableHalfLength = PLAY_H / 2;
+        const focusMargin = Math.max(BALL_R * 0.5, 0.01);
+        const safeXMin = -tableHalfWidth + focusMargin;
+        const safeXMax = tableHalfWidth - focusMargin;
+        const safeZMin = -tableHalfLength + focusMargin;
+        const safeZMax = tableHalfLength - focusMargin;
+        let maxDistance = focusDistance;
+        const originX = cueBall.pos.x;
+        const originZ = cueBall.pos.y;
+        const applyAxisLimit = (dirComponent, originComponent, minLimit, maxLimit) => {
+          if (Math.abs(dirComponent) < 1e-6) return;
+          const limitValue = dirComponent > 0 ? maxLimit : minLimit;
+          const travel = (limitValue - originComponent) / dirComponent;
+          if (travel > 0) {
+            maxDistance = Math.min(maxDistance, travel);
+          }
+        };
+        applyAxisLimit(dir.x, originX, safeXMin, safeXMax);
+        applyAxisLimit(dir.y, originZ, safeZMin, safeZMax);
+        if (!Number.isFinite(maxDistance) || maxDistance <= 0) {
+          maxDistance = focusDistance;
+        }
+        let limitedDistance = Math.min(focusDistance, maxDistance);
+        if (!Number.isFinite(limitedDistance) || limitedDistance <= 0) {
+          limitedDistance = Math.max(
+            BALL_R * 3,
+            Math.min(focusDistance, LONG_SHOT_DISTANCE)
+          );
+        } else {
+          const minimum = Math.min(BALL_R * 3, focusDistance);
+          limitedDistance = Math.max(limitedDistance, minimum);
+          limitedDistance = Math.min(limitedDistance, maxDistance);
+        }
         const focusTarget = new THREE.Vector3(
-          THREE.MathUtils.clamp(
-            cueBall.pos.x + dir.x * focusDistance,
-            -PLAY_W / 2,
-            PLAY_W / 2
-          ),
+          originX + dir.x * limitedDistance,
           BALL_CENTER_Y,
-          THREE.MathUtils.clamp(
-            cueBall.pos.y + dir.y * focusDistance,
-            -PLAY_H / 2,
-            PLAY_H / 2
-          )
+          originZ + dir.y * limitedDistance
         );
         focusStore.ballId = cueBall.id ?? null;
         focusStore.target.copy(focusTarget);
@@ -9386,7 +9519,8 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                 shotPrediction.railNormal,
                 {
                   longShot: isLongShot,
-                  travelDistance: predictedTravel
+                  travelDistance: predictedTravel,
+                  impactPoint: shotPrediction.impact
                 }
               )
             : null;
@@ -10077,7 +10211,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         tmpAim.set(camFwd.x, camFwd.z).normalize();
         const aimLerpFactor = chalkAssistTargetRef.current
           ? CHALK_AIM_LERP_SLOW
-          : 0.2;
+          : AIM_CAMERA_LOCK_FACTOR;
         aimDir.lerp(tmpAim, aimLerpFactor);
         const appliedSpin = applySpinConstraints(aimDir, true);
         const ranges = spinRangeRef.current || {};
@@ -10932,6 +11066,12 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           // Update canvas dimensions when the window size changes so the table
           // remains fully visible.
           renderer.setSize(host.clientWidth, host.clientHeight);
+          if (mobileCameraRigRef.current) {
+            mobileCameraRigRef.current.setViewport(
+              host.clientWidth,
+              host.clientHeight
+            );
+          }
           const margin = Math.max(
             STANDING_VIEW.margin,
             topViewRef.current
@@ -10957,6 +11097,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           pocketCamerasRef.current.clear();
           pocketDropRef.current.clear();
           activeRenderCameraRef.current = null;
+          mobileCameraRigRef.current = null;
           cueBodyRef.current = null;
           tipGroupRef.current = null;
           try {
@@ -11498,7 +11639,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
 }
 
 export default function PoolRoyale() {
-  const isMobileOrTablet = useIsMobile(1366);
   const location = useLocation();
   const variantKey = useMemo(() => {
     const params = new URLSearchParams(location.search);
@@ -11510,14 +11650,6 @@ export default function PoolRoyale() {
     const requested = params.get('tableSize');
     return resolveTableSize(requested).id;
   }, [location.search]);
-
-  if (!isMobileOrTablet) {
-    return (
-      <div className="flex items-center justify-center w-full h-full p-4 text-center">
-        <p>This game is available on mobile phones and tablets only.</p>
-      </div>
-    );
-  }
 
   return <PoolRoyaleGame variantKey={variantKey} tableSizeKey={tableSizeKey} />;
 }

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -17,7 +17,6 @@ import {
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { UnitySnookerRules } from '../../../../src/rules/UnitySnookerRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
-import { useIsMobile } from '../../hooks/useIsMobile.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { getBallMaterial as getBilliardBallMaterial } from '../../utils/ballMaterialFactory.js';
 import {
@@ -32,6 +31,8 @@ import {
   DEFAULT_WOOD_TEXTURE_SIZE,
   applyWoodTextures
 } from '../../utils/woodMaterials.js';
+
+const LEGACY_SRGB_ENCODING = Reflect.get(THREE, 'sRGBEncoding');
 
 function signedRingArea(ring) {
   let area = 0;
@@ -1351,8 +1352,11 @@ const createClothTextures = (() => {
     colorMap.generateMipmaps = true;
     colorMap.minFilter = THREE.LinearMipmapLinearFilter;
     colorMap.magFilter = THREE.LinearFilter;
-    if ('colorSpace' in colorMap) colorMap.colorSpace = THREE.SRGBColorSpace;
-    else colorMap.encoding = THREE.sRGBEncoding;
+    if ('colorSpace' in colorMap && THREE.SRGBColorSpace) {
+      colorMap.colorSpace = THREE.SRGBColorSpace;
+    } else if ('encoding' in colorMap && LEGACY_SRGB_ENCODING !== undefined) {
+      colorMap.encoding = LEGACY_SRGB_ENCODING;
+    }
     colorMap.needsUpdate = true;
 
     const bumpCanvas = document.createElement('canvas');
@@ -1790,8 +1794,11 @@ const createCarpetTextures = (() => {
     texture.minFilter = THREE.LinearMipMapLinearFilter;
     texture.magFilter = THREE.LinearFilter;
     texture.generateMipmaps = true;
-    if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-    else texture.encoding = THREE.sRGBEncoding;
+    if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+      texture.colorSpace = THREE.SRGBColorSpace;
+    } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+      texture.encoding = LEGACY_SRGB_ENCODING;
+    }
 
     // bump map: derive from red base with extra fiber noise
     const bumpCanvas = document.createElement('canvas');
@@ -2909,8 +2916,11 @@ function makeClothTexture(
   const repeatY = baseRepeat * (PLAY_H / TABLE.H);
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 48;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+    texture.encoding = LEGACY_SRGB_ENCODING;
+  }
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
@@ -3001,8 +3011,11 @@ function makeWoodTexture({
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 8;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+    texture.encoding = LEGACY_SRGB_ENCODING;
+  }
   texture.needsUpdate = true;
   return texture;
 }
@@ -5820,8 +5833,11 @@ function SnookerGame() {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 4;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+          texture.colorSpace = THREE.SRGBColorSpace;
+        } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+          texture.encoding = LEGACY_SRGB_ENCODING;
+        }
         let offset = 0;
         return {
           texture,
@@ -5859,8 +5875,11 @@ function SnookerGame() {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 8;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+          texture.colorSpace = THREE.SRGBColorSpace;
+        } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+          texture.encoding = LEGACY_SRGB_ENCODING;
+        }
         let pulse = 0;
         const createAvatarStore = () => ({
           image: null,
@@ -11163,15 +11182,5 @@ function SnookerGame() {
 }
 
 export default function NewSnookerGame() {
-  const isMobileOrTablet = useIsMobile(1366);
-
-  if (!isMobileOrTablet) {
-    return (
-      <div className="flex items-center justify-center w-full h-full p-4 text-center">
-        <p>This game is available on mobile phones and tablets only.</p>
-      </div>
-    );
-  }
-
   return <SnookerGame />;
 }

--- a/webapp/src/pages/Games/simpleOrbitCamera.ts
+++ b/webapp/src/pages/Games/simpleOrbitCamera.ts
@@ -1,0 +1,265 @@
+// @ts-nocheck
+import * as THREE from 'three';
+
+const DEG2RAD = Math.PI / 180;
+const MIN_THETA = 30 * DEG2RAD;
+const MAX_THETA = 48 * DEG2RAD;
+const DEFAULT_THETA = 35 * DEG2RAD;
+const MAX_SMOOTH_STEP = 1 / 30;
+const TABLE_MARGIN_SCALE = 1.03;
+const FIT_EXTRA_MARGIN = 1.005;
+const LOW_TILT_RADIUS_SCALE = 0.86;
+const AUTO_ZOOM_STRENGTH = 0.45;
+const MAX_RADIUS_SCALE = 1.35;
+
+const tmpForward = new THREE.Vector3();
+const tmpUp = new THREE.Vector3();
+const tmpCross = new THREE.Vector3();
+const tmpDesiredUp = new THREE.Vector3();
+const tmpAxis = new THREE.Vector3();
+const tmpQuat = new THREE.Quaternion();
+const cueLocalForward = new THREE.Vector3(0, 0, -1);
+const cueLocalUp = new THREE.Vector3(0, 1, 0);
+const cueTipOffset = new THREE.Vector3();
+const cueContact = new THREE.Vector3();
+const cueDirection = new THREE.Vector3();
+const cueButt = new THREE.Vector3();
+const sharedUp = new THREE.Vector3(0, 1, 0);
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function angleDelta(target: number, current: number) {
+  let diff = target - current;
+  while (diff > Math.PI) diff -= Math.PI * 2;
+  while (diff < -Math.PI) diff += Math.PI * 2;
+  return diff;
+}
+
+export function computeRFit(
+  viewHeight: number,
+  viewWidth: number,
+  tableWidth: number,
+  tableHeight: number,
+  thetaRad: number
+) {
+  const safeWidth = viewWidth > 1e-6 ? viewWidth : 1;
+  const safeHeight = viewHeight > 1e-6 ? viewHeight : 1;
+  const aspect = safeHeight / safeWidth;
+  const vFov = 50 * DEG2RAD;
+  const hFov = 2 * Math.atan(Math.tan(vFov / 2) * (1 / aspect));
+  const hx = 0.5 * tableWidth * TABLE_MARGIN_SCALE;
+  const hz = 0.5 * tableHeight * TABLE_MARGIN_SCALE;
+  const rW = hx / Math.tan(hFov / 2);
+  const cosTheta = Math.max(Math.cos(thetaRad), 1e-4);
+  const rH = (hz / cosTheta) / Math.tan(vFov / 2);
+  return Math.max(rW, rH) * FIT_EXTRA_MARGIN;
+}
+
+type CameraOptions = {
+  target?: THREE.Vector3;
+  theta?: number;
+  phi?: number;
+  radius?: number;
+};
+
+export class MobilePortraitCameraRig {
+  private camera: THREE.PerspectiveCamera;
+  private target: THREE.Vector3;
+  private theta: number;
+  private phi: number;
+  private radius: number;
+  private thetaTarget: number;
+  private phiTarget: number;
+  private radiusTarget: number;
+  private viewWidth: number;
+  private viewHeight: number;
+  private tableWidth: number;
+  private tableHeight: number;
+  private lastUpdate = performance.now();
+
+  constructor(camera: THREE.PerspectiveCamera, options: CameraOptions = {}) {
+    this.camera = camera;
+    this.camera.fov = 50;
+    this.camera.near = 0.05;
+    this.camera.far = 1000;
+    this.target = options.target ? options.target.clone() : new THREE.Vector3();
+    this.theta = options.theta ?? DEFAULT_THETA;
+    this.phi = options.phi ?? Math.PI;
+    this.radius = options.radius ?? 6;
+    this.thetaTarget = this.theta;
+    this.phiTarget = this.phi;
+    this.radiusTarget = this.radius;
+    this.viewWidth = 1;
+    this.viewHeight = 1;
+    this.tableWidth = 3.6;
+    this.tableHeight = 7.2;
+    this.camera.up.copy(sharedUp);
+    this.camera.lookAt(this.target);
+  }
+
+  setViewport(width: number, height: number) {
+    if (!Number.isFinite(width) || !Number.isFinite(height)) return;
+    if (width <= 1e-3 || height <= 1e-3) return;
+    this.viewWidth = width;
+    this.viewHeight = height;
+    const aspect = width / height;
+    if (Math.abs(this.camera.aspect - aspect) > 1e-4) {
+      this.camera.aspect = aspect;
+      this.camera.updateProjectionMatrix();
+    }
+  }
+
+  setTableDimensions(width: number, height: number) {
+    if (width > 0) this.tableWidth = width;
+    if (height > 0) this.tableHeight = height;
+  }
+
+  orbit(deltaPhi: number, deltaTheta: number) {
+    this.phiTarget += deltaPhi;
+    this.thetaTarget = clamp(this.thetaTarget + deltaTheta, MIN_THETA, MAX_THETA);
+  }
+
+  setPhiTarget(value: number) {
+    if (!Number.isFinite(value)) return;
+    this.phiTarget = value;
+  }
+
+  zoomBy(scale: number) {
+    if (!Number.isFinite(scale) || scale === 0) return;
+    const clamped = clamp(scale, 0.5, 2);
+    this.radiusTarget *= 1 / clamped;
+  }
+
+  setRadiusTarget(value: number) {
+    if (!Number.isFinite(value)) return;
+    this.radiusTarget = value;
+  }
+
+  update(now: number) {
+    const dtMs = Math.min(now - this.lastUpdate, MAX_SMOOTH_STEP * 1000);
+    this.lastUpdate = now;
+    const dt = dtMs / 1000;
+
+    const fit = computeRFit(
+      this.viewHeight,
+      this.viewWidth,
+      this.tableWidth,
+      this.tableHeight,
+      this.thetaTarget
+    );
+    const tiltNormalized = THREE.MathUtils.clamp(
+      (this.thetaTarget - MIN_THETA) / (MAX_THETA - MIN_THETA),
+      0,
+      1
+    );
+    const preferredRadius = fit * THREE.MathUtils.lerp(LOW_TILT_RADIUS_SCALE, 1, tiltNormalized);
+    const minRadius = preferredRadius;
+    const maxRadius = fit * MAX_RADIUS_SCALE;
+    if (!Number.isFinite(this.radiusTarget)) {
+      this.radiusTarget = preferredRadius;
+    }
+    this.radiusTarget = clamp(this.radiusTarget, minRadius, maxRadius);
+    const autoZoomInfluence = (1 - tiltNormalized) * AUTO_ZOOM_STRENGTH;
+    if (autoZoomInfluence > 1e-3) {
+      this.radiusTarget = THREE.MathUtils.lerp(
+        this.radiusTarget,
+        preferredRadius,
+        autoZoomInfluence
+      );
+    }
+    if (this.radius < 1e-3) this.radius = this.radiusTarget;
+
+    const smooth = 1 - Math.pow(1 - 0.18, Math.max(dt * 60, 1));
+    this.theta += (clamp(this.thetaTarget, MIN_THETA, MAX_THETA) - this.theta) * smooth;
+    this.phi += angleDelta(this.phiTarget, this.phi) * smooth;
+    this.radius += (this.radiusTarget - this.radius) * smooth;
+
+    const cosTheta = Math.cos(this.theta);
+    const sinTheta = Math.sin(this.theta);
+    const x = this.radius * cosTheta * Math.sin(this.phi);
+    const y = this.radius * sinTheta;
+    const z = this.radius * cosTheta * Math.cos(this.phi);
+    this.camera.position.set(x + this.target.x, y + this.target.y, z + this.target.z);
+    this.camera.up.copy(sharedUp);
+    this.camera.lookAt(this.target);
+  }
+
+  getState() {
+    return {
+      theta: this.theta,
+      phi: this.phi,
+      radius: this.radius,
+      radiusTarget: this.radiusTarget
+    };
+  }
+}
+
+export function alignCueRollToUp(
+  object: THREE.Object3D,
+  worldUp: THREE.Vector3,
+  lerp: number
+) {
+  if (!object) return;
+  const t = clamp(lerp ?? 0.2, 0, 1);
+  tmpForward.copy(cueLocalForward).applyQuaternion(object.quaternion).normalize();
+  tmpUp.copy(cueLocalUp).applyQuaternion(object.quaternion).normalize();
+  tmpDesiredUp.copy(tmpForward).cross(worldUp).cross(tmpForward).normalize();
+  if (tmpDesiredUp.lengthSq() < 1e-6) return;
+  const dot = clamp(tmpUp.dot(tmpDesiredUp), -1, 1);
+  const angle = Math.acos(dot);
+  if (angle < 1e-4) return;
+  tmpCross.copy(tmpUp).cross(tmpDesiredUp);
+  const sign = tmpCross.dot(tmpForward) < 0 ? -1 : 1;
+  tmpAxis.copy(tmpForward).multiplyScalar(sign).normalize();
+  tmpQuat.setFromAxisAngle(tmpAxis, angle * t);
+  object.quaternion.multiply(tmpQuat).normalize();
+}
+
+type CueSpinArgs = {
+  cue: THREE.Object3D | null;
+  cueBallPosition: THREE.Vector3;
+  cueBallRadius: number;
+  spinX: number;
+  spinY: number;
+  cueLength: number;
+};
+
+const clampSpin = (value: number) => clamp(value, -1, 1);
+
+export function updateCueFromSpin({
+  cue,
+  cueBallPosition,
+  cueBallRadius,
+  spinX,
+  spinY,
+  cueLength
+}: CueSpinArgs) {
+  if (!cue) return;
+  const k = 0.6;
+  const sx = clampSpin(spinX) * k * cueBallRadius;
+  const sy = clampSpin(spinY) * k * cueBallRadius;
+  const cap = Math.max(0, cueBallRadius * cueBallRadius - (sx * sx + sy * sy));
+  const nz = -Math.sqrt(cap);
+  cueTipOffset.set(sx, 0, sy);
+  cueContact.copy(cueBallPosition).add(cueTipOffset);
+  cueContact.y += nz;
+
+  cueDirection.copy(cueContact).sub(cueBallPosition);
+  if (cueDirection.lengthSq() < 1e-8) {
+    cueDirection.set(0, 0, -1);
+  } else {
+    cueDirection.normalize();
+  }
+  tmpQuat.setFromUnitVectors(cueLocalForward, cueDirection);
+  cue.quaternion.copy(tmpQuat);
+  alignCueRollToUp(cue, sharedUp, 0.2);
+
+  cueButt.copy(cueContact).addScaledVector(cueDirection, -cueLength);
+  cue.position.copy(cueButt);
+}
+
+export function rad(value: number) {
+  return value * DEG2RAD;
+}

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -1,5 +1,7 @@
 import * as THREE from 'three';
 
+const LEGACY_SRGB_ENCODING = Reflect.get(THREE, 'sRGBEncoding');
+
 const BALL_TEXTURE_SIZE = 1024;
 const BALL_TEXTURE_CACHE = new Map();
 const BALL_MATERIAL_CACHE = new Map();
@@ -247,8 +249,11 @@ function createBallTexture({ baseColor, pattern, number, variantKey }) {
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture && LEGACY_SRGB_ENCODING !== undefined) {
+    texture.encoding = LEGACY_SRGB_ENCODING;
+  }
   texture.needsUpdate = true;
 
   BALL_TEXTURE_CACHE.set(key, texture);


### PR DESCRIPTION
## Summary
- restore Pool Royale scene configuration to the state immediately after the camera controller removal
- revert Snooker game adjustments to the same baseline and re-enable shared texture handling
- restore the simpleOrbitCamera helper and legacy sRGB encoding support for ball textures

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ecc492faec83299e98479c74c7634d