### PR TITLE
Adjust corner pocket scale boost to 1.1

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -227,7 +227,7 @@ function adjustSideNotchDepth(mp) {
 }
 
 const POCKET_VISUAL_EXPANSION = 1.05;
-const CORNER_POCKET_SCALE_BOOST = 1.06; // widen the four corner pockets while letting every dependent mesh follow suit
+const CORNER_POCKET_SCALE_BOOST = 1.1; // widen the four corner pockets while letting every dependent mesh follow suit
 const CHROME_CORNER_POCKET_RADIUS_SCALE = 1;
 const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.08;
 const CHROME_CORNER_EXPANSION_SCALE = 1.045; // widen the corner plate reach a touch more


### PR DESCRIPTION
## Summary
- increase the corner pocket scale boost constant for Pool Royale tables to 1.1

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd977cf25c8329979c8b245818c913