### PR TITLE
Adjust Pool Royale chrome, cushions, and wood grain options

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -386,6 +386,7 @@ const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1;
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1; // keep the notch depth identical to the pocket cylinder so the chrome kisses the jaw edge
 const CHROME_SIDE_FIELD_PULL_SCALE = 0;
 const CHROME_PLATE_THICKNESS_SCALE = 0.7; // thicken fascia depth so corner and side plates share the same chunky profile
+const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.18; // middle pocket fascias get a touch more mass for a heftier chrome read
 const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually above the wood rails without z-fighting
 const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.58; // push the side fascia farther along the arch so it blankets the larger chrome reveal
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.52; // extend the middle fascia deeper along the pocket arch so it blankets the expanded rail relief
@@ -818,8 +819,8 @@ const CLOTH_EDGE_BOTTOM_RADIUS_SCALE = 1.012; // flare the lower sleeve so the w
 const CLOTH_EDGE_CURVE_INTENSITY = 0.012; // shallow easing that rounds the cloth sleeve as it transitions from lip to throat
 const CLOTH_EDGE_TEXTURE_HEIGHT_SCALE = 1.2; // boost vertical tiling so the wrapped cloth reads with tighter, more realistic fibres
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
-const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.036; // sink the cushion base slightly lower so the pads sit deeper against the rail face
-const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.02; // allow a bit more drop so the cushion lip now sits subtly below the rail cap
+const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.046; // sink the cushion base slightly lower so the pads sit deeper against the rail face
+const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.024; // allow a bit more drop so the cushion lip now sits subtly below the rail cap
 const CUSHION_FIELD_CLIP_RATIO = 0.14; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
@@ -5650,6 +5651,7 @@ function Table3D(
     SIDE_CUSHION_CORNER_SHIFT;
 
   const chromePlateThickness = railH * CHROME_PLATE_THICKNESS_SCALE; // drop the plates far enough to hide the rail pocket cuts
+  const sideChromePlateThickness = chromePlateThickness * CHROME_SIDE_PLATE_THICKNESS_BOOST; // give the middle-pocket fascias extra depth
   const chromePlateInset = TABLE.THICK * 0.02;
   const chromeCornerPlateTrim =
     TABLE.THICK * (0.03 + CHROME_CORNER_FIELD_TRIM_SCALE);
@@ -5702,6 +5704,8 @@ function Table3D(
   );
   const chromePlateY =
     railsTopY - chromePlateThickness + MICRO_EPS * 2;
+  const sideChromePlateY =
+    railsTopY - sideChromePlateThickness + MICRO_EPS * 2;
   const chromeCornerCenterOutset =
     TABLE.THICK * CHROME_CORNER_CENTER_OUTSET_SCALE;
   const chromeCornerShortRailShift =
@@ -6064,7 +6068,7 @@ function Table3D(
         width: sideChromePlateWidth,
         height: sideChromePlateHeight,
         radius: sideChromePlateRadius,
-        thickness: chromePlateThickness,
+        thickness: sideChromePlateThickness,
         corner: id,
         notchMP: notchLocalMP,
         shapeSegments: chromePlateShapeSegments,
@@ -6072,7 +6076,7 @@ function Table3D(
       }),
       trimMat
     );
-    plate.position.set(centerX, chromePlateY + chromePlateThickness, centerZ);
+    plate.position.set(centerX, sideChromePlateY + sideChromePlateThickness, centerZ);
     plate.castShadow = false;
     plate.receiveShadow = false;
     plate.renderOrder = CHROME_PLATE_RENDER_ORDER;

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -112,8 +112,8 @@ export const WOOD_FINISH_PRESETS = Object.freeze([
 export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'ph_wood_floor_01',
-    label: 'Light Natural',
-    source: 'Poly Haven — Wooden Floor 01 (Light Natural)',
+    label: 'Wooden Floor 01 — Light Natural',
+    source: 'Poly Haven — Wooden Floor 01 — Light Natural',
     rail: {
       repeat: { x: 0.12, y: 0.62 },
       rotation: Math.PI / 24,
@@ -127,8 +127,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
   }),
   Object.freeze({
     id: 'ph_wood_floor_02',
-    label: 'Warm Brown',
-    source: 'Poly Haven — Wooden Floor 02 (Warm Brown)',
+    label: 'Wooden Floor 02 — Warm Brown',
+    source: 'Poly Haven — Wooden Floor 02 — Warm Brown',
     rail: {
       repeat: { x: 0.11, y: 0.58 },
       rotation: Math.PI / 22,
@@ -142,8 +142,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
   }),
   Object.freeze({
     id: 'ph_wood_floor_03',
-    label: 'Clean Strips',
-    source: 'Poly Haven — Wood Floor (Clean Strips)',
+    label: 'Wood Floor — Clean Strips',
+    source: 'Poly Haven — Wood Floor — Clean Strips',
     rail: {
       repeat: { x: 0.14, y: 0.72 },
       rotation: 0,
@@ -157,8 +157,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
   }),
   Object.freeze({
     id: 'ph_old_wood_floor',
-    label: 'Old Wood Floor',
-    source: 'Poly Haven — Old Wood Floor',
+    label: 'Old Wood Floor — Cracks & Damage',
+    source: 'Poly Haven — Old Wood Floor — Cracks & Damage',
     rail: {
       repeat: { x: 0.16, y: 0.64 },
       rotation: Math.PI / 18,


### PR DESCRIPTION
## Summary
- thicken the Pool Royale middle-pocket chrome fascias while keeping corner plating unchanged
- sink the cushions slightly to align diamonds flush across rails and pads
- align available wood grains with the first four Poly Haven floor finishes and update labeling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eddb866e08328996eca93aeb070bf)