### PR TITLE
Increase snooker table scale by 18 percent

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -415,7 +415,7 @@ const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION; // apply uniform 30% shrink fr
 // the HUD scale and gameplay math that rely on worldScaleFactor conversions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7;
 const CUE_STYLE_STORAGE_KEY = 'tonplayCueStyleIndex';
-const TABLE_SCALE = 2.05; // ~16% increase over the previous build to uniformly enlarge the snooker table without altering its shape
+const TABLE_SCALE = 2.42; // ~18% increase over the previous build to uniformly enlarge the snooker table within the requested 15–20% range
 const TABLE = {
   W: 66 * TABLE_SCALE,
   H: 132 * TABLE_SCALE,


### PR DESCRIPTION
## Summary
- enlarge the snooker table scale factor so the table renders roughly 18% larger while preserving its proportions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5c186855083298081bdef609d0cc5