### PR TITLE
Fix billiards variant routing hooks

### DIFF
--- a/webapp/src/pages/Games/AmericanBilliards.jsx
+++ b/webapp/src/pages/Games/AmericanBilliards.jsx
@@ -1,4 +1,5 @@
-import { useLocation, useMemo } from 'react';
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { PoolRoyaleGame, resolveTableSize } from './PoolRoyale.jsx';
 
 export default function AmericanBilliards() {

--- a/webapp/src/pages/Games/NineBall.jsx
+++ b/webapp/src/pages/Games/NineBall.jsx
@@ -1,4 +1,5 @@
-import { useLocation, useMemo } from 'react';
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { PoolRoyaleGame, resolveTableSize } from './PoolRoyale.jsx';
 
 export default function NineBall() {

--- a/webapp/src/pages/Games/UkEightBall.jsx
+++ b/webapp/src/pages/Games/UkEightBall.jsx
@@ -1,4 +1,5 @@
-import { useLocation, useMemo } from 'react';
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { PoolRoyaleGame, resolveTableSize } from './PoolRoyale.jsx';
 
 export default function UkEightBall() {


### PR DESCRIPTION
## Summary
- import `useLocation` from `react-router-dom` in the 9-Ball, UK 8-Ball, and American Billiards pages
- prevent runtime `useLocation is not a function` crashes that left the billiards variants on a blank screen

## Testing
- `npm --prefix webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_68edea51229883298192da94837cbbea