### PR TITLE
Refresh chess board and piece palettes

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -77,94 +77,94 @@ const BASE_BOARD_THEME = Object.freeze({
 
 const BOARD_COLOR_BASE_OPTIONS = Object.freeze([
   {
-    id: 'royaleNight',
-    label: 'Royale Nightfall',
-    light: '#f0d9b5',
-    dark: '#8b5a2b',
-    frameLight: '#1b243b',
-    frameDark: '#0b1220',
-    accent: '#22c55e',
-    highlight: '#22c55e',
-    capture: '#f97316',
-    surfaceRoughness: 0.58,
-    surfaceMetalness: 0.22,
-    frameRoughness: 0.76,
-    frameMetalness: 0.24
-  },
-  {
-    id: 'classicWalnut',
-    label: 'Dru Klasik',
-    light: '#f3dfc1',
-    dark: '#9a6636',
-    frameLight: '#bb8451',
-    frameDark: '#4c2e18',
-    accent: '#d8b280',
-    highlight: '#4ce0c3',
-    capture: '#ff6f78',
-    surfaceRoughness: 0.72,
-    surfaceMetalness: 0.16,
-    frameRoughness: 0.84,
-    frameMetalness: 0.18
-  },
-  {
-    id: 'arcticMarble',
-    label: 'Mermer Arktik',
-    light: '#f1f4f9',
-    dark: '#6a88a6',
-    frameLight: '#cbd5e1',
-    frameDark: '#455468',
-    accent: '#6fbdf2',
-    highlight: '#76e5fc',
-    capture: '#ff7b9b',
-    surfaceRoughness: 0.42,
-    surfaceMetalness: 0.24,
-    frameRoughness: 0.58,
+    id: 'frostedSteel',
+    label: 'Frosted Steel',
+    light: '#e4f0ff',
+    dark: '#1c2738',
+    frameLight: '#c8d5e8',
+    frameDark: '#101827',
+    accent: '#7dd3fc',
+    highlight: '#7cf4c4',
+    capture: '#ff8ba7',
+    surfaceRoughness: 0.44,
+    surfaceMetalness: 0.28,
+    frameRoughness: 0.6,
     frameMetalness: 0.32
   },
   {
-    id: 'onyxGold',
-    label: 'Oniks & Ar',
-    light: '#f7d18b',
-    dark: '#2a2521',
-    frameLight: '#9f7a3c',
-    frameDark: '#1a1411',
-    accent: '#f2c57c',
-    highlight: '#7ef9a1',
-    capture: '#ff8975',
-    surfaceRoughness: 0.55,
-    surfaceMetalness: 0.4,
-    frameRoughness: 0.48,
-    frameMetalness: 0.52
+    id: 'desertCopper',
+    label: 'Desert Copper',
+    light: '#f4e3c3',
+    dark: '#4b2e1b',
+    frameLight: '#d29d6a',
+    frameDark: '#2a1b10',
+    accent: '#e38b29',
+    highlight: '#fcd34d',
+    capture: '#f97316',
+    surfaceRoughness: 0.62,
+    surfaceMetalness: 0.22,
+    frameRoughness: 0.78,
+    frameMetalness: 0.18
   },
   {
-    id: 'neonMatrix',
-    label: 'Neon Futuristik',
-    light: '#3ef8ff',
-    dark: '#1b1d36',
-    frameLight: '#2d2f5a',
-    frameDark: '#0c0d18',
-    accent: '#a855f7',
-    highlight: '#59ffa5',
-    capture: '#ff5f87',
-    surfaceRoughness: 0.36,
-    surfaceMetalness: 0.48,
+    id: 'nebulaGlass',
+    label: 'Nebula Glass',
+    light: '#e0f2fe',
+    dark: '#0b1024',
+    frameLight: '#a5b4fc',
+    frameDark: '#0a0d14',
+    accent: '#8b5cf6',
+    highlight: '#34d399',
+    capture: '#fb7185',
+    surfaceRoughness: 0.34,
+    surfaceMetalness: 0.52,
     frameRoughness: 0.42,
     frameMetalness: 0.56
   },
   {
-    id: 'stoneMarbleJade',
-    label: 'Stone & Jade',
-    light: '#e4e3dd',
-    dark: '#60605b',
-    frameLight: '#9ea09b',
-    frameDark: '#4a4d51',
-    accent: '#7ed3a0',
-    highlight: '#7ed3a0',
-    capture: '#dc5c5c',
-    surfaceRoughness: 0.52,
-    surfaceMetalness: 0.16,
+    id: 'harborMist',
+    label: 'Harbor Mist',
+    light: '#dbeafe',
+    dark: '#1f2937',
+    frameLight: '#94a3b8',
+    frameDark: '#0f172a',
+    accent: '#38bdf8',
+    highlight: '#7ef9a1',
+    capture: '#f43f5e',
+    surfaceRoughness: 0.5,
+    surfaceMetalness: 0.18,
     frameRoughness: 0.64,
-    frameMetalness: 0.2
+    frameMetalness: 0.22
+  },
+  {
+    id: 'emberRose',
+    label: 'Ember Rose',
+    light: '#ffe4e6',
+    dark: '#311424',
+    frameLight: '#f9c5d5',
+    frameDark: '#1b0d17',
+    accent: '#f43f5e',
+    highlight: '#fda4af',
+    capture: '#fb7185',
+    surfaceRoughness: 0.56,
+    surfaceMetalness: 0.26,
+    frameRoughness: 0.7,
+    frameMetalness: 0.24
+  },
+  {
+    id: 'slateJade',
+    label: 'Slate & Jade',
+    light: '#e0f2f1',
+    dark: '#1c2625',
+    frameLight: '#9bc8b3',
+    frameDark: '#15201e',
+    accent: '#34d399',
+    highlight: '#67e8f9',
+    capture: '#dc5c5c',
+    surfaceRoughness: 0.54,
+    surfaceMetalness: 0.16,
+    frameRoughness: 0.66,
+    frameMetalness: 0.18
   }
 ]);
 
@@ -271,148 +271,64 @@ const CHECKMATE_SOUND_URL =
 
 const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
   {
-    id: 'beautifulGameAuthentic',
-    name: 'Authentic',
-    piece: { preserveOriginal: true },
-    board: { light: '#e4d2b3', dark: '#2f3526', preserveOriginal: true }
+    id: 'beautifulGameAuroraMetal',
+    name: 'Aurora Metal',
+    piece: { white: '#dce6ff', black: '#111827', accent: '#7dd3fc' },
+    board: { light: '#d9f5ff', dark: '#0b1220', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameSwapPalettes',
-    name: 'Swap Palettes',
-    piece: { white: '#2f3526', black: '#e4d2b3' },
-    board: { light: '#EEE8D5', dark: '#2B2F36' }
+    id: 'beautifulGameObsidianGold',
+    name: 'Obsidian / Gold',
+    piece: { white: '#f8ead4', black: '#141414', accent: '#d4a017' },
+    board: { light: '#f4e8d2', dark: '#1e1e1e', accent: '#d4a017' }
   },
   {
-    id: 'beautifulGameBlueOrange',
-    name: 'Blue / Orange',
-    piece: { white: '#5B8DEF', black: '#F59E0B' },
-    board: { light: '#93C5FD', dark: '#1E293B' }
+    id: 'beautifulGameGlacierMint',
+    name: 'Glacier / Mint',
+    piece: { white: '#ecfeff', black: '#0f172a', accent: '#34d399' },
+    board: { light: '#d1fae5', dark: '#0f172a', accent: '#34d399' }
   },
   {
-    id: 'beautifulGameRedTeal',
-    name: 'Red / Teal',
-    piece: { white: '#EF4444', black: '#14B8A6' },
-    board: { light: '#FCA5A5', dark: '#0F766E' }
+    id: 'beautifulGameSakuraSlate',
+    name: 'Sakura / Slate',
+    piece: { white: '#ffe4ec', black: '#2b3040', accent: '#fb7185' },
+    board: { light: '#ffd8e3', dark: '#1f2635', accent: '#fb7185' }
   },
   {
-    id: 'beautifulGamePurpleLime',
-    name: 'Purple / Lime',
-    piece: { white: '#8B5CF6', black: '#84CC16' },
-    board: { light: '#C4B5FD', dark: '#365314' }
+    id: 'beautifulGameVoltTeal',
+    name: 'Volt / Teal',
+    piece: { white: '#faffb5', black: '#0f766e', accent: '#22d3ee' },
+    board: { light: '#e8ffb5', dark: '#0b3b3c', accent: '#22d3ee' }
   },
   {
-    id: 'beautifulGamePinkCyan',
-    name: 'Pink / Cyan',
-    piece: { white: '#EC4899', black: '#06B6D4' },
-    board: { light: '#F9A8D4', dark: '#164E63' }
+    id: 'beautifulGameCopperIvory',
+    name: 'Copper / Ivory',
+    piece: { white: '#f5f0e5', black: '#5a2c1f', accent: '#e38b29' },
+    board: { light: '#f4ede1', dark: '#3b241a', accent: '#e38b29' }
   },
   {
-    id: 'beautifulGameGoldSlate',
-    name: 'Gold / Slate',
-    piece: { white: '#F59E0B', black: '#64748B' },
-    board: { light: '#FDE68A', dark: '#0F172A' }
+    id: 'beautifulGameNoirNeon',
+    name: 'Noir / Neon',
+    piece: { white: '#e5e7eb', black: '#0a0d14', accent: '#06f0ff' },
+    board: { light: '#c7d2fe', dark: '#0a0d14', accent: '#06f0ff' }
   },
   {
-    id: 'beautifulGameEmeraldFuchsia',
-    name: 'Emerald / Fuchsia',
-    piece: { white: '#10B981', black: '#A21CAF' },
-    board: { light: '#6EE7B7', dark: '#4A044E' }
+    id: 'beautifulGameCinderRose',
+    name: 'Cinder / Rose',
+    piece: { white: '#f5d0c5', black: '#1f1b29', accent: '#f43f5e' },
+    board: { light: '#f8d7cc', dark: '#1b1524', accent: '#f43f5e' }
   },
   {
-    id: 'beautifulGameSilverGraphite',
-    name: 'Silver / Graphite',
-    piece: { white: '#D1D5DB', black: '#111827' },
-    board: { light: '#E5E7EB', dark: '#111827' }
+    id: 'beautifulGameHarborFog',
+    name: 'Harbor Fog',
+    piece: { white: '#e2e8f0', black: '#1e293b', accent: '#38bdf8' },
+    board: { light: '#dbeafe', dark: '#0b1220', accent: '#38bdf8' }
   },
   {
-    id: 'beautifulGameForestSand',
-    name: 'Forest / Sand',
-    piece: { white: '#22C55E', black: '#E9D5A1' },
-    board: { light: '#FDEAD7', dark: '#064E3B' }
-  },
-  {
-    id: 'beautifulGameCoffeeCream',
-    name: 'Coffee / Cream',
-    piece: { white: '#9D6B53', black: '#EEE0D5' },
-    board: { light: '#D6BFA9', dark: '#6B4F3A' }
-  },
-  {
-    id: 'beautifulGameMidnightIce',
-    name: 'Midnight / Ice',
-    piece: { white: '#C7D2FE', black: '#111827' },
-    board: { light: '#E5E7EB', dark: '#0B1220' }
-  },
-  {
-    id: 'beautifulGameNavyCoral',
-    name: 'Navy / Coral',
-    piece: { white: '#1D4ED8', black: '#FB7185' },
-    board: { light: '#93C5FD', dark: '#0F172A' }
-  },
-  {
-    id: 'beautifulGameMintCharcoal',
-    name: 'Mint / Charcoal',
-    piece: { white: '#34D399', black: '#374151' },
-    board: { light: '#A7F3D0', dark: '#111827' }
-  },
-  {
-    id: 'beautifulGameRoseIndigo',
-    name: 'Rose / Indigo',
-    piece: { white: '#F43F5E', black: '#4338CA' },
-    board: { light: '#FBCFE8', dark: '#1E1B4B' }
-  },
-  {
-    id: 'beautifulGameAmberStone',
-    name: 'Amber / Stone',
-    piece: { white: '#F59E0B', black: '#78716C' },
-    board: { light: '#FDE68A', dark: '#292524' }
-  },
-  {
-    id: 'beautifulGameVioletAmber',
-    name: 'Violet / Amber',
-    piece: { white: '#7C3AED', black: '#F59E0B' },
-    board: { light: '#DDD6FE', dark: '#1F1147' }
-  },
-  {
-    id: 'beautifulGameAquaMaroon',
-    name: 'Aqua / Maroon',
-    piece: { white: '#22D3EE', black: '#7F1D1D' },
-    board: { light: '#A5F3FC', dark: '#3F0E0E' }
-  },
-  {
-    id: 'beautifulGameBronzeCoal',
-    name: 'Bronze / Coal',
-    piece: { white: '#CD7F32', black: '#0A0A0A' },
-    board: { light: '#E9D5A1', dark: '#262626' }
-  },
-  {
-    id: 'beautifulGameSteelPlum',
-    name: 'Steel / Plum',
-    piece: { white: '#94A3B8', black: '#581C87' },
-    board: { light: '#CBD5E1', dark: '#2D1B4E' }
-  },
-  {
-    id: 'beautifulGameOceanSandstone',
-    name: 'Ocean / Sandstone',
-    piece: { white: '#3B82F6', black: '#F5DEB3' },
-    board: { light: '#BFDBFE', dark: '#7C3F00' }
-  },
-  {
-    id: 'beautifulGameTealOrange',
-    name: 'Teal / Orange',
-    piece: { white: '#14B8A6', black: '#F97316' },
-    board: { light: '#99F6E4', dark: '#1F2937' }
-  },
-  {
-    id: 'beautifulGameWineIvory',
-    name: 'Wine / Ivory',
-    piece: { white: '#991B1B', black: '#ECECEC' },
-    board: { light: '#F5EDE0', dark: '#3B1C1C' }
-  },
-  {
-    id: 'beautifulGameMono',
-    name: 'Mono',
-    piece: { white: '#E5E7EB', black: '#1F2937' },
-    board: { light: '#E5E7EB', dark: '#111827' }
+    id: 'beautifulGameDesertStorm',
+    name: 'Desert Storm',
+    piece: { white: '#fef3c7', black: '#4b3421', accent: '#fbbf24' },
+    board: { light: '#fde68a', dark: '#2d1f12', accent: '#fbbf24' }
   }
 ]);
 
@@ -420,20 +336,20 @@ const BEAUTIFUL_GAME_THEME_NAMES = BEAUTIFUL_GAME_THEME_CONFIGS.map((config) => 
 
 const BEAUTIFUL_GAME_THEME = Object.freeze(
   buildBoardTheme({
-    ...(BOARD_COLOR_BASE_OPTIONS.find((option) => option.id === 'stoneMarbleJade') ?? {}),
+    ...(BOARD_COLOR_BASE_OPTIONS.find((option) => option.id === 'slateJade') ?? {}),
     id: 'beautifulGameAuthenticBoard',
-    label: 'Authentic',
+    label: 'Aurora Metal',
     light: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.light,
     dark: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.dark,
-    frameLight: '#c7a16c',
-    frameDark: '#3a2c20',
-    accent: '#4f7f5c',
+    frameLight: '#c5d8ff',
+    frameDark: '#141b2f',
+    accent: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.accent ?? '#7dd3fc',
     highlight: '#7ef9a1',
-    capture: '#ff8975',
-    surfaceRoughness: 0.74,
-    surfaceMetalness: 0.04,
-    frameRoughness: 0.86,
-    frameMetalness: 0.05,
+    capture: '#ff8e6e',
+    surfaceRoughness: 0.62,
+    surfaceMetalness: 0.12,
+    frameRoughness: 0.74,
+    frameMetalness: 0.14,
     preserveOriginalMaterials: true
   })
 );
@@ -485,38 +401,38 @@ const SCULPTED_DRAG_STYLE = Object.freeze({
 });
 
 const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
-  id: 'beautifulGameAuthentic',
-  label: 'Classic Olive',
+  id: 'beautifulGameAuroraMetal',
+  label: 'Aurora Metal',
   white: {
-    color: '#f6f7fb',
-    roughness: 0.28,
-    metalness: 0.3,
-    sheen: 0.3,
-    sheenColor: '#ffffff',
-    clearcoat: 0.32,
-    clearcoatRoughness: 0.22,
-    specularIntensity: 0.72
+    color: '#e5edff',
+    roughness: 0.22,
+    metalness: 0.42,
+    sheen: 0.32,
+    sheenColor: '#f7fbff',
+    clearcoat: 0.4,
+    clearcoatRoughness: 0.18,
+    specularIntensity: 0.78
   },
   black: {
-    color: '#3f5f46',
-    roughness: 0.28,
-    metalness: 0.36,
-    sheen: 0.24,
-    sheenColor: '#d7c49b',
-    clearcoat: 0.3,
-    clearcoatRoughness: 0.28,
-    specularIntensity: 0.72,
-    emissive: '#25291c',
-    emissiveIntensity: 0.22
+    color: '#0f172a',
+    roughness: 0.24,
+    metalness: 0.44,
+    sheen: 0.28,
+    sheenColor: '#b8c6ff',
+    clearcoat: 0.42,
+    clearcoatRoughness: 0.2,
+    specularIntensity: 0.78,
+    emissive: '#0a1020',
+    emissiveIntensity: 0.18
   },
-  accent: '#d7b24a',
-  goldAccent: '#d7b24a',
-  whiteAccent: { color: '#f6f7fb' },
-  blackAccent: '#b7892c'
+  accent: '#7dd3fc',
+  goldAccent: '#9cc3ff',
+  whiteAccent: { color: '#e5edff' },
+  blackAccent: '#7dd3fc'
 });
 
-const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGameAuthentic';
-const BEAUTIFUL_GAME_SET_ID = 'beautifulGameClassic';
+const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGameAuroraMetal';
+const BEAUTIFUL_GAME_SET_ID = 'beautifulGameAuroraMetalSet';
 
 const BASE_PIECE_STYLE = BEAUTIFUL_GAME_PIECE_STYLE;
 


### PR DESCRIPTION
## Summary
- replace chess board palette options with new metallic, desert, neon, and jade-inspired themes while keeping sizing intact
- switch the default ABeautifulGame set to the new Aurora Metal scheme and update piece style metadata
- align board theme defaults and identifiers with the refreshed presets for consistent GLTF presentation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69371ab0e1dc83299b98bb81ba0ec7f4)