### PR TITLE
Add Texas Hold'em cosmetic unlock flow

### DIFF
--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -1,0 +1,88 @@
+import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../utils/tableCustomizationOptions.js';
+import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
+import { CARD_THEMES } from '../utils/cards3d.js';
+import { TEXAS_CHAIR_COLOR_OPTIONS } from './texasHoldemOptions.js';
+
+const reduceLabels = (items) =>
+  items.reduce((acc, option) => {
+    acc[option.id] = option.label;
+    return acc;
+  }, {});
+
+export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
+  tableWood: [TABLE_WOOD_OPTIONS[0]?.id],
+  tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
+  tableBase: [TABLE_BASE_OPTIONS[0]?.id],
+  chairColor: [TEXAS_CHAIR_COLOR_OPTIONS[0]?.id],
+  tableShape: [TABLE_SHAPE_OPTIONS[0]?.id],
+  cards: [CARD_THEMES[0]?.id]
+});
+
+export const TEXAS_HOLDEM_OPTION_LABELS = Object.freeze({
+  tableWood: Object.freeze(reduceLabels(TABLE_WOOD_OPTIONS)),
+  tableCloth: Object.freeze(reduceLabels(TABLE_CLOTH_OPTIONS)),
+  tableBase: Object.freeze(reduceLabels(TABLE_BASE_OPTIONS)),
+  chairColor: Object.freeze(reduceLabels(TEXAS_CHAIR_COLOR_OPTIONS)),
+  tableShape: Object.freeze(reduceLabels(TABLE_SHAPE_OPTIONS)),
+  cards: Object.freeze(reduceLabels(CARD_THEMES))
+});
+
+export const TEXAS_HOLDEM_STORE_ITEMS = [
+  ...TABLE_WOOD_OPTIONS.slice(1).map((option, idx) => ({
+    id: `texas-wood-${option.id}`,
+    type: 'tableWood',
+    optionId: option.id,
+    name: option.label,
+    price: 540 + idx * 40,
+    description: "Unlock an alternate wood finish for your Hold'em arena table."
+  })),
+  ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
+    id: `texas-cloth-${option.id}`,
+    type: 'tableCloth',
+    optionId: option.id,
+    name: option.label,
+    price: 360 + idx * 35,
+    description: "Swap in a premium felt tone for your poker table."
+  })),
+  ...TABLE_BASE_OPTIONS.slice(1).map((option, idx) => ({
+    id: `texas-base-${option.id}`,
+    type: 'tableBase',
+    optionId: option.id,
+    name: option.label,
+    price: 420 + idx * 35,
+    description: 'Upgrade the pedestal finish beneath your Hold\'em surface.'
+  })),
+  ...TEXAS_CHAIR_COLOR_OPTIONS.slice(1).map((option, idx) => ({
+    id: `texas-chair-${option.id}`,
+    type: 'chairColor',
+    optionId: option.id,
+    name: `${option.label} Chairs`,
+    price: 340 + idx * 30,
+    description: 'Unlock an additional lounge chair palette for the poker ring.'
+  })),
+  ...TABLE_SHAPE_OPTIONS.slice(1).map((option, idx) => ({
+    id: `texas-shape-${option.id}`,
+    type: 'tableShape',
+    optionId: option.id,
+    name: option.label,
+    price: 680 + idx * 80,
+    description: 'Change the poker table silhouette.'
+  })),
+  ...CARD_THEMES.slice(1).map((option, idx) => ({
+    id: `texas-card-${option.id}`,
+    type: 'cards',
+    optionId: option.id,
+    name: `${option.label} Cards`,
+    price: 460 + idx * 35,
+    description: 'Add a fresh premium deck style to the arena.'
+  }))
+];
+
+export const TEXAS_HOLDEM_DEFAULT_LOADOUT = [
+  { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0]?.id, label: TABLE_WOOD_OPTIONS[0]?.label },
+  { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
+  { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0]?.id, label: TABLE_BASE_OPTIONS[0]?.label },
+  { type: 'chairColor', optionId: TEXAS_CHAIR_COLOR_OPTIONS[0]?.id, label: `${TEXAS_CHAIR_COLOR_OPTIONS[0]?.label} Chairs` },
+  { type: 'tableShape', optionId: TABLE_SHAPE_OPTIONS[0]?.id, label: TABLE_SHAPE_OPTIONS[0]?.label },
+  { type: 'cards', optionId: CARD_THEMES[0]?.id, label: `${CARD_THEMES[0]?.label} Cards` }
+];

--- a/webapp/src/config/texasHoldemOptions.js
+++ b/webapp/src/config/texasHoldemOptions.js
@@ -1,0 +1,8 @@
+export const TEXAS_CHAIR_COLOR_OPTIONS = Object.freeze([
+  { id: 'ruby', label: 'Ruby', primary: '#8b0000', accent: '#8b0000', highlight: '#b22222', legColor: '#1f1f1f' },
+  { id: 'slate', label: 'Slate', primary: '#374151', accent: '#374151', highlight: '#6b7280', legColor: '#0f172a' },
+  { id: 'teal', label: 'Teal', primary: '#0f766e', accent: '#0f766e', highlight: '#38b2ac', legColor: '#082f2a' },
+  { id: 'amber', label: 'Amber', primary: '#b45309', accent: '#b45309', highlight: '#f59e0b', legColor: '#2f2410' },
+  { id: 'violet', label: 'Violet', primary: '#7c3aed', accent: '#7c3aed', highlight: '#c084fc', legColor: '#2b1059' },
+  { id: 'frost', label: 'Ice', primary: '#1f2937', accent: '#1f2937', highlight: '#9ca3af', legColor: '#0f172a' }
+]);

--- a/webapp/src/utils/texasHoldemInventory.js
+++ b/webapp/src/utils/texasHoldemInventory.js
@@ -1,0 +1,112 @@
+import {
+  TEXAS_HOLDEM_DEFAULT_LOADOUT,
+  TEXAS_HOLDEM_DEFAULT_UNLOCKS,
+  TEXAS_HOLDEM_OPTION_LABELS
+} from '../config/texasHoldemInventoryConfig.js';
+
+const STORAGE_KEY = 'texasHoldemInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(TEXAS_HOLDEM_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values].filter(Boolean) : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn("Failed to read Texas Hold'em inventory, resetting", err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getTexasHoldemInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isTexasOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getTexasHoldemInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addTexasHoldemUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('texasHoldemInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedTexasOptions = (accountId) => {
+  const inventory = getTexasHoldemInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = TEXAS_HOLDEM_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultTexasHoldemLoadout = () => [...TEXAS_HOLDEM_DEFAULT_LOADOUT];
+
+export const texasHoldemAccountId = resolveAccountId;


### PR DESCRIPTION
## Summary
- add Texas Hold'em inventory config and utilities to gate cosmetics behind NFT ownership
- integrate Texas Hold'em items into the store with free defaults and purchasable unlocks
- update the poker table setup UI to surface only unlocked options and react to new purchases

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dcdd838488329831514dd3d425948)