### PR TITLE
Align middle pocket jaws with rail cutouts

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -5214,7 +5214,7 @@ function Table3D(
       const baseMP = sideNotchMP(sx);
       const fallbackCenter = new THREE.Vector2(sx * (innerHalfW - sideInset), 0);
       const center = resolvePocketCenter(baseMP, fallbackCenter.x, fallbackCenter.y);
-      const orientationAngle = Math.atan2(0, sx);
+      const orientationAngle = Math.atan2(0, -sx);
       addPocketJaw({
         center,
         baseRadius: sideBaseRadius,


### PR DESCRIPTION
## Summary
- orient middle pocket jaw assemblies toward the playfield to match rail and chrome cut directions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692c675e35348325aa7f09620e8e1c76)