### PR TITLE
Adjust pool top view framing and prefer rail broadcast

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2437,7 +2437,7 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
     focusPan: 0,
     trackingBias: 0,
     smoothing: 0.12,
-    avoidPocketCameras: false,
+    avoidPocketCameras: true,
     forceActionActivation: true
   }
 ]);
@@ -4314,6 +4314,10 @@ const TOP_VIEW_MIN_RADIUS_SCALE = 1.0;
 const TOP_VIEW_PHI = CAMERA_ABS_MIN_PHI + 0.02;
 const TOP_VIEW_RADIUS_SCALE = 0.84;
 const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI);
+const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
+  x: BALL_R * 1.35,
+  z: -BALL_R * 1.8
+});
 const CUE_VIEW_RADIUS_RATIO = 0.04;
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.12;
 const CUE_VIEW_MIN_PHI = Math.min(
@@ -12314,9 +12318,9 @@ function PoolRoyaleGame({
           lookTarget = focusTarget;
           if (topViewRef.current) {
             const topFocusTarget = TMP_VEC3_TOP_VIEW.set(
-              playerOffsetRef.current,
+              playerOffsetRef.current + TOP_VIEW_SCREEN_OFFSET.x,
               ORBIT_FOCUS_BASE_Y,
-              0
+              TOP_VIEW_SCREEN_OFFSET.z
             ).multiplyScalar(worldScaleFactor);
             lookTarget = topFocusTarget;
             lastCameraTargetRef.current.copy(topFocusTarget);
@@ -12664,7 +12668,7 @@ function PoolRoyaleGame({
             cueBall,
             fallback: shortRailDir
           });
-          const preferRailOverhead = Boolean(railNormal);
+          const preferRailOverhead = true;
           const now = performance.now();
           const activationDelay = longShot
             ? now + LONG_SHOT_ACTIVATION_DELAY_MS


### PR DESCRIPTION
## Summary
- shift the top-down camera framing slightly toward the upper-left to better match the supplied reference
- prioritize the rail-overhead broadcast rig by default and disable pocket camera cutaways
- ensure action camera views always prefer the rail-mounted overhead perspective

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69464b6045bc83299ea5093345b6ef96)