### PR TITLE
Extend Pool Royale corner chrome plates toward the field

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -235,6 +235,7 @@ const CHROME_CORNER_FIELD_TRIM_SCALE = 0;
 const CHROME_CORNER_NOTCH_WEDGE_SCALE = 0;
 const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.9;
 const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.1;
+const CHROME_CORNER_FIELD_EXTENSION_SCALE = 0.045;
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015;
 const CHROME_CORNER_WIDTH_SCALE = 0.99;
 const CHROME_CORNER_HEIGHT_SCALE = 1.01;
@@ -4174,9 +4175,11 @@ function Table3D(
     MICRO_EPS,
     chromePlateBaseWidth * CHROME_CORNER_WIDTH_SCALE
   );
+  const chromeCornerFieldExtension =
+    POCKET_VIS_R * CHROME_CORNER_FIELD_EXTENSION_SCALE * POCKET_VISUAL_EXPANSION;
   const chromePlateHeight = Math.max(
     MICRO_EPS,
-    chromePlateBaseHeight * CHROME_CORNER_HEIGHT_SCALE
+    chromePlateBaseHeight * CHROME_CORNER_HEIGHT_SCALE + chromeCornerFieldExtension
   );
   const chromePlateRadius = Math.min(
     outerCornerRadius * 0.95,


### PR DESCRIPTION
## Summary
- add a field extension scale constant for Pool Royale corner chrome plates
- extend the corner chrome plate height slightly toward the playfield to fill the remaining gap

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fba11f844883299858143d6eb5b36a