### PR TITLE
Adjust chess board sizing and height

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -179,12 +179,13 @@ const PIECE_SCALE_FACTOR = 0.92;
 const PIECE_FOOTPRINT_RATIO = 0.9;
 const BOARD_GROUP_Y_OFFSET = -0.1;
 const BOARD_MODEL_Y_OFFSET = -0.12;
-const BOARD_VISUAL_Y_OFFSET = -0.08;
+const BOARD_VISUAL_Y_OFFSET = -0.12;
+const BOARD_SURFACE_DROP = 0.12;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
 const BOARD_SCALE = 0.06;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
-const BOARD_MODEL_SPAN_BIAS = 1.08;
+const BOARD_MODEL_SPAN_BIAS = 1.12;
 
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
@@ -1635,6 +1636,9 @@ function normalizeBoardModelToDisplaySize(boardModel, targetSize = RAW_BOARD_SIZ
     normalizedBox.max.z - normalizedBox.min.z
   );
   const top = normalizedBox.max.y;
+
+  boardModel.position.y -= BOARD_SURFACE_DROP;
+  boardModel.updateMatrixWorld(true);
 
   return { span, top };
 }


### PR DESCRIPTION
## Summary
- widen the Chess Battle Royal board model slightly to give pieces more room on each square
- lower the board surface relative to the pieces so bases and highlights are visible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a721a8cb0832998b6c96e5c181fea)