### PR TITLE
Default Chess Battle Royal pieces to ABeautifulGame authentic set

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -4485,7 +4485,9 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
     try {
       const stored = window.localStorage?.getItem(APPEARANCE_STORAGE_KEY);
       if (stored) {
-        return normalizeAppearance(JSON.parse(stored));
+        const normalized = normalizeAppearance(JSON.parse(stored));
+        normalized.pieceStyle = BEAUTIFUL_GAME_PIECE_INDEX;
+        return normalized;
       }
     } catch {}
     return { ...DEFAULT_APPEARANCE };


### PR DESCRIPTION
## Summary
- ensure Chess Battle Royal loads the authentic ABeautifulGame piece style by default even when prior appearance settings exist

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933e6fa7fb88329b38a99cbf5bd2f9b)