### PR TITLE
Improve Football Battle Royale controls and field

### DIFF
--- a/webapp/public/free-kick.html
+++ b/webapp/public/free-kick.html
@@ -91,12 +91,16 @@
     const ctx = canvas.getContext('2d');
     let W = window.innerWidth; let H = window.innerHeight;
     const DPR = Math.max(1, Math.min(2.5, window.devicePixelRatio || 1));
-    const field = { w: 120, h: 68 };
+    const field = { w: 112, h: 70 };
     const goalWidth = 7.32;
-    const goalDepth = 3;
+    const goalDepth = 3.6;
+    const penaltyDepth = 16.5;
+    const sixYardDepth = 5.5;
+    const penaltyBoxHalf = 20.15;
+    const sixYardHalf = 9.15;
+    const playersPerTeam = 3;
     const players = [];
     const teams = { home: { color:'#38bdf8', score:0 }, away:{ color:'#f87171', score:0 } };
-    const maxPlayers = 6;
     const joystick = document.getElementById('joystick');
     const knob = joystick.querySelector('.knob');
     const messageEl = document.getElementById('message');
@@ -113,10 +117,12 @@
     audio.crowd.loop = true; audio.crowd.volume = 0.35;
     audio.goal.volume = 1; audio.kick.volume = 0.75;
 
-    const ball = { x:0, y:0, vx:0, vy:0, r:1, carrier:null };
+    const ball = { x:0, y:0, vx:0, vy:0, r:0.9, carrier:null };
     let activePlayer = null;
     let joystickState = { active:false, dx:0, dy:0 };
     let sprintTimer = 0;
+    let manualSelectTimer = 0;
+    let viewState = { scale: 1, offsetX: 0, offsetY: 0 };
     let remaining = 120;
     let lastTime = performance.now();
     let running = true;
@@ -132,13 +138,15 @@
 
     function createTeams(){
       players.length = 0;
-      for(let i=0;i<maxPlayers;i++){
-        const t = i % 2 === 0 ? 'home' : 'away';
-        const side = t === 'home' ? -1 : 1;
-        const px = side * (field.w*0.25 + Math.random()*6);
-        const py = (Math.random()-0.5) * (field.h*0.6);
-        players.push({ team:t, x:px, y:py, vx:0, vy:0, speed:9, hasBall:false });
-      }
+      ['home','away'].forEach((team)=>{
+        const side = team === 'home' ? -1 : 1;
+        players.push({ team, role:'keeper', x: side * (field.w/2 - goalDepth*0.6), y:0, vx:0, vy:0, speed:12, hasBall:false });
+        for(let i=1;i<playersPerTeam;i++){
+          const px = side * (field.w*0.25 + Math.random()*6);
+          const py = (Math.random()-0.5) * (field.h*0.6);
+          players.push({ team, role:'outfield', x:px, y:py, vx:0, vy:0, speed:10, hasBall:false });
+        }
+      });
       ball.x = 0; ball.y = 0; ball.vx=0; ball.vy=0; ball.carrier=null;
       teams.home.score = 0; teams.away.score = 0;
     }
@@ -146,9 +154,10 @@
     function drawField(){
       ctx.fillStyle = '#0a8a2d';
       ctx.fillRect(0,0,W,H);
-      const scale = Math.min(W/field.w, H/field.h);
+      const scale = Math.min((W-20)/field.w, (H-40)/field.h);
       const offsetX = W/2 - (field.w*scale)/2;
-      const offsetY = H/2 - (field.h*scale)/2;
+      const offsetY = H - (field.h*scale) - 18;
+      viewState = { scale, offsetX, offsetY };
       ctx.save();
       ctx.translate(offsetX, offsetY);
       ctx.scale(scale, scale);
@@ -156,14 +165,30 @@
         ctx.fillStyle = (Math.floor(x/7)%2===0)?'rgba(255,255,255,0.02)':'rgba(0,0,0,0.04)';
         ctx.fillRect(x, -field.h/2, 7, field.h);
       }
-      ctx.strokeStyle = 'rgba(255,255,255,0.8)';
+      ctx.strokeStyle = 'rgba(255,255,255,0.85)';
       ctx.lineWidth = 0.3;
       ctx.strokeRect(-field.w/2, -field.h/2, field.w, field.h);
       ctx.beginPath();
       ctx.arc(0,0,9.15,0,Math.PI*2);
       ctx.moveTo(0,-field.h/2);
       ctx.lineTo(0,field.h/2);
+
+      ctx.rect(-field.w/2, -penaltyBoxHalf, penaltyDepth, penaltyBoxHalf*2);
+      ctx.rect(field.w/2 - penaltyDepth, -penaltyBoxHalf, penaltyDepth, penaltyBoxHalf*2);
+
+      ctx.rect(-field.w/2, -sixYardHalf, sixYardDepth, sixYardHalf*2);
+      ctx.rect(field.w/2 - sixYardDepth, -sixYardHalf, sixYardDepth, sixYardHalf*2);
       ctx.stroke();
+
+      ctx.beginPath();
+      ctx.arc(-field.w/2 + 11, 0, 0.35, 0, Math.PI*2);
+      ctx.arc(field.w/2 - 11, 0, 0.35, 0, Math.PI*2);
+      ctx.moveTo(-field.w/2 + 11, 0);
+      ctx.arc(-field.w/2 + 11, 0, 9.15, -0.3, 0.3, false);
+      ctx.moveTo(field.w/2 - 11, 0);
+      ctx.arc(field.w/2 - 11, 0, 9.15, Math.PI-0.3, Math.PI+0.3, true);
+      ctx.stroke();
+
       drawGoal(-field.w/2, -goalWidth/2);
       drawGoal(field.w/2 - goalDepth, -goalWidth/2);
 
@@ -177,6 +202,12 @@
         ctx.strokeStyle = isActive ? '#fff' : 'rgba(255,255,255,0.45)';
         ctx.lineWidth = isActive ? 0.24 : 0.18;
         ctx.stroke();
+        if(isActive){
+          ctx.fillStyle = '#fff';
+          ctx.font = 'bold 1.2px system-ui';
+          ctx.textAlign = 'center';
+          ctx.fillText('∨', 0, -2.2);
+        }
         if(p.hasBall){
           ctx.beginPath();
           ctx.arc(0,-1.7,0.4,0,Math.PI*2);
@@ -211,7 +242,8 @@
       if(remaining === 0){ endMatch(); }
       if(sprintTimer>0){ sprintTimer = Math.max(0, sprintTimer - dt); }
 
-      const speed = 8 + (sprintTimer>0?4:0);
+      const baseSpeed = (activePlayer?.speed || 10);
+      const speed = baseSpeed + (sprintTimer>0?6:0);
       if(activePlayer){
         activePlayer.vx += joystickState.dx * speed * dt;
         activePlayer.vy += joystickState.dy * speed * dt;
@@ -221,11 +253,14 @@
         p.vx *= 0.9; p.vy *= 0.9;
         p.x += p.vx * dt;
         p.y += p.vy * dt;
-        p.x = clamp(p.x, -field.w/2 + 1.5, field.w/2 - 1.5);
-        p.y = clamp(p.y, -field.h/2 + 1.5, field.h/2 - 1.5);
+        const marginX = p.role === 'keeper' ? goalDepth*0.6 : 0.6;
+        const marginY = p.role === 'keeper' ? goalWidth/2 + 0.4 : 0.6;
+        p.x = clamp(p.x, -field.w/2 + marginX, field.w/2 - marginX);
+        p.y = clamp(p.y, -field.h/2 + marginY, field.h/2 - marginY);
       });
 
       resolveAI(dt);
+      if(manualSelectTimer>0){ manualSelectTimer = Math.max(0, manualSelectTimer - dt); }
       autoSwitchPlayer();
       resolvePossession();
       updateBall(dt);
@@ -233,6 +268,7 @@
     }
 
     function autoSwitchPlayer(){
+      if(manualSelectTimer>0) return;
       let best = null; let bestDist = Infinity;
       players.filter(p=>p.team==='home').forEach((p)=>{
         const d = Math.hypot(p.x - ball.x, p.y - ball.y);
@@ -394,7 +430,8 @@
       joystick.addEventListener('pointerdown',(e)=>{ pointer=e.pointerId; joystick.setPointerCapture(e.pointerId); update(e.clientX,e.clientY); });
       joystick.addEventListener('pointermove',(e)=>{ if(pointer===e.pointerId) update(e.clientX,e.clientY); });
       const end = (e)=>{ if(pointer===e.pointerId){ reset(); } };
-      joystick.addEventListener('pointerup',end); joystick.addEventListener('pointercancel',end); joystick.addEventListener('pointerleave',end);
+      joystick.addEventListener('pointerup',end); joystick.addEventListener('pointercancel',end); joystick.addEventListener('pointerleave',end); joystick.addEventListener('pointerout',end);
+      window.addEventListener('pointerup', end);
     }
 
     function bindButtons(){
@@ -402,25 +439,46 @@
       document.getElementById('btnLeft').addEventListener('pointerdown', passBall);
       document.getElementById('btnRight').addEventListener('pointerdown', tackle);
       document.getElementById('btnDown').addEventListener('pointerdown', dash);
+      canvas.addEventListener('pointerdown', (e)=> selectPlayerFromTap(e.clientX, e.clientY));
     }
 
     function resolveAI(dt){
-      players.filter(p=>p.team==='away').forEach((bot)=>{
-        const target = ball.carrier && ball.carrier.team==='away' ? (bot===ball.carrier?null:ball.carrier) : ball;
-        if(!target) return;
+      players.forEach((bot)=>{
+        const isUserTeam = bot.team === 'home';
+        const isActive = bot === activePlayer;
+        if(isUserTeam && isActive) return;
+        const target = bot.role === 'keeper'
+          ? { x: bot.x, y: clamp(ball.y, -goalWidth/2, goalWidth/2) }
+          : (ball.carrier && ball.carrier.team===bot.team ? ball.carrier : ball);
         const dx = target.x - bot.x;
         const dy = target.y - bot.y;
         const len = Math.hypot(dx,dy)||1;
-        const speed = 7;
+        const speed = bot.role === 'keeper' ? bot.speed : bot.speed * (bot.team==='away'?1.05:0.72);
         bot.vx += (dx/len)*speed*dt;
         bot.vy += (dy/len)*speed*dt;
-        if(target===ball && Math.hypot(dx,dy)<1.6){
+        if(target===ball && Math.hypot(dx,dy)<1.4){
           ball.carrier = bot; bot.hasBall=true; ball.vx=0; ball.vy=0;
           const towardsGoal = bot.team==='away'? -1:1;
           ball.carrier=null; bot.hasBall=false;
           ball.vx = towardsGoal*18; ball.vy = (Math.random()-0.5)*8;
         }
       });
+    }
+
+    function selectPlayerFromTap(clientX, clientY){
+      const { scale, offsetX, offsetY } = viewState;
+      const worldX = (clientX - offsetX) / scale;
+      const worldY = (clientY - offsetY) / scale;
+      let best=null; let bestDist=2.2;
+      players.filter(p=>p.team==='home').forEach((p)=>{
+        const d = Math.hypot(p.x - worldX, p.y - worldY);
+        if(d < bestDist){ bestDist = d; best = p; }
+      });
+      if(best){
+        activePlayer = best;
+        manualSelectTimer = 3.5;
+        showHint('Lojtari u përzgjodh.');
+      }
     }
 
     function init(){


### PR DESCRIPTION
## Summary
- expand the Football Battle Royale pitch with official markings and bottom-biased camera framing
- speed up players and keepers, constrain keepers to lateral goal movement, and improve auto-select plus tap-to-select controls with an active indicator
- strengthen joystick handling and allow faster full-field movement and clearer possession behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69345f4d4dd4832995989f1467ba93e1)