### PR TITLE
Adjust Pool Royale chrome pockets and ball-in-hand handling

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -396,26 +396,26 @@ const CHROME_CORNER_EDGE_TRIM_SCALE = 0; // do not trim edges beyond the snooker
 const CHROME_SIDE_POCKET_RADIUS_SCALE =
   CORNER_POCKET_INWARD_SCALE *
   CHROME_CORNER_POCKET_RADIUS_SCALE *
-  0.992; // tighten the middle chrome arch so the rounded cut tracks the smaller, fuller jaws without widening the reveal
+  1.016; // mirror snooker side arches so the middle chrome cut matches its rounded radius and position
 const WOOD_RAIL_CORNER_RADIUS_SCALE = 1; // match snooker rail rounding so the chrome sits flush
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0; // disable secondary throat so the side chrome uses a single arch
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85; // reuse snooker notch height profile
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1;
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1; // keep the notch depth identical to the pocket cylinder so the chrome kisses the jaw edge
 const CHROME_SIDE_FIELD_PULL_SCALE = 0;
-const CHROME_PLATE_THICKNESS_SCALE = 0.052; // thicken fascia depth so the chrome plates read as chunky as the rail diamonds
-const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1; // keep side fascias the same depth as the diamonds
+const CHROME_PLATE_THICKNESS_SCALE = 0.034; // match snooker fascia depth for consistent chrome heft at the pockets
+const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.08; // give the middle fascias a subtle lift for extra depth like the snooker table
 const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually above the wood rails without z-fighting
 const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.58; // push the side fascia farther along the arch so it blankets the larger chrome reveal
-const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.54; // trim the field-side reach so the fascia ends flush with the wooden rail while still covering the relieved arch
+const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.52; // align fascia reach with snooker so the arch covers the relieved cut without overhang
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
-const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.58; // widen the middle fascia along the wooden rails so both edges stretch toward the end pockets
+const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.46; // mirror snooker fascia width so both edges flow into the rails cleanly
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.065; // pull the side fascias farther toward the wooden rail so the field edge stops at the rail line and the exterior face grows
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1; // match the middle chrome arch exactly to the jaw profile so both radii mirror
-const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.018; // pull the middle chrome cut inward so the added fascia extends on the rail side instead of spilling onto the cloth
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = -0.004; // align the middle chrome cut with snooker positioning so the reveal stays centered on the jaws
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
@@ -8403,20 +8403,13 @@ function PoolRoyaleGame({
   }, [isTraining, trainingModeState, trainingRulesOn, setFrameState]);
   const cueBallPlacedFromHandRef = useRef(false);
   useEffect(() => {
-    setInHandPlacementMode(false);
-    if (hud.inHand) {
+    const playerTurn = (hud.turn ?? 0) === 0;
+    const placing = Boolean(hud.inHand && playerTurn);
+    setInHandPlacementMode(placing);
+    if (placing) {
       cueBallPlacedFromHandRef.current = false;
     }
-  }, [hud.inHand]);
-  const toggleInHandPlacement = useCallback(() => {
-    setInHandPlacementMode((prev) => {
-      const next = !prev;
-      if (next) {
-        cueBallPlacedFromHandRef.current = false;
-      }
-      return next;
-    });
-  }, []);
+  }, [hud.inHand, hud.turn]);
   const [shotActive, setShotActive] = useState(false);
   const shootingRef = useRef(shotActive);
   useEffect(() => {
@@ -12650,8 +12643,12 @@ function PoolRoyaleGame({
       const tmpAim = new THREE.Vector2();
 
       // In-hand placement
-      const isAmericanVariant = () =>
-        (activeVariantRef.current?.id ?? variantKey) === 'american';
+      const variantId = () => activeVariantRef.current?.id ?? variantKey;
+
+      const allowFullTableInHand = () => {
+        const id = variantId();
+        return id === 'american' || id === '9ball';
+      };
 
       const isSpotFree = (point, clearanceMultiplier = 2.05) => {
         if (!point) return false;
@@ -12669,7 +12666,7 @@ function PoolRoyaleGame({
         const clamped = point.clone();
         const limitX = PLAY_W / 2 - BALL_R;
         clamped.x = THREE.MathUtils.clamp(clamped.x, -limitX, limitX);
-        if (isAmericanVariant()) {
+        if (allowFullTableInHand()) {
           const limitZ = PLAY_H / 2 - BALL_R;
           clamped.y = THREE.MathUtils.clamp(clamped.y, -limitZ, limitZ);
         } else {
@@ -12687,7 +12684,9 @@ function PoolRoyaleGame({
         return clamped;
       };
       const defaultInHandPosition = () =>
-        clampInHandPosition(new THREE.Vector2(0, isAmericanVariant() ? 0 : baulkZ));
+        clampInHandPosition(
+          new THREE.Vector2(0, allowFullTableInHand() ? 0 : baulkZ)
+        );
       const inHandDrag = {
         active: false,
         pointerId: null,
@@ -12730,7 +12729,7 @@ function PoolRoyaleGame({
         const baseCandidates = [];
         baseCandidates.push(new THREE.Vector2(0, baulkZ));
         baseCandidates.push(new THREE.Vector2(0, forwardBias));
-        if (isAmericanVariant()) {
+        if (allowFullTableInHand()) {
           baseCandidates.push(new THREE.Vector2(0, 0));
           baseCandidates.push(new THREE.Vector2(0, PLAY_H / 4));
           baseCandidates.push(new THREE.Vector2(0, -PLAY_H / 4));
@@ -12766,9 +12765,10 @@ function PoolRoyaleGame({
         }
         const gridCandidates = [];
         const gridCols = Math.max(8, Math.round((limitX * 2) / (BALL_R * 1.25)));
-        const gridRows = isAmericanVariant() ? 8 : 5;
-        const gridStart = isAmericanVariant() ? -PLAY_H / 2 + BALL_R : forwardBias;
-        const gridEnd = isAmericanVariant() ? PLAY_H / 2 - BALL_R : baulkZ;
+        const fullTable = allowFullTableInHand();
+        const gridRows = fullTable ? 8 : 5;
+        const gridStart = fullTable ? -PLAY_H / 2 + BALL_R : forwardBias;
+        const gridEnd = fullTable ? PLAY_H / 2 - BALL_R : baulkZ;
         for (let row = 0; row <= gridRows; row++) {
           const z = THREE.MathUtils.lerp(gridStart, gridEnd, row / gridRows);
           for (let col = 0; col <= gridCols; col++) {
@@ -12871,7 +12871,7 @@ function PoolRoyaleGame({
             return best;
           }
         }
-        const fallback = isAmericanVariant()
+        const fallback = allowFullTableInHand()
           ? defaultInHandPosition()
           : clampInHandPosition(new THREE.Vector2(0, forwardBias));
         if (fallback && isSpotFree(fallback, 2.0)) {
@@ -12966,7 +12966,7 @@ function PoolRoyaleGame({
           updateCuePlacement(startPos);
           cueBallPlacedFromHandRef.current = true;
         }
-        if (isAmericanVariant()) {
+        if (allowFullTableInHand()) {
           const focusStore = ensureOrbitFocus();
           focusStore.target.set(0, BALL_CENTER_Y, 0);
           focusStore.ballId = null;
@@ -13035,10 +13035,10 @@ function PoolRoyaleGame({
       // Fire (slider e thërret në release)
       const fire = () => {
         const currentHud = hudRef.current;
-        const americanHandPlacement =
-          isAmericanVariant() && Boolean(frameSnapshot?.meta?.state?.ballInHand);
+        const fullTableHandPlacement =
+          allowFullTableInHand() && Boolean(frameSnapshot?.meta?.state?.ballInHand);
         const inHandPlacementActive = Boolean(
-          currentHud?.inHand && !americanHandPlacement
+          currentHud?.inHand && !fullTableHandPlacement
         );
         if (
           !cue?.active ||
@@ -13047,7 +13047,7 @@ function PoolRoyaleGame({
           currentHud?.over
         )
           return;
-        if (currentHud?.inHand && (americanHandPlacement || inHandPlacementActive)) {
+        if (currentHud?.inHand && (fullTableHandPlacement || inHandPlacementActive)) {
           hudRef.current = { ...currentHud, inHand: false };
           setHud((prev) => ({ ...prev, inHand: false }));
         }
@@ -15910,18 +15910,16 @@ function PoolRoyaleGame({
         </div>
       )}
       {hud?.inHand && (
-        <div className="absolute left-1/2 top-4 z-40 flex -translate-x-1/2 flex-col items-center gap-2 px-3 text-center text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.55)]">
-          <button
-            type="button"
-            onClick={toggleInHandPlacement}
-            className={`min-w-[9rem] rounded-full px-4 py-2 text-sm font-semibold shadow-lg transition focus:outline-none focus:ring-2 focus:ring-emerald-300 focus:ring-offset-2 focus:ring-offset-black ${
-              inHandPlacementMode
-                ? 'bg-emerald-400 text-black ring-1 ring-emerald-200/80'
-                : 'bg-white/90 text-gray-900 ring-1 ring-white/60 hover:bg-white'
-            }`}
-          >
-            {inHandPlacementMode ? 'Ball in hand (placing)' : 'Ball in hand'}
-          </button>
+        <div className="pointer-events-none absolute left-1/2 top-4 z-40 flex -translate-x-1/2 flex-col items-center gap-2 px-3 text-center text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.55)]">
+          <div className="flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 text-sm font-semibold text-gray-900 shadow-lg ring-1 ring-white/60">
+            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">BIH</span>
+            <span className="text-left leading-tight">
+              Drag the cue ball {['american', '9ball'].includes(variantKey) ? 'anywhere on the table' : 'inside the baulk semicircle'}
+            </span>
+          </div>
+          <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/85">
+            Tap and hold, then slide to place
+          </span>
         </div>
       )}
       {/* Power Slider */}


### PR DESCRIPTION
## Summary
- match middle-pocket chrome fascia sizing, cut radius, and depth to the snooker configuration
- enforce official ball-in-hand bounds for American/9-ball vs UK variants and auto-enable placement without a toggle button
- present touch-friendly ball-in-hand guidance overlay for drag-to-place control

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923f53ba1308328a04bafcb8d021620)