### PR TITLE
Implement mesh-based cushion CCD for Pool Royale

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -57,6 +57,7 @@ public class PreviewRuntimeTests
     public void PreviewMatchesRuntime()
     {
         var solver = new BilliardsSolver();
+        solver.InitStandardTable();
         var others = new List<BilliardsSolver.Ball> { new BilliardsSolver.Ball { Position = new Vec2(1.2, 0.5) } };
         var start = new Vec2(0.2, 0.5);
         var dir = new Vec2(1, 0);
@@ -76,6 +77,7 @@ public class DeterminismTests
     public void PreviewDeterministic()
     {
         var solver = new BilliardsSolver();
+        solver.InitStandardTable();
         var others = new List<BilliardsSolver.Ball> { new BilliardsSolver.Ball { Position = new Vec2(1.2, 0.5) } };
         var start = new Vec2(0.2, 0.5);
         var dir = new Vec2(1, 0);
@@ -92,6 +94,7 @@ public class DirectionNormalizationTests
     public void PreviewShotNormalizesDirection()
     {
         var solver = new BilliardsSolver();
+        solver.InitStandardTable();
         var start = new Vec2(0.2, 0.5);
         double speed = 2.0;
         var p1 = solver.PreviewShot(start, new Vec2(1, 0), speed, new List<BilliardsSolver.Ball>());
@@ -106,6 +109,7 @@ public class CushionStepTests
     public void BallReflectsWithoutCrossingBoundary()
     {
         var solver = new BilliardsSolver();
+        solver.InitStandardTable();
         var ball = new BilliardsSolver.Ball { Position = new Vec2(0.2, 0.5), Velocity = new Vec2(-5, 0) };
         solver.Step(new List<BilliardsSolver.Ball> { ball }, 0.1);
         Assert.That(ball.Position.X, Is.GreaterThanOrEqualTo(PhysicsConstants.BallRadius - 1e-9));
@@ -119,14 +123,9 @@ public class PocketEdgeTests
     public void BallFallsIntoPocket()
     {
         var solver = new BilliardsSolver();
-        solver.PocketEdges.Add(new BilliardsSolver.Edge
-        {
-            A = new Vec2(0, 0.1),
-            B = new Vec2(0.1, 0),
-            Normal = new Vec2(1, 1).Normalized()
-        });
+        solver.InitStandardTable();
         var v = new Vec2(-1, -1).Normalized();
-        var ball = new BilliardsSolver.Ball { Position = new Vec2(0.2, 0.2), Velocity = v };
+        var ball = new BilliardsSolver.Ball { Position = new Vec2(0.25, 0.25), Velocity = v };
         var balls = new List<BilliardsSolver.Ball> { ball };
         solver.Step(balls, 0.3);
         Assert.That(ball.Pocketed, Is.True);
@@ -140,14 +139,15 @@ public class ConnectorEdgeTests
     public void BallBouncesOffConnectorWithReducedSpeed()
     {
         var solver = new BilliardsSolver();
+        solver.InitStandardTable();
         solver.ConnectorEdges.Add(new BilliardsSolver.Edge
         {
-            A = new Vec2(0, 0.1),
-            B = new Vec2(0.1, 0),
-            Normal = new Vec2(1, 1).Normalized()
+            A = new Vec2(1.2, 0.6),
+            B = new Vec2(1.3, 0.7),
+            Normal = new Vec2(-1, -1).Normalized()
         });
         var v = new Vec2(-1, -1).Normalized();
-        var ball = new BilliardsSolver.Ball { Position = new Vec2(0.2, 0.2), Velocity = v };
+        var ball = new BilliardsSolver.Ball { Position = new Vec2(1.4, 0.9), Velocity = v };
         var balls = new List<BilliardsSolver.Ball> { ball };
         solver.Step(balls, 0.3);
         Assert.That(ball.Pocketed, Is.False);
@@ -155,5 +155,19 @@ public class ConnectorEdgeTests
         Assert.That(ball.Velocity.X, Is.GreaterThan(0));
         Assert.That(ball.Velocity.Y, Is.GreaterThan(0));
         Assert.That(ball.Velocity.Length, Is.LessThan(0.5));
+    }
+}
+
+public class CushionGeometryTests
+{
+    [Test]
+    public void CornerJawContactMatchesVisualNose()
+    {
+        var solver = new BilliardsSolver();
+        solver.InitStandardTable();
+        var preview = solver.PreviewShot(new Vec2(0.45, 0.45), new Vec2(-1, -1), 2.0, new List<BilliardsSolver.Ball>());
+        double expected = PhysicsConstants.CornerPocketMouth / Math.Sqrt(2.0);
+        Assert.That(Math.Abs(preview.ContactPoint.X - expected), Is.LessThan(0.001));
+        Assert.That(Math.Abs(preview.ContactPoint.Y - expected), Is.LessThan(0.001));
     }
 }

--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -20,8 +20,137 @@ public class BilliardsSolver
         public Vec2 Normal;
     }
 
+    public struct Pocket
+    {
+        public Vec2 Center;
+        public double Radius;
+    }
+
+    public List<Edge> CushionEdges { get; } = new List<Edge>();
     public List<Edge> ConnectorEdges { get; } = new List<Edge>();
     public List<Edge> PocketEdges { get; } = new List<Edge>();
+    public List<Pocket> Pockets { get; } = new List<Pocket>();
+
+    /// <summary>Generates watertight cushion and pocket proxy geometry using table specs.</summary>
+    public void InitStandardTable()
+    {
+        CushionEdges.Clear();
+        ConnectorEdges.Clear();
+        PocketEdges.Clear();
+        Pockets.Clear();
+
+        double width = PhysicsConstants.TableWidth;
+        double height = PhysicsConstants.TableHeight;
+        double cornerMouth = PhysicsConstants.CornerPocketMouth;
+        double sideMouth = PhysicsConstants.SidePocketMouth;
+        double cornerCut = cornerMouth / Math.Sqrt(2.0);
+        double sideCut = sideMouth / 2.0;
+        double sideDepth = Math.Max(sideCut * 1.05, PhysicsConstants.BallRadius * 1.8);
+
+        // Straight cushion spans (long rails)
+        AddCushionSegment(new Vec2(cornerCut, 0), new Vec2(width / 2 - sideCut, 0), new Vec2(0, 1));
+        AddCushionSegment(new Vec2(width / 2 + sideCut, 0), new Vec2(width - cornerCut, 0), new Vec2(0, 1));
+        AddCushionSegment(new Vec2(cornerCut, height), new Vec2(width / 2 - sideCut, height), new Vec2(0, -1));
+        AddCushionSegment(new Vec2(width / 2 + sideCut, height), new Vec2(width - cornerCut, height), new Vec2(0, -1));
+
+        // Straight cushion spans (short rails)
+        AddCushionSegment(new Vec2(0, cornerCut), new Vec2(0, height / 2 - sideCut), new Vec2(1, 0));
+        AddCushionSegment(new Vec2(0, height / 2 + sideCut), new Vec2(0, height - cornerCut), new Vec2(1, 0));
+        AddCushionSegment(new Vec2(width, cornerCut), new Vec2(width, height / 2 - sideCut), new Vec2(-1, 0));
+        AddCushionSegment(new Vec2(width, height / 2 + sideCut), new Vec2(width, height - cornerCut), new Vec2(-1, 0));
+
+        int cornerSegments = Math.Max(8, PhysicsConstants.CornerJawSegments);
+        AddCornerJaw(new Vec2(cornerCut, cornerCut), cornerCut, Math.PI, 1.5 * Math.PI, cornerSegments);
+        AddCornerJaw(new Vec2(width - cornerCut, cornerCut), cornerCut, 1.5 * Math.PI, 2.0 * Math.PI, cornerSegments);
+        AddCornerJaw(new Vec2(width - cornerCut, height - cornerCut), cornerCut, 0, 0.5 * Math.PI, cornerSegments);
+        AddCornerJaw(new Vec2(cornerCut, height - cornerCut), cornerCut, 0.5 * Math.PI, Math.PI, cornerSegments);
+
+        int sideSegments = Math.Max(6, PhysicsConstants.SideJawSegments);
+        AddSidePocketJaw(new Vec2(width / 2, 0), sideCut, sideDepth, true, sideSegments);
+        AddSidePocketJaw(new Vec2(width / 2, height), sideCut, sideDepth, false, sideSegments);
+        AddSidePocketJaw(new Vec2(0, height / 2), sideCut, sideDepth, true, sideSegments, vertical: true);
+        AddSidePocketJaw(new Vec2(width, height / 2), sideCut, sideDepth, false, sideSegments, vertical: true);
+
+        double capture = Math.Max(PhysicsConstants.BallRadius * 1.05, PhysicsConstants.PocketCaptureRadius);
+        Pockets.Add(new Pocket { Center = new Vec2(0, 0), Radius = capture });
+        Pockets.Add(new Pocket { Center = new Vec2(width / 2, 0), Radius = capture });
+        Pockets.Add(new Pocket { Center = new Vec2(width, 0), Radius = capture });
+        Pockets.Add(new Pocket { Center = new Vec2(0, height / 2), Radius = capture });
+        Pockets.Add(new Pocket { Center = new Vec2(width, height / 2), Radius = capture });
+        Pockets.Add(new Pocket { Center = new Vec2(0, height), Radius = capture });
+        Pockets.Add(new Pocket { Center = new Vec2(width / 2, height), Radius = capture });
+        Pockets.Add(new Pocket { Center = new Vec2(width, height), Radius = capture });
+    }
+
+    private void AddCushionSegment(Vec2 a, Vec2 b, Vec2 interiorHint)
+    {
+        if ((b - a).Length < PhysicsConstants.Epsilon)
+            return;
+        Vec2 dir = (b - a).Normalized();
+        Vec2 normal = new Vec2(-dir.Y, dir.X);
+        if (Vec2.Dot(normal, interiorHint) < 0)
+            normal = -normal;
+        CushionEdges.Add(new Edge { A = a, B = b, Normal = normal.Normalized() });
+    }
+
+    private void AddCornerJaw(Vec2 center, double radius, double startAngle, double endAngle, int segments)
+    {
+        if (radius <= PhysicsConstants.Epsilon || segments <= 0)
+            return;
+        double step = (endAngle - startAngle) / segments;
+        Vec2 prev = PointOnCircle(center, radius, startAngle);
+        Vec2 prevNormal = (prev - center).Normalized();
+        for (int i = 1; i <= segments; i++)
+        {
+            double angle = startAngle + step * i;
+            Vec2 next = PointOnCircle(center, radius, angle);
+            Vec2 normal = (next - center).Normalized();
+            Vec2 blended = (prevNormal + normal).Normalized();
+            if (blended.Length < PhysicsConstants.Epsilon)
+                blended = normal;
+            CushionEdges.Add(new Edge { A = prev, B = next, Normal = blended });
+            prev = next;
+            prevNormal = normal;
+        }
+    }
+
+    private void AddSidePocketJaw(Vec2 center, double halfMouth, double depth, bool positive, int segments, bool vertical = false)
+    {
+        if (halfMouth <= PhysicsConstants.Epsilon || depth <= PhysicsConstants.Epsilon || segments <= 0)
+            return;
+
+        List<Vec2> pts = new List<Vec2>();
+        for (int i = 0; i <= segments; i++)
+        {
+            double t = (double)i / segments;
+            double eased = 0.5 - Math.Cos(t * Math.PI) * 0.5;
+            if (vertical)
+            {
+                double y = center.Y + (t - 0.5) * 2.0 * halfMouth;
+                double x = center.X + (positive ? depth : -depth) * (0.5 - eased);
+                pts.Add(new Vec2(x, y));
+            }
+            else
+            {
+                double x = center.X + (t - 0.5) * 2.0 * halfMouth;
+                double y = center.Y + (positive ? depth : -depth) * (0.5 - eased);
+                pts.Add(new Vec2(x, y));
+            }
+        }
+
+        Vec2 hint = vertical ? new Vec2(positive ? -1 : 1, 0) : new Vec2(0, positive ? 1 : -1);
+        for (int i = 0; i < pts.Count - 1; i++)
+        {
+            AddCushionSegment(pts[i], pts[i + 1], hint);
+        }
+    }
+
+    private static Vec2 PointOnCircle(Vec2 center, double radius, double angle)
+    {
+        return new Vec2(
+            center.X + Math.Cos(angle) * radius,
+            center.Y + Math.Sin(angle) * radius);
+    }
 
     public struct Preview
     {
@@ -48,21 +177,23 @@ public class BilliardsSolver
                 double remaining = dt;
                 while (remaining > PhysicsConstants.Epsilon && b.Velocity.Length > 0 && !b.Pocketed)
                 {
-                    Vec2 min = new Vec2(0, 0);
-                    Vec2 max = new Vec2(PhysicsConstants.TableWidth, PhysicsConstants.TableHeight);
-
                     double tHit = double.PositiveInfinity;
                     Vec2 normal = new Vec2();
                     double restitution = PhysicsConstants.Restitution;
                     bool hit = false;
                     bool pocket = false;
+                    Vec2 contactPoint = new Vec2();
 
-                    if (Ccd.CircleAabb(b.Position, b.Velocity, PhysicsConstants.BallRadius, min, max, out double tBox, out Vec2 nBox) && tBox <= remaining)
+                    foreach (var e in CushionEdges)
                     {
-                        tHit = tBox;
-                        normal = nBox;
-                        restitution = PhysicsConstants.CushionRestitution;
-                        hit = true;
+                        if (Ccd.CircleSegment(b.Position, b.Velocity, PhysicsConstants.BallRadius, e.A, e.B, e.Normal, out double tEdge) && tEdge <= remaining && tEdge < tHit)
+                        {
+                            tHit = tEdge;
+                            normal = e.Normal;
+                            restitution = PhysicsConstants.CushionRestitution;
+                            hit = true;
+                            contactPoint = (b.Position + b.Velocity * tEdge) - normal * PhysicsConstants.BallRadius;
+                        }
                     }
 
                     foreach (var e in ConnectorEdges)
@@ -73,6 +204,7 @@ public class BilliardsSolver
                             normal = e.Normal;
                             restitution = PhysicsConstants.ConnectorRestitution;
                             hit = true;
+                            contactPoint = (b.Position + b.Velocity * tEdge) - normal * PhysicsConstants.BallRadius;
                         }
                     }
 
@@ -84,6 +216,25 @@ public class BilliardsSolver
                             normal = e.Normal;
                             hit = true;
                             pocket = true;
+                            contactPoint = (b.Position + b.Velocity * tEdge) - normal * PhysicsConstants.BallRadius;
+                        }
+                    }
+
+                    foreach (var pocketZone in Pockets)
+                    {
+                        double captureRadius = Math.Max(PhysicsConstants.Epsilon, pocketZone.Radius - PhysicsConstants.BallRadius);
+                        if (captureRadius <= PhysicsConstants.Epsilon)
+                            continue;
+                        if (Ccd.CircleCircle(b.Position, b.Velocity, 0, pocketZone.Center, captureRadius, out double tPocket) && tPocket <= remaining && tPocket < tHit)
+                        {
+                            tHit = tPocket;
+                            Vec2 dir = (b.Position + b.Velocity * tPocket - pocketZone.Center).Normalized();
+                            if (dir.Length < PhysicsConstants.Epsilon)
+                                dir = new Vec2(0, 1);
+                            normal = dir;
+                            pocket = true;
+                            hit = true;
+                            contactPoint = pocketZone.Center + dir * captureRadius;
                         }
                     }
 
@@ -99,6 +250,7 @@ public class BilliardsSolver
                             break;
                         }
                         b.Velocity = Collision.Reflect(b.Velocity, normal, restitution);
+                        b.Position = contactPoint + normal * PhysicsConstants.BallRadius;
                         remaining -= tHit;
                     }
                     else
@@ -138,16 +290,6 @@ public class BilliardsSolver
             }
         }
 
-        Vec2 min = new Vec2(0, 0);
-        Vec2 max = new Vec2(PhysicsConstants.TableWidth, PhysicsConstants.TableHeight);
-        if (Ccd.CircleAabb(cueStart, velocity, PhysicsConstants.BallRadius, min, max, out double tc, out Vec2 n))
-        {
-            if (tc < bestT)
-            {
-                bestT = tc; hitNormal = n; ballHit = false; pocketHit = false;
-            }
-        }
-
         foreach (var e in ConnectorEdges)
         {
             if (Ccd.CircleSegment(cueStart, velocity, PhysicsConstants.BallRadius, e.A, e.B, e.Normal, out double te))
@@ -159,6 +301,18 @@ public class BilliardsSolver
             }
         }
 
+        bool cushionHit = false;
+        foreach (var e in CushionEdges)
+        {
+            if (Ccd.CircleSegment(cueStart, velocity, PhysicsConstants.BallRadius, e.A, e.B, e.Normal, out double te))
+            {
+                if (te < bestT)
+                {
+                    bestT = te; hitNormal = e.Normal; ballHit = false; pocketHit = false; connectorHit = false; cushionHit = true;
+                }
+            }
+        }
+
         foreach (var e in PocketEdges)
         {
             if (Ccd.CircleSegment(cueStart, velocity, PhysicsConstants.BallRadius, e.A, e.B, e.Normal, out double te))
@@ -166,6 +320,28 @@ public class BilliardsSolver
                 if (te < bestT)
                 {
                     bestT = te; hitNormal = e.Normal; ballHit = false; pocketHit = true; connectorHit = false;
+                    cushionHit = false;
+                }
+            }
+        }
+
+        foreach (var pocketZone in Pockets)
+        {
+            double captureRadius = Math.Max(PhysicsConstants.Epsilon, pocketZone.Radius - PhysicsConstants.BallRadius);
+            if (captureRadius <= PhysicsConstants.Epsilon)
+                continue;
+            if (Ccd.CircleCircle(cueStart, velocity, 0, pocketZone.Center, captureRadius, out double tPocket))
+            {
+                if (tPocket < bestT)
+                {
+                    bestT = tPocket;
+                    hitNormal = (cueStart + velocity * tPocket - pocketZone.Center).Normalized();
+                    if (hitNormal.Length < PhysicsConstants.Epsilon)
+                        hitNormal = new Vec2(0, 1);
+                    ballHit = false;
+                    pocketHit = true;
+                    connectorHit = false;
+                    cushionHit = false;
                 }
             }
         }
@@ -192,6 +368,14 @@ public class BilliardsSolver
             if (pocketHit)
             {
                 cuePost = new Vec2(0, 0);
+            }
+            else if (cushionHit)
+            {
+                cuePost = Collision.Reflect(velocity, hitNormal, PhysicsConstants.CushionRestitution);
+                if (cuePost.Length > PhysicsConstants.Epsilon)
+                {
+                    path.Add(contact + cuePost.Normalized() * PhysicsConstants.BallRadius);
+                }
             }
             else if (connectorHit)
             {
@@ -240,6 +424,16 @@ public class BilliardsSolver
                 }
             }
 
+            foreach (var e in CushionEdges)
+            {
+                if (Ccd.CircleSegment(cue.Position, cue.Velocity, PhysicsConstants.BallRadius, e.A, e.B, e.Normal, out double te) && te <= PhysicsConstants.FixedDt)
+                {
+                    cue.Position += cue.Velocity * te;
+                    var post = Collision.Reflect(cue.Velocity, e.Normal, PhysicsConstants.CushionRestitution);
+                    return new Impact { Point = cue.Position, CueVelocity = post };
+                }
+            }
+
             foreach (var e in PocketEdges)
             {
                 if (Ccd.CircleSegment(cue.Position, cue.Velocity, PhysicsConstants.BallRadius, e.A, e.B, e.Normal, out double te) && te <= PhysicsConstants.FixedDt)
@@ -248,11 +442,17 @@ public class BilliardsSolver
                     return new Impact { Point = cue.Position, CueVelocity = new Vec2(0, 0) };
                 }
             }
-            if (Ccd.CircleAabb(cue.Position, cue.Velocity, PhysicsConstants.BallRadius, new Vec2(0, 0), new Vec2(PhysicsConstants.TableWidth, PhysicsConstants.TableHeight), out double tc, out Vec2 n) && tc <= PhysicsConstants.FixedDt)
+
+            foreach (var pocketZone in Pockets)
             {
-                cue.Position += cue.Velocity * tc;
-                var post = Collision.Reflect(cue.Velocity, n);
-                return new Impact { Point = cue.Position, CueVelocity = post };
+                double captureRadius = Math.Max(PhysicsConstants.Epsilon, pocketZone.Radius - PhysicsConstants.BallRadius);
+                if (captureRadius <= PhysicsConstants.Epsilon)
+                    continue;
+                if (Ccd.CircleCircle(cue.Position, cue.Velocity, 0, pocketZone.Center, captureRadius, out double tPocket) && tPocket <= PhysicsConstants.FixedDt)
+                {
+                    cue.Position += cue.Velocity * tPocket;
+                    return new Impact { Point = cue.Position, CueVelocity = new Vec2(0, 0) };
+                }
             }
             Step(balls, PhysicsConstants.FixedDt);
             time += PhysicsConstants.FixedDt;

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -4,8 +4,8 @@ namespace Billiards;
 public static class PhysicsConstants
 {
     public const double BallRadius = 0.028575;        // metres (57.15 mm diameter)
-    public const double Restitution = 0.98;            // elastic coefficient
-    public const double CushionRestitution = Restitution * 1.1; // extra bounce for table edges
+    public const double Restitution = 0.9;             // elastic coefficient (clean cushion hits 0.85–0.92)
+    public const double CushionRestitution = Restitution; // use the same restitution for cushions
     // connectors retain only a quarter of the cushion bounce (lose ~75% of speed)
     public const double ConnectorRestitution = CushionRestitution * 0.25;
     // pocket edges fully absorb balls (no bounce)
@@ -16,4 +16,13 @@ public static class PhysicsConstants
     public const double FixedDt = 1.0 / 120.0;         // simulation step
     public const double Epsilon = 1e-9;                // numerical epsilon
     public const double MaxPreviewTime = 30.0;         // safeguard for CCD
+
+    // Pocket geometry derived from WPA spec (metres)
+    public const double CornerPocketMouth = 0.1143;    // 4.5" mouth between cushion noses
+    public const double SidePocketMouth = 0.127;       // 5" mouth between cushion noses
+    public const double PocketCaptureRadius = 0.095;   // radius where balls fall through
+
+    // Tesselation density for proxy mesh generation (higher => smoother normals)
+    public const int CornerJawSegments = 32;
+    public const int SideJawSegments = 24;
 }


### PR DESCRIPTION
## Summary
- add a watertight proxy mesh for cushions, pocket jaws, and capture zones with a new InitStandardTable helper
- update the solver to use mesh-driven continuous collision detection with exact TOI placement and normals
- tune physics constants to realistic restitution values and expand regression coverage for pockets, connectors, and corner jaws

## Testing
- `dotnet test` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_690302c569948329aeb35df8e412957c