### PR TITLE
Anchor Pool Royale green cushions to baseline

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2144,15 +2144,16 @@ const CHROME_COLOR_OPTIONS = Object.freeze([
 
 // Palettes derived from CC0 textile scans (ambientCG FabricWool series) and
 // popular tournament felts so every option mirrors a real pool cloth.
+const POOL_ROYALE_GREEN_BASELINE = Object.freeze({
+  shadow: 0x1d8048,
+  base: 0x3ab86e,
+  accent: 0x54cf88,
+  highlight: 0x7ef2af
+});
 const CLOTH_TEXTURE_PRESETS = Object.freeze({
   freshGreen: Object.freeze({
     id: 'freshGreen',
-    palette: {
-      shadow: 0x1d8048,
-      base: 0x3ab86e,
-      accent: 0x54cf88,
-      highlight: 0x7ef2af
-    },
+    palette: POOL_ROYALE_GREEN_BASELINE,
     sparkle: 1,
     stray: 1
   }),


### PR DESCRIPTION
## Summary
- define a baseline palette for the Pool Royale green cloth to lock the cushion color to the morning reference values
- reuse the baseline palette for the default freshGreen option to prevent accidental drift

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69400b9e86b8832988e188a350cdbfd6)