### PR TITLE
Lower cushions to align with rails

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -956,7 +956,7 @@ const CLOTH_EDGE_EMISSIVE_MULTIPLIER = 0.02; // soften light spill on the sleeve
 const CLOTH_EDGE_EMISSIVE_INTENSITY = 0.24; // further dim emissive brightness so the cutouts stay consistent with the cloth plane
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
 const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.118; // sink the cushion base further so the pads settle slightly below the rail line
-const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.128; // trim the cushion tops more so chalks and diamonds stay visible above the pads
+const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.158; // trim the cushion tops further so they sit level with the raised wood rails
 const CUSHION_FIELD_CLIP_RATIO = 0.14; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
@@ -5334,10 +5334,13 @@ function alignRailsToCushions(table, frame) {
   if (!sampleCushion) return;
   const cushionBox = new THREE.Box3().setFromObject(sampleCushion);
   const frameBox = new THREE.Box3().setFromObject(frame);
-  const diff = frameBox.max.y - cushionBox.max.y;
+  const cushionAbove = cushionBox.max.y - frameBox.max.y;
   const tolerance = 1e-3;
-  if (Math.abs(diff) > tolerance) {
-    frame.position.y -= diff;
+
+  // Only raise the rails when cushions sit higher. Avoid lowering the frame
+  // when cushions are trimmed down so the wood can stay level with the pads.
+  if (cushionAbove > tolerance) {
+    frame.position.y += cushionAbove;
   }
 }
 


### PR DESCRIPTION
## Summary
- lower the cushion tops so they sit level with the wood rails
- adjust rail alignment to only raise rails when cushions sit high, avoiding automatic lowering

## Testing
- npm test -- --runInBand *(fails: jest config expects missing tests directory)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e6d2b96048329bd6d1d916e8c6a88)