### PR TITLE
Clarify Pool Royale melamine rail layout

### DIFF
--- a/docs/3d-billiards-variants.md
+++ b/docs/3d-billiards-variants.md
@@ -23,7 +23,7 @@ Exactly **four** chalk blocks are visible at all times—one centred on each woo
 ### Pool Royal (Arcade)
 - Same table geometry as American Billiards but with neon accent lighting.
 - Power-up spawn pads appear on the long rails; reuse the chalk placement rule so props do not collide.
-- Melamine stays as-is on the short rails, but the long side rails must use a single uninterrupted melamine plank from corner to corner—no reversed orientation or mid-rail seams.
+- Rail melamine is split into **six** surface pieces in total, each one kissing the chrome fascia with no visible gaps; the grain/pattern lines must run the full length of the rails so every strip reads as a continuous long-direction plank.
 - Match the skirt underlay: melamine and wooden rails must share the same grain direction, pattern scale, and plank widths as the skirts beneath them so the table reads as one uniform shell and stops cleanly above the legs.
 - Pocket jaws and rims must match the chrome plate cutouts **100%**—never size them from the wooden rail arches.
 


### PR DESCRIPTION
## Summary
- update Pool Royale specifications to require six melamine rail pieces aligned with chrome fascia and long-grain patterning

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f1e7ed0e08325b2cb958f7d6cf74a)