### PR TITLE
Gate Chess Battle Royal cosmetics behind store unlocks

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -1,0 +1,137 @@
+import {
+  TABLE_WOOD_OPTIONS,
+  TABLE_CLOTH_OPTIONS,
+  TABLE_BASE_OPTIONS
+} from '../utils/tableCustomizationOptions.js';
+import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
+
+const DEFAULT_TABLE_SHAPE_ID = TABLE_SHAPE_OPTIONS.find((opt) => opt.id !== 'diamondEdge')?.id;
+
+export const CHESS_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
+  tableWood: [TABLE_WOOD_OPTIONS[0]?.id],
+  tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
+  tableBase: [TABLE_BASE_OPTIONS[0]?.id],
+  chairColor: ['crimsonVelvet'],
+  tableShape: [DEFAULT_TABLE_SHAPE_ID],
+  sideColor: ['amberGlow', 'mintVale'],
+  boardTheme: ['classic'],
+  headStyle: ['current']
+});
+
+export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
+  tableWood: Object.freeze(
+    TABLE_WOOD_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableCloth: Object.freeze(
+    TABLE_CLOTH_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableBase: Object.freeze(
+    TABLE_BASE_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  chairColor: Object.freeze({
+    crimsonVelvet: 'Crimson Velvet',
+    midnightNavy: 'Midnight Blue',
+    emeraldWave: 'Emerald Wave',
+    onyxShadow: 'Onyx Shadow',
+    royalPlum: 'Royal Chestnut'
+  }),
+  tableShape: Object.freeze(
+    TABLE_SHAPE_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  sideColor: Object.freeze({
+    marble: 'Marble',
+    darkForest: 'Dark Forest',
+    amberGlow: 'Amber Glow',
+    mintVale: 'Mint Vale',
+    royalWave: 'Royal Wave',
+    roseMist: 'Rose Mist',
+    amethyst: 'Amethyst'
+  }),
+  boardTheme: Object.freeze({
+    classic: 'Classic',
+    ivorySlate: 'Ivory/Slate',
+    forest: 'Forest',
+    sand: 'Sand/Brown',
+    ocean: 'Ocean',
+    violet: 'Violet',
+    chrome: 'Chrome'
+  }),
+  headStyle: Object.freeze({
+    current: 'Current',
+    headRuby: 'Ruby',
+    headSapphire: 'Sapphire',
+    headChrome: 'Chrome',
+    headGold: 'Gold'
+  })
+});
+
+export const CHESS_BATTLE_STORE_ITEMS = [
+  ...TABLE_WOOD_OPTIONS.slice(1).map((option, idx) => ({
+    id: `chess-wood-${option.id}`,
+    type: 'tableWood',
+    optionId: option.id,
+    name: option.label,
+    price: 520 + idx * 40,
+    description: 'Unlock an alternate table wood finish for Chess Battle Royal.'
+  })),
+  ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
+    id: `chess-cloth-${option.id}`,
+    type: 'tableCloth',
+    optionId: option.id,
+    name: option.label,
+    price: 360 + idx * 30,
+    description: 'Swap in a new premium cloth hue for your chess arena.'
+  })),
+  ...TABLE_BASE_OPTIONS.slice(1).map((option, idx) => ({
+    id: `chess-base-${option.id}`,
+    type: 'tableBase',
+    optionId: option.id,
+    name: option.label,
+    price: 410 + idx * 35,
+    description: 'Upgrade the pedestal finish beneath your chess board.'
+  })),
+  { id: 'chess-chair-midnight', type: 'chairColor', optionId: 'midnightNavy', name: 'Midnight Blue Chairs', price: 320, description: 'Deep navy lounge chairs for the battle table.' },
+  { id: 'chess-chair-emerald', type: 'chairColor', optionId: 'emeraldWave', name: 'Emerald Wave Chairs', price: 340, description: 'Emerald upholstery with rich contrast piping.' },
+  { id: 'chess-chair-onyx', type: 'chairColor', optionId: 'onyxShadow', name: 'Onyx Shadow Chairs', price: 380, description: 'Shadow-black seating with steel-toned trim.' },
+  { id: 'chess-chair-plum', type: 'chairColor', optionId: 'royalPlum', name: 'Royal Chestnut Chairs', price: 360, description: 'Chestnut-plum accent chairs for regal matches.' },
+  { id: 'chess-shape-oval', type: 'tableShape', optionId: 'grandOval', name: 'Grand Oval Shape', price: 640, description: 'Smooth oval table outline for the chess board.' },
+  { id: 'chess-side-marble', type: 'sideColor', optionId: 'marble', name: 'Marble Pieces', price: 1400, description: 'Premium marble-inspired pieces for either side.' },
+  { id: 'chess-side-forest', type: 'sideColor', optionId: 'darkForest', name: 'Dark Forest Pieces', price: 1300, description: 'Deep forest hue pieces with luxe accents.' },
+  { id: 'chess-side-royal', type: 'sideColor', optionId: 'royalWave', name: 'Royal Wave Pieces', price: 420, description: 'Royal blue quick-select palette.' },
+  { id: 'chess-side-rose', type: 'sideColor', optionId: 'roseMist', name: 'Rose Mist Pieces', price: 420, description: 'Rosy quick-select palette with soft glow.' },
+  { id: 'chess-side-amethyst', type: 'sideColor', optionId: 'amethyst', name: 'Amethyst Pieces', price: 460, description: 'Amethyst quick-select palette with sheen.' },
+  { id: 'chess-board-ivorySlate', type: 'boardTheme', optionId: 'ivorySlate', name: 'Ivory/Slate Board', price: 380, description: 'Alternate board palette for fast swaps.' },
+  { id: 'chess-board-forest', type: 'boardTheme', optionId: 'forest', name: 'Forest Board', price: 410, description: 'Alternate board palette for fast swaps.' },
+  { id: 'chess-board-sand', type: 'boardTheme', optionId: 'sand', name: 'Sand/Brown Board', price: 440, description: 'Alternate board palette for fast swaps.' },
+  { id: 'chess-board-ocean', type: 'boardTheme', optionId: 'ocean', name: 'Ocean Board', price: 470, description: 'Alternate board palette for fast swaps.' },
+  { id: 'chess-board-violet', type: 'boardTheme', optionId: 'violet', name: 'Violet Board', price: 500, description: 'Alternate board palette for fast swaps.' },
+  { id: 'chess-board-chrome', type: 'boardTheme', optionId: 'chrome', name: 'Chrome Board', price: 540, description: 'Alternate board palette for fast swaps.' },
+  { id: 'chess-head-ruby', type: 'headStyle', optionId: 'headRuby', name: 'Ruby Pawn Heads', price: 310, description: 'Unlocks an additional pawn head glass preset.' },
+  { id: 'chess-head-sapphire', type: 'headStyle', optionId: 'headSapphire', name: 'Sapphire Pawn Heads', price: 335, description: 'Unlocks an additional pawn head glass preset.' },
+  { id: 'chess-head-chrome', type: 'headStyle', optionId: 'headChrome', name: 'Chrome Pawn Heads', price: 360, description: 'Unlocks an additional pawn head glass preset.' },
+  { id: 'chess-head-gold', type: 'headStyle', optionId: 'headGold', name: 'Gold Pawn Heads', price: 385, description: 'Unlocks an additional pawn head glass preset.' }
+];
+
+export const CHESS_BATTLE_DEFAULT_LOADOUT = [
+  { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0]?.id, label: TABLE_WOOD_OPTIONS[0]?.label },
+  { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
+  { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0]?.id, label: TABLE_BASE_OPTIONS[0]?.label },
+  { type: 'chairColor', optionId: 'crimsonVelvet', label: 'Crimson Velvet Chairs' },
+  { type: 'tableShape', optionId: DEFAULT_TABLE_SHAPE_ID, label: CHESS_BATTLE_OPTION_LABELS.tableShape[DEFAULT_TABLE_SHAPE_ID] },
+  { type: 'sideColor', optionId: 'amberGlow', label: 'Amber Glow Pieces' },
+  { type: 'sideColor', optionId: 'mintVale', label: 'Mint Vale Pieces' },
+  { type: 'boardTheme', optionId: 'classic', label: 'Classic Board' },
+  { type: 'headStyle', optionId: 'current', label: 'Current Pawn Heads' }
+];

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -11,6 +11,17 @@ import {
   isPoolOptionUnlocked,
   poolRoyalAccountId
 } from '../utils/poolRoyalInventory.js';
+import {
+  CHESS_BATTLE_DEFAULT_LOADOUT,
+  CHESS_BATTLE_OPTION_LABELS,
+  CHESS_BATTLE_STORE_ITEMS
+} from '../config/chessBattleInventoryConfig.js';
+import {
+  addChessBattleUnlock,
+  getChessBattleInventory,
+  isChessOptionUnlocked,
+  chessBattleAccountId
+} from '../utils/chessBattleInventory.js';
 import { getAccountBalance, sendAccountTpc } from '../utils/api.js';
 import { DEV_INFO } from '../utils/constants.js';
 
@@ -22,13 +33,26 @@ const TYPE_LABELS = {
   cueStyle: 'Cue Styles'
 };
 
+const CHESS_TYPE_LABELS = {
+  tableWood: 'Table Wood',
+  tableCloth: 'Table Cloth',
+  tableBase: 'Table Base',
+  chairColor: 'Chairs',
+  tableShape: 'Table Shape',
+  sideColor: 'Piece Colors',
+  boardTheme: 'Board Themes',
+  headStyle: 'Pawn Heads'
+};
+
 const TPC_ICON = '/assets/icons/ezgif-54c96d8a9b9236.webp';
-const STORE_ACCOUNT_ID = import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const POOL_STORE_ACCOUNT_ID = import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const CHESS_STORE_ACCOUNT_ID = import.meta.env.VITE_CHESS_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
 
 export default function Store() {
   useTelegramBackButton();
   const [accountId, setAccountId] = useState(() => poolRoyalAccountId());
-  const [owned, setOwned] = useState(() => getPoolRoyalInventory(accountId));
+  const [poolOwned, setPoolOwned] = useState(() => getPoolRoyalInventory(accountId));
+  const [chessOwned, setChessOwned] = useState(() => getChessBattleInventory(accountId));
   const [info, setInfo] = useState('');
   const [tpcBalance, setTpcBalance] = useState(null);
   const [processing, setProcessing] = useState('');
@@ -38,7 +62,8 @@ export default function Store() {
   }, []);
 
   useEffect(() => {
-    setOwned(getPoolRoyalInventory(accountId));
+    setPoolOwned(getPoolRoyalInventory(accountId));
+    setChessOwned(getChessBattleInventory(chessBattleAccountId(accountId)));
   }, [accountId]);
 
   useEffect(() => {
@@ -59,32 +84,63 @@ export default function Store() {
   useEffect(() => {
     const handler = (event) => {
       if (!event?.detail?.accountId || event.detail.accountId === accountId) {
-        setOwned(getPoolRoyalInventory(accountId));
+        setPoolOwned(getPoolRoyalInventory(accountId));
       }
     };
     window.addEventListener('poolRoyalInventoryUpdate', handler);
     return () => window.removeEventListener('poolRoyalInventoryUpdate', handler);
   }, [accountId]);
 
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === accountId) {
+        setChessOwned(getChessBattleInventory(chessBattleAccountId(accountId)));
+      }
+    };
+    window.addEventListener('chessBattleInventoryUpdate', handler);
+    return () => window.removeEventListener('chessBattleInventoryUpdate', handler);
+  }, [accountId]);
+
   const groupedItems = useMemo(() => {
     const items = POOL_ROYALE_STORE_ITEMS.map((item) => ({
       ...item,
-      owned: isPoolOptionUnlocked(item.type, item.optionId, owned)
+      owned: isPoolOptionUnlocked(item.type, item.optionId, poolOwned)
     }));
     return items.reduce((acc, item) => {
       acc[item.type] = acc[item.type] || [];
       acc[item.type].push(item);
       return acc;
     }, {});
-  }, [owned]);
+  }, [poolOwned]);
 
   const defaultLoadout = useMemo(
     () =>
       POOL_ROYALE_DEFAULT_LOADOUT.map((entry) => ({
         ...entry,
-        owned: isPoolOptionUnlocked(entry.type, entry.optionId, owned)
+        owned: isPoolOptionUnlocked(entry.type, entry.optionId, poolOwned)
       })),
-    [owned]
+    [poolOwned]
+  );
+
+  const chessGroupedItems = useMemo(() => {
+    const items = CHESS_BATTLE_STORE_ITEMS.map((item) => ({
+      ...item,
+      owned: isChessOptionUnlocked(item.type, item.optionId, chessOwned)
+    }));
+    return items.reduce((acc, item) => {
+      acc[item.type] = acc[item.type] || [];
+      acc[item.type].push(item);
+      return acc;
+    }, {});
+  }, [chessOwned]);
+
+  const chessDefaultLoadout = useMemo(
+    () =>
+      CHESS_BATTLE_DEFAULT_LOADOUT.map((entry) => ({
+        ...entry,
+        owned: isChessOptionUnlocked(entry.type, entry.optionId, chessOwned)
+      })),
+    [chessOwned]
   );
 
   const handlePurchase = async (item) => {
@@ -93,7 +149,7 @@ export default function Store() {
       setInfo('Link your TPC account in the wallet first.');
       return;
     }
-    if (!STORE_ACCOUNT_ID) {
+    if (!POOL_STORE_ACCOUNT_ID) {
       setInfo('Store account unavailable. Please try again later.');
       return;
     }
@@ -111,7 +167,7 @@ export default function Store() {
     try {
       const res = await sendAccountTpc(
         accountId,
-        STORE_ACCOUNT_ID,
+        POOL_STORE_ACCOUNT_ID,
         item.price,
         `Pool Royale: ${ownedLabel}`
       );
@@ -121,8 +177,57 @@ export default function Store() {
       }
 
       const updatedInventory = addPoolRoyalUnlock(item.type, item.optionId, accountId);
-      setOwned(updatedInventory);
+      setPoolOwned(updatedInventory);
       setInfo(`${ownedLabel} purchased and added to your Pool Royale account.`);
+
+      const bal = await getAccountBalance(accountId);
+      if (typeof bal?.balance === 'number') {
+        setTpcBalance(bal.balance);
+      }
+    } catch (err) {
+      console.error('Purchase failed', err);
+      setInfo('Failed to process purchase.');
+    } finally {
+      setProcessing('');
+    }
+  };
+
+  const handleChessPurchase = async (item) => {
+    if (item.owned || processing === item.id) return;
+    if (!accountId || accountId === 'guest') {
+      setInfo('Link your TPC account in the wallet first.');
+      return;
+    }
+    if (!CHESS_STORE_ACCOUNT_ID) {
+      setInfo('Store account unavailable. Please try again later.');
+      return;
+    }
+
+    const labels = CHESS_BATTLE_OPTION_LABELS[item.type] || {};
+    const ownedLabel = labels[item.optionId] || item.name;
+
+    if (tpcBalance !== null && item.price > tpcBalance) {
+      setInfo('Insufficient TPC balance for this purchase.');
+      return;
+    }
+
+    setProcessing(item.id);
+    setInfo('');
+    try {
+      const res = await sendAccountTpc(
+        accountId,
+        CHESS_STORE_ACCOUNT_ID,
+        item.price,
+        `Chess Battle Royale: ${ownedLabel}`
+      );
+      if (res?.error) {
+        setInfo(res.error || 'Purchase failed.');
+        return;
+      }
+
+      const updatedInventory = addChessBattleUnlock(item.type, item.optionId, accountId);
+      setChessOwned(updatedInventory);
+      setInfo(`${ownedLabel} purchased and added to your Chess Battle Royal account.`);
 
       const bal = await getAccountBalance(accountId);
       if (typeof bal?.balance === 'number') {
@@ -140,13 +245,12 @@ export default function Store() {
     <div className="relative p-4 space-y-4 text-text flex flex-col items-center">
       <h2 className="text-xl font-bold">Store</h2>
       <p className="text-subtext text-sm text-center max-w-2xl">
-        Pool Royale cosmetics are organized here as non-tradable unlocks. Defaults are already
-        equipped for every player, while the cards below are minted as account-bound NFTs for this
-        game.
+        Pool Royale and Chess Battle Royal cosmetics are organized here as non-tradable unlocks. Defaults
+        remain free for every player, while the cards below are minted as account-bound NFTs for each game.
       </p>
 
       <div className="store-info-bar">
-        <span className="font-semibold">Pool Royale</span>
+        <span className="font-semibold">Pool Royale / Chess Battle Royal</span>
         <span className="text-xs text-subtext">Account: {accountId}</span>
         <span className="text-xs text-subtext">Prices shown in TPC</span>
         <span className="text-xs text-subtext">
@@ -169,6 +273,24 @@ export default function Store() {
               <span className="text-xs uppercase text-subtext">
                 {TYPE_LABELS[item.type] || item.type}
               </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="store-card max-w-2xl">
+        <h3 className="text-lg font-semibold">Chess Battle Royal Defaults (Free)</h3>
+        <p className="text-sm text-subtext">
+          Two base piece colors stay unlocked by default; purchase the others to surface them inside the table setup menu.
+        </p>
+        <ul className="mt-2 space-y-1 w-full">
+          {chessDefaultLoadout.map((item) => (
+            <li
+              key={`chess-${item.type}-${item.optionId}`}
+              className="flex items-center justify-between rounded-lg border border-border px-3 py-2 w-full"
+            >
+              <span className="font-medium">{item.label}</span>
+              <span className="text-xs uppercase text-subtext">{CHESS_TYPE_LABELS[item.type] || item.type}</span>
             </li>
           ))}
         </ul>
@@ -204,6 +326,57 @@ export default function Store() {
                     <button
                       type="button"
                       onClick={() => handlePurchase(item)}
+                      disabled={item.owned || processing === item.id}
+                      className={`buy-button mt-2 text-center ${
+                        item.owned || processing === item.id
+                          ? 'cursor-not-allowed opacity-60'
+                          : ''
+                      }`}
+                    >
+                      {item.owned
+                        ? `${ownedLabel} Owned`
+                        : processing === item.id
+                        ? 'Purchasing...'
+                        : `Purchase ${ownedLabel}`}
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="w-full space-y-3">
+        <h3 className="text-lg font-semibold text-center">Chess Battle Royal Collection</h3>
+        {Object.entries(chessGroupedItems).map(([type, items]) => (
+          <div key={type} className="space-y-2">
+            <div className="flex items-center justify-between">
+              <h4 className="text-base font-semibold">{CHESS_TYPE_LABELS[type] || type}</h4>
+              <span className="text-xs text-subtext">NFT unlocks</span>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2">
+              {items.map((item) => {
+                const labels = CHESS_BATTLE_OPTION_LABELS[item.type] || {};
+                const ownedLabel = labels[item.optionId] || item.name;
+                return (
+                  <div key={item.id} className="store-card">
+                    <div className="flex w-full items-start justify-between gap-2">
+                      <div>
+                        <p className="font-semibold text-lg leading-tight">{item.name}</p>
+                        <p className="text-xs text-subtext">{item.description}</p>
+                        <p className="text-xs text-subtext mt-1">
+                          Applies to: {CHESS_TYPE_LABELS[item.type] || item.type}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-1 text-sm font-semibold">
+                        {item.price}
+                        <img src={TPC_ICON} alt="TPC" className="h-4 w-4" />
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleChessPurchase(item)}
                       disabled={item.owned || processing === item.id}
                       className={`buy-button mt-2 text-center ${
                         item.owned || processing === item.id

--- a/webapp/src/utils/chessBattleInventory.js
+++ b/webapp/src/utils/chessBattleInventory.js
@@ -1,0 +1,112 @@
+import {
+  CHESS_BATTLE_DEFAULT_LOADOUT,
+  CHESS_BATTLE_DEFAULT_UNLOCKS,
+  CHESS_BATTLE_OPTION_LABELS
+} from '../config/chessBattleInventoryConfig.js';
+
+const STORAGE_KEY = 'chessBattleInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(CHESS_BATTLE_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values].filter(Boolean) : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read chess inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getChessBattleInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isChessOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getChessBattleInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addChessBattleUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('chessBattleInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedChessOptions = (accountId) => {
+  const inventory = getChessBattleInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = CHESS_BATTLE_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultChessBattleLoadout = () => [...CHESS_BATTLE_DEFAULT_LOADOUT];
+
+export const chessBattleAccountId = resolveAccountId;


### PR DESCRIPTION
## Summary
- add Chess Battle Royal inventory defaults, labels, and NFT store items
- gate chess table setup and quick color options behind inventory unlocks with premium marble and dark forest palettes
- extend the Store page with Chess Battle Royal collections alongside Pool Royale items

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d8d7f6c6c83298f0338111a414d53)