### PR TITLE
Use full flag set for AI opponents

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -36,6 +36,7 @@ import {
   detectCombo,
   sortHand
 } from '../../../../lib/murlan.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 
 const MODEL_SCALE = 0.75;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
@@ -48,8 +49,6 @@ const CUSTOM_SEAT_ANGLES = [
   THREE.MathUtils.degToRad(270),
   THREE.MathUtils.degToRad(225)
 ];
-
-const FLAG_EMOJIS = ['🇦🇱', '🇺🇸', '🇫🇷', '🇬🇧', '🇮🇹', '🇩🇪', '🇯🇵', '🇨🇦'];
 
 const SUITS = ['♠', '♥', '♦', '♣'];
 const SUIT_COLORS = {

--- a/webapp/src/utils/aiOpponentFlag.js
+++ b/webapp/src/utils/aiOpponentFlag.js
@@ -40,7 +40,7 @@ export function getAIOpponentFlag(playerFlag) {
   if (Array.isArray(rivals) && rivals.length > 0) {
     return rivals[Math.floor(Math.random() * rivals.length)];
   }
-  const flags = Object.keys(RIVAL_FLAGS);
+  const flags = FLAG_EMOJIS.length ? FLAG_EMOJIS : Object.keys(RIVAL_FLAGS);
   let flag;
   do {
     flag = flags[Math.floor(Math.random() * flags.length)];


### PR DESCRIPTION
## Summary
- update AI flag selection fallback to use the full flag emoji set
- switch Murlan Royale to reuse the shared flag list instead of a limited local set

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920b94b11988320b87569592c05c28d)