### PR TITLE
Adjust Pool Royale corner jaw coverage to 50 percent

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -458,7 +458,7 @@ const TABLE = {
 };
 const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top edge meets the green cushions cleanly
 const POCKET_JAW_CORNER_INNER_SCALE = 0.948; // slim the corner jaw walls so the chrome arches remain fully open
-const POCKET_JAW_CORNER_TRIM_RATIO = 0.624; // trim the corner jaw wings ~20% more so they sit tighter beneath the chrome arch
+const POCKET_JAW_CORNER_TRIM_RATIO = 0.5; // trim the corner jaw wings so each covers exactly half of the pocket perimeter
 const POCKET_JAW_SIDE_INNER_SCALE = 0.945; // keep the wider liners hugging the side pocket chamfers so the jaws stay thin and track the cushion gap
 const POCKET_JAW_DEPTH_SCALE = 0.66; // deepen the jaw liner so the taller black jaws clear the chrome finish cleanly
 const POCKET_JAW_CORNER_FLUSH_EPS = 0; // lock the corner jaw bases to the cushion line so they never intrude over the cloth


### PR DESCRIPTION
## Summary
- lower the Pool Royale corner jaw trim ratio so each corner pocket jaw spans exactly half of the pocket perimeter

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f8abf2bc8c832980151c65d4ead626