### PR TITLE
Fix Pool Royale pocket jaw orientation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4626,7 +4626,7 @@ function Table3D(
         sz * (innerHalfH - cornerInset)
       );
       const center = resolvePocketCenter(scaledMP, fallbackCenter.x, fallbackCenter.y);
-      const orientationAngle = Math.atan2(-sz, -sx);
+      const orientationAngle = Math.atan2(sz, sx);
       addPocketJaw({
         center,
         baseRadius: cornerBaseRadius,
@@ -4645,7 +4645,7 @@ function Table3D(
       const scaledMP = scaleSidePocketCut(baseMP);
       const fallbackCenter = new THREE.Vector2(sx * (innerHalfW - sideInset), 0);
       const center = resolvePocketCenter(scaledMP, fallbackCenter.x, fallbackCenter.y);
-      const orientationAngle = Math.atan2(0, -sx);
+      const orientationAngle = Math.atan2(0, sx);
       addPocketJaw({
         center,
         baseRadius: sideBaseRadius,


### PR DESCRIPTION
## Summary
- flip the Pool Royale pocket jaw orientation so the liners follow the rail cutouts

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f92753c61c832999689ffb072df3ac