### PR TITLE
Fix Pool Royale pocket jaw clipping orientation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4630,8 +4630,8 @@ function Table3D(
       RAIL_CORNER_POCKET_CUT_SCALE
     );
     addPocketJaw(scaledMP, POCKET_JAW_CORNER_INNER_SCALE, {
-      x: { threshold: scaledCenterX, keepGreater: sx > 0 },
-      z: { threshold: scaledCenterZ, keepGreater: sz > 0 }
+      x: { threshold: scaledCenterX, keepGreater: sx < 0 },
+      z: { threshold: scaledCenterZ, keepGreater: sz < 0 }
     });
   });
 
@@ -4650,7 +4650,7 @@ function Table3D(
       RAIL_SIDE_POCKET_CUT_SCALE
     );
     addPocketJaw(scaledMP, POCKET_JAW_SIDE_INNER_SCALE, {
-      x: { threshold: scaledCenterX, keepGreater: sx > 0 }
+      x: { threshold: scaledCenterX, keepGreater: sx < 0 }
     });
   });
 


### PR DESCRIPTION
## Summary
- correct the corner and side pocket jaw clipping planes so the liners stay on the pocket interior

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f787969d2483298f464ffdc7141f63