### PR TITLE
Protect dev balances and audit anonymous accounts

### DIFF
--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -24,6 +24,12 @@ const router = Router();
 router.post('/create', async (req, res) => {
   const { telegramId, googleId } = req.body;
 
+  if (!telegramId && !googleId) {
+    return res
+      .status(400)
+      .json({ error: 'telegramId or googleId is required to create an account' });
+  }
+
   try {
     let user;
     let telegramProfile = null;
@@ -82,7 +88,7 @@ router.post('/create', async (req, res) => {
         }
         if (updated) await user.save();
       }
-    } else if (googleId) {
+    } else {
       user = await User.findOne({ googleId });
       if (!user) {
         const wallet = await generateWalletAddress();
@@ -108,16 +114,6 @@ router.post('/create', async (req, res) => {
         }
         if (updated) await user.save();
       }
-    } else {
-      const wallet = await generateWalletAddress();
-      const id = uuidv4();
-      user = new User({
-        accountId: id,
-        referralCode: id,
-        walletAddress: wallet.address,
-        walletPublicKey: wallet.publicKey
-      });
-      await user.save();
     }
 
     res.json({

--- a/bot/scripts/findAnonymousAccounts.js
+++ b/bot/scripts/findAnonymousAccounts.js
@@ -1,0 +1,58 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import User from '../models/User.js';
+
+dotenv.config();
+
+const uri = process.env.MONGO_URI;
+if (!uri || uri === 'memory') {
+  console.error('MONGO_URI must be set to a MongoDB instance');
+  process.exit(1);
+}
+
+await mongoose.connect(uri);
+
+const anonymousQuery = {
+  telegramId: { $exists: false },
+  googleId: { $exists: false },
+  nickname: { $in: [null, ''] },
+  firstName: { $in: [null, ''] },
+  lastName: { $in: [null, ''] }
+};
+
+const totalAnonymous = await User.countDocuments(anonymousQuery);
+console.log(`Accounts without identity information: ${totalAnonymous}`);
+
+const dailyBreakdown = await User.aggregate([
+  { $match: anonymousQuery },
+  {
+    $group: {
+      _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } },
+      count: { $sum: 1 }
+    }
+  },
+  { $sort: { _id: 1 } }
+]);
+
+if (dailyBreakdown.length) {
+  console.log('\nDaily creation breakdown for anonymous accounts:');
+  for (const day of dailyBreakdown) {
+    console.log(`${day._id}: ${day.count}`);
+  }
+}
+
+const sample = await User.find(anonymousQuery)
+  .sort({ createdAt: -1 })
+  .limit(20)
+  .select('accountId createdAt balance walletAddress');
+
+if (sample.length) {
+  console.log('\nLatest anonymous accounts:');
+  for (const user of sample) {
+    console.log(
+      `${user.accountId} | created ${user.createdAt?.toISOString?.()} | balance ${user.balance ?? 0}`
+    );
+  }
+}
+
+await mongoose.disconnect();

--- a/bot/scripts/resetTPCBalances.js
+++ b/bot/scripts/resetTPCBalances.js
@@ -14,11 +14,29 @@ await mongoose.connect(uri);
 
 const ids = process.argv.slice(2);
 
+const devAccounts = [
+  process.env.DEV_ACCOUNT_ID || process.env.VITE_DEV_ACCOUNT_ID,
+  process.env.DEV_ACCOUNT_ID_1 || process.env.VITE_DEV_ACCOUNT_ID_1,
+  process.env.DEV_ACCOUNT_ID_2 || process.env.VITE_DEV_ACCOUNT_ID_2
+].filter(Boolean);
+
+function isDevAccount(user) {
+  if (!devAccounts.length) return false;
+  return devAccounts.includes(user.accountId);
+}
+
 // If no identifiers are provided, reset every user's TPC balance just like
 // the original behaviour of this script.
 if (ids.length === 0) {
-  const users = await User.find({});
+  const query = devAccounts.length
+    ? { accountId: { $nin: devAccounts } }
+    : {};
+  const users = await User.find(query);
   for (const user of users) {
+    if (isDevAccount(user)) {
+      console.log(`Skipping dev account ${user.accountId}`);
+      continue;
+    }
     user.balance = 0;
     user.minedTPC = 0;
     user.transactions = [];
@@ -29,6 +47,10 @@ if (ids.length === 0) {
   // Otherwise, only reset the balances of the specified users. The arguments
   // may be a telegramId, accountId or nickname.
   for (const id of ids) {
+    if (devAccounts.includes(id)) {
+      console.log(`Skipping dev account ${id}`);
+      continue;
+    }
     const query = { $or: [{ accountId: id }, { nickname: id }] };
     const asNumber = Number(id);
     if (!Number.isNaN(asNumber)) query.$or.push({ telegramId: asNumber });
@@ -36,6 +58,11 @@ if (ids.length === 0) {
     const user = await User.findOne(query);
     if (!user) {
       console.error(`User ${id} not found`);
+      continue;
+    }
+
+    if (isDevAccount(user)) {
+      console.log(`Skipping dev account ${user.accountId}`);
       continue;
     }
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "claim-test": "node bot/scripts/claimTest.js",
     "refund-withdrawals": "node bot/scripts/refundPendingWithdrawals.js",
     "reset-tpc-balances": "node bot/scripts/resetTPCBalances.js",
+    "find-anonymous-accounts": "node bot/scripts/findAnonymousAccounts.js",
     "reset-db": "node bot/scripts/resetDatabase.js",
     "dev": "concurrently -k \"npm --prefix webapp run dev\" \"node bot/server.js\""
   },

--- a/webapp/src/hooks/useTelegramAuth.js
+++ b/webapp/src/hooks/useTelegramAuth.js
@@ -15,9 +15,10 @@ export default function useTelegramAuth() {
       });
     } else {
       (async () => {
+        const googleId = localStorage.getItem('googleId');
         const accountId = acc || (await ensureAccountId());
         socket.emit('register', { playerId: accountId });
-        const googleId = localStorage.getItem('googleId');
+        if (!googleId) return;
         try {
           const res = await createAccount(undefined, googleId);
           if (res?.accountId) {


### PR DESCRIPTION
## Summary
- prevent TPC reset script from touching configured development accounts
- require a real identity before creating accounts and stop the web app from auto-creating anonymous users
- add an auditing script and npm alias to report identity-less accounts

## Testing
- npm test -- --runTestsByPath test/referralRoutes.test.js *(fails: Jest roots configuration expects /workspace/TonPlaygramWebApp/tests to exist)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ea6bf9120832982880be37c131d80)