### PR TITLE
Restore full table tennis 3D experience

### DIFF
--- a/webapp/src/pages/Games/TableTennis.jsx
+++ b/webapp/src/pages/Games/TableTennis.jsx
@@ -1,6 +1,6 @@
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
-import ArcadeRacketGame from '../../components/ArcadeRacketGame.jsx';
+import TableTennis3D from '../../components/TableTennis3D.jsx';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { avatarToName } from '../../utils/avatarUtils.js';
 
@@ -18,6 +18,6 @@ export default function TableTennis() {
     avatar: flag,
     difficulty: params.get('difficulty') || 'pro',
   };
-  return <ArcadeRacketGame mode="tabletennis" title={`${player.name} vs ${ai.name}`} />;
+  return <TableTennis3D player={player} ai={ai} />;
 }
 


### PR DESCRIPTION
## Summary
- route the table tennis page to the detailed 3D TableTennis3D experience instead of the simplified arcade version
- keep player/AI personalization while restoring the full arena, paddles, and ball visuals

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d4bf1af083208719f0181e2df2d4)