### PR TITLE
Add lobby player count selection and refine Texas Hold'em camera

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -69,7 +69,7 @@ const TABLE_HEIGHT_RAISE = TABLE_HEIGHT - BASE_TABLE_HEIGHT;
 const AI_CHAIR_GAP = CARD_W * 0.4;
 const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP;
 const DEFAULT_PLAYER_COUNT = 6;
-const MIN_PLAYER_COUNT = 2;
+const MIN_PLAYER_COUNT = 1;
 const MAX_PLAYER_COUNT = 6;
 const DIAMOND_SHAPE_ID = 'diamondEdge';
 const SMALL_BLIND = 10;
@@ -97,11 +97,12 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(52);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.08, landscape: 0.5 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 1.7, landscape: 1.16 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 1.48, landscape: 0.98 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.6, landscape: 1.18 });
 const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * 0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.64;
+const CAMERA_MANUAL_TIMEOUT_MS = 8000;
 const HUMAN_CARD_INWARD_SHIFT = CARD_W * -0.68;
 const HUMAN_CHIP_INWARD_SHIFT = CARD_W * -0.92;
 const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.82;
@@ -1248,6 +1249,7 @@ function TexasHoldemArena({ search }) {
     dragged: false
   });
   const cameraAutoTargetRef = useRef({ yaw: 0, activeIndex: null });
+  const manualCameraRef = useRef({ active: false, timestamp: 0 });
   const pointerVectorRef = useRef(new THREE.Vector2());
   const interactionsRef = useRef({
     onChip: () => {},
@@ -1405,6 +1407,9 @@ function TexasHoldemArena({ search }) {
 
   const updateCameraAutoTarget = useCallback((actionIndex) => {
     if (typeof actionIndex !== 'number' || actionIndex < 0) {
+      return;
+    }
+    if (manualCameraRef.current?.active) {
       return;
     }
     const three = threeRef.current;
@@ -1837,6 +1842,7 @@ function TexasHoldemArena({ search }) {
       };
       headAnglesRef.current.yaw = THREE.MathUtils.clamp(0, -CAMERA_HEAD_TURN_LIMIT, CAMERA_HEAD_TURN_LIMIT);
       headAnglesRef.current.pitch = 0;
+      manualCameraRef.current = { active: false, timestamp: 0 };
       cameraAutoTargetRef.current = {
         yaw: headAnglesRef.current.yaw,
         activeIndex: cameraAutoTargetRef.current.activeIndex
@@ -2159,6 +2165,8 @@ function TexasHoldemArena({ search }) {
         }
         return;
       }
+      const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+      manualCameraRef.current = { active: true, timestamp: now };
       pointerStateRef.current = {
         active: true,
         pointerId: event.pointerId,
@@ -2188,6 +2196,8 @@ function TexasHoldemArena({ search }) {
         return;
       }
       if (state.mode === 'camera') {
+        const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        manualCameraRef.current = { active: true, timestamp: now };
         const dx = event.clientX - state.startX;
         headAnglesRef.current.yaw = THREE.MathUtils.clamp(
           state.startYaw - dx * HEAD_YAW_SENSITIVITY,
@@ -2195,10 +2205,7 @@ function TexasHoldemArena({ search }) {
           CAMERA_HEAD_TURN_LIMIT
         );
         headAnglesRef.current.pitch = 0;
-        cameraAutoTargetRef.current = {
-          yaw: headAnglesRef.current.yaw,
-          activeIndex: cameraAutoTargetRef.current.activeIndex
-        };
+        cameraAutoTargetRef.current = { yaw: headAnglesRef.current.yaw, activeIndex: null };
         applyHeadOrientation();
         return;
       }
@@ -2217,13 +2224,20 @@ function TexasHoldemArena({ search }) {
             interactionsRef.current.onUndo?.();
           }
         }
+        const wasCamera = state.mode === 'camera';
         resetPointerState();
         element.style.cursor = 'grab';
         applyHoverTarget(null);
-        const currentActionIndex = gameStateRef.current?.actionIndex;
-        const stage = gameStateRef.current?.stage;
-        if (typeof currentActionIndex === 'number' && stage !== 'showdown') {
-          updateCameraAutoTarget(currentActionIndex);
+        if (wasCamera) {
+          const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+          manualCameraRef.current = { active: true, timestamp: now };
+          cameraAutoTargetRef.current = { yaw: headAnglesRef.current.yaw, activeIndex: null };
+        } else {
+          const currentActionIndex = gameStateRef.current?.actionIndex;
+          const stage = gameStateRef.current?.stage;
+          if (typeof currentActionIndex === 'number' && stage !== 'showdown') {
+            updateCameraAutoTarget(currentActionIndex);
+          }
         }
       }
     };
@@ -2250,25 +2264,39 @@ function TexasHoldemArena({ search }) {
       const three = threeRef.current;
       if (!three) return;
       const pointerState = pointerStateRef.current;
+      const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
       if (lastFrameRef.current == null) {
         lastFrameRef.current = time;
       }
       const deltaSeconds = Math.max(0, Math.min(0.1, (time - lastFrameRef.current) / 1000));
       lastFrameRef.current = time;
       three.chipFactory.update(deltaSeconds);
-      if (!pointerState.active || pointerState.mode !== 'camera') {
-        const targetYaw = cameraAutoTargetRef.current?.yaw;
-        if (typeof targetYaw === 'number') {
-          const currentYaw = headAnglesRef.current.yaw;
-          const delta = targetYaw - currentYaw;
-          if (Math.abs(delta) > 0.0005) {
-            headAnglesRef.current.yaw = currentYaw + delta * CAMERA_AUTO_YAW_SMOOTHING;
-          } else {
-            headAnglesRef.current.yaw = targetYaw;
+      if (pointerState.active && pointerState.mode === 'camera') {
+        manualCameraRef.current = { active: true, timestamp: now };
+        cameraAutoTargetRef.current = { yaw: headAnglesRef.current.yaw, activeIndex: null };
+      } else {
+        if (manualCameraRef.current.active && now - manualCameraRef.current.timestamp > CAMERA_MANUAL_TIMEOUT_MS) {
+          manualCameraRef.current = { active: false, timestamp: 0 };
+          const actionIndex = gameStateRef.current?.actionIndex;
+          const stage = gameStateRef.current?.stage;
+          if (typeof actionIndex === 'number' && stage !== 'showdown') {
+            updateCameraAutoTarget(actionIndex);
           }
         }
-      } else {
-        cameraAutoTargetRef.current.yaw = headAnglesRef.current.yaw;
+        if (!manualCameraRef.current.active) {
+          const targetYaw = cameraAutoTargetRef.current?.yaw;
+          if (typeof targetYaw === 'number') {
+            const currentYaw = headAnglesRef.current.yaw;
+            const delta = targetYaw - currentYaw;
+            if (Math.abs(delta) > 0.0005) {
+              headAnglesRef.current.yaw = currentYaw + delta * CAMERA_AUTO_YAW_SMOOTHING;
+            } else {
+              headAnglesRef.current.yaw = targetYaw;
+            }
+          }
+        } else {
+          cameraAutoTargetRef.current = { yaw: headAnglesRef.current.yaw, activeIndex: null };
+        }
       }
       headAnglesRef.current.pitch = 0;
       applyHeadOrientation();
@@ -2541,6 +2569,7 @@ function TexasHoldemArena({ search }) {
     if (!three) return;
     const seat = three.seatGroups?.[currentActionIndex];
     if (seat?.isHuman) {
+      manualCameraRef.current = { active: false, timestamp: 0 };
       headAnglesRef.current.yaw = 0;
       headAnglesRef.current.pitch = 0;
       cameraAutoTargetRef.current = { yaw: 0, activeIndex: currentActionIndex };

--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -16,6 +16,7 @@ export default function TexasHoldemLobby() {
 
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState('local');
+  const [playerCount, setPlayerCount] = useState(6);
   const [avatar, setAvatar] = useState('');
   const startBet = stake.amount / 100;
 
@@ -48,6 +49,7 @@ export default function TexasHoldemLobby() {
     if (stake.token) params.set('token', stake.token);
     if (stake.amount) params.set('amount', stake.amount);
     if (avatar) params.set('avatar', avatar);
+    if (playerCount) params.set('players', playerCount);
     const username = getTelegramUsername();
     if (username) params.set('username', username);
     if (mode === 'local') params.set('avatars', 'flags');
@@ -70,6 +72,23 @@ export default function TexasHoldemLobby() {
         <p className="text-sm text-center">
           Start bet: {startBet.toLocaleString('en-US')} TPC • Pot max: {stake.amount.toLocaleString('en-US')} TPC
         </p>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Players</h3>
+        <p className="text-xs text-center text-text/70">
+          Opponents: {Math.max(0, playerCount - 1)}
+        </p>
+        <div className="grid grid-cols-3 gap-2">
+          {Array.from({ length: 6 }, (_, idx) => idx + 1).map((count) => (
+            <button
+              key={count}
+              onClick={() => setPlayerCount(count)}
+              className={`lobby-tile ${playerCount === count ? 'lobby-selected' : ''}`}
+            >
+              {count}
+            </button>
+          ))}
+        </div>
       </div>
       <div className="space-y-2">
         <h3 className="font-semibold">Mode</h3>


### PR DESCRIPTION
## Summary
- add a player count selector to the Texas Hold'em lobby and forward the value to the arena
- bring the arena camera in closer while letting manual yaw control persist before auto focus resumes

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f37299fa208329a7f0d37575e7e73d