### PR TITLE
Tighten Pool Royale middle pockets

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -420,19 +420,20 @@ const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 2.05; // push the side fascia farthe
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.9; // align fascia reach with snooker so the arch covers the relieved cut without overhang
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.21; // stretch fascia span farther along the side rails without pushing toward the field
+const CHROME_SIDE_PLATE_NON_CUT_EXPANSION_SCALE = 1.3; // expand the side fascia on every edge except the pocket cut by thirty percent
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 0.804; // bias the side chrome growth toward the corner pockets only
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.04; // push the side fascias slightly farther from centre so their outer edge stays flush while widening the reveal
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.058; // trim the middle chrome arch so the rounded cut sits even smaller against the fascia
-const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.16; // pull the middle chrome arch farther toward centre so the rounded fascia cut tracks the shifted pocket more aggressively
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.24; // pull the middle chrome arch farther toward centre so the rounded fascia cut tracks the shifted pocket more aggressively
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
 const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.024; // pinch the middle rail arches slightly tighter so the rounded cut radius comes in further toward the jaws
-const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = 0.12; // pull the middle-pocket wood arch farther toward centre so the smaller radius aligns with the tighter inboard cut
+const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = 0.18; // pull the middle-pocket wood arch farther toward centre so the smaller radius aligns with the tighter inboard cut
 
 function buildChromePlateGeometry({
   width,
@@ -771,7 +772,7 @@ const SIDE_POCKET_JAW_LATERAL_EXPANSION =
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.862; // shave the side jaw radius a touch more so the middle pocket arc tightens while moving outward
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.06; // deepen the side jaw so it holds the same vertical mass as the corners
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * 0.024; // lower the middle jaws slightly less so the fascia trims down from the top
-const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.096; // pull the middle pocket jaws inward so the lips follow the tighter chrome cut without drifting toward the rails
+const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.052; // pull the middle pocket jaws inward so the lips follow the tighter chrome cut without drifting toward the rails
 const SIDE_POCKET_JAW_EDGE_TRIM_START = 0.72; // begin trimming the middle jaw shoulders before the cushion noses so they finish at the wooden rails
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.82; // taper the outer jaw radius near the ends to keep a slightly wider gap before the cushions
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = 1.4; // ease the taper into the trimmed ends for a smooth falloff
@@ -818,8 +819,8 @@ const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
 const SIDE_POCKET_EXTRA_SHIFT = BALL_R * 1.72; // ease the middle pockets slightly while keeping them snug against the chrome hook
-const SIDE_POCKET_OUTWARD_BIAS = BALL_R * 0.06; // pull middle pocket centres even closer to the cloth field so the jaws follow the inward shift without overshooting
-const SIDE_POCKET_FIELD_PULL = BALL_R * 0.08; // keep the centres tucked while letting the shift reach the fascia without leaving a gap
+const SIDE_POCKET_OUTWARD_BIAS = 0; // drop the outward nudge so the middle pocket centres pull further toward the field
+const SIDE_POCKET_FIELD_PULL = BALL_R * 0.12; // keep the centres tucked while letting the shift reach the fascia without leaving a gap
 const CHALK_TOP_COLOR = 0x1f6d86;
 const CHALK_SIDE_COLOR = 0x162b36;
 const CHALK_SIDE_ACTIVE_COLOR = 0x1f4b5d;
@@ -6165,10 +6166,7 @@ function Table3D(
     Math.max(MICRO_EPS, chromePlateHeight * CHROME_SIDE_PLATE_HEIGHT_SCALE - chromeOuterFlushTrim * 2),
     Math.max(MICRO_EPS, sidePlateHeightByCushion)
   );
-  const sideChromePlateRadius = Math.min(
-    chromePlateRadius * 0.3,
-    Math.min(sideChromePlateWidth, sideChromePlateHeight) * CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE
-  );
+  const sideChromePlateRadiusBase = chromePlateRadius * 0.3;
 
   const circlePoly = (cx, cz, r, seg = 96) => {
     const pts = [];
@@ -6499,15 +6497,22 @@ function Table3D(
     { id: 'sideRight', sx: 1 }
   ].forEach(({ id, sx }) => {
     let plateWidth = sideChromePlateWidth;
+    let plateHeight = sideChromePlateHeight;
     let centerX =
       sx *
       (outerHalfW - plateWidth / 2 - chromePlateInset + sideChromePlateOutwardShift +
         (sideChromePlateWidthExpansion * CHROME_SIDE_PLATE_CORNER_BIAS_SCALE) / 2);
+    const innerEdgeX = centerX - sx * (plateWidth / 2);
+
+    plateWidth *= CHROME_SIDE_PLATE_NON_CUT_EXPANSION_SCALE;
+    plateHeight *= CHROME_SIDE_PLATE_NON_CUT_EXPANSION_SCALE;
+    centerX = innerEdgeX + sx * (plateWidth / 2);
+
     const baseOuterEdge = Math.abs(centerX) + plateWidth / 2;
     if (baseOuterEdge > sideChromeOuterEdgeLimit) {
       const overrun = baseOuterEdge - sideChromeOuterEdgeLimit;
       plateWidth = Math.max(MICRO_EPS, plateWidth - overrun * 2);
-      centerX = Math.sign(centerX) * Math.max(0, Math.abs(centerX) - overrun);
+      centerX = innerEdgeX + Math.sign(centerX) * (plateWidth / 2);
     }
     const centerZ = 0;
     const notchMP = scaleChromeSidePocketCut(sideNotchMP(sx));
@@ -6521,8 +6526,11 @@ function Table3D(
     const plate = new THREE.Mesh(
       buildChromePlateGeometry({
         width: plateWidth,
-        height: sideChromePlateHeight,
-        radius: sideChromePlateRadius,
+        height: plateHeight,
+        radius: Math.min(
+          sideChromePlateRadiusBase,
+          Math.min(plateWidth, plateHeight) * CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE
+        ),
         thickness: sideChromePlateThickness,
         corner: id,
         notchMP: notchLocalMP,


### PR DESCRIPTION
## Summary
- Pull the Pool Royale middle pocket centers, wood cuts, chrome cutouts, and jaws further toward the field for a tighter alignment.
- Expand the middle-pocket chrome fascias by 30% on non-cut edges while keeping the pocket side anchored.

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930876746688328ad5d584ff9cf5120)