### PR TITLE
Improve air hockey avatars and lobby options

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -127,8 +127,8 @@ const POOL_ENVIRONMENT = (() => {
  * • Scoreboard with avatars
  */
 
-export default function AirHockey3D({ player, ai, target = 3, playType = 'regular' }) {
-  const targetValue = Number(target) || 3;
+export default function AirHockey3D({ player, ai, target = 11, playType = 'regular' }) {
+  const targetValue = Number(target) || 11;
   const hostRef = useRef(null);
   const raf = useRef(0);
   const [ui, setUi] = useState({ left: 0, right: 0 });
@@ -698,9 +698,9 @@ export default function AirHockey3D({ player, ai, target = 3, playType = 'regula
     ring(ringRadius, ringTube, -TABLE.h * 0.33);
     ring(ringRadius, ringTube, TABLE.h * 0.33);
     fieldAnchorsRef.current = {
-      ai: { x: 0, y: lineThickness * 0.6, z: -TABLE.h * 0.33 },
-      player: { x: 0, y: lineThickness * 0.6, z: TABLE.h * 0.33 },
-      size: 0.42 * SCALE_WIDTH
+      ai: { x: 0, y: railHeight * 1.05, z: -TABLE.h * 0.33 },
+      player: { x: 0, y: railHeight * 1.05, z: TABLE.h * 0.33 },
+      size: 0.48 * SCALE_WIDTH
     };
 
     const goalGeometry = new THREE.BoxGeometry(
@@ -1066,12 +1066,14 @@ export default function AirHockey3D({ player, ai, target = 3, playType = 'regula
         const material = new THREE.SpriteMaterial({
           map: texture,
           transparent: true,
-          depthWrite: false
+          depthWrite: false,
+          depthTest: false
         });
         const sprite = new THREE.Sprite(material);
         sprite.scale.set(anchors.size, anchors.size, 1);
         const target = anchors[key];
         sprite.position.set(target.x, target.y, target.z);
+        sprite.renderOrder = 10;
         tableGroup.add(sprite);
         avatarSpritesRef.current[key] = sprite;
       });
@@ -1198,16 +1200,19 @@ export default function AirHockey3D({ player, ai, target = 3, playType = 'regula
           onClick={() => setShowCustomizer((v) => !v)}
           className="rounded px-3 py-2 text-xs font-semibold text-white bg-white/10 hover:bg-white/20 backdrop-blur"
         >
-          {showCustomizer ? 'Mbyll personalizimin' : 'Personalizo lojën'}
+          <span className="inline-flex items-center gap-1">
+            <span aria-hidden>⚙️</span>
+            {showCustomizer ? 'Close customizer' : 'Customize table'}
+          </span>
         </button>
         {showCustomizer && (
           <div className="w-72 max-h-[70vh] overflow-y-auto bg-black/70 border border-white/15 rounded-lg p-3 space-y-3 backdrop-blur">
-            {renderOptionRow('Fusha', 'field')}
-            {renderOptionRow('Tavolina', 'table')}
-            {renderOptionRow('Tapat', 'puck')}
-            {renderOptionRow('Dorezat', 'mallet')}
-            {renderOptionRow('Anësoret', 'rails')}
-            {renderOptionRow('Portat', 'goals')}
+            {renderOptionRow('Field', 'field')}
+            {renderOptionRow('Table', 'table')}
+            {renderOptionRow('Puck', 'puck')}
+            {renderOptionRow('Mallets', 'mallet')}
+            {renderOptionRow('Rails', 'rails')}
+            {renderOptionRow('Goals', 'goals')}
           </div>
         )}
       </div>

--- a/webapp/src/pages/Games/AirHockey.jsx
+++ b/webapp/src/pages/Games/AirHockey.jsx
@@ -8,7 +8,7 @@ export default function AirHockey() {
   useTelegramBackButton();
   const { search } = useLocation();
   const params = new URLSearchParams(search);
-  const target = Number(params.get('target')) || 3;
+  const target = Number(params.get('target')) || 11;
   const playType = params.get('type') || 'regular';
   const playerFlagParam = params.get('flag');
   const aiFlagParam = params.get('aiFlag');

--- a/webapp/src/pages/Games/AirHockeyLobby.jsx
+++ b/webapp/src/pages/Games/AirHockeyLobby.jsx
@@ -23,7 +23,7 @@ export default function AirHockeyLobby() {
 
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState('ai');
-  const [goal, setGoal] = useState(3);
+  const [goal, setGoal] = useState(11);
   const [playType, setPlayType] = useState('regular');
   const [players, setPlayers] = useState(8);
   const [avatar, setAvatar] = useState('');
@@ -162,7 +162,7 @@ export default function AirHockeyLobby() {
       <div className="space-y-2">
         <h3 className="font-semibold">Goals</h3>
         <div className="flex gap-2">
-          {[3, 5, 10].map((g) => (
+          {[11, 21, 31].map((g) => (
             <button
               key={g}
               onClick={() => setGoal(g)}


### PR DESCRIPTION
## Summary
- raise and render air hockey field avatars above the rails for consistent visibility and set English customization controls with a gear icon
- default the air hockey target score to 11 and translate the table customization labels
- limit lobby goal options to 11, 21, or 31 points to match the new default

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69240e70ed3c8320b8cd8c2668e486f8)