### PR TITLE
Adjust Pool Royale side pocket notch position

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4110,7 +4110,7 @@ function Table3D(
     CORNER_POCKET_CENTER_INSET +
     CORNER_NOTCH_EXTRA_INSET;
   const sideInset =
-    SIDE_POCKET_RADIUS * 0.78 * POCKET_VISUAL_EXPANSION; // push the middle rail cuts a touch farther outward so the chrome and rail rounding hug the side rails tighter
+    SIDE_POCKET_RADIUS * 0.76 * POCKET_VISUAL_EXPANSION; // push the middle rail cuts slightly farther outward so the chrome and rail rounding hug the side rails tighter
 
   const circlePoly = (cx, cz, r, seg = 96) => {
     const pts = [];


### PR DESCRIPTION
## Summary
- shift the Pool Royale side pocket inset slightly farther outward so the rail and chrome cuts sit closer to the side rails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f4c800f944832985c6967dc4b5894a