### PR TITLE
Fix pool royale JSX and Three color spaces

### DIFF
--- a/webapp/src/components/TennisBattleRoyal3D.jsx
+++ b/webapp/src/components/TennisBattleRoyal3D.jsx
@@ -357,8 +357,7 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
     let H = Math.max(1, container.clientHeight || window.innerHeight || 640);
     renderer.setSize(W, H);
     renderer.setPixelRatio(Math.min(1.5, window.devicePixelRatio || 1));
-    if ('outputColorSpace' in renderer) renderer.outputColorSpace = THREE.SRGBColorSpace;
-    else renderer.outputEncoding = THREE.sRGBEncoding;
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
     renderer.toneMappingExposure = 1.55;
     renderer.shadowMap.enabled = false;
@@ -481,8 +480,7 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
         const tex = new THREE.CanvasTexture(base);
         tex.anisotropy = Math.min(16, maxAniso);
         tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
-        if ('colorSpace' in tex) tex.colorSpace = THREE.SRGBColorSpace;
-        else tex.encoding = THREE.sRGBEncoding;
+        tex.colorSpace = THREE.SRGBColorSpace;
         tex.repeat.set(8, 18);
         onReady(tex);
       };
@@ -567,8 +565,7 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
       const t = new THREE.CanvasTexture(c);
       t.anisotropy = Math.min(16, maxAniso);
       t.wrapS = t.wrapT = THREE.RepeatWrapping;
-      if ('colorSpace' in t) t.colorSpace = THREE.SRGBColorSpace;
-      else t.encoding = THREE.sRGBEncoding;
+      t.colorSpace = THREE.SRGBColorSpace;
       t.repeat.set(1, 1);
       return t;
     }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -16163,12 +16163,10 @@ function PoolRoyaleGame({
             ></div>
           </div>
         </div>
-      )}
-
-      )}
-    </div>
-  );
-}
+        )}
+      </div>
+    );
+  }
 
 export default function PoolRoyale() {
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- fix the PoolRoyale spin controller markup so the component renders without JSX syntax errors
- update the TennisBattleRoyal renderer and textures to use SRGB color space settings compatible with the current three.js version

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246d66d688832088e281cbc3c82a86)