### PR TITLE
Fix chess piece color detection for ivory vs onyx

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -3479,8 +3479,9 @@ function extractChessSetAssets(scene, options = {}) {
     ['Q', /queen/i],
     ['K', /king/i]
   ];
-  const COLOR_W = /(\b|_)(white|ivory|light|w)(\b|_)/i;
-  const COLOR_B = /(\b|_)(black|ebony|dark|b)(\b|_)/i;
+  // Avoid single-letter tokens so piece names (e.g., bishop) are not misclassified by color.
+  const COLOR_W = /(\b|_)(white|ivory|light)(\b|_)/i;
+  const COLOR_B = /(\b|_)(black|ebony|dark)(\b|_)/i;
 
   const proto = { white: {}, black: {} };
   const palettes = { white: [], black: [] };


### PR DESCRIPTION
## Summary
- tighten chess asset color detection to ignore single-letter tokens that misclassify pieces
- prevent bishop and similar names from being treated as the wrong side so ivory/onyx mapping stays consistent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938438c7cb0832988446dd882a8208c)