### PR TITLE
Tweak Texas Hold'em camera distance and elevation

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -88,10 +88,10 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(40);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0035;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: 0.55, landscape: 0.42 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 2.2, landscape: 1.68 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 2.35, landscape: 1.82 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({
-  portrait: 1.26 + TABLE_HEIGHT_RAISE,
-  landscape: 1.0 + TABLE_HEIGHT_RAISE
+  portrait: 1.18 + TABLE_HEIGHT_RAISE,
+  landscape: 0.92 + TABLE_HEIGHT_RAISE
 });
 
 const CHIP_VALUES = [1000, 500, 200, 50, 20, 10, 5, 2, 1];
@@ -1000,7 +1000,7 @@ function TexasHoldemArena({ search }) {
       CAMERA_SETTINGS.near,
       CAMERA_SETTINGS.far
     );
-    camera.position.set(0, TABLE_HEIGHT * 3.05, TABLE_RADIUS * 3.6);
+    camera.position.set(0, TABLE_HEIGHT * 2.9, TABLE_RADIUS * 3.85);
     renderer.domElement.style.touchAction = 'none';
     renderer.domElement.style.cursor = 'grab';
 


### PR DESCRIPTION
## Summary
- lower the seated camera height and increase its retreat to frame the table from farther away
- adjust the initial camera placement to match the updated framing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f105b8f15883298b8822a88c688c84