### PR TITLE
Align camera with turn indicator

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -3367,20 +3367,7 @@ function TexasHoldemArena({ search }) {
     const pointerState = pointerStateRef.current;
     const isCameraDragged = pointerState?.active && pointerState.mode === 'camera';
     if (!isCameraDragged) {
-      if (seat?.isHuman) {
-        headAnglesRef.current.yaw = 0;
-        headAnglesRef.current.pitch = 0;
-        cameraAutoTargetRef.current = { yaw: 0, activeIndex: seat.index ?? focusIndex };
-        applyHeadOrientation();
-        if (!overheadView) {
-          const mount = mountRef.current;
-          const width = mount?.clientWidth ?? window.innerWidth;
-          const height = mount?.clientHeight ?? window.innerHeight;
-          viewControlsRef.current.applySeatedCamera?.(width, height, { animate: false });
-        }
-      } else {
-        focusCameraOnSeat(focusIndex, false);
-      }
+      focusCameraOnSeat(focusIndex, true);
     }
     if (seat?.isHuman) {
       playSound('knock');


### PR DESCRIPTION
## Summary
- keep the in-game camera aligned with the active seat turn indicator instead of snapping back to a default angle
- ensure camera follow remains stable while the indicator is active without altering the base view

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69424e5fd8d88329b9db556a1c140d72)