### PR TITLE
Adjust Pool Royale pocket sizing and cloth coverage

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -186,14 +186,14 @@ const CHROME_CORNER_EXPANSION_SCALE = 1.05; // slim the chrome along the long ra
 const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.98; // ease back the chrome on the short rails while keeping the plates clear of the pocket entries
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015; // widen the notch slightly to remove leftover chrome wedges at the pocket corners
 const CHROME_CORNER_FIELD_TRIM_SCALE = 0;
-const CHROME_SIDE_POCKET_RADIUS_SCALE = 0.9; // pull the side chrome tighter so it hugs the smaller pocket openings
-const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.72; // trim the throat further to align with the reduced side pocket span
-const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.78; // lower the notch height so the rail cut follows the new pocket edge
+const CHROME_SIDE_POCKET_RADIUS_SCALE = 0.82; // pull the side chrome in further to follow the tightened middle pocket openings
+const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.68; // trim the throat further to align with the reduced side pocket span
+const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.74; // lower the notch height so the rail cut follows the new pocket edge
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1;
 const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.9; // widen the field-side trim to scoop out the lingering chrome wedge
 const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.1; // push the trim deeper along the short rail so the notch fully clears the plate
-const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.44; // pull the centre chrome in so the plates follow the tighter side pocket
-const RAIL_POCKET_CUT_SCALE = 0.94; // tighten the wooden rail pocket cuts to match the smaller pocket mouths
+const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.32; // pull the centre chrome in so the plates follow the tighter side pocket
+const RAIL_POCKET_CUT_SCALE = 0.9; // tighten the wooden rail pocket cuts to match the smaller pocket mouths
 
 function buildChromePlateGeometry({
   width,
@@ -463,8 +463,8 @@ const CHALK_RING_OPACITY = 0.18;
 const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
-const POCKET_CORNER_MOUTH_SCALE = 1.05; // open the corner pockets a bit more while keeping clear of the chrome
-const POCKET_SIDE_MOUTH_SCALE = 0.88; // tighten the middle pockets further to create smaller pocket mouths
+const POCKET_CORNER_MOUTH_SCALE = 1.08; // open the corner pockets a bit more while keeping clear of the chrome
+const POCKET_SIDE_MOUTH_SCALE = 0.82; // tighten the middle pockets further to create smaller pocket mouths
 const POCKET_CORNER_MOUTH =
   CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
 const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
@@ -473,7 +473,7 @@ const POCKET_R = POCKET_VIS_R * 0.985;
 const CORNER_POCKET_CENTER_INSET =
   POCKET_VIS_R * 0.18 * POCKET_VISUAL_EXPANSION; // pull corner pockets slightly toward centre so they sit flush with the rails
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
-const SIDE_POCKET_CENTER_VISUAL_INSET_SCALE = 0.78;
+const SIDE_POCKET_CENTER_VISUAL_INSET_SCALE = 0.74;
 const SIDE_POCKET_CENTER_VISUAL_INSET =
   SIDE_POCKET_RADIUS * SIDE_POCKET_CENTER_VISUAL_INSET_SCALE * POCKET_VISUAL_EXPANSION; // push the side pockets outward along the rail
 const SIDE_POCKET_CENTER_OUTSET =
@@ -3678,7 +3678,8 @@ function Table3D(
   const clothExtend =
     clothExtendBase +
     Math.min(PLAY_W, PLAY_H) * 0.0032; // extend the cloth slightly more so rails meet the cloth with no gaps
-  const halfWext = halfW + clothExtend;
+  const clothSideExtra = Math.min(PLAY_W, PLAY_H) * 0.0025; // push the playing surface farther into the side rails to remove visible gaps
+  const halfWext = halfW + clothExtend + clothSideExtra;
   const halfHext = halfH + clothExtend;
   const pocketPositions = pocketCenters();
   const buildSurfaceShape = (holeRadius, edgeInset = 0) => {


### PR DESCRIPTION
## Summary
- enlarge the corner pocket geometry while trimming the side pocket openings for Pool Royale
- tighten the side chrome and rail cuts so the middle pocket hardware follows the new pocket size
- extend the cloth width slightly further into the side rails to eliminate visible gaps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1c53c8b6c8329829efd20c7f4fdf8