### PR TITLE
Adjust Pool Royale cloth palette and rail markers

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1845,7 +1845,7 @@ const CLOTH_COLOR_OPTIONS = Object.freeze([
   {
     id: 'royalBlue',
     label: 'Royal Blue',
-    color: 0x3b7ff0,
+    color: 0x64a8ff,
     textureKey: 'royalBlue',
     detail: {
       bumpMultiplier: 1.05,
@@ -1869,7 +1869,7 @@ const CLOTH_COLOR_OPTIONS = Object.freeze([
     id: 'matteBlack',
     label: 'Midnight Velvet',
     color: 0x14151a,
-    cushionColor: 0x6b1b2b,
+    cushionColor: 0xff8a2b,
     textureKey: 'matteBlack',
     detail: {
       bumpMultiplier: 0.88,
@@ -6829,7 +6829,7 @@ function Table3D(
           colorId: railMarkerStyle.colorId ?? DEFAULT_RAIL_MARKER_COLOR_ID
         }
       : { shape: DEFAULT_RAIL_MARKER_SHAPE, colorId: DEFAULT_RAIL_MARKER_COLOR_ID };
-  const railMarkerOutset = TABLE.THICK * 0.26;
+  const railMarkerOutset = longRailW * 0.32; // sit markers fully on the wooden rails away from the cushions
   const railMarkerGroup = new THREE.Group();
   const railMarkerThickness = TABLE.THICK * 0.06;
   const railMarkerWidth = ORIGINAL_RAIL_WIDTH * 0.64;


### PR DESCRIPTION
## Summary
- lightened the Royal Blue cloth option and updated the Midnight Velvet cushions to an orange accent
- pushed rail markers further onto the wooden rails to keep diamonds/circles off the cushions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69208123f89c8320ab9099a09b8e09c9)