### PR TITLE
Tighten Pool Royale pocket relief

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -251,9 +251,12 @@ const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.06;
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0;
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_CORNER_POCKET_CUT_SCALE = 0.97;
+const CORNER_POCKET_RELIEF_SCALE = 0.84; // tighten the wooden rail arches so the chrome lip sets the visual pocket edge
+const SIDE_POCKET_RELIEF_SCALE = 0.72; // middle pocket cuts must hug the chrome span even more aggressively
 const CHROME_SIDE_POCKET_CUT_SCALE = 0.97;
-const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.88; // trim the wooden rail cutouts further so chrome defines the pocket arch
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 0.86; // pull middle pocket cutouts in tighter so they sit deeper inside the chrome plate span
+const WOOD_RAIL_POCKET_RELIEF_SCALE = CORNER_POCKET_RELIEF_SCALE; // trim the wooden rail cutouts further so chrome defines the pocket arch
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE =
+  SIDE_POCKET_RELIEF_SCALE / CORNER_POCKET_RELIEF_SCALE; // pull middle pocket cutouts in tighter so they sit deeper inside the chrome plate span
 
 function buildChromePlateGeometry({
   width,
@@ -476,8 +479,8 @@ const TABLE = {
   WALL: 2.6 * TABLE_SCALE
 };
 const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top edge meets the green cushions cleanly
-const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1; // match snooker jaw reach so liners hug the chrome plate cut
-const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 0.94; // pull middle jaw reach in so the liner stays tucked inside the smaller chrome cut
+const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = CORNER_POCKET_RELIEF_SCALE; // match the tightened wooden rail arches so liners hug the chrome plate cut
+const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = SIDE_POCKET_RELIEF_SCALE; // pull middle jaw reach in so the liner stays tucked inside the smaller chrome cut
 const POCKET_JAW_CORNER_INNER_SCALE = 1.11; // ease the inner lip outward so the jaw sits a touch farther from centre
 const POCKET_JAW_SIDE_INNER_SCALE = 0.962; // push the side jaw interior outward to keep the liner flush with the rail edge
 const POCKET_JAW_CORNER_OUTER_SCALE = 1.723; // preserve the playable mouth while matching the longer corner jaw fascia
@@ -4405,7 +4408,10 @@ function Table3D(
     const centerX = sx * (outerHalfW - chromePlateWidth / 2 - chromePlateInset);
     const centerZ = sz * (outerHalfH - chromePlateHeight / 2 - chromePlateInset);
     // Chrome plates use their own rounded cuts as-is; nothing references the wooden rail arches.
-    const notchMP = scaleChromeCornerPocketCut(cornerNotchMP(sx, sz));
+    const notchMP = scalePocketCutMP(
+      scaleChromeCornerPocketCut(cornerNotchMP(sx, sz)),
+      CORNER_POCKET_RELIEF_SCALE
+    );
     const notchLocalMP = notchMP.map((poly) =>
       poly.map((ring) =>
         ring.map(([x, z]) => [x - centerX, -(z - centerZ)])
@@ -4436,7 +4442,10 @@ function Table3D(
   ].forEach(({ id, sx }) => {
     const centerX = sx * (outerHalfW - sideChromePlateWidth / 2 - chromePlateInset);
     const centerZ = 0;
-    const notchMP = scaleChromeSidePocketCut(sideNotchMP(sx));
+    const notchMP = scalePocketCutMP(
+      scaleChromeSidePocketCut(sideNotchMP(sx)),
+      SIDE_POCKET_RELIEF_SCALE
+    );
     const notchLocalMP = notchMP.map((poly) =>
       poly.map((ring) => ring.map(([x, z]) => [x - centerX, -(z - centerZ)]))
     );


### PR DESCRIPTION
## Summary
- reduce the Pool Royale wooden rail pocket relief to tighten the corner and side cutouts
- align the pocket jaw spans and chrome plate rounded cuts with the new relief so every surface matches

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68fb0fe8639083299c73b14ffc13bbb3