### PR TITLE
Add Tirana 2040 game lobby and integration

### DIFF
--- a/webapp/public/tirana-2040.html
+++ b/webapp/public/tirana-2040.html
@@ -1,0 +1,631 @@
+<!doctype html>
+<html lang="sq">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, user-scalable=no" />
+<title>Tirana 2040 • Last Man Standing</title>
+<style>
+  html,body{margin:0;height:100%;background:#f5e7cf;overflow:hidden;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+  #wrap{position:fixed;inset:0}
+  canvas{display:block;width:100%;height:100%;touch-action:none;user-select:none}
+  .hud{position:fixed;inset:0;pointer-events:none}
+  .row{position:absolute;left:10px;right:10px;display:flex;gap:8px;align-items:center}
+  .top{top:8px;justify-content:space-between}
+  .bottom{bottom:10px;justify-content:space-between}
+  .chip{background:rgba(0,0,0,.35);color:#fff;border-radius:999px;padding:6px 10px;font-size:12px;backdrop-filter:blur(4px);pointer-events:auto}
+  .btn{background:rgba(0,0,0,.35);color:#fff;border:0;border-radius:14px;padding:10px 14px;font-size:14px;cursor:pointer;pointer-events:auto}
+  .btn:active{transform:translateY(1px)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
+
+  #armory{z-index:10}
+  .joy{position:absolute;width:300px;height:300px;border-radius:50%;background:rgba(0,0,0,.08);border:1px solid rgba(0,0,0,.25);opacity:.96;pointer-events:auto;touch-action:none;display:block;z-index:20}
+  .knob{position:absolute;left:50%;top:50%;width:160px;height:160px;transform:translate(-50%,-50%);border-radius:50%;background:rgba(0,0,0,.25);border:1px solid rgba(0,0,0,.35)}
+  #joyMove{left:18px;bottom:220px}
+  #shootPad{right:18px;bottom:220px}
+  #aimPad{right:18px;bottom:220px;display:none}
+  #shootPad .knob{background:radial-gradient(circle at 50% 50%, rgba(255,70,70,1) 0 30%, rgba(0,0,0,.28) 31%), rgba(0,0,0,.25);}
+  #shootPad .knob::after{content:'SHOOT';position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);color:#fff;font-weight:900;font-size:18px;letter-spacing:.6px;text-shadow:0 1px 2px rgba(0,0,0,.65);}
+  #reloadMini{position:absolute;left:50%;top:-190px;transform:translateX(-50%);width:160px;height:160px;display:flex;align-items:center;justify-content:center;border-radius:50%;border:1px solid rgba(0,0,0,.35);background:radial-gradient(circle at 50% 50%, rgba(255,70,70,1) 0 30%, rgba(0,0,0,.28) 31%), rgba(0,0,0,.25);color:#fff;font-size:18px;font-weight:900;letter-spacing:.6px;pointer-events:auto;box-shadow:0 6px 16px rgba(0,0,0,.35)}
+  #crosshair{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:30px;height:30px;pointer-events:none;z-index:50;display:block}
+  #crosshair:before,#crosshair:after{content:"";position:absolute;left:50%;top:50%;background:var(--aimColor,#ff3c3c);box-shadow:0 0 0 2px rgba(255,255,255,0.9) inset, 0 0 6px rgba(0,0,0,.35)}
+  #crosshair:before{width:24px;height:3px;transform:translate(-50%,-50%);opacity:.98}
+  #crosshair:after{width:3px;height:24px;transform:translate(-50%,-50%);opacity:.98}
+  #ammo{position:absolute;right:10px;top:40px;color:#fff;font-weight:600;background:rgba(0,0,0,.35);padding:8px 12px;border-radius:10px;pointer-events:auto}
+  #healthbar{position:absolute;left:10px;top:46px;width:260px;height:16px;background:rgba(0,0,0,.2);border-radius:999px;overflow:hidden}
+  #healthfill{width:100%;height:100%;background:linear-gradient(90deg,#29ff9a,#00c876)}
+  #armory{position:absolute;left:10px;right:10px;bottom:86px;display:flex;gap:8px;overflow:auto;padding:8px;border-radius:14px;background:rgba(0,0,0,.25);backdrop-filter:blur(6px);pointer-events:auto}
+  .armBtn{position:relative;flex:0 0 auto;min-width:138px;max-width:168px;padding:8px;border-radius:12px;border:1px solid rgba(255,255,255,.16);background:rgba(0,0,0,.35);color:#e6eefc;font-weight:700;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:6px}
+  .armBtn img{width:124px;height:76px;object-fit:contain;display:block;filter:drop-shadow(0 1px 1px rgba(0,0,0,.3))}
+  .armBtn span{font-size:12px;opacity:.95}
+  .armBtn.active{outline:2px solid #ffd966;background:rgba(17,23,42,.55)}
+  .modeToggle{position:absolute;right:6px;top:6px;padding:3px 6px;border-radius:10px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.45);color:#fff;font-size:10px;cursor:pointer}
+  #mini{position:absolute;left:10px;bottom:56px;color:#0b1324;background:rgba(255,255,255,.6);padding:4px 8px;border-radius:8px;font-size:11px;pointer-events:auto}
+  #modeBox{position:absolute;right:10px;top:46px;display:flex;gap:6px;pointer-events:auto}
+  .modeBtn{padding:6px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.35);color:#fff;font-size:12px;cursor:pointer}
+  .modeBtn.active{background:#2a7fff}
+  #climbBtn{position:absolute;left:50%;bottom:156px;transform:translateX(-50%);padding:8px 12px;border-radius:12px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.7);color:#fff;font-size:14px;pointer-events:auto;display:none}
+  #zoomBox{position:absolute;right:4px;bottom:540px;display:none;pointer-events:auto;z-index:25}
+  #zoomSlider{appearance:none;width:360px;height:64px;transform:rotate(-90deg);background:rgba(0,0,0,.4);border-radius:999px;outline:none;border:1px solid rgba(255,255,255,.2)}
+  #zoomSlider::-webkit-slider-thumb{appearance:none;width:50px;height:50px;border-radius:50%;background:#ffd966;border:1px solid rgba(0,0,0,.4)}
+  #zoomSlider::-moz-range-thumb{width:50px;height:50px;border-radius:50%;background:#ffd966;border:1px solid rgba(0,0,0,.4)}
+  #radarBox{position:absolute;left:18px;bottom:540px;width:164px;height:164px;border-radius:16px;background:rgba(0,0,0,.28);border:1px solid rgba(0,0,0,.35);overflow:hidden;pointer-events:auto}
+  #radar{width:100%;height:100%;display:block}
+  #mapOverlay{position:fixed;inset:0;background:rgba(0,0,0,.75);display:none;align-items:center;justify-content:center;z-index:200;pointer-events:auto}
+  #mapCanvas{width:min(96vw,1200px);height:min(96vh,800px);background:#0b0f1a;border:1px solid #334;box-shadow:0 20px 60px rgba(0,0,0,.4);border-radius:12px}
+  #mapClose{position:absolute;top:20px;right:20px;padding:10px 14px;border-radius:10px;border:1px solid rgba(255,255,255,.25);background:#1f2937;color:#fff;font-weight:700;cursor:pointer}
+  #legend{position:absolute;left:20px;top:20px;color:#fff;background:rgba(0,0,0,.45);padding:10px 12px;border-radius:10px;font-size:12px}
+  #result{display:none !important}
+</style>
+</head>
+<body>
+<div id="wrap"></div>
+
+<div class="hud">
+  <div class="row top">
+    <div style="display:flex;gap:6px;align-items:center">
+      <div class="chip" id="status">Tirana 2040 • Last Man Standing</div>
+      <div id="br" class="chip">Entrants: 10 • AI</div>
+    </div>
+    <div style="display:flex;gap:6px;align-items:center">
+      <div id="modeBox">
+        <button id="modeA" class="modeBtn active">A: Drag Aim</button>
+        <button id="modeB" class="modeBtn">B: Dual Sticks</button>
+      </div>
+      <button id="muteBtn" class="btn">🔊</button>
+    </div>
+  </div>
+
+  <div id="healthbar"><div id="healthfill"></div></div>
+  <div id="ammo">—</div>
+  <div id="crosshair"></div>
+
+  <div id="joyMove" class="joy"><div class="knob"></div></div>
+  <div id="shootPad" class="joy"><div class="knob"></div><button id="reloadMini" class="btn">RELOAD</button></div>
+  <div id="aimPad" class="joy"><div class="knob"></div></div>
+
+  <div id="zoomBox"><input id="zoomSlider" type="range" min="1" max="3" step="0.01" value="1" /></div>
+
+  <div id="armory"></div>
+
+  <div id="radarBox"><canvas id="radar"></canvas></div>
+  <div id="mapOverlay">
+    <canvas id="mapCanvas"></canvas>
+    <button id="mapClose">Close Map</button>
+    <div id="legend">Tap map to set a waypoint • Icons: 🏥 Hospital · 🚓 Police · 🧯 Fire · 🛍 Mall · 🛫 Airport · 🚉 Station</div>
+  </div>
+
+  <button id="climbBtn">⬆ Use/Climb Ladder</button>
+
+  <div id="mini">fps: —</div>
+  <div id="result"></div>
+
+  <div class="row bottom">
+    <div class="chip">Move = Left stick/WASD · Aim = drag screen (A) or right stick (B) · Tap right=Shoot · Zoom slider for AK47</div>
+    <button id="resetBtn" class="btn">Reset</button>
+  </div>
+</div>
+
+<script type="module">
+import * as THREE from 'https://esm.sh/three@0.160.0';
+import * as CANNON from 'https://esm.sh/cannon-es@0.20.0';
+import { GLTFLoader } from 'https://esm.sh/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'https://esm.sh/three@0.160.0/examples/jsm/loaders/DRACOLoader.js';
+import * as SkeletonUtils from 'https://esm.sh/three@0.160.0/examples/jsm/utils/SkeletonUtils.js';
+
+document.title = 'Tirana 2040 • Last Man Standing';
+
+(async function main(){
+  const $ = (id)=>document.getElementById(id);
+  const wrap = $('wrap');
+  const isTouch = ('ontouchstart' in window) || (navigator.maxTouchPoints>0);
+  const isMobile = isTouch || /Android|webOS|iPhone|iPad|iPod|Opera Mini|IEMobile/i.test(navigator.userAgent);
+
+  const params = new URLSearchParams(window.location.search);
+  const entrants = parseInt(params.get('players') || '10', 10);
+  const stakeToken = params.get('token') || 'TPC';
+  const stakeAmount = params.get('amount');
+  if(!Number.isNaN(entrants)){
+    $('br').textContent = `Entrants: ${entrants} • AI`;
+  }
+  if(stakeAmount){
+    $('status').textContent = `Tirana 2040 • ${stakeAmount} ${stakeToken}`;
+  } else {
+    $('status').textContent = 'Tirana 2040 • Last Man Standing';
+  }
+
+  const renderer = new THREE.WebGLRenderer({ antialias:true, powerPreference:'high-performance', alpha:false, stencil:false, depth:true, precision:'mediump' });
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.85;
+  const allowShadows = !isMobile;
+  renderer.shadowMap.enabled = allowShadows; renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  wrap.appendChild(renderer.domElement);
+  THREE.Cache.enabled = true;
+
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color('#f5e7cf');
+  scene.fog = new THREE.Fog('#f5e7cf', 900, 3500);
+
+  const camera = new THREE.PerspectiveCamera(70, 9/16, 0.01, 10000);
+  camera.position.set(0,1.7,5.6); scene.add(camera);
+
+  let dprBase = Math.min(window.devicePixelRatio||1, isMobile ? 0.9 : 1.5);
+  let dprScale = isMobile ? 0.72 : 1.0;
+  function fit(){ const w=wrap.clientWidth||innerWidth, h=wrap.clientHeight||innerHeight; renderer.setPixelRatio(dprBase*dprScale); renderer.setSize(w,h,false); camera.aspect=w/h; camera.updateProjectionMatrix(); }
+  addEventListener('resize', fit); fit();
+
+  const hemi = new THREE.HemisphereLight(0xfff3d6, 0x8a7a6a, 0.55);
+  const key  = new THREE.DirectionalLight(0xffd6a0, allowShadows?1.25:1.0); key.position.set(220, 350, 180); key.castShadow=allowShadows;
+  if(allowShadows){ key.shadow.mapSize.set(isMobile?1024:2048,isMobile?1024:2048); key.shadow.camera.near=1; key.shadow.camera.far=3000; key.shadow.camera.left=-900; key.shadow.camera.right=900; key.shadow.camera.top=900; key.shadow.camera.bottom=-900; }
+  const fill = new THREE.DirectionalLight(0xffffff, 0.9); fill.position.set(-320, 140, -260);
+  const rim  = new THREE.DirectionalLight(0xffffff, 0.8); rim.position.set(120, 200, -520);
+  scene.add(hemi, key, fill, rim);
+  const muzzleLight = new THREE.PointLight(0xfff1c6, 0.0, 2.0); scene.add(muzzleLight);
+
+  const world = new CANNON.World({ gravity: new CANNON.Vec3(0,-9.81,0) });
+  world.broadphase = new CANNON.SAPBroadphase(world); world.allowSleep = true;
+  const matGround=new CANNON.Material('ground'), matPlayer=new CANNON.Material('player'), matEnemy=new CANNON.Material('enemy'), matCar=new CANNON.Material('car');
+  world.addContactMaterial(new CANNON.ContactMaterial(matGround, matPlayer, { friction:.2, restitution:0 }));
+  world.addContactMaterial(new CANNON.ContactMaterial(matGround, matCar, { friction:.9, restitution:0 }));
+
+  const groundBody = new CANNON.Body({ mass:0, material:matGround, shape:new CANNON.Plane() });
+  groundBody.quaternion.setFromEuler(-Math.PI/2,0,0); world.addBody(groundBody);
+
+  function makeAsphalt(size=1024){ const c=document.createElement('canvas'); c.width=c.height=size; const x=c.getContext('2d'); x.fillStyle='#2b313a'; x.fillRect(0,0,size,size); for(let i=0;i<3800;i++){ const a=Math.random()*0.12; x.fillStyle=`rgba(255,255,255,${a})`; x.fillRect(Math.random()*size,Math.random()*size,1,1);} const t=new THREE.CanvasTexture(c); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(16,16); t.anisotropy=2; t.colorSpace=THREE.SRGBColorSpace; return t; }
+  function makeSidewalk(size=512){ const c=document.createElement('canvas'); c.width=c.height=size; const x=c.getContext('2d'); x.fillStyle='#c9ced6'; x.fillRect(0,0,size,size); x.strokeStyle='#9aa0a8'; x.lineWidth=6; for(let s=0;s<size;s+=64){ x.beginPath(); x.moveTo(s,0); x.lineTo(s,size); x.stroke(); x.beginPath(); x.moveTo(0,s); x.lineTo(size,s); x.stroke(); } const t=new THREE.CanvasTexture(c); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(32,32); t.anisotropy=2; t.colorSpace=THREE.SRGBColorSpace; return t; }
+  const maxAniso = renderer.capabilities.getMaxAnisotropy?.() || 4;
+  function grassTex(){ const imgURL='https://threejs.org/examples/textures/terrain/grasslight-big.jpg'; const tLoader=new Image(); const p=new Promise(res=>{ tLoader.crossOrigin='anonymous'; tLoader.onload=()=>{ const c=document.createElement('canvas'); c.width=1024; c.height=1024; const g=c.getContext('2d'); g.drawImage(tLoader,0,0,1024,1024); const tex=new THREE.CanvasTexture(c); tex.wrapS=tex.wrapT=THREE.RepeatWrapping; tex.repeat.set(8,18); tex.anisotropy=Math.min(16,maxAniso); tex.colorSpace=THREE.SRGBColorSpace; res(tex); }; tLoader.src=imgURL; }); return p; }
+  function trackTex(w=1024,h=1024){ const c=document.createElement('canvas'); c.width=w; c.height=h; const g=c.getContext('2d'); g.fillStyle='#b33a2c'; g.fillRect(0,0,w,h); const dots=Math.floor(w*h*0.004); for(let i=0;i<dots;i++){ const x=Math.random()*w, y=Math.random()*h, r=Math.random()*1.6+0.2; g.fillStyle=Math.random()<0.5?'rgba(255,190,180,0.35)':'rgba(40,12,10,0.35)'; g.beginPath(); g.arc(x,y,r,0,Math.PI*2); g.fill(); } const t=new THREE.CanvasTexture(c); t.anisotropy=Math.min(16,maxAniso); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.colorSpace=THREE.SRGBColorSpace; t.repeat.set(1,1); return t; }
+
+  const asphaltTex = makeAsphalt(), sidewalkTex = makeSidewalk(), redTrackTex = trackTex();
+  const tennisGrassTex = await grassTex();
+
+  const city = new THREE.Group(); scene.add(city);
+  const BLOCKS_X=6, BLOCKS_Z=6; const CELL=120; const ROAD=22; const PLOT=CELL-ROAD*2; const startX = -(BLOCKS_X*CELL)/2 + CELL/2; const startZ = -(BLOCKS_Z*CELL)/2 + CELL/2;
+
+  const groundGeo = new THREE.PlaneGeometry((CELL)*BLOCKS_X + ROAD*2, (CELL)*BLOCKS_Z + ROAD*2);
+  const groundMat = new THREE.MeshLambertMaterial({ color: 0xf0e4cf });
+  const gnd = new THREE.Mesh(groundGeo, groundMat); gnd.rotation.x=-Math.PI/2; gnd.receiveShadow=allowShadows; city.add(gnd);
+
+  const roadMat = new THREE.MeshLambertMaterial({ map: asphaltTex });
+  for(let ix=0; ix<=BLOCKS_X; ix++){ const geo=new THREE.PlaneGeometry(ROAD,(CELL)*BLOCKS_Z + ROAD); const m=new THREE.Mesh(geo, roadMat); m.rotation.x=-Math.PI/2; m.position.set(ix*CELL-(BLOCKS_X*CELL)/2, 0.01, ROAD*0.5-(BLOCKS_Z*CELL)/2); m.receiveShadow=allowShadows; city.add(m); }
+  for(let iz=0; iz<=BLOCKS_Z; iz++){ const geo=new THREE.PlaneGeometry((CELL)*BLOCKS_X + ROAD, ROAD); const m=new THREE.Mesh(geo, roadMat); m.rotation.x=-Math.PI/2; m.position.set(ROAD*0.5-(BLOCKS_X*CELL)/2, 0.01, iz*CELL-(BLOCKS_Z*CELL)/2); m.receiveShadow=allowShadows; city.add(m); }
+
+  const sidewalkMat = new THREE.MeshLambertMaterial({ map: sidewalkTex });
+  function addSidewalk(xc,zc){ const w=CELL-ROAD, h=CELL-ROAD; const geo=new THREE.BoxGeometry(w,2,h); const m=new THREE.Mesh(geo, sidewalkMat); m.castShadow=false; m.receiveShadow=allowShadows; m.position.set(xc,1,zc); city.add(m); }
+
+  function facadeTex(hue=200){ const W=256,H=512; const c=document.createElement('canvas'); c.width=W; c.height=H; const ctx=c.getContext('2d'); ctx.fillStyle=`hsl(${hue},16%,74%)`; ctx.fillRect(0,0,W,H); for(let i=0;i<1800;i++){ const a=Math.random()*0.08; ctx.fillStyle=`rgba(0,0,0,${a})`; ctx.fillRect(Math.random()*W,Math.random()*H,1,1);} const cols=6+Math.floor(Math.random()*4), rows=14+Math.floor(Math.random()*6); const padX=12,padY=16; const cellW=(W-2*padX)/cols, cellH=(H-2*padY)/rows; for(let r=0;r<rows;r++){ for(let cix=0;cix<cols;cix++){ const x=padX+cix*cellW+6, y=padY+r*cellH+6, w=cellW-12, h=cellH-12; const g=ctx.createLinearGradient(0,y,0,y+h); g.addColorStop(0,'rgba(240,245,255,0.95)'); g.addColorStop(0.5,'rgba(150,180,220,0.92)'); g.addColorStop(1,'rgba(60,80,120,0.9)'); ctx.fillStyle=g; ctx.fillRect(x,y,w,h); ctx.strokeStyle='rgba(24,28,38,0.9)'; ctx.lineWidth=2; ctx.strokeRect(x,y,w,h); } } const tex=new THREE.CanvasTexture(c); tex.anisotropy=2; tex.colorSpace=THREE.SRGBColorSpace; return tex; }
+
+  const ladders=[];
+  function addLadder(x,z,y0,y1){ const railMat=new THREE.MeshBasicMaterial({ color:0x9aa3ad }); const stepMat=new THREE.MeshBasicMaterial({ color:0x8a929c }); const g=new THREE.Group(); const railL=new THREE.Mesh(new THREE.BoxGeometry(0.08, y1-y0, 0.08), railMat); const railR=railL.clone(); railL.position.set(-0.25, (y0+y1)/2, 0); railR.position.set(0.25, (y0+y1)/2, 0); g.add(railL,railR); for(let y=y0+0.3;y<y1;y+=0.35){ const s=new THREE.Mesh(new THREE.BoxGeometry(0.6,0.05,0.08), stepMat); s.position.set(0,y,0); g.add(s); } const arrow=new THREE.Mesh(new THREE.ConeGeometry(0.25,0.6,12), new THREE.MeshBasicMaterial({ color:0x1f6feb })); arrow.position.set(0,y1+0.6,0); g.add(arrow); g.position.set(x,0,z); city.add(g); ladders.push({x,z,y0,y1}); }
+
+  function addRoofStair(x,z,y){ const m=new THREE.Mesh(new THREE.BoxGeometry(1.2,0.5,1.2), new THREE.MeshLambertMaterial({ color:0x444b55 })); m.position.set(x,y+0.4,z); city.add(m); return m; }
+
+  function addBuilding(xc,zc,opts={}){
+    const floors=opts.floors??(6+Math.floor(Math.random()*12)); const height=floors*(3.2); const w=opts.w??(30+Math.random()*20), d=opts.d??(30+Math.random()*20);
+    const geom=new THREE.BoxGeometry(w,height,d); const hue=opts.hue??(180+Math.floor(Math.random()*60));
+    const mat=new THREE.MeshLambertMaterial({ map:facadeTex(hue) }); const roof=new THREE.MeshLambertMaterial({ color:0x55585c});
+    const mesh=new THREE.Mesh(geom, [mat,mat,roof,roof,mat,mat]); mesh.castShadow=allowShadows; mesh.receiveShadow=allowShadows; mesh.position.set(xc,height/2,zc); city.add(mesh);
+    const body=new CANNON.Body({mass:0}); body.addShape(new CANNON.Box(new CANNON.Vec3(w/2,height/2,d/2))); body.position.set(xc,height/2,zc); world.addBody(body);
+    addLadder(xc, zc + d/2 + 0.12, 0.3, height+0.6);
+    addRoofStair(xc + (Math.random()*0.6-0.3)*w*0.6, zc + (Math.random()*0.6-0.3)*d*0.6, height);
+    if(opts.sign){ const s=new THREE.Mesh(new THREE.PlaneGeometry(Math.min(18,w*0.8),4), new THREE.MeshBasicMaterial({ color:0xffffff })); s.position.set(xc, Math.min(height*0.65, 14), zc + d/2 + 0.51); city.add(s); const tcv=document.createElement('canvas'); tcv.width=512; tcv.height=128; const gx=tcv.getContext('2d'); gx.fillStyle='#111827'; gx.fillRect(0,0,512,128); gx.fillStyle='#fff'; gx.font='900 62px system-ui,Segoe UI'; gx.textAlign='center'; gx.textBaseline='middle'; gx.fillText(opts.sign, 256, 64); const tex=new THREE.CanvasTexture(tcv); tex.colorSpace=THREE.SRGBColorSpace; s.material.map=tex; s.material.needsUpdate=true; }
+    return {mesh, dims:{w,d,h:height}};
+  }
+
+  function courtLinesTex(courtW,courtL){ const w=2048, h=4096; const s=h/courtL; const c=document.createElement('canvas'); c.width=w; c.height=h; const g=c.getContext('2d'); g.clearRect(0,0,w,h); const lineW=12; g.strokeStyle='#ffffff'; g.lineWidth=lineW; g.lineJoin='round'; g.lineCap='round'; const halfW=courtW/2, halfL=courtL/2; const X=(x)=>(w/2+x*s), Z=(z)=>(h/2+z*s); const line=(x1,z1,x2,z2)=>{ g.beginPath(); g.moveTo(X(x1),Z(z1)); g.lineTo(X(x2),Z(z2)); g.stroke(); }; const box=(x1,z1,x2,z2)=>{ line(x1,z1,x2,z1); line(x2,z1,x2,z2); line(x2,z2,x1,z2); line(x1,z2,x1,z1); };
+    const serviceZ=6.4; box(-halfW,-halfL,halfW,halfL); line(-halfW,-serviceZ,halfW,-serviceZ); line(-halfW,serviceZ,halfW,serviceZ); line(0,-serviceZ,0,serviceZ); const t=new THREE.CanvasTexture(c); t.anisotropy=Math.min(16,maxAniso); t.wrapS=t.wrapT=THREE.ClampToEdgeWrapping; t.needsUpdate=true; return t; }
+  function basketLinesTex(wm=28,hm=15){ const w=2048,h=1024; const c=document.createElement('canvas'); c.width=w;c.height=h; const g=c.getContext('2d'); g.clearRect(0,0,w,h); g.strokeStyle='#ffffff'; g.lineWidth=10; g.lineJoin='round'; g.lineCap='round'; const sX=w/wm, sY=h/hm; const R=(x,y)=>[x*sX+w*0.5 - (wm*sX)/2, y*sY+h*0.5 - (hm*sY)/2]; const rect=(x,y,w2,h2)=>{ const [X,Y]=R(x,y); g.strokeRect(X,Y,w2*sX,h2*sY); }; const arc=(cx,cy,r,a0,a1)=>{ const [X,Y]=R(cx,cy); g.beginPath(); g.arc(X+0, Y+0, r*sX, a0, a1); g.stroke(); };
+    rect(0,0,wm,hm); rect(0.5,0.5,wm-1,hm-1);
+    rect(0.5, hm*0.5-2.4, 4.6, 4.8); rect(wm-0.5-4.6, hm*0.5-2.4, 4.6, 4.8);
+    arc(wm*0.5, 0.5, 2.4, 0, Math.PI); arc(wm*0.5, hm-0.5, 2.4, Math.PI, Math.PI*2);
+    const t=new THREE.CanvasTexture(c); t.anisotropy=Math.min(16,maxAniso); t.wrapS=t.wrapT=THREE.ClampToEdgeWrapping; t.needsUpdate=true; return t; }
+
+  function fenceMat(){ const c=document.createElement('canvas'); c.width=512;c.height=512; const g=c.getContext('2d'); g.clearRect(0,0,512,512); g.strokeStyle='rgba(18,18,18,0.96)'; g.lineWidth=2; for(let i=16;i<512;i+=16){ g.beginPath(); g.moveTo(i,16); g.lineTo(i,496); g.stroke(); g.beginPath(); g.moveTo(16,i); g.lineTo(496,i); g.stroke(); } const t=new THREE.CanvasTexture(c); t.anisotropy=Math.min(8,maxAniso); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(4,2); return t; }
+
+  function treesPerimeter(cx,cz){ const half=PLOT*0.45; const step=8;
+    const trunkGeo=new THREE.CylinderGeometry(0.5,0.8,6,8); const crownGeo=new THREE.IcosahedronGeometry(3.2,1);
+    const trunks=new THREE.Group(), crowns=new THREE.Group();
+    const trunkMat=new THREE.MeshLambertMaterial({ color:0x6e4f2f }); const crownMat=new THREE.MeshLambertMaterial({ color:0x3a6f42 });
+    const place=(x,z)=>{ const t=new THREE.Mesh(trunkGeo,trunkMat); t.position.set(x,3,z); t.castShadow=allowShadows; t.receiveShadow=allowShadows; trunks.add(t); const cr=new THREE.Mesh(crownGeo,crownMat); cr.position.set(x,9,z); cr.castShadow=allowShadows; cr.receiveShadow=allowShadows; crowns.add(cr); };
+    for(let x=-half;x<=half;x+=step){ place(cx+x, cz-half); place(cx+x, cz+half); }
+    for(let z=-half;z<=half;z+=step){ place(cx-half, cz+z); place(cx+half, cz+z); }
+    city.add(trunks,crowns);
+  }
+
+  function addParkGrass(cx,cz,scale=1.0){ const g=new THREE.Mesh(new THREE.PlaneGeometry(PLOT*0.9*scale,PLOT*0.9*scale), new THREE.MeshStandardMaterial({ map:tennisGrassTex, roughness:0.94, metalness:0.0 })); g.rotation.x=-Math.PI/2; g.position.set(cx,0.015,cz); g.receiveShadow=allowShadows; city.add(g); }
+
+  function addTennisCourt(cx,cz){
+    addParkGrass(cx,cz,1.05);
+    const courtW=9.2, courtL=23.77, apron=2.6;
+    const track=new THREE.Mesh(new THREE.PlaneGeometry(courtW+apron*2,courtL+apron*2), new THREE.MeshStandardMaterial({ map:redTrackTex, roughness:0.96, metalness:0.0 }));
+    track.rotation.x=-Math.PI/2; track.position.set(cx,0.02,cz); city.add(track);
+    const grass=new THREE.Mesh(new THREE.PlaneGeometry(courtW,courtL), new THREE.MeshStandardMaterial({ map:tennisGrassTex, roughness:0.94, metalness:0.0 }));
+    grass.rotation.x=-Math.PI/2; grass.position.set(cx,0.021,cz); city.add(grass);
+    const lines=new THREE.Mesh(new THREE.PlaneGeometry(courtW,courtL), new THREE.MeshBasicMaterial({ map:courtLinesTex(courtW,courtL), transparent:true, opacity:0.995, polygonOffset:true, polygonOffsetFactor:-2, polygonOffsetUnits:-2, depthWrite:false }));
+    lines.rotation.x=-Math.PI/2; lines.position.set(cx,0.022,cz); city.add(lines);
+    const fenceH=3.2, fenceGap=0.4; const fMat=new THREE.MeshStandardMaterial({ map:fenceMat(), transparent:true, opacity:1.0, roughness:0.9, metalness:0.0, color:0xffffff });
+    const fx=courtW/2+apron-fenceGap, fz=courtL/2+apron-fenceGap;
+    const mk=(w,h,rx,rz)=>{ const m=new THREE.Mesh(new THREE.PlaneGeometry(w,h),fMat); m.position.set(cx+rx, h/2, cz+rz); city.add(m); };
+    mk(courtW+apron*2, fenceH, 0, -fz); mk(courtW+apron*2, fenceH, 0, fz);
+    const s1=new THREE.Mesh(new THREE.PlaneGeometry(courtL+apron*2, fenceH), fMat); s1.rotation.y=Math.PI/2; s1.position.set(cx-fx, fenceH/2, cz); city.add(s1);
+    const s2=s1.clone(); s2.position.x=cx+fx; city.add(s2);
+    treesPerimeter(cx,cz);
+  }
+
+  function addBasketCourt(cx,cz){
+    addParkGrass(cx,cz,1.05);
+    const wm=28, hm=15, apron=2.6;
+    const base=new THREE.Mesh(new THREE.PlaneGeometry(wm+apron*2,hm+apron*2), new THREE.MeshStandardMaterial({ map:redTrackTex, roughness:0.96, metalness:0.0 }));
+    base.rotation.x=-Math.PI/2; base.position.set(cx,0.02,cz); city.add(base);
+    const dark=new THREE.Mesh(new THREE.PlaneGeometry(wm,hm), new THREE.MeshBasicMaterial({ color:0x1e2329 }));
+    dark.rotation.x=-Math.PI/2; dark.position.set(cx,0.021,cz); city.add(dark);
+    const lines=new THREE.Mesh(new THREE.PlaneGeometry(wm,hm), new THREE.MeshBasicMaterial({ map:basketLinesTex(wm,hm), transparent:true, opacity:0.98 }));
+    lines.rotation.x=-Math.PI/2; lines.position.set(cx,0.022,cz); city.add(lines);
+    const hoopMat=new THREE.MeshBasicMaterial({ color:0xffffff }); const postMat=new THREE.MeshBasicMaterial({ color:0xff3c3c });
+    const makeHoop=(sx)=>{ const g=new THREE.Group(); const board=new THREE.Mesh(new THREE.BoxGeometry(1.8,1.1,0.08), hoopMat); const rim=new THREE.Mesh(new THREE.TorusGeometry(0.45,0.06,8,24), postMat); rim.rotation.x=Math.PI/2; board.position.y=2.9; rim.position.set(0,2.3,0.3); const post=new THREE.Mesh(new THREE.CylinderGeometry(0.06,0.06,2.6,16), postMat); post.position.y=1.3; g.add(post,board,rim); g.position.set(cx+sx*(wm*0.5-1.2),0,cz); city.add(g); };
+    makeHoop(-1); makeHoop(1);
+    for(let i=0;i<3;i++){ const ball=new THREE.Mesh(new THREE.SphereGeometry(0.3,20,16), new THREE.MeshStandardMaterial({ color:0xff8a00, roughness:0.65 })); ball.position.set(cx + (Math.random()*2-1)*4, 0.3, cz + (Math.random()*2-1)*3); city.add(ball); }
+    const fenceH=3.0; const fMat=new THREE.MeshStandardMaterial({ map:fenceMat(), transparent:true, opacity:1.0, roughness:0.9, metalness:0.0, color:0xffffff });
+    const fx=wm/2+apron-0.4, fz=hm/2+apron-0.4;
+    const mk=(w,h,rx,rz)=>{ const m=new THREE.Mesh(new THREE.PlaneGeometry(w,h),fMat); m.position.set(cx+rx, h/2, cz+rz); city.add(m); };
+    mk(wm+apron*2, fenceH, 0, -fz); mk(wm+apron*2, fenceH, 0, fz);
+    const s1=new THREE.Mesh(new THREE.PlaneGeometry(hm+apron*2, fenceH), fMat); s1.rotation.y=Math.PI/2; s1.position.set(cx-fx, fenceH/2, cz); city.add(s1);
+    const s2=s1.clone(); s2.position.x=cx+fx; city.add(s2);
+    treesPerimeter(cx,cz);
+  }
+
+  function addFountain(cx,cz){
+    addParkGrass(cx,cz,1.2);
+    const ringR=12;
+    const base=new THREE.Mesh(new THREE.CylinderGeometry(ringR,ringR,0.6,48), new THREE.MeshStandardMaterial({ color:0xaeb8c6, roughness:0.7 })); base.position.set(cx,0.3,cz); base.castShadow=false; base.receiveShadow=true; city.add(base);
+    const water=new THREE.Mesh(new THREE.CylinderGeometry(ringR*0.92, ringR*0.92, 0.4, 48), new THREE.MeshStandardMaterial({ color:0x3aa7ff, roughness:0.15, metalness:0.05, transparent:true, opacity:0.75 })); water.position.set(cx,0.5,cz); city.add(water);
+    for(let i=0;i<26;i++){ const ang=Math.random()*Math.PI*2, r=ringR*0.95*(0.6+Math.random()*0.35); const s=new THREE.Mesh(new THREE.DodecahedronGeometry(0.6+Math.random()*0.8), new THREE.MeshStandardMaterial({ color:0x9aa0a8, roughness:0.95 })); s.position.set(cx+Math.cos(ang)*r,0.35,cz+Math.sin(ang)*r); city.add(s); }
+    for(let i=0;i<80;i++){ const ang=Math.random()*Math.PI*2, r=ringR*(0.2+Math.random()*0.9); const f=new THREE.Mesh(new THREE.ConeGeometry(0.15,0.4,8), new THREE.MeshStandardMaterial({ color: (Math.random()<0.5?0xff4d6d:0xffc300), roughness:0.9 })); f.position.set(cx+Math.cos(ang)*r,0.2,cz+Math.sin(ang)*r); city.add(f); }
+    const jets=[]; const jetMat=new THREE.MeshBasicMaterial({ color:0xaee3ff }); for(let i=0;i<8;i++){ const j=new THREE.Mesh(new THREE.CylinderGeometry(0.05,0.05,1.2,8), jetMat); j.position.set(cx+(Math.random()*2-1)*2,1.1,cz+(Math.random()*2-1)*2); city.add(j); jets.push(j); }
+    water.userData.jets=jets;
+  }
+
+  const trafficLights=[];
+  function addTrafficLight(x,z,dir=0){ const h=5; const pole=new THREE.Mesh(new THREE.CylinderGeometry(0.1,0.1,h,10), new THREE.MeshStandardMaterial({ color:0x666 })); pole.position.set(x,h/2,z); city.add(pole); const box=new THREE.Mesh(new THREE.BoxGeometry(0.4,1,0.3), new THREE.MeshStandardMaterial({ color:0x222 })); box.position.set(x,3.6,z); box.rotation.y=dir; city.add(box);
+    const mkLamp=(c,dy)=>{ const m=new THREE.Mesh(new THREE.SphereGeometry(0.14,12,12), new THREE.MeshBasicMaterial({ color:c })); m.position.set(x+Math.sin(dir)*0.15,3.6+dy,z+Math.cos(dir)*0.15); city.add(m); return m; };
+    const Lg=mkLamp(0x2ecc71,0.28), Ly=mkLamp(0xf1c40f,0), Lr=mkLamp(0xe74c3c,-0.28);
+    trafficLights.push({pos:new THREE.Vector3(x,0,z), dir, state:'green', timer:0, lamps:{Lg,Ly,Lr}});
+  }
+
+  const POIS=[];
+  function addInstitution(kind, x, z){
+    let sign = kind==='hospital'?'HOSPITAL': kind==='police'?'POLICE': kind==='fire'?'FIRE': kind==='school'?'SCHOOL':'MALL';
+    const b=addBuilding(x,z,{floors: (kind==='mall'?6:7), w: (kind==='mall'?70:48), d:(kind==='mall'?60:40), hue: kind==='hospital'?5: (kind==='police'?210: (kind==='fire'?8: (kind==='school'?40:80))), sign});
+    if(kind==='hospital'){ const pad=new THREE.Mesh(new THREE.CircleGeometry(8,32), new THREE.MeshBasicMaterial({ color:0xffffff })); pad.rotation.x=-Math.PI/2; pad.position.set(x, b.dims.h+0.2, z- b.dims.d/2 + 10); city.add(pad); const H=new THREE.Mesh(new THREE.TorusGeometry(6,0.6,8,32), new THREE.MeshBasicMaterial({ color:0xff0000 })); H.rotation.x=-Math.PI/2; H.position.copy(pad.position).setY(b.dims.h+0.5); city.add(H); }
+    const icon = kind==='hospital'?'🏥': kind==='police'?'🚓': kind==='fire'?'🧯': kind==='school'?'🏫':'🛍';
+    POIS.push({type:kind, pos:new THREE.Vector3(x,0,z), label:icon, dims:b.dims});
+  }
+
+  function addAirport(x,z){ const runway=new THREE.Mesh(new THREE.PlaneGeometry(400,26), new THREE.MeshBasicMaterial({ color:0x2f2f2f })); runway.rotation.x=-Math.PI/2; runway.position.set(x,0.02,z); city.add(runway); const stripe=new THREE.Mesh(new THREE.PlaneGeometry(400*0.9,3), new THREE.MeshBasicMaterial({ color:0xffffff, transparent:true, opacity:0.7 })); stripe.rotation.x=-Math.PI/2; stripe.position.set(x,0.03,z); city.add(stripe); const tower=new THREE.Mesh(new THREE.CylinderGeometry(4,4,28,16), new THREE.MeshStandardMaterial({ color:0x9aa0a8 })); tower.position.set(x+40,14,z-20); city.add(tower); const top=new THREE.Mesh(new THREE.SphereGeometry(6,16,12), new THREE.MeshStandardMaterial({ color:0xbfc6cf, metalness:0.2, roughness:0.6 })); top.position.set(x+40,28,z-20); city.add(top); POIS.push({type:'airport', pos:new THREE.Vector3(x,0,z), label:'🛫'}); }
+  function addTrainStation(x,z){ const plat=new THREE.Mesh(new THREE.PlaneGeometry(160,8), new THREE.MeshBasicMaterial({ color:0x666b73 })); plat.rotation.x=-Math.PI/2; plat.position.set(x,0.02,z); city.add(plat); const rails=new THREE.Group(); for(let i=0;i<4;i++){ const r=new THREE.Mesh(new THREE.PlaneGeometry(160,0.3), new THREE.MeshBasicMaterial({ color:0x444 })); r.rotation.x=-Math.PI/2; r.position.set(x,0.021,z-2+i*1.2); rails.add(r);} city.add(rails); addBuilding(x+30,z-8,{floors:5,w:50,d:16,hue:48,sign:'STATION'}); POIS.push({type:'station', pos:new THREE.Vector3(x,0,z), label:'🚉'}); }
+
+  const parkKinds=['tennis','basket','fountain'];
+  for(let ix=0; ix<BLOCKS_X; ix++){
+    for(let iz=0; iz<BLOCKS_Z; iz++){
+      const cx=startX+ix*CELL, cz=startZ+iz*CELL; addSidewalk(cx,cz);
+      const makePark = ((ix+iz)%2===0);
+      if(makePark){
+        const pick = parkKinds[(ix+iz)%parkKinds.length];
+        if(pick==='tennis') addTennisCourt(cx,cz);
+        else if(pick==='basket') addBasketCourt(cx,cz);
+        else addFountain(cx,cz);
+      } else {
+        const bCount=2+Math.floor(Math.random()*3); for(let b=0;b<bCount;b++){ addBuilding(cx+(Math.random()-0.5)*PLOT*0.7, cz+(Math.random()-0.5)*PLOT*0.7); }
+      }
+    }
+  }
+  for(let i=-BLOCKS_X;i<=BLOCKS_X;i+=2){ addTrafficLight(i*CELL*0.5, -BLOCKS_Z*CELL*0.5, 0); addTrafficLight(i*CELL*0.5, BLOCKS_Z*CELL*0.5, Math.PI); }
+
+  const ringR = Math.max(BLOCKS_X,BLOCKS_Z)*CELL*0.65;
+  addAirport(ringR*0.9,  -ringR*0.6);
+  addTrainStation(-ringR*0.6, ringR*0.85);
+
+  addInstitution('police',   startX+CELL*1.2, startZ+CELL*1.0);
+  addInstitution('hospital', startX+CELL*2.6, startZ+CELL*2.0);
+  addInstitution('school',   startX+CELL*0.4, startZ+CELL*3.2);
+  addInstitution('fire',     startX+CELL*3.5, startZ+CELL*0.6);
+  addInstitution('mall',     startX+CELL*4.2, startZ+CELL*2.6);
+
+  const playerRadius=0.35; const player=new CANNON.Body({ mass:75, material:matPlayer, shape:new CANNON.Sphere(playerRadius), position:new CANNON.Vec3(0,1.0,10), linearDamping:0.18, angularDamping:0.9 });
+  player.fixedRotation=true; player.allowSleep=false; world.addBody(player);
+  let yaw=0, pitch=0; function clampPitch(){ pitch=Math.max(-Math.PI/2+0.005, Math.min(Math.PI/2-0.005, pitch)); }
+  let camDist=4.2;
+  function camFollow(pos,distMul=1){ const back=new THREE.Vector3(Math.sin(yaw),0,Math.cos(yaw)); const eye=new THREE.Vector3(pos.x - back.x*camDist*distMul, pos.y+2.1, pos.z - back.z*camDist*distMul); camera.position.lerp(eye,0.25); const look=new THREE.Vector3(pos.x + back.x*(camDist+0.2)*distMul, pos.y+1.25 + Math.sin(pitch)*0.8, pos.z + back.z*(camDist+0.2)*distMul); camera.lookAt(look); }
+  function grounded(){ return player.position.y < 0.38 && Math.abs(player.velocity.y) < 0.05; }
+  function jump(){ if(grounded()){ player.velocity.y = 5.2; } }
+
+  const aimGeo=new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(), new THREE.Vector3(0,0,-50)]);
+  const aimMatDark=new THREE.LineBasicMaterial({ color:0x222222, transparent:true, opacity:0.9 });
+  const aimLine=new THREE.Line(aimGeo,aimMatDark); aimLine.renderOrder=9; scene.add(aimLine);
+  const aimDotTex=(function(){ const c=document.createElement('canvas'); c.width=c.height=64; const x=c.getContext('2d'); x.fillStyle='rgba(255,255,255,0.0)'; x.fillRect(0,0,64,64); x.beginPath(); x.arc(32,32,14,0,Math.PI*2); x.fillStyle='rgba(255,60,60,0.95)'; x.fill(); x.lineWidth=3; x.strokeStyle='rgba(255,255,255,0.9)'; x.stroke(); const t=new THREE.CanvasTexture(c); t.colorSpace=THREE.SRGBColorSpace; return t; })();
+  const aimDotMat=new THREE.SpriteMaterial({ map:aimDotTex, depthWrite:false, color:0xffffff }); const aimDot=new THREE.Sprite(aimDotMat); aimDot.scale.set(0.7,0.7,1); scene.add(aimDot);
+  const crosshairEl=$('crosshair'); crosshairEl.style.setProperty('--aimColor','#ff3c3c');
+
+  const BLANK_PNG='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
+  const manager=new THREE.LoadingManager(); manager.setURLModifier((url)=>{ if(url?.startsWith('data:')||url?.startsWith('blob:')) return url; if(/(\.(png|jpg|jpeg|webp|ktx2|dds|tga)(\?|#|$))/i.test(url)) return BLANK_PNG; return url; });
+  const gltfLoader=new GLTFLoader(manager); const draco=new DRACOLoader(manager); draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/'); gltfLoader.setDRACOLoader(draco); gltfLoader.setCrossOrigin('anonymous');
+  gltfLoader.register((parser)=>{ const c=document.createElement('canvas'); c.width=c.height=1; const ctx=c.getContext('2d'); ctx.fillStyle='#888'; ctx.fillRect(0,0,1,1); const blank=new THREE.CanvasTexture(c); blank.colorSpace=THREE.SRGBColorSpace; blank.needsUpdate=true; const orig=parser.getDependency.bind(parser); parser.getDependency=function(type,index){ if(type==='texture') return Promise.resolve(blank); return orig(type,index); }; return {name:'NullTextures'}; });
+
+  const ARMORY=[
+    { key:'Glock',  name:'Glock', url:'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/glock.glb', s:0.62,  stats:{ rpm:380, dmg:24, spread:0.013, mag:17, reload:1.2 }, auto:false },
+    { key:'Pistol', name:'Pistol',url:'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb', s:0.46, stats:{ rpm:320, dmg:22, spread:0.014, mag:15, reload:1.3 }, auto:false },
+    { key:'AR',     name:'Assault Rifle', url:'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb', s:0.70, stats:{ rpm:720, dmg:26, spread:0.012, mag:30, reload:1.9 }, auto:true },
+    { key:'Uzi',    name:'Uzi',    url:'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb', s:0.60, stats:{ rpm:900, dmg:18, spread:0.02,  mag:32, reload:1.6 }, auto:true },
+    { key:'AK47',   name:'AK-pattern', url:'https://cdn.jsdelivr.net/gh/LazerMaker/gun-models-ak47-and-supprest-pistol-@master/ak47.glb', s:0.78, stats:{ rpm:600, dmg:30, spread:0.012, mag:30, reload:1.9 }, auto:true },
+    { key:'Grenade',name:'Grenade',url:'https://cdn.jsdelivr.net/gh/friuns2/bingextension@main/grenade.glb', s:0.30, stats:{ rpm:60,  dmg:120, spread:0.03,  mag:1,  reload:2.4 }, auto:false }
+  ];
+  const FIRE_MODES=new Map(); ARMORY.forEach(a=>FIRE_MODES.set(a.key, a.auto?'auto':'single'));
+
+  const weaponRoot=new THREE.Group(); camera.add(weaponRoot);
+  const weaponCache=new Map();
+  const metalTex=(()=>{ const S=256,c=document.createElement('canvas'); c.width=c.height=S; const x=c.getContext('2d'); const g=x.createLinearGradient(0,0,S,S); g.addColorStop(0,'#2e2e2e'); g.addColorStop(1,'#4a4a4a'); x.fillStyle=g; x.fillRect(0,0,S,S); const t=new THREE.CanvasTexture(c); t.colorSpace=THREE.SRGBColorSpace; t.anisotropy=2; return t; })();
+  const matMetal=new THREE.MeshLambertMaterial({ color:'#3b3b3b', map:metalTex }), matWood =new THREE.MeshLambertMaterial({ color:'#7b5331' });
+  function makeSight(){ const s=new THREE.Group(); const ring=new THREE.Mesh(new THREE.TorusGeometry(0.015,0.004,8,12), new THREE.MeshBasicMaterial({ color:'#222' })); ring.rotation.x=Math.PI/2; ring.position.set(0,0,0.02); const post=new THREE.Mesh(new THREE.BoxGeometry(0.004,0.02,0.004), new THREE.MeshBasicMaterial({ color:'#444' })); post.position.set(0,0,0.03); s.add(ring,post); return s; }
+  function makeAK47Mesh(){ const g=new THREE.Group(); const rec=new THREE.Mesh(new THREE.BoxGeometry(0.12,0.11,0.45), matMetal); const hand=new THREE.Mesh(new THREE.BoxGeometry(0.07,0.08,0.28), matWood); hand.position.set(0.07,-0.02,-0.22); const barrel=new THREE.Mesh(new THREE.CylinderGeometry(0.016,0.016,0.38,18), matMetal); barrel.rotation.z=Math.PI/2; barrel.position.set(0.12,-0.02,-0.41); const stock=new THREE.Mesh(new THREE.BoxGeometry(0.08,0.09,0.25), matWood); stock.position.set(-0.06,-0.01,0.16); const mag=new THREE.Mesh(new THREE.CapsuleGeometry(0.04,0.12,8,16), matMetal); mag.rotation.x=Math.PI/2; mag.position.set(0.02,-0.08,0.02); g.add(rec,hand,barrel,stock,mag,makeSight()); return g; }
+  function makePistolMesh(){ const g=new THREE.Group(); const slide=new THREE.Mesh(new THREE.BoxGeometry(0.08,0.05,0.18), matMetal); slide.position.set(0.02,0.02,-0.09); const frame=new THREE.Mesh(new THREE.BoxGeometry(0.09,0.07,0.14), new THREE.MeshLambertMaterial({color:'#444'})); const grip=new THREE.Mesh(new THREE.BoxGeometry(0.05,0.1,0.06), new THREE.MeshLambertMaterial({color:'#2b2b2b'})); grip.position.set(-0.02,-0.05,0.02); const barrel=new THREE.Mesh(new THREE.CylinderGeometry(0.008,0.008,0.14,10), matMetal); barrel.rotation.z=Math.PI/2; barrel.position.set(0.07,0.02,-0.18); g.add(frame,slide,grip,barrel,makeSight()); return g; }
+  function normalizeAndCenter(root, targetLen=0.6){ const box=new THREE.Box3().setFromObject(root); const size=new THREE.Vector3(); box.getSize(size); const center=new THREE.Vector3(); box.getCenter(center); root.position.sub(center); const maxDim=Math.max(size.x,size.y,size.z)||1; const s=targetLen/maxDim; root.scale.setScalar(s); return root; }
+  async function loadWeapon(key){ const entry=ARMORY.find(a=>a.key===key); if(!entry){ return new THREE.Group(); } if(weaponCache.has(key)){ const v=weaponCache.get(key); return (v.clone? v.clone(true) : v); } try{ const gltf=await gltfLoader.loadAsync(entry.url); const base=(gltf.scene||gltf.scenes?.[0]||null); let use = base || makePistolMesh(); normalizeAndCenter(use, entry.s); use.traverse?.(o=>{ if(o.isMesh){ o.castShadow=allowShadows; o.receiveShadow=allowShadows; const m=o.material; o.material = new THREE.MeshLambertMaterial({ color:(m?.color||new THREE.Color('#888')), map:m?.map||null, transparent:!!m?.transparent, opacity:(m?.opacity??1) }); }}); weaponCache.set(key, use); return (use.clone? use.clone(true) : use); }catch(_){ let alt; if(key==='AK47') alt=makeAK47Mesh(); else alt=makePistolMesh(); normalizeAndCenter(alt, key==='AK47'?0.78:0.5); weaponCache.set(key, alt); return (alt.clone? alt.clone(true) : alt); } }
+
+  const armoryDiv=$('armory'); const thumbCache=new Map();
+  function weaponIconURL(key){ const svg=(b)=>'data:image/svg+xml;utf8,'+encodeURIComponent(b); const base=(body)=>`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 112 68'><rect width='112' height='68' rx='8' ry='8' fill='rgba(0,0,0,0.18)'/><g fill='none' stroke='#e6eefc' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'>${body}</g></svg>`; switch(key){ case 'Glock': return svg(base(`<path d='M14 32h58l8 8H14z'/><path d='M64 32v-8h20l8 10'/>`)); case 'Pistol': return svg(base(`<path d='M12 34h62l10 8H12z'/>`)); case 'AR': return svg(base(`<path d='M8 38h74l8 6H8z'/>`)); case 'Uzi': return svg(base(`<path d='M10 34h52l8 6H10z'/>`)); case 'AK47': return svg(base(`<path d='M10 38h84l10 6H10z'/>`)); case 'Grenade': return svg(base(`<circle cx='42' cy='36' r='12'/>`)); default: return svg(base(`<path d='M16 34h80'/>`)); } }
+  function weaponPreviewURL(key){ return thumbCache.get(key) || weaponIconURL(key); }
+  async function generateThumb(key){ try{ if(thumbCache.has(key)) return thumbCache.get(key); const size={w:224,h:136}; const rt=new THREE.WebGLRenderTarget(size.w,size.h); const sc=new THREE.Scene(); const cam=new THREE.PerspectiveCamera(40, size.w/size.h, 0.01, 10); const amb=new THREE.AmbientLight(0xffffff,0.9); const dir=new THREE.DirectionalLight(0xffffff,0.9); dir.position.set(2,3,2); sc.add(amb,dir); const model=await loadWeapon(key); const g=new THREE.Group(); if(model) g.add(model); normalizeAndCenter(g,0.9); g.rotation.y=Math.PI*0.85; sc.add(g); const prev=new THREE.Color(); renderer.getClearColor(prev); const prevA=renderer.getClearAlpha(); renderer.setRenderTarget(rt); renderer.setClearColor(0x000000,0); cam.position.set(0.6,0.3,1.2); cam.lookAt(0,0,0); renderer.render(sc,cam); const px=new Uint8Array(size.w*size.h*4); renderer.readRenderTargetPixels(rt,0,0,size.w,size.h,px); const cv=document.createElement('canvas'); cv.width=size.w; cv.height=size.h; const ctx=cv.getContext('2d'); const img=ctx.createImageData(size.w,size.h); for(let y=0;y<size.h;y++){ const sy=size.h-1-y; img.data.set(px.subarray(sy*size.w*4, sy*size.w*4+size.w*4), y*size.w*4);} ctx.putImageData(img,0,0); const url=cv.toDataURL('image/png'); renderer.setRenderTarget(null); renderer.setClearColor(prev,prevA); rt.dispose(); thumbCache.set(key,url); return url; }catch(_){ return weaponIconURL(key); } }
+  function buildGallery(){ armoryDiv.innerHTML=''; ARMORY.forEach((a)=>{ const b=document.createElement('button'); b.className='armBtn'; b.id='arm_'+a.key; b.innerHTML = `<img alt="${a.name}" src="${weaponPreviewURL(a.key)}"><span>${a.name}</span>`; b.addEventListener('click',()=>selectWeapon(a.key)); if(a.auto){ const t=document.createElement('button'); t.className='modeToggle'; t.textContent=(FIRE_MODES.get(a.key)==='auto')?'AUTO':'SINGLE'; t.addEventListener('click',(ev)=>{ ev.stopPropagation(); FIRE_MODES.set(a.key, FIRE_MODES.get(a.key)==='auto'?'single':'auto'); t.textContent=(FIRE_MODES.get(a.key)==='auto')?'AUTO':'SINGLE'; }); b.appendChild(t); } armoryDiv.appendChild(b); generateThumb(a.key).then(url=>{ const img=b.querySelector('img'); if(img) img.src=url; }); }); }
+  buildGallery();
+
+  let currentKey=ARMORY[0].key, currentStats=ARMORY[0].stats; let weaponModel=null; const ammo=new Map(); ARMORY.forEach(a=>ammo.set(a.key,{mag:a.stats.mag,reserve:a.stats.mag*3}));
+  function updateAmmoHUD(){ const a=ammo.get(currentKey); $('ammo').textContent=`${ARMORY.find(x=>x.key===currentKey)?.name||currentKey} — ${a.mag}/${a.reserve}`; document.querySelectorAll('.armBtn').forEach(el=>el.classList.remove('active')); const ab=$('arm_'+currentKey); if(ab) ab.classList.add('active'); }
+  const MUZZLE_OFF={ Glock:[0.0,-0.02,-0.74], Pistol:[0.0,-0.02,-0.74], AR:[0.0,-0.04,-0.80], Uzi:[0.0,-0.03,-0.78], AK47:[0.0,-0.04,-0.82], Grenade:[0,0,0] };
+  const EJECT_OFF={ Glock:[0.06,-0.05,-0.36], Pistol:[0.06,-0.05,-0.36], AR:[0.08,-0.05,-0.42], Uzi:[0.06,-0.04,-0.40], AK47:[0.09,-0.05,-0.44], Grenade:[0,0,0] };
+
+  async function mountPlayerWeapon(key){ if(weaponModel){ weaponRoot.remove(weaponModel); weaponModel.traverse(o=>{ o.geometry?.dispose?.(); if(Array.isArray(o.material)) o.material.forEach(m=>m.dispose?.()); else o.material?.dispose?.(); }); weaponModel=null; }
+    const model=await loadWeapon(key); const g=new THREE.Group(); if(model) g.add(model);
+    const off={x:0.18,y:-0.10,z:-0.52}; g.position.set(off.x,off.y,off.z); g.rotation.set(-0.03, Math.PI, -0.12);
+    weaponModel=g; weaponRoot.add(g);
+    const muzzleAnchor=new THREE.Object3D(); const ejectAnchor=new THREE.Object3D(); weaponModel.add(muzzleAnchor); weaponModel.add(ejectAnchor);
+    const mo=MUZZLE_OFF[key]||MUZZLE_OFF.Glock; const eo=EJECT_OFF[key]||EJECT_OFF.Glock; muzzleAnchor.position.set(mo[0],mo[1],mo[2]); ejectAnchor.position.set(eo[0],eo[1],eo[2]);
+    weaponModel.userData.muzzleAnchor=muzzleAnchor; weaponModel.userData.ejectAnchor=ejectAnchor; }
+  async function selectWeapon(key){ currentKey=key; currentStats=ARMORY.find(a=>a.key===key)?.stats||currentStats; updateAmmoHUD(); await mountPlayerWeapon(key); updateZoomUI(); }
+  await selectWeapon(currentKey);
+
+  const impactTargets=[city];
+  const raycaster=new THREE.Raycaster(); const tracers=[]; function tracer(from,to,color=0xfff1b1,life=0.12){ const g=new THREE.BufferGeometry().setFromPoints([from,to]); const m=new THREE.LineBasicMaterial({color,transparent:true}); const l=new THREE.Line(g,m); l.userData.life=life; scene.add(l); tracers.push(l);} function updateTracers(dt){ for(let i=0;i<tracers.length;i++){ const l=tracers[i]; l.userData.life-=dt; l.material.opacity=Math.max(0,l.userData.life/0.12); if(l.userData.life<=0){ scene.remove(l); l.geometry.dispose(); l.material.dispose(); tracers.splice(i,1); i--; } } }
+  const decalTex=(function(){ const c=document.createElement('canvas'); c.width=c.height=64; const x=c.getContext('2d'); x.clearRect(0,0,64,64); x.fillStyle='rgba(0,0,0,0.9)'; x.beginPath(); x.arc(32,32,18,0,Math.PI*2); x.fill(); x.fillStyle='rgba(0,0,0,0.4)'; for(let i=0;i<10;i++){ const r=22+Math.random()*6; x.beginPath(); x.arc(32+(Math.random()-0.5)*6,32+(Math.random()-0.5)*6,r,0,Math.PI*2); x.fill(); } const t=new THREE.CanvasTexture(c); t.colorSpace=THREE.SRGBColorSpace; t.anisotropy=2; return t; })();
+  function addDecal(point, normal){ const s=0.22; const g=new THREE.PlaneGeometry(s,s); const m=new THREE.MeshBasicMaterial({ map:decalTex, transparent:true, depthWrite:false }); const q=new THREE.Quaternion(); q.setFromUnitVectors(new THREE.Vector3(0,0,1), normal.clone().normalize()); const mesh=new THREE.Mesh(g,m); mesh.position.copy(point); mesh.quaternion.copy(q); mesh.renderOrder=10; scene.add(mesh); setTimeout(()=>{ scene.remove(mesh); g.dispose(); m.dispose(); }, 15000); }
+  const bloodTex=(function(){ const c=document.createElement('canvas'); c.width=c.height=64; const x=c.getContext('2d'); x.fillStyle='rgba(160,0,0,0.0)'; x.fillRect(0,0,64,64); x.fillStyle='rgba(210,20,20,0.9)'; x.beginPath(); x.arc(32,32,20,0,Math.PI*2); x.fill(); x.fillStyle='rgba(120,0,0,0.9)'; for(let i=0;i<5;i++){ x.beginPath(); x.arc(32+(Math.random()-0.5)*16,32+(Math.random()-0.5)*16,6+Math.random()*6,0,Math.PI*2); x.fill(); } const t=new THREE.CanvasTexture(c); t.colorSpace=THREE.SRGBColorSpace; return t; })();
+  function addBlood(point){ const s=0.38; const g=new THREE.PlaneGeometry(s,s); const m=new THREE.MeshBasicMaterial({ map:bloodTex, transparent:true, depthWrite:false }); const mesh=new THREE.Mesh(g,m); mesh.position.copy(point); mesh.lookAt(camera.position); scene.add(mesh); setTimeout(()=>{ scene.remove(mesh); g.dispose(); m.dispose(); }, 12000); }
+
+  let reloading=false; function reload(){ const a=ammo.get(currentKey); const st=currentStats; if(reloading || !a) return; const need=st.mag-a.mag; if(need<=0||a.reserve<=0) return; const take=Math.min(need,a.reserve); reloading=true; setTimeout(()=>{ a.mag+=take; a.reserve-=take; reloading=false; updateAmmoHUD(); sfxReload(); }, st.reload*1000); }
+  $('reloadMini').addEventListener('click', reload);
+
+  function fireRay(off2){ raycaster.setFromCamera(off2||new THREE.Vector2(0,0), camera); const from=camera.position.clone(); const to=raycaster.ray.origin.clone().addScaledVector(raycaster.ray.direction, 8000); const pos = aimGeo.attributes.position; pos.setXYZ(0, from.x, from.y, from.z); pos.setXYZ(1, to.x, to.y, to.z); pos.needsUpdate=true; const plane = new THREE.Plane(new THREE.Vector3(0,1,0), 0); const hit = new THREE.Vector3(); raycaster.ray.intersectPlane(plane, hit); if(hit){ aimDot.position.copy(hit); } else { aimDot.position.copy(to); } return {from,to}; }
+
+  function ejection(anc){ const g=new THREE.Mesh(new THREE.SphereGeometry(0.01,6,6), new THREE.MeshBasicMaterial({ color:0xd4af37 })); const wp=new THREE.Vector3(); anc.getWorldPosition(wp); g.position.copy(wp); scene.add(g); const v=new THREE.Vector3((Math.random()*0.2+0.05), (Math.random()*0.3+0.05), (Math.random()*0.2-0.1)); const t0=performance.now(); const id=setInterval(()=>{ const t=(performance.now()-t0)/1000; g.position.x += v.x; g.position.y += v.y - 9.81*0.5*t*t*0.03; g.position.z += v.z; v.y -= 0.01; if(t>1.0){ clearInterval(id); scene.remove(g); g.geometry.dispose(); g.material.dispose(); } }, 16); }
+
+  function doShot(){ const st=currentStats; if(!st) return; const a=ammo.get(currentKey); if(a.mag<=0){ return; } muzzleLight.intensity=1.6; setTimeout(()=>muzzleLight.intensity=0,45); sfxGun(currentKey);
+    const spread=st.spread; const off=new THREE.Vector2((Math.random()-0.5)*spread*2,(Math.random()-0.5)*spread*2); const {from,to}=fireRay(off);
+    tracer(from,to,0xfff1b1);
+    const hits = raycaster.intersectObjects(impactTargets, true).filter(h=>h.object!==weaponModel && h.object !== aimLine);
+    if(hits.length){ const h=hits[0]; const normal = h.face?.normal?.clone()?.transformDirection(h.object.matrixWorld)||new THREE.Vector3(0,0,1); addDecal(h.point, normal); }
+    const hitsEnemy = raycaster.intersectObjects(enemyRoots(), true);
+    if(hitsEnemy.length){ const h=hitsEnemy[0]; const root=(function find(o){ let p=o; while(p && !p.userData?.enemy){ p=p.parent; } return p; })(h.object); const e=enemies.get(root.uuid); if(e && !e.dead){ e.hp -= st.dmg; addBlood(h.point); if(e.hp<=0){ e.dead=true; e.body.mass=0; e.body.updateMassProperties(); e.root.visible=false; e.hpBar.visible=false; } else { updateBillboardBar(e.hpBar, e.hp/120); } } }
+    if(weaponModel?.userData?.ejectAnchor && currentKey!=='Grenade'){ ejection(weaponModel.userData.ejectAnchor); }
+    a.mag--; updateAmmoHUD();
+  }
+
+  const audio={ ctx:null, muted:false };
+  function ac(){ if(audio.muted) return null; try{ audio.ctx = audio.ctx || new (window.AudioContext||window.webkitAudioContext)(); return audio.ctx; }catch(_){ return null; } }
+  function withAC(fn){ const ctx=ac(); if(!ctx) return; fn(ctx); }
+  function noiseBuffer(ctx){ const b=ctx.createBuffer(1, ctx.sampleRate*1.0, ctx.sampleRate); const d=b.getChannelData(0); for(let i=0;i<d.length;i++){ d[i]= (Math.random()*2-1) * (1 - i/d.length); } return b; }
+  function burstNoise({dur=0.12, freq=1500, type='bandpass', gain=0.12}){ withAC((ctx)=>{ const src=ctx.createBufferSource(); src.buffer=noiseBuffer(ctx); const bp=ctx.createBiquadFilter(); bp.type=type; bp.frequency.value=freq; const g=ctx.createGain(); g.gain.value=gain; src.connect(bp); bp.connect(g); g.connect(ctx.destination); src.start(); src.stop(ctx.currentTime+dur); }); }
+  function click({freq=800,dur=0.02,gain=0.08}){ withAC((ctx)=>{ const o=ctx.createOscillator(); const g=ctx.createGain(); o.type='square'; o.frequency.value=freq; g.gain.value=gain; o.connect(g); g.connect(ctx.destination); o.start(); o.stop(ctx.currentTime+dur); }); }
+  function sfxGun(kind){ switch(kind){ case 'Glock': case 'Pistol': burstNoise({dur:0.09,freq:2200,gain:0.12}); click({freq:1800,dur:0.015,gain:0.06}); break; case 'AR': burstNoise({dur:0.08,freq:1900,gain:0.13}); click({freq:1600,dur:0.012,gain:0.05}); break; case 'Uzi': burstNoise({dur:0.05,freq:2300,gain:0.12}); click({freq:1900,dur:0.01,gain:0.05}); break; case 'AK47': burstNoise({dur:0.1,freq:1400,gain:0.14}); click({freq:1200,dur:0.015,gain:0.07}); break; default: burstNoise({dur:0.07,freq:1800,gain:0.12}); } }
+  function sfxReload(){ click({freq:600,dur:0.05,gain:0.05}); setTimeout(()=>click({freq:900,dur:0.04,gain:0.05}),90); }
+  $('muteBtn').addEventListener('click',(e)=>{ audio.muted=!audio.muted; e.target.textContent=audio.muted?'🔇':'🔊'; });
+
+  const keys=new Set(); addEventListener('keydown',e=>{ keys.add(e.code); if(e.code==='Space') doShot(); if(e.code==='KeyR') reload(); }); addEventListener('keyup',e=>keys.delete(e.code));
+  $('resetBtn').addEventListener('click',()=>{ player.position.set(0,1.0,10); player.velocity.set(0,0,0); yaw=0; pitch=0; hp=100; updateHealth(); });
+
+  const joyMove=$('joyMove'), knobMove=joyMove.querySelector('.knob');
+  const R=150, K=85, DEAD=0.16;
+  const mv={active:false,id:null,vx:0,vz:0, tapStart:0, moved:false};
+  function centerOf(el){ const r=el.getBoundingClientRect(); return { cx:r.left + r.width/2, cy:r.top + r.height/2 }; }
+  joyMove.addEventListener('touchstart',e=>{ if(mv.active) return; const t=e.changedTouches[0]; mv.active=true; mv.id=t.identifier; mv.tapStart=performance.now(); mv.moved=false; e.preventDefault(); },{passive:false});
+  joyMove.addEventListener('touchmove', e=>{ for(const t of e.changedTouches){ if(mv.active&&t.identifier===mv.id){ const {cx,cy}=centerOf(joyMove); let dx=t.clientX-cx, dy=t.clientY-cy; const len=Math.hypot(dx,dy)||1; const nlen=Math.min(len/R,1); mv.moved = mv.moved || (nlen>DEAD*1.2); const nz=nlen<DEAD?0:(nlen-DEAD)/(1-DEAD); const scale = nz/(nlen||1); dx*=scale; dy*=scale; if(nlen>1){ dx/=nlen; dy/=nlen; } knobMove.style.transform=`translate(calc(-50% + ${dx}px),calc(-50% + ${dy}px))`; mv.vx = dx/K; mv.vz = -dy/K; } } e.preventDefault(); },{passive:false});
+  function mvEnd(){ knobMove.style.transform='translate(-50%,-50%)'; const tap=(performance.now()-mv.tapStart)<220 && !mv.moved; mv.active=false; mv.vx=0; mv.vz=0; if(tap) jump(); }
+  joyMove.addEventListener('touchend', mvEnd, {passive:false}); joyMove.addEventListener('touchcancel', mvEnd, {passive:false});
+  joyMove.addEventListener('pointerdown', (e)=>{ if(mv.active) return; mv.active=true; mv.id=e.pointerId; mv.tapStart=performance.now(); mv.moved=false; const r=joyMove.getBoundingClientRect(); mv.cx=r.left+r.width/2; mv.cy=r.top+r.height/2; try{ joyMove.setPointerCapture(e.pointerId); }catch(_){ } e.preventDefault(); });
+  joyMove.addEventListener('pointermove', (e)=>{ if(!mv.active||e.pointerId!==mv.id) return; let dx=e.clientX-mv.cx, dy=e.clientY-mv.cy; const len=Math.hypot(dx,dy)||1; const nlen=Math.min(len/R,1); if(!mv.moved && nlen>DEAD*1.2) mv.moved=true; const nz=nlen<DEAD?0:(nlen-DEAD)/(1-DEAD); const scale=nz/(nlen||1); dx*=scale; dy*=scale; if(nlen>1){ dx/=nlen; dy/=nlen; } knobMove.style.transform=`translate(calc(-50% + ${dx}px),calc(-50% + ${dy}px))`; mv.vx = dx/K; mv.vz = -dy/K; e.preventDefault(); });
+  function mvRelease(e){ if(!mv.active||e.pointerId!==mv.id) return; mvEnd(); try{ joyMove.releasePointerCapture(e.pointerId); }catch(_){ } e.preventDefault(); }
+  joyMove.addEventListener('pointerup', mvRelease); joyMove.addEventListener('pointercancel', mvRelease);
+
+  const shootPad=$('shootPad'); const shootKnob=shootPad.querySelector('.knob'); const aimPad=$('aimPad'); const aimKnob=aimPad.querySelector('.knob');
+  let fireHeld=false;
+  function shootDown(){ if(FIRE_MODES.get(currentKey)==='auto'){ fireHeld=true; } else { doShot(); } }
+  function shootUp(){ fireHeld=false; }
+  shootPad.addEventListener('pointerdown', (e)=>{ if(inputMode!=='A') return; shootDown(); e.preventDefault(); });
+  shootPad.addEventListener('pointerup', (e)=>{ if(inputMode!=='A') return; shootUp(); e.preventDefault(); });
+  shootPad.addEventListener('pointercancel', (e)=>{ if(inputMode!=='A') return; shootUp(); e.preventDefault(); });
+  shootPad.addEventListener('touchstart', (e)=>{ if(inputMode!=='A') return; shootDown(); e.preventDefault(); }, {passive:false});
+  shootPad.addEventListener('touchend', (e)=>{ if(inputMode!=='A') return; shootUp(); e.preventDefault(); }, {passive:false});
+
+  const aimPE={active:false,id:null,cx:0,cy:0,tapStart:0,moved:false};
+  function aimSet(dx,dy){ yaw -= dx*0.0012; pitch -= dy*0.0010; clampPitch(); }
+  aimPad.addEventListener('pointerdown', (e)=>{ if(inputMode!=='B'||aimPE.active) return; aimPE.active=true; aimPE.id=e.pointerId; aimPE.tapStart=performance.now(); aimPE.moved=false; const r=aimPad.getBoundingClientRect(); aimPE.cx=r.left+r.width/2; aimPE.cy=r.top+r.height/2; try{ aimPad.setPointerCapture(e.pointerId); }catch(_){} e.preventDefault(); });
+  aimPad.addEventListener('pointermove', (e)=>{ if(inputMode!=='B'||!aimPE.active||e.pointerId!==aimPE.id) return; let dx=e.clientX-aimPE.cx, dy=e.clientY-aimPE.cy; const len=Math.hypot(dx,dy)||1; const nlen=Math.min(len/R,1); if(!aimPE.moved && nlen>DEAD*1.2) aimPE.moved=true; const nz=nlen<DEAD?0:(nlen-DEAD)/(1-DEAD); const scale=nz/(nlen||1); dx*=scale; dy*=scale; if(nlen>1){ dx/=nlen; dy/=nlen; } aimKnob.style.transform=`translate(calc(-50% + ${dx}px),calc(-50% + ${dy}px))`; aimSet(dx,dy); e.preventDefault(); });
+  function aimRelease(e){ if(inputMode!=='B'||!aimPE.active||e.pointerId!==aimPE.id) return; aimPE.active=false; aimKnob.style.transform='translate(-50%,-50%)'; const tap=(performance.now()-aimPE.tapStart)<220 && !aimPE.moved; if(tap) doShot(); try{ aimPad.releasePointerCapture(e.pointerId); }catch(_){} e.preventDefault(); }
+  aimPad.addEventListener('pointerup', aimRelease); aimPad.addEventListener('pointercancel', aimRelease);
+
+  const canvasEl=renderer.domElement; canvasEl.style.touchAction='none';
+  const look={active:false,id:null,lastX:0,lastY:0};
+  let lookAccumX=0, lookAccumY=0; let aimSmoothX=0, aimSmoothY=0;
+  const LOOK_SENS_A  = isMobile ? 0.12 : 0.10;
+  const AIM_RATE_A   = 0.52;
+  const AIM_SMOOTH_A = 3.8;
+  function isUIBlock(el){ return el.closest('#joyMove')||el.closest('#shootPad')||el.closest('#aimPad')||el.closest('#armory')||el.closest('#reloadMini')||el.closest('#climbBtn')||el.closest('#radarBox')||el.closest('#zoomBox'); }
+  canvasEl.addEventListener('pointerdown',(e)=>{ if(inputMode!=='A') return; if(isUIBlock(e.target)) return; if(look.active) return; look.active=true; look.id=e.pointerId; look.lastX=e.clientX; look.lastY=e.clientY; try{ canvasEl.setPointerCapture(e.pointerId); }catch(_){} e.preventDefault(); });
+  canvasEl.addEventListener('pointermove',(e)=>{ if(inputMode!=='A') return; if(!look.active||e.pointerId!==look.id) return; const dx=e.clientX-look.lastX; const dy=e.clientY-look.lastY; look.lastX=e.clientX; look.lastY=e.clientY; lookAccumX += dx; lookAccumY += dy; e.preventDefault(); });
+  function lookRelease(e){ if(inputMode!=='A') return; if(!look.active||e.pointerId!==look.id) return; look.active=false; try{ canvasEl.releasePointerCapture(e.pointerId); }catch(_){} e.preventDefault(); }
+  canvasEl.addEventListener('pointerup', lookRelease); canvasEl.addEventListener('pointercancel', lookRelease);
+
+  let hp=100; function updateHealth(){ const f=$('healthfill'); f.style.width=Math.max(0,hp)+'%'; f.style.background = hp>60? 'linear-gradient(90deg,#29ff9a,#00c876)': hp>30? 'linear-gradient(90deg,#ffd966,#ff9f1a)' : 'linear-gradient(90deg,#ff6b6b,#ff2e2e)'; }
+  updateHealth();
+
+  /* Vehicles (GLTF fleet) */
+  const URLS = {
+    Sedan: [
+      'https://assets.babylonjs.com/meshes/car.glb',
+      'https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/car.glb'
+    ],
+    CarConcept: [
+      'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/CarConcept/glTF-Binary/CarConcept.glb',
+      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/CarConcept/glTF-Binary/CarConcept.glb'
+    ],
+    MilkTruck: [
+      'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/CesiumMilkTruck/glTF-Binary/CesiumMilkTruck.glb',
+      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMilkTruck/glTF-Binary/CesiumMilkTruck.glb'
+    ],
+    FireTruck: [
+      'https://raw.githubusercontent.com/Kenney-CCO/Kenney-CCO.glb/main/firetruck.glb',
+      'https://cdn.jsdelivr.net/gh/Kenney-CCO/Kenney-CCO.glb@main/firetruck.glb',
+      'https://raw.githubusercontent.com/MonuYadav05/Astrikos-gc-project/main/public/FireTruck.glb'
+    ]
+  };
+
+  function makeLabel(text, scale=1){ const cnv=document.createElement('canvas'); const ctx=cnv.getContext('2d'); const pad=28, fs=64, font=`${fs}px system-ui,Arial`; ctx.font=font; const w=Math.ceil(ctx.measureText(text).width); cnv.width=w+pad*2; cnv.height=fs+pad*2; ctx.font=font; ctx.fillStyle='#111827'; ctx.fillRect(0,0,cnv.width,cnv.height); ctx.strokeStyle='#1f2937'; ctx.lineWidth=4; ctx.strokeRect(2,2,cnv.width-4,cnv.height-4); ctx.fillStyle='#e5e7eb'; ctx.textBaseline='top'; ctx.fillText(text,pad,pad); const tex=new THREE.CanvasTexture(cnv); tex.colorSpace=THREE.SRGBColorSpace; const mat=new THREE.MeshBasicMaterial({ map:tex, transparent:true }); return new THREE.Mesh(new THREE.PlaneGeometry(cnv.width/240*scale, cnv.height/240*scale), mat); }
+  function centerXZ(root){ const box=new THREE.Box3().setFromObject(root); const c=new THREE.Vector3(); box.getCenter(c); root.position.x -= c.x; root.position.z -= c.z; }
+  function placeOnGround(root,y=0){ const box=new THREE.Box3().setFromObject(root); const dy=y - box.min.y; root.position.y += dy; }
+  function scaleToLength(root, L){ const box=new THREE.Box3().setFromObject(root); const size=new THREE.Vector3(); box.getSize(size); const len=Math.max(size.x,size.z)||1; const s=L/len; root.scale.multiplyScalar(s); root.updateMatrixWorld(true); }
+  function stripGroundMeshes(root){ const rootBox=new THREE.Box3().setFromObject(root); const rootSize=new THREE.Vector3(); rootBox.getSize(rootSize); const rootArea=rootSize.x*rootSize.z; const rm=[]; root.traverse(o=>{ if(!o.isMesh) return; const b=new THREE.Box3().setFromObject(o); const sz=new THREE.Vector3(); b.getSize(sz); const area=sz.x*sz.z; const flat=sz.y/Math.max(0.0001, Math.max(sz.x,sz.z)); const nearBottom=(b.min.y-rootBox.min.y)<=Math.max(0.05, rootSize.y*0.06); const byName=/ground|plane|cloth|board|shadow|table|grid|floor/i.test(o.name||'')||/shadow/i.test(o.material?.name||''); if(nearBottom && area>=rootArea*0.18 && (flat<0.12 || byName)){ rm.push(o); } }); for(const m of rm){ m.parent?.remove(m);} root.updateMatrixWorld(true); }
+
+  const vehicleCache=new Map();
+  async function robustLoad(urls){ for(const u of urls){ try{ const gltf=await gltfLoader.loadAsync(u); return gltf; }catch(_){ } } throw new Error('load fail'); }
+  async function getVehicle(key){ if(vehicleCache.has(key)) return vehicleCache.get(key); let urls=[]; if(key==='ambulance'||key==='police') urls=URLS.MilkTruck; else if(key==='fire') urls=URLS.FireTruck; else if(key==='sedan') urls=URLS.Sedan; else urls=URLS.CarConcept; try{ const gltf=await robustLoad(urls); const root=(gltf.scene||gltf.scenes?.[0]); stripGroundMeshes(root); vehicleCache.set(key, root); return root; }catch(_){ const g=new THREE.Mesh(new THREE.BoxGeometry(3.6,1.2,1.6), new THREE.MeshLambertMaterial({ color:0x8892a6 })); const group=new THREE.Group(); g.position.y=0.6; group.add(g); vehicleCache.set(key,group); return group; } }
+
+  function tintVehicle(root,hex){ const col=new THREE.Color(hex); root.traverse(o=>{ if(o.isMesh&&o.material&&o.material.color){ o.material.color.lerp(col,0.9); o.material.needsUpdate=true; } }); }
+  function addSideLabels(root,text){ const b=new THREE.Box3().setFromObject(root); const s=new THREE.Vector3(); b.getSize(s); const y=b.min.y+s.y*0.6; const midZ=(b.min.z+b.max.z)/2; const L=makeLabel(text,0.9); const R=makeLabel(text,0.9); L.rotation.y=Math.PI/2; R.rotation.y=-Math.PI/2; L.position.set(b.min.x-0.02,y,midZ); R.position.set(b.max.x+0.02,y,midZ); root.add(L,R); }
+
+  const parked=[]; const trafficCars=[];
+  async function spawnParkedEmergency(){
+    const hosp=POIS.find(p=>p.type==='hospital'); const pol=POIS.find(p=>p.type==='police'); const fire=POIS.find(p=>p.type==='fire');
+    if(hosp){ const v=(await getVehicle('ambulance')).clone(true); centerXZ(v); scaleToLength(v,3.8); placeOnGround(v,0); addSideLabels(v,'AMBULANCE'); tintVehicle(v,'#ef4444'); v.position.set(hosp.pos.x,0, hosp.pos.z + hosp.dims.d/2 + 6); scene.add(v); parked.push(v); }
+    if(pol){ const v=(await getVehicle('police')).clone(true); centerXZ(v); scaleToLength(v,3.8); placeOnGround(v,0); addSideLabels(v,'POLICE'); tintVehicle(v,'#1e3a8a'); v.position.set(pol.pos.x-4,0, pol.pos.z + pol.dims.d/2 + 6); scene.add(v); parked.push(v); }
+    if(fire){ const v=(await getVehicle('fire')).clone(true); centerXZ(v); scaleToLength(v,4.6); placeOnGround(v,0); addSideLabels(v,'FIRE'); tintVehicle(v,'#dc2626'); v.position.set(fire.pos.x+4,0, fire.pos.z + fire.dims.d/2 + 6); scene.add(v); parked.push(v); }
+  }
+
+  function setHeading(mesh,angle){ mesh.rotation.y = angle + Math.PI/2; }
+
+  async function spawnTraffic(n=14){ const pool=[await getVehicle('sedan'), await getVehicle('car')?.catch?.(()=>null) || await getVehicle('sedan')]; for(let i=0;i<n;i++){ const base=pool[i%pool.length]; const v=base.clone(true); centerXZ(v); scaleToLength(v,3.8); placeOnGround(v,0); const hue=Math.random(); tintVehicle(v,new THREE.Color().setHSL(hue,0.4,0.5).getHex()); const a=Math.random()*Math.PI*2; const x=Math.cos(a)*ringR, z=Math.sin(a)*ringR; v.position.set(x,0,z); setHeading(v,a); scene.add(v); trafficCars.push({mesh:v, angle:a, speed:0}); } }
+
+  await spawnParkedEmergency();
+  await spawnTraffic(16);
+
+  const ARM_SPEED_BASE = 4.8; const speedRun = 7.2; const trafficTarget = 3 * speedRun; // 3x run speed
+
+  const rayEnemies=new Map();
+  const modelCache=new Map();
+  const CHAR_PRESETS={ Soldier:['https://threejs.org/examples/models/gltf/Soldier.glb'], Xbot:['https://threejs.org/examples/models/gltf/Xbot.glb'] };
+  async function robustLoadChar(urls){ let last=null; for(const u of urls){ try{ return await gltfLoader.loadAsync(u); }catch(e){ last=e; } } throw last||new Error('Load fail'); }
+  function normalizeRoot(root){ const box=new THREE.Box3().setFromObject(root); const size=new THREE.Vector3(); box.getSize(size); const scale=1.7/(size.y||1); root.scale.setScalar(scale); return root; }
+  function makeCapsulePlaceholder(){ const g=new THREE.Group(); const body=new THREE.Mesh(new THREE.CapsuleGeometry(0.35,1.0,8,16), new THREE.MeshLambertMaterial({ color:0x556b8a })); g.add(body); return g; }
+  async function getCharacter(key){ if(modelCache.has(key)) return modelCache.get(key); try{ const gltf=await robustLoadChar(CHAR_PRESETS[key]||CHAR_PRESETS.Soldier); const baseRoot=(gltf.scene||gltf.scenes?.[0]||null); const root = baseRoot? normalizeRoot(baseRoot) : makeCapsulePlaceholder(); root.traverse?.(o=>{ if(o.isMesh){ o.castShadow=allowShadows; o.receiveShadow=allowShadows; o.material = new THREE.MeshLambertMaterial({ color:0x9fb1c6 }); }}); modelCache.set(key,{root,clips:gltf.animations||[]}); return modelCache.get(key); }catch(_){ const ph=makeCapsulePlaceholder(); modelCache.set(key,{root:ph,clips:[]}); return modelCache.get(key); } }
+  const enemies=new Map();
+  async function safeCloneSkinned(src){ try{ if(src && SkeletonUtils?.clone){ return SkeletonUtils.clone(src); } if(src?.clone){ return src.clone(true); } }catch(_){ } return makeCapsulePlaceholder(); }
+  async function spawnEnemy(x,z,key='Soldier'){ if(enemies.size>=12) return null; const base=await getCharacter(key); const clone=await safeCloneSkinned(base?.root); clone.traverse(o=>{ o.castShadow=allowShadows; }); clone.position.set(x,0,z); clone.userData.enemy=true; scene.add(clone); const r=0.35,h=1.6; const shape=new CANNON.Cylinder(r,r,h,8); const q=new CANNON.Quaternion(); q.setFromEuler(Math.PI/2,0,0); const body=new CANNON.Body({ mass:80, material:matEnemy, linearDamping:0.3, angularDamping:0.9 }); body.fixedRotation=true; body.addShape(shape,new CANNON.Vec3(0,h/2,0),q); body.position.set(x,0.9,z); world.addBody(body); const hpBar=makeBillboardBar(); scene.add(hpBar); enemies.set(clone.uuid,{root:clone, body, hp:120, dead:false, hpBar, cooldown:0}); return clone; }
+  function enemyRoots(){ return Array.from(enemies.values()).map(e=>e.root); }
+  function enemyTryFire(e, dt){ if(e.dead) return; e.cooldown -= dt; const toP = new THREE.Vector3(player.position.x-e.body.position.x, 0, player.position.z-e.body.position.z); const dist = toP.length(); if(dist>55) return; if(e.cooldown>0) return; const dir = new THREE.Vector3(player.position.x - e.body.position.x, (player.position.y+0.9) - (e.body.position.y+0.9), player.position.z - e.body.position.z).normalize(); dir.x += (Math.random()-0.5)*0.02; dir.y += (Math.random()-0.5)*0.01; dir.z += (Math.random()-0.5)*0.02; dir.normalize(); const origin = new THREE.Vector3(e.body.position.x, e.body.position.y+1.1, e.body.position.z); const to = origin.clone().addScaledVector(dir, 150); tracer(origin,to,0xff8888); e.cooldown = 0.2 + Math.random()*0.6; }
+
+  function makeBillboardBar(){ const c=document.createElement('canvas'); c.width=128; c.height=16; const t=new THREE.CanvasTexture(c); const m=new THREE.SpriteMaterial({ map:t, depthWrite:false }); const s=new THREE.Sprite(m); s.scale.set(0.9, 0.12, 1); s.userData.canvas=c; s.userData.tex=t; updateBillboardBar(s,1); return s; }
+  function updateBillboardBar(s,ratio){ const c=s.userData.canvas; const x=c.getContext('2d'); x.clearRect(0,0,c.width,c.height); x.fillStyle='rgba(0,0,0,0.6)'; x.fillRect(0,0,c.width,c.height); x.fillStyle= ratio>0.6? '#29ff9a' : ratio>0.3? '#ffd966':'#ff4d4f'; x.fillRect(2,2,(c.width-4)*Math.max(0,Math.min(1,ratio)), c.height-4); s.userData.tex.needsUpdate=true; }
+
+  function startBR(){ for(let i=0;i<8;i++){ const a=(i/8)*Math.PI*2; const r=ringR*0.6; spawnEnemy(Math.cos(a)*r, Math.sin(a)*r, ['Soldier','Xbot'][i%2]); } }
+  startBR();
+
+  let inputMode='A';
+  const modeA=$('modeA'), modeB=$('modeB');
+  function applyMode(){ const isA = inputMode==='A'; shootPad.style.display = isA? 'block':'none'; $('reloadMini').style.display = isA? 'block':'none'; aimPad.style.display = isA? 'none':'block'; $('zoomBox').style.display = (currentKey==='AK47' && isA)? 'block':'none'; modeA.classList.toggle('active', isA); modeB.classList.toggle('active', !isA); }
+  modeA.addEventListener('click',()=>{ inputMode='A'; applyMode(); });
+  modeB.addEventListener('click',()=>{ inputMode='B'; applyMode(); });
+  applyMode();
+
+  const zoomSlider=$('zoomSlider');
+  function updateZoomUI(){ const box=$('zoomBox'); if(currentKey==='AK47' && inputMode==='A'){ box.style.display='block'; } else { box.style.display='none'; } }
+  zoomSlider.addEventListener('input',()=>{ const v=parseFloat(zoomSlider.value||'1'); camera.fov = THREE.MathUtils.clamp(70 / v, 18, 70); camera.updateProjectionMatrix(); });
+
+  let climbing=false, ladderIdx=-1; const climbBtn=$('climbBtn');
+  function nearestLadder(){ let best=-1, bd=1e9; for(let i=0;i<ladders.length;i++){ const L=ladders[i]; const dx=player.position.x-L.x; const dz=player.position.z-L.z; const d=Math.hypot(dx,dz); if(d<bd){ bd=d; best=i; } } return {idx:best, dist:bd}; }
+  function setClimbUI(){ const n=nearestLadder(); if(!climbing && n.dist<1.2){ climbBtn.style.display='block'; climbBtn.textContent='⬆ Use/Climb Ladder'; } else if(climbing){ climbBtn.style.display='block'; climbBtn.textContent='⬇ Leave Ladder'; } else { climbBtn.style.display='none'; } }
+  climbBtn.addEventListener('click', ()=>{ if(climbing){ climbing=false; return; } const n=nearestLadder(); if(n.dist<1.2){ climbing=true; ladderIdx=n.idx; const L=ladders[ladderIdx]; player.velocity.x=player.velocity.z=0; player.position.x=L.x; player.position.z=L.z; } });
+  function doClimb(moveZ,dt){ const L=ladders[ladderIdx]; if(!L){ climbing=false; return; } const speed=2.6; if(moveZ>0.05) player.position.y = Math.min(L.y1+0.5, player.position.y + speed*dt); else if(moveZ<-0.05) player.position.y = Math.max(L.y0+0.4, player.position.y - speed*dt); if(Math.hypot(player.position.x-L.x, player.position.z-L.z)>0.9){ climbing=false; } }
+
+  const radar=$('radar'), rctx=radar.getContext('2d'); function resizeRadar(){ radar.width=radar.clientWidth; radar.height=radar.clientHeight; } resizeRadar(); addEventListener('resize', resizeRadar);
+  function drawRadar(){ const w=radar.width,h=radar.height; rctx.clearRect(0,0,w,h); rctx.fillStyle='rgba(20,24,38,0.9)'; rctx.fillRect(0,0,w,h); rctx.strokeStyle='rgba(255,255,255,0.2)'; rctx.strokeRect(0,0,w,h); const cx=w/2, cy=h/2; rctx.fillStyle='#7da2ff'; rctx.beginPath(); rctx.arc(cx,cy,3,0,Math.PI*2); rctx.fill(); for(const p of POIS){ const dx=p.pos.x-player.position.x, dz=p.pos.z-player.position.z; const sc=0.08; const x=cx+dx*sc, y=cy+dz*sc; if(x<0||y<0||x>w||y>h) continue; rctx.font='14px system-ui'; rctx.fillText(p.label,x-6,y-6); } }
+  const mapOverlay=$('mapOverlay'), mapCanvas=$('mapCanvas'), mctx=mapCanvas.getContext('2d'); function resizeMap(){ mapCanvas.width=mapCanvas.clientWidth; mapCanvas.height=mapCanvas.clientHeight; } resizeMap(); addEventListener('resize', resizeMap);
+  function drawMap(){ const w=mapCanvas.width,h=mapCanvas.height; mctx.fillStyle='#0b0f1a'; mctx.fillRect(0,0,w,h); mctx.strokeStyle='#3b4252'; mctx.lineWidth=2; for(let i=0;i<=BLOCKS_X;i++){ const x=(i/BLOCKS_X)*w; mctx.beginPath(); mctx.moveTo(x,0); mctx.lineTo(x,h); mctx.stroke(); } for(let i=0;i<=BLOCKS_Z;i++){ const y=(i/BLOCKS_Z)*h; mctx.beginPath(); mctx.moveTo(0,y); mctx.lineTo(w,y); mctx.stroke(); } mctx.font='16px 700 system-ui'; mctx.fillStyle='#e5e7eb'; for(const p of POIS){ const ux=(p.pos.x - (-BLOCKS_X*CELL/2)) / (BLOCKS_X*CELL); const uz=(p.pos.z - (-BLOCKS_Z*CELL/2)) / (BLOCKS_Z*CELL); const x=ux*w, y=uz*h; mctx.fillText(p.label, x-8, y-8); } mctx.fillStyle='#7da2ff'; const px=(player.position.x - (-BLOCKS_X*CELL/2)) / (BLOCKS_X*CELL)*w; const py=(player.position.z - (-BLOCKS_Z*CELL/2)) / (BLOCKS_Z*CELL)*h; mctx.beginPath(); mctx.arc(px,py,6,0,Math.PI*2); mctx.fill(); }
+  $('radarBox').addEventListener('click', ()=>{ mapOverlay.style.display='flex'; drawMap(); });
+  $('mapClose').addEventListener('click', ()=>{ mapOverlay.style.display='none'; });
+
+  let waypoint=null;
+  mapCanvas.addEventListener('click', (e)=>{ const r=mapCanvas.getBoundingClientRect(); const x=e.clientX-r.left, y=e.clientY-r.top; const ux=x/mapCanvas.width, uz=y/mapCanvas.height; const wx = -BLOCKS_X*CELL/2 + ux*(BLOCKS_X*CELL); const wz = -BLOCKS_Z*CELL/2 + uz*(BLOCKS_Z*CELL); waypoint=new THREE.Vector3(wx,0,wz); mapOverlay.style.display='none'; });
+
+  let last=performance.now(); let frameCount=0,fpsTimer=0; let fireCd=0; const mini=$('mini'); updateAmmoHUD();
+  function loop(now){
+    const dt=Math.min((now-last)/1000,0.05); last=now;
+    frameCount++; fpsTimer+=dt; if(fpsTimer>=0.5){ const fps=(frameCount/fpsTimer)|0; mini.textContent='fps: '+fps; if(fps<88 && dprScale>0.6){ dprScale=Math.max(0.6,dprScale-0.06); fit(); } else if(fps>110 && dprScale<1.0){ dprScale=Math.min(1.0,dprScale+0.04); fit(); } frameCount=0; fpsTimer=0; }
+
+    if(inputMode==='A'){ const k = Math.min(1, dt*AIM_SMOOTH_A); const ax = lookAccumX * LOOK_SENS_A; const ay = lookAccumY * LOOK_SENS_A; lookAccumX=0; lookAccumY=0; aimSmoothX += (ax - aimSmoothX)*k; aimSmoothY += (ay - aimSmoothY)*k; yaw   -= aimSmoothX * AIM_RATE_A * dt; pitch -= aimSmoothY * AIM_RATE_A * dt; clampPitch(); }
+
+    const {from,to}=fireRay(new THREE.Vector2(0,0));
+    const hitsEnemy = raycaster.intersectObjects(enemyRoots(), true);
+    const onEnemy = hitsEnemy.length>0;
+    crosshairEl.style.setProperty('--aimColor', onEnemy? '#2fe56b' : '#ff3c3c');
+    aimDotMat.color.set(onEnemy? 0x2fe56b : 0xff3c3c);
+
+    const move={x:0,z:0}; if(keys.has('KeyW')) move.z+=1; if(keys.has('KeyS')) move.z-=1; if(keys.has('KeyA')) move.x-=1; if(keys.has('KeyD')) move.x+=1; move.x += mv.vx; move.z += mv.vz; let l=Math.hypot(move.x,move.z); if(l>1){ move.x/=l; move.z/=l; }
+    const speedBase = ARM_SPEED_BASE; const speedRun = 7.2;
+    if(!climbing){ const forward=new THREE.Vector3(Math.sin(yaw),0,Math.cos(yaw)); const right=new THREE.Vector3(Math.cos(yaw),0,-Math.sin(yaw)); const sprint = (l>0.9 ? speedRun : speedBase); const vx=forward.x*move.z + right.x*move.x; const vz=forward.z*move.z + right.z*move.x; player.velocity.x=vx*sprint; player.velocity.z=vz*sprint; player.wakeUp(); camFollow(player.position,1.0); } else { player.velocity.x=player.velocity.z=0; doClimb(move.z, dt); camFollow(player.position,1.0); }
+
+    setClimbUI();
+
+    if(fireHeld){ const per=60.0/(currentStats.rpm); fireCd-=dt; while(fireCd<=0){ doShot(); fireCd+=per; } }
+
+    enemies.forEach((e)=>{ if(e.dead) return; const toP = new THREE.Vector3(player.position.x-e.body.position.x, 0, player.position.z-e.body.position.z); const d = toP.length(); if(d>0.01){ toP.normalize(); const sp=d>12?2.4:1.6; e.body.velocity.x = toP.x*sp; e.body.velocity.z = toP.z*sp; } enemyTryFire(e, dt); e.root.position.set(e.body.position.x, 0, e.body.position.z); e.hpBar.position.set(e.body.position.x, 2.2, e.body.position.z); e.hpBar.lookAt(camera.position); });
+
+    // traffic move: v = 3x run speed
+    for(const c of trafficCars){ if(!c.speed){ c.speed = trafficTarget*(0.8+Math.random()*0.4); } const radPerSec = c.speed / ringR; c.angle = (c.angle + radPerSec*dt)%(Math.PI*2); const nx=Math.cos(c.angle)*ringR, nz=Math.sin(c.angle)*ringR; // obey red
+      let blocked=false; for(const tl of trafficLights){ const d=Math.hypot(nx-tl.pos.x, nz-tl.pos.z); if(d<6 && tl.state!=='green'){ blocked=true; break; } }
+      if(!blocked){ c.mesh.position.set(nx,0,nz); setHeading(c.mesh, c.angle); }
+    }
+    trafficLights.forEach(tl=>{ tl.timer+=dt; if(tl.timer>6){ tl.timer=0; tl.state = tl.state==='green'?'yellow': tl.state==='yellow'?'red':'green'; tl.lamps.Lg.material.color.set(tl.state==='green'?0x2ecc71:0x222222); tl.lamps.Ly.material.color.set(tl.state==='yellow'?0xf1c40f:0x222222); tl.lamps.Lr.material.color.set(tl.state==='red'?0xe74c3c:0x222222); } });
+
+    drawRadar();
+    if(waypoint){ const guide=new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(player.position.x,0.1,player.position.z), new THREE.Vector3(waypoint.x,0.1,waypoint.z)]); const mat=new THREE.LineDashedMaterial({ color:0x66ccff, dashSize:2, gapSize:1 }); const ln=new THREE.Line(guide,mat); ln.computeLineDistances(); scene.add(ln); setTimeout(()=>{ scene.remove(ln); guide.dispose(); mat.dispose(); }, 120); }
+
+    world.step(1/90, dt, 3);
+    updateTracers(dt);
+
+    try{ renderer.render(scene,camera); }catch(err){ }
+    requestAnimationFrame(loop);
+  }
+  requestAnimationFrame(loop);
+
+  renderer.getContext().canvas.addEventListener('webglcontextlost', (e)=>{ e.preventDefault(); });
+  renderer.getContext().canvas.addEventListener('webglcontextrestored', ()=>{ });
+
+  setTimeout(()=>{
+    console.assert(!!document.getElementById('shootPad'), 'shootPad exists');
+    console.assert(typeof BLOCKS_X==='number' && typeof BLOCKS_Z==='number', 'grid dims defined');
+    console.assert(ARMORY.length>=6 && FIRE_MODES.size===ARMORY.length, 'armory + firemodes init');
+    console.assert(getComputedStyle(document.getElementById('crosshair')).getPropertyValue('--aimColor').trim()!=='', 'crosshair color var');
+    console.assert(typeof GLTFLoader==='function', 'GLTFLoader OK');
+  }, 800);
+})();
+</script>
+</body>
+</html>

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -48,6 +48,8 @@ import PoolRoyale from './pages/Games/PoolRoyale.jsx';
 import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
 import Snooker from './pages/Games/Snooker.jsx';
 import SnookerLobby from './pages/Games/SnookerLobby.jsx';
+import Tirana2040 from './pages/Games/Tirana2040.jsx';
+import Tirana2040Lobby from './pages/Games/Tirana2040Lobby.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -129,6 +131,8 @@ export default function App() {
             <Route path="/games/pollroyale" element={<PoolRoyale />} />
             <Route path="/games/snooker/lobby" element={<SnookerLobby />} />
             <Route path="/games/snooker" element={<Snooker />} />
+            <Route path="/games/tirana2040/lobby" element={<Tirana2040Lobby />} />
+            <Route path="/games/tirana2040" element={<Tirana2040 />} />
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />
             <Route path="/tasks" element={<Tasks />} />

--- a/webapp/src/components/GamesHallway.jsx
+++ b/webapp/src/components/GamesHallway.jsx
@@ -16,7 +16,8 @@ const fallbackGameNames = [
   'Texas Holdem',
   'Domino Royal 3D',
   'Blackjack Multi',
-  'Goal Rush'
+  'Goal Rush',
+  'Tirana 2040'
 ];
 
 function useBodyScrollLock(isLocked) {

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -20,7 +20,8 @@ const GAME_NAME_MAP = {
   domino: 'Domino Royal 3D',
   blackjack: 'Black Jack Multiplayer',
   freekick: 'Free Kick',
-  murlan: 'Murlan Royale'
+  murlan: 'Murlan Royale',
+  tirana2040: 'Tirana 2040'
 };
 
 function getGameName(slug = '') {

--- a/webapp/src/pages/GameTransactions.jsx
+++ b/webapp/src/pages/GameTransactions.jsx
@@ -13,6 +13,7 @@ const GAME_NAME_MAP = {
   blackjack: 'Black Jack Multiplayer',
   freekick: 'Free Kick',
   murlan: 'Murlan Royale',
+  tirana2040: 'Tirana 2040',
 };
 
 function getGameName(slug = '') {

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -11,6 +11,7 @@ const gamesCatalog = [
   { name: 'Pool Royale', route: '/games/pollroyale/lobby' },
   { name: '3D Snooker', route: '/games/snooker/lobby' },
   { name: 'Goal Rush', route: '/games/goalrush/lobby' },
+  { name: 'Tirana 2040', route: '/games/tirana2040/lobby' },
   { name: 'Air Hockey', route: '/games/airhockey/lobby' },
   { name: 'Table Tennis', route: '/games/tabletennis/lobby' },
   { name: 'Free Kick', route: '/games/freekick/lobby' },

--- a/webapp/src/pages/Games/Tirana2040.jsx
+++ b/webapp/src/pages/Games/Tirana2040.jsx
@@ -1,0 +1,18 @@
+import { useLocation } from 'react-router-dom';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+
+export default function Tirana2040() {
+  useTelegramBackButton();
+  const { search } = useLocation();
+
+  return (
+    <div className="relative w-full h-[100dvh]">
+      <iframe
+        src={`/tirana-2040.html${search}`}
+        title="Tirana 2040"
+        className="w-full h-full border-0"
+        allow="accelerometer; gyroscope; fullscreen"
+      />
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/Tirana2040Lobby.jsx
+++ b/webapp/src/pages/Games/Tirana2040Lobby.jsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import {
+  ensureAccountId,
+  getTelegramId,
+  getTelegramPhotoUrl,
+  getTelegramFirstName,
+} from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+
+const PLAYER_COUNTS = [10, 20, 30];
+
+export default function Tirana2040Lobby() {
+  const navigate = useNavigate();
+  const { search } = useLocation();
+  useTelegramBackButton();
+
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [players, setPlayers] = useState(10);
+  const [avatar, setAvatar] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  const startGame = async () => {
+    if (loading) return;
+    setLoading(true);
+    let tgId;
+    let accountId;
+
+    try {
+      accountId = await ensureAccountId();
+      const balRes = await getAccountBalance(accountId);
+      if ((balRes.balance || 0) < stake.amount) {
+        alert('Insufficient balance');
+        setLoading(false);
+        return;
+      }
+      tgId = getTelegramId();
+      await addTransaction(tgId, -stake.amount, 'stake', {
+        game: 'tirana2040',
+        players,
+        accountId,
+      });
+    } catch (err) {
+      // failure to set up staking should not lock the UI forever
+      alert('Unable to start game. Please try again.');
+      setLoading(false);
+      return;
+    }
+
+    const params = new URLSearchParams(search);
+    const initData = window.Telegram?.WebApp?.initData;
+    params.set('mode', 'ai');
+    params.set('players', players.toString());
+    if (stake.token) params.set('token', stake.token);
+    if (stake.amount) params.set('amount', stake.amount.toString());
+    if (avatar) params.set('avatar', avatar);
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    const name = getTelegramFirstName();
+    if (name) params.set('name', name);
+    if (initData) params.set('init', encodeURIComponent(initData));
+
+    navigate(`/games/tirana2040?${params.toString()}`);
+    setLoading(false);
+  };
+
+  return (
+    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
+      <h2 className="text-xl font-bold text-center">Tirana 2040 Lobby</h2>
+      <p className="text-sm text-subtext text-center">
+        Last agent standing wins the pot. Choose your stake and the size of the AI survival arena.
+      </p>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Opponents</h3>
+        <div className="flex gap-2">
+          {PLAYER_COUNTS.map((count) => (
+            <button
+              key={count}
+              onClick={() => setPlayers(count)}
+              className={`lobby-tile ${players === count ? 'lobby-selected' : ''}`}
+            >
+              {count} AI
+            </button>
+          ))}
+        </div>
+        <p className="text-xs text-subtext">
+          Matches currently run against AI squads. Human multiplayer will arrive in a future update.
+        </p>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Stake</h3>
+        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+      </div>
+      <button
+        onClick={startGame}
+        disabled={loading}
+        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed text-background rounded"
+      >
+        {loading ? 'STARTING…' : 'START'}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add the Tirana 2040 standalone WebGL experience and lobby page
- wire the new game into the routing, games catalog, and hallway
- extend transaction mappings so Tirana 2040 stakes display correctly

## Testing
- npm run lint *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6915650259ac8325ab2ce03e6c41599e)