### PR TITLE
Replace canvas dependency with napi build

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "canvas": "^2.11.2",
+    "@napi-rs/canvas": "^0.1.66",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",

--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { createCanvas, loadImage } from 'canvas';
+import { createCanvas, loadImage } from '@napi-rs/canvas';
 import { fetchTelegramInfo } from './telegram.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- replace the canvas dependency with the prebuilt @napi-rs/canvas package
- update notification image rendering to import from @napi-rs/canvas

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a527754083209c826833a968cb07)