### PR TITLE
Align chess board and piece palettes

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -272,63 +272,45 @@ const CHECKMATE_SOUND_URL =
 const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
   {
     id: 'beautifulGameAuroraMetal',
-    name: 'Aurora Metal',
-    piece: { white: '#dce6ff', black: '#111827', accent: '#7dd3fc' },
-    board: { light: '#d9f5ff', dark: '#0b1220', accent: '#7dd3fc' }
+    name: 'Classic',
+    piece: { white: '#ffffff', black: '#ffffff', accent: '#ffffff' },
+    board: { light: '#EEE8D5', dark: '#2B2F36', accent: '#ffffff' }
   },
   {
-    id: 'beautifulGameObsidianGold',
-    name: 'Obsidian / Gold',
-    piece: { white: '#f8ead4', black: '#141414', accent: '#d4a017' },
-    board: { light: '#f4e8d2', dark: '#1e1e1e', accent: '#d4a017' }
+    id: 'beautifulGameMono',
+    name: 'Mono',
+    piece: { white: '#111827', black: '#111827', accent: '#111827' },
+    board: { light: '#E5E7EB', dark: '#111827', accent: '#111827' }
   },
   {
-    id: 'beautifulGameGlacierMint',
-    name: 'Glacier / Mint',
-    piece: { white: '#ecfeff', black: '#0f172a', accent: '#34d399' },
-    board: { light: '#d1fae5', dark: '#0f172a', accent: '#34d399' }
+    id: 'beautifulGameBlue',
+    name: 'Blue',
+    piece: { white: '#3b82f6', black: '#3b82f6', accent: '#3b82f6' },
+    board: { light: '#93C5FD', dark: '#1E293B', accent: '#3b82f6' }
   },
   {
-    id: 'beautifulGameSakuraSlate',
-    name: 'Sakura / Slate',
-    piece: { white: '#ffe4ec', black: '#2b3040', accent: '#fb7185' },
-    board: { light: '#ffd8e3', dark: '#1f2635', accent: '#fb7185' }
+    id: 'beautifulGameAmber',
+    name: 'Amber',
+    piece: { white: '#f59e0b', black: '#f59e0b', accent: '#f59e0b' },
+    board: { light: '#FDE68A', dark: '#1F2937', accent: '#f59e0b' }
   },
   {
-    id: 'beautifulGameVoltTeal',
-    name: 'Volt / Teal',
-    piece: { white: '#faffb5', black: '#0f766e', accent: '#22d3ee' },
-    board: { light: '#e8ffb5', dark: '#0b3b3c', accent: '#22d3ee' }
+    id: 'beautifulGameMint',
+    name: 'Mint',
+    piece: { white: '#10b981', black: '#10b981', accent: '#10b981' },
+    board: { light: '#A7F3D0', dark: '#065F46', accent: '#10b981' }
   },
   {
-    id: 'beautifulGameCopperIvory',
-    name: 'Copper / Ivory',
-    piece: { white: '#f5f0e5', black: '#5a2c1f', accent: '#e38b29' },
-    board: { light: '#f4ede1', dark: '#3b241a', accent: '#e38b29' }
+    id: 'beautifulGamePink',
+    name: 'Pink',
+    piece: { white: '#ef4444', black: '#ef4444', accent: '#ef4444' },
+    board: { light: '#FBCFE8', dark: '#312E81', accent: '#ef4444' }
   },
   {
-    id: 'beautifulGameNoirNeon',
-    name: 'Noir / Neon',
-    piece: { white: '#e5e7eb', black: '#0a0d14', accent: '#06f0ff' },
-    board: { light: '#c7d2fe', dark: '#0a0d14', accent: '#06f0ff' }
-  },
-  {
-    id: 'beautifulGameCinderRose',
-    name: 'Cinder / Rose',
-    piece: { white: '#f5d0c5', black: '#1f1b29', accent: '#f43f5e' },
-    board: { light: '#f8d7cc', dark: '#1b1524', accent: '#f43f5e' }
-  },
-  {
-    id: 'beautifulGameHarborFog',
-    name: 'Harbor Fog',
-    piece: { white: '#e2e8f0', black: '#1e293b', accent: '#38bdf8' },
-    board: { light: '#dbeafe', dark: '#0b1220', accent: '#38bdf8' }
-  },
-  {
-    id: 'beautifulGameDesertStorm',
-    name: 'Desert Storm',
-    piece: { white: '#fef3c7', black: '#4b3421', accent: '#fbbf24' },
-    board: { light: '#fde68a', dark: '#2d1f12', accent: '#fbbf24' }
+    id: 'beautifulGameTeal',
+    name: 'Teal',
+    piece: { white: '#8b5cf6', black: '#8b5cf6', accent: '#8b5cf6' },
+    board: { light: '#99F6E4', dark: '#0F172A', accent: '#8b5cf6' }
   }
 ]);
 
@@ -402,9 +384,10 @@ const SCULPTED_DRAG_STYLE = Object.freeze({
 
 const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
   id: 'beautifulGameAuroraMetal',
-  label: 'Aurora Metal',
+  label: 'Classic',
+  keepTextures: true,
   white: {
-    color: '#e5edff',
+    color: '#ffffff',
     roughness: 0.22,
     metalness: 0.42,
     sheen: 0.32,
@@ -414,7 +397,7 @@ const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
     specularIntensity: 0.78
   },
   black: {
-    color: '#0f172a',
+    color: '#111827',
     roughness: 0.24,
     metalness: 0.44,
     sheen: 0.28,
@@ -425,10 +408,10 @@ const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
     emissive: '#0a1020',
     emissiveIntensity: 0.18
   },
-  accent: '#7dd3fc',
-  goldAccent: '#9cc3ff',
-  whiteAccent: { color: '#e5edff' },
-  blackAccent: '#7dd3fc'
+  accent: '#ffffff',
+  goldAccent: '#ffffff',
+  whiteAccent: { color: '#ffffff' },
+  blackAccent: '#ffffff'
 });
 
 const BEAUTIFUL_GAME_AUTHENTIC_ID = 'beautifulGameAuroraMetal';
@@ -814,8 +797,8 @@ const DEFAULT_APPEARANCE = {
   chairColor: 0,
   tableShape: 0,
   boardColor: 0,
-  whitePieceStyle: Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX),
-  blackPieceStyle: Math.max(0, BEAUTIFUL_GAME_PIECE_INDEX),
+  whitePieceStyle: 0,
+  blackPieceStyle: 1,
   headStyle: 0
 };
 const APPEARANCE_STORAGE_KEY = 'chessBattleRoyalAppearance';
@@ -868,8 +851,8 @@ const TABLE_SHAPE_MENU_OPTIONS = TABLE_SHAPE_OPTIONS.filter((option) => option.i
 const PRESERVE_NATIVE_PIECE_IDS = new Set();
 
 const CUSTOMIZATION_SECTIONS = [
-  { key: 'whitePieceStyle', label: 'White Pieces', options: PIECE_STYLE_OPTIONS },
-  { key: 'blackPieceStyle', label: 'Black Pieces', options: PIECE_STYLE_OPTIONS },
+  { key: 'whitePieceStyle', label: 'Pieces P1 (bottom)', options: PIECE_STYLE_OPTIONS },
+  { key: 'blackPieceStyle', label: 'Pieces P2 (top)', options: PIECE_STYLE_OPTIONS },
   { key: 'headStyle', label: 'Heads (Pawn & Bishop)', options: HEAD_PRESET_OPTIONS },
   { key: 'boardColor', label: 'Chess Board', options: BEAUTIFUL_GAME_BOARD_OPTIONS },
   { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },


### PR DESCRIPTION
## Summary
- updated chess board presets to match the target seven-color palette from the reference implementation
- simplified piece style palette to the same set of GLTF-friendly colors with defaults for P1 and P2
- adjusted customization labels to highlight P1/P2 piece selection

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937d090780c832999d685c615f4cb53)