### PR TITLE
Align Pool Royale green cloth options

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1450,34 +1450,8 @@ const CHROME_COLOR_OPTIONS = Object.freeze([
 
 const DEFAULT_CLOTH_COLOR_ID = 'freshGreen';
 const CLOTH_COLOR_OPTIONS = Object.freeze([
-  {
-    id: 'freshGreen',
-    label: 'Fresh Green',
-    color: 0x3fba73,
-    detail: {
-      bumpMultiplier: 1.44,
-      roughness: 0.98,
-      sheen: 0.95,
-      sheenRoughness: 0.66,
-      clearcoat: 0.014,
-      clearcoatRoughness: 0.6,
-      emissiveIntensity: 0.54
-    }
-  },
-  {
-    id: 'brightMint',
-    label: 'Bright Mint',
-    color: 0x45b974,
-    detail: {
-      bumpMultiplier: 1.28,
-      roughness: 0.965,
-      sheen: 0.94,
-      sheenRoughness: 0.64,
-      clearcoat: 0.016,
-      clearcoatRoughness: 0.56,
-      emissiveIntensity: 0.58
-    }
-  }
+  { id: 'freshGreen', label: 'Fresh Green', color: 0x3fba73 },
+  { id: 'brightMint', label: 'Bright Mint', color: 0x45b974 }
 ]);
 
 const POCKET_LINER_PRESETS = Object.freeze([


### PR DESCRIPTION
## Summary
- align the Pool Royale green cloth presets with the morning configuration by using the shared Fresh Green and Bright Mint color definitions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905ea866d208329962466a9e8737cfa