### PR TITLE
Refine broadcast and pocket camera handling

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -25,14 +25,14 @@ public class CueCamera : MonoBehaviour
 
     [Header("Cue aim view")]
     // Distance from the cue ball when the camera is fully raised above the cue.
-    public float cueRaisedDistanceFromBall = 0.68f;
+    public float cueRaisedDistanceFromBall = 0.62f;
     // Distance from the cue ball used for the lowest aiming view.  This keeps the
     // camera hovering over the mid–upper portion of the cue rather than slipping
     // all the way back to the plastic end.
-    public float cueLoweredDistanceFromBall = 0.05f;
+    public float cueLoweredDistanceFromBall = 0.04f;
     // Additional pull-in applied to the cue camera so the portrait framing hugs
     // the cloth like a player leaning over the shot.
-    public float cueDistancePullIn = 0.48f;
+    public float cueDistancePullIn = 0.54f;
     // Minimum separation we allow once the pull-in is applied. Prevents the
     // camera from intersecting the cue or cloth when the player drops in tight.
     public float cueMinimumDistance = 0.02f;
@@ -43,7 +43,7 @@ public class CueCamera : MonoBehaviour
     // view.
     public float cueRaisedHeightPadding = 0.05f;
     // Minimum height maintained when the player drops the camera toward the cue.
-    public float cueLoweredHeight = 0.27f;
+    public float cueLoweredHeight = 0.31f;
     // Extra forward push applied as the player lowers the camera so the framing
     // stays tight on the cue ball and shaft instead of drifting backward.
     public float cueLoweredForwardPush = 0.08f;
@@ -51,7 +51,7 @@ public class CueCamera : MonoBehaviour
     // retreats past the stick and always looks down the shaft.
     public float cueButtClearance = 0.12f;
     // Extra clearance to ensure the camera stays above the cue stick.
-    public float cueHeightClearance = 0.05f;
+    public float cueHeightClearance = 0.065f;
     // Limit how far toward the butt end the camera can travel as it lowers.
     // Keeps the framing over the upper half of the cue rather than drifting to
     // the plastic cap.
@@ -89,7 +89,7 @@ public class CueCamera : MonoBehaviour
     // Scale applied once the camera is fully lowered toward the cue. Lower
     // values bring the framing tighter to the cue ball and aiming line.
     [Range(0.1f, 1f)]
-    public float cueLoweredDistanceScale = 0.45f;
+    public float cueLoweredDistanceScale = 0.42f;
     // Bias used when lowering the camera to keep it hovering just above the cue
     // instead of drifting upward toward the player's face.
     [Range(0.1f, 1f)]
@@ -120,18 +120,18 @@ public class CueCamera : MonoBehaviour
     [Header("Broadcast view")]
     // Distance and height for the short-rail broadcast view used once a shot begins.
     public float broadcastDistance = 0.9f;
-    public float broadcastHeight = 0.44f;
+    public float broadcastHeight = 0.4f;
     // Bounds that encompass the full playing surface including rails and pockets.
     public Bounds tableBounds = new Bounds(new Vector3(0f, 0.36f, 0f), new Vector3(1.64465f, 0.72f, 3.301325f));
     // Keep a small margin inside the camera frame so the rails never touch the
     // edge of the screen during broadcast shots.
     [Range(0f, 0.25f)]
-    public float broadcastSafeMargin = 0.02f;
+    public float broadcastSafeMargin = 0.015f;
     // Minimum and maximum camera offsets used while fitting the table inside the
     // broadcast frame. The solver expands toward the max until every corner is
     // visible.
-    public float broadcastMinDistance = 0.95f;
-    public float broadcastMaxDistance = 5.0875f;
+    public float broadcastMinDistance = 0.82f;
+    public float broadcastMaxDistance = 4.65f;
     // Blend between the table centre and the active focus (cue ball or target)
     // when aiming the broadcast view. Keeps the play interesting while still
     // framing the entire table.
@@ -139,7 +139,22 @@ public class CueCamera : MonoBehaviour
     public float broadcastFocusBias = 0.35f;
     // Additional height applied when the broadcast camera needs to rise to keep
     // the far short rail within frame.
-    public float broadcastHeightPadding = 0.06f;
+    public float broadcastHeightPadding = 0.03f;
+    [Header("Pocket camera")]
+    // Distance within which we consider a pocketed shot guaranteed and cut to the pocket view.
+    public float pocketTriggerDistance = 0.22f;
+    // Minimum target speed aligned toward the pocket before switching to the pocket camera.
+    public float pocketTriggerVelocity = 0.14f;
+    // Speed below which we consider the shot resolved while holding on the pocket.
+    public float pocketHoldVelocity = 0.0025f;
+    // Horizontal offset from the pocket lip used to place the pocket camera outside the chrome plate.
+    public float pocketCameraOffset = 0.18f;
+    // Extra height for the pocket camera so it sits just above the chrome plate.
+    public float pocketCameraHeight = 0.08f;
+    // Additional upward focus so the pocket camera keeps the pocket mouth framed without zooming.
+    public float pocketCameraLookOffset = 0.05f;
+    // Outset used when computing the side pockets so the camera aligns with the table spec.
+    public float pocketSideOutset = 0.03f;
     // Minimum squared velocity to consider a ball as moving.
     public float velocityThreshold = 0.01f;
     // How quickly the camera aligns to the stored shot angle.
@@ -163,6 +178,9 @@ public class CueCamera : MonoBehaviour
     private int defaultShortRailSign = 1;
     private int cueAimSideSign = 1;
     private int broadcastSideSign = -1;
+    private bool usingPocketCamera;
+    private Vector3 pocketAnchor;
+    private Vector3 pocketOutward;
     private bool nextShotIsAi;
     [Header("Occlusion settings")]
     // Layers that should be considered when preventing the camera from getting
@@ -214,6 +232,9 @@ public class CueCamera : MonoBehaviour
         currentBall = CueBall;
         shotInProgress = true;
         usingTargetCamera = target != null;
+        usingPocketCamera = false;
+        pocketAnchor = tableBounds.center;
+        pocketOutward = Vector3.forward;
 
         int aimSide = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
         cueAimSideSign = aimSide;
@@ -244,6 +265,9 @@ public class CueCamera : MonoBehaviour
         cueAimLowering = Mathf.Clamp01(defaultCueAimLowering);
         cueAimForward = GetInitialCueForward();
         targetViewFocus = GetBroadcastFocus(CueBall != null ? CueBall.position : tableBounds.center);
+        usingPocketCamera = false;
+        pocketAnchor = tableBounds.center;
+        pocketOutward = Vector3.forward;
     }
 
     private void LateUpdate()
@@ -566,10 +590,15 @@ public class CueCamera : MonoBehaviour
 
     private void UpdateBroadcastCamera()
     {
+        if (usingPocketCamera)
+        {
+            UpdatePocketCamera();
+            return;
+        }
+
         currentBall = CueBall;
         yaw = Mathf.LerpAngle(yaw, targetViewYaw, Time.deltaTime * shotSnapSpeed);
-        Vector3 focus = CueBall != null ? CueBall.position : tableBounds.center;
-        ApplyBroadcastCamera(GetBroadcastFocus(focus));
+        ApplyBroadcastCamera(targetViewFocus);
 
         bool cueMoving = IsMoving(CueBall);
         bool targetMoving = TargetBall != null && IsMoving(TargetBall);
@@ -595,8 +624,19 @@ public class CueCamera : MonoBehaviour
     {
         if (TargetBall != null && TargetBall.gameObject.activeInHierarchy)
         {
-            targetViewFocus = GetBroadcastFocus(TargetBall.position);
+            Vector3 desiredFocus = GetBroadcastFocus(TargetBall.position);
+            targetViewFocus = Vector3.Lerp(targetViewFocus, desiredFocus, Time.deltaTime * 3f);
             currentBall = TargetBall;
+            if (!usingPocketCamera)
+            {
+                TryEnterPocketCamera(TargetBall);
+            }
+        }
+
+        if (usingPocketCamera)
+        {
+            UpdatePocketCamera();
+            return;
         }
 
         yaw = Mathf.LerpAngle(yaw, targetViewYaw, Time.deltaTime * shotSnapSpeed);
@@ -621,6 +661,131 @@ public class CueCamera : MonoBehaviour
             EndShot();
             UpdateCueAimCamera();
         }
+    }
+
+    private void UpdatePocketCamera()
+    {
+        Vector3 forward = pocketOutward.sqrMagnitude > 0.0001f ? -pocketOutward.normalized : Vector3.forward;
+        float offset = Mathf.Max(0.05f, pocketCameraOffset);
+        float baseHeight = Mathf.Max(pocketCameraHeight, railHeight + railClearance);
+        float height = pocketAnchor.y + baseHeight;
+        float minimumHeightOffset = Mathf.Max(minimumHeightAboveFocus, baseHeight);
+        Vector3 lookTarget = pocketAnchor + Vector3.up * Mathf.Max(0f, pocketCameraLookOffset);
+
+        ApplyCameraAt(pocketAnchor, forward, offset, height, minimumHeightOffset, lookTarget);
+
+        bool targetSettled = TargetBall == null || !TargetBall.gameObject.activeInHierarchy || GetSpeed(TargetBall) <= pocketHoldVelocity;
+        bool cueSettled = !IsMoving(CueBall);
+        if (targetSettled && cueSettled)
+        {
+            EndShot();
+            UpdateCueAimCamera();
+        }
+    }
+
+    private bool TryEnterPocketCamera(Transform target)
+    {
+        if (target == null || !target.gameObject.activeInHierarchy)
+        {
+            return false;
+        }
+
+        Rigidbody rb = target.GetComponent<Rigidbody>();
+        if (rb == null)
+        {
+            return false;
+        }
+
+        Vector3 pocketNormal;
+        Vector3 anchor = GetNearestPocket(target.position, out pocketNormal);
+        Vector3 toPocket = anchor - target.position;
+        toPocket.y = 0f;
+        Vector3 planarVelocity = rb.velocity;
+        planarVelocity.y = 0f;
+
+        float triggerDistance = Mathf.Max(0.01f, pocketTriggerDistance);
+        if (toPocket.magnitude > triggerDistance)
+        {
+            return false;
+        }
+
+        float triggerSpeed = Mathf.Max(0f, pocketTriggerVelocity);
+        if (planarVelocity.sqrMagnitude < triggerSpeed * triggerSpeed)
+        {
+            return false;
+        }
+
+        if (toPocket.sqrMagnitude < 0.0001f || planarVelocity.sqrMagnitude < 0.0001f)
+        {
+            return false;
+        }
+
+        float alignment = Vector3.Dot(planarVelocity.normalized, toPocket.normalized);
+        if (alignment < 0.35f)
+        {
+            return false;
+        }
+
+        pocketAnchor = anchor;
+        pocketOutward = pocketNormal;
+        usingPocketCamera = true;
+        targetViewFocus = GetBroadcastFocus(anchor);
+        return true;
+    }
+
+    private Vector3 GetNearestPocket(Vector3 position, out Vector3 outwardNormal)
+    {
+        Vector3 extents = tableBounds.extents;
+        float outset = Mathf.Max(0f, pocketSideOutset);
+        float pocketHeight = Mathf.Max(tableBounds.center.y, railHeight);
+        Vector3[] anchors = new Vector3[]
+        {
+            new Vector3(-extents.x, pocketHeight, -extents.z),
+            new Vector3(0f, pocketHeight, -extents.z - outset),
+            new Vector3(extents.x, pocketHeight, -extents.z),
+            new Vector3(extents.x + outset, pocketHeight, 0f),
+            new Vector3(extents.x, pocketHeight, extents.z),
+            new Vector3(0f, pocketHeight, extents.z + outset),
+            new Vector3(-extents.x, pocketHeight, extents.z),
+            new Vector3(-extents.x - outset, pocketHeight, 0f)
+        };
+
+        Vector3[] normals = new Vector3[]
+        {
+            new Vector3(-1f, 0f, -1f).normalized,
+            Vector3.back,
+            new Vector3(1f, 0f, -1f).normalized,
+            Vector3.right,
+            new Vector3(1f, 0f, 1f).normalized,
+            Vector3.forward,
+            new Vector3(-1f, 0f, 1f).normalized,
+            Vector3.left
+        };
+
+        float best = float.MaxValue;
+        outwardNormal = Vector3.forward;
+        Vector3 bestAnchor = anchors[0];
+
+        for (int i = 0; i < anchors.Length; i++)
+        {
+            Vector3 flat = position - anchors[i];
+            flat.y = 0f;
+            float sqr = flat.sqrMagnitude;
+            if (sqr < best)
+            {
+                best = sqr;
+                bestAnchor = anchors[i];
+                outwardNormal = normals[i];
+            }
+        }
+
+        return bestAnchor;
+    }
+
+    private float GetSpeed(Transform ball)
+    {
+        Rigidbody rb = ball != null ? ball.GetComponent<Rigidbody>() : null;
+        return rb != null ? rb.velocity.magnitude : 0f;
     }
 
     private void ApplyStandardCamera()
@@ -938,6 +1103,7 @@ public class CueCamera : MonoBehaviour
     {
         shotInProgress = false;
         usingTargetCamera = false;
+        usingPocketCamera = false;
         currentBall = CueBall;
         TargetBall = null;
         cueAimSideSign = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;

--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -45,20 +45,21 @@ public class BilliardsSolver
         double sideMouth = PhysicsConstants.SidePocketMouth;
         double cornerCut = cornerMouth / Math.Sqrt(2.0);
         double sideCut = sideMouth / 2.0;
+        double trimmedSideCut = sideCut + PhysicsConstants.SidePocketCushionTrim;
         double sideDepth = Math.Max(sideCut * 1.05, PhysicsConstants.BallRadius * 1.8);
         double sideOutset = Math.Max(0.0, PhysicsConstants.SidePocketOutset);
 
         // Straight cushion spans (long rails)
-        AddCushionSegment(new Vec2(cornerCut, 0), new Vec2(width / 2 - sideCut, 0), new Vec2(0, 1));
-        AddCushionSegment(new Vec2(width / 2 + sideCut, 0), new Vec2(width - cornerCut, 0), new Vec2(0, 1));
-        AddCushionSegment(new Vec2(cornerCut, height), new Vec2(width / 2 - sideCut, height), new Vec2(0, -1));
-        AddCushionSegment(new Vec2(width / 2 + sideCut, height), new Vec2(width - cornerCut, height), new Vec2(0, -1));
+        AddCushionSegment(new Vec2(cornerCut, 0), new Vec2(width / 2 - trimmedSideCut, 0), new Vec2(0, 1));
+        AddCushionSegment(new Vec2(width / 2 + trimmedSideCut, 0), new Vec2(width - cornerCut, 0), new Vec2(0, 1));
+        AddCushionSegment(new Vec2(cornerCut, height), new Vec2(width / 2 - trimmedSideCut, height), new Vec2(0, -1));
+        AddCushionSegment(new Vec2(width / 2 + trimmedSideCut, height), new Vec2(width - cornerCut, height), new Vec2(0, -1));
 
         // Straight cushion spans (short rails)
-        AddCushionSegment(new Vec2(0, cornerCut), new Vec2(0, height / 2 - sideCut), new Vec2(1, 0));
-        AddCushionSegment(new Vec2(0, height / 2 + sideCut), new Vec2(0, height - cornerCut), new Vec2(1, 0));
-        AddCushionSegment(new Vec2(width, cornerCut), new Vec2(width, height / 2 - sideCut), new Vec2(-1, 0));
-        AddCushionSegment(new Vec2(width, height / 2 + sideCut), new Vec2(width, height - cornerCut), new Vec2(-1, 0));
+        AddCushionSegment(new Vec2(0, cornerCut), new Vec2(0, height / 2 - trimmedSideCut), new Vec2(1, 0));
+        AddCushionSegment(new Vec2(0, height / 2 + trimmedSideCut), new Vec2(0, height - cornerCut), new Vec2(1, 0));
+        AddCushionSegment(new Vec2(width, cornerCut), new Vec2(width, height / 2 - trimmedSideCut), new Vec2(-1, 0));
+        AddCushionSegment(new Vec2(width, height / 2 + trimmedSideCut), new Vec2(width, height - cornerCut), new Vec2(-1, 0));
 
         int cornerSegments = Math.Max(8, PhysicsConstants.CornerJawSegments);
         AddCornerJaw(new Vec2(cornerCut, cornerCut), cornerCut, Math.PI, 1.5 * Math.PI, cornerSegments);
@@ -67,10 +68,10 @@ public class BilliardsSolver
         AddCornerJaw(new Vec2(cornerCut, height - cornerCut), cornerCut, 0.5 * Math.PI, Math.PI, cornerSegments);
 
         int sideSegments = Math.Max(6, PhysicsConstants.SideJawSegments);
-        AddSidePocketJaw(new Vec2(width / 2, 0 - sideOutset), sideCut, sideDepth, true, sideSegments);
-        AddSidePocketJaw(new Vec2(width / 2, height + sideOutset), sideCut, sideDepth, false, sideSegments);
-        AddSidePocketJaw(new Vec2(0 - sideOutset, height / 2), sideCut, sideDepth, true, sideSegments, vertical: true);
-        AddSidePocketJaw(new Vec2(width + sideOutset, height / 2), sideCut, sideDepth, false, sideSegments, vertical: true);
+        AddSidePocketJaw(new Vec2(width / 2, 0 - sideOutset), trimmedSideCut, sideDepth, true, sideSegments);
+        AddSidePocketJaw(new Vec2(width / 2, height + sideOutset), trimmedSideCut, sideDepth, false, sideSegments);
+        AddSidePocketJaw(new Vec2(0 - sideOutset, height / 2), trimmedSideCut, sideDepth, true, sideSegments, vertical: true);
+        AddSidePocketJaw(new Vec2(width + sideOutset, height / 2), trimmedSideCut, sideDepth, false, sideSegments, vertical: true);
 
         double capture = Math.Max(PhysicsConstants.BallRadius * 1.05, PhysicsConstants.PocketCaptureRadius);
         Pockets.Add(new Pocket { Center = new Vec2(0, 0), Radius = capture });

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -27,6 +27,9 @@ public static class PhysicsConstants
     // Offset that moves the side pockets slightly outside the rail line so the
     // chrome plates and wooden rails sit flush with the rounded cuts.
     public const double SidePocketOutset = 0.03;
+    // Extra trim applied to the side-rail cushions nearest the middle pockets so
+    // the green bands do not spill past the pocket perimeter.
+    public const double SidePocketCushionTrim = 0.0125;
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 32;


### PR DESCRIPTION
## Summary
- trim side-rail cushions around the middle pockets to keep them clear of the pocket perimeter
- pull broadcast and cue cameras closer while clamping the cue view above cue-stick height
- add automatic pocket-camera handoff for guaranteed pots and keep broadcast shots framed from the opposite rail

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693efc8788108329ab731bec3a286167)