### PR TITLE
Force Pool Royale to use enlarged 9ft table

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -859,9 +859,7 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
 });
 
 const TABLE_SIZE_OPTIONS = Object.freeze({
-  '7ft': { id: '7ft', label: '7 ft', scale: 0.78 },
-  '8ft': { id: '8ft', label: '8 ft', scale: 0.88 },
-  '9ft': { id: '9ft', label: '9 ft', scale: 1 }
+  '9ft': { id: '9ft', label: '9 ft', scale: 1.2 }
 });
 const DEFAULT_TABLE_SIZE_ID = '9ft';
 


### PR DESCRIPTION
## Summary
- remove the 7ft and 8ft Pool Royale table size variants
- force the game to use the 9ft table and scale it up by 20%

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68f065c75af483299ae7a41f43d5c44c