### PR TITLE
Adjust human card and chip placement in Texas Hold'em arena

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -92,11 +92,11 @@ const HEAD_PITCH_SENSITIVITY = 0.0035;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.15, landscape: 0.5 });
 const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 1.78, landscape: 1.32 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.58, landscape: 1.3 });
-const HUMAN_CARD_INWARD_SHIFT = CARD_W * -0.04;
-const HUMAN_CHIP_INWARD_SHIFT = CARD_W * 0.26;
-const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.78;
-const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * -0.4;
-const HUMAN_CARD_CHIP_BLEND = 0.08;
+const HUMAN_CARD_INWARD_SHIFT = CARD_W * -0.12;
+const HUMAN_CHIP_INWARD_SHIFT = CARD_W * 0.34;
+const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.92;
+const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.18;
+const HUMAN_CARD_CHIP_BLEND = 0.04;
 
 const CHIP_VALUES = [1000, 500, 200, 100, 50, 20, 10, 5, 2, 1];
 const WORLD_UP = new THREE.Vector3(0, 1, 0);


### PR DESCRIPTION
## Summary
- increase the inward offset of human cards and chips so they rest nearer to the cloth edge
- shift the human chip stack laterally to the left and widen lateral spacing to avoid overlap with the cards
- reduce the blend between the card and chip anchors to maintain visible separation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2049476348329a47ca182536a9b03