### PR TITLE
Fix suite placement and restore yellow goal net

### DIFF
--- a/webapp/src/components/FreeKick3DGame.jsx
+++ b/webapp/src/components/FreeKick3DGame.jsx
@@ -628,10 +628,10 @@ export default function FreeKick3DGame({ config }) {
           else ctx.lineTo(x, y);
         }
         ctx.closePath();
-        ctx.shadowColor = 'rgba(0,0,0,0.65)';
-        ctx.shadowBlur = 3.5;
+        ctx.shadowColor = 'rgba(0,0,0,0.45)';
+        ctx.shadowBlur = 2.5;
         ctx.lineWidth = outlineWidth;
-        ctx.strokeStyle = '#111827';
+        ctx.strokeStyle = '#facc15';
         ctx.stroke();
         ctx.shadowColor = 'transparent';
         ctx.lineWidth = innerWidth;
@@ -653,16 +653,21 @@ export default function FreeKick3DGame({ config }) {
       return texture;
     })();
 
+    const netColor = new THREE.Color('#facc15');
+    const netEmissive = netColor.clone().multiplyScalar(0.25);
     const netMaterial = new THREE.MeshPhysicalMaterial({
       map: netTexture,
       transparent: true,
       alphaMap: netTexture,
       side: THREE.DoubleSide,
-      roughness: 0.85,
-      metalness: 0.08,
+      color: netColor,
+      emissive: netEmissive,
+      emissiveIntensity: 1,
+      roughness: 0.72,
+      metalness: 0.05,
       transmission: 0,
       clearcoat: 0.2,
-      clearcoatRoughness: 0.5,
+      clearcoatRoughness: 0.42,
       alphaTest: 0.35
     });
 
@@ -1004,7 +1009,8 @@ export default function FreeKick3DGame({ config }) {
     const topRowY = topTierConfig.baseY + (STAND_ROWS - 1) * STAND_ROW_RISE;
     const topRowZ = -((STAND_ROWS - 1) * STAND_ROW_DEPTH) + topTierConfig.depthOffset;
     const suiteBaseY = topRowY + 1.2;
-    const suiteCenterZ = topRowZ - 6.5;
+    const SUITE_BACK_OFFSET = 3.5;
+    const suiteCenterZ = topRowZ - SUITE_BACK_OFFSET;
     const terraceGroup = new THREE.Group();
     const suiteDeck = new THREE.Mesh(suiteDeckGeo, standConcreteMaterial);
     const deckHeight = suiteBaseY - suiteDeckGeo.parameters.height / 2;
@@ -1080,7 +1086,8 @@ export default function FreeKick3DGame({ config }) {
     const stadiumRoof = new THREE.Mesh(canopyGeometry, canopyMaterial);
     stadiumRoof.castShadow = true;
     stadiumRoof.receiveShadow = true;
-    stadiumRoof.position.set(0, suiteBaseY + suiteGeo.parameters.height + 2.5, suiteCenterZ - 32);
+    const CANOPY_REAR_OFFSET = 18;
+    stadiumRoof.position.set(0, suiteBaseY + suiteGeo.parameters.height + 2.5, suiteCenterZ - CANOPY_REAR_OFFSET);
     suitesGroup.add(stadiumRoof);
 
     const roofSupportMaterial = new THREE.MeshStandardMaterial({
@@ -1098,7 +1105,7 @@ export default function FreeKick3DGame({ config }) {
       support.position.set(
         i * 22,
         suiteBaseY - 0.4 + supportHeight / 2,
-        suiteCenterZ - 40
+        suiteCenterZ - 26
       );
       roofSupports.add(support);
     }
@@ -1111,6 +1118,8 @@ export default function FreeKick3DGame({ config }) {
       clearcoatRoughness: 0.28
     });
     const roofStruts = new THREE.Group();
+    const CANOPY_FORWARD_ANCHOR_OFFSET = 10;
+    const CANOPY_MID_ANCHOR_OFFSET = CANOPY_REAR_OFFSET;
     roofSupports.children.forEach((support) => {
       const supportTop = new THREE.Vector3(
         support.position.x,
@@ -1120,12 +1129,12 @@ export default function FreeKick3DGame({ config }) {
       const forwardAnchor = new THREE.Vector3(
         support.position.x,
         suiteBaseY + suiteGeo.parameters.height + 6,
-        suiteCenterZ - 26
+        suiteCenterZ - CANOPY_FORWARD_ANCHOR_OFFSET
       );
       const midAnchor = new THREE.Vector3(
         support.position.x,
         suiteBaseY + suiteGeo.parameters.height + 4.5,
-        suiteCenterZ - 32
+        suiteCenterZ - CANOPY_MID_ANCHOR_OFFSET
       );
       [forwardAnchor, midAnchor].forEach((target, index) => {
         const strut = makeTubeBetween(supportTop, target, index === 0 ? 0.55 : 0.45, roofStrutMaterial);
@@ -1142,12 +1151,12 @@ export default function FreeKick3DGame({ config }) {
       const crossStart = new THREE.Vector3(
         leftSupport.position.x,
         suiteBaseY + suiteGeo.parameters.height + 4.5,
-        suiteCenterZ - 32
+        suiteCenterZ - CANOPY_MID_ANCHOR_OFFSET
       );
       const crossEnd = new THREE.Vector3(
         rightSupport.position.x,
         suiteBaseY + suiteGeo.parameters.height + 4.5,
-        suiteCenterZ - 32
+        suiteCenterZ - CANOPY_MID_ANCHOR_OFFSET
       );
       const crossBrace = makeTubeBetween(crossStart, crossEnd, 0.42, roofStrutMaterial);
       if (crossBrace) {


### PR DESCRIPTION
## Summary
- move the VIP suites and canopy closer to the top stand tier so the rooms sit correctly above the stairs
- realign roof supports and struts to match the relocated canopy structure
- restore a vibrant yellow goal net with updated material settings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f9d99b9f008329b9268aebff0675a8