### PR TITLE
Align chess royale palettes with GLTF set

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -269,81 +269,36 @@ const CHECK_SOUND_URL =
 const CHECKMATE_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
 
-const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
-  {
-    id: 'beautifulGameAuroraMetal',
-    name: 'Aurora Metal',
-    piece: { white: '#dce6ff', black: '#111827', accent: '#7dd3fc' },
-    board: { light: '#d9f5ff', dark: '#0b1220', accent: '#7dd3fc' }
-  },
-  {
-    id: 'beautifulGameObsidianGold',
-    name: 'Obsidian / Gold',
-    piece: { white: '#f8ead4', black: '#141414', accent: '#d4a017' },
-    board: { light: '#f4e8d2', dark: '#1e1e1e', accent: '#d4a017' }
-  },
-  {
-    id: 'beautifulGameGlacierMint',
-    name: 'Glacier / Mint',
-    piece: { white: '#ecfeff', black: '#0f172a', accent: '#34d399' },
-    board: { light: '#d1fae5', dark: '#0f172a', accent: '#34d399' }
-  },
-  {
-    id: 'beautifulGameSakuraSlate',
-    name: 'Sakura / Slate',
-    piece: { white: '#ffe4ec', black: '#2b3040', accent: '#fb7185' },
-    board: { light: '#ffd8e3', dark: '#1f2635', accent: '#fb7185' }
-  },
-  {
-    id: 'beautifulGameVoltTeal',
-    name: 'Volt / Teal',
-    piece: { white: '#faffb5', black: '#0f766e', accent: '#22d3ee' },
-    board: { light: '#e8ffb5', dark: '#0b3b3c', accent: '#22d3ee' }
-  },
-  {
-    id: 'beautifulGameCopperIvory',
-    name: 'Copper / Ivory',
-    piece: { white: '#f5f0e5', black: '#5a2c1f', accent: '#e38b29' },
-    board: { light: '#f4ede1', dark: '#3b241a', accent: '#e38b29' }
-  },
-  {
-    id: 'beautifulGameNoirNeon',
-    name: 'Noir / Neon',
-    piece: { white: '#e5e7eb', black: '#0a0d14', accent: '#06f0ff' },
-    board: { light: '#c7d2fe', dark: '#0a0d14', accent: '#06f0ff' }
-  },
-  {
-    id: 'beautifulGameCinderRose',
-    name: 'Cinder / Rose',
-    piece: { white: '#f5d0c5', black: '#1f1b29', accent: '#f43f5e' },
-    board: { light: '#f8d7cc', dark: '#1b1524', accent: '#f43f5e' }
-  },
-  {
-    id: 'beautifulGameHarborFog',
-    name: 'Harbor Fog',
-    piece: { white: '#e2e8f0', black: '#1e293b', accent: '#38bdf8' },
-    board: { light: '#dbeafe', dark: '#0b1220', accent: '#38bdf8' }
-  },
-  {
-    id: 'beautifulGameDesertStorm',
-    name: 'Desert Storm',
-    piece: { white: '#fef3c7', black: '#4b3421', accent: '#fbbf24' },
-    board: { light: '#fde68a', dark: '#2d1f12', accent: '#fbbf24' }
-  }
+const BEAUTIFUL_GAME_BOARD_PRESETS = Object.freeze([
+  { id: 'beautifulGameClassic', name: 'Classic', light: '#EEE8D5', dark: '#2B2F36' },
+  { id: 'beautifulGameMono', name: 'Mono', light: '#E5E7EB', dark: '#111827' },
+  { id: 'beautifulGameBlue', name: 'Blue', light: '#93C5FD', dark: '#1E293B' },
+  { id: 'beautifulGameAmber', name: 'Amber', light: '#FDE68A', dark: '#1F2937' },
+  { id: 'beautifulGameMint', name: 'Mint', light: '#A7F3D0', dark: '#065F46' },
+  { id: 'beautifulGamePink', name: 'Pink', light: '#FBCFE8', dark: '#312E81' },
+  { id: 'beautifulGameTeal', name: 'Teal', light: '#99F6E4', dark: '#0F172A' }
 ]);
 
-const BEAUTIFUL_GAME_THEME_NAMES = BEAUTIFUL_GAME_THEME_CONFIGS.map((config) => config.name);
+const BEAUTIFUL_GAME_PIECE_COLOR_PRESETS = Object.freeze([
+  { id: 'beautifulGameColorWhite', label: 'Bright White', color: '#ffffff', accent: '#f5f5f5' },
+  { id: 'beautifulGameColorInk', label: 'Midnight Slate', color: '#111827', accent: '#1f2937' },
+  { id: 'beautifulGameColorAmber', label: 'Amber', color: '#f59e0b', accent: '#fbbf24' },
+  { id: 'beautifulGameColorMint', label: 'Emerald Mint', color: '#10b981', accent: '#34d399' },
+  { id: 'beautifulGameColorBlue', label: 'Azure Blue', color: '#3b82f6', accent: '#60a5fa' },
+  { id: 'beautifulGameColorRed', label: 'Crimson', color: '#ef4444', accent: '#f87171' },
+  { id: 'beautifulGameColorViolet', label: 'Violet', color: '#8b5cf6', accent: '#a78bfa' }
+]);
 
 const BEAUTIFUL_GAME_THEME = Object.freeze(
   buildBoardTheme({
     ...(BOARD_COLOR_BASE_OPTIONS.find((option) => option.id === 'slateJade') ?? {}),
-    id: 'beautifulGameAuthenticBoard',
-    label: 'Aurora Metal',
-    light: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.light,
-    dark: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.dark,
+    id: 'beautifulGameClassicBoard',
+    label: 'Classic',
+    light: BEAUTIFUL_GAME_BOARD_PRESETS[0].light,
+    dark: BEAUTIFUL_GAME_BOARD_PRESETS[0].dark,
     frameLight: '#c5d8ff',
     frameDark: '#141b2f',
-    accent: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.accent ?? '#7dd3fc',
+    accent: '#7dd3fc',
     highlight: '#7ef9a1',
     capture: '#ff8e6e',
     surfaceRoughness: 0.62,
@@ -355,23 +310,23 @@ const BEAUTIFUL_GAME_THEME = Object.freeze(
 );
 
 const BEAUTIFUL_GAME_BOARD_OPTIONS = Object.freeze(
-  BEAUTIFUL_GAME_THEME_CONFIGS.map((config) =>
+  BEAUTIFUL_GAME_BOARD_PRESETS.map((preset) =>
     buildBoardTheme({
       // Board palettes lifted directly from the ABeautifulGame presets (no extra colors)
-      id: `${config.id}Board`,
-      label: config.name,
-      light: config.board?.light ?? BEAUTIFUL_GAME_THEME.light,
-      dark: config.board?.dark ?? BEAUTIFUL_GAME_THEME.dark,
+      id: `${preset.id}Board`,
+      label: preset.name,
+      light: preset.light ?? BEAUTIFUL_GAME_THEME.light,
+      dark: preset.dark ?? BEAUTIFUL_GAME_THEME.dark,
       frameLight: BEAUTIFUL_GAME_THEME.frameLight,
       frameDark: BEAUTIFUL_GAME_THEME.frameDark,
       surfaceRoughness: BEAUTIFUL_GAME_THEME.surfaceRoughness,
       surfaceMetalness: BEAUTIFUL_GAME_THEME.surfaceMetalness,
       frameRoughness: BEAUTIFUL_GAME_THEME.frameRoughness,
       frameMetalness: BEAUTIFUL_GAME_THEME.frameMetalness,
-      accent: BEAUTIFUL_GAME_THEME.accent,
+      accent: preset.accent ?? BEAUTIFUL_GAME_THEME.accent,
       highlight: BEAUTIFUL_GAME_THEME.highlight,
       capture: BEAUTIFUL_GAME_THEME.capture,
-      preserveOriginalMaterials: Boolean(config.board?.preserveOriginal)
+      preserveOriginalMaterials: Boolean(preset.preserveOriginal)
     })
   )
 );
@@ -401,10 +356,10 @@ const SCULPTED_DRAG_STYLE = Object.freeze({
 });
 
 const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
-  id: 'beautifulGameAuroraMetal',
-  label: 'Aurora Metal',
+  id: 'beautifulGameClassic',
+  label: 'Classic Finish',
   white: {
-    color: '#e5edff',
+    color: '#ffffff',
     roughness: 0.22,
     metalness: 0.42,
     sheen: 0.32,
@@ -414,11 +369,11 @@ const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
     specularIntensity: 0.78
   },
   black: {
-    color: '#0f172a',
+    color: '#111827',
     roughness: 0.24,
     metalness: 0.44,
     sheen: 0.28,
-    sheenColor: '#b8c6ff',
+    sheenColor: '#111827',
     clearcoat: 0.42,
     clearcoatRoughness: 0.2,
     specularIntensity: 0.78,
@@ -427,34 +382,31 @@ const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
   },
   accent: '#7dd3fc',
   goldAccent: '#9cc3ff',
-  whiteAccent: { color: '#e5edff' },
+  whiteAccent: { color: '#ffffff' },
   blackAccent: '#7dd3fc'
 });
 
-const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGameAuroraMetal';
-const BEAUTIFUL_GAME_SET_ID = 'beautifulGameAuroraMetalSet';
+const BEAUTIFUL_GAME_AUTHENTIC_ID = BEAUTIFUL_GAME_PIECE_COLOR_PRESETS[0].id;
+const BEAUTIFUL_GAME_SET_ID = 'beautifulGameClassicSet';
 
 const BASE_PIECE_STYLE = BEAUTIFUL_GAME_PIECE_STYLE;
 
 const BEAUTIFUL_GAME_COLOR_VARIANTS = Object.freeze(
-  BEAUTIFUL_GAME_THEME_CONFIGS.map((config) => {
-    const preserveOriginal = Boolean(config.piece?.preserveOriginal);
-    const pieceStyle = preserveOriginal
-      ? { ...BASE_PIECE_STYLE, preserveOriginalMaterials: true, keepTextures: true }
-      : {
-          ...BASE_PIECE_STYLE,
-          preserveOriginalMaterials: false,
-          keepTextures: true,
-          white: { ...BASE_PIECE_STYLE.white, color: config.piece?.white ?? BASE_PIECE_STYLE.white.color },
-          black: { ...BASE_PIECE_STYLE.black, color: config.piece?.black ?? BASE_PIECE_STYLE.black.color },
-          accent: config.piece?.accent ?? BASE_PIECE_STYLE.accent,
-          goldAccent: config.piece?.goldAccent ?? BASE_PIECE_STYLE.goldAccent,
-          whiteAccent: config.piece?.whiteAccent ?? BASE_PIECE_STYLE.whiteAccent,
-          blackAccent: config.piece?.blackAccent ?? BASE_PIECE_STYLE.blackAccent
-        };
+  BEAUTIFUL_GAME_PIECE_COLOR_PRESETS.map((preset) => {
+    const pieceStyle = {
+      ...BASE_PIECE_STYLE,
+      preserveOriginalMaterials: false,
+      keepTextures: true,
+      white: { ...BASE_PIECE_STYLE.white, color: preset.color },
+      black: { ...BASE_PIECE_STYLE.black, color: preset.color },
+      accent: preset.accent ?? BASE_PIECE_STYLE.accent,
+      goldAccent: preset.accent ?? BASE_PIECE_STYLE.goldAccent,
+      whiteAccent: preset.accent ? { color: preset.accent } : BASE_PIECE_STYLE.whiteAccent,
+      blackAccent: preset.accent ?? BASE_PIECE_STYLE.blackAccent
+    };
     return {
-      id: config.id,
-      label: `ABeautifulGame (${config.name})`,
+      id: preset.id,
+      label: `ABeautifulGame (${preset.label})`,
       style: pieceStyle
     };
   })
@@ -815,7 +767,7 @@ const DEFAULT_APPEARANCE = {
   tableShape: 0,
   boardColor: 0,
   whitePieceStyle: Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX),
-  blackPieceStyle: Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX),
+  blackPieceStyle: Math.min(1, PIECE_STYLE_OPTIONS.length - 1),
   headStyle: 0
 };
 const APPEARANCE_STORAGE_KEY = 'chessBattleRoyalAppearance';


### PR DESCRIPTION
## Summary
- replace chess board palettes with the GLTF ABeautifulGame color presets for classic, mono, blue, amber, mint, pink, and teal
- rebuild piece color options around the matching GLTF palette so defaults start with bright white pieces versus midnight pieces

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69373176f94c8329b890e528d6d26bae)