### PR TITLE
Shift Pool Royale 2D camera framing upward

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4308,7 +4308,7 @@ const TOP_VIEW_RADIUS_SCALE = 0.82;
 const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: -BALL_R * 0.85, // nudge the table slightly left in top-down framing
-  z: BALL_R * 2.6 // lift the table higher toward the top edge for 2D mode
+  z: BALL_R * 3.4 // lift the table higher toward the top edge for 2D mode and clear bottom UI
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.


### PR DESCRIPTION
## Summary
- raise the top-down view screen offset in Pool Royale so the table sits higher on screen and avoids the bottom UI

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947b1f8b1b083298bc7bd871eadebbc)