### PR TITLE
Improve Pool Royale side pockets and cue cosmetics

### DIFF
--- a/webapp/src/config/cueStyles.js
+++ b/webapp/src/config/cueStyles.js
@@ -54,6 +54,24 @@ export const CUE_STYLE_PRESETS = Object.freeze([
     light: 0.16,
     contrast: 0.75,
     source: 'ambientCG Carbon Fiber 002 (CC0)'
+  }),
+  Object.freeze({
+    id: 'maple-horizon',
+    label: 'Maple Horizon',
+    hue: 35,
+    sat: 0.3,
+    light: 0.72,
+    contrast: 0.52,
+    source: 'ambientCG Maple 003 (CC0)'
+  }),
+  Object.freeze({
+    id: 'graphite-aurora',
+    label: 'Graphite Aurora',
+    hue: 250,
+    sat: 0.22,
+    light: 0.24,
+    contrast: 0.82,
+    source: 'Poly Haven Graphite Fiber 001 (CC0)'
   })
 ]);
 


### PR DESCRIPTION
## Summary
- move middle pocket jaws slightly further toward the table center to tighten side pocket cuts
- replace floating cue stripes with painted overlays driven by cue palette colors and add new cue style presets

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303c91e314832087d610f747bc12fe)