### PR TITLE
Raise Murlan Royale graphics presets to HD and above

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -212,7 +212,7 @@ function resolveDefaultPixelRatioCap() {
 
 function detectPreferredFrameRateId() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-    return 'balanced60';
+    return 'fhd60';
   }
   const coarsePointer = detectCoarsePointer();
   const ua = navigator.userAgent ?? '';
@@ -226,39 +226,39 @@ function detectPreferredFrameRateId() {
   const rendererTier = classifyRendererTier(readGraphicsRendererString());
 
   if (lowRefresh) {
-    return 'mobile50';
+    return 'hd50';
   }
 
   if (isMobileUA || coarsePointer || isTouch || rendererTier === 'mobile') {
     if ((deviceMemory !== null && deviceMemory <= 4) || hardwareConcurrency <= 4) {
-      return 'mobile50';
+      return 'hd50';
     }
     if (highRefresh && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 6)) {
-      return 'fast120';
+      return 'uhd120';
     }
     if (
       highRefresh ||
       hardwareConcurrency >= 6 ||
       (deviceMemory != null && deviceMemory >= 6)
     ) {
-      return 'smooth90';
+      return 'qhd90';
     }
-    return 'balanced60';
+    return 'fhd60';
   }
 
   if (rendererTier === 'desktopHigh' && highRefresh) {
-    return 'esports144';
+    return 'ultra144';
   }
 
   if (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8) {
-    return 'fast120';
+    return 'uhd120';
   }
 
   if (rendererTier === 'desktopMid') {
-    return 'smooth90';
+    return 'qhd90';
   }
 
-  return 'balanced60';
+  return 'fhd60';
 }
 
 const CHAIR_MODEL_URLS = [
@@ -556,52 +556,52 @@ const clampValue = (value, min, max) => Math.min(Math.max(value, min), max);
 
 const FRAME_RATE_OPTIONS = Object.freeze([
   {
-    id: 'mobile50',
-    label: 'Battery Saver (50 Hz)',
+    id: 'hd50',
+    label: 'HD Performance (50 Hz)',
     fps: 50,
-    renderScale: 0.88,
-    pixelRatioCap: 1.15,
-    resolution: '0.88x render • DPR 1.15 cap',
-    description: 'For 50–60 Hz displays or thermally constrained mobile GPUs.'
+    renderScale: 1,
+    pixelRatioCap: 1.4,
+    resolution: 'HD render • DPR 1.4 cap',
+    description: 'Minimum HD output for battery saver and 50–60 Hz displays.'
   },
   {
-    id: 'balanced60',
-    label: 'Snooker Match (60 Hz)',
+    id: 'fhd60',
+    label: 'Full HD (60 Hz)',
     fps: 60,
-    renderScale: 0.95,
-    pixelRatioCap: 1.3,
-    resolution: '0.95x render • DPR 1.3 cap',
-    description: 'Mirror the 3D Snooker frame pacing and resolution profile.'
+    renderScale: 1.1,
+    pixelRatioCap: 1.5,
+    resolution: 'Full HD render • DPR 1.5 cap',
+    description: '1080p-focused profile that mirrors the Snooker frame pacing.'
   },
   {
-    id: 'smooth90',
-    label: 'Smooth Motion (90 Hz)',
+    id: 'qhd90',
+    label: 'Quad HD (90 Hz)',
     fps: 90,
-    renderScale: 0.92,
-    pixelRatioCap: 1.35,
-    resolution: '0.92x render • DPR 1.35 cap',
-    description: 'High-refresh option for capable 90 Hz mobile panels.'
+    renderScale: 1.25,
+    pixelRatioCap: 1.7,
+    resolution: 'QHD render • DPR 1.7 cap',
+    description: 'Sharper 1440p render for capable 90 Hz mobile and desktop GPUs.'
   },
   {
-    id: 'fast120',
-    label: 'Performance (120 Hz)',
+    id: 'uhd120',
+    label: 'Ultra HD (120 Hz)',
     fps: 120,
-    renderScale: 0.9,
-    pixelRatioCap: 1.25,
-    resolution: '0.90x render • DPR 1.25 cap',
-    description: 'Adaptive quality for 120 Hz flagships and desktops.'
+    renderScale: 1.35,
+    pixelRatioCap: 2,
+    resolution: 'Ultra HD render • DPR 2.0 cap',
+    description: '4K-oriented profile for 120 Hz flagships and desktops.'
   },
   {
-    id: 'esports144',
-    label: 'Tournament (144 Hz)',
+    id: 'ultra144',
+    label: 'Ultra HD+ (144 Hz)',
     fps: 144,
-    renderScale: 0.86,
-    pixelRatioCap: 1.2,
-    resolution: '0.86x render • DPR 1.2 cap',
-    description: 'Aggressive scaling to keep 144 Hz stable on mobile chips.'
+    renderScale: 1.5,
+    pixelRatioCap: 2.2,
+    resolution: 'Ultra HD+ render • DPR 2.2 cap',
+    description: 'Maximum clarity preset that prioritizes UHD detail at 144 Hz.'
   }
 ]);
-const DEFAULT_FRAME_RATE_ID = 'balanced60';
+const DEFAULT_FRAME_RATE_ID = 'fhd60';
 
 const GAME_CONFIG = { ...BASE_CONFIG };
 const START_CARD = { rank: '3', suit: '♠' };
@@ -679,7 +679,7 @@ export default function MurlanRoyaleArena({ search }) {
           : 60;
     const renderScale =
       typeof option?.renderScale === 'number' && Number.isFinite(option.renderScale)
-        ? THREE.MathUtils.clamp(option.renderScale, 0.75, 1)
+        ? THREE.MathUtils.clamp(option.renderScale, 1, 1.6)
         : 1;
     const pixelRatioCap =
       typeof option?.pixelRatioCap === 'number' && Number.isFinite(option.pixelRatioCap)
@@ -851,7 +851,7 @@ export default function MurlanRoyaleArena({ search }) {
       (typeof window !== 'undefined' ? resolveDefaultPixelRatioCap() : 2);
     const renderScale =
       typeof quality?.renderScale === 'number' && Number.isFinite(quality.renderScale)
-        ? THREE.MathUtils.clamp(quality.renderScale, 0.75, 1)
+        ? THREE.MathUtils.clamp(quality.renderScale, 1, 1.6)
         : 1;
     renderer.setPixelRatio(Math.min(pixelRatioCap, dpr));
     renderer.setSize(host.clientWidth * renderScale, host.clientHeight * renderScale, false);


### PR DESCRIPTION
## Summary
- upgrade Murlan Royale graphics presets to HD, Full HD, QHD, and Ultra HD profiles with clearer labels and higher render scales
- adjust default and automatic preset detection to use the new high-resolution options
- allow renderer scaling above 1.0 so UHD presets can apply increased resolution

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944f637b07c8329a453af92ca52633b)