### PR TITLE
Refine spin input easing and adjust broadcast camera distance

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -124,8 +124,8 @@ public class CueCamera : MonoBehaviour
 
     [Header("Broadcast view")]
     // Distance and height for the short-rail broadcast view used once a shot begins.
-    public float broadcastDistance = 0.78f;
-    public float broadcastHeight = 0.36f;
+    public float broadcastDistance = 0.9f;
+    public float broadcastHeight = 0.42f;
     // Bounds that encompass the full playing surface including rails and pockets.
     public Bounds tableBounds = new Bounds(new Vector3(0f, 0.36f, 0f), new Vector3(1.64465f, 0.72f, 3.301325f));
     // Keep a small margin inside the camera frame so the rails never touch the
@@ -135,7 +135,7 @@ public class CueCamera : MonoBehaviour
     // Minimum and maximum camera offsets used while fitting the table inside the
     // broadcast frame. The solver expands toward the max until every corner is
     // visible.
-    public float broadcastMinDistance = 0.78f;
+    public float broadcastMinDistance = 0.9f;
     public float broadcastMaxDistance = 5.0875f;
     // Blend between the table centre and the active focus (cue ball or target)
     // when aiming the broadcast view. Keeps the play interesting while still
@@ -144,7 +144,7 @@ public class CueCamera : MonoBehaviour
     public float broadcastFocusBias = 0.35f;
     // Additional height applied when the broadcast camera needs to rise to keep
     // the far short rail within frame.
-    public float broadcastHeightPadding = 0.06f;
+    public float broadcastHeightPadding = 0.08f;
     // Minimum squared velocity to consider a ball as moving.
     public float velocityThreshold = 0.01f;
     // How quickly the camera aligns to the stored shot angle.

--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -321,8 +321,12 @@
         const nx = Math.max(Math.min(dx / cx, 1), -1);
         const ny = Math.max(Math.min(dy / cy, 1), -1);
         // invert the vertical component so positive y is top spin
-        spin = { x: nx, y: -ny };
-        updateSpinDots(nx, ny);
+        const rawSpin = { x: nx, y: -ny };
+        // ease the response so tiny adjustments near centre produce gentle spin
+        const strength = Math.min(1, Math.hypot(rawSpin.x, rawSpin.y));
+        const eased = strength * strength;
+        spin = { x: rawSpin.x * eased, y: rawSpin.y * eased };
+        updateSpinDots(rawSpin.x, rawSpin.y);
       }
       spinController.addEventListener('pointerdown', (e) => {
         spinning = true;


### PR DESCRIPTION
## Summary
- smooth the spin controller response so small offsets apply gentle spin instead of jumping to extremes
- keep the spin indicator tied to the raw controller position while easing the applied spin vector
- pull the broadcast short-rail camera slightly farther from the table with higher minimum distance and height padding

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ea1be2288329aca025042e20d223)