### PR TITLE
Improve chess online matchmaking flow

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -5281,8 +5281,21 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag, accountId }) {
       avatarToName(effectivePlayerFlag) || username || avatarToName(avatar) || 'Player';
     const playerPhoto = avatar || effectivePlayerFlag || '🙂';
 
-    const effectiveAiFlag = aiFlag || getAIOpponentFlag(effectivePlayerFlag || FALLBACK_FLAG);
-    const aiName = avatarToName(effectiveAiFlag) || 'AI Rival';
+    const onlineEnabled = onlineRef.current.enabled;
+    const hasOpponent = Boolean(opponent);
+    const useOnlineOpponent = onlineEnabled && hasOpponent;
+    const effectiveAiFlag =
+      onlineEnabled ? '' : aiFlag || getAIOpponentFlag(effectivePlayerFlag || FALLBACK_FLAG);
+    const opponentName = useOnlineOpponent
+      ? opponent.name || avatarToName(opponent.avatar) || 'Opponent'
+      : onlineEnabled
+        ? 'Online rival'
+        : avatarToName(effectiveAiFlag) || 'AI Rival';
+    const opponentPhoto = useOnlineOpponent
+      ? opponent.avatar || effectivePlayerFlag || '🤝'
+      : onlineEnabled
+        ? '⏳'
+        : effectiveAiFlag || '🏁';
 
     return [
       {
@@ -5294,13 +5307,13 @@ function Chess3D({ avatar, username, initialFlag, initialAiFlag, accountId }) {
       },
       {
         index: 1,
-        photoUrl: effectiveAiFlag || '🏁',
-        name: aiName,
+        photoUrl: opponentPhoto,
+        name: opponentName,
         color: accentColor,
         isTurn: !ui.turnWhite
       }
     ];
-  }, [aiFlag, appearance, avatar, playerFlag, resolvedInitialFlag, ui.turnWhite, username]);
+  }, [aiFlag, appearance, avatar, opponent, playerFlag, resolvedInitialFlag, ui.turnWhite, username]);
 
   useEffect(() => {
     updateSandTimerPlacement(ui.turnWhite);


### PR DESCRIPTION
## Summary
- hide AI avatar customization when starting an online chess match and avoid sending AI flags
- add a lobby waiting step that checks for another player before opening the online chess board
- show opponent avatars during online games instead of AI placeholders

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bb1276bf483298a001c592d8b1aa7)