### PR TITLE
Align 2D human dominos to seat orientation

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -3974,7 +3974,7 @@ function renderHands(){
       }
       const yawTowardCenter = Math.atan2(-x0, -z0);
       if(openFlat){
-        orientDominoFlat(m, 0);
+        orientDominoFlat(m, yawTowardCenter);
       } else {
         m.rotation.set(0, (pi===human ? 0 : yawTowardCenter), 0);
         m.rotation.z += (Math.random()*0.006-0.003);


### PR DESCRIPTION
## Summary
- orient human player's 2D dominos using the seat-facing rotation to match the 3D layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932b8a826d08329b5acddf948ebb317)