### PR TITLE
Clamp cue camera to aiming line height

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12324,8 +12324,9 @@ function PoolRoyaleGame({
                   );
                 }
               }
+              let aimLineWorldY = null;
               if (TMP_SPH.radius > 1e-6) {
-                const aimLineWorldY =
+                aimLineWorldY =
                   (AIM_LINE_MIN_Y + CAMERA_AIM_LINE_MARGIN) * worldScaleFactor;
                 const aimOffset = aimLineWorldY - lookTarget.y;
                 if (aimOffset > 0) {
@@ -12355,12 +12356,16 @@ function PoolRoyaleGame({
                 : WORLD_SCALE;
               const surfaceMarginWorld = Math.max(0, CAMERA_SURFACE_STOP_MARGIN) * scaleFactor;
               const cueLevelWorldY = (CUE_Y + CAMERA_CUE_SURFACE_MARGIN) * scaleFactor;
+              const aimLineClampWorldY =
+                aimLineWorldY ??
+                (AIM_LINE_MIN_Y + CAMERA_AIM_LINE_MARGIN) * scaleFactor;
               const surfaceClampY = Math.max(
                 baseSurfaceWorldY + surfaceMarginWorld,
                 cueLevelWorldY
               );
-              if (camera.position.y < surfaceClampY) {
-                camera.position.y = surfaceClampY;
+              const minCameraY = Math.max(surfaceClampY, aimLineClampWorldY);
+              if (camera.position.y < minCameraY) {
+                camera.position.y = minCameraY;
                 TMP_VEC3_A.copy(camera.position).sub(lookTarget);
                 const limitedRadius = TMP_VEC3_A.length();
                 if (limitedRadius > 1e-6) {


### PR DESCRIPTION
## Summary
- track aiming-line world height while orbiting and reuse it for camera clamps
- enforce minimum camera height using the aim-line level alongside existing surface safety checks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69459a337ba4832985fc8137aa6af37b)