### PR TITLE
Adjust tennis battle royal power range

### DIFF
--- a/webapp/src/components/TennisBattleRoyal3D.jsx
+++ b/webapp/src/components/TennisBattleRoyal3D.jsx
@@ -1439,11 +1439,11 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
       const minSwipe = serve ? 320 : 420;
       const maxSwipe = serve ? 1600 : 1800;
       const swipePower = THREE.MathUtils.clamp(
-        THREE.MathUtils.mapLinear(spd, minSwipe, maxSwipe, 1, 10),
-        1,
-        10
+        THREE.MathUtils.mapLinear(spd, minSwipe, maxSwipe, 4, 15),
+        4,
+        15
       );
-      const normalizedForce = THREE.MathUtils.clamp(swipePower / 10, serve ? 0.35 : 0.26, 1);
+      const normalizedForce = THREE.MathUtils.clamp(swipePower / 15, serve ? 0.35 : 0.26, 1);
       const flat = new THREE.Vector2(vx, -vy);
       if (flat.lengthSq() < 1e-4) flat.set(0, 1);
       flat.normalize();


### PR DESCRIPTION
## Summary
- extend swipe-derived power values to range from 4 to 15 in Tennis Battle Royal swings
- adjust normalized force scaling to match the expanded power range

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922b71688888328b4939f9e2eb853d9)