### PR TITLE
Handle Telegram profile photo field variations

### DIFF
--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { FaCircle, FaTv } from 'react-icons/fa';
 import LoginOptions from './LoginOptions.jsx';
-import { getTelegramId, getTelegramPhotoUrl, getPlayerId } from '../utils/telegram.js';
+import { getTelegramId, getTelegramPhotoUrl, getPlayerId, extractTelegramPhoto } from '../utils/telegram.js';
 import {
   getLeaderboard,
   getOnlineCount,
@@ -79,7 +79,8 @@ export default function LeaderboardCard() {
             saveAvatar(p.photo);
           } else {
             fetchTelegramInfo(telegramId).then((info) => {
-              if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
+              const photo = extractTelegramPhoto(info);
+              if (photo) setMyPhotoUrl(photo);
             });
           }
           setMyName(
@@ -88,7 +89,8 @@ export default function LeaderboardCard() {
         })
         .catch(() => {
           fetchTelegramInfo(telegramId).then((info) => {
-            if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
+            const photo = extractTelegramPhoto(info);
+            if (photo) setMyPhotoUrl(photo);
             setMyName(`${info?.firstName || ''} ${info?.lastName || ''}`.trim());
           });
         });

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -32,7 +32,7 @@ import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
 import TonConnectButton from '../components/TonConnectButton.jsx';
 import useTokenBalances from '../hooks/useTokenBalances.js';
 import useWalletUsdValue from '../hooks/useWalletUsdValue.js';
-import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
+import { getTelegramId, getTelegramPhotoUrl, extractTelegramPhoto } from '../utils/telegram.js';
 
 
 export default function Home() {
@@ -71,14 +71,14 @@ export default function Home() {
             saveAvatar(p.photo);
           } else {
             fetchTelegramInfo(id).then((info) => {
-              setPhotoUrl(info?.photoUrl || getTelegramPhotoUrl());
+              setPhotoUrl(extractTelegramPhoto(info) || getTelegramPhotoUrl());
             });
           }
         })
         .catch(() => {
           fetchTelegramInfo(id)
             .then((info) => {
-              setPhotoUrl(info?.photoUrl || getTelegramPhotoUrl());
+              setPhotoUrl(extractTelegramPhoto(info) || getTelegramPhotoUrl());
             })
             .catch(() => setPhotoUrl(getTelegramPhotoUrl()));
         });
@@ -97,14 +97,14 @@ export default function Home() {
               saveAvatar(p.photo);
             } else {
               fetchTelegramInfo(id).then((info) => {
-                setPhotoUrl(info?.photoUrl || getTelegramPhotoUrl());
+                setPhotoUrl(extractTelegramPhoto(info) || getTelegramPhotoUrl());
               });
             }
           })
           .catch(() => {
             fetchTelegramInfo(id)
               .then((info) => {
-                setPhotoUrl(info?.photoUrl || getTelegramPhotoUrl());
+                setPhotoUrl(extractTelegramPhoto(info) || getTelegramPhotoUrl());
               })
               .catch(() => setPhotoUrl(getTelegramPhotoUrl()));
           });

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LoginOptions from '../components/LoginOptions.jsx';
-import { getTelegramId, getTelegramPhotoUrl, getPlayerId } from '../utils/telegram.js';
+import { getTelegramId, getTelegramPhotoUrl, getPlayerId, extractTelegramPhoto } from '../utils/telegram.js';
 import { FaCircle } from 'react-icons/fa';
 import DailyCheckIn from '../components/DailyCheckIn.jsx';
 import SpinGame from '../components/SpinGame.jsx';
@@ -82,14 +82,16 @@ export default function Mining() {
             saveAvatar(p.photo);
           } else {
             fetchTelegramInfo(telegramId).then((info) => {
-              if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
+              const photo = extractTelegramPhoto(info);
+              if (photo) setMyPhotoUrl(photo);
             });
           }
           setMyName(p?.nickname || `${p?.firstName || ''} ${p?.lastName || ''}`.trim());
         })
         .catch(() => {
           fetchTelegramInfo(telegramId).then((info) => {
-            if (info?.photoUrl) setMyPhotoUrl(info.photoUrl);
+            const photo = extractTelegramPhoto(info);
+            if (photo) setMyPhotoUrl(photo);
             setMyName(`${info?.firstName || ''} ${info?.lastName || ''}`.trim());
           });
         });

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -13,7 +13,8 @@ import {
   getTelegramId,
   getTelegramFirstName,
   getTelegramLastName,
-  getTelegramPhotoUrl
+  getTelegramPhotoUrl,
+  extractTelegramPhoto
 } from '../utils/telegram.js';
 import LoginOptions from '../components/LoginOptions.jsx';
 import { DEV_INFO } from '../utils/constants.js';
@@ -162,11 +163,12 @@ export default function MyAccount() {
             console.error('fetchTelegramInfo failed', err);
           }
 
+          const tgPhoto = extractTelegramPhoto(tg);
           const firstName =
             data.firstName || tg?.firstName || getTelegramFirstName();
           const lastName =
             data.lastName || tg?.lastName || getTelegramLastName();
-          const photo = data.photo || tg?.photoUrl || getTelegramPhotoUrl();
+          const photo = data.photo || tgPhoto || getTelegramPhotoUrl();
 
           const updated = await updateProfile({
             telegramId,
@@ -176,7 +178,7 @@ export default function MyAccount() {
             lastName
           });
 
-          const hasRealPhoto = updated.photo || tg?.photoUrl;
+          const hasRealPhoto = updated.photo || tgPhoto;
           const mergedProfile = {
             ...data,
             ...updated,
@@ -217,7 +219,8 @@ export default function MyAccount() {
     async function updatePhoto() {
       try {
         const info = await fetchTelegramInfo(telegramId);
-        if (info?.photoUrl) setPhotoUrl(info.photoUrl);
+        const photo = extractTelegramPhoto(info);
+        if (photo) setPhotoUrl(photo);
       } catch (err) {
         console.error('fetchTelegramInfo failed', err);
       }

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -101,6 +101,11 @@ export function getTelegramUserData() {
   return null;
 }
 
+export function extractTelegramPhoto(info) {
+  if (!info) return '';
+  return info.photoUrl || info.photo_url || info.photo || '';
+}
+
 export function getTelegramPhotoUrl() {
   if (typeof window !== 'undefined') {
     const photo = window?.Telegram?.WebApp?.initDataUnsafe?.user?.photo_url;
@@ -114,8 +119,9 @@ export function getTelegramPhotoUrl() {
     if (id) {
       fetchTelegramInfo(id)
         .then((info) => {
-          if (info?.photoUrl) {
-            localStorage.setItem('telegramPhotoUrl', info.photoUrl);
+          const photoUrl = extractTelegramPhoto(info);
+          if (photoUrl) {
+            localStorage.setItem('telegramPhotoUrl', photoUrl);
             window.dispatchEvent(new Event('profilePhotoUpdated'));
           }
         })


### PR DESCRIPTION
## Summary
- add helper to normalize Telegram profile photo fields and reuse across pages
- update profile, home, mining, and leaderboard pages to consume normalized photo data for avatars
- ensure Telegram photo caching refreshes when server returns alternate field names

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694241e37a5883299180bcd554e8aa23)