### PR TITLE
Tighten Pool Royale chrome plates and cushion alignment

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -189,8 +189,8 @@ function adjustSideNotchDepth(mp) {
 const POCKET_VISUAL_EXPANSION = 1.05;
 const CHROME_CORNER_POCKET_RADIUS_SCALE = 0.9; // shrink chrome arches so the rounded cut matches the corner pocket radius
 const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.16;
-const CHROME_CORNER_EXPANSION_SCALE = 1.036; // tuck the chrome just shy of the rail edge so it no longer overlaps the wood caps
-const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.998; // keep the short-rail chrome aligned without spilling over the cushion edge
+const CHROME_CORNER_EXPANSION_SCALE = 1.028; // tuck the chrome just shy of the rail edge so it no longer overlaps the wood caps
+const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.995; // keep the short-rail chrome aligned without spilling over the cushion edge
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015; // widen the notch slightly to remove leftover chrome wedges at the pocket corners
 const CHROME_CORNER_FIELD_TRIM_SCALE = 0.012; // shave a sliver off the field side so the chrome sits cleanly against the rail
 const CHROME_SIDE_POCKET_RADIUS_SCALE = 0.99; // reduce the side arches in lockstep with the corners so they share the same pocket opening
@@ -206,7 +206,7 @@ const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.6; // ease the side plate span so 
 const CHROME_SIDE_PLATE_RAIL_INSET_SCALE = 0.038; // pull the side plates inward so they clear the rail caps on mobile
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.05; // push the middle chrome slightly farther so it wraps the rail sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.058; // tighten the middle trim so the chrome reveals the rail shoulders cleanly
-const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.008; // leave a slim gap near each pocket to avoid chrome overlap on the cloth
+const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.004; // leave a slim gap near each pocket to avoid chrome overlap on the cloth
 const RAIL_POCKET_CUT_SCALE = 0.945; // trim the wooden rail cutouts tighter so the wood hugs the pocket mouths without overhangs
 
 function buildChromePlateGeometry({
@@ -3907,7 +3907,7 @@ function Table3D(
   });
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(woodRailSurface);
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
-  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.047; // pull the opposing cushions a touch closer together while keeping clearance from the rails
+  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.053; // pull the opposing cushions a touch closer together while keeping clearance from the rails
   const SHORT_CUSHION_HEIGHT_SCALE = 1.085; // raise short rail cushions to match the remaining four rails
   const railsGroup = new THREE.Group();
   finishParts.accentParent = railsGroup;


### PR DESCRIPTION
## Summary
- slightly reduce Pool Royale chrome corner and side plate expansion so the trim sits inside the rails
- nudge all Pool Royale cushions further toward the table center to avoid overlap with the wooden rails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3999159588329881b5360bff2a1bf