### PR TITLE
Add 9ft and 10ft Pool Royale tables with lobby selector

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -15,6 +15,37 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     }),
     cushionCutAngleDeg: 32,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
+  },
+  '9ft': {
+    id: '9ft',
+    label: '9 ft Pro',
+    playfield: Object.freeze({ widthMm: 2540, heightMm: 1270 }), // 100" × 50"
+    ballDiameterMm: 57.15,
+    pocketMouthMm: Object.freeze({
+      corner: Number((57.15 * 1.695).toFixed(2)),
+      side: Number((57.15 * 1.94).toFixed(2))
+    }),
+    cushionCutAngleDeg: 34,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
+    cushionRestitution: 0.88,
+    componentPreset: 'snooker'
+  },
+  '10ft': {
+    id: '10ft',
+    label: '10 ft Grand',
+    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 120" × 60"
+    ballDiameterMm: 57.15,
+    pocketMouthMm: Object.freeze({
+      corner: Number((57.15 * 1.695).toFixed(2)),
+      side: Number((57.15 * 1.94).toFixed(2))
+    }),
+    cushionCutAngleDeg: 34,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
+    cushionRestitution: 0.87,
+    componentPreset: 'snooker',
+    scaleOverrides: Object.freeze({
+      compactScale: 1.44
+    })
   }
 });
 

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -10,7 +10,10 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
-import { resolveTableSize } from '../../config/poolRoyaleTables.js';
+import {
+  resolveTableSize,
+  TABLE_SIZE_LIST
+} from '../../config/poolRoyaleTables.js';
 
 export default function PoolRoyaleLobby() {
   const navigate = useNavigate();
@@ -22,7 +25,9 @@ export default function PoolRoyaleLobby() {
   const [avatar, setAvatar] = useState('');
   const [variant, setVariant] = useState('uk');
   const searchParams = new URLSearchParams(search);
-  const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
+  const [tableSize, setTableSize] = useState(() =>
+    resolveTableSize(searchParams.get('tableSize')).id
+  );
   const [playType, setPlayType] = useState('regular');
 
   useEffect(() => {
@@ -31,6 +36,12 @@ export default function PoolRoyaleLobby() {
       setAvatar(saved || getTelegramPhotoUrl());
     } catch {}
   }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    const resolved = resolveTableSize(params.get('tableSize')).id;
+    setTableSize((prev) => (prev === resolved ? prev : resolved));
+  }, [search]);
 
   const startGame = async () => {
     let tgId;
@@ -137,6 +148,22 @@ export default function PoolRoyaleLobby() {
           </div>
         </div>
       )}
+      <div className="space-y-2">
+        <h3 className="font-semibold">Table Size</h3>
+        <div className="flex gap-2 overflow-x-auto">
+          {TABLE_SIZE_LIST.map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setTableSize(id)}
+              className={`lobby-tile whitespace-nowrap ${
+                tableSize === id ? 'lobby-selected' : ''
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
       <div className="space-y-2">
         <h3 className="font-semibold">Variant</h3>
         <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- add 9 ft and 10 ft Pool Royale table specs that reuse the snooker component preset with tuned pocket widths and cushion physics
- expose a table size selector in the Pool Royale lobby so players can pick the new tables before launching a match

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fbb5bfabc88329a6017515ba34bf0e