### PR TITLE
Add Murlan Royale NFT unlock flow

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -1,0 +1,222 @@
+import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../utils/tableCustomizationOptions.js';
+import { CARD_THEMES } from '../utils/cardThemes.js';
+import { MURLAN_STOOL_THEMES } from './murlanThemes.js';
+
+const mapLabels = (options) =>
+  Object.freeze(
+    options.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  );
+
+export const MURLAN_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
+  tableWood: [TABLE_WOOD_OPTIONS[0].id],
+  tableCloth: [TABLE_CLOTH_OPTIONS[0].id],
+  tableBase: [TABLE_BASE_OPTIONS[0].id],
+  cards: [CARD_THEMES[0].id],
+  stools: [MURLAN_STOOL_THEMES[0].id]
+});
+
+export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
+  tableWood: mapLabels(TABLE_WOOD_OPTIONS),
+  tableCloth: mapLabels(TABLE_CLOTH_OPTIONS),
+  tableBase: mapLabels(TABLE_BASE_OPTIONS),
+  cards: mapLabels(CARD_THEMES),
+  stools: mapLabels(MURLAN_STOOL_THEMES)
+});
+
+export const MURLAN_ROYALE_STORE_ITEMS = [
+  {
+    id: 'wood-warmBrown',
+    type: 'tableWood',
+    optionId: 'warmBrown',
+    name: 'Warm Brown Table Wood',
+    price: 760,
+    description: 'Walnut tone rails with a gentle satin sheen.'
+  },
+  {
+    id: 'wood-cleanStrips',
+    type: 'tableWood',
+    optionId: 'cleanStrips',
+    name: 'Clean Strips Table Wood',
+    price: 840,
+    description: 'Striped oak planks with a studio polish.'
+  },
+  {
+    id: 'wood-oldWoodFloor',
+    type: 'tableWood',
+    optionId: 'oldWoodFloor',
+    name: 'Heritage Wood Table',
+    price: 920,
+    description: 'Vintage smoked boards with deep grain detail.'
+  },
+  {
+    id: 'cloth-emerald',
+    type: 'tableCloth',
+    optionId: 'emerald',
+    name: 'Emerald Cloth',
+    price: 360,
+    description: 'Tournament emerald felt with rich shadows.'
+  },
+  {
+    id: 'cloth-arctic',
+    type: 'tableCloth',
+    optionId: 'arctic',
+    name: 'Arctic Cloth',
+    price: 380,
+    description: 'Cool arctic blue felt with crisp highlights.'
+  },
+  {
+    id: 'cloth-sunset',
+    type: 'tableCloth',
+    optionId: 'sunset',
+    name: 'Sunset Cloth',
+    price: 400,
+    description: 'Amber-orange felt inspired by dusk skies.'
+  },
+  {
+    id: 'cloth-violet',
+    type: 'tableCloth',
+    optionId: 'violet',
+    name: 'Violet Cloth',
+    price: 420,
+    description: 'Deep violet felt with subtle neon sheen.'
+  },
+  {
+    id: 'cloth-amber',
+    type: 'tableCloth',
+    optionId: 'amber',
+    name: 'Amber Cloth',
+    price: 440,
+    description: 'Golden amber felt with cinematic warmth.'
+  },
+  {
+    id: 'base-forestBronze',
+    type: 'tableBase',
+    optionId: 'forestBronze',
+    name: 'Forest Base',
+    price: 620,
+    description: 'Verdant metallic base with bronzed trim.'
+  },
+  {
+    id: 'base-midnightChrome',
+    type: 'tableBase',
+    optionId: 'midnightChrome',
+    name: 'Midnight Base',
+    price: 690,
+    description: 'Midnight blue base with chrome-inspired highlights.'
+  },
+  {
+    id: 'base-emberCopper',
+    type: 'tableBase',
+    optionId: 'emberCopper',
+    name: 'Copper Base',
+    price: 740,
+    description: 'Copper-accent base with warm metallic glints.'
+  },
+  {
+    id: 'base-violetShadow',
+    type: 'tableBase',
+    optionId: 'violetShadow',
+    name: 'Violet Shadow Base',
+    price: 780,
+    description: 'Shadowed violet base with luxe gloss trim.'
+  },
+  {
+    id: 'base-desertGold',
+    type: 'tableBase',
+    optionId: 'desertGold',
+    name: 'Desert Base',
+    price: 820,
+    description: 'Desert-inspired base with brushed gold finish.'
+  },
+  {
+    id: 'cards-solstice',
+    type: 'cards',
+    optionId: 'solstice',
+    name: 'Solstice Deck',
+    price: 260,
+    description: 'Sun-baked backs with warm metallic edgework.'
+  },
+  {
+    id: 'cards-nebula',
+    type: 'cards',
+    optionId: 'nebula',
+    name: 'Nebula Deck',
+    price: 300,
+    description: 'Cosmic purples with glowing starlit accents.'
+  },
+  {
+    id: 'cards-jade',
+    type: 'cards',
+    optionId: 'jade',
+    name: 'Jade Deck',
+    price: 280,
+    description: 'Emerald gradients with luminous jade borders.'
+  },
+  {
+    id: 'cards-ember',
+    type: 'cards',
+    optionId: 'ember',
+    name: 'Ember Deck',
+    price: 320,
+    description: 'Fiery orange backs with charcoal cores.'
+  },
+  {
+    id: 'cards-onyx',
+    type: 'cards',
+    optionId: 'onyx',
+    name: 'Onyx Deck',
+    price: 340,
+    description: 'Monochrome slate backs with steel edging.'
+  },
+  {
+    id: 'stool-slate',
+    type: 'stools',
+    optionId: 'slate',
+    name: 'Slate Stools',
+    price: 210,
+    description: 'Slate seats with midnight legs.'
+  },
+  {
+    id: 'stool-teal',
+    type: 'stools',
+    optionId: 'teal',
+    name: 'Teal Stools',
+    price: 230,
+    description: 'Teal cushions with deep green support.'
+  },
+  {
+    id: 'stool-amber',
+    type: 'stools',
+    optionId: 'amber',
+    name: 'Amber Stools',
+    price: 250,
+    description: 'Amber seats with rich brown legs.'
+  },
+  {
+    id: 'stool-violet',
+    type: 'stools',
+    optionId: 'violet',
+    name: 'Violet Stools',
+    price: 270,
+    description: 'Violet cushions with twilight framing.'
+  },
+  {
+    id: 'stool-frost',
+    type: 'stools',
+    optionId: 'frost',
+    name: 'Frost Stools',
+    price: 290,
+    description: 'Frosted charcoal seats with dark legs.'
+  }
+];
+
+export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
+  { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0].id, label: TABLE_WOOD_OPTIONS[0].label },
+  { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0].id, label: TABLE_CLOTH_OPTIONS[0].label },
+  { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0].id, label: TABLE_BASE_OPTIONS[0].label },
+  { type: 'cards', optionId: CARD_THEMES[0].id, label: CARD_THEMES[0].label },
+  { type: 'stools', optionId: MURLAN_STOOL_THEMES[0].id, label: MURLAN_STOOL_THEMES[0].label }
+];

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -1,0 +1,17 @@
+export const MURLAN_OUTFIT_THEMES = [
+  { id: 'midnight', label: 'Royal Blue', baseColor: '#1f3c88', accentColor: '#f5d547', glow: '#0f172a' },
+  { id: 'ember', label: 'Neon Red', baseColor: '#a31621', accentColor: '#ff8e3c', glow: '#22080b' },
+  { id: 'glacier', label: 'Ice', baseColor: '#1b8dbf', accentColor: '#9ff0ff', glow: '#082433' },
+  { id: 'forest', label: 'Forest', baseColor: '#1b7f4a', accentColor: '#b5f44a', glow: '#071f11' },
+  { id: 'royal', label: 'Violet', baseColor: '#6b21a8', accentColor: '#f0abfc', glow: '#220a35' },
+  { id: 'onyx', label: 'Onyx', baseColor: '#1f2937', accentColor: '#9ca3af', glow: '#090b10' }
+];
+
+export const MURLAN_STOOL_THEMES = [
+  { id: 'ruby', label: 'Ruby', seatColor: '#8b0000', legColor: '#1f1f1f' },
+  { id: 'slate', label: 'Slate', seatColor: '#374151', legColor: '#0f172a' },
+  { id: 'teal', label: 'Teal', seatColor: '#0f766e', legColor: '#082f2a' },
+  { id: 'amber', label: 'Amber', seatColor: '#b45309', legColor: '#2f2410' },
+  { id: 'violet', label: 'Violet', seatColor: '#7c3aed', legColor: '#2b1059' },
+  { id: 'frost', label: 'Ice', seatColor: '#1f2937', legColor: '#0f172a' }
+];

--- a/webapp/src/utils/murlanInventory.js
+++ b/webapp/src/utils/murlanInventory.js
@@ -1,0 +1,112 @@
+import {
+  MURLAN_ROYALE_DEFAULT_LOADOUT,
+  MURLAN_ROYALE_DEFAULT_UNLOCKS,
+  MURLAN_ROYALE_OPTION_LABELS
+} from '../config/murlanInventoryConfig.js';
+
+const STORAGE_KEY = 'murlanInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(MURLAN_ROYALE_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values].filter(Boolean) : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read murlan inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getMurlanInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isMurlanOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getMurlanInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addMurlanUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('murlanInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedMurlanOptions = (accountId) => {
+  const inventory = getMurlanInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = MURLAN_ROYALE_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultMurlanLoadout = () => [...MURLAN_ROYALE_DEFAULT_LOADOUT];
+
+export const murlanAccountId = resolveAccountId;


### PR DESCRIPTION
## Summary
- add reusable Murlan Royale inventory data and wallet-backed unlock storage
- gate Murlan Royale table setup options to owned items and surface new purchases
- expose Murlan Royale cosmetics in the store with default freebies and NFT pricing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693db85ea398832988273256a85a7c65)