### PR TITLE
Add runtime Google client ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,12 @@
 
   - `RATE_LIMIT_MAX` – (optional) max requests per window from one IP (defaults to 100)
 
-  - `ALLOWED_ORIGINS` – list of origins allowed for CORS and socket.io. Multiple
+ - `ALLOWED_ORIGINS` – list of origins allowed for CORS and socket.io. Multiple
     origins may be comma-separated, e.g.
     `https://tonplaygram-bot.onrender.com,https://t.me,https://web.telegram.org`
+  - `GOOGLE_CLIENT_ID` – (optional) Google OAuth client ID used to serve the
+    profile/login Google button when the webapp was built without
+    `VITE_GOOGLE_CLIENT_ID`.
 
   - `TWITTER_BEARER_TOKEN` – bearer token for verifying reposts on **X**.
   - `TWITTER_CLIENT_ID` – API key for **X** OAuth linking.

--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -28,6 +28,14 @@ export function parseTwitterHandle(input) {
 
 const router = Router();
 
+router.get('/google-client-id', (req, res) => {
+  const clientId = process.env.GOOGLE_CLIENT_ID || process.env.VITE_GOOGLE_CLIENT_ID;
+  if (!clientId) {
+    return res.status(404).json({ error: 'Google client ID not configured' });
+  }
+  res.json({ clientId });
+});
+
 router.post('/register-wallet', async (req, res) => {
   const { walletAddress } = req.body;
   if (!walletAddress) {

--- a/webapp/src/components/LinkGoogleButton.jsx
+++ b/webapp/src/components/LinkGoogleButton.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { createAccount, linkGoogleAccount } from '../utils/api.js';
+import { createAccount, getGoogleClientId, linkGoogleAccount } from '../utils/api.js';
 
 export default function LinkGoogleButton({ telegramId, onLinked }) {
   const buttonRef = useRef(null);
@@ -7,6 +7,7 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const initialized = useRef(false);
+  const [clientId, setClientId] = useState(import.meta.env.VITE_GOOGLE_CLIENT_ID || '');
 
   useEffect(() => {
     let cancelled = false;
@@ -97,15 +98,25 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
       });
     }
 
+    async function resolveClientId() {
+      if (clientId) return clientId;
+      const res = await getGoogleClientId();
+      if (cancelled) return null;
+      if (res?.clientId) {
+        setClientId(res.clientId);
+        return res.clientId;
+      }
+      setError(res?.error || 'Google sign-in is not configured.');
+      return null;
+    }
+
     async function init() {
       if (initialized.current) {
         return false;
       }
 
-      if (!import.meta.env.VITE_GOOGLE_CLIENT_ID) {
-        setError('Google sign-in is not configured.');
-        return false;
-      }
+      const resolvedClientId = await resolveClientId();
+      if (!resolvedClientId) return false;
 
       const ok = await ensureGoogleScript();
       if (!ok || cancelled || !window.google?.accounts?.id) {
@@ -114,7 +125,7 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
       }
 
       window.google.accounts.id.initialize({
-        client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
+        client_id: resolvedClientId,
         callback: handleCredential,
         ux_mode: 'popup',
         cancel_on_tap_outside: false
@@ -131,7 +142,7 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
     return () => {
       cancelled = true;
     };
-  }, [telegramId, onLinked]);
+  }, [telegramId, onLinked, clientId]);
 
   function handleClick() {
     if (window.google?.accounts?.id && initialized.current) {

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -366,6 +366,10 @@ export function registerWallet(walletAddress) {
   return post('/api/profile/register-wallet', { walletAddress });
 }
 
+export function getGoogleClientId() {
+  return get('/api/profile/google-client-id');
+}
+
 export function linkGoogleAccount(data) {
   return post('/api/profile/link-google', data);
 }


### PR DESCRIPTION
## Summary
- expose a backend endpoint to provide the configured Google client ID at runtime
- let the profile Google link button fetch the client ID when it was not baked into the build
- document the optional backend GOOGLE_CLIENT_ID environment variable for runtime configuration

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c17088dbc83299a80fd9d1cf71cf1)