### PR TITLE
Reduce Pool Royale shot power by 25%

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -800,8 +800,9 @@ const SPIN_AIR_DECAY = 0.997; // hold spin energy while the cue ball travels str
 const SWERVE_THRESHOLD = 0.85; // outer 15% of the spin control activates swerve behaviour
 const SWERVE_TRAVEL_MULTIPLIER = 0.55; // dampen sideways drift while swerve is active so it stays believable
 const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the cue ball is rolling after impact
-// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 50% softer than before.
-const SHOT_FORCE_BOOST = 1.5 * 0.75 * 0.5;
+// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 50% softer than before
+// and apply the latest Pool Royale tuning to reduce shot power by a further 25%.
+const SHOT_FORCE_BOOST = 1.5 * 0.75 * 0.5 * 0.75;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
 const SHOT_POWER_RANGE = 0.75;


### PR DESCRIPTION
## Summary
- lower the Pool Royale shot force boost to cut overall cue speed by 25%
- document the new tuning alongside the existing shot strength notes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6905fafb34248329a42115e06c6aa507