### PR TITLE
Align Snooker Club build with ESM modules

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -1,4 +1,4 @@
-import { FrameState, Player, ShotContext, ShotEvent } from '../types';
+import { FrameState, Player, ShotContext, ShotEvent } from '../types.js';
 import { UkPool } from '../../lib/poolUk8Ball.js';
 import { AmericanBilliards } from '../../lib/americanBilliards.js';
 import { NineBall } from '../../lib/nineBall.js';

--- a/src/rules/SnookerClubRules.ts
+++ b/src/rules/SnookerClubRules.ts
@@ -1,4 +1,4 @@
-import { FrameState, Player, ShotContext, ShotEvent } from '../types';
+import { FrameState, Player, ShotContext, ShotEvent } from '../types.js';
 import { UkPool } from '../../lib/poolUk8Ball.js';
 import { AmericanBilliards } from '../../lib/americanBilliards.js';
 import { NineBall } from '../../lib/nineBall.js';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "NodeNext",
     "rootDir": "src",
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node"
+    "moduleResolution": "NodeNext"
   },
   "include": ["src/**/*"]
 }

--- a/tsconfig.snooker.json
+++ b/tsconfig.snooker.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "NodeNext",
     "rootDir": "src",
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node"
+    "moduleResolution": "NodeNext"
   },
   "include": ["src/**/*"]
 }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18,7 +18,7 @@ import {
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { addTransaction, getAccountBalance } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
-import { PoolRoyaleRules } from '../../../../src/rules/PoolRoyaleRules.ts';
+import { PoolRoyaleRules } from '../../../../src/rules/PoolRoyaleRules.js';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -18,7 +18,7 @@ import {
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { addTransaction, getAccountBalance } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
-import { SnookerClubRules as PoolRoyaleRules } from '../../../../src/rules/SnookerClubRules.ts';
+import { SnookerClubRules as PoolRoyaleRules } from '../../../../src/rules/SnookerClubRules.js';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';


### PR DESCRIPTION
## Summary
- switch TypeScript build configs to NodeNext/ESM for Pool Royale and Snooker Club rules
- add .js extensions to rule imports to match NodeNext resolution
- keep Snooker Club and Pool Royale React pages loading compiled ESM modules cleanly

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69393da478488329b0be21b8891e33a5)