### PR TITLE
Fix Google account linking via safe JWT decoding

### DIFF
--- a/webapp/src/components/LinkGoogleButton.jsx
+++ b/webapp/src/components/LinkGoogleButton.jsx
@@ -36,24 +36,40 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
       });
     }
 
-    function handleCredential(res) {
+    function decodeJwtPayload(jwt) {
+      const [, payload] = String(jwt).split('.');
+      if (!payload) return null;
+
+      const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+      const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
+
       try {
-        const data = JSON.parse(atob(res.credential.split('.')[1]));
-        if (!data.sub) return;
-        localStorage.setItem('googleId', data.sub);
-        linkGoogleAccount({
-          telegramId,
-          googleId: data.sub,
-          email: data.email,
-          firstName: data.given_name,
-          lastName: data.family_name,
-          photo: data.picture
-        }).then(() => {
-          if (onLinked) onLinked(data.sub);
-        });
+        return JSON.parse(atob(padded));
       } catch (err) {
-        console.error('Failed to link Google account', err);
+        console.error('Failed to parse Google credential', err);
+        return null;
       }
+    }
+
+    function handleCredential(res) {
+      const data = decodeJwtPayload(res.credential);
+      if (!data?.sub) return;
+
+      localStorage.setItem('googleId', data.sub);
+      linkGoogleAccount({
+        telegramId,
+        googleId: data.sub,
+        email: data.email,
+        firstName: data.given_name,
+        lastName: data.family_name,
+        photo: data.picture
+      })
+        .then(() => {
+          if (onLinked) onLinked(data.sub);
+        })
+        .catch((err) => {
+          console.error('Failed to link Google account', err);
+        });
     }
 
     function renderOfficialButton() {


### PR DESCRIPTION
## Summary
- add base64url-safe decoding for Google ID credentials before linking accounts
- persist Google IDs and handle link errors to ensure accounts remain connected across browsers

## Testing
- npm --prefix webapp run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c0f905fb08329a6b6691387a5b5cc)