### PR TITLE
Adjust Texas Hold'em pot display and camera focus

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -808,8 +808,8 @@
         gap: 4px;
       }
       .pot-total {
-        font-size: 16px;
-        font-weight: 700;
+        font-size: 12px;
+        font-weight: 600;
       }
 
       .chip {

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -2378,6 +2378,7 @@ function TexasHoldemArena({ search }) {
       const maxCameraHeight = ARENA_WALL_TOP_Y - CAMERA_WALL_HEIGHT_MARGIN;
       position.y = Math.min(humanSeat.stoolHeight + elevation, maxCameraHeight);
       const focusBase = cameraTarget.clone().add(new THREE.Vector3(0, CAMERA_FOCUS_CENTER_LIFT, 0));
+      const seatTopPoint = seatTopPointRef.current;
       const focusForwardPull = portrait
         ? PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL
         : CAMERA_PLAYER_FOCUS_FORWARD_PULL;
@@ -2393,7 +2394,11 @@ function TexasHoldemArena({ search }) {
       const humanActing = Boolean(
         activeState?.stage !== 'showdown' && activeState?.players?.[activeState.actionIndex]?.isHuman
       );
-      const focus = humanActing ? focusBase : focusBase.lerp(chipFocus, focusBlend);
+      const topSeatFocus =
+        humanActing && seatTopPoint
+          ? seatTopPoint.clone().setY(seatTopPoint.y + CAMERA_TURN_FOCUS_LIFT)
+          : null;
+      const focus = topSeatFocus ?? (humanActing ? focusBase : focusBase.clone().lerp(chipFocus, focusBlend));
       const lookMatrix = new THREE.Matrix4();
       lookMatrix.lookAt(position, focus, WORLD_UP);
       const targetQuaternion = new THREE.Quaternion().setFromRotationMatrix(lookMatrix);


### PR DESCRIPTION
## Summary
- reduce the Total Pot label size on the table
- aim the human turn camera toward the top seat instead of the local avatar

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933dee3d848832990fb5d5243ac7ca1)