### PR TITLE
Darken Ludo dice pips

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -99,9 +99,9 @@ function makeDice() {
   });
 
   const pipMaterial = new THREE.MeshStandardMaterial({
-    color: 0x050505,
-    metalness: 0.18,
-    roughness: 0.62,
+    color: 0x000000,
+    metalness: 0,
+    roughness: 0.85,
     side: THREE.DoubleSide,
     polygonOffset: true,
     polygonOffsetFactor: -1,
@@ -109,9 +109,9 @@ function makeDice() {
   });
 
   const pipRimMaterial = new THREE.MeshStandardMaterial({
-    color: 0x1a1a1a,
-    metalness: 0.12,
-    roughness: 0.48,
+    color: 0x000000,
+    metalness: 0,
+    roughness: 0.75,
     side: THREE.DoubleSide,
     polygonOffset: true,
     polygonOffsetFactor: -0.5,


### PR DESCRIPTION
## Summary
- update the Ludo Battle Royal dice pip and rim materials to pure black with matte shading so the dots read clearly during play

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eff55e7a64832983dab21f17eae422