### PR TITLE
Fix human card orientation in Texas Hold'em arena

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -2909,9 +2909,6 @@ function TexasHoldemArena({ search }) {
           .addScaledVector(forward, seat.isHuman ? -CARD_LOOK_SPLAY * 0.3 : 0);
         const face = player.isHuman || state.showdown ? 'front' : 'back';
         orientCard(mesh, lookTarget, { face, flat: false });
-        if (seat.isHuman) {
-          mesh.rotateY(Math.PI);
-        }
         setCardFace(mesh, face);
         const key = cardKey(card);
         setCardHighlight(mesh, state.showdown && winningCardSet.has(key));


### PR DESCRIPTION
## Summary
- ensure human seat card orientation keeps fronts facing the player by removing redundant rotation
- maintain folded and showdown face handling while updating card meshes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fc9c3b3d483208e54501f548e9ed6)