### PR TITLE
Adjust Domino Royal seat avatar display

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -2440,14 +2440,11 @@ const seatNameTags = [];
 const DEFAULT_SEAT_NAMES = ['You', 'Player 2', 'Player 3', 'Player 4'];
 
 function buildSeatNames(count = N) {
-  const resolvedFlags = seatAvatarFlags.length ? seatAvatarFlags : [DEFAULT_AVATAR_EMOJI];
   return Array.from({ length: Math.max(1, count) }, (_, idx) => {
-    const flagIndex = idx === HUMAN_SEAT_INDEX ? 0 : (idx - 1 < 0 ? 0 : (idx - 1) % resolvedFlags.length);
-    const flagLabel = resolvedFlags[flagIndex] ?? DEFAULT_AVATAR_EMOJI;
     if (idx === HUMAN_SEAT_INDEX && seatAvatarUsername) {
-      return `${flagLabel} ${seatAvatarUsername}`.trim();
+      return seatAvatarUsername;
     }
-    return flagLabel || DEFAULT_SEAT_NAMES[idx] || `Player ${idx + 1}`;
+    return DEFAULT_SEAT_NAMES[idx] || `Player ${idx + 1}`;
   });
 }
 
@@ -2658,7 +2655,7 @@ function createSeatNameTag(label = '') {
   ctx.lineWidth = 12;
   ctx.strokeRect(12, 12, canvas.width - 24, canvas.height - 24);
   ctx.fillStyle = '#ffe8a3';
-  ctx.font = 'bold 96px "Inter", Arial, sans-serif';
+  ctx.font = 'bold 76px "Inter", Arial, sans-serif';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.fillText(label || 'Player', canvas.width / 2, canvas.height / 2);
@@ -2667,7 +2664,7 @@ function createSeatNameTag(label = '') {
   texture.colorSpace = THREE.SRGBColorSpace;
   texture.anisotropy = Math.min(renderer.capabilities.getMaxAnisotropy?.() || 4, 8);
   const material = new THREE.MeshBasicMaterial({ map: texture, transparent: true, depthWrite: false });
-  const geometry = new THREE.PlaneGeometry(1.6, 0.62);
+  const geometry = new THREE.PlaneGeometry(1.5, 0.48);
   const mesh = new THREE.Mesh(geometry, material);
   mesh.renderOrder = 3;
   return mesh;


### PR DESCRIPTION
## Summary
- ensure Domino Royal seats show a single avatar with username text beneath it
- resize name tag styling to better match the Ludo Battle Royal layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff0ba5d648320be4eb2c12efe2929)