### PR TITLE
Adjust GLTF chess board scale

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -456,7 +456,7 @@ const DEFAULT_PIECE_SET_ID = BEAUTIFUL_GAME_SWAP_SET_ID;
 
 // Sized to the physical ABeautifulGame set while fitting the playable footprint
 const BEAUTIFUL_GAME_ASSET_SCALE = 1.08;
-const BEAUTIFUL_GAME_BOARD_SCALE_BIAS = 1.2;
+const BEAUTIFUL_GAME_BOARD_SCALE_BIAS = 1.24;
 const BEAUTIFUL_GAME_FOOTPRINT_RATIO = 0.7;
 
 const STAUNTON_CLASSIC_STYLE = Object.freeze({


### PR DESCRIPTION
## Summary
- slightly increase the ABeautifulGame GLTF board scale bias so pieces sit more comfortably on the squares

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a81da5c048329903890792907d51a)