### PR TITLE
Improve Tirana 2040 bootstrap handling and zoom

### DIFF
--- a/webapp/public/tirana-2040-main.js
+++ b/webapp/public/tirana-2040-main.js
@@ -1939,8 +1939,20 @@ export async function startTirana2040(){
   applyMode();
 
   const zoomSlider=$('zoomSlider');
+  const MIN_ZOOM_FOV=12;
+  function applyZoomFromSlider(){
+    if(!zoomSlider) return;
+    const v=parseFloat(zoomSlider.value||'1');
+    const zoomedFov = 70 / v;
+    camera.fov = THREE.MathUtils.clamp(zoomedFov, MIN_ZOOM_FOV, 70);
+    camera.updateProjectionMatrix();
+  }
+  if(zoomSlider){
+    zoomSlider.value = zoomSlider.value || '3';
+    zoomSlider.addEventListener('input', applyZoomFromSlider);
+    applyZoomFromSlider();
+  }
   function updateZoomUI(){ const box=$('zoomBox'); if(!box) return; if(currentKey==='AK47' && inputMode==='A'){ box.style.display='flex'; } else { box.style.display='none'; } }
-  zoomSlider.addEventListener('input',()=>{ const v=parseFloat(zoomSlider.value||'1'); camera.fov = THREE.MathUtils.clamp(70 / v, 18, 70); camera.updateProjectionMatrix(); });
 
   const climbBtn=$('climbBtn');
   const ladderState={ active:false, index:-1 };
@@ -2105,5 +2117,7 @@ export async function startTirana2040(){
   } catch(err){
     console.error('Tirana 2040 failed to bootstrap', err);
     window.__phase = `error:${err?.message||err}`;
+    try { updateStatus('Tirana 2040 • Failed to load'); } catch(_){ }
+    throw err;
   }
 }

--- a/webapp/public/tirana-2040.html
+++ b/webapp/public/tirana-2040.html
@@ -26,7 +26,7 @@
   <div id="crosshair"></div>
 
   <div id="joyMove" class="joy"><div class="knob"></div></div>
-  <div id="zoomBox"><span id="zoomLabel">AK Zoom</span><input id="zoomSlider" type="range" min="1" max="3" step="0.01" value="1" /></div>
+  <div id="zoomBox"><span id="zoomLabel">AK Zoom</span><input id="zoomSlider" type="range" min="1" max="4" step="0.01" value="3" /></div>
   <div id="padContainer" class="padStack">
     <div class="fireRow">
       <button id="shootPad" class="fireButton">Shoot</button>


### PR DESCRIPTION
## Summary
- surface bootstrap failures for Tirana 2040 with clearer status feedback
- increase the AK47 zoom range and set the tighter view as the default camera

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69219d4a59188320afbb8804d411cc6c)