### PR TITLE
Adjust Pool Royale rail overhead camera framing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2428,10 +2428,10 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
       'Short-rail broadcast heads mounted above the table for the true TV feed.',
     method: 'Overhead rail mounts with fast post-shot cuts.',
     orbitBias: 0.68,
-    railPush: BALL_R * 5.8,
+    railPush: BALL_R * 4.6,
     lateralDolly: BALL_R * 0.6,
-    focusLift: BALL_R * 5.4,
-    focusDepthBias: BALL_R * 1.4,
+    focusLift: BALL_R * 4.8,
+    focusDepthBias: BALL_R * 0.6,
     focusPan: 0,
     trackingBias: 0.52,
     smoothing: 0.14,
@@ -3810,7 +3810,7 @@ function createBroadcastCameras({
   const requestedZ = Math.abs(shortRailZ) || fallbackDepth;
   const cameraCenterZOffset = Math.min(Math.max(requestedZ, fallbackDepth), maxDepth);
   const cameraScale = 1.2;
-  const cameraProximityScale = 0.54;
+  const cameraProximityScale = 0.5;
 
   const createShortRailUnit = (zSign) => {
     const direction = Math.sign(zSign) || 1;


### PR DESCRIPTION
## Summary
- move the rail overhead broadcast rig closer to the table centerline
- tweak the broadcast focus offsets so bottom pockets stay visible on the rail feed

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69466df6b57083299e68bf49717f374d)