### PR TITLE
Make cloth cast shadow to block ball shadows on carpet

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6022,6 +6022,7 @@ function Table3D(
   cloth.rotation.x = -Math.PI / 2;
   cloth.position.y = clothPlaneLocal - CLOTH_DROP;
   cloth.renderOrder = 3;
+  cloth.castShadow = true;
   cloth.receiveShadow = true;
   table.add(cloth);
   const clothBottomY = cloth.position.y - CLOTH_EXTENDED_DEPTH;


### PR DESCRIPTION
## Summary
- allow the cloth mesh to cast shadows so it occludes light hitting the carpet
- ensure carpet shows only the cloth silhouette while ball shadows stay on the playfield

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a2a6ba6e083299b1038609e74ec6d)