### PR TITLE
Improve broadcast focus and side pocket collisions

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -147,27 +147,33 @@ public class BilliardsSolver
             }
         }
 
-        Vec2 hint = vertical ? new Vec2(positive ? 1 : -1, 0) : new Vec2(0, positive ? 1 : -1);
-        // Use a thinner cushion band on side pockets so balls aren't deflected before
-        // they visually reach the jaw lips. The corner pockets keep the full
-        // PhysicsConstants.JawCushionSegments setting.
-        int cushionBands = Math.Max(1, Math.Min(PhysicsConstants.JawCushionSegments - 1, Math.Max(1, pts.Count - 1)));
-        for (int i = 0; i < pts.Count - 1; i++)
+        int cushionBands = Math.Clamp(PhysicsConstants.JawCushionSegments, 1, segments);
+        Vec2 prev = pts[0];
+        Vec2 prevNormal = (prev - center).Normalized();
+        for (int i = 1; i < pts.Count; i++)
         {
-            Vec2 a = pts[i];
-            Vec2 b = pts[i + 1];
-            if ((b - a).Length < PhysicsConstants.Epsilon)
+            Vec2 next = pts[i];
+            if ((next - prev).Length < PhysicsConstants.Epsilon)
+            {
+                prev = next;
+                prevNormal = (prev - center).Normalized();
                 continue;
-            Vec2 dir = (b - a).Normalized();
-            Vec2 normal = new Vec2(-dir.Y, dir.X);
-            if (Vec2.Dot(normal, hint) < 0)
-                normal = -normal;
-            var edge = new Edge { A = a, B = b, Normal = normal };
-            bool nearMouth = i < cushionBands || i >= pts.Count - 1 - cushionBands;
+            }
+
+            Vec2 nextNormal = (next - center).Normalized();
+            Vec2 blended = (prevNormal + nextNormal).Normalized();
+            if (blended.Length < PhysicsConstants.Epsilon)
+                blended = nextNormal;
+
+            var edge = new Edge { A = prev, B = next, Normal = blended };
+            bool nearMouth = i <= cushionBands || i > pts.Count - 1 - cushionBands;
             if (nearMouth)
                 CushionEdges.Add(edge);
             else
                 PocketEdges.Add(edge);
+
+            prev = next;
+            prevNormal = nextNormal;
         }
     }
 


### PR DESCRIPTION
## Summary
- Keep broadcast camera focus shared between cue ball and current target to frame the action together
- Reuse broadcast focus calculation for shot start and target tracking to maintain both balls in view
- Rework side pocket jaw normals to match corner logic for smoother, natural rebounds

## Testing
- dotnet test billiards.Tests *(fails: `dotnet` not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693937118fc8832989f00411c0b0cad0)