### PR TITLE
Restore ABeautifulGame board assets

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -3471,6 +3471,21 @@ async function loadBeautifulGamePiecesOnly(targetBoardSize) {
 
 async function resolveBeautifulGameAssets(targetBoardSize) {
   try {
+    const gltf = await loadBeautifulGameSet();
+    if (gltf?.scene) {
+      const assets = extractBeautifulGameAssets(gltf.scene, targetBoardSize);
+      assets.userData = {
+        ...(assets.userData || {}),
+        styleId: BEAUTIFUL_GAME_SWAP_SET_ID,
+        preserveOriginalMaterials: true
+      };
+      return assets;
+    }
+  } catch (error) {
+    console.warn('Chess Battle Royal: GLTF board+pieces failed', error);
+  }
+
+  try {
     return await loadBeautifulGamePiecesOnly(targetBoardSize);
   } catch (error) {
     console.warn('Chess Battle Royal: GLTF swap pieces failed', error);


### PR DESCRIPTION
## Summary
- load the ABeautifulGame GLTF board and pieces before falling back to swap-only assets
- preserve original materials while keeping the same target footprint and size
- retain procedural assets only when GLTF resources are unavailable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693962a402f883298bba0ab9f2650bbf)