### PR TITLE
Simplify Ludo board layout

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3120,11 +3120,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides }) {
 
 function buildLudoBoard(boardGroup) {
   const scene = boardGroup;
-  const plateMat = new THREE.MeshStandardMaterial({
-    color: 0xe6c07d,
-    roughness: 0.9,
-    metalness: 0.08
-  });
   const tileMat = new THREE.MeshStandardMaterial({
     color: 0xfef9ef,
     roughness: 0.88
@@ -3133,13 +3128,6 @@ function buildLudoBoard(boardGroup) {
     color: 0xf4e3bd,
     roughness: 0.84
   });
-
-  const plate = new THREE.Mesh(
-    new THREE.BoxGeometry(RAW_BOARD_SIZE + 0.04, 0.02, RAW_BOARD_SIZE + 0.04),
-    plateMat
-  );
-  plate.position.y = -0.011;
-  scene.add(plate);
 
   const half = (LUDO_GRID * LUDO_TILE) / 2;
   const cellToWorld = (r, c) => {
@@ -3169,10 +3157,6 @@ function buildLudoBoard(boardGroup) {
 
   const tileSize = LUDO_TILE * 0.92;
   const tileGeo = new THREE.BoxGeometry(tileSize, PLAYFIELD_HEIGHT, tileSize);
-  const homeBaseMats = BOARD_COLORS.map((color) => {
-    const darker = new THREE.Color(color).multiplyScalar(0.72);
-    return new THREE.MeshStandardMaterial({ color: darker, roughness: 0.85 });
-  });
   const pathMats = PLAYER_COLORS.map(
     (color) => new THREE.MeshStandardMaterial({ color, roughness: 0.8 })
   );
@@ -3186,9 +3170,6 @@ function buildLudoBoard(boardGroup) {
       const inCross = (r >= 6 && r <= 8) || (c >= 6 && c <= 8);
       const inTrimmedOuter = r < 2 || r > LUDO_GRID - 3 || c < 2 || c > LUDO_GRID - 3;
       if (homeIndex !== -1) {
-        const mesh = new THREE.Mesh(tileGeo, homeBaseMats[homeIndex]);
-        mesh.position.copy(pos);
-        scene.add(mesh);
         continue;
       }
       if (inCenter) {
@@ -3201,13 +3182,7 @@ function buildLudoBoard(boardGroup) {
         continue;
       }
       if (TRACK_KEY_SET.has(key)) {
-        const startOwner = START_KEY_TO_PLAYER.get(key);
-        const mat =
-          startOwner != null
-            ? pathMats[startOwner]
-            : SAFE_TRACK_KEY_SET.has(key)
-            ? safeMat
-            : tileMat;
+        const mat = SAFE_TRACK_KEY_SET.has(key) ? safeMat : tileMat;
         const mesh = new THREE.Mesh(tileGeo, mat);
         mesh.position.copy(pos);
         scene.add(mesh);


### PR DESCRIPTION
## Summary
- remove the wooden base plate and corner home pads from the 3D Ludo board so the table cloth is visible
- leave only the playable track tiles and home columns rendered, producing the requested plus-shaped layout
- neutralize starting track tiles so only the home columns retain player colors

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68fc476f17e883299a51b39c4120c48a