### PR TITLE
Update Pool Royale 10ft table specs

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -36,18 +36,21 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
   '10ft': {
     id: '10ft',
     label: '10 ft',
-    playfield: Object.freeze({ widthMm: 2845, heightMm: 1422 }), // 112" × 56"
-    ballDiameterMm: 57.15,
+    // WPA tournament specification for the 10 ft × 5 ft playing surface
+    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 120" × 60"
+    ballDiameterMm: 57.15, // reuse the official 2 1/4" pool balls (same as 8 ft spec)
     pocketMouthMm: Object.freeze({
       corner: 114.3,
       side: 127
     }),
     cushionCutAngleDeg: 32,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
+    cushionRestitution: 0.965,
+    componentPreset: 'snookerFrame',
     scaleOverrides: Object.freeze({
-      scale: 1.6,
-      mobileScale: 1.44,
-      compactScale: 1.36
+      scale: Number((BASE_TABLE_SCALE * (3048 / BASE_PLAYFIELD_WIDTH_MM)).toFixed(3)),
+      mobileScale: Number((BASE_TABLE_MOBILE_SCALE * (3048 / BASE_PLAYFIELD_WIDTH_MM)).toFixed(3)),
+      compactScale: Number((BASE_TABLE_COMPACT_SCALE * (3048 / BASE_PLAYFIELD_WIDTH_MM)).toFixed(3))
     })
   }
 });


### PR DESCRIPTION
## Summary
- update the Pool Royale 10 ft table metadata to the WPA 120" × 60" surface while reusing the official 8 ft pocket and ball sizing
- tag the 10 ft entry with the snooker-frame preset and an official-style cushion restitution to drive physics tuning
- apply table-specific physics metadata when constructing the 3D table so the active specification informs cushion behaviour

## Testing
- npm run lint *(fails: repository has existing lint violations in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68f3c16d7efc83299035d6691135806a