### PR TITLE
Improve broadcast orbit focus for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11892,9 +11892,12 @@ function PoolRoyaleGame({
               }
               camera.lookAt(lookTarget);
               renderCamera = camera;
-              broadcastArgs.focusWorld =
-                broadcastCamerasRef.current?.defaultFocusWorld ?? lookTarget;
-              broadcastArgs.targetWorld = null;
+              const broadcastFocus =
+                sanitizeVector3(lookTarget)?.clone() ??
+                broadcastCamerasRef.current?.defaultFocusWorld ??
+                  null;
+              broadcastArgs.focusWorld = broadcastFocus;
+              broadcastArgs.targetWorld = broadcastFocus?.clone() ?? null;
               broadcastArgs.lerp = 0.22;
             }
           }


### PR DESCRIPTION
## Summary
- prefer orbit look target for broadcast focus during standard camera shots
- mirror broadcast target to orbit focus to keep cue ball and target in frame

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d875c2d808329bcebe4b405cc0c9f)