### PR TITLE
Fix TypeScript build errors for billiards rule imports

### DIFF
--- a/src/types/billiards-modules.d.ts
+++ b/src/types/billiards-modules.d.ts
@@ -1,0 +1,30 @@
+declare module '*poolUk8Ball.js' {
+  class UkPool {
+    constructor(...args: any[]);
+    state: any;
+    rules: any;
+    startBreak(): void;
+    shotTaken(shot: any): any;
+  }
+  export { UkPool };
+}
+
+declare module '*americanBilliards.js' {
+  class AmericanBilliards {
+    constructor(...args: any[]);
+    state: any;
+    startBreak(): void;
+    shotTaken(shot: any): any;
+  }
+  export { AmericanBilliards };
+}
+
+declare module '*nineBall.js' {
+  class NineBall {
+    constructor(...args: any[]);
+    state: any;
+    startBreak(): void;
+    shotTaken(shot: any): any;
+  }
+  export { NineBall };
+}

--- a/tsconfig.snooker.json
+++ b/tsconfig.snooker.json
@@ -6,7 +6,8 @@
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "skipLibCheck": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- add ambient declarations for the JavaScript billiards rule engines used by Pool Royale to satisfy the TypeScript compiler
- relax the snooker TypeScript configuration by skipping library type checks so the build no longer fails when encountering the JavaScript modules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ecc87dcb6083298b5db5ce81d7be10