### PR TITLE
Enhance Domino Royal UI and chair overlays

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -8,18 +8,21 @@
   html,body{margin:0;height:100%;background:#ece6dc;overflow:hidden;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial}
   #app{position:fixed;inset:0; width:100dvw; height:100dvh;}
   canvas{display:block; width:100dvw !important; height:100dvh !important; touch-action:none}
-  button{font-weight:700;border:0;border-radius:999px;padding:.45rem .7rem;background:#ffd24a;color:#333;box-shadow:0 4px 12px rgba(0,0,0,.25);}
+  button{font-family:inherit;font-weight:600;border:0;border-radius:999px;background:transparent;color:inherit;cursor:pointer;transition:transform .15s ease,box-shadow .2s ease,background .2s ease;}
+  button:focus-visible{outline:2px solid rgba(148,197,255,.5);outline-offset:2px;}
   button:active{transform:translateY(1px);}
   #status{position:fixed;top:calc(0.65rem + env(safe-area-inset-top, 0px));left:50%;transform:translateX(-50%);padding:.35rem .75rem;border-radius:999px;background:rgba(0,0,0,.55);color:#fff;font-weight:700;z-index:2;backdrop-filter:blur(6px);}
-  #railControls{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom,0px) + clamp(2.4rem, 14vh, 6.4rem));transform:translateX(-50%);display:flex;flex-direction:column;gap:.65rem;align-items:stretch;background:rgba(64,42,20,.88);color:#fff;border-radius:1.25rem;padding:.75rem .95rem 1rem .95rem;box-shadow:0 14px 30px rgba(0,0,0,.45);z-index:2;pointer-events:auto;min-width:clamp(8.5rem, 46vw, 13rem);}
-  #railControls button{background:#ffd24a;color:#3b250f;font-size:1.05rem;padding:.7rem 1.1rem;border-radius:.9rem;}
-  #draw{font-size:1.1rem;padding:.82rem 1.2rem;box-shadow:0 6px 18px rgba(0,0,0,.35);}
-  #pass{background:rgba(255,210,74,.22);color:#f8e6b5;border:2px solid rgba(255,210,74,.55);}
-  #btnRules{position:fixed;top:calc(0.75rem + env(safe-area-inset-top,0px));right:calc(0.75rem + env(safe-area-inset-right,0px));width:2.75rem;height:2.75rem;border-radius:999px;background:rgba(0,0,0,.58);color:#fff;display:grid;place-items:center;font-size:1.3rem;box-shadow:0 6px 18px rgba(0,0,0,.35);z-index:3;backdrop-filter:blur(6px);padding:0;}
+  #railControls{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom,0px) + clamp(2rem, 12vh, 5.6rem));transform:translateX(-50%);display:flex;flex-direction:column;gap:.55rem;align-items:stretch;background:rgba(8,12,24,.85);color:#f8fafc;border-radius:1.35rem;padding:.65rem .85rem .85rem .85rem;box-shadow:0 16px 32px rgba(2,6,23,.55);border:1px solid rgba(255,215,0,.22);z-index:3;pointer-events:auto;min-width:clamp(7.8rem, 42vw, 11.8rem);backdrop-filter:blur(12px);}
+  #railControls button{background:linear-gradient(180deg,rgba(45,45,45,.96),rgba(12,12,12,.9));color:#f7e7a4;font-size:.95rem;padding:.55rem .9rem;border-radius:999px;border:1px solid rgba(255,215,0,.5);box-shadow:0 12px 22px rgba(0,0,0,.4),inset 0 1px 0 rgba(255,255,255,.15);letter-spacing:.04em;font-weight:700;}
+  #railControls button:active{transform:translateY(1px) scale(.98);}
+  #draw{font-size:1rem;padding:.68rem 1rem;background:linear-gradient(180deg,rgba(253,230,138,.55),rgba(253,216,88,.65));color:#2f2306;border-color:rgba(255,215,0,.7);box-shadow:0 14px 26px rgba(0,0,0,.38),inset 0 1px 0 rgba(255,255,255,.45);}
+  #pass{background:rgba(255,215,0,.15);color:#f7eac0;border-color:rgba(255,215,0,.32);}
+  #btnRules{position:fixed;top:calc(0.75rem + env(safe-area-inset-top,0px));right:calc(0.75rem + env(safe-area-inset-right,0px));width:2.4rem;height:2.4rem;border-radius:999px;background:rgba(8,12,24,.82);color:#f8fafc;display:grid;place-items:center;font-size:1.2rem;box-shadow:0 10px 24px rgba(0,0,0,.4);z-index:4;backdrop-filter:blur(10px);padding:0;border:1px solid rgba(148,197,255,.28);}
   #btnRules span{pointer-events:none;}
-  #configButton{position:fixed;top:calc(0.75rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));width:3rem;height:3rem;border-radius:999px;background:rgba(0,0,0,.7);color:#fff;border:1px solid rgba(255,255,255,.18);display:grid;place-items:center;box-shadow:0 6px 18px rgba(0,0,0,.35);z-index:3;backdrop-filter:blur(8px);padding:0;transition:background .2s ease, border-color .2s ease;}
-  #configButton:hover{background:rgba(0,0,0,.6);border-color:rgba(148,197,255,.45);}
-  #configButton svg{width:1.4rem;height:1.4rem;}
+  #configButton{position:fixed;top:calc(0.75rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));width:2.55rem;height:2.55rem;border-radius:999px;background:rgba(8,12,24,.82);color:#f8fafc;border:1px solid rgba(148,197,255,.28);display:grid;place-items:center;box-shadow:0 10px 24px rgba(0,0,0,.4);z-index:4;backdrop-filter:blur(10px);padding:0;transition:background .2s ease,border-color .2s ease,transform .2s ease;}
+  #configButton:hover{background:rgba(12,18,36,.9);border-color:rgba(148,197,255,.5);}
+  #configButton:active{transform:scale(.97);}
+  #configButton svg{width:1.25rem;height:1.25rem;}
   #configPanel{position:fixed;top:calc(4.4rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));max-width:min(320px, 84vw);background:rgba(3,7,18,.92);color:#fff;border-radius:1.25rem;box-shadow:0 24px 40px rgba(2,6,23,.55);padding:1rem;border:1px solid rgba(148,197,255,.2);z-index:3;backdrop-filter:blur(10px);display:none;flex-direction:column;gap:0.75rem;}
   #configPanel.active{display:flex;}
   #configPanel h3{margin:0;font-size:.65rem;text-transform:uppercase;letter-spacing:.3rem;color:rgba(148,197,255,.75);}
@@ -41,11 +44,22 @@
   #rules h2{margin:0 0 6px 0;font-size:18px}
   #rules ol{margin:6px 0 0 18px}
   #rules .row{display:flex;gap:8px;justify-content:flex-end;margin-top:12px}
+  #rules .row button{background:linear-gradient(180deg,rgba(45,45,45,.95),rgba(12,12,12,.88));color:#f7e7a4;padding:.55rem 1.1rem;border-radius:999px;border:1px solid rgba(255,215,0,.45);box-shadow:0 10px 20px rgba(0,0,0,.35);}
+  #rules .row button:active{transform:translateY(1px) scale(.98);}
+  #chairOverlays{position:fixed;inset:0;pointer-events:none;z-index:5;font-family:inherit;}
+  .seat-overlay{position:absolute;transform:translate(-50%,-50%);display:flex;flex-direction:column;align-items:center;gap:.3rem;opacity:0;transition:opacity .25s ease,transform .25s ease;}
+  .seat-overlay.inactive{opacity:0;}
+  .seat-overlay-badge{width:2.35rem;height:2.35rem;border-radius:999px;display:grid;place-items:center;background:rgba(8,12,24,.86);color:#f8fafc;font-weight:700;overflow:hidden;border:1px solid rgba(255,215,0,.45);box-shadow:0 10px 24px rgba(0,0,0,.45);backdrop-filter:blur(8px);}
+  .seat-overlay-badge img{width:100%;height:100%;object-fit:cover;display:none;}
+  .seat-overlay-badge span{font-size:1.2rem;line-height:1;}
+  .seat-overlay-name{padding:.22rem .7rem;border-radius:999px;background:rgba(7,10,18,.76);color:#e2e8f0;font-size:.62rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;border:1px solid rgba(148,197,255,.32);box-shadow:0 8px 18px rgba(0,0,0,.4);white-space:nowrap;}
+  .seat-overlay.turn .seat-overlay-badge{border-color:rgba(255,215,0,.85);box-shadow:0 0 0 2px rgba(255,215,0,.24),0 16px 30px rgba(255,187,0,.45);}
 </style>
 </head>
 <body>
 <div id="app"></div>
 <div id="status" role="status">Ready</div>
+<div id="chairOverlays" aria-hidden="true"></div>
 <button id="configButton" type="button" aria-label="Table setup">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
     <path stroke-linecap="round" stroke-linejoin="round" d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z" />
@@ -313,7 +327,8 @@ const rimLight = new THREE.DirectionalLight(0xffffff, 0.55); rimLight.position.s
 
 const getPoolCarpetTextures = (() => {
   let cache = null;
-  const clamp01 = (v) => Math.min(1, Math.max(0, v));
+const clamp01 = (v) => Math.min(1, Math.max(0, v));
+const clampValue = (value, min, max) => Math.min(max, Math.max(min, value));
   const prng = (seed) => {
     let value = seed >>> 0;
     return () => {
@@ -780,6 +795,12 @@ function createDominoChair(option, renderer, sharedMaterials = null) {
   columnCap.receiveShadow = true;
   group.add(columnCap);
 
+  const seatTop = dims.baseThickness + dims.columnHeight + dims.seatThickness;
+  const avatarAnchor = new THREE.Object3D();
+  avatarAnchor.position.set(0, seatTop + dims.backHeight * 0.72, -dims.seatDepth * 0.18);
+  group.add(avatarAnchor);
+  group.userData.avatarAnchor = avatarAnchor;
+
   return group;
 }
 
@@ -1047,11 +1068,30 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
 })();
 
 const SCALE = MODEL_SCALE * 0.92;
-const DOMINO_LENGTH = SCALE * (0.016 / 0.22) * 2;
+const DOMINO_SIZE_MULTIPLIER = 1.15;
+const BASE_DOMINO_WIDTH_RATIO = 0.1;
+const BASE_DOMINO_FLAT_LENGTH_RATIO = 0.016 / 0.22;
+const BASE_DOMINO_FLAT_THICKNESS_RATIO = 0.2 / 2.0;
+const BASE_DOMINO_STAND_LENGTH_RATIO = 0.2 / 2.0;
+const BASE_DOMINO_STAND_THICKNESS_RATIO = 0.016 / 0.22;
+
+const DOMINO_FLAT_SCALE_X = SCALE * BASE_DOMINO_WIDTH_RATIO * DOMINO_SIZE_MULTIPLIER;
+const DOMINO_FLAT_SCALE_Y = SCALE * BASE_DOMINO_FLAT_LENGTH_RATIO * DOMINO_SIZE_MULTIPLIER;
+const DOMINO_FLAT_SCALE_Z = SCALE * BASE_DOMINO_FLAT_THICKNESS_RATIO * DOMINO_SIZE_MULTIPLIER;
+
+const DOMINO_STAND_SCALE_X = DOMINO_FLAT_SCALE_X;
+const DOMINO_STAND_SCALE_Y = SCALE * BASE_DOMINO_STAND_LENGTH_RATIO * DOMINO_SIZE_MULTIPLIER;
+const DOMINO_STAND_SCALE_Z = SCALE * BASE_DOMINO_STAND_THICKNESS_RATIO * DOMINO_SIZE_MULTIPLIER;
+
+const DOMINO_LENGTH = DOMINO_FLAT_SCALE_Y * 2;
 const DOMINO_CHAIN_GAP = DOMINO_LENGTH * 0.08;
 const STEP = DOMINO_LENGTH + DOMINO_CHAIN_GAP;
 const DOMINO_HAND_GAP = DOMINO_LENGTH * 1.12;
-const TILE_UP_H = 0.2 * SCALE;
+
+const DOMINO_HALF_THICKNESS = 0.22 * DOMINO_FLAT_SCALE_Z * 0.5;
+const DOMINO_TABLE_LIFT = 0.0018;
+
+const TILE_UP_H = DOMINO_STAND_SCALE_Y * 2;
 const TILE_UP_HALF = TILE_UP_H / 2;
 const XMAX = CLOTH_RADIUS - 0.32 - DOMINO_CHAIN_GAP * 0.5;
 const ZMAX = CLOTH_RADIUS - 0.32 - DOMINO_CHAIN_GAP * 0.5;
@@ -1093,7 +1133,7 @@ const boneyardStackG = new THREE.Group();
 const BONEYARD_STACK_POSITION = new THREE.Vector3(-TABLE_RADIUS * 0.55, CLOTH_TOP + 0.0075, TABLE_RADIUS * 0.55);
 boneyardStackG.position.copy(BONEYARD_STACK_POSITION);
 piecesG.add(boneyardStackG);
-const BONEYARD_STACK_STEP = SCALE * 0.22 * 0.1 * 1.02;
+const BONEYARD_STACK_STEP = 0.22 * DOMINO_FLAT_SCALE_Z * 1.02;
 const MAX_BONEYARD_DISPLAY = 12;
 let boneyardStackVisible = 0;
 let boneyardStackTopLocal = 0;
@@ -1285,6 +1325,7 @@ function buildChairs(option = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFA
     chair.parent?.remove(chair);
     disposeChairResources(chair);
   }
+  seatAnchors.length = 0;
   const sharedMaterials = {
     fabric: createChairFabricMaterial(option, renderer),
     leg: new THREE.MeshStandardMaterial({
@@ -1312,9 +1353,23 @@ function buildChairs(option = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFA
     chair.position.y = -seatBottomOffset;
     wrapper.add(chair);
 
+    const anchor = chair.userData?.avatarAnchor;
+    if (anchor) {
+      seatAnchors.push(anchor);
+    } else {
+      const fallbackAnchor = new THREE.Object3D();
+      fallbackAnchor.position.set(0, CHAIR_DIMENSIONS.seatThickness + CHAIR_DIMENSIONS.backHeight * 0.75, 0);
+      chair.add(fallbackAnchor);
+      seatAnchors.push(fallbackAnchor);
+    }
+
     tableG.add(wrapper);
     chairs.push(wrapper);
   });
+
+  updateSeatOverlayActiveState();
+  updateSeatTurnHighlight();
+  updateSeatOverlaysPositions();
 }
 
 /* ---------- Tile Helpers (ensure defined before use) ---------- */
@@ -1428,9 +1483,11 @@ function makeDomino(a,b,{flat=true, faceUp=true}={}){
   // Integrim me sistemin ekzistues: në fushë duhen "flat" (faqe lart)
   if(flat){ group.rotation.x = -Math.PI/2; }
 
-  // Ruaj shkallën ekzistuese të botës (ashtu si para ndryshimit)
-  const sx = 0.10 / 1.0, sy = (flat? 0.016/0.22 : 0.20/2.0), sz = (flat? 0.20/2.0 : 0.016/0.22);
-  group.scale.set(SCALE*sx, SCALE*sy, SCALE*sz);
+  if (flat) {
+    group.scale.set(DOMINO_FLAT_SCALE_X, DOMINO_FLAT_SCALE_Y, DOMINO_FLAT_SCALE_Z);
+  } else {
+    group.scale.set(DOMINO_STAND_SCALE_X, DOMINO_STAND_SCALE_Y, DOMINO_STAND_SCALE_Z);
+  }
 
   group.userData.val = [a,b];
   return group;
@@ -1473,6 +1530,170 @@ if (Number.isFinite(stakeAmount) && stakeAmount > 0) {
   statusPrefix = `Stake ${stakeAmount.toLocaleString('en-US')} ${stakeToken.toUpperCase()}`;
   setStatus('Ready');
 }
+
+const overlayLayer = document.getElementById('chairOverlays');
+const seatAnchors = [];
+const seatOverlays = [];
+const seatProfiles = [];
+const FALLBACK_SEAT_NAMES = ['You', 'CPU 1', 'CPU 2', 'CPU 3'];
+const FALLBACK_SEAT_AVATARS = ['🎲', '🤖', '🦊', '🐻'];
+
+const decodeParam = (value) => {
+  if (typeof value !== 'string') return '';
+  try {
+    return decodeURIComponent(value);
+  } catch (error) {
+    return value;
+  }
+};
+
+const avatarsParamRaw = urlParams.get('avatars') || '';
+const namesParamRaw = urlParams.get('names') || '';
+const meAvatarParam = decodeParam(urlParams.get('avatar') || '');
+const meNameParam = decodeParam(urlParams.get('name') || '');
+
+const avatarTokens = avatarsParamRaw
+  ? avatarsParamRaw
+      .split(',')
+      .map((value) => decodeParam(value.trim()))
+      .filter(Boolean)
+  : [];
+const nameTokens = namesParamRaw
+  ? namesParamRaw
+      .split(',')
+      .map((value) => decodeParam(value.trim()))
+      .filter(Boolean)
+  : [];
+
+for (let i = 0; i < 4; i += 1) {
+  const fallbackName = FALLBACK_SEAT_NAMES[i] || `Player ${i + 1}`;
+  const fallbackAvatar = FALLBACK_SEAT_AVATARS[i % FALLBACK_SEAT_AVATARS.length];
+  const profile = {
+    name: nameTokens[i] || (i === 0 && meNameParam ? meNameParam : fallbackName),
+    avatar: avatarTokens[i] || (i === 0 && meAvatarParam ? meAvatarParam : fallbackAvatar)
+  };
+  if (i === 0 && meAvatarParam) profile.avatar = meAvatarParam;
+  if (i === 0 && meNameParam) profile.name = meNameParam;
+  seatProfiles[i] = profile;
+}
+
+const TEMP_WORLD = new THREE.Vector3();
+const TEMP_NDC = new THREE.Vector3();
+
+function ensureSeatOverlayElements() {
+  if (!overlayLayer) return;
+  const desired = Math.max(seatProfiles.length, CHAIR_SEAT_ANGLES.length);
+  while (seatOverlays.length < desired) {
+    const container = document.createElement('div');
+    container.className = 'seat-overlay inactive';
+    const badge = document.createElement('div');
+    badge.className = 'seat-overlay-badge';
+    const img = document.createElement('img');
+    img.alt = '';
+    img.decoding = 'async';
+    img.loading = 'lazy';
+    const emoji = document.createElement('span');
+    img.addEventListener('error', () => {
+      img.removeAttribute('src');
+      img.style.display = 'none';
+      emoji.textContent = '🎲';
+      emoji.style.display = 'block';
+    });
+    badge.append(img, emoji);
+    const label = document.createElement('div');
+    label.className = 'seat-overlay-name';
+    container.append(badge, label);
+    overlayLayer.appendChild(container);
+    const entry = { container, badge, img, emoji, label };
+    seatOverlays.push(entry);
+  }
+}
+
+function setSeatOverlayAvatar(entry, avatarValue) {
+  const avatar = (avatarValue || '').trim();
+  const { img, emoji } = entry;
+  if (avatar && (avatar.startsWith('http') || avatar.startsWith('/') || avatar.startsWith('data:'))) {
+    emoji.textContent = '';
+    emoji.style.display = 'none';
+    img.style.display = 'block';
+    img.src = avatar;
+  } else if (avatar) {
+    img.removeAttribute('src');
+    img.style.display = 'none';
+    emoji.textContent = avatar.slice(0, 2);
+    emoji.style.display = 'block';
+  } else {
+    img.removeAttribute('src');
+    img.style.display = 'none';
+    emoji.textContent = '🎲';
+    emoji.style.display = 'block';
+  }
+}
+
+function updateSeatOverlayContent() {
+  ensureSeatOverlayElements();
+  seatOverlays.forEach((entry, index) => {
+    const profile = seatProfiles[index] || {};
+    setSeatOverlayAvatar(entry, profile.avatar);
+    entry.label.textContent = profile.name || `Player ${index + 1}`;
+  });
+}
+
+function updateSeatOverlayActiveState() {
+  const activeSeats = Math.min(N, seatOverlays.length);
+  seatOverlays.forEach((entry, index) => {
+    const active = index < activeSeats;
+    entry.container.classList.toggle('inactive', !active);
+    if (!active) {
+      entry.container.style.opacity = '0';
+    }
+  });
+}
+
+function updateSeatTurnHighlight() {
+  seatOverlays.forEach((entry, index) => {
+    entry.container.classList.toggle('turn', index === current && index < N);
+  });
+}
+
+function updateSeatOverlaysPositions() {
+  if (!overlayLayer || seatOverlays.length === 0 || !renderer?.domElement) return;
+  const cameraEl = camera;
+  if (!cameraEl) return;
+  const rect = renderer.domElement.getBoundingClientRect();
+  const width = rect.width || 1;
+  const height = rect.height || 1;
+  const activeSeats = Math.min(N, seatAnchors.length, seatOverlays.length);
+  for (let i = 0; i < seatOverlays.length; i += 1) {
+    const entry = seatOverlays[i];
+    if (i >= activeSeats) {
+      entry.container.style.opacity = '0';
+      continue;
+    }
+    const anchor = seatAnchors[i];
+    if (!anchor) {
+      entry.container.style.opacity = '0';
+      continue;
+    }
+    anchor.getWorldPosition(TEMP_WORLD);
+    TEMP_NDC.copy(TEMP_WORLD).project(cameraEl);
+    if (TEMP_NDC.z < -1 || TEMP_NDC.z > 1) {
+      entry.container.style.opacity = '0';
+      continue;
+    }
+    const x = rect.left + (TEMP_NDC.x * 0.5 + 0.5) * width;
+    const y = rect.top + (0.5 - TEMP_NDC.y * 0.5) * height;
+    const depth = cameraEl.position.distanceTo(TEMP_WORLD);
+    const scale = clampValue(1.28 - (depth - CHAIR_RADIUS) * 0.28, 0.75, 1.35);
+    entry.container.style.opacity = '1';
+    entry.container.style.transform = `translate(-50%, -50%) translate(${x}px, ${y}px) scale(${scale})`;
+  }
+}
+
+ensureSeatOverlayElements();
+updateSeatOverlayContent();
+updateSeatOverlayActiveState();
+updateSeatTurnHighlight();
 
 function layoutSeat(idx){
   const EDGE = CLOTH_RADIUS;
@@ -1557,7 +1778,7 @@ function renderChain(){
   });
   chain.forEach(c=>{
     const domino = makeDomino(c.tile.a, c.tile.b, { flat: true, faceUp: true });
-    const yPos = CLOTH_TOP + 0.008;
+    const yPos = CLOTH_TOP + DOMINO_HALF_THICKNESS + DOMINO_TABLE_LIFT;
     domino.position.set(c.x, yPos, c.z);
     // Siguro që çdo domino në fushë të jetë krejtësisht e sheshtë (pa tilt)
     orientDominoFlat(domino, c.rot ?? 0);
@@ -1806,6 +2027,7 @@ function startGame(){
   const numericN = Number.isFinite(N) ? Math.round(N) : 4;
   N = Math.max(2, Math.min(4, numericN));
   players=Array.from({length:N},(_,i)=>({id:i,hand:[]}));
+  updateSeatOverlayActiveState();
   boneyard=shuffle(genSet());
   renderBoneyardStack();
   for(let r=0;r<7;r++){
@@ -1840,6 +2062,8 @@ function startGame(){
     };
   }
   renderChain(); current=(starter+1)%N; setStatus(`Turn: Player ${current+1}`); updateInteractivity();
+  updateSeatTurnHighlight();
+  updateSeatOverlaysPositions();
 }
 
 /* ---------- Placement & Snake ---------- */
@@ -1965,6 +2189,8 @@ function updateInteractivity(){
   const blk = blockedAndWinner(); if(blk){ setStatus(blk.reason); return; }
   setStatus(`Turn: Player ${current+1}`);
   renderHands(); renderChain();
+  updateSeatTurnHighlight();
+  updateSeatOverlaysPositions();
 }
 function nextTurn(){
   if(players[human].hand.length===0){ setStatus('You won!'); return; }
@@ -2068,12 +2294,22 @@ function updateDrawAnimations(now){
 }
 
 /* ---------- Loop & Resize ---------- */
-function tick(now){ updateDrawAnimations(now); controls.update(); renderer.render(scene,camera); requestAnimationFrame(tick); }
+function tick(now){
+  updateDrawAnimations(now);
+  controls.update();
+  updateSeatOverlaysPositions();
+  renderer.render(scene,camera);
+  requestAnimationFrame(tick);
+}
 requestAnimationFrame(tick);
-function onResize(){ positionCameraForViewport(); }
+function onResize(){
+  positionCameraForViewport();
+  updateSeatOverlaysPositions();
+}
 addEventListener('resize', onResize); if(window.visualViewport){ visualViewport.addEventListener('resize', onResize); }
 
 positionCameraForViewport({ force: true });
+updateSeatOverlaysPositions();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enlarge and reposition Domino tiles so pieces sit visibly on the cloth
- restyle the Domino Royal controls and HUD buttons to mirror the Snake & Ladder look at a smaller scale
- overlay dynamic chair avatars that follow seat anchors similar to the Snake & Ladder implementation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f850dffd7c8329bb2d71e0f9229fb5