### PR TITLE
Prevent camera zoom during shot replays

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11488,6 +11488,7 @@ function PoolRoyaleGame({
         };
 
         const updateCamera = () => {
+          const replayActive = Boolean(replayPlaybackRef.current);
           let renderCamera = camera;
           let lookTarget = null;
           let broadcastArgs = {
@@ -12212,7 +12213,7 @@ function PoolRoyaleGame({
             } else {
               camera.up.set(0, 1, 0);
               TMP_SPH.copy(sph);
-              if (sidePocketAimRef.current && !shooting) {
+              if (sidePocketAimRef.current && !shooting && !replayActive) {
                 TMP_SPH.radius = clampOrbitRadius(
                   TMP_SPH.radius * RAIL_OVERHEAD_AIM_ZOOM
                 );
@@ -12222,7 +12223,7 @@ function PoolRoyaleGame({
                   CAMERA.maxPhi - CAMERA_RAIL_SAFETY
                 );
               }
-              if (IN_HAND_CAMERA_RADIUS_MULTIPLIER > 1) {
+              if (IN_HAND_CAMERA_RADIUS_MULTIPLIER > 1 && !replayActive) {
                 const hudState = hudRef.current ?? null;
                 if (hudState?.inHand && !shooting) {
                   TMP_SPH.radius = clampOrbitRadius(


### PR DESCRIPTION
## Summary
- block replay sessions from triggering side pocket and in-hand camera zoom adjustments
- track replay state before updating the camera so replay playback keeps a stable framing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944e06c8eb48329ad246be1bc8c1dc2)