### PR TITLE
Improve pool AI shot selection

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -492,7 +492,8 @@ function estimatePotProbability (shot, state) {
   const pocketViewDeg = Math.atan2(state.ballRadius * 2, shot.distTP || 1) * 180 / Math.PI
   const cutRatio = angleDeg / (pocketViewDeg + 1e-6)
   const maxD = Math.hypot(state.width, state.height)
-  const distScore = 1 - Math.min((shot.distCT + shot.distTP) / maxD, 1)
+  const totalDistNorm = Math.min((shot.distCT + shot.distTP) / maxD, 1)
+  const distScore = Math.pow(1 - totalDistNorm, 1.2)
   const cueBall = state.balls.find(b => b.colour === 'cue')
   const laneClearance = clearanceMargin(
     cueBall,
@@ -505,12 +506,12 @@ function estimatePotProbability (shot, state) {
   const clearanceScore = Math.max(0, Math.min(1, (laneClearance - 0.6) / 0.8))
 
   // sharper lines receive a steeper falloff to mimic pro precision
-  const eliteStraightWindow = 0.65
-  let angleScore = Math.max(0, 1 - Math.pow(Math.max(0, cutRatio - eliteStraightWindow), 1.35))
+  const eliteStraightWindow = 0.55
+  let angleScore = Math.max(0, 1 - Math.pow(Math.max(0, cutRatio - eliteStraightWindow), 1.5))
 
   // banks are harder; drop probability but still evaluate
   if (shot.isBank) {
-    angleScore *= 0.55
+    angleScore *= 0.45
   }
 
   // combine distance, angle, and lane cleanliness with stronger emphasis on accuracy
@@ -535,6 +536,21 @@ function estimatePotProbability (shot, state) {
   const target = shot.targetBall
   if (target && (Math.min(target.x, state.width - target.x) < state.ballRadius * 2 || Math.min(target.y, state.height - target.y) < state.ballRadius * 2)) {
     P -= 0.08
+  }
+  // penalty for long travel + tight pockets
+  P -= totalDistNorm * 0.08
+  const pocketLaneClearance = shot.pocket && shot.targetBall
+    ? clearanceMargin(
+      shot.targetBall,
+      shot.pocket,
+      state.balls,
+      [shot.targetBall?.id, cueBall?.id].filter(Boolean),
+      state.ballRadius,
+      1.4
+    )
+    : 1
+  if (pocketLaneClearance < 1) {
+    P -= (1 - pocketLaneClearance) * 0.25
   }
   P -= foulRisk(shot, state) * 0.35
 
@@ -724,7 +740,16 @@ function chooseBestAction (state, colour) {
   // explored when every straight look is blocked so the AI plays bank/kick
   // shots as a last resort rather than by default.
   const directPots = generatePotCandidates(state, colour)
-  let candidates = [...directPots]
+  const directRanked = directPots
+    .map(c => {
+      const prob = estimatePotProbability(c, state)
+      const straightBonus = typeof c.angle === 'number' ? Math.max(0, (Math.PI / 14 - c.angle) / (Math.PI / 14)) : 0
+      const distanceEase = 1 - Math.min((c.distCT + c.distTP) / Math.hypot(state.width, state.height), 1)
+      const ease = prob * 0.6 + straightBonus * 0.25 + distanceEase * 0.15
+      return { c, prob, ease }
+    })
+    .sort((a, b) => b.prob - a.prob || b.ease - a.ease)
+  let candidates = directRanked.map(r => r.c)
   const kicks = generateKickCandidates(state, colour, 4)
 
   if (candidates.length === 0) {
@@ -744,19 +769,23 @@ function chooseBestAction (state, colour) {
     // No clear potting opportunity – fall back to defensive play.
     candidates = generateSafeties(state, colour)
   } else {
-    const scored = candidates.map(c =>
-      c.actionType === 'pot'
-        ? estimatePotProbability(c, state)
-        : 0
-    )
+    const scored = candidates.map(c => c.actionType === 'pot' ? estimatePotProbability(c, state) : 0)
     const maxPot = scored.reduce((m, p) => Math.max(m, p), 0)
     if (maxPot < 0.35) {
       candidates = candidates.concat(generateSafeties(state, colour))
+    } else {
+      // Keep only the best looking direct pots before exploring exotic shots.
+      const topDirect = directRanked.filter(r => r.prob >= 0.55).slice(0, 4).map(r => r.c)
+      if (topDirect.length > 0) {
+        candidates = topDirect
+      } else if (maxPot >= 0.4) {
+        candidates = directRanked.slice(0, 5).map(r => r.c)
+      }
     }
   }
   const qualityFiltered = candidates.filter(c => {
     if (c.actionType !== 'pot') return true
-    return estimatePotProbability(c, state) >= 0.2
+    return estimatePotProbability(c, state) >= 0.3
   })
   if (qualityFiltered.length > 0) {
     candidates = qualityFiltered


### PR DESCRIPTION
## Summary
- strengthen pot probability scoring to penalize long or blocked lines and reward clean, straight looks
- prioritize high-probability direct pots while de-emphasizing banks, kicks, and speculative attempts

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69438fc0995483299369db1c0bbd14b2)