### PR TITLE
Fix Pool Royale control layout syntax

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -16379,8 +16379,6 @@ function PoolRoyaleGame({
           </div>
         </div>
       )}
-
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove an extra closing brace from the Pool Royale controls layout
- ensure the power slider and spin controller sections render correctly for all variants

## Testing
- npm --prefix webapp run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bf2bd165c8328a415b34865504a3f)