### PR TITLE
Use broadcast overhead camera for replays

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13036,14 +13036,35 @@ function PoolRoyaleGame({
           }));
 
         const captureReplayCameraSnapshot = () => {
+          const usingTopView = Boolean(topViewRef.current);
+          const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
+          const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
+
+          const targetSnapshot = lastCameraTargetRef.current
+            ? lastCameraTargetRef.current.clone()
+            : null;
+
+          if (usingTopView) {
+            const railBroadcastSnapshot = resolveRailOverheadReplayCamera({
+              focusOverride: targetSnapshot,
+              minTargetY
+            });
+            if (railBroadcastSnapshot?.position && railBroadcastSnapshot?.target) {
+              return {
+                position: railBroadcastSnapshot.position.clone?.() ?? railBroadcastSnapshot.position,
+                target: railBroadcastSnapshot.target.clone?.() ?? railBroadcastSnapshot.target,
+                fov: Number.isFinite(railBroadcastSnapshot.fov)
+                  ? railBroadcastSnapshot.fov
+                  : camera.fov
+              };
+            }
+          }
+
           const currentCamera = activeRenderCameraRef.current ?? camera;
           const position = currentCamera?.position?.clone?.() ?? null;
           const fovSnapshot = Number.isFinite(currentCamera?.fov)
             ? currentCamera.fov
             : camera.fov;
-          const targetSnapshot = lastCameraTargetRef.current
-            ? lastCameraTargetRef.current.clone()
-            : null;
           if (!position && !targetSnapshot) return null;
           return {
             position,


### PR DESCRIPTION
## Summary
- prefer the rail broadcast camera snapshot when recording replays from top view so playback matches broadcast overhead framing
- keep existing camera snapshot fallback when broadcast data is unavailable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947df0870a08329b74c07627ba95739)