### PR TITLE
Refine Pool Royale rail camera and visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -241,7 +241,7 @@ function classifyRendererTier(rendererString) {
 
 function detectPreferredFrameRateId() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-    return 'fhd60';
+    return DEFAULT_FRAME_RATE_ID;
   }
   const coarsePointer = detectCoarsePointer();
   const ua = navigator.userAgent ?? '';
@@ -272,7 +272,7 @@ function detectPreferredFrameRateId() {
     ) {
       return 'qhd90';
     }
-    return 'fhd60';
+    return DEFAULT_FRAME_RATE_ID;
   }
 
   if (rendererTier === 'desktopHigh' && highRefresh) {
@@ -287,7 +287,7 @@ function detectPreferredFrameRateId() {
     return 'qhd90';
   }
 
-  return 'fhd60';
+  return DEFAULT_FRAME_RATE_ID;
 }
 
 function resolveDefaultPixelRatioCap() {
@@ -1002,7 +1002,7 @@ const CLOTH_EDGE_EMISSIVE_MULTIPLIER = 0.02; // soften light spill on the sleeve
 const CLOTH_EDGE_EMISSIVE_INTENSITY = 0.24; // further dim emissive brightness so the cutouts stay consistent with the cloth plane
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
 const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.06; // keep the cushion base closer to the rail line so the tops can sit level with the wood
-const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.18; // trim the cushion tops further so they no longer rise above the wooden rails
+const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.26; // restore the lower cushion profile so the noses sit back below the rail line
 const CUSHION_FIELD_CLIP_RATIO = 0.14; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
@@ -2417,7 +2417,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     description: 'Maximum clarity preset that prioritizes UHD detail at 144 Hz.'
   }
 ]);
-const DEFAULT_FRAME_RATE_ID = 'fhd60';
+const DEFAULT_FRAME_RATE_ID = 'qhd90';
 
 const BROADCAST_SYSTEM_STORAGE_KEY = 'poolBroadcastSystem';
 const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
@@ -10269,15 +10269,13 @@ function PoolRoyaleGame({
         shooting = value;
         shotStartedAt = shooting ? getNow() : 0;
         if (shooting) {
-          preShotTopViewRef.current = topViewRef.current;
-          preShotTopViewLockRef.current = topViewLockedRef.current;
-          topViewRef.current = true;
-          topViewLockedRef.current = true;
-          enterTopView(true);
-        } else if (!preShotTopViewRef.current) {
-          exitTopView(true);
+          preShotTopViewRef.current = false;
+          preShotTopViewLockRef.current = false;
+          topViewRef.current = false;
+          topViewLockedRef.current = false;
+          setIsTopDownView(false);
         } else {
-          topViewLockedRef.current = preShotTopViewLockRef.current;
+          exitTopView(true);
         }
         setShotActive(value);
       };
@@ -11639,6 +11637,7 @@ function PoolRoyaleGame({
             );
             const railBroadcastReplay = resolveRailOverheadReplayCamera({
               focusOverride:
+                replayCamera?.target ??
                 broadcastArgs.focusWorld ??
                 replayFrameCameraRef.current?.frameA?.target ??
                 replayFrameCameraRef.current?.frameB?.target ?? null,
@@ -12716,7 +12715,7 @@ function PoolRoyaleGame({
             cueBall,
             fallback: shortRailDir
           });
-          const preferRailOverhead = Boolean(railNormal);
+          const preferRailOverhead = true;
           const now = performance.now();
           const activationDelay = longShot
             ? now + LONG_SHOT_ACTIVATION_DELAY_MS
@@ -18486,15 +18485,11 @@ function PoolRoyaleGame({
         <button
           type="button"
           aria-pressed={isTopDownView}
-          onClick={() => setIsTopDownView((prev) => !prev)}
-          className={`pointer-events-auto flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
-            isTopDownView
-              ? 'border-emerald-300 bg-emerald-300/20 text-emerald-100'
-              : 'border-white/30 bg-black/70 text-white hover:bg-black/60'
-          }`}
+          disabled
+          className="pointer-events-auto flex items-center gap-2 rounded-full border border-white/20 bg-black/70 px-4 py-2 text-sm font-semibold text-white opacity-70 shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur"
         >
           <span className="text-base">🧭</span>
-          <span>{isTopDownView ? '3D' : '2D'}</span>
+          <span>Rail Cam</span>
         </button>
       </div>
 

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -77,7 +77,7 @@ function drawNumberBadge(ctx, size, number) {
 }
 
 function drawPoolNumberBadge(ctx, size, number) {
-  const radius = size * 0.1;
+  const radius = size * 0.086;
   const badgeStretch = 2; // compensate equirectangular vertical compression on spheres
   const cx = size * 0.5;
   const cy = size * 0.5;
@@ -90,12 +90,12 @@ function drawPoolNumberBadge(ctx, size, number) {
   ctx.fillStyle = '#ffffff';
   ctx.fill();
 
-  ctx.lineWidth = Math.max(2, Math.floor(size * 0.02));
-  ctx.strokeStyle = '#000000';
+  ctx.lineWidth = Math.max(2, Math.floor(size * 0.016));
+  ctx.strokeStyle = 'rgba(0,0,0,0.82)';
   ctx.stroke();
 
-  ctx.fillStyle = '#000000';
-  ctx.font = `bold ${size * 0.18}px Arial`;
+  ctx.fillStyle = '#0b0b0b';
+  ctx.font = `700 ${size * 0.145}px "DIN Alternate", "Arial Black", "Arial", sans-serif`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
 
@@ -127,7 +127,68 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
     const stripeHeight = size * 0.45;
     const stripeY = (size - stripeHeight) / 2;
     ctx.fillRect(0, stripeY, size, stripeHeight);
+
+    const stripeShade = ctx.createLinearGradient(0, stripeY, 0, stripeY + stripeHeight);
+    stripeShade.addColorStop(0, lighten(baseHex, 0.2));
+    stripeShade.addColorStop(0.5, baseHex);
+    stripeShade.addColorStop(1, darken(baseHex, 0.14));
+    ctx.fillStyle = stripeShade;
+    ctx.globalAlpha = 0.9;
+    ctx.fillRect(0, stripeY, size, stripeHeight);
+    ctx.globalAlpha = 1;
   }
+
+  ctx.save();
+  const bodyShade = ctx.createRadialGradient(
+    size * 0.3,
+    size * 0.3,
+    size * 0.08,
+    size * 0.55,
+    size * 0.62,
+    size * 0.52
+  );
+  bodyShade.addColorStop(0, lighten(baseHex, 0.32));
+  bodyShade.addColorStop(0.45, lighten(baseHex, 0.12));
+  bodyShade.addColorStop(1, darken(baseHex, 0.1));
+  ctx.globalCompositeOperation = 'multiply';
+  ctx.fillStyle = bodyShade;
+  ctx.fillRect(0, 0, size, size);
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalCompositeOperation = 'screen';
+  const gloss = ctx.createRadialGradient(
+    size * 0.32,
+    size * 0.28,
+    size * 0.04,
+    size * 0.32,
+    size * 0.28,
+    size * 0.22
+  );
+  gloss.addColorStop(0, 'rgba(255,255,255,0.82)');
+  gloss.addColorStop(0.5, 'rgba(255,255,255,0.28)');
+  gloss.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = gloss;
+  ctx.fillRect(0, 0, size, size);
+  ctx.restore();
+
+  ctx.save();
+  const falloff = ctx.createRadialGradient(
+    size * 0.52,
+    size * 0.74,
+    size * 0.12,
+    size * 0.52,
+    size * 0.74,
+    size * 0.45
+  );
+  falloff.addColorStop(0, 'rgba(0,0,0,0)');
+  falloff.addColorStop(1, 'rgba(0,0,0,0.22)');
+  ctx.globalCompositeOperation = 'multiply';
+  ctx.fillStyle = falloff;
+  ctx.fillRect(0, 0, size, size);
+  ctx.restore();
+
+  addNoise(ctx, size, 0.016, 2800);
 
   if (Number.isFinite(number)) {
     drawPoolNumberBadge(ctx, size, number);


### PR DESCRIPTION
## Summary
- Lowered Pool Royale cushion lips back toward the rail line and locked gameplay/replay cameras to the rail-overhead broadcast view (with top-down toggle disabled).
- Refreshed pool ball textures with more realistic shading and smaller official-style numbering.
- Raised the default graphics preset toward the 90 FPS profile to push smoother visuals on capable devices.

## Testing
- npm --prefix webapp run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947f1b836f48329aa8bd0a9dc1a91ce)