### PR TITLE
Refine Pool Royale ball rendering

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1118,8 +1118,6 @@ const CUE_PULL_BASE = BALL_R * 10 * 0.65 * 1.2;
 const CUE_PULL_SMOOTHING = 0.2;
 const CUE_Y = BALL_CENTER_Y - BALL_R * 0.05; // drop cue height slightly so the tip lines up with the cue ball centre
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
-const CUE_MARKER_RADIUS = CUE_TIP_RADIUS * 1.2 * 0.85; // shrink cue ball dots by 15%
-const CUE_MARKER_DEPTH = CUE_MARKER_RADIUS * (0.25 / 1.2);
 const CUE_BUTT_LIFT = BALL_R * 0.62; // raise the butt a little more so the rear clears rails while the tip stays aligned
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(8.5);
@@ -5238,7 +5236,7 @@ function calcTarget(cue, dir, balls) {
 }
 
 function Guret(parent, id, color, x, y, options = {}) {
-  const pattern = options.pattern || 'solid';
+  const pattern = options.pattern || (id === 'cue' ? 'cue' : 'solid');
   const number = options.number ?? null;
   const material = getBilliardBallMaterial({
     color,
@@ -5250,45 +5248,6 @@ function Guret(parent, id, color, x, y, options = {}) {
   mesh.position.set(x, BALL_CENTER_Y, y);
   mesh.castShadow = true;
   mesh.receiveShadow = true;
-  if (id === 'cue') {
-    const markerGeom = new THREE.CylinderGeometry(
-      CUE_MARKER_RADIUS,
-      CUE_MARKER_RADIUS,
-      CUE_MARKER_DEPTH,
-      48
-    );
-    const markerMat = new THREE.MeshStandardMaterial({
-      color: 0xff3b3b,
-      emissive: 0x5a0000,
-      emissiveIntensity: 0.4,
-      roughness: 0.28,
-      metalness: 0.05
-    });
-    markerMat.depthWrite = false;
-    markerMat.needsUpdate = true;
-    markerMat.toneMapped = false;
-    markerMat.polygonOffset = true;
-    markerMat.polygonOffsetFactor = -0.5;
-    markerMat.polygonOffsetUnits = -0.5;
-    const markerOffset = BALL_R - CUE_MARKER_DEPTH * 0.5 + 0.001;
-    const localUp = new THREE.Vector3(0, 1, 0);
-    [
-      new THREE.Vector3(1, 0, 0),
-      new THREE.Vector3(-1, 0, 0),
-      new THREE.Vector3(0, 1, 0),
-      new THREE.Vector3(0, -1, 0),
-      new THREE.Vector3(0, 0, 1),
-      new THREE.Vector3(0, 0, -1)
-    ].forEach((normal) => {
-      const marker = new THREE.Mesh(markerGeom, markerMat);
-      marker.position.copy(normal).multiplyScalar(markerOffset);
-      marker.quaternion.setFromUnitVectors(localUp, normal);
-      marker.castShadow = false;
-      marker.receiveShadow = false;
-      marker.renderOrder = 2;
-      mesh.add(marker);
-    });
-  }
   mesh.traverse((node) => {
     node.userData = node.userData || {};
     node.userData.ballId = id;

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -1097,8 +1097,6 @@ const CUE_PULL_BASE = BALL_R * 10 * 0.65 * 1.2;
 const CUE_PULL_SMOOTHING = 0.2;
 const CUE_Y = BALL_CENTER_Y - BALL_R * 0.05; // drop cue height slightly so the tip lines up with the cue ball centre
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
-const CUE_MARKER_RADIUS = CUE_TIP_RADIUS * 1.2 * 0.85; // shrink cue ball dots by 15%
-const CUE_MARKER_DEPTH = CUE_MARKER_RADIUS * (0.25 / 1.2);
 const CUE_BUTT_LIFT = BALL_R * 0.62; // raise the butt a little more so the rear clears rails while the tip stays aligned
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(8.5);
@@ -5233,7 +5231,7 @@ function calcTarget(cue, dir, balls) {
 }
 
 function Guret(parent, id, color, x, y, options = {}) {
-  const pattern = options.pattern || 'solid';
+  const pattern = options.pattern || (id === 'cue' ? 'cue' : 'solid');
   const number = options.number ?? null;
   const material = getBilliardBallMaterial({
     color,
@@ -5245,45 +5243,6 @@ function Guret(parent, id, color, x, y, options = {}) {
   mesh.position.set(x, BALL_CENTER_Y, y);
   mesh.castShadow = true;
   mesh.receiveShadow = true;
-  if (id === 'cue') {
-    const markerGeom = new THREE.CylinderGeometry(
-      CUE_MARKER_RADIUS,
-      CUE_MARKER_RADIUS,
-      CUE_MARKER_DEPTH,
-      48
-    );
-    const markerMat = new THREE.MeshStandardMaterial({
-      color: 0xff3b3b,
-      emissive: 0x5a0000,
-      emissiveIntensity: 0.4,
-      roughness: 0.28,
-      metalness: 0.05
-    });
-    markerMat.depthWrite = false;
-    markerMat.needsUpdate = true;
-    markerMat.toneMapped = false;
-    markerMat.polygonOffset = true;
-    markerMat.polygonOffsetFactor = -0.5;
-    markerMat.polygonOffsetUnits = -0.5;
-    const markerOffset = BALL_R - CUE_MARKER_DEPTH * 0.5 + 0.001;
-    const localUp = new THREE.Vector3(0, 1, 0);
-    [
-      new THREE.Vector3(1, 0, 0),
-      new THREE.Vector3(-1, 0, 0),
-      new THREE.Vector3(0, 1, 0),
-      new THREE.Vector3(0, -1, 0),
-      new THREE.Vector3(0, 0, 1),
-      new THREE.Vector3(0, 0, -1)
-    ].forEach((normal) => {
-      const marker = new THREE.Mesh(markerGeom, markerMat);
-      marker.position.copy(normal).multiplyScalar(markerOffset);
-      marker.quaternion.setFromUnitVectors(localUp, normal);
-      marker.castShadow = false;
-      marker.receiveShadow = false;
-      marker.renderOrder = 2;
-      mesh.add(marker);
-    });
-  }
   mesh.traverse((node) => {
     node.userData = node.userData || {};
     node.userData.ballId = id;

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -76,6 +76,36 @@ function drawNumberBadge(ctx, size, number) {
   ctx.restore();
 }
 
+function drawBadgeEllipse(ctx, size, cx, cy, radius, color, stretch = 1, outline = true) {
+  ctx.save();
+
+  ctx.beginPath();
+  ctx.ellipse(cx, cy, radius, radius * stretch, 0, 0, Math.PI * 2);
+  ctx.closePath();
+
+  const grad = ctx.createRadialGradient(
+    cx,
+    cy - radius * 0.25,
+    radius * 0.2,
+    cx,
+    cy,
+    radius
+  );
+  grad.addColorStop(0, lighten(color, 0.26));
+  grad.addColorStop(0.65, color);
+  grad.addColorStop(1, darken(color, 0.2));
+  ctx.fillStyle = grad;
+  ctx.fill();
+
+  if (outline) {
+    ctx.lineWidth = Math.max(2, Math.floor(size * 0.018));
+    ctx.strokeStyle = darken(color, 0.45);
+    ctx.stroke();
+  }
+
+  ctx.restore();
+}
+
 function drawPoolNumberBadge(ctx, size, number) {
   const radius = size * 0.1;
   const badgeStretch = 2; // compensate equirectangular vertical compression on spheres
@@ -84,18 +114,10 @@ function drawPoolNumberBadge(ctx, size, number) {
 
   ctx.save();
 
-  ctx.beginPath();
-  ctx.ellipse(cx, cy, radius, radius * badgeStretch, 0, 0, Math.PI * 2);
-  ctx.closePath();
-  ctx.fillStyle = '#ffffff';
-  ctx.fill();
-
-  ctx.lineWidth = Math.max(2, Math.floor(size * 0.02));
-  ctx.strokeStyle = '#000000';
-  ctx.stroke();
+  drawBadgeEllipse(ctx, size, cx, cy, radius, '#ffffff', badgeStretch);
 
   ctx.fillStyle = '#000000';
-  ctx.font = `bold ${size * 0.18}px Arial`;
+  ctx.font = `bold ${size * 0.165}px Arial`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
 
@@ -105,7 +127,7 @@ function drawPoolNumberBadge(ctx, size, number) {
   ctx.scale(1, badgeStretch);
   if (numStr.length === 2) {
     ctx.save();
-    ctx.scale(0.9, 1);
+    ctx.scale(0.84, 1);
     ctx.fillText(numStr, 0, 0);
     ctx.restore();
   } else {
@@ -116,18 +138,122 @@ function drawPoolNumberBadge(ctx, size, number) {
   ctx.restore();
 }
 
+function sphericalToUV([x, y, z]) {
+  const clampedY = clamp01((y + 1) / 2) * 2 - 1;
+  const u = 0.5 + Math.atan2(z, x) / (Math.PI * 2);
+  const v = 0.5 - Math.asin(clampedY) / Math.PI;
+  return { u, v };
+}
+
+function drawCueBallDots(ctx, size) {
+  const dotColor = '#c62828';
+  const badgeStretch = 2;
+  const radius = size * 0.084;
+  const normals = [
+    [1, 0, 0],
+    [-1, 0, 0],
+    [0, 1, 0],
+    [0, -1, 0],
+    [0, 0, 1],
+    [0, 0, -1]
+  ];
+
+  normals.forEach((normal) => {
+    const { u, v } = sphericalToUV(normal);
+    const targets = [u];
+    if (u < 0.02) targets.push(1 + u);
+    if (u > 0.98) targets.push(u - 1);
+
+    targets.forEach((uCoord) => {
+      const cx = uCoord * size;
+      const cy = v * size;
+      drawBadgeEllipse(ctx, size, cx, cy, radius, dotColor, badgeStretch, false);
+    });
+  });
+}
+
 function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
   const baseHex = toHexString(baseColor);
+  const milkWhite = '#f7f3ea';
 
-  ctx.fillStyle = pattern === 'stripe' ? '#ffffff' : baseHex;
+  ctx.fillStyle = pattern === 'stripe' || pattern === 'cue' ? milkWhite : baseHex;
   ctx.fillRect(0, 0, size, size);
 
   if (pattern === 'stripe') {
-    ctx.fillStyle = baseHex;
+    ctx.save();
     const stripeHeight = size * 0.45;
     const stripeY = (size - stripeHeight) / 2;
+    const stripeGrad = ctx.createLinearGradient(0, stripeY, 0, stripeY + stripeHeight);
+    stripeGrad.addColorStop(0, lighten(baseHex, 0.2));
+    stripeGrad.addColorStop(0.5, baseHex);
+    stripeGrad.addColorStop(1, darken(baseHex, 0.12));
+    ctx.fillStyle = stripeGrad;
     ctx.fillRect(0, stripeY, size, stripeHeight);
+    ctx.restore();
+  } else if (pattern === 'solid') {
+    const bodyGrad = ctx.createRadialGradient(
+      size * 0.32,
+      size * 0.32,
+      size * 0.12,
+      size * 0.52,
+      size * 0.56,
+      size * 0.52
+    );
+    bodyGrad.addColorStop(0, lighten(baseHex, 0.32));
+    bodyGrad.addColorStop(0.48, lighten(baseHex, 0.1));
+    bodyGrad.addColorStop(1, darken(baseHex, 0.1));
+    ctx.fillStyle = bodyGrad;
+    ctx.fillRect(0, 0, size, size);
   }
+
+  if (pattern === 'cue') {
+    drawCueBallDots(ctx, size);
+  }
+
+  ctx.save();
+  const diagonalShade = ctx.createLinearGradient(0, 0, size, size);
+  diagonalShade.addColorStop(0, 'rgba(255,255,255,0.88)');
+  diagonalShade.addColorStop(0.55, 'rgba(255,255,255,0.46)');
+  diagonalShade.addColorStop(1, 'rgba(0,0,0,0.2)');
+  ctx.globalCompositeOperation = 'multiply';
+  ctx.fillStyle = diagonalShade;
+  ctx.fillRect(0, 0, size, size);
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalCompositeOperation = 'screen';
+  const highlight = ctx.createRadialGradient(
+    size * 0.3,
+    size * 0.24,
+    size * 0.04,
+    size * 0.3,
+    size * 0.24,
+    size * 0.36
+  );
+  highlight.addColorStop(0, 'rgba(255,255,255,1)');
+  highlight.addColorStop(0.4, 'rgba(255,255,255,0.32)');
+  highlight.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = highlight;
+  ctx.fillRect(0, 0, size, size);
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalCompositeOperation = 'multiply';
+  const lowerShadow = ctx.createRadialGradient(
+    size * 0.55,
+    size * 0.72,
+    size * 0.1,
+    size * 0.55,
+    size * 0.72,
+    size * 0.45
+  );
+  lowerShadow.addColorStop(0, 'rgba(0,0,0,0)');
+  lowerShadow.addColorStop(1, 'rgba(0,0,0,0.26)');
+  ctx.fillStyle = lowerShadow;
+  ctx.fillRect(0, 0, size, size);
+  ctx.restore();
+
+  addNoise(ctx, size, 0.018, 3200);
 
   if (Number.isFinite(number)) {
     drawPoolNumberBadge(ctx, size, number);
@@ -277,16 +403,16 @@ export function getBallMaterial({
   });
 
   const material = new THREE.MeshPhysicalMaterial({
-    color: 0xffffff,
+    color: 0xf7f3ea,
     map,
     clearcoat: 1,
-    clearcoatRoughness: 0.015,
-    metalness: 0.24,
-    roughness: 0.06,
+    clearcoatRoughness: 0.01,
+    metalness: 0.26,
+    roughness: 0.045,
     reflectivity: 1,
-    sheen: 0.18,
-    sheenColor: new THREE.Color(0xf8f9ff),
-    envMapIntensity: 1.18
+    sheen: 0.2,
+    sheenColor: new THREE.Color(0xf5f6ff),
+    envMapIntensity: 1.26
   });
   material.needsUpdate = true;
   BALL_MATERIAL_CACHE.set(cacheKey, material);


### PR DESCRIPTION
## Summary
- shrink pool ball numerals and tighten double-digit spacing for a neater badge
- render cue ball dots directly in the texture with badge-style shading and remove separate marker meshes
- add milky white tinting and enhanced gloss/shading to pool ball materials for a more realistic finish

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aafeb639c8329b389de3c6792368b)