### PR TITLE
Shorten Pool Royale corner pocket jaws

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -458,7 +458,7 @@ const TABLE = {
 };
 const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top edge meets the green cushions cleanly
 const POCKET_JAW_CORNER_INNER_SCALE = 0.948; // slim the corner jaw walls so the chrome arches remain fully open
-const POCKET_JAW_CORNER_TRIM_RATIO = 0.406; // trim the corner jaw wings so each covers about half of the pocket perimeter
+const POCKET_JAW_CORNER_TRIM_RATIO = 0.3451; // trim the corner jaw wings so each covers roughly 15% less of the pocket perimeter
 const POCKET_JAW_SIDE_INNER_SCALE = 0.945; // keep the wider liners hugging the side pocket chamfers so the jaws stay thin and track the cushion gap
 const POCKET_JAW_DEPTH_SCALE = 0.66; // deepen the jaw liner so the taller black jaws clear the chrome finish cleanly
 const POCKET_JAW_CORNER_FLUSH_EPS = 0; // lock the corner jaw bases to the cushion line so they never intrude over the cloth
@@ -528,9 +528,9 @@ const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_JAW_SIDE_OUTWARD_OFFSET =
   POCKET_VIS_R * 0.042 * POCKET_VISUAL_EXPANSION; // nudge the middle jaws a little farther toward the wooden rails while keeping their faces straight with the cushions
 const POCKET_JAW_CORNER_SIDE_TRIM_OFFSET =
-  POCKET_VIS_R * 0.0075 * POCKET_VISUAL_EXPANSION; // narrow the diagonal trims to match the shorter 50% corner jaw coverage
+  POCKET_VIS_R * 0.006375 * POCKET_VISUAL_EXPANSION; // narrow the diagonal trims to match the new 15% shorter corner jaw coverage
 const POCKET_JAW_CORNER_LIMIT_OFFSET =
-  POCKET_VIS_R * 0.0156 * POCKET_VISUAL_EXPANSION; // pull the corner jaw lips back so they only cover about half of each pocket
+  POCKET_VIS_R * 0.01326 * POCKET_VISUAL_EXPANSION; // pull the corner jaw lips back so they only cover roughly 15% less of each pocket
 const POCKET_JAW_CORNER_OUTWARD_BIAS = 0; // lock the corner jaws directly beneath the chrome arches without any outward drift
 const POCKET_CUP_PROFILE_SAMPLES = 24;
 const POCKET_CUP_SEGMENTS = 48;


### PR DESCRIPTION
## Summary
- reduce the Pool Royale corner jaw trim ratio so the pocket liners cover roughly 15% less of each mouth
- update the side trim and limit offsets to keep the shortened jaws aligned with the cushion edges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8bdac2e4c8329a91c6bccf0553e27