### PR TITLE
Enable scrolling in Tennis Battle Royal menu

### DIFF
--- a/webapp/src/components/TennisBattleRoyal3D.jsx
+++ b/webapp/src/components/TennisBattleRoyal3D.jsx
@@ -2668,7 +2668,11 @@ export default function TennisBattleRoyal3D({ playerName, stakeLabel, trainingMo
               display: 'flex',
               flexDirection: 'column',
               gap: 12,
-              pointerEvents: 'auto'
+              pointerEvents: 'auto',
+              maxHeight: '72vh',
+              overflowY: 'auto',
+              overscrollBehavior: 'contain',
+              scrollbarWidth: 'thin'
             }}
           >
             {[{ title: 'Broadcast Techniques', data: BROADCAST_TECHNIQUES, active: broadcastId, setter: setBroadcastId }, { title: 'Ball Logic & Physics', data: PHYSICS_PROFILES, active: physicsId, setter: setPhysicsId }, { title: 'Touch Control Modes', data: TOUCH_TECHNIQUES, active: touchId, setter: setTouchId }].map((section) => (


### PR DESCRIPTION
## Summary
- allow the Tennis Battle Royal configuration menu to scroll vertically
- limit menu height to prevent clipping on smaller viewports

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69247edeb4008328ad2c48a3ea19412e)