### PR TITLE
Adjust Pool Royale cushion alignment and corner cuts

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -204,7 +204,7 @@ const CHROME_CORNER_POCKET_RADIUS_SCALE = 1;
 const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.16;
 const CHROME_CORNER_EXPANSION_SCALE = 0.992; // shrink the corner chrome footprint so it hugs the rail faces more tightly
 const CHROME_CORNER_SIDE_EXPANSION_SCALE = 0.972; // trim the short-rail chrome to keep it well clear of the cushion edge
-const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 0.992; // narrow the notch so the chrome corner cut hugs the smaller rail opening
+const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 0.988; // narrow the notch so the chrome corner cut hugs the smaller rail opening
 const CHROME_CORNER_FIELD_TRIM_SCALE = 0.018; // shave a deeper sliver off the field side so the chrome sits cleanly against the rail
 const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
 const WOOD_RAIL_CORNER_RADIUS_SCALE = 0.22;
@@ -213,14 +213,14 @@ const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.872; // align the notch opening height 
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1; // use the standard rounding to mirror the snooker side pocket arches
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1; // keep the throat depth consistent with the snooker chrome plates
 const CHROME_SIDE_FIELD_PULL_SCALE = 0; // remove the forward pull so the plates sit flush like the snooker middle pockets
-const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 1.28; // carve a deeper wedge so no chrome lingers on the field side of the pocket
+const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 1.32; // carve a deeper wedge so no chrome lingers on the field side of the pocket
 const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.18; // run the trim farther down the short rail to keep the notch flush with the cushion
 const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.72; // widen the side plates a touch more toward the short rails
 const CHROME_SIDE_PLATE_RAIL_INSET_SCALE = 0.038; // pull the side plates inward so they clear the rail caps on mobile
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.05; // push the middle chrome slightly farther so it wraps the rail sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.058; // tighten the middle trim so the chrome reveals the rail shoulders cleanly
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.008; // leave a slim gap near each pocket to avoid chrome overlap on the cloth
-const RAIL_CORNER_POCKET_CUT_SCALE = 0.94; // tighten the corner rail pocket cuts further so the curved openings read smaller
+const RAIL_CORNER_POCKET_CUT_SCALE = 0.932; // tighten the corner rail pocket cuts further so the curved openings read smaller
 const RAIL_SIDE_POCKET_CUT_SCALE = 1.036; // relax the side pocket cuts a bit more so the middle openings grow larger
 
 function buildChromePlateGeometry({
@@ -3969,7 +3969,7 @@ function Table3D(
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
   const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.056; // pull cushions a touch farther toward centre so they no longer overlap the wood trim
   const SIDE_CUSHION_RAIL_REACH =
-    TABLE.THICK * 0.034; // push the long-rail cushions out far enough that they rest against the side rails without overlapping
+    TABLE.THICK * 0.038; // push the long-rail cushions out far enough that they rest against the side rails without overlapping
   const SHORT_CUSHION_HEIGHT_SCALE = 1.085; // raise short rail cushions to match the remaining four rails
   const railsGroup = new THREE.Group();
   finishParts.accentParent = railsGroup;


### PR DESCRIPTION
## Summary
- nudge the long-rail cushions outward so they meet the side rails cleanly
- pull the corner rail and chrome pocket cuts slightly inward to match the updated cushions
- expand the chrome corner field trim to prevent any chrome overlap on the playfield

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f497e7c16c8329977af4c13fe14139