### PR TITLE
Keep Pool Royale camera static on short rails

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -783,6 +783,8 @@ const ACTION_CAM = Object.freeze({
  */
 const SHORT_RAIL_CAMERA_DISTANCE = PLAY_H / 2 + BALL_R * 18;
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // match short-rail framing so broadcast shots feel consistent
+const STATIC_SHORT_RAIL_CAMERA_HEIGHT = TABLE_Y + TABLE.THICK + BALL_R * 11.5;
+const STATIC_SHORT_RAIL_CAMERA_PULLBACK = BALL_R * 6;
 const CAMERA_LATERAL_CLAMP = Object.freeze({
   short: PLAY_W * 0.4,
   side: PLAY_H * 0.45
@@ -8645,7 +8647,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       const shortRailSlideLimit = CAMERA_LATERAL_CLAMP.short * 0.92;
       const broadcastRig = createBroadcastCameras({
         floorY,
-        cameraHeight: TABLE_Y + TABLE.THICK + BALL_R * 9.2,
+        cameraHeight: STATIC_SHORT_RAIL_CAMERA_HEIGHT,
         shortRailZ: shortRailTarget,
         slideLimit: shortRailSlideLimit,
         arenaHalfDepth: roomDepth / 2 - wallThickness - BALL_R * 4
@@ -9351,7 +9353,43 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
             lerp: 0.18
           };
           const galleryState = cueGalleryStateRef.current;
-          if (galleryState?.active) {
+          const hudState = hudRef.current ?? null;
+          const staticFocusTarget = broadcastCamerasRef.current?.defaultFocusWorld
+            ? broadcastCamerasRef.current.defaultFocusWorld.clone()
+            : new THREE.Vector3(
+                0,
+                (TABLE_Y + TABLE.THICK * 0.5) * worldScaleFactor,
+                0
+              );
+          const staticBaseDistance =
+            (SHORT_RAIL_CAMERA_DISTANCE + STATIC_SHORT_RAIL_CAMERA_PULLBACK) *
+            worldScaleFactor;
+          const staticDistance = hudState?.inHand
+            ? staticBaseDistance * IN_HAND_CAMERA_RADIUS_MULTIPLIER
+            : staticBaseDistance;
+          const staticHeight = STATIC_SHORT_RAIL_CAMERA_HEIGHT * worldScaleFactor;
+          if (!galleryState?.active && !topViewRef.current) {
+            TMP_VEC3_A.set(0, staticHeight, staticDistance);
+            camera.position.copy(TMP_VEC3_A);
+            camera.lookAt(staticFocusTarget);
+            renderCamera = camera;
+            lookTarget = staticFocusTarget.clone();
+            broadcastArgs = {
+              railDir: 1,
+              targetWorld: lookTarget.clone(),
+              focusWorld: lookTarget.clone(),
+              lerp: 1
+            };
+            const sph = sphRef.current;
+            if (sph) {
+              TMP_VEC3_A.copy(camera.position).sub(lookTarget);
+              TMP_SPH.setFromVector3(TMP_VEC3_A);
+              sph.radius = TMP_SPH.radius;
+              sph.phi = TMP_SPH.phi;
+              sph.theta = TMP_SPH.theta;
+              syncBlendToSpherical();
+            }
+          } else if (galleryState?.active) {
             const basePosition =
               galleryState.basePosition ?? galleryState.position ?? null;
             const baseTarget =


### PR DESCRIPTION
## Summary
- raise the Pool Royale broadcast rig height constant and reuse it for the static view
- lock the gameplay camera to a short-rail broadcast framing and pull back further while the cue ball is in hand

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_69097cd48bc08325b46461b4e6992de8