### PR TITLE
Align Chess Battle Royal colors with GLTF presets

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -271,64 +271,39 @@ const CHECKMATE_SOUND_URL =
 
 const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
   {
-    id: 'beautifulGameAuroraMetal',
-    name: 'Aurora Metal',
-    piece: { white: '#dce6ff', black: '#111827', accent: '#7dd3fc' },
-    board: { light: '#d9f5ff', dark: '#0b1220', accent: '#7dd3fc' }
+    id: 'beautifulGameClassic',
+    name: 'Classic',
+    board: { light: '#EEE8D5', dark: '#2B2F36', accent: BASE_BOARD_THEME.accent }
   },
   {
-    id: 'beautifulGameObsidianGold',
-    name: 'Obsidian / Gold',
-    piece: { white: '#f8ead4', black: '#141414', accent: '#d4a017' },
-    board: { light: '#f4e8d2', dark: '#1e1e1e', accent: '#d4a017' }
+    id: 'beautifulGameMono',
+    name: 'Mono',
+    board: { light: '#E5E7EB', dark: '#111827', accent: BASE_BOARD_THEME.accent }
   },
   {
-    id: 'beautifulGameGlacierMint',
-    name: 'Glacier / Mint',
-    piece: { white: '#ecfeff', black: '#0f172a', accent: '#34d399' },
-    board: { light: '#d1fae5', dark: '#0f172a', accent: '#34d399' }
+    id: 'beautifulGameBlue',
+    name: 'Blue',
+    board: { light: '#93C5FD', dark: '#1E293B', accent: BASE_BOARD_THEME.accent }
   },
   {
-    id: 'beautifulGameSakuraSlate',
-    name: 'Sakura / Slate',
-    piece: { white: '#ffe4ec', black: '#2b3040', accent: '#fb7185' },
-    board: { light: '#ffd8e3', dark: '#1f2635', accent: '#fb7185' }
+    id: 'beautifulGameAmber',
+    name: 'Amber',
+    board: { light: '#FDE68A', dark: '#1F2937', accent: BASE_BOARD_THEME.accent }
   },
   {
-    id: 'beautifulGameVoltTeal',
-    name: 'Volt / Teal',
-    piece: { white: '#faffb5', black: '#0f766e', accent: '#22d3ee' },
-    board: { light: '#e8ffb5', dark: '#0b3b3c', accent: '#22d3ee' }
+    id: 'beautifulGameMint',
+    name: 'Mint',
+    board: { light: '#A7F3D0', dark: '#065F46', accent: BASE_BOARD_THEME.accent }
   },
   {
-    id: 'beautifulGameCopperIvory',
-    name: 'Copper / Ivory',
-    piece: { white: '#f5f0e5', black: '#5a2c1f', accent: '#e38b29' },
-    board: { light: '#f4ede1', dark: '#3b241a', accent: '#e38b29' }
+    id: 'beautifulGamePink',
+    name: 'Pink',
+    board: { light: '#FBCFE8', dark: '#312E81', accent: BASE_BOARD_THEME.accent }
   },
   {
-    id: 'beautifulGameNoirNeon',
-    name: 'Noir / Neon',
-    piece: { white: '#e5e7eb', black: '#0a0d14', accent: '#06f0ff' },
-    board: { light: '#c7d2fe', dark: '#0a0d14', accent: '#06f0ff' }
-  },
-  {
-    id: 'beautifulGameCinderRose',
-    name: 'Cinder / Rose',
-    piece: { white: '#f5d0c5', black: '#1f1b29', accent: '#f43f5e' },
-    board: { light: '#f8d7cc', dark: '#1b1524', accent: '#f43f5e' }
-  },
-  {
-    id: 'beautifulGameHarborFog',
-    name: 'Harbor Fog',
-    piece: { white: '#e2e8f0', black: '#1e293b', accent: '#38bdf8' },
-    board: { light: '#dbeafe', dark: '#0b1220', accent: '#38bdf8' }
-  },
-  {
-    id: 'beautifulGameDesertStorm',
-    name: 'Desert Storm',
-    piece: { white: '#fef3c7', black: '#4b3421', accent: '#fbbf24' },
-    board: { light: '#fde68a', dark: '#2d1f12', accent: '#fbbf24' }
+    id: 'beautifulGameTeal',
+    name: 'Teal',
+    board: { light: '#99F6E4', dark: '#0F172A', accent: BASE_BOARD_THEME.accent }
   }
 ]);
 
@@ -431,41 +406,43 @@ const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
   blackAccent: '#7dd3fc'
 });
 
-const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGameAuroraMetal';
+const BEAUTIFUL_GAME_AUTHENTIC_ID = 'pieceClassicWhite';
 const BEAUTIFUL_GAME_SET_ID = 'beautifulGameAuroraMetalSet';
 
 const BASE_PIECE_STYLE = BEAUTIFUL_GAME_PIECE_STYLE;
 
+const PIECE_COLOR_SWATCHES = Object.freeze([
+  { id: 'pieceClassicWhite', label: 'Classic White', color: '#ffffff' },
+  { id: 'pieceObsidian', label: 'Obsidian', color: '#111827' },
+  { id: 'pieceAmber', label: 'Amber', color: '#f59e0b' },
+  { id: 'pieceMint', label: 'Mint', color: '#10b981' },
+  { id: 'pieceAzure', label: 'Azure', color: '#3b82f6' },
+  { id: 'pieceCrimson', label: 'Crimson', color: '#ef4444' },
+  { id: 'pieceViolet', label: 'Violet', color: '#8b5cf6' }
+]);
+
 const BEAUTIFUL_GAME_COLOR_VARIANTS = Object.freeze(
-  BEAUTIFUL_GAME_THEME_CONFIGS.map((config) => {
-    const preserveOriginal = Boolean(config.piece?.preserveOriginal);
-    const pieceStyle = preserveOriginal
-      ? { ...BASE_PIECE_STYLE, preserveOriginalMaterials: true, keepTextures: true }
-      : {
-          ...BASE_PIECE_STYLE,
-          preserveOriginalMaterials: false,
-          keepTextures: true,
-          white: { ...BASE_PIECE_STYLE.white, color: config.piece?.white ?? BASE_PIECE_STYLE.white.color },
-          black: { ...BASE_PIECE_STYLE.black, color: config.piece?.black ?? BASE_PIECE_STYLE.black.color },
-          accent: config.piece?.accent ?? BASE_PIECE_STYLE.accent,
-          goldAccent: config.piece?.goldAccent ?? BASE_PIECE_STYLE.goldAccent,
-          whiteAccent: config.piece?.whiteAccent ?? BASE_PIECE_STYLE.whiteAccent,
-          blackAccent: config.piece?.blackAccent ?? BASE_PIECE_STYLE.blackAccent
-        };
-    return {
-      id: config.id,
-      label: `ABeautifulGame (${config.name})`,
-      style: pieceStyle
-    };
-  })
+  PIECE_COLOR_SWATCHES.map((swatch) => ({
+    id: swatch.id,
+    label: swatch.label,
+    style: {
+      ...BASE_PIECE_STYLE,
+      preserveOriginalMaterials: false,
+      keepTextures: true,
+      white: { ...BASE_PIECE_STYLE.white, color: swatch.color },
+      black: { ...BASE_PIECE_STYLE.black, color: swatch.color },
+      accent: swatch.color,
+      goldAccent: BASE_PIECE_STYLE.goldAccent,
+      whiteAccent: BASE_PIECE_STYLE.whiteAccent,
+      blackAccent: BASE_PIECE_STYLE.blackAccent
+    }
+  }))
 );
 
 const pieceStyleSignature = (style) => `${style?.white?.color ?? ''}|${style?.black?.color ?? ''}`;
 
-const DEFAULT_PIECE_STYLE =
-  BEAUTIFUL_GAME_COLOR_VARIANTS.find((variant) => variant.id === BEAUTIFUL_GAME_AUTHENTIC_ID)?.style ||
-  BEAUTIFUL_GAME_PIECE_STYLE;
-const DEFAULT_PIECE_SET_ID = BEAUTIFUL_GAME_AUTHENTIC_ID;
+const DEFAULT_PIECE_STYLE = BEAUTIFUL_GAME_COLOR_VARIANTS[0]?.style || BEAUTIFUL_GAME_PIECE_STYLE;
+const DEFAULT_PIECE_SET_ID = BEAUTIFUL_GAME_COLOR_VARIANTS[0]?.id || BEAUTIFUL_GAME_AUTHENTIC_ID;
 
 // Sized to the physical ABeautifulGame set while fitting the playable footprint
 const BEAUTIFUL_GAME_ASSET_SCALE = 1.08;
@@ -814,8 +791,8 @@ const DEFAULT_APPEARANCE = {
   chairColor: 0,
   tableShape: 0,
   boardColor: 0,
-  whitePieceStyle: Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX),
-  blackPieceStyle: Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX),
+  whitePieceStyle: 0,
+  blackPieceStyle: 1,
   headStyle: 0
 };
 const APPEARANCE_STORAGE_KEY = 'chessBattleRoyalAppearance';


### PR DESCRIPTION
## Summary
- Replace chess board presets with the Classic/Mono/Blue/Amber/Mint/Pink/Teal palette from the GLTF-powered preview
- Swap chess piece color options to the GLTF swatches so both sides start with the correct white/black materials
- Keep default appearance aligned with the GLTF set and de-duplicate piece style handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69372dbdb9e8832997ee12081f06ca32)