### PR TITLE
Update Pool Royale cloth palette and frame rate presets

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1762,38 +1762,24 @@ const CHROME_COLOR_OPTIONS = Object.freeze([
 
 const DEFAULT_CLOTH_COLOR_ID = 'freshGreen';
 const CLOTH_COLOR_OPTIONS = Object.freeze([
-  { id: 'freshGreen', label: 'Fresh Green', color: 0x3fba73 },
-  { id: 'brightMint', label: 'Bright Mint', color: 0x45b974 },
-  {
-    id: 'emeraldClassic',
-    label: 'Green Cloth',
-    color: 0x19a34a,
-    detail: {
-      bumpMultiplier: 1.22,
-      roughness: 0.78,
-      sheenRoughness: 0.52,
-      clearcoat: 0.05,
-      clearcoatRoughness: 0.32,
-      emissiveIntensity: 0.52
-    }
-  }
+  { id: 'freshGreen', label: 'Fresh Green', color: 0x3fba73 }
 ]);
 
 const FRAME_RATE_STORAGE_KEY = 'snookerFrameRate';
 const FRAME_RATE_OPTIONS = Object.freeze([
-  {
-    id: 'hd',
-    label: 'HD Quality',
-    fps: 60,
-    resolution: '1280×720',
-    description: 'Energy-friendly profile tuned for HD displays.'
-  },
   {
     id: 'fullHd',
     label: 'Full HD',
     fps: 90,
     resolution: '1920×1080',
     description: 'Enhanced clarity and effects for Full HD setups.'
+  },
+  {
+    id: 'performance120',
+    label: '120 FPS Performance',
+    fps: 120,
+    resolution: '2560×1440',
+    description: 'High refresh upgrade tuned for buttery-smooth play.'
   },
   {
     id: 'ultraHd',
@@ -14308,38 +14294,40 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
                   })}
                 </div>
               </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Cloth Color
-                </h3>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {CLOTH_COLOR_OPTIONS.map((option) => {
-                    const active = option.id === clothColorId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setClothColorId(option.id)}
-                        aria-pressed={active}
-                        className={`flex-1 min-w-[8.5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="flex items-center justify-center gap-2">
-                          <span
-                            className="h-3.5 w-3.5 rounded-full border border-white/40"
-                            style={{ backgroundColor: toHexColor(option.color) }}
-                            aria-hidden="true"
-                          />
-                          {option.label}
-                        </span>
-                      </button>
-                    );
-                  })}
+              {CLOTH_COLOR_OPTIONS.length > 1 ? (
+                <div>
+                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                    Cloth Color
+                  </h3>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {CLOTH_COLOR_OPTIONS.map((option) => {
+                      const active = option.id === clothColorId;
+                      return (
+                        <button
+                          key={option.id}
+                          type="button"
+                          onClick={() => setClothColorId(option.id)}
+                          aria-pressed={active}
+                          className={`flex-1 min-w-[8.5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                            active
+                              ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                              : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                          }`}
+                        >
+                          <span className="flex items-center justify-center gap-2">
+                            <span
+                              className="h-3.5 w-3.5 rounded-full border border-white/40"
+                              style={{ backgroundColor: toHexColor(option.color) }}
+                              aria-hidden="true"
+                            />
+                            {option.label}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
                 </div>
-              </div>
+              ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Graphics


### PR DESCRIPTION
## Summary
- remove the alternate cloth finishes so Fresh Green is the only Pool Royale option
- hide the cloth picker when only one finish is available in the lobby
- replace the 60 FPS HD profile with a new 120 FPS performance preset

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_690c29c203048325a6ab6a8cc5d9fee4