### PR TITLE
Adjust Pool Royale chrome reach and cushion angle

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -237,9 +237,9 @@ const CHROME_CORNER_NOTCH_WEDGE_SCALE = 0;
 const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 1.32;
 const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.42;
 const CHROME_CORNER_FIELD_FILLET_SCALE = 0.98; // carve a rounded fillet into the inner chrome corner
-const CHROME_CORNER_FIELD_EXTENSION_SCALE = 0.12; // push the chrome fascia farther so it meets the pocket liner
+const CHROME_CORNER_FIELD_EXTENSION_SCALE = 0.18; // stretch the chrome fascia deeper so it fully reaches the pocket liner
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.01; // grow the inner cut slightly so no chrome lip creeps onto the cloth
-const CHROME_CORNER_WIDTH_SCALE = 0.962;
+const CHROME_CORNER_WIDTH_SCALE = 0.961;
 const CHROME_CORNER_HEIGHT_SCALE = 0.961;
 const CHROME_CORNER_EDGE_TRIM_SCALE = 0.012; // shave a slim band from both rail-facing edges so the chrome lands flush with the cushions
 const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
@@ -825,8 +825,8 @@ const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.6;
 const SIDE_SPIN_MULTIPLIER = 1.25;
 const BACKSPIN_MULTIPLIER = 1.7 * 1.25 * 1.5 * SPIN_VERTICAL_EFFECT_BOOST;
 const TOPSPIN_MULTIPLIER = 1.3 * SPIN_VERTICAL_EFFECT_BOOST;
-// angle for cushion cuts guiding balls into pockets (Pool Royale spec requires 33°)
-const DEFAULT_CUSHION_CUT_ANGLE = 33;
+// angle for cushion cuts guiding balls into pockets (Pool Royale spec now requires 31°)
+const DEFAULT_CUSHION_CUT_ANGLE = 31;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
 const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.09; // pull cushions slightly closer to centre for a tighter pocket entry


### PR DESCRIPTION
## Summary
- extend Pool Royale corner chrome fascia deeper so the plates touch the pocket liner
- slightly reduce the corner chrome width to match the requested 0.961 scale
- update cushion cut angle to the requested 31° specification

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fda0aa751483298d4171e816f4c626