### PR TITLE
Add Pool Royale training lobby tasks and fix online seating

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8270,13 +8270,20 @@ function PoolRoyaleGame({
   playerName,
   playerAvatar,
   opponentName,
-  opponentAvatar
+  opponentAvatar,
+  tableId = '',
+  seat = 'A',
+  trainingLevelOverride = null
 }) {
   const navigate = useNavigate();
   const location = useLocation();
   const mountRef = useRef(null);
   const rafRef = useRef(null);
   const worldRef = useRef(null);
+  const tableIdRef = useRef(tableId);
+  useEffect(() => {
+    tableIdRef.current = tableId;
+  }, [tableId]);
   const rules = useMemo(() => new PoolRoyaleRules(variantKey), [variantKey]);
   const activeVariant = useMemo(
     () => resolvePoolVariant(variantKey),
@@ -8547,11 +8554,14 @@ function PoolRoyaleGame({
   }, [trainingLevel]);
   useEffect(() => {
     const stored = loadTrainingProgress();
-    const playableLevel = resolvePlayableTrainingLevel(stored.lastLevel, stored);
+    const desiredLevel = Number.isFinite(trainingLevelOverride)
+      ? trainingLevelOverride
+      : stored.lastLevel;
+    const playableLevel = resolvePlayableTrainingLevel(desiredLevel, stored);
     trainingProgressRef.current = stored;
     setTrainingProgress(stored);
     setTrainingLevel(playableLevel);
-  }, []);
+  }, [trainingLevelOverride]);
   const currentTrainingInfo = useMemo(
     () => describeTrainingLevel(trainingLevel),
     [trainingLevel]
@@ -9183,14 +9193,17 @@ function PoolRoyaleGame({
     };
   }, [configOpen]);
   const applyFinishRef = useRef(() => {});
+  const playerSeat = seat === 'B' ? 'B' : 'A';
   const playerLabel = playerName || 'Player';
   const effectiveMode = isTraining ? trainingModeState : mode;
   const opponentLabel =
     effectiveMode === 'online' ? opponentName || 'Opponent' : opponentName || 'AI';
+  const playerAName = playerSeat === 'A' ? playerLabel : opponentLabel;
+  const playerBName = playerSeat === 'A' ? opponentLabel : playerLabel;
   const isOnlineMatch = mode === 'online';
   const initialFrame = useMemo(
-    () => rules.getInitialFrame(playerLabel, opponentLabel),
-    [rules, playerLabel, opponentLabel]
+    () => rules.getInitialFrame(playerAName, playerBName),
+    [rules, playerAName, playerBName]
   );
   const [frameState, setFrameState] = useState(initialFrame);
   useEffect(() => {
@@ -9239,11 +9252,12 @@ function PoolRoyaleGame({
     () => deriveInHandFromFrame(initialFrame),
     [initialFrame]
   );
+  const initialHudTurn = playerSeat === 'B' ? 1 : 0;
   const [hud, setHud] = useState({
     power: 0.65,
     A: 0,
     B: 0,
-    turn: 0,
+    turn: initialHudTurn,
     phase: 'reds',
     next: 'red',
     inHand: initialHudInHand,
@@ -9272,13 +9286,13 @@ function PoolRoyaleGame({
       ...prev,
       A: 0,
       B: 0,
-      turn: 0,
+      turn: playerSeat === 'B' ? 1 : 0,
       phase: 'reds',
       next: 'red',
       inHand: nextInHand,
       over: false
     }));
-  }, [initialFrame]);
+  }, [initialFrame, playerSeat]);
   useEffect(() => {
     if (!isTraining) return;
     gameOverHandledRef.current = false;
@@ -18268,6 +18282,11 @@ export default function PoolRoyale() {
     const params = new URLSearchParams(location.search);
     return params.get('tgId') || '';
   }, [location.search]);
+  const seat = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const incoming = (params.get('seat') || 'A').toUpperCase();
+    return incoming === 'B' ? 'B' : 'A';
+  }, [location.search]);
   const playerName = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return (
@@ -18280,6 +18299,21 @@ export default function PoolRoyale() {
   const playerAvatar = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return params.get('avatar') || '';
+  }, [location.search]);
+  const tableId = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const incoming = params.get('tableId');
+    if (incoming) {
+      try {
+        window.sessionStorage?.setItem('poolRoyaleTableId', incoming);
+      } catch {}
+      return incoming;
+    }
+    try {
+      return window.sessionStorage?.getItem('poolRoyaleTableId') || '';
+    } catch {
+      return '';
+    }
   }, [location.search]);
   const stakeAmount = useMemo(() => {
     const params = new URLSearchParams(location.search);
@@ -18355,20 +18389,35 @@ export default function PoolRoyale() {
     const params = new URLSearchParams(location.search);
     return params.get('opponentAvatar') || '';
   }, [location.search]);
+  const trainingLevelOverride = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = Number(params.get('level'));
+    return Number.isFinite(requested) ? requested : null;
+  }, [location.search]);
   return (
-    <PoolRoyaleGame
-      variantKey={variantKey}
-      tableSizeKey={tableSizeKey}
-      playType={playType}
-      mode={mode}
-      trainingMode={trainingMode}
-      trainingRulesEnabled={trainingRulesEnabled}
-      accountId={accountId}
-      tgId={tgId}
-      playerName={playerName}
-      playerAvatar={playerAvatar}
-      opponentName={opponentName}
-      opponentAvatar={opponentAvatar}
-    />
+    <div className="relative">
+      {tableId && (
+        <div className="pointer-events-none absolute left-3 top-3 z-20 rounded-lg bg-black/70 px-3 py-1 text-xs font-semibold text-background">
+          Table {tableId.slice(0, 8)}
+        </div>
+      )}
+      <PoolRoyaleGame
+        variantKey={variantKey}
+        tableSizeKey={tableSizeKey}
+        playType={playType}
+        mode={mode}
+        trainingMode={trainingMode}
+        trainingRulesEnabled={trainingRulesEnabled}
+        accountId={accountId}
+        tgId={tgId}
+        playerName={playerName}
+        playerAvatar={playerAvatar}
+        opponentName={opponentName}
+        opponentAvatar={opponentAvatar}
+        tableId={tableId}
+        seat={seat}
+        trainingLevelOverride={trainingLevelOverride}
+      />
+    </div>
   );
 }

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -11,6 +11,11 @@ import { socket } from '../../utils/socket.js';
 import { getOnlineUsers } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { runPoolRoyaleOnlineFlow } from './poolRoyaleOnlineFlow.js';
+import {
+  TRAINING_LEVELS,
+  loadTrainingProgress,
+  resolvePlayableTrainingLevel
+} from '../../utils/poolRoyaleTrainingProgress.js';
 
 const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
@@ -23,6 +28,7 @@ export default function PoolRoyaleLobby() {
   const searchParams = new URLSearchParams(search);
   const initialPlayType = (() => {
     const requestedType = searchParams.get('type');
+    if (requestedType === 'training') return 'training';
     return requestedType === 'tournament' ? 'tournament' : 'regular';
   })();
 
@@ -53,15 +59,49 @@ export default function PoolRoyaleLobby() {
   const stakeDebitRef = useRef(null);
   const matchTimeoutRef = useRef(null);
   const seatTimeoutRef = useRef(null);
+  const [trainingMode, setTrainingMode] = useState('solo');
+  const [trainingRulesOn, setTrainingRulesOn] = useState(true);
+  const [trainingProgress, setTrainingProgress] = useState({ completed: [], lastLevel: 1 });
+  const [trainingLevel, setTrainingLevel] = useState(1);
 
   const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
+  const completedTrainingSet = useMemo(
+    () => new Set((trainingProgress?.completed || []).map((lvl) => Number(lvl))),
+    [trainingProgress?.completed]
+  );
 
   useEffect(() => {
     try {
       const saved = loadAvatar();
       setAvatar(saved || getTelegramPhotoUrl());
     } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const progress = loadTrainingProgress();
+      setTrainingProgress(progress);
+      const requestedLevel = Number(searchParams.get('level'));
+      const desiredLevel = Number.isFinite(requestedLevel) ? requestedLevel : progress.lastLevel;
+      setTrainingLevel(resolvePlayableTrainingLevel(desiredLevel, progress));
+    } catch {}
+  }, [search]);
+
+  useEffect(() => {
+    const refreshProgress = () => {
+      try {
+        const progress = loadTrainingProgress();
+        setTrainingProgress(progress);
+        setTrainingLevel((prev) => resolvePlayableTrainingLevel(prev, progress));
+      } catch {}
+    };
+    window.addEventListener('focus', refreshProgress);
+    window.addEventListener('storage', refreshProgress);
+    return () => {
+      window.removeEventListener('focus', refreshProgress);
+      window.removeEventListener('storage', refreshProgress);
+    };
   }, []);
 
   useEffect(() => {
@@ -88,6 +128,8 @@ export default function PoolRoyaleLobby() {
     const selfId = accountId || accountIdRef.current;
     const selfEntry = roster.find((p) => String(p.id) === String(selfId));
     const opponentEntry = roster.find((p) => String(p.id) !== String(selfId));
+    const seatIndex = roster.findIndex((p) => String(p.id) === String(selfId));
+    const seat = seatIndex <= 0 ? 'A' : 'B';
     const friendlyName =
       selfEntry?.name ||
       getTelegramFirstName() ||
@@ -114,6 +156,7 @@ export default function PoolRoyaleLobby() {
     const resolvedAccountId = accountIdRef.current;
     if (resolvedAccountId) params.set('accountId', resolvedAccountId);
     if (tableSize) params.set('tableSize', tableSize);
+    params.set('seat', seat);
     const name = (friendlyName || '').trim();
     if (name) params.set('name', name);
     if (opponentName) params.set('opponent', opponentName);
@@ -123,6 +166,7 @@ export default function PoolRoyaleLobby() {
 
   const startGame = async () => {
     const isOnlineMatch = mode === 'online' && playType === 'regular';
+    const isTraining = playType === 'training';
     if (matching) return;
     await cleanupRef.current?.();
     setMatchStatus('');
@@ -167,27 +211,37 @@ export default function PoolRoyaleLobby() {
       tgId = getTelegramId();
       accountId = await ensureAccountId();
     } catch (error) {
-      const message = 'Unable to verify your TPC account. Please retry.';
-      setMatchingError(message);
-      try {
-        window?.Telegram?.WebApp?.showAlert?.(message);
-      } catch {}
-      console.error('[PoolRoyaleLobby] ensureAccountId failed (offline)', error);
-      return;
+      if (!isTraining) {
+        const message = 'Unable to verify your TPC account. Please retry.';
+        setMatchingError(message);
+        try {
+          window?.Telegram?.WebApp?.showAlert?.(message);
+        } catch {}
+        console.error('[PoolRoyaleLobby] ensureAccountId failed (offline)', error);
+        return;
+      }
+      console.warn('[PoolRoyaleLobby] starting training without verified account', error);
     }
 
-    accountIdRef.current = accountId;
+    if (accountId) accountIdRef.current = accountId;
 
     const params = new URLSearchParams();
     params.set('variant', variant);
     params.set('tableSize', tableSize);
-    params.set('type', playType);
-    params.set('mode', mode);
-    if (isOnlineMatch) {
-      if (stake.token) params.set('token', stake.token);
-      if (stake.amount) params.set('amount', stake.amount);
+    if (isTraining) {
+      params.set('type', 'training');
+      params.set('mode', trainingMode);
+      params.set('rules', trainingRulesOn ? 'on' : 'off');
+      if (Number.isFinite(trainingLevel)) params.set('level', trainingLevel);
+    } else {
+      params.set('type', playType);
+      params.set('mode', mode);
+      if (isOnlineMatch) {
+        if (stake.token) params.set('token', stake.token);
+        if (stake.amount) params.set('amount', stake.amount);
+      }
+      if (playType === 'tournament') params.set('players', players);
     }
-    if (playType === 'tournament') params.set('players', players);
     const initData = window.Telegram?.WebApp?.initData;
     if (avatar) params.set('avatar', avatar);
     if (tgId) params.set('tgId', tgId);
@@ -273,6 +327,15 @@ export default function PoolRoyaleLobby() {
     if (playType === 'tournament') {
       setMode('ai');
     }
+    if (playType === 'training') {
+      setMode('ai');
+      cleanupRef.current?.();
+      setMatching(false);
+      setMatchStatus('');
+      setMatchPlayers([]);
+      setReadyList([]);
+      setIsSearching(false);
+    }
   }, [playType]);
 
   useEffect(() => {
@@ -315,6 +378,7 @@ export default function PoolRoyaleLobby() {
         <div className="flex gap-2">
           {[
             { id: 'regular', label: 'Regular' },
+            { id: 'training', label: 'Training' },
             { id: 'tournament', label: 'Tournament' }
           ].map(({ id, label }) => (
             <button
@@ -332,7 +396,11 @@ export default function PoolRoyaleLobby() {
         <div className="flex gap-2">
           {[
             { id: 'ai', label: 'Vs AI' },
-            { id: 'online', label: '1v1 Online', disabled: playType === 'tournament' }
+            {
+              id: 'online',
+              label: '1v1 Online',
+              disabled: playType === 'tournament' || playType === 'training'
+            }
           ].map(({ id, label, disabled }) => (
             <div key={id} className="relative">
               <button
@@ -346,13 +414,89 @@ export default function PoolRoyaleLobby() {
               </button>
               {disabled && (
                 <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
-                  Tournament bracket only
+                  {playType === 'training' ? 'Training stays offline' : 'Tournament bracket only'}
                 </span>
               )}
             </div>
           ))}
         </div>
       </div>
+      {playType === 'training' && (
+        <div className="space-y-3 p-3 rounded-lg border border-border bg-surface/60">
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              <h3 className="font-semibold">Training tasks</h3>
+              <p className="text-xs text-subtext">Pick a drill, then choose solo or AI sparring.</p>
+            </div>
+            <span className="text-xs text-subtext">
+              {completedTrainingSet.size}/{TRAINING_LEVELS.length} done
+            </span>
+          </div>
+          <div className="space-y-2">
+            {TRAINING_LEVELS.map((task) => {
+              const unlocked = resolvePlayableTrainingLevel(task.level, trainingProgress) === task.level;
+              const completed = completedTrainingSet.has(task.level);
+              const active = trainingLevel === task.level;
+              return (
+                <button
+                  key={task.level}
+                  type="button"
+                  onClick={() => unlocked && setTrainingLevel(task.level)}
+                  className={`w-full rounded-lg border px-3 py-2 text-left shadow-sm transition ${
+                    active ? 'border-primary bg-primary/10' : 'border-border bg-background/60'
+                  } ${unlocked ? 'hover:border-primary' : 'opacity-60 cursor-not-allowed'}`}
+                  disabled={!unlocked}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="text-sm font-semibold">
+                        Level {task.level}: {task.title}
+                      </div>
+                      <div className="text-xs text-subtext leading-snug">{task.objective}</div>
+                      <div className="text-[11px] text-emerald-200">{task.reward}</div>
+                    </div>
+                    <span
+                      className={`text-[11px] font-semibold ${
+                        completed ? 'text-emerald-400' : unlocked ? 'text-primary' : 'text-subtext'
+                      }`}
+                    >
+                      {completed ? 'Completed' : unlocked ? (active ? 'Selected' : 'Ready') : 'Locked'}
+                    </span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            {[
+              { id: 'solo', label: 'Solo drills', desc: 'Place the cue ball and retry instantly.' },
+              { id: 'ai', label: 'AI sparring', desc: 'Trade turns with a CPU partner.' }
+            ].map(({ id, label, desc }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setTrainingMode(id)}
+                className={`h-full rounded-lg border px-3 py-2 text-left ${
+                  trainingMode === id ? 'border-primary bg-primary/10' : 'border-border bg-background/60'
+                }`}
+              >
+                <div className="text-sm font-semibold">{label}</div>
+                <div className="text-[11px] text-subtext leading-snug">{desc}</div>
+              </button>
+            ))}
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border-border"
+              checked={trainingRulesOn}
+              onChange={(event) => setTrainingRulesOn(event.target.checked)}
+            />
+            <span>Apply fouls and frame rules during training</span>
+          </label>
+          <p className="text-xs text-subtext">Training is free — no TPC stake required.</p>
+        </div>
+      )}
       <div className="space-y-2">
         <h3 className="font-semibold">Variant</h3>
         <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- add Pool Royale lobby training task cards with solo/AI options and persisted progress
- pass selected training level and rules into the game loader for consistent drills
- preserve online seating/table metadata so only one player starts the break and the table ID stays visible

## Testing
- npm test -- poolRoyaleOnlineFlow *(fails: missing @babel/preset-env dev dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943f032dee4832996d2478cfdfe061c)