### PR TITLE
Improve cue ball in-hand placement guidance

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12975,10 +12975,6 @@ function PoolRoyaleGame({
         if (e.button != null && e.button !== 0) return;
         const p = project(e);
         if (!p) return;
-        if (cueBallPlacedFromHandRef.current) {
-          const dist = p.distanceTo(cue?.pos ?? new THREE.Vector2());
-          if (!Number.isFinite(dist) || dist > BALL_R * 1.2) return;
-        }
         if (!tryUpdatePlacement(p, false)) return;
         inHandDrag.active = true;
         inHandDrag.pointerId = e.pointerId ?? 'mouse';
@@ -15911,7 +15907,7 @@ function PoolRoyaleGame({
         </div>
       )}
       {hud?.inHand && (
-        <div className="absolute bottom-24 left-1/2 z-40 -translate-x-1/2 text-center text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.55)]">
+        <div className="pointer-events-none absolute left-1/2 top-4 z-40 -translate-x-1/2 text-center text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.55)]">
           <p className="text-sm font-semibold">Ball in hand</p>
           <p className="text-xs text-white/80">Tap, hold, and release the cue ball to move it.</p>
         </div>


### PR DESCRIPTION
## Summary
- move the ball-in-hand instructions to the top of the screen and prevent the banner from blocking interactions
- allow cue ball placement to start from any tap while the ball is in hand

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a6c0d8b083289ac745f9432dd3f6)