### PR TITLE
Align Pool Royale underlay with rail openings

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5751,6 +5751,30 @@ function Table3D(
     )
   );
 
+  const updateExtrudedSurfaceFromOpening = (mesh, thickness, curveSegments = 64) => {
+    if (!mesh?.isMesh || thickness <= MICRO_EPS) {
+      return;
+    }
+    const shapes = multiPolygonToShapes(openingMP)
+      .map((shape) => shape?.clone?.())
+      .filter(Boolean);
+    if (!shapes.length) {
+      return;
+    }
+    const geometry = new THREE.ExtrudeGeometry(shapes, {
+      depth: thickness,
+      bevelEnabled: false,
+      curveSegments,
+      steps: 1
+    });
+    geometry.translate(0, 0, -thickness);
+    mesh.geometry?.dispose?.();
+    mesh.geometry = geometry;
+  };
+
+  updateExtrudedSurfaceFromOpening(clothUnderlay, CLOTH_UNDERLAY_THICKNESS, 96);
+  updateExtrudedSurfaceFromOpening(clothShadowCover, CLOTH_SHADOW_COVER_THICKNESS, 48);
+
   const railsOuter = new THREE.Shape();
   if (hasRoundedRailCorners) {
     railsOuter.moveTo(outerHalfW, -outerHalfH + outerCornerRadius);


### PR DESCRIPTION
## Summary
- rebuild the Pool Royale table underlay geometry from the rail opening multi-polygon so the wood deck matches the rail interior and clears the pocket jaws
- apply the same rail-aligned profile to the hidden shadow cover to keep its outline consistent with the resized deck

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_6905054508a48329a39aa47085e73491