### PR TITLE
Align Ludo and Snake arenas with Domino visuals

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -1,40 +1,35 @@
 import { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 
-import {
-  createArenaCarpetMaterial,
-  createArenaWallMaterial
-} from '../utils/arenaDecor.js';
 import { applyRendererSRGB } from '../utils/colorSpace.js';
-import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../utils/arenaCameraConfig.js';
-import { createMurlanStyleTable } from '../utils/murlanTable.js';
+import {
+  createDominoPokerTable,
+  createDominoChairRing,
+  decorateDominoArenaEnvelope,
+  DOMINO_CAMERA_DEFAULTS
+} from '../utils/dominoArenaAssets.js';
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 
-const TABLE_RADIUS = 3.315; // 30% wider footprint so the board matches other royale arenas
-const TABLE_HEIGHT = 2.05; // Raised to line up with the oversized chair seats
-const WALL_PROXIMITY_FACTOR = 0.5;
-const WALL_HEIGHT_MULTIPLIER = 2;
-const CHAIR_SCALE = 4;
-const CHAIR_CLEARANCE = 0.52;
+const TABLE_SCALE = 2.5;
+const BOARD_MARGIN_RATIO = 0.08;
 
 const SNAKE_BOARD_TILES = 10;
 const SNAKE_BOARD_SIZE = 3.4;
 
-const CAMERA_INITIAL_RADIUS_FACTOR = ARENA_CAMERA_DEFAULTS.initialRadiusFactor;
-const CAMERA_INITIAL_PHI_LERP = ARENA_CAMERA_DEFAULTS.initialPhiLerp;
-const CAMERA_VERTICAL_SENSITIVITY = ARENA_CAMERA_DEFAULTS.verticalSensitivity;
-const CAMERA_LEAN_STRENGTH = ARENA_CAMERA_DEFAULTS.leanStrength;
-const CAMERA_WHEEL_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
-const CAM_RANGE = buildArenaCameraConfig(SNAKE_BOARD_SIZE);
+const CAMERA_VERTICAL_SENSITIVITY = 0.003;
+const CAMERA_LEAN_STRENGTH = 0.0065;
+const CAMERA_WHEEL_FACTOR = 0.2;
 const CAM = {
-  fov: CAM_RANGE.fov,
-  near: CAM_RANGE.near,
-  far: CAM_RANGE.far,
-  minR: CAM_RANGE.minRadius,
-  maxR: CAM_RANGE.maxRadius,
-  phiMin: ARENA_CAMERA_DEFAULTS.phiMin,
-  phiMax: ARENA_CAMERA_DEFAULTS.phiMax
+  fov: DOMINO_CAMERA_DEFAULTS.fov,
+  near: DOMINO_CAMERA_DEFAULTS.near,
+  far: DOMINO_CAMERA_DEFAULTS.far,
+  minR:
+    DOMINO_CAMERA_DEFAULTS.initial.radius * DOMINO_CAMERA_DEFAULTS.minRadiusFactor,
+  maxR:
+    DOMINO_CAMERA_DEFAULTS.initial.radius * DOMINO_CAMERA_DEFAULTS.maxRadiusFactor,
+  phiMin: DOMINO_CAMERA_DEFAULTS.phiMin,
+  phiMax: DOMINO_CAMERA_DEFAULTS.phiMax
 };
 const TILE_GAP = 0.015;
 const TILE_SIZE = SNAKE_BOARD_SIZE / SNAKE_BOARD_TILES;
@@ -188,108 +183,32 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
   const arena = new THREE.Group();
   scene.add(arena);
 
-  const hemi = new THREE.HemisphereLight(0xffffff, 0x1a1f2b, 0.95);
+  const ambient = new THREE.AmbientLight(0xffffff, 0.45);
+  arena.add(ambient);
+  const hemi = new THREE.HemisphereLight(0xffffff, 0xb8b19a, 0.55);
   arena.add(hemi);
-  const key = new THREE.DirectionalLight(0xffffff, 1.0);
-  key.position.set(1.8, 2.6, 1.6);
+  const key = new THREE.DirectionalLight(0xffffff, 1.6);
+  key.position.set(3.2, 3.6, 2.2);
+  key.castShadow = true;
+  key.shadow.mapSize.set(2048, 2048);
   arena.add(key);
-  const fill = new THREE.DirectionalLight(0xffffff, 0.55);
-  fill.position.set(-1.4, 2.2, -2.0);
-  arena.add(fill);
-  const rim = new THREE.PointLight(0xff7373, 0.4, 12, 2.0);
-  rim.position.set(0, 2.1, 0);
-  arena.add(rim);
-  const spot = new THREE.SpotLight(0xffffff, 1.05, 0, Math.PI / 4, 0.35, 1.1);
-  spot.position.set(0, 4.2, 4.6);
-  arena.add(spot);
-  const spotTarget = new THREE.Object3D();
-  arena.add(spotTarget);
-  spot.target = spotTarget;
+  const rimLight = new THREE.DirectionalLight(0xffffff, 0.55);
+  rimLight.position.set(-2.2, 2.6, -1.4);
+  arena.add(rimLight);
 
-  const arenaHalfWidth = 16.5; // Derived from chess arena footprint
-  const arenaHalfDepth = 28;
-  const wallInset = 0.5;
-  const halfRoomX = (arenaHalfWidth - wallInset) * WALL_PROXIMITY_FACTOR;
-  const halfRoomZ = (arenaHalfDepth - wallInset) * WALL_PROXIMITY_FACTOR;
-  const roomHalfWidth = halfRoomX + wallInset;
-  const roomHalfDepth = halfRoomZ + wallInset;
+  const arenaDress = decorateDominoArenaEnvelope({ THREE, arena, renderer });
+  if (arenaDress?.dispose && disposeHandlers) {
+    disposeHandlers.push(() => {
+      try {
+        arenaDress.dispose();
+      } catch (error) {
+        console.warn('Failed to dispose arena decor', error);
+      }
+    });
+  }
 
-  const floor = new THREE.Mesh(
-    new THREE.PlaneGeometry(roomHalfWidth * 2, roomHalfDepth * 2),
-    new THREE.MeshStandardMaterial({
-      color: 0x0f1222,
-      roughness: 0.95,
-      metalness: 0.05
-    })
-  );
-  floor.rotation.x = -Math.PI / 2;
-  arena.add(floor);
-
-  const carpetMat = createArenaCarpetMaterial();
-  const carpet = new THREE.Mesh(
-    new THREE.PlaneGeometry(roomHalfWidth * 1.2, roomHalfDepth * 1.2),
-    carpetMat
-  );
-  carpet.rotation.x = -Math.PI / 2;
-  carpet.position.y = 0.002;
-  arena.add(carpet);
-
-  const wallH = 3 * WALL_HEIGHT_MULTIPLIER;
-  const wallT = 0.1;
-  const wallMat = createArenaWallMaterial();
-  const backWall = new THREE.Mesh(new THREE.BoxGeometry(halfRoomX * 2, wallH, wallT), wallMat);
-  backWall.position.set(0, wallH / 2, halfRoomZ);
-  arena.add(backWall);
-  const frontWall = new THREE.Mesh(new THREE.BoxGeometry(halfRoomX * 2, wallH, wallT), wallMat);
-  frontWall.position.set(0, wallH / 2, -halfRoomZ);
-  arena.add(frontWall);
-  const leftWall = new THREE.Mesh(new THREE.BoxGeometry(wallT, wallH, halfRoomZ * 2), wallMat);
-  leftWall.position.set(-halfRoomX, wallH / 2, 0);
-  arena.add(leftWall);
-  const rightWall = new THREE.Mesh(new THREE.BoxGeometry(wallT, wallH, halfRoomZ * 2), wallMat);
-  rightWall.position.set(halfRoomX, wallH / 2, 0);
-  arena.add(rightWall);
-
-  const ceilTrim = new THREE.Mesh(
-    new THREE.BoxGeometry(halfRoomX * 2, 0.02, halfRoomZ * 2),
-    new THREE.MeshStandardMaterial({
-      color: 0x1a233f,
-      roughness: 0.9,
-      metalness: 0.02,
-      side: THREE.DoubleSide
-    })
-  );
-  ceilTrim.position.set(0, wallH - 0.02, 0);
-  arena.add(ceilTrim);
-
-  const ledMat = new THREE.MeshStandardMaterial({
-    color: 0x00f7ff,
-    emissive: 0x0099aa,
-    emissiveIntensity: 0.4,
-    roughness: 0.6,
-    metalness: 0.2,
-    side: THREE.DoubleSide
-  });
-  const stripBack = new THREE.Mesh(new THREE.BoxGeometry(halfRoomX * 2, 0.02, 0.01), ledMat);
-  stripBack.position.set(0, 0.05, halfRoomZ - wallT / 2);
-  arena.add(stripBack);
-  const stripFront = stripBack.clone();
-  stripFront.position.set(0, 0.05, -halfRoomZ + wallT / 2);
-  arena.add(stripFront);
-  const stripLeft = new THREE.Mesh(new THREE.BoxGeometry(0.01, 0.02, halfRoomZ * 2), ledMat);
-  stripLeft.position.set(-halfRoomX + wallT / 2, 0.05, 0);
-  arena.add(stripLeft);
-  const stripRight = stripLeft.clone();
-  stripRight.position.set(halfRoomX - wallT / 2, 0.05, 0);
-  arena.add(stripRight);
-
-  const tableInfo = createMurlanStyleTable({
-    THREE,
-    arena,
-    renderer,
-    tableRadius: TABLE_RADIUS,
-    tableHeight: TABLE_HEIGHT
-  });
+  const tableInfo = createDominoPokerTable({ THREE, renderer, scale: TABLE_SCALE });
+  arena.add(tableInfo.group);
   if (tableInfo?.dispose && disposeHandlers) {
     disposeHandlers.push(() => {
       try {
@@ -300,130 +219,21 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
     });
   }
 
-  function makeChair() {
-    const g = new THREE.Group();
-    const seat = new THREE.Mesh(
-      new THREE.BoxGeometry(0.5, 0.06, 0.5),
-      new THREE.MeshStandardMaterial({
-        color: 0x2b314e,
-        roughness: 0.6,
-        metalness: 0.1
-      })
-    );
-    seat.position.y = 0.48;
-    g.add(seat);
-    const back = new THREE.Mesh(
-      new THREE.BoxGeometry(0.5, 0.5, 0.06),
-      new THREE.MeshStandardMaterial({
-        color: 0x32395c,
-        roughness: 0.6
-      })
-    );
-    back.position.set(0, 0.78, -0.22);
-    g.add(back);
-    const legG = new THREE.CylinderGeometry(0.03, 0.03, 0.46, 12);
-    const legM = new THREE.MeshStandardMaterial({
-      color: 0x444444,
-      roughness: 0.7
-    });
-    [
-      [-0.2, 0.23, -0.2],
-      [0.2, 0.23, -0.2],
-      [-0.2, 0.23, 0.2],
-      [0.2, 0.23, 0.2]
-    ].forEach(([x, y, z]) => {
-      const leg = new THREE.Mesh(legG, legM);
-      leg.position.set(x, y, z);
-      g.add(leg);
-    });
-    g.scale.setScalar(CHAIR_SCALE);
-    return g;
-  }
+  const chairRing = createDominoChairRing({
+    THREE,
+    renderer,
+    radius: tableInfo.chairRadius,
+    lookTargetY: tableInfo.chairLookTargetY,
+    scale: tableInfo.scale
+  });
+  chairRing.chairs.forEach((chair) => arena.add(chair));
 
-  const chairA = makeChair();
-  const seatHalfDepth = 0.25 * CHAIR_SCALE;
-  const chairDistance = (tableInfo?.radius ?? TABLE_RADIUS) + seatHalfDepth + CHAIR_CLEARANCE;
-  chairA.position.set(0, 0, -chairDistance);
-  arena.add(chairA);
-  const chairB = makeChair();
-  chairB.position.set(0, 0, chairDistance);
-  chairB.rotation.y = Math.PI;
-  arena.add(chairB);
-
-  function makeStudioCamera() {
-    const cam = new THREE.Group();
-    const legLen = 1.2;
-    const legRad = 0.025;
-    const legG = new THREE.CylinderGeometry(legRad, legRad, legLen, 10);
-    const legM = new THREE.MeshStandardMaterial({
-      color: 0x333333,
-      roughness: 0.5,
-      metalness: 0.3
-    });
-    const l1 = new THREE.Mesh(legG, legM);
-    l1.position.set(-0.28, legLen / 2, 0);
-    l1.rotation.z = THREE.MathUtils.degToRad(18);
-    const l2 = l1.clone();
-    l2.position.set(0.18, legLen / 2, 0.24);
-    const l3 = l1.clone();
-    l3.position.set(0.18, legLen / 2, -0.24);
-    cam.add(l1, l2, l3);
-    const head = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.08, 0.1, 0.08, 16),
-      new THREE.MeshStandardMaterial({
-        color: 0x2e2e2e,
-        roughness: 0.6,
-        metalness: 0.2
-      })
-    );
-    head.position.set(0, legLen + 0.04, 0);
-    cam.add(head);
-    const body = new THREE.Mesh(
-      new THREE.BoxGeometry(0.34, 0.22, 0.22),
-      new THREE.MeshStandardMaterial({
-        color: 0x151515,
-        roughness: 0.5,
-        metalness: 0.4
-      })
-    );
-    body.position.set(0, legLen + 0.2, 0);
-    cam.add(body);
-    const lens = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.06, 0.06, 0.22, 16),
-      new THREE.MeshStandardMaterial({
-        color: 0x202020,
-        roughness: 0.4,
-        metalness: 0.5
-      })
-    );
-    lens.rotation.z = Math.PI / 2;
-    lens.position.set(0.22, legLen + 0.2, 0);
-    cam.add(lens);
-    const handle = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.01, 0.01, 0.3, 10),
-      new THREE.MeshStandardMaterial({
-        color: 0x444444,
-        roughness: 0.6
-      })
-    );
-    handle.rotation.z = THREE.MathUtils.degToRad(30);
-    handle.position.set(-0.16, legLen + 0.16, -0.1);
-    cam.add(handle);
-    return cam;
-  }
-
-  const cameraRigOffsetX = (tableInfo?.radius ?? TABLE_RADIUS) + 1.4;
-  const cameraRigOffsetZ = (tableInfo?.radius ?? TABLE_RADIUS) + 1.2;
-  const studioCamA = makeStudioCamera();
-  studioCamA.position.set(-cameraRigOffsetX, 0, -cameraRigOffsetZ);
-  arena.add(studioCamA);
-  const studioCamB = makeStudioCamera();
-  studioCamB.position.set(cameraRigOffsetX, 0, cameraRigOffsetZ);
-  arena.add(studioCamB);
-
-  const tableSurfaceY = tableInfo?.surfaceY ?? TABLE_HEIGHT;
+  const boardMargin = tableInfo.clothDiameter * BOARD_MARGIN_RATIO;
+  const boardDisplaySize = tableInfo.clothDiameter - boardMargin;
+  const boardScale = boardDisplaySize / SNAKE_BOARD_SIZE;
   const boardGroup = new THREE.Group();
-  boardGroup.position.y = tableSurfaceY + 0.01;
+  boardGroup.position.y = tableInfo.surfaceY + 0.012;
+  boardGroup.scale.setScalar(boardScale);
   arena.add(boardGroup);
 
   const boardLookTarget = new THREE.Vector3(
@@ -431,21 +241,22 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
     boardGroup.position.y + BOARD_BASE_HEIGHT / 2 + 0.12,
     0
   );
-  spotTarget.position.copy(boardLookTarget);
-  spot.target.updateMatrixWorld();
-  studioCamA.lookAt(boardLookTarget);
-  studioCamB.lookAt(boardLookTarget);
 
   const camera = new THREE.PerspectiveCamera(CAM.fov, 1, CAM.near, CAM.far);
-  const initialRadius = Math.max(
-    SNAKE_BOARD_SIZE * CAMERA_INITIAL_RADIUS_FACTOR,
-    CAM.minR + 0.6
+  CAM.minR = Math.max(
+    CAM.minR,
+    boardDisplaySize * DOMINO_CAMERA_DEFAULTS.minRadiusFactor
+  );
+  CAM.maxR = Math.max(
+    CAM.maxR,
+    boardDisplaySize * DOMINO_CAMERA_DEFAULTS.maxRadiusFactor
   );
   const sph = new THREE.Spherical(
-    initialRadius,
-    THREE.MathUtils.lerp(CAM.phiMin, CAM.phiMax, CAMERA_INITIAL_PHI_LERP),
-    Math.PI * 0.25
+    clamp(DOMINO_CAMERA_DEFAULTS.initial.radius, CAM.minR, CAM.maxR),
+    DOMINO_CAMERA_DEFAULTS.initial.phi,
+    DOMINO_CAMERA_DEFAULTS.initial.theta
   );
+  const initialRadius = sph.radius;
 
   const fit = () => {
     const w = host.clientWidth;
@@ -453,12 +264,8 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers) {
     renderer.setSize(w, h, false);
     camera.aspect = w / h;
     camera.updateProjectionMatrix();
-    spotTarget.position.copy(boardLookTarget);
-    spot.target.updateMatrixWorld();
-    studioCamA.lookAt(boardLookTarget);
-    studioCamB.lookAt(boardLookTarget);
     const needed =
-      SNAKE_BOARD_SIZE / (2 * Math.tan(THREE.MathUtils.degToRad(CAM.fov) / 2));
+      boardDisplaySize / (2 * Math.tan(THREE.MathUtils.degToRad(CAM.fov) / 2));
     sph.radius = clamp(Math.max(needed, sph.radius), CAM.minR, CAM.maxR);
     const offset = new THREE.Vector3().setFromSpherical(sph);
     camera.position.copy(boardLookTarget).add(offset);

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2,10 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import * as THREE from 'three';
 import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
-import {
-  createArenaCarpetMaterial,
-  createArenaWallMaterial
-} from '../../utils/arenaDecor.js';
 import { applyRendererSRGB } from '../../utils/colorSpace.js';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
@@ -20,53 +16,32 @@ import {
   cheerSound
 } from '../../assets/soundData.js';
 import { getGameVolume } from '../../utils/sound.js';
-import { createMurlanStyleTable } from '../../utils/murlanTable.js';
+import {
+  createDominoPokerTable,
+  createDominoChairRing,
+  decorateDominoArenaEnvelope,
+  DOMINO_CAMERA_DEFAULTS
+} from '../../utils/dominoArenaAssets.js';
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 
-const TABLE_RADIUS = 3.315; // 30% wider to mirror the Chess Battle Royal arena scale
-const TABLE_HEIGHT = 2.05; // Raised so the surface meets the chair seating height
-
-const WALL_PROXIMITY_FACTOR = 0.5;
-const WALL_HEIGHT_MULTIPLIER = 2;
-const CHAIR_SCALE = 4;
-const CHAIR_CLEARANCE = 0.52;
-const CAMERA_INITIAL_RADIUS_FACTOR = 1.35;
-const CAMERA_MIN_RADIUS_FACTOR = 0.95;
-const CAMERA_MAX_RADIUS_FACTOR = 2.4;
-const CAMERA_INITIAL_PHI_LERP = 0.35;
+const TABLE_SCALE = 2.5;
+const BOARD_MARGIN_RATIO = 0.08;
 const CAMERA_VERTICAL_SENSITIVITY = 0.003;
 const CAMERA_LEAN_STRENGTH = 0.0065;
-
-const SNOOKER_TABLE_SCALE = 1.3;
-const SNOOKER_TABLE_W = 66 * SNOOKER_TABLE_SCALE;
-const SNOOKER_TABLE_H = 132 * SNOOKER_TABLE_SCALE;
-const SNOOKER_ROOM_DEPTH = SNOOKER_TABLE_H * 3.6;
-const SNOOKER_SIDE_CLEARANCE = SNOOKER_ROOM_DEPTH / 2 - SNOOKER_TABLE_H / 2;
-const SNOOKER_ROOM_WIDTH = SNOOKER_TABLE_W + SNOOKER_SIDE_CLEARANCE * 2;
-const SNOOKER_SIZE_REDUCTION = 0.7;
-const SNOOKER_GLOBAL_SIZE_FACTOR = 0.85 * SNOOKER_SIZE_REDUCTION;
-const SNOOKER_WORLD_SCALE = 0.85 * SNOOKER_GLOBAL_SIZE_FACTOR * 0.7;
-const CHESS_ARENA = Object.freeze({
-  width: (SNOOKER_ROOM_WIDTH * SNOOKER_WORLD_SCALE) / 2,
-  depth: (SNOOKER_ROOM_DEPTH * SNOOKER_WORLD_SCALE) / 2
-});
-
 const CAM = {
-  fov: 52,
-  near: 0.1,
-  far: 5000,
-  minR: 3.4 * CAMERA_MIN_RADIUS_FACTOR,
-  maxR: 3.4 * CAMERA_MAX_RADIUS_FACTOR,
-  phiMin: 0.92,
-  phiMax: 1.22
+  fov: DOMINO_CAMERA_DEFAULTS.fov,
+  near: DOMINO_CAMERA_DEFAULTS.near,
+  far: DOMINO_CAMERA_DEFAULTS.far,
+  minR: DOMINO_CAMERA_DEFAULTS.initial.radius * DOMINO_CAMERA_DEFAULTS.minRadiusFactor,
+  maxR: DOMINO_CAMERA_DEFAULTS.initial.radius * DOMINO_CAMERA_DEFAULTS.maxRadiusFactor,
+  phiMin: DOMINO_CAMERA_DEFAULTS.phiMin,
+  phiMax: DOMINO_CAMERA_DEFAULTS.phiMax
 };
 
 const LUDO_GRID = 15;
 const LUDO_TILE = 0.075;
 const RAW_BOARD_SIZE = LUDO_GRID * LUDO_TILE;
-const BOARD_DISPLAY_SIZE = 3.4;
-const BOARD_SCALE = BOARD_DISPLAY_SIZE / RAW_BOARD_SIZE;
 const RING_STEPS = 52;
 const HOME_STEPS = 4;
 const GOAL_PROGRESS = RING_STEPS + HOME_STEPS;
@@ -394,129 +369,35 @@ function Ludo3D({ avatar, username }) {
     scene = new THREE.Scene();
     scene.background = new THREE.Color(0x0c1020);
 
-    const hemi = new THREE.HemisphereLight(0xffffff, 0x1a1f2b, 1.1);
+    const ambient = new THREE.AmbientLight(0xffffff, 0.45);
+    scene.add(ambient);
+    const hemi = new THREE.HemisphereLight(0xffffff, 0xb8b19a, 0.55);
     scene.add(hemi);
-    const key = new THREE.DirectionalLight(0xffffff, 1.35);
-    key.position.set(1.6, 2.8, 1.8);
+    const key = new THREE.DirectionalLight(0xffffff, 1.6);
+    key.position.set(3.2, 3.6, 2.2);
+    key.castShadow = true;
+    key.shadow.mapSize.set(2048, 2048);
     scene.add(key);
-    const fill = new THREE.DirectionalLight(0xffffff, 0.8);
-    fill.position.set(-1.6, 2.4, -1.8);
-    scene.add(fill);
-    const rim = new THREE.PointLight(0xff7373, 0.6, 12, 2.0);
-    rim.position.set(0, 2.3, 0);
-    scene.add(rim);
-    const spot = new THREE.SpotLight(0xffffff, 1.4, 0, Math.PI / 4.5, 0.32, 1.2);
-    spot.position.set(0.4, 4.4, 4.4);
-    scene.add(spot);
-    const spotTarget = new THREE.Object3D();
-    scene.add(spotTarget);
-    spot.target = spotTarget;
+    const rimLight = new THREE.DirectionalLight(0xffffff, 0.55);
+    rimLight.position.set(-2.2, 2.6, -1.4);
+    scene.add(rimLight);
 
     const arena = new THREE.Group();
     scene.add(arena);
 
-    const arenaHalfWidth = CHESS_ARENA.width / 2;
-    const arenaHalfDepth = CHESS_ARENA.depth / 2;
-    const wallInset = 0.5;
-    const halfRoomX = (arenaHalfWidth - wallInset) * WALL_PROXIMITY_FACTOR;
-    const halfRoomZ = (arenaHalfDepth - wallInset) * WALL_PROXIMITY_FACTOR;
-    const roomHalfWidth = halfRoomX + wallInset;
-    const roomHalfDepth = halfRoomZ + wallInset;
+    const arenaDress = decorateDominoArenaEnvelope({ THREE, arena, renderer });
+    if (arenaDress?.dispose) {
+      disposers.push(() => {
+        try {
+          arenaDress.dispose();
+        } catch (error) {
+          console.warn('Failed to dispose arena decor', error);
+        }
+      });
+    }
 
-    const floor = new THREE.Mesh(
-      new THREE.PlaneGeometry(roomHalfWidth * 2, roomHalfDepth * 2),
-      new THREE.MeshStandardMaterial({
-        color: 0x0f1222,
-        roughness: 0.95,
-        metalness: 0.05
-      })
-    );
-    floor.rotation.x = -Math.PI / 2;
-    arena.add(floor);
-
-    const carpetMat = createArenaCarpetMaterial();
-    const carpet = new THREE.Mesh(
-      new THREE.PlaneGeometry(roomHalfWidth * 1.2, roomHalfDepth * 1.2),
-      carpetMat
-    );
-    carpet.rotation.x = -Math.PI / 2;
-    carpet.position.y = 0.002;
-    arena.add(carpet);
-
-    const wallH = 3 * WALL_HEIGHT_MULTIPLIER;
-    const wallT = 0.1;
-    const wallMat = createArenaWallMaterial();
-    const backWall = new THREE.Mesh(
-      new THREE.BoxGeometry(halfRoomX * 2, wallH, wallT),
-      wallMat
-    );
-    backWall.position.set(0, wallH / 2, halfRoomZ);
-    arena.add(backWall);
-    const frontWall = new THREE.Mesh(
-      new THREE.BoxGeometry(halfRoomX * 2, wallH, wallT),
-      wallMat
-    );
-    frontWall.position.set(0, wallH / 2, -halfRoomZ);
-    arena.add(frontWall);
-    const leftWall = new THREE.Mesh(
-      new THREE.BoxGeometry(wallT, wallH, halfRoomZ * 2),
-      wallMat
-    );
-    leftWall.position.set(-halfRoomX, wallH / 2, 0);
-    arena.add(leftWall);
-    const rightWall = new THREE.Mesh(
-      new THREE.BoxGeometry(wallT, wallH, halfRoomZ * 2),
-      wallMat
-    );
-    rightWall.position.set(halfRoomX, wallH / 2, 0);
-    arena.add(rightWall);
-
-    const ceilTrim = new THREE.Mesh(
-      new THREE.BoxGeometry(halfRoomX * 2, 0.02, halfRoomZ * 2),
-      new THREE.MeshStandardMaterial({
-        color: 0x1a233f,
-        roughness: 0.9,
-        metalness: 0.02,
-        side: THREE.DoubleSide
-      })
-    );
-    ceilTrim.position.set(0, wallH - 0.02, 0);
-    arena.add(ceilTrim);
-
-    const ledMat = new THREE.MeshStandardMaterial({
-      color: 0x00f7ff,
-      emissive: 0x0099aa,
-      emissiveIntensity: 0.4,
-      roughness: 0.6,
-      metalness: 0.2,
-      side: THREE.DoubleSide
-    });
-    const stripBack = new THREE.Mesh(
-      new THREE.BoxGeometry(halfRoomX * 2, 0.02, 0.01),
-      ledMat
-    );
-    stripBack.position.set(0, 0.05, halfRoomZ - wallT / 2);
-    arena.add(stripBack);
-    const stripFront = stripBack.clone();
-    stripFront.position.set(0, 0.05, -halfRoomZ + wallT / 2);
-    arena.add(stripFront);
-    const stripLeft = new THREE.Mesh(
-      new THREE.BoxGeometry(0.01, 0.02, halfRoomZ * 2),
-      ledMat
-    );
-    stripLeft.position.set(-halfRoomX + wallT / 2, 0.05, 0);
-    arena.add(stripLeft);
-    const stripRight = stripLeft.clone();
-    stripRight.position.set(halfRoomX - wallT / 2, 0.05, 0);
-    arena.add(stripRight);
-
-    const tableInfo = createMurlanStyleTable({
-      THREE,
-      arena,
-      renderer,
-      tableRadius: TABLE_RADIUS,
-      tableHeight: TABLE_HEIGHT
-    });
+    const tableInfo = createDominoPokerTable({ THREE, renderer, scale: TABLE_SCALE });
+    arena.add(tableInfo.group);
     if (tableInfo?.dispose) {
       disposers.push(() => {
         try {
@@ -527,132 +408,21 @@ function Ludo3D({ avatar, username }) {
       });
     }
 
-    function makeChair() {
-      const g = new THREE.Group();
-      const seat = new THREE.Mesh(
-        new THREE.BoxGeometry(0.5, 0.06, 0.5),
-        new THREE.MeshStandardMaterial({
-          color: 0x2b314e,
-          roughness: 0.6,
-          metalness: 0.1
-        })
-      );
-      seat.position.y = 0.48;
-      g.add(seat);
-      const back = new THREE.Mesh(
-        new THREE.BoxGeometry(0.5, 0.5, 0.06),
-        new THREE.MeshStandardMaterial({
-          color: 0x32395c,
-          roughness: 0.6
-        })
-      );
-      back.position.set(0, 0.78, -0.22);
-      g.add(back);
-      const legG = new THREE.CylinderGeometry(0.03, 0.03, 0.46, 12);
-      const legM = new THREE.MeshStandardMaterial({
-        color: 0x444444,
-        roughness: 0.7
-      });
-      [
-        [-0.2, 0.23, -0.2],
-        [0.2, 0.23, -0.2],
-        [-0.2, 0.23, 0.2],
-        [0.2, 0.23, 0.2]
-      ].forEach(([x, y, z]) => {
-        const leg = new THREE.Mesh(legG, legM);
-        leg.position.set(x, y, z);
-        g.add(leg);
-      });
-      g.scale.setScalar(CHAIR_SCALE);
-      return g;
-    }
+    const chairRing = createDominoChairRing({
+      THREE,
+      renderer,
+      radius: tableInfo.chairRadius,
+      lookTargetY: tableInfo.chairLookTargetY,
+      scale: tableInfo.scale
+    });
+    chairRing.chairs.forEach((chair) => arena.add(chair));
 
-    const chairA = makeChair();
-    const seatHalfDepth = 0.25 * CHAIR_SCALE;
-    const chairDistance = (tableInfo?.radius ?? TABLE_RADIUS) + seatHalfDepth + CHAIR_CLEARANCE;
-    const userChairOffset = 0.18;
-    chairA.position.set(0, 0, -(chairDistance + userChairOffset));
-    arena.add(chairA);
-    const chairB = makeChair();
-    chairB.position.set(0, 0, chairDistance);
-    chairB.rotation.y = Math.PI;
-    arena.add(chairB);
-
-    function makeStudioCamera() {
-      const cam = new THREE.Group();
-      const legLen = 1.2;
-      const legRad = 0.025;
-      const legG = new THREE.CylinderGeometry(legRad, legRad, legLen, 10);
-      const legM = new THREE.MeshStandardMaterial({
-        color: 0x333333,
-        roughness: 0.5,
-        metalness: 0.3
-      });
-      const l1 = new THREE.Mesh(legG, legM);
-      l1.position.set(-0.28, legLen / 2, 0);
-      l1.rotation.z = THREE.MathUtils.degToRad(18);
-      const l2 = l1.clone();
-      l2.position.set(0.18, legLen / 2, 0.24);
-      const l3 = l1.clone();
-      l3.position.set(0.18, legLen / 2, -0.24);
-      cam.add(l1, l2, l3);
-      const head = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.08, 0.1, 0.08, 16),
-        new THREE.MeshStandardMaterial({
-          color: 0x2e2e2e,
-          roughness: 0.6,
-          metalness: 0.2
-        })
-      );
-      head.position.set(0, legLen + 0.04, 0);
-      cam.add(head);
-      const body = new THREE.Mesh(
-        new THREE.BoxGeometry(0.34, 0.22, 0.22),
-        new THREE.MeshStandardMaterial({
-          color: 0x151515,
-          roughness: 0.5,
-          metalness: 0.4
-        })
-      );
-      body.position.set(0, legLen + 0.2, 0);
-      cam.add(body);
-      const lens = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.06, 0.06, 0.22, 16),
-        new THREE.MeshStandardMaterial({
-          color: 0x202020,
-          roughness: 0.4,
-          metalness: 0.5
-        })
-      );
-      lens.rotation.z = Math.PI / 2;
-      lens.position.set(0.22, legLen + 0.2, 0);
-      cam.add(lens);
-      const handle = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.01, 0.01, 0.3, 10),
-        new THREE.MeshStandardMaterial({
-          color: 0x444444,
-          roughness: 0.6
-        })
-      );
-      handle.rotation.z = THREE.MathUtils.degToRad(30);
-      handle.position.set(-0.16, legLen + 0.16, -0.1);
-      cam.add(handle);
-      return cam;
-    }
-
-    const cameraRigOffsetX = (tableInfo?.radius ?? TABLE_RADIUS) + 1.4;
-    const cameraRigOffsetZ = (tableInfo?.radius ?? TABLE_RADIUS) + 1.2;
-    const studioCamA = makeStudioCamera();
-    studioCamA.position.set(-cameraRigOffsetX, 0, -cameraRigOffsetZ);
-    arena.add(studioCamA);
-    const studioCamB = makeStudioCamera();
-    studioCamB.position.set(cameraRigOffsetX, 0, cameraRigOffsetZ);
-    arena.add(studioCamB);
-
-    const tableSurfaceY = tableInfo?.surfaceY ?? TABLE_HEIGHT;
+    const boardMargin = tableInfo.clothDiameter * BOARD_MARGIN_RATIO;
+    const boardDisplaySize = tableInfo.clothDiameter - boardMargin;
+    const boardScale = boardDisplaySize / RAW_BOARD_SIZE;
     const boardGroup = new THREE.Group();
-    boardGroup.position.y = tableSurfaceY + 0.01;
-    boardGroup.scale.setScalar(BOARD_SCALE);
+    boardGroup.position.y = tableInfo.surfaceY + 0.012;
+    boardGroup.scale.setScalar(boardScale);
     arena.add(boardGroup);
 
     const boardLookTarget = new THREE.Vector3(
@@ -660,21 +430,22 @@ function Ludo3D({ avatar, username }) {
       boardGroup.position.y + 0.16,
       0
     );
-    spotTarget.position.copy(boardLookTarget);
-    spot.target.updateMatrixWorld();
-    studioCamA.lookAt(boardLookTarget);
-    studioCamB.lookAt(boardLookTarget);
 
     camera = new THREE.PerspectiveCamera(CAM.fov, 1, CAM.near, CAM.far);
-    const initialRadius = Math.max(
-      BOARD_DISPLAY_SIZE * CAMERA_INITIAL_RADIUS_FACTOR,
-      CAM.minR + 0.6
+    CAM.minR = Math.max(
+      CAM.minR,
+      boardDisplaySize * DOMINO_CAMERA_DEFAULTS.minRadiusFactor
+    );
+    CAM.maxR = Math.max(
+      CAM.maxR,
+      boardDisplaySize * DOMINO_CAMERA_DEFAULTS.maxRadiusFactor
     );
     sph = new THREE.Spherical(
-      initialRadius,
-      THREE.MathUtils.lerp(CAM.phiMin, CAM.phiMax, CAMERA_INITIAL_PHI_LERP),
-      Math.PI * 0.25
+      clamp(DOMINO_CAMERA_DEFAULTS.initial.radius, CAM.minR, CAM.maxR),
+      DOMINO_CAMERA_DEFAULTS.initial.phi,
+      DOMINO_CAMERA_DEFAULTS.initial.theta
     );
+    const initialRadius = sph.radius;
 
     const fit = () => {
       const w = host.clientWidth;
@@ -682,9 +453,8 @@ function Ludo3D({ avatar, username }) {
       renderer.setSize(w, h, false);
       camera.aspect = w / h;
       camera.updateProjectionMatrix();
-      const boardSize = RAW_BOARD_SIZE * BOARD_SCALE;
       const needed =
-        boardSize / (2 * Math.tan(THREE.MathUtils.degToRad(CAM.fov) / 2));
+        boardDisplaySize / (2 * Math.tan(THREE.MathUtils.degToRad(CAM.fov) / 2));
       sph.radius = clamp(Math.max(needed, sph.radius), CAM.minR, CAM.maxR);
       const offset = new THREE.Vector3().setFromSpherical(sph);
       camera.position.copy(boardLookTarget).add(offset);

--- a/webapp/src/utils/dominoArenaAssets.js
+++ b/webapp/src/utils/dominoArenaAssets.js
@@ -1,0 +1,680 @@
+import * as THREE from 'three';
+
+const clamp01 = (v) => Math.min(1, Math.max(0, v));
+
+const DOMINO_ROOM = Object.freeze({
+  width: 6.2,
+  depth: 6.2,
+  wallThickness: 0.45,
+  wallHeight: 3.4,
+  carpetThickness: 0.12
+});
+
+const CHAIR_DIMENSIONS = Object.freeze({
+  seatWidth: 0.72,
+  seatDepth: 0.72,
+  seatThickness: 0.12,
+  backHeight: 0.62,
+  backThickness: 0.08,
+  armHeight: 0.3,
+  armThickness: 0.1,
+  armDepth: 0.76,
+  columnHeight: 0.38,
+  baseThickness: 0.08,
+  columnRadiusTop: 0.11,
+  columnRadiusBottom: 0.15,
+  baseRadius: 0.46,
+  footRingRadius: 0.34,
+  footRingTube: 0.03
+});
+
+export const DEFAULT_DOMINO_CHAIR_OPTION = Object.freeze({
+  id: 'crimsonVelvet',
+  primary: '#8b1538',
+  accent: '#5c0f26',
+  highlight: '#d35a7a',
+  legColor: '#1f1f1f'
+});
+
+export const DOMINO_CAMERA_DEFAULTS = Object.freeze({
+  fov: 56,
+  near: 0.05,
+  far: 100,
+  initial: Object.freeze({
+    radius: 3.3319,
+    phi: 1.034,
+    theta: 0.773
+  }),
+  phiMin: 0.82,
+  phiMax: 1.25,
+  minRadiusFactor: 0.72,
+  maxRadiusFactor: 1.65
+});
+
+let cachedCarpetTextures = null;
+
+function ensureDominoCarpetTextures(renderer) {
+  if (cachedCarpetTextures) return cachedCarpetTextures;
+  if (typeof document === 'undefined') {
+    cachedCarpetTextures = { map: null, bump: null };
+    return cachedCarpetTextures;
+  }
+
+  const size = 1024;
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext('2d');
+
+  const gradient = ctx.createLinearGradient(0, 0, size, size);
+  gradient.addColorStop(0, '#7c242f');
+  gradient.addColorStop(1, '#9d3642');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+
+  const prng = (seed) => {
+    let value = seed >>> 0;
+    return () => {
+      value = (value * 1664525 + 1013904223) % 4294967296;
+      return value / 4294967296;
+    };
+  };
+
+  const rand = prng(987654321);
+  const image = ctx.getImageData(0, 0, size, size);
+  const data = image.data;
+  const baseColor = { r: 112, g: 28, b: 34 };
+  const highlightColor = { r: 196, g: 72, b: 82 };
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const idx = (y * size + x) * 4;
+      const fiber = (Math.sin((x / size) * Math.PI * 14) + Math.cos((y / size) * Math.PI * 16)) * 0.08;
+      const grain = (rand() - 0.5) * 0.12;
+      const shade = clamp01(0.55 + fiber * 0.75 + grain * 0.6);
+      const r = baseColor.r + (highlightColor.r - baseColor.r) * shade;
+      const g = baseColor.g + (highlightColor.g - baseColor.g) * shade;
+      const b = baseColor.b + (highlightColor.b - baseColor.b) * shade;
+      data[idx] = Math.round(clamp01(r / 255) * 255);
+      data[idx + 1] = Math.round(clamp01(g / 255) * 255);
+      data[idx + 2] = Math.round(clamp01(b / 255) * 255);
+    }
+  }
+  ctx.putImageData(image, 0, 0);
+
+  ctx.globalAlpha = 0.04;
+  ctx.fillStyle = '#4f1119';
+  for (let row = 0; row < size; row += 3) {
+    ctx.fillRect(0, row, size, 1);
+  }
+  ctx.globalAlpha = 1;
+
+  const drawRoundedRect = (context, x, y, w, h, r) => {
+    const radius = Math.max(0, Math.min(r, Math.min(w, h) / 2));
+    context.beginPath();
+    context.moveTo(x + radius, y);
+    context.lineTo(x + w - radius, y);
+    context.quadraticCurveTo(x + w, y, x + w, y + radius);
+    context.lineTo(x + w, y + h - radius);
+    context.quadraticCurveTo(x + w, y + h, x + w - radius, y + h);
+    context.lineTo(x + radius, y + h);
+    context.quadraticCurveTo(x, y + h, x, y + h - radius);
+    context.lineTo(x, y + radius);
+    context.quadraticCurveTo(x, y, x + radius, y);
+    context.closePath();
+  };
+
+  const insetRatio = 0.055;
+  const stripeInset = size * insetRatio;
+  const stripeRadius = size * 0.08;
+  const stripeWidth = size * 0.012;
+  ctx.lineWidth = stripeWidth;
+  ctx.strokeStyle = '#f2b7b4';
+  ctx.shadowColor = 'rgba(80,20,30,0.18)';
+  ctx.shadowBlur = stripeWidth * 0.8;
+  drawRoundedRect(ctx, stripeInset, stripeInset, size - stripeInset * 2, size - stripeInset * 2, stripeRadius);
+  ctx.stroke();
+  ctx.shadowBlur = 0;
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.wrapS = texture.wrapT = THREE.ClampToEdgeWrapping;
+  texture.anisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 8;
+  texture.minFilter = THREE.LinearMipMapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.generateMipmaps = true;
+  if ('colorSpace' in texture) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  }
+
+  const bumpCanvas = document.createElement('canvas');
+  bumpCanvas.width = bumpCanvas.height = size;
+  const bumpCtx = bumpCanvas.getContext('2d');
+  bumpCtx.drawImage(canvas, 0, 0);
+  const bumpImage = bumpCtx.getImageData(0, 0, size, size);
+  const bumpData = bumpImage.data;
+  const bumpRand = prng(246813579);
+  for (let i = 0; i < bumpData.length; i += 4) {
+    const r = bumpData[i];
+    const g = bumpData[i + 1];
+    const b = bumpData[i + 2];
+    const lum = (r * 0.299 + g * 0.587 + b * 0.114) / 255;
+    const noise = (bumpRand() - 0.5) * 0.16;
+    const value = Math.floor(clamp01(0.62 + lum * 0.28 + noise) * 255);
+    bumpData[i] = bumpData[i + 1] = bumpData[i + 2] = value;
+  }
+  bumpCtx.putImageData(bumpImage, 0, 0);
+
+  const bump = new THREE.CanvasTexture(bumpCanvas);
+  bump.wrapS = bump.wrapT = THREE.ClampToEdgeWrapping;
+  bump.anisotropy = Math.min(texture.anisotropy ?? 4, 6);
+  bump.minFilter = THREE.LinearMipMapLinearFilter;
+  bump.magFilter = THREE.LinearFilter;
+  bump.generateMipmaps = true;
+
+  cachedCarpetTextures = { map: texture, bump };
+  return cachedCarpetTextures;
+}
+
+export function createDominoCarpetMaterial(renderer) {
+  const carpetTextures = ensureDominoCarpetTextures(renderer);
+  const material = new THREE.MeshStandardMaterial({
+    color: 0x8c2a2e,
+    roughness: 0.9,
+    metalness: 0.025
+  });
+  if (carpetTextures.map) {
+    material.map = carpetTextures.map;
+    material.map.needsUpdate = true;
+  }
+  if (carpetTextures.bump) {
+    material.bumpMap = carpetTextures.bump;
+    material.bumpScale = 0.18;
+    material.bumpMap.needsUpdate = true;
+  }
+  return material;
+}
+
+function adjustHexColor(hex, amount) {
+  const base = new THREE.Color(hex);
+  const target = amount >= 0 ? new THREE.Color(0xffffff) : new THREE.Color(0x000000);
+  base.lerp(target, Math.min(Math.abs(amount), 1));
+  return `#${base.getHexString()}`;
+}
+
+const CHAIR_CLOTH_TEXTURE_SIZE = 512;
+const CHAIR_CLOTH_REPEAT = 4;
+
+function createChairClothTexture(option, renderer) {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const primary = option?.primary ?? '#0f6a2f';
+  const accent = option?.accent ?? adjustHexColor(primary, -0.28);
+  const highlight = option?.highlight ?? adjustHexColor(primary, 0.22);
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = CHAIR_CLOTH_TEXTURE_SIZE;
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  const shadow = adjustHexColor(accent, -0.22);
+  const seam = adjustHexColor(accent, -0.35);
+
+  const gradient = ctx.createLinearGradient(0, 0, canvas.width, canvas.height);
+  gradient.addColorStop(0, adjustHexColor(primary, 0.2));
+  gradient.addColorStop(0.5, primary);
+  gradient.addColorStop(1, accent);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const spacing = canvas.width / CHAIR_CLOTH_REPEAT;
+  const halfSpacing = spacing / 2;
+  const lineWidth = Math.max(1.6, spacing * 0.06);
+
+  ctx.strokeStyle = seam;
+  ctx.lineWidth = lineWidth;
+  ctx.globalAlpha = 0.9;
+  for (let offset = -canvas.height; offset <= canvas.width + canvas.height; offset += spacing) {
+    ctx.beginPath();
+    ctx.moveTo(offset, 0);
+    ctx.lineTo(offset - canvas.height, canvas.height);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(offset, 0);
+    ctx.lineTo(offset + canvas.height, canvas.height);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+
+  ctx.strokeStyle = adjustHexColor(highlight, 0.18);
+  ctx.lineWidth = lineWidth * 0.55;
+  ctx.globalAlpha = 0.55;
+  for (let offset = -canvas.height; offset <= canvas.width + canvas.height; offset += spacing) {
+    ctx.beginPath();
+    ctx.moveTo(offset + halfSpacing, 0);
+    ctx.lineTo(offset + halfSpacing - canvas.height, canvas.height);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(offset + halfSpacing, 0);
+    ctx.lineTo(offset + halfSpacing + canvas.height, canvas.height);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.28)';
+  const tuftRadius = Math.max(1.8, spacing * 0.08);
+  for (let y = -spacing; y <= canvas.height + spacing; y += spacing) {
+    for (let x = -spacing; x <= canvas.width + spacing; x += spacing) {
+      ctx.beginPath();
+      ctx.ellipse(x + halfSpacing, y + halfSpacing, tuftRadius, tuftRadius * 0.85, 0, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  ctx.save();
+  ctx.globalCompositeOperation = 'overlay';
+  const sheenGradient = ctx.createRadialGradient(
+    canvas.width * 0.28,
+    canvas.height * 0.32,
+    canvas.width * 0.05,
+    canvas.width * 0.28,
+    canvas.height * 0.32,
+    canvas.width * 0.75
+  );
+  sheenGradient.addColorStop(0, 'rgba(255, 255, 255, 0.26)');
+  sheenGradient.addColorStop(0.5, 'rgba(255, 255, 255, 0.08)');
+  sheenGradient.addColorStop(1, 'rgba(0, 0, 0, 0.35)');
+  ctx.fillStyle = sheenGradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.restore();
+
+  ctx.globalAlpha = 0.08;
+  for (let y = 0; y < canvas.height; y += 2) {
+    for (let x = 0; x < canvas.width; x += 2) {
+      ctx.fillStyle = Math.random() > 0.5 ? highlight : shadow;
+      ctx.fillRect(x, y, 1, 1);
+    }
+  }
+  ctx.globalAlpha = 1;
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(CHAIR_CLOTH_REPEAT, CHAIR_CLOTH_REPEAT);
+  texture.anisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 8;
+  if ('colorSpace' in texture) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  }
+  texture.needsUpdate = true;
+  return texture;
+}
+
+function createChairFabricMaterial(option, renderer) {
+  const texture = createChairClothTexture(option, renderer);
+  const primary = option?.primary ?? '#0f6a2f';
+  const sheenColor = option?.highlight ?? adjustHexColor(primary, 0.2);
+  const material = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(adjustHexColor(primary, 0.04)),
+    map: texture,
+    roughness: 0.28,
+    metalness: 0.08,
+    clearcoat: 1,
+    clearcoatRoughness: 0.28,
+    sheen: 0.18
+  });
+  if ('sheenColor' in material) {
+    material.sheenColor.set(sheenColor);
+  }
+  if ('sheenRoughness' in material) {
+    material.sheenRoughness = 0.32;
+  }
+  if ('specularIntensity' in material) {
+    material.specularIntensity = 0.65;
+  }
+  return material;
+}
+
+const chairMaterialCache = new Map();
+
+function getDominoChairMaterials(renderer, option = DEFAULT_DOMINO_CHAIR_OPTION) {
+  const key = option?.id ?? JSON.stringify(option);
+  if (chairMaterialCache.has(key)) {
+    return chairMaterialCache.get(key);
+  }
+  const materials = {
+    fabric: createChairFabricMaterial(option, renderer),
+    leg: new THREE.MeshStandardMaterial({
+      color: new THREE.Color(option?.legColor ?? '#1f1f1f'),
+      metalness: 0.6,
+      roughness: 0.35
+    }),
+    accent: new THREE.MeshStandardMaterial({
+      color: new THREE.Color('#2a2a2a'),
+      metalness: 0.75,
+      roughness: 0.32
+    })
+  };
+  chairMaterialCache.set(key, materials);
+  return materials;
+}
+
+export function createDominoChair(option = DEFAULT_DOMINO_CHAIR_OPTION, renderer, sharedMaterials = null) {
+  const materials = sharedMaterials ?? getDominoChairMaterials(renderer, option);
+  const group = new THREE.Group();
+  const dims = CHAIR_DIMENSIONS;
+
+  const base = new THREE.Mesh(new THREE.CylinderGeometry(dims.baseRadius, dims.baseRadius * 1.02, dims.baseThickness, 32), materials.leg);
+  base.position.y = dims.baseThickness / 2;
+  base.castShadow = true;
+  base.receiveShadow = true;
+  group.add(base);
+
+  const column = new THREE.Mesh(
+    new THREE.CylinderGeometry(dims.columnRadiusBottom, dims.columnRadiusTop, dims.columnHeight, 24),
+    materials.leg
+  );
+  column.position.y = dims.baseThickness + dims.columnHeight / 2;
+  column.castShadow = true;
+  column.receiveShadow = true;
+  group.add(column);
+
+  const footRing = new THREE.Mesh(new THREE.TorusGeometry(dims.footRingRadius, dims.footRingTube, 16, 48), materials.accent);
+  footRing.rotation.x = Math.PI / 2;
+  footRing.position.y = dims.baseThickness + dims.columnHeight * 0.45;
+  footRing.castShadow = true;
+  group.add(footRing);
+
+  const seat = new THREE.Mesh(
+    new THREE.BoxGeometry(dims.seatWidth, dims.seatThickness, dims.seatDepth),
+    materials.fabric
+  );
+  seat.position.y = dims.baseThickness + dims.columnHeight + dims.seatThickness / 2;
+  seat.castShadow = true;
+  seat.receiveShadow = true;
+  group.add(seat);
+
+  const cushion = new THREE.Mesh(
+    new THREE.BoxGeometry(dims.seatWidth * 0.92, dims.seatThickness * 0.6, dims.seatDepth * 0.92),
+    materials.fabric
+  );
+  cushion.position.y = seat.position.y + dims.seatThickness * 0.2;
+  cushion.castShadow = true;
+  cushion.receiveShadow = true;
+  group.add(cushion);
+
+  const back = new THREE.Mesh(
+    new THREE.BoxGeometry(dims.seatWidth * 0.98, dims.backHeight, dims.backThickness),
+    materials.fabric
+  );
+  back.position.set(0, seat.position.y + dims.backHeight / 2 - dims.seatThickness / 2, dims.seatDepth / 2 - dims.backThickness / 2);
+  back.castShadow = true;
+  back.receiveShadow = true;
+  group.add(back);
+
+  const armGeo = new THREE.BoxGeometry(dims.armThickness, dims.armHeight, dims.armDepth);
+  const armY = seat.position.y + dims.armHeight / 2 - dims.seatThickness * 0.25;
+  const armOffsetZ = (dims.armDepth - dims.seatDepth) / 2;
+
+  const armLeft = new THREE.Mesh(armGeo, materials.fabric);
+  armLeft.position.set(-dims.seatWidth / 2 + dims.armThickness / 2, armY, armOffsetZ);
+  armLeft.castShadow = true;
+  armLeft.receiveShadow = true;
+  group.add(armLeft);
+
+  const armRight = new THREE.Mesh(armGeo, materials.fabric);
+  armRight.position.set(dims.seatWidth / 2 - dims.armThickness / 2, armY, armOffsetZ);
+  armRight.castShadow = true;
+  armRight.receiveShadow = true;
+  group.add(armRight);
+
+  const armCapGeo = new THREE.BoxGeometry(dims.armThickness * 0.9, dims.armThickness * 0.35, dims.armDepth * 0.92);
+  const armCapY = armY + dims.armHeight / 2 - (dims.armThickness * 0.35) / 2;
+
+  const armCapLeft = new THREE.Mesh(armCapGeo, materials.fabric);
+  armCapLeft.position.set(armLeft.position.x, armCapY, armOffsetZ * 0.94);
+  armCapLeft.castShadow = true;
+  armCapLeft.receiveShadow = true;
+  group.add(armCapLeft);
+
+  const armCapRight = new THREE.Mesh(armCapGeo, materials.fabric);
+  armCapRight.position.set(armRight.position.x, armCapY, armOffsetZ * 0.94);
+  armCapRight.castShadow = true;
+  armCapRight.receiveShadow = true;
+  group.add(armCapRight);
+
+  const columnCap = new THREE.Mesh(new THREE.CylinderGeometry(dims.columnRadiusTop * 1.05, dims.columnRadiusTop * 1.05, 0.02, 24), materials.accent);
+  columnCap.position.y = dims.baseThickness + dims.columnHeight + 0.01;
+  columnCap.castShadow = true;
+  columnCap.receiveShadow = true;
+  group.add(columnCap);
+
+  return group;
+}
+
+function roundedRectShape(hw = 0.95, hh = 0.95, r = 0.06) {
+  const s = new THREE.Shape();
+  s.moveTo(-hw + r, -hh);
+  s.lineTo(hw - r, -hh);
+  s.quadraticCurveTo(hw, -hh, hw, -hh + r);
+  s.lineTo(hw, hh - r);
+  s.quadraticCurveTo(hw, hh, hw - r, hh);
+  s.lineTo(-hw + r, hh);
+  s.quadraticCurveTo(-hw, hh, -hw, hh - r);
+  s.lineTo(-hw, -hh + r);
+  s.quadraticCurveTo(-hw, -hh, -hw + r, -hh);
+  return s;
+}
+
+function makeClothTexture(color = '#155c2a', renderer) {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const canvas = document.createElement('canvas');
+  const size = 512;
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, size, size);
+  ctx.globalAlpha = 0.08;
+  ctx.fillStyle = '#ffffff';
+  for (let i = 0; i < size; i += 6) {
+    ctx.fillRect(i, 0, 1, size);
+    ctx.fillRect(0, i, size, 1);
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(5, 5);
+  texture.anisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 8;
+  if ('colorSpace' in texture) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  }
+  return texture;
+}
+
+function disposeMaterial(material, { disposeMap = true } = {}) {
+  if (!material) return;
+  if (disposeMap && material.map?.dispose) {
+    material.map.dispose();
+  }
+  if (disposeMap && material.bumpMap?.dispose) {
+    material.bumpMap.dispose();
+  }
+  material.dispose?.();
+}
+
+export function createDominoPokerTable({ THREE: ThreeRef = THREE, renderer, scale = 1 } = {}) {
+  const tableGroup = new ThreeRef.Group();
+  const disposeItems = [];
+
+  const wood = new ThreeRef.MeshStandardMaterial({ color: '#5a3a19', roughness: 0.55, metalness: 0.08 });
+  const woodDark = new ThreeRef.MeshStandardMaterial({ color: '#4a3115', roughness: 0.7, metalness: 0.05 });
+  const feltTexture = makeClothTexture('#155c2a', renderer);
+  const felt = new ThreeRef.MeshStandardMaterial({ color: '#155c2a', map: feltTexture, roughness: 1, metalness: 0 });
+  const baseGreen = new ThreeRef.MeshStandardMaterial({ color: '#0f3e2d', roughness: 0.85, metalness: 0.05 });
+
+  disposeItems.push(() => disposeMaterial(wood));
+  disposeItems.push(() => disposeMaterial(woodDark));
+  disposeItems.push(() => disposeMaterial(felt));
+  disposeItems.push(() => disposeMaterial(baseGreen));
+
+  const Y = 0.64;
+  const OUT_HW = 0.95;
+  const IN_HW = 0.76;
+  const CLOTH_HW = 0.7;
+  const RIM_H = 0.07;
+  const clothTop = Y + 0.022;
+
+  {
+    const geo = new ThreeRef.ExtrudeGeometry(roundedRectShape(OUT_HW, OUT_HW, 0.06), {
+      depth: 0.02,
+      bevelEnabled: true,
+      bevelThickness: 0.012,
+      bevelSize: 0.012
+    });
+    geo.rotateX(-Math.PI / 2);
+    const mesh = new ThreeRef.Mesh(geo, wood);
+    mesh.position.y = Y;
+    mesh.castShadow = true;
+    tableGroup.add(mesh);
+    disposeItems.push(() => geo.dispose());
+  }
+
+  {
+    const geo = new ThreeRef.ExtrudeGeometry(roundedRectShape(CLOTH_HW, CLOTH_HW, 0.04), {
+      depth: 0.012,
+      bevelEnabled: false
+    });
+    geo.rotateX(-Math.PI / 2);
+    const mesh = new ThreeRef.Mesh(geo, felt);
+    mesh.position.y = clothTop;
+    mesh.receiveShadow = true;
+    tableGroup.add(mesh);
+    disposeItems.push(() => geo.dispose());
+  }
+
+  {
+    const outer = roundedRectShape(OUT_HW, OUT_HW, 0.06);
+    const inner = roundedRectShape(IN_HW, IN_HW, 0.05);
+    outer.holes.push(inner);
+    const geo = new ThreeRef.ExtrudeGeometry(outer, {
+      depth: RIM_H,
+      bevelEnabled: true,
+      bevelThickness: 0.02,
+      bevelSize: 0.02
+    });
+    geo.rotateX(-Math.PI / 2);
+    const mesh = new ThreeRef.Mesh(geo, woodDark);
+    mesh.position.y = Y + 0.02;
+    mesh.castShadow = true;
+    tableGroup.add(mesh);
+    disposeItems.push(() => geo.dispose());
+  }
+
+  {
+    const skirtH = 0.6;
+    const geo = new ThreeRef.BoxGeometry((OUT_HW + 0.05) * 2, skirtH, (OUT_HW + 0.05) * 2);
+    const mesh = new ThreeRef.Mesh(geo, baseGreen);
+    mesh.position.y = Y - skirtH / 2 + 0.01;
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    tableGroup.add(mesh);
+    disposeItems.push(() => geo.dispose());
+  }
+
+  tableGroup.scale.setScalar(scale);
+  const surfaceY = clothTop * scale;
+  const clothDiameter = CLOTH_HW * 2 * scale;
+  const chairRadius = (OUT_HW + 0.55) * scale;
+  const chairLookTargetY = (CHAIR_DIMENSIONS.baseThickness + CHAIR_DIMENSIONS.columnHeight + CHAIR_DIMENSIONS.seatThickness) * scale;
+
+  return {
+    group: tableGroup,
+    surfaceY,
+    clothDiameter,
+    radius: OUT_HW * scale,
+    chairRadius,
+    chairLookTargetY,
+    scale,
+    dispose: () => {
+      disposeItems.forEach((fn) => fn?.());
+    }
+  };
+}
+
+export function createDominoChairRing({
+  THREE: ThreeRef = THREE,
+  renderer,
+  radius,
+  lookTargetY,
+  option = DEFAULT_DOMINO_CHAIR_OPTION,
+  seatCount = 4,
+  scale = 1
+}) {
+  const sharedMaterials = getDominoChairMaterials(renderer, option);
+  const chairs = [];
+  const lookTarget = new ThreeRef.Vector3(0, lookTargetY, 0);
+
+  for (let i = 0; i < seatCount; i++) {
+    const angle = (i / seatCount) * Math.PI * 2;
+    const x = Math.sin(angle) * radius;
+    const z = Math.cos(angle) * radius;
+    const chair = createDominoChair(option, renderer, sharedMaterials);
+    chair.scale.setScalar(scale);
+    chair.position.set(x, 0, z);
+    chair.lookAt(lookTarget);
+    chair.rotateY(Math.PI);
+    chairs.push(chair);
+  }
+
+  return { chairs };
+}
+
+export function decorateDominoArenaEnvelope({ THREE: ThreeRef = THREE, arena, renderer }) {
+  const carpetMat = createDominoCarpetMaterial(renderer);
+  const carpetGeo = new ThreeRef.BoxGeometry(
+    DOMINO_ROOM.width - DOMINO_ROOM.wallThickness,
+    DOMINO_ROOM.carpetThickness,
+    DOMINO_ROOM.depth - DOMINO_ROOM.wallThickness
+  );
+  const carpet = new ThreeRef.Mesh(carpetGeo, carpetMat);
+  carpet.position.y = -DOMINO_ROOM.carpetThickness / 2;
+  carpet.receiveShadow = true;
+  arena.add(carpet);
+
+  const wallMat = new ThreeRef.MeshStandardMaterial({
+    color: 0xb9ddff,
+    roughness: 0.88,
+    metalness: 0.06
+  });
+
+  const makeWall = (width, height, depth) => {
+    const geo = new ThreeRef.BoxGeometry(width, height, depth);
+    const mesh = new ThreeRef.Mesh(geo, wallMat);
+    mesh.position.y = height / 2;
+    mesh.receiveShadow = true;
+    arena.add(mesh);
+    return { mesh, geo };
+  };
+
+  const walls = [];
+  walls.push(makeWall(DOMINO_ROOM.width, DOMINO_ROOM.wallHeight, DOMINO_ROOM.wallThickness));
+  walls[walls.length - 1].mesh.position.z = DOMINO_ROOM.depth / 2 - DOMINO_ROOM.wallThickness / 2;
+  walls.push(makeWall(DOMINO_ROOM.width, DOMINO_ROOM.wallHeight, DOMINO_ROOM.wallThickness));
+  walls[walls.length - 1].mesh.position.z = -DOMINO_ROOM.depth / 2 + DOMINO_ROOM.wallThickness / 2;
+  walls.push(makeWall(DOMINO_ROOM.wallThickness, DOMINO_ROOM.wallHeight, DOMINO_ROOM.depth));
+  walls[walls.length - 1].mesh.position.x = -DOMINO_ROOM.width / 2 + DOMINO_ROOM.wallThickness / 2;
+  walls.push(makeWall(DOMINO_ROOM.wallThickness, DOMINO_ROOM.wallHeight, DOMINO_ROOM.depth));
+  walls[walls.length - 1].mesh.position.x = DOMINO_ROOM.width / 2 - DOMINO_ROOM.wallThickness / 2;
+
+  return {
+    carpet,
+    walls: walls.map((w) => w.mesh),
+    dispose: () => {
+      carpetGeo.dispose();
+      disposeMaterial(carpetMat, { disposeMap: false });
+      walls.forEach(({ geo }) => geo.dispose());
+      disposeMaterial(wallMat, { disposeMap: false });
+    }
+  };
+}
+
+export const DOMINO_ROOM_DIMENSIONS = DOMINO_ROOM;
+export const DOMINO_CHAIR_DIMENSIONS = CHAIR_DIMENSIONS;


### PR DESCRIPTION
## Summary
- add a dominoArenaAssets helper with reusable carpet, wall, table, chair, and camera defaults
- restyle the Ludo Battle Royal arena to reuse the Domino Royal scenery, furniture, and camera behaviour
- restyle the Snake & Ladder 3D arena to match Domino Royal, including table scaling and camera tuning

## Testing
- npm run lint *(fails: repo-wide lint issues unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68f3a709060c832999f41b425117a7fa