### PR TITLE
Add Chess Battle Royal cosmetics gating and store integration

### DIFF
--- a/webapp/src/config/chessBattleRoyalInventoryConfig.js
+++ b/webapp/src/config/chessBattleRoyalInventoryConfig.js
@@ -1,0 +1,198 @@
+export const CHESS_BATTLE_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
+  tableWood: ['lightNatural'],
+  tableCloth: ['crimson'],
+  tableBase: ['obsidian'],
+  chairColor: ['crimsonVelvet'],
+  tableShape: ['classicOctagon']
+});
+
+export const CHESS_BATTLE_ROYALE_OPTION_LABELS = Object.freeze({
+  tableWood: Object.freeze({
+    lightNatural: 'Light Natural Wood',
+    warmBrown: 'Warm Brown Wood',
+    cleanStrips: 'Clean Strips Wood',
+    oldWoodFloor: 'Old Wood Floor'
+  }),
+  tableCloth: Object.freeze({
+    crimson: 'Crimson Cloth',
+    emerald: 'Emerald Cloth',
+    arctic: 'Arctic Cloth',
+    sunset: 'Sunset Cloth',
+    violet: 'Violet Cloth',
+    amber: 'Amber Cloth'
+  }),
+  tableBase: Object.freeze({
+    obsidian: 'Obsidian Base',
+    forestBronze: 'Forest Base',
+    midnightChrome: 'Midnight Base',
+    emberCopper: 'Copper Base',
+    violetShadow: 'Violet Shadow Base',
+    desertGold: 'Desert Base'
+  }),
+  chairColor: Object.freeze({
+    crimsonVelvet: 'Crimson Velvet Chairs',
+    midnightNavy: 'Midnight Blue Chairs',
+    emeraldWave: 'Emerald Wave Chairs',
+    onyxShadow: 'Onyx Shadow Chairs',
+    royalPlum: 'Royal Chestnut Chairs'
+  }),
+  tableShape: Object.freeze({
+    classicOctagon: 'Oktagon Klasik',
+    grandOval: 'Oval Grand'
+  })
+});
+
+export const CHESS_BATTLE_ROYALE_STORE_ITEMS = [
+  {
+    id: 'wood-warmBrown',
+    type: 'tableWood',
+    optionId: 'warmBrown',
+    name: 'Warm Brown Wood',
+    price: 520,
+    description: 'Walnut-inspired rails with rich brown grain.'
+  },
+  {
+    id: 'wood-cleanStrips',
+    type: 'tableWood',
+    optionId: 'cleanStrips',
+    name: 'Clean Strips Wood',
+    price: 560,
+    description: 'Striped oak planks with satin finish.'
+  },
+  {
+    id: 'wood-oldWoodFloor',
+    type: 'tableWood',
+    optionId: 'oldWoodFloor',
+    name: 'Old Wood Floor',
+    price: 610,
+    description: 'Weathered wood floor texture with deep grain.'
+  },
+  {
+    id: 'cloth-emerald',
+    type: 'tableCloth',
+    optionId: 'emerald',
+    name: 'Emerald Cloth',
+    price: 310,
+    description: 'Saturated emerald felt with dark undertones.'
+  },
+  {
+    id: 'cloth-arctic',
+    type: 'tableCloth',
+    optionId: 'arctic',
+    name: 'Arctic Cloth',
+    price: 330,
+    description: 'Cool arctic blue felt with clean sheen.'
+  },
+  {
+    id: 'cloth-sunset',
+    type: 'tableCloth',
+    optionId: 'sunset',
+    name: 'Sunset Cloth',
+    price: 340,
+    description: 'Copper-orange felt for a warmer arena.'
+  },
+  {
+    id: 'cloth-violet',
+    type: 'tableCloth',
+    optionId: 'violet',
+    name: 'Violet Cloth',
+    price: 340,
+    description: 'Deep violet felt with bright trim.'
+  },
+  {
+    id: 'cloth-amber',
+    type: 'tableCloth',
+    optionId: 'amber',
+    name: 'Amber Cloth',
+    price: 350,
+    description: 'Amber-toned felt with smoky shadows.'
+  },
+  {
+    id: 'base-forestBronze',
+    type: 'tableBase',
+    optionId: 'forestBronze',
+    name: 'Forest Base',
+    price: 450,
+    description: 'Deep green base with bronze highlights.'
+  },
+  {
+    id: 'base-midnightChrome',
+    type: 'tableBase',
+    optionId: 'midnightChrome',
+    name: 'Midnight Base',
+    price: 470,
+    description: 'Midnight chrome base with cool trim.'
+  },
+  {
+    id: 'base-emberCopper',
+    type: 'tableBase',
+    optionId: 'emberCopper',
+    name: 'Copper Base',
+    price: 470,
+    description: 'Copper-infused base with ember warmth.'
+  },
+  {
+    id: 'base-violetShadow',
+    type: 'tableBase',
+    optionId: 'violetShadow',
+    name: 'Violet Shadow Base',
+    price: 480,
+    description: 'Violet shadowed base with reflective trim.'
+  },
+  {
+    id: 'base-desertGold',
+    type: 'tableBase',
+    optionId: 'desertGold',
+    name: 'Desert Base',
+    price: 480,
+    description: 'Desert gold base with muted metallics.'
+  },
+  {
+    id: 'chair-midnightNavy',
+    type: 'chairColor',
+    optionId: 'midnightNavy',
+    name: 'Midnight Blue Chairs',
+    price: 260,
+    description: 'Navy upholstery with cool highlights.'
+  },
+  {
+    id: 'chair-emeraldWave',
+    type: 'chairColor',
+    optionId: 'emeraldWave',
+    name: 'Emerald Wave Chairs',
+    price: 260,
+    description: 'Emerald upholstery with deep green accents.'
+  },
+  {
+    id: 'chair-onyxShadow',
+    type: 'chairColor',
+    optionId: 'onyxShadow',
+    name: 'Onyx Shadow Chairs',
+    price: 280,
+    description: 'Onyx upholstery with soft graphite highlights.'
+  },
+  {
+    id: 'chair-royalPlum',
+    type: 'chairColor',
+    optionId: 'royalPlum',
+    name: 'Royal Chestnut Chairs',
+    price: 280,
+    description: 'Royal plum upholstery with chestnut accents.'
+  },
+  {
+    id: 'shape-grandOval',
+    type: 'tableShape',
+    optionId: 'grandOval',
+    name: 'Oval Grand Shape',
+    price: 520,
+    description: 'Rounded oval silhouette with wider seating lanes.'
+  }
+];
+
+export const CHESS_BATTLE_ROYALE_DEFAULT_LOADOUT = [
+  { type: 'tableWood', optionId: 'lightNatural', label: 'Light Natural Wood' },
+  { type: 'tableCloth', optionId: 'crimson', label: 'Crimson Cloth' },
+  { type: 'tableBase', optionId: 'obsidian', label: 'Obsidian Base' },
+  { type: 'chairColor', optionId: 'crimsonVelvet', label: 'Crimson Velvet Chairs' },
+  { type: 'tableShape', optionId: 'classicOctagon', label: 'Oktagon Klasik' }
+];

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -42,6 +42,11 @@ import { getAIOpponentFlag } from '../../utils/aiOpponentFlag.js';
 import { ipToFlag } from '../../utils/conflictMatchmaking.js';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
 import { socket } from '../../utils/socket.js';
+import {
+  chessBattleAccountId,
+  getChessBattleRoyalInventory,
+  isChessBattleOptionUnlocked
+} from '../../utils/chessBattleRoyalInventory.js';
 
 /**
  * CHESS 3D — Procedural, Modern Look (no external models)
@@ -1012,6 +1017,7 @@ const PLAYER_FLAG_STORAGE_KEY = 'chessBattleRoyalPlayerFlag';
 const FALLBACK_FLAG = '🇺🇸';
 const DEFAULT_APPEARANCE = {
   ...DEFAULT_TABLE_CUSTOMIZATION,
+  tableCloth: 0,
   chairColor: 0,
   tableShape: 0,
   boardColor: 0,
@@ -1076,11 +1082,16 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_MENU_OPTIONS }
 ];
 
-function normalizeAppearance(value = {}) {
+function normalizeAppearance(value = {}, availability = {}) {
   const normalized = { ...DEFAULT_APPEARANCE };
   const fallbackPieceStyleIndex = Number.isFinite(value?.pieceStyle)
     ? Math.min(Math.max(0, Math.round(value.pieceStyle)), PIECE_STYLE_OPTIONS.length - 1)
     : null;
+  const resolveAllowed = (key, max) => {
+    const allowed = (availability?.[key] || []).filter((idx) => Number.isFinite(idx) && idx >= 0 && idx < max);
+    if (allowed.length > 0) return allowed;
+    return Array.from({ length: max }, (_, idx) => idx);
+  };
   const entries = [
     ['tableWood', TABLE_WOOD_OPTIONS.length],
     ['tableCloth', TABLE_CLOTH_OPTIONS.length],
@@ -1089,11 +1100,14 @@ function normalizeAppearance(value = {}) {
     ['tableShape', TABLE_SHAPE_MENU_OPTIONS.length]
   ];
   entries.forEach(([key, max]) => {
+    const allowed = resolveAllowed(key, max);
     const raw = Number(value?.[key]);
-    const source = Number.isFinite(raw) ? raw : fallbackPieceStyleIndex;
-    if (!Number.isFinite(source)) return;
-    const clamped = Math.min(Math.max(0, Math.round(source)), max - 1);
-    normalized[key] = clamped;
+    const source = Number.isFinite(raw) ? Math.round(raw) : fallbackPieceStyleIndex;
+    if (Number.isFinite(source) && allowed.includes(source)) {
+      normalized[key] = source;
+      return;
+    }
+    normalized[key] = allowed[0] ?? 0;
   });
   normalized.boardColor = DEFAULT_APPEARANCE.boardColor;
   normalized.whitePieceStyle = DEFAULT_APPEARANCE.whitePieceStyle;
@@ -5140,21 +5154,53 @@ function Chess3D({
   const boardMaterialCacheRef = useRef({ gltf: new Map(), procedural: null });
   const pawnHeadMaterialCacheRef = useRef(new Map());
   const rankSwapAppliedRef = useRef(false);
+  const [inventory, setInventory] = useState(() => getChessBattleRoyalInventory(accountId));
+  const availability = useMemo(() => {
+    const build = (type, options) =>
+      options.reduce((acc, option, idx) => {
+        if (idx === 0 || isChessBattleOptionUnlocked(type, option.id, inventory)) {
+          acc.push(idx);
+        }
+        return acc;
+      }, []);
+    return {
+      tableWood: build('tableWood', TABLE_WOOD_OPTIONS),
+      tableCloth: build('tableCloth', TABLE_CLOTH_OPTIONS),
+      tableBase: build('tableBase', TABLE_BASE_OPTIONS),
+      chairColor: build('chairColor', CHAIR_COLOR_OPTIONS),
+      tableShape: build('tableShape', TABLE_SHAPE_MENU_OPTIONS)
+    };
+  }, [inventory]);
+  const availabilityRef = useRef(availability);
+  const customizationSections = useMemo(() => {
+    const attachIndices = (section) => {
+      const sourceOptions = section.options || [];
+      const allowed = availability?.[section.key];
+      const options = (Array.isArray(allowed) && allowed.length
+        ? allowed
+            .map((idx) => (sourceOptions[idx] ? { ...sourceOptions[idx], __index: idx } : null))
+            .filter(Boolean)
+        : sourceOptions.map((opt, idx) => ({ ...opt, __index: idx }))
+      ).filter(Boolean);
+      return { ...section, options };
+    };
+    return CUSTOMIZATION_SECTIONS.map(attachIndices);
+  }, [availability]);
   const [appearance, setAppearance] = useState(() => {
     if (typeof window === 'undefined') return { ...DEFAULT_APPEARANCE };
     try {
       const stored = window.localStorage?.getItem(APPEARANCE_STORAGE_KEY);
       if (stored) {
-        const normalized = normalizeAppearance(JSON.parse(stored));
+        const normalized = normalizeAppearance(JSON.parse(stored), availability);
         return normalized;
       }
     } catch {}
-    return { ...DEFAULT_APPEARANCE };
+    return normalizeAppearance(DEFAULT_APPEARANCE, availability);
   });
   const appearanceRef = useRef(appearance);
   const paletteRef = useRef(createChessPalette(appearance));
   const [activeCustomizationKey, setActiveCustomizationKey] = useState(
-    CUSTOMIZATION_SECTIONS[0]?.key ?? 'tableWood'
+    customizationSections[0]?.key ?? 'tableWood'
   );
   const seatPositionsRef = useRef([]);
   const resolvedInitialFlag = useMemo(() => {
@@ -5420,7 +5466,7 @@ function Chess3D({
   }, []);
 
   const resetAppearance = useCallback(() => {
-    setAppearance({ ...DEFAULT_APPEARANCE });
+    setAppearance(normalizeAppearance(DEFAULT_APPEARANCE, availabilityRef.current));
     if (typeof window !== 'undefined') {
       try {
         window.localStorage?.removeItem(APPEARANCE_STORAGE_KEY);
@@ -5439,7 +5485,26 @@ function Chess3D({
   }, [seatAnchors]);
 
   const activeCustomizationSection =
-    CUSTOMIZATION_SECTIONS.find(({ key }) => key === activeCustomizationKey) ?? CUSTOMIZATION_SECTIONS[0];
+    customizationSections.find(({ key }) => key === activeCustomizationKey) ?? customizationSections[0];
+
+  useEffect(() => {
+    setInventory(getChessBattleRoyalInventory(accountId));
+  }, [accountId]);
+
+  useEffect(() => {
+    availabilityRef.current = availability;
+    setAppearance((prev) => normalizeAppearance(prev, availability));
+  }, [availability]);
+
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === chessBattleAccountId(accountId)) {
+        setInventory(event.detail.inventory || getChessBattleRoyalInventory(accountId));
+      }
+    };
+    window.addEventListener('chessBattleRoyalInventoryUpdate', handler);
+    return () => window.removeEventListener('chessBattleRoyalInventoryUpdate', handler);
+  }, [accountId]);
 
   const updateSandTimerPlacement = useCallback(
     (_turnWhiteValue = uiRef.current?.turnWhite ?? true) => {
@@ -5679,7 +5744,7 @@ function Chess3D({
     const arena = arenaRef.current;
     if (!arena) return;
 
-    const normalized = normalizeAppearance(appearance);
+    const normalized = normalizeAppearance(appearance, availabilityRef.current);
     const palette = createChessPalette(normalized);
     paletteRef.current = palette;
     arena.palette = palette;
@@ -5691,10 +5756,12 @@ function Chess3D({
       PIECE_STYLE_OPTIONS[normalized.whitePieceStyle] ?? PIECE_STYLE_OPTIONS[0];
     const nextPieceSetId = BEAUTIFUL_GAME_SWAP_SET_ID;
     const isBeautifulGameSet = (arena.activePieceSetId || nextPieceSetId || '').startsWith('beautifulGame');
-    const woodOption = TABLE_WOOD_OPTIONS[normalized.tableWood] ?? TABLE_WOOD_OPTIONS[0];
-    const clothOption = TABLE_CLOTH_OPTIONS[normalized.tableCloth] ?? TABLE_CLOTH_OPTIONS[0];
-    const baseOption = TABLE_BASE_OPTIONS[normalized.tableBase] ?? TABLE_BASE_OPTIONS[0];
-    const chairOption = CHAIR_COLOR_OPTIONS[normalized.chairColor] ?? CHAIR_COLOR_OPTIONS[0];
+    const fallbackIndex = (key) => availabilityRef.current?.[key]?.[0] ?? 0;
+    const woodOption = TABLE_WOOD_OPTIONS[normalized.tableWood] ?? TABLE_WOOD_OPTIONS[fallbackIndex('tableWood')];
+    const clothOption =
+      TABLE_CLOTH_OPTIONS[normalized.tableCloth] ?? TABLE_CLOTH_OPTIONS[fallbackIndex('tableCloth')];
+    const baseOption = TABLE_BASE_OPTIONS[normalized.tableBase] ?? TABLE_BASE_OPTIONS[fallbackIndex('tableBase')];
+    const chairOption = CHAIR_COLOR_OPTIONS[normalized.chairColor] ?? CHAIR_COLOR_OPTIONS[fallbackIndex('chairColor')];
     const { option: shapeOption, rotationY } = getEffectiveShapeConfig(normalized.tableShape);
     const boardTheme = palette.board ?? BEAUTIFUL_GAME_THEME;
     const pieceStyleOption = palette.pieces ?? DEFAULT_PIECE_STYLE;
@@ -5913,7 +5980,7 @@ function Chess3D({
       const pixelRatioCap = performanceProfile.pixelRatioCap ?? DEFAULT_RENDER_PIXEL_RATIO_CAP;
       const pixelRatioScale = performanceProfile.pixelRatioScale ?? RENDER_PIXEL_RATIO_SCALE;
 
-      const normalizedAppearance = normalizeAppearance(appearanceRef.current);
+      const normalizedAppearance = normalizeAppearance(appearanceRef.current, availabilityRef.current);
       const palette = createChessPalette(normalizedAppearance);
       paletteRef.current = palette;
       const boardTheme = palette.board ?? BEAUTIFUL_GAME_THEME;
@@ -5929,10 +5996,16 @@ function Chess3D({
         (FLAG_EMOJIS.length > 0 ? FLAG_EMOJIS[0] : FALLBACK_FLAG);
       const initialAiFlagValue =
         aiFlag || initialAiFlag || getAIOpponentFlag(initialPlayerFlag || FALLBACK_FLAG);
-      const woodOption = TABLE_WOOD_OPTIONS[normalizedAppearance.tableWood] ?? TABLE_WOOD_OPTIONS[0];
-      const clothOption = TABLE_CLOTH_OPTIONS[normalizedAppearance.tableCloth] ?? TABLE_CLOTH_OPTIONS[0];
-      const baseOption = TABLE_BASE_OPTIONS[normalizedAppearance.tableBase] ?? TABLE_BASE_OPTIONS[0];
-      const chairOption = CHAIR_COLOR_OPTIONS[normalizedAppearance.chairColor] ?? CHAIR_COLOR_OPTIONS[0];
+      const fallbackIndex = (key) => availabilityRef.current?.[key]?.[0] ?? 0;
+      const woodOption =
+        TABLE_WOOD_OPTIONS[normalizedAppearance.tableWood] ?? TABLE_WOOD_OPTIONS[fallbackIndex('tableWood')];
+      const clothOption =
+        TABLE_CLOTH_OPTIONS[normalizedAppearance.tableCloth] ??
+        TABLE_CLOTH_OPTIONS[fallbackIndex('tableCloth')];
+      const baseOption =
+        TABLE_BASE_OPTIONS[normalizedAppearance.tableBase] ?? TABLE_BASE_OPTIONS[fallbackIndex('tableBase')];
+      const chairOption =
+        CHAIR_COLOR_OPTIONS[normalizedAppearance.chairColor] ?? CHAIR_COLOR_OPTIONS[fallbackIndex('chairColor')];
       const { option: shapeOption, rotationY } = getEffectiveShapeConfig(
         normalizedAppearance.tableShape
       );
@@ -7996,7 +8069,7 @@ function Chess3D({
                   </div>
                   <div className="mt-3 max-h-72 space-y-3">
                     <div className="-mx-1 flex gap-2 overflow-x-auto pb-1 px-1">
-                      {CUSTOMIZATION_SECTIONS.map(({ key, label }) => {
+                      {customizationSections.map(({ key, label }) => {
                         const selectedSection = key === activeCustomizationKey;
                         return (
                           <button
@@ -8020,18 +8093,22 @@ function Chess3D({
                           {activeCustomizationSection.label}
                         </p>
                         <div className="space-y-1.5">
-                          {activeCustomizationSection.options.map((option, idx) => {
-                            const selected = appearance[activeCustomizationSection.key] === idx;
+                          {activeCustomizationSection.options.map((option) => {
+                            const optionIndex = Number.isFinite(option.__index) ? option.__index : 0;
+                            const selected = appearance[activeCustomizationSection.key] === optionIndex;
                             return (
                               <button
                                 key={option.id}
                                 type="button"
                                 onClick={() =>
                                   setAppearance((prev) =>
-                                    normalizeAppearance({
-                                      ...prev,
-                                      [activeCustomizationSection.key]: idx
-                                    })
+                                    normalizeAppearance(
+                                      {
+                                        ...prev,
+                                        [activeCustomizationSection.key]: optionIndex
+                                      },
+                                      availabilityRef.current
+                                    )
                                   )
                                 }
                                 aria-pressed={selected}

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -32,6 +32,11 @@ import {
   listOwnedPoolRoyalOptions,
   poolRoyalAccountId
 } from '../utils/poolRoyalInventory.js';
+import {
+  chessBattleAccountId,
+  getDefaultChessBattleLoadout,
+  listOwnedChessBattleOptions
+} from '../utils/chessBattleRoyalInventory.js';
 
 import { FiCopy } from 'react-icons/fi';
 
@@ -41,6 +46,14 @@ const POOL_ROYALE_TYPE_LABELS = {
   railMarkerColor: 'Rail Markers',
   clothColor: 'Cloth Color',
   cueStyle: 'Cue Style'
+};
+
+const CHESS_ROYALE_TYPE_LABELS = {
+  tableWood: 'Table Wood',
+  tableCloth: 'Table Cloth',
+  tableBase: 'Table Base',
+  chairColor: 'Chairs',
+  tableShape: 'Table Shape'
 };
 
 function formatValue(value, decimals = 2) {
@@ -95,6 +108,10 @@ export default function MyAccount() {
   const [poolRoyaleInventory, setPoolRoyaleInventory] = useState(() =>
     listOwnedPoolRoyalOptions(poolRoyalAccountId())
   );
+  const [chessAccountId, setChessAccountId] = useState(chessBattleAccountId());
+  const [chessInventory, setChessInventory] = useState(() =>
+    listOwnedChessBattleOptions(chessBattleAccountId())
+  );
   const refreshPoolRoyale = useCallback(() => {
     const resolved = poolRoyalAccountId();
     setPoolAccountId(resolved);
@@ -103,6 +120,16 @@ export default function MyAccount() {
       setPoolRoyaleInventory(owned);
     } else {
       setPoolRoyaleInventory(getDefaultPoolRoyalLoadout());
+    }
+  }, []);
+  const refreshChessBattleRoyal = useCallback(() => {
+    const resolved = chessBattleAccountId();
+    setChessAccountId(resolved);
+    const owned = listOwnedChessBattleOptions(resolved);
+    if (Array.isArray(owned) && owned.length > 0) {
+      setChessInventory(owned);
+    } else {
+      setChessInventory(getDefaultChessBattleLoadout());
     }
   }, []);
 
@@ -175,6 +202,7 @@ export default function MyAccount() {
         setShowAvatarPrompt(true);
       }
       refreshPoolRoyale();
+      refreshChessBattleRoyal();
     }
 
     load();
@@ -201,7 +229,8 @@ export default function MyAccount() {
   }, [telegramId]);
   useEffect(() => {
     refreshPoolRoyale();
-  }, [profile, refreshPoolRoyale]);
+    refreshChessBattleRoyal();
+  }, [profile, refreshPoolRoyale, refreshChessBattleRoyal]);
   useEffect(() => {
     const handler = (event) => {
       if (!event?.detail?.accountId || event.detail.accountId === poolAccountId) {
@@ -211,6 +240,16 @@ export default function MyAccount() {
     window.addEventListener('poolRoyalInventoryUpdate', handler);
     return () => window.removeEventListener('poolRoyalInventoryUpdate', handler);
   }, [poolAccountId, refreshPoolRoyale]);
+
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === chessAccountId) {
+        refreshChessBattleRoyal();
+      }
+    };
+    window.addEventListener('chessBattleRoyalInventoryUpdate', handler);
+    return () => window.removeEventListener('chessBattleRoyalInventoryUpdate', handler);
+  }, [chessAccountId, refreshChessBattleRoyal]);
 
   if (!profile) return <div className="p-4 text-subtext">Loading...</div>;
 
@@ -467,6 +506,29 @@ export default function MyAccount() {
               <span className="font-medium">{item.label}</span>
               <span className="text-[11px] uppercase text-subtext">
                 {POOL_ROYALE_TYPE_LABELS[item.type] || item.type}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold">Chess Battle Royal Inventory</h3>
+          <span className="text-xs text-subtext">Account: {chessAccountId}</span>
+        </div>
+        <p className="text-sm text-subtext">
+          Defaults are applied automatically. Purchased NFTs show here and inside the Chess Battle Royal
+          table setup menu.
+        </p>
+        <div className="space-y-1">
+          {chessInventory.map((item) => (
+            <div
+              key={`${item.type}-${item.optionId}`}
+              className="flex items-center justify-between rounded-lg border border-border px-3 py-2 bg-surface/60"
+            >
+              <span className="font-medium">{item.label}</span>
+              <span className="text-[11px] uppercase text-subtext">
+                {CHESS_ROYALE_TYPE_LABELS[item.type] || item.type}
               </span>
             </div>
           ))}

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -6,15 +6,25 @@ import {
   POOL_ROYALE_STORE_ITEMS
 } from '../config/poolRoyaleInventoryConfig.js';
 import {
+  CHESS_BATTLE_ROYALE_DEFAULT_LOADOUT,
+  CHESS_BATTLE_ROYALE_OPTION_LABELS,
+  CHESS_BATTLE_ROYALE_STORE_ITEMS
+} from '../config/chessBattleRoyalInventoryConfig.js';
+import {
   addPoolRoyalUnlock,
   getPoolRoyalInventory,
   isPoolOptionUnlocked,
   poolRoyalAccountId
 } from '../utils/poolRoyalInventory.js';
+import {
+  addChessBattleRoyalUnlock,
+  getChessBattleRoyalInventory,
+  isChessBattleOptionUnlocked
+} from '../utils/chessBattleRoyalInventory.js';
 import { getAccountBalance, sendAccountTpc } from '../utils/api.js';
 import { DEV_INFO } from '../utils/constants.js';
 
-const TYPE_LABELS = {
+const POOL_TYPE_LABELS = {
   tableFinish: 'Table Finishes',
   chromeColor: 'Chrome Fascias',
   railMarkerColor: 'Rail Markers',
@@ -22,13 +32,23 @@ const TYPE_LABELS = {
   cueStyle: 'Cue Styles'
 };
 
+const CHESS_TYPE_LABELS = {
+  tableWood: 'Table Wood',
+  tableCloth: 'Table Cloth',
+  tableBase: 'Table Base',
+  chairColor: 'Chairs',
+  tableShape: 'Table Shape'
+};
+
 const TPC_ICON = '/assets/icons/ezgif-54c96d8a9b9236.webp';
-const STORE_ACCOUNT_ID = import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const POOL_STORE_ACCOUNT_ID = import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const CHESS_STORE_ACCOUNT_ID = import.meta.env.VITE_CHESS_BATTLE_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
 
 export default function Store() {
   useTelegramBackButton();
   const [accountId, setAccountId] = useState(() => poolRoyalAccountId());
-  const [owned, setOwned] = useState(() => getPoolRoyalInventory(accountId));
+  const [poolOwned, setPoolOwned] = useState(() => getPoolRoyalInventory(accountId));
+  const [chessOwned, setChessOwned] = useState(() => getChessBattleRoyalInventory(accountId));
   const [info, setInfo] = useState('');
   const [tpcBalance, setTpcBalance] = useState(null);
   const [processing, setProcessing] = useState('');
@@ -38,7 +58,8 @@ export default function Store() {
   }, []);
 
   useEffect(() => {
-    setOwned(getPoolRoyalInventory(accountId));
+    setPoolOwned(getPoolRoyalInventory(accountId));
+    setChessOwned(getChessBattleRoyalInventory(accountId));
   }, [accountId]);
 
   useEffect(() => {
@@ -59,70 +80,109 @@ export default function Store() {
   useEffect(() => {
     const handler = (event) => {
       if (!event?.detail?.accountId || event.detail.accountId === accountId) {
-        setOwned(getPoolRoyalInventory(accountId));
+        setPoolOwned(event.detail?.inventory || getPoolRoyalInventory(accountId));
       }
     };
     window.addEventListener('poolRoyalInventoryUpdate', handler);
     return () => window.removeEventListener('poolRoyalInventoryUpdate', handler);
   }, [accountId]);
 
-  const groupedItems = useMemo(() => {
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === accountId) {
+        setChessOwned(event.detail?.inventory || getChessBattleRoyalInventory(accountId));
+      }
+    };
+    window.addEventListener('chessBattleRoyalInventoryUpdate', handler);
+    return () => window.removeEventListener('chessBattleRoyalInventoryUpdate', handler);
+  }, [accountId]);
+
+  const groupedPoolItems = useMemo(() => {
     const items = POOL_ROYALE_STORE_ITEMS.map((item) => ({
       ...item,
-      owned: isPoolOptionUnlocked(item.type, item.optionId, owned)
+      owned: isPoolOptionUnlocked(item.type, item.optionId, poolOwned)
     }));
     return items.reduce((acc, item) => {
       acc[item.type] = acc[item.type] || [];
       acc[item.type].push(item);
       return acc;
     }, {});
-  }, [owned]);
+  }, [poolOwned]);
 
-  const defaultLoadout = useMemo(
+  const groupedChessItems = useMemo(() => {
+    const items = CHESS_BATTLE_ROYALE_STORE_ITEMS.map((item) => ({
+      ...item,
+      owned: isChessBattleOptionUnlocked(item.type, item.optionId, chessOwned)
+    }));
+    return items.reduce((acc, item) => {
+      acc[item.type] = acc[item.type] || [];
+      acc[item.type].push(item);
+      return acc;
+    }, {});
+  }, [chessOwned]);
+
+  const defaultPoolLoadout = useMemo(
     () =>
       POOL_ROYALE_DEFAULT_LOADOUT.map((entry) => ({
         ...entry,
-        owned: isPoolOptionUnlocked(entry.type, entry.optionId, owned)
+        owned: isPoolOptionUnlocked(entry.type, entry.optionId, poolOwned)
       })),
-    [owned]
+    [poolOwned]
   );
 
-  const handlePurchase = async (item) => {
-    if (item.owned || processing === item.id) return;
+  const defaultChessLoadout = useMemo(
+    () =>
+      CHESS_BATTLE_ROYALE_DEFAULT_LOADOUT.map((entry) => ({
+        ...entry,
+        owned: isChessBattleOptionUnlocked(entry.type, entry.optionId, chessOwned)
+      })),
+    [chessOwned]
+  );
+
+  const handlePurchase = async (item, gameKey) => {
+    const isPool = gameKey === 'pool';
+    const processingKey = `${gameKey}:${item.id}`;
+    const labelsMap = isPool ? POOL_ROYALE_OPTION_LABELS : CHESS_BATTLE_ROYALE_OPTION_LABELS;
+    const optionLabels = labelsMap[item.type] || {};
+    const ownedLabel = optionLabels[item.optionId] || item.name;
+    const storeAccount = isPool ? POOL_STORE_ACCOUNT_ID : CHESS_STORE_ACCOUNT_ID;
+
+    if (item.owned || processing === processingKey) return;
     if (!accountId || accountId === 'guest') {
       setInfo('Link your TPC account in the wallet first.');
       return;
     }
-    if (!STORE_ACCOUNT_ID) {
+    if (!storeAccount) {
       setInfo('Store account unavailable. Please try again later.');
       return;
     }
-
-    const labels = POOL_ROYALE_OPTION_LABELS[item.type] || {};
-    const ownedLabel = labels[item.optionId] || item.name;
 
     if (tpcBalance !== null && item.price > tpcBalance) {
       setInfo('Insufficient TPC balance for this purchase.');
       return;
     }
 
-    setProcessing(item.id);
+    setProcessing(processingKey);
     setInfo('');
     try {
       const res = await sendAccountTpc(
         accountId,
-        STORE_ACCOUNT_ID,
+        storeAccount,
         item.price,
-        `Pool Royale: ${ownedLabel}`
+        `${isPool ? 'Pool Royale' : 'Chess Battle Royal'}: ${ownedLabel}`
       );
       if (res?.error) {
         setInfo(res.error || 'Purchase failed.');
         return;
       }
 
-      const updatedInventory = addPoolRoyalUnlock(item.type, item.optionId, accountId);
-      setOwned(updatedInventory);
-      setInfo(`${ownedLabel} purchased and added to your Pool Royale account.`);
+      const updatedInventory = (isPool ? addPoolRoyalUnlock : addChessBattleRoyalUnlock)(
+        item.type,
+        item.optionId,
+        accountId
+      );
+      (isPool ? setPoolOwned : setChessOwned)(updatedInventory);
+      setInfo(`${ownedLabel} purchased and added to your ${isPool ? 'Pool Royale' : 'Chess Battle Royal'} account.`);
 
       const bal = await getAccountBalance(accountId);
       if (typeof bal?.balance === 'number') {
@@ -136,90 +196,117 @@ export default function Store() {
     }
   };
 
+  const storeGames = [
+    {
+      key: 'pool',
+      name: 'Pool Royale',
+      defaultLoadout: defaultPoolLoadout,
+      groupedItems: groupedPoolItems,
+      typeLabels: POOL_TYPE_LABELS,
+      collectionLabel: 'Pool Royale Collection',
+      defaultDescription: 'These items are always available and applied when you enter Pool Royale.'
+    },
+    {
+      key: 'chess',
+      name: 'Chess Battle Royal',
+      defaultLoadout: defaultChessLoadout,
+      groupedItems: groupedChessItems,
+      typeLabels: CHESS_TYPE_LABELS,
+      collectionLabel: 'Chess Battle Royal Collection',
+      defaultDescription: 'These items are always available inside the Chess Battle Royal table setup menu.'
+    }
+  ];
+
   return (
     <div className="relative p-4 space-y-4 text-text flex flex-col items-center">
       <h2 className="text-xl font-bold">Store</h2>
       <p className="text-subtext text-sm text-center max-w-2xl">
-        Pool Royale cosmetics are organized here as non-tradable unlocks. Defaults are already
-        equipped for every player, while the cards below are minted as account-bound NFTs for this
-        game.
+        Pool Royale and Chess Battle Royal cosmetics are organized here as non-tradable unlocks.
+        Defaults are already equipped for every player, while the cards below are minted as account-bound NFTs.
       </p>
 
       <div className="store-info-bar">
-        <span className="font-semibold">Pool Royale</span>
-        <span className="text-xs text-subtext">Account: {accountId}</span>
+        <span className="font-semibold">Account: {accountId}</span>
         <span className="text-xs text-subtext">Prices shown in TPC</span>
         <span className="text-xs text-subtext">
           Balance: {tpcBalance === null ? '...' : tpcBalance.toLocaleString()} TPC
         </span>
       </div>
 
-      <div className="store-card max-w-2xl">
-        <h3 className="text-lg font-semibold">Default Loadout (Free)</h3>
-        <p className="text-sm text-subtext">
-          These items are always available and applied when you enter Pool Royale.
-        </p>
-        <ul className="mt-2 space-y-1 w-full">
-          {defaultLoadout.map((item) => (
-            <li
-              key={`${item.type}-${item.optionId}`}
-              className="flex items-center justify-between rounded-lg border border-border px-3 py-2 w-full"
-            >
-              <span className="font-medium">{item.label}</span>
-              <span className="text-xs uppercase text-subtext">
-                {TYPE_LABELS[item.type] || item.type}
-              </span>
-            </li>
-          ))}
-        </ul>
-      </div>
-
-      <div className="w-full space-y-3">
-        <h3 className="text-lg font-semibold text-center">Pool Royale Collection</h3>
-        {Object.entries(groupedItems).map(([type, items]) => (
-          <div key={type} className="space-y-2">
-            <div className="flex items-center justify-between">
-              <h4 className="text-base font-semibold">{TYPE_LABELS[type] || type}</h4>
-              <span className="text-xs text-subtext">NFT unlocks</span>
+      <div className="w-full space-y-6">
+        {storeGames.map((game) => (
+          <div key={game.key} className="space-y-4">
+            <div className="store-card max-w-2xl">
+              <h3 className="text-lg font-semibold">{game.name} Default Loadout (Free)</h3>
+              <p className="text-sm text-subtext">{game.defaultDescription}</p>
+              <ul className="mt-2 space-y-1 w-full">
+                {game.defaultLoadout.map((item) => (
+                  <li
+                    key={`${game.key}-${item.type}-${item.optionId}`}
+                    className="flex items-center justify-between rounded-lg border border-border px-3 py-2 w-full"
+                  >
+                    <span className="font-medium">{item.label}</span>
+                    <span className="text-xs uppercase text-subtext">
+                      {game.typeLabels[item.type] || item.type}
+                    </span>
+                  </li>
+                ))}
+              </ul>
             </div>
-            <div className="grid gap-3 md:grid-cols-2">
-              {items.map((item) => {
-                const labels = POOL_ROYALE_OPTION_LABELS[item.type] || {};
-                const ownedLabel = labels[item.optionId] || item.name;
-                return (
-                  <div key={item.id} className="store-card">
-                    <div className="flex w-full items-start justify-between gap-2">
-                      <div>
-                        <p className="font-semibold text-lg leading-tight">{item.name}</p>
-                        <p className="text-xs text-subtext">{item.description}</p>
-                        <p className="text-xs text-subtext mt-1">
-                          Applies to: {TYPE_LABELS[item.type] || item.type}
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-1 text-sm font-semibold">
-                        {item.price}
-                        <img src={TPC_ICON} alt="TPC" className="h-4 w-4" />
-                      </div>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => handlePurchase(item)}
-                      disabled={item.owned || processing === item.id}
-                      className={`buy-button mt-2 text-center ${
-                        item.owned || processing === item.id
-                          ? 'cursor-not-allowed opacity-60'
-                          : ''
-                      }`}
-                    >
-                      {item.owned
-                        ? `${ownedLabel} Owned`
-                        : processing === item.id
-                        ? 'Purchasing...'
-                        : `Purchase ${ownedLabel}`}
-                    </button>
+
+            <div className="w-full space-y-3">
+              <h3 className="text-lg font-semibold text-center">{game.collectionLabel}</h3>
+              {Object.entries(game.groupedItems).map(([type, items]) => (
+                <div key={`${game.key}-${type}`} className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <h4 className="text-base font-semibold">{game.typeLabels[type] || type}</h4>
+                    <span className="text-xs text-subtext">NFT unlocks</span>
                   </div>
-                );
-              })}
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {items.map((item) => {
+                      const labels =
+                        (game.key === 'pool'
+                          ? POOL_ROYALE_OPTION_LABELS[item.type]
+                          : CHESS_BATTLE_ROYALE_OPTION_LABELS[item.type]) || {};
+                      const ownedLabel = labels[item.optionId] || item.name;
+                      const purchaseKey = `${game.key}:${item.id}`;
+                      return (
+                        <div key={purchaseKey} className="store-card">
+                          <div className="flex w-full items-start justify-between gap-2">
+                            <div>
+                              <p className="font-semibold text-lg leading-tight">{item.name}</p>
+                              <p className="text-xs text-subtext">{item.description}</p>
+                              <p className="text-xs text-subtext mt-1">
+                                Applies to: {game.typeLabels[item.type] || item.type}
+                              </p>
+                            </div>
+                            <div className="flex items-center gap-1 text-sm font-semibold">
+                              {item.price}
+                              <img src={TPC_ICON} alt="TPC" className="h-4 w-4" />
+                            </div>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => handlePurchase(item, game.key)}
+                            disabled={item.owned || processing === purchaseKey}
+                            className={`buy-button mt-2 text-center ${
+                              item.owned || processing === purchaseKey
+                                ? 'cursor-not-allowed opacity-60'
+                                : ''
+                            }`}
+                          >
+                            {item.owned
+                              ? `${ownedLabel} Owned`
+                              : processing === purchaseKey
+                              ? 'Purchasing...'
+                              : `Purchase ${ownedLabel}`}
+                          </button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         ))}

--- a/webapp/src/utils/chessBattleRoyalInventory.js
+++ b/webapp/src/utils/chessBattleRoyalInventory.js
@@ -1,0 +1,112 @@
+import {
+  CHESS_BATTLE_ROYALE_DEFAULT_LOADOUT,
+  CHESS_BATTLE_ROYALE_DEFAULT_UNLOCKS,
+  CHESS_BATTLE_ROYALE_OPTION_LABELS
+} from '../config/chessBattleRoyalInventoryConfig.js';
+
+const STORAGE_KEY = 'chessBattleRoyalInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(CHESS_BATTLE_ROYALE_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values] : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read chess inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getChessBattleRoyalInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isChessBattleOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getChessBattleRoyalInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addChessBattleRoyalUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('chessBattleRoyalInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedChessBattleOptions = (accountId) => {
+  const inventory = getChessBattleRoyalInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = CHESS_BATTLE_ROYALE_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultChessBattleLoadout = () => [...CHESS_BATTLE_ROYALE_DEFAULT_LOADOUT];
+
+export const chessBattleAccountId = resolveAccountId;


### PR DESCRIPTION
## Summary
- add Chess Battle Royal inventory config and utilities mirroring Pool Royale unlock handling
- gate Chess Battle Royal customization options to default and purchased unlocks and surface them in the store
- display Chess Battle Royal ownership in the account page alongside Pool Royale items

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d7a88803c83299640b5d776e711c3)