### PR TITLE
Sanitize Domino avatar inputs

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -419,7 +419,10 @@ async function loadHumanProfileFromApi() {
     const user = await window.fbApi.getUserInfo({ accountId, tgId: telegramId });
     if (user) {
       if (!seatAvatarPhoto) {
-        seatAvatarPhoto = (user.photo_url || '').trim();
+        const normalizedPhoto = sanitizeSeatAvatarSource(user.photo_url || '');
+        if (normalizedPhoto) {
+          seatAvatarPhoto = normalizedPhoto;
+        }
       }
       if (!seatAvatarUsername) {
         seatAvatarUsername = (user.username || user.first_name || user.last_name || '').trim();
@@ -2632,6 +2635,17 @@ function buildSeatNames(count = N) {
 function isAvatarUrl(str = '') {
   return /^https?:\/\//i.test(str) || str.startsWith('data:') || str.startsWith('/');
 }
+
+const MAX_AVATAR_SOURCE_LENGTH = 2048;
+function sanitizeSeatAvatarSource(source = '') {
+  const value = (source || '').trim();
+  if (!value || value.length > MAX_AVATAR_SOURCE_LENGTH) return '';
+  if (isAvatarUrl(value)) return value;
+  if (value.length <= 10) return value;
+  return '';
+}
+
+seatAvatarPhoto = sanitizeSeatAvatarSource(seatAvatarPhoto);
 
 function buildSeatAvatarSources(count = N) {
   const total = Math.max(1, count);

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -14,6 +14,16 @@ const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
 const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 
 const PLAYER_OPTIONS = [2, 3, 4];
+const MAX_AVATAR_QUERY_LENGTH = 2048;
+
+function normalizeAvatarSource(value = '') {
+  const trimmed = (value || '').trim();
+  if (!trimmed || trimmed.length > MAX_AVATAR_QUERY_LENGTH) return '';
+  if (trimmed.startsWith('/') || /^https?:\/\//i.test(trimmed) || trimmed.startsWith('data:')) {
+    return trimmed;
+  }
+  return trimmed.length <= 10 ? trimmed : '';
+}
 
 export default function DominoRoyalLobby() {
   const navigate = useNavigate();
@@ -37,8 +47,9 @@ export default function DominoRoyalLobby() {
 
   useEffect(() => {
     try {
-      const saved = loadAvatar();
-      setAvatar(saved || getTelegramPhotoUrl());
+      const saved = normalizeAvatarSource(loadAvatar());
+      const telegramPhoto = normalizeAvatarSource(getTelegramPhotoUrl());
+      setAvatar(saved || telegramPhoto);
     } catch {}
   }, []);
 
@@ -64,7 +75,8 @@ export default function DominoRoyalLobby() {
     params.set('players', String(totalPlayers));
     if (stake.token) params.set('token', stake.token);
     if (stake.amount) params.set('amount', stake.amount);
-    if (avatar) params.set('avatar', avatar);
+    const safeAvatar = normalizeAvatarSource(avatar);
+    if (safeAvatar) params.set('avatar', safeAvatar);
     const username = getTelegramUsername();
     if (username) params.set('username', username);
     const aiFlagSelection = flagOverride && flagOverride.length ? flagOverride : flags;


### PR DESCRIPTION
## Summary
- sanitize Domino Royal avatar sources and enforce safe length/format before using them in the arena
- normalize avatars passed from the lobby so oversized or invalid values are dropped before navigation

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693181d800dc83299508d89a2f154bb8)