### PR TITLE
Improve Pool Royale AI planning and simplify broadcast cameras

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -268,6 +268,65 @@ function generateBankPotCandidates (state, colour) {
   return shots
 }
 
+function generateKickPotCandidates (state, colour) {
+  // When a direct view of the object ball is blocked, bounce off a rail to
+  // take the shot instead of settling for a foul or poor safety.
+  const cue = state.balls.find(b => b.colour === 'cue')
+  const balls = state.balls.filter(b => b.colour === colour && !b.pocketed)
+  const shots = []
+  const rails = ['left', 'right', 'top', 'bottom']
+
+  for (const ball of balls) {
+    // only consider rails when the straight path is obstructed
+    if (!pathBlocked(cue, ball, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+    for (const rail of rails) {
+      const mirroredBall = mirrorPoint(ball, state.width, state.height, rail)
+      if (pathBlocked(cue, mirroredBall, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+
+      const anchor = intersectionWithRail(cue, mirroredBall, rail, state.width, state.height)
+      let bestPocket = null
+      let bestAngle = Infinity
+      let bestView = -Infinity
+      let bestDist = Infinity
+
+      for (const pocket of state.pockets) {
+        const entry = pocketEntry(pocket, state)
+        if (pathBlocked(ball, entry, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+        const angle = cutAngle(anchor, ball, entry)
+        const d = dist(ball, entry)
+        const view = Math.atan2(state.ballRadius * 2, d)
+        if (
+          view > bestView + 1e-6 ||
+          (Math.abs(view - bestView) <= 1e-6 && angle < bestAngle)
+        ) {
+          bestView = view
+          bestAngle = angle
+          bestDist = d
+          bestPocket = entry
+        }
+      }
+
+      if (!bestPocket) continue
+
+      for (const params of CUE_VARIATIONS) {
+        shots.push({
+          actionType: 'pot',
+          targetBall: ball,
+          pocket: bestPocket,
+          cueParams: params,
+          bankAnchor: anchor,
+          angle: bestAngle,
+          distCT: dist(cue, anchor) + dist(anchor, ball),
+          distTP: bestDist,
+          isKick: true
+        })
+      }
+    }
+  }
+
+  return shots
+}
+
 function mirrorPoint (pt, width, height, rail) {
   switch (rail) {
     case 'left':
@@ -392,6 +451,11 @@ function estimatePotProbability (shot, state) {
 
   // combine distance and angle with stronger emphasis on accuracy
   let P = angleScore * 0.75 + distScore * 0.25
+
+  if (shot.isKick) {
+    P *= 0.9
+    P -= 0.04
+  }
 
   // adjust by learnt success rates
   const angleBucket = Math.round(angleDeg / 7.5)
@@ -554,7 +618,7 @@ function evaluateCandidates (state, colour, candidates) {
       const baseValue = 1.05
       const risk = foulRisk(c, state)
       const straightBoost = typeof c.angle === 'number' ? Math.max(0, (Math.PI / 10 - c.angle) / (Math.PI / 10)) * 0.25 : 0
-      const positionWeight = 1.1
+      const positionWeight = 1.25
       EV = Ppot * (baseValue + nextBest * positionWeight + straightBoost) - riskPenalty(risk)
     }
     if (!best || EV > best.EV) {
@@ -570,8 +634,10 @@ function chooseBestAction (state, colour) {
   // nothing else is available.
   let candidates = generatePotCandidates(state, colour)
   const bankShots = generateBankPotCandidates(state, colour)
+  const kickPots = generateKickPotCandidates(state, colour)
   const kicks = generateKickCandidates(state, colour, 4)
-  if (candidates.length === 0) candidates = bankShots
+  candidates = candidates.concat(bankShots, kickPots)
+
   if (candidates.length === 0) candidates = kicks
   if (candidates.length === 0) {
     // No clear potting opportunity – fall back to defensive play.

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -9695,12 +9695,22 @@ function PoolRoyaleGame({
       });
       updateCueRackHighlights();
 
+      const resolveBroadcastDistance = () => {
+        const verticalFov = THREE.MathUtils.degToRad(STANDING_VIEW_FOV);
+        const aspect = 9 / 16; // worst-case portrait aspect to guarantee full coverage
+        const halfVertical = verticalFov / 2;
+        const halfHorizontal = Math.atan(Math.tan(halfVertical) * aspect);
+        const safety = BALL_R * 6;
+        const verticalNeed = (PLAY_H / 2 + safety) / Math.tan(halfVertical);
+        const horizontalNeed = (PLAY_W / 2 + safety) / Math.tan(halfHorizontal);
+        return Math.max(verticalNeed, horizontalNeed);
+      };
       const broadcastClearance = wallThickness * 1.1 + BALL_R * 4;
       const shortRailTarget = Math.max(
-        PLAY_H / 2 + BALL_R * 8, // keep a modest clearance so the broadcast cameras sit closer to the table
+        resolveBroadcastDistance(),
         roomDepth / 2 - wallThickness - broadcastClearance
       );
-      const shortRailSlideLimit = CAMERA_LATERAL_CLAMP.short * 0.92;
+      const shortRailSlideLimit = 0;
       const broadcastRig = createBroadcastCameras({
         floorY,
         cameraHeight: TABLE_Y + TABLE.THICK + BALL_R * 9.2,
@@ -9722,17 +9732,10 @@ function PoolRoyaleGame({
         tripodExtra;
       const tripodMaxZ = roomDepth / 2 - wallThickness - BALL_R * 4;
       const tripodZOffset = Math.min(tripodMaxZ, tripodDesiredZ);
-      const tripodSideTuck = BALL_R * 1.5;
-      const tripodDesiredX =
-        TABLE.W / 2 + BALL_R * 12 + tripodExtra - tripodSideTuck;
-      const tripodMaxX = roomWidth / 2 - wallThickness - 0.6;
-      const tripodXOffset = Math.min(tripodMaxX, tripodDesiredX);
       const tripodTarget = new THREE.Vector3(0, TABLE_Y + TABLE.THICK * 0.5, 0);
       const tripodPositions = [
-        { x: tripodXOffset, z: tripodZOffset },
-        { x: -tripodXOffset, z: tripodZOffset },
-        { x: tripodXOffset, z: -tripodZOffset },
-        { x: -tripodXOffset, z: -tripodZOffset }
+        { x: 0, z: tripodZOffset },
+        { x: 0, z: -tripodZOffset }
       ];
       tripodPositions.forEach(({ x, z }) => {
         const { group: tripodGroup, headPivot } = createTripodBroadcastCamera();


### PR DESCRIPTION
## Summary
- teach the UK 8-ball AI to choose cushion-first potting lines and weight follow-up position play more heavily
- adjust shot evaluation to favour professional pace and avoid fouls when visibility is blocked
- lock broadcast cameras to two centered short-rail mounts that frame the whole table without sliding

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69219e7ad0e883208a9ec9c0cd45b257)