### PR TITLE
Auto-seed AI avatars across lobbies

### DIFF
--- a/webapp/src/pages/Games/BlackJackLobby.jsx
+++ b/webapp/src/pages/Games/BlackJackLobby.jsx
@@ -4,6 +4,7 @@ import RoomSelector from '../../components/RoomSelector.jsx';
 import FlagPickerModal from '../../components/FlagPickerModal.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { seedFlags } from '../../utils/aiFlagDefaults.js';
 import { ensureAccountId, getTelegramId, getTelegramPhotoUrl, getTelegramUsername } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
@@ -37,6 +38,12 @@ export default function BlackJackLobby() {
       setAvatar(saved || getTelegramPhotoUrl());
     } catch {}
   }, []);
+
+  useEffect(() => {
+    if (mode !== 'local') return;
+    if (flags.length === flagPickerCount) return;
+    setFlags(seedFlags(flagPickerCount));
+  }, [mode, flagPickerCount, flags.length]);
 
   const startGame = async (flagOverride = flags) => {
     let tgId;

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -23,6 +23,7 @@ import {
 } from '../../utils/telegram.js';
 import { canStartGame } from '../../utils/lobby.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { seedFlags } from '../../utils/aiFlagDefaults.js';
 
 export default function Lobby() {
   const { game } = useParams();
@@ -38,8 +39,8 @@ export default function Lobby() {
   const [stake, setStake] = useState({ token: '', amount: 0 });
   const [players, setPlayers] = useState([]);
   const [currentTurn, setCurrentTurn] = useState(null);
-  const [aiCount, setAiCount] = useState(0);
-  const [aiType, setAiType] = useState('');
+  const [aiCount, setAiCount] = useState(1);
+  const [aiType, setAiType] = useState('flags');
   const [showFlagPicker, setShowFlagPicker] = useState(false);
   const [flags, setFlags] = useState([]);
   const [online, setOnline] = useState(0);
@@ -98,6 +99,15 @@ export default function Lobby() {
     window.addEventListener('profilePhotoUpdated', updatePhoto);
     return () => window.removeEventListener('profilePhotoUpdated', updatePhoto);
   }, []);
+
+  useEffect(() => {
+    if (game !== 'snake' || table?.id !== 'single') return;
+    const count = flagPickerCount || 1;
+    if (flags.length === count && aiType === 'flags') return;
+    setFlags(seedFlags(count, { includePlayer: false }));
+    setAiType('flags');
+    setAiCount((prev) => prev || 1);
+  }, [game, table?.id, flagPickerCount, flags.length, aiType]);
 
   useEffect(() => {
     if (game !== 'snake') return undefined;

--- a/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
@@ -6,6 +6,7 @@ import TableSelector from '../../components/TableSelector.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { seedFlags } from '../../utils/aiFlagDefaults.js';
 import {
   addTransaction,
   getAccountBalance,
@@ -31,8 +32,8 @@ export default function LudoBattleRoyalLobby() {
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [table, setTable] = useState(TABLES[0]);
   const [avatar, setAvatar] = useState('');
-  const [aiCount, setAiCount] = useState(0);
-  const [aiType, setAiType] = useState('');
+  const [aiCount, setAiCount] = useState(1);
+  const [aiType, setAiType] = useState('flags');
   const [flags, setFlags] = useState([]);
   const [showFlagPicker, setShowFlagPicker] = useState(false);
   const [online, setOnline] = useState(0);
@@ -76,6 +77,15 @@ export default function LudoBattleRoyalLobby() {
     window.addEventListener('profilePhotoUpdated', updatePhoto);
     return () => window.removeEventListener('profilePhotoUpdated', updatePhoto);
   }, []);
+
+  useEffect(() => {
+    if (table?.id !== 'practice') return;
+    const count = flagPickerCount || 1;
+    if (flags.length === count && aiType === 'flags') return;
+    setFlags(seedFlags(count, { includePlayer: false }));
+    setAiType('flags');
+    setAiCount((prev) => prev || 1);
+  }, [table?.id, flagPickerCount, flags.length, aiType]);
 
   const selectAiType = (type) => {
     setAiType(type);

--- a/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
@@ -4,6 +4,7 @@ import RoomSelector from '../../components/RoomSelector.jsx';
 import FlagPickerModal from '../../components/FlagPickerModal.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { seedFlags } from '../../utils/aiFlagDefaults.js';
 import { ensureAccountId, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
@@ -36,6 +37,12 @@ export default function MurlanRoyaleLobby() {
       setAvatar(saved || getTelegramPhotoUrl());
     } catch {}
   }, []);
+
+  useEffect(() => {
+    if (mode !== 'local') return;
+    if (flags.length === flagPickerCount) return;
+    setFlags(seedFlags(flagPickerCount));
+  }, [mode, flagPickerCount, flags.length]);
 
   const startGame = async (flagOverride = flags) => {
     let tgId;

--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -4,6 +4,7 @@ import RoomSelector from '../../components/RoomSelector.jsx';
 import FlagPickerModal from '../../components/FlagPickerModal.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { seedFlags } from '../../utils/aiFlagDefaults.js';
 import { ensureAccountId, getTelegramId, getTelegramPhotoUrl, getTelegramUsername } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
@@ -37,6 +38,12 @@ export default function TexasHoldemLobby() {
       setAvatar(saved || getTelegramPhotoUrl());
     } catch {}
   }, []);
+
+  useEffect(() => {
+    if (mode !== 'local') return;
+    if (flags.length === flagPickerCount) return;
+    setFlags(seedFlags(flagPickerCount));
+  }, [mode, flagPickerCount, flags.length]);
 
   const startGame = async (flagOverride = flags) => {
     let tgId;

--- a/webapp/src/utils/aiFlagDefaults.js
+++ b/webapp/src/utils/aiFlagDefaults.js
@@ -1,0 +1,31 @@
+import { FLAG_EMOJIS } from './flagEmojis.js';
+
+export const CHESS_PLAYER_FLAG_KEY = 'chessBattleRoyalPlayerFlag';
+export const CHESS_AI_FLAG_KEY = 'chessBattleRoyalAiFlag';
+
+export function getDefaultFlagIndices() {
+  const defaultFlagIndex = Math.max(0, FLAG_EMOJIS.indexOf('🌐'));
+  let playerIdx = defaultFlagIndex;
+  let aiIdx = defaultFlagIndex;
+
+  try {
+    const storedPlayer = window.localStorage?.getItem(CHESS_PLAYER_FLAG_KEY);
+    const storedAi = window.localStorage?.getItem(CHESS_AI_FLAG_KEY);
+    const playerFlagIndex = FLAG_EMOJIS.indexOf(storedPlayer);
+    const aiFlagIndex = FLAG_EMOJIS.indexOf(storedAi);
+    if (playerFlagIndex >= 0) playerIdx = playerFlagIndex;
+    if (aiFlagIndex >= 0) aiIdx = aiFlagIndex;
+    else aiIdx = playerIdx;
+  } catch {}
+
+  return { playerIdx, aiIdx };
+}
+
+export function seedFlags(count, { includePlayer = true } = {}) {
+  if (!count) return [];
+  const { playerIdx, aiIdx } = getDefaultFlagIndices();
+
+  return Array.from({ length: count }, (_, seat) =>
+    includePlayer && seat === 0 ? playerIdx : aiIdx
+  );
+}


### PR DESCRIPTION
## Summary
- add shared helper to reuse Chess Battle Royal flag defaults for AI avatars
- auto-seed AI flag selections in card and board lobbies so matches start with defaults
- default snake and Ludo practice lobbies to automatic AI flag avatars

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bb1fc7c588329b8ec5ac01e2c05d1)