### PR TITLE
Adjust Pool Royale pocket visuals and control visibility

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4131,6 +4131,8 @@ function Table3D(
     trimMeshes: [],
     pocketJawMeshes: [],
     pocketRimMeshes: [],
+    pocketShroudMeshes: [],
+    pocketBaseMeshes: [],
     underlayMeshes: [],
     clothEdgeMeshes: [],
     accentParent: null,
@@ -4743,6 +4745,25 @@ function Table3D(
     roughness: 0.6,
     side: THREE.BackSide
   });
+  const pocketShroudMat = new THREE.MeshStandardMaterial({
+    color: 0x050505,
+    metalness: 0.28,
+    roughness: 0.62,
+    side: THREE.DoubleSide
+  });
+  const pocketShroudGeo = new THREE.RingGeometry(
+    POCKET_TOP_R * 0.9,
+    POCKET_TOP_R * 1.14,
+    96
+  );
+  pocketShroudGeo.rotateX(-Math.PI / 2);
+  const pocketBaseMat = new THREE.MeshStandardMaterial({
+    color: 0x020202,
+    metalness: 0.16,
+    roughness: 0.68
+  });
+  const pocketBaseGeo = new THREE.CircleGeometry(POCKET_BOTTOM_R * 0.98, 64);
+  pocketBaseGeo.rotateX(-Math.PI / 2);
   const pocketMeshes = [];
   pocketCenters().forEach((p) => {
     const pocket = new THREE.Mesh(pocketGeo, pocketMat);
@@ -4753,6 +4774,18 @@ function Table3D(
     pocket.receiveShadow = true;
     table.add(pocket);
     pocketMeshes.push(pocket);
+    const shroud = new THREE.Mesh(pocketShroudGeo, pocketShroudMat);
+    shroud.position.set(p.x, pocketTopY - MICRO_EPS * 16, p.y);
+    shroud.receiveShadow = false;
+    shroud.castShadow = false;
+    table.add(shroud);
+    finishParts.pocketShroudMeshes.push(shroud);
+    const base = new THREE.Mesh(pocketBaseGeo, pocketBaseMat);
+    base.position.set(p.x, pocketTopY - TABLE.THICK + TABLE.THICK * 0.12, p.y);
+    base.receiveShadow = false;
+    base.castShadow = false;
+    table.add(base);
+    finishParts.pocketBaseMeshes.push(base);
   });
 
   const railH = RAIL_HEIGHT;
@@ -13196,7 +13229,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   }, [updateSpinDotPosition]);
 
   const bottomHudVisible = hud.turn != null && !hud.over && !shotActive;
-  const showPlayerControls = hud.turn === 0 && !hud.over && !shotActive;
+  const showPlayerControls = hud.turn === 0 && !hud.over;
   const isPlayerTurn = hud.turn === 0;
   const isOpponentTurn = hud.turn === 1;
 


### PR DESCRIPTION
## Summary
- keep the Pool Royale power slider and spin controls visible throughout the player's turn
- darken the pocket surrounds and add a shroud plus base meshes so pockets read black instead of exposing the carpet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69059b7727648329be4066b6a13a56f6