### PR TITLE
Fix Pool Royale online matchmaking start

### DIFF
--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -212,6 +212,7 @@ export default function PoolRoyaleLobby() {
           stake: stake.amount,
           token: stake.token,
           gameType: 'poolroyale',
+          maxPlayers: 2,
           mode,
           variant,
           tableSize,


### PR DESCRIPTION
## Summary
- set Pool Royale online matchmaking to request two seats so the lobby can start once both players are ready

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bef0cca88832996b925f7dde17376)