### PR TITLE
Restore Pool Royale mobile DPR cap to reduce slowdown

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -7766,9 +7766,11 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       renderer.toneMappingExposure = 1.2;
       const resolvePixelRatio = () => {
         const devicePixelRatio = window.devicePixelRatio || 1;
-        const isPortraitMobile = window.innerWidth <= 900;
-        const maxPixelRatio = isPortraitMobile ? 2 : 2.5;
-        return Math.min(devicePixelRatio, maxPixelRatio);
+        const viewportWidth = window.innerWidth || host.clientWidth || 0;
+        // Clamp portrait/mobile DPR to the 1.5 cap we used in the morning build so
+        // the renderer matches the faster baseline quality profile.
+        const mobilePixelCap = viewportWidth <= 1366 ? 1.5 : 2;
+        return Math.min(devicePixelRatio, mobilePixelCap);
       };
       renderer.setPixelRatio(resolvePixelRatio());
       renderer.shadowMap.enabled = true;


### PR DESCRIPTION
## Summary
- clamp the Pool Royale renderer pixel ratio using the morning 1.5 mobile cap so the graphics profile matches the faster baseline

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6906159c4bf083299e440444978df1c3