### PR TITLE
Rebuild Tirana scene into dual shooting range

### DIFF
--- a/webapp/public/tirana-2040-bootstrap.js
+++ b/webapp/public/tirana-2040-bootstrap.js
@@ -1,10 +1,10 @@
 import { startTirana2040 } from './tirana-2040-main.js';
 
 function displayBootstrapError(err) {
-  console.error('London 1990 failed during bootstrap import', err);
+  console.error('Dual Range failed during bootstrap import', err);
   const statusEl = document.getElementById('status');
   if (statusEl) {
-    statusEl.textContent = 'London 1990 • Failed to load';
+    statusEl.textContent = 'Dual Range • Failed to load';
   }
 }
 

--- a/webapp/public/tirana-2040.html
+++ b/webapp/public/tirana-2040.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, user-scalable=no" />
-<title>London 1990 • Baker Street District</title>
+<title>Dual Range • Two-Player Shooting Gallery</title>
 <link rel="stylesheet" href="./tirana-2040.css" />
 </head>
 <body>
@@ -12,12 +12,16 @@
   <div class="hud">
     <div class="row top">
       <div style="display:flex;gap:6px;align-items:center">
-        <div class="chip" id="status">London 1990 • Baker Street District</div>
-        <div id="br" class="chip">Entrants: 10 • AI</div>
+        <div class="chip" id="status">Dual Range • Initializing…</div>
+        <div id="br" class="chip">Mode: 2 players • Hot-seat</div>
         <div id="weaponName" class="chip" aria-live="polite">Weapon: —</div>
+        <div class="chip" id="p1Score" aria-live="polite">Shooter 1 • 0 pts</div>
+        <div class="chip" id="p2Score" aria-live="polite">Shooter 2 • 0 pts</div>
+        <div class="chip" id="activePlayer">Active: Shooter 1</div>
       </div>
       <div style="display:flex;gap:6px;align-items:center">
-        <button id="mapBtn" class="btn">🗺 Map</button>
+        <button id="swapPlayerBtn" class="btn">🔁 Switch shooter</button>
+        <button id="mapBtn" class="btn">🗺 Range map</button>
         <button id="muteBtn" class="btn">🔊</button>
       </div>
   </div>
@@ -37,7 +41,7 @@
     <div id="mapOverlay">
       <canvas id="mapCanvas"></canvas>
       <button id="mapClose">Exit Map</button>
-      <div id="legend"><strong>West End Navigation</strong>Tap Baker Street, Marble Arch, Oxford Street or Marylebone High Street on the map to set a waypoint and follow the dashed guidance in-game. Tap the same spot again to clear it. Icons: 🏥 Hospital · 🚓 Police · 🧯 Fire · 🛍 Mall · 🛫 Airport · 🚉 Station</div>
+      <div id="legend"><strong>Range Layout</strong>Targets are grouped by distance. Tap anywhere on the miniature map to check lane spacing and where the next wave will pop up. The yellow box marks the firing line; stay behind it when swapping shooters. Icons: 🎯 Target cluster · 🛡 Cover berm · 📦 Weapon rack</div>
     <div id="mapControls">
       <div class="mapRow"><span id="mapZoomLabel">Zoom 1.0x</span></div>
       <div class="mapRow">


### PR DESCRIPTION
## Summary
- Rebrand the London 1990 HUD/bootstrap into a Dual Range two-player shooting gallery with score chips and swap control.
- Replace the city layout with a modular shooting range, firing line, and weapon racks while keeping all weapons available as pickups.
- Spawn human training targets that respawn for scoring, update the mini-map for the range footprint, and keep gameplay loops stable for the hot-seat mode.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69351f5f18b08329b8af0f11d844916b)