### PR TITLE
Extend Pool Royale pocket jaw coverage

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -472,15 +472,15 @@ const TABLE = {
   WALL: 2.6 * TABLE_SCALE
 };
 const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top edge meets the green cushions cleanly
-const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.312; // extend the corner jaws to the photographed chrome footprint of a Supreme Winner corner
-const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 1.332; // stretch the side jaws so their chrome coverage mirrors the reference table photos
+const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.392; // extend the corner jaws across the full chrome arch seen on the Supreme Winner reference
+const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 1.462; // stretch the side jaws so their chrome coverage mirrors the full arch in the reference table photos
 const POCKET_JAW_CORNER_INNER_SCALE = 1.097; // maintain the observed mouth width while accommodating the wider outer shell
 const POCKET_JAW_SIDE_INNER_SCALE = 0.936; // keep the side jaw interior aligned with the cloth edge seen in the photos
-const POCKET_JAW_CORNER_OUTER_SCALE = 1.623; // preserve the playable mouth while matching the longer corner jaw fascia
-const POCKET_JAW_SIDE_OUTER_SCALE = 1.512; // keep the side mouth while matching the wide chrome-backed jaw liner
+const POCKET_JAW_CORNER_OUTER_SCALE = 1.723; // preserve the playable mouth while matching the longer corner jaw fascia
+const POCKET_JAW_SIDE_OUTER_SCALE = 1.658; // keep the side mouth while matching the wide chrome-backed jaw liner
 const POCKET_JAW_DEPTH_SCALE = 0.63; // proportion of the rail height the jaw liner drops into the pocket cut (≈3" drop as photographed)
-const POCKET_RIM_FIELD_PULL = 0.148; // pull the rim toward the cloth so the jaw lip wraps around like the reference build
-const POCKET_RIM_DEPTH_SCALE = 0.33; // depth of the rim extrusion relative to the deeper jaw body
+const POCKET_RIM_FIELD_PULL = 0.34; // pull the rim toward the cloth so the jaw lip wraps around like the reference build
+const POCKET_RIM_DEPTH_SCALE = 0.48; // depth of the rim extrusion relative to the deeper jaw body
 const POCKET_RIM_LIP = TABLE.THICK * 0.044; // lift the rim so it sits proud of the chrome plates exactly as in the photos
 const POCKET_JAW_EDGE_FLUSH_START = 0.14; // begin easing the jaw back out earlier so the lip stays long and flush with chrome
 const POCKET_JAW_EDGE_FLUSH_END = 1; // ensure the jaw and rim finish perfectly flush with the chrome trim at the very ends


### PR DESCRIPTION
## Summary
- extend the Pool Royale corner and side pocket jaw outer limit scales so the liners follow the full chrome arch
- increase the pocket rim pull and depth to create a thicker lip above the chrome trim

## Testing
- npm run lint -- webapp/src/pages/Games/PoolRoyale.jsx *(fails: repository already contains extensive lint issues outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f9fd33afd08329af8bbb0328c3b228