### PR TITLE
Adjust broadcast camera framing and cue lowering clamp

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -124,8 +124,8 @@ public class CueCamera : MonoBehaviour
 
     [Header("Broadcast view")]
     // Distance and height for the short-rail broadcast view used once a shot begins.
-    public float broadcastDistance = 0.9f;
-    public float broadcastHeight = 0.42f;
+    public float broadcastDistance = 0.78f;
+    public float broadcastHeight = 0.36f;
     // Bounds that encompass the full playing surface including rails and pockets.
     public Bounds tableBounds = new Bounds(new Vector3(0f, 0.36f, 0f), new Vector3(1.64465f, 0.72f, 3.301325f));
     // Keep a small margin inside the camera frame so the rails never touch the
@@ -135,7 +135,7 @@ public class CueCamera : MonoBehaviour
     // Minimum and maximum camera offsets used while fitting the table inside the
     // broadcast frame. The solver expands toward the max until every corner is
     // visible.
-    public float broadcastMinDistance = 0.9f;
+    public float broadcastMinDistance = 0.78f;
     public float broadcastMaxDistance = 5.0875f;
     // Blend between the table centre and the active focus (cue ball or target)
     // when aiming the broadcast view. Keeps the play interesting while still
@@ -386,7 +386,10 @@ public class CueCamera : MonoBehaviour
         height = clothAnchorHeight + (height - clothAnchorHeight) * heightScale;
         float minRailHeight = railHeight + Mathf.Max(0f, railClearance);
         height = Mathf.Max(height, minRailHeight);
-        height = Mathf.Max(height, cueSurfaceHeight + Mathf.Max(0f, cueHeightClearance));
+
+        float aimingLineHeight = CueBall.position.y + cueBallRadius;
+        float minCueHeight = aimingLineHeight + Mathf.Max(0f, cueHeightClearance);
+        height = Mathf.Max(height, minCueHeight);
 
         Vector3 focus = CueBall.position;
         float minimumHeightOffset = Mathf.Max(minimumHeightAboveFocus, height - focus.y);


### PR DESCRIPTION
## Summary
- lower the broadcast camera height and distance to enlarge the table view
- clamp cue aiming height so the camera cannot dip below the cue line

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945ac33d5608329917b353b1fa7fd28)