### PR TITLE
Adjust Pool Royale pocket cut placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4104,12 +4104,12 @@ function Table3D(
   const cornerPocketRadius = POCKET_VIS_R * 1.1 * POCKET_VISUAL_EXPANSION;
   const cornerChamfer = POCKET_VIS_R * 0.34 * POCKET_VISUAL_EXPANSION;
   const CORNER_NOTCH_EXTRA_INSET =
-    TABLE.THICK * 0.041; // nudge the chrome/rail corner cutouts slightly further toward centre for tighter alignment
+    TABLE.THICK * 0.052; // push the chrome/rail corner cutouts a touch more toward centre for tighter alignment
   const cornerInset =
     POCKET_VIS_R * 0.58 * POCKET_VISUAL_EXPANSION +
     CORNER_POCKET_CENTER_INSET +
     CORNER_NOTCH_EXTRA_INSET;
-  const sideInset = SIDE_POCKET_RADIUS * 0.84 * POCKET_VISUAL_EXPANSION;
+  const sideInset = SIDE_POCKET_RADIUS * 0.828 * POCKET_VISUAL_EXPANSION; // ease the middle rail cuts outward so they sit closer to the side rails
 
   const circlePoly = (cx, cz, r, seg = 96) => {
     const pts = [];


### PR DESCRIPTION
## Summary
- shift the Pool Royale corner rail and chrome cutouts slightly toward the table centreline
- ease the middle pocket rail and chrome cuts outward so they sit closer to the side rails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4b335d29c8329aa6f77b110724927