### PR TITLE
Fix pool pocket covers and variant handling

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -69,6 +69,14 @@ type PoolMeta =
 
 const UK_TOTAL_PER_COLOUR = 7;
 
+function normalizeVariantId(value: string | null | undefined): string {
+  if (typeof value !== 'string') return '';
+  return value
+    .toLowerCase()
+    .replace(/[_\s-]+/g, '')
+    .trim();
+}
+
 function basePlayers(playerA: string, playerB: string): { A: Player; B: Player } {
   return {
     A: { id: 'A', name: playerA, score: 0 },
@@ -200,10 +208,14 @@ export class PoolRoyaleRules {
   private readonly variant: PoolVariantId;
 
   constructor(variantKey: string | null | undefined) {
-    const normalized = typeof variantKey === 'string' ? variantKey.toLowerCase() : '';
-    if (normalized === 'uk') this.variant = 'uk';
-    else if (normalized === '9ball') this.variant = '9ball';
-    else this.variant = 'american';
+    const normalized = normalizeVariantId(variantKey);
+    if (normalized === 'uk' || normalized === '8balluk' || normalized === 'eightballuk' || normalized === 'uk8') {
+      this.variant = 'uk';
+    } else if (normalized === '9ball' || normalized === 'nineball' || normalized === '9') {
+      this.variant = '9ball';
+    } else {
+      this.variant = 'american';
+    }
   }
 
   getInitialFrame(playerA: string, playerB: string): FrameState {


### PR DESCRIPTION
## Summary
- thicken and raise cloth pocket sleeves while slightly enlarging middle cloth cutouts to hide reflections
- normalize pool variant parsing (including 9-ball) and reset HUD state when frames refresh so American play remains shootable
- align rules constructor with new variant normalization for consistent game start-up

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bf7e326d083288ecc77615e09ac1b)