### PR TITLE
Improve Pool Royale online connectivity and test account overrides

### DIFF
--- a/webapp/src/utils/socket.js
+++ b/webapp/src/utils/socket.js
@@ -10,7 +10,7 @@ function resolveSocketConfig() {
     API_BASE_URL ||
     (typeof window !== 'undefined' ? window.location.origin : '');
 
-  const options = { transports: ['websocket'] };
+  const options = { transports: ['websocket', 'polling'] };
 
   const applyDefaultPath = () => {
     if (!options.path) {

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -1,5 +1,10 @@
 import { fetchTelegramInfo } from "./api.js";
 
+const TEST_ACCOUNT_IDS = [
+  import.meta.env.VITE_TEST_ACCOUNT_ID_1,
+  import.meta.env.VITE_TEST_ACCOUNT_ID_2
+].filter(Boolean);
+
 export function isTelegramWebView() {
   if (typeof window === 'undefined') return false;
   const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
@@ -42,6 +47,23 @@ function generateAccountId() {
 
 export function getPlayerId() {
   if (typeof window === 'undefined') return null;
+  const params = new URLSearchParams(window.location.search);
+
+  const requestedTestSlot = params.get('testAccount');
+  if (requestedTestSlot) {
+    const slotIndex = Number(requestedTestSlot) - 1;
+    if (!Number.isNaN(slotIndex) && TEST_ACCOUNT_IDS[slotIndex]) {
+      localStorage.setItem('accountId', TEST_ACCOUNT_IDS[slotIndex]);
+      return TEST_ACCOUNT_IDS[slotIndex];
+    }
+  }
+
+  const explicitAccount = params.get('accountId');
+  if (explicitAccount) {
+    localStorage.setItem('accountId', explicitAccount);
+    return explicitAccount;
+  }
+
   let id = localStorage.getItem('accountId');
   if (!id) {
     id = generateAccountId();


### PR DESCRIPTION
## Summary
- allow the Socket.IO client to fall back to polling when websockets fail, improving lobby connections
- add configurable test account overrides via URL parameters to simplify multi-account debugging for online play

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ba81cea9c8329a998fa372c2ac8b0)