### PR TITLE
Improve Pool Royale cue tip alignment and pull animation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13343,6 +13343,9 @@ function PoolRoyaleGame({
       connector.position.z = -connectorHeight / 2;
       tipGroup.add(connector);
 
+      const tipOverhang = tipCylinderLen + tipRadius + connectorHeight;
+      cueStick.userData.tipOffset = cueLen / 2 + tipOverhang;
+
       const buttMaterial = new THREE.MeshPhysicalMaterial({
         map: ebonyMap,
         bumpMap: ebonyBump,
@@ -15848,10 +15851,11 @@ function PoolRoyaleGame({
             vert,
             perp.z * side
           );
+          const tipOffset = cueStick.userData?.tipOffset ?? cueLen / 2;
           cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.x,
+            cue.pos.x - dir.x * (tipOffset + pull + CUE_TIP_GAP) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y - dir.z * (tipOffset + pull + CUE_TIP_GAP) + spinWorld.z
           );
           const tiltAmount = Math.abs(appliedSpin.y || 0);
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
@@ -15861,9 +15865,9 @@ function PoolRoyaleGame({
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
           TMP_VEC3_BUTT.set(
-            cue.pos.x - dir.x * (cueLen + pull + CUE_TIP_GAP) + spinWorld.x,
+            cue.pos.x - dir.x * (tipOffset * 2 + pull + CUE_TIP_GAP) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen + pull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y - dir.z * (tipOffset * 2 + pull + CUE_TIP_GAP) + spinWorld.z
           );
           let visibleChalkIndex = null;
           const chalkMeta = table.userData?.chalkMeta;
@@ -16044,10 +16048,11 @@ function PoolRoyaleGame({
             }
           }
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
+          const tipOffset = cueStick.userData?.tipOffset ?? cueLen / 2;
           cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.x,
+            cue.pos.x - dir.x * (tipOffset + pull + CUE_TIP_GAP) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y - dir.z * (tipOffset + pull + CUE_TIP_GAP) + spinWorld.z
           );
           const tiltAmount = Math.abs(spinY);
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);


### PR DESCRIPTION
## Summary
- compute the cue tip overhang and use it for cue positioning so the tip tracks the cue ball and spin offsets precisely
- update cue placement math to keep butt placement consistent with the corrected tip offset for both player and AI

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ea6f05e848329a304753cc1f5fe7b)