### PR TITLE
Adjust Pool Royale camera framing and stability

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2429,14 +2429,14 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
     description:
       'Short-rail broadcast heads mounted above the table for the true TV feed.',
     method: 'Overhead rail mounts with fast post-shot cuts.',
-    orbitBias: 0.68,
+    orbitBias: 0.58,
     railPush: BALL_R * 5.2,
     lateralDolly: BALL_R * 0.6,
     focusLift: BALL_R * 5.4,
     focusDepthBias: BALL_R * 1.4,
     focusPan: 0,
-    trackingBias: 0.52,
-    smoothing: 0.14,
+    trackingBias: 0,
+    smoothing: 0.12,
     avoidPocketCameras: false,
     forceActionActivation: true
   }
@@ -4291,6 +4291,10 @@ const STANDING_VIEW = Object.freeze({
   phi: STANDING_VIEW_PHI,
   margin: STANDING_VIEW_MARGIN
 });
+const ORBIT_FRAMING_OFFSET = Object.freeze({
+  right: BALL_R * 2.1,
+  down: BALL_R * 1.2
+});
 const STANDING_VIEW_COT = (() => {
   const sinPhi = Math.sin(STANDING_VIEW_PHI);
   return sinPhi > 1e-6 ? Math.cos(STANDING_VIEW_PHI) / sinPhi : 0;
@@ -4462,6 +4466,8 @@ const TMP_VEC2_LIMIT = new THREE.Vector2();
 const TMP_VEC2_AXIS = new THREE.Vector2();
 const TMP_VEC2_VIEW = new THREE.Vector2();
 const TMP_VEC3_A = new THREE.Vector3();
+const TMP_VEC3_B = new THREE.Vector3();
+const TMP_VEC3_C = new THREE.Vector3();
 const TMP_VEC3_BUTT = new THREE.Vector3();
 const TMP_VEC3_CHALK = new THREE.Vector3();
 const TMP_VEC3_CHALK_DELTA = new THREE.Vector3();
@@ -10194,6 +10200,7 @@ function PoolRoyaleGame({
       return;
     }
     const cueRackDisposers = [];
+    let disposed = false;
     try {
       const updatePocketCameraState = (active) => {
         if (pocketCameraStateRef.current === active) return;
@@ -12431,12 +12438,38 @@ function PoolRoyaleGame({
                   syncBlendToSpherical();
                 }
               }
+              if ((camera.aspect || 1) < 1) {
+                const scaleFactor = Number.isFinite(worldScaleFactor)
+                  ? worldScaleFactor
+                  : WORLD_SCALE;
+                const forward = TMP_VEC3_A.copy(lookTarget).sub(camera.position);
+                if (forward.lengthSq() > 1e-6) {
+                  forward.normalize();
+                  const right = TMP_VEC3_B.crossVectors(forward, camera.up);
+                  if (right.lengthSq() > 1e-6) {
+                    right.normalize();
+                    camera.position.addScaledVector(
+                      right,
+                      ORBIT_FRAMING_OFFSET.right * scaleFactor
+                    );
+                  }
+                  const upDir = TMP_VEC3_C.copy(camera.up).normalize();
+                  camera.position.addScaledVector(
+                    upDir,
+                    -ORBIT_FRAMING_OFFSET.down * scaleFactor
+                  );
+                }
+              }
               camera.lookAt(lookTarget);
               renderCamera = camera;
-              broadcastArgs.focusWorld =
-                broadcastCamerasRef.current?.defaultFocusWorld ?? lookTarget;
-              broadcastArgs.targetWorld = null;
-              broadcastArgs.lerp = 0.22;
+              const broadcastFocus =
+                broadcastCamerasRef.current?.defaultFocusWorld ||
+                lastCameraTargetRef.current ||
+                lookTarget;
+              broadcastArgs.focusWorld = broadcastFocus;
+              broadcastArgs.targetWorld = broadcastFocus;
+              broadcastArgs.orbitWorld = null;
+              broadcastArgs.lerp = 0.18;
             }
           }
           if (lookTarget) {
@@ -16502,9 +16535,11 @@ function PoolRoyaleGame({
       // Loop
       let lastStepTime = performance.now();
       const step = (now) => {
+        if (disposed) return;
         const playback = replayPlaybackRef.current;
         if (playback) {
           const scheduleNext = () => {
+            if (disposed) return;
             rafRef.current = requestAnimationFrame(step);
           };
           const frames = playback.frames || [];
@@ -17611,12 +17646,15 @@ function PoolRoyaleGame({
           }
           const frameCamera = updateCamera();
           renderer.render(scene, frameCamera ?? camera);
-          rafRef.current = requestAnimationFrame(step);
+          if (!disposed) {
+            rafRef.current = requestAnimationFrame(step);
+          }
         };
         step(performance.now());
 
       // Resize
         const onResize = () => {
+          if (disposed || !host) return;
           renderer.setSize(host.clientWidth, host.clientHeight);
           // Update canvas dimensions when the window size changes so the table
           // remains fully visible.
@@ -17642,6 +17680,7 @@ function PoolRoyaleGame({
       window.addEventListener('resize', onResize);
 
         return () => {
+          disposed = true;
           applyWorldScaleRef.current = () => {};
           topViewControlsRef.current = { enter: () => {}, exit: () => {} };
           cameraUpdateRef.current = () => {};


### PR DESCRIPTION
## Summary
- shift the Pool Royale portrait orbit framing to pull the table higher and slightly left on screen
- lock the broadcast feed to the rail-overhead rig instead of cue-ball tracking and retune smoothing
- add disposal guards around the render loop and resize handler to prevent crashes during teardown

## Testing
- npm --prefix webapp run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694641b6786883298ec52ac9dfcff10f)