### PR TITLE
Fix cue ball projection plane

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -10150,7 +10150,7 @@ function SnookerGame() {
       const ray = new THREE.Raycaster();
       const plane = new THREE.Plane(
         new THREE.Vector3(0, 1, 0),
-        -TABLE_Y * worldScaleFactor
+        -BALL_CENTER_Y * worldScaleFactor
       );
       project = (ev) => {
         const r = dom.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- use the cue ball height when projecting pointer hits onto the table
- improve cue-ball placement and aiming line alignment with the playing surface

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936a172ba248329b24f5fb1817b6539)