### PR TITLE
Handle localStorage failures in 3D billiards

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20,6 +20,7 @@ import { PoolRoyaleRules } from '../../../../src/rules/PoolRoyaleRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { getBallMaterial as getBilliardBallMaterial } from '../../utils/ballMaterialFactory.js';
+import { safeGetItem, safeSetItem } from '../../utils/safeStorage.js';
 import {
   createCueRackDisplay,
   CUE_RACK_PALETTE
@@ -4699,38 +4700,30 @@ export function PoolRoyaleGame({ variantKey, tableSizeKey }) {
     [tableSizeKey]
   );
   const [tableFinishId, setTableFinishId] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem('snookerTableFinish');
-      if (stored && TABLE_FINISHES[stored]) {
-        return stored;
-      }
+    const stored = safeGetItem('snookerTableFinish');
+    if (stored && TABLE_FINISHES[stored]) {
+      return stored;
     }
     return DEFAULT_TABLE_FINISH_ID;
   });
   const [woodTextureId, setWoodTextureId] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem('snookerWoodTexture');
-      if (stored && WOOD_GRAIN_OPTIONS_BY_ID[stored]) {
-        return stored;
-      }
+    const stored = safeGetItem('snookerWoodTexture');
+    if (stored && WOOD_GRAIN_OPTIONS_BY_ID[stored]) {
+      return stored;
     }
     return DEFAULT_WOOD_GRAIN_ID;
   });
   const [chromeColorId, setChromeColorId] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem('snookerChromeColor');
-      if (stored && CHROME_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
-        return stored;
-      }
+    const stored = safeGetItem('snookerChromeColor');
+    if (stored && CHROME_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
+      return stored;
     }
     return DEFAULT_CHROME_COLOR_ID;
   });
   const [clothColorId, setClothColorId] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem('snookerClothColor');
-      if (stored && CLOTH_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
-        return stored;
-      }
+    const stored = safeGetItem('snookerClothColor');
+    if (stored && CLOTH_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
+      return stored;
     }
     return DEFAULT_CLOTH_COLOR_ID;
   });
@@ -4760,13 +4753,11 @@ export function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   const chalkAssistTargetRef = useRef(false);
   const visibleChalkIndexRef = useRef(null);
   const [cueStyleIndex, setCueStyleIndex] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem(CUE_STYLE_STORAGE_KEY);
-      if (stored != null) {
-        const parsed = Number.parseInt(stored, 10);
-        if (Number.isFinite(parsed) && parsed >= 0) {
-          return parsed % CUE_RACK_PALETTE.length;
-        }
+    const stored = safeGetItem(CUE_STYLE_STORAGE_KEY);
+    if (stored != null) {
+      const parsed = Number.parseInt(stored, 10);
+      if (Number.isFinite(parsed) && parsed >= 0) {
+        return parsed % CUE_RACK_PALETTE.length;
       }
     }
     return 0;
@@ -4872,12 +4863,7 @@ export function PoolRoyaleGame({ variantKey, tableSizeKey }) {
 
   useEffect(() => {
     cueStyleIndexRef.current = cueStyleIndex;
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(
-        CUE_STYLE_STORAGE_KEY,
-        String(cueStyleIndex)
-      );
-    }
+    safeSetItem(CUE_STYLE_STORAGE_KEY, String(cueStyleIndex));
     applySelectedCueStyle(cueStyleIndex);
   }, [cueStyleIndex, applySelectedCueStyle]);
 
@@ -5021,24 +5007,16 @@ export function PoolRoyaleGame({ variantKey, tableSizeKey }) {
     activeVariantRef.current = activeVariant;
   }, [activeVariant]);
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('snookerTableFinish', tableFinishId);
-    }
+    safeSetItem('snookerTableFinish', tableFinishId);
   }, [tableFinishId]);
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('snookerChromeColor', chromeColorId);
-    }
+    safeSetItem('snookerChromeColor', chromeColorId);
   }, [chromeColorId]);
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('snookerClothColor', clothColorId);
-    }
+    safeSetItem('snookerClothColor', clothColorId);
   }, [clothColorId]);
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('snookerWoodTexture', woodTextureId);
-    }
+    safeSetItem('snookerWoodTexture', woodTextureId);
   }, [woodTextureId]);
   useEffect(() => {
     if (!configOpen) return undefined;

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -19,6 +19,7 @@ import { UnitySnookerRules } from '../../../../src/rules/UnitySnookerRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { getBallMaterial as getBilliardBallMaterial } from '../../utils/ballMaterialFactory.js';
+import { safeGetItem, safeSetItem } from '../../utils/safeStorage.js';
 import {
   createCueRackDisplay,
   CUE_RACK_PALETTE
@@ -4597,38 +4598,30 @@ function SnookerGame() {
   useTelegramBackButton();
   const rules = useMemo(() => new UnitySnookerRules(), []);
   const [tableFinishId, setTableFinishId] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem('snookerTableFinish');
-      if (stored && TABLE_FINISHES[stored]) {
-        return stored;
-      }
+    const stored = safeGetItem('snookerTableFinish');
+    if (stored && TABLE_FINISHES[stored]) {
+      return stored;
     }
     return DEFAULT_TABLE_FINISH_ID;
   });
   const [woodTextureId, setWoodTextureId] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem('snookerWoodTexture');
-      if (stored && WOOD_GRAIN_OPTIONS_BY_ID[stored]) {
-        return stored;
-      }
+    const stored = safeGetItem('snookerWoodTexture');
+    if (stored && WOOD_GRAIN_OPTIONS_BY_ID[stored]) {
+      return stored;
     }
     return DEFAULT_WOOD_GRAIN_ID;
   });
   const [chromeColorId, setChromeColorId] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem('snookerChromeColor');
-      if (stored && CHROME_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
-        return stored;
-      }
+    const stored = safeGetItem('snookerChromeColor');
+    if (stored && CHROME_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
+      return stored;
     }
     return DEFAULT_CHROME_COLOR_ID;
   });
   const [clothColorId, setClothColorId] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem('snookerClothColor');
-      if (stored && CLOTH_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
-        return stored;
-      }
+    const stored = safeGetItem('snookerClothColor');
+    if (stored && CLOTH_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
+      return stored;
     }
     return DEFAULT_CLOTH_COLOR_ID;
   });
@@ -4658,13 +4651,11 @@ function SnookerGame() {
   const chalkAssistTargetRef = useRef(false);
   const visibleChalkIndexRef = useRef(null);
   const [cueStyleIndex, setCueStyleIndex] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem(CUE_STYLE_STORAGE_KEY);
-      if (stored != null) {
-        const parsed = Number.parseInt(stored, 10);
-        if (Number.isFinite(parsed) && parsed >= 0) {
-          return parsed % CUE_RACK_PALETTE.length;
-        }
+    const stored = safeGetItem(CUE_STYLE_STORAGE_KEY);
+    if (stored != null) {
+      const parsed = Number.parseInt(stored, 10);
+      if (Number.isFinite(parsed) && parsed >= 0) {
+        return parsed % CUE_RACK_PALETTE.length;
       }
     }
     return 0;
@@ -4742,12 +4733,7 @@ function SnookerGame() {
 
   useEffect(() => {
     cueStyleIndexRef.current = cueStyleIndex;
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(
-        CUE_STYLE_STORAGE_KEY,
-        String(cueStyleIndex)
-      );
-    }
+    safeSetItem(CUE_STYLE_STORAGE_KEY, String(cueStyleIndex));
     applySelectedCueStyle(cueStyleIndex);
   }, [cueStyleIndex, applySelectedCueStyle]);
 
@@ -4883,24 +4869,16 @@ function SnookerGame() {
     tableFinishRef.current = tableFinish;
   }, [tableFinish]);
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('snookerTableFinish', tableFinishId);
-    }
+    safeSetItem('snookerTableFinish', tableFinishId);
   }, [tableFinishId]);
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('snookerChromeColor', chromeColorId);
-    }
+    safeSetItem('snookerChromeColor', chromeColorId);
   }, [chromeColorId]);
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('snookerClothColor', clothColorId);
-    }
+    safeSetItem('snookerClothColor', clothColorId);
   }, [clothColorId]);
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('snookerWoodTexture', woodTextureId);
-    }
+    safeSetItem('snookerWoodTexture', woodTextureId);
   }, [woodTextureId]);
   useEffect(() => {
     if (!configOpen) return undefined;

--- a/webapp/src/utils/safeStorage.js
+++ b/webapp/src/utils/safeStorage.js
@@ -1,0 +1,73 @@
+const memoryStore = new Map();
+let storageSupported;
+const warned = new Set();
+
+function logOnce(operation, key, error) {
+  const token = `${operation}:${key}`;
+  if (warned.has(token)) return;
+  warned.add(token);
+  console.warn(`localStorage ${operation} failed for key "${key}":`, error);
+}
+
+function hasStorage() {
+  if (storageSupported !== undefined) return storageSupported;
+  if (typeof window === 'undefined' || !window.localStorage) {
+    storageSupported = false;
+    return storageSupported;
+  }
+  try {
+    const testKey = '__tonplay_safe_storage__';
+    window.localStorage.setItem(testKey, '1');
+    window.localStorage.removeItem(testKey);
+    storageSupported = true;
+  } catch (error) {
+    storageSupported = false;
+    logOnce('probe', 'localStorage', error);
+  }
+  return storageSupported;
+}
+
+export function safeGetItem(key) {
+  if (typeof key !== 'string') return null;
+  if (hasStorage()) {
+    try {
+      return window.localStorage.getItem(key);
+    } catch (error) {
+      logOnce('get', key, error);
+      storageSupported = false;
+    }
+  }
+  return memoryStore.has(key) ? memoryStore.get(key) : null;
+}
+
+export function safeSetItem(key, value) {
+  if (typeof key !== 'string') return;
+  if (value == null) {
+    safeRemoveItem(key);
+    return;
+  }
+  const stringValue = String(value);
+  if (hasStorage()) {
+    try {
+      window.localStorage.setItem(key, stringValue);
+      return;
+    } catch (error) {
+      logOnce('set', key, error);
+      storageSupported = false;
+    }
+  }
+  memoryStore.set(key, stringValue);
+}
+
+export function safeRemoveItem(key) {
+  if (typeof key !== 'string') return;
+  if (hasStorage()) {
+    try {
+      window.localStorage.removeItem(key);
+    } catch (error) {
+      logOnce('remove', key, error);
+      storageSupported = false;
+    }
+  }
+  memoryStore.delete(key);
+}


### PR DESCRIPTION
## Summary
- add a safe localStorage wrapper that falls back to in-memory storage when the browser blocks persistence
- update the Snooker and Pool Royale pages to load and store table preferences through the safe storage helper so the games keep working even when localStorage is unavailable

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee142359cc8329a91eb5df30a8f076