### PR TITLE
Update chess battle UI controls and sounds

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -10,6 +10,7 @@ export default function BottomLeftIcons({
   showChat = true,
   showGift = true,
   showMute = true,
+  showLabels = true,
 }) {
   const [muted, setMuted] = useState(isGameMuted());
 
@@ -29,25 +30,25 @@ export default function BottomLeftIcons({
       {showChat && onChat && (
         <button onClick={onChat} className="p-1 flex flex-col items-center">
           <AiOutlineMessage className="text-xl" />
-          <span className="text-xs">Chat</span>
+          {showLabels && <span className="text-xs">Chat</span>}
         </button>
       )}
       {showGift && onGift && (
         <button onClick={onGift} className="p-1 flex flex-col items-center">
           <span className="text-xl">🎁</span>
-          <span className="text-xs">Gift</span>
+          {showLabels && <span className="text-xs">Gift</span>}
         </button>
       )}
       {showInfo && (
         <button onClick={onInfo} className="p-1 flex flex-col items-center">
           <AiOutlineInfoCircle className="text-xl" />
-          <span className="text-xs">Info</span>
+          {showLabels && <span className="text-xs">Info</span>}
         </button>
       )}
       {showMute && (
         <button onClick={toggle} className="p-1 flex flex-col items-center">
           <span className="text-lg">{muted ? '🔇' : '🔊'}</span>
-          <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
+          {showLabels && <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>}
         </button>
       )}
     </div>


### PR DESCRIPTION
## Summary
- stack the Chess Battle Royal control buttons vertically with compact labels and icon-only replay
- add bottom-left chat/gift/info/mute icon cluster consistent with Snake & Ladder styling
- enforce timed playback for chess move and checkmate sounds (5s and 10s) while respecting mute/cleanup

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b256905d08329bb6411043a2d2b1d)