### PR TITLE
Fix Tirana 2040 iframe path

### DIFF
--- a/webapp/src/pages/Games/Tirana2040.jsx
+++ b/webapp/src/pages/Games/Tirana2040.jsx
@@ -5,10 +5,12 @@ export default function Tirana2040() {
   useTelegramBackButton();
   const { search } = useLocation();
 
+  const iframeSrc = `${import.meta.env.BASE_URL || '/'}tirana-2040.html${search || ''}`;
+
   return (
     <div className="relative w-full h-[100dvh]">
       <iframe
-        src={`/tirana-2040.html${search}`}
+        src={iframeSrc}
         title="Tirana 2040"
         className="w-full h-full border-0"
         allow="accelerometer; gyroscope; fullscreen"


### PR DESCRIPTION
## Summary
- use the Vite base URL when generating the Tirana 2040 iframe source so the game loads under non-root deployments

## Testing
- npm run build (reports existing sRGBEncoding import warnings and large bundle notice)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f651874048325b8219a86b1223c95)