### PR TITLE
Refine Pool Royale lighting and table shadows

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6023,6 +6023,7 @@ function Table3D(
   cloth.rotation.x = -Math.PI / 2;
   cloth.position.y = clothPlaneLocal - CLOTH_DROP;
   cloth.renderOrder = 3;
+  cloth.castShadow = true;
   cloth.receiveShadow = true;
   table.add(cloth);
   const clothBottomY = cloth.position.y - CLOTH_EXTENDED_DEPTH;
@@ -13768,22 +13769,22 @@ function PoolRoyaleGame({
         const lightingRig = new THREE.Group();
         world.add(lightingRig);
 
-        const lightRigHeight = tableSurfaceY + TABLE.THICK * 4.6;
-        const lightOffsetX = Math.max(PLAY_W * 0.18, TABLE.THICK * 2.8);
-        const lightOffsetZ = Math.max(PLAY_H * 0.12, TABLE.THICK * 2.2);
-        const shadowHalfSpan = Math.max(PLAY_W, PLAY_H) * 0.65;
-        const targetY = tableSurfaceY + TABLE.THICK * 0.24;
+        const lightRigHeight = tableSurfaceY + TABLE.THICK * 5.2;
+        const lightOffsetX = Math.max(PLAY_W * 0.16, TABLE.THICK * 2.4);
+        const lightOffsetZ = Math.max(PLAY_H * 0.14, TABLE.THICK * 2.4);
+        const shadowHalfSpan = Math.max(PLAY_W, PLAY_H) * 0.9;
+        const targetY = tableSurfaceY + TABLE.THICK * 0.2;
 
         const ambient = new THREE.AmbientLight(0xffffff, 0.22);
         lightingRig.add(ambient);
 
         const key = new THREE.DirectionalLight(0xffffff, 1.6);
-        key.position.set(lightOffsetX * 0.9, lightRigHeight, lightOffsetZ * 0.9);
+        key.position.set(lightOffsetX * 0.32, lightRigHeight, lightOffsetZ * 0.28);
         key.target.position.set(0, targetY, 0);
         key.castShadow = true;
         key.shadow.mapSize.set(2048, 2048);
         key.shadow.camera.near = 0.1;
-        key.shadow.camera.far = shadowHalfSpan * 2.4;
+        key.shadow.camera.far = shadowHalfSpan * 3.2;
         key.shadow.camera.left = -shadowHalfSpan;
         key.shadow.camera.right = shadowHalfSpan;
         key.shadow.camera.top = shadowHalfSpan;
@@ -13794,13 +13795,23 @@ function PoolRoyaleGame({
         lightingRig.add(key.target);
 
         const fill = new THREE.DirectionalLight(0xffffff, 0.75);
-        fill.position.set(-lightOffsetX * 0.86, lightRigHeight * 0.86, lightOffsetZ * 0.6);
+        fill.position.set(-lightOffsetX * 0.52, lightRigHeight * 0.94, lightOffsetZ * 0.45);
         fill.target.position.set(0, targetY, 0);
+        fill.castShadow = true;
+        fill.shadow.mapSize.set(1024, 1024);
+        fill.shadow.camera.near = 0.25;
+        fill.shadow.camera.far = shadowHalfSpan * 2.6;
+        fill.shadow.camera.left = -shadowHalfSpan * 0.9;
+        fill.shadow.camera.right = shadowHalfSpan * 0.9;
+        fill.shadow.camera.top = shadowHalfSpan * 0.9;
+        fill.shadow.camera.bottom = -shadowHalfSpan * 0.9;
+        fill.shadow.bias = -0.00008;
+        fill.shadow.normalBias = 0.0015;
         lightingRig.add(fill);
         lightingRig.add(fill.target);
 
         const rim = new THREE.DirectionalLight(0xffffff, 0.55);
-        rim.position.set(0, lightRigHeight * 0.92, -lightOffsetZ * 1.35);
+        rim.position.set(0, lightRigHeight * 0.98, -lightOffsetZ * 1.18);
         rim.target.position.set(0, targetY, 0);
         lightingRig.add(rim);
         lightingRig.add(rim.target);


### PR DESCRIPTION
## Summary
- Reposition Pool Royale lighting rig to cast more direct shadows beneath balls and across the table
- Enable softer secondary shadow casting to improve coverage on all balls and carpet
- Allow the cloth surface to cast shadows so the full table footprint appears on the carpet

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949baed24248329b1829802ffbda644)