### PR TITLE
Adjust Pool Royale rail stripes and side pocket jaws

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -844,7 +844,7 @@ const POCKET_JAW_SIDE_EDGE_FACTOR = POCKET_JAW_CORNER_EDGE_FACTOR; // keep the m
 const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thickness so the jaw crowns through the pocket centre
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.592; // nudge the corner jaw spread farther so the fascia kisses the cushion shoulders without gaps
-const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.42; // trim middle jaw reach so fascia stops at the wood rail edge while keeping the jaw radius
+const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.38; // trim middle jaw reach so fascia stops at the wood rail edge while keeping the jaw radius
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // match the middle jaw arc radius to the corner pockets
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1; // keep middle jaw depth identical to the corners
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = 0; // align middle jaw height with the corner jaws by trimming the extra top lift
@@ -7639,7 +7639,7 @@ function Table3D(
   const gapStripeThickness = Math.max(MICRO_EPS, TABLE.THICK * 0.02);
   const gapStripeHeight = Math.max(MICRO_EPS, cushionHeightTarget + TABLE.THICK * 0.06);
   const gapStripeLift = TABLE.THICK * 0.012;
-  const gapStripePad = TABLE.THICK * 0.0025;
+  const gapStripePad = TABLE.THICK * 0.005;
 
   function cushionProfileAdvanced(len, horizontal, cutAngles = {}) {
     const halfLen = len / 2;


### PR DESCRIPTION
## Summary
- push the gold gap stripes outward for symmetrical spacing between cushions and wooden rails
- trim side pocket jaws slightly more to reduce their reach at the middle pockets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949184e37448329ac6d3eb55cb3f84b)