### PR TITLE
Handle empty blackjack decks before standing

### DIFF
--- a/webapp/src/pages/Games/BlackJackArena.jsx
+++ b/webapp/src/pages/Games/BlackJackArena.jsx
@@ -1164,6 +1164,15 @@ function buildInitialState(players, token, stake) {
   };
 }
 
+function ensureDeckSize(deck, required = 1) {
+  const need = Number.isFinite(required) && required > 0 ? Math.ceil(required) : 1;
+  const safeDeck = Array.isArray(deck) ? [...deck] : [];
+  if (safeDeck.length >= need) {
+    return safeDeck;
+  }
+  return shuffle(createDeck());
+}
+
 function resetForNextRound(state) {
   const next = { ...state, round: state.round + 1 };
   next.deck = shuffle(createDeck());
@@ -1206,6 +1215,8 @@ function placeInitialBets(state, options = {}) {
 }
 
 function dealInitialCards(state) {
+  const requiredCards = state.players.length * 2;
+  state.deck = ensureDeckSize(state.deck, requiredCards);
   const { hands, deck } = dealInitial(state.deck, state.players.length);
   state.deck = deck;
   state.players.forEach((player, idx) => {
@@ -1264,12 +1275,24 @@ function resolveRound(state) {
   state.winners = winnerSeats;
 }
 
+function drawCard(state) {
+  state.deck = ensureDeckSize(state.deck, 1);
+  const { card, deck } = hitCard(state.deck);
+  state.deck = deck;
+  return card || null;
+}
+
 function applyPlayerAction(state, action) {
   const player = state.players[state.currentIndex];
   if (!player) return;
   if (action === 'hit') {
-    const { card, deck } = hitCard(state.deck);
-    state.deck = deck;
+    const card = drawCard(state);
+    if (!card) {
+      player.stood = true;
+      player.result = 'No cards left';
+      advancePlayer(state);
+      return;
+    }
     player.hand.push(card);
     player.revealed = true;
     player.viewed = true;

--- a/webapp/src/utils/blackjackLogic.js
+++ b/webapp/src/utils/blackjackLogic.js
@@ -38,17 +38,25 @@ export function hitCard(deck) {
 }
 
 function cardValue(rank) {
-  if (rank === 'A') return 11;
-  if (rank === 'K' || rank === 'Q' || rank === 'J' || rank === 'T') return 10;
-  return Number.parseInt(rank, 10);
+  if (!rank && rank !== 0) return 0;
+  const normalized = String(rank).toUpperCase();
+  if (normalized === 'A') return 11;
+  if (normalized === 'K' || normalized === 'Q' || normalized === 'J' || normalized === 'T') return 10;
+  const parsed = Number.parseInt(normalized, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 export function handValue(hand) {
+  if (!Array.isArray(hand) || hand.length === 0) {
+    return 0;
+  }
   let total = 0;
   let aces = 0;
   hand.forEach((card) => {
-    total += cardValue(card.rank);
-    if (card.rank === 'A') aces += 1;
+    if (!card) return;
+    const value = cardValue(card.rank);
+    total += value;
+    if (String(card.rank).toUpperCase() === 'A') aces += 1;
   });
   while (total > 21 && aces > 0) {
     total -= 10;


### PR DESCRIPTION
## Summary
- refill or guard the blackjack deck before dealing or drawing so hands never include missing cards
- make hand value calculation resilient to invalid cards to avoid stand-time crashes

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69438f070e6c8329a58cf79caf7cd24f)