### PR TITLE
Adjust Pool Royale corner chrome pocket cut

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -238,8 +238,9 @@ const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.42;
 const CHROME_CORNER_FIELD_FILLET_SCALE = 0.98; // carve a rounded fillet into the inner chrome corner
 const CHROME_CORNER_FIELD_EXTENSION_SCALE = 0;
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.01; // grow the inner cut slightly so no chrome lip creeps onto the cloth
-const CHROME_CORNER_WIDTH_SCALE = 0.965;
-const CHROME_CORNER_HEIGHT_SCALE = 0.965;
+const CHROME_CORNER_ZERO_EXTENSION_SCALE = 1.35; // stretch the new capsule pocket cut toward the playfield to hide the chrome sliver
+const CHROME_CORNER_WIDTH_SCALE = 0.97;
+const CHROME_CORNER_HEIGHT_SCALE = 0.97;
 const CHROME_CORNER_EDGE_TRIM_SCALE = 0.012; // shave a slim band from both rail-facing edges so the chrome lands flush with the cushions
 const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
 const WOOD_RAIL_CORNER_RADIUS_SCALE = 1; // match snooker rail rounding so the chrome sits flush
@@ -4354,10 +4355,17 @@ function Table3D(
   const cornerNotchMP = (sx, sz) => {
     const cx = sx * (innerHalfW - cornerInset);
     const cz = sz * (innerHalfH - cornerInset);
-    const notchCircle = circlePoly(
-      cx,
-      cz,
-      cornerPocketRadius * CHROME_CORNER_POCKET_RADIUS_SCALE
+    const notchRadius = cornerPocketRadius * CHROME_CORNER_POCKET_RADIUS_SCALE;
+    const capsuleExtension = Math.max(0, cornerChamfer * CHROME_CORNER_ZERO_EXTENSION_SCALE);
+    const innerCx = cx - sx * capsuleExtension;
+    const innerCz = cz - sz * capsuleExtension;
+    const notchCircle = circlePoly(cx, cz, notchRadius);
+    const notchTailCircle = circlePoly(innerCx, innerCz, notchRadius);
+    const capsuleBody = boxPoly(
+      Math.min(cx, innerCx) - notchRadius,
+      Math.min(cz, innerCz) - notchRadius,
+      Math.max(cx, innerCx) + notchRadius,
+      Math.max(cz, innerCz) + notchRadius
     );
     const x1 = cx;
     const x2 = cx + sx * cornerChamfer;
@@ -4372,7 +4380,7 @@ function Table3D(
     const fieldClipWidth = cornerChamfer * CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE;
     const fieldClipDepth = cornerChamfer * CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE;
     const wedgeDepth = cornerChamfer * Math.max(0, CHROME_CORNER_NOTCH_WEDGE_SCALE);
-    const unionParts = [notchCircle, boxX, boxZ];
+    const unionParts = [notchCircle, notchTailCircle, capsuleBody, boxX, boxZ];
     if (fieldClipWidth > MICRO_EPS && fieldClipDepth > MICRO_EPS) {
       const filletRadius =
         Math.min(fieldClipWidth, fieldClipDepth) * CHROME_CORNER_FIELD_FILLET_SCALE;


### PR DESCRIPTION
## Summary
- widen the Pool Royale corner chrome plates slightly to match the updated trim request
- replace the circular corner pocket relief with an elongated capsule cut that maintains pocket diameter while covering the exposed chrome

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd23bdb2a483298766b1998ad12d63