### PR TITLE
Adjust poker cameras and raise controls on the table rail

### DIFF
--- a/webapp/src/pages/Games/BlackJackArena.jsx
+++ b/webapp/src/pages/Games/BlackJackArena.jsx
@@ -53,8 +53,8 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(22);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0035;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: 0.62, landscape: 0.48 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 2.13, landscape: 1.63 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 2.1, landscape: 1.72 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 2.28, landscape: 1.78 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.94, landscape: 1.58 });
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
 
 const REGION_NAMES = typeof Intl !== 'undefined' ? new Intl.DisplayNames(['en'], { type: 'region' }) : null;


### PR DESCRIPTION
## Summary
- lower and retreat the seated cameras for the Texas Hold'em and Blackjack arenas for a clearer view of the table
- replace the Texas Hold'em HUD raise controls with 3D chip, slider, and button elements on the table rail and hook them into pointer interactions
- keep the in-table controls in sync with game state, updating chip previews, button availability, and labels as the hand progresses

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68f08cb169f883299df3e23352e8cbad