### PR TITLE
Simplify Pool Royale training and tweak table visuals

### DIFF
--- a/snooker-power-slider.css
+++ b/snooker-power-slider.css
@@ -52,7 +52,7 @@
 .ps.ps-theme-snooker .ps-cue-img {
   margin: 0;
   margin-bottom: 4px;
-  width: 120%;
+  width: 128%;
   max-width: none;
   transform-origin: 50% 0%;
   filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.25));


### PR DESCRIPTION
## Summary
- open up the side-rail relief and narrow/push the middle pocket jaws for a cleaner cut
- lower the Pool Royale power slider slightly and enlarge the cue cable graphic
- replace task-based training with a full-rack practice mode that lets players toggle solo/AI and rules from a new top-right menu

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f27bbd9c8320a65aadb98a0aeacd)