### PR TITLE
Improve Texas Holdem camera and layout

### DIFF
--- a/webapp/src/utils/arenaCameraConfig.js
+++ b/webapp/src/utils/arenaCameraConfig.js
@@ -4,7 +4,7 @@ export const ARENA_CAMERA_DEFAULTS = Object.freeze({
   far: 5000,
   initialRadiusFactor: 1.35,
   minRadiusFactor: 0.95,
-  maxRadiusFactor: 2.4,
+  maxRadiusFactor: 3.1,
   initialPhiLerp: 0.35,
   phiMin: 0.92,
   phiMax: 1.22,


### PR DESCRIPTION
## Summary
- move chairs and overhead camera closer to the table for a clearer view of player cards and community cards
- allow wider zoom range and smooth animated transitions between 2D and 3D views
- lower community card height and align overhead framing with the human player's position

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e0946b32883208011219505bd9079)