### PR TITLE
Adjust Pool Royale jaw and stripe spacing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -848,7 +848,7 @@ const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.26; // trim the middle jaw reach fur
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.93; // tighten the middle jaw arc radius further so side-pocket jaws sit slimmer
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1; // keep middle jaw depth identical to the corners
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = 0; // align middle jaw height with the corner jaws by trimming the extra top lift
-const SIDE_POCKET_JAW_OUTWARD_SHIFT = 0; // align middle pocket jaws directly with the corner lips
+const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.012; // nudge middle pocket jaws farther outward from centre
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.86; // taper the middle jaw edges sooner so they finish where the rails stop
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // mirror the taper curve from the corner profile
@@ -7640,7 +7640,7 @@ function Table3D(
   const gapStripeHeight = Math.max(MICRO_EPS, cushionHeightTarget + TABLE.THICK * 0.06);
   const gapStripeLift = TABLE.THICK * 0.012;
   const gapStripePad = TABLE.THICK * 0.005;
-  const gapStripeOutwardShift = TABLE.THICK * 0.03;
+  const gapStripeOutwardShift = TABLE.THICK * 0.05;
 
   function cushionProfileAdvanced(len, horizontal, cutAngles = {}) {
     const halfLen = len / 2;


### PR DESCRIPTION
## Summary
- nudge the Pool Royale side pocket jaws outward from table centre
- push the golden gap stripes farther toward the wooden rails

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694935187a30832996acc0d4aa6a035a)