### PR TITLE
Add Socket.IO multiplayer server for Blackjack example

### DIFF
--- a/examples/blackjack/README.md
+++ b/examples/blackjack/README.md
@@ -29,3 +29,26 @@ settling the pot and starting the next game.
 This example focuses on the game mechanics and is intentionally minimal. It can
 be paired with a Socket.IO server and React client similar to the other
 examples in this repository.
+
+## Running a multiplayer room server
+
+`server.js` shows a lightweight Socket.IO host that mirrors the Murlan Royale
+3D flow: rooms spin up automatically, hands are dealt once at least two players
+join, and the round advances from betting → hits → showdown without any extra
+UI scripting. To try it locally:
+
+```bash
+node examples/blackjack/server.js
+```
+
+From a client you can connect with Socket.IO and emit the following events:
+
+- `joinRoom`: `{ roomId, name? }` – join or create a room and trigger dealing
+  when the minimum player count is reached.
+- `bet`: `{ roomId, amount }` – convenience wrapper for `raise`.
+- `call`, `raise`, `fold`: `{ roomId, amount? }` – standard betting actions.
+- `hit`, `stand`: `{ roomId }` – act during the hit phase.
+
+The server emits `gameStateUpdate` after every action and a `showdown` payload
+when the hand resolves. `getState()` now includes `lastShowdown` so clients can
+render the winning line-up alongside the new deal.

--- a/examples/blackjack/gameLogic.js
+++ b/examples/blackjack/gameLogic.js
@@ -213,12 +213,17 @@ export class BlackjackGame {
       currentBet: this.currentBet,
       players: this.players,
       community: this.community,
-      phase: this.phase
+      phase: this.phase,
+      lastShowdown: this.lastShowdown
     };
   }
 
   allPlayersCalled() {
     return this.players.every(p => p.folded || (p.bet === this.currentBet && p.acted));
+  }
+
+  allPlayersSettled() {
+    return this.players.every(p => p.folded || p.stood);
   }
 }
 

--- a/examples/blackjack/server.js
+++ b/examples/blackjack/server.js
@@ -1,0 +1,124 @@
+import express from 'express';
+import http from 'http';
+import { Server } from 'socket.io';
+import { BlackjackGame } from './gameLogic.js';
+
+const MIN_PLAYERS = 2;
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server, { cors: { origin: '*' } });
+
+const games = new Map();
+
+function getGame(roomId) {
+  if (!games.has(roomId)) {
+    games.set(roomId, new BlackjackGame(roomId));
+  }
+  return games.get(roomId);
+}
+
+function broadcastState(roomId) {
+  const game = games.get(roomId);
+  if (!game) return;
+  io.to(roomId).emit('gameStateUpdate', game.getState());
+}
+
+function maybeStart(game) {
+  if (game.phase === 'waiting' && game.players.length >= MIN_PLAYERS) {
+    game.start();
+  }
+}
+
+function maybeResolveRound(game, roomId) {
+  if (game.phase === 'betting' && game.allPlayersCalled()) {
+    game.startHitPhase();
+  }
+
+  if (game.phase === 'hit' && game.allPlayersSettled()) {
+    const showdown = game.showdown();
+    io.to(roomId).emit('showdown', showdown);
+    game.finishRound();
+  }
+}
+
+io.on('connection', (socket) => {
+  socket.on('joinRoom', ({ roomId, name }) => {
+    const game = getGame(roomId);
+    const player = game.addPlayer(socket.id, name || 'Player');
+    if (!player) {
+      socket.emit('joinRejected', { reason: 'Room full or already started' });
+      return;
+    }
+    socket.join(roomId);
+    maybeStart(game);
+    broadcastState(roomId);
+  });
+
+  socket.on('bet', ({ roomId, amount }) => {
+    const game = games.get(roomId);
+    if (!game) return;
+    game.placeBet(socket.id, amount || 0);
+    maybeResolveRound(game, roomId);
+    broadcastState(roomId);
+  });
+
+  socket.on('call', ({ roomId }) => {
+    const game = games.get(roomId);
+    if (!game) return;
+    game.call(socket.id);
+    maybeResolveRound(game, roomId);
+    broadcastState(roomId);
+  });
+
+  socket.on('raise', ({ roomId, amount }) => {
+    const game = games.get(roomId);
+    if (!game) return;
+    game.raise(socket.id, amount || 0);
+    maybeResolveRound(game, roomId);
+    broadcastState(roomId);
+  });
+
+  socket.on('fold', ({ roomId }) => {
+    const game = games.get(roomId);
+    if (!game) return;
+    game.fold(socket.id);
+    maybeResolveRound(game, roomId);
+    broadcastState(roomId);
+  });
+
+  socket.on('hit', ({ roomId }) => {
+    const game = games.get(roomId);
+    if (!game) return;
+    game.hit(socket.id);
+    maybeResolveRound(game, roomId);
+    broadcastState(roomId);
+  });
+
+  socket.on('stand', ({ roomId }) => {
+    const game = games.get(roomId);
+    if (!game) return;
+    game.stand(socket.id);
+    maybeResolveRound(game, roomId);
+    broadcastState(roomId);
+  });
+
+  socket.on('disconnecting', () => {
+    for (const roomId of socket.rooms) {
+      const game = games.get(roomId);
+      if (!game) continue;
+      const player = game.players.find((p) => p.id === socket.id);
+      if (player) {
+        player.folded = true;
+        player.stood = true;
+      }
+      maybeResolveRound(game, roomId);
+      broadcastState(roomId);
+    }
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Blackjack server listening on port ${PORT}`);
+});

--- a/test/blackjackGame.test.js
+++ b/test/blackjackGame.test.js
@@ -48,3 +48,34 @@ test('standing keeps hand static when others hit', () => {
   assert.equal(game.getBestValue(alice.hand), before);
 });
 
+test('allPlayersSettled signals when everyone has acted', () => {
+  const game = new BlackjackGame('room');
+  game.addPlayer('a');
+  game.addPlayer('b');
+  game.start();
+  game.startHitPhase();
+
+  const alice = game.players.find((p) => p.id === 'a');
+  const bob = game.players.find((p) => p.id === 'b');
+  alice.stood = true;
+  bob.folded = true;
+
+  assert.equal(game.allPlayersSettled(), true);
+});
+
+test('last showdown details are exposed in getState', () => {
+  const game = new BlackjackGame('room');
+  game.addPlayer('a');
+  game.addPlayer('b');
+  game.start();
+  game.startHitPhase();
+  game.players.forEach((p) => {
+    p.stood = true;
+  });
+
+  const showdown = game.showdown();
+  const state = game.getState();
+
+  assert.deepEqual(state.lastShowdown, showdown);
+});
+


### PR DESCRIPTION
## Summary
- add a lightweight Socket.IO server to run multiplayer Blackjack rooms automatically
- expose showdown information and settlement helper methods from the Blackjack game logic
- document how to run the server and cover the new helpers with tests

## Testing
- npm test -- --runInBand *(fails in environment: npm/node not installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343a48186c8329907b7f61c75045b4)