### PR TITLE
Ensure ABeautifulGame white pieces use consistent color

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1685,7 +1685,7 @@ function harmonizeBeautifulGamePieces(piecePrototypes) {
     BEAUTIFUL_GAME_THEME.accent;
   const darkAccent = BEAUTIFUL_GAME_PIECE_STYLE.blackAccent ?? BEAUTIFUL_GAME_PIECE_STYLE.accent ?? accentLight;
 
-  const applyColor = (piece, colorHex) => {
+  const applyColor = (piece, colorHex, { stripMaps = false } = {}) => {
     if (!piece) return;
     piece.traverse((child) => {
       if (!child?.isMesh) return;
@@ -1695,6 +1695,13 @@ function harmonizeBeautifulGamePieces(piecePrototypes) {
         const applied = mat.clone ? mat.clone() : mat;
         applied.color = new THREE.Color(colorHex);
         applied.emissive?.set?.(0x000000);
+        if (stripMaps) {
+          applied.map = null;
+          applied.emissiveMap = null;
+          applied.lightMap = null;
+          applied.vertexColors = false;
+          applied.needsUpdate = true;
+        }
         if (Array.isArray(child.material)) {
           child.material[idx] = applied;
         } else {
@@ -1708,7 +1715,8 @@ function harmonizeBeautifulGamePieces(piecePrototypes) {
 
   ['white', 'black'].forEach((colorKey) => {
     const targetColor = colorKey === 'white' ? lightColor : darkColor;
-    Object.values(piecePrototypes[colorKey] || {}).forEach((piece) => applyColor(piece, targetColor));
+    const stripMaps = colorKey === 'white';
+    Object.values(piecePrototypes[colorKey] || {}).forEach((piece) => applyColor(piece, targetColor, { stripMaps }));
   });
 
   const accentize = (piece, colorKey) => {


### PR DESCRIPTION
## Summary
- strip color texture maps when harmonizing white ABeautifulGame pieces so they match the intended white appearance
- keep material cloning while removing emissive and color maps that left some white pieces dark green

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334e9ccd108329923a943f331f40e6)