### PR TITLE
Align Pool Royal melamine rails

### DIFF
--- a/docs/3d-billiards-variants.md
+++ b/docs/3d-billiards-variants.md
@@ -23,6 +23,7 @@ Exactly **four** chalk blocks are visible at all times—one centred on each woo
 ### Pool Royal (Arcade)
 - Same table geometry as American Billiards but with neon accent lighting.
 - Power-up spawn pads appear on the long rails; reuse the chalk placement rule so props do not collide.
+- Melamine stays as-is on the short rails, but the long side rails must use a single uninterrupted melamine plank from corner to corner—no reversed orientation or mid-rail seams.
 - Pocket jaws and rims must match the chrome plate cutouts **100%**—never size them from the wooden rail arches.
 
 ### 3D UK 8 Ball

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -113,7 +113,9 @@ export const WOOD_FINISH_PRESETS = Object.freeze([
   Object.freeze({ id: 'ebony', label: 'Ebony', hue: 25, sat: 0.35, light: 0.18, contrast: 0.85 })
 ]);
 
-const MELAMINE_LONG_PLANK_REPEAT_X = 0.02;
+// Keep the melamine on the short rails unchanged, but ensure the long rails read as a single
+// uninterrupted board from corner to corner (no visible tile seams).
+const MELAMINE_LONG_PLANK_REPEAT_X = 0.018;
 const MELAMINE_FRAME_REPEAT_X = MELAMINE_LONG_PLANK_REPEAT_X * 1.25;
 
 export const WOOD_GRAIN_OPTIONS = Object.freeze([


### PR DESCRIPTION
## Summary
- document that Pool Royal long side rails must use a single uninterrupted melamine plank
- tweak melamine texture repeat constants so long rails read as one continuous board while leaving short rails unchanged

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691efc1abdb88328a2da65e2b25ddb6e)