### PR TITLE
Adjust Pool Royale chrome plate and cushion spacing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -189,8 +189,8 @@ function adjustSideNotchDepth(mp) {
 const POCKET_VISUAL_EXPANSION = 1.05;
 const CHROME_CORNER_POCKET_RADIUS_SCALE = 0.86; // tighten the chrome arches so the rounded cut sits slightly smaller
 const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.16;
-const CHROME_CORNER_EXPANSION_SCALE = 1.036; // tuck the chrome just shy of the rail edge so it no longer overlaps the wood caps
-const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.998; // keep the short-rail chrome aligned without spilling over the cushion edge
+const CHROME_CORNER_EXPANSION_SCALE = 1.026; // trim the chrome back along the long rails so it clears the wooden caps
+const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.992; // pull the short-rail chrome in slightly to stop at the cushion edge
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015; // widen the notch slightly to remove leftover chrome wedges at the pocket corners
 const CHROME_CORNER_FIELD_TRIM_SCALE = 0.012; // shave a sliver off the field side so the chrome sits cleanly against the rail
 const CHROME_SIDE_POCKET_RADIUS_SCALE = CHROME_CORNER_POCKET_RADIUS_SCALE; // match corner pocket arches so all chrome cutouts share one diameter
@@ -3908,7 +3908,7 @@ function Table3D(
   });
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(woodRailSurface);
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
-  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.047; // pull the opposing cushions a touch closer together while keeping clearance from the rails
+  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.052; // push the cushions toward centre just enough to avoid touching the wooden rails
   const SHORT_CUSHION_HEIGHT_SCALE = 1.085; // raise short rail cushions to match the remaining four rails
   const railsGroup = new THREE.Group();
   finishParts.accentParent = railsGroup;


### PR DESCRIPTION
## Summary
- pull back the Pool Royale corner chrome plates slightly along both the long and short rails
- nudge the Pool Royale cushions further toward the table centre to avoid overlapping the wooden rails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f392e24a8483298a36db5ba3942d6b