### PR TITLE
Adjust player camera height limits around cue stick

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -21,6 +21,9 @@ public class CameraController : MonoBehaviour
     // Extra clearance used when clamping the camera height so it always remains
     // above the cue stick and keeps the stick visible in frame.
     public float cueStickHeightClearance = 0.05f;
+    // Additional safety margin that prevents the player view from dipping below
+    // the cue surface when the camera is lowered as far as possible.
+    public float cueStickSurfaceMargin = 0.01f;
     // Radius of the cue ball so the camera can stay above the top surface of
     // the cue stick as it rests on the cloth.
     public float cueBallRadius = 0.028575f;
@@ -30,6 +33,9 @@ public class CameraController : MonoBehaviour
     public float minimumCueViewDistance = 1.45f;
     // How far above the rails the camera is allowed to travel.
     public float maxHeightAboveTable = 1.9f;
+    // Small amount of headroom applied to the upward clamp so the player can
+    // lift the camera just past the default maximum height.
+    public float maxHeightHeadroom = 0.1f;
     // Default distance of the camera from the table centre when fully raised to
     // provide a broad overview of the action.
     public float distanceFromCenter = 3.8f;
@@ -79,13 +85,13 @@ public class CameraController : MonoBehaviour
         Vector3 pos = transform.position;
         float minRailY = railTopY + Mathf.Max(0f, railClearance);
         float cueTopClearance = Mathf.Max(0f, cueStickHeightClearance);
+        float cueSurfaceMargin = Mathf.Max(0f, cueStickSurfaceMargin);
         float cueRadius = Mathf.Max(0f, cueBallRadius);
-        float cueStickMinY = player != null
-            ? player.position.y + cueRadius + cueTopClearance
-            : minRailY;
-        float tableCueMinY = tableTopY + cueRadius + cueTopClearance;
+        float cueSurfaceY = (player != null ? player.position.y : tableTopY) + cueRadius;
+        float cueStickMinY = cueSurfaceY + cueTopClearance + cueSurfaceMargin;
+        float tableCueMinY = tableTopY + cueRadius + cueTopClearance + cueSurfaceMargin;
         float minY = Mathf.Max(minRailY, cueStickMinY, tableCueMinY);
-        float maxY = tableTopY + maxHeightAboveTable;
+        float maxY = tableTopY + maxHeightAboveTable + Mathf.Max(0f, maxHeightHeadroom);
         pos.y = Mathf.Clamp(pos.y, minY, maxY);
 
         // As the camera is pulled downward toward the rails gradually move it


### PR DESCRIPTION
## Summary
- add configurable cue stick surface margin to stop the player camera from dropping below the cue
- extend the upward clamp with adjustable headroom so the raised view slightly exceeds the original max height

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f0c0e120b48329b8188b431bbc047d