### PR TITLE
Tighten Pool Royale corner rail arches

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -253,7 +253,8 @@ const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0;
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_CORNER_POCKET_CUT_SCALE = 1; // corner chrome arches must match the pocket diameter exactly
 const CHROME_SIDE_POCKET_CUT_SCALE = 1; // middle chrome arches now track the pocket diameter precisely
-const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.96; // pull the wood relief in slightly so the rounded cuts read tighter
+const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.96; // base relief trim keeps the wood cuts tucked under the chrome plates
+const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE = 0.97; // tighten the corner arches so the wooden rail openings read smaller
 const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1; // side rail relief mirrors the pockets one-to-one
 
 function buildChromePlateGeometry({
@@ -4403,7 +4404,10 @@ function Table3D(
   const scaleChromeSidePocketCut = (mp) =>
     scalePocketCutMP(mp, CHROME_SIDE_POCKET_CUT_SCALE);
   const scaleWoodRailCornerPocketCut = (mp) =>
-    scalePocketCutMP(scaleChromeCornerPocketCut(mp), WOOD_RAIL_POCKET_RELIEF_SCALE);
+    scalePocketCutMP(
+      scaleChromeCornerPocketCut(mp),
+      WOOD_RAIL_POCKET_RELIEF_SCALE * WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE
+    );
   const scaleWoodRailSidePocketCut = (mp) =>
     scalePocketCutMP(
       scaleChromeSidePocketCut(mp),


### PR DESCRIPTION
## Summary
- tighten the Pool Royale wooden corner rail pocket relief so the arches appear smaller while leaving side relief unchanged

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fbb2b85d1c83298115aa41233e1b80