### PR TITLE
Reduce Texas Hold'em table and chip scale

### DIFF
--- a/webapp/public/texas-holdem.html
+++ b/webapp/public/texas-holdem.html
@@ -9,13 +9,13 @@
     <title>Texas Hold'em Royale</title>
     <style>
       :root {
-        --table-scale: 0.75;
-        --table-bg-scale-x: 0.81;
-        --table-bg-scale-y: 0.79;
+        --table-scale: 0.68;
+        --table-bg-scale-x: 0.74;
+        --table-bg-scale-y: 0.72;
         --shadow: rgba(0, 0, 0, 0.45);
         /* Smaller default card scale so non-player seats appear smaller */
-        --card-scale: 0.72;
-        --avatar-scale: 1;
+        --card-scale: 0.68;
+        --avatar-scale: 0.92;
         --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale));
         --card-h: calc(var(--card-w) * 1.45);
         --avatar-size: calc(54px * var(--avatar-scale));
@@ -85,7 +85,7 @@
         gap: 10px;
         z-index: 2;
         /* Make community cards a bit larger */
-        --card-scale: 1.2;
+        --card-scale: 1.1;
         --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale));
         --card-h: calc(var(--card-w) * 1.45);
       }
@@ -109,8 +109,8 @@
         align-items: center;
         gap: 6px;
         width: clamp(120px, 28vw, 200px);
-        --card-scale: 0.567;
-        --avatar-scale: 0.7;
+        --card-scale: 0.52;
+        --avatar-scale: 0.66;
         --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale));
         --card-h: calc(var(--card-w) * 1.45);
       }
@@ -420,8 +420,8 @@
         bottom: 5%;
         left: 50%;
         transform: translateX(-50%);
-        --card-scale: 1.083;
-        --avatar-scale: 1;
+        --card-scale: 0.98;
+        --avatar-scale: 0.92;
         --card-w: calc(clamp(44px, 9.6vw, 70px) * var(--card-scale));
         --card-h: calc(var(--card-w) * 1.45);
       }
@@ -647,8 +647,8 @@
         top: auto;
         cursor: pointer;
         border: 2px solid transparent;
-        width: calc(var(--avatar-size) / 1.35);
-        height: calc(var(--avatar-size) / 1.35);
+        width: calc(var(--avatar-size) / 1.5);
+        height: calc(var(--avatar-size) / 1.5);
       }
       .raise-container .chip:active {
         border-color: #0ea5e9;
@@ -659,8 +659,8 @@
         gap: 4px;
       }
       .undo-chip {
-        width: calc(var(--avatar-size) / 1.3);
-        height: calc(var(--avatar-size) / 1.3);
+        width: calc(var(--avatar-size) / 1.45);
+        height: calc(var(--avatar-size) / 1.45);
         border: 2px solid #000;
         border-radius: 4px;
         display: flex;
@@ -830,8 +830,8 @@
 
       .chip {
         position: relative;
-        width: calc(var(--avatar-size) / 1.6);
-        height: calc(var(--avatar-size) / 1.6);
+        width: calc(var(--avatar-size) / 1.8);
+        height: calc(var(--avatar-size) / 1.8);
         border-radius: 50%;
         background-size: cover;
         background-position: center;
@@ -839,8 +839,8 @@
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
       }
       .moving-pot .chip {
-        width: calc(var(--avatar-size) / 1.7);
-        height: calc(var(--avatar-size) / 1.7);
+        width: calc(var(--avatar-size) / 1.9);
+        height: calc(var(--avatar-size) / 1.9);
         z-index: 1100;
       }
       .chip.v1 {


### PR DESCRIPTION
## Summary
- Reduce the Texas Hold'em table/background, card, and avatar scaling to better match the proportions used in Murlan Royale while keeping the layout intact.
- Shrink chip visuals and raise-control chips so pot and betting elements stay proportional after the overall scale change.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943b7bbccf083299c9307563747b435)