### PR TITLE
Improve billiards games loading and compatibility on mobile

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { TonConnectUIProvider } from '@tonconnect/ui-react';
 
@@ -42,20 +42,22 @@ import TexasHoldem from './pages/Games/TexasHoldem.jsx';
 import TexasHoldemLobby from './pages/Games/TexasHoldemLobby.jsx';
 import BlackJack from './pages/Games/BlackJack.jsx';
 import BlackJackLobby from './pages/Games/BlackJackLobby.jsx';
-import PoolRoyale from './pages/Games/PoolRoyale.jsx';
-import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
-import Snooker from './pages/Games/Snooker.jsx';
-import SnookerLobby from './pages/Games/SnookerLobby.jsx';
-import AmericanBilliards from './pages/Games/AmericanBilliards.jsx';
-import AmericanBilliardsLobby from './pages/Games/AmericanBilliardsLobby.jsx';
-import NineBall from './pages/Games/NineBall.jsx';
-import NineBallLobby from './pages/Games/NineBallLobby.jsx';
-import UkEightBall from './pages/Games/UkEightBall.jsx';
-import UkEightBallLobby from './pages/Games/UkEightBallLobby.jsx';
-
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
+
+const PoolRoyale = lazy(() => import('./pages/Games/PoolRoyale.jsx'));
+const PoolRoyaleLobby = lazy(() => import('./pages/Games/PoolRoyaleLobby.jsx'));
+const Snooker = lazy(() => import('./pages/Games/Snooker.jsx'));
+const SnookerLobby = lazy(() => import('./pages/Games/SnookerLobby.jsx'));
+const AmericanBilliards = lazy(() => import('./pages/Games/AmericanBilliards.jsx'));
+const AmericanBilliardsLobby = lazy(
+  () => import('./pages/Games/AmericanBilliardsLobby.jsx')
+);
+const NineBall = lazy(() => import('./pages/Games/NineBall.jsx'));
+const NineBallLobby = lazy(() => import('./pages/Games/NineBallLobby.jsx'));
+const UkEightBall = lazy(() => import('./pages/Games/UkEightBall.jsx'));
+const UkEightBallLobby = lazy(() => import('./pages/Games/UkEightBallLobby.jsx'));
 
 export default function App() {
   useTelegramAuth();
@@ -67,8 +69,15 @@ export default function App() {
     <BrowserRouter>
       <TonConnectUIProvider manifestUrl={manifestUrl}>
         <Layout>
-          <Routes>
-            <Route path="/" element={<Home />} />
+          <Suspense
+            fallback={
+              <div className="flex h-full items-center justify-center text-text">
+                Loading…
+              </div>
+            }
+          >
+            <Routes>
+              <Route path="/" element={<Home />} />
             <Route path="/mining" element={<Mining />} />
             <Route
               path="/mining/transactions"
@@ -156,7 +165,8 @@ export default function App() {
             <Route path="/notifications" element={<Notifications />} />
             <Route path="/trending" element={<Trending />} />
             <Route path="/account" element={<MyAccount />} />
-          </Routes>
+            </Routes>
+          </Suspense>
         </Layout>
       </TonConnectUIProvider>
     </BrowserRouter>

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24,6 +24,7 @@ import {
   createCueRackDisplay,
   CUE_RACK_PALETTE
 } from '../../utils/createCueRackDisplay.js';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
   adjustCornerNotchDepth,
   adjustSideNotchDepth,
@@ -44,6 +45,7 @@ import {
   hslToHexNumber
 } from '../../utils/woodMaterials.js';
 import { MobilePortraitCameraRig, rad } from './simpleOrbitCamera';
+import { isWebGLAvailable } from '../../utils/webgl.js';
 
 const LEGACY_SRGB_ENCODING = Reflect.get(THREE, 'sRGBEncoding');
 
@@ -4686,6 +4688,7 @@ function applyTableFinishToTable(table, finish) {
 export function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   const mountRef = useRef(null);
   const rafRef = useRef(null);
+  useTelegramBackButton();
   const rules = useMemo(() => new PoolRoyaleRules(variantKey), [variantKey]);
   const activeVariant = useMemo(
     () => resolvePoolVariant(variantKey),
@@ -5732,6 +5735,13 @@ export function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   }, [frameState, hud.turn, hud.over]);
 
   useEffect(() => {
+    if (!isWebGLAvailable()) {
+      const message = 'WebGL is not supported or disabled on this device.';
+      setErr((prev) => prev ?? message);
+      setLoading(false);
+      setLoadingProgress(100);
+      return;
+    }
     const host = mountRef.current;
     if (!host) return;
     let loadTimer = null;

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -23,6 +23,7 @@ import {
   createCueRackDisplay,
   CUE_RACK_PALETTE
 } from '../../utils/createCueRackDisplay.js';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
   adjustCornerNotchDepth,
   adjustSideNotchDepth,
@@ -41,6 +42,7 @@ import {
   applyWoodTextures
 } from '../../utils/woodMaterials.js';
 import { MobilePortraitCameraRig, rad } from './simpleOrbitCamera';
+import { isWebGLAvailable } from '../../utils/webgl.js';
 
 const LEGACY_SRGB_ENCODING = Reflect.get(THREE, 'sRGBEncoding');
 
@@ -4592,6 +4594,7 @@ function applyTableFinishToTable(table, finish) {
 function SnookerGame() {
   const mountRef = useRef(null);
   const rafRef = useRef(null);
+  useTelegramBackButton();
   const rules = useMemo(() => new UnitySnookerRules(), []);
   const [tableFinishId, setTableFinishId] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -5577,6 +5580,13 @@ function SnookerGame() {
   }, [frameState, hud.turn, hud.over]);
 
   useEffect(() => {
+    if (!isWebGLAvailable()) {
+      const message = 'WebGL is not supported or disabled on this device.';
+      setErr((prev) => prev ?? message);
+      setLoading(false);
+      setLoadingProgress(100);
+      return;
+    }
     const host = mountRef.current;
     if (!host) return;
     let loadTimer = null;

--- a/webapp/src/utils/webgl.js
+++ b/webapp/src/utils/webgl.js
@@ -1,0 +1,21 @@
+export function isWebGLAvailable() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return true;
+  }
+
+  try {
+    const canvas = document.createElement('canvas');
+    const contexts = ['webgl2', 'webgl', 'experimental-webgl'];
+    for (const ctx of contexts) {
+      const gl = canvas.getContext(ctx);
+      if (gl && typeof gl.getParameter === 'function') {
+        return true;
+      }
+    }
+  } catch (err) {
+    console.warn('WebGL capability check failed', err);
+    return false;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- lazy load the 3D billiards routes so the Telegram webview only downloads heavy game bundles when needed
- guard the snooker and pool engines with a WebGL capability check and surface a friendly error instead of failing silently
- wire the Telegram back button on the billiards tables for consistent navigation in the mobile app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68edd15c85848329bd4dbd558705e43c