### PR TITLE
Handle missing balance data in game lobbies

### DIFF
--- a/webapp/src/pages/Games/AirHockeyLobby.jsx
+++ b/webapp/src/pages/Games/AirHockeyLobby.jsx
@@ -10,6 +10,7 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 export default function AirHockeyLobby() {
   const navigate = useNavigate();
@@ -32,7 +33,7 @@ export default function AirHockeyLobby() {
     try {
       accountId = await ensureAccountId();
       const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
+      if (isBalanceInsufficient(balRes, stake.amount)) {
         alert('Insufficient balance');
         return;
       }

--- a/webapp/src/pages/Games/BlackJackLobby.jsx
+++ b/webapp/src/pages/Games/BlackJackLobby.jsx
@@ -5,6 +5,7 @@ import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { ensureAccountId, getTelegramId, getTelegramPhotoUrl, getTelegramUsername } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -32,7 +33,7 @@ export default function BlackJackLobby() {
     try {
       accountId = await ensureAccountId();
       const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
+      if (isBalanceInsufficient(balRes, stake.amount)) {
         alert('Insufficient balance');
         return;
       }

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -9,6 +9,7 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -34,7 +35,7 @@ export default function ChessBattleRoyalLobby() {
     try {
       accountId = await ensureAccountId();
       const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
+      if (isBalanceInsufficient(balRes, stake.amount)) {
         alert('Insufficient balance');
         return;
       }

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -6,6 +6,7 @@ import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { ensureAccountId, getTelegramId, getTelegramPhotoUrl, getTelegramUsername } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -36,7 +37,7 @@ export default function DominoRoyalLobby() {
     try {
       accountId = await ensureAccountId();
       const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
+      if (isBalanceInsufficient(balRes, stake.amount)) {
         alert('Insufficient balance');
         return;
       }

--- a/webapp/src/pages/Games/FallingBallLobby.jsx
+++ b/webapp/src/pages/Games/FallingBallLobby.jsx
@@ -5,6 +5,7 @@ import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { ensureAccountId, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -33,7 +34,7 @@ export default function FallingBallLobby() {
     try {
       accountId = await ensureAccountId();
       const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
+      if (isBalanceInsufficient(balRes, stake.amount)) {
         alert('Insufficient balance');
         return;
       }

--- a/webapp/src/pages/Games/FreeKickLobby.jsx
+++ b/webapp/src/pages/Games/FreeKickLobby.jsx
@@ -10,6 +10,7 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 export default function FreeKickLobby() {
   const navigate = useNavigate();
@@ -37,7 +38,7 @@ export default function FreeKickLobby() {
       try {
         accountId = await ensureAccountId();
         const balRes = await getAccountBalance(accountId);
-        if ((balRes.balance || 0) < stake.amount) {
+        if (isBalanceInsufficient(balRes, stake.amount)) {
           alert('Insufficient balance');
           return;
         }

--- a/webapp/src/pages/Games/GoalRushLobby.jsx
+++ b/webapp/src/pages/Games/GoalRushLobby.jsx
@@ -10,6 +10,7 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 export default function GoalRushLobby() {
   const navigate = useNavigate();
@@ -37,7 +38,7 @@ export default function GoalRushLobby() {
       try {
         accountId = await ensureAccountId();
         const balRes = await getAccountBalance(accountId);
-        if ((balRes.balance || 0) < stake.amount) {
+        if (isBalanceInsufficient(balRes, stake.amount)) {
           alert('Insufficient balance');
           return;
         }

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -22,6 +22,7 @@ import {
   getTelegramId
 } from '../../utils/telegram.js';
 import { canStartGame } from '../../utils/lobby.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 export default function Lobby() {
   const { game } = useParams();
@@ -282,7 +283,7 @@ export default function Lobby() {
       try {
         const accountId = await ensureAccountId();
         const balRes = await getAccountBalance(accountId);
-        if ((balRes.balance || 0) < stake.amount) {
+        if (isBalanceInsufficient(balRes, stake.amount)) {
           alert('Insufficient balance');
           return;
         }

--- a/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
@@ -10,6 +10,7 @@ import {
 } from '../../utils/telegram.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -42,7 +43,7 @@ export default function LudoBattleRoyalLobby() {
     try {
       accountId = await ensureAccountId();
       const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
+      if (isBalanceInsufficient(balRes, stake.amount)) {
         alert('Insufficient balance');
         return;
       }

--- a/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
@@ -5,6 +5,7 @@ import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { ensureAccountId, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -33,7 +34,7 @@ export default function MurlanRoyaleLobby() {
     try {
       accountId = await ensureAccountId();
       const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
+      if (isBalanceInsufficient(balRes, stake.amount)) {
         alert('Insufficient balance');
         return;
       }

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -12,6 +12,7 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import poolOpponents from '../../data/poolOpponents.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 export default function PoolRoyaleLobby() {
   const navigate = useNavigate();
@@ -119,7 +120,7 @@ export default function PoolRoyaleLobby() {
       try {
         accountId = await ensureAccountId();
         const balRes = await getAccountBalance(accountId);
-        if ((balRes.balance || 0) < stake.amount) {
+        if (isBalanceInsufficient(balRes, stake.amount)) {
           alert('Insufficient balance');
           return;
         }

--- a/webapp/src/pages/Games/SnookerLobby.jsx
+++ b/webapp/src/pages/Games/SnookerLobby.jsx
@@ -10,6 +10,7 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 const FEATURED_TABLES = Object.freeze([
   {
@@ -74,7 +75,7 @@ export default function SnookerLobby() {
       try {
         accountId = await ensureAccountId();
         const balanceResponse = await getAccountBalance(accountId);
-        if ((balanceResponse.balance || 0) < stake.amount) {
+        if (isBalanceInsufficient(balanceResponse, stake.amount)) {
           alert('Insufficient balance');
           return;
         }

--- a/webapp/src/pages/Games/TableTennisLobby.jsx
+++ b/webapp/src/pages/Games/TableTennisLobby.jsx
@@ -10,6 +10,7 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 export default function TableTennisLobby() {
   const navigate = useNavigate();
@@ -32,7 +33,7 @@ export default function TableTennisLobby() {
     try {
       accountId = await ensureAccountId();
       const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
+      if (isBalanceInsufficient(balRes, stake.amount)) {
         alert('Insufficient balance');
         return;
       }

--- a/webapp/src/pages/Games/TennisBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/TennisBattleRoyalLobby.jsx
@@ -10,6 +10,7 @@ import {
 } from '../../utils/telegram.js';
 import { addTransaction, getAccountBalance } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 export default function TennisBattleRoyalLobby() {
   useTelegramBackButton();
@@ -33,7 +34,7 @@ export default function TennisBattleRoyalLobby() {
     try {
       const accountId = await ensureAccountId();
       const balance = await getAccountBalance(accountId);
-      if ((balance.balance || 0) < stake.amount) {
+      if (isBalanceInsufficient(balance, stake.amount)) {
         alert('Insufficient balance');
         setLoading(false);
         return;

--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -5,6 +5,7 @@ import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { ensureAccountId, getTelegramId, getTelegramPhotoUrl, getTelegramUsername } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -33,7 +34,7 @@ export default function TexasHoldemLobby() {
     try {
       accountId = await ensureAccountId();
       const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
+      if (isBalanceInsufficient(balRes, stake.amount)) {
         alert('Insufficient balance');
         return;
       }

--- a/webapp/src/pages/Games/Tirana2040Lobby.jsx
+++ b/webapp/src/pages/Games/Tirana2040Lobby.jsx
@@ -10,6 +10,7 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { isBalanceInsufficient } from '../../utils/balance.js';
 
 const PLAYER_COUNTS = [10, 20, 30];
 
@@ -39,7 +40,7 @@ export default function Tirana2040Lobby() {
     try {
       accountId = await ensureAccountId();
       const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
+      if (isBalanceInsufficient(balRes, stake.amount)) {
         alert('Insufficient balance');
         setLoading(false);
         return;

--- a/webapp/src/utils/balance.js
+++ b/webapp/src/utils/balance.js
@@ -1,0 +1,17 @@
+export function getNumericBalance(response) {
+  if (!response || response.balance == null) return null;
+  const value =
+    typeof response.balance === 'number'
+      ? response.balance
+      : Number(response.balance);
+  return Number.isFinite(value) ? value : null;
+}
+
+export function isBalanceInsufficient(response, requiredAmount) {
+  const balance = getNumericBalance(response);
+  const required = Number(requiredAmount);
+  if (balance == null || !Number.isFinite(required)) {
+    return false;
+  }
+  return balance < required;
+}


### PR DESCRIPTION
## Summary
- ensure every game lobby skips the staking balance check when the backend cannot provide a numeric balance so matches can still start
- add a shared balance helper to consistently parse numeric balances from API responses

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dcdc9b7c883288f75fed3e2e76f6e)