### PR TITLE
Adjust Pool Royale pocket cover widths

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -244,9 +244,9 @@ const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.12; // cap the side plate corner 
 const RAIL_CORNER_POCKET_CUT_SCALE = 0.944; // trim the corner rail pocket cuts so the rounded openings read slightly smaller
 const RAIL_SIDE_POCKET_CUT_SCALE = 0.978; // tighten the side rail cutouts so the rounded middle pockets shrink subtly
 const CORNER_POCKET_COVER_SIZE_SCALE =
-  RAIL_CORNER_POCKET_CUT_SCALE / RAIL_SIDE_POCKET_CUT_SCALE; // swap cover footprint sizes so corner liners match the former side footprint
+  (RAIL_SIDE_POCKET_CUT_SCALE / RAIL_CORNER_POCKET_CUT_SCALE) ** 2; // swap liner widths so the corner covers inherit the previous side-pocket footprint
 const SIDE_POCKET_COVER_SIZE_SCALE =
-  RAIL_SIDE_POCKET_CUT_SCALE / RAIL_CORNER_POCKET_CUT_SCALE; // swap cover footprint sizes so side liners match the former corner footprint
+  (RAIL_CORNER_POCKET_CUT_SCALE / RAIL_SIDE_POCKET_CUT_SCALE) ** 2; // swap liner widths so the side covers inherit the previous corner-pocket footprint
 const POCKET_COVER_INNER_SCALE = 0.86; // shrink interior mask so the plastic liner stays thin while matching the rail cut edge
 const POCKET_COVER_DEPTH_SCALE = 0.962; // sink the liners slightly so they sit flush with the rail tops without protruding
 


### PR DESCRIPTION
## Summary
- swap the Pool Royale pocket cover width scales so the corner liners inherit the former side-pocket span while the side liners shrink to the old corner footprint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f4f9c7946c8329993765ead9af792f