### PR TITLE
Fix melamine rail texture orientation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2759,6 +2759,35 @@ function ensureMaterialWoodOptions(material, targetSettings) {
   return material.userData?.__woodOptions || null;
 }
 
+const isMelamineWoodTexture = (id) => typeof id === 'string' && id.startsWith('acg_melamine');
+
+function reorientMelamineRailTextures(material, repeat, baseRotation = 0) {
+  if (!material) return;
+  const targetRepeat = new THREE.Vector2(repeat?.x ?? 1, repeat?.y ?? 1);
+  const swappedRepeat = new THREE.Vector2(targetRepeat.y, targetRepeat.x);
+  const targetRotation = baseRotation + Math.PI / 2;
+  const applyToTexture = (texture) => {
+    if (!texture) return;
+    texture.center.set(0.5, 0.5);
+    texture.wrapS = texture.wrapT = THREE.ClampToEdgeWrapping;
+    texture.repeat.copy(swappedRepeat);
+    texture.rotation = targetRotation;
+    texture.needsUpdate = true;
+  };
+  applyToTexture(material.map);
+  applyToTexture(material.roughnessMap);
+  material.userData = material.userData || {};
+  material.userData.woodRepeat = swappedRepeat.clone();
+  if (material.userData.__woodOptions) {
+    material.userData.__woodOptions.repeat = {
+      x: swappedRepeat.x,
+      y: swappedRepeat.y
+    };
+    material.userData.__woodOptions.rotation = targetRotation;
+  }
+  material.needsUpdate = true;
+}
+
 function applyWoodTextureToMaterial(material, repeat) {
   if (!material) return;
   const repeatVec = resolveRepeatVector(repeat, material);
@@ -4946,6 +4975,7 @@ function Table3D(
     (resolvedFinish?.woodTextureId &&
       WOOD_GRAIN_OPTIONS_BY_ID[resolvedFinish.woodTextureId]) ||
     defaultWoodOption;
+  const railUsesMelamine = isMelamineWoodTexture(resolvedWoodOption?.id);
   finishParts.woodTextureId = resolvedWoodOption?.id ?? DEFAULT_WOOD_GRAIN_ID;
 
   const createMaterialsFn =
@@ -5568,6 +5598,9 @@ function Table3D(
     textureSize: woodRailSurface.textureSize,
     woodRepeatScale
   });
+  if (railUsesMelamine) {
+    reorientMelamineRailTextures(railMat, woodRailSurface.repeat, woodRailSurface.rotation);
+  }
   finishParts.underlayMeshes.forEach((mesh) => {
     if (!mesh?.material || mesh.userData?.skipWoodTexture) return;
     applyWoodTextureToMaterial(mesh.material, {
@@ -5576,6 +5609,13 @@ function Table3D(
       textureSize: woodRailSurface.textureSize,
       woodRepeatScale
     });
+    if (railUsesMelamine) {
+      reorientMelamineRailTextures(
+        mesh.material,
+        woodRailSurface.repeat,
+        woodRailSurface.rotation
+      );
+    }
     mesh.material.needsUpdate = true;
   });
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(woodRailSurface);
@@ -7235,6 +7275,7 @@ function applyTableFinishToTable(table, finish) {
     (finishInfo.woodTextureId &&
       WOOD_GRAIN_OPTIONS_BY_ID[finishInfo.woodTextureId]) ||
     defaultWoodOption;
+  const railUsesMelamine = isMelamineWoodTexture(resolvedWoodOption?.id);
   const nextFrameSurface = resolveWoodSurfaceConfig(
     resolvedWoodOption?.frame,
     woodSurfaces.frame ?? woodSurfaces.rail ?? resolvedWoodOption?.rail ?? {
@@ -7255,6 +7296,9 @@ function applyTableFinishToTable(table, finish) {
     textureSize: nextRailSurface.textureSize,
     woodRepeatScale
   });
+  if (railUsesMelamine) {
+    reorientMelamineRailTextures(railMat, nextRailSurface.repeat, nextRailSurface.rotation);
+  }
   finishInfo.parts.underlayMeshes.forEach((mesh) => {
     if (!mesh?.material || mesh.userData?.skipWoodTexture) return;
     applyWoodTextureToMaterial(mesh.material, {
@@ -7263,6 +7307,13 @@ function applyTableFinishToTable(table, finish) {
       textureSize: nextRailSurface.textureSize,
       woodRepeatScale
     });
+    if (railUsesMelamine) {
+      reorientMelamineRailTextures(
+        mesh.material,
+        nextRailSurface.repeat,
+        nextRailSurface.rotation
+      );
+    }
     if (mesh.material.color && railMat.color) {
       mesh.material.color.copy(railMat.color);
     }


### PR DESCRIPTION
## Summary
- add melamine rail texture reorientation helper to clamp seams and rotate along rail direction
- apply melamine-specific orientation when building Pool Royale tables and when updating finishes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691effada71c832893df38ca3e64ba92)