### PR TITLE
Ensure multiplayer tables rotate turns clockwise

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -2574,7 +2574,7 @@ function startGame(){
     }
   }
   renderChain();
-  current=(starter+1)%N;
+  current=(starter+N-1)%N;
   updateInteractivity();
   if(current!==human){
     scheduleCpuPlay();
@@ -2836,7 +2836,7 @@ function nextTurn(){
   if(checkForBlockedGame()){
     return;
   }
-  current=(current+1)%N;
+  current=(current+N-1)%N;
   if(checkForBlockedGame()){
     return;
   }

--- a/webapp/src/pages/Games/BlackJackArena.jsx
+++ b/webapp/src/pages/Games/BlackJackArena.jsx
@@ -922,8 +922,9 @@ function dealInitialCards(state) {
 }
 
 function getNextPlayerIndex(players, start) {
-  for (let offset = 1; offset <= players.length; offset += 1) {
-    const idx = (start + offset) % players.length;
+  const totalPlayers = players.length;
+  for (let offset = 1; offset <= totalPlayers; offset += 1) {
+    const idx = ((start - offset) % totalPlayers + totalPlayers) % totalPlayers;
     const player = players[idx];
     if (!player) continue;
     if (!player.isDealer && player.bet > 0 && !player.bust) {

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1872,7 +1872,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides }) {
   const advanceTurn = (extraTurn) => {
     setUi((s) => {
       if (s.winner) return s;
-      const nextTurn = extraTurn ? s.turn : (s.turn + 1) % 4;
+      const totalPlayers = DEFAULT_PLAYER_COUNT;
+      const nextTurn = extraTurn ? s.turn : (s.turn - 1 + totalPlayers) % totalPlayers;
       const state = stateRef.current;
       if (state) state.turn = nextTurn;
       updateTurnIndicator(nextTurn);

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1855,17 +1855,18 @@ function dealHands(deck, playerCount) {
   let idx = 0;
   deck.forEach((card) => {
     hands[idx].push(card);
-    idx = (idx + 1) % playerCount;
+    idx = (idx - 1 + playerCount) % playerCount;
   });
   return hands;
 }
 
 function getNextAlive(players, index) {
   if (!players.length) return 0;
-  let next = (index + 1) % players.length;
+  const totalPlayers = players.length;
+  let next = ((index - 1) % totalPlayers + totalPlayers) % totalPlayers;
   let safety = 0;
   while (players[next]?.finished) {
-    next = (next + 1) % players.length;
+    next = (next - 1 + totalPlayers) % totalPlayers;
     safety += 1;
     if (safety > players.length) return index;
   }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1026,6 +1026,7 @@ export default function SnakeAndLadder() {
     let p = state.pos ?? 0;
     let aiPos = [...(state.aiPositions ?? Array(ai).fill(0))];
     let turn = state.currentTurn ?? 0;
+    const totalPlayers = ai + 1;
     let rank = [...(state.ranking ?? [])].map((r) =>
       typeof r === 'string' ? { name: r, photoUrl: '', amount: 0 } : r,
     );
@@ -1068,7 +1069,7 @@ export default function SnakeAndLadder() {
           if (rank.length === 1) over = true;
         }
       }
-      turn = (turn + 1) % (ai + 1);
+      turn = (turn - 1 + totalPlayers) % totalPlayers;
       elapsed -= 2500;
     }
     setPos(p);
@@ -1232,7 +1233,8 @@ export default function SnakeAndLadder() {
           setMessage("Need a 1 to win!");
           setTurnMessage("");
           setDiceVisible(false);
-          const next = (currentTurn + 1) % (ai + 1);
+          const totalPlayers = ai + 1;
+          const next = (currentTurn - 1 + totalPlayers) % totalPlayers;
           setTimeout(() => {
             setCurrentTurn(next);
             setDiceCount(playerDiceCounts[next] ?? 2);
@@ -1249,7 +1251,8 @@ export default function SnakeAndLadder() {
           setMessage("");
           setTurnMessage("");
           setDiceVisible(false);
-          const next = (currentTurn + 1) % (ai + 1);
+          const totalPlayers = ai + 1;
+          const next = (currentTurn - 1 + totalPlayers) % totalPlayers;
           setTimeout(() => {
             setCurrentTurn(next);
             setDiceCount(playerDiceCounts[next] ?? 2);
@@ -1264,7 +1267,8 @@ export default function SnakeAndLadder() {
         setShowExactHelp(true);
         setTurnMessage("");
         setDiceVisible(false);
-        const next = (currentTurn + 1) % (ai + 1);
+        const totalPlayers = ai + 1;
+        const next = (currentTurn - 1 + totalPlayers) % totalPlayers;
         setTimeout(() => {
           setCurrentTurn(next);
           setDiceCount(playerDiceCounts[next] ?? 2);
@@ -1281,7 +1285,10 @@ export default function SnakeAndLadder() {
         predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
       }
       const extraPred = diceCells[predicted] || doubleSix;
-      const nextPlayer = extraPred ? currentTurn : (currentTurn + 1) % (ai + 1);
+      const totalPlayers = ai + 1;
+      const nextPlayer = extraPred
+        ? currentTurn
+        : (currentTurn - 1 + totalPlayers) % totalPlayers;
 
       const steps = [];
       for (let i = current + 1; i <= target; i++) steps.push(i);
@@ -1382,7 +1389,10 @@ export default function SnakeAndLadder() {
         setDiceVisible(true);
         setMoving(false);
         if (!gameOver) {
-          const next = extraTurn ? currentTurn : (currentTurn + 1) % (ai + 1);
+          const totalPlayers = ai + 1;
+          const next = extraTurn
+            ? currentTurn
+            : (currentTurn - 1 + totalPlayers) % totalPlayers;
           setCurrentTurn(next);
           setDiceCount(playerDiceCounts[next] ?? 2);
         }
@@ -1463,7 +1473,8 @@ export default function SnakeAndLadder() {
       } else {
         setTurnMessage(`${getPlayerName(index)} needs a 6`);
         setDiceVisible(false);
-        const next = (currentTurn + 1) % (ai + 1);
+        const totalPlayers = ai + 1;
+        const next = (currentTurn - 1 + totalPlayers) % totalPlayers;
         setTimeout(() => {
           setCurrentTurn(next);
           setDiceCount(playerDiceCounts[next] ?? 2);
@@ -1476,7 +1487,8 @@ export default function SnakeAndLadder() {
       else {
         setTurnMessage('');
         setDiceVisible(false);
-        const next = (currentTurn + 1) % (ai + 1);
+        const totalPlayers = ai + 1;
+        const next = (currentTurn - 1 + totalPlayers) % totalPlayers;
         setTimeout(() => {
           setCurrentTurn(next);
           setDiceCount(playerDiceCounts[next] ?? 2);
@@ -1495,7 +1507,10 @@ export default function SnakeAndLadder() {
       predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
     }
     const extraPred = diceCells[predicted] || doubleSix;
-    const nextPlayer = extraPred ? index : (index + 1) % (ai + 1);
+    const totalPlayers = ai + 1;
+    const nextPlayer = extraPred
+      ? index
+      : (index - 1 + totalPlayers) % totalPlayers;
 
     const steps = [];
     for (let i = current + 1; i <= target; i++) steps.push(i);
@@ -1577,7 +1592,8 @@ export default function SnakeAndLadder() {
       } else if (doubleSix) {
         extraTurn = true;
       }
-      const next = extraTurn ? index : (index + 1) % (ai + 1);
+      const totalPlayers = ai + 1;
+      const next = extraTurn ? index : (index - 1 + totalPlayers) % totalPlayers;
       if (next === 0) setTurnMessage('Your turn');
       setCurrentTurn(next);
       setDiceCount(playerDiceCounts[next] ?? 2);

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -1041,7 +1041,10 @@ function resetForNextHand(state) {
   next.pot = 0;
   next.currentBet = 0;
   next.minRaise = BIG_BLIND;
-  next.dealerIndex = (state.dealerIndex + 1) % state.players.length;
+  const totalPlayers = state.players.length;
+  next.dealerIndex = totalPlayers
+    ? (state.dealerIndex - 1 + totalPlayers) % totalPlayers
+    : 0;
   next.winningCommunityCards = [];
   next.winnerFocusIndex = null;
   next.players = state.players.map((p, idx) => ({
@@ -1112,8 +1115,9 @@ function payChips(player, amount, state) {
 
 function getNextActiveIndex(players, startIndex) {
   if (!players.length) return 0;
-  for (let offset = 1; offset <= players.length; offset += 1) {
-    const idx = (startIndex + offset) % players.length;
+  const totalPlayers = players.length;
+  for (let offset = 1; offset <= totalPlayers; offset += 1) {
+    const idx = ((startIndex - offset) % totalPlayers + totalPlayers) % totalPlayers;
     const p = players[idx];
     if (!p) continue;
     if (!p.folded && p.chips > 0 && !p.allIn) {


### PR DESCRIPTION
## Summary
- update Snake & Ladder turn progression so that the fast-forward path and in-game transitions advance clockwise
- rotate the turn sequence clockwise in Ludo Battle Royal, Murlan Royale, Texas Hold'em, Blackjack, and Domino by adjusting their turn helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f8e96ee8ac83299e13512f87e9a4a0