### PR TITLE
Use 9ft table by default in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -859,7 +859,7 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
 });
 
 const TABLE_SIZE_OPTIONS = Object.freeze({
-  '9ft': { id: '9ft', label: '9 ft', scale: 1.2 }
+  '9ft': { id: '9ft', label: '9 ft', scale: 1.44 }
 });
 const DEFAULT_TABLE_SIZE_ID = '9ft';
 

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -20,7 +20,7 @@ export default function PoolRoyaleLobby() {
   const [mode, setMode] = useState('ai');
   const [avatar, setAvatar] = useState('');
   const [variant, setVariant] = useState('uk');
-  const [tableSize, setTableSize] = useState('9ft');
+  const tableSize = '9ft';
   const [playType, setPlayType] = useState('regular');
 
   useEffect(() => {
@@ -147,24 +147,6 @@ export default function PoolRoyaleLobby() {
               key={id}
               onClick={() => setVariant(id)}
               className={`lobby-tile ${variant === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-      </div>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Table Size</h3>
-        <div className="flex gap-2">
-          {[
-            { id: '7ft', label: '7 ft' },
-            { id: '8ft', label: '8 ft' },
-            { id: '9ft', label: '9 ft' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setTableSize(id)}
-              className={`lobby-tile ${tableSize === id ? 'lobby-selected' : ''}`}
             >
               {label}
             </button>


### PR DESCRIPTION
## Summary
- remove the table size selector from the Pool Royale lobby so the 9 ft table is always used
- increase the 9 ft table scale by 20% for in-game rendering

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f070fdec88832989b1cec20f591088