### PR TITLE
Remove extra cloth layers

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5608,17 +5608,6 @@ function Table3D(
   };
 
   const clothShape = buildSurfaceShape(POCKET_HOLE_R);
-  const clothUnderlayShape = (() => {
-    const insetHalfW = Math.max(MICRO_EPS, halfWext - CLOTH_UNDERLAY_GAP * 0.5);
-    const insetHalfH = Math.max(MICRO_EPS, halfHext - CLOTH_UNDERLAY_GAP * 0.5);
-    const shape = new THREE.Shape();
-    shape.moveTo(-insetHalfW, -insetHalfH);
-    shape.lineTo(insetHalfW, -insetHalfH);
-    shape.lineTo(insetHalfW, insetHalfH);
-    shape.lineTo(-insetHalfW, insetHalfH);
-    shape.lineTo(-insetHalfW, -insetHalfH);
-    return shape;
-  })();
   const clothGeo = new THREE.ExtrudeGeometry(clothShape, {
     depth: CLOTH_EXTENDED_DEPTH,
     bevelEnabled: false,
@@ -5632,29 +5621,6 @@ function Table3D(
   cloth.renderOrder = 3;
   cloth.receiveShadow = true;
   table.add(cloth);
-  const clothUnderlayDepth = Math.max(MICRO_EPS, CLOTH_UNDERLAY_THICKNESS);
-  const clothUnderlayGeo = new THREE.ExtrudeGeometry(clothUnderlayShape, {
-    depth: clothUnderlayDepth,
-    bevelEnabled: false,
-    curveSegments: 64,
-    steps: 1
-  });
-  clothUnderlayGeo.translate(0, 0, -clothUnderlayDepth);
-  const clothUnderlayMat = clothMat.clone();
-  clothUnderlayMat.color.copy(clothMat.color);
-  clothUnderlayMat.emissive.copy(clothMat.emissive);
-  clothUnderlayMat.side = THREE.DoubleSide;
-  clothUnderlayMat.polygonOffset = true;
-  clothUnderlayMat.polygonOffsetFactor = 0.5;
-  clothUnderlayMat.polygonOffsetUnits = 0.5;
-  clothUnderlayMat.needsUpdate = true;
-  const clothUnderlay = new THREE.Mesh(clothUnderlayGeo, clothUnderlayMat);
-  clothUnderlay.rotation.x = -Math.PI / 2;
-  clothUnderlay.position.y = cloth.position.y - CLOTH_UNDERLAY_GAP;
-  clothUnderlay.renderOrder = cloth.renderOrder - 1;
-  clothUnderlay.receiveShadow = true;
-  clothUnderlay.castShadow = false;
-  table.add(clothUnderlay);
   const shadowBoardGeo = new THREE.ExtrudeGeometry(clothShape, {
     depth: CLOTH_SHADOW_BOARD_THICKNESS,
     bevelEnabled: false,

--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -4156,6 +4156,7 @@ function Table3D(
     emissive: clothColor.clone().multiplyScalar(0.08),
     emissiveIntensity: 0.58
   });
+  clothMat.side = THREE.DoubleSide;
   const ballDiameter = BALL_R * 2;
   const ballsAcrossWidth = PLAY_W / ballDiameter;
   const threadsPerBallTarget = 10; // tighten the weave slightly while keeping detail visible
@@ -4457,36 +4458,6 @@ function Table3D(
   cloth.renderOrder = 3;
   cloth.receiveShadow = true;
   table.add(cloth);
-
-  const underlayShape = buildSurfaceShape(
-    POCKET_HOLE_R * CLOTH_UNDERLAY_HOLE_SCALE,
-    CLOTH_UNDERLAY_EDGE_INSET
-  );
-  const underlayGeo = new THREE.ExtrudeGeometry(underlayShape, {
-    depth: CLOTH_UNDERLAY_THICKNESS,
-    bevelEnabled: false,
-    curveSegments: 48,
-    steps: 1
-  });
-  underlayGeo.translate(0, 0, -CLOTH_UNDERLAY_THICKNESS);
-  const underlayMat = new THREE.MeshStandardMaterial({
-    color: 0x8b6f4a,
-    roughness: 0.68,
-    metalness: 0.05,
-    side: THREE.DoubleSide
-  });
-  underlayMat.transparent = true;
-  underlayMat.opacity = 0;
-  underlayMat.depthWrite = true;
-  underlayMat.colorWrite = false; // remain invisible while still blocking light for full table shadows
-  const clothUnderlay = new THREE.Mesh(underlayGeo, underlayMat);
-  clothUnderlay.rotation.x = -Math.PI / 2;
-  clothUnderlay.position.y =
-    cloth.position.y - CLOTH_THICKNESS - CLOTH_UNDERLAY_GAP;
-  clothUnderlay.castShadow = true;
-  clothUnderlay.receiveShadow = true;
-  clothUnderlay.renderOrder = cloth.renderOrder - 1;
-  table.add(clothUnderlay);
 
   const markingsGroup = new THREE.Group();
   const markingMat = new THREE.MeshBasicMaterial({


### PR DESCRIPTION
## Summary
- remove secondary cloth underlays from Pool Royale and Snooker tables
- make snooker cloth double-sided to prevent light leaks while keeping pocket cutouts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c8a377b08328970fe52d9964142c)