### PR TITLE
feat: refresh free kick field grass texture

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -811,65 +811,83 @@
     ctx.restore();
   }
 
-  function drawGrassBackground(context, rect, stripeWidth){
+  function drawGrassBackground(context, rect){
     const { x, y, w, h } = rect;
-    const effectiveStripe = Math.max(4, stripeWidth || 4);
     context.save();
     context.beginPath();
     context.rect(x, y, w, h);
     context.clip();
 
-    if(fieldTextureReady){
+    let drewTexture = false;
+    if (fieldTextureReady) {
       const source = fieldPatternCanvas || fieldTextureCanvas || fieldTextureImg;
       const pattern = source ? context.createPattern(source, 'repeat') : null;
-      if (pattern){
-        if (pattern.setTransform){
+      if (pattern) {
+        if (pattern.setTransform) {
           const base = Math.max(1, source.width || source.height || 256);
-          const density = Math.sqrt((w * h) / 650000);
-          const scale = Math.max(0.25, Math.min(0.9, density * (256 / base)));
-          pattern.setTransform(new DOMMatrix().scale(scale, scale));
+          const density = Math.sqrt((w * h) / 720000);
+          const scaleX = Math.max(0.22, Math.min(0.82, density * (256 / base)));
+          const scaleY = Math.max(0.18, Math.min(0.7, scaleX * 0.88));
+          const matrix = new DOMMatrix();
+          matrix.a = scaleX;
+          matrix.d = scaleY;
+          pattern.setTransform(matrix);
         }
         context.fillStyle = pattern;
         context.fillRect(x, y, w, h);
+        drewTexture = true;
       } else {
         const textureSource = fieldTextureCanvas || fieldTextureImg;
-        const sourceW = Math.max(1, textureSource.width || fieldTextureImg.width || 1);
-        const sourceH = Math.max(1, textureSource.height || fieldTextureImg.height || 1);
-        const widthFactor = Math.max(0.18, Math.min(0.62, 0.28 + (w / 900) * 0.6));
-        const tileW = Math.max(48, sourceW * widthFactor);
-        const tileH = Math.max(48, sourceH * widthFactor);
-        for(let ty = y; ty < y + h; ty += tileH){
-          for(let tx = x; tx < x + w; tx += tileW){
-            context.drawImage(textureSource, tx, ty, tileW, tileH);
+        if (textureSource && textureSource.width && textureSource.height) {
+          const tileBase = Math.max(textureSource.width, textureSource.height, 128);
+          const density = Math.max(0.26, Math.min(0.8, Math.sqrt((w * h) / 780000)));
+          const tileSize = tileBase * density;
+          for (let ty = y; ty < y + h; ty += tileSize) {
+            for (let tx = x; tx < x + w; tx += tileSize) {
+              context.drawImage(textureSource, tx, ty, tileSize, tileSize);
+            }
           }
+          drewTexture = true;
         }
-      }
-    } else {
-      let idx = 0;
-      for(let ty = y; ty < y + h; ty += effectiveStripe){
-        context.fillStyle = (idx % 2)
-          ? getComputedStyle(document.documentElement).getPropertyValue('--turf2')||'#0a6c1d'
-          : getComputedStyle(document.documentElement).getPropertyValue('--turf1')||'#0c7a23';
-        context.fillRect(x, ty, w, effectiveStripe);
-        idx++;
       }
     }
 
-    let overlayIndex = 0;
-    const lightAlpha = fieldTextureReady ? 0.08 : 0.04;
-    for(let ty = y; ty < y + h; ty += effectiveStripe){
-      context.fillStyle = (overlayIndex % 2)
-        ? `rgba(0,0,0,${lightAlpha * 1.4})`
-        : `rgba(255,255,255,${lightAlpha})`;
-      context.fillRect(x, ty, w, effectiveStripe);
-      overlayIndex++;
+    if (!drewTexture) {
+      const turf1 = getComputedStyle(document.documentElement).getPropertyValue('--turf1') || '#0c7a23';
+      const turf2 = getComputedStyle(document.documentElement).getPropertyValue('--turf2') || '#0a6c1d';
+      const baseGradient = context.createLinearGradient(0, y, 0, y + h);
+      baseGradient.addColorStop(0, turf1);
+      baseGradient.addColorStop(1, turf2);
+      context.fillStyle = baseGradient;
+      context.fillRect(x, y, w, h);
     }
+
+    const depthShade = context.createLinearGradient(0, y, 0, y + h);
+    depthShade.addColorStop(0, 'rgba(0, 0, 0, 0.42)');
+    depthShade.addColorStop(0.35, 'rgba(0, 0, 0, 0.18)');
+    depthShade.addColorStop(1, 'rgba(0, 0, 0, 0)');
+    context.globalAlpha = 0.55;
+    context.fillStyle = depthShade;
+    context.fillRect(x, y, w, h);
+
+    context.globalAlpha = 0.28;
+    const highlight = context.createLinearGradient(0, y, 0, y + h);
+    highlight.addColorStop(0, 'rgba(255, 255, 255, 0.16)');
+    highlight.addColorStop(0.4, 'rgba(255, 255, 255, 0.04)');
+    highlight.addColorStop(1, 'rgba(255, 255, 255, 0)');
+    const prevOp = context.globalCompositeOperation;
+    context.globalCompositeOperation = 'overlay';
+    context.fillStyle = highlight;
+    context.fillRect(x, y, w, h);
+    context.globalCompositeOperation = prevOp;
+    context.globalAlpha = 1;
+
     context.restore();
   }
 
   function drawField(){
     drawStadium();
-    drawGrassBackground(ctx, { x: 0, y: 0, w: W, h: H }, STRIPE);
+    drawGrassBackground(ctx, { x: 0, y: 0, w: W, h: H });
     const vg=ctx.createRadialGradient(W/2,H,10,W/2,H,H/1.12); vg.addColorStop(0,'rgba(0,0,0,0)'); vg.addColorStop(1,'rgba(0,0,0,0.26)'); ctx.fillStyle=vg; ctx.fillRect(0,0,W,H);
 
     const kickerLineY = H - STRIPE*3;
@@ -1824,7 +1842,7 @@ function onUp(e){
       c.beginPath();
       c.rect(field.x,field.y,field.w,field.h);
       c.clip();
-      drawGrassBackground(c, field, stripe);
+      drawGrassBackground(c, field);
       const vg=c.createRadialGradient(field.x+field.w/2,field.y+field.h,10,field.x+field.w/2,field.y+field.h,field.h/1.12);
       vg.addColorStop(0,'rgba(0,0,0,0)');
       vg.addColorStop(1,'rgba(0,0,0,0.26)');


### PR DESCRIPTION
## Summary
- replace the canvas turf rendering with the realistic grass texture used in the 3D sample and add depth/lighting shading
- update all field drawing calls to use the refreshed grass helper

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6916c8355e108325b0b0273fd72e175b)