### PR TITLE
Adjust Pool Royale top-down camera framing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4298,7 +4298,7 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.006;
-const TOP_VIEW_MARGIN = 1.08;
+const TOP_VIEW_MARGIN = 1.12;
 const TOP_VIEW_MIN_RADIUS_SCALE = 0.88;
 const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI + 0.06, CAMERA.minPhi * 0.66);
 const CUE_VIEW_RADIUS_RATIO = 0.042;
@@ -12279,10 +12279,10 @@ function PoolRoyaleGame({
             camera.position.add(topFocusTarget);
             camera.lookAt(topFocusTarget);
             renderCamera = camera;
-            broadcastArgs.focusWorld =
-              broadcastCamerasRef.current?.defaultFocusWorld ?? topFocusTarget;
+            broadcastArgs.focusWorld = topFocusTarget.clone();
             broadcastArgs.targetWorld = topFocusTarget.clone();
-              broadcastArgs.lerp = 0.12;
+            broadcastArgs.orbitWorld = topFocusTarget.clone();
+            broadcastArgs.lerp = 0.12;
             } else {
               camera.up.set(0, 1, 0);
               TMP_SPH.copy(sph);


### PR DESCRIPTION
## Summary
- raise the Pool Royale top-down camera margin so the full table stays in frame
- align the rail overhead broadcast focus/orbit with the top-down view coordinates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69453d0dab088329b10694ee37866056)