### PR TITLE
Align Pool Royale cushions with rails

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -569,7 +569,7 @@ const CLOTH_SHADOW_COVER_EDGE_INSET = TABLE.THICK * 0.02; // tuck the shadow cov
 const CLOTH_SHADOW_COVER_HOLE_RADIUS = BALL_R * 1.2; // allow just enough clearance for balls to fall through without exposing light
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
 const CUSHION_EXTRA_LIFT = 0; // keep cushion bases resting directly on the cloth plane
-const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.02; // lower the cushion lip so it finishes flush with the rail surface
+const CUSHION_HEIGHT_DROP = 0; // keep the cushion lip perfectly level with the surrounding rails
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
 const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.18; // soften the exterior rail corners with a shallow curve
@@ -4548,7 +4548,7 @@ function Table3D(
   });
   table.add(chalkGroup);
 
-  const FACE_SHRINK_LONG = 0.955;
+  const FACE_SHRINK_LONG = 1;
   const FACE_SHRINK_SHORT = FACE_SHRINK_LONG;
   const NOSE_REDUCTION = 0.75;
   const CUSHION_UNDERCUT_BASE_LIFT = 0.38;


### PR DESCRIPTION
## Summary
- remove the cushion face shrink so each Pool Royale cushion sits squarely against the wooden rails
- keep the cushion lip level with the surrounding rails so the green surface aligns with the Snooker table baseline

## Testing
- npm test -- --runTestsByPath test/poolUk8Ball.test.js *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68f5c65fc484832983c00452cde4aaa2