### PR TITLE
Adjust Pool Royale side pocket jaws and gold stripe positions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -845,7 +845,7 @@ const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thi
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.592; // nudge the corner jaw spread farther so the fascia kisses the cushion shoulders without gaps
 const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.26; // trim the middle jaw reach further so it finishes closer to the wood/cloth gap while keeping the jaw radius
-const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.962; // tighten the middle jaw arc radius so side-pocket jaws sit slimmer
+const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.94; // tighten the middle jaw arc radius so side-pocket jaws sit slimmer and read smaller
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1; // keep middle jaw depth identical to the corners
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = 0; // align middle jaw height with the corner jaws by trimming the extra top lift
 const SIDE_POCKET_JAW_OUTWARD_SHIFT = 0; // align middle pocket jaws directly with the corner lips
@@ -7640,7 +7640,7 @@ function Table3D(
   const gapStripeHeight = Math.max(MICRO_EPS, cushionHeightTarget + TABLE.THICK * 0.06);
   const gapStripeLift = TABLE.THICK * 0.012;
   const gapStripePad = TABLE.THICK * 0.005;
-  const gapStripeOutwardShift = TABLE.THICK * 0.022;
+  const gapStripeOutwardShift = TABLE.THICK * 0.028;
 
   function cushionProfileAdvanced(len, horizontal, cutAngles = {}) {
     const halfLen = len / 2;


### PR DESCRIPTION
## Summary
- shrink the middle pocket jaw arc radius to slim their appearance
- push all six gold gap stripes farther outward from the table center

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694928760c0c83299358223061aa1065)