### PR TITLE
Fix 2D domino hand orientation

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -3239,7 +3239,7 @@ function renderHands(){
       }
       const yawTowardCenter = Math.atan2(-x0, -z0);
       if(openFlat){
-        m.rotation.set(-Math.PI/2, yawTowardCenter, 0);
+        orientDominoFlat(m, 0);
       } else {
         m.rotation.set(0, (pi===human ? 0 : yawTowardCenter), 0);
         m.rotation.z += (Math.random()*0.006-0.003);


### PR DESCRIPTION
## Summary
- keep 2D view player hand dominoes aligned using the flat orientation helper

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692da77b8e7c8325887e68bef9c83467)