### PR TITLE
Fix Tirana 2040 build error

### DIFF
--- a/webapp/public/tirana-2040.html
+++ b/webapp/public/tirana-2040.html
@@ -545,7 +545,7 @@ document.title = 'Tirana 2040 • Last Man Standing';
   const ringStripe=new THREE.Mesh(new THREE.RingGeometry(ringR-2, ringR-1.4, 128), new THREE.MeshBasicMaterial({ color:0xffffff, transparent:true, opacity:0.22, side:THREE.DoubleSide })); ringStripe.rotation.x=-Math.PI/2; ringStripe.position.y=0.012; city.add(ringStripe);
   mapRoads.push({type:'ring', name:ringRoadName, from:{x:0,z:0}, to:{x:0,z:0}, width:24, radius:ringR});
   mapLandmarks.push({x:ringR*0.75,z:0,label:`🛣 ${ringRoadName}`});
-  const cityHalfX=BLOCKS_X*CELL*0.5, cityHalfZ=BLOCKS_Z*CELL*0.5; const connectorTargets=[
+  const connectorTargets=[
     {from:{x:cityHalfX+ROAD*0.5, z:0}, to:{x:ringR-8, z:0}},
     {from:{x:-cityHalfX-ROAD*0.5, z:0}, to:{x:-ringR+8, z:0}},
     {from:{x:0, z:cityHalfZ+ROAD*0.5}, to:{x:0, z:ringR-8}},


### PR DESCRIPTION
## Summary
- remove the duplicate `cityHalfX`/`cityHalfZ` declaration inside the Tirana 2040 inline script so Vite/esbuild can bundle the public HTML again
- verified the game iframe now loads by running the dev server and opening the `/games/tirana2040` route

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df816410c8328b967c99d6d3dde46)