### PR TITLE
Add new Pool Royale table size options and lobby selector

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -15,6 +15,30 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     }),
     cushionCutAngleDeg: 32,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
+  },
+  '9ft': {
+    id: '9ft',
+    label: '9 ft',
+    playfield: Object.freeze({ widthMm: 2540, heightMm: 1270 }), // 100" × 50"
+    ballDiameterMm: 57.15,
+    pocketMouthMm: Object.freeze({
+      corner: 171.45,
+      side: 152.4
+    }),
+    cushionCutAngleDeg: 32,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
+  },
+  '10ft': {
+    id: '10ft',
+    label: '10 ft',
+    playfield: Object.freeze({ widthMm: 2845, heightMm: 1422 }), // 112" × 56"
+    ballDiameterMm: 57.15,
+    pocketMouthMm: Object.freeze({
+      corner: 171.45,
+      side: 152.4
+    }),
+    cushionCutAngleDeg: 32,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });
 

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -10,7 +10,10 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
-import { resolveTableSize } from '../../config/poolRoyaleTables.js';
+import {
+  resolveTableSize,
+  TABLE_SIZE_LIST
+} from '../../config/poolRoyaleTables.js';
 
 export default function PoolRoyaleLobby() {
   const navigate = useNavigate();
@@ -22,7 +25,9 @@ export default function PoolRoyaleLobby() {
   const [avatar, setAvatar] = useState('');
   const [variant, setVariant] = useState('uk');
   const searchParams = new URLSearchParams(search);
-  const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
+  const [tableSize, setTableSize] = useState(
+    () => resolveTableSize(searchParams.get('tableSize')).id
+  );
   const [playType, setPlayType] = useState('regular');
 
   useEffect(() => {
@@ -149,6 +154,20 @@ export default function PoolRoyaleLobby() {
               key={id}
               onClick={() => setVariant(id)}
               className={`lobby-tile ${variant === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Table Size</h3>
+        <div className="flex flex-wrap gap-2">
+          {TABLE_SIZE_LIST.map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setTableSize(id)}
+              className={`lobby-tile ${tableSize === id ? 'lobby-selected' : ''}`}
             >
               {label}
             </button>


### PR DESCRIPTION
## Summary
- add 9 ft and 10 ft Pool Royale table specifications alongside the existing 8 ft setup
- expose the available table size options in the Pool Royale lobby so players can choose before starting a match

## Testing
- npm test -- tests/snooker.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fbc2e26f5083298dbf1e75c71b4c78