### PR TITLE
Adjust cloth materials and render ordering for billiards scenes

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -502,6 +502,14 @@ const CLOTH_REFLECTION_LIMITS = Object.freeze({
   clearcoatRoughnessMin: 0.48,
   envMapIntensityMax: 0.22
 });
+const RENDER_PRIORITY = Object.freeze({
+  clothShadowCover: 10,
+  clothUnderlay: 20,
+  cloth: 30,
+  tableMarkings: 40,
+  cushion: 50,
+  overlay: 60
+});
 const POCKET_HOLE_R =
   POCKET_VIS_R * 1.3 * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius for pocket openings
 const BALL_CENTER_Y =
@@ -1166,19 +1174,46 @@ const CHROME_COLOR_OPTIONS = Object.freeze([
 
 const DEFAULT_CLOTH_COLOR_ID = 'freshGreen';
 const CLOTH_COLOR_OPTIONS = Object.freeze([
-  { id: 'freshGreen', label: 'Fresh Green', color: 0x3fba73 },
-  { id: 'brightMint', label: 'Bright Mint', color: 0x45b974 },
+  {
+    id: 'freshGreen',
+    label: 'Fresh Green',
+    color: 0x3fba73,
+    detail: {
+      bumpMultiplier: 0.82,
+      roughness: 0.76,
+      sheenRoughness: 0.48,
+      clearcoat: 0.018,
+      clearcoatRoughness: 0.48,
+      emissiveIntensity: 0.48,
+      envMapIntensity: 0.14
+    }
+  },
+  {
+    id: 'brightMint',
+    label: 'Bright Mint',
+    color: 0x45b974,
+    detail: {
+      bumpMultiplier: 1.04,
+      roughness: 0.8,
+      sheenRoughness: 0.52,
+      clearcoat: 0.032,
+      clearcoatRoughness: 0.4,
+      emissiveIntensity: 0.52,
+      envMapIntensity: 0.16
+    }
+  },
   {
     id: 'emeraldClassic',
     label: 'Green Cloth',
     color: 0x19a34a,
     detail: {
-      bumpMultiplier: 1.22,
-      roughness: 0.78,
-      sheenRoughness: 0.52,
+      bumpMultiplier: 1.28,
+      roughness: 0.83,
+      sheenRoughness: 0.56,
       clearcoat: 0.05,
       clearcoatRoughness: 0.32,
-      emissiveIntensity: 0.52
+      emissiveIntensity: 0.56,
+      envMapIntensity: 0.14
     }
   }
 ]);
@@ -3317,7 +3352,7 @@ function Guret(parent, id, color, x, y, options = {}) {
       marker.quaternion.setFromUnitVectors(localUp, normal);
       marker.castShadow = false;
       marker.receiveShadow = false;
-      marker.renderOrder = 2;
+      marker.renderOrder = RENDER_PRIORITY.overlay;
       mesh.add(marker);
     });
   }
@@ -3568,6 +3603,9 @@ function Table3D(
   };
 
   const cushionMat = clothMat.clone();
+  const shadowClothMat = clothMat.clone();
+  shadowClothMat.side = THREE.DoubleSide;
+  shadowClothMat.needsUpdate = true;
   const clothBaseSettings = {
     roughness: clothMat.roughness,
     sheen: clothMat.sheen,
@@ -3578,7 +3616,7 @@ function Table3D(
     emissiveIntensity: clothMat.emissiveIntensity,
     bumpScale: clothMat.bumpScale
   };
-  const clothMaterials = [clothMat, cushionMat];
+  const clothMaterials = [clothMat, cushionMat, shadowClothMat];
   const applyClothDetail = (detail) => {
     const overrides = detail && typeof detail === 'object' ? detail : {};
     const bumpMultiplier = Number.isFinite(overrides.bumpMultiplier)
@@ -3588,7 +3626,13 @@ function Table3D(
     const targetBump = Number.isFinite(overrides.bumpScale)
       ? overrides.bumpScale
       : baseBump * (Number.isFinite(bumpMultiplier) ? bumpMultiplier : 1);
-    clothMaterials.forEach((mat) => {
+    const bumpTargets = clothMaterials.map((_, index) => {
+      if (!Number.isFinite(targetBump)) return Number.NaN;
+      if (index === 0) return targetBump;
+      if (index === 1) return targetBump * 0.86;
+      return targetBump * 1.12;
+    });
+    clothMaterials.forEach((mat, index) => {
       if (!mat) return;
       mat.roughness = Number.isFinite(overrides.roughness)
         ? THREE.MathUtils.clamp(overrides.roughness, 0, 1)
@@ -3630,8 +3674,9 @@ function Table3D(
           CLOTH_REFLECTION_LIMITS.envMapIntensityMax
         );
       }
-      if (Number.isFinite(targetBump)) {
-        mat.bumpScale = targetBump;
+      const bumpForLayer = bumpTargets[index];
+      if (Number.isFinite(bumpForLayer)) {
+        mat.bumpScale = bumpForLayer;
       } else {
         mat.bumpScale = clothBaseSettings.bumpScale;
       }
@@ -3659,6 +3704,7 @@ function Table3D(
     },
     clothMat,
     cushionMat,
+    shadowClothMat,
     parts: finishParts,
     clothDetail: resolvedFinish?.clothDetail ?? null,
     clothBase: clothBaseSettings,
@@ -3704,7 +3750,7 @@ function Table3D(
   const cloth = new THREE.Mesh(clothGeo, clothMat);
   cloth.rotation.x = -Math.PI / 2;
   cloth.position.y = clothPlaneLocal - CLOTH_DROP;
-  cloth.renderOrder = 3;
+  cloth.renderOrder = RENDER_PRIORITY.cloth;
   cloth.receiveShadow = true;
   table.add(cloth);
 
@@ -3731,7 +3777,7 @@ function Table3D(
     cloth.position.y - CLOTH_THICKNESS - CLOTH_UNDERLAY_GAP;
   clothUnderlay.castShadow = false;
   clothUnderlay.receiveShadow = true;
-  clothUnderlay.renderOrder = cloth.renderOrder - 1;
+  clothUnderlay.renderOrder = RENDER_PRIORITY.clothUnderlay;
   table.add(clothUnderlay);
 
   const shadowCoverShape = buildSurfaceShape(
@@ -3745,7 +3791,7 @@ function Table3D(
     steps: 1
   });
   shadowCoverGeo.translate(0, 0, -CLOTH_SHADOW_COVER_THICKNESS);
-  const shadowCoverMat = railMat.clone();
+  const shadowCoverMat = shadowClothMat;
   shadowCoverMat.side = THREE.DoubleSide;
   shadowCoverMat.needsUpdate = true;
   const clothShadowCover = new THREE.Mesh(shadowCoverGeo, shadowCoverMat);
@@ -3754,7 +3800,7 @@ function Table3D(
     clothUnderlay.position.y - CLOTH_UNDERLAY_THICKNESS - CLOTH_SHADOW_COVER_GAP;
   clothShadowCover.castShadow = false;
   clothShadowCover.receiveShadow = true;
-  clothShadowCover.renderOrder = clothUnderlay.renderOrder - 1;
+  clothShadowCover.renderOrder = RENDER_PRIORITY.clothShadowCover;
   table.add(clothShadowCover);
 
   const markingsGroup = new THREE.Group();
@@ -3807,7 +3853,7 @@ function Table3D(
   addSpot(0, topCushionZ - BLACK_FROM_TOP);
   markingsGroup.traverse((child) => {
     if (child.isMesh) {
-      child.renderOrder = cloth.renderOrder + 1;
+      child.renderOrder = RENDER_PRIORITY.tableMarkings;
       child.castShadow = false;
       child.receiveShadow = false;
     }
@@ -4452,7 +4498,7 @@ function Table3D(
     const mesh = new THREE.Mesh(geo, cushionMat);
     mesh.rotation.x = -Math.PI / 2;
     mesh.scale.y = cushionScaleY * (horizontal ? SHORT_CUSHION_HEIGHT_SCALE : 1);
-    mesh.renderOrder = 2;
+    mesh.renderOrder = RENDER_PRIORITY.cushion;
     const group = new THREE.Group();
     group.add(mesh);
     group.position.set(x, cushionBaseY, z);
@@ -4863,6 +4909,11 @@ function applyTableFinishToTable(table, finish) {
     finishInfo.cushionMat.color.copy(clothColor);
     finishInfo.cushionMat.emissive.copy(emissiveColor);
     finishInfo.cushionMat.needsUpdate = true;
+  }
+  if (finishInfo.shadowClothMat) {
+    finishInfo.shadowClothMat.color.copy(clothColor);
+    finishInfo.shadowClothMat.emissive.copy(emissiveColor);
+    finishInfo.shadowClothMat.needsUpdate = true;
   }
   if (typeof finishInfo.applyClothDetail === 'function') {
     finishInfo.applyClothDetail(resolvedFinish?.clothDetail ?? null);
@@ -6302,7 +6353,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       const sideClearance = roomDepth / 2 - TABLE.H / 2;
       const roomWidth = TABLE.W + sideClearance * 2;
       const wallThickness = 1.2;
-      const wallHeight = (legHeight + TABLE.THICK + 40) * 1.3;
+      const wallHeight = (legHeight + TABLE.THICK + 40) * 1.95;
       const carpetThickness = 1.2;
       const carpetInset = wallThickness * 0.02;
       const carpetWidth = roomWidth - wallThickness + carpetInset;
@@ -8830,7 +8881,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       );
       chalkPrecisionArea.rotation.x = -Math.PI / 2;
       chalkPrecisionArea.visible = false;
-      chalkPrecisionArea.renderOrder = 2;
+      chalkPrecisionArea.renderOrder = RENDER_PRIORITY.overlay;
       table.add(chalkPrecisionArea);
       chalkAreaRef.current = chalkPrecisionArea;
 


### PR DESCRIPTION
## Summary
- add wool-detail configurations to all three green cloth selections and tune per-surface bump strength for the snooker and pool tables
- raise snooker and Pool Royale arena walls by 50% and retime render priorities to prevent z-fighting between overlapping meshes
- reuse a dedicated cloth material for the Pool Royale shadow cover and ensure finish updates recolor every cloth surface

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f13be57ed48329aba52821efb48c8d