### PR TITLE
Make side pockets absorb shots like corner pockets

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -151,7 +151,10 @@ public class BilliardsSolver
         // Use a thinner cushion band on side pockets so balls aren't deflected before
         // they visually reach the jaw lips. The corner pockets keep the full
         // PhysicsConstants.JawCushionSegments setting.
-        int cushionBands = Math.Max(1, Math.Min(PhysicsConstants.JawCushionSegments - 1, Math.Max(1, pts.Count - 1)));
+        // Treat the entire side jaw as pocket-absorbing geometry so balls don't glance
+        // off an invisible cushion band before visually reaching the mouth. Corner
+        // pockets keep their own cushion treatment.
+        int cushionBands = 0;
         for (int i = 0; i < pts.Count - 1; i++)
         {
             Vec2 a = pts[i];


### PR DESCRIPTION
## Summary
- treat side pocket jaw segments as pocket-absorbing geometry to prevent early deflection and match corner pocket behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942e726eb7c8329bdeb16bf530492b2)