### PR TITLE
Tweak Texas Hold'em turn indicators and avatar layout

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -188,11 +188,11 @@
       .avatar-timer {
         position: absolute;
         inset: auto;
-        top: -12px;
-        left: 50%;
+        top: 50%;
+        right: -8px;
         width: 36px;
         height: 36px;
-        transform: translate(-50%, -65%) scale(0.92);
+        transform: translate(60%, -50%) scale(0.92);
         border-radius: 50%;
         background: radial-gradient(circle at 50% 50%, rgba(10, 12, 24, 0.92) 60%, transparent 62%);
         filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.35));
@@ -202,7 +202,7 @@
       }
       .avatar-timer.active {
         opacity: 1;
-        transform: translate(-50%, -78%) scale(1);
+        transform: translate(60%, -50%) scale(1);
       }
       .avatar-timer__fill {
         position: absolute;
@@ -417,7 +417,7 @@
       }
 
       .seat.bottom {
-        bottom: 0.5%;
+        bottom: 5%;
         left: 50%;
         transform: translateX(-50%);
         --card-scale: 1.083;
@@ -493,6 +493,22 @@
       }
       .seat.bottom .name {
         font-size: 12px;
+      }
+      .seat.bottom .avatar {
+        opacity: 0;
+        transform: translateY(-4px);
+        transition: opacity 0.2s ease, transform 0.2s ease;
+      }
+      .seat.bottom .avatar.turn {
+        opacity: 1;
+        transform: translateY(-10px);
+      }
+      .seat.small {
+        --avatar-scale: 0.8;
+      }
+      .seat.small .avatar {
+        font-size: 24px;
+        opacity: 1;
       }
       .seat-inner .cards {
         padding: 0;

--- a/webapp/public/texas-holdem.js
+++ b/webapp/public/texas-holdem.js
@@ -781,10 +781,14 @@ function setPlayerTurnIndicator(idx) {
     .forEach((a) => a.classList.remove('turn'));
   const token = document.getElementById('turnToken');
   if (token) token.classList.remove('active');
-  if (idx === null || idx === undefined || idx < 0) return;
+  if (idx === null || idx === undefined || idx < 0) {
+    state.turn = null;
+    return;
+  }
   const nextIdx = findNextActivePlayer(idx);
   if (nextIdx === null) return;
   idx = nextIdx;
+  state.turn = idx;
   const player = state.players[idx];
   const cards = document.getElementById('cards-' + idx);
   if (cards) cards.classList.add('turn');
@@ -796,8 +800,8 @@ function setPlayerTurnIndicator(idx) {
     if (stage && seat) {
       const stageRect = stage.getBoundingClientRect();
       const seatRect = seat.getBoundingClientRect();
-      token.style.left = seatRect.left - stageRect.left + seatRect.width / 2 + 'px';
-      token.style.top = seatRect.top - stageRect.top - 8 + 'px';
+      token.style.left = seatRect.right - stageRect.left + 10 + 'px';
+      token.style.top = seatRect.top - stageRect.top + seatRect.height / 2 + 'px';
       token.classList.add('active');
     }
   }
@@ -1121,6 +1125,7 @@ function updateTimer() {
   document.querySelectorAll('.avatar-timer').forEach((el) => {
     el.classList.remove('active');
   });
+  if (state.turn === null || state.turn === undefined) return;
   const t = document.getElementById('timer-' + state.turn);
   if (!t) return;
   const label = t.querySelector('.avatar-timer__label');


### PR DESCRIPTION
## Summary
- reposition the avatar timer and turn token to share the same side of the active seat
- raise the player avatar along the bottom edge and only reveal it when it is that player’s turn
- tune AI seat avatar sizing so they remain visible alongside their names

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f294763c832991805bbfb2df26c8)