### PR TITLE
Tighten Pool Royale camera framing

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -32,19 +32,19 @@ public class CameraController : MonoBehaviour
     public float maxHeightAboveTable = 2.05f;
     // Default distance of the camera from the table centre when fully raised to
     // provide a broad overview of the action.
-    public float distanceFromCenter = 2.85f;
+    public float distanceFromCenter = 2.7f;
     // Minimum distance from the table centre allowed when the camera is pulled
     // down toward the rails for a closer look.
-    public float minDistanceFromCenter = 1.65f;
+    public float minDistanceFromCenter = 1.55f;
     // Extra distance the camera is allowed to shed as it hugs the table so the
     // cue ball fills more of the view during low-angle aiming.
-    public float lowHeightDistanceReduction = 0.75f;
+    public float lowHeightDistanceReduction = 0.9f;
     // Extra pullback applied when the camera is raised to its maximum height so
     // the player gets a slightly wider view while aiming.
     public float zoomOutWhenRaised = 0.12f;
     // Buffer that keeps the camera just outside the rails even at the closest
     // zoom level.
-    public float railBuffer = 0.0185f;
+    public float railBuffer = 0.012f;
     // Slight height offset so the camera looks just above the table centre
     // to reduce the viewing angle and give a lower perspective.
     public float lookAtHeightOffset = 0.11f;
@@ -54,8 +54,8 @@ public class CameraController : MonoBehaviour
     public float lowHeightLookUpOffset = 0.12f;
     // When the camera moves close to the table corners pull back slightly so
     // the rails remain visible and aiming is easier.
-    public float cornerXThreshold = 2.405f;
-    public float cornerZThreshold = 1.2025f;
+    public float cornerXThreshold = 2.32f;
+    public float cornerZThreshold = 1.16f;
     public float cornerPullback = 0.4625f;
     // Range beyond the thresholds where the pullback gradually reaches the
     // maximum value.  This avoids a sudden jump in zoom when approaching a

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -25,11 +25,11 @@ public class CueCamera : MonoBehaviour
 
     [Header("Cue aim view")]
     // Distance from the cue ball when the camera is fully raised above the cue.
-    public float cueRaisedDistanceFromBall = 0.74f;
+    public float cueRaisedDistanceFromBall = 0.68f;
     // Distance from the cue ball used for the lowest aiming view.  This keeps the
     // camera hovering over the mid–upper portion of the cue rather than slipping
     // all the way back to the plastic end.
-    public float cueLoweredDistanceFromBall = 0.06f;
+    public float cueLoweredDistanceFromBall = 0.05f;
     // Additional pull-in applied to the cue camera so the portrait framing hugs
     // the cloth like a player leaning over the shot.
     public float cueDistancePullIn = 0.48f;
@@ -37,13 +37,13 @@ public class CueCamera : MonoBehaviour
     // camera from intersecting the cue or cloth when the player drops in tight.
     public float cueMinimumDistance = 0.02f;
     // Height the cue view should reach when the player lifts the camera.
-    public float cueRaisedHeight = 0.92f;
+    public float cueRaisedHeight = 0.86f;
     // Extra padding applied when the player lifts the camera so the frame has
     // a little more breathing room above the shaft while keeping the cue in
     // view.
     public float cueRaisedHeightPadding = 0.05f;
     // Minimum height maintained when the player drops the camera toward the cue.
-    public float cueLoweredHeight = 0.3f;
+    public float cueLoweredHeight = 0.27f;
     // Extra forward push applied as the player lowers the camera so the framing
     // stays tight on the cue ball and shaft instead of drifting backward.
     public float cueLoweredForwardPush = 0.08f;
@@ -85,11 +85,11 @@ public class CueCamera : MonoBehaviour
     // Scale applied to the cue distance when the camera is raised. Values below
     // 1 slide the camera closer to the cloth even before the player lowers it.
     [Range(0.1f, 1f)]
-    public float cueRaisedDistanceScale = 0.85f;
+    public float cueRaisedDistanceScale = 0.82f;
     // Scale applied once the camera is fully lowered toward the cue. Lower
     // values bring the framing tighter to the cue ball and aiming line.
     [Range(0.1f, 1f)]
-    public float cueLoweredDistanceScale = 0.5f;
+    public float cueLoweredDistanceScale = 0.45f;
     // Bias used when lowering the camera to keep it hovering just above the cue
     // instead of drifting upward toward the player's face.
     [Range(0.1f, 1f)]
@@ -119,18 +119,18 @@ public class CueCamera : MonoBehaviour
 
     [Header("Broadcast view")]
     // Distance and height for the short-rail broadcast view used once a shot begins.
-    public float broadcastDistance = 0.97125f;
-    public float broadcastHeight = 0.5f;
+    public float broadcastDistance = 0.9f;
+    public float broadcastHeight = 0.46f;
     // Bounds that encompass the full playing surface including rails and pockets.
     public Bounds tableBounds = new Bounds(new Vector3(0f, 0.36f, 0f), new Vector3(1.64465f, 0.72f, 3.301325f));
     // Keep a small margin inside the camera frame so the rails never touch the
     // edge of the screen during broadcast shots.
     [Range(0f, 0.25f)]
-    public float broadcastSafeMargin = 0.05f;
+    public float broadcastSafeMargin = 0.035f;
     // Minimum and maximum camera offsets used while fitting the table inside the
     // broadcast frame. The solver expands toward the max until every corner is
     // visible.
-    public float broadcastMinDistance = 1.11f;
+    public float broadcastMinDistance = 1.02f;
     public float broadcastMaxDistance = 5.0875f;
     // Blend between the table centre and the active focus (cue ball or target)
     // when aiming the broadcast view. Keeps the play interesting while still


### PR DESCRIPTION
## Summary
- Bring the player-facing aim camera closer to the cloth by trimming default cue distances, heights, and scaling values.
- Move the broadcast short-rail view nearer to the table with reduced offsets and safe margin while preserving fit logic.
- Allow the general table camera to sit closer overall by tightening corner thresholds and pull-in amounts.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d298de4ac8329b696b49e34a7cf67)