### PR TITLE
Restore Tennis Battle Royal stadium layout

### DIFF
--- a/webapp/src/components/TennisBattleRoyal3D.jsx
+++ b/webapp/src/components/TennisBattleRoyal3D.jsx
@@ -1,5 +1,13 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import * as THREE from "three";
+import { getGameVolume, isGameMuted } from "../utils/sound.js";
+
+const SOUND_SOURCES = {
+  net: encodeURI("/assets/sounds/goal net origjinal (2).mp3"),
+  kick: encodeURI("/assets/sounds/ball kick .mp3"),
+  score: encodeURI("/assets/sounds/football-crowd-3-69245.mp3"),
+  out: encodeURI("/assets/sounds/crowd-shocked-reaction-352766.mp3")
+};
 
 function buildRoyalGrandstand() {
   const group = new THREE.Group();
@@ -120,88 +128,13 @@ function buildRoyalGrandstand() {
   return group;
 }
 
-function buildSidelineChair() {
-  const chair = new THREE.Group();
-  const frameMat = new THREE.MeshStandardMaterial({ color: 0x1f2937, roughness: 0.52, metalness: 0.32 });
-  const seatMat = new THREE.MeshPhysicalMaterial({
-    color: 0x1e40af,
-    roughness: 0.36,
-    metalness: 0.22,
-    clearcoat: 0.4,
-    clearcoatRoughness: 0.3
-  });
-
-  const ladderWidth = 0.72;
-  const stepDepth = 0.18;
-  const stepHeight = 0.22;
-  for (let i = 0; i < 6; i += 1) {
-    const step = new THREE.Mesh(new THREE.BoxGeometry(ladderWidth, stepHeight * 0.36, stepDepth), frameMat);
-    step.position.set(0, (i + 0.35) * stepHeight, -0.45 - i * stepDepth * 0.75);
-    chair.add(step);
-  }
-
-  const railsGeo = new THREE.CylinderGeometry(0.04, 0.04, 2.8, 10);
-  const railL = new THREE.Mesh(railsGeo, frameMat);
-  railL.position.set(-ladderWidth / 2, 1.4, -1.2);
-  const railR = railL.clone();
-  railR.position.x = ladderWidth / 2;
-  chair.add(railL, railR);
-
-  const seat = new THREE.Mesh(new THREE.BoxGeometry(0.78, 0.08, 0.78), seatMat);
-  seat.position.set(0, 1.82, -1.8);
-  const back = new THREE.Mesh(new THREE.BoxGeometry(0.78, 0.62, 0.08), seatMat);
-  back.position.set(0, 2.13, -2.18);
-  chair.add(seat, back);
-
-  const canopy = new THREE.Mesh(new THREE.PlaneGeometry(1.8, 1.4), seatMat);
-  canopy.rotation.x = -Math.PI / 2.4;
-  canopy.position.set(0, 2.65, -1.8);
-  chair.add(canopy);
-
-  return chair;
-}
-
-function makeCourtSurfaceTexture(w = 2048, h = 4096) {
-  const c = document.createElement("canvas");
-  c.width = w;
-  c.height = h;
-  const g = c.getContext("2d");
-
-  const grad = g.createLinearGradient(0, 0, 0, h);
-  grad.addColorStop(0, "#2f3673");
-  grad.addColorStop(0.5, "#1f2b57");
-  grad.addColorStop(1, "#182648");
-  g.fillStyle = grad;
-  g.fillRect(0, 0, w, h);
-
-  g.globalAlpha = 0.1;
-  for (let i = 0; i < 1200; i += 1) {
-    const x = Math.random() * w;
-    const y = Math.random() * h;
-    const r = Math.random() * 3 + 1;
-    g.fillStyle = `rgba(255,255,255,${Math.random() * 0.35})`;
-    g.beginPath();
-    g.arc(x, y, r, 0, Math.PI * 2);
-    g.fill();
-  }
-  g.globalAlpha = 1;
-
-  const stripeCount = 6;
-  for (let i = 0; i <= stripeCount; i += 1) {
-    const t = i / stripeCount;
-    const y = t * h;
-    g.strokeStyle = "rgba(255,255,255,0.04)";
-    g.lineWidth = 8;
-    g.beginPath();
-    g.moveTo(0, y);
-    g.lineTo(w, y);
-    g.stroke();
-  }
-
-  return new THREE.CanvasTexture(c);
-}
-
-function buildGrandEntranceStairs({ stepCount = 12, run = 0.46, rise = 0.22, width = 26, landingDepth = 1.6 } = {}) {
+function buildGrandEntranceStairs({
+  stepCount = 12,
+  run = 0.46,
+  rise = 0.22,
+  width = 26,
+  landingDepth = 1.6
+} = {}) {
   const stairs = new THREE.Group();
   const treadMat = new THREE.MeshStandardMaterial({ color: 0xcdd5e0, roughness: 0.82, metalness: 0.12 });
   const riserMat = new THREE.MeshStandardMaterial({ color: 0xb3bdcc, roughness: 0.78, metalness: 0.18 });
@@ -233,146 +166,6 @@ function buildGrandEntranceStairs({ stepCount = 12, run = 0.46, rise = 0.22, wid
   stairs.add(sideL, sideR);
 
   return stairs;
-}
-
-function buildBillboard({ width = 8, height = 2.6, depth = 0.2, message = "TonPlaygram Championships" } = {}) {
-  const board = new THREE.Group();
-  const canvas = document.createElement("canvas");
-  canvas.width = 1024;
-  canvas.height = 320;
-  const g = canvas.getContext("2d");
-  const gradient = g.createLinearGradient(0, 0, canvas.width, 0);
-  gradient.addColorStop(0, "#111827");
-  gradient.addColorStop(1, "#0f172a");
-  g.fillStyle = gradient;
-  g.fillRect(0, 0, canvas.width, canvas.height);
-  g.fillStyle = "#10b981";
-  g.font = "bold 96px 'Segoe UI', sans-serif";
-  g.textAlign = "center";
-  g.textBaseline = "middle";
-  g.fillText(message, canvas.width / 2, canvas.height / 2);
-
-  const tex = new THREE.CanvasTexture(canvas);
-  const panel = new THREE.Mesh(
-    new THREE.BoxGeometry(width, height, depth),
-    [
-      new THREE.MeshStandardMaterial({ color: 0x0b1224 }),
-      new THREE.MeshStandardMaterial({ color: 0x0b1224 }),
-      new THREE.MeshStandardMaterial({ color: 0x0b1224 }),
-      new THREE.MeshStandardMaterial({ color: 0x0b1224 }),
-      new THREE.MeshStandardMaterial({ map: tex, roughness: 0.6, metalness: 0.2 }),
-      new THREE.MeshStandardMaterial({ color: 0x0b1224 })
-    ]
-  );
-  panel.position.y = height / 2;
-  board.add(panel);
-
-  const legMat = new THREE.MeshStandardMaterial({ color: 0x0f172a, roughness: 0.7, metalness: 0.1 });
-  const leg = new THREE.CylinderGeometry(0.08, 0.08, 1.4, 12);
-  const legL = new THREE.Mesh(leg, legMat);
-  legL.position.set(-width * 0.35, 0.7, 0);
-  const legR = legL.clone();
-  legR.position.x = width * 0.35;
-  board.add(legL, legR);
-
-  return board;
-}
-
-function buildUmpireChair() {
-  const chair = new THREE.Group();
-  const frameMat = new THREE.MeshStandardMaterial({ color: 0x0b172a, roughness: 0.65, metalness: 0.22 });
-  const seatMat = new THREE.MeshStandardMaterial({ color: 0xf1f5f9, roughness: 0.35, metalness: 0.12 });
-
-  const ladder = new THREE.Mesh(new THREE.BoxGeometry(0.32, 2.2, 0.16), frameMat);
-  ladder.position.y = 1.1;
-  chair.add(ladder);
-
-  const steps = 6;
-  for (let i = 0; i < steps; i += 1) {
-    const rung = new THREE.Mesh(new THREE.BoxGeometry(0.4, 0.06, 0.2), frameMat);
-    rung.position.set(0, 0.2 + (i / steps) * 1.9, 0.12);
-    chair.add(rung);
-  }
-
-  const seat = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.14, 0.6), seatMat);
-  seat.position.set(0, 2.3, 0);
-  chair.add(seat);
-  const back = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.4, 0.08), seatMat);
-  back.position.set(0, 2.53, -0.26);
-  chair.add(back);
-
-  const canopy = new THREE.Mesh(new THREE.BoxGeometry(0.9, 0.08, 0.9), new THREE.MeshStandardMaterial({ color: 0x0ea5e9, roughness: 0.55 }));
-  canopy.position.set(0, 2.85, 0);
-  chair.add(canopy);
-
-  chair.position.set(0, 0, 0.6);
-  return chair;
-}
-
-function buildNetAssembly(width) {
-  const netGroup = new THREE.Group();
-  const netHeight = 0.9;
-  const net = new THREE.Mesh(
-    new THREE.BoxGeometry(width, netHeight, 0.12),
-    new THREE.MeshStandardMaterial({ color: 0xf8f8f8, roughness: 0.7 })
-  );
-  net.position.y = netHeight / 2;
-  netGroup.add(net);
-
-  const tape = new THREE.Mesh(new THREE.BoxGeometry(width, 0.08, 0.14), new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.3 }));
-  tape.position.y = netHeight + 0.04;
-  netGroup.add(tape);
-
-  const postGeo = new THREE.CylinderGeometry(0.12, 0.12, netHeight + 0.6, 16);
-  const postMat = new THREE.MeshStandardMaterial({ color: 0x0f172a, roughness: 0.35, metalness: 0.35 });
-  const postL = new THREE.Mesh(postGeo, postMat);
-  postL.position.set(-width / 2 - 0.05, (netHeight + 0.6) / 2, 0);
-  const postR = postL.clone();
-  postR.position.x = width / 2 + 0.05;
-  netGroup.add(postL, postR);
-
-  const strap = new THREE.Mesh(new THREE.BoxGeometry(0.12, netHeight * 0.9, 0.04), new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.25 }));
-  strap.position.set(0, netHeight * 0.45, 0.07);
-  netGroup.add(strap);
-
-  const umpire = buildUmpireChair();
-  umpire.position.set(width / 2 + 1.1, 0, 0);
-  netGroup.add(umpire);
-
-  return netGroup;
-}
-
-function buildCourtSurroundings({ courtW, courtL, apron }) {
-  const group = new THREE.Group();
-  const trackMesh = new THREE.Mesh(
-    new THREE.PlaneGeometry(courtW + apron * 2.6, courtL + apron * 2.6),
-    new THREE.MeshStandardMaterial({ color: 0x17192f, roughness: 0.92, metalness: 0.05 })
-  );
-  trackMesh.rotation.x = -Math.PI / 2;
-  trackMesh.position.y = -0.0004;
-  group.add(trackMesh);
-
-  const surfaceTex = makeCourtSurfaceTexture();
-  surfaceTex.anisotropy = 8;
-  surfaceTex.wrapS = surfaceTex.wrapT = THREE.RepeatWrapping;
-  surfaceTex.repeat.set(1, 1);
-  const courtSurface = new THREE.Mesh(
-    new THREE.PlaneGeometry(courtW, courtL),
-    new THREE.MeshStandardMaterial({ map: surfaceTex, roughness: 0.82, metalness: 0.04 })
-  );
-  courtSurface.rotation.x = -Math.PI / 2;
-  courtSurface.position.y = 0.0006;
-  group.add(courtSurface);
-
-  const apronEdge = new THREE.Mesh(
-    new THREE.PlaneGeometry(courtW + apron * 2, courtL + apron * 2),
-    new THREE.MeshStandardMaterial({ color: 0x101426, roughness: 0.9, metalness: 0.02 })
-  );
-  apronEdge.rotation.x = -Math.PI / 2;
-  apronEdge.position.y = 0.0002;
-  group.add(apronEdge);
-
-  return group;
 }
 
 function buildBroadcastCameraRig(scale = 1) {
@@ -425,146 +218,173 @@ function buildBroadcastCameraRig(scale = 1) {
   headPivot.add(handle);
 
   group.scale.setScalar(scale);
-  return group;
-}
-
-function buildRacketURT() {
-  const g = new THREE.Group();
-  const frameMat = new THREE.MeshPhysicalMaterial({
-    color: 0x1e293b,
-    roughness: 0.45,
-    metalness: 0.3,
-    clearcoat: 0.4,
-    clearcoatRoughness: 0.18
-  });
-  const accentMat = new THREE.MeshStandardMaterial({ color: 0x5b94ff, roughness: 0.35, metalness: 0.28 });
-  const innerMat = new THREE.MeshStandardMaterial({ color: 0x0f172a, roughness: 0.5, metalness: 0.22 });
-
-  const headOuter = new THREE.Mesh(new THREE.TorusGeometry(1.08, 0.12, 18, 36), frameMat);
-  headOuter.rotation.x = Math.PI / 2;
-  g.add(headOuter);
-  const headInner = new THREE.Mesh(new THREE.TorusGeometry(1.0, 0.06, 16, 32), innerMat);
-  headInner.rotation.x = Math.PI / 2;
-  g.add(headInner);
-
-  const throat = new THREE.Mesh(new THREE.BoxGeometry(0.26, 0.12, 0.9), frameMat);
-  throat.position.set(0, 0, 1.3);
-  g.add(throat);
-  const bridge = new THREE.Mesh(new THREE.BoxGeometry(0.5, 0.16, 0.22), accentMat);
-  bridge.position.set(0, 0, 1.65);
-  g.add(bridge);
-
-  const handleR = 0.18;
-  const handleLen = 1.2;
-  const joinZ = 2.0;
-  const handleGeo = new THREE.CylinderGeometry(handleR * 0.9, handleR, handleLen, 40, 1, true);
-  const leather = new THREE.ShaderMaterial({
-    uniforms: {
-      uCol: { value: new THREE.Color("#2b2b2b") },
-      uEdge: { value: new THREE.Color("#111") },
-      uScale: { value: 24.0 }
-    },
-    vertexShader: `varying vec2 vUv; void main(){ vUv=uv; gl_Position=projectionMatrix*modelViewMatrix*vec4(position,1.0); }`,
-    fragmentShader: `precision mediump float; varying vec2 vUv; uniform vec3 uCol,uEdge; uniform float uScale; float h(vec2 p){return fract(sin(dot(p,vec2(127.1,311.7)))*43758.5453123);} float n(vec2 p){vec2 i=floor(p),f=fract(p);f=f*f*(3.-2.*f);float a=h(i),b=h(i+vec2(1,0)),c=h(i+vec2(0,1)),d=h(i+vec2(1,1));float nx=mix(a,b,f.x)+(c-a)*f.y*(1.-f.x)+(d-b)*f.x*f.y;return nx;} void main(){ float t = n(vUv*uScale); vec3 col = mix(uEdge,uCol, smoothstep(0.45,0.9,t)); gl_FragColor=vec4(col,1.0);} `
-  });
-  const handle = new THREE.Mesh(handleGeo, leather);
-  handle.rotation.x = Math.PI / 2;
-  handle.position.set(0, 0, joinZ - (handleLen * 0.5 + 0.08));
-  g.add(handle);
-  const butt = new THREE.Mesh(new THREE.CylinderGeometry(handleR * 0.95, handleR * 0.95, 0.12, 24), new THREE.MeshStandardMaterial({ color: 0x0e1116, roughness: 0.8 }));
-  butt.rotation.x = Math.PI / 2;
-  butt.position.copy(handle.position);
-  butt.position.z -= handleLen * 0.5 + 0.11;
-  g.add(butt);
-
-  const decalCanvas = document.createElement("canvas");
-  const dctx = decalCanvas.getContext("2d");
-  decalCanvas.width = 512;
-  decalCanvas.height = 128;
-  dctx.fillStyle = "#22262e";
-  dctx.fillRect(0, 0, 512, 128);
-  dctx.font = "700 72px system-ui";
-  dctx.fillStyle = "#f4f6fa";
-  dctx.textAlign = "center";
-  dctx.fillText("OS‑Racquet", 256, 88);
-  const decalTex = new THREE.CanvasTexture(decalCanvas);
-  const decal = new THREE.Mesh(new THREE.PlaneGeometry(0.9, 0.18), new THREE.MeshBasicMaterial({ map: decalTex, transparent: true }));
-  decal.position.set(0, 0.08, 0.55);
-  g.add(decal);
-
-  return g;
-}
-
-function buildBallURT() {
-  const felt = new THREE.ShaderMaterial({
-    uniforms: {
-      uA: { value: new THREE.Color("#e6ff3b") },
-      uB: { value: new THREE.Color("#cfe93a") },
-      uExp: { value: 1.85 }
-    },
-    vertexShader: `varying vec3 vP; varying vec3 vN; void main(){ vP=position; vN=normal; gl_Position=projectionMatrix*modelViewMatrix*vec4(position,1.0); }`,
-    fragmentShader: `precision mediump float; varying vec3 vP; varying vec3 vN; uniform vec3 uA,uB; uniform float uExp; float h(vec3 p){return fract(sin(dot(p,vec3(27.1,57.7,12.4)))*43758.5453);} float n(vec3 p){ vec3 i=floor(p), f=fract(p); f=f*f*(3.0-2.0*f); float a=h(i), b=h(i+vec3(1,0,0)), c=h(i+vec3(0,1,0)), d=h(i+vec3(1,1,0)); float e=h(i+vec3(0,0,1)), f2=h(i+vec3(1,0,1)), g=h(i+vec3(0,1,1)), h2=h(i+vec3(1,1,1)); float nx=mix(a,b,f.x)+(c-a)*f.y*(1.0-f.x)+(d-b)*f.x*f.y; float ny=mix(e,f2,f.x)+(g-e)*f.y*(1.0-f.x)+(h2-f2)*f.x*f.y; return mix(nx,ny,f.z);} float fbm(vec3 p){ float v=0.,amp=0.5; for(int i=0;i<6;i++){ v+=amp*n(p); p*=2.02; amp*=0.5;} return v;} vec3 aces(vec3 x){const float A=2.51,B=0.03,C=2.43,D=0.59,E=0.14; vec3 y=max(vec3(0.0),x*uExp); return clamp((y*(A*y+B))/(y*(C*y+D)+E),0.0,1.0);} void main(){ float f=fbm(vP*7.0+normalize(vN)*2.0); vec3 col=mix(uA,uB,smoothstep(0.35,0.8,f)); gl_FragColor=vec4(aces(col),1.0); }`,
-    lights: false
-  });
-  const ball = new THREE.Mesh(new THREE.SphereGeometry(0.26, 48, 36), felt);
-  const seamMat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.4 });
-  const band = new THREE.TorusGeometry(0.26, 0.008, 12, 96);
-  const s1 = new THREE.Mesh(band, seamMat);
-  s1.rotation.y = Math.PI / 2;
-  ball.add(s1);
-  const s2 = new THREE.Mesh(band, seamMat);
-  s2.rotation.x = Math.PI / 3;
-  ball.add(s2);
-  return ball;
-}
-
-function makeRacket() {
-  const root = new THREE.Group();
-  const headPivot = new THREE.Group();
-  root.add(headPivot);
-  const urt = buildRacketURT();
-  urt.rotation.x = 0;
-  urt.position.y = 1.0;
-  headPivot.add(urt);
-  root.userData = { headPivot };
-  root.scale.setScalar(0.608);
-  return root;
+  return { group, headPivot };
 }
 
 export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMode = false }) {
-  const mountRef = useRef(null);
-  const modeLabel = trainingMode ? "Training Mode" : "Fundraising AI";
-  const modeSummary = trainingMode
-    ? "Practice swipes and timing without staking."
-    : "Stake contributes to the rally community pot.";
+  const containerRef = useRef(null);
+  const playerLabel = playerName || 'You';
+  const cpuLabel = 'CPU';
+  const suffixParts = [];
+  if (playerName) suffixParts.push(`${playerName} vs AI`);
+  if (stakeLabel) suffixParts.push(`Stake ${stakeLabel}`);
+  const matchTag = suffixParts.join(' · ');
+  const introMessage = trainingMode ? 'Training · Swipe për shërbim' : 'Swipe & Hit';
+  const [msg, setMsg] = useState(introMessage);
+  const [hudInfo, setHudInfo] = useState(() => ({
+    points: '0 - 0',
+    games: '0 - 0',
+    sets: '0 - 0',
+    server: playerLabel,
+    side: 'deuce',
+    attempts: 2,
+    playerSets: 0,
+    cpuSets: 0,
+    playerGames: 0,
+    cpuGames: 0,
+    playerPointLabel: '0',
+    cpuPointLabel: '0'
+  }));
+  const trainingSteps = [
+    {
+      id: 'swipeServe',
+      title: 'Shërbe me swipe',
+      detail: 'Fërko gishtin nga poshtë-lart për të nisur topin.'
+    },
+    {
+      id: 'landServe',
+      title: 'Topi në kutinë e shërbimit',
+      detail: 'Sigurohu që kërcimi i parë të bjerë në anën e kundërshtarit.'
+    },
+    {
+      id: 'rallyHit',
+      title: 'Godit një rally',
+      detail: 'Prit rikthimin e CPU dhe godit topin përsëri.'
+    },
+    {
+      id: 'winPoint',
+      title: 'Fito një pikë',
+      detail: 'Mbaje rally deri sa CPU të gabojë.'
+    }
+  ];
+  const [trainingStatus, setTrainingStatus] = useState(() =>
+    Object.fromEntries(trainingSteps.map((step) => [step.id, !trainingMode]))
+  );
+  const nextTrainingStep = trainingSteps.find((step) => !trainingStatus[step.id]);
+  const trainingCompleted = !nextTrainingStep && trainingMode;
+  const [taskToast, setTaskToast] = useState(() =>
+    trainingMode
+      ? {
+          id: trainingSteps[0].id,
+          title: `Detyra: ${trainingSteps[0].title}`,
+          detail: trainingSteps[0].detail
+        }
+      : null
+  );
+  const lastTaskToastId = useRef(null);
+  const [scoreboardOpen, setScoreboardOpen] = useState(false);
+
+  const audioRef = useRef({ net: null, kick: null, score: null, out: null });
+
+  const applySoundSettings = useCallback(() => {
+    const volume = getGameVolume();
+    const muted = isGameMuted();
+    Object.values(audioRef.current).forEach((audio) => {
+      if (!audio) return;
+      audio.volume = muted ? 0 : volume;
+      audio.muted = muted;
+    });
+  }, []);
 
   useEffect(() => {
-    const container = mountRef.current;
-    if (!container) return undefined;
+    const net = new Audio(SOUND_SOURCES.net);
+    const kick = new Audio(SOUND_SOURCES.kick);
+    const score = new Audio(SOUND_SOURCES.score);
+    const out = new Audio(SOUND_SOURCES.out);
+    audioRef.current = { net, kick, score, out };
+    applySoundSettings();
 
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: "high-performance" });
-    const width = Math.max(1, container.clientWidth || window.innerWidth || 360);
-    const height = Math.max(1, container.clientHeight || window.innerHeight || 640);
-    renderer.setSize(width, height);
+    const handleVolume = () => applySoundSettings();
+    const handleMute = () => applySoundSettings();
+    window.addEventListener('gameVolumeChanged', handleVolume);
+    window.addEventListener('gameMuteChanged', handleMute);
+
+    return () => {
+      window.removeEventListener('gameVolumeChanged', handleVolume);
+      window.removeEventListener('gameMuteChanged', handleMute);
+      Object.values(audioRef.current).forEach((audio) => {
+        try {
+          audio.pause();
+        } catch (err) {}
+      });
+      audioRef.current = { net: null, kick: null, score: null, out: null };
+    };
+  }, [applySoundSettings]);
+
+  const playSound = useCallback((key) => {
+    const audio = audioRef.current[key];
+    if (!audio || isGameMuted()) return;
+    audio.currentTime = 0;
+    audio.volume = getGameVolume();
+    audio.play().catch(() => {});
+  }, []);
+
+  const playKickSound = useCallback(() => playSound('kick'), [playSound]);
+  const playNetSound = useCallback(() => playSound('net'), [playSound]);
+  const playScoreSound = useCallback(() => playSound('score'), [playSound]);
+  const playOutSound = useCallback(() => playSound('out'), [playSound]);
+
+  useEffect(() => {
+    if (!trainingMode) return undefined;
+    const stepId = nextTrainingStep?.id || (trainingCompleted ? 'done' : null);
+    if (!stepId || stepId === lastTaskToastId.current) return undefined;
+    lastTaskToastId.current = stepId;
+    const toastTitle = nextTrainingStep ? `Detyra: ${nextTrainingStep.title}` : 'Trajnimi u përfundua';
+    const toastDetail = nextTrainingStep
+      ? nextTrainingStep.detail
+      : 'Tasket u realizuan, vazhdo lojën!';
+    setTaskToast({ id: stepId, title: toastTitle, detail: toastDetail });
+    const timer = setTimeout(() => setTaskToast(null), 4200);
+    return () => clearTimeout(timer);
+  }, [nextTrainingStep, trainingCompleted, trainingMode]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
+    let W = Math.max(1, container.clientWidth || window.innerWidth || 360);
+    let H = Math.max(1, container.clientHeight || window.innerHeight || 640);
+    renderer.setSize(W, H);
     renderer.setPixelRatio(Math.min(1.5, window.devicePixelRatio || 1));
-    if ("outputColorSpace" in renderer) renderer.outputColorSpace = THREE.SRGBColorSpace;
+    if ('outputColorSpace' in renderer) renderer.outputColorSpace = THREE.SRGBColorSpace;
     else renderer.outputEncoding = THREE.sRGBEncoding;
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
     renderer.toneMappingExposure = 1.55;
+    renderer.shadowMap.enabled = false;
+    renderer.setClearColor(0x87ceeb, 1);
     container.appendChild(renderer.domElement);
 
     const scene = new THREE.Scene();
     scene.background = new THREE.Color(0x87ceeb);
-    const camera = new THREE.PerspectiveCamera(60, width / height, 0.05, 800);
+    const isNarrow = Math.min(W, H) < 860;
+    const camera = new THREE.PerspectiveCamera(60, W / H, 0.05, 800);
 
     const courtL = 23.77;
     const courtW = 9.2;
     const halfW = courtW / 2;
     const halfL = courtL / 2;
+    const SERVICE_LINE_Z = 6.4;
+    const SERVICE_BOX_INNER = 0.2;
+
     const playerZ = halfL - 1.35;
     const cpuZ = -halfL + 1.35;
 
-    // Lights and sky
+    let camBack = isNarrow ? 14.2 : 12.8;
+    let camHeight = isNarrow ? 5.8 : 5.35;
+    const cameraMinZ = 0.8;
+    const cameraMaxZ = halfL + 5.0;
+
     const hemi = new THREE.HemisphereLight(0xf2f6ff, 0xb7d4a8, 1.05);
     hemi.position.set(0, 60, 0);
     scene.add(hemi);
@@ -577,6 +397,9 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
     const bounce = new THREE.AmbientLight(0xe5f1ff, 0.18);
     scene.add(bounce);
 
+    const maxAniso = renderer.capabilities.getMaxAnisotropy?.() || 8;
+    const grassURL = 'https://threejs.org/examples/textures/terrain/grasslight-big.jpg';
+
     const skyGeo = new THREE.SphereGeometry(420, 48, 32);
     const colors = [];
     const topColor = new THREE.Color(0x8fc9ff);
@@ -588,30 +411,89 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
       const color = topColor.clone().lerp(horizonColor, Math.pow(1 - t, 0.6));
       colors.push(color.r, color.g, color.b);
     }
-    skyGeo.setAttribute("color", new THREE.Float32BufferAttribute(colors, 3));
-    const sky = new THREE.Mesh(skyGeo, new THREE.MeshBasicMaterial({ side: THREE.BackSide, vertexColors: true }));
+    skyGeo.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+    const sky = new THREE.Mesh(
+      skyGeo,
+      new THREE.MeshBasicMaterial({ side: THREE.BackSide, vertexColors: true })
+    );
     sky.position.y = -18;
     scene.add(sky);
 
-    // Court and surrounds
-    const apron = 4.2;
-    const SERVICE_LINE_Z = 6.4;
-    const SERVICE_BOX_INNER = 0.2;
-    const courtSurroundings = buildCourtSurroundings({ courtW, courtL, apron });
-    scene.add(courtSurroundings);
+    const matGrass = new THREE.MeshStandardMaterial({
+      color: 0x4fa94c,
+      roughness: 0.9,
+      metalness: 0.0,
+      emissive: new THREE.Color('#1c5c22'),
+      emissiveIntensity: 0.03
+    });
+
+    function loadDeshadowedGrass(url, onReady) {
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+      img.onload = () => {
+        const aspect = img.height / img.width;
+        const w = 1024;
+        const h = Math.round(w * aspect);
+        const base = document.createElement('canvas');
+        base.width = w;
+        base.height = h;
+        const gb = base.getContext('2d');
+        gb.drawImage(img, 0, 0, w, h);
+        const small = document.createElement('canvas');
+        small.width = Math.max(64, w >> 4);
+        small.height = Math.max(64, h >> 4);
+        const gs = small.getContext('2d');
+        gs.imageSmoothingEnabled = true;
+        gs.drawImage(base, 0, 0, small.width, small.height);
+        const blur = document.createElement('canvas');
+        blur.width = w;
+        blur.height = h;
+        const gl = blur.getContext('2d');
+        gl.imageSmoothingEnabled = true;
+        gl.drawImage(small, 0, 0, w, h);
+
+        const src = gb.getImageData(0, 0, w, h);
+        const low = gl.getImageData(0, 0, w, h);
+        const d = src.data;
+        const b = low.data;
+        const eps = 1e-3;
+        const target = 138;
+        for (let i = 0; i < d.length; i += 4) {
+          const L = 0.2126 * b[i] + 0.7152 * b[i + 1] + 0.0722 * b[i + 2];
+          const k = target / (L + eps);
+          d[i] = Math.max(0, Math.min(255, d[i] * k));
+          d[i + 1] = Math.max(0, Math.min(255, d[i + 1] * k));
+          d[i + 2] = Math.max(0, Math.min(255, d[i + 2] * k));
+        }
+        gb.putImageData(src, 0, 0);
+        gb.globalCompositeOperation = 'overlay';
+        gb.fillStyle = 'rgba(40,120,44,0.08)';
+        gb.fillRect(0, 0, w, h);
+        gb.globalCompositeOperation = 'source-over';
+
+        const tex = new THREE.CanvasTexture(base);
+        tex.anisotropy = Math.min(16, maxAniso);
+        tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+        if ('colorSpace' in tex) tex.colorSpace = THREE.SRGBColorSpace;
+        else tex.encoding = THREE.sRGBEncoding;
+        tex.repeat.set(8, 18);
+        onReady(tex);
+      };
+      img.src = url;
+    }
 
     function courtLinesTex(w = 2048, h = 4096) {
-      const c = document.createElement("canvas");
+      const c = document.createElement('canvas');
       c.width = w;
       c.height = h;
-      const g = c.getContext("2d");
+      const g = c.getContext('2d');
       g.clearRect(0, 0, w, h);
       const s = h / courtL;
       const lineW = 12;
-      g.strokeStyle = "#ffffff";
+      g.strokeStyle = '#ffffff';
       g.lineWidth = lineW;
-      g.lineJoin = "round";
-      g.lineCap = "round";
+      g.lineJoin = 'round';
+      g.lineCap = 'round';
       const X = (x) => w / 2 + x * s;
       const Z = (z) => h / 2 + z * s;
       const line = (x1, z1, x2, z2) => {
@@ -632,281 +514,1814 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
       line(-halfW, -SERVICE_LINE_Z, halfW, -SERVICE_LINE_Z);
       line(-halfW, SERVICE_LINE_Z, halfW, SERVICE_LINE_Z);
       line(0, -SERVICE_LINE_Z, 0, SERVICE_LINE_Z);
-      g.fillStyle = "#ffffff";
+      g.fillStyle = '#ffffff';
       const padLenM = 1.2;
       const padWideM = 0.2;
       const z0 = -padLenM / 2;
       const z1 = padLenM / 2;
-      g.fillRect(X(0) - (lineW + padWideM * s) / 2, Z(z0), lineW + padWideM * s, padLenM * s);
-      return new THREE.CanvasTexture(c);
+      const pxW = padWideM * s;
+      const hgt = Math.abs(Z(z1) - Z(z0));
+      g.fillRect(X(-halfW - padWideM / 2), Math.min(Z(z0), Z(z1)), pxW, hgt);
+      g.fillRect(X(halfW - padWideM / 2), Math.min(Z(z0), Z(z1)), pxW, hgt);
+      const t = new THREE.CanvasTexture(c);
+      t.anisotropy = Math.min(16, maxAniso);
+      t.wrapS = t.wrapT = THREE.ClampToEdgeWrapping;
+      t.needsUpdate = true;
+      return t;
     }
-    const linesMesh = new THREE.Mesh(
-      new THREE.PlaneGeometry(courtW, courtL),
-      new THREE.MeshBasicMaterial({ map: courtLinesTex(), transparent: true })
-    );
+
+    const matLines = new THREE.MeshBasicMaterial({
+      map: courtLinesTex(),
+      transparent: true,
+      opacity: 0.995,
+      polygonOffset: true,
+      polygonOffsetFactor: -2,
+      polygonOffsetUnits: -2,
+      depthWrite: false
+    });
+
+    function trackTex(w = 1024, h = 1024) {
+      const c = document.createElement('canvas');
+      c.width = w;
+      c.height = h;
+      const g = c.getContext('2d');
+      g.fillStyle = '#b33a2c';
+      g.fillRect(0, 0, w, h);
+      const dots = Math.floor(w * h * 0.004);
+      for (let i = 0; i < dots; i += 1) {
+        const x = Math.random() * w;
+        const y = Math.random() * h;
+        const r = Math.random() * 1.6 + 0.2;
+        g.fillStyle = Math.random() < 0.5 ? 'rgba(255,190,180,0.35)' : 'rgba(40,12,10,0.35)';
+        g.beginPath();
+        g.arc(x, y, r, 0, Math.PI * 2);
+        g.fill();
+      }
+      const t = new THREE.CanvasTexture(c);
+      t.anisotropy = Math.min(16, maxAniso);
+      t.wrapS = t.wrapT = THREE.RepeatWrapping;
+      if ('colorSpace' in t) t.colorSpace = THREE.SRGBColorSpace;
+      else t.encoding = THREE.sRGBEncoding;
+      t.repeat.set(1, 1);
+      return t;
+    }
+    const matTrack = new THREE.MeshStandardMaterial({ map: trackTex(), roughness: 0.96, metalness: 0.0 });
+
+    const apron = 2.6;
+    const trackMesh = new THREE.Mesh(new THREE.PlaneGeometry(courtW + apron * 2, courtL + apron * 2), matTrack);
+    trackMesh.rotation.x = -Math.PI / 2;
+    trackMesh.position.y = -0.001;
+    scene.add(trackMesh);
+
+    const grassMesh = new THREE.Mesh(new THREE.PlaneGeometry(courtW, courtL), matGrass);
+    grassMesh.rotation.x = -Math.PI / 2;
+    grassMesh.position.y = 0.0;
+    scene.add(grassMesh);
+
+    const linesMesh = new THREE.Mesh(new THREE.PlaneGeometry(courtW, courtL), matLines);
     linesMesh.rotation.x = -Math.PI / 2;
-    linesMesh.position.y = 0.001;
-    courtSurroundings.add(linesMesh);
+    linesMesh.position.y = 0.002;
+    scene.add(linesMesh);
 
-    const netAssembly = buildNetAssembly(courtW);
-    scene.add(netAssembly);
+    loadDeshadowedGrass(grassURL, (tex) => {
+      matGrass.map = tex;
+      matGrass.needsUpdate = true;
+    });
 
-    const billboards = [
-      buildBillboard({ message: "Battle Royal Centre Court" }),
-      buildBillboard({ message: "Powered by TonPlaygram" }),
-      buildBillboard({ message: "Ace the Competition" })
+    function tennisNetTex(w = 1024, h = 512, cell = 8, thickness = 2) {
+      const c = document.createElement('canvas');
+      c.width = w;
+      c.height = h;
+      const g = c.getContext('2d');
+      g.clearRect(0, 0, w, h);
+      g.strokeStyle = 'rgba(18,18,18,0.96)';
+      g.lineWidth = thickness;
+      g.lineJoin = 'round';
+      g.lineCap = 'round';
+      for (let y = cell; y <= h - cell; y += cell) {
+        g.beginPath();
+        g.moveTo(cell, y);
+        g.lineTo(w - cell, y);
+        g.stroke();
+      }
+      for (let x = cell; x <= w - cell; x += cell) {
+        g.beginPath();
+        g.moveTo(x, cell);
+        g.lineTo(x, h - cell);
+        g.stroke();
+      }
+      g.fillStyle = 'rgba(255,255,255,0.06)';
+      for (let y = cell; y <= h - cell; y += cell) {
+        for (let x = cell; x <= w - cell; x += cell) {
+          g.fillRect(x - 1, y - 1, 2, 2);
+        }
+      }
+      const t = new THREE.CanvasTexture(c);
+      t.anisotropy = Math.min(8, maxAniso);
+      t.wrapS = THREE.ClampToEdgeWrapping;
+      t.wrapT = THREE.ClampToEdgeWrapping;
+      return t;
+    }
+
+    const matTape = new THREE.MeshBasicMaterial({ color: 0xffffff });
+    const matPost = new THREE.MeshStandardMaterial({ color: 0xb7bcc7, roughness: 0.45, metalness: 0.35 });
+    const netH = 0.914;
+    const netW = courtW;
+    const netTex = tennisNetTex(1024, 512, 7, 2);
+    const netMesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(netW, netH, 1, 1),
+      new THREE.MeshStandardMaterial({ map: netTex, roughness: 0.8, metalness: 0.0, transparent: true, opacity: 1.0, color: 0xffffff })
+    );
+    netMesh.position.set(0, netH / 2, 0);
+    scene.add(netMesh);
+    const tapeH = 0.09;
+    const topTape = new THREE.Mesh(new THREE.BoxGeometry(netW, tapeH, 0.02), matTape);
+    topTape.position.set(0, netH - tapeH / 2, 0.005);
+    scene.add(topTape);
+    const botTape = new THREE.Mesh(new THREE.BoxGeometry(netW, tapeH, 0.02), matTape);
+    botTape.position.set(0, tapeH / 2, 0.005);
+    scene.add(botTape);
+    const postL = new THREE.Mesh(new THREE.CylinderGeometry(0.06, 0.06, 1.35, 16), matPost);
+    postL.position.set(-netW / 2, 0.675, 0);
+    scene.add(postL);
+    const postR = postL.clone();
+    postR.position.x = netW / 2;
+    scene.add(postR);
+    const capL = new THREE.Mesh(new THREE.SphereGeometry(0.07, 16, 12), matPost);
+    capL.position.set(-netW / 2, 1.35, 0);
+    scene.add(capL);
+    const capR = capL.clone();
+    capR.position.x = netW / 2;
+    scene.add(capR);
+
+    const stand = buildRoyalGrandstand();
+    const baseGap = 8;
+    const sideGap = 9;
+    const north = stand.clone();
+    north.position.z = -(halfL + baseGap);
+    const south = stand.clone();
+    south.rotation.y = Math.PI;
+    south.position.z = halfL + baseGap;
+    const east = stand.clone();
+    east.rotation.y = -Math.PI / 2;
+    east.position.x = halfW + sideGap;
+    const west = stand.clone();
+    west.rotation.y = Math.PI / 2;
+    west.position.x = -(halfW + sideGap);
+    const eastRear = stand.clone();
+    eastRear.rotation.y = -Math.PI / 2;
+    eastRear.position.x = halfW + sideGap + 7.8;
+    const westRear = stand.clone();
+    westRear.rotation.y = Math.PI / 2;
+    westRear.position.x = -(halfW + sideGap + 7.8);
+    scene.add(north, south, east, west, eastRear, westRear);
+
+    const stairsEast = buildGrandEntranceStairs({ width: courtL + apron * 1.2 });
+    stairsEast.position.set(halfW + apron + 0.4, 0, 0);
+    const stairsWest = stairsEast.clone();
+    stairsWest.rotation.y = Math.PI;
+    stairsWest.position.set(-(halfW + apron + 0.4), 0, 0);
+    scene.add(stairsEast, stairsWest);
+
+    const cameraFocus = new THREE.Vector3(0, 1.18, 0);
+    const cameraRigs = [
+      { position: new THREE.Vector3(-halfW - 1.6, 0, halfL + 2.4) },
+      { position: new THREE.Vector3(halfW + 1.6, 0, -halfL - 2.6) },
+      { position: new THREE.Vector3(0, 0, -halfL - 2.9) }
     ];
-    billboards[0].position.set(0, 0, -halfL - apron + 0.6);
-    billboards[1].position.set(0, 0, halfL + apron - 0.6);
-    billboards[2].position.set(-halfW - apron + 0.4, 0, 0);
-    billboards[2].rotation.y = Math.PI / 2;
-    billboards.forEach((b) => scene.add(b));
+    cameraRigs.forEach(({ position }) => {
+      const rig = buildBroadcastCameraRig(0.58);
+      rig.group.position.copy(position);
+      rig.group.rotation.y = Math.atan2(cameraFocus.x - position.x, cameraFocus.z - position.z);
+      rig.headPivot.up.set(0, 1, 0);
+      rig.headPivot.lookAt(cameraFocus);
+      scene.add(rig.group);
+    });
 
-    const standOffsetZ = halfL + apron + 2.2;
-    const northGrandstand = buildRoyalGrandstand();
-    northGrandstand.position.set(0, 0, -standOffsetZ);
-    scene.add(northGrandstand);
+    const ump = new THREE.Group();
+    const legH = 1.45;
+    const legR = 0.035;
+    const span = 0.6;
+    const legMat = new THREE.MeshStandardMaterial({ color: 0x6b7280, roughness: 0.6, metalness: 0.2 });
+    for (let sx of [-1, 1]) {
+      for (let sz of [-1, 1]) {
+        const cyl = new THREE.Mesh(new THREE.CylinderGeometry(legR, legR, legH, 12), legMat);
+        cyl.position.set((sx * span) / 2, legH / 2, (sz * span) / 2);
+        ump.add(cyl);
+      }
+    }
+    const plat = new THREE.Mesh(new THREE.BoxGeometry(0.72, 0.06, 0.72), new THREE.MeshStandardMaterial({ color: 0x9ca3af, roughness: 0.7, metalness: 0.15 }));
+    plat.position.y = legH + 0.03;
+    ump.add(plat);
+    const seat = new THREE.Mesh(new THREE.BoxGeometry(0.4, 0.05, 0.4), new THREE.MeshStandardMaterial({ color: 0xe5e7eb, roughness: 0.6 }));
+    seat.position.set(0, legH + 0.36, 0);
+    ump.add(seat);
+    const back = new THREE.Mesh(new THREE.BoxGeometry(0.42, 0.4, 0.04), new THREE.MeshStandardMaterial({ color: 0xe5e7eb, roughness: 0.6 }));
+    back.position.set(0, legH + 0.56, -0.18);
+    ump.add(back);
+    const ladder = new THREE.Group();
+    const railMat = new THREE.MeshStandardMaterial({ color: 0xbfbfbf, roughness: 0.55 });
+    const railL = new THREE.Mesh(new THREE.CylinderGeometry(0.02, 0.02, 1.2, 10), railMat);
+    railL.position.set(-0.28, 0.6, 0.42);
+    ladder.add(railL);
+    const railR2 = new THREE.Mesh(new THREE.CylinderGeometry(0.02, 0.02, 1.2, 10), railMat);
+    railR2.position.set(0.28, 0.6, 0.42);
+    ladder.add(railR2);
+    for (let i = 0; i < 5; i += 1) {
+      const y = 0.18 + i * 0.2;
+      const step = new THREE.Mesh(new THREE.CylinderGeometry(0.02, 0.02, 0.52, 10), railMat);
+      step.rotation.z = Math.PI / 2;
+      step.position.set(0, y, 0.42);
+      ladder.add(step);
+    }
+    ump.add(ladder);
+    ump.position.set(halfW + 0.75, 0, 0.1);
+    scene.add(ump);
 
-    const southGrandstand = buildRoyalGrandstand();
-    southGrandstand.rotation.y = Math.PI;
-    southGrandstand.position.set(0, 0, standOffsetZ);
-    scene.add(southGrandstand);
-    const stairs = buildGrandEntranceStairs();
-    stairs.rotation.y = Math.PI / 2;
-    stairs.position.set(halfW + apron + 3.2, 0, standOffsetZ - 1);
-    scene.add(stairs);
-    const broadcastRig = buildBroadcastCameraRig(1.25);
-    broadcastRig.position.set(halfW + 1.8, 0, 0);
-    scene.add(broadcastRig);
+    class EllipseCurve3D extends THREE.Curve {
+      constructor(a = 0.74, b = 0.92) {
+        super();
+        this.a = a;
+        this.b = b;
+      }
+      getPoint(t) {
+        const ang = t * 2 * Math.PI;
+        return new THREE.Vector3(this.a * Math.cos(ang), 0, this.b * Math.sin(ang));
+      }
+    }
 
-    const chairOffsetX = halfW + apron - 0.2;
-    const leftChair = buildSidelineChair();
-    leftChair.position.set(-chairOffsetX, 0, 0.6);
-    leftChair.rotation.y = Math.PI / 2;
-    scene.add(leftChair);
-    const rightChair = buildSidelineChair();
-    rightChair.position.set(chairOffsetX, 0, -0.6);
-    rightChair.rotation.y = -Math.PI / 2;
-    scene.add(rightChair);
+    function buildRacketURT() {
+      const g = new THREE.Group();
+      const a = 0.74;
+      const b = 0.92;
+      const tubeRad = 0.032;
+      const ellipse = new EllipseCurve3D(a, b);
+      const hoopGeo = new THREE.TubeGeometry(ellipse, 220, tubeRad, 20, true);
+      const frameMat = new THREE.MeshStandardMaterial({ color: 0x22262e, metalness: 0.55, roughness: 0.38 });
+      const hoop = new THREE.Mesh(hoopGeo, frameMat);
+      g.add(hoop);
+      const bump = new THREE.Mesh(new THREE.TorusGeometry(a * 0.985, 0.008, 10, 160), new THREE.MeshStandardMaterial({ color: 0x1a1f27, roughness: 0.6 }));
+      bump.rotation.x = Math.PI / 2;
+      bump.scale.z = b / a;
+      bump.position.y = 0.009;
+      g.add(bump);
+      const strings = new THREE.Group();
+      const sMat = new THREE.MeshStandardMaterial({ color: 0xeeeeee, roughness: 0.35, metalness: 0.0 });
+      const count = 22;
+      const innerA = a - tubeRad * 1.05;
+      const innerB = b - tubeRad * 1.05;
+      const thick = 0.008;
+      for (let i = -(count / 2); i <= count / 2; i += 1) {
+        const x = (i * (innerA * 1.7)) / count;
+        if (Math.abs(x) >= innerA) continue;
+        const zmax = innerB * Math.sqrt(Math.max(0, 1 - (x / innerA) * (x / innerA)));
+        const len = Math.max(0.02, zmax * 2 * 0.98);
+        const geo = new THREE.BoxGeometry(thick, thick, len);
+        const mesh = new THREE.Mesh(geo, sMat);
+        mesh.position.set(x, 0, 0);
+        strings.add(mesh);
+      }
+      for (let i = -(count / 2); i <= count / 2; i += 1) {
+        const z = (i * (innerB * 1.7)) / count;
+        if (Math.abs(z) >= innerB) continue;
+        const xmax = innerA * Math.sqrt(Math.max(0, 1 - (z / innerB) * (z / innerB)));
+        const len = Math.max(0.02, xmax * 2 * 0.98);
+        const geo = new THREE.BoxGeometry(len, thick, thick);
+        const mesh = new THREE.Mesh(geo, sMat);
+        mesh.position.set(0, 0, z);
+        strings.add(mesh);
+      }
+      g.add(strings);
+      function beamBetween(p0, p1, sx = 0.06, sy = 0.1) {
+        const d = new THREE.Vector3().subVectors(p1, p0);
+        const L = d.length();
+        const geo = new THREE.BoxGeometry(sx, sy, L);
+        const m = new THREE.Mesh(geo, frameMat);
+        const mid = new THREE.Vector3().addVectors(p0, p1).multiplyScalar(0.5);
+        m.position.copy(mid);
+        const yaw = Math.atan2(d.x, d.z);
+        m.rotation.set(0, yaw, 0);
+        return m;
+      }
+      const alpha = 0.35;
+      const thL = -Math.PI / 2 - alpha;
+      const thR = -Math.PI / 2 + alpha;
+      const innerA2 = a - tubeRad * 0.6;
+      const innerB2 = b - tubeRad * 0.6;
+      const pL = new THREE.Vector3(innerA2 * Math.cos(thL), 0, innerB2 * Math.sin(thL));
+      const pR = new THREE.Vector3(innerA2 * Math.cos(thR), 0, innerB2 * Math.sin(thR));
+      const joinZ = -(b + 0.55);
+      const J = new THREE.Vector3(0, 0, joinZ);
+      const armL = beamBetween(pL, J, 0.06, 0.1);
+      const armR = beamBetween(pR, J, 0.06, 0.1);
+      g.add(armL, armR);
+      const handleLen = 2.1;
+      const handleR = 0.11;
+      const leather = new THREE.ShaderMaterial({
+        uniforms: {
+          uCol: { value: new THREE.Color('#2b2b2b') },
+          uEdge: { value: new THREE.Color('#111') },
+          uScale: { value: 24.0 }
+        },
+        vertexShader: `varying vec2 vUv; void main(){ vUv=uv; gl_Position=projectionMatrix*modelViewMatrix*vec4(position,1.0); }`,
+        fragmentShader: `precision mediump float; varying vec2 vUv; uniform vec3 uCol,uEdge; uniform float uScale; float h(vec2 p){return fract(sin(dot(p,vec2(127.1,311.7)))*43758.5453123);} float n(vec2 p){vec2 i=floor(p),f=fract(p);f=f*f*(3.-2.*f);float a=h(i),b=h(i+vec2(1,0)),c=h(i+vec2(0,1)),d=h(i+vec2(1,1));float nx=mix(a,b,f.x)+(c-a)*f.y*(1.-f.x)+(d-b)*f.x*f.y;return nx;} void main(){ float t = n(vUv*uScale); vec3 col = mix(uEdge,uCol, smoothstep(0.45,0.9,t)); gl_FragColor=vec4(col,1.0);} `
+      });
+      const handleGeo = new THREE.CylinderGeometry(handleR * 0.9, handleR, handleLen, 40, 1, true);
+      const handle = new THREE.Mesh(handleGeo, leather);
+      handle.rotation.x = Math.PI / 2;
+      handle.position.set(0, 0, joinZ - (handleLen * 0.5 + 0.08));
+      g.add(handle);
+      const butt = new THREE.Mesh(new THREE.CylinderGeometry(handleR * 0.95, handleR * 0.95, 0.12, 24), new THREE.MeshStandardMaterial({ color: 0x0e1116, roughness: 0.8 }));
+      butt.rotation.x = Math.PI / 2;
+      butt.position.copy(handle.position);
+      butt.position.z -= handleLen * 0.5 + 0.11;
+      g.add(butt);
+      const decalCanvas = document.createElement('canvas');
+      const dctx = decalCanvas.getContext('2d');
+      decalCanvas.width = 512;
+      decalCanvas.height = 128;
+      dctx.fillStyle = '#22262e';
+      dctx.fillRect(0, 0, 512, 128);
+      dctx.font = '700 72px system-ui';
+      dctx.fillStyle = '#f4f6fa';
+      dctx.textAlign = 'center';
+      dctx.fillText('OS‑Racquet', 256, 88);
+      const decalTex = new THREE.CanvasTexture(decalCanvas);
+      const decal = new THREE.Mesh(new THREE.PlaneGeometry(0.9, 0.18), new THREE.MeshBasicMaterial({ map: decalTex, transparent: true }));
+      decal.position.set(0, 0.08, 0.55);
+      g.add(decal);
+      return g;
+    }
 
-    // Rackets and ball
+    function buildBallURT() {
+      const felt = new THREE.ShaderMaterial({
+        uniforms: {
+          uA: { value: new THREE.Color('#e6ff3b') },
+          uB: { value: new THREE.Color('#cfe93a') },
+          uExp: { value: 1.85 }
+        },
+        vertexShader: `varying vec3 vP; varying vec3 vN; void main(){ vP=position; vN=normal; gl_Position=projectionMatrix*modelViewMatrix*vec4(position,1.0); }`,
+        fragmentShader: `precision mediump float; varying vec3 vP; varying vec3 vN; uniform vec3 uA,uB; uniform float uExp; float h(vec3 p){return fract(sin(dot(p,vec3(27.1,57.7,12.4)))*43758.5453);} float n(vec3 p){ vec3 i=floor(p), f=fract(p); f=f*f*(3.0-2.0*f); float a=h(i), b=h(i+vec3(1,0,0)), c=h(i+vec3(0,1,0)), d=h(i+vec3(1,1,0)); float e=h(i+vec3(0,0,1)), f2=h(i+vec3(1,0,1)), g=h(i+vec3(0,1,1)), h2=h(i+vec3(1,1,1)); float nx=mix(a,b,f.x)+(c-a)*f.y*(1.0-f.x)+(d-b)*f.x*f.y; float ny=mix(e,f2,f.x)+(g-e)*f.y*(1.0-f.x)+(h2-f2)*f.x*f.y; return mix(nx,ny,f.z);} float fbm(vec3 p){ float v=0.,amp=0.5; for(int i=0;i<6;i++){ v+=amp*n(p); p*=2.02; amp*=0.5;} return v;} vec3 aces(vec3 x){const float A=2.51,B=0.03,C=2.43,D=0.59,E=0.14; vec3 y=max(vec3(0.0),x*uExp); return clamp((y*(A*y+B))/(y*(C*y+D)+E),0.0,1.0);} void main(){ float f=fbm(vP*7.0+normalize(vN)*2.0); vec3 col=mix(uA,uB,smoothstep(0.35,0.8,f)); gl_FragColor=vec4(aces(col),1.0); }`,
+        lights: false
+      });
+      const ball = new THREE.Mesh(new THREE.SphereGeometry(0.26, 48, 36), felt);
+      const seamMat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.4 });
+      const band = new THREE.TorusGeometry(0.26, 0.008, 12, 96);
+      const s1 = new THREE.Mesh(band, seamMat);
+      s1.rotation.y = Math.PI / 2;
+      ball.add(s1);
+      const s2 = new THREE.Mesh(band, seamMat);
+      s2.rotation.x = Math.PI / 3;
+      ball.add(s2);
+      return ball;
+    }
+
+    function makeRacket() {
+      const root = new THREE.Group();
+      const headPivot = new THREE.Group();
+      root.add(headPivot);
+      const urt = buildRacketURT();
+      urt.rotation.x = 0;
+      urt.position.y = 1.0;
+      headPivot.add(urt);
+      root.userData = { headPivot, swing: 0, swingLR: 0 };
+      root.scale.setScalar(0.608);
+      return root;
+    }
+
     const ballR = 0.076 * 1.25;
     const ball = buildBallURT();
-    ball.scale.setScalar(ballR / 0.26);
+    const s = ballR / 0.26;
+    ball.scale.setScalar(s);
     scene.add(ball);
+    const physics = {
+      gravity: -9.81,
+      airDrag: 0.32,
+      lift: 0.24,
+      bounceRestitution: 0.82,
+      courtFriction: 0.18,
+      spinDamping: 0.9,
+      spinSlip: 0.6
+    };
+
+    const sC = document.createElement('canvas');
+    sC.width = sC.height = 96;
+    const sg = sC.getContext('2d');
+    const rg = sg.createRadialGradient(48, 48, 8, 48, 48, 46);
+    rg.addColorStop(0, 'rgba(0,0,0,0.35)');
+    rg.addColorStop(1, 'rgba(0,0,0,0)');
+    sg.fillStyle = rg;
+    sg.fillRect(0, 0, 96, 96);
+    const sT = new THREE.CanvasTexture(sC);
+    const sM = new THREE.SpriteMaterial({ map: sT, transparent: true, depthWrite: false });
+    const shadow = new THREE.Sprite(sM);
+    shadow.scale.set(ballR * 10, ballR * 10, 1);
+    shadow.position.y = 0.01;
+    scene.add(shadow);
+
+    const trailN = 14;
+    const trailGeom = new THREE.BufferGeometry();
+    const trailPos = new Float32Array(trailN * 3);
+    trailGeom.setAttribute('position', new THREE.BufferAttribute(trailPos, 3));
+    const trail = new THREE.Line(trailGeom, new THREE.LineBasicMaterial({ transparent: true, opacity: 0.22 }));
+    scene.add(trail);
+    function updateTrail() {
+      for (let i = trailN - 1; i > 0; i -= 1) {
+        trailPos[i * 3 + 0] = trailPos[(i - 1) * 3 + 0];
+        trailPos[i * 3 + 1] = trailPos[(i - 1) * 3 + 1];
+        trailPos[i * 3 + 2] = trailPos[(i - 1) * 3 + 2];
+      }
+      trailPos[0] = ball.position.x;
+      trailPos[1] = ball.position.y;
+      trailPos[2] = ball.position.z;
+      trailGeom.attributes.position.needsUpdate = true;
+    }
+
+    const hitRing = new THREE.Mesh(new THREE.RingGeometry(ballR * 0.86, ballR * 1.12, 36), new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0 }));
+    hitRing.rotation.x = -Math.PI / 2;
+    hitRing.position.y = 0.002;
+    scene.add(hitRing);
+    let hitTTL = 0;
 
     const player = makeRacket();
-    player.position.set(0, 0.65, playerZ);
+    player.position.set(0, 0, playerZ);
     player.rotation.y = Math.PI / 2;
     scene.add(player);
-    const enemy = makeRacket();
-    enemy.position.set(0, 0.65, cpuZ);
-    enemy.rotation.y = -Math.PI / 2;
-    scene.add(enemy);
+    const cpu = makeRacket();
+    cpu.position.set(0, 0, cpuZ);
+    cpu.rotation.y = -Math.PI / 2;
+    scene.add(cpu);
 
-    // Physics state
-    const velocity = new THREE.Vector3();
-    const GRAVITY = -0.01;
-    const BOUNCE = 0.82;
-    const AIR = 0.996;
-    let started = false;
+    const HIT_FORCE_MULTIPLIER = 2.5;
+    const OUTGOING_SPEED_CAP = 16.4 * HIT_FORCE_MULTIPLIER;
 
-    // Touch + mouse input
-    let startX = 0;
-    let startY = 0;
-    let startT = 0;
-
-    const screenToCourt = (x) => (x / renderer.domElement.clientWidth - 0.5) * courtW;
-
-    const onDown = (x, y) => {
-      startX = x;
-      startY = y;
-      startT = Date.now();
-    };
-
-    const onUp = (x, y) => {
-      const distX = x - startX;
-      const distY = startY - y;
-      const time = Math.max((Date.now() - startT) / 1000, 0.15);
-
-      if (distY > 40) {
-        started = true;
-        const power = Math.min((distY / time) * 0.0008, 0.38);
-        velocity.x = THREE.MathUtils.clamp(distX * 0.00075, -0.18, 0.18);
-        velocity.y = 0.12 + power * 0.18;
-        velocity.z = -0.12 - power * 0.36;
-
-        player.position.x = screenToCourt(startX);
-        ball.position.set(player.position.x, player.position.y + 0.45, player.position.z - 0.42);
+    const state = {
+      gravity: -9.81,
+      drag: 0.48,
+      cor: 0.74,
+      fric: 0.24,
+      live: false,
+      serveBy: 'player',
+      serveSide: 'deuce',
+      attempts: 2,
+      awaitingServeBounce: false,
+      rallyStarted: false,
+      bounceSide: null,
+      matchOver: false,
+      score: {
+        points: { player: 0, cpu: 0 },
+        games: { player: 0, cpu: 0 },
+        sets: { player: 0, cpu: 0 }
       }
     };
+    const pos = new THREE.Vector3(0, ballR + 0.01, playerZ - 1.0);
+    const vel = new THREE.Vector3();
+    const spin = new THREE.Vector3();
+    const tmpVec = new THREE.Vector3();
+    const accVec = new THREE.Vector3();
+    const tangentVel = new THREE.Vector3();
+    const spinSurfaceVel = new THREE.Vector3();
+    let playerSwing = null;
+    let cpuSwing = null;
+    function respondToCourtImpact(impactSpeed) {
+      const incoming = Math.max(0, impactSpeed);
+      const restitution = THREE.MathUtils.clamp(physics.bounceRestitution - incoming * 0.01, 0.72, 0.9);
+      vel.y = incoming * restitution;
 
-    const handleTouchStart = (e) => {
+      tangentVel.set(vel.x, 0, vel.z);
+      spinSurfaceVel.set(-spin.z * ballR, 0, spin.x * ballR);
+      tangentVel.addScaledVector(spinSurfaceVel, physics.spinSlip * 0.8);
+      tangentVel.multiplyScalar(1 - physics.courtFriction);
+      vel.x = tangentVel.x;
+      vel.z = tangentVel.z;
+
+      spin.multiplyScalar(physics.spinDamping);
+    }
+    let lastHitter = 'player';
+    ball.position.copy(pos);
+
+    const opponentOf = (id) => (id === 'player' ? 'cpu' : 'player');
+    const POINT_LABELS = ['0', '15', '30', '40'];
+    const GAMES_TO_WIN = 4;
+    const SETS_TO_WIN = 2;
+
+    function resetRally() {
+      state.awaitingServeBounce = false;
+      state.rallyStarted = false;
+      state.bounceSide = null;
+      spin.set(0, 0, 0);
+    }
+
+    function formatPoints() {
+      const p = state.score.points.player;
+      const c = state.score.points.cpu;
+      if (p >= 3 && c >= 3) {
+        if (p === c) return 'Deuce';
+        if (p === c + 1) return `Adv ${playerLabel}`;
+        if (c === p + 1) return `Adv ${cpuLabel}`;
+      }
+      const left = POINT_LABELS[Math.min(p, 3)];
+      const right = POINT_LABELS[Math.min(c, 3)];
+      return `${playerLabel} ${left} – ${cpuLabel} ${right}`;
+    }
+
+    function pointLabelFor(playerKey) {
+      const opponentKey = opponentOf(playerKey);
+      const me = state.score.points[playerKey];
+      const opp = state.score.points[opponentKey];
+      if (me >= 3 && opp >= 3) {
+        if (me === opp) return '40';
+        if (me === opp + 1) return 'AD';
+        return '40';
+      }
+      return POINT_LABELS[Math.min(me, 3)];
+    }
+
+    function updateHud() {
+      setHudInfo({
+        points: formatPoints(),
+        games: `${state.score.games.player} - ${state.score.games.cpu}`,
+        sets: `${state.score.sets.player} - ${state.score.sets.cpu}`,
+        server: state.serveBy === 'player' ? playerLabel : cpuLabel,
+        side: state.serveSide,
+        attempts: state.attempts,
+        playerSets: state.score.sets.player,
+        cpuSets: state.score.sets.cpu,
+        playerGames: state.score.games.player,
+        cpuGames: state.score.games.cpu,
+        playerPointLabel: pointLabelFor('player'),
+        cpuPointLabel: pointLabelFor('cpu')
+      });
+    }
+
+    function serviceBoxFor(server) {
+      const receive = opponentOf(server);
+      const sign = state.serveSide === 'deuce' ? 1 : -1;
+      const minX = sign > 0 ? SERVICE_BOX_INNER : -halfW + SERVICE_BOX_INNER;
+      const maxX = sign > 0 ? halfW - SERVICE_BOX_INNER : -SERVICE_BOX_INNER;
+      const minZ = receive === 'player' ? 0.15 : -SERVICE_LINE_Z + 0.15;
+      const maxZ = receive === 'player' ? SERVICE_LINE_Z - 0.15 : -0.15;
+      return { minX, maxX, minZ, maxZ };
+    }
+
+    function inBox(x, z, box, pad = 0.08) {
+      return (
+        x >= box.minX - pad &&
+        x <= box.maxX + pad &&
+        z >= box.minZ - pad &&
+        z <= box.maxZ + pad
+      );
+    }
+
+    function rotateServeSide() {
+      state.serveSide = state.serveSide === 'deuce' ? 'ad' : 'deuce';
+    }
+
+    function resetForNextPoint() {
+      state.attempts = 2;
+      resetRally();
+      updateHud();
+    }
+
+    let matchResetTO = null;
+
+    function handleGameWin(winner, reason = '') {
+      const loser = opponentOf(winner);
+      const prefix = reason ? `${reason} · ` : '';
+      state.score.points.player = 0;
+      state.score.points.cpu = 0;
+      state.score.games[winner] += 1;
+      state.serveSide = 'deuce';
+      resetForNextPoint();
+      const label = winner === 'player' ? playerLabel : cpuLabel;
+      let announce = `${prefix}Game ${label}`;
+      const gW = state.score.games[winner];
+      const gL = state.score.games[loser];
+      if (gW >= GAMES_TO_WIN && gW >= gL + 2) {
+        state.score.sets[winner] += 1;
+        announce += ` · Set ${label}`;
+        state.score.games.player = 0;
+        state.score.games.cpu = 0;
+        const sW = state.score.sets[winner];
+        if (sW >= SETS_TO_WIN) {
+          announce += ` · Match ${label}`;
+          state.matchOver = true;
+          updateHud();
+          setMsg(formatMsg(announce));
+          if (matchResetTO) {
+            try {
+              clearTimeout(matchResetTO);
+            } catch {}
+          }
+          matchResetTO = setTimeout(() => {
+            state.matchOver = false;
+            state.score.points.player = 0;
+            state.score.points.cpu = 0;
+            state.score.games.player = 0;
+            state.score.games.cpu = 0;
+            state.score.sets.player = 0;
+            state.score.sets.cpu = 0;
+            state.serveBy = 'player';
+            state.serveSide = 'deuce';
+            resetForNextPoint();
+            prepareServe('player');
+          }, 3600);
+          return;
+        }
+      }
+      state.serveBy = opponentOf(state.serveBy);
+      updateHud();
+      prepareServe(state.serveBy, { announce });
+    }
+
+    function awardPoint(winner, reason = '') {
+      if (state.matchOver) return;
+      const loser = opponentOf(winner);
+      const pts = state.score.points;
+      const prefix = reason ? `${reason} · ` : '';
+      if (pts[winner] >= 3 && pts[loser] >= 3) {
+        if (pts[winner] === pts[loser]) {
+          pts[winner] += 1;
+          rotateServeSide();
+          resetForNextPoint();
+          const label = winner === 'player' ? playerLabel : cpuLabel;
+          prepareServe(state.serveBy, { announce: `${prefix}Adv ${label}` });
+          return;
+        }
+        if (pts[winner] === pts[loser] + 1) {
+          handleGameWin(winner, reason);
+          return;
+        }
+        pts[loser] = Math.max(0, pts[loser] - 1);
+        rotateServeSide();
+        resetForNextPoint();
+        prepareServe(state.serveBy, { announce: `${prefix}Deuce` });
+        return;
+      }
+      pts[winner] += 1;
+      if (pts[winner] >= 4 && pts[winner] >= pts[loser] + 2) {
+        handleGameWin(winner, reason);
+        return;
+      }
+      rotateServeSide();
+      resetForNextPoint();
+      const label = winner === 'player' ? playerLabel : cpuLabel;
+      prepareServe(state.serveBy, { announce: `${prefix}Point ${label}` });
+    }
+
+    function finishPoint(winner, reason = '') {
+      const normalizedReason = reason.toLowerCase();
+      state.live = false;
+      resetRally();
+      if (normalizedReason.includes('out')) {
+        playOutSound();
+      } else if (normalizedReason.includes('net')) {
+        playNetSound();
+      } else {
+        playScoreSound();
+      }
+      awardPoint(winner, reason);
+      if (trainingMode && winner === 'player') markTrainingStep('winPoint');
+    }
+
+    function registerFault(server, reason) {
+      const normalizedReason = reason.toLowerCase();
+      const notifyFault = () => {
+        if (normalizedReason.includes('net')) playNetSound();
+        else if (normalizedReason.includes('out')) playOutSound();
+      };
+      state.live = false;
+      state.awaitingServeBounce = false;
+      if (state.matchOver) return;
+      state.attempts = Math.max(0, state.attempts - 1);
+      if (state.attempts <= 0) {
+        const winner = opponentOf(server);
+        finishPoint(winner, `${reason} · Double Fault`);
+        return;
+      }
+      notifyFault();
+      updateHud();
+      const announce = state.attempts === 1 ? `${reason} · 2nd` : reason;
+      prepareServe(server, { resetAttempts: false, announce });
+    }
+
+    function solveShot(from, to, g, tSec) {
+      const t = tSec;
+      const dx = to.x - from.x;
+      const dz = to.z - from.z;
+      const dy = to.y - from.y;
+      const vx = dx / t;
+      const vz = dz / t;
+      const vy = (dy - 0.5 * g * t * t) / t;
+      return new THREE.Vector3(vx, vy, vz);
+    }
+    function ensureNetClear(from, v, g, netY, margin = ballR * 0.8) {
+      const vz = v.z;
+      const dzToNet = 0 - from.z;
+      if (Math.abs(vz) < 1e-4) return v;
+      const tNet = dzToNet / vz;
+      if (tNet <= 0) return v;
+      const yNet = from.y + v.y * tNet + 0.5 * g * tNet * tNet;
+      const need = netY + margin;
+      if (yNet < need) {
+        v.y += (need - yNet) / Math.max(0.15, tNet);
+      }
+      return v;
+    }
+
+    function clampNetSpan(from, v, singlesLimit = halfW - 0.32) {
+      const vz = v.z;
+      if (Math.abs(vz) < 1e-4) return v;
+      const tNet = (0 - from.z) / vz;
+      if (tNet <= 0) return v;
+      const netX = from.x + v.x * tNet;
+      const limit = Math.max(0.2, singlesLimit);
+      const span = Math.abs(netX);
+      if (span > limit) {
+        const scale = limit / Math.max(span, 1e-4);
+        v.x *= scale;
+      }
+      return v;
+    }
+
+    function placeCamera() {
+      const playerServingDiag = !state.live && state.serveBy === 'player';
+      const cpuServingDiag = !state.live && state.serveBy === 'cpu';
+      if (playerServingDiag) {
+        const sideOffset = state.serveSide === 'deuce' ? 1.35 : -1.35;
+        const diagTarget = new THREE.Vector3(
+          player.position.x + sideOffset,
+          camHeight + 0.2,
+          THREE.MathUtils.clamp(player.position.z + camBack + 0.8, cameraMinZ, cameraMaxZ)
+        );
+        camera.position.lerp(diagTarget, 0.25);
+        camera.lookAt(new THREE.Vector3(0, 1.15, -halfL + 0.65));
+        return;
+      }
+      if (cpuServingDiag) {
+        const sideOffset = state.serveSide === 'deuce' ? -1.35 : 1.35;
+        const diagTarget = new THREE.Vector3(
+          cpu.position.x + sideOffset,
+          camHeight + 0.2,
+          THREE.MathUtils.clamp(cpu.position.z - camBack - 0.8, -cameraMaxZ, -cameraMinZ)
+        );
+        camera.position.lerp(diagTarget, 0.25);
+        camera.lookAt(new THREE.Vector3(0, 1.15, halfL - 0.65));
+        return;
+      }
+      const camFollowZ = ball.position.z + (ball.position.z >= player.position.z - 0.5 ? 2.8 : 3.6);
+      const desiredZ = THREE.MathUtils.clamp(
+        Math.max(camFollowZ, player.position.z + 0.8),
+        cameraMinZ,
+        Math.min(cameraMaxZ + 1.0, player.position.z + camBack + 1.5)
+      );
+      const followX = THREE.MathUtils.lerp(player.position.x, ball.position.x, 0.85);
+      const followY = Math.max(camHeight * 0.9, ball.position.y + 1.05);
+      const target = new THREE.Vector3(followX, followY, desiredZ);
+      camera.position.lerp(target, 0.18);
+      const look = new THREE.Vector3(
+        THREE.MathUtils.lerp(player.position.x * 0.12, ball.position.x, 0.95),
+        Math.max(1.22, ball.position.y + 0.28),
+        Math.max(player.position.z - 1.35, ball.position.z - 2.1)
+      );
+      camera.lookAt(look);
+    }
+
+    function inSinglesX(x) {
+      return Math.abs(x) <= halfW - 0.05;
+    }
+
+    let cpuSrvTO = null;
+    let playerSrvTO = null;
+    const markTrainingStep = (id) => {
+      if (!trainingMode) return;
+      setTrainingStatus((prev) => {
+        if (prev[id]) return prev;
+        return { ...prev, [id]: true };
+      });
+    };
+
+    const formatMsg = (base) => (trainingMode ? `Training · ${base}` : base);
+
+    function prepareServe(by, options = {}) {
+      const { resetAttempts = true, announce } = options;
+      state.serveBy = by;
+      if (resetAttempts) state.attempts = 2;
+      state.live = false;
+      resetRally();
+      playerSwing = null;
+      cpuSwing = null;
+      const idleX = state.serveSide === 'deuce' ? halfW - 0.4 : -halfW + 0.4;
+      if (by === 'player') {
+        const serveZ = halfL - 0.92;
+        player.position.set(idleX, 0, serveZ);
+        const tossX = idleX;
+        const tossZ = serveZ - 0.28;
+        pos.set(tossX, 1.36, tossZ);
+      } else {
+        const serveZ = -halfL + 0.92;
+        cpu.position.set(-idleX, 0, serveZ);
+        const tossX = -idleX;
+        const tossZ = serveZ + 0.28;
+        pos.set(tossX, 1.36, tossZ);
+      }
+      vel.set(0, 0, 0);
+      spin.set(0, 0, 0);
+      ball.position.copy(pos);
+      shadow.position.set(pos.x, 0.01, pos.z);
+      const serverLabel = by === 'player' ? playerLabel : cpuLabel;
+      const sideLabel = state.serveSide === 'deuce' ? 'D' : 'Ad';
+      const base = `Serve ${sideLabel} · ${serverLabel}`;
+      const text = announce ? `${announce} · ${base}` : base;
+      setMsg(formatMsg(text));
+      lastHitter = by;
+      updateHud();
+      if (cpuSrvTO) {
+        try {
+          clearTimeout(cpuSrvTO);
+        } catch {}
+        cpuSrvTO = null;
+      }
+      if (playerSrvTO) {
+        try {
+          clearTimeout(playerSrvTO);
+        } catch {}
+        playerSrvTO = null;
+      }
+      if (by === 'cpu') {
+        cpuSrvTO = setTimeout(() => {
+          if (state.live || state.matchOver) return;
+          const box = serviceBoxFor('cpu');
+          const tx = THREE.MathUtils.randFloat(box.minX, box.maxX);
+          const tz = THREE.MathUtils.randFloat(box.minZ, box.maxZ);
+          const to = new THREE.Vector3(tx, ballR + 0.06, tz);
+          let v0 = solveShot(pos.clone(), to, state.gravity, THREE.MathUtils.randFloat(0.78, 0.96));
+          v0 = ensureNetClear(pos.clone(), v0, state.gravity, netH, ballR * 1.05);
+          clampNetSpan(pos.clone(), v0);
+          cpuSwing = {
+            normal: v0.clone().normalize(),
+            speed: v0.length(),
+            ttl: 0.35,
+            extraSpin: craftCpuSpin(v0.z, 0.65, tx / halfW),
+            friction: 0.22,
+            restitution: 1.08,
+            reach: ballR + 0.34
+          };
+          setMsg(formatMsg(`Serve · ${cpuLabel}`));
+          cpu.userData.swing = 0.95;
+          cpu.userData.swingLR = THREE.MathUtils.clamp((tx - cpu.position.x) / halfW, -1, 1);
+          lastHitter = 'cpu';
+        }, 650);
+      } else {
+        playerSrvTO = setTimeout(() => {
+          if (state.live || state.matchOver || state.serveBy !== 'player') return;
+          const box = serviceBoxFor('player');
+          const tx = THREE.MathUtils.randFloat(box.minX, box.maxX);
+          const tz = THREE.MathUtils.randFloat(box.minZ, box.maxZ);
+          const to = new THREE.Vector3(tx, ballR + 0.06, tz);
+          let v0 = solveShot(pos.clone(), to, state.gravity, THREE.MathUtils.randFloat(0.85, 0.98));
+          v0 = ensureNetClear(pos.clone(), v0, state.gravity, netH, ballR * 1.05);
+          clampNetSpan(pos.clone(), v0);
+          playerSwing = {
+            normal: v0.clone().normalize(),
+            speed: v0.length(),
+            ttl: 0.35,
+            extraSpin: new THREE.Vector3(
+              THREE.MathUtils.randFloat(26, 42) * Math.sign(v0.z || -1),
+              THREE.MathUtils.randFloatSpread(8),
+              THREE.MathUtils.randFloatSpread(4)
+            ),
+            friction: 0.26,
+            restitution: 1.1,
+            reach: ballR + 0.34,
+            force: 0.75
+          };
+          pos.y = Math.max(pos.y, 1.32);
+          setMsg(formatMsg(`Serve · ${playerLabel}`));
+          player.userData.swing = 0.65;
+          player.userData.swingLR = THREE.MathUtils.clamp((tx - player.position.x) / halfW, -1, 1);
+          lastHitter = 'player';
+        }, 1100);
+      }
+    }
+
+    const el = renderer.domElement;
+    el.style.touchAction = 'none';
+    let usingTouch = false;
+    let touching = false;
+    let sx = 0;
+    let sy = 0;
+    let lx = 0;
+    let ly = 0;
+    let st = 0;
+    const gestureTrail = [];
+    function onDown(e) {
+      if (usingTouch && e.pointerType === 'touch') return;
+      touching = true;
+      sx = lx = e.clientX;
+      sy = ly = e.clientY;
+      st = performance.now();
+      gestureTrail.length = 0;
+      gestureTrail.push({ x: sx, y: sy, t: st });
+      player.userData.swing = -0.55;
+      player.userData.swingLR = 0;
+    }
+    function onMove(e) {
+      if (!touching) return;
+      if (usingTouch && e.pointerType === 'touch') return;
+      lx = e.clientX;
+      ly = e.clientY;
+      const now = performance.now();
+      gestureTrail.push({ x: lx, y: ly, t: now });
+      while (gestureTrail.length > 1 && now - gestureTrail[0].t > 260) gestureTrail.shift();
+    }
+    function analyzeGesture() {
+      if (gestureTrail.length < 2) return null;
+      const first = gestureTrail[0];
+      const last = gestureTrail[gestureTrail.length - 1];
+      const duration = Math.max(12, last.t - first.t);
+      const dx = last.x - first.x;
+      const dy = last.y - first.y;
+      const dist = Math.hypot(dx, dy);
+      const speed = (dist / duration) * 1000;
+      const dir = new THREE.Vector2(-dx || 1e-6, -dy || 1e-6).normalize();
+      return { duration, dist, speed, dir, raw: { dx, dy } };
+    }
+
+    function deriveSwingFromGesture({ dir, speed, raw }, { serve = false } = {}) {
+      const minSwipe = serve ? 300 : 320;
+      const maxSwipe = serve ? 1650 : 1900;
+      const swipePower = THREE.MathUtils.clamp(
+        THREE.MathUtils.mapLinear(speed, minSwipe, maxSwipe, 6, 17),
+        6,
+        17
+      );
+      const normalizedForce = THREE.MathUtils.clamp(swipePower / 17, serve ? 0.46 : 0.36, 1);
+
+      const lateralLean = THREE.MathUtils.clamp(dir.x, -0.95, 0.95);
+      const verticalIntent = THREE.MathUtils.clamp(raw.dy === 0 ? 0 : -raw.dy / (Math.abs(raw.dx) + Math.abs(raw.dy)), -0.65, 0.95);
+      const depthBias = THREE.MathUtils.clamp(0.7 + Math.abs(verticalIntent) * 0.4, 0.7, 1.3);
+
+      const forwardDir = new THREE.Vector3(
+        lateralLean * 0.75,
+        THREE.MathUtils.lerp(0.36, 0.82, depthBias) + Math.max(0, verticalIntent) * 0.48,
+        -1.1
+      ).normalize();
+
+      const swingSpeed = THREE.MathUtils.lerp(10.5, 22.5, normalizedForce) * (serve ? 1.1 : 1.04);
+      const topSpin = THREE.MathUtils.lerp(12, 32, normalizedForce * depthBias);
+      const sideSpin = THREE.MathUtils.lerp(4, 14, Math.abs(lateralLean)) * Math.sign(lateralLean || 1);
+      const spinAxis = new THREE.Vector3(-depthBias * 0.9, THREE.MathUtils.clamp(lateralLean * 0.9, -0.9, 0.9), 0.45)
+        .normalize()
+        .multiplyScalar(topSpin);
+      spinAxis.y += sideSpin;
+
+      const liftBoost = THREE.MathUtils.clamp(0.55 + normalizedForce * 1.05 + Math.max(0, verticalIntent) * 1.1, 0.55, 1.8);
+
+      return {
+        normal: forwardDir,
+        speed: swingSpeed,
+        ttl: 0.34,
+        extraSpin: spinAxis,
+        friction: 0.2,
+        restitution: 1.08,
+        reach: ballR + 0.8,
+        force: normalizedForce,
+        power: swipePower,
+        aimDirection: new THREE.Vector3(lateralLean * 0.9, 0.3, -1).normalize(),
+        liftBoost
+      };
+    }
+
+    function tryApplySwing(hitter, swing, racketPos) {
+      if (!swing) return false;
+      const toBall = tmpVec.subVectors(pos, racketPos);
+      if (toBall.lengthSq() > swing.reach * swing.reach) return false;
+
+      const normal = swing.normal.clone().normalize();
+      const swingVel = normal.clone().multiplyScalar(swing.speed);
+      const relVel = vel.clone().sub(swingVel);
+      const closing = relVel.dot(normal) < -0.08 || !state.live;
+      if (!closing) return false;
+
+      const vn = relVel.dot(normal);
+      const impulse = -(1 + swing.restitution) * vn * HIT_FORCE_MULTIPLIER;
+      vel.addScaledVector(normal, impulse);
+      vel.addScaledVector(swingVel, 0.32 * HIT_FORCE_MULTIPLIER);
+
+      const tangent = relVel.sub(normal.clone().multiplyScalar(vn));
+      if (tangent.lengthSq() > 1e-5) {
+        const friction = swing.friction ?? 0.25;
+        vel.addScaledVector(tangent, -friction);
+        const spinDir = new THREE.Vector3().crossVectors(normal, tangent).normalize();
+        const spinGain = THREE.MathUtils.clamp(tangent.length() * 3.2, 0, 64);
+        spin.addScaledVector(spinDir, spinGain);
+      }
+      if (swing.extraSpin) spin.add(swing.extraSpin);
+      if (swing.aimDirection) {
+        const currentSpeed = vel.length();
+        const blended = vel
+          .clone()
+          .normalize()
+          .lerp(swing.aimDirection.clone().normalize(), THREE.MathUtils.lerp(0.35, 0.7, swing.force || 0.5))
+          .normalize();
+        vel.copy(blended.multiplyScalar(currentSpeed));
+      }
+
+      const baseLift = state.live ? 2.6 : 3.4;
+      const minUpward = baseLift + (swing.force ?? 0.5) * 2.2 + (swing.liftBoost ?? 0);
+      if (vel.y < minUpward) {
+        vel.y = minUpward;
+      }
+
+      const capped = THREE.MathUtils.clamp(vel.length(), 0, OUTGOING_SPEED_CAP);
+      if (vel.length() > capped) {
+        vel.setLength(capped);
+      }
+
+      if (!state.live && state.serveBy === hitter) state.awaitingServeBounce = true;
+      state.live = true;
+      state.rallyStarted = true;
+      state.bounceSide = null;
+      lastHitter = hitter;
+      hitTTL = 1.0;
+      hitRing.position.set(pos.x, 0.002, pos.z);
+      playKickSound();
+      if (trainingMode && hitter === 'player' && state.live) {
+        markTrainingStep('rallyHit');
+      }
+      return true;
+    }
+
+    function craftCpuSpin(directionZ, aggression = 0.55, sideBias = 0) {
+      const bias = THREE.MathUtils.clamp(sideBias, -1, 1);
+      const forwardSign = Math.sign(directionZ === 0 ? -1 : directionZ);
+      const top = THREE.MathUtils.lerp(18, 58, aggression);
+      const side = THREE.MathUtils.lerp(4, 18, aggression);
+      const randSide = THREE.MathUtils.randFloatSpread(side * 0.35);
+      const randTwist = THREE.MathUtils.randFloatSpread(6);
+      return new THREE.Vector3(forwardSign * top, bias * side + randSide, randTwist);
+    }
+    function onUp(evt, { fromTouch = false } = {}) {
+      if (!touching) return;
+      if (!fromTouch && usingTouch && evt?.pointerType === 'touch') return;
+      touching = false;
+      const gesture = analyzeGesture();
+      if (!gesture) return;
+      const spd = gesture.speed;
+      if (!state.live) {
+        if (state.serveBy === 'player') {
+          playerSwing = deriveSwingFromGesture(gesture, { serve: true });
+          markTrainingStep('swipeServe');
+          setMsg(formatMsg(`Serve · ${playerLabel}`));
+          player.userData.swing = 0.65 + 0.95 * (playerSwing.force || 0.5);
+          player.userData.swingLR = THREE.MathUtils.clamp(playerSwing.normal.x * 2.2, -1, 1);
+          lastHitter = 'player';
+          if (playerSrvTO) {
+            try {
+              clearTimeout(playerSrvTO);
+            } catch {}
+            playerSrvTO = null;
+          }
+        }
+      } else {
+        const near = pos.z > 0 && Math.abs(pos.z - (playerZ - 0.78)) < 3.0;
+        if (near && pos.y <= 2.6) {
+          playerSwing = deriveSwingFromGesture(gesture, { serve: false });
+          player.userData.swing = 0.62 + 0.9 * (playerSwing.force || 0.5);
+          player.userData.swingLR = THREE.MathUtils.clamp(playerSwing.normal.x * 2.2, -1, 1);
+          lastHitter = 'player';
+        }
+      }
+    }
+    el.addEventListener('pointerdown', onDown);
+    window.addEventListener('pointermove', onMove, { passive: true });
+    window.addEventListener('pointerup', onUp);
+
+    function onTouchStart(e) {
+      usingTouch = true;
       const t = e.touches[0];
       if (!t) return;
-      onDown(t.clientX, t.clientY);
-    };
-    const handleTouchEnd = (e) => {
-      const t = e.changedTouches[0];
+      onDown({ clientX: t.clientX, clientY: t.clientY });
+    }
+    function onTouchMove(e) {
+      const t = e.touches[0];
       if (!t) return;
-      onUp(t.clientX, t.clientY);
-    };
-    const handleMouseDown = (e) => onDown(e.clientX, e.clientY);
-    const handleMouseUp = (e) => onUp(e.clientX, e.clientY);
-
-    renderer.domElement.addEventListener("touchstart", handleTouchStart, { passive: true });
-    renderer.domElement.addEventListener("touchend", handleTouchEnd, { passive: true });
-    renderer.domElement.addEventListener("mousedown", handleMouseDown);
-    renderer.domElement.addEventListener("mouseup", handleMouseUp);
-
-    // Helpers
-    function updateRacketHeight() {
-      const targetY = Math.max(0.65, Math.min(ball.position.y, 3));
-      player.position.y += (targetY - player.position.y) * 0.2;
-      enemy.position.y += (targetY - enemy.position.y) * 0.2;
+      onMove({ clientX: t.clientX, clientY: t.clientY });
+    }
+    function onTouchEnd(e) {
+      const t = e.changedTouches[0];
+      if (!t) {
+        usingTouch = false;
+        return;
+      }
+      onUp({ clientX: t.clientX, clientY: t.clientY, pointerType: 'touch' }, { fromTouch: true });
+      usingTouch = false;
     }
 
-    function enemyAI() {
-      if (!started) return;
-      const t = Math.abs((enemy.position.z - ball.position.z) / (velocity.z || 0.01));
-      const targetX = ball.position.x + velocity.x * t;
-      enemy.position.x += (targetX - enemy.position.x) * 0.08;
-      if (ball.position.distanceTo(enemy.position) < 2.0 && velocity.z < 0) {
-        velocity.z = Math.abs(velocity.z) + 0.2;
-        velocity.y = 0.2 + Math.random() * 0.1;
+    el.addEventListener('touchstart', onTouchStart, { passive: true });
+    el.addEventListener('touchmove', onTouchMove, { passive: true });
+    el.addEventListener('touchend', onTouchEnd, { passive: true });
+    el.addEventListener('touchcancel', onTouchEnd, { passive: true });
+
+    let cpuWind = 0;
+    let cpuPlan = null;
+    function cpuTryHit(dt) {
+      if (!state.live) {
+        if (state.serveBy === 'cpu' && !cpuSwing && !cpuSrvTO && !state.matchOver) {
+          prepareServe('cpu');
+        }
+        cpuWind = Math.max(0, cpuWind - dt);
+        cpu.position.x = THREE.MathUtils.damp(cpu.position.x, 0, 4.2, dt);
+        cpu.position.z = THREE.MathUtils.damp(cpu.position.z, cpuZ, 3.5, dt);
+        return;
+      }
+      const approaching = vel.z < 0;
+      if (!approaching) {
+        cpuWind = Math.max(0, cpuWind - dt);
+        cpu.position.x = THREE.MathUtils.damp(cpu.position.x, 0, 4.5, dt);
+        cpu.position.z = THREE.MathUtils.damp(cpu.position.z, cpuZ, 4.0, dt);
+        return;
+      }
+      const vz = Math.min(-0.001, vel.z);
+      const t = THREE.MathUtils.clamp((pos.z - cpuZ) / vz, 0.06, 1.4);
+      const predictedX = pos.x + vel.x * t;
+      const clampX = THREE.MathUtils.clamp(predictedX, -halfW * 0.92, halfW * 0.92);
+      cpu.position.x = THREE.MathUtils.damp(cpu.position.x, clampX, 7.2, dt);
+      const retreat = THREE.MathUtils.mapLinear(Math.min(1.0, t), 0, 1, -0.2, 0.6);
+      const targetZ = cpuZ - retreat;
+      cpu.position.z = THREE.MathUtils.damp(cpu.position.z, targetZ, 5.5, dt);
+
+      const interceptY = pos.y + vel.y * t + 0.5 * state.gravity * t * t;
+      const close = t < 0.24 && Math.abs(predictedX - cpu.position.x) < 1.35 && interceptY <= 2.2;
+      if (close && cpuWind <= 0 && !cpuPlan) {
+        const aggression = THREE.MathUtils.clamp(Math.abs(player.position.x) / halfW, 0.25, 0.85);
+        const corner = player.position.x > 0 ? -halfW + 0.45 : halfW - 0.45;
+        const mix = THREE.MathUtils.lerp(predictedX, corner, aggression);
+        const tx = THREE.MathUtils.clamp(mix + THREE.MathUtils.randFloatSpread(0.35), -halfW + 0.35, halfW - 0.35);
+        let tz = THREE.MathUtils.mapLinear(Math.min(halfW, Math.abs(player.position.x)), 0, halfW, halfL - 1.55, halfL - 0.9);
+        if (player.position.z < halfL - 2.4) tz = halfL - 0.75;
+        tz = THREE.MathUtils.clamp(tz + THREE.MathUtils.randFloatSpread(0.3), halfL - 1.7, halfL - 0.55);
+        cpuPlan = { tx, tz };
+        cpuWind = 0.11 + Math.random() * 0.07;
+        cpu.userData.swing = -0.6;
+      }
+      if (cpuWind > 0) {
+        cpuWind -= dt;
+        if (cpuWind <= 0 && cpuPlan) {
+          const to = new THREE.Vector3(cpuPlan.tx, ballR + 0.06, cpuPlan.tz);
+          let v0 = solveShot(pos.clone(), to, state.gravity, THREE.MathUtils.randFloat(0.72, 0.94));
+          v0 = ensureNetClear(pos.clone(), v0, state.gravity, netH, ballR * 0.9);
+          clampNetSpan(pos.clone(), v0);
+          const aggression = THREE.MathUtils.clamp(Math.abs(player.position.x) / halfW, 0.4, 0.85);
+          const bias = THREE.MathUtils.clamp((cpuPlan.tx - player.position.x) / halfW, -1, 1);
+          cpuSwing = {
+            normal: v0.clone().normalize(),
+            speed: v0.length(),
+            ttl: 0.28,
+            extraSpin: craftCpuSpin(v0.z, aggression, bias),
+            friction: 0.24,
+            restitution: 1.08,
+            reach: ballR + 0.34
+          };
+          cpu.userData.swing = 1.18;
+          cpu.userData.swingLR = THREE.MathUtils.clamp((cpuPlan.tx - cpu.position.x) / halfW, -1, 1);
+          state.bounceSide = null;
+          state.rallyStarted = true;
+          lastHitter = 'cpu';
+          cpuPlan = null;
+        }
       }
     }
 
-    function updateCamera() {
-      const camTarget = new THREE.Vector3(player.position.x, 5.6, player.position.z + 9.8);
-      camera.position.lerp(camTarget, 0.08);
-      const lookTarget = new THREE.Vector3(player.position.x, player.position.y + 0.6, player.position.z - 1.2);
-      camera.lookAt(lookTarget);
+    const adPanels = [];
+    function makeAdTexture(line1 = 'TonPlaygram · the future of peer‑to‑peer crypto gaming', line2 = 'Earn · Play · Compete · Secure · Instant Payouts') {
+      const w = 1024;
+      const h = 256;
+      const c = document.createElement('canvas');
+      c.width = w;
+      c.height = h;
+      const g = c.getContext('2d');
+      const grad = g.createLinearGradient(0, 0, w, 0);
+      grad.addColorStop(0, '#111827');
+      grad.addColorStop(1, '#0ea5a1');
+      g.fillStyle = grad;
+      g.fillRect(0, 0, w, h);
+      g.font = '700 44px system-ui,Segoe UI,Arial';
+      g.fillStyle = '#ffffff';
+      g.textBaseline = 'middle';
+      const block = `${line1}   •   ${line2}   •   `;
+      let x = 20;
+      for (let i = 0; i < 6; i += 1) {
+        g.fillText(block, x, h * 0.52);
+        x += g.measureText(block).width + 40;
+      }
+      const t = new THREE.CanvasTexture(c);
+      t.anisotropy = Math.min(8, maxAniso);
+      t.wrapS = THREE.RepeatWrapping;
+      t.wrapT = THREE.ClampToEdgeWrapping;
+      t.repeat.set(4, 1);
+      return t;
+    }
+    function makeBillboard(width, height, speed = 0.06, pos = new THREE.Vector3(), rotY = 0) {
+      const tex = makeAdTexture();
+      const mat = new THREE.MeshBasicMaterial({ map: tex });
+      const geo = new THREE.PlaneGeometry(width, height);
+      const mesh = new THREE.Mesh(geo, mat);
+      mesh.position.copy(pos);
+      mesh.rotation.y = rotY;
+      scene.add(mesh);
+      const postMat = new THREE.MeshStandardMaterial({ color: 0x7c818c, roughness: 0.6, metalness: 0.2 });
+      const postH = height + 0.4;
+      const cyl = new THREE.CylinderGeometry(0.04, 0.04, postH, 10);
+      const p1 = new THREE.Mesh(cyl, postMat);
+      const p2 = new THREE.Mesh(cyl, postMat);
+      p1.position.set(pos.x - width / 2 + 0.15 * Math.cos(rotY), (postH / 2) * 0.98, pos.z - (width / 2) * Math.sin(rotY));
+      p2.position.set(pos.x + width / 2 - 0.15 * Math.cos(rotY), (postH / 2) * 0.98, pos.z + (width / 2) * Math.sin(rotY));
+      scene.add(p1);
+      scene.add(p2);
+      adPanels.push({ mesh, tex, speed });
     }
 
-    function physics() {
-      if (!started) return;
-      velocity.y += GRAVITY;
-      ball.position.add(velocity);
+    const apronSize = 2.6;
+    const outerX = halfW + apronSize;
+    const outerZ = halfL + apronSize;
+    const offset = 0.25;
+    const bbH = 1.1;
+    const sideLenZ = courtL + 2 * apronSize;
+    const endLenX = courtW + 2 * apronSize;
+    makeBillboard(sideLenZ, bbH, 0.055, new THREE.Vector3(-outerX - offset, bbH / 2, 0), Math.PI / 2);
+    makeBillboard(endLenX, bbH, 0.07, new THREE.Vector3(0, bbH / 2, -outerZ - offset), 0);
+    makeBillboard(sideLenZ, bbH, 0.055, new THREE.Vector3(outerX + offset, bbH / 2, 0), -Math.PI / 2);
 
-      const inCourt = Math.abs(ball.position.x) <= halfW && Math.abs(ball.position.z) <= halfL;
+    const MAX_SUBSTEP = 1 / 300;
+    const MIN_SUBSTEP = 1 / 900;
+    const MAX_SUBSTEP_ITER = 10;
+    function advanceBallState(dt) {
+      const prevZ = pos.z;
+      const prevY = pos.y;
 
-      if (ball.position.y < ballR) {
-        if (inCourt) {
-          ball.position.y = ballR;
-          velocity.y *= -BOUNCE;
-          velocity.x *= AIR;
-          velocity.z *= AIR;
+      const speed = vel.length();
+      accVec.set(0, physics.gravity, 0);
+      if (speed > 1e-4) {
+        accVec.addScaledVector(vel, -physics.airDrag * speed);
+        spinSurfaceVel.crossVectors(spin, vel);
+        accVec.addScaledVector(spinSurfaceVel, physics.lift);
+      }
+
+      vel.addScaledVector(accVec, dt);
+      pos.addScaledVector(vel, dt);
+      spin.multiplyScalar(Math.exp(-dt * 1.8));
+
+      if (pos.y <= ballR) {
+        pos.y = ballR;
+        if (vel.y < 0) respondToCourtImpact(Math.abs(vel.y));
+        hitTTL = 1.0;
+        hitRing.position.set(pos.x, 0.002, pos.z);
+        const side = pos.z >= 0 ? 'player' : 'cpu';
+        if (state.awaitingServeBounce) {
+          if (side !== opponentOf(state.serveBy)) {
+            registerFault(state.serveBy, 'Fault · Side');
+            return false;
+          }
+          const box = serviceBoxFor(state.serveBy);
+          if (!inBox(pos.x, pos.z, box)) {
+            registerFault(state.serveBy, 'Fault · Box');
+            return false;
+          }
+          state.awaitingServeBounce = false;
+          state.rallyStarted = true;
+          state.bounceSide = side;
+          markTrainingStep('landServe');
         } else {
-          velocity.set(0, 0, 0);
-          started = false;
+          if (state.bounceSide === side) {
+            finishPoint(opponentOf(side), 'Double Bounce');
+            return false;
+          }
+          state.rallyStarted = true;
+          state.bounceSide = side;
+        }
+
+        if (!inSinglesX(pos.x) || Math.abs(pos.z) > halfL + 0.05) {
+          finishPoint(opponentOf(side), 'Out');
+          return false;
         }
       }
 
-      if (ball.position.distanceTo(player.position) < 1.8 && velocity.z > 0) {
-        velocity.z = -Math.abs(velocity.z) - 0.15;
-        velocity.y = 0.2;
+      const crossedNet = (prevZ > 0 && pos.z <= 0) || (prevZ < 0 && pos.z >= 0);
+      if (crossedNet) {
+        const tCross = (0 - prevZ) / ((pos.z - prevZ) || 1e-6);
+        const yCross = THREE.MathUtils.lerp(prevY, pos.y, THREE.MathUtils.clamp(tCross, 0, 1));
+        if (yCross < netH + ballR * 0.45) {
+          if (state.awaitingServeBounce && lastHitter === state.serveBy) {
+            registerFault(state.serveBy, 'Fault · Net');
+          } else {
+            finishPoint(opponentOf(lastHitter), 'Net');
+          }
+          return false;
+        }
       }
 
-      enemyAI();
-      updateRacketHeight();
-      updateCamera();
+      if (!inSinglesX(pos.x) || pos.z > halfL + 0.6 || pos.z < -halfL - 0.6) {
+        if (state.awaitingServeBounce && lastHitter === state.serveBy) {
+          registerFault(state.serveBy, 'Fault · Out');
+        } else {
+          finishPoint(opponentOf(lastHitter), 'Out');
+        }
+        return false;
+      }
+
+      return true;
     }
 
-    let rafId;
-    const animate = () => {
-      rafId = requestAnimationFrame(animate);
-      physics();
+    function simulateBallMotion(dt) {
+      let remaining = dt;
+      let iter = 0;
+      while (remaining > 1e-5 && iter < MAX_SUBSTEP_ITER) {
+        const adaptive = THREE.MathUtils.lerp(MAX_SUBSTEP, MIN_SUBSTEP, THREE.MathUtils.clamp(vel.length() / 28, 0, 1));
+        const subDt = Math.min(remaining, adaptive);
+        if (!advanceBallState(subDt)) {
+          return false;
+        }
+        remaining -= subDt;
+        iter += 1;
+      }
+      return true;
+    }
+
+    const FIXED = 1 / 120;
+    let acc = 0;
+    let last = performance.now();
+    let raf = 0;
+    function step(dt) {
+      const servingPlayer = !state.live && state.serveBy === 'player';
+      const serveHomeZ = halfL - 0.92;
+      const serveHomeX = state.serveSide === 'deuce' ? halfW - 0.45 : -halfW + 0.45;
+      if (state.live && vel.z > 0) {
+        const strikeZ = playerZ - 0.8;
+        const t = Math.max(0.05, (strikeZ - pos.z) / (vel.z || 1e-6));
+        const predX = pos.x + vel.x * t;
+        player.position.x += (THREE.MathUtils.clamp(predX, -halfW, halfW) - player.position.x) * 0.22;
+      } else {
+        const targetX = servingPlayer ? serveHomeX : 0;
+        player.position.x += (targetX - player.position.x) * (servingPlayer ? 0.18 : 0.08);
+      }
+      const homeZ = servingPlayer ? serveHomeZ : playerZ - 0.3;
+      player.position.z += (homeZ - player.position.z) * (servingPlayer ? 0.18 : 0.08);
+      const targetY = THREE.MathUtils.clamp(pos.y, ballR * 0.9, 2.4);
+      player.position.y = THREE.MathUtils.damp(player.position.y, targetY, 6, dt);
+      cpu.position.y = THREE.MathUtils.damp(cpu.position.y, targetY, 6, dt);
+
+      if (playerSwing) {
+        const racketPos = new THREE.Vector3(
+          player.position.x,
+          THREE.MathUtils.clamp(pos.y, ballR * 1.05, 2.0),
+          player.position.z - 0.72
+        );
+        if (tryApplySwing('player', playerSwing, racketPos)) {
+          playerSwing.ttl = 0;
+        }
+        playerSwing.ttl -= dt;
+        if (playerSwing.ttl <= 0) playerSwing = null;
+      }
+      if (cpuSwing) {
+        const racketPos = new THREE.Vector3(
+          cpu.position.x,
+          THREE.MathUtils.clamp(pos.y, ballR * 1.05, 2.0),
+          cpu.position.z + 0.72
+        );
+        if (tryApplySwing('cpu', cpuSwing, racketPos)) {
+          cpuSwing.ttl = 0;
+        }
+        cpuSwing.ttl -= dt;
+        if (cpuSwing.ttl <= 0) cpuSwing = null;
+      }
+
+      if (state.live) {
+        if (!simulateBallMotion(dt)) {
+          return;
+        }
+        player.userData.swing *= Math.exp(-5.0 * dt);
+        cpu.userData.swing *= Math.exp(-5.0 * dt);
+        const ps = player.userData.swing || 0;
+        const plrLR = THREE.MathUtils.clamp(player.userData.swingLR || 0, -1, 1);
+        const cs = cpu.userData.swing || 0;
+        const cpuLR = THREE.MathUtils.clamp(cpu.userData.swingLR || 0, -1, 1);
+        if (player.userData.headPivot) {
+          player.userData.headPivot.rotation.x = -0.45 * ps;
+          player.userData.headPivot.rotation.z = -0.28 * plrLR * ps;
+          player.userData.headPivot.position.z = -0.06 * ps;
+        }
+        if (cpu.userData.headPivot) {
+          cpu.userData.headPivot.rotation.x = -0.55 * cs;
+          cpu.userData.headPivot.rotation.z = -0.30 * cpuLR * cs;
+          cpu.userData.headPivot.position.z = -0.07 * cs;
+        }
+      }
+
+      ball.position.copy(pos);
+      shadow.position.set(pos.x, 0.01, pos.z);
+      updateTrail();
+      if (hitTTL > 0) {
+        hitTTL -= dt;
+        hitRing.material.opacity = Math.max(0, hitTTL) * 0.9;
+      }
+      cpuTryHit(dt);
+      placeCamera();
+    }
+
+    function animate() {
+      const now = performance.now();
+      let dt = (now - last) / 1000;
+      last = now;
+      acc += dt;
+      acc = Math.min(acc, 0.25);
+      while (acc >= FIXED) {
+        step(FIXED);
+        acc -= FIXED;
+      }
+      for (const p of adPanels) {
+        p.tex.offset.x = (p.tex.offset.x + p.speed * dt) % 1;
+      }
       renderer.render(scene, camera);
-    };
+      raf = requestAnimationFrame(animate);
+    }
+
+    loadDeshadowedGrass(grassURL, (tex) => {
+      matGrass.map = tex;
+      matGrass.needsUpdate = true;
+    });
+    prepareServe('player');
     animate();
 
-    const handleResize = () => {
-      const w = Math.max(1, container.clientWidth || window.innerWidth || 360);
-      const h = Math.max(1, container.clientHeight || window.innerHeight || 640);
-      camera.aspect = w / h;
+    function onResize() {
+      W = Math.max(1, container.clientWidth || window.innerWidth || 1);
+      H = Math.max(1, container.clientHeight || window.innerHeight || 1);
+      renderer.setSize(W, H);
+      camera.aspect = W / H;
       camera.updateProjectionMatrix();
-      renderer.setSize(w, h);
-    };
-    window.addEventListener("resize", handleResize);
+    }
+    window.addEventListener('resize', onResize);
+
+    console.assert(Math.abs(new THREE.Vector3(0, 0, 1).length() - 1) < 1e-6, 'vec length test');
+    console.assert(inSinglesX(0.0) && inSinglesX(halfW - 0.06) && !inSinglesX(halfW + 0.1), 'bounds X test');
 
     return () => {
-      cancelAnimationFrame(rafId);
-      window.removeEventListener("resize", handleResize);
-      renderer.domElement.removeEventListener("touchstart", handleTouchStart);
-      renderer.domElement.removeEventListener("touchend", handleTouchEnd);
-      renderer.domElement.removeEventListener("mousedown", handleMouseDown);
-      renderer.domElement.removeEventListener("mouseup", handleMouseUp);
-      renderer.dispose();
-      scene.traverse((obj) => {
-        if (obj.geometry) obj.geometry.dispose?.();
-        if (obj.material) {
-          if (Array.isArray(obj.material)) obj.material.forEach((m) => m.dispose?.());
-          else obj.material.dispose?.();
-        }
-      });
-      if (renderer.domElement.parentNode === container) {
-        container.removeChild(renderer.domElement);
+      try {
+        cancelAnimationFrame(raf);
+      } catch {
       }
+      window.removeEventListener('resize', onResize);
+      el.removeEventListener('pointerdown', onDown);
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      el.removeEventListener('touchstart', onTouchStart);
+      el.removeEventListener('touchmove', onTouchMove);
+      el.removeEventListener('touchend', onTouchEnd);
+      el.removeEventListener('touchcancel', onTouchEnd);
+      if (cpuSrvTO) {
+        try {
+          clearTimeout(cpuSrvTO);
+        } catch {}
+      }
+      if (playerSrvTO) {
+        try {
+          clearTimeout(playerSrvTO);
+        } catch {}
+      }
+      if (matchResetTO) {
+        try {
+          clearTimeout(matchResetTO);
+        } catch {}
+      }
+      try {
+        container.removeChild(renderer.domElement);
+      } catch {}
+      renderer.dispose();
     };
-  }, [trainingMode]);
+  }, [playerLabel, playKickSound, playNetSound, playOutSound, playScoreSound, setHudInfo]);
+
+  const serveAttemptLabel = hudInfo.attempts >= 2 ? '1st serve' : hudInfo.attempts === 1 ? '2nd serve' : 'Serve reset';
+  const scoreboardRows = [
+    {
+      label: playerLabel,
+      sets: hudInfo.playerSets,
+      games: hudInfo.playerGames,
+      points: hudInfo.playerPointLabel,
+      isServer: hudInfo.server === playerLabel
+    },
+    {
+      label: cpuLabel,
+      sets: hudInfo.cpuSets,
+      games: hudInfo.cpuGames,
+      points: hudInfo.cpuPointLabel,
+      isServer: hudInfo.server === cpuLabel
+    }
+  ];
+  const activeTrainingStepId = trainingMode ? nextTrainingStep?.id : null;
 
   return (
     <div
-      ref={mountRef}
-      style={{ position: "relative", width: "100%", height: "100vh", overflow: "hidden", touchAction: "none" }}
-      aria-label="3D Tennis Battle Royal"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'linear-gradient(180deg, #e1f1ff 0%, #f5f9ff 45%, #ffffff 100%)'
+      }}
     >
-      <div
-        style={{
-          position: "absolute",
-          top: 10,
-          left: 10,
-          padding: "10px 12px",
-          background: "rgba(8,11,24,0.7)",
-          borderRadius: 12,
-          color: "#e5e7eb",
-          fontFamily: "'Inter', 'Segoe UI', sans-serif",
-          maxWidth: 260,
-          border: "1px solid rgba(255,255,255,0.06)",
-          boxShadow: "0 8px 20px rgba(0,0,0,0.35)",
-          backdropFilter: "blur(6px)",
-          pointerEvents: "none",
-          zIndex: 12
-        }}
-      >
-        <div style={{ fontSize: 11, letterSpacing: 0.7, textTransform: "uppercase", color: "#9ca3af" }}>
-          Tennis Battle Royal
+      <div ref={containerRef} style={{ flex: 1, minHeight: 560, height: '100%', width: '100%' }} />
+      <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+        <div
+          style={{
+            position: 'absolute',
+            top: 18,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 10,
+            pointerEvents: 'none'
+          }}
+        >
+          <div
+            style={{
+              background: 'rgba(15, 23, 42, 0.9)',
+              color: '#f8fafc',
+              borderRadius: 18,
+              padding: '14px 20px 16px',
+              boxShadow: '0 22px 44px rgba(15, 23, 42, 0.38)',
+              minWidth: 260,
+              fontFamily: 'ui-sans-serif, system-ui'
+            }}
+          >
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '140px repeat(3, minmax(42px, auto))',
+                columnGap: 14,
+                rowGap: 8,
+                alignItems: 'center'
+              }}
+            >
+              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 1.4, opacity: 0.75 }}>Lojtarët</div>
+              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 1.4, opacity: 0.75 }}>Sete</div>
+              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 1.4, opacity: 0.75 }}>Lojë</div>
+              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 1.4, opacity: 0.75 }}>Pikë</div>
+              {scoreboardRows.map((row) => (
+                <React.Fragment key={row.label}>
+                  <div style={{ fontSize: 15, fontWeight: 700, display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span
+                      style={{
+                        display: 'inline-flex',
+                        width: 10,
+                        height: 10,
+                        borderRadius: '50%',
+                        background: row.isServer ? '#facc15' : 'rgba(148, 163, 184, 0.65)',
+                        boxShadow: row.isServer ? '0 0 8px rgba(250, 204, 21, 0.65)' : 'none'
+                      }}
+                    />
+                    {row.label}
+                  </div>
+                  <div style={{ fontSize: 16, fontWeight: 700, justifySelf: 'center' }}>{row.sets}</div>
+                  <div style={{ fontSize: 16, fontWeight: 700, justifySelf: 'center' }}>{row.games}</div>
+                  <div style={{ fontSize: 16, fontWeight: 700, justifySelf: 'center' }}>{row.points}</div>
+                </React.Fragment>
+              ))}
+            </div>
+            {matchTag ? (
+              <div
+                style={{
+                  marginTop: 6,
+                  fontSize: 10,
+                  textTransform: 'uppercase',
+                  letterSpacing: 1.2,
+                  opacity: 0.6,
+                  textAlign: 'center'
+                }}
+              >
+                {matchTag}
+              </div>
+            ) : null}
+          </div>
+          <div
+            style={{
+              background: 'rgba(241, 245, 249, 0.95)',
+              color: '#0f172a',
+              borderRadius: 999,
+              padding: '6px 16px',
+              fontSize: 12,
+              fontWeight: 600,
+              textAlign: 'center',
+              boxShadow: '0 12px 24px rgba(15, 23, 42, 0.18)'
+            }}
+          >
+            {msg} · {serveAttemptLabel} · Court {hudInfo.side === 'deuce' ? 'D' : 'Ad'}
+          </div>
         </div>
-        <div style={{ fontSize: 16, fontWeight: 700 }}>{modeLabel}</div>
-        <div style={{ fontSize: 12, marginTop: 4, color: "#cbd5e1" }}>
-          {stakeLabel ? `Stake: ${stakeLabel}` : "No stake applied"}
+      </div>
+      {trainingMode && (
+        <div style={{ position: 'absolute', bottom: 24, left: 24, pointerEvents: 'auto', maxWidth: 320 }}>
+          <div
+            style={{
+              background: 'rgba(15, 23, 42, 0.9)',
+              color: '#f8fafc',
+              borderRadius: 16,
+              padding: '14px 16px',
+              boxShadow: '0 22px 36px rgba(15, 23, 42, 0.32)',
+              fontFamily: 'ui-sans-serif, system-ui'
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+              <span style={{ fontWeight: 700 }}>Training Tasks</span>
+              <span style={{ fontSize: 11, opacity: 0.75 }}>{trainingCompleted ? 'Përfunduar' : 'Në progres'}</span>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {trainingSteps.map((step) => {
+                const done = trainingStatus[step.id];
+                const isActive = activeTrainingStepId === step.id && !done;
+                return (
+                  <div key={step.id} style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+                    <span
+                      style={{
+                        width: 12,
+                        height: 12,
+                        borderRadius: '50%',
+                        marginTop: 3,
+                        background: done ? '#22c55e' : isActive ? '#facc15' : 'rgba(226, 232, 240, 0.7)',
+                        boxShadow: done
+                          ? '0 0 10px rgba(34, 197, 94, 0.6)'
+                          : isActive
+                            ? '0 0 10px rgba(250, 204, 21, 0.65)'
+                            : 'none'
+                      }}
+                    />
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                      <span style={{ fontSize: 13, fontWeight: 700 }}>
+                        {step.title}
+                        {isActive ? (
+                          <span
+                            style={{
+                              marginLeft: 6,
+                              background: 'rgba(250, 204, 21, 0.16)',
+                              color: '#facc15',
+                              fontSize: 10,
+                              fontWeight: 800,
+                              padding: '2px 6px',
+                              borderRadius: 999
+                            }}
+                          >
+                            Aktive
+                          </span>
+                        ) : null}
+                      </span>
+                      <span style={{ fontSize: 12, opacity: 0.75 }}>{step.detail}</span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
         </div>
-        {playerName ? (
-          <div style={{ fontSize: 12, marginTop: 2, color: "#cbd5e1" }}>Player: {playerName}</div>
-        ) : null}
-        <div style={{ fontSize: 11, marginTop: 6, color: "#94a3b8" }}>{modeSummary}</div>
-        <div style={{ fontSize: 11, marginTop: 4, color: "#a5b4fc" }}>Opponent: Rally AI</div>
+      )}
+      {trainingMode && taskToast && (
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 22,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            pointerEvents: 'none'
+          }}
+        >
+          <div
+            style={{
+              background: 'rgba(15, 23, 42, 0.92)',
+              color: '#f8fafc',
+              borderRadius: 14,
+              padding: '12px 16px',
+              boxShadow: '0 18px 32px rgba(15, 23, 42, 0.35)',
+              minWidth: 240,
+              textAlign: 'center',
+              fontFamily: 'ui-sans-serif, system-ui'
+            }}
+          >
+            <div style={{ fontSize: 13, fontWeight: 800, letterSpacing: 0.2 }}>{taskToast.title}</div>
+            <div style={{ fontSize: 12, opacity: 0.82, marginTop: 4 }}>{taskToast.detail}</div>
+          </div>
+        </div>
+      )}
+      <div style={{ position: 'absolute', bottom: 24, right: 24, pointerEvents: 'auto' }}>
+        <button
+          type="button"
+          onClick={() => setScoreboardOpen(true)}
+          style={{
+            background: 'linear-gradient(135deg, #1d4ed8 0%, #1e3a8a 100%)',
+            color: '#f8fafc',
+            border: 'none',
+            borderRadius: 999,
+            padding: '12px 22px',
+            fontFamily: 'ui-sans-serif, system-ui',
+            fontWeight: 600,
+            fontSize: 13,
+            boxShadow: '0 14px 28px rgba(30, 64, 175, 0.35)',
+            cursor: 'pointer'
+          }}
+        >
+          Match Info
+        </button>
       </div>
-      <div
-        style={{
-          position: "absolute",
-          top: 8,
-          left: "50%",
-          transform: "translateX(-50%)",
-          color: "#fff",
-          fontFamily: "Arial, sans-serif",
-          fontSize: 14,
-          zIndex: 10,
-          textAlign: "center",
-          pointerEvents: "none"
-        }}
-      >
-        Swipe up to hit • Camera tracks ball • Smart AI
-        {playerName ? ` • Player: ${playerName}` : ""}
-        {stakeLabel ? ` • Stake: ${stakeLabel}` : ""}
-        {trainingMode ? " • Training" : ""}
-      </div>
+      {scoreboardOpen && (
+        <div
+          onClick={() => setScoreboardOpen(false)}
+          role="presentation"
+          style={{
+            position: 'absolute',
+            inset: 0,
+            background: 'rgba(15, 23, 42, 0.55)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 24,
+            pointerEvents: 'auto'
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            role="presentation"
+            style={{
+              background: 'rgba(255,255,255,0.98)',
+              color: '#0f172a',
+              borderRadius: 20,
+              padding: '22px 28px',
+              maxWidth: 320,
+              width: '100%',
+              boxShadow: '0 28px 44px rgba(15, 23, 42, 0.22)',
+              fontFamily: 'ui-sans-serif, system-ui'
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+              <h3 style={{ fontSize: 16, fontWeight: 700, margin: 0 }}>Match Center</h3>
+              <button
+                type="button"
+                onClick={() => setScoreboardOpen(false)}
+                style={{
+                  background: 'transparent',
+                  border: 'none',
+                  color: '#1f2937',
+                  fontSize: 18,
+                  fontWeight: 700,
+                  cursor: 'pointer',
+                  lineHeight: 1
+                }}
+                aria-label="Close scoreboard"
+              >
+                ×
+              </button>
+            </div>
+            <div style={{ fontSize: 12, fontWeight: 700, color: '#1d4ed8', marginBottom: matchTag ? 4 : 10 }}>{msg}</div>
+            {matchTag ? (
+              <div
+                style={{
+                  fontSize: 11,
+                  textTransform: 'uppercase',
+                  letterSpacing: 1.2,
+                  opacity: 0.6,
+                  marginBottom: 10
+                }}
+              >
+                {matchTag}
+              </div>
+            ) : null}
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 10, fontSize: 13, fontWeight: 600 }}>
+              <span>{playerLabel}</span>
+              <span>{cpuLabel}</span>
+            </div>
+            <div style={{ fontSize: 13, marginBottom: 4 }}>Sets · {hudInfo.sets}</div>
+            <div style={{ fontSize: 13, marginBottom: 4 }}>Games · {hudInfo.games}</div>
+            <div style={{ fontSize: 13, marginBottom: 8 }}>Points · {hudInfo.points}</div>
+            <div style={{ fontSize: 12, opacity: 0.85, marginBottom: 2 }}>
+              Serve · {hudInfo.server} · Court {hudInfo.side === 'deuce' ? 'D' : 'Ad'}
+            </div>
+            <div style={{ fontSize: 12, opacity: 0.78, marginBottom: 12 }}>{serveAttemptLabel}</div>
+            {stakeLabel ? (
+              <div
+                style={{
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: '#0f172a',
+                  background: 'rgba(30, 64, 175, 0.08)',
+                  borderRadius: 12,
+                  padding: '8px 12px'
+                }}
+              >
+                Stake · {stakeLabel}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Restore the full stadium environment for Tennis Battle Royal, including grandstands, suites, roof, and entrance fixtures.
- Reinstate detailed court surfaces, track, grass, and line materials to match the previous tennis visuals.
- Bring back scoreboard handling and game sound hooks for net, kick, score, and out events.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692339efb774832096582a9e46b479d2)