### PR TITLE
Add training mode and improve Tennis Battle Royal controls

### DIFF
--- a/webapp/src/pages/Games/TennisBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TennisBattleRoyal.jsx
@@ -7,9 +7,11 @@ export default function TennisBattleRoyal() {
   const { search } = useLocation();
   const params = new URLSearchParams(search);
   const playerName = params.get('name') || undefined;
+  const mode = params.get('mode');
   const amount = params.get('amount');
   const token = params.get('token');
-  const stakeLabel = amount && token ? `${amount} ${token}` : undefined;
+  const trainingMode = mode === 'training';
+  const stakeLabel = !trainingMode && amount && token ? `${amount} ${token}` : undefined;
 
-  return <TennisBattleRoyal3D playerName={playerName} stakeLabel={stakeLabel} />;
+  return <TennisBattleRoyal3D playerName={playerName} stakeLabel={stakeLabel} trainingMode={trainingMode} />;
 }

--- a/webapp/src/pages/Games/TennisBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/TennisBattleRoyalLobby.jsx
@@ -64,6 +64,17 @@ export default function TennisBattleRoyalLobby() {
     }
   };
 
+  const startTraining = () => {
+    const params = new URLSearchParams();
+    params.set('mode', 'training');
+    const name = getTelegramFirstName();
+    if (name) params.set('name', name);
+    const tgId = getTelegramId();
+    if (tgId) params.set('tgId', tgId);
+    if (avatar) params.set('avatar', avatar);
+    navigate(`/games/tennisbattleroyal?${params.toString()}`);
+  };
+
   return (
     <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
       <h2 className="text-xl font-bold text-center">3D Tennis Battle Royal Lobby</h2>
@@ -88,6 +99,18 @@ export default function TennisBattleRoyalLobby() {
       >
         {loading ? 'Duke u përgatitur…' : 'Start Fundraising Rally'}
       </button>
+      <div className="space-y-2 pt-3 border-t border-border/60">
+        <h3 className="font-semibold">Training</h3>
+        <p className="text-xs text-subtext">
+          Luaj pa stake, mëso kontrollin me swipe dhe ndiq hapat e udhëzuesit në lojë para se të sfidosh AI-në.
+        </p>
+        <button
+          onClick={startTraining}
+          className="px-4 py-2 w-full bg-surface hover:bg-muted text-text rounded border border-border"
+        >
+          Start Training pa stake
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a stake-free training mode with guided tasks and UI overlay for Tennis Battle Royal
- adjust serve positioning, racket reach, and camera distance to keep the ball visible and swipable
- update lobby and routing to start training sessions without taking a stake

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a8f9a6d88320ac5665cd239250f1)