### PR TITLE
Restore Pool Royale table scaling defaults

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -14,7 +14,12 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 127
     }),
     cushionCutAngleDeg: 35,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
+    scaleOverrides: Object.freeze({
+      scale: 1.56,
+      mobileScale: 1.72,
+      compactScale: 1.48
+    })
   },
   '8ft': {
     id: '8ft',


### PR DESCRIPTION
## Summary
- restore Pool Royale table configuration to prior default scaling values

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693827188e6483298aff7c18d6b42463)