### PR TITLE
Add standalone 8 Pool UK routes and lobby

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -46,6 +46,8 @@ import BlackJack from './pages/Games/BlackJack.jsx';
 import BlackJackLobby from './pages/Games/BlackJackLobby.jsx';
 import PoolRoyale from './pages/Games/PoolRoyale.jsx';
 import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
+import PoolUk from './pages/Games/PoolUk.jsx';
+import PoolUkLobby from './pages/Games/PoolUkLobby.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -131,6 +133,8 @@ export default function App() {
               element={<PoolRoyaleLobby />}
             />
             <Route path="/games/poolroyale" element={<PoolRoyale />} />
+            <Route path="/games/pooluk/lobby" element={<PoolUkLobby />} />
+            <Route path="/games/pooluk" element={<PoolUk />} />
             <Route
               path="/games/pollroyale/lobby"
               element={<Navigate to="/games/poolroyale/lobby" replace />}

--- a/webapp/src/components/GamesHallway.jsx
+++ b/webapp/src/components/GamesHallway.jsx
@@ -16,7 +16,8 @@ const fallbackGameNames = [
   'Texas Holdem',
   'Domino Royal 3D',
   'Blackjack Multi',
-  'Goal Rush'
+  'Goal Rush',
+  '8 Pool UK'
 ];
 
 function useBodyScrollLock(isLocked) {

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -66,6 +66,19 @@ export default function HomeGamesCard() {
           </h3>
         </Link>
         <Link
+          to="/games/pooluk/lobby"
+          className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
+        >
+          <img
+            src="/assets/icons/pool-royale.svg"
+            alt=""
+            className="h-20 w-20"
+          />
+          <h3 className="text-sm font-semibold text-center text-yellow-400">
+            8 Pool UK
+          </h3>
+        </Link>
+        <Link
           to="/games/goalrush/lobby"
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -68,6 +68,11 @@ export default function InvitePopup({
                     src: '/assets/icons/pool-royale.svg',
                     alt: 'Pool Royale',
                   },
+                  {
+                    id: 'pooluk',
+                    src: '/assets/icons/pool-royale.svg',
+                    alt: '8 Pool UK',
+                  },
               ].map((g) => (
                   <img
                     key={g.id}

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -25,6 +25,7 @@ function getGameFromTableId(id) {
       'fallingball',
       'goalrush',
       'poolroyale',
+      'pooluk',
     ].includes(prefix)
   )
     return prefix;

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -16,7 +16,7 @@ function getGameFromTableId(id) {
       'fallingball',
       'goalrush',
       'poolroyale',
-      'poolroyale',
+      'pooluk',
     ].includes(prefix)
   )
     return prefix;
@@ -183,6 +183,11 @@ export default function PlayerInvitePopup({
                   id: 'poolroyale',
                   src: '/assets/icons/pool-royale.svg',
                   alt: 'Pool Royale',
+                },
+                {
+                  id: 'pooluk',
+                  src: '/assets/icons/pool-royale.svg',
+                  alt: '8 Pool UK',
                 },
               ].map((g) => (
                 <img

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -16,6 +16,7 @@ const GAME_NAME_MAP = {
   goalrush: 'Goal Rush',
   fallingball: 'Falling Ball',
   pool: 'Pool Royale',
+  pooluk: '8 Pool UK',
   texas: "Texas Hold'em",
   domino: 'Domino Royal 3D',
   blackjack: 'Black Jack Multiplayer',

--- a/webapp/src/pages/GameTransactions.jsx
+++ b/webapp/src/pages/GameTransactions.jsx
@@ -8,6 +8,7 @@ const GAME_NAME_MAP = {
   goalrush: 'Goal Rush',
   fallingball: 'Falling Ball',
   pool: 'Pool Royale',
+  pooluk: '8 Pool UK',
   texas: "Texas Hold'em",
   domino: 'Domino Royal 3D',
   blackjack: 'Black Jack Multiplayer',

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -9,6 +9,7 @@ const gamesCatalog = [
   { name: 'Domino Royal 3D', route: '/games/domino-royal/lobby' },
   { name: 'Black Jack Multiplayer', route: '/games/blackjack/lobby' },
   { name: 'Pool Royale', route: '/games/poolroyale/lobby' },
+  { name: '8 Pool UK', route: '/games/pooluk/lobby' },
   { name: 'Goal Rush', route: '/games/goalrush/lobby' },
   { name: 'Air Hockey', route: '/games/airhockey/lobby' },
   { name: 'Table Tennis', route: '/games/tabletennis/lobby' },

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8311,7 +8311,7 @@ function PoolRoyaleGame({
       }
       const telegramId = tgIdRef.current || getTelegramId();
       await addTransaction(telegramId, -50, 'cue_fee', {
-        game: 'poolroyale',
+        game: activeGameId,
         reason: 'cue_switch',
         accountId: id
       });
@@ -9302,8 +9302,8 @@ function PoolRoyaleGame({
     [stopActiveCrowdSound]
   );
   useEffect(() => {
-    document.title = 'Pool Royale 3D';
-  }, []);
+    document.title = `${activeGameName} 3D`;
+  }, [activeGameName]);
   useEffect(() => {
     setPlayer({
       name: getTelegramUsername() || 'Player',
@@ -9469,12 +9469,12 @@ function PoolRoyaleGame({
           : 'Frame tied!';
     window.alert(`${announcement} Returning to the lobby...`);
     const winnerParam = winnerId === 'A' ? '1' : '0';
-    const lobbyUrl = `/games/poolroyale/lobby?winner=${winnerParam}`;
+    const lobbyUrl = `${activeLobbyPath}?winner=${winnerParam}`;
     const redirectTimer = window.setTimeout(() => {
       window.location.assign(lobbyUrl);
     }, 1200);
     return () => window.clearTimeout(redirectTimer);
-  }, [frameState.frameOver, frameState.winner, isTraining, player.name]);
+  }, [activeLobbyPath, frameState.frameOver, frameState.winner, isTraining, player.name]);
 
   useEffect(() => {
     let wakeLock;
@@ -9930,7 +9930,7 @@ function PoolRoyaleGame({
             ctx.font = 'bold 42px "Segoe UI", "Helvetica Neue", sans-serif';
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
-            ctx.fillText('Pool Royale Match of the Day', width / 2, 60);
+            ctx.fillText(`${activeGameName} Match of the Day`, width / 2, 60);
             const drawCompetitor = ({
               x,
               name,
@@ -14949,7 +14949,7 @@ function PoolRoyaleGame({
               fire();
             }, previewDelayMs);
           } catch (err) {
-            console.error('Pool Royale AI shot failed:', err);
+            console.error(`${activeGameName} AI shot failed:`, err);
             stopAiThinking();
             setAiPlanning(null);
             aiPlanRef.current = null;
@@ -15006,7 +15006,7 @@ function PoolRoyaleGame({
           }
           shotResolved = true;
         } catch (err) {
-          console.error('Pool Royale shot resolution failed:', err);
+          console.error(`${activeGameName} shot resolution failed:`, err);
         }
         if (isTraining) {
           if (!trainingRulesRef.current) {
@@ -15124,7 +15124,7 @@ function PoolRoyaleGame({
             }
           }
         } catch (err) {
-          console.error('Pool Royale post-resolution update failed:', err);
+          console.error(`${activeGameName} post-resolution update failed:`, err);
         } finally {
           frameRef.current = safeState;
           setFrameState(safeState);
@@ -17049,9 +17049,20 @@ function PoolRoyaleGame({
   );
 }
 
-export default function PoolRoyale() {
+export default function PoolRoyale({
+  gameId = 'poolroyale',
+  gameName = 'Pool Royale',
+  lobbyPath = '/games/poolroyale/lobby'
+}) {
   const navigate = useNavigate();
   const location = useLocation();
+  const { gameId: activeGameId, gameName: activeGameName, lobbyPath: activeLobbyPath } = useMemo(
+    () =>
+      location.pathname.includes('/games/pooluk')
+        ? { gameId: 'pooluk', gameName: '8 Pool UK', lobbyPath: '/games/pooluk/lobby' }
+        : { gameId, gameName, lobbyPath },
+    [gameId, gameName, lobbyPath, location.pathname]
+  );
   const variantKey = useMemo(() => {
     const params = new URLSearchParams(location.search);
     const requested = params.get('variant');
@@ -17141,7 +17152,7 @@ export default function PoolRoyale() {
   useTelegramBackButton(() => {
     confirmExit().then((confirmed) => {
       if (confirmed) {
-        navigate('/games/poolroyale/lobby');
+        navigate(activeLobbyPath);
       }
     });
   });
@@ -17156,7 +17167,7 @@ export default function PoolRoyale() {
         if (!confirmed) {
           window.history.pushState(null, '', window.location.href);
         } else {
-          navigate('/games/poolroyale/lobby');
+          navigate(activeLobbyPath);
         }
       });
     };

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -16,10 +16,19 @@ import { socket } from '../../utils/socket.js';
 import { getOnlineUsers } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 
-const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
-const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
-
-export default function PoolRoyaleLobby() {
+export default function PoolRoyaleLobby({
+  gameId = 'poolroyale',
+  gameName = 'Pool Royale',
+  variantOptions = [
+    { id: 'american', label: 'American' },
+    { id: '9ball', label: '9-Ball' }
+  ],
+  defaultVariant,
+  bracketPage = '/pool-royale-bracket.html',
+  gamePath = '/games/poolroyale',
+  onlineGameType = 'poolroyale',
+  trainingVariantOptions,
+}) {
   const navigate = useNavigate();
   const { search } = useLocation();
   useTelegramBackButton();
@@ -32,6 +41,11 @@ export default function PoolRoyaleLobby() {
       : 'regular';
   })();
 
+  const resolvedVariantOptions = variantOptions.length ? variantOptions : [{ id: 'uk', label: '8 Pool UK' }];
+  const trainingOptions = trainingVariantOptions || resolvedVariantOptions;
+  const defaultVariantValue = defaultVariant || resolvedVariantOptions[0].id;
+  const onlineGameKey = `${gameId}-online`;
+
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState('ai');
   const [avatar, setAvatar] = useState('');
@@ -39,10 +53,10 @@ export default function PoolRoyaleLobby() {
   const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
   const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
   const [aiFlagIndex, setAiFlagIndex] = useState(null);
-  const [variant, setVariant] = useState('uk');
+  const [variant, setVariant] = useState(defaultVariantValue);
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
-  const [trainingVariant, setTrainingVariant] = useState('uk');
+  const [trainingVariant, setTrainingVariant] = useState(defaultVariantValue);
   const [trainingMode, setTrainingMode] = useState('solo');
   const [trainingRulesEnabled, setTrainingRulesEnabled] = useState(true);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
@@ -61,6 +75,9 @@ export default function PoolRoyaleLobby() {
   const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
 
+  const playerFlagStorageKey = `${gameId}PlayerFlag`;
+  const aiFlagStorageKey = `${gameId}AiFlag`;
+
   useEffect(() => {
     try {
       const saved = loadAvatar();
@@ -70,7 +87,7 @@ export default function PoolRoyaleLobby() {
 
   useEffect(() => {
     try {
-      const stored = window.localStorage?.getItem(PLAYER_FLAG_STORAGE_KEY);
+      const stored = window.localStorage?.getItem(playerFlagStorageKey);
       const idx = FLAG_EMOJIS.indexOf(stored);
       if (idx >= 0) setPlayerFlagIndex(idx);
     } catch {}
@@ -78,7 +95,7 @@ export default function PoolRoyaleLobby() {
 
   useEffect(() => {
     try {
-      const stored = window.localStorage?.getItem(AI_FLAG_STORAGE_KEY);
+      const stored = window.localStorage?.getItem(aiFlagStorageKey);
       const idx = FLAG_EMOJIS.indexOf(stored);
       if (idx >= 0) setAiFlagIndex(idx);
     } catch {}
@@ -103,7 +120,7 @@ export default function PoolRoyaleLobby() {
         tgId = getTelegramId();
         if (mode !== 'online') {
           await addTransaction(tgId, -stake.amount, 'stake', {
-            game: 'poolroyale',
+            game: gameId,
             players: playType === 'tournament' ? players : 2,
             accountId
           });
@@ -132,7 +149,7 @@ export default function PoolRoyaleLobby() {
         'seatTable',
         {
           accountId,
-          gameType: 'poolroyale',
+          gameType: onlineGameType,
           stake: stake.amount,
           maxPlayers: 2,
           token: stake.token,
@@ -194,11 +211,11 @@ export default function PoolRoyaleLobby() {
     if (initData) params.set('init', encodeURIComponent(initData));
 
     if (playType === 'tournament') {
-      window.location.href = `/pool-royale-bracket.html?${params.toString()}`;
+      window.location.href = `${bracketPage}?${params.toString()}`;
       return;
     }
 
-    navigate(`/games/poolroyale?${params.toString()}`);
+    navigate(`${gamePath}?${params.toString()}`);
   };
 
   useEffect(() => {
@@ -273,7 +290,7 @@ export default function PoolRoyaleLobby() {
         const accountId = accountIdRef.current;
         try {
           await addTransaction(tgId, -stake.amount, 'stake', {
-            game: 'poolroyale-online',
+            game: onlineGameKey,
             players: 2,
             accountId,
             tableId
@@ -296,7 +313,7 @@ export default function PoolRoyaleLobby() {
       if (tableSize) params.set('tableSize', tableSize);
       const name = getTelegramFirstName();
       if (name) params.set('name', name);
-      navigate(`/games/poolroyale?${params.toString()}`);
+      navigate(`${gamePath}?${params.toString()}`);
     };
 
     socket.on('lobbyUpdate', onUpdate);
@@ -348,7 +365,7 @@ export default function PoolRoyaleLobby() {
           {winnerParam === '1' ? 'You won!' : 'CPU won!'}
         </div>
       )}
-      <h2 className="text-xl font-bold text-center">Pool Royale Lobby</h2>
+      <h2 className="text-xl font-bold text-center">{gameName} Lobby</h2>
       <div className="space-y-2">
         <h3 className="font-semibold">Type</h3>
         <div className="flex gap-2">
@@ -439,17 +456,15 @@ export default function PoolRoyaleLobby() {
           <div className="space-y-2">
             <h3 className="font-semibold">Variant</h3>
             <div className="flex gap-2">
-              {[{ id: 'uk', label: '8 Pool UK' }, { id: 'american', label: 'American' }, { id: '9ball', label: '9-Ball' }].map(
-                ({ id, label }) => (
-                  <button
-                    key={id}
-                    onClick={() => setTrainingVariant(id)}
-                    className={`lobby-tile ${trainingVariant === id ? 'lobby-selected' : ''}`}
-                  >
-                    {label}
-                  </button>
-                )
-              )}
+              {trainingOptions.map(({ id, label }) => (
+                <button
+                  key={id}
+                  onClick={() => setTrainingVariant(id)}
+                  className={`lobby-tile ${trainingVariant === id ? 'lobby-selected' : ''}`}
+                >
+                  {label}
+                </button>
+              ))}
             </div>
           </div>
         </div>
@@ -458,11 +473,7 @@ export default function PoolRoyaleLobby() {
         <div className="space-y-2">
           <h3 className="font-semibold">Variant</h3>
           <div className="flex gap-2">
-            {[
-              { id: 'uk', label: '8 Pool UK' },
-              { id: 'american', label: 'American' },
-              { id: '9ball', label: '9-Ball' }
-            ].map(({ id, label }) => (
+            {resolvedVariantOptions.map(({ id, label }) => (
               <button
                 key={id}
                 onClick={() => setVariant(id)}
@@ -548,7 +559,7 @@ export default function PoolRoyaleLobby() {
               <h3 className="font-semibold">Online Arena</h3>
               <p className="text-sm text-subtext">
                 We match players by TPC account number, stake ({stake.amount} {stake.token}),
-                and Pool Royale game type.
+                and {gameName} game type.
               </p>
             </div>
             <div className="text-xs text-subtext">{onlinePlayers.length} online</div>
@@ -616,7 +627,7 @@ export default function PoolRoyaleLobby() {
           const idx = indices?.[0] ?? null;
           setPlayerFlagIndex(idx);
           try {
-            if (idx != null) window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            if (idx != null) window.localStorage?.setItem(playerFlagStorageKey, FLAG_EMOJIS[idx]);
           } catch {}
         }}
         onClose={() => setShowFlagPicker(false)}
@@ -630,7 +641,7 @@ export default function PoolRoyaleLobby() {
           const idx = indices?.[0] ?? null;
           setAiFlagIndex(idx);
           try {
-            if (idx != null) window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            if (idx != null) window.localStorage?.setItem(aiFlagStorageKey, FLAG_EMOJIS[idx]);
           } catch {}
         }}
         onClose={() => setShowAiFlagPicker(false)}

--- a/webapp/src/pages/Games/PoolUk.jsx
+++ b/webapp/src/pages/Games/PoolUk.jsx
@@ -1,0 +1,5 @@
+import PoolRoyale from './PoolRoyale.jsx';
+
+export default function PoolUk() {
+  return <PoolRoyale gameId="pooluk" gameName="8 Pool UK" lobbyPath="/games/pooluk/lobby" />;
+}

--- a/webapp/src/pages/Games/PoolUkLobby.jsx
+++ b/webapp/src/pages/Games/PoolUkLobby.jsx
@@ -1,0 +1,14 @@
+import PoolRoyaleLobby from './PoolRoyaleLobby.jsx';
+
+export default function PoolUkLobby() {
+  return (
+    <PoolRoyaleLobby
+      gameId="pooluk"
+      gameName="8 Pool UK"
+      variantOptions={[{ id: 'uk', label: '8 Pool UK' }]}
+      defaultVariant="uk"
+      gamePath="/games/pooluk"
+      onlineGameType="pooluk"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add dedicated 8 Pool UK lobby and gameplay routes while reusing the existing billiards experience
- limit Pool Royale lobby variants to American and 9-Ball and update shared UI invite lists and mappings
- surface the new game across home cards, hallway, invites, and transaction views

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69373647c9d08329810045a5c75bd109)