### PR TITLE
Fix middle pocket guard collision handling

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -5144,7 +5144,7 @@ function reflectRails(ball) {
     if (distNormal >= BALL_R) continue;
     TMP_VEC2_D.set(-TMP_VEC2_B.y, TMP_VEC2_B.x);
     const lateral = Math.abs(TMP_VEC2_A.dot(TMP_VEC2_D));
-    if (lateral <= sideSpan) continue;
+    if (lateral > sideSpan) continue;
     if (distNormal < -sideDepthLimit) continue;
     const push = BALL_R - distNormal;
     ball.pos.addScaledVector(TMP_VEC2_B, push);


### PR DESCRIPTION
## Summary
- correct side pocket guard span check so collisions trigger within the intended middle-pocket width
- ensure balls near the middle pockets interact with the rail guard instead of being ignored

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c53f167c8329b5a5ff15473d9315)