### PR TITLE
Adjust chess board height and add chrome/gold head styles

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -174,13 +174,13 @@ const CARD_SCALE = 0.95;
 
 const BOARD = { N: 8, tile: 4.2, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
-const PIECE_PLACEMENT_Y_OFFSET = 0.08;
+const PIECE_PLACEMENT_Y_OFFSET = 0.1;
 const PIECE_SCALE_FACTOR = 0.92;
 const PIECE_FOOTPRINT_RATIO = 0.86;
-const BOARD_GROUP_Y_OFFSET = -0.1;
-const BOARD_MODEL_Y_OFFSET = -0.12;
-const BOARD_VISUAL_Y_OFFSET = -0.12;
-const BOARD_SURFACE_DROP = 0.05;
+const BOARD_GROUP_Y_OFFSET = -0.05;
+const BOARD_MODEL_Y_OFFSET = -0.08;
+const BOARD_VISUAL_Y_OFFSET = -0.08;
+const BOARD_SURFACE_DROP = 0.03;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
 const BOARD_SCALE = 0.06;
@@ -755,6 +755,30 @@ const HEAD_PRESET_OPTIONS = Object.freeze([
       ior: 2.4,
       thickness: 0.8
     }
+  },
+  {
+    id: 'headChrome',
+    label: 'Chrome',
+    preset: {
+      color: '#d6d8dc',
+      metalness: 0.95,
+      roughness: 0.12,
+      transmission: 0.1,
+      ior: 2.1,
+      thickness: 0.22
+    }
+  },
+  {
+    id: 'headGold',
+    label: 'Gold',
+    preset: {
+      color: '#d4af37',
+      metalness: 0.92,
+      roughness: 0.16,
+      transmission: 0.06,
+      ior: 1.85,
+      thickness: 0.28
+    }
   }
 ]);
 
@@ -774,7 +798,9 @@ const QUICK_SIDE_COLORS = [
 const QUICK_HEAD_PRESETS = [
   { id: 'current', label: 'Current' },
   { id: 'headRuby', label: 'Ruby' },
-  { id: 'headSapphire', label: 'Sapphire' }
+  { id: 'headSapphire', label: 'Sapphire' },
+  { id: 'headChrome', label: 'Chrome' },
+  { id: 'headGold', label: 'Gold' }
 ];
 
 const QUICK_BOARD_THEMES = [


### PR DESCRIPTION
## Summary
- lift the chess board assembly and piece placement slightly higher to sit above the carpet surface
- add chrome and gold pawn/bishop head material presets and expose them in quick head selections

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a7bfc2dd88329836b68f91c33a057)