### PR TITLE
Fix initial chess piece size on load

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -6395,9 +6395,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
       if (!prototypes) return;
       const colorKey = (p) => (p.w ? 'white' : 'black');
       const build = (p) => prototypes[colorKey(p)]?.[p.t] ?? null;
-      const yOffset = Number.isFinite(currentPieceYOffset)
-        ? currentPieceYOffset
-        : PIECE_PLACEMENT_Y_OFFSET;
+      const yOffset = 0;
 
       allPieceMeshes.splice(0, allPieceMeshes.length).forEach((m) => {
         try {


### PR DESCRIPTION
## Summary
- align initial chess piece placement to sit at the same height used after moves so pieces start at the correct size

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69396c7bb444832990d5ee4a4e6f9605)