### PR TITLE
Restore authentic ABeautifulGame chess colors

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -394,19 +394,19 @@ const SCULPTED_DRAG_STYLE = Object.freeze({
 
 const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
   id: 'beautifulGameAuthentic',
-  label: 'Classic Olive',
+  label: 'Authentic ABeautifulGame',
   white: {
-    color: '#f6f7fb',
+    color: '#fffad3',
     roughness: 0.28,
     metalness: 0.3,
     sheen: 0.3,
-    sheenColor: '#ffffff',
+    sheenColor: '#fffad3',
     clearcoat: 0.32,
     clearcoatRoughness: 0.22,
     specularIntensity: 0.72
   },
   black: {
-    color: '#3f5f46',
+    color: '#4c8073',
     roughness: 0.28,
     metalness: 0.36,
     sheen: 0.24,
@@ -417,10 +417,10 @@ const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
     emissive: '#25291c',
     emissiveIntensity: 0.22
   },
-  accent: '#d7b24a',
-  goldAccent: '#d7b24a',
-  whiteAccent: { color: '#f6f7fb' },
-  blackAccent: '#b7892c'
+  accent: '#caa472',
+  goldAccent: '#caa472',
+  whiteAccent: { color: '#fffad3' },
+  blackAccent: '#caa472'
 });
 
 const BEAUTIFUL_GAME_SET_ID = 'beautifulGameClassic';


### PR DESCRIPTION
## Summary
- update the default ABeautifulGame piece palette to use the original light and dark colors from the source model
- align accent and sheen values with the authentic material tones while keeping existing sizing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933d9c157a4832999d0867678b12367)