### PR TITLE
Improve Pool Royale ball detailing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1118,8 +1118,6 @@ const CUE_PULL_BASE = BALL_R * 10 * 0.65 * 1.2;
 const CUE_PULL_SMOOTHING = 0.2;
 const CUE_Y = BALL_CENTER_Y - BALL_R * 0.05; // drop cue height slightly so the tip lines up with the cue ball centre
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
-const CUE_MARKER_RADIUS = CUE_TIP_RADIUS * 1.2 * 0.85; // shrink cue ball dots by 15%
-const CUE_MARKER_DEPTH = CUE_MARKER_RADIUS * (0.25 / 1.2);
 const CUE_BUTT_LIFT = BALL_R * 0.62; // raise the butt a little more so the rear clears rails while the tip stays aligned
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(8.5);
@@ -5240,55 +5238,20 @@ function calcTarget(cue, dir, balls) {
 function Guret(parent, id, color, x, y, options = {}) {
   const pattern = options.pattern || 'solid';
   const number = options.number ?? null;
+  const cueMarkers = options.cueMarkers ?? id === 'cue';
+  const cueMarkerColor = options.cueMarkerColor ?? 0xff3b3b;
   const material = getBilliardBallMaterial({
     color,
     pattern,
     number,
-    variantKey: 'pool'
+    variantKey: 'pool',
+    cueMarkers,
+    cueMarkerColor
   });
   const mesh = new THREE.Mesh(BALL_GEOMETRY, material);
   mesh.position.set(x, BALL_CENTER_Y, y);
   mesh.castShadow = true;
   mesh.receiveShadow = true;
-  if (id === 'cue') {
-    const markerGeom = new THREE.CylinderGeometry(
-      CUE_MARKER_RADIUS,
-      CUE_MARKER_RADIUS,
-      CUE_MARKER_DEPTH,
-      48
-    );
-    const markerMat = new THREE.MeshStandardMaterial({
-      color: 0xff3b3b,
-      emissive: 0x5a0000,
-      emissiveIntensity: 0.4,
-      roughness: 0.28,
-      metalness: 0.05
-    });
-    markerMat.depthWrite = false;
-    markerMat.needsUpdate = true;
-    markerMat.toneMapped = false;
-    markerMat.polygonOffset = true;
-    markerMat.polygonOffsetFactor = -0.5;
-    markerMat.polygonOffsetUnits = -0.5;
-    const markerOffset = BALL_R - CUE_MARKER_DEPTH * 0.5 + 0.001;
-    const localUp = new THREE.Vector3(0, 1, 0);
-    [
-      new THREE.Vector3(1, 0, 0),
-      new THREE.Vector3(-1, 0, 0),
-      new THREE.Vector3(0, 1, 0),
-      new THREE.Vector3(0, -1, 0),
-      new THREE.Vector3(0, 0, 1),
-      new THREE.Vector3(0, 0, -1)
-    ].forEach((normal) => {
-      const marker = new THREE.Mesh(markerGeom, markerMat);
-      marker.position.copy(normal).multiplyScalar(markerOffset);
-      marker.quaternion.setFromUnitVectors(localUp, normal);
-      marker.castShadow = false;
-      marker.receiveShadow = false;
-      marker.renderOrder = 2;
-      mesh.add(marker);
-    });
-  }
   mesh.traverse((node) => {
     node.userData = node.userData || {};
     node.userData.ballId = id;

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { applySRGBColorSpace } from './colorSpace.js';
 
 const BALL_TEXTURE_SIZE = 4096; // ultra high resolution for sharper billiard ball textures
+const MILKY_WHITE = '#f7f6f1';
 const BALL_TEXTURE_CACHE = new Map();
 const BALL_MATERIAL_CACHE = new Map();
 
@@ -77,7 +78,7 @@ function drawNumberBadge(ctx, size, number) {
 }
 
 function drawPoolNumberBadge(ctx, size, number) {
-  const radius = size * 0.1;
+  const radius = size * 0.095;
   const badgeStretch = 2; // compensate equirectangular vertical compression on spheres
   const cx = size * 0.5;
   const cy = size * 0.5;
@@ -87,15 +88,15 @@ function drawPoolNumberBadge(ctx, size, number) {
   ctx.beginPath();
   ctx.ellipse(cx, cy, radius, radius * badgeStretch, 0, 0, Math.PI * 2);
   ctx.closePath();
-  ctx.fillStyle = '#ffffff';
+  ctx.fillStyle = MILKY_WHITE;
   ctx.fill();
 
-  ctx.lineWidth = Math.max(2, Math.floor(size * 0.02));
+  ctx.lineWidth = Math.max(2, Math.floor(size * 0.018));
   ctx.strokeStyle = '#000000';
   ctx.stroke();
 
   ctx.fillStyle = '#000000';
-  ctx.font = `bold ${size * 0.18}px Arial`;
+  ctx.font = `bold ${size * 0.165}px Arial`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
 
@@ -105,7 +106,7 @@ function drawPoolNumberBadge(ctx, size, number) {
   ctx.scale(1, badgeStretch);
   if (numStr.length === 2) {
     ctx.save();
-    ctx.scale(0.9, 1);
+    ctx.scale(0.86, 1);
     ctx.fillText(numStr, 0, 0);
     ctx.restore();
   } else {
@@ -116,10 +117,66 @@ function drawPoolNumberBadge(ctx, size, number) {
   ctx.restore();
 }
 
-function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
-  const baseHex = toHexString(baseColor);
+function drawBadgeDot(ctx, cx, cy, radius, color = '#ff3b3b') {
+  const highlight = ctx.createRadialGradient(
+    cx,
+    cy - radius * 0.3,
+    radius * 0.25,
+    cx,
+    cy,
+    radius
+  );
+  const tint = new THREE.Color(color);
+  const lightTint = tint.clone().lerp(new THREE.Color('#ffffff'), 0.35);
+  highlight.addColorStop(0, `rgba(${Math.round(lightTint.r * 255)},${Math.round(lightTint.g * 255)},${Math.round(lightTint.b * 255)},1)`);
+  highlight.addColorStop(1, `rgba(${Math.round(tint.r * 255)},${Math.round(tint.g * 255)},${Math.round(tint.b * 255)},1)`);
 
-  ctx.fillStyle = pattern === 'stripe' ? '#ffffff' : baseHex;
+  ctx.save();
+  ctx.fillStyle = highlight;
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.lineWidth = Math.max(1.5, radius * 0.22);
+  ctx.strokeStyle = 'rgba(0,0,0,0.18)';
+  ctx.stroke();
+  ctx.restore();
+}
+
+function normalToUV(normal) {
+  const n = normal.clone().normalize();
+  const u = (0.5 + Math.atan2(n.z, n.x) / (2 * Math.PI) + 1) % 1;
+  const v = 0.5 - Math.asin(THREE.MathUtils.clamp(n.y, -1, 1)) / Math.PI;
+  return { u, v };
+}
+
+function drawCueMarkers(ctx, size, color) {
+  const normals = [
+    new THREE.Vector3(1, 0, 0),
+    new THREE.Vector3(-1, 0, 0),
+    new THREE.Vector3(0, 1, 0),
+    new THREE.Vector3(0, -1, 0),
+    new THREE.Vector3(0, 0, 1),
+    new THREE.Vector3(0, 0, -1)
+  ];
+
+  const radius = size * 0.06;
+  const margin = radius / size + 0.002;
+
+  normals.forEach((normal) => {
+    const { u, v } = normalToUV(normal);
+    const clampedU = Math.min(1 - margin, Math.max(margin, u));
+    const clampedV = Math.min(1 - margin, Math.max(margin, v));
+    drawBadgeDot(ctx, clampedU * size, clampedV * size, radius, color);
+  });
+}
+
+function drawPoolBallTexture(ctx, size, baseColor, pattern, number, cueMarkers, cueMarkerColor) {
+  const baseHex = toHexString(baseColor);
+  const baseWhite = MILKY_WHITE;
+
+  ctx.fillStyle = pattern === 'stripe' ? baseWhite : baseHex === '#ffffff' ? baseWhite : baseHex;
   ctx.fillRect(0, 0, size, size);
 
   if (pattern === 'stripe') {
@@ -127,6 +184,10 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
     const stripeHeight = size * 0.45;
     const stripeY = (size - stripeHeight) / 2;
     ctx.fillRect(0, stripeY, size, stripeHeight);
+  }
+
+  if (cueMarkers) {
+    drawCueMarkers(ctx, size, cueMarkerColor ?? '#ff3b3b');
   }
 
   if (Number.isFinite(number)) {
@@ -220,15 +281,17 @@ function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
   ctx.fillRect(0, 0, size, size);
   ctx.restore();
 
-    addNoise(ctx, size, 0.02, 3600);
+  addNoise(ctx, size, 0.02, 3600);
 
   if (Number.isFinite(number)) {
     drawNumberBadge(ctx, size, number);
   }
 }
 
-function createBallTexture({ baseColor, pattern, number, variantKey }) {
-  const key = `${variantKey}|${pattern}|${number ?? 'none'}|${new THREE.Color(baseColor).getHexString()}`;
+function createBallTexture({ baseColor, pattern, number, variantKey, cueMarkers, cueMarkerColor }) {
+  const baseHex = new THREE.Color(baseColor).getHexString();
+  const cueMarkerHex = cueMarkers ? new THREE.Color(cueMarkerColor ?? 0xff3b3b).getHexString() : 'none';
+  const key = `${variantKey}|${pattern}|${number ?? 'none'}|${baseHex}|${cueMarkerHex}`;
   if (BALL_TEXTURE_CACHE.has(key)) {
     return BALL_TEXTURE_CACHE.get(key);
   }
@@ -240,7 +303,7 @@ function createBallTexture({ baseColor, pattern, number, variantKey }) {
 
   const size = BALL_TEXTURE_SIZE;
   if (variantKey === 'pool') {
-    drawPoolBallTexture(ctx, size, baseColor, pattern, number);
+    drawPoolBallTexture(ctx, size, baseColor, pattern, number, cueMarkers, cueMarkerColor);
   } else {
     drawDefaultBallTexture(ctx, size, baseColor, pattern, number);
   }
@@ -261,10 +324,14 @@ export function getBallMaterial({
   color,
   pattern = 'solid',
   number = null,
-  variantKey = 'pool'
+  variantKey = 'pool',
+  cueMarkers = false,
+  cueMarkerColor
 } = {}) {
   const baseColor = color ?? 0xffffff;
-  const cacheKey = `${variantKey}|${pattern}|${number ?? 'none'}|${new THREE.Color(baseColor).getHexString()}`;
+  const cacheKey = `${variantKey}|${pattern}|${number ?? 'none'}|${new THREE.Color(baseColor).getHexString()}|${
+    cueMarkers ? new THREE.Color(cueMarkerColor ?? 0xff3b3b).getHexString() : 'none'
+  }`;
   if (BALL_MATERIAL_CACHE.has(cacheKey)) {
     return BALL_MATERIAL_CACHE.get(cacheKey);
   }
@@ -273,20 +340,22 @@ export function getBallMaterial({
     baseColor,
     pattern,
     number,
-    variantKey
+    variantKey,
+    cueMarkers,
+    cueMarkerColor
   });
 
   const material = new THREE.MeshPhysicalMaterial({
     color: 0xffffff,
     map,
     clearcoat: 1,
-    clearcoatRoughness: 0.015,
-    metalness: 0.24,
-    roughness: 0.06,
+    clearcoatRoughness: 0.01,
+    metalness: 0.26,
+    roughness: 0.05,
     reflectivity: 1,
     sheen: 0.18,
     sheenColor: new THREE.Color(0xf8f9ff),
-    envMapIntensity: 1.18
+    envMapIntensity: 1.24
   });
   material.needsUpdate = true;
   BALL_MATERIAL_CACHE.set(cacheKey, material);


### PR DESCRIPTION
## Summary
- shrink Pool Royale number decals, use a creamier badge fill, and tighten spacing for two-digit balls
- bake cue ball red dots directly into the texture while switching white areas to a subtle milky tone
- bump up material gloss parameters to give the balls a slightly more realistic sheen

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aafeb639c8329b389de3c6792368b)