### PR TITLE
Lower plywood underlayment and enable rail shadows in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -991,8 +991,8 @@ const SIDE_CAPTURE_R = CAPTURE_R * SIDE_CAPTURE_RADIUS_SCALE;
 const CLOTH_THICKNESS = TABLE.THICK * 0.12; // match snooker cloth profile so cushions blend seamlessly
 const PLYWOOD_THICKNESS = TABLE.THICK * 0.18; // add a full plywood bed under the cloth with the same footprint as the table
 const PLYWOOD_GAP = TABLE.THICK * 0.04; // leave a subtle clearance between the cloth wrap and the plywood surface
-const PLYWOOD_EXTRA_DROP = TABLE.THICK * 0.08; // let the plywood sit slightly lower so it peeks beneath the pockets
-const PLYWOOD_OUTSET = TABLE.THICK * 0.08; // widen the plywood slab so it extends past the cloth sleeve on every side
+const PLYWOOD_EXTRA_DROP = TABLE.THICK * 0.14; // drop the plywood deeper so it never crowds the pocket bowls
+const PLYWOOD_OUTSET = TABLE.THICK * 0.12; // widen the plywood slab so every edge reads as a single, unbroken piece
 const CLOTH_EXTENDED_DEPTH = TABLE.THICK * 0.362; // preserve the deeper cloth wrap without relying on a stone underlay
 const CLOTH_EDGE_TOP_RADIUS_SCALE = 0.986; // pinch the cloth sleeve opening slightly so the pocket lip picks up a soft round-over
 const CLOTH_EDGE_BOTTOM_RADIUS_SCALE = 1.012; // flare the lower sleeve so the wrap hugs the pocket throat before meeting the drop
@@ -8033,6 +8033,11 @@ function Table3D(
   });
 
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(alignedRailSurface);
+  [...finishParts.railMeshes, ...finishParts.frameMeshes].forEach((mesh) => {
+    if (!mesh) return;
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+  });
   legPositions.forEach(([lx, lz]) => {
     const leg = new THREE.Mesh(legGeo, legMat);
     leg.position.set(lx, legY, lz);


### PR DESCRIPTION
## Summary
- lower and widen the plywood base so the underlayment appears as a single uninterrupted slab beneath the pockets
- ensure wooden rails and skirts always cast/receive shadows for better contact with the carpet

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a45f205608329b91a8ad3be82fb68)