### PR TITLE
Update Tirana 2040 HUD and environment

### DIFF
--- a/webapp/public/tirana-2040.html
+++ b/webapp/public/tirana-2040.html
@@ -17,15 +17,14 @@
   #wrap{position:fixed;inset:0}
   canvas{display:block;width:100%;height:100%;touch-action:none;user-select:none}
   .hud{position:fixed;inset:0;pointer-events:none}
-  .row{position:absolute;left:var(--hud-gap);right:var(--hud-gap);display:flex;gap:10px;align-items:center}
+  .row{position:absolute;left:var(--hud-gap);right:var(--hud-gap);display:flex;gap:10px;align-items:center;z-index:15}
   .top{top:var(--hud-gap);justify-content:space-between}
-  .bottom{bottom:var(--hud-gap);justify-content:space-between}
+  .bottom{bottom:var(--hud-gap);justify-content:space-between;align-items:flex-end}
   .chip{background:rgba(0,0,0,.32);color:#fff;border-radius:999px;padding:6px 12px;font-size:clamp(11px,2.9vw,14px);backdrop-filter:blur(var(--hud-blur));pointer-events:auto}
   .btn{background:rgba(0,0,0,.35);color:#fff;border:0;border-radius:14px;padding:8px 14px;font-size:clamp(11px,3vw,14px);cursor:pointer;pointer-events:auto;backdrop-filter:blur(var(--hud-blur));transition:transform .15s ease}
   .btn:active{transform:translateY(1px)}
   .btn[disabled]{opacity:.45;cursor:not-allowed}
 
-  #armory{z-index:10}
   .joy{position:absolute;width:var(--joy-size);height:var(--joy-size);border-radius:50%;background:rgba(0,0,0,.1);border:1px solid rgba(0,0,0,.25);opacity:.95;pointer-events:auto;touch-action:none;display:block;z-index:20;backdrop-filter:blur(var(--hud-blur))}
   .joy .knob{position:absolute;left:50%;top:50%;width:var(--joy-knob);height:var(--joy-knob);transform:translate(-50%,-50%);border-radius:50%;background:rgba(0,0,0,.28);border:1px solid rgba(0,0,0,.35)}
   #joyMove{left:var(--hud-gap);bottom:var(--pad-offset)}
@@ -36,29 +35,25 @@
   .padStack .joy .knob{width:var(--joy-knob);height:var(--joy-knob)}
   #shootPad .knob{background:radial-gradient(circle at 50% 50%, rgba(255,70,70,1) 0 34%, rgba(0,0,0,.32) 36%), rgba(0,0,0,.25);box-shadow:0 10px 24px rgba(0,0,0,.28)}
   #shootPad .knob::after{content:'SHOOT';position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);color:#fff;font-weight:900;font-size:clamp(13px,3.4vw,18px);letter-spacing:.6px;text-shadow:0 1px 3px rgba(0,0,0,.6);}
-  #aimPad{display:none}
-  #aimPad .knob{background:rgba(0,0,0,.26)}
   #reloadMini{width:clamp(84px,21vw,118px);height:clamp(84px,21vw,118px);border-radius:50%;border:1px solid rgba(0,0,0,.32);background:radial-gradient(circle at 50% 50%, rgba(255,86,86,1) 0 36%, rgba(0,0,0,.28) 40%), rgba(0,0,0,.35);color:#fff;font-size:clamp(12px,3.2vw,16px);font-weight:900;letter-spacing:.5px;pointer-events:auto;box-shadow:0 10px 24px rgba(0,0,0,.3);display:flex;align-items:center;justify-content:center;text-transform:uppercase}
   #crosshair{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:30px;height:30px;pointer-events:none;z-index:50;display:block}
   #crosshair:before,#crosshair:after{content:"";position:absolute;left:50%;top:50%;background:var(--aimColor,#ff3c3c);box-shadow:0 0 0 2px rgba(255,255,255,0.9) inset, 0 0 6px rgba(0,0,0,.35)}
   #crosshair:before{width:24px;height:3px;transform:translate(-50%,-50%);opacity:.98}
   #crosshair:after{width:3px;height:24px;transform:translate(-50%,-50%);opacity:.98}
-  #ammo{position:absolute;right:var(--hud-gap);top:calc(var(--hud-gap) + 44px);color:#fff;font-weight:700;background:rgba(0,0,0,.38);padding:8px 14px;border-radius:999px;pointer-events:auto;font-size:clamp(12px,3.1vw,16px);backdrop-filter:blur(var(--hud-blur))}
+  #ammo{color:#fff;font-weight:700;background:rgba(0,0,0,.42);padding:8px 14px;border-radius:14px 14px 4px 4px;pointer-events:auto;font-size:clamp(11px,2.8vw,14px);backdrop-filter:blur(var(--hud-blur));min-width:130px;text-align:center;align-self:flex-end}
   #healthbar{position:absolute;left:50%;top:calc(var(--hud-gap) + 44px);width:clamp(160px,60vw,320px);height:14px;background:rgba(0,0,0,.22);border-radius:999px;overflow:hidden;transform:translateX(-50%)}
   #healthfill{width:100%;height:100%;background:linear-gradient(90deg,#29ff9a,#00c876)}
-  #armory{position:absolute;left:var(--hud-gap);right:var(--hud-gap);bottom:calc(var(--pad-offset) + var(--joy-size) + clamp(18px,4vh,56px));display:flex;gap:10px;overflow:auto;padding:10px;border-radius:16px;background:rgba(0,0,0,.28);backdrop-filter:blur(var(--hud-blur));pointer-events:auto}
-  .armBtn{position:relative;flex:0 0 auto;min-width:132px;max-width:168px;padding:8px;border-radius:12px;border:1px solid rgba(255,255,255,.16);background:rgba(0,0,0,.32);color:#e6eefc;font-weight:700;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:6px}
-  .armBtn img{width:120px;height:70px;object-fit:contain;display:block;filter:drop-shadow(0 1px 2px rgba(0,0,0,.35))}
-  .armBtn span{font-size:12px;opacity:.95}
-  .armBtn.active{outline:2px solid #ffd966;background:rgba(17,23,42,.55)}
-  .modeToggle{position:absolute;right:6px;top:6px;padding:3px 6px;border-radius:10px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.45);color:#fff;font-size:10px;cursor:pointer}
+  .armoryWrap{flex:1;display:flex;justify-content:flex-start;overflow:visible}
+  #armory{display:flex;gap:8px;overflow-x:auto;padding:8px 10px;border-radius:14px;background:rgba(0,0,0,.28);backdrop-filter:blur(var(--hud-blur));pointer-events:auto;max-width:100%;box-sizing:border-box}
+  .armBtn{position:relative;flex:0 0 auto;width:clamp(70px,14vw,96px);padding:6px;border-radius:12px;border:1px solid rgba(255,255,255,.16);background:rgba(0,0,0,.32);color:#e6eefc;font-weight:700;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:4px;transition:transform .2s ease}
+  .armBtn img{width:100%;aspect-ratio:4/3;object-fit:contain;display:block;filter:drop-shadow(0 1px 2px rgba(0,0,0,.35))}
+  .armBtn span{font-size:11px;opacity:.95;text-align:center}
+  .armBtn.active{outline:2px solid #ffd966;background:rgba(17,23,42,.55);transform:translateY(-4px)}
+  .modeToggle{position:absolute;right:6px;top:6px;padding:2px 5px;border-radius:9px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.45);color:#fff;font-size:9px;cursor:pointer}
   #mini{position:absolute;left:50%;bottom:calc(var(--pad-offset) + var(--joy-size) + clamp(12px,3vh,40px));transform:translateX(-50%);color:#0b1324;background:rgba(255,255,255,.75);padding:4px 10px;border-radius:999px;font-size:11px;pointer-events:auto}
-  #modeBox{position:absolute;right:var(--hud-gap);top:calc(var(--hud-gap) + 88px);display:flex;gap:6px;pointer-events:auto}
-  .modeBtn{padding:6px 12px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.35);color:#fff;font-size:clamp(11px,3vw,13px);cursor:pointer}
-  .modeBtn.active{background:#2a7fff}
   #climbBtn{position:absolute;left:50%;bottom:calc(var(--pad-offset) + var(--joy-size) + clamp(60px,8vh,120px));transform:translateX(-50%);padding:9px 16px;border-radius:14px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.7);color:#fff;font-size:clamp(12px,3.1vw,15px);pointer-events:auto;display:none}
-  #zoomBox{position:absolute;top:50%;right:calc(var(--hud-gap) - 12px);display:none;pointer-events:auto;z-index:25;transform:translateY(-50%)}
-  #zoomSlider{appearance:none;width:clamp(280px,60vh,360px);height:64px;transform:rotate(-90deg);background:rgba(0,0,0,.4);border-radius:999px;outline:none;border:1px solid rgba(255,255,255,.2)}
+  #zoomBox{display:none;pointer-events:auto;align-self:flex-end;margin-right:-4px}
+  #zoomSlider{appearance:none;width:clamp(240px,48vh,320px);height:56px;transform:rotate(-90deg);background:rgba(0,0,0,.4);border-radius:999px;outline:none;border:1px solid rgba(255,255,255,.2)}
   #zoomSlider::-webkit-slider-thumb{appearance:none;width:46px;height:46px;border-radius:50%;background:#ffd966;border:1px solid rgba(0,0,0,.4)}
   #zoomSlider::-moz-range-thumb{width:46px;height:46px;border-radius:50%;background:#ffd966;border:1px solid rgba(0,0,0,.4)}
   #radarBox{position:absolute;left:var(--hud-gap);top:calc(var(--hud-gap) + 82px);width:clamp(118px,28vw,160px);height:clamp(118px,28vw,160px);border-radius:18px;background:rgba(0,0,0,.28);border:1px solid rgba(0,0,0,.35);overflow:hidden;pointer-events:auto;backdrop-filter:blur(var(--hud-blur))}
@@ -80,29 +75,20 @@
       <div id="br" class="chip">Entrants: 10 • AI</div>
     </div>
     <div style="display:flex;gap:6px;align-items:center">
-      <div id="modeBox">
-        <button id="modeA" class="modeBtn active">A: Drag Aim</button>
-        <button id="modeB" class="modeBtn">B: Dual Sticks</button>
-      </div>
       <button id="muteBtn" class="btn">🔊</button>
     </div>
   </div>
 
   <div id="healthbar"><div id="healthfill"></div></div>
-  <div id="ammo">—</div>
   <div id="crosshair"></div>
 
   <div id="joyMove" class="joy"><div class="knob"></div></div>
   <div id="padContainer" class="padStack">
-    <button id="reloadMini">RELOAD</button>
     <div id="shootPad" class="joy"><div class="knob"></div></div>
-    <div id="aimPad" class="joy"><div class="knob"></div></div>
+    <div id="ammo">—</div>
+    <div id="zoomBox"><input id="zoomSlider" type="range" min="1" max="3" step="0.01" value="1" /></div>
+    <button id="reloadMini">RELOAD</button>
   </div>
-
-  <div id="zoomBox"><input id="zoomSlider" type="range" min="1" max="3" step="0.01" value="1" /></div>
-
-  <div id="armory"></div>
-
   <div id="radarBox"><canvas id="radar"></canvas></div>
   <div id="mapOverlay">
     <canvas id="mapCanvas"></canvas>
@@ -116,7 +102,9 @@
   <div id="result"></div>
 
   <div class="row bottom">
-    <div class="chip">Move = Left stick/WASD · Aim = drag screen (A) or right stick (B) · Tap red circle = Shoot · Zoom slider for AK47</div>
+    <div class="armoryWrap">
+      <div id="armory"></div>
+    </div>
     <button id="resetBtn" class="btn">Reset</button>
   </div>
 </div>
@@ -264,10 +252,20 @@ document.title = 'Tirana 2040 • Last Man Standing';
     lines.rotation.x=-Math.PI/2; lines.position.set(cx,0.022,cz); city.add(lines);
     const fenceH=3.2, fenceGap=0.4; const fMat=new THREE.MeshStandardMaterial({ map:fenceMat(), transparent:true, opacity:1.0, roughness:0.9, metalness:0.0, color:0xffffff });
     const fx=courtW/2+apron-fenceGap, fz=courtL/2+apron-fenceGap;
-    const mk=(w,h,rx,rz)=>{ const m=new THREE.Mesh(new THREE.PlaneGeometry(w,h),fMat); m.position.set(cx+rx, h/2, cz+rz); city.add(m); };
-    mk(courtW+apron*2, fenceH, 0, -fz); mk(courtW+apron*2, fenceH, 0, fz);
-    const s1=new THREE.Mesh(new THREE.PlaneGeometry(courtL+apron*2, fenceH), fMat); s1.rotation.y=Math.PI/2; s1.position.set(cx-fx, fenceH/2, cz); city.add(s1);
-    const s2=s1.clone(); s2.position.x=cx+fx; city.add(s2);
+    const totalW=courtW+apron*2, gateW=3.2, segW=(totalW-gateW)/2;
+    const addFencePanel=(w,h,rx,rz,rotY=0)=>{ const panel=new THREE.Mesh(new THREE.PlaneGeometry(w,h),fMat); panel.position.set(cx+rx, h/2, cz+rz); panel.rotation.y=rotY; city.add(panel); };
+    addFencePanel(segW, fenceH, -(gateW/2 + segW/2), fz);
+    addFencePanel(segW, fenceH,  gateW/2 + segW/2, fz);
+    addFencePanel(segW, fenceH, -(gateW/2 + segW/2), -fz);
+    addFencePanel(segW, fenceH,  gateW/2 + segW/2, -fz);
+    const sideLen=courtL+apron*2;
+    const sidePanel=new THREE.Mesh(new THREE.PlaneGeometry(sideLen, fenceH), fMat);
+    sidePanel.rotation.y=Math.PI/2; sidePanel.position.set(cx-fx, fenceH/2, cz); city.add(sidePanel);
+    const sidePanelB=sidePanel.clone(); sidePanelB.position.x=cx+fx; city.add(sidePanelB);
+    const gateMat=new THREE.MeshBasicMaterial({ color:0xd1d5db });
+    const gatePadW=gateW*0.6, gatePad=new THREE.Mesh(new THREE.PlaneGeometry(gatePadW, 1.2), gateMat);
+    gatePad.rotation.x=-Math.PI/2; gatePad.position.set(cx,0.03,cz+fz-0.6); city.add(gatePad);
+    const gatePadBack=gatePad.clone(); gatePadBack.position.z=cz-fz+0.6; city.add(gatePadBack);
     treesPerimeter(cx,cz);
   }
 
@@ -276,20 +274,30 @@ document.title = 'Tirana 2040 • Last Man Standing';
     const wm=28, hm=15, apron=2.6;
     const base=new THREE.Mesh(new THREE.PlaneGeometry(wm+apron*2,hm+apron*2), new THREE.MeshStandardMaterial({ map:redTrackTex, roughness:0.96, metalness:0.0 }));
     base.rotation.x=-Math.PI/2; base.position.set(cx,0.02,cz); city.add(base);
-    const dark=new THREE.Mesh(new THREE.PlaneGeometry(wm,hm), new THREE.MeshBasicMaterial({ color:0x1e2329 }));
-    dark.rotation.x=-Math.PI/2; dark.position.set(cx,0.021,cz); city.add(dark);
+    const rubberTex=trackTex(); rubberTex.repeat.set(3,2); rubberTex.needsUpdate=true;
+    const surface=new THREE.Mesh(new THREE.PlaneGeometry(wm,hm), new THREE.MeshStandardMaterial({ map:rubberTex, roughness:0.96, metalness:0.0 }));
+    surface.rotation.x=-Math.PI/2; surface.position.set(cx,0.021,cz); city.add(surface);
     const lines=new THREE.Mesh(new THREE.PlaneGeometry(wm,hm), new THREE.MeshBasicMaterial({ map:basketLinesTex(wm,hm), transparent:true, opacity:0.98 }));
     lines.rotation.x=-Math.PI/2; lines.position.set(cx,0.022,cz); city.add(lines);
     const hoopMat=new THREE.MeshBasicMaterial({ color:0xffffff }); const postMat=new THREE.MeshBasicMaterial({ color:0xff3c3c });
-    const makeHoop=(sx)=>{ const g=new THREE.Group(); const board=new THREE.Mesh(new THREE.BoxGeometry(1.8,1.1,0.08), hoopMat); const rim=new THREE.Mesh(new THREE.TorusGeometry(0.45,0.06,8,24), postMat); rim.rotation.x=Math.PI/2; board.position.y=2.9; rim.position.set(0,2.3,0.3); const post=new THREE.Mesh(new THREE.CylinderGeometry(0.06,0.06,2.6,16), postMat); post.position.y=1.3; g.add(post,board,rim); g.position.set(cx+sx*(wm*0.5-1.2),0,cz); city.add(g); };
+    const makeHoop=(sx)=>{ const g=new THREE.Group(); const board=new THREE.Mesh(new THREE.BoxGeometry(1.8,1.1,0.08), hoopMat); board.position.set(0,2.9,-0.25); const rim=new THREE.Mesh(new THREE.TorusGeometry(0.45,0.06,12,32), postMat); rim.rotation.x=Math.PI/2; rim.position.set(0,2.3,0.42); const post=new THREE.Mesh(new THREE.CylinderGeometry(0.06,0.06,2.6,16), postMat); post.position.y=1.3; const arm=new THREE.Mesh(new THREE.BoxGeometry(0.12,0.12,0.9), postMat); arm.position.set(0,2.5,0.1); const brace=new THREE.Mesh(new THREE.BoxGeometry(0.12,1.0,0.12), postMat); brace.position.set(0,1.9,0.05); g.add(post,board,rim,arm,brace); g.position.set(cx+sx*(wm*0.5-1.2),0,cz); city.add(g); };
     makeHoop(-1); makeHoop(1);
     for(let i=0;i<3;i++){ const ball=new THREE.Mesh(new THREE.SphereGeometry(0.3,20,16), new THREE.MeshStandardMaterial({ color:0xff8a00, roughness:0.65 })); ball.position.set(cx + (Math.random()*2-1)*4, 0.3, cz + (Math.random()*2-1)*3); city.add(ball); }
     const fenceH=3.0; const fMat=new THREE.MeshStandardMaterial({ map:fenceMat(), transparent:true, opacity:1.0, roughness:0.9, metalness:0.0, color:0xffffff });
     const fx=wm/2+apron-0.4, fz=hm/2+apron-0.4;
-    const mk=(w,h,rx,rz)=>{ const m=new THREE.Mesh(new THREE.PlaneGeometry(w,h),fMat); m.position.set(cx+rx, h/2, cz+rz); city.add(m); };
-    mk(wm+apron*2, fenceH, 0, -fz); mk(wm+apron*2, fenceH, 0, fz);
-    const s1=new THREE.Mesh(new THREE.PlaneGeometry(hm+apron*2, fenceH), fMat); s1.rotation.y=Math.PI/2; s1.position.set(cx-fx, fenceH/2, cz); city.add(s1);
-    const s2=s1.clone(); s2.position.x=cx+fx; city.add(s2);
+    const gateW=3.6, fullW=wm+apron*2, segW=(fullW-gateW)/2;
+    const addPanel=(w,h,rx,rz,rot=0)=>{ const mesh=new THREE.Mesh(new THREE.PlaneGeometry(w,h), fMat); mesh.position.set(cx+rx, h/2, cz+rz); mesh.rotation.y=rot; city.add(mesh); };
+    addPanel(segW, fenceH, -(gateW/2 + segW/2), fz);
+    addPanel(segW, fenceH,  gateW/2 + segW/2, fz);
+    addPanel(segW, fenceH, -(gateW/2 + segW/2), -fz);
+    addPanel(segW, fenceH,  gateW/2 + segW/2, -fz);
+    const sideLen=hm+apron*2;
+    const sideFence=new THREE.Mesh(new THREE.PlaneGeometry(sideLen, fenceH), fMat); sideFence.rotation.y=Math.PI/2; sideFence.position.set(cx-fx, fenceH/2, cz); city.add(sideFence);
+    const sideFenceOpp=sideFence.clone(); sideFenceOpp.position.x=cx+fx; city.add(sideFenceOpp);
+    const entryMat=new THREE.MeshBasicMaterial({ color:0xd1d5db });
+    const entryPad=new THREE.Mesh(new THREE.PlaneGeometry(gateW*0.6, 1.2), entryMat);
+    entryPad.rotation.x=-Math.PI/2; entryPad.position.set(cx,0.031,cz+fz-0.55); city.add(entryPad);
+    const entryPadBack=entryPad.clone(); entryPadBack.position.z=cz-fz+0.55; city.add(entryPadBack);
     treesPerimeter(cx,cz);
   }
 
@@ -401,6 +409,13 @@ document.title = 'Tirana 2040 • Last Man Standing';
   function updateAmmoHUD(){ const a=ammo.get(currentKey); $('ammo').textContent=`${ARMORY.find(x=>x.key===currentKey)?.name||currentKey} — ${a.mag}/${a.reserve}`; document.querySelectorAll('.armBtn').forEach(el=>el.classList.remove('active')); const ab=$('arm_'+currentKey); if(ab) ab.classList.add('active'); }
   const MUZZLE_OFF={ Glock:[0.0,-0.02,-0.74], Pistol:[0.0,-0.02,-0.74], AR:[0.0,-0.04,-0.80], Uzi:[0.0,-0.03,-0.78], AK47:[0.0,-0.04,-0.82], Grenade:[0,0,0] };
   const EJECT_OFF={ Glock:[0.06,-0.05,-0.36], Pistol:[0.06,-0.05,-0.36], AR:[0.08,-0.05,-0.42], Uzi:[0.06,-0.04,-0.40], AK47:[0.09,-0.05,-0.44], Grenade:[0,0,0] };
+  const SHELL_SPECS={
+    Glock:{radius:0.006,length:0.14,color:0xd6b064},
+    Pistol:{radius:0.006,length:0.14,color:0xd6b064},
+    Uzi:{radius:0.0055,length:0.13,color:0xd0a050},
+    AR:{radius:0.0064,length:0.20,color:0xcfa443},
+    AK47:{radius:0.007,length:0.22,color:0xc58f3d}
+  };
 
   async function mountPlayerWeapon(key){ if(weaponModel){ weaponRoot.remove(weaponModel); weaponModel.traverse(o=>{ o.geometry?.dispose?.(); if(Array.isArray(o.material)) o.material.forEach(m=>m.dispose?.()); else o.material?.dispose?.(); }); weaponModel=null; }
     const model=await loadWeapon(key); const g=new THREE.Group(); if(model) g.add(model);
@@ -424,7 +439,63 @@ document.title = 'Tirana 2040 • Last Man Standing';
 
   function fireRay(off2){ raycaster.setFromCamera(off2||new THREE.Vector2(0,0), camera); const from=camera.position.clone(); const to=raycaster.ray.origin.clone().addScaledVector(raycaster.ray.direction, 8000); const pos = aimGeo.attributes.position; pos.setXYZ(0, from.x, from.y, from.z); pos.setXYZ(1, to.x, to.y, to.z); pos.needsUpdate=true; const plane = new THREE.Plane(new THREE.Vector3(0,1,0), 0); const hit = new THREE.Vector3(); raycaster.ray.intersectPlane(plane, hit); if(hit){ aimDot.position.copy(hit); } else { aimDot.position.copy(to); } return {from,to}; }
 
-  function ejection(anc){ const g=new THREE.Mesh(new THREE.SphereGeometry(0.01,6,6), new THREE.MeshBasicMaterial({ color:0xd4af37 })); const wp=new THREE.Vector3(); anc.getWorldPosition(wp); g.position.copy(wp); scene.add(g); const v=new THREE.Vector3((Math.random()*0.2+0.05), (Math.random()*0.3+0.05), (Math.random()*0.2-0.1)); const t0=performance.now(); const id=setInterval(()=>{ const t=(performance.now()-t0)/1000; g.position.x += v.x; g.position.y += v.y - 9.81*0.5*t*t*0.03; g.position.z += v.z; v.y -= 0.01; if(t>1.0){ clearInterval(id); scene.remove(g); g.geometry.dispose(); g.material.dispose(); } }, 16); }
+  function makeShellInstance(key){
+    const spec=SHELL_SPECS[key]||SHELL_SPECS.Glock;
+    if(!spec) return null;
+    const group=new THREE.Group();
+    const materials=new Set();
+    const parts=[];
+    const brass=new THREE.MeshStandardMaterial({ color:spec.color, metalness:0.65, roughness:0.38 });
+    materials.add(brass);
+    const bodyLen=spec.length*0.7;
+    const neckLen=spec.length*0.2;
+    const rimLen=spec.length*0.1;
+    const body=new THREE.Mesh(new THREE.CylinderGeometry(spec.radius, spec.radius*0.95, bodyLen, 14), brass);
+    body.rotation.z=Math.PI/2;
+    parts.push(body);
+    const neckMat=brass.clone(); materials.add(neckMat);
+    const neck=new THREE.Mesh(new THREE.CylinderGeometry(spec.radius*0.72, spec.radius*0.9, neckLen, 14), neckMat);
+    neck.rotation.z=Math.PI/2; neck.position.x=bodyLen*0.5 + neckLen*0.5;
+    parts.push(neck);
+    const rimMat=brass.clone(); materials.add(rimMat);
+    const rim=new THREE.Mesh(new THREE.CylinderGeometry(spec.radius*1.12, spec.radius*1.02, rimLen, 14), rimMat);
+    rim.rotation.z=Math.PI/2; rim.position.x=-(bodyLen*0.5 + rimLen*0.5);
+    parts.push(rim);
+    parts.forEach(p=>group.add(p));
+    group.userData.dispose=()=>{
+      parts.forEach(p=>p.geometry.dispose());
+      materials.forEach(m=>m.dispose?.());
+    };
+    group.rotation.set(Math.random()*Math.PI, Math.random()*Math.PI, Math.random()*Math.PI);
+    return group;
+  }
+  function ejection(anc,key){
+    if(!anc) return;
+    const shell=makeShellInstance(key);
+    if(!shell) return;
+    const wp=new THREE.Vector3(); anc.getWorldPosition(wp);
+    shell.position.copy(wp);
+    scene.add(shell);
+    const power = key==='AK47'?1.25: key==='AR'?1.15:1.0;
+    const v=new THREE.Vector3((Math.random()*0.22+0.12)*power, (Math.random()*0.34+0.14), (Math.random()*0.24-0.12));
+    const spin=new THREE.Vector3((Math.random()*0.2+0.04)*power, (Math.random()*0.18+0.06), (Math.random()*0.2+0.04));
+    const t0=performance.now();
+    const id=setInterval(()=>{
+      const t=(performance.now()-t0)/1000;
+      shell.position.x += v.x;
+      shell.position.y += v.y - 9.81*0.5*t*t*0.045;
+      shell.position.z += v.z;
+      shell.rotation.x += spin.x;
+      shell.rotation.y += spin.y;
+      shell.rotation.z += spin.z;
+      v.y -= 0.018;
+      if(t>1.2){
+        clearInterval(id);
+        scene.remove(shell);
+        shell.userData.dispose?.();
+      }
+    },16);
+  }
 
   function doShot(){ const st=currentStats; if(!st) return; const a=ammo.get(currentKey); if(a.mag<=0){ return; } muzzleLight.intensity=1.6; setTimeout(()=>muzzleLight.intensity=0,45); sfxGun(currentKey);
     const spread=st.spread; const off=new THREE.Vector2((Math.random()-0.5)*spread*2,(Math.random()-0.5)*spread*2); const {from,to}=fireRay(off);
@@ -433,7 +504,7 @@ document.title = 'Tirana 2040 • Last Man Standing';
     if(hits.length){ const h=hits[0]; const normal = h.face?.normal?.clone()?.transformDirection(h.object.matrixWorld)||new THREE.Vector3(0,0,1); addDecal(h.point, normal); }
     const hitsEnemy = raycaster.intersectObjects(enemyRoots(), true);
     if(hitsEnemy.length){ const h=hitsEnemy[0]; const root=(function find(o){ let p=o; while(p && !p.userData?.enemy){ p=p.parent; } return p; })(h.object); const e=enemies.get(root.uuid); if(e && !e.dead){ e.hp -= st.dmg; addBlood(h.point); if(e.hp<=0){ e.dead=true; e.body.mass=0; e.body.updateMassProperties(); e.root.visible=false; e.hpBar.visible=false; } else { updateBillboardBar(e.hpBar, e.hp/120); } } }
-    if(weaponModel?.userData?.ejectAnchor && currentKey!=='Grenade'){ ejection(weaponModel.userData.ejectAnchor); }
+    if(weaponModel?.userData?.ejectAnchor && currentKey!=='Grenade'){ ejection(weaponModel.userData.ejectAnchor, currentKey); }
     a.mag--; updateAmmoHUD();
   }
 
@@ -455,15 +526,15 @@ document.title = 'Tirana 2040 • Last Man Standing';
   const mv={active:false,id:null,vx:0,vz:0, tapStart:0, moved:false};
   function centerOf(el){ const r=el.getBoundingClientRect(); return { cx:r.left + r.width/2, cy:r.top + r.height/2 }; }
   joyMove.addEventListener('touchstart',e=>{ if(mv.active) return; const t=e.changedTouches[0]; mv.active=true; mv.id=t.identifier; mv.tapStart=performance.now(); mv.moved=false; e.preventDefault(); },{passive:false});
-  joyMove.addEventListener('touchmove', e=>{ for(const t of e.changedTouches){ if(mv.active&&t.identifier===mv.id){ const {cx,cy}=centerOf(joyMove); let dx=t.clientX-cx, dy=t.clientY-cy; const len=Math.hypot(dx,dy)||1; const nlen=Math.min(len/R,1); mv.moved = mv.moved || (nlen>DEAD*1.2); const nz=nlen<DEAD?0:(nlen-DEAD)/(1-DEAD); const scale = nz/(nlen||1); dx*=scale; dy*=scale; if(nlen>1){ dx/=nlen; dy/=nlen; } knobMove.style.transform=`translate(calc(-50% + ${dx}px),calc(-50% + ${dy}px))`; mv.vx = dx/K; mv.vz = -dy/K; } } e.preventDefault(); },{passive:false});
+    joyMove.addEventListener('touchmove', e=>{ for(const t of e.changedTouches){ if(mv.active&&t.identifier===mv.id){ const {cx,cy}=centerOf(joyMove); let dx=t.clientX-cx, dy=t.clientY-cy; const len=Math.hypot(dx,dy)||1; const nlen=Math.min(len/R,1); mv.moved = mv.moved || (nlen>DEAD*1.2); const nz=nlen<DEAD?0:(nlen-DEAD)/(1-DEAD); const scale = nz/(nlen||1); dx*=scale; dy*=scale; if(nlen>1){ dx/=nlen; dy/=nlen; } knobMove.style.transform=`translate(calc(-50% + ${dx}px),calc(-50% + ${dy}px))`; mv.vx = -dx/K; mv.vz = -dy/K; } } e.preventDefault(); },{passive:false});
   function mvEnd(){ knobMove.style.transform='translate(-50%,-50%)'; const tap=(performance.now()-mv.tapStart)<220 && !mv.moved; mv.active=false; mv.vx=0; mv.vz=0; if(tap) jump(); }
   joyMove.addEventListener('touchend', mvEnd, {passive:false}); joyMove.addEventListener('touchcancel', mvEnd, {passive:false});
   joyMove.addEventListener('pointerdown', (e)=>{ if(mv.active) return; mv.active=true; mv.id=e.pointerId; mv.tapStart=performance.now(); mv.moved=false; const r=joyMove.getBoundingClientRect(); mv.cx=r.left+r.width/2; mv.cy=r.top+r.height/2; try{ joyMove.setPointerCapture(e.pointerId); }catch(_){ } e.preventDefault(); });
-  joyMove.addEventListener('pointermove', (e)=>{ if(!mv.active||e.pointerId!==mv.id) return; let dx=e.clientX-mv.cx, dy=e.clientY-mv.cy; const len=Math.hypot(dx,dy)||1; const nlen=Math.min(len/R,1); if(!mv.moved && nlen>DEAD*1.2) mv.moved=true; const nz=nlen<DEAD?0:(nlen-DEAD)/(1-DEAD); const scale=nz/(nlen||1); dx*=scale; dy*=scale; if(nlen>1){ dx/=nlen; dy/=nlen; } knobMove.style.transform=`translate(calc(-50% + ${dx}px),calc(-50% + ${dy}px))`; mv.vx = dx/K; mv.vz = -dy/K; e.preventDefault(); });
+    joyMove.addEventListener('pointermove', (e)=>{ if(!mv.active||e.pointerId!==mv.id) return; let dx=e.clientX-mv.cx, dy=e.clientY-mv.cy; const len=Math.hypot(dx,dy)||1; const nlen=Math.min(len/R,1); if(!mv.moved && nlen>DEAD*1.2) mv.moved=true; const nz=nlen<DEAD?0:(nlen-DEAD)/(1-DEAD); const scale=nz/(nlen||1); dx*=scale; dy*=scale; if(nlen>1){ dx/=nlen; dy/=nlen; } knobMove.style.transform=`translate(calc(-50% + ${dx}px),calc(-50% + ${dy}px))`; mv.vx = -dx/K; mv.vz = -dy/K; e.preventDefault(); });
   function mvRelease(e){ if(!mv.active||e.pointerId!==mv.id) return; mvEnd(); try{ joyMove.releasePointerCapture(e.pointerId); }catch(_){ } e.preventDefault(); }
   joyMove.addEventListener('pointerup', mvRelease); joyMove.addEventListener('pointercancel', mvRelease);
 
-  const shootPad=$('shootPad'); const shootKnob=shootPad.querySelector('.knob'); const aimPad=$('aimPad'); const aimKnob=aimPad.querySelector('.knob');
+  const shootPad=$('shootPad'); const shootKnob=shootPad.querySelector('.knob');
   let fireHeld=false;
   function shootDown(){ if(FIRE_MODES.get(currentKey)==='auto'){ fireHeld=true; } else { doShot(); } }
   function shootUp(){ fireHeld=false; }
@@ -473,12 +544,6 @@ document.title = 'Tirana 2040 • Last Man Standing';
   shootPad.addEventListener('touchstart', (e)=>{ if(inputMode!=='A') return; shootDown(); e.preventDefault(); }, {passive:false});
   shootPad.addEventListener('touchend', (e)=>{ if(inputMode!=='A') return; shootUp(); e.preventDefault(); }, {passive:false});
 
-  const aimPE={active:false,id:null,cx:0,cy:0,tapStart:0,moved:false};
-  function aimSet(dx,dy){ yaw -= dx*0.0012; pitch -= dy*0.0010; clampPitch(); }
-  aimPad.addEventListener('pointerdown', (e)=>{ if(inputMode!=='B'||aimPE.active) return; aimPE.active=true; aimPE.id=e.pointerId; aimPE.tapStart=performance.now(); aimPE.moved=false; const r=aimPad.getBoundingClientRect(); aimPE.cx=r.left+r.width/2; aimPE.cy=r.top+r.height/2; try{ aimPad.setPointerCapture(e.pointerId); }catch(_){} e.preventDefault(); });
-  aimPad.addEventListener('pointermove', (e)=>{ if(inputMode!=='B'||!aimPE.active||e.pointerId!==aimPE.id) return; let dx=e.clientX-aimPE.cx, dy=e.clientY-aimPE.cy; const len=Math.hypot(dx,dy)||1; const nlen=Math.min(len/R,1); if(!aimPE.moved && nlen>DEAD*1.2) aimPE.moved=true; const nz=nlen<DEAD?0:(nlen-DEAD)/(1-DEAD); const scale=nz/(nlen||1); dx*=scale; dy*=scale; if(nlen>1){ dx/=nlen; dy/=nlen; } aimKnob.style.transform=`translate(calc(-50% + ${dx}px),calc(-50% + ${dy}px))`; aimSet(dx,dy); e.preventDefault(); });
-  function aimRelease(e){ if(inputMode!=='B'||!aimPE.active||e.pointerId!==aimPE.id) return; aimPE.active=false; aimKnob.style.transform='translate(-50%,-50%)'; const tap=(performance.now()-aimPE.tapStart)<220 && !aimPE.moved; if(tap) doShot(); try{ aimPad.releasePointerCapture(e.pointerId); }catch(_){} e.preventDefault(); }
-  aimPad.addEventListener('pointerup', aimRelease); aimPad.addEventListener('pointercancel', aimRelease);
 
   const canvasEl=renderer.domElement; canvasEl.style.touchAction='none';
   const look={active:false,id:null,lastX:0,lastY:0};
@@ -486,7 +551,7 @@ document.title = 'Tirana 2040 • Last Man Standing';
   const LOOK_SENS_A  = isMobile ? 0.12 : 0.10;
   const AIM_RATE_A   = 0.52;
   const AIM_SMOOTH_A = 3.8;
-  function isUIBlock(el){ return el.closest('#joyMove')||el.closest('#shootPad')||el.closest('#aimPad')||el.closest('#armory')||el.closest('#reloadMini')||el.closest('#climbBtn')||el.closest('#radarBox')||el.closest('#zoomBox'); }
+  function isUIBlock(el){ return el.closest('#joyMove')||el.closest('#shootPad')||el.closest('#armory')||el.closest('#reloadMini')||el.closest('#climbBtn')||el.closest('#radarBox')||el.closest('#zoomBox'); }
   canvasEl.addEventListener('pointerdown',(e)=>{ if(inputMode!=='A') return; if(isUIBlock(e.target)) return; if(look.active) return; look.active=true; look.id=e.pointerId; look.lastX=e.clientX; look.lastY=e.clientY; try{ canvasEl.setPointerCapture(e.pointerId); }catch(_){} e.preventDefault(); });
   canvasEl.addEventListener('pointermove',(e)=>{ if(inputMode!=='A') return; if(!look.active||e.pointerId!==look.id) return; const dx=e.clientX-look.lastX; const dy=e.clientY-look.lastY; look.lastX=e.clientX; look.lastY=e.clientY; lookAccumX += dx; lookAccumY += dy; e.preventDefault(); });
   function lookRelease(e){ if(inputMode!=='A') return; if(!look.active||e.pointerId!==look.id) return; look.active=false; try{ canvasEl.releasePointerCapture(e.pointerId); }catch(_){} e.preventDefault(); }
@@ -539,9 +604,32 @@ document.title = 'Tirana 2040 • Last Man Standing';
 
   function setHeading(mesh,angle){ mesh.rotation.y = angle + Math.PI/2; }
 
+  async function spawnParkedCommons(){
+    const templates=[await getVehicle('sedan'), await getVehicle('car')];
+    const palette=['#64748b','#9ca3af','#475569','#7f5539','#ef8354'];
+    const spots=[
+      {x:startX+CELL*0.9, z:startZ+CELL*1.3, heading:Math.PI*0.18},
+      {x:startX+CELL*1.6, z:startZ+CELL*1.1, heading:-Math.PI*0.22},
+      {x:startX+CELL*2.3, z:startZ+CELL*1.8, heading:Math.PI*0.36},
+      {x:startX+CELL*3.1, z:startZ+CELL*2.2, heading:-Math.PI*0.48},
+      {x:startX+CELL*2.4, z:startZ+CELL*3.1, heading:Math.PI*0.52},
+      {x:startX+CELL*4.0, z:startZ+CELL*1.6, heading:-Math.PI*0.12}
+    ];
+    for(let i=0;i<spots.length;i++){
+      const base=(templates[i%templates.length]||templates[0]).clone(true);
+      centerXZ(base); scaleToLength(base,3.9); placeOnGround(base,0);
+      tintVehicle(base,palette[i%palette.length]);
+      setHeading(base, spots[i].heading||0);
+      base.position.set(spots[i].x, 0, spots[i].z);
+      scene.add(base);
+      parked.push(base);
+    }
+  }
+
   async function spawnTraffic(n=14){ const pool=[await getVehicle('sedan'), await getVehicle('car')?.catch?.(()=>null) || await getVehicle('sedan')]; for(let i=0;i<n;i++){ const base=pool[i%pool.length]; const v=base.clone(true); centerXZ(v); scaleToLength(v,3.8); placeOnGround(v,0); const hue=Math.random(); tintVehicle(v,new THREE.Color().setHSL(hue,0.4,0.5).getHex()); const a=Math.random()*Math.PI*2; const x=Math.cos(a)*ringR, z=Math.sin(a)*ringR; v.position.set(x,0,z); setHeading(v,a); scene.add(v); trafficCars.push({mesh:v, angle:a, speed:0}); } }
 
   await spawnParkedEmergency();
+  await spawnParkedCommons();
   await spawnTraffic(16);
 
   const ARM_SPEED_BASE = 4.8; const speedRun = 7.2; const trafficTarget = 3 * speedRun; // 3x run speed
@@ -566,10 +654,11 @@ document.title = 'Tirana 2040 • Last Man Standing';
   startBR();
 
   let inputMode='A';
-  const modeA=$('modeA'), modeB=$('modeB');
-  function applyMode(){ const isA = inputMode==='A'; shootPad.style.display = isA? 'block':'none'; $('reloadMini').style.display = isA? 'block':'none'; aimPad.style.display = isA? 'none':'block'; $('zoomBox').style.display = (currentKey==='AK47' && isA)? 'block':'none'; modeA.classList.toggle('active', isA); modeB.classList.toggle('active', !isA); }
-  modeA.addEventListener('click',()=>{ inputMode='A'; applyMode(); });
-  modeB.addEventListener('click',()=>{ inputMode='B'; applyMode(); });
+  function applyMode(){
+    shootPad.style.display='block';
+    $('reloadMini').style.display='block';
+    updateZoomUI();
+  }
   applyMode();
 
   const zoomSlider=$('zoomSlider');


### PR DESCRIPTION
## Summary
- refresh the Tirana 2040 HUD by removing the control mode toggle, relocating the weapon armory to the bottom row, and placing ammo and zoom controls beside the shoot/reload pads
- invert joystick lateral movement, add caliber-specific shell ejections, and keep the zoom slider confined to the AK-47
- upgrade park set dressing with gated fences, red rubber basketball surfaces, and additional parked civilian cars for player use

## Testing
- no automated tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6915ab8981188325ba36999967fe48a3)