### PR TITLE
Fix Pool Royale pocket shading artifacts

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4725,12 +4725,15 @@ function Table3D(
     POCKET_TOP_R,
     POCKET_BOTTOM_R,
     TABLE.THICK,
-    48
+    48,
+    1,
+    true
   );
   const pocketMat = new THREE.MeshStandardMaterial({
     color: 0x000000,
     metalness: 0.45,
-    roughness: 0.6
+    roughness: 0.6,
+    side: THREE.BackSide
   });
   const pocketMeshes = [];
   pocketCenters().forEach((p) => {


### PR DESCRIPTION
## Summary
- remove the top and bottom caps from the Pool Royale pocket geometry to eliminate fan artifacts on the cloth
- render the pocket interior using back faces so the hole stays visible after opening the cylinder

## Testing
- npx eslint webapp/src/pages/Games/PoolRoyale.jsx

------
https://chatgpt.com/codex/tasks/task_e_690509c2f8848329a560569e8b91d23f