### PR TITLE
Update Chess Battle Royal board and piece palettes

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -270,66 +270,23 @@ const CHECKMATE_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
 
 const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
-  {
-    id: 'beautifulGameAuroraMetal',
-    name: 'Aurora Metal',
-    piece: { white: '#dce6ff', black: '#111827', accent: '#7dd3fc' },
-    board: { light: '#d9f5ff', dark: '#0b1220', accent: '#7dd3fc' }
-  },
-  {
-    id: 'beautifulGameObsidianGold',
-    name: 'Obsidian / Gold',
-    piece: { white: '#f8ead4', black: '#141414', accent: '#d4a017' },
-    board: { light: '#f4e8d2', dark: '#1e1e1e', accent: '#d4a017' }
-  },
-  {
-    id: 'beautifulGameGlacierMint',
-    name: 'Glacier / Mint',
-    piece: { white: '#ecfeff', black: '#0f172a', accent: '#34d399' },
-    board: { light: '#d1fae5', dark: '#0f172a', accent: '#34d399' }
-  },
-  {
-    id: 'beautifulGameSakuraSlate',
-    name: 'Sakura / Slate',
-    piece: { white: '#ffe4ec', black: '#2b3040', accent: '#fb7185' },
-    board: { light: '#ffd8e3', dark: '#1f2635', accent: '#fb7185' }
-  },
-  {
-    id: 'beautifulGameVoltTeal',
-    name: 'Volt / Teal',
-    piece: { white: '#faffb5', black: '#0f766e', accent: '#22d3ee' },
-    board: { light: '#e8ffb5', dark: '#0b3b3c', accent: '#22d3ee' }
-  },
-  {
-    id: 'beautifulGameCopperIvory',
-    name: 'Copper / Ivory',
-    piece: { white: '#f5f0e5', black: '#5a2c1f', accent: '#e38b29' },
-    board: { light: '#f4ede1', dark: '#3b241a', accent: '#e38b29' }
-  },
-  {
-    id: 'beautifulGameNoirNeon',
-    name: 'Noir / Neon',
-    piece: { white: '#e5e7eb', black: '#0a0d14', accent: '#06f0ff' },
-    board: { light: '#c7d2fe', dark: '#0a0d14', accent: '#06f0ff' }
-  },
-  {
-    id: 'beautifulGameCinderRose',
-    name: 'Cinder / Rose',
-    piece: { white: '#f5d0c5', black: '#1f1b29', accent: '#f43f5e' },
-    board: { light: '#f8d7cc', dark: '#1b1524', accent: '#f43f5e' }
-  },
-  {
-    id: 'beautifulGameHarborFog',
-    name: 'Harbor Fog',
-    piece: { white: '#e2e8f0', black: '#1e293b', accent: '#38bdf8' },
-    board: { light: '#dbeafe', dark: '#0b1220', accent: '#38bdf8' }
-  },
-  {
-    id: 'beautifulGameDesertStorm',
-    name: 'Desert Storm',
-    piece: { white: '#fef3c7', black: '#4b3421', accent: '#fbbf24' },
-    board: { light: '#fde68a', dark: '#2d1f12', accent: '#fbbf24' }
-  }
+  { id: 'beautifulGameClassic', name: 'Classic', board: { light: '#EEE8D5', dark: '#2B2F36' } },
+  { id: 'beautifulGameMono', name: 'Mono', board: { light: '#E5E7EB', dark: '#111827' } },
+  { id: 'beautifulGameBlue', name: 'Blue', board: { light: '#93C5FD', dark: '#1E293B' } },
+  { id: 'beautifulGameAmber', name: 'Amber', board: { light: '#FDE68A', dark: '#1F2937' } },
+  { id: 'beautifulGameMint', name: 'Mint', board: { light: '#A7F3D0', dark: '#065F46' } },
+  { id: 'beautifulGamePink', name: 'Pink', board: { light: '#FBCFE8', dark: '#312E81' } },
+  { id: 'beautifulGameTeal', name: 'Teal', board: { light: '#99F6E4', dark: '#0F172A' } }
+]);
+
+const BEAUTIFUL_GAME_PIECE_COLORS = Object.freeze([
+  { id: 'beautifulGamePieceClassic', name: 'Classic White', color: '#ffffff' },
+  { id: 'beautifulGamePieceSlate', name: 'Midnight', color: '#111827' },
+  { id: 'beautifulGamePieceAmber', name: 'Amber', color: '#f59e0b' },
+  { id: 'beautifulGamePieceMint', name: 'Mint', color: '#10b981' },
+  { id: 'beautifulGamePieceBlue', name: 'Blue', color: '#3b82f6' },
+  { id: 'beautifulGamePieceRed', name: 'Crimson', color: '#ef4444' },
+  { id: 'beautifulGamePieceViolet', name: 'Violet', color: '#8b5cf6' }
 ]);
 
 const BEAUTIFUL_GAME_THEME_NAMES = BEAUTIFUL_GAME_THEME_CONFIGS.map((config) => config.name);
@@ -338,7 +295,7 @@ const BEAUTIFUL_GAME_THEME = Object.freeze(
   buildBoardTheme({
     ...(BOARD_COLOR_BASE_OPTIONS.find((option) => option.id === 'slateJade') ?? {}),
     id: 'beautifulGameAuthenticBoard',
-    label: 'Aurora Metal',
+    label: 'Classic',
     light: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.light,
     dark: BEAUTIFUL_GAME_THEME_CONFIGS[0].board.dark,
     frameLight: '#c5d8ff',
@@ -431,36 +388,28 @@ const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
   blackAccent: '#7dd3fc'
 });
 
-const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGameAuroraMetal';
+const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGamePieceClassic';
 const BEAUTIFUL_GAME_SET_ID = 'beautifulGameAuroraMetalSet';
 
 const BASE_PIECE_STYLE = BEAUTIFUL_GAME_PIECE_STYLE;
 
 const BEAUTIFUL_GAME_COLOR_VARIANTS = Object.freeze(
-  BEAUTIFUL_GAME_THEME_CONFIGS.map((config) => {
-    const preserveOriginal = Boolean(config.piece?.preserveOriginal);
-    const pieceStyle = preserveOriginal
-      ? { ...BASE_PIECE_STYLE, preserveOriginalMaterials: true, keepTextures: true }
-      : {
-          ...BASE_PIECE_STYLE,
-          preserveOriginalMaterials: false,
-          keepTextures: true,
-          white: { ...BASE_PIECE_STYLE.white, color: config.piece?.white ?? BASE_PIECE_STYLE.white.color },
-          black: { ...BASE_PIECE_STYLE.black, color: config.piece?.black ?? BASE_PIECE_STYLE.black.color },
-          accent: config.piece?.accent ?? BASE_PIECE_STYLE.accent,
-          goldAccent: config.piece?.goldAccent ?? BASE_PIECE_STYLE.goldAccent,
-          whiteAccent: config.piece?.whiteAccent ?? BASE_PIECE_STYLE.whiteAccent,
-          blackAccent: config.piece?.blackAccent ?? BASE_PIECE_STYLE.blackAccent
-        };
-    return {
-      id: config.id,
-      label: `ABeautifulGame (${config.name})`,
-      style: pieceStyle
-    };
-  })
+  BEAUTIFUL_GAME_PIECE_COLORS.map((swatch) => ({
+    id: swatch.id,
+    label: `Pieces ${swatch.name}`,
+    style: {
+      ...BASE_PIECE_STYLE,
+      keepTextures: true,
+      preserveOriginalMaterials: false,
+      white: { ...BASE_PIECE_STYLE.white, color: swatch.color },
+      black: { ...BASE_PIECE_STYLE.black, color: swatch.color },
+      accent: BASE_PIECE_STYLE.accent,
+      goldAccent: BASE_PIECE_STYLE.goldAccent,
+      whiteAccent: BASE_PIECE_STYLE.whiteAccent,
+      blackAccent: BASE_PIECE_STYLE.blackAccent
+    }
+  }))
 );
-
-const pieceStyleSignature = (style) => `${style?.white?.color ?? ''}|${style?.black?.color ?? ''}`;
 
 const DEFAULT_PIECE_STYLE =
   BEAUTIFUL_GAME_COLOR_VARIANTS.find((variant) => variant.id === BEAUTIFUL_GAME_AUTHENTIC_ID)?.style ||
@@ -666,19 +615,12 @@ const POLYGONAL_GRAPHITE_STYLE = Object.freeze({
 });
 
 const PIECE_STYLE_OPTIONS = Object.freeze(
-  BEAUTIFUL_GAME_COLOR_VARIANTS.reduce((list, variant) => {
-    const signature = pieceStyleSignature(variant.style);
-    if (list.some((option) => pieceStyleSignature(option.style) === signature)) {
-      return list;
-    }
-    list.push({
-      id: variant.id,
-      label: variant.label,
-      style: variant.style,
-      loader: (targetBoardSize) => resolveBeautifulGameAssets(targetBoardSize)
-    });
-    return list;
-  }, [])
+  BEAUTIFUL_GAME_COLOR_VARIANTS.map((variant) => ({
+    id: variant.id,
+    label: variant.label,
+    style: variant.style,
+    loader: (targetBoardSize) => resolveBeautifulGameAssets(targetBoardSize)
+  }))
 );
 
 const BEAUTIFUL_GAME_PIECE_INDEX = Math.max(
@@ -814,8 +756,8 @@ const DEFAULT_APPEARANCE = {
   chairColor: 0,
   tableShape: 0,
   boardColor: 0,
-  whitePieceStyle: Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX),
-  blackPieceStyle: Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX),
+  whitePieceStyle: 0,
+  blackPieceStyle: 1,
   headStyle: 0
 };
 const APPEARANCE_STORAGE_KEY = 'chessBattleRoyalAppearance';
@@ -868,8 +810,8 @@ const TABLE_SHAPE_MENU_OPTIONS = TABLE_SHAPE_OPTIONS.filter((option) => option.i
 const PRESERVE_NATIVE_PIECE_IDS = new Set();
 
 const CUSTOMIZATION_SECTIONS = [
-  { key: 'whitePieceStyle', label: 'White Pieces', options: PIECE_STYLE_OPTIONS },
-  { key: 'blackPieceStyle', label: 'Black Pieces', options: PIECE_STYLE_OPTIONS },
+  { key: 'whitePieceStyle', label: 'Pieces P1 (bottom)', options: PIECE_STYLE_OPTIONS },
+  { key: 'blackPieceStyle', label: 'Pieces P2 (top)', options: PIECE_STYLE_OPTIONS },
   { key: 'headStyle', label: 'Heads (Pawn & Bishop)', options: HEAD_PRESET_OPTIONS },
   { key: 'boardColor', label: 'Chess Board', options: BEAUTIFUL_GAME_BOARD_OPTIONS },
   { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },
@@ -2090,6 +2032,10 @@ function applyBeautifulGameStyleToMeshes(meshes, pieceStyle = BEAUTIFUL_GAME_PIE
     const targetColor = colorKey === 'black' ? darkColor : lightColor;
     mesh.traverse((child) => {
       if (!child?.isMesh) return;
+      const clonedMaterials = Array.isArray(child.material)
+        ? child.material.map((mat) => (mat?.clone ? mat.clone() : mat))
+        : [child.material?.clone ? child.material.clone() : child.material];
+      child.material = Array.isArray(child.material) ? clonedMaterials : clonedMaterials[0];
       const mats = Array.isArray(child.material) ? child.material : [child.material];
       mats.forEach((mat) => {
         if (!mat) return;


### PR DESCRIPTION
## Summary
- limit chess board presets to the ABeautifulGame palette and set the classic default
- add P1/P2 piece color swatches that reuse GLTF materials instead of procedural sets
- clone piece materials when recoloring so GLTF surfaces persist after palette changes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937d090780c832999d685c615f4cb53)