### PR TITLE
Limit pool AI cushion shots to fallback

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -629,16 +629,22 @@ function evaluateCandidates (state, colour, candidates) {
 }
 
 function chooseBestAction (state, colour) {
-  // Prefer direct pots with a clear path. Shots involving cushions are
-  // intentionally excluded so that they are only considered if absolutely
-  // nothing else is available.
-  let candidates = generatePotCandidates(state, colour)
-  const bankShots = generateBankPotCandidates(state, colour)
-  const kickPots = generateKickPotCandidates(state, colour)
+  // Prefer direct pots with a clear path. Cushion-assisted pots are only
+  // explored when every straight look is blocked so the AI plays bank/kick
+  // shots as a last resort rather than by default.
+  const directPots = generatePotCandidates(state, colour)
+  let candidates = [...directPots]
   const kicks = generateKickCandidates(state, colour, 4)
-  candidates = candidates.concat(bankShots, kickPots)
 
-  if (candidates.length === 0) candidates = kicks
+  if (candidates.length === 0) {
+    const bankShots = generateBankPotCandidates(state, colour)
+    const kickPots = generateKickPotCandidates(state, colour)
+    candidates = candidates.concat(bankShots, kickPots)
+  }
+
+  if (candidates.length === 0) {
+    candidates = kicks
+  }
   if (candidates.length === 0) {
     // No clear potting opportunity – fall back to defensive play.
     candidates = generateSafeties(state, colour)


### PR DESCRIPTION
## Summary
- restrict cushion-assisted bank and kick pots to fallback options when no direct pot is available
- keep safety and multi-rail kick logic as last resort selections

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921a2a6d078832081e5aca23c63f26c)