### PR TITLE
Add per-game store routing and NFT marketplace rules

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -144,7 +144,8 @@ export default function App() {
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />
             <Route path="/tasks" element={<Tasks />} />
-            <Route path="/store" element={<Store />} />
+            <Route path="/store" element={<Navigate to="/store/poolroyale" replace />} />
+            <Route path="/store/:gameSlug" element={<Store />} />
             <Route path="/referral" element={<Referral />} />
             <Route path="/wallet" element={<Wallet />} />
             <Route path="/messages" element={<Messages />} />

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -1,0 +1,21 @@
+const gamesCatalog = [
+  { name: "Texas Hold'em", route: '/games/texasholdem/lobby' },
+  { name: 'Domino Royal 3D', route: '/games/domino-royal/lobby' },
+  { name: 'Black Jack Multiplayer', route: '/games/blackjack/lobby' },
+  { name: 'Pool Royale', route: '/games/poolroyale/lobby' },
+  { name: 'Snooker Club', route: '/games/snookerclub/lobby' },
+  { name: 'Goal Rush', route: '/games/goalrush/lobby' },
+  { name: 'Air Hockey', route: '/games/airhockey/lobby' },
+  { name: 'Snake & Ladder', route: '/games/snake/lobby' },
+  { name: 'Falling Ball', route: '/games/fallingball/lobby' },
+  { name: 'Murlan Royale', route: '/games/murlanroyale/lobby' },
+  { name: 'Chess Battle Royal', route: '/games/chessbattleroyal/lobby' },
+  { name: 'Ludo Battle Royal', route: '/games/ludobattleroyal/lobby' }
+];
+
+export default gamesCatalog;
+
+export const catalogWithSlugs = gamesCatalog.map((game) => {
+  const [, , slug] = game.route.split('/');
+  return { ...game, slug };
+});

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -3,21 +3,7 @@ import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LeaderboardCard from '../components/LeaderboardCard.jsx';
 import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
 import GamesHallway from '../components/GamesHallway.jsx';
-
-const gamesCatalog = [
-  { name: "Texas Hold'em", route: '/games/texasholdem/lobby' },
-  { name: 'Domino Royal 3D', route: '/games/domino-royal/lobby' },
-  { name: 'Black Jack Multiplayer', route: '/games/blackjack/lobby' },
-  { name: 'Pool Royale', route: '/games/poolroyale/lobby' },
-  { name: 'Snooker Club', route: '/games/snookerclub/lobby' },
-  { name: 'Goal Rush', route: '/games/goalrush/lobby' },
-  { name: 'Air Hockey', route: '/games/airhockey/lobby' },
-  { name: 'Snake & Ladder', route: '/games/snake/lobby' },
-  { name: 'Falling Ball', route: '/games/fallingball/lobby' },
-  { name: 'Murlan Royale', route: '/games/murlanroyale/lobby' },
-  { name: 'Chess Battle Royal', route: '/games/chessbattleroyal/lobby' },
-  { name: 'Ludo Battle Royal', route: '/games/ludobattleroyal/lobby' }
-];
+import gamesCatalog from '../config/gamesCatalog.js';
 
 export default function Games() {
   useTelegramBackButton();


### PR DESCRIPTION
## Summary
- add a shared games catalog config and reuse it on the Games page
- route the Store to per-game tabs with navigation that mirrors the games catalog
- enrich Store with game-specific content plus a marketplace enforcing ownership, floor prices, and 2% dual fees

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d98caafa08329899148d1e3c98068)