### PR TITLE
Enlarge snooker table and restore ambient fill

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8588,7 +8588,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         lightingRig.add(spot);
         lightingRig.add(spot.target);
 
-        const ambient = new THREE.AmbientLight(0xffffff, 0.094); // return trimmed spot energy through ambient fill
+        const ambient = new THREE.AmbientLight(0xffffff, 0.02625);
         ambient.position.set(
           0,
           tableSurfaceY + scaledHeight * 1.95 + lightHeightLift,

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -410,12 +410,14 @@ function addPocketCuts(parent, clothPlane) {
 // separate scales for table and balls
 // Dimensions enlarged for a roomier snooker table but globally reduced by 30%
 const SIZE_REDUCTION = 0.7;
+// Apply an additional 25% boost so the table, balls, and pockets read larger on screen
+const TABLE_SIZE_BOOST = 1.25;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION; // apply uniform 30% shrink from previous tuning
 // shrink the entire 3D world to ~70% of its previous footprint while preserving
 // the HUD scale and gameplay math that rely on worldScaleFactor conversions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7;
 const CUE_STYLE_STORAGE_KEY = 'tonplayCueStyleIndex';
-const TABLE_SCALE = 1.3;
+const TABLE_SCALE = 1.3 * TABLE_SIZE_BOOST;
 const TABLE = {
   W: 66 * TABLE_SCALE,
   H: 132 * TABLE_SCALE,


### PR DESCRIPTION
## Summary
- apply a 25% size boost to the snooker table configuration so the table surface, pockets, and balls render larger while keeping proportions intact
- reset the Pool Royale ambient light intensity to the earlier spotlight fill configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0e028345883298e73eb98110f6375