### PR TITLE
Add guard to skip corner field triangle

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -242,6 +242,7 @@ const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015; // identical chrome cut growt
 const CHROME_CORNER_DIMENSION_SCALE = 0.99; // ensure each chrome corner plate mirrors snooker proportions
 const CHROME_CORNER_WIDTH_SCALE = 0.975;
 const CHROME_CORNER_HEIGHT_SCALE = 0.975;
+const DISABLE_CORNER_FIELD_TRIANGLE = true;
 const CHROME_CORNER_EDGE_TRIM_SCALE = 0; // do not trim edges beyond the snooker baseline
 const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
 const WOOD_RAIL_CORNER_RADIUS_SCALE = 1; // match snooker rail rounding so the chrome sits flush
@@ -4393,7 +4394,7 @@ function Table3D(
         ]);
       }
     }
-    if (wedgeDepth > MICRO_EPS) {
+    if (wedgeDepth > MICRO_EPS && !DISABLE_CORNER_FIELD_TRIANGLE) {
       unionParts.push([
         [
           [cx, cz],

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -211,6 +211,7 @@ const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.1; // push the trim deeper along 
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015;
 const CHROME_CORNER_WIDTH_SCALE = 0.99; // gently shrink chrome plates along the long rails
 const CHROME_CORNER_HEIGHT_SCALE = 0.99; // gently shrink chrome plates along the short rails
+const DISABLE_CORNER_FIELD_TRIANGLE = true;
 const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.82;
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85;
@@ -4101,7 +4102,7 @@ function Table3D(
         ]
       ]);
     }
-    if (wedgeDepth > MICRO_EPS) {
+    if (wedgeDepth > MICRO_EPS && !DISABLE_CORNER_FIELD_TRIANGLE) {
       unionParts.push([
         [
           [cx, cz],


### PR DESCRIPTION
## Summary
- add a shared flag in the Snooker and PoolRoyale chrome settings to disable the corner field triangle
- stop appending the field triangle wedge when the flag is enabled so the chrome notch stays rectangular

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe00516db88329899faf45d1f77658