### PR TITLE
Tune Pool Royale visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2077,22 +2077,22 @@ const CHROME_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
     label: 'Chrome',
-    color: 0xc0c9d5,
-    metalness: 0.76,
-    roughness: 0.42,
-    clearcoat: 0.26,
-    clearcoatRoughness: 0.3,
-    envMapIntensity: 0.58
+    color: 0xd6d8dc,
+    metalness: 0.95,
+    roughness: 0.12,
+    clearcoat: 0.5,
+    clearcoatRoughness: 0.06,
+    envMapIntensity: 1
   },
   {
     id: 'gold',
     label: 'Gold',
     color: 0xd4af37,
-    metalness: 0.88,
-    roughness: 0.35,
-    clearcoat: 0.26,
-    clearcoatRoughness: 0.2,
-    envMapIntensity: 0.58
+    metalness: 0.92,
+    roughness: 0.16,
+    clearcoat: 0.5,
+    clearcoatRoughness: 0.06,
+    envMapIntensity: 1
   }
 ]);
 
@@ -3367,12 +3367,12 @@ function enhanceChromeMaterial(material) {
       material[key] = value;
     }
   };
-  ensure('metalness', 0.9, (current, target) => Math.max(current, target));
-  ensure('roughness', 0.1, (current, target) => Math.min(current, target));
-  ensure('clearcoat', 0.72, (current, target) => Math.max(current, target));
-  ensure('clearcoatRoughness', 0.16, (current, target) => Math.max(current, target));
-  ensure('envMapIntensity', 1.02, (current, target) =>
-    THREE.MathUtils.clamp(current, 0.92, target)
+  ensure('metalness', 0.92, (current, target) => Math.max(current, target));
+  ensure('roughness', 0.12, (current, target) => Math.min(current, target));
+  ensure('clearcoat', 0.5, (current, target) => Math.max(current, target));
+  ensure('clearcoatRoughness', 0.06, (current, target) => Math.max(current, target));
+  ensure('envMapIntensity', 1, (current, target) =>
+    THREE.MathUtils.clamp(current, 0.9, target)
   );
   if (material.side !== THREE.DoubleSide) {
     material.side = THREE.DoubleSide;

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -148,7 +148,8 @@ function sphericalToUV([x, y, z]) {
 function drawCueBallDots(ctx, size) {
   const dotColor = '#c62828';
   const badgeStretch = 2;
-  const radius = size * 0.084;
+  // Match the cue-ball spots to the physical cue tip diameter so they read smaller on the sphere.
+  const radius = size * 0.028;
   const normals = [
     [1, 0, 0],
     [-1, 0, 0],
@@ -184,9 +185,9 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
     const stripeHeight = size * 0.45;
     const stripeY = (size - stripeHeight) / 2;
     const stripeGrad = ctx.createLinearGradient(0, stripeY, 0, stripeY + stripeHeight);
-    stripeGrad.addColorStop(0, lighten(baseHex, 0.2));
-    stripeGrad.addColorStop(0.5, baseHex);
-    stripeGrad.addColorStop(1, darken(baseHex, 0.12));
+    stripeGrad.addColorStop(0, lighten(baseHex, 0.14));
+    stripeGrad.addColorStop(0.5, lighten(baseHex, 0.04));
+    stripeGrad.addColorStop(1, darken(baseHex, 0.05));
     ctx.fillStyle = stripeGrad;
     ctx.fillRect(0, stripeY, size, stripeHeight);
     ctx.restore();
@@ -199,9 +200,9 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
       size * 0.56,
       size * 0.52
     );
-    bodyGrad.addColorStop(0, lighten(baseHex, 0.32));
-    bodyGrad.addColorStop(0.48, lighten(baseHex, 0.1));
-    bodyGrad.addColorStop(1, darken(baseHex, 0.1));
+    bodyGrad.addColorStop(0, lighten(baseHex, 0.24));
+    bodyGrad.addColorStop(0.48, lighten(baseHex, 0.06));
+    bodyGrad.addColorStop(1, darken(baseHex, 0.04));
     ctx.fillStyle = bodyGrad;
     ctx.fillRect(0, 0, size, size);
   }
@@ -212,9 +213,9 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
 
   ctx.save();
   const diagonalShade = ctx.createLinearGradient(0, 0, size, size);
-  diagonalShade.addColorStop(0, 'rgba(255,255,255,0.88)');
-  diagonalShade.addColorStop(0.55, 'rgba(255,255,255,0.46)');
-  diagonalShade.addColorStop(1, 'rgba(0,0,0,0.2)');
+  diagonalShade.addColorStop(0, 'rgba(255,255,255,0.65)');
+  diagonalShade.addColorStop(0.55, 'rgba(255,255,255,0.32)');
+  diagonalShade.addColorStop(1, 'rgba(0,0,0,0.12)');
   ctx.globalCompositeOperation = 'multiply';
   ctx.fillStyle = diagonalShade;
   ctx.fillRect(0, 0, size, size);
@@ -248,7 +249,7 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
     size * 0.45
   );
   lowerShadow.addColorStop(0, 'rgba(0,0,0,0)');
-  lowerShadow.addColorStop(1, 'rgba(0,0,0,0.26)');
+  lowerShadow.addColorStop(1, 'rgba(0,0,0,0.16)');
   ctx.fillStyle = lowerShadow;
   ctx.fillRect(0, 0, size, size);
   ctx.restore();


### PR DESCRIPTION
## Summary
- Shrink the cue-ball spot decals to match the cue tip and brighten pool ball textures for fuller colors.
- Align chrome and gold trim options with the chess pawn head materials while keeping chrome enhancement consistent.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ac70393008329908f73005b49181c)