### PR TITLE
Align air hockey lobby and sounds with Goal Rush

### DIFF
--- a/webapp/src/pages/Games/AirHockey.jsx
+++ b/webapp/src/pages/Games/AirHockey.jsx
@@ -8,11 +8,13 @@ export default function AirHockey() {
   useTelegramBackButton();
   const { search } = useLocation();
   const params = new URLSearchParams(search);
+  const target = Number(params.get('target')) || 3;
+  const playType = params.get('type') || 'regular';
   const player = {
     name: params.get('name') || 'You',
     avatar: params.get('avatar') || '/assets/icons/profile.svg'
   };
   const flag = FLAG_EMOJIS[Math.floor(Math.random() * FLAG_EMOJIS.length)];
   const ai = { name: avatarToName(flag) || 'AI', avatar: flag };
-  return <AirHockey3D player={player} ai={ai} />;
+  return <AirHockey3D player={player} ai={ai} target={target} playType={playType} />;
 }

--- a/webapp/src/pages/Games/AirHockeyLobby.jsx
+++ b/webapp/src/pages/Games/AirHockeyLobby.jsx
@@ -17,6 +17,10 @@ export default function AirHockeyLobby() {
   useTelegramBackButton();
 
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [mode, setMode] = useState('ai');
+  const [goal, setGoal] = useState(3);
+  const [playType, setPlayType] = useState('regular');
+  const [players, setPlayers] = useState(8);
   const [avatar, setAvatar] = useState('');
 
   useEffect(() => {
@@ -29,30 +33,49 @@ export default function AirHockeyLobby() {
   const startGame = async () => {
     let tgId;
     let accountId;
-    try {
-      accountId = await ensureAccountId();
-      const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
-        alert('Insufficient balance');
-        return;
-      }
-      tgId = getTelegramId();
-      await addTransaction(tgId, -stake.amount, 'stake', {
-        game: 'airhockey',
-        players: 2,
-        accountId
-      });
-    } catch {}
+    if (playType !== 'training') {
+      try {
+        accountId = await ensureAccountId();
+        const balRes = await getAccountBalance(accountId);
+        if ((balRes.balance || 0) < stake.amount) {
+          alert('Insufficient balance');
+          return;
+        }
+        tgId = getTelegramId();
+        await addTransaction(tgId, -stake.amount, 'stake', {
+          game: 'airhockey',
+          players: playType === 'tournament' ? players : 2,
+          accountId
+        });
+      } catch {}
+    } else {
+      try {
+        tgId = getTelegramId();
+        accountId = await ensureAccountId();
+      } catch {}
+    }
 
     const params = new URLSearchParams(search);
+    params.set('target', goal);
+    params.set('type', playType);
+    if (playType !== 'training') params.set('mode', mode);
+    if (playType === 'tournament') params.set('players', players);
     const initData = window.Telegram?.WebApp?.initData;
-    if (stake.token) params.set('token', stake.token);
-    if (stake.amount) params.set('amount', stake.amount);
+    if (playType !== 'training') {
+      if (stake.token) params.set('token', stake.token);
+      if (stake.amount) params.set('amount', stake.amount);
+    }
     if (avatar) params.set('avatar', avatar);
     if (tgId) params.set('tgId', tgId);
     if (accountId) params.set('accountId', accountId);
     const name = getTelegramFirstName();
     if (name) params.set('name', name);
+    const devAcc = import.meta.env.VITE_DEV_ACCOUNT_ID;
+    const devAcc1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
+    const devAcc2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
+    if (devAcc) params.set('dev', devAcc);
+    if (devAcc1) params.set('dev1', devAcc1);
+    if (devAcc2) params.set('dev2', devAcc2);
     if (initData) params.set('init', encodeURIComponent(initData));
     navigate(`/games/airhockey?${params.toString()}`);
   };
@@ -61,9 +84,88 @@ export default function AirHockeyLobby() {
     <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
       <h2 className="text-xl font-bold text-center">Air Hockey Lobby</h2>
       <div className="space-y-2">
-        <h3 className="font-semibold">Stake</h3>
-        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+        <h3 className="font-semibold">Type</h3>
+        <div className="flex gap-2">
+          {[
+            { id: 'regular', label: 'Regular' },
+            { id: 'training', label: 'Training' },
+            { id: 'tournament', label: 'Tournament' }
+          ].map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setPlayType(id)}
+              className={`lobby-tile ${playType === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
+      {playType !== 'training' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Mode</h3>
+          <div className="flex gap-2">
+            {[
+              { id: 'ai', label: 'Vs AI' },
+              { id: 'online', label: '1v1 Online', disabled: true }
+            ].map(({ id, label, disabled }) => (
+              <div key={id} className="relative">
+                <button
+                  onClick={() => !disabled && setMode(id)}
+                  className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                    disabled ? 'opacity-50 cursor-not-allowed' : ''
+                  }`}
+                  disabled={disabled}
+                >
+                  {label}
+                </button>
+                {disabled && (
+                  <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                    Under development
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      <div className="space-y-2">
+        <h3 className="font-semibold">Goals</h3>
+        <div className="flex gap-2">
+          {[3, 5, 10].map((g) => (
+            <button
+              key={g}
+              onClick={() => setGoal(g)}
+              className={`lobby-tile ${goal === g ? 'lobby-selected' : ''}`}
+            >
+              {g}
+            </button>
+          ))}
+        </div>
+      </div>
+      {playType === 'tournament' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Players</h3>
+          <div className="flex gap-2">
+            {[8, 16, 24].map((p) => (
+              <button
+                key={p}
+                onClick={() => setPlayers(p)}
+                className={`lobby-tile ${players === p ? 'lobby-selected' : ''}`}
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs">Winner takes pot minus 10% developer fee.</p>
+        </div>
+      )}
+      {playType !== 'training' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Stake</h3>
+          <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+        </div>
+      )}
       <button
         onClick={startGame}
         className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"


### PR DESCRIPTION
## Summary
- reuse Goal Rush audio cues for air hockey goals, whistles, and post hits while tracking target-score wins
- add game-over overlay with winner details and propagate lobby settings into gameplay
- sync air hockey lobby options with Goal Rush, including type, mode, goals, players, and stake controls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ba5cf4e88320b4a405de4f7a0259)