### PR TITLE
Fix Pool Royale highlight downloads in Telegram

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -9586,22 +9586,52 @@ function PoolRoyaleGame({
     }
   }, [frameState.winner, opponentLabel]);
 
-  const handleDownloadHighlight = useCallback(() => {
-    if (!highlightBlobRef.current || !highlightVideoUrl) return;
-    const link = document.createElement('a');
-    link.href = highlightVideoUrl;
-    link.download = `pool-royale-highlights-${highlightQualityRef.current}.webm`;
-    link.rel = 'noopener';
-    link.target = '_blank';
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
+  const readBlobAsDataUrl = useCallback((blob) => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        if (typeof reader.result === 'string') resolve(reader.result);
+        else reject(new Error('Unable to read highlight file.'));
+      };
+      reader.onerror = () => reject(reader.error || new Error('Failed to read highlight file.'));
+      reader.readAsDataURL(blob);
+    });
+  }, []);
 
+  const handleDownloadHighlight = useCallback(async () => {
+    if (!highlightBlobRef.current || !highlightVideoUrl) return;
+
+    const blob = highlightBlobRef.current;
+    const fileName = `pool-royale-highlights-${highlightQualityRef.current}.webm`;
     const tg = window?.Telegram?.WebApp;
-    if (tg?.openLink) {
-      tg.openLink(highlightVideoUrl, { try_instant_view: false });
+
+    if (window.navigator?.msSaveOrOpenBlob) {
+      window.navigator.msSaveOrOpenBlob(blob, fileName);
+    } else {
+      const blobUrl = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = blobUrl;
+      link.download = fileName;
+      link.rel = 'noopener';
+      link.style.display = 'none';
+      document.body.appendChild(link);
+      link.click();
+
+      setTimeout(() => {
+        link.remove();
+        URL.revokeObjectURL(blobUrl);
+      });
     }
-  }, [highlightVideoUrl]);
+
+    if (tg?.openLink) {
+      try {
+        const dataUrl = await readBlobAsDataUrl(blob);
+        tg.openLink(dataUrl, { try_instant_view: false });
+      } catch (err) {
+        console.error('Unable to open highlight download inside Telegram', err);
+      }
+    }
+  }, [highlightVideoUrl, readBlobAsDataUrl]);
 
   const handleEnterHighlightFullscreen = useCallback(() => {
     const node = highlightVideoRef.current;


### PR DESCRIPTION
## Summary
- add blob-to-data-url fallback so Telegram WebView can open highlight downloads
- ensure downloads trigger via object URLs with legacy browser support

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942717c58b083299bc95e8b391e3286)