### PR TITLE
Add AI agent chat popup backed by service endpoint

### DIFF
--- a/bot/routes/ai.js
+++ b/bot/routes/ai.js
@@ -1,0 +1,79 @@
+import { Router } from 'express';
+import OpenAI from 'openai';
+import { withProxy } from '../utils/proxyAgent.js';
+
+const router = Router();
+
+const client = process.env.OPENAI_API_KEY
+  ? new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+      fetch: (url, options) => fetch(url, withProxy(options)),
+    })
+  : null;
+
+const SYSTEM_PROMPT = `You are TonPlaygram AI Service Desk. Answer concisely, avoid speculation, and use bullet points when listing steps. Keep responses aligned with TonPlaygram features such as mining, games, wallet, and referrals. Never expose secrets or internal tokens. Use the latest context from the user to stay accurate.`;
+
+router.post('/chat', async (req, res) => {
+  const { message, history = [], telegramId, context } = req.body || {};
+  if (!message || typeof message !== 'string') {
+    return res.status(400).json({ error: 'message is required' });
+  }
+  if (!client) {
+    return res
+      .status(503)
+      .json({ error: 'AI agent is not configured. Please try again later.' });
+  }
+
+  const safeHistory = Array.isArray(history)
+    ? history
+        .filter(
+          (entry) =>
+            entry &&
+            typeof entry.content === 'string' &&
+            ['user', 'assistant'].includes(entry.role)
+        )
+        .slice(-10)
+        .map((entry) => ({
+          role: entry.role,
+          content: entry.content.slice(0, 2000)
+        }))
+    : [];
+
+  const messages = [
+    { role: 'system', content: SYSTEM_PROMPT },
+    ...safeHistory,
+    { role: 'user', content: message.slice(0, 2000) }
+  ];
+
+  if (telegramId) {
+    messages.splice(1, 0, {
+      role: 'system',
+      content: `The requester Telegram ID is ${telegramId}.`
+    });
+  }
+  if (context) {
+    messages.splice(1, 0, {
+      role: 'system',
+      content: `Additional TonPlaygram context: ${String(context).slice(0, 2000)}`
+    });
+  }
+
+  try {
+    const completion = await client.chat.completions.create({
+      model: process.env.OPENAI_MODEL || 'gpt-4o-mini',
+      messages,
+      temperature: 0.3,
+      max_tokens: 400
+    });
+    const reply = completion.choices?.[0]?.message?.content?.trim();
+    if (!reply) {
+      return res.status(502).json({ error: 'AI agent returned no reply' });
+    }
+    res.json({ reply });
+  } catch (err) {
+    console.error('AI chat failed:', err.message);
+    res.status(500).json({ error: 'Failed to contact AI agent' });
+  }
+});
+
+export default router;

--- a/bot/server.js
+++ b/bot/server.js
@@ -24,6 +24,7 @@ import storeRoutes, { BUNDLES } from './routes/store.js';
 import adsRoutes from './routes/ads.js';
 import influencerRoutes from './routes/influencer.js';
 import onlineRoutes from './routes/online.js';
+import aiRoutes from './routes/ai.js';
 import User from './models/User.js';
 import GameResult from './models/GameResult.js';
 import AdView from './models/AdView.js';
@@ -149,6 +150,7 @@ app.use('/api/social', socialRoutes);
 app.use('/api/broadcast', broadcastRoutes);
 app.use('/api/store', storeRoutes);
 app.use('/api/online', onlineRoutes);
+app.use('/api/ai', aiRoutes);
 
 app.post('/api/goal-rush/calibration', (req, res) => {
   const { accountId, calibration } = req.body || {};

--- a/webapp/src/components/AiAgentChat.jsx
+++ b/webapp/src/components/AiAgentChat.jsx
@@ -1,0 +1,204 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { AiOutlineClose, AiOutlineSend } from 'react-icons/ai';
+import LoginOptions from './LoginOptions.jsx';
+import { askAiAgent } from '../utils/api.js';
+import { getTelegramId } from '../utils/telegram.js';
+
+const QUICK_PROMPTS = [
+  'Çfarë është TonPlaygram dhe si funksionon?',
+  'Si të rris shpejtësinë e mining?',
+  'Çfarë transaksionesh shihen në wallet?',
+  'Cilat janë hapat për të nisur një ndeshje me miqtë?'
+];
+
+const CONTEXT_SNIPPET =
+  'TonPlaygram ofron mining ditor, lojëra si Pool Royale, Goal Rush dhe Free Kick, ku fitimet llogariten me stake të paracaktuara. Balancat TPC ruhen off-chain brenda aplikacionit. Referral pages japin bonuse dhe çdo përdorues ka profile me foto dhe bio.';
+
+export default function AiAgentChat({ open, onClose }) {
+  const [messages, setMessages] = useState([
+    {
+      role: 'assistant',
+      content:
+        'Përshëndetje! Jam TonPlaygram AI Service Desk. Bëj pyetje për mining, lojërat, wallet apo çdo informacion tjetër rreth platformës.'
+    }
+  ]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [telegramId, setTelegramId] = useState(null);
+  const chatRef = useRef(null);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setError('');
+    setLoading(false);
+    setInput('');
+    try {
+      setTelegramId(getTelegramId());
+    } catch (err) {
+      setTelegramId(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (chatRef.current) {
+      chatRef.current.scrollTop = chatRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  useEffect(() => {
+    if (open && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [open]);
+
+  const history = useMemo(
+    () =>
+      messages.map(({ role, content }) => ({
+        role,
+        content
+      })),
+    [messages]
+  );
+
+  async function handleSend(customText) {
+    const text = (customText ?? input).trim();
+    if (!text || loading) return;
+
+    setMessages((prev) => [...prev, { role: 'user', content: text }]);
+    setInput('');
+    setLoading(true);
+    setError('');
+
+    const res = await askAiAgent({
+      telegramId,
+      message: text,
+      history,
+      context: CONTEXT_SNIPPET
+    });
+
+    setLoading(false);
+    if (res?.error) {
+      setError(res.error);
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: 'assistant',
+          content: 'Nuk arrita të marr përgjigje. Provo përsëri pas pak.'
+        }
+      ]);
+      return;
+    }
+    if (res?.reply) {
+      setMessages((prev) => [...prev, { role: 'assistant', content: res.reply }]);
+    }
+  }
+
+  if (!open) return null;
+
+  if (!telegramId) {
+    return createPortal(
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+        <div className="bg-surface border border-border rounded-2xl shadow-xl w-full max-w-lg p-4">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-lg font-semibold text-white">TonPlaygram AI</h3>
+            <button
+              onClick={onClose}
+              className="text-subtext hover:text-white transition"
+              aria-label="Mbyll"
+            >
+              <AiOutlineClose className="w-5 h-5" />
+            </button>
+          </div>
+          <p className="text-sm text-subtext mb-3">
+            Hyr me Telegram për të biseduar me AI Agent dhe për të marrë suport të personalizuar.
+          </p>
+          <LoginOptions />
+        </div>
+      </div>,
+      document.body
+    );
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" role="dialog" aria-modal="true">
+      <div className="bg-surface border border-border rounded-2xl shadow-xl w-full max-w-lg flex flex-col">
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <div>
+            <p className="text-xs text-primary font-semibold">TonPlaygram AI Agent</p>
+            <h3 className="text-lg font-bold text-white">Service Desk</h3>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-subtext hover:text-white transition"
+            aria-label="Mbyll"
+          >
+            <AiOutlineClose className="w-5 h-5" />
+          </button>
+        </div>
+        <div className="px-4 pt-3 space-y-2 text-xs text-subtext">
+          <p>Pyet për informacion rreth lojërave, mining, wallet ose referall dhe merr përgjigje të azhurnuara.</p>
+          <div className="flex flex-wrap gap-2">
+            {QUICK_PROMPTS.map((prompt) => (
+              <button
+                key={prompt}
+                className="px-2 py-1 rounded-full border border-border bg-background/60 hover:border-primary text-[11px]"
+                onClick={() => handleSend(prompt)}
+              >
+                {prompt}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="flex-1 overflow-hidden mt-3">
+          <div
+            ref={chatRef}
+            className="h-80 overflow-y-auto px-4 space-y-3 pb-3"
+          >
+            {messages.map((msg, idx) => (
+              <div key={idx} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                <div
+                  className={`rounded-2xl px-3 py-2 max-w-[85%] text-sm whitespace-pre-wrap leading-relaxed ${
+                    msg.role === 'user'
+                      ? 'bg-primary text-black'
+                      : 'bg-background border border-border text-white'
+                  }`}
+                >
+                  {msg.content}
+                </div>
+              </div>
+            ))}
+            {loading && (
+              <div className="text-xs text-subtext">AI po shkruan…</div>
+            )}
+          </div>
+        </div>
+        {error && <p className="text-xs text-red-400 px-4">{error}</p>}
+        <div className="p-4 border-t border-border flex items-center space-x-2">
+          <input
+            ref={inputRef}
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleSend();
+            }}
+            placeholder="Shkruaj pyetjen tënde..."
+            className="flex-1 bg-background border border-border rounded-xl px-3 py-2 text-sm text-white focus:outline-none focus:border-primary"
+          />
+          <button
+            onClick={() => handleSend()}
+            className="p-2 rounded-full bg-primary text-black hover:bg-primary-hover disabled:opacity-60"
+            disabled={loading}
+            aria-label="Dërgo"
+          >
+            <AiOutlineSend className="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from 'react';
-
 import TasksCard from '../components/TasksCard.jsx';
 import NftGiftCard from '../components/NftGiftCard.jsx';
 import ProjectAchievementsCard from '../components/ProjectAchievementsCard.jsx';
 import HomeGamesCard from '../components/HomeGamesCard.jsx';
 import DailyCheckIn from '../components/DailyCheckIn.jsx';
+import { useEffect, useState } from 'react';
 
 import {
   FaArrowUp,
@@ -33,11 +32,13 @@ import TonConnectButton from '../components/TonConnectButton.jsx';
 import useTokenBalances from '../hooks/useTokenBalances.js';
 import useWalletUsdValue from '../hooks/useWalletUsdValue.js';
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
+import AiAgentChat from '../components/AiAgentChat.jsx';
 
 
 export default function Home() {
 
   const [status, setStatus] = useState('checking');
+  const [showAiChat, setShowAiChat] = useState(false);
 
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
   const { tpcBalance, tonBalance, tpcWalletBalance } = useTokenBalances();
@@ -259,12 +260,13 @@ export default function Home() {
             <p className="text-white font-semibold text-sm">Ndihmë e menjëhershme</p>
             <p className="text-xs text-subtext">Kliko më poshtë për të hapur chat-in e AI Agent dhe merr suportin e duhur.</p>
           </div>
-          <Link
-            to="/messages?channel=ai-agent"
+          <button
+            type="button"
+            onClick={() => setShowAiChat(true)}
             className="inline-flex items-center justify-center px-3 py-1.5 text-sm font-semibold bg-primary text-surface rounded-full shadow-primary/40 hover:shadow-primary/60 shadow"
           >
             Hap AI Agent
-          </Link>
+          </button>
         </div>
       </div>
       <p className="text-center text-xs text-subtext">Status: {status}</p>
@@ -290,6 +292,8 @@ export default function Home() {
           future of crypto gaming. 🚀
         </p>
       </div>
+
+      <AiAgentChat open={showAiChat} onClose={() => setShowAiChat(false)} />
     </div>
 
   );

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -394,6 +394,15 @@ export function sendMessage(fromId, toId, text) {
   return post('/api/social/send-message', { fromId, toId, text });
 }
 
+export function askAiAgent({ telegramId, message, history = [], context } = {}) {
+  return post('/api/ai/chat', {
+    telegramId,
+    message,
+    history,
+    context
+  });
+}
+
 export function sendGift(fromId, toId, gift) {
   return post('/api/account/gift', {
     fromAccount: fromId,


### PR DESCRIPTION
## Summary
- add backend `/api/ai/chat` endpoint that proxies questions to the configured OpenAI model with request context
- expose a reusable AI Agent chat modal with quick prompts, error handling, and Telegram login gating
- replace the AI button on the home page with a popup trigger using the new API helper instead of redirecting to inbox

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921b2b84490832088b72e18bba083c0)