### PR TITLE
Document trimming side-rail cushions

### DIFF
--- a/docs/3d-billiards-variants.md
+++ b/docs/3d-billiards-variants.md
@@ -21,6 +21,7 @@ Exactly **four** chalk blocks are visible at all times—one centred on each woo
 - Rail melamine is split into **six** surface pieces in total, each one kissing the chrome fascia with no visible gaps; the grain/pattern lines must run the full length of the rails so every strip reads as a continuous long-direction plank.
 - Match the skirt underlay: melamine and wooden rails must share the same grain direction, pattern scale, and plank widths as the skirts beneath them so the table reads as one uniform shell and stops cleanly above the legs.
 - Pocket jaws and rims must match the chrome plate cutouts **100%**—never size them from the wooden rail arches.
+- Trim the **four** side-rail cushion pieces nearest the middle pockets so each ends exactly where the rounded pocket cut begins; left/right pairs must be symmetric and stop cleanly before entering the pocket reveal.
 
 ### 3D UK 8 Ball
 - 7 ft pub-style table with rounded corners and smaller pockets.


### PR DESCRIPTION
## Summary
- add requirement to trim the four side-rail cushions near the middle pockets for symmetric clearance

## Testing
- not run (docs change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fa3fd9f7c8329a8ba74553832a79a)