### PR TITLE
Align Pool Royale table sizing across variants

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -14,12 +14,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 127
     }),
     cushionCutAngleDeg: 35,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
-    scaleOverrides: Object.freeze({
-      scale: 1.56,
-      mobileScale: 1.72,
-      compactScale: 1.48
-    })
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   },
   '8ft': {
     id: '8ft',


### PR DESCRIPTION
## Summary
- remove the 9ft table scale overrides so Pool Royale uses the baseline dimensions for all variants
- keep snooker club sizing untouched while preserving existing table spec metadata

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938234cde2c8329ac1f8f0618dfd021)