### PR TITLE
Adjust Pool Royale corner jaw trimming

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -444,7 +444,7 @@ const TABLE = {
 };
 const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top edge meets the green cushions cleanly
 const POCKET_JAW_CORNER_INNER_SCALE = 0.948; // slim the corner jaw walls so the chrome arches remain fully open
-const POCKET_JAW_CORNER_TRIM_RATIO = 0.68; // shorten the corner jaw wings so they finish exactly at the cushion break
+const POCKET_JAW_CORNER_TRIM_RATIO = 0.6; // tuck the corner jaw wings further so they stay behind the cushion break
 const POCKET_JAW_SIDE_INNER_SCALE = 0.945; // keep the wider liners hugging the side pocket chamfers so the jaws stay thin and track the cushion gap
 const POCKET_JAW_DEPTH_SCALE = 0.56; // proportion of the rail height the jaw liner drops into the pocket cut (taller to lift rims above chrome)
 const POCKET_JAW_CORNER_FLUSH_EPS = 0; // lock the corner jaw bases to the cushion line so they never intrude over the cloth


### PR DESCRIPTION
## Summary
- reduce the corner jaw trim ratio in Pool Royale so the jaws no longer intrude over the cloth

## Testing
- not run (visual change)


------
https://chatgpt.com/codex/tasks/task_e_68f877c45a94832994dccc85581cbaa2