### PR TITLE
Expand Pool Royale pocket jaw coverage

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -443,10 +443,10 @@ const TABLE = {
   WALL: 2.6 * TABLE_SCALE
 };
 const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top edge meets the green cushions cleanly
-const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.082; // extend the corner jaws farther so they blanket the rounded rail cut
-const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 1.046; // nudge the middle jaws outward just enough to hide the side rail cut
-const POCKET_JAW_CORNER_INNER_SCALE = 1.129; // rebalance after the limit expansion to preserve the mouth opening
-const POCKET_JAW_SIDE_INNER_SCALE = 0.994; // keep the middle jaw interior anchored while the outer edge grows
+const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.13; // push the corner jaws farther so they blanket the wood rail cutouts completely
+const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 1.095; // extend the middle jaws further to hide the side rail reliefs from both sides
+const POCKET_JAW_CORNER_INNER_SCALE = 1.081042; // rebalance after the wider limit so the mouth opening stays consistent
+const POCKET_JAW_SIDE_INNER_SCALE = 0.94952; // keep the middle jaw interior locked in place while the outer edge grows
 const POCKET_JAW_CORNER_OUTER_SCALE = 1.38173; // match the extended corner limit without shrinking the pocket opening
 const POCKET_JAW_SIDE_OUTER_SCALE = 1.22693; // track the wider middle limit while leaving the inner mouth untouched
 const POCKET_JAW_DEPTH_SCALE = 0.46; // proportion of the rail height the jaw liner drops into the pocket cut
@@ -463,7 +463,7 @@ const POCKET_JAW_OUTER_EXPONENT_MAX = 1.08;
 const POCKET_JAW_INNER_EXPONENT_MIN = 0.85; // controls inner lip easing toward the cushion
 const POCKET_JAW_INNER_EXPONENT_MAX = 1.22;
 const POCKET_JAW_SEGMENT_MIN = 64; // base tessellation for smoother arcs
-const POCKET_JAW_CLOTH_CONTACT_PAD = TABLE.THICK * 0.004; // stop the jaws right as they touch the green cloth
+const POCKET_JAW_CLOTH_CONTACT_PAD = 0; // let the jaws run right up to the green cloth without leaving a standoff gap
 const CORNER_JAW_ARC_DEG = 54;
 const SIDE_JAW_ARC_DEG = 52;
 const FRAME_TOP_Y = -TABLE.THICK + 0.01 - TABLE.THICK * 0.012; // drop the rail assembly so the frame meets the skirt without a gap


### PR DESCRIPTION
## Summary
- extend the Pool Royale pocket jaw outer limits so both the corner and side jaws blanket the exposed wood cuts while preserving the mouth opening
- remove the cloth contact pad so the jaws now meet the green cushion without leaving a gap

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f9c62924748329950e59f22e2979ca