### PR TITLE
Adjust Pool Royale pocket jaw span to half the pocket

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -497,8 +497,8 @@ const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // rely on the chrome limit scale to
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.5; // sink the middle pocket jaws deeper into the pocket by 50%
 const SIDE_POCKET_RIM_FIELD_PULL = 0.08; // keep the middle pocket rim hugging the chrome arc instead of the field
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.5; // widen the corner pocket jaws 50% along both rails
-const CORNER_JAW_ARC_DEG = 54; // base corner jaw span before lateral expansion
-const SIDE_JAW_ARC_DEG = 52; // base side jaw span; middle-pocket expansion happens via SIDE_POCKET_JAW_LATERAL_EXPANSION
+const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage
+const SIDE_JAW_ARC_DEG = 150; // base side jaw span tuned so expansion covers half of the pocket circumference
 const FRAME_TOP_Y = -TABLE.THICK + 0.01 - TABLE.THICK * 0.012; // drop the rail assembly so the frame meets the skirt without a gap
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
 // Dimensions reflect WPA specifications (playing surface 100" × 50")


### PR DESCRIPTION
## Summary
- retune the Pool Royale jaw arc constants so the expanded meshes wrap 50% of each pocket circumference

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa63ef74b88329b04037db8371f52e