### PR TITLE
Adjust Pool Royale side chalk placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5062,7 +5062,7 @@ function Table3D(
   const chalkEndRailOffset = Math.min(endRailW * 0.18, Math.max(0, endRailW * 0.45 - chalkSize * 0.5));
   const chalkLongOffsetLimit = Math.max(0, PLAY_H / 2 - BALL_R * 3.5);
   const chalkShortOffsetLimit = Math.max(0, PLAY_W / 2 - BALL_R * 3.5);
-  const chalkLongAxisOffset = Math.min(chalkLongOffsetLimit, PLAY_H * 0.22);
+  const chalkLongAxisOffset = Math.min(chalkLongOffsetLimit, PLAY_H * 0.24);
   const chalkShortAxisOffset = Math.min(chalkShortOffsetLimit, PLAY_W * 0.22);
   const chalkSlots = [
     {


### PR DESCRIPTION
## Summary
- push the Pool Royale side rail chalk props a touch further toward the corner pockets by increasing their longitudinal offset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff27b168cc8329925cff8330af7e7d