### PR TITLE
Fix Pool Royale navigation hook

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -15831,6 +15831,7 @@ function PoolRoyaleGame({
 }
 
 export default function PoolRoyale() {
+  const navigate = useNavigate();
   const location = useLocation();
   const variantKey = useMemo(() => {
     const params = new URLSearchParams(location.search);


### PR DESCRIPTION
## Summary
- add the missing navigation hook to the Pool Royale page so back button and exits work without runtime errors

## Testing
- npm run build --prefix webapp

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69216ebda2648320a46db55962dea989)