### PR TITLE
Align Pool Royale side pocket geometry

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -187,7 +187,7 @@ const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.98; // ease back the chrome on the 
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015; // widen the notch slightly to remove leftover chrome wedges at the pocket corners
 const CHROME_CORNER_FIELD_TRIM_SCALE = 0;
 const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
-const CHROME_SIDE_NOTCH_THROAT_SCALE = 1; // align the chrome cut with the side pocket throat width
+const CHROME_SIDE_NOTCH_THROAT_SCALE = 2; // match the throat width to the pocket diameter so the cut mirrors the pocket mouth
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 1; // match the notch height to the pocket opening
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1; // give the throat the same rounding profile as the pocket
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1;
@@ -195,7 +195,7 @@ const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.9; // widen the field-side trim t
 const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.1; // push the trim deeper along the short rail so the notch fully clears the plate
 const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.64; // push the center chrome farther toward the corner pockets so the trim reaches their shoulders
 const CHROME_SIDE_PLATE_HEIGHT_EXPANSION_SCALE = 1.4; // stretch the side chrome plates 40% farther overall (20% per side) toward the short rails
-const RAIL_POCKET_CUT_SCALE = 0.97; // slightly tighten the wooden rail pocket cuts to match the smaller pocket mouths
+const RAIL_POCKET_CUT_SCALE = 1; // keep the wooden rail pocket cuts aligned with the chrome and pocket diameter
 
 function buildChromePlateGeometry({
   width,


### PR DESCRIPTION
## Summary
- expand the side pocket throat geometry to span the full pocket diameter
- keep wooden rail pocket cuts aligned with the chrome notch profile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f28ce88eac83299ab66478d2a4a283