### PR TITLE
Improve Pool Royale online match synchronization

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1040,6 +1040,36 @@ io.on('connection', (socket) => {
     }
   });
 
+  socket.on('joinPoolRoom', ({ tableId, accountId, name, avatar }) => {
+    if (!tableId) return;
+    if (accountId && !ensureRegistered(socket, accountId)) return;
+    socket.join(tableId);
+    io.to(tableId).emit('poolPresence', {
+      tableId,
+      accountId: accountId ? String(accountId) : '',
+      name,
+      avatar
+    });
+  });
+
+  socket.on('leavePoolRoom', ({ tableId, accountId }) => {
+    if (!tableId) return;
+    if (accountId && !ensureRegistered(socket, accountId)) return;
+    socket.leave(tableId);
+  });
+
+  socket.on('poolFrameSync', ({ tableId, frame, hud, accountId }) => {
+    if (!tableId || !frame) return;
+    if (accountId && !ensureRegistered(socket, accountId)) return;
+    io.to(tableId).emit('poolFrameSync', {
+      tableId,
+      frame,
+      hud,
+      accountId: accountId ? String(accountId) : '',
+      ts: Date.now()
+    });
+  });
+
   socket.on('chessSyncRequest', ({ tableId }) => {
     if (!tableId) return;
     const state = getChessState(tableId);

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -84,7 +84,7 @@ export default function PoolRoyaleLobby() {
     matchPlayersRef.current = matchPlayers;
   }, [matchPlayers]);
 
-  const navigateToPoolRoyale = ({ tableId: startedId, roster = [], accountId }) => {
+  const navigateToPoolRoyale = ({ tableId: startedId, roster = [], accountId, currentTurn }) => {
     const selfId = accountId || accountIdRef.current;
     const selfEntry = roster.find((p) => String(p.id) === String(selfId));
     const opponentEntry = roster.find((p) => String(p.id) !== String(selfId));
@@ -100,6 +100,8 @@ export default function PoolRoyaleLobby() {
       opponentEntry?.telegramName ||
       (opponentEntry?.id ? `TPC ${opponentEntry.id}` : '');
     const opponentAvatar = opponentEntry?.avatar || '';
+    const opponentId = opponentEntry?.id ? String(opponentEntry.id) : '';
+    const starterId = currentTurn ? String(currentTurn) : '';
     cleanupRef.current?.({ account: accountId, skipRefReset: true });
     const params = new URLSearchParams();
     params.set('variant', variant);
@@ -118,6 +120,8 @@ export default function PoolRoyaleLobby() {
     if (name) params.set('name', name);
     if (opponentName) params.set('opponent', opponentName);
     if (opponentAvatar) params.set('opponentAvatar', opponentAvatar);
+    if (opponentId) params.set('opponentId', opponentId);
+    if (starterId) params.set('starter', starterId);
     navigate(`/games/poolroyale?${params.toString()}`);
   };
 

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -198,13 +198,13 @@ export async function runPoolRoyaleOnlineFlow({
     logSupportError(message, null, { reason, ...extra });
   };
 
-  function handleGameStart({ tableId: startedId, players: joined = [] } = {}) {
+  function handleGameStart({ tableId: startedId, players: joined = [], currentTurn } = {}) {
     if (!startedId || startedId !== pendingTableRef.current) return;
     const roster = Array.isArray(joined) && joined.length > 0 ? joined : matchPlayersRef.current;
     stakeDebitRef.current = null;
     clearTimers();
     cleanupLobby({ account: accountId, skipRefReset: true, keepError: true });
-    onGameStart?.({ tableId: startedId, roster, accountId });
+    onGameStart?.({ tableId: startedId, roster, accountId, currentTurn });
   }
 
   cleanupRef.current = cleanupLobby;


### PR DESCRIPTION
## Summary
- propagate game start details like table ID, starter account, and opponent ID into Pool Royale launches so both clients align on the same room
- join Pool Royale socket rooms in online mode and broadcast/consume frame, HUD, and ball snapshots to keep the two clients synchronized between turns
- add backend pool room events for joining/leaving and frame syncing, plus show the active table ID badge in the game UI

## Testing
- npm test -- poolRoyaleOnlineFlow.test.js *(fails: Jest cannot parse import.meta in webapp/src/utils/socket.js when running in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943f8f37ac08329bf0661f0999129b0)