### PR TITLE
Adjust Domino Royal controls and improve table tile visibility

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -11,10 +11,10 @@
   button{font-weight:700;border:0;border-radius:999px;padding:.45rem .7rem;background:#ffd24a;color:#333;box-shadow:0 4px 12px rgba(0,0,0,.25);}
   button:active{transform:translateY(1px);}
   #status{position:fixed;top:calc(0.65rem + env(safe-area-inset-top, 0px));left:50%;transform:translateX(-50%);padding:.35rem .75rem;border-radius:999px;background:rgba(0,0,0,.55);color:#fff;font-weight:700;z-index:2;backdrop-filter:blur(6px);}
-  #railControls{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom,0px) + clamp(2.4rem, 14vh, 6.4rem));transform:translateX(-50%);display:flex;flex-direction:column;gap:.65rem;align-items:stretch;background:rgba(64,42,20,.88);color:#fff;border-radius:1.25rem;padding:.75rem .95rem 1rem .95rem;box-shadow:0 14px 30px rgba(0,0,0,.45);z-index:2;pointer-events:auto;min-width:clamp(8.5rem, 46vw, 13rem);}
-  #railControls button{background:#ffd24a;color:#3b250f;font-size:1.05rem;padding:.7rem 1.1rem;border-radius:.9rem;}
-  #draw{font-size:1.1rem;padding:.82rem 1.2rem;box-shadow:0 6px 18px rgba(0,0,0,.35);}
-  #pass{background:rgba(255,210,74,.22);color:#f8e6b5;border:2px solid rgba(255,210,74,.55);}
+  #railControls{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom,0px) + clamp(2.4rem, 14vh, 6.4rem));transform:translateX(-50%);display:flex;flex-direction:row;flex-wrap:wrap;justify-content:center;gap:.5rem;align-items:center;background:transparent;color:#fff;padding:0;box-shadow:none;z-index:2;pointer-events:auto;}
+  #railControls button{background:rgba(12,16,28,.72);color:#ffe8a3;font-size:.95rem;padding:.55rem .9rem;border-radius:999px;border:1px solid rgba(255,255,255,.14);box-shadow:0 8px 18px rgba(0,0,0,.35);backdrop-filter:blur(8px);}
+  #draw{font-size:1rem;padding:.6rem 1rem;background:linear-gradient(135deg, rgba(255,210,74,.95), rgba(255,196,45,.85));color:#3b250f;border:0;}
+  #pass{background:rgba(255,210,74,.12);color:#ffe8a3;border:1px solid rgba(255,210,74,.35);}
   #btnRules{position:fixed;top:calc(0.75rem + env(safe-area-inset-top,0px));right:calc(0.75rem + env(safe-area-inset-right,0px));width:2.75rem;height:2.75rem;border-radius:999px;background:rgba(0,0,0,.58);color:#fff;display:grid;place-items:center;font-size:1.3rem;box-shadow:0 6px 18px rgba(0,0,0,.35);z-index:3;backdrop-filter:blur(6px);padding:0;}
   #btnRules span{pointer-events:none;}
   #configButton{position:fixed;top:calc(0.75rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));width:3rem;height:3rem;border-radius:999px;background:rgba(0,0,0,.7);color:#fff;border:1px solid rgba(255,255,255,.18);display:grid;place-items:center;box-shadow:0 6px 18px rgba(0,0,0,.35);z-index:3;backdrop-filter:blur(8px);padding:0;transition:background .2s ease, border-color .2s ease;}
@@ -1056,6 +1056,7 @@ const TILE_UP_HALF = TILE_UP_H / 2;
 const XMAX = CLOTH_RADIUS - 0.32 - DOMINO_CHAIN_GAP * 0.5;
 const ZMAX = CLOTH_RADIUS - 0.32 - DOMINO_CHAIN_GAP * 0.5;
 const HAND_Y = RAIL_TOP + TILE_UP_HALF + 0.0012;
+const CHAIN_TILE_Y = CLOTH_TOP + 0.014;
 
 /* ---------- Materials ---------- */
 const porcelainMat = new THREE.MeshPhysicalMaterial({
@@ -1557,8 +1558,14 @@ function renderChain(){
   });
   chain.forEach(c=>{
     const domino = makeDomino(c.tile.a, c.tile.b, { flat: true, faceUp: true });
-    const yPos = CLOTH_TOP + 0.008;
+    const yPos = CHAIN_TILE_Y;
     domino.position.set(c.x, yPos, c.z);
+    domino.renderOrder = 5;
+    domino.traverse((child) => {
+      if (child.isMesh) {
+        child.renderOrder = 5;
+      }
+    });
     // Siguro që çdo domino në fushë të jetë krejtësisht e sheshtë (pa tilt)
     orientDominoFlat(domino, c.rot ?? 0);
     c.mesh = domino;


### PR DESCRIPTION
## Summary
- restyle the Domino Royal draw/pass controls to be smaller and frameless, matching the lighter Snake & Ladder treatment
- lift the chain domino meshes and set their render order so placed tiles stay visible on the table felt

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f85de4b3d88329b52182234061ba9a