### PR TITLE
Show snooker aim line during ball-in-hand placement

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -10271,7 +10271,7 @@ function SnookerGame() {
         const clamped = clampInHandPosition(raw);
         if (!clamped) return false;
         if (!free(clamped.x, clamped.y)) return false;
-        cue.active = false;
+        cue.active = true;
         updateCuePlacement(clamped);
         inHandDrag.lastPos = clamped;
         if (commit) {
@@ -10339,7 +10339,7 @@ function SnookerGame() {
       if (hudRef.current?.inHand) {
         const startPos = clampInHandPosition(new THREE.Vector2(0, baulkZ));
         if (startPos) {
-          cue.active = false;
+          cue.active = true;
           updateCuePlacement(startPos);
         }
       }
@@ -11274,7 +11274,6 @@ function SnookerGame() {
         if (
           allStopped(balls) &&
           currentHud?.turn === 0 &&
-          !(currentHud?.inHand) &&
           cue?.active &&
           !(currentHud?.over)
         ) {


### PR DESCRIPTION
## Summary
- keep the cue ball active during initial ball-in-hand placement so the aim line can render immediately
- allow aiming visuals to show even while the player is placing the cue ball

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69353203a6a48329b08ca6bfa68106f5)