### PR TITLE
Improve pool AI targeting and camera stability

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -918,6 +918,12 @@ public class CueCamera : MonoBehaviour
             {
                 Vector3 adjustedPosition = hit.point - dir * collisionBuffer;
                 adjustedPosition.y = Mathf.Max(adjustedPosition.y, minimumHeight);
+                if (Vector3.Distance(adjustedPosition, focusPosition) < collisionRadius)
+                {
+                    float safeDistance = Mathf.Max(hit.distance - collisionBuffer, collisionRadius);
+                    adjustedPosition = focusOrigin + dir * safeDistance;
+                    adjustedPosition.y = Mathf.Max(adjustedPosition.y, minimumHeight + collisionBuffer);
+                }
                 desiredPosition = adjustedPosition;
             }
         }

--- a/billiards/AimPreview.cs
+++ b/billiards/AimPreview.cs
@@ -16,13 +16,21 @@ public static class AimPreview
     /// <summary>Runs the solver preview and formats the result.</summary>
     public static Result Build(BilliardsSolver solver, Vec2 cueStart, Vec2 dir, double speed, List<BilliardsSolver.Ball> others)
     {
-        var p = solver.PreviewShot(cueStart, dir, speed, others);
+        var preview = solver.PreviewShot(cueStart, dir, speed, others);
+        var impact = solver.SimulateFirstImpact(cueStart, dir, speed, others);
+
+        List<Vec2> path = new List<Vec2> { cueStart, impact.Point };
+        if (impact.CueVelocity.Length > PhysicsConstants.Epsilon)
+        {
+            path.Add(impact.Point + impact.CueVelocity.Normalized() * PhysicsConstants.BallRadius);
+        }
+
         return new Result
         {
-            Path = p.Path.ToArray(),
-            ContactPoint = p.ContactPoint,
-            CuePostVelocity = p.CuePostVelocity,
-            TargetPostVelocity = p.TargetPostVelocity
+            Path = path.ToArray(),
+            ContactPoint = impact.Point,
+            CuePostVelocity = impact.CueVelocity,
+            TargetPostVelocity = impact.TargetVelocity ?? preview.TargetPostVelocity
         };
     }
 }


### PR DESCRIPTION
## Summary
- refine UK 8-ball AI to aim through each pocket mouth and prioritize open entries
- synchronize AI library copy used by the web client
- tighten aiming preview accuracy and add safeguards against occlusion locking the cue camera

## Testing
- npm test -- --runTestsByPath test/poolAi.test.js *(fails: npm not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69341c119e94832998f34514ae6accc0)