### PR TITLE
Improve Pool Royale target direction accuracy

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5197,12 +5197,14 @@ function calcTarget(cue, dir, balls) {
   let targetDir = null;
   let cueDir = null;
   if (targetBall) {
-    const contactPoint = impact.clone().add(dirNorm.clone().multiplyScalar(BALL_R));
-    targetDir = targetBall.pos.clone().sub(contactPoint).normalize();
-    const projected = dirNorm.dot(targetDir);
-    cueDir = dirNorm.clone().sub(targetDir.clone().multiplyScalar(projected));
-    if (cueDir.lengthSq() > 1e-8) cueDir.normalize();
-    else cueDir = null;
+    const collisionNormal = targetBall.pos.clone().sub(impact);
+    if (collisionNormal.lengthSq() > 1e-8) {
+      targetDir = collisionNormal.clone().normalize();
+      const projected = dirNorm.dot(targetDir);
+      cueDir = dirNorm.clone().sub(targetDir.clone().multiplyScalar(projected));
+      if (cueDir.lengthSq() > 1e-8) cueDir.normalize();
+      else cueDir = null;
+    }
   } else if (railNormal) {
     const n = railNormal.clone().normalize();
     cueDir = dirNorm
@@ -15521,8 +15523,15 @@ function PoolRoyaleGame({
               tDir.copy(dir);
             }
             const distanceScale = travelScale;
-            const tEnd = end.clone().add(tDir.clone().multiplyScalar(distanceScale));
-            targetGeom.setFromPoints([end, tEnd]);
+            const targetStart = new THREE.Vector3(
+              targetBall.pos.x,
+              BALL_CENTER_Y,
+              targetBall.pos.y
+            );
+            const tEnd = targetStart
+              .clone()
+              .add(tDir.clone().multiplyScalar(distanceScale));
+            targetGeom.setFromPoints([targetStart, tEnd]);
             target.material.color.setHex(0xffd166);
             target.material.opacity = 0.65 + 0.3 * powerStrength;
             target.visible = true;


### PR DESCRIPTION
## Summary
- compute target-ball collision direction using the center-to-center normal at impact
- start the target direction guide from the target ball position so the preview aligns with its actual path

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69366508b0288329bf88b3b9eec59ea3)