### PR TITLE
Add avatar and AI flag selection to Air Hockey lobby

### DIFF
--- a/webapp/src/pages/Games/AirHockey.jsx
+++ b/webapp/src/pages/Games/AirHockey.jsx
@@ -10,11 +10,17 @@ export default function AirHockey() {
   const params = new URLSearchParams(search);
   const target = Number(params.get('target')) || 3;
   const playType = params.get('type') || 'regular';
+  const playerFlagParam = params.get('flag');
+  const aiFlagParam = params.get('aiFlag');
+  const aiFlag = aiFlagParam && FLAG_EMOJIS.includes(aiFlagParam) ? aiFlagParam : '';
   const player = {
     name: params.get('name') || 'You',
-    avatar: params.get('avatar') || '/assets/icons/profile.svg'
+    avatar: params.get('avatar') ||
+      (playerFlagParam && FLAG_EMOJIS.includes(playerFlagParam) ? playerFlagParam : '') ||
+      '/assets/icons/profile.svg'
   };
-  const flag = FLAG_EMOJIS[Math.floor(Math.random() * FLAG_EMOJIS.length)];
-  const ai = { name: avatarToName(flag) || 'AI', avatar: flag };
+  const randomAiFlag = FLAG_EMOJIS[Math.floor(Math.random() * FLAG_EMOJIS.length)];
+  const chosenAiFlag = aiFlag || randomAiFlag;
+  const ai = { name: avatarToName(chosenAiFlag) || 'AI', avatar: chosenAiFlag };
   return <AirHockey3D player={player} ai={ai} target={target} playType={playType} />;
 }

--- a/webapp/src/pages/Games/AirHockeyLobby.jsx
+++ b/webapp/src/pages/Games/AirHockeyLobby.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import RoomSelector from '../../components/RoomSelector.jsx';
+import FlagPickerModal from '../../components/FlagPickerModal.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
   ensureAccountId,
@@ -10,6 +11,10 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+
+const AI_FLAG_STORAGE_KEY = 'airHockeyAiFlag';
+const PLAYER_FLAG_STORAGE_KEY = 'airHockeyPlayerFlag';
 
 export default function AirHockeyLobby() {
   const navigate = useNavigate();
@@ -22,11 +27,34 @@ export default function AirHockeyLobby() {
   const [playType, setPlayType] = useState('regular');
   const [players, setPlayers] = useState(8);
   const [avatar, setAvatar] = useState('');
+  const [showFlagPicker, setShowFlagPicker] = useState(false);
+  const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
+  const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
+  const [aiFlagIndex, setAiFlagIndex] = useState(null);
+
+  const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
+  const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
 
   useEffect(() => {
     try {
       const saved = loadAvatar();
       setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(PLAYER_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setPlayerFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(AI_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setAiFlagIndex(idx);
     } catch {}
   }, []);
 
@@ -66,6 +94,8 @@ export default function AirHockeyLobby() {
       if (stake.amount) params.set('amount', stake.amount);
     }
     if (avatar) params.set('avatar', avatar);
+    if (selectedFlag) params.set('flag', selectedFlag);
+    if (selectedAiFlag) params.set('aiFlag', selectedAiFlag);
     if (tgId) params.set('tgId', tgId);
     if (accountId) params.set('accountId', accountId);
     const name = getTelegramFirstName();
@@ -166,12 +196,86 @@ export default function AirHockeyLobby() {
           <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
         </div>
       )}
+
+      <div className="space-y-2">
+        <h3 className="font-semibold">Your Flag & Avatar</h3>
+        <div className="rounded-xl border border-border bg-surface/60 p-3 space-y-2 shadow">
+          <button
+            type="button"
+            onClick={() => setShowFlagPicker(true)}
+            className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
+          >
+            <div className="text-[11px] uppercase tracking-wide text-subtext">Flag</div>
+            <div className="flex items-center gap-2 text-base font-semibold">
+              <span className="text-lg">{selectedFlag || '🌐'}</span>
+              <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+            </div>
+          </button>
+          {avatar && (
+            <div className="flex items-center gap-3">
+              <img
+                src={avatar}
+                alt="Your avatar"
+                className="h-12 w-12 rounded-full border border-border object-cover"
+              />
+              <div className="text-sm text-subtext">Your avatar will appear in the match intro.</div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="font-semibold">AI Avatar Flags</h3>
+        <p className="text-sm text-subtext">
+          Pick the country flag for the AI rival so it matches the Chess Battle Royal lobby experience.
+        </p>
+        <button
+          type="button"
+          onClick={() => setShowAiFlagPicker(true)}
+          className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
+        >
+          <div className="text-[11px] uppercase tracking-wide text-subtext">AI Flag</div>
+          <div className="flex items-center gap-2 text-base font-semibold">
+            <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+            <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
+          </div>
+        </button>
+      </div>
+
       <button
         onClick={startGame}
         className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
       >
         START
       </button>
+
+      <FlagPickerModal
+        open={showFlagPicker}
+        count={1}
+        selected={playerFlagIndex != null ? [playerFlagIndex] : []}
+        onSave={(indices) => {
+          const idx = indices?.[0] ?? null;
+          setPlayerFlagIndex(idx);
+          try {
+            if (idx != null) window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+          } catch {}
+        }}
+        onClose={() => setShowFlagPicker(false)}
+      />
+
+      <FlagPickerModal
+        open={showAiFlagPicker}
+        count={1}
+        selected={aiFlagIndex != null ? [aiFlagIndex] : []}
+        onSave={(indices) => {
+          const idx = indices?.[0] ?? null;
+          setAiFlagIndex(idx);
+          try {
+            if (idx != null) window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+          } catch {}
+        }}
+        onClose={() => setShowAiFlagPicker(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add flag picker and avatar preview to the Air Hockey lobby to mirror the Chess Battle Royal experience
- persist and pass selected player and AI flags into the game launch parameters
- allow the Air Hockey game to honor chosen AI flags and use player flag as an avatar fallback

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692366254b248320986c906c938ec9fb)