### PR TITLE
Enhance 3D shading for dice pips

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -281,8 +281,19 @@ input:focus {
 }
 
 .dice-face .dot {
-  @apply w-3 h-3 bg-black rounded-full;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+  @apply relative w-3 h-3 rounded-full;
+  background: radial-gradient(circle at 35% 35%, rgba(255, 255, 255, 0.75), rgba(35, 35, 35, 0.95) 55%, rgba(0, 0, 0, 0.95));
+  box-shadow: inset 0 2px 3px rgba(255, 255, 255, 0.25), inset 0 -3px 5px rgba(0, 0, 0, 0.6), 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+.dice-face .dot::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 25% 25%, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0));
+  mix-blend-mode: screen;
+  pointer-events: none;
 }
 
 .dice-face--front {


### PR DESCRIPTION
## Summary
- add radial gradients and highlights to dice pips
- enhance box shadows to give a semi-spherical appearance on dice faces

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68efced39cc08329bdf184395893ff6d