### PR TITLE
Update Murlan straights and action buttons

### DIFF
--- a/lib/murlan.js
+++ b/lib/murlan.js
@@ -70,46 +70,22 @@ export function isFlush(cards) {
 }
 
 export function isStraight(cards, config = DEFAULT_CONFIG) {
+  if (cards.length < config.MIN_STRAIGHT_LENGTH) return false;
+  if (cards.some((c) => c.rank === '2')) return false;
   const sorted = sortHand(cards, config);
   const ranks = sorted.map((c) => rankValue(c.rank, config));
-  let sequential = true;
+  const minRank = rankValue('3', config);
+  if (ranks[0] < minRank) return false;
   for (let i = 1; i < ranks.length; i++) {
-    if (ranks[i] !== ranks[i - 1] + 1) {
-      sequential = false;
-      break;
-    }
-  }
-  if (sequential) {
-    if (config.STRAIGHTS_REQUIRE_SAME_SUIT && !isFlush(cards)) return false;
-    return sorted.length >= config.MIN_STRAIGHT_LENGTH;
-  }
-  const hasAce = ranks.includes(rankValue('A', config));
-  if (!hasAce) return false;
-  const alt = cards
-    .map((c) => {
-      if (c.rank === 'A') return -1;
-      if (c.rank === '2') return 0;
-      return rankValue(c.rank, config);
-    })
-    .sort((a, b) => a - b);
-  for (let i = 1; i < alt.length; i++) {
-    if (alt[i] !== alt[i - 1] + 1) return false;
+    if (ranks[i] !== ranks[i - 1] + 1) return false;
   }
   if (config.STRAIGHTS_REQUIRE_SAME_SUIT && !isFlush(cards)) return false;
-  return cards.length >= config.MIN_STRAIGHT_LENGTH;
-}
-
-function aceLowValue(card, config = DEFAULT_CONFIG) {
-  if (card.rank === 'A') return -1;
-  if (card.rank === '2') return 0;
-  return rankValue(card.rank, config);
+  return true;
 }
 
 export function straightHighCard(cards, config = DEFAULT_CONFIG) {
   if (!isStraight(cards, config)) return null;
-  const sorted = [...cards].sort(
-    (a, b) => aceLowValue(a, config) - aceLowValue(b, config)
-  );
+  const sorted = sortHand(cards, config);
   return sorted[sorted.length - 1].rank;
 }
 
@@ -362,4 +338,3 @@ export function aiChooseAction(hand, onTable, config = DEFAULT_CONFIG) {
   moves.sort((a, b) => value(a) - value(b));
   return { type: 'PLAY', cards: moves[0].cards };
 }
-

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1753,26 +1753,26 @@ export default function MurlanRoyaleArena({ search }) {
               <button
                 type="button"
                 onClick={handlePass}
-                className="rounded-lg border border-white/25 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-gray-200 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:text-gray-500 disabled:hover:bg-transparent"
+                className="rounded-lg bg-gradient-to-r from-red-600 to-red-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow-lg transition hover:shadow-xl disabled:cursor-not-allowed disabled:from-red-900/70 disabled:to-red-800/70 disabled:opacity-60 disabled:shadow-none"
                 disabled={!uiState.humanTurn || !gameState.tableCombo}
               >
-                Paso
+                Pass
               </button>
               <button
                 type="button"
                 onClick={handleClear}
-                className="rounded-lg border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-gray-200 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:text-gray-500 disabled:hover:bg-transparent"
+                className="rounded-lg bg-gradient-to-r from-amber-300 to-amber-400 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-black shadow-lg transition hover:shadow-xl disabled:cursor-not-allowed disabled:from-amber-300/60 disabled:to-amber-400/60 disabled:text-black/60 disabled:shadow-none"
                 disabled={!selectedIds.length}
               >
-                Hiq zgjedhjet
+                Undo
               </button>
               <button
                 type="button"
                 onClick={handlePlay}
-                className="rounded-lg bg-gradient-to-r from-[#ff0050] to-[#f97316] px-5 py-2 text-xs font-bold uppercase tracking-wide text-white shadow-lg transition hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-40"
+                className="rounded-lg bg-gradient-to-r from-green-500 to-green-600 px-5 py-2 text-xs font-bold uppercase tracking-wide text-white shadow-lg transition hover:shadow-xl disabled:cursor-not-allowed disabled:from-green-800/60 disabled:to-green-700/60 disabled:opacity-60 disabled:shadow-none"
                 disabled={!uiState.humanTurn || !selectedIds.length}
               >
-                Luaj
+                Play
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- switch Murlan Royale action buttons to English labels and apply red/yellow/green styling for pass, undo, and play
- tighten straight detection so only sequences from 3 through A are valid, excluding 2s and Ace-low wraps

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943c676ae5c8329a6a4fb6fce70520e)