### PR TITLE
Allow Pool Royale spin controller on player's turn

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13141,8 +13141,20 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
     };
   }, [applySliderLock, showPowerSlider]);
 
+  const isPlayerTurn = hud.turn === 0;
+  const isOpponentTurn = hud.turn === 1;
+  const showPlayerControls = isPlayerTurn && !hud.over;
+
   // Spin controller interactions
   useEffect(() => {
+    if (!showPlayerControls) {
+      spinDotElRef.current = null;
+      resetSpinRef.current = () => {};
+      spinRequestRef.current = { x: 0, y: 0 };
+      spinLegalityRef.current = { blocked: false, reason: '' };
+      return;
+    }
+
     const box = document.getElementById('spinBox');
     const dot = document.getElementById('spinDot');
     if (!box || !dot) return;
@@ -13280,12 +13292,9 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       box.removeEventListener('pointerup', handlePointerUp);
       box.removeEventListener('pointercancel', handlePointerCancel);
     };
-  }, [updateSpinDotPosition]);
+  }, [showPlayerControls, updateSpinDotPosition]);
 
   const bottomHudVisible = hud.turn != null && !hud.over && !shotActive;
-  const isPlayerTurn = hud.turn === 0;
-  const isOpponentTurn = hud.turn === 1;
-  const showPlayerControls = isPlayerTurn && !hud.over;
 
   return (
     <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">


### PR DESCRIPTION
## Summary
- reinitialize the spin controller only when Pool Royale player controls are visible
- reset spin state references when the controller is hidden to keep interactions consistent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6906db6a59788329b3a2db493967eafa