### PR TITLE
Adjust Pool Royale top-down camera framing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4310,6 +4310,8 @@ const TOP_VIEW_MIN_RADIUS_SCALE = 1.0;
 const TOP_VIEW_PHI = CAMERA_ABS_MIN_PHI + 0.02;
 const TOP_VIEW_RADIUS_SCALE = 0.84;
 const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI);
+const TOP_VIEW_FOCUS_SHIFT_X = PLAY_W * 0.02;
+const TOP_VIEW_FOCUS_SHIFT_Z = PLAY_H * 0.04;
 const CUE_VIEW_RADIUS_RATIO = 0.04;
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.12;
 const CUE_VIEW_MIN_PHI = Math.min(
@@ -12294,9 +12296,9 @@ function PoolRoyaleGame({
           lookTarget = focusTarget;
           if (topViewRef.current) {
             const topFocusTarget = TMP_VEC3_TOP_VIEW.set(
-              playerOffsetRef.current,
+              playerOffsetRef.current + TOP_VIEW_FOCUS_SHIFT_X,
               ORBIT_FOCUS_BASE_Y,
-              0
+              TOP_VIEW_FOCUS_SHIFT_Z
             ).multiplyScalar(worldScaleFactor);
             lookTarget = topFocusTarget;
             lastCameraTargetRef.current.copy(topFocusTarget);
@@ -13213,9 +13215,9 @@ function PoolRoyaleGame({
           const margin = TOP_VIEW_MARGIN;
           fit(margin);
           const topFocusTarget = TMP_VEC3_TOP_VIEW.set(
-            playerOffsetRef.current,
+            playerOffsetRef.current + TOP_VIEW_FOCUS_SHIFT_X,
             ORBIT_FOCUS_BASE_Y,
-            0
+            TOP_VIEW_FOCUS_SHIFT_Z
           ).multiplyScalar(
             Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE
           );


### PR DESCRIPTION
## Summary
- shift the Pool Royale 2D top-down camera focus to better clear the spin controls and slider
- add reusable offsets so the top-view framing sits slightly higher and to the left on screen

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69463619c8508329980c503f1f3ee702)