### PR TITLE
Reverse turn order for Murlan Royale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1862,12 +1862,13 @@ function dealHands(deck, playerCount) {
 
 function getNextAlive(players, index) {
   if (!players.length) return 0;
-  let next = (index + 1) % players.length;
+  const { length } = players;
+  let next = (index - 1 + length) % length;
   let safety = 0;
   while (players[next]?.finished) {
-    next = (next + 1) % players.length;
+    next = (next - 1 + length) % length;
     safety += 1;
-    if (safety > players.length) return index;
+    if (safety > length) return index;
   }
   return next;
 }


### PR DESCRIPTION
## Summary
- update the turn selection helper to move to the previous active seat instead of the next one
- ensure finished players are skipped while travelling in the new direction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb3dcecc8c832981744438d88bf19d