### PR TITLE
Adjust Pool Royale rail pocket relief and side jaw sizing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -252,8 +252,8 @@ const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0;
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_CORNER_POCKET_CUT_SCALE = 0.97;
 const CHROME_SIDE_POCKET_CUT_SCALE = 0.97;
-const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // trim the wooden rail cutouts further so chrome defines the pocket arch
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 0.9; // pull middle pocket cutouts in tighter so they sit deeper inside the chrome plate span
+const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.88; // trim the wooden rail cutouts further so chrome defines the pocket arch
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 0.86; // pull middle pocket cutouts in tighter so they sit deeper inside the chrome plate span
 
 function buildChromePlateGeometry({
   width,
@@ -477,7 +477,7 @@ const TABLE = {
 };
 const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top edge meets the green cushions cleanly
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1; // match snooker jaw reach so liners hug the chrome plate cut
-const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 0.96; // pull middle jaw reach in so the liner stays tucked inside the smaller chrome cut
+const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 0.94; // pull middle jaw reach in so the liner stays tucked inside the smaller chrome cut
 const POCKET_JAW_CORNER_INNER_SCALE = 1.11; // ease the inner lip outward so the jaw sits a touch farther from centre
 const POCKET_JAW_SIDE_INNER_SCALE = 0.962; // push the side jaw interior outward to keep the liner flush with the rail edge
 const POCKET_JAW_CORNER_OUTER_SCALE = 1.723; // preserve the playable mouth while matching the longer corner jaw fascia


### PR DESCRIPTION
## Summary
- reduce the wood rail pocket relief so the rounded cuts sit tighter to the chrome plates
- shrink the side rail pocket relief and jaw limit to keep the middle pockets smaller

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb0d64d9f4832994a2736a25a34f9f