### PR TITLE
Restore 3D Snooker to October baseline

### DIFF
--- a/webapp/public/game-preloads/3d-snooker-preload.txt
+++ b/webapp/public/game-preloads/3d-snooker-preload.txt
@@ -1,8 +1,8 @@
 3D Snooker preload bundle (tekst)
 
-Përmbledhja e klasave kryesore të fizikës dhe parametrave të llogaritjes së spin-it për Snooker 3D.
-Ruajeni pranë build-it final për ta zëvendësuar me module të minifikuara kur të jenë gati.
+Summary of the core physics classes and spin calculation parameters for 3D Snooker.
+Keep it next to the final build to swap in minified modules once they are ready.
 
-- Graviteti -9.81, raporti real i topave dhe tavolinës.
-- Kontrolli pinch-to-zoom, orbitim me yaw/pitch dhe kufizim të këndeve ekstreme.
-- Shader-ët e tapetit dhe vija ndarëse për HUD-in snooker.
+- Gravity -9.81 with a realistic ball-to-table ratio.
+- Pinch-to-zoom control, yaw/pitch orbiting, and clamped extreme angles.
+- Cloth shaders and divider lines for the snooker HUD.


### PR DESCRIPTION
## Summary
- restore 3D Snooker scene configuration, sizing, and pocket handling to the earlier baseline
- revert snooker lobby defaults and preload notes to the matching baseline copy

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692711f28988832590a58882dd808092)