### PR TITLE
Align poker and blackjack seating and controls

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1627,3 +1627,102 @@ img[alt="TPC"] {
   min-width: 3rem;
   min-height: 3rem;
 }
+
+.vertical-range {
+  writing-mode: bt-lr;
+  -webkit-appearance: slider-vertical;
+  appearance: slider-vertical;
+  width: 18px;
+  height: 220px;
+  padding: 0;
+  margin: 0;
+  background: rgba(15, 23, 42, 0.25);
+  border-radius: 9999px;
+  box-shadow: inset 0 0 12px rgba(15, 23, 42, 0.45);
+}
+
+.vertical-range:disabled {
+  opacity: 0.4;
+}
+
+.vertical-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  background: radial-gradient(circle at 30% 30%, #ffffff 0%, #38bdf8 45%, #1e293b 100%);
+  border-radius: 9999px;
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  width: 28px;
+  height: 28px;
+  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.4);
+}
+
+.vertical-range::-moz-range-thumb {
+  background: radial-gradient(circle at 30% 30%, #ffffff 0%, #38bdf8 45%, #1e293b 100%);
+  border-radius: 9999px;
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  width: 28px;
+  height: 28px;
+  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.4);
+}
+
+.vertical-range::-webkit-slider-runnable-track {
+  background: transparent;
+  border-radius: 9999px;
+}
+
+.vertical-range::-moz-range-track {
+  background: transparent;
+  border-radius: 9999px;
+}
+
+.chip-select {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 9999px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--chip-text, #0f172a);
+  background: radial-gradient(
+    circle at 30% 30%,
+    rgba(255, 255, 255, 0.95) 0%,
+    var(--chip-color, #22d3ee) 46%,
+    rgba(15, 23, 42, 0.9) 100%
+  );
+  border: 3px solid rgba(255, 255, 255, 0.85);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.5);
+  text-shadow: 0 2px 5px rgba(15, 23, 42, 0.45);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.chip-select::after {
+  content: '';
+  position: absolute;
+  inset: 18%;
+  border-radius: 9999px;
+  border: 2px solid rgba(255, 255, 255, 0.75);
+  opacity: 0.9;
+}
+
+.chip-select:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 22px rgba(15, 23, 42, 0.6);
+}
+
+.chip-select:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.55);
+}
+
+.chip-select:disabled {
+  opacity: 0.45;
+  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.3);
+}
+
+.chip-select:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.85);
+  outline-offset: 3px;
+}

--- a/webapp/src/pages/Games/BlackJackArena.jsx
+++ b/webapp/src/pages/Games/BlackJackArena.jsx
@@ -121,24 +121,41 @@ function buildPlayers(search) {
 function createSeatLayout(count) {
   const radius = CHAIR_RADIUS;
   const layout = [];
+  const playerOffsets = [-TABLE_RADIUS * 0.6, -TABLE_RADIUS * 0.2, TABLE_RADIUS * 0.2, TABLE_RADIUS * 0.6].sort((a, b) => {
+    const diff = Math.abs(a) - Math.abs(b);
+    if (diff !== 0) return diff;
+    return a - b;
+  });
   for (let i = 0; i < count; i += 1) {
-    const angle = Math.PI / 2 + (i / count) * Math.PI * 2;
-    const forward = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle));
-    const right = new THREE.Vector3(-Math.sin(angle), 0, Math.cos(angle));
-    const seatPos = forward.clone().multiplyScalar(radius);
-    seatPos.y = CHAIR_BASE_HEIGHT;
-    const cardAnchor = forward.clone().multiplyScalar(TABLE_RADIUS * (i === DEALER_INDEX ? 0.45 : 0.68));
-    cardAnchor.y = TABLE_HEIGHT + CARD_D * 6;
-    const chipAnchor = forward.clone().multiplyScalar(TABLE_RADIUS * 0.55);
-    chipAnchor.y = TABLE_HEIGHT + CARD_D * 6;
-    const betAnchor = forward.clone().multiplyScalar(TABLE_RADIUS * 0.35);
-    betAnchor.y = TABLE_HEIGHT + CARD_D * 6;
-    const labelAnchor = forward.clone().multiplyScalar(radius + 0.32 * MODEL_SCALE);
-    labelAnchor.y = STOOL_HEIGHT + 0.48 * MODEL_SCALE;
-    const stoolAnchor = forward.clone().multiplyScalar(radius);
-    stoolAnchor.y = CHAIR_BASE_HEIGHT + SEAT_THICKNESS / 2;
+    const isDealer = i === DEALER_INDEX;
+    const rowSign = isDealer ? -1 : 1;
+    const seatZ = rowSign * radius;
+    const playerIndex = i < DEALER_INDEX ? i : i - 1;
+    const offset = isDealer ? 0 : playerOffsets[playerIndex] ?? 0;
+    const seatPos = new THREE.Vector3(offset, CHAIR_BASE_HEIGHT, seatZ);
+    const forward = new THREE.Vector3(0, 0, rowSign);
+    const right = new THREE.Vector3(-rowSign, 0, 0);
+    const cardDepth = isDealer ? TABLE_RADIUS * 0.38 : TABLE_RADIUS * 0.62;
+    const chipDepth = isDealer ? TABLE_RADIUS * 0.48 : TABLE_RADIUS * 0.58;
+    const betDepth = isDealer ? TABLE_RADIUS * 0.28 : TABLE_RADIUS * 0.42;
+    const cardAnchor = new THREE.Vector3(
+      offset,
+      TABLE_HEIGHT + CARD_D * 6,
+      seatZ - rowSign * (radius - cardDepth)
+    );
+    const chipAnchor = new THREE.Vector3(
+      offset,
+      TABLE_HEIGHT + CARD_D * 6,
+      seatZ - rowSign * (radius - chipDepth)
+    );
+    const betAnchor = new THREE.Vector3(
+      offset,
+      TABLE_HEIGHT + CARD_D * 6,
+      seatZ - rowSign * (radius - betDepth)
+    );
+    const labelAnchor = new THREE.Vector3(offset, STOOL_HEIGHT + 0.48 * MODEL_SCALE, seatZ + rowSign * 0.6);
+    const stoolAnchor = new THREE.Vector3(offset, CHAIR_BASE_HEIGHT + SEAT_THICKNESS / 2, seatZ);
     layout.push({
-      angle,
       forward,
       right,
       seatPos,
@@ -148,7 +165,8 @@ function createSeatLayout(count) {
       labelAnchor,
       stoolAnchor,
       stoolHeight: STOOL_HEIGHT,
-      isHuman: i === 0
+      isHuman: i === 0,
+      isDealer
     });
   }
   return layout;
@@ -552,7 +570,7 @@ function BlackJackArena({ search }) {
     seatLayout.forEach((seat, index) => {
       const group = new THREE.Group();
       group.position.copy(seat.seatPos);
-      group.lookAt(new THREE.Vector3(0, seat.seatPos.y, 0));
+      group.rotation.y = seat.forward.z > 0 ? Math.PI : 0;
 
       const seatMaterial = seat.isHuman
         ? seatMaterials.human


### PR DESCRIPTION
## Summary
- Place Texas Hold'em chairs along the long table edges, rotate them to face the felt, and move the betting controls to a vertical slider on the right with chip selectors styled like the on-table stacks.
- Apply the same straight-edge seating approach to Blackjack players and dealer, updating anchors and camera orientation to match the new alignment.
- Add shared styling for the vertical slider and chip buttons to blend with the wooden table surface.

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f0637e58488329b233f824d268dc03