### PR TITLE
Adjust chess board sizing and default P2 color

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -754,7 +754,7 @@ const HEAD_PRESET_OPTIONS = Object.freeze([
 ]);
 
 const QUICK_SIDE_COLORS = [
-  0xffffff,
+  0x0b3d2e,
   0x111827,
   0xf59e0b,
   0x10b981,
@@ -764,6 +764,19 @@ const QUICK_SIDE_COLORS = [
   0x06b6d4,
   0x22c55e,
   0xf43f5e
+];
+
+const QUICK_SIDE_COLOR_NAMES = [
+  'Dark Forest',
+  'Charcoal',
+  'Amber',
+  'Emerald',
+  'Azure',
+  'Rose',
+  'Violet',
+  'Teal',
+  'Green',
+  'Crimson'
 ];
 
 const QUICK_HEAD_PRESETS = [
@@ -1602,36 +1615,6 @@ function applyBeautifulGameBoardTheme(boardModel, boardTheme = BEAUTIFUL_GAME_TH
         : theme.frameDark;
     applySurface(node, targetColor);
   });
-}
-
-function normalizeBoardModelToDisplaySize(boardModel, targetSize = RAW_BOARD_SIZE) {
-  if (!boardModel) return { span: 0, top: 0 };
-
-  const safeTarget = Math.max(targetSize || RAW_BOARD_SIZE, 0.001);
-  const box = new THREE.Box3().setFromObject(boardModel);
-  const size = box.getSize(new THREE.Vector3());
-  const largest = Math.max(size.x || 0.001, size.z || 0.001);
-  const scale = safeTarget / largest;
-  if (Number.isFinite(scale) && scale > 0) {
-    boardModel.scale.multiplyScalar(scale);
-  }
-
-  const scaledBox = new THREE.Box3().setFromObject(boardModel);
-  const center = scaledBox.getCenter(new THREE.Vector3());
-  boardModel.position.set(
-    -center.x,
-    -scaledBox.min.y + (BOARD.baseH + 0.02 + BOARD_MODEL_Y_OFFSET),
-    -center.z
-  );
-
-  const normalizedBox = new THREE.Box3().setFromObject(boardModel);
-  const span = Math.max(
-    normalizedBox.max.x - normalizedBox.min.x,
-    normalizedBox.max.z - normalizedBox.min.z
-  );
-  const top = normalizedBox.max.y;
-
-  return { span, top };
 }
 
 function mergePieceStylesByColor(whiteStyle = DEFAULT_PIECE_STYLE, blackStyle = DEFAULT_PIECE_STYLE) {
@@ -4892,7 +4875,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
     return getAIOpponentFlag(baseFlag);
   });
   const [p1QuickIdx, setP1QuickIdx] = useState(0);
-  const [p2QuickIdx, setP2QuickIdx] = useState(1);
+  const [p2QuickIdx, setP2QuickIdx] = useState(0);
   const [headQuickIdx, setHeadQuickIdx] = useState(0);
   const [boardQuickIdx, setBoardQuickIdx] = useState(0);
   const [whiteTime, setWhiteTime] = useState(60);
@@ -6456,12 +6439,6 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
       }
       if (boardModel) {
         boardModel.visible = true;
-        const { top: boardTop } = normalizeBoardModelToDisplaySize(boardModel, RAW_BOARD_SIZE);
-        const preferredYOffset = Math.max(
-          boardTop + PIECE_PLACEMENT_Y_OFFSET,
-          currentPieceYOffset
-        );
-        currentPieceYOffset = preferredYOffset;
         boardGroup.add(boardModel);
         applyBeautifulGameBoardTheme(boardModel, paletteRef.current?.board ?? BEAUTIFUL_GAME_THEME);
         setProceduralBoardVisible(false);
@@ -7272,13 +7249,16 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
                             key={`p1-${color}-${idx}`}
                             type="button"
                             onClick={() => setP1QuickIdx(idx)}
+                            title={QUICK_SIDE_COLOR_NAMES[idx] || `Color ${idx + 1}`}
                             className={`h-8 w-8 rounded-lg border text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
                               p1QuickIdx === idx
                                 ? 'border-white/70 shadow-[0_0_0_2px_rgba(255,255,255,0.4)]'
                                 : 'border-white/20 hover:border-white/40'
                             }`}
                             style={{ backgroundColor: `#${color.toString(16).padStart(6, '0')}` }}
-                            aria-label={`Set player one color ${idx + 1}`}
+                            aria-label={`Set player one color ${
+                              QUICK_SIDE_COLOR_NAMES[idx] || idx + 1
+                            }`}
                           />
                         ))}
                       </div>
@@ -7291,13 +7271,16 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
                             key={`p2-${color}-${idx}`}
                             type="button"
                             onClick={() => setP2QuickIdx(idx)}
+                            title={QUICK_SIDE_COLOR_NAMES[idx] || `Color ${idx + 1}`}
                             className={`h-8 w-8 rounded-lg border text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
                               p2QuickIdx === idx
                                 ? 'border-white/70 shadow-[0_0_0_2px_rgba(255,255,255,0.4)]'
                                 : 'border-white/20 hover:border-white/40'
                             }`}
                             style={{ backgroundColor: `#${color.toString(16).padStart(6, '0')}` }}
-                            aria-label={`Set player two color ${idx + 1}`}
+                            aria-label={`Set player two color ${
+                              QUICK_SIDE_COLOR_NAMES[idx] || idx + 1
+                            }`}
                           />
                         ))}
                       </div>


### PR DESCRIPTION
## Summary
- restore the chess board glTF sizing by removing the normalization shim so the imported board appears as before
- switch the first quick side color to a dark forest swatch and default P2 to that option with clearer labels

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693951b8e8c483299b1e5ac5eca78a21)