### PR TITLE
Adjust chess board spacing and height

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -176,14 +176,14 @@ const BOARD = { N: 8, tile: 4, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.08;
 const PIECE_SCALE_FACTOR = 0.92;
-const PIECE_FOOTPRINT_RATIO = 0.94;
-const BOARD_GROUP_Y_OFFSET = -0.05;
+const PIECE_FOOTPRINT_RATIO = 0.9;
+const BOARD_GROUP_Y_OFFSET = -0.1;
 const BOARD_MODEL_Y_OFFSET = -0.04;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
 const BOARD_SCALE = 0.06;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
-const BOARD_MODEL_SPAN_BIAS = 1.04;
+const BOARD_MODEL_SPAN_BIAS = 1.08;
 
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;


### PR DESCRIPTION
## Summary
- widen the chess board model span and reduce piece footprint to give pieces more room on each square
- lower the board group on the table surface for better visibility of piece bases and highlights

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a642b7d64832984779a5247c7b5f5)