### PR TITLE
Align camera tracking with active turn indicator

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -2009,7 +2009,7 @@ function TexasHoldemArena({ search }) {
       const basis = cameraBasisRef.current;
       if (!three || !basis) return;
       const state = gameStateRef.current;
-      if (!hasSeatAvatar(state, seatIndex)) return;
+      if (!state?.players?.[seatIndex]) return;
       const seat = three.seatGroups?.[seatIndex];
       if (!seat) return;
       const focusPoint = seat.stoolAnchor.clone();
@@ -3361,8 +3361,7 @@ function TexasHoldemArena({ search }) {
     if (currentStage === 'showdown') return;
     const three = threeRef.current;
     if (!three) return;
-    const focusIndex = findSeatWithAvatar(currentActionIndex);
-    if (typeof focusIndex !== 'number') return;
+    const focusIndex = currentActionIndex;
     const seat = three.seatGroups?.[focusIndex];
     const pointerState = pointerStateRef.current;
     const isCameraDragged = pointerState?.active && pointerState.mode === 'camera';


### PR DESCRIPTION
## Summary
- ensure the Texas Hold'em camera focuses on the current action seat instead of skipping seats without avatars
- allow camera targeting to operate even when a player lacks an avatar so it stays synced with the turn indicator

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69424e5fd8d88329b9db556a1c140d72)