### PR TITLE
Improve chess battle royal visuals and customization

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -169,6 +169,7 @@ const BOARD_COLOR_BASE_OPTIONS = Object.freeze([
 ]);
 
 const MODEL_SCALE = 0.75;
+const PIECE_SCALE_FACTOR = 0.8; // 20% smaller pieces
 const STOOL_SCALE = 1.5 * 1.3;
 const CARD_SCALE = 0.95;
 
@@ -198,6 +199,9 @@ const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT = STOOL_HEIGHT + 0.05 * MODEL_SCALE;
 const AI_CHAIR_GAP = (0.4 * MODEL_SCALE * CARD_SCALE) * 0.4;
 const CAMERA_TABLE_SPAN_FACTOR = 2.6;
+const AI_MOVE_MIN_DELAY_MS = 3000;
+const AI_MOVE_MAX_DELAY_MS = 6000;
+const TURN_DURATION_SECONDS = 60;
 
 const WALL_PROXIMITY_FACTOR = 0.5; // Bring arena walls 50% closer
 const WALL_HEIGHT_MULTIPLIER = 2; // Double wall height
@@ -357,6 +361,8 @@ const BEAUTIFUL_GAME_BOARD_OPTIONS = Object.freeze(
     })
   )
 );
+
+const BOARD_COLOR_MENU_OPTIONS = BEAUTIFUL_GAME_BOARD_OPTIONS.slice(0, 5);
 
 const SCULPTED_DRAG_STYLE = Object.freeze({
   id: 'sculptedDrag',
@@ -864,7 +870,9 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
   { key: 'tableBase', label: 'Table Base', options: TABLE_BASE_OPTIONS },
   { key: 'chairColor', label: 'Chairs', options: CHAIR_COLOR_OPTIONS },
-  { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_MENU_OPTIONS }
+  { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_MENU_OPTIONS },
+  { key: 'boardColor', label: 'Board Colors', options: BOARD_COLOR_MENU_OPTIONS },
+  { key: 'pieceStyle', label: 'Piece Colors (P1/P2)', options: PIECE_STYLE_OPTIONS }
 ];
 
 function normalizeAppearance(value = {}) {
@@ -877,7 +885,11 @@ function normalizeAppearance(value = {}) {
     ['tableCloth', TABLE_CLOTH_OPTIONS.length],
     ['tableBase', TABLE_BASE_OPTIONS.length],
     ['chairColor', CHAIR_COLOR_OPTIONS.length],
-    ['tableShape', TABLE_SHAPE_MENU_OPTIONS.length]
+    ['tableShape', TABLE_SHAPE_MENU_OPTIONS.length],
+    ['boardColor', BOARD_COLOR_MENU_OPTIONS.length],
+    ['whitePieceStyle', PIECE_STYLE_OPTIONS.length],
+    ['blackPieceStyle', PIECE_STYLE_OPTIONS.length],
+    ['headStyle', HEAD_PRESET_OPTIONS.length]
   ];
   entries.forEach(([key, max]) => {
     const raw = Number(value?.[key]);
@@ -886,10 +898,6 @@ function normalizeAppearance(value = {}) {
     const clamped = Math.min(Math.max(0, Math.round(source)), max - 1);
     normalized[key] = clamped;
   });
-  normalized.boardColor = DEFAULT_APPEARANCE.boardColor;
-  normalized.whitePieceStyle = DEFAULT_APPEARANCE.whitePieceStyle;
-  normalized.blackPieceStyle = DEFAULT_APPEARANCE.blackPieceStyle;
-  normalized.headStyle = DEFAULT_APPEARANCE.headStyle;
   return normalized;
 }
 
@@ -1612,7 +1620,7 @@ function createChessPalette(appearance = DEFAULT_APPEARANCE) {
   const blackPieceOption =
     PIECE_STYLE_OPTIONS[normalized.blackPieceStyle]?.style ?? DEFAULT_PIECE_STYLE;
   const pieceOption = mergePieceStylesByColor(whitePieceOption, blackPieceOption);
-  const boardOption = BEAUTIFUL_GAME_BOARD_OPTIONS[normalized.boardColor] ?? BEAUTIFUL_GAME_THEME;
+  const boardOption = BOARD_COLOR_MENU_OPTIONS[normalized.boardColor] ?? BEAUTIFUL_GAME_THEME;
   const boardTheme = buildBoardTheme(boardOption);
   const headOption = HEAD_PRESET_OPTIONS[normalized.headStyle]?.preset ?? HEAD_PRESET_OPTIONS[0].preset;
   return {
@@ -3412,6 +3420,16 @@ async function loadBeautifulGamePiecesOnly(targetBoardSize) {
 
 async function resolveBeautifulGameAssets(targetBoardSize) {
   try {
+    const gltf = await loadBeautifulGameSet();
+    if (gltf?.scene) {
+      const source = gltf.scene.userData?.beautifulGameSource;
+      return extractBeautifulGameAssets(gltf.scene, targetBoardSize, { source, assetScale: 1 });
+    }
+  } catch (error) {
+    console.warn('Chess Battle Royal: GLTF board+pieces load failed, trying swaps', error);
+  }
+
+  try {
     return await loadBeautifulGamePiecesOnly(targetBoardSize);
   } catch (error) {
     console.warn('Chess Battle Royal: GLTF swap pieces failed', error);
@@ -4793,6 +4811,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
   const [activeCustomizationKey, setActiveCustomizationKey] = useState(
     CUSTOMIZATION_SECTIONS[0]?.key ?? 'tableWood'
   );
+  const [activePiecePlayer, setActivePiecePlayer] = useState('white');
   const seatPositionsRef = useRef([]);
   const resolvedInitialFlag = useMemo(() => {
     if (initialFlag && FLAG_EMOJIS.includes(initialFlag)) {
@@ -4828,12 +4847,12 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
     const baseFlag = resolvedInitialFlag || fallbackChoice || FALLBACK_FLAG;
     return getAIOpponentFlag(baseFlag);
   });
-  const [whiteTime, setWhiteTime] = useState(60);
-  const [blackTime, setBlackTime] = useState(5);
+  const [whiteTime, setWhiteTime] = useState(TURN_DURATION_SECONDS);
+  const [blackTime, setBlackTime] = useState(TURN_DURATION_SECONDS);
   const whiteTimeRef = useRef(whiteTime);
   const blackTimeRef = useRef(blackTime);
-  const initialWhiteTimeRef = useRef(60);
-  const initialBlackTimeRef = useRef(5);
+  const initialWhiteTimeRef = useRef(TURN_DURATION_SECONDS);
+  const initialBlackTimeRef = useRef(TURN_DURATION_SECONDS);
   const [configOpen, setConfigOpen] = useState(false);
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [showHighlights, setShowHighlights] = useState(true);
@@ -4877,7 +4896,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
         <span className={swatchClass} style={{ background: b }} />
       </span>
     );
-    if (key === 'whitePieceStyle' || key === 'blackPieceStyle') {
+    if (key === 'whitePieceStyle' || key === 'blackPieceStyle' || key === 'pieceStyle') {
       return dualSwatch(option.white?.color || '#f5f5f7', option.black?.color || '#111827');
     }
     if (key === 'headStyle') {
@@ -6068,6 +6087,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
           const proto = build(p);
           if (!proto) continue;
           const clone = cloneWithShadows(proto);
+          clone.scale.multiplyScalar(PIECE_SCALE_FACTOR);
           clone.position.set(
             c * tile - half + tile / 2,
             yOffset,
@@ -6274,9 +6294,9 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
         timerSoundRef.current?.pause();
       } catch {}
       if (isWhite) {
-        initialWhiteTimeRef.current = 60;
-        whiteTimeRef.current = 60;
-        setWhiteTime(60);
+        initialWhiteTimeRef.current = TURN_DURATION_SECONDS;
+        whiteTimeRef.current = TURN_DURATION_SECONDS;
+        setWhiteTime(TURN_DURATION_SECONDS);
         lastBeepRef.current.white = null;
         timerRef.current = setInterval(() => {
           setWhiteTime((t) => {
@@ -6291,9 +6311,9 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
           });
         }, 1000);
       } else {
-        initialBlackTimeRef.current = 5;
-        blackTimeRef.current = 5;
-        setBlackTime(5);
+        initialBlackTimeRef.current = TURN_DURATION_SECONDS;
+        blackTimeRef.current = TURN_DURATION_SECONDS;
+        setBlackTime(TURN_DURATION_SECONDS);
         lastBeepRef.current.black = null;
         timerRef.current = setInterval(() => {
           setBlackTime((t) => {
@@ -6317,7 +6337,10 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
         return;
       }
       startTimer(nextWhite);
-      if (!nextWhite) setTimeout(aiMove, 200);
+      if (!nextWhite) {
+        const delay = Math.random() * (AI_MOVE_MAX_DELAY_MS - AI_MOVE_MIN_DELAY_MS) + AI_MOVE_MIN_DELAY_MS;
+        setTimeout(aiMove, delay);
+      }
     }
 
     const maybePlayCountdownSound = (seconds, isWhiteTurn) => {
@@ -6456,6 +6479,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
         const queenProto = currentPiecePrototypes[color]?.Q;
         if (queenProto) {
           const replacement = cloneWithShadows(queenProto);
+          replacement.scale.multiplyScalar(PIECE_SCALE_FACTOR);
           replacement.position.copy(m.position);
           replacement.userData = {
             ...m.userData,
@@ -6850,7 +6874,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
                   <div className="flex items-start justify-between gap-3">
                     <div>
                       <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
-                      <p className="mt-1 text-[0.7rem] text-white/60">Table cloth, chairs, and table details.</p>
+                      <p className="mt-1 text-[0.7rem] text-white/60">Table cloth, chairs, board, and piece colors.</p>
                     </div>
                     <button
                       type="button"
@@ -6885,9 +6909,39 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
                         <p className="text-[10px] uppercase tracking-[0.3em] text-white/60">
                           {activeCustomizationSection.label}
                         </p>
+                        {activeCustomizationSection.key === 'pieceStyle' && (
+                          <div className="flex items-center gap-2 pb-1">
+                            {[
+                              { key: 'white', label: 'P1 (White)' },
+                              { key: 'black', label: 'P2 (Black)' }
+                            ].map(({ key, label }) => {
+                              const selected = activePiecePlayer === key;
+                              return (
+                                <button
+                                  key={key}
+                                  type="button"
+                                  onClick={() => setActivePiecePlayer(key)}
+                                  className={`rounded-full border px-3 py-1 text-[0.7rem] font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                                    selected
+                                      ? 'border-sky-400/70 bg-sky-500/10 text-white shadow-[0_0_12px_rgba(56,189,248,0.35)]'
+                                      : 'border-white/10 bg-white/5 text-white/70 hover:border-white/20 hover:text-white'
+                                  }`}
+                                >
+                                  {label}
+                                </button>
+                              );
+                            })}
+                          </div>
+                        )}
                         <div className="space-y-1.5">
                           {activeCustomizationSection.options.map((option, idx) => {
-                            const selected = appearance[activeCustomizationSection.key] === idx;
+                            const targetKey =
+                              activeCustomizationSection.key === 'pieceStyle'
+                                ? activePiecePlayer === 'black'
+                                  ? 'blackPieceStyle'
+                                  : 'whitePieceStyle'
+                                : activeCustomizationSection.key;
+                            const selected = appearance[targetKey] === idx;
                             return (
                               <button
                                 key={option.id}
@@ -6896,7 +6950,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
                                   setAppearance((prev) =>
                                     normalizeAppearance({
                                       ...prev,
-                                      [activeCustomizationSection.key]: idx
+                                      [targetKey]: idx
                                     })
                                   )
                                 }
@@ -6908,7 +6962,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
                                 }`}
                               >
                                 <span className="text-[0.7rem] font-semibold text-gray-100">{option.label}</span>
-                                {renderCustomizationPreview(activeCustomizationSection.key, option)}
+                                {renderCustomizationPreview(targetKey, option)}
                               </button>
                             );
                           })}


### PR DESCRIPTION
## Summary
- scale chess pieces down and add P1/P2-specific color customization with seven piece palettes and five board palettes
- enable chess GLTF board loading by default while keeping procedural fallback
- slow AI turns with configurable delays and align timers for longer turns

## Testing
- `npm test -- --runInBand --passWithNoTests` *(fails: jest root directory /workspace/TonPlaygramWebApp/tests not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938f93f6520832993ff561f756b1e73)