### PR TITLE
Refine Domino Royal seating and highlights

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -27,6 +27,10 @@
   #configSections::-webkit-scrollbar{width:.35rem;}
   #configSections::-webkit-scrollbar-thumb{background:rgba(148,197,255,.35);border-radius:999px;}
   #configSections::-webkit-scrollbar-track{background:transparent;}
+  #seatOverlay{position:fixed;inset:0;pointer-events:none;z-index:4;}
+  .seat-badge{position:absolute;transform:translate(-50%,-50%);width:3.25rem;height:3.25rem;pointer-events:none;}
+  .seat-badge .avatar-timer-ring{position:absolute;inset:0;border-radius:50%;pointer-events:none;background:var(--timer-gradient);-webkit-mask:radial-gradient(farthest-side,transparent 65%,black 66%);mask:radial-gradient(farthest-side,transparent 65%,black 66%);}
+  .seat-badge-core{position:absolute;inset:0;border-radius:999px;display:grid;place-items:center;font-size:1.35rem;font-weight:800;color:#0b1224;background:radial-gradient(circle at 30% 30%,rgba(255,255,255,.28),rgba(0,0,0,.12)),linear-gradient(135deg,#0ea5e9,#22c55e);box-shadow:0 10px 28px rgba(0,0,0,.35),0 0 0 2px rgba(255,255,255,.2);}
   .config-section{display:flex;flex-direction:column;gap:.3rem;}
   .config-options{display:grid;grid-template-columns:repeat(auto-fit,minmax(128px,1fr));gap:.45rem;}
   .config-option{border-radius:0.85rem;border:1px solid rgba(255,255,255,.12);background:rgba(15,23,42,.55);color:#e2e8f0;padding:.4rem .5rem;display:flex;flex-direction:column;align-items:flex-start;gap:.3rem;font-size:clamp(.62rem,1.75vw,.72rem);line-height:1.35;font-weight:600;transition:border-color .2s ease, box-shadow .2s ease, transform .2s ease;}
@@ -1254,6 +1258,33 @@ const TABLE_BASE_OPTIONS = Object.freeze([
   { id: "desertGold", label: "Desert Base", base: "#1c1a12", column: "#0f0d06", trim: "#5a4524" }
 ]);
 
+const HIGHLIGHT_STYLE_OPTIONS = Object.freeze([
+  {
+    id: 'marksmanAmber',
+    label: 'Marksman Amber',
+    gradient: 'conic-gradient(#fbbf24 360deg, #22c55e 0deg)',
+    icon: '🎯',
+    color: '#fbbf24',
+    emissive: '#c47c12'
+  },
+  {
+    id: 'iceTracer',
+    label: 'Ice Tracer',
+    gradient: 'conic-gradient(#a5f3fc 360deg, #0ea5e9 0deg)',
+    icon: '❄️',
+    color: '#67e8f9',
+    emissive: '#0ea5e9'
+  },
+  {
+    id: 'violetPulse',
+    label: 'Violet Pulse',
+    gradient: 'conic-gradient(#c084fc 360deg, #6366f1 0deg)',
+    icon: '✨',
+    color: '#c084fc',
+    emissive: '#6b21a8'
+  }
+]);
+
 const DOMINO_STYLE_OPTIONS = Object.freeze([
   {
     id: 'imperialIvory',
@@ -1429,6 +1460,76 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
       ringInner: 0.106,
       ringOuter: 0.123
     }
+  },
+  {
+    id: 'carbonVolt',
+    label: 'Carbon Volt',
+    preview: ['#0b1020', '#22d3ee'],
+    body: {
+      color: '#0c1428',
+      roughness: 0.28,
+      metalness: 0.48,
+      clearcoat: 0.95,
+      clearcoatRoughness: 0.06,
+      reflectivity: 0.62,
+      sheen: 0.24,
+      sheenColor: '#1f2a44'
+    },
+    pip: {
+      color: '#e0f2fe',
+      metalness: 0.68,
+      roughness: 0.18,
+      clearcoat: 0.62,
+      clearcoatRoughness: 0.04,
+      emissive: '#22d3ee',
+      emissiveIntensity: dimIntensity(0.2),
+      sheen: 0.18
+    },
+    accent: {
+      color: '#22d3ee',
+      emissive: '#0ea5e9',
+      emissiveIntensity: dimIntensity(0.54),
+      metalness: 0.98,
+      roughness: 0.18,
+      reflectivity: 1,
+      ringInner: 0.105,
+      ringOuter: 0.124
+    }
+  },
+  {
+    id: 'sandstoneAurora',
+    label: 'Sandstone Aurora',
+    preview: ['#f1d8b0', '#f97316'],
+    body: {
+      color: '#f1d8b0',
+      roughness: 0.34,
+      metalness: 0.22,
+      clearcoat: 0.82,
+      clearcoatRoughness: 0.08,
+      reflectivity: 0.58,
+      sheen: 0.26,
+      sheenColor: '#fff1db'
+    },
+    pip: {
+      color: '#422006',
+      metalness: 0.44,
+      roughness: 0.26,
+      clearcoat: 0.6,
+      clearcoatRoughness: 0.06,
+      emissive: '#6b2f0d',
+      emissiveIntensity: dimIntensity(0.14),
+      sheen: 0.16
+    },
+    accent: {
+      color: '#f97316',
+      emissive: '#c2410c',
+      emissiveIntensity: dimIntensity(0.46),
+      metalness: 0.93,
+      roughness: 0.2,
+      reflectivity: 0.98,
+      ringInner: 0.103,
+      ringOuter: 0.122
+    }
   }
 ]);
 
@@ -1437,10 +1538,11 @@ const TABLE_SETUP_SECTIONS = [
   { key: "tableCloth", label: "Table Cloth", options: TABLE_CLOTH_OPTIONS },
   { key: "tableBase", label: "Bazamenti", options: TABLE_BASE_OPTIONS },
   { key: "dominoStyle", label: "Domino", options: DOMINO_STYLE_OPTIONS },
+  { key: "highlightStyle", label: "Highlights", options: HIGHLIGHT_STYLE_OPTIONS },
   { key: "chairTheme", label: "Stolat", options: CHAIR_THEME_OPTIONS }
 ];
 
-const DEFAULT_APPEARANCE = { tableWood: 0, tableCloth: 1, tableBase: 0, dominoStyle: 0, chairTheme: 0 };
+const DEFAULT_APPEARANCE = { tableWood: 0, tableCloth: 1, tableBase: 0, dominoStyle: 0, highlightStyle: 0, chairTheme: 0 };
 const APPEARANCE_STORAGE_KEY = "dominoRoyalArenaAppearanceV2";
 const LEGACY_APPEARANCE_KEYS = ["dominoRoyalArenaAppearance"];
 let appearance = { ...DEFAULT_APPEARANCE };
@@ -1453,6 +1555,7 @@ function normalizeAppearance(raw) {
     ["tableCloth", TABLE_CLOTH_OPTIONS.length],
     ["tableBase", TABLE_BASE_OPTIONS.length],
     ["dominoStyle", DOMINO_STYLE_OPTIONS.length],
+    ["highlightStyle", HIGHLIGHT_STYLE_OPTIONS.length],
     ["chairTheme", CHAIR_THEME_OPTIONS.length]
   ];
   limits.forEach(([key, max]) => {
@@ -2492,6 +2595,10 @@ let seatLabelMesh = null;
 let seatLabelShouldDisplay = shouldShowSeatLabel;
 const seatAvatars = [];
 const seatNameTags = [];
+const seatBadges = [];
+const seatOverlay = document.createElement('div');
+seatOverlay.id = 'seatOverlay';
+document.body.appendChild(seatOverlay);
 
 function buildSeatNames(count = N) {
   return getSeatUsernames(count);
@@ -2575,6 +2682,27 @@ function refreshSeatAvatars() {
   ).catch((error) => console.warn('Failed to refresh seat avatars', error));
 }
 
+const projectedSeatTarget = new THREE.Vector3();
+function updateSeatBadgePositions() {
+  if (!seatBadges.length || !chairs.length || !renderer?.domElement) return;
+  const rect = renderer.domElement.getBoundingClientRect();
+  const gradient = (currentHighlightStyle && currentHighlightStyle.gradient) ||
+    'conic-gradient(#fbbf24 360deg, #22c55e 0deg)';
+  seatBadges.forEach((badge) => badge?.style?.setProperty?.('--timer-gradient', gradient));
+  chairs.forEach((wrapper, idx) => {
+    const badge = seatBadges[idx];
+    if (!badge) return;
+    const world = wrapper.getWorldPosition(projectedSeatTarget);
+    world.y += CHAIR_DIMENSIONS.seatThickness + CHAIR_DIMENSIONS.backHeight * 0.62;
+    world.project(camera);
+    const x = (world.x * 0.5 + 0.5) * rect.width + rect.left;
+    const y = (1 - (world.y * 0.5 + 0.5)) * rect.height + rect.top;
+    badge.style.left = `${x}px`;
+    badge.style.top = `${y}px`;
+    badge.style.opacity = world.z > 1 || world.z < -1 ? '0' : '1';
+  });
+}
+
 function disposeSeatAvatars() {
   while (seatAvatars.length) {
     const sprite = seatAvatars.pop();
@@ -2599,6 +2727,41 @@ function disposeSeatNameTags() {
       tag.geometry?.dispose?.();
     } catch {}
   }
+}
+
+function disposeSeatBadges() {
+  while (seatBadges.length) {
+    const badge = seatBadges.pop();
+    badge?.remove?.();
+  }
+  seatOverlay.innerHTML = '';
+}
+
+function createSeatBadge(icon = '🎯') {
+  const wrap = document.createElement('div');
+  wrap.className = 'seat-badge';
+  const ring = document.createElement('div');
+  ring.className = 'avatar-timer-ring';
+  wrap.appendChild(ring);
+  const core = document.createElement('div');
+  core.className = 'seat-badge-core';
+  core.textContent = icon || '🎯';
+  wrap.appendChild(core);
+  seatOverlay.appendChild(wrap);
+  return wrap;
+}
+
+function refreshSeatBadges(icons = []) {
+  disposeSeatBadges();
+  const gradient = (currentHighlightStyle && currentHighlightStyle.gradient) ||
+    'conic-gradient(#fbbf24 360deg, #22c55e 0deg)';
+  const entries = icons.length ? icons : Array.from({ length: N }, () => '🎯');
+  entries.forEach((icon) => {
+    const badge = createSeatBadge(icon);
+    badge.style.setProperty('--timer-gradient', gradient);
+    seatBadges.push(badge);
+  });
+  seatOverlay.style.setProperty('--timer-gradient', gradient);
 }
 
 function disposeSeatLabel({ persistPreference = true } = {}) {
@@ -2757,21 +2920,21 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   tableParts.column = column;
 
   const base = new THREE.Mesh(
-    new THREE.CylinderGeometry(TABLE_OUTER_RADIUS * 0.86, TABLE_OUTER_RADIUS * 0.96, 0.16, 64),
+    new THREE.CylinderGeometry(TABLE_OUTER_RADIUS * 1.02, TABLE_OUTER_RADIUS * 1.18, 0.22, 64),
     tableMaterials.base
   );
-  base.position.y = column.position.y - columnHeight / 2 - 0.08;
+  base.position.y = column.position.y - columnHeight / 2 - 0.11;
   base.castShadow = true;
   base.receiveShadow = true;
   tableG.add(base);
   tableParts.base = base;
 
   const trim = new THREE.Mesh(
-    new THREE.TorusGeometry(TABLE_OUTER_RADIUS * 0.9, 0.035, 16, 64),
+    new THREE.TorusGeometry(TABLE_OUTER_RADIUS * 1.08, 0.04, 16, 64),
     tableMaterials.trim
   );
   trim.rotation.x = Math.PI / 2;
-  trim.position.y = base.position.y + 0.08;
+  trim.position.y = base.position.y + 0.11;
   tableG.add(trim);
   tableParts.trim = trim;
 })();
@@ -2784,7 +2947,7 @@ const DOMINO_LENGTH = DOMINO_WORLD_SCALE * (0.016 / 0.22) * 2;
 const DOUBLE_END_SHIFT = Math.max(0, (DOMINO_LENGTH - DOMINO_WIDTH) / 2);
 const DOMINO_CHAIN_GAP = DOMINO_LENGTH * 0.03;
 const STEP = DOMINO_LENGTH + DOMINO_CHAIN_GAP;
-const DOMINO_HAND_GAP = DOMINO_LENGTH * 0.82;
+const DOMINO_HAND_GAP = DOMINO_LENGTH * 0.7;
 const TILE_UP_H = 0.2 * DOMINO_WORLD_SCALE;
 const TILE_UP_HALF = TILE_UP_H / 2;
 const XMAX = CLOTH_RADIUS - 0.32 - DOMINO_CHAIN_GAP * 0.5;
@@ -2805,6 +2968,8 @@ let dominoStyleProfile = {
   pipRadius: currentDominoStyleOption?.pip?.radius ?? 0.085,
   ringEmissiveIntensity: currentDominoStyleOption?.accent?.ringEmissiveIntensity ?? 0.55
 };
+let currentHighlightStyle = HIGHLIGHT_STYLE_OPTIONS[DEFAULT_APPEARANCE.highlightStyle] ?? HIGHLIGHT_STYLE_OPTIONS[0];
+let markers = { L: null, R: null };
 
 function disposeDominoBaseMaterials() {
   if (porcelainMat) {
@@ -2923,6 +3088,38 @@ function applyDominoStyle(option = DOMINO_STYLE_OPTIONS[0]) {
 applyDominoStyle(currentDominoStyleOption);
 const markerMat = new THREE.MeshStandardMaterial({ color:"#15d16f", roughness:.7, metalness:0, transparent:true, opacity:.55 });
 
+function applyHighlightStyle(option = HIGHLIGHT_STYLE_OPTIONS[0]) {
+  currentHighlightStyle = option ?? HIGHLIGHT_STYLE_OPTIONS[0];
+  const gradient = currentHighlightStyle.gradient ?? 'conic-gradient(#fbbf24 360deg, #22c55e 0deg)';
+  markerMat.color.set(currentHighlightStyle.color ?? '#15d16f');
+  if (markerMat.emissive) {
+    markerMat.emissive.set(currentHighlightStyle.emissive ?? '#0f172a');
+    markerMat.emissiveIntensity = 0.5;
+  }
+  markerMat.opacity = currentHighlightStyle.opacity ?? 0.6;
+  markerMat.needsUpdate = true;
+  if (markers?.L?.material) {
+    markers.L.material.color.copy(markerMat.color);
+    markers.L.material.emissive?.copy?.(markerMat.emissive ?? new THREE.Color('#0f172a'));
+    markers.L.material.opacity = markerMat.opacity;
+    markers.L.material.needsUpdate = true;
+  }
+  if (markers?.R?.material) {
+    markers.R.material.color.copy(markerMat.color);
+    markers.R.material.emissive?.copy?.(markerMat.emissive ?? new THREE.Color('#0f172a'));
+    markers.R.material.opacity = markerMat.opacity;
+    markers.R.material.needsUpdate = true;
+  }
+  seatBadges.forEach((badge) => {
+    badge?.style?.setProperty?.('--timer-gradient', gradient);
+    const core = badge?.querySelector?.('.seat-badge-core');
+    if (core) {
+      core.textContent = currentHighlightStyle.icon || core.textContent || '🎯';
+    }
+  });
+  seatOverlay.style.setProperty('--timer-gradient', gradient);
+}
+
 /* ---------- Game Collections (pre-declare for style refresh) ---------- */
 let N = 4;
 let players = [];
@@ -3032,6 +3229,7 @@ function applyAppearanceChange({ refresh = true } = {}) {
   clearExistingDominoMeshes();
   updateTableMaterials();
   applyDominoStyle(DOMINO_STYLE_OPTIONS[appearance.dominoStyle] ?? DOMINO_STYLE_OPTIONS[0]);
+  applyHighlightStyle(HIGHLIGHT_STYLE_OPTIONS[appearance.highlightStyle] ?? HIGHLIGHT_STYLE_OPTIONS[0]);
   Object.values(tableMaterials).forEach((material) => {
     if (material && typeof material.needsUpdate === 'boolean') {
       material.needsUpdate = true;
@@ -3047,6 +3245,7 @@ function applyAppearanceChange({ refresh = true } = {}) {
   renderHands();
   renderChain();
   renderBoneyardStack();
+  refreshSeatBadges(buildSeatAvatarSources(N));
   saveAppearance();
   if (refresh) {
     refreshConfigUI();
@@ -3135,6 +3334,27 @@ function createOptionPreview(key, option) {
         swatch.appendChild(inset);
       }
       break;
+    case 'highlightStyle': {
+      swatch.style.position = 'relative';
+      swatch.style.overflow = 'hidden';
+      swatch.style.background = 'radial-gradient(circle at 30% 30%, rgba(255,255,255,0.18), rgba(0,0,0,0.1))';
+      const ring = document.createElement('div');
+      ring.className = 'avatar-timer-ring';
+      ring.style.position = 'absolute';
+      ring.style.inset = '0.25rem';
+      ring.style.setProperty('--timer-gradient', option.gradient ?? 'conic-gradient(#fbbf24 360deg, #22c55e 0deg)');
+      swatch.appendChild(ring);
+      const icon = document.createElement('div');
+      icon.style.position = 'absolute';
+      icon.style.inset = '0';
+      icon.style.display = 'grid';
+      icon.style.placeItems = 'center';
+      icon.style.fontSize = '1rem';
+      icon.style.fontWeight = '800';
+      icon.textContent = option.icon || '🎯';
+      swatch.appendChild(icon);
+      break;
+    }
     case 'chairTheme':
       swatch.style.background = option.seatColor;
       break;
@@ -3261,6 +3481,7 @@ function placeChairsWithOption(option, chairData, token) {
   disposeSeatLabel({ persistPreference: false });
   disposeSeatAvatars();
   disposeSeatNameTags();
+  disposeSeatBadges();
   while (chairs.length) {
     const chair = chairs.pop();
     chair.parent?.remove(chair);
@@ -3295,7 +3516,6 @@ function placeChairsWithOption(option, chairData, token) {
       };
 
   const seatAvatarSources = buildSeatAvatarSources(N);
-  const seatNames = buildSeatNames(N);
 
   CHAIR_SEAT_ANGLES.forEach((angle, index) => {
     const radius = CHAIR_SEAT_RADII[index] ?? CHAIR_RADIUS;
@@ -3311,29 +3531,6 @@ function placeChairsWithOption(option, chairData, token) {
     wrapper.add(chair);
 
     wrapper.updateWorldMatrix(true, true);
-    const chairBox = new THREE.Box3().setFromObject(chair);
-    const avatarSource = seatAvatarSources[index] ?? DEFAULT_AVATAR_EMOJI;
-    const avatarScale = index === HUMAN_SEAT_INDEX ? 1.02 : 1.12;
-    const avatar = createSeatAvatarSprite(avatarSource, avatarScale);
-    const avatarHeight = Math.max(chairBox.max.y - wrapper.position.y, CHAIR_BASE_HEIGHT + SEAT_THICKNESS * 1.2);
-    const avatarYOffset = index === HUMAN_SEAT_INDEX ? -SEAT_THICKNESS * 1.05 : -SEAT_THICKNESS * 0.68;
-    const avatarY = avatarHeight - SEAT_THICKNESS * 0.36 + avatarYOffset;
-    const avatarDepthFactor = index === HUMAN_SEAT_INDEX ? 0.06 : 0.085;
-    avatar.position.set(0, avatarY, labelDepth * avatarDepthFactor);
-    if (index === HUMAN_SEAT_INDEX) {
-      avatar.visible = false;
-    }
-    avatar.lookAt(lookTarget.x, avatar.position.y, lookTarget.z);
-    wrapper.add(avatar);
-    seatAvatars.push(avatar);
-
-    const nameTag = createSeatNameTag(seatNames[index] ?? 'Player');
-    const nameTagYOffset = SEAT_THICKNESS * 0.28;
-    nameTag.position.set(0, avatarY + nameTagYOffset, labelDepth * (avatarDepthFactor + 0.015));
-    nameTag.lookAt(lookTarget.x, nameTag.position.y, lookTarget.z);
-    wrapper.add(nameTag);
-    seatNameTags.push(nameTag);
-
     tableG.add(wrapper);
     chairs.push(wrapper);
 
@@ -3345,7 +3542,7 @@ function placeChairsWithOption(option, chairData, token) {
     }
   });
 
-  refreshSeatAvatars();
+  refreshSeatBadges(seatAvatarSources);
 }
 
 async function buildChairs(option = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME) {
@@ -3480,7 +3677,7 @@ function makeDomino(a,b,{flat=true, faceUp=true, preserveOrder=false}={}){
   group.add(body);
 
   // Invisible collider to make touch / pick detection more forgiving on mobile
-  const colliderGeo = new THREE.BoxGeometry(1.85, faceUp ? 0.82 : 1.4, 1.85);
+  const colliderGeo = new THREE.BoxGeometry(2.05, faceUp ? 0.95 : 1.55, 2.05);
   const colliderMat = new THREE.MeshBasicMaterial({ transparent: true, opacity: 0, depthWrite: false });
   const collider = new THREE.Mesh(colliderGeo, colliderMat);
   collider.name = 'touchCollider';
@@ -3512,7 +3709,7 @@ const closeRules = document.getElementById('closeRules');
 let statusPrefix = '';
 let ends = null; // {L:{v,x,z,dir:[dx,dz]}, R:{...}}
 let current = 0; let human = 0;
-let markers = {L:null, R:null}; let selectedTile = null;
+let selectedTile = null;
 let selectedHighlight = null;
 let selectedHighlightHost = null;
 let flipDir = false; // alternate chain direction after each game
@@ -3578,7 +3775,7 @@ function renderHands(){
     const isSide = (pi===1 || pi===3);
     const openFlat = isTopDown && isHuman;
 
-    const gapBase = openFlat ? BASE_GAP * 1.3 : BASE_GAP;
+    const gapBase = openFlat ? BASE_GAP * 1.12 : BASE_GAP;
     const handY = openFlat ? CLOTH_TOP + 0.018 : HAND_Y;
 
     let span = 0;
@@ -4305,7 +4502,7 @@ function showMarkersFor(tile){
 /* ---------- Interactivity ---------- */
 const raycaster=new THREE.Raycaster(); const pointer=new THREE.Vector2();
 raycaster.params.Mesh = raycaster.params.Mesh || {};
-raycaster.params.Mesh.threshold = 0.06;
+raycaster.params.Mesh.threshold = 0.12;
 const activePointers = new Set();
 function findPickRoot(o){
   let n=o; while(n){ if(n.userData && (n.userData.owner!==undefined || n.userData.marker)) return n; n=n.parent; } return o;
@@ -4669,6 +4866,7 @@ function tick(now){
   updateDrawAnimations(current);
   updatePlacementAnimations(current);
   updateWinnerHighlight(current);
+  updateSeatBadgePositions();
   controls.update(deltaSeconds);
   renderer.render(scene,camera);
   requestAnimationFrame(tick);
@@ -4697,6 +4895,7 @@ function onResize(){
   } else {
     positionCameraForViewport();
   }
+  updateSeatBadgePositions();
 }
 addEventListener('resize', onResize); if(window.visualViewport){ visualViewport.addEventListener('resize', onResize); }
 


### PR DESCRIPTION
## Summary
- replace 3D seat avatars with Chess-style overlay badges and add configurable highlight styles
- add new Domino style variants and reduce hand spacing with improved touch sensitivity
- widen the table base footprint for better visibility and expose highlight options in the setup panel

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69305745f06c83209119b0eef55c737f)