### PR TITLE
Adjust camera framing, power, and side pocket positions

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -29,16 +29,16 @@ public class CameraController : MonoBehaviour
     // the cue stick.
     public float minimumCueViewDistance = 1.34125f;
     // How far above the rails the camera is allowed to travel.
-    public float maxHeightAboveTable = 1.9f;
+    public float maxHeightAboveTable = 2.05f;
     // Default distance of the camera from the table centre when fully raised to
     // provide a broad overview of the action.
-    public float distanceFromCenter = 3.515f;
+    public float distanceFromCenter = 3.18f;
     // Minimum distance from the table centre allowed when the camera is pulled
     // down toward the rails for a closer look.
-    public float minDistanceFromCenter = 1.98875f;
+    public float minDistanceFromCenter = 1.85f;
     // Extra distance the camera is allowed to shed as it hugs the table so the
     // cue ball fills more of the view during low-angle aiming.
-    public float lowHeightDistanceReduction = 0.41625f;
+    public float lowHeightDistanceReduction = 0.465f;
     // Extra pullback applied when the camera is raised to its maximum height so
     // the player gets a slightly wider view while aiming.
     public float zoomOutWhenRaised = 0.23125f;
@@ -47,7 +47,7 @@ public class CameraController : MonoBehaviour
     public float railBuffer = 0.0185f;
     // Slight height offset so the camera looks just above the table centre
     // to reduce the viewing angle and give a lower perspective.
-    public float lookAtHeightOffset = 0.08f;
+    public float lookAtHeightOffset = 0.11f;
     // Extra upward offset applied to the camera's look target when the camera is
     // pulled down close to the cloth so the player can still see more of the
     // table surface instead of just the rails.

--- a/billiards.Unity/DemoBehaviour.cs
+++ b/billiards.Unity/DemoBehaviour.cs
@@ -17,7 +17,7 @@ public class DemoBehaviour : MonoBehaviour
     // smaller adjustments for more precise shots so the player can line up
     // accurate shots without the aim jumping in large steps.
     public float aimSmoothing = 4f;
-    public float previewSpeed = 2.0f;
+    public float previewSpeed = 3.0f;
     // Toggle whether the aiming guide should be visible. Defaults to off for broadcast play.
     public bool showAimingLine = false;
 

--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -46,6 +46,7 @@ public class BilliardsSolver
         double cornerCut = cornerMouth / Math.Sqrt(2.0);
         double sideCut = sideMouth / 2.0;
         double sideDepth = Math.Max(sideCut * 1.05, PhysicsConstants.BallRadius * 1.8);
+        double sideOutset = Math.Max(0.0, PhysicsConstants.SidePocketOutset);
 
         // Straight cushion spans (long rails)
         AddCushionSegment(new Vec2(cornerCut, 0), new Vec2(width / 2 - sideCut, 0), new Vec2(0, 1));
@@ -66,19 +67,19 @@ public class BilliardsSolver
         AddCornerJaw(new Vec2(cornerCut, height - cornerCut), cornerCut, 0.5 * Math.PI, Math.PI, cornerSegments);
 
         int sideSegments = Math.Max(6, PhysicsConstants.SideJawSegments);
-        AddSidePocketJaw(new Vec2(width / 2, 0), sideCut, sideDepth, true, sideSegments);
-        AddSidePocketJaw(new Vec2(width / 2, height), sideCut, sideDepth, false, sideSegments);
-        AddSidePocketJaw(new Vec2(0, height / 2), sideCut, sideDepth, true, sideSegments, vertical: true);
-        AddSidePocketJaw(new Vec2(width, height / 2), sideCut, sideDepth, false, sideSegments, vertical: true);
+        AddSidePocketJaw(new Vec2(width / 2, 0 - sideOutset), sideCut, sideDepth, true, sideSegments);
+        AddSidePocketJaw(new Vec2(width / 2, height + sideOutset), sideCut, sideDepth, false, sideSegments);
+        AddSidePocketJaw(new Vec2(0 - sideOutset, height / 2), sideCut, sideDepth, true, sideSegments, vertical: true);
+        AddSidePocketJaw(new Vec2(width + sideOutset, height / 2), sideCut, sideDepth, false, sideSegments, vertical: true);
 
         double capture = Math.Max(PhysicsConstants.BallRadius * 1.05, PhysicsConstants.PocketCaptureRadius);
         Pockets.Add(new Pocket { Center = new Vec2(0, 0), Radius = capture });
-        Pockets.Add(new Pocket { Center = new Vec2(width / 2, 0), Radius = capture });
+        Pockets.Add(new Pocket { Center = new Vec2(width / 2, 0 - sideOutset), Radius = capture });
         Pockets.Add(new Pocket { Center = new Vec2(width, 0), Radius = capture });
-        Pockets.Add(new Pocket { Center = new Vec2(0, height / 2), Radius = capture });
-        Pockets.Add(new Pocket { Center = new Vec2(width, height / 2), Radius = capture });
+        Pockets.Add(new Pocket { Center = new Vec2(0 - sideOutset, height / 2), Radius = capture });
+        Pockets.Add(new Pocket { Center = new Vec2(width + sideOutset, height / 2), Radius = capture });
         Pockets.Add(new Pocket { Center = new Vec2(0, height), Radius = capture });
-        Pockets.Add(new Pocket { Center = new Vec2(width / 2, height), Radius = capture });
+        Pockets.Add(new Pocket { Center = new Vec2(width / 2, height + sideOutset), Radius = capture });
         Pockets.Add(new Pocket { Center = new Vec2(width, height), Radius = capture });
     }
 

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -24,6 +24,9 @@ public static class PhysicsConstants
     public const double CornerPocketMouth = 0.1057275; // scaled with table reduction
     public const double SidePocketMouth = 0.117475;    // scaled with table reduction
     public const double PocketCaptureRadius = 0.087875; // scaled with table reduction
+    // Offset that moves the side pockets slightly outside the rail line so the
+    // chrome plates and wooden rails sit flush with the rounded cuts.
+    public const double SidePocketOutset = 0.03;
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 32;


### PR DESCRIPTION
## Summary
- bring the player camera closer to the table with a slightly higher vantage point
- boost default shot/preview power by 50%
- move side pocket geometry outward with an adjustable offset to trim mid-rail chrome/wood overlap

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69319cc80420832987a9140467d3ac16)