### PR TITLE
Add PWA manifest, caching, and install prompt

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -19,9 +19,9 @@
     <meta name="twitter:title" content="TonPlaygram" />
     <meta name="twitter:description" content="Play games and earn TonPlaygram Coin on the TON blockchain." />
 
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-    <meta http-equiv="Pragma" content="no-cache" />
-    <meta http-equiv="Expires" content="0" />
+    <meta name="theme-color" content="#00f7ff" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="apple-touch-icon" href="/pwa-icon.svg" />
 
     <title>TonPlaygram</title>
   </head>

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-    <meta http-equiv="Pragma" content="no-cache" />
-    <meta http-equiv="Expires" content="0" />
+    <meta name="theme-color" content="#00f7ff" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="apple-touch-icon" href="/pwa-icon.svg" />
     <title>TonPlaygram</title>
     <link rel="icon" type="image/webp" href="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp" />
     <style>html,body{overscroll-behavior:none}</style>

--- a/webapp/public/manifest.webmanifest
+++ b/webapp/public/manifest.webmanifest
@@ -1,0 +1,47 @@
+{
+  "name": "TonPlaygram",
+  "short_name": "TonPlaygram",
+  "description": "TonPlaygram is a TON based gaming platform on Telegram with integrated wallet and rewards.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0c1020",
+  "theme_color": "#00f7ff",
+  "icons": [
+    {
+      "src": "/pwa-icon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/pwa-icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/pwa-icon-maskable.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ],
+  "screenshots": [
+    {
+      "src": "/pwa-splash.svg",
+      "sizes": "1280x720",
+      "type": "image/svg+xml",
+      "form_factor": "wide"
+    },
+    {
+      "src": "/pwa-splash.svg",
+      "sizes": "720x1280",
+      "type": "image/svg+xml",
+      "form_factor": "narrow"
+    }
+  ],
+  "categories": ["games", "productivity", "finance"],
+  "lang": "en"
+}

--- a/webapp/public/pwa-icon-maskable.svg
+++ b/webapp/public/pwa-icon-maskable.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="TonPlaygram maskable icon">
+  <defs>
+    <linearGradient id="maskable-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#11172f" />
+      <stop offset="100%" stop-color="#00f7ff" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="120" ry="120" fill="url(#maskable-bg)" />
+  <rect x="36" y="36" width="440" height="440" rx="120" ry="120" fill="#0c1020" opacity="0.6" />
+  <g transform="translate(96 96) scale(0.65)">
+    <rect x="48" y="48" width="512" height="512" rx="160" ry="160" fill="none" stroke="#00f7ff" stroke-width="28" />
+    <path
+      d="M304 160c-80 0-146 66-146 146s66 146 146 146 146-66 146-146S384 160 304 160zm0 40c58.7 0 106 47.3 106 106s-47.3 106-106 106-106-47.3-106-106 47.3-106 106-106z"
+      fill="#00f7ff"
+    />
+    <circle cx="304" cy="238" r="36" fill="#ffffff" />
+    <path
+      d="M214 396c18-56 48-102 90-132 43 30 72 76 90 132l-36 18c-12-36-31-70-54-96-23 26-42 60-53 96z"
+      fill="#ffffff"
+      opacity="0.92"
+    />
+  </g>
+</svg>

--- a/webapp/public/pwa-icon.svg
+++ b/webapp/public/pwa-icon.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="TonPlaygram badge">
+  <defs>
+    <linearGradient id="bg" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#00f7ff" />
+      <stop offset="50%" stop-color="#6c38ff" />
+      <stop offset="100%" stop-color="#0c1020" />
+    </linearGradient>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="12" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="512" height="512" rx="120" ry="120" fill="url(#bg)" />
+  <circle cx="256" cy="256" r="184" fill="#0c1020" opacity="0.35" />
+  <g filter="url(#glow)">
+    <path
+      fill="#00f7ff"
+      d="M256 120c-68.4 0-124 55.6-124 124s55.6 124 124 124 124-55.6 124-124S324.4 120 256 120zm0 34c49.7 0 90 40.3 90 90s-40.3 90-90 90-90-40.3-90-90 40.3-90 90-90z"
+    />
+    <path
+      fill="#ffffff"
+      d="M180 310c14-44 36-80 76-102 41 22 62 58 76 102l-31 14c-9-28-24-54-45-73-20 19-35 45-44 73z"
+      opacity="0.95"
+    />
+    <circle cx="256" cy="210" r="30" fill="#ffffff" />
+  </g>
+</svg>

--- a/webapp/public/pwa-splash.svg
+++ b/webapp/public/pwa-splash.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720" role="img" aria-label="TonPlaygram splash">
+  <defs>
+    <linearGradient id="splash" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0c1020" />
+      <stop offset="50%" stop-color="#1a2450" />
+      <stop offset="100%" stop-color="#00f7ff" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#6c38ff" />
+      <stop offset="100%" stop-color="#00f7ff" />
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="720" fill="url(#splash)" />
+  <rect x="80" y="80" width="1120" height="560" rx="48" ry="48" fill="#0c1020" opacity="0.55" />
+  <g transform="translate(190 120)">
+    <text x="0" y="120" font-size="110" font-family="'Luckiest Guy', 'Comic Sans MS', cursive" fill="#ffffff" stroke="#000" stroke-width="4">TonPlaygram</text>
+    <text x="6" y="190" font-size="48" font-family="'Inter', 'Arial', sans-serif" fill="#c7eaff">WebApp • Games • Wallet</text>
+    <rect x="0" y="230" width="900" height="14" fill="url(#accent)" rx="7" ry="7" />
+    <rect x="0" y="260" width="820" height="14" fill="url(#accent)" opacity="0.7" rx="7" ry="7" />
+  </g>
+  <g transform="translate(820 200)">
+    <circle cx="120" cy="140" r="120" fill="#11172f" stroke="#00f7ff" stroke-width="10" />
+    <circle cx="120" cy="140" r="84" fill="#00f7ff" opacity="0.15" />
+    <path d="M120 60c-52 0-94 42-94 94s42 94 94 94 94-42 94-94-42-94-94-94z" fill="#ffffff" opacity="0.85" />
+    <circle cx="120" cy="120" r="28" fill="#ffffff" />
+    <path d="M82 210c14-40 36-74 76-96 40 22 62 56 76 96l-30 14c-10-28-25-54-46-74-20 20-35 46-45 74z" fill="#ffffff" />
+  </g>
+</svg>

--- a/webapp/public/service-worker.js
+++ b/webapp/public/service-worker.js
@@ -1,16 +1,71 @@
-// Simple service worker to ensure latest assets are served
-self.addEventListener('install', () => {
-  // Take control immediately after installation
-  self.skipWaiting();
+const CACHE_NAME = 'tonplaygram-pwa-v1';
+const CORE_ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.webmanifest',
+  '/power-slider.css',
+  '/pwa-icon.svg',
+  '/pwa-icon-maskable.svg',
+  '/pwa-splash.svg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(CORE_ASSETS))
+      .then(() => self.skipWaiting())
+  );
 });
 
 self.addEventListener('activate', (event) => {
-  // Become the active worker for all clients
-  event.waitUntil(self.clients.claim());
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+      )
+      .then(() => self.clients.claim())
+  );
 });
+
+const isSameOrigin = (request) => {
+  try {
+    return new URL(request.url).origin === self.location.origin;
+  } catch (error) {
+    return false;
+  }
+};
 
 self.addEventListener('fetch', (event) => {
-  // Always go to the network and avoid caches
-  event.respondWith(fetch(event.request, { cache: 'no-store' }));
-});
+  if (event.request.method !== 'GET') return;
 
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put('/index.html', copy));
+          return response;
+        })
+        .catch(() => caches.match('/index.html'))
+    );
+    return;
+  }
+
+  if (!isSameOrigin(event.request)) return;
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      const fetchPromise = fetch(event.request)
+        .then((networkResponse) => {
+          const copy = networkResponse.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          return networkResponse;
+        })
+        .catch(() => cachedResponse);
+
+      return cachedResponse || fetchPromise;
+    })
+  );
+});

--- a/webapp/src/components/InstallPrompt.jsx
+++ b/webapp/src/components/InstallPrompt.jsx
@@ -1,0 +1,83 @@
+import React, { useCallback, useEffect, useState } from 'react';
+
+const DISMISS_KEY = 'tonplaygram_pwa_prompt_dismissed';
+
+export default function InstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = useState(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const isStandalone =
+      window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone;
+
+    if (isStandalone) return undefined;
+
+    const handleBeforeInstallPrompt = (event) => {
+      event.preventDefault();
+      if (localStorage.getItem(DISMISS_KEY) === 'true') return;
+      setDeferredPrompt(event);
+      setVisible(true);
+    };
+
+    const handleAppInstalled = () => {
+      setVisible(false);
+      setDeferredPrompt(null);
+      localStorage.removeItem(DISMISS_KEY);
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    window.addEventListener('appinstalled', handleAppInstalled);
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+      window.removeEventListener('appinstalled', handleAppInstalled);
+    };
+  }, []);
+
+  const handleInstall = useCallback(async () => {
+    if (!deferredPrompt) return;
+    deferredPrompt.prompt();
+    const choice = await deferredPrompt.userChoice.catch(() => null);
+    setDeferredPrompt(null);
+    setVisible(false);
+    if (choice?.outcome === 'dismissed') {
+      localStorage.setItem(DISMISS_KEY, 'true');
+    }
+  }, [deferredPrompt]);
+
+  const handleDismiss = () => {
+    setVisible(false);
+    setDeferredPrompt(null);
+    localStorage.setItem(DISMISS_KEY, 'true');
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-24 right-4 left-4 sm:left-auto sm:w-80 z-50">
+      <div className="bg-surface border border-accent/60 rounded-xl shadow-xl p-4 text-white">
+        <div className="font-bold text-lg mb-2 text-white">Install TonPlaygram</div>
+        <p className="text-sm mb-4 text-white/80">
+          Add TonPlaygram to your home screen for faster launches, offline-ready caching, and quick access to
+          your games and wallet.
+        </p>
+        <div className="flex gap-2 justify-end">
+          <button
+            type="button"
+            className="bg-gray-700 hover:bg-gray-600 text-white px-3 py-1 rounded"
+            onClick={handleDismiss}
+          >
+            Not now
+          </button>
+          <button
+            type="button"
+            className="bg-primary hover:bg-primary-hover text-white px-3 py-1 rounded"
+            onClick={handleInstall}
+          >
+            Install
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -7,6 +7,7 @@ import { getPlayerId } from '../utils/telegram.js';
 import { isGameMuted, getGameVolume } from '../utils/sound.js';
 import { chatBeep as inviteBeep } from '../assets/soundData.js';
 import InvitePopup from './InvitePopup.jsx';
+import InstallPrompt from './InstallPrompt.jsx';
 
 import Navbar from './Navbar.jsx';
 
@@ -144,6 +145,8 @@ export default function Layout({ children }) {
           <Navbar />
         </div>
       )}
+
+      <InstallPrompt />
 
       {showFooter && <Footer />}
 

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -14,4 +14,10 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   </React.StrictMode>
 );
 
-// Service workers are disabled to avoid unexpected reloads that could interrupt gameplay
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/service-worker.js')
+      .catch((error) => console.error('Service worker registration failed', error));
+  });
+}


### PR DESCRIPTION
## Summary
- add a PWA manifest with app metadata plus SVG icons and splash artwork
- upgrade the service worker to precache core assets and cache-first navigation for offline resilience
- register the service worker in the client and show a UX-friendly install prompt when eligible

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bc812e6d083298b3ccf7b8f33e88c)