### PR TITLE
Expand Pool Royale pocket jaw spans

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -497,7 +497,8 @@ const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.2; // widen the middle pocket jaws 2
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1.5; // enlarge the side pocket jaw footprint by 50%
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.5; // sink the middle pocket jaws deeper into the pocket by 50%
 const SIDE_POCKET_RIM_FIELD_PULL = 0.08; // keep the middle pocket rim hugging the chrome arc instead of the field
-const CORNER_JAW_ARC_DEG = 54 * 1.5; // expand the corner jaw span 50% further along the rails
+const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.5; // widen the corner pocket jaws 50% along both rails
+const CORNER_JAW_ARC_DEG = 54; // base corner jaw span before lateral expansion
 const SIDE_JAW_ARC_DEG = 52; // base side jaw span; middle-pocket expansion happens via SIDE_POCKET_JAW_LATERAL_EXPANSION
 const FRAME_TOP_Y = -TABLE.THICK + 0.01 - TABLE.THICK * 0.012; // drop the rail assembly so the frame meets the skirt without a gap
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
@@ -4691,6 +4692,12 @@ function Table3D(
       } else {
         effectiveBaseRadius = baseRadius * SIDE_POCKET_JAW_RADIUS_EXPANSION;
       }
+    } else {
+      localJawAngle *= CORNER_POCKET_JAW_LATERAL_EXPANSION;
+      steps = Math.max(
+        steps,
+        Math.ceil(steps * CORNER_POCKET_JAW_LATERAL_EXPANSION)
+      );
     }
 
     const jawShape = buildPocketJawShape({


### PR DESCRIPTION
## Summary
- introduce a dedicated constant to control the 50% lateral expansion of Pool Royale corner pocket jaws
- apply the corner jaw expansion during geometry generation and increase tessellation so the wider span renders smoothly

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa385b2abc8329a8873abe7efc7947