### PR TITLE
Lift Pool Royale chrome plates

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -414,6 +414,7 @@ const CHROME_PLATE_REFLECTION_SCALE = 0.28; // kill pocket-cut reflections by da
 const CHROME_PLATE_ROUGHNESS_LIFT = 0.08; // lift roughness on fascia cuts so pocket arches stop casting hot spots on cloth
 const CHROME_PLATE_THICKNESS_EXPANSION_SCALE = 1; // match fascia depth to the diamond markers on the wooden rails
 const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.18; // keep middle fascias proportionally deeper while following the snooker thickness target
+const CHROME_PLATE_VERTICAL_LIFT_SCALE = 0.12; // raise all chrome fascias slightly so the plates sit prouder above the rails
 const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually above the wood rails without z-fighting
 const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.58; // push the side fascia farther along the arch so it blankets the larger chrome reveal
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.52; // align fascia reach with snooker so the arch covers the relieved cut without overhang
@@ -6040,6 +6041,8 @@ function Table3D(
   const chromePlateThickness =
     RAIL_MARKER_THICKNESS * CHROME_PLATE_THICKNESS_EXPANSION_SCALE; // keep fascia flush with diamond markers while deepening toward the carpet
   const sideChromePlateThickness = chromePlateThickness * CHROME_SIDE_PLATE_THICKNESS_BOOST; // give the middle-pocket fascias extra depth
+  const chromePlateVerticalLift = chromePlateThickness * CHROME_PLATE_VERTICAL_LIFT_SCALE;
+  const sideChromePlateVerticalLift = sideChromePlateThickness * CHROME_PLATE_VERTICAL_LIFT_SCALE;
   const chromePlateInset = TABLE.THICK * 0.02;
   const chromeCornerPlateTrim =
     TABLE.THICK * (0.03 + CHROME_CORNER_FIELD_TRIM_SCALE);
@@ -6440,7 +6443,7 @@ function Table3D(
       chromePlateMat
     );
     plate.userData.isChromePlate = true;
-    plate.position.set(centerX, chromePlateY + chromePlateThickness, centerZ);
+    plate.position.set(centerX, chromePlateY + chromePlateThickness + chromePlateVerticalLift, centerZ);
     plate.castShadow = false;
     plate.receiveShadow = false;
     plate.renderOrder = CHROME_PLATE_RENDER_ORDER;
@@ -6482,7 +6485,11 @@ function Table3D(
       chromePlateMat
     );
     plate.userData.isChromePlate = true;
-    plate.position.set(centerX, sideChromePlateY + sideChromePlateThickness, centerZ);
+    plate.position.set(
+      centerX,
+      sideChromePlateY + sideChromePlateThickness + sideChromePlateVerticalLift,
+      centerZ
+    );
     plate.castShadow = false;
     plate.receiveShadow = false;
     plate.renderOrder = CHROME_PLATE_RENDER_ORDER;


### PR DESCRIPTION
## Summary
- add a vertical lift scale for Pool Royale chrome fascias to raise them slightly above the rails
- apply the lift to both corner and side chrome plates without altering their footprint

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ea80816148320b85fcf4b201b3e44)