### PR TITLE
Fix Pool Royale pocket jaw orientation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3770,7 +3770,7 @@ function buildPocketJawAssembly(table, option, clothPlaneLocal, verticalLift = T
     const toCenter = new THREE.Vector2(-center.x, -center.y);
     if (toCenter.lengthSq() > 1e-6) {
       toCenter.normalize();
-      pocketGroup.rotation.y = Math.atan2(-toCenter.y, toCenter.x);
+      pocketGroup.rotation.y = Math.atan2(toCenter.y, toCenter.x);
     }
     pocketGroup.position.set(center.x, clothPlaneLocal + verticalLift, center.y);
     assemblyGroup.add(pocketGroup);


### PR DESCRIPTION
## Summary
- update the Pool Royale pocket jaw assembly to rotate jaws toward the table center

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f3337270e48329af61a61fe4799b32