### PR TITLE
Fix chess piece animation tweening

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -6939,8 +6939,18 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
     const piecePosition = (r, c, y = currentPieceYOffset) =>
       new THREE.Vector3(c * tile - half + tile / 2, y, r * tile - half + tile / 2);
 
+    const cancelPieceAnimation = (mesh) => {
+      if (!mesh) return;
+      for (let i = activePieceAnimations.length - 1; i >= 0; i -= 1) {
+        if (activePieceAnimations[i].mesh === mesh) {
+          activePieceAnimations.splice(i, 1);
+        }
+      }
+    };
+
     const animatePieceTo = (mesh, target, duration = 0.28) => {
       if (!mesh) return;
+      cancelPieceAnimation(mesh);
       const anim = {
         mesh,
         start: mesh.position.clone(),
@@ -6949,15 +6959,6 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
         elapsed: 0
       };
       activePieceAnimations.push(anim);
-    };
-
-    const cancelPieceAnimation = (mesh) => {
-      if (!mesh) return;
-      for (let i = activePieceAnimations.length - 1; i >= 0; i -= 1) {
-        if (activePieceAnimations[i].mesh === mesh) {
-          activePieceAnimations.splice(i, 1);
-        }
-      }
     };
 
     const pickTileFromPointer = (event) => {


### PR DESCRIPTION
## Summary
- prevent overlapping chess piece tweens by cancelling any existing animation before starting a new move

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b0138b5b48329bafb41337360dbef)