### PR TITLE
Restore previous American and nine-ball logic

### DIFF
--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -57,11 +57,6 @@ export class NineBall {
     const foulLimit = 3;
 
     if (foul) {
-      const ninePotted = pottedBalls.includes(9);
-      for (const id of pottedBalls) {
-        if (id !== 9) s.ballsOnTable.delete(id);
-      }
-      if (ninePotted) s.ballsOnTable.add(9);
       nextPlayer = opp;
       ballInHandNext = true;
       s.currentPlayer = opp;

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -430,9 +430,6 @@ export class PoolRoyaleRules {
     if (previous) {
       applyAmericanState(game, previous.state);
     } else {
-      // Preserve the current turn information so the active player is not reset
-      // when the previous frame snapshot is missing (e.g. after a hot reload).
-      game.state.currentPlayer = state.activePlayer ?? 'A';
       game.state.ballInHand = true;
     }
     const contactOrder: number[] = [];
@@ -515,9 +512,6 @@ export class PoolRoyaleRules {
     if (previous) {
       applyNineState(game, previous.state);
     } else {
-      // Keep the active player in sync if we lost the previous snapshot so the
-      // turn does not get stuck on player A.
-      game.state.currentPlayer = state.activePlayer ?? 'A';
       game.state.ballInHand = true;
     }
     const contactOrder: number[] = [];

--- a/test/nineBall.test.js
+++ b/test/nineBall.test.js
@@ -40,45 +40,6 @@ test('scratch gives opponent ball in hand', () => {
   assert.equal(res1.foul, true);
   assert.equal(res1.reason, 'scratch');
   assert.equal(res1.ballInHandNext, true);
+  assert.equal(res1.nextPlayer, 'B');
   assert.equal(game.state.currentPlayer, 'B');
-  const res2 = game.shotTaken({
-    contactOrder: [1],
-    potted: [],
-    cueOffTable: false,
-    placedFromHand: true
-  });
-  assert.equal(res2.foul, false);
-  assert.equal(res2.ballInHandNext, false);
-});
-
-test('foul still grants ball-in-hand and removes pocketed object balls', () => {
-  const game = new NineBall();
-  const res = game.shotTaken({
-    contactOrder: [],
-    potted: [2, 3],
-    cueOffTable: true,
-    placedFromHand: false
-  });
-  assert.equal(res.foul, true);
-  assert.equal(res.reason, 'no contact');
-  assert.equal(res.nextPlayer, 'B');
-  assert.equal(res.ballInHandNext, true);
-  assert.equal(game.state.ballsOnTable.has(2), false);
-  assert.equal(game.state.ballsOnTable.has(3), false);
-  assert.equal(game.state.ballsOnTable.has(9), true);
-});
-
-test('pocketing the nine on a foul respots it', () => {
-  const game = new NineBall();
-  const res = game.shotTaken({
-    contactOrder: [1],
-    potted: [1, 9, 0],
-    cueOffTable: true,
-    placedFromHand: false
-  });
-  assert.equal(res.foul, true);
-  assert.equal(res.reason, 'scratch');
-  assert.equal(res.ballInHandNext, true);
-  assert.equal(game.state.ballsOnTable.has(9), true);
-  assert.equal(game.state.ballsOnTable.has(1), false);
 });


### PR DESCRIPTION
## Summary
- revert American and nine-ball rule initialization to prior behavior
- remove recent nine-ball foul respotting adjustments
- align nine-ball unit tests with the restored ruleset

## Testing
- node --test test/nineBall.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d40dac5b083288641b10fc53fdc5e)