### PR TITLE
Refine Pool Royale pockets and UK AI training

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -57,11 +57,22 @@
  */
 const shotMemory = new Map()
 
+function normaliseColourKey (input) {
+  const value = typeof input === 'string' ? input : input?.colour
+  if (!value) return 'any'
+  const lower = value.toLowerCase()
+  if (lower.startsWith('red')) return 'red'
+  if (lower.startsWith('blue') || lower.startsWith('yellow')) return 'blue'
+  if (lower.startsWith('black')) return 'black'
+  return lower || 'any'
+}
+
 export function recordShotOutcome (plan, success) {
   if (!plan || typeof plan.angle !== 'number' || typeof plan.distToPocket !== 'number') return
   const angleBucket = Math.round((plan.angle * 180 / Math.PI) / 10) // 10° buckets
   const distBucket = Math.round(plan.distToPocket / 50) // 50px buckets
-  const key = `${angleBucket}:${distBucket}`
+  const colourKey = normaliseColourKey(plan?.targetBall)
+  const key = `${colourKey}:${angleBucket}:${distBucket}`
   const stats = shotMemory.get(key) || { success: 0, attempts: 0 }
   stats.attempts += 1
   if (success) stats.success += 1
@@ -456,7 +467,8 @@ function estimatePotProbability (shot, state) {
   // adjust by learnt success rates
   const angleBucket = Math.round(angleDeg / 7.5)
   const distBucket = Math.round((shot.distTP || 0) / 40)
-  const stats = shotMemory.get(`${angleBucket}:${distBucket}`)
+  const colourKey = normaliseColourKey(shot?.targetBall)
+  const stats = shotMemory.get(`${colourKey}:${angleBucket}:${distBucket}`)
   if (stats && stats.attempts > 0) {
     const rate = stats.success / Math.max(1, stats.attempts)
     P = P * 0.6 + rate * 0.4
@@ -674,6 +686,10 @@ function chooseBestAction (state, colour) {
   if (candidates.length === 0) {
     candidates = kicks
   }
+
+  if (directPots.length === 0) {
+    candidates = candidates.concat(generateSafeties(state, colour))
+  }
   if (candidates.length === 0) {
     // No clear potting opportunity – fall back to defensive play.
     candidates = generateSafeties(state, colour)
@@ -704,25 +720,41 @@ function chooseBestAction (state, colour) {
   }
   const best = evaluateCandidates(state, colour, candidates)
   if (!best) return null
-  const c = best.c
-  const cueBall = state.balls.find(b => b.colour === 'cue')
-  const aim = c.bankAnchor ? { x: c.bankAnchor.x, y: c.bankAnchor.y } : (c.targetBall ? { x: c.targetBall.x, y: c.targetBall.y } : { x: cueBall.x, y: cueBall.y })
-  const posTarget = c.actionType === 'safety'
-    ? { x: cueBall.x, y: cueBall.y }
-    : simulateCueRollout(state, c)
-  return {
-    actionType: c.actionType,
-    targetBall: c.targetBall ? c.targetBall.colour : null,
-    pocket: c.pocket ? c.pocket.name : null,
-    aimPoint: aim,
-    cueParams: c.cueParams,
-    positionTarget: { x: posTarget.x, y: posTarget.y, radius: 40 },
-    EV: best.EV,
-    notes: c.actionType === 'safety' ? 'safety play' : `pot ${c.targetBall?.colour ?? ''}`,
-    angle: typeof c.angle === 'number' ? c.angle : undefined,
-    distToPocket: typeof c.distTP === 'number' ? c.distTP : undefined,
-    targetId: c.targetBall ? c.targetBall.id : null
+
+  const translatePlan = (candidate, EV) => {
+    const cueBall = state.balls.find(b => b.colour === 'cue')
+    const aim = candidate.bankAnchor
+      ? { x: candidate.bankAnchor.x, y: candidate.bankAnchor.y }
+      : (candidate.targetBall
+          ? { x: candidate.targetBall.x, y: candidate.targetBall.y }
+          : { x: cueBall.x, y: cueBall.y })
+    const posTarget = candidate.actionType === 'safety'
+      ? { x: cueBall.x, y: cueBall.y }
+      : simulateCueRollout(state, candidate)
+    return {
+      actionType: candidate.actionType,
+      targetBall: candidate.targetBall ? candidate.targetBall.colour : null,
+      pocket: candidate.pocket ? candidate.pocket.name : null,
+      aimPoint: aim,
+      cueParams: candidate.cueParams,
+      positionTarget: { x: posTarget.x, y: posTarget.y, radius: 40 },
+      EV,
+      notes: candidate.actionType === 'safety' ? 'safety play' : `pot ${candidate.targetBall?.colour ?? ''}`,
+      angle: typeof candidate.angle === 'number' ? candidate.angle : undefined,
+      distToPocket: typeof candidate.distTP === 'number' ? candidate.distTP : undefined,
+      targetId: candidate.targetBall ? candidate.targetBall.id : null
+    }
   }
+
+  let chosen = best
+  if (directPots.length === 0 && best.c.actionType !== 'safety') {
+    const safetyOnly = evaluateCandidates(state, colour, generateSafeties(state, colour))
+    if (safetyOnly) {
+      chosen = safetyOnly
+    }
+  }
+
+  return translatePlan(chosen.c, chosen.EV)
 }
 
 // Public entry

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -843,7 +843,7 @@ const POCKET_SIDE_MOUTH_SCALE =
   (CORNER_MOUTH_REF / SIDE_MOUTH_REF) *
   POCKET_CORNER_MOUTH_SCALE *
   SIDE_POCKET_MOUTH_REDUCTION_SCALE; // carry the new narrower middle pocket mouth while preserving the corner-to-side ratio
-const SIDE_POCKET_CUT_SCALE = 0.982; // tighten the middle cloth/rail cutouts slightly while keeping the pocket mouth ratio stable
+const SIDE_POCKET_CUT_SCALE = 0.972; // make the middle cloth/rail cutouts a touch smaller without altering fascia or jaw geometry
 const POCKET_CORNER_MOUTH =
   CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
 const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
@@ -10139,6 +10139,29 @@ function PoolRoyaleGame({
       const backInterior = roomDepth / 2 - wallInset;
       const leftInterior = -roomWidth / 2 + wallInset;
       const rightInterior = roomWidth / 2 - wallInset;
+
+      const doorMaskHeight = wallHeight * 0.72;
+      const doorMaskDepth = Math.max(wallThickness * 0.65, 0.1);
+      const interiorMaskMat = new THREE.MeshStandardMaterial({
+        color: wallMat.color.clone(),
+        roughness: wallMat.roughness,
+        metalness: wallMat.metalness,
+        flatShading: true,
+        side: THREE.FrontSide
+      });
+      const addShortRailMask = (z) => {
+        const mask = new THREE.Mesh(
+          new THREE.BoxGeometry(roomWidth - wallThickness * 1.5, doorMaskHeight, doorMaskDepth),
+          interiorMaskMat
+        );
+        mask.castShadow = false;
+        mask.receiveShadow = true;
+        mask.position.set(0, floorY + doorMaskHeight / 2, z + Math.sign(z) * doorMaskDepth * 0.45);
+        world.add(mask);
+      };
+
+      addShortRailMask(frontInterior);
+      addShortRailMask(backInterior);
 
       cueRackGroupsRef.current = [];
       cueOptionGroupsRef.current = [];


### PR DESCRIPTION
## Summary
- hide the short-rail doors from the arena by adding interior wall masks
- trim the Pool Royale middle-pocket cutouts slightly smaller without changing fascia geometry
- train the UK 8-ball AI by colour and bias it toward safeties when direct pots are blocked

## Testing
- node --test test/poolUk8Ball.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935751a70308329b33eb8e9700a917a)