### PR TITLE
Align Snooker Club table with Pool Royale sizing

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -759,7 +759,8 @@ const ENABLE_TRIPOD_CAMERAS = false;
 const TABLE_BASE_SCALE = 1.17;
 const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION; // shrink snooker build to Pool Royale footprint without altering proportions
 const TABLE = {
-  W: 72 * TABLE_SCALE,
+  // Match the Pool Royale footprint so the snooker build renders identically sized rails and fascia
+  W: 66 * TABLE_SCALE,
   H: 132 * TABLE_SCALE,
   THICK: 1.8 * TABLE_SCALE,
   WALL: 2.6 * TABLE_SCALE
@@ -818,16 +819,17 @@ const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; //
 const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
-// Dimensions reflect WPBSA snooker specifications (playing surface 3569 mm × 1778 mm)
-const WIDTH_REF = 3556;
-const HEIGHT_REF = 1778;
-const BALL_D_REF = 52.5;
+// Reuse the Pool Royale playfield and pocket metrics so pockets + balls line up exactly with that table
+// (WPA 9ft reference: 100" × 50", 2.25" balls)
+const WIDTH_REF = 2540;
+const HEIGHT_REF = 1270;
+const BALL_D_REF = 57.15;
 const BAULK_FROM_BAULK_REF = 737; // Baulk line distance from the baulk cushion (29")
 const D_RADIUS_REF = 292;
 const PINK_FROM_TOP_REF = 737;
 const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
-const CORNER_MOUTH_REF = 86;
-const SIDE_MOUTH_REF = 92;
+const CORNER_MOUTH_REF = 114.3; // 4.5" corner pocket mouth between cushion noses (Pool Royale match)
+const SIDE_MOUTH_REF = 127; // 5" side pocket mouth between cushion noses (Pool Royale match)
 const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
 const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
 const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;


### PR DESCRIPTION
## Summary
- set the Snooker Club table footprint to the Pool Royale dimensions so rails and fascia match visually
- reuse Pool Royale playfield reference sizes for balls and pockets to keep pocket layout identical
- clarify the configuration comments around the shared geometry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945431a924083298faf49c555429022)