### PR TITLE
Adjust Pool Royale rail overhead camera distance

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4325,7 +4325,7 @@ const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) =>
   const lengthDistance = (halfLength / Math.tan(halfVertical)) * TOP_VIEW_RADIUS_SCALE;
   return Math.max(widthDistance, lengthDistance);
 };
-const RAIL_OVERHEAD_DISTANCE_BIAS = 1.24; // pull the rail overhead broadcast heads farther to frame both end pockets and keep the far rail pockets in view on portrait
+const RAIL_OVERHEAD_DISTANCE_BIAS = 1.32; // pull the rail overhead broadcast heads farther to frame both end pockets and keep the far rail pockets in view on portrait
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale


### PR DESCRIPTION
## Summary
- increase the Pool Royale rail overhead broadcast distance to keep both end pockets in view on portrait

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947cd991e148329906fc67edde19363)