### PR TITLE
Implement shared dice cell sync for Snake & Ladder online mode

### DIFF
--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -84,8 +84,11 @@ export class SnakeGame {
     }
 
     let extraTurn = false;
+    let bonus = null;
+    let bonusCell = null;
     if (this.diceCells[player.position]) {
-      const bonus = this.diceCells[player.position];
+      bonus = this.diceCells[player.position];
+      bonusCell = player.position;
       player.bonus = bonus;
       delete this.diceCells[player.position];
       extraTurn = true;
@@ -108,6 +111,8 @@ export class SnakeGame {
       position: player.position,
       extraTurn,
       finished: this.finished,
+      bonus,
+      bonusCell,
     };
   }
 }

--- a/bot/models/GameRoom.js
+++ b/bot/models/GameRoom.js
@@ -20,6 +20,7 @@ const gameRoomSchema = new mongoose.Schema({
   currentTurn: { type: Number, default: 0 },
   snakes: { type: Map, of: Number, default: {} },
   ladders: { type: Map, of: Number, default: {} },
+  diceCells: { type: Map, of: Number, default: {} },
   players: { type: [playerSchema], default: [] }
 });
 

--- a/bot/server.js
+++ b/bot/server.js
@@ -603,7 +603,11 @@ app.get('/api/snake/board/:id', async (req, res) => {
   const room = await gameManager.getRoom(id, cap);
   // Persist the board so all players receive the same layout
   await gameManager.saveRoom(room).catch(() => {});
-  res.json({ snakes: room.snakes, ladders: room.ladders });
+  res.json({
+    snakes: room.snakes,
+    ladders: room.ladders,
+    diceCells: room.diceCells
+  });
 });
 app.get('/api/watchers/count/:id', (req, res) => {
   const set = tableWatchers.get(req.params.id);
@@ -897,7 +901,7 @@ io.on('connection', (socket) => {
       const room = await gameManager.getRoom(roomId);
       const board =
         room.gameType === 'snake'
-          ? { snakes: room.snakes, ladders: room.ladders }
+          ? { snakes: room.snakes, ladders: room.ladders, diceCells: room.diceCells }
           : room.gameType === 'checkers'
           ? { board: room.game.board }
           : null;


### PR DESCRIPTION
## Summary
- generate and persist shared dice-cell bonuses in the Snake & Ladder game engine
- expose dice-cell data over REST/socket endpoints and normalize storage
- consume multiplayer dice cells in the web app and cover the flow with a node test

## Testing
- node --test test/snakeGame.test.js

------
https://chatgpt.com/codex/tasks/task_b_6909a818d6c8832584a1a4f254a6e710