### PR TITLE
Align chess battle royale palettes with GLTF set

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -271,64 +271,39 @@ const CHECKMATE_SOUND_URL =
 
 const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
   {
-    id: 'beautifulGameAuroraMetal',
-    name: 'Aurora Metal',
-    piece: { white: '#dce6ff', black: '#111827', accent: '#7dd3fc' },
-    board: { light: '#d9f5ff', dark: '#0b1220', accent: '#7dd3fc' }
+    id: 'boardClassic',
+    name: 'Classic',
+    board: { light: '#EEE8D5', dark: '#2B2F36', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameObsidianGold',
-    name: 'Obsidian / Gold',
-    piece: { white: '#f8ead4', black: '#141414', accent: '#d4a017' },
-    board: { light: '#f4e8d2', dark: '#1e1e1e', accent: '#d4a017' }
+    id: 'boardMono',
+    name: 'Mono',
+    board: { light: '#E5E7EB', dark: '#111827', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameGlacierMint',
-    name: 'Glacier / Mint',
-    piece: { white: '#ecfeff', black: '#0f172a', accent: '#34d399' },
-    board: { light: '#d1fae5', dark: '#0f172a', accent: '#34d399' }
+    id: 'boardBlue',
+    name: 'Blue',
+    board: { light: '#93C5FD', dark: '#1E293B', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameSakuraSlate',
-    name: 'Sakura / Slate',
-    piece: { white: '#ffe4ec', black: '#2b3040', accent: '#fb7185' },
-    board: { light: '#ffd8e3', dark: '#1f2635', accent: '#fb7185' }
+    id: 'boardAmber',
+    name: 'Amber',
+    board: { light: '#FDE68A', dark: '#1F2937', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameVoltTeal',
-    name: 'Volt / Teal',
-    piece: { white: '#faffb5', black: '#0f766e', accent: '#22d3ee' },
-    board: { light: '#e8ffb5', dark: '#0b3b3c', accent: '#22d3ee' }
+    id: 'boardMint',
+    name: 'Mint',
+    board: { light: '#A7F3D0', dark: '#065F46', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameCopperIvory',
-    name: 'Copper / Ivory',
-    piece: { white: '#f5f0e5', black: '#5a2c1f', accent: '#e38b29' },
-    board: { light: '#f4ede1', dark: '#3b241a', accent: '#e38b29' }
+    id: 'boardPink',
+    name: 'Pink',
+    board: { light: '#FBCFE8', dark: '#312E81', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameNoirNeon',
-    name: 'Noir / Neon',
-    piece: { white: '#e5e7eb', black: '#0a0d14', accent: '#06f0ff' },
-    board: { light: '#c7d2fe', dark: '#0a0d14', accent: '#06f0ff' }
-  },
-  {
-    id: 'beautifulGameCinderRose',
-    name: 'Cinder / Rose',
-    piece: { white: '#f5d0c5', black: '#1f1b29', accent: '#f43f5e' },
-    board: { light: '#f8d7cc', dark: '#1b1524', accent: '#f43f5e' }
-  },
-  {
-    id: 'beautifulGameHarborFog',
-    name: 'Harbor Fog',
-    piece: { white: '#e2e8f0', black: '#1e293b', accent: '#38bdf8' },
-    board: { light: '#dbeafe', dark: '#0b1220', accent: '#38bdf8' }
-  },
-  {
-    id: 'beautifulGameDesertStorm',
-    name: 'Desert Storm',
-    piece: { white: '#fef3c7', black: '#4b3421', accent: '#fbbf24' },
-    board: { light: '#fde68a', dark: '#2d1f12', accent: '#fbbf24' }
+    id: 'boardTeal',
+    name: 'Teal',
+    board: { light: '#99F6E4', dark: '#0F172A', accent: '#7dd3fc' }
   }
 ]);
 
@@ -431,30 +406,37 @@ const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
   blackAccent: '#7dd3fc'
 });
 
-const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGameAuroraMetal';
+const PIECE_COLOR_SWATCHES = Object.freeze([
+  { id: 'beautifulGameClassicWhite', label: 'Classic White', color: '#ffffff' },
+  { id: 'beautifulGameMidnightSlate', label: 'Midnight Slate', color: '#111827' },
+  { id: 'beautifulGameAmber', label: 'Amber', color: '#f59e0b' },
+  { id: 'beautifulGameEmerald', label: 'Emerald', color: '#10b981' },
+  { id: 'beautifulGameRoyalBlue', label: 'Royal Blue', color: '#3b82f6' },
+  { id: 'beautifulGameCrimson', label: 'Crimson', color: '#ef4444' },
+  { id: 'beautifulGameAmethyst', label: 'Amethyst', color: '#8b5cf6' }
+]);
+
+const BEAUTIFUL_GAME_AUTHENTIC_ID = PIECE_COLOR_SWATCHES[0].id;
 const BEAUTIFUL_GAME_SET_ID = 'beautifulGameAuroraMetalSet';
 
 const BASE_PIECE_STYLE = BEAUTIFUL_GAME_PIECE_STYLE;
 
 const BEAUTIFUL_GAME_COLOR_VARIANTS = Object.freeze(
-  BEAUTIFUL_GAME_THEME_CONFIGS.map((config) => {
-    const preserveOriginal = Boolean(config.piece?.preserveOriginal);
-    const pieceStyle = preserveOriginal
-      ? { ...BASE_PIECE_STYLE, preserveOriginalMaterials: true, keepTextures: true }
-      : {
-          ...BASE_PIECE_STYLE,
-          preserveOriginalMaterials: false,
-          keepTextures: true,
-          white: { ...BASE_PIECE_STYLE.white, color: config.piece?.white ?? BASE_PIECE_STYLE.white.color },
-          black: { ...BASE_PIECE_STYLE.black, color: config.piece?.black ?? BASE_PIECE_STYLE.black.color },
-          accent: config.piece?.accent ?? BASE_PIECE_STYLE.accent,
-          goldAccent: config.piece?.goldAccent ?? BASE_PIECE_STYLE.goldAccent,
-          whiteAccent: config.piece?.whiteAccent ?? BASE_PIECE_STYLE.whiteAccent,
-          blackAccent: config.piece?.blackAccent ?? BASE_PIECE_STYLE.blackAccent
-        };
+  PIECE_COLOR_SWATCHES.map((swatch) => {
+    const pieceStyle = {
+      ...BASE_PIECE_STYLE,
+      preserveOriginalMaterials: false,
+      keepTextures: false,
+      white: { ...BASE_PIECE_STYLE.white, color: swatch.color },
+      black: { ...BASE_PIECE_STYLE.black, color: swatch.color },
+      accent: BASE_PIECE_STYLE.accent,
+      goldAccent: BASE_PIECE_STYLE.goldAccent,
+      whiteAccent: BASE_PIECE_STYLE.whiteAccent,
+      blackAccent: BASE_PIECE_STYLE.blackAccent
+    };
     return {
-      id: config.id,
-      label: `ABeautifulGame (${config.name})`,
+      id: swatch.id,
+      label: swatch.label,
       style: pieceStyle
     };
   })
@@ -809,15 +791,15 @@ const CAM = {
 
 const PLAYER_FLAG_STORAGE_KEY = 'chessBattleRoyalPlayerFlag';
 const FALLBACK_FLAG = '🇺🇸';
-const DEFAULT_APPEARANCE = {
-  ...DEFAULT_TABLE_CUSTOMIZATION,
-  chairColor: 0,
-  tableShape: 0,
-  boardColor: 0,
-  whitePieceStyle: Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX),
-  blackPieceStyle: Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX),
-  headStyle: 0
-};
+  const DEFAULT_APPEARANCE = {
+    ...DEFAULT_TABLE_CUSTOMIZATION,
+    chairColor: 0,
+    tableShape: 0,
+    boardColor: 0,
+    whitePieceStyle: Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX),
+    blackPieceStyle: Math.min(1, Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX + 1)),
+    headStyle: 0
+  };
 const APPEARANCE_STORAGE_KEY = 'chessBattleRoyalAppearance';
 const CHAIR_COLOR_OPTIONS = Object.freeze([
   {


### PR DESCRIPTION
## Summary
- replace chess board color options with the provided GLTF-friendly palette
- map piece color options to the provided GLTF swatches and default sides to white/black

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69373176f94c8329b890e528d6d26bae)