### PR TITLE
Fix chess promotion animation continuity

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -6877,6 +6877,10 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
             t: 'Q',
             __pieceStyleId: currentPieceSetId
           };
+          const activeAnim = activePieceAnimations.find((anim) => anim.mesh === m);
+          if (activeAnim) {
+            activeAnim.mesh = replacement;
+          }
           replacement.traverse((child) => {
             if (!child.isMesh) return;
             child.userData = {


### PR DESCRIPTION
## Summary
- ensure active move animations are transferred when promoting a pawn to a queen
- keep promoted chess pieces moving smoothly to their destination instead of stopping midair

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b0138b5b48329bafb41337360dbef)