### PR TITLE
Adjust Pool Royale cushion profile

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5599,9 +5599,9 @@ function Table3D(
   const FACE_SHRINK_LONG = 1;
   const FACE_SHRINK_SHORT = FACE_SHRINK_LONG;
   const NOSE_REDUCTION = 0.75;
-  const CUSHION_UNDERCUT_BASE_LIFT = 0.44;
-  const CUSHION_RAIL_BASE_LIFT = 0; // keep the cushion base flush with the cloth plane along the wooden rails
-  const CUSHION_UNDERCUT_FRONT_REMOVAL = 0.42;
+  const CUSHION_UNDERCUT_BASE_LIFT = 0.62;
+  const CUSHION_RAIL_BASE_LIFT = 0.28; // trim the rail-side base so the cushion underside sits higher without shifting its lip
+  const CUSHION_UNDERCUT_FRONT_REMOVAL = 0.54;
   const CUSHION_NOSE_FRONT_PULL_SCALE = 0.085; // extend only the exposed nose + undercut toward the playfield without moving the cushion base
   const cushionBaseY = CLOTH_TOP_LOCAL - MICRO_EPS + CUSHION_EXTRA_LIFT;
   const rawCushionHeight = Math.max(0, railsTopY - cushionBaseY);
@@ -5668,6 +5668,15 @@ function Table3D(
       const noseOffset = nosePull * frontFactor;
       if (noseOffset > 0) {
         arr[i + 1] = Math.min(arr[i + 1] - noseOffset, backY);
+      }
+    }
+    let rebasedMinZ = Infinity;
+    for (let i = 0; i < arr.length; i += 3) {
+      rebasedMinZ = Math.min(rebasedMinZ, arr[i + 2]);
+    }
+    if (Number.isFinite(rebasedMinZ) && rebasedMinZ > 0) {
+      for (let i = 0; i < arr.length; i += 3) {
+        arr[i + 2] -= rebasedMinZ;
       }
     }
     pos.needsUpdate = true;


### PR DESCRIPTION
## Summary
- raise the undercut and rail-side base trims on the Pool Royale cushions so their bodies present a shorter profile
- rebase the extruded cushion geometry so the underside now sits flush on the cloth while keeping the lip aligned with the rails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6901d821f2d08329a3e374513e414c6b