### PR TITLE
Improve mobile billiards viewport resilience and side pocket geometry

### DIFF
--- a/webapp/src/hooks/useViewportHeight.js
+++ b/webapp/src/hooks/useViewportHeight.js
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+
+function readViewportHeight() {
+  if (typeof window === 'undefined') {
+    return 0;
+  }
+  const vv = window.visualViewport;
+  if (vv && typeof vv.height === 'number') {
+    return vv.height;
+  }
+  return window.innerHeight || 0;
+}
+
+export function useViewportHeight() {
+  const [height, setHeight] = useState(() => readViewportHeight());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+    let rafId = 0;
+    const applyHeight = () => {
+      rafId = 0;
+      const next = readViewportHeight();
+      setHeight((prev) => (Math.abs(prev - next) > 0.5 ? next : prev));
+    };
+    const queueHeight = () => {
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+      }
+      rafId = requestAnimationFrame(applyHeight);
+    };
+
+    const viewport = window.visualViewport;
+
+    queueHeight();
+    window.addEventListener('resize', queueHeight);
+    window.addEventListener('orientationchange', queueHeight);
+    viewport?.addEventListener('resize', queueHeight);
+    viewport?.addEventListener('scroll', queueHeight);
+
+    return () => {
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+      }
+      window.removeEventListener('resize', queueHeight);
+      window.removeEventListener('orientationchange', queueHeight);
+      viewport?.removeEventListener('resize', queueHeight);
+      viewport?.removeEventListener('scroll', queueHeight);
+    };
+  }, []);
+
+  return height;
+}
+
+export default useViewportHeight;


### PR DESCRIPTION
## Summary
- ensure the Pool Royale renderer updates for orientation changes by tracking the dynamic viewport height, recalculating pixel ratio on resize, and resetting after WebGL context loss
- tighten Pool Royale side pocket jaws and chrome cutouts so the middle pocket fascia sits closer to the table centre
- bring the Snooker build in line with Pool Royale by mirroring the side pocket geometry, chrome plate offsets, and the new viewport handling utilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_690c5624943c83258803a05aab673308