### PR TITLE
Improve Pool Royale rendering resolution and update cadence

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8053,15 +8053,27 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       applyRendererSRGB(renderer);
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.2;
-      const devicePixelRatio = window.devicePixelRatio || 1;
-      const mobilePixelCap = window.innerWidth <= 1366 ? 1.35 : 1.9;
-      renderer.setPixelRatio(Math.min(mobilePixelCap, devicePixelRatio));
+      const targetRenderWidth = 1920;
+      const targetRenderHeight = 1080;
+      const maxPixelRatio = window.innerWidth <= 1366 ? 2.5 : 3;
+      const updateRendererResolution = () => {
+        const rect = host.getBoundingClientRect();
+        const width = Math.max(1, rect.width || host.clientWidth);
+        const height = Math.max(1, rect.height || host.clientHeight);
+        const basePixelRatio = window.devicePixelRatio || 1;
+        const desiredPixelRatio = Math.max(
+          basePixelRatio,
+          targetRenderWidth / width,
+          targetRenderHeight / height
+        );
+        const pixelRatio = Math.min(maxPixelRatio, desiredPixelRatio);
+        renderer.setPixelRatio(pixelRatio);
+        renderer.setSize(width, height, false);
+      };
+      updateRendererResolution();
       renderer.sortObjects = true;
       renderer.shadowMap.enabled = true;
       renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-      // Ensure the canvas fills the host element so the table is centered and
-      // scaled correctly on all view modes.
-      renderer.setSize(host.clientWidth, host.clientHeight);
       host.appendChild(renderer.domElement);
       renderer.domElement.addEventListener('webglcontextlost', (e) =>
         e.preventDefault()
@@ -8092,7 +8104,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       let lastShotPower = 0;
       let prevCollisions = new Set();
       let cueAnimating = false; // forward stroke animation state
-      const DYNAMIC_TEXTURE_MIN_INTERVAL = 1 / 45;
+      const DYNAMIC_TEXTURE_MIN_INTERVAL = 1 / 60;
       const dynamicTextureEntries = [];
       const registerDynamicTexture = (entry) => {
         if (!entry || !entry.texture || typeof entry.update !== 'function') {
@@ -8168,7 +8180,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
         let offset = 0;
         return {
           texture,
-          minInterval: 1 / 45,
+          minInterval: 1 / 60,
           update(delta) {
             if (!ctx) return;
             const text = coinTicker.text();
@@ -8194,7 +8206,9 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       const createMatchTvEntry = () => {
         const baseWidth = 1024;
         const baseHeight = 512;
-        const resolutionScale = 1;
+        const devicePixelRatio =
+          typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
+        const resolutionScale = Math.min(2.5, Math.max(1, devicePixelRatio));
         const canvas = document.createElement('canvas');
         canvas.width = Math.round(baseWidth * resolutionScale);
         canvas.height = Math.round(baseHeight * resolutionScale);
@@ -13438,7 +13452,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
 
       // Resize
         const onResize = () => {
-          renderer.setSize(host.clientWidth, host.clientHeight);
+          updateRendererResolution();
           // Update canvas dimensions when the window size changes so the table
           // remains fully visible.
           const scaleChanged = applyWorldScaleRef.current?.() ?? false;


### PR DESCRIPTION
## Summary
- target full HD rendering by dynamically scaling the Pool Royale WebGL renderer to higher pixel ratios
- increase auxiliary canvas texture resolutions and refresh cadence for sharper UI elements

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_69077bca5ac88329addb884b421664cf