### PR TITLE
Reverse Domino Royal turn order

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -2574,7 +2574,7 @@ function startGame(){
     }
   }
   renderChain();
-  current=(starter+1)%N;
+  current=(starter-1+N)%N;
   updateInteractivity();
   if(current!==human){
     scheduleCpuPlay();
@@ -2836,7 +2836,7 @@ function nextTurn(){
   if(checkForBlockedGame()){
     return;
   }
-  current=(current+1)%N;
+  current=(current-1+N)%N;
   if(checkForBlockedGame()){
     return;
   }


### PR DESCRIPTION
## Summary
- reverse the per-turn rotation in Domino Royal so play advances in the opposite direction
- update the post-opening starter selection to hand off the turn according to the new direction

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb3c7920b483298bb918c9c11c6d80