### PR TITLE
Add broadcast camera presets

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2327,6 +2327,7 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
   {
     id: 'skybox-truss',
     label: 'Skybox TrussCam',
+    method: 'Overhead truss glide',
     description: 'High truss glide with wide parallax sweeps.',
     railPush: BALL_R * 10.5,
     lateralDolly: BALL_R * 3.4,
@@ -2334,6 +2335,58 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
     focusDepthBias: BALL_R * 2.4,
     trackingBias: 0.58,
     smoothing: 0.16
+  },
+  {
+    id: 'rail-hero',
+    label: 'Rail Hero Dolly',
+    method: 'Low rail track',
+    description: 'Hug-the-rail dolly with aggressive sideline parallax.',
+    railPush: BALL_R * 8.2,
+    lateralDolly: BALL_R * 5.4,
+    focusLift: BALL_R * 5.1,
+    focusDepthBias: BALL_R * 1.6,
+    focusPan: BALL_R * 1,
+    trackingBias: 0.72,
+    smoothing: 0.12
+  },
+  {
+    id: 'corner-spider',
+    label: 'Corner SpiderCam',
+    method: 'High diagonal spider',
+    description: 'Spidercam cross angle with taller lift for pocket reveals.',
+    railPush: BALL_R * 12.2,
+    lateralDolly: BALL_R * 2.6,
+    focusLift: BALL_R * 8.5,
+    focusDepthBias: BALL_R * 3.4,
+    focusPan: BALL_R * 0.6,
+    trackingBias: 0.52,
+    smoothing: 0.18
+  },
+  {
+    id: 'orbit-drone',
+    label: 'Orbit DroneCast',
+    method: 'Off-axis orbit',
+    description: 'Autonomous orbit with gentle pan for roaming rallies.',
+    railPush: BALL_R * 9.5,
+    lateralDolly: BALL_R * 4.2,
+    focusLift: BALL_R * 5.4,
+    focusDepthBias: BALL_R * 1.2,
+    focusPan: BALL_R * 1.8,
+    trackingBias: 0.48,
+    smoothing: 0.2
+  },
+  {
+    id: 'booth-tripod',
+    label: 'Analyst Booth Tripod',
+    method: 'Stable booth pan',
+    description: 'Broadcast booth lock-off with slower, story-first easing.',
+    railPush: BALL_R * 7.8,
+    lateralDolly: BALL_R * 1.2,
+    focusLift: BALL_R * 4.6,
+    focusDepthBias: BALL_R * 0.8,
+    focusPan: BALL_R * 0.4,
+    trackingBias: 0.35,
+    smoothing: 0.1
   }
 ]);
 const DEFAULT_BROADCAST_SYSTEM_ID = 'skybox-truss';
@@ -16754,6 +16807,45 @@ function PoolRoyaleGame({
                               ? `${option.resolution} • ${option.fps} FPS`
                               : `${option.fps} FPS`}
                           </span>
+                        </span>
+                        {option.description ? (
+                          <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
+                            {option.description}
+                          </span>
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              <div>
+                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                  Broadcast Methods
+                </h3>
+                <div className="mt-2 grid gap-2">
+                  {BROADCAST_SYSTEM_OPTIONS.map((option) => {
+                    const active = option.id === broadcastSystemId;
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        onClick={() => setBroadcastSystemId(option.id)}
+                        aria-pressed={active}
+                        className={`w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                          active
+                            ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                        }`}
+                      >
+                        <span className="flex items-center justify-between gap-2">
+                          <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
+                            {option.label}
+                          </span>
+                          {option.method ? (
+                            <span className="rounded-full border border-white/30 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-white/80">
+                              {option.method}
+                            </span>
+                          ) : null}
                         </span>
                         {option.description ? (
                           <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">


### PR DESCRIPTION
## Summary
- add five distinct broadcast camera methods with tailored rig logic for Pool Royale
- expose broadcast method selection in the table setup panel with descriptive badges

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b31d1a420832993c8fb0518db94bd)