### PR TITLE
Gate Pool Royale cosmetics behind store unlocks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -36,6 +36,11 @@ import {
   disposeMaterialWithWood,
 } from '../../utils/woodMaterials.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
+import {
+  POOL_ROYALE_INVENTORY_STORAGE_KEY,
+  hasPoolRoyaleUnlock,
+  loadPoolRoyaleInventory,
+} from '../../utils/poolRoyaleInventory.js';
 
 function safePolygonUnion(...parts) {
   const valid = parts.filter(Boolean);
@@ -1700,7 +1705,7 @@ const DEFAULT_WOOD_PRESET_ID = 'walnut';
 // rails as a plain material without any texture maps.
 const WOOD_TEXTURES_ENABLED = false;
 
-const DEFAULT_TABLE_FINISH_ID = 'rusticSplit';
+const DEFAULT_TABLE_FINISH_ID = 'charredTimber';
 
 const POOL_ROYALE_WOOD_PRESET_FOR_FINISH = Object.freeze({
   rusticSplit: 'walnut',
@@ -2072,7 +2077,7 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
   ].filter(Boolean)
 );
 
-const DEFAULT_CHROME_COLOR_ID = 'chrome';
+const DEFAULT_CHROME_COLOR_ID = 'gold';
 const CHROME_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
@@ -2184,6 +2189,12 @@ const CLOTH_COLOR_OPTIONS = Object.freeze([
   }
 ]);
 
+const DEFAULT_CUE_STYLE_ID = 'birch-frost';
+const DEFAULT_CUE_STYLE_INDEX = Math.max(
+  0,
+  CUE_STYLE_PRESETS.findIndex((preset) => preset.id === DEFAULT_CUE_STYLE_ID)
+);
+
 const DEFAULT_RAIL_MARKER_SHAPE = 'diamond';
 const RAIL_MARKER_SHAPE_OPTIONS = Object.freeze([
   { id: 'diamond', label: 'Diamonds' },
@@ -2191,7 +2202,7 @@ const RAIL_MARKER_SHAPE_OPTIONS = Object.freeze([
 ]);
 const RAIL_MARKER_THICKNESS = TABLE.THICK * 0.06;
 
-const DEFAULT_RAIL_MARKER_COLOR_ID = 'chrome';
+const DEFAULT_RAIL_MARKER_COLOR_ID = 'gold';
 const RAIL_MARKER_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
@@ -8132,6 +8143,7 @@ function PoolRoyaleGame({
     [tableSizeKey]
   );
   const responsiveTableSize = useResponsiveTableSize(activeTableSize);
+  const [poolInventory, setPoolInventory] = useState(() => loadPoolRoyaleInventory());
   const [tableFinishId, setTableFinishId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(TABLE_FINISH_STORAGE_KEY);
@@ -8187,6 +8199,16 @@ function PoolRoyaleGame({
     }
     return DEFAULT_CHROME_COLOR_ID;
   });
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const handleInventoryUpdate = (event) => {
+      if (!event || event.key === null || event.key === POOL_ROYALE_INVENTORY_STORAGE_KEY) {
+        setPoolInventory(loadPoolRoyaleInventory());
+      }
+    };
+    window.addEventListener('storage', handleInventoryUpdate);
+    return () => window.removeEventListener('storage', handleInventoryUpdate);
+  }, []);
   const [frameRateId, setFrameRateId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(FRAME_RATE_STORAGE_KEY);
@@ -8201,6 +8223,88 @@ function PoolRoyaleGame({
     return DEFAULT_FRAME_RATE_ID;
   });
   const [broadcastSystemId, setBroadcastSystemId] = useState(() => DEFAULT_BROADCAST_SYSTEM_ID);
+  const availableTableFinishes = useMemo(
+    () =>
+      TABLE_FINISH_OPTIONS.filter((option) =>
+        hasPoolRoyaleUnlock(poolInventory, 'finishes', option.id)
+      ),
+    [poolInventory]
+  );
+  const availableChromeOptions = useMemo(
+    () =>
+      CHROME_COLOR_OPTIONS.filter((option) =>
+        hasPoolRoyaleUnlock(poolInventory, 'chromeColors', option.id)
+      ),
+    [poolInventory]
+  );
+  const availableClothOptions = useMemo(
+    () =>
+      CLOTH_COLOR_OPTIONS.filter((option) =>
+        hasPoolRoyaleUnlock(poolInventory, 'clothColors', option.id)
+      ),
+    [poolInventory]
+  );
+  const availableRailMarkerColors = useMemo(
+    () =>
+      RAIL_MARKER_COLOR_OPTIONS.filter((option) =>
+        hasPoolRoyaleUnlock(poolInventory, 'railMarkerColors', option.id)
+      ),
+    [poolInventory]
+  );
+  const availableRailMarkerShapes = useMemo(
+    () =>
+      RAIL_MARKER_SHAPE_OPTIONS.filter((option) =>
+        hasPoolRoyaleUnlock(poolInventory, 'railMarkerShapes', option.id)
+      ),
+    [poolInventory]
+  );
+  const availableCueStyles = useMemo(
+    () =>
+      CUE_STYLE_PRESETS.filter((preset) =>
+        hasPoolRoyaleUnlock(poolInventory, 'cueStyles', preset.id)
+      ),
+    [poolInventory]
+  );
+  useEffect(() => {
+    if (!hasPoolRoyaleUnlock(poolInventory, 'finishes', tableFinishId)) {
+      const fallback = availableTableFinishes[0]?.id ?? DEFAULT_TABLE_FINISH_ID;
+      setTableFinishId(fallback);
+    }
+  }, [availableTableFinishes, poolInventory, tableFinishId]);
+  useEffect(() => {
+    if (!hasPoolRoyaleUnlock(poolInventory, 'chromeColors', chromeColorId)) {
+      const fallback = availableChromeOptions[0]?.id ?? DEFAULT_CHROME_COLOR_ID;
+      setChromeColorId(fallback);
+    }
+  }, [availableChromeOptions, chromeColorId, poolInventory]);
+  useEffect(() => {
+    if (!hasPoolRoyaleUnlock(poolInventory, 'clothColors', clothColorId)) {
+      const fallback = availableClothOptions[0]?.id ?? DEFAULT_CLOTH_COLOR_ID;
+      setClothColorId(fallback);
+    }
+  }, [availableClothOptions, clothColorId, poolInventory]);
+  useEffect(() => {
+    if (!hasPoolRoyaleUnlock(poolInventory, 'railMarkerColors', railMarkerColorId)) {
+      const fallback = availableRailMarkerColors[0]?.id ?? DEFAULT_RAIL_MARKER_COLOR_ID;
+      setRailMarkerColorId(fallback);
+    }
+  }, [availableRailMarkerColors, poolInventory, railMarkerColorId]);
+  useEffect(() => {
+    if (!hasPoolRoyaleUnlock(poolInventory, 'railMarkerShapes', railMarkerShapeId)) {
+      const fallback = availableRailMarkerShapes[0]?.id ?? DEFAULT_RAIL_MARKER_SHAPE;
+      setRailMarkerShapeId(fallback);
+    }
+  }, [availableRailMarkerShapes, poolInventory, railMarkerShapeId]);
+  useEffect(() => {
+    const currentPreset = CUE_STYLE_PRESETS[cueStyleIndex];
+    const presetAllowed =
+      currentPreset && hasPoolRoyaleUnlock(poolInventory, 'cueStyles', currentPreset.id);
+    if (presetAllowed) return;
+    const fallbackPreset =
+      availableCueStyles[0] ?? CUE_STYLE_PRESETS[DEFAULT_CUE_STYLE_INDEX] ?? CUE_STYLE_PRESETS[0];
+    const fallbackIndex = CUE_STYLE_PRESETS.findIndex((preset) => preset.id === fallbackPreset?.id);
+    setCueStyleIndex(fallbackIndex >= 0 ? fallbackIndex : DEFAULT_CUE_STYLE_INDEX);
+  }, [availableCueStyles, cueStyleIndex, poolInventory]);
   const activeFrameRateOption = useMemo(
     () =>
       FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ??
@@ -8212,12 +8316,18 @@ function PoolRoyaleGame({
     [broadcastSystemId]
   );
   const activeChromeOption = useMemo(
-    () => CHROME_COLOR_OPTIONS.find((opt) => opt.id === chromeColorId) ?? CHROME_COLOR_OPTIONS[0],
-    [chromeColorId]
+    () =>
+      availableChromeOptions.find((opt) => opt.id === chromeColorId) ??
+      availableChromeOptions[0] ??
+      CHROME_COLOR_OPTIONS[0],
+    [availableChromeOptions, chromeColorId]
   );
   const activeClothOption = useMemo(
-    () => CLOTH_COLOR_OPTIONS.find((opt) => opt.id === clothColorId) ?? CLOTH_COLOR_OPTIONS[0],
-    [clothColorId]
+    () =>
+      availableClothOptions.find((opt) => opt.id === clothColorId) ??
+      availableClothOptions[0] ??
+      CLOTH_COLOR_OPTIONS[0],
+    [availableClothOptions, clothColorId]
   );
   const activePocketLinerOption = useMemo(
     () => POCKET_LINER_OPTIONS.find((opt) => opt?.id === pocketLinerId) ?? POCKET_LINER_OPTIONS[0],
@@ -8384,7 +8494,7 @@ function PoolRoyaleGame({
         }
       }
     }
-    return 0;
+    return DEFAULT_CUE_STYLE_INDEX;
   });
   const cueStyleIndexRef = useRef(cueStyleIndex);
   const cueRackGroupsRef = useRef([]);
@@ -16594,7 +16704,7 @@ function PoolRoyaleGame({
                   Table Finish
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {TABLE_FINISH_OPTIONS.map((option) => {
+                  {availableTableFinishes.map((option) => {
                     const active = option.id === tableFinishId;
                     return (
                       <button
@@ -16619,7 +16729,7 @@ function PoolRoyaleGame({
                   Chrome Plates
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {CHROME_COLOR_OPTIONS.map((option) => {
+                  {availableChromeOptions.map((option) => {
                     const active = option.id === chromeColorId;
                     return (
                       <button
@@ -16651,13 +16761,16 @@ function PoolRoyaleGame({
                   Cue Styles
                 </h3>
                 <div className="mt-2 grid grid-cols-2 gap-2">
-                  {CUE_STYLE_PRESETS.map((preset, index) => {
-                    const active = cueStyleIndex === index;
+                  {availableCueStyles.map((preset) => {
+                    const optionIndex = CUE_STYLE_PRESETS.findIndex(
+                      (option) => option.id === preset.id
+                    );
+                    const active = cueStyleIndex === optionIndex;
                     return (
                       <button
                         key={preset.id}
                         type="button"
-                        onClick={() => selectCueStyleFromMenu(index)}
+                        onClick={() => selectCueStyleFromMenu(optionIndex)}
                         aria-pressed={active}
                         className={`rounded-xl px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.2em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
                           active
@@ -16677,7 +16790,7 @@ function PoolRoyaleGame({
                     Cloth Color
                   </h3>
                   <div className="mt-2 flex flex-wrap gap-2">
-                    {CLOTH_COLOR_OPTIONS.map((option) => {
+                    {availableClothOptions.map((option) => {
                       const active = option.id === clothColorId;
                       return (
                         <button
@@ -16710,7 +16823,7 @@ function PoolRoyaleGame({
                   Rail Markers
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {RAIL_MARKER_SHAPE_OPTIONS.map((option) => {
+                  {availableRailMarkerShapes.map((option) => {
                     const active = option.id === railMarkerShapeId;
                     return (
                       <button
@@ -16730,7 +16843,7 @@ function PoolRoyaleGame({
                   })}
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {RAIL_MARKER_COLOR_OPTIONS.map((option) => {
+                  {availableRailMarkerColors.map((option) => {
                     const active = option.id === railMarkerColorId;
                     return (
                       <button

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1,12 +1,127 @@
+import React, { useCallback, useMemo, useState } from 'react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
+import {
+  POOL_ROYALE_BASE_UNLOCKS,
+  POOL_ROYALE_STORE_CATALOG,
+  grantPoolRoyaleUnlock,
+  hasPoolRoyaleUnlock,
+  loadPoolRoyaleInventory
+} from '../utils/poolRoyaleInventory.js';
+
+const CATEGORY_LABELS = {
+  finishes: 'Table Finishes',
+  chromeColors: 'Chrome Plates',
+  clothColors: 'Cloth Colors',
+  cueStyles: 'Cue Styles',
+  railMarkerColors: 'Rail Marker Colors',
+  railMarkerShapes: 'Rail Marker Shapes'
+};
 
 export default function Store() {
   useTelegramBackButton();
+  const [inventory, setInventory] = useState(() => loadPoolRoyaleInventory());
+
+  const groupedPoolRoyaleItems = useMemo(() => {
+    return POOL_ROYALE_STORE_CATALOG.reduce((acc, item) => {
+      const bucket = acc[item.category] ?? [];
+      bucket.push(item);
+      acc[item.category] = bucket;
+      return acc;
+    }, {});
+  }, []);
+
+  const handlePurchase = useCallback((item) => {
+    const updated = grantPoolRoyaleUnlock(item.category, item.id);
+    setInventory(updated);
+  }, []);
+
+  const isOwned = useCallback(
+    (item) => hasPoolRoyaleUnlock(inventory, item.category, item.id),
+    [inventory]
+  );
+
+  const isDefaultUnlock = useCallback(
+    (item) => Array.isArray(POOL_ROYALE_BASE_UNLOCKS[item.category]) &&
+      POOL_ROYALE_BASE_UNLOCKS[item.category].includes(item.id),
+    []
+  );
 
   return (
-    <div className="relative p-4 space-y-4 text-text flex flex-col items-center">
-      <h2 className="text-xl font-bold">Store</h2>
-      <p className="text-subtext text-sm">No bundles are currently available.</p>
+    <div className="relative p-4 space-y-6 text-text">
+      <div className="space-y-2 text-center">
+        <h2 className="text-xl font-bold">Store</h2>
+        <p className="text-subtext text-sm">
+          Upgrade your Pool Royale loadout. Items unlock inside the table setup menu once purchased.
+        </p>
+      </div>
+
+      <div className="space-y-5">
+        <div className="rounded-2xl border border-emerald-300/30 bg-black/60 p-4 shadow-lg">
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-emerald-200/80">Pool Royale</p>
+              <p className="text-lg font-semibold">Cosmetics Marketplace</p>
+            </div>
+            <div className="rounded-full bg-emerald-500/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-200">
+              NFT-gated unlocks
+            </div>
+          </div>
+
+          <div className="mt-4 space-y-4">
+            {Object.entries(groupedPoolRoyaleItems).map(([category, items]) => (
+              <div key={category} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <p className="text-[13px] font-semibold uppercase tracking-[0.2em]">
+                    {CATEGORY_LABELS[category] ?? category}
+                  </p>
+                  <span className="text-[11px] text-emerald-100/70">
+                    Defaults stay active; new purchases add options to the table setup.
+                  </span>
+                </div>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  {items.map((item) => {
+                    const owned = isOwned(item);
+                    const defaultOwned = isDefaultUnlock(item);
+                    return (
+                      <div
+                        key={`${category}-${item.id}`}
+                        className="flex flex-col justify-between rounded-xl border border-white/10 bg-white/5 p-3 backdrop-blur"
+                      >
+                        <div className="space-y-1">
+                          <p className="text-sm font-semibold">{item.label}</p>
+                          <p className="text-xs text-white/70">{item.description}</p>
+                        </div>
+                        <div className="mt-3 flex items-center justify-between text-sm font-semibold">
+                          <span className="text-emerald-200">{item.price}</span>
+                          <div className="flex items-center gap-2">
+                            {defaultOwned ? (
+                              <span className="rounded-full bg-emerald-500/20 px-3 py-1 text-[11px] uppercase tracking-[0.2em] text-emerald-100">
+                                Default
+                              </span>
+                            ) : null}
+                            <button
+                              type="button"
+                              onClick={() => handlePurchase(item)}
+                              disabled={owned}
+                              className={`rounded-full px-3 py-1 text-[11px] uppercase tracking-[0.2em] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                                owned
+                                  ? 'cursor-not-allowed bg-white/10 text-white/60'
+                                  : 'bg-emerald-400 text-black hover:bg-emerald-300'
+                              }`}
+                            >
+                              {owned ? 'Owned' : 'Purchase'}
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/webapp/src/utils/poolRoyaleInventory.js
+++ b/webapp/src/utils/poolRoyaleInventory.js
@@ -1,0 +1,205 @@
+const STORAGE_KEY = 'poolRoyaleInventory';
+
+export const POOL_ROYALE_BASE_UNLOCKS = Object.freeze({
+  finishes: ['charredTimber'],
+  chromeColors: ['gold'],
+  clothColors: ['freshGreen'],
+  cueStyles: ['birch-frost'],
+  railMarkerColors: ['gold'],
+  railMarkerShapes: ['diamond']
+});
+
+const CATEGORY_KEYS = Object.freeze({
+  finishes: 'finishes',
+  chromeColors: 'chromeColors',
+  clothColors: 'clothColors',
+  cueStyles: 'cueStyles',
+  railMarkerColors: 'railMarkerColors',
+  railMarkerShapes: 'railMarkerShapes'
+});
+
+const normalizeInventory = (raw = {}) => {
+  const merged = {};
+  Object.values(CATEGORY_KEYS).forEach((key) => {
+    const baseItems = POOL_ROYALE_BASE_UNLOCKS[key] ?? [];
+    const userItems = Array.isArray(raw[key]) ? raw[key] : [];
+    merged[key] = new Set([...baseItems, ...userItems]);
+  });
+  return merged;
+};
+
+const serializeInventory = (inventory) => {
+  const serialized = {};
+  Object.values(CATEGORY_KEYS).forEach((key) => {
+    const items = inventory?.[key];
+    serialized[key] = Array.from(items instanceof Set ? items : []);
+  });
+  return serialized;
+};
+
+export const loadPoolRoyaleInventory = () => {
+  if (typeof window === 'undefined') {
+    return normalizeInventory();
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) return normalizeInventory();
+    const parsed = JSON.parse(stored);
+    return normalizeInventory(parsed);
+  } catch (err) {
+    console.warn('Failed to load Pool Royale inventory', err);
+    return normalizeInventory();
+  }
+};
+
+export const savePoolRoyaleInventory = (inventory) => {
+  if (typeof window === 'undefined') return inventory;
+  try {
+    const normalized = normalizeInventory(serializeInventory(inventory));
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(serializeInventory(normalized)));
+    return normalized;
+  } catch (err) {
+    console.warn('Failed to save Pool Royale inventory', err);
+    return inventory;
+  }
+};
+
+export const grantPoolRoyaleUnlock = (category, id) => {
+  if (!id || !CATEGORY_KEYS[category]) return loadPoolRoyaleInventory();
+  const current = loadPoolRoyaleInventory();
+  const next = normalizeInventory({
+    ...serializeInventory(current),
+    [category]: [...(current?.[category] ?? []), id]
+  });
+  return savePoolRoyaleInventory(next);
+};
+
+export const hasPoolRoyaleUnlock = (inventory, category, id) => {
+  if (!id || !CATEGORY_KEYS[category]) return false;
+  const set = inventory?.[category];
+  return Boolean(set && set.has(id));
+};
+
+export const POOL_ROYALE_STORE_CATALOG = Object.freeze([
+  {
+    id: 'rusticSplit',
+    category: CATEGORY_KEYS.finishes,
+    label: 'Rustic Split Finish',
+    description: 'Warm split-plank rails with mellow walnut cues.',
+    price: '320 TON'
+  },
+  {
+    id: 'plankStudio',
+    category: CATEGORY_KEYS.finishes,
+    label: 'Plank Studio Finish',
+    description: 'Polished studio planks with satin brass trim.',
+    price: '340 TON'
+  },
+  {
+    id: 'weatheredGrey',
+    category: CATEGORY_KEYS.finishes,
+    label: 'Weathered Grey Finish',
+    description: 'Frosted coastal grey frame with low-sheen rails.',
+    price: '360 TON'
+  },
+  {
+    id: 'jetBlackCarbon',
+    category: CATEGORY_KEYS.finishes,
+    label: 'Jet Black Carbon Finish',
+    description: 'Stealth carbon rails with deep black fascia.',
+    price: '380 TON'
+  },
+  {
+    id: 'chrome',
+    category: CATEGORY_KEYS.chromeColors,
+    label: 'Chrome Plates',
+    description: 'Mirror-polished chrome fascias for every pocket.',
+    price: '240 TON'
+  },
+  {
+    id: 'graphite',
+    category: CATEGORY_KEYS.clothColors,
+    label: 'Arcadia Graphite Cloth',
+    description: 'Tournament graphite felt with subdued sheen.',
+    price: '180 TON'
+  },
+  {
+    id: 'arcticBlue',
+    category: CATEGORY_KEYS.clothColors,
+    label: 'Arctic Blue Cloth',
+    description: 'Icy blue show-floor cloth with bright sparkles.',
+    price: '180 TON'
+  },
+  {
+    id: 'redwood-ember',
+    category: CATEGORY_KEYS.cueStyles,
+    label: 'Redwood Ember Cue',
+    description: 'Deep ember cue butt with bright brass rings.',
+    price: '95 TON'
+  },
+  {
+    id: 'wenge-nightfall',
+    category: CATEGORY_KEYS.cueStyles,
+    label: 'Wenge Nightfall Cue',
+    description: 'Dark wenge cue with sleek low-gloss finish.',
+    price: '95 TON'
+  },
+  {
+    id: 'mahogany-heritage',
+    category: CATEGORY_KEYS.cueStyles,
+    label: 'Mahogany Heritage Cue',
+    description: 'Classic mahogany grain with vintage warmth.',
+    price: '95 TON'
+  },
+  {
+    id: 'walnut-satin',
+    category: CATEGORY_KEYS.cueStyles,
+    label: 'Walnut Satin Cue',
+    description: 'Smooth walnut cue with satin highlights.',
+    price: '95 TON'
+  },
+  {
+    id: 'carbon-matrix',
+    category: CATEGORY_KEYS.cueStyles,
+    label: 'Carbon Matrix Cue',
+    description: 'Carbon fiber pattern with modern contrast.',
+    price: '125 TON'
+  },
+  {
+    id: 'maple-horizon',
+    category: CATEGORY_KEYS.cueStyles,
+    label: 'Maple Horizon Cue',
+    description: 'Bright maple cue with crisp Nordic tone.',
+    price: '95 TON'
+  },
+  {
+    id: 'graphite-aurora',
+    category: CATEGORY_KEYS.cueStyles,
+    label: 'Graphite Aurora Cue',
+    description: 'Graphite fiber cue with subtle aurora tint.',
+    price: '125 TON'
+  },
+  {
+    id: 'chrome',
+    category: CATEGORY_KEYS.railMarkerColors,
+    label: 'Chrome Rail Diamonds',
+    description: 'Chrome diamond markers to match silver plates.',
+    price: '80 TON'
+  },
+  {
+    id: 'pearl',
+    category: CATEGORY_KEYS.railMarkerColors,
+    label: 'Pearl Rail Diamonds',
+    description: 'Soft pearl markers for luxe contrast.',
+    price: '80 TON'
+  },
+  {
+    id: 'circle',
+    category: CATEGORY_KEYS.railMarkerShapes,
+    label: 'Circle Rail Markers',
+    description: 'Swap diamonds for circles on every rail.',
+    price: '60 TON'
+  }
+]);
+
+export { CATEGORY_KEYS as POOL_ROYALE_INVENTORY_KEYS, STORAGE_KEY as POOL_ROYALE_INVENTORY_STORAGE_KEY };


### PR DESCRIPTION
## Summary
- set Pool Royale defaults to Charred Timber finish, gold chrome and marker accents, Tour Green cloth, and Birch Frost cue
- add local inventory tracking to gate cosmetic options and only surface owned variants in the table setup menu
- build a Pool Royale store section with purchasable finishes, cloths, cues, chrome plates, and rail markers that unlock customization entries

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d590d0fec8329894d6c5b8e0ee247)