### PR TITLE
Scale snooker table by 20% and relax lighting reflections

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -412,12 +412,13 @@ function addPocketCuts(parent, clothPlane) {
 const SIZE_REDUCTION = 0.7;
 // Apply an additional 25% boost so the table, balls, and pockets read larger on screen
 const TABLE_SIZE_BOOST = 1.25;
+const TABLE_DIMENSION_SCALE = 1.2; // enlarge the snooker table footprint (width, length, height) by 20%
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION; // apply uniform 30% shrink from previous tuning
 // shrink the entire 3D world to ~70% of its previous footprint while preserving
 // the HUD scale and gameplay math that rely on worldScaleFactor conversions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7;
 const CUE_STYLE_STORAGE_KEY = 'tonplayCueStyleIndex';
-const TABLE_SCALE = 1.3 * TABLE_SIZE_BOOST;
+const TABLE_SCALE = 1.3 * TABLE_SIZE_BOOST * TABLE_DIMENSION_SCALE;
 const TABLE = {
   W: 66 * TABLE_SCALE,
   H: 132 * TABLE_SCALE,
@@ -8360,6 +8361,8 @@ function SnookerGame() {
         lightingRig.add(dirLight);
         lightingRig.add(dirLight.target);
 
+        const LIGHT_DISTANCE_NUDGE = 1.05; // move the spotlight slightly away from the chrome plates
+        const LIGHT_HEIGHT_NUDGE = 1.035;
         const spot = new THREE.SpotLight(
           0xffffff,
           18.9,
@@ -8369,9 +8372,9 @@ function SnookerGame() {
           1
         );
         spot.position.set(
-          triangleRadius * LIGHT_LATERAL_SCALE,
-          triangleHeight,
-          triangleRadius * LIGHT_LATERAL_SCALE * 0.35
+          triangleRadius * LIGHT_LATERAL_SCALE * LIGHT_DISTANCE_NUDGE,
+          triangleHeight * LIGHT_HEIGHT_NUDGE,
+          triangleRadius * LIGHT_LATERAL_SCALE * 0.35 * LIGHT_DISTANCE_NUDGE
         );
         spot.target.position.set(0, tableSurfaceY + TABLE_H * 0.18, 0);
         spot.decay = 1.0;
@@ -8382,10 +8385,11 @@ function SnookerGame() {
         lightingRig.add(spot);
         lightingRig.add(spot.target);
 
+        const AMBIENT_HEIGHT_NUDGE = 1.045; // lift the ambient light a touch higher to soften reflections
         const ambient = new THREE.AmbientLight(0xffffff, 0.02625);
         ambient.position.set(
           0,
-          tableSurfaceY + scaledHeight * 1.95 + lightHeightLift,
+          tableSurfaceY + scaledHeight * 1.95 * AMBIENT_HEIGHT_NUDGE + lightHeightLift,
           0
         );
         lightingRig.add(ambient);


### PR DESCRIPTION
## Summary
- enlarge the snooker table configuration by 20% so the playfield, pockets, and balls scale uniformly
- nudge the spotlight and ambient light positions slightly farther from the table to soften chrome reflections

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0ee2651f083299c6d615edc5b28a7