### PR TITLE
Tighten Pool Royale rail and pocket geometry

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -250,10 +250,10 @@ const CHROME_SIDE_PLATE_HEIGHT_SCALE = 0.94;
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.06;
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0;
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_CORNER_POCKET_CUT_SCALE = 0.97;
-const CHROME_SIDE_POCKET_CUT_SCALE = 0.97;
-const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.88; // trim the wooden rail cutouts further so chrome defines the pocket arch
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 0.86; // pull middle pocket cutouts in tighter so they sit deeper inside the chrome plate span
+const CHROME_CORNER_POCKET_CUT_SCALE = 0.94; // tighten the chrome trace so the new rail relief remains fully supported
+const CHROME_SIDE_POCKET_CUT_SCALE = 0.86; // shrink the middle chrome cut significantly to mirror the slimmer wooden span
+const WOOD_RAIL_POCKET_RELIEF_SCALE = 1; // rails now reuse the chrome cut directly so every surface shares the same rounded arch
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1; // middle rail relief follows the chrome cut 1:1 to avoid mismatched pocket jaws
 
 function buildChromePlateGeometry({
   width,
@@ -477,7 +477,7 @@ const TABLE = {
 };
 const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top edge meets the green cushions cleanly
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1; // match snooker jaw reach so liners hug the chrome plate cut
-const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 0.94; // pull middle jaw reach in so the liner stays tucked inside the smaller chrome cut
+const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 1; // keep the middle jaw flush with the matched chrome/wood cut without leaving a gap
 const POCKET_JAW_CORNER_INNER_SCALE = 1.11; // ease the inner lip outward so the jaw sits a touch farther from centre
 const POCKET_JAW_SIDE_INNER_SCALE = 0.962; // push the side jaw interior outward to keep the liner flush with the rail edge
 const POCKET_JAW_CORNER_OUTER_SCALE = 1.723; // preserve the playable mouth while matching the longer corner jaw fascia
@@ -494,7 +494,7 @@ const POCKET_JAW_INNER_EXPONENT_MIN = 0.78; // controls inner lip easing toward 
 const POCKET_JAW_INNER_EXPONENT_MAX = 1.34;
 const POCKET_JAW_SEGMENT_MIN = 96; // base tessellation for smoother arcs
 const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.08; // match snooker jaw flare so liners follow the chrome cut exactly
-const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.97; // shrink side jaw footprint to match the tighter wooden relief
+const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.9; // contract the side jaw footprint further so it follows the smaller side relief exactly
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.5; // keep the drop deep while matching the tighter jaw footprint
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.5; // align the corner jaw spread with the snooker chrome cut geometry
 const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage


### PR DESCRIPTION
## Summary
- tighten the chrome pocket cut scaling so the new, smaller rail relief stays fully supported
- remove the extra wood relief scaling so the rails, chrome plates, and pocket jaws all share the same rounded arcs
- contract the side pocket jaw footprint to track the slimmer middle pocket openings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb1434bf208329bcecdcbb7c9af746