### PR TITLE
Restore sRGB compatibility across 3D games

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -5,6 +5,7 @@ import {
   createArenaCarpetMaterial,
   createArenaWallMaterial
 } from '../utils/arenaDecor.js';
+import { applyRendererSRGB } from '../utils/colorSpace.js';
 import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../utils/arenaCameraConfig.js';
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
@@ -996,7 +997,7 @@ export default function SnakeBoard3D({
     if (!mount) return;
 
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' });
-    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    applyRendererSRGB(renderer);
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
     renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
     renderer.domElement.style.width = '100%';

--- a/webapp/src/components/TableTennis3D.jsx
+++ b/webapp/src/components/TableTennis3D.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { createArenaCarpetMaterial, createArenaWallMaterial } from "../utils/arenaDecor.js";
+import { applySRGBColorSpace } from "../utils/colorSpace.js";
 
 /**
  * TABLE TENNIS 3D — Mobile Portrait (1:1)
@@ -118,7 +119,7 @@ export default function TableTennis3D({ player, ai }){
     const wheelMat = new THREE.MeshStandardMaterial({ color: 0x111111, roughness: 0.9 });
     const paddleWoodTex = makePaddleWoodTexture();
     paddleWoodTex.anisotropy = 8;
-    paddleWoodTex.colorSpace = THREE.SRGBColorSpace;
+    applySRGBColorSpace(paddleWoodTex);
     const paddleWoodMat = new THREE.MeshPhysicalMaterial({
       map: paddleWoodTex,
       color: 0xffffff,

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -5,6 +5,7 @@ import {
   createArenaCarpetMaterial,
   createArenaWallMaterial
 } from '../../utils/arenaDecor.js';
+import { applyRendererSRGB } from '../../utils/colorSpace.js';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
   getTelegramFirstName,
@@ -523,7 +524,7 @@ function Chess3D({ avatar, username }) {
       alpha: false,
       powerPreference: 'high-performance'
     });
-    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    applyRendererSRGB(renderer);
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
     renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
     // Ensure the canvas covers the entire host element so the board is centered

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -5,6 +5,7 @@ import {
   createArenaCarpetMaterial,
   createArenaWallMaterial
 } from '../../utils/arenaDecor.js';
+import { applyRendererSRGB } from '../../utils/colorSpace.js';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
   getTelegramFirstName,
@@ -337,7 +338,7 @@ function Ludo3D({ avatar, username }) {
       powerPreference: 'high-performance'
     });
     renderer.localClippingEnabled = true;
-    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    applyRendererSRGB(renderer);
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
     renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
     renderer.domElement.style.position = 'absolute';

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -11,6 +11,7 @@ import {
   createArenaCarpetMaterial,
   createArenaWallMaterial
 } from '../../utils/arenaDecor.js';
+import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../../utils/arenaCameraConfig.js';
 import {
   ComboType,
@@ -821,7 +822,7 @@ export default function MurlanRoyaleArena({ search }) {
     if (!mount) return undefined;
 
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' });
-    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    applyRendererSRGB(renderer);
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
     renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
     renderer.domElement.style.width = '100%';
@@ -946,7 +947,7 @@ export default function MurlanRoyaleArena({ search }) {
     const scoreboardContext = scoreboardCanvas.getContext('2d');
     if (scoreboardContext) {
       const scoreboardTexture = new THREE.CanvasTexture(scoreboardCanvas);
-      scoreboardTexture.colorSpace = THREE.SRGBColorSpace;
+      applySRGBColorSpace(scoreboardTexture);
       scoreboardTexture.anisotropy = 8;
       const scoreboardMaterial = new THREE.MeshBasicMaterial({
         map: scoreboardTexture,
@@ -1000,7 +1001,7 @@ export default function MurlanRoyaleArena({ search }) {
     arena.add(frame);
 
     const velvetTex = makeVelvetTexture(1024, 1024, tableTheme.feltTop, tableTheme.feltBottom);
-    velvetTex.colorSpace = THREE.SRGBColorSpace;
+    applySRGBColorSpace(velvetTex);
     velvetTex.anisotropy = 8;
     const velvetMat = new THREE.MeshStandardMaterial({ map: velvetTex, roughness: 0.7, metalness: 0.15 });
     const surface = new THREE.Mesh(
@@ -1931,7 +1932,7 @@ function makeLabelTexture(name, avatar) {
   const display = avatar && avatar.startsWith('http') ? '' : avatar || '🂠';
   g.fillText(display, 48, 172);
   const texture = new THREE.CanvasTexture(canvas);
-  texture.colorSpace = THREE.SRGBColorSpace;
+  applySRGBColorSpace(texture);
   texture.anisotropy = 8;
   if (avatar && avatar.startsWith('http')) {
     const img = new Image();
@@ -2185,7 +2186,7 @@ function makeCardFace(rank, suit, theme, w = 512, h = 720) {
   g.textAlign = 'center';
   g.fillText(suit, w / 2, h / 2 + 56);
   const tex = new THREE.CanvasTexture(canvas);
-  tex.colorSpace = THREE.SRGBColorSpace;
+  applySRGBColorSpace(tex);
   tex.anisotropy = 8;
   return tex;
 }
@@ -2215,7 +2216,7 @@ function makeCardBackTexture(theme, w = 512, h = 720) {
     }
   }
   const texture = new THREE.CanvasTexture(canvas);
-  texture.colorSpace = THREE.SRGBColorSpace;
+  applySRGBColorSpace(texture);
   texture.anisotropy = 8;
   return texture;
 }
@@ -2236,7 +2237,9 @@ function makeVelvetTexture(w, h, c1, c2) {
     ctx.fillStyle = `rgba(255,255,255,${Math.random() * 0.03})`;
     ctx.fillRect(px, py, 1, 1);
   }
-  return new THREE.CanvasTexture(canvas);
+  const texture = new THREE.CanvasTexture(canvas);
+  applySRGBColorSpace(texture);
+  return texture;
 }
 
 function applyTableThemeMaterials(three, theme) {
@@ -2248,7 +2251,7 @@ function applyTableThemeMaterials(three, theme) {
   if (parts.surfaceMat) {
     parts.velvetTexture?.dispose?.();
     const tex = makeVelvetTexture(1024, 1024, theme.feltTop, theme.feltBottom);
-    tex.colorSpace = THREE.SRGBColorSpace;
+    applySRGBColorSpace(tex);
     tex.anisotropy = 8;
     parts.surfaceMat.map = tex;
     parts.surfaceMat.needsUpdate = true;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -36,6 +36,7 @@ import {
   disposeMaterialWithWood,
   hslToHexNumber
 } from '../../utils/woodMaterials.js';
+import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 
 function signedRingArea(ring) {
   let area = 0;
@@ -1330,8 +1331,7 @@ const createClothTextures = (() => {
     colorMap.generateMipmaps = true;
     colorMap.minFilter = THREE.LinearMipmapLinearFilter;
     colorMap.magFilter = THREE.LinearFilter;
-    if ('colorSpace' in colorMap) colorMap.colorSpace = THREE.SRGBColorSpace;
-    else colorMap.encoding = THREE.sRGBEncoding;
+    applySRGBColorSpace(colorMap);
     colorMap.needsUpdate = true;
 
     const bumpCanvas = document.createElement('canvas');
@@ -1754,8 +1754,7 @@ const createCarpetTextures = (() => {
     texture.minFilter = THREE.LinearMipMapLinearFilter;
     texture.magFilter = THREE.LinearFilter;
     texture.generateMipmaps = true;
-    if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-    else texture.encoding = THREE.sRGBEncoding;
+    applySRGBColorSpace(texture);
 
     // bump map: derive from red base with extra fiber noise
     const bumpCanvas = document.createElement('canvas');
@@ -2974,8 +2973,7 @@ function makeClothTexture(
   const repeatY = baseRepeat * (PLAY_H / TABLE.H);
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 48;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applySRGBColorSpace(texture);
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
@@ -3066,8 +3064,7 @@ function makeWoodTexture({
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 8;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applySRGBColorSpace(texture);
   texture.needsUpdate = true;
   return texture;
 }
@@ -5839,7 +5836,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         powerPreference: 'high-performance'
       });
       renderer.useLegacyLights = false;
-      renderer.outputColorSpace = THREE.SRGBColorSpace;
+      applyRendererSRGB(renderer);
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.2;
       const devicePixelRatio = window.devicePixelRatio || 1;
@@ -5942,8 +5939,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 4;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        applySRGBColorSpace(texture);
         let offset = 0;
         return {
           texture,
@@ -5981,8 +5977,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 8;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        applySRGBColorSpace(texture);
         let pulse = 0;
         const createAvatarStore = () => ({
           image: null,

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -32,6 +32,7 @@ import {
   DEFAULT_WOOD_TEXTURE_SIZE,
   applyWoodTextures
 } from '../../utils/woodMaterials.js';
+import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 
 function signedRingArea(ring) {
   let area = 0;
@@ -1351,8 +1352,7 @@ const createClothTextures = (() => {
     colorMap.generateMipmaps = true;
     colorMap.minFilter = THREE.LinearMipmapLinearFilter;
     colorMap.magFilter = THREE.LinearFilter;
-    if ('colorSpace' in colorMap) colorMap.colorSpace = THREE.SRGBColorSpace;
-    else colorMap.encoding = THREE.sRGBEncoding;
+    applySRGBColorSpace(colorMap);
     colorMap.needsUpdate = true;
 
     const bumpCanvas = document.createElement('canvas');
@@ -1790,8 +1790,7 @@ const createCarpetTextures = (() => {
     texture.minFilter = THREE.LinearMipMapLinearFilter;
     texture.magFilter = THREE.LinearFilter;
     texture.generateMipmaps = true;
-    if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-    else texture.encoding = THREE.sRGBEncoding;
+    applySRGBColorSpace(texture);
 
     // bump map: derive from red base with extra fiber noise
     const bumpCanvas = document.createElement('canvas');
@@ -2909,8 +2908,7 @@ function makeClothTexture(
   const repeatY = baseRepeat * (PLAY_H / TABLE.H);
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 48;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applySRGBColorSpace(texture);
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
@@ -3001,8 +2999,7 @@ function makeWoodTexture({
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(repeatX, repeatY);
   texture.anisotropy = 8;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applySRGBColorSpace(texture);
   texture.needsUpdate = true;
   return texture;
 }
@@ -5718,7 +5715,7 @@ function SnookerGame() {
         powerPreference: 'high-performance'
       });
       renderer.useLegacyLights = false;
-      renderer.outputColorSpace = THREE.SRGBColorSpace;
+      applyRendererSRGB(renderer);
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.2;
       const devicePixelRatio = window.devicePixelRatio || 1;
@@ -5820,8 +5817,7 @@ function SnookerGame() {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 4;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        applySRGBColorSpace(texture);
         let offset = 0;
         return {
           texture,
@@ -5859,8 +5855,7 @@ function SnookerGame() {
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;
         texture.anisotropy = 8;
-        if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-        else texture.encoding = THREE.sRGBEncoding;
+        applySRGBColorSpace(texture);
         let pulse = 0;
         const createAvatarStore = () => ({
           image: null,

--- a/webapp/src/utils/arenaDecor.js
+++ b/webapp/src/utils/arenaDecor.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { applySRGBColorSpace } from './colorSpace.js';
 
 const clamp01 = (v) => Math.min(1, Math.max(0, v));
 
@@ -96,7 +97,7 @@ function ensureCarpetTextures() {
   map.minFilter = THREE.LinearMipMapLinearFilter;
   map.magFilter = THREE.LinearFilter;
   map.generateMipmaps = true;
-  if ('colorSpace' in map) map.colorSpace = THREE.SRGBColorSpace;
+  applySRGBColorSpace(map);
 
   const bumpCanvas = document.createElement('canvas');
   bumpCanvas.width = bumpCanvas.height = size;

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { applySRGBColorSpace } from './colorSpace.js';
 
 const BALL_TEXTURE_SIZE = 1024;
 const BALL_TEXTURE_CACHE = new Map();
@@ -247,8 +248,7 @@ function createBallTexture({ baseColor, pattern, number, variantKey }) {
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
-  if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
-  else texture.encoding = THREE.sRGBEncoding;
+  applySRGBColorSpace(texture);
   texture.needsUpdate = true;
 
   BALL_TEXTURE_CACHE.set(key, texture);

--- a/webapp/src/utils/colorSpace.js
+++ b/webapp/src/utils/colorSpace.js
@@ -1,0 +1,25 @@
+import * as THREE from 'three';
+
+const LEGACY_SRGB_ENCODING = 3001;
+
+function getLegacySrgbEncoding() {
+  return LEGACY_SRGB_ENCODING;
+}
+
+export function applySRGBColorSpace(target) {
+  if (!target) return;
+  if ('colorSpace' in target) {
+    target.colorSpace = THREE.SRGBColorSpace;
+  } else {
+    target.encoding = getLegacySrgbEncoding();
+  }
+}
+
+export function applyRendererSRGB(renderer) {
+  if (!renderer) return;
+  if ('outputColorSpace' in renderer) {
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+  } else {
+    renderer.outputEncoding = getLegacySrgbEncoding();
+  }
+}

--- a/webapp/src/utils/createCueRackDisplay.js
+++ b/webapp/src/utils/createCueRackDisplay.js
@@ -6,6 +6,7 @@ import {
   shiftLightness,
   shiftSaturation
 } from './woodMaterials.js';
+import { applySRGBColorSpace } from './colorSpace.js';
 
 export const CUE_RACK_PALETTE = WOOD_FINISH_PRESETS.map((preset) =>
   hslToHexNumber(preset.hue, preset.sat, preset.light)
@@ -140,7 +141,7 @@ export function createCueRackDisplay({
     ctx.globalAlpha = 1;
   }
   const clothTexture = new THREE.CanvasTexture(clothCanvas);
-  clothTexture.colorSpace = THREE.SRGBColorSpace;
+  applySRGBColorSpace(clothTexture);
   clothTexture.wrapS = THREE.RepeatWrapping;
   clothTexture.wrapT = THREE.RepeatWrapping;
   clothTexture.anisotropy = 8;

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { applySRGBColorSpace } from './colorSpace.js';
 
 const clamp01 = (value) => Math.min(1, Math.max(0, value));
 const normalizeHue = (h) => {
@@ -51,7 +52,7 @@ const makeNaturalWoodTexture = (width, height, hue, sat, light, contrast) => {
   ctx.globalAlpha = 1;
 
   const texture = new THREE.CanvasTexture(canvas);
-  texture.colorSpace = THREE.SRGBColorSpace;
+  applySRGBColorSpace(texture);
   texture.anisotropy = 16;
   return texture;
 };


### PR DESCRIPTION
## Summary
- add shared color space helpers to unify renderer and texture fallback logic
- update snooker, pool, and other 3D experiences to apply the helper so textures and renderers use sRGB output
- adjust supporting utilities to remove dark rendering artifacts on legacy WebGL environments

## Testing
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_68ef2730ef4483299dccac07e0e96803