### PR TITLE
Fix pocket cut orientation on cloth surfaces

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4347,7 +4347,8 @@ function Table3D(
     shape.lineTo(-insetHalfW, -insetHalfH);
     pocketPositions.forEach((p) => {
       const hole = new THREE.Path();
-      hole.absellipse(p.x, p.y, holeRadius, holeRadius, 0, Math.PI * 2);
+      hole.absellipse(p.x, p.y, holeRadius, holeRadius, 0, Math.PI * 2, true);
+      hole.autoClose = true;
       shape.holes.push(hole);
     });
     return shape;

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -3709,7 +3709,8 @@ function Table3D(
     shape.lineTo(-insetHalfW, -insetHalfH);
     pocketPositions.forEach((p) => {
       const hole = new THREE.Path();
-      hole.absellipse(p.x, p.y, holeRadius, holeRadius, 0, Math.PI * 2);
+      hole.absellipse(p.x, p.y, holeRadius, holeRadius, 0, Math.PI * 2, true);
+      hole.autoClose = true;
       shape.holes.push(hole);
     });
     return shape;


### PR DESCRIPTION
## Summary
- ensure pocket hole paths are wound clockwise before extruding the cloth for the Pool Royale and Snooker tables
- explicitly close the pocket hole paths so each opening stays carved out when the cloth geometry is generated

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69021d56176c8329bdf751f9ca8c587d