### PR TITLE
Adjust side pocket outset for normal middle pocket behaviour

### DIFF
--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -24,8 +24,9 @@ public static class PhysicsConstants
     public const double CornerPocketMouth = 0.1057275; // scaled with table reduction
     public const double SidePocketMouth = 0.117475;    // scaled with table reduction
     public const double PocketCaptureRadius = 0.087875; // scaled with table reduction
-    // Keep side pockets aligned with the rail line so they behave identically to corner pockets.
-    public const double SidePocketOutset = 0.0;
+    // Pull the side pocket centres slightly off the cloth so the capture circle sits under the jaws
+    // instead of the playing surface, matching corner-pocket behaviour near the middle of the table.
+    public const double SidePocketOutset = BallRadius;
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 32;


### PR DESCRIPTION
## Summary
- pull side pocket centers outward by one ball radius so the capture zone sits beneath the jaws rather than on the cloth
- align middle-pocket interactions with corner behaviour for more predictable shots near the side pockets

## Testing
- `dotnet test billiards.Tests/Billiards.Tests.csproj` *(fails: dotnet not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c53f167c8329b5a5ff15473d9315)