### PR TITLE
Restore classic snooker tables

### DIFF
--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -31,7 +31,7 @@ export default function Games() {
       <h2 className="text-2xl font-bold text-center mt-4">Games</h2>
       <p className="text-center text-sm text-subtext">Online games are under construction and will be available soon.</p>
       <div className="mx-auto max-w-md rounded-xl border border-primary/30 bg-primary/10 px-4 py-2 text-sm text-primary text-center">
-        New: Three Pool Royale-inspired snooker tables now selectable right from the lobby.
+        Classic snooker tables from the first build are back in the lobby: Pearl Cream, Charred Timber, and Carbon Midnight.
       </div>
       <div className="space-y-4">
         <div className="relative bg-surface border border-border rounded-xl p-6 shadow-lg overflow-hidden wide-card space-y-4 text-center">

--- a/webapp/src/pages/Games/SnookerLobby.jsx
+++ b/webapp/src/pages/Games/SnookerLobby.jsx
@@ -13,14 +13,19 @@ import { loadAvatar } from '../../utils/avatarUtils.js';
 
 const FEATURED_TABLES = Object.freeze([
   {
-    id: 'royalWalnut',
-    label: 'Royal Walnut',
-    description: 'Warm walnut rails with brushed brass trim inspired by the Pool Royale flagship table.'
+    id: 'rusticSplit',
+    label: 'Pearl Cream Arena',
+    description: 'Pool Royale pearl-cream rails with satin brass trim and emerald tour cloth.'
   },
   {
-    id: 'royalObsidian',
-    label: 'Royal Obsidian',
-    description: 'Midnight graphite shell with neon edge lighting for a modern arena look.'
+    id: 'charredTimber',
+    label: 'Charred Timber Elite',
+    description: 'Dark roasted planks with bronze trim and the full Pool Royale chrome accents.'
+  },
+  {
+    id: 'jetBlackCarbon',
+    label: 'Carbon Midnight',
+    description: 'Matte carbon fibre shell with smoked chrome plates and neon underglow accents.'
   }
 ]);
 
@@ -137,7 +142,7 @@ export default function SnookerLobby() {
       )}
       <h2 className="text-xl font-bold text-center">3D Snooker Lobby</h2>
       <p className="text-center text-sm text-subtext">
-        Challenge the AI in the brand-new Royal tables inspired by Pool Royale.
+        Play on the original Pool Royale-spec snooker tables restored from the earliest build.
       </p>
       <div className="space-y-2">
         <h3 className="font-semibold">Play Type</h3>
@@ -205,7 +210,7 @@ export default function SnookerLobby() {
         </div>
       ) : (
         <div className="rounded-lg border border-white/10 bg-black/20 p-3 text-xs text-subtext">
-          Training mode skips staking and lets you rehearse on the Royal cloth without deductions.
+          Training mode skips staking and lets you rehearse on the classic cloth without deductions.
         </div>
       )}
       <button


### PR DESCRIPTION
## Summary
- swap snooker lobby table options back to the original Pearl Cream, Charred Timber, and Carbon Midnight finishes
- update lobby copy to reflect the restored classic tables
- refresh the games hub announcement to highlight the returning classic snooker tables

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692aafd93d3c8325b5138a5b13a3f425)