### PR TITLE
Harden Domino avatar texture loading

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -2730,31 +2730,42 @@ async function createSeatAvatarTexture(source = DEFAULT_AVATAR_EMOJI, fallback =
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   let imageLoaded = false;
-  if (isAvatarUrl(label)) {
-    await new Promise((resolve) => {
-      const img = new Image();
-      img.crossOrigin = 'anonymous';
-      img.onload = () => resolve(img);
-      img.onerror = () => resolve(null);
-      img.src = label;
-    }).then((img) => {
-      if (!img) return;
+
+  try {
+    if (isAvatarUrl(label)) {
+      await new Promise((resolve) => {
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.onload = () => resolve(img);
+        img.onerror = () => resolve(null);
+        img.src = label;
+      }).then((img) => {
+        if (!img) return;
+        imageLoaded = true;
+        const maxSide = Math.max(img.width, img.height) || 1;
+        const drawSize = size * 0.44;
+        const ratio = drawSize / maxSide;
+        const w = img.width * ratio;
+        const h = img.height * ratio;
+        ctx.drawImage(img, center - w / 2, center - h / 2, w, h);
+      });
+    } else {
+      ctx.fillText(label, center, center);
       imageLoaded = true;
-      const maxSide = Math.max(img.width, img.height) || 1;
-      const drawSize = size * 0.44;
-      const ratio = drawSize / maxSide;
-      const w = img.width * ratio;
-      const h = img.height * ratio;
-      ctx.drawImage(img, center - w / 2, center - h / 2, w, h);
-    });
-  } else {
-    ctx.fillText(label, center, center);
-    imageLoaded = true;
+    }
+  } catch (error) {
+    console.warn('Failed to render avatar texture', error);
   }
 
   if (!imageLoaded && fallback && fallback !== label) {
     ctx.clearRect(0, 0, size, size);
     ctx.fillText(fallback, center, center);
+    imageLoaded = true;
+  }
+
+  if (!imageLoaded) {
+    ctx.fillText(DEFAULT_AVATAR_EMOJI, center, center);
+    imageLoaded = true;
   }
 
   const texture = new THREE.CanvasTexture(canvas);


### PR DESCRIPTION
## Summary
- wrap Domino Royal avatar texture rendering in error handling so failing loads don’t crash the game
- add resilient fallbacks to ensure an avatar or default emoji is always drawn

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932e11fb52c8329a0a55da9efca8cd1)