### PR TITLE
Fix human card orientation

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -2882,11 +2882,6 @@ function TexasHoldemArena({ search }) {
         }
         mesh.visible = true;
         applyCardToMesh(mesh, card, three.cardGeometry, three.faceCache, cardTheme);
-        if (player.isHuman && !player.folded && !state.showdown) {
-          setCardFace(mesh, 'front');
-          setCardHighlight(mesh, false);
-          return;
-        }
         if (player.folded && !state.showdown) {
           const railBase = seat.cardRailAnchor.clone();
           const lateral = seat.right.clone().multiplyScalar((cardIdx - 0.5) * HOLE_SPACING);
@@ -2908,8 +2903,9 @@ function TexasHoldemArena({ search }) {
           .clone()
           .add(new THREE.Vector3(0, seat.stoolHeight * 0.5 + CARD_LOOK_LIFT, 0))
           .add(right.clone().multiplyScalar((cardIdx - 0.5) * CARD_LOOK_SPLAY));
-        orientCard(mesh, lookTarget, { face: state.showdown ? 'front' : 'back', flat: false });
-        setCardFace(mesh, state.showdown ? 'front' : 'back');
+        const face = player.isHuman || state.showdown ? 'front' : 'back';
+        orientCard(mesh, lookTarget, { face, flat: false });
+        setCardFace(mesh, face);
         const key = cardKey(card);
         setCardHighlight(mesh, state.showdown && winningCardSet.has(key));
       });


### PR DESCRIPTION
## Summary
- keep player hole cards oriented and positioned even when not at showdown so they remain face up for the human seat
- centralize card face selection to show human cards while keeping opponents face down until showdown

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e897ab3508320845643cf17a5880c)