### PR TITLE
Align Snooker Club table layout with Pool Royale

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -755,19 +755,14 @@ const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const CLOTH_COLOR_STORAGE_KEY = 'poolRoyaleClothColor';
 const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
 const ENABLE_CUE_GALLERY = false;
-const ENABLE_TRIPOD_CAMERAS = false;
 const TABLE_BASE_SCALE = 1.17;
-  const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION; // shrink snooker build to Pool Royale footprint without altering proportions
-  const OFFICIAL_SNOOKER_PLAYFIELD_SCALE = 3569 / 2540; // widen to an official snooker bed while keeping the ball/pocket scale anchored
-  const TABLE = {
-    W: 66 * TABLE_SCALE * OFFICIAL_SNOOKER_PLAYFIELD_SCALE,
-    H: 132 * TABLE_SCALE * OFFICIAL_SNOOKER_PLAYFIELD_SCALE,
-    THICK: 1.8 * TABLE_SCALE,
-    WALL:
-      2.6 *
-      TABLE_SCALE *
-      (OFFICIAL_SNOOKER_PLAYFIELD_SCALE * (66 / 72)) // widen rails to maintain Pool Royale proportions on the larger snooker bed
-  };
+const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION; // reuse Pool Royale footprint without altering proportions
+const TABLE = {
+  W: 72 * TABLE_SCALE,
+  H: 132 * TABLE_SCALE,
+  THICK: 1.8 * TABLE_SCALE,
+  WALL: 2.6 * TABLE_SCALE
+};
 const RAIL_HEIGHT = TABLE.THICK * 1.96; // match Pool Royale rail height so wood meets the cushion seam cleanly
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.008; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
@@ -822,20 +817,21 @@ const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; //
 const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
-  // Dimensions reflect WPBSA full-size snooker specifications (playing surface ~3569 mm × 1778 mm)
-  const WIDTH_REF = 3569;
-  const HEIGHT_REF = 1778;
+  // Reuse the Pool Royale playfield and pocket metrics so pockets + balls line up exactly with that table
+  // (WPA 9ft reference: 100" × 50", 2.25" balls)
+  const WIDTH_REF = 2540;
+  const HEIGHT_REF = 1270;
   const BALL_D_REF = 57.15;
-  const BAULK_FROM_BAULK_REF = 558.8; // legacy head string distance retained to keep the existing pocket layout intact
+  const BAULK_FROM_BAULK_REF = 737; // Baulk line distance from the baulk cushion (29")
   const D_RADIUS_REF = 292;
   const PINK_FROM_TOP_REF = 737;
-  const BLACK_FROM_TOP_REF = 558.8; // legacy foot spot distance retained to preserve the original ball roadmap
-  const CORNER_MOUTH_REF = 114.3; // 4.5" corner pocket mouth between cushion noses
-  const SIDE_MOUTH_REF = 127; // 5" side pocket mouth between cushion noses
+  const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
+  const CORNER_MOUTH_REF = 114.3; // 4.5" corner pocket mouth between cushion noses (Pool Royale match)
+  const SIDE_MOUTH_REF = 127; // 5" side pocket mouth between cushion noses (Pool Royale match)
   const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
   const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
   const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
-  const TARGET_RATIO = WIDTH_REF / HEIGHT_REF;
+  const TARGET_RATIO = 1.83;
   const END_RAIL_INNER_SCALE =
     (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
     (2 * TABLE.WALL);
@@ -846,10 +842,10 @@ const PLAY_H = TABLE.H - 2 * END_RAIL_INNER_THICKNESS;
 const innerLong = Math.max(PLAY_W, PLAY_H);
 const innerShort = Math.min(PLAY_W, PLAY_H);
 const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
-  console.assert(
-    Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
-    'Snooker table inner ratio must match the 2:1 target after scaling.'
-  );
+console.assert(
+  Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
+  'Snooker table inner ratio must match the widened 1.83:1 target after scaling.'
+);
 const MM_TO_UNITS = innerLong / WIDTH_REF;
 const BALL_SIZE_SCALE = 0.94248; // 5% larger than the last Pool Royale build (15.8% over the original baseline)
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
@@ -10554,43 +10550,6 @@ export function PoolRoyaleGame({
       });
       world.add(broadcastRig.group);
       broadcastCamerasRef.current = broadcastRig;
-
-      if (ENABLE_TRIPOD_CAMERAS) {
-        const tripodHeightBoost = 1.04;
-        const tripodScale =
-          ((TABLE_Y + BALL_R * 6 - floorY) / 1.33) * tripodHeightBoost;
-        const tripodTilt = THREE.MathUtils.degToRad(-12);
-        const tripodProximityPull = BALL_R * 2.5;
-        const tripodExtra = Math.max(BALL_R * 2, BALL_R * 6 - tripodProximityPull);
-        const tripodDesiredZ =
-          Math.max(PLAY_H / 2 + BALL_R * 12, shortRailTarget - BALL_R * 6) +
-          tripodExtra;
-        const tripodMaxZ = roomDepth / 2 - wallThickness - BALL_R * 4;
-        const tripodZOffset = Math.min(tripodMaxZ, tripodDesiredZ);
-        const tripodTarget = new THREE.Vector3(0, TABLE_Y + TABLE.THICK * 0.5, 0);
-        const tripodPositions = [
-          { x: 0, z: tripodZOffset },
-          { x: 0, z: -tripodZOffset }
-        ];
-        tripodPositions.forEach(({ x, z }) => {
-          const { group: tripodGroup, headPivot } = createTripodBroadcastCamera();
-          tripodGroup.scale.setScalar(tripodScale);
-          tripodGroup.position.set(x, floorY, z);
-          const toTarget = new THREE.Vector3()
-            .subVectors(tripodTarget, tripodGroup.position)
-            .setY(0);
-          if (toTarget.lengthSq() > 1e-6) {
-            const yaw = Math.atan2(toTarget.z, toTarget.x);
-            tripodGroup.rotation.y = yaw;
-          }
-          world.add(tripodGroup);
-          tripodGroup.updateWorldMatrix(true, false);
-          headPivot.up.set(0, 1, 0);
-          headPivot.lookAt(tripodTarget);
-          headPivot.rotateY(Math.PI);
-          headPivot.rotateX(tripodTilt);
-        });
-      }
 
       const hospitalityMats = {
         wood: new THREE.MeshStandardMaterial({


### PR DESCRIPTION
## Summary
- reuse the Pool Royale table footprint and pocket metrics for Snooker Club so the layout and height match
- remove the broadcast tripod rigs from the Snooker Club arena to clear the walls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945ab4500a48329801f3c685bf3bf3c)