### PR TITLE
Adjust Pool Royale corner pocket inset

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -572,7 +572,7 @@ const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE
 const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_R = POCKET_VIS_R * 0.985;
 const CORNER_POCKET_CENTER_INSET =
-  POCKET_VIS_R * 0.2 * POCKET_VISUAL_EXPANSION; // bring the corner pocket centres, chrome arches, wood relief, jaws, and rims slightly further inboard per latest Pool Royale spec
+  POCKET_VIS_R * 0.24 * POCKET_VISUAL_EXPANSION; // shift the corner pocket centres, chrome arches, wood relief, jaws, and rims further inboard per refreshed Pool Royale spec
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
 const CORNER_CHROME_NOTCH_RADIUS = POCKET_VIS_R * POCKET_VISUAL_EXPANSION;
 const SIDE_CHROME_NOTCH_RADIUS = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION;


### PR DESCRIPTION
## Summary
- move the Pool Royale corner pocket centres slightly further toward the table interior so the jaws and chrome arches follow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe3cfd27cc8329b7550e0837ffcaf0