### PR TITLE
Add developer assistant for repo-aware webapp search

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -13,6 +13,7 @@ import Messages from './pages/Messages.jsx';
 import Trending from './pages/Trending.jsx';
 import Notifications from './pages/Notifications.jsx';
 import InfluencerAdmin from './pages/InfluencerAdmin.jsx';
+import DevAssistant from './pages/DevAssistant.jsx';
 
 import SnakeAndLadder from './pages/Games/SnakeAndLadder.jsx';
 import SnakeMultiplayer from './pages/Games/SnakeMultiplayer.jsx';
@@ -152,6 +153,7 @@ export default function App() {
             <Route path="/notifications" element={<Notifications />} />
             <Route path="/trending" element={<Trending />} />
             <Route path="/account" element={<MyAccount />} />
+            <Route path="/dev/assistant" element={<DevAssistant />} />
           </Routes>
         </Layout>
       </TonConnectUIProvider>

--- a/webapp/src/pages/DevAssistant.jsx
+++ b/webapp/src/pages/DevAssistant.jsx
@@ -1,0 +1,266 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { FileSearch, MessageSquare, ShieldAlert, Sparkles, Loader2 } from 'lucide-react';
+
+const devOnly = import.meta.env.DEV;
+
+function SectionCard({ title, icon: Icon, children, action }) {
+  return (
+    <section className="bg-surface border border-accent rounded-xl shadow-sm p-4 space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Icon className="w-5 h-5 text-accent" />
+          <h2 className="text-lg font-semibold">{title}</h2>
+        </div>
+        {action}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export default function DevAssistant() {
+  const [query, setQuery] = useState('');
+  const [messages, setMessages] = useState([
+    {
+      role: 'assistant',
+      text:
+        'I am the TonPlaygram dev assistant. Ask me about any part of the repo, and I will search the local codebase, surface matches with line numbers, and let you inspect full files. This tool is only active in local development and indexes the repository directly from disk.'
+    }
+  ]);
+  const [searchResults, setSearchResults] = useState([]);
+  const [filesIndexed, setFilesIndexed] = useState([]);
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [fileContent, setFileContent] = useState('');
+  const [loadingSearch, setLoadingSearch] = useState(false);
+  const [loadingFile, setLoadingFile] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!devOnly) return;
+    const loadIndex = async () => {
+      try {
+        const res = await fetch('/api/dev-assistant/index');
+        const data = await res.json();
+        setFilesIndexed(data.files || []);
+      } catch (err) {
+        setError('Failed to load the code index. Make sure the Vite dev server is running.');
+      }
+    };
+    loadIndex();
+  }, []);
+
+  const askAssistant = async (event) => {
+    event.preventDefault();
+    if (!query.trim()) return;
+    setError('');
+    const userMessage = { role: 'user', text: query.trim() };
+    setMessages((prev) => [...prev, userMessage]);
+    setLoadingSearch(true);
+
+    try {
+      const res = await fetch(`/api/dev-assistant/search?q=${encodeURIComponent(query.trim())}`);
+      const data = await res.json();
+      setSearchResults(data.results || []);
+
+      const summary = buildSummaryResponse(query.trim(), data.results || [], data.scanned || 0);
+      setMessages((prev) => [...prev, { role: 'assistant', text: summary }]);
+    } catch (err) {
+      setError('Search failed. Verify the dev server is running and try again.');
+    } finally {
+      setLoadingSearch(false);
+    }
+  };
+
+  const openFile = async (relativePath) => {
+    setSelectedFile(relativePath);
+    setLoadingFile(true);
+    setError('');
+    try {
+      const res = await fetch(`/api/dev-assistant/file?path=${encodeURIComponent(relativePath)}`);
+      const data = await res.json();
+      if (data.error) throw new Error(data.error);
+      setFileContent(data.content || '');
+    } catch (err) {
+      setError('Unable to read file. The path may be missing or outside the repo.');
+    } finally {
+      setLoadingFile(false);
+    }
+  };
+
+  const filteredFiles = useMemo(() => {
+    if (!query.trim()) return filesIndexed;
+    return filesIndexed.filter((file) => file.toLowerCase().includes(query.trim().toLowerCase()));
+  }, [filesIndexed, query]);
+
+  if (!devOnly) {
+    return (
+      <div className="max-w-4xl mx-auto bg-surface border border-accent rounded-xl p-6 space-y-4">
+        <div className="flex items-center gap-3 text-amber-500">
+          <ShieldAlert className="w-6 h-6" />
+          <h1 className="text-xl font-semibold">Dev assistant unavailable</h1>
+        </div>
+        <p className="text-text/80">
+          This assistant is restricted to developer builds. Start the Vite dev server locally to enable
+          repository-aware search and file inspection.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto space-y-6">
+      <div className="bg-surface border border-accent rounded-xl shadow-sm p-6 space-y-2">
+        <div className="flex items-center gap-2">
+          <Sparkles className="w-6 h-6 text-accent" />
+          <h1 className="text-2xl font-bold">TonPlaygram Dev Assistant</h1>
+        </div>
+        <p className="text-text/80">
+          Private, repo-aware helper for developers. I scan the local file system (no network calls) and respond with
+          file matches and content previews so you can test games and the webapp quickly.
+        </p>
+      </div>
+
+      {error && (
+        <div className="bg-rose-100 text-rose-900 border border-rose-300 rounded-lg p-3">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <div className="lg:col-span-2 space-y-4">
+          <SectionCard title="Ask the assistant" icon={MessageSquare}
+            action={loadingSearch && <Loader2 className="w-5 h-5 animate-spin text-accent" />}>
+            <form onSubmit={askAssistant} className="space-y-3">
+              <label className="text-sm text-text/70">Describe what you want to inspect</label>
+              <div className="flex flex-col sm:flex-row gap-3">
+                <input
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search for a component, hook, or keyword..."
+                  className="flex-1 rounded-lg border border-accent bg-background px-3 py-2 focus:outline-none focus:ring-2 focus:ring-accent"
+                />
+                <button
+                  type="submit"
+                  className="inline-flex items-center justify-center gap-2 bg-accent text-background font-semibold px-4 py-2 rounded-lg shadow hover:shadow-md transition"
+                  disabled={loadingSearch}
+                >
+                  <FileSearch className="w-5 h-5" />
+                  {loadingSearch ? 'Searching…' : 'Search code'}
+                </button>
+              </div>
+            </form>
+
+            <div className="space-y-3 max-h-72 overflow-y-auto pr-1">
+              {messages.map((msg, idx) => (
+                <div
+                  key={`${msg.role}-${idx}`}
+                  className={`rounded-lg px-3 py-2 text-sm ${
+                    msg.role === 'assistant'
+                      ? 'bg-background border border-accent/60'
+                      : 'bg-accent/20 border border-accent'
+                  }`}
+                >
+                  <div className="font-semibold mb-1">
+                    {msg.role === 'assistant' ? 'Assistant' : 'You'}
+                  </div>
+                  <div className="whitespace-pre-wrap leading-relaxed text-text/90">{msg.text}</div>
+                </div>
+              ))}
+            </div>
+          </SectionCard>
+
+          <SectionCard title="Search matches" icon={Sparkles}>
+            {loadingSearch && (
+              <div className="flex items-center gap-2 text-text/80">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span>Scanning repository…</span>
+              </div>
+            )}
+            {!loadingSearch && !searchResults.length && (
+              <p className="text-text/70">No matches yet. Ask a question or search for a keyword.</p>
+            )}
+            <div className="space-y-3 max-h-80 overflow-y-auto pr-1">
+              {searchResults.map((result) => (
+                <div key={result.path} className="border border-accent rounded-lg p-3 bg-background">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="font-semibold text-sm text-accent break-all">{result.path}</p>
+                    <button
+                      type="button"
+                      onClick={() => openFile(result.path)}
+                      className="text-sm text-accent underline"
+                    >
+                      Open
+                    </button>
+                  </div>
+                  <ul className="mt-2 space-y-1 text-sm text-text/80">
+                    {result.matches.map((match) => (
+                      <li key={`${result.path}-${match.lineNumber}`} className="font-mono">
+                        <span className="text-accent mr-2">{match.lineNumber}.</span>
+                        {match.line}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </SectionCard>
+        </div>
+
+        <div className="space-y-4">
+          <SectionCard title="File index" icon={FileSearch}
+            action={<span className="text-xs text-text/60">{filesIndexed.length} files</span>}>
+            <p className="text-sm text-text/70">
+              Filtered by your query. Tap a file to preview its contents directly from disk.
+            </p>
+            <div className="max-h-72 overflow-y-auto border border-accent/40 rounded-lg divide-y divide-accent/30 bg-background">
+              {filteredFiles.map((file) => (
+                <button
+                  type="button"
+                  key={file}
+                  onClick={() => openFile(file)}
+                  className="w-full text-left px-3 py-2 hover:bg-accent/10 text-sm break-all"
+                >
+                  {file}
+                </button>
+              ))}
+              {!filteredFiles.length && (
+                <p className="px-3 py-2 text-sm text-text/70">No files match this query.</p>
+              )}
+            </div>
+          </SectionCard>
+
+          <SectionCard title="File preview" icon={MessageSquare}
+            action={loadingFile && <Loader2 className="w-5 h-5 animate-spin text-accent" />}>
+            {selectedFile ? (
+              <div className="space-y-2">
+                <p className="text-sm font-semibold break-all text-accent">{selectedFile}</p>
+                <pre className="bg-background border border-accent rounded-lg p-3 text-xs overflow-auto max-h-72 whitespace-pre-wrap">
+                  {loadingFile ? 'Loading…' : fileContent || 'File is empty.'}
+                </pre>
+              </div>
+            ) : (
+              <p className="text-text/70 text-sm">Select a file from the index or from search results to preview it.</p>
+            )}
+          </SectionCard>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function buildSummaryResponse(query, results, scannedCount) {
+  if (!results.length) {
+    return `No matches for "${query}" across ${scannedCount} files. Try a different keyword or a smaller phrase.`;
+  }
+
+  const lines = results.slice(0, 5).map((result) => {
+    const locations = result.matches.map((m) => m.lineNumber).join(', ');
+    return `• ${result.path} (lines ${locations})`;
+  });
+
+  return [
+    `I scanned ${scannedCount} files and found ${results.length} match(es) for "${query}":`,
+    ...lines,
+    'Open a result to read the full source or refine your query to narrow the context.'
+  ].join('\n');
+}

--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -1,10 +1,170 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const repositoryRoot = path.resolve(__dirname, '..');
+const codeRoots = [
+  path.join(repositoryRoot, 'webapp', 'src'),
+  path.join(repositoryRoot, 'bot'),
+  path.join(repositoryRoot, 'lib'),
+  path.join(repositoryRoot, 'scripts')
+].filter((p) => fs.existsSync(p));
+
+const ignoredFolders = new Set([
+  'node_modules',
+  'dist',
+  '.git',
+  '.vite',
+  '.next',
+  'build',
+  '.DS_Store'
+]);
+
+const allowedExtensions = new Set([
+  '.js',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.json',
+  '.css',
+  '.scss',
+  '.md',
+  '.html'
+]);
+
+function walkFiles() {
+  const files = [];
+  const queue = [...codeRoots];
+
+  while (queue.length) {
+    const current = queue.pop();
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (ignoredFolders.has(entry.name)) continue;
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(fullPath);
+      } else if (allowedExtensions.has(path.extname(entry.name))) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+function sanitizeAndResolvePath(requestedPath) {
+  const fullPath = path.resolve(repositoryRoot, requestedPath);
+  if (!fullPath.startsWith(repositoryRoot)) {
+    throw new Error('Path outside repository');
+  }
+  return fullPath;
+}
+
+function createDevAssistantPlugin() {
+  return {
+    name: 'dev-assistant-api',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use('/api/dev-assistant/index', (req, res) => {
+        const files = walkFiles().map((f) => path.relative(repositoryRoot, f));
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ files, root: repositoryRoot }));
+      });
+
+      server.middlewares.use('/api/dev-assistant/search', (req, res) => {
+        const url = new URL(req.url || '', 'http://localhost');
+        const query = (url.searchParams.get('q') || '').trim();
+
+        if (!query) {
+          res.statusCode = 400;
+          res.end(JSON.stringify({ error: 'Missing query' }));
+          return;
+        }
+
+        const lowerQuery = query.toLowerCase();
+        const files = walkFiles();
+        const results = [];
+
+        for (const filePath of files) {
+          try {
+            const content = fs.readFileSync(filePath, 'utf-8');
+            const lines = content.split(/\r?\n/);
+            const matches = [];
+
+            lines.forEach((line, index) => {
+              if (line.toLowerCase().includes(lowerQuery)) {
+                matches.push({
+                  line: line.trim(),
+                  lineNumber: index + 1
+                });
+              }
+            });
+
+            if (matches.length) {
+              results.push({
+                path: path.relative(repositoryRoot, filePath),
+                matches: matches.slice(0, 6)
+              });
+            }
+
+            if (results.length >= 30) break;
+          } catch (err) {
+            server.config.logger.error(`Dev assistant search failed for ${filePath}: ${err.message}`);
+          }
+        }
+
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({
+          query,
+          results,
+          scanned: files.length
+        }));
+      });
+
+      server.middlewares.use('/api/dev-assistant/file', (req, res) => {
+        const url = new URL(req.url || '', 'http://localhost');
+        const relativePath = url.searchParams.get('path');
+
+        if (!relativePath) {
+          res.statusCode = 400;
+          res.end(JSON.stringify({ error: 'Missing path' }));
+          return;
+        }
+
+        try {
+          const fullPath = sanitizeAndResolvePath(relativePath);
+          if (!fs.existsSync(fullPath)) {
+            res.statusCode = 404;
+            res.end(JSON.stringify({ error: 'File not found' }));
+            return;
+          }
+
+          const content = fs.readFileSync(fullPath, 'utf-8');
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({
+            path: path.relative(repositoryRoot, fullPath),
+            content
+          }));
+        } catch (error) {
+          res.statusCode = 400;
+          res.end(JSON.stringify({ error: error.message }));
+        }
+      });
+    }
+  };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
   base: '/',
-  plugins: [react()],
+  plugins: [react(), createDevAssistantPlugin()],
   build: {
     outDir: 'dist',
     emptyOutDir: true


### PR DESCRIPTION
## Summary
- add a dev-only Vite middleware that indexes repository code and exposes index/search/file endpoints for the assistant
- build a developer assistant page at `/dev/assistant` with chat-style prompts, search results, file index, and file preview
- register the assistant route inside the React router and gate it to development builds

## Testing
- npm run build --prefix webapp


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943988379988329ac5e708b89fea8dc)