### PR TITLE
Add mirrored spotlight and balance pool royale lighting

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2319,7 +2319,7 @@ const LIGHTING_OPTIONS = Object.freeze([
       dirColor: 0xf6f8ff,
       dirIntensity: 1.42,
       spotColor: 0xffffff,
-      spotIntensity: 11.4,
+      spotIntensity: 6.8,
       spotAngle: Math.PI * 0.36,
       ambientIntensity: 0.16
     }
@@ -2336,7 +2336,7 @@ const LIGHTING_OPTIONS = Object.freeze([
       dirColor: 0xf2f5ff,
       dirIntensity: 1.58,
       spotColor: 0xf7fbff,
-      spotIntensity: 12.2,
+      spotIntensity: 7.2,
       spotAngle: Math.PI * 0.34,
       ambientIntensity: 0.12
     }
@@ -2353,7 +2353,7 @@ const LIGHTING_OPTIONS = Object.freeze([
       dirColor: 0xeaf1ff,
       dirIntensity: 1.28,
       spotColor: 0xf5f8ff,
-      spotIntensity: 10.2,
+      spotIntensity: 6.1,
       spotAngle: Math.PI * 0.42,
       ambientIntensity: 0.18
     }
@@ -9460,6 +9460,7 @@ function PoolRoyaleGame({
         hemisphereRig,
         dirLight,
         spot,
+        counterSpot,
         ambient
       } = rig;
 
@@ -9472,9 +9473,18 @@ function PoolRoyaleGame({
         hemisphereRig.intensity = settings.rimIntensity;
       if (settings.dirColor && dirLight) dirLight.color.set(settings.dirColor);
       if (settings.dirIntensity && dirLight) dirLight.intensity = settings.dirIntensity;
-      if (settings.spotColor && spot) spot.color.set(settings.spotColor);
-      if (settings.spotIntensity && spot) spot.intensity = settings.spotIntensity;
-      if (settings.spotAngle && spot) spot.angle = settings.spotAngle;
+      if (settings.spotColor) {
+        if (spot) spot.color.set(settings.spotColor);
+        if (counterSpot) counterSpot.color.set(settings.spotColor);
+      }
+      if (settings.spotIntensity) {
+        if (spot) spot.intensity = settings.spotIntensity;
+        if (counterSpot) counterSpot.intensity = settings.spotIntensity;
+      }
+      if (settings.spotAngle) {
+        if (spot) spot.angle = settings.spotAngle;
+        if (counterSpot) counterSpot.angle = settings.spotAngle;
+      }
       if (settings.ambientIntensity && ambient)
         ambient.intensity = settings.ambientIntensity;
     },
@@ -13491,13 +13501,17 @@ function PoolRoyaleGame({
         const heightScale = Math.max(0.001, TABLE_H / SAMPLE_TABLE_HEIGHT);
         const scaledHeight = heightScale * LIGHT_HEIGHT_SCALE;
 
-        const hemisphere = new THREE.HemisphereLight(0xdde7ff, 0x0b1020, 0.758625);
+        const hemisphere = new THREE.HemisphereLight(
+          0xdde7ff,
+          0x0b1020,
+          0.758625
+        );
         const lightHeightLift = scaledHeight * LIGHT_HEIGHT_LIFT_MULTIPLIER; // lift the lighting rig higher above the table
         const triangleHeight = tableSurfaceY + 6.6 * scaledHeight + lightHeightLift;
         const triangleRadius = fixtureScale * 0.98;
         const lightRetreatOffset = scaledHeight * 0.24;
         const lightReflectionGuard = scaledHeight * 0.32;
-        hemisphere.position.set(0, triangleHeight, -triangleRadius * 0.6);
+        hemisphere.position.set(0, triangleHeight, 0);
         lightingRig.add(hemisphere);
 
         const hemisphereRig = new THREE.HemisphereLight(0xdde7ff, 0x0b1020, 0.4284);
@@ -13514,27 +13528,49 @@ function PoolRoyaleGame({
         lightingRig.add(dirLight);
         lightingRig.add(dirLight.target);
 
-        const spot = new THREE.SpotLight(
-          0xffffff,
-          12.289725,
-          0,
-          Math.PI * 0.36,
-          0.42,
-          1
-        );
-        spot.position.set(
-          triangleRadius * LIGHT_LATERAL_SCALE,
-          triangleHeight + lightRetreatOffset + lightReflectionGuard,
-          triangleRadius * LIGHT_LATERAL_SCALE * (0.35 + LIGHT_LATERAL_SCALE * 0.12)
-        );
-        spot.target.position.set(0, tableSurfaceY + TABLE_H * 0.18, 0);
-        spot.decay = 1.0;
-        spot.castShadow = true;
-        spot.shadow.mapSize.set(2048, 2048);
-        spot.shadow.bias = -0.00004;
-        spot.shadow.normalBias = 0.006;
-        lightingRig.add(spot);
-        lightingRig.add(spot.target);
+        const spotlightConfig = {
+          color: 0xffffff,
+          intensity: 6.25,
+          distance: 0,
+          angle: Math.PI * 0.36,
+          penumbra: 0.42,
+          decay: 1
+        };
+
+        const createRigSpot = ({ xMultiplier, zMultiplier }) => {
+          const rigSpot = new THREE.SpotLight(
+            spotlightConfig.color,
+            spotlightConfig.intensity,
+            spotlightConfig.distance,
+            spotlightConfig.angle,
+            spotlightConfig.penumbra,
+            spotlightConfig.decay
+          );
+          rigSpot.position.set(
+            triangleRadius * LIGHT_LATERAL_SCALE * xMultiplier,
+            triangleHeight + lightRetreatOffset + lightReflectionGuard,
+            triangleRadius * LIGHT_LATERAL_SCALE * zMultiplier
+          );
+          rigSpot.target.position.set(0, tableSurfaceY + TABLE_H * 0.18, 0);
+          rigSpot.decay = 1.0;
+          rigSpot.castShadow = true;
+          rigSpot.shadow.mapSize.set(2048, 2048);
+          rigSpot.shadow.bias = -0.00004;
+          rigSpot.shadow.normalBias = 0.006;
+          lightingRig.add(rigSpot);
+          lightingRig.add(rigSpot.target);
+          return rigSpot;
+        };
+
+        const spot = createRigSpot({
+          xMultiplier: 1,
+          zMultiplier: 0.35 + LIGHT_LATERAL_SCALE * 0.12
+        });
+
+        const counterSpot = createRigSpot({
+          xMultiplier: -1,
+          zMultiplier: -(0.35 + LIGHT_LATERAL_SCALE * 0.12)
+        });
 
         const ambient = new THREE.AmbientLight(
           0xffffff,
@@ -13557,6 +13593,7 @@ function PoolRoyaleGame({
           hemisphereRig,
           dirLight,
           spot,
+          counterSpot,
           ambient
         };
         applyLightingPreset();


### PR DESCRIPTION
## Summary
- add a second spotlight mirroring the original pool royale table light
- center hemisphere ambient light and adjust rig to balance lighting coverage
- lower preset spotlight intensities to avoid overexposure with the twin lights

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69452227f0ec8329a914d09e268fd6d8)