### PR TITLE
Restore ABeautifulGame board assets

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -3471,6 +3471,16 @@ async function loadBeautifulGamePiecesOnly(targetBoardSize) {
 
 async function resolveBeautifulGameAssets(targetBoardSize) {
   try {
+    const gltf = await loadBeautifulGameSet();
+    if (gltf?.scene) {
+      const source = gltf.userData?.beautifulGameSource;
+      return extractBeautifulGameAssets(gltf.scene, targetBoardSize, { source });
+    }
+  } catch (error) {
+    console.warn('Chess Battle Royal: GLTF ABeautifulGame set failed, trying pieces-only', error);
+  }
+
+  try {
     return await loadBeautifulGamePiecesOnly(targetBoardSize);
   } catch (error) {
     console.warn('Chess Battle Royal: GLTF swap pieces failed', error);


### PR DESCRIPTION
## Summary
- load the full ABeautifulGame GLTF set before falling back to pieces-only assets so the board model renders
- retain the procedural fallback when the GLTF assets are unavailable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69395f0791e483298886ffa7661e28d0)