### PR TITLE
Ensure Pool Royale replays match gameplay camera

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11520,6 +11520,11 @@ function PoolRoyaleGame({
             if (safePosition.y < minCameraY) {
               safePosition.y = minCameraY;
             }
+            const storedFov = storedReplayCamera?.fov;
+            if (storedFov && camera.fov !== storedFov) {
+              camera.fov = storedFov;
+              camera.updateProjectionMatrix();
+            }
             camera.position.copy(safePosition);
             camera.lookAt(focusTarget);
             renderCamera = camera;
@@ -12981,9 +12986,11 @@ function PoolRoyaleGame({
           if (storedPosition && storedPosition.y < minTargetY) {
             storedPosition.y = minTargetY;
           }
+          const storedFov = activeCamera?.fov ?? camera.fov;
           replayCameraRef.current = {
             position: storedPosition,
-            target: storedTarget
+            target: storedTarget,
+            fov: storedFov
           };
         };
 


### PR DESCRIPTION
## Summary
- store the active camera field of view when capturing a replay frame
- reuse the stored camera FOV during replay playback so framing matches live gameplay

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ecf52f908329911d2d74357af808)