### PR TITLE
Adjust Pool Royale lighting and shadows

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6023,6 +6023,7 @@ function Table3D(
   cloth.rotation.x = -Math.PI / 2;
   cloth.position.y = clothPlaneLocal - CLOTH_DROP;
   cloth.renderOrder = 3;
+  cloth.castShadow = true;
   cloth.receiveShadow = true;
   table.add(cloth);
   const clothBottomY = cloth.position.y - CLOTH_EXTENDED_DEPTH;
@@ -6096,7 +6097,7 @@ function Table3D(
     stonePlate.rotation.x = -Math.PI / 2;
     stonePlate.position.y = stoneTopY;
     stonePlate.receiveShadow = true;
-    stonePlate.castShadow = false;
+    stonePlate.castShadow = true;
     stonePlate.renderOrder = cloth.renderOrder - 0.25;
     table.add(stonePlate);
     finishParts.underlayMeshes.push(stonePlate);
@@ -13768,39 +13769,39 @@ function PoolRoyaleGame({
         const lightingRig = new THREE.Group();
         world.add(lightingRig);
 
-        const lightRigHeight = tableSurfaceY + TABLE.THICK * 4.6;
-        const lightOffsetX = Math.max(PLAY_W * 0.18, TABLE.THICK * 2.8);
-        const lightOffsetZ = Math.max(PLAY_H * 0.12, TABLE.THICK * 2.2);
-        const shadowHalfSpan = Math.max(PLAY_W, PLAY_H) * 0.65;
-        const targetY = tableSurfaceY + TABLE.THICK * 0.24;
+        const lightRigHeight = tableSurfaceY + TABLE.THICK * 6.1;
+        const lightOffsetX = Math.max(PLAY_W * 0.12, TABLE.THICK * 1.8);
+        const lightOffsetZ = Math.max(PLAY_H * 0.12, TABLE.THICK * 1.8);
+        const shadowHalfSpan = Math.max(PLAY_W, PLAY_H) * 1.05;
+        const targetY = tableSurfaceY + TABLE.THICK * 0.16;
 
         const ambient = new THREE.AmbientLight(0xffffff, 0.22);
         lightingRig.add(ambient);
 
         const key = new THREE.DirectionalLight(0xffffff, 1.6);
-        key.position.set(lightOffsetX * 0.9, lightRigHeight, lightOffsetZ * 0.9);
+        key.position.set(lightOffsetX * 0.18, lightRigHeight, lightOffsetZ * 0.2);
         key.target.position.set(0, targetY, 0);
         key.castShadow = true;
-        key.shadow.mapSize.set(2048, 2048);
+        key.shadow.mapSize.set(3072, 3072);
         key.shadow.camera.near = 0.1;
-        key.shadow.camera.far = shadowHalfSpan * 2.4;
+        key.shadow.camera.far = shadowHalfSpan * 3.2;
         key.shadow.camera.left = -shadowHalfSpan;
         key.shadow.camera.right = shadowHalfSpan;
         key.shadow.camera.top = shadowHalfSpan;
         key.shadow.camera.bottom = -shadowHalfSpan;
-        key.shadow.bias = -0.00005;
-        key.shadow.normalBias = 0.0012;
+        key.shadow.bias = -0.0002;
+        key.shadow.normalBias = 0.0009;
         lightingRig.add(key);
         lightingRig.add(key.target);
 
-        const fill = new THREE.DirectionalLight(0xffffff, 0.75);
-        fill.position.set(-lightOffsetX * 0.86, lightRigHeight * 0.86, lightOffsetZ * 0.6);
+        const fill = new THREE.DirectionalLight(0xffffff, 0.8);
+        fill.position.set(-lightOffsetX * 0.45, lightRigHeight * 0.95, lightOffsetZ * 0.3);
         fill.target.position.set(0, targetY, 0);
         lightingRig.add(fill);
         lightingRig.add(fill.target);
 
-        const rim = new THREE.DirectionalLight(0xffffff, 0.55);
-        rim.position.set(0, lightRigHeight * 0.92, -lightOffsetZ * 1.35);
+        const rim = new THREE.DirectionalLight(0xffffff, 0.6);
+        rim.position.set(0, lightRigHeight * 0.9, -lightOffsetZ * 1.05);
         rim.target.position.set(0, targetY, 0);
         lightingRig.add(rim);
         lightingRig.add(rim.target);


### PR DESCRIPTION
## Summary
- repositioned Pool Royale lighting rig for more downward shadows and expanded shadow coverage
- enabled cloth and slate surfaces to cast shadows so the full table footprint appears on the carpet
- tweaked fill and rim lights to keep all balls visibly grounded with balanced shading

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949baed24248329b1829802ffbda644)