### PR TITLE
Adjust Pool Royale side pocket geometry

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -475,13 +475,13 @@ const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1; // keep corner jaw footprint locked to the chrome plate cut radius
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 1; // keep middle jaw footprint locked to the chrome plate cut radius
 const POCKET_JAW_CORNER_INNER_SCALE = 1.097; // maintain the observed mouth width while accommodating the wider outer shell
-const POCKET_JAW_SIDE_INNER_SCALE = 0.936; // keep the side jaw interior aligned with the cloth edge seen in the photos
+const POCKET_JAW_SIDE_INNER_SCALE = 0.95; // keep the side jaw interior aligned with the cloth edge seen in the photos
 const POCKET_JAW_CORNER_OUTER_SCALE = 1.723; // preserve the playable mouth while matching the longer corner jaw fascia
-const POCKET_JAW_SIDE_OUTER_SCALE = 1.81; // keep the side mouth consistent while letting the liner reach the longer chrome-backed arch
+const POCKET_JAW_SIDE_OUTER_SCALE = 1.78; // keep the side mouth consistent while letting the liner reach the longer chrome-backed arch
 const POCKET_JAW_DEPTH_SCALE = 0.63; // proportion of the rail height the jaw liner drops into the pocket cut (≈3" drop as photographed)
-const POCKET_RIM_FIELD_PULL = 0.34; // pull the rim toward the cloth so the jaw lip wraps around like the reference build
+const POCKET_RIM_FIELD_PULL = 0.24; // pull the rim toward the cloth so the jaw lip wraps around like the reference build
 const POCKET_RIM_DEPTH_SCALE = 0.48; // depth of the rim extrusion relative to the deeper jaw body
-const POCKET_RIM_LIP = TABLE.THICK * 0.044; // lift the rim so it sits proud of the chrome plates exactly as in the photos
+const POCKET_RIM_LIP = TABLE.THICK * 0.05; // lift the rim so it sits proud of the chrome plates exactly as in the photos
 const POCKET_JAW_EDGE_FLUSH_START = 0.14; // begin easing the jaw back out earlier so the lip stays long and flush with chrome
 const POCKET_JAW_EDGE_FLUSH_END = 1; // ensure the jaw and rim finish perfectly flush with the chrome trim at the very ends
 const POCKET_JAW_EDGE_TAPER_SCALE = 0.24; // keep the edge thickness closer to the real jaw profile before it feathers into the cushion line
@@ -492,10 +492,10 @@ const POCKET_JAW_OUTER_EXPONENT_MAX = 1.2;
 const POCKET_JAW_INNER_EXPONENT_MIN = 0.78; // controls inner lip easing toward the cushion
 const POCKET_JAW_INNER_EXPONENT_MAX = 1.34;
 const POCKET_JAW_SEGMENT_MIN = 96; // base tessellation for smoother arcs
-const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.2; // widen the middle pocket jaws 20% along the side rails
-const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // rely on the chrome limit scale to widen the footprint by 20%
+const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.08; // widen the middle pocket jaws 8% along the side rails
+const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // rely on the chrome limit scale while respecting the slimmer side jaws
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.5; // sink the middle pocket jaws deeper into the pocket by 50%
-const SIDE_POCKET_RIM_FIELD_PULL = 0.08; // keep the middle pocket rim hugging the chrome arc instead of the field
+const SIDE_POCKET_RIM_FIELD_PULL = 0; // let the middle pocket rim sit directly above the chrome arc instead of drifting inward
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.5; // widen the corner pocket jaws 50% along both rails
 const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage
 const SIDE_JAW_ARC_DEG = 150; // base side jaw span tuned so expansion covers half of the pocket circumference
@@ -549,7 +549,7 @@ const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
 const POCKET_CORNER_MOUTH_SCALE = 1.5; // widen the corner pocket jaws 50%
-const POCKET_SIDE_MOUTH_SCALE = 1.2; // widen the middle pocket jaws 20%
+const POCKET_SIDE_MOUTH_SCALE = 1.12; // widen the middle pocket jaws 12%
 const POCKET_CORNER_MOUTH =
   CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
 const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
@@ -4215,7 +4215,7 @@ function Table3D(
     CORNER_POCKET_CENTER_INSET +
     CORNER_NOTCH_EXTRA_INSET;
   const sideInset =
-    SIDE_POCKET_RADIUS * 0.76 * POCKET_VISUAL_EXPANSION; // push the middle rail cuts slightly farther outward so the chrome and rail rounding hug the side rails tighter
+    SIDE_POCKET_RADIUS * 0.7 * POCKET_VISUAL_EXPANSION; // push the middle rail cuts farther outward so the chrome and rail rounding stay tight to the side rails
 
   const circlePoly = (cx, cz, r, seg = 96) => {
     const pts = [];


### PR DESCRIPTION
## Summary
- slim the Pool Royale side pocket jaws and reduce their mouth size for closer parity with the corner pockets
- nudge the side pocket cuts, rims, and chrome alignments outward so the assemblies sit directly above the plates
- slightly raise the rim lip to keep the reshaped pocket edges clear of the chrome trim

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa6d36ef4083299dd0964876898113