### PR TITLE
Adjust top-down camera framing for portrait

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -10766,7 +10766,13 @@ function PoolRoyaleGame({
       }
 
       const resolveBroadcastDistance = () => {
-        const worstCaseAspect = 9 / 16; // worst-case portrait aspect to guarantee full coverage
+        const hostRect = host?.getBoundingClientRect?.();
+        const liveAspect =
+          hostRect && hostRect.width > 0 && hostRect.height > 0
+            ? hostRect.width / hostRect.height
+            : null;
+        const worstCaseAspect =
+          liveAspect != null ? Math.min(liveAspect, 9 / 16) : 9 / 16; // clamp to the actual portrait aspect to keep all pockets in frame
         const tempCamera = new THREE.PerspectiveCamera(
           STANDING_VIEW_FOV,
           worstCaseAspect


### PR DESCRIPTION
## Summary
- use the host element's current aspect ratio when computing the top-down broadcast camera distance so tall portrait screens keep the full table in view

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945bfe941508329803c6e5b1ff027ce)