### PR TITLE
Refine snake multiplayer seating and account tracking

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -2440,6 +2440,7 @@ function updateTokens(
   players.forEach((player, index) => {
     keep.add(index);
     let token = existing.get(index);
+    const seatIndex = Number.isFinite(player?.seatIndex) ? player.seatIndex : index;
     if (!token) {
       token = new THREE.Group();
       const baseColor = new THREE.Color(player.color || DEFAULT_COLORS[index % DEFAULT_COLORS.length]);
@@ -2593,9 +2594,9 @@ function updateTokens(
       baseVector.y += TOKEN_HEIGHT * 0.02;
       worldPos = baseVector;
     } else {
-      const fallbackHomeIndex = seatHomes.length > 0 ? index % seatHomes.length : -1;
+      const fallbackHomeIndex = seatHomes.length > 0 ? seatIndex % seatHomes.length : -1;
       const home =
-        seatHomes[index] || (fallbackHomeIndex >= 0 ? seatHomes[fallbackHomeIndex] : null) || null;
+        seatHomes[seatIndex] || (fallbackHomeIndex >= 0 ? seatHomes[fallbackHomeIndex] : null) || null;
       if (home?.position) {
         worldPos = home.position.clone();
       } else {

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -239,7 +239,10 @@ export default function Lobby() {
 
   const startGame = async (flagOverride = flags) => {
     const params = new URLSearchParams();
-    if (table) params.set('table', table.id);
+    if (table) {
+      params.set('table', table.id);
+      if (table.capacity) params.set('capacity', String(table.capacity));
+    }
 
     if (game === 'snake' && table && table.id !== 'single') {
       const accountId = await ensureAccountId().catch(() => null);
@@ -296,6 +299,7 @@ export default function Lobby() {
 
     if (game === 'snake' && table && table.id !== 'single') {
       params.set('table', table.id);
+      if (table.capacity) params.set('capacity', String(table.capacity));
     }
     startedRef.current = true;
     navigate(`/games/${game}?${params.toString()}`);

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -30,22 +30,29 @@ export function getTelegramId() {
   return null;
 }
 
-export function getPlayerId() {
-  if (typeof window !== 'undefined') {
-    const aid = localStorage.getItem('accountId');
-    if (aid) return aid;
+function generateAccountId() {
+  if (typeof window === 'undefined') return null;
+  if (window.crypto?.randomUUID) {
+    return window.crypto.randomUUID();
   }
-  return getTelegramId();
+  const random = Math.random().toString(36).slice(2, 11);
+  const timestamp = Date.now().toString(36);
+  return `tpc-${timestamp}-${random}`;
+}
+
+export function getPlayerId() {
+  if (typeof window === 'undefined') return null;
+  let id = localStorage.getItem('accountId');
+  if (!id) {
+    id = generateAccountId();
+    if (id) localStorage.setItem('accountId', id);
+  }
+  return id;
 }
 
 export async function ensureAccountId() {
   if (typeof window === 'undefined') return null;
-  let id = localStorage.getItem('accountId');
-  if (!id) {
-    id = crypto.randomUUID();
-    localStorage.setItem('accountId', id);
-  }
-  return id;
+  return getPlayerId();
 }
 
 export function getTelegramUsername() {


### PR DESCRIPTION
## Summary
- generate stable TPC account IDs in the web client and use them for Snake & Ladder multiplayer events
- keep multiplayer lobbies in sync by passing the table capacity and reacting to capacity updates from the server
- assign seat indices so two-player matches render opponents on opposite sides while updating the 3D board tokens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_6908ec1509e083259d5fa9858343c2a5