### PR TITLE
Restore 3D snooker page to prior revision

### DIFF
--- a/webapp/src/pages/Games/Snooker.jsx
+++ b/webapp/src/pages/Games/Snooker.jsx
@@ -6315,7 +6315,6 @@ function SnookerGame() {
   const stopAiThinkingRef = useRef(() => {});
   const startUserSuggestionRef = useRef(() => {});
   const autoAimRequestRef = useRef(false);
-  const autoPlaceAiCueBallRef = useRef(() => false);
   const aiTelemetryRef = useRef({ key: null, countdown: 0 });
   const [hud, setHud] = useState({
     power: 0.65,
@@ -6327,11 +6326,6 @@ function SnookerGame() {
     inHand: true,
     over: false
   });
-  const [inHandPlacementMode, setInHandPlacementMode] = useState(false);
-  const inHandPlacementModeRef = useRef(inHandPlacementMode);
-  useEffect(() => {
-    inHandPlacementModeRef.current = inHandPlacementMode;
-  }, [inHandPlacementMode]);
   const powerRef = useRef(hud.power);
   useEffect(() => {
     powerRef.current = hud.power;
@@ -6340,22 +6334,6 @@ function SnookerGame() {
   useEffect(() => {
     hudRef.current = hud;
   }, [hud]);
-  const cueBallPlacedFromHandRef = useRef(false);
-  useEffect(() => {
-    const playerTurn = (hud.turn ?? 0) === 0;
-    const placing = Boolean(hud.inHand && playerTurn);
-    setInHandPlacementMode(placing);
-    if (placing) {
-      cueBallPlacedFromHandRef.current = false;
-    } else if (!hud.inHand) {
-      cueBallPlacedFromHandRef.current = true;
-    }
-  }, [hud.inHand, hud.turn]);
-  useEffect(() => {
-    if (hud.turn === 1 && hud.inHand) {
-      autoPlaceAiCueBallRef.current?.();
-    }
-  }, [hud.turn, hud.inHand]);
   useEffect(() => {
     const sph = sphRef.current;
     const bounds = cameraBoundsRef.current;
@@ -9767,9 +9745,7 @@ function SnookerGame() {
         color: 0xffffff,
         linewidth: 2,
         transparent: true,
-        opacity: 0.9,
-        depthWrite: false,
-        depthTest: false
+        opacity: 0.9
       });
       const aimGeom = new THREE.BufferGeometry().setFromPoints([
         new THREE.Vector3(),
@@ -9777,7 +9753,6 @@ function SnookerGame() {
       ]);
       const aim = new THREE.Line(aimGeom, aimMat);
       aim.visible = false;
-      aim.renderOrder = 2;
       table.add(aim);
       const tickGeom = new THREE.BufferGeometry().setFromPoints([
         new THREE.Vector3(),
@@ -9785,14 +9760,9 @@ function SnookerGame() {
       ]);
       const tick = new THREE.Line(
         tickGeom,
-        new THREE.LineBasicMaterial({
-          color: 0xffffff,
-          depthWrite: false,
-          depthTest: false
-        })
+        new THREE.LineBasicMaterial({ color: 0xffffff })
       );
       tick.visible = false;
-      tick.renderOrder = 2;
       table.add(tick);
 
       const targetGeom = new THREE.BufferGeometry().setFromPoints([
@@ -9806,13 +9776,10 @@ function SnookerGame() {
           dashSize: 1,
           gapSize: 1,
           transparent: true,
-          opacity: 0.5,
-          depthWrite: false,
-          depthTest: false
+          opacity: 0.5
         })
       );
       target.visible = false;
-      target.renderOrder = 2;
       table.add(target);
 
       chalkAreaRef.current = null;
@@ -10259,45 +10226,30 @@ function SnookerGame() {
       const tmpAim = new THREE.Vector2();
 
       // In-hand placement
-      const allowFullTableInHand = () => false;
-
-      const isSpotFree = (point, clearanceMultiplier = 2.05) => {
-        if (!point) return false;
-        const clearance = BALL_R * clearanceMultiplier;
-        for (const ball of balls) {
-          if (!ball.active || ball === cue) continue;
-          if (point.distanceTo(ball.pos) <= clearance) {
-            return false;
-          }
-        }
-        return true;
-      };
+      const free = (x, z) =>
+        balls.every(
+          (b) =>
+            !b.active ||
+            b === cue ||
+            new THREE.Vector2(x, z).distanceTo(b.pos) > BALL_R * 2.1
+        );
       const clampInHandPosition = (point) => {
         if (!point) return null;
         const clamped = point.clone();
         const limitX = PLAY_W / 2 - BALL_R;
         clamped.x = THREE.MathUtils.clamp(clamped.x, -limitX, limitX);
-        if (allowFullTableInHand()) {
-          const limitZ = PLAY_H / 2 - BALL_R;
-          clamped.y = THREE.MathUtils.clamp(clamped.y, -limitZ, limitZ);
-        } else {
-          const maxForward = baulkZ + BALL_R * 0.1;
-          if (clamped.y > maxForward) clamped.y = maxForward;
-          const deltaY = clamped.y - baulkZ;
-          const maxRadius = Math.max(D_RADIUS - BALL_R * 0.25, BALL_R);
-          const insideSq = clamped.x * clamped.x + deltaY * deltaY;
-          if (insideSq > maxRadius * maxRadius) {
-            const angle = Math.atan2(deltaY, clamped.x);
-            clamped.x = Math.cos(angle) * maxRadius;
-            clamped.y = baulkZ + Math.sin(angle) * maxRadius;
-          }
+        const maxForward = baulkZ + BALL_R * 0.1;
+        if (clamped.y > maxForward) clamped.y = maxForward;
+        const deltaY = clamped.y - baulkZ;
+        const maxRadius = Math.max(D_RADIUS - BALL_R * 0.25, BALL_R);
+        const insideSq = clamped.x * clamped.x + deltaY * deltaY;
+        if (insideSq > maxRadius * maxRadius) {
+          const angle = Math.atan2(deltaY, clamped.x);
+          clamped.x = Math.cos(angle) * maxRadius;
+          clamped.y = baulkZ + Math.sin(angle) * maxRadius;
         }
         return clamped;
       };
-      const defaultInHandPosition = () =>
-        clampInHandPosition(
-          new THREE.Vector2(0, allowFullTableInHand() ? 0 : baulkZ)
-        );
       const inHandDrag = {
         active: false,
         pointerId: null,
@@ -10318,26 +10270,20 @@ function SnookerGame() {
         if (!(currentHud?.inHand)) return false;
         const clamped = clampInHandPosition(raw);
         if (!clamped) return false;
-        if (!isSpotFree(clamped)) return false;
+        if (!free(clamped.x, clamped.y)) return false;
         cue.active = false;
         updateCuePlacement(clamped);
         inHandDrag.lastPos = clamped;
         if (commit) {
           cue.active = true;
           inHandDrag.lastPos = null;
-          cueBallPlacedFromHandRef.current = true;
-          if (hudRef.current?.inHand) {
-            const nextHud = { ...hudRef.current, inHand: false };
-            hudRef.current = nextHud;
-            setHud(nextHud);
-          }
+          setHud((s) => ({ ...s, inHand: false }));
         }
         return true;
       };
       const handleInHandDown = (e) => {
         const currentHud = hudRef.current;
         if (!(currentHud?.inHand)) return;
-        if (!inHandPlacementModeRef.current) return;
         if (shooting) return;
         if (e.button != null && e.button !== 0) return;
         const p = project(e);
@@ -10382,8 +10328,6 @@ function SnookerGame() {
         const pos = inHandDrag.lastPos;
         if (pos) {
           tryUpdatePlacement(pos, true);
-          setInHandPlacementMode(false);
-          autoAimRequestRef.current = true;
         }
         e.preventDefault?.();
       };
@@ -10392,32 +10336,11 @@ function SnookerGame() {
       window.addEventListener('pointerup', endInHandDrag);
       dom.addEventListener('pointercancel', endInHandDrag);
       window.addEventListener('pointercancel', endInHandDrag);
-      const autoPlaceAiCueBall = () => {
-        const currentHud = hudRef.current;
-        if (!currentHud) return false;
-        if (currentHud.turn !== 1 || !currentHud.inHand) return false;
-        if (!cue) return false;
-        if (!allStopped(balls)) return false;
-        const pos = defaultInHandPosition();
-        if (!pos) return false;
-        if (!isSpotFree(pos)) return false;
-        cue.active = false;
-        updateCuePlacement(pos);
-        cue.active = true;
-        cueBallPlacedFromHandRef.current = true;
-        hudRef.current = { ...currentHud, inHand: false };
-        setHud((prev) => ({ ...prev, inHand: false }));
-        return true;
-      };
-      autoPlaceAiCueBallRef.current = autoPlaceAiCueBall;
-
       if (hudRef.current?.inHand) {
-        const startPos = defaultInHandPosition();
+        const startPos = clampInHandPosition(new THREE.Vector2(0, baulkZ));
         if (startPos) {
           cue.active = false;
           updateCuePlacement(startPos);
-          cue.active = true;
-          cueBallPlacedFromHandRef.current = true;
         }
       }
 
@@ -11267,7 +11190,7 @@ function SnookerGame() {
         if (awardInHand) {
           cue.active = false;
           pocketDropRef.current.delete(cue.id);
-          const fallback = defaultInHandPosition();
+          const fallback = clampInHandPosition(new THREE.Vector2(0, baulkZ));
           if (fallback) {
             updateCuePlacement(fallback);
           } else {
@@ -11279,7 +11202,6 @@ function SnookerGame() {
           cue.spinMode = 'standard';
           cue.impacted = false;
           cue.launchDir = null;
-          cueBallPlacedFromHandRef.current = false;
         }
         setHud((prev) => ({ ...prev, inHand: awardInHand }));
         setShootingState(false);
@@ -11403,15 +11325,13 @@ function SnookerGame() {
             targetBallColor &&
             legalTargets.length > 0 &&
             !legalTargets.includes(targetBallColor);
-          const clampedPower = THREE.MathUtils.clamp(powerRef.current, 0, 1);
-          const primaryColor = aimingWrong
-            ? 0xff3333
-            : targetBall && !railNormal
-              ? 0xffd166
-              : 0x7ce7ff;
-          aim.material.color.set(primaryColor);
-          aim.material.opacity = 0.65 + 0.25 * clampedPower;
-          aim.material.needsUpdate = true;
+          aim.material.color.set(
+            aimingWrong
+              ? 0xff3333
+              : targetBall && !railNormal
+                ? 0xffff00
+                : 0xffffff
+          );
           const perp = new THREE.Vector3(-dir.z, 0, dir.x);
           if (perp.lengthSq() > 1e-8) perp.normalize();
           tickGeom.setFromPoints([
@@ -11427,6 +11347,7 @@ function SnookerGame() {
           } else {
             aimFocusRef.current = null;
           }
+          const clampedPower = THREE.MathUtils.clamp(powerRef.current, 0, 1);
           const desiredPull = clampedPower * BALL_R * 10 * 0.65 * 1.2;
           const backInfo = calcTarget(
             cue,


### PR DESCRIPTION
## Summary
- revert the 3D snooker page to its earlier revision from five days ago
- restore the previous table geometry, materials, and UI configuration for snooker

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693728ea21c08329bf4703cd93341fd1)