### PR TITLE
Improve Pool Royale pocket visibility and jaw trimming

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -444,7 +444,7 @@ const TABLE = {
 };
 const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top edge meets the green cushions cleanly
 const POCKET_JAW_CORNER_INNER_SCALE = 0.935; // slim the corner jaw walls so the chrome arches remain fully open
-const POCKET_JAW_CORNER_TRIM_RATIO = 0.64; // trim corner jaws sooner so they end right where the cushions begin
+const POCKET_JAW_CORNER_TRIM_RATIO = 0.54; // trim corner jaws sooner so they end precisely where the cushions start
 const POCKET_JAW_SIDE_INNER_SCALE = 0.88; // keep the wider liners hugging the side pocket chamfers so the jaws track the cushion gap
 const POCKET_JAW_DEPTH_SCALE = 0.56; // proportion of the rail height the jaw liner drops into the pocket cut (taller to lift rims above chrome)
 const POCKET_RIM_OUTER_BLEND = 0; // keep the rim's outer edge flush with the chrome plate's rounded cut
@@ -512,7 +512,7 @@ const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_JAW_SIDE_OUTWARD_OFFSET =
   POCKET_VIS_R * 0.066 * POCKET_VISUAL_EXPANSION; // push the middle jaws snug against the wooden rails so the pocket mouth clears fully
 const POCKET_JAW_CORNER_SIDE_TRIM_OFFSET =
-  POCKET_VIS_R * 0.012 * POCKET_VISUAL_EXPANSION; // keep the chrome trims from stretching past the cushion edge
+  POCKET_VIS_R * 0.006 * POCKET_VISUAL_EXPANSION; // tighten the chrome trims so the corner jaws stop at the cushion edge
 const POCKET_CUP_PROFILE_SAMPLES = 24;
 const POCKET_CUP_SEGMENTS = 48;
 const POCKET_CUP_FLARE_START = 0.78;
@@ -557,7 +557,7 @@ const ACTION_CAMERA_START_BLEND = 1;
 const CLOTH_DROP = BALL_R * 0.18; // lower the cloth surface slightly for added depth
 const CLOTH_TOP_LOCAL = FRAME_TOP_Y + BALL_R * 0.09523809523809523;
 const MICRO_EPS = BALL_R * 0.022857142857142857;
-const POCKET_CUT_EXPANSION = 1.18; // widen cloth openings further so the cloth never overlaps the pocket visuals
+const POCKET_CUT_EXPANSION = 1.26; // widen cloth openings further so the cloth never overlaps the pocket visuals
 const CLOTH_REFLECTION_LIMITS = Object.freeze({
   clearcoatMax: 0.028,
   clearcoatRoughnessMin: 0.48,
@@ -3691,7 +3691,10 @@ function Table3D(
     clearcoatRoughness: 0.86,
     envMapIntensity: 0.12,
     emissive: clothColor.clone().multiplyScalar(0.05),
-    emissiveIntensity: 0.5
+    emissiveIntensity: 0.5,
+    polygonOffset: true,
+    polygonOffsetFactor: 0.5,
+    polygonOffsetUnits: 2
   });
   const ballDiameter = BALL_R * 2;
   const ballsAcrossWidth = PLAY_W / ballDiameter;


### PR DESCRIPTION
## Summary
- push the Pool Royale cloth material behind the pocket geometry and widen the cutouts to keep pockets unobstructed
- shorten the corner pocket jaws so they stop flush with the cushions and chrome trim

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7db0191a88329bb51fcd77ce7dd40