### PR TITLE
Tighten Pool Royale rail cut geometry

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -187,13 +187,13 @@ function adjustSideNotchDepth(mp) {
 }
 
 const POCKET_VISUAL_EXPANSION = 1.05;
-const CHROME_CORNER_POCKET_RADIUS_SCALE = 0.9; // shrink chrome arches so the rounded cut matches the corner pocket radius
+const CHROME_CORNER_POCKET_RADIUS_SCALE = 0.86; // tighten the chrome arches so the rounded cut sits slightly smaller
 const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.16;
 const CHROME_CORNER_EXPANSION_SCALE = 1.036; // tuck the chrome just shy of the rail edge so it no longer overlaps the wood caps
 const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.998; // keep the short-rail chrome aligned without spilling over the cushion edge
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015; // widen the notch slightly to remove leftover chrome wedges at the pocket corners
 const CHROME_CORNER_FIELD_TRIM_SCALE = 0.012; // shave a sliver off the field side so the chrome sits cleanly against the rail
-const CHROME_SIDE_POCKET_RADIUS_SCALE = 0.99; // reduce the side arches in lockstep with the corners so they share the same pocket opening
+const CHROME_SIDE_POCKET_RADIUS_SCALE = 0.965; // trim the side arches alongside the corners so the pocket openings shrink evenly
 const WOOD_RAIL_CORNER_RADIUS_SCALE = 0;
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.82; // match the snooker side pocket throat profile
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85; // align the notch opening height with the snooker middle pockets
@@ -207,7 +207,7 @@ const CHROME_SIDE_PLATE_RAIL_INSET_SCALE = 0.038; // pull the side plates inward
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.05; // push the middle chrome slightly farther so it wraps the rail sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.058; // tighten the middle trim so the chrome reveals the rail shoulders cleanly
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.008; // leave a slim gap near each pocket to avoid chrome overlap on the cloth
-const RAIL_POCKET_CUT_SCALE = 0.945; // trim the wooden rail cutouts tighter so the wood hugs the pocket mouths without overhangs
+const RAIL_POCKET_CUT_SCALE = 0.93; // trim the wooden rail cutouts tighter so the wood hugs the pocket mouths without overhangs
 
 function buildChromePlateGeometry({
   width,
@@ -4032,10 +4032,10 @@ function Table3D(
   const innerHalfW = halfWext;
   const innerHalfH = halfHext;
   const cornerPocketRadius = POCKET_VIS_R * 1.1 * POCKET_VISUAL_EXPANSION;
-  const cornerChamfer = POCKET_VIS_R * 0.34 * POCKET_VISUAL_EXPANSION;
+  const cornerChamfer = POCKET_VIS_R * 0.32 * POCKET_VISUAL_EXPANSION;
   const cornerInset =
-    POCKET_VIS_R * 0.58 * POCKET_VISUAL_EXPANSION + CORNER_POCKET_CENTER_INSET;
-  const sideInset = SIDE_POCKET_RADIUS * 0.84 * POCKET_VISUAL_EXPANSION;
+    POCKET_VIS_R * 0.54 * POCKET_VISUAL_EXPANSION + CORNER_POCKET_CENTER_INSET;
+  const sideInset = SIDE_POCKET_RADIUS * 0.8 * POCKET_VISUAL_EXPANSION;
 
   const circlePoly = (cx, cz, r, seg = 96) => {
     const pts = [];


### PR DESCRIPTION
## Summary
- shrink the chrome corner and side pocket radii so the rounded cutouts appear smaller
- shift the corner and side pocket notch centers outward to sit closer to the rails
- tighten the wooden rail cut scaling to match the smaller pocket profile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f381ee6df88329bf04aa19b45a9c6b