### PR TITLE
Fix Pool Royale highlight downloads in Telegram

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -9587,19 +9587,34 @@ function PoolRoyaleGame({
   }, [frameState.winner, opponentLabel]);
 
   const handleDownloadHighlight = useCallback(() => {
-    if (!highlightBlobRef.current || !highlightVideoUrl) return;
-    const link = document.createElement('a');
-    link.href = highlightVideoUrl;
-    link.download = `pool-royale-highlights-${highlightQualityRef.current}.webm`;
-    link.rel = 'noopener';
-    link.target = '_blank';
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
+    const blob = highlightBlobRef.current;
+    if (!blob || !highlightVideoUrl) return;
 
     const tg = window?.Telegram?.WebApp;
-    if (tg?.openLink) {
-      tg.openLink(highlightVideoUrl, { try_instant_view: false });
+    const isTelegram = Boolean(tg);
+    const filename = `pool-royale-highlights-${highlightQualityRef.current}.webm`;
+    const blobUrl =
+      highlightVideoUrl.startsWith('blob:') && blob instanceof Blob
+        ? highlightVideoUrl
+        : URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = blobUrl;
+    link.download = filename;
+    link.rel = 'noopener';
+    link.target = isTelegram ? '_self' : '_blank';
+    link.style.display = 'none';
+    document.body.appendChild(link);
+    link.click();
+    setTimeout(() => {
+      link.remove();
+      if (blobUrl !== highlightVideoUrl && blobUrl.startsWith('blob:')) {
+        URL.revokeObjectURL(blobUrl);
+      }
+    }, 0);
+
+    if (isTelegram && tg?.openLink) {
+      tg.openLink(blobUrl, { try_instant_view: false });
     }
   }, [highlightVideoUrl]);
 


### PR DESCRIPTION
## Summary
- update the Pool Royale highlight download handler to use a Telegram-friendly anchor download flow
- ensure blob URLs are cleaned up and provide a fallback openLink call when running inside Telegram

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69427d30f2d88329a475af9c817e6e19)