### PR TITLE
Fix socket URL resolution for Snake multiplayer hosting

### DIFF
--- a/webapp/src/utils/socket.js
+++ b/webapp/src/utils/socket.js
@@ -1,9 +1,66 @@
 import { io } from 'socket.io-client';
+import { API_BASE_URL } from './api.js';
 
-let baseUrl = import.meta.env.VITE_API_BASE_URL || window.location.origin;
+function resolveSocketConfig() {
+  const explicitUrl = import.meta.env.VITE_SOCKET_URL;
+  const explicitPath = import.meta.env.VITE_SOCKET_PATH;
 
-if (typeof window !== 'undefined' && window.location.protocol === 'https:' && baseUrl.startsWith('http:')) {
-  baseUrl = baseUrl.replace(/^http:/, 'https:');
+  let rawUrl =
+    explicitUrl ||
+    API_BASE_URL ||
+    (typeof window !== 'undefined' ? window.location.origin : '');
+
+  const options = { transports: ['websocket'] };
+
+  const applyDefaultPath = () => {
+    if (!options.path) {
+      options.path = '/socket.io';
+    }
+  };
+
+  if (explicitPath) {
+    options.path = explicitPath;
+  }
+
+  if (!rawUrl) {
+    applyDefaultPath();
+    return { url: rawUrl, options };
+  }
+
+  try {
+    const base = typeof window !== 'undefined' ? window.location.href : 'http://localhost';
+    const parsed = new URL(rawUrl, base);
+    if (!explicitPath) {
+      const trimmedPath = parsed.pathname.replace(/\/+$/, '');
+      if (trimmedPath && trimmedPath !== '') {
+        options.path = `${trimmedPath}/socket.io`;
+      }
+    }
+    parsed.pathname = '';
+    parsed.search = '';
+    parsed.hash = '';
+    rawUrl = parsed.toString().replace(/\/+$/, '');
+  } catch {
+    if (!explicitPath) {
+      if (/\/socket\.io\/?$/.test(rawUrl)) {
+        options.path = '/socket.io';
+        rawUrl = rawUrl.replace(/\/socket\.io\/?$/, '');
+      } else if (/\/api\/?$/.test(rawUrl)) {
+        options.path = '/socket.io';
+        rawUrl = rawUrl.replace(/\/api\/?$/, '');
+      }
+    }
+    rawUrl = rawUrl.replace(/\/+$/, '');
+  }
+
+  if (typeof window !== 'undefined' && window.location.protocol === 'https:' && rawUrl.startsWith('http:')) {
+    rawUrl = rawUrl.replace(/^http:/, 'https:');
+  }
+
+  applyDefaultPath();
+  return { url: rawUrl, options };
 }
 
-export const socket = io(baseUrl, { transports: ['websocket'] });
+const { url, options } = resolveSocketConfig();
+
+export const socket = io(url, options);


### PR DESCRIPTION
## Summary
- derive socket.io connection settings from dedicated environment variables or the API base URL
- strip API-specific path segments and enforce secure protocols so multiplayer lobbies can reach the websocket host

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_69098a0676288325a8e54bd9972e6e6d