### PR TITLE
Adjust chess board proportions

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -175,13 +175,14 @@ const CARD_SCALE = 0.95;
 const BOARD = { N: 8, tile: 4, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.08;
-const PIECE_SCALE_FACTOR = 0.95;
+const PIECE_SCALE_FACTOR = 0.92;
 const BOARD_GROUP_Y_OFFSET = -0.01;
 const BOARD_MODEL_Y_OFFSET = -0.04;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.063;
+const BOARD_SCALE = 0.06;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
+const BOARD_MODEL_SPAN_BIAS = 1.04;
 
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
@@ -1612,7 +1613,8 @@ function normalizeBoardModelToDisplaySize(boardModel, targetSize = RAW_BOARD_SIZ
   const box = new THREE.Box3().setFromObject(boardModel);
   const size = box.getSize(new THREE.Vector3());
   const largest = Math.max(size.x || 0.001, size.z || 0.001);
-  const scale = safeTarget / largest;
+  const scaledTarget = safeTarget * BOARD_MODEL_SPAN_BIAS;
+  const scale = scaledTarget / largest;
   if (Number.isFinite(scale) && scale > 0) {
     boardModel.scale.multiplyScalar(scale);
   }


### PR DESCRIPTION
## Summary
- widen the GLTF chess board footprint while keeping it centered on the table
- shrink the overall board and piece scaling to bring the pieces closer together

## Testing
- npm run lint -- --help *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a585dcad48329be97ec30b3aadf75)