### PR TITLE
Improve ball-in-hand UX and aiming visuals

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -2,8 +2,8 @@
 .ps {
   /* slimmer slider to match pool game styling */
   --ps-width: 46px;
-  --ps-height: 640px;
-  --ps-radius: 23px;
+  --ps-height: 832px;
+  --ps-radius: 30px;
   --ps-track-bg: rgba(255, 255, 255, 0.15);
   --ps-gradient-low: #ffe066;
   --ps-gradient-mid: #ff8c00;
@@ -147,8 +147,19 @@
     var(--ps-gradient-high)
   );
   padding: 7.2px 2.4px;
+  touch-action: none;
+  overflow: visible;
   pointer-events: auto;
   z-index: 1;
+}
+
+.ps .ps-handle::before {
+  content: '';
+  position: absolute;
+  inset: -12px -10px;
+  border-radius: 14px;
+  background: transparent;
+  pointer-events: auto;
 }
 
 .ps .ps-handle-text {

--- a/snooker-power-slider.css
+++ b/snooker-power-slider.css
@@ -2,8 +2,8 @@
 
 .ps.ps-theme-snooker {
   --ps-width: 28px;
-  --ps-height: 416px;
-  --ps-radius: 14px;
+  --ps-height: 540px;
+  --ps-radius: 18px;
 }
 
 .ps.ps-theme-snooker .ps-handle {


### PR DESCRIPTION
## Summary
- Add a dedicated ball-in-hand placement toggle and hide aiming until placement is confirmed.
- Revamp aiming guides with clearer cue and target trajectories plus impact feedback tied to shot power.
- Extend the power slider height, expand its touch target, and prevent zero-power shots from firing.

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922abbad4dc8328bbd9b6c72f24bbc6)