### PR TITLE
Trim side pocket cushions and hide pocketed balls

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6181,7 +6181,7 @@ function Table3D(
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = 0; // pull the short rail cushions tight so they meet the wood with no visible gap
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.012; // keep a subtle setback along the long rails to prevent overlap
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.18; // shorten the corner cushions slightly so the noses stay clear of the pocket openings
-  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.11; // trim the side cushions further so the tips no longer protrude into the pocket mouths
+  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.16; // trim the side cushions further so the tips finish exactly where the rounded pocket cuts begin
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.034; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile
@@ -17051,6 +17051,15 @@ function PoolRoyaleGame({
               }
             });
           }
+          balls.forEach((ball) => {
+            if (!ball?.mesh) return;
+            const dropping = pocketDropRef.current.has(ball.id);
+            if (!ball.active && !dropping) {
+              ball.mesh.visible = false;
+            } else if (ball.active && !dropping && !ball.mesh.visible) {
+              ball.mesh.visible = true;
+            }
+          });
           prevCollisions = newCollisions;
           const fit = fitRef.current;
           if (fit && cue?.active && !shooting) {


### PR DESCRIPTION
## Summary
- shorten the side cushions so they end at the start of each rounded pocket cut for a cleaner, symmetrical pocket opening
- ensure pocketed balls are hidden once they are inactive and not in a drop animation so pockets stay clear

## Testing
- npm test -- --runInBand *(fails: Jest roots[0] directory /workspace/TonPlaygramWebApp/tests not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693faf1bbf7c8329a25300e95a8b103e)