### PR TITLE
Reload PoolRoyale training between tasks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -7688,14 +7688,20 @@ function PoolRoyaleGame({
   const navigate = useNavigate();
   const location = useLocation();
   const goToTrainingLevel = useCallback(
-    (level, replace = false) => {
-      if (!level) {
-        navigate('/games/pollroyale/lobby', { replace });
+    (level, replace = false, reload = false) => {
+      const target = (() => {
+        if (!level) return '/games/pollroyale/lobby';
+        const params = new URLSearchParams(location.search);
+        params.set('task', level);
+        return `${location.pathname}?${params.toString()}`;
+      })();
+
+      if (reload) {
+        window.location.assign(target);
         return;
       }
-      const params = new URLSearchParams(location.search);
-      params.set('task', level);
-      navigate(`${location.pathname}?${params.toString()}`, { replace });
+
+      navigate(target, { replace });
     },
     [location.pathname, location.search, navigate]
   );
@@ -7877,7 +7883,7 @@ function PoolRoyaleGame({
       return;
     }
     if (nextLevel) {
-      goToTrainingLevel(nextLevel, true);
+      goToTrainingLevel(nextLevel, true, true);
     } else {
       goToTrainingLevel(null, true);
     }


### PR DESCRIPTION
## Summary
- allow PoolRoyale training navigation to optionally reload the page
- reload when advancing to the next training task so the game resets cleanly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d2593194832085a7e2f1dd06ca97)