### PR TITLE
Raise billiards arena walls and tune lighting

### DIFF
--- a/billiards.Unity/BilliardLighting.cs
+++ b/billiards.Unity/BilliardLighting.cs
@@ -19,7 +19,7 @@ public class BilliardLighting : MonoBehaviour
             Light spotLight = lightObj.AddComponent<Light>();
             spotLight.type = LightType.Spot;
             spotLight.color = Color.white;
-            spotLight.intensity = 2.5f;        // brightness
+            spotLight.intensity = 2.25f;       // brightness reduced by 10%
             spotLight.range = 15f;             // distance
             spotLight.spotAngle = 60f;         // cone size
             spotLight.shadows = LightShadows.Soft;

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -531,7 +531,7 @@ const CAPTURE_R = POCKET_R; // pocket capture radius
 const CLOTH_THICKNESS = TABLE.THICK * 0.12; // render a thinner cloth so the playing surface feels lighter
 const CLOTH_UNDERLAY_THICKNESS = TABLE.THICK * 0.18; // hidden plywood deck to catch shadows before they reach the carpet
 const CLOTH_UNDERLAY_GAP = TABLE.THICK * 0.02; // leave a thin air gap between the cloth and plywood
-const CLOTH_UNDERLAY_EDGE_INSET = TABLE.THICK * 0.015; // tuck the underlay slightly inside so it never peeks past the cushions
+const CLOTH_UNDERLAY_EDGE_INSET = 0; // match the playable field footprint while remaining hidden via colorWrite=false
 const CLOTH_UNDERLAY_HOLE_SCALE = 1.06; // open pocket holes wider on the underlay to avoid clipping pocket interiors
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
 const CUSHION_EXTRA_LIFT = 0; // keep cushion bases resting directly on the cloth plane
@@ -2329,7 +2329,7 @@ function applySnookerScaling({
 }
 
 // Kamera: ruaj kënd komod që mos shtrihet poshtë cloth-it, por lejo pak më shumë lartësi kur ngrihet
-const STANDING_VIEW_PHI = 0.84;
+const STANDING_VIEW_PHI = 0.86; // lift the default orbit a touch higher for a better overview
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.0024;
 const STANDING_VIEW_FOV = 66;
@@ -2337,7 +2337,7 @@ const CAMERA_ABS_MIN_PHI = 0.22;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.48);
 const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.18; // halt the downward sweep as soon as the cue level is reached
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.043;
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0405; // ease the player camera slightly closer to the table
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.08;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
 const BROADCAST_DISTANCE_MULTIPLIER = 0.32;
@@ -3684,11 +3684,15 @@ function Table3D(
     metalness: 0.05,
     side: THREE.DoubleSide
   });
+  underlayMat.transparent = true;
+  underlayMat.opacity = 0;
+  underlayMat.depthWrite = true;
+  underlayMat.colorWrite = false; // remain invisible while still blocking light for full table shadows
   const clothUnderlay = new THREE.Mesh(underlayGeo, underlayMat);
   clothUnderlay.rotation.x = -Math.PI / 2;
   clothUnderlay.position.y =
     cloth.position.y - CLOTH_THICKNESS - CLOTH_UNDERLAY_GAP;
-  clothUnderlay.castShadow = false;
+  clothUnderlay.castShadow = true;
   clothUnderlay.receiveShadow = true;
   clothUnderlay.renderOrder = cloth.renderOrder - 1;
   table.add(clothUnderlay);
@@ -3848,7 +3852,7 @@ function Table3D(
   );
   const cornerShift = (vertSeg - trimmedVertSeg) * 0.5;
 
-  const chromePlateThickness = railH * 0.08;
+  const chromePlateThickness = railH * 0.12; // thicken chrome plates by ~50% for deeper detailing
   const chromePlateInset = TABLE.THICK * 0.02;
   const chromeCornerPlateTrim =
     TABLE.THICK * (0.03 + CHROME_CORNER_FIELD_TRIM_SCALE);
@@ -6193,7 +6197,8 @@ function SnookerGame() {
       const sideClearance = roomDepth / 2 - TABLE.H / 2;
       const roomWidth = TABLE.W + sideClearance * 2;
       const wallThickness = 1.2;
-      const wallHeight = (legHeight + TABLE.THICK + 40) * 1.3;
+      const wallHeightBase = legHeight + TABLE.THICK + 40;
+      const wallHeight = wallHeightBase * 1.3 * 1.3; // raise arena walls by an additional 30%
       const carpetThickness = 1.2;
       const carpetInset = wallThickness * 0.02;
       const carpetWidth = roomWidth - wallThickness + carpetInset;
@@ -8408,7 +8413,7 @@ function SnookerGame() {
 
         const spot = new THREE.SpotLight(
           0xffffff,
-          13.65525,
+          12.289725,
           0,
           Math.PI * 0.36,
           0.42,


### PR DESCRIPTION
## Summary
- raise the 3D Snooker and Pool Royale arena walls by an additional 30% while nudging the default player camera slightly higher and closer
- thicken table chrome plates and add invisible plywood underlays to block ball shadows without disturbing the cloth
- dim the shared spotlight rigs by 10% across the Unity demo and web lighting setups

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f144fe7f20832980c2d4aa0df6cb9c