### PR TITLE
Add Telegram PWA auto-update support

### DIFF
--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#0b0f1a" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />

--- a/webapp/public/manifest.webmanifest
+++ b/webapp/public/manifest.webmanifest
@@ -1,0 +1,26 @@
+{
+  "name": "TonPlaygram",
+  "short_name": "TonPlaygram",
+  "start_url": "/",
+  "display": "standalone",
+  "scope": "/",
+  "orientation": "portrait",
+  "background_color": "#0b0f1a",
+  "theme_color": "#0b0f1a",
+  "description": "Telegram-ready TonPlaygram games with instant updates.",
+  "icons": [
+    {
+      "src": "/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp",
+      "sizes": "192x192",
+      "type": "image/webp",
+      "purpose": "any"
+    },
+    {
+      "src": "/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp",
+      "sizes": "512x512",
+      "type": "image/webp",
+      "purpose": "any maskable"
+    }
+  ]
+}
+

--- a/webapp/public/service-worker.js
+++ b/webapp/public/service-worker.js
@@ -1,16 +1,84 @@
-// Simple service worker to ensure latest assets are served
-self.addEventListener('install', () => {
-  // Take control immediately after installation
+const CACHE_NAME = 'tonplaygram-cache-v1';
+const CORE_ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.webmanifest',
+  '/tonconnect-manifest.json',
+  '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(CORE_ASSETS)).catch(() => {})
+  );
   self.skipWaiting();
 });
 
-self.addEventListener('activate', (event) => {
-  // Become the active worker for all clients
-  event.waitUntil(self.clients.claim());
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    Promise.all([
+      caches.keys().then(cacheNames =>
+        Promise.all(cacheNames.filter(name => name !== CACHE_NAME).map(name => caches.delete(name)))
+      ),
+      self.clients.claim()
+    ])
+  );
 });
 
-self.addEventListener('fetch', (event) => {
-  // Always go to the network and avoid caches
-  event.respondWith(fetch(event.request, { cache: 'no-store' }));
+self.addEventListener('message', event => {
+  if (event.data?.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
+const networkFirst = async request => {
+  try {
+    const freshResponse = await fetch(request, { cache: 'no-store' });
+    const cache = await caches.open(CACHE_NAME);
+    cache.put(request, freshResponse.clone());
+    return freshResponse;
+  } catch (err) {
+    const cached = (await caches.match(request)) || (await caches.match('/'));
+    if (cached) return cached;
+    throw err;
+  }
+};
+
+const staleWhileRevalidate = async request => {
+  const cache = await caches.open(CACHE_NAME);
+  const cached = await cache.match(request);
+  const fetchPromise = fetch(request)
+    .then(response => {
+      cache.put(request, response.clone());
+      return response;
+    })
+    .catch(() => cached);
+
+  const response = cached || (await fetchPromise);
+  return response || fetch(request);
+};
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+
+  if (request.method !== 'GET') return;
+
+  const url = new URL(request.url);
+  const isSameOrigin = url.origin === self.location.origin;
+
+  if (request.mode === 'navigate') {
+    event.respondWith(networkFirst(request));
+    return;
+  }
+
+  if (isSameOrigin) {
+    const shouldCache = ['script', 'style', 'font', 'image'].includes(request.destination);
+    if (shouldCache) {
+      event.respondWith(staleWhileRevalidate(request));
+      return;
+    }
+  }
+
+  event.respondWith(fetch(request));
 });
 

--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -2,16 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
+import { registerTelegramServiceWorker } from './pwa/registerServiceWorker.js';
 
 // Prevent Telegram in-app browser swipe-down from closing the game
 if (window.Telegram?.WebApp?.disableVerticalSwipes) {
   window.Telegram.WebApp.disableVerticalSwipes();
 }
 
+// Register a Telegram-friendly service worker for instant updates
+registerTelegramServiceWorker();
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
 );
-
-// Service workers are disabled to avoid unexpected reloads that could interrupt gameplay

--- a/webapp/src/pwa/registerServiceWorker.js
+++ b/webapp/src/pwa/registerServiceWorker.js
@@ -1,0 +1,73 @@
+const TELEGRAM_ONLY = true;
+const REFRESH_FLAG_KEY = 'tonplaygram-sw-refreshed';
+
+function shouldRegisterForTelegram() {
+  if (!('serviceWorker' in navigator)) return false;
+  if (TELEGRAM_ONLY && !window.Telegram?.WebApp) return false;
+  return true;
+}
+
+function markRefreshed() {
+  sessionStorage.setItem(REFRESH_FLAG_KEY, '1');
+}
+
+function hasRefreshedAlready() {
+  return sessionStorage.getItem(REFRESH_FLAG_KEY) === '1';
+}
+
+function forceReloadOnceReady() {
+  if (hasRefreshedAlready()) return;
+  markRefreshed();
+  window.location.reload();
+}
+
+function wireUpdateFlow(registration, shouldReload) {
+  const pushToActive = worker => {
+    if (!worker) return;
+    worker.addEventListener('statechange', () => {
+      if (worker.state === 'installed') {
+        worker.postMessage({ type: 'SKIP_WAITING' });
+      }
+    });
+  };
+
+  if (registration.waiting) {
+    registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+  }
+
+  if (registration.installing) {
+    pushToActive(registration.installing);
+  }
+
+  registration.addEventListener('updatefound', () => {
+    pushToActive(registration.installing);
+  });
+
+  if (shouldReload) {
+    navigator.serviceWorker.addEventListener('controllerchange', forceReloadOnceReady);
+  }
+}
+
+export async function registerTelegramServiceWorker() {
+  if (!shouldRegisterForTelegram()) return;
+
+  try {
+    const hadController = Boolean(navigator.serviceWorker.controller);
+    const registration = await navigator.serviceWorker.register('/service-worker.js', {
+      scope: '/'
+    });
+
+    wireUpdateFlow(registration, hadController);
+    registration.update();
+
+    // Refresh in-session to pick up any new build without prompting the user
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        registration.update();
+      }
+    });
+  } catch (err) {
+    console.error('Service worker registration failed', err);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add Telegram-focused PWA manifest and theme metadata
- register a service worker in the web client with automatic update and reload flow
- enhance the service worker to cache core assets while fetching fresh builds for Telegram users

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d43817bf48329a42cdcf8eecb0c03)