### PR TITLE
Reduce reflections around Pool Royale pocket cutouts

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5455,6 +5455,9 @@ function Table3D(
   clothEdgeMat.needsUpdate = true;
   const underlayTopMat = clothMat.clone();
   underlayTopMat.color.copy(clothColor);
+  underlayTopMat.map = null;
+  underlayTopMat.bumpMap = null;
+  underlayTopMat.bumpScale = 0;
   underlayTopMat.metalness = 0;
   underlayTopMat.roughness = 1;
   underlayTopMat.sheen = 0;
@@ -5464,9 +5467,13 @@ function Table3D(
   underlayTopMat.reflectivity = 0;
   underlayTopMat.emissive.set(0x000000);
   underlayTopMat.emissiveIntensity = 0;
+  underlayTopMat.side = THREE.DoubleSide;
   underlayTopMat.needsUpdate = true;
   const underlayEdgeMat = clothEdgeMat.clone();
   underlayEdgeMat.color.copy(clothColor);
+  underlayEdgeMat.map = null;
+  underlayEdgeMat.bumpMap = null;
+  underlayEdgeMat.bumpScale = 0;
   underlayEdgeMat.metalness = 0;
   underlayEdgeMat.roughness = 1;
   underlayEdgeMat.sheen = 0;
@@ -5476,6 +5483,7 @@ function Table3D(
   underlayEdgeMat.reflectivity = 0;
   underlayEdgeMat.emissive.copy(clothEdgeMat.emissive);
   underlayEdgeMat.emissiveIntensity = clothEdgeMat.emissiveIntensity;
+  underlayEdgeMat.side = THREE.DoubleSide;
   underlayEdgeMat.needsUpdate = true;
   const clothBaseSettings = {
     roughness: clothMat.roughness,
@@ -5739,10 +5747,12 @@ function Table3D(
     depth: CLOTH_EXTENDED_DEPTH,
     bevelEnabled: false,
     curveSegments: 96,
-    steps: 1
+    steps: 1,
+    material: 0,
+    extrudeMaterial: 1
   });
   clothGeo.translate(0, 0, -CLOTH_EXTENDED_DEPTH);
-  const cloth = new THREE.Mesh(clothGeo, clothMat);
+  const cloth = new THREE.Mesh(clothGeo, [clothMat, clothEdgeMat]);
   cloth.rotation.x = -Math.PI / 2;
   cloth.position.y = clothPlaneLocal - CLOTH_DROP;
   cloth.renderOrder = 3;
@@ -5788,11 +5798,15 @@ function Table3D(
   shadowBoardGeo.translate(0, 0, -CLOTH_SHADOW_BOARD_THICKNESS);
   const shadowBoardMat = clothMat.clone();
   shadowBoardMat.color = clothMat.color.clone();
+  shadowBoardMat.map = null;
+  shadowBoardMat.bumpMap = null;
+  shadowBoardMat.bumpScale = 0;
   shadowBoardMat.roughness = 1;
   shadowBoardMat.metalness = 0;
   shadowBoardMat.clearcoat = 0;
   shadowBoardMat.sheen = 0;
   shadowBoardMat.envMapIntensity = 0;
+  shadowBoardMat.reflectivity = 0;
   shadowBoardMat.side = THREE.DoubleSide;
   shadowBoardMat.needsUpdate = true;
   const shadowBoard = new THREE.Mesh(shadowBoardGeo, shadowBoardMat);


### PR DESCRIPTION
## Summary
- apply the cloth edge material to the extruded cloth walls so pocket sleeves match the felt tone without shine
- flatten the underlay and shadow board materials to the cloth color with no texture, sheen, or reflections to hide white seams

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692d925089648325a406edced75a66f8)