### PR TITLE
Load fbApi helper for Domino Royal avatars

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -117,6 +117,7 @@
   </div>
 </div>
 
+<script src="/blackjack-api.js"></script>
 <script type="module">
 import * as THREE from "https://esm.sh/three@0.160.0";
 import { OrbitControls } from "https://esm.sh/three@0.160.0/examples/jsm/controls/OrbitControls.js";


### PR DESCRIPTION
## Summary
- load the shared blackjack API helper on Domino Royal so fbApi is available for profile lookups

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932d20c18648329b048df028a8e0334)