### PR TITLE
Restore Domino Royal to 1-40pm state

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -272,15 +272,8 @@ const SFX = {
 const app = document.getElementById("app");
 const renderer = new THREE.WebGLRenderer({ antialias:true, alpha:true, powerPreference:"high-performance" });
 const prefersUhd = urlParams.get('uhd') === '1';
-const BASE_PIXEL_RATIO = Math.min(prefersUhd ? 3 : 2, window.devicePixelRatio || 1);
-const MAX_RENDER_WIDTH = 1920;
-const MAX_RENDER_HEIGHT = 1080;
-
-function getBoundedPixelRatio(width, height) {
-  const safeW = Math.max(1, width);
-  const safeH = Math.max(1, height);
-  return Math.min(BASE_PIXEL_RATIO, MAX_RENDER_WIDTH / safeW, MAX_RENDER_HEIGHT / safeH);
-}
+const devicePixelRatioTarget = Math.min(prefersUhd ? 3 : 2, window.devicePixelRatio || 1);
+renderer.setPixelRatio(devicePixelRatioTarget);
 renderer.shadowMap.enabled = true;
 renderer.shadowMap.autoUpdate = true;
 renderer.shadowMap.type = THREE.PCFSoftShadowMap;
@@ -290,7 +283,6 @@ renderer.toneMapping = THREE.ACESFilmicToneMapping;
 renderer.toneMappingExposure = 1.85;
 function setRendererSize(){
   const vv = window.visualViewport; const w = vv ? vv.width : window.innerWidth; const h = vv ? vv.height: window.innerHeight;
-  renderer.setPixelRatio(getBoundedPixelRatio(w, h));
   renderer.setSize(w, h, false);
 }
 setRendererSize();
@@ -390,7 +382,7 @@ function normalizeAvatarSource(src = '') {
 }
 
 const entryMode = (urlParams.get('entry') || '').toLowerCase();
-const shouldRunHallwayEntry = false;
+const shouldRunHallwayEntry = entryMode === 'hallway';
 const shouldShowSeatLabel = shouldRunHallwayEntry;
 
 const accountId = (urlParams.get('accountId') || '').trim();
@@ -2170,7 +2162,6 @@ hallwayDoorPivot.add(hallwayDoorFrame);
 const hallwayDoorGroup = new THREE.Group();
 hallwayDoorGroup.add(hallwayDoorPivot);
 arenaG.add(hallwayDoorGroup);
-hallwayDoorGroup.visible = false;
 
 const ARENA_WALKWAY_LENGTH = 14;
 const ARENA_WALKWAY_WIDTH = 4.2;

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -5,13 +5,7 @@ import RoomSelector from '../../components/RoomSelector.jsx';
 import FlagPickerModal from '../../components/FlagPickerModal.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
-import {
-  ensureAccountId,
-  getTelegramId,
-  getTelegramPhotoUrl,
-  getTelegramUsername,
-  isTelegramWebView
-} from '../../utils/telegram.js';
+import { ensureAccountId, getTelegramId, getTelegramPhotoUrl, getTelegramUsername } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 
@@ -99,10 +93,7 @@ export default function DominoRoyalLobby() {
     if (stake.token) params.set('token', stake.token);
     if (stake.amount) params.set('amount', stake.amount);
     if (avatar) params.set('avatar', avatar);
-    // UHD rendering increases devicePixelRatio to 3x which crashes Telegram's webview on some devices
-    if (!isTelegramWebView()) {
-      params.set('uhd', '1');
-    }
+    params.set('uhd', '1');
     const username = getTelegramUsername();
     if (username) params.set('username', username);
     const aiFlagSelection = flagOverride && flagOverride.length ? flagOverride : flags;


### PR DESCRIPTION
## Summary
- revert Domino Royal renderer and hallway entry configuration to the version from earlier today
- remove recent lobby changes that disabled UHD parameter in Telegram webview

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330280a1d88329b9eaca3b3ffdfe57)