### PR TITLE
Ensure Tennis Battle Royal swings add upward lift

### DIFF
--- a/webapp/src/components/TennisBattleRoyal3D.jsx
+++ b/webapp/src/components/TennisBattleRoyal3D.jsx
@@ -1493,6 +1493,12 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
         vel.copy(blended.multiplyScalar(currentSpeed));
       }
 
+      const baseLift = state.live ? 2.6 : 3.4;
+      const minUpward = baseLift + (swing.force ?? 0.5) * 2.0;
+      if (vel.y < minUpward) {
+        vel.y = minUpward;
+      }
+
       const capped = THREE.MathUtils.clamp(vel.length(), 0, OUTGOING_SPEED_CAP);
       if (vel.length() > capped) {
         vel.setLength(capped);


### PR DESCRIPTION
## Summary
- enforce a minimum upward component on Tennis Battle Royal swing impacts to prevent shots from driving into the court

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69219cdd762483209c28126d227222d4)