### PR TITLE
Fix rail alignment to cushion height

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -5376,7 +5376,8 @@ function alignRailsToCushions(table, frame) {
   const sampleCushion = table.userData.cushions[0];
   if (!sampleCushion) return;
   const cushionBox = new THREE.Box3().setFromObject(sampleCushion);
-  const frameBox = new THREE.Box3().setFromObject(frame);
+  const frameTarget = frame.userData?.railTopMesh ?? frame;
+  const frameBox = new THREE.Box3().setFromObject(frameTarget);
   const diff = frameBox.max.y - cushionBox.max.y;
   const tolerance = 1e-3;
   if (Math.abs(diff) > tolerance) {
@@ -7288,6 +7289,7 @@ function Table3D(
   railsMesh.castShadow = true;
   railsMesh.receiveShadow = true;
   railsGroup.add(railsMesh);
+  railsGroup.userData.railTopMesh = railsMesh;
   finishParts.railMeshes.push(railsMesh);
 
   let activeRailMarkerStyle =


### PR DESCRIPTION
## Summary
- use the wooden rail mesh to align rail height to the cushions
- store a reference to the rail mesh so alignment ignores raised ornaments

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e7fbc9b808329b47d601bda29f1b9)