### PR TITLE
Restore snooker middle pocket cutouts

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -146,6 +146,34 @@ function scaleMultiPolygonBy(mp, scale) {
   return scaleMultiPolygon(mp, scale);
 }
 
+function translatePocketCutMP(mp, sx, sz, offset) {
+  if (!Array.isArray(mp) || !mp.length) {
+    return mp;
+  }
+  if (!Number.isFinite(offset) || Math.abs(offset) <= MICRO_EPS) {
+    return mp;
+  }
+  const dx = -sx * offset;
+  const dz = -sz * offset;
+  if (!Number.isFinite(dx) || !Number.isFinite(dz)) {
+    return mp;
+  }
+  if (Math.abs(dx) <= MICRO_EPS && Math.abs(dz) <= MICRO_EPS) {
+    return mp;
+  }
+  return mp.map((poly) => {
+    if (!Array.isArray(poly)) return poly;
+    return poly.map((ring) => {
+      if (!Array.isArray(ring)) return ring;
+      return ring.map((pt) => {
+        if (!Array.isArray(pt) || pt.length < 2) return pt;
+        const [x, z] = pt;
+        return [x + dx, z + dz];
+      });
+    });
+  });
+}
+
 function adjustCornerNotchDepth(mp, centerZ, sz) {
   if (!Array.isArray(mp) || !Number.isFinite(centerZ) || !Number.isFinite(sz)) {
     return Array.isArray(mp) ? mp : [];
@@ -240,9 +268,10 @@ const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.52;
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0;
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.56;
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.012;
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = -0.024; // mirror Pool Royale outward pull so the chrome cut hugs the rounded rail relief
 const WOOD_CORNER_CUT_SCALE = 0.976; // pull wood reliefs inward so the rounded cuts tuck toward centre
 const WOOD_SIDE_CUT_SCALE = 1; // keep side rail apertures identical to chrome plate cuts
+const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.264; // shift middle wood arches to match Pool Royale's relieved centreline
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.004;
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = POCKET_JAW_CORNER_OUTER_LIMIT_SCALE;
 const POCKET_JAW_CORNER_INNER_SCALE = 1.472;
@@ -5210,10 +5239,12 @@ function Table3D(
   }
 
   if (sideBaseRadius && sideBaseRadius > MICRO_EPS) {
+    const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.236;
     [-1, 1].forEach((sx) => {
       const baseMP = sideNotchMP(sx);
       const fallbackCenter = new THREE.Vector2(sx * (innerHalfW - sideInset), 0);
       const center = resolvePocketCenter(baseMP, fallbackCenter.x, fallbackCenter.y);
+      center.x += sx * SIDE_POCKET_JAW_OUTWARD_SHIFT;
       const orientationAngle = Math.atan2(0, sx);
       addPocketJaw({
         center,
@@ -5239,8 +5270,16 @@ function Table3D(
     }
   }
 
+  const woodSideCutCenterOutset = TABLE.THICK * WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE;
   const woodSideNotches = [-1, 1]
-    .map((sx) => scaleMultiPolygonBy(sideNotchMP(sx), WOOD_SIDE_CUT_SCALE))
+    .map((sx) =>
+      translatePocketCutMP(
+        scaleMultiPolygonBy(sideNotchMP(sx), WOOD_SIDE_CUT_SCALE),
+        sx,
+        0,
+        woodSideCutCenterOutset
+      )
+    )
     .filter((mp) => Array.isArray(mp) && mp.length);
   let openingMP = polygonClipping.union(
     rectPoly(innerHalfW * 2, innerHalfH * 2),


### PR DESCRIPTION
## Summary
- restore the side pocket cutout translation helper so middle cutouts align with prior layout
- reinstate chrome and wood middle-pocket offset constants and jaw shifts to match the earlier pocket geometry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c8aa2685883289bd55baa4c1aa048)