### PR TITLE
Align Texas Hold'em player hand layout

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -201,6 +201,7 @@
         display: flex;
         gap: 6px;
         flex-wrap: nowrap;
+        position: relative;
         will-change: transform;
       }
       .card {

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -518,8 +518,7 @@ function renderSeats() {
       wrap.append(ring, avatar);
       const inner = document.createElement('div');
       inner.className = 'seat-inner';
-      // Move action text above the player's cards so the cards sit directly above the controls
-      inner.append(wrap, name, action, cards);
+      inner.append(wrap, name, cards);
       const controls = document.createElement('div');
       controls.className = 'controls';
       controls.id = 'controls';
@@ -527,7 +526,7 @@ function renderSeats() {
       bal.className = 'seat-balance';
       bal.id = 'balance-' + i;
       bal.innerHTML = formatAmount(p.balance || 0);
-      seat.append(inner, bal, controls);
+      seat.append(inner, bal, action, controls);
     } else {
       const timer = document.createElement('div');
       timer.className = 'timer';


### PR DESCRIPTION
## Summary
- position Texas Hold'em hand container like blackjack hands
- reorder the human seat layout so the player's cards sit with the avatar and name like blackjack

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fe5cea3d48320aa893379bc8358fa)