### PR TITLE
Adjust rail overhead broadcast camera distance

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2428,7 +2428,7 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
       'Short-rail broadcast heads mounted above the table for the true TV feed.',
     method: 'Overhead rail mounts with fast post-shot cuts.',
     orbitBias: 0.68,
-    railPush: BALL_R * 5.2,
+    railPush: BALL_R * 5.8,
     lateralDolly: BALL_R * 0.6,
     focusLift: BALL_R * 5.4,
     focusDepthBias: BALL_R * 1.4,


### PR DESCRIPTION
## Summary
- increase the rail-overhead broadcast rig offset to pull the camera farther from the table

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69466b44e8f08329a9d3dc1dc498ec1a)