### PR TITLE
Adjust Chess Battle Royale camera framing

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -248,16 +248,16 @@ const BOARD_SCALE = BOARD_DISPLAY_SIZE / RAW_BOARD_SIZE;
 
 const TABLE_RADIUS = 3.315; // 30% wider footprint to better fill the arena
 const TABLE_HEIGHT = 2.05; // Raised so the surface aligns with the oversized chairs
-const CAMERA_TABLE_SPAN_FACTOR = 2.15; // Slightly tighter framing so the orbit camera starts closer
+const CAMERA_TABLE_SPAN_FACTOR = 2.05; // Slightly tighter framing so the orbit camera starts closer
 
 const WALL_PROXIMITY_FACTOR = 0.5; // Bring arena walls 50% closer
 const WALL_HEIGHT_MULTIPLIER = 2; // Double wall height
 const CHAIR_SCALE = 4; // Chairs are 4x larger
 const CHAIR_CLEARANCE = 0.52;
-const PLAYER_CHAIR_EXTRA_CLEARANCE = 0.72; // Pull the player chair further back to clear the camera path
-const CAMERA_PHI_OFFSET = 0.18; // Lower the camera to feel closer to a seated viewpoint
-const CAMERA_INITIAL_PHI_EXTRA = 0.32;
-const SEAT_LABEL_HEIGHT = 0.82;
+const PLAYER_CHAIR_EXTRA_CLEARANCE = 0.86; // Pull the player chair further back to clear the camera path
+const CAMERA_PHI_OFFSET = 0.12; // Raise the allowable camera angle for a slightly higher view
+const CAMERA_INITIAL_PHI_EXTRA = 0.18; // Bias the starting camera angle upward a touch
+const SEAT_LABEL_HEIGHT = 0.74; // Drop the floating seat label closer to the chair back
 const SEAT_LABEL_FORWARD_OFFSET = -0.32;
 const CAMERA_INITIAL_RADIUS_FACTOR = ARENA_CAMERA_DEFAULTS.initialRadiusFactor;
 const CAMERA_INITIAL_PHI_LERP = clamp01(


### PR DESCRIPTION
## Summary
- tighten the orbit camera framing for the Chess Battle Royale table so it starts slightly closer and higher
- move the player chair back a little farther from the table and lower the floating seat labels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f892f9332c8329abb77c35b5d9af88