### PR TITLE
Adjust Chess Battle Royal UI controls and sound timings

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -10,6 +10,7 @@ export default function BottomLeftIcons({
   showChat = true,
   showGift = true,
   showMute = true,
+  showLabels = true,
 }) {
   const [muted, setMuted] = useState(isGameMuted());
 
@@ -29,25 +30,25 @@ export default function BottomLeftIcons({
       {showChat && onChat && (
         <button onClick={onChat} className="p-1 flex flex-col items-center">
           <AiOutlineMessage className="text-xl" />
-          <span className="text-xs">Chat</span>
+          {showLabels && <span className="text-xs">Chat</span>}
         </button>
       )}
       {showGift && onGift && (
         <button onClick={onGift} className="p-1 flex flex-col items-center">
           <span className="text-xl">🎁</span>
-          <span className="text-xs">Gift</span>
+          {showLabels && <span className="text-xs">Gift</span>}
         </button>
       )}
       {showInfo && (
         <button onClick={onInfo} className="p-1 flex flex-col items-center">
           <AiOutlineInfoCircle className="text-xl" />
-          <span className="text-xs">Info</span>
+          {showLabels && <span className="text-xs">Info</span>}
         </button>
       )}
       {showMute && (
         <button onClick={toggle} className="p-1 flex flex-col items-center">
           <span className="text-lg">{muted ? '🔇' : '🔊'}</span>
-          <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
+          {showLabels && <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>}
         </button>
       )}
     </div>

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -40,6 +40,8 @@ import { avatarToName } from '../../utils/avatarUtils.js';
 import { getAIOpponentFlag } from '../../utils/aiOpponentFlag.js';
 import { ipToFlag } from '../../utils/conflictMatchmaking.js';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import InfoPopup from '../../components/InfoPopup.jsx';
 
 /**
  * CHESS 3D — Procedural, Modern Look (no external models)
@@ -4959,6 +4961,9 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
   const boardMaterialCacheRef = useRef({ gltf: new Map(), procedural: null });
   const pawnHeadMaterialCacheRef = useRef(new Map());
   const rankSwapAppliedRef = useRef(false);
+  const [showInfo, setShowInfo] = useState(false);
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
   const [appearance, setAppearance] = useState(() => {
     if (typeof window === 'undefined') return { ...DEFAULT_APPEARANCE };
     try {
@@ -5616,16 +5621,31 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
       disposePieceMaterials(pieceMaterials);
     });
     const pieceSetPromise = loadPieceSet(RAW_BOARD_SIZE);
-    const playAudio = (audioRef) => {
+    const audioStopTimers = new Map();
+    disposers.push(() => {
+      audioStopTimers.forEach((timeoutId) => clearTimeout(timeoutId));
+      audioStopTimers.clear();
+    });
+    const playAudio = (audioRef, maxDurationMs) => {
       if (!audioRef?.current || !settingsRef.current.soundEnabled) return;
       try {
         audioRef.current.currentTime = 0;
         audioRef.current.play().catch(() => {});
+        if (Number.isFinite(maxDurationMs)) {
+          const previous = audioStopTimers.get(audioRef.current);
+          if (previous) clearTimeout(previous);
+          const timeoutId = setTimeout(() => {
+            audioRef.current.pause();
+            audioRef.current.currentTime = 0;
+            audioStopTimers.delete(audioRef.current);
+          }, maxDurationMs);
+          audioStopTimers.set(audioRef.current, timeoutId);
+        }
       } catch {}
     };
-    const playMoveSound = () => playAudio(moveSoundRef);
-    const playCheckSound = () => playAudio(checkSoundRef);
-    const playMateSound = () => playAudio(mateSoundRef);
+    const playMoveSound = () => playAudio(moveSoundRef, 5000);
+    const playCheckSound = () => playAudio(checkSoundRef, 5000);
+    const playMateSound = () => playAudio(mateSoundRef, 10000);
     const playLaughSound = () => playAudio(laughSoundRef);
     const chairTheme = mapChairOptionToTheme(chairOption);
     const chairBuild = await buildChessChairTemplate(chairTheme);
@@ -7434,13 +7454,31 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
   return (
     <div ref={wrapRef} className="fixed inset-0 bg-[#0c1020] text-white touch-none select-none">
       <div className="absolute inset-0 pointer-events-none">
+        <InfoPopup
+          open={showInfo}
+          onClose={() => setShowInfo(false)}
+          title="Chess Battle Royal"
+          info="Chat, gifts, and match info use the same quick actions as Snake & Ladder."
+        />
+        <InfoPopup
+          open={showChat}
+          onClose={() => setShowChat(false)}
+          title="Chat"
+          info="Chat overlays coming soon for Chess Battle Royal."
+        />
+        <InfoPopup
+          open={showGift}
+          onClose={() => setShowGift(false)}
+          title="Send a Gift"
+          info="NFT gift drops will appear here just like in Snake & Ladder."
+        />
         <div className="absolute top-4 left-4 z-20 flex flex-col items-start gap-3 pointer-events-none">
           <div className="pointer-events-none rounded bg-white/10 px-3 py-2 text-xs">
             <div className="font-semibold">{ui.status}</div>
           </div>
         </div>
         <div className="absolute top-4 right-4 z-20 flex flex-col items-end gap-3 pointer-events-none">
-          <div className="pointer-events-auto flex gap-2">
+          <div className="pointer-events-auto flex flex-col items-end gap-2">
             <button
               type="button"
               onClick={() => setConfigOpen((open) => !open)}
@@ -7471,20 +7509,32 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
               type="button"
               onClick={() => replayLastMoveRef.current?.()}
               disabled={!canReplay}
-              className={`h-12 w-32 rounded-full border px-4 text-[0.75rem] font-semibold uppercase tracking-[0.08em] shadow-lg backdrop-blur transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+              className={`flex h-12 w-12 items-center justify-center rounded-full border px-4 text-[0.75rem] font-semibold uppercase tracking-[0.08em] shadow-lg backdrop-blur transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
                 canReplay
                   ? 'border-emerald-300/40 bg-emerald-400/20 text-white hover:bg-emerald-400/25'
                   : 'border-white/10 bg-white/5 text-white/50 cursor-not-allowed'
               }`}
             >
-              Replay Move
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                className="h-6 w-6"
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3 12a9 9 0 1 0 9-9" />
+                <path strokeLinecap="round" strokeLinejoin="round" d="m3 4 0 6 6 0" />
+              </svg>
+              <span className="sr-only">Replay last move</span>
             </button>
             <button
               type="button"
               onClick={() => setViewMode((mode) => (mode === '3d' ? '2d' : '3d'))}
-              className="h-12 w-32 rounded-full border border-white/20 bg-black/70 px-4 text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-white shadow-lg backdrop-blur transition-colors duration-200 hover:bg-black/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
+              className="h-12 w-16 rounded-full border border-white/20 bg-black/70 px-4 text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-white shadow-lg backdrop-blur transition-colors duration-200 hover:bg-black/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
             >
-              {viewMode === '3d' ? '2D view' : '3D view'}
+              {viewMode === '3d' ? '2D' : '3D'}
             </button>
           </div>
           {configOpen && (
@@ -7748,6 +7798,13 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag }) {
             {ui.winner ? `${ui.winner} Wins` : ui.status}
           </div>
         </div>
+        <BottomLeftIcons
+          onInfo={() => setShowInfo(true)}
+          onChat={() => setShowChat(true)}
+          onGift={() => setShowGift(true)}
+          className="fixed left-1 bottom-4 flex flex-col items-center space-y-3 z-30 pointer-events-auto"
+          showLabels={false}
+        />
         <div className="absolute right-3 bottom-3 flex flex-col space-y-2 pointer-events-auto">
           <button
             onClick={() => zoomRef.current.zoomIn?.()}


### PR DESCRIPTION
## Summary
- align Chess Battle Royal top-right controls vertically, update view toggle text, and switch replay to an icon-only button
- add icon-only chat/gift/info/mute quick actions consistent with Snake & Ladder, plus lightweight info popups
- limit chess move/check sounds to 5 seconds and checkmate to 10 seconds while adding icon-only support to BottomLeftIcons

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b256905d08329bb6411043a2d2b1d)