### PR TITLE
Add 10ft Pool Royale table size with responsive scaling

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -1,0 +1,27 @@
+export const TABLE_SIZE_OPTIONS = Object.freeze({
+  '9ft': {
+    id: '9ft',
+    label: '9 ft',
+    scale: 1.44,
+    mobileScale: 1.44,
+    compactScale: 1.44
+  },
+  '10ft': {
+    id: '10ft',
+    label: '10 ft',
+    scale: 1.6,
+    mobileScale: 1.44,
+    compactScale: 1.36
+  }
+});
+
+export const DEFAULT_TABLE_SIZE_ID = '9ft';
+
+export function resolveTableSize(sizeId) {
+  const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';
+  return TABLE_SIZE_OPTIONS[key] || TABLE_SIZE_OPTIONS[DEFAULT_TABLE_SIZE_ID];
+}
+
+export const TABLE_SIZE_LIST = Object.freeze(
+  Object.values(TABLE_SIZE_OPTIONS).map(({ id, label }) => ({ id, label }))
+);

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -10,6 +10,10 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import {
+  TABLE_SIZE_LIST,
+  resolveTableSize
+} from '../../config/poolRoyaleTables.js';
 
 export default function PoolRoyaleLobby() {
   const navigate = useNavigate();
@@ -20,7 +24,10 @@ export default function PoolRoyaleLobby() {
   const [mode, setMode] = useState('ai');
   const [avatar, setAvatar] = useState('');
   const [variant, setVariant] = useState('uk');
-  const tableSize = '9ft';
+  const [tableSize, setTableSize] = useState(() => {
+    const params = new URLSearchParams(search);
+    return resolveTableSize(params.get('tableSize')).id;
+  });
   const [playType, setPlayType] = useState('regular');
 
   useEffect(() => {
@@ -29,6 +36,12 @@ export default function PoolRoyaleLobby() {
       setAvatar(saved || getTelegramPhotoUrl());
     } catch {}
   }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    const resolved = resolveTableSize(params.get('tableSize')).id;
+    setTableSize((prev) => (prev === resolved ? prev : resolved));
+  }, [search]);
 
   const startGame = async () => {
     let tgId;
@@ -147,6 +160,20 @@ export default function PoolRoyaleLobby() {
               key={id}
               onClick={() => setVariant(id)}
               className={`lobby-tile ${variant === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Table Size</h3>
+        <div className="flex flex-wrap gap-2">
+          {TABLE_SIZE_LIST.map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setTableSize(id)}
+              className={`lobby-tile ${tableSize === id ? 'lobby-selected' : ''}`}
             >
               {label}
             </button>


### PR DESCRIPTION
## Summary
- add a shared Pool Royale table size configuration including a new 10 ft option
- apply responsive table scaling and world resizes inside the Pool Royale scene
- expose the table size selector in the Pool Royale lobby so players can choose

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f3b27da99c8329b83ccdcc32a7bb6d