### PR TITLE
Align snooker table with Pool Royale specs

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -232,7 +232,7 @@ function createDefaultPocketJawMaterial() {
   });
 }
 
-const POCKET_VISUAL_EXPANSION = 1.018;
+const POCKET_VISUAL_EXPANSION = 1.028;
 const CHROME_CORNER_POCKET_RADIUS_SCALE = 1.01;
 const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.08; // pull corner reliefs further into the rail
 const CHROME_CORNER_EXPANSION_SCALE = 1.002;
@@ -252,48 +252,49 @@ const CHROME_CORNER_SHORT_RAIL_SHIFT_SCALE = 0;
 const CHROME_CORNER_SHORT_RAIL_CENTER_PULL_SCALE = 0;
 const CHROME_CORNER_EDGE_TRIM_SCALE = 0;
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0;
-const CHROME_SIDE_POCKET_RADIUS_SCALE = 1.026; // mirror the Pool Royale middle pocket arch radius so chrome hugs the same curve
+const CHROME_SIDE_POCKET_RADIUS_SCALE =
+  CORNER_POCKET_INWARD_SCALE * CHROME_CORNER_POCKET_RADIUS_SCALE * 1.016; // mirror the Pool Royale middle pocket arch radius so chrome hugs the same curve
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0;
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85;
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1;
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1;
 const CHROME_SIDE_FIELD_PULL_SCALE = 0;
-const CHROME_PLATE_THICKNESS_SCALE = 0.034;
-const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.24;
+const CHROME_PLATE_THICKNESS_SCALE = 0.0306;
+const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.18;
 const CHROME_PLATE_RENDER_ORDER = 3.5;
-const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.58;
-const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.52;
+const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 2.2;
+const CHROME_SIDE_PLATE_HEIGHT_SCALE = 2.64;
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0;
-const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.56;
+const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 2.14;
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_THREE_SIDE_EXPANSION = 0.34;
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.294; // match Pool Royale by pulling the chrome arches further toward centre
-const WOOD_CORNER_CUT_SCALE = 0.976; // pull wood reliefs inward so the rounded cuts tuck toward centre
-const WOOD_SIDE_CUT_SCALE = 0.986; // slightly shrink side rail apertures so the rounded cuts sit tighter to centre
+const WOOD_CORNER_CUT_SCALE = 0.984; // pull wood reliefs inward so the rounded cuts tuck toward centre
+const WOOD_SIDE_CUT_SCALE = 1.032; // slightly shrink side rail apertures so the rounded cuts sit tighter to centre
 const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = 0.2; // align middle pocket wood cuts with Pool Royale's centred arches
-const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.004;
+const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.008;
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = POCKET_JAW_CORNER_OUTER_LIMIT_SCALE;
 const POCKET_JAW_CORNER_INNER_SCALE = 1.472;
 const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE;
-const POCKET_JAW_CORNER_OUTER_SCALE = 1.76;
+const POCKET_JAW_CORNER_OUTER_SCALE = 1.92;
 const POCKET_JAW_SIDE_OUTER_SCALE = POCKET_JAW_CORNER_OUTER_SCALE;
-const POCKET_JAW_DEPTH_SCALE = 0.68;
+const POCKET_JAW_DEPTH_SCALE = 1.02;
 const POCKET_JAW_EDGE_FLUSH_START = 0.22;
 const POCKET_JAW_EDGE_FLUSH_END = 1;
 const POCKET_JAW_EDGE_TAPER_SCALE = 0.16;
 const POCKET_JAW_CENTER_THICKNESS_MIN = 0.42;
-const POCKET_JAW_CENTER_THICKNESS_MAX = 0.66;
+const POCKET_JAW_CENTER_THICKNESS_MAX = 0.74;
 const POCKET_JAW_OUTER_EXPONENT_MIN = 0.58;
 const POCKET_JAW_OUTER_EXPONENT_MAX = 1.2;
 const POCKET_JAW_INNER_EXPONENT_MIN = 0.78;
 const POCKET_JAW_INNER_EXPONENT_MAX = 1.34;
 const POCKET_JAW_SEGMENT_MIN = 144;
-const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.66;
-const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.986;
-const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.08;
+const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.592;
+const SIDE_POCKET_JAW_LATERAL_EXPANSION = CORNER_POCKET_JAW_LATERAL_EXPANSION * 0.9;
+const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.92;
+const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.15;
 const SIDE_POCKET_JAW_SIDE_TRIM_SCALE = 0.82;
 const SIDE_POCKET_JAW_MIDDLE_TRIM_SCALE = 0.86;
-const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.592;
 const CORNER_JAW_ARC_DEG = 120;
 const SIDE_JAW_ARC_DEG = 120;
 
@@ -501,10 +502,10 @@ function addPocketCuts(parent, clothPlane) {
 // Config
 // --------------------------------------------------
 // separate scales for table and balls
-// Match the Pool Royale arena footprint so pockets, rails, and ball sizing align 1:1
-const TABLE_SIZE_SHRINK = 0.78;
+// Rebuild the snooker table on the Pool Royale spec and only widen the footprint to the official snooker ratio
+const TABLE_SIZE_SHRINK = 0.92;
 const TABLE_REDUCTION = 0.84 * TABLE_SIZE_SHRINK;
-const OFFICIAL_TABLE_SCALE = 3569 / 2540; // scale up to the official snooker dimensions while keeping ball/pocket sizing intact
+const OFFICIAL_TABLE_SCALE = 3569 / 2540; // widen the playfield to the official snooker dimensions while keeping the Pool Royale height stack
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
 const TABLE_DISPLAY_SCALE = 0.88;
@@ -513,10 +514,11 @@ const TABLE_GROWTH_MULTIPLIER = 1.5;
 const TABLE_GROWTH_DURATION_MS = 1200;
 const CUE_STYLE_STORAGE_KEY = 'tonplayCueStyleIndex';
 const TABLE_BASE_SCALE = 1.17;
-const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * OFFICIAL_TABLE_SCALE;
+const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION; // keep the height stack identical to Pool Royale
+const TABLE_FOOTPRINT_SCALE = TABLE_SCALE * OFFICIAL_TABLE_SCALE;
 const TABLE = {
-  W: 66 * TABLE_SCALE,
-  H: 132 * TABLE_SCALE,
+  W: 66 * TABLE_FOOTPRINT_SCALE,
+  H: 132 * TABLE_FOOTPRINT_SCALE,
   THICK: 1.8 * TABLE_SCALE,
   WALL: 2.6 * TABLE_SCALE
 };
@@ -533,7 +535,9 @@ const D_RADIUS_REF = 292;
 const BLACK_FROM_TOP_REF = 558.8;
 const CORNER_MOUTH_REF = 114.3;
 const SIDE_MOUTH_REF = 127;
-const CORNER_POCKET_SCALE_BOOST = 1.01;
+const CORNER_POCKET_INWARD_SCALE = 1.015;
+const CORNER_POCKET_SCALE_BOOST = 0.994;
+const CORNER_POCKET_EXTRA_SCALE = 1.02;
 const SIDE_POCKET_MOUTH_REDUCTION_SCALE = 1.002;
 const SIDE_RAIL_INNER_REDUCTION = 0.72;
 const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
@@ -573,7 +577,7 @@ const CHALK_RING_OPACITY = 0.18;
 const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
-const POCKET_CORNER_MOUTH_SCALE = CORNER_POCKET_SCALE_BOOST;
+const POCKET_CORNER_MOUTH_SCALE = CORNER_POCKET_SCALE_BOOST * CORNER_POCKET_EXTRA_SCALE;
 const POCKET_SIDE_MOUTH_SCALE =
   (CORNER_MOUTH_REF / SIDE_MOUTH_REF) *
   POCKET_CORNER_MOUTH_SCALE *
@@ -645,12 +649,13 @@ const MIN_FRAME_SCALE = 1e-6; // prevent zero-length frames from collapsing phys
 const MAX_PHYSICS_SUBSTEPS = 5; // keep catch-up updates smooth without exploding work per frame
 const CAPTURE_R = POCKET_R; // pocket capture radius
 const CLOTH_THICKNESS = TABLE.THICK * 0.12; // render a thinner cloth so the playing surface feels lighter
-const CLOTH_UNDERLAY_THICKNESS = TABLE.THICK * 0.24; // hidden plywood deck to catch shadows before they reach the carpet
-const CLOTH_UNDERLAY_GAP = TABLE.THICK * 0.02; // leave a thin air gap between the cloth and plywood
+const CLOTH_UNDERLAY_THICKNESS = 0; // match Pool Royale's cloth stack height
+const CLOTH_UNDERLAY_GAP = 0; // keep the wrap tight against the frame
 const CLOTH_UNDERLAY_EDGE_INSET = 0; // match the playable field footprint while remaining hidden via colorWrite=false
 const CLOTH_UNDERLAY_HOLE_SCALE = 1; // align underlay apertures with Pool Royale pocket layout
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
-const CUSHION_EXTRA_LIFT = 0; // keep cushion bases resting directly on the cloth plane
+const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.094; // sink cushions to the Pool Royale height
+const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.128; // trim the cushion tops to match Pool Royale profiling
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
 const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.18; // soften the exterior rail corners with a shallow curve
@@ -668,30 +673,30 @@ const POCKET_DROP_TOP_SCALE = 0.82;
 const POCKET_DROP_BOTTOM_SCALE = 0.48;
 const POCKET_CLOTH_DEPTH = POCKET_RECESS_DEPTH * 1.05;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
-  (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 2.85 +
-    POCKET_VIS_R * 4.7 +
-    BALL_R * 4.1) * 0.9;
+  Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.44 +
+  POCKET_VIS_R * 2.9 +
+  BALL_R * 2.02;
 const POCKET_CAM_BASE_OUTWARD_OFFSET =
-  (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 3.4 +
-    POCKET_VIS_R * 5.2 +
-    BALL_R * 3.7) * 0.88;
+  Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.62 +
+  POCKET_VIS_R * 2.82 +
+  BALL_R * 1.92;
 const POCKET_CAM = Object.freeze({
-  triggerDist: CAPTURE_R * 9.5,
-  dotThreshold: 0.3,
+  triggerDist: CAPTURE_R * 10.5,
+  dotThreshold: 0.22,
   minOutside: POCKET_CAM_BASE_MIN_OUTSIDE,
-  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 1.12,
+  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 1.06,
   maxOutside: BALL_R * 30,
-  heightOffset: BALL_R * 11.2,
-  heightOffsetShortMultiplier: 1.02,
+  heightOffset: BALL_R * 9.6,
+  heightOffsetShortMultiplier: 1.08,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET,
-  outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1.12,
-  heightDrop: BALL_R * 1.4,
-  distanceScale: 1.18,
+  outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1.08,
+  heightDrop: BALL_R * 1.3,
+  distanceScale: 0.84,
   heightScale: 1.28,
-  focusBlend: 0.32,
-  lateralFocusShift: POCKET_VIS_R * 0.5,
-  railFocusLong: BALL_R * 9,
-  railFocusShort: BALL_R * 6
+  focusBlend: 0.38,
+  lateralFocusShift: POCKET_VIS_R * 0.4,
+  railFocusLong: BALL_R * 8,
+  railFocusShort: BALL_R * 5.4
 });
 const POCKET_CHAOS_MOVING_THRESHOLD = 3;
 const POCKET_GUARANTEED_ALIGNMENT = 0.82;
@@ -2940,10 +2945,10 @@ const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_MARGIN_WIDTH = BALL_R * 10;
 const BROADCAST_MARGIN_LENGTH = BALL_R * 10;
 const CAMERA_ZOOM_PROFILES = Object.freeze({
-  default: Object.freeze({ cue: 0.9, broadcast: 0.94, margin: 0.97 }),
-  nearLandscape: Object.freeze({ cue: 0.88, broadcast: 0.93, margin: 0.97 }),
-  portrait: Object.freeze({ cue: 0.86, broadcast: 0.92, margin: 0.96 }),
-  ultraPortrait: Object.freeze({ cue: 0.84, broadcast: 0.9, margin: 0.95 })
+  default: Object.freeze({ cue: 0.9, broadcast: 0.94, margin: 0.985 }),
+  nearLandscape: Object.freeze({ cue: 0.88, broadcast: 0.93, margin: 0.985 }),
+  portrait: Object.freeze({ cue: 0.86, broadcast: 0.91, margin: 0.975 }),
+  ultraPortrait: Object.freeze({ cue: 0.84, broadcast: 0.9, margin: 0.97 })
 });
 const resolveCameraZoomProfile = (aspect) => {
   if (!Number.isFinite(aspect)) {
@@ -2992,13 +2997,13 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.006;
-const CUE_VIEW_RADIUS_RATIO = 0.04;
-const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.16;
+const CUE_VIEW_RADIUS_RATIO = 0.045;
+const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.19;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
-  STANDING_VIEW_PHI + 0.1
+  STANDING_VIEW_PHI + 0.18
 );
-const CUE_VIEW_PHI_LIFT = 0.11;
+const CUE_VIEW_PHI_LIFT = 0.1;
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,
@@ -3010,10 +3015,10 @@ const CAMERA_MIN_HORIZONTAL =
 const CAMERA_DOWNWARD_PULL = 1.9;
 const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.29;
 const IN_HAND_CAMERA_PULLBACK = 1.38;
-const TOP_VIEW_MARGIN = 0.54; // scaled to the snooker footprint so the overhead view hugs the rails
-const TOP_VIEW_RADIUS_SCALE = 0.44;
-const TOP_VIEW_MIN_RADIUS_SCALE = 0.92;
-const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI + 0.04, CAMERA.minPhi * 0.64);
+const TOP_VIEW_MARGIN = 0.32; // match Pool Royale overhead framing
+const TOP_VIEW_RADIUS_SCALE = 0.28;
+const TOP_VIEW_MIN_RADIUS_SCALE = 0.88;
+const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI + 0.06, CAMERA.minPhi * 0.66);
 const CAMERA_TILT_ZOOM = BALL_R * 1.5;
 const CUE_VIEW_AIM_SLOW_FACTOR = 0.35; // slow pointer rotation while blended toward cue view for finer aiming
 const POCKET_VIEW_SMOOTH_TIME = 0.24; // seconds to ease pocket camera transitions


### PR DESCRIPTION
## Summary
- widen the snooker table footprint to the official ratio while keeping the Pool Royale height stack
- sync chrome, pocket, wood, and cushion tuning with the Pool Royale geometry
- align camera framing and pocket cam ranges with the Pool Royale aiming and limit presets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69358279d7e88329afefe432ad815af1)