### PR TITLE
Refresh cloth sheen colors when finish updates

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -7802,22 +7802,33 @@ function applyTableFinishToTable(table, finish) {
   const cushionColor = new THREE.Color(
     resolvedFinish.colors.cushion ?? resolvedFinish.colors.cloth
   );
+  const clothSheenColor = clothColor.clone().lerp(clothHighlight, 0.18);
+  const cushionSheenColor = cushionColor.clone().lerp(clothHighlight, 0.18);
   const emissiveColor = clothColor.clone().multiplyScalar(0.06);
   const cushionEmissive = cushionColor.clone().multiplyScalar(0.06);
   const clothEdgeColor = clothColor.clone().lerp(clothHighlight, CLOTH_EDGE_TINT);
   const clothEdgeEmissive = clothEdgeColor.clone().multiplyScalar(CLOTH_EDGE_EMISSIVE_MULTIPLIER);
   if (finishInfo.clothMat) {
     finishInfo.clothMat.color.copy(clothColor);
+    if (finishInfo.clothMat.sheenColor) {
+      finishInfo.clothMat.sheenColor.copy(clothSheenColor);
+    }
     finishInfo.clothMat.emissive.copy(emissiveColor);
     finishInfo.clothMat.needsUpdate = true;
   }
   if (finishInfo.cushionMat) {
     finishInfo.cushionMat.color.copy(cushionColor);
+    if (finishInfo.cushionMat.sheenColor) {
+      finishInfo.cushionMat.sheenColor.copy(cushionSheenColor);
+    }
     finishInfo.cushionMat.emissive.copy(cushionEmissive);
     finishInfo.cushionMat.needsUpdate = true;
   }
   if (finishInfo.clothEdgeMat) {
     finishInfo.clothEdgeMat.color.copy(clothEdgeColor);
+    if (finishInfo.clothEdgeMat.sheenColor) {
+      finishInfo.clothEdgeMat.sheenColor.copy(clothEdgeColor);
+    }
     finishInfo.clothEdgeMat.emissive.copy(clothEdgeEmissive);
     finishInfo.clothEdgeMat.emissiveIntensity = CLOTH_EDGE_EMISSIVE_INTENSITY;
     finishInfo.clothEdgeMat.needsUpdate = true;


### PR DESCRIPTION
## Summary
- update cloth, cushion, and pocket edge materials to refresh sheen colors when the cloth finish changes
- ensure reflections and highlights track the active cloth palette

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6927e32c4e00832585a12fa05b4c263f)