### PR TITLE
Update snake board to pyramid perimeter layout

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1117,13 +1117,10 @@ input:focus {
 }
 
 .pot-cell {
-  @apply absolute flex flex-col items-center justify-center;
+  @apply relative flex flex-col items-center justify-center;
   width: calc(var(--cell-width) * 2.7);
   height: calc(var(--cell-height) * 2.7);
-  /* move the pot slightly higher */
-  top: calc(var(--cell-height) * -7.1);
-  left: 50%;
-  transform: translateX(-50%) translateZ(12px);
+  transform: translateZ(12px);
   z-index: 50;
   background-color: transparent;
   border: none;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3,6 +3,10 @@ import coinConfetti from "../../utils/coinConfetti";
 import DiceRoller from "../../components/DiceRoller.jsx";
 import SnakeBoard3D from "../../components/SnakeBoard3D.jsx";
 import {
+  FINAL_TILE as BOARD_FINAL_TILE,
+  BOARD_CELL_COUNT as SNAKE_BOARD_CELL_COUNT,
+} from "../../components/SnakeBoard.jsx";
+import {
   dropSound,
   snakeSound,
   ladderSound,
@@ -98,9 +102,7 @@ const TOKEN_COLORS = [
 const PLAYERS = 4;
 // Adjusted board dimensions to show five columns
 // while keeping the total cell count at 100
-const ROWS = 20;
-const COLS = 5;
-const FINAL_TILE = ROWS * COLS + 1; // 101
+const FINAL_TILE = BOARD_FINAL_TILE;
 const TURN_TIME = 15;
 
 function shuffle(arr) {
@@ -669,7 +671,7 @@ export default function SnakeAndLadder() {
         setSnakeOffsets(snk);
         setLadderOffsets(lad);
 
-        const boardSize = ROWS * COLS;
+        const boardSize = SNAKE_BOARD_CELL_COUNT;
         const diceMap = {};
         const diceValues = [1, 2, 1];
         const usedD = new Set([


### PR DESCRIPTION
## Summary
- redesign the snake board grid to follow a four-tier pyramid perimeter layout
- adjust board sizing, transforms, and pot positioning to match the new geometry
- share board cell count and final tile constants with the game setup logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8a7bfeeb4832995897cf5be4913f6