### PR TITLE
Improve UK pool AI targeting and post-shot auto-aim

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -151,6 +151,33 @@ function pocketEntry (pocket, state) {
   return { x: pocket.x, y: pocket.y, name: pocket.name }
 }
 
+function contactPointTowardsPocket (target, pocket, radius) {
+  if (!target || !pocket) return null
+  const dir = { x: target.x - pocket.x, y: target.y - pocket.y }
+  const len = Math.hypot(dir.x, dir.y) || 1
+  const offset = radius * 2
+  return {
+    x: target.x + (dir.x / len) * offset,
+    y: target.y + (dir.y / len) * offset
+  }
+}
+
+function aimPointForCandidate (candidate, state, cueBall) {
+  if (candidate.bankAnchor) {
+    return { x: candidate.bankAnchor.x, y: candidate.bankAnchor.y }
+  }
+  const ghost = contactPointTowardsPocket(
+    candidate.targetBall,
+    candidate.pocket,
+    state.ballRadius || 0
+  )
+  if (ghost) return ghost
+  if (candidate.targetBall) {
+    return { x: candidate.targetBall.x, y: candidate.targetBall.y }
+  }
+  return cueBall ? { x: cueBall.x, y: cueBall.y } : { x: 0, y: 0 }
+}
+
 // Returns angle between cue->ball and ball->pocket in radians
 function cutAngle (cue, target, pocket) {
   const v1 = { x: target.x - cue.x, y: target.y - cue.y }
@@ -723,11 +750,7 @@ function chooseBestAction (state, colour) {
 
   const translatePlan = (candidate, EV) => {
     const cueBall = state.balls.find(b => b.colour === 'cue')
-    const aim = candidate.bankAnchor
-      ? { x: candidate.bankAnchor.x, y: candidate.bankAnchor.y }
-      : (candidate.targetBall
-          ? { x: candidate.targetBall.x, y: candidate.targetBall.y }
-          : { x: cueBall.x, y: cueBall.y })
+    const aim = aimPointForCandidate(candidate, state, cueBall)
     const posTarget = candidate.actionType === 'safety'
       ? { x: cueBall.x, y: cueBall.y }
       : simulateCueRollout(state, candidate)

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -14948,6 +14948,7 @@ function PoolRoyaleGame({
         const variantId = activeVariantRef.current?.id ?? 'american';
         const shotEvents = [];
         const firstContactColor = toBallColorId(firstHit);
+        const hadObjectPot = potted.some((entry) => entry.id !== 'cue');
         if (firstContactColor || firstHit) {
           shotEvents.push({
             type: 'HIT',
@@ -15118,6 +15119,15 @@ function PoolRoyaleGame({
           pocketSwitchIntentRef.current = null;
           lastPocketBallRef.current = null;
           updatePocketCameraState(false);
+          if (hadObjectPot && !(hudRef.current?.over)) {
+            window.setTimeout(() => {
+              const hudState = hudRef.current;
+              if (hudState?.turn === 0 && !hudState.over) {
+                autoAimRequestRef.current = true;
+                startUserSuggestionRef.current?.();
+              }
+            }, 0);
+          }
           if (cameraRef.current && sphRef.current) {
             const cuePos = cue?.pos
               ? new THREE.Vector2(cue.pos.x, cue.pos.y)


### PR DESCRIPTION
## Summary
- aim UK 8-ball AI shots at the true ghost/contact point for better potting accuracy
- keep positional logic intact while returning precise aim targets for cue control
- refresh player auto-aim suggestions after pots to immediately line up the next ball

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b100e46288329a5efc3ea1465f2a9)