### PR TITLE
Add official Google and Telegram linking options

### DIFF
--- a/webapp/src/components/LinkGoogleButton.jsx
+++ b/webapp/src/components/LinkGoogleButton.jsx
@@ -3,7 +3,9 @@ import { linkGoogleAccount } from '../utils/api.js';
 
 export default function LinkGoogleButton({ telegramId, onLinked }) {
   const [ready, setReady] = useState(false);
+  const [error, setError] = useState('');
   const initialized = useRef(false);
+  const buttonRef = useRef(null);
 
   useEffect(() => {
     function handleCredential(res) {
@@ -18,11 +20,16 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
           firstName: data.given_name,
           lastName: data.family_name,
           photo: data.picture
-        }).then(() => {
+        }).then((resp) => {
+          if (resp?.error) {
+            setError(resp.error);
+            return;
+          }
           if (onLinked) onLinked();
         });
       } catch (err) {
         console.error('Failed to link Google account', err);
+        setError('Unable to process Google response');
       }
     }
 
@@ -30,7 +37,8 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
       if (
         initialized.current ||
         !window.google ||
-        !import.meta.env.VITE_GOOGLE_CLIENT_ID
+        !import.meta.env.VITE_GOOGLE_CLIENT_ID ||
+        !buttonRef.current
       ) {
         return false;
       }
@@ -39,6 +47,16 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
         callback: handleCredential,
         ux_mode: 'popup'
       });
+
+      window.google.accounts.id.renderButton(buttonRef.current, {
+        type: 'standard',
+        shape: 'rectangular',
+        theme: 'outline',
+        text: 'continue_with',
+        size: 'large',
+        logo_alignment: 'left'
+      });
+
       initialized.current = true;
       setReady(true);
       return true;
@@ -52,20 +70,19 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
     }
   }, [telegramId, onLinked]);
 
-  function handleClick() {
-    if (window.google && initialized.current) {
-      window.google.accounts.id.prompt();
-    }
-  }
-
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      disabled={!ready}
-      className="px-3 py-1 bg-white text-black rounded disabled:opacity-50"
-    >
-      Link Google
-    </button>
+    <div className="space-y-2">
+      <div ref={buttonRef} className="inline-block" aria-live="polite" />
+      {!ready && (
+        <button
+          type="button"
+          disabled
+          className="px-3 py-1 bg-white text-black rounded opacity-60"
+        >
+          Loading Google...
+        </button>
+      )}
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
   );
 }

--- a/webapp/src/components/LinkTelegramButton.jsx
+++ b/webapp/src/components/LinkTelegramButton.jsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { linkTelegramAccount } from '../utils/api.js';
+
+function persistTelegramProfile(user) {
+  if (!user) return;
+  localStorage.setItem('telegramId', user.id);
+  if (user.username) localStorage.setItem('telegramUsername', user.username);
+  if (user.first_name) localStorage.setItem('telegramFirstName', user.first_name);
+  if (user.last_name) localStorage.setItem('telegramLastName', user.last_name);
+  if (user.photo_url) localStorage.setItem('telegramPhotoUrl', user.photo_url);
+  localStorage.setItem('telegramUserData', JSON.stringify(user));
+}
+
+export default function LinkTelegramButton({ googleId, onLinked }) {
+  const [linking, setLinking] = useState(false);
+  const [error, setError] = useState('');
+  const containerRef = useRef(null);
+  const handlerName = useRef(`onTelegramAuth_${Math.random().toString(36).slice(2)}`);
+  const botUsername = import.meta.env.VITE_TELEGRAM_BOT_USERNAME || 'TonPlaygramBot';
+
+  useEffect(() => {
+    if (!googleId || !containerRef.current) return undefined;
+
+    window[handlerName.current] = async (user) => {
+      if (!user?.id) return;
+      setLinking(true);
+      setError('');
+      try {
+        const res = await linkTelegramAccount({ authData: user, googleId });
+        if (res?.error) {
+          setError(res.error);
+          return;
+        }
+        persistTelegramProfile(user);
+        if (onLinked) onLinked(user);
+      } catch (err) {
+        console.error('Failed to link Telegram account', err);
+        setError('Failed to link Telegram account');
+      } finally {
+        setLinking(false);
+      }
+    };
+
+    const script = document.createElement('script');
+    script.src = 'https://telegram.org/js/telegram-widget.js?22';
+    script.async = true;
+    script.defer = true;
+    script.setAttribute('data-telegram-login', botUsername);
+    script.setAttribute('data-size', 'large');
+    script.setAttribute('data-userpic', 'false');
+    script.setAttribute('data-onauth', `${handlerName.current}(user)`);
+    script.setAttribute('data-request-access', 'write');
+    containerRef.current.innerHTML = '';
+    containerRef.current.appendChild(script);
+
+    return () => {
+      delete window[handlerName.current];
+      if (containerRef.current) containerRef.current.innerHTML = '';
+    };
+  }, [googleId, botUsername, onLinked]);
+
+  return (
+    <div className="space-y-2">
+      <div ref={containerRef} aria-live="polite" />
+      {linking && <p className="text-sm text-subtext">Linking Telegram...</p>}
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -27,6 +27,7 @@ import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
 import DevTasksModal from '../components/DevTasksModal.jsx';
 import Wallet from './Wallet.jsx';
 import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
+import LinkTelegramButton from '../components/LinkTelegramButton.jsx';
 
 import { FiCopy } from 'react-icons/fi';
 
@@ -348,6 +349,15 @@ export default function MyAccount() {
           >
             Use Telegram Photo
           </button>
+          {!telegramId && googleId && (
+            <div className="mt-3 p-3 bg-surface rounded border border-border space-y-1">
+              <p className="text-sm text-white-shadow">Link your Telegram account:</p>
+              <LinkTelegramButton
+                googleId={googleId}
+                onLinked={() => window.location.reload()}
+              />
+            </div>
+          )}
           <div className="mt-2">
             <a
               href="/messages"

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -370,6 +370,10 @@ export function linkGoogleAccount(data) {
   return post('/api/profile/link-google', data);
 }
 
+export function linkTelegramAccount(data) {
+  return post('/api/profile/link-telegram', data);
+}
+
 export function searchUsers(query) {
   return post('/api/social/search', { query });
 }


### PR DESCRIPTION
## Summary
- replace the Google account linker with the official Google Identity button for Telegram users
- add Telegram linking support using the official widget so non-Telegram browsers can connect accounts
- wire the new linkage flow into the profile page and API helpers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bedd51b448329a158d3059536de7b)