### PR TITLE
Translate site content to English

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -478,7 +478,7 @@ const CHAIR_CLOTH_TEXTURE_SIZE = 512;
 const CHAIR_CLOTH_REPEAT = 4;
 const DEFAULT_CHAIR_THEME = Object.freeze({
   id: "ruby",
-  label: "Rubi",
+  label: "Ruby",
   seatColor: "#8b0000",
   legColor: "#1f1f1f",
   highlight: "#d46a6a"
@@ -486,11 +486,11 @@ const DEFAULT_CHAIR_THEME = Object.freeze({
 
 const CHAIR_THEME_OPTIONS = Object.freeze([
   DEFAULT_CHAIR_THEME,
-  { id: "slate", label: "Guri", seatColor: "#374151", legColor: "#0f172a", highlight: "#9ca3af" },
-  { id: "teal", label: "Bruz", seatColor: "#0f766e", legColor: "#082f2a", highlight: "#34d399" },
-  { id: "amber", label: "Qelibari", seatColor: "#b45309", legColor: "#2f2410", highlight: "#fbbf24" },
-  { id: "violet", label: "Vjollcë", seatColor: "#7c3aed", legColor: "#2b1059", highlight: "#d8b4fe" },
-  { id: "frost", label: "Akull", seatColor: "#1f2937", legColor: "#0f172a", highlight: "#94a3b8" }
+  { id: "slate", label: "Slate", seatColor: "#374151", legColor: "#0f172a", highlight: "#9ca3af" },
+  { id: "teal", label: "Teal", seatColor: "#0f766e", legColor: "#082f2a", highlight: "#34d399" },
+  { id: "amber", label: "Amber", seatColor: "#b45309", legColor: "#2f2410", highlight: "#fbbf24" },
+  { id: "violet", label: "Violet", seatColor: "#7c3aed", legColor: "#2b1059", highlight: "#d8b4fe" },
+  { id: "frost", label: "Frost", seatColor: "#1f2937", legColor: "#0f172a", highlight: "#94a3b8" }
 ]);
 
 const clamp01f = (value) => Math.min(1, Math.max(0, value));
@@ -514,13 +514,13 @@ const shiftLightness = (light, delta) => clamp01f(light + delta);
 const shiftSaturation = (sat, delta) => clamp01f(sat + delta);
 
 const WOOD_FINISH_PRESETS = Object.freeze([
-  Object.freeze({ id: 'birch', label: 'Vidhi', hue: 38, sat: 0.25, light: 0.84, contrast: 0.42 }),
-  Object.freeze({ id: 'maple', label: 'Panjo', hue: 35, sat: 0.22, light: 0.78, contrast: 0.44 }),
-  Object.freeze({ id: 'oak', label: 'Lis', hue: 32, sat: 0.34, light: 0.7, contrast: 0.52 }),
-  Object.freeze({ id: 'cherry', label: 'Qershi', hue: 14, sat: 0.42, light: 0.6, contrast: 0.58 }),
-  Object.freeze({ id: 'teak', label: 'Tik', hue: 28, sat: 0.4, light: 0.52, contrast: 0.6 }),
-  Object.freeze({ id: 'walnut', label: 'Arre', hue: 22, sat: 0.4, light: 0.44, contrast: 0.64 }),
-  Object.freeze({ id: 'smokedOak', label: 'Lis i Tymosur', hue: 28, sat: 0.35, light: 0.28, contrast: 0.75 }),
+  Object.freeze({ id: 'birch', label: 'Birch', hue: 38, sat: 0.25, light: 0.84, contrast: 0.42 }),
+  Object.freeze({ id: 'maple', label: 'Maple', hue: 35, sat: 0.22, light: 0.78, contrast: 0.44 }),
+  Object.freeze({ id: 'oak', label: 'Oak', hue: 32, sat: 0.34, light: 0.7, contrast: 0.52 }),
+  Object.freeze({ id: 'cherry', label: 'Cherry', hue: 14, sat: 0.42, light: 0.6, contrast: 0.58 }),
+  Object.freeze({ id: 'teak', label: 'Teak', hue: 28, sat: 0.4, light: 0.52, contrast: 0.6 }),
+  Object.freeze({ id: 'walnut', label: 'Walnut', hue: 22, sat: 0.4, light: 0.44, contrast: 0.64 }),
+  Object.freeze({ id: 'smokedOak', label: 'Smoked Oak', hue: 28, sat: 0.35, light: 0.28, contrast: 0.75 }),
   Object.freeze({ id: 'wenge', label: 'Wenge', hue: 24, sat: 0.38, light: 0.22, contrast: 0.8 }),
   Object.freeze({ id: 'ebony', label: 'Eben', hue: 25, sat: 0.35, light: 0.18, contrast: 0.85 })
 ]);
@@ -847,21 +847,21 @@ const TABLE_WOOD_OPTIONS = Object.freeze([
 ]);
 
 const TABLE_CLOTH_OPTIONS = Object.freeze([
-  { id: "crimson", label: "Rrobë e Kuqe", feltTop: "#b0122d", feltBottom: "#650a1b", border: "#2b050c", emissive: "#6c101f", emissiveIntensity: 0.5 },
-  { id: "emerald", label: "Rrobë Smerald", feltTop: "#1fa44d", feltBottom: "#0b7030", border: "#043018", emissive: "#0f6a2f", emissiveIntensity: 0.72 },
-  { id: "arctic", label: "Rrobë Akull", feltTop: "#3b82f6", feltBottom: "#1d4ed8", border: "#0a1c4d", emissive: "#2563eb", emissiveIntensity: 0.62 },
-  { id: "sunset", label: "Rrobë Perëndim", feltTop: "#f97316", feltBottom: "#c2410c", border: "#3b1203", emissive: "#e2580f", emissiveIntensity: 0.58 },
-  { id: "violet", label: "Rrobë Vjollcë", feltTop: "#8b5cf6", feltBottom: "#5b21b6", border: "#241055", emissive: "#6d28d9", emissiveIntensity: 0.58 },
-  { id: "amber", label: "Rrobë Qelibari", feltTop: "#f59e0b", feltBottom: "#b45309", border: "#3b1a02", emissive: "#d97706", emissiveIntensity: 0.54 }
+  { id: "crimson", label: "Crimson Cloth", feltTop: "#b0122d", feltBottom: "#650a1b", border: "#2b050c", emissive: "#6c101f", emissiveIntensity: 0.5 },
+  { id: "emerald", label: "Emerald Cloth", feltTop: "#1fa44d", feltBottom: "#0b7030", border: "#043018", emissive: "#0f6a2f", emissiveIntensity: 0.72 },
+  { id: "arctic", label: "Arctic Cloth", feltTop: "#3b82f6", feltBottom: "#1d4ed8", border: "#0a1c4d", emissive: "#2563eb", emissiveIntensity: 0.62 },
+  { id: "sunset", label: "Sunset Cloth", feltTop: "#f97316", feltBottom: "#c2410c", border: "#3b1203", emissive: "#e2580f", emissiveIntensity: 0.58 },
+  { id: "violet", label: "Violet Cloth", feltTop: "#8b5cf6", feltBottom: "#5b21b6", border: "#241055", emissive: "#6d28d9", emissiveIntensity: 0.58 },
+  { id: "amber", label: "Amber Cloth", feltTop: "#f59e0b", feltBottom: "#b45309", border: "#3b1a02", emissive: "#d97706", emissiveIntensity: 0.54 }
 ]);
 
 const TABLE_BASE_OPTIONS = Object.freeze([
-  { id: "obsidian", label: "Bazë Obsidian", base: "#141414", column: "#0b0d10", trim: "#1f232a" },
-  { id: "forestBronze", label: "Bazë Pylli", base: "#101714", column: "#0a0f0c", trim: "#1f2d24" },
-  { id: "midnightChrome", label: "Bazë Mesnate", base: "#0f172a", column: "#0a1020", trim: "#1e2f4a" },
-  { id: "emberCopper", label: "Bazë Bakri", base: "#231312", column: "#140707", trim: "#5c2d1b" },
-  { id: "violetShadow", label: "Bazë Hije Vjollcë", base: "#1f1130", column: "#130622", trim: "#3f1b5b" },
-  { id: "desertGold", label: "Bazë Shkretëtirë", base: "#1c1a12", column: "#0f0d06", trim: "#5a4524" }
+  { id: "obsidian", label: "Obsidian Base", base: "#141414", column: "#0b0d10", trim: "#1f232a" },
+  { id: "forestBronze", label: "Forest Base", base: "#101714", column: "#0a0f0c", trim: "#1f2d24" },
+  { id: "midnightChrome", label: "Midnight Base", base: "#0f172a", column: "#0a1020", trim: "#1e2f4a" },
+  { id: "emberCopper", label: "Copper Base", base: "#231312", column: "#140707", trim: "#5c2d1b" },
+  { id: "violetShadow", label: "Violet Shadow Base", base: "#1f1130", column: "#130622", trim: "#3f1b5b" },
+  { id: "desertGold", label: "Desert Base", base: "#1c1a12", column: "#0f0d06", trim: "#5a4524" }
 ]);
 
 const DOMINO_STYLE_OPTIONS = Object.freeze([
@@ -1043,8 +1043,8 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
 ]);
 
 const TABLE_SETUP_SECTIONS = [
-  { key: "tableWood", label: "Dru i Tavolinës", options: TABLE_WOOD_OPTIONS },
-  { key: "tableCloth", label: "Rroba e Tavolinës", options: TABLE_CLOTH_OPTIONS },
+  { key: "tableWood", label: "Table Wood", options: TABLE_WOOD_OPTIONS },
+  { key: "tableCloth", label: "Table Cloth", options: TABLE_CLOTH_OPTIONS },
   { key: "tableBase", label: "Bazamenti", options: TABLE_BASE_OPTIONS },
   { key: "dominoStyle", label: "Domino", options: DOMINO_STYLE_OPTIONS },
   { key: "chairTheme", label: "Stolat", options: CHAIR_THEME_OPTIONS }
@@ -2776,7 +2776,7 @@ function canonTile(t){
   if(!isValidTile(t)) return null; let {a,b}=t; if(a>b){ const k=a; a=b; b=k; } return {a,b};
 }
 
-/* ---------- Domino EXACT per kërkesën tënde ---------- */
+/* ---------- Domino EXACT for your request ---------- */
 function pipPositions(){
   return [
     [-0.3, 0.6], [0, 0.6], [0.3, 0.6],
@@ -2845,14 +2845,14 @@ function makeDomino(a,b,{flat=true, faceUp=true, preserveOrder=false}={}){
 
   const group = new THREE.Group();
 
-  // Trupi SAKTËSISHT si në kodin tënd
+  // Body EXACTLY as in your code
   const bodyGeo = new RoundedBoxGeometry(1, 2, 0.22, 4, 0.06);
   const bodyMaterial = porcelainMat.clone();
   bodyMaterial.envMapIntensity = porcelainMat.envMapIntensity;
   const body = new THREE.Mesh(bodyGeo, bodyMaterial);
   body.castShadow = true; body.receiveShadow = true;
 
-  // Vijë mesi — accent
+  // Center line — accent
   const midW = 1 - 0.08;         // sipas kodit
   const midH = 0.03;
   const midR = 0.06;
@@ -2865,10 +2865,10 @@ function makeDomino(a,b,{flat=true, faceUp=true, preserveOrder=false}={}){
   midLine.renderOrder = 5;
   body.add(midLine);
 
-  // Kornizë luksoze rrethuese — accent
+  // Luxurious surrounding frame — accent
   addAccentPerimeter(body);
 
-  // Pikat sipas kodit — faqe sipër & poshtë (në koordinata të trupit)
+  // Dots per your code — top & bottom faces (in body coordinates)
   if(faceUp){
     addPips(body, a, -0.8);
     addPips(body, b,  0.2);
@@ -2886,10 +2886,10 @@ function makeDomino(a,b,{flat=true, faceUp=true, preserveOrder=false}={}){
   collider.receiveShadow = false;
   group.add(collider);
 
-  // Integrim me sistemin ekzistues: në fushë duhen "flat" (faqe lart)
+  // Integration with the existing system: on the board they must be flat (face up)
   if(flat){ group.rotation.x = -Math.PI/2; }
 
-  // Ruaj shkallën ekzistuese të botës (ashtu si para ndryshimit)
+  // Keep the existing world scale (same as before the change)
   const sx = 0.10 / 1.0, sy = (flat? 0.016/0.22 : 0.20/2.0), sz = (flat? 0.20/2.0 : 0.016/0.22);
   group.scale.set(DOMINO_WORLD_SCALE * sx, DOMINO_WORLD_SCALE * sy, DOMINO_WORLD_SCALE * sz);
 
@@ -2909,7 +2909,7 @@ let statusPrefix = '';
 let ends = null; // {L:{v,x,z,dir:[dx,dz]}, R:{...}}
 let current = 0; let human = 0;
 let markers = {L:null, R:null}; let selectedTile = null;
-let flipDir = false; // alterno drejtimin e zinxhirit pas çdo loje
+let flipDir = false; // alternate chain direction after each game
 const usedTileKeys = new Set();
 let gameFinished = false;
 let winnerIndex = null;
@@ -3051,7 +3051,7 @@ function renderChain(){
         child.renderOrder = 5;
       }
     });
-    // Siguro që çdo domino në fushë të jetë krejtësisht e sheshtë (pa tilt)
+    // Ensure every domino on the field is completely flat (no tilt)
     orientDominoFlat(domino, c.rot ?? 0);
     c.mesh = domino;
     piecesG.add(domino);
@@ -3659,7 +3659,7 @@ renderer.domElement.addEventListener('pointerdown',ev=>{
   if(ev.pointerType==='touch' && activePointers.size>1){
     return;
   }
-  // FIX: përdor madhësinë e saktë të canvas-it (rect) për koordinatat NDC
+  // FIX: use the exact canvas size (rect) for the NDC coordinates
   const rect = renderer.domElement.getBoundingClientRect();
   const x = ((ev.clientX - rect.left)/rect.width)*2 - 1;
   const y = -(((ev.clientY - rect.top)/rect.height)*2 - 1);

--- a/webapp/public/game-preloads/3d-snooker-preload.txt
+++ b/webapp/public/game-preloads/3d-snooker-preload.txt
@@ -1,8 +1,8 @@
 3D Snooker preload bundle (tekst)
 
-Përmbledhja e klasave kryesore të fizikës dhe parametrave të llogaritjes së spin-it për Snooker 3D.
-Ruajeni pranë build-it final për ta zëvendësuar me module të minifikuara kur të jenë gati.
+Summary of the core physics classes and spin calculation parameters for 3D Snooker.
+Keep it next to the final build to swap in minified modules once they are ready.
 
-- Graviteti -9.81, raporti real i topave dhe tavolinës.
-- Kontrolli pinch-to-zoom, orbitim me yaw/pitch dhe kufizim të këndeve ekstreme.
-- Shader-ët e tapetit dhe vija ndarëse për HUD-in snooker.
+- Gravity -9.81 with a realistic ball-to-table ratio.
+- Pinch-to-zoom control, yaw/pitch orbiting, and clamped extreme angles.
+- Cloth shaders and divider lines for the snooker HUD.

--- a/webapp/public/game-preloads/pool-royale-preload.txt
+++ b/webapp/public/game-preloads/pool-royale-preload.txt
@@ -1,8 +1,8 @@
 Pool Royale preload bundle (tekst)
 
-Ky paketim përmban përshkrime të shader-ëve, HUD-it dhe kontrollave orbitale për versionin 3D të Pool Royale.
-Përdore si vendmbajtës për kodin e optimizuar që do të ngarkohet paraprakisht në cache të shfletuesit.
+This bundle includes shader, HUD, and orbital control descriptors for the 3D version of Pool Royale.
+Use it as a placeholder for optimized code that will be preloaded into the browser cache.
 
-- Orbit +Y, yaw/pitch sipas gesturave mobile.
-- HUD i portretit me matës të forcës dhe shkumës të pozicionuar sipas standardeve të TonPlaygram.
-- Rregullim i tonemapping ACESFilmic për tavolinën dhe dritat tre-pikëshe.
+- +Y orbit with yaw/pitch mapped to mobile gestures.
+- Portrait HUD with force meter and chalk aligned to TonPlaygram standards.
+- ACESFilmic tone mapping tuned for the table and three-point lights.

--- a/webapp/public/game-preloads/tirana-2040-preload.txt
+++ b/webapp/public/game-preloads/tirana-2040-preload.txt
@@ -1,8 +1,8 @@
 Tirana 2040 preload bundle (tekst)
 
-Paketa narrative dhe placeholder-at e asset-eve për mini-lojën Tirana 2040.
-Kjo është një paketë tekstuale për të lejuar prefetching pa binare; zëvendësohet me build-in WebGL sapo të përfundojë.
+Narrative bundle and asset placeholders for the Tirana 2040 mini-game.
+This text-only package enables prefetching without binaries; it is replaced with the WebGL build once ready.
 
-- Skema e qytetit, ngarkesa e dritave dhe këndet e kamerës për korridorin futuristik.
-- Hooks të kontrollit për gesturat mobile dhe lëvizjen e avatarit në korridorin 3D.
-- Përshkrimi i missions/tutorialeve për onboarding-in e lojtarit.
+- City layout, lighting loads, and camera angles for the futuristic corridor.
+- Control hooks for mobile gestures and avatar movement in the 3D corridor.
+- Mission/tutorial descriptions for player onboarding.

--- a/webapp/public/tirana-2040-main.js
+++ b/webapp/public/tirana-2040-main.js
@@ -55,35 +55,35 @@ export async function startTirana2040(){
     {
       id: 'tree_small_02',
       name: 'Tree Small 02 – Dense Canopy (Hedge / Wall)',
-      role: 'Shumë e dendur, e mirë për rresht si mur bimësh',
+      role: 'Very dense, great in a row as a hedge wall',
       image: 'https://cdn.polyhaven.com/asset_img/primary/tree_small_02.png?height=760&quality=95',
       url: 'https://polyhaven.com/a/tree_small_02'
     },
     {
       id: 'island_tree_01',
       name: 'Island Tree 01 – Wide Crown',
-      role: 'Kur e vendos disa herë rresht, bën kurorë shumë të plotë',
+      role: 'When placed in a row, it forms a very full crown',
       image: 'https://cdn.polyhaven.com/asset_img/primary/island_tree_01.png?height=760&quality=95',
       url: 'https://polyhaven.com/a/island_tree_01'
     },
     {
       id: 'fir_sapling_medium',
       name: 'Fir Sapling Medium – Pine Wall',
-      role: 'Vendose në rresht për mur pishash shumë të dendur',
+      role: 'Place in a row for a very dense pine wall',
       image: 'https://cdn.polyhaven.com/asset_img/thumbs/fir_sapling_medium.png?format=png',
       url: 'https://polyhaven.com/a/fir_sapling_medium'
     },
     {
       id: 'quiver_tree_01',
       name: 'Quiver Tree 01 – Desert Tree',
-      role: 'Pemë me trung të bardhë, stil më ekzotik',
+      role: 'Tree with a white trunk, more exotic style',
       image: 'https://cdn.polyhaven.com/asset_img/thumbs/quiver_tree_01.png?format=png',
       url: 'https://polyhaven.com/a/quiver_tree_01'
     },
     {
       id: 'quiver_tree_02',
       name: 'Quiver Tree 02 – Compact Succulent Tree',
-      role: 'Trung i trashë + kurorë shumë kompakte me gjethe aloe',
+      role: 'Thick trunk with a very compact aloe-style crown',
       image: 'https://cdn.polyhaven.com/asset_img/thumbs/quiver_tree_02.png?format=png',
       url: 'https://polyhaven.com/a/quiver_tree_02'
     }
@@ -192,7 +192,7 @@ export async function startTirana2040(){
       return new THREE.WebGLRenderer(makeRendererOpts('high'));
     } catch(err){
       console.warn('Primary renderer failed, retrying with safer mobile defaults', err);
-      updateStatus('Po ulem cilësinë për pajisjen mobile…');
+      updateStatus('Lowering quality for the mobile device…');
       try {
         return new THREE.WebGLRenderer(makeRendererOpts('safe'));
       } catch(inner){
@@ -456,9 +456,9 @@ export async function startTirana2040(){
   window.bots=bots;
   const mapRoads=[]; const mapBuildings=[]; const mapParks=[]; const mapLandmarks=[];
   const BLOCKS_X=6, BLOCKS_Z=6; const CELL=120; const ROAD=28; const PLOT=CELL-ROAD*2; const startX = -(BLOCKS_X*CELL)/2 + CELL/2; const startZ = -(BLOCKS_Z*CELL)/2 + CELL/2; const cityHalfX = BLOCKS_X*CELL*0.5; const cityHalfZ = BLOCKS_Z*CELL*0.5;
-  const northSouthStreets=['Rr. Kombinatit','Rr. Kavajës','Rr. Dëshmorët','Rr. Myslym Shyri','Rr. Ismail Qemali','Rr. Abdyl Frashëri','Rr. Bajram Curri'];
-  const eastWestStreets=['Blvd. Nënë Tereza','Rr. Skënderbej','Rr. Ismail Ndroqi','Rr. Ali Demi','Rr. Petro Nini','Rr. Teuta','Rr. Don Bosko'];
-  const ringRoadName='Unaza Tirana 2040';
+  const northSouthStreets=['Kombinat Street','Kavaja Street','Martyrs Street','Myslym Shyri Street','Ismail Qemali Street','Abdyl Frasheri Street','Bajram Curri Street'];
+  const eastWestStreets=['Mother Teresa Blvd','Skanderbeg Street','Ismail Ndroqi Street','Ali Demi Street','Petro Nini Street','Teuta Street','Don Bosko Street'];
+  const ringRoadName='Tirana 2040 Ring Road';
 
   const groundGeo = new THREE.PlaneGeometry((CELL)*BLOCKS_X + ROAD*2, (CELL)*BLOCKS_Z + ROAD*2);
   const groundMat = new THREE.MeshStandardMaterial({ map: asphaltTex, roughness:0.95, metalness:0.08, side:THREE.DoubleSide });
@@ -648,9 +648,9 @@ export async function startTirana2040(){
   buildPerimeterWalls();
   addBusStop(-cityHalfX*0.6, cityHalfZ+ROAD*0.8, 0);
   addBusStop(cityHalfX*0.6, -cityHalfZ-ROAD*0.8, Math.PI);
-  addBikeCorridor(-cityHalfX, startZ + CELL*2.5, cityHalfX, startZ + CELL*2.5, {label:'Korsi kryesore lindje-perendim'});
-  addBikeCorridor(startX + CELL*1.5, -cityHalfZ, startX + CELL*1.5, cityHalfZ, {label:'Boshti veri-jug i biçikletave'});
-  addBikeCorridor(startX + CELL*4.5, -cityHalfZ, startX + CELL*4.5, cityHalfZ, {label:'Greenway periferik'});
+  addBikeCorridor(-cityHalfX, startZ + CELL*2.5, cityHalfX, startZ + CELL*2.5, {label:'Main east-west bike lane'});
+  addBikeCorridor(startX + CELL*1.5, -cityHalfZ, startX + CELL*1.5, cityHalfZ, {label:'North-south bicycle spine'});
+  addBikeCorridor(startX + CELL*4.5, -cityHalfZ, startX + CELL*4.5, cityHalfZ, {label:'Perimeter greenway'});
 
   const windowGeo=new THREE.PlaneGeometry(1.2,1.8);
   const windowMat=new THREE.MeshBasicMaterial({ color:0xffffff, transparent:true, opacity:0.12, depthWrite:false });

--- a/webapp/public/tonplaygram-launcher.apk
+++ b/webapp/public/tonplaygram-launcher.apk
@@ -1,9 +1,9 @@
 TonPlaygram Android Launcher (preview)
 
-Ky skedar .apk shërben si mbajtës vendi për shkarkimin e aplikacionit të plotë Android.
-Aktualisht përmban vetëm tekst për të provuar endpoint-in e shkarkimit pa kode sensitive
-ose binare të mbyllura. Zëvendësojeni me build-in zyrtar të nënshkruar sapo të jetë gati.
+This .apk file acts as a placeholder for downloading the full Android application.
+It currently includes text only to validate the download endpoint without sensitive code
+or closed binaries. Replace it with the signed official build as soon as it is ready.
 
-- Nuk përmban çelësa ose të dhëna private.
-- Mund të shpërndahet publikisht për testim të rrjedhës së shkarkimit.
-- Ruajeni emrin e skedarit që lidhjet ekzistuese të vazhdojnë të funksionojnë.
+- Contains no keys or private data.
+- Can be shared publicly to test the download flow.
+- Keep the filename so existing links continue to work.

--- a/webapp/src/components/ArcadeRacketGame.jsx
+++ b/webapp/src/components/ArcadeRacketGame.jsx
@@ -48,7 +48,7 @@ const BASE_CONFIG = GAME_CONFIGS.tennis;
 
 export default function ArcadeRacketGame({ mode = 'tennis', title, stakeLabel, trainingMode = false }) {
   const mountRef = useRef(null);
-  const [toast, setToast] = useGoalRushToast(trainingMode ? 'Modaliteti Trajnim · Swipe për shërbim' : 'Swipe UP për gjuajtje');
+  const [toast, setToast] = useGoalRushToast(trainingMode ? 'Training Mode · Swipe to serve' : 'Swipe UP to shoot');
 
   useEffect(() => {
     const config = GAME_CONFIGS[mode] || GAME_CONFIGS.tennis;
@@ -209,7 +209,7 @@ export default function ArcadeRacketGame({ mode = 'tennis', title, stakeLabel, t
         const lift = THREE.MathUtils.clamp(3 + powerScale * 1.1, 3, 7.6);
         velocity.set(lateral, lift, forward);
         started = true;
-        setToast('AI shërben · mbrohu!');
+        setToast('AI serving · defend!');
       }, 900);
     }
 
@@ -227,9 +227,9 @@ export default function ArcadeRacketGame({ mode = 'tennis', title, stakeLabel, t
 
       if (showToast) {
         if (!serverIsPlayer) {
-          setToast('AI do të shërbejë · gati për kthim');
+          setToast('AI will serve · get ready to return');
         } else {
-          setToast(trainingMode ? 'Modaliteti Trajnim · Swipe për shërbim' : 'Swipe UP për shërbim');
+          setToast(trainingMode ? 'Training Mode · Swipe to serve' : 'Swipe UP to serve');
         }
       }
 
@@ -256,7 +256,7 @@ export default function ArcadeRacketGame({ mode = 'tennis', title, stakeLabel, t
         player.position.z + hitDir * hitOffset
       );
       started = true;
-      setToast('Rally në progres');
+      setToast('Rally in progress');
     }
 
     function onPointerDown(e) {
@@ -419,7 +419,7 @@ export default function ArcadeRacketGame({ mode = 'tennis', title, stakeLabel, t
         } else {
           velocity.set(0, 0, 0);
           started = false;
-          setToast('Jashtë fushës · Swipe për të rifilluar');
+          setToast('Out of bounds · Swipe to restart');
           nextServer();
           resetBall(false);
         }
@@ -429,7 +429,7 @@ export default function ArcadeRacketGame({ mode = 'tennis', title, stakeLabel, t
       if (clippedOut) {
         velocity.set(0, 0, 0);
         started = false;
-        setToast('Rally përfundoi · Swipe për të rifilluar');
+        setToast('Rally finished · Swipe to restart');
         nextServer();
         resetBall(false);
       }

--- a/webapp/src/components/TennisBattleRoyal3D.jsx
+++ b/webapp/src/components/TennisBattleRoyal3D.jsx
@@ -229,7 +229,7 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
   if (playerName) suffixParts.push(`${playerName} vs AI`);
   if (stakeLabel) suffixParts.push(`Stake ${stakeLabel}`);
   const matchTag = suffixParts.join(' · ');
-  const introMessage = trainingMode ? 'Training · Swipe për shërbim' : 'Swipe & Hit';
+  const introMessage = trainingMode ? 'Training · Swipe to serve' : 'Swipe & Hit';
   const [msg, setMsg] = useState(introMessage);
   const [hudInfo, setHudInfo] = useState(() => ({
     points: '0 - 0',
@@ -248,23 +248,23 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
   const trainingSteps = [
     {
       id: 'swipeServe',
-      title: 'Shërbe me swipe',
-      detail: 'Fërko gishtin nga poshtë-lart për të nisur topin.'
+      title: 'Serve with a swipe',
+      detail: 'Swipe upward to launch the ball.'
     },
     {
       id: 'landServe',
-      title: 'Topi në kutinë e shërbimit',
-      detail: 'Sigurohu që kërcimi i parë të bjerë në anën e kundërshtarit.'
+      title: 'Ball in the service box',
+      detail: 'Make sure the first bounce lands on the opponent’s side.'
     },
     {
       id: 'rallyHit',
-      title: 'Godit një rally',
-      detail: 'Prit rikthimin e CPU dhe godit topin përsëri.'
+      title: 'Play a rally',
+      detail: 'Wait for the CPU return and hit the ball again.'
     },
     {
       id: 'winPoint',
-      title: 'Fito një pikë',
-      detail: 'Mbaje rally deri sa CPU të gabojë.'
+      title: 'Win a point',
+      detail: 'Keep the rally going until the CPU faults.'
     }
   ];
   const [trainingStatus, setTrainingStatus] = useState(() =>
@@ -339,10 +339,10 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
     const stepId = nextTrainingStep?.id || (trainingCompleted ? 'done' : null);
     if (!stepId || stepId === lastTaskToastId.current) return undefined;
     lastTaskToastId.current = stepId;
-    const toastTitle = nextTrainingStep ? `Detyra: ${nextTrainingStep.title}` : 'Trajnimi u përfundua';
+    const toastTitle = nextTrainingStep ? `Task: ${nextTrainingStep.title}` : 'Training complete';
     const toastDetail = nextTrainingStep
       ? nextTrainingStep.detail
-      : 'Tasket u realizuan, vazhdo lojën!';
+      : 'Tasks complete, keep playing!';
     setTaskToast({ id: stepId, title: toastTitle, detail: toastDetail });
     const timer = setTimeout(() => setTaskToast(null), 4200);
     return () => clearTimeout(timer);
@@ -2148,10 +2148,10 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
                 alignItems: 'center'
               }}
             >
-              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 1.4, opacity: 0.75 }}>Lojtarët</div>
-              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 1.4, opacity: 0.75 }}>Sete</div>
-              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 1.4, opacity: 0.75 }}>Lojë</div>
-              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 1.4, opacity: 0.75 }}>Pikë</div>
+              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 1.4, opacity: 0.75 }}>Players</div>
+              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 1.4, opacity: 0.75 }}>Sets</div>
+              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 1.4, opacity: 0.75 }}>Games</div>
+              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 1.4, opacity: 0.75 }}>Points</div>
               {scoreboardRows.map((row) => (
                 <React.Fragment key={row.label}>
                   <div style={{ fontSize: 15, fontWeight: 700, display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -2218,7 +2218,7 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
           >
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
               <span style={{ fontWeight: 700 }}>Training Tasks</span>
-              <span style={{ fontSize: 11, opacity: 0.75 }}>{trainingCompleted ? 'Përfunduar' : 'Në progres'}</span>
+              <span style={{ fontSize: 11, opacity: 0.75 }}>{trainingCompleted ? 'Completed' : 'In progress'}</span>
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               {trainingSteps.map((step) => {

--- a/webapp/src/pages/Games/BlackJackArena.jsx
+++ b/webapp/src/pages/Games/BlackJackArena.jsx
@@ -101,7 +101,7 @@ const CHIP_VALUES = [1000, 500, 100, 50, 20, 10, 5, 2, 1];
 const CHAIR_COLOR_OPTIONS = Object.freeze([
   {
     id: 'crimsonVelvet',
-    label: 'Kadife e Kuqe',
+    label: 'Crimson Velvet',
     primary: '#8b1538',
     accent: '#5c0f26',
     highlight: '#d35a7a',
@@ -109,7 +109,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'midnightNavy',
-    label: 'Blu Mesnate',
+    label: 'Midnight Blue',
     primary: '#153a8b',
     accent: '#0c214f',
     highlight: '#4d74d8',
@@ -117,7 +117,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'emeraldWave',
-    label: 'Valë Smerald',
+    label: 'Emerald Wave',
     primary: '#0f6a2f',
     accent: '#063d1b',
     highlight: '#48b26a',
@@ -125,7 +125,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'onyxShadow',
-    label: 'Hije Oniks',
+    label: 'Onyx Shadow',
     primary: '#202020',
     accent: '#101010',
     highlight: '#6f6f6f',
@@ -133,7 +133,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'goldenHour',
-    label: 'Ar Pasdite',
+    label: 'Golden Hour',
     primary: '#8b5a1a',
     accent: '#4a2f0b',
     highlight: '#d8a85f',
@@ -209,11 +209,11 @@ const DEFAULT_APPEARANCE = {
 };
 
 const CUSTOMIZATION_SECTIONS = [
-  { key: 'tableWood', label: 'Dru i Tavolinës', options: TABLE_WOOD_OPTIONS },
-  { key: 'tableCloth', label: 'Rroba e Tavolinës', options: TABLE_CLOTH_OPTIONS },
-  { key: 'chairColor', label: 'Ngjyra e Karrigeve', options: CHAIR_COLOR_OPTIONS },
-  { key: 'tableShape', label: 'Forma e Tavolinës', options: TABLE_SHAPE_OPTIONS },
-  { key: 'cards', label: 'Letrat', options: CARD_THEMES }
+  { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },
+  { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
+  { key: 'chairColor', label: 'Chair Color', options: CHAIR_COLOR_OPTIONS },
+  { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS },
+  { key: 'cards', label: 'Cards', options: CARD_THEMES }
 ];
 
 const NON_DIAMOND_SHAPE_INDEX = (() => {
@@ -2123,7 +2123,7 @@ function BlackJackArena({ search }) {
               d="m19.4 13.5-.44 1.74a1 1 0 0 1-1.07.75l-1.33-.14a7.03 7.03 0 0 1-1.01.59l-.2 1.32a1 1 0 0 1-.98.84h-1.9a1 1 0 0 1-.98-.84l-.2-1.32a7.03 7.03 0 0 1-1.01-.59l-1.33.14a1 1 0 0 1-1.07-.75L4.6 13.5a1 1 0 0 1 .24-.96l1-.98a6.97 6.97 0 0 1 0-1.12l-1-.98a1 1 0 0 1-.24-.96l.44-1.74a1 1 0 0 1 1.07-.75l1.33.14c.32-.23.66-.43 1.01-.6l.2-1.31a1 1 0 0 1 .98-.84h1.9a1 1 0 0 1 .98.84l.2 1.31c.35.17.69.37 1.01.6l1.33-.14a1 1 0 0 1 1.07.75l.44 1.74a1 1 0 0 1-.24.96l-1 .98c.03.37.03.75 0 1.12l1 .98a1 1 0 0 1 .24.96z"
             />
           </svg>
-          <span className="sr-only">Hap personalizimin e tavolinës</span>
+          <span className="sr-only">Open table customization</span>
         </button>
         {configOpen && (
           <div className="pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur">

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -40,14 +40,14 @@ import AvatarTimer from '../../components/AvatarTimer.jsx';
 /**
  * CHESS 3D — Procedural, Modern Look (no external models)
  * -------------------------------------------------------
- * • E njëjta teknikë si projektet e tua: vetëm primitive (Box/Cylinder/Cone/Sphere) + materiale standarde
- * • Fushë 8x8 me koordinata, bordure moderne, ndriçim kinematik
- * • Figura low‑poly procedurale (king/queen/rook/bishop/knight/pawn)
- * • Lojë e plotë bazë: lëvizje të ligjshme, radhë e bardhë → e zezë, kapje, shah, **checkmate/stalemate**, promovim në queen
- * • UI minimale: status bar (rendi, check, mate), reset
- * • Kontroll: klik për të zgjedhur figuren, klik te një nga synimet e theksuara për ta lëvizur
+ * • Same technique as your projects: only primitives (Box/Cylinder/Cone/Sphere) + standard materials
+ * • 8x8 board with coordinates, modern border, cinematic lighting
+ * • Procedural low-poly pieces (king/queen/rook/bishop/knight/pawn)
+ * • Full basic game: legal moves, white → black turns, captures, check, **checkmate/stalemate**, promotion to queen
+ * • Minimal UI: status bar (turn, check, mate), reset
+ * • Control: click to select a piece, click one of the highlighted targets to move it
  *
- * Shënim: për thjeshtësi, ky version nuk përfshin en‑passant dhe rokadë. Mund t’i shtojmë lehtë.
+ * Note: for simplicity, this version omits en passant and castling. We can add them easily.
  */
 
 // ========================= Config =========================
@@ -339,7 +339,7 @@ const DEFAULT_APPEARANCE = {
 const CHAIR_COLOR_OPTIONS = Object.freeze([
   {
     id: 'crimsonVelvet',
-    label: 'Kadife e Kuqe',
+    label: 'Crimson Velvet',
     primary: '#8b1538',
     accent: '#5c0f26',
     highlight: '#d35a7a',
@@ -347,7 +347,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'midnightNavy',
-    label: 'Blu Mesnate',
+    label: 'Midnight Blue',
     primary: '#153a8b',
     accent: '#0c214f',
     highlight: '#4d74d8',
@@ -355,7 +355,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'emeraldWave',
-    label: 'Valë Smerald',
+    label: 'Emerald Wave',
     primary: '#0f6a2f',
     accent: '#063d1b',
     highlight: '#48b26a',
@@ -363,7 +363,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'onyxShadow',
-    label: 'Hije Oniks',
+    label: 'Onyx Shadow',
     primary: '#202020',
     accent: '#101010',
     highlight: '#6f6f6f',
@@ -371,7 +371,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'royalPlum',
-    label: 'Gështenjë Mbretërore',
+    label: 'Royal Chestnut',
     primary: '#3f1f5b',
     accent: '#2c1340',
     highlight: '#7c4ae0',
@@ -383,13 +383,13 @@ const DIAMOND_SHAPE_ID = 'diamondEdge';
 const TABLE_SHAPE_MENU_OPTIONS = TABLE_SHAPE_OPTIONS.filter((option) => option.id !== DIAMOND_SHAPE_ID);
 
 const CUSTOMIZATION_SECTIONS = [
-  { key: 'tableWood', label: 'Dru i Tavolinës', options: TABLE_WOOD_OPTIONS },
-  { key: 'tableCloth', label: 'Rroba e Tavolinës', options: TABLE_CLOTH_OPTIONS },
-  { key: 'boardPalette', label: 'Ngjyrat e Fushës', options: BOARD_COLOR_OPTIONS },
-  { key: 'pieceStyle', label: 'Stili i Figurave', options: PIECE_STYLE_OPTIONS },
-  { key: 'chairColor', label: 'Ngjyra e Karrigeve', options: CHAIR_COLOR_OPTIONS },
-  { key: 'tableBase', label: 'Baza e Tavolinës', options: TABLE_BASE_OPTIONS },
-  { key: 'tableShape', label: 'Forma e Tavolinës', options: TABLE_SHAPE_MENU_OPTIONS }
+  { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },
+  { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
+  { key: 'boardPalette', label: 'Board Colors', options: BOARD_COLOR_OPTIONS },
+  { key: 'pieceStyle', label: 'Piece Style', options: PIECE_STYLE_OPTIONS },
+  { key: 'chairColor', label: 'Chair Color', options: CHAIR_COLOR_OPTIONS },
+  { key: 'tableBase', label: 'Table Base', options: TABLE_BASE_OPTIONS },
+  { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_MENU_OPTIONS }
 ];
 
 function normalizeAppearance(value = {}) {
@@ -3201,7 +3201,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
                 d="m19.4 13.5-.44 1.74a1 1 0 0 1-1.07.75l-1.33-.14a7.03 7.03 0 0 1-1.01.59l-.2 1.32a1 1 0 0 1-.98.84h-1.9a1 1 0 0 1-.98-.84l-.2-1.32a7.03 7.03 0 0 1-1.01-.59l-1.33.14a1 1 0 0 1-1.07-.75L4.6 13.5a1 1 0 0 1 .24-.96l1-.98a6.97 6.97 0 0 1 0-1.12l-1-.98a1 1 0 0 1-.24-.96l.44-1.74a1 1 0 0 1 1.07-.75l1.33.14c.32-.23.66-.43 1.01-.6l.2-1.31a1 1 0 0 1 .98-.84h1.9a1 1 0 0 1 .98.84l.2 1.31c.35.17.69.37 1.01.6l1.33-.14a1 1 0 0 1 1.07.75l.44 1.74a1 1 0 0 1-.24.96l-1 .98c.03.37.03.75 0 1.12l1 .98a1 1 0 0 1 .24.96z"
               />
             </svg>
-            <span className="sr-only">Hap personalizimin e tavolinës</span>
+            <span className="sr-only">Open table customization</span>
           </button>
           {configOpen && (
             <div className="pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur">
@@ -3211,7 +3211,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
                   type="button"
                   onClick={() => setConfigOpen(false)}
                   className="rounded-full p-1 text-white/70 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
-                  aria-label="Mbyll personalizimin"
+                  aria-label="Close customization"
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-4 w-4">
                     <path strokeLinecap="round" strokeLinejoin="round" d="m6 6 12 12M18 6 6 18" />
@@ -3250,7 +3250,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
               </div>
               <div className="mt-4 space-y-3">
                 <label className="flex items-center justify-between text-[0.7rem] text-gray-200">
-                  <span>Efekte zanore</span>
+                  <span>Sound effects</span>
                   <input
                     type="checkbox"
                     className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500"
@@ -3259,7 +3259,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
                   />
                 </label>
                 <label className="flex items-center justify-between text-[0.7rem] text-gray-200">
-                  <span>Shfaq lëvizjet e lejueshme</span>
+                  <span>Show legal moves</span>
                   <input
                     type="checkbox"
                     className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500"
@@ -3275,14 +3275,14 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
                   }}
                   className="w-full rounded-lg bg-white/10 py-2 text-center text-[0.7rem] font-semibold text-white transition hover:bg-white/20"
                 >
-                  Centro kamerën
+                  Center camera
                 </button>
                 <button
                   type="button"
                   onClick={() => window.location.reload()}
                   className="w-full rounded-lg bg-emerald-500/20 py-2 text-center text-[0.7rem] font-semibold text-emerald-200 transition hover:bg-emerald-500/30"
                 >
-                  Rifillo ndeshjen
+                  Restart match
                 </button>
               </div>
             </div>

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -198,7 +198,7 @@ const DEFAULT_STOOL_THEME = Object.freeze({ legColor: '#1f1f1f' });
 const CHAIR_COLOR_OPTIONS = Object.freeze([
   {
     id: 'crimsonVelvet',
-    label: 'Kadife e Kuqe',
+    label: 'Crimson Velvet',
     primary: '#8b1538',
     accent: '#5c0f26',
     highlight: '#d35a7a',
@@ -206,7 +206,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'midnightNavy',
-    label: 'Blu Mesnate',
+    label: 'Midnight Blue',
     primary: '#153a8b',
     accent: '#0c214f',
     highlight: '#4d74d8',
@@ -214,7 +214,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'emeraldWave',
-    label: 'Valë Smerald',
+    label: 'Emerald Wave',
     primary: '#0f6a2f',
     accent: '#063d1b',
     highlight: '#48b26a',
@@ -222,7 +222,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'onyxShadow',
-    label: 'Hije Oniks',
+    label: 'Onyx Shadow',
     primary: '#202020',
     accent: '#101010',
     highlight: '#6f6f6f',
@@ -230,7 +230,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'royalPlum',
-    label: 'Gështenjë Mbretërore',
+    label: 'Royal Chestnut',
     primary: '#3f1f5b',
     accent: '#2c1340',
     highlight: '#7c4ae0',
@@ -249,11 +249,11 @@ const DEFAULT_APPEARANCE = {
 };
 
 const CUSTOMIZATION_SECTIONS = [
-  { key: 'tableWood', label: 'Dru i Tavolinës', options: TABLE_WOOD_OPTIONS },
-  { key: 'tableCloth', label: 'Rroba e Tavolinës', options: TABLE_CLOTH_OPTIONS },
-  { key: 'chairColor', label: 'Ngjyra e Karrigeve', options: CHAIR_COLOR_OPTIONS },
-  { key: 'tableBase', label: 'Baza e Tavolinës', options: TABLE_BASE_OPTIONS },
-  { key: 'tableShape', label: 'Forma e Tavolinës', options: TABLE_SHAPE_OPTIONS }
+  { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },
+  { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
+  { key: 'chairColor', label: 'Chair Color', options: CHAIR_COLOR_OPTIONS },
+  { key: 'tableBase', label: 'Table Base', options: TABLE_BASE_OPTIONS },
+  { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS }
 ];
 
 const DIAMOND_SHAPE_ID = 'diamondEdge';
@@ -3449,7 +3449,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides }) {
                 d="m19.4 13.5-.44 1.74a1 1 0 0 1-1.07.75l-1.33-.14a7.03 7.03 0 0 1-1.01.59l-.2 1.32a1 1 0 0 1-.98.84h-1.9a1 1 0 0 1-.98-.84l-.2-1.32a7.03 7.03 0 0 1-1.01-.59l-1.33.14a1 1 0 0 1-1.07-.75L4.6 13.5a1 1 0 0 1 .24-.96l1-.98a6.97 6.97 0 0 1 0-1.12l-1-.98a1 1 0 0 1-.24-.96l.44-1.74a1 1 0 0 1 1.07-.75l1.33.14c.32-.23.66-.43 1.01-.6l.2-1.31a1 1 0 0 1 .98-.84h1.9a1 1 0 0 1 .98.84l.2 1.31c.35.17.69.37 1.01.6l1.33-.14a1 1 0 0 1 1.07.75l.44 1.74a1 1 0 0 1-.24.96l-1 .98c.03.37.03.75 0 1.12l1 .98a1 1 0 0 1 .24.96z"
               />
             </svg>
-            <span className="sr-only">Hap personalizimin e tavolinës</span>
+            <span className="sr-only">Open table customization</span>
           </button>
           {configOpen && (
             <div className="pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur">
@@ -3459,7 +3459,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides }) {
                   type="button"
                   onClick={() => setConfigOpen(false)}
                   className="rounded-full p-1 text-white/70 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
-                  aria-label="Mbyll personalizimin"
+                  aria-label="Close customization"
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-4 w-4">
                     <path strokeLinecap="round" strokeLinejoin="round" d="m6 6 12 12M18 6 6 18" />
@@ -3504,7 +3504,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides }) {
               </div>
               <div className="mt-4 space-y-3">
                 <label className="flex items-center justify-between text-[0.7rem] text-gray-200">
-                  <span>Efekte zanore</span>
+                  <span>Sound effects</span>
                   <input
                     type="checkbox"
                     className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500"
@@ -3520,14 +3520,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides }) {
                   }}
                   className="w-full rounded-lg bg-white/10 py-2 text-center text-[0.7rem] font-semibold text-white transition hover:bg-white/20"
                 >
-                  Centro kamerën
+                  Center camera
                 </button>
                 <button
                   type="button"
                   onClick={() => window.location.reload()}
                   className="w-full rounded-lg bg-emerald-500/20 py-2 text-center text-[0.7rem] font-semibold text-emerald-200 transition hover:bg-emerald-500/30"
                 >
-                  Rifillo lojën
+                  Restart game
                 </button>
               </div>
             </div>

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -60,21 +60,21 @@ const SUIT_COLORS = {
 };
 
 const OUTFIT_THEMES = [
-  { id: 'midnight', label: 'Blu Mbretëror', baseColor: '#1f3c88', accentColor: '#f5d547', glow: '#0f172a' },
-  { id: 'ember', label: 'E Kuqe Neon', baseColor: '#a31621', accentColor: '#ff8e3c', glow: '#22080b' },
-  { id: 'glacier', label: 'Akull', baseColor: '#1b8dbf', accentColor: '#9ff0ff', glow: '#082433' },
-  { id: 'forest', label: 'Pyje', baseColor: '#1b7f4a', accentColor: '#b5f44a', glow: '#071f11' },
-  { id: 'royal', label: 'Vjollcë', baseColor: '#6b21a8', accentColor: '#f0abfc', glow: '#220a35' },
-  { id: 'onyx', label: 'Oniks', baseColor: '#1f2937', accentColor: '#9ca3af', glow: '#090b10' }
+  { id: 'midnight', label: 'Royal Blue', baseColor: '#1f3c88', accentColor: '#f5d547', glow: '#0f172a' },
+  { id: 'ember', label: 'Neon Red', baseColor: '#a31621', accentColor: '#ff8e3c', glow: '#22080b' },
+  { id: 'glacier', label: 'Ice', baseColor: '#1b8dbf', accentColor: '#9ff0ff', glow: '#082433' },
+  { id: 'forest', label: 'Forest', baseColor: '#1b7f4a', accentColor: '#b5f44a', glow: '#071f11' },
+  { id: 'royal', label: 'Violet', baseColor: '#6b21a8', accentColor: '#f0abfc', glow: '#220a35' },
+  { id: 'onyx', label: 'Onyx', baseColor: '#1f2937', accentColor: '#9ca3af', glow: '#090b10' }
 ];
 
 const STOOL_THEMES = [
-  { id: 'ruby', label: 'Rubi', seatColor: '#8b0000', legColor: '#1f1f1f' },
-  { id: 'slate', label: 'Guri', seatColor: '#374151', legColor: '#0f172a' },
-  { id: 'teal', label: 'Bruz', seatColor: '#0f766e', legColor: '#082f2a' },
-  { id: 'amber', label: 'Qelibari', seatColor: '#b45309', legColor: '#2f2410' },
-  { id: 'violet', label: 'Vjollcë', seatColor: '#7c3aed', legColor: '#2b1059' },
-  { id: 'frost', label: 'Akull', seatColor: '#1f2937', legColor: '#0f172a' }
+  { id: 'ruby', label: 'Ruby', seatColor: '#8b0000', legColor: '#1f1f1f' },
+  { id: 'slate', label: 'Slate', seatColor: '#374151', legColor: '#0f172a' },
+  { id: 'teal', label: 'Teal', seatColor: '#0f766e', legColor: '#082f2a' },
+  { id: 'amber', label: 'Amber', seatColor: '#b45309', legColor: '#2f2410' },
+  { id: 'violet', label: 'Violet', seatColor: '#7c3aed', legColor: '#2b1059' },
+  { id: 'frost', label: 'Ice', seatColor: '#1f2937', legColor: '#0f172a' }
 ];
 
 const DEFAULT_APPEARANCE = {
@@ -84,11 +84,11 @@ const DEFAULT_APPEARANCE = {
 };
 const APPEARANCE_STORAGE_KEY = 'murlanRoyaleAppearance';
 const CUSTOMIZATION_SECTIONS = [
-  { key: 'tableWood', label: 'Dru i Tavolinës', options: TABLE_WOOD_OPTIONS },
-  { key: 'tableCloth', label: 'Rroba e Tavolinës', options: TABLE_CLOTH_OPTIONS },
-  { key: 'tableBase', label: 'Baza e Tavolinës', options: TABLE_BASE_OPTIONS },
-  { key: 'cards', label: 'Letrat', options: CARD_THEMES },
-  { key: 'stools', label: 'Stola', options: STOOL_THEMES }
+  { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },
+  { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
+  { key: 'tableBase', label: 'Table Base', options: TABLE_BASE_OPTIONS },
+  { key: 'cards', label: 'Cards', options: CARD_THEMES },
+  { key: 'stools', label: 'Stools', options: STOOL_THEMES }
 ];
 
 function createRegularPolygonShape(sides = 8, radius = 1) {
@@ -1518,23 +1518,23 @@ export default function MurlanRoyaleArena({ search }) {
     if (!active || !active.isHuman) return;
     const selectedCards = extractSelectedCards(active.hand, selectedRef.current);
     if (!selectedCards.length) {
-      setActionError('Zgjidh të paktën një letër.');
+      setActionError('Select at least one card.');
       return;
     }
     const combo = detectCombo(selectedCards, GAME_CONFIG);
     if (!combo) {
-      setActionError('Kombinimi nuk është i vlefshëm.');
+      setActionError('The combination is not valid.');
       return;
     }
     const includesStart = selectedCards.some(
       (card) => card.rank === START_CARD.rank && card.suit === START_CARD.suit
     );
     if (state.firstMove && !includesStart) {
-      setActionError('Lëvizja e parë duhet të përfshijë 3♠.');
+      setActionError('The first move must include the 3♠.');
       return;
     }
     if (!canBeat(combo, state.tableCombo, GAME_CONFIG)) {
-      setActionError('Ky kombin nuk e mund atë në tavolinë.');
+      setActionError('This combo does not beat the one on the table.');
       return;
     }
     setActionError('');
@@ -1548,7 +1548,7 @@ export default function MurlanRoyaleArena({ search }) {
     const active = state.players[state.activePlayer];
     if (!active || !active.isHuman) return;
     if (!state.tableCombo) {
-      setActionError('Nuk mund të pasosh pa një kombin në tavolinë.');
+      setActionError('You cannot pass without a combo on the table.');
       return;
     }
     setActionError('');
@@ -1567,13 +1567,13 @@ export default function MurlanRoyaleArena({ search }) {
       <div className="absolute inset-0 pointer-events-none flex h-full flex-col">
         {uiState.scoreboard?.length ? (
           <div className="sr-only" aria-live="polite">
-            <p>Rezultati aktual:</p>
+            <p>Current score:</p>
             <ul>
               {uiState.scoreboard.map((entry) => (
                 <li key={entry.id}>
                   {entry.name}
-                  {entry.isActive ? ' (radha)' : ''}
-                  {entry.finished ? ' - e përfundoi lojën' : ` - ${entry.cardsLeft} letra`}
+                  {entry.isActive ? ' (turn)' : ''}
+                  {entry.finished ? ' - finished the game' : ` - ${entry.cardsLeft} cards`}
                 </li>
               ))}
             </ul>
@@ -1605,7 +1605,7 @@ export default function MurlanRoyaleArena({ search }) {
                   d="m19.4 13.5-.44 1.74a1 1 0 0 1-1.07.75l-1.33-.14a7.03 7.03 0 0 1-1.01.59l-.2 1.32a1 1 0 0 1-.98.84h-1.9a1 1 0 0 1-.98-.84l-.2-1.32a7.03 7.03 0 0 1-1.01-.59l-1.33.14a1 1 0 0 1-1.07-.75L4.6 13.5a1 1 0 0 1 .24-.96l1-.98a6.97 6.97 0 0 1 0-1.12l-1-.98a1 1 0 0 1-.24-.96l.44-1.74a1 1 0 0 1 1.07-.75l1.33.14c.32-.23.66-.43 1.01-.6l.2-1.31a1 1 0 0 1 .98-.84h1.9a1 1 0 0 1 .98.84l.2 1.31c.35.17.69.37 1.01.6l1.33-.14a1 1 0 0 1 1.07.75l.44 1.74a1 1 0 0 1-.24.96l-1 .98c.03.37.03.75 0 1.12l1 .98a1 1 0 0 1 .24.96z"
                 />
               </svg>
-              <span className="sr-only">Hap personalizimin e tavolinës</span>
+              <span className="sr-only">Open table customization</span>
             </button>
             {configOpen && (
               <div className="pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur">
@@ -1890,19 +1890,19 @@ function computeUiState(state) {
 
   if (state.status === 'ENDED') {
     const winners = scoreboard.filter((entry) => entry.finished).map((entry) => entry.name);
-    message = winners.length === 1 ? `${winners[0]} doli fitues!` : `Fitues: ${winners.join(', ')}`;
+    message = winners.length === 1 ? `${winners[0]} emerged victorious!` : `Winners: ${winners.join(', ')}`;
   } else {
     const active = state.players[state.activePlayer];
     if (active) {
       humanTurn = !!active.isHuman;
       if (humanTurn) {
         message = state.firstMove
-          ? 'Zgjidh kartat (përfshi 3♠) dhe shtyp "Luaj".'
+          ? 'Choose the cards (include 3♠) and press "Play".'
           : state.tableCombo
-            ? 'Gjej një kombin që e mund tavolinën ose shtyp "Paso".'
-            : 'Zgjidh kartat dhe shtyp "Luaj" për të nisur hedhjen.';
+            ? 'Find a combo that beats the table or press "Pass".'
+            : 'Pick your cards and press "Play" to start the trick.';
       } else {
-        message = `Duke pritur ${active.name}...`;
+        message = `Waiting for ${active.name}...`;
       }
     }
   }
@@ -1925,17 +1925,17 @@ function describeCombo(combo, cards) {
   }
   switch (combo.type) {
     case ComboType.SINGLE:
-      return `një ${cardLabel(cards[0])}`;
+      return `a ${cardLabel(cards[0])}`;
     case ComboType.PAIR:
-      return `çift ${combo.keyRank}`;
+      return `pair ${combo.keyRank}`;
     case ComboType.TRIPS:
-      return `treshe ${combo.keyRank}`;
+      return `trips ${combo.keyRank}`;
     case ComboType.BOMB_4K:
-      return `bombë ${combo.keyRank}`;
+      return `bomb ${combo.keyRank}`;
     case ComboType.STRAIGHT:
-      return `shteg ${cardLabel(cards[0])} - ${cardLabel(cards[cards.length - 1])}`;
+      return `straight ${cardLabel(cards[0])} - ${cardLabel(cards[cards.length - 1])}`;
     case ComboType.FLUSH:
-      return `flush me ${cards.length} letra`;
+      return `flush with ${cards.length} cards`;
     case ComboType.FULL_HOUSE:
       return 'full house';
     case ComboType.STRAIGHT_FLUSH:

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -625,11 +625,11 @@ function addPocketCuts(parent, clothPlane) {
 
 /**
  * NEW SNOOKER GAME — fresh build (keep ONLY Guret for balls)
- * Per kërkesën tënde:
- *  • Kamera rotullohet si një person te tavolina (orbit e butë), me kënd pak të ulët, pa rënë në nivelin e cloth.
- *  • 6 gropa të prera realisht në cloth (Shape.holes + Extrude) + kapje (capture radius) → guret bien brenda.
- *  • Power slider i RI: i madh, djathtas ekranit, me gjest **PULL** (tërhiq POSHTË sa fort do → fuqi), dhe **gjuan në release**.
- *  • Playable: aiming line + tick, përplasje, kapje në xhepa, logjikë bazë snooker (reds→colour, pastaj colours in order, fouls, in‑hand).
+ * As requested:
+ *  • Camera orbits like a person at the table (smooth orbit) with a slightly low angle, without dropping to cloth level.
+ *  • Six holes cut realistically into the cloth (Shape.holes + Extrude) with capture radius so the balls fall inside.
+ *  • NEW power slider: large on the right side of the screen with a **PULL** gesture (drag DOWN as hard as you want for power) and fires on release.
+ *  • Playable: aiming line + tick, collisions, pocket captures, basic snooker logic (reds→colour, then colours in order, fouls, in-hand).
  */
 
 // --------------------------------------------------
@@ -907,42 +907,42 @@ const ACTION_CAM = Object.freeze({
   followHoldMs: 900
 });
 /**
- * Regji Kamera Pool
+ * Pool Camera Direction
  *
  * 0–2s (Opening Pan)
- * • Kamera nis nga lart, kënd diagonal mbi tavolinë (rreth 60°).
- * • Pan i ngadaltë djathtas → majtas që tregon gjithë tavolinën.
+ * • Camera starts high with a diagonal angle over the table (~60°).
+ * • Slow pan right → left showing the whole table.
  *
  * 2–4s (Focus on Cue Ball)
- * • Kamera afrohet tek topi i bardhë dhe shkopi.
- * • Këndi ulet në 20–25° mbi tavolinë, direkt pas shkopit.
- * • Zoom i lehtë / shtrëngim i kornizës.
+ * • Camera moves toward the cue ball and cue stick.
+ * • Angle drops to 20–25° above the table directly behind the cue.
+ * • Light zoom / tighter framing.
  *
  * 4–6s (Strike Tracking)
- * • Në momentin e goditjes kamera dridhet lehtë për impakt.
- * • Pastaj ndjek topin e bardhë përgjatë tavolinës duke e mbajtur në qendër.
+ * • At impact the camera shakes lightly.
+ * • Then it follows the cue ball across the table, keeping it centered.
  *
  * 6–9s (Impact & Spread)
- * • Kur topat përplasen, kamera ngrihet gradualisht (top-down).
- * • Hapet FOV që të futen të gjithë topat në kornizë.
- * • Bën lëvizje orbitale të shpejtë rreth tavolinës (rreth 30° rrotullim).
+ * • When the balls collide, the camera rises gradually (toward top-down).
+ * • The FOV widens to frame all balls.
+ * • Executes a quick orbital move around the table (~30° rotation).
  *
  * 9–12s (Potting Shot)
- * • Kamera bën një dolly-in tek xhepi ku bie topi.
- * • Ndjek topin brenda xhepit për ~1 sekondë.
- * • Pastaj fade-out ose rikthim tek pamja e plotë.
+ * • Camera performs a dolly-in to the pocket where the ball drops.
+ * • Follows the ball inside the pocket for ~1 second.
+ * • Then fades out or returns to the full view.
  *
  * 12s+ (Reset)
- * • Kamera kthehet në overview fillestar (45° mbi tavolinë).
- * • Mban pan shumë të ngadaltë si looping idle derisa të ndodhë goditja tjetër.
+ * • Camera returns to the initial overview (45° above the table).
+ * • Holds a very slow pan as an idle loop until the next shot.
  *
  * 🎮 Triggers
- * • Fillim loje → Opening Pan.
- * • Kur lojtari përgatitet → Focus on Cue Ball.
- * • Moment goditjeje → Strike Tracking.
- * • Kur topat përplasen → Impact & Spread.
- * • Kur një top bie në xhep → Potting Shot.
- * • Pas çdo raundi → Reset.
+ * • Start of game → Opening Pan.
+ * • When the player prepares → Focus on Cue Ball.
+ * • Moment of the hit → Strike Tracking.
+ * • When the balls collide → Impact & Spread.
+ * • When a ball drops into a pocket → Potting Shot.
+ * • After each round → Reset.
  */
 const SHORT_RAIL_CAMERA_DISTANCE = PLAY_H / 2 + BALL_R * 22; // keep at least half the field visible from the short rails
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // match short-rail framing so broadcast shots feel consistent
@@ -3840,7 +3840,7 @@ function applySnookerScaling({
   return { mmToUnits };
 }
 
-// Kamera: ruaj kënd komod që mos shtrihet poshtë cloth-it, por lejo pak më shumë lartësi kur ngrihet
+// Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
 const STANDING_VIEW_PHI = 0.86; // raise the standing orbit a touch for a clearer overview
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.0024;
@@ -13134,7 +13134,7 @@ function PoolRoyaleGame({
         );
       };
 
-      // Fire (slider e thërret në release)
+      // Fire (slider triggers on release)
       const fire = () => {
         const currentHud = hudRef.current;
         const fullTableHandPlacement =
@@ -15106,7 +15106,7 @@ function PoolRoyaleGame({
             activeShotView = bestPocketView;
           }
         }
-        // Kapje në xhepa
+        // Pocket capture
         balls.forEach((b) => {
           if (!b.active) return;
           for (let pocketIndex = 0; pocketIndex < centers.length; pocketIndex++) {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2510,7 +2510,7 @@ export default function SnakeAndLadder() {
         <div className="relative">
           <button
             type="button"
-            aria-label={showConfig ? 'Mbyll konfigurimet e lojës' : 'Hap konfigurimet e lojës'}
+            aria-label={showConfig ? 'Close game settings' : 'Open game settings'}
             onClick={() => setShowConfig((prev) => !prev)}
             className="rounded-full bg-black/70 p-2 text-lg text-gray-100 shadow-lg backdrop-blur transition hover:bg-black/60"
           >
@@ -2578,7 +2578,7 @@ export default function SnakeAndLadder() {
                   />
                 </label>
                 <label className="flex items-center justify-between text-[0.7rem] text-gray-200">
-                  <span>Shfaq gjurmën e lëvizjes</span>
+                  <span>Show movement trail</span>
                   <input
                     type="checkbox"
                     className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500"
@@ -2636,7 +2636,7 @@ export default function SnakeAndLadder() {
                   onClick={() => window.location.reload()}
                   className="w-full rounded-lg bg-emerald-500/20 py-2 text-center text-[0.7rem] font-semibold text-emerald-200 transition hover:bg-emerald-500/30"
                 >
-                  Rifillo lojën
+                  Restart game
                 </button>
               </div>
             </div>

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -462,11 +462,11 @@ function addPocketCuts(parent, clothPlane) {
 
 /**
  * NEW SNOOKER GAME — fresh build (keep ONLY Guret for balls)
- * Per kërkesën tënde:
- *  • Kamera rotullohet si një person te tavolina (orbit e butë), me kënd pak të ulët, pa rënë në nivelin e cloth.
- *  • 6 gropa të prera realisht në cloth (Shape.holes + Extrude) + kapje (capture radius) → guret bien brenda.
- *  • Power slider i RI: i madh, djathtas ekranit, me gjest **PULL** (tërhiq POSHTË sa fort do → fuqi), dhe **gjuan në release**.
- *  • Playable: aiming line + tick, përplasje, kapje në xhepa, logjikë bazë snooker (reds→colour, pastaj colours in order, fouls, in‑hand).
+ * As requested:
+ *  • Camera orbits like a person at the table (smooth orbit) with a slightly low angle, without dropping to cloth level.
+ *  • Six holes cut realistically into the cloth (Shape.holes + Extrude) with capture radius so the balls fall inside.
+ *  • NEW power slider: large on the right side of the screen with a **PULL** gesture (drag DOWN as hard as you want for power) and fires on release.
+ *  • Playable: aiming line + tick, collisions, pocket captures, basic snooker logic (reds→colour, then colours in order, fouls, in-hand).
  */
 
 // --------------------------------------------------
@@ -681,42 +681,42 @@ const ACTION_CAM = Object.freeze({
   followHoldMs: 900
 });
 /**
- * Regji Kamera Snooker
+ * Snooker Camera Direction
  *
  * 0–2s (Opening Pan)
- * • Kamera nis nga lart, kënd diagonal mbi tavolinë (rreth 60°).
- * • Pan i ngadaltë djathtas → majtas që tregon gjithë tavolinën.
+ * • Camera starts high with a diagonal angle over the table (~60°).
+ * • Slow pan right → left showing the whole table.
  *
  * 2–4s (Focus on Cue Ball)
- * • Kamera afrohet tek topi i bardhë dhe shkopi.
- * • Këndi ulet në 20–25° mbi tavolinë, direkt pas shkopit.
- * • Zoom i lehtë / shtrëngim i kornizës.
+ * • Camera moves toward the cue ball and cue stick.
+ * • Angle drops to 20–25° above the table directly behind the cue.
+ * • Light zoom / tighter framing.
  *
  * 4–6s (Strike Tracking)
- * • Në momentin e goditjes kamera dridhet lehtë për impakt.
- * • Pastaj ndjek topin e bardhë përgjatë tavolinës duke e mbajtur në qendër.
+ * • At impact the camera shakes lightly.
+ * • Then it follows the cue ball across the table, keeping it centered.
  *
  * 6–9s (Impact & Spread)
- * • Kur topat përplasen, kamera ngrihet gradualisht (top-down).
- * • Hapet FOV që të futen të gjithë topat në kornizë.
- * • Bën lëvizje orbitale të shpejtë rreth tavolinës (rreth 30° rrotullim).
+ * • When the balls collide, the camera rises gradually (toward top-down).
+ * • The FOV widens to frame all balls.
+ * • Executes a quick orbital move around the table (~30° rotation).
  *
  * 9–12s (Potting Shot)
- * • Kamera bën një dolly-in tek xhepi ku bie topi.
- * • Ndjek topin brenda xhepit për ~1 sekondë.
- * • Pastaj fade-out ose rikthim tek pamja e plotë.
+ * • Camera performs a dolly-in to the pocket where the ball drops.
+ * • Follows the ball inside the pocket for ~1 second.
+ * • Then fades out or returns to the full view.
  *
  * 12s+ (Reset)
- * • Kamera kthehet në overview fillestar (45° mbi tavolinë).
- * • Mban pan shumë të ngadaltë si looping idle derisa të ndodhë goditja tjetër.
+ * • Camera returns to the initial overview (45° above the table).
+ * • Holds a very slow pan as an idle loop until the next shot.
  *
  * 🎮 Triggers
- * • Fillim loje → Opening Pan.
- * • Kur lojtari përgatitet → Focus on Cue Ball.
- * • Moment goditjeje → Strike Tracking.
- * • Kur topat përplasen → Impact & Spread.
- * • Kur një top bie në xhep → Potting Shot.
- * • Pas çdo raundi → Reset.
+ * • Start of game → Opening Pan.
+ * • When the player prepares → Focus on Cue Ball.
+ * • Moment of the hit → Strike Tracking.
+ * • When the balls collide → Impact & Spread.
+ * • When a ball drops into a pocket → Potting Shot.
+ * • After each round → Reset.
  */
 const SHORT_RAIL_CAMERA_DISTANCE = PLAY_H / 2 + BALL_R * 12; // pull broadcast cams closer so the snooker table fills the frame
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // match short-rail framing so broadcast shots feel consistent
@@ -2898,7 +2898,7 @@ function applySnookerScaling({
   return { mmToUnits };
 }
 
-// Kamera: ruaj kënd komod që mos shtrihet poshtë cloth-it, por lejo pak më shumë lartësi kur ngrihet
+// Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
 const STANDING_VIEW_PHI = 0.86; // lift the default orbit a touch higher for a better overview
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.0024;
@@ -10259,7 +10259,7 @@ function SnookerGame() {
         );
       };
 
-      // Fire (slider e thërret në release)
+      // Fire (slider triggers on release)
       const fire = () => {
         const currentHud = hudRef.current;
         if (
@@ -11713,7 +11713,7 @@ function SnookerGame() {
             activeShotView = bestPocketView;
           }
         }
-        // Kapje në xhepa
+        // Pocket capture
         balls.forEach((b) => {
           if (!b.active) return;
           for (let pocketIndex = 0; pocketIndex < centers.length; pocketIndex++) {

--- a/webapp/src/pages/Games/TennisBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/TennisBattleRoyalLobby.jsx
@@ -111,13 +111,13 @@ export default function TennisBattleRoyalLobby() {
     <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
       <h2 className="text-xl font-bold text-center">3D Tennis Battle Royal Lobby</h2>
       <p className="text-sm text-subtext text-center">
-        Për momentin ndeshja luhet si Fundraising AI – stake TPC dhe merr pjesë në rally për të rritur pot-in e komunitetit.
+        For now the match runs as a Fundraising AI – stake TPC and rally to grow the community pot.
       </p>
       <div className="space-y-2">
         <h3 className="font-semibold">Modaliteti</h3>
         <div className="lobby-tile lobby-selected">Fundraising · Vs AI</div>
         <p className="text-xs text-subtext">
-          Stadiumi përdor shkallët, dhomat VIP dhe roof-in e rikrijuar nga përvoja jonë Free Kick 3D.
+          The stadium reuses the stands, VIP rooms, and roof recreated from our Free Kick 3D experience.
         </p>
       </div>
       <div className="space-y-2">
@@ -146,7 +146,7 @@ export default function TennisBattleRoyalLobby() {
                 alt="Your avatar"
                 className="h-12 w-12 rounded-full border border-border object-cover"
               />
-              <div className="text-sm text-subtext">Avatar-i dhe flamuri shfaqen në intro të ndeshjes.</div>
+              <div className="text-sm text-subtext">The avatar and flag appear in the match intro.</div>
             </div>
           )}
         </div>
@@ -155,7 +155,7 @@ export default function TennisBattleRoyalLobby() {
       <div className="space-y-2">
         <h3 className="font-semibold">AI Avatar Flags</h3>
         <p className="text-sm text-subtext">
-          Zgjidh flamurin e kundërshtarit AI – identik me përvojën Chess Battle Royal.
+          Choose the AI opponent flag – identical to the Chess Battle Royal experience.
         </p>
         <button
           type="button"
@@ -175,12 +175,12 @@ export default function TennisBattleRoyalLobby() {
         disabled={loading}
         className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded disabled:opacity-60"
       >
-        {loading ? 'Duke u përgatitur…' : 'Start Fundraising Rally'}
+        {loading ? 'Preparing…' : 'Start Fundraising Rally'}
       </button>
       <div className="space-y-2 pt-3 border-t border-border/60">
         <h3 className="font-semibold">Training</h3>
         <p className="text-xs text-subtext">
-          Luaj pa stake, mëso kontrollin me swipe dhe ndiq hapat e udhëzuesit në lojë para se të sfidosh AI-në.
+          Play without a stake, learn swipe controls, and follow the in-game guide steps before challenging the AI.
         </p>
         <button
           onClick={startTraining}

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -127,7 +127,7 @@ const WORLD_UP = new THREE.Vector3(0, 1, 0);
 const CHAIR_COLOR_OPTIONS = Object.freeze([
   {
     id: 'crimsonVelvet',
-    label: 'Kadife e Kuqe',
+    label: 'Crimson Velvet',
     primary: '#8b1538',
     accent: '#5c0f26',
     highlight: '#d35a7a',
@@ -135,7 +135,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'midnightNavy',
-    label: 'Blu Mesnate',
+    label: 'Midnight Blue',
     primary: '#153a8b',
     accent: '#0c214f',
     highlight: '#4d74d8',
@@ -143,7 +143,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'emeraldWave',
-    label: 'Valë Smerald',
+    label: 'Emerald Wave',
     primary: '#0f6a2f',
     accent: '#063d1b',
     highlight: '#48b26a',
@@ -151,7 +151,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'onyxShadow',
-    label: 'Hije Oniks',
+    label: 'Onyx Shadow',
     primary: '#202020',
     accent: '#101010',
     highlight: '#6f6f6f',
@@ -159,7 +159,7 @@ const CHAIR_COLOR_OPTIONS = Object.freeze([
   },
   {
     id: 'goldenHour',
-    label: 'Ar Pasdite',
+    label: 'Golden Hour',
     primary: '#8b5a1a',
     accent: '#4a2f0b',
     highlight: '#d8a85f',
@@ -300,11 +300,11 @@ const DEFAULT_APPEARANCE = {
 };
 
 const CUSTOMIZATION_SECTIONS = [
-  { key: 'tableWood', label: 'Dru i Tavolinës', options: TABLE_WOOD_OPTIONS },
-  { key: 'tableCloth', label: 'Rroba e Tavolinës', options: TABLE_CLOTH_OPTIONS },
-  { key: 'chairColor', label: 'Ngjyra e Karrigeve', options: CHAIR_COLOR_OPTIONS },
-  { key: 'tableShape', label: 'Forma e Tavolinës', options: TABLE_SHAPE_OPTIONS },
-  { key: 'cards', label: 'Letrat', options: CARD_THEMES }
+  { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },
+  { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
+  { key: 'chairColor', label: 'Chair Color', options: CHAIR_COLOR_OPTIONS },
+  { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS },
+  { key: 'cards', label: 'Cards', options: CARD_THEMES }
 ];
 
 const NON_DIAMOND_SHAPE_INDEX = (() => {
@@ -3117,7 +3117,7 @@ function TexasHoldemArena({ search }) {
               d="m19.4 13.5-.44 1.74a1 1 0 0 1-1.07.75l-1.33-.14a7.03 7.03 0 0 1-1.01.59l-.2 1.32a1 1 0 0 1-.98.84h-1.9a1 1 0 0 1-.98-.84l-.2-1.32a7.03 7.03 0 0 1-1.01-.59l-1.33.14a1 1 0 0 1-1.07-.75L4.6 13.5a1 1 0 0 1 .24-.96l1-.98a6.97 6.97 0 0 1 0-1.12l-1-.98a1 1 0 0 1-.24-.96l.44-1.74a1 1 0 0 1 1.07-.75l1.33.14c.32-.23.66-.43 1.01-.6l.2-1.31a1 1 0 0 1 .98-.84h1.9a1 1 0 0 1 .98.84l.2 1.31c.35.17.69.37 1.01.6l1.33-.14a1 1 0 0 1 1.07.75l.44 1.74a1 1 0 0 1-.24.96l-1 .98c.03.37.03.75 0 1.12l1 .98a1 1 0 0 1 .24.96z"
             />
           </svg>
-          <span className="sr-only">Hap personalizimin e tavolinës</span>
+          <span className="sr-only">Open table customization</span>
         </button>
         {configOpen && (
           <div className="pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur">

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -44,17 +44,17 @@ export default function Home() {
   const gamePreloads = [
     {
       name: 'Pool Royale preload',
-      description: 'Paketa tekstuale e kodit për animacionet dhe HUD-in e Pool Royale.',
+      description: 'Text bundle of code for Pool Royale animations and HUD.',
       href: `${baseUrl}game-preloads/pool-royale-preload.txt`
     },
     {
       name: '3D Snooker preload',
-      description: 'Snippet-et kryesore për fizikën e bilardos dhe kontrollat mobile +Y.',
+      description: 'Key snippets for billiards physics and +Y mobile controls.',
       href: `${baseUrl}game-preloads/3d-snooker-preload.txt`
     },
     {
       name: 'Tirana 2040 preload',
-      description: 'Paketa narrative + asset placeholders për mini-lojën Tirana 2040.',
+      description: 'Narrative bundle plus asset placeholders for the Tirana 2040 mini-game.',
       href: `${baseUrl}game-preloads/tirana-2040-preload.txt`
     }
   ];
@@ -248,7 +248,7 @@ export default function Home() {
         <div className="text-center space-y-1">
           <h3 className="text-lg font-semibold text-white">Preload game code (tekst)</h3>
           <p className="text-sm text-subtext">
-            Shkarkoni paketa tekstuale për lojërat kryesore që Tirana Hallway t’i cache-ojë më shpejt.
+            Download text bundles for the main games so Tirana Hallway can cache them faster.
           </p>
         </div>
         <div className="space-y-2">
@@ -263,7 +263,7 @@ export default function Home() {
                 download
                 className="mt-2 sm:mt-0 inline-flex items-center justify-center px-3 py-1.5 text-sm font-semibold bg-primary text-surface rounded-full shadow-primary/40 hover:shadow-primary/60 shadow"
               >
-                Shkarko paketën
+                Download bundle
               </a>
             </div>
           ))}

--- a/webapp/src/utils/cardThemes.js
+++ b/webapp/src/utils/cardThemes.js
@@ -23,7 +23,7 @@ export const CARD_THEMES = [
   },
   {
     id: 'nebula',
-    label: 'Nebulë',
+    label: 'Nebula',
     frontBackground: '#f8fafc',
     frontBorder: '#a855f7',
     edgeColor: '#e9d5ff',

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -11,7 +11,7 @@ import {
 
 const DEFAULT_TABLE_BASE_OPTION = Object.freeze({
   id: 'obsidian',
-  label: 'Bazë Obsidian',
+  label: 'Obsidian Base',
   baseColor: '#141414',
   columnColor: '#0b0d10',
   trimColor: '#1f232a',
@@ -28,7 +28,7 @@ const DEFAULT_TABLE_WOOD_OPTION = Object.freeze({
 
 export const DEFAULT_TABLE_CLOTH_OPTION = Object.freeze({
   id: 'emerald',
-  label: 'Rrobë Smerald',
+  label: 'Emerald Cloth',
   feltTop: '#0f6a2f',
   feltBottom: '#054d24',
   emissive: '#021a0b'

--- a/webapp/src/utils/tableCustomizationOptions.js
+++ b/webapp/src/utils/tableCustomizationOptions.js
@@ -16,18 +16,18 @@ export const TABLE_WOOD_OPTIONS = [
 ];
 
 export const TABLE_CLOTH_OPTIONS = [
-  { id: 'crimson', label: 'Rrobë e Kuqe', feltTop: '#960019', feltBottom: '#4a0012', emissive: '#210308' },
-  { id: 'emerald', label: 'Rrobë Smerald', feltTop: '#0f6a2f', feltBottom: '#054d24', emissive: '#021a0b' },
-  { id: 'arctic', label: 'Rrobë Akull', feltTop: '#2563eb', feltBottom: '#1d4ed8', emissive: '#071a42' },
-  { id: 'sunset', label: 'Rrobë Perëndim', feltTop: '#ea580c', feltBottom: '#c2410c', emissive: '#320e03' },
-  { id: 'violet', label: 'Rrobë Vjollcë', feltTop: '#7c3aed', feltBottom: '#5b21b6', emissive: '#1f0a47' },
-  { id: 'amber', label: 'Rrobë Qelibari', feltTop: '#b7791f', feltBottom: '#92571a', emissive: '#2b1402' }
+  { id: 'crimson', label: 'Crimson Cloth', feltTop: '#960019', feltBottom: '#4a0012', emissive: '#210308' },
+  { id: 'emerald', label: 'Emerald Cloth', feltTop: '#0f6a2f', feltBottom: '#054d24', emissive: '#021a0b' },
+  { id: 'arctic', label: 'Arctic Cloth', feltTop: '#2563eb', feltBottom: '#1d4ed8', emissive: '#071a42' },
+  { id: 'sunset', label: 'Sunset Cloth', feltTop: '#ea580c', feltBottom: '#c2410c', emissive: '#320e03' },
+  { id: 'violet', label: 'Violet Cloth', feltTop: '#7c3aed', feltBottom: '#5b21b6', emissive: '#1f0a47' },
+  { id: 'amber', label: 'Amber Cloth', feltTop: '#b7791f', feltBottom: '#92571a', emissive: '#2b1402' }
 ];
 
 export const TABLE_BASE_OPTIONS = [
   {
     id: 'obsidian',
-    label: 'Bazë Obsidian',
+    label: 'Obsidian Base',
     baseColor: '#141414',
     columnColor: '#0b0d10',
     trimColor: '#1f232a',
@@ -36,7 +36,7 @@ export const TABLE_BASE_OPTIONS = [
   },
   {
     id: 'forestBronze',
-    label: 'Bazë Pylli',
+    label: 'Forest Base',
     baseColor: '#101714',
     columnColor: '#0a0f0c',
     trimColor: '#1f2d24',
@@ -45,7 +45,7 @@ export const TABLE_BASE_OPTIONS = [
   },
   {
     id: 'midnightChrome',
-    label: 'Bazë Mesnate',
+    label: 'Midnight Base',
     baseColor: '#0f172a',
     columnColor: '#0a1020',
     trimColor: '#1e2f4a',
@@ -54,7 +54,7 @@ export const TABLE_BASE_OPTIONS = [
   },
   {
     id: 'emberCopper',
-    label: 'Bazë Bakri',
+    label: 'Copper Base',
     baseColor: '#231312',
     columnColor: '#140707',
     trimColor: '#5c2d1b',
@@ -63,7 +63,7 @@ export const TABLE_BASE_OPTIONS = [
   },
   {
     id: 'violetShadow',
-    label: 'Bazë Hije Vjollcë',
+    label: 'Violet Shadow Base',
     baseColor: '#1f1130',
     columnColor: '#130622',
     trimColor: '#3f1b5b',
@@ -72,7 +72,7 @@ export const TABLE_BASE_OPTIONS = [
   },
   {
     id: 'desertGold',
-    label: 'Bazë Shkretëtirë',
+    label: 'Desert Base',
     baseColor: '#1c1a12',
     columnColor: '#0f0d06',
     trimColor: '#5a4524',


### PR DESCRIPTION
## Summary
- Translate placeholder downloads and preload descriptions to English across public assets
- Update game UI strings, training prompts, and accessibility labels from Albanian to English in core components
- Align table customization option labels and theme names with English terminology across game arenas

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ff73de308328889f3a9a45bb4f76)