### PR TITLE
Add Murlan Royale NFT cosmetic unlocks

### DIFF
--- a/webapp/src/config/murlanRoyaleAppearance.js
+++ b/webapp/src/config/murlanRoyaleAppearance.js
@@ -1,0 +1,17 @@
+export const OUTFIT_THEMES = [
+  { id: 'midnight', label: 'Royal Blue', baseColor: '#1f3c88', accentColor: '#f5d547', glow: '#0f172a' },
+  { id: 'ember', label: 'Neon Red', baseColor: '#a31621', accentColor: '#ff8e3c', glow: '#22080b' },
+  { id: 'glacier', label: 'Ice', baseColor: '#1b8dbf', accentColor: '#9ff0ff', glow: '#082433' },
+  { id: 'forest', label: 'Forest', baseColor: '#1b7f4a', accentColor: '#b5f44a', glow: '#071f11' },
+  { id: 'royal', label: 'Violet', baseColor: '#6b21a8', accentColor: '#f0abfc', glow: '#220a35' },
+  { id: 'onyx', label: 'Onyx', baseColor: '#1f2937', accentColor: '#9ca3af', glow: '#090b10' }
+];
+
+export const STOOL_THEMES = [
+  { id: 'ruby', label: 'Ruby', seatColor: '#8b0000', legColor: '#1f1f1f' },
+  { id: 'slate', label: 'Slate', seatColor: '#374151', legColor: '#0f172a' },
+  { id: 'teal', label: 'Teal', seatColor: '#0f766e', legColor: '#082f2a' },
+  { id: 'amber', label: 'Amber', seatColor: '#b45309', legColor: '#2f2410' },
+  { id: 'violet', label: 'Violet', seatColor: '#7c3aed', legColor: '#2b1059' },
+  { id: 'frost', label: 'Ice', seatColor: '#1f2937', legColor: '#0f172a' }
+];

--- a/webapp/src/config/murlanRoyaleInventoryConfig.js
+++ b/webapp/src/config/murlanRoyaleInventoryConfig.js
@@ -1,0 +1,111 @@
+import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../utils/tableCustomizationOptions.js';
+import { CARD_THEMES } from '../utils/cardThemes.js';
+import { OUTFIT_THEMES, STOOL_THEMES } from './murlanRoyaleAppearance.js';
+
+export const MURLAN_DEFAULT_UNLOCKS = Object.freeze({
+  tableWood: [TABLE_WOOD_OPTIONS[0]?.id],
+  tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
+  tableBase: [TABLE_BASE_OPTIONS[0]?.id],
+  cards: [CARD_THEMES[0]?.id],
+  stools: [STOOL_THEMES[0]?.id],
+  outfit: [OUTFIT_THEMES[0]?.id]
+});
+
+export const MURLAN_OPTION_LABELS = Object.freeze({
+  tableWood: Object.freeze(
+    TABLE_WOOD_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableCloth: Object.freeze(
+    TABLE_CLOTH_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableBase: Object.freeze(
+    TABLE_BASE_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  cards: Object.freeze(
+    CARD_THEMES.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  stools: Object.freeze(
+    STOOL_THEMES.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  outfit: Object.freeze(
+    OUTFIT_THEMES.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  )
+});
+
+export const MURLAN_STORE_ITEMS = [
+  ...TABLE_WOOD_OPTIONS.slice(1).map((option, idx) => ({
+    id: `murlan-wood-${option.id}`,
+    type: 'tableWood',
+    optionId: option.id,
+    name: option.label,
+    price: 520 + idx * 40,
+    description: 'Alternate rail wood finish for the Murlan Royale table.'
+  })),
+  ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
+    id: `murlan-cloth-${option.id}`,
+    type: 'tableCloth',
+    optionId: option.id,
+    name: option.label,
+    price: 340 + idx * 30,
+    description: 'Premium felt palette applied to the Murlan Royale playfield.'
+  })),
+  ...TABLE_BASE_OPTIONS.slice(1).map((option, idx) => ({
+    id: `murlan-base-${option.id}`,
+    type: 'tableBase',
+    optionId: option.id,
+    name: option.label,
+    price: 460 + idx * 35,
+    description: 'Pedestal and trim finish upgrade for the Murlan Royale base.'
+  })),
+  ...CARD_THEMES.slice(1).map((option, idx) => ({
+    id: `murlan-cards-${option.id}`,
+    type: 'cards',
+    optionId: option.id,
+    name: `${option.label} Card Theme`,
+    price: 260 + idx * 28,
+    description: 'Front and back artwork for the Murlan Royale deck.'
+  })),
+  ...STOOL_THEMES.slice(1).map((option, idx) => ({
+    id: `murlan-stools-${option.id}`,
+    type: 'stools',
+    optionId: option.id,
+    name: `${option.label} Lounge Stools`,
+    price: 300 + idx * 35,
+    description: 'Seat and leg colors for the arena stools.'
+  })),
+  ...OUTFIT_THEMES.slice(1).map((option, idx) => ({
+    id: `murlan-outfit-${option.id}`,
+    type: 'outfit',
+    optionId: option.id,
+    name: `${option.label} Outfit`,
+    price: 340 + idx * 32,
+    description: 'Player outfit palette applied to the dealer and avatars.'
+  }))
+];
+
+export const MURLAN_DEFAULT_LOADOUT = [
+  { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0]?.id, label: TABLE_WOOD_OPTIONS[0]?.label },
+  { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
+  { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0]?.id, label: TABLE_BASE_OPTIONS[0]?.label },
+  { type: 'cards', optionId: CARD_THEMES[0]?.id, label: CARD_THEMES[0]?.label },
+  { type: 'stools', optionId: STOOL_THEMES[0]?.id, label: STOOL_THEMES[0]?.label },
+  { type: 'outfit', optionId: OUTFIT_THEMES[0]?.id, label: OUTFIT_THEMES[0]?.label }
+];

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -30,6 +30,8 @@ import {
   WOOD_PRESETS_BY_ID
 } from '../../utils/tableCustomizationOptions.js';
 import { CARD_THEMES } from '../../utils/cardThemes.js';
+import { OUTFIT_THEMES, STOOL_THEMES } from '../../config/murlanRoyaleAppearance.js';
+import { getMurlanInventory, isMurlanOptionUnlocked } from '../../utils/murlanInventory.js';
 import {
   ComboType,
   DEFAULT_CONFIG as BASE_CONFIG,
@@ -64,24 +66,6 @@ const SUIT_COLORS = {
   '🃏': '#111111'
 };
 
-const OUTFIT_THEMES = [
-  { id: 'midnight', label: 'Royal Blue', baseColor: '#1f3c88', accentColor: '#f5d547', glow: '#0f172a' },
-  { id: 'ember', label: 'Neon Red', baseColor: '#a31621', accentColor: '#ff8e3c', glow: '#22080b' },
-  { id: 'glacier', label: 'Ice', baseColor: '#1b8dbf', accentColor: '#9ff0ff', glow: '#082433' },
-  { id: 'forest', label: 'Forest', baseColor: '#1b7f4a', accentColor: '#b5f44a', glow: '#071f11' },
-  { id: 'royal', label: 'Violet', baseColor: '#6b21a8', accentColor: '#f0abfc', glow: '#220a35' },
-  { id: 'onyx', label: 'Onyx', baseColor: '#1f2937', accentColor: '#9ca3af', glow: '#090b10' }
-];
-
-const STOOL_THEMES = [
-  { id: 'ruby', label: 'Ruby', seatColor: '#8b0000', legColor: '#1f1f1f' },
-  { id: 'slate', label: 'Slate', seatColor: '#374151', legColor: '#0f172a' },
-  { id: 'teal', label: 'Teal', seatColor: '#0f766e', legColor: '#082f2a' },
-  { id: 'amber', label: 'Amber', seatColor: '#b45309', legColor: '#2f2410' },
-  { id: 'violet', label: 'Violet', seatColor: '#7c3aed', legColor: '#2b1059' },
-  { id: 'frost', label: 'Ice', seatColor: '#1f2937', legColor: '#0f172a' }
-];
-
 const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueChair/glTF-Binary/AntiqueChair.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
@@ -96,7 +80,8 @@ const TARGET_CHAIR_CENTER_Z = -0.1553906416893005 * CHAIR_SIZE_SCALE;
 const DEFAULT_APPEARANCE = {
   outfit: 0,
   stools: 0,
-  ...DEFAULT_TABLE_CUSTOMIZATION
+  ...DEFAULT_TABLE_CUSTOMIZATION,
+  tableCloth: 0
 };
 const APPEARANCE_STORAGE_KEY = 'murlanRoyaleAppearance';
 const CUSTOMIZATION_SECTIONS = [
@@ -380,6 +365,7 @@ export default function MurlanRoyaleArena({ search }) {
   const mountRef = useRef(null);
   const players = useMemo(() => buildPlayers(search), [search]);
 
+  const [murlanInventory, setMurlanInventory] = useState(() => getMurlanInventory());
   const [appearance, setAppearance] = useState(() => {
     if (typeof window === 'undefined') return { ...DEFAULT_APPEARANCE };
     try {
@@ -439,6 +425,59 @@ export default function MurlanRoyaleArena({ search }) {
   const soundsRef = useRef({ card: null, turn: null });
   const audioStateRef = useRef({ tableIds: [], activePlayer: null, status: null, initialized: false });
   const prevStateRef = useRef(null);
+
+  useEffect(() => {
+    const handler = (event) => {
+      setMurlanInventory(getMurlanInventory(event?.detail?.accountId));
+    };
+    window.addEventListener('murlanInventoryUpdate', handler);
+    return () => window.removeEventListener('murlanInventoryUpdate', handler);
+  }, []);
+
+  const ensureAppearanceUnlocked = useCallback(
+    (value = DEFAULT_APPEARANCE) => {
+      const normalized = normalizeAppearance(value);
+      const map = {
+        tableWood: TABLE_WOOD_OPTIONS,
+        tableCloth: TABLE_CLOTH_OPTIONS,
+        tableBase: TABLE_BASE_OPTIONS,
+        cards: CARD_THEMES,
+        stools: STOOL_THEMES,
+        outfit: OUTFIT_THEMES
+      };
+      let changed = false;
+      const next = { ...normalized };
+      Object.entries(map).forEach(([key, options]) => {
+        const idx = Number.isFinite(next[key]) ? next[key] : 0;
+        const option = options[idx];
+        if (!option || !isMurlanOptionUnlocked(key, option.id, murlanInventory)) {
+          const fallbackIdx = options.findIndex((opt) => isMurlanOptionUnlocked(key, opt.id, murlanInventory));
+          const safeIdx = fallbackIdx >= 0 ? fallbackIdx : 0;
+          if (safeIdx !== idx) {
+            next[key] = safeIdx;
+            changed = true;
+          }
+        }
+      });
+      return changed ? next : normalized;
+    },
+    [murlanInventory]
+  );
+
+  useEffect(() => {
+    setAppearance((prev) => ensureAppearanceUnlocked(prev));
+  }, [ensureAppearanceUnlocked]);
+
+  const customizationSections = useMemo(
+    () =>
+      CUSTOMIZATION_SECTIONS.map((section) => ({
+        ...section,
+        options: section.options
+          .map((option, idx) => ({ ...option, idx }))
+          .filter(({ id }) => isMurlanOptionUnlocked(section.key, id, murlanInventory))
+      })).filter((section) => section.options.length > 0),
+    [murlanInventory]
+  );
 
   const ensureCardMeshes = useCallback((state) => {
     const three = threeStateRef.current;
@@ -694,7 +733,7 @@ export default function MurlanRoyaleArena({ search }) {
       if (!threeReady) return;
       const three = threeStateRef.current;
       if (!three.scene) return;
-      const safe = normalizeAppearance(nextAppearance);
+      const safe = ensureAppearanceUnlocked(nextAppearance);
       const woodOption = TABLE_WOOD_OPTIONS[safe.tableWood] ?? TABLE_WOOD_OPTIONS[0];
       const clothOption = TABLE_CLOTH_OPTIONS[safe.tableCloth] ?? TABLE_CLOTH_OPTIONS[0];
       const baseOption = TABLE_BASE_OPTIONS[safe.tableBase] ?? TABLE_BASE_OPTIONS[0];
@@ -716,7 +755,7 @@ export default function MurlanRoyaleArena({ search }) {
       ensureCardMeshes(gameStateRef.current);
       applyStateToScene(gameStateRef.current, selectedRef.current, true);
     },
-    [applyStateToScene, ensureCardMeshes, threeReady]
+    [applyStateToScene, ensureAppearanceUnlocked, ensureCardMeshes, threeReady]
   );
 
   const renderPreview = useCallback((type, option) => {
@@ -1664,17 +1703,17 @@ export default function MurlanRoyaleArena({ search }) {
                   </button>
                 </div>
                 <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
-                  {CUSTOMIZATION_SECTIONS.map(({ key, label, options }) => (
+                  {customizationSections.map(({ key, label, options }) => (
                     <div key={key} className="space-y-2">
                       <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
                       <div className="grid grid-cols-2 gap-2">
-                        {options.map((option, idx) => {
-                          const selected = appearance[key] === idx;
+                        {options.map((option) => {
+                          const selected = appearance[key] === option.idx;
                           return (
                             <button
                               key={option.id}
                               type="button"
-                              onClick={() => setAppearance((prev) => ({ ...prev, [key]: idx }))}
+                              onClick={() => setAppearance((prev) => ({ ...prev, [key]: option.idx }))}
                               aria-pressed={selected}
                               className={`flex flex-col items-center rounded-2xl border p-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
                                 selected

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -25,6 +25,18 @@ import {
   listOwnedChessOptions,
   chessBattleAccountId
 } from '../utils/chessBattleInventory.js';
+import {
+  MURLAN_DEFAULT_LOADOUT,
+  MURLAN_OPTION_LABELS,
+  MURLAN_STORE_ITEMS
+} from '../config/murlanRoyaleInventoryConfig.js';
+import {
+  addMurlanUnlock,
+  getMurlanInventory,
+  isMurlanOptionUnlocked,
+  listOwnedMurlanOptions,
+  murlanAccountId
+} from '../utils/murlanInventory.js';
 import { getAccountBalance, sendAccountTpc } from '../utils/api.js';
 import { DEV_INFO } from '../utils/constants.js';
 import { catalogWithSlugs } from '../config/gamesCatalog.js';
@@ -48,10 +60,20 @@ const CHESS_TYPE_LABELS = {
   headStyle: 'Pawn Heads'
 };
 
+const MURLAN_TYPE_LABELS = {
+  tableWood: 'Table Wood',
+  tableCloth: 'Table Cloth',
+  tableBase: 'Table Base',
+  cards: 'Card Themes',
+  stools: 'Stools',
+  outfit: 'Outfit'
+};
+
 const TPC_ICON = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 const POOL_STORE_ACCOUNT_ID = import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const CHESS_STORE_ACCOUNT_ID = import.meta.env.VITE_CHESS_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
-const SUPPORTED_STORE_SLUGS = ['poolroyale', 'chessbattleroyal'];
+const MURLAN_STORE_ACCOUNT_ID = import.meta.env.VITE_MURLAN_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const SUPPORTED_STORE_SLUGS = ['poolroyale', 'chessbattleroyal', 'murlanroyale'];
 
 const createItemKey = (type, optionId) => `${type}:${optionId}`;
 
@@ -62,6 +84,7 @@ export default function Store() {
   const [accountId, setAccountId] = useState(() => poolRoyalAccountId());
   const [poolOwned, setPoolOwned] = useState(() => getPoolRoyalInventory(accountId));
   const [chessOwned, setChessOwned] = useState(() => getChessBattleInventory(chessBattleAccountId(accountId)));
+  const [murlanOwned, setMurlanOwned] = useState(() => getMurlanInventory(murlanAccountId(accountId)));
   const [info, setInfo] = useState('');
   const [marketInfo, setMarketInfo] = useState('');
   const [tpcBalance, setTpcBalance] = useState(null);
@@ -93,6 +116,7 @@ export default function Store() {
   useEffect(() => {
     setPoolOwned(getPoolRoyalInventory(accountId));
     setChessOwned(getChessBattleInventory(chessBattleAccountId(accountId)));
+    setMurlanOwned(getMurlanInventory(murlanAccountId(accountId)));
   }, [accountId]);
 
   useEffect(() => {
@@ -128,6 +152,16 @@ export default function Store() {
     };
     window.addEventListener('chessBattleInventoryUpdate', handler);
     return () => window.removeEventListener('chessBattleInventoryUpdate', handler);
+  }, [accountId]);
+
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === accountId) {
+        setMurlanOwned(getMurlanInventory(murlanAccountId(accountId)));
+      }
+    };
+    window.addEventListener('murlanInventoryUpdate', handler);
+    return () => window.removeEventListener('murlanInventoryUpdate', handler);
   }, [accountId]);
 
   useEffect(() => {
@@ -178,10 +212,32 @@ export default function Store() {
     [chessOwned]
   );
 
+  const murlanGroupedItems = useMemo(() => {
+    const items = MURLAN_STORE_ITEMS.map((item) => ({
+      ...item,
+      owned: isMurlanOptionUnlocked(item.type, item.optionId, murlanOwned)
+    }));
+    return items.reduce((acc, item) => {
+      acc[item.type] = acc[item.type] || [];
+      acc[item.type].push(item);
+      return acc;
+    }, {});
+  }, [murlanOwned]);
+
+  const murlanDefaultLoadout = useMemo(
+    () =>
+      MURLAN_DEFAULT_LOADOUT.map((entry) => ({
+        ...entry,
+        owned: isMurlanOptionUnlocked(entry.type, entry.optionId, murlanOwned)
+      })),
+    [murlanOwned]
+  );
+
   const storeItemsBySlug = useMemo(
     () => ({
       poolroyale: POOL_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
-      chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) }))
+      chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
+      murlanroyale: MURLAN_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) }))
     }),
     []
   );
@@ -200,15 +256,17 @@ export default function Store() {
   const ownedCheckers = useMemo(
     () => ({
       poolroyale: (type, optionId) => isPoolOptionUnlocked(type, optionId, poolOwned),
-      chessbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned)
+      chessbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
+      murlanroyale: (type, optionId) => isMurlanOptionUnlocked(type, optionId, murlanOwned)
     }),
-    [poolOwned, chessOwned]
+    [chessOwned, murlanOwned, poolOwned]
   );
 
   const labelResolvers = useMemo(
     () => ({
       poolroyale: (item) => POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      chessbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name
+      chessbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      murlanroyale: (item) => MURLAN_OPTION_LABELS[item.type]?.[item.optionId] || item.name
     }),
     []
   );
@@ -331,6 +389,50 @@ export default function Store() {
     }
   };
 
+  const handleMurlanPurchase = async (item) => {
+    if (item.owned || processing === item.id) return;
+    if (!accountId || accountId === 'guest') {
+      setInfo('Link your TPC account in the wallet first.');
+      return;
+    }
+    if (!MURLAN_STORE_ACCOUNT_ID) {
+      setInfo('Store account unavailable. Please try again later.');
+      return;
+    }
+
+    const labels = MURLAN_OPTION_LABELS[item.type] || {};
+    const ownedLabel = labels[item.optionId] || item.name;
+
+    if (tpcBalance !== null && item.price > tpcBalance) {
+      setInfo('Insufficient TPC balance for this purchase.');
+      return;
+    }
+
+    setProcessing(item.id);
+    setInfo('');
+    try {
+      const res = await sendAccountTpc(accountId, MURLAN_STORE_ACCOUNT_ID, item.price, `Murlan Royale: ${ownedLabel}`);
+      if (res?.error) {
+        setInfo(res.error || 'Purchase failed.');
+        return;
+      }
+
+      const updatedInventory = addMurlanUnlock(item.type, item.optionId, accountId);
+      setMurlanOwned(updatedInventory);
+      setInfo(`${ownedLabel} purchased and added to your Murlan Royale account.`);
+
+      const bal = await getAccountBalance(accountId);
+      if (typeof bal?.balance === 'number') {
+        setTpcBalance(bal.balance);
+      }
+    } catch (err) {
+      console.error('Purchase failed', err);
+      setInfo('Failed to process purchase.');
+    } finally {
+      setProcessing('');
+    }
+  };
+
   const handleCreateListing = () => {
     const item = tradableOwnedItems.find((entry) => entry.key === selectedItemKey);
     if (!item) {
@@ -392,13 +494,15 @@ export default function Store() {
 
   const poolOwnedOptions = useMemo(() => listOwnedPoolRoyalOptions(accountId), [accountId]);
   const chessOwnedOptions = useMemo(() => listOwnedChessOptions(accountId), [accountId]);
+  const murlanOwnedOptions = useMemo(() => listOwnedMurlanOptions(accountId), [accountId]);
 
   const ownedItemLookup = useMemo(
     () => ({
       poolroyale: poolOwnedOptions,
-      chessbattleroyal: chessOwnedOptions
+      chessbattleroyal: chessOwnedOptions,
+      murlanroyale: murlanOwnedOptions
     }),
-    [poolOwnedOptions, chessOwnedOptions]
+    [chessOwnedOptions, murlanOwnedOptions, poolOwnedOptions]
   );
 
   const hasStorefront = SUPPORTED_STORE_SLUGS.includes(activeSlug);
@@ -569,6 +673,76 @@ export default function Store() {
                         <button
                           type="button"
                           onClick={() => handleChessPurchase(item)}
+                          disabled={item.owned || processing === item.id}
+                          className={`buy-button mt-2 text-center ${
+                            item.owned || processing === item.id ? 'cursor-not-allowed opacity-60' : ''
+                          }`}
+                        >
+                          {item.owned
+                            ? `${ownedLabel} Owned`
+                            : processing === item.id
+                            ? 'Purchasing...'
+                            : `Purchase ${ownedLabel}`}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {activeSlug === 'murlanroyale' && (
+        <>
+          <div className="store-card max-w-2xl">
+            <h3 className="text-lg font-semibold">Murlan Royale Defaults (Free)</h3>
+            <p className="text-sm text-subtext">
+              First-look cosmetics stay free and selectable inside the table setup menu. Purchase additional presets to unlock
+              them in-game.
+            </p>
+            <ul className="mt-2 space-y-1 w-full">
+              {murlanDefaultLoadout.map((item) => (
+                <li
+                  key={`murlan-${item.type}-${item.optionId}`}
+                  className="flex items-center justify-between rounded-lg border border-border px-3 py-2 w-full"
+                >
+                  <span className="font-medium">{item.label}</span>
+                  <span className="text-xs uppercase text-subtext">{MURLAN_TYPE_LABELS[item.type] || item.type}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="w-full space-y-3">
+            <h3 className="text-lg font-semibold text-center">Murlan Royale Collection</h3>
+            {Object.entries(murlanGroupedItems).map(([type, items]) => (
+              <div key={type} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <h4 className="text-base font-semibold">{MURLAN_TYPE_LABELS[type] || type}</h4>
+                  <span className="text-xs text-subtext">NFT unlocks</span>
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  {items.map((item) => {
+                    const labels = MURLAN_OPTION_LABELS[item.type] || {};
+                    const ownedLabel = labels[item.optionId] || item.name;
+                    return (
+                      <div key={item.id} className="store-card">
+                        <div className="flex w-full items-start justify-between gap-2">
+                          <div>
+                            <p className="font-semibold text-lg leading-tight">{item.name}</p>
+                            <p className="text-xs text-subtext">{item.description}</p>
+                            <p className="text-xs text-subtext mt-1">Applies to: {MURLAN_TYPE_LABELS[item.type] || item.type}</p>
+                          </div>
+                          <div className="flex items-center gap-1 text-sm font-semibold">
+                            {item.price}
+                            <img src={TPC_ICON} alt="TPC" className="h-4 w-4" />
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => handleMurlanPurchase(item)}
                           disabled={item.owned || processing === item.id}
                           className={`buy-button mt-2 text-center ${
                             item.owned || processing === item.id ? 'cursor-not-allowed opacity-60' : ''

--- a/webapp/src/utils/murlanInventory.js
+++ b/webapp/src/utils/murlanInventory.js
@@ -1,0 +1,112 @@
+import {
+  MURLAN_DEFAULT_LOADOUT,
+  MURLAN_DEFAULT_UNLOCKS,
+  MURLAN_OPTION_LABELS
+} from '../config/murlanRoyaleInventoryConfig.js';
+
+const STORAGE_KEY = 'murlanRoyaleInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(MURLAN_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values].filter(Boolean) : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read murlan inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getMurlanInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isMurlanOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getMurlanInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addMurlanUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('murlanInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedMurlanOptions = (accountId) => {
+  const inventory = getMurlanInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = MURLAN_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultMurlanLoadout = () => [...MURLAN_DEFAULT_LOADOUT];
+
+export const murlanAccountId = resolveAccountId;


### PR DESCRIPTION
## Summary
- add shared Murlan Royale appearance data and NFT inventory tracking
- gate table setup options to unlocked cosmetics and surface store purchase updates
- extend the store with Murlan Royale listings and default loadout details

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da7ad429c8329862f848ae3d997f4)