### PR TITLE
Fix Pool Royale lobby start when both players ready

### DIFF
--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -130,7 +130,8 @@ export default function PoolRoyaleLobby() {
       }
 
       const handleLobbyUpdate = ({ tableId: tid, players: list = [], ready = [] } = {}) => {
-        if (!tid || tid !== pendingTableRef.current) return;
+        const pendingId = String(pendingTableRef.current || '');
+        if (!tid || String(tid) !== pendingId) return;
         setMatchPlayers(list);
         matchPlayersRef.current = list;
         setReadyList(ready);
@@ -141,7 +142,8 @@ export default function PoolRoyaleLobby() {
       };
 
       const handleGameStart = ({ tableId: startedId, players: joined = [] } = {}) => {
-        if (!startedId || startedId !== pendingTableRef.current) return;
+        const pendingId = String(pendingTableRef.current || '');
+        if (!startedId || String(startedId) !== pendingId) return;
         const selfId = accountIdRef.current || accountId;
         const roster = Array.isArray(joined) && joined.length > 0 ? joined : matchPlayersRef.current;
         const selfEntry = roster.find((p) => String(p.id) === String(selfId));


### PR DESCRIPTION
## Summary
- ensure Pool Royale lobby events match pending table even when IDs differ in type
- keep lobby status updates and game start navigation responsive once both players are ready

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bef0cca88832996b925f7dde17376)