### PR TITLE
Align Pool Royale side rail chrome with pocket geometry

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -187,13 +187,13 @@ const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.98; // ease back the chrome on the 
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015; // widen the notch slightly to remove leftover chrome wedges at the pocket corners
 const CHROME_CORNER_FIELD_TRIM_SCALE = 0;
 const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
-const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.82;
-const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85;
+const CHROME_SIDE_NOTCH_THROAT_SCALE = 1;
+const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 1;
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1;
 const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.9; // widen the field-side trim to scoop out the lingering chrome wedge
 const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.1; // push the trim deeper along the short rail so the notch fully clears the plate
-const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.64; // push the center chrome farther toward the corner pockets so the trim reaches their shoulders
-const RAIL_POCKET_CUT_SCALE = 0.97; // slightly tighten the wooden rail pocket cuts to match the smaller pocket mouths
+const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.968; // extend the side chrome plates 20% farther toward each pocket shoulder so they wrap the mouth
+const RAIL_POCKET_CUT_SCALE = 1; // keep the rail pocket cuts aligned with the actual pocket geometry
 
 function buildChromePlateGeometry({
   width,


### PR DESCRIPTION
## Summary
- expand the Pool Royale side rail chrome plates so they reach 20% farther toward the middle pockets
- match the chrome notch and wooden rail pocket cuts to the underlying pocket geometry

## Testing
- npx eslint webapp/src/pages/Games/PoolRoyale.jsx

------
https://chatgpt.com/codex/tasks/task_e_68f2801081a8832995824f55ee705b36