### PR TITLE
Fix Chess Battle Royal rendering

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -26,19 +26,18 @@
     <title>TonPlaygram</title>
   </head>
   <body>
+    <div id="root"></div>
     <script>
       // Clean up any stray DOM before mounting React
-      document.addEventListener('DOMContentLoaded', () => {
+      (function cleanupRoot() {
         const root = document.getElementById('root');
-        if (root) {
-          while (root.previousSibling) {
-            root.previousSibling.remove();
-          }
-          root.innerHTML = '';
+        if (!root) return;
+        while (root.previousSibling) {
+          root.previousSibling.remove();
         }
-      });
+        root.innerHTML = '';
+      })();
     </script>
-    <div id="root"></div>
     <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -14,19 +14,4 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   </React.StrictMode>
 );
 
-// Register a service worker to always fetch the latest files
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker
-      .register('/service-worker.js')
-      .then(() => {
-        navigator.serviceWorker.addEventListener('controllerchange', () => {
-          // When a new service worker takes control, reload to fetch fresh assets
-          window.location.reload();
-        });
-      })
-      .catch((error) => {
-        console.error('Service worker registration failed:', error);
-      });
-  });
-}
+// Service workers are disabled to avoid unexpected reloads that could interrupt gameplay

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1984,6 +1984,12 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
     paletteRef.current = palette;
     const boardTheme = palette.board;
     const pieceStyleOption = palette.pieces;
+    const initialPlayerFlag =
+      playerFlag ||
+      resolvedInitialFlag ||
+      (FLAG_EMOJIS.length > 0 ? FLAG_EMOJIS[0] : FALLBACK_FLAG);
+    const initialAiFlagValue =
+      aiFlag || initialAiFlag || getAIOpponentFlag(initialPlayerFlag || FALLBACK_FLAG);
     const woodOption = TABLE_WOOD_OPTIONS[normalizedAppearance.tableWood] ?? TABLE_WOOD_OPTIONS[0];
     const clothOption = TABLE_CLOTH_OPTIONS[normalizedAppearance.tableCloth] ?? TABLE_CLOTH_OPTIONS[0];
     const baseOption = TABLE_BASE_OPTIONS[normalizedAppearance.tableBase] ?? TABLE_BASE_OPTIONS[0];
@@ -2524,39 +2530,39 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
         if (p) placePieceMesh(r, c, p);
       }
 
-    arenaRef.current = {
-      renderer,
-      scene,
-      camera,
-      controls,
-      arenaGroup: arena,
-      tableInfo,
-      tableShapeId: tableInfo.shapeId,
-      boardGroup,
-      boardLookTarget,
-      chairMaterials,
-      chairs,
-      seatAnchors: chairs.map((chair) => chair.anchor),
-      sandTimer,
-      spotLight: spot,
-      spotTarget,
-      studioCameras: [studioCamA, studioCamB],
-      boardMaterials: arena.boardMaterials,
-      pieceMaterials,
-      allPieceMeshes,
-      capturedByWhite,
-      capturedByBlack,
-      palette,
-      playerFlag: initialPlayerFlag,
-      aiFlag: initialAiFlag
-    };
-    arenaRef.current.sandTimer = sandTimer;
-    arenaRef.current.palette = palette;
+      arenaRef.current = {
+        renderer,
+        scene,
+        camera,
+        controls,
+        arenaGroup: arena,
+        tableInfo,
+        tableShapeId: tableInfo.shapeId,
+        boardGroup,
+        boardLookTarget,
+        chairMaterials,
+        chairs,
+        seatAnchors: chairs.map((chair) => chair.anchor),
+        sandTimer,
+        spotLight: spot,
+        spotTarget,
+        studioCameras: [studioCamA, studioCamB],
+        boardMaterials: arena.boardMaterials,
+        pieceMaterials,
+        allPieceMeshes,
+        capturedByWhite,
+        capturedByBlack,
+        palette,
+        playerFlag: initialPlayerFlag,
+        aiFlag: initialAiFlagValue
+      };
+      arenaRef.current.sandTimer = sandTimer;
+      arenaRef.current.palette = palette;
 
-    arena.sandTimer = sandTimer;
-    arena.palette = palette;
-    arena.playerFlag = initialPlayerFlag;
-    arena.aiFlag = initialAiFlag;
+      arena.sandTimer = sandTimer;
+      arena.palette = palette;
+      arena.playerFlag = initialPlayerFlag;
+      arena.aiFlag = initialAiFlagValue;
 
     // Raycaster for picking
     ray = new THREE.Raycaster();


### PR DESCRIPTION
## Summary
- clean the React root immediately instead of wiping it on DOMContentLoaded
- disable the service worker registration that was forcing unexpected reloads
- initialize Chess Battle Royal flags before building the 3D scene to prevent runtime errors

## Testing
- npm --prefix webapp run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923714731e48328b4d786b94ff345ef)