### PR TITLE
Align camera with turn indicator

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -123,6 +123,8 @@ const CAMERA_HEAD_PITCH_UP = THREE.MathUtils.degToRad(8);
 const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(52);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0;
+const TURN_INDICATOR_HEIGHT = CARD_H * 0.42;
+const TURN_INDICATOR_RADIUS = CARD_W * 0.62;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.08, landscape: 0.5 });
 const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 1.7, landscape: 1.16 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.6, landscape: 1.18 });
@@ -1746,6 +1748,7 @@ function TexasHoldemArena({ search }) {
   const seatTopPointRef = useRef(null);
   const viewControlsRef = useRef({ applySeatedCamera: null, applyOverheadCamera: null });
   const lastViewRef = useRef(false);
+  const turnIndicatorRef = useRef(null);
   const cameraBasisRef = useRef({
     position: new THREE.Vector3(),
     baseForward: new THREE.Vector3(0, 0, -1),
@@ -2779,6 +2782,22 @@ function TexasHoldemArena({ search }) {
       }
       arenaGroup.add(potLabel);
 
+      const turnIndicator = new THREE.Mesh(
+        new THREE.RingGeometry(TURN_INDICATOR_RADIUS * 0.6, TURN_INDICATOR_RADIUS, 48),
+        new THREE.MeshBasicMaterial({
+          color: new THREE.Color('#38bdf8'),
+          transparent: true,
+          opacity: 0.88,
+          side: THREE.DoubleSide,
+          depthWrite: false
+        })
+      );
+      turnIndicator.rotation.x = -Math.PI / 2;
+      turnIndicator.position.copy(cameraTarget.clone().setY(TABLE_HEIGHT + TURN_INDICATOR_HEIGHT));
+      turnIndicator.visible = false;
+      arenaGroup.add(turnIndicator);
+      turnIndicatorRef.current = turnIndicator;
+
       const orientHumanCards = () => {
         const humanSeatGroup = seatGroups.find((seat) => seat.isHuman);
         if (!humanSeatGroup) return;
@@ -2818,6 +2837,7 @@ function TexasHoldemArena({ search }) {
           deckAnchor,
           raiseControls,
           raycaster,
+          turnIndicator,
           orientHumanCards,
           frameId: null,
           chairTemplate,
@@ -3105,6 +3125,16 @@ function TexasHoldemArena({ search }) {
           threeRef.current.potLabel.userData?.dispose?.();
           threeRef.current.potLabel.parent?.remove(threeRef.current.potLabel);
         }
+        if (turnIndicator) {
+          turnIndicator.geometry?.dispose?.();
+          if (Array.isArray(turnIndicator.material)) {
+            turnIndicator.material.forEach((mat) => mat?.dispose?.());
+          } else {
+            turnIndicator.material?.dispose?.();
+          }
+          arena?.remove(turnIndicator);
+          turnIndicatorRef.current = null;
+        }
         factory.disposeStack(threeRef.current.potStack);
         factory.dispose();
         arena?.parent?.remove(arena);
@@ -3358,28 +3388,38 @@ function TexasHoldemArena({ search }) {
   const currentStage = gameState?.stage;
   useEffect(() => {
     if (typeof currentActionIndex !== 'number') return;
-    if (currentStage === 'showdown') return;
+    if (currentStage === 'showdown') {
+      if (turnIndicatorRef.current) {
+        turnIndicatorRef.current.visible = false;
+      }
+      return;
+    }
     const three = threeRef.current;
     if (!three) return;
     const focusIndex = findSeatWithAvatar(currentActionIndex);
     if (typeof focusIndex !== 'number') return;
     const seat = three.seatGroups?.[focusIndex];
+    const indicator = three.turnIndicator;
+    if (indicator) {
+      if (seat) {
+        const anchor = seat.cardAnchor?.clone() ?? seat.seatPos.clone();
+        anchor.y = seat.stoolHeight + TURN_INDICATOR_HEIGHT;
+        indicator.position.copy(anchor);
+        indicator.lookAt(anchor.clone().add(seat.forward));
+        indicator.visible = true;
+      } else {
+        indicator.visible = false;
+      }
+    }
     const pointerState = pointerStateRef.current;
     const isCameraDragged = pointerState?.active && pointerState.mode === 'camera';
     if (!isCameraDragged) {
-      if (seat?.isHuman) {
-        headAnglesRef.current.yaw = 0;
-        headAnglesRef.current.pitch = 0;
-        cameraAutoTargetRef.current = { yaw: 0, activeIndex: seat.index ?? focusIndex };
-        applyHeadOrientation();
-        if (!overheadView) {
-          const mount = mountRef.current;
-          const width = mount?.clientWidth ?? window.innerWidth;
-          const height = mount?.clientHeight ?? window.innerHeight;
-          viewControlsRef.current.applySeatedCamera?.(width, height, { animate: false });
-        }
-      } else {
-        focusCameraOnSeat(focusIndex, false);
+      focusCameraOnSeat(focusIndex, Boolean(seat?.isHuman));
+      if (seat?.isHuman && !overheadView) {
+        const mount = mountRef.current;
+        const width = mount?.clientWidth ?? window.innerWidth;
+        const height = mount?.clientHeight ?? window.innerHeight;
+        viewControlsRef.current.applySeatedCamera?.(width, height, { animate: false });
       }
     }
     if (seat?.isHuman) {


### PR DESCRIPTION
## Summary
- add turn indicator mesh to the Texas Hold'em arena and clean it up on teardown
- sync the indicator position with the active seat and drive the camera auto-target from it
- keep the camera aligned to the indicator during turns without changing the viewing angle

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69424e5fd8d88329b9db556a1c140d72)