### PR TITLE
Add auth context and protect account route

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -45,6 +45,9 @@ import SnookerClubLobby from './pages/Games/SnookerClubLobby.jsx';
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
+import { AuthProvider } from './contexts/AuthContext.jsx';
+import PrivateRoute from './components/PrivateRoute.jsx';
+import Login from './pages/Login.jsx';
 
 export default function App() {
   useTelegramAuth();
@@ -54,96 +57,106 @@ export default function App() {
 
   return (
     <BrowserRouter>
-      <TonConnectUIProvider manifestUrl={manifestUrl}>
-        <Layout>
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/mining" element={<Mining />} />
-            <Route
-              path="/mining/transactions"
-              element={<MiningTransactions />}
-            />
-            <Route path="/games" element={<Games />} />
-            <Route path="/games/transactions" element={<GameTransactions />} />
-            <Route path="/games/:game/lobby" element={<Lobby />} />
-            <Route path="/games/snake" element={<SnakeAndLadder />} />
-            <Route path="/games/snake/mp" element={<SnakeMultiplayer />} />
-            <Route path="/games/snake/results" element={<SnakeResults />} />
-            <Route path="/games/goalrush/lobby" element={<GoalRushLobby />} />
-            <Route path="/games/goalrush" element={<GoalRush />} />
-            <Route path="/games/airhockey/lobby" element={<AirHockeyLobby />} />
-            <Route path="/games/airhockey" element={<AirHockey />} />
-            <Route
-              path="/games/chessbattleroyal/lobby"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Chess Lobby…</div>}>
-                  <ChessBattleRoyalLobby />
-                </Suspense>
-              )}
-            />
-            <Route
-              path="/games/chessbattleroyal"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Chess Battle Royal…</div>}>
-                  <ChessBattleRoyal />
-                </Suspense>
-              )}
-            />
-            <Route
-              path="/games/ludobattleroyal/lobby"
-              element={<LudoBattleRoyalLobby />}
-            />
-            <Route
-              path="/games/ludobattleroyal"
-              element={<LudoBattleRoyal />}
-            />
-            <Route
-              path="/games/texasholdem/lobby"
-              element={<TexasHoldemLobby />}
-            />
-            <Route path="/games/texasholdem" element={<TexasHoldem />} />
-            <Route
-              path="/games/domino-royal/lobby"
-              element={<DominoRoyalLobby />}
-            />
-            <Route path="/games/domino-royal" element={<DominoRoyal />} />
-            <Route
-              path="/games/murlanroyale/lobby"
-              element={<MurlanRoyaleLobby />}
-            />
-            <Route path="/games/murlanroyale" element={<MurlanRoyale />} />
-            <Route
-              path="/games/poolroyale/lobby"
-              element={<PoolRoyaleLobby />}
-            />
-            <Route path="/games/poolroyale" element={<PoolRoyale />} />
-            <Route
-              path="/games/snookerclub/lobby"
-              element={<SnookerClubLobby />}
-            />
-            <Route path="/games/snookerclub" element={<SnookerClub />} />
-            <Route
-              path="/games/pollroyale/lobby"
-              element={<Navigate to="/games/poolroyale/lobby" replace />}
-            />
-            <Route
-              path="/games/pollroyale"
-              element={<Navigate to="/games/poolroyale" replace />}
-            />
-            <Route path="/spin" element={<SpinPage />} />
-            <Route path="/admin/influencer" element={<InfluencerAdmin />} />
-            <Route path="/tasks" element={<Tasks />} />
-            <Route path="/store" element={<Navigate to="/store/poolroyale" replace />} />
-            <Route path="/store/:gameSlug" element={<Store />} />
-            <Route path="/referral" element={<Referral />} />
-            <Route path="/wallet" element={<Wallet />} />
-            <Route path="/messages" element={<Messages />} />
-            <Route path="/notifications" element={<Notifications />} />
-            <Route path="/trending" element={<Trending />} />
-            <Route path="/account" element={<MyAccount />} />
-          </Routes>
-        </Layout>
-      </TonConnectUIProvider>
+      <AuthProvider>
+        <TonConnectUIProvider manifestUrl={manifestUrl}>
+          <Layout>
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/mining" element={<Mining />} />
+              <Route
+                path="/mining/transactions"
+                element={<MiningTransactions />}
+              />
+              <Route path="/games" element={<Games />} />
+              <Route path="/games/transactions" element={<GameTransactions />} />
+              <Route path="/games/:game/lobby" element={<Lobby />} />
+              <Route path="/games/snake" element={<SnakeAndLadder />} />
+              <Route path="/games/snake/mp" element={<SnakeMultiplayer />} />
+              <Route path="/games/snake/results" element={<SnakeResults />} />
+              <Route path="/games/goalrush/lobby" element={<GoalRushLobby />} />
+              <Route path="/games/goalrush" element={<GoalRush />} />
+              <Route path="/games/airhockey/lobby" element={<AirHockeyLobby />} />
+              <Route path="/games/airhockey" element={<AirHockey />} />
+              <Route
+                path="/games/chessbattleroyal/lobby"
+                element={(
+                  <Suspense fallback={<div className="p-4 text-center">Loading Chess Lobby…</div>}>
+                    <ChessBattleRoyalLobby />
+                  </Suspense>
+                )}
+              />
+              <Route
+                path="/games/chessbattleroyal"
+                element={(
+                  <Suspense fallback={<div className="p-4 text-center">Loading Chess Battle Royal…</div>}>
+                    <ChessBattleRoyal />
+                  </Suspense>
+                )}
+              />
+              <Route
+                path="/games/ludobattleroyal/lobby"
+                element={<LudoBattleRoyalLobby />}
+              />
+              <Route
+                path="/games/ludobattleroyal"
+                element={<LudoBattleRoyal />}
+              />
+              <Route
+                path="/games/texasholdem/lobby"
+                element={<TexasHoldemLobby />}
+              />
+              <Route path="/games/texasholdem" element={<TexasHoldem />} />
+              <Route
+                path="/games/domino-royal/lobby"
+                element={<DominoRoyalLobby />}
+              />
+              <Route path="/games/domino-royal" element={<DominoRoyal />} />
+              <Route
+                path="/games/murlanroyale/lobby"
+                element={<MurlanRoyaleLobby />}
+              />
+              <Route path="/games/murlanroyale" element={<MurlanRoyale />} />
+              <Route
+                path="/games/poolroyale/lobby"
+                element={<PoolRoyaleLobby />}
+              />
+              <Route path="/games/poolroyale" element={<PoolRoyale />} />
+              <Route
+                path="/games/snookerclub/lobby"
+                element={<SnookerClubLobby />}
+              />
+              <Route path="/games/snookerclub" element={<SnookerClub />} />
+              <Route
+                path="/games/pollroyale/lobby"
+                element={<Navigate to="/games/poolroyale/lobby" replace />}
+              />
+              <Route
+                path="/games/pollroyale"
+                element={<Navigate to="/games/poolroyale" replace />}
+              />
+              <Route path="/spin" element={<SpinPage />} />
+              <Route path="/admin/influencer" element={<InfluencerAdmin />} />
+              <Route path="/tasks" element={<Tasks />} />
+              <Route path="/store" element={<Navigate to="/store/poolroyale" replace />} />
+              <Route path="/store/:gameSlug" element={<Store />} />
+              <Route path="/referral" element={<Referral />} />
+              <Route path="/wallet" element={<Wallet />} />
+              <Route path="/messages" element={<Messages />} />
+              <Route path="/notifications" element={<Notifications />} />
+              <Route path="/trending" element={<Trending />} />
+              <Route path="/login" element={<Login />} />
+              <Route
+                path="/account"
+                element={(
+                  <PrivateRoute>
+                    <MyAccount />
+                  </PrivateRoute>
+                )}
+              />
+            </Routes>
+          </Layout>
+        </TonConnectUIProvider>
+      </AuthProvider>
     </BrowserRouter>
   );
 }

--- a/webapp/src/components/PrivateRoute.jsx
+++ b/webapp/src/components/PrivateRoute.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext.jsx';
+
+export default function PrivateRoute({ children }) {
+  const { isAuthenticated } = useAuth();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+}

--- a/webapp/src/contexts/AuthContext.jsx
+++ b/webapp/src/contexts/AuthContext.jsx
@@ -1,0 +1,71 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+const AuthContext = createContext(null);
+
+const AUTH_TOKEN_KEY = 'authToken';
+const AUTH_USER_KEY = 'authUser';
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(() => localStorage.getItem(AUTH_TOKEN_KEY));
+  const [user, setUser] = useState(() => {
+    const cached = localStorage.getItem(AUTH_USER_KEY);
+    if (!cached) return null;
+    try {
+      return JSON.parse(cached);
+    } catch (err) {
+      console.warn('Failed to parse cached user', err);
+      return null;
+    }
+  });
+
+  useEffect(() => {
+    if (token) {
+      localStorage.setItem(AUTH_TOKEN_KEY, token);
+    } else {
+      localStorage.removeItem(AUTH_TOKEN_KEY);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    if (user) {
+      localStorage.setItem(AUTH_USER_KEY, JSON.stringify(user));
+    } else {
+      localStorage.removeItem(AUTH_USER_KEY);
+    }
+  }, [user]);
+
+  const login = (nextToken, nextUser = null) => {
+    setToken(nextToken);
+    setUser(nextUser);
+  };
+
+  const logout = () => {
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem(AUTH_TOKEN_KEY);
+    localStorage.removeItem(AUTH_USER_KEY);
+  };
+
+  const value = useMemo(
+    () => ({
+      token,
+      user,
+      isAuthenticated: Boolean(token),
+      login,
+      logout
+    }),
+    [token, user]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}
+
+export default AuthContext;

--- a/webapp/src/pages/Login.jsx
+++ b/webapp/src/pages/Login.jsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { loginWithPassword } from '../utils/api.js';
+import { useAuth } from '../contexts/AuthContext.jsx';
+
+export default function Login() {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+  const { isAuthenticated, login } = useAuth();
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate('/account', { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    setLoading(true);
+
+    const response = await loginWithPassword(password);
+    setLoading(false);
+
+    if (response?.error) {
+      setError(response.error);
+      return;
+    }
+
+    if (response?.token) {
+      login(response.token, response.user || null);
+      navigate('/account', { replace: true });
+      return;
+    }
+
+    setError('Invalid server response. Please try again.');
+  };
+
+  return (
+    <div className="p-4 text-text flex justify-center">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-md space-y-4 bg-surface border border-border rounded-xl p-4"
+      >
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold">Login</h1>
+          <p className="text-subtext text-sm">Enter your password to continue.</p>
+        </div>
+
+        <label className="block space-y-1">
+          <span className="text-sm font-medium">Password</span>
+          <input
+            type="password"
+            className="w-full px-3 py-2 rounded-lg bg-background border border-border focus:outline-none focus:ring-2 focus:ring-primary"
+            placeholder="••••••••"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </label>
+
+        {error && <p className="text-sm text-red-500">{error}</p>}
+
+        <button
+          type="submit"
+          disabled={loading || !password}
+          className="w-full px-4 py-2 rounded-lg bg-primary text-background font-semibold disabled:opacity-50 disabled:cursor-not-allowed hover:bg-primary-hover transition"
+        >
+          {loading ? 'Signing in…' : 'Sign In'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Navigate } from 'react-router-dom';
 import {
   getAccountInfo,
   createAccount,
@@ -15,7 +16,6 @@ import {
   getTelegramLastName,
   getTelegramPhotoUrl
 } from '../utils/telegram.js';
-import LoginOptions from '../components/LoginOptions.jsx';
 import { DEV_INFO } from '../utils/constants.js';
 import BalanceSummary from '../components/BalanceSummary.jsx';
 import AvatarPickerModal from '../components/AvatarPickerModal.jsx';
@@ -38,6 +38,7 @@ import {
   getDefaultDominoRoyalLoadout,
   listOwnedDominoOptions
 } from '../utils/dominoRoyalInventory.js';
+import { useAuth } from '../contexts/AuthContext.jsx';
 
 import { FiCopy } from 'react-icons/fi';
 
@@ -74,8 +75,13 @@ function formatValue(value, decimals = 2) {
 }
 
 export default function MyAccount() {
+  const { isAuthenticated } = useAuth();
   let telegramId = null;
   let googleId = null;
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
 
   try {
     telegramId = getTelegramId();
@@ -83,7 +89,7 @@ export default function MyAccount() {
 
   if (!telegramId) {
     googleId = localStorage.getItem('googleId');
-    if (!googleId) return <LoginOptions />;
+    if (!googleId) return <Navigate to="/login" replace />;
   }
 
   const [profile, setProfile] = useState(null);

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -606,3 +606,11 @@ export function getWatchCount(tableId) {
 export function getAppStats() {
   return get('/api/stats');
 }
+
+export function loginWithPassword(password) {
+  return post('/api/auth/login', { password });
+}
+
+export function fetchCurrentUser(token) {
+  return get('/api/auth/me', token);
+}


### PR DESCRIPTION
## Summary
- add an authentication context and private route helper to gate protected content
- introduce a login page and route that saves the returned token via the auth context
- wrap account access in the new private route and redirect unauthenticated visitors

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945060691948329904322c20dcb53bb)