### PR TITLE
Refine store list layout with detail modal

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -468,6 +468,7 @@ export default function Store() {
   const [showListModal, setShowListModal] = useState(false);
   const [listForm, setListForm] = useState(() => ({ ...DEFAULT_LIST_FORM }));
   const [showMyListings, setShowMyListings] = useState(false);
+  const [selectedItem, setSelectedItem] = useState(null);
 
   useEffect(() => {
     setAccountId(poolRoyalAccountId());
@@ -1015,6 +1016,124 @@ export default function Store() {
     );
   };
 
+  const renderDetailModal = () => {
+    if (!selectedItem) return null;
+
+    return (
+      <div className="fixed inset-0 z-40 flex items-start justify-center bg-black/70 px-3 py-6 backdrop-blur">
+        <div className="relative w-full max-w-3xl overflow-hidden rounded-3xl border border-white/10 bg-zinc-950/90 p-5 shadow-xl">
+          <button
+            type="button"
+            onClick={() => setSelectedItem(null)}
+            className="absolute right-4 top-4 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-xs font-semibold text-white/70 hover:bg-white/10"
+          >
+            Close
+          </button>
+
+          <div className="flex flex-col gap-4 md:flex-row md:items-start">
+            <div className="flex-1 space-y-3">
+              <div className="flex items-center gap-3">
+                <div className="grid h-12 w-12 place-items-center rounded-2xl bg-black/40 text-lg font-semibold">
+                  {selectedItem.gameName[0]}
+                </div>
+                <div>
+                  <div className="flex items-center gap-2 text-lg font-semibold text-white">
+                    {selectedItem.displayLabel}
+                    {selectedItem.owned ? (
+                      <span className="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 text-[11px] font-semibold text-emerald-200">
+                        Owned
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="text-sm text-white/60">
+                    {selectedItem.gameName} • {selectedItem.typeLabel}
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid gap-2 rounded-2xl border border-white/10 bg-black/30 p-3 text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="text-white/60">Price</span>
+                  <span className="flex items-center gap-1 text-base font-semibold text-white">
+                    {selectedItem.price}
+                    <img src={TPC_ICON} alt="TPC" className="h-4 w-4" />
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-white/70">
+                  <span>Status</span>
+                  <span className={selectedItem.owned ? 'text-emerald-200' : 'text-indigo-100'}>
+                    {selectedItem.owned ? 'In your inventory' : 'Mintable'}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-white/70">
+                  <span>Seller</span>
+                  <span className="text-white/80">{selectedItem.seller || 'Official store'}</span>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <div className="text-xs font-semibold text-white/70">Color samples</div>
+                <div className="flex flex-wrap items-center gap-1">
+                  {(selectedItem.swatches || []).slice(0, 6).map((color, index) => (
+                    <span
+                      key={`${selectedItem.id}-detail-swatch-${color}-${index}`}
+                      className="h-5 w-5 rounded-full border border-white/20 shadow-sm"
+                      style={{ backgroundColor: color }}
+                      title={color}
+                    />
+                  ))}
+                  {(!selectedItem.swatches || selectedItem.swatches.length === 0) && (
+                    <span className="text-xs text-white/60">No swatches available</span>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-2 text-xs font-semibold">
+                <span className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-white/80">
+                  {selectedItem.slug.replace('-', ' ')}
+                </span>
+                <span className="rounded-full border border-white/10 bg-black/20 px-2.5 py-1 text-white/60">
+                  {selectedItem.typeLabel}
+                </span>
+                <span
+                  className={`rounded-full border px-2.5 py-1 ${
+                    selectedItem.owned
+                      ? 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200'
+                      : 'border-indigo-400/30 bg-indigo-400/10 text-indigo-100'
+                  }`}
+                >
+                  {selectedItem.owned ? 'Already owned' : 'Available to mint'}
+                </span>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setConfirmItem(selectedItem)}
+                  className="flex items-center gap-2 rounded-2xl bg-white px-4 py-2 text-sm font-semibold text-zinc-950 hover:bg-white/90"
+                >
+                  Buy with TPC
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setSelectedItem(null)}
+                  className="rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white/80 hover:bg-white/10"
+                >
+                  Close details
+                </button>
+              </div>
+            </div>
+
+            <div className="w-full max-w-md rounded-2xl border border-white/10 bg-black/20 p-3">
+              <div className="text-xs font-semibold text-white/60">Preview</div>
+              <div className="mt-2">{renderPreview3d(selectedItem)}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   const renderPreview3d = (item, showCaption = true) => {
     if (!item) return null;
     const previewShape = item.previewShape || 'default';
@@ -1461,77 +1580,67 @@ export default function Store() {
             </button>
           </div>
 
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="flex flex-col gap-2">
             {visibleItems.map((item) => (
-              <button
+              <div
                 key={`${item.slug}-${item.id}`}
-                onClick={() => setConfirmItem(item)}
-                className="group flex flex-col gap-3 overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-4 text-left shadow-sm transition hover:bg-white/10"
+                className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-4 text-left shadow-sm transition hover:bg-white/10 sm:flex-row sm:items-center sm:justify-between"
               >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="flex items-center gap-3">
-                    <div className="grid h-12 w-12 place-items-center rounded-2xl bg-black/30 text-lg font-semibold">
-                      {item.gameName[0]}
+                <div className="flex flex-1 items-center gap-3">
+                  <div className="grid h-12 w-12 place-items-center rounded-2xl bg-black/30 text-lg font-semibold">
+                    {item.gameName[0]}
+                  </div>
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <div className="text-sm font-semibold">{item.displayLabel}</div>
+                      {item.owned ? (
+                        <span className="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 text-[10px] font-semibold text-emerald-200">
+                          Owned
+                        </span>
+                      ) : null}
                     </div>
-                    <div className="space-y-1">
-                      <div className="flex items-center gap-2">
-                        <div className="text-sm font-semibold">{item.displayLabel}</div>
-                        {item.owned && (
-                          <span className="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 text-[10px] font-semibold text-emerald-200">
-                            Owned
-                          </span>
-                        )}
-                      </div>
-                      <div className="text-xs text-white/60">{item.gameName} | {item.typeLabel}</div>
+                    <div className="text-xs text-white/60">{item.gameName} • {item.typeLabel}</div>
+                    <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold text-white/70">
+                      <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">{item.slug.replace('-', ' ')}</span>
+                      <span
+                        className={`rounded-full border px-2 py-1 ${
+                          item.owned
+                            ? 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200'
+                            : 'border-indigo-400/30 bg-indigo-400/10 text-indigo-100'
+                        }`}
+                      >
+                        {item.owned ? 'In inventory' : 'Mintable'}
+                      </span>
                     </div>
                   </div>
-                  <div className="text-right">
+                </div>
+
+                <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-4">
+                  <div className="text-left sm:text-right">
                     <div className="text-xs text-white/60">Price</div>
-                    <div className="flex items-center gap-1 text-sm font-semibold">
+                    <div className="flex items-center gap-1 text-sm font-semibold text-white">
                       {item.price}
                       <img src={TPC_ICON} alt="TPC" className="h-4 w-4" />
                     </div>
                   </div>
-                </div>
-
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-xs font-semibold text-white/80">
-                    {item.slug.replace('-', ' ')}
-                  </span>
-                  <span className="rounded-full border border-white/10 bg-black/20 px-2.5 py-1 text-xs font-semibold text-white/60">
-                    {item.typeLabel}
-                  </span>
-                  <span
-                    className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${
-                      item.owned ? 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200' : 'border-indigo-400/30 bg-indigo-400/10 text-indigo-100'
-                    }`}
-                  >
-                    {item.owned ? 'In inventory' : 'Mintable'}
-                  </span>
-                </div>
-
-                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                  <div className="flex flex-wrap items-center gap-1">
-                    {(item.swatches || []).slice(0, 5).map((color, index) => (
-                      <span
-                        key={`${item.id}-swatch-${color}-${index}`}
-                        className="h-4 w-4 rounded-full border border-white/20 shadow-sm"
-                        style={{ backgroundColor: color }}
-                        title={color}
-                      />
-                    ))}
-                    {(!item.swatches || item.swatches.length === 0) && (
-                      <span className="text-xs text-white/60">Color samples unavailable</span>
-                    )}
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setConfirmItem(item)}
+                      className="rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-semibold text-white/80 hover:bg-white/10"
+                    >
+                      Quick buy
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedItem(item)}
+                      className="rounded-2xl bg-white px-4 py-2 text-sm font-semibold text-zinc-950 hover:bg-white/90"
+                    >
+                      View
+                    </button>
                   </div>
-                  <div className="w-full md:w-auto">{renderPreview3d(item)}</div>
                 </div>
-
-                <div className="flex items-center justify-between text-xs text-white/60">
-                  <div>Seller: {item.seller || 'Official store'}</div>
-                  <div className="group-hover:text-white/80">Tap to view details</div>
-                </div>
-              </button>
+              </div>
             ))}
           </div>
 
@@ -1560,6 +1669,7 @@ export default function Store() {
       </main>
 
       {renderListModal()}
+      {renderDetailModal()}
       {renderConfirmModal()}
     </div>
   );


### PR DESCRIPTION
## Summary
- switch the store grid to a compact list layout that highlights essential item info
- add a detail modal so tapping view shows the full card with preview, swatches, and badges
- keep quick buy access while simplifying the main marketplace feed

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e6267552c832999fae64a5bfa6ca2)