### PR TITLE
Trim side cushions and clear pocketed balls

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6181,9 +6181,10 @@ function Table3D(
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = 0; // pull the short rail cushions tight so they meet the wood with no visible gap
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.012; // keep a subtle setback along the long rails to prevent overlap
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.18; // shorten the corner cushions slightly so the noses stay clear of the pocket openings
-  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.11; // trim the side cushions further so the tips no longer protrude into the pocket mouths
+  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.16; // trim the side cushions further so the tips no longer protrude into the pocket mouths
+  const SIDE_CUSHION_POCKET_ARC_CLEARANCE = SIDE_POCKET_RADIUS * 0.16; // end cushions exactly where the rounded side cuts begin
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.034; // press the side cushions firmly into the rails without creating overlap
-  const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
+  const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.12; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile
   const railsGroup = new THREE.Group();
   finishParts.accentParent = railsGroup;
@@ -6237,7 +6238,9 @@ function Table3D(
   );
   const adjustedSidePocketReach = Math.max(
     0,
-    sidePocketReach - SIDE_CUSHION_POCKET_REACH_REDUCTION
+    sidePocketReach -
+      SIDE_CUSHION_POCKET_REACH_REDUCTION -
+      SIDE_CUSHION_POCKET_ARC_CLEARANCE
   );
   const verticalCushionLength = Math.max(
     MICRO_EPS,
@@ -17051,6 +17054,18 @@ function PoolRoyaleGame({
               }
             });
           }
+          balls.forEach((ball) => {
+            if (!ball?.mesh) return;
+            if (ball.active) return;
+            if (pocketDropRef.current.has(ball.id)) return;
+            ball.mesh.visible = false;
+            const sunkenY = BALL_CENTER_Y - POCKET_DROP_DEPTH - BALL_R * 2;
+            ball.mesh.position.set(
+              ball.mesh.position.x,
+              sunkenY,
+              ball.mesh.position.z
+            );
+          });
           prevCollisions = newCollisions;
           const fit = fitRef.current;
           if (fit && cue?.active && !shooting) {


### PR DESCRIPTION
## Summary
- trim Pool Royale side cushions so they finish at the start of the rounded side pocket cuts for a symmetrical fit
- hide pocketed balls after their drop animation so pockets stay visually clear

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693faf1bbf7c8329a25300e95a8b103e)