### PR TITLE
Translate Murlan Royale text and auto-pick AI avatars

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2006,7 +2006,7 @@ export default function MurlanRoyaleArena({ search }) {
                   size={avatarSize}
                 />
                 <span className="text-[0.65rem] font-semibold uppercase tracking-wide text-white/80 drop-shadow">
-                  {handCount} karta
+                  {handCount} cards
                 </span>
               </div>
             );
@@ -2048,7 +2048,7 @@ export default function MurlanRoyaleArena({ search }) {
                     type="button"
                     onClick={() => setConfigOpen(false)}
                     className="rounded-full p-1 text-white/70 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
-                    aria-label="Mbyll personalizimin"
+                    aria-label="Close customization"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -2377,7 +2377,7 @@ function computeUiState(state) {
     const description = describeCombo(state.tableCombo, state.tableCards);
     if (description) {
       const owner = state.lastWinner != null ? state.players[state.lastWinner]?.name : null;
-      tableSummary = owner ? `${owner} hodhi ${description}` : description;
+      tableSummary = owner ? `${owner} played ${description}` : description;
     }
   }
 
@@ -2413,14 +2413,14 @@ function describeCombo(combo, cards) {
 
 function cardLabel(card) {
   if (!card) return '';
-  if (card.rank === 'JR') return 'Joker i kuq';
-  if (card.rank === 'JB') return 'Joker i zi';
+  if (card.rank === 'JR') return 'Red Joker';
+  if (card.rank === 'JB') return 'Black Joker';
   return `${card.rank}${card.suit}`;
 }
 
 function buildPlayers(search) {
   const params = new URLSearchParams(search);
-  const username = params.get('username') || 'Ti';
+  const username = params.get('username') || 'You';
   const avatar = params.get('avatar') || '';
   const providedFlags = (params.get('flags') || '')
     .split(',')

--- a/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
@@ -12,6 +12,16 @@ const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
 const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 
+function pickRandomFlags(count) {
+  if (!count) return [];
+  const available = FLAG_EMOJIS.map((_, idx) => idx);
+  for (let i = available.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [available[i], available[j]] = [available[j], available[i]];
+  }
+  return available.slice(0, count);
+}
+
 export default function MurlanRoyaleLobby() {
   const navigate = useNavigate();
   useTelegramBackButton();
@@ -22,7 +32,7 @@ export default function MurlanRoyaleLobby() {
   const [gameType, setGameType] = useState('single');
   const [targetPoints, setTargetPoints] = useState(11);
   const [showFlagPicker, setShowFlagPicker] = useState(false);
-  const [flags, setFlags] = useState([]);
+  const [flags, setFlags] = useState(() => pickRandomFlags(4));
 
   const flagPickerCount = mode === 'local' ? 4 : 1;
 
@@ -36,6 +46,13 @@ export default function MurlanRoyaleLobby() {
       setAvatar(saved || getTelegramPhotoUrl());
     } catch {}
   }, []);
+
+  useEffect(() => {
+    setFlags((prev) => {
+      if (prev.length === flagPickerCount) return prev;
+      return pickRandomFlags(flagPickerCount);
+    });
+  }, [flagPickerCount]);
 
   const startGame = async (flagOverride = flags) => {
     let tgId;


### PR DESCRIPTION
## Summary
- translate Murlan Royale UI strings to English, including combo summaries, joker labels, and accessibility text
- default the lobby AI avatars to randomly selected flags while keeping manual selection available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69462a98b2408329b306364bb189f419)