### PR TITLE
Refine pocket capture radii

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -72,15 +72,20 @@ public class BilliardsSolver
         AddSidePocketJaw(new Vec2(0 - sideOutset, height / 2), sideCut, sideDepth, true, sideSegments, vertical: true);
         AddSidePocketJaw(new Vec2(width + sideOutset, height / 2), sideCut, sideDepth, false, sideSegments, vertical: true);
 
-        double capture = Math.Max(PhysicsConstants.BallRadius * 1.05, PhysicsConstants.PocketCaptureRadius);
-        Pockets.Add(new Pocket { Center = new Vec2(0, 0), Radius = capture });
-        Pockets.Add(new Pocket { Center = new Vec2(width / 2, 0 - sideOutset), Radius = capture });
-        Pockets.Add(new Pocket { Center = new Vec2(width, 0), Radius = capture });
-        Pockets.Add(new Pocket { Center = new Vec2(0 - sideOutset, height / 2), Radius = capture });
-        Pockets.Add(new Pocket { Center = new Vec2(width + sideOutset, height / 2), Radius = capture });
-        Pockets.Add(new Pocket { Center = new Vec2(0, height), Radius = capture });
-        Pockets.Add(new Pocket { Center = new Vec2(width / 2, height + sideOutset), Radius = capture });
-        Pockets.Add(new Pocket { Center = new Vec2(width, height), Radius = capture });
+        // Capture radius follows the true pocket interior so balls behave identically
+        // near side and corner pockets instead of sharing an oversized fallback radius.
+        double baseCapture = Math.Max(PhysicsConstants.BallRadius * 1.05, PhysicsConstants.PocketCaptureRadius);
+        double cornerCapture = Math.Min(baseCapture, cornerCut); // follow the rounded corner cut
+        double sideCapture = Math.Min(baseCapture, Math.Min(sideCut, sideDepth)); // follow the tighter side throat
+
+        Pockets.Add(new Pocket { Center = new Vec2(0, 0), Radius = cornerCapture });
+        Pockets.Add(new Pocket { Center = new Vec2(width / 2, 0 - sideOutset), Radius = sideCapture });
+        Pockets.Add(new Pocket { Center = new Vec2(width, 0), Radius = cornerCapture });
+        Pockets.Add(new Pocket { Center = new Vec2(0 - sideOutset, height / 2), Radius = sideCapture });
+        Pockets.Add(new Pocket { Center = new Vec2(width + sideOutset, height / 2), Radius = sideCapture });
+        Pockets.Add(new Pocket { Center = new Vec2(0, height), Radius = cornerCapture });
+        Pockets.Add(new Pocket { Center = new Vec2(width / 2, height + sideOutset), Radius = sideCapture });
+        Pockets.Add(new Pocket { Center = new Vec2(width, height), Radius = cornerCapture });
     }
 
     private void AddCushionSegment(Vec2 a, Vec2 b, Vec2 interiorHint)


### PR DESCRIPTION
## Summary
- differentiate capture radii for corner and side pockets to match their real interior geometry
- tighten side pocket capture zones so balls behave consistently near middle pockets

## Testing
- `dotnet test billiards.Tests/Billiards.Tests.csproj` *(fails: dotnet not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946d0213d188329950d4bff15153f14)