### PR TITLE
Improve blackjack table UI and flow

### DIFF
--- a/webapp/public/blackjack.html
+++ b/webapp/public/blackjack.html
@@ -442,14 +442,16 @@
         flex-direction: column;
         align-items: center;
         gap: 6px;
-        border: 4px solid #000;
-        border-radius: 12px;
-        padding: 4px;
-        background: var(--seat-bg-color);
-        box-shadow: 4px 4px 0 #d4ccb3;
+        border: 2px solid #233050;
+        border-radius: 14px;
+        padding: 6px;
+        background: linear-gradient(160deg, #0b1220 0%, #121d33 55%, #0b1220 100%);
+        box-shadow:
+          0 12px 24px rgba(0, 0, 0, 0.5),
+          inset 0 0 0 2px rgba(255, 255, 255, 0.04);
       }
       .seat-inner .avatar {
-        box-shadow: 0 0 0 2px #000;
+        box-shadow: 0 0 0 2px #233050, 0 10px 20px rgba(0, 0, 0, 0.45);
       }
       .avatar.turn {
         box-shadow: 0 0 0 2px #facc15;
@@ -551,7 +553,29 @@
       }
       .raise-container,
       .slider-container {
-        display: none;
+        position: absolute;
+        bottom: 4%;
+        padding: 8px 10px;
+        border-radius: 14px;
+        background: rgba(11, 18, 32, 0.9);
+        border: 2px solid #233050;
+        box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        z-index: 6;
+      }
+      .raise-container {
+        left: 8%;
+        transform: translateX(0);
+        flex-direction: column;
+        align-items: center;
+      }
+      .slider-container {
+        right: 8%;
+        transform: translateX(0);
+        gap: 14px;
+        align-items: center;
       }
       .raise-btn {
         width: var(--avatar-size);
@@ -662,12 +686,20 @@
         z-index: 2;
         font-weight: 900;
         letter-spacing: 0.3px;
-        white-space: nowrap;
+        white-space: normal;
+        text-align: center;
       }
       .status-default {
         color: #ff0;
         text-shadow: 0 2px 6px #000;
         -webkit-text-stroke: 1px #000;
+      }
+      .status-subtext {
+        display: block;
+        font-size: 12px;
+        font-weight: 700;
+        color: #c4d4ff;
+        -webkit-text-stroke: 0;
       }
       .tpc-inline-icon {
         width: 1.8em;
@@ -872,8 +904,9 @@
       .hit-stand {
         display: flex;
         gap: 8px;
-        margin-top: 8px;
-        align-items: flex-end;
+        margin-top: -2px;
+        margin-bottom: 2px;
+        align-items: center;
         justify-content: center;
         z-index: 10;
       }

--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -751,12 +751,18 @@ async function finish() {
       .map((i) => state.players[i].name)
       .join(', ')}`;
   }
-  setStatus('', text);
-  delay(() => {
-    state.players.forEach((p) => (p.winner = false));
-    setStatus('', '');
-    startNewRound();
-  }, 5000);
+  const showWinnerCountdown = (remaining) => {
+    const sub = remaining > 0 ? `<span class="status-subtext">Next round in ${remaining}s</span>` : '';
+    setStatus('', `${text}${sub}`);
+    if (remaining <= 0) {
+      state.players.forEach((p) => (p.winner = false));
+      setStatus('', '');
+      startNewRound();
+      return;
+    }
+    delay(() => showWinnerCountdown(remaining - 1), 1000);
+  };
+  showWinnerCountdown(5);
 }
 
 function setStatus(action, text) {


### PR DESCRIPTION
## Summary
- restyle blackjack seats to match the darker Chess Battle Royal-inspired chairs and raise controls
- keep chip and slider controls visible on the table while lifting hit/stand buttons for better reach
- announce winners with an on-table countdown before automatically starting the next round

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331db3dd188329af894b55268b8fd1)