### PR TITLE
Add Pool Royale inventory sync with offline fallback

### DIFF
--- a/bot/utils/memoryUserStore.js
+++ b/bot/utils/memoryUserStore.js
@@ -1,0 +1,57 @@
+import mongoose from 'mongoose';
+import { v4 as uuidv4 } from 'uuid';
+
+const memoryUsers = new Map();
+
+const defaultUserFields = () => ({
+  balance: 0,
+  transactions: [],
+  gifts: [],
+  referralCode: null,
+  walletAddress: null,
+  walletPublicKey: null,
+  poolRoyalInventory: undefined
+});
+
+const findByKey = (key, value) => {
+  if (!value) return null;
+  for (const user of memoryUsers.values()) {
+    if (user?.[key] === value) return user;
+  }
+  return null;
+};
+
+export const shouldUseMemoryUserStore = () =>
+  process.env.MONGO_URI === 'memory' && mongoose.connection.readyState !== 1;
+
+export const findMemoryUser = ({ accountId, telegramId, googleId }) => {
+  if (accountId && memoryUsers.has(accountId)) return memoryUsers.get(accountId);
+  if (telegramId) return findByKey('telegramId', telegramId);
+  if (googleId) return findByKey('googleId', googleId);
+  return null;
+};
+
+export const saveMemoryUser = (user) => {
+  if (!user?.accountId) return null;
+  memoryUsers.set(user.accountId, { ...defaultUserFields(), ...user });
+  return memoryUsers.get(user.accountId);
+};
+
+export const createMemoryUser = (data = {}) => {
+  const accountId = data.accountId || uuidv4();
+  const base = {
+    ...defaultUserFields(),
+    ...data,
+    accountId,
+    referralCode: data.referralCode || accountId
+  };
+  memoryUsers.set(accountId, base);
+  return memoryUsers.get(accountId);
+};
+
+export const ensureMemoryUser = (user) => {
+  const accountId = user?.accountId || uuidv4();
+  const merged = { ...defaultUserFields(), ...user, accountId };
+  memoryUsers.set(accountId, merged);
+  return memoryUsers.get(accountId);
+};

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,6 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/test'],
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)', '**/?(*.)+(spec|test).mjs'],
   transform: {
     '^.+\\.(ts|tsx)$': [
       'ts-jest',
@@ -14,7 +15,8 @@ module.exports = {
     '^.+\\.(js|jsx)$': [
       'babel-jest',
       {
-        presets: [['@babel/preset-env', { targets: { node: 'current' }, modules: 'commonjs' }]]
+        presets: [['@babel/preset-env', { targets: { node: 'current' }, modules: 'commonjs' }]],
+        plugins: ['@babel/plugin-syntax-import-meta']
       }
     ]
   },


### PR DESCRIPTION
## Summary
- add GET/PUT Pool Royale inventory endpoints plus memory fallback so accounts and inventories continue to work when Mongo is unavailable in tests
- sync Pool Royale inventory client helpers to fetch and persist to the server while migrating cached data and handling offline caching
- cover unlock persistence across reloads/devices with an end-to-end test and update Jest config for ESM-friendly runs

## Testing
- npm test -- poolRoyalInventoryRoutes.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943e541fc2483299ba65b059f76916d)