### PR TITLE
Improve account linking for Google and Telegram

### DIFF
--- a/webapp/src/components/LinkGoogleButton.jsx
+++ b/webapp/src/components/LinkGoogleButton.jsx
@@ -2,10 +2,36 @@ import React, { useEffect, useRef, useState } from 'react';
 import { linkGoogleAccount } from '../utils/api.js';
 
 export default function LinkGoogleButton({ telegramId, onLinked }) {
+  const buttonRef = useRef(null);
   const [ready, setReady] = useState(false);
   const initialized = useRef(false);
 
   useEffect(() => {
+    let cancelled = false;
+
+    function ensureGoogleScript() {
+      return new Promise((resolve) => {
+        if (window.google?.accounts?.id) return resolve(true);
+
+        const existing = document.querySelector(
+          'script[src="https://accounts.google.com/gsi/client"]'
+        );
+        if (existing) {
+          existing.addEventListener('load', () => resolve(true));
+          existing.addEventListener('error', () => resolve(false));
+          return;
+        }
+
+        const script = document.createElement('script');
+        script.src = 'https://accounts.google.com/gsi/client';
+        script.async = true;
+        script.defer = true;
+        script.onload = () => resolve(true);
+        script.onerror = () => resolve(false);
+        document.head.appendChild(script);
+      });
+    }
+
     function handleCredential(res) {
       try {
         const data = JSON.parse(atob(res.credential.split('.')[1]));
@@ -19,53 +45,69 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
           lastName: data.family_name,
           photo: data.picture
         }).then(() => {
-          if (onLinked) onLinked();
+          if (onLinked) onLinked(data.sub);
         });
       } catch (err) {
         console.error('Failed to link Google account', err);
       }
     }
 
-    function init() {
+    async function init() {
       if (
         initialized.current ||
-        !window.google ||
         !import.meta.env.VITE_GOOGLE_CLIENT_ID
       ) {
         return false;
       }
+
+      const ok = await ensureGoogleScript();
+      if (!ok || cancelled || !window.google?.accounts?.id) return false;
+
       window.google.accounts.id.initialize({
         client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
         callback: handleCredential,
-        ux_mode: 'popup'
+        ux_mode: 'popup',
+        cancel_on_tap_outside: false
       });
+      if (buttonRef.current) {
+        window.google.accounts.id.renderButton(buttonRef.current, {
+          theme: 'outline',
+          shape: 'pill',
+          size: 'large',
+          text: 'continue_with'
+        });
+      }
       initialized.current = true;
       setReady(true);
       return true;
     }
 
-    if (!init()) {
-      const id = setInterval(() => {
-        if (init()) clearInterval(id);
-      }, 500);
-      return () => clearInterval(id);
-    }
+    init();
+
+    return () => {
+      cancelled = true;
+    };
   }, [telegramId, onLinked]);
 
   function handleClick() {
-    if (window.google && initialized.current) {
+    if (window.google?.accounts?.id && initialized.current) {
       window.google.accounts.id.prompt();
     }
   }
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      disabled={!ready}
-      className="px-3 py-1 bg-white text-black rounded disabled:opacity-50"
-    >
-      Link Google
-    </button>
+    <div className="inline-flex items-center space-x-2">
+      <div ref={buttonRef} />
+      {!ready && (
+        <button
+          type="button"
+          onClick={handleClick}
+          disabled={!ready}
+          className="px-3 py-1 bg-white text-black rounded disabled:opacity-50"
+        >
+          Link Google
+        </button>
+      )}
+    </div>
   );
 }

--- a/webapp/src/components/LinkTelegramButton.jsx
+++ b/webapp/src/components/LinkTelegramButton.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef } from 'react';
+import { BOT_USERNAME } from '../utils/constants.js';
+
+export default function LinkTelegramButton({ googleId, onLinked }) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!googleId) return undefined;
+
+    const callbackName = 'handleTelegramLinkAuth';
+
+    window[callbackName] = (user) => {
+      if (!user?.id) return;
+      localStorage.setItem('telegramId', user.id);
+      if (user.username) localStorage.setItem('telegramUsername', user.username);
+      if (user.first_name) localStorage.setItem('telegramFirstName', user.first_name);
+      if (user.last_name) localStorage.setItem('telegramLastName', user.last_name);
+      if (user.photo_url) localStorage.setItem('telegramPhotoUrl', user.photo_url);
+      if (onLinked) onLinked(user.id);
+    };
+
+    const script = document.createElement('script');
+    script.src = 'https://telegram.org/js/telegram-widget.js?22';
+    script.async = true;
+    script.defer = true;
+    script.dataset.telegramLogin = BOT_USERNAME;
+    script.dataset.size = 'large';
+    script.dataset.radius = '8';
+    script.dataset.userpic = 'false';
+    script.dataset.requestAccess = 'write';
+    script.dataset.onauth = callbackName;
+
+    if (containerRef.current) {
+      containerRef.current.innerHTML = '';
+      containerRef.current.appendChild(script);
+    }
+
+    return () => {
+      if (containerRef.current) containerRef.current.innerHTML = '';
+      delete window[callbackName];
+    };
+  }, [googleId, onLinked]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="inline-flex items-center justify-start"
+      aria-live="polite"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- load the official Google Identity script/button for reliable linking inside the profile
- add a Telegram login widget button so browser users can connect their Telegram account
- track linked account IDs in profile state so account info refreshes after linking

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bedd51b448329a158d3059536de7b)