### PR TITLE
Fix 2D domino hand orientation

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -3239,7 +3239,9 @@ function renderHands(){
       }
       const yawTowardCenter = Math.atan2(-x0, -z0);
       if(openFlat){
-        m.rotation.set(-Math.PI/2, yawTowardCenter, 0);
+        const flatYaw = isSide ? Math.PI / 2 : 0;
+        orientDominoFlat(m, flatYaw);
+        m.rotation.z = 0;
       } else {
         m.rotation.set(0, (pi===human ? 0 : yawTowardCenter), 0);
         m.rotation.z += (Math.random()*0.006-0.003);


### PR DESCRIPTION
## Summary
- align the player's domino hand correctly when using the 2D view
- reuse the flat orientation helper so tiles face the player instead of the table center

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692d9e02f90c83258dec6c91bc43b7eb)