### PR TITLE
style: give ludo dice an aluminum look

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -264,19 +264,25 @@ input:focus {
 }
 
 .dice-cube {
-  @apply relative w-12 h-12 bg-white rounded-xl;
-  border: none;
+  @apply relative w-12 h-12 rounded-xl;
+  background: linear-gradient(140deg, #f5f5f5 0%, #d5d5d5 45%, #b0b0b0 100%);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-shadow: inset 0 2px 3px rgba(255, 255, 255, 0.6), inset 0 -3px 6px rgba(0, 0, 0, 0.25),
+    0 10px 18px rgba(0, 0, 0, 0.45);
   transform-style: preserve-3d;
   transition: transform 0.5s;
 }
 
 .dice-face {
-  @apply absolute w-full h-full flex items-center justify-center bg-white rounded-xl shadow-lg;
-  border: none;
+  @apply absolute w-full h-full flex items-center justify-center rounded-xl;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.95), rgba(180, 180, 180, 0.95));
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  box-shadow: inset 0 2px 4px rgba(255, 255, 255, 0.5), inset 0 -3px 6px rgba(0, 0, 0, 0.3);
 }
 
 .dice-face .dot {
-  @apply w-2 h-2 bg-black rounded-full;
+  @apply w-3 h-3 bg-black rounded-full;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
 }
 
 .dice-face--front {
@@ -369,13 +375,15 @@ input:focus {
 }
 
 .token-dice .dice-face {
-  background-color: #fff;
-  border: none;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.95), rgba(180, 180, 180, 0.95));
+  border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 0.5rem;
+  box-shadow: inset 0 2px 4px rgba(255, 255, 255, 0.5), inset 0 -3px 6px rgba(0, 0, 0, 0.3);
 }
 
 .token-dice .dice-face .dot {
-  @apply w-2 h-2 bg-black;
+  @apply w-3 h-3 bg-black;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
 }
 
 /* Three.js token container */


### PR DESCRIPTION
## Summary
- refresh the shared dice styles with metallic gradients and stronger shadows
- increase dot size and contrast so pips stay visible on the aluminum finish
- apply the same finish to dice-based player tokens for consistency

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68efa76403cc83298a5bb3ea57f29e84