### PR TITLE
Fix Domino Royal chair orientation

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -2898,7 +2898,6 @@ async function buildChairs(option = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?
     const wrapper = new THREE.Group();
     wrapper.position.set(basis.position.x, CHAIR_BASE_HEIGHT, basis.position.z);
     wrapper.lookAt(lookTarget);
-    wrapper.rotateY(Math.PI);
 
     const chair = chairData
       ? cloneChairWithTheme(chairData, option)


### PR DESCRIPTION
## Summary
- orient Domino Royal chairs toward the table to align with domino layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d635ef1448320a6aac0832d880a12)