### PR TITLE
Add server-backed Pool Royale inventory syncing

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -115,7 +115,10 @@ const userSchema = new mongoose.Schema({
   inboxReadAt: { type: Date, default: Date.now },
 
   // Track which game table the user is currently seated at
-  currentTableId: { type: String, default: null }
+  currentTableId: { type: String, default: null },
+
+  // Persist Pool Royale unlocks server-side for cross-device sync
+  poolRoyalInventory: { type: Object, default: undefined }
 
 });
 

--- a/bot/routes/poolRoyale.js
+++ b/bot/routes/poolRoyale.js
@@ -1,0 +1,86 @@
+import { Router } from 'express';
+import User from '../models/User.js';
+import { POOL_ROYALE_DEFAULT_UNLOCKS } from '../../webapp/src/config/poolRoyaleInventoryConfig.js';
+
+const router = Router();
+
+const copyDefaults = () =>
+  Object.entries(POOL_ROYALE_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values] : [];
+    return acc;
+  }, {});
+
+const sortUnique = (values) => Array.from(new Set(values)).filter(Boolean).sort();
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = sortUnique([...(merged[key] || []), ...value]);
+  });
+  return merged;
+};
+
+const mergeInventories = (...inventories) => {
+  const merged = copyDefaults();
+  inventories
+    .filter(Boolean)
+    .forEach((inventory) => {
+      const normalized = normalizeInventory(inventory);
+      Object.entries(normalized).forEach(([key, values]) => {
+        if (!Array.isArray(values)) return;
+        merged[key] = sortUnique([...(merged[key] || []), ...values]);
+      });
+    });
+  return merged;
+};
+
+const areInventoriesEqual = (a, b) => {
+  const aKeys = Object.keys(a || {});
+  const bKeys = Object.keys(b || {});
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every(
+    (key) => Array.isArray(a[key]) && Array.isArray(b?.[key]) && a[key].join('|') === b[key].join('|')
+  );
+};
+
+router.post('/inventory/get', async (req, res) => {
+  const { accountId } = req.body || {};
+  if (!accountId) return res.status(400).json({ error: 'accountId required' });
+
+  const user = await User.findOne({ accountId });
+  if (!user) return res.status(404).json({ error: 'account not found' });
+
+  const normalized = normalizeInventory(user.poolRoyalInventory);
+  if (!areInventoriesEqual(user.poolRoyalInventory, normalized)) {
+    user.poolRoyalInventory = normalized;
+    try {
+      await user.save();
+    } catch (err) {
+      console.error('Failed to normalize Pool Royale inventory:', err.message);
+    }
+  }
+  res.json({ accountId, inventory: normalized });
+});
+
+router.post('/inventory/set', async (req, res) => {
+  const { accountId, inventory } = req.body || {};
+  if (!accountId) return res.status(400).json({ error: 'accountId required' });
+
+  const user = await User.findOne({ accountId });
+  if (!user) return res.status(404).json({ error: 'account not found' });
+
+  const merged = mergeInventories(user.poolRoyalInventory, inventory);
+  user.poolRoyalInventory = merged;
+  try {
+    await user.save();
+  } catch (err) {
+    console.error('Failed to persist Pool Royale inventory:', err.message);
+    return res.status(500).json({ error: 'failed to save inventory' });
+  }
+  res.json({ accountId, inventory: merged });
+});
+
+export default router;

--- a/bot/server.js
+++ b/bot/server.js
@@ -24,6 +24,7 @@ import storeRoutes, { BUNDLES } from './routes/store.js';
 import adsRoutes from './routes/ads.js';
 import influencerRoutes from './routes/influencer.js';
 import onlineRoutes from './routes/online.js';
+import poolRoyaleRoutes from './routes/poolRoyale.js';
 import User from './models/User.js';
 import GameResult from './models/GameResult.js';
 import AdView from './models/AdView.js';
@@ -152,6 +153,7 @@ app.use('/api/social', socialRoutes);
 app.use('/api/broadcast', broadcastRoutes);
 app.use('/api/store', storeRoutes);
 app.use('/api/online', onlineRoutes);
+app.use('/api/pool-royale', poolRoyaleRoutes);
 
 app.post('/api/goal-rush/calibration', (req, res) => {
   const { accountId, calibration } = req.body || {};

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/tests'],
+  roots: ['<rootDir>/test'],
 };

--- a/test/poolRoyalInventoryRoutes.test.js
+++ b/test/poolRoyalInventoryRoutes.test.js
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+async function createAccount(port, telegramId) {
+  const res = await fetch(`http://localhost:${port}/api/account/create`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ telegramId })
+  });
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.ok(data.accountId);
+  return data.accountId;
+}
+
+async function getInventory(port, accountId) {
+  const res = await fetch(`http://localhost:${port}/api/pool-royale/inventory/get`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ accountId })
+  });
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.ok(data.inventory);
+  return data.inventory;
+}
+
+async function saveInventory(port, accountId, inventory) {
+  const res = await fetch(`http://localhost:${port}/api/pool-royale/inventory/set`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ accountId, inventory })
+  });
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.ok(data.inventory);
+  return data.inventory;
+}
+
+test(
+  'Pool Royale inventory persists across reloads and devices',
+  { concurrency: false },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+
+    const env = {
+      ...process.env,
+      PORT: '3213',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+    try {
+      const accountId = await createAccount(3213, 999991);
+      const initialInventory = await getInventory(3213, accountId);
+
+      const deviceAInventory = {
+        ...initialInventory,
+        clothColor: [...(initialInventory.clothColor || []), 'graphite'],
+        cueStyle: [...(initialInventory.cueStyle || []), 'carbon-matrix']
+      };
+      const afterDeviceA = await saveInventory(3213, accountId, deviceAInventory);
+      assert.ok(afterDeviceA.clothColor.includes('graphite'));
+      assert.ok(afterDeviceA.cueStyle.includes('carbon-matrix'));
+
+      const afterReload = await getInventory(3213, accountId);
+      assert.ok(afterReload.clothColor.includes('graphite'));
+      assert.ok(afterReload.cueStyle.includes('carbon-matrix'));
+
+      const deviceBInventory = {
+        tableFinish: ['jetBlackCarbon']
+      };
+      const afterDeviceB = await saveInventory(3213, accountId, deviceBInventory);
+      assert.ok(afterDeviceB.tableFinish.includes('jetBlackCarbon'));
+      assert.ok(afterDeviceB.cueStyle.includes('carbon-matrix'));
+
+      const finalInventory = await getInventory(3213, accountId);
+      assert.ok(finalInventory.tableFinish.includes('jetBlackCarbon'));
+      assert.ok(finalInventory.clothColor.includes('graphite'));
+      assert.ok(finalInventory.cueStyle.includes('carbon-matrix'));
+    } finally {
+      server.kill();
+    }
+  }
+);

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -465,6 +465,19 @@ export default function Store() {
   }, [accountId]);
 
   useEffect(() => {
+    const handlePoolInventoryUpdate = (event) => {
+      if (event?.detail?.accountId && event.detail.accountId !== accountId) return;
+      if (event?.detail?.inventory) {
+        setPoolOwned(event.detail.inventory);
+      } else {
+        setPoolOwned(getPoolRoyalInventory(accountId));
+      }
+    };
+    window.addEventListener('poolRoyalInventoryUpdate', handlePoolInventoryUpdate);
+    return () => window.removeEventListener('poolRoyalInventoryUpdate', handlePoolInventoryUpdate);
+  }, [accountId]);
+
+  useEffect(() => {
     const loadBalance = async () => {
       if (!accountId || accountId === 'guest') return;
       try {

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -172,6 +172,14 @@ export function adminDeleteTask(id) {
   return post('/api/tasks/admin/delete', { id }, API_AUTH_TOKEN || undefined);
 }
 
+export function getPoolRoyalInventoryRemote(accountId) {
+  return post('/api/pool-royale/inventory/get', { accountId });
+}
+
+export function setPoolRoyalInventoryRemote(accountId, inventory) {
+  return post('/api/pool-royale/inventory/set', { accountId, inventory });
+}
+
 export function listVideos(telegramId) {
   return post('/api/watch/list', { telegramId });
 }

--- a/webapp/src/utils/poolRoyalInventory.js
+++ b/webapp/src/utils/poolRoyalInventory.js
@@ -3,14 +3,25 @@ import {
   POOL_ROYALE_DEFAULT_UNLOCKS,
   POOL_ROYALE_OPTION_LABELS
 } from '../config/poolRoyaleInventoryConfig.js';
+import {
+  getPoolRoyalInventoryRemote,
+  setPoolRoyalInventoryRemote
+} from './api.js';
 
 const STORAGE_KEY = 'poolRoyalInventoryByAccount';
+const MIGRATION_KEY = 'poolRoyalInventoryMigrated';
+const inflightSync = new Map();
 
 const copyDefaults = () =>
   Object.entries(POOL_ROYALE_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
     acc[key] = Array.isArray(values) ? [...values] : [];
     return acc;
   }, {});
+
+const sortUnique = (values) =>
+  Array.from(new Set(Array.isArray(values) ? values : Array.from(values || [])))
+    .filter(Boolean)
+    .sort();
 
 const resolveAccountId = (accountId) => {
   if (accountId) return accountId;
@@ -37,28 +48,154 @@ const writeAllInventories = (payload) => {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
 };
 
+const readMigrationFlags = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(MIGRATION_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read Pool Royale migration flags', err);
+    return {};
+  }
+};
+
+const writeMigrationFlags = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(MIGRATION_KEY, JSON.stringify(payload));
+};
+
 const normalizeInventory = (rawInventory) => {
   const base = copyDefaults();
   if (!rawInventory || typeof rawInventory !== 'object') return base;
   const merged = { ...base };
   Object.entries(rawInventory).forEach(([key, value]) => {
     if (!Array.isArray(value)) return;
-    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+    merged[key] = sortUnique([...(merged[key] || []), ...value]);
   });
   return merged;
 };
 
-export const getPoolRoyalInventory = (accountId) => {
-  const resolvedAccountId = resolveAccountId(accountId);
+const mergeInventories = (...inventories) => {
+  const merged = copyDefaults();
+  inventories
+    .filter(Boolean)
+    .forEach((inventory) => {
+      const normalized = normalizeInventory(inventory);
+      Object.entries(normalized).forEach(([key, values]) => {
+        if (!Array.isArray(values)) return;
+        merged[key] = sortUnique([...(merged[key] || []), ...values]);
+      });
+    });
+  return merged;
+};
+
+const persistCache = (accountId, inventory, silent = false) => {
+  if (typeof window === 'undefined') return;
   const inventories = readAllInventories();
-  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  const payload = {
+    ...inventories,
+    [accountId]: normalizeInventory(inventory)
+  };
+  writeAllInventories(payload);
+  if (!silent) {
+    window.dispatchEvent(
+      new CustomEvent('poolRoyalInventoryUpdate', {
+        detail: { accountId, inventory: payload[accountId] }
+      })
+    );
+  }
+};
+
+const markMigrated = (accountId) => {
+  if (typeof window === 'undefined') return;
+  const flags = readMigrationFlags();
+  if (flags[accountId]) return;
+  flags[accountId] = true;
+  writeMigrationFlags(flags);
+};
+
+const isInventoryEmpty = (inventory) =>
+  !inventory ||
+  !Object.values(inventory).some((value) => Array.isArray(value) && value.length > 0);
+
+const areInventoriesEqual = (a, b) => {
+  const aKeys = Object.keys(a || {});
+  const bKeys = Object.keys(b || {});
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every(
+    (key) => Array.isArray(a[key]) && Array.isArray(b?.[key]) && a[key].join('|') === b[key].join('|')
+  );
+};
+
+const syncWithServer = async (accountId, localInventory) => {
+  if (!accountId || accountId === 'guest') return localInventory;
+  const migrationFlags = readMigrationFlags();
+  const skipMigration = Boolean(migrationFlags[accountId]);
+  if (inflightSync.has(accountId)) {
+    return inflightSync.get(accountId);
+  }
+  const promise = (async () => {
+    const currentInventory = normalizeInventory(localInventory);
+    let serverInventory = currentInventory;
+    try {
+      const remote = await getPoolRoyalInventoryRemote(accountId);
+      if (remote?.error) throw new Error(remote.error);
+      serverInventory = normalizeInventory(remote.inventory);
+    } catch (err) {
+      console.warn('Pool Royale inventory fetch failed, using cache', err);
+      inflightSync.delete(accountId);
+      return currentInventory;
+    }
+
+    const merged = mergeInventories(serverInventory, currentInventory);
+    const needsPersist =
+      (!skipMigration && !isInventoryEmpty(currentInventory)) ||
+      !areInventoriesEqual(merged, serverInventory);
+
+    let finalInventory = merged;
+    if (needsPersist) {
+      try {
+        const saved = await setPoolRoyalInventoryRemote(accountId, merged);
+        if (!saved?.error) {
+          finalInventory = normalizeInventory(saved.inventory);
+        }
+      } catch (err) {
+        console.warn('Pool Royale inventory save failed, keeping cache', err);
+      }
+    }
+
+    markMigrated(accountId);
+    if (!areInventoriesEqual(finalInventory, currentInventory)) {
+      persistCache(accountId, finalInventory);
+    } else {
+      persistCache(accountId, finalInventory, true);
+    }
+    inflightSync.delete(accountId);
+    return finalInventory;
+  })();
+  inflightSync.set(accountId, promise);
+  return promise;
+};
+
+const readCachedInventory = (accountId) => {
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[accountId]);
   if (typeof window !== 'undefined') {
     writeAllInventories({
       ...inventories,
-      [resolvedAccountId]: normalized
+      [accountId]: normalized
     });
   }
   return normalized;
+};
+
+export const getPoolRoyalInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const cached = readCachedInventory(resolvedAccountId);
+  if (typeof window !== 'undefined') {
+    syncWithServer(resolvedAccountId, cached);
+  }
+  return cached;
 };
 
 export const isPoolOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
@@ -72,30 +209,25 @@ export const isPoolOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
 
 export const addPoolRoyalUnlock = (type, optionId, accountId) => {
   const resolvedAccountId = resolveAccountId(accountId);
-  const inventories = readAllInventories();
-  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const current = getPoolRoyalInventory(resolvedAccountId);
   const existing = new Set(current[type] || []);
   existing.add(optionId);
   const nextInventory = {
     ...current,
-    [type]: Array.from(existing)
+    [type]: sortUnique(existing)
   };
-  writeAllInventories({
-    ...inventories,
-    [resolvedAccountId]: nextInventory
-  });
+  persistCache(resolvedAccountId, nextInventory);
   if (typeof window !== 'undefined') {
-    window.dispatchEvent(
-      new CustomEvent('poolRoyalInventoryUpdate', {
-        detail: { accountId: resolvedAccountId, inventory: nextInventory }
-      })
-    );
+    syncWithServer(resolvedAccountId, nextInventory);
   }
   return nextInventory;
 };
 
-export const listOwnedPoolRoyalOptions = (accountId) => {
-  const inventory = getPoolRoyalInventory(accountId);
+export const listOwnedPoolRoyalOptions = (inventoryOrAccountId) => {
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getPoolRoyalInventory(inventoryOrAccountId)
+      : normalizeInventory(inventoryOrAccountId);
   return Object.entries(inventory).flatMap(([type, values]) => {
     if (!Array.isArray(values)) return [];
     const labels = POOL_ROYALE_OPTION_LABELS[type] || {};


### PR DESCRIPTION
## Summary
- add Pool Royale API routes and persistent user field to read and write inventories per account
- update the Pool Royale inventory utility to sync with the server, migrate local caches, and stay resilient when offline
- cover inventory persistence with a cross-device integration test and align Jest roots with the existing test folder

## Testing
- npm test *(fails: Jest is not configured for the existing ESM `node:test` suites and aborts before running tests)*
- node --test test/poolRoyalInventoryRoutes.test.js *(fails: mongodb-memory-server binary download blocked by environment proxy, so the in-memory MongoDB cannot start)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943d8cb38e083298e76a6fc5da4094f)