### PR TITLE
Add snooker 12ft table option using Pool Royale geometry

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -32,6 +32,24 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     }),
     cushionCutAngleDeg: 35,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
+  },
+  'snooker-12ft': {
+    id: 'snooker-12ft',
+    label: 'Snooker 12 ft (Official)',
+    playfield: Object.freeze({ widthMm: 3569, heightMm: 1778 }),
+    ballDiameterMm: 52.5,
+    pocketMouthMm: Object.freeze({
+      corner: 89,
+      side: 109
+    }),
+    cushionCutAngleDeg: 35,
+    cushionRestitution: 0.99,
+    componentPreset: 'snooker',
+    markings: Object.freeze({
+      baulkFromBaulkMm: 737,
+      dRadiusMm: 292,
+      blackFromTopMm: 324
+    })
   }
 });
 


### PR DESCRIPTION
## Summary
- add a `snooker-12ft` preset to the shared pool table config with official snooker dimensions and markings metadata
- update the Pool Royale table builder to honour snooker presets by rescaling balls, markings, and rack layout while reusing the existing components
- ensure coloured balls and reds adopt snooker materials and placement when the preset is active

## Testing
- npm run lint -- webapp/src/pages/Games/PoolRoyale.jsx webapp/src/config/poolRoyaleTables.js *(fails: repository has pre-existing lint errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_690198e0526c8329a98e4be9332ad679