### PR TITLE
Fix Snake & Ladder waiting overlay after match start

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -966,6 +966,7 @@ export default function SnakeAndLadder() {
       }
     };
     const onStarted = () => {
+      setSetupPhase(false);
       setWaitingForPlayers(false);
       if (myAccountId) {
         unseatTable(myAccountId, tableId).catch(() => {});


### PR DESCRIPTION
## Summary
- ensure the Snake & Ladder multiplayer flow exits setup when the server starts the match
- prevent the waiting overlay from reappearing after the game has begun

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_690907abeae08325b45bbd4d23ecdc46