### PR TITLE
Enforce sequential Pool Royale training flow

### DIFF
--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -1,0 +1,47 @@
+const TRAINING_PROGRESS_KEY = 'poolRoyaleTrainingProgress';
+
+export function loadTrainingProgress() {
+  if (typeof window === 'undefined') return { completed: [], lastLevel: 1 };
+  try {
+    const stored = window.localStorage.getItem(TRAINING_PROGRESS_KEY);
+    if (!stored) return { completed: [], lastLevel: 1 };
+    const parsed = JSON.parse(stored);
+    const completed = Array.isArray(parsed?.completed)
+      ? parsed.completed
+          .map((lvl) => Number(lvl))
+          .filter((lvl) => Number.isFinite(lvl) && lvl > 0)
+          .sort((a, b) => a - b)
+      : [];
+    const lastLevel = Number.isFinite(parsed?.lastLevel) ? Number(parsed.lastLevel) : 1;
+    return { completed, lastLevel };
+  } catch (err) {
+    console.warn('Failed to load Pool Royale training progress', err);
+    return { completed: [], lastLevel: 1 };
+  }
+}
+
+export function persistTrainingProgress(progress) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(TRAINING_PROGRESS_KEY, JSON.stringify(progress));
+  } catch (err) {
+    console.warn('Failed to persist Pool Royale training progress', err);
+  }
+}
+
+export function getNextIncompleteLevel(completedLevels) {
+  const completedSet = new Set((completedLevels || []).map((lvl) => Number(lvl)));
+  for (let level = 1; level <= 50; level++) {
+    if (!completedSet.has(level)) return level;
+  }
+  return null;
+}
+
+export function resolvePlayableTrainingLevel(requestedLevel, progress) {
+  const completed = progress?.completed || [];
+  const nextIncomplete = getNextIncompleteLevel(completed);
+  const lastLevel = Number.isFinite(progress?.lastLevel) ? progress.lastLevel : 1;
+  const unlocked = nextIncomplete === null ? lastLevel || 1 : nextIncomplete;
+  const desired = Number.isFinite(requestedLevel) && requestedLevel > 0 ? requestedLevel : unlocked;
+  return Math.max(1, Math.min(desired, unlocked));
+}


### PR DESCRIPTION
## Summary
- add shared Pool Royale training progress helpers and clamp gameplay to the next unlocked round
- move the training roadmap display to the lobby with locking and next-round guidance
- update the training completion popup to confirm success and auto-advance with a clear checkmark state

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c376622c83209124a5569c3da90f)