### PR TITLE
Adjust cue camera floor clearance

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2284,7 +2284,7 @@ const STANDING_VIEW_MARGIN = 0.0024;
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.22;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.48);
-const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.055; // stop just short of the lowest sweep to avoid grazing the cloth
+const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.085; // stop just short of the lowest sweep to avoid grazing the cloth and keep slightly above the cloth plane
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
 const PLAYER_CAMERA_DISTANCE_FACTOR = 0.043;
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;


### PR DESCRIPTION
## Summary
- raise the Pool Royale cue camera's lowest pitch limit so it stops slightly higher above the cloth

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0a3c0895483299d79485d8d3d606c