### PR TITLE
Fix Pool Royale American and 9-ball turns

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -430,6 +430,9 @@ export class PoolRoyaleRules {
     if (previous) {
       applyAmericanState(game, previous.state);
     } else {
+      // Preserve the current turn information so the active player is not reset
+      // when the previous frame snapshot is missing (e.g. after a hot reload).
+      game.state.currentPlayer = state.activePlayer ?? 'A';
       game.state.ballInHand = true;
     }
     const contactOrder: number[] = [];
@@ -512,6 +515,9 @@ export class PoolRoyaleRules {
     if (previous) {
       applyNineState(game, previous.state);
     } else {
+      // Keep the active player in sync if we lost the previous snapshot so the
+      // turn does not get stuck on player A.
+      game.state.currentPlayer = state.activePlayer ?? 'A';
       game.state.ballInHand = true;
     }
     const contactOrder: number[] = [];

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5471,8 +5471,8 @@ function Table3D(
   underlayEdgeMat.clearcoatRoughness = 1;
   underlayEdgeMat.envMapIntensity = 0;
   underlayEdgeMat.reflectivity = 0;
-  underlayEdgeMat.emissive.set(0x000000);
-  underlayEdgeMat.emissiveIntensity = 0;
+  underlayEdgeMat.emissive.copy(clothEdgeMat.emissive);
+  underlayEdgeMat.emissiveIntensity = clothEdgeMat.emissiveIntensity;
   underlayEdgeMat.needsUpdate = true;
   const clothBaseSettings = {
     roughness: clothMat.roughness,


### PR DESCRIPTION
## Summary
- keep American Billiards and 9-ball turns in sync when rehydrating frames so play doesn’t freeze on player A
- tint the cloth underlay pocket cutouts to match the cloth edge emissive color

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692d1c64f3a48325adc14ac9ab53f36d)