### PR TITLE
Align cue stick with cue ball and slider pull

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4378,6 +4378,7 @@ const TMP_VEC2_LIMIT = new THREE.Vector2();
 const TMP_VEC2_AXIS = new THREE.Vector2();
 const TMP_VEC2_VIEW = new THREE.Vector2();
 const TMP_VEC3_A = new THREE.Vector3();
+const TMP_VEC3_TIP = new THREE.Vector3();
 const TMP_VEC3_BUTT = new THREE.Vector3();
 const TMP_VEC3_CHALK = new THREE.Vector3();
 const TMP_VEC3_CHALK_DELTA = new THREE.Vector3();
@@ -15848,11 +15849,12 @@ function PoolRoyaleGame({
             vert,
             perp.z * side
           );
-          cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.x,
+          const tipTarget = TMP_VEC3_TIP.set(
+            cue.pos.x + spinWorld.x - dir.x * (BALL_R + CUE_TIP_GAP + pull),
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y + spinWorld.z - dir.z * (BALL_R + CUE_TIP_GAP + pull)
           );
+          cueStick.position.copy(tipTarget).addScaledVector(dir, cueLen / 2);
           const tiltAmount = Math.abs(appliedSpin.y || 0);
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
           applyCueButtTilt(cueStick, extraTilt);
@@ -15860,11 +15862,7 @@ function PoolRoyaleGame({
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
-          TMP_VEC3_BUTT.set(
-            cue.pos.x - dir.x * (cueLen + pull + CUE_TIP_GAP) + spinWorld.x,
-            CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen + pull + CUE_TIP_GAP) + spinWorld.z
-          );
+          TMP_VEC3_BUTT.copy(tipTarget).addScaledVector(dir, cueLen);
           let visibleChalkIndex = null;
           const chalkMeta = table.userData?.chalkMeta;
           if (chalkMeta) {
@@ -16044,11 +16042,12 @@ function PoolRoyaleGame({
             }
           }
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
-          cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.x,
+          const tipTarget = TMP_VEC3_TIP.set(
+            cue.pos.x + spinWorld.x - dir.x * (BALL_R + CUE_TIP_GAP + pull),
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y + spinWorld.z - dir.z * (BALL_R + CUE_TIP_GAP + pull)
           );
+          cueStick.position.copy(tipTarget).addScaledVector(dir, cueLen / 2);
           const tiltAmount = Math.abs(spinY);
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);
           applyCueButtTilt(cueStick, extraTilt);


### PR DESCRIPTION
## Summary
- position the cue stick from a tip target on the cue ball so the tip aligns with aim and spin offsets
- update butt tracking to follow the new cue placement and maintain chalk visibility logic
- base cue placement on pull distance to make slider-driven pullback and forward shot motion clearer

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ea6f05e848329a304753cc1f5fe7b)