### PR TITLE
Align Domino Royal avatars and UHD settings

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -126,6 +126,8 @@ import { GLTFLoader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/GL
 import { DRACOLoader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/DRACOLoader.js";
 import "./flag-emojis.js";
 
+const urlParams = new URLSearchParams(window.location.search);
+
 /* ---------- Audio (SFX) ---------- */
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
@@ -192,8 +194,11 @@ function playChimeSequence(notes, { gain = 0.32, type = 'triangle' } = {}) {
   });
 }
 
+const KNOCK_SFX_URL =
+  'https://cdn.pixabay.com/download/audio/2022/03/08/audio_9cfa68cdd8.mp3?filename=knocking-on-wood-14620.mp3';
+
 const sfxBuffers = {
-  place: createBuffer(0.36, (t, i) => {
+  placeFallback: createBuffer(0.36, (t, i) => {
     const strikeEnv = Math.exp(-t * 72);
     const bodyEnv = Math.exp(-t * 14);
     const click = Math.sin((i + 11) * 0.22) * strikeEnv * 0.52;
@@ -218,9 +223,28 @@ const sfxBuffers = {
   })
 };
 
+let placeBufferPromise = null;
+
+function loadPlaceBuffer() {
+  if (placeBufferPromise) return placeBufferPromise;
+  placeBufferPromise = fetch(KNOCK_SFX_URL)
+    .then((res) => {
+      if (!res?.ok) throw new Error(`Failed to fetch knock SFX: ${res?.status}`);
+      return res.arrayBuffer();
+    })
+    .then((data) => ensureAudioContext().decodeAudioData(data))
+    .catch((error) => {
+      console.warn('Domino SFX: falling back to procedural knock', error);
+      return sfxBuffers.placeFallback;
+    });
+  return placeBufferPromise;
+}
+
 const SFX = {
   place() {
-    playBuffer(sfxBuffers.place, { gain: 0.55, playbackRate: 1.05 });
+    loadPlaceBuffer().then((buffer) =>
+      playBuffer(buffer || sfxBuffers.placeFallback, { gain: 0.55, playbackRate: 1.02 })
+    );
   },
   drawTile() {
     playBuffer(sfxBuffers.draw, { gain: 0.5, playbackRate: 1.08 });
@@ -244,10 +268,11 @@ const SFX = {
   }
 };
 
-/* ---------- Renderer / Scene ---------- */
+  /* ---------- Renderer / Scene ---------- */
 const app = document.getElementById("app");
 const renderer = new THREE.WebGLRenderer({ antialias:true, alpha:true, powerPreference:"high-performance" });
-const devicePixelRatioTarget = Math.min(2, window.devicePixelRatio || 1);
+const prefersUhd = urlParams.get('uhd') === '1';
+const devicePixelRatioTarget = Math.min(prefersUhd ? 3 : 2, window.devicePixelRatio || 1);
 renderer.setPixelRatio(devicePixelRatioTarget);
 renderer.shadowMap.enabled = true;
 renderer.shadowMap.autoUpdate = true;
@@ -343,8 +368,6 @@ const UP = new THREE.Vector3(0, 1, 0);
 
 const VIEW_MODES = Object.freeze({ threeD: '3d', twoD: '2d' });
 let cameraViewMode = VIEW_MODES.threeD;
-
-const urlParams = new URLSearchParams(window.location.search);
 
 function normalizeAvatarSource(src = '') {
   const trimmed = src.trim();


### PR DESCRIPTION
## Summary
- Seed Domino Royal AI flags from existing Chess Battle Royal selections to keep avatars consistent
- Always request UHD mode and expose it to the iframe so the arena renders at higher pixel ratios
- Replace the procedural placement click with an open-source wood knock sound while keeping a synthesized fallback

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932a6947bf48329ad7d139b5c5dc04b)