### PR TITLE
Restore Tirana 2040 classic HUD layout

### DIFF
--- a/webapp/public/tirana-2040.html
+++ b/webapp/public/tirana-2040.html
@@ -1,763 +1,954 @@
 <!doctype html>
 <html lang="sq">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
-  <title>Tirana 2040 • Battle Royale Sandbox</title>
-  <style>
-    html,body{margin:0;height:100%;background:#f3e3c7;overflow:hidden;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
-    body,.hud{touch-action:none}
-    #wrap{position:fixed;inset:0}
-    canvas{width:100%;height:100%;display:block;touch-action:none;user-select:none}
-    .hud{position:fixed;inset:0;pointer-events:none}
-    .row{position:absolute;left:10px;right:10px;display:flex;gap:8px;align-items:center}
-    .top{top:8px;justify-content:space-between}
-    .bottom{bottom:10px;justify-content:space-between}
-    .chip{background:rgba(0,0,0,.35);color:#fff;border-radius:999px;padding:6px 10px;font-size:12px;backdrop-filter:blur(4px);pointer-events:auto}
-    .btn{background:rgba(0,0,0,.35);color:#fff;border:0;border-radius:14px;padding:10px 14px;font-size:14px;cursor:pointer;pointer-events:auto}
-    .btn:active{transform:translateY(1px)}
-    .btn[disabled]{opacity:.45;cursor:not-allowed}
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, user-scalable=no" />
+<title>Tirana 2040 • Last Man Standing</title>
+<style>
+  :root{
+    color-scheme: light;
+    --hud-gap: clamp(12px, 3vw, 24px);
+    --pad-offset: clamp(18px, 12vh, 120px);
+    --joy-size: clamp(98px, 23.8vw, 140px);
+    --joy-knob: clamp(56px, 15.4vw, 98px);
+    --hud-blur: 10px;
+  }
+  html,body{margin:0;height:100%;background:#f5e7cf;overflow:hidden;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+  #wrap{position:fixed;inset:0}
+  canvas{display:block;width:100%;height:100%;touch-action:none;user-select:none}
+  .hud{position:fixed;inset:0;pointer-events:none}
+  .row{position:absolute;left:var(--hud-gap);right:var(--hud-gap);display:flex;gap:10px;align-items:center;z-index:15}
+  .top{top:var(--hud-gap);justify-content:space-between}
+  .bottom{bottom:var(--hud-gap);justify-content:space-between;align-items:flex-end}
+  .chip{background:rgba(0,0,0,.32);color:#fff;border-radius:999px;padding:5px 10px;font-size:clamp(9px,2.4vw,12px);backdrop-filter:blur(var(--hud-blur));pointer-events:auto}
+  .btn{background:rgba(0,0,0,.35);color:#fff;border:0;border-radius:14px;padding:6px 10px;font-size:clamp(9px,2.4vw,12px);cursor:pointer;pointer-events:auto;backdrop-filter:blur(var(--hud-blur));transition:transform .15s ease}
+  .btn:active{transform:translateY(1px)}
+  .btn[disabled]{opacity:.45;cursor:not-allowed}
 
-    #armory{z-index:10}
-    .joy{position:absolute;width:300px;height:300px;border-radius:50%;background:rgba(0,0,0,.08);border:1px solid rgba(0,0,0,.25);opacity:.96;pointer-events:auto;touch-action:none;display:block;z-index:20}
-    .knob{position:absolute;left:50%;top:50%;width:160px;height:160px;transform:translate(-50%,-50%);border-radius:50%;background:rgba(0,0,0,.25);border:1px solid rgba(0,0,0,.35)}
-    #joyMove{left:18px;bottom:220px}
-    #shootPad{right:18px;bottom:220px}
-    #aimPad{right:18px;bottom:220px;display:none}
-    #shootPad .knob{background:radial-gradient(circle at 50% 50%, rgba(255,70,70,1) 0 30%, rgba(0,0,0,.28) 31%), rgba(0,0,0,.25);}
-    #shootPad .knob::after{content:'SHOOT';position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);color:#fff;font-weight:900;font-size:18px;letter-spacing:.6px;text-shadow:0 1px 2px rgba(0,0,0,.65);}
-
-    #reloadMini{position:absolute;left:50%;top:-190px;transform:translateX(-50%);width:160px;height:160px;display:flex;align-items:center;justify-content:center;border-radius:50%;border:1px solid rgba(0,0,0,.35);background:radial-gradient(circle at 50% 50%, rgba(255,70,70,1) 0 30%, rgba(0,0,0,.28) 31%), rgba(0,0,0,.25);color:#fff;font-size:18px;font-weight:900;letter-spacing:.6px;pointer-events:auto;box-shadow:0 6px 16px rgba(0,0,0,.35)}
-
-    #crosshair{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:var(--crossSize,30px);height:var(--crossSize,30px);pointer-events:none;z-index:50;display:block}
-    #crosshair:before,#crosshair:after{content:"";position:absolute;left:50%;top:50%;background:var(--aimColor,#ff3c3c);box-shadow:0 0 0 2px rgba(255,255,255,0.9) inset, 0 0 6px rgba(0,0,0,.35)}
-    #crosshair:before{width:24px;height:3px;transform:translate(-50%,-50%);opacity:.98}
-    #crosshair:after{width:3px;height:24px;transform:translate(-50%,-50%);opacity:.98}
-
-    #ammo{position:absolute;right:10px;top:40px;color:#fff;font-weight:600;background:rgba(0,0,0,.35);padding:8px 12px;border-radius:10px;pointer-events:auto}
-    #healthbar{position:absolute;left:10px;top:46px;width:260px;height:16px;background:rgba(0,0,0,.2);border-radius:999px;overflow:hidden}
-    #healthfill{width:100%;height:100%;background:linear-gradient(90deg,#29ff9a,#00c876)}
-
-    #armory{position:absolute;left:10px;right:10px;bottom:86px;display:flex;gap:8px;overflow:auto;padding:8px;border-radius:14px;background:rgba(0,0,0,.25);backdrop-filter:blur(6px);pointer-events:auto;scrollbar-width:none;-ms-overflow-style:none}
-    #armory::-webkit-scrollbar{height:6px}
-    #armory.dragging{cursor:grabbing}
-    .armBtn{position:relative;flex:0 0 auto;min-width:138px;max-width:168px;padding:8px;border-radius:12px;border:1px solid rgba(255,255,255,.16);background:rgba(0,0,0,.35);color:#e6eefc;font-weight:700;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:6px;user-select:none}
-    .armBtn img{width:124px;height:76px;object-fit:contain;display:block;filter:drop-shadow(0 1px 1px rgba(0,0,0,.3))}
-    .armBtn span{font-size:12px;opacity:.95}
-    .armBtn.active{outline:2px solid #ffd966;background:rgba(17,23,42,.55)}
-    .armBtn[data-dragging="true"]{pointer-events:none}
-    .modeToggle{position:absolute;right:6px;top:6px;padding:3px 6px;border-radius:10px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.45);color:#fff;font-size:10px;cursor:pointer}
-
-    #mini{position:absolute;left:10px;bottom:56px;color:#0b1324;background:rgba(255,255,255,.6);padding:4px 8px;border-radius:8px;font-size:11px;pointer-events:auto}
-
-    #br{position:absolute;left:50%;top:8px;transform:translateX(-50%);background:rgba(0,0,0,.35);color:#fff;padding:6px 10px;border-radius:999px;font-weight:700;pointer-events:auto}
-
-    #modeBox{position:absolute;right:10px;top:46px;display:flex;gap:6px;pointer-events:auto}
-    .modeBtn{padding:6px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.35);color:#fff;font-size:12px;cursor:pointer}
-    .modeBtn.active{background:#2a7fff}
-
-    #useCarBtn{position:absolute;left:50%;bottom:168px;transform:translateX(-50%);padding:10px 14px;border-radius:12px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.6);color:#fff;pointer-events:auto;display:none}
-    #exitCarBtn{position:absolute;right:12px;bottom:168px;padding:10px 14px;border-radius:12px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.6);color:#fff;pointer-events:auto;display:none}
-    #hornBtn{position:absolute;left:50%;bottom:118px;transform:translateX(-50%);padding:10px 14px;border-radius:12px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.6);color:#fff;pointer-events:auto;display:none}
-    #brakeBtn{position:absolute;left:calc(50% - 170px);bottom:118px;padding:10px 14px;border-radius:12px;border:1px solid rgba(255,255,255,.25);background:rgba(220,0,0,.75);color:#fff;pointer-events:auto;display:none}
-
-    #climbBtn{position:absolute;left:50%;bottom:156px;transform:translateX(-50%);padding:8px 12px;border-radius:12px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.7);color:#fff;font-size:14px;pointer-events:auto;display:none}
-
-    #zoomBox{position:absolute;right:4px;bottom:540px;display:none;pointer-events:auto;z-index:25}
-    #zoomSlider{appearance:none;width:360px;height:64px;transform:rotate(-90deg);background:rgba(0,0,0,.4);border-radius:999px;outline:none;border:1px solid rgba(255,255,255,.2)}
-    #zoomSlider::-webkit-slider-thumb{appearance:none;width:50px;height:50px;border-radius:50%;background:#ffd966;border:1px solid rgba(0,0,0,.4)}
-    #zoomSlider::-moz-range-thumb{width:50px;height:50%;border-radius:50%;background:#ffd966;border:1px solid rgba(0,0,0,.4)}
-
-    #result{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);padding:18px 22px;border-radius:14px;font-weight:900;color:#fff;background:rgba(0,0,0,.6);display:none}
-
-    #settingsBtn{position:absolute;right:56px;top:8px;z-index:30}
-    #muteBtn{z-index:30}
-    #settings{position:absolute;right:10px;top:56px;width:320px;max-width:calc(100% - 20px);background:rgba(17,23,42,.9);border:1px solid rgba(255,255,255,.18);border-radius:14px;padding:12px 12px 10px;display:none;color:#fff;backdrop-filter:blur(6px);pointer-events:auto}
-    #settings h3{margin:4px 0 10px 0;font-size:14px;opacity:.9}
-    #settings label{display:flex;justify-content:space-between;align-items:center;font-size:12px;margin:6px 0}
-    #settings input[type="range"]{width:160px}
-    #settings .row2{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:8px}
-    #settings .row2 button{width:100%}
-
-    #hurt{position:absolute;inset:0;background:radial-gradient(closest-side at 50% 50%, rgba(255,0,0,0) 0%, rgba(255,0,0,0) 60%, rgba(255,0,0,0.35) 100%);opacity:0;pointer-events:none;transition:opacity .12s ease-out}
-
-    #hit{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:22px;height:22px;border:2px solid #fff;border-radius:4px;opacity:0;pointer-events:none}
-
-    body.lefty #joyMove{left:18px !important;right:auto !important}
-    body.lefty #shootPad{right:18px !important;left:auto !important}
-    body.lefty #aimPad{right:18px !important;left:auto !important}
-    body.lefty #ammo{left:10px;right:auto}
-    body.lefty #modeBox{left:10px;right:auto}
-
-    #diag{position:absolute;left:10px;top:86px;background:rgba(0,0,0,.35);color:#fff;border-radius:10px;padding:8px 10px;font-size:12px;pointer-events:auto;max-width:65ch}
-
-    /* Touch-first overrides for Tirana 2040 mobile layout */
-    #joyMove{right:18px;bottom:220px !important;left:auto}
-    #shootPad{left:18px;bottom:220px !important;right:auto}
-    #aimPad{left:18px;bottom:220px !important;right:auto}
-    .joy{width:300px !important;height:300px !important;z-index:20 !important}
-    .knob{width:160px !important;height:160px !important}
-    #armory{overflow-x:auto !important;white-space:nowrap !important;display:flex !important;gap:10px !important;scroll-snap-type:x mandatory;padding:8px}
-    .armBtn{flex:0 0 auto;scroll-snap-align:start}
-    #armory::-webkit-scrollbar-thumb{background:rgba(255,255,255,.25);border-radius:999px}
-    #armLeft,#armRight{position:absolute;bottom:86px;width:44px;height:44px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:900;background:rgba(0,0,0,.5);border:1px solid rgba(255,255,255,.2);z-index:12}
-    #armLeft{left:12px}
-    #armRight{right:12px}
-    #armLeft,#armRight{display:none !important}
-  </style>
+  .joy{position:absolute;width:var(--joy-size);height:var(--joy-size);border-radius:50%;background:rgba(0,0,0,.1);border:1px solid rgba(0,0,0,.25);opacity:.95;pointer-events:auto;touch-action:none;display:block;z-index:20;backdrop-filter:blur(var(--hud-blur))}
+  .joy .knob{position:absolute;left:50%;top:50%;width:var(--joy-knob);height:var(--joy-knob);transform:translate(-50%,-50%);border-radius:50%;background:rgba(0,0,0,.28);border:1px solid rgba(0,0,0,.35)}
+  #joyMove{left:var(--hud-gap);bottom:var(--pad-offset)}
+  #joyMove .knob{background:rgba(0,0,0,.32)}
+  .padStack{position:absolute;right:var(--hud-gap);bottom:var(--pad-offset);display:flex;flex-direction:column;align-items:flex-end;gap:clamp(12px,3vw,18px);pointer-events:none}
+  .padStack > *{pointer-events:auto}
+  .fireRow{display:flex;flex-direction:row;align-items:center;justify-content:center;gap:clamp(12px,4vw,22px)}
+  .fireButton{width:clamp(67px,16.8vw,92px);height:clamp(67px,16.8vw,92px);border-radius:50%;border:1px solid rgba(0,0,0,.38);outline:none;background:radial-gradient(circle at 50% 42%, rgba(255,64,64,1) 0 58%, rgba(128,0,0,0.6) 82%, rgba(0,0,0,0.35) 100%);color:#fff;font-size:clamp(9px,2.45vw,13px);font-weight:900;letter-spacing:.6px;text-transform:uppercase;display:flex;align-items:center;justify-content:center;box-shadow:0 16px 32px rgba(0,0,0,.38);cursor:pointer;transition:transform .18s ease, box-shadow .18s ease;background-clip:padding-box}
+  .fireButton:active{transform:translateY(2px);box-shadow:0 8px 18px rgba(0,0,0,.28)}
+  #shootPad{background:radial-gradient(circle at 50% 45%, rgba(255,48,48,1) 0 52%, rgba(160,10,10,0.68) 78%, rgba(0,0,0,0.4) 100%)}
+  #reloadMini{background:radial-gradient(circle at 50% 45%, rgba(255,78,78,1) 0 54%, rgba(150,12,12,0.68) 80%, rgba(0,0,0,0.42) 100%)}
+  #crosshair{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:30px;height:30px;pointer-events:none;z-index:50;display:block}
+  #crosshair:before,#crosshair:after{content:"";position:absolute;left:50%;top:50%;background:var(--aimColor,#ff3c3c);box-shadow:0 0 0 2px rgba(255,255,255,0.9) inset, 0 0 6px rgba(0,0,0,.35)}
+  #crosshair:before{width:24px;height:3px;transform:translate(-50%,-50%);opacity:.98}
+  #crosshair:after{width:3px;height:24px;transform:translate(-50%,-50%);opacity:.98}
+  #ammo{color:#fff;font-weight:700;background:rgba(0,0,0,.42);padding:6px 12px;border-radius:14px 14px 4px 4px;pointer-events:auto;font-size:clamp(9px,2.2vw,12px);backdrop-filter:blur(var(--hud-blur));min-width:120px;text-align:center;align-self:flex-end}
+  #healthbar{position:absolute;left:50%;top:calc(var(--hud-gap) + 44px);width:clamp(160px,60vw,320px);height:14px;background:rgba(0,0,0,.22);border-radius:999px;overflow:hidden;transform:translateX(-50%)}
+  #healthfill{width:100%;height:100%;background:linear-gradient(90deg,#29ff9a,#00c876)}
+  .armoryWrap{flex:1;display:flex;justify-content:center;overflow:visible}
+  #armory{display:flex;flex-direction:row;gap:clamp(6px,2.2vw,12px);padding:8px 12px;border-radius:16px;background:rgba(0,0,0,.32);backdrop-filter:blur(var(--hud-blur));pointer-events:auto;max-width:min(100%,560px);box-sizing:border-box;align-items:stretch;overflow-x:auto;scrollbar-width:thin}
+  #armory::-webkit-scrollbar{height:6px}
+  #armory::-webkit-scrollbar-thumb{background:rgba(255,255,255,0.25);border-radius:999px}
+  .armBtn{position:relative;flex:0 0 clamp(70px,18vw,104px);padding:6px;border-radius:12px;border:1px solid rgba(255,255,255,.16);background:rgba(7,10,22,.58);color:#e6eefc;font-weight:700;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:4px;transition:transform .2s ease, border-color .2s ease}
+  .armBtn img{width:100%;aspect-ratio:4/3;object-fit:contain;display:block;filter:drop-shadow(0 1px 2px rgba(0,0,0,.35))}
+  .armBtn span{font-size:9px;letter-spacing:.18px;opacity:.95;text-align:center}
+  .armBtn.active{outline:2px solid #ffd966;background:rgba(17,23,42,.68);border-color:rgba(255,217,102,.6);transform:translateY(-4px)}
+  #armory.dragging{cursor:grabbing}
+  #armory.dragging .armBtn{pointer-events:none}
+  .modeToggle{position:absolute;right:6px;top:6px;padding:2px 5px;border-radius:9px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.45);color:#fff;font-size:9px;cursor:pointer}
+  #mini{position:absolute;left:50%;bottom:calc(var(--pad-offset) + var(--joy-size) + clamp(12px,3vh,40px));transform:translateX(-50%);color:#0b1324;background:rgba(255,255,255,.75);padding:4px 10px;border-radius:999px;font-size:11px;pointer-events:auto}
+  #climbBtn{position:absolute;left:50%;bottom:calc(var(--pad-offset) + var(--joy-size) + clamp(60px,8vh,120px));transform:translateX(-50%);padding:7px 14px;border-radius:14px;border:1px solid rgba(255,255,255,.25);background:rgba(0,0,0,.7);color:#fff;font-size:clamp(10px,2.4vw,13px);pointer-events:auto;display:none}
+  #zoomBox{display:none;pointer-events:auto;position:absolute;left:calc(var(--hud-gap) + var(--joy-size)/2);bottom:calc(var(--pad-offset) + var(--joy-size) + clamp(28px,7vh,110px));transform:translateX(-50%);z-index:22;flex-direction:column;align-items:center;gap:6px}
+  #zoomLabel{pointer-events:none;color:rgba(248,250,252,0.82);font-size:clamp(10px,2.6vw,12px);letter-spacing:.45px;text-transform:uppercase;background:rgba(12,16,28,.7);padding:4px 12px;border-radius:999px;box-shadow:0 12px 24px rgba(0,0,0,.25)}
+  #zoomSlider{appearance:none;width:clamp(250px,54vh,360px);height:56px;transform:rotate(-90deg);background:rgba(10,12,20,.62);border-radius:999px;outline:none;border:1px solid rgba(255,255,255,.28);box-shadow:0 16px 30px rgba(0,0,0,.34);transform-origin:center}
+  #zoomSlider::-webkit-slider-thumb{appearance:none;width:46px;height:46px;border-radius:50%;background:#ffd966;border:1px solid rgba(0,0,0,.4)}
+  #zoomSlider::-moz-range-thumb{width:46px;height:46px;border-radius:50%;background:#ffd966;border:1px solid rgba(0,0,0,.4)}
+  #mapBtn{margin-left:auto}
+  #mapOverlay{position:fixed;inset:0;background:rgba(10,12,18,.88);display:none;align-items:center;justify-content:center;z-index:200;pointer-events:auto}
+  #mapCanvas{width:min(96vw,1200px);height:min(96vh,820px);background:#0f172a;border:1px solid rgba(255,255,255,.12);box-shadow:0 28px 90px rgba(0,0,0,.52);border-radius:18px}
+  #mapClose{position:absolute;top:24px;right:24px;padding:12px 18px;border-radius:12px;border:1px solid rgba(255,255,255,.32);background:rgba(17,24,39,.92);color:#fff;font-weight:700;cursor:pointer;letter-spacing:.4px;text-transform:uppercase}
+  #legend{position:absolute;left:24px;top:24px;color:#f9fafb;background:rgba(17,24,39,.78);padding:14px 16px;border-radius:12px;font-size:13px;line-height:1.4;max-width:240px}
+  #legend strong{display:block;font-size:15px;margin-bottom:6px;text-transform:uppercase;letter-spacing:.5px}
+  #result{display:none !important}
+</style>
 </head>
 <body>
-  <div id="wrap"></div>
+<div id="wrap"></div>
 
-  <div class="hud">
-    <div class="row top">
-      <div style="display:flex;gap:6px;align-items:center">
-        <div class="chip" id="status">Tirana 2040 • Loading…</div>
-        <div id="br" class="chip">BR: ON</div>
-      </div>
-      <div style="display:flex;gap:6px;align-items:center">
-        <div id="modeBox">
-          <button id="modeA" class="modeBtn active">A: Drag Aim</button>
-          <button id="modeB" class="modeBtn">B: Dual Sticks</button>
-        </div>
-        <button id="settingsBtn" class="btn">⚙️</button>
-        <button id="muteBtn" class="btn">🔊</button>
-      </div>
+<div class="hud">
+  <div class="row top">
+    <div style="display:flex;gap:6px;align-items:center">
+      <div class="chip" id="status">Tirana 2040 • Last Man Standing</div>
+      <div id="br" class="chip">Entrants: 10 • AI</div>
     </div>
-
-    <div id="healthbar"><div id="healthfill"></div></div>
-    <div id="ammo">—</div>
-    <div id="crosshair"></div>
-
-    <div id="joyMove" class="joy"><div class="knob"></div></div>
-    <div id="shootPad" class="joy"><div class="knob"></div><button id="reloadMini" class="btn">RELOAD</button></div>
-    <div id="aimPad" class="joy"><div class="knob"></div></div>
-
-    <div id="zoomBox"><input id="zoomSlider" type="range" min="1" max="3" step="0.01" value="1" /></div>
-
-    <div id="armory"></div>
-    <button id="armLeft" title="Slide Left">◀</button>
-    <button id="armRight" title="Slide Right">▶</button>
-
-    <button id="useCarBtn">🚗 Enter Car</button>
-    <button id="exitCarBtn">⬅ Exit Car</button>
-    <button id="hornBtn">📣 Horn</button>
-    <button id="brakeBtn">🅿 Handbrake</button>
-    <button id="climbBtn">⬆ Climb Ladder</button>
-
-    <div id="mini">fps: —</div>
-    <div id="result"></div>
-    <div id="diag" class="chip">Diagnostics: ready.</div>
-
-    <div id="settings">
-      <h3>Settings</h3>
-      <label>Left-handed layout <input id="setLefty" type="checkbox"></label>
-      <label>Auto‑fire <input id="setAutoFire" type="checkbox"></label>
-      <label>Aim assist <input id="setAimAssist" type="checkbox"></label>
-      <label>Invert Y <input id="setInvertY" type="checkbox"></label>
-      <label>Gyro aim <input id="setGyro" type="checkbox"></label>
-      <label>Shadows <input id="setShadows" type="checkbox"></label>
-      <label>Sens A (drag) <input id="setSensA" type="range" min="0.06" max="0.3" step="0.005"></label>
-      <label>Sens B X <input id="setSensBX" type="range" min="0.0006" max="0.003" step="0.0001"></label>
-      <label>Sens B Y <input id="setSensBY" type="range" min="0.0006" max="0.003" step="0.0001"></label>
-      <label>Resolution scale <input id="setDpr" type="range" min="0.6" max="1" step="0.02"></label>
-      <label>Crosshair size <input id="setCross" type="range" min="16" max="52" step="1"></label>
-      <div class="row2">
-        <button id="setLow">Low</button>
-        <button id="setHigh">High</button>
-        <button id="setSave">Save</button>
-        <button id="setClose">Close</button>
-      </div>
-    </div>
-
-    <div id="hurt"></div>
-    <div id="hit"></div>
-
-    <div class="row bottom">
-      <div class="chip">Move = WASD/Left stick • Aim = drag (A) or right stick (B) • Tap right=Shoot • Pinch=Zoom • Tap stairs=Rooftop</div>
-      <button id="resetBtn" class="btn">Reset</button>
+    <div style="display:flex;gap:6px;align-items:center">
+      <button id="mapBtn" class="btn">🗺 Map</button>
+      <button id="muteBtn" class="btn">🔊</button>
     </div>
   </div>
 
-  <script type="module">
-    import * as THREE from 'https://esm.sh/three@0.160.0';
-    import * as CANNON from 'https://esm.sh/cannon-es@0.20.0';
-    import { GLTFLoader } from 'https://esm.sh/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
-    import { DRACOLoader } from 'https://esm.sh/three@0.160.0/examples/jsm/loaders/DRACOLoader.js';
+  <div id="healthbar"><div id="healthfill"></div></div>
+  <div id="crosshair"></div>
 
-    (async function main(){
-      const $ = (id)=>document.getElementById(id);
-      const wrap = $('wrap');
-      const isTouch = ('ontouchstart' in window) || (navigator.maxTouchPoints>0);
-      const isMobile = isTouch || /Android|webOS|iPhone|iPad|iPod|Opera Mini|IEMobile/i.test(navigator.userAgent);
+  <div id="joyMove" class="joy"><div class="knob"></div></div>
+  <div id="zoomBox"><span id="zoomLabel">AK Zoom</span><input id="zoomSlider" type="range" min="1" max="3" step="0.01" value="1" /></div>
+  <div id="padContainer" class="padStack">
+    <div class="fireRow">
+      <button id="shootPad" class="fireButton">Shoot</button>
+      <button id="reloadMini" class="fireButton">Reload</button>
+    </div>
+    <div id="ammo">—</div>
+  </div>
+  <div id="mapOverlay">
+    <canvas id="mapCanvas"></canvas>
+    <button id="mapClose">Exit Map</button>
+    <div id="legend"><strong>City Navigation</strong>Tap any district on the map to set a navigation waypoint and follow the dashed guidance in-game. Tap the same spot again to clear it. Use the Exit Map button to close. Icons: 🏥 Hospital · 🚓 Police · 🧯 Fire · 🛍 Mall · 🛫 Airport · 🚉 Station</div>
+  </div>
 
-      const store = {
-        get(k, v){ try{ return JSON.parse(localStorage.getItem(k)) ?? v; }catch(_){ return v; } },
-        set(k, v){ try{ localStorage.setItem(k, JSON.stringify(v)); }catch(_){} }
-      };
-      const settings = store.get('tirana_settings', {
-        lefty:false, autoFire:true, aimAssist:true, invertY:false, gyro:false,
-        sensA:isMobile?0.14:0.12, sensBX:0.0014, sensBY:0.0012,
-        dpr:isMobile?0.74:1.0, shadows:!isMobile,
-        autoResolution:true
-      });
+  <button id="climbBtn">⬆ Use/Climb Ladder</button>
 
-      const TARGET_FPS = 90;
-      const PHYS_HZ    = 90;
-      const AIM_RATE_A   = 0.52;
-      const AIM_SMOOTH_A = 3.8;
-      let   LOOK_SENS_A  = settings.sensA;
-      let   AIM_SENS_B_X = settings.sensBX;
-      let   AIM_SENS_B_Y = settings.sensBY;
+  <div id="mini">fps: —</div>
+  <div id="result"></div>
 
-      const renderer = new THREE.WebGLRenderer({ antialias:true, powerPreference:'high-performance', precision:'mediump', alpha:false, stencil:false });
-      renderer.useLegacyLights = false;
-      renderer.outputColorSpace = THREE.SRGBColorSpace;
-      renderer.toneMapping = THREE.ACESFilmicToneMapping;
-      renderer.toneMappingExposure = 1.95;
-      renderer.domElement.style.imageRendering = 'auto';
-      let allowShadows = settings.shadows;
-      renderer.shadowMap.enabled = allowShadows; renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-      wrap.appendChild(renderer.domElement);
-      THREE.Cache.enabled = true;
-      let dprBase = Math.min(window.devicePixelRatio||1, isMobile ? 0.9 : 1.8);
-      let dprScaleTarget = settings.dpr;
-      let dprRuntime = dprScaleTarget;
-      function fit(){
-        dprRuntime = THREE.MathUtils.clamp(dprRuntime, 0.6, 1.0);
-        const w=wrap.clientWidth||innerWidth, h=wrap.clientHeight||innerHeight;
-        renderer.setPixelRatio(dprBase * dprRuntime);
-        renderer.setSize(w,h,false);
-        camera.aspect=w/h;
-        camera.updateProjectionMatrix();
+  <div class="row bottom">
+    <div class="armoryWrap">
+      <div id="armory"></div>
+    </div>
+  </div>
+</div>
+
+<script type="module">
+import * as THREE from 'https://esm.sh/three@0.160.0';
+import * as CANNON from 'https://esm.sh/cannon-es@0.20.0';
+import { GLTFLoader } from 'https://esm.sh/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'https://esm.sh/three@0.160.0/examples/jsm/loaders/DRACOLoader.js';
+import * as SkeletonUtils from 'https://esm.sh/three@0.160.0/examples/jsm/utils/SkeletonUtils.js';
+
+document.title = 'Tirana 2040 • Last Man Standing';
+
+(async function main(){
+  const $ = (id)=>document.getElementById(id);
+  const wrap = $('wrap');
+  const isTouch = ('ontouchstart' in window) || (navigator.maxTouchPoints>0);
+  const isMobile = isTouch || /Android|webOS|iPhone|iPad|iPod|Opera Mini|IEMobile/i.test(navigator.userAgent);
+
+  const params = new URLSearchParams(window.location.search);
+  const entrants = parseInt(params.get('players') || '10', 10);
+  const stakeToken = params.get('token') || 'TPC';
+  const stakeAmount = params.get('amount');
+  if(!Number.isNaN(entrants)){
+    $('br').textContent = `Entrants: ${entrants} • AI`;
+  }
+  if(stakeAmount){
+    $('status').textContent = `Tirana 2040 • ${stakeAmount} ${stakeToken}`;
+  } else {
+    $('status').textContent = 'Tirana 2040 • Last Man Standing';
+  }
+
+  const renderer = new THREE.WebGLRenderer({ antialias:true, powerPreference:'high-performance', alpha:false, stencil:false, depth:true, precision:'mediump' });
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.85;
+  const allowShadows = !isMobile;
+  renderer.shadowMap.enabled = allowShadows; renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  wrap.appendChild(renderer.domElement);
+  THREE.Cache.enabled = true;
+
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color('#f5e7cf');
+  scene.fog = new THREE.Fog('#f5e7cf', 900, 3500);
+
+  const camera = new THREE.PerspectiveCamera(64, (innerWidth||1)/(innerHeight||1), 0.01, 10000);
+  camera.position.set(0,1.7,5.6); scene.add(camera);
+
+  let dprBase = Math.min(window.devicePixelRatio||1.2, isMobile ? 2.5 : 2.8);
+  let dprScale = 1.0;
+  const DPR_MIN = isMobile ? 0.75 : 0.6;
+  const DPR_MAX_SCALE = isMobile ? 1.0 : 1.15;
+  function fit(){ const w=wrap.clientWidth||innerWidth, h=wrap.clientHeight||innerHeight; const targetDpr=Math.min(dprBase*dprScale, isMobile?2.6:3.0); renderer.setPixelRatio(targetDpr); renderer.setSize(w,h,false); camera.aspect=w/h; camera.updateProjectionMatrix(); }
+  addEventListener('resize', fit); fit();
+
+  const hemi = new THREE.HemisphereLight(0xfff3d6, 0x8a7a6a, 0.55);
+  const key  = new THREE.DirectionalLight(0xffd6a0, allowShadows?1.25:1.0); key.position.set(220, 350, 180); key.castShadow=allowShadows;
+  if(allowShadows){ key.shadow.mapSize.set(isMobile?1024:2048,isMobile?1024:2048); key.shadow.camera.near=1; key.shadow.camera.far=3000; key.shadow.camera.left=-900; key.shadow.camera.right=900; key.shadow.camera.top=900; key.shadow.camera.bottom=-900; }
+  const fill = new THREE.DirectionalLight(0xffffff, 0.9); fill.position.set(-320, 140, -260);
+  const rim  = new THREE.DirectionalLight(0xffffff, 0.8); rim.position.set(120, 200, -520);
+  scene.add(hemi, key, fill, rim);
+  const muzzleLight = new THREE.PointLight(0xfff1c6, 0.0, 2.0); scene.add(muzzleLight);
+
+  const world = new CANNON.World({ gravity: new CANNON.Vec3(0,-9.81,0) });
+  world.broadphase = new CANNON.SAPBroadphase(world); world.allowSleep = true;
+  const matGround=new CANNON.Material('ground'), matPlayer=new CANNON.Material('player'), matEnemy=new CANNON.Material('enemy'), matCar=new CANNON.Material('car');
+  world.addContactMaterial(new CANNON.ContactMaterial(matGround, matPlayer, { friction:.2, restitution:0 }));
+  world.addContactMaterial(new CANNON.ContactMaterial(matGround, matCar, { friction:.9, restitution:0 }));
+
+  const groundBody = new CANNON.Body({ mass:0, material:matGround, shape:new CANNON.Plane() });
+  groundBody.quaternion.setFromEuler(-Math.PI/2,0,0); world.addBody(groundBody);
+
+  function makeAsphalt(size=1024){ const c=document.createElement('canvas'); c.width=c.height=size; const x=c.getContext('2d'); x.fillStyle='#2c323a'; x.fillRect(0,0,size,size); for(let i=0;i<7000;i++){ const a=Math.random()*0.12; x.fillStyle=`rgba(255,255,255,${a})`; x.fillRect(Math.random()*size,Math.random()*size,1,1);} for(let i=0;i<300;i++){ x.strokeStyle='rgba(0,0,0,0.25)'; x.lineWidth=Math.random()*1.2; x.beginPath(); x.moveTo(Math.random()*size,Math.random()*size); x.lineTo(Math.random()*size,Math.random()*size); x.stroke(); } const t=new THREE.CanvasTexture(c); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(24,24); t.anisotropy=6; t.colorSpace=THREE.SRGBColorSpace; return t; }
+  function makeSidewalk(size=512){ const c=document.createElement('canvas'); c.width=c.height=size; const x=c.getContext('2d'); x.fillStyle='#c9ced6'; x.fillRect(0,0,size,size); x.strokeStyle='#9aa0a8'; x.lineWidth=6; for(let s=0;s<size;s+=64){ x.beginPath(); x.moveTo(s,0); x.lineTo(s,size); x.stroke(); x.beginPath(); x.moveTo(0,s); x.lineTo(size,s); x.stroke(); } const t=new THREE.CanvasTexture(c); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(32,32); t.anisotropy=6; t.colorSpace=THREE.SRGBColorSpace; return t; }
+  const maxAniso = renderer.capabilities.getMaxAnisotropy?.() || 4;
+  function grassProcedural(size=1024){ const c=document.createElement('canvas'); c.width=c.height=size; const x=c.getContext('2d'); x.fillStyle='#6fa863'; x.fillRect(0,0,size,size); for(let i=0;i<2600;i++){ x.fillStyle=`rgba(0,80,0,${Math.random()*0.12})`; x.fillRect(Math.random()*size,Math.random()*size,1,1);} const t=new THREE.CanvasTexture(c); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(6,6); t.anisotropy=8; t.colorSpace=THREE.SRGBColorSpace; return t; }
+  function grassTex(){ return new Promise((resolve)=>{ const loader=new THREE.TextureLoader(); loader.load('https://threejs.org/examples/textures/terrain/grasslight-big.jpg', (tex)=>{ tex.wrapS=tex.wrapT=THREE.RepeatWrapping; tex.repeat.set(6,6); tex.anisotropy=8; tex.colorSpace=THREE.SRGBColorSpace; resolve(tex); }, ()=>resolve(grassProcedural()), ()=>resolve(grassProcedural())); }); }
+  function createCourtTexture(type){ const c=document.createElement('canvas'); c.width=1024; c.height=512; const ctx=c.getContext('2d'); ctx.fillStyle=(type==='tennis')?'#1d7d4f':'#c6864a'; ctx.fillRect(0,0,c.width,c.height); ctx.strokeStyle='#f9f5e6'; ctx.lineWidth=type==='tennis'?16:18; ctx.lineJoin='round'; if(type==='tennis'){ const margin=70; ctx.strokeRect(margin,margin,c.width-margin*2,c.height-margin*2); ctx.beginPath(); ctx.moveTo(c.width/2,margin); ctx.lineTo(c.width/2,c.height-margin); ctx.stroke(); ctx.strokeRect(margin*1.6,margin,c.width-margin*3.2,c.height-margin*2); } else { const r=180; ctx.beginPath(); ctx.rect(70,70,c.width-140,c.height-140); ctx.stroke(); ctx.beginPath(); ctx.arc(c.width/2,70,r,Math.PI,0,false); ctx.stroke(); ctx.beginPath(); ctx.arc(c.width/2,c.height-70,r,0,Math.PI,false); ctx.stroke(); ctx.beginPath(); ctx.arc(c.width/4, c.height/2, 90, Math.PI/2,-Math.PI/2,true); ctx.stroke(); ctx.beginPath(); ctx.arc(c.width*0.75, c.height/2, 90, -Math.PI/2,Math.PI/2,true); ctx.stroke(); } const t=new THREE.CanvasTexture(c); t.anisotropy=8; t.colorSpace=THREE.SRGBColorSpace; return t; }
+  function makeWaterMaterial(){ const tex = new THREE.CanvasTexture((()=>{ const c=document.createElement('canvas'); c.width=c.height=256; const ctx=c.getContext('2d'); const grd=ctx.createRadialGradient(128,128,20,128,128,128); grd.addColorStop(0,'rgba(80,180,255,0.95)'); grd.addColorStop(1,'rgba(30,90,140,0.65)'); ctx.fillStyle=grd; ctx.fillRect(0,0,256,256); return c; })()); tex.colorSpace=THREE.SRGBColorSpace; tex.wrapS=tex.wrapT=THREE.RepeatWrapping; tex.repeat.set(2,2); return new THREE.MeshStandardMaterial({ map:tex, transparent:true, opacity:0.9, roughness:0.2, metalness:0.15, side:THREE.DoubleSide }); }
+  function trackTex(w=1024,h=1024){ const c=document.createElement('canvas'); c.width=w; c.height=h; const g=c.getContext('2d'); g.fillStyle='#b33a2c'; g.fillRect(0,0,w,h); const dots=Math.floor(w*h*0.004); for(let i=0;i<dots;i++){ const x=Math.random()*w, y=Math.random()*h, r=Math.random()*1.6+0.2; g.fillStyle=Math.random()<0.5?'rgba(255,190,180,0.35)':'rgba(40,12,10,0.35)'; g.beginPath(); g.arc(x,y,r,0,Math.PI*2); g.fill(); } const t=new THREE.CanvasTexture(c); t.anisotropy=Math.min(16,maxAniso); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.colorSpace=THREE.SRGBColorSpace; t.repeat.set(1,1); return t; }
+
+  const asphaltTex = makeAsphalt(), sidewalkTex = makeSidewalk(), redTrackTex = trackTex();
+  const tennisGrassTex = await grassTex();
+  const tennisCourtTex = createCourtTexture('tennis');
+  const basketCourtTex = createCourtTexture('basket');
+  const waterMat = makeWaterMaterial();
+  const turfMat = new THREE.MeshStandardMaterial({ map:tennisGrassTex, roughness:0.65, metalness:0.02, side:THREE.DoubleSide });
+  const tennisMat = new THREE.MeshStandardMaterial({ map:tennisCourtTex, roughness:0.55, metalness:0.04, side:THREE.DoubleSide });
+  const basketMat = new THREE.MeshStandardMaterial({ map:basketCourtTex, roughness:0.6, metalness:0.03, side:THREE.DoubleSide });
+
+  const city = new THREE.Group(); scene.add(city);
+  const mapRoads=[]; const mapBuildings=[]; const mapParks=[]; const mapLandmarks=[];
+  const BLOCKS_X=6, BLOCKS_Z=6; const CELL=120; const ROAD=22; const PLOT=CELL-ROAD*2; const startX = -(BLOCKS_X*CELL)/2 + CELL/2; const startZ = -(BLOCKS_Z*CELL)/2 + CELL/2;
+  const northSouthStreets=['Rr. Kombinatit','Rr. Kavajës','Rr. Dëshmorët','Rr. Myslym Shyri','Rr. Ismail Qemali','Rr. Abdyl Frashëri','Rr. Bajram Curri'];
+  const eastWestStreets=['Blvd. Nënë Tereza','Rr. Skënderbej','Rr. Ismail Ndroqi','Rr. Ali Demi','Rr. Petro Nini','Rr. Teuta','Rr. Don Bosko'];
+  const ringRoadName='Unaza Tirana 2040';
+
+  const groundGeo = new THREE.PlaneGeometry((CELL)*BLOCKS_X + ROAD*2, (CELL)*BLOCKS_Z + ROAD*2);
+  const groundMat = new THREE.MeshStandardMaterial({ color: 0xf0e4cf, roughness:0.95, metalness:0.02, side:THREE.DoubleSide });
+  const gnd = new THREE.Mesh(groundGeo, groundMat); gnd.rotation.x=-Math.PI/2; gnd.receiveShadow=allowShadows; city.add(gnd);
+
+  const roadMat = new THREE.MeshStandardMaterial({ map: asphaltTex, roughness:0.82, metalness:0.05, side:THREE.DoubleSide });
+  for(let ix=0; ix<=BLOCKS_X; ix++){
+    const geo=new THREE.PlaneGeometry(ROAD,(CELL)*BLOCKS_Z + ROAD);
+    const m=new THREE.Mesh(geo, roadMat);
+    const xPos=ix*CELL-(BLOCKS_X*CELL)/2;
+    const zPos=ROAD*0.5-(BLOCKS_Z*CELL)/2;
+    m.rotation.x=-Math.PI/2;
+    m.position.set(xPos, 0.01, zPos);
+    m.receiveShadow=allowShadows; city.add(m);
+    const halfLen=(CELL)*BLOCKS_Z*0.5 + ROAD*0.5;
+    mapRoads.push({name:northSouthStreets[ix]||`Rruga ${ix+1}`, from:{x:xPos, z:-halfLen}, to:{x:xPos, z:halfLen}, width:ROAD});
+    if(northSouthStreets[ix]){ const label=makeLabel(northSouthStreets[ix],0.55); label.position.set(xPos,0.12,-(BLOCKS_Z*CELL)/2 - 18); label.rotation.y=Math.PI; city.add(label); }
+  }
+  for(let iz=0; iz<=BLOCKS_Z; iz++){
+    const geo=new THREE.PlaneGeometry((CELL)*BLOCKS_X + ROAD, ROAD);
+    const m=new THREE.Mesh(geo, roadMat);
+    const zPos=iz*CELL-(BLOCKS_Z*CELL)/2;
+    const xPos=ROAD*0.5-(BLOCKS_X*CELL)/2;
+    m.rotation.x=-Math.PI/2;
+    m.position.set(xPos, 0.01, zPos);
+    m.receiveShadow=allowShadows; city.add(m);
+    const halfLen=(CELL)*BLOCKS_X*0.5 + ROAD*0.5;
+    mapRoads.push({name:eastWestStreets[iz]||`Bulevardi ${iz+1}`, from:{x:-halfLen, z:zPos}, to:{x:halfLen, z:zPos}, width:ROAD});
+    if(eastWestStreets[iz]){ const label=makeLabel(eastWestStreets[iz],0.55); label.position.set(-(BLOCKS_X*CELL)/2 - 18,0.12,zPos); label.rotation.y=Math.PI/2; city.add(label); }
+  }
+
+  const sidewalkMat = new THREE.MeshStandardMaterial({ map: sidewalkTex, roughness:0.9, metalness:0.04, side:THREE.DoubleSide });
+  function addSidewalk(xc,zc){ const w=CELL-ROAD, h=CELL-ROAD; const geo=new THREE.BoxGeometry(w,2,h); const m=new THREE.Mesh(geo, sidewalkMat); m.castShadow=false; m.receiveShadow=allowShadows; m.position.set(xc,1,zc); city.add(m); }
+
+  function facadeTex(hue=200){ const W=256,H=512; const c=document.createElement('canvas'); c.width=W; c.height=H; const ctx=c.getContext('2d'); ctx.fillStyle=`hsl(${hue},16%,74%)`; ctx.fillRect(0,0,W,H); for(let i=0;i<1800;i++){ const a=Math.random()*0.08; ctx.fillStyle=`rgba(0,0,0,${a})`; ctx.fillRect(Math.random()*W,Math.random()*H,1,1);} const cols=6+Math.floor(Math.random()*4), rows=14+Math.floor(Math.random()*6); const padX=12,padY=16; const cellW=(W-2*padX)/cols, cellH=(H-2*padY)/rows; for(let r=0;r<rows;r++){ for(let cix=0;cix<cols;cix++){ const x=padX+cix*cellW+6, y=padY+r*cellH+6, w=cellW-12, h=cellH-12; const g=ctx.createLinearGradient(0,y,0,y+h); g.addColorStop(0,'rgba(240,245,255,0.95)'); g.addColorStop(0.5,'rgba(150,180,220,0.92)'); g.addColorStop(1,'rgba(60,80,120,0.9)'); ctx.fillStyle=g; ctx.fillRect(x,y,w,h); ctx.strokeStyle='rgba(24,28,38,0.9)'; ctx.lineWidth=2; ctx.strokeRect(x,y,w,h); } } const tex=new THREE.CanvasTexture(c); tex.anisotropy=2; tex.colorSpace=THREE.SRGBColorSpace; return tex; }
+
+  const ladders=[];
+  const climbMarkerTex=(function(){ const c=document.createElement('canvas'); c.width=c.height=256; const ctx=c.getContext('2d'); const grad=ctx.createLinearGradient(0,0,0,256); grad.addColorStop(0,'rgba(17,24,39,0.92)'); grad.addColorStop(1,'rgba(37,99,235,0.92)'); ctx.fillStyle=grad; ctx.fillRect(0,0,256,256); ctx.strokeStyle='rgba(255,255,255,0.65)'; ctx.lineWidth=10; ctx.strokeRect(14,14,228,228); ctx.fillStyle='#ffffff'; ctx.font='900 88px system-ui,Segoe UI'; ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillText('CLIMB',128,132); return new THREE.CanvasTexture(c); })();
+  function makeClimbMarker(){ const mat=new THREE.MeshBasicMaterial({ map:climbMarkerTex, transparent:true, opacity:0.92, depthWrite:false }); const mesh=new THREE.Mesh(new THREE.PlaneGeometry(2.6,2.6), mat); mesh.rotation.x=-Math.PI/2; mesh.position.y=0.05; return mesh; }
+  function addLadder(x,z,y0,y1){ const railMat=new THREE.MeshBasicMaterial({ color:0x9aa3ad }); const stepMat=new THREE.MeshBasicMaterial({ color:0x8a929c }); const g=new THREE.Group(); const railL=new THREE.Mesh(new THREE.BoxGeometry(0.08, y1-y0, 0.08), railMat); const railR=railL.clone(); railL.position.set(-0.25, (y0+y1)/2, 0); railR.position.set(0.25, (y0+y1)/2, 0); g.add(railL,railR); for(let y=y0+0.3;y<y1;y+=0.35){ const s=new THREE.Mesh(new THREE.BoxGeometry(0.6,0.05,0.08), stepMat); s.position.set(0,y,0); g.add(s); } const arrow=new THREE.Mesh(new THREE.ConeGeometry(0.25,0.6,12), new THREE.MeshBasicMaterial({ color:0x1f6feb })); arrow.position.set(0,y1+0.6,0); g.add(arrow); const marker=makeClimbMarker(); marker.position.set(0,0.02,-0.9); g.add(marker); g.position.set(x,0,z); city.add(g); ladders.push({x,z,y0,y1,marker}); }
+
+  function addRoofStair(x,z,y){ const m=new THREE.Mesh(new THREE.BoxGeometry(1.2,0.5,1.2), new THREE.MeshLambertMaterial({ color:0x444b55 })); m.position.set(x,y+0.4,z); city.add(m); return m; }
+
+  function addBuilding(xc,zc,opts={}){
+    const floors=opts.floors??(6+Math.floor(Math.random()*12)); const height=floors*(3.2); const w=opts.w??(30+Math.random()*20), d=opts.d??(30+Math.random()*20);
+    const geom=new THREE.BoxGeometry(w,height,d); const hue=opts.hue??(180+Math.floor(Math.random()*60));
+    const mat=new THREE.MeshLambertMaterial({ map:facadeTex(hue) }); const roof=new THREE.MeshLambertMaterial({ color:0x55585c});
+    const mesh=new THREE.Mesh(geom, [mat,mat,roof,roof,mat,mat]); mesh.castShadow=allowShadows; mesh.receiveShadow=allowShadows; mesh.position.set(xc,height/2,zc); city.add(mesh);
+    mapBuildings.push({x:xc,z:zc,w,d,h:height,floors,kind:opts.sign?opts.sign.toLowerCase():null});
+    if(opts.sign && opts.landmark!==false){ mapLandmarks.push({x:xc,z:zc,label:opts.sign}); }
+    const body=new CANNON.Body({mass:0}); body.addShape(new CANNON.Box(new CANNON.Vec3(w/2,height/2,d/2))); body.position.set(xc,height/2,zc); world.addBody(body);
+    addLadder(xc, zc + d/2 + 0.12, 0.3, height+0.6);
+    addRoofStair(xc + (Math.random()*0.6-0.3)*w*0.6, zc + (Math.random()*0.6-0.3)*d*0.6, height);
+    if(opts.sign){ const s=new THREE.Mesh(new THREE.PlaneGeometry(Math.min(18,w*0.8),4), new THREE.MeshBasicMaterial({ color:0xffffff })); s.position.set(xc, Math.min(height*0.65, 14), zc + d/2 + 0.51); city.add(s); const tcv=document.createElement('canvas'); tcv.width=512; tcv.height=128; const gx=tcv.getContext('2d'); gx.fillStyle='#111827'; gx.fillRect(0,0,512,128); gx.fillStyle='#fff'; gx.font='900 62px system-ui,Segoe UI'; gx.textAlign='center'; gx.textBaseline='middle'; gx.fillText(opts.sign, 256, 64); const tex=new THREE.CanvasTexture(tcv); tex.colorSpace=THREE.SRGBColorSpace; s.material.map=tex; s.material.needsUpdate=true; }
+    return {mesh, dims:{w,d,h:height}};
+  }
+
+  function courtLinesTex(courtW,courtL){ const w=2048, h=4096; const s=h/courtL; const c=document.createElement('canvas'); c.width=w; c.height=h; const g=c.getContext('2d'); g.clearRect(0,0,w,h); const lineW=12; g.strokeStyle='#ffffff'; g.lineWidth=lineW; g.lineJoin='round'; g.lineCap='round'; const halfW=courtW/2, halfL=courtL/2; const X=(x)=>(w/2+x*s), Z=(z)=>(h/2+z*s); const line=(x1,z1,x2,z2)=>{ g.beginPath(); g.moveTo(X(x1),Z(z1)); g.lineTo(X(x2),Z(z2)); g.stroke(); }; const box=(x1,z1,x2,z2)=>{ line(x1,z1,x2,z1); line(x2,z1,x2,z2); line(x2,z2,x1,z2); line(x1,z2,x1,z1); };
+    const serviceZ=6.4; box(-halfW,-halfL,halfW,halfL); line(-halfW,-serviceZ,halfW,-serviceZ); line(-halfW,serviceZ,halfW,serviceZ); line(0,-serviceZ,0,serviceZ); const t=new THREE.CanvasTexture(c); t.anisotropy=Math.min(16,maxAniso); t.wrapS=t.wrapT=THREE.ClampToEdgeWrapping; t.needsUpdate=true; return t; }
+  function basketLinesTex(wm=28,hm=15){ const w=2048,h=1024; const c=document.createElement('canvas'); c.width=w;c.height=h; const g=c.getContext('2d'); g.clearRect(0,0,w,h); g.strokeStyle='#ffffff'; g.lineWidth=10; g.lineJoin='round'; g.lineCap='round'; const sX=w/wm, sY=h/hm; const R=(x,y)=>[x*sX+w*0.5 - (wm*sX)/2, y*sY+h*0.5 - (hm*sY)/2]; const rect=(x,y,w2,h2)=>{ const [X,Y]=R(x,y); g.strokeRect(X,Y,w2*sX,h2*sY); }; const arc=(cx,cy,r,a0,a1)=>{ const [X,Y]=R(cx,cy); g.beginPath(); g.arc(X+0, Y+0, r*sX, a0, a1); g.stroke(); };
+    rect(0,0,wm,hm); rect(0.5,0.5,wm-1,hm-1);
+    rect(0.5, hm*0.5-2.4, 4.6, 4.8); rect(wm-0.5-4.6, hm*0.5-2.4, 4.6, 4.8);
+    arc(wm*0.5, 0.5, 2.4, 0, Math.PI); arc(wm*0.5, hm-0.5, 2.4, Math.PI, Math.PI*2);
+    const t=new THREE.CanvasTexture(c); t.anisotropy=Math.min(16,maxAniso); t.wrapS=t.wrapT=THREE.ClampToEdgeWrapping; t.needsUpdate=true; return t; }
+
+  function fenceMat(){ const c=document.createElement('canvas'); c.width=512;c.height=512; const g=c.getContext('2d'); g.clearRect(0,0,512,512); g.strokeStyle='rgba(18,18,18,0.96)'; g.lineWidth=2; for(let i=16;i<512;i+=16){ g.beginPath(); g.moveTo(i,16); g.lineTo(i,496); g.stroke(); g.beginPath(); g.moveTo(16,i); g.lineTo(496,i); g.stroke(); } const t=new THREE.CanvasTexture(c); t.anisotropy=Math.min(8,maxAniso); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(4,2); return t; }
+
+  function treesPerimeter(cx,cz){ const half=PLOT*0.45; const step=8;
+    const trunkGeo=new THREE.CylinderGeometry(0.5,0.8,6,8); const crownGeo=new THREE.IcosahedronGeometry(3.2,1);
+    const trunks=new THREE.Group(), crowns=new THREE.Group();
+    const trunkMat=new THREE.MeshLambertMaterial({ color:0x6e4f2f }); const crownMat=new THREE.MeshLambertMaterial({ color:0x3a6f42 });
+    const place=(x,z)=>{ const t=new THREE.Mesh(trunkGeo,trunkMat); t.position.set(x,3,z); t.castShadow=allowShadows; t.receiveShadow=allowShadows; trunks.add(t); const cr=new THREE.Mesh(crownGeo,crownMat); cr.position.set(x,9,z); cr.castShadow=allowShadows; cr.receiveShadow=allowShadows; crowns.add(cr); };
+    for(let x=-half;x<=half;x+=step){ place(cx+x, cz-half); place(cx+x, cz+half); }
+    for(let z=-half;z<=half;z+=step){ place(cx-half, cz+z); place(cx+half, cz+z); }
+    city.add(trunks,crowns);
+  }
+
+  function addParkGrass(cx,cz,scale=1.0){ const g=new THREE.Mesh(new THREE.PlaneGeometry(PLOT*0.9*scale,PLOT*0.9*scale), turfMat); g.rotation.x=-Math.PI/2; g.position.set(cx,0.015,cz); g.receiveShadow=allowShadows; city.add(g); }
+
+  function addTennisCourt(cx,cz){
+    addParkGrass(cx,cz,1.05);
+    const courtW=9.2, courtL=23.77, apron=2.6;
+    const track=new THREE.Mesh(new THREE.PlaneGeometry(courtW+apron*2,courtL+apron*2), new THREE.MeshStandardMaterial({ map:redTrackTex, roughness:0.9, metalness:0.04 }));
+    track.rotation.x=-Math.PI/2; track.position.set(cx,0.02,cz); city.add(track);
+    const surface=new THREE.Mesh(new THREE.PlaneGeometry(courtW,courtL), tennisMat);
+    surface.rotation.x=-Math.PI/2; surface.position.set(cx,0.021,cz); city.add(surface);
+    const fenceH=3.2, fenceGap=0.4; const fMat=new THREE.MeshStandardMaterial({ map:fenceMat(), transparent:true, opacity:1.0, roughness:0.9, metalness:0.0, color:0xffffff });
+    const fx=courtW/2+apron-fenceGap, fz=courtL/2+apron-fenceGap;
+    const totalW=courtW+apron*2, gateW=3.2, segW=(totalW-gateW)/2;
+    const addFencePanel=(w,h,rx,rz,rotY=0)=>{ const panel=new THREE.Mesh(new THREE.PlaneGeometry(w,h),fMat); panel.position.set(cx+rx, h/2, cz+rz); panel.rotation.y=rotY; city.add(panel); };
+    addFencePanel(segW, fenceH, -(gateW/2 + segW/2), fz);
+    addFencePanel(segW, fenceH,  gateW/2 + segW/2, fz);
+    addFencePanel(segW, fenceH, -(gateW/2 + segW/2), -fz);
+    addFencePanel(segW, fenceH,  gateW/2 + segW/2, -fz);
+    const sideLen=courtL+apron*2;
+    const sidePanel=new THREE.Mesh(new THREE.PlaneGeometry(sideLen, fenceH), fMat);
+    sidePanel.rotation.y=Math.PI/2; sidePanel.position.set(cx-fx, fenceH/2, cz); city.add(sidePanel);
+    const sidePanelB=sidePanel.clone(); sidePanelB.position.x=cx+fx; city.add(sidePanelB);
+    const gateMat=new THREE.MeshBasicMaterial({ color:0xd1d5db });
+    const gatePadW=gateW*0.6, gatePad=new THREE.Mesh(new THREE.PlaneGeometry(gatePadW, 1.2), gateMat);
+    gatePad.rotation.x=-Math.PI/2; gatePad.position.set(cx,0.03,cz+fz-0.6); city.add(gatePad);
+    const gatePadBack=gatePad.clone(); gatePadBack.position.z=cz-fz+0.6; city.add(gatePadBack);
+    treesPerimeter(cx,cz);
+    mapParks.push({type:'tennis',x:cx,z:cz,w:courtW+apron*2,d:courtL+apron*2});
+  }
+
+  function addBasketCourt(cx,cz){
+    addParkGrass(cx,cz,1.05);
+    const wm=28, hm=15, apron=2.6;
+    const base=new THREE.Mesh(new THREE.PlaneGeometry(wm+apron*2,hm+apron*2), new THREE.MeshStandardMaterial({ map:redTrackTex, roughness:0.9, metalness:0.04 }));
+    base.rotation.x=-Math.PI/2; base.position.set(cx,0.02,cz); city.add(base);
+    const surface=new THREE.Mesh(new THREE.PlaneGeometry(wm,hm), basketMat);
+    surface.rotation.x=-Math.PI/2; surface.position.set(cx,0.021,cz); city.add(surface);
+    const hoopMat=new THREE.MeshBasicMaterial({ color:0xffffff }); const postMat=new THREE.MeshBasicMaterial({ color:0xff3c3c });
+    const makeHoop=(sx)=>{ const g=new THREE.Group(); const board=new THREE.Mesh(new THREE.BoxGeometry(1.8,1.1,0.08), hoopMat); board.position.set(0,2.9,-0.25); const rim=new THREE.Mesh(new THREE.TorusGeometry(0.45,0.06,12,32), postMat); rim.rotation.x=Math.PI/2; rim.position.set(0,2.3,0.42); const post=new THREE.Mesh(new THREE.CylinderGeometry(0.06,0.06,2.6,16), postMat); post.position.y=1.3; const arm=new THREE.Mesh(new THREE.BoxGeometry(0.12,0.12,0.9), postMat); arm.position.set(0,2.5,0.1); const brace=new THREE.Mesh(new THREE.BoxGeometry(0.12,1.0,0.12), postMat); brace.position.set(0,1.9,0.05); g.add(post,board,rim,arm,brace); g.position.set(cx+sx*(wm*0.5-1.2),0,cz); city.add(g); };
+    makeHoop(-1); makeHoop(1);
+    for(let i=0;i<3;i++){ const ball=new THREE.Mesh(new THREE.SphereGeometry(0.3,20,16), new THREE.MeshStandardMaterial({ color:0xff8a00, roughness:0.65 })); ball.position.set(cx + (Math.random()*2-1)*4, 0.3, cz + (Math.random()*2-1)*3); city.add(ball); }
+    const fenceH=3.0; const fMat=new THREE.MeshStandardMaterial({ map:fenceMat(), transparent:true, opacity:1.0, roughness:0.9, metalness:0.0, color:0xffffff });
+    const fx=wm/2+apron-0.4, fz=hm/2+apron-0.4;
+    const gateW=3.6, fullW=wm+apron*2, segW=(fullW-gateW)/2;
+    const addPanel=(w,h,rx,rz,rot=0)=>{ const mesh=new THREE.Mesh(new THREE.PlaneGeometry(w,h), fMat); mesh.position.set(cx+rx, h/2, cz+rz); mesh.rotation.y=rot; city.add(mesh); };
+    addPanel(segW, fenceH, -(gateW/2 + segW/2), fz);
+    addPanel(segW, fenceH,  gateW/2 + segW/2, fz);
+    addPanel(segW, fenceH, -(gateW/2 + segW/2), -fz);
+    addPanel(segW, fenceH,  gateW/2 + segW/2, -fz);
+    const sideLen=hm+apron*2;
+    const sideFence=new THREE.Mesh(new THREE.PlaneGeometry(sideLen, fenceH), fMat); sideFence.rotation.y=Math.PI/2; sideFence.position.set(cx-fx, fenceH/2, cz); city.add(sideFence);
+    const sideFenceOpp=sideFence.clone(); sideFenceOpp.position.x=cx+fx; city.add(sideFenceOpp);
+    const entryMat=new THREE.MeshBasicMaterial({ color:0xd1d5db });
+    const entryPad=new THREE.Mesh(new THREE.PlaneGeometry(gateW*0.6, 1.2), entryMat);
+    entryPad.rotation.x=-Math.PI/2; entryPad.position.set(cx,0.031,cz+fz-0.55); city.add(entryPad);
+    const entryPadBack=entryPad.clone(); entryPadBack.position.z=cz-fz+0.55; city.add(entryPadBack);
+    treesPerimeter(cx,cz);
+    mapParks.push({type:'basket',x:cx,z:cz,w:wm+apron*2,d:hm+apron*2});
+  }
+
+  function addFountain(cx,cz){
+    addParkGrass(cx,cz,1.2);
+    const ringR=12;
+    const base=new THREE.Mesh(new THREE.CylinderGeometry(ringR,ringR,0.6,48), new THREE.MeshStandardMaterial({ color:0xaeb8c6, roughness:0.7 })); base.position.set(cx,0.3,cz); base.castShadow=false; base.receiveShadow=true; city.add(base);
+    const water=new THREE.Mesh(new THREE.CylinderGeometry(ringR*0.92, ringR*0.92, 0.4, 48), waterMat.clone()); water.position.set(cx,0.5,cz); city.add(water);
+    for(let i=0;i<26;i++){ const ang=Math.random()*Math.PI*2, r=ringR*0.95*(0.6+Math.random()*0.35); const s=new THREE.Mesh(new THREE.DodecahedronGeometry(0.6+Math.random()*0.8), new THREE.MeshStandardMaterial({ color:0x9aa0a8, roughness:0.95 })); s.position.set(cx+Math.cos(ang)*r,0.35,cz+Math.sin(ang)*r); city.add(s); }
+    for(let i=0;i<80;i++){ const ang=Math.random()*Math.PI*2, r=ringR*(0.2+Math.random()*0.9); const f=new THREE.Mesh(new THREE.ConeGeometry(0.15,0.4,8), new THREE.MeshStandardMaterial({ color: (Math.random()<0.5?0xff4d6d:0xffc300), roughness:0.9 })); f.position.set(cx+Math.cos(ang)*r,0.2,cz+Math.sin(ang)*r); city.add(f); }
+    const jets=[]; for(let i=0;i<8;i++){ const jet=new THREE.Mesh(new THREE.ConeGeometry(0.4,1.6,16), waterMat.clone()); jet.position.set(cx+(Math.random()*2-1)*2,1.4,cz+(Math.random()*2-1)*2); jet.rotation.x=Math.PI; city.add(jet); jets.push(jet); }
+    water.userData.jets=jets;
+    mapParks.push({type:'fountain',x:cx,z:cz,w:ringR*2.4,d:ringR*2.4});
+  }
+
+  const trafficLights=[];
+  function addTrafficLight(x,z,dir=0){ const h=5; const pole=new THREE.Mesh(new THREE.CylinderGeometry(0.1,0.1,h,10), new THREE.MeshStandardMaterial({ color:0x666 })); pole.position.set(x,h/2,z); city.add(pole); const box=new THREE.Mesh(new THREE.BoxGeometry(0.4,1,0.3), new THREE.MeshStandardMaterial({ color:0x222 })); box.position.set(x,3.6,z); box.rotation.y=dir; city.add(box);
+    const mkLamp=(c,dy)=>{ const m=new THREE.Mesh(new THREE.SphereGeometry(0.14,12,12), new THREE.MeshBasicMaterial({ color:c })); m.position.set(x+Math.sin(dir)*0.15,3.6+dy,z+Math.cos(dir)*0.15); city.add(m); return m; };
+    const Lg=mkLamp(0x2ecc71,0.28), Ly=mkLamp(0xf1c40f,0), Lr=mkLamp(0xe74c3c,-0.28);
+    trafficLights.push({pos:new THREE.Vector3(x,0,z), dir, state:'green', timer:0, lamps:{Lg,Ly,Lr}});
+  }
+
+  const POIS=[];
+  function addInstitution(kind, x, z){
+    let sign = kind==='hospital'?'HOSPITAL': kind==='police'?'POLICE': kind==='fire'?'FIRE': kind==='school'?'SCHOOL':'MALL';
+    const b=addBuilding(x,z,{floors: (kind==='mall'?6:7), w: (kind==='mall'?70:48), d:(kind==='mall'?60:40), hue: kind==='hospital'?5: (kind==='police'?210: (kind==='fire'?8: (kind==='school'?40:80))), sign, landmark:false});
+    if(kind==='hospital'){ const pad=new THREE.Mesh(new THREE.CircleGeometry(8,32), new THREE.MeshBasicMaterial({ color:0xffffff })); pad.rotation.x=-Math.PI/2; pad.position.set(x, b.dims.h+0.2, z- b.dims.d/2 + 10); city.add(pad); const H=new THREE.Mesh(new THREE.TorusGeometry(6,0.6,8,32), new THREE.MeshBasicMaterial({ color:0xff0000 })); H.rotation.x=-Math.PI/2; H.position.copy(pad.position).setY(b.dims.h+0.5); city.add(H); }
+    const icon = kind==='hospital'?'🏥': kind==='police'?'🚓': kind==='fire'?'🧯': kind==='school'?'🏫':'🛍';
+    POIS.push({type:kind, pos:new THREE.Vector3(x,0,z), label:icon, dims:b.dims});
+    mapLandmarks.push({x,z,label:`${icon} ${sign}`});
+  }
+
+  function addAirport(x,z){ const runway=new THREE.Mesh(new THREE.PlaneGeometry(400,26), new THREE.MeshBasicMaterial({ color:0x2f2f2f })); runway.rotation.x=-Math.PI/2; runway.position.set(x,0.02,z); city.add(runway); const stripe=new THREE.Mesh(new THREE.PlaneGeometry(400*0.9,3), new THREE.MeshBasicMaterial({ color:0xffffff, transparent:true, opacity:0.7 })); stripe.rotation.x=-Math.PI/2; stripe.position.set(x,0.03,z); city.add(stripe); const tower=new THREE.Mesh(new THREE.CylinderGeometry(4,4,28,16), new THREE.MeshStandardMaterial({ color:0x9aa0a8 })); tower.position.set(x+40,14,z-20); city.add(tower); const top=new THREE.Mesh(new THREE.SphereGeometry(6,16,12), new THREE.MeshStandardMaterial({ color:0xbfc6cf, metalness:0.2, roughness:0.6 })); top.position.set(x+40,28,z-20); city.add(top); POIS.push({type:'airport', pos:new THREE.Vector3(x,0,z), label:'🛫'}); mapLandmarks.push({x,z,label:'🛫 Airport'}); }
+  function addTrainStation(x,z){ const plat=new THREE.Mesh(new THREE.PlaneGeometry(160,8), new THREE.MeshBasicMaterial({ color:0x666b73 })); plat.rotation.x=-Math.PI/2; plat.position.set(x,0.02,z); city.add(plat); const rails=new THREE.Group(); for(let i=0;i<4;i++){ const r=new THREE.Mesh(new THREE.PlaneGeometry(160,0.3), new THREE.MeshBasicMaterial({ color:0x444 })); r.rotation.x=-Math.PI/2; r.position.set(x,0.021,z-2+i*1.2); rails.add(r);} city.add(rails); addBuilding(x+30,z-8,{floors:5,w:50,d:16,hue:48,sign:'STATION', landmark:false}); POIS.push({type:'station', pos:new THREE.Vector3(x,0,z), label:'🚉'}); mapLandmarks.push({x,z,label:'🚉 Station'}); }
+
+  const parkKinds=['tennis','basket','fountain'];
+  for(let ix=0; ix<BLOCKS_X; ix++){
+    for(let iz=0; iz<BLOCKS_Z; iz++){
+      const cx=startX+ix*CELL, cz=startZ+iz*CELL; addSidewalk(cx,cz);
+      const makePark = ((ix+iz)%2===0);
+      if(makePark){
+        const pick = parkKinds[(ix+iz)%parkKinds.length];
+        if(pick==='tennis') addTennisCourt(cx,cz);
+        else if(pick==='basket') addBasketCourt(cx,cz);
+        else addFountain(cx,cz);
+      } else {
+        const bCount=2+Math.floor(Math.random()*3); for(let b=0;b<bCount;b++){ addBuilding(cx+(Math.random()-0.5)*PLOT*0.7, cz+(Math.random()-0.5)*PLOT*0.7); }
       }
-      addEventListener('resize', fit);
+    }
+  }
+  for(let i=-BLOCKS_X;i<=BLOCKS_X;i+=2){ addTrafficLight(i*CELL*0.5, -BLOCKS_Z*CELL*0.5, 0); addTrafficLight(i*CELL*0.5, BLOCKS_Z*CELL*0.5, Math.PI); }
 
-      const scene = new THREE.Scene(); scene.background = new THREE.Color('#f3e3c7'); scene.fog = new THREE.Fog('#ffe8c7', 700, 2600);
-      const camera = new THREE.PerspectiveCamera(70, 9/16, 0.01, 8000); camera.position.set(0,1.7,5.6); scene.add(camera);
-      let camDist = 4.2; fit();
+  const ringR = Math.max(BLOCKS_X,BLOCKS_Z)*CELL*0.65;
+  const ringRoad=new THREE.Mesh(new THREE.RingGeometry(ringR-12, ringR+12, 128), new THREE.MeshStandardMaterial({ map:asphaltTex, side:THREE.DoubleSide, roughness:0.86 })); ringRoad.rotation.x=-Math.PI/2; ringRoad.position.y=0.011; city.add(ringRoad);
+  const ringStripe=new THREE.Mesh(new THREE.RingGeometry(ringR-2, ringR-1.4, 128), new THREE.MeshBasicMaterial({ color:0xffffff, transparent:true, opacity:0.22, side:THREE.DoubleSide })); ringStripe.rotation.x=-Math.PI/2; ringStripe.position.y=0.012; city.add(ringStripe);
+  mapRoads.push({type:'ring', name:ringRoadName, from:{x:0,z:0}, to:{x:0,z:0}, width:24, radius:ringR});
+  mapLandmarks.push({x:ringR*0.75,z:0,label:`🛣 ${ringRoadName}`});
+  const cityHalfX=BLOCKS_X*CELL*0.5, cityHalfZ=BLOCKS_Z*CELL*0.5; const connectorTargets=[
+    {from:{x:cityHalfX+ROAD*0.5, z:0}, to:{x:ringR-8, z:0}},
+    {from:{x:-cityHalfX-ROAD*0.5, z:0}, to:{x:-ringR+8, z:0}},
+    {from:{x:0, z:cityHalfZ+ROAD*0.5}, to:{x:0, z:ringR-8}},
+    {from:{x:0, z:-cityHalfZ-ROAD*0.5}, to:{x:0, z:-ringR+8}}
+  ];
+  connectorTargets.forEach((c)=>{ const dx=c.to.x-c.from.x, dz=c.to.z-c.from.z; const len=Math.hypot(dx,dz); if(len<1) return; const mesh=new THREE.Mesh(new THREE.PlaneGeometry(len, ROAD), roadMat); mesh.rotation.x=-Math.PI/2; mesh.rotation.y=Math.atan2(dz,dx); mesh.position.set((c.from.x+c.to.x)/2, 0.012, (c.from.z+c.to.z)/2); city.add(mesh); mapRoads.push({name:ringRoadName, from:c.from, to:c.to, width:ROAD}); });
+  addAirport(ringR*0.9,  -ringR*0.6);
+  addTrainStation(-ringR*0.6, ringR*0.85);
 
-      const hemi = new THREE.HemisphereLight(0xfff3d6, 0x8a7a6a, 0.7);
-      const key  = new THREE.DirectionalLight(0xffd6a0, allowShadows?1.28:1.1); key.position.set(220, 350, 180); key.castShadow=allowShadows; if(allowShadows){ key.shadow.mapSize.set(isMobile?1024:2048,isMobile?1024:2048); key.shadow.camera.near=1; key.shadow.camera.far=3000; key.shadow.camera.left=-900; key.shadow.camera.right=900; key.shadow.camera.top=900; key.shadow.camera.bottom=-900; }
-      const fill = new THREE.DirectionalLight(0xbfd6ff, 0.55); fill.position.set(-160,150,-260);
-      const rim  = new THREE.DirectionalLight(0x88c2ff, 0.8); rim.position.set(0,200,-280);
-      scene.add(hemi, key, fill, rim);
+  addInstitution('police',   startX+CELL*1.2, startZ+CELL*1.0);
+  addInstitution('hospital', startX+CELL*2.6, startZ+CELL*2.0);
+  addInstitution('school',   startX+CELL*0.4, startZ+CELL*3.2);
+  addInstitution('fire',     startX+CELL*3.5, startZ+CELL*0.6);
+  addInstitution('mall',     startX+CELL*4.2, startZ+CELL*2.6);
 
-      const world = new CANNON.World({ gravity: new CANNON.Vec3(0,-9.81,0) });
-      world.broadphase = new CANNON.SAPBroadphase(world); world.allowSleep = true;
-      const matGround=new CANNON.Material('ground'), matPlayer=new CANNON.Material('player'), matEnemy=new CANNON.Material('enemy'), matCar=new CANNON.Material('car'), matBall=new CANNON.Material('bball');
-      world.addContactMaterial(new CANNON.ContactMaterial(matGround, matPlayer, { friction:.2, restitution:0 }));
-      world.addContactMaterial(new CANNON.ContactMaterial(matGround, matCar, { friction:.9, restitution:0 }));
-      world.addContactMaterial(new CANNON.ContactMaterial(matGround, matBall, { friction:.45, restitution:0.86 }));
-      const groundBody = new CANNON.Body({ mass:0, material:matGround, shape:new CANNON.Plane() });
-      groundBody.quaternion.setFromEuler(-Math.PI/2,0,0); world.addBody(groundBody);
+  const playerRadius=0.35; const player=new CANNON.Body({ mass:75, material:matPlayer, shape:new CANNON.Sphere(playerRadius), position:new CANNON.Vec3(0,1.0,10), linearDamping:0.18, angularDamping:0.9 });
+  player.fixedRotation=true; player.allowSleep=false; world.addBody(player);
+  let yaw=0, pitch=0; const PITCH_LIMIT=Math.PI*0.498; function clampPitch(){ pitch=Math.max(-PITCH_LIMIT, Math.min(PITCH_LIMIT, pitch)); }
+  let camDist=4.2;
+  function camFollow(pos,distMul=1){ const back=new THREE.Vector3(Math.sin(yaw),0,Math.cos(yaw)); const eye=new THREE.Vector3(pos.x - back.x*camDist*distMul, pos.y+2.1, pos.z - back.z*camDist*distMul); camera.position.lerp(eye,0.25); const look=new THREE.Vector3(pos.x + back.x*(camDist+0.2)*distMul, pos.y+1.25 + Math.sin(pitch)*0.8, pos.z + back.z*(camDist+0.2)*distMul); camera.lookAt(look); }
+  function grounded(){ return player.position.y < 0.38 && Math.abs(player.velocity.y) < 0.05; }
+  function jump(){ if(grounded()){ player.velocity.y = 5.2; } }
 
-      function makeAsphalt(size=1024){ const c=document.createElement('canvas'); c.width=c.height=size; const x=c.getContext('2d'); x.fillStyle='#2c323a'; x.fillRect(0,0,size,size); for(let i=0;i<8000;i++){ const a=Math.random()*0.12; x.fillStyle=`rgba(255,255,255,${a})`; x.fillRect(Math.random()*size,Math.random()*size,1,1);} for(let i=0;i<320;i++){ x.strokeStyle='rgba(0,0,0,0.25)'; x.lineWidth=Math.random()*1.2; x.beginPath(); x.moveTo(Math.random()*size,Math.random()*size); x.lineTo(Math.random()*size,Math.random()*size); x.stroke(); } const t=new THREE.CanvasTexture(c); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(24,24); t.anisotropy=8; t.colorSpace=THREE.SRGBColorSpace; return t; }
-      function makeSidewalk(size=512){ const c=document.createElement('canvas'); c.width=c.height=size; const x=c.getContext('2d'); x.fillStyle='#c9ced6'; x.fillRect(0,0,size,size); x.strokeStyle='#9aa0a8'; x.lineWidth=6; for(let s=0;s<size;s+=64){ x.beginPath(); x.moveTo(s,0); x.lineTo(s,size); x.stroke(); x.beginPath(); x.moveTo(0,s); x.lineTo(size,s); x.stroke(); } const t=new THREE.CanvasTexture(c); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(32,32); t.anisotropy=6; t.colorSpace=THREE.SRGBColorSpace; return t; }
-      function facadeTex(hue=200){ const W=256,H=512; const c=document.createElement('canvas'); c.width=W; c.height=H; const ctx=c.getContext('2d'); ctx.fillStyle=`hsl(${hue},16%,74%)`; ctx.fillRect(0,0,W,H); for(let i=0;i<1800;i++){ const a=Math.random()*0.08; ctx.fillStyle=`rgba(0,0,0,${a})`; ctx.fillRect(Math.random()*W,Math.random()*H,1,1);} const cols=6+Math.floor(Math.random()*4), rows=14+Math.floor(Math.random()*6); const padX=12,padY=16; const cellW=(W-2*padX)/cols, cellH=(H-2*padY)/rows; for(let r=0;r<rows;r++){ for(let cix=0;cix<cols;cix++){ const x=padX+cix*cellW+6, y=padY+r*cellH+6, w=cellW-12, h=cellH-12; const g=ctx.createLinearGradient(0,y,0,y+h); g.addColorStop(0,'rgba(240,245,255,0.95)'); g.addColorStop(0.5,'rgba(150,180,220,0.92)'); g.addColorStop(1,'rgba(60,80,120,0.9)'); ctx.fillStyle=g; ctx.fillRect(x,y,w,h); ctx.strokeStyle='rgba(24,28,38,0.9)'; ctx.lineWidth=2; ctx.strokeRect(x,y,w,h); } } const tex=new THREE.CanvasTexture(c); tex.anisotropy=4; tex.colorSpace=THREE.SRGBColorSpace; return tex; }
-      function grassProcedural(size=1024){ const c=document.createElement('canvas'); c.width=c.height=size; const x=c.getContext('2d'); x.fillStyle='#6fa863'; x.fillRect(0,0,size,size); for(let i=0;i<2600;i++){ x.fillStyle=`rgba(0,80,0,${Math.random()*0.12})`; x.fillRect(Math.random()*size,Math.random()*size,1,1);} const t=new THREE.CanvasTexture(c); t.wrapS=t.wrapT=THREE.RepeatWrapping; t.repeat.set(6,6); t.anisotropy=8; t.colorSpace=THREE.SRGBColorSpace; return t; }
-      async function grassFromURL(){ return new Promise((resolve)=>{ const loader=new THREE.TextureLoader(); loader.load('https://threejs.org/examples/textures/terrain/grasslight-big.jpg', (tex)=>{ tex.wrapS=tex.wrapT=THREE.RepeatWrapping; tex.repeat.set(6,6); tex.anisotropy=8; tex.colorSpace=THREE.SRGBColorSpace; resolve(tex); }, ()=>resolve(grassProcedural()), ()=>resolve(grassProcedural())); }); }
+  const aimGeo=new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(), new THREE.Vector3(0,0,-50)]);
+  const aimMatDark=new THREE.LineBasicMaterial({ color:0x222222, transparent:true, opacity:0.9 });
+  const aimLine=new THREE.Line(aimGeo,aimMatDark); aimLine.renderOrder=9; scene.add(aimLine);
+  const aimDotTex=(function(){ const c=document.createElement('canvas'); c.width=c.height=64; const x=c.getContext('2d'); x.fillStyle='rgba(255,255,255,0.0)'; x.fillRect(0,0,64,64); x.beginPath(); x.arc(32,32,14,0,Math.PI*2); x.fillStyle='rgba(255,60,60,0.95)'; x.fill(); x.lineWidth=3; x.strokeStyle='rgba(255,255,255,0.9)'; x.stroke(); const t=new THREE.CanvasTexture(c); t.colorSpace=THREE.SRGBColorSpace; return t; })();
+  const aimDotMat=new THREE.SpriteMaterial({ map:aimDotTex, depthWrite:false, color:0xffffff }); const aimDot=new THREE.Sprite(aimDotMat); aimDot.scale.set(0.7,0.7,1); scene.add(aimDot);
+  const crosshairEl=$('crosshair'); crosshairEl.style.setProperty('--aimColor','#ff3c3c');
 
-      function createCourtTexture(type){
-        const c=document.createElement('canvas'); c.width=1024; c.height=512; const ctx=c.getContext('2d');
-        ctx.fillStyle=(type==='tennis')?'#1d7d4f':'#c6864a';
-        ctx.fillRect(0,0,c.width,c.height);
-        ctx.strokeStyle='#f9f5e6'; ctx.lineWidth=type==='tennis'?16:18; ctx.lineJoin='round';
-        if(type==='tennis'){
-          const margin=70; ctx.strokeRect(margin,margin,c.width-margin*2,c.height-margin*2);
-          ctx.beginPath(); ctx.moveTo(c.width/2,margin); ctx.lineTo(c.width/2,c.height-margin); ctx.stroke();
-          ctx.strokeRect(margin*1.6,margin,c.width-margin*3.2,c.height-margin*2);
-        } else {
-          const r=180; ctx.beginPath(); ctx.rect(70,70,c.width-140,c.height-140); ctx.stroke();
-          ctx.beginPath(); ctx.arc(c.width/2,70,r,Math.PI,0,false); ctx.stroke();
-          ctx.beginPath(); ctx.arc(c.width/2,c.height-70,r,0,Math.PI,false); ctx.stroke();
-          ctx.beginPath(); ctx.arc(c.width/4, c.height/2, 90, Math.PI/2,-Math.PI/2,true); ctx.stroke();
-          ctx.beginPath(); ctx.arc(c.width*0.75, c.height/2, 90, -Math.PI/2,Math.PI/2,true); ctx.stroke();
-        }
-        const t=new THREE.CanvasTexture(c); t.anisotropy=8; t.colorSpace=THREE.SRGBColorSpace; return t;
+  const smokeTex=(function(){ const c=document.createElement('canvas'); c.width=c.height=128; const ctx=c.getContext('2d'); const grad=ctx.createRadialGradient(64,64,12,64,64,64); grad.addColorStop(0,'rgba(255,255,255,0.28)'); grad.addColorStop(0.45,'rgba(148,163,184,0.22)'); grad.addColorStop(1,'rgba(15,23,42,0)'); ctx.fillStyle=grad; ctx.fillRect(0,0,128,128); const tex=new THREE.CanvasTexture(c); tex.colorSpace=THREE.SRGBColorSpace; return tex; })();
+  const scorchTex=(function(){ const c=document.createElement('canvas'); c.width=c.height=128; const ctx=c.getContext('2d'); ctx.fillStyle='rgba(0,0,0,0)'; ctx.fillRect(0,0,128,128); ctx.translate(64,64); const grd=ctx.createRadialGradient(0,0,6,0,0,60); grd.addColorStop(0,'rgba(64,64,64,0.9)'); grd.addColorStop(0.55,'rgba(40,40,40,0.65)'); grd.addColorStop(1,'rgba(0,0,0,0)'); ctx.fillStyle=grd; ctx.beginPath(); ctx.arc(0,0,60,0,Math.PI*2); ctx.fill(); const tex=new THREE.CanvasTexture(c); tex.colorSpace=THREE.SRGBColorSpace; return tex; })();
+  const grenadeFallbackGeo=new THREE.SphereGeometry(0.18,18,18);
+  const grenadeFallbackMat=new THREE.MeshStandardMaterial({ color:0x4a4f59, metalness:0.32, roughness:0.58 });
+
+  const BLANK_PNG='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
+  const manager=new THREE.LoadingManager(); manager.setURLModifier((url)=>{ if(url?.startsWith('data:')||url?.startsWith('blob:')) return url; if(/(\.(png|jpg|jpeg|webp|ktx2|dds|tga)(\?|#|$))/i.test(url)) return BLANK_PNG; return url; });
+  const gltfLoader=new GLTFLoader(manager); const draco=new DRACOLoader(manager); draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/'); gltfLoader.setDRACOLoader(draco); gltfLoader.setCrossOrigin('anonymous');
+  gltfLoader.register((parser)=>{ const c=document.createElement('canvas'); c.width=c.height=1; const ctx=c.getContext('2d'); ctx.fillStyle='#888'; ctx.fillRect(0,0,1,1); const blank=new THREE.CanvasTexture(c); blank.colorSpace=THREE.SRGBColorSpace; blank.needsUpdate=true; const orig=parser.getDependency.bind(parser); parser.getDependency=function(type,index){ if(type==='texture') return Promise.resolve(blank); return orig(type,index); }; return {name:'NullTextures'}; });
+
+  const ARMORY=[
+    { key:'Glock',  name:'Glock', url:'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/glock.glb', s:0.62,  stats:{ rpm:380, dmg:24, spread:0.013, mag:17, reload:1.2 }, auto:false },
+    { key:'Pistol', name:'Pistol',url:'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb', s:0.46, stats:{ rpm:320, dmg:22, spread:0.014, mag:15, reload:1.3 }, auto:false },
+    { key:'AR',     name:'Assault Rifle', url:'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb', s:0.70, stats:{ rpm:720, dmg:26, spread:0.012, mag:30, reload:1.9 }, auto:true },
+    { key:'Uzi',    name:'Uzi',    url:'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb', s:0.60, stats:{ rpm:900, dmg:18, spread:0.02,  mag:32, reload:1.6 }, auto:true },
+    { key:'AK47',   name:'AK-pattern', url:'https://cdn.jsdelivr.net/gh/LazerMaker/gun-models-ak47-and-supprest-pistol-@master/ak47.glb', s:0.78, stats:{ rpm:600, dmg:30, spread:0.012, mag:30, reload:1.9 }, auto:true },
+    { key:'Grenade',name:'Grenade',url:'https://cdn.jsdelivr.net/gh/friuns2/bingextension@main/grenade.glb', s:0.30, stats:{ rpm:60,  dmg:120, spread:0.03,  mag:1,  reload:2.4 }, auto:false }
+  ];
+  const FIRE_MODES=new Map(); ARMORY.forEach(a=>FIRE_MODES.set(a.key, a.auto?'auto':'single'));
+
+  const weaponRoot=new THREE.Group(); camera.add(weaponRoot);
+  const weaponCache=new Map();
+  const metalTex=(()=>{ const S=256,c=document.createElement('canvas'); c.width=c.height=S; const x=c.getContext('2d'); const g=x.createLinearGradient(0,0,S,S); g.addColorStop(0,'#2e2e2e'); g.addColorStop(1,'#4a4a4a'); x.fillStyle=g; x.fillRect(0,0,S,S); const t=new THREE.CanvasTexture(c); t.colorSpace=THREE.SRGBColorSpace; t.anisotropy=2; return t; })();
+  const matMetal=new THREE.MeshLambertMaterial({ color:'#3b3b3b', map:metalTex }), matWood =new THREE.MeshLambertMaterial({ color:'#7b5331' });
+  function makeSight(){ const s=new THREE.Group(); const ring=new THREE.Mesh(new THREE.TorusGeometry(0.015,0.004,8,12), new THREE.MeshBasicMaterial({ color:'#222' })); ring.rotation.x=Math.PI/2; ring.position.set(0,0,0.02); const post=new THREE.Mesh(new THREE.BoxGeometry(0.004,0.02,0.004), new THREE.MeshBasicMaterial({ color:'#444' })); post.position.set(0,0,0.03); s.add(ring,post); return s; }
+  function makeAK47Mesh(){ const g=new THREE.Group(); const rec=new THREE.Mesh(new THREE.BoxGeometry(0.12,0.11,0.45), matMetal); const hand=new THREE.Mesh(new THREE.BoxGeometry(0.07,0.08,0.28), matWood); hand.position.set(0.07,-0.02,-0.22); const barrel=new THREE.Mesh(new THREE.CylinderGeometry(0.016,0.016,0.38,18), matMetal); barrel.rotation.z=Math.PI/2; barrel.position.set(0.12,-0.02,-0.41); const stock=new THREE.Mesh(new THREE.BoxGeometry(0.08,0.09,0.25), matWood); stock.position.set(-0.06,-0.01,0.16); const mag=new THREE.Mesh(new THREE.CapsuleGeometry(0.04,0.12,8,16), matMetal); mag.rotation.x=Math.PI/2; mag.position.set(0.02,-0.08,0.02); g.add(rec,hand,barrel,stock,mag,makeSight()); return g; }
+  function makePistolMesh(){ const g=new THREE.Group(); const slide=new THREE.Mesh(new THREE.BoxGeometry(0.08,0.05,0.18), matMetal); slide.position.set(0.02,0.02,-0.09); const frame=new THREE.Mesh(new THREE.BoxGeometry(0.09,0.07,0.14), new THREE.MeshLambertMaterial({color:'#444'})); const grip=new THREE.Mesh(new THREE.BoxGeometry(0.05,0.1,0.06), new THREE.MeshLambertMaterial({color:'#2b2b2b'})); grip.position.set(-0.02,-0.05,0.02); const barrel=new THREE.Mesh(new THREE.CylinderGeometry(0.008,0.008,0.14,10), matMetal); barrel.rotation.z=Math.PI/2; barrel.position.set(0.07,0.02,-0.18); g.add(frame,slide,grip,barrel,makeSight()); return g; }
+  function normalizeAndCenter(root, targetLen=0.6){ const box=new THREE.Box3().setFromObject(root); const size=new THREE.Vector3(); box.getSize(size); const center=new THREE.Vector3(); box.getCenter(center); root.position.sub(center); const maxDim=Math.max(size.x,size.y,size.z)||1; const s=targetLen/maxDim; root.scale.setScalar(s); return root; }
+  async function loadWeapon(key){ const entry=ARMORY.find(a=>a.key===key); if(!entry){ return new THREE.Group(); } if(weaponCache.has(key)){ const v=weaponCache.get(key); return (v.clone? v.clone(true) : v); } try{ const gltf=await gltfLoader.loadAsync(entry.url); const base=(gltf.scene||gltf.scenes?.[0]||null); let use = base || makePistolMesh(); normalizeAndCenter(use, entry.s); use.traverse?.(o=>{ if(o.isMesh){ o.castShadow=allowShadows; o.receiveShadow=allowShadows; const m=o.material; o.material = new THREE.MeshLambertMaterial({ color:(m?.color||new THREE.Color('#888')), map:m?.map||null, transparent:!!m?.transparent, opacity:(m?.opacity??1) }); }}); weaponCache.set(key, use); return (use.clone? use.clone(true) : use); }catch(_){ let alt; if(key==='AK47') alt=makeAK47Mesh(); else alt=makePistolMesh(); normalizeAndCenter(alt, key==='AK47'?0.78:0.5); weaponCache.set(key, alt); return (alt.clone? alt.clone(true) : alt); } }
+
+  let grenadeProjectileTemplate=null; let grenadeProjectileLoading=false;
+  async function ensureGrenadeTemplate(){ if(grenadeProjectileTemplate || grenadeProjectileLoading) return; grenadeProjectileLoading=true; try{ const model=await loadWeapon('Grenade'); const holder=new THREE.Group(); const instance=model.clone(true); holder.add(instance); holder.traverse?.(o=>{ if(o.isMesh){ o.castShadow=allowShadows; o.receiveShadow=allowShadows; } }); grenadeProjectileTemplate=holder; }catch(_){ grenadeProjectileTemplate=null; }finally{ grenadeProjectileLoading=false; } }
+  function buildGrenadeMesh(){ if(grenadeProjectileTemplate){ const inst=grenadeProjectileTemplate.clone(true); inst.traverse?.(o=>{ if(o.isMesh){ o.castShadow=allowShadows; o.receiveShadow=allowShadows; } }); return inst; } const fallback=new THREE.Mesh(grenadeFallbackGeo, grenadeFallbackMat.clone()); fallback.castShadow=allowShadows; fallback.receiveShadow=allowShadows; return fallback; }
+
+  const armoryDiv=$('armory'); const thumbCache=new Map();
+  function weaponIconURL(key){ const svg=(b)=>'data:image/svg+xml;utf8,'+encodeURIComponent(b); const base=(body)=>`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 112 68'><rect width='112' height='68' rx='8' ry='8' fill='rgba(0,0,0,0.18)'/><g fill='none' stroke='#e6eefc' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'>${body}</g></svg>`; switch(key){ case 'Glock': return svg(base(`<path d='M14 32h58l8 8H14z'/><path d='M64 32v-8h20l8 10'/>`)); case 'Pistol': return svg(base(`<path d='M12 34h62l10 8H12z'/>`)); case 'AR': return svg(base(`<path d='M8 38h74l8 6H8z'/>`)); case 'Uzi': return svg(base(`<path d='M10 34h52l8 6H10z'/>`)); case 'AK47': return svg(base(`<path d='M10 38h84l10 6H10z'/>`)); case 'Grenade': return svg(base(`<circle cx='42' cy='36' r='12'/>`)); default: return svg(base(`<path d='M16 34h80'/>`)); } }
+  function weaponPreviewURL(key){ return thumbCache.get(key) || weaponIconURL(key); }
+  async function generateThumb(key){ try{ if(thumbCache.has(key)) return thumbCache.get(key); const size={w:224,h:136}; const rt=new THREE.WebGLRenderTarget(size.w,size.h); const sc=new THREE.Scene(); const cam=new THREE.PerspectiveCamera(40, size.w/size.h, 0.01, 10); const amb=new THREE.AmbientLight(0xffffff,0.9); const dir=new THREE.DirectionalLight(0xffffff,0.9); dir.position.set(2,3,2); sc.add(amb,dir); const model=await loadWeapon(key); const g=new THREE.Group(); if(model) g.add(model); normalizeAndCenter(g,0.9); g.rotation.y=Math.PI*0.85; sc.add(g); const prev=new THREE.Color(); renderer.getClearColor(prev); const prevA=renderer.getClearAlpha(); renderer.setRenderTarget(rt); renderer.setClearColor(0x000000,0); cam.position.set(0.6,0.3,1.2); cam.lookAt(0,0,0); renderer.render(sc,cam); const px=new Uint8Array(size.w*size.h*4); renderer.readRenderTargetPixels(rt,0,0,size.w,size.h,px); const cv=document.createElement('canvas'); cv.width=size.w; cv.height=size.h; const ctx=cv.getContext('2d'); const img=ctx.createImageData(size.w,size.h); for(let y=0;y<size.h;y++){ const sy=size.h-1-y; img.data.set(px.subarray(sy*size.w*4, sy*size.w*4+size.w*4), y*size.w*4);} ctx.putImageData(img,0,0); const url=cv.toDataURL('image/png'); renderer.setRenderTarget(null); renderer.setClearColor(prev,prevA); rt.dispose(); thumbCache.set(key,url); return url; }catch(_){ return weaponIconURL(key); } }
+  function enableDragScroll(el){ let isDown=false; let startX=0; let scrollLeft=0; let moved=false; el.addEventListener('pointerdown',(e)=>{ isDown=true; moved=false; startX=e.clientX; scrollLeft=el.scrollLeft; el.classList.add('dragging'); try{ el.setPointerCapture(e.pointerId); }catch(_){ } }); el.addEventListener('pointermove',(e)=>{ if(!isDown) return; const dx=e.clientX-startX; if(Math.abs(dx)>6) moved=true; el.scrollLeft=scrollLeft-dx; }); const stop=(e)=>{ if(isDown){ try{ el.releasePointerCapture(e.pointerId); }catch(_){ } } isDown=false; el.classList.remove('dragging'); }; el.addEventListener('pointerup',stop); el.addEventListener('pointercancel',stop); el.addEventListener('click',(e)=>{ if(moved){ e.preventDefault(); e.stopPropagation(); }}); }
+  function buildGallery(){ armoryDiv.innerHTML=''; ARMORY.forEach((a)=>{ const b=document.createElement('button'); b.className='armBtn'; b.id='arm_'+a.key; b.innerHTML = `<img alt="${a.name}" src="${weaponPreviewURL(a.key)}"><span>${a.name}</span>`; b.addEventListener('click',()=>selectWeapon(a.key)); if(a.auto){ const t=document.createElement('button'); t.className='modeToggle'; t.textContent=(FIRE_MODES.get(a.key)==='auto')?'AUTO':'SINGLE'; t.addEventListener('click',(ev)=>{ ev.stopPropagation(); FIRE_MODES.set(a.key, FIRE_MODES.get(a.key)==='auto'?'single':'auto'); t.textContent=(FIRE_MODES.get(a.key)==='auto')?'AUTO':'SINGLE'; }); b.appendChild(t); } armoryDiv.appendChild(b); generateThumb(a.key).then(url=>{ const img=b.querySelector('img'); if(img) img.src=url; }); }); enableDragScroll(armoryDiv); }
+  buildGallery();
+
+  let currentKey=ARMORY[0].key, currentStats=ARMORY[0].stats; let weaponModel=null; const ammo=new Map(); ARMORY.forEach(a=>ammo.set(a.key,{mag:a.stats.mag,reserve:a.stats.mag*3}));
+  function updateAmmoHUD(){ const a=ammo.get(currentKey); $('ammo').textContent=`${ARMORY.find(x=>x.key===currentKey)?.name||currentKey} — ${a.mag}/${a.reserve}`; document.querySelectorAll('.armBtn').forEach(el=>el.classList.remove('active')); const ab=$('arm_'+currentKey); if(ab) ab.classList.add('active'); }
+  const MUZZLE_OFF={ Glock:[0.0,-0.02,-0.74], Pistol:[0.0,-0.02,-0.74], AR:[0.0,-0.04,-0.80], Uzi:[0.0,-0.03,-0.78], AK47:[0.0,-0.04,-0.82], Grenade:[0,0,0] };
+  const EJECT_OFF={ Glock:[0.06,-0.05,-0.36], Pistol:[0.06,-0.05,-0.36], AR:[0.08,-0.05,-0.42], Uzi:[0.06,-0.04,-0.40], AK47:[0.09,-0.05,-0.44], Grenade:[0,0,0] };
+  const SHELL_SPECS={
+    Glock:{radius:0.006,length:0.14,color:0xd6b064},
+    Pistol:{radius:0.006,length:0.14,color:0xd6b064},
+    Uzi:{radius:0.0055,length:0.13,color:0xd0a050},
+    AR:{radius:0.0064,length:0.20,color:0xcfa443},
+    AK47:{radius:0.007,length:0.22,color:0xc58f3d}
+  };
+  const HAND_OFFSETS={
+    Glock:{pos:[0.18,-0.09,-0.48], rot:[-0.02,Math.PI,-0.11]},
+    Pistol:{pos:[0.18,-0.09,-0.48], rot:[-0.02,Math.PI,-0.11]},
+    Uzi:{pos:[0.2,-0.1,-0.5], rot:[-0.03,Math.PI,-0.12]},
+    AR:{pos:[0.22,-0.11,-0.54], rot:[-0.03,Math.PI,-0.12]},
+    AK47:{pos:[0.22,-0.1,-0.56], rot:[-0.035,Math.PI,-0.14]},
+    Grenade:{pos:[0.16,-0.06,-0.42], rot:[-0.01,Math.PI,-0.08]}
+  };
+
+  async function mountPlayerWeapon(key){ if(weaponModel){ weaponRoot.remove(weaponModel); weaponModel.traverse(o=>{ o.geometry?.dispose?.(); if(Array.isArray(o.material)) o.material.forEach(m=>m.dispose?.()); else o.material?.dispose?.(); }); weaponModel=null; }
+    const model=await loadWeapon(key); const g=new THREE.Group(); if(model) g.add(model);
+    const hoff=HAND_OFFSETS[key]||HAND_OFFSETS.Pistol; g.position.set(hoff.pos[0], hoff.pos[1], hoff.pos[2]); g.rotation.set(hoff.rot[0], hoff.rot[1], hoff.rot[2]);
+    weaponModel=g; weaponRoot.add(g);
+    const muzzleAnchor=new THREE.Object3D(); const ejectAnchor=new THREE.Object3D(); weaponModel.add(muzzleAnchor); weaponModel.add(ejectAnchor);
+    const mo=MUZZLE_OFF[key]||MUZZLE_OFF.Glock; const eo=EJECT_OFF[key]||EJECT_OFF.Glock; muzzleAnchor.position.set(mo[0],mo[1],mo[2]); ejectAnchor.position.set(eo[0],eo[1],eo[2]);
+    weaponModel.userData.muzzleAnchor=muzzleAnchor; weaponModel.userData.ejectAnchor=ejectAnchor; }
+  async function selectWeapon(key){ currentKey=key; currentStats=ARMORY.find(a=>a.key===key)?.stats||currentStats; updateAmmoHUD(); await mountPlayerWeapon(key); updateZoomUI(); }
+  await selectWeapon(currentKey);
+  ensureGrenadeTemplate();
+
+  const impactTargets=[city];
+  const activeGrenades=[]; const explosionFX=[];
+  const raycaster=new THREE.Raycaster(); const tracers=[]; function tracer(from,to,color=0xfff1b1,life=0.12){ const g=new THREE.BufferGeometry().setFromPoints([from,to]); const m=new THREE.LineBasicMaterial({color,transparent:true}); const l=new THREE.Line(g,m); l.userData.life=life; scene.add(l); tracers.push(l);} function updateTracers(dt){ for(let i=0;i<tracers.length;i++){ const l=tracers[i]; l.userData.life-=dt; l.material.opacity=Math.max(0,l.userData.life/0.12); if(l.userData.life<=0){ scene.remove(l); l.geometry.dispose(); l.material.dispose(); tracers.splice(i,1); i--; } } }
+  const decalTex=(function(){ const c=document.createElement('canvas'); c.width=c.height=64; const x=c.getContext('2d'); x.clearRect(0,0,64,64); x.fillStyle='rgba(0,0,0,0.9)'; x.beginPath(); x.arc(32,32,18,0,Math.PI*2); x.fill(); x.fillStyle='rgba(0,0,0,0.4)'; for(let i=0;i<10;i++){ const r=22+Math.random()*6; x.beginPath(); x.arc(32+(Math.random()-0.5)*6,32+(Math.random()-0.5)*6,r,0,Math.PI*2); x.fill(); } const t=new THREE.CanvasTexture(c); t.colorSpace=THREE.SRGBColorSpace; t.anisotropy=2; return t; })();
+  function addDecal(point, normal){ const s=0.22; const g=new THREE.PlaneGeometry(s,s); const m=new THREE.MeshBasicMaterial({ map:decalTex, transparent:true, depthWrite:false }); const q=new THREE.Quaternion(); q.setFromUnitVectors(new THREE.Vector3(0,0,1), normal.clone().normalize()); const mesh=new THREE.Mesh(g,m); mesh.position.copy(point); mesh.quaternion.copy(q); mesh.renderOrder=10; scene.add(mesh); setTimeout(()=>{ scene.remove(mesh); g.dispose(); m.dispose(); }, 15000); }
+  const bloodTex=(function(){ const c=document.createElement('canvas'); c.width=c.height=64; const x=c.getContext('2d'); x.fillStyle='rgba(160,0,0,0.0)'; x.fillRect(0,0,64,64); x.fillStyle='rgba(210,20,20,0.9)'; x.beginPath(); x.arc(32,32,20,0,Math.PI*2); x.fill(); x.fillStyle='rgba(120,0,0,0.9)'; for(let i=0;i<5;i++){ x.beginPath(); x.arc(32+(Math.random()-0.5)*16,32+(Math.random()-0.5)*16,6+Math.random()*6,0,Math.PI*2); x.fill(); } const t=new THREE.CanvasTexture(c); t.colorSpace=THREE.SRGBColorSpace; return t; })();
+  function addBlood(point){ const s=0.38; const g=new THREE.PlaneGeometry(s,s); const m=new THREE.MeshBasicMaterial({ map:bloodTex, transparent:true, depthWrite:false }); const mesh=new THREE.Mesh(g,m); mesh.position.copy(point); mesh.lookAt(camera.position); scene.add(mesh); setTimeout(()=>{ scene.remove(mesh); g.dispose(); m.dispose(); }, 12000); }
+
+  let reloading=false; function reload(){ const a=ammo.get(currentKey); const st=currentStats; if(reloading || !a) return; const need=st.mag-a.mag; if(need<=0||a.reserve<=0) return; const take=Math.min(need,a.reserve); reloading=true; setTimeout(()=>{ a.mag+=take; a.reserve-=take; reloading=false; updateAmmoHUD(); sfxReload(); }, st.reload*1000); }
+  $('reloadMini').addEventListener('click', reload);
+
+  function sfxGrenadeThrow(){ burstNoise({dur:0.12,freq:900,gain:0.1}); click({freq:520,dur:0.06,gain:0.04}); }
+  function sfxExplosion(){ burstNoise({dur:0.65,freq:220,gain:0.28}); setTimeout(()=>burstNoise({dur:0.35,freq:320,gain:0.18}),110); }
+
+  function throwGrenade(){ if(!grenadeProjectileTemplate && !grenadeProjectileLoading){ ensureGrenadeTemplate(); }
+    const spawn=camera.position.clone(); const dir=new THREE.Vector3(); camera.getWorldDirection(dir); const aimDir=dir.clone().normalize(); const start=spawn.clone().add(aimDir.clone().multiplyScalar(0.9)).add(new THREE.Vector3(0,-0.05,0));
+    const mesh=buildGrenadeMesh(); mesh.position.copy(start); scene.add(mesh);
+    const body=new CANNON.Body({ mass:1.1, shape:new CANNON.Sphere(0.18), material:matPlayer, linearDamping:0.02, angularDamping:0.1 });
+    body.position.set(start.x,start.y,start.z);
+    const vel=aimDir.multiplyScalar(15.8); vel.y += 5.6; body.velocity.set(vel.x, vel.y, vel.z);
+    body.angularVelocity.set((Math.random()-0.5)*6,(Math.random()-0.5)*6,(Math.random()-0.5)*6);
+    world.addBody(body);
+    activeGrenades.push({mesh, body, fuse:2.6});
+    sfxGrenadeThrow(); }
+
+  function createExplosionFX(pos){ const core=new THREE.Mesh(new THREE.SphereGeometry(0.6,24,16), new THREE.MeshBasicMaterial({ color:0xffc857, transparent:true, opacity:0.98 })); core.position.copy(pos); scene.add(core); const ring=new THREE.Mesh(new THREE.RingGeometry(0.3,0.35,48), new THREE.MeshBasicMaterial({ color:0xff9f1c, transparent:true, opacity:0.9, side:THREE.DoubleSide })); ring.rotation.x=-Math.PI/2; ring.position.set(pos.x,0.04,pos.z); scene.add(ring); const flash=new THREE.PointLight(0xffd27a, 18, 52); flash.position.set(pos.x, pos.y+2.4, pos.z); scene.add(flash);
+    const smoke=new THREE.Sprite(new THREE.SpriteMaterial({ map:smokeTex, transparent:true, opacity:0.82, depthWrite:false })); smoke.position.copy(pos).setY(pos.y+1.4); smoke.scale.set(5.6,5.6,1); scene.add(smoke);
+    const shards=[]; const shardGeo=new THREE.ConeGeometry(0.12,0.52,12); const shardMat=new THREE.MeshStandardMaterial({ color:0xffa94d, emissive:0xff922b, emissiveIntensity:0.8, roughness:0.55, metalness:0.2, transparent:true, opacity:0.95 });
+    for(let i=0;i<22;i++){ const shard=new THREE.Mesh(shardGeo, shardMat.clone()); shard.position.copy(pos); shard.castShadow=allowShadows; shard.receiveShadow=allowShadows; const dir=new THREE.Vector3((Math.random()*2-1),(Math.random()*1.2+0.2),(Math.random()*2-1)).normalize(); const speed=6.5+Math.random()*5.5; shards.push({mesh:shard, velocity:dir.multiplyScalar(speed), spin:new THREE.Vector3((Math.random()-0.5)*6,(Math.random()-0.5)*6,(Math.random()-0.5)*6)}); scene.add(shard); }
+    const scorch=new THREE.Mesh(new THREE.CircleGeometry(1.8,28), new THREE.MeshBasicMaterial({ map:scorchTex, transparent:true, opacity:0.85, depthWrite:false })); scorch.rotation.x=-Math.PI/2; scorch.position.set(pos.x,0.025,pos.z); scorch.rotation.z=Math.random()*Math.PI*2; scene.add(scorch); setTimeout(()=>{ scene.remove(scorch); scorch.geometry.dispose(); scorch.material.dispose(); }, 20000);
+    explosionFX.push({core, ring, light:flash, smoke, shards, life:1.2, maxLife:1.2}); }
+
+  function applyExplosionDamage(center,radius,power){ enemies.forEach((enemy)=>{ if(enemy.dead) return; const dx=enemy.body.position.x-center.x; const dz=enemy.body.position.z-center.z; const dy=enemy.body.position.y-center.y; const dist=Math.sqrt(dx*dx + dy*dy + dz*dz); if(dist<radius){ const impact=(1 - dist/radius); enemy.hp -= power*impact; addBlood(new THREE.Vector3(enemy.body.position.x, enemy.body.position.y+1.4, enemy.body.position.z)); if(enemy.hp<=0){ enemy.dead=true; enemy.body.mass=0; enemy.body.updateMassProperties(); enemy.root.visible=false; enemy.hpBar.visible=false; } else { updateBillboardBar(enemy.hpBar, enemy.hp/120); enemy.body.velocity.x += (dx/dist||0)*impact*6; enemy.body.velocity.z += (dz/dist||0)*impact*6; } } }); const pdx=player.position.x-center.x; const pdz=player.position.z-center.z; const pdist=Math.hypot(pdx,pdz); if(pdist<radius*0.9){ const hurt=Math.max(6, power*0.35*(1 - pdist/(radius*0.9))); hp=Math.max(0,hp-hurt); updateHealth(); if(pdist>0.1){ player.velocity.x += (pdx/pdist)*3; player.velocity.z += (pdz/pdist)*3; } }
+    for(const car of trafficCars){ const dx=car.mesh.position.x-center.x; const dz=car.mesh.position.z-center.z; const dist=Math.hypot(dx,dz); if(dist<radius*1.3){ const push=(1-dist/(radius*1.3))*8; const dirX=(dx/dist)||0, dirZ=(dz/dist)||0; let newX=car.mesh.position.x + dirX*push; let newZ=car.mesh.position.z + dirZ*push; const ang=Math.atan2(newZ,newX); const clampR=Math.max(ringR-4, Math.min(ringR+4, Math.hypot(newX,newZ))); newX=Math.cos(ang)*clampR; newZ=Math.sin(ang)*clampR; car.mesh.position.set(newX,0,newZ); car.angle=ang; } }
+  }
+
+  function explodeGrenade(grenade){ if(grenade.exploded) return; grenade.exploded=true; const pos=new THREE.Vector3(grenade.body.position.x, grenade.body.position.y, grenade.body.position.z); world.removeBody(grenade.body); if(grenade.mesh){ scene.remove(grenade.mesh); grenade.mesh.traverse?.((child)=>{ if(child.isMesh){ child.geometry?.dispose?.(); if(Array.isArray(child.material)){ child.material.forEach((m)=>m?.dispose?.()); } else { child.material?.dispose?.(); } } }); } createExplosionFX(pos); applyExplosionDamage(pos, 12, 160); dispatchEmergency(pos); sfxExplosion(); }
+
+  function fireRay(off2){ raycaster.setFromCamera(off2||new THREE.Vector2(0,0), camera); const from=camera.position.clone(); const to=raycaster.ray.origin.clone().addScaledVector(raycaster.ray.direction, 8000); const pos = aimGeo.attributes.position; pos.setXYZ(0, from.x, from.y, from.z); pos.setXYZ(1, to.x, to.y, to.z); pos.needsUpdate=true; const plane = new THREE.Plane(new THREE.Vector3(0,1,0), 0); const hit = new THREE.Vector3(); raycaster.ray.intersectPlane(plane, hit); if(hit){ aimDot.position.copy(hit); } else { aimDot.position.copy(to); } return {from,to}; }
+
+  function makeShellInstance(key){
+    const spec=SHELL_SPECS[key]||SHELL_SPECS.Glock;
+    if(!spec) return null;
+    const group=new THREE.Group();
+    const materials=new Set();
+    const parts=[];
+    const brass=new THREE.MeshStandardMaterial({ color:spec.color, metalness:0.65, roughness:0.38 });
+    materials.add(brass);
+    const bodyLen=spec.length*0.7;
+    const neckLen=spec.length*0.2;
+    const rimLen=spec.length*0.1;
+    const body=new THREE.Mesh(new THREE.CylinderGeometry(spec.radius, spec.radius*0.95, bodyLen, 14), brass);
+    body.rotation.z=Math.PI/2;
+    parts.push(body);
+    const neckMat=brass.clone(); materials.add(neckMat);
+    const neck=new THREE.Mesh(new THREE.CylinderGeometry(spec.radius*0.72, spec.radius*0.9, neckLen, 14), neckMat);
+    neck.rotation.z=Math.PI/2; neck.position.x=bodyLen*0.5 + neckLen*0.5;
+    parts.push(neck);
+    const rimMat=brass.clone(); materials.add(rimMat);
+    const rim=new THREE.Mesh(new THREE.CylinderGeometry(spec.radius*1.12, spec.radius*1.02, rimLen, 14), rimMat);
+    rim.rotation.z=Math.PI/2; rim.position.x=-(bodyLen*0.5 + rimLen*0.5);
+    parts.push(rim);
+    parts.forEach(p=>group.add(p));
+    group.userData.dispose=()=>{
+      parts.forEach(p=>p.geometry.dispose());
+      materials.forEach(m=>m.dispose?.());
+    };
+    group.rotation.set(Math.random()*Math.PI, Math.random()*Math.PI, Math.random()*Math.PI);
+    return group;
+  }
+  function ejection(anc,key){
+    if(!anc) return;
+    const shell=makeShellInstance(key);
+    if(!shell) return;
+    const wp=new THREE.Vector3(); anc.getWorldPosition(wp);
+    shell.position.copy(wp);
+    scene.add(shell);
+    const power = key==='AK47'?1.25: key==='AR'?1.15:1.0;
+    const v=new THREE.Vector3((Math.random()*0.22+0.12)*power, (Math.random()*0.34+0.14), (Math.random()*0.24-0.12));
+    const spin=new THREE.Vector3((Math.random()*0.2+0.04)*power, (Math.random()*0.18+0.06), (Math.random()*0.2+0.04));
+    const t0=performance.now();
+    const id=setInterval(()=>{
+      const t=(performance.now()-t0)/1000;
+      shell.position.x += v.x;
+      shell.position.y += v.y - 9.81*0.5*t*t*0.045;
+      shell.position.z += v.z;
+      shell.rotation.x += spin.x;
+      shell.rotation.y += spin.y;
+      shell.rotation.z += spin.z;
+      v.y -= 0.018;
+      if(t>1.2){
+        clearInterval(id);
+        scene.remove(shell);
+        shell.userData.dispose?.();
       }
-      function makeWaterMaterial(){
-        const tex = new THREE.CanvasTexture((()=>{ const c=document.createElement('canvas'); c.width=c.height=256; const ctx=c.getContext('2d'); const grd=ctx.createRadialGradient(128,128,20,128,128,128); grd.addColorStop(0,'rgba(80,180,255,0.95)'); grd.addColorStop(1,'rgba(30,90,140,0.65)'); ctx.fillStyle=grd; ctx.fillRect(0,0,256,256); return c; })());
-        tex.colorSpace=THREE.SRGBColorSpace; tex.wrapS=tex.wrapT=THREE.RepeatWrapping; tex.repeat.set(2,2);
-        return new THREE.MeshStandardMaterial({ map:tex, transparent:true, opacity:0.9, roughness:0.2, metalness:0.15, side:THREE.DoubleSide });
+    },16);
+  }
+
+  function doShot(){ const st=currentStats; if(!st) return; const a=ammo.get(currentKey); if(!a||a.mag<=0){ return; }
+    if(currentKey==='Grenade'){
+      a.mag--;
+      if(a.reserve>0) a.reserve--;
+      updateAmmoHUD();
+      throwGrenade();
+      return;
+    }
+    muzzleLight.intensity=1.6; setTimeout(()=>muzzleLight.intensity=0,45); sfxGun(currentKey);
+    const spread=st.spread; const off=new THREE.Vector2((Math.random()-0.5)*spread*2,(Math.random()-0.5)*spread*2); const {from,to}=fireRay(off);
+    tracer(from,to,0xfff1b1);
+    const hits = raycaster.intersectObjects(impactTargets, true).filter(h=>h.object!==weaponModel && h.object !== aimLine);
+    if(hits.length){ const h=hits[0]; const normal = h.face?.normal?.clone()?.transformDirection(h.object.matrixWorld)||new THREE.Vector3(0,0,1); addDecal(h.point, normal); }
+    const hitsEnemy = raycaster.intersectObjects(enemyRoots(), true);
+    if(hitsEnemy.length){ const h=hitsEnemy[0]; const root=(function find(o){ let p=o; while(p && !p.userData?.enemy){ p=p.parent; } return p; })(h.object); const e=enemies.get(root.uuid); if(e && !e.dead){ e.hp -= st.dmg; addBlood(h.point); if(e.hp<=0){ e.dead=true; e.body.mass=0; e.body.updateMassProperties(); e.root.visible=false; e.hpBar.visible=false; } else { updateBillboardBar(e.hpBar, e.hp/120); } } }
+    if(weaponModel?.userData?.ejectAnchor && currentKey!=='Grenade'){ ejection(weaponModel.userData.ejectAnchor, currentKey); }
+    a.mag--; updateAmmoHUD();
+  }
+
+  const audio={ ctx:null, muted:false };
+  function ac(){ if(audio.muted) return null; try{ audio.ctx = audio.ctx || new (window.AudioContext||window.webkitAudioContext)(); return audio.ctx; }catch(_){ return null; } }
+  function withAC(fn){ const ctx=ac(); if(!ctx) return; fn(ctx); }
+  function noiseBuffer(ctx){ const b=ctx.createBuffer(1, ctx.sampleRate*1.0, ctx.sampleRate); const d=b.getChannelData(0); for(let i=0;i<d.length;i++){ d[i]= (Math.random()*2-1) * (1 - i/d.length); } return b; }
+  function burstNoise({dur=0.12, freq=1500, type='bandpass', gain=0.12}){ withAC((ctx)=>{ const src=ctx.createBufferSource(); src.buffer=noiseBuffer(ctx); const bp=ctx.createBiquadFilter(); bp.type=type; bp.frequency.value=freq; const g=ctx.createGain(); g.gain.value=gain; src.connect(bp); bp.connect(g); g.connect(ctx.destination); src.start(); src.stop(ctx.currentTime+dur); }); }
+  function click({freq=800,dur=0.02,gain=0.08}){ withAC((ctx)=>{ const o=ctx.createOscillator(); const g=ctx.createGain(); o.type='square'; o.frequency.value=freq; g.gain.value=gain; o.connect(g); g.connect(ctx.destination); o.start(); o.stop(ctx.currentTime+dur); }); }
+  function sfxGun(kind){ switch(kind){ case 'Glock': case 'Pistol': burstNoise({dur:0.09,freq:2200,gain:0.12}); click({freq:1800,dur:0.015,gain:0.06}); break; case 'AR': burstNoise({dur:0.08,freq:1900,gain:0.13}); click({freq:1600,dur:0.012,gain:0.05}); break; case 'Uzi': burstNoise({dur:0.05,freq:2300,gain:0.12}); click({freq:1900,dur:0.01,gain:0.05}); break; case 'AK47': burstNoise({dur:0.1,freq:1400,gain:0.14}); click({freq:1200,dur:0.015,gain:0.07}); break; default: burstNoise({dur:0.07,freq:1800,gain:0.12}); } }
+  function sfxReload(){ click({freq:600,dur:0.05,gain:0.05}); setTimeout(()=>click({freq:900,dur:0.04,gain:0.05}),90); }
+  $('muteBtn').addEventListener('click',(e)=>{ audio.muted=!audio.muted; e.target.textContent=audio.muted?'🔇':'🔊'; });
+
+  const keys=new Set(); addEventListener('keydown',e=>{ keys.add(e.code); if(e.code==='Space') doShot(); if(e.code==='KeyR') reload(); }); addEventListener('keyup',e=>keys.delete(e.code));
+  const joyMove=$('joyMove'), knobMove=joyMove.querySelector('.knob');
+  const R=150, K=85, DEAD=0.16;
+  const mv={active:false,id:null,vx:0,vz:0, tapStart:0, moved:false};
+  function centerOf(el){ const r=el.getBoundingClientRect(); return { cx:r.left + r.width/2, cy:r.top + r.height/2 }; }
+  joyMove.addEventListener('touchstart',e=>{ if(mv.active) return; const t=e.changedTouches[0]; mv.active=true; mv.id=t.identifier; mv.tapStart=performance.now(); mv.moved=false; e.preventDefault(); },{passive:false});
+    joyMove.addEventListener('touchmove', e=>{ for(const t of e.changedTouches){ if(mv.active&&t.identifier===mv.id){ const {cx,cy}=centerOf(joyMove); let dx=t.clientX-cx, dy=t.clientY-cy; const len=Math.hypot(dx,dy)||1; const nlen=Math.min(len/R,1); mv.moved = mv.moved || (nlen>DEAD*1.2); const nz=nlen<DEAD?0:(nlen-DEAD)/(1-DEAD); const scale = nz/(nlen||1); dx*=scale; dy*=scale; if(nlen>1){ dx/=nlen; dy/=nlen; } knobMove.style.transform=`translate(calc(-50% + ${dx}px),calc(-50% + ${dy}px))`; mv.vx = -dx/K; mv.vz = -dy/K; } } e.preventDefault(); },{passive:false});
+  function mvEnd(){ knobMove.style.transform='translate(-50%,-50%)'; const tap=(performance.now()-mv.tapStart)<220 && !mv.moved; mv.active=false; mv.vx=0; mv.vz=0; if(tap) jump(); }
+  joyMove.addEventListener('touchend', mvEnd, {passive:false}); joyMove.addEventListener('touchcancel', mvEnd, {passive:false});
+  joyMove.addEventListener('pointerdown', (e)=>{ if(mv.active) return; mv.active=true; mv.id=e.pointerId; mv.tapStart=performance.now(); mv.moved=false; const r=joyMove.getBoundingClientRect(); mv.cx=r.left+r.width/2; mv.cy=r.top+r.height/2; try{ joyMove.setPointerCapture(e.pointerId); }catch(_){ } e.preventDefault(); });
+    joyMove.addEventListener('pointermove', (e)=>{ if(!mv.active||e.pointerId!==mv.id) return; let dx=e.clientX-mv.cx, dy=e.clientY-mv.cy; const len=Math.hypot(dx,dy)||1; const nlen=Math.min(len/R,1); if(!mv.moved && nlen>DEAD*1.2) mv.moved=true; const nz=nlen<DEAD?0:(nlen-DEAD)/(1-DEAD); const scale=nz/(nlen||1); dx*=scale; dy*=scale; if(nlen>1){ dx/=nlen; dy/=nlen; } knobMove.style.transform=`translate(calc(-50% + ${dx}px),calc(-50% + ${dy}px))`; mv.vx = -dx/K; mv.vz = -dy/K; e.preventDefault(); });
+  function mvRelease(e){ if(!mv.active||e.pointerId!==mv.id) return; mvEnd(); try{ joyMove.releasePointerCapture(e.pointerId); }catch(_){ } e.preventDefault(); }
+  joyMove.addEventListener('pointerup', mvRelease); joyMove.addEventListener('pointercancel', mvRelease);
+
+  const shootPad=$('shootPad');
+  let fireHeld=false;
+  function shootDown(){ if(FIRE_MODES.get(currentKey)==='auto'){ fireHeld=true; } else { doShot(); } }
+  function shootUp(){ fireHeld=false; }
+  shootPad.addEventListener('pointerdown', (e)=>{ if(inputMode!=='A') return; shootDown(); e.preventDefault(); });
+  shootPad.addEventListener('pointerup', (e)=>{ if(inputMode!=='A') return; shootUp(); e.preventDefault(); });
+  shootPad.addEventListener('pointercancel', (e)=>{ if(inputMode!=='A') return; shootUp(); e.preventDefault(); });
+  shootPad.addEventListener('touchstart', (e)=>{ if(inputMode!=='A') return; shootDown(); e.preventDefault(); }, {passive:false});
+  shootPad.addEventListener('touchend', (e)=>{ if(inputMode!=='A') return; shootUp(); e.preventDefault(); }, {passive:false});
+
+
+  const canvasEl=renderer.domElement; canvasEl.style.touchAction='none';
+  const look={active:false,id:null,lastX:0,lastY:0};
+  let lookAccumX=0, lookAccumY=0; let aimSmoothX=0, aimSmoothY=0;
+  const LOOK_SENS_A  = isMobile ? 0.22 : 0.18;
+  const AIM_RATE_A   = 1.05;
+  const AIM_SMOOTH_A = 4.6;
+  function isUIBlock(el){ return el.closest('#joyMove')||el.closest('#shootPad')||el.closest('#armory')||el.closest('#reloadMini')||el.closest('#climbBtn')||el.closest('#zoomBox'); }
+  canvasEl.addEventListener('pointerdown',(e)=>{ if(inputMode!=='A') return; if(isUIBlock(e.target)) return; if(look.active) return; look.active=true; look.id=e.pointerId; look.lastX=e.clientX; look.lastY=e.clientY; try{ canvasEl.setPointerCapture(e.pointerId); }catch(_){} e.preventDefault(); });
+  canvasEl.addEventListener('pointermove',(e)=>{ if(inputMode!=='A') return; if(!look.active||e.pointerId!==look.id) return; const dx=e.clientX-look.lastX; const dy=e.clientY-look.lastY; look.lastX=e.clientX; look.lastY=e.clientY; lookAccumX += dx; lookAccumY += dy; e.preventDefault(); });
+  function lookRelease(e){ if(inputMode!=='A') return; if(!look.active||e.pointerId!==look.id) return; look.active=false; try{ canvasEl.releasePointerCapture(e.pointerId); }catch(_){} e.preventDefault(); }
+  canvasEl.addEventListener('pointerup', lookRelease); canvasEl.addEventListener('pointercancel', lookRelease);
+
+  let hp=100; function updateHealth(){ const f=$('healthfill'); f.style.width=Math.max(0,hp)+'%'; f.style.background = hp>60? 'linear-gradient(90deg,#29ff9a,#00c876)': hp>30? 'linear-gradient(90deg,#ffd966,#ff9f1a)' : 'linear-gradient(90deg,#ff6b6b,#ff2e2e)'; }
+  updateHealth();
+
+  /* Vehicles (GLTF fleet) */
+  const URLS = {
+    Sedan: [
+      'https://assets.babylonjs.com/meshes/car.glb',
+      'https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/car.glb'
+    ],
+    CarConcept: [
+      'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/CarConcept/glTF-Binary/CarConcept.glb',
+      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/CarConcept/glTF-Binary/CarConcept.glb'
+    ],
+    MilkTruck: [
+      'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/CesiumMilkTruck/glTF-Binary/CesiumMilkTruck.glb',
+      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMilkTruck/glTF-Binary/CesiumMilkTruck.glb'
+    ],
+    FireTruck: [
+      'https://raw.githubusercontent.com/Kenney-CCO/Kenney-CCO.glb/main/firetruck.glb',
+      'https://cdn.jsdelivr.net/gh/Kenney-CCO/Kenney-CCO.glb@main/firetruck.glb',
+      'https://raw.githubusercontent.com/MonuYadav05/Astrikos-gc-project/main/public/FireTruck.glb'
+    ],
+    Bus: [
+      'https://raw.githubusercontent.com/jade0815/my-3d-bus-models/main/Bus.glb',
+      'https://raw.githubusercontent.com/IHyeonii/PythonStudy/main/free_school_bus_-_low_poly.glb',
+      'https://raw.githubusercontent.com/haelimk/project/8c50930d7f283f345c46a0dcdf2a984286c3b4c0/bus.glb'
+    ],
+    Motorcycle: [
+      'https://raw.githubusercontent.com/shosuz-evangelist/3dObjects4Apps/main/Motorcycle.glb',
+      'https://raw.githubusercontent.com/jade12855/3D_model/main/Motorcycle.glb'
+    ]
+  };
+
+  function makeLabel(text, scale=1){ const cnv=document.createElement('canvas'); const ctx=cnv.getContext('2d'); const pad=28, fs=64, font=`${fs}px system-ui,Arial`; ctx.font=font; const w=Math.ceil(ctx.measureText(text).width); cnv.width=w+pad*2; cnv.height=fs+pad*2; ctx.font=font; ctx.fillStyle='#111827'; ctx.fillRect(0,0,cnv.width,cnv.height); ctx.strokeStyle='#1f2937'; ctx.lineWidth=4; ctx.strokeRect(2,2,cnv.width-4,cnv.height-4); ctx.fillStyle='#e5e7eb'; ctx.textBaseline='top'; ctx.fillText(text,pad,pad); const tex=new THREE.CanvasTexture(cnv); tex.colorSpace=THREE.SRGBColorSpace; const mat=new THREE.MeshBasicMaterial({ map:tex, transparent:true }); return new THREE.Mesh(new THREE.PlaneGeometry(cnv.width/240*scale, cnv.height/240*scale), mat); }
+  function centerXZ(root){ const box=new THREE.Box3().setFromObject(root); const c=new THREE.Vector3(); box.getCenter(c); root.position.x -= c.x; root.position.z -= c.z; }
+  function placeOnGround(root,y=0){ const box=new THREE.Box3().setFromObject(root); const dy=y - box.min.y; root.position.y += dy; }
+  function scaleToLength(root, L){ const box=new THREE.Box3().setFromObject(root); const size=new THREE.Vector3(); box.getSize(size); const len=Math.max(size.x,size.z)||1; const s=L/len; root.scale.multiplyScalar(s); root.updateMatrixWorld(true); }
+  function stripGroundMeshes(root){ const rootBox=new THREE.Box3().setFromObject(root); const rootSize=new THREE.Vector3(); rootBox.getSize(rootSize); const rootArea=rootSize.x*rootSize.z; const rm=[]; root.traverse(o=>{ if(!o.isMesh) return; const b=new THREE.Box3().setFromObject(o); const sz=new THREE.Vector3(); b.getSize(sz); const area=sz.x*sz.z; const flat=sz.y/Math.max(0.0001, Math.max(sz.x,sz.z)); const nearBottom=(b.min.y-rootBox.min.y)<=Math.max(0.05, rootSize.y*0.06); const byName=/ground|plane|cloth|board|shadow|table|grid|floor/i.test(o.name||'')||/shadow/i.test(o.material?.name||''); if(nearBottom && area>=rootArea*0.18 && (flat<0.12 || byName)){ rm.push(o); } }); for(const m of rm){ m.parent?.remove(m);} root.updateMatrixWorld(true); }
+
+  const vehicleCache=new Map();
+  async function robustLoad(urls){ for(const u of urls){ try{ const gltf=await gltfLoader.loadAsync(u); return gltf; }catch(_){ } } throw new Error('load fail'); }
+  async function getVehicle(key){ const normalized=key?.toLowerCase?.()||key; if(vehicleCache.has(normalized)) return vehicleCache.get(normalized); let urls=[]; if(normalized==='ambulance'||normalized==='police') urls=URLS.MilkTruck; else if(normalized==='fire'||normalized==='firetruck') urls=URLS.FireTruck; else if(normalized==='bus') urls=URLS.Bus; else if(normalized==='motorcycle'||normalized==='moto'||normalized==='bike') urls=URLS.Motorcycle; else if(normalized==='sedan') urls=URLS.Sedan; else urls=URLS.CarConcept; try{ const gltf=await robustLoad(urls); const root=(gltf.scene||gltf.scenes?.[0]); stripGroundMeshes(root); vehicleCache.set(normalized, root); return root; }catch(_){ const size = (normalized==='motorcycle'||normalized==='moto'||normalized==='bike')? {w:1.2,h:1.4,l:2.2}:{w:3.6,h:1.2,l:1.6}; const geom=new THREE.BoxGeometry(size.w,size.h,size.l); const mat=new THREE.MeshLambertMaterial({ color:0x8892a6 }); const base=new THREE.Mesh(geom, mat); base.position.y=size.h/2; const group=new THREE.Group(); group.add(base); vehicleCache.set(normalized,group); return group; } }
+
+  function tintVehicle(root,hex){ const col=new THREE.Color(hex); root.traverse(o=>{ if(o.isMesh&&o.material&&o.material.color){ o.material.color.lerp(col,0.9); o.material.needsUpdate=true; } }); }
+  function addSideLabels(root,text){ const b=new THREE.Box3().setFromObject(root); const s=new THREE.Vector3(); b.getSize(s); const y=b.min.y+s.y*0.6; const midZ=(b.min.z+b.max.z)/2; const L=makeLabel(text,0.9); const R=makeLabel(text,0.9); L.rotation.y=Math.PI/2; R.rotation.y=-Math.PI/2; L.position.set(b.min.x-0.02,y,midZ); R.position.set(b.max.x+0.02,y,midZ); root.add(L,R); }
+  function attachSiren(root){ const box=new THREE.Box3().setFromObject(root); const spanX=(box.max.x-box.min.x); const top=box.max.y+0.18; const offset=spanX*0.28; const geo=new THREE.SphereGeometry(0.14,14,12); const leftMat=new THREE.MeshBasicMaterial({ color:0xef4444, transparent:true, opacity:0.28 }); const rightMat=new THREE.MeshBasicMaterial({ color:0x3b82f6, transparent:true, opacity:0.28 }); const left=new THREE.Mesh(geo,leftMat); const right=new THREE.Mesh(geo,rightMat); left.position.set(-offset, top, 0); right.position.set(offset, top, 0); const grp=new THREE.Group(); grp.add(left,right); root.add(grp); const light=new THREE.PointLight(0xff6b6b, 0, 18); light.position.set(0, top+0.2, 0); root.add(light); return {group:grp,left,right,light,phase:Math.random()*Math.PI*2}; }
+
+  const parked=[]; const trafficCars=[]; const emergencyUnits=[];
+  async function spawnParkedEmergency(){
+    const hosp=POIS.find(p=>p.type==='hospital'); const pol=POIS.find(p=>p.type==='police'); const fire=POIS.find(p=>p.type==='fire');
+    if(hosp){ const v=(await getVehicle('ambulance')).clone(true); centerXZ(v); scaleToLength(v,3.8); placeOnGround(v,0); addSideLabels(v,'AMBULANCE'); tintVehicle(v,'#ef4444'); v.position.set(hosp.pos.x,0, hosp.pos.z + hosp.dims.d/2 + 6); setHeading(v,Math.PI); scene.add(v); const siren=attachSiren(v); emergencyUnits.push({mesh:v, base:v.position.clone(), baseHeading:v.rotation.y, target:null, state:'idle', siren, speed:12, type:'ambulance'}); parked.push(v); }
+    if(pol){ const v=(await getVehicle('police')).clone(true); centerXZ(v); scaleToLength(v,3.8); placeOnGround(v,0); addSideLabels(v,'POLICE'); tintVehicle(v,'#1e3a8a'); v.position.set(pol.pos.x-4,0, pol.pos.z + pol.dims.d/2 + 6); setHeading(v,Math.PI); scene.add(v); const siren=attachSiren(v); emergencyUnits.push({mesh:v, base:v.position.clone(), baseHeading:v.rotation.y, target:null, state:'idle', siren, speed:13, type:'police'}); parked.push(v); }
+    if(fire){ const v=(await getVehicle('fire')).clone(true); centerXZ(v); scaleToLength(v,4.6); placeOnGround(v,0); addSideLabels(v,'FIRE'); tintVehicle(v,'#dc2626'); v.position.set(fire.pos.x+4,0, fire.pos.z + fire.dims.d/2 + 6); setHeading(v,Math.PI); scene.add(v); const siren=attachSiren(v); emergencyUnits.push({mesh:v, base:v.position.clone(), baseHeading:v.rotation.y, target:null, state:'idle', siren, speed:11, type:'fire'}); parked.push(v); }
+  }
+
+  function setHeading(mesh,angle){ mesh.rotation.y = angle + Math.PI/2; }
+
+  async function spawnParkedCommons(){
+    const palette=['#64748b','#9ca3af','#475569','#7f5539','#ef8354','#14b8a6'];
+    const spots=[
+      {kind:'sedan', x:startX+CELL*0.9,  z:startZ+CELL*1.3, heading:Math.PI*0.18},
+      {kind:'car',   x:startX+CELL*1.6,  z:startZ+CELL*1.1, heading:-Math.PI*0.22},
+      {kind:'motorcycle', x:startX+CELL*1.95, z:startZ+CELL*1.55, heading:-Math.PI*0.12, color:'#f97316'},
+      {kind:'sedan', x:startX+CELL*2.3,  z:startZ+CELL*1.8, heading:Math.PI*0.36},
+      {kind:'bus',   x:startX+CELL*3.1,  z:startZ+CELL*2.35, heading:-Math.PI*0.48, color:'#facc15'},
+      {kind:'car',   x:startX+CELL*2.4,  z:startZ+CELL*3.1, heading:Math.PI*0.52},
+      {kind:'sedan', x:startX+CELL*4.0,  z:startZ+CELL*1.6, heading:-Math.PI*0.12},
+      {kind:'motorcycle', x:startX+CELL*4.2, z:startZ+CELL*2.05, heading:Math.PI*0.08, color:'#38bdf8'}
+    ];
+    for(let i=0;i<spots.length;i++){
+      const spot=spots[i];
+      const template=await getVehicle(spot.kind||'car');
+      if(!template) continue;
+      const base=template.clone(true);
+      centerXZ(base);
+      const targetLen = spot.kind==='bus'?8.4 : spot.kind==='motorcycle'?2.2 : 3.9;
+      scaleToLength(base,targetLen);
+      placeOnGround(base,0);
+      tintVehicle(base, spot.color || palette[i%palette.length]);
+      setHeading(base, spot.heading||0);
+      base.position.set(spot.x, 0, spot.z);
+      scene.add(base);
+      parked.push(base);
+    }
+
+    const mall=POIS.find(p=>p.type==='mall');
+    if(mall){
+      const shuttle=(await getVehicle('bus'))?.clone?.(true);
+      if(shuttle){
+        centerXZ(shuttle); scaleToLength(shuttle,8.6); placeOnGround(shuttle,0);
+        tintVehicle(shuttle,'#fde047');
+        setHeading(shuttle, Math.PI/2);
+        shuttle.position.set(mall.pos.x + (mall.dims?.w||32)/2 + 6, 0, mall.pos.z - 6);
+        scene.add(shuttle);
+        parked.push(shuttle);
       }
-
-      const asphaltTex = makeAsphalt(); const sidewalkTex = makeSidewalk(); const turfTex = await grassFromURL();
-      const tennisTex = createCourtTexture('tennis');
-      const basketTex = createCourtTexture('basket');
-      const waterMat = makeWaterMaterial();
-
-      const asphaltMat = new THREE.MeshStandardMaterial({ map: asphaltTex, roughness:0.82, metalness:0.05, side:THREE.DoubleSide });
-      const sidewalkMat = new THREE.MeshStandardMaterial({ map: sidewalkTex, roughness:0.9, metalness:0.04, side:THREE.DoubleSide });
-      const groundMat = new THREE.MeshStandardMaterial({ color: 0xf0e4cf, roughness:0.95, metalness:0.02, side:THREE.DoubleSide });
-      const turfMat = new THREE.MeshStandardMaterial({ map:turfTex, roughness:0.65, metalness:0.02, side:THREE.DoubleSide });
-      const tennisMat = new THREE.MeshStandardMaterial({ map:tennisTex, roughness:0.55, metalness:0.04, side:THREE.DoubleSide });
-      const basketMat = new THREE.MeshStandardMaterial({ map:basketTex, roughness:0.6, metalness:0.03, side:THREE.DoubleSide });
-      const assetManager = new THREE.LoadingManager();
-      assetManager.onError = (url)=>console.warn('Asset load error:', url);
-      const gltfLoaderAssets = new GLTFLoader(assetManager);
-      const dracoAssets = new DRACOLoader(assetManager); dracoAssets.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/'); gltfLoaderAssets.setDRACOLoader(dracoAssets); gltfLoaderAssets.setCrossOrigin('anonymous');
-      gltfLoaderAssets.register((parser)=>{
-        const c=document.createElement('canvas'); c.width=c.height=1; const ctx=c.getContext('2d'); ctx.fillStyle='#888'; ctx.fillRect(0,0,1,1);
-        const blank=new THREE.CanvasTexture(c); blank.colorSpace=THREE.SRGBColorSpace; blank.needsUpdate=true;
-        const orig = parser.getDependency.bind(parser);
-        parser.getDependency = function(type,index){
-          if(type==='texture'){
-            return orig(type,index).catch(()=>blank);
-          }
-          return orig(type,index);
-        };
-        return { name:'TextureFallbackIfMissing' };
-      });
-
-      const BLANK_PNG='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
-      const managerGuns=new THREE.LoadingManager(); managerGuns.setURLModifier((url)=>{ if(url?.startsWith('data:')||url?.startsWith('blob:')) return url; if(/(\.(png|jpg|jpeg|webp|ktx2|dds|tga)(\?|#|$))/i.test(url)) return BLANK_PNG; return url; });
-      const gltfLoaderGuns=new GLTFLoader(managerGuns); const dracoGuns=new DRACOLoader(managerGuns); dracoGuns.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/'); gltfLoaderGuns.setDRACOLoader(dracoGuns); gltfLoaderGuns.setCrossOrigin('anonymous');
-      gltfLoaderGuns.register((parser)=>{ const c=document.createElement('canvas'); c.width=c.height=1; const ctx=c.getContext('2d'); ctx.fillStyle='#888'; ctx.fillRect(0,0,1,1); const blank=new THREE.CanvasTexture(c); blank.colorSpace=THREE.SRGBColorSpace; blank.needsUpdate=true; const orig=parser.getDependency.bind(parser); parser.getDependency=function(type,index){ if(type==='texture') return Promise.resolve(blank); return orig(type,index); }; return {name:'NullTextures'}; });
-
-      const URLS = {
-        Sedan: [
-          'https://assets.babylonjs.com/meshes/car.glb',
-          'https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/car.glb'
-        ],
-        CarConcept: [
-          'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/CarConcept/glTF-Binary/CarConcept.glb',
-          'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/CarConcept/glTF-Binary/CarConcept.glb'
-        ],
-        MilkTruck: [
-          'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/CesiumMilkTruck/glTF-Binary/CesiumMilkTruck.glb',
-          'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMilkTruck/glTF-Binary/CesiumMilkTruck.glb'
-        ],
-        FireTruck: [
-          'https://raw.githubusercontent.com/Kenney-CCO/Kenney-CCO.glb/main/firetruck.glb',
-          'https://cdn.jsdelivr.net/gh/Kenney-CCO/Kenney-CCO.glb@main/firetruck.glb',
-          'https://raw.githubusercontent.com/MonuYadav05/Astrikos-gc-project/main/public/FireTruck.glb'
-        ],
-        Bus: [
-          'https://raw.githubusercontent.com/jade0815/my-3d-bus-models/main/Bus.glb',
-          'https://raw.githubusercontent.com/IHyeonii/PythonStudy/main/free_school_bus_-_low_poly.glb',
-          'https://raw.githubusercontent.com/haelimk/project/8c50930d7f283f345c46a0dcdf2a984286c3b4c0/bus.glb'
-        ],
-        Motorcycle: [
-          'https://raw.githubusercontent.com/shosuz-evangelist/3dObjects4Apps/main/Motorcycle.glb',
-          'https://raw.githubusercontent.com/jade12855/3D_model/main/Motorcycle.glb'
-        ],
-        Soldier: [
-          'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/Soldier/glTF-Binary/Soldier.glb',
-          'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Soldier/glTF-Binary/Soldier.glb'
-        ]
-      };
-
-      async function loadGLB(urls){
-        for(const u of urls){ try{ const gltf = await gltfLoaderAssets.loadAsync(u); return gltf; }catch(_){ } }
-        throw new Error('All sources failed for '+urls[0]);
+    }
+    const station=POIS.find(p=>p.type==='station');
+    if(station){
+      for(let i=0;i<3;i++){
+        const bike=(await getVehicle('motorcycle'))?.clone?.(true);
+        if(!bike) break;
+        centerXZ(bike); scaleToLength(bike,2.2); placeOnGround(bike,0);
+        tintVehicle(bike,['#22d3ee','#f43f5e','#a855f7'][i%3]);
+        const ang=-Math.PI/2;
+        setHeading(bike, ang);
+        bike.position.set(station.pos.x - 6 + i*2.8, 0, station.pos.z + (station.dims?.d||18)/2 + 3.5);
+        scene.add(bike);
+        parked.push(bike);
       }
-      function centerXZ(root){ const box=new THREE.Box3().setFromObject(root); const c=new THREE.Vector3(); box.getCenter(c); root.position.x -= c.x; root.position.z -= c.z; }
-      function placeOnGround(root,y=0){ const box=new THREE.Box3().setFromObject(root); const dy=y - box.min.y; root.position.y += dy; }
-      function scaleToLen(root, L=3.8){ const box=new THREE.Box3().setFromObject(root); const s=new THREE.Vector3(); box.getSize(s); const cur=Math.max(s.x,s.z)||1; const k=L/cur; root.scale.multiplyScalar(k); root.updateMatrixWorld(true); }
+    }
+  }
 
-      const depot = { refs:{}, ready:false };
-      const REF_LEN = 3.9;
-      async function buildDepot(){
-        const def = [
-          ['sedan','Sedan'], ['concept','CarConcept'], ['milk','MilkTruck'], ['bus','Bus'], ['fire','FireTruck'], ['moto','Motorcycle']
-        ];
-        for(const [k,keyName] of def){
-          try{ const gltf=await loadGLB(URLS[keyName]); const base=(gltf.scene||gltf.scenes?.[0]); base.traverse(o=>{ if(o.isMesh){ o.castShadow=allowShadows; o.receiveShadow=allowShadows; o.material && (o.material.needsUpdate = true); } }); centerXZ(base); scaleToLen(base, keyName==='bus'? 8.5 : keyName==='moto'? 2.0 : REF_LEN); placeOnGround(base,0); depot.refs[k]=base; }catch(e){ console.warn('Vehicle failed', keyName, e); }
-        }
-        depot.ready=true; $('status').textContent = 'Tirana 2040 • Ready';
-      }
+  async function spawnTraffic(n=14){
+    for(let i=0;i<n;i++){
+      const r=Math.random();
+      let kind;
+      if(r<0.18) kind='bus';
+      else if(r<0.42) kind='motorcycle';
+      else if(r<0.68) kind='car';
+      else kind='sedan';
+      const template=await getVehicle(kind);
+      if(!template) continue;
+      const v=template.clone(true);
+      centerXZ(v);
+      const len = kind==='bus'?8.6 : kind==='motorcycle'?2.4 : 3.8;
+      scaleToLength(v,len);
+      placeOnGround(v,0);
+      if(kind==='bus'){ tintVehicle(v,'#facc15'); }
+      else if(kind==='motorcycle'){ tintVehicle(v,'#ec4899'); }
+      else { tintVehicle(v,new THREE.Color().setHSL(Math.random(),0.45,0.5).getHex()); }
+      const a=Math.random()*Math.PI*2;
+      const x=Math.cos(a)*ringR, z=Math.sin(a)*ringR;
+      v.position.set(x,0,z);
+      setHeading(v,a);
+      scene.add(v);
+      trafficCars.push({mesh:v, angle:a, speed:0, kind});
+    }
+  }
 
-      const city = new THREE.Group(); scene.add(city);
-      const BLOCKS_X=6, BLOCKS_Z=6; const CELL=120; const ROAD=22; const SIDE=8; const PLOT=CELL-ROAD*2; const startX = -(BLOCKS_X*CELL)/2 + CELL/2; const startZ = -(BLOCKS_Z*CELL)/2 + CELL/2;
+  await spawnParkedEmergency();
+  await spawnParkedCommons();
+  await spawnTraffic(16);
 
-      const groundGeo = new THREE.PlaneGeometry((CELL)*BLOCKS_X + ROAD*2, (CELL)*BLOCKS_Z + ROAD*2);
-      const gnd = new THREE.Mesh(groundGeo, groundMat); gnd.rotation.x=-Math.PI/2; gnd.receiveShadow=allowShadows; city.add(gnd);
+  function dispatchEmergency(pos){ const total=Math.max(1, emergencyUnits.length); emergencyUnits.forEach((unit,idx)=>{ const offsetAngle=(idx/total)*Math.PI*2; const offset=new THREE.Vector3(Math.cos(offsetAngle)*2.4,0,Math.sin(offsetAngle)*2.4); unit.target=pos.clone().add(offset); unit.state='responding'; unit.arrivalTimer=0; if(unit.siren){ unit.siren.phase=0; unit.siren.left.material.opacity=0.9; unit.siren.right.material.opacity=0.9; if(unit.siren.light){ unit.siren.light.intensity=14; } } }); }
 
-      const xRoads=[], zRoads=[]; const sidewalks=new THREE.Group(); city.add(sidewalks);
-      for(let ix=0; ix<=BLOCKS_X; ix++){
-        const geo=new THREE.PlaneGeometry(ROAD,(CELL)*BLOCKS_Z + ROAD);
-        const m=new THREE.Mesh(geo, asphaltMat);
-        m.rotation.x=-Math.PI/2; const x = ix*CELL-(BLOCKS_X*CELL)/2; m.position.set(x, 0.01, ROAD*0.5-(BLOCKS_Z*CELL)/2); m.receiveShadow=allowShadows; city.add(m); xRoads.push(x);
-        const sL=new THREE.Mesh(new THREE.PlaneGeometry(SIDE,(CELL)*BLOCKS_Z + ROAD), sidewalkMat); sL.rotation.x=-Math.PI/2; sL.position.set(x-ROAD/2 - SIDE/2, 0.012, ROAD*0.5-(BLOCKS_Z*CELL)/2); sidewalks.add(sL);
-        const sR=sL.clone(); sR.position.x = x+ROAD/2 + SIDE/2; sidewalks.add(sR);
-      }
-      for(let iz=0; iz<=BLOCKS_Z; iz++){
-        const geo=new THREE.PlaneGeometry((CELL)*BLOCKS_X + ROAD, ROAD);
-        const m=new THREE.Mesh(geo, asphaltMat);
-        m.rotation.x=-Math.PI/2; const z = iz*CELL-(BLOCKS_Z*CELL)/2; m.position.set(ROAD*0.5-(BLOCKS_X*CELL)/2, 0.01, z); m.receiveShadow=allowShadows; city.add(m); zRoads.push(z);
-        const sT=new THREE.Mesh(new THREE.PlaneGeometry((CELL)*BLOCKS_X + ROAD, SIDE), sidewalkMat); sT.rotation.x=-Math.PI/2; sT.position.set(ROAD*0.5-(BLOCKS_X*CELL)/2, 0.012, z-ROAD/2 - SIDE/2); sidewalks.add(sT);
-        const sB=sT.clone(); sB.position.z = z+ROAD/2 + SIDE/2; sidewalks.add(sB);
-      }
+  const ARM_SPEED_BASE = 4.8 * 2.5; const speedRun = 7.2 * 2.5; const trafficTarget = 3 * speedRun; // 3x run speed
 
-      function addMarkings(){
-        const marks=new THREE.Group(); marks.renderOrder=5; city.add(marks);
-        function centerDashLineX(z){ for(let ix=0; ix<BLOCKS_X; ix++){ const x0=xRoads[ix], x1=xRoads[ix+1]; const segs=14; for(let s=0;s<segs;s++){ const px = THREE.MathUtils.lerp(x0,x1,s/segs) + (x1-x0)/(segs*2); const dash=new THREE.Mesh(new THREE.PlaneGeometry(4,0.7), new THREE.MeshBasicMaterial({color:0xffffff,transparent:true,opacity:0.9, side:THREE.DoubleSide})); dash.rotation.x=-Math.PI/2; dash.position.set(px,0.021,z); marks.add(dash);} const stop=new THREE.Mesh(new THREE.PlaneGeometry(8,0.8), new THREE.MeshBasicMaterial({color:0xffffff, side:THREE.DoubleSide})); stop.rotation.x=-Math.PI/2; stop.position.set(x1-ROAD*0.6,0.022,z); marks.add(stop);} }
-        function centerDashLineZ(x){ for(let iz=0; iz<BLOCKS_Z; iz++){ const z0=zRoads[iz], z1=zRoads[iz+1]; const segs=14; for(let s=0;s<segs;s++){ const pz = THREE.MathUtils.lerp(z0,z1,s/segs) + (z1-z0)/(segs*2); const dash=new THREE.Mesh(new THREE.PlaneGeometry(4,0.7), new THREE.MeshBasicMaterial({color:0xffffff,transparent:true,opacity:0.9, side:THREE.DoubleSide})); dash.rotation.x=-Math.PI/2; dash.position.set(x,0.021,pz); marks.add(dash);} const stop=new THREE.Mesh(new THREE.PlaneGeometry(8,0.8), new THREE.MeshBasicMaterial({color:0xffffff, side:THREE.DoubleSide})); stop.rotation.x=-Math.PI/2; stop.position.set(x,0.022,z1-ROAD*0.6); marks.add(stop);} }
-        xRoads.forEach(z=>centerDashLineX(z));
-        zRoads.forEach(x=>centerDashLineZ(x));
-        const zebraM=new THREE.MeshBasicMaterial({color:0xffffff,transparent:true,opacity:0.95, side:THREE.DoubleSide});
-        for(let ix=1; ix<BLOCKS_X; ix++){
-          for(let iz=1; iz<BLOCKS_Z; iz++){
-            const x=xRoads[ix], z=zRoads[iz];
-            for(let i=0;i<10;i++){ const stripe=new THREE.Mesh(new THREE.PlaneGeometry(0.7,3.6), zebraM); stripe.rotation.x=-Math.PI/2; stripe.position.set(x-5+i*1.2,0.023,z-ROAD*0.2); marks.add(stripe); }
-            for(let i=0;i<10;i++){ const stripe=new THREE.Mesh(new THREE.PlaneGeometry(0.7,3.6), zebraM); stripe.rotation.x=-Math.PI/2; stripe.position.set(x-ROAD*0.2,0.023,z-5+i*1.2); marks.add(stripe); }
-          }
-        }
-      }
-      addMarkings();
+  const rayEnemies=new Map();
+  const modelCache=new Map();
+  const CHAR_PRESETS={ Soldier:['https://threejs.org/examples/models/gltf/Soldier.glb'], Xbot:['https://threejs.org/examples/models/gltf/Xbot.glb'] };
+  async function robustLoadChar(urls){ let last=null; for(const u of urls){ try{ return await gltfLoader.loadAsync(u); }catch(e){ last=e; } } throw last||new Error('Load fail'); }
+  function normalizeRoot(root){ const box=new THREE.Box3().setFromObject(root); const size=new THREE.Vector3(); box.getSize(size); const scale=1.7/(size.y||1); root.scale.setScalar(scale); return root; }
+  function makeCapsulePlaceholder(){ const g=new THREE.Group(); const body=new THREE.Mesh(new THREE.CapsuleGeometry(0.35,1.0,8,16), new THREE.MeshLambertMaterial({ color:0x556b8a })); g.add(body); return g; }
+  async function getCharacter(key){ if(modelCache.has(key)) return modelCache.get(key); try{ const gltf=await robustLoadChar(CHAR_PRESETS[key]||CHAR_PRESETS.Soldier); const baseRoot=(gltf.scene||gltf.scenes?.[0]||null); const root = baseRoot? normalizeRoot(baseRoot) : makeCapsulePlaceholder(); root.traverse?.(o=>{ if(o.isMesh){ o.castShadow=allowShadows; o.receiveShadow=allowShadows; o.material = new THREE.MeshLambertMaterial({ color:0x9fb1c6 }); }}); modelCache.set(key,{root,clips:gltf.animations||[]}); return modelCache.get(key); }catch(_){ const ph=makeCapsulePlaceholder(); modelCache.set(key,{root:ph,clips:[]}); return modelCache.get(key); } }
+  const enemies=new Map();
+  async function safeCloneSkinned(src){ try{ if(src && SkeletonUtils?.clone){ return SkeletonUtils.clone(src); } if(src?.clone){ return src.clone(true); } }catch(_){ } return makeCapsulePlaceholder(); }
+  async function spawnEnemy(x,z,key='Soldier'){ if(enemies.size>=12) return null; const base=await getCharacter(key); const clone=await safeCloneSkinned(base?.root); clone.traverse(o=>{ o.castShadow=allowShadows; }); clone.position.set(x,0,z); clone.userData.enemy=true; scene.add(clone); const r=0.35,h=1.6; const shape=new CANNON.Cylinder(r,r,h,8); const q=new CANNON.Quaternion(); q.setFromEuler(Math.PI/2,0,0); const body=new CANNON.Body({ mass:80, material:matEnemy, linearDamping:0.3, angularDamping:0.9 }); body.fixedRotation=true; body.addShape(shape,new CANNON.Vec3(0,h/2,0),q); body.position.set(x,0.9,z); world.addBody(body); const hpBar=makeBillboardBar(); scene.add(hpBar); enemies.set(clone.uuid,{root:clone, body, hp:120, dead:false, hpBar, cooldown:0}); return clone; }
+  function enemyRoots(){ return Array.from(enemies.values()).map(e=>e.root); }
+  function enemyTryFire(e, dt){ if(e.dead) return; e.cooldown -= dt; const toP = new THREE.Vector3(player.position.x-e.body.position.x, 0, player.position.z-e.body.position.z); const dist = toP.length(); if(dist>55) return; if(e.cooldown>0) return; const dir = new THREE.Vector3(player.position.x - e.body.position.x, (player.position.y+0.9) - (e.body.position.y+0.9), player.position.z - e.body.position.z).normalize(); dir.x += (Math.random()-0.5)*0.02; dir.y += (Math.random()-0.5)*0.01; dir.z += (Math.random()-0.5)*0.02; dir.normalize(); const origin = new THREE.Vector3(e.body.position.x, e.body.position.y+1.1, e.body.position.z); const to = origin.clone().addScaledVector(dir, 150); tracer(origin,to,0xff8888); e.cooldown = 0.2 + Math.random()*0.6; }
 
-      const ladders=[]; const stairMeshes=[]; const buildings=[]; const institutions=[];
-      function makeSign(text, w=24, h=6, bg='#111', fg='#ffd966'){ const c=document.createElement('canvas'); c.width=1024; c.height=256; const x=c.getContext('2d'); x.fillStyle=bg; x.fillRect(0,0,1024,256); x.fillStyle=fg; x.font='900 140px system-ui, Arial'; x.textAlign='center'; x.textBaseline='middle'; x.fillText(text,512,140); const t=new THREE.CanvasTexture(c); t.colorSpace=THREE.SRGBColorSpace; const m=new THREE.MeshBasicMaterial({ map:t, side:THREE.DoubleSide }); const mesh=new THREE.Mesh(new THREE.PlaneGeometry(w,h), m); return mesh; }
+  function makeBillboardBar(){ const c=document.createElement('canvas'); c.width=128; c.height=16; const t=new THREE.CanvasTexture(c); const m=new THREE.SpriteMaterial({ map:t, depthWrite:false }); const s=new THREE.Sprite(m); s.scale.set(0.9, 0.12, 1); s.userData.canvas=c; s.userData.tex=t; updateBillboardBar(s,1); return s; }
+  function updateBillboardBar(s,ratio){ const c=s.userData.canvas; const x=c.getContext('2d'); x.clearRect(0,0,c.width,c.height); x.fillStyle='rgba(0,0,0,0.6)'; x.fillRect(0,0,c.width,c.height); x.fillStyle= ratio>0.6? '#29ff9a' : ratio>0.3? '#ffd966':'#ff4d4f'; x.fillRect(2,2,(c.width-4)*Math.max(0,Math.min(1,ratio)), c.height-4); s.userData.tex.needsUpdate=true; }
 
-      function addTower(xc,zc){
-        const w=THREE.MathUtils.randFloat(PLOT*0.32,PLOT*0.46), d=THREE.MathUtils.randFloat(PLOT*0.28,PLOT*0.46), h=THREE.MathUtils.randFloat(26,78);
-        const geo=new THREE.BoxGeometry(w,h,d); const hue=(180+Math.random()*80)|0; const mat=new THREE.MeshStandardMaterial({ map:facadeTex(hue), roughness:0.8, metalness:0.05 });
-        const m=new THREE.Mesh(geo, mat); m.position.set(xc, h/2, zc); m.castShadow=allowShadows; m.receiveShadow=allowShadows; city.add(m);
-        buildings.push({mesh:m,w,d,h});
-        if(h>52){ const lx=xc+w/2-2, lz=zc+d/2-2; ladders.push({x:lx,y0:0,y1:h-2,z:lz}); makeFireEscape(m, lx, lz, h); }
-      }
-      function makeFireEscape(buildMesh, x, z, h){
-        const g=new THREE.Group(); const stairM=new THREE.MeshStandardMaterial({color:'#2c2f33', roughness:0.7, metalness:0.2}); const stepH=2.8; const levels=Math.floor(h/stepH);
-        for(let i=1;i<levels;i++){
-          const y=i*stepH; const plat=new THREE.Mesh(new THREE.BoxGeometry(3,0.12,1.2), stairM); plat.position.set(x, y, z); g.add(plat);
-          const railL=new THREE.Mesh(new THREE.BoxGeometry(0.1,1.0,1.2), stairM); railL.position.set(x-1.45,y+0.5,z); g.add(railL);
-          const railR=railL.clone(); railR.position.x = x+1.45; g.add(railR);
-          const steps=8; for(let s=0;s<steps;s++){ const st=new THREE.Mesh(new THREE.BoxGeometry(0.3,0.06,1.0), stairM); st.position.set(x-1.2+s*(2.4/steps), y-0.6+s*(1.2/steps), z); g.add(st);} }
-        g.userData.type='fireEscape'; stairMeshes.push(g);
-        city.add(g);
-      }
-      function addTrees(area, count=8){ const g=new THREE.Group(); for(let i=0;i<count;i++){ const x=area.x + (Math.random()-0.5)*area.w; const z=area.z + (Math.random()-0.5)*area.h; const trunk=new THREE.Mesh(new THREE.CylinderGeometry(0.3,0.4,2,8), new THREE.MeshStandardMaterial({color:'#6d4c41', roughness:0.9})); const crown=new THREE.Mesh(new THREE.DodecahedronGeometry(1.2), new THREE.MeshStandardMaterial({color:'#2e7d32', roughness:0.8})); trunk.position.set(x,1,z); crown.position.set(x,2.6,z); trunk.castShadow=crown.castShadow=allowShadows; g.add(trunk,crown);} city.add(g); }
-      function addFountain(xc, zc){
-        const base=new THREE.Mesh(new THREE.CylinderGeometry(4.4,4.8,0.6,24), new THREE.MeshStandardMaterial({color:'#d8d9dc', roughness:0.4, metalness:0.2})); base.position.set(xc,0.2,zc); base.receiveShadow=allowShadows; base.castShadow=allowShadows;
-        const bowl=new THREE.Mesh(new THREE.CylinderGeometry(3.2,3.6,0.4,24), new THREE.MeshStandardMaterial({color:'#c6c7cb', roughness:0.35, metalness:0.25})); bowl.position.set(xc,0.55,zc);
-        const water=new THREE.Mesh(new THREE.CylinderGeometry(2.6,2.6,0.3,24), waterMat); water.position.set(xc,0.7,zc);
-        const jet=new THREE.Mesh(new THREE.ConeGeometry(0.4,1.6,16), waterMat.clone()); jet.position.set(xc,1.5,zc); jet.rotation.x=Math.PI;
-        city.add(base,bowl,water,jet);
-      }
-      function addTennis(xc,zc){ const court=new THREE.Mesh(new THREE.PlaneGeometry(32,16), tennisMat); court.rotation.x=-Math.PI/2; court.position.set(xc-20,0.02,zc-10); city.add(court); }
-      function addBasket(xc,zc){ const court=new THREE.Mesh(new THREE.PlaneGeometry(30,17), basketMat); court.rotation.x=-Math.PI/2; court.position.set(xc+22,0.02,zc+10); city.add(court); const poleM=new THREE.MeshStandardMaterial({color:'#333', roughness:0.5}); const boardM=new THREE.MeshStandardMaterial({color:'#eee', roughness:0.35}); const ringM=new THREE.MeshStandardMaterial({color:'#f44336', roughness:0.4}); function hoop(x,z,dir=1){ const pole=new THREE.Mesh(new THREE.CylinderGeometry(0.15,0.15,3,8), poleM); pole.position.set(x,1.5,z); const board=new THREE.Mesh(new THREE.BoxGeometry(1.8,1.0,0.08), boardM); board.position.set(x,3.2,z+0.4*dir); const ring=new THREE.Mesh(new THREE.TorusGeometry(0.45,0.06,8,16), ringM); ring.rotation.x=Math.PI/2; ring.position.set(x,2.9,z+0.85*dir); city.add(pole,board,ring); } hoop(xc+7,zc+18,1); hoop(xc+37,zc-2,-1); }
-      function addPark(xc,zc){ const park=new THREE.Mesh(new THREE.PlaneGeometry(PLOT-6,PLOT-6), turfMat); park.rotation.x=-Math.PI/2; park.position.set(xc,0.015,zc); park.receiveShadow=allowShadows; city.add(park); addFountain(xc+8,zc-6); addTennis(xc,zc); addBasket(xc,zc); addTrees({x:xc,z:zc,w:PLOT*0.7,h:PLOT*0.7}, 10+((Math.random()*6)|0)); }
+  function startBR(){ for(let i=0;i<8;i++){ const a=(i/8)*Math.PI*2; const r=ringR*0.6; spawnEnemy(Math.cos(a)*r, Math.sin(a)*r, ['Soldier','Xbot'][i%2]); } }
+  startBR();
 
-      function addInstitution(type, ix, iz){
-        const xc=startX + ix*CELL, zc=startZ + iz*CELL;
-        const w=PLOT*0.7, d=PLOT*0.5, h= type==='Hospital'? 40: (type==='Mall'? 34: 26);
-        const body=new THREE.Mesh(new THREE.BoxGeometry(w,h,d), new THREE.MeshStandardMaterial({ map:facadeTex(type==='Mall'?280: type==='Broadway'? 20: 200), roughness:0.78, metalness:0.05 }));
-        body.position.set(xc, h/2, zc); body.castShadow=allowShadows; body.receiveShadow=allowShadows; city.add(body);
-        const signText = type==='Police'?'POLICE STATION': type==='Hospital'? 'HOSPITAL': type==='Fire'?'FIRE BRIGADE': type==='Broadway'?'BROADWAY': 'SHOPPING MALL';
-        const sign = makeSign(signText, 30, 6, type==='Broadway'? '#111': '#0b1222', '#ffd966'); sign.position.set(xc, h+4, zc+ d/2 + 1.2); city.add(sign);
-        const lot = new THREE.Mesh(new THREE.PlaneGeometry(w+26, d+30), asphaltMat); lot.rotation.x=-Math.PI/2; lot.position.set(xc, 0.012, zc - d/2 - 16); lot.receiveShadow=allowShadows; city.add(lot);
-        institutions.push({type, pos:new THREE.Vector3(xc,0,zc), w, d, h, lot});
-      }
+  let inputMode='A';
+  function applyMode(){
+    shootPad.style.display='block';
+    $('reloadMini').style.display='block';
+    updateZoomUI();
+  }
+  applyMode();
 
-      addInstitution('Police', 1, 1);
-      addInstitution('Hospital', 4, 2);
-      addInstitution('Fire', 2, 4);
-      addInstitution('Broadway', 3, 0);
-      addInstitution('Mall', 5, 3);
+  const zoomSlider=$('zoomSlider');
+  function updateZoomUI(){ const box=$('zoomBox'); if(!box) return; if(currentKey==='AK47' && inputMode==='A'){ box.style.display='flex'; } else { box.style.display='none'; } }
+  zoomSlider.addEventListener('input',()=>{ const v=parseFloat(zoomSlider.value||'1'); camera.fov = THREE.MathUtils.clamp(70 / v, 18, 70); camera.updateProjectionMatrix(); });
 
-      for(let ix=0; ix<BLOCKS_X; ix++){
-        for(let iz=0; iz<BLOCKS_Z; iz++){
-          const xc=startX + ix*CELL;
-          const zc=startZ + iz*CELL;
-          const isInst = institutions.some(it=> Math.hypot(it.pos.x-xc, it.pos.z-zc) < 2);
-          if(isInst) continue;
-          const r=Math.random();
-          if(r<0.28){ addPark(xc,zc); }
-          else { const n=1 + (Math.random()<0.5?1:0); for(let i=0;i<n;i++){ const ox=(Math.random()-0.5)*PLOT*0.25; const oz=(Math.random()-0.5)*PLOT*0.25; addTower(xc+ox, zc+oz); } }
-        }
-      }
-      const audio={ ctx:null, muted:false };
-      function ac(){ if(audio.muted) return null; try{ audio.ctx = audio.ctx || new (window.AudioContext||window.webkitAudioContext)(); return audio.ctx; }catch(_){ return null; } }
-      function withAC(fn){ const ctx=ac(); if(!ctx) return; fn(ctx); }
-      function noiseBuffer(ctx){ const b=ctx.createBuffer(1, ctx.sampleRate*1.0, ctx.sampleRate); const d=b.getChannelData(0); for(let i=0;i<d.length;i++){ d[i]= (Math.random()*2-1) * (1 - i/d.length); } return b; }
-      function burstNoise({dur=0.12, freq=1500, type='bandpass', gain=0.12}){ withAC((ctx)=>{ const src=ctx.createBufferSource(); src.buffer=noiseBuffer(ctx); const bp=ctx.createBiquadFilter(); bp.type=type; bp.frequency.value=freq; const g=ctx.createGain(); g.gain.value=gain; src.connect(bp); bp.connect(g); g.connect(ctx.destination); src.start(); src.stop(ctx.currentTime+dur); }); }
-      function clickS({freq=800,dur=0.02,gain=0.08}){ withAC((ctx)=>{ const o=ctx.createOscillator(); const g=ctx.createGain(); o.type='square'; o.frequency.value=freq; g.gain.value=gain; o.connect(g); g.connect(ctx.destination); o.start(); o.stop(ctx.currentTime+dur); }); }
-      function sfxGun(kind){ switch(kind){ case 'Glock': case 'Pistol': burstNoise({dur:0.09,freq:2200,gain:0.12}); clickS({freq:1800,dur:0.015,gain:0.06}); break; case 'AR': burstNoise({dur:0.08,freq:1900,gain:0.13}); clickS({freq:1600,dur:0.012,gain:0.05}); break; case 'Uzi': burstNoise({dur:0.05,freq:2300,gain:0.12}); clickS({freq:1900,dur:0.01,gain:0.05}); break; case 'AK47': burstNoise({dur:0.1,freq:1400,gain:0.14}); clickS({freq:1200,dur:0.015,gain:0.07}); break; default: burstNoise({dur:0.07,freq:1800,gain:0.12}); } }
-      function sfxReload(){ clickS({freq:600,dur:0.05,gain:0.05}); setTimeout(()=>clickS({freq:900,dur:0.04,gain:0.05}),90); }
-      $('muteBtn').addEventListener('click',(e)=>{ audio.muted=!audio.muted; e.target.textContent=audio.muted?'🔇':'🔊'; });
+  const climbBtn=$('climbBtn');
+  const ladderState={ active:false, index:-1 };
+  function detachFromLadder(){ if(!ladderState.active) return; ladderState.active=false; ladderState.index=-1; climbBtn.textContent='⬆ Use/Climb Ladder'; }
+  function nearestLadder(){ if(ladderState.active && ladderState.index>=0) return {idx:ladderState.index, dist:0}; let best=-1, bd=1e9; for(let i=0;i<ladders.length;i++){ const L=ladders[i]; const dx=player.position.x-L.x; const dz=player.position.z-L.z; const d=Math.hypot(dx,dz); if(d<bd){ bd=d; best=i; } } return {idx:best, dist:bd}; }
+  function snapToLadder(idx){ const L=ladders[idx]; if(!L) return; ladderState.active=true; ladderState.index=idx; player.velocity.x=player.velocity.z=0; player.angularVelocity.set(0,0,0); player.position.x=L.x; player.position.z=L.z; player.position.y=Math.max(player.position.y, L.y0+0.6); climbBtn.textContent='⬇ Leave Ladder'; }
+  function setClimbUI(){ const n=nearestLadder(); ladders.forEach((L,i)=>{ if(L.marker){ const close = ladderState.active? (i===ladderState.index) : (i===n.idx && n.dist<2.2); L.marker.material.opacity = close?0.98:0.78; L.marker.scale.setScalar(close?1.04:0.9); } }); const show = ladderState.active || n.dist<1.6; climbBtn.style.display = show? 'block':'none'; climbBtn.textContent = ladderState.active? '⬇ Leave Ladder' : '⬆ Use/Climb Ladder'; }
+  climbBtn.addEventListener('click', ()=>{ if(ladderState.active){ detachFromLadder(); return; } const n=nearestLadder(); if(n.dist<1.2 && n.idx>=0){ snapToLadder(n.idx); vib(16); } });
+  function updateClimbMovement(moveInput,dt){ const idx=ladderState.index; const L=ladders[idx]; if(!ladderState.active || !L) return; const climbSpeed=2.6; const nextY = THREE.MathUtils.clamp(player.position.y + moveInput*climbSpeed*dt, L.y0+0.6, L.y1+1.1); player.position.y = nextY; player.position.x = L.x; player.position.z = L.z; player.velocity.set(0,0,0); player.angularVelocity.set(0,0,0); if(nextY>=L.y1+0.95 && moveInput>0.1){ detachFromLadder(); player.position.y = L.y1+1.0; player.position.x += Math.sin(yaw)*1.1; player.position.z += Math.cos(yaw)*1.1; }
+    if(nextY<=L.y0+0.6 && moveInput<-0.1){ detachFromLadder(); player.position.y = L.y0+0.6; }
+  }
 
-      const playerRadius=0.35; const player=new CANNON.Body({ mass:75, material:matPlayer, shape:new CANNON.Sphere(playerRadius), position:new CANNON.Vec3(0,1.0,10), linearDamping:0.18, angularDamping:0.9 });
-      player.fixedRotation=true; player.allowSleep=false; world.addBody(player);
-      let yaw=0, pitch=0; function clampPitch(){ const inv = settings.invertY?-1:1; pitch=Math.max(-Math.PI/2+0.005*inv, Math.min(Math.PI/2-0.005*inv, pitch)); }
-      function camFollow(pos,distMul=1){ const back=new THREE.Vector3(Math.sin(yaw),0,Math.cos(yaw)); const eye=new THREE.Vector3(pos.x - back.x*camDist*distMul, pos.y+2.1, pos.z - back.z*camDist*distMul); camera.position.lerp(eye,0.25); const look=new THREE.Vector3(pos.x + back.x*(camDist+0.2)*distMul, pos.y+1.25 + Math.sin(pitch)*0.8, pos.z + back.z*(camDist+0.2)*distMul); camera.lookAt(look); }
-      function grounded(){ return player.position.y < 0.38 && Math.abs(player.velocity.y) < 0.05; }
-      const ladderState = { active:false, ladder:null };
-      function detachFromLadder(){ if(!ladderState.active) return; ladderState.active=false; ladderState.ladder=null; $('climbBtn').textContent='⬆ Climb Ladder'; }
-      function jump(){ if(ladderState.active){ detachFromLadder(); return; } if(grounded()){ player.velocity.y = 5.2; vib(12); } }
+  const mapOverlay=$('mapOverlay'), mapCanvas=$('mapCanvas'), mctx=mapCanvas.getContext('2d'); function resizeMap(){ mapCanvas.width=mapCanvas.clientWidth; mapCanvas.height=mapCanvas.clientHeight; }
+  function drawMap(){ resizeMap(); const w=mapCanvas.width,h=mapCanvas.height; const grad=mctx.createLinearGradient(0,0,0,h); grad.addColorStop(0,'#0f172a'); grad.addColorStop(1,'#111827'); mctx.fillStyle=grad; mctx.fillRect(0,0,w,h); const cx=w/2, cy=h/2; const extent=Math.max(BLOCKS_X,BLOCKS_Z)*CELL*0.5 + ringR*0.7; const scale=Math.min(w,h)/(extent*2.05);
+    mctx.save(); mctx.translate(cx,cy);
+    mctx.strokeStyle='rgba(57,66,88,0.9)'; mctx.lineWidth=ROAD*scale*2; mctx.beginPath(); mctx.arc(0,0,ringR*scale,0,Math.PI*2); mctx.stroke();
+    mapRoads.forEach((road)=>{ const x1=(road.from.x)*scale; const y1=(road.from.z)*scale; const x2=(road.to.x)*scale; const y2=(road.to.z)*scale; mctx.strokeStyle='rgba(76,86,106,0.92)'; mctx.lineWidth=Math.max(3, (road.width||ROAD)*scale*1.15); mctx.beginPath(); mctx.moveTo(x1,y1); mctx.lineTo(x2,y2); mctx.stroke(); mctx.strokeStyle='rgba(255,255,255,0.16)'; mctx.lineWidth=Math.max(1, (road.width||ROAD)*scale*0.35); mctx.beginPath(); mctx.moveTo(x1,y1); mctx.lineTo(x2,y2); mctx.stroke(); });
+    mctx.font='13px 600 system-ui'; mctx.fillStyle='rgba(226,232,240,0.86)'; mapRoads.forEach((road)=>{ if(!road.name) return; const x1=(road.from.x)*scale; const y1=(road.from.z)*scale; const x2=(road.to.x)*scale; const y2=(road.to.z)*scale; if(Math.hypot(x2-x1,y2-y1)<12) return; const midX=(x1+x2)/2; const midY=(y1+y2)/2; const ang=Math.atan2(y2-y1,x2-x1); mctx.save(); mctx.translate(midX,midY); mctx.rotate(ang); const textW=mctx.measureText(road.name).width; mctx.fillText(road.name,-textW/2,-6); mctx.restore(); });
+    mapParks.forEach((park)=>{ const px=park.x*scale; const py=park.z*scale; const wpx=park.w*scale; const hpx=park.d*scale; mctx.fillStyle=park.type==='fountain'?'rgba(59,130,246,0.35)': park.type==='basket'?'rgba(239,68,68,0.32)':'rgba(34,197,94,0.32)'; mctx.fillRect(px-wpx/2, py-hpx/2, wpx, hpx); mctx.strokeStyle='rgba(255,255,255,0.12)'; mctx.strokeRect(px-wpx/2, py-hpx/2, wpx, hpx); });
+    mapBuildings.forEach((b)=>{ const px=b.x*scale, py=b.z*scale; const wpx=b.w*scale, hpx=b.d*scale; mctx.fillStyle='rgba(148,163,184,0.32)'; mctx.fillRect(px-wpx/2, py-hpx/2, wpx, hpx); });
+    mctx.font='17px 700 system-ui'; mctx.fillStyle='#facc15'; mapLandmarks.forEach((L)=>{ const px=L.x*scale, py=L.z*scale; mctx.fillText(L.label, px - mctx.measureText(L.label).width/2, py-8); });
+    POIS.forEach((p)=>{ const px=p.pos.x*scale, py=p.pos.z*scale; mctx.fillText(p.label, px-6, py-6); });
+    if(waypoint){ const wx=waypoint.x*scale, wy=waypoint.z*scale; mctx.strokeStyle='rgba(102,204,255,0.9)'; mctx.lineWidth=3; mctx.setLineDash([18,10]); mctx.beginPath(); mctx.moveTo(player.position.x*scale, player.position.z*scale); mctx.lineTo(wx,wy); mctx.stroke(); mctx.setLineDash([]); mctx.fillStyle='#38bdf8'; mctx.beginPath(); mctx.arc(wx,wy,8,0,Math.PI*2); mctx.fill(); mctx.fillStyle='#38bdf8'; mctx.fillText('Waypoint', wx-38, wy-12); }
+    mctx.fillStyle='#7dd3fc'; mctx.beginPath(); mctx.arc(player.position.x*scale, player.position.z*scale, 8, 0, Math.PI*2); mctx.fill(); mctx.strokeStyle='#38bdf8'; mctx.lineWidth=2.4; mctx.beginPath(); mctx.moveTo(player.position.x*scale, player.position.z*scale); mctx.lineTo(player.position.x*scale + Math.sin(yaw)*32, player.position.z*scale + Math.cos(yaw)*32); mctx.stroke();
+    mctx.restore();
+  }
+  resizeMap(); addEventListener('resize', resizeMap);
+  $('mapBtn').addEventListener('click', ()=>{ mapOverlay.style.display='flex'; requestAnimationFrame(()=>drawMap()); });
+  $('mapClose').addEventListener('click', ()=>{ mapOverlay.style.display='none'; });
 
-      const aimGeo=new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(), new THREE.Vector3(0,0,-50)]);
-      const aimMatDark=new THREE.LineBasicMaterial({ color:0x222222, transparent:true, opacity:0.9 });
-      const aimLine=new THREE.Line(aimGeo,aimMatDark); aimLine.renderOrder=9; scene.add(aimLine);
-      const aimDotTex=(function(){ const c=document.createElement('canvas'); c.width=c.height=64; const x=c.getContext('2d'); x.fillStyle='rgba(255,255,255,0.0)'; x.fillRect(0,0,64,64); x.beginPath(); x.arc(32,32,14,0,Math.PI*2); x.fillStyle='rgba(255,60,60,0.95)'; x.fill(); x.lineWidth=3; x.strokeStyle='rgba(255,255,255,0.9)'; x.stroke(); const t=new THREE.CanvasTexture(c); t.colorSpace=THREE.SRGBColorSpace; return t; })();
-      const aimDot=new THREE.Sprite(new THREE.SpriteMaterial({ map:aimDotTex, depthWrite:false, color:0xffffff })); aimDot.scale.set(0.7,0.7,1); scene.add(aimDot);
-      const crosshairEl=$('crosshair'); crosshairEl.style.setProperty('--aimColor','#ff3c3c');
+  let waypoint=null; let navGuide=null;
+  function updateNavGuide(){ if(navGuide){ scene.remove(navGuide); navGuide.geometry.dispose(); navGuide.material.dispose(); navGuide=null; } if(!waypoint) return; const guideGeo=new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(player.position.x,0.1,player.position.z), new THREE.Vector3(waypoint.x,0.1,waypoint.z)]); const guideMat=new THREE.LineDashedMaterial({ color:0x66ccff, dashSize:2.2, gapSize:1.2, linewidth:1 }); navGuide=new THREE.Line(guideGeo, guideMat); navGuide.computeLineDistances(); scene.add(navGuide); }
+  mapCanvas.addEventListener('click', (e)=>{ const r=mapCanvas.getBoundingClientRect(); const x=e.clientX-r.left, y=e.clientY-r.top; const ux=x/mapCanvas.width, uz=y/mapCanvas.height; const wx = -BLOCKS_X*CELL/2 + ux*(BLOCKS_X*CELL); const wz = -BLOCKS_Z*CELL/2 + uz*(BLOCKS_Z*CELL); const candidate=new THREE.Vector3(wx,0,wz); if(waypoint && waypoint.distanceTo(candidate)<8){ waypoint=null; } else { waypoint=candidate; } updateNavGuide(); drawMap(); });
 
-      const ARMORY=[
-        { key:'Glock',  name:'Glock', url:'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/glock.glb', s:0.62,  stats:{ rpm:380, dmg:24, spread:0.013, mag:17, reload:1.2, recoil:0.5 }, auto:false },
-        { key:'Pistol', name:'Pistol',url:'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb', s:0.46, stats:{ rpm:320, dmg:22, spread:0.014, mag:15, reload:1.3, recoil:0.55 }, auto:false },
-        { key:'AR',     name:'Assault Rifle', url:'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb', s:0.70, stats:{ rpm:720, dmg:26, spread:0.012, mag:30, reload:1.9, recoil:0.36 }, auto:true },
-        { key:'Uzi',    name:'Uzi',    url:'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb', s:0.60, stats:{ rpm:900, dmg:18, spread:0.02,  mag:32, reload:1.6, recoil:0.32 }, auto:true },
-        { key:'AK47',   name:'AK‑pattern', url:'https://cdn.jsdelivr.net/gh/LazerMaker/gun-models-ak47-and-supprest-pistol-@master/ak47.glb', s:0.78, stats:{ rpm:600, dmg:30, spread:0.012, mag:30, reload:1.9, recoil:0.42 }, auto:true },
-        { key:'Grenade',name:'Grenade',url:'https://cdn.jsdelivr.net/gh/friuns2/bingextension@main/grenade.glb', s:0.30, stats:{ rpm:60,  dmg:120, spread:0.03,  mag:1,  reload:2.4, recoil:0.0 }, auto:false }
-      ];
-      const FIRE_MODES=new Map(); ARMORY.forEach(a=>FIRE_MODES.set(a.key,a.auto?'auto':'single'));
+  function updateEmergencyUnits(dt){ for(const unit of emergencyUnits){ const mesh=unit.mesh; if(!mesh) continue; if(unit.state==='responding' || unit.state==='returning'){ if(unit.target){ const dir=new THREE.Vector3(unit.target.x-mesh.position.x,0,unit.target.z-mesh.position.z); const dist=dir.length(); if(dist>0.4){ dir.normalize(); const sp=(unit.state==='responding'?unit.speed:unit.speed*0.7); mesh.position.x += dir.x*sp*dt; mesh.position.z += dir.z*sp*dt; setHeading(mesh, Math.atan2(dir.x, dir.z)); } else { if(unit.state==='responding'){ unit.state='onsite'; unit.arrivalTimer=0; } else { unit.state='idle'; unit.target=null; mesh.position.copy(unit.base); setHeading(mesh, unit.baseHeading||0); } } } } else if(unit.state==='onsite'){ unit.arrivalTimer=(unit.arrivalTimer||0)+dt; if(unit.arrivalTimer>14){ unit.state='returning'; unit.target=unit.base.clone(); } } else if(unit.state==='idle'){ const drift=Math.hypot(mesh.position.x-unit.base.x, mesh.position.z-unit.base.z); if(drift>0.6){ unit.state='returning'; unit.target=unit.base.clone(); } }
+      if(unit.siren){ unit.siren.phase += dt*6; const active=(unit.state==='responding'||unit.state==='onsite'); const pulse=Math.abs(Math.sin(unit.siren.phase)); const low=Math.max(0.16,0.18- dt*0.5); const leftIntensity=active?(0.45+0.55*pulse):low; const rightIntensity=active?(0.45+0.55*Math.abs(Math.sin(unit.siren.phase+Math.PI/2))):low; unit.siren.left.material.opacity=leftIntensity; unit.siren.right.material.opacity=rightIntensity; if(unit.siren.light){ const tint=unit.type==='fire'?0xff6b6b: unit.type==='ambulance'?0xffc857:0x60a5fa; unit.siren.light.intensity = active ? 8 + pulse*6 : 0; unit.siren.light.color.set(active ? tint : 0xffffff); } } }
+  }
 
-      const weaponRoot=new THREE.Group(); camera.add(weaponRoot);
-      const weaponCache=new Map();
-      function normalizeAndCenter(root, targetLen=0.6){ const box=new THREE.Box3().setFromObject(root); const size=new THREE.Vector3(); box.getSize(size); const center=new THREE.Vector3(); box.getCenter(center); root.position.sub(center); const maxDim=Math.max(size.x,size.y,size.z)||1; const s=targetLen/maxDim; root.scale.setScalar(s); return root; }
-      async function loadWeapon(key){ const entry=ARMORY.find(a=>a.key===key); if(!entry){ return new THREE.Group(); } if(weaponCache.has(key)){ const v=weaponCache.get(key); return (v.clone? v.clone(true) : v); } try{ const gltf=await gltfLoaderGuns.loadAsync(entry.url); const base=(gltf.scene||gltf.scenes?.[0]||null); let use = base || new THREE.Group(); normalizeAndCenter(use, entry.s); use.traverse?.(o=>{ if(o.isMesh){ o.castShadow=allowShadows; o.receiveShadow=allowShadows; const m=o.material; o.material = new THREE.MeshStandardMaterial({ color:(m?.color||new THREE.Color('#888')), map:m?.map||null, transparent:!!m?.transparent, opacity:(m?.opacity??1), roughness:0.72, metalness:0.1 }); }}); weaponCache.set(key, use); return (use.clone? use.clone(true) : use); }catch(_){ const g=new THREE.Group(); const b=new THREE.Mesh(new THREE.BoxGeometry(0.12,0.08,0.35), new THREE.MeshStandardMaterial({color:'#444', roughness:0.7})); g.add(b); normalizeAndCenter(g, entry.s); weaponCache.set(key,g); return g.clone(); } }
+  let last=performance.now(); let frameCount=0,fpsTimer=0; let fireCd=0; const mini=$('mini'); updateAmmoHUD();
+  function loop(now){
+    const dt=Math.min((now-last)/1000,0.05); last=now;
+    frameCount++; fpsTimer+=dt; if(fpsTimer>=0.5){ const fps=(frameCount/fpsTimer)|0; mini.textContent='fps: '+fps; if(fps<88 && dprScale>DPR_MIN){ dprScale=Math.max(DPR_MIN,dprScale-0.05); fit(); } else if(fps>120 && dprScale<DPR_MAX_SCALE){ dprScale=Math.min(DPR_MAX_SCALE,dprScale+0.04); fit(); } frameCount=0; fpsTimer=0; }
 
-      const armoryDiv=$('armory');
-      const thumbCache=new Map();
-      function weaponIconURL(key){ const svg=(p)=>'data:image/svg+xml;utf8,'+encodeURIComponent(p); const base=(body)=>`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 112 68'><rect width='112' height='68' rx='8' ry='8' fill='rgba(0,0,0,0.18)'/><g fill='none' stroke='#e6eefc' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'>${body}</g></svg>`; switch(key){ case 'Glock': return svg(base(`<path d='M14 32h58l8 8H14z'/><path d='M64 32v-8h20l8 10'/>`)); case 'Pistol': return svg(base(`<path d='M12 34h62l10 8H12z'/>`)); case 'AR': return svg(base(`<path d='M8 38h74l8 6H8z'/>`)); case 'Uzi': return svg(base(`<path d='M10 34h52l8 6H10z'/>`)); case 'AK47': return svg(base(`<path d='M10 38h84l10 6H10z'/>`)); case 'Grenade': return svg(base(`<circle cx='42' cy='36' r='12'/>`)); default: return svg(base(`<path d='M16 34h80'/>`)); } }
-      function weaponPreviewURL(key){ return thumbCache.get(key) || weaponIconURL(key); }
-      async function generateThumb(key){ try{ if(thumbCache.has(key)) return thumbCache.get(key); const size={w:224,h:136}; const rt=new THREE.WebGLRenderTarget(size.w,size.h); const sc=new THREE.Scene(); const cam=new THREE.PerspectiveCamera(40, size.w/size.h, 0.01, 10); const amb=new THREE.AmbientLight(0xffffff,0.9); const dir=new THREE.DirectionalLight(0xffffff,0.9); dir.position.set(2,3,2); sc.add(amb,dir); const model=await loadWeapon(key); const g=new THREE.Group(); if(model) g.add(model); normalizeAndCenter(g,0.9); g.rotation.y=Math.PI*0.85; sc.add(g); const prev=new THREE.Color(); renderer.getClearColor(prev); const prevA=renderer.getClearAlpha(); renderer.setRenderTarget(rt); renderer.setClearColor(0x000000,0); cam.position.set(0.6,0.3,1.2); cam.lookAt(0,0,0); renderer.render(sc,cam); const px=new Uint8Array(size.w*size.h*4); renderer.readRenderTargetPixels(rt,0,0,size.w,size.h,px); const cv=document.createElement('canvas'); cv.width=size.w; cv.height=size.h; const ctx=cv.getContext('2d'); const img=ctx.createImageData(size.w,size.h); for(let y=0;y<size.h;y++){ const sy=size.h-1-y; img.data.set(px.subarray(sy*size.w*4, sy*size.w*4+size.w*4), y*size.w*4);} ctx.putImageData(img,0,0); const url=cv.toDataURL('image/png'); renderer.setRenderTarget(null); renderer.setClearColor(prev,prevA); rt.dispose(); thumbCache.set(key,url); return url; }catch(_){ return weaponIconURL(key); } }
-      function buildGallery(){ armoryDiv.innerHTML=''; ARMORY.forEach((a)=>{ const b=document.createElement('button'); b.className='armBtn'; b.id='arm_'+a.key; b.innerHTML = `<img alt="${a.name}" src="${weaponPreviewURL(a.key)}"><span>${a.name}</span>`; b.addEventListener('click',()=>selectWeapon(a.key)); armoryDiv.appendChild(b); generateThumb(a.key).then(url=>{ const img=b.querySelector('img'); if(img) img.src=url; }); }); enableDragScroll(armoryDiv); }
+    if(inputMode==='A'){ const k = Math.min(1, dt*AIM_SMOOTH_A); const ax = lookAccumX * LOOK_SENS_A; const ay = lookAccumY * LOOK_SENS_A; lookAccumX=0; lookAccumY=0; aimSmoothX += (ax - aimSmoothX)*k; aimSmoothY += (ay - aimSmoothY)*k; yaw   -= aimSmoothX * AIM_RATE_A * dt; pitch -= aimSmoothY * AIM_RATE_A * dt; clampPitch(); }
 
-      function enableDragScroll(el){ let isDown=false; let startX=0; let scrollLeft=0; let moved=false; el.addEventListener('pointerdown',(e)=>{ isDown=true; moved=false; startX=e.clientX; scrollLeft=el.scrollLeft; el.classList.add('dragging'); el.setPointerCapture(e.pointerId); }); el.addEventListener('pointermove',(e)=>{ if(!isDown) return; const dx=e.clientX-startX; if(Math.abs(dx)>6) moved=true; el.scrollLeft=scrollLeft-dx; }); const clear=(e)=>{ if(isDown && moved){ e.preventDefault?.(); } isDown=false; el.releasePointerCapture?.(e.pointerId); el.classList.remove('dragging'); }; el.addEventListener('pointerup',clear); el.addEventListener('pointercancel',clear); el.addEventListener('click',(e)=>{ if(moved){ e.preventDefault(); e.stopPropagation(); }}); }
-      let currentWeaponKey='Uzi';
-      let currentWeapon=null; let ammoInMag=30; let reserveAmmo=120; let canShoot=true; let lastShot=0; let reloadTime=0; let shooting=false;
-      const weaponPose = { pos: new THREE.Vector3(0.5,-0.4,-0.8), rot: new THREE.Euler(-0.08, Math.PI, 0.02) };
-      async function selectWeapon(key){ currentWeaponKey=key; const entry=ARMORY.find(a=>a.key===key); if(!entry) return; if(currentWeapon){ weaponRoot.remove(currentWeapon); currentWeapon=null; }
-        const w=await loadWeapon(key); currentWeapon=w; weaponRoot.add(currentWeapon); currentWeapon.position.copy(weaponPose.pos); currentWeapon.rotation.copy(weaponPose.rot); ammoInMag = Math.min(entry.stats.mag, ammoInMag>0?ammoInMag:entry.stats.mag); updateAmmoHUD(); setActiveBtn(key); }
-      function setActiveBtn(key){ ARMORY.forEach(a=>{ const el=$('arm_'+a.key); if(!el) return; if(a.key===key) el.classList.add('active'); else el.classList.remove('active'); }); }
-      function updateAmmoHUD(){ const e=$('ammo'); const st=ARMORY.find(a=>a.key===currentWeaponKey)?.stats; e.textContent = `${currentWeaponKey} • ${ammoInMag}/${reserveAmmo} • ${st? st.rpm: ''}rpm`; }
+    const {from,to}=fireRay(new THREE.Vector2(0,0));
+    if(navGuide && waypoint){ const posAttr=navGuide.geometry.attributes.position; posAttr.setXYZ(0, player.position.x, 0.1, player.position.z); posAttr.setXYZ(1, waypoint.x, 0.1, waypoint.z); posAttr.needsUpdate=true; navGuide.computeLineDistances(); const mat=navGuide.material; if(mat){ mat.dashOffset=(mat.dashOffset||0)-dt*2.1; } }
+    const hitsEnemy = raycaster.intersectObjects(enemyRoots(), true);
+    const onEnemy = hitsEnemy.length>0;
+    crosshairEl.style.setProperty('--aimColor', onEnemy? '#2fe56b' : '#ff3c3c');
+    aimDotMat.color.set(onEnemy? 0x2fe56b : 0xff3c3c);
 
-      let soldierBase=null;
-      async function loadSoldier(){ try{ const gltf=await loadGLB(URLS.Soldier); const base=(gltf.scene||gltf.scenes?.[0]); base.traverse(o=>{ if(o.isMesh){ o.castShadow=allowShadows; o.receiveShadow=allowShadows; o.material && (o.material.needsUpdate=true); } });
-        const box=new THREE.Box3().setFromObject(base); const s=new THREE.Vector3(); box.getSize(s); const k=1.8/(s.y||1); base.scale.setScalar(k); placeOnGround(base,0); soldierBase=base; }catch(e){ console.error('Soldier load failed', e); }}
+    const move={x:0,z:0}; if(keys.has('KeyW')) move.z+=1; if(keys.has('KeyS')) move.z-=1; if(keys.has('KeyA')) move.x-=1; if(keys.has('KeyD')) move.x+=1; move.x += mv.vx; move.z += mv.vz; let l=Math.hypot(move.x,move.z); if(l>1){ move.x/=l; move.z/=l; }
+    const speedBase = ARM_SPEED_BASE; const speedRun = 7.2;
+    if(!ladderState.active){ const forward=new THREE.Vector3(Math.sin(yaw),0,Math.cos(yaw)); const right=new THREE.Vector3(Math.cos(yaw),0,-Math.sin(yaw)); const sprint = (l>0.9 ? speedRun : speedBase); const vx=forward.x*move.z + right.x*move.x; const vz=forward.z*move.z + right.z*move.x; player.velocity.x=vx*sprint; player.velocity.z=vz*sprint; player.wakeUp(); camFollow(player.position,1.0); } else { player.velocity.x=player.velocity.z=0; updateClimbMovement(move.z, dt); camFollow(player.position,1.0); }
 
-      const enemies=[]; const enemyMeshes=new THREE.Group(); scene.add(enemyMeshes);
-      function spawnEnemy(x,z){ const g=(soldierBase? soldierBase.clone(true): null) || (function(){ const tmp=new THREE.Group(); const body=new THREE.Mesh(new THREE.CapsuleGeometry(0.35,0.9,6,12), new THREE.MeshStandardMaterial({color:'#385'})); const head=new THREE.Mesh(new THREE.SphereGeometry(0.22,16,16), new THREE.MeshStandardMaterial({color:'#f0d2b1'})); head.position.y=1.1; tmp.add(body,head); return tmp; })(); g.position.set(x,0,z); enemyMeshes.add(g); const body=new CANNON.Body({ mass:70, material:matEnemy, shape:new CANNON.Sphere(0.38), position:new CANNON.Vec3(x,0.9,z), linearDamping:0.12 }); world.addBody(body); enemies.push({mesh:g, body, hp:100, fireCD:0, goal:new THREE.Vector3(x+ (Math.random()*20-10), 0, z+(Math.random()*20-10))}); }
+    setClimbUI();
 
-      const vehiclesGroup=new THREE.Group(); city.add(vehiclesGroup);
-      function labelOnCar(root, txt){ const c=document.createElement('canvas'); c.width=512; c.height=128; const x=c.getContext('2d'); x.fillStyle='rgba(10,16,34,0.95)'; x.fillRect(0,0,512,128); x.fillStyle='#d8e4ff'; x.font='900 82px system-ui'; x.textAlign='center'; x.textBaseline='middle'; x.fillText(txt,256,70); const t=new THREE.CanvasTexture(c); t.colorSpace=THREE.SRGBColorSpace; const m=new THREE.MeshBasicMaterial({map:t}); const plate=new THREE.Mesh(new THREE.PlaneGeometry(1.8,0.45), m); plate.rotation.x=-Math.PI; plate.position.set(0,1.2,0); root.add(plate); }
-      function cloneCar(tag){ const base = (tag==='police'||tag==='ambulance')? depot.refs['milk'] : (tag==='fire'? depot.refs['fire'] : (tag==='bus'? depot.refs['bus'] : (tag==='moto'? depot.refs['moto'] : (Math.random()<0.5? depot.refs['sedan'] : depot.refs['concept'])))); if(!base) return null; const car=base.clone(true); if(tag==='police') labelOnCar(car,'POLICE'); if(tag==='ambulance') labelOnCar(car,'AMBULANCE'); if(tag==='fire') labelOnCar(car,'FIRE'); return car; }
+    if(fireHeld){ const per=60.0/(currentStats.rpm); fireCd-=dt; while(fireCd<=0){ doShot(); fireCd+=per; } }
 
-      const parkedCars=new THREE.Group(); city.add(parkedCars);
-      function addParkedCars(){
-        for(let ix=0; ix<BLOCKS_X; ix++){
-          for(let iz=0; iz<BLOCKS_Z; iz++){
-            const x=xRoads[ix], xNext=xRoads[ix+1]; const z=zRoads[iz], zNext=zRoads[iz+1]; if(xNext==null||zNext==null) continue;
-            const n = 2 + (Math.random()<0.5?1:0);
-            for(let i=0;i<n;i++){
-              const side = Math.random()<0.5? -1:1; const along = THREE.MathUtils.lerp(z, zNext, Math.random()*0.8+0.1);
-              const car=cloneCar('civil'); if(!car) continue;
-              car.position.set(x + side*(ROAD/2 + SIDE*0.6), 0.0, along + (Math.random()*6-3));
-              car.rotation.y = side>0? Math.PI/2 : -Math.PI/2;
-              parkedCars.add(car);
-            }
-          }
-        }
-      }
+    enemies.forEach((e)=>{ if(e.dead) return; const toP = new THREE.Vector3(player.position.x-e.body.position.x, 0, player.position.z-e.body.position.z); const d = toP.length(); if(d>0.01){ toP.normalize(); const sp=d>12?2.4:1.6; e.body.velocity.x = toP.x*sp; e.body.velocity.z = toP.z*sp; } enemyTryFire(e, dt); e.root.position.set(e.body.position.x, 0, e.body.position.z); e.hpBar.position.set(e.body.position.x, 2.2, e.body.position.z); e.hpBar.lookAt(camera.position); });
 
-      function addFleet(inst){
-        const baseX = inst.pos.x - inst.w/2 + 8; const baseZ = inst.pos.z - inst.d/2 - 10;
-        const rows=2, cols=4; let idx=0;
-        for(let r=0;r<rows;r++) for(let c=0;c<cols;c++){
-          let tag='civil';
-          if(inst.type==='Police') tag='police';
-          else if(inst.type==='Hospital') tag='ambulance';
-          else if(inst.type==='Fire') tag='fire';
-          const car=cloneCar(tag) || cloneCar('civil'); if(!car) continue;
-          car.position.set(baseX + c*6.2, 0.0, baseZ - r*4.2); car.rotation.y=Math.PI/2; city.add(car); idx++; if(inst.type==='Mall' && idx>4) break;
-        }
-      }
+    // traffic move: v = 3x run speed
+    for(const c of trafficCars){ if(!c.speed){ c.speed = trafficTarget*(0.8+Math.random()*0.4); } const radPerSec = c.speed / ringR; c.angle = (c.angle + radPerSec*dt)%(Math.PI*2); const nx=Math.cos(c.angle)*ringR, nz=Math.sin(c.angle)*ringR; // obey red
+      let blocked=false; for(const tl of trafficLights){ const d=Math.hypot(nx-tl.pos.x, nz-tl.pos.z); if(d<6 && tl.state!=='green'){ blocked=true; break; } }
+      if(!blocked){ c.mesh.position.set(nx,0,nz); setHeading(c.mesh, c.angle); }
+    }
+    trafficLights.forEach(tl=>{ tl.timer+=dt; if(tl.timer>6){ tl.timer=0; tl.state = tl.state==='green'?'yellow': tl.state==='yellow'?'red':'green'; tl.lamps.Lg.material.color.set(tl.state==='green'?0x2ecc71:0x222222); tl.lamps.Ly.material.color.set(tl.state==='yellow'?0xf1c40f:0x222222); tl.lamps.Lr.material.color.set(tl.state==='red'?0xe74c3c:0x222222); } });
 
-      const movers=[];
-      function spawnMover(){
-        const side=Math.random()<0.5? 'x':'z';
-        if(side==='x'){
-          const iz = Math.floor(Math.random()*BLOCKS_Z);
-          const z=zRoads[iz]+(Math.random()*CELL - CELL/2)*0.02;
-          const car=cloneCar(Math.random()<0.15?'bus':'civil'); if(!car) return;
-          car.position.set(xRoads[0]-CELL/2,0.0,z); vehiclesGroup.add(car);
-          movers.push({mesh:car, dir:'x+', speed: (2+Math.random()*2)});
-        } else {
-          const ix = Math.floor(Math.random()*BLOCKS_X);
-          const x=xRoads[ix]+(Math.random()*CELL - CELL/2)*0.02;
-          const car=cloneCar(Math.random()<0.15?'bus':'civil'); if(!car) return;
-          car.position.set(x,0.0,zRoads[0]-CELL/2); car.rotation.y=Math.PI/2; vehiclesGroup.add(car);
-          movers.push({mesh:car, dir:'z+', speed: (2+Math.random()*2)});
-        }
-      }
+    updateEmergencyUnits(dt);
 
-      const lights=[]; const TL_RED=0, TL_GREEN=1;
-      function addTrafficLight(x,z,dir='x'){
-        const pole=new THREE.Mesh(new THREE.CylinderGeometry(0.15,0.15,4,8), new THREE.MeshStandardMaterial({color:'#333', roughness:0.6})); pole.position.set(x,2,z); city.add(pole);
-        const box=new THREE.Mesh(new THREE.BoxGeometry(0.5,1.4,0.4), new THREE.MeshStandardMaterial({color:'#222', roughness:0.7})); box.position.set(x+(dir==='x'?0.6:-0.6),3.0,z+(dir==='x'?-0.6:0.6)); city.add(box);
-        const lampR=new THREE.Mesh(new THREE.SphereGeometry(0.15,12,12), new THREE.MeshBasicMaterial({color:'#800'})); lampR.position.copy(box.position).add(new THREE.Vector3(0,0.3,0)); city.add(lampR);
-        const lampG=new THREE.Mesh(new THREE.SphereGeometry(0.15,12,12), new THREE.MeshBasicMaterial({color:'#060'})); lampG.position.copy(box.position).add(new THREE.Vector3(0,-0.3,0)); city.add(lampG);
-        lights.push({x,z,dir,state:TL_RED,t:Math.random()*6+2, R:lampR, G:lampG});
-      }
-      for(let ix=1; ix<BLOCKS_X; ix++) for(let iz=1; iz<BLOCKS_Z; iz++){ const x=xRoads[ix], z=zRoads[iz]; addTrafficLight(x-5,z,'x'); addTrafficLight(x,z-5,'z'); }
+    if(!waypoint && navGuide){ updateNavGuide(); }
 
-      function updateTraffic(dt){
-        lights.forEach(L=>{ L.t -= dt; if(L.t<=0){ L.state = (L.state===TL_RED? TL_GREEN: TL_RED); L.t = (L.state===TL_GREEN? 8: 6); L.R.material.color.set(L.state===TL_RED? '#f00':'#400'); L.G.material.color.set(L.state===TL_GREEN? '#0f0':'#030'); } });
-        movers.forEach(m=>{
-          const pos=m.mesh.position; let vx=0, vz=0; if(m.dir==='x+'||m.dir==='x-'){ vx = (m.dir==='x+'?1:-1)*m.speed; m.mesh.rotation.y = (m.dir==='x+'?0:Math.PI); } else { vz=(m.dir==='z+'?1:-1)*m.speed; m.mesh.rotation.y = (m.dir==='z+'?Math.PI/2:-Math.PI/2); }
-          let blocked=false; for(const L of lights){ const dx=Math.abs(pos.x-L.x), dz=Math.abs(pos.z-L.z); if(dx<3 && dz<3){ if(L.state===TL_RED) blocked=true; } }
-          if(blocked){ vx*=0.1; vz*=0.1; }
-          pos.x += vx*dt; pos.z += vz*dt;
-          const maxX=xRoads[xRoads.length-1]+CELL/2, minX=xRoads[0]-CELL/2; const maxZ=zRoads[zRoads.length-1]+CELL/2, minZ=zRoads[0]-CELL/2;
-          if(pos.x>maxX+20||pos.x<minX-20||pos.z>maxZ+20||pos.z<minZ-20){ vehiclesGroup.remove(m.mesh); m.dead=true; }
-        });
-        for(let i=movers.length-1;i>=0;i--) if(movers[i].dead) movers.splice(i,1);
-        if(movers.length<16 && depot.ready && Math.random()<0.04) spawnMover();
-      }
+    world.step(1/90, dt, 3);
+    updateTracers(dt);
 
-      function nearLadder(){ if(ladderState.active) return ladderState.ladder; const p=new THREE.Vector3(player.position.x,0,player.position.z); for(const L of ladders){ const d=Math.hypot(p.x-L.x, p.z-L.z); if(d<2.2) return L; } return null; }
-      function snapToLadder(L){ ladderState.active=true; ladderState.ladder=L; $('climbBtn').textContent='⬇ Leave Ladder'; player.velocity.set(0,0,0); player.angularVelocity.set(0,0,0); player.position.x=L.x; player.position.z=L.z; player.position.y=Math.max(player.position.y, L.y0+0.6); }
-      $('climbBtn').addEventListener('click',()=>{ if(ladderState.active){ detachFromLadder(); return; } const L=nearLadder(); if(!L) return; snapToLadder(L); vib(18); });
+    for(let i=0;i<activeGrenades.length;i++){ const g=activeGrenades[i]; g.fuse-=dt; const bp=g.body.position; g.mesh.position.set(bp.x,bp.y,bp.z); g.mesh.quaternion.set(g.body.quaternion.x,g.body.quaternion.y,g.body.quaternion.z,g.body.quaternion.w); if(bp.y<0.2 && g.body.velocity.length()<0.8){ g.fuse=Math.min(g.fuse,0.45); } if(g.fuse<=0){ explodeGrenade(g); activeGrenades.splice(i,1); i--; } }
+    for(let i=0;i<explosionFX.length;i++){ const fx=explosionFX[i]; fx.life-=dt; const norm=Math.max(0,fx.life/fx.maxLife||0); const prog=1-norm;
+      if(fx.core){ fx.core.scale.setScalar(1+prog*7.5); const mat=fx.core.material; if(mat){ mat.opacity=Math.max(0,0.98-prog*1.1); mat.needsUpdate=true; } }
+      if(fx.ring){ fx.ring.scale.setScalar(1+prog*18); const mat=fx.ring.material; if(mat){ mat.opacity=Math.max(0,0.9-prog); mat.needsUpdate=true; } }
+      if(fx.light){ fx.light.intensity=Math.max(0, fx.light.intensity - dt*32); }
+      if(fx.smoke){ const mat=fx.smoke.material; if(mat){ mat.opacity=Math.max(0,0.82-prog*0.82); } fx.smoke.scale.setScalar(5.6+prog*4.8); }
+      if(fx.shards){ for(const shard of fx.shards){ const vel=shard.velocity; vel.y -= 9.81*dt*0.6; shard.mesh.position.x += vel.x*dt; shard.mesh.position.y += vel.y*dt; shard.mesh.position.z += vel.z*dt; shard.mesh.rotation.x += shard.spin.x*dt; shard.mesh.rotation.y += shard.spin.y*dt; shard.mesh.rotation.z += shard.spin.z*dt; const mat=shard.mesh.material; if(mat){ mat.opacity=Math.max(0, mat.opacity - dt*1.2); mat.needsUpdate=true; } } }
+      if(fx.life<=0){ if(fx.core){ scene.remove(fx.core); fx.core.geometry.dispose(); fx.core.material.dispose(); }
+        if(fx.ring){ scene.remove(fx.ring); fx.ring.geometry.dispose(); fx.ring.material.dispose(); }
+        if(fx.light){ scene.remove(fx.light); }
+        if(fx.smoke){ scene.remove(fx.smoke); fx.smoke.material.dispose(); }
+        if(fx.shards){ fx.shards.forEach((sh)=>{ scene.remove(sh.mesh); sh.mesh.geometry.dispose(); sh.mesh.material.dispose(); }); }
+        explosionFX.splice(i,1); i--; }
+    }
 
-      const keys={}; addEventListener('keydown',e=>{ keys[e.key.toLowerCase()]=true; if(e.key===' ') jump(); if(e.key==='r') manualReload(); if(e.key==='e') tryEnterExitCar(); }); addEventListener('keyup',e=>{ keys[e.key.toLowerCase()]=false; });
-      const joyMove=$('joyMove'), shootPad=$('shootPad'), aimPad=$('aimPad');
-      function vib(ms){ if('vibrate' in navigator) navigator.vibrate(ms); }
-      function stick(dir){ const el = dir==='move'? joyMove : (dir==='aim'? aimPad : shootPad); const knob=el.querySelector('.knob'); let id=0, base=null, vec={x:0,y:0}; const onDown=(x,y)=>{ id=1; base={x,y}; knob.style.transform=`translate(-50%,-50%)`;}; const onMove=(x,y)=>{ if(!id) return; const r=120; const dx=x-base.x, dy=y-base.y; const len=Math.hypot(dx,dy)||1; const cl=Math.min(len,r); const nx=dx/len, ny=dy/len; knob.style.transform=`translate(${nx*cl-0.5}px,${ny*cl-0.5}px) translate(-50%,-50%)`; vec.x=cl/r*nx; vec.y=cl/r*ny; }; const onUp=()=>{ id=0; vec.x=vec.y=0; knob.style.transform='translate(-50%,-50%)'; };
-        el.addEventListener('touchstart',e=>{ const t=e.touches[0]; onDown(t.clientX,t.clientY); },{passive:true});
-        el.addEventListener('touchmove',e=>{ const t=e.touches[0]; onMove(t.clientX,t.clientY); },{passive:true});
-        el.addEventListener('touchend',()=>onUp(),{passive:true});
-        el.addEventListener('mousedown',e=>{ onDown(e.clientX,e.clientY); });
-        addEventListener('mousemove',e=>{ onMove(e.clientX,e.clientY); });
-        addEventListener('mouseup',()=>onUp());
-        return ()=>({x:vec.x,y:vec.y});
-      }
-      const getMove = stick('move'); const getAimB = stick('aim');
-      shootPad.addEventListener('touchstart',()=>{ shooting=true; vib(12); },{passive:true}); shootPad.addEventListener('touchend',()=>{ shooting=false; },{passive:true});
-      shootPad.addEventListener('mousedown',()=>{ shooting=true; vib(8); }); addEventListener('mouseup',()=>{ shooting=false; });
-      $('reloadMini').addEventListener('click',()=>manualReload());
+    try{ renderer.render(scene,camera); }catch(err){ }
+  }
+  renderer.setAnimationLoop(loop);
 
-      let controlModeA=true; $('modeA').addEventListener('click',()=>{ controlModeA=true; $('modeA').classList.add('active'); $('modeB').classList.remove('active'); aimPad.style.display='none'; }); $('modeB').addEventListener('click',()=>{ controlModeA=false; $('modeB').classList.add('active'); $('modeA').classList.remove('active'); aimPad.style.display='block'; });
+  renderer.getContext().canvas.addEventListener('webglcontextlost', (e)=>{ e.preventDefault(); });
+  renderer.getContext().canvas.addEventListener('webglcontextrestored', ()=>{ });
 
-      const zoomSlider=$('zoomSlider');
-      zoomSlider.addEventListener('input',()=>{ camDist = THREE.MathUtils.lerp(2.6, 7.2, (zoomSlider.value-1)/2); });
-
-      const setBox=$('settings'); $('settingsBtn').addEventListener('click',()=>{ setBox.style.display=setBox.style.display==='block'?'none':'block'; }); $('setClose').addEventListener('click',()=>{ setBox.style.display='none'; });
-      $('setLefty').checked=settings.lefty; $('setLefty').addEventListener('change',e=>{ document.body.classList.toggle('lefty', e.target.checked); settings.lefty=e.target.checked; }); document.body.classList.toggle('lefty', settings.lefty);
-      $('setAutoFire').checked=settings.autoFire; $('setAutoFire').addEventListener('change',e=>{ settings.autoFire=e.target.checked; });
-      $('setAimAssist').checked=settings.aimAssist; $('setAimAssist').addEventListener('change',e=>{ settings.aimAssist=e.target.checked; });
-      $('setInvertY').checked=settings.invertY; $('setInvertY').addEventListener('change',e=>{ settings.invertY=e.target.checked; });
-      $('setGyro').checked=settings.gyro; $('setGyro').addEventListener('change',e=>{ settings.gyro=e.target.checked; });
-      $('setShadows').checked=settings.shadows; $('setShadows').addEventListener('change',e=>{ settings.shadows=e.target.checked; location.reload(); });
-      $('setSensA').value=settings.sensA; $('setSensA').addEventListener('input',e=>{ LOOK_SENS_A=parseFloat(e.target.value); });
-      $('setSensBX').value=settings.sensBX; $('setSensBX').addEventListener('input',e=>{ AIM_SENS_B_X=parseFloat(e.target.value); });
-      $('setSensBY').value=settings.sensBY; $('setSensBY').addEventListener('input',e=>{ AIM_SENS_B_Y=parseFloat(e.target.value); });
-      $('setDpr').value=settings.dpr; $('setDpr').addEventListener('input',e=>{ settings.dpr=parseFloat(e.target.value); dprScaleTarget=settings.dpr; if(!settings.autoResolution) dprRuntime=settings.dpr; fit(); });
-      $('setCross').value=getComputedStyle($('crosshair')).getPropertyValue('--crossSize').replace('px','')||30; $('setCross').addEventListener('input',e=>{ $('crosshair').style.setProperty('--crossSize', e.target.value+'px'); });
-      $('setLow').addEventListener('click',()=>{ settings.dpr=0.72; settings.shadows=false; settings.autoResolution=true; dprScaleTarget=settings.dpr; allowShadows=false; renderer.shadowMap.enabled=false; fit(); });
-      $('setHigh').addEventListener('click',()=>{ settings.dpr=1.0; settings.shadows=true; settings.autoResolution=false; dprScaleTarget=settings.dpr; dprRuntime=settings.dpr; allowShadows=true; renderer.shadowMap.enabled=true; fit(); });
-      $('setSave').addEventListener('click',()=>{ store.set('tirana_settings', settings); vib(12); });
-
-      let hp=100; function hurt(d){ hp=Math.max(0,hp-d); $('healthfill').style.width=hp+'%'; const h=$('hurt'); h.style.opacity='1'; setTimeout(()=>h.style.opacity='0', 120); if(hp<=0) gameOver(false); }
-      function gameOver(win){ const r=$('result'); r.style.display='block'; r.textContent = win? '🏆 FITORE!': '☠️ HUMBJE'; setTimeout(()=>location.reload(), 3500); }
-
-      const driveCars=[];
-      function spawnDriveCar(x,z){ const car = (depot.refs['sedan']? depot.refs['sedan'].clone(true): null); if(!car){ const g=new THREE.Group(); const b=new THREE.Mesh(new THREE.BoxGeometry(3.8,1,1.8), new THREE.MeshStandardMaterial({color:'#2b9'})); g.add(b); placeOnGround(g,0); return {mesh:g}; } car.position.set(x,0.0,z); city.add(car); const obj={mesh:car}; driveCars.push(obj); return obj; }
-      let playerCar=null; let inCar=false; let carSpeed=0; let carYaw=0; const useCarBtn=$('useCarBtn'); const exitCarBtn=$('exitCarBtn'); const hornBtn=$('hornBtn'); const brakeBtn=$('brakeBtn');
-      function nearCar(){ const p=new THREE.Vector3(player.position.x,0,player.position.z); for(const c of driveCars){ if(p.distanceTo(new THREE.Vector3(c.mesh.position.x,0,c.mesh.position.z))<3) return c; } return null; }
-      function tryEnterExitCar(){ if(ladderState.active){ detachFromLadder(); }
-        if(inCar){ inCar=false; exitCarBtn.style.display=hornBtn.style.display=brakeBtn.style.display='none'; useCarBtn.style.display='block'; player.position.set(playerCar.mesh.position.x+1, 1.0, playerCar.mesh.position.z+1); }
-        else { const c=nearCar(); if(!c) return; playerCar=c; inCar=true; useCarBtn.style.display='none'; exitCarBtn.style.display=hornBtn.style.display=brakeBtn.style.display='block'; vib(18); }
-      }
-      useCarBtn.addEventListener('click',tryEnterExitCar); exitCarBtn.addEventListener('click',tryEnterExitCar); hornBtn.addEventListener('click',()=>{ burstNoise({dur:0.2,freq:800,gain:0.2}); });
-      function updateCarControl(dt){ if(!inCar||!playerCar) return; const mv=getMove(); const accel = (mv.y<0?1:-1) * Math.abs(mv.y) * 12; carSpeed += accel*dt; carSpeed *= 0.98; carYaw -= mv.x * 1.8 * dt * (carSpeed>=0?1:-1); const forward=new THREE.Vector3(Math.sin(carYaw),0,Math.cos(carYaw)); playerCar.mesh.position.addScaledVector(forward, carSpeed*dt); playerCar.mesh.rotation.y = -carYaw; const camPos=playerCar.mesh.position.clone().add(new THREE.Vector3(-8*Math.sin(carYaw), 5, -8*Math.cos(carYaw))); camera.position.lerp(camPos,0.1); camera.lookAt(playerCar.mesh.position); }
-
-      function weaponStats(){ return ARMORY.find(a=>a.key===currentWeaponKey)?.stats; }
-      function manualReload(){ const st=weaponStats(); if(!st) return; if(ammoInMag>=st.mag || reserveAmmo<=0) return; sfxReload(); reloadTime = st.reload; }
-      function canFire(){ const st=weaponStats(); if(!st) return false; const now=performance.now(); const cd = 60000/st.rpm; return now-lastShot>cd && reloadTime<=0 && ammoInMag>0; }
-      function shoot(){ if(!canFire()) return; const st=weaponStats(); lastShot=performance.now(); ammoInMag--; updateAmmoHUD(); sfxGun(currentWeaponKey); vib(8);
-        const dir = new THREE.Vector3(Math.sin(yaw), Math.sin(pitch)*0.8, Math.cos(yaw)).normalize();
-        const spread=st.spread; dir.x += (Math.random()-0.5)*spread; dir.y += (Math.random()-0.5)*spread*0.6; dir.z += (Math.random()-0.5)*spread; dir.normalize();
-        const origin = new THREE.Vector3(player.position.x, player.position.y+1.2, player.position.z);
-        const hit = raycastEnemies(origin, dir, 120);
-        if(hit){ const e=enemies[hit.idx]; e.hp -= st.dmg; flashHit(); if(e.hp<=0){ killEnemy(hit.idx); } }
-      }
-      function flashHit(){ const h=$('hit'); h.style.opacity='1'; setTimeout(()=>h.style.opacity='0',120); }
-      function raycastEnemies(o, d, max){ let best=null; enemies.forEach((e,idx)=>{ if(!e) return; const to=new THREE.Vector3(e.body.position.x-o.x, e.body.position.y-o.y, e.body.position.z-o.z); const proj = to.x*d.x + to.y*d.y + to.z*d.z; if(proj<0||proj>max) return; const closest = new THREE.Vector3(o.x + d.x*proj, o.y+d.y*proj, o.z+d.z*proj); const dist = closest.distanceTo(new THREE.Vector3(e.body.position.x,e.body.position.y,e.body.position.z)); if(dist<0.6){ best={idx,dist}; } }); return best; }
-      function killEnemy(i){ const e=enemies[i]; if(!e) return; enemyMeshes.remove(e.mesh); world.removeBody(e.body); enemies[i]=null; if(enemies.filter(Boolean).length===0) gameOver(true); }
-
-      function updateEnemies(dt){
-        enemies.forEach((e)=>{
-          if(!e) return;
-          const toP = new THREE.Vector3(player.position.x - e.body.position.x, 0, player.position.z - e.body.position.z);
-          const dist= toP.length();
-          if(dist>2.5){ toP.normalize(); e.body.velocity.x = toP.x*2.2; e.body.velocity.z = toP.z*2.2; e.mesh.position.set(e.body.position.x, 0, e.body.position.z); e.mesh.lookAt(player.position.x, 0, player.position.z); }
-          e.fireCD -= dt; if(dist<28 && e.fireCD<=0){ e.fireCD = 0.4 + Math.random()*0.6; if(Math.random()<0.6) hurt(6+Math.random()*4); }
-        });
-      }
-
-      function updatePlayerMove(dt){ if(inCar) return; const mv=getMove(); const speed=ladderState.active?0:6.2; const vx = ( (keys['a']?-1:0) + (keys['d']?1:0) + mv.x ) * speed; const vz = ( (keys['w']?-1:0) + (keys['s']?1:0) + -mv.y ) * speed; const back=new THREE.Vector3(Math.sin(yaw),0,Math.cos(yaw)); const right=new THREE.Vector3(back.z,0,-back.x);
-        if(ladderState.active){ const L=ladderState.ladder; const climbInput = ((keys['w']?-1:0) + (keys['s']?1:0) + -mv.y);
-          const climbSpeed = 2.6;
-          const nextY = THREE.MathUtils.clamp(player.position.y + climbInput*climbSpeed*dt, L.y0+0.6, L.y1+1.2);
-          player.position.y = nextY;
-          player.position.x = L.x; player.position.z = L.z;
-          player.velocity.set(0,0,0); player.angularVelocity.set(0,0,0); player.force?.set?.(0,0,0);
-          if((nextY>=L.y1+0.95 && climbInput>0) || climbInput>0.4){ detachFromLadder(); player.position.y = L.y1+1.0; player.position.x += back.x*1.1; player.position.z += back.z*1.1; }
-          if(nextY<=L.y0+0.6 && climbInput<-0.2){ detachFromLadder(); player.position.y = L.y0+0.6; }
-          return;
-        }
-        const v = new CANNON.Vec3(right.x*vx + back.x*vz, player.velocity.y, right.z*vx + back.z*vz); player.velocity.copy(v);
-      }
-      let dragActive=false, dragLast=null;
-      function onDrag(e){ const p = {x: (e.touches? e.touches[0].clientX : e.clientX), y: (e.touches? e.touches[0].clientY : e.clientY)}; if(!dragActive){ dragActive=true; dragLast=p; return; } const dx=p.x - dragLast.x, dy=p.y - dragLast.y; dragLast=p; yaw -= dx * LOOK_SENS_A * 0.01; pitch += (settings.invertY?-1:1) * -dy * LOOK_SENS_A * 0.008; clampPitch(); }
-      function stopDrag(){ dragActive=false; }
-      if(isTouch){ addEventListener('touchstart',onDrag,{passive:true}); addEventListener('touchmove',onDrag,{passive:true}); addEventListener('touchend',stopDrag,{passive:true}); }
-      else { addEventListener('mousedown',onDrag); addEventListener('mousemove',onDrag); addEventListener('mouseup',stopDrag); }
-
-      buildGallery(); await selectWeapon('Uzi');
-
-      function proximityUI(){ const ladderCandidate=nearLadder(); const showLadder = ladderState.active || !!ladderCandidate; $('climbBtn').style.display = showLadder? 'block':'none'; $('climbBtn').textContent = ladderState.active? '⬇ Leave Ladder' : '⬆ Climb Ladder'; const C=nearCar(); $('useCarBtn').style.display = (!inCar && C)? 'block':'none'; $('exitCarBtn').style.display = inCar? 'block':'none'; $('hornBtn').style.display = inCar? 'block':'none'; $('brakeBtn').style.display = inCar? 'block':'none'; }
-
-      const mini=$('mini'); let fpsSamp=0, fpsAcc=0; const fpsWindow=[];
-      function autoTuneResolution(avg){ if(!settings.autoResolution) return; if(avg < TARGET_FPS*0.82 && dprRuntime>0.62){ dprRuntime = Math.max(0.6, dprRuntime-0.05); fit(); mini.dataset.scale=(dprRuntime).toFixed(2); }
-        else if(avg > TARGET_FPS*1.05 && dprRuntime < dprScaleTarget){ dprRuntime = Math.min(dprScaleTarget, dprRuntime+0.04); fit(); mini.dataset.scale=(dprRuntime).toFixed(2); }
-      }
-
-      await Promise.all([buildDepot(), loadSoldier()]);
-      addParkedCars();
-      institutions.forEach(addFleet);
-      for(let i=0;i<14;i++) spawnMover();
-      for(let i=0;i<14;i++){ const bx = startX + Math.floor(Math.random()*BLOCKS_X)*CELL + (Math.random()*PLOT - PLOT/2); const bz = startZ + Math.floor(Math.random()*BLOCKS_Z)*CELL + (Math.random()*PLOT - PLOT/2); spawnEnemy(bx,bz); }
-      const nearPolice = institutions.find(i=>i.type==='Police'); const pcPos = nearPolice? nearPolice.pos.clone().add(new THREE.Vector3(8,0,-nearPolice.d/2-12)) : new THREE.Vector3(startX + 1*CELL - 20, 0, startZ + 1*CELL - 20); playerCar = spawnDriveCar(pcPos.x, pcPos.z);
-
-      function diag(msg){ const el=$('diag'); el.textContent = `Diagnostics: ${msg}`; }
-      function runSelfTests(){
-        const checks=[]; const ok=(name,pass,note='')=>checks.push({name,pass,note});
-        ok('Renderer OK', !!renderer.getContext());
-        ok('Depot ready', depot.ready===true);
-        ok('At least 3 vehicles', Object.keys(depot.refs).length>=3, `count=${Object.keys(depot.refs).length}`);
-        ok('Weapons listed', ARMORY.length===6);
-        ok('Dynamic DPR', typeof dprRuntime==='number');
-        const pass=checks.filter(c=>c.pass).length; diag(`${pass}/${checks.length} passed • ${checks.map(c=>`${c.pass?'✅':'❌'} ${c.name}`).join(' • ')}`);
-      }
-      runSelfTests();
-
-      let last=performance.now();
-      function loop(){ const now=performance.now(); const dt=Math.min((now-last)/1000, 0.033); last=now;
-        world.step(1/PHYS_HZ, dt, 3);
-        if(controlModeA===false){ const aim=getAimB(); yaw -= aim.x * (AIM_SENS_B_X*1200); pitch += (settings.invertY?-1:1) * -aim.y * (AIM_SENS_B_Y*1200); clampPitch(); }
-        updatePlayerMove(dt);
-        updateEnemies(dt);
-        updateTraffic(dt);
-        updateCarControl(dt);
-        if(reloadTime>0){ reloadTime -= dt; if(reloadTime<=0){ const st=weaponStats(); const need = (st.mag - ammoInMag); const take = Math.min(need, reserveAmmo); ammoInMag += take; reserveAmmo -= take; updateAmmoHUD(); } }
-        if(!inCar){ const auto = settings.autoFire && controlModeA? shooting : shooting; if(auto && canFire()) shoot(); }
-        if(!inCar) camFollow(player.position, 1);
-        const a0 = new THREE.Vector3(0,0,0); const a1 = new THREE.Vector3(0,0,-10); a1.applyEuler(new THREE.Euler(-pitch, -yaw, 0)); a1.add(new THREE.Vector3(player.position.x, player.position.y+1.2, player.position.z)); a0.copy(new THREE.Vector3(player.position.x, player.position.y+1.2, player.position.z));
-        aimLine.position.copy(a0); aimDot.position.copy(a1);
-        proximityUI(); fpsSamp++; fpsAcc += 1/dt; fpsWindow.push(1/dt); if(fpsWindow.length>20) fpsWindow.shift(); const avgFps = fpsWindow.reduce((a,b)=>a+b,0)/fpsWindow.length;
-        if(fpsSamp>=10){ mini.textContent = `fps: ${(fpsAcc/fpsSamp|0)} • scale ${dprRuntime.toFixed(2)}`; fpsSamp=0; fpsAcc=0; }
-        autoTuneResolution(avgFps);
-        renderer.render(scene,camera);
-        requestAnimationFrame(loop);
-      }
-      loop();
-
-      $('resetBtn').addEventListener('click',()=>location.reload());
-
-    })();
-  </script>
+  setTimeout(()=>{
+    console.assert(!!document.getElementById('shootPad'), 'shootPad exists');
+    console.assert(typeof BLOCKS_X==='number' && typeof BLOCKS_Z==='number', 'grid dims defined');
+    console.assert(ARMORY.length>=6 && FIRE_MODES.size===ARMORY.length, 'armory + firemodes init');
+    console.assert(getComputedStyle(document.getElementById('crosshair')).getPropertyValue('--aimColor').trim()!=='', 'crosshair color var');
+    console.assert(typeof GLTFLoader==='function', 'GLTFLoader OK');
+  }, 800);
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- revert Tirana 2040 public build to the classic HUD arrangement and styling
- remove the diagnostics overlay and touch overrides that added extra on-screen text
- restore the previous renderer configuration and FPS display behaviour

## Testing
- not run (HTML only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69170e8128108325aa925df7368f30f4)