### PR TITLE
Optimize cloth texture generation for billiards games

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1049,8 +1049,23 @@ const ORIGINAL_HALF_H = ORIGINAL_PLAY_H / 2;
 const ORIGINAL_OUTER_HALF_H =
   ORIGINAL_HALF_H + ORIGINAL_RAIL_WIDTH * 2 + ORIGINAL_FRAME_WIDTH;
 
-const CLOTH_TEXTURE_SIZE = 4096;
 const CLOTH_THREAD_PITCH = 12 * 0.8;
+const resolveClothTextureSize = () => {
+  if (typeof window === 'undefined') {
+    return 1024;
+  }
+  const pixelRatio = window.devicePixelRatio || 1;
+  const shortEdge = Math.min(window.innerWidth || 0, window.innerHeight || 0);
+  const deviceMemory =
+    typeof navigator !== 'undefined' && typeof navigator.deviceMemory === 'number'
+      ? navigator.deviceMemory
+      : undefined;
+  if (pixelRatio >= 2 && shortEdge >= 1280 && (deviceMemory === undefined || deviceMemory >= 6)) {
+    return 2048;
+  }
+  return 1024;
+};
+const CLOTH_TEXTURE_SIZE = resolveClothTextureSize();
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 
 const createClothTextures = (() => {

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -1061,8 +1061,23 @@ const ORIGINAL_HALF_H = ORIGINAL_PLAY_H / 2;
 const ORIGINAL_OUTER_HALF_H =
   ORIGINAL_HALF_H + ORIGINAL_RAIL_WIDTH * 2 + ORIGINAL_FRAME_WIDTH;
 
-const CLOTH_TEXTURE_SIZE = 4096;
 const CLOTH_THREAD_PITCH = 12 * 0.8;
+const resolveClothTextureSize = () => {
+  if (typeof window === 'undefined') {
+    return 1024;
+  }
+  const pixelRatio = window.devicePixelRatio || 1;
+  const shortEdge = Math.min(window.innerWidth || 0, window.innerHeight || 0);
+  const deviceMemory =
+    typeof navigator !== 'undefined' && typeof navigator.deviceMemory === 'number'
+      ? navigator.deviceMemory
+      : undefined;
+  if (pixelRatio >= 2 && shortEdge >= 1280 && (deviceMemory === undefined || deviceMemory >= 6)) {
+    return 2048;
+  }
+  return 1024;
+};
+const CLOTH_TEXTURE_SIZE = resolveClothTextureSize();
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 
 const createClothTextures = (() => {


### PR DESCRIPTION
## Summary
- choose a lighter canvas size when generating cloth textures so the 3D billiards tables no longer stall during loading

## Testing
- npx eslint webapp/src/pages/Games/Snooker.jsx webapp/src/pages/Games/PoolRoyale.jsx

------
https://chatgpt.com/codex/tasks/task_e_68edfc28b6a08329a75f939b390c133b