### PR TITLE
Add Pool Royale cosmetic defaults and store gating

### DIFF
--- a/webapp/src/config/poolRoyaleStoreItems.js
+++ b/webapp/src/config/poolRoyaleStoreItems.js
@@ -1,0 +1,121 @@
+export const POOL_ROYALE_STORE_ITEMS = [
+  {
+    id: 'rusticSplit',
+    type: 'tableFinish',
+    name: 'Pearl Cream Finish',
+    description: 'Matte pearl rails with bright cream legs and trim.',
+    price: '22 TON'
+  },
+  {
+    id: 'plankStudio',
+    type: 'tableFinish',
+    name: 'Plank Studio Finish',
+    description: 'Gallery-gray rails with a darker base for a studio look.',
+    price: '18 TON'
+  },
+  {
+    id: 'weatheredGrey',
+    type: 'tableFinish',
+    name: 'Weathered Grey Finish',
+    description: 'Washed grey rails with brushed chrome trim accents.',
+    price: '18 TON'
+  },
+  {
+    id: 'jetBlackCarbon',
+    type: 'tableFinish',
+    name: 'Jet Black Carbon Finish',
+    description: 'Carbon fibre fascia with smoked trim and stealth rails.',
+    price: '26 TON'
+  },
+  {
+    id: 'chrome',
+    type: 'chromeColor',
+    name: 'Chrome Plates',
+    description: 'High-gloss chrome fascia around every pocket.',
+    price: '12 TON'
+  },
+  {
+    id: 'graphite',
+    type: 'clothColor',
+    name: 'Arcadia Graphite Cloth',
+    description: 'Tournament graphite cloth with subtle sheen.',
+    price: '9 TON'
+  },
+  {
+    id: 'arcticBlue',
+    type: 'clothColor',
+    name: 'Arctic Blue Cloth',
+    description: 'Vibrant blue tour-grade cloth with cool highlights.',
+    price: '9 TON'
+  },
+  {
+    id: 'chrome',
+    type: 'railMarkerColor',
+    name: 'Chrome Diamonds',
+    description: 'Cool-toned diamonds that mirror the chrome fascia.',
+    price: '6 TON'
+  },
+  {
+    id: 'pearl',
+    type: 'railMarkerColor',
+    name: 'Pearl Diamonds',
+    description: 'Soft pearl markers that glow against darker cloths.',
+    price: '6 TON'
+  },
+  {
+    id: 'circle',
+    type: 'railMarkerShape',
+    name: 'Circle Rail Markers',
+    description: 'Rounded markers for a modern rail look.',
+    price: '4 TON'
+  },
+  {
+    id: 'redwood-ember',
+    type: 'cueStyle',
+    name: 'Redwood Ember Cue',
+    description: 'Warm redwood butt with bright ember grain.',
+    price: '10 TON'
+  },
+  {
+    id: 'wenge-nightfall',
+    type: 'cueStyle',
+    name: 'Wenge Nightfall Cue',
+    description: 'Dark wenge cue with high-contrast figuring.',
+    price: '10 TON'
+  },
+  {
+    id: 'mahogany-heritage',
+    type: 'cueStyle',
+    name: 'Mahogany Heritage Cue',
+    description: 'Classic mahogany tone with heritage gloss.',
+    price: '10 TON'
+  },
+  {
+    id: 'walnut-satin',
+    type: 'cueStyle',
+    name: 'Walnut Satin Cue',
+    description: 'Balanced walnut cue with satin depth.',
+    price: '10 TON'
+  },
+  {
+    id: 'carbon-matrix',
+    type: 'cueStyle',
+    name: 'Carbon Matrix Cue',
+    description: 'Stealth carbon fibre cue with metallic flecks.',
+    price: '12 TON'
+  },
+  {
+    id: 'maple-horizon',
+    type: 'cueStyle',
+    name: 'Maple Horizon Cue',
+    description: 'Light maple cue with crisp horizon grain.',
+    price: '8 TON'
+  },
+  {
+    id: 'graphite-aurora',
+    type: 'cueStyle',
+    name: 'Graphite Aurora Cue',
+    description: 'Graphite weave cue with aurora tint.',
+    price: '12 TON'
+  }
+];

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -36,6 +36,12 @@ import {
   disposeMaterialWithWood,
 } from '../../utils/woodMaterials.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
+import {
+  DEFAULT_POOL_ROYALE_OWNERSHIP,
+  POOL_ROYALE_OWNERSHIP_STORAGE_KEY,
+  filterOwnedOptions,
+  loadPoolRoyaleOwnership
+} from '../../utils/poolRoyaleEntitlements.js';
 
 function safePolygonUnion(...parts) {
   const valid = parts.filter(Boolean);
@@ -743,6 +749,7 @@ const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
 const CUE_STYLE_STORAGE_KEY = 'tonplayCueStyleIndex';
+const DEFAULT_CUE_STYLE_INDEX = 1;
 const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const CLOTH_COLOR_STORAGE_KEY = 'poolRoyaleClothColor';
 const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
@@ -1700,7 +1707,7 @@ const DEFAULT_WOOD_PRESET_ID = 'walnut';
 // rails as a plain material without any texture maps.
 const WOOD_TEXTURES_ENABLED = false;
 
-const DEFAULT_TABLE_FINISH_ID = 'rusticSplit';
+const DEFAULT_TABLE_FINISH_ID = 'charredTimber';
 
 const POOL_ROYALE_WOOD_PRESET_FOR_FINISH = Object.freeze({
   rusticSplit: 'walnut',
@@ -2072,7 +2079,7 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
   ].filter(Boolean)
 );
 
-const DEFAULT_CHROME_COLOR_ID = 'chrome';
+const DEFAULT_CHROME_COLOR_ID = 'gold';
 const CHROME_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
@@ -2191,7 +2198,7 @@ const RAIL_MARKER_SHAPE_OPTIONS = Object.freeze([
 ]);
 const RAIL_MARKER_THICKNESS = TABLE.THICK * 0.06;
 
-const DEFAULT_RAIL_MARKER_COLOR_ID = 'chrome';
+const DEFAULT_RAIL_MARKER_COLOR_ID = 'gold';
 const RAIL_MARKER_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
@@ -8132,6 +8139,20 @@ function PoolRoyaleGame({
     [tableSizeKey]
   );
   const responsiveTableSize = useResponsiveTableSize(activeTableSize);
+  const [poolRoyaleOwnership, setPoolRoyaleOwnership] = useState(() =>
+    loadPoolRoyaleOwnership()
+  );
+  useEffect(() => {
+    setPoolRoyaleOwnership(loadPoolRoyaleOwnership());
+    if (typeof window === 'undefined') return undefined;
+    const handleStorage = (event) => {
+      if (event.key === POOL_ROYALE_OWNERSHIP_STORAGE_KEY) {
+        setPoolRoyaleOwnership(loadPoolRoyaleOwnership());
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
   const [tableFinishId, setTableFinishId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(TABLE_FINISH_STORAGE_KEY);
@@ -8187,6 +8208,52 @@ function PoolRoyaleGame({
     }
     return DEFAULT_CHROME_COLOR_ID;
   });
+  const availableTableFinishes = useMemo(
+    () => filterOwnedOptions(TABLE_FINISH_OPTIONS, 'tableFinish', poolRoyaleOwnership),
+    [poolRoyaleOwnership]
+  );
+  const availableChromeOptions = useMemo(
+    () => filterOwnedOptions(CHROME_COLOR_OPTIONS, 'chromeColor', poolRoyaleOwnership),
+    [poolRoyaleOwnership]
+  );
+  const availableClothOptions = useMemo(
+    () => filterOwnedOptions(CLOTH_COLOR_OPTIONS, 'clothColor', poolRoyaleOwnership),
+    [poolRoyaleOwnership]
+  );
+  const availableRailMarkerColors = useMemo(
+    () =>
+      filterOwnedOptions(
+        RAIL_MARKER_COLOR_OPTIONS,
+        'railMarkerColor',
+        poolRoyaleOwnership
+      ),
+    [poolRoyaleOwnership]
+  );
+  const availableRailMarkerShapes = useMemo(
+    () =>
+      filterOwnedOptions(
+        RAIL_MARKER_SHAPE_OPTIONS,
+        'railMarkerShape',
+        poolRoyaleOwnership
+      ),
+    [poolRoyaleOwnership]
+  );
+  const availableCueStyleIndices = useMemo(() => {
+    const ownedIds = new Set(
+      poolRoyaleOwnership?.cueStyle ?? DEFAULT_POOL_ROYALE_OWNERSHIP.cueStyle
+    );
+    return CUE_STYLE_PRESETS.map((preset, index) =>
+      ownedIds.has(preset.id) ? index : null
+    ).filter((index) => index != null);
+  }, [poolRoyaleOwnership]);
+  const availableCueStyles = useMemo(
+    () =>
+      availableCueStyleIndices.map((presetIndex) => ({
+        ...CUE_STYLE_PRESETS[presetIndex],
+        presetIndex
+      })),
+    [availableCueStyleIndices]
+  );
   const [frameRateId, setFrameRateId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(FRAME_RATE_STORAGE_KEY);
@@ -8200,6 +8267,46 @@ function PoolRoyaleGame({
     }
     return DEFAULT_FRAME_RATE_ID;
   });
+  useEffect(() => {
+    if (!availableTableFinishes.some((option) => option.id === tableFinishId)) {
+      const fallback = availableTableFinishes[0]?.id ?? DEFAULT_TABLE_FINISH_ID;
+      setTableFinishId(fallback);
+    }
+  }, [availableTableFinishes, tableFinishId]);
+  useEffect(() => {
+    if (!availableChromeOptions.some((option) => option.id === chromeColorId)) {
+      const fallback = availableChromeOptions[0]?.id ?? DEFAULT_CHROME_COLOR_ID;
+      setChromeColorId(fallback);
+    }
+  }, [availableChromeOptions, chromeColorId]);
+  useEffect(() => {
+    if (!availableClothOptions.some((option) => option.id === clothColorId)) {
+      const fallback = availableClothOptions[0]?.id ?? DEFAULT_CLOTH_COLOR_ID;
+      setClothColorId(fallback);
+    }
+  }, [availableClothOptions, clothColorId]);
+  useEffect(() => {
+    if (!availableRailMarkerColors.some((option) => option.id === railMarkerColorId)) {
+      const fallback = availableRailMarkerColors[0]?.id ?? DEFAULT_RAIL_MARKER_COLOR_ID;
+      setRailMarkerColorId(fallback);
+    }
+  }, [availableRailMarkerColors, railMarkerColorId]);
+  useEffect(() => {
+    if (!availableRailMarkerShapes.some((option) => option.id === railMarkerShapeId)) {
+      const fallback = availableRailMarkerShapes[0]?.id ?? DEFAULT_RAIL_MARKER_SHAPE;
+      setRailMarkerShapeId(fallback);
+    }
+  }, [availableRailMarkerShapes, railMarkerShapeId]);
+  useEffect(() => {
+    if (!availableCueStyleIndices.includes(cueStyleIndex)) {
+      const fallback =
+        availableCueStyleIndices[0] ?? availableCueStyleIndices[availableCueStyleIndices.length - 1];
+      if (fallback != null) {
+        setCueStyleIndex(fallback);
+        cueStyleIndexRef.current = fallback;
+      }
+    }
+  }, [availableCueStyleIndices, cueStyleIndex]);
   const [broadcastSystemId, setBroadcastSystemId] = useState(() => DEFAULT_BROADCAST_SYSTEM_ID);
   const activeFrameRateOption = useMemo(
     () =>
@@ -8212,12 +8319,18 @@ function PoolRoyaleGame({
     [broadcastSystemId]
   );
   const activeChromeOption = useMemo(
-    () => CHROME_COLOR_OPTIONS.find((opt) => opt.id === chromeColorId) ?? CHROME_COLOR_OPTIONS[0],
-    [chromeColorId]
+    () =>
+      availableChromeOptions.find((opt) => opt.id === chromeColorId) ??
+      availableChromeOptions[0] ??
+      CHROME_COLOR_OPTIONS[0],
+    [availableChromeOptions, chromeColorId]
   );
   const activeClothOption = useMemo(
-    () => CLOTH_COLOR_OPTIONS.find((opt) => opt.id === clothColorId) ?? CLOTH_COLOR_OPTIONS[0],
-    [clothColorId]
+    () =>
+      availableClothOptions.find((opt) => opt.id === clothColorId) ??
+      availableClothOptions[0] ??
+      CLOTH_COLOR_OPTIONS[0],
+    [availableClothOptions, clothColorId]
   );
   const activePocketLinerOption = useMemo(
     () => POCKET_LINER_OPTIONS.find((opt) => opt?.id === pocketLinerId) ?? POCKET_LINER_OPTIONS[0],
@@ -8384,7 +8497,7 @@ function PoolRoyaleGame({
         }
       }
     }
-    return 0;
+    return DEFAULT_CUE_STYLE_INDEX;
   });
   const cueStyleIndexRef = useRef(cueStyleIndex);
   const cueRackGroupsRef = useRef([]);
@@ -9167,10 +9280,11 @@ function PoolRoyaleGame({
       if (!charged) return;
       const paletteLength = CUE_RACK_PALETTE.length || 1;
       const normalized = ((index % paletteLength) + paletteLength) % paletteLength;
+      if (!availableCueStyleIndices.includes(normalized)) return;
       applySelectedCueStyle(normalized);
       setCueStyleIndex(normalized);
     },
-    [applySelectedCueStyle, ensureCueFeePaid]
+    [applySelectedCueStyle, availableCueStyleIndices, ensureCueFeePaid]
   );
 
   const playCueHit = useCallback((vol = 1) => {
@@ -16594,7 +16708,7 @@ function PoolRoyaleGame({
                   Table Finish
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {TABLE_FINISH_OPTIONS.map((option) => {
+                  {availableTableFinishes.map((option) => {
                     const active = option.id === tableFinishId;
                     return (
                       <button
@@ -16619,7 +16733,7 @@ function PoolRoyaleGame({
                   Chrome Plates
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {CHROME_COLOR_OPTIONS.map((option) => {
+                  {availableChromeOptions.map((option) => {
                     const active = option.id === chromeColorId;
                     return (
                       <button
@@ -16651,13 +16765,13 @@ function PoolRoyaleGame({
                   Cue Styles
                 </h3>
                 <div className="mt-2 grid grid-cols-2 gap-2">
-                  {CUE_STYLE_PRESETS.map((preset, index) => {
-                    const active = cueStyleIndex === index;
+                  {availableCueStyles.map((preset) => {
+                    const active = cueStyleIndex === preset.presetIndex;
                     return (
                       <button
                         key={preset.id}
                         type="button"
-                        onClick={() => selectCueStyleFromMenu(index)}
+                        onClick={() => selectCueStyleFromMenu(preset.presetIndex)}
                         aria-pressed={active}
                         className={`rounded-xl px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.2em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
                           active
@@ -16671,13 +16785,13 @@ function PoolRoyaleGame({
                   })}
                 </div>
               </div>
-              {CLOTH_COLOR_OPTIONS.length > 1 ? (
+              {availableClothOptions.length > 0 ? (
                 <div>
                   <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                     Cloth Color
                   </h3>
                   <div className="mt-2 flex flex-wrap gap-2">
-                    {CLOTH_COLOR_OPTIONS.map((option) => {
+                    {availableClothOptions.map((option) => {
                       const active = option.id === clothColorId;
                       return (
                         <button
@@ -16710,7 +16824,7 @@ function PoolRoyaleGame({
                   Rail Markers
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {RAIL_MARKER_SHAPE_OPTIONS.map((option) => {
+                  {availableRailMarkerShapes.map((option) => {
                     const active = option.id === railMarkerShapeId;
                     return (
                       <button
@@ -16730,7 +16844,7 @@ function PoolRoyaleGame({
                   })}
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {RAIL_MARKER_COLOR_OPTIONS.map((option) => {
+                  {availableRailMarkerColors.map((option) => {
                     const active = option.id === railMarkerColorId;
                     return (
                       <button

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1,12 +1,123 @@
+import { useMemo, useState } from 'react';
+import { POOL_ROYALE_STORE_ITEMS } from '../config/poolRoyaleStoreItems.js';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
+import {
+  hasPoolRoyaleOwnership,
+  loadPoolRoyaleOwnership,
+  mergePoolRoyaleOwnership,
+  persistPoolRoyaleOwnership
+} from '../utils/poolRoyaleEntitlements.js';
+
+const LABELS = {
+  tableFinish: 'Table Finishes',
+  chromeColor: 'Chrome Plates',
+  clothColor: 'Cloth Colors',
+  railMarkerColor: 'Rail Marker Colors',
+  railMarkerShape: 'Rail Marker Shapes',
+  cueStyle: 'Cue Styles'
+};
 
 export default function Store() {
   useTelegramBackButton();
+  const [ownership, setOwnership] = useState(() => loadPoolRoyaleOwnership());
+
+  const groupedItems = useMemo(
+    () =>
+      POOL_ROYALE_STORE_ITEMS.reduce((acc, item) => {
+        if (!acc[item.type]) acc[item.type] = [];
+        acc[item.type].push(item);
+        return acc;
+      }, {}),
+    []
+  );
+
+  const handlePurchase = (item) => {
+    const current = ownership[item.type] ?? [];
+    if (current.includes(item.id)) return;
+    const updated = mergePoolRoyaleOwnership({
+      ...ownership,
+      [item.type]: [...current, item.id]
+    });
+    const persisted = persistPoolRoyaleOwnership(updated);
+    setOwnership(persisted);
+  };
 
   return (
-    <div className="relative p-4 space-y-4 text-text flex flex-col items-center">
-      <h2 className="text-xl font-bold">Store</h2>
-      <p className="text-subtext text-sm">No bundles are currently available.</p>
+    <div className="relative p-4 space-y-6 text-text flex flex-col items-center">
+      <div className="text-center space-y-2">
+        <h2 className="text-xl font-bold">Store</h2>
+        <p className="text-subtext text-sm">
+          Stock up on Pool Royale cosmetics and unlock them in your table setup.
+        </p>
+      </div>
+
+      <div className="w-full max-w-3xl space-y-5">
+        <div className="rounded-2xl border border-emerald-500/40 bg-emerald-900/15 p-4 shadow-[0_12px_32px_rgba(0,0,0,0.35)]">
+          <div className="flex items-center justify-between flex-wrap gap-2">
+            <div>
+              <p className="text-[11px] uppercase tracking-[0.25em] text-emerald-200/80">
+                Pool Royale Sector
+              </p>
+              <h3 className="text-lg font-semibold text-white">Customization Vault</h3>
+            </div>
+            <span className="rounded-full border border-emerald-300/60 bg-emerald-300/10 px-3 py-1 text-xs text-emerald-100">
+              NFTs unlock in-game
+            </span>
+          </div>
+          <div className="mt-4 space-y-4">
+            {Object.entries(groupedItems).map(([type, items]) => (
+              <div key={type} className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <h4 className="text-sm font-semibold text-white">
+                    {LABELS[type] ?? type}
+                  </h4>
+                  <span className="text-[11px] uppercase tracking-[0.18em] text-emerald-200/70">
+                    {items.length} options
+                  </span>
+                </div>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  {items.map((item) => {
+                    const owned = hasPoolRoyaleOwnership(item.type, item.id, ownership);
+                    return (
+                      <div
+                        key={`${item.type}-${item.id}`}
+                        className="flex flex-col justify-between gap-3 rounded-xl border border-white/10 bg-white/5 p-3 text-left shadow-inner shadow-black/30"
+                      >
+                        <div className="space-y-1">
+                          <div className="flex items-center justify-between gap-2">
+                            <p className="font-semibold text-white">{item.name}</p>
+                            {owned ? (
+                              <span className="rounded-full bg-emerald-500/20 px-2 py-0.5 text-[11px] font-semibold text-emerald-200">
+                                Owned
+                              </span>
+                            ) : null}
+                          </div>
+                          <p className="text-xs text-white/70">{item.description}</p>
+                        </div>
+                        <div className="flex items-center justify-between text-sm text-emerald-100">
+                          <span className="font-semibold">{item.price}</span>
+                          <button
+                            type="button"
+                            onClick={() => handlePurchase(item)}
+                            disabled={owned}
+                            className={`rounded-full px-3 py-1 font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                              owned
+                                ? 'cursor-not-allowed border border-white/20 bg-white/10 text-white/70'
+                                : 'border border-emerald-300 bg-emerald-400/20 text-emerald-100 hover:bg-emerald-300/30'
+                            }`}
+                          >
+                            {owned ? 'Added' : 'Purchase'}
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/webapp/src/utils/poolRoyaleEntitlements.js
+++ b/webapp/src/utils/poolRoyaleEntitlements.js
@@ -1,0 +1,71 @@
+export const POOL_ROYALE_OWNERSHIP_STORAGE_KEY = 'poolRoyaleOwnedItems';
+
+export const DEFAULT_POOL_ROYALE_OWNERSHIP = Object.freeze({
+  tableFinish: Object.freeze(['charredTimber']),
+  chromeColor: Object.freeze(['gold']),
+  clothColor: Object.freeze(['freshGreen']),
+  railMarkerColor: Object.freeze(['gold']),
+  railMarkerShape: Object.freeze(['diamond']),
+  cueStyle: Object.freeze(['birch-frost'])
+});
+
+const normalizeIds = (value) => {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry) => typeof entry === 'string' && entry.trim().length > 0);
+};
+
+const createOwnership = (raw = {}) => {
+  const merged = {};
+  for (const key of Object.keys(DEFAULT_POOL_ROYALE_OWNERSHIP)) {
+    const baseline = Array.from(DEFAULT_POOL_ROYALE_OWNERSHIP[key]);
+    const extras = normalizeIds(raw?.[key]);
+    merged[key] = Array.from(new Set([...baseline, ...extras]));
+  }
+  return merged;
+};
+
+export function mergePoolRoyaleOwnership(raw) {
+  return createOwnership(raw);
+}
+
+export function loadPoolRoyaleOwnership() {
+  if (typeof window === 'undefined') {
+    return createOwnership();
+  }
+  try {
+    const stored = window.localStorage.getItem(POOL_ROYALE_OWNERSHIP_STORAGE_KEY);
+    if (!stored) return createOwnership();
+    const parsed = JSON.parse(stored);
+    return createOwnership(parsed);
+  } catch (err) {
+    console.warn('Failed to load Pool Royale ownership', err);
+    return createOwnership();
+  }
+}
+
+export function persistPoolRoyaleOwnership(nextOwnership) {
+  if (typeof window === 'undefined') {
+    return createOwnership(nextOwnership);
+  }
+  const merged = createOwnership(nextOwnership);
+  try {
+    window.localStorage.setItem(
+      POOL_ROYALE_OWNERSHIP_STORAGE_KEY,
+      JSON.stringify(merged)
+    );
+  } catch (err) {
+    console.warn('Failed to persist Pool Royale ownership', err);
+  }
+  return merged;
+}
+
+export function filterOwnedOptions(options, type, ownership) {
+  const owned = new Set((ownership?.[type] ?? DEFAULT_POOL_ROYALE_OWNERSHIP[type]) || []);
+  return options.filter((option) => owned.has(option.id));
+}
+
+export function hasPoolRoyaleOwnership(type, id, ownership) {
+  if (!id || !type) return false;
+  const ownedList = ownership?.[type] ?? DEFAULT_POOL_ROYALE_OWNERSHIP[type];
+  return Array.isArray(ownedList) && ownedList.includes(id);
+}


### PR DESCRIPTION
## Summary
- set Pool Royale defaults to charred timber table finish, gold chrome/rail markers, Tour Green cloth, and Birch Frost cue
- gate table setup options behind Pool Royale ownership entitlements loaded from local storage
- add a Pool Royale store catalog with purchase buttons for unlockable finishes, cloths, chrome, rail markers, and cues

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d590d0fec8329894d6c5b8e0ee247)