### PR TITLE
Align Pool Royale rail wood grain with skirts

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2881,14 +2881,14 @@ function cloneWoodSurfaceConfig(config) {
 
 function orientRailWoodSurface(surface) {
   if (!surface) {
-    return { repeat: { x: 1, y: 1 }, rotation: Math.PI / 2 };
+    return { repeat: { x: 1, y: 1 }, rotation: 0 };
   }
   return {
     repeat: {
-      x: Number.isFinite(surface.repeat?.y) ? surface.repeat.y : 1,
-      y: Number.isFinite(surface.repeat?.x) ? surface.repeat.x : 1
+      x: Number.isFinite(surface.repeat?.x) ? surface.repeat.x : 1,
+      y: Number.isFinite(surface.repeat?.y) ? surface.repeat.y : 1
     },
-    rotation: (surface.rotation ?? 0) + Math.PI / 2,
+    rotation: surface.rotation ?? 0,
     textureSize:
       typeof surface.textureSize === 'number' ? surface.textureSize : undefined
   };


### PR DESCRIPTION
## Summary
- keep rail wood textures oriented with the configured direction instead of rotating/swap axes
- ensure side and short rails share the same grain alignment as the skirt without extra seams

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f153bdbf8832581968225288ad9d1)