### PR TITLE
Reset pool loading flags when tearing down game scenes

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11066,6 +11066,7 @@ export function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           if (loadTimer) {
             clearTimeout(loadTimer);
           }
+          loadingClearedRef.current = false;
         };
       } catch (e) {
         console.error(e);

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -10616,6 +10616,7 @@ function SnookerGame() {
           if (loadTimer) {
             clearTimeout(loadTimer);
           }
+          loadingClearedRef.current = false;
         };
       } catch (e) {
         console.error(e);


### PR DESCRIPTION
## Summary
- reset the 3D billiards loading guard flag when the WebGL scene is destroyed so the loader can complete again
- apply the same fix to Snooker and all Pool Royale variants so their overlays clear correctly

## Testing
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_68ee059f02a483298d8266a770f0d8a1