### PR TITLE
Adjust chess board and piece sizing

### DIFF
--- a/webapp/public/chess-royale.html
+++ b/webapp/public/chess-royale.html
@@ -198,9 +198,9 @@ const THREE_URLS=['https://cdn.jsdelivr.net/npm/three@0.159.0/build/three.module
 const ORBIT_URLS=['https://cdn.jsdelivr.net/npm/three@0.159.0/examples/jsm/controls/OrbitControls.js','https://unpkg.com/three@0.159.0/examples/jsm/controls/OrbitControls.js','https://esm.sh/three@0.159.0/examples/jsm/controls/OrbitControls.js','https://cdn.skypack.dev/three@0.159.0/examples/jsm/controls/OrbitControls.js'];
 const GLTF_URLS=['https://cdn.jsdelivr.net/npm/three@0.159.0/examples/jsm/loaders/GLTFLoader.js','https://unpkg.com/three@0.159.0/examples/jsm/loaders/GLTFLoader.js','https://esm.sh/three@0.159.0/examples/jsm/loaders/GLTFLoader.js','https://cdn.skypack.dev/three@0.159.0/examples/jsm/loaders/GLTFLoader.js'];
 const MODEL_URLS=['https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf','https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf','https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/ABeautifulGame/glTF-Binary/ABeautifulGame.glb','https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/ABeautifulGame/glTF-Binary/ABeautifulGame.glb','https://fastly.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/ABeautifulGame/glTF-Binary/ABeautifulGame.glb'];
-const BOARD_GROWTH=0.96;
-const PIECE_SPACING_SCALE=0.92;
-const BOARD_Y_OFFSET=-0.02;
+const BOARD_GROWTH=1.06;
+const PIECE_SPACING_SCALE=1;
+const BOARD_Y_OFFSET=0;
 
 const files='abcdefgh';
 function rcToSq(r,c){ return files[c]+(8-r); }

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -175,12 +175,12 @@ const CARD_SCALE = 0.95;
 const BOARD = { N: 8, tile: 4.2, rim: 2.2, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.08;
-const PIECE_SCALE_FACTOR = 1;
-const BOARD_GROUP_Y_OFFSET = -0.01;
+const PIECE_SCALE_FACTOR = 0.8;
+const BOARD_GROUP_Y_OFFSET = -0.02;
 const BOARD_MODEL_Y_OFFSET = -0.04;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.063;
+const BOARD_SCALE = 0.063 * 1.15 * 1.15;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;


### PR DESCRIPTION
## Summary
- revert chess board and piece sizing constants to the previous dimensions
- update Three.js chess demo constants to match restored board growth and spacing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69399a85ccc483299072504bd4dadedf)