### PR TITLE
Allow billiards games to start when balance is unavailable

### DIFF
--- a/webapp/src/components/billiards/BilliardsLobbyBase.jsx
+++ b/webapp/src/components/billiards/BilliardsLobbyBase.jsx
@@ -93,9 +93,21 @@ export default function BilliardsLobbyBase({
       try {
         accountId = await ensureAccountId();
         const balRes = await getAccountBalance(accountId);
-        if ((balRes.balance || 0) < stake.amount) {
+        const stakeAmount = Number.parseFloat(stake?.amount) || 0;
+        let balance = null;
+        if (balRes && balRes.balance != null) {
+          const rawBalance =
+            typeof balRes.balance === 'string'
+              ? Number.parseFloat(balRes.balance)
+              : balRes.balance;
+          if (Number.isFinite(rawBalance)) balance = rawBalance;
+        }
+        if (balance != null && stakeAmount > 0 && balance < stakeAmount) {
           alert('Insufficient balance');
           return;
+        }
+        if (balance == null && balRes?.error) {
+          console.warn('Failed to read account balance:', balRes.error);
         }
         tgId = getTelegramId();
         await addTransaction(tgId, -stake.amount, 'stake', {


### PR DESCRIPTION
## Summary
- relax the stake validation in the shared billiards lobby so only a confirmed low balance blocks starting a match
- warn when the balance API fails instead of treating it as zero funds

## Testing
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_68ee70b7c0188329bdf0276a1537d468