### PR TITLE
Enhance Pool Royale visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -584,7 +584,7 @@ console.assert(
   'Pool table inner ratio must match 2:1 after scaling.'
 );
 const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 0.8976; // 10% size boost over the previous scale keeps the visuals aligned with the larger balls
+const BALL_SIZE_SCALE = 0.94248; // 5% larger than the last Pool Royale build (15.8% over the original baseline)
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -1363,25 +1363,25 @@ const applySnookerStyleWoodPreset = (materials, finishId) => {
 const createPocketMaterials = () => ({
   pocketJaw: new THREE.MeshPhysicalMaterial({
     color: 0x6d7177,
-    metalness: 0.05,
-    roughness: 0.68,
-    clearcoat: 0.18,
-    clearcoatRoughness: 0.48,
-    sheen: 0.52,
-    sheenColor: new THREE.Color(0x8f949b),
-    sheenRoughness: 0.58,
-    envMapIntensity: 0.28
+    metalness: 0.18,
+    roughness: 0.42,
+    clearcoat: 0.34,
+    clearcoatRoughness: 0.26,
+    sheen: 0.48,
+    sheenColor: new THREE.Color(0xa4aab4),
+    sheenRoughness: 0.44,
+    envMapIntensity: 0.46
   }),
   pocketRim: new THREE.MeshPhysicalMaterial({
     color: 0x383b40,
-    metalness: 0.06,
-    roughness: 0.76,
-    clearcoat: 0.14,
-    clearcoatRoughness: 0.54,
-    sheen: 0.44,
-    sheenColor: new THREE.Color(0x6f747b),
-    sheenRoughness: 0.62,
-    envMapIntensity: 0.24
+    metalness: 0.32,
+    roughness: 0.38,
+    clearcoat: 0.32,
+    clearcoatRoughness: 0.22,
+    sheen: 0.4,
+    sheenColor: new THREE.Color(0x88909a),
+    sheenRoughness: 0.5,
+    envMapIntensity: 0.52
   })
 });
 
@@ -6011,7 +6011,7 @@ function Table3D(
     let localClampOuter = clampOuter;
     let localJawAngle = jawAngle;
     let depthMultiplier = 1;
-    let steps = wide ? 88 : 68;
+    let steps = wide ? 132 : 104;
 
     if (isMiddle) {
       localJawAngle *= SIDE_POCKET_JAW_LATERAL_EXPANSION;
@@ -6084,7 +6084,7 @@ function Table3D(
     const jawGeom = new THREE.ExtrudeGeometry(jawShape, {
       depth: jawDepth,
       bevelEnabled: false,
-      curveSegments: Math.max(96, Math.ceil(localJawAngle / (Math.PI / 64))),
+      curveSegments: Math.max(144, Math.ceil(localJawAngle / (Math.PI / 96))),
       steps: 1
     });
     jawGeom.rotateX(-Math.PI / 2);
@@ -6106,7 +6106,7 @@ function Table3D(
       const rimGeom = new THREE.ExtrudeGeometry(rimShape, {
         depth: rimDepth,
         bevelEnabled: false,
-        curveSegments: Math.max(72, Math.ceil(localJawAngle / (Math.PI / 80))),
+        curveSegments: Math.max(128, Math.ceil(localJawAngle / (Math.PI / 112))),
         steps: 1
       });
       rimGeom.rotateX(-Math.PI / 2);

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { applySRGBColorSpace } from './colorSpace.js';
 
-const BALL_TEXTURE_SIZE = 2048; // double resolution for sharper billiard ball textures
+const BALL_TEXTURE_SIZE = 4096; // ultra high resolution for sharper billiard ball textures
 const BALL_TEXTURE_CACHE = new Map();
 const BALL_MATERIAL_CACHE = new Map();
 
@@ -29,7 +29,7 @@ function darken(hex, amount) {
   return mixHex(hex, 0x000000, amount);
 }
 
-function addNoise(ctx, size, strength = 0.03, samples = 2800) {
+function addNoise(ctx, size, strength = 0.02, samples = 3600) {
   ctx.save();
   ctx.globalAlpha = strength;
   for (let i = 0; i < samples; i++) {
@@ -175,9 +175,9 @@ function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
 
   ctx.save();
   const diagonalShade = ctx.createLinearGradient(0, 0, size, size);
-  diagonalShade.addColorStop(0, 'rgba(255,255,255,0.78)');
-  diagonalShade.addColorStop(0.55, 'rgba(255,255,255,0.38)');
-  diagonalShade.addColorStop(1, 'rgba(0,0,0,0.18)');
+  diagonalShade.addColorStop(0, 'rgba(255,255,255,0.86)');
+  diagonalShade.addColorStop(0.55, 'rgba(255,255,255,0.42)');
+  diagonalShade.addColorStop(1, 'rgba(0,0,0,0.16)');
   ctx.globalCompositeOperation = 'multiply';
   ctx.fillStyle = diagonalShade;
   ctx.fillRect(0, 0, size, size);
@@ -186,15 +186,16 @@ function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
   ctx.save();
   ctx.globalCompositeOperation = 'screen';
   const highlight = ctx.createRadialGradient(
-    size * 0.32,
-    size * 0.28,
-    size * 0.04,
-    size * 0.32,
-    size * 0.28,
-    size * 0.28
+    size * 0.3,
+    size * 0.26,
+    size * 0.035,
+    size * 0.3,
+    size * 0.26,
+    size * 0.32
   );
-  highlight.addColorStop(0, 'rgba(255,255,255,0.98)');
-  highlight.addColorStop(1, 'rgba(255,255,255,0.05)');
+  highlight.addColorStop(0, 'rgba(255,255,255,1)');
+  highlight.addColorStop(0.45, 'rgba(255,255,255,0.26)');
+  highlight.addColorStop(1, 'rgba(255,255,255,0)');
   ctx.fillStyle = highlight;
   ctx.fillRect(0, 0, size, size);
   ctx.restore();
@@ -215,7 +216,7 @@ function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
   ctx.fillRect(0, 0, size, size);
   ctx.restore();
 
-  addNoise(ctx, size, 0.03, 4200);
+    addNoise(ctx, size, 0.02, 3600);
 
   if (Number.isFinite(number)) {
     drawNumberBadge(ctx, size, number);
@@ -244,7 +245,7 @@ function createBallTexture({ baseColor, pattern, number, variantKey }) {
   }
 
   const texture = new THREE.CanvasTexture(canvas);
-  texture.anisotropy = 16;
+  texture.anisotropy = 32;
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
@@ -280,19 +281,25 @@ export function getBallMaterial({
           color: 0xffffff,
           map,
           clearcoat: 1,
-          clearcoatRoughness: 0.05,
-          metalness: 0.05,
-          roughness: 0.13,
-          reflectivity: 0.9
+          clearcoatRoughness: 0.02,
+          metalness: 0.16,
+          roughness: 0.07,
+          reflectivity: 1,
+          sheen: 0.12,
+          sheenColor: new THREE.Color(0xf6f7ff),
+          envMapIntensity: 1.1
         })
       : new THREE.MeshPhysicalMaterial({
           color: 0xffffff,
           map,
           clearcoat: 1,
-          clearcoatRoughness: 0.04,
-          metalness: 0.1,
-          roughness: 0.12,
-          reflectivity: 1
+          clearcoatRoughness: 0.015,
+          metalness: 0.24,
+          roughness: 0.06,
+          reflectivity: 1,
+          sheen: 0.18,
+          sheenColor: new THREE.Color(0xf8f9ff),
+          envMapIntensity: 1.18
         });
   material.needsUpdate = true;
   BALL_MATERIAL_CACHE.set(cacheKey, material);


### PR DESCRIPTION
## Summary
- enlarge Pool Royale balls by 5% and retune pocket geometry tessellation for sharper pocket edges
- upgrade billiard ball textures and shading for higher fidelity, glossier renders
- refresh pocket material settings to deliver a sharper, more reflective finish

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_6909e18f78f4832585d18e4720ccd8c7