### PR TITLE
Boost Tennis Battle Royal ball force

### DIFF
--- a/webapp/src/components/TennisBattleRoyal3D.jsx
+++ b/webapp/src/components/TennisBattleRoyal3D.jsx
@@ -952,7 +952,8 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
     cpu.rotation.y = -Math.PI / 2;
     scene.add(cpu);
 
-    const OUTGOING_SPEED_CAP = 16.4;
+    const HIT_FORCE_MULTIPLIER = 5;
+    const OUTGOING_SPEED_CAP = 16.4 * HIT_FORCE_MULTIPLIER;
 
     const state = {
       gravity: -9.81,
@@ -1463,9 +1464,9 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
       if (!closing) return false;
 
       const vn = relVel.dot(normal);
-      const impulse = -(1 + swing.restitution) * vn;
+      const impulse = -(1 + swing.restitution) * vn * HIT_FORCE_MULTIPLIER;
       vel.addScaledVector(normal, impulse);
-      vel.addScaledVector(swingVel, 0.32);
+      vel.addScaledVector(swingVel, 0.32 * HIT_FORCE_MULTIPLIER);
 
       const tangent = relVel.sub(normal.clone().multiplyScalar(vn));
       if (tangent.lengthSq() > 1e-5) {


### PR DESCRIPTION
## Summary
- increase the tennis battle royal hit force by applying a 5x multiplier to swing impulses
- raise the outgoing speed cap to accommodate the stronger hits

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a6f5574c832897dbe0899ea143ee)