### PR TITLE
Sync multiplayer snake dice rolls with client results

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -265,7 +265,7 @@ export class GameRoom {
     }
   }
 
-  rollDice(socket, value) {
+  rollDice(socket, value, diceValues) {
     if (this.status !== 'playing') return;
     if (this.turnTimer) {
       clearTimeout(this.turnTimer);
@@ -289,7 +289,9 @@ export class GameRoom {
     const prevPositions = this.players.map((p) => p.position);
 
     if (this.gameType === 'snake') {
-      const result = this.game.rollDice(value != null ? [value] : undefined);
+      const result = this.game.rollDice(
+        diceValues ? diceValues : value != null ? [value] : undefined
+      );
       if (!result) return;
 
       const total = result.dice.reduce((a, b) => a + b, 0);
@@ -524,10 +526,10 @@ export class GameRoomManager {
     return result;
   }
 
-  async rollDice(socket) {
+  async rollDice(socket, diceValues) {
     const room = this.findRoomBySocket(socket.id);
     if (room) {
-      room.rollDice(socket);
+      room.rollDice(socket, undefined, diceValues);
       await this.saveRoom(room);
     }
   }

--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -40,9 +40,16 @@ export class SnakeGame {
     const player = this.players[this.currentTurn];
     if (!player) return null;
 
-    const dice = Array.isArray(diceValues)
-      ? diceValues.map((v) => Math.max(1, Math.min(6, Math.floor(v))))
-      : [Math.floor(Math.random() * 6) + 1];
+    const diceCount = player.diceCount || 1;
+    const parsed = Array.isArray(diceValues)
+      ? diceValues
+          .filter((v) => Number.isFinite(v))
+          .slice(0, Math.max(1, diceCount))
+          .map((v) => Math.max(1, Math.min(6, Math.floor(v))))
+      : [];
+    const dice = parsed.length
+      ? parsed
+      : Array.from({ length: Math.max(1, diceCount) }, () => Math.floor(Math.random() * 6) + 1);
     const total = dice.reduce((a, b) => a + b, 0);
     const rolledSix = dice.includes(6);
     const doubleSix = dice.length === 2 && dice[0] === 6 && dice[1] === 6;

--- a/bot/server.js
+++ b/bot/server.js
@@ -1088,7 +1088,13 @@ io.on('connection', (socket) => {
   });
 
   socket.on('rollDice', async (payload = {}) => {
-    const { accountId, tableId } = payload;
+    const { accountId, tableId, values: payloadValues } = payload;
+    const diceValues = Array.isArray(payloadValues)
+      ? payloadValues
+          .filter((v) => Number.isFinite(v))
+          .map((v) => Math.max(1, Math.min(6, Math.floor(v))))
+      : undefined;
+
     if (accountId && tableId && tableMap.has(tableId)) {
       if (!ensureRegistered(socket, accountId)) return;
       if (isRateLimited(socket, 'rollDice', rollRateLimitMs)) {
@@ -1100,11 +1106,13 @@ io.on('connection', (socket) => {
       }
       const player = table.players.find((p) => p.id === accountId);
       if (!player) return;
-      const dice = Math.floor(Math.random() * 6) + 1;
+      const diceArray = diceValues?.length ? diceValues.slice(0, 2) : null;
+      const dice = diceArray?.reduce((a, b) => a + b, 0) || Math.floor(Math.random() * 6) + 1;
       player.position += dice;
       io.to(tableId).emit('diceRolled', {
         accountId,
         dice,
+        values: diceArray || undefined,
         newPosition: player.position
       });
       const idx = table.players.findIndex((p) => p.id === accountId);
@@ -1123,7 +1131,7 @@ io.on('connection', (socket) => {
     if (!current || current.socketId !== socket.id) {
       return socket.emit('errorMessage', 'Not your turn');
     }
-    await gameManager.rollDice(socket);
+    await gameManager.rollDice(socket, diceValues);
   });
 
   socket.on('invite1v1', async (payload, cb) => {

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -87,14 +87,14 @@ export default function DiceRoller({
       if (count >= iterations) {
         clearInterval(id);
         // allow the final face to be visible before stopping
-        setTimeout(() => {
-          setRolling(false);
-          startValuesRef.current = results;
-          onRollEnd && onRollEnd(results);
-          if (emitRollEvent) {
-            socket.emit('rollDice');
-          }
-        }, tick);
+          setTimeout(() => {
+            setRolling(false);
+            startValuesRef.current = results;
+            onRollEnd && onRollEnd(results);
+            if (emitRollEvent) {
+              socket.emit('rollDice', { values: results });
+            }
+          }, tick);
       }
     }, tick);
   };


### PR DESCRIPTION
## Summary
- respect each player's dice count when rolling and sanitize any client-provided dice values
- propagate dice arrays through the server/game manager so multiplayer snake games use the player's roll
- emit rolled dice values from the client to keep online animations and moves in sync

## Testing
- npm test (fails: Directory /workspace/TonPlaygramWebApp/tests in the roots[0] option was not found)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d5c42c6c48329a54f4d9c12012b5a)