### PR TITLE
Adjust Texas Hold'em arena seating and materials

### DIFF
--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -89,7 +89,7 @@ function makeRoughClothTexture(size, topHex, bottomHex, anisotropy = 8) {
   const texture = new THREE.CanvasTexture(canvas);
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   const baseRepeat = 12;
-  const scaledRepeat = baseRepeat * 30;
+  const scaledRepeat = baseRepeat * 30 * 3;
   texture.repeat.set(scaledRepeat, scaledRepeat);
   texture.anisotropy = anisotropy;
   applySRGBColorSpace(texture);


### PR DESCRIPTION
## Summary
- thicken and round the Texas Hold'em chair armrests while enlarging the chair fabric pattern and keeping all new meshes managed
- rotate the seating layout so the human player sits along a flat edge and adjust rail chip offsets to keep stacks on the wood while sitting closer to the cards
- tighten the table cloth texture repeat so the felt pattern appears finer

## Testing
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_68f12d3caba083299d5f5b8cdc056bd9