### PR TITLE
Disable caching for webapp HTML

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -228,10 +228,21 @@ function ensureWebappBuilt() {
 
 ensureWebappBuilt();
 
-app.use(express.static(webappPath, { maxAge: '1y', immutable: true }));
+app.use(
+  express.static(webappPath, {
+    maxAge: '1y',
+    immutable: true,
+    setHeaders: (res, filePath) => {
+      if (path.extname(filePath) === '.html') {
+        res.setHeader('Cache-Control', 'no-store');
+      }
+    }
+  })
+);
 
 function sendIndex(res) {
   if (ensureWebappBuilt()) {
+    res.setHeader('Cache-Control', 'no-store');
     res.sendFile(path.join(webappPath, 'index.html'));
   } else {
     res.status(503).send('Webapp build not available');


### PR DESCRIPTION
## Summary
- prevent long-term caching of webapp HTML files so clients always fetch the latest bundle
- send index responses with no-store headers to avoid stale asset references

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c18503b588320a482a9519d01a8e3)