### PR TITLE
Fix foul handling and add fallback auto-aim

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -63,14 +63,11 @@ export class AmericanBilliards {
     let winner = null;
     const targetScore = 61;
 
-    const spotPotted = () => {
-      for (const id of pottedBalls) s.ballsOnTable.add(id);
-    };
-
     if (foul) {
       s.scores[current] = Math.max(0, s.scores[current] - 1);
       s.scores[opp] += 1;
-      spotPotted();
+      // Balls pocketed on a foul stay down, but the turn still passes.
+      for (const id of pottedBalls) s.ballsOnTable.delete(id);
       nextPlayer = opp;
       s.currentPlayer = opp;
       ballInHandNext = true;

--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -57,6 +57,12 @@ export class NineBall {
     const foulLimit = 3;
 
     if (foul) {
+      // Any object balls potted on a foul stay down except the nine, which is
+      // spotted back on the table. The inning still passes to the opponent.
+      for (const id of pottedBalls) {
+        if (id === 9) s.ballsOnTable.add(id);
+        else s.ballsOnTable.delete(id);
+      }
       nextPlayer = opp;
       ballInHandNext = true;
       s.currentPlayer = opp;

--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -457,6 +457,57 @@ function safetyShot (req) {
   }
 }
 
+function fallbackAimAtTarget (req) {
+  const cue = req.state.balls.find(b => b.id === 0)
+  const targets = chooseTargets(req)
+  if (!cue || targets.length === 0) return null
+
+  let best = null
+  for (const target of targets) {
+    let bestPocket = null
+    let bestAlign = -Infinity
+    for (const pocket of req.state.pockets) {
+      const align = pocketAlignment(pocket, target, req.state.width, req.state.height)
+      if (align > bestAlign) {
+        bestAlign = align
+        bestPocket = pocket
+      }
+    }
+    if (!bestPocket) continue
+    const entry = pocketEntry(bestPocket, req.state.ballRadius, req.state.width, req.state.height, target)
+    const ghost = {
+      x: target.x - (entry.x - target.x) * (req.state.ballRadius * 2 / dist(target, entry)),
+      y: target.y - (entry.y - target.y) * (req.state.ballRadius * 2 / dist(target, entry))
+    }
+    if (
+      ghost.x < req.state.ballRadius ||
+      ghost.x > req.state.width - req.state.ballRadius ||
+      ghost.y < req.state.ballRadius ||
+      ghost.y > req.state.height - req.state.ballRadius
+    ) {
+      continue
+    }
+    const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
+    const candidate = {
+      angleRad: angle,
+      power: 0.65,
+      spin: { top: 0, side: 0, back: 0 },
+      targetBallId: target.id,
+      targetPocket: bestPocket,
+      aimPoint: ghost,
+      quality: 0,
+      rationale: 'fallback-aim'
+    }
+    if (!best || bestAlign > best.align) {
+      best = { ...candidate, align: bestAlign }
+    }
+  }
+
+  if (!best) return null
+  const { align: _align, ...rest } = best
+  return rest
+}
+
 /**
  * @param {AimRequest} req
  * @returns {ShotDecision}
@@ -466,6 +517,7 @@ export function planShot (req) {
   const start = Date.now()
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity
   let best = null
+  let fallback = null
 
   const powers = [0.5, 0.7, 0.85]
   const spins = [
@@ -558,7 +610,7 @@ export function planShot (req) {
           for (const spin of spins) {
             if (power === powers[0] && spin === spins[0]) continue
             if (Date.now() > deadline) {
-              return best && best.quality >= 0.1 ? best : safetyShot(req)
+              return best && best.quality >= 0.1 ? best : fallbackAimAtTarget(req) || safetyShot(req)
             }
             const cand = evaluate(
               req,
@@ -584,7 +636,10 @@ export function planShot (req) {
     if (best) break
   }
 
-  return best && best.quality >= 0.1 ? best : safetyShot(req)
+  if (best && best.quality >= 0.1) return best
+  fallback = fallbackAimAtTarget(req)
+  if (fallback) return fallback
+  return safetyShot(req)
 }
 
 export default planShot

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -457,6 +457,57 @@ function safetyShot (req) {
   }
 }
 
+function fallbackAimAtTarget (req) {
+  const cue = req.state.balls.find(b => b.id === 0)
+  const targets = chooseTargets(req)
+  if (!cue || targets.length === 0) return null
+
+  let best = null
+  for (const target of targets) {
+    let bestPocket = null
+    let bestAlign = -Infinity
+    for (const pocket of req.state.pockets) {
+      const align = pocketAlignment(pocket, target, req.state.width, req.state.height)
+      if (align > bestAlign) {
+        bestAlign = align
+        bestPocket = pocket
+      }
+    }
+    if (!bestPocket) continue
+    const entry = pocketEntry(bestPocket, req.state.ballRadius, req.state.width, req.state.height, target)
+    const ghost = {
+      x: target.x - (entry.x - target.x) * (req.state.ballRadius * 2 / dist(target, entry)),
+      y: target.y - (entry.y - target.y) * (req.state.ballRadius * 2 / dist(target, entry))
+    }
+    if (
+      ghost.x < req.state.ballRadius ||
+      ghost.x > req.state.width - req.state.ballRadius ||
+      ghost.y < req.state.ballRadius ||
+      ghost.y > req.state.height - req.state.ballRadius
+    ) {
+      continue
+    }
+    const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
+    const candidate = {
+      angleRad: angle,
+      power: 0.65,
+      spin: { top: 0, side: 0, back: 0 },
+      targetBallId: target.id,
+      targetPocket: bestPocket,
+      aimPoint: ghost,
+      quality: 0,
+      rationale: 'fallback-aim'
+    }
+    if (!best || bestAlign > best.align) {
+      best = { ...candidate, align: bestAlign }
+    }
+  }
+
+  if (!best) return null
+  const { align: _align, ...rest } = best
+  return rest
+}
+
 /**
  * @param {AimRequest} req
  * @returns {ShotDecision}
@@ -466,6 +517,7 @@ export function planShot (req) {
   const start = Date.now()
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity
   let best = null
+  let fallback = null
 
   const powers = [0.5, 0.7, 0.85]
   const spins = [
@@ -558,7 +610,7 @@ export function planShot (req) {
           for (const spin of spins) {
             if (power === powers[0] && spin === spins[0]) continue
             if (Date.now() > deadline) {
-              return best && best.quality >= 0.1 ? best : safetyShot(req)
+              return best && best.quality >= 0.1 ? best : fallbackAimAtTarget(req) || safetyShot(req)
             }
             const cand = evaluate(
               req,
@@ -584,7 +636,10 @@ export function planShot (req) {
     if (best) break
   }
 
-  return best && best.quality >= 0.1 ? best : safetyShot(req)
+  if (best && best.quality >= 0.1) return best
+  fallback = fallbackAimAtTarget(req)
+  if (fallback) return fallback
+  return safetyShot(req)
 }
 
 export default planShot


### PR DESCRIPTION
## Summary
- ensure fouled pots transfer the turn while keeping object balls down in American Billiards and Nine Ball
- add a fallback aim helper so the aiming guide reorients toward the best available target when no high-quality shot is found
- mirror the aiming fallback logic in the web public bundle

## Testing
- npm test --silent (fails: directory /workspace/TonPlaygramWebApp/tests not found in Jest config)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b14a8fe888329b89ae2e74530dcf4)