### PR TITLE
Add APK download CTA to home page

### DIFF
--- a/webapp/public/tonplaygram-launcher.apk
+++ b/webapp/public/tonplaygram-launcher.apk
@@ -1,0 +1,9 @@
+TonPlaygram Android Launcher (preview)
+
+Ky skedar .apk shërben si mbajtës vendi për shkarkimin e aplikacionit të plotë Android.
+Aktualisht përmban vetëm tekst për të provuar endpoint-in e shkarkimit pa kode sensitive
+ose binare të mbyllura. Zëvendësojeni me build-in zyrtar të nënshkruar sapo të jetë gati.
+
+- Nuk përmban çelësa ose të dhëna private.
+- Mund të shpërndahet publikisht për testim të rrjedhës së shkarkimit.
+- Ruajeni emrin e skedarit që lidhjet ekzistuese të vazhdojnë të funksionojnë.

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -225,6 +225,27 @@ export default function Home() {
           <IoLogoTiktok className="text-pink-500 w-6 h-6" />
         </a>
       </div>
+
+      <div className="mt-6">
+        <div className="bg-gradient-to-r from-primary/20 via-primary/10 to-primary/20 border border-primary/40 rounded-xl p-4 text-center space-y-2">
+          <h3 className="text-lg font-semibold text-white">
+            TonPlaygram Android Launcher (APK beta)
+          </h3>
+          <p className="text-sm text-subtext">
+            Instaloni një paketë të lehtë pa të dhëna sensitive që hap direkt lojërat nga telefoni.
+          </p>
+          <a
+            href="/tonplaygram-launcher.apk"
+            download
+            className="inline-flex items-center justify-center px-4 py-2 bg-primary text-surface font-semibold rounded-full shadow-lg shadow-primary/40 hover:shadow-primary/60 transition"
+          >
+            Shkarko APK-në e lehtë
+          </a>
+          <p className="text-xs text-subtext">
+            Skedari është vetëm tekst për rrjedhën e shkarkimit; zëvendësohet lehtësisht me build-in zyrtar kur të jetë gati.
+          </p>
+        </div>
+      </div>
       <p className="text-center text-xs text-subtext">Status: {status}</p>
       <div className="mt-4 space-y-2 text-center text-xs text-subtext">
         <p>


### PR DESCRIPTION
## Summary
- add a download card to the Home page linking to the Android launcher APK for easier access
- include a text-only placeholder APK file to keep the download endpoint safe and ready for replacement

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f305cfb888325a7b748a45a513970)