### PR TITLE
Improve Pool Royale highlight playback

### DIFF
--- a/webapp/src/pages/GameTransactions.jsx
+++ b/webapp/src/pages/GameTransactions.jsx
@@ -71,6 +71,35 @@ export default function GameTransactions() {
             USDT: '/assets/icons/Usdt.webp',
           };
           const icon = iconMap[token] || `/assets/icons/${token}.webp`;
+          const highlightUrl =
+            tx.highlightUrl || tx.highlight?.url || tx.highlight || null;
+          const highlightCreatedAt =
+            tx.highlightCreatedAt || tx.highlight?.createdAt || tx.date || null;
+          const highlightExpiresAt =
+            tx.highlightExpiresAt ||
+            tx.highlight?.expiresAt ||
+            (highlightCreatedAt ? new Date(highlightCreatedAt).getTime() + 24 * 60 * 60 * 1000 : null);
+          const highlightActive =
+            highlightUrl && highlightExpiresAt && Number.isFinite(highlightExpiresAt) && Date.now() < highlightExpiresAt;
+          const expiresLabel = highlightExpiresAt
+            ? new Date(highlightExpiresAt).toLocaleString(undefined, { hour12: false })
+            : null;
+
+          const openHighlight = () => {
+            if (!highlightUrl) return;
+            window.open(highlightUrl, '_blank', 'noreferrer');
+          };
+
+          const downloadHighlight = () => {
+            if (!highlightUrl) return;
+            const link = document.createElement('a');
+            link.href = highlightUrl;
+            link.download = `${tx.game || 'game'}-highlight.webm`;
+            link.rel = 'noopener';
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+          };
           return (
             <div key={i} className="lobby-tile w-full flex justify-between items-center">
               <div className="flex items-center space-x-2">
@@ -89,6 +118,30 @@ export default function GameTransactions() {
                 <div className="text-xs">
                   {tx.date ? new Date(tx.date).toLocaleString(undefined, { hour12: false }) : ''}
                 </div>
+                {highlightActive && (
+                  <div className="mt-2 space-y-1 text-left">
+                    <div className="text-[10px] uppercase tracking-[0.18em] text-emerald-200">Highlight</div>
+                    <div className="flex flex-wrap justify-end gap-2 text-xs">
+                      <button
+                        type="button"
+                        onClick={openHighlight}
+                        className="rounded-lg bg-emerald-500/20 px-2 py-1 font-semibold text-emerald-100 transition hover:bg-emerald-500/40"
+                      >
+                        Watch
+                      </button>
+                      <button
+                        type="button"
+                        onClick={downloadHighlight}
+                        className="rounded-lg bg-white/10 px-2 py-1 font-semibold text-white transition hover:bg-white/20"
+                      >
+                        Download
+                      </button>
+                    </div>
+                    {expiresLabel && (
+                      <div className="text-[11px] text-subtext">Available until {expiresLabel}</div>
+                    )}
+                  </div>
+                )}
               </div>
             </div>
           );

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -9586,45 +9586,38 @@ function PoolRoyaleGame({
     }
   }, [frameState.winner, opponentLabel]);
 
-  const handleDownloadHighlight = useCallback(() => {
+  const handleDownloadHighlight = useCallback(async () => {
     if (!highlightBlobRef.current || !highlightVideoUrl) return;
+    const filename = `pool-royale-highlights-${highlightQualityRef.current}.webm`;
+    const tg = window?.Telegram?.WebApp;
+    if (tg?.downloadFile) {
+      try {
+        const dataUrl = await new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result);
+          reader.onerror = () => reject(reader.error);
+          reader.readAsDataURL(highlightBlobRef.current);
+        });
+        await tg.downloadFile(dataUrl, filename);
+        return;
+      } catch (err) {
+        console.warn('Telegram download fallback', err);
+      }
+    }
+
     const link = document.createElement('a');
     link.href = highlightVideoUrl;
-    link.download = `pool-royale-highlights-${highlightQualityRef.current}.webm`;
+    link.download = filename;
     link.rel = 'noopener';
     link.target = '_blank';
     document.body.appendChild(link);
     link.click();
     link.remove();
 
-    const tg = window?.Telegram?.WebApp;
     if (tg?.openLink) {
       tg.openLink(highlightVideoUrl, { try_instant_view: false });
     }
   }, [highlightVideoUrl]);
-
-  const handleEnterHighlightFullscreen = useCallback(() => {
-    const node = highlightVideoRef.current;
-    if (!node) return;
-    const requestFullscreen =
-      node.requestFullscreen || node.webkitRequestFullscreen || node.msRequestFullscreen;
-    if (requestFullscreen) {
-      const attempt = requestFullscreen.call(node, { navigationUI: 'hide' });
-      if (attempt?.catch) {
-        attempt.catch(() => {
-          if (node.webkitEnterFullscreen) {
-            node.webkitEnterFullscreen();
-          }
-        });
-      }
-      return;
-    }
-    if (node.webkitEnterFullscreen) {
-      node.webkitEnterFullscreen();
-    } else if (node.parentElement?.requestFullscreen) {
-      node.parentElement.requestFullscreen();
-    }
-  }, []);
 
   const handleCloseHighlights = useCallback(() => {
     setHighlightModalOpen(false);
@@ -14991,8 +14984,7 @@ function PoolRoyaleGame({
           if (isPowerShot) replayTags.add('power');
           if (spinMagnitude >= SPIN_REPLAY_THRESHOLD) replayTags.add('spin');
           const shouldRecordReplay = true;
-          const preferZoomReplay =
-            replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
+          const preferZoomReplay = false;
           playCueHit(clampedPower * 0.6);
           const frameStateCurrent = frameRef.current ?? null;
           const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
@@ -16223,7 +16215,7 @@ function PoolRoyaleGame({
           if (tags.size === 0) return null;
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
-          const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
+          const zoomOnly = false;
           return {
             shouldReplay: hadObjectPot || tags.size > 0,
             banner: selectReplayBanner(primary),
@@ -17938,7 +17930,7 @@ function PoolRoyaleGame({
 
       {highlightModalOpen && (
         <div className="fixed inset-0 z-[140] flex items-center justify-center bg-black/80 px-4 py-6">
-          <div className="w-full max-w-2xl rounded-2xl border border-emerald-400/60 bg-slate-900/95 p-4 shadow-[0_24px_48px_rgba(0,0,0,0.6)] backdrop-blur">
+          <div className="flex h-[90vh] w-full max-w-5xl flex-col rounded-2xl border border-emerald-400/60 bg-slate-900/95 p-4 shadow-[0_24px_48px_rgba(0,0,0,0.6)] backdrop-blur">
             <div className="flex items-start justify-between gap-4">
               <div>
                 <p className="text-[10px] uppercase tracking-[0.3em] text-emerald-200/70">Match Highlights</p>
@@ -17953,28 +17945,21 @@ function PoolRoyaleGame({
                 ×
               </button>
             </div>
-            <div className="mt-4 rounded-xl border border-white/15 bg-black/40 p-3">
+            <div className="mt-4 flex flex-1 flex-col rounded-xl border border-white/15 bg-black/40 p-3">
               {highlightGenerating ? (
-                <div className="flex h-64 items-center justify-center text-sm text-white/80">
+                <div className="flex flex-1 items-center justify-center text-sm text-white/80">
                   Building your highlight reel...
                 </div>
               ) : highlightVideoUrl ? (
-                <div className="space-y-3">
-                  <div className="relative">
+                <div className="flex h-full flex-col space-y-3">
+                  <div className="flex-1">
                     <video
                       ref={highlightVideoRef}
                       src={highlightVideoUrl}
                       controls
                       playsInline
-                      className="h-64 w-full rounded-lg border border-white/10 bg-black"
+                      className="h-full w-full rounded-lg border border-white/10 bg-black object-contain"
                     />
-                    <button
-                      type="button"
-                      onClick={handleEnterHighlightFullscreen}
-                      className="absolute right-2 top-2 rounded-full bg-black/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-white shadow-[0_6px_18px_rgba(0,0,0,0.45)] transition hover:bg-emerald-500/70"
-                    >
-                      Fullscreen
-                    </button>
                   </div>
                   <div className="flex flex-col gap-2 rounded-lg border border-white/10 bg-white/5 p-2">
                     <span className="text-[10px] uppercase tracking-[0.28em] text-emerald-100/70">Quality</span>


### PR DESCRIPTION
## Summary
- remove zoom-only replay handling and present highlights in a larger modal view
- add Telegram-friendly highlight downloading and surface match highlights on the game transactions list with 24-hour visibility

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69411f0fef9c8329b24f479ae5f15dc5)