### PR TITLE
Adjust Snooker Club table to scaled official specs

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -760,13 +760,10 @@ const TABLE_BASE_SCALE = 1.17;
   const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION; // shrink snooker build to Pool Royale footprint without altering proportions
   const OFFICIAL_SNOOKER_PLAYFIELD_SCALE = 3569 / 2540; // widen to an official snooker bed while keeping the ball/pocket scale anchored
   const TABLE = {
-    W: 66 * TABLE_SCALE * OFFICIAL_SNOOKER_PLAYFIELD_SCALE,
+    W: 72 * TABLE_SCALE * OFFICIAL_SNOOKER_PLAYFIELD_SCALE,
     H: 132 * TABLE_SCALE * OFFICIAL_SNOOKER_PLAYFIELD_SCALE,
     THICK: 1.8 * TABLE_SCALE,
-    WALL:
-      2.6 *
-      TABLE_SCALE *
-      (OFFICIAL_SNOOKER_PLAYFIELD_SCALE * (66 / 72)) // widen rails to maintain Pool Royale proportions on the larger snooker bed
+    WALL: 2.6 * TABLE_SCALE * OFFICIAL_SNOOKER_PLAYFIELD_SCALE // keep the Pool Royale rail proportions while scaling to official snooker dimensions
   };
 // Match Pool Royale's visible rail + cushion height so the cushion lip sits at the same
 // on-screen height despite the wider snooker footprint.
@@ -827,17 +824,17 @@ const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   // Dimensions reflect WPBSA full-size snooker specifications (playing surface ~3569 mm × 1778 mm)
   const WIDTH_REF = 3569;
   const HEIGHT_REF = 1778;
-  const BALL_D_REF = 57.15;
-  const BAULK_FROM_BAULK_REF = 558.8; // legacy head string distance retained to keep the existing pocket layout intact
-  const D_RADIUS_REF = 292;
-  const PINK_FROM_TOP_REF = 737;
-  const BLACK_FROM_TOP_REF = 558.8; // legacy foot spot distance retained to preserve the original ball roadmap
-  const CORNER_MOUTH_REF = 114.3; // 4.5" corner pocket mouth between cushion noses
-  const SIDE_MOUTH_REF = 127; // 5" side pocket mouth between cushion noses
+  const BALL_D_REF = 52.5; // official snooker ball diameter
+  const BAULK_FROM_BAULK_REF = 737; // official head string distance from the baulk cushion
+  const D_RADIUS_REF = 292; // official D radius
+  const PINK_FROM_TOP_REF = 737; // official pink spot distance from the top cushion
+  const BLACK_FROM_TOP_REF = 324; // official black spot distance from the top cushion
+  const CORNER_MOUTH_REF = 86; // official corner pocket mouth between cushion noses
+  const SIDE_MOUTH_REF = 89; // official side pocket mouth between cushion noses
   const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
   const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
   const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
-  const TARGET_RATIO = WIDTH_REF / HEIGHT_REF;
+  const TARGET_RATIO = 1.83; // reuse the Pool Royale layout ratio while scaling the playfield to official snooker measurements
   const END_RAIL_INNER_SCALE =
     (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
     (2 * TABLE.WALL);
@@ -850,7 +847,7 @@ const innerShort = Math.min(PLAY_W, PLAY_H);
 const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
   console.assert(
     Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
-    'Snooker table inner ratio must match the 2:1 target after scaling.'
+    'Snooker table inner ratio must match the Pool Royale layout target after scaling.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF;
 const BALL_SIZE_SCALE = 0.94248; // 5% larger than the last Pool Royale build (15.8% over the original baseline)


### PR DESCRIPTION
## Summary
- scale the Snooker Club table using official snooker measurements while keeping the Pool Royale layout ratio
- update ball, pocket, and spot references to official dimensions and keep rail proportions aligned

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69464c67e97883299e4be106b798f93e)