### PR TITLE
Map Tennis Battle Royal swipe power to 1-10 scale

### DIFF
--- a/webapp/src/components/TennisBattleRoyal3D.jsx
+++ b/webapp/src/components/TennisBattleRoyal3D.jsx
@@ -1436,8 +1436,14 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
       while (gestureTrail.length > 1 && now - gestureTrail[0].t > 260) gestureTrail.shift();
     }
     function deriveSwingFromGesture(vx, vy, spd, { serve = false } = {}) {
-      const baseline = serve ? 420 : 540;
-      const normalizedForce = THREE.MathUtils.clamp(spd / baseline, serve ? 0.35 : 0.26, 1);
+      const minSwipe = serve ? 320 : 420;
+      const maxSwipe = serve ? 1600 : 1800;
+      const swipePower = THREE.MathUtils.clamp(
+        THREE.MathUtils.mapLinear(spd, minSwipe, maxSwipe, 1, 10),
+        1,
+        10
+      );
+      const normalizedForce = THREE.MathUtils.clamp(swipePower / 10, serve ? 0.35 : 0.26, 1);
       const flat = new THREE.Vector2(vx, -vy);
       if (flat.lengthSq() < 1e-4) flat.set(0, 1);
       flat.normalize();
@@ -1460,6 +1466,7 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
         restitution: 1.06,
         reach: ballR + 0.7,
         force: normalizedForce,
+        power: swipePower,
         aimDirection: forwardDir.clone()
       };
     }


### PR DESCRIPTION
## Summary
- map Tennis Battle Royal swipe speed to a 1-10 power scale when deriving swings
- normalize swing force from the mapped power value and expose it on the swing payload for later use

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922b390302c832897cbc26525d96b8b)