### PR TITLE
Add developer assistant backed by repo index

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -13,6 +13,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-rate-limit": "^7.5.1",
+    "fast-glob": "^3.3.2",
     "geoip-lite": "^1.4.10",
     "https-proxy-agent": "^7.0.2",
     "mongodb-memory-server": "^10.1.4",

--- a/bot/routes/devAssistant.js
+++ b/bot/routes/devAssistant.js
@@ -1,0 +1,102 @@
+import express from 'express';
+import OpenAI from 'openai';
+import { findRelevantChunks, getIndexStats } from '../utils/codeIndex.js';
+import { withProxy } from '../utils/proxyAgent.js';
+
+const router = express.Router();
+
+const devAccounts = [
+  process.env.DEV_ACCOUNT_ID || process.env.VITE_DEV_ACCOUNT_ID,
+  process.env.DEV_ACCOUNT_ID_1 || process.env.VITE_DEV_ACCOUNT_ID_1,
+  process.env.DEV_ACCOUNT_ID_2 || process.env.VITE_DEV_ACCOUNT_ID_2
+]
+  .filter(Boolean)
+  .map(String);
+
+const openaiClient = process.env.OPENAI_API_KEY
+  ? new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+      fetch: (url, options) => fetch(url, withProxy(options))
+    })
+  : null;
+
+function isAuthorized(accountId) {
+  if (!devAccounts.length) return true;
+  if (!accountId) return false;
+  return devAccounts.includes(String(accountId));
+}
+
+router.get('/stats', (req, res) => {
+  const { accountId } = req.query || {};
+  if (!isAuthorized(accountId)) {
+    return res.status(403).json({ error: 'unauthorized' });
+  }
+  try {
+    const stats = getIndexStats();
+    return res.json({
+      ready: Boolean(openaiClient),
+      ...stats
+    });
+  } catch (err) {
+    console.error('dev assistant stats failed', err);
+    return res.status(500).json({ error: 'failed to load index stats' });
+  }
+});
+
+router.post('/ask', async (req, res) => {
+  const { question, accountId } = req.body || {};
+  if (!isAuthorized(accountId)) {
+    return res.status(403).json({ error: 'unauthorized' });
+  }
+  if (!question || typeof question !== 'string' || !question.trim()) {
+    return res.status(400).json({ error: 'question is required' });
+  }
+  if (!openaiClient) {
+    return res.status(503).json({ error: 'assistant not configured' });
+  }
+
+  const trimmedQuestion = question.trim().slice(0, 2000);
+  let contextChunks = [];
+  try {
+    contextChunks = findRelevantChunks(trimmedQuestion, {
+      maxChunks: 12,
+      maxChars: 11_000
+    });
+  } catch (err) {
+    console.error('dev assistant indexing failed', err);
+    return res.status(500).json({ error: 'code index unavailable' });
+  }
+
+  const contextText = contextChunks
+    .map((chunk) => `File: ${chunk.path}\n${chunk.content}`)
+    .join('\n---\n');
+
+  const systemPrompt = `You are TonPlaygram's private developer assistant. You have read access to the full monorepo and must answer with precise, actionable steps. Reference file paths and key identifiers when suggesting changes. Keep answers concise and focused on implementation details. If information is missing in the provided context, state what else is needed instead of inventing details.`;
+
+  try {
+    const completion = await openaiClient.chat.completions.create({
+      model: process.env.OPENAI_MODEL || 'gpt-4o-mini',
+      messages: [
+        { role: 'system', content: systemPrompt },
+        {
+          role: 'user',
+          content: `Project context:\n${contextText || 'No context available.'}\n\nQuestion: ${trimmedQuestion}`
+        }
+      ],
+      max_tokens: 900,
+      temperature: 0.2
+    });
+
+    const answer = completion.choices?.[0]?.message?.content?.trim();
+    return res.json({
+      answer: answer || 'No answer produced.',
+      sources: contextChunks.map(({ path, score }) => ({ path, score })),
+      index: getIndexStats()
+    });
+  } catch (err) {
+    console.error('dev assistant failed', err);
+    return res.status(500).json({ error: 'assistant failed to respond' });
+  }
+});
+
+export default router;

--- a/bot/server.js
+++ b/bot/server.js
@@ -24,6 +24,7 @@ import storeRoutes, { BUNDLES } from './routes/store.js';
 import adsRoutes from './routes/ads.js';
 import influencerRoutes from './routes/influencer.js';
 import onlineRoutes from './routes/online.js';
+import devAssistantRoutes from './routes/devAssistant.js';
 import User from './models/User.js';
 import GameResult from './models/GameResult.js';
 import AdView from './models/AdView.js';
@@ -152,6 +153,7 @@ app.use('/api/social', socialRoutes);
 app.use('/api/broadcast', broadcastRoutes);
 app.use('/api/store', storeRoutes);
 app.use('/api/online', onlineRoutes);
+app.use('/api/dev-assistant', devAssistantRoutes);
 
 app.post('/api/goal-rush/calibration', (req, res) => {
   const { accountId, calibration } = req.body || {};

--- a/bot/utils/codeIndex.js
+++ b/bot/utils/codeIndex.js
@@ -1,0 +1,151 @@
+import fg from 'fast-glob';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+const CODE_GLOBS = [
+  'webapp/src/**/*.{js,jsx,ts,tsx,css,scss,md,json,html}',
+  'webapp/public/**/*.{js,json,md,html,css}',
+  'bot/**/*.{js,json,md}',
+  'docs/**/*.{md,yml,yaml,json}',
+  'examples/**/*.{js,ts,tsx,md,json}',
+  'scripts/**/*.{js,ts,md}',
+  'render.yaml',
+  '*.md'
+];
+
+const IGNORE = [
+  '**/node_modules/**',
+  '**/.git/**',
+  '**/.cache/**',
+  '**/.turbo/**',
+  '**/.idea/**',
+  '**/.vscode/**',
+  '**/dist/**',
+  '**/build/**',
+  'webapp/.vite/**',
+  'webapp/coverage/**',
+  'webapp/public/assets/**',
+  'billiards.Unity/**',
+  'billiards.Tests/**',
+  'billiards/**/Library/**',
+  '**/*.log'
+];
+
+const MAX_FILE_BYTES = 160_000;
+const CHUNK_SIZE = 1200;
+const CHUNK_OVERLAP = 200;
+
+let indexCache = null;
+let chunkCache = null;
+
+function chunkContent(content = '') {
+  const chunks = [];
+  let start = 0;
+  const len = content.length;
+  while (start < len) {
+    const end = Math.min(len, start + CHUNK_SIZE);
+    chunks.push(content.slice(start, end));
+    if (end >= len) break;
+    const nextStart = Math.max(0, end - CHUNK_OVERLAP);
+    if (nextStart <= start) break;
+    start = nextStart;
+  }
+  return chunks;
+}
+
+function buildIndex() {
+  if (indexCache) return indexCache;
+  const entries = fg.sync(CODE_GLOBS, {
+    cwd: repoRoot,
+    ignore: IGNORE,
+    dot: false
+  });
+  indexCache = entries
+    .map((relPath) => {
+      const full = path.join(repoRoot, relPath);
+      try {
+        const stats = fs.statSync(full);
+        if (!stats.isFile()) return null;
+        if (stats.size === 0 || stats.size > MAX_FILE_BYTES) return null;
+        const content = fs.readFileSync(full, 'utf8');
+        return {
+          path: relPath.replace(/\\/g, '/'),
+          size: stats.size,
+          content
+        };
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+  return indexCache;
+}
+
+function buildChunks() {
+  if (chunkCache) return chunkCache;
+  const files = buildIndex();
+  chunkCache = files.flatMap((file) => {
+    const parts = chunkContent(file.content);
+    return parts.map((text, idx) => ({
+      path: file.path,
+      key: `${file.path}#${idx}`,
+      content: text,
+      lower: text.toLowerCase()
+    }));
+  });
+  return chunkCache;
+}
+
+function tokenize(query = '') {
+  return query
+    .toLowerCase()
+    .split(/[^a-z0-9_]+/g)
+    .filter((t) => t && t.length > 2 && !['this', 'that', 'with', 'from'].includes(t));
+}
+
+export function findRelevantChunks(query, { maxChunks = 10, maxChars = 9000 } = {}) {
+  const terms = tokenize(query);
+  const chunks = buildChunks();
+  const scored = chunks
+    .map((chunk) => {
+      let score = 0;
+      for (const term of terms) {
+        if (chunk.lower.includes(term)) score += 2;
+        if (chunk.path.toLowerCase().includes(term)) score += 3;
+      }
+      return { ...chunk, score };
+    })
+    .sort((a, b) => b.score - a.score || b.content.length - a.content.length);
+
+  const result = [];
+  let totalChars = 0;
+  for (const chunk of scored) {
+    if (result.length >= maxChunks) break;
+    if (totalChars + chunk.content.length > maxChars && result.length > 0) break;
+    result.push({ path: chunk.path, content: chunk.content, score: chunk.score });
+    totalChars += chunk.content.length;
+  }
+  if (result.length === 0 && scored.length > 0) {
+    result.push({ path: scored[0].path, content: scored[0].content.slice(0, maxChars), score: scored[0].score });
+  }
+  return result;
+}
+
+export function getIndexStats() {
+  const files = buildIndex();
+  const totalBytes = files.reduce((sum, f) => sum + f.size, 0);
+  return {
+    files: files.length,
+    totalBytes,
+  };
+}
+
+export function resetIndexCache() {
+  indexCache = null;
+  chunkCache = null;
+}

--- a/webapp/src/components/DevAssistantModal.jsx
+++ b/webapp/src/components/DevAssistantModal.jsx
@@ -1,0 +1,195 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import ReactMarkdown from 'react-markdown';
+import { FiCpu, FiRefreshCw, FiSend, FiX } from 'react-icons/fi';
+import { askDevAssistant, getDevAssistantStats } from '../utils/api.js';
+
+export default function DevAssistantModal({ open, onClose, accountId }) {
+  const [messages, setMessages] = useState([
+    {
+      role: 'assistant',
+      content:
+        'Hi! I can answer developer-only questions about this webapp. Ask me about components, routes, APIs, or how to test specific game flows.'
+    }
+  ]);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState('');
+  const [stats, setStats] = useState(null);
+  const [statsLoading, setStatsLoading] = useState(false);
+  const bottomRef = useRef(null);
+
+  useEffect(() => {
+    if (open) {
+      refreshStats();
+    }
+  }, [open, accountId]);
+
+  useEffect(() => {
+    if (bottomRef.current) {
+      bottomRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, error]);
+
+  if (!open) return null;
+
+  const refreshStats = async () => {
+    if (!accountId) return;
+    setStatsLoading(true);
+    const res = await getDevAssistantStats(accountId);
+    if (!res.error) {
+      setStats(res);
+      setError('');
+    } else {
+      setError(res.error);
+    }
+    setStatsLoading(false);
+  };
+
+  const handleSend = async () => {
+    if (!input.trim() || sending) return;
+    if (!accountId) {
+      setError('Dev account required to use the assistant.');
+      return;
+    }
+    const question = input.trim();
+    const nextMessages = [...messages, { role: 'user', content: question }];
+    setMessages(nextMessages);
+    setInput('');
+    setSending(true);
+    setError('');
+
+    const res = await askDevAssistant(question, accountId);
+    if (res.error) {
+      setError(res.error);
+      setSending(false);
+      return;
+    }
+    const assistantContent = res.answer || 'No answer returned.';
+    setMessages([
+      ...nextMessages,
+      {
+        role: 'assistant',
+        content: assistantContent,
+        sources: res.sources || []
+      }
+    ]);
+    setStats(res.index || stats);
+    setSending(false);
+  };
+
+  const renderSources = (sources = []) => {
+    if (!Array.isArray(sources) || sources.length === 0) return null;
+    return (
+      <div className="flex flex-wrap gap-2 mt-2 text-[11px] text-subtext">
+        {sources.map((src) => (
+          <span
+            key={`${src.path}-${src.score}`}
+            className="px-2 py-1 rounded-full bg-surface/70 border border-border"
+          >
+            {src.path}
+          </span>
+        ))}
+      </div>
+    );
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 bg-black bg-opacity-70 z-50 flex items-center justify-center p-4">
+      <div className="bg-surface border border-border rounded-2xl shadow-2xl w-full max-w-4xl h-full max-h-[90vh] flex flex-col">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+          <div>
+            <p className="font-semibold">Dev Assistant</p>
+            <p className="text-xs text-subtext">Private, repo-aware helper for TonPlaygram developers.</p>
+          </div>
+          <div className="flex items-center gap-3 text-xs text-subtext">
+            <div className="flex items-center gap-1">
+              <FiCpu className="w-4 h-4" />
+              <span>
+                {stats
+                  ? `${stats.files || 0} files indexed`
+                  : 'Loading index…'}
+              </span>
+            </div>
+            <button
+              className="inline-flex items-center gap-1 px-2 py-1 rounded bg-background hover:bg-background/80 border border-border"
+              onClick={refreshStats}
+              disabled={statsLoading || !accountId}
+            >
+              <FiRefreshCw className={`w-4 h-4 ${statsLoading ? 'animate-spin' : ''}`} />
+              Refresh
+            </button>
+            <button
+              onClick={onClose}
+              className="px-3 py-1 bg-primary hover:bg-primary-hover text-background rounded flex items-center gap-2"
+            >
+              <FiX />
+              Close
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 space-y-3 bg-surface/60">
+          {messages.map((msg, idx) => (
+            <div
+              key={idx}
+              className={`p-3 rounded-xl border ${
+                msg.role === 'assistant'
+                  ? 'bg-background/90 border-border'
+                  : 'bg-primary/10 border-primary/40'
+              }`}
+            >
+              <div className="text-[11px] uppercase font-semibold text-subtext mb-1">
+                {msg.role === 'assistant' ? 'Assistant' : 'You'}
+              </div>
+              <ReactMarkdown className="prose prose-invert text-sm max-w-none">
+                {msg.content}
+              </ReactMarkdown>
+              {renderSources(msg.sources)}
+            </div>
+          ))}
+          {error && (
+            <div className="p-3 rounded-xl border border-red-500 bg-red-500/10 text-red-200 text-sm">
+              {error}
+            </div>
+          )}
+          <div ref={bottomRef} />
+        </div>
+
+        <div className="p-4 border-t border-border space-y-2 bg-surface">
+          <div className="flex items-center justify-between text-xs text-subtext">
+            <span>
+              Ask about game test flows, API contracts, or component entry points. Shift+Enter adds a newline.
+            </span>
+            {stats?.totalBytes && (
+              <span className="text-[11px]">Indexed size: {(stats.totalBytes / 1024 / 1024).toFixed(1)} MB</span>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <textarea
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSend();
+                }
+              }}
+              placeholder={accountId ? 'Ask anything about the codebase…' : 'Dev account required'}
+              className="flex-1 border border-border rounded-lg p-3 bg-background/90 text-sm text-text min-h-[80px]"
+            />
+            <button
+              onClick={handleSend}
+              disabled={sending || !input.trim() || !accountId}
+              className="px-4 py-2 bg-primary hover:bg-primary-hover text-background rounded-lg flex items-center gap-2 h-[80px]"
+            >
+              <FiSend />
+              {sending ? 'Sending…' : 'Send'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -25,6 +25,7 @@ import InfoPopup from '../components/InfoPopup.jsx';
 import DevNotifyModal from '../components/DevNotifyModal.jsx';
 import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
 import DevTasksModal from '../components/DevTasksModal.jsx';
+import DevAssistantModal from '../components/DevAssistantModal.jsx';
 import Wallet from './Wallet.jsx';
 import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
 import {
@@ -101,6 +102,7 @@ export default function MyAccount() {
   const [notifyStatus, setNotifyStatus] = useState('');
   const [showNotifyModal, setShowNotifyModal] = useState(false);
   const [showTasksModal, setShowTasksModal] = useState(false);
+  const [showAssistantModal, setShowAssistantModal] = useState(false);
   const [twitterError, setTwitterError] = useState('');
   const [twitterLink, setTwitterLink] = useState('');
   const [unread, setUnread] = useState(0);
@@ -573,6 +575,18 @@ export default function MyAccount() {
             </button>
           </div>
 
+          <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
+            <button
+              onClick={() => setShowAssistantModal(true)}
+              className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background w-full"
+            >
+              Open Dev Assistant
+            </button>
+            <p className="text-xs text-subtext text-center">
+              Chat with a repo-aware helper that can outline tests, entry points, and flows for any game.
+            </p>
+          </div>
+
           <InfluencerClaimsCard />
         </>
       )}
@@ -592,6 +606,11 @@ export default function MyAccount() {
       <DevTasksModal
         open={showTasksModal}
         onClose={() => setShowTasksModal(false)}
+      />
+      <DevAssistantModal
+        open={showAssistantModal}
+        onClose={() => setShowAssistantModal(false)}
+        accountId={profile?.accountId}
       />
       <InfoPopup
         open={showSaved}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -542,3 +542,12 @@ export function getWatchCount(tableId) {
 export function getAppStats() {
   return get('/api/stats');
 }
+
+export function getDevAssistantStats(accountId) {
+  const query = accountId ? `?accountId=${encodeURIComponent(accountId)}` : '';
+  return get(`/api/dev-assistant/stats${query}`);
+}
+
+export function askDevAssistant(question, accountId) {
+  return post('/api/dev-assistant/ask', { question, accountId });
+}


### PR DESCRIPTION
## Summary
- add a backend dev-assistant endpoint that authorizes developer accounts and relays answers from OpenAI
- index repository source files with a new utility to supply contextual snippets to the assistant
- ship a dev-only assistant modal in the webapp plus API helpers so developers can ask repo-aware questions

## Testing
- npm run build (webapp)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943988379988329ac5e708b89fea8dc)