### PR TITLE
Align snooker snooker table with Pool Royale spec

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -232,7 +232,10 @@ function createDefaultPocketJawMaterial() {
   });
 }
 
-const POCKET_VISUAL_EXPANSION = 1.018;
+const POCKET_VISUAL_EXPANSION = 1.028;
+const CORNER_POCKET_INWARD_SCALE = 1.015;
+const CORNER_POCKET_SCALE_BOOST = 0.994;
+const CORNER_POCKET_EXTRA_SCALE = 1.02;
 const CHROME_CORNER_POCKET_RADIUS_SCALE = 1.01;
 const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.08; // pull corner reliefs further into the rail
 const CHROME_CORNER_EXPANSION_SCALE = 1.002;
@@ -252,47 +255,66 @@ const CHROME_CORNER_SHORT_RAIL_SHIFT_SCALE = 0;
 const CHROME_CORNER_SHORT_RAIL_CENTER_PULL_SCALE = 0;
 const CHROME_CORNER_EDGE_TRIM_SCALE = 0;
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0;
-const CHROME_SIDE_POCKET_RADIUS_SCALE = 1.026; // mirror the Pool Royale middle pocket arch radius so chrome hugs the same curve
+const CHROME_SIDE_POCKET_RADIUS_SCALE =
+  CORNER_POCKET_INWARD_SCALE *
+  CHROME_CORNER_POCKET_RADIUS_SCALE *
+  1.016; // mirror Pool Royale middle pocket arch radius and offset
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0;
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85;
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1;
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1;
 const CHROME_SIDE_FIELD_PULL_SCALE = 0;
-const CHROME_PLATE_THICKNESS_SCALE = 0.034;
-const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.24;
+const CHROME_PLATE_THICKNESS_SCALE = 0.0306;
+const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.18;
 const CHROME_PLATE_RENDER_ORDER = 3.5;
-const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.58;
-const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.52;
+const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 2.2;
+const CHROME_SIDE_PLATE_HEIGHT_SCALE = 2.64;
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0;
-const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 0.56;
+const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 2.14;
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_THREE_SIDE_EXPANSION = 0.34;
+const CHROME_SIDE_PLATE_THREE_SIDE_EXPANSION = 1.14;
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.294; // match Pool Royale by pulling the chrome arches further toward centre
 const WOOD_CORNER_CUT_SCALE = 0.976; // pull wood reliefs inward so the rounded cuts tuck toward centre
 const WOOD_SIDE_CUT_SCALE = 0.986; // slightly shrink side rail apertures so the rounded cuts sit tighter to centre
 const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = 0.2; // align middle pocket wood cuts with Pool Royale's centred arches
-const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.004;
+const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.008;
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = POCKET_JAW_CORNER_OUTER_LIMIT_SCALE;
 const POCKET_JAW_CORNER_INNER_SCALE = 1.472;
 const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE;
-const POCKET_JAW_CORNER_OUTER_SCALE = 1.76;
+const POCKET_JAW_CORNER_OUTER_SCALE = 1.92;
 const POCKET_JAW_SIDE_OUTER_SCALE = POCKET_JAW_CORNER_OUTER_SCALE;
-const POCKET_JAW_DEPTH_SCALE = 0.68;
+const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.016;
+const SIDE_POCKET_JAW_OUTER_EXPANSION = POCKET_JAW_CORNER_OUTER_EXPANSION;
+const POCKET_JAW_DEPTH_SCALE = 1.02;
+const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.114;
+const POCKET_JAW_BOTTOM_CLEARANCE = 0;
+const POCKET_JAW_FLOOR_CONTACT_LIFT = TABLE.THICK * 0.12;
 const POCKET_JAW_EDGE_FLUSH_START = 0.22;
 const POCKET_JAW_EDGE_FLUSH_END = 1;
 const POCKET_JAW_EDGE_TAPER_SCALE = 0.16;
+const POCKET_JAW_CENTER_TAPER_HOLD = 0.46;
+const POCKET_JAW_EDGE_TAPER_PROFILE_POWER = 1.6;
 const POCKET_JAW_CENTER_THICKNESS_MIN = 0.42;
-const POCKET_JAW_CENTER_THICKNESS_MAX = 0.66;
+const POCKET_JAW_CENTER_THICKNESS_MAX = 0.74;
 const POCKET_JAW_OUTER_EXPONENT_MIN = 0.58;
 const POCKET_JAW_OUTER_EXPONENT_MAX = 1.2;
 const POCKET_JAW_INNER_EXPONENT_MIN = 0.78;
 const POCKET_JAW_INNER_EXPONENT_MAX = 1.34;
 const POCKET_JAW_SEGMENT_MIN = 144;
+const POCKET_JAW_CORNER_EDGE_FACTOR = 0.42;
+const POCKET_JAW_SIDE_EDGE_FACTOR = POCKET_JAW_CORNER_EDGE_FACTOR;
+const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97;
+const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR;
 const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.66;
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.986;
-const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.08;
+const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.15;
+const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * 0.036;
+const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.004;
 const SIDE_POCKET_JAW_SIDE_TRIM_SCALE = 0.82;
 const SIDE_POCKET_JAW_MIDDLE_TRIM_SCALE = 0.86;
+const SIDE_POCKET_JAW_EDGE_TRIM_START = 0.72;
+const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.82;
+const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = 1.4;
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.592;
 const CORNER_JAW_ARC_DEG = 120;
 const SIDE_JAW_ARC_DEG = 120;
@@ -876,6 +898,7 @@ const WOOD_PRESETS_BY_ID = Object.freeze(
   }, {})
 );
 const DEFAULT_WOOD_PRESET_ID = 'walnut';
+const WOOD_TEXTURES_ENABLED = false;
 const SNOOKER_WOOD_PRESET_FOR_FINISH = Object.freeze({
   rusticSplit: 'walnut',
   charredTimber: 'wenge',
@@ -903,6 +926,7 @@ const SNOOKER_WOOD_SURFACE_PROPS = Object.freeze({
 const DEFAULT_TABLE_FINISH_ID = 'rusticSplit';
 
 const applySnookerWoodPreset = (materials, finishId) => {
+  if (!WOOD_TEXTURES_ENABLED) return;
   const presetId = SNOOKER_WOOD_PRESET_FOR_FINISH[finishId];
   if (!presetId) return;
   const preset = WOOD_PRESETS_BY_ID[presetId];
@@ -3010,7 +3034,7 @@ const CAMERA_MIN_HORIZONTAL =
 const CAMERA_DOWNWARD_PULL = 1.9;
 const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.29;
 const IN_HAND_CAMERA_PULLBACK = 1.38;
-const TOP_VIEW_MARGIN = 0.54; // scaled to the snooker footprint so the overhead view hugs the rails
+const TOP_VIEW_MARGIN = 0.32; // mirror Pool Royale's overhead framing while scaling to the snooker footprint
 const TOP_VIEW_RADIUS_SCALE = 0.44;
 const TOP_VIEW_MIN_RADIUS_SCALE = 0.92;
 const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI + 0.04, CAMERA.minPhi * 0.64);
@@ -5119,7 +5143,7 @@ function Table3D(
     let localClampOuter = clampOuter;
     let localJawAngle = jawAngle;
     let depthMultiplier = 1;
-    let steps = wide ? 88 : 68;
+    let steps = wide ? 132 : 104;
 
     if (isMiddle) {
       localJawAngle *= SIDE_POCKET_JAW_LATERAL_EXPANSION;
@@ -5139,8 +5163,10 @@ function Table3D(
       );
     }
 
-    let sideThinFactor = wide ? 0.3 : 0.36;
-    let middleThinFactor = wide ? 0.82 : 0.92;
+    let sideThinFactor = wide ? POCKET_JAW_SIDE_EDGE_FACTOR : POCKET_JAW_CORNER_EDGE_FACTOR;
+    let middleThinFactor = wide
+      ? POCKET_JAW_SIDE_MIDDLE_FACTOR
+      : POCKET_JAW_CORNER_MIDDLE_FACTOR;
     if (isMiddle && wide) {
       sideThinFactor *= SIDE_POCKET_JAW_SIDE_TRIM_SCALE;
       middleThinFactor *= SIDE_POCKET_JAW_MIDDLE_TRIM_SCALE;
@@ -5156,12 +5182,14 @@ function Table3D(
       steps,
       sideThinFactor,
       middleThinFactor,
-      centerEase: wide ? 0.28 : 0.36,
+      centerEase: 0.36,
       clampOuter: localClampOuter
     });
     if (!jawShape) {
       return null;
     }
+    const jawVerticalOffset = isMiddle ? SIDE_POCKET_JAW_VERTICAL_TWEAK : 0;
+    const jawTopY = railsTopY + POCKET_JAW_VERTICAL_LIFT + jawVerticalOffset;
     const jawDepth = Math.max(
       MICRO_EPS,
       railH * POCKET_JAW_DEPTH_SCALE * depthMultiplier
@@ -5176,7 +5204,7 @@ function Table3D(
     jawGeom.translate(0, -jawDepth, 0);
     jawGeom.computeVertexNormals();
     const jawMesh = new THREE.Mesh(jawGeom, pocketJawMat);
-    jawMesh.position.y = railsTopY;
+    jawMesh.position.y = jawTopY;
     jawMesh.castShadow = false;
     jawMesh.receiveShadow = true;
 
@@ -5272,7 +5300,6 @@ function Table3D(
   }
 
   if (sideBaseRadius && sideBaseRadius > MICRO_EPS) {
-    const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.26;
     [-1, 1].forEach((sx) => {
       const baseMP = sideNotchMP(sx);
       const fallbackCenter = new THREE.Vector2(sx * (innerHalfW - sideInset), 0);


### PR DESCRIPTION
## Summary
- align snooker chrome, pocket, and jaw dimensions with the Pool Royale layout while keeping 12 ft scaling
- disable wood grain overlays so snooker finishes render with the same material treatment as Pool Royale
- match overhead camera framing and pocket jaw construction to the Pool Royale experience

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936923926308329abf2ec5d80056eff)