### PR TITLE
Ensure chess board uses GLTF palette presets

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -441,7 +441,7 @@ const BEAUTIFUL_GAME_THEME = Object.freeze(
 const BOARD_COLOR_OPTIONS = Object.freeze(
   BEAUTIFUL_GAME_THEME_CONFIGS.map((config) =>
     buildBoardTheme({
-      // Board palettes lifted directly from the ABeautifulGame presets (no extra colors)
+      // Only expose the board color pairs that exist inside the ABeautifulGame GLTF theme list
       id: `${config.id}Board`,
       label: config.name,
       light: config.board?.light ?? BEAUTIFUL_GAME_THEME.light,
@@ -5156,7 +5156,9 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
     if (arena.boardModel) {
       applyBeautifulGameBoardTheme(arena.boardModel, boardTheme);
       arena.boardModel.visible = true;
+      // Always prefer the GLTF chessboard over the procedural fallback once it is available
       arena.setProceduralBoardVisible?.(false);
+      arena.usingProceduralBoard = false;
     }
 
     const shouldSwapPieces = !arena.activePieceSetId || nextPieceSetId !== arena.activePieceSetId;


### PR DESCRIPTION
## Summary
- align chess board palette options with the GLTF-based ABeautifulGame presets
- force the experience to prefer the GLTF chessboard instead of the procedural fallback once available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693545f30c78832981b1cb00e31758d6)