### PR TITLE
Adjust Pool Royale corner cushion cut

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1192,9 +1192,9 @@ const TOPSPIN_MULTIPLIER = 1.3;
 const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
 const SPIN_CONTROL_DIAMETER_PX = 96;
 const SPIN_DOT_DIAMETER_PX = 10;
-// angle for cushion cuts guiding balls into corner pockets (Pool Royale spec now requires 31°)
-const DEFAULT_CUSHION_CUT_ANGLE = 31;
-// middle pocket cushion cuts now match the corner spec at 33°
+// angle for cushion cuts guiding balls into corner pockets (revert to previous 33° spec)
+const DEFAULT_CUSHION_CUT_ANGLE = 33;
+// middle pocket cushion cuts stay at the current 33°
 const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 33;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;


### PR DESCRIPTION
## Summary
- revert Pool Royale corner cushion cut angle to prior 33° while keeping side pocket cuts unchanged

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69498596abc08329beabb72ab58ab9b1)