### PR TITLE
Fix Domino Royal avatar source normalization

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -339,17 +339,30 @@ const VIEW_MODES = Object.freeze({ threeD: '3d', twoD: '2d' });
 let cameraViewMode = VIEW_MODES.threeD;
 
 const urlParams = new URLSearchParams(window.location.search);
+
+function normalizeAvatarSource(src = '') {
+  const trimmed = src.trim();
+  if (!trimmed) return '';
+  if (trimmed.startsWith('http') || trimmed.startsWith('data:') || trimmed.startsWith('/')) {
+    return trimmed;
+  }
+  if (trimmed.startsWith('assets/')) {
+    return `/${trimmed}`;
+  }
+  return trimmed;
+}
+
 const entryMode = (urlParams.get('entry') || '').toLowerCase();
 const shouldRunHallwayEntry = entryMode === 'hallway';
 const shouldShowSeatLabel = shouldRunHallwayEntry;
 
 const accountId = (urlParams.get('accountId') || '').trim();
 const telegramId = (urlParams.get('tgId') || urlParams.get('telegramId') || '').trim();
-let seatAvatarPhoto = (urlParams.get('avatar') || '').trim();
+let seatAvatarPhoto = normalizeAvatarSource(urlParams.get('avatar') || '');
 let seatAvatarUsername = (urlParams.get('username') || '').trim();
 const lobbyAvatarFallback = (() => {
   try {
-    return localStorage.getItem('profilePhoto') || '';
+    return normalizeAvatarSource(localStorage.getItem('profilePhoto') || '');
   } catch (error) {
     console.warn('Unable to read lobby avatar fallback', error);
     return '';
@@ -432,7 +445,7 @@ async function loadHumanProfileFromApi() {
     const user = await window.fbApi.getUserInfo({ accountId, tgId: telegramId });
     if (user) {
       if (!seatAvatarPhoto) {
-        seatAvatarPhoto = (user.photo_url || '').trim();
+        seatAvatarPhoto = normalizeAvatarSource(user.photo_url || '');
       }
       if (!seatAvatarUsername) {
         seatAvatarUsername = (user.username || user.first_name || user.last_name || '').trim();
@@ -2654,7 +2667,10 @@ function buildSeatAvatarSources(count = N) {
   const total = Math.max(1, count);
   return Array.from({ length: total }, (_, idx) => {
     if (idx === HUMAN_SEAT_INDEX) {
-      const preferred = seatAvatarPhoto || lobbyAvatarFallback || (aiAvatarMode === 'flags' ? selectedFlagAvatars[idx] : '');
+      const preferred =
+        normalizeAvatarSource(seatAvatarPhoto) ||
+        lobbyAvatarFallback ||
+        (aiAvatarMode === 'flags' ? selectedFlagAvatars[idx] : '');
       return preferred || pickFlagForSeat(idx);
     }
     if (aiAvatarMode === 'flags') {


### PR DESCRIPTION
## Summary
- normalize Domino Royal avatar sources from query params and local storage
- ensure fallback profile photos and API avatars are treated as valid URLs when rendering seat badges

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69312b827970832088aaba8e79fdf751)