### PR TITLE
Align chess palettes with GLTF color presets

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -62,13 +62,13 @@ const clamp01 = (value, fallback = 0) => {
 };
 
 const BASE_BOARD_THEME = Object.freeze({
-  light: '#e7e2d3',
-  dark: '#776a5a',
+  light: '#eee8d5',
+  dark: '#2b2f36',
   frameLight: '#d2b48c',
   frameDark: '#3a2d23',
-  accent: '#00e5ff',
-  highlight: '#6ee7b7',
-  capture: '#f87171',
+  accent: '#3b82f6',
+  highlight: '#10b981',
+  capture: '#ef4444',
   surfaceRoughness: 0.74,
   surfaceMetalness: 0.04,
   frameRoughness: 0.86,
@@ -271,64 +271,46 @@ const CHECKMATE_SOUND_URL =
 
 const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
   {
-    id: 'beautifulGameAuroraMetal',
-    name: 'Aurora Metal',
-    piece: { white: '#dce6ff', black: '#111827', accent: '#7dd3fc' },
-    board: { light: '#d9f5ff', dark: '#0b1220', accent: '#7dd3fc' }
+    id: 'beautifulGameClassic',
+    name: 'Classic',
+    piece: { white: '#ffffff', black: '#111827', accent: '#f59e0b' },
+    board: { light: '#eee8d5', dark: '#2b2f36', accent: '#f59e0b' }
   },
   {
-    id: 'beautifulGameObsidianGold',
-    name: 'Obsidian / Gold',
-    piece: { white: '#f8ead4', black: '#141414', accent: '#d4a017' },
-    board: { light: '#f4e8d2', dark: '#1e1e1e', accent: '#d4a017' }
+    id: 'beautifulGameMono',
+    name: 'Mono',
+    piece: { white: '#ffffff', black: '#111827', accent: '#10b981' },
+    board: { light: '#e5e7eb', dark: '#111827', accent: '#10b981' }
   },
   {
-    id: 'beautifulGameGlacierMint',
-    name: 'Glacier / Mint',
-    piece: { white: '#ecfeff', black: '#0f172a', accent: '#34d399' },
-    board: { light: '#d1fae5', dark: '#0f172a', accent: '#34d399' }
+    id: 'beautifulGameBlue',
+    name: 'Blue',
+    piece: { white: '#ffffff', black: '#1e293b', accent: '#3b82f6' },
+    board: { light: '#93c5fd', dark: '#1e293b', accent: '#3b82f6' }
   },
   {
-    id: 'beautifulGameSakuraSlate',
-    name: 'Sakura / Slate',
-    piece: { white: '#ffe4ec', black: '#2b3040', accent: '#fb7185' },
-    board: { light: '#ffd8e3', dark: '#1f2635', accent: '#fb7185' }
+    id: 'beautifulGameAmber',
+    name: 'Amber',
+    piece: { white: '#f59e0b', black: '#111827', accent: '#f59e0b' },
+    board: { light: '#fde68a', dark: '#1f2937', accent: '#f59e0b' }
   },
   {
-    id: 'beautifulGameVoltTeal',
-    name: 'Volt / Teal',
-    piece: { white: '#faffb5', black: '#0f766e', accent: '#22d3ee' },
-    board: { light: '#e8ffb5', dark: '#0b3b3c', accent: '#22d3ee' }
+    id: 'beautifulGameMint',
+    name: 'Mint',
+    piece: { white: '#ffffff', black: '#065f46', accent: '#10b981' },
+    board: { light: '#a7f3d0', dark: '#065f46', accent: '#10b981' }
   },
   {
-    id: 'beautifulGameCopperIvory',
-    name: 'Copper / Ivory',
-    piece: { white: '#f5f0e5', black: '#5a2c1f', accent: '#e38b29' },
-    board: { light: '#f4ede1', dark: '#3b241a', accent: '#e38b29' }
+    id: 'beautifulGamePink',
+    name: 'Pink',
+    piece: { white: '#ffffff', black: '#312e81', accent: '#ef4444' },
+    board: { light: '#fbcfe8', dark: '#312e81', accent: '#ef4444' }
   },
   {
-    id: 'beautifulGameNoirNeon',
-    name: 'Noir / Neon',
-    piece: { white: '#e5e7eb', black: '#0a0d14', accent: '#06f0ff' },
-    board: { light: '#c7d2fe', dark: '#0a0d14', accent: '#06f0ff' }
-  },
-  {
-    id: 'beautifulGameCinderRose',
-    name: 'Cinder / Rose',
-    piece: { white: '#f5d0c5', black: '#1f1b29', accent: '#f43f5e' },
-    board: { light: '#f8d7cc', dark: '#1b1524', accent: '#f43f5e' }
-  },
-  {
-    id: 'beautifulGameHarborFog',
-    name: 'Harbor Fog',
-    piece: { white: '#e2e8f0', black: '#1e293b', accent: '#38bdf8' },
-    board: { light: '#dbeafe', dark: '#0b1220', accent: '#38bdf8' }
-  },
-  {
-    id: 'beautifulGameDesertStorm',
-    name: 'Desert Storm',
-    piece: { white: '#fef3c7', black: '#4b3421', accent: '#fbbf24' },
-    board: { light: '#fde68a', dark: '#2d1f12', accent: '#fbbf24' }
+    id: 'beautifulGameTeal',
+    name: 'Teal',
+    piece: { white: '#99f6e4', black: '#0f172a', accent: '#8b5cf6' },
+    board: { light: '#99f6e4', dark: '#0f172a', accent: '#8b5cf6' }
   }
 ]);
 
@@ -336,20 +318,11 @@ const BEAUTIFUL_GAME_THEME_NAMES = BEAUTIFUL_GAME_THEME_CONFIGS.map((config) => 
 
 const BEAUTIFUL_GAME_THEME = Object.freeze(
   buildBoardTheme({
-    ...(BOARD_COLOR_BASE_OPTIONS.find((option) => option.id === 'slateJade') ?? {}),
-    id: 'beautifulGameAuthenticBoard',
-    label: 'Aurora Metal',
-    light: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.light,
-    dark: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.dark,
-    frameLight: '#c5d8ff',
-    frameDark: '#141b2f',
-    accent: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.accent ?? '#7dd3fc',
-    highlight: '#7ef9a1',
-    capture: '#ff8e6e',
-    surfaceRoughness: 0.62,
-    surfaceMetalness: 0.12,
-    frameRoughness: 0.74,
-    frameMetalness: 0.14,
+    ...(BEAUTIFUL_GAME_THEME_CONFIGS[0].board ?? {}),
+    id: `${BEAUTIFUL_GAME_THEME_CONFIGS[0].id}Board`,
+    label: BEAUTIFUL_GAME_THEME_CONFIGS[0].name,
+    highlight: '#10b981',
+    capture: '#ef4444',
     preserveOriginalMaterials: true
   })
 );
@@ -401,8 +374,8 @@ const SCULPTED_DRAG_STYLE = Object.freeze({
 });
 
 const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
-  id: 'beautifulGameAuroraMetal',
-  label: 'Aurora Metal',
+  id: 'beautifulGameClassic',
+  label: 'Classic',
   white: {
     color: '#e5edff',
     roughness: 0.22,
@@ -431,8 +404,8 @@ const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
   blackAccent: '#7dd3fc'
 });
 
-const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGameAuroraMetal';
-const BEAUTIFUL_GAME_SET_ID = 'beautifulGameAuroraMetalSet';
+const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGameClassic';
+const BEAUTIFUL_GAME_SET_ID = 'beautifulGameClassicSet';
 
 const BASE_PIECE_STYLE = BEAUTIFUL_GAME_PIECE_STYLE;
 


### PR DESCRIPTION
## Summary
- update the default board theme to the classic palette used by the GLTF chess preview
- replace ABeautifulGame board and piece variants with the GLTF color presets seen in the chess UI
- point default piece style identifiers at the new classic-themed GLTF set

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693723bbc010832995a5b073abc57fd5)