### PR TITLE
Refine pool ball textures and cue ball details

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1118,8 +1118,6 @@ const CUE_PULL_BASE = BALL_R * 10 * 0.65 * 1.2;
 const CUE_PULL_SMOOTHING = 0.2;
 const CUE_Y = BALL_CENTER_Y - BALL_R * 0.05; // drop cue height slightly so the tip lines up with the cue ball centre
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
-const CUE_MARKER_RADIUS = CUE_TIP_RADIUS * 1.2 * 0.85; // shrink cue ball dots by 15%
-const CUE_MARKER_DEPTH = CUE_MARKER_RADIUS * (0.25 / 1.2);
 const CUE_BUTT_LIFT = BALL_R * 0.62; // raise the butt a little more so the rear clears rails while the tip stays aligned
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(8.5);
@@ -5250,45 +5248,6 @@ function Guret(parent, id, color, x, y, options = {}) {
   mesh.position.set(x, BALL_CENTER_Y, y);
   mesh.castShadow = true;
   mesh.receiveShadow = true;
-  if (id === 'cue') {
-    const markerGeom = new THREE.CylinderGeometry(
-      CUE_MARKER_RADIUS,
-      CUE_MARKER_RADIUS,
-      CUE_MARKER_DEPTH,
-      48
-    );
-    const markerMat = new THREE.MeshStandardMaterial({
-      color: 0xff3b3b,
-      emissive: 0x5a0000,
-      emissiveIntensity: 0.4,
-      roughness: 0.28,
-      metalness: 0.05
-    });
-    markerMat.depthWrite = false;
-    markerMat.needsUpdate = true;
-    markerMat.toneMapped = false;
-    markerMat.polygonOffset = true;
-    markerMat.polygonOffsetFactor = -0.5;
-    markerMat.polygonOffsetUnits = -0.5;
-    const markerOffset = BALL_R - CUE_MARKER_DEPTH * 0.5 + 0.001;
-    const localUp = new THREE.Vector3(0, 1, 0);
-    [
-      new THREE.Vector3(1, 0, 0),
-      new THREE.Vector3(-1, 0, 0),
-      new THREE.Vector3(0, 1, 0),
-      new THREE.Vector3(0, -1, 0),
-      new THREE.Vector3(0, 0, 1),
-      new THREE.Vector3(0, 0, -1)
-    ].forEach((normal) => {
-      const marker = new THREE.Mesh(markerGeom, markerMat);
-      marker.position.copy(normal).multiplyScalar(markerOffset);
-      marker.quaternion.setFromUnitVectors(localUp, normal);
-      marker.castShadow = false;
-      marker.receiveShadow = false;
-      marker.renderOrder = 2;
-      mesh.add(marker);
-    });
-  }
   mesh.traverse((node) => {
     node.userData = node.userData || {};
     node.userData.ballId = id;

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -1097,8 +1097,6 @@ const CUE_PULL_BASE = BALL_R * 10 * 0.65 * 1.2;
 const CUE_PULL_SMOOTHING = 0.2;
 const CUE_Y = BALL_CENTER_Y - BALL_R * 0.05; // drop cue height slightly so the tip lines up with the cue ball centre
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
-const CUE_MARKER_RADIUS = CUE_TIP_RADIUS * 1.2 * 0.85; // shrink cue ball dots by 15%
-const CUE_MARKER_DEPTH = CUE_MARKER_RADIUS * (0.25 / 1.2);
 const CUE_BUTT_LIFT = BALL_R * 0.62; // raise the butt a little more so the rear clears rails while the tip stays aligned
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(8.5);
@@ -5245,45 +5243,6 @@ function Guret(parent, id, color, x, y, options = {}) {
   mesh.position.set(x, BALL_CENTER_Y, y);
   mesh.castShadow = true;
   mesh.receiveShadow = true;
-  if (id === 'cue') {
-    const markerGeom = new THREE.CylinderGeometry(
-      CUE_MARKER_RADIUS,
-      CUE_MARKER_RADIUS,
-      CUE_MARKER_DEPTH,
-      48
-    );
-    const markerMat = new THREE.MeshStandardMaterial({
-      color: 0xff3b3b,
-      emissive: 0x5a0000,
-      emissiveIntensity: 0.4,
-      roughness: 0.28,
-      metalness: 0.05
-    });
-    markerMat.depthWrite = false;
-    markerMat.needsUpdate = true;
-    markerMat.toneMapped = false;
-    markerMat.polygonOffset = true;
-    markerMat.polygonOffsetFactor = -0.5;
-    markerMat.polygonOffsetUnits = -0.5;
-    const markerOffset = BALL_R - CUE_MARKER_DEPTH * 0.5 + 0.001;
-    const localUp = new THREE.Vector3(0, 1, 0);
-    [
-      new THREE.Vector3(1, 0, 0),
-      new THREE.Vector3(-1, 0, 0),
-      new THREE.Vector3(0, 1, 0),
-      new THREE.Vector3(0, -1, 0),
-      new THREE.Vector3(0, 0, 1),
-      new THREE.Vector3(0, 0, -1)
-    ].forEach((normal) => {
-      const marker = new THREE.Mesh(markerGeom, markerMat);
-      marker.position.copy(normal).multiplyScalar(markerOffset);
-      marker.quaternion.setFromUnitVectors(localUp, normal);
-      marker.castShadow = false;
-      marker.receiveShadow = false;
-      marker.renderOrder = 2;
-      mesh.add(marker);
-    });
-  }
   mesh.traverse((node) => {
     node.userData = node.userData || {};
     node.userData.ballId = id;

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -4,6 +4,9 @@ import { applySRGBColorSpace } from './colorSpace.js';
 const BALL_TEXTURE_SIZE = 4096; // ultra high resolution for sharper billiard ball textures
 const BALL_TEXTURE_CACHE = new Map();
 const BALL_MATERIAL_CACHE = new Map();
+const MILK_WHITE = '#f7f3eb';
+const CUE_DOT_COLOR = '#e43b3b';
+const CUE_DOT_SHADOW = '#9b1c1c';
 
 function clamp01(value) {
   return Math.min(1, Math.max(0, value));
@@ -41,142 +44,41 @@ function addNoise(ctx, size, strength = 0.02, samples = 3600) {
   ctx.restore();
 }
 
-function drawNumberBadge(ctx, size, number) {
-  const radius = size * 0.132;
-  const cx = size * 0.5;
-  const cy = size * 0.55;
+function directionToUV([x, y, z]) {
+  const u = 0.5 + Math.atan2(z, x) / (Math.PI * 2);
+  const v = 0.5 - Math.asin(Math.max(-1, Math.min(1, y))) / Math.PI;
+  return { u, v };
+}
 
-  ctx.save();
-  const badgeGrad = ctx.createRadialGradient(
-    cx,
-    cy - radius * 0.35,
-    radius * 0.25,
+function drawRaisedDot(ctx, cx, cy, radius, color = CUE_DOT_COLOR) {
+  const highlight = lighten(color, 0.2);
+  const edge = darken(color, 0.2);
+  const grad = ctx.createRadialGradient(
+    cx - radius * 0.25,
+    cy - radius * 0.25,
+    radius * 0.2,
     cx,
     cy,
     radius
   );
-  badgeGrad.addColorStop(0, 'rgba(255,255,255,1)');
-  badgeGrad.addColorStop(1, 'rgba(222,222,222,1)');
-  ctx.fillStyle = badgeGrad;
+  grad.addColorStop(0, highlight);
+  grad.addColorStop(0.6, color);
+  grad.addColorStop(1, edge);
+
+  ctx.save();
+  ctx.fillStyle = grad;
   ctx.beginPath();
   ctx.arc(cx, cy, radius, 0, Math.PI * 2);
   ctx.closePath();
   ctx.fill();
 
-  ctx.lineWidth = size * 0.008;
-  ctx.strokeStyle = 'rgba(0,0,0,0.16)';
+  ctx.lineWidth = Math.max(1, radius * 0.22);
+  ctx.strokeStyle = CUE_DOT_SHADOW;
   ctx.stroke();
-
-  const fontSize = size * 0.164;
-  ctx.fillStyle = '#121212';
-  ctx.font = `600 ${fontSize}px "Arial"`;
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'middle';
-  ctx.fillText(String(number), cx, cy + size * 0.005);
   ctx.restore();
 }
 
-function drawPoolNumberBadge(ctx, size, number) {
-  const radius = size * 0.1;
-  const badgeStretch = 2; // compensate equirectangular vertical compression on spheres
-  const cx = size * 0.5;
-  const cy = size * 0.5;
-
-  ctx.save();
-
-  ctx.beginPath();
-  ctx.ellipse(cx, cy, radius, radius * badgeStretch, 0, 0, Math.PI * 2);
-  ctx.closePath();
-  ctx.fillStyle = '#ffffff';
-  ctx.fill();
-
-  ctx.lineWidth = Math.max(2, Math.floor(size * 0.02));
-  ctx.strokeStyle = '#000000';
-  ctx.stroke();
-
-  ctx.fillStyle = '#000000';
-  ctx.font = `bold ${size * 0.18}px Arial`;
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'middle';
-
-  const numStr = String(number);
-  ctx.save();
-  ctx.translate(cx, cy);
-  ctx.scale(1, badgeStretch);
-  if (numStr.length === 2) {
-    ctx.save();
-    ctx.scale(0.9, 1);
-    ctx.fillText(numStr, 0, 0);
-    ctx.restore();
-  } else {
-    ctx.fillText(numStr, 0, 0);
-  }
-  ctx.restore();
-
-  ctx.restore();
-}
-
-function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
-  const baseHex = toHexString(baseColor);
-
-  ctx.fillStyle = pattern === 'stripe' ? '#ffffff' : baseHex;
-  ctx.fillRect(0, 0, size, size);
-
-  if (pattern === 'stripe') {
-    ctx.fillStyle = baseHex;
-    const stripeHeight = size * 0.45;
-    const stripeY = (size - stripeHeight) / 2;
-    ctx.fillRect(0, stripeY, size, stripeHeight);
-  }
-
-  if (Number.isFinite(number)) {
-    drawPoolNumberBadge(ctx, size, number);
-  }
-}
-
-function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
-  const baseHex = toHexString(baseColor);
-
-  ctx.save();
-  if (pattern === 'stripe') {
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, size, size);
-    const stripeHeight = size * 0.46;
-    const stripeY = (size - stripeHeight) / 2;
-    const stripeGrad = ctx.createLinearGradient(0, stripeY, 0, stripeY + stripeHeight);
-    stripeGrad.addColorStop(0, lighten(baseHex, 0.28));
-    stripeGrad.addColorStop(0.5, lighten(baseHex, 0.1));
-    stripeGrad.addColorStop(1, darken(baseHex, 0.06));
-    ctx.fillStyle = stripeGrad;
-    ctx.fillRect(0, stripeY, size, stripeHeight);
-
-    ctx.lineWidth = size * 0.015;
-    ctx.strokeStyle = 'rgba(0,0,0,0.12)';
-    ctx.beginPath();
-    ctx.moveTo(0, stripeY);
-    ctx.lineTo(size, stripeY);
-    ctx.stroke();
-    ctx.beginPath();
-    ctx.moveTo(0, stripeY + stripeHeight);
-    ctx.lineTo(size, stripeY + stripeHeight);
-    ctx.stroke();
-  } else {
-    const radial = ctx.createRadialGradient(
-      size * 0.3,
-      size * 0.3,
-      size * 0.1,
-      size * 0.5,
-      size * 0.55,
-      size * 0.5
-    );
-    radial.addColorStop(0, lighten(baseHex, 0.34));
-    radial.addColorStop(0.45, lighten(baseHex, 0.12));
-    radial.addColorStop(1, darken(baseHex, 0.08));
-    ctx.fillStyle = radial;
-    ctx.fillRect(0, 0, size, size);
-  }
-  ctx.restore();
-
+function drawGlossPasses(ctx, size) {
   ctx.save();
   const diagonalShade = ctx.createLinearGradient(0, 0, size, size);
   diagonalShade.addColorStop(0, 'rgba(255,255,255,0.86)');
@@ -219,8 +121,171 @@ function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
   ctx.fillStyle = lowerShadow;
   ctx.fillRect(0, 0, size, size);
   ctx.restore();
+}
 
-    addNoise(ctx, size, 0.02, 3600);
+function drawNumberBadge(ctx, size, number) {
+  const radius = size * 0.132;
+  const cx = size * 0.5;
+  const cy = size * 0.55;
+
+  ctx.save();
+  const badgeGrad = ctx.createRadialGradient(
+    cx,
+    cy - radius * 0.35,
+    radius * 0.25,
+    cx,
+    cy,
+    radius
+  );
+  badgeGrad.addColorStop(0, 'rgba(255,255,255,1)');
+  badgeGrad.addColorStop(1, 'rgba(222,222,222,1)');
+  ctx.fillStyle = badgeGrad;
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.lineWidth = size * 0.008;
+  ctx.strokeStyle = 'rgba(0,0,0,0.16)';
+  ctx.stroke();
+
+  const fontSize = size * 0.164;
+  ctx.fillStyle = '#121212';
+  ctx.font = `600 ${fontSize}px "Arial"`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(String(number), cx, cy + size * 0.005);
+  ctx.restore();
+}
+
+function drawPoolNumberBadge(ctx, size, number) {
+  const radius = size * 0.092;
+  const badgeStretch = 2; // compensate equirectangular vertical compression on spheres
+  const cx = size * 0.5;
+  const cy = size * 0.5;
+
+  ctx.save();
+
+  ctx.beginPath();
+  ctx.ellipse(cx, cy, radius, radius * badgeStretch, 0, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.fillStyle = '#ffffff';
+  ctx.fill();
+
+  ctx.lineWidth = Math.max(2, Math.floor(size * 0.02));
+  ctx.strokeStyle = '#000000';
+  ctx.stroke();
+
+  ctx.fillStyle = '#000000';
+  ctx.font = `bold ${size * 0.165}px Arial`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+
+  const numStr = String(number);
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.scale(1, badgeStretch);
+  if (numStr.length === 2) {
+    ctx.save();
+    ctx.scale(0.84, 1);
+    ctx.fillText(numStr, 0, 0);
+    ctx.restore();
+  } else {
+    ctx.fillText(numStr, 0, 0);
+  }
+  ctx.restore();
+
+  ctx.restore();
+}
+
+function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
+  const color = new THREE.Color(baseColor);
+  const baseHex = `#${color.getHexString()}`;
+  const isCueWhite = color.getHexString() === 'ffffff';
+
+  const cueBase = pattern === 'stripe' || isCueWhite ? MILK_WHITE : baseHex;
+  ctx.fillStyle = cueBase;
+  ctx.fillRect(0, 0, size, size);
+
+  if (pattern === 'stripe') {
+    ctx.fillStyle = baseHex;
+    const stripeHeight = size * 0.45;
+    const stripeY = (size - stripeHeight) / 2;
+    ctx.fillRect(0, stripeY, size, stripeHeight);
+  }
+
+  const isCueBall = pattern === 'solid' && !Number.isFinite(number) && isCueWhite;
+
+  if (isCueBall) {
+    const dotRadius = size * 0.044;
+    const normals = [
+      [1, 0, 0],
+      [-1, 0, 0],
+      [0, 1, 0],
+      [0, -1, 0],
+      [0, 0, 1],
+      [0, 0, -1]
+    ];
+    normals.forEach((dir) => {
+      const { u, v } = directionToUV(dir);
+      drawRaisedDot(ctx, u * size, v * size, dotRadius);
+    });
+  }
+
+  drawGlossPasses(ctx, size);
+  addNoise(ctx, size, 0.012, 3200);
+
+  if (Number.isFinite(number)) {
+    drawPoolNumberBadge(ctx, size, number);
+  }
+}
+
+function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
+  const baseHex = toHexString(baseColor);
+
+  ctx.save();
+  if (pattern === 'stripe') {
+    ctx.fillStyle = MILK_WHITE;
+    ctx.fillRect(0, 0, size, size);
+    const stripeHeight = size * 0.46;
+    const stripeY = (size - stripeHeight) / 2;
+    const stripeGrad = ctx.createLinearGradient(0, stripeY, 0, stripeY + stripeHeight);
+    stripeGrad.addColorStop(0, lighten(baseHex, 0.28));
+    stripeGrad.addColorStop(0.5, lighten(baseHex, 0.1));
+    stripeGrad.addColorStop(1, darken(baseHex, 0.06));
+    ctx.fillStyle = stripeGrad;
+    ctx.fillRect(0, stripeY, size, stripeHeight);
+
+    ctx.lineWidth = size * 0.015;
+    ctx.strokeStyle = 'rgba(0,0,0,0.12)';
+    ctx.beginPath();
+    ctx.moveTo(0, stripeY);
+    ctx.lineTo(size, stripeY);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(0, stripeY + stripeHeight);
+    ctx.lineTo(size, stripeY + stripeHeight);
+    ctx.stroke();
+  } else {
+    const radial = ctx.createRadialGradient(
+      size * 0.3,
+      size * 0.3,
+      size * 0.1,
+      size * 0.5,
+      size * 0.55,
+      size * 0.5
+    );
+    radial.addColorStop(0, lighten(baseHex, 0.34));
+    radial.addColorStop(0.45, lighten(baseHex, 0.12));
+    radial.addColorStop(1, darken(baseHex, 0.08));
+    ctx.fillStyle = radial;
+    ctx.fillRect(0, 0, size, size);
+  }
+  ctx.restore();
+
+  drawGlossPasses(ctx, size);
+
+  addNoise(ctx, size, 0.02, 3600);
 
   if (Number.isFinite(number)) {
     drawNumberBadge(ctx, size, number);
@@ -277,16 +342,16 @@ export function getBallMaterial({
   });
 
   const material = new THREE.MeshPhysicalMaterial({
-    color: 0xffffff,
+    color: 0xfaf7f0,
     map,
     clearcoat: 1,
-    clearcoatRoughness: 0.015,
-    metalness: 0.24,
-    roughness: 0.06,
+    clearcoatRoughness: 0.009,
+    metalness: 0.22,
+    roughness: 0.045,
     reflectivity: 1,
-    sheen: 0.18,
-    sheenColor: new THREE.Color(0xf8f9ff),
-    envMapIntensity: 1.18
+    sheen: 0.22,
+    sheenColor: new THREE.Color(0xf2f4ff),
+    envMapIntensity: 1.24
   });
   material.needsUpdate = true;
   BALL_MATERIAL_CACHE.set(cacheKey, material);


### PR DESCRIPTION
## Summary
- shrink pool number badges and tighten spacing on double-digit labels for cleaner decals
- bake cue-ball red dots into the generated texture using the same shaded circle treatment
- increase ball gloss, add a subtle milky base tint, and remove legacy cue-ball marker meshes in both pool builds

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aafeb639c8329b389de3c6792368b)