### PR TITLE
Tweak Pool Royale broadcast camera and replay timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4321,7 +4321,7 @@ const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) =>
   const lengthDistance = (halfLength / Math.tan(halfVertical)) * TOP_VIEW_RADIUS_SCALE;
   return Math.max(widthDistance, lengthDistance);
 };
-const RAIL_OVERHEAD_DISTANCE_BIAS = 1.04; // pull the rail overhead broadcast heads slightly away from the cloth
+const RAIL_OVERHEAD_DISTANCE_BIAS = 1.06; // pull the rail overhead broadcast heads slightly away from the cloth
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
@@ -16532,10 +16532,21 @@ function PoolRoyaleGame({
 
       // Loop
       let lastStepTime = performance.now();
+      let lastReplayFrameAt = 0;
       const step = (now) => {
         if (disposed) return;
         const playback = replayPlaybackRef.current;
         if (playback) {
+          const frameTiming = frameTimingRef.current;
+          const targetReplayFrameTime =
+            frameTiming && Number.isFinite(frameTiming.targetMs)
+              ? frameTiming.targetMs
+              : 1000 / 60;
+          if (lastReplayFrameAt && now - lastReplayFrameAt < targetReplayFrameTime) {
+            rafRef.current = requestAnimationFrame(step);
+            return;
+          }
+          lastReplayFrameAt = now;
           const scheduleNext = () => {
             if (disposed) return;
             rafRef.current = requestAnimationFrame(step);


### PR DESCRIPTION
## Summary
- pull the rail overhead broadcast camera a bit farther from the table
- throttle replay playback to use the active frame timing so it matches game FPS

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694696c183108329a5f6ae5638c78de1)