### PR TITLE
Fix power slider shot handling for pool variants

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13426,6 +13426,7 @@ function PoolRoyaleGame({
       // Fire (slider triggers on release)
       const fire = () => {
         const currentHud = hudRef.current;
+        const frameSnapshot = frameRef.current ?? frameState;
         const fullTableHandPlacement =
           allowFullTableInHand() && Boolean(frameSnapshot?.meta?.state?.ballInHand);
         const inHandPlacementActive = Boolean(
@@ -13448,7 +13449,6 @@ function PoolRoyaleGame({
         alignStandingCameraToAim(cue, aimDirRef.current);
         applyCameraBlend(forcedCueView ? 0 : 1);
         updateCamera();
-        const frameSnapshot = frameRef.current ?? frameState;
         let placedFromHand = false;
         const meta = frameSnapshot?.meta;
         if (meta && typeof meta === 'object') {


### PR DESCRIPTION
## Summary
- resolve power slider shots by initializing frame state before checking ball-in-hand status

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c078ff734832887e624e4286107c3)