### PR TITLE
Adjust Pool Royale chrome plate coverage

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -210,8 +210,8 @@ const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1;
 const CHROME_SIDE_FIELD_PULL_SCALE = 0.24; // extend the side pocket chrome toward the cloth without adding new trim pieces
 const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.9; // widen the field-side trim to scoop out the lingering chrome wedge
 const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.1; // push the trim deeper along the short rail so the notch fully clears the plate
-const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.64; // push the center chrome farther toward the corner pockets so the trim reaches their shoulders
-const CHROME_PLATE_THICKNESS_SCALE = 1.05; // drop the chrome plates down far enough to wrap the full rail depth and hide the pocket cutouts
+const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.82; // push the center chrome farther toward the corner pockets so the trim reaches their shoulders
+const CHROME_PLATE_THICKNESS_SCALE = 1.12; // drop the chrome plates down far enough to wrap the full rail depth and hide the pocket cutouts
 const RAIL_POCKET_CUT_SCALE = 0.97; // slightly tighten the wooden rail pocket cuts to match the smaller pocket mouths
 
 function buildChromePlateGeometry({
@@ -3996,7 +3996,7 @@ function Table3D(
   );
   const sideChromePlateWidth = Math.max(
     MICRO_EPS,
-    Math.min(sidePlatePocketWidth, sidePlateMaxWidth) - TABLE.THICK * 0.03
+    Math.min(sidePlatePocketWidth, sidePlateMaxWidth) - TABLE.THICK * 0.01
   );
   const sidePlateHalfHeightLimit = Math.max(
     0,


### PR DESCRIPTION
## Summary
- increase Pool Royale chrome plate thickness so the trim wraps the rails more fully
- widen the side chrome plates so they bridge the center gaps between pockets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2449267a083299117be52e5dc7889