### PR TITLE
Fix Pool Royale training navigation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -7707,8 +7707,11 @@ function PoolRoyaleGame({
   const goToTrainingLevel = useCallback(
     (level, replace = false, reload = false) => {
       const target = (() => {
-        if (!level) return '/games/poolroyale/lobby';
+        if (!level) return '/games/poolroyale/lobby?type=training';
         const params = new URLSearchParams(location.search);
+        if (params.get('type') !== 'training') {
+          params.set('type', 'training');
+        }
         params.set('task', level);
         return `${location.pathname}?${params.toString()}`;
       })();

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -24,11 +24,19 @@ export default function PoolRoyaleLobby() {
   const { search } = useLocation();
   useTelegramBackButton();
 
+  const searchParams = new URLSearchParams(search);
+  const initialPlayType = (() => {
+    const requestedType = searchParams.get('type');
+    return requestedType === 'training' || requestedType === 'tournament'
+      ? requestedType
+      : 'regular';
+  })();
+
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState('ai');
   const [avatar, setAvatar] = useState('');
   const [variant, setVariant] = useState('uk');
-  const [playType, setPlayType] = useState('regular');
+  const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const [trainingProgress, setTrainingProgress] = useState(() => loadTrainingProgress());
   const [trainingTask, setTrainingTask] = useState(() => {
@@ -40,7 +48,6 @@ export default function PoolRoyaleLobby() {
     () => getNextIncompleteLevel(trainingProgress.completed),
     [trainingProgress]
   );
-  const searchParams = new URLSearchParams(search);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);


### PR DESCRIPTION
## Summary
- keep Pool Royale training navigation anchored to the training lobby when returning or advancing between tasks
- initialize the Pool Royale lobby play type from the URL so training sessions reopen directly in the training tab

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921677acdb88320a0d20ca7d10cfa63)