### PR TITLE
Reverse turn order in 3D Snake and Ladder

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -501,6 +501,15 @@ export default function SnakeAndLadder() {
   const aiRollTimeRef = useRef(null);
   const prevTimeLeftRef = useRef(TURN_TIME);
 
+  const getPreviousTurn = useCallback(
+    (turn) => {
+      const totalPlayers = (ai ?? 0) + 1;
+      if (totalPlayers <= 0) return 0;
+      return (turn - 1 + totalPlayers) % totalPlayers;
+    },
+    [ai]
+  );
+
   useEffect(() => {
     const id = getPlayerId();
     const saved = loadAvatar();
@@ -1068,7 +1077,7 @@ export default function SnakeAndLadder() {
           if (rank.length === 1) over = true;
         }
       }
-      turn = (turn + 1) % (ai + 1);
+      turn = getPreviousTurn(turn);
       elapsed -= 2500;
     }
     setPos(p);
@@ -1232,7 +1241,7 @@ export default function SnakeAndLadder() {
           setMessage("Need a 1 to win!");
           setTurnMessage("");
           setDiceVisible(false);
-          const next = (currentTurn + 1) % (ai + 1);
+          const next = getPreviousTurn(currentTurn);
           setTimeout(() => {
             setCurrentTurn(next);
             setDiceCount(playerDiceCounts[next] ?? 2);
@@ -1249,7 +1258,7 @@ export default function SnakeAndLadder() {
           setMessage("");
           setTurnMessage("");
           setDiceVisible(false);
-          const next = (currentTurn + 1) % (ai + 1);
+          const next = getPreviousTurn(currentTurn);
           setTimeout(() => {
             setCurrentTurn(next);
             setDiceCount(playerDiceCounts[next] ?? 2);
@@ -1264,7 +1273,7 @@ export default function SnakeAndLadder() {
         setShowExactHelp(true);
         setTurnMessage("");
         setDiceVisible(false);
-        const next = (currentTurn + 1) % (ai + 1);
+        const next = getPreviousTurn(currentTurn);
         setTimeout(() => {
           setCurrentTurn(next);
           setDiceCount(playerDiceCounts[next] ?? 2);
@@ -1281,7 +1290,7 @@ export default function SnakeAndLadder() {
         predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
       }
       const extraPred = diceCells[predicted] || doubleSix;
-      const nextPlayer = extraPred ? currentTurn : (currentTurn + 1) % (ai + 1);
+      const nextPlayer = extraPred ? currentTurn : getPreviousTurn(currentTurn);
 
       const steps = [];
       for (let i = current + 1; i <= target; i++) steps.push(i);
@@ -1382,7 +1391,7 @@ export default function SnakeAndLadder() {
         setDiceVisible(true);
         setMoving(false);
         if (!gameOver) {
-          const next = extraTurn ? currentTurn : (currentTurn + 1) % (ai + 1);
+          const next = extraTurn ? currentTurn : getPreviousTurn(currentTurn);
           setCurrentTurn(next);
           setDiceCount(playerDiceCounts[next] ?? 2);
         }
@@ -1463,7 +1472,7 @@ export default function SnakeAndLadder() {
       } else {
         setTurnMessage(`${getPlayerName(index)} needs a 6`);
         setDiceVisible(false);
-        const next = (currentTurn + 1) % (ai + 1);
+        const next = getPreviousTurn(currentTurn);
         setTimeout(() => {
           setCurrentTurn(next);
           setDiceCount(playerDiceCounts[next] ?? 2);
@@ -1476,7 +1485,7 @@ export default function SnakeAndLadder() {
       else {
         setTurnMessage('');
         setDiceVisible(false);
-        const next = (currentTurn + 1) % (ai + 1);
+        const next = getPreviousTurn(currentTurn);
         setTimeout(() => {
           setCurrentTurn(next);
           setDiceCount(playerDiceCounts[next] ?? 2);
@@ -1495,7 +1504,7 @@ export default function SnakeAndLadder() {
       predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
     }
     const extraPred = diceCells[predicted] || doubleSix;
-    const nextPlayer = extraPred ? index : (index + 1) % (ai + 1);
+    const nextPlayer = extraPred ? index : getPreviousTurn(index);
 
     const steps = [];
     for (let i = current + 1; i <= target; i++) steps.push(i);
@@ -1577,7 +1586,7 @@ export default function SnakeAndLadder() {
       } else if (doubleSix) {
         extraTurn = true;
       }
-      const next = extraTurn ? index : (index + 1) % (ai + 1);
+      const next = extraTurn ? index : getPreviousTurn(index);
       if (next === 0) setTurnMessage('Your turn');
       setCurrentTurn(next);
       setDiceCount(playerDiceCounts[next] ?? 2);


### PR DESCRIPTION
## Summary
- add a helper that calculates the previous participant in the turn order
- update player and AI move handling to advance turns in reverse order so play proceeds counter to the original direction

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fb3d4cdc788329ad67a9c1c145e41c