### PR TITLE
Reduce tennis ball force multiplier

### DIFF
--- a/webapp/src/components/TennisBattleRoyal3D.jsx
+++ b/webapp/src/components/TennisBattleRoyal3D.jsx
@@ -952,7 +952,7 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
     cpu.rotation.y = -Math.PI / 2;
     scene.add(cpu);
 
-    const HIT_FORCE_MULTIPLIER = 0.5;
+    const HIT_FORCE_MULTIPLIER = 0.05;
     const OUTGOING_SPEED_CAP = 16.4 * HIT_FORCE_MULTIPLIER;
 
     const state = {


### PR DESCRIPTION
## Summary
- reduce the tennis ball hit force multiplier to lower outgoing shot strength

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ad5240048328857d192deb86b396)