### PR TITLE
Attempt touch ABeautifulGame fallback before procedural sets

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -2531,6 +2531,15 @@ async function resolveBeautifulGameAssets(targetBoardSize, extractor = extractBe
     assetScale: 1
   };
 
+  try {
+    const touchAssets = await withTimeout(resolveBeautifulGameTouchAssets(targetBoardSize));
+    if (touchAssets?.boardModel || touchAssets?.piecePrototypes) {
+      return touchAssets;
+    }
+  } catch (error) {
+    console.warn('Chess Battle Royal: touch ABeautifulGame fallback failed', error);
+  }
+
   const texturedFallbacks = [
     { urls: STAUNTON_SET_URLS, name: 'Staunton', styleId: 'stauntonFallback' },
     { urls: KENNEY_SET_URLS, name: 'BoardGameKit', styleId: 'kenneyFallback' },


### PR DESCRIPTION
## Summary
- try the touch edition of the ABeautifulGame model before procedural/textured fallbacks so authentic assets remain available when the primary download fails
- log failures from the touch fallback to aid debugging

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69327a3d276c83298bed2dcfc18556ae)