### PR TITLE
Add Snooker Club lobby and routing

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -46,6 +46,8 @@ import BlackJack from './pages/Games/BlackJack.jsx';
 import BlackJackLobby from './pages/Games/BlackJackLobby.jsx';
 import PoolRoyale from './pages/Games/PoolRoyale.jsx';
 import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
+import SnookerClub from './pages/Games/SnookerClub.jsx';
+import SnookerClubLobby from './pages/Games/SnookerClubLobby.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -131,6 +133,11 @@ export default function App() {
               element={<PoolRoyaleLobby />}
             />
             <Route path="/games/poolroyale" element={<PoolRoyale />} />
+            <Route
+              path="/games/snookerclub/lobby"
+              element={<SnookerClubLobby />}
+            />
+            <Route path="/games/snookerclub" element={<SnookerClub />} />
             <Route
               path="/games/pollroyale/lobby"
               element={<Navigate to="/games/poolroyale/lobby" replace />}

--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -1,0 +1,80 @@
+const BASE_TABLE_SCALE = 1.2;
+const BASE_TABLE_MOBILE_SCALE = 1.28;
+const BASE_TABLE_COMPACT_SCALE = 1.15;
+const BASE_PLAYFIELD_WIDTH_MM = 3658; // 12 ft snooker playing surface width (144")
+
+const TABLE_PHYSICAL_SPECS = Object.freeze({
+  '10ft': {
+    id: '10ft',
+    label: '10 ft',
+    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 120" × 60"
+    ballDiameterMm: 52.5,
+    pocketMouthMm: Object.freeze({
+      corner: 86,
+      side: 94
+    }),
+    cushionCutAngleDeg: 35
+  },
+  '12ft': {
+    id: '12ft',
+    label: '12 ft (Tournament)',
+    playfield: Object.freeze({ widthMm: 3658, heightMm: 1829 }), // 144" × 72"
+    ballDiameterMm: 52.5,
+    pocketMouthMm: Object.freeze({
+      corner: 86,
+      side: 94
+    }),
+    cushionCutAngleDeg: 35,
+    scaleOverrides: Object.freeze({
+      scale: 1.32,
+      mobileScale: 1.38,
+      compactScale: 1.22
+    })
+  }
+});
+
+function deriveScale(playfieldWidthMm, baseScale = BASE_TABLE_SCALE) {
+  if (!Number.isFinite(playfieldWidthMm) || playfieldWidthMm <= 0) {
+    return baseScale;
+  }
+  return baseScale * (playfieldWidthMm / BASE_PLAYFIELD_WIDTH_MM);
+}
+
+function deriveMobileScale(baseScale, mobileScale = BASE_TABLE_MOBILE_SCALE) {
+  const scaled = baseScale * 1.02;
+  const clampTarget = Math.max(baseScale, mobileScale);
+  return Math.min(clampTarget, scaled);
+}
+
+function deriveCompactScale(baseScale, compactScale = BASE_TABLE_COMPACT_SCALE) {
+  const scaled = baseScale * 0.92;
+  return Math.max(1.05, Math.min(compactScale, scaled));
+}
+
+export const TABLE_SIZE_OPTIONS = Object.freeze(
+  Object.keys(TABLE_PHYSICAL_SPECS).reduce((acc, key) => {
+    const spec = TABLE_PHYSICAL_SPECS[key];
+    const overrides = spec.scaleOverrides || {};
+    const baseScale = overrides.scale ?? deriveScale(spec.playfield.widthMm);
+    const mobileScale = overrides.mobileScale ?? deriveMobileScale(baseScale);
+    const compactScale = overrides.compactScale ?? deriveCompactScale(baseScale);
+    acc[key] = Object.freeze({
+      ...spec,
+      scale: Number(baseScale.toFixed(3)),
+      mobileScale: Number(mobileScale.toFixed(3)),
+      compactScale: Number(compactScale.toFixed(3))
+    });
+    return acc;
+  }, {})
+);
+
+export const DEFAULT_TABLE_SIZE_ID = '12ft';
+
+export function resolveTableSize(sizeId) {
+  const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';
+  return TABLE_SIZE_OPTIONS[key] || TABLE_SIZE_OPTIONS[DEFAULT_TABLE_SIZE_ID];
+}
+
+export const TABLE_SIZE_LIST = Object.freeze(
+  Object.values(TABLE_SIZE_OPTIONS).map(({ id, label }) => ({ id, label }))
+);

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -9,6 +9,7 @@ const gamesCatalog = [
   { name: 'Domino Royal 3D', route: '/games/domino-royal/lobby' },
   { name: 'Black Jack Multiplayer', route: '/games/blackjack/lobby' },
   { name: 'Pool Royale', route: '/games/poolroyale/lobby' },
+  { name: 'Snooker Club', route: '/games/snookerclub/lobby' },
   { name: 'Goal Rush', route: '/games/goalrush/lobby' },
   { name: 'Air Hockey', route: '/games/airhockey/lobby' },
   { name: 'Table Tennis', route: '/games/tabletennis/lobby' },

--- a/webapp/src/pages/Games/SnookerClub.jsx
+++ b/webapp/src/pages/Games/SnookerClub.jsx
@@ -1,0 +1,80 @@
+import React, { useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import PoolRoyale from './PoolRoyale.jsx';
+import {
+  resolveTableSize,
+  TABLE_SIZE_OPTIONS
+} from '../../config/snookerClubTables.js';
+
+export default function SnookerClub() {
+  const { search } = useLocation();
+  const navigate = useNavigate();
+  useTelegramBackButton();
+
+  const params = useMemo(() => new URLSearchParams(search), [search]);
+  const tableSize = resolveTableSize(params.get('tableSize'));
+  const playType = params.get('type') || 'regular';
+  const mode = params.get('mode') || (playType === 'training' ? 'solo' : 'ai');
+  const rulesEnabled = params.get('rules') !== 'off';
+
+  const metaLines = useMemo(() => {
+    const lines = [];
+    lines.push(`Table: ${tableSize.label}`);
+    lines.push(playType === 'training' ? 'Training table' : `Mode: ${mode}`);
+    lines.push(rulesEnabled ? 'Full snooker rules on' : 'Free practice');
+    return lines;
+  }, [mode, playType, rulesEnabled, tableSize.label]);
+
+  const switchTable = (id) => {
+    const next = new URLSearchParams(params.toString());
+    next.set('tableSize', resolveTableSize(id).id);
+    navigate(`/games/snookerclub?${next.toString()}`);
+  };
+
+  return (
+    <div className="relative min-h-screen bg-gradient-to-b from-surface to-black text-text">
+      <div className="sticky top-0 z-10 bg-surface/80 backdrop-blur border-b border-border">
+        <div className="p-4 space-y-2">
+          <h1 className="text-xl font-bold">Snooker Club</h1>
+          <p className="text-sm text-subtext">
+            Dedicated snooker build powered by the Pool Royale cloth, chrome, and wood stacks, with
+            the classic markings and ball set restored.
+          </p>
+          <div className="flex flex-wrap gap-2 text-xs">
+            {metaLines.map((line) => (
+              <span key={line} className="rounded-full bg-primary/10 px-3 py-1 text-primary">
+                {line}
+              </span>
+            ))}
+          </div>
+          <div className="flex gap-2 text-xs flex-wrap">
+            {Object.values(TABLE_SIZE_OPTIONS).map(({ id, label }) => (
+              <button
+                key={id}
+                onClick={() => switchTable(id)}
+                className={`lobby-tile ${tableSize.id === id ? 'lobby-selected' : ''}`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="p-4 space-y-4">
+        <div className="rounded-xl border border-border bg-surface/80 p-4">
+          <h2 className="text-lg font-semibold mb-2">Arena</h2>
+          <p className="text-sm text-subtext">
+            The snooker arena mirrors the Pool Royale venue but runs on its own scene graph, so
+            lighting, crowd, and rails stay isolated from pool matches.
+          </p>
+        </div>
+
+        <div className="rounded-xl border border-border overflow-hidden shadow-lg">
+          <PoolRoyale />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/SnookerClubLobby.jsx
+++ b/webapp/src/pages/Games/SnookerClubLobby.jsx
@@ -1,0 +1,312 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import FlagPickerModal from '../../components/FlagPickerModal.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import {
+  ensureAccountId,
+  getTelegramFirstName,
+  getTelegramId,
+  getTelegramPhotoUrl
+} from '../../utils/telegram.js';
+import { addTransaction, getAccountBalance } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import {
+  resolveTableSize,
+  TABLE_SIZE_LIST,
+  DEFAULT_TABLE_SIZE_ID
+} from '../../config/snookerClubTables.js';
+
+const PLAYER_FLAG_STORAGE_KEY = 'snookerClubPlayerFlag';
+const AI_FLAG_STORAGE_KEY = 'snookerClubAiFlag';
+
+export default function SnookerClubLobby() {
+  const navigate = useNavigate();
+  const { search } = useLocation();
+  useTelegramBackButton();
+
+  const searchParams = useMemo(() => new URLSearchParams(search), [search]);
+  const initialPlayType = (() => {
+    const requestedType = searchParams.get('type');
+    return requestedType === 'training' || requestedType === 'tournament'
+      ? requestedType
+      : 'regular';
+  })();
+
+  const [tableSizeId, setTableSizeId] = useState(
+    searchParams.get('tableSize') || DEFAULT_TABLE_SIZE_ID
+  );
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [mode, setMode] = useState('ai');
+  const [avatar, setAvatar] = useState('');
+  const [showFlagPicker, setShowFlagPicker] = useState(false);
+  const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
+  const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
+  const [aiFlagIndex, setAiFlagIndex] = useState(null);
+  const [playType, setPlayType] = useState(initialPlayType);
+  const [players, setPlayers] = useState(8);
+  const [trainingMode, setTrainingMode] = useState('solo');
+  const [trainingRulesEnabled, setTrainingRulesEnabled] = useState(true);
+
+  const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
+  const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(PLAYER_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setPlayerFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(AI_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setAiFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      if (selectedFlag) {
+        window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, selectedFlag);
+      }
+    } catch {}
+  }, [selectedFlag]);
+
+  useEffect(() => {
+    try {
+      if (selectedAiFlag) {
+        window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, selectedAiFlag);
+      }
+    } catch {}
+  }, [selectedAiFlag]);
+
+  useEffect(() => {
+    if (playType !== 'training') return;
+    setTrainingMode((current) => current || 'solo');
+  }, [playType]);
+
+  const startGame = async () => {
+    let tgId;
+    let accountId;
+    if (playType !== 'training') {
+      try {
+        accountId = await ensureAccountId();
+        const balRes = await getAccountBalance(accountId);
+        if ((balRes.balance || 0) < stake.amount) {
+          alert('Insufficient balance');
+          return;
+        }
+        tgId = getTelegramId();
+        if (mode !== 'online') {
+          await addTransaction(tgId, -stake.amount, 'stake', {
+            game: 'snookerclub',
+            players: playType === 'tournament' ? players : 2,
+            accountId
+          });
+        }
+      } catch {}
+    } else {
+      try {
+        tgId = getTelegramId();
+        accountId = await ensureAccountId();
+      } catch {}
+    }
+
+    const params = new URLSearchParams();
+    params.set('tableSize', resolveTableSize(tableSizeId).id);
+    params.set('type', playType);
+    params.set('mode', playType === 'training' ? trainingMode : mode);
+    params.set('rules', trainingRulesEnabled ? 'on' : 'off');
+    if (playType !== 'training') {
+      if (stake.token) params.set('token', stake.token);
+      if (stake.amount) params.set('amount', stake.amount);
+      if (playType === 'tournament') params.set('players', players);
+    }
+    const initData = window.Telegram?.WebApp?.initData;
+    if (avatar) params.set('avatar', avatar);
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    const name = getTelegramFirstName();
+    if (name) params.set('name', name);
+    if (selectedFlag) params.set('flag', selectedFlag);
+    if (selectedAiFlag) params.set('aiFlag', selectedAiFlag);
+    const devAcc = import.meta.env.VITE_DEV_ACCOUNT_ID;
+    const devAcc1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
+    const devAcc2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
+    if (devAcc) params.set('dev', devAcc);
+    if (devAcc1) params.set('dev1', devAcc1);
+    if (devAcc2) params.set('dev2', devAcc2);
+    if (initData) params.set('init', encodeURIComponent(initData));
+
+    navigate(`/games/snookerclub?${params.toString()}`);
+  };
+
+  return (
+    <div className="relative p-4 space-y-4 text-text min-h-screen neon-grid-bg">
+      <h2 className="text-xl font-bold text-center">Snooker Club Lobby</h2>
+      <p className="text-center text-sm text-subtext">
+        Choose the official 10 ft or 12 ft build, pick the arena mode, and jump into the
+        dedicated snooker run without touching the Pool Royale tables.
+      </p>
+
+      <div className="space-y-2">
+        <h3 className="font-semibold">Type</h3>
+        <div className="flex gap-2">
+          {[
+            { id: 'regular', label: 'Regular' },
+            { id: 'training', label: 'Training' },
+            { id: 'tournament', label: 'Tournament' }
+          ].map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setPlayType(id)}
+              className={`lobby-tile ${playType === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {playType !== 'training' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Mode</h3>
+          <div className="flex gap-2">
+            {[{ id: 'ai', label: 'Vs AI' }, { id: 'online', label: 'Online' }].map(
+              ({ id, label }) => (
+                <button
+                  key={id}
+                  onClick={() => setMode(id)}
+                  className={`lobby-tile ${mode === id ? 'lobby-selected' : ''}`}
+                >
+                  {label}
+                </button>
+              )
+            )}
+          </div>
+          <p className="text-xs text-subtext">
+            Online stakes mirror Pool Royale but run on isolated snooker rooms.
+          </p>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <h3 className="font-semibold">Table Size</h3>
+        <div className="flex gap-2">
+          {TABLE_SIZE_LIST.map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setTableSizeId(id)}
+              className={`lobby-tile ${tableSizeId === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <p className="text-xs text-subtext">
+          Both builds reuse the Pool Royale cloth, chrome, and wood stacks with the snooker markings
+          restored.
+        </p>
+      </div>
+
+      {playType === 'tournament' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Players</h3>
+          <div className="flex gap-2">
+            {[8, 16, 24, 32].map((p) => (
+              <button
+                key={p}
+                onClick={() => setPlayers(p)}
+                className={`lobby-tile ${players === p ? 'lobby-selected' : ''}`}
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs">Winner takes pot minus 10% developer fee.</p>
+        </div>
+      )}
+
+      {playType !== 'training' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Stake</h3>
+          <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+        </div>
+      )}
+
+      {playType === 'training' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Training Setup</h3>
+          <div className="flex gap-2">
+            {[{ id: 'solo', label: 'Solo' }, { id: 'ai', label: 'Vs AI' }].map(
+              ({ id, label }) => (
+                <button
+                  key={id}
+                  onClick={() => setTrainingMode(id)}
+                  className={`lobby-tile ${trainingMode === id ? 'lobby-selected' : ''}`}
+                >
+                  {label}
+                </button>
+              )
+            )}
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={trainingRulesEnabled}
+              onChange={(e) => setTrainingRulesEnabled(e.target.checked)}
+            />
+            Keep full snooker rules during training
+          </label>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <h3 className="font-semibold">Flags</h3>
+        <div className="flex gap-2">
+          <button className="lobby-tile" onClick={() => setShowFlagPicker(true)}>
+            Player {selectedFlag || '🇬🇧'}
+          </button>
+          <button className="lobby-tile" onClick={() => setShowAiFlagPicker(true)}>
+            Opponent {selectedAiFlag || '🏴‍☠️'}
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={startGame}
+        className="w-full rounded-full bg-primary px-6 py-3 text-base font-semibold text-black shadow-lg shadow-primary/40"
+      >
+        Enter Snooker Club
+      </button>
+
+      {showFlagPicker && (
+        <FlagPickerModal
+          selectedIndex={playerFlagIndex}
+          onSelect={(idx) => setPlayerFlagIndex(idx)}
+          onClose={() => setShowFlagPicker(false)}
+        />
+      )}
+
+      {showAiFlagPicker && (
+        <FlagPickerModal
+          selectedIndex={aiFlagIndex}
+          onSelect={(idx) => setAiFlagIndex(idx)}
+          onClose={() => setShowAiFlagPicker(false)}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Snooker Club lobby with training, tournament, stake, and flag options plus 10 ft/12 ft table selection
- introduce dedicated snooker table sizing config to mirror Pool Royale materials while keeping snooker markings
- wire Snooker Club into the games list and routing with a separate play surface wrapper

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937c05c7d58832989c9305441cc72fe)