### PR TITLE
Refresh Domino seat badges after loading profile

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -4673,6 +4673,7 @@ btnPass.addEventListener('click',()=>{
 
 async function bootstrapDominoRoyal() {
   await loadHumanProfileFromApi();
+  refreshSeatBadges(buildSeatAvatarSources(N), buildSeatNames(N));
   startGame();
 }
 


### PR DESCRIPTION
## Summary
- update Domino Royal bootstrap to rebuild seat badges after loading the user profile so the human avatar appears

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931499398a08329ada955a528ad4af7)