### PR TITLE
Align pocket cuts with WPA angles

### DIFF
--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -27,6 +27,10 @@ public static class PhysicsConstants
     // Keep side pockets aligned with the rail line so they behave identically to corner pockets.
     public const double SidePocketOutset = 0.0;
 
+    // Cushion cut angles (degrees) based on WPA/BCA specs
+    public const double CornerCutAngleDeg = 19.0;
+    public const double SideCutAngleDeg = 38.0;
+
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 32;
     public const int SideJawSegments = 24;


### PR DESCRIPTION
## Summary
- add configurable corner and side cut angles matching WPA/BCA specs
- rebuild pocket jaw generation to use angled cuts for corners and sides while keeping cushion spans intact
- centralise helpers for rotating vectors and building segment strips with correct surface normals

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694981a24f8c83299b4bc61e0b00cb35)