### PR TITLE
Adjust Snake & Ladder board styling

### DIFF
--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -4,6 +4,10 @@ import PlayerToken from "./PlayerToken.jsx";
 // Board dimensions
 const ROWS = 20;
 const COLS = 5;
+const CHESS_TILE_LIGHT = "#e7e2d3";
+const CHESS_TILE_DARK = "#776a5a";
+const LIGHT_NUMBER_COLOR = "#1f2937";
+const DARK_NUMBER_COLOR = "#f9fafb";
 export const FINAL_TILE = ROWS * COLS + 1; // 101
 
 function CoinBurst({ token }) {
@@ -78,11 +82,12 @@ export default function SnakeBoard({
     const scaleX = scale * (1 + rowPos * widenStep);
     const offsetX = (scaleX - 1) * cellWidth;
     const reversed = r % 2 === 1;
-    const rowColor = "#6db0ad";
-
     for (let c = 0; c < COLS; c++) {
       const col = c;
       const num = reversed ? (r + 1) * COLS - c : r * COLS + c + 1;
+      const isLightTile = (r + c) % 2 === 0;
+      const tileColor = isLightTile ? CHESS_TILE_LIGHT : CHESS_TILE_DARK;
+      const numberColor = isLightTile ? LIGHT_NUMBER_COLOR : DARK_NUMBER_COLOR;
       const translateX = (col - centerCol) * offsetX;
       const translateY = -rowOffsets[r];
       const isHighlight = highlight && highlight.cell === num;
@@ -118,8 +123,10 @@ export default function SnakeBoard({
         gridColumnStart: col + 1,
         transform: `translate(${translateX}px, ${translateY}px) scaleX(${scaleX}) scaleY(${scale}) translateZ(5px)`,
         transformOrigin: "bottom center",
+        "--tile-bg": tileColor,
+        "--number-color": numberColor,
       };
-      if (!highlightClass) style.backgroundColor = rowColor;
+      if (!highlightClass) style.backgroundColor = tileColor;
 
       tiles.push(
         <div
@@ -208,6 +215,7 @@ export default function SnakeBoard({
   const boardYOffset = 60;
   const boardZOffset = -50;
   const CAMERA_OFFSET_ROWS = 0;
+  const boardScale = 0.8;
 
   useEffect(() => {
     const container = containerRef.current;
@@ -259,7 +267,7 @@ export default function SnakeBoard({
               '--board-height': `${cellHeight * ROWS + offsetYMax}px`,
               '--board-angle': `${angle}deg`,
               '--final-scale': finalScale,
-              transform: `translate(${boardXOffset}px, ${boardYOffset}px) translateZ(${boardZOffset}px) rotateX(${angle}deg) scale(0.9)`,
+              transform: `translate(${boardXOffset}px, ${boardYOffset}px) translateZ(${boardZOffset}px) rotateX(${angle}deg) scale(${boardScale})`,
             }}
           >
             {tiles}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1079,14 +1079,17 @@ input:focus {
 }
 
 .cell-number {
-  position: relative;
+  position: absolute;
+  top: 50%;
+  left: 50%;
   z-index: 1;
-  color: #ffffff;
+  color: var(--number-color, #ffffff);
   font-family: 'Comic Sans MS', 'Comic Sans', cursive;
   font-weight: bold;
   font-size: 1.3rem; /* slightly bigger numbers */
   line-height: 1;
-  transform: translateY(-10%);
+  transform: translate(-50%, -50%) translateZ(2px);
+  transform-style: preserve-3d;
 }
 
 /* Small hexagonal frame for the starting cell number */


### PR DESCRIPTION
## Summary
- recolor Snake & Ladder tiles using the chess board light and dark palette
- shrink the rendered board footprint by about 20% for a tighter layout
- update cell number styling so digits sit flat on each tile with tile-specific contrast

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68efe60d27008329b240fde9dd860d80