### PR TITLE
Adjust royale table proportions

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -11,8 +11,8 @@ import { createMurlanStyleTable } from '../utils/murlanTable.js';
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 
-const TABLE_RADIUS = 2.55; // Matches the Murlan Royale octagonal table footprint
-const TABLE_HEIGHT = 0.81;
+const TABLE_RADIUS = 3.315; // 30% wider footprint so the board matches other royale arenas
+const TABLE_HEIGHT = 2.05; // Raised to line up with the oversized chair seats
 const WALL_PROXIMITY_FACTOR = 0.5;
 const WALL_HEIGHT_MULTIPLIER = 2;
 const CHAIR_SCALE = 4;

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -54,8 +54,8 @@ const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
 const BOARD_DISPLAY_SIZE = 3.4;
 const BOARD_SCALE = BOARD_DISPLAY_SIZE / RAW_BOARD_SIZE;
 
-const TABLE_RADIUS = 2.55; // Matches the octagonal table footprint from Murlan Royale
-const TABLE_HEIGHT = 0.81; // Same tabletop elevation as Murlan Royale
+const TABLE_RADIUS = 3.315; // 30% wider footprint to better fill the arena
+const TABLE_HEIGHT = 2.05; // Raised so the surface aligns with the oversized chairs
 
 const WALL_PROXIMITY_FACTOR = 0.5; // Bring arena walls 50% closer
 const WALL_HEIGHT_MULTIPLIER = 2; // Double wall height

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -24,8 +24,8 @@ import { createMurlanStyleTable } from '../../utils/murlanTable.js';
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 
-const TABLE_RADIUS = 2.55;
-const TABLE_HEIGHT = 0.81;
+const TABLE_RADIUS = 3.315; // 30% wider to mirror the Chess Battle Royal arena scale
+const TABLE_HEIGHT = 2.05; // Raised so the surface meets the chair seating height
 
 const WALL_PROXIMITY_FACTOR = 0.5;
 const WALL_HEIGHT_MULTIPLIER = 2;

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -220,8 +220,13 @@ export function createMurlanStyleTable({
   const trimHeight = 0.08 * scaleFactor;
   const trimOffset = 0.06 * scaleFactor;
   const clothRise = 0.07 * scaleFactor;
-  const baseHeight = 0.62 * scaleFactor;
+  let baseHeight = 0.62 * scaleFactor;
   const tableY = tableHeight - clothRise;
+
+  const minBaseHeight = tableY > 0 ? tableY * 2 : 0;
+  if (baseHeight < minBaseHeight) {
+    baseHeight = minBaseHeight;
+  }
 
   const baseMat = new ThreeNamespace.MeshPhysicalMaterial({
     color: new ThreeNamespace.Color(baseOption.baseColor),


### PR DESCRIPTION
## Summary
- widen the chess, ludo, and snake royale tables by 30% and raise their surfaces to align with the oversized chairs
- extend the reusable table builder so taller tables keep their bases planted on the arena floor

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68efdf570fbc8329b3447b34aaa1b315