### PR TITLE
Ensure ABeautifulGame materials remain authentic

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -282,18 +282,7 @@ const BEAUTIFUL_GAME_THEME = Object.freeze(
   })
 );
 
-const BEAUTIFUL_GAME_THEME_NAMES = [
-  'Authentic',
-  'Swap Palettes',
-  'Blue / Orange',
-  'Red / Teal',
-  'Purple / Lime',
-  'Pink / Cyan',
-  'Gold / Slate',
-  'Emerald / Fuchsia',
-  'Silver / Graphite',
-  'Forest / Sand'
-];
+const BEAUTIFUL_GAME_THEME_NAMES = ['Authentic'];
 
 const BEAUTIFUL_GAME_BOARD_VARIANTS = Object.freeze([
   buildBoardTheme({
@@ -301,87 +290,6 @@ const BEAUTIFUL_GAME_BOARD_VARIANTS = Object.freeze([
     label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[0]})`,
     ...BEAUTIFUL_GAME_THEME,
     preserveOriginalMaterials: true
-  }),
-  buildBoardTheme({
-    id: 'beautifulGameSwapBoard',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[1]})`,
-    light: '#EEE8D5',
-    dark: '#2B2F36',
-    frameLight: BEAUTIFUL_GAME_THEME.frameLight,
-    frameDark: BEAUTIFUL_GAME_THEME.frameDark,
-    preserveOriginalMaterials: false
-  }),
-  buildBoardTheme({
-    id: 'beautifulGameBlueOrangeBoard',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[2]})`,
-    light: '#93C5FD',
-    dark: '#1E293B',
-    frameLight: BEAUTIFUL_GAME_THEME.frameLight,
-    frameDark: BEAUTIFUL_GAME_THEME.frameDark,
-    preserveOriginalMaterials: false
-  }),
-  buildBoardTheme({
-    id: 'beautifulGameRedTealBoard',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[3]})`,
-    light: '#FCA5A5',
-    dark: '#0F766E',
-    frameLight: BEAUTIFUL_GAME_THEME.frameLight,
-    frameDark: BEAUTIFUL_GAME_THEME.frameDark,
-    preserveOriginalMaterials: false
-  }),
-  buildBoardTheme({
-    id: 'beautifulGamePurpleLimeBoard',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[4]})`,
-    light: '#C4B5FD',
-    dark: '#365314',
-    frameLight: BEAUTIFUL_GAME_THEME.frameLight,
-    frameDark: BEAUTIFUL_GAME_THEME.frameDark,
-    preserveOriginalMaterials: false
-  }),
-  buildBoardTheme({
-    id: 'beautifulGamePinkCyanBoard',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[5]})`,
-    light: '#F9A8D4',
-    dark: '#164E63',
-    frameLight: BEAUTIFUL_GAME_THEME.frameLight,
-    frameDark: BEAUTIFUL_GAME_THEME.frameDark,
-    preserveOriginalMaterials: false
-  }),
-  buildBoardTheme({
-    id: 'beautifulGameGoldSlateBoard',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[6]})`,
-    light: '#FDE68A',
-    dark: '#0F172A',
-    frameLight: BEAUTIFUL_GAME_THEME.frameLight,
-    frameDark: BEAUTIFUL_GAME_THEME.frameDark,
-    preserveOriginalMaterials: false
-  }),
-  buildBoardTheme({
-    id: 'beautifulGameEmeraldFuchsiaBoard',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[7]})`,
-    light: '#6EE7B7',
-    dark: '#4A044E',
-    frameLight: BEAUTIFUL_GAME_THEME.frameLight,
-    frameDark: BEAUTIFUL_GAME_THEME.frameDark,
-    preserveOriginalMaterials: false
-  }),
-  buildBoardTheme({
-    id: 'beautifulGameSilverGraphiteBoard',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[8]})`,
-    light: '#E5E7EB',
-    dark: '#111827',
-    frameLight: BEAUTIFUL_GAME_THEME.frameLight,
-    frameDark: BEAUTIFUL_GAME_THEME.frameDark,
-    preserveOriginalMaterials: false
-  }),
-  buildBoardTheme({
-    id: 'beautifulGameForestSandBoard',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[9]})`,
-    light: '#FDEAD7',
-    dark: '#064E3B',
-    frameLight: BEAUTIFUL_GAME_THEME.frameLight,
-    frameDark: BEAUTIFUL_GAME_THEME.frameDark,
-    preserveOriginalMaterials: false
   })
 ]);
 
@@ -452,107 +360,6 @@ const BEAUTIFUL_GAME_COLOR_VARIANTS = Object.freeze([
     id: BEAUTIFUL_GAME_AUTHENTIC_ID,
     label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[0]})`,
     style: { ...BASE_PIECE_STYLE, preserveOriginalMaterials: true, keepTextures: true }
-  },
-  {
-    id: 'beautifulGameSwapPalettes',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[1]})`,
-    style: {
-      ...BASE_PIECE_STYLE,
-      preserveOriginalMaterials: false,
-      keepTextures: true,
-      white: { ...BASE_PIECE_STYLE.white, color: BEAUTIFUL_GAME_THEME.dark },
-      black: { ...BASE_PIECE_STYLE.black, color: BEAUTIFUL_GAME_THEME.light }
-    }
-  },
-  {
-    id: 'beautifulGameBlueOrange',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[2]})`,
-    style: {
-      ...BASE_PIECE_STYLE,
-      preserveOriginalMaterials: false,
-      keepTextures: true,
-      white: { ...BASE_PIECE_STYLE.white, color: '#93C5FD' },
-      black: { ...BASE_PIECE_STYLE.black, color: '#1E293B' },
-      accent: '#F59E0B'
-    }
-  },
-  {
-    id: 'beautifulGameRedTeal',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[3]})`,
-    style: {
-      ...BASE_PIECE_STYLE,
-      preserveOriginalMaterials: false,
-      keepTextures: true,
-      white: { ...BASE_PIECE_STYLE.white, color: '#FCA5A5' },
-      black: { ...BASE_PIECE_STYLE.black, color: '#0F766E' }
-    }
-  },
-  {
-    id: 'beautifulGamePurpleLime',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[4]})`,
-    style: {
-      ...BASE_PIECE_STYLE,
-      preserveOriginalMaterials: false,
-      keepTextures: true,
-      white: { ...BASE_PIECE_STYLE.white, color: '#C4B5FD' },
-      black: { ...BASE_PIECE_STYLE.black, color: '#365314' }
-    }
-  },
-  {
-    id: 'beautifulGamePinkCyan',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[5]})`,
-    style: {
-      ...BASE_PIECE_STYLE,
-      preserveOriginalMaterials: false,
-      keepTextures: true,
-      white: { ...BASE_PIECE_STYLE.white, color: '#F9A8D4' },
-      black: { ...BASE_PIECE_STYLE.black, color: '#164E63' }
-    }
-  },
-  {
-    id: 'beautifulGameGoldSlate',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[6]})`,
-    style: {
-      ...BASE_PIECE_STYLE,
-      preserveOriginalMaterials: false,
-      keepTextures: true,
-      white: { ...BASE_PIECE_STYLE.white, color: '#FDE68A' },
-      black: { ...BASE_PIECE_STYLE.black, color: '#0F172A' },
-      goldAccent: '#d7b24a'
-    }
-  },
-  {
-    id: 'beautifulGameEmeraldFuchsia',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[7]})`,
-    style: {
-      ...BASE_PIECE_STYLE,
-      preserveOriginalMaterials: false,
-      keepTextures: true,
-      white: { ...BASE_PIECE_STYLE.white, color: '#6EE7B7' },
-      black: { ...BASE_PIECE_STYLE.black, color: '#4A044E' }
-    }
-  },
-  {
-    id: 'beautifulGameSilverGraphite',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[8]})`,
-    style: {
-      ...BASE_PIECE_STYLE,
-      preserveOriginalMaterials: false,
-      keepTextures: true,
-      white: { ...BASE_PIECE_STYLE.white, color: '#E5E7EB' },
-      black: { ...BASE_PIECE_STYLE.black, color: '#111827' }
-    }
-  },
-  {
-    id: 'beautifulGameForestSand',
-    label: `ABeautifulGame (${BEAUTIFUL_GAME_THEME_NAMES[9]})`,
-    style: {
-      ...BASE_PIECE_STYLE,
-      preserveOriginalMaterials: false,
-      keepTextures: true,
-      white: { ...BASE_PIECE_STYLE.white, color: '#FDEAD7' },
-      black: { ...BASE_PIECE_STYLE.black, color: '#064E3B' }
-    }
   }
 ]);
 


### PR DESCRIPTION
## Summary
- restrict ABeautifulGame board and piece color options to the authentic glTF materials
- keep board rendering using the original model materials instead of procedural recoloring

## Testing
- not tested (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693477bb900883299db12e1b0c364c6b)