### PR TITLE
Improve broadcast orbit framing for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11799,28 +11799,56 @@ function PoolRoyaleGame({
                   setOrbitFocusToDefault();
                 }
               }
-            focusTarget = store.target.clone();
-          }
-          focusTarget.multiplyScalar(worldScaleFactor);
-          lookTarget = focusTarget;
-          if (topViewRef.current) {
-            const topRadius = clampOrbitRadius(
-              Math.max(
-                getMaxOrbitRadius() * TOP_VIEW_RADIUS_SCALE,
-                CAMERA.minR * TOP_VIEW_MIN_RADIUS_SCALE
-              )
-            );
-            const topTheta = sph.theta;
-            const topPhi = Math.max(TOP_VIEW_PHI, CAMERA.minPhi);
-            TMP_SPH.set(topRadius, topPhi, topTheta);
-            camera.up.set(0, 1, 0);
-            camera.position.setFromSpherical(TMP_SPH);
-            camera.position.add(focusTarget);
-            camera.lookAt(focusTarget);
-            renderCamera = camera;
-            broadcastArgs.focusWorld =
-              broadcastCamerasRef.current?.defaultFocusWorld ?? focusTarget;
-            broadcastArgs.targetWorld = focusTarget.clone();
+              focusTarget = store.target.clone();
+            }
+            const cueCenter =
+              cue?.active &&
+              Number.isFinite(cue.pos?.x) &&
+              Number.isFinite(cue.pos?.y)
+                ? new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y)
+                : null;
+            const broadcastFocusLocal = (() => {
+              if (focusTarget && cueCenter) {
+                return focusTarget.clone().add(cueCenter).multiplyScalar(0.5);
+              }
+              if (focusTarget) return focusTarget.clone();
+              if (cueCenter) return cueCenter.clone();
+              return null;
+            })();
+            const focusTargetWorld = focusTarget
+              ? focusTarget.clone().multiplyScalar(worldScaleFactor)
+              : null;
+            const broadcastFocusWorld = broadcastFocusLocal
+              ? broadcastFocusLocal.multiplyScalar(worldScaleFactor)
+              : null;
+            const resolvedLookTarget =
+              focusTargetWorld ?? broadcastFocusWorld ?? null;
+            lookTarget =
+              resolvedLookTarget ??
+              new THREE.Vector3(0, BALL_CENTER_Y, 0).multiplyScalar(worldScaleFactor);
+            if (topViewRef.current) {
+              const topRadius = clampOrbitRadius(
+                Math.max(
+                  getMaxOrbitRadius() * TOP_VIEW_RADIUS_SCALE,
+                  CAMERA.minR * TOP_VIEW_MIN_RADIUS_SCALE
+                )
+              );
+              const topTheta = sph.theta;
+              const topPhi = Math.max(TOP_VIEW_PHI, CAMERA.minPhi);
+              TMP_SPH.set(topRadius, topPhi, topTheta);
+              camera.up.set(0, 1, 0);
+              camera.position.setFromSpherical(TMP_SPH);
+              camera.position.add(lookTarget);
+              camera.lookAt(lookTarget);
+              renderCamera = camera;
+              const resolvedBroadcastTarget =
+                broadcastFocusWorld ?? lookTarget ?? focusTargetWorld;
+              broadcastArgs.focusWorld =
+                resolvedBroadcastTarget ??
+                broadcastCamerasRef.current?.defaultFocusWorld ??
+                lookTarget;
+              broadcastArgs.targetWorld =
+                resolvedBroadcastTarget?.clone() ?? lookTarget.clone();
               broadcastArgs.lerp = 0.12;
             } else {
               camera.up.set(0, 1, 0);
@@ -11892,9 +11920,14 @@ function PoolRoyaleGame({
               }
               camera.lookAt(lookTarget);
               renderCamera = camera;
+              const resolvedBroadcastTarget =
+                broadcastFocusWorld ?? lookTarget ?? focusTargetWorld;
               broadcastArgs.focusWorld =
-                broadcastCamerasRef.current?.defaultFocusWorld ?? lookTarget;
-              broadcastArgs.targetWorld = null;
+                resolvedBroadcastTarget ??
+                broadcastCamerasRef.current?.defaultFocusWorld ??
+                lookTarget;
+              broadcastArgs.targetWorld =
+                resolvedBroadcastTarget?.clone() ?? lookTarget.clone();
               broadcastArgs.lerp = 0.22;
             }
           }


### PR DESCRIPTION
## Summary
- blend cue and target focus into broadcast tracking so orbit camera framing keeps both balls visible
- align broadcast focus and targets with the active orbit view in both top and standing modes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d875c2d808329bcebe4b405cc0c9f)