### PR TITLE
Improve Google and Telegram account linking

### DIFF
--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { v4 as uuidv4 } from 'uuid';
+import crypto from 'crypto';
 import User from '../models/User.js';
 import { fetchTelegramInfo } from '../utils/telegram.js';
 import { ensureTransactionArray, calculateBalance, sanitizeUser } from '../utils/userUtils.js';
@@ -24,6 +25,26 @@ export function parseTwitterHandle(input) {
   // Strip leading @ if present
   handle = handle.replace(/^@/, '');
   return handle;
+}
+
+function verifyTelegramAuth(data) {
+  if (!data || !data.hash || !process.env.BOT_TOKEN) return false;
+  const authData = { ...data };
+  const { hash } = authData;
+  delete authData.hash;
+
+  const checkString = Object.keys(authData)
+    .sort()
+    .map((k) => `${k}=${authData[k]}`)
+    .join('\n');
+
+  const secret = crypto.createHmac('sha256', process.env.BOT_TOKEN).digest();
+  const computedHash = crypto
+    .createHmac('sha256', secret)
+    .update(checkString)
+    .digest('hex');
+
+  return computedHash === hash;
 }
 
 const router = Router();
@@ -216,6 +237,44 @@ router.post('/link-google', async (req, res) => {
     { $set: update, $setOnInsert: { referralCode: telegramId.toString() } },
     { upsert: true, new: true, setDefaultsOnInsert: true }
   );
+  res.json(sanitizeUser(user));
+});
+
+router.post('/link-telegram', async (req, res) => {
+  const { googleId, accountId, telegramData } = req.body || {};
+  if (!googleId && !accountId) {
+    return res.status(400).json({ error: 'googleId or accountId required' });
+  }
+  if (!verifyTelegramAuth(telegramData)) {
+    return res.status(400).json({ error: 'invalid telegram auth' });
+  }
+  if (!telegramData?.id) {
+    return res.status(400).json({ error: 'telegram id missing' });
+  }
+
+  const telegramId = Number(telegramData.id);
+
+  let user = null;
+  if (accountId) user = await User.findOne({ accountId });
+  if (!user && googleId) user = await User.findOne({ googleId });
+  if (!user) {
+    return res.status(404).json({ error: 'user not found' });
+  }
+
+  const existingTelegram = await User.findOne({ telegramId });
+  if (existingTelegram && !existingTelegram._id.equals(user._id)) {
+    return res.status(409).json({ error: 'telegram id already linked' });
+  }
+
+  user.telegramId = telegramId;
+  if (!user.referralCode) user.referralCode = String(telegramId);
+  if (!user.firstName && telegramData.first_name) user.firstName = telegramData.first_name;
+  if (!user.lastName && telegramData.last_name) user.lastName = telegramData.last_name;
+  if (!user.photo && telegramData.photo_url) user.photo = telegramData.photo_url;
+  if (!user.social) user.social = {};
+  if (telegramData.username) user.social.telegram = telegramData.username;
+
+  await user.save();
   res.json(sanitizeUser(user));
 });
 

--- a/webapp/src/components/LinkTelegramButton.jsx
+++ b/webapp/src/components/LinkTelegramButton.jsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useRef } from 'react';
+import { linkTelegramAccount } from '../utils/api.js';
+
+const TELEGRAM_WIDGET_SRC = 'https://telegram.org/js/telegram-widget.js?22';
+
+export default function LinkTelegramButton({ googleId, accountId, onLinked }) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!googleId && !accountId) return undefined;
+    const handlerName = `onTelegramAuth_${Date.now()}`;
+
+    window[handlerName] = async (user) => {
+      try {
+        localStorage.setItem('telegramId', user.id);
+        if (user.username) localStorage.setItem('telegramUsername', user.username);
+        if (user.first_name) localStorage.setItem('telegramFirstName', user.first_name);
+        if (user.last_name) localStorage.setItem('telegramLastName', user.last_name);
+        if (user.photo_url) localStorage.setItem('telegramPhotoUrl', user.photo_url);
+
+        const res = await linkTelegramAccount({
+          googleId,
+          accountId,
+          telegramData: user
+        });
+
+        if (res?.error) {
+          console.error('Failed to link Telegram account', res.error);
+          return;
+        }
+
+        if (onLinked) onLinked(user.id, res);
+      } catch (err) {
+        console.error('Telegram auth failed', err);
+      }
+    };
+
+    const botName = import.meta.env.VITE_TELEGRAM_BOT || 'TonPlaygramBot';
+    const script = document.createElement('script');
+    script.src = TELEGRAM_WIDGET_SRC;
+    script.async = true;
+    script.setAttribute('data-telegram-login', botName);
+    script.setAttribute('data-size', 'large');
+    script.setAttribute('data-userpic', 'false');
+    script.setAttribute('data-request-access', 'write');
+    script.setAttribute('data-onauth', handlerName);
+
+    const current = containerRef.current;
+    if (current) {
+      current.innerHTML = '';
+      current.appendChild(script);
+    }
+
+    return () => {
+      if (current) current.innerHTML = '';
+      delete window[handlerName];
+    };
+  }, [googleId, accountId, onLinked]);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div ref={containerRef} />
+      <p className="text-xs text-subtext">
+        Use the official Telegram login button to link your chat account.
+      </p>
+    </div>
+  );
+}

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   getAccountInfo,
   createAccount,
@@ -27,6 +27,7 @@ import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
 import DevTasksModal from '../components/DevTasksModal.jsx';
 import Wallet from './Wallet.jsx';
 import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
+import LinkTelegramButton from '../components/LinkTelegramButton.jsx';
 
 import { FiCopy } from 'react-icons/fi';
 
@@ -46,18 +47,21 @@ function formatValue(value, decimals = 2) {
 }
 
 export default function MyAccount() {
-  let telegramId = null;
-  let googleId = null;
+  const initialTelegramId = useMemo(() => {
+    try {
+      return getTelegramId();
+    } catch {
+      return null;
+    }
+  }, []);
 
-  try {
-    telegramId = getTelegramId();
-  } catch {}
+  const initialGoogleId = useMemo(() => {
+    if (initialTelegramId) return null;
+    return localStorage.getItem('googleId');
+  }, [initialTelegramId]);
 
-  if (!telegramId) {
-    googleId = localStorage.getItem('googleId');
-    if (!googleId) return <LoginOptions />;
-  }
-
+  const [telegramId, setTelegramId] = useState(initialTelegramId);
+  const [googleId, setGoogleId] = useState(initialGoogleId);
   const [profile, setProfile] = useState(null);
   const [photoUrl, setPhotoUrl] = useState('');
   const [autoUpdating, setAutoUpdating] = useState(false);
@@ -77,7 +81,11 @@ export default function MyAccount() {
   const [twitterError, setTwitterError] = useState('');
   const [twitterLink, setTwitterLink] = useState('');
   const [unread, setUnread] = useState(0);
-  const [googleLinked, setGoogleLinked] = useState(!!googleId);
+  const [googleLinked, setGoogleLinked] = useState(!!initialGoogleId);
+
+  useEffect(() => {
+    setGoogleLinked(Boolean(googleId));
+  }, [googleId]);
 
   useEffect(() => {
     async function load() {
@@ -171,6 +179,8 @@ export default function MyAccount() {
     window.addEventListener('profilePhotoUpdated', handler);
     return () => window.removeEventListener('profilePhotoUpdated', handler);
   }, [telegramId]);
+
+  if (!telegramId && !googleId) return <LoginOptions />;
 
   if (!profile) return <div className="p-4 text-subtext">Loading...</div>;
 
@@ -368,7 +378,25 @@ export default function MyAccount() {
               </p>
               <LinkGoogleButton
                 telegramId={telegramId}
-                onLinked={() => setGoogleLinked(true)}
+                onLinked={(gid) => {
+                  setGoogleId(gid);
+                  setGoogleLinked(true);
+                }}
+              />
+            </div>
+          )}
+          {!telegramId && googleId && (
+            <div className="mt-3 space-y-1">
+              <p className="text-sm mb-1 text-white-shadow">
+                Link your Telegram account:
+              </p>
+              <LinkTelegramButton
+                googleId={googleId}
+                accountId={localStorage.getItem('accountId')}
+                onLinked={(tgId, updated) => {
+                  setTelegramId(tgId);
+                  setProfile((prev) => ({ ...prev, ...updated }));
+                }}
               />
             </div>
           )}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -261,6 +261,10 @@ export function linkSocial(data) {
   return post('/api/profile/link-social', data);
 }
 
+export function linkTelegramAccount(data) {
+  return post('/api/profile/link-telegram', data);
+}
+
 export function fetchTelegramInfo(telegramId) {
   return post('/api/profile/telegram-info', { telegramId });
 }


### PR DESCRIPTION
## Summary
- update Google linking button to load the official Identity Services widget and reliably capture credentials from Telegram webviews
- add a Telegram login widget button plus backend API to link chat identities for browser-based users
- refresh profile state handling to react to new Google/Telegram links and expose the new client API helper

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bedd51b448329a158d3059536de7b)