### PR TITLE
Tighten wooden rail pocket cutouts

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -201,8 +201,8 @@ const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.82;
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85;
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1;
-const WOOD_CORNER_CUT_SCALE = 0.993; // tighten wooden rail corner cutouts to better match the chrome plates
-const WOOD_SIDE_CUT_SCALE = 0.995; // gently shrink side pocket cutouts on the wooden rails
+const WOOD_CORNER_CUT_SCALE = 0.985; // tighten wooden rail corner cutouts further so the chrome notches stay fully covered
+const WOOD_SIDE_CUT_SCALE = 0.99; // shrink side pocket cutouts so the wooden rails wrap cleanly around the pocket entries
 
 function buildChromePlateGeometry({
   width,


### PR DESCRIPTION
## Summary
- tighten the wooden corner rail cutouts so chrome pocket plates remain fully covered
- shrink the side pocket rail cutouts to keep the wood rails hugging the pocket entries

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3d13410e88329800021075e699033