### PR TITLE
Align Pool Royale pocket cuts with field diameter

### DIFF
--- a/docs/3d-billiards-variants.md
+++ b/docs/3d-billiards-variants.md
@@ -24,6 +24,7 @@ Exactly **four** chalk blocks are visible at all times—one centred on each woo
 - Same table geometry as American Billiards but with neon accent lighting.
 - Power-up spawn pads appear on the long rails; reuse the chalk placement rule so props do not collide.
 - Pocket jaws and rims must match the chrome plate cutouts **100%**—never size them from the wooden rail arches.
+- Rounded cuts in wood rails, chrome plates, and pocket jaws must reuse the exact field pocket diameter.
 
 ### 3D UK 8 Ball
 - 7 ft pub-style table with rounded corners and smaller pockets.

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -250,8 +250,8 @@ const CHROME_SIDE_PLATE_HEIGHT_SCALE = 0.94;
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.06;
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0;
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_CORNER_POCKET_CUT_SCALE = 0.97;
-const CHROME_SIDE_POCKET_CUT_SCALE = 0.97;
+const CHROME_CORNER_POCKET_CUT_SCALE = 1;
+const CHROME_SIDE_POCKET_CUT_SCALE = 1;
 
 function buildChromePlateGeometry({
   width,
@@ -556,8 +556,10 @@ const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_R = POCKET_VIS_R * 0.985;
 const CORNER_POCKET_CENTER_INSET = 0; // align corner pocket centres exactly with the snooker geometry
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
-const CORNER_CHROME_NOTCH_RADIUS = POCKET_VIS_R * POCKET_VISUAL_EXPANSION;
-const SIDE_CHROME_NOTCH_RADIUS = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION;
+const POCKET_FIELD_RADIUS = POCKET_VIS_R * POCKET_VISUAL_EXPANSION; // field pocket mouth controls every rounded cut
+const SIDE_POCKET_FIELD_RADIUS = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION; // side mouth mirrors the field pocket diameter
+const CORNER_CHROME_NOTCH_RADIUS = POCKET_FIELD_RADIUS;
+const SIDE_CHROME_NOTCH_RADIUS = SIDE_POCKET_FIELD_RADIUS;
 const POCKET_MOUTH_TOLERANCE = 0.5 * MM_TO_UNITS;
 console.assert(
   Math.abs(POCKET_CORNER_MOUTH - POCKET_VIS_R * 2) <= POCKET_MOUTH_TOLERANCE,
@@ -4171,7 +4173,7 @@ function Table3D(
   const chromePlateY =
     railsTopY - chromePlateThickness + MICRO_EPS * 2;
 
-  const sidePocketRadius = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION;
+  const sidePocketRadius = SIDE_POCKET_FIELD_RADIUS; // match the playable field mouth exactly
   const sidePlatePocketWidth = sidePocketRadius * 2 * CHROME_SIDE_PLATE_POCKET_SPAN_SCALE;
   const sidePlateMaxWidth = Math.max(
     MICRO_EPS,
@@ -4202,7 +4204,7 @@ function Table3D(
 
   const innerHalfW = halfWext;
   const innerHalfH = halfHext;
-  const cornerPocketRadius = POCKET_VIS_R * 1.1 * POCKET_VISUAL_EXPANSION;
+  const cornerPocketRadius = POCKET_FIELD_RADIUS; // match the playable field mouth exactly
   const cornerChamfer = POCKET_VIS_R * 0.34 * POCKET_VISUAL_EXPANSION;
   const cornerInset =
     POCKET_VIS_R * 0.58 * POCKET_VISUAL_EXPANSION + CORNER_POCKET_CENTER_INSET;
@@ -4687,6 +4689,7 @@ function Table3D(
 
   // Each pocket jaw must match 100% to the rounded chrome plate cuts—never the wooden rail arches.
   // Repeat: each pocket jaw must match 100% to the size of the rounded cuts on the chrome plates.
+  // Because the chrome now mirrors the field pocket diameter exactly, the jaws inherit that precise width too.
   const cornerJawOuterLimit =
     cornerPocketRadius *
     CHROME_CORNER_POCKET_RADIUS_SCALE *
@@ -4790,6 +4793,7 @@ function Table3D(
   }
 
   // Rail openings simply reuse the chrome plate cuts; wood never dictates alternate pocket sizing.
+  // With the chrome following the field pocket diameter, every rounded cut now aligns 1:1 with the cloth openings.
   let openingMP = polygonClipping.union(
     rectPoly(innerHalfW * 2, innerHalfH * 2),
     ...scaleChromeSidePocketCut(sideNotchMP(-1)),


### PR DESCRIPTION
## Summary
- ensure Pool Royale chrome and wood pocket cuts reuse the exact field pocket diameter
- adjust pocket jaw limits to inherit the updated chrome geometry
- document the requirement that every rounded cut matches the field pocket size

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb00c1ad948329a3073af7cb73f66b