### PR TITLE
Enhance Pool Royale ball visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5238,7 +5238,7 @@ function calcTarget(cue, dir, balls) {
 }
 
 function Guret(parent, id, color, x, y, options = {}) {
-  const pattern = options.pattern || 'solid';
+  const pattern = id === 'cue' ? 'cue' : options.pattern || 'solid';
   const number = options.number ?? null;
   const material = getBilliardBallMaterial({
     color,
@@ -5250,45 +5250,6 @@ function Guret(parent, id, color, x, y, options = {}) {
   mesh.position.set(x, BALL_CENTER_Y, y);
   mesh.castShadow = true;
   mesh.receiveShadow = true;
-  if (id === 'cue') {
-    const markerGeom = new THREE.CylinderGeometry(
-      CUE_MARKER_RADIUS,
-      CUE_MARKER_RADIUS,
-      CUE_MARKER_DEPTH,
-      48
-    );
-    const markerMat = new THREE.MeshStandardMaterial({
-      color: 0xff3b3b,
-      emissive: 0x5a0000,
-      emissiveIntensity: 0.4,
-      roughness: 0.28,
-      metalness: 0.05
-    });
-    markerMat.depthWrite = false;
-    markerMat.needsUpdate = true;
-    markerMat.toneMapped = false;
-    markerMat.polygonOffset = true;
-    markerMat.polygonOffsetFactor = -0.5;
-    markerMat.polygonOffsetUnits = -0.5;
-    const markerOffset = BALL_R - CUE_MARKER_DEPTH * 0.5 + 0.001;
-    const localUp = new THREE.Vector3(0, 1, 0);
-    [
-      new THREE.Vector3(1, 0, 0),
-      new THREE.Vector3(-1, 0, 0),
-      new THREE.Vector3(0, 1, 0),
-      new THREE.Vector3(0, -1, 0),
-      new THREE.Vector3(0, 0, 1),
-      new THREE.Vector3(0, 0, -1)
-    ].forEach((normal) => {
-      const marker = new THREE.Mesh(markerGeom, markerMat);
-      marker.position.copy(normal).multiplyScalar(markerOffset);
-      marker.quaternion.setFromUnitVectors(localUp, normal);
-      marker.castShadow = false;
-      marker.receiveShadow = false;
-      marker.renderOrder = 2;
-      mesh.add(marker);
-    });
-  }
   mesh.traverse((node) => {
     node.userData = node.userData || {};
     node.userData.ballId = id;

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -2,6 +2,9 @@ import * as THREE from 'three';
 import { applySRGBColorSpace } from './colorSpace.js';
 
 const BALL_TEXTURE_SIZE = 4096; // ultra high resolution for sharper billiard ball textures
+const MILKY_WHITE = '#f7f3ec';
+const MILKY_WHITE_SHADE = '#ede6dc';
+const MILKY_WHITE_GLOSS = '#fff8f1';
 const BALL_TEXTURE_CACHE = new Map();
 const BALL_MATERIAL_CACHE = new Map();
 
@@ -77,7 +80,7 @@ function drawNumberBadge(ctx, size, number) {
 }
 
 function drawPoolNumberBadge(ctx, size, number) {
-  const radius = size * 0.1;
+  const radius = size * 0.092;
   const badgeStretch = 2; // compensate equirectangular vertical compression on spheres
   const cx = size * 0.5;
   const cy = size * 0.5;
@@ -87,15 +90,16 @@ function drawPoolNumberBadge(ctx, size, number) {
   ctx.beginPath();
   ctx.ellipse(cx, cy, radius, radius * badgeStretch, 0, 0, Math.PI * 2);
   ctx.closePath();
-  ctx.fillStyle = '#ffffff';
+  ctx.fillStyle = MILKY_WHITE_GLOSS;
   ctx.fill();
 
-  ctx.lineWidth = Math.max(2, Math.floor(size * 0.02));
+  ctx.lineWidth = Math.max(1.6, Math.floor(size * 0.016));
   ctx.strokeStyle = '#000000';
   ctx.stroke();
 
   ctx.fillStyle = '#000000';
-  ctx.font = `bold ${size * 0.18}px Arial`;
+  const fontSize = size * 0.16;
+  ctx.font = `bold ${fontSize}px Arial`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
 
@@ -104,10 +108,15 @@ function drawPoolNumberBadge(ctx, size, number) {
   ctx.translate(cx, cy);
   ctx.scale(1, badgeStretch);
   if (numStr.length === 2) {
-    ctx.save();
-    ctx.scale(0.9, 1);
-    ctx.fillText(numStr, 0, 0);
-    ctx.restore();
+    const [first, second] = numStr.split('');
+    const w1 = ctx.measureText(first).width;
+    const w2 = ctx.measureText(second).width;
+    const spacing = -fontSize * 0.08; // pull double digits slightly closer together
+    const total = w1 + w2 + spacing;
+    let cursor = -total / 2;
+    ctx.fillText(first, cursor + w1 / 2, 0);
+    cursor += w1 + spacing;
+    ctx.fillText(second, cursor + w2 / 2, 0);
   } else {
     ctx.fillText(numStr, 0, 0);
   }
@@ -116,10 +125,54 @@ function drawPoolNumberBadge(ctx, size, number) {
   ctx.restore();
 }
 
+function drawEmbeddedSpot(ctx, cx, cy, radius, color, stretch = 1.12) {
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.scale(1, stretch);
+
+  const grad = ctx.createRadialGradient(0, 0, radius * 0.2, 0, 0, radius);
+  grad.addColorStop(0, lighten(color, 0.16));
+  grad.addColorStop(0.55, color);
+  grad.addColorStop(1, darken(color, 0.12));
+  ctx.fillStyle = grad;
+  ctx.beginPath();
+  ctx.arc(0, 0, radius, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.lineWidth = radius * 0.18;
+  ctx.strokeStyle = 'rgba(0,0,0,0.16)';
+  ctx.stroke();
+
+  ctx.globalCompositeOperation = 'multiply';
+  const insetShadow = ctx.createRadialGradient(0, 0, radius * 0.3, 0, 0, radius * 1.1);
+  insetShadow.addColorStop(0, 'rgba(0,0,0,0)');
+  insetShadow.addColorStop(1, 'rgba(0,0,0,0.22)');
+  ctx.fillStyle = insetShadow;
+  ctx.fill();
+
+  ctx.restore();
+}
+
+function drawCueBallSpots(ctx, size) {
+  const radius = size * 0.092;
+  const positions = [
+    { u: 0.5, v: 0.5 },
+    { u: 0.999, v: 0.5 },
+    { u: 0.75, v: 0.5 },
+    { u: 0.25, v: 0.5 },
+    { u: 0.5, v: 0.035 },
+    { u: 0.5, v: 0.965 }
+  ];
+  positions.forEach(({ u, v }) => {
+    drawEmbeddedSpot(ctx, size * u, size * v, radius, '#d82626');
+  });
+}
+
 function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
   const baseHex = toHexString(baseColor);
 
-  ctx.fillStyle = pattern === 'stripe' ? '#ffffff' : baseHex;
+  ctx.fillStyle = pattern === 'stripe' ? MILKY_WHITE : baseHex;
   ctx.fillRect(0, 0, size, size);
 
   if (pattern === 'stripe') {
@@ -127,6 +180,44 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
     const stripeHeight = size * 0.45;
     const stripeY = (size - stripeHeight) / 2;
     ctx.fillRect(0, stripeY, size, stripeHeight);
+  }
+
+  if (pattern === 'cue') {
+    ctx.save();
+    const radial = ctx.createRadialGradient(
+      size * 0.32,
+      size * 0.3,
+      size * 0.12,
+      size * 0.6,
+      size * 0.7,
+      size * 0.64
+    );
+    radial.addColorStop(0, lighten(MILKY_WHITE, 0.18));
+    radial.addColorStop(0.45, MILKY_WHITE);
+    radial.addColorStop(1, darken(MILKY_WHITE_SHADE, 0.08));
+    ctx.globalCompositeOperation = 'source-over';
+    ctx.fillStyle = radial;
+    ctx.fillRect(0, 0, size, size);
+    ctx.restore();
+
+    ctx.save();
+    ctx.globalCompositeOperation = 'screen';
+    const highlight = ctx.createRadialGradient(
+      size * 0.34,
+      size * 0.28,
+      size * 0.06,
+      size * 0.34,
+      size * 0.28,
+      size * 0.24
+    );
+    highlight.addColorStop(0, MILKY_WHITE_GLOSS);
+    highlight.addColorStop(0.5, 'rgba(255,255,255,0.32)');
+    highlight.addColorStop(1, 'rgba(255,255,255,0)');
+    ctx.fillStyle = highlight;
+    ctx.fillRect(0, 0, size, size);
+    ctx.restore();
+
+    drawCueBallSpots(ctx, size);
   }
 
   if (Number.isFinite(number)) {
@@ -139,7 +230,7 @@ function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
 
   ctx.save();
   if (pattern === 'stripe') {
-    ctx.fillStyle = '#ffffff';
+    ctx.fillStyle = MILKY_WHITE;
     ctx.fillRect(0, 0, size, size);
     const stripeHeight = size * 0.46;
     const stripeY = (size - stripeHeight) / 2;
@@ -277,16 +368,16 @@ export function getBallMaterial({
   });
 
   const material = new THREE.MeshPhysicalMaterial({
-    color: 0xffffff,
+    color: 0xfaf7f2,
     map,
     clearcoat: 1,
-    clearcoatRoughness: 0.015,
-    metalness: 0.24,
-    roughness: 0.06,
+    clearcoatRoughness: 0.01,
+    metalness: 0.28,
+    roughness: 0.045,
     reflectivity: 1,
-    sheen: 0.18,
-    sheenColor: new THREE.Color(0xf8f9ff),
-    envMapIntensity: 1.18
+    sheen: 0.2,
+    sheenColor: new THREE.Color(0xf4f4fb),
+    envMapIntensity: 1.3
   });
   material.needsUpdate = true;
   BALL_MATERIAL_CACHE.set(cacheKey, material);


### PR DESCRIPTION
## Summary
- adjust pool ball number badges to be smaller with tighter double-digit spacing
- bake cue ball red spots into the texture with a milky off-white base
- increase ball material glossiness for a more realistic sheen

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aafeb639c8329b389de3c6792368b)