### PR TITLE
Fix chess board and piece swaps when appearance changes

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -3073,7 +3073,8 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
       }
     }
 
-    if (arena.activePieceSetId && nextPieceSetId !== arena.activePieceSetId) {
+    const shouldSwapPieces = !arena.activePieceSetId || nextPieceSetId !== arena.activePieceSetId;
+    if (shouldSwapPieces) {
       pieceSetLoader(RAW_BOARD_SIZE)
         .then((assets) => {
           if (!arenaRef.current) return;


### PR DESCRIPTION
## Summary
- ensure Chess Battle Royal swaps piece sets even when no active set is recorded yet
- allow board and piece customization selections to apply consistently when appearance updates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693030b1f4088328bc69d9614427d99c)