### PR TITLE
Adjust Pool Royale side cushion reach towards corner pockets

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4107,7 +4107,7 @@ function Table3D(
   const CUSHION_RAIL_FLUSH = 0; // let cushions sit directly against the rail edge without a visible seam
   const CUSHION_CENTER_NUDGE = TABLE.THICK * 0.088; // pull the six green cushion segments slightly toward centre without changing their profile
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.038; // trim the remaining corner gap so cushions reach further into each pocket
-  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.014; // extend the side cushions a touch further toward the corner arches
+  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.022; // extend the side cushions a touch further toward the corner arches (extra inset per latest mobile request)
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.016; // push side cushions fractionally deeper into the rail edge without creating overlap
   const SHORT_CUSHION_HEIGHT_SCALE = 1.085; // raise short rail cushions to match the remaining four rails
   const railsGroup = new THREE.Group();


### PR DESCRIPTION
## Summary
- increase the side cushion reach reduction factor so the side rails sit closer to the corner pockets per the latest mobile spec

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff14ab29fc8329b0efb776a4cae4e8