### PR TITLE
Adjust studio camera offset

### DIFF
--- a/webapp/src/utils/dominoArena.js
+++ b/webapp/src/utils/dominoArena.js
@@ -788,7 +788,7 @@ export function buildDominoArena({ scene, renderer }) {
 
   const studioCamA = buildStudioCamera();
   const studioCamB = buildStudioCamera();
-  const cameraOffset = TABLE_DIMENSIONS.outerHalfWidth + 1.1;
+  const cameraOffset = TABLE_DIMENSIONS.outerHalfWidth + 1.3;
   studioCamA.position.set(-cameraOffset, 0, -cameraOffset);
   studioCamB.position.set(cameraOffset, 0, cameraOffset);
   arena.add(studioCamA, studioCamB);


### PR DESCRIPTION
## Summary
- increase the rail studio camera offset so the overhead view sits slightly farther from the table

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694795d727c48329ac6cd32c2b66078a)