### PR TITLE
Improve Pool Royale cue stick positioning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -15849,9 +15849,9 @@ function PoolRoyaleGame({
             perp.z * side
           );
           cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.x,
+            cue.pos.x - dir.x * (pull + CUE_TIP_GAP - cueLen / 2) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y - dir.z * (pull + CUE_TIP_GAP - cueLen / 2) + spinWorld.z
           );
           const tiltAmount = Math.abs(appliedSpin.y || 0);
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
@@ -15861,9 +15861,9 @@ function PoolRoyaleGame({
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
           TMP_VEC3_BUTT.set(
-            cue.pos.x - dir.x * (cueLen + pull + CUE_TIP_GAP) + spinWorld.x,
+            cue.pos.x - dir.x * (pull + CUE_TIP_GAP - cueLen) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen + pull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y - dir.z * (pull + CUE_TIP_GAP - cueLen) + spinWorld.z
           );
           let visibleChalkIndex = null;
           const chalkMeta = table.userData?.chalkMeta;
@@ -16045,9 +16045,9 @@ function PoolRoyaleGame({
           }
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
           cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.x,
+            cue.pos.x - dir.x * (pull + CUE_TIP_GAP - cueLen / 2) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y - dir.z * (pull + CUE_TIP_GAP - cueLen / 2) + spinWorld.z
           );
           const tiltAmount = Math.abs(spinY);
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);


### PR DESCRIPTION
## Summary
- align the cue stick placement so the tip tracks the cue ball and spin offsets precisely
- tie the power pull distance to the cue position so the stick visibly retracts and drives forward on a shot

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ea6f05e848329a304753cc1f5fe7b)