### PR TITLE
Align Pool Royale rail wood texture with snooker

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1457,8 +1457,8 @@ const POOL_ROYALE_WOOD_PRESET_FOR_FINISH = Object.freeze({
 });
 
 const POOL_ROYALE_WOOD_REPEAT = Object.freeze({
-  x: 1,
-  y: 5.5
+  x: CUE_WOOD_REPEAT.x,
+  y: CUE_WOOD_REPEAT.y
 });
 
 const POOL_ROYALE_WOOD_SURFACE_PROPS = Object.freeze({
@@ -1477,7 +1477,7 @@ const applySnookerStyleWoodPreset = (materials, finishId) => {
     light: preset.light,
     contrast: preset.contrast,
     repeat: POOL_ROYALE_WOOD_REPEAT,
-    sharedKey: `pool-royale-wood-${preset.id}`,
+    sharedKey: `snooker-wood-${preset.id}`,
     ...POOL_ROYALE_WOOD_SURFACE_PROPS
   };
   const uniqueMaterials = new Set(


### PR DESCRIPTION
## Summary
- match Pool Royale rail wood repeat to the cue repeat used by snooker
- share the snooker wood texture cache so Pool Royale rails render with the same grain

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691fcfbff6508325af97b525aeacd37e)