### PR TITLE
Update Chess Battle Royal controls and audio

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -10,6 +10,9 @@ export default function BottomLeftIcons({
   showChat = true,
   showGift = true,
   showMute = true,
+  showLabels = true,
+  muted: controlledMuted,
+  onToggleMute,
 }) {
   const [muted, setMuted] = useState(isGameMuted());
 
@@ -19,7 +22,19 @@ export default function BottomLeftIcons({
     return () => window.removeEventListener('gameMuteChanged', handler);
   }, []);
 
+  useEffect(() => {
+    if (typeof controlledMuted === 'boolean') {
+      setMuted(controlledMuted);
+    }
+  }, [controlledMuted]);
+
   const toggle = () => {
+    if (typeof onToggleMute === 'function') {
+      const next = !muted;
+      onToggleMute(next);
+      setMuted(next);
+      return;
+    }
     toggleGameMuted();
     setMuted(isGameMuted());
   };
@@ -28,26 +43,34 @@ export default function BottomLeftIcons({
     <div className={className}>
       {showChat && onChat && (
         <button onClick={onChat} className="p-1 flex flex-col items-center">
-          <AiOutlineMessage className="text-xl" />
-          <span className="text-xs">Chat</span>
+          <AiOutlineMessage className="text-xl" aria-hidden />
+          {showLabels ? <span className="text-xs">Chat</span> : <span className="sr-only">Chat</span>}
         </button>
       )}
       {showGift && onGift && (
         <button onClick={onGift} className="p-1 flex flex-col items-center">
-          <span className="text-xl">🎁</span>
-          <span className="text-xs">Gift</span>
+          <span className="text-xl" role="img" aria-hidden>
+            🎁
+          </span>
+          {showLabels ? <span className="text-xs">Gift</span> : <span className="sr-only">Gift</span>}
         </button>
       )}
       {showInfo && (
         <button onClick={onInfo} className="p-1 flex flex-col items-center">
-          <AiOutlineInfoCircle className="text-xl" />
-          <span className="text-xs">Info</span>
+          <AiOutlineInfoCircle className="text-xl" aria-hidden />
+          {showLabels ? <span className="text-xs">Info</span> : <span className="sr-only">Info</span>}
         </button>
       )}
       {showMute && (
         <button onClick={toggle} className="p-1 flex flex-col items-center">
-          <span className="text-lg">{muted ? '🔇' : '🔊'}</span>
-          <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
+          <span className="text-lg" role="img" aria-hidden>
+            {muted ? '🔇' : '🔊'}
+          </span>
+          {showLabels ? (
+            <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
+          ) : (
+            <span className="sr-only">{muted ? 'Unmute' : 'Mute'}</span>
+          )}
         </button>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Align the Chess Battle Royal top-right controls vertically with an icon-only replay button and a simplified 2D/3D toggle.
- Add bottom-left quick actions for chat, gifts, info, and mute to mirror the Snake & Ladder experience and surface the related popups.
- Extend chess sound effect playback with fixed durations and sync mute state handling for the game UI.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b256905d08329bb6411043a2d2b1d)