### PR TITLE
Shift side pockets outward from the table center

### DIFF
--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -25,7 +25,7 @@ public static class PhysicsConstants
     public const double SidePocketMouth = 0.117475;    // scaled with table reduction
     public const double PocketCaptureRadius = 0.087875; // scaled with table reduction
     // Keep side pockets aligned with the rail line so they behave identically to corner pockets.
-    public const double SidePocketOutset = 0.0;
+    public const double SidePocketOutset = 0.02;       // gentle outward offset to keep mid pockets slightly outside the table
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 32;


### PR DESCRIPTION
## Summary
- slightly offset side pocket geometry outward from the table center so middle pockets and cutouts sit outside the playfield

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694966514df883299ee52623cb5846ec)