### PR TITLE
Adjust Pool Royale top-down camera framing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4308,7 +4308,7 @@ const TOP_VIEW_RADIUS_SCALE = 0.82;
 const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: -BALL_R * 0.85, // nudge the table slightly left in top-down framing
-  z: BALL_R * 4.2 // lift the table higher toward the top edge for 2D mode and clear bottom UI/widgets
+  z: BALL_R * 5.6 // lift the table higher toward the top edge for 2D mode, clearing avatars/controls and balancing top-bottom space
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.


### PR DESCRIPTION
## Summary
- raise the 2D top-down camera offset so the table sits higher on screen, clearing avatars and power controls and balancing top/bottom spacing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947ba74a9948329839467b54516c4ee)