### PR TITLE
Adjust Pool Royale cue ball details and metal materials

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2077,22 +2077,22 @@ const CHROME_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
     label: 'Chrome',
-    color: 0xc0c9d5,
-    metalness: 0.76,
-    roughness: 0.42,
-    clearcoat: 0.26,
-    clearcoatRoughness: 0.3,
-    envMapIntensity: 0.58
+    color: 0xd6d8dc,
+    metalness: 0.95,
+    roughness: 0.12,
+    clearcoat: 0.5,
+    clearcoatRoughness: 0.06,
+    envMapIntensity: 0.72
   },
   {
     id: 'gold',
     label: 'Gold',
     color: 0xd4af37,
-    metalness: 0.88,
-    roughness: 0.35,
-    clearcoat: 0.26,
-    clearcoatRoughness: 0.2,
-    envMapIntensity: 0.58
+    metalness: 0.92,
+    roughness: 0.16,
+    clearcoat: 0.5,
+    clearcoatRoughness: 0.06,
+    envMapIntensity: 0.72
   }
 ]);
 

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -147,8 +147,8 @@ function sphericalToUV([x, y, z]) {
 
 function drawCueBallDots(ctx, size) {
   const dotColor = '#c62828';
-  const badgeStretch = 2;
-  const radius = size * 0.084;
+  const badgeStretch = 1.8;
+  const radius = size * 0.06;
   const normals = [
     [1, 0, 0],
     [-1, 0, 0],
@@ -184,9 +184,9 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
     const stripeHeight = size * 0.45;
     const stripeY = (size - stripeHeight) / 2;
     const stripeGrad = ctx.createLinearGradient(0, stripeY, 0, stripeY + stripeHeight);
-    stripeGrad.addColorStop(0, lighten(baseHex, 0.2));
+    stripeGrad.addColorStop(0, lighten(baseHex, 0.14));
     stripeGrad.addColorStop(0.5, baseHex);
-    stripeGrad.addColorStop(1, darken(baseHex, 0.12));
+    stripeGrad.addColorStop(1, darken(baseHex, 0.08));
     ctx.fillStyle = stripeGrad;
     ctx.fillRect(0, stripeY, size, stripeHeight);
     ctx.restore();
@@ -199,9 +199,9 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
       size * 0.56,
       size * 0.52
     );
-    bodyGrad.addColorStop(0, lighten(baseHex, 0.32));
-    bodyGrad.addColorStop(0.48, lighten(baseHex, 0.1));
-    bodyGrad.addColorStop(1, darken(baseHex, 0.1));
+    bodyGrad.addColorStop(0, lighten(baseHex, 0.24));
+    bodyGrad.addColorStop(0.48, lighten(baseHex, 0.08));
+    bodyGrad.addColorStop(1, darken(baseHex, 0.06));
     ctx.fillStyle = bodyGrad;
     ctx.fillRect(0, 0, size, size);
   }
@@ -212,9 +212,9 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
 
   ctx.save();
   const diagonalShade = ctx.createLinearGradient(0, 0, size, size);
-  diagonalShade.addColorStop(0, 'rgba(255,255,255,0.88)');
-  diagonalShade.addColorStop(0.55, 'rgba(255,255,255,0.46)');
-  diagonalShade.addColorStop(1, 'rgba(0,0,0,0.2)');
+  diagonalShade.addColorStop(0, 'rgba(255,255,255,0.72)');
+  diagonalShade.addColorStop(0.55, 'rgba(255,255,255,0.32)');
+  diagonalShade.addColorStop(1, 'rgba(0,0,0,0.12)');
   ctx.globalCompositeOperation = 'multiply';
   ctx.fillStyle = diagonalShade;
   ctx.fillRect(0, 0, size, size);
@@ -248,7 +248,7 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
     size * 0.45
   );
   lowerShadow.addColorStop(0, 'rgba(0,0,0,0)');
-  lowerShadow.addColorStop(1, 'rgba(0,0,0,0.26)');
+  lowerShadow.addColorStop(1, 'rgba(0,0,0,0.18)');
   ctx.fillStyle = lowerShadow;
   ctx.fillRect(0, 0, size, size);
   ctx.restore();


### PR DESCRIPTION
## Summary
- shrink cue ball spotting to match the cue tip diameter and refresh pool ball shading for fuller color
- align Pool Royale chrome and gold material presets with the Chess Battle Royal pawn head materials

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ad1991c9483299e41ebae9e039330)