### PR TITLE
Add thin shadow board beneath Pool Royale cloth

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -841,6 +841,8 @@ const CLOTH_UNDERLAY_GAP = TABLE.THICK * 0.02; // legacy gap kept so the cloth p
 const CLOTH_UNDERLAY_EXTRA_DROP = TABLE.THICK * 0.032; // legacy drop retained to keep pocket sleeves occupying the same space
 const CLOTH_EXTENDED_DEPTH =
   CLOTH_THICKNESS + CLOTH_UNDERLAY_GAP + CLOTH_UNDERLAY_EXTRA_DROP + CLOTH_UNDERLAY_THICKNESS; // wrap the cloth down to replace the removed underlay
+const CLOTH_SHADOW_BOARD_THICKNESS = TABLE.THICK * 0.06; // ultra-thin black wooden board to help catch shadows beneath the felt
+const CLOTH_SHADOW_BOARD_GAP = TABLE.THICK * 0.01; // small offset so the board sits just under the cloth without z-fighting
 const CLOTH_SHADOW_COVER_THICKNESS = TABLE.THICK * 0.14; // concealed wooden cover that blocks direct light spill onto the carpet
 const CLOTH_SHADOW_COVER_GAP = TABLE.THICK * 0.035; // keep a slim air gap so dropped balls pass cleanly into the pockets
 const CLOTH_SHADOW_COVER_EDGE_INSET = TABLE.THICK * 0.02; // tuck the shadow cover inside the cushion line so it remains hidden
@@ -5619,6 +5621,25 @@ function Table3D(
   cloth.renderOrder = 3;
   cloth.receiveShadow = true;
   table.add(cloth);
+  const shadowBoardGeo = new THREE.ExtrudeGeometry(clothShape, {
+    depth: CLOTH_SHADOW_BOARD_THICKNESS,
+    bevelEnabled: false,
+    curveSegments: 80,
+    steps: 1
+  });
+  shadowBoardGeo.translate(0, 0, -CLOTH_SHADOW_BOARD_THICKNESS);
+  const shadowBoardMat = railMat.clone();
+  shadowBoardMat.color = new THREE.Color(0x080808);
+  shadowBoardMat.roughness = Math.min(1, (shadowBoardMat.roughness ?? 0.68) * 1.12);
+  shadowBoardMat.metalness = Math.max(0, (shadowBoardMat.metalness ?? 0.08) * 0.42);
+  shadowBoardMat.needsUpdate = true;
+  const shadowBoard = new THREE.Mesh(shadowBoardGeo, shadowBoardMat);
+  shadowBoard.rotation.x = -Math.PI / 2;
+  shadowBoard.position.y = cloth.position.y - CLOTH_SHADOW_BOARD_GAP;
+  shadowBoard.renderOrder = cloth.renderOrder - 1.5;
+  shadowBoard.receiveShadow = true;
+  shadowBoard.castShadow = false;
+  table.add(shadowBoard);
   const clothBottomY = cloth.position.y - CLOTH_EXTENDED_DEPTH;
   const clothEdgeTopY = cloth.position.y - MICRO_EPS;
   const clothEdgeBottomY = clothBottomY - MICRO_EPS;


### PR DESCRIPTION
## Summary
- add ultra-thin black wooden board beneath the Pool Royale cloth to restore visible table shadows
- tune board material and placement to avoid z-fighting while matching cloth footprint

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924b7fa739c8328bc7651e64a632417)