### PR TITLE
Adjust Pool Royale pocket cut alignment

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4104,12 +4104,12 @@ function Table3D(
   const cornerPocketRadius = POCKET_VIS_R * 1.1 * POCKET_VISUAL_EXPANSION;
   const cornerChamfer = POCKET_VIS_R * 0.34 * POCKET_VISUAL_EXPANSION;
   const CORNER_NOTCH_EXTRA_INSET =
-    TABLE.THICK * 0.052; // push the chrome/rail corner cutouts a touch more toward centre for tighter alignment
+    TABLE.THICK * 0.062; // push the chrome/rail corner cutouts farther toward centre for tighter alignment
   const cornerInset =
     POCKET_VIS_R * 0.58 * POCKET_VISUAL_EXPANSION +
     CORNER_POCKET_CENTER_INSET +
     CORNER_NOTCH_EXTRA_INSET;
-  const sideInset = SIDE_POCKET_RADIUS * 0.828 * POCKET_VISUAL_EXPANSION; // ease the middle rail cuts outward so they sit closer to the side rails
+  const sideInset = SIDE_POCKET_RADIUS * 0.812 * POCKET_VISUAL_EXPANSION; // ease the middle rail cuts outward so they sit closer to the side rails
 
   const circlePoly = (cx, cz, r, seg = 96) => {
     const pts = [];


### PR DESCRIPTION
## Summary
- nudge the Pool Royale corner rail and chrome cutouts farther toward the table centre
- pull the side pocket rail and chrome cutouts slightly toward the long-rail edges for better alignment

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f4b698223c8329838200a418b8e791