### PR TITLE
Add detailed material styling for ABeautifulGame pieces

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -2138,6 +2138,196 @@ function harmonizeBeautifulGamePieces(piecePrototypes, pieceStyle = BEAUTIFUL_GA
 function applyBeautifulGameStyleToMeshes(meshes, pieceStyle = BEAUTIFUL_GAME_PIECE_STYLE) {
   if (!meshes) return;
   const list = Array.isArray(meshes) ? meshes : [meshes];
+
+  const detailColors = Object.freeze({
+    ivory: 0xeee8d5,
+    ebony: 0x0a0a0a,
+    gold: 0xd4af37,
+    ruby: 0x9b111e
+  });
+
+  const setMatProps = (mesh, colorHex, metalness, roughness, emissiveHex) => {
+    if (!mesh) return;
+    const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+    mats.forEach((m) => {
+      if (!m) return;
+      if (colorHex !== undefined && m.color) m.color = new THREE.Color(colorHex);
+      if (emissiveHex !== undefined && m.emissive) m.emissive.set(emissiveHex);
+      if (metalness !== undefined && typeof m.metalness === 'number') m.metalness = metalness;
+      if (roughness !== undefined && typeof m.roughness === 'number') m.roughness = roughness;
+    });
+  };
+
+  const eachMesh = (root, fn) => {
+    root?.traverse?.((node) => {
+      if (node?.isMesh) fn(node);
+    });
+  };
+
+  const bounds = (obj) => {
+    const b = new THREE.Box3().setFromObject(obj);
+    const s = new THREE.Vector3();
+    b.getSize(s);
+    return { b, s, h: s.y, top: b.max.y, bottom: b.min.y };
+  };
+
+  const meshesNearTop = (root, topFrac = 0.2) => {
+    const pb = bounds(root);
+    const cutoff = pb.top - pb.h * topFrac;
+    const out = [];
+    eachMesh(root, (m) => {
+      const mb = new THREE.Box3().setFromObject(m);
+      if (mb.max.y >= cutoff) out.push(m);
+    });
+    return out;
+  };
+
+  const isSphereLike = (mesh, tolerance = 0.3) => {
+    const size = new THREE.Vector3();
+    new THREE.Box3().setFromObject(mesh).getSize(size);
+    const avg = (size.x + size.y + size.z) / 3;
+    if (avg === 0) return false;
+    const dx = Math.abs(size.x - avg) / avg;
+    const dy = Math.abs(size.y - avg) / avg;
+    const dz = Math.abs(size.z - avg) / avg;
+    return dx < tolerance && dy < tolerance && dz < tolerance;
+  };
+
+  const nameIncludes = (node, regex) => regex.test((node?.name || '').toLowerCase());
+
+  const styleRookOrKnight = (piece) => {
+    eachMesh(piece, (m) => setMatProps(m, detailColors.ivory, 0.2, 0.5));
+  };
+
+  const styleBishop = (piece) => {
+    const near = meshesNearTop(piece, 0.28);
+    const spheres = near.filter((m) => isSphereLike(m, 0.35));
+    const tinySphere = spheres
+      .sort((a, b) => {
+        const sa = new THREE.Vector3();
+        const sb = new THREE.Vector3();
+        new THREE.Box3().setFromObject(a).getSize(sa);
+        new THREE.Box3().setFromObject(b).getSize(sb);
+        return sa.length() - sb.length();
+      })[0];
+    if (tinySphere) setMatProps(tinySphere, detailColors.gold, 1.0, 0.25);
+
+    const pb = bounds(piece);
+    const bulb = near
+      .filter((m) => m !== tinySphere)
+      .filter((m) => {
+        const mb = new THREE.Box3().setFromObject(m);
+        const size = new THREE.Vector3();
+        mb.getSize(size);
+        const centerY = (mb.min.y + mb.max.y) / 2;
+        return (
+          isSphereLike(m, 0.5) &&
+          size.y > pb.h * 0.08 &&
+          centerY > pb.top - pb.h * 0.32
+        );
+      })
+      .sort((a, b) => {
+        const sa = new THREE.Vector3();
+        const sb = new THREE.Vector3();
+        new THREE.Box3().setFromObject(a).getSize(sa);
+        new THREE.Box3().setFromObject(b).getSize(sb);
+        return sb.length() - sa.length();
+      })[0];
+    if (bulb) setMatProps(bulb, detailColors.ebony, 0.2, 0.5);
+  };
+
+  const styleQueen = (piece) => {
+    const near = meshesNearTop(piece, 0.3);
+    const pb = bounds(piece);
+    const topSpheres = near.filter((m) => isSphereLike(m, 0.35));
+    const orb = topSpheres
+      .sort((a, b) => {
+        const ab = new THREE.Box3().setFromObject(a);
+        const bb = new THREE.Box3().setFromObject(b);
+        return bb.max.y - ab.max.y;
+      })[0];
+    if (orb) setMatProps(orb, detailColors.ruby, 0.05, 0.25);
+
+    let crown = undefined;
+    for (const m of near) {
+      if (nameIncludes(m, /(crown|tiara|corona|spike|prong)/)) {
+        crown = m;
+        break;
+      }
+    }
+    if (!crown) {
+      const cand = near
+        .filter((m) => m !== orb)
+        .filter((m) => !isSphereLike(m, 0.3))
+        .sort((a, b) => {
+          const sa = new THREE.Vector3();
+          const sb = new THREE.Vector3();
+          new THREE.Box3().setFromObject(a).getSize(sa);
+          new THREE.Box3().setFromObject(b).getSize(sb);
+          return sb.length() - sa.length();
+        })[0];
+      crown = cand;
+    }
+    if (crown) setMatProps(crown, detailColors.gold, 1.0, 0.25);
+
+    const cap = near
+      .filter((m) => m !== orb && m !== crown)
+      .filter((m) => {
+        const mb = new THREE.Box3().setFromObject(m);
+        const centerY = (mb.min.y + mb.max.y) / 2;
+        return centerY > pb.top - pb.h * 0.35;
+      })
+      .sort((a, b) => {
+        const ab = new THREE.Box3().setFromObject(a);
+        const bb = new THREE.Box3().setFromObject(b);
+        return bb.max.y - ab.max.y;
+      })[0];
+    if (cap) setMatProps(cap, detailColors.ebony, 0.2, 0.5);
+  };
+
+  const stylePawn = (piece) => {
+    const pb = bounds(piece);
+    const near = meshesNearTop(piece, 0.5);
+    const ring = near
+      .map((m) => ({ m, mb: new THREE.Box3().setFromObject(m) }))
+      .filter(({ mb }) => {
+        const s = new THREE.Vector3();
+        mb.getSize(s);
+        const width = (s.x + s.z) / 2;
+        const ratio = width > 0 ? s.y / width : 1;
+        const centerY = (mb.min.y + mb.max.y) / 2;
+        return ratio < 0.25 && centerY > pb.top - pb.h * 0.45 && centerY < pb.top - pb.h * 0.12;
+      })
+      .sort((a, b) => b.mb.max.y - a.mb.max.y)[0]?.m;
+    if (ring) setMatProps(ring, detailColors.gold, 1.0, 0.28);
+  };
+
+  const applyDetailPass = (mesh) => {
+    if (!mesh) return;
+    const styleId = (mesh?.userData?.__pieceStyleId || '').toString();
+    if (!styleId.startsWith('beautifulGame')) return;
+    const type = (mesh?.userData?.__pieceType || mesh?.userData?.t || mesh?.userData?.type || '')
+      .toString()
+      .toLowerCase();
+    switch (type) {
+      case 'r':
+      case 'n':
+        styleRookOrKnight(mesh);
+        break;
+      case 'b':
+        styleBishop(mesh);
+        break;
+      case 'q':
+        styleQueen(mesh);
+        break;
+      case 'p':
+        stylePawn(mesh);
+        break;
+      default:
+        break;
+    }
+  };
+
   if (pieceStyle?.preserveOriginalMaterials) {
     list.forEach((mesh) => {
       mesh?.traverse?.((child) => {
@@ -2146,6 +2336,7 @@ function applyBeautifulGameStyleToMeshes(meshes, pieceStyle = BEAUTIFUL_GAME_PIE
           child.receiveShadow = true;
         }
       });
+      applyDetailPass(mesh);
     });
     return;
   }
@@ -2241,6 +2432,8 @@ function applyBeautifulGameStyleToMeshes(meshes, pieceStyle = BEAUTIFUL_GAME_PIE
     recolorMesh(mesh, colorKey);
     accentize(mesh, colorKey);
   });
+
+  list.forEach(applyDetailPass);
 }
 
 function makeHeadMaterial(preset) {


### PR DESCRIPTION
## Summary
- add detailed in-scene material pass for ABeautifulGame pieces to enforce ivory/gold/ebony/ruby accents per piece type
- ensure preserve-original mode still applies the targeted styling while keeping materials intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935aa851d8c8329b6c2d37e3a5490b3)