### PR TITLE
Stop rail collisions from triggering ball impact audio

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -10409,8 +10409,8 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                 const baseVol = speed / RAIL_HIT_SOUND_REFERENCE_SPEED;
                 const railVolume = clamp(baseVol * shotScale, 0, 1);
                 if (railVolume > 0) {
-                  const railMultiplier = hitRail === 'corner' ? 1.1 : 0.9;
-                  playBallHit(railVolume * railMultiplier);
+                  // Cushion contacts should remain silent so only ball collisions
+                  // trigger impact audio cues. Leave the cooldown updates intact.
                 }
                 railSoundTimeRef.current.set(b.id, nowRail);
               }

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -10191,8 +10191,10 @@ function SnookerGame() {
                 const baseVol = speed / RAIL_HIT_SOUND_REFERENCE_SPEED;
                 const railVolume = clamp(baseVol * shotScale, 0, 1);
                 if (railVolume > 0) {
-                  const railMultiplier = hitRail === 'corner' ? 1.1 : 0.9;
-                  playBallHit(railVolume * railMultiplier);
+                  // Previously cushion contacts reused the ball impact sound which
+                  // made every rail touch sound like a ball collision. The sound
+                  // should only play for ball-on-ball impacts, so we avoid playing
+                  // audio here while keeping the cooldown bookkeeping intact.
                 }
                 railSoundTimeRef.current.set(b.id, nowRail);
               }


### PR DESCRIPTION
## Summary
- stop reusing the ball impact sound effect for cushion collisions in Snooker and Pool Royale
- keep the cushion hit bookkeeping but ensure audio only fires for ball-on-ball contacts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efd4391d6c8329b57ec668b9c54e0b