### PR TITLE
Adjust chess board scale and lift pieces

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -174,7 +174,7 @@ const CARD_SCALE = 0.95;
 
 const BOARD = { N: 8, tile: 4.2, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
-const PIECE_PLACEMENT_Y_OFFSET = 0.12;
+const PIECE_PLACEMENT_Y_OFFSET = 0.14;
 const PIECE_SCALE_FACTOR = 0.92;
 const PIECE_FOOTPRINT_RATIO = 0.86;
 const BOARD_GROUP_Y_OFFSET = -0.05;
@@ -185,7 +185,8 @@ const BOARD_SURFACE_DROP = 0.03;
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
 const BOARD_SCALE = 0.06;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
-const BOARD_MODEL_SPAN_BIAS = 1.16;
+const BOARD_MODEL_SPAN_BIAS = 1.2;
+const HIGHLIGHT_VERTICAL_OFFSET = 0.02;
 
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
@@ -6779,7 +6780,9 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
             metalness: 0.2
           })
         );
-        h.position.copy(mesh.position).add(new THREE.Vector3(0, highlightHeight, 0));
+        h.position
+          .copy(mesh.position)
+          .add(new THREE.Vector3(0, highlightHeight + HIGHLIGHT_VERTICAL_OFFSET, 0));
         h.userData.__highlight = true;
         boardGroup.add(h);
       });


### PR DESCRIPTION
## Summary
- widen the chess battle royal GLTF board span so tiles fully fit
- raise piece placement offset slightly so models sit higher on squares
- lift move highlight meshes for better clearance above the board

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a8f9a392483299f817def5e9e9e6c)