### PR TITLE
Restore Pool Royale pocket trims on right side

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4568,19 +4568,6 @@ function Table3D(
     });
   };
 
-  const shouldOmitPocketCover = (clip) => {
-    if (!clip) return false;
-    if (clip.type === 'corner' && clip.sx === 1 && clip.sz === 1) {
-      // Remove one plastic cover from the front-right corner pocket
-      return true;
-    }
-    if (clip.type === 'side' && clip.sx === 1) {
-      // Remove one plastic cover from the right middle pocket
-      return true;
-    }
-    return false;
-  };
-
   [
     {
       mp: createCornerPocketCover(1, 1),
@@ -4641,7 +4628,6 @@ function Table3D(
       }
     }
   ]
-    .filter(({ clip }) => !shouldOmitPocketCover(clip))
     .forEach(addPocketCoverFromMP);
 
   if (pocketCoverGroup.children.length) {


### PR DESCRIPTION
## Summary
- ensure the Pool Royale table keeps plastic trim meshes on the right middle and front-right pockets
- rely on the existing corner and side pocket cover generators so both pockets render matching liners again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f50a9080a88329ba9de02d29d93d61