### PR TITLE
Align Pool Royale side pocket width with corners

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -464,7 +464,9 @@ const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
 const POCKET_CORNER_MOUTH_SCALE = 1.005; // open the corner pockets a touch more while keeping clear of the chrome
-const POCKET_SIDE_MOUTH_SCALE = 0.935; // tighten the middle pockets slightly further for consistent rail alignment
+const POCKET_SIDE_MOUTH_SCALE =
+  (CORNER_MOUTH_REF * POCKET_CORNER_MOUTH_SCALE) /
+  SIDE_MOUTH_REF; // match the middle pocket mouth width to the corners
 const POCKET_CORNER_MOUTH =
   CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
 const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;


### PR DESCRIPTION
## Summary
- match the Pool Royale side pocket mouth scale to the corner pockets
- update the side pocket documentation comment to reflect the equal sizing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f1f53398948329b9d1f2fb33d0a75e