### PR TITLE
Align Pool Royale cue camera with Snooker

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2277,8 +2277,8 @@ const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.3;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.18);
 const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.24; // keep orbit camera from dipping below the table surface
-// Pull the baseline player orbit in so the cue perspective hugs the cloth a bit more, especially on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.135;
+// Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.085;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
 const BROADCAST_DISTANCE_MULTIPLIER = 0.36;
@@ -2298,8 +2298,7 @@ const CAMERA = {
   // keep the camera slightly above the horizontal plane but allow a lower sweep
   maxPhi: CAMERA_MAX_PHI
 };
-const CAMERA_CUSHION_CLEARANCE = TABLE.THICK * 0.92; // keep standing orbit safely above cushion lip and align with pocket cam height
-const CUE_VIEW_CUSHION_CLEARANCE = CAMERA_CUSHION_CLEARANCE; // match the snooker cue clearance so transitions stay consistent
+const CAMERA_CUSHION_CLEARANCE = TABLE.THICK * 0.6; // keep orbit height safely above cushion lip while hugging the rail
 const STANDING_VIEW = Object.freeze({
   phi: STANDING_VIEW_PHI,
   margin: STANDING_VIEW_MARGIN
@@ -2317,23 +2316,15 @@ const BREAK_VIEW = Object.freeze({
   radius: CAMERA.minR, // start the intro framing closer to the table surface
   phi: CAMERA.maxPhi - 0.01
 });
-const CAMERA_RAIL_SAFETY = 0.02;
-const CUE_VIEW_RADIUS_RATIO = 0.095;
-const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.45;
+const CAMERA_RAIL_SAFETY = 0.006;
+const CUE_VIEW_RADIUS_RATIO = 0.085;
+const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.35;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
   STANDING_VIEW_PHI + 0.22
 );
 const CUE_VIEW_PHI_LIFT = 0.08;
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
-// Mirror the snooker cue framing so both games share the same up-close feel around the cloth.
-const CUE_VIEW_RAIL_CLEARANCE = BALL_R * 0.1;
-// Lift the cue-view camera so the cue stick and cue ball stay framed together while aiming.
-const CUE_VIEW_ABOVE_CUE = BALL_R * 1.08;
-const CUE_VIEW_EXTRA_HEIGHT = BALL_R * 0.42;
-const CUE_VIEW_BACK_MIN_RATIO = 0.26;
-const CUE_VIEW_BACK_RATIO = 0.34;
-const CUE_VIEW_BASE_CUE_LENGTH = (BALL_R / 0.0525) * 1.5 * CUE_LENGTH_MULTIPLIER;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,
   CAMERA_MAX_PHI - 0.02
@@ -2408,9 +2399,6 @@ const TMP_VEC2_LIMIT = new THREE.Vector2();
 const TMP_VEC2_AXIS = new THREE.Vector2();
 const TMP_VEC2_VIEW = new THREE.Vector2();
 const TMP_VEC3_A = new THREE.Vector3();
-const TMP_VEC3_B = new THREE.Vector3();
-const TMP_VEC3_CAMERA = new THREE.Vector3();
-const TMP_VEC3_DIR = new THREE.Vector3();
 const TMP_VEC3_BUTT = new THREE.Vector3();
 const TMP_VEC3_CHALK = new THREE.Vector3();
 const TMP_VEC3_CHALK_DELTA = new THREE.Vector3();
@@ -2483,89 +2471,6 @@ const computeCueViewVector = (cueBall, camera) => {
   TMP_VEC2_VIEW.set(cx, cz);
   if (TMP_VEC2_VIEW.lengthSq() < 1e-8) return null;
   return TMP_VEC2_VIEW.clone().normalize();
-};
-
-const computeCueCameraMinHeight = (worldScaleFactor, cushionHeight = TABLE.THICK) => {
-  const cushion = Number.isFinite(cushionHeight) ? cushionHeight : TABLE.THICK;
-  const railHeightLocal = TABLE_Y + cushion;
-  const railHeightWorld = railHeightLocal * worldScaleFactor;
-  const cueHeightWorld = CUE_Y * worldScaleFactor;
-  const railClearanceWorld = CUE_VIEW_RAIL_CLEARANCE * worldScaleFactor;
-  const aboveCueWorld = CUE_VIEW_ABOVE_CUE * worldScaleFactor;
-  return Math.max(railHeightWorld + railClearanceWorld, cueHeightWorld + aboveCueWorld);
-};
-
-const computeAimFocusTarget = (cueBall, aimDir) => {
-  if (!cueBall?.pos || !aimDir) return null;
-  const dir = new THREE.Vector2(aimDir.x ?? 0, aimDir.y ?? 0);
-  if (dir.lengthSq() < 1e-6) return null;
-  dir.normalize();
-  const focusDistance = Math.max(
-    BALL_R * 32,
-    Math.min(LONG_SHOT_DISTANCE, PLAY_H * 0.48)
-  );
-  return new THREE.Vector3(
-    THREE.MathUtils.clamp(
-      cueBall.pos.x + dir.x * focusDistance,
-      -PLAY_W / 2,
-      PLAY_W / 2
-    ),
-    BALL_CENTER_Y,
-    THREE.MathUtils.clamp(
-      cueBall.pos.y + dir.y * focusDistance,
-      -PLAY_H / 2,
-      PLAY_H / 2
-    )
-  );
-};
-
-const computeCueAimCameraOffset = ({
-  cueBall,
-  aimDir,
-  focusWorld,
-  worldScaleFactor,
-  cushionHeight,
-  orbitOffset
-}) => {
-  if (!cueBall || !aimDir || !focusWorld) return null;
-  const aimX = Number.isFinite(aimDir.x) ? aimDir.x : 0;
-  const aimY = Number.isFinite(aimDir.y) ? aimDir.y : 0;
-  TMP_VEC3_DIR.set(-aimX, 0, -aimY);
-  if (TMP_VEC3_DIR.lengthSq() < 1e-6) return null;
-  TMP_VEC3_DIR.normalize();
-  const cueLengthWorld = CUE_VIEW_BASE_CUE_LENGTH * worldScaleFactor;
-  const tipGapWorld = CUE_TIP_GAP * worldScaleFactor;
-  const minBackWorld = Math.max(
-    cueLengthWorld * CUE_VIEW_BACK_MIN_RATIO,
-    BALL_R * 10 * worldScaleFactor
-  );
-  const maxBackWorld = Math.max(
-    cueLengthWorld + tipGapWorld - BALL_R * 2.2 * worldScaleFactor,
-    minBackWorld
-  );
-  const targetBackWorld = THREE.MathUtils.clamp(
-    cueLengthWorld * CUE_VIEW_BACK_RATIO,
-    minBackWorld,
-    maxBackWorld
-  );
-  TMP_VEC3_B.copy(TMP_VEC3_DIR).multiplyScalar(targetBackWorld);
-  const cueBallWorldY = focusWorld.y;
-  const minCameraY = computeCueCameraMinHeight(worldScaleFactor, cushionHeight);
-  const desiredY = Math.max(
-    minCameraY,
-    cueBallWorldY + CUE_VIEW_EXTRA_HEIGHT * worldScaleFactor
-  );
-  TMP_VEC3_B.y = desiredY - cueBallWorldY;
-  if (orbitOffset) {
-    const orbitHorizontal = Math.hypot(orbitOffset.x, orbitOffset.z);
-    const cueHorizontal = Math.hypot(TMP_VEC3_B.x, TMP_VEC3_B.z);
-    if (cueHorizontal > orbitHorizontal && orbitHorizontal > 1e-3) {
-      const scale = orbitHorizontal / cueHorizontal;
-      TMP_VEC3_B.x *= scale;
-      TMP_VEC3_B.z *= scale;
-    }
-  }
-  return TMP_VEC3_B.clone();
 };
 
 const computeShortRailBroadcastDistance = (camera) => {
@@ -6853,15 +6758,6 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           return clamp(value, min, maxRadius);
         };
 
-        const getCameraClearance = (blend = cameraBlendRef.current ?? 1) => {
-          const normalized = THREE.MathUtils.clamp(blend ?? 1, 0, 1);
-          return THREE.MathUtils.lerp(
-            CUE_VIEW_CUSHION_CLEARANCE,
-            CAMERA_CUSHION_CLEARANCE,
-            normalized
-          );
-        };
-
         const syncBlendToSpherical = () => {
           const bounds = cameraBoundsRef.current;
           if (!bounds) return;
@@ -6910,7 +6806,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           const cushionHeight = cushionHeightRef.current ?? TABLE.THICK;
           const minHeightFromTarget = Math.max(
             TABLE.THICK,
-            cushionHeight + getCameraClearance(blend)
+            cushionHeight + CAMERA_CUSHION_CLEARANCE
           );
           const phiRailLimit = Math.acos(
             THREE.MathUtils.clamp(minHeightFromTarget / Math.max(radius, 1e-3), -1, 1)
@@ -7568,7 +7464,8 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             }
             lookTarget = activeShotView.smoothedTarget;
           } else {
-            const aimFocus = !shooting && cue?.active ? aimFocusRef.current : null;
+            const aimFocus =
+              !shooting && cue?.active ? aimFocusRef.current : null;
             let focusTarget;
             if (
               aimFocus &&
@@ -7578,14 +7475,12 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             ) {
               focusTarget = aimFocus.clone();
             } else if (cue?.active && !shooting) {
-              const aimFocus = computeAimFocusTarget(cue, aimDirRef.current);
-              if (aimFocus) {
-                aimFocusRef.current = aimFocus.clone();
-                focusTarget = aimFocus;
-              } else {
-                aimFocusRef.current = null;
-                focusTarget = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
-              }
+              aimFocusRef.current = null;
+              focusTarget = new THREE.Vector3(
+                cue.pos.x,
+                BALL_CENTER_Y,
+                cue.pos.y
+              );
             } else {
               aimFocusRef.current = null;
               const store = ensureOrbitFocus();
@@ -7608,48 +7503,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             focusTarget.multiplyScalar(worldScaleFactor);
             lookTarget = focusTarget;
             TMP_SPH.copy(sph);
-            TMP_VEC3_A.setFromSpherical(TMP_SPH);
-            let finalOffset = TMP_VEC3_A;
-            const cueBlend = THREE.MathUtils.clamp(
-              cameraBlendRef.current ?? 1,
-              0,
-              1
-            );
-            const cueWeight = Math.pow(1 - cueBlend, 0.85);
-            if (
-              cueWeight > 1e-4 &&
-              cue?.active &&
-              !shooting &&
-              aimDirRef.current &&
-              Number.isFinite(aimDirRef.current.x) &&
-              Number.isFinite(aimDirRef.current.y)
-            ) {
-              TMP_VEC2_A.copy(aimDirRef.current);
-              if (TMP_VEC2_A.lengthSq() > 1e-6) {
-                TMP_VEC2_A.normalize();
-                const cueOffset = computeCueAimCameraOffset({
-                  cueBall: cue,
-                  aimDir: TMP_VEC2_A,
-                  focusWorld: lookTarget,
-                  worldScaleFactor,
-                  cushionHeight: cushionHeightRef.current ?? TABLE.THICK,
-                  orbitOffset: TMP_VEC3_A
-                });
-                if (cueOffset) {
-                  TMP_VEC3_B.copy(TMP_VEC3_A).lerp(cueOffset, cueWeight);
-                  finalOffset = TMP_VEC3_B;
-                }
-              }
-            }
-            TMP_VEC3_CAMERA.copy(lookTarget).add(finalOffset);
-            const minCameraHeight = computeCueCameraMinHeight(
-              worldScaleFactor,
-              cushionHeightRef.current ?? TABLE.THICK
-            );
-            if (TMP_VEC3_CAMERA.y < minCameraHeight) {
-              TMP_VEC3_CAMERA.y = minCameraHeight;
-            }
-            camera.position.copy(TMP_VEC3_CAMERA);
+            camera.position.setFromSpherical(TMP_SPH).add(lookTarget);
             camera.lookAt(lookTarget);
             renderCamera = camera;
             broadcastArgs.focusWorld =
@@ -7751,7 +7605,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           const theta = orbit.theta ?? sph.theta;
           const cushionLimit = Math.max(
             TABLE.THICK * 0.5,
-            (cushionHeightRef.current ?? TABLE.THICK) + getCameraClearance()
+            (cushionHeightRef.current ?? TABLE.THICK) + CAMERA_CUSHION_CLEARANCE
           );
           const phiCap = Math.acos(
             THREE.MathUtils.clamp(cushionLimit / radius, -1, 1)
@@ -8047,7 +7901,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           orbitRadiusLimitRef.current = standingRadius;
           const cushionLimit = Math.max(
             TABLE.THICK * 0.5,
-            (cushionHeightRef.current ?? TABLE.THICK) + getCameraClearance()
+            (cushionHeightRef.current ?? TABLE.THICK) + CAMERA_CUSHION_CLEARANCE
           );
           const phiCap = Math.acos(
             THREE.MathUtils.clamp(cushionLimit / sph.radius, -1, 1)


### PR DESCRIPTION
## Summary
- align the Pool Royale cue camera distance and clearance constants with the Snooker configuration
- simplify the cue camera update path to match the Snooker orbit logic and remove bespoke offset helpers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef47c504c48329b170daa14a226158