### PR TITLE
Align Pool Royale side chrome plates with rail pocket cuts

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4212,7 +4212,16 @@ function Table3D(
   ].forEach(({ id, sx }) => {
     const centerX = sx * (outerHalfW - sideChromePlateWidth / 2 - sideChromePlateInset);
     const centerZ = 0;
-    const notchLocalMP = sideNotchMP(sx).map((poly) =>
+    const baseSideNotchMP = sideNotchMP(sx);
+    const scaledSideNotchMP = scaleMultiPolygon(
+      baseSideNotchMP,
+      RAIL_POCKET_CUT_SCALE
+    );
+    const chromeSideNotchMP =
+      Array.isArray(scaledSideNotchMP) && scaledSideNotchMP.length
+        ? scaledSideNotchMP
+        : baseSideNotchMP;
+    const notchLocalMP = chromeSideNotchMP.map((poly) =>
       poly.map((ring) => ring.map(([x, z]) => [x - centerX, -(z - centerZ)]))
     );
     const plate = new THREE.Mesh(


### PR DESCRIPTION
## Summary
- scale the Pool Royale side chrome plate pocket notch so it matches the wooden rail cutout
- fall back to the original notch geometry if scaling fails to produce a usable multipolygon

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2ad089eec832986a168e90804ac80