### PR TITLE
Align side pocket geometry with corners

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -45,8 +45,9 @@ public class BilliardsSolver
         double sideMouth = PhysicsConstants.SidePocketMouth;
         double cornerCut = cornerMouth / Math.Sqrt(2.0);
         double sideCut = sideMouth / 2.0;
-        double sideDepth = Math.Max(sideCut * 1.05, PhysicsConstants.BallRadius * 1.8);
-        double sideOutset = Math.Max(0.0, PhysicsConstants.SidePocketOutset);
+        // Make the side jaws slightly deeper to present a fuller capture profile after the mouth reduction.
+        double sideDepth = Math.Max(sideCut * 1.1, PhysicsConstants.BallRadius * 1.8);
+        double sideOutset = PhysicsConstants.SidePocketOutset;
 
         // Straight cushion spans (long rails)
         AddCushionSegment(new Vec2(cornerCut, 0), new Vec2(width / 2 - sideCut, 0), new Vec2(0, 1));

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -22,10 +22,11 @@ public static class PhysicsConstants
 
     // Pocket geometry derived from WPA spec (metres)
     public const double CornerPocketMouth = 0.1057275; // scaled with table reduction
-    public const double SidePocketMouth = 0.117475;    // scaled with table reduction
+    // Match side pocket mouth to the corner pocket so the cutouts are identical.
+    public const double SidePocketMouth = CornerPocketMouth;
     public const double PocketCaptureRadius = 0.087875; // scaled with table reduction
-    // Keep side pockets aligned with the rail line so they behave identically to corner pockets.
-    public const double SidePocketOutset = 0.0;
+    // Pull side pockets slightly inward so the jaws sit closer to the table center.
+    public const double SidePocketOutset = -BallRadius * 0.1;
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 32;


### PR DESCRIPTION
## Summary
- match side pocket mouth width to the corner pocket to keep cutouts consistent
- inset side pocket centers slightly and deepen their jaws for a fuller capture profile toward the table center

## Testing
- dotnet test *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949540938308329b2fd8660ad465dc7)