### PR TITLE
Restrict snooker broadcast and pocket camera activation

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -6953,13 +6953,7 @@ function SnookerGame() {
             if (!unit) return;
             if (unit.slider) {
               const settle = Math.max(THREE.MathUtils.clamp(t ?? 0, 0, 1), 0.5);
-              const limit = Math.max(
-                unit.slider.userData?.slideLimit ?? rig.slideLimit ?? 0,
-                0
-              );
-              const targetX = lookAt
-                ? THREE.MathUtils.clamp(lookAt.x * 0.25, -limit, limit)
-                : 0;
+              const targetX = 0;
               unit.slider.position.x = THREE.MathUtils.lerp(
                 unit.slider.position.x,
                 targetX,
@@ -7606,9 +7600,13 @@ function SnookerGame() {
           camera.position.setFromSpherical(TMP_SPH).add(lookTarget);
           const surfaceMarginWorld = Math.max(0, CAMERA_SURFACE_STOP_MARGIN) *
             (Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE);
+          const cueHeightWorld =
+            (CUE_Y + CAMERA_CUE_SURFACE_MARGIN) *
+            (Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE);
           const surfaceClampY = baseSurfaceWorldY + surfaceMarginWorld;
-          if (camera.position.y < surfaceClampY) {
-            camera.position.y = surfaceClampY;
+          const minCameraY = Math.max(surfaceClampY, cueHeightWorld);
+          if (camera.position.y < minCameraY) {
+            camera.position.y = minCameraY;
             TMP_VEC3_A.copy(camera.position).sub(lookTarget);
             const limitedRadius = TMP_VEC3_A.length();
             if (limitedRadius > 1e-6) {
@@ -7898,6 +7896,8 @@ function SnookerGame() {
             }
           }
           if (!best || bestScore < POCKET_CAM.dotThreshold) return null;
+          const securedPot = bestScore >= POCKET_GUARANTEED_ALIGNMENT;
+          if (!securedPot) return null;
           const predictedTravelForBall =
             shotPrediction?.ballId === ballId
               ? shotPrediction?.travel ?? null
@@ -8001,7 +8001,8 @@ function SnookerGame() {
             lastRailHitAt: targetBall.lastRailHitAt ?? null,
             lastRailHitType: targetBall.lastRailHitType ?? null,
             predictedAlignment,
-            forcedEarly
+            forcedEarly,
+            securedPot
           };
         };
         const fit = (m = STANDING_VIEW.margin) => {
@@ -9331,25 +9332,32 @@ function SnookerGame() {
           }
           let pocketViewActivated = false;
           if (earlyPocketView) {
-            const now = performance.now();
-            earlyPocketView.lastUpdate = now;
-            if (cameraRef.current) {
-              const cam = cameraRef.current;
-              earlyPocketView.smoothedPos = cam.position.clone();
-              const storedTarget = lastCameraTargetRef.current?.clone();
-              if (storedTarget) {
-                earlyPocketView.smoothedTarget = storedTarget;
-              }
-            }
-            if (actionView) {
-              earlyPocketView.resumeAction = actionView;
-              suspendedActionView = actionView;
+            const movingNow = balls.some(
+              (b) => b.active && b.vel.lengthSq() > STOP_EPS * STOP_EPS
+            );
+            if (!movingNow) {
+              suspendedActionView = actionView ?? null;
             } else {
-              suspendedActionView = null;
+              const now = performance.now();
+              earlyPocketView.lastUpdate = now;
+              if (cameraRef.current) {
+                const cam = cameraRef.current;
+                earlyPocketView.smoothedPos = cam.position.clone();
+                const storedTarget = lastCameraTargetRef.current?.clone();
+                if (storedTarget) {
+                  earlyPocketView.smoothedTarget = storedTarget;
+                }
+              }
+              if (actionView) {
+                earlyPocketView.resumeAction = actionView;
+                suspendedActionView = actionView;
+              } else {
+                suspendedActionView = null;
+              }
+              updatePocketCameraState(true);
+              activeShotView = earlyPocketView;
+              pocketViewActivated = true;
             }
-            updatePocketCameraState(true);
-            activeShotView = earlyPocketView;
-            pocketViewActivated = true;
           }
           if (!pocketViewActivated && actionView) {
             if (isLongShot) {
@@ -10599,6 +10607,17 @@ function SnookerGame() {
               forceEarly: matchesIntent && pocketIntent?.allowEarly
             });
             if (!candidate) continue;
+            if (!candidate.securedPot) continue;
+            if (movingCount === 0) continue;
+            if (movingCount > 2) continue;
+            if (
+              movingCount === 1 &&
+              movingBalls[0] &&
+              movingBalls[0].id !== candidate.ballId &&
+              movingBalls[0].id !== 'cue'
+            ) {
+              continue;
+            }
             const matchesPrediction = shotPrediction?.ballId === ball.id;
             const predictedAlignment = candidate.predictedAlignment ?? candidate.score ?? 0;
             const isDirectPrediction =
@@ -10606,7 +10625,9 @@ function SnookerGame() {
               (shotPrediction?.railNormal === null ||
                 shotPrediction?.railNormal === undefined);
             const qualifiesAsGuaranteed =
-              isDirectPrediction && predictedAlignment >= POCKET_GUARANTEED_ALIGNMENT;
+              candidate.securedPot &&
+              isDirectPrediction &&
+              predictedAlignment >= POCKET_GUARANTEED_ALIGNMENT;
             const allowDuringChaos =
               movingCount <= POCKET_CHAOS_MOVING_THRESHOLD ||
               matchesIntent ||


### PR DESCRIPTION
## Summary
- lock the broadcast camera rigs to the midpoints of the short rails
- clamp the player camera height so it stays at or above the cue stick level
- only allow pocket camera cuts when a secured two-ball pot is in progress

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5ccf60b188329b2d96ed35d983bf8