### PR TITLE
Adjust Pool Royale side rail cuts and jaw depth

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -431,7 +431,7 @@ const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.028; // trim the middle rail arches so the rounded cut radius tucks a bit tighter around the jaws
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 0.984; // trim the middle rail arches so the rounded cut radius tucks a bit tighter around the jaws
 const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = 0.2; // pull the middle-pocket wood arch farther toward centre so the smaller radius aligns with the tighter inboard cut
 
 function buildChromePlateGeometry({
@@ -744,9 +744,9 @@ const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
 const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.016; // flare the exterior jaw edge slightly so the chrome-facing finish broadens without widening the mouth
 const SIDE_POCKET_JAW_OUTER_EXPANSION = POCKET_JAW_CORNER_OUTER_EXPANSION; // keep the outer fascia consistent with the corner jaws
-const POCKET_JAW_DEPTH_SCALE = 0.9; // extend the jaws farther downward so their length reads longer without lifting the tops
+const POCKET_JAW_DEPTH_SCALE = 1.12; // extend the jaws farther downward so their length reads longer without lifting the tops
 const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.098; // drop the jaws a touch farther so their lips sit closer to the cloth plane
-const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.036; // leave a lean clearance so the added jaw depth clears the cloth without moving the tops
+const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.012; // leave a lean clearance so the added jaw depth clears the cloth without moving the tops
 const POCKET_JAW_EDGE_FLUSH_START = 0.22; // hold the thicker centre section longer before easing toward the chrome trim
 const POCKET_JAW_EDGE_FLUSH_END = 1; // ensure the jaw finish meets the chrome trim flush at the very ends
 const POCKET_JAW_EDGE_TAPER_SCALE = 0.16; // draw the edge down to a finer, pointier profile while keeping the middle volume intact
@@ -769,7 +769,7 @@ const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.592; // nudge the corner jaw spread farther so the fascia kisses the cushion shoulders without gaps
 const SIDE_POCKET_JAW_LATERAL_EXPANSION =
   CORNER_POCKET_JAW_LATERAL_EXPANSION * 0.9; // widen the middle jaw span slightly so the wooden rail cut breathes more like the corners
-const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.92; // relax the side jaw radius a touch so the middle pocket arc reads larger while still moving outward
+const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.98; // relax the side jaw radius a touch so the middle pocket arc reads larger while still moving outward
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.15; // deepen the side jaw a bit more so it carries extra mass at the middle pockets
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * 0.036; // lower the middle jaws slightly less so the fascia trims down from the top
 const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * -0.002; // pull the middle pocket jaws further inward so the lips sit closer to centre


### PR DESCRIPTION
## Summary
- shrink the wooden side-rail pocket relief so the middle pocket cuts appear smaller
- extend pocket jaws deeper toward the cloth with a reduced clearance to meet the pockets visually
- slightly increase the middle pocket jaw radius for a broader diameter

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69348b049bac832980387aca12ea0737)