### PR TITLE
Adjust Pool Royale cushion placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4103,7 +4103,7 @@ function Table3D(
   });
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(woodRailSurface);
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
-  const CUSHION_CENTER_NUDGE = 0; // keep cushions flush with the rail like the snooker layout
+  const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.06; // pull the six green cushion segments slightly toward centre without changing their profile
   const SIDE_CUSHION_RAIL_REACH = 0; // snooker rails do not extend beyond the chrome, so no additional reach is required
   const SHORT_CUSHION_HEIGHT_SCALE = 1.085; // raise short rail cushions to match the remaining four rails
   const railsGroup = new THREE.Group();


### PR DESCRIPTION
## Summary
- nudge the six green cushion segments in the Pool Royale table slightly toward the centre so they better match the latest spec

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fe47c251048329b485c54a6c1e72c3