### PR TITLE
Adjust side pocket jaws and gold stripe positions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -845,7 +845,7 @@ const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thi
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.592; // nudge the corner jaw spread farther so the fascia kisses the cushion shoulders without gaps
 const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.26; // trim the middle jaw reach further so it finishes closer to the wood/cloth gap while keeping the jaw radius
-const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // match the middle jaw arc radius to the corner pockets
+const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.94; // trim the middle jaw arc radius slightly so the side-pocket jaws read slimmer
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1; // keep middle jaw depth identical to the corners
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = 0; // align middle jaw height with the corner jaws by trimming the extra top lift
 const SIDE_POCKET_JAW_OUTWARD_SHIFT = 0; // align middle pocket jaws directly with the corner lips
@@ -7640,7 +7640,7 @@ function Table3D(
   const gapStripeHeight = Math.max(MICRO_EPS, cushionHeightTarget + TABLE.THICK * 0.06);
   const gapStripeLift = TABLE.THICK * 0.012;
   const gapStripePad = TABLE.THICK * 0.005;
-  const gapStripeOutwardShift = TABLE.THICK * 0.012;
+const gapStripeOutwardShift = TABLE.THICK * 0.02; // push all six gold stripes farther from the table centreline
 
   function cushionProfileAdvanced(len, horizontal, cutAngles = {}) {
     const halfLen = len / 2;


### PR DESCRIPTION
## Summary
- trim the side pocket jaw radius so middle pocket lips appear slimmer
- push the decorative gold gap stripes farther from the table centreline

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694924ff39f483298f1ef4cf005e0ab7)