### PR TITLE
Align side pocket physics with corners

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -148,10 +148,9 @@ public class BilliardsSolver
         }
 
         Vec2 hint = vertical ? new Vec2(positive ? 1 : -1, 0) : new Vec2(0, positive ? 1 : -1);
-        // Use a thinner cushion band on side pockets so balls aren't deflected before
-        // they visually reach the jaw lips. The corner pockets keep the full
-        // PhysicsConstants.JawCushionSegments setting.
-        int cushionBands = Math.Max(1, Math.Min(PhysicsConstants.JawCushionSegments - 1, Math.Max(1, pts.Count - 1)));
+        // Match the cushion treatment of corner pockets so balls contact the jaws only
+        // once they visually reach the lip.
+        int cushionBands = Math.Max(1, Math.Min(PhysicsConstants.JawCushionSegments, Math.Max(1, pts.Count - 1)));
         for (int i = 0; i < pts.Count - 1; i++)
         {
             Vec2 a = pts[i];

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -24,9 +24,8 @@ public static class PhysicsConstants
     public const double CornerPocketMouth = 0.1057275; // scaled with table reduction
     public const double SidePocketMouth = 0.117475;    // scaled with table reduction
     public const double PocketCaptureRadius = 0.087875; // scaled with table reduction
-    // Offset that moves the side pockets slightly outside the rail line so the
-    // chrome plates and wooden rails sit flush with the rounded cuts.
-    public const double SidePocketOutset = 0.03;
+    // Keep side pockets aligned with the rail line so they behave identically to corner pockets.
+    public const double SidePocketOutset = 0.0;
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 32;


### PR DESCRIPTION
## Summary
- align side pocket positions with the rail line to match corner pocket placement
- use the same cushion band treatment on side pockets so collisions occur at the lip

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942e726eb7c8329bdeb16bf530492b2)