### PR TITLE
Refine Pool Royale side pocket jaws

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -250,7 +250,7 @@ const CHROME_CORNER_EDGE_TRIM_SCALE = 0; // do not trim edges beyond the snooker
 const CHROME_SIDE_POCKET_RADIUS_SCALE =
   CORNER_POCKET_INWARD_SCALE *
   CHROME_CORNER_POCKET_RADIUS_SCALE *
-  1.018; // open the middle chrome arch slightly more so the jaws sit deeper inside the wider chrome reveal
+  1.006; // keep the middle chrome arch slightly relaxed so the rounded cut hugs the slimmer jaws without widening the reveal
 const WOOD_RAIL_CORNER_RADIUS_SCALE = 1; // match snooker rail rounding so the chrome sits flush
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0; // disable secondary throat so the side chrome uses a single arch
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85; // reuse snooker notch height profile
@@ -509,9 +509,11 @@ const RAIL_HEIGHT = TABLE.THICK * 1.96; // raise the wooden rails slightly so th
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.004; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // match the side jaw clamp to the chrome plates so the fascia reaches the cushions
 const POCKET_JAW_CORNER_INNER_SCALE = 1.472; // pull the inner lip slightly farther outward so the jaw thins from the pocket side while keeping the chrome-facing radius and exterior fascia untouched
-const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE; // match the middle pocket jaw thickness to the corner profile for identical mass
+const POCKET_JAW_SIDE_INNER_SCALE =
+  POCKET_JAW_CORNER_INNER_SCALE * 0.988; // ease the middle pocket jaw thickness so it sits fractionally leaner than the corners
 const POCKET_JAW_CORNER_OUTER_SCALE = 1.76; // preserve the playable mouth while matching the longer corner jaw fascia
-const POCKET_JAW_SIDE_OUTER_SCALE = POCKET_JAW_CORNER_OUTER_SCALE; // lock the middle jaw rims to the same span as the chrome pocket rims
+const POCKET_JAW_SIDE_OUTER_SCALE =
+  POCKET_JAW_CORNER_OUTER_SCALE * 0.986; // tighten the middle jaw fascia span so the visible bite narrows without affecting the corner profile
 const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.01; // flare the exterior jaw edge slightly so the chrome-facing finish broadens without widening the mouth
 const SIDE_POCKET_JAW_OUTER_EXPANSION = 0; // keep the middle pocket fascia flush with the wood rail so it no longer creeps over the cloth
 const POCKET_JAW_DEPTH_SCALE = 0.52; // drop the jaws slightly deeper so the underside fills out the pocket throat
@@ -537,10 +539,10 @@ const POCKET_JAW_SIDE_EDGE_FACTOR = POCKET_JAW_CORNER_EDGE_FACTOR; // keep the m
 const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thickness so the jaw crowns through the pocket centre
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.592; // nudge the corner jaw spread farther so the fascia kisses the cushion shoulders without gaps
-const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.472; // trim the middle jaw span so it stops where the wooden rail arch ends
-const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // mirror the corner jaw radius so the side fascia matches the cushion arch perfectly
-const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1; // keep the middle jaw depth identical to the corners for a uniform vertical profile
-const SIDE_POCKET_JAW_VERTICAL_TWEAK = -TABLE.THICK * 0.015; // drop the middle jaw crowns slightly so they finish level with the surrounding rails
+const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.426; // pull the middle jaw span in a touch further so the fascia clears the rounded rail cut
+const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.986; // shave the middle jaw radius so the pocket mouth presents narrower than before
+const SIDE_POCKET_JAW_DEPTH_EXPANSION = 0.982; // let the middle jaw depth follow the slimmer profile instead of matching the corners exactly
+const SIDE_POCKET_JAW_VERTICAL_TWEAK = -TABLE.THICK * 0.028; // lower the middle jaw crowns more so their top edge aligns with the corner jaw altitude
 const SIDE_POCKET_JAW_EDGE_TRIM_START = 0.62; // begin trimming the side pocket jaw shoulders roughly two thirds toward each chrome plate
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.86; // blend the outer radius toward the inner lip to visually shave the jaw edges
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = 1.35; // ease the trim-in blend so the side jaw taper feels progressive instead of abrupt


### PR DESCRIPTION
## Summary
- narrow the Pool Royale side chrome cut so the middle pocket reveal sits tighter around the jaws
- slim the middle pocket jaw thickness, span, and depth to deliver a smaller bite than the corners
- drop the side jaws slightly so their height matches the corner jaw altitude

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_6909c90bccb0832584f25647828918a5