### PR TITLE
Lower Pool Royale rail overhead camera height

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -10436,7 +10436,7 @@ function PoolRoyaleGame({
       const shortRailSlideLimit = 0;
       const broadcastRig = createBroadcastCameras({
         floorY,
-        cameraHeight: TABLE_Y + TABLE.THICK + BALL_R * 9.2,
+        cameraHeight: TABLE_Y + TABLE.THICK + BALL_R * 8.8,
         shortRailZ: shortRailTarget,
         slideLimit: shortRailSlideLimit,
         arenaHalfDepth: roomDepth / 2 - wallThickness - BALL_R * 4


### PR DESCRIPTION
## Summary
- lower the Pool Royale rail overhead broadcast camera height slightly to bring the viewpoint down

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da45537588329b729aa3fc3eeed48)