### PR TITLE
Fix Air Hockey avatar visibility

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -1183,16 +1183,16 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
         const material = new THREE.MeshBasicMaterial({
           map: texture,
           transparent: true,
-          depthWrite: true,
-          depthTest: true,
+          depthWrite: false,
+          depthTest: false,
           side: THREE.DoubleSide
         });
-        const geometry = new THREE.PlaneGeometry(anchors.size, anchors.size);
+        const geometry = new THREE.PlaneGeometry(anchors.size * 0.86, anchors.size * 0.86);
         const badge = new THREE.Mesh(geometry, material);
         const target = anchors[key];
-        badge.position.set(target.x, target.y, target.z);
+        badge.position.set(target.x, target.y + anchors.size * 0.04, target.z);
         badge.rotation.x = -Math.PI / 2;
-        badge.renderOrder = -5;
+        badge.renderOrder = 20;
         tableGroup.add(badge);
         avatarSpritesRef.current[key] = badge;
       });


### PR DESCRIPTION
## Summary
- Ensure Air Hockey field avatars render above the table surface with consistent draw order
- Resize and slightly lift avatar badges so they align cleanly with the circle markers

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692aad24d2848325930dc7c25ef71081)