### PR TITLE
Align pocket cloth edges with cloth texture

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5353,8 +5353,6 @@ function Table3D(
   clothEdgeMat.clearcoat = 0;
   clothEdgeMat.clearcoatRoughness = 1;
   clothEdgeMat.sheen = 0;
-  clothEdgeMat.map = null;
-  clothEdgeMat.bumpMap = null;
   const clothBaseSettings = {
     roughness: clothMat.roughness,
     sheen: clothMat.sheen,


### PR DESCRIPTION
## Summary
- keep pocket cloth edge material textures to match the main cloth tone

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924672b87208320a2b1d6c08b8312c4)