### PR TITLE
Align Domino Royal UI with Chess Battle Royale

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -4,17 +4,22 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <title>Domino Royal 3D</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Luckiest+Guy&display=swap" rel="stylesheet" />
 <style>
-  html,body{margin:0;height:100%;background:#ece6dc;overflow:hidden;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial}
-  #app{position:fixed;inset:0; width:100dvw; height:100dvh;}
-  canvas{display:block; width:100dvw !important; height:100dvh !important; touch-action:none}
-  button{font-weight:700;border:0;border-radius:999px;padding:.45rem .7rem;background:#ffd24a;color:#333;box-shadow:0 4px 12px rgba(0,0,0,.25);}
+  :root{--bg:#050812;--panel:#0b1220;--panel-border:#233050;--accent:#22c55e;--accent-2:#f59e0b;--fg:#e8eef7;--muted:#94a3b8;--glass:rgba(11,18,32,0.9);}
+  *{box-sizing:border-box;-webkit-tap-highlight-color:transparent;}
+  html,body{margin:0;height:100%;background:var(--bg);overflow:hidden;font-family:'Luckiest Guy','Comic Sans MS',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;}
+  #app{position:fixed;inset:0;width:100dvw;height:100dvh;}
+  canvas{display:block;width:100dvw !important;height:100dvh !important;touch-action:none;}
+  button{font-weight:800;border:0;border-radius:12px;padding:.6rem 1rem;background:var(--panel);color:var(--fg);border:1px solid var(--panel-border);box-shadow:0 10px 28px rgba(0,0,0,.38);} 
   button:active{transform:translateY(1px);}
-  #status{position:fixed;top:calc(0.65rem + env(safe-area-inset-top, 0px));left:50%;transform:translateX(-50%);padding:.35rem .75rem;border-radius:999px;background:rgba(0,0,0,.55);color:#fff;font-weight:700;z-index:2;backdrop-filter:blur(6px);}
-  #railControls{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom,0px) + clamp(0.8rem, 6vh, 2.4rem));transform:translateX(-50%);display:flex;flex-direction:row;flex-wrap:wrap;justify-content:center;gap:.5rem;align-items:center;background:transparent;color:#fff;padding:0;box-shadow:none;z-index:2;pointer-events:auto;}
-  #railControls button{background:rgba(12,16,28,.72);color:#ffe8a3;font-size:.95rem;padding:.55rem .9rem;border-radius:999px;border:1px solid rgba(255,255,255,.14);box-shadow:0 8px 18px rgba(0,0,0,.35);backdrop-filter:blur(8px);}
-  #draw{font-size:1rem;padding:.6rem 1rem;background:linear-gradient(135deg, rgba(255,210,74,.95), rgba(255,196,45,.85));color:#3b250f;border:0;}
-  #pass{background:rgba(255,210,74,.12);color:#ffe8a3;border:1px solid rgba(255,210,74,.35);}
+  #status{position:fixed;top:calc(0.65rem + env(safe-area-inset-top, 0px));left:50%;transform:translateX(-50%);padding:.45rem .9rem;border-radius:14px;background:rgba(11,18,32,0.85);color:var(--fg);font-weight:800;z-index:4;backdrop-filter:blur(10px);border:1px solid var(--panel-border);box-shadow:0 12px 32px rgba(0,0,0,.35);}
+  #railControls{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom,0px) + clamp(0.8rem, 6vh, 2.4rem));transform:translateX(-50%);display:flex;flex-direction:row;flex-wrap:wrap;justify-content:center;gap:.65rem;align-items:center;background:var(--glass);color:var(--fg);padding:.6rem .85rem;border-radius:14px;border:1px solid var(--panel-border);box-shadow:0 10px 28px rgba(0,0,0,0.38);z-index:4;pointer-events:auto;backdrop-filter:blur(10px);}
+  #railControls button{background:#121d33;color:#fff;font-size:.95rem;padding:.65rem 1rem;border-radius:10px;border:1px solid var(--panel-border);box-shadow:0 8px 18px rgba(0,0,0,.35);backdrop-filter:blur(8px);}
+  #draw{font-size:1rem;padding:.7rem 1.15rem;background:linear-gradient(135deg, rgba(34,197,94,.95), rgba(12,180,75,.9));color:#041204;border:1px solid rgba(34,197,94,.6);}
+  #pass{background:rgba(37,45,71,.92);color:#e5e7eb;border:1px solid rgba(35,48,80,.85);} 
   #btnRules{position:fixed;top:calc(0.75rem + env(safe-area-inset-top,0px));right:calc(0.75rem + env(safe-area-inset-right,0px));width:2.75rem;height:2.75rem;border-radius:999px;background:rgba(0,0,0,.58);color:#fff;display:grid;place-items:center;font-size:1.3rem;box-shadow:0 6px 18px rgba(0,0,0,.35);z-index:3;backdrop-filter:blur(6px);padding:0;}
   #btnRules span{pointer-events:none;}
   #configButton{position:fixed;top:calc(0.75rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));width:3rem;height:3rem;border-radius:999px;background:rgba(0,0,0,.7);color:#fff;border:1px solid rgba(255,255,255,.18);display:grid;place-items:center;box-shadow:0 6px 18px rgba(0,0,0,.35);z-index:3;backdrop-filter:blur(8px);padding:0;transition:background .2s ease, border-color .2s ease;}
@@ -47,10 +52,10 @@
   @media (max-width:640px){
     #configPanel{left:50%;transform:translateX(-50%);top:calc(4.75rem + env(safe-area-inset-top,0px));}
   }
-  #rules{position:fixed;top:0;left:0;right:0;bottom:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);z-index:3}
-  #rules .card{max-width:720px;background:#fff;color:#222;border-radius:16px;box-shadow:0 12px 40px rgba(0,0,0,.25);padding:16px 18px}
-  #rules h2{margin:0 0 6px 0;font-size:18px}
-  #rules ol{margin:6px 0 0 18px}
+  #rules{position:fixed;top:0;left:0;right:0;bottom:0;display:none;align-items:center;justify-content:center;background:rgba(5,8,18,.75);z-index:6;backdrop-filter:blur(2px);}
+  #rules .card{max-width:720px;background:var(--panel);color:var(--fg);border-radius:16px;box-shadow:0 18px 38px rgba(0,0,0,.45);padding:16px 18px;border:1px solid var(--panel-border);} 
+  #rules h2{margin:0 0 6px 0;font-size:18px;letter-spacing:0.35px;}
+  #rules ol{margin:6px 0 0 18px;color:var(--muted);}
   #rules .row{display:flex;gap:8px;justify-content:flex-end;margin-top:12px}
 </style>
 </head>


### PR DESCRIPTION
## Summary
- restyle the Domino Royal HTML shell to match the Chess Battle Royale dark UI theme
- add the shared Luckiest Guy typeface and glassmorphic controls for consistency
- darken supporting panels like the rules modal to align with the battle-royale look

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69328e31cb408329ba00745758ac9685)