### PR TITLE
Give American and 9-ball cue ball in hand at break

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -249,6 +249,7 @@ export class PoolRoyaleRules {
       }
       case '9ball': {
         const game = new NineBall();
+        game.state.ballInHand = true;
         const snapshot = serializeNineState(game.state);
         const lowest = lowestBall(snapshot.ballsOnTable) ?? 1;
         const base: FrameState = {
@@ -275,6 +276,7 @@ export class PoolRoyaleRules {
       }
       default: {
         const game = new AmericanBilliards();
+        game.state.ballInHand = true;
         const snapshot = serializeAmericanState(game.state);
         const lowest = lowestBall(snapshot.ballsOnTable) ?? 1;
         const base: FrameState = {


### PR DESCRIPTION
## Summary
- start American and 9-ball rules with the cue ball in hand so the break can be taken from a legal placement zone

## Testing
- npm test -- --runTestsByPath *(fails: no test script defined)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c2db90d5883209bcdcff8653864c7)