### PR TITLE
Improve Pool Royale AI shot evaluation

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -131,6 +131,26 @@ function pathBlocked (a, b, balls, ignoreIds, radius) {
   )
 }
 
+function clearanceMargin (a, b, balls, ignoreIds, radius, multiplier = 1.35) {
+  let min = Infinity
+  for (const ball of balls) {
+    if (ball.pocketed) continue
+    if (ignoreIds.includes(ball.id)) continue
+    const apx = ball.x - a.x
+    const apy = ball.y - a.y
+    const abx = b.x - a.x
+    const aby = b.y - a.y
+    const t = (apx * abx + apy * aby) / (abx * abx + aby * aby)
+    if (t <= 0 || t >= 1) continue
+    const closest = { x: a.x + abx * t, y: a.y + aby * t }
+    const d = dist(closest, ball)
+    if (d < min) min = d
+  }
+  if (!Number.isFinite(min)) return 1
+  const ratio = min / (radius * multiplier)
+  return Math.min(Math.max(ratio, 0), 2)
+}
+
 function pocketBetween (cue, ball, pockets, radius) {
   const dx = ball.x - cue.x
   const dy = ball.y - cue.y
@@ -473,6 +493,16 @@ function estimatePotProbability (shot, state) {
   const cutRatio = angleDeg / (pocketViewDeg + 1e-6)
   const maxD = Math.hypot(state.width, state.height)
   const distScore = 1 - Math.min((shot.distCT + shot.distTP) / maxD, 1)
+  const cueBall = state.balls.find(b => b.colour === 'cue')
+  const laneClearance = clearanceMargin(
+    cueBall,
+    shot.targetBall,
+    state.balls,
+    [shot.targetBall.id, cueBall.id],
+    state.ballRadius,
+    1.6
+  )
+  const clearanceScore = Math.max(0, Math.min(1, (laneClearance - 0.6) / 0.8))
 
   // sharper lines receive a steeper falloff to mimic pro precision
   const eliteStraightWindow = 0.65
@@ -483,8 +513,8 @@ function estimatePotProbability (shot, state) {
     angleScore *= 0.55
   }
 
-  // combine distance and angle with stronger emphasis on accuracy
-  let P = angleScore * 0.75 + distScore * 0.25
+  // combine distance, angle, and lane cleanliness with stronger emphasis on accuracy
+  let P = angleScore * 0.6 + distScore * 0.2 + clearanceScore * 0.2
 
   if (shot.isKick) {
     P *= 0.9
@@ -518,7 +548,7 @@ function estimatePotProbability (shot, state) {
   const cueAfter = simulateCueRollout(state, shot)
   const center = { x: state.width / 2, y: state.height / 2 }
   const centerScore = 1 - Math.min(dist(cueAfter, center) / maxD, 1)
-  P = P * 0.85 + centerScore * 0.15
+  P = P * 0.8 + centerScore * 0.2
   return Math.max(0, Math.min(1, P))
 }
 
@@ -558,6 +588,11 @@ function simulateCueRollout (state, shot) {
   const cue = state.balls.find(b => b.colour === 'cue')
   const ball = shot.targetBall
   let pos = { x: ball.x, y: ball.y }
+  const speedScale = shot.cueParams?.speed === 'soft'
+    ? 0.65
+    : shot.cueParams?.speed === 'firm'
+      ? 1.4
+      : 1
   const toPocket = { x: shot.pocket.x - ball.x, y: shot.pocket.y - ball.y }
   const toPocketLen = Math.hypot(toPocket.x, toPocket.y) || 1
   const dirPocket = { x: toPocket.x / toPocketLen, y: toPocket.y / toPocketLen }
@@ -566,20 +601,20 @@ function simulateCueRollout (state, shot) {
   const dirCue = { x: toCue.x / toCueLen, y: toCue.y / toCueLen }
   switch (shot.cueParams.spin) {
     case 'followS':
-      pos = { x: pos.x + dirPocket.x * 30, y: pos.y + dirPocket.y * 30 }; break
+      pos = { x: pos.x + dirPocket.x * 30 * speedScale, y: pos.y + dirPocket.y * 30 * speedScale }; break
     case 'followL':
-      pos = { x: pos.x + dirPocket.x * 60, y: pos.y + dirPocket.y * 60 }; break
+      pos = { x: pos.x + dirPocket.x * 60 * speedScale, y: pos.y + dirPocket.y * 60 * speedScale }; break
     case 'drawS':
-      pos = { x: pos.x + dirCue.x * 20, y: pos.y + dirCue.y * 20 }; break
+      pos = { x: pos.x + dirCue.x * 20 * speedScale, y: pos.y + dirCue.y * 20 * speedScale }; break
     case 'drawL':
-      pos = { x: pos.x + dirCue.x * 40, y: pos.y + dirCue.y * 40 }; break
+      pos = { x: pos.x + dirCue.x * 40 * speedScale, y: pos.y + dirCue.y * 40 * speedScale }; break
     case 'sideL': {
       const angle = Math.atan2(dirPocket.y, dirPocket.x) - Math.PI / 12
-      pos = { x: pos.x + Math.cos(angle) * 40, y: pos.y + Math.sin(angle) * 40 }; break
+      pos = { x: pos.x + Math.cos(angle) * 40 * speedScale, y: pos.y + Math.sin(angle) * 40 * speedScale }; break
     }
     case 'sideR': {
       const angle = Math.atan2(dirPocket.y, dirPocket.x) + Math.PI / 12
-      pos = { x: pos.x + Math.cos(angle) * 40, y: pos.y + Math.sin(angle) * 40 }; break
+      pos = { x: pos.x + Math.cos(angle) * 40 * speedScale, y: pos.y + Math.sin(angle) * 40 * speedScale }; break
     }
     default: // stun
       // cue stops near target
@@ -589,33 +624,11 @@ function simulateCueRollout (state, shot) {
 }
 
 function generateFastCandidates (state, colour) {
-  // only consider straight pots for nearest ball
-  const cue = state.balls.find(b => b.colour === 'cue')
-  const ownBalls = visibleOwnBalls(state, colour)
-  if (ownBalls.length === 0) return []
-  const ball = ownBalls.reduce((m, b) => dist(cue, b) < dist(cue, m) ? b : m, ownBalls[0])
-  let bestPocket = null
-  let bestAngle = Infinity
-  let bestDist = Infinity
-  let bestView = -Infinity
-  for (const p of state.pockets) {
-    const entry = pocketEntry(p, state)
-    if (pathBlocked(ball, entry, state.balls, [cue.id, ball.id], state.ballRadius)) continue
-    const angle = cutAngle(cue, ball, entry)
-    const d = dist(ball, entry)
-    const view = Math.atan2(state.ballRadius * 2, d)
-    if (
-      view > bestView + 1e-6 ||
-      (Math.abs(view - bestView) <= 1e-6 && angle < bestAngle)
-    ) {
-      bestAngle = angle
-      bestDist = d
-      bestView = view
-      bestPocket = entry
-    }
-  }
-  if (!bestPocket) return []
-  return [{ actionType: 'pot', targetBall: ball, pocket: bestPocket, cueParams: { speed: 'med', spin: 'stun' }, angle: bestAngle, distCT: dist(cue, ball), distTP: bestDist }]
+  const candidates = generatePotCandidates(state, colour)
+  const ranked = candidates
+    .map(c => ({ c, score: estimatePotProbability(c, state) }))
+    .sort((a, b) => b.score - a.score)
+  return ranked.slice(0, 3).map(r => r.c)
 }
 
 function valueOfPositionAfter (nc, state, colour) {
@@ -642,6 +655,16 @@ function foulRisk (shot, state) {
   let risk = 0
   if (state.pockets.some(p => dist(cueAfter, p) < state.ballRadius * 1.1)) {
     risk += 0.6
+  }
+  const cue = state.balls.find(b => b.colour === 'cue')
+  if (shot.targetBall) {
+    const oppBalls = state.balls.filter(
+      b => !b.pocketed && b.id !== shot.targetBall.id && b.colour !== shot.targetBall.colour && b.colour !== 'cue'
+    )
+    const clearance = clearanceMargin(cue, shot.targetBall, oppBalls, [], state.ballRadius, 1.15)
+    if (clearance < 1) {
+      risk += (1 - clearance) * 0.55
+    }
   }
   return risk
 }


### PR DESCRIPTION
## Summary
- enhance UK pool AI shot probability by factoring in lane clearance and positional centering
- scale cue rollout by speed presets to better shape for next shots and reduce scratch risks
- rank follow-up candidates by estimated probability to bias toward easier pots

## Testing
- npm test -- --runInBand *(fails: Jest root path configuration expects missing /workspace/TonPlaygramWebApp/tests directory)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d1de0beb88329b6794e7278af2195)