### PR TITLE
Remove fake loaders from snooker and pool royale

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -5062,34 +5062,6 @@ function SnookerGame() {
   const startUserSuggestionRef = useRef(() => {});
   const autoAimRequestRef = useRef(false);
   const aiTelemetryRef = useRef({ key: null, countdown: 0 });
-  const [loading, setLoading] = useState(true);
-  const [loadingProgress, setLoadingProgress] = useState(0);
-  const loadingClearedRef = useRef(false);
-  useEffect(() => {
-    let raf = null;
-    let active = true;
-    if (!loading) {
-      setLoadingProgress(100);
-      return () => {};
-    }
-    const start = performance.now();
-    const duration = 2200;
-    const tick = (now) => {
-      if (!active) return;
-      const t = Math.min(1, (now - start) / duration);
-      const eased = 1 - Math.pow(1 - t, 3);
-      const next = Math.min(95, Math.max(0, Math.round(eased * 95)));
-      setLoadingProgress((prev) => (prev >= next ? prev : next));
-      if (loading) {
-        raf = requestAnimationFrame(tick);
-      }
-    };
-    raf = requestAnimationFrame(tick);
-    return () => {
-      active = false;
-      if (raf) cancelAnimationFrame(raf);
-    };
-  }, [loading]);
   const [hud, setHud] = useState({
     power: 0.65,
     A: 0,
@@ -5698,7 +5670,6 @@ function SnookerGame() {
   useEffect(() => {
     const host = mountRef.current;
     if (!host) return;
-    let loadTimer = null;
     const cueRackDisposers = [];
     try {
       const updatePocketCameraState = (active) => {
@@ -10580,13 +10551,6 @@ function SnookerGame() {
           }
           const frameCamera = updateCamera();
           renderer.render(scene, frameCamera ?? camera);
-          if (!loadingClearedRef.current) {
-            loadingClearedRef.current = true;
-            loadTimer = window.setTimeout(() => {
-              setLoading(false);
-              setLoadingProgress(100);
-            }, 120);
-          }
           rafRef.current = requestAnimationFrame(step);
         };
         step(performance.now());
@@ -10658,15 +10622,10 @@ function SnookerGame() {
           cueGalleryStateRef.current.prev = null;
           cueGalleryStateRef.current.position?.set(0, 0, 0);
           cueGalleryStateRef.current.target?.set(0, 0, 0);
-          if (loadTimer) {
-            clearTimeout(loadTimer);
-          }
         };
       } catch (e) {
         console.error(e);
         setErr(e?.message || String(e));
-        setLoading(false);
-        setLoadingProgress(100);
       }
   }, []);
 
@@ -10843,19 +10802,6 @@ function SnookerGame() {
     };
   }, [updateSpinDotPosition]);
 
-  const displayedProgress = Math.min(
-    100,
-    Math.max(0, Math.round(loadingProgress))
-  );
-  const cueStrikeProgress = Math.min(1, displayedProgress / 12);
-  const cueBaseOffset = 16;
-  const cueDrawBack = 18;
-  const cueTrackWidth = 200;
-  const ballOffsetStart = cueBaseOffset + 28;
-  const cueBallRadius = 12;
-  const ballTravel = Math.max(0, Math.min(1, (displayedProgress - 12) / 88));
-  const cuePosition = cueBaseOffset - cueDrawBack * (1 - cueStrikeProgress);
-  const cueBallPosition = ballOffsetStart + cueTrackWidth * ballTravel;
   const bottomHudVisible = hud.turn === 0 && !hud.over && !shotActive;
 
   return (
@@ -11049,31 +10995,6 @@ function SnookerGame() {
           </div>
         )}
       </div>
-
-      {(loading || displayedProgress < 100) && (
-        <div className="absolute inset-0 z-[70] flex flex-col items-center justify-center gap-6 bg-gradient-to-b from-black via-black/95 to-black text-white">
-          <div className="relative w-64 h-24">
-            <div className="absolute left-0 top-1/2 h-1.5 w-full -translate-y-1/2 rounded-full bg-white/15" />
-            <div
-              className="absolute left-0 top-1/2 h-1.5 -translate-y-1/2 rounded-full bg-emerald-400/80 transition-all duration-150 ease-out"
-              style={{ width: `${displayedProgress}%` }}
-            />
-            <div
-              className="absolute left-0 top-1/2 h-2 w-28 rounded-r-full bg-amber-300 shadow-lg shadow-amber-500/40 transition-transform duration-150 ease-out"
-              style={{ transform: `translate(${cuePosition}px, -50%)` }}
-            />
-            <div
-              className="absolute left-0 top-1/2 h-6 w-6 rounded-full border border-emerald-200 bg-white shadow-[0_0_16px_rgba(74,222,128,0.5)] transition-transform duration-150 ease-out"
-              style={{
-                transform: `translate(${cueBallPosition - cueBallRadius}px, -50%)`
-              }}
-            />
-          </div>
-          <div className="text-sm tracking-[0.3em] uppercase text-emerald-200">
-            Loading {displayedProgress}%
-          </div>
-        </div>
-      )}
 
       {bottomHudVisible && (
         <div


### PR DESCRIPTION
## Summary
- remove the simulated loading overlays from the 3D Snooker and Pool Royale pages so the tables appear immediately
- simplify the initialization and cleanup logic now that the fake loading timers are gone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ef3de047dc8329915545923e9f712d