### PR TITLE
Auto-start blackjack rounds with initial bets and align action controls

### DIFF
--- a/webapp/src/pages/Games/BlackJackArena.jsx
+++ b/webapp/src/pages/Games/BlackJackArena.jsx
@@ -1186,6 +1186,7 @@ function resetForNextRound(state) {
     bust: false,
     stood: false
   }));
+  placeInitialBets(next);
   dealInitialCards(next);
   return next;
 }
@@ -2776,7 +2777,7 @@ function BlackJackArena({ search }) {
         </div>
       )}
       {(sliderEnabled || showHumanTurn) && (
-        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex flex-wrap items-center justify-center gap-3">
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex flex-nowrap items-center justify-center gap-3">
           {showHumanTurn &&
             uiState.actions.map((action) => {
               const isStand = action.id === 'stand';


### PR DESCRIPTION
## Summary
- automatically place initial bets at the start of each blackjack round so cards are dealt immediately
- keep the action and betting buttons aligned in a single horizontal row

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f15b3130832988fd8f205c45b853)