### PR TITLE
Extend Pool Royale chrome plates to rail depth

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3924,7 +3924,11 @@ function Table3D(
   );
   const cornerShift = (vertSeg - trimmedVertSeg) * 0.5;
 
-  const chromePlateThickness = railH * 0.12; // thicken chrome plates by ~50% to better catch highlights
+  const chromePlateBottomY = frameTopY + MICRO_EPS * 6; // tuck chrome plates just above the wooden rail base to avoid z-fighting
+  const chromePlateThickness = Math.max(
+    railH * 0.12,
+    railsTopY - chromePlateBottomY
+  ); // stretch chrome plates downward so they span the full wooden rail thickness
   const chromePlateInset = TABLE.THICK * 0.02;
   const chromeCornerPlateTrim =
     TABLE.THICK * (0.03 + CHROME_CORNER_FIELD_TRIM_SCALE);
@@ -3966,8 +3970,7 @@ function Table3D(
     chromePlateWidth / 2,
     chromePlateHeight / 2
   );
-  const chromePlateY =
-    railsTopY - chromePlateThickness + MICRO_EPS * 2;
+  const chromePlateY = chromePlateBottomY;
 
   const sidePocketRadius = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION;
   const sidePlatePocketWidth = sidePocketRadius * 2 * CHROME_SIDE_PLATE_POCKET_SPAN_SCALE;


### PR DESCRIPTION
## Summary
- extend the Pool Royale chrome plate geometry downward so it covers the full wooden rail thickness
- keep the plates seated just above the rail base to avoid z-fighting while aligning with the rail tops

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2673bb3488329be95c6ffbbc3621d