### PR TITLE
Reduce lighting brightness in 3D snooker and Pool Royale scenes

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8582,7 +8582,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
 
         const spot = new THREE.SpotLight(
           0xffffff,
-          16.66,
+          14.161,
           0,
           Math.PI * 0.36,
           0.42,
@@ -8602,7 +8602,10 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         lightingRig.add(spot);
         lightingRig.add(spot.target);
 
-        const ambient = new THREE.AmbientLight(0xffffff, 0.094); // return trimmed spot energy through ambient fill
+        const ambient = new THREE.AmbientLight(
+          0xffffff,
+          0.0799
+        ); // return trimmed spot energy through ambient fill
         ambient.position.set(
           0,
           tableSurfaceY + scaledHeight * 1.95 + lightHeightLift,

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -8374,7 +8374,7 @@ function SnookerGame() {
 
         const spot = new THREE.SpotLight(
           0xffffff,
-          16.065,
+          13.65525,
           0,
           Math.PI * 0.36,
           0.42,
@@ -8394,7 +8394,7 @@ function SnookerGame() {
         lightingRig.add(spot);
         lightingRig.add(spot.target);
 
-        const ambient = new THREE.AmbientLight(0xffffff, 0.02625);
+        const ambient = new THREE.AmbientLight(0xffffff, 0.0223125);
         ambient.position.set(
           0,
           tableSurfaceY + scaledHeight * 1.95 + lightHeightLift,


### PR DESCRIPTION
## Summary
- lower the spotlight intensity in the 3D Pool Royale and Snooker games by 15%
- dim the ambient fill lighting in both scenes to keep overall illumination consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f12394df5483299084814c4de9dba5