### PR TITLE
Resize Pool Royale table and refine broadcast framing

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -27,24 +27,24 @@ public class CameraController : MonoBehaviour
     // Minimum distance the camera should maintain when hugging the table so the
     // framing ends up closer to the cue ball without drifting toward the butt of
     // the cue stick.
-    public float minimumCueViewDistance = 1.45f;
+    public float minimumCueViewDistance = 1.34125f;
     // How far above the rails the camera is allowed to travel.
     public float maxHeightAboveTable = 1.9f;
     // Default distance of the camera from the table centre when fully raised to
     // provide a broad overview of the action.
-    public float distanceFromCenter = 3.8f;
+    public float distanceFromCenter = 3.515f;
     // Minimum distance from the table centre allowed when the camera is pulled
     // down toward the rails for a closer look.
-    public float minDistanceFromCenter = 2.15f;
+    public float minDistanceFromCenter = 1.98875f;
     // Extra distance the camera is allowed to shed as it hugs the table so the
     // cue ball fills more of the view during low-angle aiming.
-    public float lowHeightDistanceReduction = 0.45f;
+    public float lowHeightDistanceReduction = 0.41625f;
     // Extra pullback applied when the camera is raised to its maximum height so
     // the player gets a slightly wider view while aiming.
-    public float zoomOutWhenRaised = 0.25f;
+    public float zoomOutWhenRaised = 0.23125f;
     // Buffer that keeps the camera just outside the rails even at the closest
     // zoom level.
-    public float railBuffer = 0.02f;
+    public float railBuffer = 0.0185f;
     // Slight height offset so the camera looks just above the table centre
     // to reduce the viewing angle and give a lower perspective.
     public float lookAtHeightOffset = 0.08f;
@@ -54,13 +54,13 @@ public class CameraController : MonoBehaviour
     public float lowHeightLookUpOffset = 0.12f;
     // When the camera moves close to the table corners pull back slightly so
     // the rails remain visible and aiming is easier.
-    public float cornerXThreshold = 2.6f;
-    public float cornerZThreshold = 1.3f;
-    public float cornerPullback = 0.5f;
+    public float cornerXThreshold = 2.405f;
+    public float cornerZThreshold = 1.2025f;
+    public float cornerPullback = 0.4625f;
     // Range beyond the thresholds where the pullback gradually reaches the
     // maximum value.  This avoids a sudden jump in zoom when approaching a
     // corner and gives a smoother transition.
-    public float cornerBlendRange = 0.4f;
+    public float cornerBlendRange = 0.37f;
     // Optional reference to the active player (usually the cue ball). When set,
     // corner pullback is based on the player's position instead of the camera
     // so that approaching a rail gives a better view of the shot.

--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -123,22 +123,25 @@ public class BilliardsSolver
         for (int i = 0; i <= segments; i++)
         {
             double t = (double)i / segments;
-            double eased = 0.5 - Math.Cos(t * Math.PI) * 0.5;
+            double angle = Math.PI * (1.0 - t);
+            double mouthOffset = halfMouth * Math.Cos(angle);
+            double depthOffset = depth * Math.Sin(angle);
+
             if (vertical)
             {
-                double y = center.Y + (t - 0.5) * 2.0 * halfMouth;
-                double x = center.X + (positive ? depth : -depth) * (0.5 - eased);
+                double y = center.Y + mouthOffset;
+                double x = center.X + (positive ? depthOffset : -depthOffset);
                 pts.Add(new Vec2(x, y));
             }
             else
             {
-                double x = center.X + (t - 0.5) * 2.0 * halfMouth;
-                double y = center.Y + (positive ? depth : -depth) * (0.5 - eased);
+                double x = center.X + mouthOffset;
+                double y = center.Y + (positive ? depthOffset : -depthOffset);
                 pts.Add(new Vec2(x, y));
             }
         }
 
-        Vec2 hint = vertical ? new Vec2(positive ? -1 : 1, 0) : new Vec2(0, positive ? 1 : -1);
+        Vec2 hint = vertical ? new Vec2(positive ? 1 : -1, 0) : new Vec2(0, positive ? 1 : -1);
         for (int i = 0; i < pts.Count - 1; i++)
         {
             AddCushionSegment(pts[i], pts[i + 1], hint);

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -11,16 +11,16 @@ public static class PhysicsConstants
     // pocket edges fully absorb balls (no bounce)
     public const double PocketRestitution = 0.0;
     public const double Mu = 0.2;                      // linear damping (m/s^2)
-    public const double TableWidth = 2.84;             // 9ft table internal size
-    public const double TableHeight = 1.42;
+    public const double TableWidth = 2.627;            // 9ft table reduced by ~7.5%
+    public const double TableHeight = 1.3135;
     public const double FixedDt = 1.0 / 120.0;         // simulation step
     public const double Epsilon = 1e-9;                // numerical epsilon
     public const double MaxPreviewTime = 30.0;         // safeguard for CCD
 
     // Pocket geometry derived from WPA spec (metres)
-    public const double CornerPocketMouth = 0.1143;    // 4.5" mouth between cushion noses
-    public const double SidePocketMouth = 0.127;       // 5" mouth between cushion noses
-    public const double PocketCaptureRadius = 0.095;   // radius where balls fall through
+    public const double CornerPocketMouth = 0.1057275; // scaled with table reduction
+    public const double SidePocketMouth = 0.117475;    // scaled with table reduction
+    public const double PocketCaptureRadius = 0.087875; // scaled with table reduction
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 32;


### PR DESCRIPTION
## Summary
- shrink the deterministic table dimensions by roughly 7.5% and scale pocket measurements to match
- extend side pocket jaws with curved segments so the throat meets the cushions cleanly
- retune cue and broadcast cameras for the smaller table and keep moving balls framed from the short rail view

## Testing
- dotnet build billiards/Billiards.csproj *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6909964f01ec832595ac85fb8989096c