### PR TITLE
Align side pocket collision guard with visual size

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5040,8 +5040,11 @@ function reflectRails(ball) {
     return 'corner';
   }
 
-  const sideSpan = SIDE_POCKET_RADIUS + BALL_R * 0.65; // extend the middle pocket guard for more precise collisions
-  const sideDepthLimit = POCKET_VIS_R * 1.45 * POCKET_VISUAL_EXPANSION;
+  const sideSpan =
+    SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION +
+    BALL_R * 0.65; // extend the middle pocket guard for more precise collisions and align with the visible cutout
+  const sideDepthLimit =
+    SIDE_POCKET_RADIUS * 1.45 * POCKET_VISUAL_EXPANSION; // match the middle pocket throat depth to the scaled radius
   const sideRad = THREE.MathUtils.degToRad(SIDE_CUSHION_CUT_ANGLE);
   const sideCos = Math.cos(sideRad);
   const sideSin = Math.sin(sideRad);


### PR DESCRIPTION
## Summary
- expand side pocket guard span using the scaled pocket radius to match visual geometry
- adjust side pocket depth limit to respect the scaled radius and avoid premature rail reflections near middle pockets

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c10153e4c83299a6146676c0ef954)