### PR TITLE
Add avatar and AI flag pickers to Goal Rush lobby

### DIFF
--- a/webapp/src/pages/Games/GoalRushLobby.jsx
+++ b/webapp/src/pages/Games/GoalRushLobby.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import RoomSelector from '../../components/RoomSelector.jsx';
+import FlagPickerModal from '../../components/FlagPickerModal.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
   ensureAccountId,
@@ -10,6 +11,10 @@ import {
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+
+const AI_FLAG_STORAGE_KEY = 'goalRushAiFlag';
+const PLAYER_FLAG_STORAGE_KEY = 'goalRushPlayerFlag';
 
 export default function GoalRushLobby() {
   const navigate = useNavigate();
@@ -22,11 +27,34 @@ export default function GoalRushLobby() {
   const [avatar, setAvatar] = useState('');
   const [playType, setPlayType] = useState('regular');
   const [players, setPlayers] = useState(8);
+  const [showFlagPicker, setShowFlagPicker] = useState(false);
+  const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
+  const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
+  const [aiFlagIndex, setAiFlagIndex] = useState(null);
+
+  const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
+  const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
 
   useEffect(() => {
     try {
       const saved = loadAvatar();
       setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(PLAYER_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setPlayerFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(AI_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setAiFlagIndex(idx);
     } catch {}
   }, []);
 
@@ -55,7 +83,7 @@ export default function GoalRushLobby() {
       } catch {}
     }
 
-    const params = new URLSearchParams();
+    const params = new URLSearchParams(search);
     params.set('target', goal);
     params.set('type', playType);
     if (playType !== 'training') params.set('mode', mode);
@@ -66,6 +94,8 @@ export default function GoalRushLobby() {
       if (stake.amount) params.set('amount', stake.amount);
     }
     if (avatar) params.set('avatar', avatar);
+    if (selectedFlag) params.set('flag', selectedFlag);
+    if (selectedAiFlag) params.set('aiFlag', selectedAiFlag);
     if (tgId) params.set('tgId', tgId);
     if (accountId) params.set('accountId', accountId);
     const name = getTelegramFirstName();
@@ -170,12 +200,85 @@ export default function GoalRushLobby() {
           <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
         </div>
       )}
+
+      <div className="space-y-2">
+        <h3 className="font-semibold">Your Flag & Avatar</h3>
+        <div className="rounded-xl border border-border bg-surface/60 p-3 space-y-2 shadow">
+          <button
+            type="button"
+            onClick={() => setShowFlagPicker(true)}
+            className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
+          >
+            <div className="text-[11px] uppercase tracking-wide text-subtext">Flag</div>
+            <div className="flex items-center gap-2 text-base font-semibold">
+              <span className="text-lg">{selectedFlag || '🌐'}</span>
+              <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+            </div>
+          </button>
+          {avatar && (
+            <div className="flex items-center gap-3">
+              <img
+                src={avatar}
+                alt="Your avatar"
+                className="h-12 w-12 rounded-full border border-border object-cover"
+              />
+              <div className="text-sm text-subtext">Your avatar will appear in the match intro.</div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="font-semibold">AI Avatar Flags</h3>
+        <p className="text-sm text-subtext">
+          Pick the country flag for the AI rival so it matches the Chess Battle Royal lobby experience.
+        </p>
+        <button
+          type="button"
+          onClick={() => setShowAiFlagPicker(true)}
+          className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
+        >
+          <div className="text-[11px] uppercase tracking-wide text-subtext">AI Flag</div>
+          <div className="flex items-center gap-2 text-base font-semibold">
+            <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+            <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
+          </div>
+        </button>
+      </div>
       <button
         onClick={startGame}
         className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
       >
         START
       </button>
+
+      <FlagPickerModal
+        open={showFlagPicker}
+        count={1}
+        selected={playerFlagIndex != null ? [playerFlagIndex] : []}
+        onSave={(indices) => {
+          const idx = indices?.[0] ?? null;
+          setPlayerFlagIndex(idx);
+          try {
+            if (idx != null) window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+          } catch {}
+        }}
+        onClose={() => setShowFlagPicker(false)}
+      />
+
+      <FlagPickerModal
+        open={showAiFlagPicker}
+        count={1}
+        selected={aiFlagIndex != null ? [aiFlagIndex] : []}
+        onSave={(indices) => {
+          const idx = indices?.[0] ?? null;
+          setAiFlagIndex(idx);
+          try {
+            if (idx != null) window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+          } catch {}
+        }}
+        onClose={() => setShowAiFlagPicker(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add player flag picker and avatar preview to the Goal Rush lobby to mirror the Chess Battle Royal experience
- allow selecting AI opponent flags, persisting choices, and sending them through game start parameters

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692369576b988320a94782305643bf8d)