### PR TITLE
Tweak chess board and piece proportions

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -172,10 +172,10 @@ const MODEL_SCALE = 0.75;
 const STOOL_SCALE = 1.5 * 1.3;
 const CARD_SCALE = 0.95;
 
-const BOARD = { N: 8, tile: 4.2, rim: 2.2, baseH: 0.8 };
+const BOARD = { N: 8, tile: 4, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.08;
-const PIECE_SCALE_FACTOR = 1;
+const PIECE_SCALE_FACTOR = 0.95;
 const BOARD_GROUP_Y_OFFSET = -0.01;
 const BOARD_MODEL_Y_OFFSET = -0.04;
 
@@ -452,8 +452,8 @@ const DEFAULT_PIECE_SET_ID = BEAUTIFUL_GAME_SWAP_SET_ID;
 
 // Sized to the physical ABeautifulGame set while fitting the playable footprint
 const BEAUTIFUL_GAME_ASSET_SCALE = 1.08;
-const BEAUTIFUL_GAME_BOARD_SCALE_BIAS = 1.16;
-const BEAUTIFUL_GAME_FOOTPRINT_RATIO = 0.72;
+const BEAUTIFUL_GAME_BOARD_SCALE_BIAS = 1.2;
+const BEAUTIFUL_GAME_FOOTPRINT_RATIO = 0.7;
 
 const STAUNTON_CLASSIC_STYLE = Object.freeze({
   id: 'stauntonClassic',


### PR DESCRIPTION
## Summary
- widen the chess board model to better frame the squares
- shrink and tighten chess pieces for a more compact layout
- adjust default tile and rim sizing to give the board more visible edges

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a5538c0088329b9d4505023e25a01)