### PR TITLE
Add GLTF-only chess scene with white palette swap

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -4743,7 +4743,7 @@ const formatTime = (t) =>
   `${Math.floor(t / 60)}:${String(t % 60).padStart(2, '0')}`;
 
 // ======================= Main Component =======================
-function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
+function LegacyChess3D({ avatar, username, initialFlag, initialAiFlag }) {
   const wrapRef = useRef(null);
   const rafRef = useRef(0);
   const timerRef = useRef(null);
@@ -6977,28 +6977,610 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
   );
 }
 
+function Chess3D() {
+  const hostRef = useRef(null);
+  const [status, setStatus] = useState('Starting…');
+  const [banner, setBanner] = useState('Loading ABeautifulGame…');
+
+  useEffect(() => {
+    const container = hostRef.current;
+    if (!container) return;
+
+    const S = 8;
+    const TILE = 1.0;
+    const BOARD = S * TILE;
+    const HALF = BOARD / 2;
+    const MODEL_URLS = [
+      'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
+      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
+      'https://rawcdn.githack.com/KhronosGroup/glTF-Sample-Models/master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
+      'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf'
+    ];
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.setSize(
+      container.clientWidth || window.innerWidth,
+      container.clientHeight || window.innerHeight
+    );
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 1.25;
+    renderer.domElement.style.touchAction = 'none';
+    renderer.domElement.oncontextmenu = (e) => e.preventDefault();
+    container.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x0c0e10);
+    const camera = new THREE.PerspectiveCamera(
+      45,
+      (container.clientWidth || window.innerWidth) /
+        (container.clientHeight || window.innerHeight),
+      0.1,
+      100
+    );
+    camera.position.set(6.4, 7.6, 7.6);
+    camera.lookAt(0, 0.4, 0);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.target.set(0, 0.4, 0);
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.08;
+    controls.enablePan = true;
+    controls.screenSpacePanning = false;
+    controls.minDistance = 4;
+    controls.maxDistance = 18;
+    controls.minPolarAngle = Math.PI * 0.15;
+    controls.maxPolarAngle = Math.PI * 0.49;
+
+    scene.add(new THREE.HemisphereLight(0xeef2ff, 0x101215, 1.05));
+    const key = new THREE.DirectionalLight(0xffffff, 1.6);
+    key.position.set(8, 12, 6);
+    key.castShadow = true;
+    key.shadow.mapSize.set(2048, 2048);
+    key.shadow.camera.left = -9;
+    key.shadow.camera.right = 9;
+    key.shadow.camera.top = 9;
+    key.shadow.camera.bottom = -9;
+    scene.add(key);
+    const fill = new THREE.DirectionalLight(0xffffff, 0.8);
+    fill.position.set(-6, 6, -8);
+    scene.add(fill);
+    const rim = new THREE.DirectionalLight(0xffffff, 0.6);
+    rim.position.set(0, 6, -10);
+    scene.add(rim);
+    scene.add(new THREE.AmbientLight(0xffffff, 0.18));
+
+    const labelsGroup = new THREE.Group();
+    scene.add(labelsGroup);
+
+    const boardRoot = new THREE.Group();
+    scene.add(boardRoot);
+    const piecesGroup = new THREE.Group();
+    scene.add(piecesGroup);
+    const srcProtos = { w: {}, b: {} };
+
+    function bbox(obj) {
+      const b = new THREE.Box3().setFromObject(obj);
+      const s = new THREE.Vector3();
+      b.getSize(s);
+      return { b, s, h: s.y, top: b.max.y, bottom: b.min.y };
+    }
+
+    function nodePath(n) {
+      const names = [];
+      for (let cur = n; cur; cur = cur.parent) {
+        if (cur.name) names.push(cur.name);
+      }
+      return names.reverse().join('/');
+    }
+
+    const TYPE_MAP = [
+      ['p', /pawn/],
+      ['r', /rook|castle/],
+      ['n', /knight|horse/],
+      ['b', /bishop/],
+      ['q', /queen/],
+      ['k', /king/]
+    ];
+
+    function detectTypeFromPath(p) {
+      const q = p.toLowerCase();
+      for (const [t, re] of TYPE_MAP) {
+        if (re.test(q)) return t;
+      }
+      return undefined;
+    }
+
+    function promoteToPieceRoot(o, t) {
+      let cur = o;
+      let p = o.parent;
+      while (p) {
+        const tt = detectTypeFromPath(nodePath(p));
+        if (tt === t) {
+          cur = p;
+          p = p.parent;
+        } else break;
+      }
+      return cur;
+    }
+
+    function squareToPos(sq) {
+      const file = sq.charCodeAt(0) - 97;
+      const rank = parseInt(sq[1], 10) - 1;
+      const c = file;
+      const r = 7 - rank;
+      const x = -HALF + c * TILE + TILE / 2;
+      const z = -HALF + r * TILE + TILE / 2;
+      return new THREE.Vector3(x, 0, z);
+    }
+
+    function makeTextSprite(text) {
+      const cv = document.createElement('canvas');
+      cv.width = 256;
+      cv.height = 128;
+      const ctx = cv.getContext('2d');
+      if (!ctx) {
+        return new THREE.Sprite(new THREE.SpriteMaterial({}));
+      }
+      ctx.clearRect(0, 0, cv.width, cv.height);
+      ctx.font = 'bold 64px system-ui, Segoe UI, Roboto, Helvetica, Arial';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillStyle = 'rgba(255,255,255,0.95)';
+      ctx.strokeStyle = 'rgba(0,0,0,0.6)';
+      ctx.lineWidth = 8;
+      ctx.strokeText(text, cv.width / 2, cv.height / 2);
+      ctx.fillText(text, cv.width / 2, cv.height / 2);
+      const tex = new THREE.CanvasTexture(cv);
+      const mat = new THREE.SpriteMaterial({ map: tex, transparent: true, depthTest: false });
+      const sp = new THREE.Sprite(mat);
+      sp.scale.set(0.6, 0.3, 1);
+      return sp;
+    }
+
+    function buildLabels() {
+      labelsGroup.clear();
+      const files = 'abcdefgh';
+      for (let i = 0; i < 8; i += 1) {
+        const f = files[i];
+        const near = squareToPos(`${f}1`).clone();
+        near.z += 0.6;
+        near.y = 0.02;
+        const sN = makeTextSprite(f);
+        sN.position.copy(near);
+        labelsGroup.add(sN);
+        const far = squareToPos(`${f}8`).clone();
+        far.z -= 0.6;
+        far.y = 0.02;
+        const sF = makeTextSprite(f);
+        sF.position.copy(far);
+        labelsGroup.add(sF);
+      }
+      for (let r = 1; r <= 8; r += 1) {
+        const left = squareToPos(`a${r}`).clone();
+        left.x -= 0.6;
+        left.y = 0.02;
+        const sL = makeTextSprite(String(r));
+        sL.position.copy(left);
+        labelsGroup.add(sL);
+        const right = squareToPos(`h${r}`).clone();
+        right.x += 0.6;
+        right.y = 0.02;
+        const sR = makeTextSprite(String(r));
+        sR.position.copy(right);
+        labelsGroup.add(sR);
+      }
+    }
+
+    function relPath(root, n) {
+      const stack = [];
+      let cur = n;
+      while (cur && cur !== root) {
+        if (cur.name) stack.push(cur.name);
+        cur = cur.parent;
+      }
+      return stack.reverse().join('/');
+    }
+
+    function annotateProto(root) {
+      root.traverse((n) => {
+        if (n && n.isMesh) {
+          n.userData.__rel = relPath(root, n);
+        }
+      });
+    }
+
+    function snapshotPaletteFromProto(protoRoot) {
+      const map = new Map();
+      protoRoot.traverse((n) => {
+        if (n && n.isMesh) {
+          const key = relPath(protoRoot, n);
+          const src = n.material;
+          map.set(
+            key,
+            Array.isArray(src)
+              ? src.map((m) => (m && m.clone ? m.clone() : m))
+              : src && src.clone
+              ? src.clone()
+              : src
+          );
+        }
+      });
+      return map;
+    }
+
+    function applyPaletteToHolder(holder, protoRoot, palette) {
+      holder.traverse((n) => {
+        if (!n || !n.isMesh) return;
+        const key = n.userData.__rel || relPath(protoRoot, n);
+        const saved = palette.get(key);
+        if (!saved) return;
+        n.material = Array.isArray(saved)
+          ? saved.map((m) => (m && m.clone ? m.clone() : m))
+          : saved && saved.clone
+          ? saved.clone()
+          : saved;
+      });
+    }
+
+    function applyWhitePaletteSide(side) {
+      const perType = new Map();
+      ['p', 'r', 'n', 'b', 'q', 'k'].forEach((t) => {
+        const pr = srcProtos.w && srcProtos.w[t];
+        if (pr && !perType.has(t)) perType.set(t, snapshotPaletteFromProto(pr));
+      });
+      piecesGroup.children.forEach((holder) => {
+        const u = holder.userData || {};
+        if (!u.isPiece) return;
+        const sq = u.square;
+        if (!sq) return;
+        const r = parseInt(String(sq).slice(1), 10);
+        const sideNow = r <= 2 ? 'w' : r >= 7 ? 'b' : r < 5 ? 'b' : 'w';
+        if (sideNow !== side) return;
+        const palette = perType.get(u.type);
+        if (!palette) return;
+        applyPaletteToHolder(holder, srcProtos.w[u.type], palette);
+      });
+      setBanner(`Applied white palette to ${side === 'w' ? 'P1' : 'P2'}`);
+    }
+
+    const START = {
+      w: {
+        back: ['r', 'n', 'b', 'q', 'k', 'b', 'n', 'r'],
+        backSquares: ['a1', 'b1', 'c1', 'd1', 'e1', 'f1', 'g1', 'h1'],
+        pawns: ['a2', 'b2', 'c2', 'd2', 'e2', 'f2', 'g2', 'h2']
+      },
+      b: {
+        back: ['r', 'n', 'b', 'q', 'k', 'b', 'n', 'r'],
+        backSquares: ['a8', 'b8', 'c8', 'd8', 'e8', 'f8', 'g8', 'h8'],
+        pawns: ['a7', 'b7', 'c7', 'd7', 'e7', 'f7', 'g7', 'h7']
+      }
+    };
+
+    function normalizeAndSeatClone(o) {
+      const c = o.clone(true);
+      const b0 = bbox(c);
+      const footprint = Math.max(b0.s.x, b0.s.z) || 1;
+      const sc = (TILE * 0.995) / footprint;
+      c.scale.multiplyScalar(sc);
+      const b1 = bbox(c);
+      const dy = -b1.bottom;
+      c.position.y += dy;
+      const holder = new THREE.Group();
+      holder.add(c);
+      holder.position.y = 0.18;
+      return holder;
+    }
+
+    function fromProto(t, c) {
+      const proto = srcProtos[c][t];
+      if (!proto) return null;
+      const h = normalizeAndSeatClone(proto);
+      h.userData = { isPiece: true, type: t, color: c };
+      return h;
+    }
+
+    function buildOfficialStart() {
+      piecesGroup.clear();
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].forEach((f, i) => {
+        const t = START.w.back[i];
+        const h = fromProto(t, 'w');
+        if (h) {
+          const p = squareToPos(`${f}1`);
+          h.position.set(p.x, 0.18, p.z);
+          h.userData.square = `${f}1`;
+          piecesGroup.add(h);
+        }
+      });
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].forEach((f) => {
+        const h = fromProto('p', 'w');
+        if (h) {
+          const p = squareToPos(`${f}2`);
+          h.position.set(p.x, 0.18, p.z);
+          h.userData.square = `${f}2`;
+          piecesGroup.add(h);
+        }
+      });
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].forEach((f, i) => {
+        const t = START.b.back[i];
+        const h = fromProto(t, 'b');
+        if (h) {
+          const p = squareToPos(`${f}8`);
+          h.position.set(p.x, 0.18, p.z);
+          h.userData.square = `${f}8`;
+          piecesGroup.add(h);
+        }
+      });
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].forEach((f) => {
+        const h = fromProto('p', 'b');
+        if (h) {
+          const p = squareToPos(`${f}7`);
+          h.position.set(p.x, 0.18, p.z);
+          h.userData.square = `${f}7`;
+          piecesGroup.add(h);
+        }
+      });
+      setStatus(`Official start – pieces: ${piecesGroup.children.length}/32`);
+    }
+
+    function snapshotMaterials(root) {
+      const m = new Map();
+      root.traverse((n) => {
+        if (!n || !n.isMesh) return;
+        const key = n.userData.__rel;
+        const src = n.material;
+        m.set(
+          key,
+          Array.isArray(src)
+            ? src.map((x) => (x && x.clone ? x.clone() : x))
+            : src && src.clone
+            ? src.clone()
+            : src
+        );
+      });
+      return m;
+    }
+
+    function applyMaterials(root, snap) {
+      root.traverse((n) => {
+        if (!n || !n.isMesh) return;
+        const key = n.userData.__rel;
+        const saved = snap.get(key);
+        if (!saved) return;
+        n.material = Array.isArray(saved)
+          ? saved.map((x) => (x && x.clone ? x.clone() : x))
+          : saved && saved.clone
+          ? saved.clone()
+          : saved;
+      });
+    }
+
+    function swapMaterialsBetween(a, b) {
+      if (!a || !b) return;
+      const ma = snapshotMaterials(a);
+      const mb = snapshotMaterials(b);
+      applyMaterials(a, mb);
+      applyMaterials(b, ma);
+    }
+
+    function indexBySquare() {
+      const M = {};
+      piecesGroup.children.forEach((h) => {
+        const u = h.userData || {};
+        if (u.isPiece && u.square) M[u.square] = h;
+      });
+      return M;
+    }
+
+    function swapRankMaterialsOnly(rankA, rankB) {
+      const files = 'abcdefgh';
+      const map = indexBySquare();
+      for (const f of files) {
+        const A = map[`${f}${rankA}`];
+        const B = map[`${f}${rankB}`];
+        if (A && B) swapMaterialsBetween(A, B);
+      }
+      setBanner(`Materials swapped (only) between ranks ${rankA} and ${rankB}`);
+    }
+
+    async function loadABG() {
+      const loader = new GLTFLoader();
+      loader.setCrossOrigin('anonymous');
+      let gltf = null;
+      let lastErr = null;
+      for (const url of MODEL_URLS) {
+        try {
+          gltf = await loader.loadAsync(url);
+          break;
+        } catch (e) {
+          lastErr = e;
+          console.warn('Load failed:', url, e);
+        }
+      }
+      if (!gltf) {
+        setBanner(`GLTF unavailable (${lastErr?.message || 'unknown'})`);
+        return false;
+      }
+      const root = gltf.scene;
+      root.updateMatrixWorld(true);
+
+      const boards = [];
+      root.traverse((o) => {
+        const n = (o.name || '').toLowerCase();
+        if (/\b(board|chessboard|table)\b/.test(n)) boards.push(o);
+      });
+      const boardNode = boards[0] || root;
+      const boardClone = boardNode.clone(true);
+      boardClone.traverse((n) => {
+        if (n.isMesh) {
+          n.receiveShadow = true;
+          n.castShadow = false;
+        }
+        const isPiece = /(pawn|rook|castle|knight|horse|bishop|queen|king)/i.test(n.name || '');
+        if (isPiece) n.visible = false;
+      });
+      const { b: bb, s } = bbox(boardClone);
+      const srcBoardW = Math.max(s.x, s.z) || 1;
+      const scale = (BOARD + 0.2) / srcBoardW;
+      boardClone.scale.setScalar(scale);
+      const center = bb.b.getCenter(new THREE.Vector3());
+      boardClone.position.sub(center.multiplyScalar(scale));
+      boardClone.position.y = 0;
+      boardRoot.clear();
+      boardRoot.add(boardClone);
+
+      const buckets = {
+        p: { w: [], b: [], any: [] },
+        r: { w: [], b: [], any: [] },
+        n: { w: [], b: [], any: [] },
+        b: { w: [], b: [], any: [] },
+        q: { w: [], b: [], any: [] },
+        k: { w: [], b: [], any: [] }
+      };
+      const NAME_W = /(^|[\W_])(white|ivory|light)([\W_]|$)/i;
+      const NAME_B = /(^|[\W_])(black|ebony|dark)([\W_]|$)/i;
+      const seen = new Set();
+      root.traverse((o) => {
+        const t = detectTypeFromPath(nodePath(o));
+        if (!t) return;
+        const pr = promoteToPieceRoot(o, t);
+        if (seen.has(pr.uuid)) return;
+        seen.add(pr.uuid);
+        const pth = nodePath(pr).toLowerCase();
+        const byW = NAME_W.test(pth);
+        const byB = NAME_B.test(pth);
+        if (byW) buckets[t].w.push(pr);
+        if (byB) buckets[t].b.push(pr);
+        if (!byW && !byB) buckets[t].any.push(pr);
+      });
+      ['p', 'r', 'n', 'b', 'q', 'k'].forEach((t) => {
+        const wPick = buckets[t].w[0] || buckets[t].any[0] || null;
+        const bPick = buckets[t].b[0] || buckets[t].any[buckets[t].any.length - 1] || null;
+        if (wPick) {
+          annotateProto(wPick);
+          srcProtos.w[t] = wPick;
+        }
+        if (bPick) {
+          annotateProto(bPick);
+          srcProtos.b[t] = bPick;
+        }
+      });
+      setBanner('Board & pieces loaded from GLTF');
+      return true;
+    }
+
+    let raf = 0;
+    (async function init() {
+      const ok = await loadABG();
+      if (!ok) {
+        setStatus('GLTF load failed – GLTF-only mode');
+        return;
+      }
+      buildOfficialStart();
+      applyWhitePaletteSide('w');
+      applyWhitePaletteSide('b');
+      swapRankMaterialsOnly(1, 8);
+      buildLabels();
+      setStatus('Ready – GLTF active, 1↔8 materials swapped, both sides white');
+      const loop = () => {
+        controls.update();
+        renderer.render(scene, camera);
+        raf = requestAnimationFrame(loop);
+      };
+      loop();
+    })();
+
+    function onResize() {
+      const w = container.clientWidth || window.innerWidth;
+      const h = container.clientHeight || window.innerHeight;
+      renderer.setSize(w, h);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    }
+
+    window.addEventListener('resize', onResize);
+
+    function runSelfTests() {
+      try {
+        const count =
+          piecesGroup.children.filter?.((h) => h?.userData?.isPiece).length ||
+          piecesGroup.children.length;
+        console.log('TEST pieces count', count, count === 32 ? 'OK' : 'FAIL');
+        const map = {};
+        piecesGroup.children.forEach((h) => {
+          const u = h.userData || {};
+          if (u.square) map[u.square] = h;
+        });
+        const A1 = map.a1;
+        const A8 = map.a8;
+        if (A1 && A8) {
+          const m1 = A1.children[0]?.children?.[0]?.material;
+          const m8 = A8.children[0]?.children?.[0]?.material;
+          console.log('TEST materials a1/a8 present', !!m1 && !!m8 ? 'OK' : 'FAIL');
+        }
+      } catch (e) {
+        console.warn('self-tests error', e);
+      }
+    }
+
+    runSelfTests();
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', onResize);
+      if (renderer.domElement && renderer.domElement.parentElement === container) {
+        container.removeChild(renderer.domElement);
+      }
+      renderer.dispose();
+    };
+  }, []);
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100vh',
+        background: '#0c0e10',
+        color: '#e7e9ec',
+        fontFamily: 'system-ui, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+      }}
+    >
+      <div ref={hostRef} style={{ position: 'absolute', inset: 0 }} />
+      <div
+        style={{
+          position: 'absolute',
+          top: 12,
+          left: 12,
+          zIndex: 10,
+          display: 'flex',
+          gap: 8,
+          alignItems: 'center',
+          background: 'rgba(10,12,14,.55)',
+          border: '1px solid rgba(255,255,255,.08)',
+          borderRadius: 10,
+          padding: '8px 10px'
+        }}
+      >
+        <span style={{ fontWeight: 700, opacity: 0.9 }}>{status}</span>
+        {!!banner && <span style={{ marginLeft: 12, opacity: 0.8 }}>{banner}</span>}
+      </div>
+    </div>
+  );
+}
+
 export default function ChessBattleRoyal() {
   useTelegramBackButton();
   const { search } = useLocation();
   const params = new URLSearchParams(search);
   const avatar = params.get('avatar') || getTelegramPhotoUrl();
   let username =
-    params.get('username') ||
-    params.get('name') ||
-    getTelegramFirstName() ||
-    getTelegramUsername();
+    params.get('username') || params.get('name') || getTelegramFirstName() || getTelegramUsername();
   const flagParam = params.get('flag') || params.get('playerFlag');
-  const initialFlag =
-    flagParam && FLAG_EMOJIS.includes(flagParam) ? flagParam : '';
+  const initialFlag = flagParam && FLAG_EMOJIS.includes(flagParam) ? flagParam : '';
   const aiFlagParam = params.get('aiFlag') || (params.get('aiFlags') || '').split(',')[0];
-  const initialAiFlag =
-    aiFlagParam && FLAG_EMOJIS.includes(aiFlagParam) ? aiFlagParam : '';
-  return (
-    <Chess3D
-      avatar={avatar}
-      username={username}
-      initialFlag={initialFlag}
-      initialAiFlag={initialAiFlag}
-    />
-  );
+  const initialAiFlag = aiFlagParam && FLAG_EMOJIS.includes(aiFlagParam) ? aiFlagParam : '';
+  return <Chess3D avatar={avatar} username={username} initialFlag={initialFlag} initialAiFlag={initialAiFlag} />;
 }


### PR DESCRIPTION
## Summary
- add a new Chess3D scene that loads the ABeautifulGame GLTF only and applies the white palette to both sides
- swap materials between ranks 1 and 8 while keeping pieces in place and show bright lighting plus labels
- keep existing entry flow while routing the page to the new GLTF-focused view

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693826497a248329b21b912d58add914)