### PR TITLE
Align chess palette with GLTF set

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -271,64 +271,46 @@ const CHECKMATE_SOUND_URL =
 
 const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
   {
-    id: 'beautifulGameAuroraMetal',
-    name: 'Aurora Metal',
-    piece: { white: '#dce6ff', black: '#111827', accent: '#7dd3fc' },
-    board: { light: '#d9f5ff', dark: '#0b1220', accent: '#7dd3fc' }
+    id: 'classicBoard',
+    name: 'Classic',
+    piece: { white: '#ffffff', black: '#ffffff', accent: '#7dd3fc' },
+    board: { light: '#EEE8D5', dark: '#2B2F36', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameObsidianGold',
-    name: 'Obsidian / Gold',
-    piece: { white: '#f8ead4', black: '#141414', accent: '#d4a017' },
-    board: { light: '#f4e8d2', dark: '#1e1e1e', accent: '#d4a017' }
+    id: 'monoBoard',
+    name: 'Mono',
+    piece: { white: '#111827', black: '#111827', accent: '#7dd3fc' },
+    board: { light: '#E5E7EB', dark: '#111827', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameGlacierMint',
-    name: 'Glacier / Mint',
-    piece: { white: '#ecfeff', black: '#0f172a', accent: '#34d399' },
-    board: { light: '#d1fae5', dark: '#0f172a', accent: '#34d399' }
+    id: 'blueBoard',
+    name: 'Blue',
+    piece: { white: '#f59e0b', black: '#f59e0b', accent: '#7dd3fc' },
+    board: { light: '#93C5FD', dark: '#1E293B', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameSakuraSlate',
-    name: 'Sakura / Slate',
-    piece: { white: '#ffe4ec', black: '#2b3040', accent: '#fb7185' },
-    board: { light: '#ffd8e3', dark: '#1f2635', accent: '#fb7185' }
+    id: 'amberBoard',
+    name: 'Amber',
+    piece: { white: '#10b981', black: '#10b981', accent: '#7dd3fc' },
+    board: { light: '#FDE68A', dark: '#1F2937', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameVoltTeal',
-    name: 'Volt / Teal',
-    piece: { white: '#faffb5', black: '#0f766e', accent: '#22d3ee' },
-    board: { light: '#e8ffb5', dark: '#0b3b3c', accent: '#22d3ee' }
+    id: 'mintBoard',
+    name: 'Mint',
+    piece: { white: '#3b82f6', black: '#3b82f6', accent: '#7dd3fc' },
+    board: { light: '#A7F3D0', dark: '#065F46', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameCopperIvory',
-    name: 'Copper / Ivory',
-    piece: { white: '#f5f0e5', black: '#5a2c1f', accent: '#e38b29' },
-    board: { light: '#f4ede1', dark: '#3b241a', accent: '#e38b29' }
+    id: 'pinkBoard',
+    name: 'Pink',
+    piece: { white: '#ef4444', black: '#ef4444', accent: '#7dd3fc' },
+    board: { light: '#FBCFE8', dark: '#312E81', accent: '#7dd3fc' }
   },
   {
-    id: 'beautifulGameNoirNeon',
-    name: 'Noir / Neon',
-    piece: { white: '#e5e7eb', black: '#0a0d14', accent: '#06f0ff' },
-    board: { light: '#c7d2fe', dark: '#0a0d14', accent: '#06f0ff' }
-  },
-  {
-    id: 'beautifulGameCinderRose',
-    name: 'Cinder / Rose',
-    piece: { white: '#f5d0c5', black: '#1f1b29', accent: '#f43f5e' },
-    board: { light: '#f8d7cc', dark: '#1b1524', accent: '#f43f5e' }
-  },
-  {
-    id: 'beautifulGameHarborFog',
-    name: 'Harbor Fog',
-    piece: { white: '#e2e8f0', black: '#1e293b', accent: '#38bdf8' },
-    board: { light: '#dbeafe', dark: '#0b1220', accent: '#38bdf8' }
-  },
-  {
-    id: 'beautifulGameDesertStorm',
-    name: 'Desert Storm',
-    piece: { white: '#fef3c7', black: '#4b3421', accent: '#fbbf24' },
-    board: { light: '#fde68a', dark: '#2d1f12', accent: '#fbbf24' }
+    id: 'tealBoard',
+    name: 'Teal',
+    piece: { white: '#8b5cf6', black: '#8b5cf6', accent: '#7dd3fc' },
+    board: { light: '#99F6E4', dark: '#0F172A', accent: '#7dd3fc' }
   }
 ]);
 
@@ -431,7 +413,7 @@ const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
   blackAccent: '#7dd3fc'
 });
 
-const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGameAuroraMetal';
+const BEAUTIFUL_GAME_AUTHENTIC_ID = 'classicBoard';
 const BEAUTIFUL_GAME_SET_ID = 'beautifulGameAuroraMetalSet';
 
 const BASE_PIECE_STYLE = BEAUTIFUL_GAME_PIECE_STYLE;


### PR DESCRIPTION
## Summary
- replace chess board and piece palette options with seven presets that mirror the GLTF material set
- default the chess setup to the classic GLTF colors to keep materials consistent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937ac528a308329b2ae368eab7db844)