### PR TITLE
Adjust Pool Royale pocket rim elevation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -534,7 +534,9 @@ const SIDE_JAW_ARC_DEG = CORNER_JAW_ARC_DEG; // match the middle pocket jaw span
 const POCKET_RIM_DEPTH_RATIO = 1; // match the jaw depth so the pocket rims share the same vertical reach
 const SIDE_POCKET_RIM_DEPTH_RATIO = POCKET_RIM_DEPTH_RATIO; // keep the middle pocket rims identical to the jaw fascia depth
 const POCKET_RIM_SURFACE_OFFSET_SCALE = 0.02; // lift the rim slightly so the taller parts avoid z-fighting while staying aligned
+const POCKET_RIM_SURFACE_ABSOLUTE_LIFT = TABLE.THICK * 0.052; // ensure the rim clears the jaw top even when the rails compress
 const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; // reuse the corner elevation so the middle rims sit flush
+const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
 // Dimensions reflect WPA specifications (playing surface 100" × 50")
@@ -5481,8 +5483,12 @@ function Table3D(
       const rimOffsetScale = isMiddle
         ? SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE
         : POCKET_RIM_SURFACE_OFFSET_SCALE;
+      const rimAbsoluteLift = isMiddle
+        ? SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT
+        : POCKET_RIM_SURFACE_ABSOLUTE_LIFT;
+      const rimVerticalLift = Math.max(rimAbsoluteLift, railH * rimOffsetScale);
       rimMesh.position.y =
-        railsTopY + POCKET_JAW_VERTICAL_LIFT + jawVerticalOffset + railH * rimOffsetScale;
+        railsTopY + POCKET_JAW_VERTICAL_LIFT + jawVerticalOffset + rimVerticalLift;
       rimMesh.castShadow = false;
       rimMesh.receiveShadow = false;
       group.add(rimMesh);


### PR DESCRIPTION
## Summary
- ensure the Pool Royale pocket rims are positioned above the jaw surface by introducing an absolute lift
- reuse the new lift for side pockets so middle and corner rims stay aligned vertically

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6903ac8842808329bf650b19f22adc02