### PR TITLE
Enforce ivory and onyx materials for Chess Battle Royal players

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -628,6 +628,9 @@ const MARBLE_ONYX_STYLE = Object.freeze({
   accent: '#b1c4cf'
 });
 
+const IVORY_HEX = '#f6f1e6';
+const ONYX_HEX = '#0f1217';
+
 const KENNEY_WOOD_STYLE = Object.freeze({
   id: 'kenneyWood',
   label: 'Kenney Woodcut',
@@ -2036,6 +2039,35 @@ function harmonizeBeautifulGamePieces(piecePrototypes, pieceStyle = BEAUTIFUL_GA
 
   ['white', 'black'].forEach((colorKey) => {
     Object.values(piecePrototypes[colorKey] || {}).forEach((piece) => accentize(piece, colorKey));
+  });
+}
+
+function enforcePlayerPieceMaterials(piecePrototypes, whiteColor = IVORY_HEX, blackColor = ONYX_HEX) {
+  if (!piecePrototypes) return;
+  const applyColor = (piece, colorHex) => {
+    if (!piece) return;
+    piece.traverse((child) => {
+      if (!child?.isMesh) return;
+      const materials = Array.isArray(child.material) ? child.material : [child.material];
+      materials.forEach((mat, idx) => {
+        if (!mat) return;
+        const applied = mat.clone ? mat.clone() : mat;
+        applied.color = new THREE.Color(colorHex);
+        if (applied?.emissive?.set) applied.emissive.set(0x000000);
+        if (Array.isArray(child.material)) {
+          child.material[idx] = applied;
+        } else {
+          child.material = applied;
+        }
+      });
+      child.castShadow = true;
+      child.receiveShadow = true;
+    });
+  };
+
+  ['white', 'black'].forEach((colorKey) => {
+    const target = colorKey === 'white' ? whiteColor : blackColor;
+    Object.values(piecePrototypes[colorKey] || {}).forEach((piece) => applyColor(piece, target));
   });
 }
 
@@ -6126,6 +6158,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
         }
         applyHeadPresetToPrototypes(currentPiecePrototypes, headPreset);
         adornPiecePrototypes(currentPiecePrototypes, currentTileSize);
+        enforcePlayerPieceMaterials(currentPiecePrototypes, IVORY_HEX, ONYX_HEX);
         paintPiecesFromPrototypes(piecePrototypes, setId);
         applyHeadPresetToMeshes(allPieceMeshes, headPreset);
       }


### PR DESCRIPTION
## Summary
- enforce consistent ivory materials for player 1 pieces and onyx materials for player 2 pieces
- add helper to retint chess piece prototypes before painting meshes
- centralize ivory and onyx color constants for reuse

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69383d13f5548329aa5d997672404fd9)