### PR TITLE
Add 3D arenas for poker experiences

### DIFF
--- a/webapp/src/pages/Games/BlackJack.jsx
+++ b/webapp/src/pages/Games/BlackJack.jsx
@@ -1,16 +1,13 @@
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import BlackJackArena from './BlackJackArena.jsx';
 
 export default function BlackJack() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
     <div className="relative w-full h-screen">
-      <iframe
-        src={`/blackjack.html${search}`}
-        title="Black Jack Multiplayer"
-        className="w-full h-full border-0"
-      />
+      <BlackJackArena search={search} />
     </div>
   );
 }

--- a/webapp/src/pages/Games/BlackJackArena.jsx
+++ b/webapp/src/pages/Games/BlackJackArena.jsx
@@ -1,0 +1,708 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+import { createArenaCarpetMaterial, createArenaWallMaterial } from '../../utils/arenaDecor.js';
+import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
+import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../../utils/arenaCameraConfig.js';
+import { createMurlanStyleTable } from '../../utils/murlanTable.js';
+import { createCardGeometry, createCardMesh, orientCard, setCardFace } from '../../utils/cards3d.js';
+import { createChipFactory } from '../../utils/chips3d.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import {
+  createDeck,
+  shuffle,
+  dealInitial,
+  hitCard,
+  handValue,
+  isBust,
+  aiAction
+} from '../../utils/blackjackLogic.js';
+
+const MODEL_SCALE = 0.75;
+const TABLE_RADIUS = 3.2 * MODEL_SCALE;
+const TABLE_HEIGHT = 1.05 * MODEL_SCALE;
+const ARENA_GROWTH = 1.45;
+const CARD_W = 0.4 * MODEL_SCALE;
+const CARD_H = 0.56 * MODEL_SCALE;
+const CARD_D = 0.02 * MODEL_SCALE;
+const HOLE_SPACING = CARD_W * 0.65;
+const DEALER_INDEX = 4;
+const PLAYER_COUNT = 5; // 4 seats + dealer
+const CAMERA_SETTINGS = buildArenaCameraConfig(TABLE_RADIUS * ARENA_GROWTH);
+
+const REGION_NAMES = typeof Intl !== 'undefined' ? new Intl.DisplayNames(['en'], { type: 'region' }) : null;
+
+function flagToName(flag) {
+  if (!flag || !REGION_NAMES) return 'Guest';
+  const codes = Array.from(flag, (c) => c.codePointAt(0) - 0x1f1e6 + 65);
+  if (codes.length !== 2) return 'Guest';
+  const code = String.fromCharCode(codes[0], codes[1]);
+  return REGION_NAMES.of(code) || 'Guest';
+}
+
+function parseSearch(search) {
+  const params = new URLSearchParams(search);
+  const username = params.get('username') || 'You';
+  const amount = Number.parseInt(params.get('amount') || '500', 10);
+  const token = params.get('token') || 'TPC';
+  const stake = Number.isFinite(amount) && amount > 0 ? amount : 500;
+  return { username, stake, token };
+}
+
+function buildPlayers(search) {
+  const { username, stake } = parseSearch(search);
+  const baseChips = Math.max(200, Math.round(stake));
+  const flags = [...FLAG_EMOJIS].sort(() => 0.5 - Math.random());
+  const players = [];
+  for (let i = 0; i < PLAYER_COUNT; i += 1) {
+    if (i === DEALER_INDEX) {
+      players.push({
+        id: 'dealer',
+        name: 'Dealer',
+        flag: '🎩',
+        isDealer: true,
+        isHuman: false,
+        chips: baseChips * 2,
+        avatar: null
+      });
+    } else if (i === 0) {
+      const flag = flags.shift() || '🇦🇱';
+      players.push({
+        id: 'player',
+        name: username,
+        flag,
+        isDealer: false,
+        isHuman: true,
+        chips: baseChips,
+        avatar: null
+      });
+    } else {
+      const flag = flags[i] || FLAG_EMOJIS[(i * 11) % FLAG_EMOJIS.length];
+      players.push({
+        id: `ai-${i}`,
+        name: flagToName(flag),
+        flag,
+        isDealer: false,
+        isHuman: false,
+        chips: baseChips,
+        avatar: null
+      });
+    }
+  }
+  return players;
+}
+
+function createSeatLayout(count) {
+  const radius = TABLE_RADIUS * ARENA_GROWTH * 1.02;
+  const layout = [];
+  for (let i = 0; i < count; i += 1) {
+    const angle = Math.PI / 2 + (i / count) * Math.PI * 2;
+    const forward = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle));
+    const right = new THREE.Vector3(-Math.sin(angle), 0, Math.cos(angle));
+    const seatPos = forward.clone().multiplyScalar(radius);
+    seatPos.y = TABLE_HEIGHT * 0.3;
+    const cardAnchor = forward.clone().multiplyScalar(TABLE_RADIUS * (i === DEALER_INDEX ? 0.45 : 0.68));
+    cardAnchor.y = TABLE_HEIGHT + CARD_D * 6;
+    const chipAnchor = forward.clone().multiplyScalar(TABLE_RADIUS * 0.55);
+    chipAnchor.y = TABLE_HEIGHT + CARD_D * 6;
+    const betAnchor = forward.clone().multiplyScalar(TABLE_RADIUS * 0.35);
+    betAnchor.y = TABLE_HEIGHT + CARD_D * 6;
+    const labelAnchor = forward.clone().multiplyScalar(radius + 0.28 * MODEL_SCALE);
+    labelAnchor.y = TABLE_HEIGHT + 0.6 * MODEL_SCALE;
+    layout.push({ angle, forward, right, seatPos, cardAnchor, chipAnchor, betAnchor, labelAnchor });
+  }
+  return layout;
+}
+
+function makeNameplate(name, chips, renderer) {
+  const canvas = document.createElement('canvas');
+  canvas.width = 512;
+  canvas.height = 220;
+  const ctx = canvas.getContext('2d');
+  const draw = (playerName, stack, highlight, status) => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = highlight ? 'rgba(34,197,94,0.3)' : 'rgba(15,23,42,0.78)';
+    ctx.strokeStyle = highlight ? '#4ade80' : 'rgba(255,255,255,0.16)';
+    ctx.lineWidth = 10;
+    roundRect(ctx, 16, 16, canvas.width - 32, canvas.height - 32, 32);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = '#f8fafc';
+    ctx.font = '700 64px "Inter", system-ui, sans-serif';
+    ctx.textBaseline = 'top';
+    ctx.fillText(playerName, 40, 40);
+    ctx.font = '600 48px "Inter", system-ui, sans-serif';
+    ctx.fillStyle = '#cbd5f5';
+    ctx.fillText(`${stack} chips`, 40, 130);
+    if (status) {
+      ctx.textAlign = 'right';
+      ctx.fillStyle = '#facc15';
+      ctx.fillText(status, canvas.width - 40, 130);
+      ctx.textAlign = 'left';
+    }
+  };
+  draw(name, chips, false, '');
+  const texture = new THREE.CanvasTexture(canvas);
+  applySRGBColorSpace(texture);
+  texture.anisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 4;
+  const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
+  const sprite = new THREE.Sprite(material);
+  const scale = 1.3 * MODEL_SCALE;
+  sprite.scale.set(scale, scale * 0.45, 1);
+  sprite.userData.update = draw;
+  sprite.userData.texture = texture;
+  return sprite;
+}
+
+function roundRect(ctx, x, y, width, height, radius) {
+  const r = Math.min(radius, width / 2, height / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + width, y, x + width, y + height, r);
+  ctx.arcTo(x + width, y + height, x, y + height, r);
+  ctx.arcTo(x, y + height, x, y, r);
+  ctx.arcTo(x, y, x + width, y, r);
+  ctx.closePath();
+}
+
+function applyCardToMesh(mesh, card, geometry, cache) {
+  if (!mesh || !card) return;
+  const prev = mesh.userData?.card;
+  if (prev && prev.rank === card.rank && prev.suit === card.suit) {
+    mesh.userData.card = card;
+    return;
+  }
+  const fresh = createCardMesh(card, geometry, cache);
+  const existing = mesh.material;
+  if (Array.isArray(existing)) {
+    existing.forEach((mat) => mat?.dispose?.());
+  } else {
+    existing?.dispose?.();
+  }
+  mesh.material = fresh.material;
+  mesh.userData = { ...mesh.userData, ...fresh.userData, card };
+}
+
+function buildInitialState(players, token, stake) {
+  return {
+    players: players.map((p, idx) => ({
+      ...p,
+      seatIndex: idx,
+      hand: [],
+      bet: 0,
+      result: '',
+      revealed: false,
+      bust: false
+    })),
+    deck: [],
+    token,
+    stake,
+    stage: 'betting',
+    currentIndex: 0,
+    dealerIndex: DEALER_INDEX,
+    pot: 0,
+    awaitingInput: false,
+    winners: [],
+    round: 0
+  };
+}
+
+function resetForNextRound(state) {
+  const next = { ...state, round: state.round + 1 };
+  next.deck = shuffle(createDeck());
+  next.stage = 'betting';
+  next.currentIndex = 0;
+  next.pot = 0;
+  next.winners = [];
+  next.players = state.players.map((p) => ({
+    ...p,
+    hand: [],
+    bet: 0,
+    result: '',
+    revealed: p.isDealer,
+    bust: false
+  }));
+  return next;
+}
+
+function placeInitialBets(state) {
+  state.players.forEach((player, idx) => {
+    if (player.isDealer) return;
+    const wager = Math.min(player.chips, Math.max(20, Math.round(state.stake * 0.2)));
+    player.chips -= wager;
+    player.bet = wager;
+    state.pot += wager;
+    player.result = `Bet ${wager}`;
+    if (player.chips <= 0) player.chips = 0;
+  });
+}
+
+function dealInitialCards(state) {
+  const { hands, deck } = dealInitial(state.deck, state.players.length);
+  state.deck = deck;
+  state.players.forEach((player, idx) => {
+    player.hand = hands[idx];
+    player.bust = false;
+    player.revealed = player.isDealer ? false : true;
+  });
+  state.stage = 'player-turns';
+  state.currentIndex = getNextPlayerIndex(state.players, -1);
+}
+
+function getNextPlayerIndex(players, start) {
+  for (let offset = 1; offset <= players.length; offset += 1) {
+    const idx = (start + offset) % players.length;
+    const player = players[idx];
+    if (!player) continue;
+    if (!player.isDealer && player.bet > 0 && !player.bust) {
+      return idx;
+    }
+  }
+  return DEALER_INDEX;
+}
+
+function playDealer(state) {
+  const dealer = state.players[state.dealerIndex];
+  dealer.revealed = true;
+  dealer.result = '';
+  while (handValue(dealer.hand) < 17) {
+    const { card, deck } = hitCard(state.deck);
+    state.deck = deck;
+    dealer.hand.push(card);
+  }
+  if (isBust(dealer.hand)) {
+    dealer.bust = true;
+    dealer.result = 'Bust';
+  } else {
+    dealer.result = `Dealer ${handValue(dealer.hand)}`;
+  }
+}
+
+function resolveRound(state) {
+  playDealer(state);
+  const dealer = state.players[state.dealerIndex];
+  const contenders = state.players.filter((p) => !p.isDealer);
+  const winners = [];
+  contenders.forEach((player) => {
+    if (player.bet <= 0) return;
+    const playerValue = handValue(player.hand);
+    const dealerValue = handValue(dealer.hand);
+    if (player.bust) {
+      player.result = 'Lose';
+    } else if (dealer.bust || playerValue > dealerValue) {
+      const payout = player.bet * 2;
+      player.chips += payout;
+      player.result = `Win ${payout}`;
+      winners.push(player.seatIndex);
+    } else if (playerValue === dealerValue) {
+      player.chips += player.bet;
+      player.result = 'Push';
+    } else {
+      player.result = 'Lose';
+    }
+  });
+  state.pot = 0;
+  state.stage = 'round-end';
+  state.winners = winners;
+}
+
+function applyPlayerAction(state, action) {
+  const player = state.players[state.currentIndex];
+  if (!player || player.isDealer) return;
+  if (action === 'hit') {
+    const { card, deck } = hitCard(state.deck);
+    state.deck = deck;
+    player.hand.push(card);
+    player.revealed = true;
+    if (isBust(player.hand)) {
+      player.bust = true;
+      player.result = 'Bust';
+      advancePlayer(state);
+    }
+  } else if (action === 'stand') {
+    player.result = `Stand ${handValue(player.hand)}`;
+    advancePlayer(state);
+  }
+}
+
+function advancePlayer(state) {
+  const nextIndex = getNextPlayerIndex(state.players, state.currentIndex);
+  if (nextIndex === DEALER_INDEX) {
+    state.stage = 'dealer';
+    state.currentIndex = DEALER_INDEX;
+    resolveRound(state);
+  } else {
+    state.currentIndex = nextIndex;
+  }
+}
+
+function cloneState(state) {
+  return {
+    ...state,
+    players: state.players.map((p) => ({ ...p, hand: [...p.hand] }))
+  };
+}
+
+function BlackJackArena({ search }) {
+  const mountRef = useRef(null);
+  const threeRef = useRef(null);
+  const animationRef = useRef(null);
+  const [gameState, setGameState] = useState(() => {
+    const players = buildPlayers(search);
+    const { token, stake } = parseSearch(search);
+    const base = buildInitialState(players, token, stake);
+    const prepared = resetForNextRound(base);
+    placeInitialBets(prepared);
+    dealInitialCards(prepared);
+    return prepared;
+  });
+  const [uiState, setUiState] = useState({ actions: [] });
+  const timerRef = useRef(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
+    applyRendererSRGB(renderer);
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(mount.clientWidth, mount.clientHeight);
+    renderer.shadowMap.enabled = true;
+    mount.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color('#020617');
+
+    const camera = new THREE.PerspectiveCamera(
+      CAMERA_SETTINGS.fov,
+      mount.clientWidth / mount.clientHeight,
+      CAMERA_SETTINGS.near,
+      CAMERA_SETTINGS.far
+    );
+    camera.position.set(0, TABLE_HEIGHT * 3.4, TABLE_RADIUS * 3.1);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    controls.enablePan = false;
+    controls.minPolarAngle = ARENA_CAMERA_DEFAULTS.phiMin;
+    controls.maxPolarAngle = ARENA_CAMERA_DEFAULTS.phiMax;
+    controls.minDistance = CAMERA_SETTINGS.minRadius;
+    controls.maxDistance = CAMERA_SETTINGS.maxRadius;
+    controls.target.set(0, TABLE_HEIGHT, 0);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.55);
+    scene.add(ambient);
+    const spot = new THREE.SpotLight(0xffffff, 2.4, TABLE_RADIUS * 8, Math.PI / 3, 0.35, 1);
+    spot.position.set(4, 7, 4);
+    spot.castShadow = true;
+    scene.add(spot);
+    const rim = new THREE.PointLight(0x60a5fa, 1.1);
+    rim.position.set(-4, 3, -3);
+    scene.add(rim);
+
+    const arena = new THREE.Group();
+    scene.add(arena);
+
+    const floor = new THREE.Mesh(
+      new THREE.CircleGeometry(TABLE_RADIUS * ARENA_GROWTH * 3, 64),
+      new THREE.MeshStandardMaterial({ color: 0x0b1220, roughness: 0.92, metalness: 0.1 })
+    );
+    floor.rotation.x = -Math.PI / 2;
+    floor.receiveShadow = true;
+    arena.add(floor);
+
+    const carpet = new THREE.Mesh(
+      new THREE.CircleGeometry(TABLE_RADIUS * ARENA_GROWTH * 2.1, 64),
+      createArenaCarpetMaterial(new THREE.Color('#1e293b'), new THREE.Color('#0f172a'))
+    );
+    carpet.rotation.x = -Math.PI / 2;
+    carpet.position.y = 0.01;
+    carpet.receiveShadow = true;
+    arena.add(carpet);
+
+    const wall = new THREE.Mesh(
+      new THREE.CylinderGeometry(TABLE_RADIUS * ARENA_GROWTH * 2.3, TABLE_RADIUS * ARENA_GROWTH * 2.5, 3.4, 32, 1, true),
+      createArenaWallMaterial('#0b1120', '#111827')
+    );
+    wall.position.y = 1.7;
+    arena.add(wall);
+
+    const tableInfo = createMurlanStyleTable({ arena, tableRadius: TABLE_RADIUS, tableHeight: TABLE_HEIGHT });
+
+    const cardGeometry = createCardGeometry(CARD_W, CARD_H, CARD_D);
+    const faceCache = new Map();
+    const chipFactory = createChipFactory(renderer, { cardWidth: CARD_W });
+    const seatLayout = createSeatLayout(PLAYER_COUNT);
+    const seatGroups = [];
+
+    seatLayout.forEach((seat, index) => {
+      const group = new THREE.Group();
+      group.position.copy(seat.seatPos);
+      group.lookAt(new THREE.Vector3(0, seat.seatPos.y, 0));
+      const base = new THREE.Mesh(new THREE.CylinderGeometry(0.3 * MODEL_SCALE, 0.34 * MODEL_SCALE, 0.22 * MODEL_SCALE, 24), new THREE.MeshStandardMaterial({ color: 0x1f2937 }));
+      base.castShadow = true;
+      base.receiveShadow = true;
+      group.add(base);
+      const cushion = new THREE.Mesh(new THREE.CylinderGeometry(0.4 * MODEL_SCALE, 0.4 * MODEL_SCALE, 0.08 * MODEL_SCALE, 24), new THREE.MeshPhysicalMaterial({ color: index === 0 ? 0x2563eb : index === DEALER_INDEX ? 0xf97316 : 0x334155, roughness: 0.4, metalness: 0.28, clearcoat: 1 }));
+      cushion.position.y = 0.14 * MODEL_SCALE;
+      cushion.castShadow = true;
+      group.add(cushion);
+      const back = new THREE.Mesh(new THREE.BoxGeometry(0.45 * MODEL_SCALE, 0.4 * MODEL_SCALE, 0.08 * MODEL_SCALE), new THREE.MeshStandardMaterial({ color: 0x1f2937 }));
+      back.position.set(0, 0.36 * MODEL_SCALE, -0.16 * MODEL_SCALE);
+      back.castShadow = true;
+      group.add(back);
+      arena.add(group);
+
+      const cardMeshes = Array.from({ length: 6 }, () => {
+        const mesh = createCardMesh({ rank: 'A', suit: 'S' }, cardGeometry, faceCache);
+        mesh.position.set(0, TABLE_HEIGHT + CARD_D * 6, 0);
+        mesh.castShadow = true;
+        arena.add(mesh);
+        return mesh;
+      });
+
+      const chipStack = chipFactory.createStack(0);
+      chipStack.position.copy(seat.chipAnchor);
+      arena.add(chipStack);
+
+      const betStack = chipFactory.createStack(0);
+      betStack.position.copy(seat.betAnchor);
+      arena.add(betStack);
+
+      const nameplate = makeNameplate('Player', 0, renderer);
+      nameplate.position.copy(seat.labelAnchor);
+      arena.add(nameplate);
+
+      seatGroups.push({
+        group,
+        cardMeshes,
+        chipStack,
+        betStack,
+        nameplate,
+        forward: seat.forward.clone(),
+        right: seat.right.clone(),
+        cardAnchor: seat.cardAnchor.clone(),
+        chipAnchor: seat.chipAnchor.clone(),
+        betAnchor: seat.betAnchor.clone(),
+        labelAnchor: seat.labelAnchor.clone()
+      });
+    });
+
+    const potStack = chipFactory.createStack(0);
+    potStack.position.set(0, TABLE_HEIGHT + CARD_D * 6, 0);
+    arena.add(potStack);
+
+    threeRef.current = {
+      renderer,
+      scene,
+      camera,
+      controls,
+      arena,
+      tableInfo,
+      cardGeometry,
+      faceCache,
+      chipFactory,
+      seatGroups,
+      potStack
+    };
+
+    const onResize = () => {
+      if (!threeRef.current) return;
+      const { renderer: r, camera: cam } = threeRef.current;
+      const { clientWidth, clientHeight } = mount;
+      r.setSize(clientWidth, clientHeight);
+      cam.aspect = clientWidth / clientHeight;
+      cam.updateProjectionMatrix();
+    };
+    window.addEventListener('resize', onResize);
+
+    const animate = () => {
+      const three = threeRef.current;
+      if (!three) return;
+      three.controls.update();
+      three.renderer.render(three.scene, three.camera);
+      animationRef.current = requestAnimationFrame(animate);
+    };
+    animate();
+
+    return () => {
+      window.removeEventListener('resize', onResize);
+      cancelAnimationFrame(animationRef.current);
+      if (threeRef.current) {
+        const { renderer: r, scene: s, chipFactory: factory, seatGroups: seats, potStack: pot, tableInfo: info } = threeRef.current;
+        seats.forEach((seat) => {
+          seat.cardMeshes.forEach((mesh) => {
+            mesh.geometry?.dispose?.();
+            if (Array.isArray(mesh.material)) {
+              mesh.material.forEach((mat) => mat?.dispose?.());
+            } else {
+              mesh.material?.dispose?.();
+            }
+            s.remove(mesh);
+          });
+          factory.disposeStack(seat.chipStack);
+          factory.disposeStack(seat.betStack);
+          if (seat.nameplate) {
+            seat.nameplate.material?.map?.dispose?.();
+            seat.nameplate.material?.dispose?.();
+            s.remove(seat.nameplate);
+          }
+        });
+        factory.disposeStack(pot);
+        factory.dispose();
+        info?.dispose?.();
+        r.dispose();
+      }
+      mount.removeChild(renderer.domElement);
+      threeRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const three = threeRef.current;
+    if (!three) return;
+    const { seatGroups, chipFactory, potStack, cardGeometry, faceCache } = three;
+    const state = gameState;
+    if (!state) return;
+
+    seatGroups.forEach((seat, idx) => {
+      const player = state.players[idx];
+      if (!player) return;
+      const base = seat.cardAnchor.clone();
+      const right = seat.right.clone();
+      const forward = seat.forward.clone();
+      seat.cardMeshes.forEach((mesh, cardIdx) => {
+        const card = player.hand[cardIdx];
+        if (!card) {
+          mesh.visible = false;
+          return;
+        }
+        mesh.visible = true;
+        applyCardToMesh(mesh, card, cardGeometry, faceCache);
+        const target = base
+          .clone()
+          .add(right.clone().multiplyScalar((cardIdx - (player.hand.length - 1) / 2) * HOLE_SPACING));
+        mesh.position.copy(target);
+        const look = target.clone().add(forward.clone().multiplyScalar(player.isDealer ? -1 : 1));
+        const face = player.isDealer && cardIdx === 1 && !player.revealed ? 'back' : 'front';
+        orientCard(mesh, look, { face, flat: true });
+        setCardFace(mesh, face);
+      });
+      chipFactory.setAmount(seat.chipStack, player.chips);
+      chipFactory.setAmount(seat.betStack, player.bet);
+      if (seat.nameplate?.userData?.update) {
+        const active = state.currentIndex === idx && state.stage === 'player-turns';
+        seat.nameplate.userData.update(player.name, Math.round(player.chips), active, player.result || '');
+        seat.nameplate.userData.texture.needsUpdate = true;
+      }
+    });
+    chipFactory.setAmount(potStack, state.pot);
+  }, [gameState]);
+
+  useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (!gameState) return;
+    if (gameState.stage === 'round-end') {
+      timerRef.current = setTimeout(() => {
+        setGameState((prev) => {
+          const next = resetForNextRound(cloneState(prev));
+          placeInitialBets(next);
+          dealInitialCards(next);
+          return next;
+        });
+      }, 3000);
+      setUiState({ actions: [] });
+      return () => {
+        if (timerRef.current) {
+          clearTimeout(timerRef.current);
+          timerRef.current = null;
+        }
+      };
+    }
+    if (gameState.stage === 'player-turns') {
+      const actor = gameState.players[gameState.currentIndex];
+      if (!actor) return;
+      if (actor.isHuman) {
+        setUiState({
+          actions: [
+            { id: 'hit', label: 'Hit' },
+            { id: 'stand', label: 'Stand' }
+          ]
+        });
+      } else {
+        setUiState({ actions: [] });
+        timerRef.current = setTimeout(() => {
+          setGameState((prev) => {
+            const next = cloneState(prev);
+            const player = next.players[next.currentIndex];
+            const decision = aiAction(player.hand);
+            applyPlayerAction(next, decision);
+            return next;
+          });
+        }, 900);
+      }
+    } else if (gameState.stage === 'dealer') {
+      setUiState({ actions: [] });
+      timerRef.current = setTimeout(() => {
+        setGameState((prev) => {
+          const next = cloneState(prev);
+          resolveRound(next);
+          return next;
+        });
+      }, 600);
+    }
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [gameState]);
+
+  const handleAction = (id) => {
+    setGameState((prev) => {
+      const next = cloneState(prev);
+      if (next.stage !== 'player-turns') return next;
+      applyPlayerAction(next, id);
+      return next;
+    });
+  };
+
+  const dealer = gameState.players[DEALER_INDEX];
+
+  return (
+    <div className="relative w-full h-full">
+      <div ref={mountRef} className="absolute inset-0" />
+      <div className="absolute top-4 left-1/2 -translate-x-1/2 text-center text-white drop-shadow-lg">
+        <p className="text-lg font-semibold">Black Jack Multiplayer</p>
+        <p className="text-sm opacity-80">
+          Pot: {Math.round(gameState.pot)} {gameState.token} · Dealer:{' '}
+          {dealer.revealed ? handValue(dealer.hand) : '??'}
+        </p>
+      </div>
+      {gameState.stage === 'round-end' && (
+        <div className="absolute top-24 left-1/2 -translate-x-1/2 bg-black/60 text-white px-4 py-2 rounded-lg text-sm">
+          Round complete
+        </div>
+      )}
+      {gameState.stage === 'player-turns' && gameState.players[gameState.currentIndex]?.isHuman && (
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-3">
+          {uiState.actions.map((action) => (
+            <button
+              key={action.id}
+              onClick={() => handleAction(action.id)}
+              className="px-5 py-2 rounded-lg bg-green-600/90 text-white font-semibold shadow-lg"
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default BlackJackArena;

--- a/webapp/src/pages/Games/TexasHoldem.jsx
+++ b/webapp/src/pages/Games/TexasHoldem.jsx
@@ -1,16 +1,13 @@
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import TexasHoldemArena from './TexasHoldemArena.jsx';
 
 export default function TexasHoldem() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
     <div className="relative w-full h-screen">
-      <iframe
-        src={`/texas-holdem.html${search}`}
-        title="Texas Hold'em"
-        className="w-full h-full border-0"
-      />
+      <TexasHoldemArena search={search} />
     </div>
   );
 }

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -1,0 +1,940 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+import { createArenaCarpetMaterial, createArenaWallMaterial } from '../../utils/arenaDecor.js';
+import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
+import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../../utils/arenaCameraConfig.js';
+import { createMurlanStyleTable } from '../../utils/murlanTable.js';
+import { createCardGeometry, createCardMesh, orientCard, setCardFace } from '../../utils/cards3d.js';
+import { createChipFactory } from '../../utils/chips3d.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+
+import {
+  createDeck,
+  shuffle,
+  dealHoleCards,
+  compareHands,
+  estimateWinProbability
+} from '../../../../lib/texasHoldem.js';
+
+const MODEL_SCALE = 0.75;
+const TABLE_RADIUS = 3.4 * MODEL_SCALE;
+const TABLE_HEIGHT = 1.08 * MODEL_SCALE;
+const ARENA_GROWTH = 1.45;
+const PLAYER_COUNT = 6;
+const SMALL_BLIND = 10;
+const BIG_BLIND = 20;
+const CARD_W = 0.4 * MODEL_SCALE;
+const CARD_H = 0.56 * MODEL_SCALE;
+const CARD_D = 0.02 * MODEL_SCALE;
+const COMMUNITY_SPACING = CARD_W * 0.85;
+const HOLE_SPACING = CARD_W * 0.7;
+const POT_OFFSET = new THREE.Vector3(0, TABLE_HEIGHT + CARD_D * 6, 0);
+const DECK_POSITION = new THREE.Vector3(-TABLE_RADIUS * 0.55, TABLE_HEIGHT + CARD_D * 6, TABLE_RADIUS * 0.55);
+const CAMERA_SETTINGS = buildArenaCameraConfig(TABLE_RADIUS * ARENA_GROWTH);
+
+const STAGE_SEQUENCE = ['preflop', 'flop', 'turn', 'river'];
+
+const REGION_NAMES = typeof Intl !== 'undefined' ? new Intl.DisplayNames(['en'], { type: 'region' }) : null;
+
+function flagToName(flag) {
+  if (!flag || !REGION_NAMES) return 'Guest';
+  const points = Array.from(flag, (c) => c.codePointAt(0) - 0x1f1e6 + 65);
+  if (points.length !== 2) return 'Guest';
+  const code = String.fromCharCode(points[0], points[1]);
+  return REGION_NAMES.of(code) || 'Guest';
+}
+
+function parseSearch(search) {
+  const params = new URLSearchParams(search);
+  const username = params.get('username') || 'You';
+  const avatar = params.get('avatar') || '';
+  const amount = Number.parseInt(params.get('amount') || '1000', 10);
+  const token = params.get('token') || 'TPC';
+  const stake = Number.isFinite(amount) && amount > 0 ? amount : 1000;
+  return { username, avatar, stake, token };
+}
+
+function buildPlayers(search) {
+  const { username, stake } = parseSearch(search);
+  const baseChips = Math.max(400, Math.round(stake));
+  const flags = [...FLAG_EMOJIS].sort(() => 0.5 - Math.random());
+  const humanFlag = flags.shift() || '🇦🇱';
+  const players = [
+    {
+      id: 'player-0',
+      name: username,
+      flag: humanFlag,
+      isHuman: true,
+      chips: baseChips,
+      avatar: null
+    }
+  ];
+  for (let i = 0; i < PLAYER_COUNT - 1; i += 1) {
+    const flag = flags[i] || FLAG_EMOJIS[(i * 17) % FLAG_EMOJIS.length];
+    players.push({
+      id: `ai-${i}`,
+      name: flagToName(flag),
+      flag,
+      isHuman: false,
+      chips: baseChips,
+      avatar: null
+    });
+  }
+  return players;
+}
+
+function createSeatLayout(count) {
+  const radius = TABLE_RADIUS * ARENA_GROWTH * 1.05;
+  const layout = [];
+  for (let i = 0; i < count; i += 1) {
+    const angle = Math.PI / 2 + (i / count) * Math.PI * 2;
+    const forward = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle));
+    const right = new THREE.Vector3(-Math.sin(angle), 0, Math.cos(angle));
+    const seatPos = forward.clone().multiplyScalar(radius);
+    seatPos.y = TABLE_HEIGHT * 0.3;
+    const cardAnchor = forward.clone().multiplyScalar(TABLE_RADIUS * 0.72);
+    cardAnchor.y = TABLE_HEIGHT + CARD_D * 6;
+    const chipAnchor = forward.clone().multiplyScalar(TABLE_RADIUS * 0.6);
+    chipAnchor.y = TABLE_HEIGHT + CARD_D * 6;
+    const labelAnchor = forward.clone().multiplyScalar(radius + 0.3 * MODEL_SCALE);
+    labelAnchor.y = TABLE_HEIGHT + 0.65 * MODEL_SCALE;
+    layout.push({
+      angle,
+      forward,
+      right,
+      seatPos,
+      cardAnchor,
+      chipAnchor,
+      labelAnchor
+    });
+  }
+  return layout;
+}
+
+function makeNameplate(name, chips, renderer) {
+  const canvas = document.createElement('canvas');
+  canvas.width = 512;
+  canvas.height = 256;
+  const ctx = canvas.getContext('2d');
+  const draw = (playerName, stack, highlight, status) => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = highlight ? 'rgba(59,130,246,0.32)' : 'rgba(15,23,42,0.78)';
+    ctx.strokeStyle = highlight ? '#60a5fa' : 'rgba(255,255,255,0.18)';
+    ctx.lineWidth = 12;
+    roundRect(ctx, 16, 16, canvas.width - 32, canvas.height - 32, 36);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = '#f8fafc';
+    ctx.font = '700 72px "Inter", system-ui, sans-serif';
+    ctx.textBaseline = 'top';
+    ctx.fillText(playerName, 40, 48);
+    ctx.font = '600 54px "Inter", system-ui, sans-serif';
+    ctx.fillStyle = '#e0f2fe';
+    ctx.fillText(`${stack} chips`, 40, 140);
+    if (status) {
+      ctx.fillStyle = '#facc15';
+      ctx.font = '600 50px "Inter", system-ui, sans-serif';
+      ctx.textAlign = 'right';
+      ctx.fillText(status, canvas.width - 40, 140);
+      ctx.textAlign = 'left';
+    }
+  };
+  draw(name, chips, false, '');
+  const texture = new THREE.CanvasTexture(canvas);
+  applySRGBColorSpace(texture);
+  texture.anisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 4;
+  const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
+  const sprite = new THREE.Sprite(material);
+  const scale = 1.45 * MODEL_SCALE;
+  sprite.scale.set(scale, scale * 0.5, 1);
+  sprite.userData.update = draw;
+  sprite.userData.texture = texture;
+  sprite.userData.canvas = canvas;
+  return sprite;
+}
+
+function roundRect(ctx, x, y, width, height, radius) {
+  const r = Math.min(radius, width / 2, height / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + width, y, x + width, y + height, r);
+  ctx.arcTo(x + width, y + height, x, y + height, r);
+  ctx.arcTo(x, y + height, x, y, r);
+  ctx.arcTo(x, y, x + width, y, r);
+  ctx.closePath();
+}
+
+function applyCardToMesh(mesh, card, geometry, cache) {
+  if (!mesh || !card) return;
+  const prev = mesh.userData?.card;
+  if (prev && prev.rank === card.rank && prev.suit === card.suit) {
+    mesh.userData.card = card;
+    return;
+  }
+  const fresh = createCardMesh(card, geometry, cache);
+  const existing = mesh.material;
+  if (Array.isArray(existing)) {
+    existing.forEach((mat) => mat?.dispose?.());
+  } else {
+    existing?.dispose?.();
+  }
+  mesh.material = fresh.material;
+  mesh.userData = { ...mesh.userData, ...fresh.userData, card };
+}
+
+function buildInitialState(players, token, stake) {
+  return {
+    players: players.map((p, index) => ({
+      ...p,
+      seatIndex: index,
+      hand: [],
+      bet: 0,
+      totalBet: 0,
+      folded: false,
+      allIn: false,
+      actedInRound: false,
+      status: ''
+    })),
+    token,
+    stake,
+    pot: 0,
+    deck: [],
+    community: [],
+    stage: 'preflop',
+    dealerIndex: players.length - 1,
+    actionIndex: 0,
+    currentBet: 0,
+    minRaise: BIG_BLIND,
+    winners: [],
+    awaitingInput: false,
+    handId: 0,
+    showdown: false
+  };
+}
+
+function resetForNextHand(state) {
+  const next = { ...state, handId: state.handId + 1 };
+  next.deck = shuffle(createDeck());
+  next.community = [];
+  next.stage = 'preflop';
+  next.winners = [];
+  next.showdown = false;
+  next.pot = 0;
+  next.currentBet = 0;
+  next.minRaise = BIG_BLIND;
+  next.dealerIndex = (state.dealerIndex + 1) % state.players.length;
+  next.players = state.players.map((p, idx) => ({
+    ...p,
+    seatIndex: p.seatIndex ?? idx,
+    bet: 0,
+    totalBet: 0,
+    hand: [],
+    folded: p.chips <= 0,
+    allIn: p.chips <= 0,
+    actedInRound: false,
+    status: p.chips <= 0 ? 'Out' : ''
+  }));
+  const active = next.players.filter((p) => p.chips > 0);
+  if (active.length < 2) {
+    return next;
+  }
+  dealHoleCardsToState(next);
+  postBlinds(next);
+  prepareNextAction(next, true);
+  return next;
+}
+
+function dealHoleCardsToState(state) {
+  const { hands, deck } = dealHoleCards(state.deck, state.players.length);
+  state.deck = deck;
+  state.players.forEach((player, idx) => {
+    player.hand = hands[idx];
+    player.folded = player.chips <= 0;
+    player.allIn = player.chips <= 0;
+    player.status = player.folded ? 'Out' : '';
+  });
+}
+
+function postBlinds(state) {
+  const smallBlindIndex = getNextActiveIndex(state.players, state.dealerIndex);
+  const bigBlindIndex = getNextActiveIndex(state.players, smallBlindIndex);
+  const sbPlayer = state.players[smallBlindIndex];
+  const bbPlayer = state.players[bigBlindIndex];
+  const sbAmount = payChips(sbPlayer, Math.min(SMALL_BLIND, sbPlayer.chips), state);
+  const bbAmount = payChips(bbPlayer, Math.min(BIG_BLIND, bbPlayer.chips), state);
+  sbPlayer.bet = sbAmount;
+  sbPlayer.totalBet = sbAmount;
+  bbPlayer.bet = bbAmount;
+  bbPlayer.totalBet = bbAmount;
+  sbPlayer.status = `SB ${sbAmount}`;
+  bbPlayer.status = `BB ${bbAmount}`;
+  state.currentBet = bbPlayer.bet;
+  state.smallBlindIndex = smallBlindIndex;
+  state.bigBlindIndex = bigBlindIndex;
+  state.actionIndex = getNextActiveIndex(state.players, bigBlindIndex);
+  resetActedFlags(state);
+}
+
+function payChips(player, amount, state) {
+  if (amount <= 0) return 0;
+  const spend = Math.min(amount, player.chips);
+  player.chips -= spend;
+  state.pot += spend;
+  if (player.chips <= 0) {
+    player.chips = 0;
+    player.allIn = true;
+  }
+  return spend;
+}
+
+function getNextActiveIndex(players, startIndex) {
+  if (!players.length) return 0;
+  for (let offset = 1; offset <= players.length; offset += 1) {
+    const idx = (startIndex + offset) % players.length;
+    const p = players[idx];
+    if (!p) continue;
+    if (!p.folded && p.chips > 0 && !p.allIn) {
+      return idx;
+    }
+  }
+  return players.findIndex((p) => !p.folded) ?? 0;
+}
+
+function resetActedFlags(state) {
+  state.players.forEach((p) => {
+    p.actedInRound = p.folded || p.allIn;
+  });
+}
+
+function allActiveMatched(state) {
+  const active = state.players.filter((p) => !p.folded && !p.allIn);
+  if (!active.length) return true;
+  return active.every((p) => p.actedInRound && p.bet === state.currentBet);
+}
+
+function advanceStage(state) {
+  if (state.stage === 'river') {
+    goToShowdown(state);
+    return;
+  }
+  const stageIndex = STAGE_SEQUENCE.indexOf(state.stage);
+  const nextStage = STAGE_SEQUENCE[stageIndex + 1];
+  state.stage = nextStage;
+  if (nextStage === 'flop') {
+    state.deck.pop();
+    const cardA = state.deck.pop();
+    const cardB = state.deck.pop();
+    const cardC = state.deck.pop();
+    state.community = [cardA, cardB, cardC];
+  } else if (nextStage === 'turn' || nextStage === 'river') {
+    state.deck.pop();
+    state.community = [...state.community, state.deck.pop()];
+  }
+  state.players.forEach((p) => {
+    p.bet = 0;
+    p.actedInRound = p.folded || p.allIn;
+    if (!p.folded && !p.allIn) {
+      p.status = '';
+    }
+  });
+  state.currentBet = 0;
+  state.minRaise = BIG_BLIND;
+  state.actionIndex = getNextActiveIndex(state.players, state.dealerIndex);
+  prepareNextAction(state, false);
+}
+
+function goToShowdown(state) {
+  while (state.community.length < 5 && state.deck.length) {
+    if (state.community.length === 3 || state.community.length === 4) {
+      state.deck.pop();
+    }
+    state.community.push(state.deck.pop());
+  }
+  const pots = buildSidePots(state.players);
+  const results = [];
+  pots.forEach((pot) => {
+    const eligible = pot.players.filter((idx) => !state.players[idx].folded);
+    if (!eligible.length) return;
+    const winners = determineWinners(state.players, state.community, eligible);
+    const share = pot.amount / winners.length;
+    winners.forEach((idx) => {
+      state.players[idx].chips += share;
+      state.players[idx].status = `Win ${Math.round(share)}`;
+    });
+    results.push({ amount: pot.amount, winners });
+  });
+  state.pot = 0;
+  state.winners = results;
+  state.stage = 'showdown';
+  state.showdown = true;
+  state.awaitingInput = false;
+}
+
+function buildSidePots(players) {
+  const active = players.filter((p) => p.totalBet > 0);
+  if (!active.length) return [];
+  const bets = [...new Set(active.map((p) => p.totalBet))].sort((a, b) => a - b);
+  const pots = [];
+  let previous = 0;
+  bets.forEach((amount) => {
+    const eligible = players.filter((p) => p.totalBet >= amount).map((p) => p.seatIndex ?? players.indexOf(p));
+    const potAmount = (amount - previous) * eligible.length;
+    pots.push({ amount: potAmount, players: eligible });
+    previous = amount;
+  });
+  return pots;
+}
+
+function determineWinners(players, community, indices) {
+  let winners = [];
+  indices.forEach((idx) => {
+    const player = players[idx];
+    if (!player || player.folded) return;
+    if (!winners.length) {
+      winners = [idx];
+      return;
+    }
+    const contender = compareHands([...player.hand, ...community], [...players[winners[0]].hand, ...community]);
+    if (contender > 0) {
+      winners = [idx];
+    } else if (contender === 0) {
+      winners.push(idx);
+    }
+  });
+  return winners;
+}
+
+function prepareNextAction(state, isNewHand) {
+  const activePlayers = state.players.filter((p) => !p.folded);
+  if (activePlayers.length <= 1) {
+    goToShowdown(state);
+    return;
+  }
+  const actor = state.players[state.actionIndex];
+  if (!actor || actor.folded || actor.allIn || actor.chips <= 0) {
+    const nextIndex = getNextActiveIndex(state.players, state.actionIndex);
+    if (nextIndex === state.actionIndex) {
+      if (allActiveMatched(state)) {
+        advanceStage(state);
+      }
+    } else {
+      state.actionIndex = nextIndex;
+      prepareNextAction(state, false);
+    }
+    return;
+  }
+  state.awaitingInput = actor.isHuman;
+  if (!actor.isHuman) {
+    actor.status = actor.status || 'Thinking';
+  }
+  if (isNewHand && actor.isHuman && state.stage === 'preflop') {
+    actor.status = 'Your move';
+  }
+}
+
+function performPlayerAction(state, action, raiseSize = BIG_BLIND) {
+  const player = state.players[state.actionIndex];
+  if (!player || player.folded || player.allIn) return;
+  const toCall = Math.max(0, state.currentBet - player.bet);
+  let advanced = false;
+  if (action === 'fold') {
+    player.folded = true;
+    player.status = 'Fold';
+    player.actedInRound = true;
+    advanced = true;
+  } else if (action === 'check') {
+    if (toCall === 0) {
+      player.status = 'Check';
+      player.actedInRound = true;
+      advanced = true;
+    } else {
+      return;
+    }
+  } else if (action === 'call') {
+    const amount = Math.min(toCall, player.chips);
+    if (amount <= 0 && toCall > 0) {
+      player.status = 'Check';
+      player.actedInRound = true;
+      advanced = true;
+    } else {
+      const paid = payChips(player, amount, state);
+      player.bet += paid;
+      player.totalBet += paid;
+      player.status = paid === toCall ? 'Call' : 'All-in';
+      player.actedInRound = true;
+      if (player.chips === 0) {
+        player.allIn = true;
+      }
+      advanced = true;
+    }
+  } else if (action === 'bet' || action === 'raise') {
+    let amount = Math.max(state.minRaise, raiseSize);
+    if (action === 'raise') {
+      amount += toCall;
+    }
+    let spend = Math.min(player.chips, amount);
+    if (action === 'raise') {
+      spend = Math.min(player.chips, toCall + Math.max(state.minRaise, raiseSize));
+    }
+    if (spend <= 0) {
+      return;
+    }
+    const paid = payChips(player, spend, state);
+    player.bet += paid;
+    player.totalBet += paid;
+    state.currentBet = Math.max(state.currentBet, player.bet);
+    state.minRaise = Math.max(state.minRaise, paid - toCall);
+    player.status = player.chips === 0 ? 'All-in' : action === 'bet' ? 'Bet' : 'Raise';
+    player.actedInRound = true;
+    state.players.forEach((p, idx) => {
+      if (idx !== player.seatIndex && !p.folded && !p.allIn) {
+        p.actedInRound = false;
+      }
+    });
+    advanced = true;
+  }
+  if (!advanced) return;
+  const nextIndex = getNextActiveIndex(state.players, state.actionIndex);
+  if (nextIndex === state.actionIndex || nextIndex < 0) {
+    if (allActiveMatched(state)) {
+      advanceStage(state);
+      return;
+    }
+  }
+  state.actionIndex = nextIndex;
+  prepareNextAction(state, false);
+}
+
+function performAiAction(state) {
+  const player = state.players[state.actionIndex];
+  if (!player || player.isHuman || player.folded || player.allIn) return;
+  const toCall = Math.max(0, state.currentBet - player.bet);
+  const community = state.community;
+  const opponents = state.players.filter((p) => p !== player && !p.folded).length;
+  const winRate = estimateWinProbability(player.hand, community, Math.max(1, opponents - 1), 80);
+  let action = 'check';
+  let raiseSize = state.minRaise;
+  if (toCall > 0) {
+    if (winRate < 0.28) {
+      action = 'fold';
+    } else if (winRate < 0.45) {
+      action = 'call';
+    } else {
+      action = 'raise';
+      raiseSize = Math.min(player.chips, Math.round(state.minRaise * (0.75 + winRate)));
+    }
+  } else {
+    if (winRate > 0.55 && player.chips > state.minRaise) {
+      action = 'bet';
+      raiseSize = Math.min(player.chips, Math.round(state.minRaise * (0.5 + winRate)));
+    } else {
+      action = 'check';
+    }
+  }
+  performPlayerAction(state, action, raiseSize);
+}
+
+function cloneState(state) {
+  return {
+    ...state,
+    players: state.players.map((p) => ({ ...p }))
+  };
+}
+
+function TexasHoldemArena({ search }) {
+  const mountRef = useRef(null);
+  const threeRef = useRef(null);
+  const animationRef = useRef(null);
+  const [gameState, setGameState] = useState(() => {
+    const players = buildPlayers(search);
+    const { token, stake } = parseSearch(search);
+    const baseState = buildInitialState(players, token, stake);
+    return resetForNextHand(baseState);
+  });
+  const [uiState, setUiState] = useState({ availableActions: [], toCall: 0 });
+  const timerRef = useRef(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
+    applyRendererSRGB(renderer);
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(mount.clientWidth, mount.clientHeight);
+    renderer.shadowMap.enabled = true;
+    mount.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color('#030712');
+
+    const camera = new THREE.PerspectiveCamera(
+      CAMERA_SETTINGS.fov,
+      mount.clientWidth / mount.clientHeight,
+      CAMERA_SETTINGS.near,
+      CAMERA_SETTINGS.far
+    );
+    camera.position.set(0, TABLE_HEIGHT * 3.5, TABLE_RADIUS * 3.4);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    controls.enablePan = false;
+    controls.minDistance = CAMERA_SETTINGS.minRadius;
+    controls.maxDistance = CAMERA_SETTINGS.maxRadius;
+    controls.minPolarAngle = ARENA_CAMERA_DEFAULTS.phiMin;
+    controls.maxPolarAngle = ARENA_CAMERA_DEFAULTS.phiMax;
+    controls.target.set(0, TABLE_HEIGHT, 0);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.5);
+    scene.add(ambient);
+    const spot = new THREE.SpotLight(0xffffff, 2.8, TABLE_RADIUS * 10, Math.PI / 3, 0.35, 1);
+    spot.position.set(3, 7, 3);
+    spot.castShadow = true;
+    scene.add(spot);
+    const rim = new THREE.PointLight(0x33ccff, 1.2);
+    rim.position.set(-4, 3, -4);
+    scene.add(rim);
+
+    const arenaGroup = new THREE.Group();
+    scene.add(arenaGroup);
+
+    const floorGeometry = new THREE.CircleGeometry(TABLE_RADIUS * ARENA_GROWTH * 3.2, 64);
+    const floorMaterial = new THREE.MeshStandardMaterial({ color: 0x0b1120, roughness: 0.9, metalness: 0.1 });
+    const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+    floor.rotation.x = -Math.PI / 2;
+    floor.receiveShadow = true;
+    arenaGroup.add(floor);
+
+    const carpet = new THREE.Mesh(
+      new THREE.CircleGeometry(TABLE_RADIUS * ARENA_GROWTH * 2.2, 64),
+      createArenaCarpetMaterial(new THREE.Color('#0f172a'), new THREE.Color('#1e3a8a'))
+    );
+    carpet.rotation.x = -Math.PI / 2;
+    carpet.position.y = 0.01;
+    carpet.receiveShadow = true;
+    arenaGroup.add(carpet);
+
+    const wall = new THREE.Mesh(
+      new THREE.CylinderGeometry(TABLE_RADIUS * ARENA_GROWTH * 2.4, TABLE_RADIUS * ARENA_GROWTH * 2.6, 3.6, 32, 1, true),
+      createArenaWallMaterial('#0b1120', '#1e293b')
+    );
+    wall.position.y = 1.8;
+    wall.receiveShadow = false;
+    arenaGroup.add(wall);
+
+    const tableInfo = createMurlanStyleTable({ arena: arenaGroup, tableRadius: TABLE_RADIUS, tableHeight: TABLE_HEIGHT });
+
+    const cardGeometry = createCardGeometry(CARD_W, CARD_H, CARD_D);
+    const faceCache = new Map();
+
+    const chipFactory = createChipFactory(renderer, { cardWidth: CARD_W });
+    const seatLayout = createSeatLayout(PLAYER_COUNT);
+    const seatGroups = [];
+    const deckAnchor = DECK_POSITION.clone();
+
+    seatLayout.forEach((seat, index) => {
+      const group = new THREE.Group();
+      group.position.copy(seat.seatPos);
+      group.lookAt(new THREE.Vector3(0, seat.seatPos.y, 0));
+      const seatBase = new THREE.Mesh(new THREE.CylinderGeometry(0.32 * MODEL_SCALE, 0.36 * MODEL_SCALE, 0.24 * MODEL_SCALE, 24), new THREE.MeshStandardMaterial({ color: 0x1f2937 }));
+      seatBase.castShadow = true;
+      seatBase.receiveShadow = true;
+      group.add(seatBase);
+      const cushion = new THREE.Mesh(new THREE.CylinderGeometry(0.42 * MODEL_SCALE, 0.42 * MODEL_SCALE, 0.08 * MODEL_SCALE, 24), new THREE.MeshPhysicalMaterial({ color: index === 0 ? 0x2563eb : 0x334155, roughness: 0.35, metalness: 0.3, clearcoat: 1 }));
+      cushion.position.y = 0.16 * MODEL_SCALE;
+      cushion.castShadow = true;
+      group.add(cushion);
+      const back = new THREE.Mesh(
+        new THREE.BoxGeometry(0.48 * MODEL_SCALE, 0.46 * MODEL_SCALE, 0.08 * MODEL_SCALE),
+        new THREE.MeshStandardMaterial({ color: 0x1f2937 })
+      );
+      back.position.set(0, 0.42 * MODEL_SCALE, -0.18 * MODEL_SCALE);
+      back.castShadow = true;
+      group.add(back);
+      arenaGroup.add(group);
+
+      const cardMeshes = [0, 1].map(() => {
+        const mesh = createCardMesh({ rank: 'A', suit: 'S' }, cardGeometry, faceCache);
+        mesh.position.copy(deckAnchor);
+        mesh.castShadow = true;
+        arenaGroup.add(mesh);
+        return mesh;
+      });
+
+      const chipStack = chipFactory.createStack(0);
+      chipStack.position.copy(seat.chipAnchor);
+      arenaGroup.add(chipStack);
+
+      const nameplate = makeNameplate('Player', 0, renderer);
+      nameplate.position.copy(seat.labelAnchor);
+      arenaGroup.add(nameplate);
+
+      seatGroups.push({
+        group,
+        cardMeshes,
+        chipStack,
+        nameplate,
+        forward: seat.forward.clone(),
+        right: seat.right.clone(),
+        cardAnchor: seat.cardAnchor.clone(),
+        chipAnchor: seat.chipAnchor.clone(),
+        labelAnchor: seat.labelAnchor.clone()
+      });
+    });
+
+    const communityMeshes = Array.from({ length: 5 }, () => {
+      const mesh = createCardMesh({ rank: 'A', suit: 'S' }, cardGeometry, faceCache);
+      mesh.position.copy(deckAnchor);
+      mesh.castShadow = true;
+      arenaGroup.add(mesh);
+      return mesh;
+    });
+
+    const potStack = chipFactory.createStack(0);
+    potStack.position.copy(POT_OFFSET);
+    arenaGroup.add(potStack);
+
+    threeRef.current = {
+      renderer,
+      scene,
+      camera,
+      controls,
+      chipFactory,
+      cardGeometry,
+      faceCache,
+      seatGroups,
+      communityMeshes,
+      potStack,
+      deckAnchor,
+      frameId: null
+    };
+
+    const handleResize = () => {
+      if (!mount || !threeRef.current) return;
+      const { renderer: r, camera: cam } = threeRef.current;
+      const { clientWidth, clientHeight } = mount;
+      r.setSize(clientWidth, clientHeight);
+      cam.aspect = clientWidth / clientHeight;
+      cam.updateProjectionMatrix();
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    const animate = () => {
+      const three = threeRef.current;
+      if (!three) return;
+      three.controls.update();
+      three.renderer.render(three.scene, three.camera);
+      animationRef.current = requestAnimationFrame(animate);
+    };
+    animate();
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      cancelAnimationFrame(animationRef.current);
+      if (threeRef.current) {
+        const { renderer: r, scene: s, chipFactory: factory, seatGroups: seats, communityMeshes: community } = threeRef.current;
+        seats.forEach((seat) => {
+          seat.cardMeshes.forEach((mesh) => {
+            mesh.geometry?.dispose?.();
+            if (Array.isArray(mesh.material)) {
+              mesh.material.forEach((mat) => mat?.dispose?.());
+            } else {
+              mesh.material?.dispose?.();
+            }
+            s.remove(mesh);
+          });
+          factory.disposeStack(seat.chipStack);
+          if (seat.nameplate) {
+            seat.nameplate.material?.map?.dispose?.();
+            seat.nameplate.material?.dispose?.();
+            s.remove(seat.nameplate);
+          }
+        });
+        community.forEach((mesh) => {
+          mesh.geometry?.dispose?.();
+          if (Array.isArray(mesh.material)) {
+            mesh.material.forEach((mat) => mat?.dispose?.());
+          } else {
+            mesh.material?.dispose?.();
+          }
+          s.remove(mesh);
+        });
+        factory.disposeStack(threeRef.current.potStack);
+        factory.dispose();
+        tableInfo?.dispose?.();
+        r.dispose();
+      }
+      mount.removeChild(renderer.domElement);
+      threeRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const three = threeRef.current;
+    if (!three) return;
+    const { seatGroups, communityMeshes, chipFactory, potStack } = three;
+    const state = gameState;
+    if (!state) return;
+    state.players.forEach((player, idx) => {
+      const seat = seatGroups[idx];
+      if (!seat) return;
+      const base = seat.cardAnchor.clone();
+      const right = seat.right.clone();
+      const forward = seat.forward.clone();
+      seat.cardMeshes.forEach((mesh, cardIdx) => {
+        const card = player.hand[cardIdx];
+        if (!card) {
+          mesh.visible = false;
+          mesh.position.copy(three.deckAnchor);
+          return;
+        }
+        mesh.visible = !player.folded || state.showdown;
+        applyCardToMesh(mesh, card, three.cardGeometry, three.faceCache);
+        const target = base
+          .clone()
+          .add(right.clone().multiplyScalar((cardIdx - 0.5) * HOLE_SPACING));
+        mesh.position.copy(target);
+        const look = target.clone().add(forward.clone().multiplyScalar(player.isHuman ? -1 : 1));
+        orientCard(mesh, look, { face: player.isHuman || state.showdown ? 'front' : 'back', flat: true });
+        setCardFace(mesh, player.isHuman || state.showdown ? 'front' : 'back');
+      });
+      chipFactory.setAmount(seat.chipStack, player.chips);
+      const label = seat.nameplate;
+      if (label?.userData?.update) {
+        const highlight = state.stage !== 'showdown' && idx === state.actionIndex && !player.folded && !player.allIn;
+        const status = player.status || '';
+        label.userData.update(player.name, Math.round(player.chips), highlight, status);
+        label.userData.texture.needsUpdate = true;
+      }
+    });
+
+    communityMeshes.forEach((mesh, idx) => {
+      const card = state.community[idx];
+      if (!card) {
+        mesh.position.copy(three.deckAnchor);
+        mesh.visible = false;
+        return;
+      }
+      mesh.visible = true;
+      applyCardToMesh(mesh, card, three.cardGeometry, three.faceCache);
+      const offset = (idx - 2) * COMMUNITY_SPACING;
+      const position = new THREE.Vector3(offset, TABLE_HEIGHT + CARD_D * 6, 0);
+      mesh.position.copy(position);
+      orientCard(mesh, position.clone().add(new THREE.Vector3(0, 0, 1)), { face: 'front', flat: true });
+      setCardFace(mesh, 'front');
+    });
+
+    chipFactory.setAmount(potStack, state.pot);
+  }, [gameState]);
+
+  useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (!gameState) return;
+    if (gameState.stage === 'showdown') {
+      timerRef.current = setTimeout(() => {
+        setGameState((prev) => resetForNextHand(cloneState(prev)));
+      }, 4000);
+      return () => {
+        if (timerRef.current) {
+          clearTimeout(timerRef.current);
+          timerRef.current = null;
+        }
+      };
+    }
+    const actor = gameState.players[gameState.actionIndex];
+    if (!actor) return;
+    if (actor.isHuman) {
+      const toCall = Math.max(0, gameState.currentBet - actor.bet);
+      const canCheck = toCall === 0;
+      const canRaise = actor.chips > toCall;
+      const actions = [];
+      actions.push({ id: 'fold', label: 'Fold' });
+      if (canCheck) {
+        actions.push({ id: 'check', label: 'Check' });
+        if (canRaise) {
+          actions.push({ id: 'bet', label: 'Bet' });
+        }
+      } else {
+        actions.push({ id: 'call', label: `Call ${toCall}` });
+        if (canRaise) {
+          actions.push({ id: 'raise', label: 'Raise' });
+        }
+      }
+      setUiState({ availableActions: actions, toCall });
+    } else {
+      setUiState({ availableActions: [], toCall: 0 });
+      timerRef.current = setTimeout(() => {
+        setGameState((prev) => {
+          const next = cloneState(prev);
+          performAiAction(next);
+          return next;
+        });
+      }, 900);
+    }
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [gameState]);
+
+  const handleAction = (id) => {
+    setGameState((prev) => {
+      const next = cloneState(prev);
+      if (next.stage === 'showdown') return next;
+      performPlayerAction(next, id, next.minRaise);
+      return next;
+    });
+  };
+
+  const actor = gameState.players[gameState.actionIndex];
+
+  return (
+    <div className="relative w-full h-full">
+      <div ref={mountRef} className="absolute inset-0" />
+      <div className="absolute top-4 left-1/2 -translate-x-1/2 text-center text-white drop-shadow-lg">
+        <p className="text-lg font-semibold">Texas Hold'em Royale</p>
+        <p className="text-sm opacity-80">
+          Pot: {Math.round(gameState.pot)} {gameState.token} · Stage: {gameState.stage.toUpperCase()}
+        </p>
+        {gameState.stage === 'showdown' && (
+          <div className="mt-2 text-sm">
+            {gameState.winners.length === 0 ? (
+              <span>No contest</span>
+            ) : (
+              gameState.winners.map((win, idx) => (
+                <div key={idx}>
+                  Pot {Math.round(win.amount)} →{' '}
+                  {win.winners
+                    .map((i) => gameState.players[i]?.name || 'Player')
+                    .join(', ')}
+                </div>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+      {actor?.isHuman && gameState.stage !== 'showdown' && (
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-3">
+          {uiState.availableActions.map((action) => (
+            <button
+              key={action.id}
+              onClick={() => handleAction(action.id)}
+              className="px-5 py-2 rounded-lg bg-blue-600/90 text-white font-semibold shadow-lg"
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TexasHoldemArena;

--- a/webapp/src/utils/blackjackLogic.js
+++ b/webapp/src/utils/blackjackLogic.js
@@ -1,0 +1,95 @@
+export const RANKS = ['2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K', 'A'];
+export const SUITS = ['H', 'D', 'C', 'S'];
+
+export function createDeck() {
+  const deck = [];
+  for (const rank of RANKS) {
+    for (const suit of SUITS) {
+      deck.push({ rank, suit });
+    }
+  }
+  return deck;
+}
+
+export function shuffle(deck) {
+  const copy = [...deck];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+export function dealInitial(deck, players) {
+  const copy = [...deck];
+  const hands = Array.from({ length: players }, () => []);
+  for (let r = 0; r < 2; r += 1) {
+    for (let p = 0; p < players; p += 1) {
+      hands[p].push(copy.pop());
+    }
+  }
+  return { hands, deck: copy };
+}
+
+export function hitCard(deck) {
+  const copy = [...deck];
+  const card = copy.pop();
+  return { card, deck: copy };
+}
+
+function cardValue(rank) {
+  if (rank === 'A') return 11;
+  if (rank === 'K' || rank === 'Q' || rank === 'J' || rank === 'T') return 10;
+  return Number.parseInt(rank, 10);
+}
+
+export function handValue(hand) {
+  let total = 0;
+  let aces = 0;
+  hand.forEach((card) => {
+    total += cardValue(card.rank);
+    if (card.rank === 'A') aces += 1;
+  });
+  while (total > 21 && aces > 0) {
+    total -= 10;
+    aces -= 1;
+  }
+  return total;
+}
+
+export function isBust(hand) {
+  return handValue(hand) > 21;
+}
+
+export function evaluateWinners(players) {
+  let best = 0;
+  const winners = [];
+  players.forEach((player, index) => {
+    if (player.bust) return;
+    const value = handValue(player.hand);
+    if (value > 21) return;
+    if (value > best) {
+      best = value;
+      winners.splice(0, winners.length, index);
+    } else if (value === best) {
+      winners.push(index);
+    }
+  });
+  return winners;
+}
+
+export function aiAction(hand) {
+  return handValue(hand) < 17 ? 'hit' : 'stand';
+}
+
+export function aiBetAction(hand) {
+  const value = handValue(hand);
+  const bluff = Math.random() < 0.1;
+  if (value >= 19) return 'raise';
+  if (value >= 15) return bluff ? 'raise' : 'call';
+  if (value >= 12) {
+    if (bluff) return 'raise';
+    return Math.random() < 0.5 ? 'call' : 'fold';
+  }
+  return bluff ? 'raise' : 'fold';
+}

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -1,0 +1,209 @@
+import * as THREE from 'three';
+import { applySRGBColorSpace } from './colorSpace.js';
+
+export const CARD_THEMES = [
+  {
+    id: 'aurora',
+    label: 'Aurora',
+    frontBackground: '#ffffff',
+    frontBorder: '#e2e8f0',
+    edgeColor: '#f0f2f5',
+    backColor: '#0f172a',
+    backGradient: ['#1f2937', '#0b1220'],
+    backBorder: 'rgba(255,255,255,0.18)',
+    backAccent: 'rgba(255,255,255,0.08)',
+    centerAccent: 'rgba(15,118,110,0.12)',
+    hiddenColor: '#0f172a'
+  }
+];
+
+export const DEFAULT_CARD_THEME = CARD_THEMES[0];
+
+export function createCardGeometry(width, height, depth) {
+  return new THREE.BoxGeometry(width, height, depth, 1, 1, 1);
+}
+
+export function createCardMesh(card, geometry, cache, theme = DEFAULT_CARD_THEME) {
+  const faceKey = `${theme.id}-${card.rank}-${card.suit}`;
+  let faceTexture = cache?.get?.(faceKey);
+  if (!faceTexture) {
+    faceTexture = makeCardFace(card.rank, card.suit, theme);
+    cache?.set?.(faceKey, faceTexture);
+  }
+  const backTexture = makeCardBackTexture(theme);
+  const edgeMaterial = new THREE.MeshStandardMaterial({
+    color: new THREE.Color(theme.edgeColor || '#f0f2f5'),
+    roughness: 0.55,
+    metalness: 0.1
+  });
+  const frontMaterial = new THREE.MeshStandardMaterial({
+    map: faceTexture,
+    roughness: 0.35,
+    metalness: 0.08,
+    color: new THREE.Color('#ffffff')
+  });
+  const backMaterial = new THREE.MeshStandardMaterial({
+    map: backTexture,
+    color: new THREE.Color(theme.backColor || '#0f172a'),
+    roughness: 0.6,
+    metalness: 0.15
+  });
+  const hiddenMaterial = new THREE.MeshStandardMaterial({
+    color: new THREE.Color(theme.hiddenColor || theme.backColor || '#0f172a'),
+    roughness: 0.7,
+    metalness: 0.12
+  });
+  const materials = [edgeMaterial, edgeMaterial.clone(), edgeMaterial.clone(), edgeMaterial.clone(), frontMaterial, backMaterial];
+  const mesh = new THREE.Mesh(geometry, materials);
+  mesh.userData.card = card;
+  mesh.userData.frontMaterial = frontMaterial;
+  mesh.userData.backMaterial = backMaterial;
+  mesh.userData.hiddenMaterial = hiddenMaterial;
+  mesh.userData.edgeMaterials = materials.slice(0, 4);
+  mesh.userData.backTexture = backTexture;
+  mesh.userData.cardFace = 'front';
+  return mesh;
+}
+
+export function orientCard(mesh, lookTarget, { face = 'front', flat = true } = {}) {
+  if (!mesh) return;
+  mesh.up.set(0, 1, 0);
+  mesh.lookAt(lookTarget);
+  mesh.rotation.z = 0;
+  if (flat) {
+    mesh.rotateX(-Math.PI / 2);
+  }
+  if (face === 'back') {
+    mesh.rotateY(Math.PI);
+  }
+}
+
+export function setCardFace(mesh, face) {
+  if (!mesh?.material) return;
+  const { frontMaterial, backMaterial, hiddenMaterial, cardFace } = mesh.userData ?? {};
+  if (!frontMaterial || !backMaterial || face === cardFace) return;
+  if (face === 'back') {
+    const mat = hiddenMaterial ?? backMaterial;
+    mesh.material[4] = mat;
+    mesh.material[5] = mat;
+    mesh.userData.cardFace = 'back';
+  } else {
+    mesh.material[4] = frontMaterial;
+    mesh.material[5] = backMaterial;
+    mesh.userData.cardFace = 'front';
+  }
+}
+
+function makeCardFace(rank, suit, theme, w = 512, h = 720) {
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = theme.frontBackground || '#ffffff';
+  ctx.fillRect(0, 0, w, h);
+  ctx.strokeStyle = theme.frontBorder || '#e5e7eb';
+  ctx.lineWidth = 8;
+  roundRect(ctx, 6, 6, w - 12, h - 12, 32);
+  ctx.stroke();
+  const suitColor = getSuitColor(suit);
+  ctx.fillStyle = suitColor;
+  const label = String(rank);
+  const padding = 36;
+  const topRankY = 96;
+  const topSuitY = topRankY + 76;
+  const bottomSuitY = h - 92;
+  const bottomRankY = bottomSuitY - 76;
+  ctx.font = 'bold 96px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
+  ctx.textAlign = 'left';
+  ctx.fillText(label, padding, topRankY);
+  ctx.font = 'bold 78px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
+  ctx.fillText(convertSuit(suit), padding, topSuitY);
+  ctx.font = 'bold 96px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
+  ctx.fillText(label, padding, bottomRankY);
+  ctx.font = 'bold 78px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
+  ctx.fillText(convertSuit(suit), padding, bottomSuitY);
+  ctx.textAlign = 'right';
+  ctx.font = 'bold 96px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
+  ctx.fillText(label, w - padding, topRankY);
+  ctx.font = 'bold 78px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
+  ctx.fillText(convertSuit(suit), w - padding, topSuitY);
+  ctx.font = 'bold 96px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
+  ctx.fillText(label, w - padding, bottomRankY);
+  ctx.font = 'bold 78px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
+  ctx.fillText(convertSuit(suit), w - padding, bottomSuitY);
+  if (theme.centerAccent) {
+    ctx.fillStyle = theme.centerAccent;
+    ctx.beginPath();
+    ctx.ellipse(w / 2, h / 2, w * 0.18, h * 0.22, 0, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.fillStyle = suitColor;
+  ctx.font = 'bold 160px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
+  ctx.textAlign = 'center';
+  ctx.fillText(convertSuit(suit), w / 2, h / 2 + 56);
+  const texture = new THREE.CanvasTexture(canvas);
+  applySRGBColorSpace(texture);
+  texture.anisotropy = 8;
+  return texture;
+}
+
+function makeCardBackTexture(theme, w = 512, h = 720) {
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  const [c1, c2] = theme.backGradient || [theme.backColor, theme.backColor];
+  const gradient = ctx.createLinearGradient(0, 0, w, h);
+  gradient.addColorStop(0, c1 || '#0f172a');
+  gradient.addColorStop(1, c2 || '#0b1220');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, w, h);
+  ctx.strokeStyle = theme.backBorder || 'rgba(255,255,255,0.18)';
+  ctx.lineWidth = 14;
+  roundRect(ctx, 18, 18, w - 36, h - 36, 48);
+  ctx.stroke();
+  if (theme.backAccent) {
+    ctx.strokeStyle = theme.backAccent;
+    ctx.lineWidth = 8;
+    for (let i = 0; i < 6; i += 1) {
+      const inset = 36 + i * 18;
+      roundRect(ctx, inset, inset, w - inset * 2, h - inset * 2, 42);
+      ctx.stroke();
+    }
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  applySRGBColorSpace(texture);
+  texture.anisotropy = 8;
+  return texture;
+}
+
+function convertSuit(suit) {
+  switch (suit) {
+    case 'H':
+      return '♥';
+    case 'D':
+      return '♦';
+    case 'C':
+      return '♣';
+    case 'S':
+      return '♠';
+    default:
+      return suit;
+  }
+}
+
+function getSuitColor(suit) {
+  if (suit === 'H' || suit === 'D') return '#cc2233';
+  return '#111111';
+}
+
+function roundRect(ctx, x, y, width, height, radius) {
+  const r = Math.min(radius, width / 2, height / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + width, y, x + width, y + height, r);
+  ctx.arcTo(x + width, y + height, x, y + height, r);
+  ctx.arcTo(x, y + height, x, y, r);
+  ctx.arcTo(x, y, x + width, y, r);
+  ctx.closePath();
+}

--- a/webapp/src/utils/chips3d.js
+++ b/webapp/src/utils/chips3d.js
@@ -1,0 +1,171 @@
+import * as THREE from 'three';
+import { applySRGBColorSpace } from './colorSpace.js';
+
+const DENOMINATIONS = [
+  { value: 1, color: '#f2b21a' },
+  { value: 5, color: '#d54a3a' },
+  { value: 10, color: '#2196f3' },
+  { value: 20, color: '#4caf50' },
+  { value: 50, color: '#3a3331' },
+  { value: 100, color: '#7b4abd' },
+  { value: 500, color: '#a3362e' },
+  { value: 1000, color: '#1fb3d6' }
+];
+
+export function createChipFactory(renderer, { cardWidth }) {
+  const radius = cardWidth * 0.18;
+  const height = cardWidth * 0.04;
+  const geometry = new THREE.CylinderGeometry(radius, radius, height, 64, 1, false);
+  const cache = new Map();
+
+  function getMaterials(denom) {
+    const key = denom.value;
+    if (cache.has(key)) return cache.get(key);
+    const topTexture = makeChipTexture(denom.color, denom.value, renderer);
+    const topMaterial = new THREE.MeshPhysicalMaterial({
+      map: topTexture,
+      roughness: 0.3,
+      metalness: 0.6,
+      clearcoat: 1,
+      reflectivity: 0.8
+    });
+    const sideMaterial = new THREE.MeshPhysicalMaterial({
+      color: new THREE.Color(denom.color),
+      roughness: 0.2,
+      metalness: 0.8,
+      clearcoat: 1
+    });
+    const bottomMaterial = topMaterial.clone();
+    const materials = [sideMaterial, topMaterial, bottomMaterial];
+    cache.set(key, { materials, texture: topTexture });
+    return cache.get(key);
+  }
+
+  function disposeMaterials() {
+    cache.forEach(({ materials, texture }) => {
+      materials.forEach((mat) => mat?.dispose?.());
+      texture?.dispose?.();
+    });
+    cache.clear();
+  }
+
+  function createChipMesh(denom) {
+    const { materials } = getMaterials(denom);
+    return new THREE.Mesh(geometry, materials.map((mat) => mat.clone()));
+  }
+
+  function applyAmount(group, amount) {
+    while (group.children.length) {
+      const child = group.children[group.children.length - 1];
+      if (Array.isArray(child.material)) {
+        child.material.forEach((mat) => mat?.dispose?.());
+      } else {
+        child.material?.dispose?.();
+      }
+      group.remove(child);
+    }
+    const chips = splitAmount(amount);
+    let offset = 0;
+    chips.forEach(({ denom, count }) => {
+      for (let i = 0; i < count; i += 1) {
+        const mesh = createChipMesh(denom);
+        mesh.position.y = offset + height / 2;
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        group.add(mesh);
+        offset += height * 0.95;
+      }
+    });
+  }
+
+  function createStack(amount = 0) {
+    const group = new THREE.Group();
+    applyAmount(group, amount);
+    return group;
+  }
+
+  function disposeStack(group) {
+    if (!group) return;
+    while (group.children.length) {
+      const child = group.children[group.children.length - 1];
+      if (Array.isArray(child.material)) {
+        child.material.forEach((mat) => mat?.dispose?.());
+      } else {
+        child.material?.dispose?.();
+      }
+      group.remove(child);
+    }
+  }
+
+  function dispose() {
+    geometry.dispose();
+    disposeMaterials();
+  }
+
+  return {
+    createStack,
+    setAmount: applyAmount,
+    disposeStack,
+    dispose,
+    chipHeight: height
+  };
+}
+
+function splitAmount(amount) {
+  let remaining = Math.max(0, Math.floor(amount));
+  const stacks = [];
+  for (let i = DENOMINATIONS.length - 1; i >= 0; i -= 1) {
+    const denom = DENOMINATIONS[i];
+    const count = Math.floor(remaining / denom.value);
+    if (count > 0) {
+      stacks.push({ denom, count });
+      remaining -= count * denom.value;
+    }
+  }
+  if (stacks.length === 0) {
+    stacks.push({ denom: DENOMINATIONS[0], count: 0 });
+  }
+  return stacks;
+}
+
+function makeChipTexture(color, value, renderer) {
+  const size = 512;
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext('2d');
+
+  const grad = ctx.createRadialGradient(size / 2, size / 2, 10, size / 2, size / 2, size / 2);
+  grad.addColorStop(0, '#fff');
+  grad.addColorStop(0.3, color);
+  grad.addColorStop(1, '#222');
+  ctx.fillStyle = grad;
+  ctx.beginPath();
+  ctx.arc(size / 2, size / 2, size / 2.2, 0, Math.PI * 2);
+  ctx.fill();
+
+  for (let i = 0; i < 200; i += 1) {
+    const x = Math.random() * size;
+    const y = Math.random() * size;
+    ctx.fillStyle = `rgba(255,255,255,${Math.random() * 0.03})`;
+    ctx.fillRect(x, y, 1, 1);
+  }
+
+  ctx.lineWidth = 12;
+  ctx.strokeStyle = '#fff';
+  ctx.beginPath();
+  ctx.arc(size / 2, size / 2, size / 3, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.font = 'bold 180px sans-serif';
+  ctx.fillStyle = '#fff';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(value, size / 2, size / 2);
+
+  const tex = new THREE.CanvasTexture(canvas);
+  applySRGBColorSpace(tex);
+  tex.anisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 4;
+  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+  tex.repeat.set(1, 1);
+  return tex;
+}


### PR DESCRIPTION
## Summary
- replace the iframe wrappers for Texas Hold'em and Blackjack with native 3D arena components that reuse the Murlan Royale table
- introduce shared utilities for card meshes, chip stacks, and blackjack game logic to drive the new scenes
- render updated stacks, cards, and UI controls while preserving the underlying game rules and mobile-friendly overlays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68efe31a74288329a5752c8c6ae23ca9