### PR TITLE
Adjust Pool Royale plywood and lighting

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -991,7 +991,8 @@ const SIDE_CAPTURE_R = CAPTURE_R * SIDE_CAPTURE_RADIUS_SCALE;
 const CLOTH_THICKNESS = TABLE.THICK * 0.12; // match snooker cloth profile so cushions blend seamlessly
 const PLYWOOD_THICKNESS = TABLE.THICK * 0.18; // add a full plywood bed under the cloth with the same footprint as the table
 const PLYWOOD_GAP = TABLE.THICK * 0.04; // leave a subtle clearance between the cloth wrap and the plywood surface
-const PLYWOOD_EXTRA_DROP = 0; // keep the plywood tight to the cloth underside with no extra offset
+const PLYWOOD_EXTRA_DROP = TABLE.THICK * 0.06; // lower the plywood so it reads under the pockets instead of hugging the cloth
+const PLYWOOD_OVERHANG = TABLE.THICK * 0.06; // widen the plywood slab so it peeks out evenly around the pocket bowls
 const CLOTH_EXTENDED_DEPTH = TABLE.THICK * 0.362; // preserve the deeper cloth wrap without relying on a stone underlay
 const CLOTH_EDGE_TOP_RADIUS_SCALE = 0.986; // pinch the cloth sleeve opening slightly so the pocket lip picks up a soft round-over
 const CLOTH_EDGE_BOTTOM_RADIUS_SCALE = 1.012; // flare the lower sleeve so the wrap hugs the pocket throat before meeting the drop
@@ -6088,7 +6089,7 @@ function Table3D(
       return shape;
     };
 
-    const plywoodShape = buildSolidSurfaceShape();
+    const plywoodShape = buildSolidSurfaceShape(-PLYWOOD_OVERHANG);
     const plywoodGeo = new THREE.ExtrudeGeometry(plywoodShape, {
       depth: plywoodDepth,
       bevelEnabled: false,
@@ -6104,7 +6105,7 @@ function Table3D(
     plywoodPlate.rotation.x = -Math.PI / 2;
     plywoodPlate.position.y = plywoodTopY;
     plywoodPlate.receiveShadow = true;
-    plywoodPlate.castShadow = false;
+    plywoodPlate.castShadow = true;
     plywoodPlate.renderOrder = cloth.renderOrder - 0.25;
     table.add(plywoodPlate);
     finishParts.underlayMeshes.push(plywoodPlate);
@@ -13763,11 +13764,11 @@ function PoolRoyaleGame({
         const lightingRig = new THREE.Group();
         world.add(lightingRig);
 
-        const lightRigHeight = tableSurfaceY + TABLE.THICK * 5.2;
+        const lightRigHeight = tableSurfaceY + TABLE.THICK * 5.4;
         const lightOffsetX = Math.max(PLAY_W * 0.12, TABLE.THICK * 2.6);
-        const lightOffsetZ = Math.max(PLAY_H * 0.1, TABLE.THICK * 2.4);
-        const shadowHalfSpan = Math.max(TABLE.W, TABLE.H) * 0.8;
-        const targetY = tableSurfaceY + TABLE.THICK * 0.18;
+        const lightOffsetZ = Math.max(PLAY_H * 0.12, TABLE.THICK * 2.6);
+        const shadowHalfSpan = Math.max(TABLE.W, TABLE.H) * 1.08;
+        const targetY = tableSurfaceY + TABLE.THICK * 0.12;
         const shadowDepth =
           lightRigHeight + Math.abs(targetY - floorY) + TABLE.THICK * 12;
 
@@ -13775,7 +13776,7 @@ function PoolRoyaleGame({
         lightingRig.add(ambient);
 
         const key = new THREE.DirectionalLight(0xffffff, 1.6);
-        key.position.set(lightOffsetX * 0.24, lightRigHeight, lightOffsetZ * 0.2);
+        key.position.set(lightOffsetX * 0.16, lightRigHeight, lightOffsetZ * 0.12);
         key.target.position.set(0, targetY, 0);
         key.castShadow = true;
         key.shadow.mapSize.set(2048, 2048);
@@ -13785,19 +13786,19 @@ function PoolRoyaleGame({
         key.shadow.camera.right = shadowHalfSpan;
         key.shadow.camera.top = shadowHalfSpan;
         key.shadow.camera.bottom = -shadowHalfSpan;
-        key.shadow.bias = -0.00008;
-        key.shadow.normalBias = 0.0008;
+        key.shadow.bias = -0.00006;
+        key.shadow.normalBias = 0.0006;
         lightingRig.add(key);
         lightingRig.add(key.target);
 
         const fill = new THREE.DirectionalLight(0xffffff, 0.75);
-        fill.position.set(-lightOffsetX * 0.22, lightRigHeight * 0.94, lightOffsetZ * 0.2);
+        fill.position.set(-lightOffsetX * 0.18, lightRigHeight * 0.96, lightOffsetZ * 0.12);
         fill.target.position.set(0, targetY, 0);
         lightingRig.add(fill);
         lightingRig.add(fill.target);
 
         const rim = new THREE.DirectionalLight(0xffffff, 0.55);
-        rim.position.set(0, lightRigHeight * 0.98, -lightOffsetZ * 0.32);
+        rim.position.set(0, lightRigHeight * 1.02, -lightOffsetZ * 0.28);
         rim.target.position.set(0, targetY, 0);
         lightingRig.add(rim);
         lightingRig.add(rim.target);


### PR DESCRIPTION
## Summary
- lower and widen the Pool Royale plywood underlay and enable it to cast a visible shadow on the carpet
- adjust the lighting rig coverage and angles so ball shadows appear across the full table while aiming them onto the cloth

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a3edb3b2483298ceeb93615e40f1d)