### PR TITLE
Improve Domino Royal 2D hand view and table visuals

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -421,6 +421,7 @@ function setCameraViewMode(mode = VIEW_MODES.threeD) {
   applyCameraConstraints();
   positionCameraForViewport({ force: true });
   updateViewToggleLabel();
+  renderHands();
 }
 
 function toggleCameraViewMode() {
@@ -3190,16 +3191,23 @@ function renderHands(){
   const MIN_GAP = DOMINO_LENGTH * 1.05;
   const MAX_SPAN = Math.max(0, EDGE_SPAN * 2 - DOMINO_LENGTH * 0.6);
 
+  const isTopDown = cameraViewMode === VIEW_MODES.twoD;
+
   players.forEach((p,pi)=>{
     const [x0,z0] = layoutSeat(pi);
-    const faceUp = revealAllHands || pi === human || (gameFinished && pi === winnerIndex);
+    const isHuman = pi === human;
+    const faceUp = revealAllHands || isHuman || (gameFinished && pi === winnerIndex);
     const count = p.hand.length;
     const isSide = (pi===1 || pi===3);
+    const openFlat = isTopDown && isHuman;
+
+    const gapBase = openFlat ? BASE_GAP * 1.3 : BASE_GAP;
+    const handY = openFlat ? CLOTH_TOP + 0.018 : HAND_Y;
 
     let span = 0;
     let gap = 0;
     if(count>1){
-      const desiredSpan = BASE_GAP * (count-1);
+      const desiredSpan = gapBase * (count-1);
       const minSpan = Math.min(MIN_GAP * (count-1), MAX_SPAN);
       span = Math.min(Math.max(desiredSpan, minSpan), MAX_SPAN);
       gap = span/(count-1);
@@ -3221,17 +3229,21 @@ function renderHands(){
     }
 
     p.hand.forEach((h,hi)=>{
-      const m = makeDomino(h.a,h.b,{flat:false, faceUp});
+      const m = makeDomino(h.a,h.b,{flat: openFlat, faceUp});
       const offset = count>1 ? start + gap*hi : 0;
       if(isSide){
-        m.position.set(x0, HAND_Y, z0 + offset);
+        m.position.set(x0, handY, z0 + offset);
       }
       else{
-        m.position.set(x0 + offset, HAND_Y, z0);
+        m.position.set(x0 + offset, handY, z0);
       }
       const yawTowardCenter = Math.atan2(-x0, -z0);
-      m.rotation.set(0, (pi===human ? 0 : yawTowardCenter), 0);
-      m.rotation.z += (Math.random()*0.006-0.003);
+      if(openFlat){
+        m.rotation.set(-Math.PI/2, yawTowardCenter, 0);
+      } else {
+        m.rotation.set(0, (pi===human ? 0 : yawTowardCenter), 0);
+        m.rotation.z += (Math.random()*0.006-0.003);
+      }
       h.mesh = m; m.userData = {tile:h, owner:pi}; piecesG.add(m);
     });
   });

--- a/webapp/src/utils/dominoArena.js
+++ b/webapp/src/utils/dominoArena.js
@@ -757,15 +757,17 @@ export function buildDominoArena({ scene, renderer }) {
   const chairHeight =
     CHAIR_DIMENSIONS.baseThickness + CHAIR_DIMENSIONS.columnHeight + CHAIR_DIMENSIONS.seatThickness;
   const lookTarget = new THREE.Vector3(0, chairHeight, 0);
+  const dominoFacing = new THREE.Vector3(1, 0, 0);
   const chairs = [
-    new THREE.Vector3(0, 0, chairRadius),
-    new THREE.Vector3(chairRadius, 0, 0),
-    new THREE.Vector3(0, 0, -chairRadius),
-    new THREE.Vector3(-chairRadius, 0, 0)
-  ].map((position) => {
+    { position: new THREE.Vector3(0, 0, chairRadius) },
+    { position: new THREE.Vector3(chairRadius, 0, 0), forward: dominoFacing },
+    { position: new THREE.Vector3(0, 0, -chairRadius) },
+    { position: new THREE.Vector3(-chairRadius, 0, 0), forward: dominoFacing }
+  ].map(({ position, forward }) => {
     const chair = createDominoChair(DEFAULT_CHAIR_OPTION, renderer, sharedChairMaterials);
     chair.position.copy(position);
-    chair.lookAt(lookTarget);
+    const forwardDir = forward?.clone().normalize() ?? lookTarget.clone().sub(chair.position).normalize();
+    chair.lookAt(chair.position.clone().add(forwardDir));
     chair.rotateY(Math.PI);
     table.group.add(chair);
     chair.traverse((child) => {

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -227,10 +227,13 @@ export function makeRoughClothTexture(size, topHex, bottomHex, anisotropy = 8) {
   ctx.fillStyle = centerGradient;
   ctx.fillRect(0, 0, size, size);
 
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.08)';
+  ctx.fillRect(0, 0, size, size);
+
   const texture = new THREE.CanvasTexture(canvas);
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   const baseRepeat = 12;
-  const scaledRepeat = baseRepeat * 30 * 3;
+  const scaledRepeat = baseRepeat * 30 * 6;
   texture.repeat.set(scaledRepeat, scaledRepeat);
   texture.anisotropy = anisotropy;
   applySRGBColorSpace(texture);


### PR DESCRIPTION
## Summary
- open the human hand flat in 2D mode for clearer selection and refresh the layout when toggling views
- align side chairs along the domino direction while keeping the seating centered around the table
- darken and tighten the table cloth texture pattern for a smaller, richer weave

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d81e2217c8320b94ca1d2b2706e58)