### PR TITLE
Fix side pocket collisions

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -131,6 +131,23 @@ public class PocketEdgeTests
         Assert.That(ball.Pocketed, Is.True);
         Assert.That(balls, Is.Empty);
     }
+
+    [Test]
+    public void BallRailsIntoSidePocketWithoutBouncingOut()
+    {
+        var solver = new BilliardsSolver();
+        solver.InitStandardTable();
+        // Roll a ball tight along the top rail toward the middle pocket to ensure it enters cleanly.
+        var ball = new BilliardsSolver.Ball
+        {
+            Position = new Vec2(PhysicsConstants.TableWidth / 2 - PhysicsConstants.BallRadius * 2, PhysicsConstants.BallRadius),
+            Velocity = new Vec2(1.0, 0)
+        };
+        var balls = new List<BilliardsSolver.Ball> { ball };
+        solver.Step(balls, 1.0);
+        Assert.That(ball.Pocketed, Is.True);
+        Assert.That(balls, Is.Empty);
+    }
 }
 
 public class ConnectorEdgeTests

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -24,8 +24,9 @@ public static class PhysicsConstants
     public const double CornerPocketMouth = 0.1057275; // scaled with table reduction
     public const double SidePocketMouth = 0.117475;    // scaled with table reduction
     public const double PocketCaptureRadius = 0.087875; // scaled with table reduction
-    // Keep side pockets aligned with the rail line so they behave identically to corner pockets.
-    public const double SidePocketOutset = 0.0;
+    // Offset the side pockets slightly outside the cushion line so balls hugging the rail
+    // enter the jaws instead of catching on the invisible lip along the middle pockets.
+    public const double SidePocketOutset = BallRadius * 0.5;
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 32;


### PR DESCRIPTION
## Summary
- offset side pocket geometry outward so rail-hugging shots enter side pockets cleanly
- add regression test to ensure balls rolling along the rail fall into middle pockets instead of bouncing out

## Testing
- dotnet test billiards.Tests/Billiards.Tests.csproj *(fails: dotnet not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c53f167c8329b5a5ff15473d9315)