### PR TITLE
Fix snooker aiming line visibility

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -9750,7 +9750,9 @@ function SnookerGame() {
         color: 0xffffff,
         linewidth: 2,
         transparent: true,
-        opacity: 0.9
+        opacity: 0.9,
+        depthWrite: false,
+        depthTest: false
       });
       const aimGeom = new THREE.BufferGeometry().setFromPoints([
         new THREE.Vector3(),
@@ -9758,6 +9760,7 @@ function SnookerGame() {
       ]);
       const aim = new THREE.Line(aimGeom, aimMat);
       aim.visible = false;
+      aim.renderOrder = 2;
       table.add(aim);
       const tickGeom = new THREE.BufferGeometry().setFromPoints([
         new THREE.Vector3(),
@@ -9765,9 +9768,14 @@ function SnookerGame() {
       ]);
       const tick = new THREE.Line(
         tickGeom,
-        new THREE.LineBasicMaterial({ color: 0xffffff })
+        new THREE.LineBasicMaterial({
+          color: 0xffffff,
+          depthWrite: false,
+          depthTest: false
+        })
       );
       tick.visible = false;
+      tick.renderOrder = 2;
       table.add(tick);
 
       const targetGeom = new THREE.BufferGeometry().setFromPoints([
@@ -9781,10 +9789,13 @@ function SnookerGame() {
           dashSize: 1,
           gapSize: 1,
           transparent: true,
-          opacity: 0.5
+          opacity: 0.5,
+          depthWrite: false,
+          depthTest: false
         })
       );
       target.visible = false;
+      target.renderOrder = 2;
       table.add(target);
 
       chalkAreaRef.current = null;
@@ -11330,13 +11341,15 @@ function SnookerGame() {
             targetBallColor &&
             legalTargets.length > 0 &&
             !legalTargets.includes(targetBallColor);
-          aim.material.color.set(
-            aimingWrong
-              ? 0xff3333
-              : targetBall && !railNormal
-                ? 0xffff00
-                : 0xffffff
-          );
+          const clampedPower = THREE.MathUtils.clamp(powerRef.current, 0, 1);
+          const primaryColor = aimingWrong
+            ? 0xff3333
+            : targetBall && !railNormal
+              ? 0xffd166
+              : 0x7ce7ff;
+          aim.material.color.set(primaryColor);
+          aim.material.opacity = 0.65 + 0.25 * clampedPower;
+          aim.material.needsUpdate = true;
           const perp = new THREE.Vector3(-dir.z, 0, dir.x);
           if (perp.lengthSq() > 1e-8) perp.normalize();
           tickGeom.setFromPoints([
@@ -11352,7 +11365,6 @@ function SnookerGame() {
           } else {
             aimFocusRef.current = null;
           }
-          const clampedPower = THREE.MathUtils.clamp(powerRef.current, 0, 1);
           const desiredPull = clampedPower * BALL_R * 10 * 0.65 * 1.2;
           const backInfo = calcTarget(
             cue,


### PR DESCRIPTION
## Summary
- disable depth writing/testing on snooker aiming guides and raise render order so lines sit above the table
- brighten aiming line visuals with dynamic colors and opacity based on shot state and power

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936d47b1e048329a61351de17c70b45)