### PR TITLE
Refine Tirana 2040 HUD and city interactions

### DIFF
--- a/webapp/public/tirana-2040.html
+++ b/webapp/public/tirana-2040.html
@@ -12,6 +12,7 @@
     --joy-size: clamp(140px, 34vw, 200px);
     --joy-knob: clamp(80px, 22vw, 140px);
     --hud-blur: 10px;
+    --fire-size: clamp(104px, 24vw, 148px);
   }
   html,body{margin:0;height:100%;background:#f5e7cf;overflow:hidden;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
   #wrap{position:fixed;inset:0}
@@ -29,34 +30,34 @@
   .joy .knob{position:absolute;left:50%;top:50%;width:var(--joy-knob);height:var(--joy-knob);transform:translate(-50%,-50%);border-radius:50%;background:rgba(0,0,0,.28);border:1px solid rgba(0,0,0,.35)}
   #joyMove{left:var(--hud-gap);bottom:var(--pad-offset)}
   #joyMove .knob{background:rgba(0,0,0,.32)}
-  .padStack{position:absolute;right:var(--hud-gap);bottom:var(--pad-offset);display:flex;flex-direction:column;align-items:flex-end;gap:clamp(12px,3vw,18px);pointer-events:none}
-  .padStack > *{pointer-events:auto}
-  .padStack .joy{position:relative}
-  .padStack .joy .knob{width:var(--joy-knob);height:var(--joy-knob)}
-  #shootPad .knob{background:radial-gradient(circle at 50% 50%, rgba(255,70,70,1) 0 34%, rgba(0,0,0,.32) 36%), rgba(0,0,0,.25);box-shadow:0 10px 24px rgba(0,0,0,.28)}
-  #shootPad .knob::after{content:'SHOOT';position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);color:#fff;font-weight:900;font-size:clamp(13px,3.4vw,18px);letter-spacing:.6px;text-shadow:0 1px 3px rgba(0,0,0,.6);}
-  #reloadMini{width:clamp(84px,21vw,118px);height:clamp(84px,21vw,118px);border-radius:50%;border:1px solid rgba(0,0,0,.32);background:radial-gradient(circle at 50% 50%, rgba(255,86,86,1) 0 36%, rgba(0,0,0,.28) 40%), rgba(0,0,0,.35);color:#fff;font-size:clamp(12px,3.2vw,16px);font-weight:900;letter-spacing:.5px;pointer-events:auto;box-shadow:0 10px 24px rgba(0,0,0,.3);display:flex;align-items:center;justify-content:center;text-transform:uppercase}
+  .padCluster{position:absolute;right:var(--hud-gap);bottom:var(--pad-offset);display:flex;flex-direction:column;align-items:flex-end;gap:clamp(14px,4vw,22px);pointer-events:none}
+  .padCluster > *{pointer-events:auto}
+  .padActions{display:flex;gap:clamp(18px,4.5vw,28px);align-items:flex-end}
+  .fireBtn{width:var(--fire-size);height:var(--fire-size);border-radius:50%;border:1px solid rgba(0,0,0,.36);background:radial-gradient(circle at 50% 50%, rgba(255,68,68,1) 0 35%, rgba(0,0,0,.32) 37%), rgba(0,0,0,.38);color:#fff;font-size:clamp(13px,3.6vw,18px);font-weight:900;letter-spacing:.6px;box-shadow:0 12px 26px rgba(0,0,0,.32);text-transform:uppercase;display:flex;align-items:center;justify-content:center;cursor:pointer;transition:transform .12s ease, box-shadow .12s ease;text-shadow:0 2px 6px rgba(0,0,0,.45)}
+  .fireBtn:active{transform:translateY(1px);box-shadow:0 6px 18px rgba(0,0,0,.28)}
+  #reloadMini{background:radial-gradient(circle at 50% 50%, rgba(255,132,60,1) 0 35%, rgba(0,0,0,.32) 37%), rgba(0,0,0,.38)}
   #crosshair{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:30px;height:30px;pointer-events:none;z-index:50;display:block}
   #crosshair:before,#crosshair:after{content:"";position:absolute;left:50%;top:50%;background:var(--aimColor,#ff3c3c);box-shadow:0 0 0 2px rgba(255,255,255,0.9) inset, 0 0 6px rgba(0,0,0,.35)}
   #crosshair:before{width:24px;height:3px;transform:translate(-50%,-50%);opacity:.98}
   #crosshair:after{width:3px;height:24px;transform:translate(-50%,-50%);opacity:.98}
-  #ammo{color:#fff;font-weight:700;background:rgba(0,0,0,.42);padding:8px 14px;border-radius:14px 14px 4px 4px;pointer-events:auto;font-size:clamp(11px,2.8vw,14px);backdrop-filter:blur(var(--hud-blur));min-width:130px;text-align:center;align-self:flex-end}
+  #ammo{color:#fff;font-weight:700;background:rgba(0,0,0,.42);padding:10px 18px;border-radius:14px 14px 4px 4px;pointer-events:auto;font-size:clamp(11px,2.8vw,15px);backdrop-filter:blur(var(--hud-blur));min-width:150px;text-align:center;align-self:flex-end}
   #healthbar{position:absolute;left:50%;top:calc(var(--hud-gap) + 44px);width:clamp(160px,60vw,320px);height:14px;background:rgba(0,0,0,.22);border-radius:999px;overflow:hidden;transform:translateX(-50%)}
   #healthfill{width:100%;height:100%;background:linear-gradient(90deg,#29ff9a,#00c876)}
-  .armoryWrap{flex:1;display:flex;justify-content:flex-start;overflow:visible}
-  #armory{display:flex;gap:8px;overflow-x:auto;padding:8px 10px;border-radius:14px;background:rgba(0,0,0,.28);backdrop-filter:blur(var(--hud-blur));pointer-events:auto;max-width:100%;box-sizing:border-box}
-  .armBtn{position:relative;flex:0 0 auto;width:clamp(70px,14vw,96px);padding:6px;border-radius:12px;border:1px solid rgba(255,255,255,.16);background:rgba(0,0,0,.32);color:#e6eefc;font-weight:700;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:4px;transition:transform .2s ease}
-  .armBtn img{width:100%;aspect-ratio:4/3;object-fit:contain;display:block;filter:drop-shadow(0 1px 2px rgba(0,0,0,.35))}
-  .armBtn span{font-size:11px;opacity:.95;text-align:center}
+  .armoryWrap{flex:1;display:flex;justify-content:center;overflow:visible}
+  #armory{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:clamp(4px,1.4vw,10px);overflow:visible;padding:8px 10px;border-radius:16px;background:rgba(0,0,0,.28);backdrop-filter:blur(var(--hud-blur));pointer-events:auto;max-width:clamp(240px,60vw,360px);width:100%;box-sizing:border-box;align-items:stretch;justify-items:stretch}
+  .armBtn{position:relative;width:100%;padding:6px 4px;border-radius:12px;border:1px solid rgba(255,255,255,.16);background:rgba(0,0,0,.32);color:#e6eefc;font-weight:700;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:4px;transition:transform .2s ease}
+  .armBtn img{width:100%;aspect-ratio:1/1;object-fit:contain;display:block;filter:drop-shadow(0 1px 2px rgba(0,0,0,.35))}
+  .armBtn span{font-size:10px;opacity:.95;text-align:center}
   .armBtn.active{outline:2px solid #ffd966;background:rgba(17,23,42,.55);transform:translateY(-4px)}
   .modeToggle{position:absolute;right:6px;top:6px;padding:2px 5px;border-radius:9px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.45);color:#fff;font-size:9px;cursor:pointer}
   #mini{position:absolute;left:50%;bottom:calc(var(--pad-offset) + var(--joy-size) + clamp(12px,3vh,40px));transform:translateX(-50%);color:#0b1324;background:rgba(255,255,255,.75);padding:4px 10px;border-radius:999px;font-size:11px;pointer-events:auto}
   #climbBtn{position:absolute;left:50%;bottom:calc(var(--pad-offset) + var(--joy-size) + clamp(60px,8vh,120px));transform:translateX(-50%);padding:9px 16px;border-radius:14px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.7);color:#fff;font-size:clamp(12px,3.1vw,15px);pointer-events:auto;display:none}
-  #zoomBox{display:none;pointer-events:auto;align-self:flex-end;margin-right:-4px}
-  #zoomSlider{appearance:none;width:clamp(240px,48vh,320px);height:56px;transform:rotate(-90deg);background:rgba(0,0,0,.4);border-radius:999px;outline:none;border:1px solid rgba(255,255,255,.2)}
-  #zoomSlider::-webkit-slider-thumb{appearance:none;width:46px;height:46px;border-radius:50%;background:#ffd966;border:1px solid rgba(0,0,0,.4)}
-  #zoomSlider::-moz-range-thumb{width:46px;height:46px;border-radius:50%;background:#ffd966;border:1px solid rgba(0,0,0,.4)}
-  #radarBox{position:absolute;left:var(--hud-gap);top:calc(var(--hud-gap) + 82px);width:clamp(118px,28vw,160px);height:clamp(118px,28vw,160px);border-radius:18px;background:rgba(0,0,0,.28);border:1px solid rgba(0,0,0,.35);overflow:hidden;pointer-events:auto;backdrop-filter:blur(var(--hud-blur))}
+  #climbBtn[disabled]{opacity:.55;cursor:not-allowed}
+  #zoomBox{position:absolute;left:calc(var(--hud-gap) + var(--joy-size)*0.5);bottom:calc(var(--pad-offset) + var(--joy-size) + clamp(48px,10vh,140px));display:none;pointer-events:auto;transform:translateX(-50%)}
+  #zoomSlider{appearance:none;width:clamp(200px,44vh,300px);height:clamp(46px,9vw,62px);transform:rotate(-90deg);transform-origin:50% 50%;background:rgba(0,0,0,.45);border-radius:999px;outline:none;border:1px solid rgba(255,255,255,.22);box-shadow:0 12px 24px rgba(0,0,0,.28);padding:0;touch-action:none}
+  #zoomSlider::-webkit-slider-thumb{appearance:none;width:44px;height:44px;border-radius:50%;background:#ffd966;border:1px solid rgba(0,0,0,.4);box-shadow:0 6px 14px rgba(0,0,0,.3)}
+  #zoomSlider::-moz-range-thumb{width:44px;height:44px;border-radius:50%;background:#ffd966;border:1px solid rgba(0,0,0,.4);box-shadow:0 6px 14px rgba(0,0,0,.3)}
+  #radarBox{position:absolute;left:var(--hud-gap);top:calc(var(--hud-gap) + 82px);width:clamp(160px,36vw,220px);height:clamp(160px,36vw,220px);border-radius:18px;background:rgba(0,0,0,.28);border:1px solid rgba(0,0,0,.35);overflow:hidden;pointer-events:auto;backdrop-filter:blur(var(--hud-blur))}
   #radar{width:100%;height:100%;display:block}
   #mapOverlay{position:fixed;inset:0;background:rgba(0,0,0,.75);display:none;align-items:center;justify-content:center;z-index:200;pointer-events:auto}
   #mapCanvas{width:min(96vw,1200px);height:min(96vh,800px);background:#0b0f1a;border:1px solid #334;box-shadow:0 20px 60px rgba(0,0,0,.4);border-radius:12px}
@@ -83,17 +84,19 @@
   <div id="crosshair"></div>
 
   <div id="joyMove" class="joy"><div class="knob"></div></div>
-  <div id="padContainer" class="padStack">
-    <div id="shootPad" class="joy"><div class="knob"></div></div>
+  <div id="zoomBox"><input id="zoomSlider" type="range" min="1" max="3" step="0.01" value="1" /></div>
+  <div id="padContainer" class="padCluster">
+    <div class="padActions">
+      <button id="shootPad" class="fireBtn">SHOOT</button>
+      <button id="reloadMini" class="fireBtn">RELOAD</button>
+    </div>
     <div id="ammo">—</div>
-    <div id="zoomBox"><input id="zoomSlider" type="range" min="1" max="3" step="0.01" value="1" /></div>
-    <button id="reloadMini">RELOAD</button>
   </div>
   <div id="radarBox"><canvas id="radar"></canvas></div>
   <div id="mapOverlay">
     <canvas id="mapCanvas"></canvas>
     <button id="mapClose">Close Map</button>
-    <div id="legend">Tap map to set a waypoint • Icons: 🏥 Hospital · 🚓 Police · 🧯 Fire · 🛍 Mall · 🛫 Airport · 🚉 Station</div>
+    <div id="legend">Tap the map for directions &amp; waypoint • Icons: 🏥 Hospital · 🚓 Police · 🧯 Fire · 🛍 Mall · 🛫 Airport · 🚉 Station • Use Exit to close</div>
   </div>
 
   <button id="climbBtn">⬆ Use/Climb Ladder</button>
@@ -105,7 +108,6 @@
     <div class="armoryWrap">
       <div id="armory"></div>
     </div>
-    <button id="resetBtn" class="btn">Reset</button>
   </div>
 </div>
 
@@ -170,9 +172,10 @@ document.title = 'Tirana 2040 • Last Man Standing';
 
   const world = new CANNON.World({ gravity: new CANNON.Vec3(0,-9.81,0) });
   world.broadphase = new CANNON.SAPBroadphase(world); world.allowSleep = true;
-  const matGround=new CANNON.Material('ground'), matPlayer=new CANNON.Material('player'), matEnemy=new CANNON.Material('enemy'), matCar=new CANNON.Material('car');
+  const matGround=new CANNON.Material('ground'), matPlayer=new CANNON.Material('player'), matEnemy=new CANNON.Material('enemy'), matCar=new CANNON.Material('car'), matGrenade=new CANNON.Material('grenade');
   world.addContactMaterial(new CANNON.ContactMaterial(matGround, matPlayer, { friction:.2, restitution:0 }));
   world.addContactMaterial(new CANNON.ContactMaterial(matGround, matCar, { friction:.9, restitution:0 }));
+  world.addContactMaterial(new CANNON.ContactMaterial(matGround, matGrenade, { friction:0.42, restitution:0.36 }));
 
   const groundBody = new CANNON.Body({ mass:0, material:matGround, shape:new CANNON.Plane() });
   groundBody.quaternion.setFromEuler(-Math.PI/2,0,0); world.addBody(groundBody);
@@ -180,7 +183,7 @@ document.title = 'Tirana 2040 • Last Man Standing';
   function makeAsphalt(size=1024){ const c=document.createElement('canvas'); c.width=c.height=size; const x=c.getContext('2d'); x.fillStyle='#2b313a'; x.fillRect(0,0,size,size); for(let i=0;i<3800;i++){ const a=Math.random()*0.12; x.fillStyle=`rgba(255,255,255,${a})`; x.fillRect(Math.random()*size,Math.random()*size,1,1);} const t=new THREE.CanvasTexture(c); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(16,16); t.anisotropy=2; t.colorSpace=THREE.SRGBColorSpace; return t; }
   function makeSidewalk(size=512){ const c=document.createElement('canvas'); c.width=c.height=size; const x=c.getContext('2d'); x.fillStyle='#c9ced6'; x.fillRect(0,0,size,size); x.strokeStyle='#9aa0a8'; x.lineWidth=6; for(let s=0;s<size;s+=64){ x.beginPath(); x.moveTo(s,0); x.lineTo(s,size); x.stroke(); x.beginPath(); x.moveTo(0,s); x.lineTo(size,s); x.stroke(); } const t=new THREE.CanvasTexture(c); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(32,32); t.anisotropy=2; t.colorSpace=THREE.SRGBColorSpace; return t; }
   const maxAniso = renderer.capabilities.getMaxAnisotropy?.() || 4;
-  function grassTex(){ const imgURL='https://threejs.org/examples/textures/terrain/grasslight-big.jpg'; const tLoader=new Image(); const p=new Promise(res=>{ tLoader.crossOrigin='anonymous'; tLoader.onload=()=>{ const c=document.createElement('canvas'); c.width=1024; c.height=1024; const g=c.getContext('2d'); g.drawImage(tLoader,0,0,1024,1024); const tex=new THREE.CanvasTexture(c); tex.wrapS=tex.wrapT=THREE.RepeatWrapping; tex.repeat.set(8,18); tex.anisotropy=Math.min(16,maxAniso); tex.colorSpace=THREE.SRGBColorSpace; res(tex); }; tLoader.src=imgURL; }); return p; }
+  function grassTex(){ const imgURL='https://threejs.org/examples/textures/terrain/grasslight-big.jpg'; const tLoader=new Image(); const p=new Promise(res=>{ tLoader.crossOrigin='anonymous'; tLoader.onload=()=>{ const c=document.createElement('canvas'); c.width=1024; c.height=1024; const g=c.getContext('2d'); g.drawImage(tLoader,0,0,1024,1024); const tex=new THREE.CanvasTexture(c); tex.wrapS=tex.wrapT=THREE.RepeatWrapping; tex.repeat.set(12,26); tex.anisotropy=Math.min(16,maxAniso); tex.colorSpace=THREE.SRGBColorSpace; res(tex); }; tLoader.src=imgURL; }); return p; }
   function trackTex(w=1024,h=1024){ const c=document.createElement('canvas'); c.width=w; c.height=h; const g=c.getContext('2d'); g.fillStyle='#b33a2c'; g.fillRect(0,0,w,h); const dots=Math.floor(w*h*0.004); for(let i=0;i<dots;i++){ const x=Math.random()*w, y=Math.random()*h, r=Math.random()*1.6+0.2; g.fillStyle=Math.random()<0.5?'rgba(255,190,180,0.35)':'rgba(40,12,10,0.35)'; g.beginPath(); g.arc(x,y,r,0,Math.PI*2); g.fill(); } const t=new THREE.CanvasTexture(c); t.anisotropy=Math.min(16,maxAniso); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.colorSpace=THREE.SRGBColorSpace; t.repeat.set(1,1); return t; }
 
   const asphaltTex = makeAsphalt(), sidewalkTex = makeSidewalk(), redTrackTex = trackTex();
@@ -194,8 +197,38 @@ document.title = 'Tirana 2040 • Last Man Standing';
   const gnd = new THREE.Mesh(groundGeo, groundMat); gnd.rotation.x=-Math.PI/2; gnd.receiveShadow=allowShadows; city.add(gnd);
 
   const roadMat = new THREE.MeshLambertMaterial({ map: asphaltTex });
-  for(let ix=0; ix<=BLOCKS_X; ix++){ const geo=new THREE.PlaneGeometry(ROAD,(CELL)*BLOCKS_Z + ROAD); const m=new THREE.Mesh(geo, roadMat); m.rotation.x=-Math.PI/2; m.position.set(ix*CELL-(BLOCKS_X*CELL)/2, 0.01, ROAD*0.5-(BLOCKS_Z*CELL)/2); m.receiveShadow=allowShadows; city.add(m); }
-  for(let iz=0; iz<=BLOCKS_Z; iz++){ const geo=new THREE.PlaneGeometry((CELL)*BLOCKS_X + ROAD, ROAD); const m=new THREE.Mesh(geo, roadMat); m.rotation.x=-Math.PI/2; m.position.set(ROAD*0.5-(BLOCKS_X*CELL)/2, 0.01, iz*CELL-(BLOCKS_Z*CELL)/2); m.receiveShadow=allowShadows; city.add(m); }
+  for(let ix=0; ix<=BLOCKS_X; ix++){
+    const geo=new THREE.PlaneGeometry(ROAD,(CELL)*BLOCKS_Z + ROAD);
+    const m=new THREE.Mesh(geo, roadMat);
+    m.rotation.x=-Math.PI/2;
+    m.position.set(ix*CELL-(BLOCKS_X*CELL)/2, 0.01, ROAD*0.5-(BLOCKS_Z*CELL)/2);
+    m.receiveShadow=allowShadows;
+    city.add(m);
+    const length=(CELL)*BLOCKS_Z + ROAD;
+    const zCenter=m.position.z;
+    const z0=zCenter-length/2;
+    const z1=zCenter+length/2;
+    const nameIdx=ix % STREET_NAMES_NS.length;
+    const suffix=Math.floor(ix/STREET_NAMES_NS.length);
+    const name=suffix>0?`${STREET_NAMES_NS[nameIdx]} ${suffix+1}`:STREET_NAMES_NS[nameIdx];
+    ROAD_SEGMENTS.push({name, from:new THREE.Vector3(m.position.x,0,z0), to:new THREE.Vector3(m.position.x,0,z1), width:ROAD, orientation:'NS'});
+  }
+  for(let iz=0; iz<=BLOCKS_Z; iz++){
+    const geo=new THREE.PlaneGeometry((CELL)*BLOCKS_X + ROAD, ROAD);
+    const m=new THREE.Mesh(geo, roadMat);
+    m.rotation.x=-Math.PI/2;
+    m.position.set(ROAD*0.5-(BLOCKS_X*CELL)/2, 0.01, iz*CELL-(BLOCKS_Z*CELL)/2);
+    m.receiveShadow=allowShadows;
+    city.add(m);
+    const length=(CELL)*BLOCKS_X + ROAD;
+    const xCenter=m.position.x;
+    const x0=xCenter-length/2;
+    const x1=xCenter+length/2;
+    const nameIdx=iz % STREET_NAMES_EW.length;
+    const suffix=Math.floor(iz/STREET_NAMES_EW.length);
+    const name=suffix>0?`${STREET_NAMES_EW[nameIdx]} ${suffix+1}`:STREET_NAMES_EW[nameIdx];
+    ROAD_SEGMENTS.push({name, from:new THREE.Vector3(x0,0,m.position.z), to:new THREE.Vector3(x1,0,m.position.z), width:ROAD, orientation:'EW'});
+  }
 
   const sidewalkMat = new THREE.MeshLambertMaterial({ map: sidewalkTex });
   function addSidewalk(xc,zc){ const w=CELL-ROAD, h=CELL-ROAD; const geo=new THREE.BoxGeometry(w,2,h); const m=new THREE.Mesh(geo, sidewalkMat); m.castShadow=false; m.receiveShadow=allowShadows; m.position.set(xc,1,zc); city.add(m); }
@@ -267,6 +300,7 @@ document.title = 'Tirana 2040 • Last Man Standing';
     gatePad.rotation.x=-Math.PI/2; gatePad.position.set(cx,0.03,cz+fz-0.6); city.add(gatePad);
     const gatePadBack=gatePad.clone(); gatePadBack.position.z=cz-fz+0.6; city.add(gatePadBack);
     treesPerimeter(cx,cz);
+    CITY_LABELS.push({name:'Fusha Tenisi', pos:new THREE.Vector3(cx,0,cz)});
   }
 
   function addBasketCourt(cx,cz){
@@ -274,7 +308,7 @@ document.title = 'Tirana 2040 • Last Man Standing';
     const wm=28, hm=15, apron=2.6;
     const base=new THREE.Mesh(new THREE.PlaneGeometry(wm+apron*2,hm+apron*2), new THREE.MeshStandardMaterial({ map:redTrackTex, roughness:0.96, metalness:0.0 }));
     base.rotation.x=-Math.PI/2; base.position.set(cx,0.02,cz); city.add(base);
-    const rubberTex=trackTex(); rubberTex.repeat.set(3,2); rubberTex.needsUpdate=true;
+    const rubberTex=redTrackTex.clone?.() || redTrackTex; rubberTex.repeat.set(4,3); rubberTex.needsUpdate=true;
     const surface=new THREE.Mesh(new THREE.PlaneGeometry(wm,hm), new THREE.MeshStandardMaterial({ map:rubberTex, roughness:0.96, metalness:0.0 }));
     surface.rotation.x=-Math.PI/2; surface.position.set(cx,0.021,cz); city.add(surface);
     const lines=new THREE.Mesh(new THREE.PlaneGeometry(wm,hm), new THREE.MeshBasicMaterial({ map:basketLinesTex(wm,hm), transparent:true, opacity:0.98 }));
@@ -299,6 +333,7 @@ document.title = 'Tirana 2040 • Last Man Standing';
     entryPad.rotation.x=-Math.PI/2; entryPad.position.set(cx,0.031,cz+fz-0.55); city.add(entryPad);
     const entryPadBack=entryPad.clone(); entryPadBack.position.z=cz-fz+0.55; city.add(entryPadBack);
     treesPerimeter(cx,cz);
+    CITY_LABELS.push({name:'Fusha Basketbolli', pos:new THREE.Vector3(cx,0,cz)});
   }
 
   function addFountain(cx,cz){
@@ -309,7 +344,9 @@ document.title = 'Tirana 2040 • Last Man Standing';
     for(let i=0;i<26;i++){ const ang=Math.random()*Math.PI*2, r=ringR*0.95*(0.6+Math.random()*0.35); const s=new THREE.Mesh(new THREE.DodecahedronGeometry(0.6+Math.random()*0.8), new THREE.MeshStandardMaterial({ color:0x9aa0a8, roughness:0.95 })); s.position.set(cx+Math.cos(ang)*r,0.35,cz+Math.sin(ang)*r); city.add(s); }
     for(let i=0;i<80;i++){ const ang=Math.random()*Math.PI*2, r=ringR*(0.2+Math.random()*0.9); const f=new THREE.Mesh(new THREE.ConeGeometry(0.15,0.4,8), new THREE.MeshStandardMaterial({ color: (Math.random()<0.5?0xff4d6d:0xffc300), roughness:0.9 })); f.position.set(cx+Math.cos(ang)*r,0.2,cz+Math.sin(ang)*r); city.add(f); }
     const jets=[]; const jetMat=new THREE.MeshBasicMaterial({ color:0xaee3ff }); for(let i=0;i<8;i++){ const j=new THREE.Mesh(new THREE.CylinderGeometry(0.05,0.05,1.2,8), jetMat); j.position.set(cx+(Math.random()*2-1)*2,1.1,cz+(Math.random()*2-1)*2); city.add(j); jets.push(j); }
+    const glow=new THREE.PointLight(0x66d8ff,3.5,45); glow.position.set(cx,6,cz); city.add(glow);
     water.userData.jets=jets;
+    CITY_LABELS.push({name:'Shatërvani Qendror', pos:new THREE.Vector3(cx,0,cz)});
   }
 
   const trafficLights=[];
@@ -319,17 +356,63 @@ document.title = 'Tirana 2040 • Last Man Standing';
     trafficLights.push({pos:new THREE.Vector3(x,0,z), dir, state:'green', timer:0, lamps:{Lg,Ly,Lr}});
   }
 
+  function addRingRoad(radius){
+    const width=26;
+    const ringGeo=new THREE.RingGeometry(radius-width/2, radius+width/2, 160);
+    const ring=new THREE.Mesh(ringGeo, new THREE.MeshLambertMaterial({ map: asphaltTex, side:THREE.DoubleSide }));
+    ring.rotation.x=-Math.PI/2;
+    ring.position.y=0.015;
+    ring.receiveShadow=allowShadows;
+    city.add(ring);
+    const stripe=new THREE.Mesh(new THREE.RingGeometry(radius-4, radius+4, 160), new THREE.MeshBasicMaterial({ color:0xffffff, transparent:true, opacity:0.35, side:THREE.DoubleSide }));
+    stripe.rotation.x=-Math.PI/2;
+    stripe.position.y=0.016;
+    city.add(stripe);
+    ringRoadData={radius,width,name:'Unaza e Madhe'};
+    const inner=Math.max(BLOCKS_X,BLOCKS_Z)*CELL*0.5 + ROAD*0.5;
+    const exits=6;
+    for(let i=0;i<exits;i++){
+      const ang=(i/exits)*Math.PI*2;
+      const start=inner;
+      const end=radius-ROAD*0.5;
+      if(end<=start) continue;
+      const length=end-start;
+      const geo=new THREE.PlaneGeometry(ROAD*1.2, length);
+      const connector=new THREE.Mesh(geo, roadMat);
+      connector.rotation.x=-Math.PI/2;
+      connector.rotation.y=ang;
+      const mid=start+length/2;
+      connector.position.set(Math.cos(ang)*mid,0.012,Math.sin(ang)*mid);
+      connector.receiveShadow=allowShadows;
+      city.add(connector);
+      const from=new THREE.Vector3(Math.cos(ang)*start,0,Math.sin(ang)*start);
+      const to=new THREE.Vector3(Math.cos(ang)*end,0,Math.sin(ang)*end);
+      ROAD_SEGMENTS.push({name:`Dalja ${i+1}`, from, to, width:ROAD*1.2, orientation:'connector'});
+      const sign=makeLabel('Ring Road',0.6);
+      sign.position.set(Math.cos(ang)*(end+3),3,Math.sin(ang)*(end+3));
+      sign.lookAt(sign.position.clone().add(new THREE.Vector3(0,0,1)));
+      city.add(sign);
+    }
+  }
+
   const POIS=[];
+  const CITY_LABELS=[];
+  const ROAD_SEGMENTS=[];
+  let ringRoadData=null;
+  const STREET_NAMES_NS=['Rr. Dëshmorët e Kombit','Rr. Skënderbej','Rr. Ismail Qemali','Rr. Kavajës','Rr. Myslym Shyri','Rr. Kodra e Diellit','Rr. Ali Demi','Rr. Don Bosko'];
+  const STREET_NAMES_EW=['Blv. Gjergj Fishta','Blv. Bajram Curri','Rr. e Barrikadave','Blv. Zogu I','Rr. Kongresi i Lushnjës','Rr. Pandeli Evangjeli','Blv. Dritan Hoxha','Rr. Teodor Keko'];
   function addInstitution(kind, x, z){
     let sign = kind==='hospital'?'HOSPITAL': kind==='police'?'POLICE': kind==='fire'?'FIRE': kind==='school'?'SCHOOL':'MALL';
     const b=addBuilding(x,z,{floors: (kind==='mall'?6:7), w: (kind==='mall'?70:48), d:(kind==='mall'?60:40), hue: kind==='hospital'?5: (kind==='police'?210: (kind==='fire'?8: (kind==='school'?40:80))), sign});
     if(kind==='hospital'){ const pad=new THREE.Mesh(new THREE.CircleGeometry(8,32), new THREE.MeshBasicMaterial({ color:0xffffff })); pad.rotation.x=-Math.PI/2; pad.position.set(x, b.dims.h+0.2, z- b.dims.d/2 + 10); city.add(pad); const H=new THREE.Mesh(new THREE.TorusGeometry(6,0.6,8,32), new THREE.MeshBasicMaterial({ color:0xff0000 })); H.rotation.x=-Math.PI/2; H.position.copy(pad.position).setY(b.dims.h+0.5); city.add(H); }
     const icon = kind==='hospital'?'🏥': kind==='police'?'🚓': kind==='fire'?'🧯': kind==='school'?'🏫':'🛍';
     POIS.push({type:kind, pos:new THREE.Vector3(x,0,z), label:icon, dims:b.dims});
+    const cityName = kind==='hospital'?'Spitali Qendror': kind==='police'?'Komisariati i Policisë': kind==='fire'?'Brigada e Zjarrfikësve': kind==='school'?'Akademia Metropolitane':'Qendra Tregtare';
+    CITY_LABELS.push({name:cityName,pos:new THREE.Vector3(x,0,z)});
   }
 
-  function addAirport(x,z){ const runway=new THREE.Mesh(new THREE.PlaneGeometry(400,26), new THREE.MeshBasicMaterial({ color:0x2f2f2f })); runway.rotation.x=-Math.PI/2; runway.position.set(x,0.02,z); city.add(runway); const stripe=new THREE.Mesh(new THREE.PlaneGeometry(400*0.9,3), new THREE.MeshBasicMaterial({ color:0xffffff, transparent:true, opacity:0.7 })); stripe.rotation.x=-Math.PI/2; stripe.position.set(x,0.03,z); city.add(stripe); const tower=new THREE.Mesh(new THREE.CylinderGeometry(4,4,28,16), new THREE.MeshStandardMaterial({ color:0x9aa0a8 })); tower.position.set(x+40,14,z-20); city.add(tower); const top=new THREE.Mesh(new THREE.SphereGeometry(6,16,12), new THREE.MeshStandardMaterial({ color:0xbfc6cf, metalness:0.2, roughness:0.6 })); top.position.set(x+40,28,z-20); city.add(top); POIS.push({type:'airport', pos:new THREE.Vector3(x,0,z), label:'🛫'}); }
-  function addTrainStation(x,z){ const plat=new THREE.Mesh(new THREE.PlaneGeometry(160,8), new THREE.MeshBasicMaterial({ color:0x666b73 })); plat.rotation.x=-Math.PI/2; plat.position.set(x,0.02,z); city.add(plat); const rails=new THREE.Group(); for(let i=0;i<4;i++){ const r=new THREE.Mesh(new THREE.PlaneGeometry(160,0.3), new THREE.MeshBasicMaterial({ color:0x444 })); r.rotation.x=-Math.PI/2; r.position.set(x,0.021,z-2+i*1.2); rails.add(r);} city.add(rails); addBuilding(x+30,z-8,{floors:5,w:50,d:16,hue:48,sign:'STATION'}); POIS.push({type:'station', pos:new THREE.Vector3(x,0,z), label:'🚉'}); }
+  function addAirport(x,z){ const runway=new THREE.Mesh(new THREE.PlaneGeometry(400,26), new THREE.MeshBasicMaterial({ color:0x2f2f2f })); runway.rotation.x=-Math.PI/2; runway.position.set(x,0.02,z); city.add(runway); const stripe=new THREE.Mesh(new THREE.PlaneGeometry(400*0.9,3), new THREE.MeshBasicMaterial({ color:0xffffff, transparent:true, opacity:0.7 })); stripe.rotation.x=-Math.PI/2; stripe.position.set(x,0.03,z); city.add(stripe); const tower=new THREE.Mesh(new THREE.CylinderGeometry(4,4,28,16), new THREE.MeshStandardMaterial({ color:0x9aa0a8 })); tower.position.set(x+40,14,z-20); city.add(tower); const top=new THREE.Mesh(new THREE.SphereGeometry(6,16,12), new THREE.MeshStandardMaterial({ color:0xbfc6cf, metalness:0.2, roughness:0.6 })); top.position.set(x+40,28,z-20); city.add(top); POIS.push({type:'airport', pos:new THREE.Vector3(x,0,z), label:'🛫'}); CITY_LABELS.push({name:'Aeroporti Tirana 2040', pos:new THREE.Vector3(x,0,z)}); }
+  function addTrainStation(x,z){ const plat=new THREE.Mesh(new THREE.PlaneGeometry(160,8), new THREE.MeshBasicMaterial({ color:0x666b73 })); plat.rotation.x=-Math.PI/2; plat.position.set(x,0.02,z); city.add(plat); const rails=new THREE.Group(); for(let i=0;i<4;i++){ const r=new THREE.Mesh(new THREE.PlaneGeometry(160,0.3), new THREE.MeshBasicMaterial({ color:0x444 })); r.rotation.x=-Math.PI/2; r.position.set(x,0.021,z-2+i*1.2); rails.add(r);} city.add(rails); addBuilding(x+30,z-8,{floors:5,w:50,d:16,hue:48,sign:'STATION'}); POIS.push({type:'station', pos:new THREE.Vector3(x,0,z), label:'🚉'}); CITY_LABELS.push({name:'Stacioni Qendror', pos:new THREE.Vector3(x,0,z)}); }
 
   const parkKinds=['tennis','basket','fountain'];
   for(let ix=0; ix<BLOCKS_X; ix++){
@@ -349,6 +432,8 @@ document.title = 'Tirana 2040 • Last Man Standing';
   for(let i=-BLOCKS_X;i<=BLOCKS_X;i+=2){ addTrafficLight(i*CELL*0.5, -BLOCKS_Z*CELL*0.5, 0); addTrafficLight(i*CELL*0.5, BLOCKS_Z*CELL*0.5, Math.PI); }
 
   const ringR = Math.max(BLOCKS_X,BLOCKS_Z)*CELL*0.65;
+  addRingRoad(ringR);
+  const MAP_EXTENT = ringR*1.25;
   addAirport(ringR*0.9,  -ringR*0.6);
   addTrainStation(-ringR*0.6, ringR*0.85);
 
@@ -360,7 +445,7 @@ document.title = 'Tirana 2040 • Last Man Standing';
 
   const playerRadius=0.35; const player=new CANNON.Body({ mass:75, material:matPlayer, shape:new CANNON.Sphere(playerRadius), position:new CANNON.Vec3(0,1.0,10), linearDamping:0.18, angularDamping:0.9 });
   player.fixedRotation=true; player.allowSleep=false; world.addBody(player);
-  let yaw=0, pitch=0; function clampPitch(){ pitch=Math.max(-Math.PI/2+0.005, Math.min(Math.PI/2-0.005, pitch)); }
+  let yaw=0, pitch=0; function clampPitch(){ const limit=Math.PI*0.72; pitch=Math.max(-limit, Math.min(limit, pitch)); }
   let camDist=4.2;
   function camFollow(pos,distMul=1){ const back=new THREE.Vector3(Math.sin(yaw),0,Math.cos(yaw)); const eye=new THREE.Vector3(pos.x - back.x*camDist*distMul, pos.y+2.1, pos.z - back.z*camDist*distMul); camera.position.lerp(eye,0.25); const look=new THREE.Vector3(pos.x + back.x*(camDist+0.2)*distMul, pos.y+1.25 + Math.sin(pitch)*0.8, pos.z + back.z*(camDist+0.2)*distMul); camera.lookAt(look); }
   function grounded(){ return player.position.y < 0.38 && Math.abs(player.velocity.y) < 0.05; }
@@ -387,6 +472,7 @@ document.title = 'Tirana 2040 • Last Man Standing';
     { key:'Grenade',name:'Grenade',url:'https://cdn.jsdelivr.net/gh/friuns2/bingextension@main/grenade.glb', s:0.30, stats:{ rpm:60,  dmg:120, spread:0.03,  mag:1,  reload:2.4 }, auto:false }
   ];
   const FIRE_MODES=new Map(); ARMORY.forEach(a=>FIRE_MODES.set(a.key, a.auto?'auto':'single'));
+  const GRENADE_STATS=ARMORY.find(a=>a.key==='Grenade')?.stats||{dmg:120, spread:0.03, mag:1, reload:2.4};
 
   const weaponRoot=new THREE.Group(); camera.add(weaponRoot);
   const weaponCache=new Map();
@@ -497,7 +583,159 @@ document.title = 'Tirana 2040 • Last Man Standing';
     },16);
   }
 
-  function doShot(){ const st=currentStats; if(!st) return; const a=ammo.get(currentKey); if(a.mag<=0){ return; } muzzleLight.intensity=1.6; setTimeout(()=>muzzleLight.intensity=0,45); sfxGun(currentKey);
+  async function createGrenade(origin, dir){
+    try{
+      const base=await loadWeapon('Grenade');
+      const grenade=base?.clone? base.clone(true) : base;
+      const holder=new THREE.Group();
+      if(grenade) holder.add(grenade);
+      holder.position.copy(origin);
+      scene.add(holder);
+      const body=new CANNON.Body({ mass:4.2, material:matGrenade, shape:new CANNON.Sphere(0.22), linearDamping:0.12, angularDamping:0.08 });
+      body.position.set(origin.x,origin.y,origin.z);
+      body.velocity.set(dir.x*18, dir.y*18 + 6, dir.z*18);
+      body.angularVelocity.set((Math.random()-0.5)*4,(Math.random()-0.5)*6,(Math.random()-0.5)*4);
+      world.addBody(body);
+      grenades.push({mesh:holder, body, fuse:2.4, exploded:false});
+    }catch(_){
+      const body=new CANNON.Body({ mass:4.2, material:matGrenade, shape:new CANNON.Sphere(0.22) });
+      body.position.set(origin.x,origin.y,origin.z);
+      body.velocity.set(dir.x*18, dir.y*18 + 6, dir.z*18);
+      world.addBody(body);
+      const fallback=new THREE.Mesh(new THREE.SphereGeometry(0.22,12,10), new THREE.MeshBasicMaterial({ color:0x999999 }));
+      fallback.position.copy(origin);
+      scene.add(fallback);
+      grenades.push({mesh:fallback, body, fuse:2.4, exploded:false});
+    }
+  }
+
+  function launchGrenade(){
+    const dir=new THREE.Vector3();
+    camera.getWorldDirection(dir);
+    dir.normalize();
+    const origin=camera.position.clone().addScaledVector(dir, 0.9);
+    origin.y = Math.max(origin.y, player.position.y + 1.1);
+    createGrenade(origin, dir);
+  }
+
+  function applyExplosionDamage(pos, baseDamage){
+    const radius=10;
+    enemies.forEach((e)=>{
+      if(e.dead) return;
+      const dist=e.body.position.distanceTo(pos);
+      if(dist>radius) return;
+      const falloff=Math.max(0,1-dist/radius);
+      const dmg=baseDamage*falloff;
+      e.hp -= dmg;
+      if(e.hp<=0){ e.dead=true; e.body.mass=0; e.body.updateMassProperties(); e.root.visible=false; e.hpBar.visible=false; }
+      else { updateBillboardBar(e.hpBar, e.hp/120); }
+    });
+    const playerDist=player.position.distanceTo(pos);
+    if(playerDist<=radius){ const falloff=Math.max(0,1-playerDist/radius); const harm=Math.round(45*falloff); if(harm>0){ hp=Math.max(0,hp-harm); updateHealth(); } }
+  }
+
+  function createExplosionEffect(pos){
+    const sphere=new THREE.Mesh(new THREE.SphereGeometry(0.6,24,18), new THREE.MeshBasicMaterial({ color:0xffa34d, transparent:true, opacity:0.85 }));
+    sphere.position.copy(pos);
+    scene.add(sphere);
+    const flash=new THREE.PointLight(0xffc878, 14, 32);
+    flash.position.copy(pos).setY(pos.y+2);
+    scene.add(flash);
+    explosions.push({mesh:sphere, light:flash, age:0});
+  }
+
+  function dispatchEmergency(pos){
+    emergencyUnits.forEach((unit)=>{
+      unit.dispatch={target:pos.clone(), arrived:false};
+      if(unit.mesh?.userData?.siren){ unit.mesh.userData.siren.active=true; }
+    });
+    setMiniMessage('Emergjencat u nisën!',5);
+  }
+
+  function explodeGrenade(entry){
+    if(entry.exploded) return;
+    entry.exploded=true;
+    if(entry.body){ world.removeBody(entry.body); entry.body=null; }
+    entry.mesh.visible=false;
+    const pos=entry.mesh.position.clone();
+    createExplosionEffect(pos);
+    applyExplosionDamage(pos, GRENADE_STATS.dmg);
+    dispatchEmergency(pos);
+  }
+
+  function updateGrenades(dt){
+    for(let i=grenades.length-1;i>=0;i--){
+      const g=grenades[i];
+      if(g.body){
+        g.mesh.position.set(g.body.position.x,g.body.position.y,g.body.position.z);
+        g.mesh.quaternion.set(g.body.quaternion.x,g.body.quaternion.y,g.body.quaternion.z,g.body.quaternion.w);
+      }
+      g.fuse -= dt;
+      if(g.fuse<=0 && !g.exploded){
+        explodeGrenade(g);
+      }
+      if(g.exploded){
+        g.fade=(g.fade||0)+dt;
+        if(g.fade>2){
+          scene.remove(g.mesh);
+          g.mesh.traverse?.((o)=>{
+            if(o.geometry?.dispose) o.geometry.dispose();
+            if(o.material){ if(Array.isArray(o.material)) o.material.forEach(m=>m.dispose?.()); else o.material.dispose?.(); }
+          });
+          grenades.splice(i,1);
+        }
+      }
+    }
+  }
+
+  function updateExplosions(dt){
+    for(let i=explosions.length-1;i>=0;i--){
+      const ex=explosions[i];
+      ex.age+=dt;
+      const scale=1+ex.age*9;
+      ex.mesh.scale.setScalar(scale);
+      ex.mesh.material.opacity=Math.max(0,0.9-ex.age*1.5);
+      if(ex.light){ ex.light.intensity=Math.max(0,12-ex.age*20); }
+      if(ex.age>1.2){
+        if(ex.light){ scene.remove(ex.light); }
+        scene.remove(ex.mesh);
+        ex.mesh.geometry.dispose();
+        ex.mesh.material.dispose();
+        explosions.splice(i,1);
+      }
+    }
+  }
+
+  const tempDir=new THREE.Vector3();
+  function updateEmergencyUnits(dt){
+    emergencyUnits.forEach((unit)=>{
+      const siren=unit.mesh.userData?.siren;
+      if(unit.dispatch){
+        const target=unit.dispatch.target;
+        const pos=unit.mesh.position;
+        tempDir.set(target.x-pos.x,0,target.z-pos.z);
+        const dist=tempDir.length();
+        if(dist>1.6){
+          tempDir.normalize();
+          const speed = unit.type==='fire'?11.5:9.5;
+          pos.x += tempDir.x*speed*dt;
+          pos.z += tempDir.z*speed*dt;
+          setHeading(unit.mesh, Math.atan2(tempDir.z, tempDir.x));
+        } else {
+          unit.mesh.position.set(target.x, 0, target.z);
+          unit.dispatch.arrived=true;
+        }
+      }
+      if(siren){
+        const active=!!unit.dispatch;
+        siren.phase = (siren.phase||0) + dt*(active?8:2);
+        const pulse=Math.sin(siren.phase);
+        siren.lamps?.forEach((lamp,idx)=>{ const on = active ? ((idx===0 && pulse>0) || (idx===1 && pulse<0)) : false; lamp.material.opacity=on?0.95:0.18; lamp.material.needsUpdate=true; });
+      }
+    });
+  }
+
+  function doShot(){ const st=currentStats; if(!st) return; const a=ammo.get(currentKey); if(a.mag<=0){ return; } if(currentKey==='Grenade'){ a.mag--; updateAmmoHUD(); sfxGun('Grenade'); launchGrenade(); return; } muzzleLight.intensity=1.6; setTimeout(()=>muzzleLight.intensity=0,45); sfxGun(currentKey);
     const spread=st.spread; const off=new THREE.Vector2((Math.random()-0.5)*spread*2,(Math.random()-0.5)*spread*2); const {from,to}=fireRay(off);
     tracer(from,to,0xfff1b1);
     const hits = raycaster.intersectObjects(impactTargets, true).filter(h=>h.object!==weaponModel && h.object !== aimLine);
@@ -514,12 +752,11 @@ document.title = 'Tirana 2040 • Last Man Standing';
   function noiseBuffer(ctx){ const b=ctx.createBuffer(1, ctx.sampleRate*1.0, ctx.sampleRate); const d=b.getChannelData(0); for(let i=0;i<d.length;i++){ d[i]= (Math.random()*2-1) * (1 - i/d.length); } return b; }
   function burstNoise({dur=0.12, freq=1500, type='bandpass', gain=0.12}){ withAC((ctx)=>{ const src=ctx.createBufferSource(); src.buffer=noiseBuffer(ctx); const bp=ctx.createBiquadFilter(); bp.type=type; bp.frequency.value=freq; const g=ctx.createGain(); g.gain.value=gain; src.connect(bp); bp.connect(g); g.connect(ctx.destination); src.start(); src.stop(ctx.currentTime+dur); }); }
   function click({freq=800,dur=0.02,gain=0.08}){ withAC((ctx)=>{ const o=ctx.createOscillator(); const g=ctx.createGain(); o.type='square'; o.frequency.value=freq; g.gain.value=gain; o.connect(g); g.connect(ctx.destination); o.start(); o.stop(ctx.currentTime+dur); }); }
-  function sfxGun(kind){ switch(kind){ case 'Glock': case 'Pistol': burstNoise({dur:0.09,freq:2200,gain:0.12}); click({freq:1800,dur:0.015,gain:0.06}); break; case 'AR': burstNoise({dur:0.08,freq:1900,gain:0.13}); click({freq:1600,dur:0.012,gain:0.05}); break; case 'Uzi': burstNoise({dur:0.05,freq:2300,gain:0.12}); click({freq:1900,dur:0.01,gain:0.05}); break; case 'AK47': burstNoise({dur:0.1,freq:1400,gain:0.14}); click({freq:1200,dur:0.015,gain:0.07}); break; default: burstNoise({dur:0.07,freq:1800,gain:0.12}); } }
+  function sfxGun(kind){ switch(kind){ case 'Glock': case 'Pistol': burstNoise({dur:0.09,freq:2200,gain:0.12}); click({freq:1800,dur:0.015,gain:0.06}); break; case 'AR': burstNoise({dur:0.08,freq:1900,gain:0.13}); click({freq:1600,dur:0.012,gain:0.05}); break; case 'Uzi': burstNoise({dur:0.05,freq:2300,gain:0.12}); click({freq:1900,dur:0.01,gain:0.05}); break; case 'AK47': burstNoise({dur:0.1,freq:1400,gain:0.14}); click({freq:1200,dur:0.015,gain:0.07}); break; case 'Grenade': burstNoise({dur:0.16,freq:680,gain:0.16}); break; default: burstNoise({dur:0.07,freq:1800,gain:0.12}); } }
   function sfxReload(){ click({freq:600,dur:0.05,gain:0.05}); setTimeout(()=>click({freq:900,dur:0.04,gain:0.05}),90); }
   $('muteBtn').addEventListener('click',(e)=>{ audio.muted=!audio.muted; e.target.textContent=audio.muted?'🔇':'🔊'; });
 
   const keys=new Set(); addEventListener('keydown',e=>{ keys.add(e.code); if(e.code==='Space') doShot(); if(e.code==='KeyR') reload(); }); addEventListener('keyup',e=>keys.delete(e.code));
-  $('resetBtn').addEventListener('click',()=>{ player.position.set(0,1.0,10); player.velocity.set(0,0,0); yaw=0; pitch=0; hp=100; updateHealth(); });
 
   const joyMove=$('joyMove'), knobMove=joyMove.querySelector('.knob');
   const R=150, K=85, DEAD=0.16;
@@ -534,7 +771,7 @@ document.title = 'Tirana 2040 • Last Man Standing';
   function mvRelease(e){ if(!mv.active||e.pointerId!==mv.id) return; mvEnd(); try{ joyMove.releasePointerCapture(e.pointerId); }catch(_){ } e.preventDefault(); }
   joyMove.addEventListener('pointerup', mvRelease); joyMove.addEventListener('pointercancel', mvRelease);
 
-  const shootPad=$('shootPad'); const shootKnob=shootPad.querySelector('.knob');
+  const shootPad=$('shootPad');
   let fireHeld=false;
   function shootDown(){ if(FIRE_MODES.get(currentKey)==='auto'){ fireHeld=true; } else { doShot(); } }
   function shootUp(){ fireHeld=false; }
@@ -548,9 +785,9 @@ document.title = 'Tirana 2040 • Last Man Standing';
   const canvasEl=renderer.domElement; canvasEl.style.touchAction='none';
   const look={active:false,id:null,lastX:0,lastY:0};
   let lookAccumX=0, lookAccumY=0; let aimSmoothX=0, aimSmoothY=0;
-  const LOOK_SENS_A  = isMobile ? 0.12 : 0.10;
-  const AIM_RATE_A   = 0.52;
-  const AIM_SMOOTH_A = 3.8;
+  const LOOK_SENS_A  = isMobile ? 0.24 : 0.16;
+  const AIM_RATE_A   = 1.28;
+  const AIM_SMOOTH_A = 7.2;
   function isUIBlock(el){ return el.closest('#joyMove')||el.closest('#shootPad')||el.closest('#armory')||el.closest('#reloadMini')||el.closest('#climbBtn')||el.closest('#radarBox')||el.closest('#zoomBox'); }
   canvasEl.addEventListener('pointerdown',(e)=>{ if(inputMode!=='A') return; if(isUIBlock(e.target)) return; if(look.active) return; look.active=true; look.id=e.pointerId; look.lastX=e.clientX; look.lastY=e.clientY; try{ canvasEl.setPointerCapture(e.pointerId); }catch(_){} e.preventDefault(); });
   canvasEl.addEventListener('pointermove',(e)=>{ if(inputMode!=='A') return; if(!look.active||e.pointerId!==look.id) return; const dx=e.clientX-look.lastX; const dy=e.clientY-look.lastY; look.lastX=e.clientX; look.lastY=e.clientY; lookAccumX += dx; lookAccumY += dy; e.preventDefault(); });
@@ -594,12 +831,28 @@ document.title = 'Tirana 2040 • Last Man Standing';
   function tintVehicle(root,hex){ const col=new THREE.Color(hex); root.traverse(o=>{ if(o.isMesh&&o.material&&o.material.color){ o.material.color.lerp(col,0.9); o.material.needsUpdate=true; } }); }
   function addSideLabels(root,text){ const b=new THREE.Box3().setFromObject(root); const s=new THREE.Vector3(); b.getSize(s); const y=b.min.y+s.y*0.6; const midZ=(b.min.z+b.max.z)/2; const L=makeLabel(text,0.9); const R=makeLabel(text,0.9); L.rotation.y=Math.PI/2; R.rotation.y=-Math.PI/2; L.position.set(b.min.x-0.02,y,midZ); R.position.set(b.max.x+0.02,y,midZ); root.add(L,R); }
 
+  function equipSiren(root, colors=['#ff3b30','#3aa7ff']){
+    const box=new THREE.Box3().setFromObject(root);
+    const width=box.max.x-box.min.x;
+    const bar=new THREE.Mesh(new THREE.BoxGeometry(width*0.42,0.18,0.6), new THREE.MeshBasicMaterial({ color:0x111827 }));
+    bar.position.set(0, box.max.y+0.32, 0);
+    const mkLamp=(color,offset)=>{ const lamp=new THREE.Mesh(new THREE.SphereGeometry(0.22,12,12), new THREE.MeshBasicMaterial({ color, transparent:true, opacity:0.95 })); lamp.position.set(offset, box.max.y+0.42, 0); return lamp; };
+    const left=mkLamp(colors[0], -width*0.22);
+    const right=mkLamp(colors[1], width*0.22);
+    const rig=new THREE.Group(); rig.add(bar,left,right);
+    root.add(rig);
+    root.userData.siren={lamps:[left,right], colors, phase:0, active:false};
+  }
+
   const parked=[]; const trafficCars=[];
+  const emergencyUnits=[];
+  const grenades=[];
+  const explosions=[];
   async function spawnParkedEmergency(){
     const hosp=POIS.find(p=>p.type==='hospital'); const pol=POIS.find(p=>p.type==='police'); const fire=POIS.find(p=>p.type==='fire');
-    if(hosp){ const v=(await getVehicle('ambulance')).clone(true); centerXZ(v); scaleToLength(v,3.8); placeOnGround(v,0); addSideLabels(v,'AMBULANCE'); tintVehicle(v,'#ef4444'); v.position.set(hosp.pos.x,0, hosp.pos.z + hosp.dims.d/2 + 6); scene.add(v); parked.push(v); }
-    if(pol){ const v=(await getVehicle('police')).clone(true); centerXZ(v); scaleToLength(v,3.8); placeOnGround(v,0); addSideLabels(v,'POLICE'); tintVehicle(v,'#1e3a8a'); v.position.set(pol.pos.x-4,0, pol.pos.z + pol.dims.d/2 + 6); scene.add(v); parked.push(v); }
-    if(fire){ const v=(await getVehicle('fire')).clone(true); centerXZ(v); scaleToLength(v,4.6); placeOnGround(v,0); addSideLabels(v,'FIRE'); tintVehicle(v,'#dc2626'); v.position.set(fire.pos.x+4,0, fire.pos.z + fire.dims.d/2 + 6); scene.add(v); parked.push(v); }
+    if(hosp){ const v=(await getVehicle('ambulance')).clone(true); centerXZ(v); scaleToLength(v,3.8); placeOnGround(v,0); addSideLabels(v,'AMBULANCE'); tintVehicle(v,'#ef4444'); equipSiren(v); v.position.set(hosp.pos.x,0, hosp.pos.z + hosp.dims.d/2 + 6); v.userData.home=v.position.clone(); scene.add(v); parked.push(v); emergencyUnits.push({mesh:v,type:'ambulance',dispatch:null}); }
+    if(pol){ const v=(await getVehicle('police')).clone(true); centerXZ(v); scaleToLength(v,3.8); placeOnGround(v,0); addSideLabels(v,'POLICE'); tintVehicle(v,'#1e3a8a'); equipSiren(v,['#1463ff','#f97316']); v.position.set(pol.pos.x-4,0, pol.pos.z + pol.dims.d/2 + 6); v.userData.home=v.position.clone(); scene.add(v); parked.push(v); emergencyUnits.push({mesh:v,type:'police',dispatch:null}); }
+    if(fire){ const v=(await getVehicle('fire')).clone(true); centerXZ(v); scaleToLength(v,4.6); placeOnGround(v,0); addSideLabels(v,'FIRE'); tintVehicle(v,'#dc2626'); equipSiren(v,['#ff2d20','#fffb00']); v.position.set(fire.pos.x+4,0, fire.pos.z + fire.dims.d/2 + 6); v.userData.home=v.position.clone(); scene.add(v); parked.push(v); emergencyUnits.push({mesh:v,type:'fire',dispatch:null}); }
   }
 
   function setHeading(mesh,angle){ mesh.rotation.y = angle + Math.PI/2; }
@@ -667,24 +920,166 @@ document.title = 'Tirana 2040 • Last Man Standing';
 
   let climbing=false, ladderIdx=-1; const climbBtn=$('climbBtn');
   function nearestLadder(){ let best=-1, bd=1e9; for(let i=0;i<ladders.length;i++){ const L=ladders[i]; const dx=player.position.x-L.x; const dz=player.position.z-L.z; const d=Math.hypot(dx,dz); if(d<bd){ bd=d; best=i; } } return {idx:best, dist:bd}; }
-  function setClimbUI(){ const n=nearestLadder(); if(!climbing && n.dist<1.2){ climbBtn.style.display='block'; climbBtn.textContent='⬆ Use/Climb Ladder'; } else if(climbing){ climbBtn.style.display='block'; climbBtn.textContent='⬇ Leave Ladder'; } else { climbBtn.style.display='none'; } }
-  climbBtn.addEventListener('click', ()=>{ if(climbing){ climbing=false; return; } const n=nearestLadder(); if(n.dist<1.2){ climbing=true; ladderIdx=n.idx; const L=ladders[ladderIdx]; player.velocity.x=player.velocity.z=0; player.position.x=L.x; player.position.z=L.z; } });
+  function setClimbUI(){ const n=nearestLadder(); climbBtn.style.display='block'; if(climbing){ climbBtn.disabled=false; climbBtn.textContent='⬇ Zbrit nga shkalla'; } else if(n.dist<1.5){ climbBtn.disabled=false; climbBtn.textContent='⬆ Ngjitu në shkallë'; } else { climbBtn.disabled=true; climbBtn.textContent='Pozicionohu te shkalla'; } }
+  climbBtn.addEventListener('click', ()=>{ if(climbBtn.disabled) return; if(climbing){ climbing=false; return; } const n=nearestLadder(); if(n.dist<1.5){ climbing=true; ladderIdx=n.idx; const L=ladders[ladderIdx]; player.velocity.x=player.velocity.z=0; player.position.x=L.x; player.position.z=L.z; } });
   function doClimb(moveZ,dt){ const L=ladders[ladderIdx]; if(!L){ climbing=false; return; } const speed=2.6; if(moveZ>0.05) player.position.y = Math.min(L.y1+0.5, player.position.y + speed*dt); else if(moveZ<-0.05) player.position.y = Math.max(L.y0+0.4, player.position.y - speed*dt); if(Math.hypot(player.position.x-L.x, player.position.z-L.z)>0.9){ climbing=false; } }
 
   const radar=$('radar'), rctx=radar.getContext('2d'); function resizeRadar(){ radar.width=radar.clientWidth; radar.height=radar.clientHeight; } resizeRadar(); addEventListener('resize', resizeRadar);
-  function drawRadar(){ const w=radar.width,h=radar.height; rctx.clearRect(0,0,w,h); rctx.fillStyle='rgba(20,24,38,0.9)'; rctx.fillRect(0,0,w,h); rctx.strokeStyle='rgba(255,255,255,0.2)'; rctx.strokeRect(0,0,w,h); const cx=w/2, cy=h/2; rctx.fillStyle='#7da2ff'; rctx.beginPath(); rctx.arc(cx,cy,3,0,Math.PI*2); rctx.fill(); for(const p of POIS){ const dx=p.pos.x-player.position.x, dz=p.pos.z-player.position.z; const sc=0.08; const x=cx+dx*sc, y=cy+dz*sc; if(x<0||y<0||x>w||y>h) continue; rctx.font='14px system-ui'; rctx.fillText(p.label,x-6,y-6); } }
+  function drawRadar(){
+    const w=radar.width,h=radar.height;
+    rctx.clearRect(0,0,w,h);
+    rctx.fillStyle='rgba(20,24,38,0.9)';
+    rctx.fillRect(0,0,w,h);
+    rctx.strokeStyle='rgba(255,255,255,0.2)';
+    rctx.strokeRect(0,0,w,h);
+    const cx=w/2, cy=h/2; const sc=0.08;
+    rctx.lineWidth=2;
+    rctx.strokeStyle='rgba(255,255,255,0.28)';
+    for(const road of ROAD_SEGMENTS){
+      const x0=cx+(road.from.x-player.position.x)*sc;
+      const y0=cy+(road.from.z-player.position.z)*sc;
+      const x1=cx+(road.to.x-player.position.x)*sc;
+      const y1=cy+(road.to.z-player.position.z)*sc;
+      if((x0<-20&&x1<-20)||(x0>w+20&&x1>w+20)||(y0<-20&&y1<-20)||(y0>h+20&&y1>h+20)) continue;
+      rctx.beginPath();
+      rctx.moveTo(x0,y0);
+      rctx.lineTo(x1,y1);
+      rctx.stroke();
+      const mx=(x0+x1)/2, my=(y0+y1)/2;
+      if(road.orientation!=='connector' && mx>12&&mx<w-12&&my>12&&my<h-12){
+        rctx.save();
+        rctx.translate(mx,my);
+        const ang=Math.atan2(y1-y0,x1-x0);
+        rctx.rotate(ang);
+        rctx.fillStyle='rgba(255,255,255,0.85)';
+        rctx.font='10px 600 system-ui';
+        rctx.textAlign='center';
+        rctx.fillText(road.name,0,-4);
+        rctx.restore();
+      }
+    }
+    if(ringRoadData){
+      rctx.strokeStyle='rgba(255,255,255,0.2)';
+      rctx.lineWidth=1.5;
+      const rad=ringRoadData.radius*sc;
+      rctx.beginPath();
+      rctx.arc(cx,cy,rad,0,Math.PI*2);
+      rctx.stroke();
+    }
+    rctx.fillStyle='#7da2ff';
+    rctx.beginPath();
+    rctx.arc(cx,cy,3,0,Math.PI*2);
+    rctx.fill();
+    rctx.font='13px system-ui';
+    for(const p of POIS){
+      const dx=p.pos.x-player.position.x, dz=p.pos.z-player.position.z;
+      const x=cx+dx*sc, y=cy+dz*sc;
+      if(x<8||y<8||x>w-8||y>h-8) continue;
+      rctx.fillText(p.label,x-8,y-6);
+    }
+    rctx.fillStyle='rgba(255,255,255,0.9)';
+    rctx.font='11px 600 system-ui';
+    for(const label of CITY_LABELS){
+      const dx=label.pos.x-player.position.x, dz=label.pos.z-player.position.z;
+      const x=cx+dx*sc, y=cy+dz*sc;
+      if(x<10||y<10||x>w-10||y>h-10) continue;
+      rctx.textAlign='center';
+      rctx.fillText(label.name,x,y+10);
+    }
+  }
   const mapOverlay=$('mapOverlay'), mapCanvas=$('mapCanvas'), mctx=mapCanvas.getContext('2d'); function resizeMap(){ mapCanvas.width=mapCanvas.clientWidth; mapCanvas.height=mapCanvas.clientHeight; } resizeMap(); addEventListener('resize', resizeMap);
-  function drawMap(){ const w=mapCanvas.width,h=mapCanvas.height; mctx.fillStyle='#0b0f1a'; mctx.fillRect(0,0,w,h); mctx.strokeStyle='#3b4252'; mctx.lineWidth=2; for(let i=0;i<=BLOCKS_X;i++){ const x=(i/BLOCKS_X)*w; mctx.beginPath(); mctx.moveTo(x,0); mctx.lineTo(x,h); mctx.stroke(); } for(let i=0;i<=BLOCKS_Z;i++){ const y=(i/BLOCKS_Z)*h; mctx.beginPath(); mctx.moveTo(0,y); mctx.lineTo(w,y); mctx.stroke(); } mctx.font='16px 700 system-ui'; mctx.fillStyle='#e5e7eb'; for(const p of POIS){ const ux=(p.pos.x - (-BLOCKS_X*CELL/2)) / (BLOCKS_X*CELL); const uz=(p.pos.z - (-BLOCKS_Z*CELL/2)) / (BLOCKS_Z*CELL); const x=ux*w, y=uz*h; mctx.fillText(p.label, x-8, y-8); } mctx.fillStyle='#7da2ff'; const px=(player.position.x - (-BLOCKS_X*CELL/2)) / (BLOCKS_X*CELL)*w; const py=(player.position.z - (-BLOCKS_Z*CELL/2)) / (BLOCKS_Z*CELL)*h; mctx.beginPath(); mctx.arc(px,py,6,0,Math.PI*2); mctx.fill(); }
-  $('radarBox').addEventListener('click', ()=>{ mapOverlay.style.display='flex'; drawMap(); });
+  function drawMap(){
+    const w=mapCanvas.width,h=mapCanvas.height;
+    const range=MAP_EXTENT*2;
+    const project=(x,z)=>[(x+MAP_EXTENT)/range*w,(z+MAP_EXTENT)/range*h];
+    mctx.clearRect(0,0,w,h);
+    mctx.fillStyle='#0b1120';
+    mctx.fillRect(0,0,w,h);
+    mctx.strokeStyle='#283347';
+    mctx.lineWidth=1.2;
+    for(const road of ROAD_SEGMENTS){
+      const [x0,y0]=project(road.from.x, road.from.z);
+      const [x1,y1]=project(road.to.x, road.to.z);
+      mctx.lineWidth=Math.max(1.2, road.width/range*w);
+      mctx.beginPath();
+      mctx.moveTo(x0,y0);
+      mctx.lineTo(x1,y1);
+      mctx.stroke();
+      if(road.orientation!=='connector'){
+        const mx=(x0+x1)/2, my=(y0+y1)/2;
+        mctx.save();
+        mctx.translate(mx,my);
+        const ang=Math.atan2(y1-y0,x1-x0);
+        mctx.rotate(ang);
+        mctx.fillStyle='rgba(255,255,255,0.7)';
+        mctx.font='14px 600 system-ui';
+        mctx.textAlign='center';
+        mctx.fillText(road.name,0,-6);
+        mctx.restore();
+      }
+    }
+    if(ringRoadData){
+      const center=project(0,0);
+      const radius=ringRoadData.radius/range*w;
+      mctx.lineWidth=ringRoadData.width/range*w;
+      mctx.strokeStyle='#3d4b5f';
+      mctx.beginPath();
+      mctx.arc(center[0],center[1],radius,0,Math.PI*2);
+      mctx.stroke();
+      mctx.lineWidth=1.4;
+      mctx.strokeStyle='rgba(255,255,255,0.35)';
+      mctx.beginPath();
+      mctx.arc(center[0],center[1],radius-ringRoadData.width*0.15/range*w,0,Math.PI*2);
+      mctx.stroke();
+    }
+    mctx.save();
+    mctx.fillStyle='rgba(255,255,255,0.08)';
+    for(const p of POIS){
+      if(!p.dims) continue;
+      const halfW=p.dims.w/2, halfD=p.dims.d/2;
+      const [x0,y0]=project(p.pos.x-halfW,p.pos.z-halfD);
+      const [x1,y1]=project(p.pos.x+halfW,p.pos.z+halfD);
+      const wRect=x1-x0, hRect=y1-y0;
+      mctx.fillRect(x0,y0,wRect,hRect);
+    }
+    mctx.restore();
+    mctx.font='24px system-ui';
+    mctx.textAlign='center';
+    mctx.textBaseline='middle';
+    mctx.fillStyle='#f4f5f7';
+    for(const p of POIS){
+      const [x,y]=project(p.pos.x,p.pos.z);
+      mctx.fillText(p.label,x-10,y-10);
+    }
+    mctx.font='16px 600 system-ui';
+    mctx.textBaseline='top';
+    mctx.fillStyle='#e0e5ef';
+    for(const label of CITY_LABELS){
+      const [x,y]=project(label.pos.x,label.pos.z);
+      mctx.textAlign='center';
+      mctx.fillText(label.name,x,y+18);
+    }
+    const [px,py]=project(player.position.x,player.position.z);
+    mctx.fillStyle='#7da2ff';
+    mctx.beginPath();
+    mctx.arc(px,py,6,0,Math.PI*2);
+    mctx.fill();
+  }
+  $('radarBox').addEventListener('click', ()=>{ mapOverlay.style.display='flex'; requestAnimationFrame(()=>{ resizeMap(); drawMap(); }); });
   $('mapClose').addEventListener('click', ()=>{ mapOverlay.style.display='none'; });
 
   let waypoint=null;
-  mapCanvas.addEventListener('click', (e)=>{ const r=mapCanvas.getBoundingClientRect(); const x=e.clientX-r.left, y=e.clientY-r.top; const ux=x/mapCanvas.width, uz=y/mapCanvas.height; const wx = -BLOCKS_X*CELL/2 + ux*(BLOCKS_X*CELL); const wz = -BLOCKS_Z*CELL/2 + uz*(BLOCKS_Z*CELL); waypoint=new THREE.Vector3(wx,0,wz); mapOverlay.style.display='none'; });
+  mapCanvas.addEventListener('click', (e)=>{ const r=mapCanvas.getBoundingClientRect(); const x=e.clientX-r.left, y=e.clientY-r.top; const ux=x/mapCanvas.width, uz=y/mapCanvas.height; const wx = -MAP_EXTENT + ux*(MAP_EXTENT*2); const wz = -MAP_EXTENT + uz*(MAP_EXTENT*2); waypoint=new THREE.Vector3(wx,0,wz); mapOverlay.style.display='none'; announceNavigation(wx,wz); });
 
-  let last=performance.now(); let frameCount=0,fpsTimer=0; let fireCd=0; const mini=$('mini'); updateAmmoHUD();
+  let last=performance.now(); let frameCount=0,fpsTimer=0; let fireCd=0; const mini=$('mini');
+  let miniMsgTimer=0, miniMessage=''; let fpsDisplay='fps: 0';
+  function setMiniMessage(msg,duration=4){ miniMessage=msg; miniMsgTimer=duration; }
+  function announceNavigation(wx,wz){ const target=new THREE.Vector3(wx,0,wz); let closestRoad=null, roadDist=Infinity; for(const road of ROAD_SEGMENTS){ const mid=new THREE.Vector3((road.from.x+road.to.x)/2,0,(road.from.z+road.to.z)/2); const d=mid.distanceTo(target); if(d<roadDist){ roadDist=d; closestRoad=road; } } let closestLabel=null, labelDist=Infinity; for(const label of CITY_LABELS){ const d=label.pos.distanceTo(target); if(d<labelDist){ labelDist=d; closestLabel=label; } } const roadName=closestRoad?.name||'rruga kryesore'; const msg=closestLabel?`Navigim drejt ${closestLabel.name} • ${roadName}`:`Navigim përgjatë ${roadName}`; setMiniMessage(msg,6); }
+  updateAmmoHUD();
   function loop(now){
     const dt=Math.min((now-last)/1000,0.05); last=now;
-    frameCount++; fpsTimer+=dt; if(fpsTimer>=0.5){ const fps=(frameCount/fpsTimer)|0; mini.textContent='fps: '+fps; if(fps<88 && dprScale>DPR_MIN){ dprScale=Math.max(DPR_MIN,dprScale-0.05); fit(); } else if(fps>120 && dprScale<DPR_MAX_SCALE){ dprScale=Math.min(DPR_MAX_SCALE,dprScale+0.04); fit(); } frameCount=0; fpsTimer=0; }
+    frameCount++; fpsTimer+=dt; if(fpsTimer>=0.5){ const fps=(frameCount/fpsTimer)|0; fpsDisplay='fps: '+fps; if(fps<88 && dprScale>DPR_MIN){ dprScale=Math.max(DPR_MIN,dprScale-0.05); fit(); } else if(fps>120 && dprScale<DPR_MAX_SCALE){ dprScale=Math.min(DPR_MAX_SCALE,dprScale+0.04); fit(); } frameCount=0; fpsTimer=0; }
+    if(miniMsgTimer>0){ miniMsgTimer=Math.max(0, miniMsgTimer-dt); mini.textContent=miniMessage; } else { mini.textContent=fpsDisplay; }
 
     if(inputMode==='A'){ const k = Math.min(1, dt*AIM_SMOOTH_A); const ax = lookAccumX * LOOK_SENS_A; const ay = lookAccumY * LOOK_SENS_A; lookAccumX=0; lookAccumY=0; aimSmoothX += (ax - aimSmoothX)*k; aimSmoothY += (ay - aimSmoothY)*k; yaw   -= aimSmoothX * AIM_RATE_A * dt; pitch -= aimSmoothY * AIM_RATE_A * dt; clampPitch(); }
 
@@ -715,6 +1110,9 @@ document.title = 'Tirana 2040 • Last Man Standing';
     if(waypoint){ const guide=new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(player.position.x,0.1,player.position.z), new THREE.Vector3(waypoint.x,0.1,waypoint.z)]); const mat=new THREE.LineDashedMaterial({ color:0x66ccff, dashSize:2, gapSize:1 }); const ln=new THREE.Line(guide,mat); ln.computeLineDistances(); scene.add(ln); setTimeout(()=>{ scene.remove(ln); guide.dispose(); mat.dispose(); }, 120); }
 
     world.step(1/90, dt, 3);
+    updateGrenades(dt);
+    updateExplosions(dt);
+    updateEmergencyUnits(dt);
     updateTracers(dt);
 
     try{ renderer.render(scene,camera); }catch(err){ }


### PR DESCRIPTION
## Summary
- restyle the Tirana 2040 mobile HUD to keep the shoot/reload controls aligned, enlarge the radar, and reposition the AK47 zoom slider near the screen edge
- enrich the city data so radar and map views render street names, destinations, and a working ring road while the big map provides click-to-navigate directions
- implement live grenade projectiles with explosive damage and emergency vehicle response, expand sports and civic landmarks, and keep ladder climb controls visible

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6915b5d448b083258f3b393150faf1ce)