### PR TITLE
Ensure human turns keep camera centered

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -514,6 +514,11 @@ export default function MurlanRoyaleArena({ search }) {
         focusCameraOnPlayer(activeIdx, immediate);
         return;
       }
+      const activePlayer = playersList[activeIdx];
+      if (activePlayer?.isHuman) {
+        focusCameraOnPlayer(activeIdx, immediate);
+        return;
+      }
       const nextIdx = getNextAlive(playersList, activeIdx);
       const focusIdx = typeof nextIdx === 'number' && nextIdx !== activeIdx ? nextIdx : activeIdx;
       focusCameraOnPlayer(focusIdx, immediate);


### PR DESCRIPTION
## Summary
- ensure the arena camera keeps the human player's seat orientation when their turn begins
- continue to aim the camera toward the center of the table while avoiding unnecessary pans to other seats during human turns

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb435bc164832983222978686bfa25