### PR TITLE
Adjust Pool Royale rails, controls, and training options

### DIFF
--- a/snooker-power-slider.css
+++ b/snooker-power-slider.css
@@ -52,7 +52,7 @@
 .ps.ps-theme-snooker .ps-cue-img {
   margin: 0;
   margin-bottom: 4px;
-  width: 120%;
+  width: 132%;
   max-width: none;
   transform-origin: 50% 0%;
   filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.25));


### PR DESCRIPTION
## Summary
- Widened side rail cut relief and tightened middle pocket jaw geometry to match feedback.
- Lowered the power slider placement and enlarged the pull cable artwork.
- Added a simple training menu that lets players choose solo or AI practice and toggle rule enforcement while hiding legacy task overlays.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ecfe56488320b2fd87710202b39c)