### PR TITLE
Fix Domino Royal config panel toggle and tile height

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -1056,7 +1056,7 @@ const TILE_UP_HALF = TILE_UP_H / 2;
 const XMAX = CLOTH_RADIUS - 0.32 - DOMINO_CHAIN_GAP * 0.5;
 const ZMAX = CLOTH_RADIUS - 0.32 - DOMINO_CHAIN_GAP * 0.5;
 const HAND_Y = RAIL_TOP + TILE_UP_HALF + 0.0012;
-const CHAIN_TILE_Y = CLOTH_TOP + 0.014;
+const CHAIN_TILE_Y = CLOTH_TOP + 0.02;
 
 /* ---------- Materials ---------- */
 const porcelainMat = new THREE.MeshPhysicalMaterial({
@@ -1226,7 +1226,7 @@ configButtonEl?.addEventListener('click', () => {
 configCloseEl?.addEventListener('click', () => closeConfigPanel());
 document.addEventListener('click', (event) => {
   if (!configPanelEl?.classList.contains('active')) return;
-  if (configPanelEl.contains(event.target) || event.target === configButtonEl) return;
+  if (configPanelEl.contains(event.target) || configButtonEl?.contains(event.target)) return;
   closeConfigPanel();
 });
 document.addEventListener('keydown', (event) => {


### PR DESCRIPTION
## Summary
- ensure the Domino Royal table setup panel stays open when activating the gear button
- lift chain domino tiles slightly higher above the cloth so they remain visible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f86b6369e083298ddf4b89096757a4