### PR TITLE
Use official Google sign-in button on profile page

### DIFF
--- a/webapp/src/components/LinkGoogleButton.jsx
+++ b/webapp/src/components/LinkGoogleButton.jsx
@@ -1,38 +1,44 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { linkGoogleAccount } from '../utils/api.js';
 
 export default function LinkGoogleButton({ telegramId, onLinked }) {
   const buttonRef = useRef(null);
+  const ensureScriptPromise = useRef(null);
   const [ready, setReady] = useState(false);
+  const [status, setStatus] = useState('loading');
   const initialized = useRef(false);
 
-  useEffect(() => {
-    let cancelled = false;
+  const ensureGoogleScript = useCallback(() => {
+    if (window.google?.accounts?.id) return Promise.resolve(true);
+    if (ensureScriptPromise.current) return ensureScriptPromise.current;
 
-    function ensureGoogleScript() {
-      return new Promise((resolve) => {
-        if (window.google?.accounts?.id) return resolve(true);
+    ensureScriptPromise.current = new Promise((resolve) => {
+      const existing = document.querySelector(
+        'script[src="https://accounts.google.com/gsi/client"]'
+      );
+      if (existing) {
+        existing.addEventListener('load', () => resolve(true), { once: true });
+        existing.addEventListener('error', () => resolve(false), { once: true });
+        return;
+      }
 
-        const existing = document.querySelector(
-          'script[src="https://accounts.google.com/gsi/client"]'
-        );
-        if (existing) {
-          existing.addEventListener('load', () => resolve(true));
-          existing.addEventListener('error', () => resolve(false));
-          return;
-        }
+      const script = document.createElement('script');
+      script.src = 'https://accounts.google.com/gsi/client';
+      script.async = true;
+      script.defer = true;
+      script.onload = () => resolve(true);
+      script.onerror = () => resolve(false);
+      document.head.appendChild(script);
+    }).then((ok) => {
+      if (!ok) ensureScriptPromise.current = null;
+      return ok;
+    });
 
-        const script = document.createElement('script');
-        script.src = 'https://accounts.google.com/gsi/client';
-        script.async = true;
-        script.defer = true;
-        script.onload = () => resolve(true);
-        script.onerror = () => resolve(false);
-        document.head.appendChild(script);
-      });
-    }
+    return ensureScriptPromise.current;
+  }, []);
 
-    function handleCredential(res) {
+  const handleCredential = useCallback(
+    (res) => {
       try {
         const data = JSON.parse(atob(res.credential.split('.')[1]));
         if (!data.sub) return;
@@ -50,18 +56,37 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
       } catch (err) {
         console.error('Failed to link Google account', err);
       }
-    }
+    },
+    [onLinked, telegramId]
+  );
 
-    async function init() {
-      if (
-        initialized.current ||
-        !import.meta.env.VITE_GOOGLE_CLIENT_ID
-      ) {
+  const initGoogle = useCallback(
+    async (isCancelled = () => false) => {
+      if (!import.meta.env.VITE_GOOGLE_CLIENT_ID) {
+        setReady(false);
+        setStatus('error');
         return false;
       }
 
+      if (initialized.current) {
+        setReady(true);
+        setStatus('ready');
+        return true;
+      }
+
+      setStatus('loading');
       const ok = await ensureGoogleScript();
-      if (!ok || cancelled || !window.google?.accounts?.id) return false;
+      if (!ok || isCancelled()) {
+        setReady(false);
+        setStatus('error');
+        return false;
+      }
+
+      if (!window.google?.accounts?.id) {
+        setReady(false);
+        setStatus('error');
+        return false;
+      }
 
       window.google.accounts.id.initialize({
         client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
@@ -69,44 +94,70 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
         ux_mode: 'popup',
         cancel_on_tap_outside: false
       });
+
       if (buttonRef.current) {
+        buttonRef.current.innerHTML = '';
         window.google.accounts.id.renderButton(buttonRef.current, {
+          type: 'standard',
           theme: 'outline',
           shape: 'pill',
           size: 'large',
-          text: 'continue_with'
+          text: 'signin_with',
+          logo_alignment: 'center'
         });
       }
+
       initialized.current = true;
       setReady(true);
+      setStatus('ready');
       return true;
-    }
+    },
+    [ensureGoogleScript, handleCredential]
+  );
 
-    init();
+  useEffect(() => {
+    let cancelled = false;
+
+    initGoogle(() => cancelled);
 
     return () => {
       cancelled = true;
     };
-  }, [telegramId, onLinked]);
+  }, [initGoogle]);
 
   function handleClick() {
+    if (status === 'error') {
+      initialized.current = false;
+      initGoogle();
+      return;
+    }
+
     if (window.google?.accounts?.id && initialized.current) {
       window.google.accounts.id.prompt();
     }
   }
 
   return (
-    <div className="inline-flex items-center space-x-2">
-      <div ref={buttonRef} />
+    <div className="inline-flex flex-col space-y-2">
+      <div ref={buttonRef} aria-live="polite" className="flex items-center" />
       {!ready && (
         <button
           type="button"
           onClick={handleClick}
-          disabled={!ready}
-          className="px-3 py-1 bg-white text-black rounded disabled:opacity-50"
+          disabled={status === 'loading'}
+          className="inline-flex items-center space-x-2 rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:bg-gray-50 disabled:opacity-50"
         >
-          Link Google
+          <img
+            alt="Google"
+            src="https://developers.google.com/identity/images/g-logo.png"
+            className="h-5 w-5"
+            aria-hidden="true"
+          />
+          <span>{status === 'loading' ? 'Loading Google...' : 'Sign in with Google'}</span>
         </button>
+      )}
+      {status === 'error' && (
+        <p className="text-sm text-red-500">Unable to load Google Sign-In right now. Tap the button to retry.</p>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- ensure the Google Identity Services script is loaded reliably before rendering the sign-in control
- render the official Google Sign-In button with branding while providing a branded fallback and retry messaging
- keep account linking callback intact so Google sign-ins sync the user profile

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bfbc76bdc8329a42cba12d17ff0e0)