### PR TITLE
Prevent top-down camera activation during active shots

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8270,6 +8270,12 @@ function PoolRoyaleGame({
   }, [isLookMode]);
 
   useEffect(() => {
+    if (shotActive && isTopDownView) {
+      // Avoid entering the locked overhead view while a shot is still in motion,
+      // which could trap the broadcast camera and block play until the frame resets.
+      setIsTopDownView(false);
+      return;
+    }
     if (isTopDownView) {
       topViewLockedRef.current = true;
       topViewControlsRef.current.enter?.();
@@ -8277,7 +8283,7 @@ function PoolRoyaleGame({
       topViewLockedRef.current = false;
       topViewControlsRef.current.exit?.();
     }
-  }, [isTopDownView]);
+  }, [isTopDownView, shotActive]);
   const [activeChalkIndex, setActiveChalkIndex] = useState(null);
   const activeChalkIndexRef = useRef(null);
   const chalkAssistEnabledRef = useRef(false);


### PR DESCRIPTION
## Summary
- block entering the locked overhead camera while a shot is active to keep broadcasts responsive
- ensure top-down toggle exits immediately if triggered mid-shot

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932674faf808329b61998d2ada1ff23)