### PR TITLE
Ensure Pool Royale chrome trim renders from all viewpoints

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1646,6 +1646,10 @@ function enhanceChromeMaterial(material) {
   ensure('envMapIntensity', 1.02, (current, target) =>
     THREE.MathUtils.clamp(current, 0.92, target)
   );
+  if (material.side !== THREE.DoubleSide) {
+    material.side = THREE.DoubleSide;
+  }
+  material.shadowSide = THREE.DoubleSide;
   if ('reflectivity' in material) {
     material.reflectivity = THREE.MathUtils.clamp(
       material.reflectivity ?? 0.8,


### PR DESCRIPTION
## Summary
- force the Pool Royale chrome material to render on both sides so the corner and side plates stay visible at extreme camera angles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f35788d4c08329a884cf6cf289b694