### PR TITLE
Fix Pool Royale pocket cover sizing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -244,9 +244,9 @@ const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.12; // cap the side plate corner 
 const RAIL_CORNER_POCKET_CUT_SCALE = 0.944; // trim the corner rail pocket cuts so the rounded openings read slightly smaller
 const RAIL_SIDE_POCKET_CUT_SCALE = 0.978; // tighten the side rail cutouts so the rounded middle pockets shrink subtly
 const CORNER_POCKET_COVER_SIZE_SCALE =
-  (RAIL_SIDE_POCKET_CUT_SCALE / RAIL_CORNER_POCKET_CUT_SCALE) ** 2; // swap liner widths so the corner covers inherit the previous side-pocket footprint
+  RAIL_SIDE_POCKET_CUT_SCALE / RAIL_CORNER_POCKET_CUT_SCALE; // swap liner widths so the corner covers inherit the previous side-pocket footprint
 const SIDE_POCKET_COVER_SIZE_SCALE =
-  (RAIL_CORNER_POCKET_CUT_SCALE / RAIL_SIDE_POCKET_CUT_SCALE) ** 2; // swap liner widths so the side covers inherit the previous corner-pocket footprint
+  RAIL_CORNER_POCKET_CUT_SCALE / RAIL_SIDE_POCKET_CUT_SCALE; // swap liner widths so the side covers inherit the previous corner-pocket footprint
 const POCKET_COVER_INNER_SCALE = 0.86; // shrink interior mask so the plastic liner stays thin while matching the rail cut edge
 const POCKET_COVER_DEPTH_SCALE = 0.962; // sink the liners slightly so they sit flush with the rail tops without protruding
 


### PR DESCRIPTION
## Summary
- adjust the Pool Royale pocket cover scaling ratios so the corner liners inherit the wider footprint and the side liners shrink accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5146e419c832993bea0cebeaba497