### PR TITLE
Raise lighting offsets for pool and snooker tables

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8563,6 +8563,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         const lightHeightLift = scaledHeight * LIGHT_HEIGHT_LIFT_MULTIPLIER; // lift the lighting rig higher above the table
         const triangleHeight = tableSurfaceY + 6.6 * scaledHeight + lightHeightLift;
         const triangleRadius = fixtureScale * 0.98;
+        const lightRetreatOffset = scaledHeight * 0.24;
         hemisphere.position.set(0, triangleHeight, -triangleRadius * 0.6);
         lightingRig.add(hemisphere);
 
@@ -8590,7 +8591,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         );
         spot.position.set(
           triangleRadius * LIGHT_LATERAL_SCALE,
-          triangleHeight,
+          triangleHeight + lightRetreatOffset,
           triangleRadius * LIGHT_LATERAL_SCALE * 0.35
         );
         spot.target.position.set(0, tableSurfaceY + TABLE_H * 0.18, 0);
@@ -8608,7 +8609,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         ); // return trimmed spot energy through ambient fill
         ambient.position.set(
           0,
-          tableSurfaceY + scaledHeight * 1.95 + lightHeightLift,
+          tableSurfaceY + scaledHeight * 1.95 + lightHeightLift + lightRetreatOffset,
           0
         );
         lightingRig.add(ambient);

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -8355,6 +8355,7 @@ function SnookerGame() {
         const lightHeightLift = scaledHeight * LIGHT_HEIGHT_LIFT_MULTIPLIER; // lift the lighting rig higher above the table
         const triangleHeight = tableSurfaceY + 6.6 * scaledHeight + lightHeightLift;
         const triangleRadius = fixtureScale * 0.98;
+        const lightRetreatOffset = scaledHeight * 0.24;
         hemisphere.position.set(0, triangleHeight, -triangleRadius * 0.6);
         lightingRig.add(hemisphere);
 
@@ -8382,7 +8383,7 @@ function SnookerGame() {
         );
         spot.position.set(
           triangleRadius * LIGHT_LATERAL_SCALE,
-          triangleHeight,
+          triangleHeight + lightRetreatOffset,
           triangleRadius * LIGHT_LATERAL_SCALE * 0.35
         );
         spot.target.position.set(0, tableSurfaceY + TABLE_H * 0.18, 0);
@@ -8397,7 +8398,7 @@ function SnookerGame() {
         const ambient = new THREE.AmbientLight(0xffffff, 0.0223125);
         ambient.position.set(
           0,
-          tableSurfaceY + scaledHeight * 1.95 + lightHeightLift,
+          tableSurfaceY + scaledHeight * 1.95 + lightHeightLift + lightRetreatOffset,
           0
         );
         lightingRig.add(ambient);


### PR DESCRIPTION
## Summary
- add a scaled offset that raises the Pool Royale spotlight and ambient light farther from the table
- apply the same adjustment to the Snooker spotlight and ambient light to curb reflections on rail materials

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f12c972e848329b2ad2c137dec499a