### PR TITLE
Add Pool Royale training progress tracking and rules tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,25 @@
 module.exports = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   roots: ['<rootDir>/test'],
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: './tsconfig.json'
+      }
+    ],
+    '^.+\\.(js|jsx)$': [
+      'babel-jest',
+      {
+        presets: [['@babel/preset-env', { targets: { node: 'current' }, modules: 'commonjs' }]]
+      }
+    ]
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^node:test$': '<rootDir>/test/jestNodeTestShim.js'
+  }
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ton-x": "^2.1.0-preview"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.26.0",
     "concurrently": "^8.2.2",
     "eslint": "^8.57.1",
     "eslint-config-standard": "^17.1.0",

--- a/test/jestNodeTestShim.js
+++ b/test/jestNodeTestShim.js
@@ -1,0 +1,24 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+  test as jestTest
+} from '@jest/globals';
+
+const test = (...args) => jestTest(...args);
+
+export default test;
+export {
+  test,
+  it,
+  describe,
+  beforeAll as before,
+  beforeAll,
+  afterAll as after,
+  afterEach,
+  beforeEach,
+  afterAll
+};

--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -1,0 +1,123 @@
+import { PoolRoyaleRules } from '../src/rules/PoolRoyaleRules';
+import { ShotContext, ShotEvent } from '../src/types';
+
+describe('PoolRoyaleRules', () => {
+  test('UK variant preserves assignments through serialization and updates HUD', () => {
+    const rules = new PoolRoyaleRules('uk');
+    const initialFrame = rules.getInitialFrame('Player A', 'Player B');
+    const initialMeta = initialFrame.meta as any;
+
+    expect(initialMeta?.variant).toBe('uk');
+    expect(initialMeta?.hud?.next).toBe('open table');
+    expect(initialMeta?.state?.isOpenTable).toBe(true);
+
+    const assignEvents: ShotEvent[] = [
+      { type: 'HIT', firstContact: 'red', ballId: 'RED' },
+      { type: 'POTTED', ball: 'RED', pocket: 'TM', ballId: 'RED' }
+    ];
+    const assigned = rules.applyShot(initialFrame, assignEvents, {
+      placedFromHand: true,
+      contactMade: true,
+      cushionAfterContact: true
+    });
+    const assignedMeta = assigned.meta as any;
+
+    expect(assignedMeta?.state?.assignments?.A).toBe('red');
+    expect(assignedMeta?.state?.assignments?.B).toBe('blue');
+    expect(assignedMeta?.state?.isOpenTable).toBe(false);
+    expect(assigned.ballOn).toEqual(['RED']);
+    expect(assignedMeta?.hud?.next).toBe('red');
+    expect(assignedMeta?.hud?.phase).toBe('groups');
+
+    const foulEvents: ShotEvent[] = [
+      { type: 'HIT', firstContact: 'black', ballId: 'BLACK' },
+      { type: 'POTTED', ball: 'cue', pocket: 'BR', ballId: 'cue' }
+    ];
+    const foulContext: ShotContext = { cueBallPotted: true, contactMade: true };
+    const foulState = new PoolRoyaleRules('uk').applyShot(assigned, foulEvents, foulContext);
+    const foulMeta = foulState.meta as any;
+
+    expect(foulState.foul?.reason).toBe('scratch');
+    expect(foulMeta?.state?.mustPlayFromBaulk).toBe(true);
+    expect(foulState.activePlayer).toBe('B');
+    expect(foulMeta?.hud?.phase).toBe('groups');
+    expect(foulState.ballOn).toContain('YELLOW');
+  });
+
+  test('American variant handles break transition, fouls, and ball-in-hand', () => {
+    const rules = new PoolRoyaleRules('american');
+    const initialFrame = rules.getInitialFrame('Breaker', 'Opponent');
+    const initialMeta = initialFrame.meta as any;
+
+    expect(initialMeta?.variant).toBe('american');
+    expect(initialMeta?.breakInProgress).toBe(true);
+    expect(initialMeta?.state?.ballInHand).toBe(true);
+    expect(initialMeta?.hud?.next).toBe('ball 1');
+
+    const breakEvents: ShotEvent[] = [
+      { type: 'HIT', firstContact: 1, ballId: 1 },
+      { type: 'POTTED', ball: 1, pocket: 'BL', ballId: 1 },
+      { type: 'POTTED', ball: 2, pocket: 'BR', ballId: 2 }
+    ];
+    const cleared = rules.applyShot(initialFrame, breakEvents, {
+      placedFromHand: true,
+      contactMade: true,
+      cushionAfterContact: true
+    });
+    const clearedMeta = cleared.meta as any;
+
+    expect(clearedMeta?.breakInProgress).toBe(false);
+    expect(clearedMeta?.state?.ballInHand).toBe(false);
+    expect(cleared.ballOn).toEqual(['BALL_3']);
+    expect(clearedMeta?.hud?.next).toBe('ball 3');
+    expect(cleared.players.A.score).toBe(3);
+
+    const scratchEvents: ShotEvent[] = [
+      { type: 'HIT', firstContact: 3, ballId: 3 },
+      { type: 'POTTED', ball: 0, pocket: 'TR', ballId: 'cue' }
+    ];
+    const scratchContext: ShotContext = { cueBallPotted: true, contactMade: true };
+    const scratch = rules.applyShot(cleared, scratchEvents, scratchContext);
+    const scratchMeta = scratch.meta as any;
+
+    expect(scratch.foul?.reason).toBe('scratch');
+    expect(scratchMeta?.state?.ballInHand).toBe(true);
+    expect(scratch.activePlayer).toBe('B');
+    expect(scratch.ballOn).toEqual(['BALL_3']);
+    expect(scratchMeta?.hud?.phase).toBe('rotation');
+  });
+
+  test('Nine-ball enforces lowest-ball contact and updates HUD after recovery', () => {
+    const rules = new PoolRoyaleRules('9ball');
+    const initialFrame = rules.getInitialFrame('Challenger', 'Rival');
+    const initialMeta = initialFrame.meta as any;
+
+    expect(initialMeta?.variant).toBe('9ball');
+    expect(initialMeta?.breakInProgress).toBe(true);
+    expect(initialMeta?.state?.ballInHand).toBe(true);
+    expect(initialFrame.ballOn).toEqual(['BALL_1']);
+    expect(initialMeta?.hud?.next).toBe('ball 1');
+
+    const foulEvents: ShotEvent[] = [{ type: 'HIT', firstContact: 2, ballId: 2 }];
+    const foulState = rules.applyShot(initialFrame, foulEvents, { contactMade: true });
+    const foulMeta = foulState.meta as any;
+
+    expect(foulState.foul?.reason).toBe('wrong first contact');
+    expect(foulMeta?.state?.ballInHand).toBe(true);
+    expect(foulState.activePlayer).toBe('B');
+    expect(foulState.ballOn).toEqual(['BALL_1']);
+
+    const recoveryEvents: ShotEvent[] = [
+      { type: 'HIT', firstContact: 1, ballId: 1 },
+      { type: 'POTTED', ball: 1, pocket: 'TM', ballId: 1 }
+    ];
+    const recoveryContext: ShotContext = { placedFromHand: true, contactMade: true };
+    const recoveryState = rules.applyShot(foulState, recoveryEvents, recoveryContext);
+    const recoveryMeta = recoveryState.meta as any;
+
+    expect(recoveryMeta?.breakInProgress).toBe(false);
+    expect(recoveryMeta?.state?.ballInHand).toBe(false);
+    expect(recoveryState.ballOn).toEqual(['BALL_2']);
+    expect(recoveryMeta?.hud?.next).toBe('ball 2');
+  });
+});

--- a/test/poolRoyaleTrainingProgress.test.js
+++ b/test/poolRoyaleTrainingProgress.test.js
@@ -1,0 +1,18 @@
+import { resolvePlayableTrainingLevel } from '../webapp/src/utils/poolRoyaleTrainingProgress.js';
+
+describe('resolvePlayableTrainingLevel', () => {
+  test('caps requested levels to the next incomplete slot', () => {
+    const progress = { completed: [1, 2], lastLevel: 2 };
+    expect(resolvePlayableTrainingLevel(5, progress)).toBe(3);
+  });
+
+  test('allows replaying unlocked levels without rewinding progress', () => {
+    const progress = { completed: [1, 2, 3], lastLevel: 3 };
+    expect(resolvePlayableTrainingLevel(2, progress)).toBe(2);
+  });
+
+  test('falls back to the last level when every task is already complete', () => {
+    const progress = { completed: Array.from({ length: 50 }, (_, i) => i + 1), lastLevel: 4 };
+    expect(resolvePlayableTrainingLevel(null, progress)).toBe(4);
+  });
+});

--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -1,5 +1,45 @@
 const TRAINING_PROGRESS_KEY = 'poolRoyaleTrainingProgress';
 
+export const TRAINING_LEVELS = [
+  {
+    level: 1,
+    title: 'Opening break',
+    objective: 'Place the cue ball, hit the rack cleanly, and pocket any object ball.',
+    reward: 'Unlocks aim assist calibration.'
+  },
+  {
+    level: 2,
+    title: 'Position & safety',
+    objective: 'Avoid fouls while leaving the cue ball safe for your next shot.',
+    reward: 'Ball-in-hand respot practice.'
+  },
+  {
+    level: 3,
+    title: 'Run the table',
+    objective: 'Sink three balls in one visit without scratching.',
+    reward: 'Pro tip overlays for long pots.'
+  },
+  {
+    level: 4,
+    title: 'Finishing shot',
+    objective: 'Clear the final ball under pressure to close the frame.',
+    reward: 'Celebration banners and XP boost.'
+  }
+];
+
+export function describeTrainingLevel(level) {
+  const numeric = Number(level);
+  const fallback = Number.isFinite(numeric) && numeric > 0 ? Math.floor(numeric) : 1;
+  const preset = TRAINING_LEVELS.find((entry) => entry.level === fallback);
+  if (preset) return preset;
+  return {
+    level: fallback,
+    title: `Level ${fallback}`,
+    objective: 'Complete drills to unlock new cues and tips.',
+    reward: 'Progress boost'
+  };
+}
+
 export function loadTrainingProgress() {
   if (typeof window === 'undefined') return { completed: [], lastLevel: 1 };
   try {


### PR DESCRIPTION
## Summary
- enable Jest ESM support with ts-jest/Babel transforms and shim node:test imports to execute existing suites
- add regression coverage for PoolRoyaleRules serialization, fouls, HUD transitions, and training progression guardrails
- load and persist Pool Royale training progress while surfacing level objectives and rewards in the HUD/menu

## Testing
- npm test -- --runTestsByPath test/poolRoyaleRules.test.ts test/poolRoyaleTrainingProgress.test.js test/nineBall.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943dd75691c8329bc604747b5faac2b)