### PR TITLE
Adjust chess battle royal piece and board sizing

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -175,12 +175,12 @@ const CARD_SCALE = 0.95;
 const BOARD = { N: 8, tile: 4.2, rim: 2.2, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.08;
-const PIECE_SCALE_FACTOR = 1;
-const BOARD_GROUP_Y_OFFSET = -0.01;
+const PIECE_SCALE_FACTOR = 0.8;
+const BOARD_GROUP_Y_OFFSET = -0.02;
 const BOARD_MODEL_Y_OFFSET = -0.04;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.063;
+const BOARD_SCALE = 0.063 * 1.15 * 1.15;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;


### PR DESCRIPTION
## Summary
- reduce chess piece scale and lower the board group to match previous spacing
- enlarge the displayed board scale to restore prior distances between pieces

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69399faee8e883298c9730a1603f8a08)