### PR TITLE
Fix domino orientation in Domino Royal views

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -4011,9 +4011,9 @@ function renderHands(){
       else{
         m.position.set(x0 + offset, handY, z0);
       }
-      const yawTowardCenter = Math.atan2(-x0, -z0);
+      const yawTowardCenter = Math.atan2(-z0, -x0);
       if(openFlat){
-        orientDominoFlat(m, 0);
+        orientDominoFlat(m, Math.PI / 2);
       } else {
         const facing = pi === human ? yawTowardCenter : yawTowardCenter;
         m.rotation.set(0, facing, 0);


### PR DESCRIPTION
## Summary
- correct domino yaw orientation in 3D view so faces are visible
- rotate player's flat dominoes vertically in 2D view to match layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69308cf16a3883288a6a7fe3d819eece)