### PR TITLE
Set default lighting and broadcast rigs for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -388,7 +388,7 @@ const CHROME_CORNER_FIELD_EXTENSION_SCALE = 0; // keep fascia depth identical to
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1; // no scaling so the notch mirrors the pocket radius perfectly
 const CHROME_CORNER_DIMENSION_SCALE = 1; // keep the fascia dimensions identical to the cushion span so both surfaces meet cleanly
 const CHROME_CORNER_WIDTH_SCALE = 0.982; // shave the chrome plate slightly so it ends at the jaw line on the long rail
-const CHROME_CORNER_HEIGHT_SCALE = 0.962; // mirror the trim on the short rail so the fascia meets the jaw corner without overlap
+const CHROME_CORNER_HEIGHT_SCALE = 1.02; // lift fascia slightly so chrome plates stand taller along the corners
 const CHROME_CORNER_CENTER_OUTSET_SCALE = -0.008; // pull the corner fascia slightly toward the table centre so the chrome hugs the jaws
 const CHROME_CORNER_SHORT_RAIL_SHIFT_SCALE = 0; // let the corner fascia terminate precisely where the cushion noses stop
 const CHROME_CORNER_SHORT_RAIL_CENTER_PULL_SCALE = 0; // stop pulling the chrome off the short-rail centreline so the jaws stay flush
@@ -403,11 +403,11 @@ const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85; // reuse snooker notch height profi
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1;
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1; // keep the notch depth identical to the pocket cylinder so the chrome kisses the jaw edge
 const CHROME_SIDE_FIELD_PULL_SCALE = 0;
-const CHROME_PLATE_THICKNESS_SCALE = 0.034; // match snooker fascia depth for consistent chrome heft at the pockets
+const CHROME_PLATE_THICKNESS_SCALE = 0.0306; // align fascia depth with the diamond markers for consistent sponsor thickness
 const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.08; // give the middle fascias a subtle lift for extra depth like the snooker table
 const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually above the wood rails without z-fighting
 const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.58; // push the side fascia farther along the arch so it blankets the larger chrome reveal
-const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.52; // align fascia reach with snooker so the arch covers the relieved cut without overhang
+const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.6; // raise side fascia height to match the lifted chrome reveal
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.46; // mirror snooker fascia width so both edges flow into the rails cleanly
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
@@ -1999,26 +1999,8 @@ const resolveRailMarkerColorOption = (id) =>
   RAIL_MARKER_COLOR_OPTIONS.find((opt) => opt.id === DEFAULT_RAIL_MARKER_COLOR_ID) ??
   RAIL_MARKER_COLOR_OPTIONS[0];
 
-const DEFAULT_LIGHTING_ID = 'studio-soft';
-const LIGHTING_STORAGE_KEY = 'poolLightingPreset';
+const DEFAULT_LIGHTING_ID = 'arena-prime';
 const LIGHTING_OPTIONS = Object.freeze([
-  {
-    id: 'studio-soft',
-    label: 'Studio Soft',
-    description: 'Gentle TV studio fill with reduced contrast for practice.',
-    settings: {
-      hemiSky: 0xe3ecff,
-      hemiGround: 0x0c101c,
-      hemiIntensity: 1.02,
-      rimIntensity: 0.62,
-      dirColor: 0xf5f7fb,
-      dirIntensity: 1.2,
-      spotColor: 0xfafcff,
-      spotIntensity: 9.6,
-      spotAngle: Math.PI * 0.4,
-      ambientIntensity: 0.14
-    }
-  },
   {
     id: 'arena-prime',
     label: 'Arena Prime',
@@ -2034,40 +2016,6 @@ const LIGHTING_OPTIONS = Object.freeze([
       spotIntensity: 11.4,
       spotAngle: Math.PI * 0.36,
       ambientIntensity: 0.16
-    }
-  },
-  {
-    id: 'proscenium-contrast',
-    label: 'Proscenium Contrast',
-    description: 'High-contrast stage look with tight rim control.',
-    settings: {
-      hemiSky: 0xd8e3ff,
-      hemiGround: 0x0b0f1c,
-      hemiIntensity: 0.96,
-      rimIntensity: 0.9,
-      dirColor: 0xf2f5ff,
-      dirIntensity: 1.58,
-      spotColor: 0xf7fbff,
-      spotIntensity: 12.2,
-      spotAngle: Math.PI * 0.34,
-      ambientIntensity: 0.12
-    }
-  },
-  {
-    id: 'noir-telecast',
-    label: 'Noir Telecast',
-    description: 'Cool broadcast grade with soft rim and wider beam.',
-    settings: {
-      hemiSky: 0xcfd9ec,
-      hemiGround: 0x0c111c,
-      hemiIntensity: 1,
-      rimIntensity: 0.82,
-      dirColor: 0xeaf1ff,
-      dirIntensity: 1.28,
-      spotColor: 0xf5f8ff,
-      spotIntensity: 10.2,
-      spotAngle: Math.PI * 0.42,
-      ambientIntensity: 0.18
     }
   }
 ]);
@@ -2090,19 +2038,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
 ]);
 const DEFAULT_FRAME_RATE_ID = 'balanced60';
 
-const BROADCAST_SYSTEM_STORAGE_KEY = 'poolBroadcastSystem';
 const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
-  {
-    id: 'arena-railcam',
-    label: 'Arena RailCam',
-    description: 'Championship rail ride with shoulder-led pans.',
-    railPush: BALL_R * 6.8,
-    lateralDolly: BALL_R * 1.8,
-    focusLift: BALL_R * 1.4,
-    focusPan: BALL_R * 0.28,
-    trackingBias: 0.38,
-    smoothing: 0.14
-  },
   {
     id: 'skybox-truss',
     label: 'Skybox TrussCam',
@@ -2113,40 +2049,6 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
     focusDepthBias: BALL_R * 2.4,
     trackingBias: 0.58,
     smoothing: 0.16
-  },
-  {
-    id: 'cine-dolly',
-    label: 'Cine Dolly Track',
-    description: 'Broadcast dolly track with filmic slide offsets.',
-    railPush: BALL_R * 7.4,
-    lateralDolly: BALL_R * 2.6,
-    focusLift: BALL_R * 2.8,
-    focusDepthBias: BALL_R * 1.6,
-    focusPan: BALL_R * 0.36,
-    trackingBias: 0.52,
-    smoothing: 0.18
-  },
-  {
-    id: 'immersive-rail',
-    label: 'Immersive Rail Follow',
-    description: 'Low esports follow that hugs the cushions closely.',
-    railPush: BALL_R * 3.8,
-    lateralDolly: BALL_R * 1.2,
-    focusLift: BALL_R * 0.9,
-    focusPan: BALL_R * 0.46,
-    trackingBias: 0.72,
-    smoothing: 0.22
-  },
-  {
-    id: 'analyst-overhead',
-    label: 'Analyst Overhead',
-    description: 'Coach-box overhead track with measured drift.',
-    railPush: BALL_R * 5.8,
-    lateralDolly: BALL_R * 1.5,
-    focusLift: BALL_R * 4.6,
-    focusDepthBias: BALL_R * 1.1,
-    trackingBias: 0.48,
-    smoothing: 0.12
   }
 ]);
 const DEFAULT_BROADCAST_SYSTEM_ID = BROADCAST_SYSTEM_OPTIONS[0].id;
@@ -7947,15 +7849,7 @@ function PoolRoyaleGame({
     }
     return DEFAULT_RAIL_MARKER_COLOR_ID;
   });
-  const [lightingId, setLightingId] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem(LIGHTING_STORAGE_KEY);
-      if (stored && LIGHTING_OPTIONS.some((opt) => opt.id === stored)) {
-        return stored;
-      }
-    }
-    return DEFAULT_LIGHTING_ID;
-  });
+  const lightingId = DEFAULT_LIGHTING_ID;
   const [chromeColorId, setChromeColorId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem('poolChromeColor');
@@ -7978,15 +7872,6 @@ function PoolRoyaleGame({
     }
     return DEFAULT_FRAME_RATE_ID;
   });
-  const [broadcastSystemId, setBroadcastSystemId] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem(BROADCAST_SYSTEM_STORAGE_KEY);
-      if (stored && BROADCAST_SYSTEM_OPTIONS.some((opt) => opt.id === stored)) {
-        return stored;
-      }
-    }
-    return DEFAULT_BROADCAST_SYSTEM_ID;
-  });
   const activeFrameRateOption = useMemo(
     () =>
       FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ??
@@ -7994,8 +7879,8 @@ function PoolRoyaleGame({
     [frameRateId]
   );
   const activeBroadcastSystem = useMemo(
-    () => resolveBroadcastSystem(broadcastSystemId),
-    [broadcastSystemId]
+    () => resolveBroadcastSystem(DEFAULT_BROADCAST_SYSTEM_ID),
+    []
   );
   const activeChromeOption = useMemo(
     () => CHROME_COLOR_OPTIONS.find((opt) => opt.id === chromeColorId) ?? CHROME_COLOR_OPTIONS[0],
@@ -8358,10 +8243,6 @@ function PoolRoyaleGame({
     window.localStorage.setItem('poolRailMarkerColor', railMarkerColorId);
   }, [railMarkerColorId]);
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    window.localStorage.setItem(LIGHTING_STORAGE_KEY, lightingId);
-  }, [lightingId]);
-  useEffect(() => {
     applyRailMarkerStyleRef.current?.(railMarkerStyleRef.current);
   }, [railMarkerColorId, railMarkerShapeId]);
   const tableFinish = useMemo(() => {
@@ -8452,11 +8333,6 @@ function PoolRoyaleGame({
       window.localStorage.setItem(FRAME_RATE_STORAGE_KEY, frameRateId);
     }
   }, [frameRateId]);
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(BROADCAST_SYSTEM_STORAGE_KEY, broadcastSystemId);
-    }
-  }, [broadcastSystemId]);
   useEffect(() => {
     if (!configOpen) return undefined;
     const handleKeyDown = (event) => {
@@ -8642,7 +8518,7 @@ function PoolRoyaleGame({
   }, [applySliderLock, hud.turn, hud.over, shotActive]);
 
   const applyLightingPreset = useCallback(
-    (presetId = lightingId) => {
+    (presetId = DEFAULT_LIGHTING_ID) => {
       const rig = lightingRigRef.current;
       const world = worldRef.current;
       if (!rig || !world) return;
@@ -8672,12 +8548,12 @@ function PoolRoyaleGame({
       if (settings.ambientIntensity && ambient)
         ambient.intensity = settings.ambientIntensity;
     },
-    [lightingId]
+    []
   );
 
   useEffect(() => {
-    applyLightingPreset(lightingId);
-  }, [applyLightingPreset, lightingId]);
+    applyLightingPreset(DEFAULT_LIGHTING_ID);
+  }, [applyLightingPreset]);
   const [err, setErr] = useState(null);
   const fireRef = useRef(() => {}); // set from effect so slider can trigger fire()
   const cameraRef = useRef(null);
@@ -15905,70 +15781,6 @@ function PoolRoyaleGame({
                           />
                           {option.label}
                         </span>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Lighting
-                </h3>
-                <div className="mt-2 grid gap-2">
-                  {LIGHTING_OPTIONS.map((option) => {
-                    const active = option.id === lightingId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setLightingId(option.id)}
-                        aria-pressed={active}
-                        className={`w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
-                          {option.label}
-                        </span>
-                        {option.description ? (
-                          <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
-                            {option.description}
-                          </span>
-                        ) : null}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Broadcast System
-                </h3>
-                <div className="mt-2 grid gap-2">
-                  {BROADCAST_SYSTEM_OPTIONS.map((option) => {
-                    const active = option.id === broadcastSystemId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setBroadcastSystemId(option.id)}
-                        aria-pressed={active}
-                        className={`w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
-                          {option.label}
-                        </span>
-                        {option.description ? (
-                          <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
-                            {option.description}
-                          </span>
-                        ) : null}
                       </button>
                     );
                   })}


### PR DESCRIPTION
## Summary
- default Pool Royale lighting to Arena Prime and remove menu switching
- lock broadcast camera to Skybox TrussCam and drop alternative systems
- raise chrome plate proportions while matching diamond marker thickness

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69240f67944c8320a5fd98eec634a881)