### PR TITLE
Add snooker visuals and training defaults to Snooker Club

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -211,7 +211,13 @@ export class PoolRoyaleRules {
 
   constructor(variantKey: string | null | undefined) {
     const normalized = normalizeVariantId(variantKey);
-    if (normalized === 'uk' || normalized === '8balluk' || normalized === 'eightballuk' || normalized === 'uk8') {
+    if (
+      normalized === 'uk' ||
+      normalized === '8balluk' ||
+      normalized === 'eightballuk' ||
+      normalized === 'uk8' ||
+      normalized === 'snooker'
+    ) {
       this.variant = 'uk';
     } else if (normalized === '9ball' || normalized === 'nineball' || normalized === '9') {
       this.variant = '9ball';

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1138,7 +1138,18 @@ const DEFAULT_POOL_VARIANT = 'american';
 const UK_POOL_RED = 0xd12c2c;
 const UK_POOL_YELLOW = 0xffd700;
 const UK_POOL_BLACK = 0x000000;
+const SNOOKER_RED = 0xc3092f;
 const POOL_VARIANT_COLOR_SETS = Object.freeze({
+  snooker: {
+    id: 'snooker',
+    label: 'Snooker',
+    cueColor: 0xffffff,
+    rackLayout: 'triangle',
+    disableSnookerMarkings: false,
+    objectColors: new Array(15).fill(SNOOKER_RED),
+    objectNumbers: new Array(15).fill(null),
+    objectPatterns: new Array(15).fill('solid')
+  },
   uk: {
     id: 'uk',
     label: '8-Ball UK',
@@ -1282,7 +1293,9 @@ function normalizeVariantKey(value) {
 function resolvePoolVariant(variantId) {
   const normalized = normalizeVariantKey(variantId);
   let key = normalized;
-  if (normalized === '9' || normalized === 'nineball') {
+  if (normalized === 'snooker' || normalized === 'snookerclub') {
+    key = 'snooker';
+  } else if (normalized === '9' || normalized === 'nineball') {
     key = '9ball';
   } else if (
     normalized === '8balluk' ||
@@ -1467,6 +1480,9 @@ function getPoolBallPattern(variant, index) {
 
 function getPoolBallId(variant, index) {
   if (!variant) return `ball_${index + 1}`;
+  if (variant.id === 'snooker') {
+    return `red_${index + 1}`;
+  }
   if (variant.id === 'uk') {
     const color = getPoolBallColor(variant, index);
     if (color === UK_POOL_BLACK) return 'black_8';
@@ -14551,6 +14567,13 @@ export function PoolRoyaleGame({
           const upper = colorId.toUpperCase();
           if (upper === 'CUE') return 'cue';
           if (upper.startsWith('YELLOW') || upper.startsWith('BLUE')) return 'blue';
+          if (
+            upper.startsWith('GREEN') ||
+            upper.startsWith('BROWN') ||
+            upper.startsWith('PINK')
+          ) {
+            return 'blue';
+          }
           if (upper.startsWith('RED')) return 'red';
           if (upper.startsWith('BLACK')) return 'black';
           return null;

--- a/webapp/src/pages/Games/SnookerClub.jsx
+++ b/webapp/src/pages/Games/SnookerClub.jsx
@@ -17,7 +17,8 @@ function resolveVariant(variantId) {
   const normalized = normalizeVariantKey(variantId);
   if (normalized === 'american' || normalized === 'us') return 'american';
   if (normalized === '9ball' || normalized === 'nineball' || normalized === '9') return '9ball';
-  return 'uk';
+  if (normalized === 'snooker' || normalized === 'snookerclub') return 'snooker';
+  return 'snooker';
 }
 
 export default function SnookerClub() {

--- a/webapp/src/pages/Games/SnookerClubLobby.jsx
+++ b/webapp/src/pages/Games/SnookerClubLobby.jsx
@@ -29,11 +29,11 @@ export default function SnookerClubLobby() {
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState('ai');
   const [avatar, setAvatar] = useState('');
-  const variant = 'uk';
+  const variant = 'snooker';
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
-  const [trainingVariant, setTrainingVariant] = useState('uk');
-  const [trainingMode, setTrainingMode] = useState('solo');
+  const [trainingVariant, setTrainingVariant] = useState('snooker');
+  const [trainingMode, setTrainingMode] = useState('ai');
   const [trainingRulesEnabled, setTrainingRulesEnabled] = useState(true);
   const [tableSize, setTableSize] = useState(() => resolveTableSize(searchParams.get('tableSize')).id);
   const [matching, setMatching] = useState(false);


### PR DESCRIPTION
## Summary
- add a dedicated snooker variant so the D-line markings and spot balls render like the 3D build
- default the Snooker Club lobby and game to the snooker set with AI training enabled by default
- route snooker selections through existing rule handling and ball IDs for AI compatibility

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e0c74ff88329ab8a835bf7eb6bb4)