### PR TITLE
Reverse Texas Hold'em turn direction

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -1470,7 +1470,7 @@ function payChips(player, amount, state) {
 function getNextActiveIndex(players, startIndex) {
   if (!players.length) return 0;
   for (let offset = 1; offset <= players.length; offset += 1) {
-    const idx = (startIndex + offset) % players.length;
+    const idx = (startIndex - offset + players.length) % players.length;
     const p = players[idx];
     if (!p) continue;
     if (!p.folded && p.chips > 0 && !p.allIn) {


### PR DESCRIPTION
## Summary
- reverse the Texas Hold'em turn rotation so actions and indicators advance in the opposite direction

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693566266ccc83298b859e0eca43f63b)