### PR TITLE
Fix Pool Royale routing and relax mobile gating

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -115,10 +115,10 @@ export default function App() {
             />
             <Route path="/games/murlanroyale" element={<MurlanRoyale />} />
             <Route
-              path="/games/pollroyale/lobby"
+              path="/games/poolroyale/lobby"
               element={<PoolRoyaleLobby />}
             />
-            <Route path="/games/pollroyale" element={<PoolRoyale />} />
+            <Route path="/games/poolroyale" element={<PoolRoyale />} />
             <Route path="/games/snooker" element={<Snooker />} />
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -40,7 +40,7 @@ export default function HomeGamesCard() {
           </h3>
         </Link>
         <Link
-          to="/games/pollroyale/lobby"
+          to="/games/poolroyale/lobby"
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -64,7 +64,7 @@ export default function InvitePopup({
                     alt: 'Goal Rush',
                   },
                   {
-                    id: 'pollroyale',
+                    id: 'poolroyale',
                     src: '/assets/icons/pool-royale.svg',
                     alt: 'Pool Royale',
                   },

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -10,15 +10,8 @@ import { NFT_GIFTS } from '../utils/nftGifts.js';
 function getGameFromTableId(id) {
   if (!id) return 'snake';
   const prefix = id.split('-')[0];
-  if (
-    [
-      'snake',
-      'fallingball',
-      'goalrush',
-      'pollroyale',
-      'poolroyale',
-    ].includes(prefix)
-  )
+  if (prefix === 'pollroyale') return 'poolroyale';
+  if (['snake', 'fallingball', 'goalrush', 'poolroyale'].includes(prefix))
     return prefix;
   return 'snake';
 }
@@ -180,7 +173,7 @@ export default function PlayerInvitePopup({
                   alt: 'Goal Rush',
                 },
                 {
-                  id: 'pollroyale',
+                  id: 'poolroyale',
                   src: '/assets/icons/pool-royale.svg',
                   alt: 'Pool Royale',
                 },

--- a/webapp/src/hooks/useIsMobile.js
+++ b/webapp/src/hooks/useIsMobile.js
@@ -4,16 +4,25 @@ export function useIsMobile(maxWidth = 768) {
   const [isMobile, setIsMobile] = useState(() => {
     if (typeof window === 'undefined') return false;
     const touch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-    return touch && window.innerWidth <= maxWidth;
+    const narrow = window.innerWidth <= maxWidth;
+    return touch || narrow;
   });
 
   useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
     const check = () => {
       const touch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-      setIsMobile(touch && window.innerWidth <= maxWidth);
+      const narrow = window.innerWidth <= maxWidth;
+      setIsMobile(touch || narrow);
     };
+
+    check();
     window.addEventListener('resize', check);
-    return () => window.removeEventListener('resize', check);
+    window.addEventListener('orientationchange', check);
+    return () => {
+      window.removeEventListener('resize', check);
+      window.removeEventListener('orientationchange', check);
+    };
   }, [maxWidth]);
 
   return isMobile;

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -45,7 +45,7 @@ export default function Games() {
               </h3>
             </Link>
             <Link
-              to="/games/pollroyale/lobby"
+              to="/games/poolroyale/lobby"
               className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
             >
               <img

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -77,7 +77,7 @@ export default function PoolRoyaleLobby() {
     if (devAcc1) params.set('dev1', devAcc1);
     if (devAcc2) params.set('dev2', devAcc2);
     if (initData) params.set('init', encodeURIComponent(initData));
-    navigate(`/games/pollroyale?${params.toString()}`);
+    navigate(`/games/poolroyale?${params.toString()}`);
   };
 
   const winnerParam = new URLSearchParams(search).get('winner');


### PR DESCRIPTION
## Summary
- allow Pool Royale routes and invites to use the correct poolroyale slug everywhere
- relax the mobile-only gate so Pool Royale and Snooker can run on wider or non-touch devices

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ee9322d8b08329999caad5f81b0b90