### PR TITLE
Preserve Pool Royale replay camera framing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11520,6 +11520,11 @@ function PoolRoyaleGame({
             if (safePosition.y < minCameraY) {
               safePosition.y = minCameraY;
             }
+            const storedFov = storedReplayCamera?.fov;
+            if (Number.isFinite(storedFov) && camera.fov !== storedFov) {
+              camera.fov = storedFov;
+              camera.updateProjectionMatrix();
+            }
             camera.position.copy(safePosition);
             camera.lookAt(focusTarget);
             renderCamera = camera;
@@ -12981,9 +12986,14 @@ function PoolRoyaleGame({
           if (storedPosition && storedPosition.y < minTargetY) {
             storedPosition.y = minTargetY;
           }
+          const storedFov = Number.isFinite(activeCamera?.fov)
+            ? activeCamera.fov
+            : camera.fov;
           replayCameraRef.current = {
             position: storedPosition,
-            target: storedTarget
+            target: storedTarget,
+            fov: storedFov,
+            restoreFov: camera?.fov
           };
         };
 
@@ -13049,6 +13059,14 @@ function PoolRoyaleGame({
             applyBallSnapshot(playback.postState);
           }
           replayTrail.visible = false;
+          const storedReplayCamera = replayCameraRef.current;
+          const targetFov = Number.isFinite(storedReplayCamera?.restoreFov)
+            ? storedReplayCamera.restoreFov
+            : CAMERA.fov;
+          if (Number.isFinite(targetFov) && camera.fov !== targetFov) {
+            camera.fov = targetFov;
+            camera.updateProjectionMatrix();
+          }
           if (playback.pocketDrops) {
             const pocketDuration = Number.isFinite(playback.duration)
               ? playback.duration


### PR DESCRIPTION
## Summary
- store the active camera's FOV alongside position/target when capturing a replay
- apply the recorded FOV during replay playback and restore it afterward to keep framing consistent with gameplay

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ecf52f908329911d2d74357af808)