### PR TITLE
Align chess color presets with snippet

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -269,68 +269,34 @@ const CHECK_SOUND_URL =
 const CHECKMATE_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
 
-const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
-  {
-    id: 'beautifulGameAuroraMetal',
-    name: 'Aurora Metal',
-    piece: { white: '#dce6ff', black: '#111827', accent: '#7dd3fc' },
-    board: { light: '#d9f5ff', dark: '#0b1220', accent: '#7dd3fc' }
-  },
-  {
-    id: 'beautifulGameObsidianGold',
-    name: 'Obsidian / Gold',
-    piece: { white: '#f8ead4', black: '#141414', accent: '#d4a017' },
-    board: { light: '#f4e8d2', dark: '#1e1e1e', accent: '#d4a017' }
-  },
-  {
-    id: 'beautifulGameGlacierMint',
-    name: 'Glacier / Mint',
-    piece: { white: '#ecfeff', black: '#0f172a', accent: '#34d399' },
-    board: { light: '#d1fae5', dark: '#0f172a', accent: '#34d399' }
-  },
-  {
-    id: 'beautifulGameSakuraSlate',
-    name: 'Sakura / Slate',
-    piece: { white: '#ffe4ec', black: '#2b3040', accent: '#fb7185' },
-    board: { light: '#ffd8e3', dark: '#1f2635', accent: '#fb7185' }
-  },
-  {
-    id: 'beautifulGameVoltTeal',
-    name: 'Volt / Teal',
-    piece: { white: '#faffb5', black: '#0f766e', accent: '#22d3ee' },
-    board: { light: '#e8ffb5', dark: '#0b3b3c', accent: '#22d3ee' }
-  },
-  {
-    id: 'beautifulGameCopperIvory',
-    name: 'Copper / Ivory',
-    piece: { white: '#f5f0e5', black: '#5a2c1f', accent: '#e38b29' },
-    board: { light: '#f4ede1', dark: '#3b241a', accent: '#e38b29' }
-  },
-  {
-    id: 'beautifulGameNoirNeon',
-    name: 'Noir / Neon',
-    piece: { white: '#e5e7eb', black: '#0a0d14', accent: '#06f0ff' },
-    board: { light: '#c7d2fe', dark: '#0a0d14', accent: '#06f0ff' }
-  },
-  {
-    id: 'beautifulGameCinderRose',
-    name: 'Cinder / Rose',
-    piece: { white: '#f5d0c5', black: '#1f1b29', accent: '#f43f5e' },
-    board: { light: '#f8d7cc', dark: '#1b1524', accent: '#f43f5e' }
-  },
-  {
-    id: 'beautifulGameHarborFog',
-    name: 'Harbor Fog',
-    piece: { white: '#e2e8f0', black: '#1e293b', accent: '#38bdf8' },
-    board: { light: '#dbeafe', dark: '#0b1220', accent: '#38bdf8' }
-  },
-  {
-    id: 'beautifulGameDesertStorm',
-    name: 'Desert Storm',
-    piece: { white: '#fef3c7', black: '#4b3421', accent: '#fbbf24' },
-    board: { light: '#fde68a', dark: '#2d1f12', accent: '#fbbf24' }
-  }
+const SNIPPET_PIECE_COLORS = Object.freeze([
+  { id: 'pureWhite', label: 'P1 Default', color: '#ffffff' },
+  { id: 'onyx', label: 'P2 Default', color: '#111827' },
+  { id: 'amber', label: 'Amber', color: '#f59e0b' },
+  { id: 'mint', label: 'Mint', color: '#10b981' },
+  { id: 'blue', label: 'Blue', color: '#3b82f6' },
+  { id: 'crimson', label: 'Red', color: '#ef4444' },
+  { id: 'violet', label: 'Violet', color: '#8b5cf6' }
 ]);
+
+const SNIPPET_BOARD_THEMES = Object.freeze([
+  { id: 'classic', name: 'Classic', light: '#EEE8D5', dark: '#2B2F36' },
+  { id: 'mono', name: 'Mono', light: '#E5E7EB', dark: '#111827' },
+  { id: 'blue', name: 'Blue', light: '#93C5FD', dark: '#1E293B' },
+  { id: 'amber', name: 'Amber', light: '#FDE68A', dark: '#1F2937' },
+  { id: 'mint', name: 'Mint', light: '#A7F3D0', dark: '#065F46' },
+  { id: 'pink', name: 'Pink', light: '#FBCFE8', dark: '#312E81' },
+  { id: 'teal', name: 'Teal', light: '#99F6E4', dark: '#0F172A' }
+]);
+
+const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze(
+  SNIPPET_BOARD_THEMES.map((theme) => ({
+    id: `beautifulGame-${theme.id}`,
+    name: theme.name,
+    piece: { white: SNIPPET_PIECE_COLORS[0].color, black: SNIPPET_PIECE_COLORS[1].color },
+    board: { light: theme.light, dark: theme.dark, accent: theme.dark }
+  }))
+);
 
 const BEAUTIFUL_GAME_THEME_NAMES = BEAUTIFUL_GAME_THEME_CONFIGS.map((config) => config.name);
 
@@ -431,33 +397,27 @@ const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
   blackAccent: '#7dd3fc'
 });
 
-const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGameAuroraMetal';
-const BEAUTIFUL_GAME_SET_ID = 'beautifulGameAuroraMetalSet';
+const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGamePiece-pureWhite';
+const BEAUTIFUL_GAME_SET_ID = 'beautifulGamePiece-classic';
 
 const BASE_PIECE_STYLE = BEAUTIFUL_GAME_PIECE_STYLE;
 
 const BEAUTIFUL_GAME_COLOR_VARIANTS = Object.freeze(
-  BEAUTIFUL_GAME_THEME_CONFIGS.map((config) => {
-    const preserveOriginal = Boolean(config.piece?.preserveOriginal);
-    const pieceStyle = preserveOriginal
-      ? { ...BASE_PIECE_STYLE, preserveOriginalMaterials: true, keepTextures: true }
-      : {
-          ...BASE_PIECE_STYLE,
-          preserveOriginalMaterials: false,
-          keepTextures: true,
-          white: { ...BASE_PIECE_STYLE.white, color: config.piece?.white ?? BASE_PIECE_STYLE.white.color },
-          black: { ...BASE_PIECE_STYLE.black, color: config.piece?.black ?? BASE_PIECE_STYLE.black.color },
-          accent: config.piece?.accent ?? BASE_PIECE_STYLE.accent,
-          goldAccent: config.piece?.goldAccent ?? BASE_PIECE_STYLE.goldAccent,
-          whiteAccent: config.piece?.whiteAccent ?? BASE_PIECE_STYLE.whiteAccent,
-          blackAccent: config.piece?.blackAccent ?? BASE_PIECE_STYLE.blackAccent
-        };
-    return {
-      id: config.id,
-      label: `ABeautifulGame (${config.name})`,
-      style: pieceStyle
-    };
-  })
+  SNIPPET_PIECE_COLORS.map((swatch) => ({
+    id: `beautifulGamePiece-${swatch.id}`,
+    label: swatch.label,
+    style: {
+      ...BASE_PIECE_STYLE,
+      preserveOriginalMaterials: false,
+      keepTextures: true,
+      white: { ...BASE_PIECE_STYLE.white, color: swatch.color },
+      black: { ...BASE_PIECE_STYLE.black, color: swatch.color },
+      accent: swatch.color,
+      goldAccent: swatch.color,
+      whiteAccent: { color: swatch.color },
+      blackAccent: swatch.color
+    }
+  }))
 );
 
 const pieceStyleSignature = (style) => `${style?.white?.color ?? ''}|${style?.black?.color ?? ''}`;
@@ -868,8 +828,8 @@ const TABLE_SHAPE_MENU_OPTIONS = TABLE_SHAPE_OPTIONS.filter((option) => option.i
 const PRESERVE_NATIVE_PIECE_IDS = new Set();
 
 const CUSTOMIZATION_SECTIONS = [
-  { key: 'whitePieceStyle', label: 'White Pieces', options: PIECE_STYLE_OPTIONS },
-  { key: 'blackPieceStyle', label: 'Black Pieces', options: PIECE_STYLE_OPTIONS },
+  { key: 'whitePieceStyle', label: 'Pieces P1 (bottom)', options: PIECE_STYLE_OPTIONS },
+  { key: 'blackPieceStyle', label: 'Pieces P2 (top)', options: PIECE_STYLE_OPTIONS },
   { key: 'headStyle', label: 'Heads (Pawn & Bishop)', options: HEAD_PRESET_OPTIONS },
   { key: 'boardColor', label: 'Chess Board', options: BEAUTIFUL_GAME_BOARD_OPTIONS },
   { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },
@@ -4739,7 +4699,8 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
       </span>
     );
     if (key === 'whitePieceStyle' || key === 'blackPieceStyle') {
-      return dualSwatch(option.white?.color || '#f5f5f7', option.black?.color || '#111827');
+      const color = option.white?.color || option.black?.color || option.accent || '#ffffff';
+      return <span className={swatchClass} style={{ background: color }} />;
     }
     if (key === 'headStyle') {
       const color = option.preset?.color || '#ffffff';


### PR DESCRIPTION
## Summary
- replace chess piece and board color options with the single-color snippet palette
- relabel customization controls to P1/P2 and show single-color swatches to match the new presets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937baa62b488329a3a296ff78e8f7fa)