### PR TITLE
Adjust camera framing and add auto-aim suggestion helper

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -121,6 +121,11 @@ public class CueCamera : MonoBehaviour
     // Distance and height for the short-rail broadcast view used once a shot begins.
     public float broadcastDistance = 0.97125f;
     public float broadcastHeight = 0.5f;
+    // When relying on the overhead broadcast view, pull the camera a little closer
+    // to the cloth so the rolling balls stay readable without switching to pocket
+    // cameras.
+    public float overheadHeightPullIn = 0.08f;
+    public float overheadDistancePullIn = 0.28f;
     // Bounds that encompass the full playing surface including rails and pockets.
     public Bounds tableBounds = new Bounds(new Vector3(0f, 0.36f, 0f), new Vector3(1.64465f, 0.72f, 3.301325f));
     // Keep a small margin inside the camera frame so the rails never touch the
@@ -164,6 +169,8 @@ public class CueCamera : MonoBehaviour
     private int cueAimSideSign = 1;
     private int broadcastSideSign = -1;
     private bool nextShotIsAi;
+    // Toggle to always rely on the overhead broadcast camera instead of pocket cameras.
+    public bool useOverheadBroadcast = true;
     [Header("Occlusion settings")]
     // Layers that should be considered when preventing the camera from getting
     // blocked by level geometry (walls, scoreboards, etc.). Defaults to all
@@ -213,7 +220,7 @@ public class CueCamera : MonoBehaviour
         TargetBall = target;
         currentBall = CueBall;
         shotInProgress = true;
-        usingTargetCamera = target != null;
+        usingTargetCamera = target != null && !useOverheadBroadcast;
 
         int aimSide = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
         cueAimSideSign = aimSide;
@@ -221,7 +228,7 @@ public class CueCamera : MonoBehaviour
 
         Vector3 focus = CueBall != null ? CueBall.position : tableBounds.center;
         targetViewFocus = GetBroadcastFocus(focus);
-        if (target != null && target.gameObject.activeInHierarchy)
+        if (!useOverheadBroadcast && target != null && target.gameObject.activeInHierarchy)
         {
             currentBall = target;
             targetViewFocus = GetBroadcastFocus(target.position);
@@ -657,16 +664,16 @@ public class CueCamera : MonoBehaviour
 
         float minRailHeight = railHeight + Mathf.Max(0f, railClearance);
         float baseHeight = Mathf.Max(broadcastHeight, focus.y + minimumHeightAboveFocus);
-        float height = Mathf.Max(baseHeight + Mathf.Max(0f, broadcastHeightPadding), minRailHeight);
+        float height = Mathf.Max(baseHeight + Mathf.Max(0f, broadcastHeightPadding) - Mathf.Max(0f, overheadHeightPullIn), minRailHeight);
 
         Quaternion rotation = Quaternion.Euler(0f, yaw, 0f);
         Vector3 forward = rotation * Vector3.forward;
 
         Bounds broadcastBounds = GetBroadcastBounds(focus);
-        focus.x = 0f;
-        focus.z = broadcastBounds.center.z;
+        focus = new Vector3(0f, Mathf.Max(focus.y, tableBounds.center.y), tableBounds.center.z);
 
         float distance = ComputeBroadcastDistance(focus, height, forward, cam, broadcastBounds);
+        distance = Mathf.Max(distance - Mathf.Max(0f, overheadDistancePullIn), broadcastMinDistance);
         float minimumHeightOffset = Mathf.Max(minimumHeightAboveFocus, height - focus.y);
         Vector3 lookTarget = focus + Vector3.up * Mathf.Max(0f, broadcastHeightPadding);
 

--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -642,4 +642,25 @@ export function planShot (req) {
   return safetyShot(req)
 }
 
+/**
+ * Pick a single recommended target for automatic aiming overlays.
+ * Prioritises the best clear shot candidate; falls back to the next legal
+ * ball for the variant (lowest for American/9-ball, best colour for UK 8-ball).
+ * @param {AimRequest} req
+ * @returns {{targetBallId:number,targetPocket: Pocket|null}|null}
+ */
+export function autoAimSuggestion (req) {
+  const strict = clearShotCandidates(req)
+  if (strict.length > 0) {
+    const best = strict[0]
+    return { targetBallId: best.target.id, targetPocket: best.pocket }
+  }
+
+  const targets = chooseTargets(req)
+  if (targets.length === 0) return null
+  const preferred = targets[0]
+  const fallbackPocket = (req.state.pockets && req.state.pockets[0]) || null
+  return { targetBallId: preferred.id, targetPocket: fallbackPocket }
+}
+
 export default planShot

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -642,4 +642,25 @@ export function planShot (req) {
   return safetyShot(req)
 }
 
+/**
+ * Pick a single recommended target for automatic aiming overlays.
+ * Prioritises the best clear shot candidate; falls back to the next legal
+ * ball for the variant (lowest for American/9-ball, best colour for UK 8-ball).
+ * @param {AimRequest} req
+ * @returns {{targetBallId:number,targetPocket: Pocket|null}|null}
+ */
+export function autoAimSuggestion (req) {
+  const strict = clearShotCandidates(req)
+  if (strict.length > 0) {
+    const best = strict[0]
+    return { targetBallId: best.target.id, targetPocket: best.pocket }
+  }
+
+  const targets = chooseTargets(req)
+  if (targets.length === 0) return null
+  const preferred = targets[0]
+  const fallbackPocket = (req.state.pockets && req.state.pockets[0]) || null
+  return { targetBallId: preferred.id, targetPocket: fallbackPocket }
+}
+
 export default planShot


### PR DESCRIPTION
## Summary
- tune the broadcast camera to favor the overhead view, keeping the table centered and closer to the cloth instead of switching to pocket cameras
- add a reusable autoAimSuggestion helper so the aiming line can snap to the correct target for each variant after turns or pots
- keep the existing planning utilities unchanged while exposing the new helper in both library bundles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b269023a48329ae50b28c814b75ee)