### PR TITLE
Show Domino Royal table cloth and refine setup panel

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -20,13 +20,17 @@
   #configButton{position:fixed;top:calc(0.75rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));width:3rem;height:3rem;border-radius:999px;background:rgba(0,0,0,.7);color:#fff;border:1px solid rgba(255,255,255,.18);display:grid;place-items:center;box-shadow:0 6px 18px rgba(0,0,0,.35);z-index:3;backdrop-filter:blur(8px);padding:0;transition:background .2s ease, border-color .2s ease;}
   #configButton:hover{background:rgba(0,0,0,.6);border-color:rgba(148,197,255,.45);}
   #configButton svg{width:1.4rem;height:1.4rem;}
-  #configPanel{position:fixed;top:calc(4.4rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));max-width:min(320px, 84vw);background:rgba(3,7,18,.92);color:#fff;border-radius:1.25rem;box-shadow:0 24px 40px rgba(2,6,23,.55);padding:1rem;border:1px solid rgba(148,197,255,.2);z-index:3;backdrop-filter:blur(10px);display:none;flex-direction:column;gap:0.75rem;}
+  #configPanel{position:fixed;top:calc(4.4rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));max-width:min(320px, 84vw);max-height:min(72dvh, 480px);background:rgba(3,7,18,.92);color:#fff;border-radius:1.25rem;box-shadow:0 24px 40px rgba(2,6,23,.55);padding:0.85rem 1rem;border:1px solid rgba(148,197,255,.2);z-index:3;backdrop-filter:blur(10px);display:none;flex-direction:column;gap:0.65rem;overflow:hidden;}
   #configPanel.active{display:flex;}
-  #configPanel h3{margin:0;font-size:.65rem;text-transform:uppercase;letter-spacing:.3rem;color:rgba(148,197,255,.75);}
-  .config-section{display:flex;flex-direction:column;gap:.35rem;}
-  .config-options{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.5rem;}
-  .config-option{border-radius:0.9rem;border:1px solid rgba(255,255,255,.12);background:rgba(15,23,42,.55);color:#e2e8f0;padding:.45rem .55rem;display:flex;flex-direction:column;align-items:flex-start;gap:.35rem;font-size:.75rem;font-weight:600;transition:border-color .2s ease, box-shadow .2s ease, transform .2s ease;}
-  .config-option span{font-size:.62rem;text-transform:uppercase;letter-spacing:.28rem;color:rgba(148,197,255,.7);}
+  #configPanel h3{margin:0;font-size:.62rem;text-transform:uppercase;letter-spacing:.28rem;color:rgba(148,197,255,.75);}
+  #configSections{display:flex;flex-direction:column;gap:.55rem;overflow-y:auto;padding-right:.3rem;margin-right:-.3rem;scrollbar-gutter:stable both-edges;overscroll-behavior:contain;}
+  #configSections::-webkit-scrollbar{width:.35rem;}
+  #configSections::-webkit-scrollbar-thumb{background:rgba(148,197,255,.35);border-radius:999px;}
+  #configSections::-webkit-scrollbar-track{background:transparent;}
+  .config-section{display:flex;flex-direction:column;gap:.3rem;}
+  .config-options{display:grid;grid-template-columns:repeat(auto-fit,minmax(128px,1fr));gap:.45rem;}
+  .config-option{border-radius:0.85rem;border:1px solid rgba(255,255,255,.12);background:rgba(15,23,42,.55);color:#e2e8f0;padding:.4rem .5rem;display:flex;flex-direction:column;align-items:flex-start;gap:.3rem;font-size:clamp(.62rem,1.75vw,.72rem);line-height:1.35;font-weight:600;transition:border-color .2s ease, box-shadow .2s ease, transform .2s ease;}
+  .config-option span{font-size:clamp(.5rem,1.45vw,.58rem);text-transform:uppercase;letter-spacing:.24rem;color:rgba(148,197,255,.68);}
   .config-option.active{border-color:rgba(56,189,248,.7);background:rgba(56,189,248,.15);box-shadow:0 0 0 1px rgba(56,189,248,.35),0 12px 24px rgba(8,145,178,.28);}
   .config-option:disabled{opacity:.45;cursor:not-allowed;}
   .config-option:not(.active):hover{border-color:rgba(255,255,255,.32);transform:translateY(-1px);}
@@ -461,12 +465,12 @@ const TABLE_WOOD_OPTIONS = Object.freeze([
 ]);
 
 const TABLE_CLOTH_OPTIONS = Object.freeze([
-  { id: "crimson", label: "Rrobë e Kuqe", feltTop: "#960019", feltBottom: "#4a0012", border: "#210308" },
-  { id: "emerald", label: "Rrobë Smerald", feltTop: "#0f6a2f", feltBottom: "#054d24", border: "#021a0b" },
-  { id: "arctic", label: "Rrobë Akull", feltTop: "#2563eb", feltBottom: "#1d4ed8", border: "#071a42" },
-  { id: "sunset", label: "Rrobë Perëndim", feltTop: "#ea580c", feltBottom: "#c2410c", border: "#320e03" },
-  { id: "violet", label: "Rrobë Vjollcë", feltTop: "#7c3aed", feltBottom: "#5b21b6", border: "#1f0a47" },
-  { id: "amber", label: "Rrobë Qelibari", feltTop: "#b7791f", feltBottom: "#92571a", border: "#2b1402" }
+  { id: "crimson", label: "Rrobë e Kuqe", feltTop: "#b0122d", feltBottom: "#650a1b", border: "#2b050c", emissive: "#6c101f", emissiveIntensity: 0.5 },
+  { id: "emerald", label: "Rrobë Smerald", feltTop: "#1fa44d", feltBottom: "#0b7030", border: "#043018", emissive: "#0f6a2f", emissiveIntensity: 0.72 },
+  { id: "arctic", label: "Rrobë Akull", feltTop: "#3b82f6", feltBottom: "#1d4ed8", border: "#0a1c4d", emissive: "#2563eb", emissiveIntensity: 0.62 },
+  { id: "sunset", label: "Rrobë Perëndim", feltTop: "#f97316", feltBottom: "#c2410c", border: "#3b1203", emissive: "#e2580f", emissiveIntensity: 0.58 },
+  { id: "violet", label: "Rrobë Vjollcë", feltTop: "#8b5cf6", feltBottom: "#5b21b6", border: "#241055", emissive: "#6d28d9", emissiveIntensity: 0.58 },
+  { id: "amber", label: "Rrobë Qelibari", feltTop: "#f59e0b", feltBottom: "#b45309", border: "#3b1a02", emissive: "#d97706", emissiveIntensity: 0.54 }
 ]);
 
 const TABLE_BASE_OPTIONS = Object.freeze([
@@ -878,19 +882,48 @@ function makeClothTexture({ top = "#155c2a", bottom = "#0b3a1d", border = "#041f
   ctx.fillStyle = gradient;
   ctx.fillRect(0, 0, size, size);
 
+  ctx.save();
+  ctx.globalCompositeOperation = "screen";
+  const glow = ctx.createRadialGradient(size * 0.5, size * 0.45, size * 0.12, size * 0.5, size * 0.45, size * 0.6);
+  glow.addColorStop(0, "rgba(255,255,255,0.25)");
+  glow.addColorStop(0.65, "rgba(255,255,255,0.08)");
+  glow.addColorStop(1, "rgba(255,255,255,0)");
+  ctx.fillStyle = glow;
+  ctx.fillRect(0, 0, size, size);
+  ctx.restore();
+
   ctx.globalAlpha = 0.12;
   ctx.strokeStyle = border;
   ctx.lineWidth = size * 0.012;
   ctx.strokeRect(0, 0, size, size);
   ctx.globalAlpha = 1;
 
-  ctx.globalAlpha = 0.08;
+  ctx.globalAlpha = 0.16;
   ctx.fillStyle = "#ffffff";
   for (let i = 0; i < size; i += 6) {
     ctx.fillRect(i, 0, 1, size);
     ctx.fillRect(0, i, size, 1);
   }
   ctx.globalAlpha = 1;
+
+  const prng = (() => {
+    let value = 246813579;
+    return () => {
+      value = (value * 1664525 + 1013904223) % 4294967296;
+      return value / 4294967296;
+    };
+  })();
+  const image = ctx.getImageData(0, 0, size, size);
+  const { data } = image;
+  for (let idx = 0; idx < data.length; idx += 4) {
+    const fiber = (prng() - 0.5) * 0.18;
+    const greenFactor = 1 + fiber * 0.9;
+    const sideFactor = 1 + fiber * 0.45;
+    data[idx] = Math.min(255, Math.max(0, data[idx] * sideFactor));
+    data[idx + 1] = Math.min(255, Math.max(0, data[idx + 1] * greenFactor));
+    data[idx + 2] = Math.min(255, Math.max(0, data[idx + 2] * sideFactor));
+  }
+  ctx.putImageData(image, 0, 0);
 
   const texture = new THREE.CanvasTexture(canvas);
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
@@ -935,12 +968,15 @@ function updateTableMaterials() {
   tableMaterials.accent.color.set(wood.accent);
 
   const cloth = TABLE_CLOTH_OPTIONS[appearance.tableCloth] ?? TABLE_CLOTH_OPTIONS[0];
-  tableMaterials.felt.color.set(cloth.feltTop);
+  tableMaterials.felt.color.set(0xffffff);
+  tableMaterials.felt.emissive.set(cloth.emissive ?? adjustHexColor(cloth.feltTop, 0.2));
+  tableMaterials.felt.emissiveIntensity = cloth.emissiveIntensity ?? 0.34;
   if (tableMaterials.felt.map) {
     tableMaterials.felt.map.dispose();
   }
   tableMaterials.felt.map = makeClothTexture({ top: cloth.feltTop, bottom: cloth.feltBottom, border: cloth.border });
   tableMaterials.felt.map.needsUpdate = true;
+  tableMaterials.felt.needsUpdate = true;
 
   const base = TABLE_BASE_OPTIONS[appearance.tableBase] ?? TABLE_BASE_OPTIONS[0];
   tableMaterials.base.color.set(base.base);
@@ -966,7 +1002,9 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   const feltShape = createRegularPolygonShape(sides, CLOTH_RADIUS);
   const rimInnerShape = createRegularPolygonShape(sides, TABLE_INNER_RADIUS);
 
-  const topGeo = new THREE.ExtrudeGeometry(topShape, {
+  const topShapeWithHole = topShape.clone();
+  topShapeWithHole.holes.push(feltShape);
+  const topGeo = new THREE.ExtrudeGeometry(topShapeWithHole, {
     depth: TABLE_TOP_DEPTH,
     bevelEnabled: true,
     bevelThickness: TABLE_TOP_DEPTH * 0.55,
@@ -984,7 +1022,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   const feltGeo = new THREE.ExtrudeGeometry(feltShape, { depth: 0.01, bevelEnabled: false });
   feltGeo.rotateX(-Math.PI / 2);
   const feltMesh = new THREE.Mesh(feltGeo, tableMaterials.felt);
-  feltMesh.position.y = CLOTH_TOP;
+  feltMesh.position.y = CLOTH_TOP + 0.0025;
   feltMesh.receiveShadow = true;
   tableG.add(feltMesh);
   tableParts.felt = feltMesh;


### PR DESCRIPTION
## Summary
- expose the Domino Royal table cloth by carving a window in the wooden top, raising the felt surface slightly, and refreshing the cloth texture and emissive palette so the green fabric reads clearly
- slim down and constrain the table setup menu with scrolling content to keep options comfortable on mobile portrait layouts

## Testing
- Manual - Opened `domino-royal.html` via `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the felt surface and setup panel on a mobile viewport


------
https://chatgpt.com/codex/tasks/task_e_68f8b8cbf74083298a277e421d4725da