### PR TITLE
Restore Domino Royal to morning state

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -339,14 +339,35 @@ const VIEW_MODES = Object.freeze({ threeD: '3d', twoD: '2d' });
 let cameraViewMode = VIEW_MODES.threeD;
 
 const urlParams = new URLSearchParams(window.location.search);
+
+function normalizeAvatarSource(src = '') {
+  const trimmed = src.trim();
+  if (!trimmed) return '';
+  if (trimmed.startsWith('http') || trimmed.startsWith('data:') || trimmed.startsWith('/')) {
+    return trimmed;
+  }
+  if (trimmed.startsWith('assets/')) {
+    return `/${trimmed}`;
+  }
+  return trimmed;
+}
+
 const entryMode = (urlParams.get('entry') || '').toLowerCase();
 const shouldRunHallwayEntry = entryMode === 'hallway';
 const shouldShowSeatLabel = shouldRunHallwayEntry;
 
 const accountId = (urlParams.get('accountId') || '').trim();
 const telegramId = (urlParams.get('tgId') || urlParams.get('telegramId') || '').trim();
-let seatAvatarPhoto = (urlParams.get('avatar') || '').trim();
+let seatAvatarPhoto = normalizeAvatarSource(urlParams.get('avatar') || '');
 let seatAvatarUsername = (urlParams.get('username') || '').trim();
+const lobbyAvatarFallback = (() => {
+  try {
+    return normalizeAvatarSource(localStorage.getItem('profilePhoto') || '');
+  } catch (error) {
+    console.warn('Unable to read lobby avatar fallback', error);
+    return '';
+  }
+})();
 const DEFAULT_AVATAR_EMOJI = '🌐';
 const DEFAULT_SEAT_NAMES = ['You', 'Player 2', 'Player 3', 'Player 4'];
 const FLAG_EMOJI_POOL = Array.isArray(window.FLAG_EMOJIS) ? window.FLAG_EMOJIS : [];
@@ -414,15 +435,17 @@ function getSeatUsernames(count = N) {
 }
 
 async function loadHumanProfileFromApi() {
-  if ((!accountId && !telegramId) || !window?.fbApi?.getUserInfo) return null;
+  if ((!accountId && !telegramId) || !window?.fbApi?.getUserInfo) {
+    if (!seatAvatarPhoto && lobbyAvatarFallback) {
+      seatAvatarPhoto = lobbyAvatarFallback;
+    }
+    return null;
+  }
   try {
     const user = await window.fbApi.getUserInfo({ accountId, tgId: telegramId });
     if (user) {
       if (!seatAvatarPhoto) {
-        const normalizedPhoto = sanitizeSeatAvatarSource(user.photo_url || '');
-        if (normalizedPhoto) {
-          seatAvatarPhoto = normalizedPhoto;
-        }
+        seatAvatarPhoto = normalizeAvatarSource(user.photo_url || '');
       }
       if (!seatAvatarUsername) {
         seatAvatarUsername = (user.username || user.first_name || user.last_name || '').trim();
@@ -430,6 +453,9 @@ async function loadHumanProfileFromApi() {
     }
   } catch (error) {
     console.warn('Failed to load Domino player profile', error);
+  }
+  if (!seatAvatarPhoto && lobbyAvatarFallback) {
+    seatAvatarPhoto = lobbyAvatarFallback;
   }
   return { photo: seatAvatarPhoto, name: seatAvatarUsername };
 }
@@ -611,6 +637,7 @@ function setCameraViewMode(mode = VIEW_MODES.threeD) {
 
   cameraViewMode = mode;
   cameraHasUserControl = false;
+  updateRaycasterThreshold();
   applyCameraConstraints();
   positionCameraForViewport({ force: true });
   updateViewToggleLabel();
@@ -2636,22 +2663,14 @@ function isAvatarUrl(str = '') {
   return /^https?:\/\//i.test(str) || str.startsWith('data:') || str.startsWith('/');
 }
 
-const MAX_AVATAR_SOURCE_LENGTH = 2048;
-function sanitizeSeatAvatarSource(source = '') {
-  const value = (source || '').trim();
-  if (!value || value.length > MAX_AVATAR_SOURCE_LENGTH) return '';
-  if (isAvatarUrl(value)) return value;
-  if (value.length <= 10) return value;
-  return '';
-}
-
-seatAvatarPhoto = sanitizeSeatAvatarSource(seatAvatarPhoto);
-
 function buildSeatAvatarSources(count = N) {
   const total = Math.max(1, count);
   return Array.from({ length: total }, (_, idx) => {
     if (idx === HUMAN_SEAT_INDEX) {
-      const preferred = seatAvatarPhoto || (aiAvatarMode === 'flags' ? selectedFlagAvatars[idx] : '');
+      const preferred =
+        normalizeAvatarSource(seatAvatarPhoto) ||
+        lobbyAvatarFallback ||
+        (aiAvatarMode === 'flags' ? selectedFlagAvatars[idx] : '');
       return preferred || pickFlagForSeat(idx);
     }
     if (aiAvatarMode === 'flags') {
@@ -2661,7 +2680,7 @@ function buildSeatAvatarSources(count = N) {
   });
 }
 
-async function createSeatAvatarTexture(source = DEFAULT_AVATAR_EMOJI) {
+async function createSeatAvatarTexture(source = DEFAULT_AVATAR_EMOJI, fallback = DEFAULT_AVATAR_EMOJI) {
   const size = 512;
   const canvas = document.createElement('canvas');
   canvas.width = canvas.height = size;
@@ -2674,6 +2693,7 @@ async function createSeatAvatarTexture(source = DEFAULT_AVATAR_EMOJI) {
   ctx.font = `${size * 0.22}px "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji", sans-serif`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
+  let imageLoaded = false;
   if (isAvatarUrl(label)) {
     await new Promise((resolve) => {
       const img = new Image();
@@ -2683,6 +2703,7 @@ async function createSeatAvatarTexture(source = DEFAULT_AVATAR_EMOJI) {
       img.src = label;
     }).then((img) => {
       if (!img) return;
+      imageLoaded = true;
       const maxSide = Math.max(img.width, img.height) || 1;
       const drawSize = size * 0.44;
       const ratio = drawSize / maxSide;
@@ -2692,6 +2713,12 @@ async function createSeatAvatarTexture(source = DEFAULT_AVATAR_EMOJI) {
     });
   } else {
     ctx.fillText(label, center, center);
+    imageLoaded = true;
+  }
+
+  if (!imageLoaded && fallback && fallback !== label) {
+    ctx.clearRect(0, 0, size, size);
+    ctx.fillText(fallback, center, center);
   }
 
   const texture = new THREE.CanvasTexture(canvas);
@@ -2703,7 +2730,7 @@ async function createSeatAvatarTexture(source = DEFAULT_AVATAR_EMOJI) {
 
 async function applySeatAvatarTexture(sprite, source = DEFAULT_AVATAR_EMOJI) {
   if (!sprite) return null;
-  const texture = await createSeatAvatarTexture(source);
+  const texture = await createSeatAvatarTexture(source, pickFlagForSeat(HUMAN_SEAT_INDEX));
   if (!sprite.material) {
     sprite.material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthWrite: false });
   } else {
@@ -3015,7 +3042,7 @@ const DOMINO_LENGTH = DOMINO_WORLD_SCALE * (0.016 / 0.22) * 2;
 const DOUBLE_END_SHIFT = Math.max(0, (DOMINO_LENGTH - DOMINO_WIDTH) / 2);
 const DOMINO_CHAIN_GAP = DOMINO_LENGTH * 0.03;
 const STEP = DOMINO_LENGTH + DOMINO_CHAIN_GAP;
-const DOMINO_HAND_GAP = DOMINO_LENGTH * 0.7;
+const DOMINO_HAND_GAP = DOMINO_LENGTH * 0.58;
 const TILE_UP_H = 0.2 * DOMINO_WORLD_SCALE;
 const TILE_UP_HALF = TILE_UP_H / 2;
 const XMAX = CLOTH_RADIUS - 0.32 - DOMINO_CHAIN_GAP * 0.5;
@@ -3830,7 +3857,7 @@ function renderHands(){
 
   const EDGE_SPAN = CLOTH_RADIUS - 0.28;
   const BASE_GAP = DOMINO_HAND_GAP;
-  const MIN_GAP = DOMINO_LENGTH * 1.05;
+  const MIN_GAP = DOMINO_LENGTH * 0.95;
   const MAX_SPAN = Math.max(0, EDGE_SPAN * 2 - DOMINO_LENGTH * 0.6);
 
   const isTopDown = cameraViewMode === VIEW_MODES.twoD;
@@ -4570,7 +4597,11 @@ function showMarkersFor(tile){
 /* ---------- Interactivity ---------- */
 const raycaster=new THREE.Raycaster(); const pointer=new THREE.Vector2();
 raycaster.params.Mesh = raycaster.params.Mesh || {};
-raycaster.params.Mesh.threshold = 0.2;
+const RAYCAST_THRESHOLD = { normal: 0.22, topdown: 0.45 };
+const updateRaycasterThreshold = () => {
+  raycaster.params.Mesh.threshold = cameraViewMode === VIEW_MODES.twoD ? RAYCAST_THRESHOLD.topdown : RAYCAST_THRESHOLD.normal;
+};
+updateRaycasterThreshold();
 const activePointers = new Set();
 function findPickRoot(o){
   let n=o; while(n){ if(n.userData && (n.userData.owner!==undefined || n.userData.marker)) return n; n=n.parent; } return o;
@@ -4582,6 +4613,7 @@ renderer.domElement.addEventListener('pointerdown',ev=>{
   if(gameFinished){
     return;
   }
+  updateRaycasterThreshold();
   if(ev.pointerType==='touch' && activePointers.size>1){
     return;
   }

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -14,16 +14,6 @@ const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
 const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 
 const PLAYER_OPTIONS = [2, 3, 4];
-const MAX_AVATAR_QUERY_LENGTH = 2048;
-
-function normalizeAvatarSource(value = '') {
-  const trimmed = (value || '').trim();
-  if (!trimmed || trimmed.length > MAX_AVATAR_QUERY_LENGTH) return '';
-  if (trimmed.startsWith('/') || /^https?:\/\//i.test(trimmed) || trimmed.startsWith('data:')) {
-    return trimmed;
-  }
-  return trimmed.length <= 10 ? trimmed : '';
-}
 
 export default function DominoRoyalLobby() {
   const navigate = useNavigate();
@@ -47,9 +37,8 @@ export default function DominoRoyalLobby() {
 
   useEffect(() => {
     try {
-      const saved = normalizeAvatarSource(loadAvatar());
-      const telegramPhoto = normalizeAvatarSource(getTelegramPhotoUrl());
-      setAvatar(saved || telegramPhoto);
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
     } catch {}
   }, []);
 
@@ -75,8 +64,7 @@ export default function DominoRoyalLobby() {
     params.set('players', String(totalPlayers));
     if (stake.token) params.set('token', stake.token);
     if (stake.amount) params.set('amount', stake.amount);
-    const safeAvatar = normalizeAvatarSource(avatar);
-    if (safeAvatar) params.set('avatar', safeAvatar);
+    if (avatar) params.set('avatar', avatar);
     const username = getTelegramUsername();
     if (username) params.set('username', username);
     const aiFlagSelection = flagOverride && flagOverride.length ? flagOverride : flags;


### PR DESCRIPTION
## Summary
- revert Domino Royal HTML to the version from this morning (7–8am), restoring avatar normalization and lobby fallbacks
- restore Domino Royal lobby parameters and flag handling to match the earlier working build

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693189262adc8329a3743ffb3fa3a535)