### PR TITLE
Restrict break in-hand placement and restore slider firing

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -60,11 +60,13 @@ type PoolMeta =
       variant: 'american';
       state: AmericanSerializedState;
       hud: HudInfo;
+      breakInProgress?: boolean;
     }
   | {
       variant: '9ball';
       state: NineSerializedState;
       hud: HudInfo;
+      breakInProgress?: boolean;
     };
 
 const UK_TOTAL_PER_COLOUR = 7;
@@ -270,7 +272,8 @@ export class PoolRoyaleRules {
         base.meta = {
           variant: '9ball',
           state: snapshot,
-          hud
+          hud,
+          breakInProgress: true
         } satisfies PoolMeta;
         return base;
       }
@@ -297,7 +300,8 @@ export class PoolRoyaleRules {
         base.meta = {
           variant: 'american',
           state: snapshot,
-          hud
+          hud,
+          breakInProgress: true
         } satisfies PoolMeta;
         return base;
       }
@@ -492,7 +496,8 @@ export class PoolRoyaleRules {
       meta: {
         variant: 'american',
         state: snapshot,
-        hud
+        hud,
+        breakInProgress: false
       } satisfies PoolMeta
     };
     return nextState;
@@ -554,7 +559,8 @@ export class PoolRoyaleRules {
       meta: {
         variant: '9ball',
         state: snapshot,
-        hud
+        hud,
+        breakInProgress: false
       } satisfies PoolMeta
     };
     return nextState;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13035,9 +13035,23 @@ function PoolRoyaleGame({
       // In-hand placement
       const variantId = () => activeVariantRef.current?.id ?? variantKey;
 
+      const isBreakRestrictedInHand = () => {
+        const frameSnapshot = frameRef.current ?? frameState;
+        const meta = frameSnapshot?.meta;
+        if (!meta || typeof meta !== 'object') return false;
+        if (meta.variant === 'american' || meta.variant === '9ball') {
+          return Boolean(meta.breakInProgress);
+        }
+        return false;
+      };
+
       const allowFullTableInHand = () => {
         const id = variantId();
-        return id === 'american' || id === '9ball';
+        if (id === 'uk') return false;
+        if (id === 'american' || id === '9ball') {
+          return !isBreakRestrictedInHand();
+        }
+        return false;
       };
 
       const isSpotFree = (point, clearanceMultiplier = 2.05) => {
@@ -15728,14 +15742,11 @@ function PoolRoyaleGame({
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
       onChange: (v) => setHud((s) => ({ ...s, power: v / 100 })),
-      onCommit: (value) => {
-        const pct = Number.isFinite(value) ? value : slider.get?.() ?? 0;
-        const isZeroShot = pct <= slider.min + 0.0001;
+      onCommit: () => {
+        fireRef.current?.();
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
         });
-        if (isZeroShot) return;
-        fireRef.current?.();
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
## Summary
- add break-in-progress metadata to 9-ball and American starts so ball-in-hand is limited behind the line only on the break
- update Pool Royale in-hand placement to enforce the break-only restriction while allowing full-table placement afterward
- align the Pool Royale power slider commit behavior with the working 8 Pool UK flow so shots fire reliably

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c32bf9df083209f2c0ffc0bc0aad1)