### PR TITLE
Improve pool AI target selection

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -220,15 +220,19 @@ function clearShotCandidates (req) {
       const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
       const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
       const weightedView = viewScore * (0.7 + 0.3 * entryAlignment)
+      const approachStraightness = 1 - Math.min(cut / (Math.PI / 2), 1)
+      const cueToTarget = cue ? dist(cue, target) : 0
+      const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
+      const rank = weightedView * 0.5 + approachStraightness * 0.3 + distanceScore * 0.2
 
       // require fairly central hit and open pocket view
       if (cut <= maxCut && weightedView >= minView) {
-        candidates.push({ target, pocket, cut, view: weightedView })
+        candidates.push({ target, pocket, cut, view: weightedView, rank })
       }
     }
   }
 
-  candidates.sort((a, b) => a.cut - b.cut || b.view - a.view)
+  candidates.sort((a, b) => b.rank - a.rank || a.cut - b.cut || b.view - a.view)
   return candidates
 }
 
@@ -401,6 +405,11 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
   const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
   const pocketOpen = viewScore * (0.7 + 0.3 * entryAlignment)
+  const cueToTarget = dist(cue, target)
+  const shotLengthFactor = Math.min(cueToTarget / (r * 40), 2)
+  const cutSeverity = Math.min(cutAngle / (Math.PI / 2), 1)
+  const pocketTightness = 1 - pocketOpen
+  const difficultyPenalty = 0.25 * (0.5 * cutSeverity + 0.3 * shotLengthFactor + 0.2 * pocketTightness)
   if (strict && (centerAlign < 0.5 || pocketOpen < 0.3)) {
     return null
   }
@@ -414,13 +423,14 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     0,
     Math.min(
       1,
-      0.3 * potChance +
-        0.2 * centerAlign +
-        0.18 * pocketOpen +
-        0.08 * nextScore +
-        0.08 * nearHole +
-        0.16 * runoutPotential -
-        0.2 * risk
+      0.42 * potChance +
+        0.2 * pocketOpen +
+        0.18 * centerAlign +
+        0.06 * nextScore +
+        0.06 * nearHole +
+        0.08 * runoutPotential -
+        0.15 * risk -
+        difficultyPenalty
     )
   )
   const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
@@ -518,6 +528,7 @@ export function planShot (req) {
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity
   let best = null
   let fallback = null
+  let hasViableShot = false
 
   const powers = [0.5, 0.7, 0.85]
   const spins = [
@@ -596,6 +607,7 @@ export function planShot (req) {
           { lookaheadDepth: LOOKAHEAD_DEPTH }
         )
         if (baseCand) {
+          hasViableShot = true
           const { nextScore, hasNext, ...rest } = baseCand
           if (!best || rest.quality > best.quality) {
             best = { ...rest, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
@@ -624,6 +636,7 @@ export function planShot (req) {
               { lookaheadDepth: LOOKAHEAD_DEPTH }
             )
             if (cand) {
+              hasViableShot = true
               const { nextScore, hasNext, ...rest } = cand
               if (!best || rest.quality > best.quality) {
                 best = { ...rest, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
@@ -636,7 +649,11 @@ export function planShot (req) {
     if (best) break
   }
 
-  if (best && best.quality >= 0.1) return best
+  if (best) {
+    if (best.quality >= 0.1) return best
+    if (hasViableShot) return best
+  }
+  if (!hasViableShot) return safetyShot(req)
   fallback = fallbackAimAtTarget(req)
   if (fallback) return fallback
   return safetyShot(req)

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -220,15 +220,19 @@ function clearShotCandidates (req) {
       const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
       const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
       const weightedView = viewScore * (0.7 + 0.3 * entryAlignment)
+      const approachStraightness = 1 - Math.min(cut / (Math.PI / 2), 1)
+      const cueToTarget = cue ? dist(cue, target) : 0
+      const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
+      const rank = weightedView * 0.5 + approachStraightness * 0.3 + distanceScore * 0.2
 
       // require fairly central hit and open pocket view
       if (cut <= maxCut && weightedView >= minView) {
-        candidates.push({ target, pocket, cut, view: weightedView })
+        candidates.push({ target, pocket, cut, view: weightedView, rank })
       }
     }
   }
 
-  candidates.sort((a, b) => a.cut - b.cut || b.view - a.view)
+  candidates.sort((a, b) => b.rank - a.rank || a.cut - b.cut || b.view - a.view)
   return candidates
 }
 
@@ -401,6 +405,11 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
   const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
   const pocketOpen = viewScore * (0.7 + 0.3 * entryAlignment)
+  const cueToTarget = dist(cue, target)
+  const shotLengthFactor = Math.min(cueToTarget / (r * 40), 2)
+  const cutSeverity = Math.min(cutAngle / (Math.PI / 2), 1)
+  const pocketTightness = 1 - pocketOpen
+  const difficultyPenalty = 0.25 * (0.5 * cutSeverity + 0.3 * shotLengthFactor + 0.2 * pocketTightness)
   if (strict && (centerAlign < 0.5 || pocketOpen < 0.3)) {
     return null
   }
@@ -414,13 +423,14 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     0,
     Math.min(
       1,
-      0.3 * potChance +
-        0.2 * centerAlign +
-        0.18 * pocketOpen +
-        0.08 * nextScore +
-        0.08 * nearHole +
-        0.16 * runoutPotential -
-        0.2 * risk
+      0.42 * potChance +
+        0.2 * pocketOpen +
+        0.18 * centerAlign +
+        0.06 * nextScore +
+        0.06 * nearHole +
+        0.08 * runoutPotential -
+        0.15 * risk -
+        difficultyPenalty
     )
   )
   const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
@@ -518,6 +528,7 @@ export function planShot (req) {
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity
   let best = null
   let fallback = null
+  let hasViableShot = false
 
   const powers = [0.5, 0.7, 0.85]
   const spins = [
@@ -596,6 +607,7 @@ export function planShot (req) {
           { lookaheadDepth: LOOKAHEAD_DEPTH }
         )
         if (baseCand) {
+          hasViableShot = true
           const { nextScore, hasNext, ...rest } = baseCand
           if (!best || rest.quality > best.quality) {
             best = { ...rest, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
@@ -624,6 +636,7 @@ export function planShot (req) {
               { lookaheadDepth: LOOKAHEAD_DEPTH }
             )
             if (cand) {
+              hasViableShot = true
               const { nextScore, hasNext, ...rest } = cand
               if (!best || rest.quality > best.quality) {
                 best = { ...rest, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
@@ -636,7 +649,11 @@ export function planShot (req) {
     if (best) break
   }
 
-  if (best && best.quality >= 0.1) return best
+  if (best) {
+    if (best.quality >= 0.1) return best
+    if (hasViableShot) return best
+  }
+  if (!hasViableShot) return safetyShot(req)
   fallback = fallbackAimAtTarget(req)
   if (fallback) return fallback
   return safetyShot(req)


### PR DESCRIPTION
## Summary
- Rank pocket candidates by view, straightness, and distance so the AI prioritizes easier shots
- Heavily penalize difficult cut and long-distance attempts in the quality score to choose safer pots
- Return a safety play when no viable paths exist instead of forcing blocked fallback aims

## Testing
- node --test test/poolAi.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69438fc0995483299369db1c0bbd14b2)