### PR TITLE
Ensure Snooker Club uses snooker markings and AI training

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8142,10 +8142,13 @@ export function PoolRoyaleGame({
   const rafRef = useRef(null);
   const worldRef = useRef(null);
   const rules = useMemo(() => new PoolRoyaleRules(variantKey), [variantKey]);
-  const activeVariant = useMemo(
-    () => resolvePoolVariant(variantKey),
-    [variantKey]
-  );
+  const activeVariant = useMemo(() => {
+    const resolved = resolvePoolVariant(variantKey);
+    if (gameId === 'snookerclub') {
+      return { ...resolved, disableSnookerMarkings: false };
+    }
+    return resolved;
+  }, [gameId, variantKey]);
   const activeTableSize = useMemo(
     () => tableResolver(tableSizeKey),
     [tableResolver, tableSizeKey]

--- a/webapp/src/pages/Games/SnookerClubLobby.jsx
+++ b/webapp/src/pages/Games/SnookerClubLobby.jsx
@@ -33,7 +33,7 @@ export default function SnookerClubLobby() {
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const [trainingVariant, setTrainingVariant] = useState('uk');
-  const [trainingMode, setTrainingMode] = useState('solo');
+  const [trainingMode, setTrainingMode] = useState('ai');
   const [trainingRulesEnabled, setTrainingRulesEnabled] = useState(true);
   const [tableSize, setTableSize] = useState(() => resolveTableSize(searchParams.get('tableSize')).id);
   const [matching, setMatching] = useState(false);


### PR DESCRIPTION
## Summary
- keep snooker baulk/D-line markings visible in Snooker Club regardless of pool variant defaults
- default Snooker Club training sessions to AI mode to mirror the previous snooker training experience

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e0c74ff88329ab8a835bf7eb6bb4)