### PR TITLE
Load authentic ABeautifulGame GLTF assets remotely

### DIFF
--- a/scripts/generateBeautifulGameSet.mjs
+++ b/scripts/generateBeautifulGameSet.mjs
@@ -10,6 +10,7 @@ globalThis.FileReader =
   class FileReader {
     constructor() {
       this.onload = null;
+      this.onloadend = null;
       this.result = null;
     }
 
@@ -18,6 +19,9 @@ globalThis.FileReader =
         this.result = arrayBuffer;
         if (typeof this.onload === 'function') {
           this.onload({ target: this });
+        }
+        if (typeof this.onloadend === 'function') {
+          this.onloadend({ target: this });
         }
       });
     }
@@ -30,6 +34,9 @@ globalThis.FileReader =
           this.result = `data:${blob.type || 'application/octet-stream'};base64,${base64}`;
           if (typeof this.onload === 'function') {
             this.onload({ target: this });
+          }
+          if (typeof this.onloadend === 'function') {
+            this.onloadend({ target: this });
           }
         });
     }
@@ -300,13 +307,17 @@ populate('White', whiteColor, 1);
 populate('Black', blackColor, -1);
 
 const exporter = new GLTFExporter();
-const arrayBuffer = await new Promise((resolve, reject) => {
-  exporter.parse(scene, resolve, { binary: true }, reject);
-});
 
-const buffer = Buffer.from(Array.isArray(arrayBuffer) ? arrayBuffer[0] : arrayBuffer);
-const outputPath = path.join(process.cwd(), 'webapp/public/assets/ABeautifulGame.glb');
-fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-fs.writeFileSync(outputPath, buffer);
-// eslint-disable-next-line no-console
-console.log('Saved', outputPath, 'bytes', buffer.length);
+try {
+  const arrayBuffer = await exporter.parseAsync(scene, { binary: true });
+  const buffer = Buffer.from(Array.isArray(arrayBuffer) ? arrayBuffer[0] : arrayBuffer);
+  const outputPath = path.join(process.cwd(), 'webapp/public/assets/ABeautifulGame.glb');
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, buffer);
+  // eslint-disable-next-line no-console
+  console.log('Saved', outputPath, 'bytes', buffer.length);
+} catch (error) {
+  // eslint-disable-next-line no-console
+  console.error('Failed to export ABeautifulGame GLB', error);
+  process.exitCode = 1;
+}

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -817,9 +817,12 @@ async function loadBeautifulGameSet() {
   let lastError = null;
   for (const url of BEAUTIFUL_GAME_URLS) {
     try {
+      const resolvedUrl = new URL(url, window.location.href).href;
+      const resourcePath = resolvedUrl.substring(0, resolvedUrl.lastIndexOf('/') + 1);
+      loader.setResourcePath(resourcePath);
       // eslint-disable-next-line no-await-in-loop
       const gltf = await new Promise((resolve, reject) => {
-        loader.load(url, resolve, undefined, reject);
+        loader.load(resolvedUrl, resolve, undefined, reject);
       });
       return gltf;
     } catch (error) {

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -214,9 +214,9 @@ const SAND_TIMER_SURFACE_OFFSET = 0.2;
 const SAND_TIMER_SCALE = 0.36;
 
 const BEAUTIFUL_GAME_URLS = [
-  'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/ABeautifulGame/glTF/ABeautifulGame.gltf',
-  'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/ABeautifulGame/glTF/ABeautifulGame.gltf',
-  'https://fastly.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/ABeautifulGame/glTF/ABeautifulGame.gltf'
+  'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf',
+  'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf',
+  'https://fastly.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf'
 ];
 
 const BEAUTIFUL_GAME_THEME = Object.freeze(
@@ -819,6 +819,7 @@ async function loadBeautifulGameSet() {
     try {
       const resolvedUrl = new URL(url, window.location.href).href;
       const resourcePath = resolvedUrl.substring(0, resolvedUrl.lastIndexOf('/') + 1);
+      loader.setPath(resourcePath);
       loader.setResourcePath(resourcePath);
       // eslint-disable-next-line no-await-in-loop
       const gltf = await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- remove the bundled ABeautifulGame GLB asset and rely on the upstream glTF source
- resolve the model resource path per URL so textures and buffers load correctly from the glTF directory

## Testing
- npm --prefix webapp run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c7f75922c8328a15a60eb59e37e72)