### PR TITLE
Update Domino Royal avatars and layout

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -33,12 +33,7 @@
   .seat-badge-core{position:relative;width:2.6rem;height:2.6rem;border-radius:999px;display:grid;place-items:center;font-size:1.35rem;font-weight:800;color:#0b1224;background:radial-gradient(circle at 30% 30%,rgba(255,255,255,.28),rgba(0,0,0,.12)),linear-gradient(135deg,#0ea5e9,#22c55e);overflow:hidden;}
   .seat-badge-core.has-photo{background-size:cover;background-position:center;color:transparent;text-indent:-9999px;}
   .seat-badge-name{position:relative;font-size:.95rem;font-weight:800;letter-spacing:.01em;color:#e8eef7;text-shadow:0 2px 8px rgba(0,0,0,.35);padding:.2rem .55rem;border-radius:999px;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.12);}
-  #playerBadges{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom,0px) + 0.75rem);transform:translateX(-50%);display:flex;flex-wrap:wrap;justify-content:center;gap:.55rem;z-index:5;pointer-events:none;}
-  .player-badge{display:flex;align-items:center;gap:.55rem;padding:.4rem .75rem;border-radius:999px;background:rgba(7,11,22,.9);border:1px solid rgba(255,255,255,.14);box-shadow:0 14px 32px rgba(0,0,0,.35);backdrop-filter:blur(10px);pointer-events:auto;}
-  .player-avatar{width:2.65rem;height:2.65rem;border-radius:999px;background:radial-gradient(circle at 30% 30%,rgba(255,255,255,.28),rgba(0,0,0,.12)),linear-gradient(135deg,#0ea5e9,#22c55e);display:grid;place-items:center;font-weight:800;font-size:1.35rem;color:#0b1224;overflow:hidden;box-shadow:0 0 0 2px rgba(255,255,255,.12);}
-  .player-avatar.has-photo{background-size:cover;background-position:center;color:transparent;text-indent:-9999px;}
-  .player-name{font-size:1rem;font-weight:800;letter-spacing:.01em;color:#e5e7eb;text-shadow:0 2px 10px rgba(0,0,0,.36);}
-  #viewToggle{position:fixed;right:calc(0.75rem + env(safe-area-inset-right,0px));bottom:calc(env(safe-area-inset-bottom,0px) + clamp(0.8rem, 6vh, 2.4rem));padding:.65rem 1rem;border-radius:999px;border:1px solid rgba(255,255,255,.16);background:rgba(12,16,28,.78);color:#ffe8a3;font-weight:800;font-size:.98rem;box-shadow:0 10px 24px rgba(0,0,0,.32);backdrop-filter:blur(10px);pointer-events:auto;z-index:4;}
+  #viewToggle{position:fixed;left:calc(0.75rem + env(safe-area-inset-left,0px));top:calc(4.1rem + env(safe-area-inset-top,0px));padding:.65rem 1rem;border-radius:999px;border:1px solid rgba(255,255,255,.16);background:rgba(12,16,28,.78);color:#ffe8a3;font-weight:800;font-size:.98rem;box-shadow:0 10px 24px rgba(0,0,0,.32);backdrop-filter:blur(10px);pointer-events:auto;z-index:4;}
   .config-section{display:flex;flex-direction:column;gap:.3rem;}
   .config-options{display:grid;grid-template-columns:repeat(auto-fit,minmax(128px,1fr));gap:.45rem;}
   .config-option{border-radius:0.85rem;border:1px solid rgba(255,255,255,.12);background:rgba(15,23,42,.55);color:#e2e8f0;padding:.4rem .5rem;display:flex;flex-direction:column;align-items:flex-start;gap:.3rem;font-size:clamp(.62rem,1.75vw,.72rem);line-height:1.35;font-weight:600;transition:border-color .2s ease, box-shadow .2s ease, transform .2s ease;}
@@ -62,7 +57,6 @@
 <body>
 <div id="app"></div>
 <div id="status" role="status">Ready</div>
-<div id="playerBadges" aria-label="Players"></div>
 <button id="configButton" type="button" aria-label="Table setup">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
     <path stroke-linecap="round" stroke-linejoin="round" d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z" />
@@ -349,8 +343,10 @@ const entryMode = (urlParams.get('entry') || '').toLowerCase();
 const shouldRunHallwayEntry = entryMode === 'hallway';
 const shouldShowSeatLabel = shouldRunHallwayEntry;
 
-const seatAvatarPhoto = (urlParams.get('avatar') || '').trim();
-const seatAvatarUsername = (urlParams.get('username') || '').trim();
+const accountId = (urlParams.get('accountId') || '').trim();
+const telegramId = (urlParams.get('tgId') || urlParams.get('telegramId') || '').trim();
+let seatAvatarPhoto = (urlParams.get('avatar') || '').trim();
+let seatAvatarUsername = (urlParams.get('username') || '').trim();
 const DEFAULT_AVATAR_EMOJI = '🌐';
 const DEFAULT_SEAT_NAMES = ['You', 'Player 2', 'Player 3', 'Player 4'];
 const FLAG_EMOJI_POOL = Array.isArray(window.FLAG_EMOJIS) ? window.FLAG_EMOJIS : [];
@@ -415,6 +411,24 @@ function getSeatUsernames(count = N) {
     if (derived) return derived;
     return DEFAULT_SEAT_NAMES[idx] || `Player ${idx + 1}`;
   });
+}
+
+async function loadHumanProfileFromApi() {
+  if ((!accountId && !telegramId) || !window?.fbApi?.getUserInfo) return null;
+  try {
+    const user = await window.fbApi.getUserInfo({ accountId, tgId: telegramId });
+    if (user) {
+      if (!seatAvatarPhoto) {
+        seatAvatarPhoto = (user.photo_url || '').trim();
+      }
+      if (!seatAvatarUsername) {
+        seatAvatarUsername = (user.username || user.first_name || user.last_name || '').trim();
+      }
+    }
+  } catch (error) {
+    console.warn('Failed to load Domino player profile', error);
+  }
+  return { photo: seatAvatarPhoto, name: seatAvatarUsername };
 }
 
 function seatBasisForAngle(angle, radius = CHAIR_RADIUS) {
@@ -2690,9 +2704,7 @@ function refreshSeatAvatars() {
   const sources = buildSeatAvatarSources(N);
   return Promise.all(
     seatAvatars.map((sprite, idx) => applySeatAvatarTexture(sprite, sources[idx] ?? DEFAULT_AVATAR_EMOJI))
-  )
-    .then(() => renderPlayerBadges(sources, buildSeatNames(N)))
-    .catch((error) => console.warn('Failed to refresh seat avatars', error));
+  ).catch((error) => console.warn('Failed to refresh seat avatars', error));
 }
 
 const projectedSeatTarget = new THREE.Vector3();
@@ -2792,30 +2804,6 @@ function createSeatBadge({ avatar = '🎯', name = '' } = {}) {
   return wrap;
 }
 
-function renderPlayerBadges(avatars = [], names = []) {
-  if (!playerBadgesEl) return;
-  playerBadgesEl.innerHTML = '';
-  const avatarSources = avatars.length ? avatars : buildSeatAvatarSources(N);
-  const nameSources = names.length ? names : buildSeatNames(N);
-  avatarSources.forEach((avatar, idx) => {
-    const badge = document.createElement('div');
-    badge.className = 'player-badge';
-    badge.dataset.seat = `${idx}`;
-    const avatarEl = document.createElement('div');
-    avatarEl.className = 'player-avatar';
-    applyBadgeAvatar(avatarEl, avatar);
-    const nameEl = document.createElement('span');
-    nameEl.className = 'player-name';
-    nameEl.textContent = nameSources[idx] || `Player ${idx + 1}`;
-    badge.appendChild(avatarEl);
-    badge.appendChild(nameEl);
-    if (idx === HUMAN_SEAT_INDEX) {
-      badge.style.boxShadow = '0 14px 32px rgba(0,0,0,.38), 0 0 0 2px rgba(255,210,74,.45)';
-    }
-    playerBadgesEl.appendChild(badge);
-  });
-}
-
 function refreshSeatBadges(avatars = [], names = []) {
   disposeSeatBadges();
   const gradient = (currentHighlightStyle && currentHighlightStyle.gradient) ||
@@ -2828,7 +2816,6 @@ function refreshSeatBadges(avatars = [], names = []) {
     seatBadges.push(badge);
   });
   seatOverlay.style.setProperty('--timer-gradient', gradient);
-  renderPlayerBadges(avatarSources, nameSources);
 }
 
 function disposeSeatLabel({ persistPreference = true } = {}) {
@@ -3766,7 +3753,6 @@ function makeDomino(a,b,{flat=true, faceUp=true, preserveOrder=false}={}){
 
 /* ---------- Game State ---------- */
 const statusEl = document.getElementById('status');
-const playerBadgesEl = document.getElementById('playerBadges');
 const btnDraw = document.getElementById('draw');
 const btnPass = document.getElementById('pass');
 const btnRules = document.getElementById('btnRules');
@@ -4639,7 +4625,12 @@ btnPass.addEventListener('click',()=>{
   }
 });
 
-startGame();
+async function bootstrapDominoRoyal() {
+  await loadHumanProfileFromApi();
+  startGame();
+}
+
+bootstrapDominoRoyal();
 
 function blockedAndWinner(){
   if(!ends) return null;


### PR DESCRIPTION
## Summary
- remove the bottom player badge UI and its rendering so only seat overlays remain
- move the 2D view toggle button beneath the configuration control in the top-left
- load the human player avatar/name from the user profile via fbApi before starting the game

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693095b935f48320a326f7d653b08131)