### PR TITLE
Add snooker-styled 9ft Pool Royale table option

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -4,6 +4,19 @@ const BASE_TABLE_COMPACT_SCALE = 1.44;
 const BASE_PLAYFIELD_WIDTH_MM = 2540; // WPA 9 ft playing surface width (100")
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
+  '9ft': {
+    id: '9ft',
+    label: '9 ft Pro',
+    playfield: Object.freeze({ widthMm: 2540, heightMm: 1270 }), // 100" × 50"
+    ballDiameterMm: 57.15,
+    pocketMouthMm: Object.freeze({
+      corner: 114.3,
+      side: 127
+    }),
+    cushionCutAngleDeg: 32,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
+    componentPreset: 'snooker'
+  },
   '8ft': {
     id: '8ft',
     label: '8 ft',
@@ -14,7 +27,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 152.4
     }),
     cushionCutAngleDeg: 32,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
+    componentPreset: 'pool'
   }
 });
 
@@ -56,7 +70,7 @@ export const TABLE_SIZE_OPTIONS = Object.freeze(
   }, {})
 );
 
-export const DEFAULT_TABLE_SIZE_ID = '8ft';
+export const DEFAULT_TABLE_SIZE_ID = '9ft';
 
 export function resolveTableSize(sizeId) {
   const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -10,7 +10,10 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
-import { resolveTableSize } from '../../config/poolRoyaleTables.js';
+import {
+  resolveTableSize,
+  TABLE_SIZE_LIST
+} from '../../config/poolRoyaleTables.js';
 
 export default function PoolRoyaleLobby() {
   const navigate = useNavigate();
@@ -22,7 +25,9 @@ export default function PoolRoyaleLobby() {
   const [avatar, setAvatar] = useState('');
   const [variant, setVariant] = useState('uk');
   const searchParams = new URLSearchParams(search);
-  const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
+  const [tableSize, setTableSize] = useState(() =>
+    resolveTableSize(searchParams.get('tableSize')).id
+  );
   const [playType, setPlayType] = useState('regular');
 
   useEffect(() => {
@@ -31,6 +36,10 @@ export default function PoolRoyaleLobby() {
       setAvatar(saved || getTelegramPhotoUrl());
     } catch {}
   }, []);
+
+  useEffect(() => {
+    setTableSize(resolveTableSize(new URLSearchParams(search).get('tableSize')).id);
+  }, [search]);
 
   const startGame = async () => {
     let tgId;
@@ -149,6 +158,20 @@ export default function PoolRoyaleLobby() {
               key={id}
               onClick={() => setVariant(id)}
               className={`lobby-tile ${variant === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Table</h3>
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {TABLE_SIZE_LIST.map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setTableSize(id)}
+              className={`lobby-tile ${tableSize === id ? 'lobby-selected' : ''}`}
             >
               {label}
             </button>


### PR DESCRIPTION
## Summary
- add a 9 ft pro table specification that keeps the snooker-styled components and mobile scaling
- expose the table size selector in the Pool Royale lobby so players can launch the new table size

## Testing
- npm run lint *(fails: existing lint issues in unrelated legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68fa889fd28c832982fa78a5036d7db2