### PR TITLE
Restore Pool Royale chrome and pocket geometry to 1:45 PM baseline

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -189,10 +189,10 @@ function adjustSideNotchDepth(mp) {
 const POCKET_VISUAL_EXPANSION = 1.05;
 const CHROME_CORNER_POCKET_RADIUS_SCALE = 1;
 const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.16;
-const CHROME_CORNER_EXPANSION_SCALE = 1.08; // push the chrome slightly farther along the long rails so the plates hug the cushions
-const CHROME_CORNER_SIDE_EXPANSION_SCALE = 1.01; // nudge the chrome farther along the short rails for better pocket coverage
+const CHROME_CORNER_EXPANSION_SCALE = 1.036; // tuck the chrome just shy of the rail edge so it no longer overlaps the wood caps
+const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.998; // keep the short-rail chrome aligned without spilling over the cushion edge
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015; // widen the notch slightly to remove leftover chrome wedges at the pocket corners
-const CHROME_CORNER_FIELD_TRIM_SCALE = 0;
+const CHROME_CORNER_FIELD_TRIM_SCALE = 0.012; // shave a sliver off the field side so the chrome sits cleanly against the rail
 const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
 const WOOD_RAIL_CORNER_RADIUS_SCALE = 0;
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.82; // match the snooker side pocket throat profile
@@ -200,14 +200,14 @@ const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85; // align the notch opening height w
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1; // use the standard rounding to mirror the snooker side pocket arches
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1; // keep the throat depth consistent with the snooker chrome plates
 const CHROME_SIDE_FIELD_PULL_SCALE = 0; // remove the forward pull so the plates sit flush like the snooker middle pockets
-const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.9; // widen the field-side trim to scoop out the lingering chrome wedge
-const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.1; // push the trim deeper along the short rail so the notch fully clears the plate
+const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 1.28; // carve a deeper wedge so no chrome lingers on the field side of the pocket
+const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.18; // run the trim farther down the short rail to keep the notch flush with the cushion
 const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.72; // widen the side plates a touch more toward the short rails
-const CHROME_SIDE_PLATE_RAIL_INSET_SCALE = 0.02; // align the side plate inset with the snooker chrome placement
+const CHROME_SIDE_PLATE_RAIL_INSET_SCALE = 0.038; // pull the side plates inward so they clear the rail caps on mobile
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.05; // push the middle chrome slightly farther so it wraps the rail sides
-const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.045; // extend the center trim span so the chrome fully blankets the rail caps
-const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.012; // widen the side plates a touch toward each pocket for better coverage
-const RAIL_POCKET_CUT_SCALE = 0.97; // slightly tighten the wooden rail pocket cuts to match the smaller pocket mouths
+const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.058; // tighten the middle trim so the chrome reveals the rail shoulders cleanly
+const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.008; // leave a slim gap near each pocket to avoid chrome overlap on the cloth
+const RAIL_POCKET_CUT_SCALE = 0.965; // tighten the wooden rail pocket cuts a touch more so the wood fully wraps the pocket mouths
 
 function buildChromePlateGeometry({
   width,
@@ -3948,7 +3948,7 @@ function Table3D(
     0,
     railsTopY - (clothPlaneLocal - CLOTH_DROP) + MICRO_EPS * 6
   ); // extend the pocket arches until they meet the lowered cloth plane
-  const chromePlateThickness = railH * 0.16; // deepen the corner chrome so it blankets the rail sides and pocket cuts
+  const chromePlateThickness = railH * 0.17; // deepen the corner chrome so it blankets the rail sides and pocket cuts
   const sideChromePlateThickness = Math.min(
     railH * 0.92,
     Math.max(chromePlateThickness, chromePocketCoverageDepth)


### PR DESCRIPTION
## Summary
- restore Pool Royale chrome plate expansion and trim constants to the 1:45 PM baseline values
- revert the corner chrome plate thickness to match the earlier geometry alignment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3aa228e30832980a8334ed3b4ee6c