### PR TITLE
Enhance pool rules and chalk orientation

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -4,12 +4,27 @@ export class AmericanBilliards {
       ballsOnTable: new Set(Array.from({ length: 15 }, (_, i) => i + 1)),
       currentPlayer: 'A',
       scores: { A: 0, B: 0 },
-      ballInHand: false
+      ballInHand: false,
+      foulStreak: { A: 0, B: 0 },
+      frameOver: false,
+      winner: null
     };
   }
 
   shotTaken (shot) {
     const s = this.state;
+    if (s.frameOver) {
+      return {
+        legal: false,
+        foul: true,
+        reason: 'frame over',
+        potted: [],
+        nextPlayer: s.currentPlayer,
+        ballInHandNext: false,
+        frameOver: true,
+        winner: s.winner
+      };
+    }
     const current = s.currentPlayer;
     const opp = current === 'A' ? 'B' : 'A';
     const lowest = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
@@ -17,6 +32,11 @@ export class AmericanBilliards {
     let reason = '';
 
     const first = shot.contactOrder && shot.contactOrder[0];
+    if (!foul && !first) {
+      foul = true;
+      reason = 'no contact';
+    }
+
     if (!foul && first !== lowest) {
       foul = true;
       reason = 'wrong first contact';
@@ -27,20 +47,38 @@ export class AmericanBilliards {
       reason = 'scratch';
     }
 
+    if (!foul && shot.noCushionAfterContact && shot.potted.length === 0) {
+      foul = true;
+      reason = 'no cushion';
+    }
+
     const pottedBalls = shot.potted.filter(id => id !== 0);
     const points = pottedBalls.reduce((a, b) => a + b, 0);
 
     let nextPlayer = current;
     let ballInHandNext = false;
+    let frameOver = false;
+    let winner = null;
+    const targetScore = 61;
+
+    const spotPotted = () => {
+      for (const id of pottedBalls) s.ballsOnTable.add(id);
+    };
 
     if (foul) {
-      s.scores[opp] += points;
+      s.scores[current] = Math.max(0, s.scores[current] - 1);
+      s.scores[opp] += 1;
+      spotPotted();
       nextPlayer = opp;
       s.currentPlayer = opp;
       ballInHandNext = true;
+      s.foulStreak[current] = (s.foulStreak[current] ?? 0) + 1;
+      s.foulStreak[opp] = 0;
     } else {
       for (const id of pottedBalls) s.ballsOnTable.delete(id);
       s.scores[current] += points;
+      s.foulStreak[current] = 0;
+      s.foulStreak[opp] = 0;
       if (pottedBalls.length === 0) {
         nextPlayer = opp;
         s.currentPlayer = opp;
@@ -50,6 +88,15 @@ export class AmericanBilliards {
     s.ballInHand = ballInHandNext;
     const nextBall = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
 
+    if (s.scores[current] >= targetScore || s.scores[opp] >= targetScore || s.ballsOnTable.size === 0) {
+      frameOver = true;
+      if (s.scores[current] > s.scores[opp]) winner = current;
+      else if (s.scores[opp] > s.scores[current]) winner = opp;
+      else winner = 'TIE';
+      s.frameOver = true;
+      s.winner = winner;
+    }
+
     return {
       legal: !foul,
       foul,
@@ -58,7 +105,9 @@ export class AmericanBilliards {
       nextPlayer,
       ballInHandNext,
       scores: { ...s.scores },
-      currentBall: nextBall
+      currentBall: nextBall,
+      frameOver,
+      winner
     };
   }
 }

--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -9,7 +9,8 @@ export class NineBall {
       currentPlayer: 'A',
       ballInHand: false,
       gameOver: false,
-      winner: null
+      winner: null,
+      foulStreak: { A: 0, B: 0 }
     };
   }
 
@@ -25,6 +26,11 @@ export class NineBall {
     let reason = '';
 
     const first = shot.contactOrder && shot.contactOrder[0];
+    if (!foul && !first) {
+      foul = true;
+      reason = 'no contact';
+    }
+
     if (!foul && first !== lowest) {
       foul = true;
       reason = 'wrong first contact';
@@ -35,20 +41,29 @@ export class NineBall {
       reason = 'scratch';
     }
 
+    if (!foul && shot.noCushionAfterContact && shot.potted.length === 0) {
+      foul = true;
+      reason = 'no cushion';
+    }
+
     const pottedBalls = shot.potted.filter(id => id !== 0);
 
     let nextPlayer = current;
     let ballInHandNext = false;
     let frameOver = false;
     let winner = null;
+    const foulLimit = 3;
 
     if (foul) {
       nextPlayer = opp;
       ballInHandNext = true;
       s.currentPlayer = opp;
-      s.ballInHand = true;
+      s.foulStreak[current] = (s.foulStreak[current] ?? 0) + 1;
+      s.foulStreak[opp] = 0;
     } else {
       for (const id of pottedBalls) s.ballsOnTable.delete(id);
+      s.foulStreak[current] = 0;
+      s.foulStreak[opp] = 0;
       if (pottedBalls.includes(9)) {
         frameOver = true;
         winner = current;
@@ -61,7 +76,15 @@ export class NineBall {
         nextPlayer = opp;
         s.currentPlayer = opp;
       }
-      s.ballInHand = false;
+    }
+
+    s.ballInHand = ballInHandNext;
+
+    if (!frameOver && s.foulStreak[current] >= foulLimit) {
+      frameOver = true;
+      winner = opp;
+      s.gameOver = true;
+      s.winner = winner;
     }
 
     return {

--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -69,6 +69,7 @@ export class UkPool {
     const oppGroup = s.assignments[opp];
     let foul = false;
     let reason = '';
+    const scratched = shot.potted.includes('cue') || shot.cueOffTable;
 
     const first = shot.contactOrder && shot.contactOrder[0];
     const isBreak = s.lastEvent === 'BREAK_START' || s.lastEvent === null;
@@ -87,7 +88,7 @@ export class UkPool {
     }
 
     // scratch
-    if (!foul && (shot.potted.includes('cue') || shot.cueOffTable)) {
+    if (!foul && scratched) {
       foul = true;
       reason = 'scratch';
     }
@@ -209,7 +210,7 @@ export class UkPool {
       shotsNext = 2;
       s.currentPlayer = nextPlayer;
       s.shotsRemaining = shotsNext;
-      s.mustPlayFromBaulk = true;
+      s.mustPlayFromBaulk = scratched;
       s.lastEvent = 'FOUL';
       if (blackPotted) {
         frameOver = true;


### PR DESCRIPTION
## Summary
- implement official rotation scoring, foul handling, and ball-in-hand logic for American billiards and 9-ball, including cushion and no-contact fouls plus foul streak tracking
- align UK 8-ball baulk placement and fouls with official rules and sync in-hand HUD state to allow shooting in training and rotation modes
- correct chalk orientation so the top faces upward and renders brightly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69242011f8748320bf37afb389fea043)