### PR TITLE
Trim Pool Royale corner jaws flush with cushions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4870,7 +4870,10 @@ function Table3D(
       POCKET_JAW_CORNER_FLUSH_EPS
     );
     addPocketJaw(scaledMP, POCKET_JAW_CORNER_INNER_SCALE, {
-      combine: 'union',
+      // Force both half-plane clips to apply together so each jaw wing stops flush
+      // with the corresponding cushion edge instead of leaving a slight overhang
+      // into the playfield when the planes are unioned.
+      combine: 'intersection',
       x: { threshold: trimmedCenterX, keepGreater: sx > 0 },
       z: { threshold: trimmedCenterZ, keepGreater: sz > 0 }
     });


### PR DESCRIPTION
## Summary
- clamp the corner pocket jaw clipping to use intersecting half-planes so both wings end flush with the cushions
- document the intent directly above the clip configuration to avoid future overhang regressions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f84d0af654832994c9db655f521a09