### PR TITLE
Add NFT store unlocks for Ludo Battle Royal

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -1,0 +1,128 @@
+import {
+  CHAIR_COLOR_OPTIONS,
+  HEAD_PRESET_OPTIONS,
+  TOKEN_PALETTE_OPTIONS,
+  TOKEN_PIECE_OPTIONS,
+  TOKEN_STYLE_OPTIONS
+} from './ludoBattleOptions.js';
+import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../utils/tableCustomizationOptions.js';
+import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
+
+const DEFAULT_TABLE_SHAPE_ID = TABLE_SHAPE_OPTIONS[0]?.id;
+
+export const LUDO_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
+  tableWood: [TABLE_WOOD_OPTIONS[0]?.id],
+  tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
+  tableBase: [TABLE_BASE_OPTIONS[0]?.id],
+  chairColor: [CHAIR_COLOR_OPTIONS[0]?.id],
+  tableShape: [DEFAULT_TABLE_SHAPE_ID],
+  tokenPalette: [TOKEN_PALETTE_OPTIONS[0]?.id],
+  tokenStyle: [TOKEN_STYLE_OPTIONS[0]?.id],
+  tokenPiece: [TOKEN_PIECE_OPTIONS[0]?.id],
+  headStyle: [HEAD_PRESET_OPTIONS[0]?.id]
+});
+
+const reduceLabels = (options) =>
+  options.reduce((acc, option) => {
+    acc[option.id] = option.label;
+    return acc;
+  }, {});
+
+export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
+  tableWood: Object.freeze(reduceLabels(TABLE_WOOD_OPTIONS)),
+  tableCloth: Object.freeze(reduceLabels(TABLE_CLOTH_OPTIONS)),
+  tableBase: Object.freeze(reduceLabels(TABLE_BASE_OPTIONS)),
+  chairColor: Object.freeze(reduceLabels(CHAIR_COLOR_OPTIONS)),
+  tableShape: Object.freeze(reduceLabels(TABLE_SHAPE_OPTIONS)),
+  tokenPalette: Object.freeze(reduceLabels(TOKEN_PALETTE_OPTIONS)),
+  tokenStyle: Object.freeze(reduceLabels(TOKEN_STYLE_OPTIONS)),
+  tokenPiece: Object.freeze(reduceLabels(TOKEN_PIECE_OPTIONS)),
+  headStyle: Object.freeze(reduceLabels(HEAD_PRESET_OPTIONS))
+});
+
+export const LUDO_BATTLE_STORE_ITEMS = [
+  ...TABLE_WOOD_OPTIONS.slice(1).map((option, idx) => ({
+    id: `ludo-wood-${option.id}`,
+    type: 'tableWood',
+    optionId: option.id,
+    name: option.label,
+    price: 620 + idx * 40,
+    description: 'Alternate wood finish for the Ludo royale table.'
+  })),
+  ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
+    id: `ludo-cloth-${option.id}`,
+    type: 'tableCloth',
+    optionId: option.id,
+    name: option.label,
+    price: 360 + idx * 35,
+    description: 'Premium felt hue to swap into the arena surface.'
+  })),
+  ...TABLE_BASE_OPTIONS.slice(1).map((option, idx) => ({
+    id: `ludo-base-${option.id}`,
+    type: 'tableBase',
+    optionId: option.id,
+    name: option.label,
+    price: 460 + idx * 40,
+    description: 'Pedestal and trim upgrade for the Ludo table.'
+  })),
+  ...CHAIR_COLOR_OPTIONS.slice(1).map((option, idx) => ({
+    id: `ludo-chair-${option.id}`,
+    type: 'chairColor',
+    optionId: option.id,
+    name: `${option.label} Chairs`,
+    price: 320 + idx * 20,
+    description: 'Unlock an alternate lounge chair upholstery color.'
+  })),
+  ...TABLE_SHAPE_OPTIONS.slice(1).map((option, idx) => ({
+    id: `ludo-shape-${option.id}`,
+    type: 'tableShape',
+    optionId: option.id,
+    name: option.label,
+    price: 640 + idx * 80,
+    description: 'Swap the arena outline for a new premium silhouette.'
+  })),
+  ...TOKEN_PALETTE_OPTIONS.slice(1).map((option, idx) => ({
+    id: `ludo-palette-${option.id}`,
+    type: 'tokenPalette',
+    optionId: option.id,
+    name: `${option.label} Palette`,
+    price: 260 + idx * 20,
+    description: 'Alternate pawn color palette for every side.'
+  })),
+  ...TOKEN_STYLE_OPTIONS.slice(1).map((option) => ({
+    id: `ludo-style-${option.id}`,
+    type: 'tokenStyle',
+    optionId: option.id,
+    name: option.label,
+    price: 450,
+    description: 'Swap the token mesh set for a new silhouette.'
+  })),
+  ...TOKEN_PIECE_OPTIONS.slice(1).map((option, idx) => ({
+    id: `ludo-piece-${option.id}`,
+    type: 'tokenPiece',
+    optionId: option.id,
+    name: option.label,
+    price: 300 + idx * 20,
+    description: 'Unlock an alternate piece identity for your pawns.'
+  })),
+  ...HEAD_PRESET_OPTIONS.slice(1).map((option, idx) => ({
+    id: `ludo-head-${option.id}`,
+    type: 'headStyle',
+    optionId: option.id,
+    name: `${option.label} Heads`,
+    price: 310 + idx * 20,
+    description: 'Unlock a new glass preset for the pawn and bishop heads.'
+  }))
+];
+
+export const LUDO_BATTLE_DEFAULT_LOADOUT = [
+  { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0]?.id, label: TABLE_WOOD_OPTIONS[0]?.label },
+  { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
+  { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0]?.id, label: TABLE_BASE_OPTIONS[0]?.label },
+  { type: 'chairColor', optionId: CHAIR_COLOR_OPTIONS[0]?.id, label: `${CHAIR_COLOR_OPTIONS[0]?.label} Chairs` },
+  { type: 'tableShape', optionId: DEFAULT_TABLE_SHAPE_ID, label: LUDO_BATTLE_OPTION_LABELS.tableShape[DEFAULT_TABLE_SHAPE_ID] },
+  { type: 'tokenPalette', optionId: TOKEN_PALETTE_OPTIONS[0]?.id, label: `${TOKEN_PALETTE_OPTIONS[0]?.label} Palette` },
+  { type: 'tokenStyle', optionId: TOKEN_STYLE_OPTIONS[0]?.id, label: TOKEN_STYLE_OPTIONS[0]?.label },
+  { type: 'tokenPiece', optionId: TOKEN_PIECE_OPTIONS[0]?.id, label: TOKEN_PIECE_OPTIONS[0]?.label },
+  { type: 'headStyle', optionId: HEAD_PRESET_OPTIONS[0]?.id, label: `${HEAD_PRESET_OPTIONS[0]?.label} Heads` }
+];

--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -1,0 +1,177 @@
+import { TOKEN_TYPE_SEQUENCE } from '../utils/ludoTokenConstants.js';
+
+export const HEAD_PRESET_OPTIONS = Object.freeze([
+  {
+    id: 'headGlass',
+    label: 'Glass',
+    preset: {
+      color: '#ffffff',
+      metalness: 0,
+      roughness: 0.05,
+      transmission: 0.95,
+      ior: 1.5,
+      thickness: 0.5
+    }
+  },
+  {
+    id: 'headRuby',
+    label: 'Ruby',
+    preset: {
+      color: '#9b111e',
+      metalness: 0.05,
+      roughness: 0.08,
+      transmission: 0.92,
+      ior: 2.4,
+      thickness: 0.6
+    }
+  },
+  {
+    id: 'headPearl',
+    label: 'Pearl',
+    preset: {
+      color: '#f5f5f5',
+      metalness: 0.05,
+      roughness: 0.25,
+      transmission: 0,
+      ior: 1.3,
+      thickness: 0.2
+    }
+  },
+  {
+    id: 'headSapphire',
+    label: 'Sapphire',
+    preset: {
+      color: '#0f52ba',
+      metalness: 0.05,
+      roughness: 0.08,
+      transmission: 0.9,
+      ior: 1.8,
+      thickness: 0.7
+    }
+  },
+  {
+    id: 'headEmerald',
+    label: 'Emerald',
+    preset: {
+      color: '#046a38',
+      metalness: 0.05,
+      roughness: 0.08,
+      transmission: 0.9,
+      ior: 1.8,
+      thickness: 0.7
+    }
+  },
+  {
+    id: 'headDiamond',
+    label: 'Diamond',
+    preset: {
+      color: '#ffffff',
+      metalness: 0,
+      roughness: 0.03,
+      transmission: 0.98,
+      ior: 2.4,
+      thickness: 0.8
+    }
+  }
+]);
+
+export const TOKEN_STYLE_OPTIONS = Object.freeze([
+  {
+    id: 'battleChess',
+    label: 'Battle Chess Tokens',
+    description: 'Use the Chess Battle Royale GLTF set for every pawn.',
+    typeSequence: TOKEN_TYPE_SEQUENCE,
+    prefersAbg: true
+  },
+  {
+    id: 'towerRooks',
+    label: 'Minimal Rook Set',
+    description: 'Swap every pawn with sleek rooks for a clean read.',
+    typeSequence: ['r']
+  }
+]);
+
+export const TOKEN_PIECE_OPTIONS = Object.freeze([
+  { id: 'piecePawn', label: 'Play as Pawn', type: 'p', symbol: '♙' },
+  { id: 'pieceRook', label: 'Play as Rook', type: 'r', symbol: '♖' },
+  { id: 'pieceKnight', label: 'Play as Knight', type: 'n', symbol: '♘' },
+  { id: 'pieceBishop', label: 'Play as Bishop', type: 'b', symbol: '♗' },
+  { id: 'pieceQueen', label: 'Play as Queen', type: 'q', symbol: '♕' },
+  { id: 'pieceKing', label: 'Play as King', type: 'k', symbol: '♔' }
+]);
+
+export const TOKEN_PALETTE_OPTIONS = Object.freeze([
+  {
+    id: 'vividCore',
+    label: 'Vivid Core',
+    swatches: [0xef4444, 0x3b82f6, 0xfacc15, 0x22c55e]
+  },
+  {
+    id: 'frostbite',
+    label: 'Frostbite Pastel',
+    swatches: [0xfb7185, 0x60a5fa, 0xfde047, 0x86efac]
+  },
+  {
+    id: 'midnightPulse',
+    label: 'Midnight Pulse',
+    swatches: [0xbe123c, 0x1d4ed8, 0xca8a04, 0x15803d]
+  },
+  {
+    id: 'radiantCandy',
+    label: 'Radiant Candy',
+    swatches: [0xff7aa2, 0x7dd3fc, 0xffe999, 0x6ee7b7]
+  },
+  {
+    id: 'steelPulse',
+    label: 'Steel Pulse',
+    swatches: [0xe2e8f0, 0x94a3b8, 0x475569, 0x0ea5e9]
+  },
+  {
+    id: 'sunsetArena',
+    label: 'Sunset Arena',
+    swatches: [0xfb7185, 0xf97316, 0xfacc15, 0x4ade80]
+  }
+]);
+
+export const CHAIR_COLOR_OPTIONS = Object.freeze([
+  {
+    id: 'crimsonVelvet',
+    label: 'Crimson Velvet',
+    primary: '#8b1538',
+    accent: '#5c0f26',
+    highlight: '#d35a7a',
+    legColor: '#1f1f1f'
+  },
+  {
+    id: 'midnightNavy',
+    label: 'Midnight Blue',
+    primary: '#153a8b',
+    accent: '#0c214f',
+    highlight: '#4d74d8',
+    legColor: '#10131c'
+  },
+  {
+    id: 'emeraldWave',
+    label: 'Emerald Wave',
+    primary: '#0f6a2f',
+    accent: '#063d1b',
+    highlight: '#48b26a',
+    legColor: '#142318'
+  },
+  {
+    id: 'onyxShadow',
+    label: 'Onyx Shadow',
+    primary: '#202020',
+    accent: '#101010',
+    highlight: '#6f6f6f',
+    legColor: '#080808'
+  },
+  {
+    id: 'royalPlum',
+    label: 'Royal Chestnut',
+    primary: '#3f1f5b',
+    accent: '#2c1340',
+    highlight: '#7c4ae0',
+    legColor: '#140a24'
+  }
+]);

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -40,6 +40,19 @@ import {
   WOOD_GRAIN_OPTIONS_BY_ID
 } from '../../utils/tableCustomizationOptions.js';
 import { hslToHexNumber, WOOD_FINISH_PRESETS } from '../../utils/woodMaterials.js';
+import {
+  CHAIR_COLOR_OPTIONS,
+  HEAD_PRESET_OPTIONS,
+  TOKEN_PALETTE_OPTIONS,
+  TOKEN_PIECE_OPTIONS,
+  TOKEN_STYLE_OPTIONS
+} from '../../config/ludoBattleOptions.js';
+import { TOKEN_TYPE_SEQUENCE } from '../../utils/ludoTokenConstants.js';
+import {
+  getLudoBattleInventory,
+  isLudoOptionUnlocked,
+  ludoBattleAccountId
+} from '../../utils/ludoBattleInventory.js';
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 
@@ -58,82 +71,6 @@ const ABG_TYPE_ALIASES = Object.freeze([
 ]);
 const ABG_COLOR_W = /\b(white|ivory|light|w)\b/i;
 const ABG_COLOR_B = /\b(black|ebony|dark|b)\b/i;
-
-const TOKEN_TYPE_SEQUENCE = ['k', 'q', 'b', 'n', 'r', 'p'];
-const HEAD_PRESET_OPTIONS = Object.freeze([
-  {
-    id: 'headGlass',
-    label: 'Glass',
-    preset: {
-      color: '#ffffff',
-      metalness: 0,
-      roughness: 0.05,
-      transmission: 0.95,
-      ior: 1.5,
-      thickness: 0.5
-    }
-  },
-  {
-    id: 'headRuby',
-    label: 'Ruby',
-    preset: {
-      color: '#9b111e',
-      metalness: 0.05,
-      roughness: 0.08,
-      transmission: 0.92,
-      ior: 2.4,
-      thickness: 0.6
-    }
-  },
-  {
-    id: 'headPearl',
-    label: 'Pearl',
-    preset: {
-      color: '#f5f5f5',
-      metalness: 0.05,
-      roughness: 0.25,
-      transmission: 0,
-      ior: 1.3,
-      thickness: 0.2
-    }
-  },
-  {
-    id: 'headSapphire',
-    label: 'Sapphire',
-    preset: {
-      color: '#0f52ba',
-      metalness: 0.05,
-      roughness: 0.08,
-      transmission: 0.9,
-      ior: 1.8,
-      thickness: 0.7
-    }
-  },
-  {
-    id: 'headEmerald',
-    label: 'Emerald',
-    preset: {
-      color: '#046a38',
-      metalness: 0.05,
-      roughness: 0.08,
-      transmission: 0.9,
-      ior: 1.8,
-      thickness: 0.7
-    }
-  },
-  {
-    id: 'headDiamond',
-    label: 'Diamond',
-    preset: {
-      color: '#ffffff',
-      metalness: 0,
-      roughness: 0.03,
-      transmission: 0.98,
-      ior: 2.4,
-      thickness: 0.8
-    }
-  }
-]);
 
 const ARENA_SCALE = 0.85;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
@@ -223,110 +160,10 @@ const CAMERA_TARGET_LIFT = 0.04 * MODEL_SCALE;
 
 const DEFAULT_STOOL_THEME = Object.freeze({ legColor: '#1f1f1f' });
 
-const TOKEN_STYLE_OPTIONS = Object.freeze([
-  {
-    id: 'battleChess',
-    label: 'Battle Chess Tokens',
-    description: 'Use the Chess Battle Royale GLTF set for every pawn.',
-    typeSequence: TOKEN_TYPE_SEQUENCE,
-    prefersAbg: true
-  },
-  {
-    id: 'towerRooks',
-    label: 'Minimal Rook Set',
-    description: 'Swap every pawn with sleek rooks for a clean read.',
-    typeSequence: ['r']
-  }
-]);
-
-const TOKEN_PIECE_OPTIONS = Object.freeze([
-  { id: 'piecePawn', label: 'Play as Pawn', type: 'p', symbol: '♙' },
-  { id: 'pieceRook', label: 'Play as Rook', type: 'r', symbol: '♖' },
-  { id: 'pieceKnight', label: 'Play as Knight', type: 'n', symbol: '♘' },
-  { id: 'pieceBishop', label: 'Play as Bishop', type: 'b', symbol: '♗' },
-  { id: 'pieceQueen', label: 'Play as Queen', type: 'q', symbol: '♕' },
-  { id: 'pieceKing', label: 'Play as King', type: 'k', symbol: '♔' }
-]);
-
-const TOKEN_PALETTE_OPTIONS = Object.freeze([
-  {
-    id: 'vividCore',
-    label: 'Vivid Core',
-    swatches: [0xef4444, 0x3b82f6, 0xfacc15, 0x22c55e]
-  },
-  {
-    id: 'frostbite',
-    label: 'Frostbite Pastel',
-    swatches: [0xfb7185, 0x60a5fa, 0xfde047, 0x86efac]
-  },
-  {
-    id: 'midnightPulse',
-    label: 'Midnight Pulse',
-    swatches: [0xbe123c, 0x1d4ed8, 0xca8a04, 0x15803d]
-  },
-  {
-    id: 'radiantCandy',
-    label: 'Radiant Candy',
-    swatches: [0xff7aa2, 0x7dd3fc, 0xffe999, 0x6ee7b7]
-  },
-  {
-    id: 'steelPulse',
-    label: 'Steel Pulse',
-    swatches: [0xe2e8f0, 0x94a3b8, 0x475569, 0x0ea5e9]
-  },
-  {
-    id: 'sunsetArena',
-    label: 'Sunset Arena',
-    swatches: [0xfb7185, 0xf97316, 0xfacc15, 0x4ade80]
-  }
-]);
-
-const CHAIR_COLOR_OPTIONS = Object.freeze([
-  {
-    id: 'crimsonVelvet',
-    label: 'Crimson Velvet',
-    primary: '#8b1538',
-    accent: '#5c0f26',
-    highlight: '#d35a7a',
-    legColor: '#1f1f1f'
-  },
-  {
-    id: 'midnightNavy',
-    label: 'Midnight Blue',
-    primary: '#153a8b',
-    accent: '#0c214f',
-    highlight: '#4d74d8',
-    legColor: '#10131c'
-  },
-  {
-    id: 'emeraldWave',
-    label: 'Emerald Wave',
-    primary: '#0f6a2f',
-    accent: '#063d1b',
-    highlight: '#48b26a',
-    legColor: '#142318'
-  },
-  {
-    id: 'onyxShadow',
-    label: 'Onyx Shadow',
-    primary: '#202020',
-    accent: '#101010',
-    highlight: '#6f6f6f',
-    legColor: '#080808'
-  },
-  {
-    id: 'royalPlum',
-    label: 'Royal Chestnut',
-    primary: '#3f1f5b',
-    accent: '#2c1340',
-    highlight: '#7c4ae0',
-    legColor: '#140a24'
-  }
-]);
-
 const APPEARANCE_STORAGE_KEY = 'ludoBattleRoyalArenaAppearance';
 const DEFAULT_APPEARANCE = {
   ...DEFAULT_TABLE_CUSTOMIZATION,
+  tableCloth: 0,
   chairColor: 0,
   tableShape: 0,
   tokenPalette: 0,
@@ -2009,6 +1846,21 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     () => clamp(Math.floor(aiCount ?? aiSlots), 0, aiSlots),
     [aiCount, aiSlots]
   );
+  const resolvedAccountId = useMemo(() => ludoBattleAccountId(), []);
+  const [inventoryVersion, setInventoryVersion] = useState(0);
+  const ludoInventory = useMemo(
+    () => getLudoBattleInventory(resolvedAccountId),
+    [resolvedAccountId, inventoryVersion]
+  );
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === resolvedAccountId) {
+        setInventoryVersion((value) => value + 1);
+      }
+    };
+    window.addEventListener('ludoBattleInventoryUpdate', handler);
+    return () => window.removeEventListener('ludoBattleInventoryUpdate', handler);
+  }, [resolvedAccountId]);
   const [configOpen, setConfigOpen] = useState(false);
   const [soundEnabled, setSoundEnabled] = useState(true);
   const settingsRef = useRef({ soundEnabled: true });
@@ -2026,6 +1878,51 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   });
   const appearanceRef = useRef(appearance);
   const playerColorsRef = useRef(resolvePlayerColors(appearance));
+  const ensureAppearanceUnlocked = useCallback(
+    (value = DEFAULT_APPEARANCE) => {
+      const normalized = normalizeAppearance(value);
+      const map = {
+        tableWood: TABLE_WOOD_OPTIONS,
+        tableCloth: TABLE_CLOTH_OPTIONS,
+        tableBase: TABLE_BASE_OPTIONS,
+        chairColor: CHAIR_COLOR_OPTIONS,
+        tableShape: TABLE_SHAPE_OPTIONS,
+        tokenPalette: TOKEN_PALETTE_OPTIONS,
+        tokenStyle: TOKEN_STYLE_OPTIONS,
+        tokenPiece: TOKEN_PIECE_OPTIONS,
+        headStyle: HEAD_PRESET_OPTIONS
+      };
+      let changed = false;
+      const next = { ...normalized };
+      Object.entries(map).forEach(([key, options]) => {
+        const idx = Number.isFinite(next[key]) ? next[key] : 0;
+        const option = options[idx];
+        if (!option || !isLudoOptionUnlocked(key, option.id, ludoInventory)) {
+          const fallbackIdx = options.findIndex((opt) => isLudoOptionUnlocked(key, opt.id, ludoInventory));
+          const safeIdx = fallbackIdx >= 0 ? fallbackIdx : 0;
+          if (safeIdx !== idx) {
+            next[key] = safeIdx;
+            changed = true;
+          }
+        }
+      });
+      return changed ? next : normalized;
+    },
+    [ludoInventory]
+  );
+  useEffect(() => {
+    setAppearance((prev) => ensureAppearanceUnlocked(prev));
+  }, [ensureAppearanceUnlocked]);
+  const customizationSections = useMemo(
+    () =>
+      CUSTOMIZATION_SECTIONS.map((section) => ({
+        ...section,
+        options: section.options
+          .map((option, idx) => ({ ...option, idx }))
+          .filter(({ id }) => isLudoOptionUnlocked(section.key, id, ludoInventory))
+      })).filter((section) => section.options.length > 0),
+    [ludoInventory]
+  );
   const arenaRef = useRef(null);
   const [seatAnchors, setSeatAnchors] = useState([]);
   const seatPositionsRef = useRef([]);
@@ -4032,21 +3929,21 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                 </button>
               </div>
               <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
-                {CUSTOMIZATION_SECTIONS.map(({ key, label, options }) => (
+                {customizationSections.map(({ key, label, options }) => (
                   <div key={key} className="space-y-2">
                     <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
                     <div className="grid grid-cols-2 gap-2">
-                      {options.map((option, idx) => {
-                        const selected = appearance[key] === idx;
+                      {options.map((option) => {
+                        const selected = appearance[key] === option.idx;
                         const disabled =
                           key === 'tableShape' && option.id === DIAMOND_SHAPE_ID && DEFAULT_PLAYER_COUNT > 4;
                         return (
                           <button
-                            key={option.id ?? idx}
+                            key={option.id ?? option.idx}
                             type="button"
                             onClick={() => {
                               if (disabled) return;
-                              setAppearance((prev) => ({ ...prev, [key]: idx }));
+                              setAppearance((prev) => ({ ...prev, [key]: option.idx }));
                             }}
                             aria-pressed={selected}
                             disabled={disabled}

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -26,6 +26,18 @@ import {
   chessBattleAccountId
 } from '../utils/chessBattleInventory.js';
 import {
+  LUDO_BATTLE_DEFAULT_LOADOUT,
+  LUDO_BATTLE_OPTION_LABELS,
+  LUDO_BATTLE_STORE_ITEMS
+} from '../config/ludoBattleInventoryConfig.js';
+import {
+  addLudoBattleUnlock,
+  getLudoBattleInventory,
+  isLudoOptionUnlocked,
+  listOwnedLudoOptions,
+  ludoBattleAccountId
+} from '../utils/ludoBattleInventory.js';
+import {
   DOMINO_ROYAL_DEFAULT_LOADOUT,
   DOMINO_ROYAL_OPTION_LABELS,
   DOMINO_ROYAL_STORE_ITEMS
@@ -60,6 +72,18 @@ const CHESS_TYPE_LABELS = {
   headStyle: 'Pawn Heads'
 };
 
+const LUDO_TYPE_LABELS = {
+  tableWood: 'Table Wood',
+  tableCloth: 'Table Cloth',
+  tableBase: 'Table Base',
+  chairColor: 'Chairs',
+  tableShape: 'Table Shape',
+  tokenPalette: 'Token Palette',
+  tokenStyle: 'Token Style',
+  tokenPiece: 'Token Piece',
+  headStyle: 'Heads'
+};
+
 const DOMINO_TYPE_LABELS = {
   tableWood: 'Table Wood',
   tableCloth: 'Table Cloth',
@@ -72,8 +96,9 @@ const DOMINO_TYPE_LABELS = {
 const TPC_ICON = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 const POOL_STORE_ACCOUNT_ID = import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const CHESS_STORE_ACCOUNT_ID = import.meta.env.VITE_CHESS_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const LUDO_STORE_ACCOUNT_ID = import.meta.env.VITE_LUDO_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const DOMINO_STORE_ACCOUNT_ID = import.meta.env.VITE_DOMINO_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
-const SUPPORTED_STORE_SLUGS = ['poolroyale', 'chessbattleroyal', 'domino-royal'];
+const SUPPORTED_STORE_SLUGS = ['poolroyale', 'chessbattleroyal', 'ludobattleroyal', 'domino-royal'];
 
 const createItemKey = (type, optionId) => `${type}:${optionId}`;
 
@@ -84,6 +109,7 @@ export default function Store() {
   const [accountId, setAccountId] = useState(() => poolRoyalAccountId());
   const [poolOwned, setPoolOwned] = useState(() => getPoolRoyalInventory(accountId));
   const [chessOwned, setChessOwned] = useState(() => getChessBattleInventory(chessBattleAccountId(accountId)));
+  const [ludoOwned, setLudoOwned] = useState(() => getLudoBattleInventory(ludoBattleAccountId(accountId)));
   const [dominoOwned, setDominoOwned] = useState(() => getDominoRoyalInventory(dominoRoyalAccountId(accountId)));
   const [info, setInfo] = useState('');
   const [marketInfo, setMarketInfo] = useState('');
@@ -116,6 +142,7 @@ export default function Store() {
   useEffect(() => {
     setPoolOwned(getPoolRoyalInventory(accountId));
     setChessOwned(getChessBattleInventory(chessBattleAccountId(accountId)));
+    setLudoOwned(getLudoBattleInventory(ludoBattleAccountId(accountId)));
     setDominoOwned(getDominoRoyalInventory(dominoRoyalAccountId(accountId)));
   }, [accountId]);
 
@@ -152,6 +179,16 @@ export default function Store() {
     };
     window.addEventListener('chessBattleInventoryUpdate', handler);
     return () => window.removeEventListener('chessBattleInventoryUpdate', handler);
+  }, [accountId]);
+
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === accountId) {
+        setLudoOwned(getLudoBattleInventory(ludoBattleAccountId(accountId)));
+      }
+    };
+    window.addEventListener('ludoBattleInventoryUpdate', handler);
+    return () => window.removeEventListener('ludoBattleInventoryUpdate', handler);
   }, [accountId]);
 
   useEffect(() => {
@@ -212,6 +249,27 @@ export default function Store() {
     [chessOwned]
   );
 
+  const ludoGroupedItems = useMemo(() => {
+    const items = LUDO_BATTLE_STORE_ITEMS.map((item) => ({
+      ...item,
+      owned: isLudoOptionUnlocked(item.type, item.optionId, ludoOwned)
+    }));
+    return items.reduce((acc, item) => {
+      acc[item.type] = acc[item.type] || [];
+      acc[item.type].push(item);
+      return acc;
+    }, {});
+  }, [ludoOwned]);
+
+  const ludoDefaultLoadout = useMemo(
+    () =>
+      LUDO_BATTLE_DEFAULT_LOADOUT.map((entry) => ({
+        ...entry,
+        owned: isLudoOptionUnlocked(entry.type, entry.optionId, ludoOwned)
+      })),
+    [ludoOwned]
+  );
+
   const dominoGroupedItems = useMemo(() => {
     const items = DOMINO_ROYAL_STORE_ITEMS.map((item) => ({
       ...item,
@@ -237,6 +295,7 @@ export default function Store() {
     () => ({
       poolroyale: POOL_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
       chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
+      ludobattleroyal: LUDO_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
       'domino-royal': DOMINO_ROYAL_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) }))
     }),
     []
@@ -257,15 +316,17 @@ export default function Store() {
     () => ({
       poolroyale: (type, optionId) => isPoolOptionUnlocked(type, optionId, poolOwned),
       chessbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
+      ludobattleroyal: (type, optionId) => isLudoOptionUnlocked(type, optionId, ludoOwned),
       'domino-royal': (type, optionId) => isDominoOptionUnlocked(type, optionId, dominoOwned)
     }),
-    [poolOwned, chessOwned, dominoOwned]
+    [poolOwned, chessOwned, ludoOwned, dominoOwned]
   );
 
   const labelResolvers = useMemo(
     () => ({
       poolroyale: (item) => POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       chessbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      ludobattleroyal: (item) => LUDO_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       'domino-royal': (item) => DOMINO_ROYAL_OPTION_LABELS[item.type]?.[item.optionId] || item.name
     }),
     []
@@ -300,6 +361,7 @@ export default function Store() {
     const storeAccounts = {
       poolroyale: POOL_STORE_ACCOUNT_ID,
       chessbattleroyal: CHESS_STORE_ACCOUNT_ID,
+      ludobattleroyal: LUDO_STORE_ACCOUNT_ID,
       'domino-royal': DOMINO_STORE_ACCOUNT_ID
     };
     const storeId = storeAccounts[activeSlug];
@@ -311,6 +373,7 @@ export default function Store() {
     const labelMaps = {
       poolroyale: POOL_ROYALE_OPTION_LABELS,
       chessbattleroyal: CHESS_BATTLE_OPTION_LABELS,
+      ludobattleroyal: LUDO_BATTLE_OPTION_LABELS,
       'domino-royal': DOMINO_ROYAL_OPTION_LABELS
     };
     const labels = labelMaps[activeSlug]?.[item.type] || {};
@@ -343,6 +406,10 @@ export default function Store() {
         const updatedInventory = addChessBattleUnlock(item.type, item.optionId, accountId);
         setChessOwned(updatedInventory);
         setInfo(`${ownedLabel} purchased and added to your Chess Battle Royal account.`);
+      } else if (activeSlug === 'ludobattleroyal') {
+        const updatedInventory = addLudoBattleUnlock(item.type, item.optionId, accountId);
+        setLudoOwned(updatedInventory);
+        setInfo(`${ownedLabel} purchased and added to your Ludo Battle Royal account.`);
       } else if (activeSlug === 'domino-royal') {
         const updatedInventory = addDominoRoyalUnlock(item.type, item.optionId, accountId);
         setDominoOwned(updatedInventory);
@@ -422,15 +489,17 @@ export default function Store() {
 
   const poolOwnedOptions = useMemo(() => listOwnedPoolRoyalOptions(accountId), [accountId]);
   const chessOwnedOptions = useMemo(() => listOwnedChessOptions(accountId), [accountId]);
+  const ludoOwnedOptions = useMemo(() => listOwnedLudoOptions(accountId), [accountId]);
   const dominoOwnedOptions = useMemo(() => listOwnedDominoOptions(accountId), [accountId]);
 
   const ownedItemLookup = useMemo(
     () => ({
       poolroyale: poolOwnedOptions,
       chessbattleroyal: chessOwnedOptions,
+      ludobattleroyal: ludoOwnedOptions,
       'domino-royal': dominoOwnedOptions
     }),
-    [poolOwnedOptions, chessOwnedOptions, dominoOwnedOptions]
+    [poolOwnedOptions, chessOwnedOptions, ludoOwnedOptions, dominoOwnedOptions]
   );
 
   const hasStorefront = SUPPORTED_STORE_SLUGS.includes(activeSlug);
@@ -662,6 +731,76 @@ export default function Store() {
                             <p className="text-xs text-subtext mt-1">
                               Applies to: {CHESS_TYPE_LABELS[item.type] || item.type}
                             </p>
+                          </div>
+                          <div className="flex items-center gap-1 text-sm font-semibold">
+                            {item.price}
+                            <img src={TPC_ICON} alt="TPC" className="h-4 w-4" />
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => handlePurchase(item)}
+                          disabled={item.owned || processing === item.id}
+                          className={`buy-button mt-2 text-center ${
+                            item.owned || processing === item.id ? 'cursor-not-allowed opacity-60' : ''
+                          }`}
+                        >
+                          {item.owned
+                            ? `${ownedLabel} Owned`
+                            : processing === item.id
+                            ? 'Purchasing...'
+                            : `Purchase ${ownedLabel}`}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {activeSlug === 'ludobattleroyal' && (
+        <>
+          <div className="store-card max-w-2xl">
+            <h3 className="text-lg font-semibold">Ludo Battle Royal Defaults (Free)</h3>
+            <p className="text-sm text-subtext">
+              The first option in each category stays free. Purchase the others to surface them inside the Ludo table setup
+              menu.
+            </p>
+            <ul className="mt-2 space-y-1 w-full">
+              {ludoDefaultLoadout.map((item) => (
+                <li
+                  key={`ludo-${item.type}-${item.optionId}`}
+                  className="flex items-center justify-between rounded-lg border border-border px-3 py-2 w-full"
+                >
+                  <span className="font-medium">{item.label}</span>
+                  <span className="text-xs uppercase text-subtext">{LUDO_TYPE_LABELS[item.type] || item.type}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="w-full space-y-3">
+            <h3 className="text-lg font-semibold text-center">Ludo Battle Royal Collection</h3>
+            {Object.entries(ludoGroupedItems).map(([type, items]) => (
+              <div key={type} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <h4 className="text-base font-semibold">{LUDO_TYPE_LABELS[type] || type}</h4>
+                  <span className="text-xs text-subtext">NFT unlocks</span>
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  {items.map((item) => {
+                    const labels = LUDO_BATTLE_OPTION_LABELS[item.type] || {};
+                    const ownedLabel = labels[item.optionId] || item.name;
+                    return (
+                      <div key={item.id} className="store-card">
+                        <div className="flex w-full items-start justify-between gap-2">
+                          <div>
+                            <p className="font-semibold text-lg leading-tight">{item.name}</p>
+                            <p className="text-xs text-subtext">{item.description}</p>
+                            <p className="text-xs text-subtext mt-1">Applies to: {LUDO_TYPE_LABELS[item.type] || item.type}</p>
                           </div>
                           <div className="flex items-center gap-1 text-sm font-semibold">
                             {item.price}

--- a/webapp/src/utils/ludoBattleInventory.js
+++ b/webapp/src/utils/ludoBattleInventory.js
@@ -1,0 +1,112 @@
+import {
+  LUDO_BATTLE_DEFAULT_LOADOUT,
+  LUDO_BATTLE_DEFAULT_UNLOCKS,
+  LUDO_BATTLE_OPTION_LABELS
+} from '../config/ludoBattleInventoryConfig.js';
+
+const STORAGE_KEY = 'ludoBattleInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(LUDO_BATTLE_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values].filter(Boolean) : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read ludo inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getLudoBattleInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isLudoOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getLudoBattleInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addLudoBattleUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('ludoBattleInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedLudoOptions = (accountId) => {
+  const inventory = getLudoBattleInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = LUDO_BATTLE_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultLudoBattleLoadout = () => [...LUDO_BATTLE_DEFAULT_LOADOUT];
+
+export const ludoBattleAccountId = resolveAccountId;

--- a/webapp/src/utils/ludoTokenConstants.js
+++ b/webapp/src/utils/ludoTokenConstants.js
@@ -1,0 +1,1 @@
+export const TOKEN_TYPE_SEQUENCE = ['k', 'q', 'b', 'n', 'r', 'p'];


### PR DESCRIPTION
## Summary
- gate Ludo Battle Royal table customization behind unlockable NFT options with default free choices
- add Ludo Battle Royal store inventory, unlock persistence, and marketplace support alongside existing games
- centralize Ludo cosmetic option definitions for reuse between the game and store

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693db1e3e5d88329a36495a5798c4e80)