### PR TITLE
Align Pool Royale pocket rims above chrome

### DIFF
--- a/webapp/src/components/PocketJawsGallery.jsx
+++ b/webapp/src/components/PocketJawsGallery.jsx
@@ -154,11 +154,36 @@ function createPocketJaw(style, materials) {
   const rimOuter = lipRadius;
   const tube = Math.max(0.004 * scale, (rimOuter - rimInner) * 0.5);
   const major = (rimOuter + rimInner) * 0.5;
-  const rimGeo = new THREE.TorusGeometry(major, tube, 22, 96, Math.PI);
+  const rimCenterY = 0.06 * scale + tube;
+  const rimSegments = 72;
+  const rimRingSegments = 28;
+  const rimPts = [];
+  for (let i = 0; i <= rimRingSegments; i += 1) {
+    const theta = (i / rimRingSegments) * Math.PI * 2;
+    const x = major + tube * Math.cos(theta);
+    const y = rimCenterY + tube * Math.sin(theta);
+    rimPts.push(new THREE.Vector2(x, y));
+  }
+  const rimGeo = new THREE.LatheGeometry(rimPts, rimSegments, 0, Math.PI);
+  rimGeo.computeVertexNormals();
   const rim = new THREE.Mesh(rimGeo, materials.rim);
-  rim.rotation.x = Math.PI / 2;
-  rim.position.y = 0.06 * scale;
   group.add(rim);
+  const coverInner = Math.min(rimOuter - tube * 0.25, rimInner + tube * 0.85);
+  const coverOuter = rimOuter - Math.max(tube * 0.25, 0.004 * scale);
+  if (coverOuter > coverInner + 1e-4) {
+    const coverLift = 0.04 * scale;
+    const coverThickness = Math.max(0.012 * scale, tube * 1.1);
+    const coverPts = [
+      new THREE.Vector2(coverInner, coverLift),
+      new THREE.Vector2(coverOuter, coverLift),
+      new THREE.Vector2(coverOuter, coverLift - coverThickness),
+      new THREE.Vector2(coverInner, coverLift - coverThickness)
+    ];
+    const coverGeo = new THREE.LatheGeometry(coverPts, rimSegments, 0, Math.PI);
+    coverGeo.computeVertexNormals();
+    const coverMesh = new THREE.Mesh(coverGeo, materials.rim);
+    group.add(coverMesh);
+  }
   const baseR = rimOuter + 0.02 * scale;
   const plate = new THREE.Mesh(
     new THREE.CylinderGeometry(baseR, baseR, 0.03 * scale, 48, 1, false, 0, Math.PI),

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -490,6 +490,7 @@ const CORNER_CHROME_NOTCH_RADIUS = POCKET_VIS_R * 1.1 * POCKET_VISUAL_EXPANSION;
 const SIDE_CHROME_NOTCH_RADIUS = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION;
 const POCKET_RIM_OVERHANG = TABLE.THICK * 0.004;
 const POCKET_RIM_LIFT = TABLE.THICK * 0.006;
+const POCKET_RIM_ASSEMBLY_MIN_LIFT = TABLE.THICK * 0.02;
 const POCKET_MOUTH_TOLERANCE = 0.5 * MM_TO_UNITS;
 console.assert(
   Math.abs(POCKET_CORNER_MOUTH - POCKET_VIS_R * 2) <= POCKET_MOUTH_TOLERANCE,
@@ -3703,7 +3704,31 @@ function buildPocketJawAssembly(table, option, clothPlaneLocal, verticalLift = T
     const baseThickness = Math.max(TABLE.THICK * 0.05, Math.abs(minY) * 0.12);
     const baseOffset = minY - baseThickness / 2 - TABLE.THICK * 0.012;
     const baseRadius = rimOuter + Math.max(scale * 0.03, TABLE.THICK * 0.03);
-    return { finalPts, rimOuter, rimTube, rimMajor, baseThickness, baseOffset, baseRadius };
+    const rimCenterY = lipHeight + rimTube + POCKET_RIM_LIFT;
+    const coverInner = innerRadius + Math.max(lipInset * 0.35, rimTube * 0.8);
+    const coverOuter = Math.min(
+      rimOuter - Math.max(rimTube * 0.25, TABLE.THICK * 0.006),
+      baseRadius - TABLE.THICK * 0.008
+    );
+    const coverThickness = Math.max(TABLE.THICK * 0.012, rimTube * 1.05);
+    const coverLift = Math.max(lipHeight * 0.45, POCKET_RIM_LIFT * 0.75);
+    const assemblyLift = Math.max(POCKET_RIM_ASSEMBLY_MIN_LIFT, lipHeight * 0.6);
+    return {
+      finalPts,
+      rimOuter,
+      rimTube,
+      rimMajor,
+      baseThickness,
+      baseOffset,
+      baseRadius,
+      rimCenterY,
+      coverInner,
+      coverOuter,
+      coverThickness,
+      coverLift,
+      assemblyLift,
+      lipHeight
+    };
   };
   const profileCache = { corner: null, side: null };
 
@@ -3733,19 +3758,42 @@ function buildPocketJawAssembly(table, option, clothPlaneLocal, verticalLift = T
     jawMesh.receiveShadow = true;
     jawMesh.castShadow = false;
 
-    const rimSegments = isSide ? 128 : 96;
-    const rimGeom = new THREE.TorusGeometry(
-      profile.rimMajor,
-      profile.rimTube,
-      24,
-      rimSegments,
-      arc
-    );
+    const rimSegments = isSide ? 96 : 72;
+    const rimRingSegments = 36;
+    const rimPts = [];
+    for (let i = 0; i <= rimRingSegments; i += 1) {
+      const theta = (i / rimRingSegments) * Math.PI * 2;
+      const x = profile.rimMajor + profile.rimTube * Math.cos(theta);
+      const y = profile.rimCenterY + profile.rimTube * Math.sin(theta);
+      rimPts.push(new THREE.Vector2(x, y));
+    }
+    const rimGeom = new THREE.LatheGeometry(rimPts, rimSegments, phiStart, arc);
+    rimGeom.computeVertexNormals();
     const rimMesh = new THREE.Mesh(rimGeom, materials.rim);
-    rimMesh.rotation.x = Math.PI / 2;
-    rimMesh.position.y = profile.rimTube + POCKET_RIM_LIFT;
     rimMesh.castShadow = false;
     rimMesh.receiveShadow = true;
+
+    const coverInner = Math.min(profile.coverOuter - TABLE.THICK * 0.002, profile.coverInner);
+    if (profile.coverOuter > coverInner + TABLE.THICK * 0.001) {
+      const coverPts = [
+        new THREE.Vector2(coverInner, profile.coverLift),
+        new THREE.Vector2(profile.coverOuter, profile.coverLift),
+        new THREE.Vector2(
+          profile.coverOuter,
+          profile.coverLift - profile.coverThickness
+        ),
+        new THREE.Vector2(
+          coverInner,
+          profile.coverLift - profile.coverThickness
+        )
+      ];
+      const coverGeom = new THREE.LatheGeometry(coverPts, 64, phiStart, arc);
+      coverGeom.computeVertexNormals();
+      const coverMesh = new THREE.Mesh(coverGeom, materials.rim);
+      coverMesh.castShadow = false;
+      coverMesh.receiveShadow = true;
+      pocketGroup.add(coverMesh);
+    }
 
     const baseGeom = new THREE.CylinderGeometry(
       profile.baseRadius,
@@ -3772,18 +3820,23 @@ function buildPocketJawAssembly(table, option, clothPlaneLocal, verticalLift = T
       toCenter.normalize();
       pocketGroup.rotation.y = Math.atan2(toCenter.y, toCenter.x);
     }
-    pocketGroup.position.set(center.x, clothPlaneLocal + verticalLift, center.y);
+    const assemblyLift = Math.max(verticalLift, profile.assemblyLift);
+    pocketGroup.position.set(center.x, clothPlaneLocal + assemblyLift, center.y);
     assemblyGroup.add(pocketGroup);
     pocketGroups.push(pocketGroup);
   });
   table.add(assemblyGroup);
   const referenceProfile = profileCache.corner ?? profileCache.side;
+  const appliedLift = Math.max(
+    verticalLift,
+    referenceProfile?.assemblyLift ?? POCKET_RIM_ASSEMBLY_MIN_LIFT
+  );
   return {
     group: assemblyGroup,
     optionId: resolved.id,
     materials,
     pockets: pocketGroups,
-    verticalLift,
+    verticalLift: appliedLift,
     rimOuter: referenceProfile?.rimOuter ?? innerRadius + lipInset
   };
 }
@@ -3824,7 +3877,7 @@ function applyPocketJawSelection(table, finishInfo, option) {
   const verticalLift =
     typeof context.verticalLift === 'number'
       ? context.verticalLift
-      : TABLE.THICK * 0.01;
+      : POCKET_RIM_ASSEMBLY_MIN_LIFT;
   const current = finishInfo.pocketJawState || null;
   if (current?.optionId === resolved.id) {
     return;
@@ -3845,6 +3898,11 @@ function applyPocketJawSelection(table, finishInfo, option) {
   if (finishInfo.parts) {
     finishInfo.parts.pocketJawGroup = next?.group ?? null;
   }
+  context.clothPlaneLocal = clothPlaneLocal;
+  if (typeof next?.verticalLift === 'number') {
+    context.verticalLift = next.verticalLift;
+  }
+  finishInfo.pocketJawContext = context;
 }
 
 function Table3D(
@@ -4272,7 +4330,7 @@ function Table3D(
     pocketJawState?.optionId ?? initialPocketJawOption?.id ?? DEFAULT_POCKET_JAW_ID;
   finishInfo.pocketJawContext = {
     clothPlaneLocal,
-    verticalLift: TABLE.THICK * 0.01
+    verticalLift: pocketJawState?.verticalLift ?? POCKET_RIM_ASSEMBLY_MIN_LIFT
   };
 
   const railH = RAIL_HEIGHT;
@@ -5312,7 +5370,7 @@ function applyTableFinishToTable(table, finish) {
     context.clothPlaneLocal = table.userData?.clothPlaneLocal ?? CLOTH_TOP_LOCAL + CLOTH_LIFT;
   }
   if (typeof context.verticalLift !== 'number') {
-    context.verticalLift = TABLE.THICK * 0.01;
+    context.verticalLift = POCKET_RIM_ASSEMBLY_MIN_LIFT;
   }
   finishInfo.pocketJawContext = context;
   applyPocketJawSelection(table, finishInfo, resolvedFinish?.pocketJawOption);


### PR DESCRIPTION
## Summary
- rebuild the Pool Royale pocket rim geometry so the arc matches the chrome plates and sits higher
- add a mid-rim cover and enforce a minimum jaw lift to hide the wooden rail cuts
- mirror the refreshed pocket assembly in the PocketJawsGallery preview component

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f33ca4dcb88329ab772cf4d263d8a5