### PR TITLE
Restore Pool Royale rotation fouls and slider layout

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -60,6 +60,7 @@ export class AmericanBilliards {
     let frameOver = false;
     let winner = null;
     const targetScore = 61;
+    const foulLimit = 3;
 
     const spotPotted = () => {
       for (const id of pottedBalls) s.ballsOnTable.add(id);
@@ -87,6 +88,13 @@ export class AmericanBilliards {
 
     s.ballInHand = ballInHandNext;
     const nextBall = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
+
+    if (!frameOver && s.foulStreak[current] >= foulLimit) {
+      frameOver = true;
+      winner = opp;
+      s.frameOver = true;
+      s.winner = winner;
+    }
 
     if (s.scores[current] >= targetScore || s.scores[opp] >= targetScore || s.ballsOnTable.size === 0) {
       frameOver = true;

--- a/power-slider.js
+++ b/power-slider.js
@@ -86,13 +86,22 @@ export class PowerSlider {
     this._onPointerUp = this._pointerUp.bind(this);
     this._onWheel = this._wheel.bind(this);
     this._onKeyDown = this._keyDown.bind(this);
+    this._onResize = () => {
+      this._setupPowerBar();
+      this._update(false);
+    };
+
     this.el.addEventListener('pointerdown', this._onPointerDown);
     this.el.addEventListener('wheel', this._onWheel, { passive: false });
     this.el.addEventListener('keydown', this._onKeyDown);
+    window.addEventListener('resize', this._onResize);
 
     this.cueImg.addEventListener('load', () => {
+      this._setupPowerBar();
       this._update(false);
     });
+
+    this._setupPowerBar();
 
     this.set(value);
   }
@@ -130,6 +139,7 @@ export class PowerSlider {
     this.el.removeEventListener('pointerdown', this._onPointerDown);
     this.el.removeEventListener('wheel', this._onWheel);
     this.el.removeEventListener('keydown', this._onKeyDown);
+    window.removeEventListener('resize', this._onResize);
     this.el.remove();
   }
 
@@ -181,10 +191,32 @@ export class PowerSlider {
     this.track.style.background = `linear-gradient(to bottom, ${lowColor} 0%, ${color} ${pct}%, var(--ps-track-bg) ${pct}%, var(--ps-track-bg) 100%)`;
   }
 
-  _setupPowerBar() {}
+  _setupPowerBar() {
+    if (!this.powerBar) return;
+    const uWidth = this._measureCharWidth('u');
+    const pWidth = this._measureCharWidth('P');
+    this.powerBar.style.width = `${uWidth}px`;
+    const textRect = this.handleText.getBoundingClientRect();
+    const imgRect = this.cueImg.getBoundingClientRect();
+    const elRect = this.el.getBoundingClientRect();
+    const left = textRect.left - elRect.left + pWidth;
+    const top = textRect.bottom - elRect.top;
+    const height = imgRect.bottom - textRect.bottom;
+    this.powerBar.style.left = `${left}px`;
+    this.powerBar.style.top = `${top}px`;
+    this.powerBar.style.height = `${height}px`;
+  }
 
-  _measureCharWidth() {
-    return 0;
+  _measureCharWidth(ch) {
+    const span = document.createElement('span');
+    span.textContent = ch;
+    span.className = this.handleText.className;
+    span.style.visibility = 'hidden';
+    span.style.position = 'absolute';
+    this.el.appendChild(span);
+    const width = span.getBoundingClientRect().width;
+    span.remove();
+    return width;
   }
 
   _updateFromClientY(y) {


### PR DESCRIPTION
## Summary
- enforce a three-foul limit in American rotation so frames end correctly and winner state is set
- restore power slider setup to recalc sizing and cue visuals after load or resize for reliable input

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bfe41d0b48328999efc426edd6dfe)