### PR TITLE
Serve London 1990 example dependencies locally

### DIFF
--- a/examples/tirana-2040.html
+++ b/examples/tirana-2040.html
@@ -164,10 +164,10 @@
   </div>
 
   <script type="module">
-    import * as THREE from 'https://esm.sh/three@0.160.0';
-    import * as CANNON from 'https://esm.sh/cannon-es@0.20.0';
-    import { GLTFLoader } from 'https://esm.sh/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
-    import { DRACOLoader } from 'https://esm.sh/three@0.160.0/examples/jsm/loaders/DRACOLoader.js';
+    import * as THREE from '../node_modules/three/build/three.module.js';
+    import * as CANNON from '../node_modules/cannon-es/dist/cannon-es.js';
+    import { GLTFLoader } from '../node_modules/three/examples/jsm/loaders/GLTFLoader.js';
+    import { DRACOLoader } from '../node_modules/three/examples/jsm/loaders/DRACOLoader.js';
 
     (async function main(){
       const $ = (id)=>document.getElementById(id);


### PR DESCRIPTION
## Summary
- load Three.js and Cannon from local node_modules in the London 1990 example
- avoid external CDN TLS errors when running the demo via the static server

## Testing
- python -m http.server 8000
- playwright smoke check of examples/tirana-2040.html


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693495e893388329a22e1892f30e3134)