### PR TITLE
Fix aiming after cue ball placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12833,6 +12833,11 @@ function PoolRoyaleGame({
           cue.active = true;
           inHandDrag.lastPos = null;
           cueBallPlacedFromHandRef.current = true;
+          if (hudRef.current?.inHand) {
+            const nextHud = { ...hudRef.current, inHand: false };
+            hudRef.current = nextHud;
+            setHud(nextHud);
+          }
         }
         return true;
       };


### PR DESCRIPTION
## Summary
- clear ball-in-hand state once the player commits a cue ball placement
- allow aiming controls and HUD to reflect the placement immediately

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922b33304208328b18700acf81284f2)