### PR TITLE
Adjust broadcast camera framing

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -131,7 +131,7 @@ public class CueCamera : MonoBehaviour
     // Keep a small margin inside the camera frame so the rails never touch the
     // edge of the screen during broadcast shots.
     [Range(0f, 0.25f)]
-    public float broadcastSafeMargin = 0.02f;
+    public float broadcastSafeMargin = 0.06f;
     // Minimum and maximum camera offsets used while fitting the table inside the
     // broadcast frame. The solver expands toward the max until every corner is
     // visible.


### PR DESCRIPTION
## Summary
- increase the broadcast safe margin so the overhead rail camera pulls back slightly
- ensure all table pockets remain in frame during broadcast view

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946735ff7a883299470e98e45dd2c8d)