### PR TITLE
Keep broadcast cue camera level

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -943,7 +943,15 @@ public class CueCamera : MonoBehaviour
         desiredPosition.y = Mathf.Max(desiredPosition.y, minimumHeight);
         desiredPosition.y = Mathf.Max(desiredPosition.y, minRailHeight);
         transform.position = desiredPosition;
-        transform.LookAt(lookTarget);
+
+        Vector3 lookDirection = lookTarget - desiredPosition;
+        if (lookDirection.sqrMagnitude < 0.0001f)
+        {
+            lookDirection = forward;
+        }
+
+        lookDirection = lookDirection.normalized;
+        transform.rotation = Quaternion.LookRotation(lookDirection, Vector3.up);
     }
 
     private void EndShot()


### PR DESCRIPTION
## Summary
- lock the cue broadcast camera rotation to the world up vector to avoid any roll
- ensure broadcast framing stays level so both short-rail pockets remain visible

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947c5e841488329b3346511b3903d0c)