### PR TITLE
Adjust Pool Royale corner pocket inset

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -572,7 +572,7 @@ const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE
 const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_R = POCKET_VIS_R * 0.985;
 const CORNER_POCKET_CENTER_INSET =
-  POCKET_VIS_R * 0.02 * POCKET_VISUAL_EXPANSION; // pull every corner pocket centre a hair toward the table middle
+  POCKET_VIS_R * 0.065 * POCKET_VISUAL_EXPANSION; // tuck the corner pocket centres further toward the table middle so the chrome cuts read more inward
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
 const CORNER_CHROME_NOTCH_RADIUS = POCKET_VIS_R * POCKET_VISUAL_EXPANSION;
 const SIDE_CHROME_NOTCH_RADIUS = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION;


### PR DESCRIPTION
## Summary
- increase the Pool Royale corner pocket inset so the chrome cuts and jaws sit further into the table corners

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe2879d5a88329a0434324cf987d39