### PR TITLE
Update dice interactions for snake and ludo

### DIFF
--- a/webapp/src/components/Dice.jsx
+++ b/webapp/src/components/Dice.jsx
@@ -1,11 +1,17 @@
 import LuxuryDice from './LuxuryDice.jsx';
 
 export default function DiceSet(props) {
-  const { values = [1], rolling = false } = props;
+  const { values = [1], rolling = false, transparent = false } = props;
   return (
     <div className="flex gap-4 justify-center items-center">
       {values.map((v, i) => (
-        <LuxuryDice key={i} value={v} rolling={rolling} size={values.length > 1 ? 110 : 140} />
+        <LuxuryDice
+          key={i}
+          value={v}
+          rolling={rolling}
+          size={values.length > 1 ? 110 : 140}
+          transparent={transparent}
+        />
       ))}
     </div>
   );

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -15,6 +15,7 @@ export default function DiceRoller({
   emitRollEvent = false,
   divRef,
   className = '',
+  diceTransparent = false,
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -102,7 +103,12 @@ export default function DiceRoller({
         onClick={clickable ? rollDice : undefined}
         ref={divRef}
       >
-        <Dice values={values} rolling={rolling} startValues={startValuesRef.current} />
+        <Dice
+          values={values}
+          rolling={rolling}
+          startValues={startValuesRef.current}
+          transparent={diceTransparent}
+        />
       </div>
       {!clickable && showButton && (
         <button

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1761,6 +1761,34 @@ export default function SnakeAndLadder() {
         }))
       ];
 
+  const computedIndex = isMultiplayer
+    ? mpPlayers.findIndex((p) => p.id === getPlayerId())
+    : 0;
+  const myPlayerIndex = computedIndex >= 0 ? computedIndex : null;
+  const canRoll =
+    myPlayerIndex !== null &&
+    currentTurn === myPlayerIndex &&
+    !moving &&
+    rollCooldown === 0 &&
+    !gameOver &&
+    !waitingForPlayers &&
+    !playerAutoRolling &&
+    aiRollingIndex == null &&
+    !watchOnly;
+  const hasTurnMessage =
+    turnMessage !== null &&
+    turnMessage !== '' &&
+    turnMessage !== false;
+  const displayedTurnMessage = hasTurnMessage
+    ? turnMessage
+    : canRoll
+    ? 'Your turn'
+    : null;
+
+  const handleRollButtonClick = () => {
+    diceRollerDivRef.current?.click();
+  };
+
   // determine ranking numbers based on board positions
   const rankMap = {};
   players
@@ -2040,6 +2068,7 @@ export default function SnakeAndLadder() {
             trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
             showButton={false}
             muted={muted}
+            diceTransparent
           />
           </div>
         </div>
@@ -2052,9 +2081,8 @@ export default function SnakeAndLadder() {
         >
           <div className="scale-90">
           {(() => {
-            const myId = getPlayerId();
-            const myIndex = mpPlayers.findIndex(p => p.id === myId);
-            if (currentTurn === myIndex && !moving) {
+            if (myPlayerIndex === null) return null;
+            if (currentTurn === myPlayerIndex && !moving) {
               return (
                 <DiceRoller
                   clickable
@@ -2062,12 +2090,31 @@ export default function SnakeAndLadder() {
                   muted={muted}
                   emitRollEvent
                   divRef={diceRollerDivRef}
+                  diceTransparent
                 />
               );
             }
             return null;
           })()}
           </div>
+        </div>
+      )}
+      {!watchOnly && (
+        <div className="fixed bottom-6 inset-x-0 flex flex-col items-center z-30 pointer-events-none space-y-3">
+          {displayedTurnMessage && (
+            <div className="px-4 py-2 rounded-full bg-[rgba(7,10,18,0.7)] border border-[rgba(255,215,0,0.25)] text-white text-sm font-semibold backdrop-blur">
+              {displayedTurnMessage}
+            </div>
+          )}
+          {canRoll && (
+            <button
+              type="button"
+              onClick={handleRollButtonClick}
+              className="pointer-events-auto px-6 py-3 rounded-full font-semibold text-sm text-[#f7e7a4] shadow-lg bg-gradient-to-b from-[#2b2b2b] to-[#121212] border border-[rgba(255,215,0,0.45)]"
+            >
+              ROLL
+            </button>
+          )}
         </div>
       )}
       {!watchOnly && (


### PR DESCRIPTION
## Summary
- make the luxury dice component support transparent rendering so it can match the provided 3D gold dice design across games
- surface bottom roll UI messaging in Snake & Ladder and hook the roll button into the dice roller while using the transparent dice
- enable tap-to-roll dice interaction in Ludo Battle Royal with updated status messaging in place of the old button

## Testing
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_68efa1eab1648329ba3478768298c5e3