### PR TITLE
Tune Pool Royale aiming, safety logic, and lobby visuals

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -39,7 +39,7 @@ export class AmericanBilliards {
       reason = 'no contact';
     }
 
-    if (!foul && first !== lowest) {
+    if (!foul && lowest != null && first !== lowest) {
       foul = true;
       reason = 'wrong first contact';
     }

--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -33,7 +33,7 @@ export class NineBall {
       reason = 'no contact';
     }
 
-    if (!foul && first !== lowest) {
+    if (!foul && lowest != null && first !== lowest) {
       foul = true;
       reason = 'wrong first contact';
     }

--- a/webapp/src/components/GamesHallway.jsx
+++ b/webapp/src/components/GamesHallway.jsx
@@ -261,24 +261,6 @@ export default function GamesHallway({ games, onClose }) {
     floorGlow.position.set(0, 1.2, 0);
     scene.add(floorGlow);
 
-    const woodTex = loader.load('https://cdn.jsdelivr.net/gh/mrdoob/three.js@r150/examples/textures/wood/mahogany_diffuse.jpg');
-    woodTex.colorSpace = THREE.SRGBColorSpace;
-
-    const handleTex = loader.load('https://cdn.jsdelivr.net/gh/mrdoob/three.js@r150/examples/textures/metal/Brass_Albedo.jpg');
-    handleTex.colorSpace = THREE.SRGBColorSpace;
-
-    const doorMat = new THREE.MeshStandardMaterial({
-      map: woodTex,
-      color: '#7b4a1a',
-      roughness: 0.3,
-      metalness: 0.25
-    });
-    const handleMat = new THREE.MeshStandardMaterial({
-      map: handleTex,
-      color: '#ffd700',
-      metalness: 1,
-      roughness: 0.1
-    });
     const frameMat = new THREE.MeshStandardMaterial({ color: '#c4a26c', metalness: 0.8, roughness: 0.2 });
 
     const signBackgroundColor = '#000000';
@@ -290,7 +272,6 @@ export default function GamesHallway({ games, onClose }) {
       : fallbackGameNames.map((name) => ({ name }));
 
     const interactable = [];
-    const handleGeom = new THREE.CylinderGeometry(0.07, 0.07, 0.4, 32);
 
     doorEntries.forEach((game, index) => {
       const label = String(game?.name || fallbackGameNames[index % fallbackGameNames.length]);
@@ -311,34 +292,6 @@ export default function GamesHallway({ games, onClose }) {
       frame.userData = { type: 'door', route: game?.route ?? null, game };
       doorGroup.add(frame);
       interactable.push(frame);
-
-      const leftDoor = new THREE.Mesh(new THREE.BoxGeometry(2, 4.8, 0.12), doorMat);
-      const rightDoor = new THREE.Mesh(new THREE.BoxGeometry(2, 4.8, 0.12), doorMat);
-      leftDoor.position.set(-1.05, 0, 0.12);
-      rightDoor.position.set(1.05, 0, 0.12);
-      [leftDoor, rightDoor].forEach((doorPanel) => {
-        doorPanel.castShadow = true;
-        doorPanel.receiveShadow = true;
-        doorPanel.userData = { type: 'door', route: game?.route ?? null, game };
-        interactable.push(doorPanel);
-      });
-      doorGroup.add(leftDoor);
-      doorGroup.add(rightDoor);
-
-      const leftHandle = new THREE.Mesh(handleGeom, handleMat);
-      const rightHandle = leftHandle.clone();
-      leftHandle.rotation.z = Math.PI / 2;
-      rightHandle.rotation.z = Math.PI / 2;
-      leftHandle.position.set(0.85, 0, 0.16);
-      rightHandle.position.set(-0.85, 0, 0.16);
-      [leftHandle, rightHandle].forEach((handle) => {
-        handle.castShadow = true;
-        handle.receiveShadow = false;
-        handle.userData = { type: 'door', route: game?.route ?? null, game };
-        interactable.push(handle);
-      });
-      leftDoor.add(leftHandle);
-      rightDoor.add(rightHandle);
 
       const signCanvas = document.createElement('canvas');
       signCanvas.width = 2048;

--- a/webapp/src/config/poolRoyaleTraining.js
+++ b/webapp/src/config/poolRoyaleTraining.js
@@ -38,6 +38,18 @@ const TRAINING_BLUEPRINTS = [
     shotLimit: 4
   },
   {
+    title: 'Pro safe escape',
+    discipline: 'UK 8-Ball',
+    objective: 'Feather a legal contact on your colour and hide the cue ball to avoid giving away two visits.',
+    cue: { x: -0.64, z: -0.52 },
+    balls: [
+      { rackIndex: 5, x: -0.08, z: -0.34 },
+      { rackIndex: 6, x: 0.18, z: -0.06 }
+    ],
+    tip: 'Glance off the object ball with pocket speed and use the blocker as a shield.',
+    shotLimit: 5
+  },
+  {
     title: 'Two-ball pattern',
     discipline: 'American Billiards',
     objective: 'Clear two open balls while floating gently into shape.',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1111,7 +1111,9 @@ const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.6;
 const SIDE_SPIN_MULTIPLIER = 1.25;
 const BACKSPIN_MULTIPLIER = 1.7 * 1.25 * 1.5;
 const TOPSPIN_MULTIPLIER = 1.3;
-const CUE_CLEARANCE_PADDING = BALL_R * 0.25;
+// Tighten the clearance so the preview line better matches the real collision
+// point between the cue ball and the next object ball.
+const CUE_CLEARANCE_PADDING = BALL_R * 0.1;
 const SPIN_CONTROL_DIAMETER_PX = 96;
 const SPIN_DOT_DIAMETER_PX = 10;
 // angle for cushion cuts guiding balls into corner pockets (Pool Royale spec now requires 35°)
@@ -5187,7 +5189,9 @@ function calcTarget(cue, dir, balls) {
   });
 
   const fallbackDistance = Math.sqrt(PLAY_W * PLAY_W + PLAY_H * PLAY_H);
-  let travel = Number.isFinite(tHit) ? tHit : fallbackDistance;
+  // Pull the preview impact point slightly closer to the cue ball to avoid
+  // overshooting the real collision point due to the clearance padding.
+  let travel = Number.isFinite(tHit) ? Math.max(0, tHit - CUE_CLEARANCE_PADDING) : fallbackDistance;
   if (travel <= 0) {
     travel = fallbackDistance;
   }


### PR DESCRIPTION
## Summary
- tighten the Pool Royale aiming line clearance so previews match collisions more closely
- remove the physical door panels from the 3D hallway while keeping entrances interactable
- add a UK 8-Ball pro safety training scenario and relax first-contact checks when the lowest ball is already off the table

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933ff384aa083298041b5ae75a48686)