### PR TITLE
Configure Google sign-in client id

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -19,4 +19,7 @@ services:
     rootDir: webapp
     buildCommand: npm install && npm run build
     staticPublishPath: dist
+    envVars:
+      - key: VITE_GOOGLE_CLIENT_ID
+        fromSecret: GOOGLE_CLIENT_ID
 

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
+    <meta name="google-client-id" content="%VITE_GOOGLE_CLIENT_ID%" />
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <meta name="theme-color" content="#00f7ff" />
     <link rel="manifest" href="/manifest.webmanifest" />


### PR DESCRIPTION
## Summary
- allow Google sign-in to use a client ID from environment variables, window globals, or meta tags
- expose the Google client ID to the built site via meta tag in the public index
- configure the Render static deployment to inject the Google client ID from a secret

## Testing
- npm --prefix webapp run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c17088dbc83299a80fd9d1cf71cf1)