### PR TITLE
Enhance Domino Royal avatars and scoreboard

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -20,17 +20,20 @@
   #configButton{position:fixed;top:calc(0.75rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));width:3rem;height:3rem;border-radius:999px;background:rgba(0,0,0,.7);color:#fff;border:1px solid rgba(255,255,255,.18);display:grid;place-items:center;box-shadow:0 6px 18px rgba(0,0,0,.35);z-index:3;backdrop-filter:blur(8px);padding:0;transition:background .2s ease, border-color .2s ease;}
   #configButton:hover{background:rgba(0,0,0,.6);border-color:rgba(148,197,255,.45);}
   #configButton svg{width:1.4rem;height:1.4rem;}
-  #configPanel{position:fixed;top:calc(4.4rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));max-width:min(320px, 84vw);max-height:min(72dvh, 480px);background:rgba(3,7,18,.92);color:#fff;border-radius:1.25rem;box-shadow:0 24px 40px rgba(2,6,23,.55);padding:0.85rem 1rem;border:1px solid rgba(148,197,255,.2);z-index:3;backdrop-filter:blur(10px);display:none;flex-direction:column;gap:0.65rem;overflow:hidden;}
-  #configPanel.active{display:flex;}
+  #configPanel{position:fixed;top:50%;left:calc(0.75rem + env(safe-area-inset-left,0px));transform:translate(-110%,-50%);width:clamp(320px,32vw,420px);max-height:min(82dvh,640px);background:rgba(3,7,18,.94);color:#fff;border-radius:1.5rem;box-shadow:0 26px 46px rgba(2,6,23,.6);padding:1rem 1.15rem;border:1px solid rgba(148,197,255,.24);z-index:3;backdrop-filter:blur(12px);display:flex;flex-direction:column;gap:0.65rem;overflow:hidden;opacity:0;pointer-events:none;transition:transform .2s ease-out, opacity .18s ease-out;}
+  #configPanel.active{transform:translate(0,-50%);opacity:1;pointer-events:auto;}
   #configPanel h3{margin:0;font-size:.62rem;text-transform:uppercase;letter-spacing:.28rem;color:rgba(148,197,255,.75);}
   #configSections{display:flex;flex-direction:column;gap:.55rem;overflow-y:auto;padding-right:.3rem;margin-right:-.3rem;scrollbar-gutter:stable both-edges;overscroll-behavior:contain;}
   #configSections::-webkit-scrollbar{width:.35rem;}
   #configSections::-webkit-scrollbar-thumb{background:rgba(148,197,255,.35);border-radius:999px;}
   #configSections::-webkit-scrollbar-track{background:transparent;}
   #seatOverlay{position:fixed;inset:0;pointer-events:none;z-index:4;}
-  .seat-badge{position:absolute;transform:translate(-50%,-50%);width:3.25rem;height:3.25rem;pointer-events:none;}
+  .seat-badge{position:absolute;transform:translate(-50%,-50%);width:min(18vw,4.1rem);height:min(18vw,4.1rem);pointer-events:none;}
   .seat-badge .avatar-timer-ring{position:absolute;inset:0;border-radius:50%;pointer-events:none;background:var(--timer-gradient);-webkit-mask:radial-gradient(farthest-side,transparent 65%,black 66%);mask:radial-gradient(farthest-side,transparent 65%,black 66%);}
-  .seat-badge-core{position:absolute;inset:0;border-radius:999px;display:grid;place-items:center;font-size:1.35rem;font-weight:800;color:#0b1224;background:radial-gradient(circle at 30% 30%,rgba(255,255,255,.28),rgba(0,0,0,.12)),linear-gradient(135deg,#0ea5e9,#22c55e);box-shadow:0 10px 28px rgba(0,0,0,.35),0 0 0 2px rgba(255,255,255,.2);}
+  .seat-badge-core{display:none;}
+  .seat-badge-img{position:absolute;inset:0;border-radius:50%;object-fit:cover;border:2px solid rgba(255,255,255,.82);box-shadow:0 6px 14px rgba(0,0,0,.35);background:radial-gradient(circle at 30% 30%,rgba(255,255,255,.28),rgba(0,0,0,.12));}
+  .seat-name-arc{position:absolute;inset:0;pointer-events:none;}
+  .seat-name-arc text{font-size:11px;font-weight:800;letter-spacing:.6px;fill:#ffe8a3;paint-order:stroke;stroke:#0b1224;stroke-width:1px;}
   .config-section{display:flex;flex-direction:column;gap:.3rem;}
   .config-options{display:grid;grid-template-columns:repeat(auto-fit,minmax(128px,1fr));gap:.45rem;}
   .config-option{border-radius:0.85rem;border:1px solid rgba(255,255,255,.12);background:rgba(15,23,42,.55);color:#e2e8f0;padding:.4rem .5rem;display:flex;flex-direction:column;align-items:flex-start;gap:.3rem;font-size:clamp(.62rem,1.75vw,.72rem);line-height:1.35;font-weight:600;transition:border-color .2s ease, box-shadow .2s ease, transform .2s ease;}
@@ -41,8 +44,24 @@
   .config-close{display:flex;justify-content:flex-end;}
   .config-close button{background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.12);color:#f1f5f9;border-radius:999px;padding:.35rem;display:grid;place-items:center;transition:background .2s ease, border-color .2s ease;}
   .config-close button:hover{background:rgba(248,250,252,.16);border-color:rgba(248,250,252,.38);}
+  #scoreboard{position:fixed;top:calc(1rem + env(safe-area-inset-top,0px));right:calc(0.85rem + env(safe-area-inset-right,0px));width:min(320px,88vw);background:rgba(7,10,18,.8);color:#f8fafc;border-radius:1rem;border:1px solid rgba(255,210,74,.4);box-shadow:0 18px 36px rgba(0,0,0,.35);backdrop-filter:blur(8px);padding:0.75rem 0.85rem;z-index:3;}
+  #scoreboard h3{margin:0 0 .35rem 0;font-size:.9rem;letter-spacing:.04em;text-transform:uppercase;color:#facc15;}
+  #scoreboard table{width:100%;border-collapse:separate;border-spacing:0 .35rem;}
+  #scoreboard th,#scoreboard td{font-size:.82rem;padding:.35rem .55rem;text-align:left;}
+  #scoreboard tr{background:rgba(255,255,255,.05);border-radius:0.65rem;overflow:hidden;}
+  #scoreboard tr.active-row{background:rgba(52,211,153,.16);}
+  #scoreboard tr:first-child th:first-child,#scoreboard tr td:first-child{border-top-left-radius:.65rem;border-bottom-left-radius:.65rem;}
+  #scoreboard tr:first-child th:last-child,#scoreboard tr td:last-child{border-top-right-radius:.65rem;border-bottom-right-radius:.65rem;}
+  #scoreboard .score-pill{display:inline-block;padding:.12rem .45rem;border-radius:999px;background:rgba(250,204,21,.16);border:1px solid rgba(250,204,21,.4);font-weight:700;}
   @media (max-width:640px){
-    #configPanel{left:50%;transform:translateX(-50%);top:calc(4.75rem + env(safe-area-inset-top,0px));}
+    #scoreboard{left:calc(0.75rem + env(safe-area-inset-left,0px));right:calc(0.75rem + env(safe-area-inset-right,0px));top:calc(0.75rem + env(safe-area-inset-top,0px));width:auto;}
+  }
+  @media (max-width:720px){
+    #configPanel{left:calc(0.75rem + env(safe-area-inset-left,0px));right:calc(0.75rem + env(safe-area-inset-right,0px));width:auto;max-width:unset;top:calc(4.4rem + env(safe-area-inset-top,0px));transform:translateY(-120%);max-height:72dvh;border-radius:1rem;}
+    #configPanel.active{transform:translateY(0);}
+  }
+  @media (max-width:480px){
+    #configPanel{padding:0.85rem 1rem;gap:0.55rem;}
   }
   #rules{position:fixed;top:0;left:0;right:0;bottom:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);z-index:3}
   #rules .card{max-width:720px;background:#fff;color:#222;border-radius:16px;box-shadow:0 12px 40px rgba(0,0,0,.25);padding:16px 18px}
@@ -267,7 +286,7 @@ const TABLE_SCALE = 0.85;
 const ARENA_GROWTH = 1.45;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE * TABLE_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE * TABLE_SCALE;
-const STOOL_SCALE = 1.5 * 1.3;
+const STOOL_SCALE = 1.5 * 1.28;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
@@ -283,7 +302,7 @@ const COLUMN_RADIUS_BOTTOM = 0.26 * MODEL_SCALE;
 const BASE_RADIUS = 0.72 * MODEL_SCALE;
 const FOOT_RING_RADIUS = 0.52 * MODEL_SCALE;
 const FOOT_RING_TUBE = 0.04 * MODEL_SCALE;
-const CHAIR_GAP = 0.12 * MODEL_SCALE;
+const CHAIR_GAP = 0.04 * MODEL_SCALE;
 const CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + CHAIR_GAP;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
@@ -2600,8 +2619,79 @@ const seatOverlay = document.createElement('div');
 seatOverlay.id = 'seatOverlay';
 document.body.appendChild(seatOverlay);
 
+const SCOREBOARD_STORAGE_KEY = 'dominoRoyalScores';
+let seatNames = [];
+let seatScores = [];
+const scoreBoard = document.createElement('div');
+scoreBoard.id = 'scoreboard';
+const scoreTitle = document.createElement('h3');
+scoreTitle.textContent = 'Scoreboard';
+const scoreTable = document.createElement('table');
+scoreBoard.append(scoreTitle, scoreTable);
+document.body.appendChild(scoreBoard);
+
+function emojiToDataUrl(symbol = DEFAULT_AVATAR_EMOJI) {
+  const svg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'><text y='96' font-size='96'>${symbol}</text></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+function normalizeAvatarSource(source = DEFAULT_AVATAR_EMOJI) {
+  const label = (source || DEFAULT_AVATAR_EMOJI).toString().trim();
+  if (!label) return emojiToDataUrl(DEFAULT_AVATAR_EMOJI);
+  if (isAvatarUrl(label)) return label;
+  return emojiToDataUrl(label);
+}
+
+function loadSeatScores() {
+  try {
+    const raw = localStorage.getItem(SCOREBOARD_STORAGE_KEY);
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.map((n) => (Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0));
+    }
+  } catch {}
+  return [];
+}
+
+function saveSeatScores() {
+  try {
+    localStorage.setItem(SCOREBOARD_STORAGE_KEY, JSON.stringify(seatScores));
+  } catch {}
+}
+
+function syncSeatScores(count = N) {
+  const maxPlayers = Math.max(2, Math.min(4, Number.isFinite(count) ? count : 4));
+  const stored = seatScores.length ? seatScores : loadSeatScores();
+  seatScores = Array.from({ length: maxPlayers }, (_, idx) => stored[idx] ?? 0);
+  saveSeatScores();
+}
+
+function updateScoreboardUI(activeIndex = null) {
+  if (!scoreTable) return;
+  const names = seatNames.length ? seatNames : getSeatUsernames(N);
+  const bodyRows = names
+    .map((name, idx) => {
+      const score = seatScores[idx] ?? 0;
+      const active = activeIndex === idx;
+      return `<tr class="${active ? 'active-row' : ''}"><td>${name || `Player ${idx + 1}`}</td><td><span class="score-pill">${score}</span></td></tr>`;
+    })
+    .join('');
+  scoreTable.innerHTML = `<thead><tr><th>Player</th><th>Score</th></tr></thead><tbody>${bodyRows}</tbody>`;
+}
+
+function recordWinScore(winnerIdx = null) {
+  syncSeatScores(N);
+  if (Number.isInteger(winnerIdx) && winnerIdx >= 0 && winnerIdx < seatScores.length) {
+    seatScores[winnerIdx] = (seatScores[winnerIdx] || 0) + 1;
+    saveSeatScores();
+  }
+  updateScoreboardUI(winnerIdx);
+}
+
 function buildSeatNames(count = N) {
-  return getSeatUsernames(count);
+  seatNames = getSeatUsernames(count);
+  updateScoreboardUI(current);
+  return seatNames;
 }
 
 function isAvatarUrl(str = '') {
@@ -2613,12 +2703,12 @@ function buildSeatAvatarSources(count = N) {
   return Array.from({ length: total }, (_, idx) => {
     if (idx === HUMAN_SEAT_INDEX) {
       const preferred = seatAvatarPhoto || (aiAvatarMode === 'flags' ? selectedFlagAvatars[idx] : '');
-      return preferred || pickFlagForSeat(idx);
+      return normalizeAvatarSource(preferred || pickFlagForSeat(idx));
     }
     if (aiAvatarMode === 'flags') {
-      return pickFlagForSeat(idx);
+      return normalizeAvatarSource(pickFlagForSeat(idx));
     }
-    return pickFlagForSeat(idx);
+    return normalizeAvatarSource(pickFlagForSeat(idx));
   });
 }
 
@@ -2630,7 +2720,7 @@ async function createSeatAvatarTexture(source = DEFAULT_AVATAR_EMOJI) {
   ctx.clearRect(0, 0, size, size);
 
   const center = size / 2;
-  const label = typeof source === 'string' && source.trim() ? source.trim() : DEFAULT_AVATAR_EMOJI;
+  const label = normalizeAvatarSource(typeof source === 'string' && source.trim() ? source.trim() : DEFAULT_AVATAR_EMOJI);
   ctx.fillStyle = '#fffbe6';
   ctx.font = `${size * 0.22}px "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji", sans-serif`;
   ctx.textAlign = 'center';
@@ -2639,11 +2729,16 @@ async function createSeatAvatarTexture(source = DEFAULT_AVATAR_EMOJI) {
     await new Promise((resolve) => {
       const img = new Image();
       img.crossOrigin = 'anonymous';
+      img.referrerPolicy = 'no-referrer';
+      img.decoding = 'async';
       img.onload = () => resolve(img);
       img.onerror = () => resolve(null);
       img.src = label;
     }).then((img) => {
-      if (!img) return;
+      if (!img) {
+        ctx.fillText(DEFAULT_AVATAR_EMOJI, center, center);
+        return;
+      }
       const maxSide = Math.max(img.width, img.height) || 1;
       const drawSize = size * 0.44;
       const ratio = drawSize / maxSide;
@@ -2737,30 +2832,67 @@ function disposeSeatBadges() {
   seatOverlay.innerHTML = '';
 }
 
-function createSeatBadge(icon = '🎯') {
+function createSeatNameArc(label = '', index = 0) {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 100 50');
+  svg.classList.add('seat-name-arc');
+  const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  const radius = 46;
+  const start = 50 - radius;
+  const end = 50 + radius;
+  const arcId = `seat-name-${index}-${Math.floor(performance.now())}`;
+  path.setAttribute('id', arcId);
+  path.setAttribute('d', `M${start},50 A${radius},${radius} 0 0 1 ${end},50`);
+  defs.appendChild(path);
+  const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+  const textPath = document.createElementNS('http://www.w3.org/2000/svg', 'textPath');
+  textPath.setAttributeNS('http://www.w3.org/1999/xlink', 'href', `#${arcId}`);
+  textPath.setAttribute('startOffset', '50%');
+  textPath.setAttribute('text-anchor', 'middle');
+  textPath.textContent = label;
+  text.appendChild(textPath);
+  svg.append(defs, text);
+  return svg;
+}
+
+function createSeatBadge(icon = '🎯', name = '', index = 0) {
   const wrap = document.createElement('div');
   wrap.className = 'seat-badge';
   const ring = document.createElement('div');
   ring.className = 'avatar-timer-ring';
   wrap.appendChild(ring);
-  const core = document.createElement('div');
-  core.className = 'seat-badge-core';
-  core.textContent = icon || '🎯';
-  wrap.appendChild(core);
+  const img = document.createElement('img');
+  img.className = 'seat-badge-img';
+  img.alt = name || 'Player avatar';
+  img.decoding = 'async';
+  img.loading = 'lazy';
+  img.referrerPolicy = 'no-referrer';
+  img.src = normalizeAvatarSource(icon || DEFAULT_AVATAR_EMOJI);
+  img.onerror = () => {
+    img.src = emojiToDataUrl(DEFAULT_AVATAR_EMOJI);
+  };
+  wrap.appendChild(img);
+  if (name) {
+    wrap.appendChild(createSeatNameArc(name, index));
+  }
   seatOverlay.appendChild(wrap);
   return wrap;
 }
 
-function refreshSeatBadges(icons = []) {
+function refreshSeatBadges({ avatars = [], names = [] } = {}) {
   disposeSeatBadges();
   const gradient = (currentHighlightStyle && currentHighlightStyle.gradient) ||
     'conic-gradient(#fbbf24 360deg, #22c55e 0deg)';
-  const entries = icons.length ? icons : Array.from({ length: N }, () => '🎯');
-  entries.forEach((icon) => {
-    const badge = createSeatBadge(icon);
+  const entries = avatars.length ? avatars : Array.from({ length: N }, () => DEFAULT_AVATAR_EMOJI);
+  const labels = names.length ? names : buildSeatNames(entries.length);
+  entries.forEach((icon, idx) => {
+    const badge = createSeatBadge(icon, labels[idx] || `Player ${idx + 1}`, idx);
     badge.style.setProperty('--timer-gradient', gradient);
     seatBadges.push(badge);
   });
+  seatNames = labels;
+  updateScoreboardUI(current);
   seatOverlay.style.setProperty('--timer-gradient', gradient);
 }
 
@@ -3112,10 +3244,6 @@ function applyHighlightStyle(option = HIGHLIGHT_STYLE_OPTIONS[0]) {
   }
   seatBadges.forEach((badge) => {
     badge?.style?.setProperty?.('--timer-gradient', gradient);
-    const core = badge?.querySelector?.('.seat-badge-core');
-    if (core) {
-      core.textContent = currentHighlightStyle.icon || core.textContent || '🎯';
-    }
   });
   seatOverlay.style.setProperty('--timer-gradient', gradient);
 }
@@ -3245,7 +3373,7 @@ function applyAppearanceChange({ refresh = true } = {}) {
   renderHands();
   renderChain();
   renderBoneyardStack();
-  refreshSeatBadges(buildSeatAvatarSources(N));
+  refreshSeatBadges({ avatars: buildSeatAvatarSources(N), names: buildSeatNames(N) });
   saveAppearance();
   if (refresh) {
     refreshConfigUI();
@@ -3542,7 +3670,7 @@ function placeChairsWithOption(option, chairData, token) {
     }
   });
 
-  refreshSeatBadges(seatAvatarSources);
+  refreshSeatBadges({ avatars: seatAvatarSources, names: buildSeatNames(N) });
 }
 
 async function buildChairs(option = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME) {
@@ -3741,6 +3869,10 @@ if (Number.isFinite(stakeAmount) && stakeAmount > 0) {
   statusPrefix = `Stake ${stakeAmount.toLocaleString('en-US')} ${stakeToken.toUpperCase()}`;
   setStatus('Ready');
 }
+
+syncSeatScores(N);
+buildSeatNames(N);
+updateScoreboardUI();
 
 applyAppearanceChange({ refresh: false });
 refreshConfigUI();
@@ -4635,6 +4767,8 @@ function finishGame({ winner = null, reason = '', revealAll = false } = {}){
     setStatus('Game over');
   }
 
+  recordWinScore(winnerIndex);
+
   if(winnerIndex !== null){
     SFX.win();
   } else {
@@ -4661,6 +4795,7 @@ function updateInteractivity(){
     return;
   }
   setStatus(`Turn: Player ${current+1}`);
+  updateScoreboardUI(current);
   renderHands(); renderChain();
 }
 function nextTurn(){


### PR DESCRIPTION
## Summary
- reposition and restyle the Domino Royal table setup panel for better mobile usability while bringing chairs closer to the table
- harden avatar loading and render curved username badges around seats matching the Ludo Battle Royal style
- add a persistent scoreboard overlay to track player points across Domino Royal rounds

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69305df3c6dc83209047ef4eed420d52)