### PR TITLE
Add Pool Royale default cosmetics and storefront

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -36,6 +36,12 @@ import {
   disposeMaterialWithWood,
 } from '../../utils/woodMaterials.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
+import {
+  filterOwnedOptions,
+  getOwnedPoolRoyaleItems,
+  loadPoolRoyaleInventory,
+  makeInventoryKey
+} from '../../utils/poolRoyaleInventory.js';
 
 function safePolygonUnion(...parts) {
   const valid = parts.filter(Boolean);
@@ -1700,7 +1706,7 @@ const DEFAULT_WOOD_PRESET_ID = 'walnut';
 // rails as a plain material without any texture maps.
 const WOOD_TEXTURES_ENABLED = false;
 
-const DEFAULT_TABLE_FINISH_ID = 'rusticSplit';
+const DEFAULT_TABLE_FINISH_ID = 'charredTimber';
 
 const POOL_ROYALE_WOOD_PRESET_FOR_FINISH = Object.freeze({
   rusticSplit: 'walnut',
@@ -2072,7 +2078,7 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
   ].filter(Boolean)
 );
 
-const DEFAULT_CHROME_COLOR_ID = 'chrome';
+const DEFAULT_CHROME_COLOR_ID = 'gold';
 const CHROME_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
@@ -2191,7 +2197,8 @@ const RAIL_MARKER_SHAPE_OPTIONS = Object.freeze([
 ]);
 const RAIL_MARKER_THICKNESS = TABLE.THICK * 0.06;
 
-const DEFAULT_RAIL_MARKER_COLOR_ID = 'chrome';
+const DEFAULT_RAIL_MARKER_COLOR_ID = 'gold';
+const DEFAULT_CUE_STYLE_ID = 'birch-frost';
 const RAIL_MARKER_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
@@ -8132,23 +8139,40 @@ function PoolRoyaleGame({
     [tableSizeKey]
   );
   const responsiveTableSize = useResponsiveTableSize(activeTableSize);
+  const [ownedPoolRoyaleItems, setOwnedPoolRoyaleItems] = useState(() =>
+    getOwnedPoolRoyaleItems()
+  );
   const [tableFinishId, setTableFinishId] = useState(() => {
+    const ownedSet = new Set(getOwnedPoolRoyaleItems());
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(TABLE_FINISH_STORAGE_KEY);
-      if (stored && TABLE_FINISHES[stored]) {
+      if (stored && TABLE_FINISHES[stored] && ownedSet.has(makeInventoryKey('finish', stored))) {
         return stored;
       }
     }
-    return DEFAULT_TABLE_FINISH_ID;
+    if (ownedSet.has(makeInventoryKey('finish', DEFAULT_TABLE_FINISH_ID))) {
+      return DEFAULT_TABLE_FINISH_ID;
+    }
+    const firstOwned = TABLE_FINISH_OPTIONS.find((opt) =>
+      ownedSet.has(makeInventoryKey('finish', opt.id))
+    );
+    return firstOwned?.id ?? DEFAULT_TABLE_FINISH_ID;
   });
   const [clothColorId, setClothColorId] = useState(() => {
+    const ownedSet = new Set(getOwnedPoolRoyaleItems());
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(CLOTH_COLOR_STORAGE_KEY);
       if (stored && CLOTH_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
-        return stored;
+        if (ownedSet.has(makeInventoryKey('cloth', stored))) return stored;
       }
     }
-    return DEFAULT_CLOTH_COLOR_ID;
+    if (ownedSet.has(makeInventoryKey('cloth', DEFAULT_CLOTH_COLOR_ID))) {
+      return DEFAULT_CLOTH_COLOR_ID;
+    }
+    const firstOwned = CLOTH_COLOR_OPTIONS.find((opt) =>
+      ownedSet.has(makeInventoryKey('cloth', opt.id))
+    );
+    return firstOwned?.id ?? DEFAULT_CLOTH_COLOR_ID;
   });
   const [pocketLinerId, setPocketLinerId] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -8160,33 +8184,98 @@ function PoolRoyaleGame({
     return DEFAULT_POCKET_LINER_OPTION_ID;
   });
   const [railMarkerShapeId, setRailMarkerShapeId] = useState(() => {
+    const ownedSet = new Set(getOwnedPoolRoyaleItems());
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem('poolRailMarkerShape');
       if (stored && RAIL_MARKER_SHAPE_OPTIONS.some((opt) => opt.id === stored)) {
-        return stored;
+        if (ownedSet.has(makeInventoryKey('marker-shape', stored))) return stored;
       }
     }
-    return DEFAULT_RAIL_MARKER_SHAPE;
+    if (ownedSet.has(makeInventoryKey('marker-shape', DEFAULT_RAIL_MARKER_SHAPE))) {
+      return DEFAULT_RAIL_MARKER_SHAPE;
+    }
+    const firstOwned = RAIL_MARKER_SHAPE_OPTIONS.find((opt) =>
+      ownedSet.has(makeInventoryKey('marker-shape', opt.id))
+    );
+    return firstOwned?.id ?? DEFAULT_RAIL_MARKER_SHAPE;
   });
   const [railMarkerColorId, setRailMarkerColorId] = useState(() => {
+    const ownedSet = new Set(getOwnedPoolRoyaleItems());
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem('poolRailMarkerColor');
       if (stored && RAIL_MARKER_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
-        return stored;
+        if (ownedSet.has(makeInventoryKey('marker', stored))) return stored;
       }
     }
-    return DEFAULT_RAIL_MARKER_COLOR_ID;
+    if (ownedSet.has(makeInventoryKey('marker', DEFAULT_RAIL_MARKER_COLOR_ID))) {
+      return DEFAULT_RAIL_MARKER_COLOR_ID;
+    }
+    const firstOwned = RAIL_MARKER_COLOR_OPTIONS.find((opt) =>
+      ownedSet.has(makeInventoryKey('marker', opt.id))
+    );
+    return firstOwned?.id ?? DEFAULT_RAIL_MARKER_COLOR_ID;
   });
   const [lightingId, setLightingId] = useState(() => DEFAULT_LIGHTING_ID);
   const [chromeColorId, setChromeColorId] = useState(() => {
+    const ownedSet = new Set(getOwnedPoolRoyaleItems());
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem('poolChromeColor');
       if (stored && CHROME_COLOR_OPTIONS.some((opt) => opt.id === stored)) {
-        return stored;
+        if (ownedSet.has(makeInventoryKey('chrome', stored))) return stored;
       }
     }
-    return DEFAULT_CHROME_COLOR_ID;
+    if (ownedSet.has(makeInventoryKey('chrome', DEFAULT_CHROME_COLOR_ID))) {
+      return DEFAULT_CHROME_COLOR_ID;
+    }
+    const firstOwned = CHROME_COLOR_OPTIONS.find((opt) =>
+      ownedSet.has(makeInventoryKey('chrome', opt.id))
+    );
+    return firstOwned?.id ?? DEFAULT_CHROME_COLOR_ID;
   });
+  useEffect(() => {
+    const handler = (event) => {
+      const owned = event?.detail?.owned ?? loadPoolRoyaleInventory();
+      setOwnedPoolRoyaleItems(
+        Array.isArray(owned) ? owned : getOwnedPoolRoyaleItems()
+      );
+    };
+    window.addEventListener('poolRoyaleInventoryChanged', handler);
+    return () => window.removeEventListener('poolRoyaleInventoryChanged', handler);
+  }, []);
+  const ownedPoolRoyaleSet = useMemo(
+    () => new Set(getOwnedPoolRoyaleItems(ownedPoolRoyaleItems)),
+    [ownedPoolRoyaleItems]
+  );
+  const availableTableFinishOptions = useMemo(
+    () => filterOwnedOptions(TABLE_FINISH_OPTIONS, 'finish', ownedPoolRoyaleSet),
+    [ownedPoolRoyaleSet]
+  );
+  const availableClothOptions = useMemo(
+    () => filterOwnedOptions(CLOTH_COLOR_OPTIONS, 'cloth', ownedPoolRoyaleSet),
+    [ownedPoolRoyaleSet]
+  );
+  const availableChromeOptions = useMemo(
+    () => filterOwnedOptions(CHROME_COLOR_OPTIONS, 'chrome', ownedPoolRoyaleSet),
+    [ownedPoolRoyaleSet]
+  );
+  const availableRailMarkerColors = useMemo(
+    () => filterOwnedOptions(RAIL_MARKER_COLOR_OPTIONS, 'marker', ownedPoolRoyaleSet),
+    [ownedPoolRoyaleSet]
+  );
+  const availableRailMarkerShapes = useMemo(
+    () => filterOwnedOptions(RAIL_MARKER_SHAPE_OPTIONS, 'marker-shape', ownedPoolRoyaleSet),
+    [ownedPoolRoyaleSet]
+  );
+  const availableCueIndices = useMemo(
+    () =>
+      CUE_STYLE_PRESETS.reduce((indices, preset, index) => {
+        if (ownedPoolRoyaleSet.has(makeInventoryKey('cue', preset.id))) {
+          indices.push(index);
+        }
+        return indices;
+      }, []),
+    [ownedPoolRoyaleSet]
+  );
   const [frameRateId, setFrameRateId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(FRAME_RATE_STORAGE_KEY);
@@ -8212,17 +8301,68 @@ function PoolRoyaleGame({
     [broadcastSystemId]
   );
   const activeChromeOption = useMemo(
-    () => CHROME_COLOR_OPTIONS.find((opt) => opt.id === chromeColorId) ?? CHROME_COLOR_OPTIONS[0],
-    [chromeColorId]
+    () =>
+      availableChromeOptions.find((opt) => opt.id === chromeColorId) ??
+      availableChromeOptions[0] ??
+      CHROME_COLOR_OPTIONS[0],
+    [availableChromeOptions, chromeColorId]
   );
   const activeClothOption = useMemo(
-    () => CLOTH_COLOR_OPTIONS.find((opt) => opt.id === clothColorId) ?? CLOTH_COLOR_OPTIONS[0],
-    [clothColorId]
+    () =>
+      availableClothOptions.find((opt) => opt.id === clothColorId) ??
+      availableClothOptions[0] ??
+      CLOTH_COLOR_OPTIONS[0],
+    [availableClothOptions, clothColorId]
   );
   const activePocketLinerOption = useMemo(
     () => POCKET_LINER_OPTIONS.find((opt) => opt?.id === pocketLinerId) ?? POCKET_LINER_OPTIONS[0],
     [pocketLinerId]
   );
+  useEffect(() => {
+    const ownedFinishIds = new Set(availableTableFinishOptions.map((opt) => opt.id));
+    if (!ownedFinishIds.has(tableFinishId)) {
+      const fallback = availableTableFinishOptions[0]?.id ?? DEFAULT_TABLE_FINISH_ID;
+      setTableFinishId(fallback);
+    }
+  }, [availableTableFinishOptions, tableFinishId]);
+  useEffect(() => {
+    const ownedClothIds = new Set(availableClothOptions.map((opt) => opt.id));
+    if (!ownedClothIds.has(clothColorId)) {
+      const fallback = availableClothOptions[0]?.id ?? DEFAULT_CLOTH_COLOR_ID;
+      setClothColorId(fallback);
+    }
+  }, [availableClothOptions, clothColorId]);
+  useEffect(() => {
+    const ownedChromeIds = new Set(availableChromeOptions.map((opt) => opt.id));
+    if (!ownedChromeIds.has(chromeColorId)) {
+      const fallback = availableChromeOptions[0]?.id ?? DEFAULT_CHROME_COLOR_ID;
+      setChromeColorId(fallback);
+    }
+  }, [availableChromeOptions, chromeColorId]);
+  useEffect(() => {
+    const ownedRailColors = new Set(availableRailMarkerColors.map((opt) => opt.id));
+    if (!ownedRailColors.has(railMarkerColorId)) {
+      const fallback = availableRailMarkerColors[0]?.id ?? DEFAULT_RAIL_MARKER_COLOR_ID;
+      setRailMarkerColorId(fallback);
+    }
+  }, [availableRailMarkerColors, railMarkerColorId]);
+  useEffect(() => {
+    const ownedRailShapes = new Set(availableRailMarkerShapes.map((opt) => opt.id));
+    if (!ownedRailShapes.has(railMarkerShapeId)) {
+      const fallback = availableRailMarkerShapes[0]?.id ?? DEFAULT_RAIL_MARKER_SHAPE;
+      setRailMarkerShapeId(fallback);
+    }
+  }, [availableRailMarkerShapes, railMarkerShapeId]);
+  const availableCueIndicesRef = useRef([]);
+  useEffect(() => {
+    availableCueIndicesRef.current = availableCueIndices;
+  }, [availableCueIndices]);
+  useEffect(() => {
+    if (!availableCueIndices.length) return;
+    if (!availableCueIndices.includes(cueStyleIndex)) {
+      setCueStyleIndex(availableCueIndices[0]);
+    }
+  }, [availableCueIndices, cueStyleIndex]);
   const isTraining = playType === 'training';
   const [trainingMenuOpen, setTrainingMenuOpen] = useState(false);
   const [trainingModeState, setTrainingModeState] = useState(
@@ -8375,16 +8515,32 @@ function PoolRoyaleGame({
   const chalkAssistTargetRef = useRef(false);
   const visibleChalkIndexRef = useRef(null);
   const [cueStyleIndex, setCueStyleIndex] = useState(() => {
+    const ownedSet = new Set(getOwnedPoolRoyaleItems());
+    const availableIndices = CUE_STYLE_PRESETS.reduce((acc, preset, index) => {
+      if (ownedSet.has(makeInventoryKey('cue', preset.id))) acc.push(index);
+      return acc;
+    }, []);
+    const paletteLength = CUE_STYLE_PRESETS.length || 1;
+    const defaultIndex = Math.max(
+      0,
+      CUE_STYLE_PRESETS.findIndex((preset) => preset.id === DEFAULT_CUE_STYLE_ID)
+    );
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(CUE_STYLE_STORAGE_KEY);
       if (stored != null) {
         const parsed = Number.parseInt(stored, 10);
         if (Number.isFinite(parsed) && parsed >= 0) {
-          return parsed % CUE_RACK_PALETTE.length;
+          const normalized = ((parsed % paletteLength) + paletteLength) % paletteLength;
+          if (availableIndices.includes(normalized)) {
+            return normalized;
+          }
         }
       }
     }
-    return 0;
+    if (availableIndices.includes(defaultIndex)) {
+      return defaultIndex;
+    }
+    return availableIndices[0] ?? 0;
   });
   const cueStyleIndexRef = useRef(cueStyleIndex);
   const cueRackGroupsRef = useRef([]);
@@ -9167,6 +9323,7 @@ function PoolRoyaleGame({
       if (!charged) return;
       const paletteLength = CUE_RACK_PALETTE.length || 1;
       const normalized = ((index % paletteLength) + paletteLength) % paletteLength;
+      if (!availableCueIndicesRef.current.includes(normalized)) return;
       applySelectedCueStyle(normalized);
       setCueStyleIndex(normalized);
     },
@@ -16594,7 +16751,7 @@ function PoolRoyaleGame({
                   Table Finish
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {TABLE_FINISH_OPTIONS.map((option) => {
+                  {availableTableFinishOptions.map((option) => {
                     const active = option.id === tableFinishId;
                     return (
                       <button
@@ -16619,7 +16776,7 @@ function PoolRoyaleGame({
                   Chrome Plates
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {CHROME_COLOR_OPTIONS.map((option) => {
+                  {availableChromeOptions.map((option) => {
                     const active = option.id === chromeColorId;
                     return (
                       <button
@@ -16651,7 +16808,8 @@ function PoolRoyaleGame({
                   Cue Styles
                 </h3>
                 <div className="mt-2 grid grid-cols-2 gap-2">
-                  {CUE_STYLE_PRESETS.map((preset, index) => {
+                  {availableCueIndices.map((index) => {
+                    const preset = CUE_STYLE_PRESETS[index];
                     const active = cueStyleIndex === index;
                     return (
                       <button
@@ -16671,13 +16829,13 @@ function PoolRoyaleGame({
                   })}
                 </div>
               </div>
-              {CLOTH_COLOR_OPTIONS.length > 1 ? (
+              {availableClothOptions.length > 1 ? (
                 <div>
                   <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                     Cloth Color
                   </h3>
                   <div className="mt-2 flex flex-wrap gap-2">
-                    {CLOTH_COLOR_OPTIONS.map((option) => {
+                    {availableClothOptions.map((option) => {
                       const active = option.id === clothColorId;
                       return (
                         <button
@@ -16710,7 +16868,7 @@ function PoolRoyaleGame({
                   Rail Markers
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {RAIL_MARKER_SHAPE_OPTIONS.map((option) => {
+                  {availableRailMarkerShapes.map((option) => {
                     const active = option.id === railMarkerShapeId;
                     return (
                       <button
@@ -16730,7 +16888,7 @@ function PoolRoyaleGame({
                   })}
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {RAIL_MARKER_COLOR_OPTIONS.map((option) => {
+                  {availableRailMarkerColors.map((option) => {
                     const active = option.id === railMarkerColorId;
                     return (
                       <button

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -27,6 +27,7 @@ import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
 import DevTasksModal from '../components/DevTasksModal.jsx';
 import Wallet from './Wallet.jsx';
 import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
+import { getOwnedPoolRoyaleStoreItems } from '../utils/poolRoyaleInventory.js';
 
 import { FiCopy } from 'react-icons/fi';
 
@@ -77,6 +78,9 @@ export default function MyAccount() {
   const [twitterError, setTwitterError] = useState('');
   const [twitterLink, setTwitterLink] = useState('');
   const [unread, setUnread] = useState(0);
+  const [ownedPoolItems, setOwnedPoolItems] = useState(() =>
+    getOwnedPoolRoyaleStoreItems()
+  );
   const [googleLinked, setGoogleLinked] = useState(!!googleId);
 
   useEffect(() => {
@@ -171,6 +175,20 @@ export default function MyAccount() {
     window.addEventListener('profilePhotoUpdated', handler);
     return () => window.removeEventListener('profilePhotoUpdated', handler);
   }, [telegramId]);
+
+  useEffect(() => {
+    setOwnedPoolItems(getOwnedPoolRoyaleStoreItems());
+    const handler = (event) => {
+      const owned = event?.detail?.owned;
+      if (Array.isArray(owned)) {
+        setOwnedPoolItems(getOwnedPoolRoyaleStoreItems(owned));
+      } else {
+        setOwnedPoolItems(getOwnedPoolRoyaleStoreItems());
+      }
+    };
+    window.addEventListener('poolRoyaleInventoryChanged', handler);
+    return () => window.removeEventListener('poolRoyaleInventoryChanged', handler);
+  }, []);
 
   if (!profile) return <div className="p-4 text-subtext">Loading...</div>;
 
@@ -452,6 +470,32 @@ export default function MyAccount() {
           <InfluencerClaimsCard />
         </>
       )}
+
+      <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-white-shadow">Pool Royale Inventory</h3>
+          <span className="text-[11px] uppercase tracking-[0.25em] text-subtext">
+            {ownedPoolItems.length} item{ownedPoolItems.length === 1 ? '' : 's'}
+          </span>
+        </div>
+        {ownedPoolItems.length === 0 ? (
+          <p className="text-sm text-subtext">No Pool Royale cosmetics owned yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {ownedPoolItems.map((item) => (
+              <li
+                key={item.id}
+                className="flex items-center justify-between rounded-xl bg-white/5 px-3 py-2"
+              >
+                <span className="font-semibold text-white-shadow">{item.name}</span>
+                <span className="text-xs uppercase tracking-[0.2em] text-subtext">
+                  {item.category}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
 
       {/* Wallet section */}
       <Wallet hideClaim />

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1,12 +1,163 @@
+import { useEffect, useMemo, useState } from 'react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
+import {
+  POOL_ROYALE_STORE_ITEMS,
+  getOwnedPoolRoyaleItems,
+  getOwnedPoolRoyaleStoreItems,
+  purchasePoolRoyaleItem
+} from '../utils/poolRoyaleInventory.js';
+
+function TpcBadge() {
+  return (
+    <span className="inline-flex items-center justify-center rounded-full bg-gradient-to-br from-amber-300 via-yellow-400 to-orange-500 px-2 py-0.5 text-[10px] font-black text-black shadow-[0_6px_16px_rgba(250,204,21,0.45)]">
+      TPC
+    </span>
+  );
+}
+
+function PriceTag({ amount }) {
+  if (!amount) return <span className="text-emerald-300 font-semibold">Included</span>;
+  return (
+    <span className="inline-flex items-center gap-1 font-semibold text-amber-200">
+      <TpcBadge />
+      {amount.toLocaleString()}
+    </span>
+  );
+}
+
+function StoreCard({ item, owned, onPurchase }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-lg backdrop-blur">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="text-sm font-semibold text-white">{item.name}</p>
+          <p className="text-xs text-white/70">{item.description}</p>
+          {item.tradable === false && (
+            <p className="mt-1 text-[10px] uppercase tracking-[0.2em] text-emerald-200/80">
+              Included • Non-tradable
+            </p>
+          )}
+        </div>
+        <PriceTag amount={item.priceTpc} />
+      </div>
+      <div className="mt-3 flex items-center justify-between">
+        <span className="text-[11px] uppercase tracking-[0.25em] text-white/70">
+          {item.category}
+        </span>
+        <button
+          type="button"
+          disabled={owned}
+          onClick={() => onPurchase(item.id)}
+          className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+            owned
+              ? 'cursor-not-allowed border border-emerald-400/30 bg-emerald-400/20 text-emerald-100'
+              : 'border border-amber-300/60 bg-amber-300/20 text-amber-100 hover:bg-amber-300/40'
+          }`}
+        >
+          {owned ? 'Owned' : 'Buy NFT'}
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export default function Store() {
   useTelegramBackButton();
+  const [ownedItems, setOwnedItems] = useState(() => new Set(getOwnedPoolRoyaleItems()));
+
+  useEffect(() => {
+    const handler = (event) => {
+      const updated = event?.detail?.owned;
+      if (Array.isArray(updated)) {
+        setOwnedItems(new Set(updated));
+      } else {
+        setOwnedItems(new Set(getOwnedPoolRoyaleItems()));
+      }
+    };
+    window.addEventListener('poolRoyaleInventoryChanged', handler);
+    return () => window.removeEventListener('poolRoyaleInventoryChanged', handler);
+  }, []);
+
+  const ownedPoolItems = useMemo(
+    () => new Set(getOwnedPoolRoyaleStoreItems(ownedItems)),
+    [ownedItems]
+  );
+
+  const poolRoyaleIncluded = useMemo(
+    () => POOL_ROYALE_STORE_ITEMS.filter((item) => item.priceTpc === 0),
+    []
+  );
+  const poolRoyaleUpgrades = useMemo(
+    () => POOL_ROYALE_STORE_ITEMS.filter((item) => item.priceTpc > 0),
+    []
+  );
+
+  const handlePurchase = (itemId) => {
+    const updated = purchasePoolRoyaleItem(itemId);
+    setOwnedItems(new Set(updated));
+  };
 
   return (
-    <div className="relative p-4 space-y-4 text-text flex flex-col items-center">
-      <h2 className="text-xl font-bold">Store</h2>
-      <p className="text-subtext text-sm">No bundles are currently available.</p>
+    <div className="relative p-4 space-y-6 text-text">
+      <div className="space-y-1">
+        <h2 className="text-xl font-bold text-white">Store</h2>
+        <p className="text-subtext text-sm">
+          Pool Royale cosmetics now live as NFTs. Default gear stays free so you can jump in and play.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-lg backdrop-blur">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-white">Pool Royale Starter Kit</h3>
+          <span className="text-[11px] uppercase tracking-[0.25em] text-emerald-200/80">Included</span>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2">
+          {poolRoyaleIncluded.map((item) => (
+            <StoreCard
+              key={item.id}
+              item={item}
+              owned={ownedItems.has(item.id)}
+              onPurchase={handlePurchase}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-lg backdrop-blur">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-white">Pool Royale NFT Upgrades</h3>
+          <span className="text-[11px] uppercase tracking-[0.25em] text-amber-200/80">Cosmetics</span>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2">
+          {poolRoyaleUpgrades.map((item) => (
+            <StoreCard
+              key={item.id}
+              item={item}
+              owned={ownedItems.has(item.id)}
+              onPurchase={handlePurchase}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-lg backdrop-blur">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-white">Account Inventory</h3>
+          <span className="text-[11px] uppercase tracking-[0.25em] text-white/70">Pool Royale</span>
+        </div>
+        {ownedPoolItems.size === 0 ? (
+          <p className="text-sm text-subtext">No Pool Royale items owned yet.</p>
+        ) : (
+          <ul className="space-y-2 text-sm text-white">
+            {Array.from(ownedPoolItems).map((item) => (
+              <li key={item.id} className="flex items-center justify-between rounded-xl bg-white/5 px-3 py-2">
+                <span className="font-semibold">{item.name}</span>
+                <span className="text-[11px] uppercase tracking-[0.2em] text-white/70">{item.category}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </div>
   );
 }

--- a/webapp/src/utils/poolRoyaleInventory.js
+++ b/webapp/src/utils/poolRoyaleInventory.js
@@ -1,0 +1,265 @@
+const STORAGE_KEY = 'poolRoyaleOwnedItems';
+
+export const POOL_ROYALE_FREE_ITEMS = Object.freeze([
+  'finish:charredTimber',
+  'chrome:gold',
+  'cloth:freshGreen',
+  'cue:birch-frost',
+  'marker:gold',
+  'marker-shape:diamond'
+]);
+
+export const POOL_ROYALE_STORE_ITEMS = Object.freeze([
+  {
+    id: 'finish:charredTimber',
+    name: 'Charred Timber Table',
+    description: 'Baseline table finish included for every player.',
+    priceTpc: 0,
+    category: 'finish',
+    optionId: 'charredTimber',
+    tradable: false
+  },
+  {
+    id: 'finish:rusticSplit',
+    name: 'Rustic Split Finish',
+    description: 'Warm studio wood treatment for the rails and frame.',
+    priceTpc: 1800,
+    category: 'finish',
+    optionId: 'rusticSplit'
+  },
+  {
+    id: 'finish:plankStudio',
+    name: 'Plank Studio Finish',
+    description: 'Cinematic honey oak planks with satin sheen.',
+    priceTpc: 2100,
+    category: 'finish',
+    optionId: 'plankStudio'
+  },
+  {
+    id: 'finish:weatheredGrey',
+    name: 'Weathered Grey Finish',
+    description: 'Smoked oak palette with brushed metal trim.',
+    priceTpc: 2400,
+    category: 'finish',
+    optionId: 'weatheredGrey'
+  },
+  {
+    id: 'finish:jetBlackCarbon',
+    name: 'Jet Black Carbon',
+    description: 'Matte carbon fibre rails with graphite sheen.',
+    priceTpc: 3000,
+    category: 'finish',
+    optionId: 'jetBlackCarbon'
+  },
+  {
+    id: 'chrome:gold',
+    name: 'Gold Chrome Plates',
+    description: 'Tournament spec gold fascia for every pocket.',
+    priceTpc: 0,
+    category: 'chrome',
+    optionId: 'gold',
+    tradable: false
+  },
+  {
+    id: 'chrome:chrome',
+    name: 'Polished Chrome Plates',
+    description: 'Silver mirror finish on the pocket fascias.',
+    priceTpc: 950,
+    category: 'chrome',
+    optionId: 'chrome'
+  },
+  {
+    id: 'cloth:freshGreen',
+    name: 'Tour Green Cloth',
+    description: 'Official tour-grade green nap with lively bounce.',
+    priceTpc: 0,
+    category: 'cloth',
+    optionId: 'freshGreen',
+    tradable: false
+  },
+  {
+    id: 'cloth:graphite',
+    name: 'Arcadia Graphite Cloth',
+    description: 'Dark graphite cloth with reduced sparkle.',
+    priceTpc: 1300,
+    category: 'cloth',
+    optionId: 'graphite'
+  },
+  {
+    id: 'cloth:arcticBlue',
+    name: 'Arctic Blue Cloth',
+    description: 'Cool ice-blue felt with crisp highlights.',
+    priceTpc: 1500,
+    category: 'cloth',
+    optionId: 'arcticBlue'
+  },
+  {
+    id: 'cue:birch-frost',
+    name: 'Birch Frost Cue',
+    description: 'Frosted birch shaft with pearl grain—standard issue.',
+    priceTpc: 0,
+    category: 'cue',
+    optionId: 'birch-frost',
+    tradable: false
+  },
+  {
+    id: 'cue:redwood-ember',
+    name: 'Redwood Ember Cue',
+    description: 'Rich ember gradient on a redwood butt.',
+    priceTpc: 1000,
+    category: 'cue',
+    optionId: 'redwood-ember'
+  },
+  {
+    id: 'cue:wenge-nightfall',
+    name: 'Wenge Nightfall Cue',
+    description: 'Deep nightfall finish with high-contrast veins.',
+    priceTpc: 1350,
+    category: 'cue',
+    optionId: 'wenge-nightfall'
+  },
+  {
+    id: 'cue:mahogany-heritage',
+    name: 'Mahogany Heritage Cue',
+    description: 'Classic mahogany gloss with heritage rings.',
+    priceTpc: 1600,
+    category: 'cue',
+    optionId: 'mahogany-heritage'
+  },
+  {
+    id: 'cue:walnut-satin',
+    name: 'Walnut Satin Cue',
+    description: 'Balanced walnut satin sheen for control players.',
+    priceTpc: 1500,
+    category: 'cue',
+    optionId: 'walnut-satin'
+  },
+  {
+    id: 'cue:carbon-matrix',
+    name: 'Carbon Matrix Cue',
+    description: 'Technical carbon weave with metallic rings.',
+    priceTpc: 1850,
+    category: 'cue',
+    optionId: 'carbon-matrix'
+  },
+  {
+    id: 'cue:maple-horizon',
+    name: 'Maple Horizon Cue',
+    description: 'Bright maple cue with horizon fade.',
+    priceTpc: 1200,
+    category: 'cue',
+    optionId: 'maple-horizon'
+  },
+  {
+    id: 'cue:graphite-aurora',
+    name: 'Graphite Aurora Cue',
+    description: 'Graphite core with aurora tint for break shots.',
+    priceTpc: 1900,
+    category: 'cue',
+    optionId: 'graphite-aurora'
+  },
+  {
+    id: 'marker:gold',
+    name: 'Gold Rail Diamonds',
+    description: 'Default gold markers to match the chrome set.',
+    priceTpc: 0,
+    category: 'marker',
+    optionId: 'gold',
+    tradable: false
+  },
+  {
+    id: 'marker:chrome',
+    name: 'Chrome Rail Diamonds',
+    description: 'Silver diamonds to match chrome fascias.',
+    priceTpc: 600,
+    category: 'marker',
+    optionId: 'chrome'
+  },
+  {
+    id: 'marker:pearl',
+    name: 'Pearl Rail Diamonds',
+    description: 'Pearl rail sights with soft sheen.',
+    priceTpc: 850,
+    category: 'marker',
+    optionId: 'pearl'
+  },
+  {
+    id: 'marker-shape:diamond',
+    name: 'Diamond Markers',
+    description: 'Standard diamond shape on the rails.',
+    priceTpc: 0,
+    category: 'marker-shape',
+    optionId: 'diamond',
+    tradable: false
+  },
+  {
+    id: 'marker-shape:circle',
+    name: 'Circle Markers',
+    description: 'Alternate circular rail markers.',
+    priceTpc: 700,
+    category: 'marker-shape',
+    optionId: 'circle'
+  }
+]);
+
+export function makeInventoryKey(category, optionId) {
+  return `${category}:${optionId}`;
+}
+
+function normalizeInventory(list = []) {
+  const parsed = Array.isArray(list) ? list : [];
+  const owned = new Set([...POOL_ROYALE_FREE_ITEMS]);
+  parsed.forEach((id) => {
+    if (typeof id === 'string') owned.add(id);
+  });
+  return owned;
+}
+
+export function loadPoolRoyaleInventory() {
+  if (typeof window === 'undefined') return Array.from(POOL_ROYALE_FREE_ITEMS);
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    const parsed = stored ? JSON.parse(stored) : [];
+    return Array.from(normalizeInventory(parsed));
+  } catch {
+    return Array.from(POOL_ROYALE_FREE_ITEMS);
+  }
+}
+
+function persistInventory(ownedSet) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(ownedSet)));
+  } catch {}
+}
+
+export function purchasePoolRoyaleItem(itemId) {
+  const owned = normalizeInventory(loadPoolRoyaleInventory());
+  owned.add(itemId);
+  persistInventory(owned);
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('poolRoyaleInventoryChanged', { detail: { owned: Array.from(owned) } })
+    );
+  }
+  return Array.from(owned);
+}
+
+export function isPoolRoyaleItemOwned(itemId, ownedSet) {
+  const collection = ownedSet ? new Set(ownedSet) : normalizeInventory(loadPoolRoyaleInventory());
+  return collection.has(itemId);
+}
+
+export function filterOwnedOptions(options, category, ownedSet) {
+  const set = ownedSet ? new Set(ownedSet) : normalizeInventory(loadPoolRoyaleInventory());
+  return options.filter((opt) => set.has(makeInventoryKey(category, opt.id)));
+}
+
+export function getOwnedPoolRoyaleItems(ownedSet) {
+  return Array.from(ownedSet ? new Set(ownedSet) : normalizeInventory(loadPoolRoyaleInventory()));
+}
+
+export function getOwnedPoolRoyaleStoreItems(ownedSet) {
+  const set = ownedSet ? new Set(ownedSet) : normalizeInventory(loadPoolRoyaleInventory());
+  return POOL_ROYALE_STORE_ITEMS.filter((item) => set.has(item.id));
+}


### PR DESCRIPTION
## Summary
- set Pool Royale defaults to free non-tradable options and gate customization choices behind owned NFTs
- add Pool Royale storefront listings with TPC pricing and synchronized account inventory display
- introduce shared Pool Royale inventory utilities to keep store, account, and table setup in sync

## Testing
- npm test *(fails: jest config references missing tests directory)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d6711a6308329bac0098f8c981832)