### PR TITLE
Swap Pool Royale pocket cover footprints

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -243,6 +243,10 @@ const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.008; // leave a slim gap near 
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.12; // cap the side plate corner fillet so it matches the rail cut without overpowering the plate footprint
 const RAIL_CORNER_POCKET_CUT_SCALE = 0.944; // trim the corner rail pocket cuts so the rounded openings read slightly smaller
 const RAIL_SIDE_POCKET_CUT_SCALE = 0.978; // tighten the side rail cutouts so the rounded middle pockets shrink subtly
+const CORNER_POCKET_COVER_SIZE_SCALE =
+  RAIL_CORNER_POCKET_CUT_SCALE / RAIL_SIDE_POCKET_CUT_SCALE; // swap cover footprint sizes so corner liners match the former side footprint
+const SIDE_POCKET_COVER_SIZE_SCALE =
+  RAIL_SIDE_POCKET_CUT_SCALE / RAIL_CORNER_POCKET_CUT_SCALE; // swap cover footprint sizes so side liners match the former corner footprint
 const POCKET_COVER_INNER_SCALE = 0.86; // shrink interior mask so the plastic liner stays thin while matching the rail cut edge
 const POCKET_COVER_DEPTH_SCALE = 0.962; // sink the liners slightly so they sit flush with the rail tops without protruding
 
@@ -4460,9 +4464,10 @@ function Table3D(
   finishParts.railMeshes.push(railsMesh);
 
   const createCornerPocketCover = (sx, sz) =>
-    scaleCornerPocketCut(cornerNotchMP(sx, sz));
+    scaleMultiPolygon(scaleCornerPocketCut(cornerNotchMP(sx, sz)), CORNER_POCKET_COVER_SIZE_SCALE);
 
-  const createSidePocketCover = (sx) => scaleSidePocketCut(sideNotchMP(sx));
+  const createSidePocketCover = (sx) =>
+    scaleMultiPolygon(scaleSidePocketCut(sideNotchMP(sx)), SIDE_POCKET_COVER_SIZE_SCALE);
 
   const pocketCoverGroup = new THREE.Group();
   const pocketCoverMat = new THREE.MeshPhysicalMaterial({


### PR DESCRIPTION
## Summary
- swap the Pool Royale plastic pocket cover footprints so the side pockets use the larger liner and corners use the smaller one

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f4f5fde40c8329948209e0da79b099