### PR TITLE
Refine chess board fit and piece motion

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -185,7 +185,7 @@ const BOARD_SURFACE_DROP = 0.05;
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
 const BOARD_SCALE = 0.06;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
-const BOARD_MODEL_SPAN_BIAS = 1.18;
+const BOARD_MODEL_SPAN_BIAS = 1.12;
 const HIGHLIGHT_VERTICAL_OFFSET = 0.18;
 
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
@@ -214,7 +214,7 @@ const CAMERA_PHI_OFFSET = 0;
 const CAMERA_TOPDOWN_EXTRA = 0;
 const CAMERA_INITIAL_PHI_EXTRA = 0;
 const CAMERA_TOPDOWN_LOCK = THREE.MathUtils.degToRad(4);
-const TARGET_FPS = 90;
+const TARGET_FPS = 120;
 const TARGET_FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
 const RENDER_PIXEL_RATIO_CAP = 1.25;
 const RENDER_PIXEL_RATIO_SCALE = 1.0;
@@ -6820,11 +6820,13 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
         const idx = zone.push(targetMesh) - 1;
         const row = Math.floor(idx / 8);
         const col = idx % 8;
-        const capX = (col - 3.5) * (tile * 0.5);
+        const captureSpacing = tile * 0.65;
+        const capX = (col - 3.5) * captureSpacing;
         const capZ = capturingWhite
-          ? half + BOARD.rim + 1 + row * (tile * 0.5)
-          : -half - BOARD.rim - 1 - row * (tile * 0.5);
-        targetMesh.position.set(capX, 0, capZ);
+          ? half + BOARD.rim + 1.2 + row * captureSpacing
+          : -half - BOARD.rim - 1.2 - row * captureSpacing;
+        const capY = Math.max(currentPieceYOffset, PIECE_PLACEMENT_Y_OFFSET);
+        targetMesh.position.set(capX, capY, capZ);
         createExplosion(worldPos);
         if (bombSoundRef.current && settingsRef.current.soundEnabled) {
           bombSoundRef.current.currentTime = 0;
@@ -6851,7 +6853,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
       m.userData.t = board[rr][cc].t;
       cancelPieceAnimation(m);
       const targetPosition = piecePosition(rr, cc, currentPieceYOffset);
-      animatePieceTo(m, targetPosition, 0.42);
+      animatePieceTo(m, targetPosition, 0.6);
       if (promoted && currentPiecePrototypes) {
         const color = board[rr][cc].w ? 'white' : 'black';
         const queenProto = currentPiecePrototypes[color]?.Q;
@@ -6923,7 +6925,7 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
     const piecePosition = (r, c, y = currentPieceYOffset) =>
       new THREE.Vector3(c * tile - half + tile / 2, y, r * tile - half + tile / 2);
 
-    const animatePieceTo = (mesh, target, duration = 0.35) => {
+    const animatePieceTo = (mesh, target, duration = 0.5) => {
       if (!mesh) return;
       const anim = {
         mesh,


### PR DESCRIPTION
## Summary
- slightly reduce the GLTF chess board footprint so pieces sit cleanly on squares
- reposition captured pieces with consistent height and wider spacing beside the board
- slow piece move animation with higher frame rate for smoother, more natural motion

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ada101f388329b0e1443e297b2bfa)