### PR TITLE
Align underlay pocket cutouts for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5624,7 +5624,9 @@ function Table3D(
   cloth.renderOrder = 3;
   cloth.receiveShadow = true;
   table.add(cloth);
-  const plywoodShape = buildSurfaceShape(POCKET_CLOTH_TOP_RADIUS);
+  // Keep the underlay apertures exactly matched to the cloth cutouts so no
+  // reflective wood peeks through around the middle pockets.
+  const plywoodShape = buildSurfaceShape(POCKET_HOLE_R);
   const plywoodGeo = new THREE.ExtrudeGeometry(plywoodShape, {
     depth: CLOTH_UNDERLAY_THICKNESS,
     bevelEnabled: false,


### PR DESCRIPTION
## Summary
- match the Pool Royale underlay pocket apertures to the cloth cutouts to prevent side-pocket reflections

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6927564968bc8325b2bcd3b5bf910696)