### PR TITLE
Boost cue power and spin effects

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -641,8 +641,8 @@ const SPIN_AIR_DECAY = 0.997; // hold spin energy while the cue ball travels str
 const SWERVE_THRESHOLD = 0.85; // outer 15% of the spin control activates swerve behaviour
 const SWERVE_TRAVEL_MULTIPLIER = 0.55; // dampen sideways drift while swerve is active so it stays believable
 const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the cue ball is rolling after impact
-// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) so identical slider values feel the same.
-const SHOT_FORCE_BOOST = 1;
+// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while adding a 50% boost for livelier strikes.
+const SHOT_FORCE_BOOST = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
 const SHOT_POWER_RANGE = 0.75;
@@ -707,6 +707,9 @@ const SPIN_BOX_FILL_RATIO =
     : 1;
 const SPIN_CLEARANCE_MARGIN = BALL_R * 0.4;
 const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.6;
+const SIDE_SPIN_MULTIPLIER = 1.25;
+const BACKSPIN_MULTIPLIER = 1.7;
+const TOPSPIN_MULTIPLIER = 1.3;
 // angle for cushion cuts guiding balls into pockets
 const CUSHION_CUT_ANGLE = 32;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
@@ -3182,15 +3185,27 @@ function Guret(parent, id, color, x, y, options = {}) {
   mesh.castShadow = true;
   mesh.receiveShadow = true;
   if (id === 'cue') {
-    const markerGeom = new THREE.CircleGeometry(CUE_MARKER_RADIUS, 48);
-    const markerMat = new THREE.MeshBasicMaterial({
+    const markerGeom = new THREE.CylinderGeometry(
+      CUE_MARKER_RADIUS,
+      CUE_MARKER_RADIUS,
+      CUE_MARKER_DEPTH,
+      48
+    );
+    const markerMat = new THREE.MeshStandardMaterial({
       color: 0xff3b3b,
-      side: THREE.DoubleSide
+      emissive: 0x5a0000,
+      emissiveIntensity: 0.4,
+      roughness: 0.28,
+      metalness: 0.05
     });
     markerMat.depthWrite = false;
+    markerMat.needsUpdate = true;
     markerMat.toneMapped = false;
-    const markerOffset = BALL_R - CUE_MARKER_DEPTH * 0.5;
-    const localForward = new THREE.Vector3(0, 0, 1);
+    markerMat.polygonOffset = true;
+    markerMat.polygonOffsetFactor = -0.5;
+    markerMat.polygonOffsetUnits = -0.5;
+    const markerOffset = BALL_R - CUE_MARKER_DEPTH * 0.5 + 0.001;
+    const localUp = new THREE.Vector3(0, 1, 0);
     [
       new THREE.Vector3(1, 0, 0),
       new THREE.Vector3(-1, 0, 0),
@@ -3201,7 +3216,7 @@ function Guret(parent, id, color, x, y, options = {}) {
     ].forEach((normal) => {
       const marker = new THREE.Mesh(markerGeom, markerMat);
       marker.position.copy(normal).multiplyScalar(markerOffset);
-      marker.quaternion.setFromUnitVectors(localForward, normal);
+      marker.quaternion.setFromUnitVectors(localUp, normal);
       marker.castShadow = false;
       marker.receiveShadow = false;
       marker.renderOrder = 2;
@@ -9381,8 +9396,14 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           }
           const appliedSpin = applySpinConstraints(aimDir, true);
           const ranges = spinRangeRef.current || {};
-          const spinSide = appliedSpin.x * (ranges.side ?? 0);
-          const spinTop = -appliedSpin.y * (ranges.forward ?? 0);
+          const baseSide = appliedSpin.x * (ranges.side ?? 0);
+          let spinSide = baseSide * SIDE_SPIN_MULTIPLIER;
+          let spinTop = -appliedSpin.y * (ranges.forward ?? 0);
+          if (appliedSpin.y > 0) {
+            spinTop *= BACKSPIN_MULTIPLIER;
+          } else if (appliedSpin.y < 0) {
+            spinTop *= TOPSPIN_MULTIPLIER;
+          }
           const perp = new THREE.Vector2(-aimDir.y, aimDir.x);
           cue.vel.copy(base);
           if (cue.spin) {


### PR DESCRIPTION
## Summary
- increase shot force for the 3D snooker and Pool Royale builds by 50%
- amplify applied side/top/back spin scaling to hit the requested targets
- rebuild the cue-ball markers as filled red cylinders so the dots stay visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68efd8eb55a08329bb3c3d801f94af11