### PR TITLE
Adjust chess board spacing and placement

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -176,14 +176,14 @@ const BOARD = { N: 8, tile: 4, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.08;
 const PIECE_SCALE_FACTOR = 0.92;
-const PIECE_FOOTPRINT_RATIO = 0.9;
-const BOARD_GROUP_Y_OFFSET = -0.1;
+const PIECE_FOOTPRINT_RATIO = 0.86;
+const BOARD_GROUP_Y_OFFSET = -0.16;
 const BOARD_MODEL_Y_OFFSET = -0.04;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
 const BOARD_SCALE = 0.06;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
-const BOARD_MODEL_SPAN_BIAS = 1.08;
+const BOARD_MODEL_SPAN_BIAS = 1.12;
 
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;


### PR DESCRIPTION
## Summary
- widen the chess board and reduce piece footprint ratio so pieces sit comfortably within their tiles
- lower the board grouping on the table for better visibility of piece bases and board highlights

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a66f652648329aa7751cc67e9a96d)