### PR TITLE
Reduce Pool Royale table height by 20%

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -657,7 +657,8 @@ const LEG_HEIGHT_FACTOR = 4;
 const LEG_HEIGHT_MULTIPLIER = 2.25;
 const BASE_TABLE_LIFT = 3.6;
 const TABLE_DROP = 0.4;
-const TABLE_H = 0.75 * LEG_SCALE; // physical height of table used for legs/skirt
+const TABLE_HEIGHT_REDUCTION = 0.8;
+const TABLE_H = 0.75 * LEG_SCALE * TABLE_HEIGHT_REDUCTION; // physical height of table used for legs/skirt after 20% reduction
 const TABLE_LIFT =
   BASE_TABLE_LIFT + TABLE_H * (LEG_HEIGHT_FACTOR - 1);
 const BASE_LEG_HEIGHT = TABLE.THICK * 2 * 3 * 1.15 * LEG_HEIGHT_MULTIPLIER;


### PR DESCRIPTION
## Summary
- add a shared constant that reduces the Pool Royale table height by 20%
- update the table height calculation to use the new reduction factor so the physical table sits lower

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f07fe579948329ae77735a70a8c8f4