### PR TITLE
Tighten Pool Royale side pocket geometry

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -193,7 +193,7 @@ const CHROME_CORNER_EXPANSION_SCALE = 1.036; // tuck the chrome just shy of the 
 const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.998; // keep the short-rail chrome aligned without spilling over the cushion edge
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015; // widen the notch slightly to remove leftover chrome wedges at the pocket corners
 const CHROME_CORNER_FIELD_TRIM_SCALE = 0.012; // shave a sliver off the field side so the chrome sits cleanly against the rail
-const CHROME_SIDE_POCKET_RADIUS_SCALE = 0.965; // trim the side arches alongside the corners so the pocket openings shrink evenly
+const CHROME_SIDE_POCKET_RADIUS_SCALE = 0.92; // tighten the side arches so the chrome hugs the slimmer middle pocket openings
 const WOOD_RAIL_CORNER_RADIUS_SCALE = 0;
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.82; // match the snooker side pocket throat profile
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85; // align the notch opening height with the snooker middle pockets
@@ -478,9 +478,10 @@ const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
 const POCKET_CORNER_MOUTH_SCALE = 1.005; // open the corner pockets a touch more while keeping clear of the chrome
+const POCKET_SIDE_MOUTH_TIGHTEN = 0.94; // shrink the middle pocket mouth slightly so it reads tighter than regulation
 const POCKET_SIDE_MOUTH_SCALE =
-  (CORNER_MOUTH_REF * POCKET_CORNER_MOUTH_SCALE) /
-  SIDE_MOUTH_REF; // match the middle pocket mouth width to the corners
+  ((CORNER_MOUTH_REF * POCKET_CORNER_MOUTH_SCALE) / SIDE_MOUTH_REF) *
+  POCKET_SIDE_MOUTH_TIGHTEN; // keep side pockets slimmer than the corners so the middle pockets feel more challenging
 const POCKET_CORNER_MOUTH =
   CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
 const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
@@ -4035,7 +4036,7 @@ function Table3D(
   const cornerChamfer = POCKET_VIS_R * 0.32 * POCKET_VISUAL_EXPANSION;
   const cornerInset =
     POCKET_VIS_R * 0.54 * POCKET_VISUAL_EXPANSION + CORNER_POCKET_CENTER_INSET;
-  const sideInset = SIDE_POCKET_RADIUS * 0.8 * POCKET_VISUAL_EXPANSION;
+  const sideInset = SIDE_POCKET_RADIUS * 0.76 * POCKET_VISUAL_EXPANSION; // push the middle pocket cutouts outward so the tighter arches sit closer to the rails
 
   const circlePoly = (cx, cz, r, seg = 96) => {
     const pts = [];


### PR DESCRIPTION
## Summary
- shrink the Pool Royale side pocket mouth to make the middle pockets visibly tighter
- tighten the side chrome and wooden rail notch geometry so the smaller arches sit farther from the table centre

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3857e18048329ac9113b2f5b72fa4