### PR TITLE
Align Pool Royale replays with rail broadcast camera

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11569,12 +11569,16 @@ function PoolRoyaleGame({
           const head = activeRail?.head ?? null;
           if (!head) return null;
           const position = head.getWorldPosition(new THREE.Vector3());
-          const target =
+          let target =
             focusOverride?.clone?.() ??
             rig.userData?.focus?.clone?.() ??
             rig.defaultFocusWorld?.clone?.() ??
             rig.defaultFocus?.clone?.() ??
             null;
+          if (!target) {
+            const forward = head.getWorldDirection(new THREE.Vector3());
+            target = position.clone().add(forward.multiplyScalar(SHORT_RAIL_CAMERA_DISTANCE));
+          }
           if (target && Number.isFinite(minTargetY)) {
             target.y = Math.max(target.y ?? minTargetY, minTargetY);
           }
@@ -13036,6 +13040,36 @@ function PoolRoyaleGame({
           }));
 
         const captureReplayCameraSnapshot = () => {
+          const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
+          const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
+          const broadcastRig = broadcastCamerasRef.current;
+          const activeRail = broadcastRig?.activeRail === 'front'
+            ? broadcastRig.cameras?.front
+            : broadcastRig?.activeRail === 'back'
+              ? broadcastRig.cameras?.back
+              : broadcastRig?.cameras?.back ?? broadcastRig?.cameras?.front;
+          const head = activeRail?.head ?? null;
+          if (head) {
+            const position = head.getWorldPosition(new THREE.Vector3());
+            let targetSnapshot =
+              broadcastRig?.userData?.focus?.clone?.() ??
+              broadcastRig?.defaultFocusWorld?.clone?.() ??
+              broadcastRig?.defaultFocus?.clone?.() ??
+              null;
+            if (!targetSnapshot) {
+              const forward = head.getWorldDirection(new THREE.Vector3());
+              targetSnapshot = position.clone().add(forward.multiplyScalar(SHORT_RAIL_CAMERA_DISTANCE));
+            }
+            if (targetSnapshot) {
+              targetSnapshot.y = Math.max(targetSnapshot.y ?? minTargetY, minTargetY);
+            }
+            return {
+              position,
+              target: targetSnapshot,
+              fov: STANDING_VIEW_FOV
+            };
+          }
+
           const currentCamera = activeRenderCameraRef.current ?? camera;
           const position = currentCamera?.position?.clone?.() ?? null;
           const fovSnapshot = Number.isFinite(currentCamera?.fov)
@@ -13044,6 +13078,9 @@ function PoolRoyaleGame({
           const targetSnapshot = lastCameraTargetRef.current
             ? lastCameraTargetRef.current.clone()
             : null;
+          if (targetSnapshot) {
+            targetSnapshot.y = Math.max(targetSnapshot.y ?? minTargetY, minTargetY);
+          }
           if (!position && !targetSnapshot) return null;
           return {
             position,


### PR DESCRIPTION
## Summary
- capture replay camera snapshots directly from the active rail broadcast camera so playback matches broadcast framing
- fall back to broadcast head orientation when resolving replay camera targets to keep angles consistent

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947d64164008329b82343b3b3a1c58b)