### PR TITLE
Fix Pool Royale fire sequencing for AI shots

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13532,6 +13532,7 @@ function PoolRoyaleGame({
       // Fire (slider triggers on release)
       const fire = () => {
         const currentHud = hudRef.current;
+        const frameSnapshot = frameRef.current ?? frameState;
         const fullTableHandPlacement =
           allowFullTableInHand() && Boolean(frameSnapshot?.meta?.state?.ballInHand);
         const inHandPlacementActive = Boolean(
@@ -13554,7 +13555,6 @@ function PoolRoyaleGame({
         alignStandingCameraToAim(cue, aimDirRef.current);
         applyCameraBlend(forcedCueView ? 0 : 1);
         updateCamera();
-        const frameSnapshot = frameRef.current ?? frameState;
         let placedFromHand = false;
         const meta = frameSnapshot?.meta;
         if (meta && typeof meta === 'object') {


### PR DESCRIPTION
## Summary
- prevent the Pool Royale fire handler from referencing frame data before initialization
- ensure AI and player shots proceed by evaluating in-hand placement with a valid frame snapshot

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d441f5120832899c4e47d85681a7b)