### PR TITLE
Reverse blackjack turn rotation

### DIFF
--- a/webapp/src/pages/Games/BlackJackArena.jsx
+++ b/webapp/src/pages/Games/BlackJackArena.jsx
@@ -922,8 +922,21 @@ function dealInitialCards(state) {
 }
 
 function getNextPlayerIndex(players, start) {
-  for (let offset = 1; offset <= players.length; offset += 1) {
-    const idx = (start + offset) % players.length;
+  const total = players.length;
+
+  if (start < 0) {
+    for (let idx = 0; idx < total; idx += 1) {
+      const player = players[idx];
+      if (!player) continue;
+      if (!player.isDealer && player.bet > 0 && !player.bust) {
+        return idx;
+      }
+    }
+    return DEALER_INDEX;
+  }
+
+  for (let offset = 1; offset <= total; offset += 1) {
+    const idx = (start - offset + total) % total;
     const player = players[idx];
     if (!player) continue;
     if (!player.isDealer && player.bet > 0 && !player.bust) {


### PR DESCRIPTION
## Summary
- update the Blackjack arena turn iterator to walk seats in the opposite direction after the human player acts
- ensure the initial turn still starts with the first eligible (non-dealer) participant

## Testing
- npm test -- --runTestsByPath test/blackjackGame.test.js --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68fb3ccd064c8329b3eee5427655e1f5