### PR TITLE
Tweak blackjack layout and handle bust endgame

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -51,7 +51,11 @@
         height: 100vh;
         display: grid;
         place-items: center;
-        perspective: 1100px;
+        perspective: 1400px;
+        transform: scale(0.94);
+        transform-origin: center;
+        background: radial-gradient(circle at 50% 42%, #0b1428 0, #02060f 52%);
+        padding-bottom: env(safe-area-inset-bottom, 12px);
       }
       .stage::before {
         content: '';
@@ -395,7 +399,7 @@
       }
 
       .seat.bottom {
-        bottom: 0.5%;
+        bottom: 6%;
         left: 50%;
         transform: translateX(-50%);
         --card-scale: var(--bottom-card-scale);
@@ -545,40 +549,9 @@
       #fold {
         background: #dc2626;
       }
-        .raise-container {
-        position: absolute;
-        bottom: 2%;
-        left: 2%;
-        z-index: 5;
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        justify-content: flex-end;
-        gap: 8px;
-        padding: 0;
-        padding-top: 4px;
-        padding-right: 4px;
-        border: none;
-        border-radius: 0;
-        background: none;
-        transform: scale(var(--ui-scale));
-        transform-origin: bottom left;
-      }
+      .raise-container,
       .slider-container {
-        position: absolute;
-        bottom: 3%;
-        right: 1%;
-        z-index: 5;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 8px;
-        padding: 0;
-        border: none;
-        border-radius: 0;
-        background: none;
-        transform: scale(var(--ui-scale));
-        transform-origin: bottom right;
+        display: none;
       }
       .raise-btn {
         width: var(--avatar-size);

--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -701,6 +701,20 @@ async function finish() {
   const winners = evaluateWinners(state.players);
   const pot = state.pot;
   awardDevShare(pot);
+
+  if (winners.length === 0) {
+    state.players.forEach((p) => (p.revealed = true));
+    state.pot = 0;
+    render();
+    renderPot();
+    setStatus('', 'All players busted. Starting a new round.');
+    delay(() => {
+      setStatus('', '');
+      startNewRound();
+    }, 4000);
+    return;
+  }
+
   const share = Math.floor((pot * 0.9) / winners.length);
   for (const i of winners) {
     const player = state.players[i];
@@ -725,6 +739,7 @@ async function finish() {
   state.players.forEach((p) => (p.revealed = true));
   state.pot = 0;
   render();
+  renderPot();
   const status = document.getElementById('status');
   let text = '';
   if (winners.length === 1) {


### PR DESCRIPTION
## Summary
- align the blackjack table view with the Texas Hold'em styling and lift the bottom seat for better visibility
- hide the unused bottom betting controls so player cards and chips stay unobstructed
- prevent crashes when all players bust by messaging and restarting the round safely

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69329bae9f908329985a267580596fbf)