### PR TITLE
Fix color space setup for 3D billiards textures

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25,6 +25,7 @@ import {
   createCueRackDisplay,
   CUE_RACK_PALETTE
 } from '../../utils/createCueRackDisplay.js';
+import { applySRGBColorSpace } from '../../utils/applySRGBColorSpace.js';
 import {
   WOOD_FINISH_PRESETS,
   WOOD_GRAIN_OPTIONS,
@@ -1331,8 +1332,7 @@ const createClothTextures = (() => {
     colorMap.generateMipmaps = true;
     colorMap.minFilter = THREE.LinearMipmapLinearFilter;
     colorMap.magFilter = THREE.LinearFilter;
-    if ('colorSpace' in colorMap) colorMap.colorSpace = THREE.SRGBColorSpace;
-    else colorMap.encoding = THREE.sRGBEncoding;
+    applySRGBColorSpace(colorMap);
     colorMap.needsUpdate = true;
 
     const bumpCanvas = document.createElement('canvas');
@@ -1755,8 +1755,7 @@ const createCarpetTextures = (() => {
     texture.minFilter = THREE.LinearMipMapLinearFilter;
     texture.magFilter = THREE.LinearFilter;
     texture.generateMipmaps = true;
-    if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-    else texture.encoding = THREE.sRGBEncoding;
+    applySRGBColorSpace(texture);
 
     // bump map: derive from red base with extra fiber noise
     const bumpCanvas = document.createElement('canvas');
@@ -2978,8 +2977,7 @@ function makeClothTexture(
   const repeatY = baseRepeat * (PLAY_H / TABLE.H);
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 48;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applySRGBColorSpace(texture);
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
@@ -3070,8 +3068,7 @@ function makeWoodTexture({
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 8;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applySRGBColorSpace(texture);
   texture.needsUpdate = true;
   return texture;
 }
@@ -5956,8 +5953,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 4;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        applySRGBColorSpace(texture);
         let offset = 0;
         return {
           texture,
@@ -5995,8 +5991,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 8;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        applySRGBColorSpace(texture);
         let pulse = 0;
         const createAvatarStore = () => ({
           image: null,

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -32,6 +32,7 @@ import {
   DEFAULT_WOOD_TEXTURE_SIZE,
   applyWoodTextures
 } from '../../utils/woodMaterials.js';
+import { applySRGBColorSpace } from '../../utils/applySRGBColorSpace.js';
 
 function signedRingArea(ring) {
   let area = 0;
@@ -1351,8 +1352,7 @@ const createClothTextures = (() => {
     colorMap.generateMipmaps = true;
     colorMap.minFilter = THREE.LinearMipmapLinearFilter;
     colorMap.magFilter = THREE.LinearFilter;
-    if ('colorSpace' in colorMap) colorMap.colorSpace = THREE.SRGBColorSpace;
-    else colorMap.encoding = THREE.sRGBEncoding;
+    applySRGBColorSpace(colorMap);
     colorMap.needsUpdate = true;
 
     const bumpCanvas = document.createElement('canvas');
@@ -1790,8 +1790,7 @@ const createCarpetTextures = (() => {
     texture.minFilter = THREE.LinearMipMapLinearFilter;
     texture.magFilter = THREE.LinearFilter;
     texture.generateMipmaps = true;
-    if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-    else texture.encoding = THREE.sRGBEncoding;
+    applySRGBColorSpace(texture);
 
     // bump map: derive from red base with extra fiber noise
     const bumpCanvas = document.createElement('canvas');
@@ -2909,8 +2908,7 @@ function makeClothTexture(
   const repeatY = baseRepeat * (PLAY_H / TABLE.H);
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 48;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applySRGBColorSpace(texture);
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
@@ -3001,8 +2999,7 @@ function makeWoodTexture({
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 8;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applySRGBColorSpace(texture);
   texture.needsUpdate = true;
   return texture;
 }
@@ -5826,8 +5823,7 @@ function SnookerGame() {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 4;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        applySRGBColorSpace(texture);
         let offset = 0;
         return {
           texture,
@@ -5865,8 +5861,7 @@ function SnookerGame() {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 8;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        applySRGBColorSpace(texture);
         let pulse = 0;
         const createAvatarStore = () => ({
           image: null,

--- a/webapp/src/utils/applySRGBColorSpace.js
+++ b/webapp/src/utils/applySRGBColorSpace.js
@@ -1,0 +1,13 @@
+import * as THREE from 'three';
+
+const SRGB_COLOR_SPACE = THREE.SRGBColorSpace ?? null;
+
+export function applySRGBColorSpace(texture) {
+  if (!texture) {
+    return;
+  }
+
+  if (SRGB_COLOR_SPACE && 'colorSpace' in texture) {
+    texture.colorSpace = SRGB_COLOR_SPACE;
+  }
+}

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { applySRGBColorSpace } from './applySRGBColorSpace.js';
 
 const BALL_TEXTURE_SIZE = 1024;
 const BALL_TEXTURE_CACHE = new Map();
@@ -247,8 +248,7 @@ function createBallTexture({ baseColor, pattern, number, variantKey }) {
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applySRGBColorSpace(texture);
   texture.needsUpdate = true;
 
   BALL_TEXTURE_CACHE.set(key, texture);


### PR DESCRIPTION
## Summary
- add a shared helper to apply the SRGB color space using the current Three.js API
- update the 3D Snooker and Pool Royale pages to rely on the helper instead of the removed sRGBEncoding constant
- adjust the billiard ball material factory to use the helper when generating textures

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ee9df24b7483299d6f827f3bba271d