### PR TITLE
Adjust Pool Royale side pocket spacing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -420,7 +420,7 @@ const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief 
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
 const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 0.978; // open the middle rail arches slightly more so the rounded cut breathes around the side pockets
-const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.0115; // push the wooden middle-pocket arches further outward while keeping the chrome fascia fixed
+const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.0165; // push the wooden middle-pocket arches further outward while keeping the chrome fascia fixed
 
 function buildChromePlateGeometry({
   width,
@@ -691,7 +691,7 @@ const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thi
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.592; // nudge the corner jaw spread farther so the fascia kisses the cushion shoulders without gaps
 const SIDE_POCKET_JAW_LATERAL_EXPANSION =
-  CORNER_POCKET_JAW_LATERAL_EXPANSION * 0.87; // ease the middle jaw shoulders outward slightly so they settle nearer the side rail relief without overshooting
+  CORNER_POCKET_JAW_LATERAL_EXPANSION * 0.93; // push the middle jaw shoulders outward so they follow the shifted pocket cuts without overshooting the chrome
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.9; // shrink the side jaw radius further while keeping the fascia thickness intact
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.06; // deepen the side jaw so it holds the same vertical mass as the corners
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = -TABLE.THICK * 0.012; // drop the middle jaw crowns slightly so they sit deeper than the corners
@@ -740,7 +740,7 @@ const BALL_SIZE_SCALE = 0.94248; // 5% larger than the last Pool Royale build (1
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
-const SIDE_POCKET_EXTRA_SHIFT = BALL_R * 1.2; // push the middle pockets slightly farther into the rails so the centres sit off the table axis
+const SIDE_POCKET_EXTRA_SHIFT = BALL_R * 1.34; // push the middle pockets farther into the rails so the centres sit off the table axis
 const SIDE_POCKET_FIELD_PULL = BALL_R * 0.35; // ease the centre pull so the shifted side pockets remain tucked against the wooden apron
 const CHALK_TOP_COLOR = 0x1f6d86;
 const CHALK_SIDE_COLOR = 0x162b36;


### PR DESCRIPTION
## Summary
- push the middle-pocket wooden rail arches further outward while keeping chrome fascias unchanged
- increase side pocket offset and jaw lateral expansion so the shifted pockets stay aligned with the rail cuts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6923312aa93c83258ffa9dff568b67db)