### PR TITLE
Fix turn progression after player call

### DIFF
--- a/webapp/public/blackjack.js
+++ b/webapp/public/blackjack.js
@@ -659,8 +659,8 @@ function playerCall() {
   playCallRaise();
   renderPot();
   p.action = { type: 'call', text: `${p.name} calls ${formatAmount(pay)}` };
-  state.awaitingCall = false;
   render();
+  nextTurn();
 }
 
 function canSplit(p) {


### PR DESCRIPTION
## Summary
- ensure player call actions advance to the next turn so the indicator moves correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69355d4b99a48329a69e3006a9ea3742)