### PR TITLE
Restore GLTF board loading for Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -3471,6 +3471,12 @@ async function loadBeautifulGamePiecesOnly(targetBoardSize) {
 
 async function resolveBeautifulGameAssets(targetBoardSize) {
   try {
+    return await resolveBeautifulGameBoardStrict(targetBoardSize);
+  } catch (error) {
+    console.warn('Chess Battle Royal: GLTF board failed, trying swap pieces', error);
+  }
+
+  try {
     return await loadBeautifulGamePiecesOnly(targetBoardSize);
   } catch (error) {
     console.warn('Chess Battle Royal: GLTF swap pieces failed', error);


### PR DESCRIPTION
## Summary
- attempt to load the full GLTF chess board before falling back to swap pieces or procedural assets
- keep procedural fallback while restoring the expected GLTF board and sizing behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69395f0791e483298886ffa7661e28d0)