### PR TITLE
Reverse Ludo Battle Royal turn order

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1872,7 +1872,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides }) {
   const advanceTurn = (extraTurn) => {
     setUi((s) => {
       if (s.winner) return s;
-      const nextTurn = extraTurn ? s.turn : (s.turn + 1) % 4;
+      const nextTurn = extraTurn ? s.turn : (s.turn + 3) % 4;
       const state = stateRef.current;
       if (state) state.turn = nextTurn;
       updateTurnIndicator(nextTurn);


### PR DESCRIPTION
## Summary
- reverse the Ludo Battle Royal turn rotation so turns progress in the opposite direction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb3d98a3c08329bf7e39d94fc892ab