### PR TITLE
Align Ludo Battle Royale graphics presets with Murlan

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -211,7 +211,7 @@ function resolveDefaultPixelRatioCap() {
 
 function detectPreferredFrameRateId() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-    return 'balanced60';
+    return 'fhd60';
   }
   const coarsePointer = detectCoarsePointer();
   const ua = navigator.userAgent ?? '';
@@ -225,34 +225,39 @@ function detectPreferredFrameRateId() {
   const rendererTier = classifyRendererTier(readGraphicsRendererString());
 
   if (lowRefresh) {
-    return 'mobile50';
+    return 'hd50';
   }
 
   if (isMobileUA || coarsePointer || isTouch || rendererTier === 'mobile') {
     if ((deviceMemory !== null && deviceMemory <= 4) || hardwareConcurrency <= 4) {
-      return 'mobile50';
+      return 'hd50';
     }
     if (highRefresh && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 6)) {
-      return 'fast120';
+      return 'uhd120';
     }
     if (
       highRefresh ||
-      (!lowRefresh && hardwareConcurrency >= 6 && (deviceMemory == null || deviceMemory >= 4))
+      hardwareConcurrency >= 6 ||
+      (deviceMemory != null && deviceMemory >= 6)
     ) {
-      return 'smooth90';
+      return 'qhd90';
     }
-    return 'balanced60';
+    return 'fhd60';
+  }
+
+  if (rendererTier === 'desktopHigh' && highRefresh) {
+    return 'ultra144';
   }
 
   if (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8) {
-    return 'fast120';
+    return 'uhd120';
   }
 
   if (rendererTier === 'desktopMid') {
-    return 'smooth90';
+    return 'qhd90';
   }
 
-  return 'balanced60';
+  return 'fhd60';
 }
 
 const ABG_MODEL_URLS = Object.freeze([
@@ -392,52 +397,52 @@ const NON_DIAMOND_SHAPE_INDEX = (() => {
 const FRAME_RATE_STORAGE_KEY = 'ludoFrameRate';
 const FRAME_RATE_OPTIONS = Object.freeze([
   {
-    id: 'mobile50',
-    label: 'Battery Saver (50 Hz)',
+    id: 'hd50',
+    label: 'HD Performance (50 Hz)',
     fps: 50,
-    renderScale: 0.88,
-    pixelRatioCap: 1.15,
-    resolution: '0.88x render • DPR 1.15 cap',
-    description: 'For 50–60 Hz displays or thermally constrained mobile GPUs.'
+    renderScale: 1,
+    pixelRatioCap: 1.4,
+    resolution: 'HD render • DPR 1.4 cap',
+    description: 'Minimum HD output for battery saver and 50–60 Hz displays.'
   },
   {
-    id: 'balanced60',
-    label: 'Snooker Match (60 Hz)',
+    id: 'fhd60',
+    label: 'Full HD (60 Hz)',
     fps: 60,
-    renderScale: 0.95,
-    pixelRatioCap: 1.3,
-    resolution: '0.95x render • DPR 1.3 cap',
-    description: 'Mirror the 3D Snooker frame pacing and resolution profile.'
+    renderScale: 1.1,
+    pixelRatioCap: 1.5,
+    resolution: 'Full HD render • DPR 1.5 cap',
+    description: '1080p-focused profile that mirrors the Snooker frame pacing.'
   },
   {
-    id: 'smooth90',
-    label: 'Smooth Motion (90 Hz)',
+    id: 'qhd90',
+    label: 'Quad HD (90 Hz)',
     fps: 90,
-    renderScale: 0.92,
-    pixelRatioCap: 1.35,
-    resolution: '0.92x render • DPR 1.35 cap',
-    description: 'High-refresh option for capable 90 Hz mobile panels.'
+    renderScale: 1.25,
+    pixelRatioCap: 1.7,
+    resolution: 'QHD render • DPR 1.7 cap',
+    description: 'Sharper 1440p render for capable 90 Hz mobile and desktop GPUs.'
   },
   {
-    id: 'fast120',
-    label: 'Performance (120 Hz)',
+    id: 'uhd120',
+    label: 'Ultra HD (120 Hz)',
     fps: 120,
-    renderScale: 0.9,
-    pixelRatioCap: 1.25,
-    resolution: '0.90x render • DPR 1.25 cap',
-    description: 'Raised fps with modest render scale for powerful devices.'
+    renderScale: 1.35,
+    pixelRatioCap: 2,
+    resolution: 'Ultra HD render • DPR 2.0 cap',
+    description: '4K-oriented profile for 120 Hz flagships and desktops.'
   },
   {
-    id: 'esports144',
-    label: 'Tournament (144 Hz)',
+    id: 'ultra144',
+    label: 'Ultra HD+ (144 Hz)',
     fps: 144,
-    renderScale: 0.86,
-    pixelRatioCap: 1.2,
-    resolution: '0.86x render • DPR 1.2 cap',
-    description: 'Aggressive scaling to keep 144 Hz stable on mobile chips.'
+    renderScale: 1.5,
+    pixelRatioCap: 2.2,
+    resolution: 'Ultra HD+ render • DPR 2.2 cap',
+    description: 'Maximum clarity preset that prioritizes UHD detail at 144 Hz.'
   }
 ]);
-const DEFAULT_FRAME_RATE_ID = 'balanced60';
+const DEFAULT_FRAME_RATE_ID = 'fhd60';
 
 function normalizeAppearance(value = {}) {
   const normalized = { ...DEFAULT_APPEARANCE };


### PR DESCRIPTION
## Summary
- align Ludo Battle Royale frame rate presets with the Murlan Royale profiles, including labels and scaling caps
- update frame rate auto-detection defaults to choose the shared preset IDs

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945087c0430832981f69ad583ff5bc4)