### PR TITLE
Adjust Tennis Battle Royal hit force multiplier

### DIFF
--- a/webapp/src/components/TennisBattleRoyal3D.jsx
+++ b/webapp/src/components/TennisBattleRoyal3D.jsx
@@ -952,7 +952,7 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
     cpu.rotation.y = -Math.PI / 2;
     scene.add(cpu);
 
-    const HIT_FORCE_MULTIPLIER = 0.05;
+    const HIT_FORCE_MULTIPLIER = 2.5;
     const OUTGOING_SPEED_CAP = 16.4 * HIT_FORCE_MULTIPLIER;
 
     const state = {


### PR DESCRIPTION
## Summary
- set the Tennis Battle Royal hit force multiplier to 2.5 for stronger ball impacts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922afc79b688328961264de6d255a78)