### PR TITLE
Improve Pool Royale aiming and AI targeting

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -137,11 +137,7 @@ function pocketBetween (cue, ball, pockets, radius) {
 }
 
 function pocketEntry (pocket, state) {
-  const center = { x: state.width / 2, y: state.height / 2 }
-  const dir = { x: center.x - pocket.x, y: center.y - pocket.y }
-  const len = Math.hypot(dir.x, dir.y) || 1
-  const offset = state.ballRadius * 1.05
-  return { x: pocket.x + (dir.x / len) * offset, y: pocket.y + (dir.y / len) * offset, name: pocket.name }
+  return { x: pocket.x, y: pocket.y, name: pocket.name }
 }
 
 // Returns angle between cue->ball and ball->pocket in radians

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1111,7 +1111,7 @@ const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.6;
 const SIDE_SPIN_MULTIPLIER = 1.25;
 const BACKSPIN_MULTIPLIER = 1.7 * 1.25 * 1.5;
 const TOPSPIN_MULTIPLIER = 1.3;
-const CUE_CLEARANCE_PADDING = BALL_R * 0.25;
+const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
 const SPIN_CONTROL_DIAMETER_PX = 96;
 const SPIN_DOT_DIAMETER_PX = 10;
 // angle for cushion cuts guiding balls into corner pockets (Pool Royale spec now requires 35°)
@@ -10847,6 +10847,15 @@ function PoolRoyaleGame({
           syncBlendToSpherical();
         };
 
+        const sanitizeVector3 = (vec, fallback = null) => {
+          if (!vec) return fallback;
+          const { x, y, z } = vec;
+          if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+            return fallback;
+          }
+          return vec;
+        };
+
 
         const updateBroadcastCameras = ({
           railDir = 1,
@@ -10856,6 +10865,8 @@ function PoolRoyaleGame({
         } = {}) => {
           const rig = broadcastCamerasRef.current;
           if (!rig || !rig.cameras) return;
+          const safeTargetWorld = sanitizeVector3(targetWorld, null);
+          const safeFocusWorld = sanitizeVector3(focusWorld, null);
           const system =
             broadcastSystemRef.current ?? activeBroadcastSystem ?? BROADCAST_SYSTEM_OPTIONS[0];
           const smoothing = THREE.MathUtils.clamp(
@@ -10864,8 +10875,8 @@ function PoolRoyaleGame({
             1
           );
           const baseFocus =
-            focusWorld ?? rig.defaultFocusWorld ?? rig.defaultFocus ?? null;
-          const trackingTarget = targetWorld ?? baseFocus;
+            safeFocusWorld ?? rig.defaultFocusWorld ?? rig.defaultFocus ?? null;
+          const trackingTarget = safeTargetWorld ?? baseFocus;
           const bias = THREE.MathUtils.clamp(system?.trackingBias ?? 0, 0, 1);
           const focusTarget =
             baseFocus && trackingTarget


### PR DESCRIPTION
## Summary
- tighten cue-ball clearance used by the aiming guide for more accurate impact previews
- retarget UK 8-ball AI pocket entries to the centre of the pocket mouth for cleaner shots
- harden broadcast camera updates against invalid focus targets that could stall playback

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693408edcf5c8329ae0d36b35d23089d)