### PR TITLE
Improve Pool Royale auto aim and cameras

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4201,6 +4201,7 @@ const TOP_VIEW_MARGIN = 0.32;
 const TOP_VIEW_RADIUS_SCALE = 0.28;
 const TOP_VIEW_MIN_RADIUS_SCALE = 0.88;
 const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI + 0.06, CAMERA.minPhi * 0.66);
+const OVERHEAD_FOLLOW_RADIUS_SCALE = 0.92;
 const CUE_VIEW_RADIUS_RATIO = 0.045;
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.19;
 const CUE_VIEW_MIN_PHI = Math.min(
@@ -11329,6 +11330,7 @@ function PoolRoyaleGame({
               }
             }
           } else if (activeShotView?.mode === 'pocket') {
+            updatePocketCameraState(false);
             const ballsList = ballsRef.current || [];
             const focusBall = ballsList.find(
               (b) => b.id === activeShotView.ballId
@@ -11339,224 +11341,35 @@ function PoolRoyaleGame({
                 focusBall.pos.y
               );
             }
-            const pocketCenter = activeShotView.pocketCenter;
-            const anchorType =
-              activeShotView.anchorType ??
-              (activeShotView.isSidePocket ? 'side' : 'short');
-            let railDir =
-              activeShotView.railDir ??
-              (anchorType === 'side'
-                ? signed(pocketCenter.x, 1)
-                : signed(pocketCenter.y, 1));
-            if (!Number.isFinite(activeShotView.railDir) || activeShotView.railDir === 0) {
-              activeShotView.railDir = railDir;
-            } else {
-              railDir = activeShotView.railDir;
-            }
-            let broadcastRailDir =
-              activeShotView.broadcastRailDir ?? (anchorType === 'side' ? null : railDir);
-            const fallbackBroadcast = signed(
-              activeShotView.lastBallPos?.y ?? pocketCenter.y ?? 0,
-              broadcastRailDir ?? railDir ?? 1
+            const focusPosSource =
+              activeShotView.lastBallPos ?? activeShotView.pocketCenter;
+            const focusPos2D = focusPosSource
+              ? focusPosSource.clone()
+              : new THREE.Vector2();
+            const focusTarget = new THREE.Vector3(
+              focusPos2D.x * worldScaleFactor,
+              BALL_CENTER_Y * worldScaleFactor,
+              focusPos2D.y * worldScaleFactor
             );
-            if (anchorType === 'side') {
-              const resolvedBroadcastRailDir =
-                resolveShortRailBroadcastDirection({
-                  pocketCenter: pocketCenter2D,
-                  approachDir,
-                  ballPos: activeShotView.lastBallPos,
-                  ballVel: focusBall?.vel,
-                  fallback: fallbackBroadcast
-                });
-              if (Number.isFinite(resolvedBroadcastRailDir)) {
-                broadcastRailDir = resolvedBroadcastRailDir;
-              }
-            } else {
-              broadcastRailDir = railDir;
-            }
-            activeShotView.broadcastRailDir = broadcastRailDir;
-            broadcastArgs = {
-              railDir: broadcastRailDir ?? railDir,
-              targetWorld: null,
-              focusWorld: broadcastCamerasRef.current?.defaultFocusWorld ?? null,
-              lerp: 0.25
-            };
-            const heightScale =
-              activeShotView.heightScale ?? POCKET_CAM.heightScale ?? 1;
-            let approachDir = activeShotView.approach
-              ? activeShotView.approach.clone()
-              : new THREE.Vector2(0, -railDir);
-            if (approachDir.lengthSq() < 1e-6) {
-              approachDir.set(0, -railDir);
-            }
-            approachDir.normalize();
-            if (activeShotView.approach) {
-              activeShotView.approach.copy(approachDir);
-            } else {
-              activeShotView.approach = approachDir.clone();
-            }
-            const resolvedAnchorId = resolvePocketCameraAnchor(
-              activeShotView.pocketId ?? pocketIdFromCenter(pocketCenter),
-              pocketCenter,
-              approachDir,
-              activeShotView.lastBallPos ?? pocketCenter
+            const maxRadius = clampOrbitRadius(
+              Math.max(
+                getMaxOrbitRadius() * TOP_VIEW_RADIUS_SCALE,
+                CAMERA.minR * TOP_VIEW_MIN_RADIUS_SCALE
+              )
             );
-            const anchorId =
-              resolvedAnchorId ??
-              activeShotView.anchorId ??
-              pocketIdFromCenter(pocketCenter);
-            if (anchorId !== activeShotView.anchorId) {
-              activeShotView.anchorId = anchorId;
-              const latestOutward = getPocketCameraOutward(anchorId);
-              if (latestOutward) {
-                activeShotView.anchorOutward = latestOutward;
-              }
-            }
-            let pocketCamEntry = getPocketCameraEntry(anchorId);
-            const anchorCenter = getPocketCenterById(anchorId);
-            const pocketCamera = pocketCamEntry
-              ? pocketCamEntry.camera
-              : ensurePocketCamera(anchorId, anchorCenter);
-            if (!pocketCamEntry) {
-              pocketCamEntry = getPocketCameraEntry(anchorId) ?? null;
-            }
-            const pocketCenter2D = pocketCenter.clone();
-            const outward = activeShotView.anchorOutward
-              ? activeShotView.anchorOutward.clone()
-              : getPocketCameraOutward(anchorId) ?? pocketCenter2D.clone();
-            if (outward.lengthSq() < 1e-6) {
-              outward.set(
-                anchorType === 'side' ? railDir : 0,
-                anchorType === 'side' ? 0 : railDir
-              );
-            }
-            outward.normalize();
-            if (!activeShotView.anchorOutward) {
-              activeShotView.anchorOutward = outward.clone();
-            }
-            const cameraBounds = cameraBoundsRef.current ?? null;
-            const cueBounds = cameraBounds?.cueShot ?? null;
-            const standingBounds = cameraBounds?.standing ?? null;
-            const focusHeightLocal = BALL_CENTER_Y + BALL_R * 0.12;
-            const focusTarget = new THREE.Vector3(0, focusHeightLocal, 0);
-            const cueBallForPocket = ballsList.find((b) => b.id === 'cue');
-            if (cueBallForPocket && focusBall?.active) {
-              focusTarget.set(
-                (cueBallForPocket.pos.x + focusBall.pos.x) * 0.5,
-                focusHeightLocal,
-                (cueBallForPocket.pos.y + focusBall.pos.y) * 0.5
-              );
-            }
-            focusTarget.multiplyScalar(worldScaleFactor);
-            if (POCKET_CAM.focusBlend > 0 && pocketCenter2D) {
-              const focusBlend = THREE.MathUtils.clamp(
-                POCKET_CAM.focusBlend,
-                0,
-                1
-              );
-              if (focusBlend > 0) {
-                const pocketFocus = new THREE.Vector3(
-                  pocketCenter2D.x * worldScaleFactor,
-                  focusHeightLocal,
-                  pocketCenter2D.y * worldScaleFactor
-                );
-                focusTarget.lerp(pocketFocus, focusBlend);
-              }
-            }
-            if (POCKET_CAM.lateralFocusShift) {
-              const lateral2D = new THREE.Vector2(-outward.y, outward.x);
-              if (lateral2D.lengthSq() > 1e-6) {
-                lateral2D.normalize().multiplyScalar(
-                  POCKET_CAM.lateralFocusShift * worldScaleFactor
-                );
-                focusTarget.add(
-                  new THREE.Vector3(lateral2D.x, 0, lateral2D.y)
-                );
-              }
-            }
-            if (
-              anchorType === 'short' &&
-              (POCKET_CAM.railFocusLong || POCKET_CAM.railFocusShort)
-            ) {
-              const signX =
-                pocketCenter2D.x !== 0
-                  ? Math.sign(pocketCenter2D.x)
-                  : Math.sign(outward.x);
-              const signZ =
-                pocketCenter2D.y !== 0
-                  ? Math.sign(pocketCenter2D.y)
-                  : Math.sign(outward.y);
-              const offsetX =
-                (POCKET_CAM.railFocusLong ?? 0) * (signX ? -signX : 0);
-              const offsetZ =
-                (POCKET_CAM.railFocusShort ?? 0) * (signZ ? -signZ : 0);
-              if (offsetX || offsetZ) {
-                TMP_VEC3_A.set(
-                  offsetX * worldScaleFactor,
-                  0,
-                  offsetZ * worldScaleFactor
-                );
-                focusTarget.add(TMP_VEC3_A);
-              }
-            }
-            const pocketDirection2D = pocketCenter2D.clone();
-            if (pocketDirection2D.lengthSq() < 1e-6) {
-              pocketDirection2D.copy(outward.lengthSq() > 1e-6 ? outward : new THREE.Vector2(0, -1));
-            }
-            const azimuth = Math.atan2(pocketDirection2D.x, pocketDirection2D.y);
-            const baseRadius = (() => {
-              const fallback = clamp(
-                fitRadius(camera, STANDING_VIEW.margin),
-                CAMERA.minR,
-                CAMERA.maxR
-              );
-              const standingRadius = standingBounds?.radius ?? fallback;
-              const pocketRadius = pocketDirection2D.length();
-              const minOutside =
-                anchorType === 'short'
-                  ? POCKET_CAM.minOutsideShort ?? POCKET_CAM.minOutside
-                  : POCKET_CAM.minOutside;
-              return Math.max(standingRadius, pocketRadius + minOutside);
-            })();
-            const cuePhi = cueBounds?.phi ?? CUE_VIEW_TARGET_PHI;
+            const overheadRadius = clampOrbitRadius(
+              maxRadius * OVERHEAD_FOLLOW_RADIUS_SCALE
+            );
+            const overheadPhi = Math.max(TOP_VIEW_PHI, CAMERA.minPhi);
             const spherical = new THREE.Spherical(
-              baseRadius * worldScaleFactor,
-              cuePhi,
-              azimuth
+              overheadRadius * worldScaleFactor,
+              overheadPhi,
+              sph.theta
             );
             const desiredPosition = focusTarget
               .clone()
               .add(new THREE.Vector3().setFromSpherical(spherical));
-            const outwardOffsetMagnitude =
-              anchorType === 'short'
-                ? POCKET_CAM.outwardOffsetShort ?? POCKET_CAM.outwardOffset
-                : POCKET_CAM.outwardOffset;
-            if (outwardOffsetMagnitude) {
-              const outwardOffset = new THREE.Vector3(outward.x, 0, outward.y);
-              if (outwardOffset.lengthSq() > 1e-6) {
-                outwardOffset
-                  .normalize()
-                  .multiplyScalar(outwardOffsetMagnitude * worldScaleFactor);
-                desiredPosition.add(outwardOffset);
-              }
-            }
-            const minHeightWorld =
-              (TABLE_Y + TABLE.THICK + activeShotView.heightOffset * heightScale) *
-              worldScaleFactor;
-            const loweredY =
-              desiredPosition.y -
-              (POCKET_CAM.heightDrop ?? 0) * worldScaleFactor;
-            desiredPosition.y =
-              loweredY < minHeightWorld ? minHeightWorld : loweredY;
             const now = performance.now();
-            if (focusBall?.active) {
-              activeShotView.completed = false;
-              const extendTo = now + POCKET_VIEW_ACTIVE_EXTENSION_MS;
-              activeShotView.holdUntil =
-                activeShotView.holdUntil != null
-                  ? Math.max(activeShotView.holdUntil, extendTo)
-                  : extendTo;
-            }
             const lastUpdate = activeShotView.lastUpdate ?? now;
             const dt = Math.min(0.2, Math.max(0, (now - lastUpdate) / 1000));
             activeShotView.lastUpdate = now;
@@ -11575,13 +11388,16 @@ function PoolRoyaleGame({
             } else {
               activeShotView.smoothedTarget.lerp(focusTarget, lerpT);
             }
-            if (pocketCamera) {
-              pocketCamera.position.copy(activeShotView.smoothedPos);
-              pocketCamera.lookAt(activeShotView.smoothedTarget);
-              pocketCamera.updateMatrixWorld();
-              renderCamera = pocketCamera;
-            }
+            camera.position.copy(activeShotView.smoothedPos);
+            camera.lookAt(activeShotView.smoothedTarget);
+            renderCamera = camera;
             lookTarget = activeShotView.smoothedTarget;
+            broadcastArgs = {
+              railDir: null,
+              targetWorld: null,
+              focusWorld: activeShotView.smoothedTarget.clone(),
+              lerp: 0.18
+            };
           } else {
             const aimFocus =
               !shooting && cue?.active ? aimFocusRef.current : null;
@@ -11618,6 +11434,10 @@ function PoolRoyaleGame({
                 }
               }
             focusTarget = store.target.clone();
+          }
+          if (topViewRef.current) {
+            setOrbitFocusToDefault();
+            focusTarget = new THREE.Vector3(0, BALL_CENTER_Y, 0);
           }
           focusTarget.multiplyScalar(worldScaleFactor);
           lookTarget = focusTarget;
@@ -13986,7 +13806,7 @@ function PoolRoyaleGame({
             } else {
               suspendedActionView = null;
             }
-            updatePocketCameraState(true);
+            updatePocketCameraState(false);
             activeShotView = earlyPocketView;
             pocketViewActivated = true;
           }
@@ -14777,6 +14597,21 @@ function PoolRoyaleGame({
             });
           }
         };
+
+        const applyAimPlan = (plan, key = null) => {
+          if (plan?.aimDir) {
+            const dir = plan.aimDir.clone();
+            if (dir.lengthSq() > 1e-6) {
+              dir.normalize();
+              aimDirRef.current.copy(dir);
+              alignStandingCameraToAim(cue, dir);
+              autoAimRequestRef.current = false;
+              suggestionAimKeyRef.current = key ?? null;
+              return;
+            }
+          }
+          suggestionAimKeyRef.current = null;
+        };
         const stopAiThinking = () => {
           if (aiThinkingHandle) {
             cancelAnimationFrame(aiThinkingHandle);
@@ -14818,8 +14653,7 @@ function PoolRoyaleGame({
             const plan = options.bestPot ?? options.bestSafety ?? null;
             if (plan) {
               aiPlanRef.current = plan;
-              aimDirRef.current.copy(plan.aimDir);
-              alignStandingCameraToAim(cue, plan.aimDir);
+              applyAimPlan(plan, planKey(plan));
             } else {
               aiPlanRef.current = null;
             }
@@ -14842,20 +14676,7 @@ function PoolRoyaleGame({
           userSuggestionPlanRef.current = plan;
           const summary = summarizePlan(plan);
           userSuggestionRef.current = summary;
-          if (plan?.aimDir) {
-            const dir = plan.aimDir.clone();
-            if (dir.lengthSq() > 1e-6) {
-              dir.normalize();
-              aimDirRef.current.copy(dir);
-              alignStandingCameraToAim(cue, dir);
-              autoAimRequestRef.current = false;
-              suggestionAimKeyRef.current = summary?.key ?? null;
-            } else {
-              suggestionAimKeyRef.current = null;
-            }
-          } else {
-            suggestionAimKeyRef.current = null;
-          }
+          applyAimPlan(plan, summary?.key ?? null);
         };
         const computeAiShot = () => {
           const options = evaluateShotOptions();
@@ -15234,6 +15055,60 @@ function PoolRoyaleGame({
           !(currentHud?.over) &&
           !(inHandPlacementModeRef.current) &&
           (!(currentHud?.inHand) || cueBallPlacedFromHandRef.current);
+
+        if (
+          autoAimRequestRef.current &&
+          canShowCue &&
+          isPlayerTurn &&
+          !previewingAiShot
+        ) {
+          const options = evaluateShotOptions();
+          const variantId = activeVariantRef.current?.id ?? variantKey;
+          let plan = options.bestPot ?? null;
+          if (plan && (variantId === 'american' || variantId === '9ball')) {
+            const stateSnapshot = frameRef.current ?? frameState;
+            const activeBallsList =
+              ballsRef.current?.length > 0 ? ballsRef.current : balls;
+            const legalTargets = Array.isArray(stateSnapshot?.ballOn)
+              ? stateSnapshot.ballOn
+                  .map((entry) =>
+                    typeof entry === 'string'
+                      ? entry.toUpperCase()
+                      : toBallColorId(entry)
+                  )
+                  .filter(Boolean)
+              : [];
+            let nextBallTarget = null;
+            if (legalTargets.length > 0) {
+              nextBallTarget = activeBallsList.find((b) =>
+                legalTargets.includes(toBallColorId(b.id))
+              );
+            }
+            if (!nextBallTarget) {
+              nextBallTarget = activeBallsList
+                .filter((b) => b.id !== 'cue')
+                .sort((a, b) => Number(a.id) - Number(b.id))[0];
+            }
+            if (
+              nextBallTarget &&
+              plan.targetBall &&
+              String(plan.targetBall.id) !== String(nextBallTarget.id)
+            ) {
+              const directDir = nextBallTarget.pos
+                .clone()
+                .sub(cue.pos.clone())
+                .normalize();
+              plan = {
+                ...plan,
+                aimDir: directDir,
+                targetBall: nextBallTarget,
+                target: toBallColorId(nextBallTarget.id)
+              };
+            }
+          }
+          applyAimPlan(plan, summarizePlan(plan)?.key ?? null);
+          autoAimRequestRef.current = false;
+        }
 
         if (canShowCue && (isPlayerTurn || previewingAiShot)) {
           const baseAimDir = new THREE.Vector3(aimDir.x, 0, aimDir.y);


### PR DESCRIPTION
## Summary
- add auto-aim selection for player turns with variant-specific targeting
- replace pocket camera usage with overhead broadcast-style follow framing
- keep top-down 2D view centered on the table while preserving distance cues

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b269023a48329ae50b28c814b75ee)