### PR TITLE
Trim Pool Royale side pocket jaws

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -446,6 +446,7 @@ const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top
 const POCKET_JAW_CORNER_INNER_SCALE = 0.935; // slim the corner jaw walls so the chrome arches remain fully open
 const POCKET_JAW_CORNER_TRIM_RATIO = 0.74; // stop the corner jaw exactly where the chrome arch transitions across the chamfer
 const POCKET_JAW_SIDE_INNER_SCALE = 0.88; // keep the wider liners hugging the side pocket chamfers so the jaws track the cushion gap
+const POCKET_JAW_SIDE_TRIM_RATIO = 0.82; // trim the side pocket jaws so they stop flush with the chrome break
 const POCKET_JAW_DEPTH_SCALE = 0.56; // proportion of the rail height the jaw liner drops into the pocket cut (taller to lift rims above chrome)
 const POCKET_RIM_OUTER_BLEND = 0; // keep the rim's outer edge flush with the chrome plate's rounded cut
 const POCKET_RIM_INNER_SCALE = 1.035; // bias the rim toward the rail side while leaving a thicker metal band above the jaw
@@ -4744,7 +4745,7 @@ function Table3D(
       sx > 0
         ? Math.max(scaledCenterX, Math.min(desiredThreshold, extremeX - MICRO_EPS * 8))
         : Math.min(scaledCenterX, Math.max(desiredThreshold, extremeX + MICRO_EPS * 8));
-    const zLimit = Math.max(MICRO_EPS, sideChromeMeetZ);
+    const zLimit = Math.max(MICRO_EPS, sideChromeMeetZ * POCKET_JAW_SIDE_TRIM_RATIO);
     addPocketJaw(
       scaledMP,
       POCKET_JAW_SIDE_INNER_SCALE,


### PR DESCRIPTION
## Summary
- introduce a trim ratio for Pool Royale side pocket jaws so the liners end at the chrome break

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7c4e07db48329a8ecfc258b2df546