### PR TITLE
Align Pool Royale rail overhead camera

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2429,7 +2429,7 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
     method: 'Overhead rail mounts with fast post-shot cuts.',
     orbitBias: 0.68,
     railPush: BALL_R * 6,
-    lateralDolly: BALL_R * 0.6,
+    lateralDolly: 0,
     focusLift: BALL_R * 5.4,
     focusDepthBias: -BALL_R * 0.6,
     focusPan: 0,


### PR DESCRIPTION
## Summary
- remove the lateral dolly offset from the rail-overhead broadcast rig so the short-rail feed stays centered

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947c5e841488329b3346511b3903d0c)