### PR TITLE
Refine Pool Royale lighting and shadows

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -6008,6 +6008,7 @@ function Table3D(
   cloth.rotation.x = -Math.PI / 2;
   cloth.position.y = clothPlaneLocal - CLOTH_DROP;
   cloth.renderOrder = 3;
+  cloth.castShadow = true;
   cloth.receiveShadow = true;
   table.add(cloth);
   const clothBottomY = cloth.position.y - CLOTH_EXTENDED_DEPTH;
@@ -13165,7 +13166,7 @@ export function PoolRoyaleGame({
         const LIGHT_DIMENSION_SCALE = 0.8; // reduce fixture footprint by 20%
         const LIGHT_HEIGHT_SCALE = 1.4; // lift the rig further above the table
         const LIGHT_HEIGHT_LIFT_MULTIPLIER = 5.8; // bring fixtures closer so the spot highlight reads on the balls
-        const LIGHT_LATERAL_SCALE = 0.45; // pull shadow-casting lights nearer the table centre
+        const LIGHT_LATERAL_SCALE = 0.22; // pull shadow-casting lights nearer the table centre for vertical shadows
 
         const baseWidthScale = (PLAY_W / SAMPLE_PLAY_W) * LIGHT_DIMENSION_SCALE;
         const baseLengthScale = (PLAY_H / SAMPLE_PLAY_H) * LIGHT_DIMENSION_SCALE;
@@ -13187,12 +13188,18 @@ export function PoolRoyaleGame({
         lightingRig.add(hemisphereRig);
 
         const dirLight = new THREE.DirectionalLight(0xffffff, 1.176);
-        dirLight.position.set(
-          -triangleRadius * LIGHT_LATERAL_SCALE,
-          triangleHeight,
-          triangleRadius * LIGHT_LATERAL_SCALE * 0.4
-        );
-        dirLight.target.position.set(0, tableSurfaceY + BALL_R * 0.05, 0);
+        dirLight.position.set(0, triangleHeight + lightRetreatOffset * 0.35, triangleRadius * 0.06);
+        dirLight.target.position.set(0, tableSurfaceY + BALL_R * 0.12, 0);
+        dirLight.castShadow = true;
+        dirLight.shadow.mapSize.set(2048, 2048);
+        dirLight.shadow.camera.near = 0.6;
+        dirLight.shadow.camera.far = 14;
+        dirLight.shadow.camera.left = -triangleRadius * 1.2;
+        dirLight.shadow.camera.right = triangleRadius * 1.2;
+        dirLight.shadow.camera.top = triangleRadius * 1.4;
+        dirLight.shadow.camera.bottom = -triangleRadius * 1.4;
+        dirLight.shadow.bias = -0.00018;
+        dirLight.shadow.normalBias = 0.0085;
         lightingRig.add(dirLight);
         lightingRig.add(dirLight.target);
 
@@ -13205,16 +13212,18 @@ export function PoolRoyaleGame({
           1
         );
         spot.position.set(
-          triangleRadius * LIGHT_LATERAL_SCALE,
+          triangleRadius * LIGHT_LATERAL_SCALE * 0.35,
           triangleHeight + lightRetreatOffset + lightReflectionGuard,
-          triangleRadius * LIGHT_LATERAL_SCALE * (0.35 + LIGHT_LATERAL_SCALE * 0.12)
+          triangleRadius * LIGHT_LATERAL_SCALE * 0.24
         );
-        spot.target.position.set(0, tableSurfaceY + TABLE_H * 0.18, 0);
+        spot.target.position.set(0, tableSurfaceY + TABLE_H * 0.22, 0);
         spot.decay = 1.0;
         spot.castShadow = true;
         spot.shadow.mapSize.set(2048, 2048);
         spot.shadow.bias = -0.00004;
         spot.shadow.normalBias = 0.006;
+        spot.shadow.camera.near = 0.5;
+        spot.shadow.camera.far = 16;
         lightingRig.add(spot);
         lightingRig.add(spot.target);
 


### PR DESCRIPTION
## Summary
- Repositioned the Pool Royale lighting rig and enabled shadow casting on the key lights to push ball shadows directly beneath the balls while keeping the existing color/intensity palette.
- Tuned spot light targeting and shadow camera ranges to cover the full cloth so every ball projects onto the playfield.
- Enabled the cloth surface to cast shadows, completing the table silhouette on the carpet.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a238809c88329a3cf53c5ca6afc03)