### PR TITLE
Use broadcast overhead camera for Pool Royale replays

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13036,14 +13036,24 @@ function PoolRoyaleGame({
           }));
 
         const captureReplayCameraSnapshot = () => {
+          const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
+          const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
+          const broadcastCamera = resolveRailOverheadReplayCamera({
+            focusOverride: lastCameraTargetRef.current,
+            minTargetY
+          });
           const currentCamera = activeRenderCameraRef.current ?? camera;
-          const position = currentCamera?.position?.clone?.() ?? null;
-          const fovSnapshot = Number.isFinite(currentCamera?.fov)
-            ? currentCamera.fov
-            : camera.fov;
-          const targetSnapshot = lastCameraTargetRef.current
-            ? lastCameraTargetRef.current.clone()
-            : null;
+          const position = broadcastCamera?.position ?? currentCamera?.position?.clone?.() ?? null;
+          const fovSnapshot = Number.isFinite(broadcastCamera?.fov)
+            ? broadcastCamera.fov
+            : Number.isFinite(currentCamera?.fov)
+              ? currentCamera.fov
+              : camera.fov;
+          const targetSnapshot = broadcastCamera?.target
+            ? broadcastCamera.target.clone()
+            : lastCameraTargetRef.current
+              ? lastCameraTargetRef.current.clone()
+              : null;
           if (!position && !targetSnapshot) return null;
           return {
             position,


### PR DESCRIPTION
## Summary
- prefer the broadcast overhead camera when capturing replay snapshots in Pool Royale
- keep replay camera focus and fov aligned with the broadcast rig instead of the 2D view

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947df0870a08329b74c07627ba95739)