### PR TITLE
Tweak Texas Hold'em table and camera setup

### DIFF
--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -74,7 +74,7 @@ export function setCardFace(mesh, face) {
     mesh.userData.cardFace = 'back';
   } else {
     mesh.material[4] = frontMaterial;
-    mesh.material[5] = backMaterial;
+    mesh.material[5] = frontMaterial;
     mesh.userData.cardFace = 'front';
   }
 }


### PR DESCRIPTION
## Summary
- shrink the Texas Hold'em table, cards, and chips while moving chairs closer for a tighter layout and closer seated camera
- disable automatic turn-based camera steering and lower the overhead view height while hiding chairs in 2D mode
- make card faces render on both sides so community cards stay visible from every angle

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dfaff154c83208392ba916d8ece90)