### PR TITLE
Add matchmaking wait flow to Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import RoomSelector from '../../components/RoomSelector.jsx';
 import FlagPickerModal from '../../components/FlagPickerModal.jsx';
@@ -6,11 +6,14 @@ import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
   ensureAccountId,
   getTelegramId,
-  getTelegramPhotoUrl
+  getTelegramFirstName,
+  getTelegramPhotoUrl,
+  getTelegramUsername
 } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction, getOnlineCount } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { socket } from '../../utils/socket.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -30,6 +33,11 @@ export default function ChessBattleRoyalLobby() {
   const [aiFlagIndex, setAiFlagIndex] = useState(null);
   const [onlineCount, setOnlineCount] = useState(null);
   const [accountId, setAccountId] = useState('');
+  const [matching, setMatching] = useState(false);
+  const [matchStatus, setMatchStatus] = useState('');
+  const [matchError, setMatchError] = useState('');
+  const pendingTableRef = useRef('');
+  const cleanupRef = useRef(() => {});
 
   const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
@@ -88,8 +96,54 @@ export default function ChessBattleRoyalLobby() {
     };
   }, []);
 
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  const navigateToGame = (extraParams = {}) => {
+    const params = new URLSearchParams();
+    const initData = window.Telegram?.WebApp?.initData;
+    const isOnline = mode === 'online';
+
+    if (isOnline && stake.token) params.set('token', stake.token);
+    if (isOnline && stake.amount) params.set('amount', stake.amount);
+    if (avatar) params.set('avatar', avatar);
+    if (extraParams.tgId) params.set('tgId', extraParams.tgId);
+    if (isOnline && (extraParams.trackedAccountId || accountId))
+      params.set('accountId', extraParams.trackedAccountId || accountId);
+    if (selectedFlag) params.set('flag', selectedFlag);
+    if (!isOnline && selectedAiFlag) params.set('aiFlag', selectedAiFlag);
+    if (DEV_ACCOUNT) params.set('dev', DEV_ACCOUNT);
+    if (DEV_ACCOUNT_1) params.set('dev1', DEV_ACCOUNT_1);
+    if (DEV_ACCOUNT_2) params.set('dev2', DEV_ACCOUNT_2);
+    if (isOnline && initData) params.set('init', encodeURIComponent(initData));
+    params.set('mode', mode);
+
+    Object.entries(extraParams).forEach(([key, value]) => {
+      if (value != null && key !== 'tgId' && key !== 'trackedAccountId') {
+        params.set(key, value);
+      }
+    });
+
+    navigate(`/games/chessbattleroyal?${params.toString()}`);
+  };
+
+  const cleanupLobby = ({ account, skipRefReset } = {}) => {
+    socket.off('gameStart');
+    socket.off('lobbyUpdate');
+    if (pendingTableRef.current && (account || accountId)) {
+      socket.emit('leaveLobby', {
+        accountId: account || accountId,
+        tableId: pendingTableRef.current
+      });
+    }
+    pendingTableRef.current = '';
+    setMatching(false);
+    setMatchStatus('');
+    if (!skipRefReset) cleanupRef.current = null;
+  };
+
   const startGame = async () => {
     const isOnline = mode === 'online';
+    if (matching) return;
     let tgId;
     let trackedAccountId;
     if (isOnline) {
@@ -110,22 +164,72 @@ export default function ChessBattleRoyalLobby() {
       } catch {}
     }
 
-    const params = new URLSearchParams();
-    const initData = window.Telegram?.WebApp?.initData;
-    if (isOnline && stake.token) params.set('token', stake.token);
-    if (isOnline && stake.amount) params.set('amount', stake.amount);
-    if (avatar) params.set('avatar', avatar);
-    if (tgId) params.set('tgId', tgId);
-    if (isOnline && (trackedAccountId || accountId))
-      params.set('accountId', trackedAccountId || accountId);
-    if (selectedFlag) params.set('flag', selectedFlag);
-    if (selectedAiFlag) params.set('aiFlag', selectedAiFlag);
-    if (DEV_ACCOUNT) params.set('dev', DEV_ACCOUNT);
-    if (DEV_ACCOUNT_1) params.set('dev1', DEV_ACCOUNT_1);
-    if (DEV_ACCOUNT_2) params.set('dev2', DEV_ACCOUNT_2);
-    if (isOnline && initData) params.set('init', encodeURIComponent(initData));
-    params.set('mode', mode);
-    navigate(`/games/chessbattleroyal?${params.toString()}`);
+    if (!isOnline) {
+      navigateToGame({ tgId, trackedAccountId });
+      return;
+    }
+
+    setMatchError('');
+    setMatching(true);
+    setMatchStatus('Connecting to lobby…');
+
+    const handleLobbyUpdate = ({ tableId: tid, players: list = [] } = {}) => {
+      if (!tid || tid !== pendingTableRef.current) return;
+      const others = list.filter((p) => String(p.id) !== String(trackedAccountId || accountId));
+      if (others.length > 0) {
+        setMatchStatus('Opponent joined. Locking seats…');
+      } else {
+        setMatchStatus('Waiting for another player…');
+      }
+    };
+
+    const handleGameStart = ({ tableId: startedId, players = [] } = {}) => {
+      if (!startedId || startedId !== pendingTableRef.current) return;
+      const meIndex = players.findIndex((p) => String(p.id) === String(trackedAccountId || accountId));
+      const opp = players.find((p) => String(p.id) !== String(trackedAccountId || accountId));
+      const side = meIndex === 0 ? 'white' : 'black';
+      cleanupLobby({ account: trackedAccountId });
+      navigateToGame({
+        tgId,
+        trackedAccountId,
+        tableId: startedId,
+        side,
+        opponentName: opp?.name,
+        opponentAvatar: opp?.avatar
+      });
+    };
+
+    cleanupRef.current = () => cleanupLobby({ account: trackedAccountId, skipRefReset: true });
+
+    socket.on('gameStart', handleGameStart);
+    socket.on('lobbyUpdate', handleLobbyUpdate);
+    socket.emit('register', { playerId: trackedAccountId || accountId });
+
+    const friendlyName = getTelegramFirstName() || getTelegramUsername() || 'Player';
+    socket.emit(
+      'seatTable',
+      {
+        accountId: trackedAccountId || accountId,
+        gameType: 'chess',
+        stake: stake.amount ?? 0,
+        maxPlayers: 2,
+        playerName: friendlyName,
+        avatar
+      },
+      (res) => {
+        if (!res?.success || !res.tableId) {
+          setMatchError('Could not join the online lobby. Please try again.');
+          cleanupLobby({ account: trackedAccountId });
+          return;
+        }
+        pendingTableRef.current = res.tableId;
+        setMatchStatus('Waiting for another player…');
+        socket.emit('confirmReady', {
+          accountId: trackedAccountId || accountId,
+          tableId: res.tableId
+        });
+      }
+    );
   };
 
   return (
@@ -205,29 +309,51 @@ export default function ChessBattleRoyalLobby() {
         </div>
       </div>
 
-      <div className="space-y-2">
-        <h3 className="font-semibold">AI Avatar Flags</h3>
-        <p className="text-sm text-subtext">
-          Pick the country flag for the AI rival so it matches the Snake &amp; Ladder experience.
-        </p>
-        <button
-          type="button"
-          onClick={() => setShowAiFlagPicker(true)}
-          className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
-        >
-          <div className="text-[11px] uppercase tracking-wide text-subtext">AI Flag</div>
-          <div className="flex items-center gap-2 text-base font-semibold">
-            <span className="text-lg">{selectedAiFlag || '🌐'}</span>
-            <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
-          </div>
-        </button>
-      </div>
+      {mode === 'ai' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">AI Avatar Flags</h3>
+          <p className="text-sm text-subtext">
+            Pick the country flag for the AI rival so it matches the Snake &amp; Ladder experience.
+          </p>
+          <button
+            type="button"
+            onClick={() => setShowAiFlagPicker(true)}
+            className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
+          >
+            <div className="text-[11px] uppercase tracking-wide text-subtext">AI Flag</div>
+            <div className="flex items-center gap-2 text-base font-semibold">
+              <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+              <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
+            </div>
+          </button>
+        </div>
+      )}
+
+      {mode === 'online' && matching && (
+        <div className="space-y-2 rounded-xl border border-primary/40 bg-primary/5 p-3 shadow">
+          <h3 className="font-semibold text-primary">Matching players…</h3>
+          <p className="text-sm text-subtext">{matchStatus || 'Syncing with the lobby…'}</p>
+          {matchError && <p className="text-sm text-red-500">{matchError}</p>}
+          <button
+            type="button"
+            className="w-full rounded-lg border border-border bg-background/60 px-3 py-2 text-sm hover:border-primary"
+            onClick={() => cleanupLobby({ account: accountId })}
+          >
+            Cancel matchmaking
+          </button>
+        </div>
+      )}
 
       <button
         onClick={startGame}
-        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
+        disabled={matching}
+        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded disabled:opacity-60 disabled:cursor-not-allowed"
       >
-        {mode === 'online' ? 'Find Online Match' : 'Play vs AI'}
+        {mode === 'online'
+          ? matching
+            ? 'Finding Online Match…'
+            : 'Find Online Match'
+          : 'Play vs AI'}
       </button>
 
       <FlagPickerModal


### PR DESCRIPTION
## Summary
- prevent AI customization when selecting online play and add matchmaking status controls
- connect players in the lobby, wait for a confirmed opponent, and pass matched table details into the game
- render online opponent avatars/names in the Chess Battle Royal scene instead of AI stand-ins

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bb1276bf483298a001c592d8b1aa7)