### PR TITLE
Restore sRGB renderer compatibility for billiards tables

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5761,7 +5761,12 @@ export function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         powerPreference: 'high-performance'
       });
       renderer.useLegacyLights = false;
-      renderer.outputColorSpace = THREE.SRGBColorSpace;
+      if ('outputColorSpace' in renderer && THREE.SRGBColorSpace) {
+        renderer.outputColorSpace = THREE.SRGBColorSpace;
+      }
+      if ('outputEncoding' in renderer && LEGACY_SRGB_ENCODING !== undefined) {
+        renderer.outputEncoding = LEGACY_SRGB_ENCODING;
+      }
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.2;
       const devicePixelRatio = window.devicePixelRatio || 1;

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -5606,7 +5606,12 @@ function SnookerGame() {
         powerPreference: 'high-performance'
       });
       renderer.useLegacyLights = false;
-      renderer.outputColorSpace = THREE.SRGBColorSpace;
+      if ('outputColorSpace' in renderer && THREE.SRGBColorSpace) {
+        renderer.outputColorSpace = THREE.SRGBColorSpace;
+      }
+      if ('outputEncoding' in renderer && LEGACY_SRGB_ENCODING !== undefined) {
+        renderer.outputEncoding = LEGACY_SRGB_ENCODING;
+      }
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.2;
       const devicePixelRatio = window.devicePixelRatio || 1;


### PR DESCRIPTION
## Summary
- guard the billiards WebGL renderers when assigning the new colorSpace APIs
- fall back to the legacy sRGB output encoding so tables, balls, and arena props render with the previous RGB tonality

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68edf2829dfc832989ec58c5ab614c03