### PR TITLE
Adjust snooker chrome cut depth

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -201,7 +201,7 @@ function createDefaultPocketJawMaterial() {
 
 const POCKET_VISUAL_EXPANSION = 1.012;
 const CHROME_CORNER_POCKET_RADIUS_SCALE = 1.01;
-const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.028;
+const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.052; // pull the rounded chrome cut deeper toward the table centre
 const CHROME_CORNER_EXPANSION_SCALE = 1.002;
 const CHROME_CORNER_SIDE_EXPANSION_SCALE = 1.002;
 const CHROME_CORNER_FIELD_TRIM_SCALE = -0.03;


### PR DESCRIPTION
## Summary
- deepen the rounded chrome cut on the 3D snooker table so the fascia sits further toward centre

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_690d06a8aec88325a83a6af9fb4c1b8a