### PR TITLE
Adjust broadcast and standing camera framing

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -27,7 +27,7 @@ public class CameraController : MonoBehaviour
     // Minimum distance the camera should maintain when hugging the table so the
     // framing ends up closer to the cue ball without drifting toward the butt of
     // the cue stick.
-    public float minimumCueViewDistance = 1.25f;
+    public float minimumCueViewDistance = 1.05f;
     // How far above the rails the camera is allowed to travel.
     public float maxHeightAboveTable = 2.05f;
     // Default distance of the camera from the table centre when fully raised to
@@ -74,7 +74,7 @@ public class CameraController : MonoBehaviour
     // view settles closer to the middle of the cue instead of drifting all the
     // way to the plastic cap at the end of the stick.
     [Range(0f, 1f)]
-    public float cueViewMaxCueDistanceRatio = 0.65f;
+    public float cueViewMaxCueDistanceRatio = 0.5f;
 
     private void LateUpdate()
     {

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -125,13 +125,13 @@ public class CueCamera : MonoBehaviour
     [Header("Broadcast view")]
     // Distance and height for the short-rail broadcast view used once a shot begins.
     public float broadcastDistance = 0.9f;
-    public float broadcastHeight = 0.48f;
+    public float broadcastHeight = 0.6f;
     // Bounds that encompass the full playing surface including rails and pockets.
     public Bounds tableBounds = new Bounds(new Vector3(0f, 0.36f, 0f), new Vector3(1.64465f, 0.72f, 3.301325f));
     // Keep a small margin inside the camera frame so the rails never touch the
     // edge of the screen during broadcast shots.
     [Range(0f, 0.25f)]
-    public float broadcastSafeMargin = 0.08f;
+    public float broadcastSafeMargin = 0.05f;
     // Minimum and maximum camera offsets used while fitting the table inside the
     // broadcast frame. The solver expands toward the max until every corner is
     // visible.
@@ -141,10 +141,10 @@ public class CueCamera : MonoBehaviour
     // when aiming the broadcast view. Keeps the play interesting while still
     // framing the entire table.
     [Range(0f, 1f)]
-    public float broadcastFocusBias = 0.35f;
+    public float broadcastFocusBias = 0.22f;
     // Additional height applied when the broadcast camera needs to rise to keep
     // the far short rail within frame.
-    public float broadcastHeightPadding = 0.08f;
+    public float broadcastHeightPadding = 0.12f;
     // Minimum squared velocity to consider a ball as moving.
     public float velocityThreshold = 0.01f;
     // How quickly the camera aligns to the stored shot angle.


### PR DESCRIPTION
## Summary
- raise the rail broadcast camera height and padding while reducing focus bias to keep all pockets visible
- tighten standing camera follow distances to keep the view closer to the cue ball and avoid showing cue stick stripes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69478b4309bc83298c4470df7382df08)