### PR TITLE
Align upper-level rail gaps with stair direction

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -529,8 +529,8 @@ function getRailingEntryConfig(levelIndex, indexToPosition) {
   if (!fromPos || !toPos) {
     return { side: 'front', axis: 'x', center: null };
   }
-  const dx = toPos.x - fromPos.x;
-  const dz = toPos.z - fromPos.z;
+  const dx = fromPos.x - toPos.x;
+  const dz = fromPos.z - toPos.z;
   if (Math.abs(dx) >= Math.abs(dz)) {
     return {
       side: dx >= 0 ? 'right' : 'left',


### PR DESCRIPTION
## Summary
- adjust rail gap orientation on the 3D snake board so the entries line up with the black staircases feeding tiles 41, 73, and 93

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68fc7ff0f45883299ecfd2df94ce9c74