### PR TITLE
Align Domino Royal hand orientation in 2D view

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -3974,7 +3974,8 @@ function renderHands(){
       }
       const yawTowardCenter = Math.atan2(-x0, -z0);
       if(openFlat){
-        orientDominoFlat(m, yawTowardCenter);
+        const yaw = isHuman ? 0 : yawTowardCenter;
+        orientDominoFlat(m, yaw);
       } else {
         m.rotation.set(0, (pi===human ? 0 : yawTowardCenter), 0);
         m.rotation.z += (Math.random()*0.006-0.003);


### PR DESCRIPTION
## Summary
- keep the human player's dominoes flat and horizontal in 2D view to match the central double-six orientation
- leave other players' 2D/3D orientations unchanged

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932bc5c394483298b8ae83db482f763)