### PR TITLE
Restore Pool Royale side pocket plate geometry

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4212,16 +4212,7 @@ function Table3D(
   ].forEach(({ id, sx }) => {
     const centerX = sx * (outerHalfW - sideChromePlateWidth / 2 - sideChromePlateInset);
     const centerZ = 0;
-    const baseSideNotchMP = sideNotchMP(sx);
-    const scaledSideNotchMP = scaleMultiPolygon(
-      baseSideNotchMP,
-      RAIL_POCKET_CUT_SCALE
-    );
-    const chromeSideNotchMP =
-      Array.isArray(scaledSideNotchMP) && scaledSideNotchMP.length
-        ? scaledSideNotchMP
-        : baseSideNotchMP;
-    const notchLocalMP = chromeSideNotchMP.map((poly) =>
+    const notchLocalMP = sideNotchMP(sx).map((poly) =>
       poly.map((ring) => ring.map(([x, z]) => [x - centerX, -(z - centerZ)]))
     );
     const plate = new THREE.Mesh(


### PR DESCRIPTION
## Summary
- revert the Pool Royale side chrome plate notch mapping so the middle pockets match the prior layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2af1c17b483298688d0204ca95500