### PR TITLE
Enable scrolling in Ludo table setup menu

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -4297,7 +4297,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   </svg>
                 </button>
               </div>
-              <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
+              <div className="mt-4 max-h-[70vh] space-y-4 overflow-y-auto pr-1 touch-pan-y overscroll-contain">
                 {customizationSections.map(({ key, label, options }) => (
                   <div key={key} className="space-y-2">
                     <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>


### PR DESCRIPTION
## Summary
- allow the Ludo Battle Royal table setup list to scroll on mobile and long option lists by enabling touch panning and higher max height

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69450de54d48832980fb647bb2f2e463)