### PR TITLE
Improve billiards game route loading reliability

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { TonConnectUIProvider } from '@tonconnect/ui-react';
 
@@ -45,19 +45,28 @@ import BlackJackLobby from './pages/Games/BlackJackLobby.jsx';
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
+import lazyWithRetry from './utils/lazyWithRetry.js';
 
-const PoolRoyale = lazy(() => import('./pages/Games/PoolRoyale.jsx'));
-const PoolRoyaleLobby = lazy(() => import('./pages/Games/PoolRoyaleLobby.jsx'));
-const Snooker = lazy(() => import('./pages/Games/Snooker.jsx'));
-const SnookerLobby = lazy(() => import('./pages/Games/SnookerLobby.jsx'));
-const AmericanBilliards = lazy(() => import('./pages/Games/AmericanBilliards.jsx'));
-const AmericanBilliardsLobby = lazy(
+const PoolRoyale = lazyWithRetry(() => import('./pages/Games/PoolRoyale.jsx'));
+const PoolRoyaleLobby = lazyWithRetry(
+  () => import('./pages/Games/PoolRoyaleLobby.jsx')
+);
+const Snooker = lazyWithRetry(() => import('./pages/Games/Snooker.jsx'));
+const SnookerLobby = lazyWithRetry(() => import('./pages/Games/SnookerLobby.jsx'));
+const AmericanBilliards = lazyWithRetry(
+  () => import('./pages/Games/AmericanBilliards.jsx')
+);
+const AmericanBilliardsLobby = lazyWithRetry(
   () => import('./pages/Games/AmericanBilliardsLobby.jsx')
 );
-const NineBall = lazy(() => import('./pages/Games/NineBall.jsx'));
-const NineBallLobby = lazy(() => import('./pages/Games/NineBallLobby.jsx'));
-const UkEightBall = lazy(() => import('./pages/Games/UkEightBall.jsx'));
-const UkEightBallLobby = lazy(() => import('./pages/Games/UkEightBallLobby.jsx'));
+const NineBall = lazyWithRetry(() => import('./pages/Games/NineBall.jsx'));
+const NineBallLobby = lazyWithRetry(
+  () => import('./pages/Games/NineBallLobby.jsx')
+);
+const UkEightBall = lazyWithRetry(() => import('./pages/Games/UkEightBall.jsx'));
+const UkEightBallLobby = lazyWithRetry(
+  () => import('./pages/Games/UkEightBallLobby.jsx')
+);
 
 export default function App() {
   useTelegramAuth();

--- a/webapp/src/utils/lazyWithRetry.js
+++ b/webapp/src/utils/lazyWithRetry.js
@@ -1,0 +1,66 @@
+import { lazy } from 'react';
+
+const CHUNK_ERROR_PATTERNS = [
+  /Loading chunk [\d]+ failed/i,
+  /ChunkLoadError/i,
+  /CSS chunk load failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /Importing a module script failed/i,
+  /Cannot read properties of undefined \(reading 'call'\)/i
+];
+
+function isRecoverableChunkError(error) {
+  if (!error) return false;
+  const message = String(error?.message || error);
+  return CHUNK_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+function wait(delayMs) {
+  return new Promise((resolve) => {
+    const schedule = typeof setTimeout === 'function'
+      ? setTimeout
+      : (fn) => {
+          fn();
+          return 0;
+        };
+    schedule(resolve, delayMs);
+  });
+}
+
+export function lazyWithRetry(factory, options = {}) {
+  const {
+    maxRetries = 3,
+    retryDelay = (attempt) => Math.min(2000 * attempt, 5000)
+  } = options;
+
+  return lazy(() => {
+    let attempt = 0;
+
+    const load = () =>
+      factory().catch(async (error) => {
+        const recoverable = isRecoverableChunkError(error);
+        attempt += 1;
+        const canRetry = attempt <= maxRetries && recoverable;
+        if (canRetry) {
+          const delay = typeof retryDelay === 'function'
+            ? retryDelay(attempt, error)
+            : retryDelay;
+          if (delay > 0) {
+            await wait(delay);
+          }
+          return load();
+        }
+
+        if (recoverable && typeof window !== 'undefined') {
+          window.location.reload();
+          return new Promise(() => {});
+        }
+
+        throw error;
+      });
+
+    return load();
+  });
+}
+
+export default lazyWithRetry;


### PR DESCRIPTION
## Summary
- add a reusable lazyWithRetry helper that retries dynamic imports and reloads on persistent chunk failures
- switch billiards-related routes to use the retrying lazy loader so the 3D tables no longer hang on loading when chunks fail

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68edd694628c8329a45587e3339dff3d