### PR TITLE
Align Snooker Club rails with Pool Royale layout

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -752,8 +752,10 @@ const ENABLE_CUE_GALLERY = false;
 const ENABLE_TRIPOD_CAMERAS = false;
 const TABLE_BASE_SCALE = 1.17;
 const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION; // shrink snooker build to Pool Royale footprint without altering proportions
+// Match the Pool Royale outer width so wooden rails and chrome fascias sit in the
+// exact same positions between both builds.
 const TABLE = {
-  W: 72 * TABLE_SCALE,
+  W: 66 * TABLE_SCALE,
   H: 132 * TABLE_SCALE,
   THICK: 1.8 * TABLE_SCALE,
   WALL: 2.6 * TABLE_SCALE


### PR DESCRIPTION
## Summary
- align the Snooker Club table width with the Pool Royale footprint so wooden rails and chrome fascias line up identically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d536ebeb883299acc17810b1cff19)