### PR TITLE
Normalize side pocket normals

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -162,6 +162,9 @@ public class BilliardsSolver
             Vec2 normal = new Vec2(-dir.Y, dir.X);
             if (Vec2.Dot(normal, hint) < 0)
                 normal = -normal;
+            // Normalise to keep contact offsets consistent with other pocket/cushion edges.
+            if (normal.Length > PhysicsConstants.Epsilon)
+                normal = normal.Normalized();
             var edge = new Edge { A = a, B = b, Normal = normal };
             bool nearMouth = i < cushionBands || i >= pts.Count - 1 - cushionBands;
             if (nearMouth)


### PR DESCRIPTION
## Summary
- normalize side pocket jaw normals to keep contact offsets consistent with other pocket geometry
- reduce unexpected deflections near middle pockets by aligning collision handling

## Testing
- dotnet test billiards.Tests/Billiards.Tests.csproj *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693af90c6e9083299e25253ab8b607d5)