### PR TITLE
Enhance Pool Royale UK AI shot planning

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -487,6 +487,38 @@ function estimatePotProbability (shot, state) {
   return Math.max(0, Math.min(1, P))
 }
 
+function nextShapeWindow (state, colour) {
+  const cue = state.balls.find(b => b.colour === 'cue')
+  let best = 0
+  const diag = Math.hypot(state.width, state.height) || 1
+  for (const ball of state.balls) {
+    if (ball.pocketed || ball.colour !== colour) continue
+    for (const pocket of state.pockets) {
+      const entry = pocketEntry(pocket, state)
+      if (pathBlocked(ball, entry, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+      if (pathBlocked(cue, ball, state.balls, [cue.id], state.ballRadius)) continue
+      const angle = cutAngle(cue, ball, entry)
+      const distCT = dist(cue, ball)
+      const distTP = dist(ball, entry)
+      const previewShot = {
+        actionType: 'pot',
+        targetBall: ball,
+        pocket: entry,
+        cueParams: { speed: 'med', spin: 'stun' },
+        angle,
+        distCT,
+        distTP
+      }
+      const prob = estimatePotProbability(previewShot, state)
+      const angleWindow = Math.max(0, (Math.PI / 6 - angle) / (Math.PI / 6))
+      const distanceEase = 1 - Math.min((distCT + distTP) / diag, 1)
+      const score = prob * 0.6 + angleWindow * 0.3 + distanceEase * 0.1
+      if (score > best) best = score
+    }
+  }
+  return best
+}
+
 function simulateCueRollout (state, shot) {
   const cue = state.balls.find(b => b.colour === 'cue')
   const ball = shot.targetBall
@@ -619,7 +651,8 @@ function evaluateCandidates (state, colour, candidates) {
       const risk = foulRisk(c, state)
       const straightBoost = typeof c.angle === 'number' ? Math.max(0, (Math.PI / 10 - c.angle) / (Math.PI / 10)) * 0.25 : 0
       const positionWeight = 1.25
-      EV = Ppot * (baseValue + nextBest * positionWeight + straightBoost) - riskPenalty(risk)
+      const shapeWindow = nextShapeWindow(nextState, colour)
+      EV = Ppot * (baseValue + nextBest * positionWeight + straightBoost + shapeWindow * 0.65) - riskPenalty(risk)
     }
     if (!best || EV > best.EV) {
       best = { c, EV }
@@ -658,6 +691,13 @@ function chooseBestAction (state, colour) {
     if (maxPot < 0.35) {
       candidates = candidates.concat(generateSafeties(state, colour))
     }
+  }
+  const qualityFiltered = candidates.filter(c => {
+    if (c.actionType !== 'pot') return true
+    return estimatePotProbability(c, state) >= 0.2
+  })
+  if (qualityFiltered.length > 0) {
+    candidates = qualityFiltered
   }
   const STRAIGHT_THRESHOLD = Math.PI / 12 // ~15 degrees
   const straightShots = candidates.filter(


### PR DESCRIPTION
## Summary
- prioritize high-probability pots for Pool Royale UK AI instead of low-quality attempts
- add positional window scoring to favor cue paths that keep shape for the next shot
- filter candidate shots to maintain controlled aiming, speed, and spin choices

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fc6d381ec8320bdf21f7ec1810a19)