### PR TITLE
Brighten Pool Royale balls and align materials

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2077,22 +2077,22 @@ const CHROME_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
     label: 'Chrome',
-    color: 0xc0c9d5,
-    metalness: 0.76,
-    roughness: 0.42,
-    clearcoat: 0.26,
-    clearcoatRoughness: 0.3,
-    envMapIntensity: 0.58
+    color: 0xd6d8dc,
+    metalness: 0.95,
+    roughness: 0.12,
+    clearcoat: 0.5,
+    clearcoatRoughness: 0.06,
+    envMapIntensity: 1
   },
   {
     id: 'gold',
     label: 'Gold',
     color: 0xd4af37,
-    metalness: 0.88,
-    roughness: 0.35,
-    clearcoat: 0.26,
-    clearcoatRoughness: 0.2,
-    envMapIntensity: 0.58
+    metalness: 0.92,
+    roughness: 0.16,
+    clearcoat: 0.5,
+    clearcoatRoughness: 0.06,
+    envMapIntensity: 1
   }
 ]);
 
@@ -2196,11 +2196,11 @@ const RAIL_MARKER_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
     label: 'Chrome',
-    color: 0xd2d8e2,
-    metalness: 0.9,
-    roughness: 0.22,
-    clearcoat: 0.6,
-    clearcoatRoughness: 0.18
+    color: 0xd6d8dc,
+    metalness: 0.95,
+    roughness: 0.12,
+    clearcoat: 0.5,
+    clearcoatRoughness: 0.06
   },
   {
     id: 'pearl',
@@ -2217,10 +2217,10 @@ const RAIL_MARKER_COLOR_OPTIONS = Object.freeze([
     id: 'gold',
     label: 'Gold',
     color: 0xd4af37,
-    metalness: 0.88,
-    roughness: 0.26,
-    clearcoat: 0.58,
-    clearcoatRoughness: 0.18,
+    metalness: 0.92,
+    roughness: 0.16,
+    clearcoat: 0.5,
+    clearcoatRoughness: 0.06,
     sheen: 0.32,
     sheenRoughness: 0.4
   }

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -148,7 +148,7 @@ function sphericalToUV([x, y, z]) {
 function drawCueBallDots(ctx, size) {
   const dotColor = '#c62828';
   const badgeStretch = 2;
-  const radius = size * 0.084;
+  const radius = size * 0.06;
   const normals = [
     [1, 0, 0],
     [-1, 0, 0],
@@ -184,9 +184,9 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
     const stripeHeight = size * 0.45;
     const stripeY = (size - stripeHeight) / 2;
     const stripeGrad = ctx.createLinearGradient(0, stripeY, 0, stripeY + stripeHeight);
-    stripeGrad.addColorStop(0, lighten(baseHex, 0.2));
-    stripeGrad.addColorStop(0.5, baseHex);
-    stripeGrad.addColorStop(1, darken(baseHex, 0.12));
+    stripeGrad.addColorStop(0, lighten(baseHex, 0.28));
+    stripeGrad.addColorStop(0.5, lighten(baseHex, 0.14));
+    stripeGrad.addColorStop(1, darken(baseHex, 0.05));
     ctx.fillStyle = stripeGrad;
     ctx.fillRect(0, stripeY, size, stripeHeight);
     ctx.restore();
@@ -199,9 +199,9 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
       size * 0.56,
       size * 0.52
     );
-    bodyGrad.addColorStop(0, lighten(baseHex, 0.32));
-    bodyGrad.addColorStop(0.48, lighten(baseHex, 0.1));
-    bodyGrad.addColorStop(1, darken(baseHex, 0.1));
+    bodyGrad.addColorStop(0, lighten(baseHex, 0.38));
+    bodyGrad.addColorStop(0.48, lighten(baseHex, 0.18));
+    bodyGrad.addColorStop(1, darken(baseHex, 0.04));
     ctx.fillStyle = bodyGrad;
     ctx.fillRect(0, 0, size, size);
   }
@@ -212,9 +212,9 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
 
   ctx.save();
   const diagonalShade = ctx.createLinearGradient(0, 0, size, size);
-  diagonalShade.addColorStop(0, 'rgba(255,255,255,0.88)');
-  diagonalShade.addColorStop(0.55, 'rgba(255,255,255,0.46)');
-  diagonalShade.addColorStop(1, 'rgba(0,0,0,0.2)');
+  diagonalShade.addColorStop(0, 'rgba(255,255,255,0.72)');
+  diagonalShade.addColorStop(0.55, 'rgba(255,255,255,0.34)');
+  diagonalShade.addColorStop(1, 'rgba(0,0,0,0.12)');
   ctx.globalCompositeOperation = 'multiply';
   ctx.fillStyle = diagonalShade;
   ctx.fillRect(0, 0, size, size);
@@ -248,7 +248,7 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
     size * 0.45
   );
   lowerShadow.addColorStop(0, 'rgba(0,0,0,0)');
-  lowerShadow.addColorStop(1, 'rgba(0,0,0,0.26)');
+  lowerShadow.addColorStop(1, 'rgba(0,0,0,0.16)');
   ctx.fillStyle = lowerShadow;
   ctx.fillRect(0, 0, size, size);
   ctx.restore();


### PR DESCRIPTION
## Summary
- reduce cue-ball dot size to match the cue tip footprint
- boost pool ball texture highlights and reduce shading so colors render fully
- align Pool Royale chrome and gold plate/diamond materials with the Chess Battle Royal pawn head presets

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ad1991c9483299e41ebae9e039330)