### PR TITLE
Lower rail overhead camera height

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2348,7 +2348,7 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
     orbitBias: 0.68,
     railPush: BALL_R * 7.2,
     lateralDolly: BALL_R * 0.6,
-    focusLift: BALL_R * 6.6,
+    focusLift: BALL_R * 6.0,
     focusDepthBias: BALL_R * 1.8,
     focusPan: 0,
     trackingBias: 0.52,


### PR DESCRIPTION
## Summary
- reduce the Rail Overhead broadcast camera lift to sit slightly lower

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da45537588329b729aa3fc3eeed48)