### PR TITLE
Add official 8ft Pool Royale table option

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -1,19 +1,94 @@
-export const TABLE_SIZE_OPTIONS = Object.freeze({
+const BASE_TABLE_SCALE = 1.44;
+const BASE_TABLE_MOBILE_SCALE = 1.44;
+const BASE_TABLE_COMPACT_SCALE = 1.44;
+const BASE_PLAYFIELD_WIDTH_MM = 2540; // WPA 9 ft playing surface width (100")
+
+const TABLE_PHYSICAL_SPECS = Object.freeze({
+  '8ft': {
+    id: '8ft',
+    label: '8 ft',
+    playfield: Object.freeze({ widthMm: 2235, heightMm: 1118 }), // 88" × 44"
+    ballDiameterMm: 57.15,
+    pocketMouthMm: Object.freeze({
+      corner: 114.3,
+      side: 127
+    }),
+    cushionCutAngleDeg: 32,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
+  },
   '9ft': {
     id: '9ft',
     label: '9 ft',
-    scale: 1.44,
-    mobileScale: 1.44,
-    compactScale: 1.44
+    playfield: Object.freeze({ widthMm: 2540, heightMm: 1270 }), // 100" × 50"
+    ballDiameterMm: 57.15,
+    pocketMouthMm: Object.freeze({
+      corner: 114.3,
+      side: 127
+    }),
+    cushionCutAngleDeg: 32,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
+    scaleOverrides: Object.freeze({
+      scale: BASE_TABLE_SCALE,
+      mobileScale: BASE_TABLE_MOBILE_SCALE,
+      compactScale: BASE_TABLE_COMPACT_SCALE
+    })
   },
   '10ft': {
     id: '10ft',
     label: '10 ft',
-    scale: 1.6,
-    mobileScale: 1.44,
-    compactScale: 1.36
+    playfield: Object.freeze({ widthMm: 2845, heightMm: 1422 }), // 112" × 56"
+    ballDiameterMm: 57.15,
+    pocketMouthMm: Object.freeze({
+      corner: 114.3,
+      side: 127
+    }),
+    cushionCutAngleDeg: 32,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
+    scaleOverrides: Object.freeze({
+      scale: 1.6,
+      mobileScale: 1.44,
+      compactScale: 1.36
+    })
   }
 });
+
+function deriveScale(playfieldWidthMm, baseScale = BASE_TABLE_SCALE) {
+  if (!Number.isFinite(playfieldWidthMm) || playfieldWidthMm <= 0) {
+    return baseScale;
+  }
+  return baseScale * (playfieldWidthMm / BASE_PLAYFIELD_WIDTH_MM);
+}
+
+function deriveMobileScale(baseScale, mobileScale = BASE_TABLE_MOBILE_SCALE) {
+  const scaled = baseScale * 1.02;
+  const clampTarget = Math.max(baseScale, mobileScale);
+  return Math.min(clampTarget, scaled);
+}
+
+function deriveCompactScale(baseScale, compactScale = BASE_TABLE_COMPACT_SCALE) {
+  const scaled = baseScale * 0.94;
+  return Math.max(1.1, Math.min(compactScale, scaled));
+}
+
+export const TABLE_SIZE_OPTIONS = Object.freeze(
+  Object.keys(TABLE_PHYSICAL_SPECS).reduce((acc, key) => {
+    const spec = TABLE_PHYSICAL_SPECS[key];
+    const overrides = spec.scaleOverrides || {};
+    const baseScale =
+      overrides.scale ?? deriveScale(spec.playfield.widthMm);
+    const mobileScale =
+      overrides.mobileScale ?? deriveMobileScale(baseScale);
+    const compactScale =
+      overrides.compactScale ?? deriveCompactScale(baseScale);
+    acc[key] = Object.freeze({
+      ...spec,
+      scale: Number(baseScale.toFixed(3)),
+      mobileScale: Number(mobileScale.toFixed(3)),
+      compactScale: Number(compactScale.toFixed(3))
+    });
+    return acc;
+  }, {})
+);
 
 export const DEFAULT_TABLE_SIZE_ID = '9ft';
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -739,7 +739,7 @@ const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.6;
 const SIDE_SPIN_MULTIPLIER = 1.25;
 const BACKSPIN_MULTIPLIER = 1.7 * 1.25 * 1.5;
 const TOPSPIN_MULTIPLIER = 1.3;
-// angle for cushion cuts guiding balls into pockets
+// angle for cushion cuts guiding balls into pockets (WPA K-55 profile ≈32°)
 const CUSHION_CUT_ANGLE = 32;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
 const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.09; // pull cushions slightly closer to centre for a tighter pocket entry
@@ -8796,6 +8796,17 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       if (table?.userData) {
         const cushionLip = table.userData.cushionTopLocal ?? TABLE.THICK;
         cushionHeightRef.current = Math.max(TABLE.THICK + 0.1, cushionLip - 0.02);
+        const tableSizeMeta = tableSizeRef.current;
+        if (tableSizeMeta) {
+          table.userData.officialSpec = {
+            id: tableSizeMeta.id,
+            playfield: tableSizeMeta.playfield,
+            ballDiameterMm: tableSizeMeta.ballDiameterMm,
+            pocketMouthMm: tableSizeMeta.pocketMouthMm,
+            cushionCutAngleDeg: tableSizeMeta.cushionCutAngleDeg,
+            cushionPocketAnglesDeg: tableSizeMeta.cushionPocketAnglesDeg
+          };
+        }
       }
       // ensure the camera respects the configured zoom limits
       sph.radius = clampOrbitRadius(sph.radius);


### PR DESCRIPTION
## Summary
- add an official 8-foot Pool Royale table option with scaled mobile and compact factors derived from WPA dimensions
- expose the table size metadata on the 3D table instance so gameplay logic can reference the official measurements
- document the cushion cut angle to highlight the official K-55 profile used by all table sizes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3bb1ad6d48329bbca8c667d474d59