### PR TITLE
Open side pocket rail cuts for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -496,13 +496,13 @@ const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.095; // pull the side fascias in
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.026; // pull back the middle chrome arch so the rounded cut radius reads smaller at the side pockets while leaving a touch more breathing room
-const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.24; // pull the middle chrome arch toward centre a little less so the fascia stops before the side pockets
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.34; // pull the middle chrome arch further toward centre so the fascia notch clears more rail at the side pockets
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 0.962; // tighten the middle rail arches so the rounded cuts stay slimmer and avoid the pocket area
-const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = 0.12; // ease the centre pull so the wood cut stops short of the side-pocket throat
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.08; // open the middle rail arches so the rounded cuts bite farther toward the pocket
+const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = 0.24; // pull the wood cut nearer to the side-pocket throat to expose the rail edge around the hole
 
 function buildChromePlateGeometry({
   width,


### PR DESCRIPTION
## Summary
- pull the chrome side pocket notch farther toward the centre so the fascia clears more rail around the middle pockets
- expand the wooden side-rail pocket relief and centre pull to expose the rail edge near the side-pocket throat

## Testing
- npm test -- poolRoyaleRules.test.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948de4d9b488329bc2a1ad55bbb97ce)