### PR TITLE
Add Domino Royal NFT store integration

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -1632,10 +1632,104 @@ const TABLE_SETUP_SECTIONS = [
   { key: "chairTheme", label: "Stolat", options: CHAIR_THEME_OPTIONS }
 ];
 
-const DEFAULT_APPEARANCE = { tableWood: 0, tableCloth: 1, tableBase: 0, dominoStyle: 0, highlightStyle: 0, chairTheme: 0 };
+const DOMINO_OPTIONS_BY_KEY = Object.freeze({
+  tableWood: TABLE_WOOD_OPTIONS,
+  tableCloth: TABLE_CLOTH_OPTIONS,
+  tableBase: TABLE_BASE_OPTIONS,
+  dominoStyle: DOMINO_STYLE_OPTIONS,
+  highlightStyle: HIGHLIGHT_STYLE_OPTIONS,
+  chairTheme: CHAIR_THEME_OPTIONS
+});
+
+const DOMINO_DEFAULT_UNLOCKS = Object.freeze(
+  Object.entries(DOMINO_OPTIONS_BY_KEY).reduce((acc, [key, options]) => {
+    acc[key] = options.length && options[0]?.id ? [options[0].id] : [];
+    return acc;
+  }, {})
+);
+
+const DOMINO_INVENTORY_STORAGE_KEY = "dominoRoyalInventoryByAccount";
+
+const copyDominoDefaults = () =>
+  Object.entries(DOMINO_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values] : [];
+    return acc;
+  }, {});
+
+const resolveDominoAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== "undefined") {
+    const stored = window.localStorage.getItem("accountId");
+    if (stored) return stored;
+  }
+  return "guest";
+};
+
+const readDominoInventories = () => {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(DOMINO_INVENTORY_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (error) {
+    console.warn("Failed to read domino inventory, resetting", error);
+    return {};
+  }
+};
+
+const writeDominoInventories = (payload) => {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(DOMINO_INVENTORY_STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeDominoInventory = (rawInventory) => {
+  const base = copyDominoDefaults();
+  if (!rawInventory || typeof rawInventory !== "object") return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+function getDominoInventory(accountId) {
+  const resolvedAccountId = resolveDominoAccountId(accountId);
+  const inventories = readDominoInventories();
+  const normalized = normalizeDominoInventory(inventories[resolvedAccountId]);
+  if (typeof window !== "undefined") {
+    writeDominoInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+}
+
+function isDominoOptionUnlocked(type, optionId, inventoryOrAccountId) {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === "string" || !inventoryOrAccountId
+      ? getDominoInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+}
+
+const findDominoOptionIndex = (key, optionId) => {
+  const options = DOMINO_OPTIONS_BY_KEY[key] || [];
+  const idx = options.findIndex((opt) => opt.id === optionId);
+  return idx >= 0 ? idx : 0;
+};
+
+const DEFAULT_APPEARANCE = Object.freeze(
+  Object.entries(DOMINO_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = findDominoOptionIndex(key, values?.[0]);
+    return acc;
+  }, {})
+);
 const APPEARANCE_STORAGE_KEY = "dominoRoyalArenaAppearanceV2";
 const LEGACY_APPEARANCE_KEYS = ["dominoRoyalArenaAppearance"];
 let appearance = { ...DEFAULT_APPEARANCE };
+let dominoInventory = getDominoInventory();
 
 function normalizeAppearance(raw) {
   const normalized = { ...DEFAULT_APPEARANCE };
@@ -1657,6 +1751,24 @@ function normalizeAppearance(raw) {
   return normalized;
 }
 
+function sanitizeAppearance(rawAppearance, inventory = dominoInventory) {
+  const normalized = normalizeAppearance(rawAppearance);
+  const next = { ...normalized };
+  Object.entries(DOMINO_OPTIONS_BY_KEY).forEach(([key, options]) => {
+    const option = options[next[key]] ?? options[0];
+    if (!option || !isDominoOptionUnlocked(key, option.id, inventory)) {
+      const fallbackId = DOMINO_DEFAULT_UNLOCKS[key]?.[0] || options[0]?.id;
+      next[key] = findDominoOptionIndex(key, fallbackId);
+    }
+  });
+  return next;
+}
+
+function getUnlockedOptions(key, inventory = dominoInventory) {
+  const options = DOMINO_OPTIONS_BY_KEY[key] || [];
+  return options.filter((option) => isDominoOptionUnlocked(key, option.id, inventory));
+}
+
 try {
   const keysToCheck = [APPEARANCE_STORAGE_KEY, ...LEGACY_APPEARANCE_KEYS];
   for (const key of keysToCheck) {
@@ -1664,17 +1776,17 @@ try {
     if (!stored) continue;
     const parsed = JSON.parse(stored);
     if (parsed && typeof parsed === "object") {
-      appearance = normalizeAppearance({ ...appearance, ...parsed });
+      appearance = sanitizeAppearance({ ...appearance, ...parsed });
       if (key !== APPEARANCE_STORAGE_KEY) {
         window.localStorage?.setItem(APPEARANCE_STORAGE_KEY, JSON.stringify(appearance));
       }
       break;
     }
   }
-  appearance = normalizeAppearance(appearance);
+  appearance = sanitizeAppearance(appearance);
 } catch (error) {
   console.warn("Failed to load Domino Royal appearance", error);
-  appearance = normalizeAppearance(appearance);
+  appearance = sanitizeAppearance(appearance);
 }
 
 function adjustHexColor(hex, amount) {
@@ -3363,7 +3475,7 @@ if (configPanelEl) {
 
 function saveAppearance() {
   try {
-    const normalized = normalizeAppearance(appearance);
+    const normalized = sanitizeAppearance(appearance);
     appearance = normalized;
     localStorage.setItem(APPEARANCE_STORAGE_KEY, JSON.stringify(normalized));
   } catch (error) {
@@ -3372,7 +3484,7 @@ function saveAppearance() {
 }
 
 function applyAppearanceChange({ refresh = true } = {}) {
-  appearance = normalizeAppearance(appearance);
+  appearance = sanitizeAppearance(appearance);
   clearExistingDominoMeshes();
   updateTableMaterials();
   applyDominoStyle(DOMINO_STYLE_OPTIONS[appearance.dominoStyle] ?? DOMINO_STYLE_OPTIONS[0]);
@@ -3398,6 +3510,16 @@ function applyAppearanceChange({ refresh = true } = {}) {
     refreshConfigUI();
   }
 }
+
+window.addEventListener('dominoRoyalInventoryUpdate', (event) => {
+  const targetAccount = resolveDominoAccountId(event?.detail?.accountId);
+  const currentAccount = resolveDominoAccountId();
+  if (!event?.detail?.accountId || targetAccount === currentAccount) {
+    dominoInventory = getDominoInventory(currentAccount);
+    appearance = sanitizeAppearance(appearance, dominoInventory);
+    applyAppearanceChange({ refresh: true });
+  }
+});
 
 function createOptionPreview(key, option) {
   const swatch = document.createElement('div');
@@ -3522,7 +3644,9 @@ function refreshConfigUI() {
     wrapper.appendChild(label);
     const optionsGrid = document.createElement('div');
     optionsGrid.className = 'config-options';
-    section.options.forEach((option, idx) => {
+    const availableOptions = getUnlockedOptions(section.key, dominoInventory);
+    availableOptions.forEach((option) => {
+      const idx = findDominoOptionIndex(section.key, option.id);
       const button = document.createElement('button');
       button.type = 'button';
       button.className = 'config-option';

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,0 +1,121 @@
+export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
+  tableWood: [
+    { id: 'oakEstate', label: 'Lis Estate' },
+    { id: 'teakStudio', label: 'Tik Studio' }
+  ],
+  tableCloth: [
+    { id: 'crimson', label: 'Crimson Cloth' },
+    { id: 'emerald', label: 'Emerald Cloth' },
+    { id: 'arctic', label: 'Arctic Cloth' },
+    { id: 'sunset', label: 'Sunset Cloth' },
+    { id: 'violet', label: 'Violet Cloth' },
+    { id: 'amber', label: 'Amber Cloth' }
+  ],
+  tableBase: [
+    { id: 'obsidian', label: 'Obsidian Base' },
+    { id: 'forestBronze', label: 'Forest Base' },
+    { id: 'midnightChrome', label: 'Midnight Base' },
+    { id: 'emberCopper', label: 'Copper Base' },
+    { id: 'violetShadow', label: 'Violet Shadow Base' },
+    { id: 'desertGold', label: 'Desert Base' }
+  ],
+  dominoStyle: [
+    { id: 'imperialIvory', label: 'Imperial Ivory' },
+    { id: 'obsidianPlatinum', label: 'Obsidian Platinum' },
+    { id: 'midnightRose', label: 'Midnight Rose' },
+    { id: 'auroraJade', label: 'Aurora Jade' },
+    { id: 'frostedOpal', label: 'Frosted Opal' },
+    { id: 'carbonVolt', label: 'Carbon Volt' },
+    { id: 'sandstoneAurora', label: 'Sandstone Aurora' }
+  ],
+  highlightStyle: [
+    { id: 'marksmanAmber', label: 'Marksman Amber' },
+    { id: 'iceTracer', label: 'Ice Tracer' },
+    { id: 'violetPulse', label: 'Violet Pulse' }
+  ],
+  chairTheme: [
+    { id: 'crimsonVelvet', label: 'Crimson Velvet Chairs' },
+    { id: 'midnightNavy', label: 'Midnight Blue Chairs' },
+    { id: 'emeraldWave', label: 'Emerald Wave Chairs' },
+    { id: 'onyxShadow', label: 'Onyx Shadow Chairs' },
+    { id: 'royalPlum', label: 'Royal Chestnut Chairs' }
+  ]
+});
+
+export const DOMINO_ROYAL_DEFAULT_UNLOCKS = Object.freeze(
+  Object.entries(DOMINO_ROYAL_OPTION_SETS).reduce((acc, [type, options]) => {
+    acc[type] = options.length ? [options[0].id] : [];
+    return acc;
+  }, {})
+);
+
+export const DOMINO_ROYAL_OPTION_LABELS = Object.freeze(
+  Object.entries(DOMINO_ROYAL_OPTION_SETS).reduce((acc, [type, options]) => {
+    acc[type] = Object.freeze(
+      options.reduce((map, option) => {
+        map[option.id] = option.label;
+        return map;
+      }, {})
+    );
+    return acc;
+  }, {})
+);
+
+export const DOMINO_ROYAL_STORE_ITEMS = [
+  ...DOMINO_ROYAL_OPTION_SETS.tableWood.slice(1).map((option) => ({
+    id: `domino-wood-${option.id}`,
+    type: 'tableWood',
+    optionId: option.id,
+    name: option.label,
+    price: 780,
+    description: 'Alternate premium wood finish for your Domino Royal arena.'
+  })),
+  ...DOMINO_ROYAL_OPTION_SETS.tableCloth.slice(1).map((option, idx) => ({
+    id: `domino-cloth-${option.id}`,
+    type: 'tableCloth',
+    optionId: option.id,
+    name: option.label,
+    price: 340 + idx * 30,
+    description: 'Unlock a new felt tone for the Domino Royal table surface.'
+  })),
+  ...DOMINO_ROYAL_OPTION_SETS.tableBase.slice(1).map((option, idx) => ({
+    id: `domino-base-${option.id}`,
+    type: 'tableBase',
+    optionId: option.id,
+    name: option.label,
+    price: 520 + idx * 40,
+    description: 'Swap in a different pedestal finish beneath the table.'
+  })),
+  ...DOMINO_ROYAL_OPTION_SETS.dominoStyle.slice(1).map((option, idx) => ({
+    id: `domino-style-${option.id}`,
+    type: 'dominoStyle',
+    optionId: option.id,
+    name: option.label,
+    price: 820 + idx * 40,
+    description: 'Premium domino material set for tiles and pips.'
+  })),
+  ...DOMINO_ROYAL_OPTION_SETS.highlightStyle.slice(1).map((option, idx) => ({
+    id: `domino-highlight-${option.id}`,
+    type: 'highlightStyle',
+    optionId: option.id,
+    name: option.label,
+    price: 260 + idx * 40,
+    description: 'Unlocks a new tracer highlight for the table setup.'
+  })),
+  ...DOMINO_ROYAL_OPTION_SETS.chairTheme.slice(1).map((option, idx) => ({
+    id: `domino-chair-${option.id}`,
+    type: 'chairTheme',
+    optionId: option.id,
+    name: option.label,
+    price: 300 + idx * 20,
+    description: 'Alternate spectator chair upholstery for the arena.'
+  }))
+];
+
+export const DOMINO_ROYAL_DEFAULT_LOADOUT = Object.entries(DOMINO_ROYAL_OPTION_SETS).map(
+  ([type, options]) => ({
+    type,
+    optionId: options[0]?.id,
+    label: options[0]?.label
+  })
+);

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -32,6 +32,11 @@ import {
   listOwnedPoolRoyalOptions,
   poolRoyalAccountId
 } from '../utils/poolRoyalInventory.js';
+import {
+  dominoRoyalAccountId,
+  getDefaultDominoRoyalLoadout,
+  listOwnedDominoOptions
+} from '../utils/dominoRoyalInventory.js';
 
 import { FiCopy } from 'react-icons/fi';
 
@@ -41,6 +46,15 @@ const POOL_ROYALE_TYPE_LABELS = {
   railMarkerColor: 'Rail Markers',
   clothColor: 'Cloth Color',
   cueStyle: 'Cue Style'
+};
+
+const DOMINO_ROYALE_TYPE_LABELS = {
+  tableWood: 'Table Wood',
+  tableCloth: 'Table Cloth',
+  tableBase: 'Table Base',
+  dominoStyle: 'Domino Style',
+  highlightStyle: 'Highlight Style',
+  chairTheme: 'Chair Theme'
 };
 
 function formatValue(value, decimals = 2) {
@@ -95,6 +109,10 @@ export default function MyAccount() {
   const [poolRoyaleInventory, setPoolRoyaleInventory] = useState(() =>
     listOwnedPoolRoyalOptions(poolRoyalAccountId())
   );
+  const [dominoAccountId, setDominoAccountId] = useState(dominoRoyalAccountId());
+  const [dominoInventory, setDominoInventory] = useState(() =>
+    listOwnedDominoOptions(dominoRoyalAccountId())
+  );
   const refreshPoolRoyale = useCallback(() => {
     const resolved = poolRoyalAccountId();
     setPoolAccountId(resolved);
@@ -103,6 +121,16 @@ export default function MyAccount() {
       setPoolRoyaleInventory(owned);
     } else {
       setPoolRoyaleInventory(getDefaultPoolRoyalLoadout());
+    }
+  }, []);
+  const refreshDominoRoyal = useCallback(() => {
+    const resolved = dominoRoyalAccountId();
+    setDominoAccountId(resolved);
+    const owned = listOwnedDominoOptions(resolved);
+    if (Array.isArray(owned) && owned.length > 0) {
+      setDominoInventory(owned);
+    } else {
+      setDominoInventory(getDefaultDominoRoyalLoadout());
     }
   }, []);
 
@@ -201,7 +229,8 @@ export default function MyAccount() {
   }, [telegramId]);
   useEffect(() => {
     refreshPoolRoyale();
-  }, [profile, refreshPoolRoyale]);
+    refreshDominoRoyal();
+  }, [profile, refreshPoolRoyale, refreshDominoRoyal]);
   useEffect(() => {
     const handler = (event) => {
       if (!event?.detail?.accountId || event.detail.accountId === poolAccountId) {
@@ -211,6 +240,15 @@ export default function MyAccount() {
     window.addEventListener('poolRoyalInventoryUpdate', handler);
     return () => window.removeEventListener('poolRoyalInventoryUpdate', handler);
   }, [poolAccountId, refreshPoolRoyale]);
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === dominoAccountId) {
+        refreshDominoRoyal();
+      }
+    };
+    window.addEventListener('dominoRoyalInventoryUpdate', handler);
+    return () => window.removeEventListener('dominoRoyalInventoryUpdate', handler);
+  }, [dominoAccountId, refreshDominoRoyal]);
 
   if (!profile) return <div className="p-4 text-subtext">Loading...</div>;
 
@@ -467,6 +505,29 @@ export default function MyAccount() {
               <span className="font-medium">{item.label}</span>
               <span className="text-[11px] uppercase text-subtext">
                 {POOL_ROYALE_TYPE_LABELS[item.type] || item.type}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold">Domino Royal Inventory</h3>
+          <span className="text-xs text-subtext">Account: {dominoAccountId}</span>
+        </div>
+        <p className="text-sm text-subtext">
+          First-look options are free. Purchased NFTs appear here and inside the Domino Royal table setup menu once
+          unlocked.
+        </p>
+        <div className="space-y-1">
+          {dominoInventory.map((item) => (
+            <div
+              key={`${item.type}-${item.optionId}`}
+              className="flex items-center justify-between rounded-lg border border-border px-3 py-2 bg-surface/60"
+            >
+              <span className="font-medium">{item.label}</span>
+              <span className="text-[11px] uppercase text-subtext">
+                {DOMINO_ROYALE_TYPE_LABELS[item.type] || item.type}
               </span>
             </div>
           ))}

--- a/webapp/src/utils/dominoRoyalInventory.js
+++ b/webapp/src/utils/dominoRoyalInventory.js
@@ -1,0 +1,112 @@
+import {
+  DOMINO_ROYAL_DEFAULT_LOADOUT,
+  DOMINO_ROYAL_DEFAULT_UNLOCKS,
+  DOMINO_ROYAL_OPTION_LABELS
+} from '../config/dominoRoyalInventoryConfig.js';
+
+const STORAGE_KEY = 'dominoRoyalInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(DOMINO_ROYAL_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values] : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read domino inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getDominoRoyalInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isDominoOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getDominoRoyalInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addDominoRoyalUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('dominoRoyalInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedDominoOptions = (accountId) => {
+  const inventory = getDominoRoyalInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = DOMINO_ROYAL_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultDominoRoyalLoadout = () => [...DOMINO_ROYAL_DEFAULT_LOADOUT];
+
+export const dominoRoyalAccountId = resolveAccountId;


### PR DESCRIPTION
## Summary
- add Domino Royal inventory config and utilities with default unlocks and store items
- gate Domino Royal table setup options behind NFT purchases and refresh from inventory updates
- surface Domino Royal ownership in the store UI and account inventory list

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da75dee508329b37988400e253cd6)