### PR TITLE
Make cloth underlay matte and color-matched

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5638,26 +5638,18 @@ function Table3D(
   underlayMat.depthWrite = true;
   underlayMat.colorWrite = true;
   underlayMat.metalness = 0;
-  underlayMat.clearcoat = clothMat.clearcoat;
-  underlayMat.clearcoatRoughness = clothMat.clearcoatRoughness;
-  underlayMat.roughness = clothMat.roughness;
-  underlayMat.emissive.copy(clothMat.emissive);
-  underlayMat.emissiveIntensity = clothMat.emissiveIntensity;
-  if (underlayMat.map && clothMat.map) {
-    underlayMat.map.repeat.copy(clothMat.map.repeat);
-    underlayMat.map.center.copy(clothMat.map.center ?? underlayMat.map.center);
-    underlayMat.map.rotation = clothMat.map.rotation ?? underlayMat.map.rotation ?? 0;
-    underlayMat.map.needsUpdate = true;
-  }
-  if (underlayMat.bumpMap && clothMat.bumpMap) {
-    underlayMat.bumpMap.repeat.copy(clothMat.bumpMap.repeat);
-    underlayMat.bumpScale = clothMat.bumpScale;
-    underlayMat.bumpMap.center.copy(clothMat.bumpMap.center ?? underlayMat.bumpMap.center);
-    underlayMat.bumpMap.rotation = clothMat.bumpMap.rotation ?? underlayMat.bumpMap.rotation ?? 0;
-    underlayMat.bumpMap.needsUpdate = true;
-  } else {
-    underlayMat.bumpScale = clothMat.bumpScale;
-  }
+  underlayMat.clearcoat = 0;
+  underlayMat.clearcoatRoughness = 1;
+  underlayMat.roughness = 1;
+  underlayMat.sheen = 0;
+  underlayMat.sheenRoughness = 1;
+  underlayMat.envMapIntensity = 0;
+  underlayMat.emissive.set(clothMat.color);
+  underlayMat.emissiveIntensity = 0;
+  underlayMat.color.copy(clothMat.color);
+  underlayMat.map = null;
+  underlayMat.bumpMap = null;
+  underlayMat.needsUpdate = true;
   const clothUnderlay = new THREE.Mesh(underlayGeo, underlayMat);
   clothUnderlay.rotation.x = -Math.PI / 2;
   clothUnderlay.position.y =


### PR DESCRIPTION
## Summary
- align the cloth underlay color directly with the felt and drop texture use
- remove sheen, clearcoat, and reflections so the wood panel beneath the cloth renders as a matte surface

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a270b5ec8328a4752677be25b738)