### PR TITLE
Improve Pool Royale AI, training tasks, and HUD

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -2,7 +2,7 @@
 .ps {
   /* slimmer slider to match pool game styling */
   --ps-width: 46px;
-  --ps-height: 576px;
+  --ps-height: 640px;
   --ps-radius: 23px;
   --ps-track-bg: rgba(255, 255, 255, 0.15);
   --ps-gradient-low: #ffe066;

--- a/webapp/src/config/poolRoyaleTraining.js
+++ b/webapp/src/config/poolRoyaleTraining.js
@@ -1,115 +1,148 @@
-export const TRAINING_SCENARIOS = (() => {
-  const baseLayouts = [
-    {
-      title: 'Tap-in to corner',
-      description: 'Pocket a ball that is hanging over the corner with simple center-ball strike.',
-      cue: { x: -0.55, z: -0.6 },
-      balls: [{ rackIndex: 7, x: 0.82, z: 0.82 }],
-      tip: 'Feather the cue and roll the ball gently into the pocket.'
-    },
-    {
-      title: 'Mid-distance stun',
-      description: 'Stop the cue ball after contact on a mid-table cut.',
-      cue: { x: -0.35, z: -0.2 },
-      balls: [
-        { rackIndex: 2, x: 0.35, z: 0.18 },
-        { rackIndex: 6, x: 0.55, z: -0.1 }
-      ],
-      tip: 'Keep the tip at center ball and use a crisp stroke.'
-    },
-    {
-      title: 'Soft follow',
-      description: 'Float the cue ball forward for next position after a short pot.',
-      cue: { x: -0.5, z: -0.25 },
-      balls: [{ rackIndex: 3, x: 0.55, z: -0.35 }],
-      tip: 'Drag the spin marker just above center and use light power.'
-    },
-    {
-      title: 'Controlled draw',
-      description: 'Pull the cue ball back a few inches for shape.',
-      cue: { x: -0.4, z: -0.15 },
-      balls: [{ rackIndex: 4, x: 0.45, z: -0.05 }],
-      tip: 'Aim below center with a smooth acceleration.'
-    },
-    {
-      title: 'Side pocket test',
-      description: 'Cut a ball to the side pocket without scratching.',
-      cue: { x: -0.6, z: 0.0 },
-      balls: [{ rackIndex: 5, x: 0.0, z: 0.02 }],
-      tip: 'Favor a trace of stun to keep the cue ball away from the corner.'
-    },
-    {
-      title: 'Long rail bank',
-      description: 'Bank a ball off the long rail to the opposite corner.',
-      cue: { x: -0.65, z: -0.45 },
-      balls: [{ rackIndex: 8, x: 0.25, z: 0.4 }],
-      tip: 'Visualize the mirror angle and strike with medium pace.'
-    },
-    {
-      title: 'Two-ball pattern',
-      description: 'Clear two open balls with simple position routes.',
-      cue: { x: -0.45, z: -0.25 },
-      balls: [
-        { rackIndex: 1, x: 0.25, z: -0.15 },
-        { rackIndex: 9, x: 0.4, z: 0.35 }
-      ],
-      tip: 'Play the easier ball first and float to the second angle.'
-    },
-    {
-      title: 'Three-ball ladder',
-      description: 'Run a short three-ball ladder staying on the same rail.',
-      cue: { x: -0.35, z: -0.35 },
-      balls: [
-        { rackIndex: 10, x: 0.2, z: -0.25 },
-        { rackIndex: 11, x: 0.35, z: -0.05 },
-        { rackIndex: 12, x: 0.5, z: 0.15 }
-      ],
-      tip: 'Use soft follow to move up-table a few inches at a time.'
-    },
-    {
-      title: 'Nine-ball break shot',
-      description: 'Start with the 1-ball in the side and open the 9 for the win.',
-      cue: { x: -0.4, z: -0.4 },
-      balls: [
-        { rackIndex: 0, x: -0.05, z: 0.1 },
-        { rackIndex: 8, x: 0.45, z: 0.45 }
-      ],
-      tip: 'Aim thin on the 1-ball to send the cue ball down-table.'
-    },
-    {
-      title: 'Safety lock-up',
-      description: 'Hide the cue ball behind a blocker after contact.',
-      cue: { x: -0.5, z: -0.2 },
-      balls: [
-        { rackIndex: 13, x: 0.2, z: 0.1 },
-        { rackIndex: 14, x: 0.35, z: 0.12 }
-      ],
-      tip: 'Use soft stun and a blocker ball to deny a reply.'
-    }
-  ];
+const DIFFICULTY_LABELS = ['Intro', 'Rookie', 'Challenger', 'Advanced', 'Elite'];
 
+const TRAINING_TEMPLATES = [
+  {
+    title: 'Tap-in to corner',
+    discipline: 'American Billiards',
+    objective: 'Feather the overhanging ball into the corner without scratching.',
+    cue: { x: -0.55, z: -0.6 },
+    balls: [{ rackIndex: 1, x: 0.82, z: 0.82 }],
+    tip: 'Gently roll through center ball to let gravity do the work.'
+  },
+  {
+    title: 'UK 8-ball cut',
+    discipline: 'UK 8-Ball',
+    objective: 'Cut the object ball to the corner and hold the cue ball for the next shot.',
+    cue: { x: -0.38, z: -0.18 },
+    balls: [{ rackIndex: 2, x: 0.42, z: 0.24 }],
+    tip: 'Use a soft stun and favor the center of the pocket mouth.'
+  },
+  {
+    title: 'Side pocket tester',
+    discipline: 'UK 8-Ball',
+    objective: 'Slide the ball into the side pocket while avoiding the scratch lanes.',
+    cue: { x: -0.62, z: 0.02 },
+    balls: [{ rackIndex: 3, x: 0.02, z: 0.08 }],
+    tip: 'Aim for the middle of the side opening and keep the pace light.'
+  },
+  {
+    title: 'Long rail bank',
+    discipline: 'American Billiards',
+    objective: 'Bank off the long rail and drop the ball in the opposite corner.',
+    cue: { x: -0.65, z: -0.45 },
+    balls: [{ rackIndex: 4, x: 0.28, z: 0.46 }],
+    tip: 'Mirror the line with the diamonds and commit to a medium stroke.'
+  },
+  {
+    title: '9-ball side starter',
+    discipline: '9-Ball',
+    objective: 'Pocket the 1-ball in the side and drift down-table for position.',
+    cue: { x: -0.44, z: -0.38 },
+    balls: [
+      { rackIndex: 1, x: -0.02, z: 0.12 },
+      { rackIndex: 9, x: 0.46, z: 0.46 }
+    ],
+    tip: 'Favor a thin hit so the cue ball clears the top rail safely.'
+  },
+  {
+    title: 'Two-ball pattern',
+    discipline: 'American Billiards',
+    objective: 'Clear two open balls while floating gently into shape.',
+    cue: { x: -0.46, z: -0.26 },
+    balls: [
+      { rackIndex: 6, x: 0.24, z: -0.12 },
+      { rackIndex: 7, x: 0.38, z: 0.34 }
+    ],
+    tip: 'Play the nearer ball first and let a soft follow open the angle.'
+  },
+  {
+    title: 'Three-ball ladder',
+    discipline: 'UK 8-Ball',
+    objective: 'Work up the rail through three balls without losing angle.',
+    cue: { x: -0.32, z: -0.36 },
+    balls: [
+      { rackIndex: 8, x: 0.18, z: -0.26 },
+      { rackIndex: 10, x: 0.34, z: -0.06 },
+      { rackIndex: 11, x: 0.5, z: 0.14 }
+    ],
+    tip: 'Use gentle follow to step the cue ball up-table one pocket at a time.'
+  },
+  {
+    title: 'Safety tuck',
+    discipline: 'American Billiards',
+    objective: 'Hide the cue ball behind a blocker after contacting the target.',
+    cue: { x: -0.52, z: -0.2 },
+    balls: [
+      { rackIndex: 12, x: 0.22, z: 0.1 },
+      { rackIndex: 13, x: 0.36, z: 0.14 }
+    ],
+    tip: 'Feather the hit and let the blocker carry the defensive weight.'
+  },
+  {
+    title: 'Double-kiss escape',
+    discipline: 'UK 8-Ball',
+    objective: 'Use the long rail to double the ball back to the corner.',
+    cue: { x: -0.58, z: 0.36 },
+    balls: [{ rackIndex: 14, x: 0.24, z: 0.64 }],
+    tip: 'Count the diamonds and trust the mirror line to find the pocket center.'
+  },
+  {
+    title: 'Rail-first 9-ball',
+    discipline: '9-Ball',
+    objective: 'Kick at the lowest ball first and open the rack without fouling.',
+    cue: { x: -0.62, z: -0.12 },
+    balls: [
+      { rackIndex: 1, x: 0.02, z: -0.3 },
+      { rackIndex: 9, x: 0.46, z: 0.28 }
+    ],
+    tip: 'Use the rail to guarantee a legal hit and let the cue ball run free.'
+  }
+];
+
+const clamp = (value) => Math.max(-0.94, Math.min(0.94, value));
+
+export const TRAINING_SCENARIOS = (() => {
   const scenarios = [];
   for (let i = 0; i < 50; i++) {
-    const base = baseLayouts[i % baseLayouts.length];
     const level = i + 1;
-    const drift = (level % 5) * 0.04;
-    const rotatedBalls = base.balls.map((ball, idx) => ({
-      ...ball,
-      x: Math.max(-0.9, Math.min(0.9, ball.x + (idx % 2 === 0 ? drift : -drift))),
-      z: Math.max(-0.9, Math.min(0.9, ball.z + (idx % 2 === 0 ? -drift : drift)))
-    }));
+    const template = TRAINING_TEMPLATES[i % TRAINING_TEMPLATES.length];
+    const tier = Math.min(DIFFICULTY_LABELS.length - 1, Math.floor(i / 10));
+    const drift = (level % 5) * 0.018 + tier * 0.02;
+    const rotation = ((level + 1) % 2 === 0 ? 1 : -1) * 0.03 * tier;
+
+    const balls = template.balls.map((ball, idx) => {
+      const xOffset = (idx % 2 === 0 ? 1 : -1) * drift + rotation;
+      const zOffset = (idx % 2 === 0 ? -1 : 1) * drift;
+      return {
+        rackIndex: ball.rackIndex,
+        x: clamp(ball.x + xOffset),
+        z: clamp(ball.z + zOffset)
+      };
+    });
+
+    if (tier >= 2 && template.balls.length < 3) {
+      balls.push({ rackIndex: 15 + tier, x: clamp(0.32 - drift), z: clamp(0.22 + drift) });
+    }
+    if (tier >= 3) {
+      balls.push({ rackIndex: 30 + tier, x: clamp(-0.18 - rotation), z: clamp(-0.14 - drift) });
+    }
+
     const cue = {
-      x: Math.max(-0.9, Math.min(0.9, (base.cue?.x ?? -0.4) + drift * 0.5)),
-      z: Math.max(-0.9, Math.min(0.9, (base.cue?.z ?? -0.2) - drift * 0.4))
+      x: clamp((template.cue?.x ?? -0.4) - drift * 0.6),
+      z: clamp((template.cue?.z ?? -0.2) - drift * 0.35)
     };
+
     scenarios.push({
       level,
-      title: base.title,
-      description: `${base.description} (Level ${level})`,
+      title: `${template.title} (${template.discipline})`,
+      discipline: template.discipline,
+      objective: template.objective,
+      description: `${template.objective} — ${template.discipline} path ${DIFFICULTY_LABELS[tier]}.`,
       cue,
-      balls: rotatedBalls,
-      tip: base.tip,
-      reward: 50 + level * 10,
+      balls,
+      tip: template.tip,
+      difficultyLabel: DIFFICULTY_LABELS[tier],
+      reward: 60 + level * 12,
       nft: level % 10 === 0
     });
   }


### PR DESCRIPTION
## Summary
- retune Pool Royale AI targeting to prefer pocket centers, wide entrances, and avoid unnecessary cushion routes
- extend Pool Royale training pack with clearer objectives, difficulty tiers, and an always-available briefing panel with close control
- adjust HUD and styling tweaks including longer power slider, aligned chrome plate thickness, inward side pockets, and frame rate menu cleanup

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6921ef3f70dc8325be5262a81a23d4a4)