### PR TITLE
Adjust cue and broadcast camera constraints

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -84,7 +84,7 @@ public class CueCamera : MonoBehaviour
     // Keeps the framing just above the cue stick instead of letting the
     // view slide down into the shaft.
     [Range(0f, 1f)]
-    public float maxCueAimLowering = 0.82f;
+    public float maxCueAimLowering = 0.75f;
 
     [Header("Cue aim framing")]
     // Scale applied to the cue distance when the camera is raised. Values below
@@ -125,17 +125,17 @@ public class CueCamera : MonoBehaviour
     [Header("Broadcast view")]
     // Distance and height for the short-rail broadcast view used once a shot begins.
     public float broadcastDistance = 0.9f;
-    public float broadcastHeight = 0.42f;
+    public float broadcastHeight = 0.36f;
     // Bounds that encompass the full playing surface including rails and pockets.
     public Bounds tableBounds = new Bounds(new Vector3(0f, 0.36f, 0f), new Vector3(1.64465f, 0.72f, 3.301325f));
     // Keep a small margin inside the camera frame so the rails never touch the
     // edge of the screen during broadcast shots.
     [Range(0f, 0.25f)]
-    public float broadcastSafeMargin = 0.02f;
+    public float broadcastSafeMargin = 0.015f;
     // Minimum and maximum camera offsets used while fitting the table inside the
     // broadcast frame. The solver expands toward the max until every corner is
     // visible.
-    public float broadcastMinDistance = 0.9f;
+    public float broadcastMinDistance = 0.8f;
     public float broadcastMaxDistance = 5.0875f;
     // Blend between the table centre and the active focus (cue ball or target)
     // when aiming the broadcast view. Keeps the play interesting while still
@@ -144,7 +144,7 @@ public class CueCamera : MonoBehaviour
     public float broadcastFocusBias = 0.35f;
     // Additional height applied when the broadcast camera needs to rise to keep
     // the far short rail within frame.
-    public float broadcastHeightPadding = 0.06f;
+    public float broadcastHeightPadding = 0.05f;
     // Minimum squared velocity to consider a ball as moving.
     public float velocityThreshold = 0.01f;
     // How quickly the camera aligns to the stored shot angle.
@@ -375,7 +375,8 @@ public class CueCamera : MonoBehaviour
         }
 
         float cueSurfaceHeight = CueBall.position.y + cueBallRadius;
-        float minimumCueHeight = cueSurfaceHeight + Mathf.Max(0f, cueHeightClearance);
+        float cueAimFloor = cueSurfaceHeight + Mathf.Max(0f, cueHeightClearance);
+        float minimumCueHeight = cueAimFloor;
         minimumCueHeight = Mathf.Max(minimumCueHeight, cueSamplePoint.y + Mathf.Max(0f, cueHeightClearance));
 
         float raisedHeight = Mathf.Max(minimumCueHeight, cueRaisedHeight + Mathf.Max(0f, cueRaisedHeightPadding));
@@ -389,7 +390,8 @@ public class CueCamera : MonoBehaviour
         height = Mathf.Max(height, cueSurfaceHeight + Mathf.Max(0f, cueHeightClearance));
 
         Vector3 focus = CueBall.position;
-        float minimumHeightOffset = Mathf.Max(minimumHeightAboveFocus, height - focus.y);
+        float aimLineOffset = Mathf.Max(0f, cueAimFloor - focus.y);
+        float minimumHeightOffset = Mathf.Max(minimumHeightAboveFocus, height - focus.y, aimLineOffset);
         Vector3 lookTarget = GetCueAimLookTarget(focus, cueAimForward);
 
         ApplyCueAimZoom(blend, deltaTime);


### PR DESCRIPTION
## Summary
- Lowered and tightened the broadcast rail camera framing so the table and balls appear larger while staying in frame
- Reduced how far players can lower the cue camera and enforced an aim-line height floor to prevent dipping below the cue

## Testing
- Not run (Unity project)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945ac33d5608329917b353b1fa7fd28)