### PR TITLE
Enhance Pool Royale aim visuals

### DIFF
--- a/snooker-power-slider.css
+++ b/snooker-power-slider.css
@@ -2,7 +2,7 @@
 
 .ps.ps-theme-snooker {
   --ps-width: 28px;
-  --ps-height: 540px;
+  --ps-height: 702px;
   --ps-radius: 18px;
 }
 


### PR DESCRIPTION
## Summary
- show distinct cue ball and target ball trajectories in the Pool Royale aiming guide
- size the contact ring to match the balls and keep it anchored at the impact point
- extend the Pool Royale power slider height by 30% for a longer pull range

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922b63d78d48328bbc801ae913d96d3)