### PR TITLE
Improve Pool Royale auto aim defaults

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -14984,6 +14984,54 @@ function PoolRoyaleGame({
             return evaluateShotOptionsBaseline();
           }
         };
+
+        const computeAutoAimFallback = () => {
+          if (!cue?.active) return null;
+          const stateSnapshot = frameRef.current ?? frameState;
+          const variantId = activeVariantRef.current?.id ?? variantKey;
+          const activeBalls = balls.filter((b) => b.active && b.id !== cue.id);
+          if (!activeBalls.length) return null;
+
+          const legalTargetsRaw = Array.isArray(stateSnapshot?.ballOn)
+            ? stateSnapshot.ballOn
+            : [];
+          const legalTargets = new Set(
+            legalTargetsRaw
+              .map((entry) => (typeof entry === 'string' ? entry.toUpperCase() : ''))
+              .filter(Boolean)
+          );
+          if (!legalTargets.size && (variantId === 'american' || variantId === '9ball')) {
+            const lowestActive = activeBalls.reduce(
+              (best, ball) => (best == null || ball.id < best.id ? ball : best),
+              null
+            );
+            const mapped = lowestActive ? toBallColorId(lowestActive.id) : null;
+            if (mapped) legalTargets.add(mapped.toUpperCase());
+          }
+
+          const matchesLegalTargets = (ball) => {
+            if (!legalTargets.size) return true;
+            const colorId = toBallColorId(ball.id);
+            if (!colorId) return false;
+            return legalTargets.has(colorId.toUpperCase());
+          };
+
+          let candidates = activeBalls.filter(matchesLegalTargets);
+          if (!candidates.length) candidates = activeBalls;
+
+          const targetBall = candidates.reduce((best, ball) => {
+            if (!best) return ball;
+            const bestDist = best.pos.distanceToSquared(cue.pos);
+            const dist = ball.pos.distanceToSquared(cue.pos);
+            return dist < bestDist ? ball : best;
+          }, null);
+
+          if (!targetBall) return null;
+          const aimDir = targetBall.pos.clone().sub(cue.pos);
+          if (aimDir.lengthSq() < 1e-6) aimDir.set(0, 1);
+          aimDir.normalize();
+          return { aimDir };
+        };
         const updateAiPlanningState = (plan, options, countdownSeconds) => {
           const summary = summarizePlan(plan);
           const potSummary = summarizePlan(options?.bestPot ?? null);
@@ -15082,6 +15130,12 @@ function PoolRoyaleGame({
               suggestionAimKeyRef.current = null;
             }
           } else {
+            const fallbackAim = computeAutoAimFallback();
+            if (fallbackAim?.aimDir) {
+              aimDirRef.current.copy(fallbackAim.aimDir);
+              alignStandingCameraToAim(cue, fallbackAim.aimDir);
+              autoAimRequestRef.current = false;
+            }
             suggestionAimKeyRef.current = null;
           }
         };


### PR DESCRIPTION
## Summary
- add an auto-aim fallback that targets the nearest legal object ball for faster setup
- reuse the fallback when player suggestions are unavailable so the cue points at the rack or owned balls by default

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dc74b4f4483299aac76ee68f39581)