### PR TITLE
Restore Pool Royale baseline tuning for 5am build

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -655,7 +655,7 @@ const BALL_GEOMETRY = new THREE.SphereGeometry(
 );
 // Match the snooker build so pace and rebound energy stay consistent between modes.
 const FRICTION = 0.993;
-const DEFAULT_CUSHION_RESTITUTION = 1;
+const DEFAULT_CUSHION_RESTITUTION = 0.99;
 let CUSHION_RESTITUTION = DEFAULT_CUSHION_RESTITUTION;
 const STOP_EPS = 0.02;
 const TARGET_FPS = 90;
@@ -797,8 +797,8 @@ const SPIN_AIR_DECAY = 0.997; // hold spin energy while the cue ball travels str
 const SWERVE_THRESHOLD = 0.85; // outer 15% of the spin control activates swerve behaviour
 const SWERVE_TRAVEL_MULTIPLIER = 0.55; // dampen sideways drift while swerve is active so it stays believable
 const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the cue ball is rolling after impact
-// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power punchier for 3D play.
-const SHOT_FORCE_BOOST = 2.7 * 0.75; // align cue launch strength with snooker build
+// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
+const SHOT_FORCE_BOOST = 1.5 * 0.75;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
 const SHOT_POWER_RANGE = 0.75;
@@ -7758,7 +7758,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.2;
       const devicePixelRatio = window.devicePixelRatio || 1;
-      const mobilePixelCap = window.innerWidth <= 1366 ? 1.5 : 2;
+      const mobilePixelCap = window.innerWidth <= 1366 ? 1.35 : 1.9;
       renderer.setPixelRatio(Math.min(mobilePixelCap, devicePixelRatio));
       renderer.sortObjects = true;
       renderer.shadowMap.enabled = true;


### PR DESCRIPTION
## Summary
- reset the Pool Royale cushion restitution to the prior 0.99 baseline so rebounds match the previous morning build
- dial the cue shot force boost back to the legacy tuning for correct ball speed and shoot power
- restore the mobile pixel ratio caps used yesterday morning to keep the rendering resolution consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69072ee1e6fc8329b460a03df7cc82df