### PR TITLE
Fix Pool Royale non-UK crash and adjust side pockets

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -321,7 +321,7 @@ export class PoolRoyaleRules {
 
   private applyUkShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
     const meta = state.meta as PoolMeta | undefined;
-    const previous = meta && meta.variant === 'uk' ? meta : null;
+    const previous = meta && meta.variant === 'uk' && meta.state ? meta : null;
     const game = new UkPool();
     if (previous) {
       applyUkState(game, previous.state);
@@ -425,10 +425,12 @@ export class PoolRoyaleRules {
 
   private applyAmericanShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
     const meta = state.meta as PoolMeta | undefined;
-    const previous = meta && meta.variant === 'american' ? meta : null;
+    const previous = meta && meta.variant === 'american' && meta.state ? meta : null;
     const game = new AmericanBilliards();
     if (previous) {
       applyAmericanState(game, previous.state);
+    } else {
+      game.state.ballInHand = true;
     }
     const contactOrder: number[] = [];
     for (const ev of events) {
@@ -505,10 +507,12 @@ export class PoolRoyaleRules {
 
   private applyNineBallShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
     const meta = state.meta as PoolMeta | undefined;
-    const previous = meta && meta.variant === '9ball' ? meta : null;
+    const previous = meta && meta.variant === '9ball' && meta.state ? meta : null;
     const game = new NineBall();
     if (previous) {
       applyNineState(game, previous.state);
+    } else {
+      game.state.ballInHand = true;
     }
     const contactOrder: number[] = [];
     for (const ev of events) {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -737,7 +737,7 @@ const SIDE_POCKET_JAW_LATERAL_EXPANSION =
   CORNER_POCKET_JAW_LATERAL_EXPANSION * 1; // expand the middle jaw span so it follows the wider chrome and wood arcs cleanly
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.986; // shave the side jaw radius so it sits just inside the circular cuts without touching the cushions
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.06; // deepen the side jaw so it holds the same vertical mass as the corners
-const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * 0.02; // lift the middle jaw crowns so side pockets sit tighter to the cloth wrap
+const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * 0.06; // raise middle jaws so the side pockets press firmly into the cloth-backed plywood
 const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.236; // push the middle pocket jaws farther from table centre so they sit flush with the widened chrome cut
 const SIDE_POCKET_JAW_EDGE_TRIM_START = 0.72; // begin trimming the middle jaw shoulders before the cushion noses so they finish at the wooden rails
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.82; // taper the outer jaw radius near the ends to keep a slightly wider gap before the cushions


### PR DESCRIPTION
## Summary
- guard Pool Royale American and 9-Ball state restoration to avoid crashes
- default ball-in-hand setup when prior state is missing for rotation variants
- raise middle pocket jaws to sit flush against the plywood underlay

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c79ee0cdc83289569f31890461493)