### PR TITLE
Adjust Snooker Club rail and cushion alignment

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -765,7 +765,7 @@ const TABLE_BASE_SCALE = 1.17;
     THICK: 1.8 * TABLE_SCALE,
     WALL: 2.6 * TABLE_SCALE
   };
-const RAIL_HEIGHT = TABLE.THICK * 1.96; // raise the wooden rails slightly so their top edge now meets the cushion surface
+const RAIL_HEIGHT = TABLE.THICK * 1.96; // match Pool Royale rail height so wood meets the cushion seam cleanly
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.008; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
@@ -954,8 +954,8 @@ const CLOTH_EDGE_TINT = 0.18; // keep the pocket sleeves closer to the base felt
 const CLOTH_EDGE_EMISSIVE_MULTIPLIER = 0.02; // soften light spill on the sleeve walls while keeping reflections muted
 const CLOTH_EDGE_EMISSIVE_INTENSITY = 0.24; // further dim emissive brightness so the cutouts stay consistent with the cloth plane
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
-const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.06; // match Pool Royale by lowering the base so the cushion pads sit flush to the rails with no gaps
-const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.18; // trim the tops to the Pool Royale profile so they finish level with the wooden rails
+const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.07; // lower the base further so the pads settle into the rails without a gap
+const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.2; // shave the tops a touch more so they finish level with the Pool Royale rail height
 const CUSHION_FIELD_CLIP_RATIO = 0.14; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth


### PR DESCRIPTION
## Summary
- keep Snooker Club rail height aligned to the Pool Royale spec so the wood meets the cushions cleanly
- lower and trim the snooker cushions to sit flush with the wooden rails like Pool Royale

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69456f96f70c8329b855701a0fb7cb6d)