### PR TITLE
Restore Domino Royal page to 11:08 state

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -117,7 +117,6 @@
   </div>
 </div>
 
-<script src="/blackjack-api.js"></script>
 <script type="module">
 import * as THREE from "https://esm.sh/three@0.160.0";
 import { OrbitControls } from "https://esm.sh/three@0.160.0/examples/jsm/controls/OrbitControls.js";


### PR DESCRIPTION
## Summary
- remove the stray blackjack API script include from the Domino Royal HTML to match the earlier 11:08 state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330ce73bb483299ea85411fecdd8ff)