### PR TITLE
Add NFT unlock flow for Snake & Ladder cosmetics

### DIFF
--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -1,0 +1,65 @@
+export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
+  arenaTheme: ['nebulaAtrium'],
+  boardPalette: ['desertMarble'],
+  snakeSkin: ['emeraldScales'],
+  diceTheme: ['imperialIvory'],
+  railTheme: ['platinumOak'],
+  tokenFinish: ['ceramicSheen']
+});
+
+export const SNAKE_OPTION_LABELS = Object.freeze({
+  arenaTheme: Object.freeze({
+    nebulaAtrium: 'Nebula Atrium',
+    crystalLagoon: 'Crystal Lagoon',
+    royalEmber: 'Royal Ember'
+  }),
+  boardPalette: Object.freeze({
+    desertMarble: 'Desert Marble',
+    glacierGlass: 'Glacier Glass',
+    jadeSanctum: 'Jade Sanctum'
+  }),
+  snakeSkin: Object.freeze({
+    emeraldScales: 'Emerald Scales',
+    midnightCobra: 'Midnight Cobra',
+    emberSerpent: 'Ember Serpent'
+  }),
+  diceTheme: Object.freeze({
+    imperialIvory: 'Imperial Ivory',
+    onyxChrome: 'Onyx Chrome',
+    auroraQuartz: 'Aurora Quartz'
+  }),
+  railTheme: Object.freeze({
+    platinumOak: 'Platinum & Oak',
+    obsidianSteel: 'Obsidian Steel',
+    emberBrass: 'Ember Brass'
+  }),
+  tokenFinish: Object.freeze({
+    ceramicSheen: 'Ceramic Sheen',
+    matteVelvet: 'Matte Velvet',
+    holographicPulse: 'Holographic Pulse'
+  })
+});
+
+export const SNAKE_DEFAULT_LOADOUT = Object.freeze([
+  { type: 'arenaTheme', optionId: 'nebulaAtrium', label: 'Nebula Atrium' },
+  { type: 'boardPalette', optionId: 'desertMarble', label: 'Desert Marble' },
+  { type: 'snakeSkin', optionId: 'emeraldScales', label: 'Emerald Scales' },
+  { type: 'diceTheme', optionId: 'imperialIvory', label: 'Imperial Ivory' },
+  { type: 'railTheme', optionId: 'platinumOak', label: 'Platinum & Oak' },
+  { type: 'tokenFinish', optionId: 'ceramicSheen', label: 'Ceramic Sheen' }
+]);
+
+export const SNAKE_STORE_ITEMS = [
+  { id: 'snake-arena-crystal', type: 'arenaTheme', optionId: 'crystalLagoon', name: 'Crystal Lagoon Arena', price: 520, description: 'Swap in a turquoise-lit lagoon arena vibe for Snake & Ladder.' },
+  { id: 'snake-arena-ember', type: 'arenaTheme', optionId: 'royalEmber', name: 'Royal Ember Arena', price: 560, description: 'Warm ember glow with royal trims for the Snake & Ladder hall.' },
+  { id: 'snake-board-glacier', type: 'boardPalette', optionId: 'glacierGlass', name: 'Glacier Glass Board', price: 360, description: 'Frosted glass board palette with neon highlights.' },
+  { id: 'snake-board-jade', type: 'boardPalette', optionId: 'jadeSanctum', name: 'Jade Sanctum Board', price: 390, description: 'Jade and gold board palette for your Snake & Ladder grid.' },
+  { id: 'snake-skin-midnight', type: 'snakeSkin', optionId: 'midnightCobra', name: 'Midnight Cobra Skin', price: 430, description: 'Dark-scaled cobra texture for premium snake renders.' },
+  { id: 'snake-skin-ember', type: 'snakeSkin', optionId: 'emberSerpent', name: 'Ember Serpent Skin', price: 450, description: 'Smoldering ember serpent skin for the animated snakes.' },
+  { id: 'snake-dice-onyx', type: 'diceTheme', optionId: 'onyxChrome', name: 'Onyx Chrome Dice', price: 320, description: 'Chrome-edged onyx dice for high-stakes rolls.' },
+  { id: 'snake-dice-aurora', type: 'diceTheme', optionId: 'auroraQuartz', name: 'Aurora Quartz Dice', price: 340, description: 'Iridescent quartz dice with cyan pips.' },
+  { id: 'snake-rail-obsidian', type: 'railTheme', optionId: 'obsidianSteel', name: 'Obsidian Steel Rails', price: 410, description: 'Steel-and-obsidian rails with cool blue netting.' },
+  { id: 'snake-rail-ember', type: 'railTheme', optionId: 'emberBrass', name: 'Ember Brass Rails', price: 430, description: 'Brass and ember rail package with rose highlights.' },
+  { id: 'snake-token-matte', type: 'tokenFinish', optionId: 'matteVelvet', name: 'Matte Velvet Tokens', price: 300, description: 'Velvet-matte finish for player tokens.' },
+  { id: 'snake-token-holo', type: 'tokenFinish', optionId: 'holographicPulse', name: 'Holographic Pulse Tokens', price: 360, description: 'Holographic clearcoat tokens with shimmering accents.' }
+];

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -29,6 +29,12 @@ import useTelegramBackButton from "../../hooks/useTelegramBackButton.js";
 import { useNavigate } from "react-router-dom";
 import { getPlayerId, getTelegramId, ensureAccountId } from "../../utils/telegram.js";
 import {
+  addSnakeUnlock,
+  getSnakeInventory,
+  isSnakeOptionUnlocked,
+  snakeAccountId
+} from "../../utils/snakeInventory.js";
+import {
   getProfileByAccount,
   depositAccount,
   getSnakeBoard,
@@ -609,6 +615,12 @@ export default function SnakeAndLadder() {
   const navigate = useNavigate();
 
   const [accountId, setAccountId] = useState(() => getPlayerId());
+  const resolvedSnakeAccountId = useMemo(() => snakeAccountId(accountId), [accountId]);
+  const [snakeInventoryVersion, setSnakeInventoryVersion] = useState(0);
+  const snakeInventory = useMemo(
+    () => getSnakeInventory(resolvedSnakeAccountId),
+    [resolvedSnakeAccountId, snakeInventoryVersion]
+  );
   const [tableCapacity, setTableCapacity] = useState(DEFAULT_CAPACITY);
   const tableCapacityRef = useRef(DEFAULT_CAPACITY);
 
@@ -619,6 +631,16 @@ export default function SnakeAndLadder() {
       })
       .catch(() => {});
   }, []);
+
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === resolvedSnakeAccountId) {
+        setSnakeInventoryVersion((value) => value + 1);
+      }
+    };
+    window.addEventListener('snakeInventoryUpdate', handler);
+    return () => window.removeEventListener('snakeInventoryUpdate', handler);
+  }, [resolvedSnakeAccountId]);
 
   useEffect(() => {
     const handler = () => setMuted(isGameMuted());
@@ -754,9 +776,54 @@ export default function SnakeAndLadder() {
   const [isMultiplayer, setIsMultiplayer] = useState(false);
   const [watchOnly, setWatchOnly] = useState(false);
   const [mpPlayers, setMpPlayers] = useState([]);
-  const normalizedAppearance = useMemo(() => normalizeAppearance(appearance), [appearance]);
-  const appearanceKey = useMemo(() => buildAppearanceKey(appearance), [appearance]);
-  const resolvedAppearance = useMemo(() => resolveAppearance(appearance), [appearance]);
+  const ensureAppearanceUnlocked = useCallback(
+    (value = DEFAULT_APPEARANCE) => {
+      const normalized = normalizeAppearance(value);
+      const map = {
+        arenaTheme: ARENA_THEME_OPTIONS,
+        boardPalette: BOARD_PALETTE_OPTIONS,
+        snakeSkin: SNAKE_SKIN_OPTIONS,
+        diceTheme: DICE_THEME_OPTIONS,
+        railTheme: RAIL_THEME_OPTIONS,
+        tokenFinish: TOKEN_FINISH_OPTIONS
+      };
+      let changed = false;
+      const next = { ...normalized };
+      Object.entries(map).forEach(([key, options]) => {
+        const idx = Number.isFinite(next[key]) ? next[key] : 0;
+        const option = options[idx];
+        if (!option || !isSnakeOptionUnlocked(key, option.id, snakeInventory)) {
+          const fallbackIdx = options.findIndex((opt) => isSnakeOptionUnlocked(key, opt.id, snakeInventory));
+          const safeIdx = fallbackIdx >= 0 ? fallbackIdx : 0;
+          if (safeIdx !== idx) {
+            next[key] = safeIdx;
+            changed = true;
+          }
+        }
+      });
+      return changed ? next : normalized;
+    },
+    [snakeInventory]
+  );
+  const normalizedAppearance = useMemo(
+    () => ensureAppearanceUnlocked(appearance),
+    [appearance, ensureAppearanceUnlocked]
+  );
+  useEffect(() => {
+    setAppearance((prev) => ensureAppearanceUnlocked(prev));
+  }, [ensureAppearanceUnlocked]);
+  const appearanceKey = useMemo(() => buildAppearanceKey(normalizedAppearance), [normalizedAppearance]);
+  const resolvedAppearance = useMemo(() => resolveAppearance(normalizedAppearance), [normalizedAppearance]);
+  const customizationSections = useMemo(
+    () =>
+      SNAKE_CUSTOMIZATION_SECTIONS.map((section) => ({
+        ...section,
+        options: section.options
+          .map((option, idx) => ({ ...option, idx }))
+          .filter(({ id }) => isSnakeOptionUnlocked(section.key, id, snakeInventory))
+      })).filter((section) => section.options.length > 0),
+    [snakeInventory]
+  );
   const activeFrameRateOption = useMemo(
     () => FRAME_RATE_OPTIONS.find((option) => option.id === frameRateId) ?? FRAME_RATE_OPTIONS[0],
     [frameRateId]
@@ -768,10 +835,10 @@ export default function SnakeAndLadder() {
       if (typeof window === 'undefined') return;
       window.localStorage.setItem(
         APPEARANCE_STORAGE_KEY,
-        JSON.stringify(normalizeAppearance(appearance))
+        JSON.stringify(normalizedAppearance)
       );
     } catch {}
-  }, [appearanceKey]);
+  }, [appearanceKey, normalizedAppearance]);
 
   useEffect(() => {
     try {
@@ -2546,18 +2613,18 @@ export default function SnakeAndLadder() {
                 </button>
               </div>
               <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
-                {SNAKE_CUSTOMIZATION_SECTIONS.map(({ key, label, options }) => (
+                {customizationSections.map(({ key, label, options }) => (
                   <div key={key} className="space-y-2">
                     <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
                     <div className="grid grid-cols-1 gap-2">
-                      {options.map((option, idx) => {
-                        const selected = normalizedAppearance[key] === idx;
+                      {options.map((option) => {
+                        const selected = normalizedAppearance[key] === option.idx;
                         return (
                           <button
-                            key={option.id ?? idx}
+                            key={option.id ?? option.idx}
                             type="button"
                             onClick={() =>
-                              setAppearance((prev) => normalizeAppearance({ ...prev, [key]: idx }))
+                              setAppearance((prev) => normalizeAppearance({ ...prev, [key]: option.idx }))
                             }
                             aria-pressed={selected}
                             className={`flex flex-col items-center gap-2 rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -50,6 +50,18 @@ import {
   murlanAccountId
 } from '../utils/murlanInventory.js';
 import {
+  SNAKE_DEFAULT_LOADOUT,
+  SNAKE_OPTION_LABELS,
+  SNAKE_STORE_ITEMS
+} from '../config/snakeInventoryConfig.js';
+import {
+  addSnakeUnlock,
+  getSnakeInventory,
+  isSnakeOptionUnlocked,
+  listOwnedSnakeOptions,
+  snakeAccountId
+} from '../utils/snakeInventory.js';
+import {
   DOMINO_ROYAL_DEFAULT_LOADOUT,
   DOMINO_ROYAL_OPTION_LABELS,
   DOMINO_ROYAL_STORE_ITEMS
@@ -113,13 +125,30 @@ const DOMINO_TYPE_LABELS = {
   chairTheme: 'Chairs'
 };
 
+const SNAKE_TYPE_LABELS = {
+  arenaTheme: 'Arena Atmosphere',
+  boardPalette: 'Board Palette',
+  snakeSkin: 'Snake Skins',
+  diceTheme: 'Dice Finish',
+  railTheme: 'Rails & Nets',
+  tokenFinish: 'Token Finish'
+};
+
 const TPC_ICON = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 const POOL_STORE_ACCOUNT_ID = import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const CHESS_STORE_ACCOUNT_ID = import.meta.env.VITE_CHESS_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const LUDO_STORE_ACCOUNT_ID = import.meta.env.VITE_LUDO_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const MURLAN_STORE_ACCOUNT_ID = import.meta.env.VITE_MURLAN_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const DOMINO_STORE_ACCOUNT_ID = import.meta.env.VITE_DOMINO_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
-const SUPPORTED_STORE_SLUGS = ['poolroyale', 'chessbattleroyal', 'ludobattleroyal', 'murlanroyale', 'domino-royal'];
+const SNAKE_STORE_ACCOUNT_ID = import.meta.env.VITE_SNAKE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const SUPPORTED_STORE_SLUGS = [
+  'poolroyale',
+  'chessbattleroyal',
+  'ludobattleroyal',
+  'murlanroyale',
+  'domino-royal',
+  'snake'
+];
 
 const createItemKey = (type, optionId) => `${type}:${optionId}`;
 
@@ -133,6 +162,7 @@ export default function Store() {
   const [ludoOwned, setLudoOwned] = useState(() => getLudoBattleInventory(ludoBattleAccountId(accountId)));
   const [murlanOwned, setMurlanOwned] = useState(() => getMurlanInventory(murlanAccountId(accountId)));
   const [dominoOwned, setDominoOwned] = useState(() => getDominoRoyalInventory(dominoRoyalAccountId(accountId)));
+  const [snakeOwned, setSnakeOwned] = useState(() => getSnakeInventory(snakeAccountId(accountId)));
   const [info, setInfo] = useState('');
   const [marketInfo, setMarketInfo] = useState('');
   const [tpcBalance, setTpcBalance] = useState(null);
@@ -167,6 +197,7 @@ export default function Store() {
     setLudoOwned(getLudoBattleInventory(ludoBattleAccountId(accountId)));
     setMurlanOwned(getMurlanInventory(murlanAccountId(accountId)));
     setDominoOwned(getDominoRoyalInventory(dominoRoyalAccountId(accountId)));
+    setSnakeOwned(getSnakeInventory(snakeAccountId(accountId)));
   }, [accountId]);
 
   useEffect(() => {
@@ -232,6 +263,16 @@ export default function Store() {
     };
     window.addEventListener('dominoRoyalInventoryUpdate', handler);
     return () => window.removeEventListener('dominoRoyalInventoryUpdate', handler);
+  }, [accountId]);
+
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === snakeAccountId(accountId)) {
+        setSnakeOwned(getSnakeInventory(snakeAccountId(accountId)));
+      }
+    };
+    window.addEventListener('snakeInventoryUpdate', handler);
+    return () => window.removeEventListener('snakeInventoryUpdate', handler);
   }, [accountId]);
 
   useEffect(() => {
@@ -345,13 +386,35 @@ export default function Store() {
     [dominoOwned]
   );
 
+  const snakeGroupedItems = useMemo(() => {
+    const items = SNAKE_STORE_ITEMS.map((item) => ({
+      ...item,
+      owned: isSnakeOptionUnlocked(item.type, item.optionId, snakeOwned)
+    }));
+    return items.reduce((acc, item) => {
+      acc[item.type] = acc[item.type] || [];
+      acc[item.type].push(item);
+      return acc;
+    }, {});
+  }, [snakeOwned]);
+
+  const snakeDefaultLoadout = useMemo(
+    () =>
+      SNAKE_DEFAULT_LOADOUT.map((entry) => ({
+        ...entry,
+        owned: isSnakeOptionUnlocked(entry.type, entry.optionId, snakeOwned)
+      })),
+    [snakeOwned]
+  );
+
   const storeItemsBySlug = useMemo(
     () => ({
       poolroyale: POOL_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
       chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
       ludobattleroyal: LUDO_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
       murlanroyale: MURLAN_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
-      'domino-royal': DOMINO_ROYAL_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) }))
+      'domino-royal': DOMINO_ROYAL_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) })),
+      snake: SNAKE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId) }))
     }),
     []
   );
@@ -373,9 +436,10 @@ export default function Store() {
       chessbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
       ludobattleroyal: (type, optionId) => isLudoOptionUnlocked(type, optionId, ludoOwned),
       murlanroyale: (type, optionId) => isMurlanOptionUnlocked(type, optionId, murlanOwned),
-      'domino-royal': (type, optionId) => isDominoOptionUnlocked(type, optionId, dominoOwned)
+      'domino-royal': (type, optionId) => isDominoOptionUnlocked(type, optionId, dominoOwned),
+      snake: (type, optionId) => isSnakeOptionUnlocked(type, optionId, snakeOwned)
     }),
-    [poolOwned, chessOwned, ludoOwned, murlanOwned, dominoOwned]
+    [poolOwned, chessOwned, ludoOwned, murlanOwned, dominoOwned, snakeOwned]
   );
 
   const labelResolvers = useMemo(
@@ -384,7 +448,8 @@ export default function Store() {
       chessbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       ludobattleroyal: (item) => LUDO_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       murlanroyale: (item) => MURLAN_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      'domino-royal': (item) => DOMINO_ROYAL_OPTION_LABELS[item.type]?.[item.optionId] || item.name
+      'domino-royal': (item) => DOMINO_ROYAL_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      snake: (item) => SNAKE_OPTION_LABELS[item.type]?.[item.optionId] || item.name
     }),
     []
   );
@@ -420,7 +485,8 @@ export default function Store() {
       chessbattleroyal: CHESS_STORE_ACCOUNT_ID,
       ludobattleroyal: LUDO_STORE_ACCOUNT_ID,
       murlanroyale: MURLAN_STORE_ACCOUNT_ID,
-      'domino-royal': DOMINO_STORE_ACCOUNT_ID
+      'domino-royal': DOMINO_STORE_ACCOUNT_ID,
+      snake: SNAKE_STORE_ACCOUNT_ID
     };
     const storeId = storeAccounts[activeSlug];
     if (!storeId) {
@@ -433,7 +499,8 @@ export default function Store() {
       chessbattleroyal: CHESS_BATTLE_OPTION_LABELS,
       ludobattleroyal: LUDO_BATTLE_OPTION_LABELS,
       murlanroyale: MURLAN_ROYALE_OPTION_LABELS,
-      'domino-royal': DOMINO_ROYAL_OPTION_LABELS
+      'domino-royal': DOMINO_ROYAL_OPTION_LABELS,
+      snake: SNAKE_OPTION_LABELS
     };
     const labels = labelMaps[activeSlug]?.[item.type] || {};
     const ownedLabel = labels[item.optionId] || item.name;
@@ -477,6 +544,10 @@ export default function Store() {
         const updatedInventory = addDominoRoyalUnlock(item.type, item.optionId, accountId);
         setDominoOwned(updatedInventory);
         setInfo(`${ownedLabel} purchased and added to your Domino Royal account.`);
+      } else if (activeSlug === 'snake') {
+        const updatedInventory = addSnakeUnlock(item.type, item.optionId, snakeAccountId(accountId));
+        setSnakeOwned(updatedInventory);
+        setInfo(`${ownedLabel} purchased and added to your Snake & Ladder account.`);
       }
 
       const bal = await getAccountBalance(accountId);
@@ -555,6 +626,7 @@ export default function Store() {
   const ludoOwnedOptions = useMemo(() => listOwnedLudoOptions(accountId), [accountId]);
   const murlanOwnedOptions = useMemo(() => listOwnedMurlanOptions(accountId), [accountId]);
   const dominoOwnedOptions = useMemo(() => listOwnedDominoOptions(accountId), [accountId]);
+  const snakeOwnedOptions = useMemo(() => listOwnedSnakeOptions(snakeAccountId(accountId)), [accountId]);
 
   const ownedItemLookup = useMemo(
     () => ({
@@ -562,9 +634,10 @@ export default function Store() {
       chessbattleroyal: chessOwnedOptions,
       ludobattleroyal: ludoOwnedOptions,
       murlanroyale: murlanOwnedOptions,
-      'domino-royal': dominoOwnedOptions
+      'domino-royal': dominoOwnedOptions,
+      snake: snakeOwnedOptions
     }),
-    [poolOwnedOptions, chessOwnedOptions, ludoOwnedOptions, murlanOwnedOptions, dominoOwnedOptions]
+    [poolOwnedOptions, chessOwnedOptions, ludoOwnedOptions, murlanOwnedOptions, dominoOwnedOptions, snakeOwnedOptions]
   );
 
   const hasStorefront = SUPPORTED_STORE_SLUGS.includes(activeSlug);
@@ -724,6 +797,76 @@ export default function Store() {
                             <p className="font-semibold text-lg leading-tight">{item.name}</p>
                             <p className="text-xs text-subtext">{item.description}</p>
                             <p className="text-xs text-subtext mt-1">Applies to: {DOMINO_TYPE_LABELS[item.type] || item.type}</p>
+                          </div>
+                          <div className="flex items-center gap-1 text-sm font-semibold">
+                            {item.price}
+                            <img src={TPC_ICON} alt="TPC" className="h-4 w-4" />
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => handlePurchase(item)}
+                          disabled={item.owned || processing === item.id}
+                          className={`buy-button mt-2 text-center ${
+                            item.owned || processing === item.id ? 'cursor-not-allowed opacity-60' : ''
+                          }`}
+                        >
+                          {item.owned
+                            ? `${ownedLabel} Owned`
+                            : processing === item.id
+                            ? 'Purchasing...'
+                            : `Purchase ${ownedLabel}`}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {activeSlug === 'snake' && (
+        <>
+          <div className="store-card max-w-2xl">
+            <h3 className="text-lg font-semibold">Snake &amp; Ladder Defaults (Free)</h3>
+            <p className="text-sm text-subtext">
+              The first option in each category stays unlocked. Buy the rest as NFTs to surface them inside the Snake &amp;
+              Ladder table setup menu.
+            </p>
+            <ul className="mt-2 space-y-1 w-full">
+              {snakeDefaultLoadout.map((item) => (
+                <li
+                  key={`snake-${item.type}-${item.optionId}`}
+                  className="flex items-center justify-between rounded-lg border border-border px-3 py-2 w-full"
+                >
+                  <span className="font-medium">{item.label}</span>
+                  <span className="text-xs uppercase text-subtext">{SNAKE_TYPE_LABELS[item.type] || item.type}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="w-full space-y-3">
+            <h3 className="text-lg font-semibold text-center">Snake &amp; Ladder Collection</h3>
+            {Object.entries(snakeGroupedItems).map(([type, items]) => (
+              <div key={type} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <h4 className="text-base font-semibold">{SNAKE_TYPE_LABELS[type] || type}</h4>
+                  <span className="text-xs text-subtext">NFT unlocks</span>
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  {items.map((item) => {
+                    const labels = SNAKE_OPTION_LABELS[item.type] || {};
+                    const ownedLabel = labels[item.optionId] || item.name;
+                    return (
+                      <div key={item.id} className="store-card">
+                        <div className="flex w-full items-start justify-between gap-2">
+                          <div>
+                            <p className="font-semibold text-lg leading-tight">{item.name}</p>
+                            <p className="text-xs text-subtext">{item.description}</p>
+                            <p className="text-xs text-subtext mt-1">Applies to: {SNAKE_TYPE_LABELS[item.type] || item.type}</p>
                           </div>
                           <div className="flex items-center gap-1 text-sm font-semibold">
                             {item.price}

--- a/webapp/src/utils/snakeInventory.js
+++ b/webapp/src/utils/snakeInventory.js
@@ -1,0 +1,112 @@
+import {
+  SNAKE_DEFAULT_LOADOUT,
+  SNAKE_DEFAULT_UNLOCKS,
+  SNAKE_OPTION_LABELS
+} from '../config/snakeInventoryConfig.js';
+
+const STORAGE_KEY = 'snakeInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(SNAKE_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values].filter(Boolean) : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read snake inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getSnakeInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isSnakeOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getSnakeInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addSnakeUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('snakeInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedSnakeOptions = (accountId) => {
+  const inventory = getSnakeInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = SNAKE_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultSnakeLoadout = () => [...SNAKE_DEFAULT_LOADOUT];
+
+export const snakeAccountId = resolveAccountId;


### PR DESCRIPTION
## Summary
- gate Snake & Ladder customization options behind NFT unlocks while keeping first options free
- add Snake & Ladder inventory storage and display in the store and My Account pages
- enable purchasing and marketplace visibility for Snake & Ladder cosmetics in the store

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dbf450664832991d8560ede6dd816)