### PR TITLE
Adjust Pool Royale cloth and cushion visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -989,10 +989,10 @@ const CAPTURE_R = POCKET_R * 0.94; // pocket capture radius trimmed so rails sta
 const SIDE_CAPTURE_RADIUS_SCALE = 0.88; // shrink middle pocket capture so behaviour matches the smaller side pocket cuts
 const SIDE_CAPTURE_R = CAPTURE_R * SIDE_CAPTURE_RADIUS_SCALE;
 const CLOTH_THICKNESS = TABLE.THICK * 0.12; // match snooker cloth profile so cushions blend seamlessly
-const STONE_PLATE_THICKNESS = TABLE.THICK * 0.32; // matte stone slab replacing the old cloth underlay beneath the felt
-const STONE_PLATE_GAP = TABLE.THICK * 0.008; // tiny separation so the stone never z-fights the felt wrap
-const STONE_PLATE_EXTRA_DROP = TABLE.THICK * 0.022; // recess the stone plate slightly so its edges stay hidden under the cloth
-const CLOTH_EXTENDED_DEPTH = STONE_PLATE_THICKNESS + CLOTH_THICKNESS * 0.35; // wrap the felt down over the stone plate edges
+const STONE_PLATE_THICKNESS = 0; // remove the rigid underlay so the felt wraps directly over the pockets
+const STONE_PLATE_GAP = 0; // no spacer needed with the stone removed
+const STONE_PLATE_EXTRA_DROP = 0; // keep the cloth sleeve aligned to the playfield depth without recessing a plate
+const CLOTH_EXTENDED_DEPTH = CLOTH_THICKNESS * 0.9; // extend only the felt so the wrap stays visible without an underlay
 const CLOTH_EDGE_TOP_RADIUS_SCALE = 0.986; // pinch the cloth sleeve opening slightly so the pocket lip picks up a soft round-over
 const CLOTH_EDGE_BOTTOM_RADIUS_SCALE = 1.012; // flare the lower sleeve so the wrap hugs the pocket throat before meeting the drop
 const CLOTH_EDGE_CURVE_INTENSITY = 0.012; // shallow easing that rounds the cloth sleeve as it transitions from lip to throat
@@ -1193,9 +1193,9 @@ const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
 const SPIN_CONTROL_DIAMETER_PX = 96;
 const SPIN_DOT_DIAMETER_PX = 10;
 // angle for cushion cuts guiding balls into corner pockets (tighten the trim slightly)
-const DEFAULT_CUSHION_CUT_ANGLE = 31;
-// middle pocket cushion cuts stay at the current 33°
-const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 33;
+const DEFAULT_CUSHION_CUT_ANGLE = 38;
+// middle pocket cushion cuts mirror the sharper trim for the reference photo
+const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 42;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
@@ -6035,6 +6035,10 @@ function Table3D(
   cloth.position.y = clothPlaneLocal - CLOTH_DROP;
   cloth.renderOrder = 3;
   cloth.receiveShadow = true;
+  if (cloth.material) {
+    cloth.material.shadowSide = THREE.DoubleSide;
+    cloth.material.needsUpdate = true;
+  }
   table.add(cloth);
   const clothBottomY = cloth.position.y - CLOTH_EXTENDED_DEPTH;
   const stoneTopY = clothBottomY - STONE_PLATE_GAP - STONE_PLATE_EXTRA_DROP;
@@ -6086,7 +6090,7 @@ function Table3D(
     clothEdgeMat.needsUpdate = true;
   }
 
-  const stoneDepth = Math.max(MICRO_EPS, STONE_PLATE_THICKNESS);
+  const stoneDepth = STONE_PLATE_THICKNESS;
   if (stoneDepth > MICRO_EPS) {
     const stoneShape = buildSurfaceShape(POCKET_HOLE_R);
     const stoneGeo = new THREE.ExtrudeGeometry(stoneShape, {
@@ -10753,7 +10757,7 @@ function PoolRoyaleGame({
         carpetMat
       );
       carpet.castShadow = false;
-      carpet.receiveShadow = true;
+      carpet.receiveShadow = false;
       carpet.position.set(0, floorY - carpetThickness / 2, 0);
       world.add(carpet);
 


### PR DESCRIPTION
## Summary
- remove the stone underlay and wrap the cloth directly around the pockets
- route table shadows onto the cloth surface instead of the carpet
- sharpen cushion cut angles to match the reference pocket trims

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949a1d16124832984f728bf0e5ea5f8)