### PR TITLE
Adjust Pool Royale side pocket rail cuts

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4158,7 +4158,21 @@ function Table3D(
       256
     );
 
-    const union = polygonClipping.union(circle, throat);
+    const playfieldClip = [[[
+      [cx, -radius * 4],
+      [cx - sx * radius * 8, -radius * 4],
+      [cx - sx * radius * 8, radius * 4],
+      [cx, radius * 4],
+      [cx, -radius * 4]
+    ]]];
+
+    const circleInterior = polygonClipping.intersection(circle, playfieldClip);
+    const union = polygonClipping.union(
+      ...(Array.isArray(circleInterior) && circleInterior.length
+        ? circleInterior
+        : circle),
+      throat
+    );
     return adjustSideNotchDepth(union);
   };
 


### PR DESCRIPTION
## Summary
- clip the Pool Royale side pocket rail cutouts to only round toward the playfield
- keep the exterior side of the side pocket rail cuts straight while preserving the throat union

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f29d5a58c8832981aed2c434a53653