### PR TITLE
Default Pool Royale lobby to the 8ft table

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -15,43 +15,6 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     }),
     cushionCutAngleDeg: 32,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
-  },
-  '9ft': {
-    id: '9ft',
-    label: '9 ft',
-    playfield: Object.freeze({ widthMm: 2540, heightMm: 1270 }), // 100" × 50"
-    ballDiameterMm: 57.15,
-    pocketMouthMm: Object.freeze({
-      corner: 114.3,
-      side: 127
-    }),
-    cushionCutAngleDeg: 32,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
-    scaleOverrides: Object.freeze({
-      scale: BASE_TABLE_SCALE,
-      mobileScale: BASE_TABLE_MOBILE_SCALE,
-      compactScale: BASE_TABLE_COMPACT_SCALE
-    })
-  },
-  '10ft': {
-    id: '10ft',
-    label: '10 ft',
-    // WPA tournament specification for the 10 ft × 5 ft playing surface
-    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 120" × 60"
-    ballDiameterMm: 57.15, // reuse the official 2 1/4" pool balls (same as 8 ft spec)
-    pocketMouthMm: Object.freeze({
-      corner: 114.3,
-      side: 127
-    }),
-    cushionCutAngleDeg: 32,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
-    cushionRestitution: 0.965,
-    componentPreset: 'snookerFrame',
-    scaleOverrides: Object.freeze({
-      scale: Number((BASE_TABLE_SCALE * (3048 / BASE_PLAYFIELD_WIDTH_MM)).toFixed(3)),
-      mobileScale: Number((BASE_TABLE_MOBILE_SCALE * (3048 / BASE_PLAYFIELD_WIDTH_MM)).toFixed(3)),
-      compactScale: Number((BASE_TABLE_COMPACT_SCALE * (3048 / BASE_PLAYFIELD_WIDTH_MM)).toFixed(3))
-    })
   }
 });
 
@@ -93,7 +56,7 @@ export const TABLE_SIZE_OPTIONS = Object.freeze(
   }, {})
 );
 
-export const DEFAULT_TABLE_SIZE_ID = '9ft';
+export const DEFAULT_TABLE_SIZE_ID = '8ft';
 
 export function resolveTableSize(sizeId) {
   const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -10,10 +10,7 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
-import {
-  TABLE_SIZE_LIST,
-  resolveTableSize
-} from '../../config/poolRoyaleTables.js';
+import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 
 export default function PoolRoyaleLobby() {
   const navigate = useNavigate();
@@ -24,10 +21,8 @@ export default function PoolRoyaleLobby() {
   const [mode, setMode] = useState('ai');
   const [avatar, setAvatar] = useState('');
   const [variant, setVariant] = useState('uk');
-  const [tableSize, setTableSize] = useState(() => {
-    const params = new URLSearchParams(search);
-    return resolveTableSize(params.get('tableSize')).id;
-  });
+  const searchParams = new URLSearchParams(search);
+  const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
   const [playType, setPlayType] = useState('regular');
 
   useEffect(() => {
@@ -36,12 +31,6 @@ export default function PoolRoyaleLobby() {
       setAvatar(saved || getTelegramPhotoUrl());
     } catch {}
   }, []);
-
-  useEffect(() => {
-    const params = new URLSearchParams(search);
-    const resolved = resolveTableSize(params.get('tableSize')).id;
-    setTableSize((prev) => (prev === resolved ? prev : resolved));
-  }, [search]);
 
   const startGame = async () => {
     let tgId;
@@ -93,7 +82,7 @@ export default function PoolRoyaleLobby() {
     navigate(`/games/pollroyale?${params.toString()}`);
   };
 
-  const winnerParam = new URLSearchParams(search).get('winner');
+  const winnerParam = searchParams.get('winner');
 
   return (
     <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
@@ -160,20 +149,6 @@ export default function PoolRoyaleLobby() {
               key={id}
               onClick={() => setVariant(id)}
               className={`lobby-tile ${variant === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-      </div>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Table Size</h3>
-        <div className="flex flex-wrap gap-2">
-          {TABLE_SIZE_LIST.map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setTableSize(id)}
-              className={`lobby-tile ${tableSize === id ? 'lobby-selected' : ''}`}
             >
               {label}
             </button>


### PR DESCRIPTION
## Summary
- remove the 9ft and 10ft Pool Royale table specifications so only the 8ft table remains available
- default the Pool Royale lobby to use the resolved table size without exposing a table size selector

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f3c52bd5b883299c141a164ea6ac18