### PR TITLE
Fix Pool Royale training progression when tasks are cleared

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8905,6 +8905,21 @@ function PoolRoyaleGame({
     }, 1200);
     return () => window.clearTimeout(redirectTimer);
   }, [frameState.frameOver, frameState.winner, handleTrainingOutcome, isTraining, player.name]);
+
+  useEffect(() => {
+    if (!isTraining || trainingPopup) return;
+    if (gameOverHandledRef.current) return;
+    const balls = Array.isArray(frameState?.balls) ? frameState.balls : [];
+    const remaining = balls.filter((ball) => {
+      if (!ball || ball.id === 'cue') return false;
+      const onTable = ball.onTable ?? !ball.potted;
+      return onTable === true;
+    }).length;
+    if (remaining === 0) {
+      gameOverHandledRef.current = true;
+      handleTrainingOutcome(true);
+    }
+  }, [frameState?.balls, handleTrainingOutcome, isTraining, trainingPopup]);
   useEffect(() => {
     let wakeLock;
     const request = async () => {


### PR DESCRIPTION
## Summary
- detect when all training layout balls are cleared in Pool Royale
- trigger task success and advance to the next round automatically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ce10b5b88320a69a51d954db28b3)