### PR TITLE
Add Snooker Club game shell and lobby

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -46,6 +46,8 @@ import BlackJack from './pages/Games/BlackJack.jsx';
 import BlackJackLobby from './pages/Games/BlackJackLobby.jsx';
 import PoolRoyale from './pages/Games/PoolRoyale.jsx';
 import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
+import SnookerClub from './pages/Games/SnookerClub.jsx';
+import SnookerClubLobby from './pages/Games/SnookerClubLobby.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
@@ -131,6 +133,11 @@ export default function App() {
               element={<PoolRoyaleLobby />}
             />
             <Route path="/games/poolroyale" element={<PoolRoyale />} />
+            <Route
+              path="/games/snookerclub/lobby"
+              element={<SnookerClubLobby />}
+            />
+            <Route path="/games/snookerclub" element={<SnookerClub />} />
             <Route
               path="/games/pollroyale/lobby"
               element={<Navigate to="/games/poolroyale/lobby" replace />}

--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -1,0 +1,82 @@
+const BASE_TABLE_SCALE = 1.32;
+const BASE_TABLE_MOBILE_SCALE = 1.36;
+const BASE_TABLE_COMPACT_SCALE = 1.28;
+const BASE_PLAYFIELD_WIDTH_MM = 3556; // reference 12 ft match table width
+
+const TABLE_PHYSICAL_SPECS = Object.freeze({
+  '12ft': {
+    id: '12ft',
+    label: '12 ft (Championship)',
+    playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }), // 12' x 6'
+    ballDiameterMm: 52.5,
+    pocketMouthMm: Object.freeze({
+      corner: 86,
+      side: 92
+    }),
+    cushionCutAngleDeg: 35,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 }),
+    scaleOverrides: Object.freeze({
+      scale: 1.36,
+      mobileScale: 1.44,
+      compactScale: 1.3
+    })
+  },
+  '10ft': {
+    id: '10ft',
+    label: '10 ft (Club)',
+    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 10' x 5'
+    ballDiameterMm: 52.5,
+    pocketMouthMm: Object.freeze({
+      corner: 86,
+      side: 92
+    }),
+    cushionCutAngleDeg: 35,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 })
+  }
+});
+
+function deriveScale(playfieldWidthMm, baseScale = BASE_TABLE_SCALE) {
+  if (!Number.isFinite(playfieldWidthMm) || playfieldWidthMm <= 0) {
+    return baseScale;
+  }
+  return baseScale * (playfieldWidthMm / BASE_PLAYFIELD_WIDTH_MM);
+}
+
+function deriveMobileScale(baseScale, mobileScale = BASE_TABLE_MOBILE_SCALE) {
+  const scaled = baseScale * 1.02;
+  const clampTarget = Math.max(baseScale, mobileScale);
+  return Math.min(clampTarget, scaled);
+}
+
+function deriveCompactScale(baseScale, compactScale = BASE_TABLE_COMPACT_SCALE) {
+  const scaled = baseScale * 0.94;
+  return Math.max(1.08, Math.min(compactScale, scaled));
+}
+
+export const TABLE_SIZE_OPTIONS = Object.freeze(
+  Object.keys(TABLE_PHYSICAL_SPECS).reduce((acc, key) => {
+    const spec = TABLE_PHYSICAL_SPECS[key];
+    const overrides = spec.scaleOverrides || {};
+    const baseScale = overrides.scale ?? deriveScale(spec.playfield.widthMm);
+    const mobileScale = overrides.mobileScale ?? deriveMobileScale(baseScale);
+    const compactScale = overrides.compactScale ?? deriveCompactScale(baseScale);
+    acc[key] = Object.freeze({
+      ...spec,
+      scale: Number(baseScale.toFixed(3)),
+      mobileScale: Number(mobileScale.toFixed(3)),
+      compactScale: Number(compactScale.toFixed(3))
+    });
+    return acc;
+  }, {})
+);
+
+export const DEFAULT_TABLE_SIZE_ID = '12ft';
+
+export function resolveTableSize(sizeId) {
+  const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';
+  return TABLE_SIZE_OPTIONS[key] || TABLE_SIZE_OPTIONS[DEFAULT_TABLE_SIZE_ID];
+}
+
+export const TABLE_SIZE_LIST = Object.freeze(
+  Object.values(TABLE_SIZE_OPTIONS).map(({ id, label }) => ({ id, label }))
+);

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -9,6 +9,7 @@ const gamesCatalog = [
   { name: 'Domino Royal 3D', route: '/games/domino-royal/lobby' },
   { name: 'Black Jack Multiplayer', route: '/games/blackjack/lobby' },
   { name: 'Pool Royale', route: '/games/poolroyale/lobby' },
+  { name: 'Snooker Club', route: '/games/snookerclub/lobby' },
   { name: 'Goal Rush', route: '/games/goalrush/lobby' },
   { name: 'Air Hockey', route: '/games/airhockey/lobby' },
   { name: 'Table Tennis', route: '/games/tabletennis/lobby' },

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8119,7 +8119,7 @@ function applyTableFinishToTable(table, finish) {
 // --------------------------------------------------
 // NEW Engine (no globals). Camera feels like standing at the side.
 // --------------------------------------------------
-function PoolRoyaleGame({
+export function PoolRoyaleGame({
   variantKey,
   tableSizeKey,
   playType = 'regular',
@@ -8129,7 +8129,10 @@ function PoolRoyaleGame({
   accountId,
   tgId,
   playerName,
-  opponentName
+  opponentName,
+  gameId = 'poolroyale',
+  lobbyPath = '/games/poolroyale/lobby',
+  tableResolver = resolveTableSize
 }) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -8142,8 +8145,8 @@ function PoolRoyaleGame({
     [variantKey]
   );
   const activeTableSize = useMemo(
-    () => resolveTableSize(tableSizeKey),
-    [tableSizeKey]
+    () => tableResolver(tableSizeKey),
+    [tableResolver, tableSizeKey]
   );
   const responsiveTableSize = useResponsiveTableSize(activeTableSize);
   const [tableFinishId, setTableFinishId] = useState(() => {
@@ -8311,7 +8314,7 @@ function PoolRoyaleGame({
       }
       const telegramId = tgIdRef.current || getTelegramId();
       await addTransaction(telegramId, -50, 'cue_fee', {
-        game: 'poolroyale',
+        game: gameId,
         reason: 'cue_switch',
         accountId: id
       });
@@ -9469,7 +9472,7 @@ function PoolRoyaleGame({
           : 'Frame tied!';
     window.alert(`${announcement} Returning to the lobby...`);
     const winnerParam = winnerId === 'A' ? '1' : '0';
-    const lobbyUrl = `/games/poolroyale/lobby?winner=${winnerParam}`;
+    const lobbyUrl = `${lobbyPath}?winner=${winnerParam}`;
     const redirectTimer = window.setTimeout(() => {
       window.location.assign(lobbyUrl);
     }, 1200);
@@ -17049,7 +17052,7 @@ function PoolRoyaleGame({
   );
 }
 
-export default function PoolRoyale() {
+export function PoolRoyale({ lobbyPath = '/games/poolroyale/lobby' }) {
   const navigate = useNavigate();
   const location = useLocation();
   const variantKey = useMemo(() => {
@@ -17141,10 +17144,10 @@ export default function PoolRoyale() {
   useTelegramBackButton(() => {
     confirmExit().then((confirmed) => {
       if (confirmed) {
-        navigate('/games/poolroyale/lobby');
+        navigate(lobbyPath);
       }
     });
-  });
+  }, [confirmExit, lobbyPath, navigate]);
   useEffect(() => {
     const handleBeforeUnload = (event) => {
       event.preventDefault();
@@ -17156,7 +17159,7 @@ export default function PoolRoyale() {
         if (!confirmed) {
           window.history.pushState(null, '', window.location.href);
         } else {
-          navigate('/games/poolroyale/lobby');
+          navigate(lobbyPath);
         }
       });
     };
@@ -17167,7 +17170,7 @@ export default function PoolRoyale() {
       window.removeEventListener('beforeunload', handleBeforeUnload);
       window.removeEventListener('popstate', handlePopState);
     };
-  }, [confirmExit, exitMessage, navigate]);
+  }, [confirmExit, exitMessage, lobbyPath, navigate]);
   const opponentName = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return params.get('opponent') || '';
@@ -17184,6 +17187,9 @@ export default function PoolRoyale() {
       tgId={tgId}
       playerName={playerName}
       opponentName={opponentName}
+      lobbyPath={lobbyPath}
     />
   );
 }
+
+export default PoolRoyale;

--- a/webapp/src/pages/Games/SnookerClub.jsx
+++ b/webapp/src/pages/Games/SnookerClub.jsx
@@ -1,0 +1,181 @@
+import React, { useCallback, useEffect, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { PoolRoyaleGame } from './PoolRoyale.jsx';
+import { getTelegramUsername, getTelegramId } from '../../utils/telegram.js';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { resolveTableSize as resolveSnookerTableSize } from '../../config/snookerClubTables.js';
+
+function normalizeVariantKey(value) {
+  if (typeof value !== 'string') return '';
+  return value
+    .toLowerCase()
+    .replace(/[_\s-]+/g, '')
+    .trim();
+}
+
+function resolveVariant(variantId) {
+  const normalized = normalizeVariantKey(variantId);
+  if (normalized === 'american' || normalized === 'us') return 'american';
+  if (normalized === '9ball' || normalized === 'nineball' || normalized === '9') return '9ball';
+  return 'uk';
+}
+
+export default function SnookerClub() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const lobbyPath = '/games/snookerclub/lobby';
+
+  const variantKey = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('variant');
+    return resolveVariant(requested);
+  }, [location.search]);
+
+  const tableSizeKey = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('tableSize');
+    return resolveSnookerTableSize(requested).id;
+  }, [location.search]);
+
+  const playType = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('type');
+    if (requested === 'training') return 'training';
+    if (requested === 'tournament') return 'tournament';
+    return 'regular';
+  }, [location.search]);
+
+  const mode = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('mode');
+    if (requested === 'online') return 'online';
+    if (requested === 'local') return 'local';
+    return 'ai';
+  }, [location.search]);
+
+  const trainingMode = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('mode');
+    return requested === 'solo' ? 'solo' : 'ai';
+  }, [location.search]);
+
+  const trainingRulesEnabled = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('rules') !== 'off';
+  }, [location.search]);
+
+  const accountId = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('accountId') || '';
+  }, [location.search]);
+
+  const tgId = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('tgId') || '';
+  }, [location.search]);
+
+  const playerName = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return (
+      params.get('name') ||
+      getTelegramUsername() ||
+      getTelegramId() ||
+      'Player'
+    );
+  }, [location.search]);
+
+  const stakeAmount = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return Number(params.get('amount')) || 0;
+  }, [location.search]);
+
+  const stakeToken = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('token') || 'TPC';
+  }, [location.search]);
+
+  const exitMessage = useMemo(
+    () =>
+      stakeAmount > 0
+        ? `Are you sure you want to exit? Your ${stakeAmount} ${stakeToken} stake will be lost.`
+        : 'Are you sure you want to exit the match?',
+    [stakeAmount, stakeToken]
+  );
+
+  const confirmExit = useCallback(() => {
+    return new Promise((resolve) => {
+      const tg = window?.Telegram?.WebApp;
+      if (tg?.showPopup) {
+        tg.showPopup(
+          {
+            title: 'Exit game?',
+            message: exitMessage,
+            buttons: [
+              { id: 'yes', type: 'destructive', text: 'Yes' },
+              { id: 'no', type: 'default', text: 'No' }
+            ]
+          },
+          (buttonId) => resolve(buttonId === 'yes')
+        );
+        return;
+      }
+
+      resolve(window.confirm(exitMessage));
+    });
+  }, [exitMessage]);
+
+  useTelegramBackButton(() => {
+    confirmExit().then((confirmed) => {
+      if (confirmed) {
+        navigate(lobbyPath);
+      }
+    });
+  });
+
+  useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      event.preventDefault();
+      event.returnValue = exitMessage;
+      return exitMessage;
+    };
+    const handlePopState = () => {
+      confirmExit().then((confirmed) => {
+        if (!confirmed) {
+          window.history.pushState(null, '', window.location.href);
+        } else {
+          navigate(lobbyPath);
+        }
+      });
+    };
+    window.history.pushState(null, '', window.location.href);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [confirmExit, exitMessage, lobbyPath, navigate]);
+
+  const opponentName = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('opponent') || '';
+  }, [location.search]);
+
+  return (
+    <PoolRoyaleGame
+      variantKey={variantKey}
+      tableSizeKey={tableSizeKey}
+      playType={playType}
+      mode={mode}
+      trainingMode={trainingMode}
+      trainingRulesEnabled={trainingRulesEnabled}
+      accountId={accountId}
+      tgId={tgId}
+      playerName={playerName}
+      opponentName={opponentName}
+      gameId="snookerclub"
+      lobbyPath={lobbyPath}
+      tableResolver={resolveSnookerTableSize}
+    />
+  );
+}

--- a/webapp/src/pages/Games/SnookerClubLobby.jsx
+++ b/webapp/src/pages/Games/SnookerClubLobby.jsx
@@ -1,0 +1,344 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import TableSelector from '../../components/TableSelector.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import {
+  ensureAccountId,
+  getTelegramId,
+  getTelegramPhotoUrl,
+  getTelegramFirstName
+} from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { resolveTableSize, TABLE_SIZE_LIST } from '../../config/snookerClubTables.js';
+import { socket } from '../../utils/socket.js';
+
+export default function SnookerClubLobby() {
+  const navigate = useNavigate();
+  const { search } = useLocation();
+  useTelegramBackButton();
+
+  const searchParams = new URLSearchParams(search);
+  const initialPlayType = (() => {
+    const requestedType = searchParams.get('type');
+    return requestedType === 'training' || requestedType === 'tournament'
+      ? requestedType
+      : 'regular';
+  })();
+
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [mode, setMode] = useState('ai');
+  const [avatar, setAvatar] = useState('');
+  const variant = 'uk';
+  const [playType, setPlayType] = useState(initialPlayType);
+  const [players, setPlayers] = useState(8);
+  const [trainingVariant, setTrainingVariant] = useState('uk');
+  const [trainingMode, setTrainingMode] = useState('solo');
+  const [trainingRulesEnabled, setTrainingRulesEnabled] = useState(true);
+  const [tableSize, setTableSize] = useState(() => resolveTableSize(searchParams.get('tableSize')).id);
+  const [matching, setMatching] = useState(false);
+  const [matchingError, setMatchingError] = useState('');
+  const [matchPlayers, setMatchPlayers] = useState([]);
+  const [matchTableId, setMatchTableId] = useState('');
+  const [readyList, setReadyList] = useState([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const spinIntervalRef = useRef(null);
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    const syncAvatar = () => {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    };
+    window.addEventListener('profilePhotoUpdated', syncAvatar);
+    return () => window.removeEventListener('profilePhotoUpdated', syncAvatar);
+  }, []);
+
+  useEffect(() => {
+    if (playType !== 'training') return;
+    setTrainingVariant((current) => current || variant);
+  }, [playType, variant]);
+
+  const startGame = async () => {
+    let tgId;
+    let accountId;
+    if (playType !== 'training') {
+      try {
+        accountId = await ensureAccountId();
+        const balRes = await getAccountBalance(accountId);
+        if ((balRes.balance || 0) < stake.amount) {
+          alert('Insufficient balance');
+          return;
+        }
+        tgId = getTelegramId();
+        if (mode !== 'online') {
+          await addTransaction(tgId, -stake.amount, 'stake', {
+            game: 'snookerclub',
+            players: playType === 'tournament' ? players : 2,
+            accountId
+          });
+        }
+      } catch {}
+    } else {
+      try {
+        tgId = getTelegramId();
+        accountId = await ensureAccountId();
+      } catch {}
+    }
+
+    if (mode === 'online' && playType === 'regular') {
+      setMatchingError('');
+      setIsSearching(true);
+      if (!accountId) {
+        setIsSearching(false);
+        setMatchingError('Unable to resolve your TPC account.');
+        return;
+      }
+      socket.emit('register', { playerId: accountId, accountId });
+      socket.emit(
+        'seatTable',
+        {
+          accountId,
+          gameType: 'snookerclub',
+          stake: stake.amount,
+          maxPlayers: 2,
+          token: stake.token,
+          variant,
+          tableSize,
+          playType,
+          playerName: getTelegramFirstName() || `TPC ${accountId}`,
+          avatar
+        },
+        (res) => {
+          setIsSearching(false);
+          if (res?.success) {
+            setMatchTableId(res.tableId);
+            setMatchPlayers(res.players || []);
+            setReadyList(res.ready || []);
+            socket.emit('confirmReady', {
+              accountId,
+              tableId: res.tableId
+            });
+            setMatching(true);
+          } else {
+            setMatchingError(
+              res?.message || 'Failed to join the online arena. Please retry.'
+            );
+          }
+        }
+      );
+      return;
+    }
+
+    const params = new URLSearchParams();
+    const resolvedVariant = playType === 'training' ? trainingVariant : variant;
+    params.set('variant', resolvedVariant);
+    params.set('tableSize', tableSize);
+    params.set('type', playType);
+    params.set('mode', playType === 'training' ? trainingMode : mode);
+    if (playType === 'training') {
+      params.set('rules', trainingRulesEnabled ? 'on' : 'off');
+    }
+    if (playType !== 'training') {
+      if (stake.token) params.set('token', stake.token);
+      if (stake.amount) params.set('amount', stake.amount);
+      if (playType === 'tournament') params.set('players', players);
+    }
+    const initData = window.Telegram?.WebApp?.initData;
+    if (avatar) params.set('avatar', avatar);
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    const name = getTelegramFirstName();
+    if (name) params.set('name', name);
+    if (initData) params.set('init', encodeURIComponent(initData));
+
+    if (playType === 'tournament') {
+      window.location.href = `/pool-royale-bracket.html?${params.toString()}`;
+      return;
+    }
+
+    const target = `/games/snookerclub?${params.toString()}`;
+    window.location.href = target;
+  };
+
+  useEffect(() => {
+    return () => {
+      if (spinIntervalRef.current) {
+        clearInterval(spinIntervalRef.current);
+      }
+    };
+  }, []);
+
+  const tableOptions = useMemo(
+    () => TABLE_SIZE_LIST.map((entry) => ({ id: entry.id, label: entry.label })),
+    []
+  );
+
+  return (
+    <div className="p-4 space-y-4 text-text">
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          className="text-sm text-primary"
+          onClick={() => navigate(-1)}
+        >
+          Back
+        </button>
+        <h2 className="text-xl font-semibold">Snooker Club Lobby</h2>
+        <div className="w-10 h-10 rounded-full overflow-hidden border border-border bg-surface">
+          {avatar ? (
+            <img src={avatar} alt="avatar" className="w-full h-full object-cover" />
+          ) : (
+            <div className="w-full h-full bg-border" />
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-4 bg-surface rounded-xl border border-border p-4">
+        <div className="grid grid-cols-2 gap-2 text-sm">
+          <button
+            type="button"
+            className={`lobby-pill ${playType === 'regular' ? 'lobby-selected' : ''}`}
+            onClick={() => setPlayType('regular')}
+          >
+            Staking
+          </button>
+          <button
+            type="button"
+            className={`lobby-pill ${playType === 'training' ? 'lobby-selected' : ''}`}
+            onClick={() => setPlayType('training')}
+          >
+            Training
+          </button>
+          <button
+            type="button"
+            className={`lobby-pill ${playType === 'tournament' ? 'lobby-selected' : ''}`}
+            onClick={() => setPlayType('tournament')}
+          >
+            Tournament
+          </button>
+        </div>
+
+        <RoomSelector
+          title="Mode"
+          options={[
+            { id: 'ai', label: 'VS AI' },
+            { id: 'online', label: 'Online' },
+            { id: 'local', label: 'Local Multiplayer' }
+          ]}
+          selected={mode}
+          onChange={setMode}
+        />
+
+        <div className="space-y-2">
+          <p className="text-sm font-semibold">Table</p>
+          <TableSelector
+            tables={tableOptions}
+            selected={tableOptions.find((t) => t.id === tableSize)}
+            onSelect={(t) => setTableSize(t.id)}
+          />
+        </div>
+
+        {playType !== 'training' && (
+          <div className="grid grid-cols-2 gap-2 text-sm">
+            <label className="flex flex-col">
+              <span className="text-subtext text-xs">Token</span>
+              <input
+                value={stake.token}
+                onChange={(e) => setStake((s) => ({ ...s, token: e.target.value }))}
+                className="lobby-input"
+              />
+            </label>
+            <label className="flex flex-col">
+              <span className="text-subtext text-xs">Stake</span>
+              <input
+                type="number"
+                value={stake.amount}
+                onChange={(e) => setStake((s) => ({ ...s, amount: Number(e.target.value) }))}
+                className="lobby-input"
+              />
+            </label>
+          </div>
+        )}
+
+        {playType === 'tournament' && (
+          <div className="space-y-1">
+            <p className="text-sm">Players</p>
+            <input
+              type="number"
+              className="lobby-input"
+              min={4}
+              max={32}
+              value={players}
+              onChange={(e) => setPlayers(Number(e.target.value))}
+            />
+          </div>
+        )}
+
+        {playType === 'training' && (
+          <div className="space-y-2">
+            <RoomSelector
+              title="Training Mode"
+              options={[
+                { id: 'solo', label: 'Solo' },
+                { id: 'ai', label: 'VS AI' }
+              ]}
+              selected={trainingMode}
+              onChange={setTrainingMode}
+            />
+            <RoomSelector
+              title="Rules"
+              options={[
+                { id: 'on', label: 'Follow Rules' },
+                { id: 'off', label: 'Free Practice' }
+              ]}
+              selected={trainingRulesEnabled ? 'on' : 'off'}
+              onChange={(val) => setTrainingRulesEnabled(val === 'on')}
+            />
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={startGame}
+          disabled={isSearching}
+          className="w-full lobby-button"
+        >
+          {isSearching ? 'Finding Table…' : 'Start'}
+        </button>
+
+        {matching && (
+          <div className="p-3 rounded-lg bg-surface/70 border border-border space-y-2">
+            <p className="text-sm font-semibold">Matching…</p>
+            <p className="text-xs text-subtext">
+              Waiting for your opponent to confirm. Table {matchTableId || 'pending'}
+            </p>
+            {matchPlayers.length > 0 && (
+              <ul className="text-xs list-disc list-inside text-subtext">
+                {matchPlayers.map((p) => (
+                  <li key={p.accountId || p.id}>{p.name || p.accountId}</li>
+                ))}
+              </ul>
+            )}
+            {readyList.length > 0 && (
+              <p className="text-xs text-primary">Ready: {readyList.length}</p>
+            )}
+          </div>
+        )}
+
+        {matchingError && (
+          <div className="text-xs text-red-400 bg-red-900/20 border border-red-700 rounded-lg p-2">
+            {matchingError}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Snooker Club routes alongside Pool Royale
- introduce snooker table presets and wrapper game component that reuses the 3D table with independent lobby navigation
- build a dedicated Snooker Club lobby with staking, training, tournament, and online/AI options

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937ca7662948329b5a606e2774c88e3)