### PR TITLE
Add NFT unlocks for Chess Battle Royal customization

### DIFF
--- a/webapp/src/config/chessInventoryConfig.js
+++ b/webapp/src/config/chessInventoryConfig.js
@@ -1,0 +1,275 @@
+import {
+  TABLE_WOOD_OPTIONS,
+  TABLE_CLOTH_OPTIONS,
+  TABLE_BASE_OPTIONS,
+  DEFAULT_TABLE_CUSTOMIZATION
+} from '../utils/tableCustomizationOptions.js';
+import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
+
+const AVAILABLE_TABLE_SHAPES = TABLE_SHAPE_OPTIONS.filter((shape) => shape.id !== 'diamondEdge');
+
+export const CHESS_SIDE_COLOR_OPTIONS = Object.freeze([
+  { id: 'marble', hex: 0xffffff, label: 'Marble' },
+  { id: 'darkForest', hex: 0x0b3b29, label: 'Dark Forest' },
+  { id: 'amberGlow', hex: 0xf59e0b, label: 'Amber Glow' },
+  { id: 'mintVale', hex: 0x10b981, label: 'Mint Vale' },
+  { id: 'royalWave', hex: 0x3b82f6, label: 'Royal Wave' },
+  { id: 'roseMist', hex: 0xef4444, label: 'Rose Mist' },
+  { id: 'amethyst', hex: 0x8b5cf6, label: 'Amethyst' }
+]);
+
+export const CHESS_DEFAULT_UNLOCKS = Object.freeze({
+  tableWood: [TABLE_WOOD_OPTIONS[0]?.id],
+  tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
+  tableBase: [TABLE_BASE_OPTIONS[0]?.id],
+  chairColor: ['crimsonVelvet'],
+  tableShape: [AVAILABLE_TABLE_SHAPES[0]?.id],
+  sideColor: ['amberGlow', 'mintVale']
+});
+
+export const CHESS_OPTION_LABELS = Object.freeze({
+  tableWood: TABLE_WOOD_OPTIONS.reduce((acc, option) => {
+    acc[option.id] = option.label;
+    return acc;
+  }, {}),
+  tableCloth: TABLE_CLOTH_OPTIONS.reduce((acc, option) => {
+    acc[option.id] = option.label;
+    return acc;
+  }, {}),
+  tableBase: TABLE_BASE_OPTIONS.reduce((acc, option) => {
+    acc[option.id] = option.label;
+    return acc;
+  }, {}),
+  chairColor: Object.freeze({
+    crimsonVelvet: 'Crimson Velvet',
+    midnightNavy: 'Midnight Blue',
+    emeraldWave: 'Emerald Wave',
+    onyxShadow: 'Onyx Shadow',
+    royalPlum: 'Royal Chestnut'
+  }),
+  tableShape: AVAILABLE_TABLE_SHAPES.reduce((acc, option) => {
+    acc[option.id] = option.label;
+    return acc;
+  }, {}),
+  sideColor: CHESS_SIDE_COLOR_OPTIONS.reduce((acc, option) => {
+    acc[option.id] = option.label;
+    return acc;
+  }, {})
+});
+
+export const CHESS_STORE_ITEMS = [
+  // Table wood (beyond the first free option)
+  {
+    id: 'chess-wood-warmBrown',
+    type: 'tableWood',
+    optionId: 'warmBrown',
+    name: 'Warm Brown Wood',
+    price: 820,
+    description: 'Rich walnut-inspired planks with deep grain and warmth.'
+  },
+  {
+    id: 'chess-wood-cleanStrips',
+    type: 'tableWood',
+    optionId: 'cleanStrips',
+    name: 'Clean Strip Wood',
+    price: 860,
+    description: 'Studio-style oak strips with crisp seams and satin finish.'
+  },
+  {
+    id: 'chess-wood-oldFloor',
+    type: 'tableWood',
+    optionId: 'oldWoodFloor',
+    name: 'Heritage Floor Wood',
+    price: 940,
+    description: 'Weathered floorboards with smoked oak character.'
+  },
+  // Cloth colors
+  {
+    id: 'chess-cloth-emerald',
+    type: 'tableCloth',
+    optionId: 'emerald',
+    name: 'Emerald Cloth',
+    price: 620,
+    description: 'Tournament emerald felt with deep shading.'
+  },
+  {
+    id: 'chess-cloth-arctic',
+    type: 'tableCloth',
+    optionId: 'arctic',
+    name: 'Arctic Cloth',
+    price: 640,
+    description: 'Cool arctic blue felt with vibrant contrast.'
+  },
+  {
+    id: 'chess-cloth-sunset',
+    type: 'tableCloth',
+    optionId: 'sunset',
+    name: 'Sunset Cloth',
+    price: 660,
+    description: 'Amber sunset felt for a dramatic arena glow.'
+  },
+  {
+    id: 'chess-cloth-violet',
+    type: 'tableCloth',
+    optionId: 'violet',
+    name: 'Violet Cloth',
+    price: 660,
+    description: 'Royal violet felt with soft sheen.'
+  },
+  {
+    id: 'chess-cloth-amber',
+    type: 'tableCloth',
+    optionId: 'amber',
+    name: 'Amber Cloth',
+    price: 640,
+    description: 'Amber-inspired felt with warm undertones.'
+  },
+  // Base finishes
+  {
+    id: 'chess-base-forestBronze',
+    type: 'tableBase',
+    optionId: 'forestBronze',
+    name: 'Forest Bronze Base',
+    price: 710,
+    description: 'Dark bronze base with forest undertones.'
+  },
+  {
+    id: 'chess-base-midnightChrome',
+    type: 'tableBase',
+    optionId: 'midnightChrome',
+    name: 'Midnight Chrome Base',
+    price: 760,
+    description: 'Deep navy base with chrome trim accents.'
+  },
+  {
+    id: 'chess-base-emberCopper',
+    type: 'tableBase',
+    optionId: 'emberCopper',
+    name: 'Ember Copper Base',
+    price: 760,
+    description: 'Copper-trimmed base with ember shimmer.'
+  },
+  {
+    id: 'chess-base-violetShadow',
+    type: 'tableBase',
+    optionId: 'violetShadow',
+    name: 'Violet Shadow Base',
+    price: 780,
+    description: 'Violet shadow base with rich metalness.'
+  },
+  {
+    id: 'chess-base-desertGold',
+    type: 'tableBase',
+    optionId: 'desertGold',
+    name: 'Desert Gold Base',
+    price: 800,
+    description: 'Sandy gold base with bold contrast trim.'
+  },
+  // Chair colors
+  {
+    id: 'chess-chair-midnight',
+    type: 'chairColor',
+    optionId: 'midnightNavy',
+    name: 'Midnight Chairs',
+    price: 520,
+    description: 'Midnight blue upholstery with brushed accents.'
+  },
+  {
+    id: 'chess-chair-emerald',
+    type: 'chairColor',
+    optionId: 'emeraldWave',
+    name: 'Emerald Chairs',
+    price: 540,
+    description: 'Emerald upholstery with deep forest tones.'
+  },
+  {
+    id: 'chess-chair-onyx',
+    type: 'chairColor',
+    optionId: 'onyxShadow',
+    name: 'Onyx Chairs',
+    price: 560,
+    description: 'Onyx shadow chairs with graphite legs.'
+  },
+  {
+    id: 'chess-chair-royalPlum',
+    type: 'chairColor',
+    optionId: 'royalPlum',
+    name: 'Royal Chestnut Chairs',
+    price: 560,
+    description: 'Royal plum upholstery with chestnut warmth.'
+  },
+  // Table shapes
+  {
+    id: 'chess-shape-grandOval',
+    type: 'tableShape',
+    optionId: 'grandOval',
+    name: 'Grand Oval Table',
+    price: 760,
+    description: 'Sleek oval chess table silhouette.'
+  },
+  // Side colors (premium for marble + dark forest)
+  {
+    id: 'chess-side-marble',
+    type: 'sideColor',
+    optionId: 'marble',
+    name: 'Marble Side Color',
+    price: 1800,
+    description: 'Premium marble-inspired polish for your pieces.'
+  },
+  {
+    id: 'chess-side-darkForest',
+    type: 'sideColor',
+    optionId: 'darkForest',
+    name: 'Dark Forest Side Color',
+    price: 1750,
+    description: 'Deep forest tone with luxurious lacquer.'
+  },
+  {
+    id: 'chess-side-royalWave',
+    type: 'sideColor',
+    optionId: 'royalWave',
+    name: 'Royal Wave Side Color',
+    price: 640,
+    description: 'Royal blue wave tint for your chess set.'
+  },
+  {
+    id: 'chess-side-roseMist',
+    type: 'sideColor',
+    optionId: 'roseMist',
+    name: 'Rose Mist Side Color',
+    price: 640,
+    description: 'Soft rose hue with gentle highlights.'
+  },
+  {
+    id: 'chess-side-amethyst',
+    type: 'sideColor',
+    optionId: 'amethyst',
+    name: 'Amethyst Side Color',
+    price: 680,
+    description: 'Amethyst tint with crystalline sheen.'
+  }
+];
+
+export const CHESS_DEFAULT_LOADOUT = [
+  { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0]?.id, label: 'Light Natural Wood' },
+  { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: 'Crimson Cloth' },
+  { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0]?.id, label: 'Obsidian Base' },
+  { type: 'chairColor', optionId: 'crimsonVelvet', label: 'Crimson Velvet Chairs' },
+  {
+    type: 'tableShape',
+    optionId: AVAILABLE_TABLE_SHAPES[0]?.id,
+    label: AVAILABLE_TABLE_SHAPES[0]?.label || 'Tournament Table'
+  },
+  { type: 'sideColor', optionId: 'amberGlow', label: 'Amber Glow Side Color' },
+  { type: 'sideColor', optionId: 'mintVale', label: 'Mint Vale Side Color' }
+];
+
+export const CHESS_DEFAULT_LOADOUT_IDS = Object.freeze(
+  CHESS_DEFAULT_LOADOUT.map((entry) => entry.optionId)
+);
+
+export const CHESS_DEFAULT_CUSTOMIZATION = Object.freeze({
+  ...DEFAULT_TABLE_CUSTOMIZATION,
+  chairColor: 0,
+  tableShape: 0
+});

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -11,6 +11,17 @@ import {
   isPoolOptionUnlocked,
   poolRoyalAccountId
 } from '../utils/poolRoyalInventory.js';
+import {
+  CHESS_DEFAULT_LOADOUT,
+  CHESS_OPTION_LABELS,
+  CHESS_STORE_ITEMS
+} from '../config/chessInventoryConfig.js';
+import {
+  addChessUnlock,
+  chessAccountId,
+  getChessInventory,
+  isChessOptionUnlocked
+} from '../utils/chessInventory.js';
 import { getAccountBalance, sendAccountTpc } from '../utils/api.js';
 import { DEV_INFO } from '../utils/constants.js';
 
@@ -22,16 +33,29 @@ const TYPE_LABELS = {
   cueStyle: 'Cue Styles'
 };
 
+const CHESS_TYPE_LABELS = {
+  tableWood: 'Table Wood',
+  tableCloth: 'Table Cloth',
+  tableBase: 'Table Base',
+  chairColor: 'Chairs',
+  tableShape: 'Table Shape',
+  sideColor: 'Side Colors'
+};
+
 const TPC_ICON = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 const STORE_ACCOUNT_ID = import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const CHESS_STORE_ACCOUNT_ID = import.meta.env.VITE_CHESS_STORE_ACCOUNT_ID || STORE_ACCOUNT_ID;
 
 export default function Store() {
   useTelegramBackButton();
   const [accountId, setAccountId] = useState(() => poolRoyalAccountId());
   const [owned, setOwned] = useState(() => getPoolRoyalInventory(accountId));
+  const [chessOwned, setChessOwned] = useState(() => getChessInventory(accountId));
   const [info, setInfo] = useState('');
+  const [chessInfo, setChessInfo] = useState('');
   const [tpcBalance, setTpcBalance] = useState(null);
   const [processing, setProcessing] = useState('');
+  const [chessProcessing, setChessProcessing] = useState('');
 
   useEffect(() => {
     setAccountId(poolRoyalAccountId());
@@ -39,6 +63,7 @@ export default function Store() {
 
   useEffect(() => {
     setOwned(getPoolRoyalInventory(accountId));
+    setChessOwned(getChessInventory(accountId));
   }, [accountId]);
 
   useEffect(() => {
@@ -66,6 +91,16 @@ export default function Store() {
     return () => window.removeEventListener('poolRoyalInventoryUpdate', handler);
   }, [accountId]);
 
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === accountId) {
+        setChessOwned(getChessInventory(accountId));
+      }
+    };
+    window.addEventListener('chessInventoryUpdate', handler);
+    return () => window.removeEventListener('chessInventoryUpdate', handler);
+  }, [accountId]);
+
   const groupedItems = useMemo(() => {
     const items = POOL_ROYALE_STORE_ITEMS.map((item) => ({
       ...item,
@@ -85,6 +120,27 @@ export default function Store() {
         owned: isPoolOptionUnlocked(entry.type, entry.optionId, owned)
       })),
     [owned]
+  );
+
+  const chessGroupedItems = useMemo(() => {
+    const items = CHESS_STORE_ITEMS.map((item) => ({
+      ...item,
+      owned: isChessOptionUnlocked(item.type, item.optionId, chessOwned)
+    }));
+    return items.reduce((acc, item) => {
+      acc[item.type] = acc[item.type] || [];
+      acc[item.type].push(item);
+      return acc;
+    }, {});
+  }, [chessOwned]);
+
+  const chessDefaultLoadout = useMemo(
+    () =>
+      CHESS_DEFAULT_LOADOUT.map((entry) => ({
+        ...entry,
+        owned: isChessOptionUnlocked(entry.type, entry.optionId, chessOwned)
+      })),
+    [chessOwned]
   );
 
   const handlePurchase = async (item) => {
@@ -136,13 +192,62 @@ export default function Store() {
     }
   };
 
+  const handleChessPurchase = async (item) => {
+    if (item.owned || chessProcessing === item.id) return;
+    if (!accountId || accountId === 'guest') {
+      setChessInfo('Link your TPC account in the wallet first.');
+      return;
+    }
+    if (!CHESS_STORE_ACCOUNT_ID) {
+      setChessInfo('Store account unavailable. Please try again later.');
+      return;
+    }
+
+    const labels = CHESS_OPTION_LABELS[item.type] || {};
+    const ownedLabel = labels[item.optionId] || item.name;
+
+    if (tpcBalance !== null && item.price > tpcBalance) {
+      setChessInfo('Insufficient TPC balance for this purchase.');
+      return;
+    }
+
+    setChessProcessing(item.id);
+    setChessInfo('');
+    try {
+      const res = await sendAccountTpc(
+        accountId,
+        CHESS_STORE_ACCOUNT_ID,
+        item.price,
+        `Chess Battle Royal: ${ownedLabel}`
+      );
+      if (res?.error) {
+        setChessInfo(res.error || 'Purchase failed.');
+        return;
+      }
+
+      const updatedInventory = addChessUnlock(item.type, item.optionId, accountId);
+      setChessOwned(updatedInventory);
+      setChessInfo(`${ownedLabel} purchased and added to your Chess Battle Royal account.`);
+
+      const bal = await getAccountBalance(accountId);
+      if (typeof bal?.balance === 'number') {
+        setTpcBalance(bal.balance);
+      }
+    } catch (err) {
+      console.error('Purchase failed', err);
+      setChessInfo('Failed to process purchase.');
+    } finally {
+      setChessProcessing('');
+    }
+  };
+
   return (
     <div className="relative p-4 space-y-4 text-text flex flex-col items-center">
       <h2 className="text-xl font-bold">Store</h2>
       <p className="text-subtext text-sm text-center max-w-2xl">
-        Pool Royale cosmetics are organized here as non-tradable unlocks. Defaults are already
-        equipped for every player, while the cards below are minted as account-bound NFTs for this
-        game.
+        Pool Royale and Chess Battle Royal cosmetics are organized here as non-tradable unlocks.
+        Defaults stay free for every player, while the cards below are minted as account-bound NFTs
+        for each game.
       </p>
 
       <div className="store-info-bar">
@@ -227,6 +332,86 @@ export default function Store() {
 
       {info ? (
         <div className="checkout-card text-center text-sm font-semibold">{info}</div>
+      ) : null}
+
+      <div className="store-info-bar">
+        <span className="font-semibold">Chess Battle Royal</span>
+        <span className="text-xs text-subtext">Account: {accountId || chessAccountId()}</span>
+        <span className="text-xs text-subtext">Prices shown in TPC</span>
+        <span className="text-xs text-subtext">Balances use your linked wallet</span>
+      </div>
+
+      <div className="store-card max-w-2xl">
+        <h3 className="text-lg font-semibold">Default Loadout (Free)</h3>
+        <p className="text-sm text-subtext">
+          Two side colors stay free, along with the first chair, cloth, wood, base, and table shape.
+        </p>
+        <ul className="mt-2 space-y-1 w-full">
+          {chessDefaultLoadout.map((item) => (
+            <li
+              key={`${item.type}-${item.optionId}`}
+              className="flex items-center justify-between rounded-lg border border-border px-3 py-2 w-full"
+            >
+              <span className="font-medium">{item.label}</span>
+              <span className="text-xs uppercase text-subtext">{CHESS_TYPE_LABELS[item.type] || item.type}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="w-full space-y-3">
+        <h3 className="text-lg font-semibold text-center">Chess Battle Royal Collection</h3>
+        {Object.entries(chessGroupedItems).map(([type, items]) => (
+          <div key={type} className="space-y-2">
+            <div className="flex items-center justify-between">
+              <h4 className="text-base font-semibold">{CHESS_TYPE_LABELS[type] || type}</h4>
+              <span className="text-xs text-subtext">NFT unlocks</span>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2">
+              {items.map((item) => {
+                const labels = CHESS_OPTION_LABELS[item.type] || {};
+                const ownedLabel = labels[item.optionId] || item.name;
+                return (
+                  <div key={item.id} className="store-card">
+                    <div className="flex w-full items-start justify-between gap-2">
+                      <div>
+                        <p className="font-semibold text-lg leading-tight">{item.name}</p>
+                        <p className="text-xs text-subtext">{item.description}</p>
+                        <p className="text-xs text-subtext mt-1">
+                          Applies to: {CHESS_TYPE_LABELS[item.type] || item.type}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-1 text-sm font-semibold">
+                        {item.price}
+                        <img src={TPC_ICON} alt="TPC" className="h-4 w-4" />
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleChessPurchase(item)}
+                      disabled={item.owned || chessProcessing === item.id}
+                      className={`buy-button mt-2 text-center ${
+                        item.owned || chessProcessing === item.id
+                          ? 'cursor-not-allowed opacity-60'
+                          : ''
+                      }`}
+                    >
+                      {item.owned
+                        ? `${ownedLabel} Owned`
+                        : chessProcessing === item.id
+                        ? 'Purchasing...'
+                        : `Purchase ${ownedLabel}`}
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {chessInfo ? (
+        <div className="checkout-card text-center text-sm font-semibold">{chessInfo}</div>
       ) : null}
     </div>
   );

--- a/webapp/src/utils/chessInventory.js
+++ b/webapp/src/utils/chessInventory.js
@@ -1,0 +1,112 @@
+import {
+  CHESS_DEFAULT_LOADOUT,
+  CHESS_DEFAULT_UNLOCKS,
+  CHESS_OPTION_LABELS
+} from '../config/chessInventoryConfig.js';
+
+const STORAGE_KEY = 'chessInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(CHESS_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values] : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read chess inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getChessInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isChessOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getChessInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addChessUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('chessInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedChessOptions = (accountId) => {
+  const inventory = getChessInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = CHESS_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultChessLoadout = () => [...CHESS_DEFAULT_LOADOUT];
+
+export const chessAccountId = resolveAccountId;


### PR DESCRIPTION
## Summary
- add a Chess Battle Royal inventory config with premium NFT store items and default unlocks
- gate chess table setup and side color options behind unlock checks while keeping initial free options
- extend the store page to list and purchase Chess Battle Royal cosmetics alongside Pool Royale

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d8d7f6c6c83298f0338111a414d53)