### PR TITLE
Reduce 3D snake board size and improve dice throws

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2140,7 +2140,8 @@ export default function SnakeAndLadder() {
                   startDiceBoardAnimation({
                     id: diceRollIdRef.current,
                     phase: 'end',
-                    values: vals
+                    values: vals,
+                    seatIndex: aiRollingIndex ?? 0
                   });
                   if (aiRollingIndex) {
                     handleAIRoll(aiRollingIndex, vals);
@@ -2157,7 +2158,8 @@ export default function SnakeAndLadder() {
                   startDiceBoardAnimation({
                     id: diceRollIdRef.current,
                     phase: 'start',
-                    count: diceCount + bonusDice
+                    count: diceCount + bonusDice,
+                    seatIndex: aiRollingIndex ?? 0
                   });
                   if (timerRef.current) clearInterval(timerRef.current);
                   timerSoundRef.current?.pause();
@@ -2227,14 +2229,16 @@ export default function SnakeAndLadder() {
                     startDiceBoardAnimation({
                       id: diceRollIdRef.current,
                       phase: 'start',
-                      count: diceCount + bonusDice
+                      count: diceCount + bonusDice,
+                      seatIndex: currentTurn
                     });
                   }}
                   onRollEnd={(vals) => {
                     startDiceBoardAnimation({
                       id: diceRollIdRef.current,
                       phase: 'end',
-                      values: vals
+                      values: vals,
+                      seatIndex: currentTurn
                     });
                   }}
                 />


### PR DESCRIPTION
## Summary
- shrink the 3D snake board by an extra 15% so it sits deeper on the table
- drive dice throws from the active seat and animate them travelling across the felt before settling
- include the roller's seat index in dice events so the board can launch dice from the correct side

## Testing
- npx eslint --no-ignore webapp/src/components/SnakeBoard3D.jsx webapp/src/pages/Games/SnakeAndLadder.jsx *(warns because the files are ignored by the repo eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_68f865f4424483298ac8a250fa805932