### PR TITLE
Fix snake dice visuals and align 3D camera

### DIFF
--- a/webapp/src/components/LuxuryDice.jsx
+++ b/webapp/src/components/LuxuryDice.jsx
@@ -23,10 +23,12 @@ const orientationMap = (() => {
 })();
 
 function placePips(group, pipMaterial, geometrySet) {
-  const pipRadius = 0.085;
-  const pipDepth = 0.05;
+  const pipRadius = 0.09;
+  const pipDepth = 0.08;
   const pipGeo = new THREE.CylinderGeometry(pipRadius, pipRadius, pipDepth, 28, 1);
-  const inset = DIE_SIZE / 2 - 0.02;
+  const surface = DIE_SIZE / 2;
+  const embedOffset = 0.0025;
+  const centerOffset = surface - pipDepth / 2 + embedOffset;
   const faceDefinitions = [
     { normal: new THREE.Vector3(0, 1, 0), points: [[0, 0]] },
     {
@@ -88,8 +90,10 @@ function placePips(group, pipMaterial, geometrySet) {
         .copy(new THREE.Vector3())
         .addScaledVector(x, gx)
         .addScaledVector(y, gy)
-        .addScaledVector(n, inset - pipDepth / 2);
+        .addScaledVector(n, centerOffset);
       mesh.quaternion.copy(new THREE.Quaternion().setFromUnitVectors(up, n));
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
       group.add(mesh);
       geometrySet?.add(mesh.geometry);
     });


### PR DESCRIPTION
## Summary
- adjust the Three.js dice pip geometry so dots sit on the surface and receive lighting
- retune the Snake & Ladder 3D arena camera to use the same targeting/fit behaviour as the Chess Battle Royal view
- update the renderer canvas styling and board centering so the scene matches the chess arena presentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68efa6dbfa78832983369293145f2322