### PR TITLE
Fix chess battle royal starting positions

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -4117,7 +4117,7 @@ const BUILDERS = {
 };
 
 // ======================= Game logic ========================
-const START_FEN = 'RNBQKBNR/pppppppp/8/8/8/8/PPPPPPPP/rnbqkbnr';
+const START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR';
 
 function parseFEN(fen) {
   const rows = fen.split('/');


### PR DESCRIPTION
## Summary
- correct the Chess Battle Royal initial FEN string so black pieces start on the top and white pieces on the bottom

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939361a5e98832997157e56cd988d75)