### PR TITLE
Avoid UHD Domino rendering in Telegram

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -5,7 +5,13 @@ import RoomSelector from '../../components/RoomSelector.jsx';
 import FlagPickerModal from '../../components/FlagPickerModal.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
-import { ensureAccountId, getTelegramId, getTelegramPhotoUrl, getTelegramUsername } from '../../utils/telegram.js';
+import {
+  ensureAccountId,
+  getTelegramId,
+  getTelegramPhotoUrl,
+  getTelegramUsername,
+  isTelegramWebView
+} from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 
@@ -93,7 +99,10 @@ export default function DominoRoyalLobby() {
     if (stake.token) params.set('token', stake.token);
     if (stake.amount) params.set('amount', stake.amount);
     if (avatar) params.set('avatar', avatar);
-    params.set('uhd', '1');
+    // UHD rendering increases devicePixelRatio to 3x which crashes Telegram's webview on some devices
+    if (!isTelegramWebView()) {
+      params.set('uhd', '1');
+    }
     const username = getTelegramUsername();
     if (username) params.set('username', username);
     const aiFlagSelection = flagOverride && flagOverride.length ? flagOverride : flags;


### PR DESCRIPTION
## Summary
- avoid forcing UHD rendering when launching Domino Royal from the Telegram webview to prevent crashes
- document why UHD is disabled for Telegram clients

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932f8a702f083299388de89984961c8)