### PR TITLE
Ensure replay uses stored camera framing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12992,7 +12992,17 @@ function PoolRoyaleGame({
           topViewRef.current = false;
           topViewLockedRef.current = false;
           setIsTopDownView(false);
-          setOrbitFocusToDefault();
+          const storedReplayCamera = replayCameraRef.current;
+          if (storedReplayCamera?.target) {
+            const orbitStore = ensureOrbitFocus();
+            orbitStore.target.copy(storedReplayCamera.target);
+            lastCameraTargetRef.current.copy(storedReplayCamera.target);
+          } else {
+            setOrbitFocusToDefault();
+          }
+          if (storedReplayCamera?.position) {
+            camera.position.copy(storedReplayCamera.position);
+          }
           applyCameraBlend(1);
           syncBlendToSpherical();
           updateCamera();


### PR DESCRIPTION
## Summary
- preserve the camera target and position captured at replay start instead of resetting to defaults
- restore the stored framing before replay playback begins to keep gameplay and replay views identical

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ecf52f908329911d2d74357af808)