### PR TITLE
Adjust poker and blackjack table footprint

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -56,12 +56,14 @@
       .stage::before {
         content: '';
         position: absolute;
-        top: 0;
-        bottom: 2%;
-        left: 1vw;
-        right: 1vw;
+        top: -2%;
+        bottom: 0;
+        left: 0.5vw;
+        right: 0.5vw;
         background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp')
           center/cover no-repeat;
+        transform: scaleX(1.08) scaleY(1.05);
+        transform-origin: center;
         z-index: 0;
       }
       /* Community cards slightly larger */

--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -54,12 +54,14 @@
       .stage::before {
         content: '';
         position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 1vw;
-        right: 1vw;
+        top: -2%;
+        bottom: -2%;
+        left: 0.5vw;
+        right: 0.5vw;
         background: url('assets/icons/de2a24a7-922a-4400-8edc-027a1017224e.webp')
           center/cover no-repeat;
+        transform: scaleX(1.08) scaleY(1.05);
+        transform-origin: center;
         z-index: 0;
       }
       /* Community cards slightly larger */


### PR DESCRIPTION
## Summary
- enlarge the background table footprint for the Texas Hold'em scene so it sits slightly higher than the surrounding chairs
- make the blackjack table backdrop wider and taller to leave only a slim gap around the seats

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eff0ff82f883299b3badaca25adb20