### PR TITLE
Adjust Pool Royale match TV resolution scale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8287,7 +8287,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       const createMatchTvEntry = () => {
         const baseWidth = 1024;
         const baseHeight = 512;
-        const resolutionScale = 1;
+        const resolutionScale = 0.96;
         const canvas = document.createElement('canvas');
         canvas.width = Math.round(baseWidth * resolutionScale);
         canvas.height = Math.round(baseHeight * resolutionScale);


### PR DESCRIPTION
## Summary
- reduce the Pool Royale match TV canvas resolution scale from 1 to 0.96 to slightly decrease rendering size

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_6909fb7791bc83258d6b93165f3c7a1b