### PR TITLE
Adjust Pool Royale side pocket rail cut

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4110,7 +4110,7 @@ function Table3D(
     CORNER_POCKET_CENTER_INSET +
     CORNER_NOTCH_EXTRA_INSET;
   const sideInset =
-    SIDE_POCKET_RADIUS * 0.765 * POCKET_VISUAL_EXPANSION; // push the middle rail cuts farther outward so the chrome and rail rounding hug the side rails
+    SIDE_POCKET_RADIUS * 0.78 * POCKET_VISUAL_EXPANSION; // push the middle rail cuts a touch farther outward so the chrome and rail rounding hug the side rails tighter
 
   const circlePoly = (cx, cz, r, seg = 96) => {
     const pts = [];


### PR DESCRIPTION
## Summary
- shift the Pool Royale side pocket rail and chrome notch origin slightly farther toward each side to better align the rounded cuts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4c160c814832991ab3970070d6ce5