### PR TITLE
Fix Pool Royale pocket liner selection

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8277,6 +8277,13 @@ function PoolRoyaleGame({
       ),
     [poolInventory]
   );
+  const availablePocketLiners = useMemo(
+    () =>
+      POCKET_LINER_OPTIONS.filter((option) =>
+        isPoolOptionUnlocked('pocketLiner', option.id, poolInventory)
+      ),
+    [poolInventory]
+  );
   const availableCueStyles = useMemo(
     () =>
       CUE_STYLE_PRESETS.map((preset, index) => ({ preset, index })).filter(({ preset }) =>
@@ -8298,6 +8305,13 @@ function PoolRoyaleGame({
       CLOTH_COLOR_OPTIONS[0],
     [availableClothOptions, clothColorId]
   );
+  const activePocketLinerOption = useMemo(
+    () =>
+      availablePocketLiners.find((opt) => opt?.id === pocketLinerId) ??
+      availablePocketLiners[0] ??
+      POCKET_LINER_OPTIONS[0],
+    [availablePocketLiners, pocketLinerId]
+  );
   useEffect(() => {
     if (!isPoolOptionUnlocked('tableFinish', tableFinishId, poolInventory)) {
       setTableFinishId(DEFAULT_TABLE_FINISH_ID);
@@ -8311,9 +8325,13 @@ function PoolRoyaleGame({
     if (!isPoolOptionUnlocked('railMarkerColor', railMarkerColorId, poolInventory)) {
       setRailMarkerColorId(DEFAULT_RAIL_MARKER_COLOR_ID);
     }
+    if (!isPoolOptionUnlocked('pocketLiner', pocketLinerId, poolInventory)) {
+      setPocketLinerId(DEFAULT_POCKET_LINER_OPTION_ID);
+    }
   }, [
     chromeColorId,
     clothColorId,
+    pocketLinerId,
     poolInventory,
     railMarkerColorId,
     tableFinishId


### PR DESCRIPTION
## Summary
- add pocket liner availability and active selection lookups to Pool Royale
- reset stored pocket liner choice when it is not unlocked and reuse unlock checks

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d733abc6483298b497f35191d5adb)