### PR TITLE
Ensure pocket camera captures all pocket drops

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12282,7 +12282,8 @@ function PoolRoyaleGame({
             shotPrediction?.ballId === ballId &&
             predictedAlignment != null &&
             predictedAlignment >= POCKET_GUARANTEED_ALIGNMENT;
-          if (!isGuaranteedPocket) return null;
+          const isAlreadyDropping = best.dist <= POCKET_CAM.triggerDist;
+          if (!isGuaranteedPocket && !isAlreadyDropping) return null;
           const predictedTravelForBall =
             shotPrediction?.ballId === ballId
               ? shotPrediction?.travel ?? null


### PR DESCRIPTION
## Summary
- allow the pocket camera to activate when a ball is already entering a pocket, even without a guaranteed prediction

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f0efe2790832996efba2089a956ed)