### PR TITLE
Improve Pool Royale highlight handling and surface in transactions

### DIFF
--- a/webapp/src/pages/GameTransactions.jsx
+++ b/webapp/src/pages/GameTransactions.jsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { getGameTransactions } from '../utils/api.js';
 import { getAvatarUrl } from '../utils/avatarUtils.js';
+import { getActiveHighlights } from '../utils/highlightStorage.js';
 
 const GAME_NAME_MAP = {
   snake: 'Snake & Ladder',
@@ -22,6 +23,8 @@ function getGameName(slug = '') {
 export default function GameTransactions() {
   useTelegramBackButton();
   const [transactions, setTransactions] = useState([]);
+  const [highlights, setHighlights] = useState([]);
+  const highlightUrlsRef = useRef({});
 
   useEffect(() => {
     getGameTransactions(1000)
@@ -29,8 +32,88 @@ export default function GameTransactions() {
       .catch(() => setTransactions([]));
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadHighlights = async () => {
+      try {
+        const active = await getActiveHighlights();
+        if (cancelled) return;
+        const urlMap = {};
+        const decorated = active.map((entry) => {
+          const url = URL.createObjectURL(entry.blob);
+          urlMap[entry.id] = url;
+          return { ...entry, url };
+        });
+        Object.values(highlightUrlsRef.current).forEach((href) => URL.revokeObjectURL(href));
+        highlightUrlsRef.current = urlMap;
+        setHighlights(decorated);
+      } catch (err) {
+        console.warn('Unable to load highlights', err);
+        setHighlights([]);
+      }
+    };
+
+    loadHighlights();
+
+    return () => {
+      cancelled = true;
+      Object.values(highlightUrlsRef.current).forEach((href) => URL.revokeObjectURL(href));
+    };
+  }, []);
+
   const formatValue = (v) =>
     Number(v).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+  const formatExpiresIn = (expiresAt) => {
+    const remaining = Math.max(0, expiresAt - Date.now());
+    const hours = Math.floor(remaining / 3600000);
+    const minutes = Math.floor((remaining % 3600000) / 60000);
+    if (hours <= 0) return `${minutes}m left`;
+    return `${hours}h ${minutes}m left`;
+  };
+
+  const HIGHLIGHT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+  const findHighlightForTx = (tx) => {
+    if (!tx?.game) return null;
+    const txTime = tx.date ? new Date(tx.date).getTime() : Date.now();
+    return (
+      highlights.find(
+        (entry) => entry.game === tx.game && Math.abs(txTime - entry.createdAt) <= HIGHLIGHT_WINDOW_MS
+      ) || null
+    );
+  };
+
+  const downloadHighlight = (entry) => {
+    if (!entry?.blob) return;
+    const filename = `${entry.game || 'game'}-highlight-${entry.quality || 'hd'}.webm`;
+    const url = entry.url || URL.createObjectURL(entry.blob);
+    const tg = window?.Telegram?.WebApp;
+
+    const trigger = (href) => {
+      const link = document.createElement('a');
+      link.href = href;
+      link.download = filename;
+      link.rel = 'noopener';
+      link.target = '_blank';
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    };
+
+    if (tg?.downloadFile) {
+      tg.downloadFile({ url, file_name: filename });
+    } else if (tg?.openLink) {
+      tg.openLink(url, { try_instant_view: false });
+    }
+
+    trigger(url);
+
+    if (!entry.url) {
+      URL.revokeObjectURL(url);
+    }
+  };
 
   const games = transactions.filter((t) => t.game);
   const totalGames = games.length;
@@ -71,24 +154,57 @@ export default function GameTransactions() {
             USDT: '/assets/icons/Usdt.webp',
           };
           const icon = iconMap[token] || `/assets/icons/${token}.webp`;
+          const highlight = findHighlightForTx(tx);
           return (
             <div key={i} className="lobby-tile w-full flex justify-between items-center">
-              <div className="flex items-center space-x-2">
-                <img src={avatarUrl} alt="avatar" className="w-8 h-8 rounded-full" />
-                <div>
-                  <div className="font-semibold">{tx.fromName || tx.fromAccount}</div>
-                  {gameName && <div className="text-xs text-subtext">{gameName}</div>}
+              <div className="flex w-full flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-2">
+                    <img src={avatarUrl} alt="avatar" className="w-8 h-8 rounded-full" />
+                    <div>
+                      <div className="font-semibold">{tx.fromName || tx.fromAccount}</div>
+                      {gameName && <div className="text-xs text-subtext">{gameName}</div>}
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <div className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
+                      {tx.amount > 0 ? '+' : ''}
+                      {formatValue(tx.amount)}
+                      <img src={icon} alt={token} className="inline w-4 h-4 ml-1" />
+                    </div>
+                    <div className="text-xs">
+                      {tx.date ? new Date(tx.date).toLocaleString(undefined, { hour12: false }) : ''}
+                    </div>
+                  </div>
                 </div>
-              </div>
-              <div className="text-right">
-                <div className={tx.amount > 0 ? 'text-green-500' : 'text-red-500'}>
-                  {tx.amount > 0 ? '+' : ''}
-                  {formatValue(tx.amount)}
-                  <img src={icon} alt={token} className="inline w-4 h-4 ml-1" />
-                </div>
-                <div className="text-xs">
-                  {tx.date ? new Date(tx.date).toLocaleString(undefined, { hour12: false }) : ''}
-                </div>
+                {highlight && (
+                  <div className="w-full space-y-2 rounded-lg border border-border bg-surface/80 p-2">
+                    <div className="flex items-center justify-between text-xs text-subtext">
+                      <span>
+                        Highlight ready — {highlight.quality?.toUpperCase?.() || 'HD'} · expires in{' '}
+                        {formatExpiresIn(highlight.expiresAt)}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => downloadHighlight(highlight)}
+                        className="rounded-md border border-border bg-background px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-text transition hover:border-emerald-400 hover:text-emerald-300"
+                      >
+                        Download
+                      </button>
+                    </div>
+                    <video
+                      controls
+                      playsInline
+                      src={highlight.url}
+                      className="h-48 w-full rounded-md border border-border bg-black object-contain"
+                    />
+                    {highlight.metadata?.playerName && highlight.metadata?.opponentName && (
+                      <div className="text-[11px] text-subtext">
+                        {highlight.metadata.playerName} vs {highlight.metadata.opponentName}
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
             </div>
           );

--- a/webapp/src/utils/highlightStorage.js
+++ b/webapp/src/utils/highlightStorage.js
@@ -1,0 +1,119 @@
+const DB_NAME = 'tonplaygram-highlights';
+const STORE_NAME = 'highlights';
+const DB_VERSION = 1;
+const EXPIRATION_MS = 24 * 60 * 60 * 1000;
+
+const hasIndexedDb = typeof indexedDB !== 'undefined';
+
+const openDb = () =>
+  new Promise((resolve, reject) => {
+    if (!hasIndexedDb) {
+      reject(new Error('IndexedDB is not available'));
+      return;
+    }
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onerror = () => reject(request.error || new Error('Unable to open highlights storage'));
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+  });
+
+const storeDataUrl = async (record) => {
+  const existing = JSON.parse(window.localStorage.getItem(STORE_NAME) || '[]');
+  const filtered = existing.filter((entry) => entry.expiresAt > Date.now());
+  filtered.push(record);
+  window.localStorage.setItem(STORE_NAME, JSON.stringify(filtered));
+  return record;
+};
+
+const blobToDataUrl = (blob) =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error || new Error('Failed to read highlight blob'));
+    reader.readAsDataURL(blob);
+  });
+
+const dataUrlToBlob = async (dataUrl) => {
+  const response = await fetch(dataUrl);
+  return response.blob();
+};
+
+export async function saveHighlightClip({ game, blob, quality = 'hd', createdAt = Date.now(), metadata = {} }) {
+  const record = {
+    game,
+    quality,
+    createdAt,
+    expiresAt: createdAt + EXPIRATION_MS,
+    metadata,
+  };
+
+  if (!blob) throw new Error('No highlight data provided');
+
+  if (hasIndexedDb) {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      const request = store.add({ ...record, blob });
+      tx.oncomplete = () => resolve({ ...record, id: request.result, blob });
+      tx.onerror = () => reject(tx.error || new Error('Failed to persist highlight'));
+    });
+  }
+
+  const dataUrl = await blobToDataUrl(blob);
+  return storeDataUrl({ ...record, id: `${Date.now()}`, dataUrl });
+}
+
+export async function getActiveHighlights() {
+  const now = Date.now();
+  if (hasIndexedDb) {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      const request = store.getAll();
+      request.onsuccess = async () => {
+        const all = request.result || [];
+        const valid = all.filter((entry) => entry.expiresAt > now);
+        const expiredIds = all.filter((entry) => entry.expiresAt <= now).map((entry) => entry.id);
+        if (expiredIds.length) {
+          expiredIds.forEach((id) => store.delete(id));
+        }
+        resolve(valid);
+      };
+      request.onerror = () => reject(request.error || new Error('Failed to read highlights'));
+    });
+  }
+
+  const stored = JSON.parse(window.localStorage.getItem(STORE_NAME) || '[]');
+  const valid = stored.filter((entry) => entry.expiresAt > now);
+  const expired = stored.filter((entry) => entry.expiresAt <= now);
+  if (expired.length) {
+    window.localStorage.setItem(STORE_NAME, JSON.stringify(valid));
+  }
+  const mapped = await Promise.all(
+    valid.map(async (entry) => ({ ...entry, blob: await dataUrlToBlob(entry.dataUrl) }))
+  );
+  return mapped;
+}
+
+export async function clearHighlight(id) {
+  if (id == null) return;
+  if (hasIndexedDb) {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      tx.objectStore(STORE_NAME).delete(id);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error || new Error('Failed to delete highlight'));
+    });
+  }
+  const stored = JSON.parse(window.localStorage.getItem(STORE_NAME) || '[]');
+  const filtered = stored.filter((entry) => entry.id !== id);
+  window.localStorage.setItem(STORE_NAME, JSON.stringify(filtered));
+}


### PR DESCRIPTION
## Summary
- remove zoom-only replay trimming and expand the highlight modal to a full-frame player without fullscreen control
- persist generated Pool Royale highlight clips for 24 hours and expose them on the Game Transactions page with download support
- harden highlight downloads for Telegram clients

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69411f0fef9c8329b24f479ae5f15dc5)