### PR TITLE
Adjust Snake and Ladder dice position

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -1142,7 +1142,8 @@ function buildSnakeBoard(
 
   const diceGroup = new THREE.Group();
   const diceBaseY = tileGroup.position.y + tileHeight + DICE_SIZE * 0.5 + TILE_SIZE * 0.02;
-  const diceAnchorZ = -half + TILE_SIZE * 1.25;
+  // Keep the dice resting near the player-facing edge of the board
+  const diceAnchorZ = half + TILE_SIZE * 0.65;
   const diceSpacing = DICE_SIZE * 1.35;
   const diceSet = [];
   for (let i = 0; i < MAX_DICE; i += 1) {


### PR DESCRIPTION
## Summary
- reposition the 3D dice anchor to the player-facing edge of the board
- ensure the fallback dice placement matches the on-screen roll button location

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f870da85c08329bbb8cfb54fc09e1c