### PR TITLE
Tweak Pool Royale render resolution

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8287,7 +8287,7 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
       const createMatchTvEntry = () => {
         const baseWidth = 1024;
         const baseHeight = 512;
-        const resolutionScale = 0.96;
+        const resolutionScale = 0.95;
         const canvas = document.createElement('canvas');
         canvas.width = Math.round(baseWidth * resolutionScale);
         canvas.height = Math.round(baseHeight * resolutionScale);


### PR DESCRIPTION
## Summary
- reduce the Pool Royale match TV canvas resolution scale slightly so ball movement renders more smoothly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_6909fede966c8325bac66284350c7997