### PR TITLE
Restore rail overhead camera and visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -275,6 +275,10 @@ function detectPreferredFrameRateId() {
     return 'fhd60';
   }
 
+  if (rendererTier === 'desktopHigh' && highRefresh && hardwareConcurrency >= 12) {
+    return 'esports165';
+  }
+
   if (rendererTier === 'desktopHigh' && highRefresh) {
     return 'ultra144';
   }
@@ -810,7 +814,7 @@ const SHOW_SHORT_RAIL_TRIPODS = false;
     THICK: 1.8 * TABLE_SCALE,
     WALL: 2.6 * TABLE_SCALE
   };
-const RAIL_HEIGHT = TABLE.THICK * 1.96; // raise the wooden rails slightly so their top edge now meets the cushion surface
+const RAIL_HEIGHT = TABLE.THICK * 1.82; // return rail height to the lower stance used previously so cushions no longer sit too tall
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.008; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
@@ -2415,6 +2419,15 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     pixelRatioCap: 2.2,
     resolution: 'Ultra HD+ render • DPR 2.2 cap',
     description: 'Maximum clarity preset that prioritizes UHD detail at 144 Hz.'
+  },
+  {
+    id: 'esports165',
+    label: 'Esports (165 Hz)',
+    fps: 165,
+    renderScale: 1.4,
+    pixelRatioCap: 2.3,
+    resolution: 'High-FPS render • DPR 2.3 cap',
+    description: 'Highest frame pacing for ultra-fast 165 Hz broadcasts and replays.'
   }
 ]);
 const DEFAULT_FRAME_RATE_ID = 'fhd60';
@@ -12716,7 +12729,7 @@ function PoolRoyaleGame({
             cueBall,
             fallback: shortRailDir
           });
-          const preferRailOverhead = Boolean(railNormal);
+          const preferRailOverhead = true; // force every shot to use the rail-mounted overhead broadcast angle
           const now = performance.now();
           const activationDelay = longShot
             ? now + LONG_SHOT_ACTIVATION_DELAY_MS
@@ -13038,23 +13051,23 @@ function PoolRoyaleGame({
         const captureReplayCameraSnapshot = () => {
           const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
           const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
-          const fallbackCamera = activeRenderCameraRef.current ?? camera;
-          const fovSnapshot = Number.isFinite(fallbackCamera?.fov)
-            ? fallbackCamera.fov
+          const liveCamera = activeRenderCameraRef.current ?? camera;
+          const fovSnapshot = Number.isFinite(liveCamera?.fov)
+            ? liveCamera.fov
             : camera.fov;
           const targetSnapshot = lastCameraTargetRef.current
             ? lastCameraTargetRef.current.clone()
             : broadcastCamerasRef.current?.defaultFocusWorld?.clone?.() ?? null;
+          const positionSnapshot = liveCamera?.position?.clone?.() ?? null;
           const overheadCamera = resolveRailOverheadReplayCamera({
             focusOverride: targetSnapshot,
             minTargetY
           });
-          const resolvedPosition = overheadCamera?.position?.clone?.() ??
-            fallbackCamera?.position?.clone?.() ?? null;
-          const resolvedTarget = overheadCamera?.target?.clone?.() ?? targetSnapshot;
-          const resolvedFov = Number.isFinite(overheadCamera?.fov)
-            ? overheadCamera.fov
-            : fovSnapshot;
+          const resolvedPosition = positionSnapshot ?? overheadCamera?.position?.clone?.() ?? null;
+          const resolvedTarget = targetSnapshot ?? overheadCamera?.target?.clone?.() ?? null;
+          const resolvedFov = Number.isFinite(fovSnapshot)
+            ? fovSnapshot
+            : overheadCamera?.fov ?? camera.fov;
           if (!resolvedPosition && !resolvedTarget) return null;
           const snapshot = {
             position: resolvedPosition,

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -4,6 +4,7 @@ import { applySRGBColorSpace } from './colorSpace.js';
 const BALL_TEXTURE_SIZE = 4096; // ultra high resolution for sharper billiard ball textures
 const BALL_TEXTURE_CACHE = new Map();
 const BALL_MATERIAL_CACHE = new Map();
+const BALL_NORMAL_MAP_KEY = 'pool-ball-micro-normal';
 
 function clamp01(value) {
   return Math.min(1, Math.max(0, value));
@@ -39,6 +40,29 @@ function addNoise(ctx, size, strength = 0.02, samples = 3600) {
     ctx.fillRect(Math.random() * size, Math.random() * size, 1, 1);
   }
   ctx.restore();
+}
+
+function createBallNormalMap() {
+  if (BALL_TEXTURE_CACHE.has(BALL_NORMAL_MAP_KEY)) {
+    return BALL_TEXTURE_CACHE.get(BALL_NORMAL_MAP_KEY);
+  }
+  const size = 256;
+  const data = new Uint8Array(size * size * 4);
+  const clampByte = (v) => Math.max(0, Math.min(255, Math.round(v)));
+  for (let i = 0; i < size * size; i++) {
+    const stride = i * 4;
+    const grain = (Math.random() - 0.5) * 12;
+    const swirl = (Math.random() - 0.5) * 10;
+    data[stride] = clampByte(128 + grain);
+    data[stride + 1] = clampByte(128 + swirl);
+    data[stride + 2] = clampByte(255 - Math.abs(grain) * 0.6);
+    data[stride + 3] = 255;
+  }
+  const texture = new THREE.DataTexture(data, size, size);
+  texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+  texture.needsUpdate = true;
+  BALL_TEXTURE_CACHE.set(BALL_NORMAL_MAP_KEY, texture);
+  return texture;
 }
 
 function drawNumberBadge(ctx, size, number) {
@@ -77,7 +101,7 @@ function drawNumberBadge(ctx, size, number) {
 }
 
 function drawPoolNumberBadge(ctx, size, number) {
-  const radius = size * 0.1;
+  const radius = size * 0.088;
   const badgeStretch = 2; // compensate equirectangular vertical compression on spheres
   const cx = size * 0.5;
   const cy = size * 0.5;
@@ -90,12 +114,12 @@ function drawPoolNumberBadge(ctx, size, number) {
   ctx.fillStyle = '#ffffff';
   ctx.fill();
 
-  ctx.lineWidth = Math.max(2, Math.floor(size * 0.02));
+  ctx.lineWidth = Math.max(2, Math.floor(size * 0.018));
   ctx.strokeStyle = '#000000';
   ctx.stroke();
 
   ctx.fillStyle = '#000000';
-  ctx.font = `bold ${size * 0.18}px Arial`;
+  ctx.font = `700 ${size * 0.15}px "Helvetica Neue", "Futura", "Arial Black", Arial`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
 
@@ -246,7 +270,7 @@ function createBallTexture({ baseColor, pattern, number, variantKey }) {
   }
 
   const texture = new THREE.CanvasTexture(canvas);
-  texture.anisotropy = 32;
+  texture.anisotropy = 64;
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
@@ -275,18 +299,26 @@ export function getBallMaterial({
     number,
     variantKey
   });
+  const normalMap = createBallNormalMap();
 
   const material = new THREE.MeshPhysicalMaterial({
     color: 0xffffff,
     map,
+    normalMap,
+    clearcoatNormalMap: normalMap,
+    normalScale: new THREE.Vector2(0.32, 0.32),
+    clearcoatNormalScale: new THREE.Vector2(0.12, 0.12),
     clearcoat: 1,
-    clearcoatRoughness: 0.015,
-    metalness: 0.24,
-    roughness: 0.06,
+    clearcoatRoughness: 0.01,
+    metalness: 0.22,
+    roughness: 0.045,
     reflectivity: 1,
     sheen: 0.18,
     sheenColor: new THREE.Color(0xf8f9ff),
-    envMapIntensity: 1.18
+    sheenRoughness: 0.35,
+    envMapIntensity: 1.28,
+    ior: 1.52,
+    specularIntensity: 1.08
   });
   material.needsUpdate = true;
   BALL_MATERIAL_CACHE.set(cacheKey, material);


### PR DESCRIPTION
## Summary
- lower Pool Royale rails to the previous stance and always use the rail overhead broadcast for shots and replays
- reintroduce esports-grade 165 Hz graphics preset for higher frame pacing
- refresh pool ball materials with micro-normal detail and smaller official-style numbering for more realism

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947f1b836f48329aa8bd0a9dc1a91ce)