### PR TITLE
Match snooker table styling to Pool Royale

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -199,31 +199,64 @@ function createDefaultPocketJawMaterial() {
   });
 }
 
-const POCKET_VISUAL_EXPANSION = 1.05;
-const CHROME_CORNER_POCKET_RADIUS_SCALE = 1;
-const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.08;
-const CHROME_CORNER_EXPANSION_SCALE = 1.02;
-const CHROME_CORNER_SIDE_EXPANSION_SCALE = 1;
-const CHROME_CORNER_FIELD_TRIM_SCALE = 0;
+const POCKET_VISUAL_EXPANSION = 1.012;
+const CORNER_POCKET_INWARD_SCALE = 1.015; // mirror Pool Royale inward pull so chrome hugs the cloth
+const CORNER_POCKET_SCALE_BOOST = 0.985; // reuse Pool Royale mouth tightening for matching capture visuals
+const CHROME_CORNER_POCKET_RADIUS_SCALE = 1.01;
+const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.028;
+const CHROME_CORNER_EXPANSION_SCALE = 1.002;
+const CHROME_CORNER_SIDE_EXPANSION_SCALE = 1.002;
+const CHROME_CORNER_FIELD_TRIM_SCALE = -0.03;
 const CHROME_CORNER_NOTCH_WEDGE_SCALE = 0;
-const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.9; // widen the field-side trim to scoop out the lingering chrome wedge
-const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 1.1; // push the trim deeper along the short rail so the notch fully clears the plate
-const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1.015;
-const CHROME_CORNER_WIDTH_SCALE = 0.99; // gently shrink chrome plates along the long rails
-const CHROME_CORNER_HEIGHT_SCALE = 0.99; // gently shrink chrome plates along the short rails
-const CHROME_SIDE_POCKET_RADIUS_SCALE = 1;
-const CHROME_SIDE_NOTCH_THROAT_SCALE = 0.82;
+const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.034;
+const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 0.034;
+const CHROME_CORNER_FIELD_FILLET_SCALE = 0;
+const CHROME_CORNER_FIELD_EXTENSION_SCALE = 0;
+const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1;
+const CHROME_CORNER_DIMENSION_SCALE = 1;
+const CHROME_CORNER_WIDTH_SCALE = 0.982;
+const CHROME_CORNER_HEIGHT_SCALE = 0.962;
+const CHROME_CORNER_CENTER_OUTSET_SCALE = -0.008;
+const CHROME_CORNER_SHORT_RAIL_SHIFT_SCALE = 0;
+const CHROME_CORNER_SHORT_RAIL_CENTER_PULL_SCALE = 0;
+const CHROME_CORNER_EDGE_TRIM_SCALE = 0;
+const CHROME_SIDE_POCKET_RADIUS_SCALE =
+  CORNER_POCKET_INWARD_SCALE * CHROME_CORNER_POCKET_RADIUS_SCALE * 1.006;
+const WOOD_RAIL_CORNER_RADIUS_SCALE = 1;
+const CHROME_SIDE_NOTCH_THROAT_SCALE = 0;
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85;
+const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1;
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1;
-const WOOD_CORNER_CUT_SCALE = 0.993; // tighten wooden rail corner cutouts to better match the chrome plates
-const WOOD_SIDE_CUT_SCALE = 0.995; // gently shrink side pocket cutouts on the wooden rails
-const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1;
-const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 1;
-const POCKET_JAW_CORNER_INNER_SCALE = 1.11;
-const POCKET_JAW_SIDE_INNER_SCALE = 0.962;
-const POCKET_JAW_CORNER_OUTER_SCALE = 1.723;
-const POCKET_JAW_SIDE_OUTER_SCALE = 1.78;
-const POCKET_JAW_DEPTH_SCALE = 0.63;
+const CHROME_SIDE_FIELD_PULL_SCALE = 0;
+const CHROME_PLATE_THICKNESS_SCALE = 0.42;
+const CHROME_PLATE_RENDER_ORDER = 3.5;
+const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.5;
+const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.48;
+const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0;
+const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.28;
+const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
+const CHROME_OUTER_FLUSH_TRIM_SCALE = 0;
+const CHROME_CORNER_POCKET_CUT_SCALE = 0.992;
+const CHROME_SIDE_POCKET_CUT_SCALE = 1.04;
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0;
+const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9;
+const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.988;
+const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
+  (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE;
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.012;
+const WOOD_CORNER_CUT_SCALE = WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE;
+const WOOD_SIDE_CUT_SCALE =
+  WOOD_RAIL_POCKET_RELIEF_SCALE * WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE;
+const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.004;
+const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = POCKET_JAW_CORNER_OUTER_LIMIT_SCALE;
+const POCKET_JAW_CORNER_INNER_SCALE = 1.472;
+const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE * 0.988;
+const POCKET_JAW_CORNER_OUTER_SCALE = 1.76;
+const POCKET_JAW_SIDE_OUTER_SCALE = POCKET_JAW_CORNER_OUTER_SCALE * 0.986;
+const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.01;
+const SIDE_POCKET_JAW_OUTER_EXPANSION = 0;
+const POCKET_JAW_DEPTH_SCALE = 0.52;
+const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.085;
 const POCKET_JAW_EDGE_FLUSH_START = 0.14;
 const POCKET_JAW_EDGE_FLUSH_END = 1;
 const POCKET_JAW_EDGE_TAPER_SCALE = 0.24;
@@ -467,12 +500,12 @@ const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
 // shrink the inside rails so their exposed width is roughly 30% of the cushion depth
 const WIDTH_REF = 3569;
 const HEIGHT_REF = 1778;
-const BALL_D_REF = 52.5;
+const BALL_D_REF = 57.15;
 const BAULK_FROM_BAULK_REF = 737;
 const D_RADIUS_REF = 292;
 const BLACK_FROM_TOP_REF = 324;
-const CORNER_MOUTH_REF = 89;
-const SIDE_MOUTH_REF = 109;
+const CORNER_MOUTH_REF = 114.3;
+const SIDE_MOUTH_REF = 127;
 const SIDE_RAIL_INNER_REDUCTION = 0.8;
 const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
 const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
@@ -494,7 +527,8 @@ console.assert(
   'Snooker table inner ratio must match 3569:1778 after scaling.'
 );
 const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS;
+const BALL_SIZE_SCALE = 1.02; // mirror Pool Royale silhouette
+const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
 const CHALK_TOP_COLOR = 0x1f6d86;
@@ -511,13 +545,24 @@ const CHALK_RING_OPACITY = 0.18;
 const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
-const POCKET_CORNER_MOUTH = CORNER_MOUTH_REF * MM_TO_UNITS;
-const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS;
+const POCKET_CORNER_MOUTH_SCALE = CORNER_POCKET_SCALE_BOOST;
+const SIDE_POCKET_MOUTH_REDUCTION_SCALE = 1.006;
+const POCKET_SIDE_MOUTH_SCALE =
+  (CORNER_MOUTH_REF / SIDE_MOUTH_REF) *
+  POCKET_CORNER_MOUTH_SCALE *
+  SIDE_POCKET_MOUTH_REDUCTION_SCALE;
+const POCKET_CORNER_MOUTH =
+  CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
+const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
 const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
+const POCKET_INTERIOR_TOP_SCALE = 0.92;
 const POCKET_R = POCKET_VIS_R * 0.985;
 const CORNER_POCKET_CENTER_INSET =
-  POCKET_VIS_R * 0.64 * POCKET_VISUAL_EXPANSION; // pull chrome plates, jaws, and rims further onto the cloth
+  POCKET_VIS_R * 0.3 * POCKET_VISUAL_EXPANSION;
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
+const CORNER_CHROME_NOTCH_RADIUS =
+  POCKET_VIS_R * POCKET_VISUAL_EXPANSION * CORNER_POCKET_INWARD_SCALE;
+const SIDE_CHROME_NOTCH_RADIUS = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION;
 const POCKET_MOUTH_TOLERANCE = 0.5 * MM_TO_UNITS;
 console.assert(
   Math.abs(POCKET_CORNER_MOUTH - POCKET_VIS_R * 2) <= POCKET_MOUTH_TOLERANCE,
@@ -541,14 +586,14 @@ const ACTION_CAMERA_START_BLEND = 1;
 const CLOTH_DROP = BALL_R * 0.18; // lower the cloth surface slightly for added depth
 const CLOTH_TOP_LOCAL = FRAME_TOP_Y + BALL_R * 0.09523809523809523;
 const MICRO_EPS = BALL_R * 0.022857142857142857;
-const POCKET_CUT_EXPANSION = 1.12; // widen cloth openings further to trim stray cloth around the pockets
+const POCKET_CUT_EXPANSION = POCKET_INTERIOR_TOP_SCALE; // align cloth aperture with Pool Royale throat
 const CLOTH_REFLECTION_LIMITS = Object.freeze({
   clearcoatMax: 0.028,
   clearcoatRoughnessMin: 0.48,
   envMapIntensityMax: 0.22
 });
 const POCKET_HOLE_R =
-  POCKET_VIS_R * 1.3 * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius for pocket openings
+  POCKET_VIS_R * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION;
 const BALL_CENTER_Y =
   CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP; // rest balls directly on the lowered cloth plane
 const BALL_SEGMENTS = Object.freeze({ width: 64, height: 48 });
@@ -570,15 +615,15 @@ const MIN_FRAME_SCALE = 1e-6; // prevent zero-length frames from collapsing phys
 const MAX_PHYSICS_SUBSTEPS = 5; // keep catch-up updates smooth without exploding work per frame
 const CAPTURE_R = POCKET_R; // pocket capture radius
 const CLOTH_THICKNESS = TABLE.THICK * 0.12; // render a thinner cloth so the playing surface feels lighter
-const CLOTH_UNDERLAY_THICKNESS = TABLE.THICK * 0.18; // hidden plywood deck to catch shadows before they reach the carpet
+const CLOTH_UNDERLAY_THICKNESS = TABLE.THICK * 0.24; // match Pool Royale plywood depth
 const CLOTH_UNDERLAY_GAP = TABLE.THICK * 0.02; // leave a thin air gap between the cloth and plywood
 const CLOTH_UNDERLAY_EDGE_INSET = 0; // match the playable field footprint while remaining hidden via colorWrite=false
-const CLOTH_UNDERLAY_HOLE_SCALE = 1.06; // open pocket holes wider on the underlay to avoid clipping pocket interiors
+const CLOTH_UNDERLAY_HOLE_SCALE = 1; // align underlay apertures with the cloth openings
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
-const CUSHION_EXTRA_LIFT = 0; // keep cushion bases resting directly on the cloth plane
+const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.032; // sink the cushion base to match Pool Royale fascia
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
-const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.18; // soften the exterior rail corners with a shallow curve
+const RAIL_OUTER_EDGE_RADIUS_RATIO = 0; // keep exterior rail corners crisp like Pool Royale
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
 const POCKET_DROP_ANIMATION_MS = 420;
@@ -587,7 +632,7 @@ const POCKET_DROP_MAX_MS = Math.round(POCKET_DROP_ANIMATION_MS * 1.285);
 const POCKET_DROP_SPEED_REFERENCE = 1.4;
 const POCKET_DROP_DEPTH = TABLE.THICK * 0.9;
 const POCKET_DROP_SCALE = 0.55;
-const POCKET_CLOTH_TOP_RADIUS = POCKET_VIS_R * 0.84 * POCKET_VISUAL_EXPANSION;
+const POCKET_CLOTH_TOP_RADIUS = POCKET_VIS_R * 0.8 * POCKET_VISUAL_EXPANSION;
 const POCKET_CLOTH_BOTTOM_RADIUS = POCKET_CLOTH_TOP_RADIUS * 0.62;
 const POCKET_DROP_TOP_SCALE = 0.82;
 const POCKET_DROP_BOTTOM_SCALE = 0.48;
@@ -2299,8 +2344,10 @@ function applySnookerScaling({
     Math.abs(ratio - TARGET_RATIO) < 1e-4,
     'applySnookerScaling: table aspect ratio must remain 3569:1778.'
   );
-  const expectedCornerMouth = CORNER_MOUTH_REF * mmToUnits;
-  const expectedSideMouth = SIDE_MOUTH_REF * mmToUnits;
+  const expectedCornerMouth =
+    CORNER_MOUTH_REF * mmToUnits * POCKET_CORNER_MOUTH_SCALE;
+  const expectedSideMouth =
+    SIDE_MOUTH_REF * mmToUnits * POCKET_SIDE_MOUTH_SCALE;
   const actualCornerMouth = POCKET_VIS_R * 2;
   const actualSideMouth = SIDE_POCKET_RADIUS * 2;
   console.assert(


### PR DESCRIPTION
## Summary
- align the snooker table's chrome, wood, and pocket jaw constants with the Pool Royale configuration so the visuals match
- scale snooker ball and pocket references to reuse Pool Royale component sizing while retaining the 3569:1778 playfield ratio
- update runtime scaling checks to account for the new mouth multipliers and keep the geometry assertions consistent

## Testing
- `npx eslint webapp/src/pages/Games/Snooker.jsx`


------
https://chatgpt.com/codex/tasks/task_b_6909cb24b4f0832591bec4d5ebc025db