### PR TITLE
Add Domino Royal NFT unlock flow and storefront

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -1637,6 +1637,108 @@ const APPEARANCE_STORAGE_KEY = "dominoRoyalArenaAppearanceV2";
 const LEGACY_APPEARANCE_KEYS = ["dominoRoyalArenaAppearance"];
 let appearance = { ...DEFAULT_APPEARANCE };
 
+const DOMINO_INVENTORY_KEY = 'dominoRoyalInventoryByAccount';
+const DOMINO_DEFAULT_UNLOCKS = Object.freeze({
+  tableWood: ['oakEstate'],
+  tableCloth: ['crimson'],
+  tableBase: ['obsidian'],
+  dominoStyle: ['imperialIvory'],
+  highlightStyle: ['marksmanAmber'],
+  chairTheme: ['crimsonVelvet']
+});
+
+const dominoInventoryDefaults = () =>
+  Object.entries(DOMINO_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values] : [];
+    return acc;
+  }, {});
+
+const resolveDominoAccountId = () => {
+  if (accountId) return accountId;
+  try {
+    const stored = window.localStorage?.getItem('accountId');
+    if (stored) return stored;
+  } catch {}
+  return 'guest';
+};
+
+const readDominoInventories = () => {
+  try {
+    const raw = window.localStorage?.getItem(DOMINO_INVENTORY_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (error) {
+    console.warn('Failed to read Domino inventory', error);
+    return {};
+  }
+};
+
+const writeDominoInventories = (payload) => {
+  try {
+    window.localStorage?.setItem(DOMINO_INVENTORY_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('Failed to persist Domino inventory', error);
+  }
+};
+
+const normalizeDominoInventory = (rawInventory) => {
+  const base = dominoInventoryDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+const getDominoInventory = () => {
+  const resolvedAccount = resolveDominoAccountId();
+  const inventories = readDominoInventories();
+  const normalized = normalizeDominoInventory(inventories[resolvedAccount]);
+  writeDominoInventories({
+    ...inventories,
+    [resolvedAccount]: normalized
+  });
+  return normalized;
+};
+
+const isDominoOptionUnlocked = (type, optionId, inventory = null) => {
+  const inv = inventory || dominoInventory;
+  return Array.isArray(inv?.[type]) && inv[type].includes(optionId);
+};
+
+const optionsByKey = {
+  tableWood: TABLE_WOOD_OPTIONS,
+  tableCloth: TABLE_CLOTH_OPTIONS,
+  tableBase: TABLE_BASE_OPTIONS,
+  dominoStyle: DOMINO_STYLE_OPTIONS,
+  highlightStyle: HIGHLIGHT_STYLE_OPTIONS,
+  chairTheme: CHAIR_THEME_OPTIONS
+};
+
+const ensureAppearanceUnlocked = () => {
+  appearance = normalizeAppearance(appearance);
+  Object.entries(optionsByKey).forEach(([key, options]) => {
+    const currentIndex = Number(appearance[key] ?? 0);
+    const currentOption = options[currentIndex];
+    const fallbackIndex = options.findIndex((opt) => isDominoOptionUnlocked(key, opt.id));
+    if (!currentOption || !isDominoOptionUnlocked(key, currentOption.id)) {
+      appearance[key] = fallbackIndex >= 0 ? fallbackIndex : 0;
+    }
+  });
+};
+
+const dominoAccount = resolveDominoAccountId();
+let dominoInventory = getDominoInventory();
+
+window.addEventListener('dominoInventoryUpdate', (event) => {
+  if (!event?.detail?.accountId || event.detail.accountId === dominoAccount) {
+    dominoInventory = normalizeDominoInventory(event?.detail?.inventory) || getDominoInventory();
+    ensureAppearanceUnlocked();
+    applyAppearanceChange();
+  }
+});
+
 function normalizeAppearance(raw) {
   const normalized = { ...DEFAULT_APPEARANCE };
   const source = raw && typeof raw === "object" ? raw : {};
@@ -1672,9 +1774,11 @@ try {
     }
   }
   appearance = normalizeAppearance(appearance);
+  ensureAppearanceUnlocked();
 } catch (error) {
   console.warn("Failed to load Domino Royal appearance", error);
   appearance = normalizeAppearance(appearance);
+  ensureAppearanceUnlocked();
 }
 
 function adjustHexColor(hex, amount) {
@@ -3373,6 +3477,7 @@ function saveAppearance() {
 
 function applyAppearanceChange({ refresh = true } = {}) {
   appearance = normalizeAppearance(appearance);
+  ensureAppearanceUnlocked();
   clearExistingDominoMeshes();
   updateTableMaterials();
   applyDominoStyle(DOMINO_STYLE_OPTIONS[appearance.dominoStyle] ?? DOMINO_STYLE_OPTIONS[0]);
@@ -3522,7 +3627,10 @@ function refreshConfigUI() {
     wrapper.appendChild(label);
     const optionsGrid = document.createElement('div');
     optionsGrid.className = 'config-options';
-    section.options.forEach((option, idx) => {
+    const unlockedOptions = section.options
+      .map((option, idx) => ({ option, idx }))
+      .filter(({ option }) => isDominoOptionUnlocked(section.key, option.id));
+    unlockedOptions.forEach(({ option, idx }) => {
       const button = document.createElement('button');
       button.type = 'button';
       button.className = 'config-option';

--- a/webapp/src/config/dominoInventoryConfig.js
+++ b/webapp/src/config/dominoInventoryConfig.js
@@ -1,0 +1,239 @@
+export const DOMINO_DEFAULT_UNLOCKS = Object.freeze({
+  tableWood: ['oakEstate'],
+  tableCloth: ['crimson'],
+  tableBase: ['obsidian'],
+  dominoStyle: ['imperialIvory'],
+  highlightStyle: ['marksmanAmber'],
+  chairTheme: ['crimsonVelvet']
+});
+
+export const DOMINO_OPTION_LABELS = Object.freeze({
+  tableWood: Object.freeze({
+    oakEstate: 'Lis Estate',
+    teakStudio: 'Tik Studio'
+  }),
+  tableCloth: Object.freeze({
+    crimson: 'Crimson Cloth',
+    emerald: 'Emerald Cloth',
+    arctic: 'Arctic Cloth',
+    sunset: 'Sunset Cloth',
+    violet: 'Violet Cloth',
+    amber: 'Amber Cloth'
+  }),
+  tableBase: Object.freeze({
+    obsidian: 'Obsidian Base',
+    forestBronze: 'Forest Base',
+    midnightChrome: 'Midnight Base',
+    emberCopper: 'Copper Base',
+    violetShadow: 'Violet Shadow Base',
+    desertGold: 'Desert Base'
+  }),
+  dominoStyle: Object.freeze({
+    imperialIvory: 'Imperial Ivory',
+    obsidianPlatinum: 'Obsidian Platinum',
+    midnightRose: 'Midnight Rose',
+    auroraJade: 'Aurora Jade',
+    carbonVolt: 'Carbon Volt',
+    sandstoneAurora: 'Sandstone Aurora'
+  }),
+  highlightStyle: Object.freeze({
+    marksmanAmber: 'Marksman Amber',
+    iceTracer: 'Ice Tracer',
+    violetPulse: 'Violet Pulse'
+  }),
+  chairTheme: Object.freeze({
+    crimsonVelvet: 'Crimson Velvet',
+    midnightNavy: 'Midnight Blue',
+    emeraldWave: 'Emerald Wave',
+    onyxShadow: 'Onyx Shadow',
+    royalPlum: 'Royal Chestnut'
+  })
+});
+
+export const DOMINO_STORE_ITEMS = [
+  {
+    id: 'wood-teakStudio',
+    type: 'tableWood',
+    optionId: 'teakStudio',
+    name: 'Tik Studio Wood',
+    price: 720,
+    description: 'Studio teak grain rails with warm highlights.'
+  },
+  {
+    id: 'cloth-emerald',
+    type: 'tableCloth',
+    optionId: 'emerald',
+    name: 'Emerald Cloth',
+    price: 340,
+    description: 'Deep emerald felt with balanced shading.'
+  },
+  {
+    id: 'cloth-arctic',
+    type: 'tableCloth',
+    optionId: 'arctic',
+    name: 'Arctic Cloth',
+    price: 360,
+    description: 'Cool arctic blue felt with crisp border glow.'
+  },
+  {
+    id: 'cloth-sunset',
+    type: 'tableCloth',
+    optionId: 'sunset',
+    name: 'Sunset Cloth',
+    price: 360,
+    description: 'Sunset orange felt with warm ember trim.'
+  },
+  {
+    id: 'cloth-violet',
+    type: 'tableCloth',
+    optionId: 'violet',
+    name: 'Violet Cloth',
+    price: 370,
+    description: 'Vibrant violet felt with royal edging.'
+  },
+  {
+    id: 'cloth-amber',
+    type: 'tableCloth',
+    optionId: 'amber',
+    name: 'Amber Cloth',
+    price: 370,
+    description: 'Amber tournament felt with subtle glow.'
+  },
+  {
+    id: 'base-forestBronze',
+    type: 'tableBase',
+    optionId: 'forestBronze',
+    name: 'Forest Base',
+    price: 420,
+    description: 'Forest-toned base with bronze trim.'
+  },
+  {
+    id: 'base-midnightChrome',
+    type: 'tableBase',
+    optionId: 'midnightChrome',
+    name: 'Midnight Base',
+    price: 440,
+    description: 'Midnight chrome base with cool highlights.'
+  },
+  {
+    id: 'base-emberCopper',
+    type: 'tableBase',
+    optionId: 'emberCopper',
+    name: 'Copper Base',
+    price: 440,
+    description: 'Copper accented base with ember undertone.'
+  },
+  {
+    id: 'base-violetShadow',
+    type: 'tableBase',
+    optionId: 'violetShadow',
+    name: 'Violet Shadow Base',
+    price: 450,
+    description: 'Shadowed violet base with luxe trim.'
+  },
+  {
+    id: 'base-desertGold',
+    type: 'tableBase',
+    optionId: 'desertGold',
+    name: 'Desert Base',
+    price: 460,
+    description: 'Desert-inspired base with gold accenting.'
+  },
+  {
+    id: 'domino-obsidianPlatinum',
+    type: 'dominoStyle',
+    optionId: 'obsidianPlatinum',
+    name: 'Obsidian Platinum Dominos',
+    price: 510,
+    description: 'Obsidian tiles with platinum inlays.'
+  },
+  {
+    id: 'domino-midnightRose',
+    type: 'dominoStyle',
+    optionId: 'midnightRose',
+    name: 'Midnight Rose Dominos',
+    price: 520,
+    description: 'Midnight blue bodies with rose accents.'
+  },
+  {
+    id: 'domino-auroraJade',
+    type: 'dominoStyle',
+    optionId: 'auroraJade',
+    name: 'Aurora Jade Dominos',
+    price: 520,
+    description: 'Jade porcelain tiles with champagne trim.'
+  },
+  {
+    id: 'domino-carbonVolt',
+    type: 'dominoStyle',
+    optionId: 'carbonVolt',
+    name: 'Carbon Volt Dominos',
+    price: 530,
+    description: 'Carbon fiber finish with electric cyan pips.'
+  },
+  {
+    id: 'domino-sandstoneAurora',
+    type: 'dominoStyle',
+    optionId: 'sandstoneAurora',
+    name: 'Sandstone Aurora Dominos',
+    price: 530,
+    description: 'Sandstone body with aurora orange accents.'
+  },
+  {
+    id: 'highlight-iceTracer',
+    type: 'highlightStyle',
+    optionId: 'iceTracer',
+    name: 'Ice Tracer Highlights',
+    price: 280,
+    description: 'Frosted tracer arcs and cool emissive glow.'
+  },
+  {
+    id: 'highlight-violetPulse',
+    type: 'highlightStyle',
+    optionId: 'violetPulse',
+    name: 'Violet Pulse Highlights',
+    price: 280,
+    description: 'Violet pulse tracers with rich emissive flare.'
+  },
+  {
+    id: 'chair-midnightNavy',
+    type: 'chairTheme',
+    optionId: 'midnightNavy',
+    name: 'Midnight Blue Chairs',
+    price: 240,
+    description: 'Midnight navy seating with satin finish.'
+  },
+  {
+    id: 'chair-emeraldWave',
+    type: 'chairTheme',
+    optionId: 'emeraldWave',
+    name: 'Emerald Wave Chairs',
+    price: 240,
+    description: 'Emerald seat cushions with dark frames.'
+  },
+  {
+    id: 'chair-onyxShadow',
+    type: 'chairTheme',
+    optionId: 'onyxShadow',
+    name: 'Onyx Shadow Chairs',
+    price: 250,
+    description: 'Onyx seating set with monochrome highlights.'
+  },
+  {
+    id: 'chair-royalPlum',
+    type: 'chairTheme',
+    optionId: 'royalPlum',
+    name: 'Royal Chestnut Chairs',
+    price: 250,
+    description: 'Royal chestnut cushions with plum highlight.'
+  }
+];
+
+export const DOMINO_DEFAULT_LOADOUT = [
+  { type: 'tableWood', optionId: 'oakEstate', label: 'Lis Estate Wood' },
+  { type: 'tableCloth', optionId: 'crimson', label: 'Crimson Cloth' },
+  { type: 'tableBase', optionId: 'obsidian', label: 'Obsidian Base' },
+  { type: 'dominoStyle', optionId: 'imperialIvory', label: 'Imperial Ivory Dominos' },
+  { type: 'highlightStyle', optionId: 'marksmanAmber', label: 'Marksman Amber Highlights' },
+  { type: 'chairTheme', optionId: 'crimsonVelvet', label: 'Crimson Velvet Chairs' }
+];

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -19,12 +19,24 @@ import {
   CHESS_BATTLE_STORE_ITEMS
 } from '../config/chessBattleInventoryConfig.js';
 import {
+  DOMINO_DEFAULT_LOADOUT,
+  DOMINO_OPTION_LABELS,
+  DOMINO_STORE_ITEMS
+} from '../config/dominoInventoryConfig.js';
+import {
   addChessBattleUnlock,
   getChessBattleInventory,
   isChessOptionUnlocked,
   listOwnedChessOptions,
   chessBattleAccountId
 } from '../utils/chessBattleInventory.js';
+import {
+  addDominoUnlock,
+  dominoAccountId,
+  getDominoInventory,
+  isDominoOptionUnlocked,
+  listOwnedDominoOptions
+} from '../utils/dominoInventory.js';
 import { getAccountBalance, sendAccountTpc } from '../utils/api.js';
 import { DEV_INFO } from '../utils/constants.js';
 import { catalogWithSlugs } from '../config/gamesCatalog.js';
@@ -48,10 +60,20 @@ const CHESS_TYPE_LABELS = {
   headStyle: 'Pawn Heads'
 };
 
+const DOMINO_TYPE_LABELS = {
+  tableWood: 'Table Wood',
+  tableCloth: 'Table Cloth',
+  tableBase: 'Table Base',
+  dominoStyle: 'Domino Styles',
+  highlightStyle: 'Highlights',
+  chairTheme: 'Chairs'
+};
+
 const TPC_ICON = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 const POOL_STORE_ACCOUNT_ID = import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const CHESS_STORE_ACCOUNT_ID = import.meta.env.VITE_CHESS_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
-const SUPPORTED_STORE_SLUGS = ['poolroyale', 'chessbattleroyal'];
+const DOMINO_STORE_ACCOUNT_ID = import.meta.env.VITE_DOMINO_ROYAL_STORE_ACCOUNT_ID || DEV_INFO.account;
+const SUPPORTED_STORE_SLUGS = ['poolroyale', 'chessbattleroyal', 'domino-royal'];
 
 const createItemKey = (type, optionId) => `${type}:${optionId}`;
 
@@ -62,6 +84,7 @@ export default function Store() {
   const [accountId, setAccountId] = useState(() => poolRoyalAccountId());
   const [poolOwned, setPoolOwned] = useState(() => getPoolRoyalInventory(accountId));
   const [chessOwned, setChessOwned] = useState(() => getChessBattleInventory(chessBattleAccountId(accountId)));
+  const [dominoOwned, setDominoOwned] = useState(() => getDominoInventory(dominoAccountId(accountId)));
   const [info, setInfo] = useState('');
   const [marketInfo, setMarketInfo] = useState('');
   const [tpcBalance, setTpcBalance] = useState(null);
@@ -93,6 +116,7 @@ export default function Store() {
   useEffect(() => {
     setPoolOwned(getPoolRoyalInventory(accountId));
     setChessOwned(getChessBattleInventory(chessBattleAccountId(accountId)));
+    setDominoOwned(getDominoInventory(dominoAccountId(accountId)));
   }, [accountId]);
 
   useEffect(() => {
@@ -131,6 +155,16 @@ export default function Store() {
   }, [accountId]);
 
   useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === accountId) {
+        setDominoOwned(getDominoInventory(dominoAccountId(accountId)));
+      }
+    };
+    window.addEventListener('dominoInventoryUpdate', handler);
+    return () => window.removeEventListener('dominoInventoryUpdate', handler);
+  }, [accountId]);
+
+  useEffect(() => {
     setSelectedItemKey('');
     setListingPrice('');
     setMarketInfo('');
@@ -157,6 +191,27 @@ export default function Store() {
     [poolOwned]
   );
 
+  const dominoGroupedItems = useMemo(() => {
+    const items = DOMINO_STORE_ITEMS.map((item) => ({
+      ...item,
+      owned: isDominoOptionUnlocked(item.type, item.optionId, dominoOwned)
+    }));
+    return items.reduce((acc, item) => {
+      acc[item.type] = acc[item.type] || [];
+      acc[item.type].push(item);
+      return acc;
+    }, {});
+  }, [dominoOwned]);
+
+  const dominoDefaultLoadout = useMemo(
+    () =>
+      DOMINO_DEFAULT_LOADOUT.map((entry) => ({
+        ...entry,
+        owned: isDominoOptionUnlocked(entry.type, entry.optionId, dominoOwned)
+      })),
+    [dominoOwned]
+  );
+
   const chessGroupedItems = useMemo(() => {
     const items = CHESS_BATTLE_STORE_ITEMS.map((item) => ({
       ...item,
@@ -181,7 +236,8 @@ export default function Store() {
   const storeItemsBySlug = useMemo(
     () => ({
       poolroyale: POOL_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
-      chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) }))
+      chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
+      'domino-royal': DOMINO_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) }))
     }),
     []
   );
@@ -200,15 +256,17 @@ export default function Store() {
   const ownedCheckers = useMemo(
     () => ({
       poolroyale: (type, optionId) => isPoolOptionUnlocked(type, optionId, poolOwned),
-      chessbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned)
+      chessbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
+      'domino-royal': (type, optionId) => isDominoOptionUnlocked(type, optionId, dominoOwned)
     }),
-    [poolOwned, chessOwned]
+    [poolOwned, chessOwned, dominoOwned]
   );
 
   const labelResolvers = useMemo(
     () => ({
       poolroyale: (item) => POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      chessbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name
+      chessbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      'domino-royal': (item) => DOMINO_OPTION_LABELS[item.type]?.[item.optionId] || item.name
     }),
     []
   );
@@ -331,6 +389,50 @@ export default function Store() {
     }
   };
 
+  const handleDominoPurchase = async (item) => {
+    if (item.owned || processing === item.id) return;
+    if (!accountId || accountId === 'guest') {
+      setInfo('Link your TPC account in the wallet first.');
+      return;
+    }
+    if (!DOMINO_STORE_ACCOUNT_ID) {
+      setInfo('Store account unavailable. Please try again later.');
+      return;
+    }
+
+    const labels = DOMINO_OPTION_LABELS[item.type] || {};
+    const ownedLabel = labels[item.optionId] || item.name;
+
+    if (tpcBalance !== null && item.price > tpcBalance) {
+      setInfo('Insufficient TPC balance for this purchase.');
+      return;
+    }
+
+    setProcessing(item.id);
+    setInfo('');
+    try {
+      const res = await sendAccountTpc(accountId, DOMINO_STORE_ACCOUNT_ID, item.price, `Domino Royal 3D: ${ownedLabel}`);
+      if (res?.error) {
+        setInfo(res.error || 'Purchase failed.');
+        return;
+      }
+
+      const updatedInventory = addDominoUnlock(item.type, item.optionId, accountId);
+      setDominoOwned(updatedInventory);
+      setInfo(`${ownedLabel} purchased and added to your Domino Royal account.`);
+
+      const bal = await getAccountBalance(accountId);
+      if (typeof bal?.balance === 'number') {
+        setTpcBalance(bal.balance);
+      }
+    } catch (err) {
+      console.error('Purchase failed', err);
+      setInfo('Failed to process purchase.');
+    } finally {
+      setProcessing('');
+    }
+  };
+
   const handleCreateListing = () => {
     const item = tradableOwnedItems.find((entry) => entry.key === selectedItemKey);
     if (!item) {
@@ -392,13 +494,15 @@ export default function Store() {
 
   const poolOwnedOptions = useMemo(() => listOwnedPoolRoyalOptions(accountId), [accountId]);
   const chessOwnedOptions = useMemo(() => listOwnedChessOptions(accountId), [accountId]);
+  const dominoOwnedOptions = useMemo(() => listOwnedDominoOptions(accountId), [accountId]);
 
   const ownedItemLookup = useMemo(
     () => ({
       poolroyale: poolOwnedOptions,
-      chessbattleroyal: chessOwnedOptions
+      chessbattleroyal: chessOwnedOptions,
+      'domino-royal': dominoOwnedOptions
     }),
-    [poolOwnedOptions, chessOwnedOptions]
+    [chessOwnedOptions, dominoOwnedOptions, poolOwnedOptions]
   );
 
   const hasStorefront = SUPPORTED_STORE_SLUGS.includes(activeSlug);
@@ -569,6 +673,76 @@ export default function Store() {
                         <button
                           type="button"
                           onClick={() => handleChessPurchase(item)}
+                          disabled={item.owned || processing === item.id}
+                          className={`buy-button mt-2 text-center ${
+                            item.owned || processing === item.id ? 'cursor-not-allowed opacity-60' : ''
+                          }`}
+                        >
+                          {item.owned
+                            ? `${ownedLabel} Owned`
+                            : processing === item.id
+                            ? 'Purchasing...'
+                            : `Purchase ${ownedLabel}`}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {activeSlug === 'domino-royal' && (
+        <>
+          <div className="store-card max-w-2xl">
+            <h3 className="text-lg font-semibold">Domino Royal Defaults (Free)</h3>
+            <p className="text-sm text-subtext">
+              First-look options stay unlocked; purchase the premium finishes below to surface them inside the table setup
+              menu.
+            </p>
+            <ul className="mt-2 space-y-1 w-full">
+              {dominoDefaultLoadout.map((item) => (
+                <li
+                  key={`domino-${item.type}-${item.optionId}`}
+                  className="flex items-center justify-between rounded-lg border border-border px-3 py-2 w-full"
+                >
+                  <span className="font-medium">{item.label}</span>
+                  <span className="text-xs uppercase text-subtext">{DOMINO_TYPE_LABELS[item.type] || item.type}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="w-full space-y-3">
+            <h3 className="text-lg font-semibold text-center">Domino Royal Collection</h3>
+            {Object.entries(dominoGroupedItems).map(([type, items]) => (
+              <div key={type} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <h4 className="text-base font-semibold">{DOMINO_TYPE_LABELS[type] || type}</h4>
+                  <span className="text-xs text-subtext">NFT unlocks</span>
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  {items.map((item) => {
+                    const labels = DOMINO_OPTION_LABELS[item.type] || {};
+                    const ownedLabel = labels[item.optionId] || item.name;
+                    return (
+                      <div key={item.id} className="store-card">
+                        <div className="flex w-full items-start justify-between gap-2">
+                          <div>
+                            <p className="font-semibold text-lg leading-tight">{item.name}</p>
+                            <p className="text-xs text-subtext">{item.description}</p>
+                            <p className="text-xs text-subtext mt-1">Applies to: {DOMINO_TYPE_LABELS[item.type] || item.type}</p>
+                          </div>
+                          <div className="flex items-center gap-1 text-sm font-semibold">
+                            {item.price}
+                            <img src={TPC_ICON} alt="TPC" className="h-4 w-4" />
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => handleDominoPurchase(item)}
                           disabled={item.owned || processing === item.id}
                           className={`buy-button mt-2 text-center ${
                             item.owned || processing === item.id ? 'cursor-not-allowed opacity-60' : ''

--- a/webapp/src/utils/dominoInventory.js
+++ b/webapp/src/utils/dominoInventory.js
@@ -1,0 +1,112 @@
+import {
+  DOMINO_DEFAULT_LOADOUT,
+  DOMINO_DEFAULT_UNLOCKS,
+  DOMINO_OPTION_LABELS
+} from '../config/dominoInventoryConfig.js';
+
+const STORAGE_KEY = 'dominoRoyalInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(DOMINO_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values].filter(Boolean) : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read domino inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getDominoInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isDominoOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getDominoInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addDominoUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('dominoInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedDominoOptions = (accountId) => {
+  const inventory = getDominoInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = DOMINO_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultDominoLoadout = () => [...DOMINO_DEFAULT_LOADOUT];
+
+export const dominoAccountId = resolveAccountId;


### PR DESCRIPTION
## Summary
- add Domino Royal inventory configuration and storage utilities with default unlocks
- integrate Domino Royal cosmetics into the store and marketplace with NFT purchasing
- gate Domino Royal table setup options so only unlocked items appear and update after purchases

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da75dee508329b37988400e253cd6)