### PR TITLE
Adjust Pool Royale side pocket rounding

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4110,7 +4110,7 @@ function Table3D(
     CORNER_POCKET_CENTER_INSET +
     CORNER_NOTCH_EXTRA_INSET;
   const sideInset =
-    SIDE_POCKET_RADIUS * 0.79 * POCKET_VISUAL_EXPANSION; // ease the middle rail cuts outward a touch more so they sit closer to the side rails
+    SIDE_POCKET_RADIUS * 0.765 * POCKET_VISUAL_EXPANSION; // push the middle rail cuts farther outward so the chrome and rail rounding hug the side rails
 
   const circlePoly = (cx, cz, r, seg = 96) => {
     const pts = [];


### PR DESCRIPTION
## Summary
- reduce the side pocket inset used for Pool Royale rail geometry
- push the rounded middle rail and chrome cuts slightly outward so they hug the side rails better

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4bd4b0bd0832995cf4a9b0c1e0665