### PR TITLE
Adjust Pool Royale cushion cut and chrome reach

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -237,10 +237,10 @@ const CHROME_CORNER_NOTCH_WEDGE_SCALE = 0;
 const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 1.32;
 const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.42;
 const CHROME_CORNER_FIELD_FILLET_SCALE = 0.98; // carve a rounded fillet into the inner chrome corner
-const CHROME_CORNER_FIELD_EXTENSION_SCALE = 0.08; // push the chrome fascia farther so it meets the pocket liner
+const CHROME_CORNER_FIELD_EXTENSION_SCALE = 0.12; // push the chrome fascia farther so it meets the pocket liner
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.01; // grow the inner cut slightly so no chrome lip creeps onto the cloth
 const CHROME_CORNER_WIDTH_SCALE = 0.962;
-const CHROME_CORNER_HEIGHT_SCALE = 0.963;
+const CHROME_CORNER_HEIGHT_SCALE = 0.961;
 const CHROME_CORNER_EDGE_TRIM_SCALE = 0.012; // shave a slim band from both rail-facing edges so the chrome lands flush with the cushions
 const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
 const WOOD_RAIL_CORNER_RADIUS_SCALE = 1; // match snooker rail rounding so the chrome sits flush
@@ -825,8 +825,8 @@ const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.6;
 const SIDE_SPIN_MULTIPLIER = 1.25;
 const BACKSPIN_MULTIPLIER = 1.7 * 1.25 * 1.5 * SPIN_VERTICAL_EFFECT_BOOST;
 const TOPSPIN_MULTIPLIER = 1.3 * SPIN_VERTICAL_EFFECT_BOOST;
-// angle for cushion cuts guiding balls into pockets (Pool Royale spec requires 35°)
-const DEFAULT_CUSHION_CUT_ANGLE = 35;
+// angle for cushion cuts guiding balls into pockets (Pool Royale spec requires 33°)
+const DEFAULT_CUSHION_CUT_ANGLE = 33;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
 const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.09; // pull cushions slightly closer to centre for a tighter pocket entry


### PR DESCRIPTION
## Summary
- set the Pool Royale cushion cut angle default to 33 degrees for the green cushions
- extend the corner chrome plates farther toward the pockets and tweak their height scaling to match the desired proportions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd9ee163748329afd1256cadfd91a6