### PR TITLE
Tighten Pool Royale corner pocket jaws

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -444,7 +444,7 @@ const TABLE = {
 };
 const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top edge meets the green cushions cleanly
 const POCKET_JAW_CORNER_INNER_SCALE = 0.948; // slim the corner jaw walls so the chrome arches remain fully open
-const POCKET_JAW_CORNER_TRIM_RATIO = 0.72; // pull the corner jaw wings deeper behind the cushion break so less liner remains visible
+const POCKET_JAW_CORNER_TRIM_RATIO = 0.86; // pull the corner jaw wings even deeper behind the cushion break so the corner jaws present slimmer side walls
 const POCKET_JAW_SIDE_INNER_SCALE = 0.945; // keep the wider liners hugging the side pocket chamfers so the jaws stay thin and track the cushion gap
 const POCKET_JAW_DEPTH_SCALE = 0.56; // proportion of the rail height the jaw liner drops into the pocket cut (taller to lift rims above chrome)
 const POCKET_JAW_CORNER_FLUSH_EPS = 0; // lock the corner jaw bases to the cushion line so they never intrude over the cloth


### PR DESCRIPTION
## Summary
- increase the corner pocket jaw trim ratio so the Pool Royale corner pockets present slimmer side walls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f8838975f48329aa101935bc3d9aa9