### PR TITLE
Add NFT-gated cosmetics to blackjack

### DIFF
--- a/webapp/src/config/blackjackInventoryConfig.js
+++ b/webapp/src/config/blackjackInventoryConfig.js
@@ -1,0 +1,98 @@
+import { TABLE_WOOD_OPTIONS, TABLE_CLOTH_OPTIONS } from '../utils/tableCustomizationOptions.js';
+import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
+import { CARD_THEMES } from '../utils/cards3d.js';
+import { CHAIR_COLOR_OPTIONS } from './blackjackOptions.js';
+
+const DEFAULT_TABLE_SHAPE_ID = TABLE_SHAPE_OPTIONS[0]?.id;
+
+export const BLACKJACK_DEFAULT_UNLOCKS = Object.freeze({
+  tableWood: [TABLE_WOOD_OPTIONS[0]?.id],
+  tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
+  chairColor: [CHAIR_COLOR_OPTIONS[0]?.id],
+  tableShape: [DEFAULT_TABLE_SHAPE_ID],
+  cards: [CARD_THEMES[0]?.id]
+});
+
+export const BLACKJACK_OPTION_LABELS = Object.freeze({
+  tableWood: Object.freeze(
+    TABLE_WOOD_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableCloth: Object.freeze(
+    TABLE_CLOTH_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  chairColor: Object.freeze(
+    CHAIR_COLOR_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableShape: Object.freeze(
+    TABLE_SHAPE_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  cards: Object.freeze(
+    CARD_THEMES.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  )
+});
+
+export const BLACKJACK_STORE_ITEMS = [
+  ...TABLE_WOOD_OPTIONS.slice(1).map((option, idx) => ({
+    id: `blackjack-wood-${option.id}`,
+    type: 'tableWood',
+    optionId: option.id,
+    name: option.label,
+    price: 440 + idx * 35,
+    description: 'Premium blackjack table wood finish.'
+  })),
+  ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
+    id: `blackjack-cloth-${option.id}`,
+    type: 'tableCloth',
+    optionId: option.id,
+    name: option.label,
+    price: 320 + idx * 30,
+    description: 'Alternate felt palette for your blackjack arena.'
+  })),
+  ...CHAIR_COLOR_OPTIONS.slice(1).map((option, idx) => ({
+    id: `blackjack-chair-${option.id}`,
+    type: 'chairColor',
+    optionId: option.id,
+    name: `${option.label} Chairs`,
+    price: 280 + idx * 25,
+    description: 'Unlocks an extra lounge chair finish for the table.'
+  })),
+  ...TABLE_SHAPE_OPTIONS.slice(1).map((option, idx) => ({
+    id: `blackjack-shape-${option.id}`,
+    type: 'tableShape',
+    optionId: option.id,
+    name: `${option.label} Shape`,
+    price: 650 + idx * 45,
+    description: 'Adds an extra table silhouette to the setup menu.'
+  })),
+  ...CARD_THEMES.slice(1).map((option, idx) => ({
+    id: `blackjack-cards-${option.id}`,
+    type: 'cards',
+    optionId: option.id,
+    name: `${option.label} Deck`,
+    price: 360 + idx * 28,
+    description: 'New card back and face style for blackjack hands.'
+  }))
+];
+
+export const BLACKJACK_DEFAULT_LOADOUT = [
+  { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0]?.id, label: TABLE_WOOD_OPTIONS[0]?.label },
+  { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
+  { type: 'chairColor', optionId: CHAIR_COLOR_OPTIONS[0]?.id, label: CHAIR_COLOR_OPTIONS[0]?.label },
+  { type: 'tableShape', optionId: DEFAULT_TABLE_SHAPE_ID, label: BLACKJACK_OPTION_LABELS.tableShape[DEFAULT_TABLE_SHAPE_ID] },
+  { type: 'cards', optionId: CARD_THEMES[0]?.id, label: CARD_THEMES[0]?.label }
+];

--- a/webapp/src/config/blackjackOptions.js
+++ b/webapp/src/config/blackjackOptions.js
@@ -1,0 +1,8 @@
+export const CHAIR_COLOR_OPTIONS = Object.freeze([
+  { id: 'ruby', label: 'Ruby', primary: '#8b0000', accent: '#8b0000', highlight: '#b22222', legColor: '#1f1f1f' },
+  { id: 'slate', label: 'Slate', primary: '#374151', accent: '#374151', highlight: '#6b7280', legColor: '#0f172a' },
+  { id: 'teal', label: 'Teal', primary: '#0f766e', accent: '#0f766e', highlight: '#38b2ac', legColor: '#082f2a' },
+  { id: 'amber', label: 'Amber', primary: '#b45309', accent: '#b45309', highlight: '#f59e0b', legColor: '#2f2410' },
+  { id: 'violet', label: 'Violet', primary: '#7c3aed', accent: '#7c3aed', highlight: '#c084fc', legColor: '#2b1059' },
+  { id: 'frost', label: 'Ice', primary: '#1f2937', accent: '#1f2937', highlight: '#9ca3af', legColor: '#0f172a' }
+]);

--- a/webapp/src/utils/blackjackInventory.js
+++ b/webapp/src/utils/blackjackInventory.js
@@ -1,0 +1,112 @@
+import {
+  BLACKJACK_DEFAULT_LOADOUT,
+  BLACKJACK_DEFAULT_UNLOCKS,
+  BLACKJACK_OPTION_LABELS
+} from '../config/blackjackInventoryConfig.js';
+
+const STORAGE_KEY = 'blackjackInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(BLACKJACK_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values].filter(Boolean) : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read blackjack inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getBlackjackInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isBlackjackOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getBlackjackInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addBlackjackUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('blackjackInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedBlackjackOptions = (accountId) => {
+  const inventory = getBlackjackInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = BLACKJACK_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultBlackjackLoadout = () => [...BLACKJACK_DEFAULT_LOADOUT];
+
+export const blackjackAccountId = resolveAccountId;


### PR DESCRIPTION
## Summary
- add blackjack cosmetic inventory config, storage helpers, and store listings as NFT unlocks
- gate blackjack table setup options to owned items while keeping first options free by default
- expose new blackjack store tab with purchasable cosmetics that unlock in the setup menu

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dca76b1e88329b71dad8222002466)