### PR TITLE
Ensure domino chain lies flat on table

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -867,6 +867,31 @@ function renderHands(){
 }
 
 /* ---------- Chain Rendering ---------- */
+const DOMINO_UP = new THREE.Vector3(0, 1, 0);
+const DOMINO_FORWARD = new THREE.Vector3();
+const DOMINO_RIGHT = new THREE.Vector3();
+const DOMINO_BASIS = new THREE.Matrix4();
+
+function orientDominoFlat(domino, yawAngle = 0) {
+  const angle = Number.isFinite(yawAngle) ? yawAngle : 0;
+  DOMINO_FORWARD.set(Math.cos(angle), 0, Math.sin(angle));
+  if (DOMINO_FORWARD.lengthSq() === 0) {
+    DOMINO_FORWARD.set(1, 0, 0);
+  } else {
+    DOMINO_FORWARD.normalize();
+  }
+
+  DOMINO_RIGHT.crossVectors(DOMINO_FORWARD, DOMINO_UP);
+  if (DOMINO_RIGHT.lengthSq() === 0) {
+    DOMINO_RIGHT.set(0, 0, 1);
+  } else {
+    DOMINO_RIGHT.normalize();
+  }
+
+  DOMINO_BASIS.makeBasis(DOMINO_RIGHT, DOMINO_FORWARD, DOMINO_UP);
+  domino.setRotationFromMatrix(DOMINO_BASIS);
+}
+
 function renderChain(){
   chain.forEach(c=>{
     if(c.mesh){
@@ -879,7 +904,7 @@ function renderChain(){
     const yPos = CLOTH_TOP + 0.008;
     domino.position.set(c.x, yPos, c.z);
     // Siguro që çdo domino në fushë të jetë krejtësisht e sheshtë (pa tilt)
-    domino.rotation.set(-Math.PI / 2, c.rot || 0, 0);
+    orientDominoFlat(domino, c.rot ?? 0);
     c.mesh = domino;
     piecesG.add(domino);
   });


### PR DESCRIPTION
## Summary
- add a reusable helper to align domino pieces flat against the table surface
- use the new orientation helper so chain dominoes always lay flat without any tilt

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f38cd9c48083298744a82c52f0102f