### PR TITLE
Align Chess Battle Royal palette with GLTF presets

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -271,64 +271,46 @@ const CHECKMATE_SOUND_URL =
 
 const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
   {
-    id: 'beautifulGameAuroraMetal',
-    name: 'Aurora Metal',
-    piece: { white: '#dce6ff', black: '#111827', accent: '#7dd3fc' },
-    board: { light: '#d9f5ff', dark: '#0b1220', accent: '#7dd3fc' }
+    id: 'beautifulGameClassic',
+    name: 'Classic',
+    piece: { white: '#ffffff', black: '#ffffff', accent: '#7dd3fc' },
+    board: { light: '#eee8d5', dark: '#2b2f36', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameObsidianGold',
-    name: 'Obsidian / Gold',
-    piece: { white: '#f8ead4', black: '#141414', accent: '#d4a017' },
-    board: { light: '#f4e8d2', dark: '#1e1e1e', accent: '#d4a017' }
+    id: 'beautifulGameObsidian',
+    name: 'Obsidian',
+    piece: { white: '#111827', black: '#111827', accent: '#111827' },
+    board: { light: '#e5e7eb', dark: '#111827', accent: '#111827' }
   },
   {
-    id: 'beautifulGameGlacierMint',
-    name: 'Glacier / Mint',
-    piece: { white: '#ecfeff', black: '#0f172a', accent: '#34d399' },
-    board: { light: '#d1fae5', dark: '#0f172a', accent: '#34d399' }
+    id: 'beautifulGameAmber',
+    name: 'Amber',
+    piece: { white: '#f59e0b', black: '#f59e0b', accent: '#f59e0b' },
+    board: { light: '#fde68a', dark: '#1f2937', accent: '#f59e0b' }
   },
   {
-    id: 'beautifulGameSakuraSlate',
-    name: 'Sakura / Slate',
-    piece: { white: '#ffe4ec', black: '#2b3040', accent: '#fb7185' },
-    board: { light: '#ffd8e3', dark: '#1f2635', accent: '#fb7185' }
+    id: 'beautifulGameMint',
+    name: 'Mint',
+    piece: { white: '#10b981', black: '#10b981', accent: '#10b981' },
+    board: { light: '#a7f3d0', dark: '#065f46', accent: '#10b981' }
   },
   {
-    id: 'beautifulGameVoltTeal',
-    name: 'Volt / Teal',
-    piece: { white: '#faffb5', black: '#0f766e', accent: '#22d3ee' },
-    board: { light: '#e8ffb5', dark: '#0b3b3c', accent: '#22d3ee' }
+    id: 'beautifulGameCobalt',
+    name: 'Cobalt',
+    piece: { white: '#3b82f6', black: '#3b82f6', accent: '#3b82f6' },
+    board: { light: '#93c5fd', dark: '#1e293b', accent: '#3b82f6' }
   },
   {
-    id: 'beautifulGameCopperIvory',
-    name: 'Copper / Ivory',
-    piece: { white: '#f5f0e5', black: '#5a2c1f', accent: '#e38b29' },
-    board: { light: '#f4ede1', dark: '#3b241a', accent: '#e38b29' }
+    id: 'beautifulGameCrimson',
+    name: 'Crimson',
+    piece: { white: '#ef4444', black: '#ef4444', accent: '#ef4444' },
+    board: { light: '#fbcfe8', dark: '#312e81', accent: '#ef4444' }
   },
   {
-    id: 'beautifulGameNoirNeon',
-    name: 'Noir / Neon',
-    piece: { white: '#e5e7eb', black: '#0a0d14', accent: '#06f0ff' },
-    board: { light: '#c7d2fe', dark: '#0a0d14', accent: '#06f0ff' }
-  },
-  {
-    id: 'beautifulGameCinderRose',
-    name: 'Cinder / Rose',
-    piece: { white: '#f5d0c5', black: '#1f1b29', accent: '#f43f5e' },
-    board: { light: '#f8d7cc', dark: '#1b1524', accent: '#f43f5e' }
-  },
-  {
-    id: 'beautifulGameHarborFog',
-    name: 'Harbor Fog',
-    piece: { white: '#e2e8f0', black: '#1e293b', accent: '#38bdf8' },
-    board: { light: '#dbeafe', dark: '#0b1220', accent: '#38bdf8' }
-  },
-  {
-    id: 'beautifulGameDesertStorm',
-    name: 'Desert Storm',
-    piece: { white: '#fef3c7', black: '#4b3421', accent: '#fbbf24' },
-    board: { light: '#fde68a', dark: '#2d1f12', accent: '#fbbf24' }
+    id: 'beautifulGameViolet',
+    name: 'Violet',
+    piece: { white: '#8b5cf6', black: '#8b5cf6', accent: '#8b5cf6' },
+    board: { light: '#99f6e4', dark: '#0f172a', accent: '#8b5cf6' }
   }
 ]);
 
@@ -336,21 +318,20 @@ const BEAUTIFUL_GAME_THEME_NAMES = BEAUTIFUL_GAME_THEME_CONFIGS.map((config) => 
 
 const BEAUTIFUL_GAME_THEME = Object.freeze(
   buildBoardTheme({
-    ...(BOARD_COLOR_BASE_OPTIONS.find((option) => option.id === 'slateJade') ?? {}),
     id: 'beautifulGameAuthenticBoard',
-    label: 'Aurora Metal',
+    label: 'Classic',
     light: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.light,
     dark: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.dark,
-    frameLight: '#c5d8ff',
-    frameDark: '#141b2f',
+    frameLight: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.light,
+    frameDark: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.dark,
     accent: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.accent ?? '#7dd3fc',
-    highlight: '#7ef9a1',
-    capture: '#ff8e6e',
-    surfaceRoughness: 0.62,
+    highlight: '#6ee7b7',
+    capture: '#ef4444',
+    surfaceRoughness: 0.6,
     surfaceMetalness: 0.12,
-    frameRoughness: 0.74,
-    frameMetalness: 0.14,
-    preserveOriginalMaterials: true
+    frameRoughness: 0.7,
+    frameMetalness: 0.16,
+    preserveOriginalMaterials: false
   })
 );
 
@@ -362,8 +343,8 @@ const BEAUTIFUL_GAME_BOARD_OPTIONS = Object.freeze(
       label: config.name,
       light: config.board?.light ?? BEAUTIFUL_GAME_THEME.light,
       dark: config.board?.dark ?? BEAUTIFUL_GAME_THEME.dark,
-      frameLight: BEAUTIFUL_GAME_THEME.frameLight,
-      frameDark: BEAUTIFUL_GAME_THEME.frameDark,
+      frameLight: config.board?.light ?? BEAUTIFUL_GAME_THEME.frameLight,
+      frameDark: config.board?.dark ?? BEAUTIFUL_GAME_THEME.frameDark,
       surfaceRoughness: BEAUTIFUL_GAME_THEME.surfaceRoughness,
       surfaceMetalness: BEAUTIFUL_GAME_THEME.surfaceMetalness,
       frameRoughness: BEAUTIFUL_GAME_THEME.frameRoughness,
@@ -431,8 +412,8 @@ const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
   blackAccent: '#7dd3fc'
 });
 
-const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGameAuroraMetal';
-const BEAUTIFUL_GAME_SET_ID = 'beautifulGameAuroraMetalSet';
+const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGameClassic';
+const BEAUTIFUL_GAME_SET_ID = 'beautifulGameClassicSet';
 
 const BASE_PIECE_STYLE = BEAUTIFUL_GAME_PIECE_STYLE;
 
@@ -814,8 +795,8 @@ const DEFAULT_APPEARANCE = {
   chairColor: 0,
   tableShape: 0,
   boardColor: 0,
-  whitePieceStyle: Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX),
-  blackPieceStyle: Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX),
+  whitePieceStyle: 0,
+  blackPieceStyle: 1,
   headStyle: 0
 };
 const APPEARANCE_STORAGE_KEY = 'chessBattleRoyalAppearance';


### PR DESCRIPTION
## Summary
- Replace chess board and piece palettes with the 7 GLTF-aligned color presets
- Default to Classic board, white P1 pieces, and dark P2 pieces for startup appearance
- Keep board frame tinting aligned with each preset and update identifiers for the new palette

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937ac528a308329b2ae368eab7db844)