### PR TITLE
Fix chess starting orientation

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -4117,7 +4117,8 @@ const BUILDERS = {
 };
 
 // ======================= Game logic ========================
-const START_FEN = 'RNBQKBNR/pppppppp/8/8/8/8/PPPPPPPP/rnbqkbnr';
+// Standard starting position with black at the top and white at the bottom.
+const START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR';
 
 function parseFEN(fen) {
   const rows = fen.split('/');


### PR DESCRIPTION
## Summary
- corrected the starting FEN to match standard chess orientation with black on top and white on bottom

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939361a5e98832997157e56cd988d75)