### PR TITLE
Expand snooker table scale

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -415,7 +415,7 @@ const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION; // apply uniform 30% shrink fr
 // the HUD scale and gameplay math that rely on worldScaleFactor conversions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7;
 const CUE_STYLE_STORAGE_KEY = 'tonplayCueStyleIndex';
-const TABLE_SCALE = 1.77; // ~18% increase to expand the snooker table uniformly without altering its shape
+const TABLE_SCALE = 2.05; // ~16% increase over the previous build to uniformly enlarge the snooker table without altering its shape
 const TABLE = {
   W: 66 * TABLE_SCALE,
   H: 132 * TABLE_SCALE,


### PR DESCRIPTION
## Summary
- increase the snooker table TABLE_SCALE constant so the table renders about 16% larger without changing its proportions

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f5bf5941348329826bd010ca8f3f26