### PR TITLE
Mirror the Snake & Ladder board orientation

### DIFF
--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -64,16 +64,36 @@ function buildPyramidLayout() {
   const totalCells = cell - 1;
   const widthUnits = maxX - minX;
   const heightUnits = maxY;
-  const centerColumn = minX + widthUnits / 2;
+
+  const mirrorColumn = (col) => minX + widthUnits - (col + 1);
+
+  const mirroredTiles = tiles.map((tile) => ({
+    ...tile,
+    col: mirrorColumn(tile.col),
+  }));
+
+  const mirroredLevels = levels.map((level) => ({
+    ...level,
+    xOffset: mirrorColumn(level.xOffset + level.size - 1),
+  }));
+
+  let mirroredMinX = Infinity;
+  let mirroredMaxX = -Infinity;
+  mirroredTiles.forEach((tile) => {
+    mirroredMinX = Math.min(mirroredMinX, tile.col);
+    mirroredMaxX = Math.max(mirroredMaxX, tile.col + 1);
+  });
+
+  const centerColumn = mirroredMinX + (mirroredMaxX - mirroredMinX) / 2;
 
   return {
-    tiles,
-    levels,
+    tiles: mirroredTiles,
+    levels: mirroredLevels,
     totalCells,
-    widthUnits,
+    widthUnits: mirroredMaxX - mirroredMinX,
     heightUnits,
-    minX,
-    maxX,
+    minX: mirroredMinX,
+    maxX: mirroredMaxX,
     centerColumn,
   };
 }


### PR DESCRIPTION
## Summary
- mirror the Snake & Ladder board tile positions horizontally so gameplay starts from the opposite edge
- update board metadata to keep pot placement and scaling aligned with the mirrored layout

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68fb16b341508329aec9747b9cf12ff2