### PR TITLE
Fix snake lobby capacity tracking

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -385,7 +385,8 @@ async function seatTableSocket(
     tableId,
     players: table.players,
     currentTurn: table.currentTurn,
-    ready: Array.from(table.ready)
+    ready: Array.from(table.ready),
+    maxPlayers: table.maxPlayers
   });
   return table;
 }
@@ -456,7 +457,8 @@ function unseatTableSocket(accountId, tableId, socketId) {
       tableId,
       players: table.players,
       currentTurn: table.currentTurn,
-      ready: Array.from(table.ready || [])
+      ready: Array.from(table.ready || []),
+      maxPlayers: table.maxPlayers
     });
     if (accountId && table.currentTurn && table.currentTurn !== accountId) {
       io.to(tableId).emit('turnUpdate', { currentTurn: table.currentTurn });

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -105,7 +105,9 @@ test('joining player receives full player list', () => {
   room.addPlayer('p2', 'B', s2);
   const cur = events.find(e => e.event === 'currentPlayers');
   assert.ok(cur, 'currentPlayers event should be sent');
-  assert.equal(cur.data.length, 2);
+  assert.ok(cur.data && Array.isArray(cur.data.players), 'payload should include players array');
+  assert.equal(cur.data.players.length, 2);
+  assert.equal(cur.data.maxPlayers, 3);
 });
 
 test('player wins when landing on the final tile', () => {


### PR DESCRIPTION
## Summary
- include the table capacity with snake multiplayer socket events
- make lobby updates report the active max player count to clients
- adjust snake unit test to cover the richer currentPlayers payload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_6909848ac4308325872ce8a94cdb3aa1