### PR TITLE
Add NFT unlock flow for Snooker Club customizations

### DIFF
--- a/webapp/src/config/snookerClubInventoryConfig.js
+++ b/webapp/src/config/snookerClubInventoryConfig.js
@@ -1,0 +1,131 @@
+import { CUE_STYLE_PRESETS } from './cueStyles.js';
+
+export const SNOOKER_CLUB_DEFAULT_UNLOCKS = Object.freeze({
+  tableFinish: ['rusticSplit'],
+  chromeColor: ['chrome'],
+  railMarkerColor: ['chrome'],
+  clothColor: ['freshGreen'],
+  cueStyle: [CUE_STYLE_PRESETS[0]?.id],
+  pocketLiner: ['blackPocket']
+});
+
+export const SNOOKER_CLUB_OPTION_LABELS = Object.freeze({
+  tableFinish: Object.freeze({
+    rusticSplit: 'Pearl Cream',
+    charredTimber: 'Charred Timber',
+    plankStudio: 'Plank Studio',
+    weatheredGrey: 'Weathered Grey',
+    jetBlackCarbon: 'Jet Black Carbon'
+  }),
+  chromeColor: Object.freeze({
+    chrome: 'Chrome',
+    gold: 'Gold'
+  }),
+  railMarkerColor: Object.freeze({
+    chrome: 'Chrome',
+    pearl: 'Pearl',
+    gold: 'Gold'
+  }),
+  clothColor: Object.freeze({
+    freshGreen: 'Tour Green',
+    graphite: 'Arcadia Graphite',
+    arcticBlue: 'Arctic Blue'
+  }),
+  cueStyle: Object.freeze(
+    CUE_STYLE_PRESETS.reduce((acc, preset) => {
+      acc[preset.id] = preset.label;
+      return acc;
+    }, {})
+  )
+});
+
+export const SNOOKER_CLUB_STORE_ITEMS = [
+  {
+    id: 'snooker-finish-charredTimber',
+    type: 'tableFinish',
+    optionId: 'charredTimber',
+    name: 'Charred Timber Finish',
+    price: 880,
+    description: 'Dark burned timber rails with rich contrast trim.'
+  },
+  {
+    id: 'snooker-finish-plankStudio',
+    type: 'tableFinish',
+    optionId: 'plankStudio',
+    name: 'Plank Studio Finish',
+    price: 930,
+    description: 'Crisp plank-style oak studio rails with satin sheen.'
+  },
+  {
+    id: 'snooker-finish-weatheredGrey',
+    type: 'tableFinish',
+    optionId: 'weatheredGrey',
+    name: 'Weathered Grey Finish',
+    price: 960,
+    description: 'Driftwood grey rails with softened grain highlights.'
+  },
+  {
+    id: 'snooker-finish-jetBlack',
+    type: 'tableFinish',
+    optionId: 'jetBlackCarbon',
+    name: 'Jet Black Carbon Finish',
+    price: 1040,
+    description: 'Matte carbon-inspired rails with smoked metallic trim.'
+  },
+  {
+    id: 'snooker-chrome-gold',
+    type: 'chromeColor',
+    optionId: 'gold',
+    name: 'Gold Fascias',
+    price: 420,
+    description: 'Gold-plated chrome plates for the fascia set.'
+  },
+  {
+    id: 'snooker-railMarkers-pearl',
+    type: 'railMarkerColor',
+    optionId: 'pearl',
+    name: 'Pearl Rail Markers',
+    price: 310,
+    description: 'Pearlescent rail diamonds with soft sheen.'
+  },
+  {
+    id: 'snooker-railMarkers-gold',
+    type: 'railMarkerColor',
+    optionId: 'gold',
+    name: 'Gold Rail Markers',
+    price: 340,
+    description: 'Gold rail diamonds to match premium fascias.'
+  },
+  {
+    id: 'snooker-cloth-graphite',
+    type: 'clothColor',
+    optionId: 'graphite',
+    name: 'Arcadia Graphite Cloth',
+    price: 560,
+    description: 'Tournament graphite cloth for a darker arena mood.'
+  },
+  {
+    id: 'snooker-cloth-arcticBlue',
+    type: 'clothColor',
+    optionId: 'arcticBlue',
+    name: 'Arctic Blue Cloth',
+    price: 590,
+    description: 'Cool arctic blue cloth with crisp broadcast sheen.'
+  },
+  ...CUE_STYLE_PRESETS.slice(1).map((preset, idx) => ({
+    id: `snooker-cue-${preset.id}`,
+    type: 'cueStyle',
+    optionId: preset.id,
+    name: `${preset.label} Cue`,
+    price: 320 + idx * 25,
+    description: 'Unlock an alternate cue butt finish for Snooker Club.'
+  }))
+];
+
+export const SNOOKER_CLUB_DEFAULT_LOADOUT = [
+  { type: 'tableFinish', optionId: 'rusticSplit', label: 'Pearl Cream Finish' },
+  { type: 'chromeColor', optionId: 'chrome', label: 'Chrome Fascias' },
+  { type: 'railMarkerColor', optionId: 'chrome', label: 'Chrome Rail Markers' },
+  { type: 'clothColor', optionId: 'freshGreen', label: 'Tour Green Cloth' },
+  { type: 'cueStyle', optionId: CUE_STYLE_PRESETS[0]?.id, label: CUE_STYLE_PRESETS[0]?.label }
+];

--- a/webapp/src/utils/snookerClubInventory.js
+++ b/webapp/src/utils/snookerClubInventory.js
@@ -1,0 +1,112 @@
+import {
+  SNOOKER_CLUB_DEFAULT_LOADOUT,
+  SNOOKER_CLUB_DEFAULT_UNLOCKS,
+  SNOOKER_CLUB_OPTION_LABELS
+} from '../config/snookerClubInventoryConfig.js';
+
+const STORAGE_KEY = 'snookerClubInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(SNOOKER_CLUB_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values] : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read snooker inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getSnookerClubInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isSnookerOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getSnookerClubInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addSnookerClubUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('snookerClubInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedSnookerOptions = (accountId) => {
+  const inventory = getSnookerClubInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = SNOOKER_CLUB_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultSnookerLoadout = () => [...SNOOKER_CLUB_DEFAULT_LOADOUT];
+
+export const snookerClubAccountId = resolveAccountId;


### PR DESCRIPTION
## Summary
- add Snooker Club inventory config and persistence for gated table customizations
- gate Snooker Club setup options behind NFT unlocks and surface purchased items in the UI
- expose Snooker Club cosmetics in the store alongside marketplace tooling

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dd2b7938483299e61784c45bb5db4)