### PR TITLE
Add Pool Royale training lobby selection and table id tracking

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8270,7 +8270,8 @@ function PoolRoyaleGame({
   playerName,
   playerAvatar,
   opponentName,
-  opponentAvatar
+  opponentAvatar,
+  tableId
 }) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -8539,6 +8540,12 @@ function PoolRoyaleGame({
   const trainingProgressRef = useRef(trainingProgress);
   const trainingLevelRef = useRef(trainingLevel);
   const trainingCompletionHandledRef = useRef(false);
+  const requestedTrainingLevel = useMemo(() => {
+    if (!isTraining) return null;
+    const params = new URLSearchParams(location.search);
+    const raw = Number(params.get('level'));
+    return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : null;
+  }, [isTraining, location.search]);
   useEffect(() => {
     trainingProgressRef.current = trainingProgress;
   }, [trainingProgress]);
@@ -8547,11 +8554,13 @@ function PoolRoyaleGame({
   }, [trainingLevel]);
   useEffect(() => {
     const stored = loadTrainingProgress();
-    const playableLevel = resolvePlayableTrainingLevel(stored.lastLevel, stored);
+    const desiredLevel = requestedTrainingLevel ?? stored.lastLevel;
+    const playableLevel = resolvePlayableTrainingLevel(desiredLevel, stored);
     trainingProgressRef.current = stored;
     setTrainingProgress(stored);
     setTrainingLevel(playableLevel);
-  }, []);
+    trainingCompletionHandledRef.current = false;
+  }, [requestedTrainingLevel]);
   const currentTrainingInfo = useMemo(
     () => describeTrainingLevel(trainingLevel),
     [trainingLevel]
@@ -17570,7 +17579,10 @@ function PoolRoyaleGame({
   const bottomHudVisible = hud.turn != null && !hud.over && !shotActive;
 
   return (
-    <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
+    <div
+      className="w-full h-[100vh] bg-black text-white overflow-hidden select-none"
+      data-table-id={tableId || undefined}
+    >
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
 
@@ -18281,6 +18293,21 @@ export default function PoolRoyale() {
     const params = new URLSearchParams(location.search);
     return params.get('avatar') || '';
   }, [location.search]);
+  const tableId = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const incoming = params.get('tableId');
+    if (incoming) {
+      try {
+        window.sessionStorage?.setItem('poolRoyaleTableId', incoming);
+      } catch {}
+      return incoming;
+    }
+    try {
+      return window.sessionStorage?.getItem('poolRoyaleTableId') || '';
+    } catch {
+      return '';
+    }
+  }, [location.search]);
   const stakeAmount = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return Number(params.get('amount')) || 0;
@@ -18356,19 +18383,27 @@ export default function PoolRoyale() {
     return params.get('opponentAvatar') || '';
   }, [location.search]);
   return (
-    <PoolRoyaleGame
-      variantKey={variantKey}
-      tableSizeKey={tableSizeKey}
-      playType={playType}
-      mode={mode}
-      trainingMode={trainingMode}
-      trainingRulesEnabled={trainingRulesEnabled}
-      accountId={accountId}
-      tgId={tgId}
-      playerName={playerName}
-      playerAvatar={playerAvatar}
-      opponentName={opponentName}
-      opponentAvatar={opponentAvatar}
-    />
+    <div className="relative" data-table-id={tableId || undefined}>
+      {tableId && (
+        <div className="pointer-events-none absolute left-3 top-3 z-20 rounded-lg bg-black/70 px-3 py-1 text-xs font-semibold text-background">
+          Table {tableId.slice(0, 8)}
+        </div>
+      )}
+      <PoolRoyaleGame
+        variantKey={variantKey}
+        tableSizeKey={tableSizeKey}
+        playType={playType}
+        mode={mode}
+        trainingMode={trainingMode}
+        trainingRulesEnabled={trainingRulesEnabled}
+        accountId={accountId}
+        tgId={tgId}
+        playerName={playerName}
+        playerAvatar={playerAvatar}
+        opponentName={opponentName}
+        opponentAvatar={opponentAvatar}
+        tableId={tableId}
+      />
+    </div>
   );
 }

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -11,6 +11,11 @@ import { socket } from '../../utils/socket.js';
 import { getOnlineUsers } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { runPoolRoyaleOnlineFlow } from './poolRoyaleOnlineFlow.js';
+import {
+  TRAINING_LEVELS,
+  loadTrainingProgress,
+  resolvePlayableTrainingLevel
+} from '../../utils/poolRoyaleTrainingProgress.js';
 
 const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
@@ -46,6 +51,8 @@ export default function PoolRoyaleLobby() {
   const [isSearching, setIsSearching] = useState(false);
   const [matchingError, setMatchingError] = useState('');
   const [matchStatus, setMatchStatus] = useState('');
+  const [trainingProgress, setTrainingProgress] = useState({ completed: [], lastLevel: 1 });
+  const [trainingLevel, setTrainingLevel] = useState(1);
   const spinIntervalRef = useRef(null);
   const accountIdRef = useRef(null);
   const pendingTableRef = useRef('');
@@ -56,6 +63,10 @@ export default function PoolRoyaleLobby() {
 
   const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
+  const maxUnlockedTrainingLevel = useMemo(
+    () => resolvePlayableTrainingLevel(50, trainingProgress),
+    [trainingProgress]
+  );
 
   useEffect(() => {
     try {
@@ -83,6 +94,18 @@ export default function PoolRoyaleLobby() {
   useEffect(() => {
     matchPlayersRef.current = matchPlayers;
   }, [matchPlayers]);
+
+  useEffect(() => {
+    const storedProgress = loadTrainingProgress();
+    setTrainingProgress(storedProgress);
+    setTrainingLevel(resolvePlayableTrainingLevel(storedProgress.lastLevel, storedProgress));
+  }, []);
+
+  useEffect(() => {
+    if (trainingLevel > maxUnlockedTrainingLevel) {
+      setTrainingLevel(maxUnlockedTrainingLevel);
+    }
+  }, [maxUnlockedTrainingLevel, trainingLevel]);
 
   const navigateToPoolRoyale = ({ tableId: startedId, roster = [], accountId }) => {
     const selfId = accountId || accountIdRef.current;
@@ -122,6 +145,28 @@ export default function PoolRoyaleLobby() {
   };
 
   const startGame = async () => {
+    if (playType === 'training') {
+      const params = new URLSearchParams();
+      params.set('variant', variant);
+      params.set('tableSize', tableSize);
+      params.set('type', 'training');
+      params.set('mode', 'solo');
+      params.set('level', trainingLevel);
+      const tgId = getTelegramId();
+      if (tgId) params.set('tgId', tgId);
+      if (avatar) params.set('avatar', avatar);
+      const name = getTelegramFirstName();
+      if (name) params.set('name', name);
+      if (selectedFlag) params.set('flag', selectedFlag);
+      if (selectedAiFlag) params.set('aiFlag', selectedAiFlag);
+      try {
+        const accountId = await ensureAccountId();
+        if (accountId) params.set('accountId', accountId);
+      } catch {}
+      navigate(`/games/poolroyale?${params.toString()}`);
+      return;
+    }
+
     const isOnlineMatch = mode === 'online' && playType === 'regular';
     if (matching) return;
     await cleanupRef.current?.();
@@ -270,7 +315,7 @@ export default function PoolRoyaleLobby() {
   useEffect(() => () => cleanupRef.current?.(), []);
 
   useEffect(() => {
-    if (playType === 'tournament') {
+    if (playType !== 'regular') {
       setMode('ai');
     }
   }, [playType]);
@@ -315,6 +360,7 @@ export default function PoolRoyaleLobby() {
         <div className="flex gap-2">
           {[
             { id: 'regular', label: 'Regular' },
+            { id: 'training', label: 'Training' },
             { id: 'tournament', label: 'Tournament' }
           ].map(({ id, label }) => (
             <button
@@ -327,32 +373,34 @@ export default function PoolRoyaleLobby() {
           ))}
         </div>
       </div>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Mode</h3>
-        <div className="flex gap-2">
-          {[
-            { id: 'ai', label: 'Vs AI' },
-            { id: 'online', label: '1v1 Online', disabled: playType === 'tournament' }
-          ].map(({ id, label, disabled }) => (
-            <div key={id} className="relative">
-              <button
-                onClick={() => !disabled && setMode(id)}
-                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
-                  disabled ? 'opacity-50 cursor-not-allowed' : ''
-                }`}
-                disabled={disabled}
-              >
-                {label}
-              </button>
-              {disabled && (
-                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
-                  Tournament bracket only
-                </span>
-              )}
-            </div>
-          ))}
+      {playType !== 'training' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Mode</h3>
+          <div className="flex gap-2">
+            {[
+              { id: 'ai', label: 'Vs AI' },
+              { id: 'online', label: '1v1 Online', disabled: playType === 'tournament' }
+            ].map(({ id, label, disabled }) => (
+              <div key={id} className="relative">
+                <button
+                  onClick={() => !disabled && setMode(id)}
+                  className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                    disabled ? 'opacity-50 cursor-not-allowed' : ''
+                  }`}
+                  disabled={disabled}
+                >
+                  {label}
+                </button>
+                {disabled && (
+                  <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
+                    Tournament bracket only
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
       <div className="space-y-2">
         <h3 className="font-semibold">Variant</h3>
         <div className="flex gap-2">
@@ -386,6 +434,41 @@ export default function PoolRoyaleLobby() {
             ))}
           </div>
           <p className="text-xs">Winner takes pot minus 10% developer fee.</p>
+        </div>
+      )}
+      {playType === 'training' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Training tasks</h3>
+          <p className="text-sm text-subtext">Pick a practice task to load the right drill and rewards.</p>
+          <div className="space-y-2">
+            {TRAINING_LEVELS.map(({ level, title, objective }) => {
+              const locked = level > maxUnlockedTrainingLevel;
+              return (
+                <button
+                  key={level}
+                  type="button"
+                  onClick={() => !locked && setTrainingLevel(level)}
+                  className={`lobby-tile w-full text-left ${
+                    trainingLevel === level ? 'lobby-selected' : ''
+                  } ${locked ? 'opacity-50 cursor-not-allowed' : ''}`}
+                  disabled={locked}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div>
+                      <p className="text-sm font-semibold">Level {level}: {title}</p>
+                      <p className="text-xs text-subtext">{objective}</p>
+                    </div>
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-400">
+                      {locked ? 'Locked' : trainingLevel === level ? 'Selected' : 'Play'}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-subtext">
+            Completing tasks unlocks the next level automatically. Your progress is saved locally.
+          </p>
         </div>
       )}
       {mode === 'online' && playType === 'regular' && (


### PR DESCRIPTION
## Summary
- add a training task picker to the Pool Royale lobby, using saved progress to unlock levels
- launch training games with the selected drill details and player metadata
- persist and surface online table ids in Pool Royale to keep both players on the same match

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943f032dee4832996d2478cfdfe061c)