### PR TITLE
Adjust Pool Royale table detailing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -202,14 +202,14 @@ function adjustSideNotchDepth(mp) {
 const POCKET_VISUAL_EXPANSION = 1.05;
 const CHROME_CORNER_POCKET_RADIUS_SCALE = 1;
 const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.16;
-const CHROME_CORNER_EXPANSION_SCALE = 1.012; // trim the chrome width slightly so it eases back toward the rail edges
-const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.982; // pull the short-rail chrome in a touch more to match the tightened rail cuts
+const CHROME_CORNER_EXPANSION_SCALE = 1.004; // trim the chrome width slightly so it eases back toward the rail edges
+const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.968; // pull the short-rail chrome in a touch more to match the tightened rail cuts
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 0.985; // narrow the notch further so the chrome corner cut mirrors the smaller rail opening
 const CHROME_CORNER_FIELD_TRIM_SCALE = 0.012; // shave a sliver off the field side so the chrome sits cleanly against the rail
 const CHROME_SIDE_POCKET_RADIUS_SCALE = 1.02;
 const WOOD_RAIL_CORNER_RADIUS_SCALE = 0;
-const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.905; // open the side chrome throat a touch more to mirror the larger middle rail cuts
-const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.872; // align the notch opening height with the snooker middle pockets
+const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.942; // open the side chrome throat a touch more to mirror the larger middle rail cuts
+const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.894; // align the notch opening height with the snooker middle pockets
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1; // use the standard rounding to mirror the snooker side pocket arches
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1; // keep the throat depth consistent with the snooker chrome plates
 const CHROME_SIDE_FIELD_PULL_SCALE = 0; // remove the forward pull so the plates sit flush like the snooker middle pockets
@@ -221,7 +221,7 @@ const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.05; // push the middle chrome slightly 
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.058; // tighten the middle trim so the chrome reveals the rail shoulders cleanly
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.008; // leave a slim gap near each pocket to avoid chrome overlap on the cloth
 const RAIL_CORNER_POCKET_CUT_SCALE = 0.925; // tighten the corner rail pocket cuts further so the curved openings read smaller
-const RAIL_SIDE_POCKET_CUT_SCALE = 1.052; // relax the side pocket cuts a bit more so the middle openings grow larger
+const RAIL_SIDE_POCKET_CUT_SCALE = 1.078; // relax the side pocket cuts a bit more so the middle openings grow larger
 
 function buildChromePlateGeometry({
   width,
@@ -492,9 +492,10 @@ const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
 const POCKET_CORNER_MOUTH_SCALE = 1.005; // open the corner pockets a touch more while keeping clear of the chrome
+const SIDE_POCKET_MOUTH_SHRINK = 0.962; // gently tighten the middle pocket opening so it reads smaller than the corners
 const POCKET_SIDE_MOUTH_SCALE =
-  (CORNER_MOUTH_REF * POCKET_CORNER_MOUTH_SCALE) /
-  SIDE_MOUTH_REF; // match the middle pocket mouth width to the corners
+  ((CORNER_MOUTH_REF * POCKET_CORNER_MOUTH_SCALE) / SIDE_MOUTH_REF) *
+  SIDE_POCKET_MOUTH_SHRINK; // keep proportions in sync with corners while trimming the middle mouth a touch
 const POCKET_CORNER_MOUTH =
   CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
 const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
@@ -3754,7 +3755,7 @@ function Table3D(
   );
   const clothExtend =
     clothExtendBase +
-    Math.min(PLAY_W, PLAY_H) * 0.0032; // extend the cloth slightly more so rails meet the cloth with no gaps
+    Math.min(PLAY_W, PLAY_H) * 0.0044; // extend the cloth slightly more so rails meet the cloth with no gaps
   const halfWext = halfW + clothExtend;
   const halfHext = halfH + clothExtend;
   const pocketPositions = pocketCenters();
@@ -3967,7 +3968,7 @@ function Table3D(
   });
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(woodRailSurface);
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
-  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.042; // push cushions slightly farther from the rails so they clear the wood trim
+  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.058; // push cushions slightly farther from the rails so they clear the wood trim
   const SHORT_CUSHION_HEIGHT_SCALE = 1.085; // raise short rail cushions to match the remaining four rails
   const railsGroup = new THREE.Group();
   finishParts.accentParent = railsGroup;


### PR DESCRIPTION
## Summary
- enlarge the side-rail pocket cutouts and matching chrome notches to better frame the middle pockets
- trim the corner chrome plates and pull every cushion slightly toward the playfield to avoid overlap with the wood rails
- expand the cloth surface and modestly tighten the middle pocket mouth to keep the playfield flush while preserving pocket placement

## Testing
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_68f467cefaa48329b15c027ea00426b3