### PR TITLE
Add Domino Royal NFT inventory and store integration

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -1632,7 +1632,98 @@ const TABLE_SETUP_SECTIONS = [
   { key: "chairTheme", label: "Stolat", options: CHAIR_THEME_OPTIONS }
 ];
 
-const DEFAULT_APPEARANCE = { tableWood: 0, tableCloth: 1, tableBase: 0, dominoStyle: 0, highlightStyle: 0, chairTheme: 0 };
+const DOMINO_DEFAULT_UNLOCKS = Object.freeze({
+  tableWood: ["oakEstate"],
+  tableCloth: ["crimson"],
+  tableBase: ["obsidian"],
+  dominoStyle: ["imperialIvory"],
+  highlightStyle: ["marksmanAmber"],
+  chairTheme: ["crimsonVelvet"]
+});
+
+const DOMINO_INVENTORY_STORAGE_KEY = "dominoRoyalInventoryByAccount";
+
+function resolveDominoAccountId() {
+  const stored = window.localStorage?.getItem("accountId");
+  return stored || "guest";
+}
+
+function readDominoInventories() {
+  try {
+    const raw = window.localStorage?.getItem(DOMINO_INVENTORY_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (error) {
+    console.warn("Failed to read Domino inventory", error);
+    return {};
+  }
+}
+
+function writeDominoInventories(payload) {
+  try {
+    window.localStorage?.setItem(DOMINO_INVENTORY_STORAGE_KEY, JSON.stringify(payload));
+  } catch {}
+}
+
+function normalizeDominoInventory(raw) {
+  const base = Object.entries(DOMINO_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values] : [];
+    return acc;
+  }, {});
+  if (!raw || typeof raw !== "object") return base;
+  const merged = { ...base };
+  Object.entries(raw).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+}
+
+function getDominoInventory(accountId = resolveDominoAccountId()) {
+  const inventories = readDominoInventories();
+  const current = normalizeDominoInventory(inventories[accountId]);
+  writeDominoInventories({ ...inventories, [accountId]: current });
+  return current;
+}
+
+function isDominoOptionUnlocked(type, optionId, inventory = getDominoInventory()) {
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+}
+
+function clampAppearanceToUnlocked(currentAppearance = DEFAULT_APPEARANCE) {
+  const inventory = getDominoInventory();
+  const resolved = { ...DEFAULT_APPEARANCE, ...currentAppearance };
+  const sections = [
+    ["tableWood", TABLE_WOOD_OPTIONS],
+    ["tableCloth", TABLE_CLOTH_OPTIONS],
+    ["tableBase", TABLE_BASE_OPTIONS],
+    ["dominoStyle", DOMINO_STYLE_OPTIONS],
+    ["highlightStyle", HIGHLIGHT_STYLE_OPTIONS],
+    ["chairTheme", CHAIR_THEME_OPTIONS]
+  ];
+  sections.forEach(([key, options]) => {
+    const allowedIds = new Set(inventory[key] || []);
+    const fallbackIndex = options.findIndex((option) => allowedIds.has(option.id));
+    const currentIndex = Number(resolved[key]);
+    const option = options[currentIndex];
+    if (!option || !allowedIds.has(option.id)) {
+      resolved[key] = fallbackIndex >= 0 ? fallbackIndex : 0;
+    }
+  });
+  return resolved;
+}
+
+function buildUnlockedTableSections() {
+  const inventory = getDominoInventory();
+  return TABLE_SETUP_SECTIONS.map((section) => ({
+    key: section.key,
+    label: section.label,
+    options: section.options
+      .map((option, idx) => ({ option, index: idx }))
+      .filter(({ option }) => isDominoOptionUnlocked(section.key, option.id, inventory))
+  }));
+}
+
+const DEFAULT_APPEARANCE = { tableWood: 0, tableCloth: 0, tableBase: 0, dominoStyle: 0, highlightStyle: 0, chairTheme: 0 };
 const APPEARANCE_STORAGE_KEY = "dominoRoyalArenaAppearanceV2";
 const LEGACY_APPEARANCE_KEYS = ["dominoRoyalArenaAppearance"];
 let appearance = { ...DEFAULT_APPEARANCE };
@@ -1654,7 +1745,7 @@ function normalizeAppearance(raw) {
       normalized[key] = Math.min(Math.max(0, Math.round(value)), Math.max(0, max - 1));
     }
   });
-  return normalized;
+  return clampAppearanceToUnlocked(normalized);
 }
 
 try {
@@ -1671,10 +1762,10 @@ try {
       break;
     }
   }
-  appearance = normalizeAppearance(appearance);
+  appearance = clampAppearanceToUnlocked(normalizeAppearance(appearance));
 } catch (error) {
   console.warn("Failed to load Domino Royal appearance", error);
-  appearance = normalizeAppearance(appearance);
+  appearance = clampAppearanceToUnlocked(normalizeAppearance(appearance));
 }
 
 function adjustHexColor(hex, amount) {
@@ -3363,7 +3454,7 @@ if (configPanelEl) {
 
 function saveAppearance() {
   try {
-    const normalized = normalizeAppearance(appearance);
+    const normalized = clampAppearanceToUnlocked(normalizeAppearance(appearance));
     appearance = normalized;
     localStorage.setItem(APPEARANCE_STORAGE_KEY, JSON.stringify(normalized));
   } catch (error) {
@@ -3372,7 +3463,7 @@ function saveAppearance() {
 }
 
 function applyAppearanceChange({ refresh = true } = {}) {
-  appearance = normalizeAppearance(appearance);
+  appearance = clampAppearanceToUnlocked(normalizeAppearance(appearance));
   clearExistingDominoMeshes();
   updateTableMaterials();
   applyDominoStyle(DOMINO_STYLE_OPTIONS[appearance.dominoStyle] ?? DOMINO_STYLE_OPTIONS[0]);
@@ -3514,7 +3605,8 @@ function createOptionPreview(key, option) {
 function refreshConfigUI() {
   if (!configSectionsEl) return;
   configSectionsEl.replaceChildren();
-  TABLE_SETUP_SECTIONS.forEach((section) => {
+  const sections = buildUnlockedTableSections();
+  sections.forEach((section) => {
     const wrapper = document.createElement('div');
     wrapper.className = 'config-section';
     const label = document.createElement('h4');
@@ -3522,11 +3614,11 @@ function refreshConfigUI() {
     wrapper.appendChild(label);
     const optionsGrid = document.createElement('div');
     optionsGrid.className = 'config-options';
-    section.options.forEach((option, idx) => {
+    section.options.forEach(({ option, index }) => {
       const button = document.createElement('button');
       button.type = 'button';
       button.className = 'config-option';
-      if (appearance[section.key] === idx) {
+      if (appearance[section.key] === index) {
         button.classList.add('active');
       }
       button.appendChild(createOptionPreview(section.key, option));
@@ -3534,8 +3626,8 @@ function refreshConfigUI() {
       name.textContent = option.label ?? option.id;
       button.appendChild(name);
       button.addEventListener('click', () => {
-        if (appearance[section.key] === idx) return;
-        appearance[section.key] = idx;
+        if (appearance[section.key] === index) return;
+        appearance[section.key] = index;
         applyAppearanceChange({ refresh: false });
         refreshConfigUI();
       });
@@ -3578,6 +3670,14 @@ document.addEventListener('keydown', (event) => {
     closeConfigPanel();
   }
 });
+
+const handleDominoInventoryUpdate = (event) => {
+  if (!event?.detail?.accountId || event.detail.accountId === resolveDominoAccountId()) {
+    appearance = clampAppearanceToUnlocked(appearance);
+    applyAppearanceChange();
+  }
+};
+window.addEventListener('dominoRoyalInventoryUpdate', handleDominoInventoryUpdate);
 
 /* ---------- Seating (Texas Hold'em Style Chairs) ---------- */
 const CHAIR_TEXTURE_PROPS = Object.freeze([

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,0 +1,239 @@
+export const DOMINO_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
+  tableWood: ['oakEstate'],
+  tableCloth: ['crimson'],
+  tableBase: ['obsidian'],
+  dominoStyle: ['imperialIvory'],
+  highlightStyle: ['marksmanAmber'],
+  chairTheme: ['crimsonVelvet']
+});
+
+export const DOMINO_ROYALE_OPTION_LABELS = Object.freeze({
+  tableWood: Object.freeze({
+    oakEstate: 'Lis Estate Wood',
+    teakStudio: 'Tik Studio Wood'
+  }),
+  tableCloth: Object.freeze({
+    crimson: 'Crimson Cloth',
+    emerald: 'Emerald Cloth',
+    arctic: 'Arctic Cloth',
+    sunset: 'Sunset Cloth',
+    violet: 'Violet Cloth',
+    amber: 'Amber Cloth'
+  }),
+  tableBase: Object.freeze({
+    obsidian: 'Obsidian Base',
+    forestBronze: 'Forest Bronze Base',
+    midnightChrome: 'Midnight Chrome Base',
+    emberCopper: 'Ember Copper Base',
+    violetShadow: 'Violet Shadow Base',
+    desertGold: 'Desert Gold Base'
+  }),
+  dominoStyle: Object.freeze({
+    imperialIvory: 'Imperial Ivory Dominoes',
+    obsidianPlatinum: 'Obsidian Platinum Dominoes',
+    midnightRose: 'Midnight Rose Dominoes',
+    auroraJade: 'Aurora Jade Dominoes',
+    sandstoneAurora: 'Sandstone Aurora Dominoes'
+  }),
+  highlightStyle: Object.freeze({
+    marksmanAmber: 'Marksman Amber Highlights',
+    iceTracer: 'Ice Tracer Highlights',
+    violetPulse: 'Violet Pulse Highlights'
+  }),
+  chairTheme: Object.freeze({
+    crimsonVelvet: 'Crimson Velvet Chairs',
+    midnightNavy: 'Midnight Blue Chairs',
+    emeraldWave: 'Emerald Wave Chairs',
+    onyxShadow: 'Onyx Shadow Chairs',
+    royalPlum: 'Royal Chestnut Chairs'
+  })
+});
+
+export const DOMINO_ROYALE_STORE_ITEMS = [
+  {
+    id: 'wood-teakStudio',
+    type: 'tableWood',
+    optionId: 'teakStudio',
+    name: 'Tik Studio Wood',
+    price: 780,
+    description: 'Teak studio grain with bright estate banding.'
+  },
+  {
+    id: 'cloth-emerald',
+    type: 'tableCloth',
+    optionId: 'emerald',
+    name: 'Emerald Cloth',
+    price: 260,
+    description: 'Deep emerald felt with balanced sheen.'
+  },
+  {
+    id: 'cloth-arctic',
+    type: 'tableCloth',
+    optionId: 'arctic',
+    name: 'Arctic Cloth',
+    price: 280,
+    description: 'Cool arctic blue felt for crisp contrast.'
+  },
+  {
+    id: 'cloth-sunset',
+    type: 'tableCloth',
+    optionId: 'sunset',
+    name: 'Sunset Cloth',
+    price: 300,
+    description: 'Warm sunset gradient cloth with copper notes.'
+  },
+  {
+    id: 'cloth-violet',
+    type: 'tableCloth',
+    optionId: 'violet',
+    name: 'Violet Cloth',
+    price: 300,
+    description: 'Violet felt with deep royal shading.'
+  },
+  {
+    id: 'cloth-amber',
+    type: 'tableCloth',
+    optionId: 'amber',
+    name: 'Amber Cloth',
+    price: 320,
+    description: 'Amber-toned cloth to warm the arena lighting.'
+  },
+  {
+    id: 'base-forestBronze',
+    type: 'tableBase',
+    optionId: 'forestBronze',
+    name: 'Forest Bronze Base',
+    price: 520,
+    description: 'Forest bronze legs with bronze-trimmed columns.'
+  },
+  {
+    id: 'base-midnightChrome',
+    type: 'tableBase',
+    optionId: 'midnightChrome',
+    name: 'Midnight Chrome Base',
+    price: 560,
+    description: 'Chrome-detailed midnight column set.'
+  },
+  {
+    id: 'base-emberCopper',
+    type: 'tableBase',
+    optionId: 'emberCopper',
+    name: 'Ember Copper Base',
+    price: 540,
+    description: 'Copper-infused base with ember accents.'
+  },
+  {
+    id: 'base-violetShadow',
+    type: 'tableBase',
+    optionId: 'violetShadow',
+    name: 'Violet Shadow Base',
+    price: 560,
+    description: 'Violet shadow legs with twilight trims.'
+  },
+  {
+    id: 'base-desertGold',
+    type: 'tableBase',
+    optionId: 'desertGold',
+    name: 'Desert Gold Base',
+    price: 600,
+    description: 'Desert gold metallic base for luxe seating.'
+  },
+  {
+    id: 'domino-obsidian',
+    type: 'dominoStyle',
+    optionId: 'obsidianPlatinum',
+    name: 'Obsidian Platinum Dominoes',
+    price: 880,
+    description: 'Obsidian tiles with platinum insets.'
+  },
+  {
+    id: 'domino-midnight',
+    type: 'dominoStyle',
+    optionId: 'midnightRose',
+    name: 'Midnight Rose Dominoes',
+    price: 900,
+    description: 'Midnight blue porcelain with rose copper accents.'
+  },
+  {
+    id: 'domino-aurora',
+    type: 'dominoStyle',
+    optionId: 'auroraJade',
+    name: 'Aurora Jade Dominoes',
+    price: 940,
+    description: 'Jade emerald tones with bronze rims.'
+  },
+  {
+    id: 'domino-sandstone',
+    type: 'dominoStyle',
+    optionId: 'sandstoneAurora',
+    name: 'Sandstone Aurora Dominoes',
+    price: 960,
+    description: 'Sandstone porcelain with amber glow rings.'
+  },
+  {
+    id: 'highlight-iceTracer',
+    type: 'highlightStyle',
+    optionId: 'iceTracer',
+    name: 'Ice Tracer Highlights',
+    price: 210,
+    description: 'Glacial tracer arcs for targeting highlights.'
+  },
+  {
+    id: 'highlight-violetPulse',
+    type: 'highlightStyle',
+    optionId: 'violetPulse',
+    name: 'Violet Pulse Highlights',
+    price: 230,
+    description: 'Violet pulse rings with energetic glow.'
+  },
+  {
+    id: 'chair-midnight',
+    type: 'chairTheme',
+    optionId: 'midnightNavy',
+    name: 'Midnight Blue Chairs',
+    price: 260,
+    description: 'Velvet navy seating with chrome studs.'
+  },
+  {
+    id: 'chair-emerald',
+    type: 'chairTheme',
+    optionId: 'emeraldWave',
+    name: 'Emerald Wave Chairs',
+    price: 260,
+    description: 'Emerald seating with deep forest legs.'
+  },
+  {
+    id: 'chair-onyx',
+    type: 'chairTheme',
+    optionId: 'onyxShadow',
+    name: 'Onyx Shadow Chairs',
+    price: 280,
+    description: 'Matte onyx chairs with gunmetal studs.'
+  },
+  {
+    id: 'chair-royal',
+    type: 'chairTheme',
+    optionId: 'royalPlum',
+    name: 'Royal Chestnut Chairs',
+    price: 280,
+    description: 'Royal plum seating with chestnut trim.'
+  }
+];
+
+export const DOMINO_ROYALE_DEFAULT_LOADOUT = [
+  { type: 'tableWood', optionId: 'oakEstate', label: 'Lis Estate Wood' },
+  { type: 'tableCloth', optionId: 'crimson', label: 'Crimson Cloth' },
+  { type: 'tableBase', optionId: 'obsidian', label: 'Obsidian Base' },
+  { type: 'dominoStyle', optionId: 'imperialIvory', label: 'Imperial Ivory Dominoes' },
+  { type: 'highlightStyle', optionId: 'marksmanAmber', label: 'Marksman Amber Highlights' },
+  { type: 'chairTheme', optionId: 'crimsonVelvet', label: 'Crimson Velvet Chairs' }
+];
+
+export const DOMINO_ROYALE_TYPE_LABELS = Object.freeze({
+  tableWood: 'Table Wood',
+  tableCloth: 'Table Cloth',
+  tableBase: 'Table Base',
+  dominoStyle: 'Domino Style',
+  highlightStyle: 'Highlights',
+  chairTheme: 'Chairs'
+});

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -32,6 +32,12 @@ import {
   listOwnedPoolRoyalOptions,
   poolRoyalAccountId
 } from '../utils/poolRoyalInventory.js';
+import {
+  getDefaultDominoRoyalLoadout,
+  listOwnedDominoOptions,
+  dominoRoyalAccountId
+} from '../utils/dominoRoyalInventory.js';
+import { DOMINO_ROYALE_TYPE_LABELS } from '../config/dominoRoyalInventoryConfig.js';
 
 import { FiCopy } from 'react-icons/fi';
 
@@ -95,6 +101,10 @@ export default function MyAccount() {
   const [poolRoyaleInventory, setPoolRoyaleInventory] = useState(() =>
     listOwnedPoolRoyalOptions(poolRoyalAccountId())
   );
+  const [dominoAccountId, setDominoAccountId] = useState(dominoRoyalAccountId());
+  const [dominoInventory, setDominoInventory] = useState(() =>
+    listOwnedDominoOptions(dominoRoyalAccountId())
+  );
   const refreshPoolRoyale = useCallback(() => {
     const resolved = poolRoyalAccountId();
     setPoolAccountId(resolved);
@@ -103,6 +113,16 @@ export default function MyAccount() {
       setPoolRoyaleInventory(owned);
     } else {
       setPoolRoyaleInventory(getDefaultPoolRoyalLoadout());
+    }
+  }, []);
+  const refreshDominoRoyal = useCallback(() => {
+    const resolved = dominoRoyalAccountId();
+    setDominoAccountId(resolved);
+    const owned = listOwnedDominoOptions(resolved);
+    if (Array.isArray(owned) && owned.length > 0) {
+      setDominoInventory(owned);
+    } else {
+      setDominoInventory(getDefaultDominoRoyalLoadout());
     }
   }, []);
 
@@ -175,6 +195,7 @@ export default function MyAccount() {
         setShowAvatarPrompt(true);
       }
       refreshPoolRoyale();
+      refreshDominoRoyal();
     }
 
     load();
@@ -201,7 +222,8 @@ export default function MyAccount() {
   }, [telegramId]);
   useEffect(() => {
     refreshPoolRoyale();
-  }, [profile, refreshPoolRoyale]);
+    refreshDominoRoyal();
+  }, [profile, refreshDominoRoyal, refreshPoolRoyale]);
   useEffect(() => {
     const handler = (event) => {
       if (!event?.detail?.accountId || event.detail.accountId === poolAccountId) {
@@ -211,6 +233,15 @@ export default function MyAccount() {
     window.addEventListener('poolRoyalInventoryUpdate', handler);
     return () => window.removeEventListener('poolRoyalInventoryUpdate', handler);
   }, [poolAccountId, refreshPoolRoyale]);
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === dominoAccountId) {
+        refreshDominoRoyal();
+      }
+    };
+    window.addEventListener('dominoRoyalInventoryUpdate', handler);
+    return () => window.removeEventListener('dominoRoyalInventoryUpdate', handler);
+  }, [dominoAccountId, refreshDominoRoyal]);
 
   if (!profile) return <div className="p-4 text-subtext">Loading...</div>;
 
@@ -467,6 +498,28 @@ export default function MyAccount() {
               <span className="font-medium">{item.label}</span>
               <span className="text-[11px] uppercase text-subtext">
                 {POOL_ROYALE_TYPE_LABELS[item.type] || item.type}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold">Domino Royal Inventory</h3>
+          <span className="text-xs text-subtext">Account: {dominoAccountId}</span>
+        </div>
+        <p className="text-sm text-subtext">
+          Base options stay free. Purchased NFTs also show inside the Domino Royal table setup menu.
+        </p>
+        <div className="space-y-1">
+          {dominoInventory.map((item) => (
+            <div
+              key={`domino-${item.type}-${item.optionId}`}
+              className="flex items-center justify-between rounded-lg border border-border px-3 py-2 bg-surface/60"
+            >
+              <span className="font-medium">{item.label}</span>
+              <span className="text-[11px] uppercase text-subtext">
+                {DOMINO_ROYALE_TYPE_LABELS[item.type] || item.type}
               </span>
             </div>
           ))}

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -7,12 +7,24 @@ import {
   POOL_ROYALE_STORE_ITEMS
 } from '../config/poolRoyaleInventoryConfig.js';
 import {
+  DOMINO_ROYALE_DEFAULT_LOADOUT,
+  DOMINO_ROYALE_OPTION_LABELS,
+  DOMINO_ROYALE_STORE_ITEMS
+} from '../config/dominoRoyalInventoryConfig.js';
+import {
   addPoolRoyalUnlock,
   getPoolRoyalInventory,
   isPoolOptionUnlocked,
   listOwnedPoolRoyalOptions,
   poolRoyalAccountId
 } from '../utils/poolRoyalInventory.js';
+import {
+  addDominoRoyalUnlock,
+  dominoRoyalAccountId,
+  getDominoRoyalInventory,
+  isDominoOptionUnlocked,
+  listOwnedDominoOptions
+} from '../utils/dominoRoyalInventory.js';
 import {
   CHESS_BATTLE_DEFAULT_LOADOUT,
   CHESS_BATTLE_OPTION_LABELS,
@@ -37,6 +49,15 @@ const TYPE_LABELS = {
   cueStyle: 'Cue Styles'
 };
 
+const DOMINO_TYPE_LABELS = {
+  tableWood: 'Table Wood',
+  tableCloth: 'Table Cloth',
+  tableBase: 'Table Base',
+  dominoStyle: 'Domino Style',
+  highlightStyle: 'Highlights',
+  chairTheme: 'Chairs'
+};
+
 const CHESS_TYPE_LABELS = {
   tableWood: 'Table Wood',
   tableCloth: 'Table Cloth',
@@ -50,8 +71,9 @@ const CHESS_TYPE_LABELS = {
 
 const TPC_ICON = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 const POOL_STORE_ACCOUNT_ID = import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const DOMINO_STORE_ACCOUNT_ID = import.meta.env.VITE_DOMINO_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const CHESS_STORE_ACCOUNT_ID = import.meta.env.VITE_CHESS_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
-const SUPPORTED_STORE_SLUGS = ['poolroyale', 'chessbattleroyal'];
+const SUPPORTED_STORE_SLUGS = ['poolroyale', 'domino-royal', 'chessbattleroyal'];
 
 const createItemKey = (type, optionId) => `${type}:${optionId}`;
 
@@ -61,6 +83,9 @@ export default function Store() {
   const navigate = useNavigate();
   const [accountId, setAccountId] = useState(() => poolRoyalAccountId());
   const [poolOwned, setPoolOwned] = useState(() => getPoolRoyalInventory(accountId));
+  const [dominoOwned, setDominoOwned] = useState(() =>
+    getDominoRoyalInventory(dominoRoyalAccountId(accountId))
+  );
   const [chessOwned, setChessOwned] = useState(() => getChessBattleInventory(chessBattleAccountId(accountId)));
   const [info, setInfo] = useState('');
   const [marketInfo, setMarketInfo] = useState('');
@@ -92,6 +117,7 @@ export default function Store() {
 
   useEffect(() => {
     setPoolOwned(getPoolRoyalInventory(accountId));
+    setDominoOwned(getDominoRoyalInventory(dominoRoyalAccountId(accountId)));
     setChessOwned(getChessBattleInventory(chessBattleAccountId(accountId)));
   }, [accountId]);
 
@@ -118,6 +144,16 @@ export default function Store() {
     };
     window.addEventListener('poolRoyalInventoryUpdate', handler);
     return () => window.removeEventListener('poolRoyalInventoryUpdate', handler);
+  }, [accountId]);
+
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === accountId) {
+        setDominoOwned(getDominoRoyalInventory(dominoRoyalAccountId(accountId)));
+      }
+    };
+    window.addEventListener('dominoRoyalInventoryUpdate', handler);
+    return () => window.removeEventListener('dominoRoyalInventoryUpdate', handler);
   }, [accountId]);
 
   useEffect(() => {
@@ -157,6 +193,27 @@ export default function Store() {
     [poolOwned]
   );
 
+  const dominoGroupedItems = useMemo(() => {
+    const items = DOMINO_ROYALE_STORE_ITEMS.map((item) => ({
+      ...item,
+      owned: isDominoOptionUnlocked(item.type, item.optionId, dominoOwned)
+    }));
+    return items.reduce((acc, item) => {
+      acc[item.type] = acc[item.type] || [];
+      acc[item.type].push(item);
+      return acc;
+    }, {});
+  }, [dominoOwned]);
+
+  const dominoDefaultLoadout = useMemo(
+    () =>
+      DOMINO_ROYALE_DEFAULT_LOADOUT.map((entry) => ({
+        ...entry,
+        owned: isDominoOptionUnlocked(entry.type, entry.optionId, dominoOwned)
+      })),
+    [dominoOwned]
+  );
+
   const chessGroupedItems = useMemo(() => {
     const items = CHESS_BATTLE_STORE_ITEMS.map((item) => ({
       ...item,
@@ -181,6 +238,7 @@ export default function Store() {
   const storeItemsBySlug = useMemo(
     () => ({
       poolroyale: POOL_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
+      'domino-royal': DOMINO_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
       chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) }))
     }),
     []
@@ -200,14 +258,16 @@ export default function Store() {
   const ownedCheckers = useMemo(
     () => ({
       poolroyale: (type, optionId) => isPoolOptionUnlocked(type, optionId, poolOwned),
+      'domino-royal': (type, optionId) => isDominoOptionUnlocked(type, optionId, dominoOwned),
       chessbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned)
     }),
-    [poolOwned, chessOwned]
+    [dominoOwned, poolOwned, chessOwned]
   );
 
   const labelResolvers = useMemo(
     () => ({
       poolroyale: (item) => POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      'domino-royal': (item) => DOMINO_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       chessbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name
     }),
     []
@@ -269,6 +329,50 @@ export default function Store() {
       const updatedInventory = addPoolRoyalUnlock(item.type, item.optionId, accountId);
       setPoolOwned(updatedInventory);
       setInfo(`${ownedLabel} purchased and added to your Pool Royale account.`);
+
+      const bal = await getAccountBalance(accountId);
+      if (typeof bal?.balance === 'number') {
+        setTpcBalance(bal.balance);
+      }
+    } catch (err) {
+      console.error('Purchase failed', err);
+      setInfo('Failed to process purchase.');
+    } finally {
+      setProcessing('');
+    }
+  };
+
+  const handleDominoPurchase = async (item) => {
+    if (item.owned || processing === item.id) return;
+    if (!accountId || accountId === 'guest') {
+      setInfo('Link your TPC account in the wallet first.');
+      return;
+    }
+    if (!DOMINO_STORE_ACCOUNT_ID) {
+      setInfo('Store account unavailable. Please try again later.');
+      return;
+    }
+
+    const labels = DOMINO_ROYALE_OPTION_LABELS[item.type] || {};
+    const ownedLabel = labels[item.optionId] || item.name;
+
+    if (tpcBalance !== null && item.price > tpcBalance) {
+      setInfo('Insufficient TPC balance for this purchase.');
+      return;
+    }
+
+    setProcessing(item.id);
+    setInfo('');
+    try {
+      const res = await sendAccountTpc(accountId, DOMINO_STORE_ACCOUNT_ID, item.price, `Domino Royal: ${ownedLabel}`);
+      if (res?.error) {
+        setInfo(res.error || 'Purchase failed.');
+        return;
+      }
+
+      const updatedInventory = addDominoRoyalUnlock(item.type, item.optionId, accountId);
+      setDominoOwned(updatedInventory);
+      setInfo(`${ownedLabel} purchased and added to your Domino Royal account.`);
 
       const bal = await getAccountBalance(accountId);
       if (typeof bal?.balance === 'number') {
@@ -391,14 +495,16 @@ export default function Store() {
   );
 
   const poolOwnedOptions = useMemo(() => listOwnedPoolRoyalOptions(accountId), [accountId]);
+  const dominoOwnedOptions = useMemo(() => listOwnedDominoOptions(accountId), [accountId]);
   const chessOwnedOptions = useMemo(() => listOwnedChessOptions(accountId), [accountId]);
 
   const ownedItemLookup = useMemo(
     () => ({
       poolroyale: poolOwnedOptions,
+      'domino-royal': dominoOwnedOptions,
       chessbattleroyal: chessOwnedOptions
     }),
-    [poolOwnedOptions, chessOwnedOptions]
+    [dominoOwnedOptions, poolOwnedOptions, chessOwnedOptions]
   );
 
   const hasStorefront = SUPPORTED_STORE_SLUGS.includes(activeSlug);
@@ -454,11 +560,11 @@ export default function Store() {
           <div className="store-card max-w-2xl">
             <h3 className="text-lg font-semibold">Default Loadout (Free)</h3>
             <p className="text-sm text-subtext">
-              These items are always available and applied when you enter Pool Royale.
-            </p>
-            <ul className="mt-2 space-y-1 w-full">
-              {poolDefaultLoadout.map((item) => (
-                <li
+            These items are always available and applied when you enter Pool Royale.
+          </p>
+          <ul className="mt-2 space-y-1 w-full">
+            {poolDefaultLoadout.map((item) => (
+              <li
                   key={`${item.type}-${item.optionId}`}
                   className="flex items-center justify-between rounded-lg border border-border px-3 py-2 w-full"
                 >
@@ -497,6 +603,75 @@ export default function Store() {
                         <button
                           type="button"
                           onClick={() => handlePurchase(item)}
+                          disabled={item.owned || processing === item.id}
+                          className={`buy-button mt-2 text-center ${
+                            item.owned || processing === item.id ? 'cursor-not-allowed opacity-60' : ''
+                          }`}
+                        >
+                          {item.owned
+                            ? `${ownedLabel} Owned`
+                            : processing === item.id
+                            ? 'Purchasing...'
+                            : `Purchase ${ownedLabel}`}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {activeSlug === 'domino-royal' && (
+        <>
+          <div className="store-card max-w-2xl">
+            <h3 className="text-lg font-semibold">Domino Royal Defaults (Free)</h3>
+            <p className="text-sm text-subtext">
+              First options stay unlocked; purchase the premium sets to surface them inside the table setup menu.
+            </p>
+            <ul className="mt-2 space-y-1 w-full">
+              {dominoDefaultLoadout.map((item) => (
+                <li
+                  key={`domino-${item.type}-${item.optionId}`}
+                  className="flex items-center justify-between rounded-lg border border-border px-3 py-2 w-full"
+                >
+                  <span className="font-medium">{item.label}</span>
+                  <span className="text-xs uppercase text-subtext">{DOMINO_TYPE_LABELS[item.type] || item.type}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="w-full space-y-3">
+            <h3 className="text-lg font-semibold text-center">Domino Royal Collection</h3>
+            {Object.entries(dominoGroupedItems).map(([type, items]) => (
+              <div key={type} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <h4 className="text-base font-semibold">{DOMINO_TYPE_LABELS[type] || type}</h4>
+                  <span className="text-xs text-subtext">NFT unlocks</span>
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  {items.map((item) => {
+                    const labels = DOMINO_ROYALE_OPTION_LABELS[item.type] || {};
+                    const ownedLabel = labels[item.optionId] || item.name;
+                    return (
+                      <div key={item.id} className="store-card">
+                        <div className="flex w-full items-start justify-between gap-2">
+                          <div>
+                            <p className="font-semibold text-lg leading-tight">{item.name}</p>
+                            <p className="text-xs text-subtext">{item.description}</p>
+                            <p className="text-xs text-subtext mt-1">Applies to: {DOMINO_TYPE_LABELS[item.type] || item.type}</p>
+                          </div>
+                          <div className="flex items-center gap-1 text-sm font-semibold">
+                            {item.price}
+                            <img src={TPC_ICON} alt="TPC" className="h-4 w-4" />
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => handleDominoPurchase(item)}
                           disabled={item.owned || processing === item.id}
                           className={`buy-button mt-2 text-center ${
                             item.owned || processing === item.id ? 'cursor-not-allowed opacity-60' : ''

--- a/webapp/src/utils/dominoRoyalInventory.js
+++ b/webapp/src/utils/dominoRoyalInventory.js
@@ -1,0 +1,112 @@
+import {
+  DOMINO_ROYALE_DEFAULT_LOADOUT,
+  DOMINO_ROYALE_DEFAULT_UNLOCKS,
+  DOMINO_ROYALE_OPTION_LABELS
+} from '../config/dominoRoyalInventoryConfig.js';
+
+const STORAGE_KEY = 'dominoRoyalInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(DOMINO_ROYALE_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values].filter(Boolean) : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read domino inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getDominoRoyalInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isDominoOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getDominoRoyalInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addDominoRoyalUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('dominoRoyalInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedDominoOptions = (accountId) => {
+  const inventory = getDominoRoyalInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = DOMINO_ROYALE_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultDominoRoyalLoadout = () => [...DOMINO_ROYALE_DEFAULT_LOADOUT];
+
+export const dominoRoyalAccountId = resolveAccountId;


### PR DESCRIPTION
## Summary
- add Domino Royal NFT catalog, default unlocks, and inventory storage utilities shared with the web app
- expose Domino Royal cosmetics in the store and account pages with purchase flow and marketplace support
- gate Domino Royal table setup options to free defaults and unlocked NFT selections, updating automatically when items are bought

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da75dee508329b37988400e253cd6)