### PR TITLE
Align pool pocket jaws with chrome arches

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -472,8 +472,8 @@ const TABLE = {
   WALL: 2.6 * TABLE_SCALE
 };
 const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top edge meets the green cushions cleanly
-const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.5; // allow the corner jaw footprint to widen 50%
-const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 1.2; // allow the middle pocket jaw footprint to widen 20%
+const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1; // keep corner jaw footprint locked to the chrome plate cut radius
+const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 1; // keep middle jaw footprint locked to the chrome plate cut radius
 const POCKET_JAW_CORNER_INNER_SCALE = 1.097; // maintain the observed mouth width while accommodating the wider outer shell
 const POCKET_JAW_SIDE_INNER_SCALE = 0.936; // keep the side jaw interior aligned with the cloth edge seen in the photos
 const POCKET_JAW_CORNER_OUTER_SCALE = 1.723; // preserve the playable mouth while matching the longer corner jaw fascia
@@ -4743,9 +4743,15 @@ function Table3D(
   // Each pocket jaw must match 100% to the rounded chrome plate cuts—never the wooden rail arches.
   // Repeat: each pocket jaw must match 100% to the size of the rounded cuts on the chrome plates.
   const cornerJawOuterLimit =
-    cornerPocketRadius * CHROME_CORNER_POCKET_RADIUS_SCALE * POCKET_JAW_CORNER_OUTER_LIMIT_SCALE;
+    cornerPocketRadius *
+    CHROME_CORNER_POCKET_RADIUS_SCALE *
+    CHROME_CORNER_POCKET_CUT_SCALE *
+    POCKET_JAW_CORNER_OUTER_LIMIT_SCALE;
   const sideJawOuterLimit =
-    sidePocketRadius * CHROME_SIDE_POCKET_RADIUS_SCALE * POCKET_JAW_SIDE_OUTER_LIMIT_SCALE;
+    sidePocketRadius *
+    CHROME_SIDE_POCKET_RADIUS_SCALE *
+    CHROME_SIDE_POCKET_CUT_SCALE *
+    POCKET_JAW_SIDE_OUTER_LIMIT_SCALE;
 
   const resolveBaseRadius = (outerLimit, outerScale) => {
     if (!Number.isFinite(outerLimit) || outerLimit <= MICRO_EPS) {


### PR DESCRIPTION
## Summary
- lock the corner pocket jaw and rim outer limits to the chrome plate cut radius so they mirror the plate arches
- match the side pocket jaw and rim limits to the side chrome plate cut, keeping middle pockets independent from the corners

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa671b9b988329ad5975ba02337ecc