### PR TITLE
Adjust Texas Hold'em player chip placement and camera height

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -91,11 +91,11 @@ const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0035;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.15, landscape: 0.5 });
 const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 1.78, landscape: 1.32 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.58, landscape: 1.3 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.74, landscape: 1.42 });
 const HUMAN_CARD_INWARD_SHIFT = CARD_W * 0.36;
-const HUMAN_CHIP_INWARD_SHIFT = CARD_W * -0.65;
+const HUMAN_CHIP_INWARD_SHIFT = CARD_W * -0.82;
 const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.86;
-const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.12;
+const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.22;
 const HUMAN_CARD_CHIP_BLEND = 0.04;
 
 const CHIP_VALUES = [1000, 500, 200, 100, 50, 20, 10, 5, 2, 1];


### PR DESCRIPTION
## Summary
- pull the human chip anchor further toward the table center and toward the undo control side
- raise the seated camera position to provide a slightly higher viewpoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2191125d083298c3950a8d3658a1e