### PR TITLE
Fix blackjack hand scoring crash and enable Jest ESM tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,11 @@
 module.exports = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
-  roots: ['<rootDir>/tests'],
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  globals: {
+    'ts-jest': {
+      useESM: true
+    }
+  },
+  roots: ['<rootDir>/tests', '<rootDir>/test'],
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node bot/server.js",
     "install-all": "npm install && npm install --prefix bot && npm install --prefix webapp",
     "build": "tsc -p tsconfig.build.json",
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "demo": "node dist/demo.js demo/demo.json",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/tests/blackjackLogic.test.js
+++ b/tests/blackjackLogic.test.js
@@ -1,0 +1,7 @@
+import { expect, test } from '@jest/globals';
+import { handValue } from '../webapp/src/utils/blackjackLogic.js';
+
+test('handValue handles missing or invalid cards without throwing', () => {
+  expect(handValue([{ rank: 'A', suit: 'S' }, null, undefined])).toBe(11);
+  expect(handValue([{ rank: '10', suit: 'H' }])).toBe(10);
+});

--- a/webapp/src/utils/blackjackLogic.js
+++ b/webapp/src/utils/blackjackLogic.js
@@ -38,15 +38,18 @@ export function hitCard(deck) {
 }
 
 function cardValue(rank) {
+  if (!rank) return 0;
   if (rank === 'A') return 11;
-  if (rank === 'K' || rank === 'Q' || rank === 'J' || rank === 'T') return 10;
-  return Number.parseInt(rank, 10);
+  if (rank === 'K' || rank === 'Q' || rank === 'J' || rank === 'T' || rank === '10') return 10;
+  const parsed = Number.parseInt(rank, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 export function handValue(hand) {
   let total = 0;
   let aces = 0;
   hand.forEach((card) => {
+    if (!card || !card.rank) return;
     total += cardValue(card.rank);
     if (card.rank === 'A') aces += 1;
   });


### PR DESCRIPTION
## Summary
- make blackjack hand scoring robust to missing or invalid card data to prevent crashes
- add coverage for handValue edge cases
- configure Jest to run ESM-based tests from both `tests` and `test` directories

## Testing
- npm test -- --runInBand tests/blackjackLogic.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69438f070e6c8329a58cf79caf7cd24f)