### PR TITLE
Adjust middle pocket chrome cut and collision guard

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -486,8 +486,8 @@ const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.095; // pull the side fascias inward so their outer edge trims back while keeping the reveal tidy
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
-const CHROME_SIDE_POCKET_CUT_SCALE = 1.02; // trim the middle chrome arch so the rounded cut sits tighter around the side pockets
-const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.19; // ease the pull toward centre so the chrome cut follows the outward-biased pocket position without over-widening
+const CHROME_SIDE_POCKET_CUT_SCALE = 1.04; // open the middle chrome arch slightly more so the rounded cut reads larger around the side pockets
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.14; // lighten the centre pull so the enlarged cut stays centred on the outward-biased pocket without pinching
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
@@ -5125,8 +5125,8 @@ function reflectRails(ball) {
     return 'corner';
   }
 
-  const sideSpan = SIDE_POCKET_RADIUS + BALL_R * 0.65; // extend the middle pocket guard for more precise collisions
-  const sideDepthLimit = POCKET_VIS_R * 1.45 * POCKET_VISUAL_EXPANSION;
+  const sideSpan = SIDE_POCKET_RADIUS + BALL_R * 0.95; // widen the middle pocket guard so balls slide in without abrupt deflections
+  const sideDepthLimit = POCKET_VIS_R * 1.65 * POCKET_VISUAL_EXPANSION; // mirror the corner pocket depth window for consistent entry behaviour
   const sideRad = THREE.MathUtils.degToRad(SIDE_CUSHION_CUT_ANGLE);
   const sideCos = Math.cos(sideRad);
   const sideSin = Math.sin(sideRad);


### PR DESCRIPTION
## Summary
- slightly widen the chrome cutouts on middle pocket fascias and ease their centering pull
- expand middle pocket rail guard and depth allowances to prevent deflecting shots and match corner behaviour

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ff76cdd3c8329903bbf239ffed877)