### PR TITLE
Adjust chess board sizing and position for Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -176,11 +176,11 @@ const BOARD = { N: 8, tile: 4.2, rim: 2.2, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.08;
 const PIECE_SCALE_FACTOR = 0.8;
-const BOARD_GROUP_Y_OFFSET = -0.01;
+const BOARD_GROUP_Y_OFFSET = -0.02;
 const BOARD_MODEL_Y_OFFSET = -0.04;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.063 * 1.15;
+const BOARD_SCALE = 0.063 * 1.15 * 1.15;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;


### PR DESCRIPTION
## Summary
- increase the chess board scale so the board appears roughly 15% wider
- lower the board group slightly to position the board a bit lower

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939834006b4832982d51e580de6960b)