### PR TITLE
Add Snooker Club lobby and rules scaffolding

### DIFF
--- a/src/rules/SnookerClubRules.ts
+++ b/src/rules/SnookerClubRules.ts
@@ -1,0 +1,249 @@
+import { Ball, BallColor, FrameState, Player, ShotContext, ShotEvent } from '../types';
+
+const BALL_VALUES: Record<BallColor, number> = Object.freeze({
+  RED: 1,
+  YELLOW: 2,
+  GREEN: 3,
+  BROWN: 4,
+  BLUE: 5,
+  PINK: 6,
+  BLACK: 7,
+  CUE: 0
+});
+
+const COLOR_ORDER: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
+
+export type SerializedSnookerState = {
+  balls: Ball[];
+  activePlayer: 'A' | 'B';
+  players: { A: Player; B: Player };
+  currentBreak: number;
+  phase: FrameState['phase'];
+  redsRemaining: number;
+  colorOnAfterRed: boolean;
+  ballOn: (BallColor | string)[];
+  frameOver: boolean;
+  winner: 'A' | 'B' | 'TIE' | null;
+  foul?: FrameState['foul'];
+};
+
+function basePlayers(playerA: string, playerB: string): { A: Player; B: Player } {
+  return {
+    A: { id: 'A', name: playerA, score: 0, highestBreak: 0 },
+    B: { id: 'B', name: playerB, score: 0, highestBreak: 0 }
+  };
+}
+
+function createBalls(): Ball[] {
+  const reds: Ball[] = Array.from({ length: 15 }).map((_, idx) => ({
+    id: `R${idx + 1}`,
+    color: 'RED',
+    onTable: true,
+    potted: false
+  }));
+
+  const colours: Ball[] = [
+    { id: 'Y', color: 'YELLOW', onTable: true, potted: false },
+    { id: 'G', color: 'GREEN', onTable: true, potted: false },
+    { id: 'BR', color: 'BROWN', onTable: true, potted: false },
+    { id: 'BL', color: 'BLUE', onTable: true, potted: false },
+    { id: 'P', color: 'PINK', onTable: true, potted: false },
+    { id: 'BK', color: 'BLACK', onTable: true, potted: false },
+    { id: 'CUE', color: 'CUE', onTable: true, potted: false }
+  ];
+
+  return [...reds, ...colours];
+}
+
+export function createSnookerFrame(playerA: string, playerB: string): FrameState {
+  return {
+    balls: createBalls(),
+    activePlayer: 'A',
+    players: basePlayers(playerA, playerB),
+    currentBreak: 0,
+    phase: 'REDS_AND_COLORS',
+    redsRemaining: 15,
+    colorOnAfterRed: false,
+    ballOn: ['RED'],
+    frameOver: false
+  };
+}
+
+function ballValue(color: BallColor): number {
+  return BALL_VALUES[color] ?? 0;
+}
+
+function ballsOn(state: FrameState): (BallColor | string)[] {
+  if (state.phase === 'COLORS_ORDER') {
+    const next = COLOR_ORDER.find((color) => state.balls.some((b) => b.color === color && b.onTable));
+    return next ? [next] : [];
+  }
+
+  if (state.colorOnAfterRed) {
+    return COLOR_ORDER.filter((color) => state.balls.some((b) => b.color === color && b.onTable));
+  }
+
+  return ['RED'];
+}
+
+function markPotted(state: FrameState, colour: BallColor, ballId?: string | number | null) {
+  const target = state.balls.find(
+    (b) => b.color === colour && !b.potted && b.onTable && (!ballId || b.id === ballId)
+  );
+  if (target) {
+    target.onTable = false;
+    target.potted = true;
+    if (colour === 'RED') {
+      state.redsRemaining = Math.max(0, state.redsRemaining - 1);
+    }
+  }
+}
+
+function respotColours(state: FrameState) {
+  for (const ball of state.balls) {
+    if (ball.color === 'RED' || ball.color === 'CUE') continue;
+    if (!ball.potted) continue;
+    ball.onTable = true;
+    ball.potted = false;
+  }
+}
+
+function switchPlayer(state: FrameState) {
+  state.activePlayer = state.activePlayer === 'A' ? 'B' : 'A';
+  state.currentBreak = 0;
+}
+
+function awardPoints(state: FrameState, points: number) {
+  const player = state.players[state.activePlayer];
+  player.score += points;
+  state.currentBreak = (state.currentBreak || 0) + points;
+  if (!player.highestBreak || state.currentBreak > player.highestBreak) {
+    player.highestBreak = state.currentBreak;
+  }
+}
+
+function registerFoul(state: FrameState, points: number, reason: string) {
+  const opponent = state.activePlayer === 'A' ? 'B' : 'A';
+  const value = Math.max(4, points);
+  state.players[opponent].score += value;
+  state.foul = { points: value, reason };
+  switchPlayer(state);
+}
+
+function validateFirstContact(event: ShotEvent | undefined, legalBalls: (BallColor | string)[]): string | null {
+  if (!event || event.type !== 'HIT') return null;
+  const hit = typeof event.firstContact === 'string' ? event.firstContact.toUpperCase() : '';
+  if (!hit) return null;
+  if (!legalBalls.includes(hit)) return hit;
+  return null;
+}
+
+function updatePhaseAfterPot(state: FrameState) {
+  if (state.phase === 'REDS_AND_COLORS' && state.redsRemaining <= 0 && !state.colorOnAfterRed) {
+    state.phase = 'COLORS_ORDER';
+  }
+}
+
+export function applySnookerEvents(events: ShotEvent[], ctx: ShotContext, state: FrameState): FrameState {
+  if (state.frameOver) return state;
+  const legalBalls = ballsOn(state);
+  const wrongContact = validateFirstContact(events.find((e) => e.type === 'HIT'), legalBalls);
+
+  let foulPoints = 0;
+  let foulReason: string | null = wrongContact ? `Hit wrong ball: ${wrongContact}` : null;
+  let pottedAny = false;
+
+  for (const evt of events) {
+    if (evt.type === 'FOUL') {
+      foulPoints = Math.max(foulPoints, evt.ball ? ballValue(evt.ball as BallColor) : 4);
+      foulReason = evt.reason || 'Foul';
+      continue;
+    }
+    if (evt.type !== 'POTTED') continue;
+
+    const color = typeof evt.ball === 'string' ? (evt.ball.toUpperCase() as BallColor) : null;
+    if (!color) continue;
+    const isLegal = legalBalls.includes(color);
+    if (!isLegal) {
+      foulPoints = Math.max(foulPoints, ballValue(color));
+      foulReason = `Potted wrong ball (${color})`;
+      continue;
+    }
+
+    pottedAny = true;
+    awardPoints(state, ballValue(color));
+    markPotted(state, color, evt.ballId);
+
+    if (state.phase === 'REDS_AND_COLORS') {
+      if (color === 'RED') {
+        state.colorOnAfterRed = true;
+      } else {
+        state.colorOnAfterRed = false;
+        respotColours(state);
+      }
+    } else if (state.phase === 'COLORS_ORDER') {
+      // Colours stay potted in the final phase.
+    }
+
+    updatePhaseAfterPot(state);
+  }
+
+  if (ctx?.cueBallPotted) {
+    foulPoints = Math.max(foulPoints, 4);
+    foulReason = foulReason || 'Cue ball potted';
+  }
+
+  if (foulPoints > 0) {
+    registerFoul(state, foulPoints, foulReason || 'Foul');
+    return state;
+  }
+
+  state.ballOn = ballsOn(state);
+
+  if (!pottedAny || ctx?.placedFromHand) {
+    switchPlayer(state);
+  }
+
+  const coloursCleared = COLOR_ORDER.every(
+    (color) => !state.balls.some((ball) => ball.color === color && ball.onTable)
+  );
+  if (state.phase === 'COLORS_ORDER' && coloursCleared) {
+    state.frameOver = true;
+    const { A, B } = state.players;
+    state.winner = A.score === B.score ? 'TIE' : A.score > B.score ? 'A' : 'B';
+  }
+
+  return state;
+}
+
+export function serializeSnookerState(state: FrameState): SerializedSnookerState {
+  return {
+    balls: state.balls.map((b) => ({ ...b })),
+    activePlayer: state.activePlayer,
+    players: { A: { ...state.players.A }, B: { ...state.players.B } },
+    currentBreak: state.currentBreak || 0,
+    phase: state.phase,
+    redsRemaining: state.redsRemaining,
+    colorOnAfterRed: !!state.colorOnAfterRed,
+    ballOn: [...(state.ballOn || [])],
+    frameOver: state.frameOver,
+    winner: (state.winner as SerializedSnookerState['winner']) || null,
+    foul: state.foul ? { ...state.foul } : undefined
+  };
+}
+
+export function applySerializedSnookerState(snapshot: SerializedSnookerState): FrameState {
+  return {
+    balls: snapshot.balls.map((b) => ({ ...b })),
+    activePlayer: snapshot.activePlayer,
+    players: { A: { ...snapshot.players.A }, B: { ...snapshot.players.B } },
+    currentBreak: snapshot.currentBreak,
+    phase: snapshot.phase,
+    redsRemaining: snapshot.redsRemaining,
+    colorOnAfterRed: snapshot.colorOnAfterRed,
+    ballOn: [...snapshot.ballOn],
+    frameOver: snapshot.frameOver,
+    winner: snapshot.winner ?? undefined,
+    foul: snapshot.foul
+  };
+}

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -46,6 +46,8 @@ import BlackJack from './pages/Games/BlackJack.jsx';
 import BlackJackLobby from './pages/Games/BlackJackLobby.jsx';
 import PoolRoyale from './pages/Games/PoolRoyale.jsx';
 import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
+import SnookerClub from './pages/Games/SnookerClub.jsx';
+import SnookerClubLobby from './pages/Games/SnookerClubLobby.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -131,6 +133,11 @@ export default function App() {
               element={<PoolRoyaleLobby />}
             />
             <Route path="/games/poolroyale" element={<PoolRoyale />} />
+            <Route
+              path="/games/snookerclub/lobby"
+              element={<SnookerClubLobby />}
+            />
+            <Route path="/games/snookerclub" element={<SnookerClub />} />
             <Route
               path="/games/pollroyale/lobby"
               element={<Navigate to="/games/poolroyale/lobby" replace />}

--- a/webapp/src/config/snookerTables.js
+++ b/webapp/src/config/snookerTables.js
@@ -1,0 +1,85 @@
+const BASE_TABLE_SCALE = 1.64;
+const BASE_TABLE_MOBILE_SCALE = 1.78;
+const BASE_TABLE_COMPACT_SCALE = 1.56;
+const BASE_PLAYFIELD_WIDTH_MM = 3556; // WPA full-size snooker playfield width (approx. 11'8.5")
+
+const TABLE_PHYSICAL_SPECS = Object.freeze({
+  '12ft': {
+    id: '12ft',
+    label: '12 ft (Championship)',
+    playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }),
+    ballDiameterMm: 52.5,
+    pocketMouthMm: Object.freeze({
+      corner: 86,
+      side: 94
+    }),
+    cushionCutAngleDeg: 35,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
+  },
+  '10ft': {
+    id: '10ft',
+    label: '10 ft',
+    playfield: Object.freeze({ widthMm: 2946, heightMm: 1473 }),
+    ballDiameterMm: 52.5,
+    pocketMouthMm: Object.freeze({
+      corner: 86,
+      side: 94
+    }),
+    cushionCutAngleDeg: 35,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
+    scaleOverrides: Object.freeze({
+      scale: 1.46,
+      mobileScale: 1.6,
+      compactScale: 1.42
+    })
+  }
+});
+
+function deriveScale(playfieldWidthMm, baseScale = BASE_TABLE_SCALE) {
+  if (!Number.isFinite(playfieldWidthMm) || playfieldWidthMm <= 0) {
+    return baseScale;
+  }
+  return baseScale * (playfieldWidthMm / BASE_PLAYFIELD_WIDTH_MM);
+}
+
+function deriveMobileScale(baseScale, mobileScale = BASE_TABLE_MOBILE_SCALE) {
+  const scaled = baseScale * 1.02;
+  const clampTarget = Math.max(baseScale, mobileScale);
+  return Math.min(clampTarget, scaled);
+}
+
+function deriveCompactScale(baseScale, compactScale = BASE_TABLE_COMPACT_SCALE) {
+  const scaled = baseScale * 0.94;
+  return Math.max(1.1, Math.min(compactScale, scaled));
+}
+
+export const SNOOKER_TABLE_SIZE_OPTIONS = Object.freeze(
+  Object.keys(TABLE_PHYSICAL_SPECS).reduce((acc, key) => {
+    const spec = TABLE_PHYSICAL_SPECS[key];
+    const overrides = spec.scaleOverrides || {};
+    const baseScale = overrides.scale ?? deriveScale(spec.playfield.widthMm);
+    const mobileScale = overrides.mobileScale ?? deriveMobileScale(baseScale);
+    const compactScale = overrides.compactScale ?? deriveCompactScale(baseScale);
+    acc[key] = Object.freeze({
+      ...spec,
+      scale: Number(baseScale.toFixed(3)),
+      mobileScale: Number(mobileScale.toFixed(3)),
+      compactScale: Number(compactScale.toFixed(3))
+    });
+    return acc;
+  }, {})
+);
+
+export const DEFAULT_SNOOKER_TABLE_SIZE_ID = '12ft';
+
+export function resolveSnookerTableSize(sizeId) {
+  const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';
+  return (
+    SNOOKER_TABLE_SIZE_OPTIONS[key] ||
+    SNOOKER_TABLE_SIZE_OPTIONS[DEFAULT_SNOOKER_TABLE_SIZE_ID]
+  );
+}
+
+export const SNOOKER_TABLE_SIZE_LIST = Object.freeze(
+  Object.values(SNOOKER_TABLE_SIZE_OPTIONS).map(({ id, label }) => ({ id, label }))
+);

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -8,6 +8,7 @@ const gamesCatalog = [
   { name: "Texas Hold'em", route: '/games/texasholdem/lobby' },
   { name: 'Domino Royal 3D', route: '/games/domino-royal/lobby' },
   { name: 'Black Jack Multiplayer', route: '/games/blackjack/lobby' },
+  { name: 'Snooker Club', route: '/games/snookerclub/lobby' },
   { name: 'Pool Royale', route: '/games/poolroyale/lobby' },
   { name: 'Goal Rush', route: '/games/goalrush/lobby' },
   { name: 'Air Hockey', route: '/games/airhockey/lobby' },

--- a/webapp/src/pages/Games/SnookerClub.jsx
+++ b/webapp/src/pages/Games/SnookerClub.jsx
@@ -1,0 +1,161 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  applySerializedSnookerState,
+  applySnookerEvents,
+  createSnookerFrame,
+  serializeSnookerState
+} from '../../../src/rules/SnookerClubRules.ts';
+import { resolveSnookerTableSize } from '../../config/snookerTables.js';
+import { getTelegramId, getTelegramUsername } from '../../utils/telegram.js';
+
+function SnookerFrameCard({ frame }) {
+  const ballsOn = (frame.ballOn || []).join(', ') || 'Open';
+  return (
+    <div className="rounded-xl border border-border bg-surface p-4 shadow space-y-2">
+      <div className="flex justify-between text-sm text-subtext">
+        <span>Active: {frame.activePlayer}</span>
+        <span>Phase: {frame.phase}</span>
+      </div>
+      <div className="flex justify-between text-sm text-subtext">
+        <span>Reds left: {frame.redsRemaining}</span>
+        <span>Ball on: {ballsOn}</span>
+      </div>
+      <div className="grid grid-cols-2 gap-2 text-sm">
+        <div className="rounded-lg border border-border p-2">
+          <p className="font-semibold">{frame.players.A.name}</p>
+          <p>Score: {frame.players.A.score}</p>
+          <p>Break: {frame.activePlayer === 'A' ? frame.currentBreak || 0 : 0}</p>
+        </div>
+        <div className="rounded-lg border border-border p-2">
+          <p className="font-semibold">{frame.players.B.name}</p>
+          <p>Score: {frame.players.B.score}</p>
+          <p>Break: {frame.activePlayer === 'B' ? frame.currentBreak || 0 : 0}</p>
+        </div>
+      </div>
+      {frame.foul && (
+        <div className="rounded-lg border border-red-500 text-red-500 p-2 text-sm">
+          Foul: {frame.foul.reason} ({frame.foul.points} pts)
+        </div>
+      )}
+      {frame.frameOver && frame.winner && (
+        <div className="rounded-lg border border-primary text-primary p-2 text-sm">
+          Frame winner: {frame.winner}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function SnookerClub() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const params = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const tableSize = resolveSnookerTableSize(params.get('tableSize'));
+  const playerName = useMemo(() => {
+    const name = params.get('name');
+    return name || getTelegramUsername() || getTelegramId() || 'Player';
+  }, [params]);
+
+  const [frame, setFrame] = useState(() => createSnookerFrame(playerName, 'Opponent'));
+  const [history, setHistory] = useState(() => [serializeSnookerState(frame)]);
+
+  useEffect(() => {
+    const restored = params.get('state');
+    if (restored) {
+      try {
+        const snapshot = JSON.parse(decodeURIComponent(restored));
+        setFrame(applySerializedSnookerState(snapshot));
+      } catch {}
+    }
+  }, [params]);
+
+  const recordShot = (events) => {
+    const updated = applySnookerEvents(events, { mode: params.get('mode') || 'ai' }, { ...frame });
+    const serialized = serializeSnookerState(updated);
+    setFrame({ ...updated });
+    setHistory((h) => [...h, serialized].slice(-8));
+  };
+
+  const restart = () => {
+    const fresh = createSnookerFrame(playerName, 'Opponent');
+    setFrame(fresh);
+    setHistory([serializeSnookerState(fresh)]);
+    navigate(`/games/snookerclub?tableSize=${tableSize.id}`);
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-text">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Snooker Club</h1>
+          <p className="text-sm text-subtext">
+            Championship cloth and chrome from Pool Royale, dedicated snooker markings, and AI-ready match flow.
+          </p>
+        </div>
+        <div className="rounded-lg border border-border px-3 py-2 text-sm text-subtext">
+          <p>Table: {tableSize.label}</p>
+          <p>Ball diameter: {tableSize.ballDiameterMm} mm</p>
+        </div>
+      </div>
+
+      <SnookerFrameCard frame={frame} />
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <button
+          type="button"
+          className="rounded-lg border border-border bg-surface px-3 py-2 text-sm hover:border-primary"
+          onClick={() => recordShot([{ type: 'POTTED', ball: 'RED', pocket: 'TM' }])}
+        >
+          Pot Red
+        </button>
+        <button
+          type="button"
+          className="rounded-lg border border-border bg-surface px-3 py-2 text-sm hover:border-primary"
+          onClick={() =>
+            recordShot([
+              { type: 'HIT', firstContact: 'YELLOW' },
+              { type: 'POTTED', ball: 'YELLOW', pocket: 'TR' }
+            ])
+          }
+        >
+          Pot Colour
+        </button>
+        <button
+          type="button"
+          className="rounded-lg border border-border bg-surface px-3 py-2 text-sm hover:border-primary"
+          onClick={() => recordShot([{ type: 'FOUL', reason: 'Miss', ball: 'BLACK' }])}
+        >
+          Register Foul
+        </button>
+      </div>
+
+      <div className="rounded-xl border border-border bg-surface p-4 shadow space-y-2 text-sm text-subtext">
+        <p>
+          Shots and fouls are tracked independently from Pool Royale so we can train the snooker-specific AI without coupling
+          code paths.
+        </p>
+        <button
+          type="button"
+          className="rounded-lg border border-border px-3 py-2 text-sm hover:border-primary text-text"
+          onClick={restart}
+        >
+          Restart Frame
+        </button>
+      </div>
+
+      <div className="rounded-xl border border-dashed border-border bg-surface p-4 text-xs text-subtext space-y-1">
+        <p className="font-semibold text-text">History</p>
+        {history.map((snap, idx) => (
+          <div key={idx} className="flex gap-2">
+            <span className="text-primary">#{idx + 1}</span>
+            <span>Active: {snap.activePlayer}</span>
+            <span>Score A/B: {snap.players.A.score}/{snap.players.B.score}</span>
+            <span>Phase: {snap.phase}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/SnookerClubLobby.jsx
+++ b/webapp/src/pages/Games/SnookerClubLobby.jsx
@@ -1,0 +1,438 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import FlagPickerModal from '../../components/FlagPickerModal.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { ensureAccountId, getTelegramFirstName, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import { addTransaction, getAccountBalance, getOnlineUsers } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { resolveSnookerTableSize, SNOOKER_TABLE_SIZE_LIST } from '../../config/snookerTables.js';
+import { socket } from '../../utils/socket.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+
+const PLAYER_FLAG_STORAGE_KEY = 'snookerClubPlayerFlag';
+const AI_FLAG_STORAGE_KEY = 'snookerClubAiFlag';
+
+export default function SnookerClubLobby() {
+  const navigate = useNavigate();
+  const { search } = useLocation();
+  useTelegramBackButton();
+
+  const searchParams = new URLSearchParams(search);
+  const initialPlayType = (() => {
+    const requestedType = searchParams.get('type');
+    return requestedType === 'training' || requestedType === 'tournament' ? requestedType : 'regular';
+  })();
+
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [mode, setMode] = useState('ai');
+  const [avatar, setAvatar] = useState('');
+  const [showFlagPicker, setShowFlagPicker] = useState(false);
+  const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
+  const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
+  const [aiFlagIndex, setAiFlagIndex] = useState(null);
+  const [playType, setPlayType] = useState(initialPlayType);
+  const [players, setPlayers] = useState(8);
+  const [onlinePlayers, setOnlinePlayers] = useState([]);
+  const [matching, setMatching] = useState(false);
+  const [spinningPlayer, setSpinningPlayer] = useState('');
+  const [matchingError, setMatchingError] = useState('');
+  const [isSearching, setIsSearching] = useState(false);
+  const [readyList, setReadyList] = useState([]);
+  const [matchPlayers, setMatchPlayers] = useState([]);
+  const [matchTableId, setMatchTableId] = useState('');
+  const [tableSize, setTableSize] = useState(resolveSnookerTableSize(searchParams.get('tableSize')).id);
+
+  const spinIntervalRef = useRef(null);
+  const accountIdRef = useRef(null);
+  const stakeChargedRef = useRef(false);
+
+  const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
+  const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(PLAYER_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setPlayerFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(AI_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setAiFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    getOnlineUsers('snookerclub')
+      .then((res) => {
+        if (active) setOnlinePlayers(res?.users || []);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!matching) return () => {};
+    spinIntervalRef.current = setInterval(() => {
+      setSpinningPlayer((curr) => {
+        const fallback = 'Reds are getting racked...';
+        if (!onlinePlayers.length) return fallback;
+        const nextIndex = onlinePlayers.indexOf(curr);
+        const idx = (nextIndex + 1) % onlinePlayers.length;
+        return onlinePlayers[idx] || fallback;
+      });
+    }, 1200);
+    return () => clearInterval(spinIntervalRef.current);
+  }, [matching, onlinePlayers]);
+
+  const startGame = async () => {
+    let tgId;
+    let accountId;
+    if (playType !== 'training') {
+      try {
+        accountId = await ensureAccountId();
+        const balRes = await getAccountBalance(accountId);
+        if ((balRes.balance || 0) < stake.amount) {
+          alert('Insufficient balance');
+          return;
+        }
+        tgId = getTelegramId();
+        if (mode !== 'online') {
+          await addTransaction(tgId, -stake.amount, 'stake', {
+            game: 'snookerclub',
+            players: playType === 'tournament' ? players : 2,
+            accountId
+          });
+        }
+      } catch {}
+    } else {
+      try {
+        tgId = getTelegramId();
+        accountId = await ensureAccountId();
+      } catch {}
+    }
+
+    accountIdRef.current = accountId;
+
+    if (mode === 'online' && playType === 'regular') {
+      setMatchingError('');
+      setIsSearching(true);
+      stakeChargedRef.current = false;
+      if (!accountId) {
+        setIsSearching(false);
+        setMatchingError('Unable to resolve your TPC account.');
+        return;
+      }
+      socket.emit('register', { playerId: accountId, accountId });
+      socket.emit(
+        'seatTable',
+        {
+          accountId,
+          gameType: 'snookerclub',
+          stake: stake.amount,
+          maxPlayers: 2,
+          token: stake.token,
+          playType,
+          tableSize,
+          playerName: getTelegramFirstName() || `TPC ${accountId}`,
+          avatar
+        },
+        (res) => {
+          setIsSearching(false);
+          if (res?.success) {
+            setMatchTableId(res.tableId);
+            setMatchPlayers(res.players || []);
+            setReadyList(res.ready || []);
+            socket.emit('confirmReady', {
+              accountId,
+              tableId: res.tableId
+            });
+            setMatching(true);
+          } else {
+            setMatchingError(res?.message || 'Failed to join the online arena. Please retry.');
+          }
+        }
+      );
+      return;
+    }
+
+    const params = new URLSearchParams();
+    params.set('tableSize', tableSize);
+    params.set('type', playType);
+    params.set('mode', mode);
+    if (playType !== 'training') {
+      if (stake.token) params.set('token', stake.token);
+      if (stake.amount) params.set('amount', stake.amount);
+      if (playType === 'tournament') params.set('players', players);
+    }
+    const initData = window.Telegram?.WebApp?.initData;
+    if (avatar) params.set('avatar', avatar);
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    const name = getTelegramFirstName();
+    if (name) params.set('name', name);
+    if (selectedFlag) params.set('flag', selectedFlag);
+    if (selectedAiFlag) params.set('aiFlag', selectedAiFlag);
+    const devAcc = import.meta.env.VITE_DEV_ACCOUNT_ID;
+    if (devAcc) params.set('dev', devAcc);
+    if (initData) params.set('init', encodeURIComponent(initData));
+
+    if (playType === 'tournament') {
+      window.location.href = `/snooker-club-bracket.html?${params.toString()}`;
+      return;
+    }
+
+    navigate(`/games/snookerclub?${params.toString()}`);
+  };
+
+  const closeMatchmaking = () => {
+    setMatching(false);
+    setMatchTableId('');
+    setMatchPlayers([]);
+    setReadyList([]);
+    setSpinningPlayer('');
+    setIsSearching(false);
+  };
+
+  const confirmReady = () => {
+    const id = accountIdRef.current;
+    if (id && matchTableId) {
+      socket.emit('confirmReady', { tableId: matchTableId, accountId: id });
+    }
+  };
+
+  const toggleReady = () => {
+    const id = accountIdRef.current;
+    if (!id || !matchTableId) return;
+    const isReady = readyList.includes(id);
+    socket.emit('toggleReady', { tableId: matchTableId, accountId: id, ready: !isReady });
+  };
+
+  const lobbyTitle = useMemo(() => {
+    if (playType === 'training') return 'Snooker Club Training';
+    if (playType === 'tournament') return 'Snooker Club Tournament';
+    return 'Snooker Club';
+  }, [playType]);
+
+  return (
+    <div className="p-4 space-y-4 text-text">
+      <h1 className="text-2xl font-bold text-center">{lobbyTitle}</h1>
+      <p className="text-center text-sm text-subtext">
+        Choose your table size, mode, and stake to rack up a frame with the classic snooker markings.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="space-y-3 bg-surface border border-border rounded-xl p-4 shadow">
+          <h2 className="font-semibold text-lg">Match Setup</h2>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Table Size</label>
+            <div className="grid grid-cols-2 gap-2">
+              {SNOOKER_TABLE_SIZE_LIST.map((entry) => (
+                <button
+                  key={entry.id}
+                  type="button"
+                  className={`rounded-lg border px-3 py-2 text-sm ${
+                    tableSize === entry.id
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-border hover:border-primary'
+                  }`}
+                  onClick={() => setTableSize(entry.id)}
+                >
+                  {entry.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Play Type</label>
+            <div className="flex gap-2">
+              {['regular', 'training', 'tournament'].map((type) => (
+                <button
+                  key={type}
+                  type="button"
+                  className={`flex-1 rounded-lg border px-3 py-2 text-sm capitalize ${
+                    playType === type
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-border hover:border-primary'
+                  }`}
+                  onClick={() => setPlayType(type)}
+                >
+                  {type}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {playType === 'tournament' && (
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Players</label>
+              <RoomSelector value={players} onChange={setPlayers} min={4} max={16} step={2} />
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Mode</label>
+            <div className="flex gap-2">
+              {['ai', 'online', 'local'].map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  className={`flex-1 rounded-lg border px-3 py-2 text-sm capitalize ${
+                    mode === value
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-border hover:border-primary'
+                  }`}
+                  onClick={() => setMode(value)}
+                >
+                  {value === 'ai' ? 'vs AI' : value}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {playType !== 'training' && (
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <label className="text-sm font-medium">Token</label>
+                <input
+                  value={stake.token}
+                  onChange={(e) => setStake((s) => ({ ...s, token: e.target.value }))}
+                  className="w-full rounded border border-border bg-background px-2 py-1"
+                />
+              </div>
+              <div>
+                <label className="text-sm font-medium">Stake</label>
+                <input
+                  type="number"
+                  value={stake.amount}
+                  onChange={(e) => setStake((s) => ({ ...s, amount: Number(e.target.value || 0) }))}
+                  className="w-full rounded border border-border bg-background px-2 py-1"
+                  min={0}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-3 bg-surface border border-border rounded-xl p-4 shadow">
+          <h2 className="font-semibold text-lg">Identity</h2>
+          <div className="flex gap-3 items-center">
+            <div className="w-12 h-12 rounded-full overflow-hidden bg-border">
+              {avatar ? <img src={avatar} alt="Avatar" className="w-full h-full object-cover" /> : null}
+            </div>
+            <div className="space-y-1 text-sm text-subtext">
+              <p>Flag: {selectedFlag || 'None'}</p>
+              <p>AI Flag: {selectedAiFlag || 'Default'}</p>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="flex-1 rounded-lg border border-border px-3 py-2 text-sm"
+              onClick={() => setShowFlagPicker(true)}
+            >
+              Choose Player Flag
+            </button>
+            <button
+              type="button"
+              className="flex-1 rounded-lg border border-border px-3 py-2 text-sm"
+              onClick={() => setShowAiFlagPicker(true)}
+            >
+              Choose AI Flag
+            </button>
+          </div>
+          <div className="rounded-lg border border-dashed border-border p-3 text-sm text-subtext">
+            Training mode keeps the classic markings without staking. Tournament auto-seats you into an arena separate from Pool
+            Royale.
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between bg-surface border border-border rounded-xl p-4 shadow">
+        <div>
+          <p className="text-sm text-subtext">Online players</p>
+          <p className="text-lg font-semibold">{onlinePlayers.length || 0}</p>
+        </div>
+        <button
+          type="button"
+          className="rounded-full bg-primary px-6 py-3 text-black font-semibold shadow-lg shadow-primary/40"
+          onClick={startGame}
+          disabled={isSearching}
+        >
+          {isSearching ? 'Searching...' : 'Start'}
+        </button>
+      </div>
+
+      {matching && (
+        <div className="rounded-xl border border-border bg-surface p-4 shadow space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold">Arena Matchmaking</h3>
+            <button className="text-sm text-primary" onClick={closeMatchmaking} type="button">
+              Cancel
+            </button>
+          </div>
+          <p className="text-sm text-subtext">{spinningPlayer || 'Waiting for opponent...'}</p>
+          <div className="text-sm text-subtext">Table ID: {matchTableId || 'pending'}</div>
+          <div className="text-sm text-subtext">Ready: {readyList.length}</div>
+          <div className="text-sm text-subtext">Players: {matchPlayers.length || 1}/2</div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="flex-1 rounded-lg border border-border px-3 py-2 text-sm"
+              onClick={confirmReady}
+            >
+              Confirm Ready
+            </button>
+            <button
+              type="button"
+              className="flex-1 rounded-lg border border-border px-3 py-2 text-sm"
+              onClick={toggleReady}
+            >
+              Toggle Ready
+            </button>
+          </div>
+          {matchingError && <p className="text-sm text-red-500">{matchingError}</p>}
+        </div>
+      )}
+
+      {showFlagPicker && (
+        <FlagPickerModal
+          onClose={() => setShowFlagPicker(false)}
+          onPick={(flagIndex) => {
+            setPlayerFlagIndex(flagIndex);
+            try {
+              window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, FLAG_EMOJIS[flagIndex] || '');
+            } catch {}
+          }}
+        />
+      )}
+
+      {showAiFlagPicker && (
+        <FlagPickerModal
+          onClose={() => setShowAiFlagPicker(false)}
+          onPick={(flagIndex) => {
+            setAiFlagIndex(flagIndex);
+            try {
+              window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[flagIndex] || '');
+            } catch {}
+          }}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Snooker Club lobby with table-size selection, staking/training/tournament paths, and online/AI toggles
- introduce snooker-specific table specs and rules serialization to keep logic isolated from Pool Royale
- wire new Snooker Club routes and placeholder frame tracker to host future gameplay work

## Testing
- `npm test -- --runInBand` *(fails: jest roots directory /workspace/TonPlaygramWebApp/tests not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937c05c7d58832989c9305441cc72fe)