### PR TITLE
Fix power slider lock for player turn fallback

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8733,8 +8733,8 @@ function PoolRoyaleGame({
     const slider = sliderInstanceRef.current;
     if (!slider) return;
     const hudState = hudRef.current;
-    const shouldLock =
-      hudState?.turn !== 0 || hudState?.over || shootingRef.current;
+    const isPlayerTurn = (hudState?.turn ?? 0) === 0;
+    const shouldLock = !isPlayerTurn || hudState?.over || shootingRef.current;
     if (shouldLock) slider.lock();
     else slider.unlock();
   }, []);
@@ -15746,7 +15746,7 @@ function PoolRoyaleGame({
     };
   }, [applySliderLock, showPowerSlider]);
 
-  const isPlayerTurn = hud.turn === 0;
+  const isPlayerTurn = (hud.turn ?? 0) === 0;
   const isOpponentTurn = hud.turn === 1;
   const showPlayerControls = isPlayerTurn && !hud.over;
 


### PR DESCRIPTION
## Summary
- prevent the power slider from remaining locked when the HUD turn value is missing by defaulting to player turn
- align player turn checks to treat undefined as the local player

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c038f86348328bb0dc02dfb6cc684)