### PR TITLE
Restore Pool Royale geometry to 6:15 AM baseline

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -229,16 +229,18 @@ function adjustSideNotchDepth(mp) {
 const POCKET_VISUAL_EXPANSION = 1.05;
 const CHROME_CORNER_POCKET_RADIUS_SCALE = 1;
 const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.08;
-const CHROME_CORNER_EXPANSION_SCALE = 1.035; // widen the corner plate reach a touch more
-const CHROME_CORNER_SIDE_EXPANSION_SCALE = 1.085; // push the short-rail chrome edge farther so it lines up with the marked trim
+const CHROME_CORNER_EXPANSION_SCALE = 1.045; // widen the corner plate reach a touch more
+const CHROME_CORNER_SIDE_EXPANSION_SCALE = 1.1; // push the short-rail chrome edge farther so it lines up with the marked trim
 const CHROME_CORNER_FIELD_TRIM_SCALE = 0;
 const CHROME_CORNER_NOTCH_WEDGE_SCALE = 0;
 const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.9;
 const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.1;
+const CHROME_CORNER_FIELD_FILLET_SCALE = 0.85; // carve a rounded fillet into the inner chrome corner
 const CHROME_CORNER_FIELD_EXTENSION_SCALE = 0.045;
-const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015;
+const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1; // keep chrome arcs identical to the master pocket cut
 const CHROME_CORNER_WIDTH_SCALE = 0.99;
-const CHROME_CORNER_HEIGHT_SCALE = 1.01;
+const CHROME_CORNER_HEIGHT_SCALE = 0.99;
+const CHROME_CORNER_EDGE_TRIM_SCALE = 0.012; // shave a slim band from both rail-facing edges so the chrome lands flush with the cushions
 const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
 const WOOD_RAIL_CORNER_RADIUS_SCALE = 1; // match snooker rail rounding so the chrome sits flush
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0;
@@ -254,7 +256,8 @@ const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_CORNER_POCKET_CUT_SCALE = 1; // corner chrome arches must match the pocket diameter exactly
 const CHROME_SIDE_POCKET_CUT_SCALE = 1; // middle chrome arches now track the pocket diameter precisely
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.96; // base relief trim keeps the wood cuts tucked under the chrome plates
-const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE = 0.97; // tighten the corner arches so the wooden rail openings read smaller
+const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
+  1 / WOOD_RAIL_POCKET_RELIEF_SCALE; // corner wood arches must now mirror the chrome radius exactly
 const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1; // side rail relief mirrors the pockets one-to-one
 
 function buildChromePlateGeometry({
@@ -478,11 +481,11 @@ const TABLE = {
   WALL: 2.6 * TABLE_SCALE
 };
 const RAIL_HEIGHT = TABLE.THICK * 1.78; // raise the rails slightly so their top edge meets the green cushions cleanly
-const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.012; // extend the jaw reach so the liner follows the larger chrome plate cut cleanly
+const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.018; // nudge the corner jaws farther into the widened chrome arches
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 1.015; // let the middle jaw ride the expanded chrome/wood arc without leaving a gap
 const POCKET_JAW_CORNER_INNER_SCALE = 1.11; // ease the inner lip outward so the jaw sits a touch farther from centre
 const POCKET_JAW_SIDE_INNER_SCALE = 0.984; // pull the inner lip farther out so the widened jaw still meets the chrome cut
-const POCKET_JAW_CORNER_OUTER_SCALE = 1.735; // preserve the playable mouth while matching the longer corner jaw fascia
+const POCKET_JAW_CORNER_OUTER_SCALE = 1.76; // preserve the playable mouth while matching the longer corner jaw fascia
 const POCKET_JAW_SIDE_OUTER_SCALE = 1.81; // keep the side mouth consistent while letting the liner reach the longer chrome-backed arch
 const POCKET_JAW_DEPTH_SCALE = 0.66; // proportion of the rail height the jaw liner drops into the pocket cut (≈3" drop as photographed)
 const POCKET_JAW_EDGE_FLUSH_START = 0.14; // begin easing the jaw back out earlier so the lip stays long and flush with chrome
@@ -502,7 +505,7 @@ const POCKET_JAW_SIDE_MIDDLE_FACTOR = 0.86; // let the side pockets carry more m
 const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1; // side jaws now keep a single arc that matches the pocket diameter
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // jaw footprint mirrors the pocket cut with no additional widening
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.5; // keep the drop deep while matching the tighter jaw footprint
-const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.5; // align the corner jaw spread with the snooker chrome cut geometry
+const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.54; // align the corner jaw spread with the expanded chrome cut geometry
 const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage
 const SIDE_JAW_ARC_DEG = 150; // base side jaw span tuned so expansion covers half of the pocket circumference
 const POCKET_RIM_DEPTH_RATIO = 0.3; // shallow lip that hugs the top of each pocket jaw
@@ -4181,15 +4184,18 @@ function Table3D(
     outerHalfH - chromePlateInset - chromePlateInnerLimitZ + chromePlateExpansionZ -
       chromeCornerPlateTrim
   );
+  const chromeCornerEdgeTrim = TABLE.THICK * CHROME_CORNER_EDGE_TRIM_SCALE;
   const chromePlateWidth = Math.max(
     MICRO_EPS,
-    chromePlateBaseWidth * CHROME_CORNER_WIDTH_SCALE
+    chromePlateBaseWidth * CHROME_CORNER_WIDTH_SCALE - chromeCornerEdgeTrim
   );
   const chromeCornerFieldExtension =
     POCKET_VIS_R * CHROME_CORNER_FIELD_EXTENSION_SCALE * POCKET_VISUAL_EXPANSION;
   const chromePlateHeight = Math.max(
     MICRO_EPS,
-    chromePlateBaseHeight * CHROME_CORNER_HEIGHT_SCALE + chromeCornerFieldExtension
+    chromePlateBaseHeight * CHROME_CORNER_HEIGHT_SCALE -
+      chromeCornerEdgeTrim +
+      chromeCornerFieldExtension
   );
   const chromePlateRadius = Math.min(
     outerCornerRadius * 0.95,
@@ -4306,6 +4312,43 @@ function Table3D(
     }
     return [[pts]];
   };
+  const cornerFieldFilletPoly = (cx, cz, sx, sz, radius, segments = 64) => {
+    if (radius <= MICRO_EPS) {
+      return null;
+    }
+    const axisXAngle = sx > 0 ? 0 : Math.PI;
+    const axisZAngle = sz > 0 ? Math.PI / 2 : -Math.PI / 2;
+    let startAngle = axisXAngle;
+    let endAngle = axisZAngle;
+    let sweep = endAngle - startAngle;
+    if (sweep <= 0) {
+      endAngle += Math.PI * 2;
+      sweep = endAngle - startAngle;
+    }
+    if (sweep > Math.PI) {
+      startAngle = axisZAngle;
+      endAngle = axisXAngle;
+      sweep = endAngle - startAngle;
+      if (sweep <= 0) {
+        endAngle += Math.PI * 2;
+        sweep = endAngle - startAngle;
+      }
+    }
+    if (sweep <= MICRO_EPS) {
+      return null;
+    }
+    const steps = Math.max(2, Math.ceil((segments * Math.abs(sweep)) / (Math.PI / 2)));
+    const pts = [[cx, cz]];
+    for (let i = 0; i <= steps; i++) {
+      const t = i / steps;
+      const angle = startAngle + sweep * t;
+      const x = cx + Math.cos(angle) * radius;
+      const z = cz + Math.sin(angle) * radius;
+      pts.push([x, z]);
+    }
+    pts.push([cx, cz]);
+    return [[pts]];
+  };
   const ringArea = (ring) => signedRingArea(ring);
 
   const cornerNotchMP = (sx, sz) => {
@@ -4331,14 +4374,21 @@ function Table3D(
     const wedgeDepth = cornerChamfer * Math.max(0, CHROME_CORNER_NOTCH_WEDGE_SCALE);
     const unionParts = [notchCircle, boxX, boxZ];
     if (fieldClipWidth > MICRO_EPS && fieldClipDepth > MICRO_EPS) {
-      unionParts.push([
-        [
-          [cx, cz],
-          [cx + sx * fieldClipWidth, cz],
-          [cx, cz + sz * fieldClipDepth],
-          [cx, cz]
-        ]
-      ]);
+      const filletRadius =
+        Math.min(fieldClipWidth, fieldClipDepth) * CHROME_CORNER_FIELD_FILLET_SCALE;
+      const fillet = cornerFieldFilletPoly(cx, cz, sx, sz, filletRadius);
+      if (fillet) {
+        unionParts.push(fillet);
+      } else {
+        unionParts.push([
+          [
+            [cx, cz],
+            [cx + sx * fieldClipWidth, cz],
+            [cx, cz + sz * fieldClipDepth],
+            [cx, cz]
+          ]
+        ]);
+      }
     }
     if (wedgeDepth > MICRO_EPS) {
       unionParts.push([
@@ -4426,49 +4476,9 @@ function Table3D(
   ].forEach(({ corner, sx, sz }) => {
     const centerX = sx * (outerHalfW - chromePlateWidth / 2 - chromePlateInset);
     const centerZ = sz * (outerHalfH - chromePlateHeight / 2 - chromePlateInset);
-    const plateMinX = centerX - chromePlateWidth / 2;
-    const plateMaxX = centerX + chromePlateWidth / 2;
-    const plateMinZ = centerZ - chromePlateHeight / 2;
-    const plateMaxZ = centerZ + chromePlateHeight / 2;
     // Chrome plates use their own rounded cuts as-is; nothing references the wooden rail arches.
     const notchMP = scaleChromeCornerPocketCut(cornerNotchMP(sx, sz));
-    const trimPolys = [];
-    const xTrimLimit = sx * chromePlateInnerLimitX;
-    if (Number.isFinite(xTrimLimit)) {
-      if (sx === 1) {
-        const cutMinX = plateMinX;
-        const cutMaxX = Math.min(xTrimLimit, plateMaxX);
-        if (cutMaxX - cutMinX > MICRO_EPS) {
-          trimPolys.push(boxPoly(cutMinX, plateMinZ, cutMaxX, plateMaxZ));
-        }
-      } else {
-        const cutMinX = Math.max(xTrimLimit, plateMinX);
-        const cutMaxX = plateMaxX;
-        if (cutMaxX - cutMinX > MICRO_EPS) {
-          trimPolys.push(boxPoly(cutMinX, plateMinZ, cutMaxX, plateMaxZ));
-        }
-      }
-    }
-    const zTrimLimit = sz * chromePlateInnerLimitZ;
-    if (Number.isFinite(zTrimLimit)) {
-      if (sz === 1) {
-        const cutMinZ = plateMinZ;
-        const cutMaxZ = Math.min(zTrimLimit, plateMaxZ);
-        if (cutMaxZ - cutMinZ > MICRO_EPS) {
-          trimPolys.push(boxPoly(plateMinX, cutMinZ, plateMaxX, cutMaxZ));
-        }
-      } else {
-        const cutMinZ = Math.max(zTrimLimit, plateMinZ);
-        const cutMaxZ = plateMaxZ;
-        if (cutMaxZ - cutMinZ > MICRO_EPS) {
-          trimPolys.push(boxPoly(plateMinX, cutMinZ, plateMaxX, cutMaxZ));
-        }
-      }
-    }
-    const notchWithTrim = trimPolys.length
-      ? polygonClipping.union(notchMP, ...trimPolys)
-      : notchMP;
-    const notchLocalMP = notchWithTrim.map((poly) =>
+    const notchLocalMP = notchMP.map((poly) =>
       poly.map((ring) =>
         ring.map(([x, z]) => [x - centerX, -(z - centerZ)])
       )


### PR DESCRIPTION
## Summary
- revert Pool Royale table geometry constants to the state from the 6:15 AM baseline
- reinstate the earlier chrome plate trimming, pocket jaw sizing, and notch construction logic used before later tweaks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fceaaad9c08329a3a41d6a9d3aea1f