### PR TITLE
feat: move poker controls onto table rails

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1726,3 +1726,173 @@ img[alt="TPC"] {
   outline: 3px solid rgba(255, 255, 255, 0.85);
   outline-offset: 3px;
 }
+
+.rail-ui-root {
+  font-family: 'Inter', system-ui, sans-serif;
+  pointer-events: auto;
+}
+
+.rail-ui-surface {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  background: linear-gradient(155deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.78));
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 18px 35px rgba(2, 6, 23, 0.55);
+  color: #f8fafc;
+  min-width: 0;
+}
+
+.rail-ui-summary {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.rail-ui-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.rail-ui-value {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #facc15;
+  text-shadow: 0 0 8px rgba(250, 204, 21, 0.35);
+}
+
+.rail-ui-section {
+  background: rgba(15, 23, 42, 0.58);
+  border-radius: 0.85rem;
+  padding: 0.85rem;
+}
+
+.rail-ui-section--split {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.rail-ui-section--disabled {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 1rem;
+  background: rgba(30, 41, 59, 0.58);
+  border-radius: 0.85rem;
+  text-align: center;
+}
+
+.rail-ui-chips-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.rail-ui-chips-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+.rail-ui-slider-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.rail-ui-note {
+  font-size: 0.72rem;
+  color: rgba(226, 232, 240, 0.82);
+  text-align: center;
+}
+
+.rail-ui-note--stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.rail-ui-subtle {
+  font-size: 0.7rem;
+  color: rgba(148, 163, 184, 0.8);
+  text-align: center;
+}
+
+.rail-ui-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.6rem;
+}
+
+.rail-ui-actions--center {
+  justify-content: center;
+}
+
+.rail-ui-button {
+  border: none;
+  border-radius: 9999px;
+  padding: 0.45rem 1.1rem;
+  font-weight: 600;
+  font-size: 0.82rem;
+  color: #f8fafc;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
+}
+
+.rail-ui-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.rail-ui-button--ghost {
+  background: rgba(148, 163, 184, 0.18);
+  color: #e2e8f0;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.32);
+}
+
+.rail-ui-button--ghost:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.28);
+}
+
+.rail-ui-button--danger {
+  background: rgba(239, 68, 68, 0.85);
+  box-shadow: 0 12px 24px rgba(239, 68, 68, 0.32);
+}
+
+.rail-ui-button--danger:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.95);
+  transform: translateY(-1px);
+}
+
+.rail-ui-button--primary {
+  background: rgba(37, 99, 235, 0.88);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.32);
+}
+
+.rail-ui-button--primary:hover:not(:disabled) {
+  background: rgba(37, 99, 235, 0.98);
+  transform: translateY(-1px);
+}
+
+.rail-ui-button--action {
+  background: rgba(34, 197, 94, 0.85);
+  box-shadow: 0 12px 24px rgba(34, 197, 94, 0.28);
+  padding: 0.55rem 1.35rem;
+}
+
+.rail-ui-button--action:hover:not(:disabled) {
+  background: rgba(34, 197, 94, 0.95);
+  transform: translateY(-1px);
+}

--- a/webapp/src/pages/Games/BlackJackArena.jsx
+++ b/webapp/src/pages/Games/BlackJackArena.jsx
@@ -1,5 +1,7 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import * as THREE from 'three';
+import { CSS3DObject, CSS3DRenderer } from 'three/addons/renderers/CSS3DRenderer.js';
 
 import { createArenaCarpetMaterial, createArenaWallMaterial } from '../../utils/arenaDecor.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
@@ -8,6 +10,7 @@ import { createMurlanStyleTable } from '../../utils/murlanTable.js';
 import { createCardGeometry, createCardMesh, orientCard, setCardFace } from '../../utils/cards3d.js';
 import { createChipFactory } from '../../utils/chips3d.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { DEFAULT_CHIP_VALUES, getChipVisual } from '../../utils/chipUi.js';
 import {
   createDeck,
   shuffle,
@@ -261,7 +264,8 @@ function buildInitialState(players, token, stake) {
     pot: 0,
     awaitingInput: false,
     winners: [],
-    round: 0
+    round: 0,
+    autoBetsPrepared: false
   };
 }
 
@@ -272,6 +276,7 @@ function resetForNextRound(state) {
   next.currentIndex = 0;
   next.pot = 0;
   next.winners = [];
+  next.autoBetsPrepared = false;
   next.players = state.players.map((p) => ({
     ...p,
     hand: [],
@@ -283,16 +288,39 @@ function resetForNextRound(state) {
   return next;
 }
 
-function placeInitialBets(state) {
-  state.players.forEach((player, idx) => {
+function placeAutoBets(state, { includeHuman = false } = {}) {
+  state.players.forEach((player) => {
     if (player.isDealer) return;
+    if (!includeHuman && player.isHuman) return;
+    if (player.bet > 0) return;
     const wager = Math.min(player.chips, Math.max(20, Math.round(state.stake * 0.2)));
+    if (wager <= 0) {
+      player.bet = 0;
+      player.result = player.chips <= 0 ? 'Out' : 'No bet';
+      return;
+    }
     player.chips -= wager;
+    if (player.chips < 0) player.chips = 0;
     player.bet = wager;
     state.pot += wager;
     player.result = `Bet ${wager}`;
-    if (player.chips <= 0) player.chips = 0;
   });
+}
+
+function applyHumanBet(state, amount) {
+  const human = state.players.find((p) => p.isHuman && !p.isDealer);
+  if (!human) return;
+  const wager = Math.max(0, Math.min(human.chips, Math.round(amount)));
+  if (wager > 0) {
+    human.chips -= wager;
+    if (human.chips < 0) human.chips = 0;
+    human.bet = wager;
+    state.pot += wager;
+    human.result = `Bet ${wager}`;
+  } else {
+    human.bet = 0;
+    human.result = human.chips <= 0 ? 'Out' : 'No bet';
+  }
 }
 
 function dealInitialCards(state) {
@@ -405,6 +433,7 @@ function BlackJackArena({ search }) {
   const mountRef = useRef(null);
   const threeRef = useRef(null);
   const animationRef = useRef(null);
+  const railUiHostRef = useRef(null);
   const headAnglesRef = useRef({ yaw: 0, pitch: 0 });
   const cameraBasisRef = useRef({
     position: new THREE.Vector3(),
@@ -424,13 +453,23 @@ function BlackJackArena({ search }) {
     const players = buildPlayers(search);
     const { token, stake } = parseSearch(search);
     const base = buildInitialState(players, token, stake);
-    const prepared = resetForNextRound(base);
-    placeInitialBets(prepared);
-    dealInitialCards(prepared);
-    return prepared;
+    return resetForNextRound(base);
   });
   const [uiState, setUiState] = useState({ actions: [] });
+  const [betChipSelection, setBetChipSelection] = useState([]);
+  const [betSliderValue, setBetSliderValue] = useState(0);
   const timerRef = useRef(null);
+
+  if (!railUiHostRef.current && typeof document !== 'undefined') {
+    const host = document.createElement('div');
+    host.className = 'rail-ui-root rail-ui-root--blackjack';
+    host.style.width = '320px';
+    host.style.pointerEvents = 'auto';
+    host.style.transformStyle = 'preserve-3d';
+    host.style.transformOrigin = 'center';
+    host.style.display = 'none';
+    railUiHostRef.current = host;
+  }
 
   const applyHeadOrientation = useCallback(() => {
     const three = threeRef.current;
@@ -460,7 +499,20 @@ function BlackJackArena({ search }) {
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(mount.clientWidth, mount.clientHeight);
     renderer.shadowMap.enabled = true;
+    renderer.domElement.style.position = 'absolute';
+    renderer.domElement.style.inset = '0';
+    renderer.domElement.style.zIndex = '1';
     mount.appendChild(renderer.domElement);
+
+    const cssRenderer = new CSS3DRenderer();
+    cssRenderer.setSize(mount.clientWidth, mount.clientHeight);
+    cssRenderer.domElement.style.position = 'absolute';
+    cssRenderer.domElement.style.inset = '0';
+    cssRenderer.domElement.style.zIndex = '2';
+    cssRenderer.domElement.style.background = 'transparent';
+    mount.appendChild(cssRenderer.domElement);
+
+    const cssScene = new THREE.Scene();
 
     const scene = new THREE.Scene();
     scene.background = new THREE.Color('#020617');
@@ -560,6 +612,26 @@ function BlackJackArena({ search }) {
 
     applySeatedCamera(mount.clientWidth, mount.clientHeight);
 
+    let railHud = null;
+    if (railUiHostRef.current && humanSeat) {
+      const host = railUiHostRef.current;
+      const hudObject = new CSS3DObject(host);
+      const basePosition = humanSeat.cardAnchor
+        .clone()
+        .addScaledVector(humanSeat.forward, TABLE_RADIUS * 0.36)
+        .addScaledVector(humanSeat.right, TABLE_RADIUS * 0.22);
+      basePosition.y = tableInfo.tableHeight + CARD_D * 20;
+      const scale = 0.0038 * MODEL_SCALE;
+      hudObject.scale.setScalar(scale);
+      cssScene.add(hudObject);
+      railHud = {
+        object: hudObject,
+        basePosition,
+        forward: humanSeat.forward.clone(),
+        right: humanSeat.right.clone()
+      };
+    }
+
     const seatMaterials = {
       human: new THREE.MeshPhysicalMaterial({ color: 0x2563eb, roughness: 0.35, metalness: 0.5, clearcoat: 1 }),
       dealer: new THREE.MeshPhysicalMaterial({ color: 0xf97316, roughness: 0.35, metalness: 0.5, clearcoat: 1 }),
@@ -653,6 +725,16 @@ function BlackJackArena({ search }) {
     potStack.position.set(0, TABLE_HEIGHT + CARD_D * 6, 0);
     arena.add(potStack);
 
+    const updateRailHudPose = () => {
+      if (!railHud?.object) return;
+      const { object, basePosition, forward } = railHud;
+      object.position.copy(basePosition);
+      const lookTarget = basePosition.clone().add(forward.clone());
+      object.lookAt(lookTarget);
+      object.rotateX(-THREE.MathUtils.degToRad(56));
+    };
+    updateRailHudPose();
+
     threeRef.current = {
       renderer,
       scene,
@@ -663,10 +745,21 @@ function BlackJackArena({ search }) {
       faceCache,
       chipFactory,
       seatGroups,
-      potStack
+      potStack,
+      cssRenderer,
+      cssScene,
+      railHud,
+      updateRailHudPose
     };
 
     const element = renderer.domElement;
+    const cssElement = cssRenderer.domElement;
+    const forwardedEvents = ['pointerdown', 'pointermove', 'pointerup', 'pointercancel', 'pointerleave'];
+    const forwardPointerEvent = (event) => {
+      if (event.target !== cssElement) return;
+      element.dispatchEvent(new PointerEvent(event.type, event));
+    };
+    forwardedEvents.forEach((name) => cssElement.addEventListener(name, forwardPointerEvent));
     const handlePointerDown = (event) => {
       event.preventDefault();
       pointerStateRef.current = {
@@ -721,12 +814,14 @@ function BlackJackArena({ search }) {
 
     const onResize = () => {
       if (!threeRef.current) return;
-      const { renderer: r, camera: cam } = threeRef.current;
+      const { renderer: r, camera: cam, cssRenderer: cssR, updateRailHudPose: updateHud } = threeRef.current;
       const { clientWidth, clientHeight } = mount;
       r.setSize(clientWidth, clientHeight);
       cam.aspect = clientWidth / clientHeight;
       cam.updateProjectionMatrix();
+      cssR?.setSize(clientWidth, clientHeight);
       applySeatedCamera(clientWidth, clientHeight);
+      updateHud?.();
     };
     window.addEventListener('resize', onResize);
 
@@ -734,7 +829,9 @@ function BlackJackArena({ search }) {
       const three = threeRef.current;
       if (!three) return;
       applyHeadOrientation();
+      three.updateRailHudPose?.();
       three.renderer.render(three.scene, three.camera);
+      three.cssRenderer?.render(three.cssScene, three.camera);
       animationRef.current = requestAnimationFrame(animate);
     };
     animate();
@@ -742,13 +839,24 @@ function BlackJackArena({ search }) {
     return () => {
       window.removeEventListener('resize', onResize);
       cancelAnimationFrame(animationRef.current);
+      forwardedEvents.forEach((name) => cssElement.removeEventListener(name, forwardPointerEvent));
       element.removeEventListener('pointerdown', handlePointerDown);
       element.removeEventListener('pointermove', handlePointerMove);
       element.removeEventListener('pointerup', handlePointerUp);
       element.removeEventListener('pointercancel', handlePointerUp);
       element.removeEventListener('pointerleave', handlePointerUp);
       if (threeRef.current) {
-        const { renderer: r, scene: s, chipFactory: factory, seatGroups: seats, potStack: pot, tableInfo: info } = threeRef.current;
+        const {
+          renderer: r,
+          scene: s,
+          chipFactory: factory,
+          seatGroups: seats,
+          potStack: pot,
+          tableInfo: info,
+          cssRenderer: cssR,
+          cssScene: cssS,
+          railHud: hud
+        } = threeRef.current;
         seats.forEach((seat) => {
           seat.cardMeshes.forEach((mesh) => {
             mesh.geometry?.dispose?.();
@@ -770,9 +878,20 @@ function BlackJackArena({ search }) {
         factory.disposeStack(pot);
         factory.dispose();
         info?.dispose?.();
+        if (hud?.object) {
+          cssS?.remove(hud.object);
+          hud.object.element?.remove?.();
+        }
+        cssR?.domElement?.remove?.();
         r.dispose();
       }
       mount.removeChild(renderer.domElement);
+      if (cssRenderer.domElement.parentNode === mount) {
+        mount.removeChild(cssRenderer.domElement);
+      }
+      if (railUiHostRef.current) {
+        railUiHostRef.current.style.display = 'none';
+      }
       threeRef.current = null;
     };
   }, []);
@@ -826,14 +945,26 @@ function BlackJackArena({ search }) {
     if (!gameState) return;
     if (gameState.stage === 'round-end') {
       timerRef.current = setTimeout(() => {
-        setGameState((prev) => {
-          const next = resetForNextRound(cloneState(prev));
-          placeInitialBets(next);
-          dealInitialCards(next);
-          return next;
-        });
+        setGameState((prev) => resetForNextRound(cloneState(prev)));
       }, 3000);
       setUiState({ actions: [] });
+      return () => {
+        if (timerRef.current) {
+          clearTimeout(timerRef.current);
+          timerRef.current = null;
+        }
+      };
+    }
+    if (gameState.stage === 'betting') {
+      setUiState({ actions: [] });
+      if (!gameState.autoBetsPrepared) {
+        setGameState((prev) => {
+          const next = cloneState(prev);
+          placeAutoBets(next);
+          next.autoBetsPrepared = true;
+          return next;
+        });
+      }
       return () => {
         if (timerRef.current) {
           clearTimeout(timerRef.current);
@@ -890,7 +1021,204 @@ function BlackJackArena({ search }) {
     });
   };
 
+  const humanPlayer = useMemo(
+    () => gameState.players.find((p) => p.isHuman && !p.isDealer) ?? null,
+    [gameState.players]
+  );
+  const actor = gameState.players[gameState.currentIndex] || null;
+  const betSliderMax = humanPlayer ? Math.max(0, Math.round(humanPlayer.chips)) : 0;
+  const baseBet = humanPlayer ? Math.max(20, Math.round(gameState.stake * 0.2)) : 0;
+  const defaultBet = humanPlayer ? Math.min(betSliderMax, Math.max(baseBet, 0)) : 0;
+  const betChipTotal = useMemo(
+    () => betChipSelection.reduce((sum, chip) => sum + chip, 0),
+    [betChipSelection]
+  );
+  const betEffective = betChipTotal > 0 ? betChipTotal : betSliderValue;
+  const finalBet =
+    betSliderMax > 0
+      ? Math.min(betSliderMax, Math.max(betEffective, defaultBet))
+      : Math.max(0, betEffective);
+  const betSliderEnabled = Boolean(humanPlayer && betSliderMax > 0);
+  const humanNeedsBet = gameState.stage === 'betting' && !!humanPlayer && humanPlayer.bet <= 0;
+  const showRailHud = (gameState.stage === 'betting' && humanNeedsBet) || (gameState.stage === 'player-turns' && actor?.isHuman);
+  const betRemaining = humanPlayer ? Math.max(0, Math.round(humanPlayer.chips - finalBet)) : 0;
+
+  useEffect(() => {
+    if (gameState.stage !== 'betting') {
+      setBetChipSelection([]);
+      setBetSliderValue(0);
+      return;
+    }
+    setBetChipSelection([]);
+    if (!humanPlayer || betSliderMax <= 0) {
+      setBetSliderValue(0);
+      return;
+    }
+    setBetSliderValue(defaultBet);
+  }, [gameState.stage, humanPlayer?.id, betSliderMax, defaultBet]);
+
+  useEffect(() => {
+    if (betSliderMax <= 0) return;
+    setBetSliderValue((prev) => Math.min(prev, betSliderMax));
+  }, [betSliderMax]);
+
+  useEffect(() => {
+    const host = railUiHostRef.current;
+    if (!host) return;
+    host.style.display = showRailHud ? 'block' : 'none';
+    if (showRailHud) {
+      threeRef.current?.updateRailHudPose?.();
+    }
+  }, [showRailHud]);
+
+  const handleBetChip = (value) => {
+    if (gameState.stage !== 'betting' || !betSliderEnabled) return;
+    setBetChipSelection((prev) => {
+      const total = prev.reduce((sum, chip) => sum + chip, 0);
+      const nextTotal = total + value;
+      if (nextTotal > betSliderMax) return prev;
+      const next = [...prev, value];
+      setBetSliderValue(Math.min(betSliderMax, nextTotal));
+      return next;
+    });
+  };
+
+  const handleBetUndo = () => {
+    if (gameState.stage !== 'betting') return;
+    setBetChipSelection((prev) => {
+      if (!prev.length) return prev;
+      const updated = prev.slice(0, -1);
+      const nextTotal = updated.reduce((sum, chip) => sum + chip, 0);
+      setBetSliderValue(nextTotal > 0 ? Math.min(betSliderMax, nextTotal) : defaultBet);
+      return updated;
+    });
+  };
+
+  const handleBetSliderChange = (event) => {
+    if (gameState.stage !== 'betting') return;
+    const value = Number(event.target.value);
+    setBetSliderValue(value);
+    setBetChipSelection([]);
+  };
+
+  const handleBetConfirm = () => {
+    if (gameState.stage !== 'betting' || !humanPlayer) return;
+    setGameState((prev) => {
+      const next = cloneState(prev);
+      applyHumanBet(next, finalBet);
+      dealInitialCards(next);
+      return next;
+    });
+  };
+
+  const handleBetAllIn = () => {
+    if (gameState.stage !== 'betting' || !humanPlayer) return;
+    setGameState((prev) => {
+      const next = cloneState(prev);
+      applyHumanBet(next, betSliderMax);
+      dealInitialCards(next);
+      return next;
+    });
+  };
+
   const dealer = gameState.players[DEALER_INDEX];
+
+  const railUiContent =
+    showRailHud && railUiHostRef.current
+      ? createPortal(
+          <div className="rail-ui-surface">
+            {gameState.stage === 'betting' ? (
+              <>
+                <div className="rail-ui-summary">
+                  <span className="rail-ui-label">Place your wager</span>
+                  <span className="rail-ui-value">
+                    {Math.round(finalBet)} {gameState.token}
+                  </span>
+                </div>
+                <div className="rail-ui-section rail-ui-section--split">
+                  <div className="rail-ui-chips-panel">
+                    <div className="rail-ui-chips-grid">
+                      {DEFAULT_CHIP_VALUES.map((value) => {
+                        const { base, text } = getChipVisual(value);
+                        const disabled = value > betSliderMax;
+                        return (
+                          <button
+                            key={value}
+                            onClick={() => handleBetChip(value)}
+                            className="chip-select"
+                            style={{ '--chip-color': base, '--chip-text': text }}
+                            disabled={!betSliderEnabled || disabled}
+                          >
+                            {value}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    <button
+                      onClick={handleBetUndo}
+                      disabled={!betChipSelection.length}
+                      className="rail-ui-button rail-ui-button--ghost"
+                    >
+                      Undo
+                    </button>
+                    <span className="rail-ui-note">
+                      Selected: {Math.round(betChipTotal)} {gameState.token}
+                    </span>
+                  </div>
+                  <div className="rail-ui-slider-panel">
+                    <button
+                      onClick={handleBetAllIn}
+                      disabled={!humanPlayer}
+                      className="rail-ui-button rail-ui-button--danger"
+                    >
+                      All-in
+                    </button>
+                    <input
+                      type="range"
+                      orient="vertical"
+                      min={0}
+                      max={betSliderMax}
+                      step={1}
+                      value={Math.min(betSliderMax, betSliderValue)}
+                      onChange={handleBetSliderChange}
+                      disabled={!humanPlayer}
+                      className="vertical-range accent-green-400"
+                    />
+                    <div className="rail-ui-note rail-ui-note--stack">
+                      <span>
+                        Bet: {Math.round(finalBet)} {gameState.token}
+                      </span>
+                      <span>
+                        Remaining: {betRemaining} {gameState.token}
+                      </span>
+                    </div>
+                    <button
+                      onClick={handleBetConfirm}
+                      disabled={!humanPlayer}
+                      className="rail-ui-button rail-ui-button--primary"
+                    >
+                      Confirm {Math.round(finalBet)} {gameState.token}
+                    </button>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className="rail-ui-actions rail-ui-actions--center">
+                {uiState.actions.map((action) => (
+                  <button
+                    key={action.id}
+                    onClick={() => handleAction(action.id)}
+                    className="rail-ui-button rail-ui-button--action"
+                  >
+                    {action.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>,
+          railUiHostRef.current
+        )
+      : null;
 
   return (
     <div className="relative w-full h-full">
@@ -907,19 +1235,7 @@ function BlackJackArena({ search }) {
           Round complete
         </div>
       )}
-      {gameState.stage === 'player-turns' && gameState.players[gameState.currentIndex]?.isHuman && (
-        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-3">
-          {uiState.actions.map((action) => (
-            <button
-              key={action.id}
-              onClick={() => handleAction(action.id)}
-              className="px-5 py-2 rounded-lg bg-green-600/90 text-white font-semibold shadow-lg"
-            >
-              {action.label}
-            </button>
-          ))}
-        </div>
-      )}
+      {railUiContent}
     </div>
   );
 }

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import * as THREE from 'three';
+import { CSS3DObject, CSS3DRenderer } from 'three/addons/renderers/CSS3DRenderer.js';
 
 import { createArenaCarpetMaterial, createArenaWallMaterial } from '../../utils/arenaDecor.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
@@ -8,6 +10,7 @@ import { createMurlanStyleTable } from '../../utils/murlanTable.js';
 import { createCardGeometry, createCardMesh, orientCard, setCardFace } from '../../utils/cards3d.js';
 import { createChipFactory } from '../../utils/chips3d.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { DEFAULT_CHIP_VALUES, getChipVisual } from '../../utils/chipUi.js';
 
 import {
   createDeck,
@@ -58,24 +61,6 @@ const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: 0.62, landscape: 0.48 }
 const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 2.05, landscape: 1.55 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 2.1, landscape: 1.72 });
 
-const CHIP_VALUES = [1000, 500, 200, 50, 20, 10, 5, 2, 1];
-const CHIP_COLOR_MAP = {
-  1: '#f2b21a',
-  2: '#f97316',
-  5: '#d54a3a',
-  10: '#2196f3',
-  20: '#4caf50',
-  50: '#3a3331',
-  200: '#7b4abd',
-  500: '#a3362e',
-  1000: '#1fb3d6'
-};
-
-function getChipVisual(value) {
-  const base = CHIP_COLOR_MAP[value] ?? '#22d3ee';
-  const text = value >= 50 ? '#f8fafc' : '#0f172a';
-  return { base, text };
-}
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
 
 const STAGE_SEQUENCE = ['preflop', 'flop', 'turn', 'river'];
@@ -622,6 +607,7 @@ function TexasHoldemArena({ search }) {
   const mountRef = useRef(null);
   const threeRef = useRef(null);
   const animationRef = useRef(null);
+  const railUiHostRef = useRef(null);
   const headAnglesRef = useRef({ yaw: 0, pitch: 0 });
   const cameraBasisRef = useRef({
     position: new THREE.Vector3(),
@@ -654,6 +640,17 @@ function TexasHoldemArena({ search }) {
   const [sliderValue, setSliderValue] = useState(0);
   const timerRef = useRef(null);
 
+  if (!railUiHostRef.current && typeof document !== 'undefined') {
+    const host = document.createElement('div');
+    host.className = 'rail-ui-root rail-ui-root--texas';
+    host.style.width = '360px';
+    host.style.pointerEvents = 'auto';
+    host.style.transformStyle = 'preserve-3d';
+    host.style.transformOrigin = 'center';
+    host.style.display = 'none';
+    railUiHostRef.current = host;
+  }
+
   const applyHeadOrientation = useCallback(() => {
     const three = threeRef.current;
     if (!three) return;
@@ -682,7 +679,20 @@ function TexasHoldemArena({ search }) {
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(mount.clientWidth, mount.clientHeight);
     renderer.shadowMap.enabled = true;
+    renderer.domElement.style.position = 'absolute';
+    renderer.domElement.style.inset = '0';
+    renderer.domElement.style.zIndex = '1';
     mount.appendChild(renderer.domElement);
+
+    const cssRenderer = new CSS3DRenderer();
+    cssRenderer.setSize(mount.clientWidth, mount.clientHeight);
+    cssRenderer.domElement.style.position = 'absolute';
+    cssRenderer.domElement.style.inset = '0';
+    cssRenderer.domElement.style.zIndex = '2';
+    cssRenderer.domElement.style.background = 'transparent';
+    mount.appendChild(cssRenderer.domElement);
+
+    const cssScene = new THREE.Scene();
 
     const scene = new THREE.Scene();
     scene.background = new THREE.Color('#030712');
@@ -784,6 +794,26 @@ function TexasHoldemArena({ search }) {
 
     applySeatedCamera(mount.clientWidth, mount.clientHeight);
 
+    let railHud = null;
+    if (railUiHostRef.current && humanSeat) {
+      const host = railUiHostRef.current;
+      const hudObject = new CSS3DObject(host);
+      const basePosition = humanSeat.cardAnchor
+        .clone()
+        .addScaledVector(humanSeat.forward, TABLE_RADIUS * 0.34)
+        .addScaledVector(humanSeat.right, TABLE_RADIUS * 0.26);
+      basePosition.y = tableInfo.tableHeight + CARD_D * 24;
+      const scale = 0.004 * MODEL_SCALE;
+      hudObject.scale.setScalar(scale);
+      cssScene.add(hudObject);
+      railHud = {
+        object: hudObject,
+        basePosition,
+        forward: humanSeat.forward.clone(),
+        right: humanSeat.right.clone()
+      };
+    }
+
     const seatMaterials = {
       human: new THREE.MeshPhysicalMaterial({ color: 0x2563eb, roughness: 0.35, metalness: 0.5, clearcoat: 1 }),
       ai: new THREE.MeshPhysicalMaterial({ color: 0x334155, roughness: 0.35, metalness: 0.5, clearcoat: 1 })
@@ -873,6 +903,16 @@ function TexasHoldemArena({ search }) {
     potStack.position.copy(POT_OFFSET);
     arenaGroup.add(potStack);
 
+    const updateRailHudPose = () => {
+      if (!railHud?.object) return;
+      const { object, basePosition, forward } = railHud;
+      object.position.copy(basePosition);
+      const lookTarget = basePosition.clone().add(forward.clone());
+      object.lookAt(lookTarget);
+      object.rotateX(-THREE.MathUtils.degToRad(58));
+    };
+    updateRailHudPose();
+
     threeRef.current = {
       renderer,
       scene,
@@ -884,10 +924,21 @@ function TexasHoldemArena({ search }) {
       communityMeshes,
       potStack,
       deckAnchor,
+      cssRenderer,
+      cssScene,
+      railHud,
+      updateRailHudPose,
       frameId: null
     };
 
     const element = renderer.domElement;
+    const cssElement = cssRenderer.domElement;
+    const forwardedEvents = ['pointerdown', 'pointermove', 'pointerup', 'pointercancel', 'pointerleave'];
+    const forwardPointerEvent = (event) => {
+      if (event.target !== cssElement) return;
+      element.dispatchEvent(new PointerEvent(event.type, event));
+    };
+    forwardedEvents.forEach((name) => cssElement.addEventListener(name, forwardPointerEvent));
     const handlePointerDown = (event) => {
       event.preventDefault();
       pointerStateRef.current = {
@@ -942,12 +993,14 @@ function TexasHoldemArena({ search }) {
 
     const handleResize = () => {
       if (!mount || !threeRef.current) return;
-      const { renderer: r, camera: cam } = threeRef.current;
+      const { renderer: r, camera: cam, cssRenderer: cssR, updateRailHudPose: updateHud } = threeRef.current;
       const { clientWidth, clientHeight } = mount;
       r.setSize(clientWidth, clientHeight);
       cam.aspect = clientWidth / clientHeight;
       cam.updateProjectionMatrix();
+      cssR?.setSize(clientWidth, clientHeight);
       applySeatedCamera(clientWidth, clientHeight);
+      updateHud?.();
     };
 
     window.addEventListener('resize', handleResize);
@@ -956,7 +1009,9 @@ function TexasHoldemArena({ search }) {
       const three = threeRef.current;
       if (!three) return;
       applyHeadOrientation();
+      three.updateRailHudPose?.();
       three.renderer.render(three.scene, three.camera);
+      three.cssRenderer?.render(three.cssScene, three.camera);
       animationRef.current = requestAnimationFrame(animate);
     };
     animate();
@@ -964,13 +1019,23 @@ function TexasHoldemArena({ search }) {
     return () => {
       window.removeEventListener('resize', handleResize);
       cancelAnimationFrame(animationRef.current);
+      forwardedEvents.forEach((name) => cssElement.removeEventListener(name, forwardPointerEvent));
       element.removeEventListener('pointerdown', handlePointerDown);
       element.removeEventListener('pointermove', handlePointerMove);
       element.removeEventListener('pointerup', handlePointerUp);
       element.removeEventListener('pointercancel', handlePointerUp);
       element.removeEventListener('pointerleave', handlePointerUp);
       if (threeRef.current) {
-        const { renderer: r, scene: s, chipFactory: factory, seatGroups: seats, communityMeshes: community } = threeRef.current;
+        const {
+          renderer: r,
+          scene: s,
+          chipFactory: factory,
+          seatGroups: seats,
+          communityMeshes: community,
+          cssRenderer: cssR,
+          cssScene: cssS,
+          railHud: hud
+        } = threeRef.current;
         seats.forEach((seat) => {
           seat.cardMeshes.forEach((mesh) => {
             mesh.geometry?.dispose?.();
@@ -1000,9 +1065,20 @@ function TexasHoldemArena({ search }) {
         factory.disposeStack(threeRef.current.potStack);
         factory.dispose();
         tableInfo?.dispose?.();
+        if (hud?.object) {
+          cssS?.remove(hud.object);
+          hud.object.element?.remove?.();
+        }
+        cssR?.domElement?.remove?.();
         r.dispose();
       }
       mount.removeChild(renderer.domElement);
+      if (cssRenderer.domElement.parentNode === mount) {
+        mount.removeChild(cssRenderer.domElement);
+      }
+      if (railUiHostRef.current) {
+        railUiHostRef.current.style.display = 'none';
+      }
       threeRef.current = null;
     };
   }, []);
@@ -1200,6 +1276,120 @@ function TexasHoldemArena({ search }) {
     handleAction(action, sliderMax);
   };
 
+  const showRailHud = actor?.isHuman && gameState.stage !== 'showdown';
+
+  useEffect(() => {
+    const host = railUiHostRef.current;
+    if (!host) return;
+    host.style.display = showRailHud ? 'block' : 'none';
+    if (showRailHud) {
+      threeRef.current?.updateRailHudPose?.();
+    }
+  }, [showRailHud]);
+
+  const railUiContent =
+    showRailHud && railUiHostRef.current
+      ? createPortal(
+          <div className="rail-ui-surface">
+            <div className="rail-ui-summary">
+              <span className="rail-ui-label">To call</span>
+              <span className="rail-ui-value">
+                {Math.round(toCall)} {gameState.token}
+              </span>
+            </div>
+            {sliderEnabled ? (
+              <div className="rail-ui-section rail-ui-section--split">
+                <div className="rail-ui-chips-panel">
+                  <div className="rail-ui-chips-grid">
+                    {DEFAULT_CHIP_VALUES.map((value) => {
+                      const { base, text } = getChipVisual(value);
+                      const disabled = value > sliderMax;
+                      return (
+                        <button
+                          key={value}
+                          onClick={() => handleChipClick(value)}
+                          className="chip-select"
+                          style={{ '--chip-color': base, '--chip-text': text }}
+                          disabled={!sliderEnabled || disabled}
+                        >
+                          {value}
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <button
+                    onClick={handleUndoChip}
+                    disabled={!chipSelection.length}
+                    className="rail-ui-button rail-ui-button--ghost"
+                  >
+                    Undo
+                  </button>
+                  <span className="rail-ui-note">
+                    Selected raise: {Math.round(raisePreview)} {gameState.token}
+                  </span>
+                </div>
+                <div className="rail-ui-slider-panel">
+                  <button
+                    onClick={handleAllIn}
+                    disabled={!sliderEnabled}
+                    className="rail-ui-button rail-ui-button--danger"
+                  >
+                    All-in
+                  </button>
+                  <input
+                    type="range"
+                    orient="vertical"
+                    min={0}
+                    max={sliderMax}
+                    step={1}
+                    value={Math.min(sliderMax, sliderValue)}
+                    onChange={handleSliderChange}
+                    disabled={!sliderEnabled}
+                    className="vertical-range accent-sky-400"
+                  />
+                  <div className="rail-ui-note rail-ui-note--stack">
+                    <span>
+                      Raise amount: {Math.round(finalRaise)} {gameState.token}
+                    </span>
+                    <span>
+                      Total commitment: {Math.round(totalSpend)} {gameState.token}
+                    </span>
+                  </div>
+                  <button
+                    onClick={handleRaiseConfirm}
+                    disabled={!sliderEnabled}
+                    className="rail-ui-button rail-ui-button--primary"
+                  >
+                    {sliderLabel} {Math.round(totalSpend)} {gameState.token}
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="rail-ui-section rail-ui-section--disabled">
+                <span className="rail-ui-label">Raise unavailable</span>
+                <span className="rail-ui-subtle">
+                  {toCall > 0
+                    ? `Call ${Math.round(toCall)} ${gameState.token}`
+                    : 'You can only check or fold this turn'}
+                </span>
+              </div>
+            )}
+            <div className="rail-ui-actions">
+              {uiState.availableActions.map((action) => (
+                <button
+                  key={action.id}
+                  onClick={() => handleAction(action.id)}
+                  className="rail-ui-button rail-ui-button--action"
+                >
+                  {action.label}
+                </button>
+              ))}
+            </div>
+          </div>,
+          railUiHostRef.current
+        )
+      : null;
+
   return (
     <div className="relative w-full h-full">
       <div ref={mountRef} className="absolute inset-0" />
@@ -1225,85 +1415,7 @@ function TexasHoldemArena({ search }) {
           </div>
         )}
       </div>
-      {actor?.isHuman && gameState.stage !== 'showdown' && (
-        <>
-          {sliderEnabled && (
-            <>
-              <div className="absolute top-1/2 right-32 -translate-y-1/2 flex flex-col items-center gap-3 z-20">
-                <div className="grid grid-cols-2 gap-3">
-                  {CHIP_VALUES.map((value) => {
-                    const { base, text } = getChipVisual(value);
-                    return (
-                      <button
-                        key={value}
-                        onClick={() => handleChipClick(value)}
-                        className="chip-select"
-                        style={{ '--chip-color': base, '--chip-text': text }}
-                      >
-                        {value}
-                      </button>
-                    );
-                  })}
-                </div>
-                <div className="flex flex-col items-center gap-2 text-xs text-white drop-shadow-lg">
-                  <button
-                    onClick={handleUndoChip}
-                    disabled={!chipSelection.length}
-                    className="rounded-full bg-amber-400/90 px-4 py-1 text-black font-semibold shadow disabled:opacity-40"
-                  >
-                    Undo
-                  </button>
-                  <span className="text-center">
-                    Selected raise: {Math.round(raisePreview)} {gameState.token}
-                  </span>
-                </div>
-              </div>
-              <div className="absolute top-1/2 right-6 -translate-y-1/2 flex flex-col items-center gap-4 z-20">
-                <button
-                  onClick={handleAllIn}
-                  disabled={!sliderEnabled}
-                  className="rounded-full border border-red-300/80 bg-red-600/80 px-5 py-2 text-white font-semibold shadow-lg disabled:opacity-40"
-                >
-                  All-in
-                </button>
-                <input
-                  type="range"
-                  orient="vertical"
-                  min={0}
-                  max={sliderMax}
-                  step={1}
-                  value={Math.min(sliderMax, sliderValue)}
-                  onChange={handleSliderChange}
-                  disabled={!sliderEnabled}
-                  className="vertical-range accent-sky-400"
-                />
-                <div className="text-xs text-white drop-shadow-lg text-center space-y-1">
-                  <div>Raise amount: {Math.round(finalRaise)} {gameState.token}</div>
-                  <div>Total commitment: {Math.round(totalSpend)} {gameState.token}</div>
-                </div>
-                <button
-                  onClick={handleRaiseConfirm}
-                  disabled={!sliderEnabled}
-                  className="rounded-full bg-blue-600 px-4 py-2 text-white font-semibold shadow-lg disabled:opacity-40 disabled:bg-blue-600/40"
-                >
-                  {sliderLabel} {Math.round(totalSpend)} {gameState.token}
-                </button>
-              </div>
-            </>
-          )}
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-3">
-            {uiState.availableActions.map((action) => (
-              <button
-                key={action.id}
-                onClick={() => handleAction(action.id)}
-                className="px-5 py-2 rounded-lg bg-blue-600/90 text-white font-semibold shadow-lg"
-              >
-                {action.label}
-              </button>
-            ))}
-          </div>
-        </>
-      )}
+      {railUiContent}
     </div>
   );
 }

--- a/webapp/src/utils/chipUi.js
+++ b/webapp/src/utils/chipUi.js
@@ -1,0 +1,20 @@
+export const DEFAULT_CHIP_VALUES = Object.freeze([1000, 500, 200, 100, 50, 20, 10, 5, 2, 1]);
+
+const CHIP_COLOR_MAP = Object.freeze({
+  1: '#f2b21a',
+  2: '#f97316',
+  5: '#d54a3a',
+  10: '#2196f3',
+  20: '#4caf50',
+  50: '#3a3331',
+  100: '#38bdf8',
+  200: '#7b4abd',
+  500: '#a3362e',
+  1000: '#1fb3d6'
+});
+
+export function getChipVisual(value) {
+  const base = CHIP_COLOR_MAP[value] ?? '#22d3ee';
+  const text = value >= 50 ? '#f8fafc' : '#0f172a';
+  return { base, text };
+}


### PR DESCRIPTION
## Summary
- anchor the Texas Hold'em UI to the 3D table using CSS3D overlays that follow the player seat and mirror the Murlan camera behavior
- refresh the blackjack arena with on-table betting controls, staged betting flow, and shared chip visuals consistent with the poker table
- add reusable chip UI helpers and styling for the new rail-mounted panels across both games

## Testing
- npm run build --prefix webapp

------
https://chatgpt.com/codex/tasks/task_e_68f071b86780832987541467f4292557