### PR TITLE
Align Pool Royale plywood pocket cutouts with cloth

### DIFF
--- a/docs/3d-billiards-variants.md
+++ b/docs/3d-billiards-variants.md
@@ -26,6 +26,7 @@ Exactly **four** chalk blocks are visible at all times—one centred on each woo
 - Rail melamine is split into **six** surface pieces in total, each one kissing the chrome fascia with no visible gaps; the grain/pattern lines must run the full length of the rails so every strip reads as a continuous long-direction plank.
 - Match the skirt underlay: melamine and wooden rails must share the same grain direction, pattern scale, and plank widths as the skirts beneath them so the table reads as one uniform shell and stops cleanly above the legs.
 - Pocket jaws and rims must match the chrome plate cutouts **100%**—never size them from the wooden rail arches.
+- The plywood underlay sitting beneath the cloth must have pocket cutouts identical to the cloth apertures, and the cloth weave around those openings must tile seamlessly with the main field pattern so no mismatched sleeve texture appears at the holes.
 
 ### 3D UK 8 Ball
 - 7 ft pub-style table with rounded corners and smaller pockets.

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -842,6 +842,7 @@ const CLOTH_UNDERLAY_GAP = TABLE.THICK * 0.02; // thin air gap so the cloth sits
 const CLOTH_UNDERLAY_EXTRA_DROP = TABLE.THICK * 0.032; // preserve the additional drop for cloth sleeves beneath the plywood edge
 const CLOTH_EXTENDED_DEPTH =
   CLOTH_THICKNESS + CLOTH_UNDERLAY_GAP + CLOTH_UNDERLAY_EXTRA_DROP + CLOTH_UNDERLAY_THICKNESS; // wrap the cloth down to replace the removed underlay
+const CLOTH_UNDERLAY_HOLE_SCALE = 1; // keep the plywood pocket cutouts 1:1 with the cloth apertures above
 const CLOTH_SHADOW_BOARD_THICKNESS = TABLE.THICK * 0.12; // thicker cloth-wrapped support to catch shadows beneath the felt
 const CLOTH_SHADOW_BOARD_GAP = TABLE.THICK * 0.01; // small offset so the board sits just under the cloth without z-fighting
 const CLOTH_SHADOW_COVER_THICKNESS = TABLE.THICK * 0.14; // concealed wooden cover that blocks direct light spill onto the carpet
@@ -5624,7 +5625,9 @@ function Table3D(
   cloth.renderOrder = 3;
   cloth.receiveShadow = true;
   table.add(cloth);
-  const plywoodShape = buildSurfaceShape(POCKET_CLOTH_TOP_RADIUS);
+  const plywoodShape = buildSurfaceShape(
+    POCKET_HOLE_R * CLOTH_UNDERLAY_HOLE_SCALE
+  );
   const plywoodGeo = new THREE.ExtrudeGeometry(plywoodShape, {
     depth: CLOTH_UNDERLAY_THICKNESS,
     bevelEnabled: false,


### PR DESCRIPTION
## Summary
- align Pool Royale plywood underlay pocket apertures with the cloth cutouts to keep geometry consistent
- document the requirement that cloth patterns around pocket sleeves match the main field texture

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69270e5031948325aca47df38f7a766a)