### PR TITLE
Disable Domino Royale hallway entry animation

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -382,7 +382,7 @@ function normalizeAvatarSource(src = '') {
 }
 
 const entryMode = (urlParams.get('entry') || '').toLowerCase();
-const shouldRunHallwayEntry = entryMode === 'hallway';
+const shouldRunHallwayEntry = false;
 const shouldShowSeatLabel = shouldRunHallwayEntry;
 
 const accountId = (urlParams.get('accountId') || '').trim();
@@ -2162,6 +2162,7 @@ hallwayDoorPivot.add(hallwayDoorFrame);
 const hallwayDoorGroup = new THREE.Group();
 hallwayDoorGroup.add(hallwayDoorPivot);
 arenaG.add(hallwayDoorGroup);
+hallwayDoorGroup.visible = false;
 
 const ARENA_WALKWAY_LENGTH = 14;
 const ARENA_WALKWAY_WIDTH = 4.2;


### PR DESCRIPTION
## Summary
- always skip the Domino Royale hallway entry sequence to jump straight into gameplay
- hide the hallway door group so it no longer appears

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932f0ae386483298a321f51978d5811)