### PR TITLE
Adjust Murlan Royale table cloth texture density

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2445,7 +2445,9 @@ function makeRoughClothTexture(size, topHex, bottomHex, anisotropy = 8) {
 
   const texture = new THREE.CanvasTexture(canvas);
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
-  texture.repeat.set(12, 12);
+  const baseRepeat = 12;
+  const scaledRepeat = baseRepeat * 10; // shrink the cloth weave by repeating the texture 10x more densely
+  texture.repeat.set(scaledRepeat, scaledRepeat);
   texture.anisotropy = anisotropy;
   applySRGBColorSpace(texture);
   texture.needsUpdate = true;


### PR DESCRIPTION
## Summary
- increase the repeat density of the Murlan Royale table cloth texture to make the weave appear 10x smaller

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efce7e5c2c8329b97dd0ece506ff82