### PR TITLE
Enhance Table Tennis AI and HUD

### DIFF
--- a/webapp/src/pages/Games/TableTennis.jsx
+++ b/webapp/src/pages/Games/TableTennis.jsx
@@ -13,7 +13,11 @@ export default function TableTennis() {
     avatar: params.get('avatar') || '/assets/icons/profile.svg'
   };
   const flag = FLAG_EMOJIS[Math.floor(Math.random() * FLAG_EMOJIS.length)];
-  const ai = { name: avatarToName(flag) || 'AI', avatar: flag };
+  const ai = {
+    name: avatarToName(flag) || 'AI',
+    avatar: flag,
+    difficulty: params.get('difficulty') || 'pro',
+  };
   return <TableTennis3D player={player} ai={ai} />;
 }
 


### PR DESCRIPTION
## Summary
- add configurable AI difficulty with adaptive tuning during rallies
- improve serve reset flow, scoring messages, and in-game overlays for mobile users
- expose difficulty query parameter in the Table Tennis lobby and align renderer tone mapping

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_690c2a6bc8a08325a9798827ec4da9b7