### PR TITLE
Expand snooker table footprint by 18%

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -415,7 +415,7 @@ const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION; // apply uniform 30% shrink fr
 // the HUD scale and gameplay math that rely on worldScaleFactor conversions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7;
 const CUE_STYLE_STORAGE_KEY = 'tonplayCueStyleIndex';
-const TABLE_SCALE = 1.5; // ~15% larger footprint to expand the snooker table uniformly
+const TABLE_SCALE = 1.77; // ~18% increase to expand the snooker table uniformly without altering its shape
 const TABLE = {
   W: 66 * TABLE_SCALE,
   H: 132 * TABLE_SCALE,


### PR DESCRIPTION
## Summary
- increase the snooker table scale multiplier to make the playing surface roughly eighteen percent larger without changing its proportions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5bbd6d06c8329aeed32404db5c2df