### PR TITLE
Fix Google linking flow

### DIFF
--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -196,9 +196,28 @@ router.post('/addTransaction', async (req, res) => {
 });
 
 router.post('/link-google', async (req, res) => {
-  const { telegramId, googleId, email, dob, firstName, lastName, photo } = req.body;
-  if (!telegramId || !googleId) {
-    return res.status(400).json({ error: 'telegramId and googleId required' });
+  const {
+    telegramId,
+    accountId,
+    googleId,
+    email,
+    dob,
+    firstName,
+    lastName,
+    photo
+  } = req.body;
+  if (!googleId) {
+    return res.status(400).json({ error: 'googleId required' });
+  }
+
+  // Allow linking by either telegramId (existing users coming from the bot)
+  // or accountId (users who created an account with Google first).
+  const query = {};
+  if (telegramId) query.telegramId = telegramId;
+  if (accountId) query.accountId = accountId;
+
+  if (!query.telegramId && !query.accountId) {
+    return res.status(400).json({ error: 'telegramId or accountId required' });
   }
 
   const update = {
@@ -212,10 +231,18 @@ router.post('/link-google', async (req, res) => {
   if (photo !== undefined) update.photo = photo;
 
   const user = await User.findOneAndUpdate(
-    { telegramId },
-    { $set: update, $setOnInsert: { referralCode: telegramId.toString() } },
+    query,
+    {
+      $set: update,
+      $setOnInsert: {
+        referralCode: String(telegramId || accountId || googleId)
+      }
+    },
     { upsert: true, new: true, setDefaultsOnInsert: true }
   );
+
+  if (!user) return res.status(404).json({ error: 'user not found' });
+
   res.json(sanitizeUser(user));
 });
 

--- a/webapp/src/components/LinkGoogleButton.jsx
+++ b/webapp/src/components/LinkGoogleButton.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { linkGoogleAccount } from '../utils/api.js';
 
-export default function LinkGoogleButton({ telegramId, onLinked }) {
+export default function LinkGoogleButton({ telegramId, accountId, onLinked }) {
   const buttonRef = useRef(null);
   const [ready, setReady] = useState(false);
   const initialized = useRef(false);
@@ -43,6 +43,7 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
         localStorage.setItem('googleId', data.sub);
         linkGoogleAccount({
           telegramId,
+          accountId,
           googleId: data.sub,
           email: data.email,
           firstName: data.given_name,
@@ -72,80 +73,89 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
     }
 
     async function init() {
-      if (
-        initialized.current ||
-        !import.meta.env.VITE_GOOGLE_CLIENT_ID
-      ) {
+      if (!import.meta.env.VITE_GOOGLE_CLIENT_ID) {
+        console.warn('Missing Google client id');
         return false;
       }
 
       const ok = await ensureGoogleScript();
       if (!ok || cancelled || !window.google?.accounts?.id) return false;
 
-      window.google.accounts.id.initialize({
-        client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
-        callback: handleCredential,
-        ux_mode: 'popup',
-        cancel_on_tap_outside: false
-      });
+      if (!initialized.current) {
+        window.google.accounts.id.initialize({
+          client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
+          callback: handleCredential,
+          ux_mode: 'popup',
+          cancel_on_tap_outside: false
+        });
+        initialized.current = true;
+      }
 
       renderOfficialButton();
-      initialized.current = true;
       setReady(true);
       return true;
     }
 
     init();
 
+    const onDemandInit = () => {
+      if (!ready) init();
+    };
+
+    window.addEventListener('google-account-init', onDemandInit);
+
     return () => {
       cancelled = true;
+      window.removeEventListener('google-account-init', onDemandInit);
     };
-  }, [telegramId, onLinked]);
+  }, [telegramId, accountId, onLinked]);
 
   function handleClick() {
     if (window.google?.accounts?.id && initialized.current) {
       window.google.accounts.id.prompt();
+      return;
     }
+
+    // Try to initialise on demand if the automatic load failed
+    const event = new Event('google-account-init');
+    window.dispatchEvent(event);
   }
 
   return (
     <div className="inline-flex items-center space-x-2" aria-live="polite">
       <div ref={buttonRef} />
-      {!ready && (
-        <button
-          type="button"
-          onClick={handleClick}
-          disabled={!ready}
-          className="flex items-center gap-2 rounded border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm disabled:opacity-50"
-          aria-label="Sign in with Google"
+      <button
+        type="button"
+        onClick={handleClick}
+        className="flex items-center gap-2 rounded border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm"
+        aria-label="Sign in with Google"
+      >
+        <svg
+          className="h-5 w-5"
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+          focusable="false"
         >
-          <svg
-            className="h-5 w-5"
-            viewBox="0 0 18 18"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
-            focusable="false"
-          >
-            <path
-              fill="#4285F4"
-              d="M17.64 9.2045c0-.6385-.0573-1.2518-.1636-1.8409H9v3.4818h4.8441c-.2086 1.125-.8432 2.0796-1.7978 2.7195v2.2581h2.9086c1.7018-1.5668 2.6851-3.8741 2.6851-6.6185z"
-            />
-            <path
-              fill="#34A853"
-              d="M9 18c2.43 0 4.4673-.8067 5.9568-2.1764l-2.9086-2.2581c-.8068.54-1.8377.8627-3.0482.8627-2.3455 0-4.3296-1.5832-5.0373-3.7104H.9577v2.3318C2.4382 15.9832 5.4818 18 9 18z"
-            />
-            <path
-              fill="#FBBC05"
-              d="M3.9627 10.7178c-.1832-.54-.2877-1.1168-.2877-1.7178s.1045-1.1777.2877-1.7178V4.9505H.9577C.3477 6.161 0 7.5478 0 9s.3477 2.839 1.0145 4.0495l2.9482-2.3317z"
-            />
-            <path
-              fill="#EA4335"
-              d="M9 3.5795c1.3209 0 2.5073.4545 3.4395 1.3464l2.5791-2.5791C13.4645.891 11.4273 0 9 0 5.4818 0 2.4382 2.0168.9577 4.9505l3.005 2.3317C4.6704 5.1627 6.6545 3.5795 9 3.5795z"
-            />
-          </svg>
-          Sign in with Google
-        </button>
-      )}
+          <path
+            fill="#4285F4"
+            d="M17.64 9.2045c0-.6385-.0573-1.2518-.1636-1.8409H9v3.4818h4.8441c-.2086 1.125-.8432 2.0796-1.7978 2.7195v2.2581h2.9086c1.7018-1.5668 2.6851-3.8741 2.6851-6.6185z"
+          />
+          <path
+            fill="#34A853"
+            d="M9 18c2.43 0 4.4673-.8067 5.9568-2.1764l-2.9086-2.2581c-.8068.54-1.8377.8627-3.0482.8627-2.3455 0-4.3296-1.5832-5.0373-3.7104H.9577v2.3318C2.4382 15.9832 5.4818 18 9 18z"
+          />
+          <path
+            fill="#FBBC05"
+            d="M3.9627 10.7178c-.1832-.54-.2877-1.1168-.2877-1.7178s.1045-1.1777.2877-1.7178V4.9505H.9577C.3477 6.161 0 7.5478 0 9s.3477 2.839 1.0145 4.0495l2.9482-2.3317z"
+          />
+          <path
+            fill="#EA4335"
+            d="M9 3.5795c1.3209 0 2.5073.4545 3.4395 1.3464l2.5791-2.5791C13.4645.891 11.4273 0 9 0 5.4818 0 2.4382 2.0168.9577 4.9505l3.005 2.3317C4.6704 5.1627 6.6545 3.5795 9 3.5795z"
+          />
+        </svg>
+        {ready ? 'Sign in with Google' : 'Connect Google'}
+      </button>
     </div>
   );
 }

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -375,6 +375,7 @@ export default function MyAccount() {
               </p>
               <LinkGoogleButton
                 telegramId={telegramId}
+                accountId={profile?.accountId || localStorage.getItem('accountId')}
                 onLinked={(linkedId) => {
                   setGoogleLinked(true);
                   if (linkedId) setGoogleId(linkedId);


### PR DESCRIPTION
## Summary
- handle Google account linking on the backend using either telegramId or accountId to persist IDs in MongoDB
- improve the Google sign-in button to initialize on demand and always expose a clickable prompt
- include accountId when linking from the profile page so Google logins keep the same account across browsers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c0f905fb08329a6b6691387a5b5cc)