### PR TITLE
Improve Pool Royale broadcast view and AI

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -74,6 +74,9 @@ function pocketEntry (pocket, radius, width, height) {
   }
 }
 
+const PRO_MONTE_CARLO_SAMPLES = 48
+const POSITIONING_LOOKAHEAD = 3
+
 function currentGroup (state) {
   let g = state.myGroup
   if (!g || g === 'UNASSIGNED') {
@@ -144,6 +147,31 @@ function nextTargetsAfter (targetId, req) {
     return cloned.filter(b => b.id !== 8)
   }
   return cloned
+}
+
+function cueCushionPenalty (point, state, radius) {
+  if (!point) return 0
+  const clearanceX = Math.min(point.x, state.width - point.x)
+  const clearanceY = Math.min(point.y, state.height - point.y)
+  const minClear = Math.min(clearanceX, clearanceY)
+  if (minClear >= radius * 2) return 0
+  return 1 - Math.min(minClear / (radius * 2), 1)
+}
+
+function positioningAdvantage (req, cueAfter, nextTargets, balls) {
+  if (!cueAfter || !nextTargets || nextTargets.length === 0) return 0
+  const radius = req.state.ballRadius
+  let best = 0
+  const sampleCount = Math.min(nextTargets.length, POSITIONING_LOOKAHEAD)
+  for (let i = 0; i < sampleCount; i++) {
+    const next = nextTargets[i]
+    if (!next) continue
+    if (pathBlocked(cueAfter, next, balls, [0, next.id], radius, 1.05)) continue
+    const d = dist(cueAfter, next)
+    const score = 1 - Math.min(d / (radius * 40), 1)
+    if (score > best) best = score
+  }
+  return best
 }
 
 // Identify target/pocket pairs that satisfy core aiming criteria:
@@ -236,7 +264,7 @@ export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
 // Rough Monte Carlo estimate of potting probability by jittering the cue
 // aim slightly and checking if paths remain clear. This models human
 // imprecision and rewards shorter, straighter shots.
-function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 20) {
+function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = PRO_MONTE_CARLO_SAMPLES) {
   const r = req.state.ballRadius
   const baseAngle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
   const distCG = dist(cue, ghost)
@@ -294,6 +322,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     const next = nextTargets[0]
     nextScore = 1 - Math.min(dist(cueAfter, next) / maxD, 1)
   }
+  const positionBonus = positioningAdvantage(req, cueAfter, nextTargets, balls)
   const risk = req.state.pockets.some(p => dist(cueAfter, p) < r * 1.2) ? 1 : 0
   const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
   const potVec = { x: entry.x - target.x, y: entry.y - target.y }
@@ -305,11 +334,18 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   if (strict && (centerAlign < 0.5 || viewScore < 0.3)) {
     return null
   }
+  const cushionPenalty = cueCushionPenalty(cueAfter, req.state, r)
   const quality = Math.max(
     0,
     Math.min(
       1,
-      0.35 * potChance + 0.25 * centerAlign + 0.2 * viewScore + 0.1 * nextScore + 0.1 * nearHole - 0.2 * risk
+      0.4 * potChance +
+        0.2 * centerAlign +
+        0.15 * viewScore +
+        0.15 * Math.max(nextScore, positionBonus) +
+        0.1 * nearHole -
+        0.15 * risk -
+        0.1 * cushionPenalty
     )
   )
   const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
@@ -321,7 +357,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     targetPocket: entry,
     aimPoint: ghost,
     quality,
-    rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} nh=${nearHole.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)}`,
+    rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} nh=${nearHole.toFixed(2)} np=${nextScore.toFixed(2)} pos=${positionBonus.toFixed(2)} risk=${risk.toFixed(2)}`,
     nextScore,
     hasNext
   }
@@ -356,13 +392,15 @@ export function planShot (req) {
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity
   let best = null
 
-  const powers = [0.5, 0.7, 0.85]
+  const powers = [0.45, 0.6, 0.75, 0.9]
   const spins = [
     { top: 0, side: 0, back: 0 },
-    { top: 0.3, side: 0, back: -0.3 },
+    { top: 0.3, side: 0, back: -0.25 },
     { top: -0.3, side: 0.3, back: 0 },
     { top: -0.3, side: -0.3, back: 0 },
-    { top: 0, side: 0.3, back: 0 }
+    { top: 0.15, side: 0.25, back: -0.1 },
+    { top: 0, side: 0.4, back: 0 },
+    { top: -0.4, side: 0, back: 0.25 }
   ]
 
   // first, gather candidate target/pocket pairs meeting strict criteria
@@ -410,6 +448,12 @@ export function planShot (req) {
           )
           if (overlap) continue
           placements.push(cand)
+        }
+        if (placements.length === 0) {
+          const safeY = typeof req.state.baulkLineY === 'number'
+            ? Math.max(req.state.baulkLineY + r * 2, r * 2)
+            : r * 6
+          placements.push({ x: req.state.width / 2, y: safeY })
         }
       } else {
         const cue = req.state.balls.find(b => b.id === 0)

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1806,7 +1806,7 @@ const CHROME_COLOR_OPTIONS = Object.freeze([
 
 const DEFAULT_CLOTH_COLOR_ID = 'freshGreen';
 const CLOTH_COLOR_OPTIONS = Object.freeze([
-  { id: 'freshGreen', label: 'Fresh Green', color: 0x3fba73 }
+  { id: 'freshGreen', label: 'Fresh Green', color: 0x2d7f4b }
 ]);
 
 const FRAME_RATE_STORAGE_KEY = 'snookerFrameRate';
@@ -1815,8 +1815,8 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     id: 'balanced60',
     label: '60 Hz Smooth',
     fps: 60,
-    resolution: '1920×1080',
-    description: 'Balanced frame pacing tuned for modern mobile displays.'
+    resolution: '1280×720',
+    description: 'Balanced frame pacing tuned for modern mobile HD displays.'
   },
   {
     id: 'fullHd',
@@ -3444,6 +3444,15 @@ const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_MARGIN_WIDTH = BALL_R * 10;
 const BROADCAST_MARGIN_LENGTH = BALL_R * 10;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
+const USE_STATIC_BROADCAST_CAMERA = true;
+const STATIC_BROADCAST_HEIGHT = TABLE_Y + TABLE.THICK + BALL_R * 9.6;
+const STATIC_BROADCAST_LOOK_TARGET = new THREE.Vector3(
+  0,
+  TABLE_Y + TABLE.THICK * 0.35,
+  0
+);
+const STATIC_BROADCAST_DISTANCE_PAD = 1.04;
+const STATIC_BROADCAST_SWITCH_THRESHOLD = BALL_R * 2.4;
 const CAMERA_ZOOM_PROFILES = Object.freeze({
   default: Object.freeze({ cue: 0.96, broadcast: 0.98, margin: 0.99 }),
   nearLandscape: Object.freeze({ cue: 0.94, broadcast: 0.97, margin: 0.99 }),
@@ -3549,6 +3558,23 @@ const AI_SHOT_PREVIEW_DELAY_MS = 450;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const signed = (value, fallback = 1) =>
   value > 0 ? 1 : value < 0 ? -1 : fallback;
+const isCueBall = (ball) => {
+  if (!ball) return false;
+  if (ball.isCue) return true;
+  if (ball.id === 0) return true;
+  if (typeof ball.id === 'string') {
+    const normalized = ball.id.toLowerCase();
+    return normalized === 'cue' || normalized === 'cue_ball';
+  }
+  return false;
+};
+const findCueBall = (balls = []) => balls.find((ball) => isCueBall(ball));
+const formatMatchTimer = (totalSeconds = 0) => {
+  const seconds = Math.max(0, Math.floor(totalSeconds));
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+};
 const resolveShortRailBroadcastDirection = ({
   pocketCenter = null,
   approachDir = null,
@@ -7668,6 +7694,10 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   const pocketCamerasRef = useRef(new Map());
   const broadcastCamerasRef = useRef(null);
   const activeRenderCameraRef = useRef(null);
+  const staticBroadcastViewRef = useRef({
+    lastSide: 1,
+    distance: SHORT_RAIL_CAMERA_DISTANCE
+  });
   const pocketSwitchIntentRef = useRef(null);
   const lastPocketBallRef = useRef(null);
   const cameraBlendRef = useRef(ACTION_CAMERA_START_BLEND);
@@ -7701,6 +7731,17 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
   useEffect(() => {
     timerValueRef.current = timer;
   }, [timer]);
+  const [matchSeconds, setMatchSeconds] = useState(0);
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const startedAt = Date.now();
+    setMatchSeconds(0);
+    const id = window.setInterval(() => {
+      setMatchSeconds(Math.floor((Date.now() - startedAt) / 1000));
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, []);
+  const matchClock = useMemo(() => formatMatchTimer(matchSeconds), [matchSeconds]);
   const spinRef = useRef({ x: 0, y: 0 });
   const spinRequestRef = useRef({ x: 0, y: 0 });
   const resetSpinRef = useRef(() => {});
@@ -9415,7 +9456,39 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           );
         };
 
+        const resolveStaticBroadcastFrame = () => {
+          const cueBall = findCueBall(ballsRef.current || []);
+          const state = staticBroadcastViewRef.current || { lastSide: 1 };
+          let side = state.lastSide ?? 1;
+          const cueAxis = cueBall?.pos?.y;
+          if (Number.isFinite(cueAxis) && Math.abs(cueAxis) > STATIC_BROADCAST_SWITCH_THRESHOLD) {
+            side = cueAxis >= 0 ? 1 : -1;
+          }
+          state.lastSide = side;
+          const baseDistance =
+            computeShortRailBroadcastDistance(camera) * STATIC_BROADCAST_DISTANCE_PAD;
+          state.distance = baseDistance;
+          const position = new THREE.Vector3(0, STATIC_BROADCAST_HEIGHT, side * baseDistance);
+          const target = STATIC_BROADCAST_LOOK_TARGET.clone();
+          return { position, target, side };
+        };
+
         const updateCamera = () => {
+          if (USE_STATIC_BROADCAST_CAMERA) {
+            const broadcastFrame = resolveStaticBroadcastFrame();
+            camera.position.copy(broadcastFrame.position);
+            camera.lookAt(broadcastFrame.target);
+            lastCameraTargetRef.current.copy(broadcastFrame.target);
+            updateBroadcastCameras({
+              railDir: broadcastFrame.side,
+              targetWorld: broadcastFrame.target.clone(),
+              focusWorld: broadcastFrame.target.clone(),
+              lerp: 1
+            });
+            updatePocketCameraState(false);
+            activeRenderCameraRef.current = camera;
+            return camera;
+          }
           let renderCamera = camera;
           let lookTarget = null;
           let broadcastArgs = {
@@ -14233,6 +14306,23 @@ function PoolRoyaleGame({ variantKey, tableSizeKey }) {
           Scroll and click to change the cue
         </div>
       )}
+
+      <div className="pointer-events-none absolute top-4 left-1/2 z-40 -translate-x-1/2">
+        <div
+          className="pointer-events-auto flex items-center gap-3 rounded-full border border-emerald-400/50 bg-black/75 px-5 py-2 text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur"
+          style={{
+            transform: `scale(${uiScale})`,
+            transformOrigin: 'top center'
+          }}
+        >
+          <span className="text-[10px] uppercase tracking-[0.45em] text-emerald-200/80">
+            Match Time
+          </span>
+          <span className="font-mono text-lg tracking-[0.3em] text-emerald-100">
+            {matchClock}
+          </span>
+        </div>
+      </div>
 
       <div className="absolute bottom-4 left-4 z-50 flex flex-col items-start gap-2">
         <button


### PR DESCRIPTION
## Summary
- restore the classic green cloth option and adjust the 60 Hz preset to target HD output
- lock the Pool Royale camera to stationary short-rail broadcast angles, add a visible match timer, and display the timer UI
- enhance the generic pool AI heuristics/placement logic and copy the updated planner to the public bundle

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dc6accabc832894a767d624c9df37)