### PR TITLE
Fix Chess Battle Royale UI state ordering

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1458,6 +1458,16 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [showHighlights, setShowHighlights] = useState(true);
   const [seatAnchors, setSeatAnchors] = useState([]);
+  const [ui, setUi] = useState({
+    turnWhite: true,
+    status: 'White to move',
+    promoting: null,
+    winner: null
+  });
+  const uiRef = useRef(ui);
+  useEffect(() => {
+    uiRef.current = ui;
+  }, [ui]);
 
   const seatAnchorMap = useMemo(() => {
     const map = new Map();
@@ -1497,17 +1507,6 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
       }
     ];
   }, [aiFlag, appearance, avatar, playerFlag, resolvedInitialFlag, ui.turnWhite, username]);
-
-  const [ui, setUi] = useState({
-    turnWhite: true,
-    status: 'White to move',
-    promoting: null,
-    winner: null
-  });
-  const uiRef = useRef(ui);
-  useEffect(() => {
-    uiRef.current = ui;
-  }, [ui]);
 
   useEffect(() => {
     if (aiFlag && FLAG_EMOJIS.includes(aiFlag)) {


### PR DESCRIPTION
## Summary
- initialize Chess Battle Royale UI state before player memoization to avoid accessing it before definition
- keep UI ref updates aligned with the moved state initialization

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692365aed84c83209738dd92ccab585b)