### PR TITLE
Expand air hockey table dimensions by 50%

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -112,7 +112,8 @@ export default function AirHockey3D({ player, ai }) {
     const scene = new THREE.Scene();
     scene.background = new THREE.Color(0x050505);
 
-    const TABLE_SCALE = 1.2;
+    // Expand the playable field by 50% to give more room on every side
+    const TABLE_SCALE = 1.8;
     const TABLE = {
       w: POOL_ENVIRONMENT.tableWidth * TABLE_SCALE,
       h: POOL_ENVIRONMENT.tableLength * TABLE_SCALE,


### PR DESCRIPTION
## Summary
- expand the 3D air hockey table by increasing the table scale 50%
- document the change inline so the larger field is clear in the code

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f895c402f88329b12c62deac66cd26