### PR TITLE
Restore Pool Royale to 2pm configuration

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -187,13 +187,13 @@ function adjustSideNotchDepth(mp) {
 }
 
 const POCKET_VISUAL_EXPANSION = 1.05;
-const CHROME_CORNER_POCKET_RADIUS_SCALE = 0.86; // tighten the chrome arches so the rounded cut sits slightly smaller
+const CHROME_CORNER_POCKET_RADIUS_SCALE = 0.9; // shrink chrome arches so the rounded cut matches the corner pocket radius
 const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.16;
-const CHROME_CORNER_EXPANSION_SCALE = 1.026; // trim the chrome back along the long rails so it clears the wooden caps
-const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.992; // pull the short-rail chrome in slightly to stop at the cushion edge
+const CHROME_CORNER_EXPANSION_SCALE = 1.036; // tuck the chrome just shy of the rail edge so it no longer overlaps the wood caps
+const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.998; // keep the short-rail chrome aligned without spilling over the cushion edge
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015; // widen the notch slightly to remove leftover chrome wedges at the pocket corners
 const CHROME_CORNER_FIELD_TRIM_SCALE = 0.012; // shave a sliver off the field side so the chrome sits cleanly against the rail
-const CHROME_SIDE_POCKET_RADIUS_SCALE = CHROME_CORNER_POCKET_RADIUS_SCALE; // match corner pocket arches so all chrome cutouts share one diameter
+const CHROME_SIDE_POCKET_RADIUS_SCALE = 0.99; // reduce the side arches in lockstep with the corners so they share the same pocket opening
 const WOOD_RAIL_CORNER_RADIUS_SCALE = 0;
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.82; // match the snooker side pocket throat profile
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85; // align the notch opening height with the snooker middle pockets
@@ -207,7 +207,7 @@ const CHROME_SIDE_PLATE_RAIL_INSET_SCALE = 0.038; // pull the side plates inward
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.05; // push the middle chrome slightly farther so it wraps the rail sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.058; // tighten the middle trim so the chrome reveals the rail shoulders cleanly
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.008; // leave a slim gap near each pocket to avoid chrome overlap on the cloth
-const RAIL_POCKET_CUT_SCALE = 1; // keep wooden rail cutouts the same size as the pocket geometry for consistent alignment
+const RAIL_POCKET_CUT_SCALE = 0.945; // trim the wooden rail cutouts tighter so the wood hugs the pocket mouths without overhangs
 
 function buildChromePlateGeometry({
   width,
@@ -478,10 +478,9 @@ const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
 const POCKET_CORNER_MOUTH_SCALE = 1.005; // open the corner pockets a touch more while keeping clear of the chrome
-const POCKET_SIDE_MOUTH_TIGHTEN = 1; // mirror the corner pocket mouth so all six pockets share the same opening
 const POCKET_SIDE_MOUTH_SCALE =
-  ((CORNER_MOUTH_REF * POCKET_CORNER_MOUTH_SCALE) / SIDE_MOUTH_REF) *
-  POCKET_SIDE_MOUTH_TIGHTEN; // keep side pockets identical to the corners by reusing the corner mouth diameter
+  (CORNER_MOUTH_REF * POCKET_CORNER_MOUTH_SCALE) /
+  SIDE_MOUTH_REF; // match the middle pocket mouth width to the corners
 const POCKET_CORNER_MOUTH =
   CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
 const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
@@ -3908,7 +3907,7 @@ function Table3D(
   });
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(woodRailSurface);
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
-  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.052; // push the cushions toward centre just enough to avoid touching the wooden rails
+  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.047; // pull the opposing cushions a touch closer together while keeping clearance from the rails
   const SHORT_CUSHION_HEIGHT_SCALE = 1.085; // raise short rail cushions to match the remaining four rails
   const railsGroup = new THREE.Group();
   finishParts.accentParent = railsGroup;
@@ -4033,10 +4032,10 @@ function Table3D(
   const innerHalfW = halfWext;
   const innerHalfH = halfHext;
   const cornerPocketRadius = POCKET_VIS_R * 1.1 * POCKET_VISUAL_EXPANSION;
-  const cornerChamfer = POCKET_VIS_R * 0.32 * POCKET_VISUAL_EXPANSION;
+  const cornerChamfer = POCKET_VIS_R * 0.34 * POCKET_VISUAL_EXPANSION;
   const cornerInset =
-    POCKET_VIS_R * 0.54 * POCKET_VISUAL_EXPANSION + CORNER_POCKET_CENTER_INSET;
-  const sideInset = SIDE_POCKET_RADIUS * 0.76 * POCKET_VISUAL_EXPANSION; // push the middle pocket cutouts outward so the tighter arches sit closer to the rails
+    POCKET_VIS_R * 0.58 * POCKET_VISUAL_EXPANSION + CORNER_POCKET_CENTER_INSET;
+  const sideInset = SIDE_POCKET_RADIUS * 0.84 * POCKET_VISUAL_EXPANSION;
 
   const circlePoly = (cx, cz, r, seg = 96) => {
     const pts = [];


### PR DESCRIPTION
## Summary
- revert Pool Royale table geometry, chrome trims, and pocket measurements to the exact values used at 2 PM today

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f396f00a3c8329b7f6ee30979a9b27