### PR TITLE
Refine Pool Royale visuals and materials

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2072,27 +2072,41 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
   ].filter(Boolean)
 );
 
+const PAWN_HEAD_CHROME = Object.freeze({
+  color: 0xd6d8dc,
+  metalness: 0.95,
+  roughness: 0.12,
+  clearcoat: 0.5,
+  clearcoatRoughness: 0.06,
+  transmission: 0.1,
+  ior: 2.1,
+  thickness: 0.22
+});
+
+const PAWN_HEAD_GOLD = Object.freeze({
+  color: 0xd4af37,
+  metalness: 0.92,
+  roughness: 0.16,
+  clearcoat: 0.5,
+  clearcoatRoughness: 0.06,
+  transmission: 0.06,
+  ior: 1.85,
+  thickness: 0.28
+});
+
 const DEFAULT_CHROME_COLOR_ID = 'chrome';
 const CHROME_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
     label: 'Chrome',
-    color: 0xc0c9d5,
-    metalness: 0.76,
-    roughness: 0.42,
-    clearcoat: 0.26,
-    clearcoatRoughness: 0.3,
-    envMapIntensity: 0.58
+    ...PAWN_HEAD_CHROME,
+    envMapIntensity: 1.1
   },
   {
     id: 'gold',
     label: 'Gold',
-    color: 0xd4af37,
-    metalness: 0.88,
-    roughness: 0.35,
-    clearcoat: 0.26,
-    clearcoatRoughness: 0.2,
-    envMapIntensity: 0.58
+    ...PAWN_HEAD_GOLD,
+    envMapIntensity: 1.1
   }
 ]);
 
@@ -2196,11 +2210,8 @@ const RAIL_MARKER_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
     label: 'Chrome',
-    color: 0xd2d8e2,
-    metalness: 0.9,
-    roughness: 0.22,
-    clearcoat: 0.6,
-    clearcoatRoughness: 0.18
+    ...PAWN_HEAD_CHROME,
+    envMapIntensity: 1.1
   },
   {
     id: 'pearl',
@@ -2216,13 +2227,8 @@ const RAIL_MARKER_COLOR_OPTIONS = Object.freeze([
   {
     id: 'gold',
     label: 'Gold',
-    color: 0xd4af37,
-    metalness: 0.88,
-    roughness: 0.26,
-    clearcoat: 0.58,
-    clearcoatRoughness: 0.18,
-    sheen: 0.32,
-    sheenRoughness: 0.4
+    ...PAWN_HEAD_GOLD,
+    envMapIntensity: 1.1
   }
 ]);
 
@@ -7299,11 +7305,23 @@ function Table3D(
     if (typeof colorOpt?.clearcoatRoughness === 'number') {
       railMarkerMat.clearcoatRoughness = colorOpt.clearcoatRoughness;
     }
+    if (typeof colorOpt?.transmission === 'number') {
+      railMarkerMat.transmission = colorOpt.transmission;
+    }
+    if (typeof colorOpt?.ior === 'number') {
+      railMarkerMat.ior = colorOpt.ior;
+    }
+    if (typeof colorOpt?.thickness === 'number') {
+      railMarkerMat.thickness = colorOpt.thickness;
+    }
     if (typeof colorOpt?.sheen === 'number') {
       railMarkerMat.sheen = colorOpt.sheen;
     }
     if (typeof colorOpt?.sheenRoughness === 'number') {
       railMarkerMat.sheenRoughness = colorOpt.sheenRoughness;
+    }
+    if (typeof colorOpt?.envMapIntensity === 'number') {
+      railMarkerMat.envMapIntensity = colorOpt.envMapIntensity;
     }
     railMarkerMat.needsUpdate = true;
     clearRailMarkerMeshes();
@@ -8721,7 +8739,10 @@ function PoolRoyaleGame({
             metalness: chromeSelection.metalness,
             roughness: chromeSelection.roughness,
             clearcoat: chromeSelection.clearcoat,
-            clearcoatRoughness: chromeSelection.clearcoatRoughness
+            clearcoatRoughness: chromeSelection.clearcoatRoughness,
+            transmission: chromeSelection.transmission,
+            ior: chromeSelection.ior,
+            thickness: chromeSelection.thickness
           });
         }
         materials.trim.color.set(chromeSelection.color);
@@ -8729,6 +8750,15 @@ function PoolRoyaleGame({
         materials.trim.roughness = chromeSelection.roughness;
         materials.trim.clearcoat = chromeSelection.clearcoat;
         materials.trim.clearcoatRoughness = chromeSelection.clearcoatRoughness;
+        if (typeof chromeSelection.transmission === 'number') {
+          materials.trim.transmission = chromeSelection.transmission;
+        }
+        if (typeof chromeSelection.ior === 'number') {
+          materials.trim.ior = chromeSelection.ior;
+        }
+        if (typeof chromeSelection.thickness === 'number') {
+          materials.trim.thickness = chromeSelection.thickness;
+        }
         if (typeof chromeSelection.envMapIntensity === 'number') {
           materials.trim.envMapIntensity = chromeSelection.envMapIntensity;
         }

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -148,7 +148,7 @@ function sphericalToUV([x, y, z]) {
 function drawCueBallDots(ctx, size) {
   const dotColor = '#c62828';
   const badgeStretch = 2;
-  const radius = size * 0.084;
+  const radius = size * 0.06;
   const normals = [
     [1, 0, 0],
     [-1, 0, 0],
@@ -184,9 +184,9 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
     const stripeHeight = size * 0.45;
     const stripeY = (size - stripeHeight) / 2;
     const stripeGrad = ctx.createLinearGradient(0, stripeY, 0, stripeY + stripeHeight);
-    stripeGrad.addColorStop(0, lighten(baseHex, 0.2));
-    stripeGrad.addColorStop(0.5, baseHex);
-    stripeGrad.addColorStop(1, darken(baseHex, 0.12));
+    stripeGrad.addColorStop(0, lighten(baseHex, 0.28));
+    stripeGrad.addColorStop(0.5, lighten(baseHex, 0.06));
+    stripeGrad.addColorStop(1, darken(baseHex, 0.06));
     ctx.fillStyle = stripeGrad;
     ctx.fillRect(0, stripeY, size, stripeHeight);
     ctx.restore();
@@ -199,9 +199,9 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
       size * 0.56,
       size * 0.52
     );
-    bodyGrad.addColorStop(0, lighten(baseHex, 0.32));
-    bodyGrad.addColorStop(0.48, lighten(baseHex, 0.1));
-    bodyGrad.addColorStop(1, darken(baseHex, 0.1));
+    bodyGrad.addColorStop(0, lighten(baseHex, 0.36));
+    bodyGrad.addColorStop(0.48, lighten(baseHex, 0.14));
+    bodyGrad.addColorStop(1, darken(baseHex, 0.06));
     ctx.fillStyle = bodyGrad;
     ctx.fillRect(0, 0, size, size);
   }
@@ -212,9 +212,9 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
 
   ctx.save();
   const diagonalShade = ctx.createLinearGradient(0, 0, size, size);
-  diagonalShade.addColorStop(0, 'rgba(255,255,255,0.88)');
-  diagonalShade.addColorStop(0.55, 'rgba(255,255,255,0.46)');
-  diagonalShade.addColorStop(1, 'rgba(0,0,0,0.2)');
+  diagonalShade.addColorStop(0, 'rgba(255,255,255,0.8)');
+  diagonalShade.addColorStop(0.55, 'rgba(255,255,255,0.38)');
+  diagonalShade.addColorStop(1, 'rgba(0,0,0,0.08)');
   ctx.globalCompositeOperation = 'multiply';
   ctx.fillStyle = diagonalShade;
   ctx.fillRect(0, 0, size, size);
@@ -248,7 +248,7 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
     size * 0.45
   );
   lowerShadow.addColorStop(0, 'rgba(0,0,0,0)');
-  lowerShadow.addColorStop(1, 'rgba(0,0,0,0.26)');
+  lowerShadow.addColorStop(1, 'rgba(0,0,0,0.14)');
   ctx.fillStyle = lowerShadow;
   ctx.fillRect(0, 0, size, size);
   ctx.restore();
@@ -270,9 +270,9 @@ function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
     const stripeHeight = size * 0.46;
     const stripeY = (size - stripeHeight) / 2;
     const stripeGrad = ctx.createLinearGradient(0, stripeY, 0, stripeY + stripeHeight);
-    stripeGrad.addColorStop(0, lighten(baseHex, 0.28));
-    stripeGrad.addColorStop(0.5, lighten(baseHex, 0.1));
-    stripeGrad.addColorStop(1, darken(baseHex, 0.06));
+    stripeGrad.addColorStop(0, lighten(baseHex, 0.32));
+    stripeGrad.addColorStop(0.5, lighten(baseHex, 0.18));
+    stripeGrad.addColorStop(1, darken(baseHex, 0.04));
     ctx.fillStyle = stripeGrad;
     ctx.fillRect(0, stripeY, size, stripeHeight);
 
@@ -295,9 +295,9 @@ function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
       size * 0.55,
       size * 0.5
     );
-    radial.addColorStop(0, lighten(baseHex, 0.34));
-    radial.addColorStop(0.45, lighten(baseHex, 0.12));
-    radial.addColorStop(1, darken(baseHex, 0.08));
+    radial.addColorStop(0, lighten(baseHex, 0.38));
+    radial.addColorStop(0.45, lighten(baseHex, 0.18));
+    radial.addColorStop(1, darken(baseHex, 0.04));
     ctx.fillStyle = radial;
     ctx.fillRect(0, 0, size, size);
   }
@@ -305,9 +305,9 @@ function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
 
   ctx.save();
   const diagonalShade = ctx.createLinearGradient(0, 0, size, size);
-  diagonalShade.addColorStop(0, 'rgba(255,255,255,0.86)');
-  diagonalShade.addColorStop(0.55, 'rgba(255,255,255,0.42)');
-  diagonalShade.addColorStop(1, 'rgba(0,0,0,0.16)');
+  diagonalShade.addColorStop(0, 'rgba(255,255,255,0.78)');
+  diagonalShade.addColorStop(0.55, 'rgba(255,255,255,0.36)');
+  diagonalShade.addColorStop(1, 'rgba(0,0,0,0.08)');
   ctx.globalCompositeOperation = 'multiply';
   ctx.fillStyle = diagonalShade;
   ctx.fillRect(0, 0, size, size);
@@ -341,7 +341,7 @@ function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
     size * 0.45
   );
   lowerShadow.addColorStop(0, 'rgba(0,0,0,0)');
-  lowerShadow.addColorStop(1, 'rgba(0,0,0,0.22)');
+  lowerShadow.addColorStop(1, 'rgba(0,0,0,0.12)');
   ctx.fillStyle = lowerShadow;
   ctx.fillRect(0, 0, size, size);
   ctx.restore();


### PR DESCRIPTION
## Summary
- Reduce cue-ball spot size and rebalance ball texture shading to remove the dark cast.
- Align chrome and gold material presets for plates and rail markers with the Chess Battle Royale pawn head materials.
- Propagate pawn-inspired material properties (transmission, IOR, thickness, env-map intensity) into trim and marker rendering.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ac70393008329908f73005b49181c)