### PR TITLE
Improve Pool Royale lobby stake handling

### DIFF
--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -1,0 +1,187 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'events';
+import { setTimeout as delay } from 'timers/promises';
+import { socket as liveSocket } from '../webapp/src/utils/socket.js';
+import { runPoolRoyaleOnlineFlow } from '../webapp/src/pages/Games/poolRoyaleOnlineFlow.js';
+
+liveSocket.disconnect?.();
+liveSocket.close?.();
+
+class MockSocket extends EventEmitter {
+  constructor() {
+    super();
+    this.connected = true;
+    this.seatRequests = [];
+    this.leaveRequests = [];
+  }
+
+  emit(event, payload, cb) {
+    if (event === 'seatTable') {
+      this.seatRequests.push({ payload, cb });
+      return true;
+    }
+    if (event === 'leaveLobby') {
+      this.leaveRequests.push(payload);
+      return true;
+    }
+    return super.emit(event, payload, cb);
+  }
+}
+
+function createState() {
+  const snapshot = {
+    matchingError: '',
+    matchStatus: '',
+    matching: false,
+    isSearching: false,
+    matchPlayers: [],
+    readyList: [],
+    spinningPlayer: ''
+  };
+  return {
+    snapshot,
+    setMatchingError: (v) => {
+      snapshot.matchingError = v;
+    },
+    setMatchStatus: (v) => {
+      snapshot.matchStatus = v;
+    },
+    setMatching: (v) => {
+      snapshot.matching = v;
+    },
+    setIsSearching: (v) => {
+      snapshot.isSearching = v;
+    },
+    setMatchPlayers: (v) => {
+      snapshot.matchPlayers = v;
+    },
+    setReadyList: (v) => {
+      snapshot.readyList = v;
+    },
+    setSpinningPlayer: (v) => {
+      snapshot.spinningPlayer = v;
+    }
+  };
+}
+
+function createRefs() {
+  return {
+    accountIdRef: { current: null },
+    matchPlayersRef: { current: [] },
+    pendingTableRef: { current: '' },
+    cleanupRef: { current: () => {} },
+    spinIntervalRef: { current: null },
+    stakeDebitRef: { current: null },
+    matchTimeoutRef: { current: null },
+    seatTimeoutRef: { current: null }
+  };
+}
+
+test('runPoolRoyaleOnlineFlow debits once and keeps stake for game start', async () => {
+  const mockSocket = new MockSocket();
+  const refs = createRefs();
+  const state = createState();
+  const addCalls = [];
+  const started = [];
+
+  const deps = {
+    ensureAccountId: () => Promise.resolve('acct-1'),
+    getAccountBalance: () => Promise.resolve({ balance: 200 }),
+    addTransaction: (...args) => {
+      addCalls.push(args);
+      return Promise.resolve();
+    },
+    getTelegramId: () => 'tg-1',
+    getTelegramFirstName: () => 'Alice',
+    socket: mockSocket
+  };
+
+  await runPoolRoyaleOnlineFlow({
+    stake: { token: 'TPC', amount: 100 },
+    variant: 'uk',
+    playType: 'regular',
+    mode: 'online',
+    tableSize: 'medium',
+    avatar: 'me.png',
+    deps,
+    state,
+    refs,
+    timeouts: { seat: 50, matchmaking: 200 },
+    onGameStart: (payload) => started.push(payload)
+  });
+
+  assert.equal(mockSocket.seatRequests.length, 1);
+  const seatCb = mockSocket.seatRequests[0].cb;
+  seatCb({
+    success: true,
+    tableId: 'tbl-1',
+    players: [
+      { id: 'acct-1', name: 'Alice' },
+      { id: 'acct-2', name: 'Bob' }
+    ],
+    ready: ['acct-1']
+  });
+
+  mockSocket.emit('gameStart', {
+    tableId: 'tbl-1',
+    players: [
+      { id: 'acct-1', name: 'Alice' },
+      { id: 'acct-2', name: 'Bob' }
+    ]
+  });
+
+  await delay(0);
+
+  assert.equal(addCalls.length, 1, 'should only debit once');
+  assert.equal(addCalls[0][1], -100);
+  assert.equal(addCalls[0][2], 'stake');
+  assert.equal(started.length, 1);
+  assert.equal(started[0].tableId, 'tbl-1');
+  assert.equal(refs.stakeDebitRef.current, null, 'stake cleared after start');
+});
+
+test('runPoolRoyaleOnlineFlow refunds when matchmaking times out', async () => {
+  const mockSocket = new MockSocket();
+  const refs = createRefs();
+  const state = createState();
+  const addCalls = [];
+
+  const deps = {
+    ensureAccountId: () => Promise.resolve('acct-9'),
+    getAccountBalance: () => Promise.resolve({ balance: 200 }),
+    addTransaction: (...args) => {
+      addCalls.push(args);
+      return Promise.resolve();
+    },
+    getTelegramId: () => 'tg-9',
+    getTelegramFirstName: () => 'Alex',
+    socket: mockSocket
+  };
+
+  await runPoolRoyaleOnlineFlow({
+    stake: { token: 'TPC', amount: 75 },
+    variant: 'uk',
+    playType: 'regular',
+    mode: 'online',
+    tableSize: 'medium',
+    avatar: 'me.png',
+    deps,
+    state,
+    refs,
+    timeouts: { seat: 50, matchmaking: 80 }
+  });
+
+  assert.equal(mockSocket.seatRequests.length, 1);
+  const seatCb = mockSocket.seatRequests[0].cb;
+  seatCb({ success: true, tableId: 'tbl-timeout', players: [], ready: [] });
+
+  await delay(120);
+
+  assert.equal(addCalls.length, 2, 'should debit then refund');
+  assert.equal(addCalls[0][1], -75);
+  assert.equal(addCalls[1][1], 75);
+  assert.equal(addCalls[1][2], 'stake_refund');
+  assert.ok(state.snapshot.matchingError.includes('timed out'));
+  assert.equal(refs.pendingTableRef.current, '');
+});

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -1,0 +1,275 @@
+import { ensureAccountId, getTelegramFirstName, getTelegramId } from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { socket } from '../../utils/socket.js';
+
+const DEFAULT_SEAT_TIMEOUT_MS = 12000;
+const DEFAULT_MATCH_TIMEOUT_MS = 30000;
+
+function logSupportError(message, error, context = {}) {
+  // Surface in console for support teams; caller will also show inline errors.
+  console.error('[PoolRoyaleLobby]', message, { ...context, error });
+}
+
+function clearTimeoutSafely(ref) {
+  if (ref?.current) {
+    clearTimeout(ref.current);
+    ref.current = null;
+  }
+}
+
+export async function runPoolRoyaleOnlineFlow({
+  stake,
+  variant,
+  playType,
+  mode,
+  tableSize,
+  avatar,
+  deps = {},
+  state,
+  refs,
+  timeouts = {},
+  onGameStart
+}) {
+  const {
+    ensureAccountId: ensureAccountIdFn = ensureAccountId,
+    getAccountBalance: getAccountBalanceFn = getAccountBalance,
+    addTransaction: addTransactionFn = addTransaction,
+    getTelegramId: getTelegramIdFn = getTelegramId,
+    getTelegramFirstName: getTelegramFirstNameFn = getTelegramFirstName,
+    socket: socketInstance = socket
+  } = deps;
+  const {
+    setMatchingError,
+    setMatchStatus,
+    setMatching,
+    setIsSearching,
+    setMatchPlayers,
+    setReadyList,
+    setSpinningPlayer
+  } = state;
+  const {
+    accountIdRef,
+    matchPlayersRef,
+    pendingTableRef,
+    cleanupRef,
+    spinIntervalRef,
+    stakeDebitRef,
+    matchTimeoutRef,
+    seatTimeoutRef
+  } = refs;
+
+  const seatTimeoutMs = timeouts.seat ?? DEFAULT_SEAT_TIMEOUT_MS;
+  const matchmakingTimeoutMs = timeouts.matchmaking ?? DEFAULT_MATCH_TIMEOUT_MS;
+
+  const telegramId = getTelegramIdFn?.();
+
+  setMatchingError('');
+  setMatchStatus('Checking your TPC account…');
+  setMatching(true);
+  setIsSearching(true);
+
+  const refundStake = async (reason, extra = {}) => {
+    if (!stakeDebitRef?.current) return false;
+    const { telegramId: debitedTelegram, accountId: debitedAccount, amount } = stakeDebitRef.current;
+    try {
+      await addTransactionFn(debitedTelegram, amount, 'stake_refund', {
+        game: 'poolroyale-online',
+        players: 2,
+        accountId: debitedAccount,
+        reason,
+        ...extra
+      });
+      return true;
+    } catch (error) {
+      logSupportError('Stake refund failed', error, { reason, extra });
+      return false;
+    } finally {
+      stakeDebitRef.current = null;
+    }
+  };
+
+  const clearTimers = () => {
+    clearTimeoutSafely(matchTimeoutRef);
+    clearTimeoutSafely(seatTimeoutRef);
+  };
+
+  let accountId;
+  try {
+    accountId = await ensureAccountIdFn();
+    accountIdRef.current = accountId;
+  } catch (error) {
+    setMatchingError('Unable to verify your TPC account. Please retry.');
+    setMatchStatus('');
+    setMatching(false);
+    setIsSearching(false);
+    logSupportError('ensureAccountId failed', error);
+    return { success: false };
+  }
+
+  try {
+    const balRes = await getAccountBalanceFn(accountId);
+    const balance = balRes?.balance || 0;
+    if (balance < stake.amount) {
+      setMatchingError('Insufficient balance for this stake.');
+      setMatchStatus('');
+      setMatching(false);
+      setIsSearching(false);
+      return { success: false };
+    }
+  } catch (error) {
+    setMatchingError('Could not check your balance. Please try again.');
+    setMatchStatus('');
+    setMatching(false);
+    setIsSearching(false);
+    logSupportError('getAccountBalance failed', error, { accountId });
+    return { success: false };
+  }
+
+  try {
+    await addTransactionFn(telegramId, -stake.amount, 'stake', {
+      game: 'poolroyale-online',
+      players: 2,
+      accountId
+    });
+    stakeDebitRef.current = { telegramId, accountId, amount: stake.amount };
+  } catch (error) {
+    setMatchingError('Unable to reserve your stake. Please retry.');
+    setMatchStatus('');
+    setMatching(false);
+    setIsSearching(false);
+    logSupportError('addTransaction debit failed', error, { accountId, telegramId });
+    return { success: false };
+  }
+
+  if (!socketInstance?.connected) {
+    setMatchStatus('');
+    setMatchingError('Unable to reach the online arena. We refunded your stake.');
+    await refundStake('socket_registration_failed', { accountId });
+    setMatching(false);
+    setIsSearching(false);
+    return { success: false };
+  }
+
+  function handleLobbyUpdate({ tableId: tid, players: list = [], ready = [] } = {}) {
+    if (!tid || tid !== pendingTableRef.current) return;
+    setMatchPlayers(list);
+    matchPlayersRef.current = list;
+    setReadyList(ready);
+    const others = list.filter((p) => String(p.id) !== String(accountId));
+    setMatchStatus(
+      others.length > 0 ? 'Opponent joined. Locking seats…' : 'Waiting for another player…'
+    );
+  }
+
+  function clearSpinInterval() {
+    if (spinIntervalRef?.current) {
+      clearInterval(spinIntervalRef.current);
+      spinIntervalRef.current = null;
+    }
+  }
+
+  async function cleanupLobby({ account = accountIdRef.current, skipRefReset, refundReason, keepError } = {}) {
+    socketInstance.off('lobbyUpdate', handleLobbyUpdate);
+    socketInstance.off('gameStart', handleGameStart);
+    if (pendingTableRef.current && account) {
+      socketInstance.emit('leaveLobby', { accountId: account, tableId: pendingTableRef.current });
+    }
+    pendingTableRef.current = '';
+    clearSpinInterval();
+    clearTimers();
+    setMatchPlayers([]);
+    matchPlayersRef.current = [];
+    setReadyList([]);
+    setMatchStatus('');
+    setMatching(false);
+    setSpinningPlayer('');
+    setIsSearching(false);
+    if (!keepError) setMatchingError('');
+    if (refundReason || stakeDebitRef?.current) {
+      await refundStake(refundReason || 'manual_cleanup', { account });
+    }
+    if (!skipRefReset) cleanupRef.current = () => {};
+  }
+
+  const triggerTimeoutRefund = (reason, message, extra = {}) => {
+    setMatchStatus('');
+    setMatchingError(message);
+    cleanupLobby({ account: accountId, refundReason: reason, keepError: true });
+    logSupportError(message, null, { reason, ...extra });
+  };
+
+  function handleGameStart({ tableId: startedId, players: joined = [] } = {}) {
+    if (!startedId || startedId !== pendingTableRef.current) return;
+    const roster = Array.isArray(joined) && joined.length > 0 ? joined : matchPlayersRef.current;
+    stakeDebitRef.current = null;
+    clearTimers();
+    cleanupLobby({ account: accountId, skipRefReset: true, keepError: true });
+    onGameStart?.({ tableId: startedId, roster, accountId });
+  }
+
+  cleanupRef.current = cleanupLobby;
+
+  seatTimeoutRef.current = setTimeout(() => {
+    triggerTimeoutRefund(
+      'seat_ack_timeout',
+      'Timed out while joining the online arena. We refunded your stake.',
+      { accountId }
+    );
+  }, seatTimeoutMs);
+
+  socketInstance.on('lobbyUpdate', handleLobbyUpdate);
+  socketInstance.on('gameStart', handleGameStart);
+  socketInstance.emit('register', { playerId: accountId });
+
+  function startMatchTimeout(tableId) {
+    clearTimeoutSafely(matchTimeoutRef);
+    matchTimeoutRef.current = setTimeout(() => {
+      triggerTimeoutRefund('matchmaking_timeout', 'Matchmaking timed out. We refunded your stake.', {
+        accountId,
+        tableId
+      });
+    }, matchmakingTimeoutMs);
+  }
+
+  socketInstance.emit(
+    'seatTable',
+    {
+      accountId,
+      stake: stake.amount,
+      token: stake.token,
+      gameType: 'poolroyale',
+      maxPlayers: 2,
+      mode,
+      variant,
+      tableSize,
+      playType,
+      playerName: getTelegramFirstNameFn?.() || `TPC ${accountId}` || 'Player',
+      avatar
+    },
+    (res) => {
+      clearTimeoutSafely(seatTimeoutRef);
+      setIsSearching(false);
+      if (!res?.success || !res.tableId) {
+        triggerTimeoutRefund(
+          'seat_table_failed',
+          res?.message || 'Failed to join the online arena. Please retry.',
+          { response: res, accountId }
+        );
+        return;
+      }
+      pendingTableRef.current = res.tableId;
+      setMatchStatus('Waiting for another player…');
+      const playersList = res.players || [];
+      setMatchPlayers(playersList);
+      matchPlayersRef.current = playersList;
+      setReadyList(res.ready || []);
+      socketInstance.emit('confirmReady', {
+        accountId,
+        tableId: res.tableId
+      });
+      startMatchTimeout(res.tableId);
+    }
+  );
+
+  return { success: true };
+}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -1,9 +1,8 @@
 // Use the API base URL from the build environment or fallback to the same origin
-
 // so the webapp works when served by the Express server in production.
-
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
-export const API_AUTH_TOKEN = import.meta.env.VITE_API_AUTH_TOKEN || '';
+const metaEnv = (typeof import.meta !== 'undefined' && import.meta?.env) || {};
+export const API_BASE_URL = metaEnv.VITE_API_BASE_URL || '';
+export const API_AUTH_TOKEN = metaEnv.VITE_API_AUTH_TOKEN || '';
 
 export async function ping() {
   const data = await get('/api/ping');

--- a/webapp/src/utils/socket.js
+++ b/webapp/src/utils/socket.js
@@ -27,8 +27,9 @@ function normalizeBaseUrl(rawUrl) {
 }
 
 function resolveSocketConfig() {
-  const explicitUrl = import.meta.env.VITE_SOCKET_URL;
-  const explicitPath = import.meta.env.VITE_SOCKET_PATH;
+  const metaEnv = (typeof import.meta !== 'undefined' && import.meta?.env) || {};
+  const explicitUrl = metaEnv.VITE_SOCKET_URL;
+  const explicitPath = metaEnv.VITE_SOCKET_PATH;
 
   const url = normalizeBaseUrl(explicitUrl || API_BASE_URL);
   const path = normalizePath(explicitPath);


### PR DESCRIPTION
## Summary
- add a reusable Pool Royale online flow with inline error messaging for account, balance, and stake failures
- refund reserved stakes on socket/seat failures or matchmaking timeouts while logging issues for support
- add integration coverage for the Pool Royale stake flow and guard env access in shared utils

## Testing
- node --test test/poolRoyaleOnlineFlow.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943ccb715408329b38b5240e00bce5e)