### PR TITLE
Lower Pool Royale cushions toward carpet

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -944,6 +944,7 @@ const CLOTH_EDGE_EMISSIVE_MULTIPLIER = 0.02; // soften light spill on the sleeve
 const CLOTH_EDGE_EMISSIVE_INTENSITY = 0.24; // further dim emissive brightness so the cutouts stay consistent with the cloth plane
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
 const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.118; // sink the cushion base further so the pads settle slightly below the rail line
+const CUSHION_VERTICAL_DROP = TABLE.THICK * 0.06; // pull the cushions downward so the full pad sits closer to the carpet
 const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.128; // trim the cushion tops more so chalks and diamonds stay visible above the pads
 const CUSHION_FIELD_CLIP_RATIO = 0.14; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
@@ -7566,7 +7567,7 @@ function Table3D(
     mesh.renderOrder = 2;
     const group = new THREE.Group();
     group.add(mesh);
-    group.position.set(x, cushionBaseY, z);
+    group.position.set(x, cushionBaseY - CUSHION_VERTICAL_DROP, z);
     if (!horizontal) group.rotation.y = Math.PI / 2;
     if (flip) group.rotation.y += Math.PI;
 


### PR DESCRIPTION
## Summary
- add a configurable vertical drop to nudge Pool Royale cushions closer to the carpet
- apply the new drop when positioning each cushion group

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c40e00ecc8329b68cbc0839c69aec)