### PR TITLE
Adjust Pool Royale corner pocket positions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -572,7 +572,7 @@ const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE
 const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_R = POCKET_VIS_R * 0.985;
 const CORNER_POCKET_CENTER_INSET =
-  POCKET_VIS_R * 0.065 * POCKET_VISUAL_EXPANSION; // tuck the corner pocket centres further toward the table middle so the chrome cuts read more inward
+  POCKET_VIS_R * 0.095 * POCKET_VISUAL_EXPANSION; // pull the corner pocket centres deeper toward the table middle so the chrome cuts, jaws, and rims sit further inboard
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
 const CORNER_CHROME_NOTCH_RADIUS = POCKET_VIS_R * POCKET_VISUAL_EXPANSION;
 const SIDE_CHROME_NOTCH_RADIUS = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION;


### PR DESCRIPTION
## Summary
- move the Pool Royale corner pocket centres further toward the table middle so the chrome cuts and jaw rims sit deeper in the playfield view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe2b1a38d483298f7da5fc34a4fb80