### PR TITLE
Preserve Pool Royale table identity

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -8177,6 +8177,7 @@ export function PoolRoyaleGame({
   tgId,
   playerName,
   opponentName,
+  tableId = '',
   gameId = 'poolroyale',
   lobbyPath = '/games/poolroyale/lobby',
   tableResolver = resolveTableSize
@@ -16599,7 +16600,10 @@ export function PoolRoyaleGame({
   const bottomHudVisible = hud.turn != null && !hud.over && !shotActive;
 
   return (
-    <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
+    <div
+      className="w-full h-[100vh] bg-black text-white overflow-hidden select-none"
+      data-table-id={tableId || undefined}
+    >
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
 
@@ -17207,6 +17211,21 @@ export function PoolRoyale({ lobbyPath = '/games/poolroyale/lobby' }) {
       'Player'
     );
   }, [location.search]);
+  const tableId = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const incoming = params.get('tableId');
+    if (incoming) {
+      try {
+        window.sessionStorage?.setItem('poolRoyaleTableId', incoming);
+      } catch {}
+      return incoming;
+    }
+    try {
+      return window.sessionStorage?.getItem('poolRoyaleTableId') || '';
+    } catch {
+      return '';
+    }
+  }, [location.search]);
   const stakeAmount = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return Number(params.get('amount')) || 0;
@@ -17278,19 +17297,27 @@ export function PoolRoyale({ lobbyPath = '/games/poolroyale/lobby' }) {
     return params.get('opponent') || '';
   }, [location.search]);
   return (
-    <PoolRoyaleGame
-      variantKey={variantKey}
-      tableSizeKey={tableSizeKey}
-      playType={playType}
-      mode={mode}
-      trainingMode={trainingMode}
-      trainingRulesEnabled={trainingRulesEnabled}
-      accountId={accountId}
-      tgId={tgId}
-      playerName={playerName}
-      opponentName={opponentName}
-      lobbyPath={lobbyPath}
-    />
+    <div className="relative">
+      {tableId && (
+        <div className="pointer-events-none absolute left-3 top-3 z-20 rounded-lg bg-black/70 px-3 py-1 text-xs font-semibold text-background">
+          Table {tableId.slice(0, 8)}
+        </div>
+      )}
+      <PoolRoyaleGame
+        variantKey={variantKey}
+        tableSizeKey={tableSizeKey}
+        playType={playType}
+        mode={mode}
+        trainingMode={trainingMode}
+        trainingRulesEnabled={trainingRulesEnabled}
+        accountId={accountId}
+        tgId={tgId}
+        playerName={playerName}
+        opponentName={opponentName}
+        tableId={tableId}
+        lobbyPath={lobbyPath}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- persist and reuse Pool Royale table ids from lobby parameters to avoid mismatched games
- surface the active table id in the game view and propagate it into the gameplay container

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c020f660c83298b597489aa7d6824)