### PR TITLE
Extend Pool Royale chrome pocket trims to meet cloth

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3942,7 +3942,15 @@ function Table3D(
   );
   const cornerShift = (vertSeg - trimmedVertSeg) * 0.5;
 
-  const chromePlateThickness = railH * 0.12; // thicken chrome plates by ~50% to better catch highlights
+  const chromePlateThicknessBase = railH * 0.12; // thicken chrome plates by ~50% to better catch highlights
+  const chromePocketCoverageDepth = Math.max(
+    0,
+    railsTopY - (clothPlaneLocal - CLOTH_DROP) + MICRO_EPS * 6
+  ); // extend the pocket arches until they meet the lowered cloth plane
+  const chromePlateThickness = Math.min(
+    railH * 0.92,
+    Math.max(chromePlateThicknessBase, chromePocketCoverageDepth)
+  );
   const chromePlateInset = TABLE.THICK * 0.02;
   const chromeCornerPlateTrim =
     TABLE.THICK * (0.03 + CHROME_CORNER_FIELD_TRIM_SCALE);


### PR DESCRIPTION
## Summary
- extend the Pool Royale chrome plate thickness so the pocket arches drop to the cloth plane

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f24ebb2c9c83299ea131e82251c9e8