### PR TITLE
Adjust Pool Royale rail pocket positions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4104,12 +4104,12 @@ function Table3D(
   const cornerPocketRadius = POCKET_VIS_R * 1.1 * POCKET_VISUAL_EXPANSION;
   const cornerChamfer = POCKET_VIS_R * 0.34 * POCKET_VISUAL_EXPANSION;
   const CORNER_NOTCH_EXTRA_INSET =
-    TABLE.THICK * 0.062; // push the chrome/rail corner cutouts farther toward centre for tighter alignment
+    TABLE.THICK * 0.074; // push the chrome/rail corner cutouts farther toward centre for tighter alignment
   const cornerInset =
     POCKET_VIS_R * 0.58 * POCKET_VISUAL_EXPANSION +
     CORNER_POCKET_CENTER_INSET +
     CORNER_NOTCH_EXTRA_INSET;
-  const sideInset = SIDE_POCKET_RADIUS * 0.812 * POCKET_VISUAL_EXPANSION; // ease the middle rail cuts outward so they sit closer to the side rails
+  const sideInset = SIDE_POCKET_RADIUS * 0.802 * POCKET_VISUAL_EXPANSION; // ease the middle rail cuts outward so they sit closer to the side rails
 
   const circlePoly = (cx, cz, r, seg = 96) => {
     const pts = [];


### PR DESCRIPTION
## Summary
- nudge the Pool Royale corner rail and chrome notch geometry further toward the table centre
- shift the middle pocket rail and chrome cutouts slightly toward the side rails for better alignment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4b9516af88329a4e0dc20e30b4bb5