### PR TITLE
Hide waiting overlay after multiplayer game begins

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -816,7 +816,11 @@ export default function SnakeAndLadder() {
   }, [isMultiplayer, tableId]);
 
   useEffect(() => {
-    if (!isMultiplayer || watchOnly || !setupPhase) return;
+    if (!isMultiplayer || watchOnly) return;
+    if (!setupPhase) {
+      setWaitingForPlayers(false);
+      return;
+    }
     setWaitingForPlayers(playersNeeded > 0);
   }, [isMultiplayer, playersNeeded, setupPhase, watchOnly]);
 


### PR DESCRIPTION
## Summary
- stop showing the Snake & Ladder multiplayer waiting overlay once the setup phase ends
- keep the overlay active only while seats are still filling before the match starts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_69090083a0b48325831e21684bab2958