### PR TITLE
Ensure cue reactivates after AI cue ball is potted

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -14681,15 +14681,16 @@ function PoolRoyaleGame({
                 };
               }
             }
-              if (cueBallPotted) {
-                cue.active = false;
-                pocketDropRef.current.delete(cue.id);
+            if (cueBallPotted) {
+              cue.active = false;
+              pocketDropRef.current.delete(cue.id);
               const fallback = defaultInHandPosition();
-                if (fallback) {
-                  updateCuePlacement(fallback);
-                } else {
+              if (fallback) {
+                updateCuePlacement(fallback);
+              } else {
                 cue.mesh.visible = true;
               }
+              cue.active = true;
               cue.vel.set(0, 0);
               cue.spin?.set(0, 0);
               cue.pendingSpin?.set(0, 0);


### PR DESCRIPTION
## Summary
- reactivate the cue ball after it is repositioned following a foul or pocket
- keep AI turns unblocked so American and 9-Ball opponents can line up and shoot

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692d263fae8c8325aed2e9380f82ac69)