### PR TITLE
Adjust Pool Royale pocket cover sizing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -443,8 +443,8 @@ const TABLE = {
   WALL: 2.6 * TABLE_SCALE
 };
 const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top edge meets the green cushions cleanly
-const POCKET_COVER_CORNER_INNER_SCALE = 0.86; // move the slimmer middle-pocket liners to the corners so the mouths stay wide open
-const POCKET_COVER_SIDE_INNER_SCALE = 0.9; // relocate the beefier corner liners to the side pockets to better hide the rail cuts
+const POCKET_COVER_CORNER_INNER_SCALE = 0.9; // keep the wider covers on the corner chamfers so they span the cushion gap
+const POCKET_COVER_SIDE_INNER_SCALE = 0.86; // move the slimmer liners back to the side pockets where the opening is tighter
 const FRAME_TOP_Y = -TABLE.THICK + 0.01 - TABLE.THICK * 0.012; // drop the rail assembly so the frame meets the skirt without a gap
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
 // Dimensions reflect WPA specifications (playing surface 100" × 50")


### PR DESCRIPTION
## Summary
- swap the Pool Royale pocket cover scale factors so the corner liners span the rail chamfers and the side pockets keep the slimmer inserts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f73dfdfb488329becb986479d3bb8b