### PR TITLE
Align snooker cushion height with Pool Royale

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -768,8 +768,9 @@ const TABLE_BASE_SCALE = 1.17;
       TABLE_SCALE *
       (OFFICIAL_SNOOKER_PLAYFIELD_SCALE * (66 / 72)) // widen rails to maintain Pool Royale proportions on the larger snooker bed
   };
-// Match Pool Royale's visible rail + cushion height even with the wider snooker thickness.
-const RAIL_HEIGHT = TABLE.THICK * (1.96 / OFFICIAL_SNOOKER_PLAYFIELD_SCALE);
+// Match Pool Royale's visible rail + cushion height so the cushion lip sits at the same
+// on-screen height despite the wider snooker footprint.
+const RAIL_HEIGHT = TABLE.THICK * 1.96;
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.008; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches


### PR DESCRIPTION
## Summary
- Raise the snooker table rail and cushion height to match Pool Royale's visible lip position despite the larger playfield scale.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69463a66bb888329bbc458335259a51a)