### PR TITLE
Fix board color presets

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -421,6 +421,8 @@ const BEAUTIFUL_GAME_THEME_NAMES = BEAUTIFUL_GAME_THEME_CONFIGS.map((config) => 
 const BEAUTIFUL_GAME_THEME = Object.freeze(
   buildBoardTheme({
     ...(BOARD_COLOR_BASE_OPTIONS.find((option) => option.id === 'stoneMarbleJade') ?? {}),
+    id: 'beautifulGameAuthenticBoard',
+    label: 'Authentic',
     light: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.light,
     dark: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.dark,
     frameLight: '#c7a16c',
@@ -457,8 +459,8 @@ const LUDO_COLORS = Object.freeze({
 const BEAUTIFUL_GAME_BOARD_VARIANTS = Object.freeze(
   BEAUTIFUL_GAME_THEME_CONFIGS.map((config) =>
     buildBoardTheme({
-      id: `${config.id}Board`,
-      label: `ABeautifulGame (${config.name})`,
+      id: config.id,
+      label: config.name,
       light: config.board?.light ?? BEAUTIFUL_GAME_THEME.light,
       dark: config.board?.dark ?? BEAUTIFUL_GAME_THEME.dark,
       frameLight: BEAUTIFUL_GAME_THEME.frameLight,
@@ -1550,6 +1552,8 @@ function createSandTimer(accentColor = '#f4b400') {
 function buildBoardTheme(option) {
   const source = option || {};
   return {
+    id: source.id,
+    label: source.label ?? source.name,
     light: source.light ?? BASE_BOARD_THEME.light,
     dark: source.dark ?? BASE_BOARD_THEME.dark,
     frameLight: source.frameLight ?? BASE_BOARD_THEME.frameLight,
@@ -1561,7 +1565,9 @@ function buildBoardTheme(option) {
     surfaceMetalness: clamp01(source.surfaceMetalness, BASE_BOARD_THEME.surfaceMetalness),
     frameRoughness: clamp01(source.frameRoughness, BASE_BOARD_THEME.frameRoughness),
     frameMetalness: clamp01(source.frameMetalness, BASE_BOARD_THEME.frameMetalness),
-    preserveOriginalMaterials: Boolean(source.preserveOriginalMaterials)
+    preserveOriginalMaterials: Boolean(
+      source.preserveOriginalMaterials ?? source.preserveOriginal
+    )
   };
 }
 


### PR DESCRIPTION
## Summary
- preserve board preset ids and labels when building board themes
- use ABeautifulGame board color names directly for the board selection menu

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69353df364208329a5aecdc9b0b7b4dc)