### PR TITLE
Align Pool Royale cushions and corner trim

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3969,7 +3969,7 @@ function Table3D(
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
   const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.056; // pull cushions a touch farther toward centre so they no longer overlap the wood trim
   const SIDE_CUSHION_RAIL_REACH =
-    TABLE.THICK * 0.02; // push the long-rail cushions out just enough to kiss the side rails without crossing over
+    TABLE.THICK * 0.026; // push the long-rail cushions out far enough that they rest against the side rails without overlapping
   const SHORT_CUSHION_HEIGHT_SCALE = 1.085; // raise short rail cushions to match the remaining four rails
   const railsGroup = new THREE.Group();
   finishParts.accentParent = railsGroup;
@@ -4096,7 +4096,7 @@ function Table3D(
   const cornerPocketRadius = POCKET_VIS_R * 1.1 * POCKET_VISUAL_EXPANSION;
   const cornerChamfer = POCKET_VIS_R * 0.34 * POCKET_VISUAL_EXPANSION;
   const CORNER_NOTCH_EXTRA_INSET =
-    TABLE.THICK * 0.012; // tuck the chrome/rail corner cutouts slightly further inward to match the cloth pocket line
+    TABLE.THICK * 0.018; // move the chrome/rail corner cutouts a touch further toward centre to keep the curved trim aligned
   const cornerInset =
     POCKET_VIS_R * 0.58 * POCKET_VISUAL_EXPANSION +
     CORNER_POCKET_CENTER_INSET +


### PR DESCRIPTION
## Summary
- extend the long-rail cushion reach so the green cushions rest against the side rails
- shift the corner rail and chrome cutouts slightly inward to line up with the cloth

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f48edb3f8c8329b70d02c2cf49a80c