### PR TITLE
Restore site to Oct 10 05:00 baseline

### DIFF
--- a/tests/simpleOrbitCamera.test.ts
+++ b/tests/simpleOrbitCamera.test.ts
@@ -1,0 +1,13 @@
+import { computeRFit, rad } from '../webapp/src/pages/Games/simpleOrbitCamera';
+
+describe('computeRFit', () => {
+  it('fits standard portrait viewport with default theta', () => {
+    const result = computeRFit(1600, 720, 3.6, 7.2, rad(35));
+    expect(result).toBeCloseTo(10.0938048563, 6);
+  });
+
+  it('fits larger viewport with steeper pitch', () => {
+    const result = computeRFit(1920, 1080, 3.6, 7.2, rad(45));
+    expect(result).toBeCloseTo(11.6932280989, 6);
+  });
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -36,6 +36,7 @@ import {
   disposeMaterialWithWood,
   hslToHexNumber
 } from '../../utils/woodMaterials.js';
+import { MobilePortraitCameraRig, rad } from './simpleOrbitCamera';
 
 function signedRingArea(ring) {
   let area = 0;
@@ -2272,12 +2273,15 @@ function applySnookerScaling({
 
 // Kamera: ruaj kënd komod që mos shtrihet poshtë cloth-it, por lejo pak më shumë lartësi kur ngrihet
 const STANDING_VIEW_PHI = 0.92;
-const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
+// Lower the cue shot tilt so the camera can skim the rail line while staying just
+// above the cloth. Keeping the delta small ensures we don't clip through the
+// table surface when blending between views.
+const CUE_SHOT_PHI = Math.PI / 2 - 0.12;
 const STANDING_VIEW_MARGIN = 0.0024;
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.3;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.18);
-const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.24; // keep orbit camera from dipping below the table surface
+const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.08; // keep orbit camera from dipping below the table surface
 // Pull the baseline player orbit in so the cue perspective hugs the cloth a bit more, especially on portrait screens.
 const PLAYER_CAMERA_DISTANCE_FACTOR = 0.135;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
@@ -2319,11 +2323,11 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.02;
-const CUE_VIEW_RADIUS_RATIO = 0.095;
-const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.45;
+const CUE_VIEW_RADIUS_RATIO = 0.085;
+const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.34;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
-  STANDING_VIEW_PHI + 0.22
+  STANDING_VIEW_PHI + 0.38
 );
 const CUE_VIEW_PHI_LIFT = 0.08;
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
@@ -5262,6 +5266,10 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   const [err, setErr] = useState(null);
   const fireRef = useRef(() => {}); // set from effect so slider can trigger fire()
   const cameraRef = useRef(null);
+  const mobileCameraRigRef = useRef(null);
+  const lastCameraTickRef = useRef(
+    typeof performance !== 'undefined' ? performance.now() : 0
+  );
   const sphRef = useRef(null);
   const initialOrbitRef = useRef(null);
   const aimFocusRef = useRef(null);
@@ -6754,9 +6762,16 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       const camera = new THREE.PerspectiveCamera(
         CAMERA.fov,
         aspect,
-          CAMERA.near,
-          CAMERA.far
-        );
+        CAMERA.near,
+        CAMERA.far
+      );
+      const mobileCameraRig = new MobilePortraitCameraRig(camera, {
+        theta: rad(35),
+        phi: Math.PI,
+        radius: fitRadius(camera, 1.6)
+      });
+      mobileCameraRig.setViewport(host.clientWidth, host.clientHeight);
+      mobileCameraRigRef.current = mobileCameraRig;
         const standingPhi = THREE.MathUtils.clamp(
           STANDING_VIEW.phi,
           CAMERA.minPhi,
@@ -7044,6 +7059,30 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         };
 
         const updateCamera = () => {
+          const mobileRig = mobileCameraRigRef.current;
+          if (
+            mobileRig &&
+            !topViewRef.current &&
+            !(cueGalleryStateRef.current?.active ?? false) &&
+            !(activeShotView && activeShotView.mode === 'action') &&
+            !pocketCameraStateRef.current
+          ) {
+            const now = performance.now();
+            lastCameraTickRef.current = now;
+            mobileRig.setViewport(host.clientWidth, host.clientHeight);
+            mobileRig.update(now);
+            const state = mobileRig.getState();
+            const currentSph = sphRef.current;
+            if (currentSph) {
+              currentSph.radius = state.radius;
+              currentSph.theta = state.phi;
+              currentSph.phi = Math.max(1e-3, Math.PI / 2 - state.theta);
+            }
+            camera.up.set(0, 1, 0);
+            camera.lookAt(0, 0, 0);
+            activeRenderCameraRef.current = camera;
+            return camera;
+          }
           let renderCamera = camera;
           let lookTarget = null;
           let broadcastArgs = {
@@ -8163,6 +8202,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           return result;
         };
         const drag = { on: false, x: 0, y: 0, moved: false };
+        const pinch = { active: false, distance: 0 };
         const galleryDrag = {
           active: false,
           startX: 0,
@@ -8222,7 +8262,17 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           if (attemptChalkPress(e)) return;
           const currentHud = hudRef.current;
           if (currentHud?.turn === 1 || currentHud?.inHand || shooting) return;
-          if (e.touches?.length === 2) return;
+          if (e.touches?.length === 2) {
+            const t0 = e.touches[0];
+            const t1 = e.touches[1];
+            if (t0 && t1) {
+              const dx = t0.clientX - t1.clientX;
+              const dy = t0.clientY - t1.clientY;
+              pinch.active = true;
+              pinch.distance = Math.hypot(dx, dy);
+            }
+            return;
+          }
           if (topViewRef.current) return;
           drag.on = true;
           drag.moved = false;
@@ -8282,6 +8332,24 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             registerInteraction();
             return;
           }
+          if (pinch.active && e.touches?.length === 2) {
+            const t0 = e.touches[0];
+            const t1 = e.touches[1];
+            if (t0 && t1) {
+              const dx = t0.clientX - t1.clientX;
+              const dy = t0.clientY - t1.clientY;
+              const dist = Math.hypot(dx, dy);
+              if (dist > 0 && pinch.distance > 0 && mobileCameraRigRef.current) {
+                const scale = dist / pinch.distance;
+                if (Math.abs(scale - 1) > 1e-3) {
+                  mobileCameraRigRef.current.zoomBy(scale);
+                }
+              }
+              pinch.distance = dist;
+            }
+            registerInteraction();
+            return;
+          }
           if (topViewRef.current || !drag.on) return;
           const currentHud = hudRef.current;
           if (currentHud?.turn === 1) return;
@@ -8310,6 +8378,11 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                 ? CHALK_PRECISION_SLOW_MULTIPLIER
                 : 1;
             const precisionScale = basePrecisionScale * slowScale;
+            if (mobileCameraRigRef.current) {
+              const yawDelta = -dx * 0.005 * precisionScale;
+              const pitchDelta = -dy * 0.003 * precisionScale;
+              mobileCameraRigRef.current.orbit(yawDelta, pitchDelta);
+            }
             sph.theta -= dx * 0.0035 * precisionScale;
             const phiRange = CAMERA.maxPhi - CAMERA.minPhi;
             const phiDelta = dy * 0.0025 * precisionScale;
@@ -8337,6 +8410,8 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           const moved = drag.moved;
           drag.on = false;
           drag.moved = false;
+          pinch.active = false;
+          pinch.distance = 0;
           if (
             !moved &&
             !topViewRef.current &&
@@ -8365,14 +8440,17 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           const step = baseStep * slowScale;
           if (e.code === 'ArrowLeft') {
             sph.theta += step;
+            mobileCameraRigRef.current?.orbit(step, 0);
           } else if (e.code === 'ArrowRight') {
             sph.theta -= step;
+            mobileCameraRigRef.current?.orbit(-step, 0);
           } else if (e.code === 'ArrowUp' || e.code === 'ArrowDown') {
             const phiRange = CAMERA.maxPhi - CAMERA.minPhi;
             const dir = e.code === 'ArrowUp' ? -1 : 1;
             const blendDelta =
               phiRange > 1e-5 ? (step * dir) / phiRange : 0;
             applyCameraBlend(cameraBlendRef.current - blendDelta);
+            mobileCameraRigRef.current?.orbit(0, step * dir * 0.6);
           } else return;
           registerInteraction();
           updateCamera();
@@ -8484,6 +8562,12 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       sph.radius = clampOrbitRadius(sph.radius);
       const tableScale = tableSizeRef.current?.scale ?? 1;
       worldScaleFactor = WORLD_SCALE * tableScale;
+      if (mobileCameraRigRef.current) {
+        mobileCameraRigRef.current.setTableDimensions(
+          PLAY_W * worldScaleFactor,
+          PLAY_H * worldScaleFactor
+        );
+      }
       world.scale.setScalar(worldScaleFactor);
       const surfaceOffset = baseSurfaceWorldY - tableSurfaceY * worldScaleFactor;
       world.position.y = surfaceOffset;
@@ -10932,6 +11016,12 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           // Update canvas dimensions when the window size changes so the table
           // remains fully visible.
           renderer.setSize(host.clientWidth, host.clientHeight);
+          if (mobileCameraRigRef.current) {
+            mobileCameraRigRef.current.setViewport(
+              host.clientWidth,
+              host.clientHeight
+            );
+          }
           const margin = Math.max(
             STANDING_VIEW.margin,
             topViewRef.current
@@ -10957,6 +11047,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           pocketCamerasRef.current.clear();
           pocketDropRef.current.clear();
           activeRenderCameraRef.current = null;
+          mobileCameraRigRef.current = null;
           cueBodyRef.current = null;
           tipGroupRef.current = null;
           try {

--- a/webapp/src/pages/Games/simpleOrbitCamera.ts
+++ b/webapp/src/pages/Games/simpleOrbitCamera.ts
@@ -1,0 +1,265 @@
+// @ts-nocheck
+import * as THREE from 'three';
+
+const DEG2RAD = Math.PI / 180;
+const MIN_THETA = 30 * DEG2RAD;
+const MAX_THETA = 48 * DEG2RAD;
+const DEFAULT_THETA = 35 * DEG2RAD;
+const MAX_SMOOTH_STEP = 1 / 30;
+const TABLE_MARGIN_SCALE = 1.03;
+const FIT_EXTRA_MARGIN = 1.005;
+const LOW_TILT_RADIUS_SCALE = 0.86;
+const AUTO_ZOOM_STRENGTH = 0.45;
+const MAX_RADIUS_SCALE = 1.35;
+
+const tmpForward = new THREE.Vector3();
+const tmpUp = new THREE.Vector3();
+const tmpCross = new THREE.Vector3();
+const tmpDesiredUp = new THREE.Vector3();
+const tmpAxis = new THREE.Vector3();
+const tmpQuat = new THREE.Quaternion();
+const cueLocalForward = new THREE.Vector3(0, 0, -1);
+const cueLocalUp = new THREE.Vector3(0, 1, 0);
+const cueTipOffset = new THREE.Vector3();
+const cueContact = new THREE.Vector3();
+const cueDirection = new THREE.Vector3();
+const cueButt = new THREE.Vector3();
+const sharedUp = new THREE.Vector3(0, 1, 0);
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function angleDelta(target: number, current: number) {
+  let diff = target - current;
+  while (diff > Math.PI) diff -= Math.PI * 2;
+  while (diff < -Math.PI) diff += Math.PI * 2;
+  return diff;
+}
+
+export function computeRFit(
+  viewHeight: number,
+  viewWidth: number,
+  tableWidth: number,
+  tableHeight: number,
+  thetaRad: number
+) {
+  const safeWidth = viewWidth > 1e-6 ? viewWidth : 1;
+  const safeHeight = viewHeight > 1e-6 ? viewHeight : 1;
+  const aspect = safeHeight / safeWidth;
+  const vFov = 50 * DEG2RAD;
+  const hFov = 2 * Math.atan(Math.tan(vFov / 2) * (1 / aspect));
+  const hx = 0.5 * tableWidth * TABLE_MARGIN_SCALE;
+  const hz = 0.5 * tableHeight * TABLE_MARGIN_SCALE;
+  const rW = hx / Math.tan(hFov / 2);
+  const cosTheta = Math.max(Math.cos(thetaRad), 1e-4);
+  const rH = (hz / cosTheta) / Math.tan(vFov / 2);
+  return Math.max(rW, rH) * FIT_EXTRA_MARGIN;
+}
+
+type CameraOptions = {
+  target?: THREE.Vector3;
+  theta?: number;
+  phi?: number;
+  radius?: number;
+};
+
+export class MobilePortraitCameraRig {
+  private camera: THREE.PerspectiveCamera;
+  private target: THREE.Vector3;
+  private theta: number;
+  private phi: number;
+  private radius: number;
+  private thetaTarget: number;
+  private phiTarget: number;
+  private radiusTarget: number;
+  private viewWidth: number;
+  private viewHeight: number;
+  private tableWidth: number;
+  private tableHeight: number;
+  private lastUpdate = performance.now();
+
+  constructor(camera: THREE.PerspectiveCamera, options: CameraOptions = {}) {
+    this.camera = camera;
+    this.camera.fov = 50;
+    this.camera.near = 0.05;
+    this.camera.far = 1000;
+    this.target = options.target ? options.target.clone() : new THREE.Vector3();
+    this.theta = options.theta ?? DEFAULT_THETA;
+    this.phi = options.phi ?? Math.PI;
+    this.radius = options.radius ?? 6;
+    this.thetaTarget = this.theta;
+    this.phiTarget = this.phi;
+    this.radiusTarget = this.radius;
+    this.viewWidth = 1;
+    this.viewHeight = 1;
+    this.tableWidth = 3.6;
+    this.tableHeight = 7.2;
+    this.camera.up.copy(sharedUp);
+    this.camera.lookAt(this.target);
+  }
+
+  setViewport(width: number, height: number) {
+    if (!Number.isFinite(width) || !Number.isFinite(height)) return;
+    if (width <= 1e-3 || height <= 1e-3) return;
+    this.viewWidth = width;
+    this.viewHeight = height;
+    const aspect = width / height;
+    if (Math.abs(this.camera.aspect - aspect) > 1e-4) {
+      this.camera.aspect = aspect;
+      this.camera.updateProjectionMatrix();
+    }
+  }
+
+  setTableDimensions(width: number, height: number) {
+    if (width > 0) this.tableWidth = width;
+    if (height > 0) this.tableHeight = height;
+  }
+
+  orbit(deltaPhi: number, deltaTheta: number) {
+    this.phiTarget += deltaPhi;
+    this.thetaTarget = clamp(this.thetaTarget + deltaTheta, MIN_THETA, MAX_THETA);
+  }
+
+  setPhiTarget(value: number) {
+    if (!Number.isFinite(value)) return;
+    this.phiTarget = value;
+  }
+
+  zoomBy(scale: number) {
+    if (!Number.isFinite(scale) || scale === 0) return;
+    const clamped = clamp(scale, 0.5, 2);
+    this.radiusTarget *= 1 / clamped;
+  }
+
+  setRadiusTarget(value: number) {
+    if (!Number.isFinite(value)) return;
+    this.radiusTarget = value;
+  }
+
+  update(now: number) {
+    const dtMs = Math.min(now - this.lastUpdate, MAX_SMOOTH_STEP * 1000);
+    this.lastUpdate = now;
+    const dt = dtMs / 1000;
+
+    const fit = computeRFit(
+      this.viewHeight,
+      this.viewWidth,
+      this.tableWidth,
+      this.tableHeight,
+      this.thetaTarget
+    );
+    const tiltNormalized = THREE.MathUtils.clamp(
+      (this.thetaTarget - MIN_THETA) / (MAX_THETA - MIN_THETA),
+      0,
+      1
+    );
+    const preferredRadius = fit * THREE.MathUtils.lerp(LOW_TILT_RADIUS_SCALE, 1, tiltNormalized);
+    const minRadius = preferredRadius;
+    const maxRadius = fit * MAX_RADIUS_SCALE;
+    if (!Number.isFinite(this.radiusTarget)) {
+      this.radiusTarget = preferredRadius;
+    }
+    this.radiusTarget = clamp(this.radiusTarget, minRadius, maxRadius);
+    const autoZoomInfluence = (1 - tiltNormalized) * AUTO_ZOOM_STRENGTH;
+    if (autoZoomInfluence > 1e-3) {
+      this.radiusTarget = THREE.MathUtils.lerp(
+        this.radiusTarget,
+        preferredRadius,
+        autoZoomInfluence
+      );
+    }
+    if (this.radius < 1e-3) this.radius = this.radiusTarget;
+
+    const smooth = 1 - Math.pow(1 - 0.18, Math.max(dt * 60, 1));
+    this.theta += (clamp(this.thetaTarget, MIN_THETA, MAX_THETA) - this.theta) * smooth;
+    this.phi += angleDelta(this.phiTarget, this.phi) * smooth;
+    this.radius += (this.radiusTarget - this.radius) * smooth;
+
+    const cosTheta = Math.cos(this.theta);
+    const sinTheta = Math.sin(this.theta);
+    const x = this.radius * cosTheta * Math.sin(this.phi);
+    const y = this.radius * sinTheta;
+    const z = this.radius * cosTheta * Math.cos(this.phi);
+    this.camera.position.set(x + this.target.x, y + this.target.y, z + this.target.z);
+    this.camera.up.copy(sharedUp);
+    this.camera.lookAt(this.target);
+  }
+
+  getState() {
+    return {
+      theta: this.theta,
+      phi: this.phi,
+      radius: this.radius,
+      radiusTarget: this.radiusTarget
+    };
+  }
+}
+
+export function alignCueRollToUp(
+  object: THREE.Object3D,
+  worldUp: THREE.Vector3,
+  lerp: number
+) {
+  if (!object) return;
+  const t = clamp(lerp ?? 0.2, 0, 1);
+  tmpForward.copy(cueLocalForward).applyQuaternion(object.quaternion).normalize();
+  tmpUp.copy(cueLocalUp).applyQuaternion(object.quaternion).normalize();
+  tmpDesiredUp.copy(tmpForward).cross(worldUp).cross(tmpForward).normalize();
+  if (tmpDesiredUp.lengthSq() < 1e-6) return;
+  const dot = clamp(tmpUp.dot(tmpDesiredUp), -1, 1);
+  const angle = Math.acos(dot);
+  if (angle < 1e-4) return;
+  tmpCross.copy(tmpUp).cross(tmpDesiredUp);
+  const sign = tmpCross.dot(tmpForward) < 0 ? -1 : 1;
+  tmpAxis.copy(tmpForward).multiplyScalar(sign).normalize();
+  tmpQuat.setFromAxisAngle(tmpAxis, angle * t);
+  object.quaternion.multiply(tmpQuat).normalize();
+}
+
+type CueSpinArgs = {
+  cue: THREE.Object3D | null;
+  cueBallPosition: THREE.Vector3;
+  cueBallRadius: number;
+  spinX: number;
+  spinY: number;
+  cueLength: number;
+};
+
+const clampSpin = (value: number) => clamp(value, -1, 1);
+
+export function updateCueFromSpin({
+  cue,
+  cueBallPosition,
+  cueBallRadius,
+  spinX,
+  spinY,
+  cueLength
+}: CueSpinArgs) {
+  if (!cue) return;
+  const k = 0.6;
+  const sx = clampSpin(spinX) * k * cueBallRadius;
+  const sy = clampSpin(spinY) * k * cueBallRadius;
+  const cap = Math.max(0, cueBallRadius * cueBallRadius - (sx * sx + sy * sy));
+  const nz = -Math.sqrt(cap);
+  cueTipOffset.set(sx, 0, sy);
+  cueContact.copy(cueBallPosition).add(cueTipOffset);
+  cueContact.y += nz;
+
+  cueDirection.copy(cueContact).sub(cueBallPosition);
+  if (cueDirection.lengthSq() < 1e-8) {
+    cueDirection.set(0, 0, -1);
+  } else {
+    cueDirection.normalize();
+  }
+  tmpQuat.setFromUnitVectors(cueLocalForward, cueDirection);
+  cue.quaternion.copy(tmpQuat);
+  alignCueRollToUp(cue, sharedUp, 0.2);
+
+  cueButt.copy(cueContact).addScaledVector(cueDirection, -cueLength);
+  cue.position.copy(cueButt);
+}
+
+export function rad(value: number) {
+  return value * DEG2RAD;
+}


### PR DESCRIPTION
## Summary
- restore the PoolRoyale camera configuration to the Oct 10 05:00 baseline
- reintroduce the mobile portrait camera rig utilities used for cue alignment
- restore the computeRFit unit tests from the 5:00 AM snapshot

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee88c79c18832983bc1d5455708be2