### PR TITLE
Align Domino Royal arena with Pool Royale decor and seating

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -107,12 +107,457 @@ scene.add(new THREE.HemisphereLight(0xffffff, 0xb8b19a, 0.55));
 const key = new THREE.DirectionalLight(0xffffff, 1.6); key.position.set(3.2,3.6,2.2); key.castShadow=true; key.shadow.mapSize.set(2048,2048); scene.add(key);
 const rimLight = new THREE.DirectionalLight(0xffffff, 0.55); rimLight.position.set(-2.2,2.6,-1.4); scene.add(rimLight);
 
+const getPoolCarpetTextures = (() => {
+  let cache = null;
+  const clamp01 = (v) => Math.min(1, Math.max(0, v));
+  const prng = (seed) => {
+    let value = seed >>> 0;
+    return () => {
+      value = (value * 1664525 + 1013904223) % 4294967296;
+      return value / 4294967296;
+    };
+  };
+  const drawRoundedRect = (ctx, x, y, w, h, r) => {
+    const radius = Math.max(0, Math.min(r, Math.min(w, h) / 2));
+    ctx.beginPath();
+    ctx.moveTo(x + radius, y);
+    ctx.lineTo(x + w - radius, y);
+    ctx.quadraticCurveTo(x + w, y, x + w, y + radius);
+    ctx.lineTo(x + w, y + h - radius);
+    ctx.quadraticCurveTo(x + w, y + h, x + w - radius, y + h);
+    ctx.lineTo(x + radius, y + h);
+    ctx.quadraticCurveTo(x, y + h, x, y + h - radius);
+    ctx.lineTo(x, y + radius);
+    ctx.quadraticCurveTo(x, y, x + radius, y);
+    ctx.closePath();
+  };
+  return (renderer) => {
+    if (cache) return cache;
+    if (typeof document === "undefined") {
+      cache = { map: null, bump: null };
+      return cache;
+    }
+    const size = 1024;
+    const canvas = document.createElement("canvas");
+    canvas.width = canvas.height = size;
+    const ctx = canvas.getContext("2d");
+
+    const gradient = ctx.createLinearGradient(0, 0, size, size);
+    gradient.addColorStop(0, "#7c242f");
+    gradient.addColorStop(1, "#9d3642");
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, size, size);
+
+    const rand = prng(987654321);
+    const image = ctx.getImageData(0, 0, size, size);
+    const data = image.data;
+    const baseColor = { r: 112, g: 28, b: 34 };
+    const highlightColor = { r: 196, g: 72, b: 82 };
+    const toChannel = (component) => Math.round(clamp01(component / 255) * 255);
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        const idx = (y * size + x) * 4;
+        const fiber = (Math.sin((x / size) * Math.PI * 14) + Math.cos((y / size) * Math.PI * 16)) * 0.08;
+        const grain = (rand() - 0.5) * 0.12;
+        const shade = clamp01(0.55 + fiber * 0.75 + grain * 0.6);
+        const r = baseColor.r + (highlightColor.r - baseColor.r) * shade;
+        const g = baseColor.g + (highlightColor.g - baseColor.g) * shade;
+        const b = baseColor.b + (highlightColor.b - baseColor.b) * shade;
+        data[idx] = toChannel(r);
+        data[idx + 1] = toChannel(g);
+        data[idx + 2] = toChannel(b);
+      }
+    }
+    ctx.putImageData(image, 0, 0);
+
+    ctx.globalAlpha = 0.04;
+    ctx.fillStyle = "#4f1119";
+    for (let row = 0; row < size; row += 3) {
+      ctx.fillRect(0, row, size, 1);
+    }
+    ctx.globalAlpha = 1;
+
+    const insetRatio = 0.055;
+    const stripeInset = size * insetRatio;
+    const stripeRadius = size * 0.08;
+    const stripeWidth = size * 0.012;
+    ctx.lineWidth = stripeWidth;
+    ctx.strokeStyle = "#f2b7b4";
+    ctx.shadowColor = "rgba(80,20,30,0.18)";
+    ctx.shadowBlur = stripeWidth * 0.8;
+    drawRoundedRect(ctx, stripeInset, stripeInset, size - stripeInset * 2, size - stripeInset * 2, stripeRadius);
+    ctx.stroke();
+    ctx.shadowBlur = 0;
+
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.wrapS = texture.wrapT = THREE.ClampToEdgeWrapping;
+    texture.anisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 8;
+    texture.minFilter = THREE.LinearMipMapLinearFilter;
+    texture.magFilter = THREE.LinearFilter;
+    texture.generateMipmaps = true;
+    texture.colorSpace = THREE.SRGBColorSpace;
+
+    const bumpCanvas = document.createElement("canvas");
+    bumpCanvas.width = bumpCanvas.height = size;
+    const bumpCtx = bumpCanvas.getContext("2d");
+    bumpCtx.drawImage(canvas, 0, 0);
+    const bumpImage = bumpCtx.getImageData(0, 0, size, size);
+    const bumpData = bumpImage.data;
+    const bumpRand = prng(246813579);
+    for (let i = 0; i < bumpData.length; i += 4) {
+      const r = bumpData[i];
+      const g = bumpData[i + 1];
+      const b = bumpData[i + 2];
+      const lum = (r * 0.299 + g * 0.587 + b * 0.114) / 255;
+      const noise = (bumpRand() - 0.5) * 0.16;
+      const v = clamp01(0.62 + lum * 0.28 + noise);
+      const value = Math.floor(v * 255);
+      bumpData[i] = bumpData[i + 1] = bumpData[i + 2] = value;
+    }
+    bumpCtx.putImageData(bumpImage, 0, 0);
+
+    const bump = new THREE.CanvasTexture(bumpCanvas);
+    bump.wrapS = bump.wrapT = THREE.ClampToEdgeWrapping;
+    bump.anisotropy = Math.min(texture.anisotropy ?? 4, 6);
+    bump.minFilter = THREE.LinearMipMapLinearFilter;
+    bump.magFilter = THREE.LinearFilter;
+    bump.generateMipmaps = true;
+
+    cache = { map: texture, bump };
+    return cache;
+  };
+})();
+
+const CHAIR_CLOTH_TEXTURE_SIZE = 512;
+const CHAIR_CLOTH_REPEAT = 4;
+const DEFAULT_CHAIR_OPTION = Object.freeze({
+  id: "crimsonVelvet",
+  primary: "#8b1538",
+  accent: "#5c0f26",
+  highlight: "#d35a7a",
+  legColor: "#1f1f1f"
+});
+
+function adjustHexColor(hex, amount) {
+  const base = new THREE.Color(hex);
+  const target = amount >= 0 ? new THREE.Color(0xffffff) : new THREE.Color(0x000000);
+  base.lerp(target, Math.min(Math.abs(amount), 1));
+  return `#${base.getHexString()}`;
+}
+
+function createChairClothTexture(option, renderer) {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const primary = option?.primary ?? "#0f6a2f";
+  const accent = option?.accent ?? adjustHexColor(primary, -0.28);
+  const highlight = option?.highlight ?? adjustHexColor(primary, 0.22);
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = CHAIR_CLOTH_TEXTURE_SIZE;
+  const ctx = canvas.getContext("2d");
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  const shadow = adjustHexColor(accent, -0.22);
+  const seam = adjustHexColor(accent, -0.35);
+
+  const gradient = ctx.createLinearGradient(0, 0, canvas.width, canvas.height);
+  gradient.addColorStop(0, adjustHexColor(primary, 0.2));
+  gradient.addColorStop(0.5, primary);
+  gradient.addColorStop(1, accent);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const spacing = canvas.width / CHAIR_CLOTH_REPEAT;
+  const halfSpacing = spacing / 2;
+  const lineWidth = Math.max(1.6, spacing * 0.06);
+
+  ctx.strokeStyle = seam;
+  ctx.lineWidth = lineWidth;
+  ctx.globalAlpha = 0.9;
+  for (let offset = -canvas.height; offset <= canvas.width + canvas.height; offset += spacing) {
+    ctx.beginPath();
+    ctx.moveTo(offset, 0);
+    ctx.lineTo(offset - canvas.height, canvas.height);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(offset, 0);
+    ctx.lineTo(offset + canvas.height, canvas.height);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+
+  ctx.strokeStyle = adjustHexColor(highlight, 0.18);
+  ctx.lineWidth = lineWidth * 0.55;
+  ctx.globalAlpha = 0.55;
+  for (let offset = -canvas.height; offset <= canvas.width + canvas.height; offset += spacing) {
+    ctx.beginPath();
+    ctx.moveTo(offset + halfSpacing, 0);
+    ctx.lineTo(offset + halfSpacing - canvas.height, canvas.height);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(offset + halfSpacing, 0);
+    ctx.lineTo(offset + halfSpacing + canvas.height, canvas.height);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+
+  ctx.fillStyle = "rgba(0, 0, 0, 0.28)";
+  const tuftRadius = Math.max(1.8, spacing * 0.08);
+  for (let y = -spacing; y <= canvas.height + spacing; y += spacing) {
+    for (let x = -spacing; x <= canvas.width + spacing; x += spacing) {
+      ctx.beginPath();
+      ctx.ellipse(x + halfSpacing, y + halfSpacing, tuftRadius, tuftRadius * 0.85, 0, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  ctx.save();
+  ctx.globalCompositeOperation = "overlay";
+  const sheenGradient = ctx.createRadialGradient(
+    canvas.width * 0.28,
+    canvas.height * 0.32,
+    canvas.width * 0.05,
+    canvas.width * 0.28,
+    canvas.height * 0.32,
+    canvas.width * 0.75
+  );
+  sheenGradient.addColorStop(0, "rgba(255, 255, 255, 0.26)");
+  sheenGradient.addColorStop(0.5, "rgba(255, 255, 255, 0.08)");
+  sheenGradient.addColorStop(1, "rgba(0, 0, 0, 0.35)");
+  ctx.fillStyle = sheenGradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.restore();
+
+  ctx.globalAlpha = 0.08;
+  for (let y = 0; y < canvas.height; y += 2) {
+    for (let x = 0; x < canvas.width; x += 2) {
+      ctx.fillStyle = Math.random() > 0.5 ? highlight : shadow;
+      ctx.fillRect(x, y, 1, 1);
+    }
+  }
+  ctx.globalAlpha = 1;
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(CHAIR_CLOTH_REPEAT, CHAIR_CLOTH_REPEAT);
+  texture.anisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 8;
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.needsUpdate = true;
+  return texture;
+}
+
+function createChairFabricMaterial(option, renderer) {
+  const texture = createChairClothTexture(option, renderer);
+  const primary = option?.primary ?? "#0f6a2f";
+  const sheenColor = option?.highlight ?? adjustHexColor(primary, 0.2);
+  const material = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(adjustHexColor(primary, 0.04)),
+    map: texture,
+    roughness: 0.28,
+    metalness: 0.08,
+    clearcoat: 0.48,
+    clearcoatRoughness: 0.28,
+    sheen: 0.18
+  });
+  if ("sheenColor" in material) {
+    material.sheenColor.set(sheenColor);
+  }
+  if ("sheenRoughness" in material) {
+    material.sheenRoughness = 0.32;
+  }
+  if ("specularIntensity" in material) {
+    material.specularIntensity = 0.65;
+  }
+  return material;
+}
+
+const CHAIR_DIMENSIONS = Object.freeze({
+  seatWidth: 0.72,
+  seatDepth: 0.72,
+  seatThickness: 0.12,
+  backHeight: 0.62,
+  backThickness: 0.08,
+  armHeight: 0.3,
+  armThickness: 0.1,
+  armDepth: 0.76,
+  columnHeight: 0.38,
+  baseThickness: 0.08,
+  columnRadiusTop: 0.11,
+  columnRadiusBottom: 0.15,
+  baseRadius: 0.46,
+  footRingRadius: 0.34,
+  footRingTube: 0.03
+});
+
+function createDominoChair(option, renderer, sharedMaterials = null) {
+  const material = sharedMaterials?.fabric ?? createChairFabricMaterial(option, renderer);
+  const legMaterial = sharedMaterials?.leg ??
+    new THREE.MeshStandardMaterial({
+      color: new THREE.Color(option?.legColor ?? "#1f1f1f"),
+      metalness: 0.6,
+      roughness: 0.35
+    });
+  const metalAccent = sharedMaterials?.accent ??
+    new THREE.MeshStandardMaterial({
+      color: new THREE.Color("#2a2a2a"),
+      metalness: 0.75,
+      roughness: 0.32
+    });
+
+  const group = new THREE.Group();
+  const dims = CHAIR_DIMENSIONS;
+
+  const base = new THREE.Mesh(new THREE.CylinderGeometry(dims.baseRadius, dims.baseRadius * 1.02, dims.baseThickness, 32), legMaterial);
+  base.position.y = dims.baseThickness / 2;
+  base.castShadow = true;
+  base.receiveShadow = true;
+  group.add(base);
+
+  const column = new THREE.Mesh(
+    new THREE.CylinderGeometry(dims.columnRadiusBottom, dims.columnRadiusTop, dims.columnHeight, 24),
+    legMaterial
+  );
+  column.position.y = dims.baseThickness + dims.columnHeight / 2;
+  column.castShadow = true;
+  column.receiveShadow = true;
+  group.add(column);
+
+  const footRing = new THREE.Mesh(new THREE.TorusGeometry(dims.footRingRadius, dims.footRingTube, 16, 48), metalAccent);
+  footRing.rotation.x = Math.PI / 2;
+  footRing.position.y = dims.baseThickness + dims.columnHeight * 0.45;
+  footRing.castShadow = true;
+  group.add(footRing);
+
+  const seat = new THREE.Mesh(
+    new THREE.BoxGeometry(dims.seatWidth, dims.seatThickness, dims.seatDepth),
+    material
+  );
+  seat.position.y = dims.baseThickness + dims.columnHeight + dims.seatThickness / 2;
+  seat.castShadow = true;
+  seat.receiveShadow = true;
+  group.add(seat);
+
+  const cushion = new THREE.Mesh(
+    new THREE.BoxGeometry(dims.seatWidth * 0.92, dims.seatThickness * 0.6, dims.seatDepth * 0.92),
+    material
+  );
+  cushion.position.y = seat.position.y + dims.seatThickness * 0.2;
+  cushion.castShadow = true;
+  cushion.receiveShadow = true;
+  group.add(cushion);
+
+  const back = new THREE.Mesh(
+    new THREE.BoxGeometry(dims.seatWidth * 0.98, dims.backHeight, dims.backThickness),
+    material
+  );
+  back.position.set(0, seat.position.y + dims.backHeight / 2 - dims.seatThickness / 2, dims.seatDepth / 2 - dims.backThickness / 2);
+  back.castShadow = true;
+  back.receiveShadow = true;
+  group.add(back);
+
+  const armGeo = new THREE.BoxGeometry(dims.armThickness, dims.armHeight, dims.armDepth);
+  const armY = seat.position.y + dims.armHeight / 2 - dims.seatThickness * 0.25;
+  const armOffsetZ = (dims.armDepth - dims.seatDepth) / 2;
+  const armLeft = new THREE.Mesh(armGeo, material);
+  armLeft.position.set(-dims.seatWidth / 2 + dims.armThickness / 2, armY, armOffsetZ);
+  armLeft.castShadow = true;
+  armLeft.receiveShadow = true;
+  group.add(armLeft);
+  const armRight = new THREE.Mesh(armGeo, material);
+  armRight.position.set(dims.seatWidth / 2 - dims.armThickness / 2, armY, armOffsetZ);
+  armRight.castShadow = true;
+  armRight.receiveShadow = true;
+  group.add(armRight);
+
+  const armCapGeo = new THREE.BoxGeometry(dims.armThickness * 0.9, dims.armThickness * 0.35, dims.armDepth * 0.92);
+  const armCapY = armY + dims.armHeight / 2 - (dims.armThickness * 0.35) / 2;
+  const armCapLeft = new THREE.Mesh(armCapGeo, material);
+  armCapLeft.position.set(armLeft.position.x, armCapY, armOffsetZ * 0.94);
+  armCapLeft.castShadow = true;
+  armCapLeft.receiveShadow = true;
+  group.add(armCapLeft);
+  const armCapRight = new THREE.Mesh(armCapGeo, material);
+  armCapRight.position.set(armRight.position.x, armCapY, armOffsetZ * 0.94);
+  armCapRight.castShadow = true;
+  armCapRight.receiveShadow = true;
+  group.add(armCapRight);
+
+  const columnCap = new THREE.Mesh(new THREE.CylinderGeometry(dims.columnRadiusTop * 1.05, dims.columnRadiusTop * 1.05, 0.02, 24), metalAccent);
+  columnCap.position.y = dims.baseThickness + dims.columnHeight + 0.01;
+  columnCap.castShadow = true;
+  columnCap.receiveShadow = true;
+  group.add(columnCap);
+
+  return group;
+}
+
 /* ---------- World / Groups ---------- */
+const arenaG = new THREE.Group();
+scene.add(arenaG);
+
 const tableG = new THREE.Group();
-scene.add(tableG);
+arenaG.add(tableG);
 tableG.rotation.y = 0.10; // pak rrotullim për perspektivë
 const piecesG = new THREE.Group();
 tableG.add(piecesG);
+
+/* ---------- Arena Dressings (Carpet & Walls) ---------- */
+const roomWidth = 6.2;
+const roomDepth = 6.2;
+const wallThickness = 0.45;
+const wallHeight = 3.4;
+const carpetThickness = 0.12;
+const carpetTextures = getPoolCarpetTextures(renderer);
+const carpetMat = new THREE.MeshStandardMaterial({
+  color: 0x8c2a2e,
+  roughness: 0.9,
+  metalness: 0.025
+});
+if (carpetTextures.map) {
+  carpetMat.map = carpetTextures.map;
+  carpetMat.map.needsUpdate = true;
+}
+if (carpetTextures.bump) {
+  carpetMat.bumpMap = carpetTextures.bump;
+  carpetMat.bumpScale = 0.18;
+  carpetMat.bumpMap.needsUpdate = true;
+}
+const carpet = new THREE.Mesh(
+  new THREE.BoxGeometry(roomWidth - wallThickness, carpetThickness, roomDepth - wallThickness),
+  carpetMat
+);
+carpet.position.y = -carpetThickness / 2;
+carpet.receiveShadow = true;
+arenaG.add(carpet);
+
+const wallMat = new THREE.MeshStandardMaterial({
+  color: 0xb9ddff,
+  roughness: 0.88,
+  metalness: 0.06
+});
+
+const makeWall = (width, height, depth) => {
+  const wall = new THREE.Mesh(new THREE.BoxGeometry(width, height, depth), wallMat);
+  wall.position.y = height / 2;
+  wall.receiveShadow = true;
+  wall.castShadow = false;
+  arenaG.add(wall);
+  return wall;
+};
+
+const backWall = makeWall(roomWidth, wallHeight, wallThickness);
+backWall.position.z = roomDepth / 2 - wallThickness / 2;
+
+const frontWall = makeWall(roomWidth, wallHeight, wallThickness);
+frontWall.position.z = -roomDepth / 2 + wallThickness / 2;
+
+const leftWall = makeWall(wallThickness, wallHeight, roomDepth);
+leftWall.position.x = -roomWidth / 2 + wallThickness / 2;
+
+const rightWall = makeWall(wallThickness, wallHeight, roomDepth);
+rightWall.position.x = roomWidth / 2 - wallThickness / 2;
 
 /* ---------- Shapes ---------- */
 function roundedRectShape(hw=0.95, hh=0.95, r=0.06){
@@ -209,10 +654,39 @@ const HAND_Y = RAIL_TOP + TILE_UP_HALF + 0.0011;
   const skirtH=.60; const skirt = new THREE.Mesh(new THREE.BoxGeometry((OUT_HW+0.05)*2, skirtH, (OUT_HW+0.05)*2), baseGreen);
   skirt.position.y=Y - skirtH/2 + 0.01; skirt.castShadow=true; skirt.receiveShadow=true; tableG.add(skirt);
 }
+
+/* ---------- Seating (Texas Hold'em Style Chairs) ---------- */
 {
-  // dysheme
-  const floor=new THREE.Mesh(new THREE.CircleGeometry(6,48), new THREE.MeshStandardMaterial({color:"#ece6dc", roughness:.98}));
-  floor.rotation.x=-Math.PI/2; floor.receiveShadow=true; tableG.add(floor);
+  const chairRadius = OUT_HW + 0.55;
+  const chairHeight = CHAIR_DIMENSIONS.baseThickness + CHAIR_DIMENSIONS.columnHeight + CHAIR_DIMENSIONS.seatThickness;
+  const sharedMaterials = {
+    fabric: createChairFabricMaterial(DEFAULT_CHAIR_OPTION, renderer),
+    leg: new THREE.MeshStandardMaterial({
+      color: new THREE.Color(DEFAULT_CHAIR_OPTION.legColor ?? "#1f1f1f"),
+      metalness: 0.6,
+      roughness: 0.35
+    }),
+    accent: new THREE.MeshStandardMaterial({
+      color: new THREE.Color("#2a2a2a"),
+      metalness: 0.75,
+      roughness: 0.32
+    })
+  };
+  const chairPositions = [
+    new THREE.Vector3(0, 0, chairRadius),
+    new THREE.Vector3(chairRadius, 0, 0),
+    new THREE.Vector3(0, 0, -chairRadius),
+    new THREE.Vector3(-chairRadius, 0, 0)
+  ];
+  tableG.updateWorldMatrix(true, false);
+  const lookTargetWorld = new THREE.Vector3(0, chairHeight, 0);
+  tableG.localToWorld(lookTargetWorld);
+  chairPositions.forEach((pos) => {
+    const chair = createDominoChair(DEFAULT_CHAIR_OPTION, renderer, sharedMaterials);
+    chair.position.copy(pos);
+    tableG.add(chair);
+    chair.lookAt(lookTargetWorld);
+  });
 }
 
 /* ---------- Tile Helpers (ensure defined before use) ---------- */


### PR DESCRIPTION
## Summary
- reuse the Pool Royale carpet styling and pastel wall treatment inside the Domino Royal 3D scene
- add a reusable Texas Hold'em inspired chair builder and place four seats around the domino table to match the poker experience

## Testing
- npm run lint *(fails: repository already contains lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f368fea6cc8329b086159976343339