### PR TITLE
Add profile linking for Google and Telegram accounts

### DIFF
--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -4,6 +4,7 @@ import User from '../models/User.js';
 import { fetchTelegramInfo } from '../utils/telegram.js';
 import { ensureTransactionArray, calculateBalance, sanitizeUser } from '../utils/userUtils.js';
 import { normalizeAddress } from '../utils/ton.js';
+import { verifyTelegramLogin } from '../utils/telegramLogin.js';
 
 export function parseTwitterHandle(input) {
   if (!input) return '';
@@ -216,6 +217,39 @@ router.post('/link-google', async (req, res) => {
     { $set: update, $setOnInsert: { referralCode: telegramId.toString() } },
     { upsert: true, new: true, setDefaultsOnInsert: true }
   );
+  res.json(sanitizeUser(user));
+});
+
+router.post('/link-telegram', async (req, res) => {
+  const { googleId, authData } = req.body;
+  if (!googleId || !authData?.id || !authData?.hash) {
+    return res.status(400).json({ error: 'googleId and Telegram auth data required' });
+  }
+
+  if (!verifyTelegramLogin(authData)) {
+    return res.status(400).json({ error: 'Invalid Telegram login' });
+  }
+
+  const telegramId = Number(authData.id);
+
+  const existingGoogle = await User.findOne({ googleId });
+  const existingTelegram = await User.findOne({ telegramId });
+
+  if (existingGoogle && existingTelegram && existingGoogle.id !== existingTelegram.id) {
+    return res
+      .status(409)
+      .json({ error: 'This Telegram account is already linked to another user' });
+  }
+
+  const user = existingGoogle || existingTelegram || new User({ referralCode: telegramId.toString() });
+  user.googleId = googleId;
+  user.telegramId = telegramId;
+  if (authData?.first_name) user.firstName = user.firstName || authData.first_name;
+  if (authData?.last_name) user.lastName = user.lastName || authData.last_name;
+  if (authData?.photo_url) user.photo = user.photo || authData.photo_url;
+
+  await user.save();
+
   res.json(sanitizeUser(user));
 });
 

--- a/bot/utils/telegramLogin.js
+++ b/bot/utils/telegramLogin.js
@@ -1,0 +1,30 @@
+import crypto from 'crypto';
+
+// Verification follows the official Telegram Login Widget guidance:
+// https://core.telegram.org/widgets/login#checking-authorization
+export function verifyTelegramLogin(authData = {}) {
+  try {
+    if (!authData.hash) return false;
+    const entries = Object.keys(authData)
+      .filter((k) => k !== 'hash' && authData[k] !== undefined)
+      .sort()
+      .map((key) => `${key}=${authData[key]}`);
+
+    const dataCheckString = entries.join('\n');
+    const secretKey = crypto
+      .createHash('sha256')
+      .update(process.env.BOT_TOKEN || '')
+      .digest();
+    const computed = crypto
+      .createHmac('sha256', secretKey)
+      .update(dataCheckString)
+      .digest('hex');
+
+    return computed === authData.hash;
+  } catch (err) {
+    console.error('Failed to verify Telegram login', err);
+    return false;
+  }
+}
+
+export default verifyTelegramLogin;

--- a/webapp/src/components/LinkGoogleButton.jsx
+++ b/webapp/src/components/LinkGoogleButton.jsx
@@ -3,6 +3,7 @@ import { linkGoogleAccount } from '../utils/api.js';
 
 export default function LinkGoogleButton({ telegramId, onLinked }) {
   const [ready, setReady] = useState(false);
+  const buttonRef = useRef(null);
   const initialized = useRef(false);
 
   useEffect(() => {
@@ -19,11 +20,33 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
           lastName: data.family_name,
           photo: data.picture
         }).then(() => {
-          if (onLinked) onLinked();
+          if (onLinked) onLinked(data.sub);
         });
       } catch (err) {
         console.error('Failed to link Google account', err);
       }
+    }
+
+    function injectScript() {
+      const existing = document.querySelector(
+        'script[src="https://accounts.google.com/gsi/client"]'
+      );
+      if (existing) return existing;
+      const script = document.createElement('script');
+      script.src = 'https://accounts.google.com/gsi/client';
+      script.async = true;
+      script.defer = true;
+      document.head.appendChild(script);
+      return script;
+    }
+
+    function renderButton() {
+      if (!buttonRef.current) return;
+      window.google.accounts.id.renderButton(buttonRef.current, {
+        theme: 'outline',
+        size: 'large',
+        type: 'standard'
+      });
     }
 
     function init() {
@@ -39,10 +62,13 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
         callback: handleCredential,
         ux_mode: 'popup'
       });
+      renderButton();
       initialized.current = true;
       setReady(true);
       return true;
     }
+
+    injectScript();
 
     if (!init()) {
       const id = setInterval(() => {
@@ -59,13 +85,16 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
   }
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      disabled={!ready}
-      className="px-3 py-1 bg-white text-black rounded disabled:opacity-50"
-    >
-      Link Google
-    </button>
+    <div className="space-y-1">
+      <div ref={buttonRef} />
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={!ready}
+        className="px-3 py-1 bg-white text-black rounded disabled:opacity-50"
+      >
+        Link Google
+      </button>
+    </div>
   );
 }

--- a/webapp/src/components/LinkTelegramButton.jsx
+++ b/webapp/src/components/LinkTelegramButton.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from 'react';
+import { linkTelegramAccount } from '../utils/api.js';
+
+export default function LinkTelegramButton({ googleId, onLinked }) {
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!googleId) return;
+
+    window.handleTelegramLinkAuth = async (user) => {
+      setError('');
+      setLoading(true);
+      try {
+        const res = await linkTelegramAccount({ googleId, authData: user });
+        if (res?.error) {
+          setError(res.error);
+        } else {
+          if (user?.id) localStorage.setItem('telegramId', user.id);
+          if (onLinked) onLinked(Number(user?.id));
+        }
+      } catch (err) {
+        console.error('Failed to link Telegram', err);
+        setError('Failed to link Telegram. Please try again.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    const container = containerRef.current;
+    if (container) container.innerHTML = '';
+
+    const script = document.createElement('script');
+    script.src = 'https://telegram.org/js/telegram-widget.js?22';
+    script.async = true;
+    script.setAttribute(
+      'data-telegram-login',
+      import.meta.env.VITE_TELEGRAM_BOT_USERNAME || 'TonPlaygramBot'
+    );
+    script.setAttribute('data-size', 'large');
+    script.setAttribute('data-userpic', 'true');
+    script.setAttribute('data-request-access', 'write');
+    script.setAttribute('data-onauth', 'handleTelegramLinkAuth');
+
+    if (container) container.appendChild(script);
+
+    return () => {
+      if (container) container.innerHTML = '';
+      delete window.handleTelegramLinkAuth;
+    };
+  }, [googleId, onLinked]);
+
+  return (
+    <div className="space-y-2">
+      <div ref={containerRef} />
+      {loading && <p className="text-sm text-subtext">Linking Telegram...</p>}
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -27,6 +27,7 @@ import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
 import DevTasksModal from '../components/DevTasksModal.jsx';
 import Wallet from './Wallet.jsx';
 import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
+import LinkTelegramButton from '../components/LinkTelegramButton.jsx';
 
 import { FiCopy } from 'react-icons/fi';
 
@@ -46,17 +47,19 @@ function formatValue(value, decimals = 2) {
 }
 
 export default function MyAccount() {
-  let telegramId = null;
-  let googleId = null;
+  const [telegramId, setTelegramId] = useState(() => {
+    try {
+      return getTelegramId();
+    } catch {
+      return null;
+    }
+  });
+  const [googleId, setGoogleId] = useState(() => {
+    if (telegramId) return null;
+    return localStorage.getItem('googleId');
+  });
 
-  try {
-    telegramId = getTelegramId();
-  } catch {}
-
-  if (!telegramId) {
-    googleId = localStorage.getItem('googleId');
-    if (!googleId) return <LoginOptions />;
-  }
+  if (!telegramId && !googleId) return <LoginOptions />;
 
   const [profile, setProfile] = useState(null);
   const [photoUrl, setPhotoUrl] = useState('');
@@ -368,7 +371,24 @@ export default function MyAccount() {
               </p>
               <LinkGoogleButton
                 telegramId={telegramId}
-                onLinked={() => setGoogleLinked(true)}
+                onLinked={(id) => {
+                  setGoogleLinked(true);
+                  setGoogleId(id || localStorage.getItem('googleId'));
+                }}
+              />
+            </div>
+          )}
+          {!telegramId && googleId && (
+            <div className="mt-2 space-y-1">
+              <p className="text-sm text-white-shadow">
+                Link your Telegram account to sync progress:
+              </p>
+              <LinkTelegramButton
+                googleId={googleId}
+                onLinked={(tgId) => {
+                  setTelegramId(tgId);
+                  setTimeout(() => window.location.reload(), 300);
+                }}
               />
             </div>
           )}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -370,6 +370,10 @@ export function linkGoogleAccount(data) {
   return post('/api/profile/link-google', data);
 }
 
+export function linkTelegramAccount(data) {
+  return post('/api/profile/link-telegram', data);
+}
+
 export function searchUsers(query) {
   return post('/api/social/search', { query });
 }


### PR DESCRIPTION
## Summary
- add backend validation for Telegram login widget data and new API to link Telegram to existing Google accounts
- introduce Telegram linking button and improve Google linking on the profile page using official widgets
- ensure client API exposes Telegram linking and update profile flow to sync linked IDs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bedd51b448329a158d3059536de7b)