### PR TITLE
Fix Domino Royal board tiles orientation

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -878,7 +878,8 @@ function renderChain(){
     const domino = makeDomino(c.tile.a, c.tile.b, { flat: true, faceUp: true });
     const yPos = CLOTH_TOP + 0.008;
     domino.position.set(c.x, yPos, c.z);
-    domino.rotation.y = c.rot || 0;
+    // Siguro që çdo domino në fushë të jetë krejtësisht e sheshtë (pa tilt)
+    domino.rotation.set(-Math.PI / 2, c.rot || 0, 0);
     c.mesh = domino;
     piecesG.add(domino);
   });


### PR DESCRIPTION
## Summary
- force Domino Royal table tiles to reset their rotation so they always lie flat on the cloth

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f389952784832988ee885f2067b2e3