### PR TITLE
Restore Tennis Battle Royal stadium props

### DIFF
--- a/webapp/src/components/TennisBattleRoyal3D.jsx
+++ b/webapp/src/components/TennisBattleRoyal3D.jsx
@@ -120,6 +120,46 @@ function buildRoyalGrandstand() {
   return group;
 }
 
+function makeCourtSurfaceTexture(w = 2048, h = 4096) {
+  const c = document.createElement("canvas");
+  c.width = w;
+  c.height = h;
+  const g = c.getContext("2d");
+
+  const grad = g.createLinearGradient(0, 0, 0, h);
+  grad.addColorStop(0, "#2f3673");
+  grad.addColorStop(0.5, "#1f2b57");
+  grad.addColorStop(1, "#182648");
+  g.fillStyle = grad;
+  g.fillRect(0, 0, w, h);
+
+  g.globalAlpha = 0.1;
+  for (let i = 0; i < 1200; i += 1) {
+    const x = Math.random() * w;
+    const y = Math.random() * h;
+    const r = Math.random() * 3 + 1;
+    g.fillStyle = `rgba(255,255,255,${Math.random() * 0.35})`;
+    g.beginPath();
+    g.arc(x, y, r, 0, Math.PI * 2);
+    g.fill();
+  }
+  g.globalAlpha = 1;
+
+  const stripeCount = 6;
+  for (let i = 0; i <= stripeCount; i += 1) {
+    const t = i / stripeCount;
+    const y = t * h;
+    g.strokeStyle = "rgba(255,255,255,0.04)";
+    g.lineWidth = 8;
+    g.beginPath();
+    g.moveTo(0, y);
+    g.lineTo(w, y);
+    g.stroke();
+  }
+
+  return new THREE.CanvasTexture(c);
+}
+
 function buildGrandEntranceStairs({ stepCount = 12, run = 0.46, rise = 0.22, width = 26, landingDepth = 1.6 } = {}) {
   const stairs = new THREE.Group();
   const treadMat = new THREE.MeshStandardMaterial({ color: 0xcdd5e0, roughness: 0.82, metalness: 0.12 });
@@ -152,6 +192,146 @@ function buildGrandEntranceStairs({ stepCount = 12, run = 0.46, rise = 0.22, wid
   stairs.add(sideL, sideR);
 
   return stairs;
+}
+
+function buildBillboard({ width = 8, height = 2.6, depth = 0.2, message = "TonPlaygram Championships" } = {}) {
+  const board = new THREE.Group();
+  const canvas = document.createElement("canvas");
+  canvas.width = 1024;
+  canvas.height = 320;
+  const g = canvas.getContext("2d");
+  const gradient = g.createLinearGradient(0, 0, canvas.width, 0);
+  gradient.addColorStop(0, "#111827");
+  gradient.addColorStop(1, "#0f172a");
+  g.fillStyle = gradient;
+  g.fillRect(0, 0, canvas.width, canvas.height);
+  g.fillStyle = "#10b981";
+  g.font = "bold 96px 'Segoe UI', sans-serif";
+  g.textAlign = "center";
+  g.textBaseline = "middle";
+  g.fillText(message, canvas.width / 2, canvas.height / 2);
+
+  const tex = new THREE.CanvasTexture(canvas);
+  const panel = new THREE.Mesh(
+    new THREE.BoxGeometry(width, height, depth),
+    [
+      new THREE.MeshStandardMaterial({ color: 0x0b1224 }),
+      new THREE.MeshStandardMaterial({ color: 0x0b1224 }),
+      new THREE.MeshStandardMaterial({ color: 0x0b1224 }),
+      new THREE.MeshStandardMaterial({ color: 0x0b1224 }),
+      new THREE.MeshStandardMaterial({ map: tex, roughness: 0.6, metalness: 0.2 }),
+      new THREE.MeshStandardMaterial({ color: 0x0b1224 })
+    ]
+  );
+  panel.position.y = height / 2;
+  board.add(panel);
+
+  const legMat = new THREE.MeshStandardMaterial({ color: 0x0f172a, roughness: 0.7, metalness: 0.1 });
+  const leg = new THREE.CylinderGeometry(0.08, 0.08, 1.4, 12);
+  const legL = new THREE.Mesh(leg, legMat);
+  legL.position.set(-width * 0.35, 0.7, 0);
+  const legR = legL.clone();
+  legR.position.x = width * 0.35;
+  board.add(legL, legR);
+
+  return board;
+}
+
+function buildUmpireChair() {
+  const chair = new THREE.Group();
+  const frameMat = new THREE.MeshStandardMaterial({ color: 0x0b172a, roughness: 0.65, metalness: 0.22 });
+  const seatMat = new THREE.MeshStandardMaterial({ color: 0xf1f5f9, roughness: 0.35, metalness: 0.12 });
+
+  const ladder = new THREE.Mesh(new THREE.BoxGeometry(0.32, 2.2, 0.16), frameMat);
+  ladder.position.y = 1.1;
+  chair.add(ladder);
+
+  const steps = 6;
+  for (let i = 0; i < steps; i += 1) {
+    const rung = new THREE.Mesh(new THREE.BoxGeometry(0.4, 0.06, 0.2), frameMat);
+    rung.position.set(0, 0.2 + (i / steps) * 1.9, 0.12);
+    chair.add(rung);
+  }
+
+  const seat = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.14, 0.6), seatMat);
+  seat.position.set(0, 2.3, 0);
+  chair.add(seat);
+  const back = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.4, 0.08), seatMat);
+  back.position.set(0, 2.53, -0.26);
+  chair.add(back);
+
+  const canopy = new THREE.Mesh(new THREE.BoxGeometry(0.9, 0.08, 0.9), new THREE.MeshStandardMaterial({ color: 0x0ea5e9, roughness: 0.55 }));
+  canopy.position.set(0, 2.85, 0);
+  chair.add(canopy);
+
+  chair.position.set(0, 0, 0.6);
+  return chair;
+}
+
+function buildNetAssembly(width) {
+  const netGroup = new THREE.Group();
+  const netHeight = 0.9;
+  const net = new THREE.Mesh(
+    new THREE.BoxGeometry(width, netHeight, 0.12),
+    new THREE.MeshStandardMaterial({ color: 0xf8f8f8, roughness: 0.7 })
+  );
+  net.position.y = netHeight / 2;
+  netGroup.add(net);
+
+  const tape = new THREE.Mesh(new THREE.BoxGeometry(width, 0.08, 0.14), new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.3 }));
+  tape.position.y = netHeight + 0.04;
+  netGroup.add(tape);
+
+  const postGeo = new THREE.CylinderGeometry(0.12, 0.12, netHeight + 0.6, 16);
+  const postMat = new THREE.MeshStandardMaterial({ color: 0x0f172a, roughness: 0.35, metalness: 0.35 });
+  const postL = new THREE.Mesh(postGeo, postMat);
+  postL.position.set(-width / 2 - 0.05, (netHeight + 0.6) / 2, 0);
+  const postR = postL.clone();
+  postR.position.x = width / 2 + 0.05;
+  netGroup.add(postL, postR);
+
+  const strap = new THREE.Mesh(new THREE.BoxGeometry(0.12, netHeight * 0.9, 0.04), new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.25 }));
+  strap.position.set(0, netHeight * 0.45, 0.07);
+  netGroup.add(strap);
+
+  const umpire = buildUmpireChair();
+  umpire.position.set(width / 2 + 1.1, 0, 0);
+  netGroup.add(umpire);
+
+  return netGroup;
+}
+
+function buildCourtSurroundings({ courtW, courtL, apron }) {
+  const group = new THREE.Group();
+  const trackMesh = new THREE.Mesh(
+    new THREE.PlaneGeometry(courtW + apron * 2.6, courtL + apron * 2.6),
+    new THREE.MeshStandardMaterial({ color: 0x17192f, roughness: 0.92, metalness: 0.05 })
+  );
+  trackMesh.rotation.x = -Math.PI / 2;
+  trackMesh.position.y = -0.0004;
+  group.add(trackMesh);
+
+  const surfaceTex = makeCourtSurfaceTexture();
+  surfaceTex.anisotropy = 8;
+  surfaceTex.wrapS = surfaceTex.wrapT = THREE.RepeatWrapping;
+  surfaceTex.repeat.set(1, 1);
+  const courtSurface = new THREE.Mesh(
+    new THREE.PlaneGeometry(courtW, courtL),
+    new THREE.MeshStandardMaterial({ map: surfaceTex, roughness: 0.82, metalness: 0.04 })
+  );
+  courtSurface.rotation.x = -Math.PI / 2;
+  courtSurface.position.y = 0.0006;
+  group.add(courtSurface);
+
+  const apronEdge = new THREE.Mesh(
+    new THREE.PlaneGeometry(courtW + apron * 2, courtL + apron * 2),
+    new THREE.MeshStandardMaterial({ color: 0x101426, roughness: 0.9, metalness: 0.02 })
+  );
+  apronEdge.rotation.x = -Math.PI / 2;
+  apronEdge.position.y = 0.0002;
+  group.add(apronEdge);
+
+  return group;
 }
 
 function buildBroadcastCameraRig(scale = 1) {
@@ -372,21 +552,8 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
     const apron = 4.2;
     const SERVICE_LINE_Z = 6.4;
     const SERVICE_BOX_INNER = 0.2;
-    const trackMesh = new THREE.Mesh(
-      new THREE.PlaneGeometry(courtW + apron * 2, courtL + apron * 2),
-      new THREE.MeshStandardMaterial({ color: 0x2e2b44, roughness: 0.9, metalness: 0.04 })
-    );
-    trackMesh.rotation.x = -Math.PI / 2;
-    trackMesh.position.y = -0.0004;
-    scene.add(trackMesh);
-
-    const grassMesh = new THREE.Mesh(
-      new THREE.PlaneGeometry(courtW, courtL),
-      new THREE.MeshStandardMaterial({ color: 0x4fa94c, roughness: 0.9, metalness: 0.0 })
-    );
-    grassMesh.rotation.x = -Math.PI / 2;
-    grassMesh.position.y = 0.0004;
-    scene.add(grassMesh);
+    const courtSurroundings = buildCourtSurroundings({ courtW, courtL, apron });
+    scene.add(courtSurroundings);
 
     function courtLinesTex(w = 2048, h = 4096) {
       const c = document.createElement("canvas");
@@ -434,14 +601,21 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
     );
     linesMesh.rotation.x = -Math.PI / 2;
     linesMesh.position.y = 0.001;
-    scene.add(linesMesh);
+    courtSurroundings.add(linesMesh);
 
-    const net = new THREE.Mesh(
-      new THREE.BoxGeometry(courtW, 0.9, 0.12),
-      new THREE.MeshStandardMaterial({ color: 0xf8f8f8, roughness: 0.7 })
-    );
-    net.position.y = 0.45;
-    scene.add(net);
+    const netAssembly = buildNetAssembly(courtW);
+    scene.add(netAssembly);
+
+    const billboards = [
+      buildBillboard({ message: "Battle Royal Centre Court" }),
+      buildBillboard({ message: "Powered by TonPlaygram" }),
+      buildBillboard({ message: "Ace the Competition" })
+    ];
+    billboards[0].position.set(0, 0, -halfL - apron + 0.6);
+    billboards[1].position.set(0, 0, halfL + apron - 0.6);
+    billboards[2].position.set(-halfW - apron + 0.4, 0, 0);
+    billboards[2].rotation.y = Math.PI / 2;
+    billboards.forEach((b) => scene.add(b));
 
     const grandstand = buildRoyalGrandstand();
     grandstand.position.set(0, 0, -8);


### PR DESCRIPTION
## Summary
- restore the detailed Tennis Battle Royal court surroundings, net assembly, and signage
- keep existing ball physics and touch controls while reintroducing the original stadium look

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69231505a580832590629d13d48ed323)