### PR TITLE
Improve poker camera controls and raise UI

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -505,20 +505,20 @@
       }
       .raise-container {
         position: absolute;
-        bottom: 0;
-        left: 2%;
+        bottom: 12%;
+        left: 50%;
+        transform: translate(-50%, 0);
         z-index: 5;
         display: flex;
         flex-direction: column;
-        align-items: flex-start;
+        align-items: center;
         justify-content: flex-end;
         gap: 8px;
-        padding: 0;
-        padding-top: 4px;
-        padding-right: 4px;
-        border: none;
-        border-radius: 0;
-        background: none;
+        padding: 8px 12px 10px;
+        border: 3px solid rgba(15, 23, 42, 0.8);
+        border-radius: 14px;
+        background: rgba(8, 11, 19, 0.72);
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
       }
       .slider-container {
         position: absolute;

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -832,7 +832,7 @@ function showControls() {
 
     const sliderRaise = document.createElement('button');
     sliderRaise.id = 'sliderRaise';
-    sliderRaise.textContent = 'raise';
+    sliderRaise.textContent = 'Raise';
     sliderRaise.className = 'raise-btn';
     sliderRaise.addEventListener('click', () => {
       const sliderVal = parseInt(slider.value, 10);

--- a/webapp/src/utils/chips3d.js
+++ b/webapp/src/utils/chips3d.js
@@ -3,11 +3,12 @@ import { applySRGBColorSpace } from './colorSpace.js';
 
 const DENOMINATIONS = [
   { value: 1, color: '#f2b21a' },
+  { value: 2, color: '#f97316' },
   { value: 5, color: '#d54a3a' },
   { value: 10, color: '#2196f3' },
   { value: 20, color: '#4caf50' },
   { value: 50, color: '#3a3331' },
-  { value: 100, color: '#7b4abd' },
+  { value: 200, color: '#7b4abd' },
   { value: 500, color: '#a3362e' },
   { value: 1000, color: '#1fb3d6' }
 ];


### PR DESCRIPTION
## Summary
- Lock the Texas Hold'em and Blackjack 3D arena cameras to head-turn rotations, expand the viewable yaw range, and drive them with pointer gestures.
- Add a chip selection rail and right-side raise slider so Hold'em players can raise via preset chips or the slider, mirroring the displayed denominations.
- Reposition the legacy web raise chip stack in front of the player and align the slider button label, while synchronizing 3D chip denominations with the in-game set.

## Testing
- npm run lint *(fails: existing style violations in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68f000e07540832988644e48ca520f35