### PR TITLE
Add cloth textures to pocket edge material

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2831,9 +2831,11 @@ function updateClothTexturesForFinish (finishInfo, textureKey = DEFAULT_CLOTH_TE
     }
   }
   if (finishInfo.clothEdgeMat) {
-    finishInfo.clothEdgeMat.map = null;
-    finishInfo.clothEdgeMat.bumpMap = null;
-    finishInfo.clothEdgeMat.needsUpdate = true;
+    replaceMaterialTexture(finishInfo.clothEdgeMat, 'map', textures.map, fallbackRepeat);
+    replaceMaterialTexture(finishInfo.clothEdgeMat, 'bumpMap', textures.bump, fallbackRepeat);
+    if (Number.isFinite(finishInfo.clothBase?.baseBumpScale)) {
+      finishInfo.clothEdgeMat.bumpScale = finishInfo.clothBase.baseBumpScale;
+    }
   }
   finishInfo.parts?.underlayMeshes?.forEach((mesh) => {
     if (!mesh?.material) return;


### PR DESCRIPTION
## Summary
- keep cloth and bump textures on the pocket edge material when updating Pool Royale finishes to avoid texture gaps around cutouts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924cbeb97f883288957a0eb96d12aed)