### PR TITLE
Improve Pool Royale highlight download support

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -9587,19 +9587,43 @@ function PoolRoyaleGame({
   }, [frameState.winner, opponentLabel]);
 
   const handleDownloadHighlight = useCallback(() => {
-    if (!highlightBlobRef.current || !highlightVideoUrl) return;
-    const link = document.createElement('a');
-    link.href = highlightVideoUrl;
-    link.download = `pool-royale-highlights-${highlightQualityRef.current}.webm`;
-    link.rel = 'noopener';
-    link.target = '_blank';
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
+    const blob = highlightBlobRef.current;
+    if (!blob) return;
 
+    const fileName = `pool-royale-highlights-${highlightQualityRef.current}.webm`;
+    const downloadUrl = highlightVideoUrl || URL.createObjectURL(blob);
+
+    const triggerAnchorDownload = () => {
+      const anchor = document.createElement('a');
+      anchor.href = downloadUrl;
+      anchor.download = fileName;
+      anchor.rel = 'noopener';
+      anchor.target = '_self';
+      anchor.style.position = 'fixed';
+      anchor.style.left = '-9999px';
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+    };
+
+    // Try the most compatible approach first.
+    if (window.navigator?.msSaveOrOpenBlob) {
+      window.navigator.msSaveOrOpenBlob(blob, fileName);
+    } else {
+      triggerAnchorDownload();
+    }
+
+    // Telegram's in-app browser sometimes blocks the download attribute; open the link as a fallback.
     const tg = window?.Telegram?.WebApp;
     if (tg?.openLink) {
-      tg.openLink(highlightVideoUrl, { try_instant_view: false });
+      tg.openLink(downloadUrl, { try_instant_view: false });
+    } else {
+      window.open(downloadUrl, '_blank', 'noopener');
+    }
+
+    if (!highlightVideoUrl) {
+      // If we created a temporary URL for this download, clean it up after the user gesture.
+      setTimeout(() => URL.revokeObjectURL(downloadUrl), 3000);
     }
   }, [highlightVideoUrl]);
 


### PR DESCRIPTION
## Summary
- ensure Pool Royale highlights download via compatible anchor fallback and IE-specific blob save when available
- add Telegram and browser fallbacks to open the generated video if the download attribute is blocked
- clean up temporary object URLs created solely for downloading

## Testing
- npm test -- --runInBand *(fails: Jest config references missing /workspace/TonPlaygramWebApp/tests directory)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942717c58b083299bc95e8b391e3286)