### PR TITLE
Improve Pool Royale AI shot selection

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -122,6 +122,27 @@ function lineIntersectsBall (a, b, ball, radius) {
   return dist(closest, ball) < radius * 2
 }
 
+function segmentClearance (a, b, balls, ignoreIds, radius) {
+  let minGap = Infinity
+  const abx = b.x - a.x
+  const aby = b.y - a.y
+  const abLenSq = abx * abx + aby * aby || 1
+
+  for (const ball of balls) {
+    if (ball.pocketed) continue
+    if (ignoreIds.includes(ball.id)) continue
+    const apx = ball.x - a.x
+    const apy = ball.y - a.y
+    const t = (apx * abx + apy * aby) / abLenSq
+    if (t <= 0 || t >= 1) continue
+    const closest = { x: a.x + abx * t, y: a.y + aby * t }
+    const gap = dist(closest, ball) - radius * 2
+    if (gap < minGap) minGap = gap
+  }
+
+  return minGap
+}
+
 function pathBlocked (a, b, balls, ignoreIds, radius) {
   return balls.some(
     ball =>
@@ -215,41 +236,36 @@ function generatePotCandidates (state, colour) {
   const balls = visibleOwnBalls(state, colour)
   const shots = []
   for (const ball of balls) {
-    let bestPocket = null
-    let bestView = -Infinity
-    let bestAngle = Infinity
-    let bestDist = Infinity
+    const pocketOptions = []
     for (const pocket of state.pockets) {
       const entry = pocketEntry(pocket, state)
       if (pathBlocked(ball, entry, state.balls, [cue.id, ball.id], state.ballRadius)) continue
       const angle = cutAngle(cue, ball, entry)
       const d = dist(ball, entry)
       const view = Math.atan2(state.ballRadius * 2, d)
-      if (
-        view > bestView + 1e-6 ||
-        (Math.abs(view - bestView) <= 1e-6 && angle < bestAngle)
-      ) {
-        bestView = view
-        bestAngle = angle
-        bestDist = d
-        bestPocket = entry
-      }
+      const clearanceCue = segmentClearance(cue, ball, state.balls, [cue.id, ball.id], state.ballRadius)
+      const clearancePot = segmentClearance(ball, entry, state.balls, [cue.id, ball.id], state.ballRadius)
+      const clearanceScore = Math.max(0, Math.min(1, Math.min(clearanceCue, clearancePot) / (state.ballRadius * 1.5)))
+      const distScore = 1 - Math.min((dist(cue, ball) + d) / Math.hypot(state.width, state.height), 1)
+      const pocketScore = view * 0.45 + (Math.PI - angle) * 0.35 + clearanceScore * 0.2 + distScore * 0.2
+      pocketOptions.push({ entry, angle, distCT: dist(cue, ball), distTP: d, pocketScore })
     }
-    if (bestPocket && !pathBlocked(ball, bestPocket, state.balls, [cue.id, ball.id], state.ballRadius)) {
-      const angle = bestAngle
-      const distCT = dist(cue, ball)
-      const distTP = bestDist
-      for (const params of CUE_VARIATIONS) {
-        shots.push({
-          actionType: 'pot',
-          targetBall: ball,
-          pocket: bestPocket,
-          cueParams: params,
-          angle,
-          distCT,
-          distTP
-        })
-      }
+    pocketOptions
+      .sort((a, b) => b.pocketScore - a.pocketScore)
+      .slice(0, 3)
+      .forEach(option => {
+        for (const params of CUE_VARIATIONS) {
+          shots.push({
+            actionType: 'pot',
+            targetBall: ball,
+            pocket: option.entry,
+            cueParams: params,
+            angle: option.angle,
+            distCT: option.distCT,
+            distTP: option.distTP
+          })
+        }
+      })
     }
   }
   return shots
@@ -283,6 +299,9 @@ function generateBankPotCandidates (state, colour) {
         const angle = cutAngle(cue, ball, mirror)
         const distCT = dist(cue, ball)
         const distTP = dist(ball, entry)
+        const clearanceCue = segmentClearance(cue, ball, state.balls, [cue.id, ball.id], state.ballRadius)
+        const clearancePot = segmentClearance(ball, entry, state.balls, [cue.id, ball.id], state.ballRadius)
+        if (Math.min(clearanceCue, clearancePot) < state.ballRadius * 0.35) continue
         for (const params of CUE_VARIATIONS) {
           shots.push({
             actionType: 'pot',
@@ -467,6 +486,26 @@ function generateSafeties (state, colour) {
 }
 
 // ----------------- evaluation heuristics -----------------
+function landingShapeScore (state, cueAfter, colour, pocketedId) {
+  const remaining = state.balls.filter(
+    b => !b.pocketed && b.id !== pocketedId && b.colour === colour
+  )
+  if (remaining.length === 0) return 0.5
+  const cue = { ...cueAfter }
+  const diag = Math.hypot(state.width, state.height) || 1
+  let best = 0
+  for (const ball of remaining) {
+    const distanceEase = 1 - Math.min(dist(cue, ball) / (diag * 0.6), 1)
+    const sight = state.pockets.some(p => {
+      const entry = pocketEntry(p, state)
+      return !pathBlocked(ball, entry, state.balls, [ball.id], state.ballRadius)
+    })
+    const visibility = sight ? 0.3 : 0
+    best = Math.max(best, distanceEase * 0.7 + visibility)
+  }
+  return best
+}
+
 function estimatePotProbability (shot, state) {
   const angleDeg = shot.angle * 180 / Math.PI
   const pocketViewDeg = Math.atan2(state.ballRadius * 2, shot.distTP || 1) * 180 / Math.PI
@@ -490,6 +529,12 @@ function estimatePotProbability (shot, state) {
     P *= 0.9
     P -= 0.04
   }
+
+  const cue = state.balls.find(b => b.colour === 'cue')
+  const clearanceCue = segmentClearance(cue, shot.targetBall, state.balls, [cue.id, shot.targetBall.id], state.ballRadius)
+  const clearancePot = segmentClearance(shot.targetBall, shot.pocket, state.balls, [cue.id, shot.targetBall.id], state.ballRadius)
+  const clearancePenalty = Math.max(0, (state.ballRadius * 1.2 - Math.min(clearanceCue, clearancePot)) / (state.ballRadius * 1.2))
+  P -= clearancePenalty * 0.25
 
   // adjust by learnt success rates
   const angleBucket = Math.round(angleDeg / 7.5)
@@ -518,7 +563,8 @@ function estimatePotProbability (shot, state) {
   const cueAfter = simulateCueRollout(state, shot)
   const center = { x: state.width / 2, y: state.height / 2 }
   const centerScore = 1 - Math.min(dist(cueAfter, center) / maxD, 1)
-  P = P * 0.85 + centerScore * 0.15
+  const shapeScore = landingShapeScore(state, cueAfter, state.ballOn || shot.targetBall.colour, shot.targetBall?.id)
+  P = P * 0.75 + centerScore * 0.12 + shapeScore * 0.13
   return Math.max(0, Math.min(1, P))
 }
 
@@ -564,26 +610,27 @@ function simulateCueRollout (state, shot) {
   const toCue = { x: ball.x - cue.x, y: ball.y - cue.y }
   const toCueLen = Math.hypot(toCue.x, toCue.y) || 1
   const dirCue = { x: toCue.x / toCueLen, y: toCue.y / toCueLen }
+  const speedScale = shot.cueParams.speed === 'firm' ? 1.4 : shot.cueParams.speed === 'med' ? 1.0 : 0.65
   switch (shot.cueParams.spin) {
     case 'followS':
-      pos = { x: pos.x + dirPocket.x * 30, y: pos.y + dirPocket.y * 30 }; break
+      pos = { x: pos.x + dirPocket.x * 30 * speedScale, y: pos.y + dirPocket.y * 30 * speedScale }; break
     case 'followL':
-      pos = { x: pos.x + dirPocket.x * 60, y: pos.y + dirPocket.y * 60 }; break
+      pos = { x: pos.x + dirPocket.x * 60 * speedScale, y: pos.y + dirPocket.y * 60 * speedScale }; break
     case 'drawS':
-      pos = { x: pos.x + dirCue.x * 20, y: pos.y + dirCue.y * 20 }; break
+      pos = { x: pos.x + dirCue.x * 20 * speedScale, y: pos.y + dirCue.y * 20 * speedScale }; break
     case 'drawL':
-      pos = { x: pos.x + dirCue.x * 40, y: pos.y + dirCue.y * 40 }; break
+      pos = { x: pos.x + dirCue.x * 40 * speedScale, y: pos.y + dirCue.y * 40 * speedScale }; break
     case 'sideL': {
       const angle = Math.atan2(dirPocket.y, dirPocket.x) - Math.PI / 12
-      pos = { x: pos.x + Math.cos(angle) * 40, y: pos.y + Math.sin(angle) * 40 }; break
+      pos = { x: pos.x + Math.cos(angle) * 40 * speedScale, y: pos.y + Math.sin(angle) * 40 * speedScale }; break
     }
     case 'sideR': {
       const angle = Math.atan2(dirPocket.y, dirPocket.x) + Math.PI / 12
-      pos = { x: pos.x + Math.cos(angle) * 40, y: pos.y + Math.sin(angle) * 40 }; break
+      pos = { x: pos.x + Math.cos(angle) * 40 * speedScale, y: pos.y + Math.sin(angle) * 40 * speedScale }; break
     }
     default: // stun
-      // cue stops near target
-      pos = { x: pos.x, y: pos.y }
+      // cue stops near target with slight drift based on power
+      pos = { x: pos.x + dirPocket.x * 10 * speedScale, y: pos.y + dirPocket.y * 10 * speedScale }
   }
   return { x: pos.x, y: pos.y }
 }
@@ -631,7 +678,8 @@ function valueOfPositionAfter (nc, state, colour) {
   const cueAfter = simulateCueRollout(state, nc)
   const center = { x: state.width / 2, y: state.height / 2 }
   const centerBonus = 0.1 * (1 - Math.min(dist(cueAfter, center) / Math.hypot(state.width, state.height), 1))
-  return (P2 + straightBonus) * base + centerBonus
+  const shapeAssist = landingShapeScore(state, cueAfter, colour, nc.targetBall?.id)
+  return (P2 + straightBonus) * base + centerBonus + shapeAssist * 0.35
 }
 
 function foulRisk (shot, state) {
@@ -643,6 +691,28 @@ function foulRisk (shot, state) {
   if (state.pockets.some(p => dist(cueAfter, p) < state.ballRadius * 1.1)) {
     risk += 0.6
   }
+  const cue = state.balls.find(b => b.colour === 'cue')
+  const interfering = state.balls.some(
+    b =>
+      !b.pocketed &&
+      b.id !== cue.id &&
+      b.id !== shot.targetBall.id &&
+      b.colour !== shot.targetBall.colour &&
+      lineIntersectsBall(cue, shot.targetBall, b, state.ballRadius * 1.05)
+  )
+  if (interfering) risk += 0.35
+
+  const pocketOnPath = state.pockets.some(p => {
+    const apx = p.x - cue.x
+    const apy = p.y - cue.y
+    const abx = shot.targetBall.x - cue.x
+    const aby = shot.targetBall.y - cue.y
+    const t = (apx * abx + apy * aby) / (abx * abx + aby * aby)
+    if (t <= 0 || t >= 1) return false
+    const closest = { x: cue.x + abx * t, y: cue.y + aby * t }
+    return dist(closest, p) < state.ballRadius * 1.4
+  })
+  if (pocketOnPath && shot.cueParams.speed === 'firm') risk += 0.2
   return risk
 }
 


### PR DESCRIPTION
## Summary
- prioritize high-probability pots by evaluating multiple pocket options with clearance scoring
- model cue power and spin in rollout predictions to choose speeds that leave better position
- penalize risky lines that approach pockets or opponent balls to reduce fouls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d1de0beb88329b6794e7278af2195)