### PR TITLE
Protect chess turn handling and user piece control

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1045,13 +1045,28 @@ io.on('connection', (socket) => {
   });
 
   socket.on('chessMove', ({ tableId, move }) => {
+    const playerId = socket.data?.playerId;
     if (!tableId || !move) return;
+    if (!ensureRegistered(socket, playerId)) return;
+    const table = tableMap.get(tableId);
+    if (!table || table.gameType !== 'chess') return;
+    const player = table.players.find((p) => String(p.id) === String(playerId));
+    if (!player) return;
+    const state = getChessState(tableId);
+    const isPlayersTurnWhite = player.side === 'white';
+    if (state.turnWhite !== isPlayersTurnWhite) {
+      socket.emit('errorMessage', 'not_your_turn');
+      return;
+    }
+    const nextTurnWhite = !state.turnWhite;
     const next = updateChessState(tableId, {
-      fen: move.fen || CHESS_START_FEN,
-      turnWhite: typeof move.turnWhite === 'boolean' ? move.turnWhite : true,
+      fen: move.fen || state.fen || CHESS_START_FEN,
+      turnWhite: nextTurnWhite,
       lastMove: move.lastMove || null
     });
-    socket.to(tableId).emit('chessMove', { tableId, ...next });
+    const nextPlayer = table.players.find((p) => p.side === (nextTurnWhite ? 'white' : 'black'));
+    table.currentTurn = nextPlayer?.id || null;
+    io.to(tableId).emit('chessMove', { tableId, ...next });
   });
   socket.on('watchRoom', async ({ roomId }) => {
     if (!roomId) return;

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -5092,6 +5092,7 @@ function Chess3D({
     requestSync: () => {},
     status: 'connecting'
   });
+  const playerSideRef = useRef(normalizedInitialSide);
   onlineRef.current.enabled = Boolean(accountId);
   const rafRef = useRef(0);
   const timerRef = useRef(null);
@@ -5241,6 +5242,7 @@ function Chess3D({
         players.find((p) => String(p.id) === String(accountId))?.side ||
         (meIndex === 0 ? 'white' : 'black');
       onlineRef.current.side = mySide;
+      playerSideRef.current = mySide;
       onlineRef.current.status = 'started';
       setOnlineStatus('starting');
       socket.emit('joinChessRoom', { tableId: startedId, accountId });
@@ -7251,6 +7253,8 @@ function Chess3D({
         resetSelectedMeshElevation();
         return ((sel = null), clearHighlights());
       }
+      const playerIsWhite = playerSideRef.current === 'white';
+      if (!force && p.w !== playerIsWhite) return; // opponent piece
       if (!force && p.w !== uiRef.current.turnWhite) return; // not your turn
 
       resetSelectedMeshElevation();


### PR DESCRIPTION
## Summary
- enforce server-side chess move validation against player turn and table membership
- keep chess turn tracking in sync after moves and broadcast validated state
- restrict client-side selection to the local player's pieces and capture assigned side when a game starts

## Testing
- npm test -- --runInBand *(fails: Jest config roots include missing /tests directory)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d4bc319f88329807774f39f75191a)