### PR TITLE
Set Pool Royale default cosmetics and add NFT store

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -35,6 +35,12 @@ import {
   applyWoodTextures,
   disposeMaterialWithWood,
 } from '../../utils/woodMaterials.js';
+import {
+  POOL_ROYALE_INVENTORY_EVENT,
+  POOL_ROYALE_OPTION_TYPES,
+  isPoolRoyaleOptionUnlocked,
+  loadPoolRoyaleOwnedSet
+} from '../../utils/poolRoyaleStore.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 
 function safePolygonUnion(...parts) {
@@ -743,6 +749,7 @@ const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
 const CUE_STYLE_STORAGE_KEY = 'tonplayCueStyleIndex';
+const DEFAULT_CUE_STYLE_ID = 'birch-frost';
 const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const CLOTH_COLOR_STORAGE_KEY = 'poolRoyaleClothColor';
 const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
@@ -1700,7 +1707,7 @@ const DEFAULT_WOOD_PRESET_ID = 'walnut';
 // rails as a plain material without any texture maps.
 const WOOD_TEXTURES_ENABLED = false;
 
-const DEFAULT_TABLE_FINISH_ID = 'rusticSplit';
+const DEFAULT_TABLE_FINISH_ID = 'charredTimber';
 
 const POOL_ROYALE_WOOD_PRESET_FOR_FINISH = Object.freeze({
   rusticSplit: 'walnut',
@@ -2072,7 +2079,7 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
   ].filter(Boolean)
 );
 
-const DEFAULT_CHROME_COLOR_ID = 'chrome';
+const DEFAULT_CHROME_COLOR_ID = 'gold';
 const CHROME_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
@@ -2183,6 +2190,10 @@ const CLOTH_COLOR_OPTIONS = Object.freeze([
     }
   }
 ]);
+const DEFAULT_CUE_STYLE_INDEX = Math.max(
+  0,
+  CUE_STYLE_PRESETS.findIndex((preset) => preset.id === DEFAULT_CUE_STYLE_ID)
+);
 
 const DEFAULT_RAIL_MARKER_SHAPE = 'diamond';
 const RAIL_MARKER_SHAPE_OPTIONS = Object.freeze([
@@ -2191,7 +2202,7 @@ const RAIL_MARKER_SHAPE_OPTIONS = Object.freeze([
 ]);
 const RAIL_MARKER_THICKNESS = TABLE.THICK * 0.06;
 
-const DEFAULT_RAIL_MARKER_COLOR_ID = 'chrome';
+const DEFAULT_RAIL_MARKER_COLOR_ID = 'gold';
 const RAIL_MARKER_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
@@ -8132,10 +8143,21 @@ function PoolRoyaleGame({
     [tableSizeKey]
   );
   const responsiveTableSize = useResponsiveTableSize(activeTableSize);
+  const [ownedPoolRoyaleSet, setOwnedPoolRoyaleSet] = useState(() =>
+    loadPoolRoyaleOwnedSet()
+  );
   const [tableFinishId, setTableFinishId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(TABLE_FINISH_STORAGE_KEY);
-      if (stored && TABLE_FINISHES[stored]) {
+      if (
+        stored &&
+        TABLE_FINISHES[stored] &&
+        isPoolRoyaleOptionUnlocked(
+          POOL_ROYALE_OPTION_TYPES.finish,
+          stored,
+          ownedPoolRoyaleSet
+        )
+      ) {
         return stored;
       }
     }
@@ -8144,7 +8166,15 @@ function PoolRoyaleGame({
   const [clothColorId, setClothColorId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(CLOTH_COLOR_STORAGE_KEY);
-      if (stored && CLOTH_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
+      if (
+        stored &&
+        CLOTH_COLOR_OPTIONS.some((opt) => opt.id === stored) &&
+        isPoolRoyaleOptionUnlocked(
+          POOL_ROYALE_OPTION_TYPES.cloth,
+          stored,
+          ownedPoolRoyaleSet
+        )
+      ) {
         return stored;
       }
     }
@@ -8162,7 +8192,15 @@ function PoolRoyaleGame({
   const [railMarkerShapeId, setRailMarkerShapeId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem('poolRailMarkerShape');
-      if (stored && RAIL_MARKER_SHAPE_OPTIONS.some((opt) => opt.id === stored)) {
+      if (
+        stored &&
+        RAIL_MARKER_SHAPE_OPTIONS.some((opt) => opt.id === stored) &&
+        isPoolRoyaleOptionUnlocked(
+          POOL_ROYALE_OPTION_TYPES.railMarkerShape,
+          stored,
+          ownedPoolRoyaleSet
+        )
+      ) {
         return stored;
       }
     }
@@ -8171,7 +8209,15 @@ function PoolRoyaleGame({
   const [railMarkerColorId, setRailMarkerColorId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem('poolRailMarkerColor');
-      if (stored && RAIL_MARKER_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
+      if (
+        stored &&
+        RAIL_MARKER_COLOR_OPTIONS.some((opt) => opt.id === stored) &&
+        isPoolRoyaleOptionUnlocked(
+          POOL_ROYALE_OPTION_TYPES.railMarkerColor,
+          stored,
+          ownedPoolRoyaleSet
+        )
+      ) {
         return stored;
       }
     }
@@ -8181,7 +8227,15 @@ function PoolRoyaleGame({
   const [chromeColorId, setChromeColorId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem('poolChromeColor');
-      if (stored && CHROME_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
+      if (
+        stored &&
+        CHROME_COLOR_OPTIONS.some((opt) => opt.id === stored) &&
+        isPoolRoyaleOptionUnlocked(
+          POOL_ROYALE_OPTION_TYPES.chrome,
+          stored,
+          ownedPoolRoyaleSet
+        )
+      ) {
         return stored;
       }
     }
@@ -8201,6 +8255,150 @@ function PoolRoyaleGame({
     return DEFAULT_FRAME_RATE_ID;
   });
   const [broadcastSystemId, setBroadcastSystemId] = useState(() => DEFAULT_BROADCAST_SYSTEM_ID);
+  useEffect(() => {
+    const handleInventoryUpdate = () => {
+      setOwnedPoolRoyaleSet(loadPoolRoyaleOwnedSet());
+    };
+    window.addEventListener(POOL_ROYALE_INVENTORY_EVENT, handleInventoryUpdate);
+    window.addEventListener('storage', handleInventoryUpdate);
+    return () => {
+      window.removeEventListener(POOL_ROYALE_INVENTORY_EVENT, handleInventoryUpdate);
+      window.removeEventListener('storage', handleInventoryUpdate);
+    };
+  }, []);
+  const availableTableFinishes = useMemo(
+    () =>
+      TABLE_FINISH_OPTIONS.filter((option) =>
+        isPoolRoyaleOptionUnlocked(
+          POOL_ROYALE_OPTION_TYPES.finish,
+          option.id,
+          ownedPoolRoyaleSet
+        )
+      ),
+    [ownedPoolRoyaleSet]
+  );
+  const availableChromeOptions = useMemo(
+    () =>
+      CHROME_COLOR_OPTIONS.filter((option) =>
+        isPoolRoyaleOptionUnlocked(
+          POOL_ROYALE_OPTION_TYPES.chrome,
+          option.id,
+          ownedPoolRoyaleSet
+        )
+      ),
+    [ownedPoolRoyaleSet]
+  );
+  const availableClothOptions = useMemo(
+    () =>
+      CLOTH_COLOR_OPTIONS.filter((option) =>
+        isPoolRoyaleOptionUnlocked(
+          POOL_ROYALE_OPTION_TYPES.cloth,
+          option.id,
+          ownedPoolRoyaleSet
+        )
+      ),
+    [ownedPoolRoyaleSet]
+  );
+  const availableRailMarkerShapes = useMemo(
+    () =>
+      RAIL_MARKER_SHAPE_OPTIONS.filter((option) =>
+        isPoolRoyaleOptionUnlocked(
+          POOL_ROYALE_OPTION_TYPES.railMarkerShape,
+          option.id,
+          ownedPoolRoyaleSet
+        )
+      ),
+    [ownedPoolRoyaleSet]
+  );
+  const availableRailMarkerColors = useMemo(
+    () =>
+      RAIL_MARKER_COLOR_OPTIONS.filter((option) =>
+        isPoolRoyaleOptionUnlocked(
+          POOL_ROYALE_OPTION_TYPES.railMarkerColor,
+          option.id,
+          ownedPoolRoyaleSet
+        )
+      ),
+    [ownedPoolRoyaleSet]
+  );
+  const availableCueStyles = useMemo(
+    () =>
+      CUE_STYLE_PRESETS.map((preset, index) => ({ preset, index })).filter(({ preset }) =>
+        isPoolRoyaleOptionUnlocked(POOL_ROYALE_OPTION_TYPES.cue, preset.id, ownedPoolRoyaleSet)
+      ),
+    [ownedPoolRoyaleSet]
+  );
+  useEffect(() => {
+    if (
+      !isPoolRoyaleOptionUnlocked(
+        POOL_ROYALE_OPTION_TYPES.finish,
+        tableFinishId,
+        ownedPoolRoyaleSet
+      )
+    ) {
+      setTableFinishId(DEFAULT_TABLE_FINISH_ID);
+    }
+  }, [ownedPoolRoyaleSet, tableFinishId]);
+  useEffect(() => {
+    if (
+      !isPoolRoyaleOptionUnlocked(
+        POOL_ROYALE_OPTION_TYPES.cloth,
+        clothColorId,
+        ownedPoolRoyaleSet
+      )
+    ) {
+      setClothColorId(DEFAULT_CLOTH_COLOR_ID);
+    }
+  }, [clothColorId, ownedPoolRoyaleSet]);
+  useEffect(() => {
+    if (
+      !isPoolRoyaleOptionUnlocked(
+        POOL_ROYALE_OPTION_TYPES.railMarkerShape,
+        railMarkerShapeId,
+        ownedPoolRoyaleSet
+      )
+    ) {
+      setRailMarkerShapeId(DEFAULT_RAIL_MARKER_SHAPE);
+    }
+  }, [ownedPoolRoyaleSet, railMarkerShapeId]);
+  useEffect(() => {
+    if (
+      !isPoolRoyaleOptionUnlocked(
+        POOL_ROYALE_OPTION_TYPES.railMarkerColor,
+        railMarkerColorId,
+        ownedPoolRoyaleSet
+      )
+    ) {
+      setRailMarkerColorId(DEFAULT_RAIL_MARKER_COLOR_ID);
+    }
+  }, [ownedPoolRoyaleSet, railMarkerColorId]);
+  useEffect(() => {
+    if (
+      !isPoolRoyaleOptionUnlocked(
+        POOL_ROYALE_OPTION_TYPES.chrome,
+        chromeColorId,
+        ownedPoolRoyaleSet
+      )
+    ) {
+      setChromeColorId(DEFAULT_CHROME_COLOR_ID);
+    }
+  }, [chromeColorId, ownedPoolRoyaleSet]);
+  useEffect(() => {
+    const currentCueId = CUE_STYLE_PRESETS[cueStyleIndex]?.id;
+    if (
+      !isPoolRoyaleOptionUnlocked(
+        POOL_ROYALE_OPTION_TYPES.cue,
+        currentCueId,
+        ownedPoolRoyaleSet
+      )
+    ) {
+      const fallbackIndex =
+        availableCueStyles.find((entry) => entry.preset.id === DEFAULT_CUE_STYLE_ID)?.index ??
+        availableCueStyles[0]?.index ??
+        DEFAULT_CUE_STYLE_INDEX;
+      setCueStyleIndex(fallbackIndex);
+    }
+  }, [availableCueStyles, cueStyleIndex, ownedPoolRoyaleSet]);
   const activeFrameRateOption = useMemo(
     () =>
       FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ??
@@ -8212,12 +8410,16 @@ function PoolRoyaleGame({
     [broadcastSystemId]
   );
   const activeChromeOption = useMemo(
-    () => CHROME_COLOR_OPTIONS.find((opt) => opt.id === chromeColorId) ?? CHROME_COLOR_OPTIONS[0],
-    [chromeColorId]
+    () =>
+      availableChromeOptions.find((opt) => opt.id === chromeColorId) ??
+      availableChromeOptions[0],
+    [availableChromeOptions, chromeColorId]
   );
   const activeClothOption = useMemo(
-    () => CLOTH_COLOR_OPTIONS.find((opt) => opt.id === clothColorId) ?? CLOTH_COLOR_OPTIONS[0],
-    [clothColorId]
+    () =>
+      availableClothOptions.find((opt) => opt.id === clothColorId) ??
+      availableClothOptions[0],
+    [availableClothOptions, clothColorId]
   );
   const activePocketLinerOption = useMemo(
     () => POCKET_LINER_OPTIONS.find((opt) => opt?.id === pocketLinerId) ?? POCKET_LINER_OPTIONS[0],
@@ -8375,16 +8577,27 @@ function PoolRoyaleGame({
   const chalkAssistTargetRef = useRef(false);
   const visibleChalkIndexRef = useRef(null);
   const [cueStyleIndex, setCueStyleIndex] = useState(() => {
+    const defaultIndex = DEFAULT_CUE_STYLE_INDEX;
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(CUE_STYLE_STORAGE_KEY);
       if (stored != null) {
         const parsed = Number.parseInt(stored, 10);
-        if (Number.isFinite(parsed) && parsed >= 0) {
+        const storedPreset = CUE_STYLE_PRESETS[parsed % CUE_STYLE_PRESETS.length];
+        if (
+          Number.isFinite(parsed) &&
+          parsed >= 0 &&
+          storedPreset?.id &&
+          isPoolRoyaleOptionUnlocked(
+            POOL_ROYALE_OPTION_TYPES.cue,
+            storedPreset.id,
+            ownedPoolRoyaleSet
+          )
+        ) {
           return parsed % CUE_RACK_PALETTE.length;
         }
       }
     }
-    return 0;
+    return defaultIndex;
   });
   const cueStyleIndexRef = useRef(cueStyleIndex);
   const cueRackGroupsRef = useRef([]);
@@ -16594,7 +16807,7 @@ function PoolRoyaleGame({
                   Table Finish
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {TABLE_FINISH_OPTIONS.map((option) => {
+                  {availableTableFinishes.map((option) => {
                     const active = option.id === tableFinishId;
                     return (
                       <button
@@ -16619,7 +16832,7 @@ function PoolRoyaleGame({
                   Chrome Plates
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {CHROME_COLOR_OPTIONS.map((option) => {
+                  {availableChromeOptions.map((option) => {
                     const active = option.id === chromeColorId;
                     return (
                       <button
@@ -16651,7 +16864,7 @@ function PoolRoyaleGame({
                   Cue Styles
                 </h3>
                 <div className="mt-2 grid grid-cols-2 gap-2">
-                  {CUE_STYLE_PRESETS.map((preset, index) => {
+                  {availableCueStyles.map(({ preset, index }) => {
                     const active = cueStyleIndex === index;
                     return (
                       <button
@@ -16671,13 +16884,13 @@ function PoolRoyaleGame({
                   })}
                 </div>
               </div>
-              {CLOTH_COLOR_OPTIONS.length > 1 ? (
+              {availableClothOptions.length > 0 ? (
                 <div>
                   <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                     Cloth Color
                   </h3>
                   <div className="mt-2 flex flex-wrap gap-2">
-                    {CLOTH_COLOR_OPTIONS.map((option) => {
+                    {availableClothOptions.map((option) => {
                       const active = option.id === clothColorId;
                       return (
                         <button
@@ -16710,7 +16923,7 @@ function PoolRoyaleGame({
                   Rail Markers
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {RAIL_MARKER_SHAPE_OPTIONS.map((option) => {
+                  {availableRailMarkerShapes.map((option) => {
                     const active = option.id === railMarkerShapeId;
                     return (
                       <button
@@ -16730,7 +16943,7 @@ function PoolRoyaleGame({
                   })}
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {RAIL_MARKER_COLOR_OPTIONS.map((option) => {
+                  {availableRailMarkerColors.map((option) => {
                     const active = option.id === railMarkerColorId;
                     return (
                       <button

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   getAccountInfo,
   createAccount,
@@ -27,6 +27,12 @@ import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
 import DevTasksModal from '../components/DevTasksModal.jsx';
 import Wallet from './Wallet.jsx';
 import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
+import {
+  POOL_ROYALE_INVENTORY_EVENT,
+  POOL_ROYALE_STORE_ITEMS,
+  getPoolRoyaleItemMeta,
+  loadPoolRoyaleOwnedSet
+} from '../utils/poolRoyaleStore.js';
 
 import { FiCopy } from 'react-icons/fi';
 
@@ -78,6 +84,9 @@ export default function MyAccount() {
   const [twitterLink, setTwitterLink] = useState('');
   const [unread, setUnread] = useState(0);
   const [googleLinked, setGoogleLinked] = useState(!!googleId);
+  const [poolRoyaleOwned, setPoolRoyaleOwned] = useState(() =>
+    loadPoolRoyaleOwnedSet()
+  );
 
   useEffect(() => {
     async function load() {
@@ -171,6 +180,33 @@ export default function MyAccount() {
     window.addEventListener('profilePhotoUpdated', handler);
     return () => window.removeEventListener('profilePhotoUpdated', handler);
   }, [telegramId]);
+  useEffect(() => {
+    const handleInventory = () => setPoolRoyaleOwned(loadPoolRoyaleOwnedSet());
+    window.addEventListener(POOL_ROYALE_INVENTORY_EVENT, handleInventory);
+    window.addEventListener('storage', handleInventory);
+    return () => {
+      window.removeEventListener(POOL_ROYALE_INVENTORY_EVENT, handleInventory);
+      window.removeEventListener('storage', handleInventory);
+    };
+  }, []);
+
+  const poolRoyaleOwnedList = useMemo(
+    () => Array.from(poolRoyaleOwned ?? []),
+    [poolRoyaleOwned]
+  );
+  const poolRoyalePremium = useMemo(
+    () =>
+      poolRoyaleOwnedList
+        .map((id) => getPoolRoyaleItemMeta(id))
+        .filter((meta) =>
+          meta ? POOL_ROYALE_STORE_ITEMS.some((item) => item.id === meta.id) : false
+        ),
+    [poolRoyaleOwnedList]
+  );
+  const poolRoyaleDefaultCount = Math.max(
+    0,
+    poolRoyaleOwnedList.length - poolRoyalePremium.length
+  );
 
   if (!profile) return <div className="p-4 text-subtext">Loading...</div>;
 
@@ -409,6 +445,34 @@ export default function MyAccount() {
       </div>
 
       <BalanceSummary className="bg-surface border border-border rounded-xl p-4 wide-card" />
+      <div className="bg-surface border border-border rounded-xl p-4 wide-card space-y-2">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="text-lg font-semibold text-white">Pool Royale NFTs</h3>
+          <span className="text-xs uppercase tracking-[0.2em] text-subtext">Ready</span>
+        </div>
+        <p className="text-sm text-subtext">
+          Charred Timber table, gold fascia and diamonds, Tour Green cloth, and the Birch Frost cue load for free. Premium
+          Pool Royale NFTs you own are listed below.
+        </p>
+        <div className="text-sm text-white-shadow">Default loadouts: {poolRoyaleDefaultCount}</div>
+        <div className="space-y-1">
+          <p className="text-sm font-semibold text-white">Premium unlocks</p>
+          {poolRoyalePremium.length ? (
+            <ul className="list-disc list-inside space-y-1 text-sm text-subtext">
+              {poolRoyalePremium.map((item) => (
+                <li key={item.id} className="flex items-center justify-between">
+                  <span className="text-white-shadow">{item.name}</span>
+                  {item.category ? (
+                    <span className="text-[11px] uppercase tracking-[0.2em] text-subtext">{item.category}</span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-subtext">No premium Pool Royale NFTs yet.</p>
+          )}
+        </div>
+      </div>
       {profile && profile.accountId === DEV_ACCOUNT_ID && (
         <>
           <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1,12 +1,121 @@
+import { useEffect, useMemo, useState } from 'react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
+import {
+  POOL_ROYALE_INVENTORY_EVENT,
+  POOL_ROYALE_STORE_ITEMS,
+  formatTPC,
+  loadPoolRoyaleOwnedSet,
+  purchasePoolRoyaleItem
+} from '../utils/poolRoyaleStore.js';
+
+const TPC_ICON = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 
 export default function Store() {
   useTelegramBackButton();
+  const [ownedItems, setOwnedItems] = useState(() => loadPoolRoyaleOwnedSet());
+
+  useEffect(() => {
+    const handleUpdate = () => setOwnedItems(loadPoolRoyaleOwnedSet());
+    window.addEventListener(POOL_ROYALE_INVENTORY_EVENT, handleUpdate);
+    window.addEventListener('storage', handleUpdate);
+    return () => {
+      window.removeEventListener(POOL_ROYALE_INVENTORY_EVENT, handleUpdate);
+      window.removeEventListener('storage', handleUpdate);
+    };
+  }, []);
+
+  const poolRoyaleByCategory = useMemo(() => {
+    const grouped = new Map();
+    POOL_ROYALE_STORE_ITEMS.forEach((item) => {
+      const list = grouped.get(item.category) ?? [];
+      list.push({ ...item, owned: ownedItems.has(item.id) });
+      grouped.set(item.category, list);
+    });
+    return grouped;
+  }, [ownedItems]);
+
+  const handlePurchase = (id) => {
+    const updated = purchasePoolRoyaleItem(id);
+    setOwnedItems(updated);
+  };
 
   return (
-    <div className="relative p-4 space-y-4 text-text flex flex-col items-center">
-      <h2 className="text-xl font-bold">Store</h2>
-      <p className="text-subtext text-sm">No bundles are currently available.</p>
+    <div className="relative p-4 space-y-6 text-text flex flex-col items-center">
+      <div className="w-full max-w-4xl space-y-4">
+        <div className="text-center space-y-1">
+          <h2 className="text-2xl font-bold">Store</h2>
+          <p className="text-subtext text-sm">
+            Pool Royale cosmetics are organized below. Defaults (Charred Timber table, gold chrome and diamonds, Tour Green
+            cloth, Birch Frost cue) stay free and non-tradable.
+          </p>
+        </div>
+
+        <div className="rounded-2xl border border-border bg-surface p-4 shadow-lg">
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              <h3 className="text-xl font-semibold text-white">Pool Royale Collection</h3>
+              <p className="text-subtext text-sm">NFT unlocks appear in your account and table setup when owned.</p>
+            </div>
+            <span className="rounded-full bg-emerald-500/15 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-emerald-200">
+              Organized
+            </span>
+          </div>
+
+          <div className="mt-4 grid gap-3 md:grid-cols-2">
+            {Array.from(poolRoyaleByCategory.entries()).map(([category, items]) => (
+              <div
+                key={category}
+                className="rounded-xl border border-border/60 bg-black/40 p-3 space-y-2 shadow-[0_12px_32px_rgba(0,0,0,0.35)]"
+              >
+                <div className="flex items-center justify-between">
+                  <h4 className="text-sm font-semibold uppercase tracking-[0.25em] text-emerald-100">
+                    {category}
+                  </h4>
+                  <span className="text-[11px] text-subtext">{items.length} options</span>
+                </div>
+                <div className="space-y-2">
+                  {items.map((item) => {
+                    const owned = item.owned;
+                    return (
+                      <div
+                        key={item.id}
+                        className="flex flex-col gap-2 rounded-lg border border-white/10 bg-white/5 p-3"
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <div>
+                            <p className="font-semibold text-white">{item.name}</p>
+                            <p className="text-xs text-subtext">{item.description}</p>
+                          </div>
+                          <div className="flex items-center gap-1 text-sm font-semibold text-amber-200">
+                            {formatTPC(item.priceTPC)}
+                            <img src={TPC_ICON} alt="TPC" className="h-4 w-4" />
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          disabled={owned}
+                          onClick={() => handlePurchase(item.id)}
+                          className={`rounded-full px-3 py-2 text-sm font-semibold uppercase tracking-[0.2em] transition-colors duration-200 ${
+                            owned
+                              ? 'bg-emerald-500/20 text-emerald-100 cursor-default'
+                              : 'bg-emerald-500 text-black hover:bg-emerald-400'
+                          }`}
+                        >
+                          {owned ? 'Owned' : 'Purchase NFT'}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+          <p className="mt-4 text-xs text-subtext">
+            More game collections will appear here later; Pool Royale items stay grouped so your lobby and table setup remain
+            tidy.
+          </p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/webapp/src/utils/poolRoyaleStore.js
+++ b/webapp/src/utils/poolRoyaleStore.js
@@ -1,0 +1,217 @@
+const STORAGE_KEY = 'poolRoyaleOwnedItems';
+export const POOL_ROYALE_INVENTORY_EVENT = 'poolRoyaleInventoryUpdated';
+
+export const POOL_ROYALE_OPTION_TYPES = Object.freeze({
+  finish: 'finish',
+  chrome: 'chrome',
+  cloth: 'cloth',
+  railMarkerColor: 'railMarkerColor',
+  railMarkerShape: 'railMarkerShape',
+  cue: 'cue'
+});
+
+const freeItems = [
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.finish}:charredTimber`,
+    name: 'Charred Timber Finish',
+    description: 'Default Pool Royale wood finish (non-tradable).'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.chrome}:gold`,
+    name: 'Gold Chrome Plates',
+    description: 'Gold fascia plates default for every table.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.railMarkerColor}:gold`,
+    name: 'Gold Rail Diamonds',
+    description: 'Diamond markers set to gold by default.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.railMarkerShape}:diamond`,
+    name: 'Diamond Rail Shape',
+    description: 'Default diamond rail markers.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.cloth}:freshGreen`,
+    name: 'Tour Green Cloth',
+    description: 'Tour green felt is free for everyone.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.cue}:birch-frost`,
+    name: 'Birch Frost Cue',
+    description: 'Starter cue finish (non-tradable).'
+  }
+];
+
+export const POOL_ROYALE_STORE_ITEMS = [
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.finish}:rusticSplit`,
+    name: 'Rustic Split Finish',
+    priceTPC: 4200,
+    category: 'Table Finish',
+    description: 'Brushed rustic rails and fascia as a collectible NFT.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.finish}:plankStudio`,
+    name: 'Plank Studio Finish',
+    priceTPC: 4800,
+    category: 'Table Finish',
+    description: 'Studio plank aesthetic with warm trim.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.finish}:weatheredGrey`,
+    name: 'Weathered Grey Finish',
+    priceTPC: 5200,
+    category: 'Table Finish',
+    description: 'Storm-worn grey rails and fascia.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.finish}:jetBlackCarbon`,
+    name: 'Jet Black Carbon Fibre',
+    priceTPC: 6200,
+    category: 'Table Finish',
+    description: 'Matte carbon fibre body with metallic trim.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.chrome}:chrome`,
+    name: 'Chrome Plates',
+    priceTPC: 2600,
+    category: 'Chrome Fascia',
+    description: 'Swap fascia plates back to polished chrome.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.railMarkerColor}:chrome`,
+    name: 'Chrome Diamonds',
+    priceTPC: 1800,
+    category: 'Rail Markers',
+    description: 'Diamond markers with chrome sparkle.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.railMarkerColor}:pearl`,
+    name: 'Pearl Diamonds',
+    priceTPC: 2100,
+    category: 'Rail Markers',
+    description: 'Pearlescent rail markers for a softer glow.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.railMarkerShape}:circle`,
+    name: 'Circular Markers',
+    priceTPC: 1500,
+    category: 'Rail Markers',
+    description: 'Circle marker set for the rails.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.cloth}:graphite`,
+    name: 'Arcadia Graphite Cloth',
+    priceTPC: 3500,
+    category: 'Cloth',
+    description: 'Deep graphite felt with subdued sheen.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.cloth}:arcticBlue`,
+    name: 'Arctic Blue Cloth',
+    priceTPC: 3400,
+    category: 'Cloth',
+    description: 'Cool blue tournament-ready felt.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.cue}:redwood-ember`,
+    name: 'Redwood Ember Cue',
+    priceTPC: 1200,
+    category: 'Cue Styles',
+    description: 'Warm redwood grain with ember contrast.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.cue}:wenge-nightfall`,
+    name: 'Wenge Nightfall Cue',
+    priceTPC: 1400,
+    category: 'Cue Styles',
+    description: 'Dark wenge finish with high contrast.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.cue}:mahogany-heritage`,
+    name: 'Mahogany Heritage Cue',
+    priceTPC: 1550,
+    category: 'Cue Styles',
+    description: 'Classic mahogany tones for traditionalists.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.cue}:walnut-satin`,
+    name: 'Walnut Satin Cue',
+    priceTPC: 1650,
+    category: 'Cue Styles',
+    description: 'Balanced walnut finish with satin sheen.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.cue}:carbon-matrix`,
+    name: 'Carbon Matrix Cue',
+    priceTPC: 1900,
+    category: 'Cue Styles',
+    description: 'Technical carbon fibre weave with gloss highlights.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.cue}:maple-horizon`,
+    name: 'Maple Horizon Cue',
+    priceTPC: 1750,
+    category: 'Cue Styles',
+    description: 'Light maple with airy highlight balance.'
+  },
+  {
+    id: `${POOL_ROYALE_OPTION_TYPES.cue}:graphite-aurora`,
+    name: 'Graphite Aurora Cue',
+    priceTPC: 1850,
+    category: 'Cue Styles',
+    description: 'Graphite fibre cue with aurora tint.'
+  }
+];
+
+export const POOL_ROYALE_ITEM_CATALOG = [...freeItems, ...POOL_ROYALE_STORE_ITEMS];
+
+const parseStoredItems = () => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (err) {
+    console.warn('Failed to parse Pool Royale inventory', err);
+    return [];
+  }
+};
+
+const persistOwnedItems = (ids) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify([...ids]));
+  window.dispatchEvent(
+    new CustomEvent(POOL_ROYALE_INVENTORY_EVENT, { detail: [...ids] })
+  );
+};
+
+export const toPoolRoyaleKey = (type, optionId) => `${type}:${optionId}`;
+
+export const loadPoolRoyaleOwnedSet = () => {
+  const stored = new Set(parseStoredItems());
+  freeItems.forEach((item) => stored.add(item.id));
+  return stored;
+};
+
+export const isPoolRoyaleOptionUnlocked = (type, optionId, ownedSet) => {
+  const key = toPoolRoyaleKey(type, optionId);
+  const set = ownedSet ?? loadPoolRoyaleOwnedSet();
+  return set.has(key);
+};
+
+export const purchasePoolRoyaleItem = (itemId) => {
+  const owned = loadPoolRoyaleOwnedSet();
+  owned.add(itemId);
+  persistOwnedItems(owned);
+  return owned;
+};
+
+export const getPoolRoyaleItemMeta = (itemId) =>
+  POOL_ROYALE_ITEM_CATALOG.find((item) => item.id === itemId) ?? null;
+
+export const formatTPC = (amount) =>
+  amount.toLocaleString('en-US', { maximumFractionDigits: 0 });
+


### PR DESCRIPTION
## Summary
- set Pool Royale default cosmetics to gold plates/diamonds, Tour Green cloth, Charred Timber finish, and Birch Frost cue while hiding locked options until owned
- add reusable Pool Royale store/inventory utility and expose purchases through the store page and account view
- keep table setup and account inventory in sync with local NFT unlocks and defaults

## Testing
- npm test -- --runInBand *(fails: jest roots config points to missing tests directory)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d6711a6308329bac0098f8c981832)