### PR TITLE
Adjust Pool Royale corner pockets inward

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -572,7 +572,7 @@ const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE
 const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_R = POCKET_VIS_R * 0.985;
 const CORNER_POCKET_CENTER_INSET =
-  POCKET_VIS_R * 0.095 * POCKET_VISUAL_EXPANSION; // pull the corner pocket centres deeper toward the table middle so the chrome cuts, jaws, and rims sit further inboard
+  POCKET_VIS_R * 0.12 * POCKET_VISUAL_EXPANSION; // pull the corner pocket centres deeper toward the table middle so the chrome cuts, jaws, and rims sit further inboard per latest spec
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
 const CORNER_CHROME_NOTCH_RADIUS = POCKET_VIS_R * POCKET_VISUAL_EXPANSION;
 const SIDE_CHROME_NOTCH_RADIUS = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION;


### PR DESCRIPTION
## Summary
- increase the Pool Royale corner pocket center inset so the chrome, wood, and jaw arcs sit further toward the table middle

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe302d74fc8329b84eccad66fe6ea3